### PR TITLE
Consolidate svelte2tsx script, store, and type analysis

### DIFF
--- a/crates/rsvelte_projection/src/svelte2tsx/create_render_function.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/create_render_function.rs
@@ -10,6 +10,7 @@ use super::interfaces::{Svelte2TsxMode, Svelte2TsxOptions};
 use super::magic_string::MagicString;
 use super::nodes::scripts::find_instance_imports;
 use super::nodes::slot::{collect_slot_names_from_ast, escape_js_single_quoted};
+use super::script::StoreScanContext;
 use super::svelte2tsx::slice_src;
 
 /// Prepend the reference-types header and open the `$$render()` wrapper.
@@ -23,6 +24,7 @@ pub(crate) fn create_render_function(
     ast: &Root,
     module_program: Option<&oxc_ast::ast::Program>,
     source: &str,
+    store_scan: &mut StoreScanContext<'_>,
     options: &Svelte2TsxOptions,
     str: &mut MagicString,
     dollar_decls: &str,
@@ -73,7 +75,7 @@ pub(crate) fn create_render_function(
         // For module-script-only components, inject store subscriptions for
         // module-level imports at the start of the $$render async wrapper.
         let store_decls =
-            super::script::collect_module_import_store_declarations(source, module_program);
+            super::script::collect_module_import_store_declarations(store_scan, module_program);
         // Suppress the `__sveltets_createSlot` binding in dts mode; matches
         // `createRenderFunction.ts`'s `slots.size > 0 && mode !== 'dts'` gate.
         let slot_decl_mod = if has_slot_elements && !is_dts_mode {

--- a/crates/rsvelte_projection/src/svelte2tsx/process_instance_script_tag.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/process_instance_script_tag.rs
@@ -328,8 +328,7 @@ pub(crate) fn process_instance_script_tag(
         // BEFORE the interface that depends on it, even when it appears
         // later in source. Sorting by start position would wrongly
         // restore source order.
-        let type_ranges = exported_names.hoistable_type_ranges.clone();
-        for (s, e) in type_ranges {
+        for &(s, e) in &exported_names.hoistable_type_ranges {
             if s < e && (e as usize) <= source.len() {
                 // `prepend_right` / `append_left` add to the moved
                 // chunk itself (intro / outro of the [s..e] chunk),
@@ -356,9 +355,9 @@ pub(crate) fn process_instance_script_tag(
         // `node.getStart()` (no leading trivia) and ends the chunk
         // with `\n` so the following text in `part_b` (`function
         // $$render`) starts on its own line.
-        let mut nodes_to_move = exported_names.dollar_generic_referenced_ranges.clone();
-        nodes_to_move.sort_by_key(|(s, _)| *s);
-        for (s, e) in nodes_to_move {
+        // `hoist_dollar_generic_referenced_types` filters the source-ordered
+        // candidate list, matching upstream `InterfacesAndTypes.all.filter`.
+        for &(s, e) in &exported_names.dollar_generic_referenced_ranges {
             if s < e && (e as usize) <= source.len() {
                 str.prepend_right(s, "\n");
                 str.append_left(e, "\n");

--- a/crates/rsvelte_projection/src/svelte2tsx/script/ast_utils.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/script/ast_utils.rs
@@ -162,13 +162,39 @@ pub(super) fn module_export_name_to_string(name: &oxc::ModuleExportName) -> Stri
 /// initializer was checked, over-detecting runes. Mirrors upstream
 /// `ImplicitStoreValues` / `checkGlobalsForRunes`.
 pub(super) fn collect_top_level_declared_names(body: &[oxc::Statement]) -> HashSet<String> {
+    fn add_binding(pattern: &oxc::BindingPattern, names: &mut HashSet<String>) {
+        if let oxc::BindingPattern::BindingIdentifier(id) = pattern {
+            names.insert(id.name.to_string());
+            return;
+        }
+        visit_binding_names(pattern, &mut |name| {
+            names.insert(name.to_string());
+        });
+    }
+
     fn add_var(vd: &oxc::VariableDeclaration, names: &mut HashSet<String>) {
         for d in vd.declarations.iter() {
-            for n in extract_all_names_from_binding_pattern(&d.id) {
-                names.insert(n);
-            }
+            add_binding(&d.id, names);
         }
     }
+
+    fn add_declaration(decl: &oxc::Declaration, names: &mut HashSet<String>) {
+        match decl {
+            oxc::Declaration::VariableDeclaration(vd) => add_var(vd, names),
+            oxc::Declaration::FunctionDeclaration(f) => {
+                if let Some(id) = &f.id {
+                    names.insert(id.name.to_string());
+                }
+            }
+            oxc::Declaration::ClassDeclaration(c) => {
+                if let Some(id) = &c.id {
+                    names.insert(id.name.to_string());
+                }
+            }
+            _ => {}
+        }
+    }
+
     let mut names = HashSet::new();
     for stmt in body {
         match stmt {
@@ -211,20 +237,7 @@ pub(super) fn collect_top_level_declared_names(body: &[oxc::Statement]) -> HashS
             }
             oxc::Statement::ExportNamedDeclaration(ex) => {
                 if let Some(decl) = &ex.declaration {
-                    match decl {
-                        oxc::Declaration::VariableDeclaration(vd) => add_var(vd, &mut names),
-                        oxc::Declaration::FunctionDeclaration(f) => {
-                            if let Some(id) = &f.id {
-                                names.insert(id.name.to_string());
-                            }
-                        }
-                        oxc::Declaration::ClassDeclaration(c) => {
-                            if let Some(id) = &c.id {
-                                names.insert(id.name.to_string());
-                            }
-                        }
-                        _ => {}
-                    }
+                    add_declaration(decl, &mut names);
                 }
             }
             _ => {}
@@ -245,28 +258,35 @@ pub(super) fn extract_all_names_from_binding_pattern(pattern: &oxc::BindingPatte
 }
 
 pub(super) fn collect_binding_names(pattern: &oxc::BindingPattern, names: &mut Vec<String>) {
+    visit_binding_names(pattern, &mut |name| names.push(name.to_string()));
+}
+
+fn visit_binding_names<F>(pattern: &oxc::BindingPattern, visit: &mut F)
+where
+    F: FnMut(&str),
+{
     match pattern {
         oxc::BindingPattern::BindingIdentifier(id) => {
-            names.push(id.name.to_string());
+            visit(id.name.as_str());
         }
         oxc::BindingPattern::ObjectPattern(obj) => {
             for prop in obj.properties.iter() {
-                collect_binding_names(&prop.value, names);
+                visit_binding_names(&prop.value, visit);
             }
             if let Some(ref rest) = obj.rest {
-                collect_binding_names(&rest.argument, names);
+                visit_binding_names(&rest.argument, visit);
             }
         }
         oxc::BindingPattern::ArrayPattern(arr) => {
             for el in arr.elements.iter().flatten() {
-                collect_binding_names(el, names);
+                visit_binding_names(el, visit);
             }
             if let Some(ref rest) = arr.rest {
-                collect_binding_names(&rest.argument, names);
+                visit_binding_names(&rest.argument, visit);
             }
         }
         oxc::BindingPattern::AssignmentPattern(assign) => {
-            collect_binding_names(&assign.left, names);
+            visit_binding_names(&assign.left, visit);
         }
     }
 }

--- a/crates/rsvelte_projection/src/svelte2tsx/script/ast_utils.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/script/ast_utils.rs
@@ -115,9 +115,11 @@ pub(super) fn extract_names_from_binding_pattern_full(
 }
 
 /// Get a simple name from a binding pattern (only works for BindingIdentifier).
-pub(super) fn binding_pattern_simple_name(pattern: &oxc::BindingPattern) -> Option<String> {
+pub(super) fn binding_pattern_simple_name<'a>(
+    pattern: &'a oxc::BindingPattern<'_>,
+) -> Option<&'a str> {
     match pattern {
-        oxc::BindingPattern::BindingIdentifier(id) => Some(id.name.to_string()),
+        oxc::BindingPattern::BindingIdentifier(id) => Some(id.name.as_str()),
         _ => None,
     }
 }
@@ -356,5 +358,34 @@ fn collect_assignment_target_names(target: &oxc::AssignmentTarget, names: &mut V
             }
         }
         _ => {}
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use oxc_allocator::Allocator;
+    use oxc_parser::Parser;
+    use oxc_span::SourceType;
+
+    use super::{binding_pattern_simple_name, oxc};
+
+    #[test]
+    fn simple_binding_name_borrows_the_ast_identifier() {
+        let allocator = Allocator::default();
+        let parsed = Parser::new(&allocator, "let exported = 1;", SourceType::mjs()).parse();
+        let oxc::Statement::VariableDeclaration(declaration) = &parsed.program.body[0] else {
+            panic!("expected variable declaration");
+        };
+        let pattern = &declaration.declarations[0].id;
+        let oxc::BindingPattern::BindingIdentifier(identifier) = pattern else {
+            panic!("expected binding identifier");
+        };
+
+        let name = binding_pattern_simple_name(pattern).unwrap();
+        assert_eq!(name, "exported");
+        assert!(std::ptr::eq(
+            name.as_ptr(),
+            identifier.name.as_str().as_ptr()
+        ));
     }
 }

--- a/crates/rsvelte_projection/src/svelte2tsx/script/component_events.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/script/component_events.rs
@@ -249,7 +249,7 @@ pub(super) fn detect_create_event_dispatcher(
             // call sites can be scanned — and order-gated against this position —
             // to populate the events return.
             let decl_pos = content_offset + declarator.span.start;
-            events.dispatcher_decls.push((name, decl_pos));
+            events.dispatcher_decls.push((name.to_owned(), decl_pos));
             // Record the callee end (before `(`) so a `$$Events` interface can
             // inject `<__sveltets_2_CustomEvents<$$Events>>` onto the untyped call.
             events

--- a/crates/rsvelte_projection/src/svelte2tsx/script/export_decl.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/script/export_decl.rs
@@ -107,7 +107,7 @@ pub(super) fn handle_export_named_decl(
                         // Update the type annotation on the exported name
                         if let Some(ref ta_text) = type_annotation_text
                             && let Some(name) = binding_pattern_simple_name(&declarator.id)
-                            && let Some(info) = exported_names.get_mut(&name)
+                            && let Some(info) = exported_names.get_mut(name)
                         {
                             info.type_annotation = Some(ta_text.clone());
                         }
@@ -121,7 +121,7 @@ pub(super) fn handle_export_named_decl(
                         if let Some(name) = binding_pattern_simple_name(&declarator.id)
                             && let Some(ref doc) = leading_doc
                         {
-                            exported_names.set_doc(&name, doc.clone());
+                            exported_names.set_doc(name, doc.clone());
                         }
                         // For multi-declarator let exports (export let a, b, c;),
                         // replace the comma between declarators with `;let `.
@@ -177,12 +177,12 @@ pub(super) fn handle_export_named_decl(
                             binding_pattern_simple_name(&declarator.id).and_then(|name| {
                                 classify_kit_route_file(basename).and_then(|layout| {
                                     if !is_let {
-                                        match name.as_str() {
+                                        match name {
                                             "snapshot" => Some("import('./$types.js').Snapshot"),
                                             _ => None,
                                         }
                                     } else {
-                                        match (name.as_str(), layout) {
+                                        match (name, layout) {
                                             ("data", true) => {
                                                 Some("import('./$types.js').LayoutData")
                                             }

--- a/crates/rsvelte_projection/src/svelte2tsx/script/hoistable_types.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/script/hoistable_types.rs
@@ -59,16 +59,18 @@ pub(super) fn is_special_type_name(name: &str) -> bool {
 /// actually matter for the hoist decision. The JS reference uses TS AST
 /// walking to be exact; this lexical filter matches its decisions on the
 /// fixtures the rsvelte port currently cares about.
-pub(super) fn collect_type_body_deps(
-    body: &str,
+pub(super) fn collect_type_body_deps<'a>(
+    body: &'a str,
     candidate_indices: &FxHashMap<&str, u32>,
     self_name: &str,
-    generics: &HashSet<String>,
+    generics: &FxHashSet<&str>,
+    script_generic_names: &HashSet<String>,
     instance_value_names: &HashSet<String>,
     instance_import_names: &HashSet<String>,
-) -> (HashSet<String>, FxHashSet<u32>) {
-    let mut value_deps: HashSet<String> = HashSet::new();
-    let mut type_deps: FxHashSet<u32> = FxHashSet::default();
+) -> (FxHashSet<&'a str>, FxHashSet<u32>, bool) {
+    let mut value_deps = FxHashSet::default();
+    let mut type_deps = FxHashSet::default();
+    let mut references_script_generic = false;
     let bytes = body.as_bytes();
     let len = bytes.len();
     let mut i = 0usize;
@@ -151,9 +153,11 @@ pub(super) fn collect_type_body_deps(
                 && (bytes[k] == b':' || (bytes[k] == b'?' && k + 1 < len && bytes[k + 1] == b':'));
 
             if preceded_by_typeof {
-                value_deps.insert(ident.to_string());
+                value_deps.insert(ident);
             } else if is_property_key {
                 // skip — property keys aren't dependencies
+            } else if script_generic_names.contains(ident) {
+                references_script_generic = true;
             } else if let Some(&candidate_index) = candidate_indices.get(ident) {
                 type_deps.insert(candidate_index);
             } else if instance_value_names.contains(ident) && !instance_import_names.contains(ident)
@@ -163,13 +167,13 @@ pub(super) fn collect_type_body_deps(
                 // import. Even outside a `typeof`, mentioning such a name
                 // inside a type body forbids hoisting because hoisting would
                 // place the type at module scope where the binding is gone.
-                value_deps.insert(ident.to_string());
+                value_deps.insert(ident);
             }
             continue;
         }
         i += 1;
     }
-    (value_deps, type_deps)
+    (value_deps, type_deps, references_script_generic)
 }
 
 /// Returns `true` for TypeScript / JavaScript reserved keywords that can
@@ -406,10 +410,10 @@ pub(super) fn resolve_hoistable_type_decls(
     }
     // Per-candidate: collect generic parameter names (so `interface Props<T>`
     // doesn't see `T` as a dependency).
-    let generics: Vec<HashSet<String>> = candidates
+    let generics: Vec<FxHashSet<&str>> = candidates
         .iter()
         .map(|c| {
-            let mut g = HashSet::new();
+            let mut g = FxHashSet::default();
             // Look at the text between `name` and the first `{` / `=`. If a
             // `<...>` block exists in that range, parse comma-separated entries
             // and take their leading identifier.
@@ -423,8 +427,16 @@ pub(super) fn resolve_hoistable_type_decls(
                 .map(|p| s + p)
                 .unwrap_or(e);
             let header = &raw_content[s..header_end];
-            if let (Some(lt), Some(gt)) = (header.find('<'), header.rfind('>'))
+            let generic_start = header.find(&c.name).map(|name_start| {
+                let mut position = name_start + c.name.len();
+                while position < header.len() && header.as_bytes()[position].is_ascii_whitespace() {
+                    position += 1;
+                }
+                position
+            });
+            if let (Some(lt), Some(gt)) = (generic_start, header.rfind('>'))
                 && lt < gt
+                && header.as_bytes()[lt] == b'<'
             {
                 let inner = &header[lt + 1..gt];
                 for part in inner.split(',') {
@@ -434,7 +446,7 @@ pub(super) fn resolve_hoistable_type_decls(
                         .find(|s| !s.is_empty())
                         .unwrap_or("");
                     if !name.is_empty() {
-                        g.insert(name.to_string());
+                        g.insert(name);
                     }
                 }
                 // type_deps are limited to candidate_indices by
@@ -446,7 +458,7 @@ pub(super) fn resolve_hoistable_type_decls(
         .collect();
 
     // Pre-compute deps for each candidate.
-    let deps: Vec<(HashSet<String>, FxHashSet<u32>)> = candidates
+    let deps: Vec<(FxHashSet<&str>, FxHashSet<u32>, bool)> = candidates
         .iter()
         .enumerate()
         .map(|(i, c)| {
@@ -458,6 +470,7 @@ pub(super) fn resolve_hoistable_type_decls(
                 &candidate_indices,
                 &c.name,
                 &generics[i],
+                script_generic_names,
                 &exported_names.instance_value_names,
                 &exported_names.instance_import_names,
             )
@@ -480,31 +493,16 @@ pub(super) fn resolve_hoistable_type_decls(
     // parameter name. Hoisting them out of `function $$render<T>(){...}` would
     // put them at module scope where `T` no longer exists.
     if !script_generic_names.is_empty() {
-        for (i, c) in candidates.iter().enumerate() {
-            if blocked[i] {
-                continue;
-            }
-            let s = c.rel_start as usize;
-            let e = c.rel_end.min(raw_content.len() as u32) as usize;
-            if s >= e {
-                continue;
-            }
-            let body = &raw_content[s..e];
-            for name in script_generic_names.iter() {
-                if has_whole_ident(body, name) {
-                    blocked[i] = true;
-                    break;
-                }
-                // A type dep that isn't a local candidate is an outside
-                // reference (import / global) — fine to reference from a hoisted
-                // declaration.
+        for (i, (_, _, references_script_generic)) in deps.iter().enumerate() {
+            if !blocked[i] && *references_script_generic {
+                blocked[i] = true;
             }
         }
     }
     // Initial blocked: candidates with a value_dep that isn't allowed.
     // "Allowed" = NOT in instance_value_names except imports, OR in any
     // module-script set (module-script bindings are stable references).
-    for (i, (value_deps, _)) in deps.iter().enumerate() {
+    for (i, (value_deps, _, _)) in deps.iter().enumerate() {
         if blocked[i] {
             continue;
         }
@@ -516,10 +514,10 @@ pub(super) fn resolve_hoistable_type_decls(
                 if !stripped.is_empty() && !stripped.starts_with('$') {
                     stripped
                 } else {
-                    v.as_str()
+                    v
                 }
             } else {
-                v.as_str()
+                v
             };
             let in_instance_value = exported_names.instance_value_names.contains(resolved);
             let in_instance_import = exported_names.instance_import_names.contains(resolved);
@@ -545,7 +543,7 @@ pub(super) fn resolve_hoistable_type_decls(
     // emits `B` first). We mirror that by emitting `hoistable_type_ranges` in
     // promotion order rather than source order.
     let (hoistable, hoist_order) =
-        resolve_candidate_dependencies(deps.iter().map(|(_, deps)| deps), &mut blocked);
+        resolve_candidate_dependencies(deps.iter().map(|(_, deps, _)| deps), &mut blocked);
 
     // Gate the entire move on the props interface being hoistable. Mirrors
     // `HoistableInterfaces.moveHoistableInterfaces`, which only moves anything
@@ -572,26 +570,18 @@ pub(super) fn resolve_hoistable_type_decls(
         // hoistable iff every type dependency is a hoistable candidate (or an
         // outside reference such as an import) AND it doesn't reference a
         // `<script generics=...>` parameter and has no disallowed value deps.
-        let (value_deps, type_deps) = collect_type_body_deps(
+        let (value_deps, type_deps, references_script_generic) = collect_type_body_deps(
             inline,
             &candidate_indices,
             // No self-name for the synthetic interface.
             "",
             // No own generics on the synthetic props interface.
-            &HashSet::new(),
+            &FxHashSet::default(),
+            script_generic_names,
             &exported_names.instance_value_names,
             &exported_names.instance_import_names,
         );
-        let mut ok = true;
-        // Generic references make the synthetic props interface non-hoistable.
-        if !script_generic_names.is_empty() {
-            for g in script_generic_names.iter() {
-                if has_whole_ident(inline, g) {
-                    ok = false;
-                    break;
-                }
-            }
-        }
+        let mut ok = !references_script_generic;
         if ok {
             for &idx in &type_deps {
                 let idx = idx as usize;
@@ -780,32 +770,6 @@ fn find_line_comment_start(line: &[u8]) -> Option<usize> {
     None
 }
 
-/// Return true if `text` contains `name` as a whole identifier (not as a
-/// substring of a longer one).
-fn has_whole_ident(text: &str, name: &str) -> bool {
-    if name.is_empty() {
-        return false;
-    }
-    let bytes = text.as_bytes();
-    let nbytes = name.as_bytes();
-    if nbytes.len() > bytes.len() {
-        return false;
-    }
-    let mut i = 0usize;
-    while i + nbytes.len() <= bytes.len() {
-        if &bytes[i..i + nbytes.len()] == nbytes {
-            let before_ok = i == 0 || !is_ident_byte(bytes[i - 1]);
-            let after_idx = i + nbytes.len();
-            let after_ok = after_idx == bytes.len() || !is_ident_byte(bytes[after_idx]);
-            if before_ok && after_ok {
-                return true;
-            }
-        }
-        i += 1;
-    }
-    false
-}
-
 /// Rewrite a top-level `interface X { ... }` (with optional `extends Y, Z`)
 /// into `type X = Y & Z & { ... }` for dts-mode output. Indirectly using
 /// interfaces inside the return type of a function is forbidden by the
@@ -900,6 +864,8 @@ pub(super) fn rewrite_interface_to_type_dts(
 
 #[cfg(test)]
 mod tests {
+    use std::fmt::Write as _;
+
     use super::*;
     use crate::svelte2tsx::svelte2tsx::{Svelte2TsxOptions, Svelte2TsxResult, svelte2tsx};
 
@@ -1078,12 +1044,109 @@ mod tests {
             \u{20}\u{20}/** \u{753B}\u{50CF} (content='image' \u{306E}\u{5834}\u{5408}\u{306B}\u{5FC5}\u{9808}) */\n\
             \u{20}\u{20}imageSrc?: string;\n}";
         let candidates: FxHashMap<&str, u32> = FxHashMap::default();
-        let generics: HashSet<String> = HashSet::new();
+        let generics = FxHashSet::default();
+        let script_generics = HashSet::new();
         let values: HashSet<String> = HashSet::new();
         let imports: HashSet<String> = HashSet::new();
         // Must not panic.
-        let (_value_deps, _type_deps) =
-            collect_type_body_deps(body, &candidates, "Props", &generics, &values, &imports);
+        let (_value_deps, _type_deps, _references_script_generic) = collect_type_body_deps(
+            body,
+            &candidates,
+            "Props",
+            &generics,
+            &script_generics,
+            &values,
+            &imports,
+        );
+    }
+
+    #[test]
+    fn dependency_tokens_ignore_unicode_trivia_keys_keywords_and_candidate_generics() {
+        let body = "type Props<Local> = {\n\
+            /** 日本語 T type */\n\
+            T: 'T';\n\
+            type: Local;\n\
+            wrapped: Wrapper;\n\
+            value: typeof local_value;\n\
+        }";
+        let candidates = FxHashMap::from_iter([("Props", 0), ("Wrapper", 1)]);
+        let generics = FxHashSet::from_iter(["Local"]);
+        let script_generics = HashSet::from(["T".to_string(), "type".to_string()]);
+        let values = HashSet::from(["local_value".to_string()]);
+        let imports = HashSet::new();
+
+        let (value_deps, type_deps, references_script_generic) = collect_type_body_deps(
+            body,
+            &candidates,
+            "Props",
+            &generics,
+            &script_generics,
+            &values,
+            &imports,
+        );
+
+        assert_eq!(value_deps, FxHashSet::from_iter(["local_value"]));
+        assert_eq!(type_deps, FxHashSet::from_iter([1]));
+        assert!(!references_script_generic);
+        let value = value_deps.iter().next().unwrap();
+        let body_start = body.as_ptr() as usize;
+        let value_start = value.as_ptr() as usize;
+        assert!((body_start..body_start + body.len()).contains(&value_start));
+    }
+
+    #[test]
+    fn candidate_generic_shadows_script_generic_when_hoisting() {
+        let source = "<script lang=\"ts\" generics=\"T\">\n\
+            type Local<T> = { value: T };\n\
+            type Props = { item: Local<string> };\n\
+            let { item }: Props = $props();\n\
+            </script>\n\
+            <p>{item.value}</p>";
+        let out = svelte2tsx(source, Svelte2TsxOptions::default())
+            .expect("svelte2tsx ok")
+            .code;
+        let local = out.find("type Local").expect("emits Local");
+        let props = out.find("type Props").expect("emits Props");
+        let render = out.find("function $$render").expect("has $$render");
+        assert!(local < props && props < render, "{out}");
+    }
+
+    #[test]
+    fn large_reverse_dependency_graph_keeps_official_order_with_unicode_trivia() {
+        const TYPE_COUNT: usize = 256;
+        let mut source = String::from("<script lang=\"ts\" generics=\"T\">\n");
+        for index in 0..TYPE_COUNT - 1 {
+            writeln!(
+                source,
+                "// 日本語 T appears only in trivia\ntype T{index} = {{ value: T{} }};\n",
+                index + 1
+            )
+            .unwrap();
+        }
+        write!(
+            source,
+            "// 日本語 T appears only in trivia\ntype T{} = string;\n\
+             type Props = {{ value: T0 }};\n\
+             let {{ value }}: Props = $props();\n\
+             </script>\n<p>{{value}}</p>",
+            TYPE_COUNT - 1
+        )
+        .unwrap();
+
+        let out = svelte2tsx(&source, Svelte2TsxOptions::default())
+            .expect("svelte2tsx ok")
+            .code;
+        let render = out.find("function $$render").expect("has $$render");
+        let mut previous = 0;
+        for index in (0..TYPE_COUNT).rev() {
+            let position = out
+                .find(&format!("type T{index} ="))
+                .unwrap_or_else(|| panic!("missing T{index}"));
+            assert!(position > previous && position < render, "T{index}: {out}");
+            previous = position;
+        }
+        let props = out.find("type Props").expect("emits Props");
+        assert!(props > previous && props < render, "{out}");
     }
 
     #[test]

--- a/crates/rsvelte_projection/src/svelte2tsx/script/hoistable_types.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/script/hoistable_types.rs
@@ -1,9 +1,9 @@
 //! Hoisting of instance-script `type` / `interface` declarations above
 //! `function $$render()`, plus the dts-mode interface→type rewrite.
 
-use std::collections::HashSet;
+use std::collections::{HashSet, VecDeque};
 
-use rustc_hash::FxHashMap;
+use rustc_hash::{FxHashMap, FxHashSet};
 #[cfg(test)]
 use std::cell::Cell;
 
@@ -12,23 +12,23 @@ use super::ExportedNames;
 
 #[cfg(test)]
 thread_local! {
-    static FIXED_POINT_LOOKUPS: Cell<usize> = const { Cell::new(0) };
+    static DEPENDENCY_EDGES: Cell<usize> = const { Cell::new(0) };
 }
 
 #[inline(always)]
-fn record_fixed_point_lookup() {
+fn record_dependency_edge() {
     #[cfg(test)]
-    FIXED_POINT_LOOKUPS.with(|lookups| lookups.set(lookups.get() + 1));
+    DEPENDENCY_EDGES.with(|edges| edges.set(edges.get() + 1));
 }
 
 #[cfg(test)]
-fn reset_fixed_point_lookups() {
-    FIXED_POINT_LOOKUPS.with(|lookups| lookups.set(0));
+fn reset_dependency_edges() {
+    DEPENDENCY_EDGES.with(|edges| edges.set(0));
 }
 
 #[cfg(test)]
-fn fixed_point_lookups() -> usize {
-    FIXED_POINT_LOOKUPS.with(Cell::get)
+fn dependency_edges() -> usize {
+    DEPENDENCY_EDGES.with(Cell::get)
 }
 
 /// One top-level `type X = ...` or `interface X { ... }` from the instance
@@ -61,14 +61,14 @@ pub(super) fn is_special_type_name(name: &str) -> bool {
 /// fixtures the rsvelte port currently cares about.
 pub(super) fn collect_type_body_deps(
     body: &str,
-    candidate_indices: &FxHashMap<&str, usize>,
+    candidate_indices: &FxHashMap<&str, u32>,
     self_name: &str,
     generics: &HashSet<String>,
     instance_value_names: &HashSet<String>,
     instance_import_names: &HashSet<String>,
-) -> (HashSet<String>, HashSet<String>) {
+) -> (HashSet<String>, FxHashSet<u32>) {
     let mut value_deps: HashSet<String> = HashSet::new();
-    let mut type_deps: HashSet<String> = HashSet::new();
+    let mut type_deps: FxHashSet<u32> = FxHashSet::default();
     let bytes = body.as_bytes();
     let len = bytes.len();
     let mut i = 0usize;
@@ -154,8 +154,8 @@ pub(super) fn collect_type_body_deps(
                 value_deps.insert(ident.to_string());
             } else if is_property_key {
                 // skip — property keys aren't dependencies
-            } else if candidate_indices.contains_key(ident) {
-                type_deps.insert(ident.to_string());
+            } else if let Some(&candidate_index) = candidate_indices.get(ident) {
+                type_deps.insert(candidate_index);
             } else if instance_value_names.contains(ident) && !instance_import_names.contains(ident)
             {
                 // Identifier resolves to an instance-script value (a `let`,
@@ -268,6 +268,110 @@ fn is_ident_byte(b: u8) -> bool {
     b.is_ascii_alphanumeric() || b == b'_' || b == b'$'
 }
 
+fn resolve_candidate_dependencies<'a, I>(
+    type_dependencies: I,
+    blocked: &mut [bool],
+) -> (Vec<bool>, Vec<usize>)
+where
+    I: Clone + ExactSizeIterator<Item = &'a FxHashSet<u32>>,
+{
+    let candidate_count = type_dependencies.len();
+    let mut dependents = vec![Vec::<u32>::new(); candidate_count];
+    for (candidate, dependencies) in type_dependencies.clone().enumerate() {
+        for &dependency in dependencies {
+            record_dependency_edge();
+            dependents[dependency as usize].push(candidate as u32);
+        }
+    }
+
+    let initially_blocked = blocked.to_vec();
+    let mut blocked_pass = vec![u32::MAX; candidate_count];
+    let mut blocked_queue = VecDeque::new();
+    for (candidate, &is_blocked) in initially_blocked.iter().enumerate() {
+        if is_blocked {
+            blocked_pass[candidate] = 0;
+            blocked_queue.push_back(candidate as u32);
+        }
+    }
+    // Initially disallowed names are visible for the entire first upstream scan.
+    for (dependency, &is_blocked) in initially_blocked.iter().enumerate() {
+        if !is_blocked {
+            continue;
+        }
+        for &candidate in &dependents[dependency] {
+            let candidate_index = candidate as usize;
+            if blocked_pass[candidate_index] != 0 {
+                blocked_pass[candidate_index] = 0;
+                blocked_queue.push_front(candidate);
+            }
+        }
+    }
+    while let Some(dependency) = blocked_queue.pop_front() {
+        for &candidate in &dependents[dependency as usize] {
+            let candidate_index = candidate as usize;
+            let weight = u32::from(dependency >= candidate);
+            let candidate_pass = blocked_pass[dependency as usize].saturating_add(weight);
+            if candidate_pass < blocked_pass[candidate_index] {
+                blocked_pass[candidate_index] = candidate_pass;
+                if weight == 0 {
+                    blocked_queue.push_front(candidate);
+                } else {
+                    blocked_queue.push_back(candidate);
+                }
+            }
+        }
+    }
+
+    let mut remaining_dependencies: Vec<u32> = type_dependencies
+        .map(|dependencies| dependencies.len() as u32)
+        .collect();
+    let mut promotion_pass = vec![0u32; candidate_count];
+    let mut ready = VecDeque::new();
+    for candidate in 0..candidate_count {
+        if blocked_pass[candidate] == u32::MAX && remaining_dependencies[candidate] == 0 {
+            ready.push_back(candidate as u32);
+        }
+    }
+
+    let mut hoistable = vec![false; candidate_count];
+    while let Some(dependency) = ready.pop_front() {
+        let dependency_index = dependency as usize;
+        hoistable[dependency_index] = true;
+        for &candidate in &dependents[dependency_index] {
+            let candidate_index = candidate as usize;
+            if blocked_pass[candidate_index] != u32::MAX {
+                continue;
+            }
+            let candidate_pass =
+                promotion_pass[dependency_index] + u32::from(dependency >= candidate);
+            promotion_pass[candidate_index] = promotion_pass[candidate_index].max(candidate_pass);
+            remaining_dependencies[candidate_index] -= 1;
+            if remaining_dependencies[candidate_index] == 0 {
+                ready.push_back(candidate);
+            }
+        }
+    }
+
+    let max_pass = promotion_pass.iter().copied().max().unwrap_or(0) as usize;
+    let mut candidates_by_pass = vec![Vec::new(); max_pass + 1];
+    for candidate in 0..candidate_count {
+        if hoistable[candidate] {
+            candidates_by_pass[promotion_pass[candidate] as usize].push(candidate);
+        }
+    }
+    let hoist_order: Vec<usize> = candidates_by_pass.into_iter().flatten().collect();
+    // Upstream performs one final scan after the last pass that promotes a type.
+    let last_executed_pass = if hoist_order.is_empty() {
+        0
+    } else {
+        max_pass as u32 + 1
+    };
+    for candidate in 0..candidate_count {
+        blocked[candidate] = blocked_pass[candidate] <= last_executed_pass;
+    }
+    (hoistable, hoist_order)
+}
+
 /// Determine which `HoistCandidate`s can be hoisted above `function $$render()`
 /// and record their absolute source ranges (and names) on `exported_names`.
 ///
@@ -293,12 +397,12 @@ pub(super) fn resolve_hoistable_type_decls(
     if candidates.is_empty() {
         return;
     }
-    let mut candidate_indices: FxHashMap<&str, usize> =
+    let mut candidate_indices: FxHashMap<&str, u32> =
         FxHashMap::with_capacity_and_hasher(candidates.len(), Default::default());
     for (index, candidate) in candidates.iter().enumerate() {
         candidate_indices
             .entry(candidate.name.as_str())
-            .or_insert(index);
+            .or_insert(index as u32);
     }
     // Per-candidate: collect generic parameter names (so `interface Props<T>`
     // doesn't see `T` as a dependency).
@@ -342,7 +446,7 @@ pub(super) fn resolve_hoistable_type_decls(
         .collect();
 
     // Pre-compute deps for each candidate.
-    let deps: Vec<(HashSet<String>, HashSet<String>)> = candidates
+    let deps: Vec<(HashSet<String>, FxHashSet<u32>)> = candidates
         .iter()
         .enumerate()
         .map(|(i, c)| {
@@ -431,10 +535,6 @@ pub(super) fn resolve_hoistable_type_decls(
         }
     }
 
-    // Fixed-point: a candidate that depends on a blocked candidate's type is
-    // itself blocked. Promote candidates to hoistable when all type-deps are
-    // hoistable.
-    let mut hoistable = vec![false; candidates.len()];
     // Record the order in which candidates are promoted to hoistable. The JS
     // reference (`HoistableInterfaces.determineHoistableInterfaces`) inserts
     // each interface into a `Map` as soon as all its type dependencies are
@@ -444,36 +544,8 @@ pub(super) fn resolve_hoistable_type_decls(
     // source (e.g. `interface A extends B<A>` followed by `interface B<T> {}`
     // emits `B` first). We mirror that by emitting `hoistable_type_ranges` in
     // promotion order rather than source order.
-    let mut hoist_order: Vec<usize> = Vec::new();
-    let mut progress = true;
-    while progress {
-        progress = false;
-        for i in 0..candidates.len() {
-            if hoistable[i] || blocked[i] {
-                continue;
-            }
-            let (_, type_deps) = &deps[i];
-            let mut can_hoist = true;
-            for dep in type_deps {
-                record_fixed_point_lookup();
-                if let Some(&idx) = candidate_indices.get(dep.as_str()) {
-                    if blocked[idx] {
-                        blocked[i] = true;
-                        can_hoist = false;
-                        break;
-                    }
-                    if !hoistable[idx] {
-                        can_hoist = false;
-                    }
-                }
-            }
-            if can_hoist {
-                hoistable[i] = true;
-                hoist_order.push(i);
-                progress = true;
-            }
-        }
-    }
+    let (hoistable, hoist_order) =
+        resolve_candidate_dependencies(deps.iter().map(|(_, deps)| deps), &mut blocked);
 
     // Gate the entire move on the props interface being hoistable. Mirrors
     // `HoistableInterfaces.moveHoistableInterfaces`, which only moves anything
@@ -486,7 +558,7 @@ pub(super) fn resolve_hoistable_type_decls(
         // `Props`; it's hoistable iff that candidate was promoted.
         candidate_indices
             .get(named)
-            .map(|&idx| hoistable[idx])
+            .map(|&idx| hoistable[idx as usize])
             // A bare `: Props` reference whose `Props` is NOT a local interface
             // (an imported / global type) never sets `props_interface.name` in
             // upstream `analyze$propsRune` (its `interface_map.get(name)` misses),
@@ -521,10 +593,9 @@ pub(super) fn resolve_hoistable_type_decls(
             }
         }
         if ok {
-            for dep in &type_deps {
-                if let Some(&idx) = candidate_indices.get(dep.as_str())
-                    && (blocked[idx] || !hoistable[idx])
-                {
+            for &idx in &type_deps {
+                let idx = idx as usize;
+                if blocked[idx] || !hoistable[idx] {
                     ok = false;
                     break;
                 }
@@ -852,6 +923,120 @@ mod tests {
         (line, column)
     }
 
+    fn old_resolve_candidate_dependencies(
+        dependencies: &[FxHashSet<u32>],
+        mut blocked: Vec<bool>,
+    ) -> (Vec<bool>, Vec<usize>) {
+        let mut hoistable = vec![false; dependencies.len()];
+        let mut hoist_order = Vec::new();
+        let mut progress = true;
+        while progress {
+            progress = false;
+            for candidate in 0..dependencies.len() {
+                if blocked[candidate] || hoistable[candidate] {
+                    continue;
+                }
+                let mut can_hoist = true;
+                for &dependency in &dependencies[candidate] {
+                    let dependency = dependency as usize;
+                    if blocked[dependency] {
+                        blocked[candidate] = true;
+                        can_hoist = false;
+                        break;
+                    }
+                    if !hoistable[dependency] {
+                        can_hoist = false;
+                    }
+                }
+                if can_hoist {
+                    hoistable[candidate] = true;
+                    hoist_order.push(candidate);
+                    progress = true;
+                }
+            }
+        }
+        (blocked, hoist_order)
+    }
+
+    #[test]
+    fn dependency_graph_matches_fixed_point_oracle() {
+        let mut state = 0x9e37_79b9_u32;
+        for candidate_count in 1..=32 {
+            for _ in 0..32 {
+                let mut dependencies = vec![FxHashSet::default(); candidate_count];
+                let mut blocked = vec![false; candidate_count];
+                for candidate in 0..candidate_count {
+                    state = state.wrapping_mul(1_664_525).wrapping_add(1_013_904_223);
+                    blocked[candidate] = state & 31 == 0;
+                    for dependency in 0..candidate_count {
+                        if candidate == dependency {
+                            continue;
+                        }
+                        state = state.wrapping_mul(1_664_525).wrapping_add(1_013_904_223);
+                        if state & 15 == 0 {
+                            dependencies[candidate].insert(dependency as u32);
+                        }
+                    }
+                }
+
+                let expected = old_resolve_candidate_dependencies(&dependencies, blocked.clone());
+                let mut actual_blocked = blocked;
+                let (actual_hoistable, actual_order) =
+                    resolve_candidate_dependencies(dependencies.iter(), &mut actual_blocked);
+                let expected_hoistable: Vec<bool> = (0..candidate_count)
+                    .map(|candidate| expected.1.contains(&candidate))
+                    .collect();
+                assert_eq!(
+                    actual_blocked, expected.0,
+                    "hoistable={actual_hoistable:?} dependencies={dependencies:?}"
+                );
+                assert_eq!(actual_hoistable, expected_hoistable);
+                assert_eq!(actual_order, expected.1);
+            }
+        }
+    }
+
+    #[test]
+    fn dependency_graph_handles_reverse_chain_fanout_cycles_and_order() {
+        let candidate_count = 4096;
+        let mut reverse_chain = vec![FxHashSet::default(); candidate_count];
+        for (candidate, dependencies) in reverse_chain
+            .iter_mut()
+            .enumerate()
+            .take(candidate_count - 1)
+        {
+            dependencies.insert(candidate as u32 + 1);
+        }
+        let mut blocked = vec![false; candidate_count];
+        let (hoistable, order) = resolve_candidate_dependencies(reverse_chain.iter(), &mut blocked);
+        assert!(hoistable.iter().all(|&value| value));
+        assert_eq!(order, (0..candidate_count).rev().collect::<Vec<_>>());
+
+        let mut fanout = vec![FxHashSet::default(); 256];
+        for dependencies in fanout.iter_mut().skip(1) {
+            dependencies.insert(0);
+        }
+        let mut blocked = vec![false; fanout.len()];
+        blocked[0] = true;
+        let (hoistable, order) = resolve_candidate_dependencies(fanout.iter(), &mut blocked);
+        assert!(blocked.iter().all(|&value| value));
+        assert!(hoistable.iter().all(|&value| !value));
+        assert!(order.is_empty());
+
+        let dependencies = [
+            FxHashSet::from_iter([3]),
+            FxHashSet::from_iter([2]),
+            FxHashSet::default(),
+            FxHashSet::default(),
+            FxHashSet::from_iter([5]),
+            FxHashSet::from_iter([4]),
+        ];
+        let mut blocked = vec![false; dependencies.len()];
+        let (hoistable, order) = resolve_candidate_dependencies(dependencies.iter(), &mut blocked);
+        assert_eq!(order, vec![2, 3, 0, 1]);
+        assert_eq!(hoistable, vec![true, true, true, true, false, false]);
+    }
+
     #[test]
     fn is_ts_structural_keyword_matches_keywords_not_type_names() {
         // Declaration / operator / control-flow keywords + primitive type
@@ -892,7 +1077,7 @@ mod tests {
             \u{20}\u{20}content: 'image' | 'initial' | 'count';\n\
             \u{20}\u{20}/** \u{753B}\u{50CF} (content='image' \u{306E}\u{5834}\u{5408}\u{306B}\u{5FC5}\u{9808}) */\n\
             \u{20}\u{20}imageSrc?: string;\n}";
-        let candidates: FxHashMap<&str, usize> = FxHashMap::default();
+        let candidates: FxHashMap<&str, u32> = FxHashMap::default();
         let generics: HashSet<String> = HashSet::new();
         let values: HashSet<String> = HashSet::new();
         let imports: HashSet<String> = HashSet::new();
@@ -1001,7 +1186,7 @@ let { value }: Root = $props();
     }
 
     #[test]
-    fn reverse_chain_uses_one_index_lookup_per_dependency_check() {
+    fn reverse_chain_builds_one_reverse_edge_per_dependency() {
         let source = r#"<script lang="ts">
 type T0 = { value: T1 };
 type T1 = { value: T2 };
@@ -1014,16 +1199,16 @@ type T7 = string;
 let { value }: T0 = $props();
 </script>
 <p>{value}</p>"#;
-        reset_fixed_point_lookups();
+        reset_dependency_edges();
         let output = convert_ts(source);
-        assert_eq!(fixed_point_lookups(), 35);
+        assert_eq!(dependency_edges(), 7);
         assert!(
             output.code.find("type T7").expect("T7") < output.code.find("type T0").expect("T0")
         );
     }
 
     #[test]
-    fn dense_reverse_dag_has_quadratic_lookup_count() {
+    fn dense_reverse_dag_builds_one_reverse_edge_per_dependency() {
         let source = r#"<script lang="ts">
 type T0 = { a: T1; b: T2; c: T3; d: T4; e: T5 };
 type T1 = { b: T2; c: T3; d: T4; e: T5 };
@@ -1034,9 +1219,9 @@ type T5 = string;
 let { a }: T0 = $props();
 </script>
 <p>{a}</p>"#;
-        reset_fixed_point_lookups();
+        reset_dependency_edges();
         let output = convert_ts(source);
-        assert_eq!(fixed_point_lookups(), 70);
+        assert_eq!(dependency_edges(), 15);
         let mut previous = 0;
         for name in ["T5", "T4", "T3", "T2", "T1", "T0"] {
             let position = output

--- a/crates/rsvelte_projection/src/svelte2tsx/script/hoistable_types.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/script/hoistable_types.rs
@@ -3,8 +3,33 @@
 
 use std::collections::HashSet;
 
+use rustc_hash::FxHashMap;
+#[cfg(test)]
+use std::cell::Cell;
+
 use super::super::magic_string::MagicString;
 use super::ExportedNames;
+
+#[cfg(test)]
+thread_local! {
+    static FIXED_POINT_LOOKUPS: Cell<usize> = const { Cell::new(0) };
+}
+
+#[inline(always)]
+fn record_fixed_point_lookup() {
+    #[cfg(test)]
+    FIXED_POINT_LOOKUPS.with(|lookups| lookups.set(lookups.get() + 1));
+}
+
+#[cfg(test)]
+fn reset_fixed_point_lookups() {
+    FIXED_POINT_LOOKUPS.with(|lookups| lookups.set(0));
+}
+
+#[cfg(test)]
+fn fixed_point_lookups() -> usize {
+    FIXED_POINT_LOOKUPS.with(Cell::get)
+}
 
 /// One top-level `type X = ...` or `interface X { ... }` from the instance
 /// script that may be hoistable above `function $$render()`.
@@ -36,7 +61,7 @@ pub(super) fn is_special_type_name(name: &str) -> bool {
 /// fixtures the rsvelte port currently cares about.
 pub(super) fn collect_type_body_deps(
     body: &str,
-    candidate_names: &HashSet<String>,
+    candidate_indices: &FxHashMap<&str, usize>,
     self_name: &str,
     generics: &HashSet<String>,
     instance_value_names: &HashSet<String>,
@@ -129,7 +154,7 @@ pub(super) fn collect_type_body_deps(
                 value_deps.insert(ident.to_string());
             } else if is_property_key {
                 // skip — property keys aren't dependencies
-            } else if candidate_names.contains(ident) {
+            } else if candidate_indices.contains_key(ident) {
                 type_deps.insert(ident.to_string());
             } else if instance_value_names.contains(ident) && !instance_import_names.contains(ident)
             {
@@ -268,7 +293,13 @@ pub(super) fn resolve_hoistable_type_decls(
     if candidates.is_empty() {
         return;
     }
-    let candidate_names: HashSet<String> = candidates.iter().map(|c| c.name.clone()).collect();
+    let mut candidate_indices: FxHashMap<&str, usize> =
+        FxHashMap::with_capacity_and_hasher(candidates.len(), Default::default());
+    for (index, candidate) in candidates.iter().enumerate() {
+        candidate_indices
+            .entry(candidate.name.as_str())
+            .or_insert(index);
+    }
     // Per-candidate: collect generic parameter names (so `interface Props<T>`
     // doesn't see `T` as a dependency).
     let generics: Vec<HashSet<String>> = candidates
@@ -302,7 +333,7 @@ pub(super) fn resolve_hoistable_type_decls(
                         g.insert(name.to_string());
                     }
                 }
-                // type_deps are limited to candidate_names by
+                // type_deps are limited to candidate_indices by
                 // `collect_type_body_deps`, so anything else simply doesn't
                 // appear here.
             }
@@ -320,7 +351,7 @@ pub(super) fn resolve_hoistable_type_decls(
             let body = if s < e { &raw_content[s..e] } else { "" };
             collect_type_body_deps(
                 body,
-                &candidate_names,
+                &candidate_indices,
                 &c.name,
                 &generics[i],
                 &exported_names.instance_value_names,
@@ -424,8 +455,8 @@ pub(super) fn resolve_hoistable_type_decls(
             let (_, type_deps) = &deps[i];
             let mut can_hoist = true;
             for dep in type_deps {
-                let dep_idx = candidates.iter().position(|c| &c.name == dep);
-                if let Some(idx) = dep_idx {
+                record_fixed_point_lookup();
+                if let Some(&idx) = candidate_indices.get(dep.as_str()) {
                     if blocked[idx] {
                         blocked[i] = true;
                         can_hoist = false;
@@ -453,10 +484,9 @@ pub(super) fn resolve_hoistable_type_decls(
     let props_interface_hoistable = if let Some(named) = props_named_ref {
         // Bare `: Props` reference. The props interface is the candidate named
         // `Props`; it's hoistable iff that candidate was promoted.
-        candidates
-            .iter()
-            .position(|c| c.name == named)
-            .map(|idx| hoistable[idx])
+        candidate_indices
+            .get(named)
+            .map(|&idx| hoistable[idx])
             // A bare `: Props` reference whose `Props` is NOT a local interface
             // (an imported / global type) never sets `props_interface.name` in
             // upstream `analyze$propsRune` (its `interface_map.get(name)` misses),
@@ -472,7 +502,7 @@ pub(super) fn resolve_hoistable_type_decls(
         // `<script generics=...>` parameter and has no disallowed value deps.
         let (value_deps, type_deps) = collect_type_body_deps(
             inline,
-            &candidate_names,
+            &candidate_indices,
             // No self-name for the synthetic interface.
             "",
             // No own generics on the synthetic props interface.
@@ -492,7 +522,7 @@ pub(super) fn resolve_hoistable_type_decls(
         }
         if ok {
             for dep in &type_deps {
-                if let Some(idx) = candidates.iter().position(|c| &c.name == dep)
+                if let Some(&idx) = candidate_indices.get(dep.as_str())
                     && (blocked[idx] || !hoistable[idx])
                 {
                     ok = false;
@@ -800,7 +830,27 @@ pub(super) fn rewrite_interface_to_type_dts(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::svelte2tsx::svelte2tsx::{Svelte2TsxOptions, svelte2tsx};
+    use crate::svelte2tsx::svelte2tsx::{Svelte2TsxOptions, Svelte2TsxResult, svelte2tsx};
+
+    fn convert_ts(source: &str) -> Svelte2TsxResult {
+        svelte2tsx(
+            source,
+            Svelte2TsxOptions {
+                filename: "Hoist.svelte".to_string(),
+                is_ts_file: true,
+                ..Default::default()
+            },
+        )
+        .expect("svelte2tsx ok")
+    }
+
+    fn line_column(text: &str, offset: usize) -> (u32, u32) {
+        let prefix = &text[..offset];
+        let line = prefix.bytes().filter(|byte| *byte == b'\n').count() as u32;
+        let line_start = prefix.rfind('\n').map_or(0, |index| index + 1);
+        let column = text[line_start..offset].encode_utf16().count() as u32;
+        (line, column)
+    }
 
     #[test]
     fn is_ts_structural_keyword_matches_keywords_not_type_names() {
@@ -842,7 +892,7 @@ mod tests {
             \u{20}\u{20}content: 'image' | 'initial' | 'count';\n\
             \u{20}\u{20}/** \u{753B}\u{50CF} (content='image' \u{306E}\u{5834}\u{5408}\u{306B}\u{5FC5}\u{9808}) */\n\
             \u{20}\u{20}imageSrc?: string;\n}";
-        let candidates: HashSet<String> = HashSet::new();
+        let candidates: FxHashMap<&str, usize> = FxHashMap::default();
         let generics: HashSet<String> = HashSet::new();
         let values: HashSet<String> = HashSet::new();
         let imports: HashSet<String> = HashSet::new();
@@ -904,5 +954,187 @@ mod tests {
             out.contains("$props<") && out.contains("$$ComponentProps"),
             "call rewritten to reference the alias:\n{out}"
         );
+    }
+
+    #[test]
+    fn reverse_dependency_chain_keeps_promotion_and_source_map_order() {
+        let source = r#"<script lang="ts">
+type Root = { value: Middle };
+type Middle = { value: Leaf };
+type Leaf = string;
+let { value }: Root = $props();
+</script>
+<p>{value}</p>"#;
+        let output = convert_ts(source);
+        let leaf = output.code.find("type Leaf").expect("Leaf");
+        let middle = output.code.find("type Middle").expect("Middle");
+        let root = output.code.find("type Root").expect("Root");
+        let render = output.code.find("function $$render").expect("render");
+        assert!(leaf < middle && middle < root && root < render);
+
+        let map =
+            sourcemap::SourceMap::from_slice(output.map.as_deref().expect("source map").as_bytes())
+                .expect("valid source map");
+        for name in ["Leaf", "Middle", "Root"] {
+            let source_declaration = source.find(&format!("type {name}")).expect("source type");
+            let source_offset = source_declaration + "type ".len();
+            let generated_declaration = output
+                .code
+                .find(&format!("type {name}"))
+                .expect("generated type");
+            let generated_offset = generated_declaration + "type ".len();
+            assert_eq!(
+                output.map_offset_forward(source_offset as u32),
+                Some(generated_offset as u32)
+            );
+            let (generated_line, _) = line_column(&output.code, generated_declaration);
+            let (source_line, _) = line_column(source, source_declaration);
+            assert!(
+                map.tokens().any(|token| {
+                    token.get_dst_line() == generated_line
+                        && token.get_src_line() == source_line
+                        && token.get_src_col() == 0
+                }),
+                "{name} has no source-map segment on its moved output line"
+            );
+        }
+    }
+
+    #[test]
+    fn reverse_chain_uses_one_index_lookup_per_dependency_check() {
+        let source = r#"<script lang="ts">
+type T0 = { value: T1 };
+type T1 = { value: T2 };
+type T2 = { value: T3 };
+type T3 = { value: T4 };
+type T4 = { value: T5 };
+type T5 = { value: T6 };
+type T6 = { value: T7 };
+type T7 = string;
+let { value }: T0 = $props();
+</script>
+<p>{value}</p>"#;
+        reset_fixed_point_lookups();
+        let output = convert_ts(source);
+        assert_eq!(fixed_point_lookups(), 35);
+        assert!(
+            output.code.find("type T7").expect("T7") < output.code.find("type T0").expect("T0")
+        );
+    }
+
+    #[test]
+    fn dense_reverse_dag_has_quadratic_lookup_count() {
+        let source = r#"<script lang="ts">
+type T0 = { a: T1; b: T2; c: T3; d: T4; e: T5 };
+type T1 = { b: T2; c: T3; d: T4; e: T5 };
+type T2 = { c: T3; d: T4; e: T5 };
+type T3 = { d: T4; e: T5 };
+type T4 = { e: T5 };
+type T5 = string;
+let { a }: T0 = $props();
+</script>
+<p>{a}</p>"#;
+        reset_fixed_point_lookups();
+        let output = convert_ts(source);
+        assert_eq!(fixed_point_lookups(), 70);
+        let mut previous = 0;
+        for name in ["T5", "T4", "T3", "T2", "T1", "T0"] {
+            let position = output
+                .code
+                .find(&format!("type {name}"))
+                .expect("hoisted type");
+            assert!(position >= previous);
+            previous = position;
+        }
+    }
+
+    #[test]
+    fn cyclic_types_and_their_props_consumer_stay_in_render() {
+        let source = r#"<script lang="ts">
+type A = B;
+type B = A;
+interface Props { value: A }
+let { value }: Props = $props();
+</script>
+<p>{value}</p>"#;
+        let output = convert_ts(source);
+        let render = output.code.find("function $$render").expect("render");
+        for declaration in ["type A", "type B", "interface Props"] {
+            assert!(
+                output.code.find(declaration).expect("declaration") > render,
+                "{declaration} was unexpectedly hoisted:\n{}",
+                output.code
+            );
+        }
+    }
+
+    #[test]
+    fn module_shadow_blocks_type_and_dependent_props() {
+        let source = r#"<script module lang="ts">
+type Shared = { module: true };
+</script>
+<script lang="ts">
+type Shared = { instance: true };
+interface Props { value: Shared }
+let { value }: Props = $props();
+</script>
+<p>{value}</p>"#;
+        let output = convert_ts(source);
+        let render = output.code.find("function $$render").expect("render");
+        assert!(output.code.rfind("type Shared").expect("instance Shared") > render);
+        assert!(output.code.find("interface Props").expect("Props") > render);
+    }
+
+    #[test]
+    fn component_generic_dependency_blocks_the_whole_hoist() {
+        let source = r#"<script lang="ts" generics="T">
+type Box = { value: T };
+interface Props { box: Box }
+let { box }: Props = $props();
+</script>
+<p>{box.value}</p>"#;
+        let output = convert_ts(source);
+        let render = output
+            .code
+            .find("function $$render<T>")
+            .expect("generic render");
+        assert!(output.code.find("type Box").expect("Box") > render);
+        assert!(output.code.find("interface Props").expect("Props") > render);
+    }
+
+    #[test]
+    fn inline_props_type_uses_indexed_hoistability() {
+        let source = r#"<script lang="ts">
+type Leaf = string;
+type Wrapper = { value: Leaf };
+let { item }: { item: Wrapper } = $props();
+</script>
+<p>{item.value}</p>"#;
+        let output = convert_ts(source);
+        let leaf = output.code.find("type Leaf").expect("Leaf");
+        let wrapper = output.code.find("type Wrapper").expect("Wrapper");
+        let props = output
+            .code
+            .find("type $$ComponentProps")
+            .expect("component props");
+        let render = output.code.find("function $$render").expect("render");
+        assert!(leaf < wrapper && wrapper < props && props < render);
+    }
+
+    #[test]
+    fn dollar_generic_referenced_ranges_keep_candidate_source_order() {
+        let source = r#"<script lang="ts">
+interface First { first: true }
+interface Second { second: true }
+type A = $$Generic<Second>;
+type B = $$Generic<First>;
+export let value: A;
+</script>
+<p>{value}</p>"#;
+        let output = convert_ts(source);
+        let first = output.code.find("interface First").expect("First");
+        let second = output.code.find("interface Second").expect("Second");
+        let render = output.code.find("function $$render").expect("render");
+        assert!(first < second && second < render);
     }
 }

--- a/crates/rsvelte_projection/src/svelte2tsx/script/mod.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/script/mod.rs
@@ -15,6 +15,7 @@ mod parse;
 mod props_rune;
 mod reactive;
 mod runes;
+mod script_facts;
 mod stores;
 #[cfg(test)]
 mod test_support;
@@ -55,11 +56,12 @@ use runes::{
     detect_rune_in_class_body, detect_rune_in_expr, detect_rune_in_nested_body, detect_runes_call,
     detect_runes_expr_stmt, scope_with_params,
 };
+use script_facts::ScriptFacts;
 use stores::{
     collect_loose_dollar_names_from_script, inject_store_subscriptions_vars_only_with_program,
     inject_store_subscriptions_with_program,
 };
-use type_assertion::{disambiguate_arrow_type_params, rewrite_type_assertions_with_program};
+use type_assertion::{disambiguate_arrow_type_params, rewrite_type_assertions};
 
 /// Classify a Svelte component basename for SvelteKit autotype injection.
 ///
@@ -110,6 +112,8 @@ pub fn process_instance_script(
 ) {
     let offset = script.content_offset;
     with_parsed_script(parsed, |program, raw_content| {
+        let script_facts = ScriptFacts::collect(program, offset, raw_content, true);
+
         // Pass 1: collect top-level declared names and possible exports
         let mut possible_exports: HashMap<String, PossibleExport> = HashMap::new();
         // Pre-populate with ALL top-level declared names so rune-vs-store
@@ -684,16 +688,23 @@ pub fn process_instance_script(
 
         // Pass 5: store subscriptions. Reuses the already-parsed program
         // so we don't re-parse the instance script content with OXC.
-        inject_store_subscriptions_with_program(program, module_program, offset, source, str);
+        inject_store_subscriptions_with_program(
+            program,
+            module_program,
+            offset,
+            source,
+            &script_facts.dollar_param_shadow,
+            str,
+        );
 
         // Pass 6: disambiguate generic arrow type-parameter lists for the
         // `.tsx` overlay (`<T>` → `<T,>`) so they aren't misparsed as JSX.
-        disambiguate_arrow_type_params(program, offset, raw_content, str);
+        disambiguate_arrow_type_params(&script_facts.arrow_generic_commas, str);
 
         // Pass 7: rewrite TS angle-bracket type assertions (`<X>e` → `e as X`)
         // anywhere in the instance script — TSX cannot parse the `<X>e` form.
         // Mirrors official `handleTypeAssertion`, applied during the same walk.
-        rewrite_type_assertions_with_program(program, offset as usize, str);
+        rewrite_type_assertions(&script_facts.type_assertions, str);
     });
 }
 /// Process a module script block (`<script context="module">`).
@@ -725,6 +736,8 @@ pub fn process_module_script(
     // Parse once and share the program across all three passes.
     let offset = script.content_offset;
     with_parsed_script(parsed, |program, raw_content| {
+        let script_facts = ScriptFacts::collect(program, offset, raw_content, false);
+
         // Inject store subscriptions for module-level variable declarations
         // only. Import-based store subscriptions are NOT injected here
         // because they need to go inside the $$render function body.
@@ -734,12 +747,12 @@ pub fn process_module_script(
         // the `e as X` form. Inside the module script the rewrite is
         // required because the generated `.tsx` parses the module-script
         // body at top level, where `<X>e` would be lexed as JSX.
-        rewrite_type_assertions_with_program(program, offset as usize, str);
+        rewrite_type_assertions(&script_facts.type_assertions, str);
 
         // Disambiguate generic arrow type-parameter lists (`<T>` → `<T,>`) so
         // the module-script body, parsed at the top level of the `.tsx`
         // overlay, doesn't lex a single-parameter arrow generic as JSX.
-        disambiguate_arrow_type_params(program, offset, raw_content, str);
+        disambiguate_arrow_type_params(&script_facts.arrow_generic_commas, str);
 
         // Snapshot top-level module-script names for the snippet hoist analysis.
         for stmt in program.body.iter() {

--- a/crates/rsvelte_projection/src/svelte2tsx/script/mod.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/script/mod.rs
@@ -117,7 +117,7 @@ pub fn process_instance_script(
         // `state`) sees the complete scope — incl. a name declared by the very
         // statement whose initializer we're checking. See
         // collect_top_level_declared_names.
-        let mut declared_names: HashSet<String> = collect_top_level_declared_names(&program.body);
+        let declared_names: HashSet<String> = collect_top_level_declared_names(&program.body);
         // Top-level `type` / `interface` declarations that may be hoistable
         // out of `function $$render()`. Resolved (with `instance_value_names`
         // and `module_*_names`) into `hoistable_type_ranges` after Pass 1.
@@ -153,11 +153,8 @@ pub fn process_instance_script(
                         ) {
                             props_rune_infos.push(info);
                         }
-                        let names = extract_all_names_from_binding_pattern(&declarator.id);
-                        for name in &names {
-                            declared_names.insert(name.clone());
-                        }
-                        if let Some(name) = binding_pattern_simple_name(&declarator.id) {
+                        if let oxc::BindingPattern::BindingIdentifier(id) = &declarator.id {
+                            let name = id.name.to_string();
                             let ta_text = declarator.type_annotation.as_ref().and_then(|ta| {
                                 let ts_type = &ta.type_annotation;
                                 let start = ts_type.span().start as usize;
@@ -189,9 +186,9 @@ pub fn process_instance_script(
                             // re-exported via `export { a, c }`. Record them as
                             // possible exports so the specifier handler resolves
                             // the correct `is_let` (a `let` destructure → prop).
-                            for name in &names {
+                            for name in extract_all_names_from_binding_pattern(&declarator.id) {
                                 possible_exports.insert(
-                                    name.clone(),
+                                    name,
                                     PossibleExport {
                                         is_let,
                                         has_init: declarator.init.is_some(),
@@ -220,15 +217,11 @@ pub fn process_instance_script(
                                     s.local.name.to_string()
                                 }
                             };
-                            declared_names.insert(name.clone());
                             exported_names.instance_import_names.insert(name);
                         }
                     }
                 }
                 oxc::Statement::FunctionDeclaration(func) => {
-                    if let Some(ref id) = func.id {
-                        declared_names.insert(id.name.to_string());
-                    }
                     // Detect rune calls nested inside the function body.
                     // The official svelte2tsx `checkGlobalsForRunes` walks the
                     // entire TypeScript AST (including function bodies) and flags
@@ -246,9 +239,6 @@ pub fn process_instance_script(
                     }
                 }
                 oxc::Statement::ClassDeclaration(class) => {
-                    if let Some(ref id) = class.id {
-                        declared_names.insert(id.name.to_string());
-                    }
                     // Detect rune calls nested inside class method bodies.
                     if class.body.body.iter().any(|member| match member {
                         oxc::ClassElement::MethodDefinition(method) => {
@@ -265,18 +255,6 @@ pub fn process_instance_script(
                         exported_names.set_uses_runes(true);
                     }
                 }
-                // Track instance-script namespace and enum names so the
-                // hoist analyser treats `A.Abc` references as blocking when
-                // `A` is bound in the instance script. Mirrors the JS
-                // reference's `disallowed_types.add(...)` for namespaces.
-                oxc::Statement::TSModuleDeclaration(module) => {
-                    if let oxc_ast::ast::TSModuleDeclarationName::Identifier(id) = &module.id {
-                        declared_names.insert(id.name.to_string());
-                    }
-                }
-                oxc::Statement::TSEnumDeclaration(enum_decl) => {
-                    declared_names.insert(enum_decl.id.name.to_string());
-                }
                 oxc::Statement::ExportNamedDeclaration(export) => {
                     // Also check exports for declared names
                     if let Some(ref decl) = export.declaration {
@@ -287,11 +265,6 @@ pub fn process_instance_script(
                                 let is_let =
                                     matches!(var_decl.kind, oxc::VariableDeclarationKind::Let);
                                 for declarator in var_decl.declarations.iter() {
-                                    let names =
-                                        extract_all_names_from_binding_pattern(&declarator.id);
-                                    for name in &names {
-                                        declared_names.insert(name.clone());
-                                    }
                                     if let Some(name) = binding_pattern_simple_name(&declarator.id)
                                     {
                                         let ta_text =
@@ -328,9 +301,6 @@ pub fn process_instance_script(
                                 }
                             }
                             oxc::Declaration::FunctionDeclaration(func) => {
-                                if let Some(ref id) = func.id {
-                                    declared_names.insert(id.name.to_string());
-                                }
                                 // Runes inside an exported function body still
                                 // put the component in runes mode.
                                 if let Some(ref body) = func.body {
@@ -341,9 +311,6 @@ pub fn process_instance_script(
                                 }
                             }
                             oxc::Declaration::ClassDeclaration(class) => {
-                                if let Some(ref id) = class.id {
-                                    declared_names.insert(id.name.to_string());
-                                }
                                 // `export class C { x = $state(0) }` → runes mode.
                                 if detect_rune_in_class_body(class, &declared_names) {
                                     exported_names.set_uses_runes(true);
@@ -618,9 +585,7 @@ pub fn process_instance_script(
         // Snapshot instance-script value declarations so callers (in particular
         // the force-inside-render heuristic for `$$ComponentProps`) can detect
         // when the props type references an instance-scope binding.
-        for name in declared_names.iter() {
-            exported_names.instance_value_names.insert(name.clone());
-        }
+        exported_names.instance_value_names = declared_names;
 
         // Collect loose `$name` references from the instance script WITHOUT the
         // rune-exclusion filter.  The official JS svelte2tsx's `is_rune` check is
@@ -896,7 +861,7 @@ pub fn process_module_script(
 
 #[cfg(test)]
 mod tests {
-    use super::test_support::run_svelte2tsx;
+    use super::test_support::{run_svelte2tsx, run_svelte2tsx_ts};
     use crate::svelte2tsx::svelte2tsx::{Svelte2TsxOptions, svelte2tsx};
 
     #[test]
@@ -968,5 +933,118 @@ mod tests {
         assert!(result.exported_names.has("name"));
         assert!(result.exported_names.get("name").unwrap().is_prop);
         assert_eq!(result.exported_names.get_prop_names(), vec!["name"]);
+    }
+
+    #[test]
+    fn top_level_binding_inventory_covers_every_prepass_declaration() {
+        let source = r#"<script lang="ts">
+import default_import, { named as aliased_import } from "pkg";
+import * as namespace_import from "other";
+var plain_var;
+let plain_let = 1;
+const plain_const = 2;
+function plain_function() {}
+class PlainClass {}
+namespace PlainNamespace {}
+enum PlainEnum { Value }
+export let exported_var = 3;
+export function exported_function() {}
+export class ExportedClass {}
+</script>"#;
+        let result = run_svelte2tsx_ts(source);
+        let expected = [
+            "default_import",
+            "aliased_import",
+            "namespace_import",
+            "plain_var",
+            "plain_let",
+            "plain_const",
+            "plain_function",
+            "PlainClass",
+            "PlainNamespace",
+            "PlainEnum",
+            "exported_var",
+            "exported_function",
+            "ExportedClass",
+        ]
+        .into_iter()
+        .map(str::to_string)
+        .collect();
+
+        assert_eq!(result.exported_names.instance_value_names, expected);
+    }
+
+    #[test]
+    fn top_level_binding_inventory_flattens_deep_destructuring_and_rest() {
+        let source = r#"<script lang="ts">
+let {
+    direct,
+    nested: { assigned = 1, ...object_rest },
+    list: [array_first, , { deep }, ...array_rest],
+    ...outer_rest
+} = {} as any;
+</script>"#;
+        let result = run_svelte2tsx_ts(source);
+        let expected = [
+            "direct",
+            "assigned",
+            "object_rest",
+            "array_first",
+            "deep",
+            "array_rest",
+            "outer_rest",
+        ]
+        .into_iter()
+        .map(str::to_string)
+        .collect();
+
+        assert_eq!(result.exported_names.instance_value_names, expected);
+    }
+
+    #[test]
+    fn late_same_name_binding_keeps_earlier_dollar_call_out_of_runes_mode() {
+        let source = r#"<script>
+let answer = $state(0);
+let state;
+</script>"#;
+        let result = run_svelte2tsx(source);
+
+        assert!(!result.exported_names.is_runes_mode());
+        assert!(
+            result.code.contains("bindings: \"\""),
+            "legacy bindings marker missing:\n{}",
+            result.code
+        );
+    }
+
+    #[test]
+    fn binding_inventory_does_not_affect_output_or_source_maps() {
+        let source = r#"<script lang="ts">
+import { readable as mapped_import } from "svelte/store";
+let { nested: { mapped_binding }, ...mapped_rest } = {} as any;
+export { mapped_binding };
+</script>
+<p>{mapped_binding}{mapped_rest}{mapped_import}</p>"#;
+        let first = run_svelte2tsx_ts(source);
+        let second = run_svelte2tsx_ts(source);
+
+        assert_eq!(first.code, second.code);
+        assert_eq!(first.map, second.map);
+        assert_eq!(first.forward_map, second.forward_map);
+
+        let binding_offset = source.find("mapped_binding").unwrap() as u32;
+        let generated_offset = first
+            .map_offset_forward(binding_offset)
+            .expect("binding declaration should remain forward-mapped")
+            as usize;
+        assert_eq!(
+            &first.code[generated_offset..generated_offset + "mapped_binding".len()],
+            "mapped_binding"
+        );
+
+        let raw_map = first.map.as_deref().expect("source map");
+        let map = sourcemap::SourceMap::from_slice(raw_map.as_bytes()).expect("valid source map");
+        assert_eq!(map.get_source(0), Some("Component.svelte"));
+        assert!(map.tokens().next().is_some());
     }
 }

--- a/crates/rsvelte_projection/src/svelte2tsx/script/mod.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/script/mod.rs
@@ -33,7 +33,7 @@ use super::svelte2tsx::slice_src;
 
 pub use component_events::ComponentEvents;
 pub use exported_names::{ExportedNameInfo, ExportedNames};
-pub use stores::collect_module_import_store_declarations;
+pub(super) use stores::{StoreScanContext, collect_module_import_store_declarations};
 
 use ast_utils::{
     binding_pattern_simple_name, collect_top_level_declared_names, declarator_has_boolean_init,
@@ -58,8 +58,7 @@ use runes::{
 };
 use script_facts::ScriptFacts;
 use stores::{
-    collect_loose_dollar_names_from_script, inject_store_subscriptions_vars_only_with_program,
-    inject_store_subscriptions_with_program,
+    inject_store_subscriptions_vars_only_with_program, inject_store_subscriptions_with_program,
 };
 use type_assertion::{disambiguate_arrow_type_params, rewrite_type_assertions};
 
@@ -101,6 +100,7 @@ pub fn process_instance_script(
     parsed: &ParsedScript<'_>,
     module_program: Option<&oxc::Program<'_>>,
     source: &str,
+    store_scan: &mut StoreScanContext<'_>,
     str: &mut MagicString,
     exported_names: &mut ExportedNames,
     _events: &mut ComponentEvents,
@@ -112,7 +112,7 @@ pub fn process_instance_script(
 ) {
     let offset = script.content_offset;
     with_parsed_script(parsed, |program, raw_content| {
-        let script_facts = ScriptFacts::collect(program, offset, raw_content, true);
+        let script_facts = ScriptFacts::collect(program, offset, raw_content, true, store_scan);
 
         // Pass 1: collect top-level declared names and possible exports
         let mut possible_exports: HashMap<String, PossibleExport> = HashMap::new();
@@ -600,11 +600,11 @@ pub fn process_instance_script(
         // snippets that reference `props` / `bindable` / etc. as plain identifiers
         // (e.g. from a nested `{#snippet child({ props })}`) to be treated as
         // non-hoistable.  Mirroring that behaviour here.
-        for name in collect_loose_dollar_names_from_script(raw_content) {
-            exported_names
-                .instance_script_loose_dollar_names
-                .insert(name);
-        }
+        store_scan.collect_loose_dollar_names(
+            content_start,
+            content_end,
+            &mut exported_names.instance_script_loose_dollar_names,
+        );
 
         // Unconditionally hoist instance-script type/interface declarations whose
         // names appear as `$$Generic<X>` constraints. Mirrors the JS reference's
@@ -688,14 +688,7 @@ pub fn process_instance_script(
 
         // Pass 5: store subscriptions. Reuses the already-parsed program
         // so we don't re-parse the instance script content with OXC.
-        inject_store_subscriptions_with_program(
-            program,
-            module_program,
-            offset,
-            source,
-            &script_facts.dollar_param_shadow,
-            str,
-        );
+        inject_store_subscriptions_with_program(program, module_program, offset, store_scan, str);
 
         // Pass 6: disambiguate generic arrow type-parameter lists for the
         // `.tsx` overlay (`<T>` → `<T,>`) so they aren't misparsed as JSX.
@@ -724,7 +717,7 @@ pub fn process_instance_script(
 pub fn process_module_script(
     script: &Script,
     parsed: &ParsedScript<'_>,
-    source: &str,
+    store_scan: &mut StoreScanContext<'_>,
     str: &mut MagicString,
     exported_names: &mut ExportedNames,
 ) {
@@ -736,12 +729,12 @@ pub fn process_module_script(
     // Parse once and share the program across all three passes.
     let offset = script.content_offset;
     with_parsed_script(parsed, |program, raw_content| {
-        let script_facts = ScriptFacts::collect(program, offset, raw_content, false);
+        let script_facts = ScriptFacts::collect(program, offset, raw_content, false, store_scan);
 
         // Inject store subscriptions for module-level variable declarations
         // only. Import-based store subscriptions are NOT injected here
         // because they need to go inside the $$render function body.
-        inject_store_subscriptions_vars_only_with_program(program, offset, source, str);
+        inject_store_subscriptions_vars_only_with_program(program, offset, store_scan, str);
 
         // Rewrite TypeScript angle-bracket type assertions (`<X>e`) into
         // the `e as X` form. Inside the module script the rewrite is

--- a/crates/rsvelte_projection/src/svelte2tsx/script/mod.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/script/mod.rs
@@ -170,7 +170,7 @@ pub fn process_instance_script(
                                 }
                             });
                             possible_exports.insert(
-                                name,
+                                name.to_owned(),
                                 PossibleExport {
                                     is_let,
                                     has_init: declarator.init.is_some(),
@@ -283,7 +283,7 @@ pub fn process_instance_script(
                                                 }
                                             });
                                         possible_exports.insert(
-                                            name,
+                                            name.to_owned(),
                                             PossibleExport {
                                                 is_let,
                                                 has_init: declarator.init.is_some(),
@@ -512,7 +512,7 @@ pub fn process_instance_script(
                             // Match through aliases: `export { v1 as a1 }` keys
                             // the entry by `a1`, so `has(v1)` is false — check
                             // the local name too.
-                            exported_names.has(&name) || exported_names.has_local(&name)
+                            exported_names.has(name) || exported_names.has_local(name)
                         } else {
                             false
                         }
@@ -539,7 +539,7 @@ pub fn process_instance_script(
                             let Some(name) = binding_pattern_simple_name(&d.id) else {
                                 continue;
                             };
-                            if exported_names.has(&name) || exported_names.has_local(&name) {
+                            if exported_names.has(name) || exported_names.has_local(name) {
                                 continue;
                             }
                             // Match handleTypeAssertion's widening condition:

--- a/crates/rsvelte_projection/src/svelte2tsx/script/props_rune.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/script/props_rune.rs
@@ -616,7 +616,7 @@ pub(super) fn extract_props_from_binding_pattern_runes(
                 };
 
                 if let Some(ref key) = key_name {
-                    let local = local_name.unwrap_or_else(|| key.clone());
+                    let local = local_name.unwrap_or(key).to_owned();
                     exported_names.add(key.clone(), local, has_default, None, true);
                     if is_bindable {
                         exported_names.bindable_props.push(key.clone());
@@ -739,7 +739,7 @@ pub(super) fn collect_props_rune_info(
                             // The bindable marker statement uses the LOCAL binding
                             // name, not the prop key: `{ count: definedCount =
                             // $bindable() }` → `definedCount;`.
-                            bindable_names.push(local_name);
+                            bindable_names.push(local_name.to_owned());
                         }
                     }
                     oxc::BindingPattern::BindingIdentifier(_) => {

--- a/crates/rsvelte_projection/src/svelte2tsx/script/script_facts.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/script/script_facts.rs
@@ -1,0 +1,256 @@
+use std::collections::HashMap;
+
+use oxc_ast::ast as oxc;
+use oxc_ast_visit::Visit;
+use oxc_span::GetSpan;
+
+use super::ast_utils::collect_binding_names;
+
+pub(super) struct ScriptFacts {
+    pub(super) dollar_param_shadow: HashMap<String, Vec<(u32, u32)>>,
+    pub(super) type_assertions: Vec<TypeAssertionFacts>,
+    pub(super) arrow_generic_commas: Vec<u32>,
+    #[cfg(test)]
+    pub(super) visitor_dispatches: VisitorDispatches,
+}
+
+impl ScriptFacts {
+    pub(super) fn collect(
+        program: &oxc::Program,
+        offset: u32,
+        raw_content: &str,
+        collect_dollar_param_shadow: bool,
+    ) -> Self {
+        let mut collector = ScriptFactsCollector {
+            offset,
+            raw_content,
+            collect_dollar_param_shadow,
+            facts: Self {
+                dollar_param_shadow: HashMap::new(),
+                type_assertions: Vec::new(),
+                arrow_generic_commas: Vec::new(),
+                #[cfg(test)]
+                visitor_dispatches: VisitorDispatches::default(),
+            },
+        };
+        collector.visit_program(program);
+        collector.facts
+    }
+}
+
+pub(super) struct TypeAssertionFacts {
+    pub(super) assertion_start: u32,
+    pub(super) type_start: u32,
+    pub(super) type_end: u32,
+    pub(super) expr_start: u32,
+    pub(super) expr_end: u32,
+}
+
+#[cfg(test)]
+#[derive(Debug, Default, PartialEq, Eq)]
+pub(super) struct VisitorDispatches {
+    pub(super) functions: usize,
+    pub(super) arrows: usize,
+    pub(super) type_assertions: usize,
+}
+
+struct ScriptFactsCollector<'s> {
+    offset: u32,
+    raw_content: &'s str,
+    collect_dollar_param_shadow: bool,
+    facts: ScriptFacts,
+}
+
+impl ScriptFactsCollector<'_> {
+    fn add_params(&mut self, params: &oxc::FormalParameters, span: oxc_span::Span) {
+        if !self.collect_dollar_param_shadow {
+            return;
+        }
+        let src_span = (span.start + self.offset, span.end + self.offset);
+        for item in params.items.iter() {
+            let mut names = Vec::new();
+            collect_binding_names(&item.pattern, &mut names);
+            for name in names {
+                if let Some(base) = name.strip_prefix('$') {
+                    self.facts
+                        .dollar_param_shadow
+                        .entry(base.to_string())
+                        .or_default()
+                        .push(src_span);
+                }
+            }
+        }
+    }
+
+    fn add_arrow_generic_comma(&mut self, arrow: &oxc::ArrowFunctionExpression<'_>) {
+        let Some(type_parameters) = arrow.type_parameters.as_deref() else {
+            return;
+        };
+        if type_parameters.params.len() != 1 {
+            return;
+        }
+        let param = &type_parameters.params[0];
+        if param.constraint.is_some() || param.default.is_some() {
+            return;
+        }
+        let bytes = self.raw_content.as_bytes();
+        let mut index = param.span.end as usize;
+        while index < bytes.len() && bytes[index].is_ascii_whitespace() {
+            index += 1;
+        }
+        if index >= bytes.len() || bytes[index] != b',' {
+            self.facts
+                .arrow_generic_commas
+                .push(param.span.end + self.offset);
+        }
+    }
+}
+
+impl<'a> Visit<'a> for ScriptFactsCollector<'_> {
+    fn visit_function(&mut self, it: &oxc::Function<'a>, flags: oxc_syntax::scope::ScopeFlags) {
+        #[cfg(test)]
+        {
+            self.facts.visitor_dispatches.functions += 1;
+        }
+        self.add_params(&it.params, it.span);
+        oxc_ast_visit::walk::walk_function(self, it, flags);
+    }
+
+    fn visit_arrow_function_expression(&mut self, it: &oxc::ArrowFunctionExpression<'a>) {
+        #[cfg(test)]
+        {
+            self.facts.visitor_dispatches.arrows += 1;
+        }
+        self.add_params(&it.params, it.span);
+        self.add_arrow_generic_comma(it);
+        oxc_ast_visit::walk::walk_arrow_function_expression(self, it);
+    }
+
+    fn visit_ts_type_assertion(&mut self, it: &oxc::TSTypeAssertion<'a>) {
+        #[cfg(test)]
+        {
+            self.facts.visitor_dispatches.type_assertions += 1;
+        }
+        let (type_start, type_end) = oxc_ast_span(&it.type_annotation);
+        let expression = it.expression.span();
+        self.facts.type_assertions.push(TypeAssertionFacts {
+            assertion_start: it.span.start + self.offset,
+            type_start: type_start + self.offset,
+            type_end: type_end + self.offset,
+            expr_start: expression.start + self.offset,
+            expr_end: expression.end + self.offset,
+        });
+        oxc_ast_visit::walk::walk_ts_type_assertion(self, it);
+    }
+}
+
+fn oxc_ast_span(ty: &oxc::TSType) -> (u32, u32) {
+    use oxc::TSType::*;
+    let span = match ty {
+        TSAnyKeyword(t) => t.span,
+        TSBigIntKeyword(t) => t.span,
+        TSBooleanKeyword(t) => t.span,
+        TSIntrinsicKeyword(t) => t.span,
+        TSNeverKeyword(t) => t.span,
+        TSNullKeyword(t) => t.span,
+        TSNumberKeyword(t) => t.span,
+        TSObjectKeyword(t) => t.span,
+        TSStringKeyword(t) => t.span,
+        TSSymbolKeyword(t) => t.span,
+        TSUndefinedKeyword(t) => t.span,
+        TSUnknownKeyword(t) => t.span,
+        TSVoidKeyword(t) => t.span,
+        TSThisType(t) => t.span,
+        TSTypeReference(t) => t.span,
+        TSArrayType(t) => t.span,
+        TSConditionalType(t) => t.span,
+        TSConstructorType(t) => t.span,
+        TSFunctionType(t) => t.span,
+        TSImportType(t) => t.span,
+        TSIndexedAccessType(t) => t.span,
+        TSInferType(t) => t.span,
+        TSIntersectionType(t) => t.span,
+        TSLiteralType(t) => t.span,
+        TSMappedType(t) => t.span,
+        TSNamedTupleMember(t) => t.span,
+        TSTemplateLiteralType(t) => t.span,
+        TSTupleType(t) => t.span,
+        TSTypeLiteral(t) => t.span,
+        TSTypeOperatorType(t) => t.span,
+        TSTypePredicate(t) => t.span,
+        TSTypeQuery(t) => t.span,
+        TSUnionType(t) => t.span,
+        _ => return (0, 0),
+    };
+    (span.start, span.end)
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::ast::oxc_program::RetainedProgram;
+
+    use super::*;
+
+    #[test]
+    fn nested_cross_product_is_dispatched_once_with_absolute_offsets() {
+        let source = "\
+function outer($outer) {
+    return <Outer>(() => {
+        const inner = <T>($arrow: T) =>
+            <Inner>(function nested($nested) { return <Leaf>$nested; });
+        return inner;
+    })();
+}";
+        let retained = RetainedProgram::parse(source, true);
+        assert!(retained.diagnostics().is_empty());
+
+        let offset = 41;
+        let facts = ScriptFacts::collect(retained.program(), offset, source, true);
+
+        assert_eq!(
+            facts.visitor_dispatches,
+            VisitorDispatches {
+                functions: 2,
+                arrows: 2,
+                type_assertions: 3,
+            }
+        );
+        assert_eq!(
+            facts.arrow_generic_commas,
+            vec![source.find("<T>").unwrap() as u32 + 2 + offset]
+        );
+
+        let outer_start = source.find("function outer").unwrap() as u32 + offset;
+        let nested_start = source.find("function nested").unwrap() as u32 + offset;
+        let arrow_start = source.find("<T>").unwrap() as u32 + offset;
+        assert_eq!(
+            facts.dollar_param_shadow["outer"],
+            vec![(outer_start, source.len() as u32 + offset)]
+        );
+        assert_eq!(
+            facts.dollar_param_shadow["arrow"],
+            vec![(
+                arrow_start,
+                source.find(";\n        return inner").unwrap() as u32 + offset
+            )]
+        );
+        assert_eq!(
+            facts.dollar_param_shadow["nested"],
+            vec![(
+                nested_start,
+                source.find("; });").unwrap() as u32 + 3 + offset
+            )]
+        );
+
+        let assertion_starts: Vec<u32> = facts
+            .type_assertions
+            .iter()
+            .map(|assertion| assertion.assertion_start)
+            .collect();
+        assert_eq!(
+            assertion_starts,
+            ["<Outer>", "<Inner>", "<Leaf>"]
+                .map(|needle| source.find(needle).unwrap() as u32 + offset)
+        );
+    }
+}

--- a/crates/rsvelte_projection/src/svelte2tsx/script/script_facts.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/script/script_facts.rs
@@ -1,13 +1,11 @@
-use std::collections::HashMap;
-
 use oxc_ast::ast as oxc;
 use oxc_ast_visit::Visit;
 use oxc_span::GetSpan;
 
 use super::ast_utils::collect_binding_names;
+use super::stores::{StoreScanContext, collect_self_named_rune_call_positions};
 
 pub(super) struct ScriptFacts {
-    pub(super) dollar_param_shadow: HashMap<String, Vec<(u32, u32)>>,
     pub(super) type_assertions: Vec<TypeAssertionFacts>,
     pub(super) arrow_generic_commas: Vec<u32>,
     #[cfg(test)]
@@ -15,18 +13,24 @@ pub(super) struct ScriptFacts {
 }
 
 impl ScriptFacts {
-    pub(super) fn collect(
+    pub(super) fn collect<'s>(
         program: &oxc::Program,
         offset: u32,
         raw_content: &str,
         collect_dollar_param_shadow: bool,
+        store_scan: &mut StoreScanContext<'s>,
     ) -> Self {
+        store_scan.begin_script_facts();
+        let collect_store_facts = store_scan.has_dollar();
+        if collect_store_facts {
+            collect_self_named_rune_call_positions(store_scan, program, offset);
+        }
         let mut collector = ScriptFactsCollector {
             offset,
             raw_content,
-            collect_dollar_param_shadow,
+            collect_dollar_param_shadow: collect_store_facts && collect_dollar_param_shadow,
+            store_scan,
             facts: Self {
-                dollar_param_shadow: HashMap::new(),
                 type_assertions: Vec::new(),
                 arrow_generic_commas: Vec::new(),
                 #[cfg(test)]
@@ -34,6 +38,7 @@ impl ScriptFacts {
             },
         };
         collector.visit_program(program);
+        collector.store_scan.finish_script_facts();
         collector.facts
     }
 }
@@ -54,14 +59,15 @@ pub(super) struct VisitorDispatches {
     pub(super) type_assertions: usize,
 }
 
-struct ScriptFactsCollector<'s> {
+struct ScriptFactsCollector<'r, 'c, 's> {
     offset: u32,
-    raw_content: &'s str,
+    raw_content: &'r str,
     collect_dollar_param_shadow: bool,
+    store_scan: &'c mut StoreScanContext<'s>,
     facts: ScriptFacts,
 }
 
-impl ScriptFactsCollector<'_> {
+impl ScriptFactsCollector<'_, '_, '_> {
     fn add_params(&mut self, params: &oxc::FormalParameters, span: oxc_span::Span) {
         if !self.collect_dollar_param_shadow {
             return;
@@ -71,13 +77,7 @@ impl ScriptFactsCollector<'_> {
             let mut names = Vec::new();
             collect_binding_names(&item.pattern, &mut names);
             for name in names {
-                if let Some(base) = name.strip_prefix('$') {
-                    self.facts
-                        .dollar_param_shadow
-                        .entry(base.to_string())
-                        .or_default()
-                        .push(src_span);
-                }
+                self.store_scan.add_dollar_param_shadow(&name, src_span);
             }
         }
     }
@@ -106,7 +106,7 @@ impl ScriptFactsCollector<'_> {
     }
 }
 
-impl<'a> Visit<'a> for ScriptFactsCollector<'_> {
+impl<'a> Visit<'a> for ScriptFactsCollector<'_, '_, '_> {
     fn visit_function(&mut self, it: &oxc::Function<'a>, flags: oxc_syntax::scope::ScopeFlags) {
         #[cfg(test)]
         {
@@ -205,7 +205,8 @@ function outer($outer) {
         assert!(retained.diagnostics().is_empty());
 
         let offset = 41;
-        let facts = ScriptFacts::collect(retained.program(), offset, source, true);
+        let mut store_scan = StoreScanContext::new(source);
+        let facts = ScriptFacts::collect(retained.program(), offset, source, true, &mut store_scan);
 
         assert_eq!(
             facts.visitor_dispatches,
@@ -224,18 +225,18 @@ function outer($outer) {
         let nested_start = source.find("function nested").unwrap() as u32 + offset;
         let arrow_start = source.find("<T>").unwrap() as u32 + offset;
         assert_eq!(
-            facts.dollar_param_shadow["outer"],
+            store_scan.dollar_param_shadow["outer"],
             vec![(outer_start, source.len() as u32 + offset)]
         );
         assert_eq!(
-            facts.dollar_param_shadow["arrow"],
+            store_scan.dollar_param_shadow["arrow"],
             vec![(
                 arrow_start,
                 source.find(";\n        return inner").unwrap() as u32 + offset
             )]
         );
         assert_eq!(
-            facts.dollar_param_shadow["nested"],
+            store_scan.dollar_param_shadow["nested"],
             vec![(
                 nested_start,
                 source.find("; });").unwrap() as u32 + 3 + offset

--- a/crates/rsvelte_projection/src/svelte2tsx/script/script_facts.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/script/script_facts.rs
@@ -205,7 +205,7 @@ function outer($outer) {
         assert!(retained.diagnostics().is_empty());
 
         let offset = 41;
-        let mut store_scan = StoreScanContext::new(source);
+        let mut store_scan = StoreScanContext::new(source, false);
         let facts = ScriptFacts::collect(retained.program(), offset, source, true, &mut store_scan);
 
         assert_eq!(

--- a/crates/rsvelte_projection/src/svelte2tsx/script/stores.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/script/stores.rs
@@ -6,9 +6,8 @@ use std::collections::HashSet;
 use std::fmt::Write as _;
 
 use oxc_ast::ast as oxc;
-use oxc_ast_visit::Visit;
 
-use super::ast_utils::{collect_binding_names, extract_all_names_from_binding_pattern};
+use super::ast_utils::extract_all_names_from_binding_pattern;
 use super::reactive::extract_names_from_labeled_body;
 use super::runes::excluded_rune_init;
 
@@ -484,57 +483,6 @@ fn is_dollar_binding_shadowed(
     }
 }
 
-/// Collect, from the instance-script AST, every `$`-prefixed function / arrow
-/// parameter binding mapped (sans `$`) to the source span of its enclosing
-/// function. A `$name` reference inside such a span is a local binding read, not
-/// a store auto-subscription (official tracks this via `Scope.declared`).
-pub(super) fn collect_dollar_param_shadow(
-    program: &oxc::Program,
-    offset: u32,
-) -> HashMap<String, Vec<(u32, u32)>> {
-    let mut collector = DollarParamShadowCollector {
-        offset,
-        spans: HashMap::new(),
-    };
-    collector.visit_program(program);
-    collector.spans
-}
-
-struct DollarParamShadowCollector {
-    offset: u32,
-    spans: HashMap<String, Vec<(u32, u32)>>,
-}
-
-impl DollarParamShadowCollector {
-    fn add_params(&mut self, params: &oxc::FormalParameters, span: oxc_span::Span) {
-        let src_span = (span.start + self.offset, span.end + self.offset);
-        for item in params.items.iter() {
-            let mut names = Vec::new();
-            collect_binding_names(&item.pattern, &mut names);
-            for n in names {
-                if let Some(base) = n.strip_prefix('$') {
-                    self.spans
-                        .entry(base.to_string())
-                        .or_default()
-                        .push(src_span);
-                }
-            }
-        }
-    }
-}
-
-impl<'a> Visit<'a> for DollarParamShadowCollector {
-    fn visit_function(&mut self, it: &oxc::Function<'a>, flags: oxc_syntax::scope::ScopeFlags) {
-        self.add_params(&it.params, it.span);
-        oxc_ast_visit::walk::walk_function(self, it, flags);
-    }
-
-    fn visit_arrow_function_expression(&mut self, it: &oxc::ArrowFunctionExpression<'a>) {
-        self.add_params(&it.params, it.span);
-        oxc_ast_visit::walk::walk_arrow_function_expression(self, it);
-    }
-}
-
 /// Create the store subscription declaration string for a list of store names.
 ///
 /// Returns a string like `/*Ωignore_startΩ*/;let $a = __sveltets_2_store_get(a);;let $b = __sveltets_2_store_get(b);/*Ωignore_endΩ*/`
@@ -610,15 +558,15 @@ pub(super) fn inject_store_subscriptions_with_program(
     module_program: Option<&oxc::Program>,
     offset: u32,
     source: &str,
+    shadow: &HashMap<String, Vec<(u32, u32)>>,
     str: &mut MagicString,
 ) {
     // Exclude `$name` references that are shadowed by a `$`-prefixed function /
     // arrow parameter binding in the instance script (official `resolveStore`
     // scope-chain check). The shadow map is keyed by source byte ranges.
-    let shadow = collect_dollar_param_shadow(program, offset);
     let self_named_rune_calls = collect_self_named_rune_call_positions(program, offset);
     let accessed_stores =
-        collect_store_references_with_shadow(source, &shadow, &self_named_rune_calls);
+        collect_store_references_with_shadow(source, shadow, &self_named_rune_calls);
     if accessed_stores.is_empty() {
         return;
     }

--- a/crates/rsvelte_projection/src/svelte2tsx/script/stores.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/script/stores.rs
@@ -16,17 +16,46 @@ use super::super::magic_string::MagicString;
 /// Reserved names that should not be treated as store references.
 const RESERVED_STORE_NAMES: &[&str] = &["$$props", "$$restProps", "$$slots"];
 
-struct StoreCandidate<'s> {
-    name: &'s str,
-    pos: u32,
-    may_be_self_named_rune: bool,
+struct StoreCandidate {
+    name_start: u32,
+    name_len_and_flags: u32,
+}
+
+impl StoreCandidate {
+    const SELF_NAMED_RUNE_FLAG: u32 = 1;
+
+    fn new(name_start: usize, name_end: usize, may_be_self_named_rune: bool) -> Self {
+        let name_len = u32::try_from(name_end - name_start).expect("store name exceeds u32");
+        let name_len_and_flags = name_len
+            .checked_mul(2)
+            .expect("store name exceeds packed length");
+        Self {
+            name_start: name_start as u32,
+            name_len_and_flags: name_len_and_flags + u32::from(may_be_self_named_rune),
+        }
+    }
+
+    fn name<'s>(&self, source: &'s str) -> &'s str {
+        let start = self.name_start as usize;
+        let end = start + (self.name_len_and_flags >> 1) as usize;
+        &source[start..end]
+    }
+
+    fn pos(&self) -> u32 {
+        self.name_start - 1
+    }
+
+    fn may_be_self_named_rune(&self) -> bool {
+        self.name_len_and_flags & Self::SELF_NAMED_RUNE_FLAG != 0
+    }
 }
 
 pub(crate) struct StoreScanContext<'s> {
     source: &'s str,
+    cache_candidates: bool,
     has_dollar: Option<bool>,
     candidates_scanned: bool,
-    candidates: Vec<StoreCandidate<'s>>,
+    candidates: Vec<StoreCandidate>,
     accessed_stores: HashSet<&'s str>,
     pub(super) dollar_param_shadow: HashMap<String, Vec<(u32, u32)>>,
     pub(super) self_named_rune_calls: Vec<u32>,
@@ -35,9 +64,10 @@ pub(crate) struct StoreScanContext<'s> {
 }
 
 impl<'s> StoreScanContext<'s> {
-    pub(crate) fn new(source: &'s str) -> Self {
+    pub(crate) fn new(source: &'s str, cache_candidates: bool) -> Self {
         Self {
             source,
+            cache_candidates,
             has_dollar: None,
             candidates_scanned: false,
             candidates: Vec::new(),
@@ -102,30 +132,42 @@ impl<'s> StoreScanContext<'s> {
         let has_dollar = self.has_dollar();
         self.candidates_scanned = true;
         if has_dollar {
-            collect_store_candidates(self.source, &mut self.candidates);
+            self.candidates
+                .reserve(memchr::memchr_iter(b'$', self.source.as_bytes()).count());
+            collect_store_candidates(self.source, |candidate| {
+                self.candidates.push(candidate);
+            });
         }
     }
 
     fn resolve_accessed_stores(&mut self) {
-        self.ensure_candidates();
         self.accessed_stores.clear();
-        for candidate in &self.candidates {
-            if candidate.may_be_self_named_rune
-                && self
-                    .self_named_rune_calls
-                    .binary_search(&candidate.pos)
-                    .is_ok()
-            {
-                continue;
+        if self.cache_candidates {
+            self.ensure_candidates();
+            for candidate in &self.candidates {
+                if let Some(name) = resolve_store_candidate(
+                    self.source,
+                    candidate,
+                    &self.dollar_param_shadow,
+                    &self.self_named_rune_calls,
+                ) {
+                    self.accessed_stores.insert(name);
+                }
             }
-            if !is_dollar_binding_shadowed(
-                &self.dollar_param_shadow,
-                candidate.name,
-                candidate.pos as usize,
-            ) {
-                self.accessed_stores.insert(candidate.name);
-            }
+            return;
         }
+        if !self.has_dollar() {
+            return;
+        }
+        let source = self.source;
+        let shadow = &self.dollar_param_shadow;
+        let rune_calls = &self.self_named_rune_calls;
+        let stores = &mut self.accessed_stores;
+        collect_store_candidates(source, |candidate| {
+            if let Some(name) = resolve_store_candidate(source, &candidate, shadow, rune_calls) {
+                stores.insert(name);
+            }
+        });
     }
 
     fn is_accessed(&self, name: &str) -> bool {
@@ -409,11 +451,7 @@ fn collect_loose_dollar_names_from_script(text: &str) -> HashSet<String> {
     names.into_iter().map(str::to_string).collect()
 }
 
-fn collect_store_candidates<'s>(source: &'s str, candidates: &mut Vec<StoreCandidate<'s>>) {
-    if memchr::memchr(b'$', source.as_bytes()).is_none() {
-        return;
-    }
-
+fn collect_store_candidates(source: &str, mut visit: impl FnMut(StoreCandidate)) {
     // Hand-rolled byte-level scan. The previous implementation compiled a
     // regex on every call; using `memchr` to jump between `$` bytes is
     // dramatically faster on the common script-free template (one SIMD
@@ -427,7 +465,6 @@ fn collect_store_candidates<'s>(source: &'s str, candidates: &mut Vec<StoreCandi
     // official `svelte2tsx` only runs the `Stores` walker over the instance
     // script + template, never the module script body. So a `<script module>`
     // that internally reads `$foo` must not make `foo` look like a store.
-    let original_source = source;
     let blanked;
     // Instance-script JS comments must be blanked too: official only collects
     // `$name` store accesses from the parsed instance-script AST + template
@@ -550,14 +587,27 @@ fn collect_store_candidates<'s>(source: &'s str, candidates: &mut Vec<StoreCandi
         // generic-argument commas can't fool a text scan, and — crucially — only
         // the CALL occurrence is skipped: a sibling `$state.snapshot(state)`
         // keeps `state` a store, matching upstream.
-        let base = &original_source[next..end];
-        candidates.push(StoreCandidate {
-            name: base,
-            pos: pos as u32,
-            may_be_self_named_rune: matches!(full, "$state" | "$props" | "$derived"),
-        });
+        visit(StoreCandidate::new(
+            next,
+            end,
+            matches!(full, "$state" | "$props" | "$derived"),
+        ));
         i = end;
     }
+}
+
+fn resolve_store_candidate<'s>(
+    source: &'s str,
+    candidate: &StoreCandidate,
+    shadow: &HashMap<String, Vec<(u32, u32)>>,
+    self_named_rune_calls: &[u32],
+) -> Option<&'s str> {
+    let pos = candidate.pos();
+    if candidate.may_be_self_named_rune() && self_named_rune_calls.binary_search(&pos).is_ok() {
+        return None;
+    }
+    let name = candidate.name(source);
+    (!is_dollar_binding_shadowed(shadow, name, pos as usize)).then_some(name)
 }
 
 /// True when the `$name` token spanning `[pos, end)` is an object-literal
@@ -954,6 +1004,7 @@ mod tests {
 
     #[test]
     fn cached_candidates_match_fresh_resolution_across_script_facts() {
+        assert_eq!(std::mem::size_of::<StoreCandidate>(), 8);
         let source = "<script module>$ignored</script><script>\
             const state=$state(0); function f($local,$shadowed){return $local+$shadowed+$outside}\
             const text='prefix $string'; // $comment\n</script>{$local}{$outside}";
@@ -961,7 +1012,7 @@ mod tests {
         let function_end = source.find("const text").unwrap() as u32;
         let rune_pos = source.find("$state(0)").unwrap() as u32;
 
-        let mut context = StoreScanContext::new(source);
+        let mut context = StoreScanContext::new(source, true);
         for name in ["local", "shadowed"] {
             context
                 .dollar_param_shadow
@@ -980,6 +1031,14 @@ mod tests {
             &["local", "outside", "shadowed", "state", "string"],
         );
         assert_eq!(context.candidates.capacity(), candidate_capacity);
+
+        let mut direct = StoreScanContext::new(source, false);
+        direct.resolve_accessed_stores();
+        assert_names(
+            &direct,
+            &["local", "outside", "shadowed", "state", "string"],
+        );
+        assert!(direct.candidates.is_empty() && !direct.candidates_scanned);
     }
 
     #[test]
@@ -990,7 +1049,7 @@ mod tests {
         let instance_rune = source.find("$props()").unwrap() as u32;
         let function_start = source.find("function f").unwrap() as u32;
         let function_end = source.rfind("</script>").unwrap() as u32;
-        let mut context = StoreScanContext::new(source);
+        let mut context = StoreScanContext::new(source, true);
 
         context.begin_script_facts();
         context.add_self_named_rune_call(module_rune);
@@ -1008,7 +1067,7 @@ mod tests {
         assert_eq!(context.dollar_param_shadow.len(), 1);
 
         let module_only = "<script module>const local=$state(0)</script>{$state}";
-        let mut context = StoreScanContext::new(module_only);
+        let mut context = StoreScanContext::new(module_only, true);
         context.self_named_rune_calls = vec![module_only.find("$state(0)").unwrap() as u32];
         context.resolve_accessed_stores();
         assert_names(&context, &["state"]);
@@ -1017,7 +1076,7 @@ mod tests {
     #[test]
     fn no_dollar_keeps_candidate_scan_lazy() {
         let source = "<script>const value = 1;</script><p>{value}</p>";
-        let mut context = StoreScanContext::new(source);
+        let mut context = StoreScanContext::new(source, false);
         assert_eq!(context.has_dollar, None);
         assert!(!context.has_dollar());
         assert!(!context.candidates_scanned);

--- a/crates/rsvelte_projection/src/svelte2tsx/script/stores.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/script/stores.rs
@@ -176,6 +176,9 @@ fn blank_instance_script_comments(source: &str, buf: &mut [u8]) {
 /// applying the rune-name filter.
 pub(super) fn collect_loose_dollar_names_from_script(text: &str) -> HashSet<String> {
     let bytes = text.as_bytes();
+    if memchr::memchr(b'$', bytes).is_none() {
+        return HashSet::new();
+    }
     let len = bytes.len();
     let mut names = HashSet::new();
     let mut i = 0usize;
@@ -279,6 +282,10 @@ pub(super) fn collect_store_references_with_shadow(
     shadow: &HashMap<String, Vec<(u32, u32)>>,
     self_named_rune_calls: &HashSet<u32>,
 ) -> HashSet<String> {
+    if memchr::memchr(b'$', source.as_bytes()).is_none() {
+        return HashSet::new();
+    }
+
     // Hand-rolled byte-level scan. The previous implementation compiled a
     // regex on every call; using `memchr` to jump between `$` bytes is
     // dramatically faster on the common script-free template (one SIMD
@@ -561,6 +568,10 @@ pub(super) fn inject_store_subscriptions_with_program(
     shadow: &HashMap<String, Vec<(u32, u32)>>,
     str: &mut MagicString,
 ) {
+    if memchr::memchr(b'$', source.as_bytes()).is_none() {
+        return;
+    }
+
     // Exclude `$name` references that are shadowed by a `$`-prefixed function /
     // arrow parameter binding in the instance script (official `resolveStore`
     // scope-chain check). The shadow map is keyed by source byte ranges.
@@ -777,6 +788,10 @@ pub(super) fn inject_store_subscriptions_vars_only_with_program(
     source: &str,
     str: &mut MagicString,
 ) {
+    if memchr::memchr(b'$', source.as_bytes()).is_none() {
+        return;
+    }
+
     let self_named_rune_calls = collect_self_named_rune_call_positions(program, offset);
     let accessed_stores =
         collect_store_references_with_shadow(source, &HashMap::new(), &self_named_rune_calls);

--- a/crates/rsvelte_projection/src/svelte2tsx/script/stores.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/script/stores.rs
@@ -16,6 +16,139 @@ use super::super::magic_string::MagicString;
 /// Reserved names that should not be treated as store references.
 const RESERVED_STORE_NAMES: &[&str] = &["$$props", "$$restProps", "$$slots"];
 
+struct StoreCandidate<'s> {
+    name: &'s str,
+    pos: u32,
+    may_be_self_named_rune: bool,
+}
+
+pub(crate) struct StoreScanContext<'s> {
+    source: &'s str,
+    has_dollar: Option<bool>,
+    candidates_scanned: bool,
+    candidates: Vec<StoreCandidate<'s>>,
+    accessed_stores: HashSet<&'s str>,
+    pub(super) dollar_param_shadow: HashMap<String, Vec<(u32, u32)>>,
+    pub(super) self_named_rune_calls: Vec<u32>,
+    import_store_names: Vec<&'s str>,
+    seen_import_store_names: HashSet<&'s str>,
+}
+
+impl<'s> StoreScanContext<'s> {
+    pub(crate) fn new(source: &'s str) -> Self {
+        Self {
+            source,
+            has_dollar: None,
+            candidates_scanned: false,
+            candidates: Vec::new(),
+            accessed_stores: HashSet::new(),
+            dollar_param_shadow: HashMap::new(),
+            self_named_rune_calls: Vec::new(),
+            import_store_names: Vec::new(),
+            seen_import_store_names: HashSet::new(),
+        }
+    }
+
+    pub(super) fn begin_script_facts(&mut self) {
+        self.dollar_param_shadow.clear();
+        self.self_named_rune_calls.clear();
+    }
+
+    pub(super) fn has_dollar(&mut self) -> bool {
+        if let Some(has_dollar) = self.has_dollar {
+            return has_dollar;
+        }
+        let has_dollar = memchr::memchr(b'$', self.source.as_bytes()).is_some();
+        self.has_dollar = Some(has_dollar);
+        has_dollar
+    }
+
+    pub(super) fn add_dollar_param_shadow(&mut self, name: &str, span: (u32, u32)) {
+        if let Some(base) = name.strip_prefix('$') {
+            self.dollar_param_shadow
+                .entry(base.to_string())
+                .or_default()
+                .push(span);
+        }
+    }
+
+    pub(super) fn add_self_named_rune_call(&mut self, pos: u32) {
+        self.self_named_rune_calls.push(pos);
+    }
+
+    pub(super) fn finish_script_facts(&mut self) {
+        self.self_named_rune_calls.sort_unstable();
+        self.self_named_rune_calls.dedup();
+    }
+
+    pub(super) fn collect_loose_dollar_names(
+        &mut self,
+        start: usize,
+        end: usize,
+        output: &mut HashSet<String>,
+    ) {
+        self.accessed_stores.clear();
+        let Some(text) = self.source.get(start..end) else {
+            return;
+        };
+        collect_loose_dollar_names_into(text, &mut self.accessed_stores);
+        output.extend(self.accessed_stores.iter().map(|name| (*name).to_string()));
+    }
+
+    fn ensure_candidates(&mut self) {
+        if self.candidates_scanned {
+            return;
+        }
+        let has_dollar = self.has_dollar();
+        self.candidates_scanned = true;
+        if has_dollar {
+            collect_store_candidates(self.source, &mut self.candidates);
+        }
+    }
+
+    fn resolve_accessed_stores(&mut self) {
+        self.ensure_candidates();
+        self.accessed_stores.clear();
+        for candidate in &self.candidates {
+            if candidate.may_be_self_named_rune
+                && self
+                    .self_named_rune_calls
+                    .binary_search(&candidate.pos)
+                    .is_ok()
+            {
+                continue;
+            }
+            if !is_dollar_binding_shadowed(
+                &self.dollar_param_shadow,
+                candidate.name,
+                candidate.pos as usize,
+            ) {
+                self.accessed_stores.insert(candidate.name);
+            }
+        }
+    }
+
+    fn is_accessed(&self, name: &str) -> bool {
+        self.accessed_stores.contains(name)
+    }
+
+    fn begin_import_collection(&mut self) {
+        self.import_store_names.clear();
+        self.seen_import_store_names.clear();
+    }
+
+    fn push_import_if_accessed(&mut self, name: &str) {
+        if let Some(&source_name) = self.accessed_stores.get(name) {
+            self.import_store_names.push(source_name);
+        }
+    }
+
+    fn dedup_imports_preserving_order(&mut self) {
+        let seen = &mut self.seen_import_store_names;
+        self.import_store_names.retain(|name| seen.insert(*name));
+    }
+}
+
 /// True when the source has a `<script context="module">` / `<script module>` tag.
 fn has_module_script(source: &str) -> bool {
     find_module_script_span(source).is_some()
@@ -174,13 +307,12 @@ fn blank_instance_script_comments(source: &str, buf: &mut [u8]) {
 /// name `X` for every `$X` token found, skipping only `$$`-prefixed forms and
 /// obvious non-identifiers (comments, strings, member accesses, etc.) but NOT
 /// applying the rune-name filter.
-pub(super) fn collect_loose_dollar_names_from_script(text: &str) -> HashSet<String> {
+fn collect_loose_dollar_names_into<'s>(text: &'s str, names: &mut HashSet<&'s str>) {
     let bytes = text.as_bytes();
     if memchr::memchr(b'$', bytes).is_none() {
-        return HashSet::new();
+        return;
     }
     let len = bytes.len();
-    let mut names = HashSet::new();
     let mut i = 0usize;
 
     // Simple comment/string skipper — matches the level of care in
@@ -265,25 +397,21 @@ pub(super) fn collect_loose_dollar_names_from_script(text: &str) -> HashSet<Stri
         }
 
         let base = &text[next..end];
-        names.insert(base.to_string());
+        names.insert(base);
         i = end;
     }
-    names
 }
 
-pub(super) fn collect_store_references(source: &str) -> HashSet<String> {
-    // No parsed program here (import-only module path): there are no self-named
-    // rune-call callees to exclude, so an empty position set is exact.
-    collect_store_references_with_shadow(source, &HashMap::new(), &HashSet::new())
+#[cfg(test)]
+fn collect_loose_dollar_names_from_script(text: &str) -> HashSet<String> {
+    let mut names = HashSet::new();
+    collect_loose_dollar_names_into(text, &mut names);
+    names.into_iter().map(str::to_string).collect()
 }
 
-pub(super) fn collect_store_references_with_shadow(
-    source: &str,
-    shadow: &HashMap<String, Vec<(u32, u32)>>,
-    self_named_rune_calls: &HashSet<u32>,
-) -> HashSet<String> {
+fn collect_store_candidates<'s>(source: &'s str, candidates: &mut Vec<StoreCandidate<'s>>) {
     if memchr::memchr(b'$', source.as_bytes()).is_none() {
-        return HashSet::new();
+        return;
     }
 
     // Hand-rolled byte-level scan. The previous implementation compiled a
@@ -299,6 +427,7 @@ pub(super) fn collect_store_references_with_shadow(
     // official `svelte2tsx` only runs the `Stores` walker over the instance
     // script + template, never the module script body. So a `<script module>`
     // that internally reads `$foo` must not make `foo` look like a store.
+    let original_source = source;
     let blanked;
     // Instance-script JS comments must be blanked too: official only collects
     // `$name` store accesses from the parsed instance-script AST + template
@@ -306,7 +435,7 @@ pub(super) fn collect_store_references_with_shadow(
     // comment (e.g. a JSDoc `[`$on`](…$on)` link) is never a store reference.
     let needs_blank =
         source.contains("<!--") || has_module_script(source) || instance_script_has_comment(source);
-    let source: &str = if needs_blank {
+    let scan_source: &str = if needs_blank {
         let mut buf = source.as_bytes().to_vec();
         let mut j = 0usize;
         while let Some(rel) = source[j..].find("<!--") {
@@ -329,8 +458,7 @@ pub(super) fn collect_store_references_with_shadow(
     } else {
         source
     };
-    let mut stores = HashSet::new();
-    let bytes = source.as_bytes();
+    let bytes = scan_source.as_bytes();
     let len = bytes.len();
     let mut i = 0usize;
     while let Some(off) = memchr::memchr(b'$', &bytes[i..]) {
@@ -374,7 +502,7 @@ pub(super) fn collect_store_references_with_shadow(
                 while k > 0 && bytes[k - 1].is_ascii_lowercase() {
                     k -= 1;
                 }
-                let kw = &source[k..kw_end];
+                let kw = &scan_source[k..kw_end];
                 let boundary_ok =
                     k == 0 || matches!(bytes[k - 1], b' ' | b'\t' | b'\n' | b'\r' | b'<');
                 if boundary_ok && matches!(kw, "use" | "transition" | "in" | "out" | "animate") {
@@ -396,7 +524,7 @@ pub(super) fn collect_store_references_with_shadow(
                 break;
             }
         }
-        let full = &source[pos..end];
+        let full = &scan_source[pos..end];
         // Object-literal property KEY (`{ $name: value }` / after a `,`): the
         // `$name` is a property name, not a store reference. Official walks the
         // parsed AST and skips `Property.key` identifiers, so e.g. a row object
@@ -422,24 +550,14 @@ pub(super) fn collect_store_references_with_shadow(
         // generic-argument commas can't fool a text scan, and — crucially — only
         // the CALL occurrence is skipped: a sibling `$state.snapshot(state)`
         // keeps `state` a store, matching upstream.
-        if matches!(full, "$state" | "$props" | "$derived")
-            && self_named_rune_calls.contains(&(pos as u32))
-        {
-            i = end;
-            continue;
-        }
-        let base = &source[next..end];
-        // A `$name` whose `$`-prefixed binding (a function/arrow parameter)
-        // lexically encloses this position is a LOCAL binding reference, not a
-        // store auto-subscription. Mirrors official `resolveStore`, which walks
-        // the scope chain and skips a `$name` reference declared in any
-        // enclosing `scope.declared` set.
-        if !is_dollar_binding_shadowed(shadow, base, pos) {
-            stores.insert(base.to_string());
-        }
+        let base = &original_source[next..end];
+        candidates.push(StoreCandidate {
+            name: base,
+            pos: pos as u32,
+            may_be_self_named_rune: matches!(full, "$state" | "$props" | "$derived"),
+        });
         i = end;
     }
-    stores
 }
 
 /// True when the `$name` token spanning `[pos, end)` is an object-literal
@@ -517,10 +635,10 @@ pub(super) fn create_store_declarations(store_names: &[&str]) -> String {
 /// `let state = $state([])` next to `$state.snapshot(state)` still auto-
 /// subscribes exactly as upstream does.
 pub(super) fn collect_self_named_rune_call_positions(
+    context: &mut StoreScanContext<'_>,
     program: &oxc::Program,
     offset: u32,
-) -> HashSet<u32> {
-    let mut positions = HashSet::new();
+) {
     let mut visit_var_decl = |var_decl: &oxc::VariableDeclaration| {
         for declarator in var_decl.declarations.iter() {
             let Some(init) = declarator.init.as_ref() else {
@@ -529,7 +647,7 @@ pub(super) fn collect_self_named_rune_call_positions(
             if let Some(call) = excluded_rune_init(init, &declarator.id)
                 && let oxc::Expression::Identifier(callee) = &call.callee
             {
-                positions.insert(callee.span.start + offset);
+                context.add_self_named_rune_call(callee.span.start + offset);
             }
         }
     };
@@ -544,7 +662,6 @@ pub(super) fn collect_self_named_rune_call_positions(
             _ => {}
         }
     }
-    positions
 }
 
 /// Inject store subscription declarations into the script.
@@ -564,25 +681,19 @@ pub(super) fn inject_store_subscriptions_with_program(
     program: &oxc::Program,
     module_program: Option<&oxc::Program>,
     offset: u32,
-    source: &str,
-    shadow: &HashMap<String, Vec<(u32, u32)>>,
+    context: &mut StoreScanContext<'_>,
     str: &mut MagicString,
 ) {
-    if memchr::memchr(b'$', source.as_bytes()).is_none() {
+    if !context.has_dollar() {
         return;
     }
 
-    // Exclude `$name` references that are shadowed by a `$`-prefixed function /
-    // arrow parameter binding in the instance script (official `resolveStore`
-    // scope-chain check). The shadow map is keyed by source byte ranges.
-    let self_named_rune_calls = collect_self_named_rune_call_positions(program, offset);
-    let accessed_stores =
-        collect_store_references_with_shadow(source, shadow, &self_named_rune_calls);
-    if accessed_stores.is_empty() {
+    context.resolve_accessed_stores();
+    if context.accessed_stores.is_empty() {
         return;
     }
 
-    let mut import_store_names: Vec<String> = Vec::new();
+    context.begin_import_collection();
 
     for stmt in program.body.iter() {
         match stmt {
@@ -598,7 +709,7 @@ pub(super) fn inject_store_subscriptions_with_program(
                     let names = extract_all_names_from_binding_pattern(&declarator.id);
                     let matching: Vec<String> = names
                         .into_iter()
-                        .filter(|name| accessed_stores.contains(name))
+                        .filter(|name| context.is_accessed(name))
                         .collect();
 
                     if !matching.is_empty() {
@@ -610,7 +721,7 @@ pub(super) fn inject_store_subscriptions_with_program(
             }
 
             oxc::Statement::ImportDeclaration(import) => {
-                collect_import_store_names(import, &accessed_stores, &mut import_store_names);
+                collect_import_store_names(import, context);
             }
 
             oxc::Statement::ExportNamedDeclaration(export) => {
@@ -628,7 +739,7 @@ pub(super) fn inject_store_subscriptions_with_program(
                         let names = extract_all_names_from_binding_pattern(&declarator.id);
                         let matching: Vec<String> = names
                             .into_iter()
-                            .filter(|name| accessed_stores.contains(name))
+                            .filter(|name| context.is_accessed(name))
                             .collect();
 
                         if !matching.is_empty() {
@@ -645,7 +756,7 @@ pub(super) fn inject_store_subscriptions_with_program(
                 let names = extract_names_from_labeled_body(&labeled.body);
                 let matching: Vec<String> = names
                     .into_iter()
-                    .filter(|n| accessed_stores.contains(n))
+                    .filter(|name| context.is_accessed(name))
                     .collect();
 
                 if !matching.is_empty() {
@@ -660,19 +771,15 @@ pub(super) fn inject_store_subscriptions_with_program(
         }
     }
 
-    collect_module_script_import_stores(module_program, &accessed_stores, &mut import_store_names);
+    collect_module_script_import_stores(module_program, context);
 
     // Official `attachStoreValueDeclarationOfImportsToRenderFn` iterates
     // `importStatements` in IMPORT-DECLARATION order (not first-`$store`-use
     // order), which is exactly the collection order here (instance imports in
     // program order, then module imports). Just dedup preserving that order.
-    {
-        let mut seen = std::collections::HashSet::new();
-        import_store_names.retain(|n| seen.insert(n.clone()));
-    }
-    if !import_store_names.is_empty() {
-        let name_refs: Vec<&str> = import_store_names.iter().map(|s| s.as_str()).collect();
-        let store_decls = create_store_declarations(&name_refs);
+    context.dedup_imports_preserving_order();
+    if !context.import_store_names.is_empty() {
+        let store_decls = create_store_declarations(&context.import_store_names);
         str.append_right(offset, &store_decls);
     }
 }
@@ -681,11 +788,7 @@ pub(super) fn inject_store_subscriptions_with_program(
 ///
 /// In Svelte 5 mode, `derived` imported from `svelte/store` is excluded because
 /// it's a known rune function, not a store.
-fn collect_import_store_names(
-    import: &oxc::ImportDeclaration,
-    accessed_stores: &HashSet<String>,
-    import_store_names: &mut Vec<String>,
-) {
+fn collect_import_store_names(import: &oxc::ImportDeclaration, context: &mut StoreScanContext<'_>) {
     // Skip type-only imports
     if import.import_kind.is_type() {
         return;
@@ -698,10 +801,10 @@ fn collect_import_store_names(
         for spec in specifiers.iter() {
             let (local_name, is_derived_import) = match spec {
                 oxc::ImportDeclarationSpecifier::ImportDefaultSpecifier(s) => {
-                    (s.local.name.to_string(), false)
+                    (s.local.name.as_str(), false)
                 }
                 oxc::ImportDeclarationSpecifier::ImportNamespaceSpecifier(s) => {
-                    (s.local.name.to_string(), false)
+                    (s.local.name.as_str(), false)
                 }
                 oxc::ImportDeclarationSpecifier::ImportSpecifier(s) => {
                     // Skip type-only import specifiers
@@ -709,7 +812,7 @@ fn collect_import_store_names(
                         continue;
                     }
                     let is_derived = is_svelte_store_import && s.local.name == "derived";
-                    (s.local.name.to_string(), is_derived)
+                    (s.local.name.as_str(), is_derived)
                 }
             };
 
@@ -720,9 +823,7 @@ fn collect_import_store_names(
                 continue;
             }
 
-            if accessed_stores.contains(&local_name) {
-                import_store_names.push(local_name);
-            }
+            context.push_import_if_accessed(local_name);
         }
     }
 }
@@ -733,8 +834,7 @@ fn collect_import_store_names(
 /// imports at the $$render function body start.
 fn collect_module_script_import_stores(
     program: Option<&oxc::Program>,
-    accessed_stores: &HashSet<String>,
-    import_store_names: &mut Vec<String>,
+    context: &mut StoreScanContext<'_>,
 ) {
     let program = match program {
         Some(program) => program,
@@ -742,7 +842,7 @@ fn collect_module_script_import_stores(
     };
     for stmt in program.body.iter() {
         if let oxc::Statement::ImportDeclaration(import) = stmt {
-            collect_import_store_names(import, accessed_stores, import_store_names);
+            collect_import_store_names(import, context);
         }
     }
 }
@@ -753,27 +853,26 @@ fn collect_module_script_import_stores(
 /// module-script import names that are used as stores (`$name`) in the source
 /// and returns the store subscription declarations string to inject at the
 /// start of the $$render async wrapper.
-pub fn collect_module_import_store_declarations(
-    source: &str,
+pub(crate) fn collect_module_import_store_declarations(
+    context: &mut StoreScanContext<'_>,
     module_program: Option<&oxc::Program>,
 ) -> String {
-    let accessed_stores = collect_store_references(source);
-    if accessed_stores.is_empty() {
+    context.resolve_accessed_stores();
+    if context.accessed_stores.is_empty() {
         return String::new();
     }
 
-    let mut import_store_names: Vec<String> = Vec::new();
-    collect_module_script_import_stores(module_program, &accessed_stores, &mut import_store_names);
+    context.begin_import_collection();
+    collect_module_script_import_stores(module_program, context);
 
-    import_store_names.sort();
-    import_store_names.dedup();
+    context.import_store_names.sort_unstable();
+    context.import_store_names.dedup();
 
-    if import_store_names.is_empty() {
+    if context.import_store_names.is_empty() {
         return String::new();
     }
 
-    let name_refs: Vec<&str> = import_store_names.iter().map(|s| s.as_str()).collect();
-    create_store_declarations(&name_refs)
+    create_store_declarations(&context.import_store_names)
 }
 
 /// Inject store subscription declarations for variable declarations only.
@@ -785,17 +884,15 @@ pub fn collect_module_import_store_declarations(
 pub(super) fn inject_store_subscriptions_vars_only_with_program(
     program: &oxc::Program,
     offset: u32,
-    source: &str,
+    context: &mut StoreScanContext<'_>,
     str: &mut MagicString,
 ) {
-    if memchr::memchr(b'$', source.as_bytes()).is_none() {
+    if !context.has_dollar() {
         return;
     }
 
-    let self_named_rune_calls = collect_self_named_rune_call_positions(program, offset);
-    let accessed_stores =
-        collect_store_references_with_shadow(source, &HashMap::new(), &self_named_rune_calls);
-    if accessed_stores.is_empty() {
+    context.resolve_accessed_stores();
+    if context.accessed_stores.is_empty() {
         return;
     }
 
@@ -812,7 +909,7 @@ pub(super) fn inject_store_subscriptions_vars_only_with_program(
                 let names = extract_all_names_from_binding_pattern(&declarator.id);
                 let matching: Vec<String> = names
                     .into_iter()
-                    .filter(|name| accessed_stores.contains(name))
+                    .filter(|name| context.is_accessed(name))
                     .collect();
 
                 if !matching.is_empty() {
@@ -829,6 +926,10 @@ pub(super) fn inject_store_subscriptions_vars_only_with_program(
 mod tests {
     use super::super::test_support::run_svelte2tsx;
     use super::*;
+
+    fn assert_names(context: &StoreScanContext<'_>, expected: &[&str]) {
+        assert_eq!(context.accessed_stores, expected.iter().copied().collect());
+    }
 
     #[test]
     fn collect_loose_dollar_names_strips_dollar_skips_comments_strings_members() {
@@ -849,6 +950,77 @@ mod tests {
         assert!(!got.contains("stringy"), "string literal skipped: {got:?}");
         assert!(!got.contains("member"), "member access skipped: {got:?}");
         assert!(!got.contains("props"), "$$-prefixed skipped: {got:?}");
+    }
+
+    #[test]
+    fn cached_candidates_match_fresh_resolution_across_script_facts() {
+        let source = "<script module>$ignored</script><script>\
+            const state=$state(0); function f($local,$shadowed){return $local+$shadowed+$outside}\
+            const text='prefix $string'; // $comment\n</script>{$local}{$outside}";
+        let function_start = source.find("function f").unwrap() as u32;
+        let function_end = source.find("const text").unwrap() as u32;
+        let rune_pos = source.find("$state(0)").unwrap() as u32;
+
+        let mut context = StoreScanContext::new(source);
+        for name in ["local", "shadowed"] {
+            context
+                .dollar_param_shadow
+                .insert(name.to_string(), vec![(function_start, function_end)]);
+        }
+        context.self_named_rune_calls = vec![rune_pos];
+        context.resolve_accessed_stores();
+        assert_names(&context, &["local", "outside", "string"]);
+
+        let candidate_capacity = context.candidates.capacity();
+        context.dollar_param_shadow.clear();
+        context.self_named_rune_calls.clear();
+        context.resolve_accessed_stores();
+        assert_names(
+            &context,
+            &["local", "outside", "shadowed", "state", "string"],
+        );
+        assert_eq!(context.candidates.capacity(), candidate_capacity);
+    }
+
+    #[test]
+    fn script_fact_resets_do_not_leak_between_module_and_instance() {
+        let source = "<script module>let state=$state(0)</script>\
+            <script>let props=$props();function f($local){return $local}</script>{$visible}";
+        let module_rune = source.find("$state(0)").unwrap() as u32;
+        let instance_rune = source.find("$props()").unwrap() as u32;
+        let function_start = source.find("function f").unwrap() as u32;
+        let function_end = source.rfind("</script>").unwrap() as u32;
+        let mut context = StoreScanContext::new(source);
+
+        context.begin_script_facts();
+        context.add_self_named_rune_call(module_rune);
+        context.finish_script_facts();
+        context.resolve_accessed_stores();
+        assert_names(&context, &["local", "props", "visible"]);
+
+        context.begin_script_facts();
+        context.add_self_named_rune_call(instance_rune);
+        context.add_dollar_param_shadow("$local", (function_start, function_end));
+        context.finish_script_facts();
+        context.resolve_accessed_stores();
+        assert_names(&context, &["visible"]);
+        assert!(!context.self_named_rune_calls.contains(&module_rune));
+        assert_eq!(context.dollar_param_shadow.len(), 1);
+
+        let module_only = "<script module>const local=$state(0)</script>{$state}";
+        let mut context = StoreScanContext::new(module_only);
+        context.self_named_rune_calls = vec![module_only.find("$state(0)").unwrap() as u32];
+        context.resolve_accessed_stores();
+        assert_names(&context, &["state"]);
+    }
+
+    #[test]
+    fn no_dollar_keeps_candidate_scan_lazy() {
+        let source = "<script>const value = 1;</script><p>{value}</p>";
+        let mut context = StoreScanContext::new(source);
+        assert_eq!(context.has_dollar, None);
+        assert!(!context.has_dollar());
+        assert!(!context.candidates_scanned);
     }
 
     #[test]
@@ -969,5 +1141,40 @@ mod tests {
             result.code.contains(store2_block),
             "store2 should have separate ignore block"
         );
+    }
+
+    #[test]
+    fn store_scan_context_preserves_instance_then_module_import_order_at_scale() {
+        let imports = |prefix| {
+            (0..64)
+                .map(|index| format!("{prefix}{index}"))
+                .collect::<Vec<_>>()
+                .join(", ")
+        };
+        let module_imports = imports("moduleStore");
+        let instance_imports = imports("instanceStore");
+        let uses = (0..64)
+            .map(|index| format!("{{$instanceStore{index}}}{{$moduleStore{index}}}"))
+            .collect::<String>();
+        let source = format!(
+            "<script module>import {{ {module_imports} }} from './module'</script>\
+             <script>import {{ {instance_imports} }} from './instance'</script>{uses}"
+        );
+        let result = run_svelte2tsx(&source);
+
+        let mut previous = 0;
+        for prefix in ["instanceStore", "moduleStore"] {
+            for index in 0..64 {
+                let declaration = format!("__sveltets_2_store_get({prefix}{index})");
+                assert_eq!(
+                    result.code.matches(&declaration).count(),
+                    1,
+                    "{declaration} must be emitted exactly once"
+                );
+                let position = result.code.find(&declaration).unwrap();
+                assert!(position >= previous, "import declaration order changed");
+                previous = position;
+            }
+        }
     }
 }

--- a/crates/rsvelte_projection/src/svelte2tsx/script/type_assertion.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/script/type_assertion.rs
@@ -1,79 +1,32 @@
-//! TypeScript syntax rewrites needed to make the script body parse as TSX:
-//! angle-bracket type assertions and single-parameter generic arrows.
-
-use oxc_ast::ast as oxc;
-use oxc_ast_visit::Visit;
-use oxc_span::GetSpan;
+//! TypeScript syntax rewrites needed to make the script body parse as TSX.
 
 use super::super::magic_string::MagicString;
+use super::script_facts::TypeAssertionFacts;
 
-/// Reuses an already-parsed module program (callers parse the module
-/// script once and pass the result here, avoiding a second OXC parse).
 /// Rewrite every TS angle-bracket type assertion `<Type>expr` → `expr as Type`
-/// in `program`, anywhere it appears (function bodies, return statements, etc.),
+/// recorded in `assertions`,
 /// because TSX cannot parse the `<Type>expr` form. Mirrors the official
 /// `handleTypeAssertion` (`nodes/handleTypeAssertion.ts`) surgically — moving the
 /// type after the expression and removing the `<` / `>` — so any inner edits on
 /// the expression (store wraps, etc.) survive untouched.
-pub(super) fn rewrite_type_assertions_with_program(
-    program: &oxc::Program,
-    content_offset: usize,
-    str: &mut MagicString,
-) {
-    let mut collector = TypeAssertionCollector { out: Vec::new() };
-    collector.visit_program(program);
-    let off = content_offset as u32;
-    for a in &collector.out {
-        // assertionStart = `<`, typeStart/typeEnd = the `Type`, exprStart/exprEnd.
-        let assertion_start = a.assertion_start + off;
-        let type_start = a.type_start + off;
-        let type_end = a.type_end + off;
-        let expr_start = a.expr_start + off;
-        let expr_end = a.expr_end + off;
+pub(super) fn rewrite_type_assertions(assertions: &[TypeAssertionFacts], str: &mut MagicString) {
+    for assertion in assertions {
         // ` as ` before the (moved) type, which lands at the expression end.
-        str.append_left(expr_end, " as ");
+        str.append_left(assertion.expr_end, " as ");
         // Move `<Type` to the end of the expression…
-        str.move_range(assertion_start, type_end, expr_end);
+        str.move_range(
+            assertion.assertion_start,
+            assertion.type_end,
+            assertion.expr_end,
+        );
         // …then drop the leading `<` and the trailing `>`.
-        str.remove(assertion_start, type_start);
-        str.remove(type_end, expr_start);
+        str.remove(assertion.assertion_start, assertion.type_start);
+        str.remove(assertion.type_end, assertion.expr_start);
     }
 }
 
-/// One collected `<Type>expr` assertion, spans relative to script content.
-struct CollectedTypeAssertion {
-    assertion_start: u32,
-    type_start: u32,
-    type_end: u32,
-    expr_start: u32,
-    expr_end: u32,
-}
-
-/// Recursively collects every `TSTypeAssertion` in a parsed script.
-struct TypeAssertionCollector {
-    out: Vec<CollectedTypeAssertion>,
-}
-
-impl<'a> Visit<'a> for TypeAssertionCollector {
-    fn visit_ts_type_assertion(&mut self, it: &oxc::TSTypeAssertion<'a>) {
-        let (type_start, type_end) = oxc_ast_span(&it.type_annotation);
-        let expr_span = it.expression.span();
-        self.out.push(CollectedTypeAssertion {
-            assertion_start: it.span.start,
-            type_start,
-            type_end,
-            expr_start: expr_span.start,
-            expr_end: expr_span.end,
-        });
-        // Recurse so nested assertions (and assertions inside the expression)
-        // are collected too.
-        oxc_ast_visit::walk::walk_ts_type_assertion(self, it);
-    }
-}
-
-/// Walk a parsed script `program` and add a trailing comma to every generic
-/// **arrow function** type-parameter list that would otherwise be misparsed as
-/// JSX in the generated `.tsx` overlay.
+/// Add a trailing comma to every collected generic arrow type-parameter list
+/// that would otherwise be misparsed as JSX in the generated `.tsx` overlay.
 ///
 /// In a `.tsx` file `const f = <T>(x: T) => x` is lexed as a JSX element
 /// (`<T>…`), producing a cascade of bogus "JSX element 'T' has no corresponding
@@ -86,97 +39,10 @@ impl<'a> Visit<'a> for TypeAssertionCollector {
 /// Note: this targets arrow functions only. `function foo<T>()`, call type
 /// arguments `f<T>()`, and class / interface generics are all unambiguous in
 /// TSX and are left untouched.
-pub(super) fn disambiguate_arrow_type_params(
-    program: &oxc::Program,
-    offset: u32,
-    raw_content: &str,
-    str: &mut MagicString,
-) {
-    let mut collector = ArrowGenericCommaCollector {
-        raw_content,
-        insert_at: Vec::new(),
-    };
-    collector.visit_program(program);
-    for pos in collector.insert_at {
-        str.append_left(pos + offset, ",");
+pub(super) fn disambiguate_arrow_type_params(insert_at: &[u32], str: &mut MagicString) {
+    for &pos in insert_at {
+        str.append_left(pos, ",");
     }
-}
-
-/// Collects byte offsets (relative to the script content) where a trailing
-/// comma must be inserted into a single-parameter generic arrow function.
-struct ArrowGenericCommaCollector<'s> {
-    raw_content: &'s str,
-    insert_at: Vec<u32>,
-}
-
-impl<'a> Visit<'a> for ArrowGenericCommaCollector<'_> {
-    fn visit_arrow_function_expression(&mut self, it: &oxc::ArrowFunctionExpression<'a>) {
-        if let Some(tp) = it.type_parameters.as_deref() {
-            // Only the single-parameter form is ambiguous. `<T, U>` already
-            // carries a disambiguating comma.
-            if tp.params.len() == 1 {
-                let param = &tp.params[0];
-                // A constraint (`extends`) or default (`=`) already makes the
-                // list unambiguous in TSX, so leave those alone.
-                if param.constraint.is_none() && param.default.is_none() {
-                    let bytes = self.raw_content.as_bytes();
-                    let mut i = param.span.end as usize;
-                    // Skip whitespace up to the closing `>` (or an existing
-                    // trailing comma).
-                    while i < bytes.len() && bytes[i].is_ascii_whitespace() {
-                        i += 1;
-                    }
-                    let already_has_comma = i < bytes.len() && bytes[i] == b',';
-                    if !already_has_comma {
-                        self.insert_at.push(param.span.end);
-                    }
-                }
-            }
-        }
-        // Recurse so nested arrow functions are handled too.
-        oxc_ast_visit::walk::walk_arrow_function_expression(self, it);
-    }
-}
-
-fn oxc_ast_span(ty: &oxc::TSType) -> (u32, u32) {
-    use oxc::TSType::*;
-    let span = match ty {
-        TSAnyKeyword(t) => t.span,
-        TSBigIntKeyword(t) => t.span,
-        TSBooleanKeyword(t) => t.span,
-        TSIntrinsicKeyword(t) => t.span,
-        TSNeverKeyword(t) => t.span,
-        TSNullKeyword(t) => t.span,
-        TSNumberKeyword(t) => t.span,
-        TSObjectKeyword(t) => t.span,
-        TSStringKeyword(t) => t.span,
-        TSSymbolKeyword(t) => t.span,
-        TSUndefinedKeyword(t) => t.span,
-        TSUnknownKeyword(t) => t.span,
-        TSVoidKeyword(t) => t.span,
-        TSThisType(t) => t.span,
-        TSTypeReference(t) => t.span,
-        TSArrayType(t) => t.span,
-        TSConditionalType(t) => t.span,
-        TSConstructorType(t) => t.span,
-        TSFunctionType(t) => t.span,
-        TSImportType(t) => t.span,
-        TSIndexedAccessType(t) => t.span,
-        TSInferType(t) => t.span,
-        TSIntersectionType(t) => t.span,
-        TSLiteralType(t) => t.span,
-        TSMappedType(t) => t.span,
-        TSNamedTupleMember(t) => t.span,
-        TSTemplateLiteralType(t) => t.span,
-        TSTupleType(t) => t.span,
-        TSTypeLiteral(t) => t.span,
-        TSTypeOperatorType(t) => t.span,
-        TSTypePredicate(t) => t.span,
-        TSTypeQuery(t) => t.span,
-        TSUnionType(t) => t.span,
-        _ => return (0, 0),
-    };
-    (span.start, span.end)
 }
 
 #[cfg(test)]
@@ -246,5 +112,66 @@ mod tests {
             "got: {}",
             result.code
         );
+    }
+
+    #[test]
+    fn test_nested_function_arrow_assertion_facts_apply_without_store_injection() {
+        let source = "<script lang=\"ts\">\n\
+            const store = {};\n\
+            function outer($store: unknown) {\n\
+                const inner = <T>($inner: T) => {\n\
+                    const asserted = <Inner>$inner;\n\
+                    return asserted;\n\
+                };\n\
+                return <Outer>inner;\n\
+            }\n\
+            </script>";
+        let result = run_svelte2tsx(source);
+
+        assert!(
+            result.code.contains("<T,>($inner: T)"),
+            "got: {}",
+            result.code
+        );
+        assert!(
+            result.code.contains("$inner as Inner"),
+            "got: {}",
+            result.code
+        );
+        assert!(
+            result.code.contains("inner as Outer"),
+            "got: {}",
+            result.code
+        );
+        assert!(
+            !result.code.contains("__sveltets_2_store_get(store)"),
+            "got: {}",
+            result.code
+        );
+        assert!(
+            !result.code.contains("__sveltets_2_store_get(inner)"),
+            "got: {}",
+            result.code
+        );
+    }
+
+    #[test]
+    fn test_module_nested_arrow_assertion_uses_collected_facts() {
+        let source = "<script context=\"module\" lang=\"ts\">\n\
+            export const wrap = <T>(value: T) => <Box<T>>(() => <Inner<T>>value);\n\
+            </script>";
+        let result = run_svelte2tsx(source);
+
+        assert!(
+            result.code.contains("<T,>(value: T)"),
+            "got: {}",
+            result.code
+        );
+        assert!(
+            result.code.contains("value as Inner<T>"),
+            "got: {}",
+            result.code
+        );
+        assert!(result.code.contains("as Box<T>"), "got: {}", result.code);
     }
 }

--- a/crates/rsvelte_projection/src/svelte2tsx/svelte2tsx.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/svelte2tsx.rs
@@ -295,7 +295,7 @@ pub fn svelte2tsx(
     // Step 5: Initialize tracking structures
     let mut exported_names = ExportedNames::new();
     let mut events = ComponentEvents::new();
-    let mut store_scan = StoreScanContext::new(source);
+    let mut store_scan = StoreScanContext::new(source, ast.module.is_some());
 
     if explicit_runes {
         exported_names.set_uses_runes(true);

--- a/crates/rsvelte_projection/src/svelte2tsx/svelte2tsx.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/svelte2tsx.rs
@@ -20,7 +20,7 @@ use super::nodes::slot::fragment_has_slot_element;
 use super::nodes::snippet_hoisting::hoist_top_level_snippets;
 use super::nodes::svelte_options::emit_svelte_options_element;
 use super::process_instance_script_tag::process_instance_script_tag;
-use super::script::{ComponentEvents, ExportedNames};
+use super::script::{ComponentEvents, ExportedNames, StoreScanContext};
 use super::template;
 use super::utils::htmlxparser::{blank_style_content, blank_style_tags, remove_orphan_scripts};
 use super::validation::{validate_debug_tag_arguments, validate_meta_element_placement};
@@ -295,6 +295,7 @@ pub fn svelte2tsx(
     // Step 5: Initialize tracking structures
     let mut exported_names = ExportedNames::new();
     let mut events = ComponentEvents::new();
+    let mut store_scan = StoreScanContext::new(source);
 
     if explicit_runes {
         exported_names.set_uses_runes(true);
@@ -302,7 +303,13 @@ pub fn svelte2tsx(
 
     // Step 6: Process module script (<script context="module">)
     if let (Some(module), Some(parsed)) = (&ast.module, &parsed_scripts.module) {
-        super::script::process_module_script(module, parsed, source, &mut str, &mut exported_names);
+        super::script::process_module_script(
+            module,
+            parsed,
+            &mut store_scan,
+            &mut str,
+            &mut exported_names,
+        );
     }
 
     // Step 7: Process instance script (<script>)
@@ -338,6 +345,7 @@ pub fn svelte2tsx(
                 .as_ref()
                 .map(|script| script.program()),
             source,
+            &mut store_scan,
             &mut str,
             &mut exported_names,
             &mut events,
@@ -602,6 +610,7 @@ pub fn svelte2tsx(
             .as_ref()
             .map(|script| script.program()),
         source,
+        &mut store_scan,
         &options,
         &mut str,
         &dollar_decls,


### PR DESCRIPTION
> Stack 2/8  
> Base: `agent/svelte2tsx-release-01-front-end` (`e0196d5f`)  
> Head: `agent/svelte2tsx-release-02-script-analysis` (`52785492`)

## Summary

- reuse one binding inventory and fuse script fact collection
- skip store analysis when no dollar token exists, then share and right-size the
  remaining store scan state
- borrow simple binding names from source
- replace repeated hoist fixed-point scans with indexed dependencies and
  worklists
- fuse hoistable-type token scans

The changes build on retained parser programs from PR 1 and preserve store
shadowing, rune handling, declaration order, blocked propagation, cycles, and
duplicate-name behavior.

## Commit scope

- `13019fd5` perf(svelte2tsx): reuse binding inventory ownership
- `04e5f522` perf(svelte2tsx): fuse script fact walks
- `ba7188f3` perf(svelte2tsx): skip store analysis without dollar tokens
- `efd99a48` perf(svelte2tsx): reuse store scan state
- `33d5554a` perf(svelte2tsx): avoid one-shot store candidate caches
- `e0674779` perf(svelte2tsx): borrow simple binding names
- `daac32ee` perf(svelte2tsx): index hoist dependencies
- `36b402cd` perf(svelte2tsx): linearize type hoist dependencies
- `52785492` perf(svelte2tsx): fuse hoistable type token scans

## Validation

- [ ] `cargo fmt --check`
- [ ] `cargo clippy -p rsvelte_projection --all-targets --all-features -- -D warnings`
- [ ] `cargo test -p rsvelte_projection --test svelte2tsx_binding_ts_assertion`
- [ ] `cargo test -p rsvelte_projection --test svelte2tsx_fixtures`
- [ ] `cargo test -p rsvelte_projection`

## Stack order

Merge after PR 1. PR 3 is based on this head.
