### PR TITLE
perf(compiler): project retained TypeScript state transforms

### DIFF
--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/types.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/types.rs
@@ -1,9 +1,10 @@
 //! Type definitions for the analysis phase.
 
 use super::scope::{Scope, ScopeRoot};
-use crate::ast::template::{Root, Script};
+use crate::ast::template::{Root, Script, ScriptContext};
 use crate::compiler::CompileOptions;
 use rustc_hash::{FxHashMap, FxHashSet};
+use std::ops::Range;
 
 #[cfg(test)]
 thread_local! {
@@ -23,6 +24,43 @@ pub struct ScriptContent {
     pub end: u32,
     /// Whether this script uses runes ($state, $derived, $effect, $props).
     pub uses_runes: bool,
+    /// Mapping from the original TypeScript source to `raw`.
+    ///
+    /// `None` means the mapping is the identity.
+    pub(crate) source_projection: Option<ScriptProjection>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct CopiedSourceChunk {
+    pub(crate) source: Range<u32>,
+    pub(crate) output: Range<u32>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ScriptProjection {
+    /// Exact source slices copied into the output, including re-emitted comments.
+    pub(crate) copied_chunks: Vec<CopiedSourceChunk>,
+    /// Original script-content length in bytes.
+    pub(crate) source_len: u32,
+    /// Stripped script-content length in bytes.
+    pub(crate) output_len: u32,
+}
+
+impl ScriptProjection {
+    /// Map a range only when all of its bytes were copied contiguously and unchanged.
+    pub(crate) fn output_range_for_source(&self, source: Range<u32>) -> Option<Range<u32>> {
+        if source.start > source.end || source.end > self.source_len {
+            return None;
+        }
+
+        self.copied_chunks.iter().find_map(|chunk| {
+            if source.start < chunk.source.start || source.end > chunk.source.end {
+                return None;
+            }
+            let start = chunk.output.start + (source.start - chunk.source.start);
+            Some(start..start + (source.end - source.start))
+        })
+    }
 }
 
 /// A reactive statement ($: statement) in legacy mode (Svelte 4).
@@ -96,7 +134,6 @@ impl ScriptContent {
             program.source().len() == raw_source.len()
                 && std::ptr::eq(program.source().as_ptr(), raw_source.as_ptr())
         });
-        let raw = raw_source.to_string();
         // Check if this script uses TypeScript
         let is_typescript = force_typescript
             || script.attributes.iter().any(|attr| {
@@ -109,9 +146,12 @@ impl ScriptContent {
                 }
                 false
             });
+        let needs_state_projection = is_typescript
+            && script.context == ScriptContext::Default
+            && raw_source.as_bytes().contains(&b'$');
 
         // Strip TypeScript from the raw content if this is a TypeScript script
-        let raw = if is_typescript && !raw.is_empty() {
+        let (raw, source_projection) = if is_typescript && !raw_source.is_empty() {
             retained_program
                 .filter(|program| {
                     !program.panicked()
@@ -119,11 +159,23 @@ impl ScriptContent {
                         && retained_matches_source
                 })
                 .map_or_else(
-                    || strip_typescript(&raw),
-                    |program| strip_typescript_from_program(&raw, program.program()),
+                    || (strip_typescript(raw_source), None),
+                    |program| {
+                        if needs_state_projection {
+                            strip_typescript_from_program_with_projection(
+                                raw_source,
+                                program.program(),
+                            )
+                        } else {
+                            (
+                                strip_typescript_from_program(raw_source, program.program()),
+                                None,
+                            )
+                        }
+                    },
                 )
         } else {
-            raw
+            (raw_source.to_string(), None)
         };
 
         if !raw.as_bytes().contains(&b'$') {
@@ -132,6 +184,7 @@ impl ScriptContent {
                 start,
                 end,
                 uses_runes: false,
+                source_projection,
             };
         }
 
@@ -156,6 +209,7 @@ impl ScriptContent {
             start,
             end,
             uses_runes,
+            source_projection,
         }
     }
 }
@@ -533,6 +587,21 @@ pub(crate) fn strip_typescript_from_program(
     source: &str,
     program: &oxc_ast::ast::Program<'_>,
 ) -> String {
+    strip_typescript_from_program_impl(source, program, false).0
+}
+
+pub(crate) fn strip_typescript_from_program_with_projection(
+    source: &str,
+    program: &oxc_ast::ast::Program<'_>,
+) -> (String, Option<ScriptProjection>) {
+    strip_typescript_from_program_impl(source, program, true)
+}
+
+fn strip_typescript_from_program_impl(
+    source: &str,
+    program: &oxc_ast::ast::Program<'_>,
+    include_projection: bool,
+) -> (String, Option<ScriptProjection>) {
     debug_assert_eq!(source, program.source_text);
 
     let mut removals: Vec<(u32, u32)> = Vec::new();
@@ -590,7 +659,7 @@ pub(crate) fn strip_typescript_from_program(
     }
 
     if removals.is_empty() {
-        return source.to_string();
+        return (source.to_string(), None);
     }
 
     // Sort removals by start position
@@ -610,11 +679,18 @@ pub(crate) fn strip_typescript_from_program(
 
     // Build output by skipping removed regions
     let mut output = String::with_capacity(source.len());
+    let mut copied_chunks =
+        include_projection.then(|| Vec::with_capacity(merged.len().saturating_add(1)));
     let mut pos = 0u32;
 
     for (remove_start, remove_end) in &merged {
         if *remove_start > pos {
-            output.push_str(&source[pos as usize..*remove_start as usize]);
+            push_source_range(
+                source,
+                pos..*remove_start,
+                &mut output,
+                copied_chunks.as_mut(),
+            );
         }
         // The official compiler PARSES TypeScript and only removes the
         // type-only nodes — comments inside a removed declaration (e.g. the
@@ -643,11 +719,27 @@ pub(crate) fn strip_typescript_from_program(
                 && removed.contains('\n')
                 && (removed.contains("/*") || removed.contains("//"))
             {
-                for comment in
-                    crate::compiler::phases::phase3_transform::server::transform_script::extract_comments_from_snippet(removed)
-                {
-                    output.push_str(&comment);
-                    output.push('\n');
+                if let Some(copied_chunks) = copied_chunks.as_mut() {
+                    for (comment_offset, comment) in
+                        crate::compiler::phases::phase3_transform::server::transform_script::extract_comments_from_snippet_with_pos(removed)
+                    {
+                        let comment_start = *remove_start + comment_offset as u32;
+                        let comment_end = comment_start + comment.len() as u32;
+                        push_source_range(
+                            source,
+                            comment_start..comment_end,
+                            &mut output,
+                            Some(copied_chunks),
+                        );
+                        output.push('\n');
+                    }
+                } else {
+                    for comment in
+                        crate::compiler::phases::phase3_transform::server::transform_script::extract_comments_from_snippet(removed)
+                    {
+                        output.push_str(&comment);
+                        output.push('\n');
+                    }
                 }
             }
         }
@@ -656,10 +748,51 @@ pub(crate) fn strip_typescript_from_program(
 
     // Add remaining content
     if (pos as usize) < source.len() {
-        output.push_str(&source[pos as usize..]);
+        push_source_range(
+            source,
+            pos..source.len() as u32,
+            &mut output,
+            copied_chunks.as_mut(),
+        );
     }
 
-    output
+    let projection = copied_chunks.map(|copied_chunks| ScriptProjection {
+        copied_chunks,
+        source_len: source.len() as u32,
+        output_len: output.len() as u32,
+    });
+
+    (output, projection)
+}
+
+fn push_source_range(
+    source: &str,
+    source_range: Range<u32>,
+    output: &mut String,
+    copied_chunks: Option<&mut Vec<CopiedSourceChunk>>,
+) {
+    if source_range.is_empty() {
+        return;
+    }
+
+    let output_start = output.len() as u32;
+    output.push_str(&source[source_range.start as usize..source_range.end as usize]);
+    let output_end = output.len() as u32;
+
+    if let Some(copied_chunks) = copied_chunks {
+        if let Some(last) = copied_chunks.last_mut()
+            && last.source.end == source_range.start
+            && last.output.end == output_start
+        {
+            last.source.end = source_range.end;
+            last.output.end = output_end;
+        } else {
+            copied_chunks.push(CopiedSourceChunk {
+                source: source_range,
+                output: output_start..output_end,
+            });
+        }
+    }
 }
 
 /// Blank TypeScript-specific syntax with spaces instead of removing it, so the
@@ -2567,8 +2700,13 @@ pub struct CustomElementConfig {
 
 #[cfg(test)]
 mod strip_typescript_tests {
-    use super::{strip_typescript, strip_typescript_from_program};
+    use super::{
+        STRIP_TYPESCRIPT_REPARSES, ScriptContent, ScriptProjection, strip_typescript,
+        strip_typescript_from_program, strip_typescript_from_program_with_projection,
+    };
+    use crate::ast::js::{Expression, LazyKind};
     use crate::ast::oxc_program::RetainedProgram;
+    use crate::ast::template::{Script, ScriptContext, ScriptType};
 
     #[test]
     fn retained_program_matches_parser_entry_point() {
@@ -2586,6 +2724,161 @@ count! += 1;
             strip_typescript_from_program(source, retained.program()),
             strip_typescript(source)
         );
+    }
+
+    #[test]
+    fn identity_strip_does_not_allocate_a_projection() {
+        let source = "const answer = 42;\n";
+        let retained = RetainedProgram::parse(source, true);
+        let (output, projection) =
+            strip_typescript_from_program_with_projection(source, retained.program());
+
+        assert_eq!(output, source);
+        assert!(projection.is_none());
+    }
+
+    #[test]
+    fn script_content_stores_projection_without_reparsing_retained_program() {
+        let source = "let count: number = $state<number>(0);\n";
+        let script = Script {
+            node_type: ScriptType::Script,
+            start: 0,
+            end: source.len() as u32,
+            context: ScriptContext::Default,
+            content: Expression::Lazy {
+                start: 0,
+                end: source.len() as u32,
+                ts: true,
+                kind: LazyKind::Lenient,
+            },
+            attributes: Vec::new(),
+            raw_content: "",
+            content_offset: 0,
+            is_typescript: true,
+        };
+        let retained = RetainedProgram::parse(source, true);
+        STRIP_TYPESCRIPT_REPARSES.with(|count| count.set(0));
+
+        let content = ScriptContent::from_script_with_ts(&script, source, true, Some(&retained));
+
+        assert_eq!(content.raw, "let count = $state(0);\n");
+        assert!(content.source_projection.is_some());
+        STRIP_TYPESCRIPT_REPARSES.with(|count| assert_eq!(count.get(), 0));
+    }
+
+    #[test]
+    fn projection_tracks_copied_chunks_and_typescript_omissions() {
+        let source = "let count: number = $state<number>(0);\ncount! += 1;\n";
+        let retained = RetainedProgram::parse(source, true);
+        let (output, projection) =
+            strip_typescript_from_program_with_projection(source, retained.program());
+        let projection = projection.expect("TypeScript syntax should create a projection");
+
+        assert_eq!(output, "let count = $state(0);\ncount += 1;\n");
+        assert_projection_chunks_are_exact(source, &output, &projection);
+        assert_eq!(projection.source_len, source.len() as u32);
+        assert_eq!(projection.output_len, output.len() as u32);
+
+        let rune_start = source.find("$state").unwrap() as u32;
+        let rune_source = rune_start..rune_start + "$state".len() as u32;
+        let rune_output = projection
+            .output_range_for_source(rune_source.clone())
+            .expect("unchanged rune name should be mapped");
+        assert_eq!(
+            &source[rune_source.start as usize..rune_source.end as usize],
+            &output[rune_output.start as usize..rune_output.end as usize]
+        );
+
+        let annotation_start = source.find(':').unwrap() as u32;
+        assert!(
+            !projection
+                .copied_chunks
+                .iter()
+                .any(|chunk| chunk.source.start <= annotation_start
+                    && annotation_start < chunk.source.end)
+        );
+        let count_start = source.find("count").unwrap() as u32;
+        assert!(
+            projection
+                .output_range_for_source(count_start..annotation_start + 1)
+                .is_none(),
+            "a range crossing an omitted type annotation must not map exactly"
+        );
+    }
+
+    #[test]
+    fn projection_records_comments_reemitted_from_removed_declarations() {
+        let source = "\
+interface Props {
+\t/** Documentation. */
+\tvalue: string;
+}
+const answer: number = 42;
+";
+        let retained = RetainedProgram::parse(source, true);
+        let (output, projection) =
+            strip_typescript_from_program_with_projection(source, retained.program());
+        let projection = projection.expect("TypeScript syntax should create a projection");
+
+        assert_eq!(output, "/** Documentation. */\n\nconst answer = 42;\n");
+        assert_projection_chunks_are_exact(source, &output, &projection);
+
+        let comment_start = source.find("/** Documentation. */").unwrap() as u32;
+        let comment_source = comment_start..comment_start + "/** Documentation. */".len() as u32;
+        let comment_output = projection
+            .output_range_for_source(comment_source)
+            .expect("re-emitted comments are exact copied chunks");
+        assert_eq!(
+            &output[comment_output.start as usize..comment_output.end as usize],
+            "/** Documentation. */"
+        );
+
+        let declaration_start = source.find("interface").unwrap() as u32;
+        assert!(
+            !projection
+                .copied_chunks
+                .iter()
+                .any(|chunk| chunk.source.start <= declaration_start
+                    && declaration_start < chunk.source.end)
+        );
+    }
+
+    #[test]
+    fn projection_includes_declare_text_fallback_omissions() {
+        let source = "\
+declare global {
+\tinterface Window { answer: number }
+}
+const answer = 42;
+";
+        let retained = RetainedProgram::parse(source, true);
+        let (output, projection) =
+            strip_typescript_from_program_with_projection(source, retained.program());
+        let projection = projection.expect("declare global should create a projection");
+
+        assert_eq!(output, "\nconst answer = 42;\n");
+        assert_projection_chunks_are_exact(source, &output, &projection);
+        let declaration_start = source.find("declare global").unwrap() as u32;
+        assert!(
+            !projection
+                .copied_chunks
+                .iter()
+                .any(|chunk| chunk.source.start <= declaration_start
+                    && declaration_start < chunk.source.end)
+        );
+    }
+
+    fn assert_projection_chunks_are_exact(
+        source: &str,
+        output: &str,
+        projection: &ScriptProjection,
+    ) {
+        for chunk in &projection.copied_chunks {
+            assert_eq!(
+                &source[chunk.source.start as usize..chunk.source.end as usize],
+                &output[chunk.output.start as usize..chunk.output.end as usize]
+            );
+        }
     }
 
     /// Regression: `strip_typescript` must NOT re-emit JSDoc comments that live

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/ast_state_transform.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/ast_state_transform.rs
@@ -3954,15 +3954,36 @@ fn projected_statement_is_type_only(statement: &Statement<'_>) -> bool {
 fn projected_state_transform_requires_fallback(
     program: &Program<'_>,
     state_vars: &[String],
+    projection: &ScriptProjection,
 ) -> bool {
     struct Finder<'a> {
         state_vars: &'a [String],
+        projection: &'a ScriptProjection,
         found: bool,
+    }
+
+    impl Finder<'_> {
+        fn target_crosses_omitted_source(&self, start: u32, end: u32) -> bool {
+            let source = start..end;
+            self.projection
+                .output_range_for_source(source.clone())
+                .is_none()
+                && self
+                    .projection
+                    .copied_chunks
+                    .iter()
+                    .any(|chunk| source.start < chunk.source.end && source.end > chunk.source.start)
+        }
     }
 
     impl<'a, 'ast> Visit<'ast> for Finder<'a> {
         fn visit_assignment_expression(&mut self, expression: &AssignmentExpression<'ast>) {
             if self.found {
+                return;
+            }
+            let target_span = expression.left.span();
+            if self.target_crosses_omitted_source(target_span.start, target_span.end) {
+                self.found = true;
                 return;
             }
             if let AssignmentTarget::AssignmentTargetIdentifier(target) = &expression.left {
@@ -3987,6 +4008,18 @@ fn projected_state_transform_requires_fallback(
                 }
             }
             walk::walk_assignment_expression(self, expression);
+        }
+
+        fn visit_update_expression(&mut self, expression: &UpdateExpression<'ast>) {
+            if self.found {
+                return;
+            }
+            let target_span = expression.argument.span();
+            if self.target_crosses_omitted_source(target_span.start, target_span.end) {
+                self.found = true;
+                return;
+            }
+            walk::walk_update_expression(self, expression);
         }
 
         fn visit_variable_declarator(&mut self, declarator: &VariableDeclarator<'ast>) {
@@ -4029,6 +4062,7 @@ fn projected_state_transform_requires_fallback(
 
     let mut finder = Finder {
         state_vars,
+        projection,
         found: false,
     };
     finder.visit_program(program);
@@ -4109,7 +4143,7 @@ pub(super) fn transform_state_vars_ast_projected_from_program(
         return Err(());
     }
 
-    if projected_state_transform_requires_fallback(program, config.state_vars) {
+    if projected_state_transform_requires_fallback(program, config.state_vars, projection) {
         return Err(());
     }
 

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/ast_state_transform.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/ast_state_transform.rs
@@ -31,6 +31,7 @@ use super::props_transforms::transform_props_destructuring;
 use super::rune_transforms::{process_derived_destructuring_pattern, wrap_state_value};
 use super::{DERIVED_TMP_COUNTER, SCRIPT_ARRAY_COUNTER, STATE_TMP_COUNTER, VAR_STATE_VARS};
 use crate::compiler::phases::phase2_analyze::ComponentAnalysis;
+use crate::compiler::phases::phase2_analyze::types::ScriptProjection;
 
 thread_local! {
     static AST_TRANSFORM_ALLOCATOR: RefCell<Allocator> = RefCell::new(Allocator::default());
@@ -3892,6 +3893,148 @@ fn state_assignment_needs_semantic(program: &Program<'_>, state_vars: &FxHashSet
     finder.found
 }
 
+fn projected_statement_is_type_only(statement: &Statement<'_>) -> bool {
+    match statement {
+        Statement::ImportDeclaration(_)
+        | Statement::TSTypeAliasDeclaration(_)
+        | Statement::TSInterfaceDeclaration(_)
+        | Statement::TSEnumDeclaration(_)
+        | Statement::TSModuleDeclaration(_) => true,
+        Statement::VariableDeclaration(declaration) => declaration.declare,
+        Statement::FunctionDeclaration(function) => {
+            function.r#type == FunctionType::TSDeclareFunction
+                || function.declare
+                || function.body.is_none()
+        }
+        Statement::ClassDeclaration(class) => class.declare,
+        Statement::ExportNamedDeclaration(export) => {
+            export.export_kind == ImportOrExportKind::Type
+                || export.declaration.as_ref().is_some_and(|declaration| {
+                    matches!(
+                        declaration,
+                        Declaration::TSTypeAliasDeclaration(_)
+                            | Declaration::TSInterfaceDeclaration(_)
+                            | Declaration::TSEnumDeclaration(_)
+                            | Declaration::TSModuleDeclaration(_)
+                    ) || matches!(
+                        declaration,
+                        Declaration::FunctionDeclaration(function)
+                            if function.r#type == FunctionType::TSDeclareFunction
+                                || function.declare
+                                || function.body.is_none()
+                    ) || matches!(
+                        declaration,
+                        Declaration::VariableDeclaration(declaration) if declaration.declare
+                    ) || matches!(
+                        declaration,
+                        Declaration::ClassDeclaration(class) if class.declare
+                    )
+                })
+        }
+        Statement::ExportDefaultDeclaration(export) => {
+            matches!(
+                &export.declaration,
+                ExportDefaultDeclarationKind::TSInterfaceDeclaration(_)
+            ) || matches!(
+                &export.declaration,
+                ExportDefaultDeclarationKind::FunctionDeclaration(function)
+                    if function.r#type == FunctionType::TSDeclareFunction
+                        || function.declare
+                        || function.body.is_none()
+            ) || matches!(
+                &export.declaration,
+                ExportDefaultDeclarationKind::ClassDeclaration(class) if class.declare
+            )
+        }
+        Statement::ExportAllDeclaration(export) => export.export_kind == ImportOrExportKind::Type,
+        _ => false,
+    }
+}
+
+fn projected_state_transform_requires_fallback(
+    program: &Program<'_>,
+    state_vars: &[String],
+) -> bool {
+    struct Finder<'a> {
+        state_vars: &'a [String],
+        found: bool,
+    }
+
+    impl<'a, 'ast> Visit<'ast> for Finder<'a> {
+        fn visit_assignment_expression(&mut self, expression: &AssignmentExpression<'ast>) {
+            if self.found {
+                return;
+            }
+            if let AssignmentTarget::AssignmentTargetIdentifier(target) = &expression.left {
+                let needs_site_resolution = matches!(
+                    expression.operator,
+                    AssignmentOperator::Assign
+                        | AssignmentOperator::LogicalOr
+                        | AssignmentOperator::LogicalAnd
+                        | AssignmentOperator::LogicalNullish
+                ) && matches!(
+                    expression.right.get_inner_expression(),
+                    Expression::Identifier(_)
+                );
+                if needs_site_resolution
+                    && self
+                        .state_vars
+                        .iter()
+                        .any(|name| name == target.name.as_str())
+                {
+                    self.found = true;
+                    return;
+                }
+            }
+            walk::walk_assignment_expression(self, expression);
+        }
+
+        fn visit_variable_declarator(&mut self, declarator: &VariableDeclarator<'ast>) {
+            if self.found {
+                return;
+            }
+            let Some(init) = &declarator.init else {
+                return;
+            };
+            if !matches!(
+                init,
+                Expression::TSAsExpression(_)
+                    | Expression::TSSatisfiesExpression(_)
+                    | Expression::TSNonNullExpression(_)
+                    | Expression::TSTypeAssertion(_)
+                    | Expression::TSInstantiationExpression(_)
+            ) {
+                walk::walk_variable_declarator(self, declarator);
+                return;
+            }
+            let Expression::CallExpression(call) = init.get_inner_expression() else {
+                walk::walk_variable_declarator(self, declarator);
+                return;
+            };
+            let rune_name = match &call.callee {
+                Expression::Identifier(identifier) => Some(identifier.name.as_str()),
+                Expression::StaticMemberExpression(member) => match &member.object {
+                    Expression::Identifier(object) => Some(object.name.as_str()),
+                    _ => None,
+                },
+                _ => None,
+            };
+            self.found = rune_name
+                .is_some_and(|name| matches!(name, "$state" | "$derived" | "$props" | "$bindable"));
+            if !self.found {
+                walk::walk_variable_declarator(self, declarator);
+            }
+        }
+    }
+
+    let mut finder = Finder {
+        state_vars,
+        found: false,
+    };
+    finder.visit_program(program);
+    finder.found
+}
+
 pub(super) fn transform_state_vars_ast(
     script: &str,
     config: &AstTransformConfig,
@@ -3947,12 +4090,116 @@ pub(super) fn transform_state_vars_ast_range_from_program(
     transform_state_vars_ast_from_program_unchecked(script, program, output_range, config)
 }
 
+pub(super) fn transform_state_vars_ast_projected_from_program(
+    script: &str,
+    program: &Program<'_>,
+    candidate: &str,
+    projection: &ScriptProjection,
+    projection_output_range: std::ops::Range<usize>,
+    config: &AstTransformConfig,
+) -> Result<Option<String>, ()> {
+    debug_assert_eq!(script, program.source_text);
+    if !has_state_transform_candidate(candidate, config) {
+        return Ok(None);
+    }
+    if projection.source_len as usize != script.len()
+        || projection_output_range.end > projection.output_len as usize
+        || projection_output_range.end - projection_output_range.start != candidate.len()
+    {
+        return Err(());
+    }
+
+    if projected_state_transform_requires_fallback(program, config.state_vars) {
+        return Err(());
+    }
+
+    let mut mapped = Vec::new();
+    for replacement in collect_state_var_replacements_without_semantic_scan(script, program, config)
+    {
+        let source_range = replacement.start..replacement.end;
+        if let Some(output_range) = projection.output_range_for_source(source_range.clone()) {
+            let output_start = output_range.start as usize;
+            let output_end = output_range.end as usize;
+            if output_end <= projection_output_range.start
+                || output_start >= projection_output_range.end
+            {
+                continue;
+            }
+            if output_start < projection_output_range.start
+                || output_end > projection_output_range.end
+            {
+                return Err(());
+            }
+            let candidate_start = output_start - projection_output_range.start;
+            let candidate_end = output_end - projection_output_range.start;
+            if script.get(source_range.start as usize..source_range.end as usize)
+                != candidate.get(candidate_start..candidate_end)
+            {
+                return Err(());
+            }
+            mapped.push(Replacement {
+                start: candidate_start as u32,
+                end: candidate_end as u32,
+                text: replacement.text,
+            });
+            continue;
+        }
+
+        let overlaps_copied_source = projection.copied_chunks.iter().any(|chunk| {
+            source_range.start < chunk.source.end && source_range.end > chunk.source.start
+        });
+        if source_range.is_empty() || overlaps_copied_source {
+            return Err(());
+        }
+    }
+
+    if mapped.is_empty() {
+        return Ok(None);
+    }
+    mapped.sort_by_key(|replacement| std::cmp::Reverse(replacement.start));
+    let mut output = candidate.to_string();
+    for replacement in mapped {
+        output.replace_range(
+            replacement.start as usize..replacement.end as usize,
+            &replacement.text,
+        );
+    }
+    Ok(Some(output))
+}
+
 fn transform_state_vars_ast_from_program_unchecked(
     script: &str,
     program: &Program<'_>,
     output_range: std::ops::Range<usize>,
     config: &AstTransformConfig,
 ) -> Option<String> {
+    let mut replacements = collect_state_var_replacements(script, program, config);
+    replacements.retain(|replacement| {
+        replacement.start as usize >= output_range.start
+            && replacement.end as usize <= output_range.end
+    });
+    if replacements.is_empty() {
+        return None;
+    }
+
+    replacements.sort_by_key(|r| std::cmp::Reverse(r.start));
+
+    let mut result = script[output_range.clone()].to_string();
+    for rep in &replacements {
+        result.replace_range(
+            rep.start as usize - output_range.start..rep.end as usize - output_range.start,
+            &rep.text,
+        );
+    }
+
+    Some(result)
+}
+
+fn collect_state_var_replacements(
+    script: &str,
+    program: &Program<'_>,
+    config: &AstTransformConfig,
+) -> Vec<Replacement> {
     let var_set: FxHashSet<&str> = config.state_vars.iter().map(String::as_str).collect();
     let non_reactive_set: FxHashSet<&str> = config
         .non_reactive_vars
@@ -3989,28 +4236,48 @@ fn transform_state_vars_ast_from_program_unchecked(
     );
     collector.semantic = semantic_ret.as_ref().map(|ret| &ret.semantic);
     collector.visit_program(program);
+    collector.replacements
+}
 
-    collector.replacements.retain(|replacement| {
-        replacement.start as usize >= output_range.start
-            && replacement.end as usize <= output_range.end
-    });
-    if collector.replacements.is_empty() {
-        return None;
+fn collect_state_var_replacements_without_semantic_scan(
+    script: &str,
+    program: &Program<'_>,
+    config: &AstTransformConfig,
+) -> Vec<Replacement> {
+    let var_set: FxHashSet<&str> = config.state_vars.iter().map(String::as_str).collect();
+    let non_reactive_set: FxHashSet<&str> = config
+        .non_reactive_vars
+        .iter()
+        .map(String::as_str)
+        .collect();
+    let raw_set: FxHashSet<&str> = config.raw_state_vars.iter().map(String::as_str).collect();
+    let mut collector = StateVarCollector::new(
+        script,
+        &var_set,
+        &non_reactive_set,
+        &raw_set,
+        config.derived_vars,
+        config.non_proxy_vars,
+        config.reassign_non_proxy_vars,
+        config.is_runes,
+        config.dev,
+        config.analysis_source,
+        config.filename,
+        config.prop_source_vars,
+        config.non_bindable_prop_vars,
+        config.store_sub_vars,
+        config.read_only_props,
+        config.rest_prop_vars,
+        config.prop_assignment_transform_vars,
+        config.analysis,
+        config.exported_names,
+    );
+    for statement in &program.body {
+        if !projected_statement_is_type_only(statement) {
+            collector.visit_statement(statement);
+        }
     }
-
-    collector
-        .replacements
-        .sort_by_key(|r| std::cmp::Reverse(r.start));
-
-    let mut result = script[output_range.clone()].to_string();
-    for rep in &collector.replacements {
-        result.replace_range(
-            rep.start as usize - output_range.start..rep.end as usize - output_range.start,
-            &rep.text,
-        );
-    }
-
-    Some(result)
+    collector.replacements
 }
 
 #[cfg(test)]
@@ -4118,6 +4385,64 @@ mod tests {
         assert_eq!(retained, reparsed);
         assert!(retained.starts_with("\n\n"));
         assert!(retained.ends_with("\n\n"));
+    }
+
+    #[test]
+    fn projected_typescript_type_declaration_does_not_shadow_runtime_state() {
+        let script = "type count = number;\nenum Removed { Value = count }\nlet count = $state(0);\nconst read = () => count;\n";
+        let allocator = Allocator::default();
+        let parsed = Parser::new(&allocator, script, SourceType::ts()).parse();
+        assert!(parsed.diagnostics.is_empty());
+        let (candidate, projection) =
+            crate::compiler::phases::phase2_analyze::types::strip_typescript_from_program_with_projection(
+                script,
+                &parsed.program,
+            );
+        let projection = projection.expect("type declaration must be omitted");
+        let state_vars = vec!["count".to_string()];
+        let config = AstTransformConfig {
+            state_vars: &state_vars,
+            non_reactive_vars: &[],
+            raw_state_vars: &[],
+            derived_vars: &[],
+            non_proxy_vars: &[],
+            reassign_non_proxy_vars: &[],
+            is_runes: true,
+            dev: false,
+            analysis_source: None,
+            filename: None,
+            prop_source_vars: &[],
+            prop_assignment_transform_vars: &[],
+            non_bindable_prop_vars: &[],
+            store_sub_vars: &[],
+            read_only_props: &[],
+            rest_prop_vars: &[],
+            analysis: None,
+            exported_names: &[],
+        };
+        let runtime_start = script.find("let count").unwrap() as u32;
+        assert!(
+            collect_state_var_replacements_without_semantic_scan(script, &parsed.program, &config)
+                .iter()
+                .all(|replacement| replacement.start >= runtime_start),
+            "removed enum initializers must not participate in runtime state transforms"
+        );
+
+        let transformed = transform_state_vars_ast_projected_from_program(
+            script,
+            &parsed.program,
+            &candidate,
+            &projection,
+            0..candidate.len(),
+            &config,
+        )
+        .expect("type-only omission is safe to project")
+        .expect("runtime state references must be transformed");
+
+        assert_eq!(
+            transformed,
+            "\n\nlet count = $.state(0);\nconst read = () => $.get(count);\n"
+        );
     }
 
     #[test]

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
@@ -150,6 +150,31 @@ thread_local! {
     pub(super) static VAR_STATE_VARS: RefCell<Vec<String>> = const { RefCell::new(Vec::new()) };
 }
 
+struct AstStateCounterSnapshot {
+    script_array: usize,
+    array_lookup: usize,
+    state_tmp: usize,
+    derived_tmp: usize,
+}
+
+impl AstStateCounterSnapshot {
+    fn capture() -> Self {
+        Self {
+            script_array: SCRIPT_ARRAY_COUNTER.with(Cell::get),
+            array_lookup: ARRAY_LOOKUP_COUNTER.with(Cell::get),
+            state_tmp: STATE_TMP_COUNTER.with(Cell::get),
+            derived_tmp: DERIVED_TMP_COUNTER.with(Cell::get),
+        }
+    }
+
+    fn restore(&self) {
+        SCRIPT_ARRAY_COUNTER.with(|counter| counter.set(self.script_array));
+        ARRAY_LOOKUP_COUNTER.with(|counter| counter.set(self.array_lookup));
+        STATE_TMP_COUNTER.with(|counter| counter.set(self.state_tmp));
+        DERIVED_TMP_COUNTER.with(|counter| counter.set(self.derived_tmp));
+    }
+}
+
 // Thread-local cache for dynamically-constructed regex patterns to avoid recompilation.
 // `Arc<Regex>` keeps the cache lookup cheap: cloning the Arc is a single
 // refcount bump rather than copying the (multi-KB) compiled NFA.
@@ -6022,6 +6047,7 @@ fn transform_instance_script_for_visitors(
                     let projection_core_start =
                         original_script.len() - original_script.trim_start().len();
                     let projection_core_end = projection_core_start + original_script.trim().len();
+                    let counters = AstStateCounterSnapshot::capture();
                     match ast_state_transform::transform_state_vars_ast_projected_from_program(
                         program.source(),
                         program.program(),
@@ -6030,8 +6056,15 @@ fn transform_instance_script_for_visitors(
                         projection_core_start..projection_core_end,
                         &ast_config,
                     ) {
-                        Ok(transformed) => transformed,
-                        Err(()) => return None,
+                        Ok(Some(transformed)) => Some(transformed),
+                        Ok(None) => {
+                            counters.restore();
+                            None
+                        }
+                        Err(()) => {
+                            counters.restore();
+                            return None;
+                        }
                     }
                 } else {
                     let mut retained_matches = program.source().match_indices(retained_core);

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
@@ -98,6 +98,7 @@ use crate::ast::template::Root;
 use crate::compiler::CompileOptions;
 use crate::compiler::phases::phase2_analyze::ComponentAnalysis;
 use crate::compiler::phases::phase2_analyze::scope::{BindingKind, DeclarationKind};
+use crate::compiler::phases::phase2_analyze::types::{CopiedSourceChunk, ScriptProjection};
 
 // Import new visitor system types
 use types::{ComponentClientTransformState, ComponentContext, TransformOptions, TransformResult};
@@ -456,44 +457,80 @@ fn transform_client_with_visitors(
     // This also determines how many $$array names it consumes (for template generation)
     // and is used for blocker_map computation and the final output.
     let mut instance_script_imports = Vec::new();
-    let mut pre_transformed_script =
-        if let Some(instance_script) = &analysis.instance_script_content {
-            let (imports, script_body) = extract_imports(&instance_script.raw);
-            instance_script_imports = imports;
-            let split_top_level_declarations =
-                instance_has_top_level_multi_declarator(ast, &instance_script.raw);
-            let _script_start = super::profile::timer_start();
-            let mut transformed = transform_instance_script_for_visitors(
-                &script_body,
-                analysis,
-                options.dev,
-                &reactive_import_names,
-                split_top_level_declarations,
-                retained_scripts.and_then(|scripts| scripts.instance.as_ref()),
-            );
-            rest_excludes_hoists = extract_rest_excludes_hoists(&mut transformed);
-            super::profile::record_script_text(super::profile::timer_elapsed(_script_start));
-            // Transfer the script's $$array counter to the context state so that the template
-            // visitor continues numbering from where the script left off.
-            let script_array_count = SCRIPT_ARRAY_COUNTER.with(|c| c.get());
-            context
-                .state
-                .destructure_array_counter
-                .set(script_array_count);
-            // Also seed the memoizer's conflicts set with names already used by the script,
-            // so that generate_array_name() (which uses the memoizer) won't reuse them.
-            for i in 0..script_array_count {
-                let name = if i == 0 {
-                    "$$array".to_string()
-                } else {
-                    format!("$$array_{}", i)
-                };
-                context.state.memoizer.add_conflict(&name);
-            }
-            Some(transformed)
+    let mut pre_transformed_script = if let Some(instance_script) =
+        &analysis.instance_script_content
+    {
+        let retained_instance = retained_scripts.and_then(|scripts| scripts.instance.as_ref());
+        let needs_projection = analysis.runes
+            && retained_instance.is_some()
+            && instance_script.source_projection.is_some();
+        let can_borrow_projection = needs_projection
+            && memmem::find(instance_script.raw.as_bytes(), b"import").is_none()
+            && !instance_script.raw.as_bytes().contains(&b'\r');
+        let (imports, script_body, body_chunks) = if can_borrow_projection {
+            (
+                Vec::new(),
+                instance_script
+                    .raw
+                    .strip_suffix('\n')
+                    .unwrap_or(&instance_script.raw)
+                    .to_string(),
+                Vec::new(),
+            )
+        } else if needs_projection {
+            extract_imports_with_projection(&instance_script.raw)
         } else {
-            None
+            let (imports, script_body) = extract_imports(&instance_script.raw);
+            (imports, script_body, Vec::new())
         };
+        let composed_body_projection = (needs_projection && !can_borrow_projection).then(|| {
+            compose_script_projection(
+                instance_script.source_projection.as_ref().unwrap(),
+                &body_chunks,
+                script_body.len(),
+            )
+        });
+        let body_projection = if can_borrow_projection {
+            instance_script.source_projection.as_ref()
+        } else {
+            composed_body_projection.as_ref()
+        };
+        instance_script_imports = imports;
+        let split_top_level_declarations =
+            instance_has_top_level_multi_declarator(ast, &instance_script.raw);
+        let _script_start = super::profile::timer_start();
+        let mut transformed = transform_instance_script_for_visitors(
+            &script_body,
+            analysis,
+            options.dev,
+            &reactive_import_names,
+            split_top_level_declarations,
+            retained_instance,
+            body_projection,
+        );
+        rest_excludes_hoists = extract_rest_excludes_hoists(&mut transformed);
+        super::profile::record_script_text(super::profile::timer_elapsed(_script_start));
+        // Transfer the script's $$array counter to the context state so that the template
+        // visitor continues numbering from where the script left off.
+        let script_array_count = SCRIPT_ARRAY_COUNTER.with(|c| c.get());
+        context
+            .state
+            .destructure_array_counter
+            .set(script_array_count);
+        // Also seed the memoizer's conflicts set with names already used by the script,
+        // so that generate_array_name() (which uses the memoizer) won't reuse them.
+        for i in 0..script_array_count {
+            let name = if i == 0 {
+                "$$array".to_string()
+            } else {
+                format!("$$array_{}", i)
+            };
+            context.state.memoizer.add_conflict(&name);
+        }
+        Some(transformed)
+    } else {
+        None
+    };
 
     // Pre-compute blocker map for async components.
     if options.experimental.r#async
@@ -2755,14 +2792,10 @@ pub(crate) fn extract_imports(script: &str) -> (Vec<String>, String) {
     let mut scan = ScanState::default();
 
     for line in script.lines() {
-        // Only treat a line as import-eligible when it begins in pure-code state
-        // (not inside a multi-line template literal / block comment).
         let line_starts_in_code = scan.in_code();
         scan.advance(line);
         let scan = line_starts_in_code; // shadow for the decision below
         if let Some(ref mut import_lines) = current_import {
-            // We're inside a multi-line import. The closing line may carry
-            // trailing statements after the import terminator; split them off.
             let trimmed = line.trim();
             let closes = trimmed.contains(';')
                 || trimmed.ends_with('\'')
@@ -2830,6 +2863,195 @@ pub(crate) fn extract_imports(script: &str) -> (Vec<String>, String) {
     (imports, rest.join("\n"))
 }
 
+struct ExtractedSourcePart {
+    text: String,
+    source: std::ops::Range<u32>,
+}
+
+fn extract_imports_with_projection(script: &str) -> (Vec<String>, String, Vec<CopiedSourceChunk>) {
+    let mut imports = Vec::new();
+    let mut rest: Vec<ExtractedSourcePart> = Vec::new();
+    let mut current_import: Option<Vec<String>> = None;
+    let mut scan = ScanState::default();
+    let mut line_start = 0usize;
+
+    for physical_line in script.split_inclusive('\n') {
+        let line = if let Some(line_without_lf) = physical_line.strip_suffix('\n') {
+            line_without_lf
+                .strip_suffix('\r')
+                .unwrap_or(line_without_lf)
+        } else {
+            physical_line
+        };
+        let line_starts_in_code = scan.in_code();
+        scan.advance(line);
+        let scan = line_starts_in_code;
+        if let Some(ref mut import_lines) = current_import {
+            let trimmed = line.trim();
+            let closes = trimmed.contains(';')
+                || trimmed.ends_with('\'')
+                || trimmed.ends_with('"')
+                || trimmed.ends_with('`');
+            if closes {
+                if let Some(end) = import_statement_end(trimmed)
+                    && end < trimmed.len()
+                    && !trimmed[end..].trim().is_empty()
+                {
+                    import_lines.push(trimmed[..end].to_string());
+                    imports.push(import_lines.join("\n"));
+                    current_import = None;
+                    let trimmed_start = line.len() - line.trim_start().len();
+                    let remainder_source_start = trimmed_start + end;
+                    let (remainder, remainder_offset) =
+                        peel_leading_imports_ref(&trimmed[end..], &mut imports);
+                    if !remainder.trim().is_empty() {
+                        rest.push(ExtractedSourcePart {
+                            text: remainder.to_string(),
+                            source: (line_start + remainder_source_start + remainder_offset) as u32
+                                ..(line_start
+                                    + remainder_source_start
+                                    + remainder_offset
+                                    + remainder.len()) as u32,
+                        });
+                    }
+                } else {
+                    import_lines.push(line.to_string());
+                    imports.push(import_lines.join("\n"));
+                    current_import = None;
+                }
+            } else {
+                import_lines.push(line.to_string());
+            }
+        } else {
+            let trimmed = line.trim();
+            if scan && (trimmed.starts_with("import ") || trimmed.starts_with("import{")) {
+                if trimmed.contains(';')
+                    || is_complete_side_effect_import(trimmed)
+                    || (memmem::find(trimmed.as_bytes(), b" from ").is_some()
+                        && (trimmed.ends_with('\'')
+                            || trimmed.ends_with('"')
+                            || trimmed.ends_with('`')))
+                {
+                    let trimmed_start = line.len() - line.trim_start().len();
+                    let (remainder, remainder_offset) =
+                        peel_leading_imports_ref(trimmed, &mut imports);
+                    if !remainder.trim().is_empty() {
+                        rest.push(ExtractedSourcePart {
+                            text: remainder.to_string(),
+                            source: (line_start + trimmed_start + remainder_offset) as u32
+                                ..(line_start + trimmed_start + remainder_offset + remainder.len())
+                                    as u32,
+                        });
+                    }
+                } else {
+                    current_import = Some(vec![line.to_string()]);
+                }
+            } else {
+                rest.push(ExtractedSourcePart {
+                    text: line.to_string(),
+                    source: line_start as u32..(line_start + line.len()) as u32,
+                });
+            }
+        }
+        line_start += physical_line.len();
+    }
+
+    if let Some(import_lines) = current_import {
+        imports.push(import_lines.join("\n"));
+    }
+
+    let mut output = String::new();
+    let mut copied_chunks = Vec::with_capacity(rest.len().saturating_mul(2));
+    for (index, part) in rest.iter().enumerate() {
+        if index != 0 {
+            let output_start = output.len() as u32;
+            output.push('\n');
+            let previous = &rest[index - 1];
+            if previous.source.end + 1 == part.source.start
+                && script.as_bytes().get(previous.source.end as usize) == Some(&b'\n')
+            {
+                push_projection_chunk(
+                    &mut copied_chunks,
+                    previous.source.end..part.source.start,
+                    output_start..output.len() as u32,
+                );
+            }
+        }
+
+        let output_start = output.len() as u32;
+        output.push_str(&part.text);
+        push_projection_chunk(
+            &mut copied_chunks,
+            part.source.clone(),
+            output_start..output.len() as u32,
+        );
+    }
+
+    (imports, output, copied_chunks)
+}
+
+fn push_projection_chunk(
+    chunks: &mut Vec<CopiedSourceChunk>,
+    source: std::ops::Range<u32>,
+    output: std::ops::Range<u32>,
+) {
+    if source.is_empty() {
+        return;
+    }
+    debug_assert_eq!(source.end - source.start, output.end - output.start);
+    if let Some(previous) = chunks.last_mut()
+        && previous.source.end == source.start
+        && previous.output.end == output.start
+    {
+        previous.source.end = source.end;
+        previous.output.end = output.end;
+    } else {
+        chunks.push(CopiedSourceChunk { source, output });
+    }
+}
+
+fn compose_script_projection(
+    source_projection: &ScriptProjection,
+    raw_to_body: &[CopiedSourceChunk],
+    body_len: usize,
+) -> ScriptProjection {
+    let mut copied_chunks = Vec::new();
+    let mut source_index = 0usize;
+    for body_chunk in raw_to_body {
+        while source_index < source_projection.copied_chunks.len()
+            && source_projection.copied_chunks[source_index].output.end <= body_chunk.source.start
+        {
+            source_index += 1;
+        }
+
+        for source_chunk in &source_projection.copied_chunks[source_index..] {
+            if source_chunk.output.start >= body_chunk.source.end {
+                break;
+            }
+            let intersection_start = source_chunk.output.start.max(body_chunk.source.start);
+            let intersection_end = source_chunk.output.end.min(body_chunk.source.end);
+            if intersection_start >= intersection_end {
+                continue;
+            }
+            let source_start =
+                source_chunk.source.start + intersection_start - source_chunk.output.start;
+            let output_start =
+                body_chunk.output.start + intersection_start - body_chunk.source.start;
+            push_projection_chunk(
+                &mut copied_chunks,
+                source_start..source_start + intersection_end - intersection_start,
+                output_start..output_start + intersection_end - intersection_start,
+            );
+        }
+    }
+
+    ScriptProjection {
+        copied_chunks,
+        source_len: source_projection.source_len,
+        output_len: body_len as u32,
+    }
+}
+
 /// Check whether `trimmed` is a complete *side-effect* import statement —
 /// `import "module"` or `import 'module'` with no `from` clause and no
 /// terminating semicolon. ASI in real JavaScript allows this form to stand
@@ -2883,16 +3105,23 @@ fn import_statement_end(s: &str) -> Option<usize> {
 /// the first non-import token or an *incomplete* import (one that continues on a
 /// following line) and returns it so the caller can route it.
 fn peel_leading_imports(s: &str, imports: &mut Vec<String>) -> String {
-    let mut cur = s.trim_start();
+    peel_leading_imports_ref(s, imports).0.to_string()
+}
+
+fn peel_leading_imports_ref<'a>(s: &'a str, imports: &mut Vec<String>) -> (&'a str, usize) {
+    let mut offset = s.len() - s.trim_start().len();
+    let mut cur = &s[offset..];
     while cur.starts_with("import ") || cur.starts_with("import{") {
         let Some(end) = import_statement_end(cur) else {
             break;
         };
         let (import_part, remainder) = cur.split_at(end);
         imports.push(import_part.trim().to_string());
-        cur = remainder.trim_start();
+        let whitespace = remainder.len() - remainder.trim_start().len();
+        offset += end + whitespace;
+        cur = &s[offset..];
     }
-    cur.to_string()
+    (cur, offset)
 }
 
 fn is_complete_side_effect_import(trimmed: &str) -> bool {
@@ -3917,6 +4146,7 @@ pub(crate) fn transform_instance_script_for_visitors_pub(
         reactive_import_names,
         might_have_comma_separated_declaration(script),
         None,
+        None,
     )
 }
 
@@ -3996,6 +4226,7 @@ fn transform_instance_script_for_visitors(
     reactive_import_names: &[String],
     split_top_level_declarations: bool,
     retained_program: Option<&crate::ast::oxc_program::RetainedProgram<'_>>,
+    source_projection: Option<&ScriptProjection>,
 ) -> String {
     if script.is_empty() {
         return String::new();
@@ -5782,27 +6013,46 @@ fn transform_instance_script_for_visitors(
                 if retained_core != result_core {
                     return None;
                 }
-                let mut retained_matches = program.source().match_indices(retained_core);
-                let (retained_core_start, _) = retained_matches.next()?;
-                if retained_matches.next().is_some() {
-                    return None;
-                }
-                let retained_core_end = retained_core_start + retained_core.len();
                 let result_core_start = result.find(result_core).unwrap_or(0);
                 let result_core_end = result_core_start + result_core.len();
                 let prefix = &result[..result_core_start];
                 let suffix = &result[result_core_end..];
+
+                let transformed = if let Some(projection) = source_projection {
+                    let projection_core_start =
+                        original_script.len() - original_script.trim_start().len();
+                    let projection_core_end = projection_core_start + original_script.trim().len();
+                    match ast_state_transform::transform_state_vars_ast_projected_from_program(
+                        program.source(),
+                        program.program(),
+                        result_core,
+                        projection,
+                        projection_core_start..projection_core_end,
+                        &ast_config,
+                    ) {
+                        Ok(transformed) => transformed,
+                        Err(()) => return None,
+                    }
+                } else {
+                    let mut retained_matches = program.source().match_indices(retained_core);
+                    let (retained_core_start, _) = retained_matches.next()?;
+                    if retained_matches.next().is_some() {
+                        return None;
+                    }
+                    let retained_core_end = retained_core_start + retained_core.len();
+                    ast_state_transform::transform_state_vars_ast_range_from_program(
+                        program.source(),
+                        program.program(),
+                        result_core,
+                        retained_core_start..retained_core_end,
+                        &ast_config,
+                    )
+                };
+
                 used_retained = true;
                 #[cfg(test)]
                 AST_STATE_RETAINED_USES.with(|count| count.set(count.get() + 1));
-                ast_state_transform::transform_state_vars_ast_range_from_program(
-                    program.source(),
-                    program.program(),
-                    result_core,
-                    retained_core_start..retained_core_end,
-                    &ast_config,
-                )
-                .map(|transformed| {
+                transformed.map(|transformed| {
                     let mut output =
                         String::with_capacity(prefix.len() + transformed.len() + suffix.len());
                     output.push_str(prefix);

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/tests.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/tests.rs
@@ -223,6 +223,84 @@ let double = $derived(count! * 2)!;
 }
 
 #[test]
+fn projected_typescript_assertion_update_falls_back() {
+    AST_STATE_REPARSES.with(|count| count.set(0));
+    AST_STATE_RETAINED_USES.with(|count| count.set(0));
+    let result = crate::compiler::compile(
+        r#"<script lang="ts">
+let count: number = $state(0);
+function increment() { count!++; }
+</script>
+
+<button onclick={increment}>{count}</button>
+"#,
+        crate::compiler::CompileOptions {
+            generate: crate::compiler::GenerateMode::Client,
+            filename: Some("retained-state-typescript-assertion-update/index.svelte".to_string()),
+            ..Default::default()
+        },
+    )
+    .unwrap();
+
+    assert!(result.js.code.contains("$.update(count)"));
+    assert!(!result.js.code.contains("$.get(count)++"));
+    AST_STATE_RETAINED_USES.with(|count| assert_eq!(count.get(), 0));
+    AST_STATE_REPARSES.with(|count| assert_eq!(count.get(), 1));
+}
+
+#[test]
+fn projected_fallback_restores_generated_name_counters() {
+    AST_STATE_REPARSES.with(|count| count.set(0));
+    AST_STATE_RETAINED_USES.with(|count| count.set(0));
+    let result = crate::compiler::compile(
+        r#"<script lang="ts">
+let { a }: { a: string } = $state({});
+let { b }: { b: string } = $derived(a);
+let [c]: [number] = $derived([1]);
+</script>
+
+<button onclick={() => a++}>{b}{c}</button>
+"#,
+        crate::compiler::CompileOptions {
+            generate: crate::compiler::GenerateMode::Client,
+            filename: Some("retained-state-typescript-counter-rollback/index.svelte".to_string()),
+            ..Default::default()
+        },
+    )
+    .unwrap();
+
+    assert!(!result.js.code.contains("tmp_1"));
+    assert!(!result.js.code.contains("$$d_1"));
+    assert!(!result.js.code.contains("$$array_1"));
+
+    let code_wrapper = crate::compiler::compile(
+        r#"<script lang="ts">
+interface Props {
+    children?: unknown;
+    codeblock?: unknown;
+    innerClass?: string;
+    class?: string;
+}
+let { children, codeblock, innerClass, class: classname }: Props = $props();
+const { base, inner } = $derived(codewrapper());
+</script>
+
+<div class={base({ class: classname })}>{innerClass}</div>
+"#,
+        crate::compiler::CompileOptions {
+            generate: crate::compiler::GenerateMode::Client,
+            filename: Some("flowbite-code-wrapper-counter-rollback/index.svelte".to_string()),
+            ..Default::default()
+        },
+    )
+    .unwrap();
+
+    assert!(!code_wrapper.js.code.contains("$$d_1"));
+    AST_STATE_RETAINED_USES.with(|count| assert_eq!(count.get(), 0));
+    AST_STATE_REPARSES.with(|count| assert_eq!(count.get(), 2));
+}
+
+#[test]
 fn retained_typescript_projection_reduces_fixture_reparses_from_five_to_one() {
     AST_STATE_REPARSES.with(|count| count.set(0));
     AST_STATE_RETAINED_USES.with(|count| count.set(0));

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/tests.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/tests.rs
@@ -114,6 +114,180 @@ let count: number = $state<number>(0);
 }
 
 #[test]
+fn retained_typescript_projection_avoids_state_transform_reparse() {
+    AST_STATE_REPARSES.with(|count| count.set(0));
+    AST_STATE_RETAINED_USES.with(|count| count.set(0));
+    let source = r#"<script lang="ts">
+import type { Widget } from './types';
+import { noop } from './helpers';
+let count: number = $state(0);
+const read = (value: Widget & { count: number }) => count + value.count;
+noop(read);
+</script>
+
+<button onclick={() => count++}>{count}</button>
+"#;
+    let result = crate::compiler::compile(
+        source,
+        crate::compiler::CompileOptions {
+            generate: crate::compiler::GenerateMode::Client,
+            filename: Some("retained-state-typescript-projection/index.svelte".to_string()),
+            ..Default::default()
+        },
+    )
+    .unwrap();
+
+    assert!(result.js.code.contains("let count = $.state(0)"));
+    assert!(result.js.code.contains("=> $.get(count) + value.count"));
+    AST_STATE_RETAINED_USES.with(|count| assert_eq!(count.get(), 1));
+    AST_STATE_REPARSES.with(|count| assert_eq!(count.get(), 0));
+}
+
+#[test]
+fn projected_replacement_crossing_removed_typescript_falls_back() {
+    AST_STATE_REPARSES.with(|count| count.set(0));
+    AST_STATE_RETAINED_USES.with(|count| count.set(0));
+    let source = r#"<script lang="ts">
+let count = $state<number>(0);
+</script>
+
+<button onclick={() => count++}>{count}</button>
+"#;
+    let result = crate::compiler::compile(
+        source,
+        crate::compiler::CompileOptions {
+            generate: crate::compiler::GenerateMode::Client,
+            filename: Some("retained-state-typescript-partial/index.svelte".to_string()),
+            ..Default::default()
+        },
+    )
+    .unwrap();
+
+    assert!(result.js.code.contains("let count = $.state(0)"));
+    AST_STATE_RETAINED_USES.with(|count| assert_eq!(count.get(), 0));
+    AST_STATE_REPARSES.with(|count| assert_eq!(count.get(), 1));
+}
+
+#[test]
+fn projected_typescript_semantic_assignment_falls_back() {
+    AST_STATE_REPARSES.with(|count| count.set(0));
+    AST_STATE_RETAINED_USES.with(|count| count.set(0));
+    let source = r#"<script lang="ts">
+let next: number = 1;
+let count: number = $state(0);
+count = next;
+</script>
+
+<p>{count}</p>
+"#;
+    let result = crate::compiler::compile(
+        source,
+        crate::compiler::CompileOptions {
+            generate: crate::compiler::GenerateMode::Client,
+            filename: Some("retained-state-typescript-semantic/index.svelte".to_string()),
+            ..Default::default()
+        },
+    )
+    .unwrap();
+
+    assert!(result.js.code.contains("$.set(count, next)"));
+    AST_STATE_RETAINED_USES.with(|count| assert_eq!(count.get(), 0));
+    AST_STATE_REPARSES.with(|count| assert_eq!(count.get(), 1));
+}
+
+#[test]
+fn projected_typescript_wrapped_rune_initializer_falls_back() {
+    AST_STATE_REPARSES.with(|count| count.set(0));
+    AST_STATE_RETAINED_USES.with(|count| count.set(0));
+    let source = r#"<script lang="ts">
+let count = $state(1)!;
+let double = $derived(count! * 2)!;
+</script>
+
+<p>{count} {double}</p>
+"#;
+    let result = crate::compiler::compile(
+        source,
+        crate::compiler::CompileOptions {
+            generate: crate::compiler::GenerateMode::Client,
+            filename: Some("retained-state-typescript-wrapped-rune/index.svelte".to_string()),
+            ..Default::default()
+        },
+    )
+    .unwrap();
+
+    assert!(result.js.code.contains("let count = 1"));
+    assert!(result.js.code.contains("$.derived(() => count * 2)"));
+    AST_STATE_RETAINED_USES.with(|count| assert_eq!(count.get(), 0));
+    AST_STATE_REPARSES.with(|count| assert_eq!(count.get(), 1));
+}
+
+#[test]
+fn retained_typescript_projection_reduces_fixture_reparses_from_five_to_one() {
+    AST_STATE_REPARSES.with(|count| count.set(0));
+    AST_STATE_RETAINED_USES.with(|count| count.set(0));
+    let projected_sources = [
+        r#"<script lang="ts">
+	const p = { m: 1 } satisfies Record<string, number>;
+	let count = $state(0);
+</script>
+<button onclick={() => count++}>{count}{p.m}</button>"#,
+        r#"<script module lang="ts">
+	export const K = 1;
+</script>
+<script>
+	const p = { m: 1 } satisfies Record<string, number>;
+	let count = $state(0);
+</script>
+<button onclick={() => count++}>{count}{p.m}</button>"#,
+        r#"<script lang="ts">
+	function f(a: boolean): boolean;
+	function f(a: string): number;
+	function f(a: any): any { return a; }
+	let count = $state(0);
+	const r = f(true);
+</script>
+<button onclick={() => count++}>{r}{count}</button>"#,
+        r#"<script lang="ts">
+	function f(a: number): number { return a + 1; }
+	let count = $state(0);
+	const r = f(1);
+</script>
+<button onclick={() => count++}>{r}{count}</button>"#,
+    ];
+
+    for (index, source) in projected_sources.iter().enumerate() {
+        crate::compiler::compile(
+            source,
+            crate::compiler::CompileOptions {
+                generate: crate::compiler::GenerateMode::Client,
+                filename: Some(format!("retained-typescript-fixture-{index}.svelte")),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+    }
+    AST_STATE_RETAINED_USES.with(|count| assert_eq!(count.get(), 4));
+    AST_STATE_REPARSES.with(|count| assert_eq!(count.get(), 0));
+
+    crate::compiler::compile(
+        r#"<script lang="ts">
+	let count = $state<number | null>(0);
+</script>
+<button onclick={() => { count = count! + 1; }}>{count}</button>"#,
+        crate::compiler::CompileOptions {
+            generate: crate::compiler::GenerateMode::Client,
+            filename: Some("retained-typescript-fallback-fixture.svelte".to_string()),
+            ..Default::default()
+        },
+    )
+    .unwrap();
+
+    AST_STATE_RETAINED_USES.with(|count| assert_eq!(count.get(), 4));
+    AST_STATE_REPARSES.with(|count| assert_eq!(count.get(), 1));
+}
+
+#[test]
 fn retained_instance_program_is_repeatable() {
     let source = "<script>let count = $state(0); const read = () => count;</script><p>{read()}</p>";
     let mut prepared = crate::toolchain::Toolchain::new()
@@ -143,31 +317,22 @@ fn retained_instance_program_is_repeatable() {
 
 #[test]
 fn changed_instance_source_falls_back_to_state_transform_reparse() {
-    for (filename, source) in [
-        (
-            "retained-state-class/index.svelte",
-            "<script>class Counter { value = $state(0); } let count = $state(0);</script><p>{count + new Counter().value}</p>",
-        ),
-        (
-            "retained-state-typescript/index.svelte",
-            r#"<script lang="ts">let count: number = $state(0);</script><button>{count}</button>"#,
-        ),
-    ] {
-        AST_STATE_REPARSES.with(|count| count.set(0));
-        AST_STATE_RETAINED_USES.with(|count| count.set(0));
-        crate::compiler::compile(
-            source,
-            crate::compiler::CompileOptions {
-                generate: crate::compiler::GenerateMode::Client,
-                filename: Some(filename.to_string()),
-                ..Default::default()
-            },
-        )
-        .unwrap();
+    let filename = "retained-state-class/index.svelte";
+    let source = "<script>class Counter { value = $state(0); } let count = $state(0);</script><p>{count + new Counter().value}</p>";
+    AST_STATE_REPARSES.with(|count| count.set(0));
+    AST_STATE_RETAINED_USES.with(|count| count.set(0));
+    crate::compiler::compile(
+        source,
+        crate::compiler::CompileOptions {
+            generate: crate::compiler::GenerateMode::Client,
+            filename: Some(filename.to_string()),
+            ..Default::default()
+        },
+    )
+    .unwrap();
 
-        AST_STATE_RETAINED_USES.with(|count| assert_eq!(count.get(), 0, "{filename}"));
-        AST_STATE_REPARSES.with(|count| assert_eq!(count.get(), 1, "{filename}"));
-    }
+    AST_STATE_RETAINED_USES.with(|count| assert_eq!(count.get(), 0, "{filename}"));
+    AST_STATE_REPARSES.with(|count| assert_eq!(count.get(), 1, "{filename}"));
 }
 
 #[test]
@@ -516,6 +681,32 @@ fn test_extract_imports_no_semicolon_side_effect() {
     let (imports, rest) = extract_imports(script);
     assert_eq!(imports, vec!["import \"./Inner.svelte\"".to_string()]);
     assert_eq!(rest, "let count = 1;");
+}
+
+#[test]
+fn projected_import_extraction_preserves_legacy_output() {
+    for script in [
+        "",
+        "let count = 1;\n",
+        "let count = 1;\r",
+        "import { x } from 'x';\nlet count = x;\n",
+        "import { x } from 'x';\r\n\r\nlet count = x;\r\n",
+        "import a from 'a';import b from 'b'; const value = a + b;",
+        "import {\n  first,\n  second\n} from 'pkg'; const value = first + second;",
+        "const text = `not an import\\nimport x from 'x'`;\nlet value = 1;",
+        "/*\nimport x from 'x';\n*/\nlet value = 1;",
+    ] {
+        let expected = extract_imports(script);
+        let (imports, body, copied_chunks) = extract_imports_with_projection(script);
+        assert_eq!((imports, body.clone()), expected, "{script:?}");
+        for chunk in copied_chunks {
+            assert_eq!(
+                &script[chunk.source.start as usize..chunk.source.end as usize],
+                &body[chunk.output.start as usize..chunk.output.end as usize],
+                "{script:?}"
+            );
+        }
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- retain an exact copied-chunk projection while erasing TypeScript syntax
- compose that projection through instance-script import extraction
- apply state-transform replacements directly from the retained Phase 1 TypeScript program
- fall back to the stripped-JavaScript parser for semantic assignments, wrapped rune initializers, and replacements that cross an erased span
- keep the normal JavaScript collector and call graph unchanged

## Performance

- state-transform parser invocations on the 1,666-file corpus: **61 -> 57**
- retained/fallback fixture group: **5 -> 1** parser invocations
- four successfully projected fixtures, ABBA (50,000 iterations): median **-1.54%**, trimmed mean **-1.50%**
- all 29 TypeScript fixtures: median **+0.24%**, trimmed mean **+0.095%** (neutral)
- full 1,666-file corpus, two ABBA blocks: median **+0.33%**, trimmed mean **+0.14%**; block results changed sign, within run-to-run noise
- non-TypeScript corpus showed no regression signal

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test -p rsvelte_core --lib` (1,522 passed, 1 ignored)
- compatibility report tests (15 passed, 1 ignored)
- runes runtime fixtures (1,007/1,007 passed)
- legacy runtime fixtures (1,207/1,207 passed with a 16 MiB test-thread stack)
