### PR TITLE
Optimize svelte2tsx front-end scans and retain parsed scripts

### DIFF
--- a/crates/rsvelte_core/src/ast/mod.rs
+++ b/crates/rsvelte_core/src/ast/mod.rs
@@ -9,7 +9,8 @@
 pub mod arena;
 pub mod css;
 pub mod js;
-pub(crate) mod oxc_program;
+#[doc(hidden)]
+pub mod oxc_program;
 pub mod span;
 pub mod template;
 pub mod typed_expr;

--- a/crates/rsvelte_core/src/ast/oxc_program.rs
+++ b/crates/rsvelte_core/src/ast/oxc_program.rs
@@ -24,7 +24,7 @@ struct ParsedProgram<'alloc> {
 }
 
 self_cell!(
-    pub(crate) struct RetainedProgram<'source> {
+    pub struct RetainedProgram<'source> {
         owner: ProgramOwner<'source>,
 
         #[covariant]
@@ -33,7 +33,7 @@ self_cell!(
 );
 
 impl<'source> RetainedProgram<'source> {
-    pub(crate) fn parse(source: &'source str, is_typescript: bool) -> Self {
+    pub fn parse(source: &'source str, is_typescript: bool) -> Self {
         let source_type = if is_typescript {
             SourceType::ts()
         } else {
@@ -57,19 +57,19 @@ impl<'source> RetainedProgram<'source> {
         )
     }
 
-    pub(crate) fn program(&self) -> &Program<'_> {
+    pub fn program(&self) -> &Program<'_> {
         &self.borrow_dependent().program
     }
 
-    pub(crate) fn source(&self) -> &str {
+    pub fn source(&self) -> &str {
         self.borrow_owner().source()
     }
 
-    pub(crate) fn diagnostics(&self) -> &[OxcDiagnostic] {
+    pub fn diagnostics(&self) -> &[OxcDiagnostic] {
         &self.borrow_dependent().diagnostics
     }
 
-    pub(crate) fn panicked(&self) -> bool {
+    pub fn panicked(&self) -> bool {
         self.borrow_dependent().panicked
     }
 }

--- a/crates/rsvelte_core/src/compiler/phases/1_parse/parser.rs
+++ b/crates/rsvelte_core/src/compiler/phases/1_parse/parser.rs
@@ -143,6 +143,13 @@ pub struct Parser<'a> {
 /// and the 8 MiB of a default main thread.
 pub const MAX_NESTING_DEPTH: u32 = 128;
 
+impl Parser<'_> {
+    #[inline]
+    pub(crate) fn should_defer_template_parse(&self) -> bool {
+        !self.script_ts && self.options.defer_script_parse
+    }
+}
+
 /// An entry on the parser stack.
 #[derive(Debug, Clone)]
 pub enum StackEntry {

--- a/crates/rsvelte_core/src/compiler/phases/1_parse/read/style.rs
+++ b/crates/rsvelte_core/src/compiler/phases/1_parse/read/style.rs
@@ -353,7 +353,7 @@ impl<'a> Parser<'a> {
         // by the underlying CSS parser (e.g. `css_expected_identifier` for
         // tokens like `$blue`) propagate to the user instead of being
         // silently dropped.
-        let css_children = if self.options.defer_script_parse {
+        let css_children = if self.should_defer_template_parse() {
             Vec::new() // Will be resolved by ensure_css_parsed() before analysis
         } else if lenient_non_css {
             // Non-CSS `lang` block in lint mode: the body is sass/scss/stylus/…,

--- a/crates/rsvelte_core/src/compiler/phases/1_parse/state/tag.rs
+++ b/crates/rsvelte_core/src/compiler/phases/1_parse/state/tag.rs
@@ -2257,7 +2257,7 @@ impl<'a> Parser<'a> {
         offset: usize,
     ) -> crate::error::ParseResult<Expression<'a>> {
         // In deferred mode, create a Lazy expression
-        if self.options.defer_script_parse {
+        if self.should_defer_template_parse() {
             let trimmed = content.trim_ws();
             if !trimmed.is_empty() {
                 let leading_ws = content.len() - content.trim_start().len();
@@ -2323,7 +2323,7 @@ impl<'a> Parser<'a> {
         trimmed_offset: usize,
         kind: LazyKind,
     ) -> Option<Expression<'a>> {
-        (self.options.defer_script_parse
+        (self.should_defer_template_parse()
             && !self.options.loose
             && !self.in_svelte_options
             && !trimmed.is_empty()

--- a/crates/rsvelte_projection/src/svelte2tsx/create_render_function.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/create_render_function.rs
@@ -21,6 +21,7 @@ use super::svelte2tsx::slice_src;
 )]
 pub(crate) fn create_render_function(
     ast: &Root,
+    module_program: Option<&oxc_ast::ast::Program>,
     source: &str,
     options: &Svelte2TsxOptions,
     str: &mut MagicString,
@@ -55,7 +56,8 @@ pub(crate) fn create_render_function(
         // ? lastImport.end + moduleAst.astOffset : moduleAst.astOffset` and the
         // accompanying `appendLeft(target, '\n')` for the no-imports case.
         if !hoistable_snippet_ranges.is_empty() {
-            let module_imports = find_instance_imports(module, source);
+            let module_imports =
+                find_instance_imports(module, source, module_program.expect("module script"));
             let module_hoist_target = match module_imports.last() {
                 Some(&(_, _, last_end)) => mod_content_start + last_end,
                 None => mod_content_start,
@@ -70,7 +72,8 @@ pub(crate) fn create_render_function(
 
         // For module-script-only components, inject store subscriptions for
         // module-level imports at the start of the $$render async wrapper.
-        let store_decls = super::script::collect_module_import_store_declarations(source);
+        let store_decls =
+            super::script::collect_module_import_store_declarations(source, module_program);
         // Suppress the `__sveltets_createSlot` binding in dts mode; matches
         // `createRenderFunction.ts`'s `slots.size > 0 && mode !== 'dts'` gate.
         let slot_decl_mod = if has_slot_elements && !is_dts_mode {

--- a/crates/rsvelte_projection/src/svelte2tsx/nodes/scripts.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/nodes/scripts.rs
@@ -43,11 +43,9 @@ pub(crate) fn find_script_close_tag_start(source: &str, script_end: u32) -> u32 
 pub(crate) fn find_instance_imports(
     script: &crate::ast::template::Script,
     source: &str,
+    program: &oxc_ast::ast::Program,
 ) -> Vec<(u32, u32, u32)> {
-    use oxc_allocator::Allocator;
     use oxc_ast::ast as oxc;
-    use oxc_parser::Parser as OxcParser;
-    use oxc_span::SourceType;
 
     let content_start = script.content_offset as usize;
     let script_source = slice_src(source, script.start as usize, script.end as usize);
@@ -65,23 +63,13 @@ pub(crate) fn find_instance_imports(
         return Vec::new();
     }
 
-    let allocator = Allocator::default();
-    // Always use TypeScript source type for import detection.
-    // TypeScript is a superset of JavaScript, so TS parsing handles
-    // both `import type` (TS syntax) and regular imports correctly,
-    // even when the script doesn't have `lang="ts"`.
-    let source_type = SourceType::ts();
-    let parser = OxcParser::new(&allocator, raw_content, source_type);
-    let result = parser.parse();
-
     // Comment spans (start, end) discovered by the parser, sorted by end. Used
     // to compute each import's leading-comment region the way TS
     // `getLeadingCommentRanges(node.getFullText())` does — including a TRAILING
     // line comment on the PREVIOUS statement's line (it is leading trivia of the
     // following import and moves up with it). The parser already tokenised
     // strings/regex correctly, so `// …` inside a string is never misread.
-    let comment_spans: Vec<(u32, u32)> = result
-        .program
+    let comment_spans: Vec<(u32, u32)> = program
         .comments
         .iter()
         .map(|c| (c.span.start, c.span.end))
@@ -89,7 +77,7 @@ pub(crate) fn find_instance_imports(
 
     let mut imports = Vec::new();
     let bytes = raw_content.as_bytes();
-    for stmt in result.program.body.iter() {
+    for stmt in program.body.iter() {
         if let oxc::Statement::ImportDeclaration(import) = stmt {
             // All import declarations (including side-effect imports like `import ''`)
             // should be lifted. The parser only creates ImportDeclaration nodes for
@@ -138,24 +126,15 @@ fn scan_back_leading_comments(bytes: &[u8], pos: usize, comment_spans: &[(u32, u
 
 /// Detect whether a script content contains top-level `await` expressions.
 ///
-/// Uses OXC to parse the content as a module (which allows top-level await)
-/// and checks for AwaitExpression at the top level of the program body.
-pub(crate) fn detect_top_level_await(content: &str) -> bool {
-    use oxc_allocator::Allocator;
+/// Checks the retained OXC program for AwaitExpression at the top level.
+pub(crate) fn detect_top_level_await(content: &str, program: &oxc_ast::ast::Program) -> bool {
     use oxc_ast::ast as oxc;
-    use oxc_parser::Parser as OxcParser;
-    use oxc_span::SourceType;
 
     // Fast path: an `await` substring is required for any top-level await
-    // to exist. Skip the OXC parse entirely when the keyword is absent.
+    // to exist. Skip the AST walk when the keyword is absent.
     if !contains_word(content.as_bytes(), b"await") {
         return false;
     }
-
-    let allocator = Allocator::default();
-    let source_type = SourceType::ts().with_module(true);
-    let parser = OxcParser::new(&allocator, content, source_type);
-    let result = parser.parse();
 
     // Mirror upstream `processInstanceScriptContent.ts` which sets
     // `hasTopLevelAwait = true` whenever an AwaitExpression is visited at the
@@ -174,7 +153,7 @@ pub(crate) fn detect_top_level_await(content: &str) -> bool {
     // For both, we use a deep recursive scan that stops at function
     // boundaries (`FunctionExpression` / `ArrowFunctionExpression`) — those
     // introduce a new scope and their inner `await` is NOT top-level.
-    for stmt in result.program.body.iter() {
+    for stmt in program.body.iter() {
         match stmt {
             oxc::Statement::VariableDeclaration(decl) => {
                 for declarator in decl.declarations.iter() {

--- a/crates/rsvelte_projection/src/svelte2tsx/process_instance_script_tag.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/process_instance_script_tag.rs
@@ -29,6 +29,7 @@ use super::svelte2tsx::slice_src;
 )]
 pub(crate) fn process_instance_script_tag(
     ast: &Root,
+    instance_program: &oxc_ast::ast::Program,
     source: &str,
     options: &Svelte2TsxOptions,
     str: &mut MagicString,
@@ -55,7 +56,8 @@ pub(crate) fn process_instance_script_tag(
     // official does NOT detect its top-level `await` / wrap `$$render` in
     // `async`; mirror that (the awaits stay in the raw, oxfmt-skipped output).
     let script_parse_failed = !instance.raw_content.is_empty();
-    let has_top_level_await = !script_parse_failed && detect_top_level_await(raw_content);
+    let has_top_level_await =
+        !script_parse_failed && detect_top_level_await(raw_content, instance_program);
     if has_top_level_await {
         exported_names.set_uses_runes(true);
     }
@@ -121,7 +123,7 @@ pub(crate) fn process_instance_script_tag(
     };
 
     // Find import declarations in the instance script content
-    let imports = find_instance_imports(instance, source);
+    let imports = find_instance_imports(instance, source, instance_program);
 
     let has_imports = !imports.is_empty();
     // Lift imports above $$render(): each import is collected individually

--- a/crates/rsvelte_projection/src/svelte2tsx/script/mod.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/script/mod.rs
@@ -4,9 +4,7 @@
 //! Extracts exported names, component events, and prop declarations to generate
 //! proper TypeScript type information.
 //!
-//! Script AST is obtained by re-parsing the raw script content via OXC and walking
-//! the OXC AST directly. This avoids dependency on the thread-local ParseArena
-//! used by the main compiler, keeping svelte2tsx self-contained.
+//! Script AST is parsed once with OXC and retained across every processing pass.
 
 mod ast_utils;
 mod component_events;
@@ -48,6 +46,7 @@ use hoistable_types::{
     is_special_type_name, resolve_hoistable_type_decls, rewrite_interface_to_type_dts,
 };
 use parse::with_parsed_script;
+pub(crate) use parse::{ParsedScript, ParsedScripts};
 use props_rune::{
     PropsRuneInfo, apply_props_typedef, collect_props_rune_info, detect_props_rune_oxc,
 };
@@ -97,6 +96,8 @@ pub fn classify_kit_route_file(basename: &str) -> Option<bool> {
 /// - Store subscriptions
 pub fn process_instance_script(
     script: &Script,
+    parsed: &ParsedScript<'_>,
+    module_program: Option<&oxc::Program<'_>>,
     source: &str,
     str: &mut MagicString,
     exported_names: &mut ExportedNames,
@@ -108,7 +109,7 @@ pub fn process_instance_script(
     script_generic_names: &HashSet<String>,
 ) {
     let offset = script.content_offset;
-    with_parsed_script(script, source, |program, raw_content| {
+    with_parsed_script(parsed, |program, raw_content| {
         // Pass 1: collect top-level declared names and possible exports
         let mut possible_exports: HashMap<String, PossibleExport> = HashMap::new();
         // Pre-populate with ALL top-level declared names so rune-vs-store
@@ -718,7 +719,7 @@ pub fn process_instance_script(
 
         // Pass 5: store subscriptions. Reuses the already-parsed program
         // so we don't re-parse the instance script content with OXC.
-        inject_store_subscriptions_with_program(program, offset, source, str);
+        inject_store_subscriptions_with_program(program, module_program, offset, source, str);
 
         // Pass 6: disambiguate generic arrow type-parameter lists for the
         // `.tsx` overlay (`<T>` → `<T,>`) so they aren't misparsed as JSX.
@@ -746,6 +747,7 @@ pub fn process_instance_script(
 /// * `exported_names` - Accumulator for exported names
 pub fn process_module_script(
     script: &Script,
+    parsed: &ParsedScript<'_>,
     source: &str,
     str: &mut MagicString,
     exported_names: &mut ExportedNames,
@@ -757,7 +759,7 @@ pub fn process_module_script(
     // store-subscription injection, type-assertion rewrite, name snapshot).
     // Parse once and share the program across all three passes.
     let offset = script.content_offset;
-    with_parsed_script(script, source, |program, raw_content| {
+    with_parsed_script(parsed, |program, raw_content| {
         // Inject store subscriptions for module-level variable declarations
         // only. Import-based store subscriptions are NOT injected here
         // because they need to go inside the $$render function body.

--- a/crates/rsvelte_projection/src/svelte2tsx/script/parse.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/script/parse.rs
@@ -1,40 +1,54 @@
-//! Script-content extraction and OXC re-parsing.
+//! Retained OXC programs shared by every script-processing pass.
 
-use oxc_allocator::Allocator;
 use oxc_ast::ast as oxc;
-use oxc_parser::Parser as OxcParser;
-use oxc_span::SourceType;
 
-use crate::ast::template::Script;
+use crate::ast::oxc_program::RetainedProgram;
+use crate::ast::template::Root;
 
-use super::super::svelte2tsx::slice_src;
+pub(crate) struct ParsedScript<'source> {
+    retained: RetainedProgram<'source>,
+}
 
-/// Extract the raw script content from the source and parse it with OXC,
-/// then invoke the callback with the parsed program.
-///
-/// This approach avoids lifetime issues since the OXC allocator and parsed
-/// program are created and consumed within the closure scope.
-pub(super) fn with_parsed_script<F>(script: &Script, source: &str, f: F)
+impl<'source> ParsedScript<'source> {
+    fn new(script: &mut crate::ast::template::Script<'source>) -> Self {
+        let retained = RetainedProgram::parse(script.raw_content, true);
+        // raw_content doubles as the lenient script-parse failure marker.
+        if retained.diagnostics().is_empty() {
+            script.raw_content = "";
+        }
+        Self { retained }
+    }
+
+    pub(crate) fn program(&self) -> &oxc::Program<'_> {
+        self.retained.program()
+    }
+
+    pub(crate) fn source(&self) -> &str {
+        self.retained.source()
+    }
+}
+
+pub(crate) struct ParsedScripts<'source> {
+    pub(crate) instance: Option<ParsedScript<'source>>,
+    pub(crate) module: Option<ParsedScript<'source>>,
+}
+
+impl<'source> ParsedScripts<'source> {
+    pub(crate) fn new(ast: &mut Root<'source>) -> Self {
+        Self {
+            instance: ast
+                .instance
+                .as_mut()
+                .map(|script| ParsedScript::new(script)),
+            module: ast.module.as_mut().map(|script| ParsedScript::new(script)),
+        }
+    }
+}
+
+#[inline]
+pub(super) fn with_parsed_script<F>(script: &ParsedScript<'_>, f: F)
 where
     F: FnOnce(&oxc::Program, &str),
 {
-    let content_start = script.content_offset as usize;
-    // Find the end of script content: from content_offset to the start of </script>
-    let script_source = slice_src(source, script.start as usize, script.end as usize);
-    let close_tag_offset = script_source
-        .rfind("</script>")
-        .or_else(|| script_source.rfind("</Script>"))
-        .unwrap_or(script_source.len());
-    let content_end = script.start as usize + close_tag_offset;
-    let raw_content = &source[content_start..content_end];
-
-    let allocator = Allocator::default();
-    // Always use TypeScript source type. TypeScript is a superset of JavaScript,
-    // so TS parsing handles both TS syntax (like `import type`, type annotations)
-    // and regular JS correctly, even when the script doesn't have `lang="ts"`.
-    let source_type = SourceType::ts();
-    let parser = OxcParser::new(&allocator, raw_content, source_type);
-    let result = parser.parse();
-
-    f(&result.program, raw_content);
+    f(script.program(), script.source());
 }

--- a/crates/rsvelte_projection/src/svelte2tsx/script/stores.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/script/stores.rs
@@ -5,11 +5,8 @@ use std::collections::HashMap;
 use std::collections::HashSet;
 use std::fmt::Write as _;
 
-use oxc_allocator::Allocator;
 use oxc_ast::ast as oxc;
 use oxc_ast_visit::Visit;
-use oxc_parser::Parser as OxcParser;
-use oxc_span::SourceType;
 
 use super::ast_utils::{collect_binding_names, extract_all_names_from_binding_pattern};
 use super::reactive::extract_names_from_labeled_body;
@@ -610,6 +607,7 @@ pub(super) fn collect_self_named_rune_call_positions(
 /// once and pass the result here, avoiding a second OXC parse).
 pub(super) fn inject_store_subscriptions_with_program(
     program: &oxc::Program,
+    module_program: Option<&oxc::Program>,
     offset: u32,
     source: &str,
     str: &mut MagicString,
@@ -703,7 +701,7 @@ pub(super) fn inject_store_subscriptions_with_program(
         }
     }
 
-    collect_module_script_import_stores(source, &accessed_stores, &mut import_store_names);
+    collect_module_script_import_stores(module_program, &accessed_stores, &mut import_store_names);
 
     // Official `attachStoreValueDeclarationOfImportsToRenderFn` iterates
     // `importStatements` in IMPORT-DECLARATION order (not first-`$store`-use
@@ -775,36 +773,15 @@ fn collect_import_store_names(
 /// This allows the instance script to inject store subscriptions for module-level
 /// imports at the $$render function body start.
 fn collect_module_script_import_stores(
-    source: &str,
+    program: Option<&oxc::Program>,
     accessed_stores: &HashSet<String>,
     import_store_names: &mut Vec<String>,
 ) {
-    // Fast path: no `<script` substring → no module script.
-    if !source.contains("<script") {
-        return;
-    }
-    // Locate the module script body. `find_module_script_span` matches BOTH
-    // `<script context="module">` and the Svelte 5 `<script module>` shorthand
-    // (the old regex only matched the `context=` form, so `<script module>`
-    // imports used as stores were never injected).
-    let (content_start, close_tag) = match find_module_script_span(source) {
-        Some(span) => span,
+    let program = match program {
+        Some(program) => program,
         None => return,
     };
-
-    let raw_content = &source[content_start..close_tag];
-
-    // Skip the OXC parse when there are no `import` declarations to find.
-    if !raw_content.contains("import") {
-        return;
-    }
-
-    let allocator = Allocator::default();
-    let source_type = SourceType::mjs();
-    let parser = OxcParser::new(&allocator, raw_content, source_type);
-    let result = parser.parse();
-
-    for stmt in result.program.body.iter() {
+    for stmt in program.body.iter() {
         if let oxc::Statement::ImportDeclaration(import) = stmt {
             collect_import_store_names(import, accessed_stores, import_store_names);
         }
@@ -817,14 +794,17 @@ fn collect_module_script_import_stores(
 /// module-script import names that are used as stores (`$name`) in the source
 /// and returns the store subscription declarations string to inject at the
 /// start of the $$render async wrapper.
-pub fn collect_module_import_store_declarations(source: &str) -> String {
+pub fn collect_module_import_store_declarations(
+    source: &str,
+    module_program: Option<&oxc::Program>,
+) -> String {
     let accessed_stores = collect_store_references(source);
     if accessed_stores.is_empty() {
         return String::new();
     }
 
     let mut import_store_names: Vec<String> = Vec::new();
-    collect_module_script_import_stores(source, &accessed_stores, &mut import_store_names);
+    collect_module_script_import_stores(module_program, &accessed_stores, &mut import_store_names);
 
     import_store_names.sort();
     import_store_names.dedup();

--- a/crates/rsvelte_projection/src/svelte2tsx/svelte2tsx.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/svelte2tsx.rs
@@ -274,8 +274,13 @@ pub fn svelte2tsx(
     // (`{@debug user.firstname}` / `{@debug a[0]}`) at PARSE time. rsvelte does
     // this in the analyze DebugTag visitor, which svelte2tsx never runs — so
     // replicate it here to preserve error-parity with official svelte2tsx.
-    validate_debug_tag_arguments(&ast, source)?;
-    validate_meta_element_placement(&ast, source)?;
+    let (has_debug_marker, has_meta_marker) = validation_markers(source);
+    if has_debug_marker {
+        validate_debug_tag_arguments(&ast, source)?;
+    }
+    if has_meta_marker {
+        validate_meta_element_placement(&ast, source)?;
+    }
 
     // Step 2: Determine component name from filename
     let component_name = derive_component_name(&options.filename);
@@ -648,4 +653,30 @@ pub fn svelte2tsx(
         events,
         forward_map,
     })
+}
+
+fn validation_markers(source: &str) -> (bool, bool) {
+    let bytes = source.as_bytes();
+    let mut has_debug = false;
+    let mut has_meta = false;
+
+    for index in memchr::memchr2_iter(b'@', b':', bytes) {
+        match bytes[index] {
+            b'@' => {
+                has_debug =
+                    index > 0 && bytes.get(index - 1..index + 6) == Some(b"{@debug".as_slice());
+            }
+            b':' => {
+                has_meta = (index >= 7
+                    && bytes.get(index - 7..=index) == Some(b"<svelte:".as_slice()))
+                    || (index >= 3 && bytes.get(index - 3..=index) == Some(b"use:".as_slice()));
+            }
+            _ => unreachable!(),
+        }
+        if has_debug && has_meta {
+            break;
+        }
+    }
+
+    (has_debug, has_meta)
 }

--- a/crates/rsvelte_projection/src/svelte2tsx/svelte2tsx.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/svelte2tsx.rs
@@ -663,13 +663,17 @@ fn validation_markers(source: &str) -> (bool, bool) {
     for index in memchr::memchr2_iter(b'@', b':', bytes) {
         match bytes[index] {
             b'@' => {
-                has_debug =
-                    index > 0 && bytes.get(index - 1..index + 6) == Some(b"{@debug".as_slice());
+                if !has_debug {
+                    has_debug =
+                        index > 0 && bytes.get(index - 1..index + 6) == Some(b"{@debug".as_slice());
+                }
             }
             b':' => {
-                has_meta = (index >= 7
-                    && bytes.get(index - 7..=index) == Some(b"<svelte:".as_slice()))
-                    || (index >= 3 && bytes.get(index - 3..=index) == Some(b"use:".as_slice()));
+                if !has_meta {
+                    has_meta = (index >= 7
+                        && bytes.get(index - 7..=index) == Some(b"<svelte:".as_slice()))
+                        || (index >= 3 && bytes.get(index - 3..=index) == Some(b"use:".as_slice()));
+                }
             }
             _ => unreachable!(),
         }
@@ -679,4 +683,18 @@ fn validation_markers(source: &str) -> (bool, bool) {
     }
 
     (has_debug, has_meta)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::validation_markers;
+
+    #[test]
+    fn validation_markers_remain_set_after_unrelated_candidates() {
+        assert_eq!(validation_markers("{@debug user.name} @"), (true, false));
+        assert_eq!(
+            validation_markers("<div><svelte:window /></div>:"),
+            (false, true)
+        );
+    }
 }

--- a/crates/rsvelte_projection/src/svelte2tsx/svelte2tsx.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/svelte2tsx.rs
@@ -262,13 +262,14 @@ pub fn svelte2tsx(
         modern: true,
         loose: false,
         skip_expression_loc: false,
-        defer_script_parse: false,
+        defer_script_parse: true,
         force_typescript: false,
         lenient_script: false,
         skip_non_css_lang_style: false,
         capture_comments: false,
     };
-    let ast = phase1_parse::parse_script_ts(&parse_source, parse_options)?;
+    let mut ast = phase1_parse::parse_script_ts(&parse_source, parse_options)?;
+    let parsed_scripts = super::script::ParsedScripts::new(&mut ast);
 
     // svelte rejects `{@debug expr}` whose arguments are not plain identifiers
     // (`{@debug user.firstname}` / `{@debug a[0]}`) at PARSE time. rsvelte does
@@ -300,8 +301,8 @@ pub fn svelte2tsx(
     }
 
     // Step 6: Process module script (<script context="module">)
-    if let Some(ref module) = ast.module {
-        super::script::process_module_script(module, source, &mut str, &mut exported_names);
+    if let (Some(module), Some(parsed)) = (&ast.module, &parsed_scripts.module) {
+        super::script::process_module_script(module, parsed, source, &mut str, &mut exported_names);
     }
 
     // Step 7: Process instance script (<script>)
@@ -328,9 +329,14 @@ pub fn svelte2tsx(
                 .collect::<std::collections::HashSet<String>>()
         })
         .unwrap_or_default();
-    if let Some(ref instance) = ast.instance {
+    if let (Some(instance), Some(parsed)) = (&ast.instance, &parsed_scripts.instance) {
         super::script::process_instance_script(
             instance,
+            parsed,
+            parsed_scripts
+                .module
+                .as_ref()
+                .map(|script| script.program()),
             source,
             &mut str,
             &mut exported_names,
@@ -546,6 +552,11 @@ pub fn svelte2tsx(
     if has_instance_script {
         has_top_level_await = process_instance_script_tag(
             &ast,
+            parsed_scripts
+                .instance
+                .as_ref()
+                .expect("instance script")
+                .program(),
             source,
             &options,
             &mut str,
@@ -586,6 +597,10 @@ pub fn svelte2tsx(
 
     create_render_function(
         &ast,
+        parsed_scripts
+            .module
+            .as_ref()
+            .map(|script| script.program()),
         source,
         &options,
         &mut str,
@@ -596,6 +611,7 @@ pub fn svelte2tsx(
         &hoistable_snippet_ranges,
         &embedded_script_content,
     );
+    drop(parsed_scripts);
 
     let closing = add_component_export(
         ComponentExportParams {

--- a/crates/rsvelte_projection/src/svelte2tsx/utils/htmlxparser.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/utils/htmlxparser.rs
@@ -336,7 +336,64 @@ fn collect_html_tag_ranges(fragment: &crate::ast::template::Fragment, out: &mut 
 /// Returns a list of `(start, end, inner_content)` triples, where `start`/`end`
 /// are byte offsets in `source` and `inner_content` is the raw text between
 /// `<script…>` and `</script>`.
+fn only_has_top_level_script_candidates(ast: &Root, source: &str) -> bool {
+    only_has_script_candidates_in_ranges(
+        source,
+        ast.instance
+            .as_ref()
+            .map(|script| (script.start, script.end)),
+        ast.module.as_ref().map(|script| (script.start, script.end)),
+    )
+}
+
+fn only_has_script_candidates_in_ranges(
+    source: &str,
+    instance: Option<(u32, u32)>,
+    module: Option<(u32, u32)>,
+) -> bool {
+    let bytes = source.as_bytes();
+    let mut search = 0;
+
+    while search < bytes.len() {
+        let Some(relative_start) = memchr::memchr(b'<', &bytes[search..]) else {
+            break;
+        };
+        let tag_start = search + relative_start;
+        search = tag_start + 1;
+        let Some(tag) = bytes.get(tag_start..tag_start + 7) else {
+            continue;
+        };
+        if !tag.eq_ignore_ascii_case(b"<script") {
+            continue;
+        }
+
+        let after = bytes.get(tag_start + 7).copied();
+        search = tag_start + 7;
+        if !matches!(
+            after,
+            Some(b'>') | Some(b' ') | Some(b'\t') | Some(b'\n') | Some(b'\r') | Some(b'/') | None
+        ) {
+            continue;
+        }
+
+        let tag_start = tag_start as u32;
+        if ![instance, module]
+            .into_iter()
+            .flatten()
+            .any(|(start, end)| tag_start == start || (tag_start > start && tag_start < end))
+        {
+            return false;
+        }
+    }
+
+    true
+}
+
 fn find_orphan_scripts(ast: &Root, source: &str) -> Vec<(u32, u32, String)> {
+    if only_has_top_level_script_candidates(ast, source) {
+        return Vec::new();
+    }
+
     // 1. Collect known "legitimate" script start positions and their full ranges.
     let mut known_starts: std::collections::HashSet<u32> = std::collections::HashSet::default();
     // Also collect ranges of instance/module scripts so we can skip `<script>`
@@ -428,7 +485,27 @@ fn find_orphan_scripts(ast: &Root, source: &str) -> Vec<(u32, u32, String)> {
 
 #[cfg(test)]
 mod tests {
-    use super::{blank_style_content, find_ci};
+    use super::*;
+    use crate::compiler::phases::phase1_parse::{self, ParseOptions};
+
+    fn parse(source: &str) -> Root<'_> {
+        phase1_parse::parse_script_ts(
+            source,
+            ParseOptions {
+                modern: true,
+                ..Default::default()
+            },
+        )
+        .expect("fixture should parse")
+    }
+
+    fn can_skip(source: &str) -> bool {
+        only_has_top_level_script_candidates(&parse(source), source)
+    }
+
+    fn orphans(source: &str) -> Vec<(u32, u32, String)> {
+        find_orphan_scripts(&parse(source), source)
+    }
 
     #[test]
     fn case_insensitive_search_preserves_utf8_byte_offsets() {
@@ -479,5 +556,57 @@ mod tests {
                 .collect::<Vec<_>>()
         );
         assert!(!blanked.contains("color"));
+    }
+
+    #[test]
+    fn orphan_script_fast_path_accepts_templates_without_script_candidates() {
+        assert!(can_skip("<main><h1>Hello</h1><scripted /></main>"));
+    }
+
+    #[test]
+    fn orphan_script_fast_path_accepts_top_level_scripts_and_inner_candidates() {
+        let source = r#"<script context="module">
+const module_marker = "<SCRIPT data-marker>";
+</script>
+<script>
+const instance_marker = `<script data-marker>`;
+</script>
+<main>Hello</main>"#;
+        assert!(can_skip(source));
+    }
+
+    #[test]
+    fn orphan_script_fast_path_defers_uppercase_and_nested_scripts() {
+        let uppercase = "<SCRIPT>console.log('upper')</SCRIPT>";
+        let nested = "<main><script>console.log('nested')</script></main>";
+        assert!(!can_skip(uppercase));
+        assert!(!can_skip(nested));
+        assert_eq!(orphans(uppercase)[0].2, "console.log('upper')");
+        assert!(orphans(nested).is_empty());
+    }
+
+    #[test]
+    fn orphan_script_fast_path_defers_raw_html_and_comments() {
+        let raw_html = r#"{@html "<script>raw</script>"}"#;
+        let comment = "<!-- <script>comment</script> -->";
+        assert!(!can_skip(raw_html));
+        assert!(!can_skip(comment));
+        assert!(orphans(raw_html).is_empty());
+        assert_eq!(orphans(comment)[0].2, "comment");
+    }
+
+    #[test]
+    fn orphan_script_fast_path_defers_attribute_and_malformed_candidates() {
+        assert!(!only_has_script_candidates_in_ranges(
+            r#"<noscript><a href="</noscript><script>orphan</script>">link</a>"#,
+            None,
+            None,
+        ));
+        assert!(!only_has_script_candidates_in_ranges(
+            r#"<div data-script="<script data-x>">value</div>"#,
+            None,
+            None,
+        ));
+        assert!(!only_has_script_candidates_in_ranges("<script", None, None,));
     }
 }

--- a/crates/rsvelte_projection/src/svelte2tsx/utils/htmlxparser.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/utils/htmlxparser.rs
@@ -16,10 +16,29 @@ fn find_ci(haystack: &[u8], from: usize, needle: &[u8]) -> Option<usize> {
     if from > haystack.len() {
         return None;
     }
-    haystack[from..]
-        .windows(needle.len())
-        .position(|w| w.eq_ignore_ascii_case(needle))
-        .map(|p| from + p)
+    assert!(!needle.is_empty());
+    let last_start = haystack.len().checked_sub(needle.len())?;
+    if from > last_start {
+        return None;
+    }
+
+    let first_lower = needle[0].to_ascii_lowercase();
+    let first_upper = needle[0].to_ascii_uppercase();
+    let mut search = from;
+    while search <= last_start {
+        let candidates = &haystack[search..=last_start];
+        let offset = if first_lower == first_upper {
+            memchr::memchr(first_lower, candidates)
+        } else {
+            memchr::memchr2(first_lower, first_upper, candidates)
+        }?;
+        let candidate = search + offset;
+        if haystack[candidate..candidate + needle.len()].eq_ignore_ascii_case(needle) {
+            return Some(candidate);
+        }
+        search = candidate + 1;
+    }
+    None
 }
 
 /// Replace the content of every `<style …>…</style>` with spaces (newlines and
@@ -405,4 +424,60 @@ fn find_orphan_scripts(ast: &Root, source: &str) -> Vec<(u32, u32, String)> {
     }
 
     result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{blank_style_content, find_ci};
+
+    #[test]
+    fn case_insensitive_search_preserves_utf8_byte_offsets() {
+        let source = "前😀<STYLE>色</StYlE>後";
+        let open = source.find("<STYLE>").unwrap();
+        let close = source.find("</StYlE>").unwrap();
+
+        assert_eq!(find_ci(source.as_bytes(), 0, b"<style"), Some(open));
+        assert_eq!(
+            find_ci(source.as_bytes(), open + 1, b"</style>"),
+            Some(close)
+        );
+        assert_eq!(find_ci(source.as_bytes(), close + 1, b"<style"), None);
+    }
+
+    #[test]
+    fn search_skips_partial_candidates_and_honors_start_offset() {
+        let source = "<stale><StYlInG><style lang=\"scss\">";
+        let expected = source.find("<style lang").unwrap();
+
+        assert_eq!(find_ci(source.as_bytes(), 0, b"<style"), Some(expected));
+        assert_eq!(find_ci(source.as_bytes(), expected + 1, b"<style"), None);
+        assert_eq!(find_ci(source.as_bytes(), 0, b">"), source.find('>'));
+        assert_eq!(
+            find_ci(source.as_bytes(), source.len() + 1, b"<style"),
+            None
+        );
+    }
+
+    #[test]
+    fn style_blanking_keeps_unicode_offsets_and_line_endings() {
+        let source = "前<STYLE lang=\"x\">色 {\r\n color: red;\n}</StYlE>後";
+        let blanked = blank_style_content(source);
+
+        assert_eq!(blanked.len(), source.len());
+        assert!(blanked.starts_with("前<STYLE lang=\"x\">"));
+        assert!(blanked.ends_with("</StYlE>後"));
+        assert_eq!(
+            blanked
+                .bytes()
+                .enumerate()
+                .filter_map(|(index, byte)| matches!(byte, b'\r' | b'\n').then_some((index, byte)))
+                .collect::<Vec<_>>(),
+            source
+                .bytes()
+                .enumerate()
+                .filter_map(|(index, byte)| matches!(byte, b'\r' | b'\n').then_some((index, byte)))
+                .collect::<Vec<_>>()
+        );
+        assert!(!blanked.contains("color"));
+    }
 }

--- a/crates/rsvelte_projection/tests/svelte2tsx_validation_walk_gates.rs
+++ b/crates/rsvelte_projection/tests/svelte2tsx_validation_walk_gates.rs
@@ -1,0 +1,56 @@
+use rsvelte_projection::svelte2tsx::{Svelte2TsxOptions, svelte2tsx};
+
+fn error(source: &str) -> String {
+    svelte2tsx(source, Svelte2TsxOptions::default())
+        .expect_err("fixture should fail")
+        .to_string()
+}
+
+#[test]
+fn validation_markers_preserve_debug_and_meta_errors() {
+    assert!(error("{@debug user.name}").contains("arguments must be identifiers"));
+    assert!(error("<div><svelte:window /></div>").contains("cannot be inside"));
+    assert!(error("<svelte:window /><svelte:window />").contains("only have one"));
+    assert!(error("<svelte:element />").contains("must have a 'this' attribute"));
+}
+
+#[test]
+fn validation_markers_preserve_component_action_errors() {
+    assert!(error("<Component use:action />").contains("directive is not valid"));
+    assert!(
+        error("<svelte:component this={Component} use:action />")
+            .contains("directive is not valid")
+    );
+}
+
+#[test]
+fn validation_false_positive_markers_are_harmless() {
+    let source = r#"<script>
+const markers = ["{@debug", "<svelte:", "use:"];
+</script>
+<style>/* {@debug <svelte: use: */</style>
+<!-- {@debug <svelte: use: -->
+<p>{markers.length}</p>"#;
+
+    svelte2tsx(source, Svelte2TsxOptions::default()).expect("markers are not template nodes");
+}
+
+#[test]
+fn debug_error_keeps_precedence_over_meta_error() {
+    let source = "<div><svelte:window /></div>{@debug user.name}";
+    assert!(error(source).contains("arguments must be identifiers"));
+}
+
+#[test]
+fn deeply_nested_template_without_markers_converts() {
+    let mut source = String::new();
+    for _ in 0..32 {
+        source.push_str("{#if ready}<div>");
+    }
+    source.push_str("{value}");
+    for _ in 0..32 {
+        source.push_str("</div>{/if}");
+    }
+
+    svelte2tsx(&source, Svelte2TsxOptions::default()).expect("marker-free template should convert");
+}


### PR DESCRIPTION
> Stack 1/8  
> Base: `main` (`af1fa166`)  
> Head: `agent/svelte2tsx-release-01-front-end` (`e0196d5f`)

## Summary

- vectorize case-insensitive tag candidate searches
- avoid redundant orphan-script walks
- gate sparse validation traversals while retaining discovered marker state
- parse instance and module scripts once and retain their OXC programs across
  projection passes

This is the front-end foundation for the remaining svelte2tsx optimization
stack. It preserves byte offsets, diagnostic precedence, recovered-program
behavior, and raw-script fallback markers.

## Commit scope

- `8986eb4f` perf(svelte2tsx): vectorize tag searches
- `0c2466f8` perf(svelte2tsx): skip redundant orphan script walks
- `f99ce2f3` perf(svelte2tsx): gate sparse validation walks
- `9d68afd7` fix(svelte2tsx): retain discovered validation markers
- `e0196d5f` perf(svelte2tsx): retain script programs across passes

No alternate topic-branch commits are included.

## Validation

- [ ] `cargo fmt --check`
- [ ] `cargo clippy -p rsvelte_projection --all-targets --all-features -- -D warnings`
- [ ] `cargo test -p rsvelte_projection --test svelte2tsx_validation_walk_gates`
- [ ] `cargo test -p rsvelte_projection --test svelte2tsx_fixtures`
- [ ] `cargo test -p rsvelte_projection`

## Stack order

Merge this PR first. PR 2 is based on this head.
