### PR TITLE
perf(core): stop deep-cloning template subtrees in phase-3 hot paths (-15% client, -12% server)

### DIFF
--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/types.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/types.rs
@@ -611,50 +611,58 @@ fn strip_typescript_from_program_impl(
     // and `declare namespace ... { ... }` blocks. These may not always be parsed as
     // TSModuleDeclaration depending on the OXC version, so do a simple text-based scan
     // to ensure they're removed.
-    for keyword in &["declare global", "declare module", "declare namespace"] {
-        let bytes = source.as_bytes();
-        let mut search_from = 0;
-        while let Some(rel) = source[search_from..].find(keyword) {
-            let start = search_from + rel;
-            // Ensure it's at start of line (or preceded only by whitespace)
-            let line_start = source[..start].rfind('\n').map(|n| n + 1).unwrap_or(0);
-            let prefix = &source[line_start..start];
-            if !prefix.chars().all(char::is_whitespace) {
-                search_from = start + keyword.len();
-                continue;
-            }
-            // Find the matching `{` after the keyword
-            let after = &source[start + keyword.len()..];
-            if let Some(brace_rel) = after.find('{') {
-                let brace_pos = start + keyword.len() + brace_rel;
-                // Find matching `}` by depth tracking
-                let mut depth = 1i32;
-                let mut i = brace_pos + 1;
-                while i < bytes.len() && depth > 0 {
-                    match bytes[i] {
-                        b'{' => depth += 1,
-                        b'}' => depth -= 1,
-                        b'"' | b'\'' | b'`' => {
-                            let q = bytes[i];
-                            i += 1;
-                            while i < bytes.len() && bytes[i] != q {
-                                if bytes[i] == b'\\' {
-                                    i += 1;
-                                }
-                                i += 1;
-                            }
-                        }
-                        _ => {}
-                    }
-                    i += 1;
-                }
-                if depth == 0 {
-                    removals.push((start as u32, i as u32));
-                    search_from = i;
+    //
+    // Every keyword below starts with `declare `, so one SIMD scan for that prefix
+    // decides all three at once — the common case (generated output, which this runs
+    // over in full) has none and skips three whole-source `str::find` passes.
+    if memchr::memmem::find(source.as_bytes(), b"declare ").is_some() {
+        for keyword in &["declare global", "declare module", "declare namespace"] {
+            let bytes = source.as_bytes();
+            let mut search_from = 0;
+            while let Some(rel) =
+                memchr::memmem::find(&source.as_bytes()[search_from..], keyword.as_bytes())
+            {
+                let start = search_from + rel;
+                // Ensure it's at start of line (or preceded only by whitespace)
+                let line_start = source[..start].rfind('\n').map(|n| n + 1).unwrap_or(0);
+                let prefix = &source[line_start..start];
+                if !prefix.chars().all(char::is_whitespace) {
+                    search_from = start + keyword.len();
                     continue;
                 }
+                // Find the matching `{` after the keyword
+                let after = &source[start + keyword.len()..];
+                if let Some(brace_rel) = after.find('{') {
+                    let brace_pos = start + keyword.len() + brace_rel;
+                    // Find matching `}` by depth tracking
+                    let mut depth = 1i32;
+                    let mut i = brace_pos + 1;
+                    while i < bytes.len() && depth > 0 {
+                        match bytes[i] {
+                            b'{' => depth += 1,
+                            b'}' => depth -= 1,
+                            b'"' | b'\'' | b'`' => {
+                                let q = bytes[i];
+                                i += 1;
+                                while i < bytes.len() && bytes[i] != q {
+                                    if bytes[i] == b'\\' {
+                                        i += 1;
+                                    }
+                                    i += 1;
+                                }
+                            }
+                            _ => {}
+                        }
+                        i += 1;
+                    }
+                    if depth == 0 {
+                        removals.push((start as u32, i as u32));
+                        search_from = i;
+                        continue;
+                    }
+                }
+                search_from = start + keyword.len();
             }
-            search_from = start + keyword.len();
         }
     }
 

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/call_expression.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/call_expression.rs
@@ -191,13 +191,88 @@ fn is_bindable_valid_placement(context: &VisitorContext) -> bool {
         return false;
     }
 
-    // Check that VariableDeclarator init is $props()
+    // Check that VariableDeclarator init is $props().
+    //
+    // Read `init` straight off the typed node when there is one: `as_value()`
+    // would lower the whole declarator — including the `$props()` destructuring
+    // pattern, which real components make very large — into a `Value` just to
+    // reach this one field.
+    if let Some(JsNode::VariableDeclarator { init, .. }) = var_declarator.as_js_node() {
+        let Some(init) = init else {
+            return false;
+        };
+        let init_node = context.parse_arena.get_js_node(*init);
+        return get_rune_node(init_node, context).as_deref() == Some("$props");
+    }
+
     if let Some(init) = var_declarator.as_value().get("init") {
         let rune = get_rune(init, context);
         return rune.as_deref() == Some("$props");
     }
 
     false
+}
+
+/// Typed mirror of [`get_rune`].
+fn get_rune_node(node: &JsNode, context: &VisitorContext) -> Option<String> {
+    let JsNode::CallExpression { callee, .. } = node else {
+        return None;
+    };
+    let callee = context.parse_arena.get_js_node(*callee);
+    let keypath = get_global_keypath_node(callee, context)?;
+    if super::shared::function::is_rune(&keypath) {
+        Some(keypath)
+    } else {
+        None
+    }
+}
+
+/// Typed mirror of [`get_global_keypath`].
+fn get_global_keypath_node(node: &JsNode, context: &VisitorContext) -> Option<String> {
+    let arena = context.parse_arena;
+    let mut n = node;
+    let mut joined = String::new();
+
+    while let JsNode::MemberExpression {
+        object,
+        property,
+        computed,
+        ..
+    } = n
+    {
+        if *computed {
+            return None;
+        }
+        let JsNode::Identifier { name, .. } = arena.get_js_node(*property) else {
+            return None;
+        };
+        joined = format!(".{}{}", name, joined);
+        n = arena.get_js_node(*object);
+    }
+
+    if let JsNode::CallExpression { callee, .. } = n {
+        let callee = arena.get_js_node(*callee);
+        if !matches!(callee, JsNode::Identifier { .. }) {
+            return None;
+        }
+        joined = format!("(){}", joined);
+        n = callee;
+    }
+
+    let JsNode::Identifier { name, .. } = n else {
+        return None;
+    };
+
+    if context
+        .analysis
+        .root
+        .find_binding_any_scope(name.as_str())
+        .is_some()
+    {
+        return None;
+    }
+
+    Some(format!("{}{}", name, joined))
 }
 
 /// Check if $props is in a valid placement.
@@ -308,7 +383,14 @@ fn is_props_id_valid_placement(context: &VisitorContext) -> bool {
     }
 
     // The id field of VariableDeclarator must be an Identifier (not ObjectPattern or ArrayPattern)
-    if let Some(id) = parent.as_value().get("id") {
+    if let Some(JsNode::VariableDeclarator { id, .. }) = parent.as_js_node() {
+        if !matches!(
+            context.parse_arena.get_js_node(*id),
+            JsNode::Identifier { .. }
+        ) {
+            return false;
+        }
+    } else if let Some(id) = parent.as_value().get("id") {
         let id_type = id.get("type").and_then(|t| t.as_str());
         if id_type != Some("Identifier") {
             return false;

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/types.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/types.rs
@@ -120,7 +120,7 @@ impl<'a> ComponentContext<'a> {
         };
 
         let component_name = comp.name.to_string();
-        let stmt = build_component(ComponentNode::Component(comp.clone()), component_name, self);
+        let stmt = build_component(ComponentNode::Component(comp), component_name, self);
 
         TransformResult::Statement(stmt)
     }
@@ -136,7 +136,7 @@ impl<'a> ComponentContext<'a> {
 
         // For svelte:component, we use '$$component' as the component name
         let stmt = build_component(
-            ComponentNode::SvelteComponent(comp.clone()),
+            ComponentNode::SvelteComponent(comp),
             "$$component".to_string(),
             self,
         );
@@ -155,11 +155,7 @@ impl<'a> ComponentContext<'a> {
 
         // For svelte:self, we use the component's own name for self-reference
         let component_name = self.state.analysis.name.clone();
-        let stmt = build_component(
-            ComponentNode::SvelteSelf(self_node.clone()),
-            component_name,
-            self,
-        );
+        let stmt = build_component(ComponentNode::SvelteSelf(self_node), component_name, self);
 
         TransformResult::Statement(stmt)
     }

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/component.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/component.rs
@@ -46,7 +46,7 @@ pub fn visit_component(node: &Component, context: &mut ComponentContext) {
 
     // Build component instantiation statement
     let component = build_component(
-        ComponentNode::Component(node.clone()),
+        ComponentNode::Component(node),
         component_name,
         context,
     );

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/component.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/component.rs
@@ -2215,7 +2215,7 @@ fn visit_slot_children(
     context: &mut ComponentContext,
 ) -> Vec<JsStatement> {
     use crate::compiler::phases::phase3_transform::client::transform_template::Namespace;
-    use crate::compiler::phases::phase3_transform::utils::clean_nodes;
+    use crate::compiler::phases::phase3_transform::utils::clean_nodes_refs;
 
     // SAFETY: `JsArena` allocates via interior mutability (`UnsafeCell`) with
     // nodes behind stable `Box`es, so a shared `&JsArena` stays valid while
@@ -2223,9 +2223,6 @@ fn visit_slot_children(
     // and traversal is single-threaded (no aliasing).
     let arena_local2: &crate::compiler::phases::phase3_transform::js_ast::arena::JsArena =
         unsafe { &*(&context.arena as *const _) };
-
-    // Convert &[&TemplateNode] to Vec<TemplateNode> for clean_nodes
-    let nodes: Vec<TemplateNode> = children.iter().map(|n| (*n).clone()).collect();
 
     // Slot content is its own fragment, so its namespace is RE-INFERRED from the
     // children (a component is a namespace-reset boundary), NOT inherited from
@@ -2239,15 +2236,15 @@ fn visit_slot_children(
     let inferred_ns = crate::compiler::phases::phase3_transform::utils::infer_namespace(
         &context.state.metadata.namespace,
         crate::compiler::phases::phase3_transform::utils::ParentRef::None,
-        &nodes,
+        children,
         context.state.analysis,
         true,
     );
 
     // Clean the nodes (trim whitespace, etc.)
-    let cleaned = clean_nodes(
+    let cleaned = clean_nodes_refs(
         crate::compiler::phases::phase3_transform::utils::ParentRef::None, // No parent in slot context
-        &nodes,
+        children,
         &context.path,
         inferred_ns,
         context.state.scope,

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/component.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/component.rs
@@ -19,16 +19,16 @@ use indexmap::IndexMap;
 
 /// Component node types.
 #[derive(Debug, Clone)]
-pub enum ComponentNode<'a> {
+pub enum ComponentNode<'n, 'a> {
     /// Regular component (`<MyComponent>`)
-    Component(Component<'a>),
+    Component(&'n Component<'a>),
     /// Dynamic component (`<svelte:component this={...}>`)
-    SvelteComponent(SvelteComponentElement<'a>),
+    SvelteComponent(&'n SvelteComponentElement<'a>),
     /// Self-reference (`<svelte:self>`)
-    SvelteSelf(SvelteElement<'a>),
+    SvelteSelf(&'n SvelteElement<'a>),
 }
 
-impl<'a> ComponentNode<'a> {
+impl<'a> ComponentNode<'_, 'a> {
     /// Get the start position of the component node.
     pub fn start(&self) -> u32 {
         match self {
@@ -67,7 +67,7 @@ struct DelayedProp {
 ///
 /// Returns a statement that instantiates the component.
 pub fn build_component(
-    node: ComponentNode<'_>,
+    node: ComponentNode<'_, '_>,
     component_name: String,
     context: &mut ComponentContext,
 ) -> JsStatement {
@@ -2794,7 +2794,7 @@ fn visit_slot_children(
 
 /// Build the component expression for dynamic components.
 fn build_component_expression(
-    node: &ComponentNode<'_>,
+    node: &ComponentNode<'_, '_>,
     component_name: &str,
     context: &mut ComponentContext,
 ) -> JsExpr {
@@ -3076,7 +3076,7 @@ fn build_component_meta_stmt(
     arena: &crate::compiler::phases::phase3_transform::js_ast::arena::JsArena,
 
     expression: JsExpr,
-    node: &ComponentNode<'_>,
+    node: &ComponentNode<'_, '_>,
     analysis_name: &str,
     dev: bool,
     source: &str,

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/mod.rs
@@ -379,10 +379,14 @@ impl<'a> ServerTransformState<'a> {
     /// contains exactly one node that is a non-dynamic RenderTag or non-dynamic
     /// Component (so the parent anchors suffice and the trailing `<!---->` is
     /// elided). Snippet defs / const tags / head-like nodes are hoisted out.
-    pub fn is_standalone_fragment(nodes: &[TemplateNode], preserve_whitespace: bool) -> bool {
+    pub fn is_standalone_fragment<'t, N: AsRef<TemplateNode<'t>>>(
+        nodes: &[N],
+        preserve_whitespace: bool,
+    ) -> bool {
         use crate::compiler::phases::phase3_transform::utils::is_svelte_whitespace_only;
         let meaningful: Vec<&TemplateNode> = nodes
             .iter()
+            .map(|n| n.as_ref())
             .filter(|n| match n {
                 // In a whitespace-preserving context (`<pre>` / `<textarea>` /
                 // sticky descendant), whitespace-only text is NOT trimmed, so it
@@ -885,7 +889,7 @@ pub fn server_component_ast<'a>(
     // rendered template, after the instance body), and for block-nested snippets
     // they stay inside their block body. No extra splice is needed here.
     let template_body =
-        visitors::shared::build_fragment_body(&ast.fragment, true, true, &mut state);
+        visitors::shared::build_fragment_body(&ast.fragment.nodes, true, true, &mut state);
 
     // -- component-bindings settle-loop (upstream lines 178-211) ------------
     // If the component binds to a child (`<Child bind:value={v} />`), legacy

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/visitors/component.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/visitors/component.rs
@@ -58,8 +58,8 @@
 //! dynamic path (the guard supplies its own close marker).
 
 use crate::ast::template::{
-    Attribute, AttributeValue, AttributeValuePart, Fragment, FragmentType, SnippetBlock,
-    SpreadAttribute, TemplateNode,
+    Attribute, AttributeValue, AttributeValuePart, Fragment, SnippetBlock, SpreadAttribute,
+    TemplateNode,
 };
 use crate::compiler::phases::phase3_transform::builders::B;
 use crate::compiler::phases::phase3_transform::server::ast::ServerTransformState;
@@ -539,20 +539,14 @@ fn build_component_children<'a, 'b>(
 }
 
 /// Render a slot body (a slice of sibling template nodes) into the statements of
-/// a fragment block. Wraps the nodes in a synthetic [`Fragment`] and routes them
-/// through the shared fragment machinery — a Component slot IS an `is_text_first`
-/// parent, so leading text gets the `<!---->` anchor.
+/// a fragment block. Routes the nodes through the shared fragment machinery — a
+/// Component slot IS an `is_text_first` parent, so leading text gets the
+/// `<!---->` anchor.
 fn render_slot_body<'a>(
     nodes: &[&TemplateNode<'a>],
     is_text_first_parent: bool,
     state: &mut ServerTransformState<'a>,
 ) -> Vec<Statement<'a>> {
-    let synthetic = Fragment {
-        node_type: FragmentType::Fragment,
-        nodes: nodes.iter().map(|n| (*n).clone()).collect(),
-        metadata: Default::default(),
-    };
-
     // Slot content is its own fragment, and a component is a namespace-RESET
     // boundary, so re-infer the namespace from the slot children — DEEPLY,
     // descending through `{#if}` / `{#each}` blocks (写经 upstream
@@ -564,7 +558,7 @@ fn render_slot_body<'a>(
     // `<!---->` markers) rather than kept. `process_fragment`'s own shallow
     // re-inference then inherits this value when it finds no direct element.
     use crate::compiler::phases::phase3_transform::utils::{NsScan, check_nodes_for_namespace};
-    let inferred_ns: &'static str = match check_nodes_for_namespace(&synthetic.nodes) {
+    let inferred_ns: &'static str = match check_nodes_for_namespace(nodes) {
         NsScan::Html => "html",
         NsScan::Svg => "svg",
         NsScan::Mathml => "mathml",
@@ -572,7 +566,7 @@ fn render_slot_body<'a>(
     };
     let saved_namespace = state.namespace;
     state.namespace = inferred_ns;
-    let body = super::shared::build_fragment_body(&synthetic, is_text_first_parent, true, state);
+    let body = super::shared::build_fragment_body(nodes, is_text_first_parent, true, state);
     state.namespace = saved_namespace;
     body
 }
@@ -714,7 +708,7 @@ fn build_snippet_declaration<'a>(
     }
     state.shadowed_names.push(shadow);
     // SnippetBlock body IS an `is_text_first` parent.
-    let body_block = super::shared::build_fragment_body(&snippet.body, true, true, state);
+    let body_block = super::shared::build_fragment_body(&snippet.body.nodes, true, true, state);
     state.shadowed_names.pop();
     let fn_body = state.b.body(body_block);
     state.b.function_declaration(name, params, fn_body, false)

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/visitors/each_block.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/visitors/each_block.rs
@@ -175,7 +175,7 @@ pub fn visit_each_block<'a>(node: &EachBlock<'a>, state: &mut ServerTransformSta
         state.slot_let_shadows.push(each_shadow);
     }
     // EachBlock body IS an `is_text_first` parent (upstream `clean_nodes`).
-    each_body.extend(build_fragment_body(&node.body, true, false, state));
+    each_body.extend(build_fragment_body(&node.body.nodes, true, false, state));
     if pushed_shadow {
         state.slot_let_shadows.pop();
         state.shadowed_names.pop();
@@ -205,7 +205,7 @@ pub fn visit_each_block<'a>(node: &EachBlock<'a>, state: &mut ServerTransformSta
         // EachBlock node, so it IS an `is_text_first` parent (upstream
         // `clean_nodes`: `parent.type === 'EachBlock'`) — a text-first fallback
         // gets a leading `<!---->` anchor, same as the loop body.
-        let mut fallback_body = build_fragment_body(fallback, true, false, state);
+        let mut fallback_body = build_fragment_body(&fallback.nodes, true, false, state);
         let b = state.b;
         let open_else_push = b.stmt(b.call("$$renderer.push", vec![b.string(BLOCK_OPEN_ELSE)]));
         fallback_body.insert(0, open_else_push);

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/visitors/if_block.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/visitors/if_block.rs
@@ -257,7 +257,7 @@ fn build_branch_block<'a>(
     state: &mut ServerTransformState<'a>,
 ) -> Statement<'a> {
     // IfBlock consequent/alternate is NOT an `is_text_first` parent.
-    let mut body = build_fragment_body(frag, false, false, state);
+    let mut body = build_fragment_body(&frag.nodes, false, false, state);
     let marker = marker_push(state.b, marker_index);
     body.insert(0, marker);
     state.b.block(body)

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/visitors/shared.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/visitors/shared.rs
@@ -98,8 +98,8 @@ pub fn process_children<'a>(
 /// pushed so the text node isn't fused with the surrounding fragment during
 /// hydration. RegularElement / TitleElement parents pass `false` (they are not
 /// in upstream's `is_text_first` parent list).
-pub fn process_children_inner<'a>(
-    nodes: &[TemplateNode<'a>],
+pub fn process_children_inner<'a, N: AsRef<TemplateNode<'a>>>(
+    nodes: &[N],
     parent: Option<&RegularElement<'_>>,
     namespace: &str,
     is_block_parent: bool,
@@ -140,7 +140,7 @@ pub fn process_children_inner<'a>(
     let reordered = sort_const_tags(nodes, state);
     let iter_nodes: Vec<&TemplateNode> = match reordered {
         Some(v) => v,
-        None => nodes.iter().collect(),
+        None => nodes.iter().map(|n| n.as_ref()).collect(),
     };
 
     let mut hoisted: Vec<&TemplateNode> = Vec::new();
@@ -737,8 +737,8 @@ fn flush_sequence<'a>(sequence: &[SeqNode<'_>], state: &mut ServerTransformState
 /// dependency scan only needs each const's declared names + the identifiers
 /// referenced in its initializer (reusing the same string-based extraction the
 /// const-tag visitor uses, so the two stay consistent).
-fn sort_const_tags<'n, 'b>(
-    nodes: &'n [TemplateNode<'b>],
+fn sort_const_tags<'n, 'b, N: AsRef<TemplateNode<'b>>>(
+    nodes: &'n [N],
     state: &ServerTransformState<'_>,
 ) -> Option<Vec<&'n TemplateNode<'b>>> {
     if state.analysis.runes {
@@ -754,6 +754,7 @@ fn sort_const_tags<'n, 'b>(
     let mut consts: Vec<ConstInfo<'n, 'b>> = Vec::new();
     let mut others: Vec<&'n TemplateNode> = Vec::new();
     for n in nodes {
+        let n = n.as_ref();
         if let TemplateNode::ConstTag(ct) = n {
             // Slice the FIRST declarator's span (`x = (rhs)`), not the whole
             // `VariableDeclaration` span — the latter now starts at the `const`
@@ -982,8 +983,8 @@ pub fn build_template<'a>(
 /// `{#key}` / `{#await}` arms) pass `false` and keep the shallow direct-child
 /// inference — mirroring upstream `infer_namespace`, which only runs the deep
 /// check for the reset-parent kinds.
-pub fn build_fragment_body<'a>(
-    fragment: &Fragment<'a>,
+pub fn build_fragment_body<'a, N: AsRef<TemplateNode<'a>>>(
+    nodes: &[N],
     is_text_first_parent: bool,
     reset_namespace: bool,
     state: &mut ServerTransformState<'a>,
@@ -1008,7 +1009,7 @@ pub fn build_fragment_body<'a>(
     // upstream.
     let saved_standalone = state.is_standalone;
     state.is_standalone =
-        ServerTransformState::is_standalone_fragment(&fragment.nodes, state.preserve_whitespace);
+        ServerTransformState::is_standalone_fragment(nodes, state.preserve_whitespace);
     // Track fragment nesting depth: the root component fragment is depth 1; any
     // nested block / boundary / snippet body is depth ≥ 2. The boundary visitor
     // reads this to decide `failed`-snippet hoist-vs-inline placement.
@@ -1047,12 +1048,12 @@ pub fn build_fragment_body<'a>(
     // (issue #1227). The root component fragment has `state.namespace == "html"`,
     // so its default is unchanged.
     let fragment_namespace = if reset_namespace {
-        infer_namespace_reset(&fragment.nodes, state.namespace)
+        infer_namespace_reset(nodes, state.namespace)
     } else {
-        infer_namespace_from_nodes_owned(&fragment.nodes, state.namespace)
+        infer_namespace_from_nodes_owned(nodes, state.namespace)
     };
     process_children_inner(
-        &fragment.nodes,
+        nodes,
         None,
         &fragment_namespace,
         is_text_first_parent,
@@ -1210,7 +1211,7 @@ pub fn build_fragment_block<'a>(
     // Block visitors (IfBlock / EachBlock / KeyBlock / AwaitBlock) are NOT
     // namespace-resetting parents upstream, so they keep the shallow direct-child
     // inference (`reset_namespace = false`).
-    let body = build_fragment_body(fragment, is_text_first_parent, false, state);
+    let body = build_fragment_body(&fragment.nodes, is_text_first_parent, false, state);
     state.b.block(body)
 }
 
@@ -1778,10 +1779,10 @@ fn check_ns_walk(node: &TemplateNode, ns: &mut NsCheck) {
     }
 }
 
-fn check_nodes_for_namespace(nodes: &[TemplateNode]) -> NsCheck {
+fn check_nodes_for_namespace<'t, N: AsRef<TemplateNode<'t>>>(nodes: &[N]) -> NsCheck {
     let mut ns = NsCheck::Keep;
     for node in nodes {
-        check_ns_walk(node, &mut ns);
+        check_ns_walk(node.as_ref(), &mut ns);
         if ns == NsCheck::Html {
             return ns;
         }
@@ -1795,7 +1796,10 @@ fn check_nodes_for_namespace(nodes: &[TemplateNode]) -> NsCheck {
 /// inside `{#if}` / `{#each}` blocks); a definitive verdict wins, otherwise
 /// falls back to the shallow direct-child inference. 写经 upstream
 /// `infer_namespace`'s reset-parent branch + element-loop fall-through.
-pub(crate) fn infer_namespace_reset(nodes: &[TemplateNode<'_>], parent_namespace: &str) -> String {
+pub(crate) fn infer_namespace_reset<'a, N: AsRef<TemplateNode<'a>>>(
+    nodes: &[N],
+    parent_namespace: &str,
+) -> String {
     match check_nodes_for_namespace(nodes) {
         NsCheck::Svg => "svg".to_string(),
         NsCheck::Mathml => "mathml".to_string(),
@@ -1806,13 +1810,13 @@ pub(crate) fn infer_namespace_reset(nodes: &[TemplateNode<'_>], parent_namespace
     }
 }
 
-pub(crate) fn infer_namespace_from_nodes_owned(
-    nodes: &[TemplateNode<'_>],
+pub(crate) fn infer_namespace_from_nodes_owned<'a, N: AsRef<TemplateNode<'a>>>(
+    nodes: &[N],
     parent_namespace: &str,
 ) -> String {
     let mut found_namespace: Option<&str> = None;
     for node in nodes {
-        if let TemplateNode::RegularElement(el) = node {
+        if let TemplateNode::RegularElement(el) = node.as_ref() {
             if el.metadata.svg {
                 match found_namespace {
                     None => found_namespace = Some("svg"),

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/visitors/slot_element.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/visitors/slot_element.rs
@@ -117,7 +117,7 @@ pub fn visit_slot_element<'a>(node: &SlotElement<'a>, state: &mut ServerTransfor
         // SnippetBlock / EachBlock / SvelteComponent / SvelteBoundary / Component /
         // SvelteSelf only), so leading text does NOT get a `<!---->` anchor.
         // `b.thunk(BlockStatement)` → `() => { <body> }`.
-        let body = build_fragment_body(&node.fragment, false, true, state);
+        let body = build_fragment_body(&node.fragment.nodes, false, true, state);
         let params = state.b.params(vec![], None);
         state.b.arrow(params, state.b.body(body), false, false)
     };

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/visitors/snippet_block.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/visitors/snippet_block.rs
@@ -78,7 +78,7 @@ pub fn visit_snippet_block<'a>(node: &SnippetBlock<'a>, state: &mut ServerTransf
     // Body: render the fragment as a `{ ... }` block, then reuse its statements
     // as the function body.
     // SnippetBlock body IS an `is_text_first` parent (upstream `clean_nodes`).
-    let body_block = super::shared::build_fragment_body(&node.body, true, true, state);
+    let body_block = super::shared::build_fragment_body(&node.body.nodes, true, true, state);
     let fn_body = b.body(body_block);
 
     state.shadowed_names.pop();

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/visitors/svelte_boundary.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/visitors/svelte_boundary.rs
@@ -245,7 +245,7 @@ fn build_boundary_snippet<'a>(
     }
     let params = b.params(patterns, None);
     // SnippetBlock body IS an `is_text_first` parent.
-    let body_block = super::shared::build_fragment_body(&snippet.body, true, true, state);
+    let body_block = super::shared::build_fragment_body(&snippet.body.nodes, true, true, state);
     let fn_body = state.b.body(body_block);
     state.b.function_declaration(name, params, fn_body, false)
 }

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/visitors/svelte_element.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/visitors/svelte_element.rs
@@ -131,7 +131,7 @@ pub fn visit_svelte_element<'a>(
 
     // -- children -----------------------------------------------------------
     // SvelteElement children are NOT an `is_text_first` parent.
-    let children_body = build_fragment_body(&node.fragment, false, false, state);
+    let children_body = build_fragment_body(&node.fragment.nodes, false, false, state);
     let b = state.b;
     let children_thunk = if children_body.is_empty() {
         None

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/visitors/svelte_head.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/visitors/svelte_head.rs
@@ -36,7 +36,7 @@ pub fn visit_svelte_head<'a>(node: &SvelteElement<'a>, state: &mut ServerTransfo
     // visited `b.block([...])` directly as the arrow body, so we splice the
     // fragment statements straight in — no extra `{ }` nesting).
     // SvelteHead body is NOT an `is_text_first` parent.
-    let body_stmts = build_fragment_body(&node.fragment, false, false, state);
+    let body_stmts = build_fragment_body(&node.fragment.nodes, false, false, state);
 
     // `($$renderer) => { <body> }`
     let params = b.params(vec![b.id_pat("$$renderer")], None);

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/utils.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/utils.rs
@@ -182,7 +182,7 @@ pub fn svelte_trim_end(s: &str) -> &str {
 /// correct, so cloning to return an identical Vec was pure waste — and the
 /// common case for `clean_nodes`, which runs over every sibling group in the
 /// tree in legacy mode.
-fn sort_const_tags<'a>(nodes: &[TemplateNode<'a>]) -> Option<Vec<TemplateNode<'a>>> {
+fn sort_const_tags<'a, L: NodeList<'a>>(nodes: &L) -> Option<Vec<TemplateNode<'a>>> {
     // Collect const tags with their indices, declared names, and dependencies
     struct ConstTagInfo {
         index: usize,
@@ -193,8 +193,8 @@ fn sort_const_tags<'a>(nodes: &[TemplateNode<'a>]) -> Option<Vec<TemplateNode<'a
     let mut const_infos: Vec<ConstTagInfo> = Vec::new();
     let mut other_indices: Vec<usize> = Vec::new();
 
-    for (i, node) in nodes.iter().enumerate() {
-        if let TemplateNode::ConstTag(tag) = node {
+    for i in 0..nodes.count() {
+        if let TemplateNode::ConstTag(tag) = nodes.get(i) {
             let (declared, referenced) = extract_const_tag_names_and_deps(&tag.declaration);
             const_infos.push(ConstTagInfo {
                 index: i,
@@ -265,17 +265,17 @@ fn sort_const_tags<'a>(nodes: &[TemplateNode<'a>]) -> Option<Vec<TemplateNode<'a
     // index sets partition `0..nodes.len()`), so cloning per index clones every
     // node exactly once — the same total work as the previous move-based path,
     // but only on this rare reorder branch rather than on every call.
-    let mut result: Vec<TemplateNode> = Vec::with_capacity(nodes.len());
+    let mut result: Vec<TemplateNode> = Vec::with_capacity(nodes.count());
 
     // Add sorted const tags first
     for &tag_idx in &sorted_tag_indices {
         let original_index = const_infos[tag_idx].index;
-        result.push(nodes[original_index].clone());
+        result.push(nodes.get(original_index).clone());
     }
 
     // Add other nodes in original order
     for &other_idx in &other_indices {
-        result.push(nodes[other_idx].clone());
+        result.push(nodes.get(other_idx).clone());
     }
 
     Some(result)
@@ -573,6 +573,36 @@ pub struct CleanedNodes<'a> {
     pub is_text_first: bool,
 }
 
+/// A list of template nodes that can be viewed as `&'a TemplateNode<'a>` by index,
+/// so [`clean_nodes`] works off either a slice of nodes or a slice of *pointers*
+/// to nodes without the caller having to deep-clone one into the other.
+trait NodeList<'a> {
+    fn count(&self) -> usize;
+    fn get(&self, i: usize) -> &'a TemplateNode<'a>;
+}
+
+impl<'a> NodeList<'a> for &'a [TemplateNode<'a>] {
+    #[inline]
+    fn count(&self) -> usize {
+        self.len()
+    }
+    #[inline]
+    fn get(&self, i: usize) -> &'a TemplateNode<'a> {
+        &self[i]
+    }
+}
+
+impl<'a> NodeList<'a> for &[&'a TemplateNode<'a>] {
+    #[inline]
+    fn count(&self) -> usize {
+        self.len()
+    }
+    #[inline]
+    fn get(&self, i: usize) -> &'a TemplateNode<'a> {
+        self[i]
+    }
+}
+
 /// Clean and organize template nodes.
 ///
 /// Extracts nodes that are hoisted and trims whitespace according to the following rules:
@@ -600,6 +630,53 @@ pub struct CleanedNodes<'a> {
 pub fn clean_nodes<'a>(
     parent: ParentRef<'_>,
     nodes: &'a [TemplateNode<'a>],
+    path: &[&TemplateNode<'_>],
+    namespace: &str,
+    scope: &Scope,
+    analysis: &ComponentAnalysis,
+    preserve_whitespace: bool,
+    preserve_comments: bool,
+) -> CleanedNodes<'a> {
+    clean_node_list(
+        parent,
+        nodes,
+        path,
+        namespace,
+        scope,
+        analysis,
+        preserve_whitespace,
+        preserve_comments,
+    )
+}
+
+/// [`clean_nodes`] over a slice of node *references* — the shape the slot-content
+/// and fragment visitors hold, which would otherwise have to deep-clone every
+/// child subtree just to hand over a contiguous `&[TemplateNode]`.
+pub fn clean_nodes_refs<'a>(
+    parent: ParentRef<'_>,
+    nodes: &[&'a TemplateNode<'a>],
+    path: &[&TemplateNode<'_>],
+    namespace: &str,
+    scope: &Scope,
+    analysis: &ComponentAnalysis,
+    preserve_whitespace: bool,
+    preserve_comments: bool,
+) -> CleanedNodes<'a> {
+    clean_node_list(
+        parent,
+        nodes,
+        path,
+        namespace,
+        scope,
+        analysis,
+        preserve_whitespace,
+        preserve_comments,
+    )
+}
+
+fn clean_node_list<'a, L: NodeList<'a>>(
+    parent: ParentRef<'_>,
+    nodes: L,
     _path: &[&TemplateNode<'_>],
     namespace: &str,
     _scope: &Scope,
@@ -614,14 +691,14 @@ pub fn clean_nodes<'a>(
     // borrowing `nodes` below instead of cloning the whole slice every call.
     let is_legacy = !analysis.runes;
     let sorted_nodes = if is_legacy {
-        sort_const_tags(nodes)
+        sort_const_tags(&nodes)
     } else {
         None
     };
 
     // Pre-allocate based on input size
-    let mut hoisted: Vec<Cow<'a, TemplateNode<'a>>> = Vec::with_capacity(nodes.len().min(8));
-    let mut regular: Vec<Cow<'a, TemplateNode<'a>>> = Vec::with_capacity(nodes.len());
+    let mut hoisted: Vec<Cow<'a, TemplateNode<'a>>> = Vec::with_capacity(nodes.count().min(8));
+    let mut regular: Vec<Cow<'a, TemplateNode<'a>>> = Vec::with_capacity(nodes.count());
 
     // Helper: process a single node into hoisted or regular
     let mut process_node = |node: Cow<'a, TemplateNode<'a>>| {
@@ -656,8 +733,8 @@ pub fn clean_nodes<'a>(
         }
     } else {
         // Runes mode: borrow from input
-        for node in nodes {
-            process_node(Cow::Borrowed(node));
+        for i in 0..nodes.count() {
+            process_node(Cow::Borrowed(nodes.get(i)));
         }
     }
 


### PR DESCRIPTION
## Summary

Serial-compile performance, wave 3 (stacked on #1912). Profiling showed the real bottleneck was **deep clones of `TemplateNode` / `Component` subtrees** in phase-3 hot paths, not re-parsing or serde_json.

End-to-end on bits-ui + shadcn-svelte (2297 files), paired A/B binaries interleaved in palindrome order, median of per-round deltas vs wave 2 (10/10 rounds each):

- **client-prod −15.3%**
- **client-dev −10.9%**
- **server-prod −12.0%**

## Changes (in order of impact)

- `ComponentNode` borrowed instead of owned: four construction sites deep-cloned the whole component subtree although `build_component` only reads `&node` (client-prod −7%).
- server `render_slot_body`: pass the slot children list directly instead of cloning them into a synthetic `Fragment` (`build_fragment_body` only reads `fragment.nodes`; four helpers generalized over `AsRef<TemplateNode>`) (server-prod −4.9%).
- client `visit_slot_children`: replace the `&[&TemplateNode]` → `Vec<TemplateNode>` deep clone with a private `NodeList` view + `clean_nodes_refs` (client-prod −4.6%).
- `strip_typescript`: probe the shared `declare ` prefix once (memchr) instead of three full scans for `declare global/module/namespace` — this also runs over entire SSR outputs (server-prod −3.3%).
- `is_bindable_valid_placement`: resolve `VariableDeclarator.init` from the arena instead of materializing the whole declarator via `as_value()` on every visit; adds a typed mirror because the existing `get_rune_from_node` resolves bindings through a different scope path and is not equivalent (client −2.0% / server −2.5%).

Investigated and dropped (measured too small): to_oxc comment double-pass (≤1%), `extract_metadata_from_tag` JsNode walk (1.24%), JsNode→JSON→JsNode roundtrip (~0.9%).

## Verification

- Output equivalence: 8,637 files × 3 modes = **25,911 outputs** across 6 corpora, digests of js / js-map / css / css-map / warnings — **zero diffs** per change and on the final tree; error paths matched byte-for-byte.
- `cargo test --release`: 3479 passed / 0 failed (exit 0).
- `cargo fmt` / `cargo clippy --all-targets --all-features -- -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)