### PR TITLE
Remove redundant client arrow postpass

### DIFF
--- a/crates/rsvelte_core/src/compiler/phases/3_transform/js_ast/codegen.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/js_ast/codegen.rs
@@ -1439,8 +1439,11 @@ impl<'a> JsCodegen<'a> {
         is_left: bool,
     ) -> bool {
         match operand {
-            // Conditional and assignment always need parens inside binary
-            JsExpr::Conditional(_) | JsExpr::Assignment(_) | JsExpr::Sequence(_) => true,
+            // Low-precedence operands need parens inside binary expressions.
+            JsExpr::Conditional(_)
+            | JsExpr::Assignment(_)
+            | JsExpr::Sequence(_)
+            | JsExpr::Arrow(_) => true,
             JsExpr::Binary(inner) => {
                 let parent_prec = binary_op_precedence(parent_op);
                 let inner_prec = binary_op_precedence(&inner.operator);
@@ -1538,6 +1541,7 @@ impl<'a> JsCodegen<'a> {
                 | JsExpr::Assignment(_)
                 | JsExpr::Conditional(_)
                 | JsExpr::Sequence(_)
+                | JsExpr::Arrow(_)
         )
     }
 
@@ -1587,7 +1591,15 @@ impl<'a> JsCodegen<'a> {
     }
 
     fn emit_conditional_expression(&mut self, cond: &JsConditionalExpression) {
-        self.emit_expression(self.arena.get_expr(cond.test));
+        let test = self.arena.get_expr(cond.test);
+        let test_needs_parens = matches!(test, JsExpr::Arrow(_));
+        if test_needs_parens {
+            self.output.push('(');
+        }
+        self.emit_expression(test);
+        if test_needs_parens {
+            self.output.push(')');
+        }
         self.output.push_str(" ? ");
         self.emit_expression(self.arena.get_expr(cond.consequent));
         self.output.push_str(" : ");
@@ -3041,6 +3053,114 @@ mod tests {
         let code = generate(&prog, &arena).unwrap();
         println!("{}", code);
         assert!(code.contains("const add = (a, b) => a + b"));
+    }
+
+    #[test]
+    fn arrow_parentheses_match_in_both_client_printers() {
+        let arena = JsArena::new();
+        let prog = program(vec![
+            const_decl(&arena, "plain", arrow(&arena, vec![], number(1.0))),
+            const_decl(
+                &arena,
+                "iife",
+                call(&arena, arrow(&arena, vec![], number(2.0)), vec![]),
+            ),
+            const_decl(
+                &arena,
+                "conditional",
+                conditional(
+                    &arena,
+                    id("flag"),
+                    arrow(&arena, vec![], number(3.0)),
+                    arrow(&arena, vec![], number(4.0)),
+                ),
+            ),
+            const_decl(
+                &arena,
+                "nullish",
+                nullish(&arena, id("value"), arrow(&arena, vec![], number(5.0))),
+            ),
+            const_decl(
+                &arena,
+                "logical",
+                and(&arena, id("value"), arrow(&arena, vec![], number(6.0))),
+            ),
+            const_decl(
+                &arena,
+                "nested",
+                arrow(&arena, vec![], arrow(&arena, vec![], number(7.0))),
+            ),
+            const_decl(
+                &arena,
+                "binary",
+                binary(
+                    &arena,
+                    JsBinaryOp::Add,
+                    arrow(&arena, vec![], number(8.0)),
+                    number(1.0),
+                ),
+            ),
+            const_decl(
+                &arena,
+                "conditional_test",
+                conditional(
+                    &arena,
+                    arrow(&arena, vec![], boolean(true)),
+                    id("yes"),
+                    id("no"),
+                ),
+            ),
+            const_decl(
+                &arena,
+                "negated",
+                JsExpr::Unary(JsUnaryExpression {
+                    operator: JsUnaryOp::Not,
+                    argument: arena.alloc_expr(arrow(&arena, vec![], boolean(true))),
+                    prefix: true,
+                }),
+            ),
+            const_decl(&arena, "string_value", string("literal (() => marker")),
+            const_decl(
+                &arena,
+                "template_value",
+                template_string("literal (() => marker"),
+            ),
+        ]);
+
+        let handwritten = generate(&prog, &arena).unwrap();
+        let allocator = oxc_allocator::Allocator::default();
+        let converted = super::super::to_oxc::program_to_oxc(&prog, &arena, &allocator).unwrap();
+        let esrap = rsvelte_esrap::print(&converted.program, "");
+
+        for (printer, code) in [("handwritten", handwritten), ("oxc/esrap", esrap)] {
+            let parse_allocator = oxc_allocator::Allocator::default();
+            let parsed =
+                oxc_parser::Parser::new(&parse_allocator, &code, oxc_span::SourceType::mjs())
+                    .parse();
+            assert!(
+                parsed.diagnostics.is_empty(),
+                "{printer} emitted invalid JavaScript: {code}"
+            );
+
+            for expected in [
+                "const plain = () => 1;",
+                "const iife = (() => 2)();",
+                "const conditional = flag ? () => 3 : () => 4;",
+                "const nullish = value ?? (() => 5);",
+                "const logical = value && (() => 6);",
+                "const nested = () => () => 7;",
+                "const binary = (() => 8) + 1;",
+                "const conditional_test = (() => true) ? yes : no;",
+                "const negated = !(() => true);",
+                "const string_value = 'literal (() => marker';",
+                "const template_value = `literal (() => marker`;",
+            ] {
+                assert!(
+                    code.contains(expected),
+                    "{printer} did not emit `{expected}`:\n{code}"
+                );
+            }
+        }
     }
 
     #[test]

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/mod.rs
@@ -120,11 +120,8 @@ pub(crate) fn transform_component_with_scripts(
 
     let (js, mut js_mappings) = match options.generate {
         GenerateMode::Client => {
-            let mut result =
+            let result =
                 client::transform_client(analysis, ast, source, options, retained_scripts)?;
-            // Strip unnecessary parens around arrow functions (e.g., (() => { ... }) → () => { ... })
-            // matching the official Svelte compiler's AST printer behavior.
-            result.code = server::transform_script::strip_arrow_function_parens(result.code);
 
             if options.enable_sourcemap {
                 // Merge codegen-tracked mappings with full token-level mappings.


### PR DESCRIPTION
## Summary

- remove the unconditional client-side `strip_arrow_function_parens` output scan
- keep the server-side normalization unchanged
- make the handwritten client fallback printer parenthesize arrow operands where JavaScript grammar requires it
- test arrow precedence through both the handwritten and OXC/esrap client printers

## Why

The client compiler already prints its final AST with correct arrow-function parentheses. It nevertheless scanned every generated client module afterward to remove redundant parentheses. On the fixed 3,459-file corpus this post-pass ran 3,457 times over 2.70 MB of JavaScript, found 1,734 candidate substrings, and changed zero outputs.

Removing the scan exposed three missing required-parenthesis cases in the handwritten fallback printer: arrow expressions used as binary operands, unary operands, and conditional tests. Those cases now emit the required parentheses directly instead of relying on an unrelated post-pass.

## Performance

Full client compilation over 3,459 successful Svelte corpus files:

- baseline and candidate output: 3,209,758 bytes, exact hash `8d570ae1be56d3bf`
- stable ABBA pooled median: 173.97 ms → 171.06 ms
- conservative improvement: 1.70%

Across all four ABBA block medians the improvement was 2.68%; 1.70% is reported conservatively because some blocks contained outliers.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- workspace lib tests: 1,525 passed, 1 ignored
- compatibility report tests
- compiler fixture tests
- runtime browser, hydration, runes, and legacy suites
- client transform pin/comment/switch/legacy-pre-effect/arrow-span tests
- sourcemap tests and sourcemap gate
- dual-printer arrow precedence test reparsed with OXC
