### PR TITLE
perf(compiler): reuse retained program for no-op TypeScript

### DIFF
--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
@@ -469,12 +469,7 @@ fn transform_client_with_visitors(
                 options.dev,
                 &reactive_import_names,
                 split_top_level_declarations,
-                retained_scripts.and_then(|scripts| {
-                    scripts
-                        .instance
-                        .as_ref()
-                        .filter(|_| !analysis.is_typescript)
-                }),
+                retained_scripts.and_then(|scripts| scripts.instance.as_ref()),
             );
             rest_excludes_hoists = extract_rest_excludes_hoists(&mut transformed);
             super::profile::record_script_text(super::profile::timer_elapsed(_script_start));

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/tests.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/tests.rs
@@ -61,6 +61,33 @@ noop(read);
 }
 
 #[test]
+fn retained_typescript_program_avoids_reparse_when_stripping_is_a_noop() {
+    AST_STATE_REPARSES.with(|count| count.set(0));
+    AST_STATE_RETAINED_USES.with(|count| count.set(0));
+    let source = r#"<script lang="ts">
+let count = $state(0);
+const read = () => count;
+</script>
+
+<button onclick={() => count++}>{read()}</button>
+"#;
+    let result = crate::compiler::compile(
+        source,
+        crate::compiler::CompileOptions {
+            generate: crate::compiler::GenerateMode::Client,
+            filename: Some("retained-state-typescript-js-subset/index.svelte".to_string()),
+            ..Default::default()
+        },
+    )
+    .unwrap();
+
+    assert!(result.js.code.contains("let count = $.state(0)"));
+    assert!(result.js.code.contains("() => $.get(count)"));
+    AST_STATE_RETAINED_USES.with(|count| assert_eq!(count.get(), 1));
+    AST_STATE_REPARSES.with(|count| assert_eq!(count.get(), 0));
+}
+
+#[test]
 fn retained_instance_program_is_repeatable() {
     let source = "<script>let count = $state(0); const read = () => count;</script><p>{read()}</p>";
     let mut prepared = crate::toolchain::Toolchain::new()


### PR DESCRIPTION
Reuse the Phase 1 OXC Program for TypeScript-tagged instance scripts when TypeScript stripping leaves the source unchanged. This removes the final state-transform reparse for the JavaScript-compatible TypeScript subset while preserving the existing fallback for scripts that actually need type erasure.

Validation:
- cargo test -p rsvelte_core --lib (1508 passed, 1 ignored)
- cargo fmt --all -- --check
- cargo clippy --all-targets --all-features -- -D warnings
- full 3312-fixture compatibility report passed on the earlier superset of this change