### PR TITLE
fix(fmt): match oxfmt for real-world Svelte layouts

### DIFF
--- a/.changeset/tidy-svelte-layouts.md
+++ b/.changeset/tidy-svelte-layouts.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/fmt": patch
+---
+
+Match oxfmt's Svelte output for deep attribute expressions, adjacent interpolations, block headers, attach tags, TypeScript assertions, and nested component children.

--- a/compatibility/fmt-known-failures.json
+++ b/compatibility/fmt-known-failures.json
@@ -3,7 +3,6 @@
   "cmsaasstarter/src/routes/(marketing)/+page.svelte",
   "layercake/src/_components/AxisY.percent-range.html.svelte",
   "layercake/src/_components/AxisYRight.percent-range.html.svelte",
-  "layercake/src/routes/components/+page.svelte",
   "layerchart/docs/src/routes/+page.svelte",
   "powertable/app/src/lib/components/PowerTable.svelte",
   "powertable/app/src/routes/examples/+layout.svelte",
@@ -13,6 +12,5 @@
   "svelte-ux/packages/svelte-ux/src/lib/components/Collapse.svelte",
   "svelte-ux/packages/svelte-ux/src/routes/+error.svelte",
   "svelte-ux/packages/svelte-ux/src/routes/docs/components/Gooey/+page.svelte",
-  "svelte-ux/packages/svelte-ux/src/routes/docs/components/TextField/+page.svelte",
   "svelte/packages/svelte/tests/parser-modern/samples/const-tag-parenthesized-init/input.svelte"
 ]

--- a/crates/rsvelte_formatter/src/collapse/children_port.rs
+++ b/crates/rsvelte_formatter/src/collapse/children_port.rs
@@ -26,8 +26,10 @@ pub(super) fn collect_children_port_only(
         {
             continue;
         }
-        if matches!(node, TemplateNode::RegularElement(_))
-            && let Some(maybe_edit) = try_children_port(out, node, line_width, options)
+        if matches!(
+            node,
+            TemplateNode::RegularElement(_) | TemplateNode::Component(_)
+        ) && let Some(maybe_edit) = try_children_port(out, node, line_width, options)
         {
             if let Some(edit) = maybe_edit {
                 edits.push(edit);
@@ -49,6 +51,7 @@ pub(super) fn node_to_child(
     out: &str,
     node: &TemplateNode,
     line_width: usize,
+    options: &FormatOptions,
 ) -> Option<crate::children::Child> {
     use crate::children::Child;
     use crate::doc::Doc;
@@ -84,7 +87,7 @@ pub(super) fn node_to_child(
                 && !is_whitespace_preserving(ve.name.as_str()) =>
         {
             Some(Child::Inline(build_inline_element_doc(
-                out, ve, line_width,
+                out, ve, line_width, options,
             )?))
         }
         // Block-display element (`<div>`, `<h1>`, `<ul>`, …). prettier classifies
@@ -94,9 +97,13 @@ pub(super) fn node_to_child(
             if is_block_display(ve.name.as_str())
                 && !is_whitespace_preserving(ve.name.as_str()) =>
         {
-            Some(Child::Block(build_inline_element_doc(out, ve, line_width)?))
+            Some(Child::Block(build_inline_element_doc(
+                out, ve, line_width, options,
+            )?))
         }
-        TemplateNode::Component(c) => Some(Child::Other(build_component_doc(out, c, line_width)?)),
+        TemplateNode::Component(c) => Some(Child::Other(build_component_doc(
+            out, c, line_width, options,
+        )?)),
         // Cut 3: mustache atoms (`{expr}`, `{@html …}`). prettier-plugin-svelte's
         // `isInlineElement` requires `type === 'RegularElement'`, so a MustacheTag
         // is NOT inline — it goes through `printChildren`'s `else` branch: pushed
@@ -115,7 +122,10 @@ pub(super) fn node_to_child(
         TemplateNode::ExpressionTag(_) | TemplateNode::HtmlTag(_) | TemplateNode::RenderTag(_) => {
             let span = out.get(node_start(node) as usize..node_end(node) as usize)?;
             if span.contains('\n') {
-                return None;
+                return matches!(node, TemplateNode::ExpressionTag(_))
+                    .then(|| content_tag_breakable_doc(out, node, options))
+                    .flatten()
+                    .map(Child::Other);
             }
             Some(Child::Other(Doc::Text(span.to_string())))
         }
@@ -124,12 +134,14 @@ pub(super) fn node_to_child(
         // `printChildren`'s `else` branch and are pushed bare. Their own print is
         // `group([def, breakParent])`, so they force every enclosing group to break
         // even when the whole element would fit on one line.
-        TemplateNode::IfBlock(blk) => Some(Child::Other(build_if_block_doc(out, blk, line_width)?)),
+        TemplateNode::IfBlock(blk) => Some(Child::Other(build_if_block_doc(
+            out, blk, line_width, options,
+        )?)),
         TemplateNode::EachBlock(blk) => {
             let mut branches: Vec<&Fragment> = vec![&blk.body];
             branches.extend(blk.fallback.as_ref());
             Some(Child::Other(build_simple_block_doc(
-                out, blk.start, blk.end, &branches, line_width,
+                out, blk.start, blk.end, &branches, line_width, options,
             )?))
         }
         TemplateNode::KeyBlock(blk) => Some(Child::Other(build_simple_block_doc(
@@ -138,6 +150,7 @@ pub(super) fn node_to_child(
             blk.end,
             &[&blk.fragment],
             line_width,
+            options,
         )?)),
         _ => None,
     }
@@ -179,19 +192,33 @@ pub(super) fn try_children_port(
     options: &FormatOptions,
 ) -> Option<Option<(u32, u32, String)>> {
     use crate::children::{Child, ElementLayout, build_element_doc};
-    let TemplateNode::RegularElement(e) = node else {
-        return None;
+    let (tag, attributes, fragment, start, end, is_inline, self_closing) = match node {
+        TemplateNode::RegularElement(e) => (
+            e.name.as_str(),
+            e.attributes.as_slice(),
+            &e.fragment,
+            e.start,
+            e.end,
+            !is_block_display(e.name.as_str()),
+            did_self_close(out, e.end) || is_html_void_element(e.name.as_str()),
+        ),
+        TemplateNode::Component(c) => (
+            c.name.as_str(),
+            c.attributes.as_slice(),
+            &c.fragment,
+            c.start,
+            c.end,
+            true,
+            did_self_close(out, c.end),
+        ),
+        _ => return None,
     };
-    let tag = e.name.as_str();
     // Cut 1: inline or block elements (not pre/textarea/script/style, not
     // inline-block like button/select/input). `is_inline` follows prettier's
     // `isInlineElement` = not in the block-element list.
     if is_whitespace_preserving(tag) || is_inline_block(tag) {
         return None;
     }
-    let is_inline = !is_block_display(tag);
-    let fragment = &e.fragment;
-    let (start, end) = (e.start, e.end);
     let (s, ee) = (start as usize, end as usize);
     let whole = out.get(s..ee)?;
 
@@ -280,10 +307,10 @@ pub(super) fn try_children_port(
 
     // Build the ElementLayout from the AST, recursively converting each child via
     // the faithful port (`node_to_child` bails on any unsupported child).
-    let attrs = build_attrs_concat(out, &e.attributes)?;
+    let attrs = build_attrs_concat(out, attributes)?;
     let mut children: Vec<Child> = Vec::with_capacity(fragment.nodes.len());
     for n in &fragment.nodes {
-        children.push(node_to_child(out, n, line_width)?);
+        children.push(node_to_child(out, n, line_width, options)?);
     }
     let doc = build_element_doc(ElementLayout {
         name: tag.to_string(),
@@ -293,7 +320,7 @@ pub(super) fn try_children_port(
         // Inert at this call site — the gate above requires a non-text child, so
         // `is_empty` is never true here. Only the recursive descent into children
         // (`build_inline_element_doc`) reaches the self-closing branch.
-        self_closing: did_self_close(out, end) || is_html_void_element(tag),
+        self_closing,
         omit_softline_allowed: omit_softline_allowed(out, end),
     });
     let doc = crate::doc::propagate_breaks(doc);

--- a/crates/rsvelte_formatter/src/collapse/doc_build.rs
+++ b/crates/rsvelte_formatter/src/collapse/doc_build.rs
@@ -14,6 +14,7 @@ pub(super) fn build_block_branch_doc(
     start: usize,
     end: usize,
     line_width: usize,
+    options: &FormatOptions,
 ) -> Option<Vec<crate::doc::Doc>> {
     use crate::children::Child;
     use crate::doc::Doc;
@@ -23,7 +24,7 @@ pub(super) fn build_block_branch_doc(
 
     let mut children: Vec<Child> = Vec::with_capacity(frag.nodes.len());
     for n in &frag.nodes {
-        children.push(node_to_child(out, n, line_width)?);
+        children.push(node_to_child(out, n, line_width, options)?);
     }
     // The branch tag owns its own outer whitespace, so trim it off the edge text
     // children (prettier's `trimTextNodeLeft` / `trimTextNodeRight`).
@@ -55,6 +56,7 @@ pub(super) fn build_if_block_doc(
     out: &str,
     blk: &rsvelte_core::ast::template::IfBlock,
     line_width: usize,
+    options: &FormatOptions,
 ) -> Option<crate::doc::Doc> {
     use crate::doc::Doc;
     let mut parts: Vec<Doc> = Vec::new();
@@ -69,6 +71,7 @@ pub(super) fn build_if_block_doc(
             cs,
             ce,
             line_width,
+            options,
         )?);
         tok_start = ce;
         let Some(alt) = &cur.alternate else { break };
@@ -77,7 +80,9 @@ pub(super) fn build_if_block_doc(
             None => {
                 let (as_, ae) = block_branch_bounds(out, alt)?;
                 parts.push(Doc::Text(out.get(tok_start..as_)?.to_string()));
-                parts.extend(build_block_branch_doc(out, alt, as_, ae, line_width)?);
+                parts.extend(build_block_branch_doc(
+                    out, alt, as_, ae, line_width, options,
+                )?);
                 tok_start = ae;
                 break;
             }
@@ -97,6 +102,7 @@ pub(super) fn build_simple_block_doc(
     end: u32,
     branches: &[&Fragment],
     line_width: usize,
+    options: &FormatOptions,
 ) -> Option<crate::doc::Doc> {
     use crate::doc::Doc;
     let mut parts: Vec<Doc> = Vec::new();
@@ -104,7 +110,9 @@ pub(super) fn build_simple_block_doc(
     for frag in branches {
         let (cs, ce) = block_branch_bounds(out, frag)?;
         parts.push(Doc::Text(out.get(tok_start..cs)?.to_string()));
-        parts.extend(build_block_branch_doc(out, frag, cs, ce, line_width)?);
+        parts.extend(build_block_branch_doc(
+            out, frag, cs, ce, line_width, options,
+        )?);
         tok_start = ce;
     }
     parts.push(Doc::Text(out.get(tok_start..end as usize)?.to_string()));
@@ -118,12 +126,13 @@ pub(super) fn build_inline_element_doc(
     out: &str,
     e: &rsvelte_core::ast::template::RegularElement,
     line_width: usize,
+    options: &FormatOptions,
 ) -> Option<crate::doc::Doc> {
     use crate::children::{Child, ElementLayout, build_element_doc};
     let attrs = build_attrs_concat(out, &e.attributes)?;
     let mut children: Vec<Child> = Vec::with_capacity(e.fragment.nodes.len());
     for n in &e.fragment.nodes {
-        children.push(node_to_child(out, n, line_width)?);
+        children.push(node_to_child(out, n, line_width, options)?);
     }
     let children = layout_children(out, &e.fragment.nodes, e.start, children);
     Some(build_element_doc(ElementLayout {
@@ -143,12 +152,13 @@ pub(super) fn build_component_doc(
     out: &str,
     c: &rsvelte_core::ast::template::Component,
     line_width: usize,
+    options: &FormatOptions,
 ) -> Option<crate::doc::Doc> {
     use crate::children::{Child, ElementLayout, build_element_doc};
     let attrs = build_attrs_concat(out, &c.attributes)?;
     let mut children: Vec<Child> = Vec::with_capacity(c.fragment.nodes.len());
     for n in &c.fragment.nodes {
-        children.push(node_to_child(out, n, line_width)?);
+        children.push(node_to_child(out, n, line_width, options)?);
     }
     let children = layout_children(out, &c.fragment.nodes, c.start, children);
     Some(build_element_doc(ElementLayout {

--- a/crates/rsvelte_formatter/src/expression/collect.rs
+++ b/crates/rsvelte_formatter/src/expression/collect.rs
@@ -154,6 +154,7 @@ fn collect_node_edits(
             // whose sole child is another IfBlock, so recursing naively would
             // add a level per branch. Mirrors `crate::indent`.
             let mut current: &rsvelte_core::ast::template::IfBlock = blk;
+            let mut is_first = true;
             loop {
                 // Normalize extra whitespace between `{` and `#`/`:` in the
                 // block opener: `{     #if cond}` → `{#if cond}`.
@@ -167,8 +168,13 @@ fn collect_node_edits(
                 // outer parens (`{#if (b)}` → `{#if b}`) and returns the
                 // effective end of the edit (which may be past the AST expression
                 // end when parens were consumed).
+                let prefix_len = if is_first {
+                    "{#if ".len()
+                } else {
+                    "{:else if ".len()
+                };
                 let effective_end =
-                    push_bare_expression(source, &current.test, options, depth, edits)?;
+                    push_bare_expression(source, &current.test, options, depth, prefix_len, edits)?;
                 // Trim trailing whitespace before the header `}` — e.g.
                 // `{#if cond }` → `{#if cond}`.
                 trim_trailing_ws_before_close_brace(source, effective_end, edits);
@@ -182,6 +188,7 @@ fn collect_node_edits(
                     Some(alt) => match crate::indent::else_if_branch(alt) {
                         Some(chained) => {
                             current = chained;
+                            is_first = false;
                         }
                         None => {
                             expand_inline_empty_block_body(alt, depth, options, edits);
@@ -201,7 +208,14 @@ fn collect_node_edits(
             if let Some(start) = blk.expression.start() {
                 normalize_leading_ws_before_expr(source, start, edits);
             }
-            push_bare_expression(source, &blk.expression, options, depth, edits)?;
+            push_bare_expression(
+                source,
+                &blk.expression,
+                options,
+                depth,
+                "{#each ".len(),
+                edits,
+            )?;
             if let Some(ctx) = &blk.context {
                 push_pattern_at_span(source, ctx, options, edits)?;
             }
@@ -356,8 +370,14 @@ fn collect_node_edits(
                 if let Some(start) = blk.expression.start() {
                     normalize_leading_ws_before_expr(source, start, edits);
                 }
-                let expr_end =
-                    push_bare_expression(source, &blk.expression, options, depth, edits)?;
+                let expr_end = push_bare_expression(
+                    source,
+                    &blk.expression,
+                    options,
+                    depth,
+                    "{#await ".len(),
+                    edits,
+                )?;
                 // `blk.value` is the binding from `{#await expr then binding}` (header
                 // inline) when pending is None, or from `{:then binding}` (separator)
                 // when pending is Some.  Only treat it as a header binding in the first
@@ -439,8 +459,14 @@ fn collect_node_edits(
             if let Some(start) = blk.expression.start() {
                 normalize_leading_ws_before_expr(source, start, edits);
             }
-            let effective_end =
-                push_bare_expression(source, &blk.expression, options, depth, edits)?;
+            let effective_end = push_bare_expression(
+                source,
+                &blk.expression,
+                options,
+                depth,
+                "{#key ".len(),
+                edits,
+            )?;
             // Trim `{#key expr }` → `{#key expr}`.
             trim_trailing_ws_before_close_brace(source, effective_end, edits);
             // Expand inline-empty body `{#key expr} {/key}` → blank-line form.
@@ -452,7 +478,14 @@ fn collect_node_edits(
             normalize_block_opener_ws(source, blk.start, edits);
             if blk.parameters.is_empty() {
                 // No params — just normalize the name (`{#snippet foo()}`).
-                push_bare_expression(source, &blk.expression, options, depth, edits)?;
+                push_bare_expression(
+                    source,
+                    &blk.expression,
+                    options,
+                    depth,
+                    "{#snippet ".len(),
+                    edits,
+                )?;
             } else {
                 // Format the whole header `name<…>(params)` as one function
                 // signature so a long parameter list breaks across lines like

--- a/crates/rsvelte_formatter/src/expression/collect.rs
+++ b/crates/rsvelte_formatter/src/expression/collect.rs
@@ -154,7 +154,6 @@ fn collect_node_edits(
             // whose sole child is another IfBlock, so recursing naively would
             // add a level per branch. Mirrors `crate::indent`.
             let mut current: &rsvelte_core::ast::template::IfBlock = blk;
-            let mut is_first = true;
             loop {
                 // Normalize extra whitespace between `{` and `#`/`:` in the
                 // block opener: `{     #if cond}` → `{#if cond}`.
@@ -168,20 +167,8 @@ fn collect_node_edits(
                 // outer parens (`{#if (b)}` → `{#if b}`) and returns the
                 // effective end of the edit (which may be past the AST expression
                 // end when parens were consumed).
-                // `{#if ` = 5 chars, `{:else if ` = 10 chars.
-                let if_prefix_len = if is_first {
-                    "{#if ".len()
-                } else {
-                    "{:else if ".len()
-                };
-                let effective_end = push_bare_expression(
-                    source,
-                    &current.test,
-                    options,
-                    depth,
-                    if_prefix_len,
-                    edits,
-                )?;
+                let effective_end =
+                    push_bare_expression(source, &current.test, options, depth, edits)?;
                 // Trim trailing whitespace before the header `}` — e.g.
                 // `{#if cond }` → `{#if cond}`.
                 trim_trailing_ws_before_close_brace(source, effective_end, edits);
@@ -195,7 +182,6 @@ fn collect_node_edits(
                     Some(alt) => match crate::indent::else_if_branch(alt) {
                         Some(chained) => {
                             current = chained;
-                            is_first = false;
                         }
                         None => {
                             expand_inline_empty_block_body(alt, depth, options, edits);
@@ -215,15 +201,7 @@ fn collect_node_edits(
             if let Some(start) = blk.expression.start() {
                 normalize_leading_ws_before_expr(source, start, edits);
             }
-            // `{#each ` = 7 chars.
-            push_bare_expression(
-                source,
-                &blk.expression,
-                options,
-                depth,
-                "{#each ".len(),
-                edits,
-            )?;
+            push_bare_expression(source, &blk.expression, options, depth, edits)?;
             if let Some(ctx) = &blk.context {
                 push_pattern_at_span(source, ctx, options, edits)?;
             }
@@ -378,15 +356,8 @@ fn collect_node_edits(
                 if let Some(start) = blk.expression.start() {
                     normalize_leading_ws_before_expr(source, start, edits);
                 }
-                // `{#await ` = 8 chars.
-                let expr_end = push_bare_expression(
-                    source,
-                    &blk.expression,
-                    options,
-                    depth,
-                    "{#await ".len(),
-                    edits,
-                )?;
+                let expr_end =
+                    push_bare_expression(source, &blk.expression, options, depth, edits)?;
                 // `blk.value` is the binding from `{#await expr then binding}` (header
                 // inline) when pending is None, or from `{:then binding}` (separator)
                 // when pending is Some.  Only treat it as a header binding in the first
@@ -468,15 +439,8 @@ fn collect_node_edits(
             if let Some(start) = blk.expression.start() {
                 normalize_leading_ws_before_expr(source, start, edits);
             }
-            // `{#key ` = 6 chars.
-            let effective_end = push_bare_expression(
-                source,
-                &blk.expression,
-                options,
-                depth,
-                "{#key ".len(),
-                edits,
-            )?;
+            let effective_end =
+                push_bare_expression(source, &blk.expression, options, depth, edits)?;
             // Trim `{#key expr }` → `{#key expr}`.
             trim_trailing_ws_before_close_brace(source, effective_end, edits);
             // Expand inline-empty body `{#key expr} {/key}` → blank-line form.
@@ -488,15 +452,7 @@ fn collect_node_edits(
             normalize_block_opener_ws(source, blk.start, edits);
             if blk.parameters.is_empty() {
                 // No params — just normalize the name (`{#snippet foo()}`).
-                // `{#snippet ` = 10 chars.
-                push_bare_expression(
-                    source,
-                    &blk.expression,
-                    options,
-                    depth,
-                    "{#snippet ".len(),
-                    edits,
-                )?;
+                push_bare_expression(source, &blk.expression, options, depth, edits)?;
             } else {
                 // Format the whole header `name<…>(params)` as one function
                 // signature so a long parameter list breaks across lines like

--- a/crates/rsvelte_formatter/src/expression/format_core.rs
+++ b/crates/rsvelte_formatter/src/expression/format_core.rs
@@ -20,30 +20,16 @@ use crate::options::FormatOptions;
 /// width) for spots where a break can't survive — block headers and the like.
 /// The result may otherwise be multi-line, with continuation lines at
 /// `oxc_formatter`'s own relative indent (measured from column 0).
-/// Returns `true` if `s` contains the keyword `await` (not as part of a larger
-/// identifier like `awaiting` or `getAwaited`).
-pub(super) fn has_word_await(s: &str) -> bool {
-    let bytes = s.as_bytes();
-    let mut i = 0;
-    while i + 5 <= bytes.len() {
-        if &bytes[i..i + 5] == b"await" {
-            let before_ok = i == 0
-                || !matches!(
-                    bytes[i - 1],
-                    b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'_' | b'$'
-                );
-            let after_ok = i + 5 >= bytes.len()
-                || !matches!(
-                    bytes[i + 5],
-                    b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'_' | b'$'
-                );
-            if before_ok && after_ok {
-                return true;
-            }
-        }
-        i += 1;
-    }
-    false
+/// Nested awaits do not need the statement wrapper's width compensation.
+pub(super) fn has_leading_await(s: &str) -> bool {
+    let rest = s.trim_start_matches(|c: char| c.is_ascii_whitespace() || c == '(');
+    let Some(rest) = rest.strip_prefix("await") else {
+        return false;
+    };
+    !matches!(
+        rest.as_bytes().first(),
+        Some(b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'_' | b'$')
+    )
 }
 
 /// A reserved word or contextual keyword that a bare word matching the
@@ -265,9 +251,9 @@ pub(super) fn format_expr_core(
 
     // The wrapper and source type used to parse the expression snippet vary
     // depending on whether the file is TypeScript and whether the expression
-    // contains `await`:
+    // starts with `await`:
     //
-    // Case A — TypeScript + contains `await`:
+    // Case A — TypeScript + leading `await`:
     //   Use `const _rsvelte_x_ = (expr);` with `SourceType::ts().with_module(true)`.
     //
     //   `with_module(true)` is required so `await` is always a keyword: in
@@ -279,9 +265,8 @@ pub(super) fn format_expr_core(
     //   expression appears as a top-level ExpressionStatement, OXC breaks it
     //   (`(await (await a.nested).one);` → multi-line); as a const initializer
     //   OXC keeps it on one line.  The const wrapper is only used when `await`
-    //   is present to avoid applying the prefix-length compensation below to
-    //   non-await expressions with nested multi-line content (objects, arrays)
-    //   where the extra width would suppress correct inner breaking.
+    //   is the outer expression; applying its width compensation to nested awaits
+    //   would suppress correct inner breaking.
     //
     //   The const-wrapper prefix is exactly 20 characters (`const _rsvelte_x_ = `).
     //   We pass `line_width + 20` to the formatter so OXC's break decision is
@@ -294,11 +279,11 @@ pub(super) fn format_expr_core(
     //   parenthesized expression (`await (x)`, not `await(x)`), so no post-pass
     //   is needed.
     //
-    // Case B — TypeScript, no `await`:
+    // Case B — TypeScript, no leading `await`:
     //   Use `(expr);` with `SourceType::ts().with_module(true)`.
     //   `with_module(true)` ensures consistent TS parsing (e.g., type casts),
-    //   but since there is no `await` the expression statement wrapper doesn't
-    //   cause the multi-line wrapping problem, so no const wrapper is needed.
+    //   Nested awaits remain inside their own expression context, so no const
+    //   wrapper is needed.
     //
     // Case C — JavaScript:
     //   Use `(expr);` with `SourceType::default()` (Unambiguous).
@@ -308,15 +293,15 @@ pub(super) fn format_expr_core(
     // TS_CONST_PREFIX.len() == 20
     const TS_CONST_PREFIX_LEN: u16 = 20;
 
-    let expr_has_await = options.typescript && has_word_await(expr_source);
+    let expr_has_await = options.typescript && has_leading_await(expr_source);
 
     let (wrapped, source_type, use_const_wrapper) = if expr_has_await {
-        // Case A: TS + await — use const wrapper to avoid multi-line breaking
+        // Case A: TS + leading await — use const wrapper to avoid multi-line breaking
         let wrapped = format!("{TS_CONST_PREFIX}({expr_source});");
         let source_type = SourceType::ts().with_module(true);
         (wrapped, source_type, true)
     } else if options.typescript {
-        // Case B: TS, no await — plain paren wrapper, still ESM for consistency
+        // Case B: TS, no leading await — plain paren wrapper, still ESM for consistency
         let wrapped = format!("({expr_source});");
         let source_type = SourceType::ts().with_module(true);
         (wrapped, source_type, false)
@@ -378,6 +363,12 @@ pub(super) fn format_expr_core(
             parser_ret.program.body.first(),
             Some(oxc_ast::ast::Statement::ExpressionStatement(stmt))
                 if expr_has_object_head(&stmt.expression)
+        );
+    let object_type_assertion = !use_const_wrapper
+        && matches!(
+            parser_ret.program.body.first(),
+            Some(oxc_ast::ast::Statement::ExpressionStatement(stmt))
+                if expr_is_object_type_assertion(&stmt.expression)
         );
 
     let mut js = options.js.clone();
@@ -467,9 +458,9 @@ pub(super) fn format_expr_core(
                 inner = stripped;
             }
             format!("({inner})")
-        } else if leading_object_head {
+        } else if leading_object_head || object_type_assertion {
             // Strip the leading `( … )` pair OXC wrapped around the head object,
-            // keeping the postfix (`[key]` / `.foo` / `( … )`) verbatim.
+            // keeping the postfix or type operator verbatim.
             strip_leading_paren_pair(s).unwrap_or_else(|| s.to_string())
         } else {
             strip_outer_parens(s).trim().to_string()
@@ -477,6 +468,16 @@ pub(super) fn format_expr_core(
     };
     EXPR_MEMO.with(|m| m.borrow_mut().insert(key, result.clone()));
     Ok(result)
+}
+
+fn expr_is_object_type_assertion(expr: &oxc_ast::ast::Expression) -> bool {
+    use oxc_ast::ast::Expression as E;
+
+    match expr {
+        E::TSAsExpression(expr) => matches!(expr.expression, E::ObjectExpression(_)),
+        E::TSSatisfiesExpression(expr) => matches!(expr.expression, E::ObjectExpression(_)),
+        _ => false,
+    }
 }
 
 /// AST gate for [`reflow_flat_as_satisfies_unions`]: does the program contain

--- a/crates/rsvelte_formatter/src/expression/splice.rs
+++ b/crates/rsvelte_formatter/src/expression/splice.rs
@@ -12,8 +12,8 @@ use super::declaration::{
 use super::format_core::format_expr_core;
 use super::text::{
     collapse_block_header_expanded_call, collapse_expanded_arg_form,
-    collapse_multiline_to_single_line, compute_header_suffix_len, first_line_ends_with_logical_op,
-    is_method_chain_break, starts_with_array_or_object_literal,
+    collapse_multiline_to_single_line, first_line_ends_with_logical_op, is_method_chain_break,
+    starts_with_array_or_object_literal,
 };
 use super::width::{
     format_content_expression, format_content_expression_with_prefix, format_inline_expression,
@@ -132,7 +132,19 @@ pub(super) fn push_expression_tag(
         return Ok(());
     }
 
-    let formatted = format_content_expression(inner, options, depth)?;
+    let prefix_lead =
+        if tag.start > 0 && source.as_bytes().get(tag.start as usize - 1) == Some(&b'}') {
+            let line_start = source[..tag.start as usize]
+                .rfind('\n')
+                .map_or(0, |index| index + 1);
+            let source_column =
+                UnicodeWidthStr::width(source.get(line_start..tag.start as usize).unwrap_or(""));
+            let indent = depth * options.js.indent_width.value() as usize;
+            source_column.saturating_sub(indent) + 1
+        } else {
+            1
+        };
+    let formatted = format_content_expression_with_prefix(inner, options, depth, prefix_lead)?;
     edits.push((tag.start, tag.end, format!("{{{formatted}}}")));
     Ok(())
 }
@@ -379,7 +391,6 @@ pub(super) fn push_bare_expression(
     expr: &Expression,
     options: &FormatOptions,
     depth: usize,
-    prefix_len: usize,
     edits: &mut Vec<(u32, u32, String)>,
 ) -> Result<u32, FormatError> {
     let (Some(start), Some(end)) = (expr.start(), expr.end()) else {
@@ -392,13 +403,7 @@ pub(super) fn push_bare_expression(
     if slice.is_empty() {
         return Ok(end);
     }
-    let indent_width = options.js.indent_width.value() as usize;
     let full_width = options.js.line_width.value() as usize;
-    // Compute the header suffix length — the text from the expression end to the
-    // closing `}` of the block header (inclusive).  For `{#each expr as x (k)}`,
-    // this is ` as x (k)}`.  For `{#if cond}`, it is `}`.  We scan the source
-    // looking for the first `}` that is not nested inside `{…}`, `(…)`, or `[…]`.
-    let suffix_len = compute_header_suffix_len(source, end as usize);
     // First format inline (single-line) to get the canonical expression text.
     let formatted = format_inline_expression(slice, options)?;
     // prettier-plugin-svelte forces block-header expressions onto one line
@@ -432,48 +437,14 @@ pub(super) fn push_bare_expression(
     // When wrapping, we pass the full `line_width` to OXC.  Continuation lines
     // carry only the block's indent (not the keyword prefix), so using the full
     // width avoids over-wrapping inner call arguments.
-    // Compute the full visible start-of-line width: indentation + block keyword prefix.
-    // prettier-plugin-svelte breaks a block-header expression when the COMPLETE header
-    // line (indent + keyword + expression + suffix-after-expression) would overflow the
-    // print width, not just when the expression alone is wider than the print width.
-    // E.g. `{#each table.call().filter() as column (column)}` can overflow even though
-    // `table.call().filter()` alone fits within 80 chars.
-    let lead_width = depth * indent_width + prefix_len;
     let formatted = if !formatted.contains('\n')
-            && lead_width + UnicodeWidthStr::width(formatted.as_str()) + suffix_len > full_width
+            && UnicodeWidthStr::width(formatted.as_str()) > full_width
             // prettier-plugin-svelte never breaks array or object literals in
             // block headers even when they are far wider than the print width —
             // e.g. `{#each ["a", "b", "c", …] as x}` stays on one line.
             && !starts_with_array_or_object_literal(formatted.as_str())
     {
-        // First, try at the full line width — OXC may already decide to break
-        // when the expression alone overflows.
         let multi = format_expr_core(slice, options, options.js.line_width, false)?;
-        // If full-width didn't break, try a narrower width computed from how
-        // much room the expression actually has in the block header:
-        //   available = full_width − lead_width − suffix_len
-        // This mirrors the oracle's decision: a method chain breaks when the
-        // complete header line overflows, even if the expression alone fits
-        // within `full_width`.  We only use the narrowed result when OXC breaks
-        // it as a method chain (hard line breaks starting with `.`).
-        let multi = if multi.contains('\n') {
-            multi
-        } else {
-            let expr_len = UnicodeWidthStr::width(formatted.as_str());
-            let available = full_width.saturating_sub(lead_width + suffix_len);
-            // Only narrow when the expression genuinely doesn't fit in the
-            // available space; use `expr_len - 1` as the narrowed width to
-            // force the break while giving inner content maximum room.
-            if expr_len > available {
-                let narrowed_width = oxc_formatter_core::LineWidth::try_from(
-                    (expr_len.saturating_sub(1)).max(1) as u16,
-                )
-                .unwrap_or(options.js.line_width);
-                format_expr_core(slice, options, narrowed_width, false)?
-            } else {
-                multi
-            }
-        };
         // Only accept a method-chain break (hard `.`-led continuation lines,
         // which prettier's removeLines keeps); OXC's soft argument-wrap breaks are
         // collapsed back to one line by the oracle.

--- a/crates/rsvelte_formatter/src/expression/splice.rs
+++ b/crates/rsvelte_formatter/src/expression/splice.rs
@@ -12,8 +12,8 @@ use super::declaration::{
 use super::format_core::format_expr_core;
 use super::text::{
     collapse_block_header_expanded_call, collapse_expanded_arg_form,
-    collapse_multiline_to_single_line, first_line_ends_with_logical_op, is_method_chain_break,
-    starts_with_array_or_object_literal,
+    collapse_multiline_to_single_line, compute_header_suffix_len, first_line_ends_with_logical_op,
+    is_method_chain_break, starts_with_array_or_object_literal,
 };
 use super::width::{
     format_content_expression, format_content_expression_with_prefix, format_inline_expression,
@@ -68,6 +68,27 @@ fn expression_code_range(rest: &str, options: &FormatOptions) -> Option<std::ops
     let (start, end) = (span.start as usize, span.end as usize);
     // The `(` wrapper shifts every offset by one byte.
     (start >= 1 && end >= start && end - 1 <= rest.len()).then(|| start - 1..end - 1)
+}
+
+fn is_top_level_call_expression(source: &str, options: &FormatOptions) -> bool {
+    let allocator = crate::scratch::acquire();
+    let wrapped = format!("({source});");
+    let source_type = if options.typescript {
+        SourceType::ts().with_module(true)
+    } else {
+        SourceType::default()
+    };
+    let ret = Parser::new(allocator, &wrapped, source_type)
+        .with_options(formatter_parse_options())
+        .parse();
+    if !ret.diagnostics.is_empty() {
+        return false;
+    }
+    matches!(
+        ret.program.body.first(),
+        Some(oxc_ast::ast::Statement::ExpressionStatement(stmt))
+            if matches!(stmt.expression, oxc_ast::ast::Expression::CallExpression(_))
+    )
 }
 
 pub(super) fn push_expression_tag(
@@ -391,6 +412,7 @@ pub(super) fn push_bare_expression(
     expr: &Expression,
     options: &FormatOptions,
     depth: usize,
+    prefix_len: usize,
     edits: &mut Vec<(u32, u32, String)>,
 ) -> Result<u32, FormatError> {
     let (Some(start), Some(end)) = (expr.start(), expr.end()) else {
@@ -403,7 +425,9 @@ pub(super) fn push_bare_expression(
     if slice.is_empty() {
         return Ok(end);
     }
+    let indent_width = options.js.indent_width.value() as usize;
     let full_width = options.js.line_width.value() as usize;
+    let suffix_len = compute_header_suffix_len(source, end as usize);
     // First format inline (single-line) to get the canonical expression text.
     let formatted = format_inline_expression(slice, options)?;
     // prettier-plugin-svelte forces block-header expressions onto one line
@@ -427,24 +451,29 @@ pub(super) fn push_bare_expression(
     } else {
         formatted
     };
-    // prettier-plugin-svelte wraps a block-header expression across lines when
-    // the expression itself is longer than the print width (OXC at `full_width`
-    // would break it).  When the expression fits within `full_width` — even if
-    // the full header line (prefix + expression + suffix) overflows 80 cols —
-    // prettier keeps it inline.  This avoids break points at logical operators
-    // (`&&`, `||`) that OXC would pick but prettier does not in block headers.
-    //
-    // When wrapping, we pass the full `line_width` to OXC.  Continuation lines
-    // carry only the block's indent (not the keyword prefix), so using the full
-    // width avoids over-wrapping inner call arguments.
+    let expression_width = UnicodeWidthStr::width(formatted.as_str());
+    let header_width = depth * indent_width + prefix_len + expression_width + suffix_len;
+    // The oracle accounts for the full header around call expressions, but keeps
+    // a fitting plain member chain inline even when its `as` suffix overflows.
+    let should_break = expression_width > full_width
+        || (header_width > full_width && is_top_level_call_expression(slice, options));
     let formatted = if !formatted.contains('\n')
-            && UnicodeWidthStr::width(formatted.as_str()) > full_width
+            && should_break
             // prettier-plugin-svelte never breaks array or object literals in
             // block headers even when they are far wider than the print width —
             // e.g. `{#each ["a", "b", "c", …] as x}` stays on one line.
             && !starts_with_array_or_object_literal(formatted.as_str())
     {
         let multi = format_expr_core(slice, options, options.js.line_width, false)?;
+        let multi = if multi.contains('\n') || expression_width > full_width {
+            multi
+        } else {
+            let narrowed_width = oxc_formatter_core::LineWidth::try_from(
+                expression_width.saturating_sub(1).max(1) as u16,
+            )
+            .unwrap_or(options.js.line_width);
+            format_expr_core(slice, options, narrowed_width, false)?
+        };
         // Only accept a method-chain break (hard `.`-led continuation lines,
         // which prettier's removeLines keeps); OXC's soft argument-wrap breaks are
         // collapsed back to one line by the oracle.

--- a/crates/rsvelte_formatter/src/expression/tests.rs
+++ b/crates/rsvelte_formatter/src/expression/tests.rs
@@ -1,4 +1,4 @@
-use super::format_core::{has_word_await, trivial_expr_verbatim};
+use super::format_core::{has_leading_await, trivial_expr_verbatim};
 use super::text::{
     collapse_block_header_expanded_call, collapse_expanded_arg_form, expand_obj_arg_call,
     outer_parens_match, strip_leading_paren_pair, strip_outer_parens,
@@ -83,25 +83,11 @@ fn trivial_fastpath_rejects_reserved_and_nonverbatim() {
 }
 
 #[test]
-fn has_word_await_detects_standalone() {
-    assert!(has_word_await("await foo"));
-    assert!(has_word_await("x = await bar()"));
-    assert!(has_word_await("(await x)"));
-}
-
-#[test]
-fn has_word_await_rejects_subword() {
-    assert!(!has_word_await("getAwaiter"));
-    assert!(!has_word_await("awaiting"));
-    assert!(!has_word_await("noawait"));
-    assert!(!has_word_await("$await"));
-    assert!(!has_word_await("_await"));
-}
-
-#[test]
-fn has_word_await_empty() {
-    assert!(!has_word_await(""));
-    assert!(!has_word_await("foo bar"));
+fn leading_await_excludes_nested_arrow_body() {
+    assert!(has_leading_await("await (await value).field"));
+    assert!(has_leading_await("((await value).field)"));
+    assert!(!has_leading_await("async () => await value"));
+    assert!(!has_leading_await("awaiting + await value"));
 }
 
 #[test]

--- a/crates/rsvelte_formatter/src/expression/text.rs
+++ b/crates/rsvelte_formatter/src/expression/text.rs
@@ -130,6 +130,45 @@ pub(super) fn collapse_multiline_to_single_line(formatted: &str) -> String {
     format!("{first}{joined}{last}")
 }
 
+pub(super) fn compute_header_suffix_len(source: &str, expr_end: usize) -> usize {
+    let Some(tail) = source.get(expr_end..) else {
+        return 0;
+    };
+    let mut depth = 0i32;
+    let mut scanned_bytes = 0usize;
+    let mut quote = None;
+    let chars: Vec<char> = tail.chars().collect();
+    let mut index = 0usize;
+    while index < chars.len() {
+        let character = chars[index];
+        scanned_bytes += character.len_utf8();
+        match quote {
+            Some(delimiter) => {
+                if character == '\\' {
+                    index += 1;
+                    if index < chars.len() {
+                        scanned_bytes += chars[index].len_utf8();
+                    }
+                } else if character == delimiter {
+                    quote = None;
+                }
+            }
+            None => match character {
+                '"' | '\'' | '`' => quote = Some(character),
+                '{' | '(' | '[' => depth += 1,
+                '}' if depth == 0 => {
+                    return UnicodeWidthStr::width(&tail[..scanned_bytes]);
+                }
+                '}' | ')' | ']' if depth > 0 => depth -= 1,
+                '\n' => return 0,
+                _ => {}
+            },
+        }
+        index += 1;
+    }
+    0
+}
+
 /// Returns `true` when OXC's multi-line output represents a method-chain break —
 /// i.e. at least one continuation line starts with `.` after trimming whitespace.
 /// This distinguishes call-chain breaks (hardlines in prettier, kept by removeLines)
@@ -537,3 +576,4 @@ pub(crate) fn expand_obj_arg_call(s: &str, indent_width: usize) -> Option<String
         Some(result)
     }
 }
+use unicode_width::UnicodeWidthStr;

--- a/crates/rsvelte_formatter/src/expression/text.rs
+++ b/crates/rsvelte_formatter/src/expression/text.rs
@@ -130,66 +130,6 @@ pub(super) fn collapse_multiline_to_single_line(formatted: &str) -> String {
     format!("{first}{joined}{last}")
 }
 
-/// Computes the length of the block-header "suffix" — the text from the end of the
-/// block's expression to the closing `}` of the header line (inclusive).
-///
-/// For `{#each items as x (k)}`, if `expr_end` points right after `items`, the suffix
-/// is ` as x (k)}` (length 12).  For `{#if cond}` with `expr_end` after `cond`, the
-/// suffix is `}` (length 1).
-///
-/// We scan forward through `source` starting at `expr_end`, tracking brace/paren/bracket
-/// depth, and stop at the first `}` that returns us to depth 0.
-pub(super) fn compute_header_suffix_len(source: &str, expr_end: usize) -> usize {
-    let tail = match source.get(expr_end..) {
-        Some(t) => t,
-        None => return 0,
-    };
-    let mut depth: i32 = 0;
-    let mut len = 0usize;
-    let mut in_string: Option<char> = None;
-    let chars: Vec<char> = tail.chars().collect();
-    let mut i = 0;
-    while i < chars.len() {
-        let c = chars[i];
-        len += c.len_utf8();
-        match in_string {
-            Some(q) => {
-                if c == '\\' {
-                    // skip next char
-                    i += 1;
-                    if i < chars.len() {
-                        len += chars[i].len_utf8();
-                    }
-                } else if c == q {
-                    in_string = None;
-                }
-            }
-            None => match c {
-                '"' | '\'' | '`' => in_string = Some(c),
-                '{' | '(' | '[' => depth += 1,
-                '}' => {
-                    if depth == 0 {
-                        // This `}` closes the block header — include it and stop.
-                        return len;
-                    }
-                    depth -= 1;
-                }
-                ')' | ']' if depth > 0 => {
-                    depth -= 1;
-                }
-                '\n' => {
-                    // If we hit a newline before finding the closing `}`, the
-                    // header closes on the next line — return current len (0 suffix).
-                    return 0;
-                }
-                _ => {}
-            },
-        }
-        i += 1;
-    }
-    0
-}
-
 /// Returns `true` when OXC's multi-line output represents a method-chain break —
 /// i.e. at least one continuation line starts with `.` after trimming whitespace.
 /// This distinguishes call-chain breaks (hardlines in prettier, kept by removeLines)

--- a/crates/rsvelte_formatter/src/expression/width.rs
+++ b/crates/rsvelte_formatter/src/expression/width.rs
@@ -165,9 +165,9 @@ pub(super) fn format_content_expression_with_prefix(
     // width so OXC breaks it the same way prettier-plugin-svelte does.
     // `overhead` = prefix_lead (e.g. `{@render ` = 9) + 1 (closing `}`).
     let overhead = prefix_lead + 1;
-    let formatted = if !formatted.contains('\n')
-        && lead + overhead + UnicodeWidthStr::width(formatted.as_str()) > full_width
-    {
+    let first_line_width =
+        UnicodeWidthStr::width(formatted.lines().next().unwrap_or(formatted.as_str()));
+    let formatted = if lead + overhead + first_line_width > full_width {
         let narrowed2 = full_width.saturating_sub(lead + overhead);
         let lw2 = oxc_formatter_core::LineWidth::try_from(narrowed2.max(1) as u16)
             .unwrap_or(options.js.line_width);

--- a/crates/rsvelte_formatter/src/markup/attribute.rs
+++ b/crates/rsvelte_formatter/src/markup/attribute.rs
@@ -4,8 +4,8 @@ use crate::error::FormatError;
 use crate::options::FormatOptions;
 
 use super::directive::{
-    format_expression_at, render_directive_value, render_directive_value_narrow, render_modifiers,
-    render_spread,
+    format_expression_at, format_expression_at_extra, render_directive_value,
+    render_directive_value_narrow, render_modifiers, render_spread,
 };
 use super::util::visual_width;
 use super::value::{render_attribute_node, render_attribute_value_for_directive};
@@ -25,8 +25,26 @@ pub(super) fn render_attribute(
         }
         Attribute::SpreadAttribute(spread) => render_spread(spread, source, options, attr_depth),
         Attribute::AttachTag(attach) => {
-            let inner = format_expression_at(source, &attach.expression, options, attr_depth)?
+            let mut inner = format_expression_at(source, &attach.expression, options, attr_depth)?
                 .unwrap_or_default();
+            const ATTACH_PREFIX: &str = "{@attach ";
+            if narrow_value
+                && !inner.contains('\n')
+                && attr_depth * options.js.indent_width.value() as usize
+                    + ATTACH_PREFIX.len()
+                    + visual_width(&inner)
+                    + 1
+                    > options.js.line_width.value() as usize
+            {
+                inner = format_expression_at_extra(
+                    source,
+                    &attach.expression,
+                    options,
+                    attr_depth,
+                    ATTACH_PREFIX.len() + 1,
+                )?
+                .unwrap_or(inner);
+            }
             Ok(format!("{{@attach {inner}}}"))
         }
         Attribute::BindDirective(d) => {

--- a/crates/rsvelte_formatter/src/markup/directive.rs
+++ b/crates/rsvelte_formatter/src/markup/directive.rs
@@ -138,6 +138,16 @@ pub(super) fn format_expression_at(
     options: &FormatOptions,
     attr_depth: usize,
 ) -> Result<Option<String>, FormatError> {
+    format_expression_at_extra(source, expr, options, attr_depth, 0)
+}
+
+pub(super) fn format_expression_at_extra(
+    source: &str,
+    expr: &Expression,
+    options: &FormatOptions,
+    attr_depth: usize,
+    extra_lead: usize,
+) -> Result<Option<String>, FormatError> {
     let (Some(start), Some(end)) = (expr.start(), expr.end()) else {
         return Ok(None);
     };
@@ -149,6 +159,6 @@ pub(super) fn format_expression_at(
         return Ok(None);
     }
     Ok(Some(format_attribute_value_expression(
-        raw, options, attr_depth, 0,
+        raw, options, attr_depth, extra_lead,
     )?))
 }

--- a/crates/rsvelte_formatter/src/markup/value.rs
+++ b/crates/rsvelte_formatter/src/markup/value.rs
@@ -37,7 +37,7 @@ pub(super) fn expression_tag_inner<'a>(tag: &ExpressionTag, source: &'a str) -> 
 /// `name={` prefix (that over-wraps the body). Detected syntactically: no arrow
 /// and no leading object/array/function token.
 pub(super) fn is_shallow_value(src: &str) -> bool {
-    if src.contains("=>") {
+    if has_top_level_arrow(src) {
         return false;
     }
     let t = src.trim_start();
@@ -45,6 +45,37 @@ pub(super) fn is_shallow_value(src: &str) -> bool {
     // (`(a ?? b) === c`), not a block body — only arrows open a body, and those
     // are already excluded by the `=>` check above.
     !(t.starts_with('{') || t.starts_with('[') || t.starts_with("function"))
+}
+
+fn has_top_level_arrow(src: &str) -> bool {
+    let bytes = src.as_bytes();
+    let mut depth = 0usize;
+    let mut quote: Option<u8> = None;
+    let mut escaped = false;
+    let mut index = 0usize;
+    while index < bytes.len() {
+        let byte = bytes[index];
+        if let Some(delimiter) = quote {
+            if escaped {
+                escaped = false;
+            } else if byte == b'\\' {
+                escaped = true;
+            } else if byte == delimiter {
+                quote = None;
+            }
+            index += 1;
+            continue;
+        }
+        match byte {
+            b'\'' | b'"' | b'`' => quote = Some(byte),
+            b'(' | b'[' | b'{' => depth += 1,
+            b')' | b']' | b'}' => depth = depth.saturating_sub(1),
+            b'=' if depth == 0 && bytes.get(index + 1) == Some(&b'>') => return true,
+            _ => {}
+        }
+        index += 1;
+    }
+    false
 }
 
 /// Render an attribute whose value is a single `{expr}` mustache (whether the
@@ -142,6 +173,27 @@ fn render_single_expression_value(
                     let prefix_result =
                         format_attribute_value_expression(inner_src, options, attr_depth, prefix)?;
                     if prefix_result.contains('\n') {
+                        let has_chain_break = prefix_result.lines().skip(1).any(|line| {
+                            let line = line.trim_start();
+                            line.starts_with('.') || line.starts_with("?.")
+                        });
+                        if has_chain_break {
+                            let prefix_first =
+                                prefix_result.lines().next().unwrap_or("").trim_end();
+                            let prefix_total =
+                                indent_cols + prefix + visual_width(prefix_first) + 1;
+                            if prefix_total <= line_width {
+                                return Ok(format!("{}={{{prefix_result}}}", node.name));
+                            }
+                            let overflow = prefix_total - line_width;
+                            let tighter = format_attribute_value_expression(
+                                inner_src,
+                                options,
+                                attr_depth,
+                                prefix + overflow + 1,
+                            )?;
+                            return Ok(format!("{}={{{tighter}}}", node.name));
+                        }
                         // The `prefix` narrowing forced a break. Try widening to
                         // `single_line_len` to give inner content more room.
                         let base_width = line_width.saturating_sub(indent_cols);
@@ -166,7 +218,7 @@ fn render_single_expression_value(
                     } else {
                         prefix_result
                     }
-                } else if inner_src.contains("=>") {
+                } else if has_top_level_arrow(inner_src) {
                     // Arrow function: narrow so the arrow body breaks when the
                     // attribute line overflows.
                     //
@@ -217,6 +269,19 @@ fn render_single_expression_value(
             // Multi-line shallow: check the first line to decide whether to
             // re-format with extra_lead.
             let first_line = formatted.lines().next().unwrap_or("").trim_end();
+            let first_line_total = indent_cols + prefix + visual_width(first_line) + 1;
+            if first_line_total > line_width {
+                let overflow = first_line_total - line_width;
+                let tighter = format_attribute_value_expression(
+                    inner_src,
+                    options,
+                    attr_depth,
+                    prefix + overflow + 1,
+                )?;
+                if tighter.lines().next().unwrap_or("").trim_end() != first_line {
+                    return Ok(format!("{}={{{tighter}}}", node.name));
+                }
+            }
             // If the first line ends with `{` or `[`, an inner block/array is
             // being expanded — the continuation lines are inside that block and
             // do NOT start at the attribute column with the `name={` prefix.

--- a/crates/rsvelte_formatter/tests/real_world_parity.rs
+++ b/crates/rsvelte_formatter/tests/real_world_parity.rs
@@ -1,0 +1,393 @@
+use oxc_formatter::QuoteStyle;
+use rsvelte_formatter::{FormatOptions, JsFormatOptions, LineWidth, format};
+
+fn options() -> FormatOptions {
+    FormatOptions {
+        js: JsFormatOptions {
+            line_width: LineWidth::try_from(100).expect("valid line width"),
+            quote_style: QuoteStyle::Single,
+            ..JsFormatOptions::new()
+        },
+        ..FormatOptions::default()
+    }
+}
+
+fn assert_parity(source: &str, expected: &str) {
+    let formatted = format(source, &options()).expect("format ok");
+    assert_eq!(formatted, expected);
+    assert_eq!(
+        format(&formatted, &options()).expect("format ok"),
+        formatted,
+        "formatting must be idempotent"
+    );
+}
+
+#[test]
+fn adjacent_content_expression_accounts_for_previous_sibling_width() {
+    let source = r#"<section>
+  <div>
+    <div>
+      <div>
+        <div>
+          <div>
+            <Label>
+              {formatTarget(suggestion.target)}{suggestion.targetName == null || suggestion.targetName === ''
+                ? ''
+                : `「${suggestion.targetName}」`}
+            </Label>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+"#;
+    let expected = r#"<section>
+  <div>
+    <div>
+      <div>
+        <div>
+          <div>
+            <Label>
+              {formatTarget(suggestion.target)}{suggestion.targetName == null ||
+              suggestion.targetName === ''
+                ? ''
+                : `「${suggestion.targetName}」`}
+            </Label>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+"#;
+    assert_parity(source, expected);
+}
+
+#[test]
+fn attach_attribute_accounts_for_directive_prefix() {
+    let source = r#"<section>
+  <div>
+    <button
+      popovertarget={popoverTarget}
+      {tabindex}
+      {disabled}
+      {@attach effectiveTooltip != null && tooltip({ content: effectiveTooltip, placement: 'right' })}
+    >
+      {@render content()}
+    </button>
+  </div>
+</section>
+"#;
+    let expected = r#"<section>
+  <div>
+    <button
+      popovertarget={popoverTarget}
+      {tabindex}
+      {disabled}
+      {@attach effectiveTooltip != null &&
+        tooltip({ content: effectiveTooltip, placement: 'right' })}
+    >
+      {@render content()}
+    </button>
+  </div>
+</section>
+"#;
+    assert_parity(source, expected);
+}
+
+#[test]
+fn optional_chain_attribute_breaks_at_oracle_boundary() {
+    let source = r#"<section>
+  <Report
+    selectedCategories={dashboardFilter?.getDrillDownQuery(reportData.reportId)?.selectedCategories ??
+      []}
+  />
+</section>
+"#;
+    let expected = r#"<section>
+  <Report
+    selectedCategories={dashboardFilter?.getDrillDownQuery(reportData.reportId)
+      ?.selectedCategories ?? []}
+  />
+</section>
+"#;
+    assert_parity(source, expected);
+}
+
+#[test]
+fn each_header_keeps_fitting_member_chain_inline() {
+    let source = r#"<Field label="Output" tag="fieldset" width="100%">
+  <div class="flex flex-col gap-y-2">
+    {#each selectedNode.data.config
+      .outputContexts as outputContext, index (outputContext.key + index)}
+      <div>{outputContext.key}</div>
+    {/each}
+  </div>
+</Field>
+"#;
+    let expected = r#"<Field label="Output" tag="fieldset" width="100%">
+  <div class="flex flex-col gap-y-2">
+    {#each selectedNode.data.config.outputContexts as outputContext, index (outputContext.key + index)}
+      <div>{outputContext.key}</div>
+    {/each}
+  </div>
+</Field>
+"#;
+    assert_parity(source, expected);
+}
+
+#[test]
+fn satisfies_object_attribute_drops_statement_context_parentheses() {
+    let source = r#"<script lang="ts"></script>
+
+{#if isQueryBuilderQuery(queryBase)}
+  <QueryBuilder
+    bind:query={queryBase}
+    binaryConditionOnAdded={({
+      type: 'BINARY',
+      left: { field: '', fieldType: 'STRING' },
+      masterBinaryOperator: 'EQUAL',
+      right: '',
+    }) satisfies BinaryCondition}
+  />
+{/if}
+"#;
+    let expected = r#"<script lang="ts"></script>
+
+{#if isQueryBuilderQuery(queryBase)}
+  <QueryBuilder
+    bind:query={queryBase}
+    binaryConditionOnAdded={{
+      type: 'BINARY',
+      left: { field: '', fieldType: 'STRING' },
+      masterBinaryOperator: 'EQUAL',
+      right: '',
+    } satisfies BinaryCondition}
+  />
+{/if}
+"#;
+    assert_parity(source, expected);
+}
+
+#[test]
+fn nested_component_children_follow_oracle_hugging() {
+    let source = r#"<ol>
+  <li class="flex items-start gap-x-8">
+    <span class="step-no flex shrink-0 justify-center items-center"
+      ><Text type="caption-12" color="inherit">1</Text></span
+    >
+    <Text type="body-13" color="gray-700">Workflow「{buildInfo.workflow ??
+      'Default workflow name'}」を<Text
+      tag="span"
+      type="body-13-bold">publish</Text
+    >します。</Text>
+  </li>
+  <li class="flex items-start gap-x-8">
+    <span class="step-no flex shrink-0 justify-center items-center"
+      ><Text type="caption-12" color="inherit">2</Text></span
+    >
+    <Text type="body-13" color="gray-700">After publishing、selected tableに<Text
+      tag="span"
+      type="body-13-bold">new records</Text
+    >が追加されます。</Text>
+  </li>
+</ol>
+"#;
+    let expected = r#"<ol>
+  <li class="flex items-start gap-x-8">
+    <span class="step-no flex shrink-0 justify-center items-center"
+      ><Text type="caption-12" color="inherit">1</Text></span
+    >
+    <Text type="body-13" color="gray-700"
+      >Workflow「{buildInfo.workflow ?? 'Default workflow name'}」を<Text
+        tag="span"
+        type="body-13-bold">publish</Text
+      >します。</Text
+    >
+  </li>
+  <li class="flex items-start gap-x-8">
+    <span class="step-no flex shrink-0 justify-center items-center"
+      ><Text type="caption-12" color="inherit">2</Text></span
+    >
+    <Text type="body-13" color="gray-700"
+      >After publishing、selected tableに<Text tag="span" type="body-13-bold">new records</Text
+      >が追加されます。</Text
+    >
+  </li>
+</ol>
+"#;
+    assert_parity(source, expected);
+}
+
+#[test]
+fn arrow_attribute_body_uses_rendered_column_width() {
+    let source = r#"<script lang="ts"></script>
+
+<section>
+  <div>
+    <div>
+      <Modal
+        onsubmit={async (enableEmbedding: boolean) => {
+          try {
+            await persistAiGrouping(enableEmbedding);
+          } catch (err) {
+            const fallbackMessage = enableEmbedding ? '類似検索の有効化または作成に失敗しました' : '作成に失敗しました';
+            const queryWithExclusions = buildQueryWithExcludedRecords(baseQuery, excludedRecordIds);
+            const res = await backendClient.api.v1['table-records'][':tableId']['bulk-delete'].$post({
+              param: { tableId },
+            });
+            if (field.maxSelectionCount === 1 && currentValue.length === 1 && diff.added.length > 0) {
+              return;
+            }
+          }
+        }}
+      />
+    </div>
+  </div>
+</section>
+"#;
+    let expected = r#"<script lang="ts"></script>
+
+<section>
+  <div>
+    <div>
+      <Modal
+        onsubmit={async (enableEmbedding: boolean) => {
+          try {
+            await persistAiGrouping(enableEmbedding);
+          } catch (err) {
+            const fallbackMessage = enableEmbedding
+              ? '類似検索の有効化または作成に失敗しました'
+              : '作成に失敗しました';
+            const queryWithExclusions = buildQueryWithExcludedRecords(baseQuery, excludedRecordIds);
+            const res = await backendClient.api.v1['table-records'][':tableId'][
+              'bulk-delete'
+            ].$post({
+              param: { tableId },
+            });
+            if (
+              field.maxSelectionCount === 1 &&
+              currentValue.length === 1 &&
+              diff.added.length > 0
+            ) {
+              return;
+            }
+          }
+        }}
+      />
+    </div>
+  </div>
+</section>
+"#;
+    assert_parity(source, expected);
+}
+
+#[test]
+fn deep_attribute_chain_breaks_call_before_optional_member() {
+    let source = r#"<section>
+  <div>
+    <div>
+      <div>
+        <div>
+          <div>
+            <div>
+              <div>
+                <div>
+                  <div>
+                    <DropdownTrigger
+                      label={propOperatorOptions.find((o) => o.value === condition.masterBinaryOperator)?.label}
+                    />
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+"#;
+    let expected = r#"<section>
+  <div>
+    <div>
+      <div>
+        <div>
+          <div>
+            <div>
+              <div>
+                <div>
+                  <div>
+                    <DropdownTrigger
+                      label={propOperatorOptions.find(
+                        (o) => o.value === condition.masterBinaryOperator,
+                      )?.label}
+                    />
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+"#;
+    assert_parity(source, expected);
+}
+
+#[test]
+fn deep_attribute_call_accounts_for_name_prefix() {
+    let source = r#"<section>
+  <div>
+    <div>
+      <div>
+        <div>
+          <div>
+            <div>
+              <DropdownMenuItemAction
+                label="History"
+                icon="file-clock"
+                href={resolve('/(app)/folders/[parentFolderId]/tables/[tableId]/import-export-history', {
+                  parentFolderId,
+                  tableId,
+                })}
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+"#;
+    let expected = r#"<section>
+  <div>
+    <div>
+      <div>
+        <div>
+          <div>
+            <div>
+              <DropdownMenuItemAction
+                label="History"
+                icon="file-clock"
+                href={resolve(
+                  '/(app)/folders/[parentFolderId]/tables/[tableId]/import-export-history',
+                  {
+                    parentFolderId,
+                    tableId,
+                  },
+                )}
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+"#;
+    assert_parity(source, expected);
+}

--- a/crates/rsvelte_formatter/tests/real_world_parity.rs
+++ b/crates/rsvelte_formatter/tests/real_world_parity.rs
@@ -138,6 +138,102 @@ fn each_header_keeps_fitting_member_chain_inline() {
 }
 
 #[test]
+fn each_call_chain_accounts_for_full_header_width() {
+    let source = r#"<section>
+  <div>
+    <div>
+      <div>
+        <div>
+          <div>
+            <div>
+              <div>
+                <div>
+                  {#each table.getAllColumns().filter((column) => column.getCanHide()) as column (column)}
+                    <div>{column.id}</div>
+                  {/each}
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+"#;
+    let expected = r#"<section>
+  <div>
+    <div>
+      <div>
+        <div>
+          <div>
+            <div>
+              <div>
+                <div>
+                  {#each table
+                    .getAllColumns()
+                    .filter((column) => column.getCanHide()) as column (column)}
+                    <div>{column.id}</div>
+                  {/each}
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+"#;
+    assert_parity(source, expected);
+}
+
+#[test]
+fn each_expanded_call_accounts_for_full_header_width() {
+    let source = r#"<section>
+  <div>
+    <div>
+      <div>
+        <div>
+          <div>
+            <div>
+              <div>
+                {#each options.filter((option) => selectedValues.has(option.value)) as option (option)}
+                  <div>{option.value}</div>
+                {/each}
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+"#;
+    let expected = r#"<section>
+  <div>
+    <div>
+      <div>
+        <div>
+          <div>
+            <div>
+              <div>
+                {#each options.filter( (option) => selectedValues.has(option.value) ) as option (option)}
+                  <div>{option.value}</div>
+                {/each}
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+"#;
+    assert_parity(source, expected);
+}
+
+#[test]
 fn satisfies_object_attribute_drops_statement_context_parentheses() {
     let source = r#"<script lang="ts"></script>
 


### PR DESCRIPTION
## Summary

- match oxfmt 0.60.0 when rendered attribute prefixes change the available expression width
- preserve oxfmt's block-header, TypeScript assertion, adjacent interpolation, and nested component-child layouts
- add exact-output and idempotence regressions for the real-world layout classes
- add a patch changeset for `@rsvelte/fmt`

## Context

- **Problem:** A migration surfaced 14 Svelte layout differences between `rsvelte-fmt` and the current oxfmt Svelte oracle.
- **Scope:** This PR fixes the native Svelte formatter. It intentionally does not emulate the older oxfmt 0.49.0 output used by the downstream repository.
- **Approach:** Width decisions now include the rendered Svelte prefix where the oracle does, while nested callback expressions avoid unrelated top-level width compensation. Component children also use the same breakable expression document path as regular elements.

## Verification

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test -p rsvelte_formatter`
- [x] 17 downstream Svelte files format byte-for-byte identically to oxfmt 0.60.0
- [x] oxfmt 0.60.0 reports all 18 matched files correctly formatted

## User guide

Not applicable. This changes a developer formatter package and includes its release changeset.
