### PR TITLE
ci: exercise the tsgo backend in CI + smoke-test the svelte-check npm launcher

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -670,6 +670,16 @@ jobs:
       - name: Run @rsvelte/svelte2tsx tests (sync API)
         run: pnpm --filter @rsvelte/svelte2tsx run test
 
+      # apps/npm/svelte-check/bin/svelte-check.cjs (the npm launcher) had zero
+      # tests (#1897 Layer 4 CI hygiene). Its smoke test drives the launcher
+      # against a locally built native binary via RSVELTE_CHECK_BIN, so build
+      # that binary first; debug is enough and this job never runs --release.
+      - name: Build rsvelte-check
+        run: cargo build -p rsvelte_check --bin svelte_check
+
+      - name: Run @rsvelte/svelte-check smoke test (npm launcher)
+        run: pnpm --filter @rsvelte/svelte-check run test
+
       - name: Generate oxlint-plugin recommended config
         run: pnpm run build:oxlint-plugin
 

--- a/.github/workflows/corpus-compat.yml
+++ b/.github/workflows/corpus-compat.yml
@@ -375,9 +375,20 @@ jobs:
         run: node scripts/compat-corpus/lint-verify.mjs
 
   check-parity:
-    name: svelte-check parity (official svelte-check)
+    name: svelte-check parity (official svelte-check vs ${{ matrix.backend }})
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        # The oracle (official svelte-check) is always tsc-based; only the
+        # rsvelte-check side under test switches backend. `tsgo` is rsvelte's
+        # other shipped backend (`rsvelte-check --tsgo`) and was, before this
+        # matrix, never exercised by any CI job (#1897 Layer 4). Measured
+        # locally: tsc and tsgo produce identical diagnostics across every
+        # scenario, so both legs ratchet against the same
+        # check-known-failures.json (see check-verify.mjs's BACKEND comment).
+        backend: [tsc, tsgo]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -401,6 +412,8 @@ jobs:
 
       - name: Cache cargo
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          shared-key: check-parity
 
       - name: Build rsvelte-check
         run: cargo build --release -p rsvelte_check
@@ -410,14 +423,23 @@ jobs:
       - name: Install check oracle (real svelte-check)
         run: npm --prefix scripts/compat-corpus/check-oracle install --no-package-lock
 
+      # Only the tsgo leg needs this: the tsc leg type-checks against the
+      # oracle's own tsc (scripts/compat-corpus/check-oracle), same as before
+      # this matrix existed.
+      - name: Install tsgo backend
+        if: matrix.backend == 'tsgo'
+        run: npm --prefix scripts/compat-corpus/check-tsgo install --no-package-lock
+
       - name: Verify svelte-check parity (ratchet against check-known-failures.json)
-        run: node scripts/compat-corpus/check-verify.mjs
+        run: node scripts/compat-corpus/check-verify.mjs --rsvelte-backend ${{ matrix.backend }}
 
       - name: Upload check report on failure
         if: failure()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: corpus-check-report
-          path: compatibility/check-report.json
+          name: corpus-check-report-${{ matrix.backend }}
+          path: |
+            compatibility/check-report.json
+            compatibility/check-report.tsgo.json
           if-no-files-found: ignore
           retention-days: 14

--- a/.gitignore
+++ b/.gitignore
@@ -152,7 +152,10 @@ compatibility/fmt-report.json
 # svelte-check diagnostic-parity gate (generated; check-known-failures.json is tracked)
 scripts/compat-corpus/check-oracle/node_modules/
 scripts/compat-corpus/check-oracle/package-lock.json
+scripts/compat-corpus/check-tsgo/node_modules/
+scripts/compat-corpus/check-tsgo/package-lock.json
 compatibility/check-report.json
+compatibility/check-report.tsgo.json
 
 # Dedicated CARGO_TARGET_DIRs used during Phase-3 corpus burndown (never commit)
 /target-ast/

--- a/apps/npm/svelte-check/bin/svelte-check.cjs
+++ b/apps/npm/svelte-check/bin/svelte-check.cjs
@@ -32,29 +32,39 @@ function resolveTriple() {
 	return null;
 }
 
-const triple = resolveTriple();
-if (!triple) {
-	console.error(
-		`[@rsvelte/svelte-check] Unsupported platform: ${process.platform}-${process.arch}.\n` +
-			`Open an issue at https://github.com/baseballyama/rsvelte/issues if you'd like this platform supported.`,
-	);
-	process.exit(1);
-}
-
-const pkgName = `@rsvelte/svelte-check-${triple}`;
-const binName = process.platform === 'win32' ? 'svelte-check.exe' : 'svelte-check';
+// Escape hatch for anything driving this launcher against a binary that
+// isn't the published platform package — e.g. the smoke test in `test/`
+// pointing it at a locally `cargo build`-ed `target/{release,debug}/svelte_check`.
+// Not documented as public API; it's a test seam, not a supported flag.
+const binOverride = process.env.RSVELTE_CHECK_BIN;
 
 let binPath;
-try {
-	binPath = require.resolve(`${pkgName}/${binName}`);
-} catch (err) {
-	console.error(
-		`[@rsvelte/svelte-check] Couldn't find the platform binary "${pkgName}".\n` +
-			`This usually means npm/pnpm skipped the optional dependency for your platform.\n` +
-			`Try reinstalling: npm install --include=optional ${pkgName}\n\n` +
-			`Original error: ${err.message}`,
-	);
-	process.exit(1);
+if (binOverride) {
+	binPath = binOverride;
+} else {
+	const triple = resolveTriple();
+	if (!triple) {
+		console.error(
+			`[@rsvelte/svelte-check] Unsupported platform: ${process.platform}-${process.arch}.\n` +
+				`Open an issue at https://github.com/baseballyama/rsvelte/issues if you'd like this platform supported.`,
+		);
+		process.exit(1);
+	}
+
+	const pkgName = `@rsvelte/svelte-check-${triple}`;
+	const binName = process.platform === 'win32' ? 'svelte-check.exe' : 'svelte-check';
+
+	try {
+		binPath = require.resolve(`${pkgName}/${binName}`);
+	} catch (err) {
+		console.error(
+			`[@rsvelte/svelte-check] Couldn't find the platform binary "${pkgName}".\n` +
+				`This usually means npm/pnpm skipped the optional dependency for your platform.\n` +
+				`Try reinstalling: npm install --include=optional ${pkgName}\n\n` +
+				`Original error: ${err.message}`,
+		);
+		process.exit(1);
+	}
 }
 
 // `pnpm pack` (used by `pnpm publish` and therefore `changeset publish` when

--- a/apps/npm/svelte-check/package.json
+++ b/apps/npm/svelte-check/package.json
@@ -26,6 +26,10 @@
     "bin/svelte-check.cjs",
     "lib/warning-filter.mjs"
   ],
+  "scripts": {
+    "pretest": "node test/setup-ts-toolchain.mjs",
+    "test": "node --test \"test/*.test.mjs\""
+  },
   "optionalDependencies": {
     "@rsvelte/svelte-check-darwin-arm64": "workspace:^",
     "@rsvelte/svelte-check-darwin-x64": "workspace:^",

--- a/apps/npm/svelte-check/test/bin.test.mjs
+++ b/apps/npm/svelte-check/test/bin.test.mjs
@@ -1,0 +1,139 @@
+// Smoke test for the npm entry point (bin/svelte-check.cjs), not for
+// rsvelte-check's diagnostics themselves — those are covered by
+// crates/rsvelte_check's own tests and by the corpus-compat.yml parity gate.
+// This only proves the JS launcher correctly resolves and execs the native
+// binary and passes its output/exit code straight through: #1897 Layer 4
+// noted apps/npm/svelte-check/bin/svelte-check.cjs had zero tests.
+//
+// The launcher normally resolves a platform-specific `@rsvelte/svelte-check-*`
+// optional dependency; here it's redirected at a locally `cargo build`-ed
+// binary via RSVELTE_CHECK_BIN (see bin/svelte-check.cjs).
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { existsSync, mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(here, '../../../..');
+const CLI = path.join(here, '../bin/svelte-check.cjs');
+const TSC = path.join(here, 'ts-toolchain/node_modules/.bin/tsc');
+
+/** Mirrors scripts/compat-corpus/check-verify.mjs's findBinary(). */
+function findNativeBinary() {
+	for (const profile of ['release', 'debug']) {
+		const p = path.join(ROOT, 'target', profile, 'svelte_check');
+		if (existsSync(p)) return p;
+	}
+	throw new Error(
+		'svelte_check binary not found; run `cargo build -p rsvelte_check --bin svelte_check` (or --release) first'
+	);
+}
+
+function findTsc() {
+	if (!existsSync(TSC)) {
+		throw new Error(`isolated tsc not found at ${TSC}; run \`node test/setup-ts-toolchain.mjs\` first`);
+	}
+	return TSC;
+}
+
+function run(cwd, args, env = {}) {
+	const bin = findNativeBinary();
+	try {
+		const stdout = execFileSync(process.execPath, [CLI, ...args], {
+			cwd,
+			encoding: 'utf8',
+			env: { ...process.env, RSVELTE_CHECK_BIN: bin, ...env }
+		});
+		return { status: 0, stdout };
+	} catch (err) {
+		// A diagnostic-bearing run exits non-zero; stdout still carries the report.
+		if (err.stdout === undefined) throw err;
+		return { status: err.status ?? 1, stdout: err.stdout };
+	}
+}
+
+function makeCleanProject() {
+	const dir = mkdtempSync(path.join(os.tmpdir(), 'rsvelte-check-smoke-clean-'));
+	mkdirSync(path.join(dir, 'src'), { recursive: true });
+	writeFileSync(path.join(dir, 'src/App.svelte'), '<script>\n\tlet count = 0;\n</script>\n\n<p>{count}</p>\n');
+	return dir;
+}
+
+function makeTypeErrorProject() {
+	const dir = mkdtempSync(path.join(os.tmpdir(), 'rsvelte-check-smoke-terr-'));
+	mkdirSync(path.join(dir, 'src'), { recursive: true });
+	writeFileSync(
+		path.join(dir, 'src/Bad.svelte'),
+		'<script lang="ts">\n\tconst count: number = \'not a number\';\n</script>\n\n<p>{count}</p>\n'
+	);
+	writeFileSync(
+		path.join(dir, 'tsconfig.json'),
+		JSON.stringify(
+			{
+				compilerOptions: {
+					target: 'esnext',
+					module: 'esnext',
+					moduleResolution: 'bundler',
+					strict: true,
+					skipLibCheck: true,
+					noEmit: true
+				},
+				include: ['src/**/*.ts', 'src/**/*.svelte']
+			},
+			null,
+			'\t'
+		)
+	);
+	return dir;
+}
+
+test('(a) exits 0 and prints the human-verbose summary for a clean project', () => {
+	const dir = makeCleanProject();
+	try {
+		const { status, stdout } = run(dir, ['--workspace', '.', '--no-type-check']);
+		assert.equal(status, 0, stdout);
+		assert.match(stdout, /svelte-check found 0 errors and 0 warnings in 1 file/);
+	} finally {
+		rmSync(dir, { recursive: true, force: true });
+	}
+});
+
+test('(b) --output machine-verbose emits epoch-prefixed START/COMPLETED lines', () => {
+	const dir = makeCleanProject();
+	try {
+		const { status, stdout } = run(dir, [
+			'--workspace',
+			'.',
+			'--no-type-check',
+			'--output',
+			'machine-verbose'
+		]);
+		assert.equal(status, 0, stdout);
+		const lines = stdout.trim().split('\n');
+		assert.ok(lines.length >= 2, `expected at least a START and a COMPLETED line:\n${stdout}`);
+		for (const line of lines) {
+			assert.match(line, /^\d+ /, `line missing epoch-ms prefix: ${line}`);
+		}
+		assert.match(lines[0], /^\d+ START "/);
+		assert.match(lines.at(-1), /^\d+ COMPLETED \d+ FILES \d+ ERRORS \d+ WARNINGS \d+ FILES_WITH_PROBLEMS$/);
+	} finally {
+		rmSync(dir, { recursive: true, force: true });
+	}
+});
+
+test('(c) an intentional TypeScript type error causes a non-zero exit', () => {
+	const dir = makeTypeErrorProject();
+	try {
+		const { status, stdout } = run(dir, ['--workspace', '.', '--tsconfig', 'tsconfig.json'], {
+			TSGO_BIN: findTsc()
+		});
+		assert.notEqual(status, 0, stdout);
+		assert.match(stdout, /svelte-check found [1-9]\d* errors?/, stdout);
+	} finally {
+		rmSync(dir, { recursive: true, force: true });
+	}
+});

--- a/apps/npm/svelte-check/test/setup-ts-toolchain.mjs
+++ b/apps/npm/svelte-check/test/setup-ts-toolchain.mjs
@@ -1,0 +1,19 @@
+// Dev/CI setup: installs the isolated `tsc` that test/bin.test.mjs's
+// intentional-type-error case injects via TSGO_BIN. Idempotent — skips the
+// install when a previous run (or a CI cache) already populated it. See
+// test/ts-toolchain/package.json for why this lives outside the pnpm
+// workspace.
+
+import { existsSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const dir = path.join(here, 'ts-toolchain');
+const tsc = path.join(dir, 'node_modules', '.bin', 'tsc');
+
+if (!existsSync(tsc)) {
+	console.log('setup-ts-toolchain: installing isolated tsc...');
+	execFileSync('npm', ['install', '--no-package-lock'], { cwd: dir, stdio: 'inherit' });
+}

--- a/apps/npm/svelte-check/test/ts-toolchain/package.json
+++ b/apps/npm/svelte-check/test/ts-toolchain/package.json
@@ -1,0 +1,8 @@
+{
+	"name": "rsvelte-svelte-check-smoke-ts-toolchain",
+	"private": true,
+	"description": "Isolated `tsc` install for apps/npm/svelte-check's launcher smoke test (test/bin.test.mjs), which needs a real TypeScript compiler to prove an intentional type error becomes a non-zero exit. Installed with --no-package-lock, same as scripts/compat-corpus/check-oracle and scripts/dev/type-aware-lint, so it stays outside the pnpm workspace (not under apps/npm/*) and never touches pnpm-lock.yaml. Unlike those two, this is not exact-pinned: the smoke test only exercises the CLI's argv/exit-code plumbing (bin/svelte-check.cjs -> the native binary), not diagnostic parity against an oracle, so a floating range is fine and skips Renovate PRs for a test-only toolchain. Matches the `typescript` version scripts/compat-corpus/check-oracle pins.",
+	"dependencies": {
+		"typescript": "^6.0.3"
+	}
+}

--- a/compatibility/check-known-failures.md
+++ b/compatibility/check-known-failures.md
@@ -18,6 +18,26 @@ positions back through its own source map and TypeScript wording moves between
 patch releases, so keying on them would make the ratchet churn without telling
 anyone anything. See the header of `check-verify.mjs`.
 
+## Backend matrix (tsc vs tsgo)
+
+`check-parity` in `corpus-compat.yml` runs this gate twice: `--rsvelte-backend
+tsc` (rsvelte-check type-checks with the oracle's own `tsc`, as before) and
+`--rsvelte-backend tsgo` (rsvelte-check type-checks with the pinned
+`@typescript/native-preview` in `scripts/compat-corpus/check-tsgo` — the other
+backend the product ships, `rsvelte-check --tsgo`, previously never exercised
+in CI; #1897 Layer 4). The oracle side is unconditionally `tsc`-based in both
+legs — only rsvelte-check's own backend switches.
+
+Measured locally across every scenario at the time the matrix landed: **tsc and
+tsgo produce byte-for-byte identical diagnostic sets** (down to file/line/code
+for every diagnostic in every scenario, `basic` included). Both legs therefore
+ratchet against the same `check-known-failures.json` rather than a
+backend-specific file — see the `BACKEND`/`KNOWN` comment in
+`check-verify.mjs` for the reasoning. If a real tsc/tsgo divergence is ever
+found, split the ratchet then (a `.tsgo.json` sibling, same shrink-only +
+per-entry-justification convention) rather than papering over it in the shared
+file.
+
 ## Current baseline: 0 entries / 0 surplus diagnostics — full parity
 
 The gate landed with 16 entries across the #1883–#1889 cluster and is now empty:

--- a/package.json
+++ b/package.json
@@ -72,9 +72,12 @@
 		"lint-corpus:update": "node scripts/compat-corpus/lint-verify.mjs --update",
 		"lint-corpus": "pnpm run lint-corpus:sync && pnpm run lint-corpus:oracle-install && pnpm run lint-corpus:collect && pnpm run lint-corpus:verify",
 		"check-corpus:oracle-install": "npm --prefix scripts/compat-corpus/check-oracle install --no-package-lock",
+		"check-corpus:tsgo-install": "npm --prefix scripts/compat-corpus/check-tsgo install --no-package-lock",
 		"check-corpus:verify": "node scripts/compat-corpus/check-verify.mjs",
+		"check-corpus:verify:tsgo": "node scripts/compat-corpus/check-verify.mjs --rsvelte-backend tsgo",
 		"check-corpus:update": "node scripts/compat-corpus/check-verify.mjs --update",
 		"test:svelte-check": "cargo build --release -p rsvelte_check && pnpm run check-corpus:oracle-install && pnpm run check-corpus:verify",
+		"test:svelte-check:tsgo": "cargo build --release -p rsvelte_check && pnpm run check-corpus:oracle-install && pnpm run check-corpus:tsgo-install && pnpm run check-corpus:verify:tsgo",
 		"changeset": "changeset",
 		"version-packages": "changeset version && pnpm run sync-version",
 		"release": "pnpm run sync-version && pnpm run build:wasm && pnpm run finalize-pkg && pnpm run publish-platform-binaries && pnpm run build:language-server && changeset publish"

--- a/scripts/compat-corpus/README.md
+++ b/scripts/compat-corpus/README.md
@@ -343,13 +343,24 @@ pnpm run check-corpus:verify           # diff oracle vs rsvelte-check, ratchet c
 # or, all of the above:
 pnpm run test:svelte-check
 pnpm run check-corpus:update           # re-baseline check-known-failures.json after a fix
+
+# rsvelte-check's *other* backend (rsvelte-check --tsgo). The oracle stays
+# tsc-based in both cases — only rsvelte-check's own compiler switches:
+pnpm run check-corpus:tsgo-install
+pnpm run test:svelte-check:tsgo
 ```
 
 - **Oracle** (`check-oracle/`) — an isolated package pinning `svelte-check`,
   `svelte`, `typescript` and `@sveltejs/kit` at **exact** versions. Its
   `node_modules` is symlinked into each materialised fixture and also supplies
-  the `tsc` that `rsvelte-check` runs (`TSGO_BIN`), so both sides type-check
-  against byte-identical dependencies.
+  the `tsc` that `rsvelte-check` runs (`TSGO_BIN`) by default, so both sides
+  type-check against byte-identical dependencies.
+- **tsgo backend** (`check-tsgo/`) — a separate isolated package pinning
+  `@typescript/native-preview` at an **exact** version, used only when
+  `check-verify.mjs --rsvelte-backend tsgo` points rsvelte-check's `TSGO_BIN`
+  at it instead of the oracle's `tsc`. Kept out of `check-oracle/` on purpose:
+  that directory is the ground-truth environment (never swapped), this one is
+  just the other backend under test.
 - **Scenarios** (`compatibility/check-fixtures/<name>/`) — `scenario.json`
   (workspace, `--tsconfig`, extra `node_modules` symlinks) plus a `project/`
   tree. Each encodes one real-world shape: single package, pnpm sibling via a
@@ -369,7 +380,8 @@ pnpm run check-corpus:update           # re-baseline check-known-failures.json a
   ` xN` suffix when the surplus is larger than one. Justifications live in
   [compatibility/check-known-failures.md](../../compatibility/check-known-failures.md).
 
-The `check-parity` job in `.github/workflows/corpus-compat.yml` runs this track;
+The `check-parity` job in `.github/workflows/corpus-compat.yml` runs this track
+as a `backend: [tsc, tsgo]` matrix (see [check-known-failures.md](../../compatibility/check-known-failures.md#backend-matrix-tsc-vs-tsgo));
 it needs no submodules.
 
 ## Adding a repository to the corpus

--- a/scripts/compat-corpus/check-tsgo/package.json
+++ b/scripts/compat-corpus/check-tsgo/package.json
@@ -1,0 +1,8 @@
+{
+	"name": "rsvelte-check-tsgo-backend",
+	"private": true,
+	"description": "Pins the tsgo binary that scripts/compat-corpus/check-verify.mjs's --rsvelte-backend tsgo mode points rsvelte-check at (TSGO_BIN). Deliberately separate from scripts/compat-corpus/check-oracle: that directory is the ORACLE environment (the real svelte-check + the svelte/typescript/@sveltejs/kit its diagnostics are produced against, always tsc-based, never swapped), whereas this one only supplies a backend for the RSVELTE side under test — swapping it changes what rsvelte-check runs against, not what the gate compares to. The version is EXACT on purpose, same rationale as scripts/dev/type-aware-lint/package.json: @typescript/native-preview publishes dated dev builds, and a floating range would let an upstream nightly move the tsgo-backend baseline with no change in this repo. Renovate tracks it like any other npm dep.",
+	"dependencies": {
+		"@typescript/native-preview": "7.0.0-dev.20260707.2"
+	}
+}

--- a/scripts/compat-corpus/check-verify.mjs
+++ b/scripts/compat-corpus/check-verify.mjs
@@ -40,6 +40,12 @@
  *   node scripts/compat-corpus/check-verify.mjs --show N       # print up to N new diffs
  *   node scripts/compat-corpus/check-verify.mjs --scenario a,b # restrict to scenarios
  *   node scripts/compat-corpus/check-verify.mjs --keep         # keep the temp workspaces
+ *   node scripts/compat-corpus/check-verify.mjs --rsvelte-backend tsgo
+ *                                                               # type-check the rsvelte
+ *                                                               # side with tsgo instead of
+ *                                                               # tsc (scripts/compat-corpus/
+ *                                                               # check-tsgo); the oracle side
+ *                                                               # is always tsc-based.
  */
 
 import fs from 'node:fs';
@@ -51,9 +57,8 @@ import { fileURLToPath } from 'node:url';
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '../..');
 const FIXTURES = path.join(ROOT, 'compatibility/check-fixtures');
-const KNOWN = path.join(ROOT, 'compatibility/check-known-failures.json');
-const REPORT = path.join(ROOT, 'compatibility/check-report.json');
 const ORACLE_DIR = path.join(__dirname, 'check-oracle');
+const TSGO_DIR = path.join(__dirname, 'check-tsgo');
 
 const args = process.argv.slice(2);
 const UPDATE = args.includes('--update');
@@ -62,6 +67,28 @@ const SHOW = args.includes('--show') ? Number(args[args.indexOf('--show') + 1] |
 const ONLY = args.includes('--scenario')
 	? new Set((args[args.indexOf('--scenario') + 1] || '').split(',').filter(Boolean))
 	: null;
+// Which compiler backend rsvelte-check itself type-checks with. The oracle
+// (real svelte-check) is unconditionally tsc-based regardless of this flag —
+// only the side under test switches. `tsc` keeps today's behaviour untouched;
+// `tsgo` is the product's other shipped backend (`rsvelte-check --tsgo`),
+// exercised nowhere else in CI (#1897 Layer 4).
+const BACKEND = args.includes('--rsvelte-backend')
+	? args[args.indexOf('--rsvelte-backend') + 1]
+	: 'tsc';
+if (BACKEND !== 'tsc' && BACKEND !== 'tsgo') {
+	fail(`--rsvelte-backend must be "tsc" or "tsgo", got "${BACKEND}"`);
+}
+// One ratchet shared by both backends: measured locally, tsc and tsgo produce
+// IDENTICAL diagnostic sets across every scenario (0 divergence either way —
+// see the tsc-vs-tsgo comparison in the PR that added `--rsvelte-backend`).
+// Splitting the file only pays off once the backends actually disagree; until
+// then a shared ratchet is simpler and a `tsgo`-only regression still fails
+// the gate (it shows up as a new divergence against the same known-good
+// baseline the `tsc` leg already cleared).
+const KNOWN = path.join(ROOT, 'compatibility/check-known-failures.json');
+// Report filename still varies by backend so a `--rsvelte-backend tsgo` run
+// doesn't clobber the `tsc` leg's debug artifact when run back-to-back locally.
+const REPORT = path.join(ROOT, `compatibility/check-report${BACKEND === 'tsgo' ? '.tsgo' : ''}.json`);
 
 function fail(msg) {
 	console.error(`[check-verify] ${msg}`);
@@ -96,6 +123,22 @@ function oracleModules() {
 		);
 	}
 	return nm;
+}
+
+/** Resolve the compiler binary rsvelte-check's TSGO_BIN should point at, per `--rsvelte-backend`. */
+function rsvelteCompiler(oracleNodeModules) {
+	if (BACKEND === 'tsc') {
+		const tsc = path.join(oracleNodeModules, '.bin/tsc');
+		if (!fs.existsSync(tsc)) return fail(`oracle typescript missing its tsc at ${tsc}`);
+		return tsc;
+	}
+	const tsgo = path.join(TSGO_DIR, 'node_modules/.bin/tsgo');
+	if (!fs.existsSync(tsgo)) {
+		return fail(
+			'tsgo backend not installed; run `npm --prefix scripts/compat-corpus/check-tsgo install --no-package-lock`'
+		);
+	}
+	return tsgo;
 }
 
 function scenarios() {
@@ -192,8 +235,8 @@ function diffCounts(scenario, oracle, rsvelte) {
 function main() {
 	const bin = findBinary();
 	const nodeModules = oracleModules();
-	const tsc = path.join(nodeModules, '.bin/tsc');
-	if (!fs.existsSync(tsc)) return fail(`oracle typescript missing its tsc at ${tsc}`);
+	const rsvelteTsBin = rsvelteCompiler(nodeModules);
+	console.log(`[check-verify] rsvelte-check backend: ${BACKEND} (${rsvelteTsBin})`);
 	const names = scenarios();
 	if (names.length === 0) return fail('no scenarios under compatibility/check-fixtures');
 
@@ -229,10 +272,18 @@ function main() {
 				path.join(oracleDir, ws)
 			)
 		);
+		// `TSGO_BIN` always wins over `--tsgo` (see tsgo.rs's `find_compiler`), so
+		// pointing it straight at the chosen binary is enough on its own; `--tsgo`
+		// is added too so the invocation matches how a real caller selects the
+		// backend and isn't relying on an implementation detail of the override.
+		const backendArgs = BACKEND === 'tsgo' ? ['--tsgo'] : [];
 		const actual = parseMachineVerbose(
-			runCapture(bin, ['--output', 'machine-verbose', ...common], path.join(actualDir, ws), {
-				TSGO_BIN: tsc
-			})
+			runCapture(
+				bin,
+				['--output', 'machine-verbose', ...common, ...backendArgs],
+				path.join(actualDir, ws),
+				{ TSGO_BIN: rsvelteTsBin }
+			)
 		);
 
 		diffs.push(...diffCounts(name, oracle.counts, actual.counts));


### PR DESCRIPTION
## Summary

Part of #1897 Layer 4 (CI hygiene), the last 2 of 3 checklist items:

- **Exercise the tsgo backend in CI.** `.github/workflows/ci.yml:280` pins `TSGO_BIN` to the submodule's `tsc` for the Rust integration-test job (`svelte_check_golden.rs`), which is correct and left untouched — but rsvelte-check's *other* shipped backend (`rsvelte-check --tsgo`, Microsoft's native `tsgo`) had never run in any CI job. `corpus-compat.yml`'s `check-parity` job is now a `backend: [tsc, tsgo]` matrix; the oracle (real `svelte-check`) stays `tsc`-based in both legs, only rsvelte-check's own backend switches.
- **Smoke-test `apps/npm/svelte-check/bin/svelte-check.cjs`.** The npm launcher had zero tests. It's now exercised by `apps/npm/svelte-check/test/bin.test.mjs` (`node --test`), wired into `ci.yml`'s `language-server` job next to the existing `@rsvelte/svelte2tsx` test step.

(The third Layer 4 item — hard-failing `svelte_check_golden.rs` under CI when no compiler is found — was already implemented; verified before starting this work.)

## tsc vs tsgo — local measurement

Ran `check-verify.mjs` against every scenario under `compatibility/check-fixtures/` with both backends (`cargo build --release -p rsvelte_check`, oracle + tsgo pins installed locally):

| Scenario | oracle diagnostics | rsvelte (tsc) | rsvelte (tsgo) |
|---|---|---|---|
| basic | 2 | 2 | 2 |
| boundary-elements | 0 | 0 | 0 |
| external-self-alias | 0 | 0 | 0 |
| kit-hooks-arrow-ts | 0 | 0 | 0 |
| kit-hooks-fn-ts | 0 | 0 | 0 |
| kit-hooks-js | 0 | 0 | 0 |
| kit-hooks-satisfies-ts | 0 | 0 | 0 |
| kit-routes-js | 0 | 0 | 0 |
| no-tsconfig | 0 | 0 | 0 |
| sibling-paths-alias | 0 | 0 | 0 |
| sibling-symlink | 0 | 0 | 0 |
| ts-aliased-import | 0 | 0 | 0 |

**0 divergence** in both directions across every scenario — tsc and tsgo produce byte-for-byte identical diagnostic sets (file/line/code) here. Negative-verified the gate itself (temporarily injected a fake divergence — confirmed exit 1 and the expected diff line; reverted).

## Design decisions

- **Shared ratchet, not a per-backend file.** Since the measured divergence is 0, both matrix legs ratchet against the same `compatibility/check-known-failures.json` rather than splitting it — simpler, and a `tsgo`-only regression still fails the gate (shows up as a new divergence against the same known-good baseline). Documented in `check-known-failures.md`'s new "Backend matrix" section; if a real tsc/tsgo divergence ever appears, split then.
- **`scripts/compat-corpus/check-tsgo/` is separate from `check-oracle/`.** `check-oracle` is the ground-truth environment (real `svelte-check` + the `svelte`/`typescript`/`@sveltejs/kit` its diagnostics are produced against) and is never swapped; `check-tsgo` only supplies the *other* backend for the *rsvelte* side under test. Pins `@typescript/native-preview` at an exact version, same pinning rationale as `scripts/dev/type-aware-lint/package.json` (dated dev builds; a floating range would let an upstream nightly move the baseline with no repo change).
- **`check-verify.mjs --rsvelte-backend tsc|tsgo`** resolves which binary `TSGO_BIN` should point rsvelte-check at, and adds `--tsgo` to the invocation for the tsgo leg (redundant with the `TSGO_BIN` override per `find_compiler`'s precedence, but matches how a real caller selects the backend rather than relying on an override implementation detail).
- **`RSVELTE_CHECK_BIN` launcher test seam.** `bin/svelte-check.cjs` normally resolves a platform `@rsvelte/svelte-check-<triple>` optional dependency; the smoke test redirects it at a locally `cargo build`-ed binary via this new env var (not documented as public API).
- **Isolated, non-exact-pinned `typescript` for the smoke test's type-error case** (`apps/npm/svelte-check/test/ts-toolchain/`), installed with `--no-package-lock` like `check-oracle`/`check-tsgo` so it stays outside the pnpm workspace. Not exact-pinned: the smoke test only exercises the CLI's argv/exit-code plumbing, not diagnostic parity, so a floating range is fine.

## Test plan

- [x] `node scripts/compat-corpus/check-verify.mjs` (tsc, default) — 0 divergences, matches existing empty ratchet.
- [x] `node scripts/compat-corpus/check-verify.mjs --rsvelte-backend tsgo` — 0 divergences.
- [x] Negative-verified the gate: temporarily injected a fake divergence into `check-verify.mjs`, confirmed exit 1 with the expected diff output, reverted.
- [x] `cd apps/npm/svelte-check && node test/setup-ts-toolchain.mjs && node --test "test/*.test.mjs"` — all 3 smoke tests pass.
- [x] Negative-verified the smoke test: temporarily broke an assertion, confirmed it fails with a clear diff, restored.
- [x] `cargo build -p rsvelte_check --bin svelte_check` (debug, matching the new ci.yml step) and `--release` both compile cleanly.
- [x] No Rust files touched — fmt/clippy not applicable. No changeset — `ci:`-prefixed title is exempt per `changeset.yml`.
- [ ] `pnpm --filter @rsvelte/svelte-check run test` and the `corpus-compat.yml` matrix itself run green in CI (local `pnpm` in this sandbox is blocked by an unrelated pnpm-self-management/minimum-release-age quirk; validated the equivalent `node`/`npm` invocations directly instead — see test plan above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JFL7CmMS1hd9sJA3yU4GTC