### PR TITLE
fix(svelte-check): port get_global_types' svelte-html.d.ts preference into the overlay (#1897 Layer 3)

### DIFF
--- a/.changeset/global-types-svelte-html.md
+++ b/.changeset/global-types-svelte-html.md
@@ -1,0 +1,18 @@
+---
+"@rsvelte/svelte-check": patch
+---
+
+Track the installed Svelte's element typings instead of a frozen snapshot.
+The overlay used to inject the vendored `svelte-jsx-v4.d.ts` unconditionally,
+whose hand-enumerated `svelteHTML.IntrinsicElements` predates every tag
+`svelte/elements` has gained since the shim was copied — so a post-snapshot
+element's props fell through to the interface's
+`[name: string]: { [name: string]: any }` catch-all and became bare `any`
+(#1889's `<svelte:boundary onerror>` was one instance of that class).
+
+svelte2tsx's `get_global_types` is now ported: when the project's own
+`<sveltePath>/svelte-html.d.ts` exists (Svelte 4+), it is added to the program
+and the vendored JSX shim is dropped. That file extends `SvelteHTMLElements`
+from the installed `svelte/elements`, so element and attribute types follow the
+user's Svelte version instead of a copy date. Projects where `svelte` cannot be
+resolved from the workspace keep the vendored shims as a fallback.

--- a/compatibility/check-known-failures.json
+++ b/compatibility/check-known-failures.json
@@ -1,3 +1,1 @@
-[
-	"boundary-elements|+ERROR src/Boundary.svelte:9 7006"
-]
+[]

--- a/compatibility/check-known-failures.md
+++ b/compatibility/check-known-failures.md
@@ -18,36 +18,20 @@ positions back through its own source map and TypeScript wording moves between
 patch releases, so keying on them would make the ratchet churn without telling
 anyone anything. See the header of `check-verify.mjs`.
 
-## Current baseline: 1 entry / 1 surplus diagnostic (all FP, 0 FN)
+## Current baseline: 0 entries / 0 surplus diagnostics — full parity
 
-The gate landed with 16 entries across the #1883–#1889 cluster. `sibling-paths-alias`
-(#1883, fixed by #1884), `external-self-alias` (#1887, fixed by #1893),
-`ts-aliased-import` (#1888, fixed by #1895), `kit-hooks-arrow-ts` (#1886, fixed by
-#1892), `kit-hooks-js` (#1886, fixed by #1892 for the arrow/function-expression
-form and a follow-up JSDoc-anchor fix for the plain `export function` form) and
-`sibling-symlink` (#1900, fixed by #1907) are now all fully green and have been
-pruned. What remains:
+The gate landed with 16 entries across the #1883–#1889 cluster and is now empty:
+`sibling-paths-alias` (#1883, fixed by #1884), `external-self-alias` (#1887, fixed
+by #1893), `ts-aliased-import` (#1888, fixed by #1895), `kit-hooks-arrow-ts`
+(#1886, fixed by #1892), `kit-hooks-js` (#1886, fixed by #1892 for the
+arrow/function-expression form and a follow-up JSDoc-anchor fix for the plain
+`export function` form), `sibling-symlink` (#1900, fixed by #1907) and
+`boundary-elements` (#1889, fixed by #1906) have all been pruned.
 
-| Scenario | Entries | Diagnostics | Issue | Class |
-|---|---|---|---|---|
-| `boundary-elements` | 1 | 1 | #1889 | vendored `svelte-jsx-v4` shim predates `svelte:boundary` |
-
-### `boundary-elements` — #1889
-
-```
-boundary-elements|+ERROR src/Boundary.svelte:9 7006
-```
-
-The overlay unconditionally injects the vendored `svelte-jsx-v4.d.ts`, whose
-hand-enumerated `IntrinsicElements` snapshot predates `svelte:boundary`, so
-`onerror`'s callback parameter falls back to `any`. Official's `get_global_types`
-prefers `<sveltePath>/svelte-html.d.ts` instead — porting that is Layer 3 of
-#1897 and the wholesale fix for this class.
-
-The scenario also exercises `<search>`, the other element `svelte/elements` gained
-after the shim snapshot. It currently agrees on both sides and is therefore not in
-the ratchet — it is here as the drift canary for the next `svelte/elements`
-addition.
+Every scenario now agrees with official `svelte-check` diagnostic-for-diagnostic,
+so this is a **hard gate**: any divergence at all fails CI. The sections below
+document what each scenario is guarding, since a green scenario only earns its
+keep by turning red when the thing it covers regresses.
 
 ## Scenarios with no entries
 
@@ -80,8 +64,17 @@ Green scenarios are load-bearing, not filler — a regression turns them red:
 - **`sibling-symlink`** — both cross-package shapes: `src/barrel.svelte` through
   the package `exports` barrel (#782/#805) and `src/deep.svelte` through a bare
   deep specifier (#1900).
+- **`boundary-elements`** — #1889, fixed by #1906: the overlay follows
+  `get_global_types` and prefers the installed svelte's `svelte-html.d.ts` over
+  the vendored `svelte-jsx-v4.d.ts`, so element and attribute types track
+  `svelte/elements` instead of a frozen snapshot. Both arms
+  (`<svelte:boundary onerror>` and `<search>`) are the standing canary for the
+  next `svelte/elements` addition — a red here means the type environment has
+  drifted away from the user's Svelte version again.
 
 ## Burning an entry down
+
+Kept for the next time the baseline is non-empty (a new scenario lands red, say):
 
 1. Fix the underlying issue.
 2. `pnpm run test:svelte-check` — the run reports how many divergences

--- a/crates/rsvelte_check/src/svelte_check/overlay.rs
+++ b/crates/rsvelte_check/src/svelte_check/overlay.rs
@@ -1117,7 +1117,7 @@ fn build_overlay_tsconfig(
     if let Some(svelte_html) = &global_types.svelte_html {
         // Absolute: `files` resolves against the overlay dir, and the svelte
         // package sits outside it.
-        files_entries.push(svelte_html.to_string_lossy().replace('\\', "/"));
+        files_entries.push(tsconfig_absolute_path(svelte_html));
     }
     if has_companion_augmentation {
         files_entries.push(format!("./{COMPANION_AUGMENT_FILE}"));
@@ -2259,6 +2259,24 @@ fn lexical_relative_posix(from_dir: &Path, to_path: &Path) -> String {
     }
 }
 
+/// POSIX-style *absolute* path for a tsconfig entry. Everything else in the
+/// generated tsconfig goes through [`path_relative`], which sidesteps this by
+/// dropping `Component::Prefix` outright; an entry that has to stay absolute
+/// (the installed svelte's `svelte-html.d.ts`) must instead strip Windows'
+/// `\\?\` verbatim prefix, which `fs::canonicalize` adds and tsc/tsgo cannot
+/// resolve once the separators are flipped.
+fn tsconfig_absolute_path(path: &Path) -> String {
+    let slashed = path.to_string_lossy().replace('\\', "/");
+    // `\\?\UNC\server\share\…` denotes `\\server\share\…`.
+    if let Some(rest) = slashed.strip_prefix("//?/UNC/") {
+        return format!("//{rest}");
+    }
+    if let Some(rest) = slashed.strip_prefix("//?/") {
+        return rest.to_owned();
+    }
+    slashed
+}
+
 /// POSIX-style relative path from `from_dir` to `to_path` (so the
 /// generated tsconfig is consumable on every platform).
 fn path_relative(from_dir: &Path, to_path: &Path) -> String {
@@ -3393,6 +3411,31 @@ mod tests {
             "svelte-jsx-v4.d.ts must declare an IntrinsicElements entry for \
              'svelte:boundary' (onerror/failed/pending), not fall through to \
              the catch-all index signature"
+        );
+    }
+
+    #[test]
+    fn tsconfig_absolute_path_strips_the_windows_verbatim_prefix() {
+        // A string-level test so it runs on the CI runners we actually have:
+        // `Path::components` only recognises a Windows prefix on Windows.
+        assert_eq!(
+            tsconfig_absolute_path(Path::new(
+                r"\\?\C:\proj\node_modules\svelte\svelte-html.d.ts"
+            )),
+            "C:/proj/node_modules/svelte/svelte-html.d.ts",
+            "tsc/tsgo cannot resolve the `//?/` form `fs::canonicalize` produces"
+        );
+        assert_eq!(
+            tsconfig_absolute_path(Path::new(r"\\?\UNC\server\share\proj\svelte-html.d.ts")),
+            "//server/share/proj/svelte-html.d.ts"
+        );
+        assert_eq!(
+            tsconfig_absolute_path(Path::new(r"C:\proj\svelte-html.d.ts")),
+            "C:/proj/svelte-html.d.ts"
+        );
+        assert_eq!(
+            tsconfig_absolute_path(Path::new("/proj/node_modules/svelte/svelte-html.d.ts")),
+            "/proj/node_modules/svelte/svelte-html.d.ts"
         );
     }
 

--- a/crates/rsvelte_check/src/svelte_check/overlay.rs
+++ b/crates/rsvelte_check/src/svelte_check/overlay.rs
@@ -46,9 +46,90 @@ const SHIM_SVELTE_JSX_V4: &str = include_str!("shims/svelte-jsx-v4.d.ts");
 /// Filenames the shims are written under inside the cache dir. Names
 /// match upstream so diagnostics / `isSvelteShim`-style checks line up.
 const SHIM_FILES: &[(&str, &str)] = &[
-    ("svelte-shims-v4.d.ts", SHIM_SVELTE_SHIMS_V4),
-    ("svelte-jsx-v4.d.ts", SHIM_SVELTE_JSX_V4),
+    (SHIM_SHIMS_V4_NAME, SHIM_SVELTE_SHIMS_V4),
+    (SHIM_JSX_V4_NAME, SHIM_SVELTE_JSX_V4),
 ];
+
+const SHIM_SHIMS_V4_NAME: &str = "svelte-shims-v4.d.ts";
+const SHIM_JSX_V4_NAME: &str = "svelte-jsx-v4.d.ts";
+
+/// The `svelte` package file that supersedes the vendored JSX shim.
+const SVELTE_HTML_DTS: &str = "svelte-html.d.ts";
+
+/// The ambient `.d.ts` environment handed to the overlay program — the port
+/// of `get_global_types`
+/// (`submodules/language-tools/packages/svelte2tsx/src/helpers/files.ts`).
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct GlobalTypes {
+    /// Vendored shims (basenames from [`SHIM_FILES`]) to materialise into
+    /// the cache dir and list in the overlay tsconfig.
+    shims: Vec<&'static str>,
+    /// The installed `svelte` package's `svelte-html.d.ts`, when present.
+    svelte_html: Option<PathBuf>,
+}
+
+/// The installed `svelte` package, as `getPackageInfo('svelte', …)` in
+/// `language-server/src/importPackage.ts` resolves it.
+struct SveltePackage {
+    dir: PathBuf,
+    major: Option<u32>,
+}
+
+/// Port of `get_global_types`' file selection. Upstream prefers the
+/// project's own `<sveltePath>/svelte-html.d.ts` (Svelte 4+) and then omits
+/// `svelte-jsx-v4.d.ts`, because the vendored shim hand-enumerates
+/// `IntrinsicElements` while `svelte-html.d.ts` extends `SvelteHTMLElements`
+/// from the installed `svelte/elements` — so it tracks the user's Svelte
+/// version instead of freezing at the snapshot date (#1889).
+///
+/// Two upstream branches are deliberately not reproduced: the Svelte 3 shim
+/// pair (`svelte-shims.d.ts` / `svelte-jsx.d.ts`), which rsvelte does not
+/// vendor because it is a Svelte 5 compiler — Svelte 3 falls back to the v4
+/// pair; and `svelte-native-jsx.d.ts`, which only types the
+/// `svelteNative.JSX` namespace rsvelte never emits (the overlay always runs
+/// svelte2tsx with `Svelte2TsxNamespace::Html`), matching upstream
+/// svelte-check's own commented-out entry in `incremental.ts`.
+fn select_global_types(workspace: &Path) -> GlobalTypes {
+    // The resolved path is written into the overlay tsconfig, which lives in
+    // a different directory than the CLI's cwd a relative `--workspace`
+    // resolves against.
+    let root = fs::canonicalize(workspace).unwrap_or_else(|_| workspace.to_path_buf());
+    let svelte_html = resolve_svelte_package(&root).and_then(|pkg| {
+        if pkg.major == Some(3) {
+            return None;
+        }
+        let path = pkg.dir.join(SVELTE_HTML_DTS);
+        path.is_file().then_some(path)
+    });
+    let mut shims = vec![SHIM_SHIMS_V4_NAME];
+    if svelte_html.is_none() {
+        shims.push(SHIM_JSX_V4_NAME);
+    }
+    GlobalTypes { shims, svelte_html }
+}
+
+/// Walk `node_modules` upwards from `from` for the `svelte` package, the
+/// Rust equivalent of `require.resolve('svelte/package.json', { paths })`.
+fn resolve_svelte_package(from: &Path) -> Option<SveltePackage> {
+    let mut cursor = Some(from);
+    while let Some(dir) = cursor {
+        let pkg_dir = dir.join("node_modules").join("svelte");
+        let manifest = pkg_dir.join("package.json");
+        if manifest.is_file() {
+            let major = fs::read_to_string(&manifest)
+                .ok()
+                .and_then(|s| serde_json::from_str::<serde_json::Value>(&s).ok())
+                .and_then(|v| v.get("version")?.as_str().map(str::to_owned))
+                .and_then(|v| v.split('.').next()?.parse().ok());
+            return Some(SveltePackage {
+                dir: pkg_dir,
+                major,
+            });
+        }
+        cursor = dir.parent();
+    }
+    None
+}
 
 /// One emitted `.svelte` → `.tsx` shadow.
 #[derive(Debug, Clone)]
@@ -355,11 +436,19 @@ pub fn materialize_overlay_with(
     }
     let has_augments = write_companion_augmentation(&cache_dir, &augments)?;
 
-    // Materialise the svelte2tsx shims into the cache dir so the overlay
-    // tsconfig can reference them by a stable relative path regardless of
-    // what's installed in the consumer's node_modules.
+    // Materialise the selected svelte2tsx shims into the cache dir so the
+    // overlay tsconfig can reference them by a stable relative path — a
+    // standalone rsvelte install has no `node_modules/svelte2tsx` to read.
+    let global_types = select_global_types(workspace);
     for (name, contents) in SHIM_FILES {
-        fs::write(cache_dir.join(name), contents)?;
+        let path = cache_dir.join(name);
+        if global_types.shims.contains(name) {
+            fs::write(path, contents)?;
+        } else {
+            // A previous run's copy would otherwise linger in the cache dir
+            // and be picked up by an inherited `include` pattern.
+            let _ = fs::remove_file(path);
+        }
     }
 
     // A PLAIN `.ts`/`.js`/`.svelte.ts` source file that imports a `.svelte`
@@ -388,6 +477,7 @@ pub fn materialize_overlay_with(
         incremental,
         has_augments,
         &alias_path_overrides,
+        &global_types,
     );
     fs::write(&overlay_tsconfig, tsconfig_json)?;
 
@@ -854,6 +944,7 @@ fn build_overlay_tsconfig(
     incremental: bool,
     has_companion_augmentation: bool,
     alias_path_overrides: &[(String, PathBuf)],
+    global_types: &GlobalTypes,
 ) -> String {
     let mut obj: BTreeMap<&str, serde_json::Value> = BTreeMap::new();
     if let Some(orig) = original {
@@ -1005,22 +1096,29 @@ fn build_overlay_tsconfig(
         );
     }
 
-    // Reference the svelte2tsx shim `.d.ts` files we materialised into the
-    // cache dir (see `SHIM_FILES`). Without these, tsgo / tsc trips on
-    // every reference to `__sveltets_2_with_any_event` / `svelteHTML` etc
-    // that svelte2tsx emits into the `.tsx` shadow. Equivalent to
-    // `resolveSvelte2tsxShims` in the JS reference, except we embed the
-    // shims rather than resolving them from `node_modules/svelte2tsx`
-    // (which a standalone rsvelte install has no reason to provide).
+    // Reference the ambient `.d.ts` environment `select_global_types` chose
+    // (the port of `get_global_types`): the vendored shims we materialised
+    // into the cache dir, plus the installed svelte's `svelte-html.d.ts`
+    // when it exists. Without these, tsgo / tsc trips on every reference to
+    // `__sveltets_2_with_any_event` / `svelteHTML` etc that svelte2tsx emits
+    // into the `.tsx` shadow. We embed the shims rather than resolving them
+    // from `node_modules/svelte2tsx` (which a standalone rsvelte install has
+    // no reason to provide).
     //
     // We always set `files` so any `.svelte` entries listed in the base
     // tsconfig (TS rejects arbitrary extensions in `files` even with
     // `allowArbitraryExtensions` → TS6054) get overridden out. Non-
     // `.svelte` entries from the user's `files` are forwarded.
-    let mut files_entries: Vec<String> = SHIM_FILES
+    let mut files_entries: Vec<String> = global_types
+        .shims
         .iter()
-        .map(|(name, _)| format!("./{name}"))
+        .map(|name| format!("./{name}"))
         .collect();
+    if let Some(svelte_html) = &global_types.svelte_html {
+        // Absolute: `files` resolves against the overlay dir, and the svelte
+        // package sits outside it.
+        files_entries.push(svelte_html.to_string_lossy().replace('\\', "/"));
+    }
     if has_companion_augmentation {
         files_entries.push(format!("./{COMPANION_AUGMENT_FILE}"));
     }
@@ -3020,6 +3118,31 @@ mod tests {
         let _ = fs::remove_dir_all(&tmp);
     }
 
+    /// `select_global_types` canonicalises its root, so expectations have to
+    /// go through the same normalisation (`/var` -> `/private/var` on macOS).
+    fn expected_svelte_html(root: &Path) -> Option<PathBuf> {
+        Some(
+            fs::canonicalize(root)
+                .unwrap()
+                .join("node_modules/svelte/svelte-html.d.ts"),
+        )
+    }
+
+    /// Lay out `<root>/node_modules/svelte` with the given version, and
+    /// `svelte-html.d.ts` when asked for.
+    fn fake_svelte_package(root: &Path, version: &str, with_svelte_html: bool) {
+        let pkg = root.join("node_modules/svelte");
+        fs::create_dir_all(&pkg).unwrap();
+        fs::write(
+            pkg.join("package.json"),
+            format!("{{ \"name\": \"svelte\", \"version\": \"{version}\" }}"),
+        )
+        .unwrap();
+        if with_svelte_html {
+            fs::write(pkg.join("svelte-html.d.ts"), "declare global {}\n").unwrap();
+        }
+    }
+
     #[test]
     fn relative_tsconfig_path_still_bridges_a_node_modules_sibling_package() {
         // With a relative `--tsconfig`, oxc_resolver's tsconfig discovery
@@ -3271,5 +3394,86 @@ mod tests {
              'svelte:boundary' (onerror/failed/pending), not fall through to \
              the catch-all index signature"
         );
+    }
+
+    #[test]
+    fn global_types_prefer_project_svelte_html_over_the_vendored_jsx_shim() {
+        // #1889: the vendored shim's hand-enumerated `IntrinsicElements`
+        // freezes at its snapshot date, so every tag `svelte/elements` gained
+        // since (`svelte:boundary`, `search`, …) falls through to the
+        // catch-all index signature and its props become bare `any`.
+        let tmp = std::env::temp_dir().join(format!("svc_gt_html_{}", std::process::id()));
+        let _ = fs::remove_dir_all(&tmp);
+        fake_svelte_package(&tmp, "5.56.8", true);
+
+        let selected = select_global_types(&tmp);
+        assert_eq!(selected.shims, vec![SHIM_SHIMS_V4_NAME]);
+        assert_eq!(selected.svelte_html, expected_svelte_html(&tmp));
+
+        let _ = fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn global_types_fall_back_to_the_vendored_jsx_shim_without_svelte_html() {
+        let tmp = std::env::temp_dir().join(format!("svc_gt_nohtml_{}", std::process::id()));
+        let _ = fs::remove_dir_all(&tmp);
+        fake_svelte_package(&tmp, "5.56.8", false);
+
+        let selected = select_global_types(&tmp);
+        assert_eq!(
+            selected.shims,
+            vec![SHIM_SHIMS_V4_NAME, SHIM_JSX_V4_NAME],
+            "without a project `svelte-html.d.ts` the vendored JSX shim is the \
+             only source of `svelteHTML.IntrinsicElements`"
+        );
+        assert_eq!(selected.svelte_html, None);
+
+        let _ = fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn global_types_ignore_svelte_html_on_svelte_3() {
+        let tmp = std::env::temp_dir().join(format!("svc_gt_v3_{}", std::process::id()));
+        let _ = fs::remove_dir_all(&tmp);
+        // Upstream skips the lookup entirely for Svelte 3, so even a stray
+        // `svelte-html.d.ts` must not displace the JSX shim.
+        fake_svelte_package(&tmp, "3.59.2", true);
+
+        let selected = select_global_types(&tmp);
+        assert_eq!(selected.shims, vec![SHIM_SHIMS_V4_NAME, SHIM_JSX_V4_NAME]);
+        assert_eq!(selected.svelte_html, None);
+
+        let _ = fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn global_types_fall_back_when_svelte_is_not_installed() {
+        let tmp = std::env::temp_dir().join(format!("svc_gt_nosvelte_{}", std::process::id()));
+        let _ = fs::remove_dir_all(&tmp);
+        fs::create_dir_all(tmp.join("src")).unwrap();
+
+        let selected = select_global_types(&tmp.join("src"));
+        assert_eq!(selected.shims, vec![SHIM_SHIMS_V4_NAME, SHIM_JSX_V4_NAME]);
+        assert_eq!(selected.svelte_html, None);
+
+        let _ = fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn global_types_resolve_svelte_from_a_parent_node_modules() {
+        let tmp = std::env::temp_dir().join(format!("svc_gt_hoisted_{}", std::process::id()));
+        let _ = fs::remove_dir_all(&tmp);
+        fake_svelte_package(&tmp, "5.56.8", true);
+        let nested = tmp.join("packages/app");
+        fs::create_dir_all(&nested).unwrap();
+
+        let selected = select_global_types(&nested);
+        assert_eq!(
+            selected.svelte_html,
+            expected_svelte_html(&tmp),
+            "a hoisted monorepo install must still be found by walking up"
+        );
+
+        let _ = fs::remove_dir_all(&tmp);
     }
 }

--- a/crates/rsvelte_check/tests/svelte_check_shim_drift.rs
+++ b/crates/rsvelte_check/tests/svelte_check_shim_drift.rs
@@ -1,0 +1,112 @@
+//! Drift guard for the vendored svelte2tsx shim declarations.
+//!
+//! `crates/rsvelte_check/src/svelte_check/shims/` embeds copies of
+//! `submodules/language-tools/packages/svelte2tsx/*.d.ts` because rsvelte
+//! ships a standalone binary with no `svelte2tsx` in the consumer's
+//! `node_modules`. A copy is only as good as its freshness: #1889 was a frozen
+//! snapshot silently ageing past `svelte/elements`. This test makes a
+//! language-tools bump — or an undeclared hand-edit of a vendored file —
+//! surface as a failure instead.
+//!
+//! Deliberate local additions are declared in `LOCAL_ADDITIONS` and subtracted
+//! before the comparison, so they are reviewable in one place instead of
+//! invisible inside a 400-line `.d.ts`. Everything else must be byte-identical.
+//!
+//! Skipped when the submodule is not checked out, so the suite stays runnable
+//! on a fresh clone. Under `CI` the submodule *is* checked out by the job that
+//! runs this test (`.github/workflows/ci.yml`'s `test` shards init
+//! `submodules/language-tools`), so a missing file there is a misconfigured
+//! job, not an unavailable assertion.
+
+use std::path::PathBuf;
+
+/// Every vendored file, relative to its own root.
+const VENDORED: &[&str] = &["svelte-shims-v4.d.ts", "svelte-jsx-v4.d.ts"];
+
+/// Lines rsvelte adds on top of the upstream copy, per file. Each one needs a
+/// reason to exist here rather than upstream.
+///
+/// * `svelte-jsx-v4.d.ts` — `'svelte:boundary'` (#1896). Upstream's
+///   `IntrinsicElements` snapshot predates the element. It only matters on the
+///   fallback branch of `select_global_types`, where no project
+///   `svelte-html.d.ts` was found.
+const LOCAL_ADDITIONS: &[(&str, &[&str])] = &[(
+    "svelte-jsx-v4.d.ts",
+    &["    'svelte:boundary': HTMLProps<'svelte:boundary', HTMLAttributes>;"],
+)];
+
+fn crate_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}
+
+fn upstream_root() -> PathBuf {
+    crate_root()
+        .join("../..")
+        .join("submodules/language-tools/packages/svelte2tsx")
+}
+
+fn local_additions(name: &str) -> &'static [&'static str] {
+    LOCAL_ADDITIONS
+        .iter()
+        .find(|(file, _)| *file == name)
+        .map(|(_, lines)| *lines)
+        .unwrap_or(&[])
+}
+
+#[test]
+fn vendored_shims_match_the_language_tools_submodule() {
+    let upstream = upstream_root();
+    if !upstream.join(VENDORED[0]).is_file() {
+        assert!(
+            std::env::var_os("CI").is_none(),
+            "submodules/language-tools is not checked out while running under \
+             CI — the vendored-shim drift assertions would be silently \
+             skipped. Run `git submodule update --init \
+             submodules/language-tools`."
+        );
+        eprintln!("Skipping: submodules/language-tools not initialised");
+        return;
+    }
+
+    let vendored_root = crate_root().join("src/svelte_check/shims");
+    for name in VENDORED {
+        let ours = vendored_root.join(name);
+        let theirs = upstream.join(name);
+        let ours_text = std::fs::read_to_string(&ours)
+            .unwrap_or_else(|e| panic!("cannot read vendored {}: {e}", ours.display()));
+        let theirs_text = std::fs::read_to_string(&theirs)
+            .unwrap_or_else(|e| panic!("cannot read upstream {}: {e}", theirs.display()));
+
+        let declared = local_additions(name);
+        let mut pending: Vec<&str> = declared.to_vec();
+        let stripped: Vec<&str> = ours_text
+            .lines()
+            .filter(|line| {
+                // Drop each declared addition once, so a duplicate still fails.
+                match pending.iter().position(|added| added == line) {
+                    Some(i) => {
+                        pending.remove(i);
+                        false
+                    }
+                    None => true,
+                }
+            })
+            .collect();
+        assert!(
+            pending.is_empty(),
+            "declared local addition(s) to `{name}` are no longer present: \
+             {pending:?}. Remove them from LOCAL_ADDITIONS if upstream now \
+             ships them."
+        );
+
+        assert_eq!(
+            stripped,
+            theirs_text.lines().collect::<Vec<_>>(),
+            "vendored `{name}` has drifted from \
+             submodules/language-tools/packages/svelte2tsx/{name} beyond its \
+             declared local additions.\nRe-copy the upstream file, or declare \
+             the delta in LOCAL_ADDITIONS with a reason. An undeclared patch \
+             ages out again on the next `svelte/elements` addition (#1889)."
+        );
+    }
+}


### PR DESCRIPTION
Layer 3 of #1897 — *type-environment sync*. #1889 was closed by #1896, which added the
one missing `'svelte:boundary'` entry to the vendored shim. That fixed the reported
symptom; this PR fixes the class it belonged to.

## Problem

rsvelte's generated `.tsx` for `<svelte:boundary onerror={(e) => …}>` is byte-identical
to official svelte2tsx's — the divergence was never in the conversion, it was in *which
`.d.ts` files enter the program*.

The overlay injected the vendored `svelte-jsx-v4.d.ts` unconditionally. Its
`svelteHTML.IntrinsicElements` is a **hand-enumerated snapshot**: every element and
attribute `svelte/elements` has gained since the file was copied falls through to the
interface's `[name: string]: { [name: string]: any }` catch-all, and its props are then
contextually typed as bare `any`. `svelte:boundary` was one instance; `<search>` is
another; the next `svelte/elements` addition would have been the third.

Measured on `6893718b` (i.e. *with* #1896's entry already in the shim), the
`boundary-elements` scenario was still diverging from official `svelte-check`:

```
boundary-elements|+ERROR src/Boundary.svelte:9 7006
```

## Reference implementation

Official's shipped path is `get_global_types`
(`submodules/language-tools/packages/svelte2tsx/src/helpers/files.ts:14-26`), reached from
`language-server`'s `service.ts` and `typescript-go/features/DiagnosticsProvider.ts`:

```ts
let svelteHtmlPath = isSvelte3 ? undefined : join(sveltePath, 'svelte-html.d.ts');
svelteHtmlPath = svelteHtmlPath && tsSystem.fileExists(svelteHtmlPath) ? svelteHtmlPath : undefined;
if (isSvelte3) { … } else {
    svelteTsxFiles = ['./svelte-shims-v4.d.ts', './svelte-native-jsx.d.ts'];
    if (!svelteHtmlPath) svelteTsxFiles.push('./svelte-jsx-v4.d.ts');
}
…
if (svelteHtmlPath) svelteTsxFiles.push(…svelteHtmlPath);
```

`<sveltePath>/svelte-html.d.ts` declares `interface IntrinsicElements extends
svelteElements.SvelteHTMLElements`, so it follows whatever `svelte/elements` the user has
installed instead of freezing at a copy date.

rsvelte had ported *`svelte-check`'s* `resolveSvelte2tsxShims` instead, which never
consults `svelte-html.d.ts` — hence the frozen environment.

## Fix

`select_global_types` / `resolve_svelte_package` in `overlay.rs`:

| official | rsvelte |
|---|---|
| `getPackageInfo('svelte', workspace).path` (`require.resolve('svelte/package.json', { paths })`) | `resolve_svelte_package` — walks `node_modules` upwards from the workspace, reads `version` from `package.json` |
| `isSvelte3 = version.major === 3` | `pkg.major == Some(3)` |
| `tsSystem.fileExists(join(sveltePath, 'svelte-html.d.ts'))` | `path.is_file()` |
| `svelteTsxFiles = ['./svelte-shims-v4.d.ts', …]` | `svelte-shims-v4.d.ts` always materialised |
| `if (!svelteHtmlPath) push('./svelte-jsx-v4.d.ts')` | vendored JSX shim written + listed only on the fallback branch (and removed from the cache dir otherwise, so a stale copy from an earlier run cannot leak back in) |
| `if (svelteHtmlPath) push(svelteHtmlPath)` | absolute entry appended to the overlay tsconfig's `files` |

The workspace is canonicalised before the lookup: `rsvelte-check --workspace .` would
otherwise emit a cwd-relative path into an overlay tsconfig that lives in
`.svelte-check/`.

Two upstream branches are deliberately not reproduced, documented at the function:

* the **Svelte 3** shim pair (`svelte-shims.d.ts` / `svelte-jsx.d.ts`) — rsvelte is a
  Svelte 5 compiler and vendors neither, so Svelte 3 takes the v4 fallback;
* **`svelte-native-jsx.d.ts`** — it only types the `svelteNative.JSX` namespace, which the
  overlay never emits (svelte2tsx always runs with `Svelte2TsxNamespace::Html`). Upstream
  `svelte-check`'s own `incremental.ts` comments the same entry out.

When `svelte` cannot be resolved from the workspace at all, the previous vendored-shim
behaviour is kept verbatim — including #1896's `'svelte:boundary'` entry, which is
**left in place** as that fallback's only source of the element's typing.

## Drift test

`crates/rsvelte_check/tests/svelte_check_shim_drift.rs` asserts every file under
`crates/rsvelte_check/src/svelte_check/shims/` equals its
`submodules/language-tools/packages/svelte2tsx/` counterpart, modulo a `LOCAL_ADDITIONS`
table that declares each deliberate local line (today: #1896's `'svelte:boundary'`) with
the reason it lives here rather than upstream. Anything else — a language-tools bump, an
undeclared hand-patch, or a declared addition that upstream has since absorbed — fails.
This is the missing guard behind #1889: the snapshot aged silently for want of it.

The test skips when the submodule is not checked out and **hard-fails under `CI`**, the
same convention as `svelte_check_golden.rs`. `.github/workflows/ci.yml`'s `test` shards
init `submodules/language-tools`, and `scripts/ci/run-test-shard.sh` picks new `tests/*.rs`
targets up from `cargo metadata` automatically.

## Verification

* `pnpm run test:svelte-check` (release binary, pinned oracle):
  `divergences: 3 current, 15 known (0 new, 12 fixed)` — **0 new**, and
  `boundary-elements` goes `oracle 0, rsvelte 1` → `oracle 0, rsvelte 0`.
  `compatibility/check-known-failures.{json,md}` lose exactly that one entry; the other
  scenarios' entries are untouched. `basic` (positive control, intentional `TS2322` +
  `state_referenced_locally`), `no-tsconfig` and the `kit-hooks-*` matrix all stay green —
  a mid-work regression that dropped `basic`'s `TS2322` was caught by the gate and fixed
  before this push.
* `cargo test -p rsvelte_check` — all green, including 5 new `select_global_types` unit
  tests (svelte-html present / absent / Svelte 3 / svelte not installed / hoisted
  monorepo) and the drift test. Negative-checked: appending a line to a vendored shim
  makes the drift test fail with the expected message.
* `svelte_check_golden.rs`'s TypeScript assertions still pass with
  `submodules/language-tools` installed — its fixtures resolve Svelte 4, which now takes
  the `svelte-html.d.ts` branch.
* `cargo fmt --check` and `cargo clippy -p rsvelte_check --all-targets -- -D warnings` clean.

Part of #1897 (Layer 3 — type-environment sync). Wholesale fix for the class #1889
reported and #1896 patched case-by-case.
