### PR TITLE
fix(svelte-check): resolve bare deep .svelte specifiers from a symlinked sibling (#1900)

### DIFF
--- a/.changeset/quiet-shadows-resolve.md
+++ b/.changeset/quiet-shadows-resolve.md
@@ -1,0 +1,19 @@
+---
+"@rsvelte/svelte-check": patch
+---
+
+Fix a bare package specifier deep-importing a `.svelte` file from a
+`node_modules`-symlinked sibling (`import X from 'libs/components/x.svelte'`)
+resolving to the ambient `declare module '*.svelte'` fallback, so the
+component's `<script module>` named exports were reported missing.
+
+`rootDirs` only bridges relative specifiers, so a bare one has to be rewritten
+to point at the sibling's shadow directly. The rewrite resolved the specifier
+from the importing file's directory, which `--workspace .` — the documented CLI
+usage, and what the overlay walks with — leaves relative; a relative resolution
+base has no parent to climb, so the resolver's `node_modules` walk-up never
+reached the sibling's symlink and nothing was rewritten. A `paths`-aliased
+specifier was unaffected because it resolves through the tsconfig's own
+absolute base.
+
+Fixes #1900.

--- a/compatibility/check-known-failures.json
+++ b/compatibility/check-known-failures.json
@@ -1,4 +1,3 @@
 [
-	"boundary-elements|+ERROR src/Boundary.svelte:9 7006",
-	"sibling-symlink|+ERROR src/deep.svelte:1 2614"
+	"boundary-elements|+ERROR src/Boundary.svelte:9 7006"
 ]

--- a/compatibility/check-known-failures.md
+++ b/compatibility/check-known-failures.md
@@ -18,33 +18,19 @@ positions back through its own source map and TypeScript wording moves between
 patch releases, so keying on them would make the ratchet churn without telling
 anyone anything. See the header of `check-verify.mjs`.
 
-## Current baseline: 2 entries / 2 surplus diagnostics (all FP, 0 FN)
+## Current baseline: 1 entry / 1 surplus diagnostic (all FP, 0 FN)
 
 The gate landed with 16 entries across the #1883–#1889 cluster. `sibling-paths-alias`
 (#1883, fixed by #1884), `external-self-alias` (#1887, fixed by #1893),
 `ts-aliased-import` (#1888, fixed by #1895), `kit-hooks-arrow-ts` (#1886, fixed by
-#1892) and `kit-hooks-js` (#1886, fixed by #1892 for the arrow/function-expression
-form and a follow-up JSDoc-anchor fix for the plain `export function` form) are
-now all fully green and have been pruned. What remains:
+#1892), `kit-hooks-js` (#1886, fixed by #1892 for the arrow/function-expression
+form and a follow-up JSDoc-anchor fix for the plain `export function` form) and
+`sibling-symlink` (#1900, fixed by #1907) are now all fully green and have been
+pruned. What remains:
 
 | Scenario | Entries | Diagnostics | Issue | Class |
 |---|---|---|---|---|
-| `sibling-symlink` | 1 | 1 | #1883 (same class) | bare-specifier deep `.svelte` import through a `node_modules` symlink |
 | `boundary-elements` | 1 | 1 | #1889 | vendored `svelte-jsx-v4` shim predates `svelte:boundary` |
-
-### `sibling-symlink` — same class as #1883, different trigger
-
-```
-sibling-symlink|+ERROR src/deep.svelte:1 2614
-```
-
-Found while building this gate, not previously reported. The sibling *is*
-discovered here (there is a `node_modules/libs` symlink) and a shadow *is*
-emitted with a `rootDirs` bridge — but `rootDirs` only applies to **relative**
-specifiers, and `libs/components/survey-options.svelte` is a bare package
-specifier, so the bridge never fires. The barrel arm of the same scenario
-(`src/barrel.svelte`, importing through the package `exports` barrel — the shape
-#782/#805 fixed) is green and must stay green.
 
 ### `boundary-elements` — #1889
 
@@ -91,8 +77,9 @@ Green scenarios are load-bearing, not filler — a regression turns them red:
   | `kit-hooks-satisfies-ts` | `satisfies` / explicit annotation / `sequence()` | green — nothing should be augmented; guards the #1886 fix against over-augmenting |
   | `kit-hooks-js` | plain JS under `checkJs`, function + arrow | green — arrow/function-expression forms fixed by #1892, plain `export function` form fixed by anchoring its JSDoc `@type` tag at the exported statement's start instead of the `function` keyword (TypeScript ignores the tag otherwise) |
   | `kit-routes-js` | `+page.js` `load`/`entries`, `+server.js` method handlers, `params/*.js` `match` under `checkJs` | green — regression guard for the same anchor bug across the other JSDoc-emitting paths in `kit_file.rs` |
-- **`sibling-symlink` / `src/barrel.svelte`** — the cross-package shape #782/#805
-  fixed.
+- **`sibling-symlink`** — both cross-package shapes: `src/barrel.svelte` through
+  the package `exports` barrel (#782/#805) and `src/deep.svelte` through a bare
+  deep specifier (#1900).
 
 ## Burning an entry down
 

--- a/crates/rsvelte_check/src/svelte_check/overlay.rs
+++ b/crates/rsvelte_check/src/svelte_check/overlay.rs
@@ -1887,8 +1887,9 @@ fn build_svelte_import_resolver(tsconfig: Option<&Path>) -> Option<oxc_resolver:
 /// sibling package discovered by [`discover_external_svelte_packages`], via
 /// either a `node_modules` symlink or a `paths` alias) is rewritten to that
 /// package's mirror shadow instead — `rootDirs` cannot bridge a non-relative
-/// alias (#782), so the specifier itself has to point at the shadow. Bare
-/// packages and anything resolving outside both are left untouched.
+/// alias (#782), so the specifier itself has to point at the shadow. A bare
+/// package specifier deep-importing a `.svelte` file from such a package is
+/// rewritten the same way; anything resolving outside both is left untouched.
 ///
 /// `confine_to` restricts what counts as a valid target: when emitting an
 /// external package's own shadows the alias was resolved with a `paths` map
@@ -1907,6 +1908,11 @@ fn rewrite_aliased_svelte_imports(
     let (Some(source_dir), Some(generated_dir)) = (abs_source.parent(), tsx_path.parent()) else {
         return tsx.to_string();
     };
+    // `--workspace .` makes every walked source path relative, and a relative
+    // resolution base has no parent to climb, so oxc_resolver's `node_modules`
+    // walk-up never leaves the workspace and every bare specifier fails.
+    let source_dir = absolutize(source_dir);
+    let source_dir = source_dir.as_path();
     // oxc_resolver returns canonicalised paths (symlinks resolved), so compare
     // against a canonicalised workspace — otherwise a symlinked root (e.g.
     // macOS `/var` → `/private/var`) makes `strip_prefix` spuriously fail and

--- a/crates/rsvelte_check/tests/svelte_check_cross_package.rs
+++ b/crates/rsvelte_check/tests/svelte_check_cross_package.rs
@@ -24,6 +24,12 @@ use std::path::{Path, PathBuf};
 
 use rsvelte_check::{RunOptions, run};
 
+/// The current directory is process-wide while tests run in parallel, so every
+/// test that has to exercise a CLI-relative path takes this first. The other
+/// tests here drive `run` with an absolute workspace and tsconfig, which never
+/// consults the CWD.
+static CWD_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
 fn target_dir(name: &str) -> PathBuf {
     let base = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .join("../../target")
@@ -201,6 +207,73 @@ fn external_package_self_referential_alias_import_is_rewritten_to_its_own_shadow
     assert!(
         tsx_code.contains("input.svelte.tsx"),
         "rewritten specifier should still point at Input's own shadow:\n{tsx_code}"
+    );
+}
+
+/// A bare package specifier deep-importing a `.svelte` file from a symlinked
+/// sibling (`import X from 'libs/components/x.svelte'`) has to be rewritten to
+/// the mirror shadow: `rootDirs` only bridges relative specifiers. The CLI is
+/// documented as `--workspace .`, which makes every walked source path
+/// relative — and a relative resolution base has no parent to climb, so the
+/// resolver's `node_modules` walk-up never reaches the symlink.
+#[test]
+fn bare_deep_specifier_is_rewritten_under_a_relative_workspace() {
+    let root = target_dir("_xpkg1900");
+
+    let libs = root.join("pkg-libs");
+    fs::create_dir_all(libs.join("src/components")).unwrap();
+    fs::write(
+        libs.join("package.json"),
+        r#"{ "name": "libs", "version": "0.0.0", "type": "module", "exports": { "./components/*": "./src/components/*" } }"#,
+    )
+    .unwrap();
+    fs::write(
+        libs.join("src/components/survey-options.svelte"),
+        "<script module lang=\"ts\">export type WithOther<T extends string> = T | `OTHER: ${string}`;</script>\n<script lang=\"ts\">let { id }: { id: string } = $props();</script>\n<div>{id}</div>\n",
+    )
+    .unwrap();
+
+    let a = root.join("pkg-a");
+    fs::create_dir_all(a.join("src")).unwrap();
+    fs::create_dir_all(a.join("node_modules")).unwrap();
+    fs::write(
+        a.join("package.json"),
+        r#"{ "name": "pkg-a", "version": "0.0.0", "type": "module" }"#,
+    )
+    .unwrap();
+    fs::write(
+        a.join("tsconfig.json"),
+        r#"{ "compilerOptions": { "moduleResolution": "bundler" }, "include": ["src/**/*.svelte"] }"#,
+    )
+    .unwrap();
+    fs::write(
+        a.join("src/deep.svelte"),
+        "<script lang=\"ts\">import SurveyOptions, { type WithOther } from 'libs/components/survey-options.svelte';\nconst answer: WithOther<'a'> = 'OTHER: c';</script>\n<SurveyOptions id={answer} />\n",
+    )
+    .unwrap();
+    symlink(Path::new("../../pkg-libs"), a.join("node_modules/libs")).unwrap();
+
+    let _cwd_guard = CWD_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let cwd = std::env::current_dir().unwrap();
+    std::env::set_current_dir(&a).unwrap();
+    let result = run(&RunOptions {
+        workspace: PathBuf::from("."),
+        emit_overlay: true,
+        tsconfig: Some(PathBuf::from("./tsconfig.json")),
+        ..RunOptions::default()
+    });
+    std::env::set_current_dir(&cwd).unwrap();
+
+    result.overlay.expect("overlay should be materialised");
+    // `emit_dir` is relative to the (now restored) CWD, so re-anchor on `a`.
+    let deep_tsx = fs::read_to_string(a.join(".svelte-check/svelte/src/deep.svelte.tsx")).unwrap();
+    assert!(
+        !deep_tsx.contains("'libs/components/survey-options.svelte'"),
+        "bare deep specifier was not rewritten:\n{deep_tsx}"
+    );
+    assert!(
+        deep_tsx.contains("ext/0/src/components/survey-options.svelte.tsx"),
+        "bare deep specifier should point at the sibling's mirror shadow:\n{deep_tsx}"
     );
 }
 


### PR DESCRIPTION
## What

A **bare package specifier** deep-importing a `.svelte` file from a
`node_modules`-symlinked sibling package (`import X from 'libs/components/x.svelte'`)
resolved to the ambient `declare module '*.svelte'` fallback, so the component's
`<script module>` named exports were reported missing (`TS2614`).

The sibling *was* discovered, its shadows *were* emitted, and the `rootDirs`
bridge *was* written — but `rootDirs` only applies to **relative** specifiers, so
a bare one has to be rewritten to point at the mirror shadow directly.
`rewrite_aliased_svelte_imports` already does that, and it already accepts bare
specifiers; it just never resolved one.

## Root cause

The rewrite resolves each specifier from the importing file's directory. The CLI
is documented as `--workspace .` (and that is exactly how the parity gate and
most users invoke it), which makes every path the overlay walker produces
relative. A relative resolution base has no parent to climb, so `oxc_resolver`'s
`node_modules` walk-up never left the workspace and never reached
`pkg-a/node_modules/libs`.

A `paths`-aliased specifier was unaffected, which is why this only ever showed up
for bare specifiers: an alias resolves through the tsconfig's own absolute
`paths` base, never through the walk-up.

Fix: absolutise the resolution base before handing it to the resolver.

## Diagnostics, before / after

`pnpm run test:svelte-check` (official `svelte-check` as the oracle), measured on
this branch's base `6b52469d` before and after the fix:

| Scenario | Oracle | rsvelte before | rsvelte after |
|---|---|---|---|
| `sibling-symlink` (`barrel` + `deep` arms) | 0 | 1 (`TS2614` on `src/deep.svelte`) | **0** |
| `sibling-paths-alias` | 0 | 0 | 0 |
| `external-self-alias` | 0 | 0 | 0 |
| `ts-aliased-import` | 0 | 0 | 0 |
| `basic` | 2 | 2 | 2 |
| every other scenario | 0 | 0 | 0 |

Gate verdict after the fix — with the sibling PRs in the #1883–#1889 cluster all
landed, this was the last scenario still diverging, so the corpus is now clean:

```
[check-verify] divergences: 0 current, 1 known (0 new, 1 fixed)
[check-verify] ✅ no new divergences
```

## Ratchet

`compatibility/check-known-failures.json` shrinks by exactly one entry
(`sibling-symlink|+ERROR src/deep.svelte:1 2614`) — 2 → 1 — with its
justification section removed from the paired `.md` and the baseline count
updated. The one remaining entry (`boundary-elements`, #1889) is untouched.

## Scope note

This PR was originally scoped to #1883 / #1887 / #1888 / #1900. The first three
were fixed and merged in parallel (#1884, #1893, #1895) and measure green on
`main`; only #1900 remained, so this PR is just that fix.

## Tests

- `crates/rsvelte_check/tests/svelte_check_cross_package.rs::bare_deep_specifier_is_rewritten_under_a_relative_workspace`
  — builds the symlinked-sibling workspace, runs the overlay with
  `workspace: "."` (the shape that reproduces it), and asserts the shadow's
  specifier points at `ext/0/...`. Verified to fail without the fix. Its
  process-wide `chdir` is serialised behind a `CWD_LOCK`, mirroring the overlay
  unit tests.
- `cargo test -p rsvelte_check` green (91 unit + all integration), re-run 5× in
  parallel mode with no flakes.

Closes #1900

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JFL7CmMS1hd9sJA3yU4GTC
