### PR TITLE
fix(svelte-check): align machine-verbose output with upstream, force a modern overlay target

### DIFF
--- a/.changeset/1901-1898-check-machine-output.md
+++ b/.changeset/1901-1898-check-machine-output.md
@@ -1,0 +1,20 @@
+---
+"@rsvelte/svelte-check": patch
+---
+
+Fix `rsvelte-check --output machine-verbose` (and the terser `machine`
+format) diverging from upstream `svelte-check`: they were line-oriented text
+with no diagnostic `code`, instead of upstream's one-`<epoch-ms> <JSON>`-
+line-per-diagnostic shape (`type`/`filename`/`start`/`end`/`message`/`code`/
+`source`, 0-indexed `start`/`end`), and were missing the bracketing `START`
+/ `COMPLETED` lines. Drop-in consumers (editor integrations, CI annotators,
+scripts keyed on `code`) can now parse rsvelte's machine output the same way
+they parse upstream's. Fixes #1901.
+
+Fix the overlay tsconfig synthesized for a `--tsconfig`-less run specifying
+no `target`, which let tsgo/tsc fall back to the ES5 default lib — the
+vendored shims themselves then failed to compile (`Cannot find name
+'Iterable'`) before any user code was considered. The overlay now mirrors
+official svelte-check's own default-compiler-options forcing: an unset
+target becomes the latest (`ESNext`), and a target below ES2015 is bumped
+up to ES2015; an already-modern target is left untouched. Fixes #1898.

--- a/crates/rsvelte_check/src/lib.rs
+++ b/crates/rsvelte_check/src/lib.rs
@@ -14,7 +14,7 @@ pub(crate) mod svelte2tsx {
 mod svelte_check;
 
 pub use rsvelte_diagnostics::{
-    Diagnostic, DiagnosticSeverity, OutputFormat, Position, Range, Threshold, write_diagnostic,
-    write_summary,
+    Diagnostic, DiagnosticSeverity, OutputFormat, Position, Range, Threshold,
+    count_files_with_problems, write_completion, write_diagnostic, write_start, write_summary,
 };
 pub use svelte_check::*;

--- a/crates/rsvelte_check/src/main.rs
+++ b/crates/rsvelte_check/src/main.rs
@@ -13,7 +13,10 @@ use rsvelte_check::{
     OutputFormat, RunOptions, Threshold, run,
     runner::{DiagnosticSource, WarningOverride},
     watch::{WatchOptions, run_watch},
+    writers::count_files_with_problems,
+    writers::write_completion,
     writers::write_diagnostic,
+    writers::write_start,
     writers::write_summary,
 };
 
@@ -263,6 +266,7 @@ fn print_run(
     threshold: Threshold,
 ) {
     let mut out = String::new();
+    write_start(&mut out, workspace, format);
     for diag in &result.diagnostics {
         // The threshold filters only what is *printed*; the summary and
         // exit code are always computed from the full diagnostic set,
@@ -275,6 +279,14 @@ fn print_run(
     if matches!(format, OutputFormat::Human | OutputFormat::HumanVerbose) {
         write_summary(&mut out, &result.diagnostics, result.files_checked);
     }
+    write_completion(
+        &mut out,
+        result.files_checked,
+        result.error_count(),
+        result.warning_count(),
+        count_files_with_problems(&result.diagnostics),
+        format,
+    );
     print!("{}", out);
 }
 

--- a/crates/rsvelte_check/src/svelte_check/overlay.rs
+++ b/crates/rsvelte_check/src/svelte_check/overlay.rs
@@ -889,6 +889,10 @@ fn build_overlay_tsconfig(
     // output is written against. The overlay tsconfig is isolated, so this
     // never leaks into the user's real build.
     compiler_opts.insert("jsx".into(), "preserve".into());
+    // An unset target falls back to tsgo/tsc's ES5/ES3 default lib, which breaks the vendored shims themselves; mirrors `service.ts#getParsedConfig`'s unconditional forcing.
+    if let Some(target) = resolve_forced_target(original) {
+        compiler_opts.insert("target".into(), target.into());
+    }
     // rootDirs: virtually overlay the emitted `.tsx`/kit shadows
     // (`<cacheDir>/svelte`) on top of the project's own rootDirs. We must
     // MERGE — not replace — the base rootDirs, otherwise frameworks that
@@ -1365,6 +1369,61 @@ fn resolve_root_dirs_abs(tsconfig_path: &Path) -> Vec<PathBuf> {
         }
     }
     Vec::new()
+}
+
+/// Whether a tsconfig `target` is ES2015+; `None` for an unrecognized string — a year-numbered target is parsed generically so newer TS releases need no change here.
+fn is_es2015_or_newer(target: &str) -> Option<bool> {
+    Some(match target.to_ascii_lowercase().as_str() {
+        "es3" | "es5" => false,
+        "es6" | "esnext" | "latest" => true,
+        other => other.strip_prefix("es")?.parse::<u32>().ok()? >= 2015,
+    })
+}
+
+/// Nearest-definition-wins `compilerOptions.target`, found by following the `extends` chain the same way [`resolve_root_dirs_abs`] does.
+fn resolve_effective_target(tsconfig_path: Option<&Path>) -> Option<String> {
+    let mut current = tsconfig_path.map(Path::to_path_buf);
+    let mut hops = 0;
+    while let Some(file) = current {
+        hops += 1;
+        if hops > 32 {
+            break;
+        }
+        let Ok(raw) = fs::read_to_string(&file) else {
+            break;
+        };
+        let stripped = strip_jsonc_comments(&raw);
+        let Ok(parsed) = serde_json::from_str::<serde_json::Value>(&stripped) else {
+            break;
+        };
+        let dir = file.parent().unwrap_or(Path::new("."));
+
+        if let Some(target) = parsed
+            .get("compilerOptions")
+            .and_then(|c| c.get("target"))
+            .and_then(|v| v.as_str())
+        {
+            return Some(target.to_string());
+        }
+
+        match parsed.get("extends").and_then(|v| v.as_str()) {
+            Some(ext) if ext.starts_with('.') => current = Some(resolve_extends_path(dir, ext)),
+            _ => break,
+        }
+    }
+    None
+}
+
+/// The `target` the overlay tsconfig should force, or `None` to leave the inherited value alone (already ES2015+, so the `extends` chain provides it).
+fn resolve_forced_target(original: Option<&Path>) -> Option<&'static str> {
+    match resolve_effective_target(original)
+        .as_deref()
+        .map(is_es2015_or_newer)
+    {
+        None | Some(None) => Some("ESNext"),
+        Some(Some(false)) => Some("ES2015"),
+        Some(Some(true)) => None,
+    }
 }
 
 /// The nearest `compilerOptions.paths` in a tsconfig's `extends` chain, paired
@@ -2475,6 +2534,160 @@ mod tests {
         );
 
         let _ = fs::remove_dir_all(&tmp);
+    }
+
+    /// With no `--tsconfig` at all, tsgo/tsc would otherwise fall back to the ES5/ES3 default lib and the vendored shims themselves fail to compile.
+    #[test]
+    fn overlay_tsconfig_forces_modern_target_with_no_tsconfig() {
+        let tmp =
+            std::env::temp_dir().join(format!("svc_overlay_target_none_{}", std::process::id()));
+        let _ = fs::remove_dir_all(&tmp);
+        fs::create_dir_all(tmp.join("src")).unwrap();
+        fs::write(tmp.join("src/App.svelte"), "<div>hi</div>").unwrap();
+
+        let files = vec![tmp.join("src/App.svelte")];
+        let layout = materialize_overlay(&tmp, &files, None).unwrap();
+
+        let cfg: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(&layout.overlay_tsconfig).unwrap()).unwrap();
+        assert_eq!(
+            cfg["compilerOptions"]["target"],
+            serde_json::json!("ESNext")
+        );
+
+        let _ = fs::remove_dir_all(&tmp);
+    }
+
+    /// A target below ES2015 is bumped to ES2015 rather than left at whatever pre-ES2015 default lib it would otherwise pull in.
+    #[test]
+    fn overlay_tsconfig_bumps_low_target_to_es2015() {
+        let tmp =
+            std::env::temp_dir().join(format!("svc_overlay_target_es5_{}", std::process::id()));
+        let _ = fs::remove_dir_all(&tmp);
+        fs::create_dir_all(tmp.join("src")).unwrap();
+        fs::write(
+            tmp.join("tsconfig.json"),
+            r#"{ "compilerOptions": { "target": "es5" } }"#,
+        )
+        .unwrap();
+        fs::write(tmp.join("src/App.svelte"), "<div>hi</div>").unwrap();
+
+        let files = vec![tmp.join("src/App.svelte")];
+        let tsconfig = tmp.join("tsconfig.json");
+        let layout = materialize_overlay(&tmp, &files, Some(&tsconfig)).unwrap();
+
+        let cfg: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(&layout.overlay_tsconfig).unwrap()).unwrap();
+        assert_eq!(
+            cfg["compilerOptions"]["target"],
+            serde_json::json!("ES2015")
+        );
+
+        let _ = fs::remove_dir_all(&tmp);
+    }
+
+    /// The overlay must not clobber a deliberate, already-modern-enough target with its own override.
+    #[test]
+    fn overlay_tsconfig_leaves_modern_target_untouched() {
+        let tmp =
+            std::env::temp_dir().join(format!("svc_overlay_target_modern_{}", std::process::id()));
+        let _ = fs::remove_dir_all(&tmp);
+        fs::create_dir_all(tmp.join("src")).unwrap();
+        fs::write(
+            tmp.join("tsconfig.json"),
+            r#"{ "compilerOptions": { "target": "ES2022" } }"#,
+        )
+        .unwrap();
+        fs::write(tmp.join("src/App.svelte"), "<div>hi</div>").unwrap();
+
+        let files = vec![tmp.join("src/App.svelte")];
+        let tsconfig = tmp.join("tsconfig.json");
+        let layout = materialize_overlay(&tmp, &files, Some(&tsconfig)).unwrap();
+
+        let cfg: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(&layout.overlay_tsconfig).unwrap()).unwrap();
+        assert!(
+            cfg["compilerOptions"]["target"].is_null(),
+            "overlay should not override an already-modern target: {cfg}"
+        );
+
+        let _ = fs::remove_dir_all(&tmp);
+    }
+
+    /// A year-numbered target beyond the hardcoded aliases (`es3`/`es5`/`es6`/`esnext`) must still be recognized as modern via the generic `esNNNN` parse.
+    #[test]
+    fn overlay_tsconfig_leaves_es2025_target_untouched() {
+        let tmp =
+            std::env::temp_dir().join(format!("svc_overlay_target_es2025_{}", std::process::id()));
+        let _ = fs::remove_dir_all(&tmp);
+        fs::create_dir_all(tmp.join("src")).unwrap();
+        fs::write(
+            tmp.join("tsconfig.json"),
+            r#"{ "compilerOptions": { "target": "ES2025" } }"#,
+        )
+        .unwrap();
+        fs::write(tmp.join("src/App.svelte"), "<div>hi</div>").unwrap();
+
+        let files = vec![tmp.join("src/App.svelte")];
+        let tsconfig = tmp.join("tsconfig.json");
+        let layout = materialize_overlay(&tmp, &files, Some(&tsconfig)).unwrap();
+
+        let cfg: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(&layout.overlay_tsconfig).unwrap()).unwrap();
+        assert!(
+            cfg["compilerOptions"]["target"].is_null(),
+            "overlay should not override an already-modern target: {cfg}"
+        );
+
+        let _ = fs::remove_dir_all(&tmp);
+    }
+
+    /// A target set only on a grandparent config (e.g. SvelteKit's generated `.svelte-kit/tsconfig.json`) must still be found via the `extends` chain.
+    #[test]
+    fn overlay_tsconfig_target_search_follows_extends_chain() {
+        let tmp =
+            std::env::temp_dir().join(format!("svc_overlay_target_chain_{}", std::process::id()));
+        let _ = fs::remove_dir_all(&tmp);
+        fs::create_dir_all(tmp.join("src")).unwrap();
+        fs::create_dir_all(tmp.join(".svelte-kit")).unwrap();
+        fs::write(
+            tmp.join(".svelte-kit/tsconfig.json"),
+            r#"{ "compilerOptions": { "target": "ES2020" } }"#,
+        )
+        .unwrap();
+        fs::write(
+            tmp.join("tsconfig.json"),
+            r#"{ "extends": "./.svelte-kit/tsconfig.json" }"#,
+        )
+        .unwrap();
+        fs::write(tmp.join("src/App.svelte"), "<div>hi</div>").unwrap();
+
+        let files = vec![tmp.join("src/App.svelte")];
+        let tsconfig = tmp.join("tsconfig.json");
+        let layout = materialize_overlay(&tmp, &files, Some(&tsconfig)).unwrap();
+
+        let cfg: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(&layout.overlay_tsconfig).unwrap()).unwrap();
+        assert!(
+            cfg["compilerOptions"]["target"].is_null(),
+            "inherited ES2020 target found via extends chain should not be overridden: {cfg}"
+        );
+
+        let _ = fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn is_es2015_or_newer_parses_year_targets_generically() {
+        assert_eq!(is_es2015_or_newer("es3"), Some(false));
+        assert_eq!(is_es2015_or_newer("es5"), Some(false));
+        assert_eq!(is_es2015_or_newer("ES6"), Some(true));
+        assert_eq!(is_es2015_or_newer("es2015"), Some(true));
+        assert_eq!(is_es2015_or_newer("ES2024"), Some(true));
+        // Not a hardcoded alias — must resolve through the generic `esNNNN` parse.
+        assert_eq!(is_es2015_or_newer("es2025"), Some(true));
+        assert_eq!(is_es2015_or_newer("esnext"), Some(true));
+        assert_eq!(is_es2015_or_newer("latest"), Some(true));
+        assert_eq!(is_es2015_or_newer("nonsense"), None);
     }
 
     /// `rebase_spec` must rebase the non-glob directory prefix and keep

--- a/crates/rsvelte_diagnostics/src/lib.rs
+++ b/crates/rsvelte_diagnostics/src/lib.rs
@@ -7,4 +7,7 @@ mod diagnostic;
 mod writers;
 
 pub use diagnostic::{Diagnostic, DiagnosticSeverity, Position, Range};
-pub use writers::{OutputFormat, Threshold, write_diagnostic, write_summary};
+pub use writers::{
+    OutputFormat, Threshold, count_files_with_problems, write_completion, write_diagnostic,
+    write_start, write_summary,
+};

--- a/crates/rsvelte_diagnostics/src/writers.rs
+++ b/crates/rsvelte_diagnostics/src/writers.rs
@@ -2,12 +2,11 @@
 //! shape `svelte-check` callers expect. Mirrors
 //! `submodules/language-tools/packages/svelte-check/src/writers.ts`.
 //!
-//! v0.1 implements `human` and `machine` formats; the verbose variants
-//! reuse the human/machine path with extra fields.
+//! `machine` / `machine-verbose` line-for-line mirror `MachineFriendlyWriter`; `human` / `human-verbose` remain a v0.1 approximation of `HumanFriendlyWriter`.
 
 use std::fmt::Write;
 
-use crate::{Diagnostic, DiagnosticSeverity};
+use crate::{Diagnostic, DiagnosticSeverity, Range};
 
 /// Output mode. Matches the values accepted by `--output` on the JS CLI,
 /// plus `github-actions` for CI-friendly workflow-command annotations.
@@ -117,37 +116,179 @@ fn write_machine(
     workspace_root: &std::path::Path,
     format: OutputFormat,
 ) {
-    // `<unix_ts> <severity> <abs_path>:<line>:<col> "<msg>" <source>`
-    // The JS reference's machine format is line-oriented for grep-ability.
-    let line = diag.range.map(|r| r.start.line).unwrap_or(1);
-    let col = diag.range.map(|r| r.start.column).unwrap_or(1);
-    let path = if matches!(format, OutputFormat::MachineVerbose) {
-        diag.file.display().to_string()
-    } else {
-        diag.file
-            .strip_prefix(workspace_root)
-            .unwrap_or(&diag.file)
-            .display()
-            .to_string()
+    // Upstream's `type` stays null for info/hint, so no line is logged at all.
+    let severity = match diag.severity {
+        DiagnosticSeverity::Error => "ERROR",
+        DiagnosticSeverity::Warning => "WARNING",
+        DiagnosticSeverity::Info | DiagnosticSeverity::Hint => return,
     };
-    // The machine format is line-oriented (one diagnostic per line), so a
-    // message carrying newlines must be encoded or it splits into several
-    // un-parseable lines (H-098). Escape quotes and CR/LF.
-    let escaped = diag
-        .message
-        .replace('"', "\\\"")
-        .replace('\r', "\\r")
-        .replace('\n', "\\n");
-    let _ = writeln!(
-        out,
-        "{} {}:{}:{} \"{}\" {}",
-        diag.severity.label().to_uppercase(),
-        path,
-        line,
-        col,
-        escaped,
-        diag.source
+
+    let rel = diag
+        .file
+        .strip_prefix(workspace_root)
+        .unwrap_or(&diag.file)
+        .display()
+        .to_string();
+    let (start, end) = zero_based_range(diag.range);
+
+    if matches!(format, OutputFormat::MachineVerbose) {
+        // Field order matches `JSON.stringify({ type, filename, start, end, message, code, codeDescription, source })`; an absent field is omitted rather than written as `null`, matching what `JSON.stringify` does to `undefined`.
+        let mut json = String::from("{");
+        let _ = write!(json, "\"type\":\"{severity}\",");
+        let _ = write!(json, "\"filename\":{},", json_quoted(&rel));
+        let _ = write!(
+            json,
+            "\"start\":{{\"line\":{},\"character\":{}}},",
+            start.0, start.1
+        );
+        let _ = write!(
+            json,
+            "\"end\":{{\"line\":{},\"character\":{}}},",
+            end.0, end.1
+        );
+        let _ = write!(json, "\"message\":{},", json_quoted(&diag.message));
+        write_code_field(&mut json, diag);
+        write_code_description_field(&mut json, diag, severity);
+        let _ = write!(json, "\"source\":{}", json_quoted(diag.source));
+        json.push('}');
+        write_epoch_line(out, &json);
+    } else {
+        // 1-based line/col, matching `${start.line + 1}:${start.character + 1}`.
+        let payload = format!(
+            "{severity} {} {}:{} {}",
+            json_quoted(&rel),
+            start.0 + 1,
+            start.1 + 1,
+            json_quoted(&diag.message)
+        );
+        write_epoch_line(out, &payload);
+    }
+}
+
+/// Converts rsvelte's 1-based-line/0-based-column `Range` to the 0-based-on-both-axes LSP shape `machine-verbose` needs; a missing range falls back to the file start.
+fn zero_based_range(range: Option<Range>) -> ((u32, u32), (u32, u32)) {
+    match range {
+        Some(r) => (
+            (r.start.line.saturating_sub(1), r.start.column),
+            (r.end.line.saturating_sub(1), r.end.column),
+        ),
+        None => ((0, 0), (0, 0)),
+    }
+}
+
+/// `code` is omitted entirely when absent, matching `JSON.stringify` dropping an `undefined` property.
+fn write_code_field(json: &mut String, diag: &Diagnostic) {
+    let Some(code) = diag.code.as_deref() else {
+        return;
+    };
+    // Upstream's TS `code` is a bare number; rsvelte stores the CLI-facing `TS`-prefixed string, so strip it back off to match the JSON type.
+    if diag.source == "ts"
+        && let Some(num) = code.strip_prefix("TS").and_then(|n| n.parse::<u64>().ok())
+    {
+        let _ = write!(json, "\"code\":{num},");
+        return;
+    }
+    let _ = write!(json, "\"code\":{},", json_quoted(code));
+}
+
+/// Mirrors `getDiagnostics.ts`'s `getCodeDescription`, which only fires for a Svelte-sourced, lowercase, `-`/`_`-bearing code — never for a bare TS number.
+fn write_code_description_field(json: &mut String, diag: &Diagnostic, severity: &str) {
+    if diag.source != "svelte" {
+        return;
+    }
+    let Some(code) = diag.code.as_deref() else {
+        return;
+    };
+    let starts_lowercase = code.chars().next().is_some_and(|c| c.is_ascii_lowercase());
+    if !starts_lowercase || !(code.contains('-') || code.contains('_')) {
+        return;
+    }
+    let anchor = code.replace('-', "_");
+    let base = if severity == "ERROR" {
+        "compiler-errors"
+    } else {
+        "compiler-warnings"
+    };
+    let href = json_quoted(&format!("https://svelte.dev/docs/svelte/{base}#{anchor}"));
+    let _ = write!(json, "\"codeDescription\":{{\"href\":{href}}},");
+}
+
+/// Mirrors `JSON.stringify` on a plain string: non-ASCII passes through unescaped.
+fn json_escape(s: &str) -> String {
+    let mut out = String::with_capacity(s.len() + 2);
+    for c in s.chars() {
+        match c {
+            '"' => out.push_str("\\\""),
+            '\\' => out.push_str("\\\\"),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            c if (c as u32) < 0x20 => {
+                let _ = write!(out, "\\u{:04x}", c as u32);
+            }
+            c => out.push(c),
+        }
+    }
+    out
+}
+
+fn json_quoted(s: &str) -> String {
+    format!("\"{}\"", json_escape(s))
+}
+
+fn epoch_ms() -> u128 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis())
+        .unwrap_or(0)
+}
+
+fn write_epoch_line(out: &mut String, payload: &str) {
+    let _ = writeln!(out, "{} {}", epoch_ms(), payload);
+}
+
+/// Mirrors `MachineFriendlyWriter#start`; a no-op for every other format.
+pub fn write_start(out: &mut String, workspace_root: &std::path::Path, format: OutputFormat) {
+    if !matches!(format, OutputFormat::Machine | OutputFormat::MachineVerbose) {
+        return;
+    }
+    let payload = format!(
+        "START {}",
+        json_quoted(&workspace_root.display().to_string())
     );
+    write_epoch_line(out, &payload);
+}
+
+/// Mirrors `MachineFriendlyWriter#completion`; a no-op for every other format.
+pub fn write_completion(
+    out: &mut String,
+    file_count: usize,
+    error_count: usize,
+    warning_count: usize,
+    file_count_with_problems: usize,
+    format: OutputFormat,
+) {
+    if !matches!(format, OutputFormat::Machine | OutputFormat::MachineVerbose) {
+        return;
+    }
+    let payload = format!(
+        "COMPLETED {file_count} FILES {error_count} ERRORS {warning_count} WARNINGS {file_count_with_problems} FILES_WITH_PROBLEMS"
+    );
+    write_epoch_line(out, &payload);
+}
+
+/// Computed over the full diagnostic set, not the threshold-filtered subset that gets printed — matching the JS reference's `fileCountWithProblems`.
+pub fn count_files_with_problems(diagnostics: &[Diagnostic]) -> usize {
+    let mut files = std::collections::HashSet::new();
+    for d in diagnostics {
+        if matches!(
+            d.severity,
+            DiagnosticSeverity::Error | DiagnosticSeverity::Warning
+        ) {
+            files.insert(&d.file);
+        }
+    }
+    files.len()
 }
 
 /// GitHub Actions workflow-command annotation:
@@ -349,6 +490,172 @@ mod tests {
         assert!(Threshold::Warning.includes(DiagnosticSeverity::Warning));
         assert!(!Threshold::Warning.includes(DiagnosticSeverity::Info));
         assert!(!Threshold::Warning.includes(DiagnosticSeverity::Hint));
+    }
+
+    /// Strip the epoch-ms prefix every `machine` / `machine-verbose` line
+    /// carries, returning the payload after the first space.
+    fn strip_epoch(line: &str) -> &str {
+        line.split_once(' ').map(|(_, rest)| rest).unwrap_or(line)
+    }
+
+    #[test]
+    fn machine_verbose_emits_upstream_shaped_json() {
+        // Verified byte-for-byte (modulo the epoch) against the real `svelte-check` binary for this exact diagnostic shape.
+        let ws = Path::new("/work");
+        let d = diag(DiagnosticSeverity::Error, "/work/src/Foo.svelte", 12, 3);
+        let mut out = String::new();
+        write_diagnostic(&mut out, &d, ws, OutputFormat::MachineVerbose);
+        let line = out.trim_end();
+        let (epoch, payload) = line.split_once(' ').expect("epoch-ms prefix");
+        assert!(epoch.parse::<u128>().is_ok(), "not an epoch prefix: {line}");
+        assert_eq!(
+            payload,
+            "{\"type\":\"ERROR\",\"filename\":\"src/Foo.svelte\",\"start\":{\"line\":11,\"character\":3},\
+             \"end\":{\"line\":11,\"character\":3},\"message\":\"Unused CSS selector \\\"foo\\\"\",\
+             \"code\":\"css_unused_selector\",\"codeDescription\":{\"href\":\"https://svelte.dev/docs/svelte/\
+             compiler-errors#css_unused_selector\"},\"source\":\"svelte\"}"
+        );
+    }
+
+    #[test]
+    fn machine_verbose_code_description_uses_warnings_anchor_for_warnings() {
+        let ws = Path::new("/work");
+        let d = diag(DiagnosticSeverity::Warning, "/work/A.svelte", 1, 1);
+        let mut out = String::new();
+        write_diagnostic(&mut out, &d, ws, OutputFormat::MachineVerbose);
+        assert!(
+            strip_epoch(out.trim_end()).contains(
+                "\"codeDescription\":{\"href\":\"https://svelte.dev/docs/svelte/compiler-warnings#css_unused_selector\"}"
+            ),
+            "{out}"
+        );
+    }
+
+    #[test]
+    fn machine_verbose_ts_diagnostics_never_get_a_code_description() {
+        let ws = Path::new("/work");
+        let mut d = diag(DiagnosticSeverity::Error, "/work/src/foo.ts", 1, 1);
+        d.source = "ts";
+        d.code = Some("TS2322".into());
+        let mut out = String::new();
+        write_diagnostic(&mut out, &d, ws, OutputFormat::MachineVerbose);
+        assert!(
+            !strip_epoch(out.trim_end()).contains("codeDescription"),
+            "{out}"
+        );
+    }
+
+    #[test]
+    fn machine_verbose_ts_code_is_a_json_number() {
+        let ws = Path::new("/work");
+        let mut d = diag(DiagnosticSeverity::Error, "/work/src/foo.ts", 1, 1);
+        d.source = "ts";
+        d.code = Some("TS2322".into());
+        let mut out = String::new();
+        write_diagnostic(&mut out, &d, ws, OutputFormat::MachineVerbose);
+        assert!(
+            strip_epoch(out.trim_end()).contains("\"code\":2322,"),
+            "{out}"
+        );
+    }
+
+    #[test]
+    fn machine_verbose_omits_code_when_absent() {
+        let ws = Path::new("/work");
+        let mut d = diag(DiagnosticSeverity::Error, "/work/A.svelte", 1, 1);
+        d.code = None;
+        let mut out = String::new();
+        write_diagnostic(&mut out, &d, ws, OutputFormat::MachineVerbose);
+        let payload = strip_epoch(out.trim_end());
+        assert!(!payload.contains("\"code\""), "{payload}");
+        assert!(payload.contains("\"source\":\"svelte\""), "{payload}");
+    }
+
+    #[test]
+    fn machine_verbose_missing_range_falls_back_to_file_start() {
+        let ws = Path::new("/work");
+        let mut d = diag(DiagnosticSeverity::Error, "/work/A.svelte", 1, 1);
+        d.range = None;
+        let mut out = String::new();
+        write_diagnostic(&mut out, &d, ws, OutputFormat::MachineVerbose);
+        let payload = strip_epoch(out.trim_end());
+        assert!(
+            payload.contains("\"start\":{\"line\":0,\"character\":0}"),
+            "{payload}"
+        );
+        assert!(
+            payload.contains("\"end\":{\"line\":0,\"character\":0}"),
+            "{payload}"
+        );
+    }
+
+    #[test]
+    fn machine_terse_format_is_epoch_prefixed_and_one_based() {
+        let ws = Path::new("/work");
+        let d = diag(DiagnosticSeverity::Warning, "/work/src/Foo.svelte", 12, 3);
+        let mut out = String::new();
+        write_diagnostic(&mut out, &d, ws, OutputFormat::Machine);
+        let line = out.trim_end();
+        let (epoch, payload) = line.split_once(' ').expect("epoch-ms prefix");
+        assert!(epoch.parse::<u128>().is_ok(), "not an epoch prefix: {line}");
+        assert_eq!(
+            payload,
+            "WARNING \"src/Foo.svelte\" 12:4 \"Unused CSS selector \\\"foo\\\"\""
+        );
+    }
+
+    #[test]
+    fn machine_formats_drop_info_and_hint_diagnostics() {
+        let ws = Path::new("/work");
+        for severity in [DiagnosticSeverity::Info, DiagnosticSeverity::Hint] {
+            let d = diag(severity, "/work/A.svelte", 1, 1);
+            let mut out = String::new();
+            write_diagnostic(&mut out, &d, ws, OutputFormat::MachineVerbose);
+            assert!(out.is_empty(), "{severity:?}: {out}");
+            let mut out = String::new();
+            write_diagnostic(&mut out, &d, ws, OutputFormat::Machine);
+            assert!(out.is_empty(), "{severity:?}: {out}");
+        }
+    }
+
+    #[test]
+    fn write_start_emits_json_quoted_workspace_path() {
+        let ws = Path::new("/work/app");
+        let mut out = String::new();
+        write_start(&mut out, ws, OutputFormat::MachineVerbose);
+        let payload = strip_epoch(out.trim_end());
+        assert_eq!(payload, "START \"/work/app\"");
+
+        // No-op for formats other than machine / machine-verbose.
+        let mut out = String::new();
+        write_start(&mut out, ws, OutputFormat::GithubActions);
+        assert!(out.is_empty());
+    }
+
+    #[test]
+    fn write_completion_emits_expected_counts() {
+        let mut out = String::new();
+        write_completion(&mut out, 5, 2, 1, 3, OutputFormat::Machine);
+        let payload = strip_epoch(out.trim_end());
+        assert_eq!(
+            payload,
+            "COMPLETED 5 FILES 2 ERRORS 1 WARNINGS 3 FILES_WITH_PROBLEMS"
+        );
+
+        let mut out = String::new();
+        write_completion(&mut out, 5, 2, 1, 3, OutputFormat::HumanVerbose);
+        assert!(out.is_empty());
+    }
+
+    #[test]
+    fn count_files_with_problems_ignores_info_and_hint_and_dedupes() {
+        let diags = vec![
+            diag(DiagnosticSeverity::Error, "/work/A.svelte", 1, 1),
+            diag(DiagnosticSeverity::Warning, "/work/A.svelte", 2, 1),
+            diag(DiagnosticSeverity::Info, "/work/B.svelte", 1, 1),
+            diag(DiagnosticSeverity::Error, "/work/C.svelte", 1, 1),
+        ];
+        assert_eq!(count_files_with_problems(&diags), 2);
     }
 
     #[test]

--- a/scripts/compat-corpus/check-verify.mjs
+++ b/scripts/compat-corpus/check-verify.mjs
@@ -8,7 +8,8 @@
  *      see byte-identical dependencies.
  *   2. Check it with the REAL `svelte-check` — the ground truth.
  *   3. Check it with the native `rsvelte-check` binary.
- *   4. Diff the two normalized diagnostic sets.
+ *   4. Diff the two normalized diagnostic sets — both sides read via
+ *      `--output machine-verbose`, so one parser covers both.
  *
  * Unlike the compiler / fmt / svelte2tsx / lint gates, this one compares
  * *diagnostics of a type-checked project*, not per-file text: alias resolution,
@@ -17,7 +18,8 @@
  *
  * NORMALIZATION — a diagnostic collapses to `<SEVERITY> <relpath>:<line> <code>`:
  *   - path is relative to the checked workspace, `/`-separated;
- *   - line is 1-based (the oracle's machine-verbose JSON is 0-based, so +1);
+ *   - line is 1-based (both sides' machine-verbose JSON `start.line` is
+ *     0-based, so +1);
  *   - code is the bare TS error number (`TS2322` -> `2322`) or, for Svelte
  *     compiler diagnostics, the warning/error code string.
  * COLUMN and MESSAGE TEXT are deliberately dropped: both differ for reasons that
@@ -147,11 +149,12 @@ function normalizeCode(code) {
 }
 
 /**
- * Official `--output machine-verbose`: one `<epoch-ms> <payload>` line per
- * event, where a diagnostic payload is the JSON object built by
- * `MachineFriendlyWriter`. START / COMPLETED lines are not JSON objects.
+ * `--output machine-verbose`: one `<epoch-ms> <payload>` line per event, where
+ * a diagnostic payload is the JSON object built by `MachineFriendlyWriter`.
+ * START / COMPLETED lines are not JSON objects and are skipped. Both checkers
+ * emit this same shape, so a single parser covers both sides.
  */
-function parseOracle(stdout) {
+function parseMachineVerbose(stdout) {
 	const counts = new Map();
 	const detail = [];
 	for (const line of stdout.split('\n')) {
@@ -167,40 +170,6 @@ function parseOracle(stdout) {
 		const k = key(d.type, d.filename, d.start.line + 1, normalizeCode(d.code));
 		bump(counts, k);
 		detail.push({ key: k, message: d.message, source: d.source });
-	}
-	return { counts, detail };
-}
-
-/**
- * rsvelte-check's `--output github-actions`:
- *   `::<level> file=<rel>,line=<L>,col=<C>::(<source>) <message> [<code>]`
- * It is the only rsvelte output format carrying the diagnostic code, which the
- * normalization key needs. (rsvelte's own `machine-verbose` is a line-oriented
- * format rather than upstream's JSON — a separate parity gap, tracked outside
- * this gate.)
- */
-function parseRsvelte(stdout) {
-	const unescape = (s) =>
-		s
-			.replace(/%3A/g, ':')
-			.replace(/%2C/g, ',')
-			.replace(/%0A/g, '\n')
-			.replace(/%0D/g, '\r')
-			.replace(/%25/g, '%');
-	const counts = new Map();
-	const detail = [];
-	const re = /^::(error|warning|notice) file=(.*?),line=(\d+),col=(\d+)::(.*)$/;
-	for (const line of stdout.split('\n')) {
-		const m = re.exec(line.trim());
-		if (!m) continue;
-		const level = m[1] === 'error' ? 'ERROR' : m[1] === 'warning' ? 'WARNING' : null;
-		if (!level) continue;
-		// Match the trailing `[code]` on the still-escaped body: the message may
-		// carry `%0A`-encoded newlines, but a code never does.
-		const codeMatch = /\[([^\]]+)\]$/.exec(m[5]);
-		const k = key(level, unescape(m[2]), Number(m[3]), normalizeCode(codeMatch?.[1]));
-		bump(counts, k);
-		detail.push({ key: k, message: unescape(m[5]) });
 	}
 	return { counts, detail };
 }
@@ -248,7 +217,7 @@ function main() {
 		if (config.tsconfig) common.push('--tsconfig', config.tsconfig);
 		const ws = config.workspace ?? '.';
 
-		const oracle = parseOracle(
+		const oracle = parseMachineVerbose(
 			runCapture(
 				'node',
 				[
@@ -260,8 +229,8 @@ function main() {
 				path.join(oracleDir, ws)
 			)
 		);
-		const actual = parseRsvelte(
-			runCapture(bin, ['--output', 'github-actions', ...common], path.join(actualDir, ws), {
+		const actual = parseMachineVerbose(
+			runCapture(bin, ['--output', 'machine-verbose', ...common], path.join(actualDir, ws), {
 				TSGO_BIN: tsc
 			})
 		);


### PR DESCRIPTION
## Summary

- **#1901** — `rsvelte-check --output machine-verbose` (and the terser `machine` format) emitted a line-oriented, non-JSON format with no diagnostic `code`, instead of upstream `svelte-check`'s `MachineFriendlyWriter` shape: an epoch-ms-prefixed `START` line, one `<epoch-ms> <JSON>` line per diagnostic (`type`/`filename`/`start`/`end`/`message`/`code`/`codeDescription`/`source`, 0-indexed `start`/`end`), and a `COMPLETED` summary line. Ported the writer to match upstream field-for-field. `scripts/compat-corpus/check-verify.mjs` now reads rsvelte's side via `--output machine-verbose` too (previously `--output github-actions`, the only rsvelte format that carried a code before this fix), so both sides are parsed by the same function.
- **#1898** — the overlay tsconfig synthesized for a `--tsconfig`-less run left `target` unset, so tsgo/tsc fell back to the ES5 default lib and the vendored shims themselves failed to compile (`Cannot find name 'Iterable'`) before any user code was considered. The overlay now mirrors official svelte-check's own `service.ts#getParsedConfig` forcing: an unset target becomes `ESNext`, a target below ES2015 is bumped to ES2015, and an already-modern target is left alone (found by walking the tsconfig `extends` chain, the same way the existing `rootDirs` resolution does). The ES2015-or-newer check parses any `esNNNN` year generically (not a hardcoded `es2015`..`es2024` table), so a newer pinned TypeScript recognizing e.g. `ES2025` doesn't need a matching code change here.

## Before / after (`--output machine-verbose`)

Before:
```
WARNING /abs/path/to/demo/App.svelte:6:1 "Unused CSS selector \".unused\"\nhttps://svelte.dev/e/css_unused_selector" svelte
```
(single line, absolute path, no epoch prefix, no `START`/`COMPLETED`, no `code`)

After (verified byte-identical, modulo the epoch, against the real `svelte-check` binary):
```
1785326700162 START "/abs/path/to/demo"
1785326700162 {"type":"WARNING","filename":"App.svelte","start":{"line":5,"character":1},"end":{"line":5,"character":8},"message":"Unused CSS selector \".unused\"\nhttps://svelte.dev/e/css_unused_selector","code":"css_unused_selector","codeDescription":{"href":"https://svelte.dev/docs/svelte/compiler-warnings#css_unused_selector"},"source":"svelte"}
1785326700162 COMPLETED 1 FILES 0 ERRORS 1 WARNINGS 1 FILES_WITH_PROBLEMS
```

## Known constraint (out of scope)

`resolve_effective_target`'s `extends`-chain walk (like the pre-existing `rootDirs` walk it mirrors) only follows relative `extends` paths; a bare package-specifier `extends` (e.g. `@tsconfig/svelte`) stops the walk, so a `target` set only inside such a package won't be found and the overlay may still force one. Same pre-existing limitation as the neighboring `rootDirs`/`paths` resolution — not addressed here.

## Test plan

- [x] `cargo test -p rsvelte_diagnostics -p rsvelte_check` — new unit tests cover the `machine`/`machine-verbose` JSON schema (field coverage/order, 0-indexed positions, TS-code-as-number, `codeDescription` gating), plus the overlay `target` defaulting (no-tsconfig, low-target bump, modern-target no-op, `extends`-chain search, generic `esNNNN` parsing incl. ES2025).
- [x] `cargo fmt --check` / `cargo clippy --all-targets --all-features -- -D warnings` clean.
- [x] `pnpm run test:svelte-check` (the `check-verify.mjs` diagnostic-parity gate, now reading rsvelte via `machine-verbose`): 0 new divergences (16 known → 5 current; the other 11 were already fixed by unrelated, already-merged PRs — ratchet file intentionally left untouched per scope).
- [x] Manually installed the real `svelte-check`/`svelte`/`typescript` packages and compared `--output machine-verbose` output against `rsvelte-check` on the same fixture — byte-identical apart from the epoch timestamp (this is how the `codeDescription` field was discovered and added).

Closes #1901, closes #1898

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JFL7CmMS1hd9sJA3yU4GTC
