### PR TITLE
fix(svelte-check): type SvelteKit hooks written as plain JS export function

### DIFF
--- a/.changeset/quiet-hooks-jsdoc.md
+++ b/.changeset/quiet-hooks-jsdoc.md
@@ -1,0 +1,22 @@
+---
+"@rsvelte/svelte-check": patch
+---
+
+Fix a residual false `implicit any` on SvelteKit hooks written as
+`export function handle(...) {...}` in plain JS/JSDoc (not TypeScript):
+the `/** @type {Handle} */` annotation was inserted between `export` and
+`function`, which TypeScript silently ignores. A JSDoc `@type` tag only
+re-types a `function` declaration when it leads the *entire* exported
+statement — matching the official implementation, whose
+`ts.FunctionDeclaration.getStart()` includes the `export` modifier in the
+node's own span. Every binding element of the hook's destructured
+parameter stayed implicit `any` despite the annotation being present in
+the overlay.
+
+The `const` + arrow-function/function-expression form (`export const
+handle = (...) => {...}`, fixed by #1892) already anchored the JSDoc
+annotation correctly and is unaffected.
+
+This completes #1886's fix for the JSDoc/JS path (closed by #1892, but
+the `kit-hooks-js` fixture still diverged for the plain `export function`
+hooks).

--- a/.changeset/quiet-hooks-jsdoc.md
+++ b/.changeset/quiet-hooks-jsdoc.md
@@ -2,14 +2,16 @@
 "@rsvelte/svelte-check": patch
 ---
 
-Fix a residual false `implicit any` on SvelteKit hooks written as
-`export function handle(...) {...}` in plain JS/JSDoc (not TypeScript):
-the `/** @type {Handle} */` annotation was inserted between `export` and
-`function`, which TypeScript silently ignores. A JSDoc `@type` tag only
-re-types a `function` declaration when it leads the *entire* exported
-statement — matching the official implementation, whose
-`ts.FunctionDeclaration.getStart()` includes the `export` modifier in the
-node's own span. Every binding element of the hook's destructured
+Fix a residual false `implicit any` on SvelteKit files written as plain
+JS/JSDoc `export function` declarations (not TypeScript): hooks
+(`handle`/`handleError`/`handleFetch`/`reroute`), route `load`/`entries`,
+`+server.js` request-method handlers (`GET`/`POST`/...), and
+`params/*.js`'s `match` all prepended their `/** @type {...} */` or
+`/** @param {...} */` JSDoc annotation between `export` and `function`,
+which TypeScript silently ignores. A JSDoc tag only re-types a `function`
+declaration when it leads the *entire* exported statement — matching the
+official implementation, whose `ts.FunctionDeclaration.getStart()`
+includes the `export` modifier in the node's own span. Every affected
 parameter stayed implicit `any` despite the annotation being present in
 the overlay.
 
@@ -19,4 +21,6 @@ annotation correctly and is unaffected.
 
 This completes #1886's fix for the JSDoc/JS path (closed by #1892, but
 the `kit-hooks-js` fixture still diverged for the plain `export function`
-hooks).
+hooks) and fixes the same latent bug across the other four JSDoc-emitting
+paths in `kit_file.rs`, previously untested by the diagnostic-parity gate
+— added a new `kit-routes-js` fixture covering all four.

--- a/compatibility/check-fixtures/kit-routes-js/project/package.json
+++ b/compatibility/check-fixtures/kit-routes-js/project/package.json
@@ -1,0 +1,9 @@
+{
+	"name": "check-fixture-kit-routes-js",
+	"private": true,
+	"type": "module",
+	"devDependencies": {
+		"@sveltejs/kit": "*",
+		"svelte": "*"
+	}
+}

--- a/compatibility/check-fixtures/kit-routes-js/project/src/params/slug.js
+++ b/compatibility/check-fixtures/kit-routes-js/project/src/params/slug.js
@@ -1,0 +1,3 @@
+export function match(param) {
+	return param.length > 0;
+}

--- a/compatibility/check-fixtures/kit-routes-js/project/src/routes/$types.d.ts
+++ b/compatibility/check-fixtures/kit-routes-js/project/src/routes/$types.d.ts
@@ -1,0 +1,13 @@
+// Stand-in for SvelteKit's generated `$types.d.ts` (normally produced by
+// `svelte-kit sync`, not run by this fixture harness). A plain sibling file
+// resolves `import('./$types.js')` directly — no `rootDirs` bridge needed.
+export type PageLoadEvent = { params: Record<string, never> };
+export type PageLoad = (event: PageLoadEvent) => unknown;
+export type EntryGenerator = () =>
+	| Array<Record<string, string>>
+	| Promise<Array<Record<string, string>>>;
+// `+page.svelte`'s `data` prop is typed against this by svelte2tsx/rsvelte's
+// own (separate) page-component augmentation, independent of `kit_file.rs`'s
+// route-*file* augmentation this fixture targets — needed so official
+// `svelte-check` doesn't also flag a missing `PageData` member.
+export type PageData = Record<string, unknown>;

--- a/compatibility/check-fixtures/kit-routes-js/project/src/routes/+page.js
+++ b/compatibility/check-fixtures/kit-routes-js/project/src/routes/+page.js
@@ -1,0 +1,7 @@
+export function load(event) {
+	return { greeting: event.params };
+}
+
+export function entries() {
+	return [{ slug: 'hello-world' }];
+}

--- a/compatibility/check-fixtures/kit-routes-js/project/src/routes/+page.svelte
+++ b/compatibility/check-fixtures/kit-routes-js/project/src/routes/+page.svelte
@@ -1,0 +1,5 @@
+<script>
+	let { data } = $props();
+</script>
+
+<p>{data}</p>

--- a/compatibility/check-fixtures/kit-routes-js/project/src/routes/api/$types.d.ts
+++ b/compatibility/check-fixtures/kit-routes-js/project/src/routes/api/$types.d.ts
@@ -1,0 +1,4 @@
+// Stand-in for SvelteKit's generated `$types.d.ts` (normally produced by
+// `svelte-kit sync`, not run by this fixture harness). A plain sibling file
+// resolves `import('./$types.js')` directly — no `rootDirs` bridge needed.
+export type RequestEvent = { params: Record<string, never>; request: Request };

--- a/compatibility/check-fixtures/kit-routes-js/project/src/routes/api/+server.js
+++ b/compatibility/check-fixtures/kit-routes-js/project/src/routes/api/+server.js
@@ -1,0 +1,3 @@
+export function GET(event) {
+	return new Response(event.request.method);
+}

--- a/compatibility/check-fixtures/kit-routes-js/project/svelte.config.js
+++ b/compatibility/check-fixtures/kit-routes-js/project/svelte.config.js
@@ -1,0 +1,3 @@
+export default {
+	kit: {}
+};

--- a/compatibility/check-fixtures/kit-routes-js/project/tsconfig.json
+++ b/compatibility/check-fixtures/kit-routes-js/project/tsconfig.json
@@ -1,0 +1,20 @@
+{
+	"compilerOptions": {
+		"target": "esnext",
+		"module": "esnext",
+		"moduleResolution": "bundler",
+		"strict": true,
+		"skipLibCheck": true,
+		"noEmit": true,
+		"types": [
+			"@sveltejs/kit"
+		],
+		"allowJs": true,
+		"checkJs": true
+	},
+	"include": [
+		"src/**/*.ts",
+		"src/**/*.js",
+		"src/**/*.svelte"
+	]
+}

--- a/compatibility/check-fixtures/kit-routes-js/scenario.json
+++ b/compatibility/check-fixtures/kit-routes-js/scenario.json
@@ -1,0 +1,8 @@
+{
+	"description": "The route-level JSDoc/JS augmentation paths in `kit_file.rs` that share `add_hooks_type`'s anchor bug: `+page.js`'s `load`/`entries`, `+server.js`'s `GET`, and `params/slug.js`'s `match`, all written as plain `export function` under `checkJs`. Regression guard for the same export-statement anchoring fix that closed out #1886 for `kit-hooks-js`.",
+	"workspace": ".",
+	"tsconfig": "tsconfig.json",
+	"issues": [
+		1886
+	]
+}

--- a/compatibility/check-known-failures.json
+++ b/compatibility/check-known-failures.json
@@ -1,6 +1,4 @@
 [
 	"boundary-elements|+ERROR src/Boundary.svelte:9 7006",
-	"kit-hooks-js|+ERROR src/hooks.js:1 7031",
-	"kit-hooks-js|+ERROR src/hooks.server.js:1 7031 x2",
 	"sibling-symlink|+ERROR src/deep.svelte:1 2614"
 ]

--- a/compatibility/check-known-failures.md
+++ b/compatibility/check-known-failures.md
@@ -18,17 +18,18 @@ positions back through its own source map and TypeScript wording moves between
 patch releases, so keying on them would make the ratchet churn without telling
 anyone anything. See the header of `check-verify.mjs`.
 
-## Current baseline: 4 entries / 5 surplus diagnostics (all FP, 0 FN)
+## Current baseline: 2 entries / 2 surplus diagnostics (all FP, 0 FN)
 
-The gate landed with 16 entries across the #1883–#1889 cluster; `sibling-paths-alias`
-(#1883), `external-self-alias` (#1887), `ts-aliased-import` (#1888) and
-`kit-hooks-arrow-ts` (#1886) are now fully green and have been pruned. What
-remains:
+The gate landed with 16 entries across the #1883–#1889 cluster. `sibling-paths-alias`
+(#1883, fixed by #1884), `external-self-alias` (#1887, fixed by #1893),
+`ts-aliased-import` (#1888, fixed by #1895), `kit-hooks-arrow-ts` (#1886, fixed by
+#1892) and `kit-hooks-js` (#1886, fixed by #1892 for the arrow/function-expression
+form and a follow-up JSDoc-anchor fix for the plain `export function` form) are
+now all fully green and have been pruned. What remains:
 
 | Scenario | Entries | Diagnostics | Issue | Class |
 |---|---|---|---|---|
 | `sibling-symlink` | 1 | 1 | #1883 (same class) | bare-specifier deep `.svelte` import through a `node_modules` symlink |
-| `kit-hooks-js` | 2 | 3 | #1886 | JSDoc/JS `export function` hooks still not augmented |
 | `boundary-elements` | 1 | 1 | #1889 | vendored `svelte-jsx-v4` shim predates `svelte:boundary` |
 
 ### `sibling-symlink` — same class as #1883, different trigger
@@ -44,29 +45,6 @@ specifiers, and `libs/components/survey-options.svelte` is a bare package
 specifier, so the bridge never fires. The barrel arm of the same scenario
 (`src/barrel.svelte`, importing through the package `exports` barrel — the shape
 #782/#805 fixed) is green and must stay green.
-
-### `kit-hooks-js` — #1886, JSDoc/JS `export function` path
-
-```
-kit-hooks-js|+ERROR src/hooks.js:1 7031
-kit-hooks-js|+ERROR src/hooks.server.js:1 7031 x2
-```
-
-#1892 fixed the `const` + arrow/function-expression form (`kit-hooks-arrow-ts` is
-now fully green, and so are the arrow-const hooks inside this same JS fixture —
-`hooks.client.js`'s `handleError`, `hooks.server.js`'s `handleError`/
-`handleFetch`). What's left is the plain `export function` form under JSDoc
-(`hooks.js`'s `reroute`, `hooks.server.js`'s `handle`): still `TS7031` on every
-binding element, tracked as the JSDoc/JS-path remainder of #1886.
-
-The four `kit-hooks-*` scenarios are one matrix:
-
-| Scenario | Form | Status |
-|---|---|---|
-| `kit-hooks-fn-ts` | `export function` (TS) | green — the form the port already matches |
-| `kit-hooks-arrow-ts` | `export const … = () => {}` (TS) | green — fixed by #1892 |
-| `kit-hooks-satisfies-ts` | `satisfies` / explicit annotation / `sequence()` | green — nothing should be augmented; guards the #1886 fix against over-augmenting |
-| `kit-hooks-js` | plain JS under `checkJs`, function + arrow | red (partial) — arrow/function-expression forms fixed by #1892, plain `export function` still open |
 
 ### `boundary-elements` — #1889
 
@@ -102,8 +80,17 @@ Green scenarios are load-bearing, not filler — a regression turns them red:
 - **`sibling-paths-alias`**, **`external-self-alias`**, **`ts-aliased-import`** —
   fixed by #1884/#1893/#1895 respectively; kept as regression guards for their
   alias-rewrite paths.
-- **`kit-hooks-fn-ts`**, **`kit-hooks-arrow-ts`**, **`kit-hooks-satisfies-ts`** —
-  see the matrix above.
+- **`kit-hooks-fn-ts`**, **`kit-hooks-arrow-ts`**, **`kit-hooks-satisfies-ts`**,
+  **`kit-hooks-js`** — one matrix covering every `handle`/`handleError`/
+  `handleFetch`/`reroute` declaration shape:
+
+  | Scenario | Form | Status |
+  |---|---|---|
+  | `kit-hooks-fn-ts` | `export function` (TS) | green — the form the port already matches |
+  | `kit-hooks-arrow-ts` | `export const … = () => {}` (TS) | green — fixed by #1892 |
+  | `kit-hooks-satisfies-ts` | `satisfies` / explicit annotation / `sequence()` | green — nothing should be augmented; guards the #1886 fix against over-augmenting |
+  | `kit-hooks-js` | plain JS under `checkJs`, function + arrow | green — arrow/function-expression forms fixed by #1892, plain `export function` form fixed by anchoring its JSDoc `@type` tag at the exported statement's start instead of the `function` keyword (TypeScript ignores the tag otherwise) |
+  | `kit-routes-js` | `+page.js` `load`/`entries`, `+server.js` method handlers, `params/*.js` `match` under `checkJs` | green — regression guard for the same anchor bug across the other JSDoc-emitting paths in `kit_file.rs` |
 - **`sibling-symlink` / `src/barrel.svelte`** — the cross-package shape #782/#805
   fixed.
 

--- a/crates/rsvelte_check/src/svelte_check/kit_file.rs
+++ b/crates/rsvelte_check/src/svelte_check/kit_file.rs
@@ -702,7 +702,12 @@ fn add_hooks_type(
                 &f.params,
                 f.return_type.is_some(),
                 f.body.as_deref().map(|b| b.span().start),
-                f.span.start,
+                // JS-only: TypeScript's `@type` JSDoc tag only re-types a
+                // `function` declaration when it leads the whole exported
+                // statement (`ts.FunctionDeclaration.getStart()` includes the
+                // `export` modifier upstream); placed after `export` instead
+                // it's silently ignored and params stay implicit `any`.
+                ex.span.start,
                 false,
                 ty,
                 is_ts,
@@ -1034,9 +1039,32 @@ mod tests {
         let adds = build_added_code(&path, source, &KitFilesSettings::default())
             .expect("js handle should emit insertions");
         let augmented = apply_added_code(source, &adds);
+        // The JSDoc `@type` tag must precede the *whole* exported statement
+        // (`export function …`), not just the `function` keyword — TypeScript
+        // silently ignores an `@type` tag sitting between `export` and
+        // `function` and every binding element stays implicit `any`.
         assert!(
             augmented.contains(&format!(
-                "{IGNORE_START_COMMENT}/** @type {{import('@sveltejs/kit').Handle}} */ {IGNORE_END_COMMENT}function handle"
+                "{IGNORE_START_COMMENT}/** @type {{import('@sveltejs/kit').Handle}} */ {IGNORE_END_COMMENT}export function handle"
+            )),
+            "augmented = {augmented:?}"
+        );
+    }
+
+    #[test]
+    fn js_hooks_handle_fetch_arrow_const_form_uses_jsdoc_type() {
+        // JS mirrors the TS arrow-const case above (#1886): the augmentation
+        // reaches `add_hooks_type_to_function_like` through the same
+        // `VariableDeclaration` -> `ArrowFunctionExpression` path, just with
+        // the JSDoc wrapper instead of an inline type annotation.
+        let path = PathBuf::from("src/hooks.server.js");
+        let source = "export const handleFetch = async ({ request, fetch, event }) => {\n  return fetch(request);\n};\n";
+        let adds = build_added_code(&path, source, &KitFilesSettings::default())
+            .expect("js arrow-const handleFetch should emit insertions");
+        let augmented = apply_added_code(source, &adds);
+        assert!(
+            augmented.contains(&format!(
+                "= {IGNORE_START_COMMENT}/** @type {{import('@sveltejs/kit').HandleFetch}} */ {IGNORE_END_COMMENT}async ({{ request, fetch, event }})"
             )),
             "augmented = {augmented:?}"
         );

--- a/crates/rsvelte_check/src/svelte_check/kit_file.rs
+++ b/crates/rsvelte_check/src/svelte_check/kit_file.rs
@@ -492,11 +492,11 @@ fn visit_route_statement(
                             inserted: format!(": {load_type}Event"),
                         });
                     } else {
-                        // JSDoc `@param {LoadEvent} paramName` prepended to function start.
+                        // JSDoc `@param` must precede the whole exported statement, not just
+                        // `function` — TypeScript ignores a tag sandwiched after `export`.
                         let param_name = binding_pattern_name(&param.pattern).unwrap_or("arg0");
-                        let fn_start = f.span.start;
                         adds.push(AddedCode {
-                            original_pos: fn_start,
+                            original_pos: ex.span.start,
                             inserted: format!(
                                 "/** @param {{{}Event}} {} */ ",
                                 load_type, param_name
@@ -519,15 +519,15 @@ fn visit_route_statement(
                             inserted: ": ReturnType<import('./$types.js').EntryGenerator> ".into(),
                         });
                     } else {
-                        // `/** @type {import('./$types.js').EntryGenerator} */ ` prepended to fn
+                        // Same export-statement anchoring as the `load` branch above.
                         adds.push(AddedCode {
-                            original_pos: f.span.start,
+                            original_pos: ex.span.start,
                             inserted: "/** @type {import('./$types.js').EntryGenerator} */ ".into(),
                         });
                     }
                 }
                 "GET" | "PUT" | "POST" | "PATCH" | "DELETE" | "OPTIONS" | "HEAD" | "fallback" => {
-                    add_api_method_types(f, is_ts, adds);
+                    add_api_method_types(f, ex.span.start, is_ts, adds);
                 }
                 _ => {}
             }
@@ -536,7 +536,12 @@ fn visit_route_statement(
     }
 }
 
-fn add_api_method_types(f: &oxc::Function, is_ts: bool, adds: &mut Vec<AddedCode>) {
+fn add_api_method_types(
+    f: &oxc::Function,
+    export_start: u32,
+    is_ts: bool,
+    adds: &mut Vec<AddedCode>,
+) {
     if f.params.items.len() != 1 {
         return;
     }
@@ -563,15 +568,15 @@ fn add_api_method_types(f: &oxc::Function, is_ts: bool, adds: &mut Vec<AddedCode
             });
         }
     } else {
-        // JS: `/** @type {(event: RequestEvent) => Response | Promise<Response>} */`
-        // prepended to the function declaration.
+        // JS: `/** @type {(event: RequestEvent) => Response | Promise<Response>} */`,
+        // anchored on the exported statement (see the `load` branch above for why).
         let ret_ty = if f.r#async {
             "Promise<Response>"
         } else {
             "Response | Promise<Response>"
         };
         adds.push(AddedCode {
-            original_pos: f.span.start,
+            original_pos: export_start,
             inserted: format!(
                 "/** @type {{(event: import('./$types.js').RequestEvent) => {ret_ty}}} */ "
             ),
@@ -608,9 +613,10 @@ fn visit_param_statement(stmt: &oxc::Statement, is_ts: bool, adds: &mut Vec<Adde
             inserted: ": boolean ".into(),
         });
     } else {
-        // JS: `/** @type {(param: string) => boolean} */` prepended to fn.
+        // JS: `/** @type {(param: string) => boolean} */`, anchored on the exported
+        // statement (see `add_hooks_type`'s `FunctionDeclaration` arm for why).
         adds.push(AddedCode {
-            original_pos: f.span.start,
+            original_pos: ex.span.start,
             inserted: "/** @type {(param: string) => boolean} */ ".into(),
         });
     }
@@ -702,11 +708,7 @@ fn add_hooks_type(
                 &f.params,
                 f.return_type.is_some(),
                 f.body.as_deref().map(|b| b.span().start),
-                // JS-only: TypeScript's `@type` JSDoc tag only re-types a
-                // `function` declaration when it leads the whole exported
-                // statement (`ts.FunctionDeclaration.getStart()` includes the
-                // `export` modifier upstream); placed after `export` instead
-                // it's silently ignored and params stay implicit `any`.
+                // JS-only: a JSDoc `@type` tag on a `function` declaration is ignored unless it leads the whole exported statement.
                 ex.span.start,
                 false,
                 ty,
@@ -1077,9 +1079,10 @@ mod tests {
         let adds = build_added_code(&path, source, &KitFilesSettings::default())
             .expect("js params should emit insertions");
         let augmented = apply_added_code(source, &adds);
+        // Anchored before `export`, not just `function` — see the hooks test above.
         assert!(
             augmented.contains(&format!(
-                "{IGNORE_START_COMMENT}/** @type {{(param: string) => boolean}} */ {IGNORE_END_COMMENT}function match"
+                "{IGNORE_START_COMMENT}/** @type {{(param: string) => boolean}} */ {IGNORE_END_COMMENT}export function match"
             )),
             "augmented = {augmented:?}"
         );
@@ -1094,7 +1097,37 @@ mod tests {
         let augmented = apply_added_code(source, &adds);
         assert!(
             augmented.contains(&format!(
-                "{IGNORE_START_COMMENT}/** @type {{(event: import('./$types.js').RequestEvent) => Response | Promise<Response>}} */ {IGNORE_END_COMMENT}function GET"
+                "{IGNORE_START_COMMENT}/** @type {{(event: import('./$types.js').RequestEvent) => Response | Promise<Response>}} */ {IGNORE_END_COMMENT}export function GET"
+            )),
+            "augmented = {augmented:?}"
+        );
+    }
+
+    #[test]
+    fn js_route_load_function_uses_jsdoc_param() {
+        let path = PathBuf::from("src/routes/+page.js");
+        let source = "export function load(event) { return event; }\n";
+        let adds = build_added_code(&path, source, &KitFilesSettings::default())
+            .expect("js route load should emit insertions");
+        let augmented = apply_added_code(source, &adds);
+        assert!(
+            augmented.contains(&format!(
+                "{IGNORE_START_COMMENT}/** @param {{import('./$types.js').PageLoadEvent}} event */ {IGNORE_END_COMMENT}export function load"
+            )),
+            "augmented = {augmented:?}"
+        );
+    }
+
+    #[test]
+    fn js_route_entries_function_uses_jsdoc_type() {
+        let path = PathBuf::from("src/routes/+page.js");
+        let source = "export function entries() { return []; }\n";
+        let adds = build_added_code(&path, source, &KitFilesSettings::default())
+            .expect("js route entries should emit insertions");
+        let augmented = apply_added_code(source, &adds);
+        assert!(
+            augmented.contains(&format!(
+                "{IGNORE_START_COMMENT}/** @type {{import('./$types.js').EntryGenerator}} */ {IGNORE_END_COMMENT}export function entries"
             )),
             "augmented = {augmented:?}"
         );


### PR DESCRIPTION
## Summary

This completes #1886's fix for the JSDoc/JS path (closed by #1892, but the `kit-hooks-js` fixture still diverged for the plain `export function` form), **and** fixes the same anchor bug in four other JSDoc-emitting paths found during review.

### The bug

#1892 fixed the `const` + arrow-function/function-expression hook form (`export const handle = (...) => {...}`) by wrapping the initializer with a JSDoc `/** @type {Handle} */ (...)` cast — correct there. It reused the same helper for the plain `export function handle(...) {...}` form, but anchored the JSDoc comment at `f.span.start` (oxc's span for the `FunctionDeclaration` itself, which starts at the `function` keyword, *after* the `export` modifier).

TypeScript only associates a `@type`/`@param` tag with a `function` declaration when the comment precedes the **entire exported statement** — this is why the official `svelte2tsx` reference (`submodules/language-tools/packages/svelte2tsx/src/helpers/sveltekit.ts`) calls `insert(node.getStart(), ...)`, and `ts.FunctionDeclaration.getStart()` includes the `export` modifier in the node's own span (unlike oxc, which separates the `ExportNamedDeclaration` wrapper from the inner `Declaration`). With the comment sitting between `export` and `function`, tsc silently ignores it and every affected parameter stays implicit `any`.

Confirmed with a minimal repro against the pinned oracle `tsc`:
```js
/** @type {(x: { foo: number }) => void} */ export function handleA({ foo }) { return foo; }
// -> only the deliberate TS2322 return-type mismatch is reported; `foo` is correctly typed

export /** @type {(x: { foo: number }) => void} */ function handleB({ foo }) { return foo; }
// -> TS7031: Binding element 'foo' implicitly has an 'any' type.
```

### Fix — same bug, five call sites

`crates/rsvelte_check/src/svelte_check/kit_file.rs`'s `add_hooks_type`'s `FunctionDeclaration` arm now anchors the JS-only insertion at `ex.span.start` (the `ExportNamedDeclaration`'s span, i.e. before `export`) instead of `f.span.start`. Review found the same copy-pasted bug in four more places, all fixed the same way:
- `visit_route_statement`'s `"load"` branch (`@param {LoadEvent}`)
- `visit_route_statement`'s `"entries"` branch (`@type {EntryGenerator}`)
- `add_api_method_types` (`+server.js`'s `GET`/`POST`/etc. — now takes an explicit `export_start` parameter since it only sees the `Function`, not the `ExportNamedDeclaration`)
- `visit_param_statement` (`params/*.js`'s `match`)

### New fixture: `kit-routes-js`

None of these four paths had gate coverage before — `check-fixtures/` had no `+page.*`/`+server.*`/`params/*.js` scenario at all. Added `compatibility/check-fixtures/kit-routes-js/`, covering `+page.js`'s `load`+`entries`, `+server.js`'s `GET`, and `params/slug.js`'s `match`, all as plain `export function` under `checkJs`. It needs a hand-authored `src/routes/$types.d.ts` / `src/routes/api/$types.d.ts` sibling (SvelteKit normally generates these via `svelte-kit sync`, which this harness doesn't run) — verified experimentally that a plain sibling file resolves `./$types.js` directly, no `rootDirs` bridge needed.

**Confirmed the fixture actually catches the bug**: built a binary with only the hooks fix (not the other four), ran it against `kit-routes-js` — 3 false positives (`+page.js`'s `load`, `+server.js`'s `GET`, `params/slug.js`'s `match`, all `TS7006`). With the full fix: `oracle 0, rsvelte 0`.

### Before / after (diagnostic-parity gate)

| Scenario | Before this PR | After |
|---|---|---|
| `kit-hooks-js` | 3 diagnostics vs official | 0 |
| `kit-routes-js` (new) | n/a (no fixture existed) | 0 (3 diagnostics with only the hooks fix, proving the new fixture catches the bug) |

```
$ pnpm run test:svelte-check
...
[check-verify] kit-hooks-js: oracle 0, rsvelte 0 diagnostic(s)
[check-verify] kit-routes-js: oracle 0, rsvelte 0 diagnostic(s)
...
[check-verify] divergences: 1 current, 2 known (0 new, 1 fixed)
[check-verify] ✅ no new divergences
```

Rebased onto `main` (`eb963ad9`, #1909 merged) and reconciled the ratchet conflict: this PR only removes `kit-hooks-js`'s already-fixed entries (#1909's own removals are already on `main`), leaving `boundary-elements` and `sibling-symlink` for their respective PRs (#1906/#1907).

## Test plan

- [x] `cargo test -p rsvelte_check` — 94 lib tests + all integration suites pass
- [x] `cargo fmt --check && cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `pnpm run test:svelte-check` — `kit-hooks-js` and new `kit-routes-js` both green, 0 new divergences, exit 0
- [x] Green guards unaffected: `kit-hooks-fn-ts`, `kit-hooks-satisfies-ts` still 0/0
- [x] Verified the new fixture actually regresses against a pre-fix binary (3 diagnostics), then passes against the fixed binary (0)

https://claude.ai/code/session_01JFL7CmMS1hd9sJA3yU4GTC