### PR TITLE
Stream svelte2tsx events, exports, and comment metadata

### DIFF
--- a/crates/rsvelte_projection/src/svelte2tsx/add_component_export.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/add_component_export.rs
@@ -21,7 +21,7 @@ pub(crate) struct ComponentExportParams<'a> {
     pub source: &'a str,
     pub options: &'a Svelte2TsxOptions,
     pub component_name: &'a str,
-    pub template_info: &'a template::TemplateInfo,
+    pub template_info: &'a template::TemplateInfo<'a>,
     pub exported_names: &'a ExportedNames,
     pub events: &'a mut ComponentEvents,
     pub generics_attribute: Option<&'a str>,

--- a/crates/rsvelte_projection/src/svelte2tsx/nodes/component_events.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/nodes/component_events.rs
@@ -10,24 +10,24 @@ use super::super::script::{ComponentEvents, ExportedNames};
 use super::super::template;
 
 struct ForwardedEventValues<'a> {
-    first: &'a str,
-    rest: Vec<&'a str>,
+    first: &'a template::ForwardedEvent<'a>,
+    rest: Vec<&'a template::ForwardedEvent<'a>>,
 }
 
 impl<'a> ForwardedEventValues<'a> {
-    fn new(value: &'a str) -> Self {
+    fn new(value: &'a template::ForwardedEvent<'a>) -> Self {
         Self {
             first: value,
             rest: Vec::new(),
         }
     }
 
-    fn overwrite(&mut self, value: &'a str) {
+    fn overwrite(&mut self, value: &'a template::ForwardedEvent<'a>) {
         self.first = value;
         self.rest.clear();
     }
 
-    fn append(&mut self, value: &'a str) {
+    fn append(&mut self, value: &'a template::ForwardedEvent<'a>) {
         self.rest.push(value);
     }
 
@@ -38,43 +38,74 @@ impl<'a> ForwardedEventValues<'a> {
 
 type ForwardedEvents<'a> = IndexMap<&'a str, ForwardedEventValues<'a>, FxBuildHasher>;
 
-fn group_forwarded_events(
-    events: &[(String, String, template::ForwardedEventKind)],
-) -> ForwardedEvents<'_> {
-    group_forwarded_events_with_observer(events, || {})
-}
-
 fn group_forwarded_events_with_observer<'a>(
-    events: &'a [(String, String, template::ForwardedEventKind)],
+    events: &'a [template::ForwardedEvent<'a>],
     mut observe_lookup: impl FnMut(),
 ) -> ForwardedEvents<'a> {
     let mut grouped: ForwardedEvents<'a> =
         IndexMap::with_capacity_and_hasher(events.len(), FxBuildHasher);
-    for (name, value, kind) in events {
+    for event in events {
         observe_lookup();
-        match grouped.entry(name.as_str()) {
-            Entry::Occupied(mut entry) => match kind {
-                template::ForwardedEventKind::Element => {
-                    entry.get_mut().overwrite(value);
+        match grouped.entry(event.name) {
+            Entry::Occupied(mut entry) => match event.source {
+                template::ForwardedEventSource::Mapped(_) => {
+                    entry.get_mut().overwrite(event);
                 }
-                template::ForwardedEventKind::Component => {
-                    entry.get_mut().append(value);
+                template::ForwardedEventSource::Component(_) => {
+                    entry.get_mut().append(event);
                 }
             },
             Entry::Vacant(entry) => {
-                entry.insert(ForwardedEventValues::new(value));
+                entry.insert(ForwardedEventValues::new(event));
             }
         }
     }
     grouped
 }
 
+fn write_forwarded_event_value(
+    output: &mut String,
+    event: &template::ForwardedEvent<'_>,
+    observe_materialization: &mut impl FnMut(),
+) {
+    observe_materialization();
+    match event.source {
+        template::ForwardedEventSource::Mapped(mapper) => {
+            let mapper = match mapper {
+                template::ForwardedEventMapper::Element => "mapElementEvent",
+                template::ForwardedEventMapper::Body => "mapBodyEvent",
+                template::ForwardedEventMapper::Window => "mapWindowEvent",
+            };
+            write!(output, "__sveltets_2_{mapper}('{}')", event.name)
+                .expect("writing to a String cannot fail");
+        }
+        template::ForwardedEventSource::Component(component) => {
+            write!(
+                output,
+                "__sveltets_2_bubbleEventDef(__sveltets_2_instanceOf({component}).$$events_def, '{}')",
+                event.name
+            )
+            .expect("writing to a String cannot fail");
+        }
+    }
+}
+
 /// Build the `events` object literal for the component export from template info
 /// and component events.
 pub(crate) fn build_events_str(
     exported_names: &ExportedNames,
-    template_info: &template::TemplateInfo,
+    template_info: &template::TemplateInfo<'_>,
     events: &ComponentEvents,
+) -> String {
+    build_events_str_with_observer(exported_names, template_info, events, || {}, || {})
+}
+
+fn build_events_str_with_observer(
+    exported_names: &ExportedNames,
+    template_info: &template::TemplateInfo<'_>,
+    events: &ComponentEvents,
+    mut observe_lookup: impl FnMut(),
+    mut observe_materialization: impl FnMut(),
 ) -> String {
     if exported_names.has_events_type {
         "{} as unknown as $$Events".to_string()
@@ -98,14 +129,21 @@ pub(crate) fn build_events_str(
         //     forwarding component instance contributes a `unionType` member).
         // Key insertion order (first occurrence) is preserved. A single value is
         // emitted plain; multiple values become `__sveltets_2_unionType(...)`.
-        let grouped = group_forwarded_events(&template_info.element_events);
+        let grouped = group_forwarded_events_with_observer(
+            &template_info.element_events,
+            &mut observe_lookup,
+        );
         for (name, values) in grouped {
             if values.is_single() {
-                event_parts.push(format!("'{name}':{}", values.first));
+                let mut part = format!("'{name}':");
+                write_forwarded_event_value(&mut part, values.first, &mut observe_materialization);
+                event_parts.push(part);
             } else {
-                let mut part = format!("'{name}':__sveltets_2_unionType({}", values.first);
+                let mut part = format!("'{name}':__sveltets_2_unionType(");
+                write_forwarded_event_value(&mut part, values.first, &mut observe_materialization);
                 for value in values.rest {
-                    write!(part, ", {value}").expect("writing to a String cannot fail");
+                    part.push_str(", ");
+                    write_forwarded_event_value(&mut part, value, &mut observe_materialization);
                 }
                 part.push(')');
                 event_parts.push(part);
@@ -127,43 +165,29 @@ pub(crate) fn build_events_str(
 mod tests {
     use super::*;
 
-    fn forwarded(
-        name: &str,
-        value: &str,
-        kind: template::ForwardedEventKind,
-    ) -> (String, String, template::ForwardedEventKind) {
-        (name.to_string(), value.to_string(), kind)
+    fn mapped(name: &str, mapper: template::ForwardedEventMapper) -> template::ForwardedEvent<'_> {
+        template::ForwardedEvent {
+            name,
+            source: template::ForwardedEventSource::Mapped(mapper),
+        }
+    }
+
+    fn component<'a>(name: &'a str, target: &'a str) -> template::ForwardedEvent<'a> {
+        template::ForwardedEvent {
+            name,
+            source: template::ForwardedEventSource::Component(target),
+        }
     }
 
     #[test]
     fn forwarded_events_preserve_first_key_order_through_overwrite() {
         let template_info = template::TemplateInfo {
             element_events: vec![
-                forwarded(
-                    "alpha",
-                    "alpha-component-first",
-                    template::ForwardedEventKind::Component,
-                ),
-                forwarded(
-                    "beta",
-                    "beta-element-first",
-                    template::ForwardedEventKind::Element,
-                ),
-                forwarded(
-                    "gamma",
-                    "gamma-component-first",
-                    template::ForwardedEventKind::Component,
-                ),
-                forwarded(
-                    "alpha",
-                    "alpha-element-overwrite",
-                    template::ForwardedEventKind::Element,
-                ),
-                forwarded(
-                    "beta",
-                    "beta-element-overwrite",
-                    template::ForwardedEventKind::Element,
-                ),
+                component("alpha", "AlphaFirst"),
+                mapped("beta", template::ForwardedEventMapper::Window),
+                component("gamma", "Gamma"),
+                mapped("alpha", template::ForwardedEventMapper::Body),
+                mapped("beta", template::ForwardedEventMapper::Element),
             ],
             ..Default::default()
         };
@@ -174,8 +198,10 @@ mod tests {
                 &template_info,
                 &ComponentEvents::default()
             ),
-            "{'alpha':alpha-element-overwrite, 'beta':beta-element-overwrite, \
-             'gamma':gamma-component-first}"
+            "{'alpha':__sveltets_2_mapBodyEvent('alpha'), \
+             'beta':__sveltets_2_mapElementEvent('beta'), \
+             'gamma':__sveltets_2_bubbleEventDef(__sveltets_2_instanceOf(Gamma).$$events_def, \
+             'gamma')}"
         );
     }
 
@@ -183,26 +209,10 @@ mod tests {
     fn forwarded_component_unions_retain_encounter_order_after_overwrite() {
         let template_info = template::TemplateInfo {
             element_events: vec![
-                forwarded(
-                    "alpha",
-                    "alpha-component-before-overwrite",
-                    template::ForwardedEventKind::Component,
-                ),
-                forwarded(
-                    "alpha",
-                    "alpha-element-overwrite",
-                    template::ForwardedEventKind::Element,
-                ),
-                forwarded(
-                    "alpha",
-                    "alpha-component-second",
-                    template::ForwardedEventKind::Component,
-                ),
-                forwarded(
-                    "alpha",
-                    "alpha-component-third",
-                    template::ForwardedEventKind::Component,
-                ),
+                component("alpha", "Before"),
+                mapped("alpha", template::ForwardedEventMapper::Element),
+                component("alpha", "Second"),
+                component("alpha", "Third"),
             ],
             ..Default::default()
         };
@@ -213,63 +223,43 @@ mod tests {
                 &template_info,
                 &ComponentEvents::default()
             ),
-            "{'alpha':__sveltets_2_unionType(alpha-element-overwrite, \
-             alpha-component-second, alpha-component-third)}"
+            "{'alpha':__sveltets_2_unionType(__sveltets_2_mapElementEvent('alpha'), \
+             __sveltets_2_bubbleEventDef(__sveltets_2_instanceOf(Second).$$events_def, 'alpha'), \
+             __sveltets_2_bubbleEventDef(__sveltets_2_instanceOf(Third).$$events_def, 'alpha'))}"
         );
     }
 
     #[test]
-    fn forwarded_event_grouping_uses_one_lookup_per_unique_or_repeated_event() {
-        for event_count in [32, 256, 1024] {
-            let unique: Vec<_> = (0..event_count)
-                .map(|index| {
-                    forwarded(
-                        &format!("event-{index}"),
-                        &format!("value-{index}"),
-                        template::ForwardedEventKind::Element,
-                    )
-                })
-                .collect();
-            let mut unique_lookups = 0;
-            let unique_grouped =
-                group_forwarded_events_with_observer(&unique, || unique_lookups += 1);
-
-            assert_eq!(unique_lookups, event_count);
-            assert_eq!(unique_grouped.len(), event_count);
-            for index in 0..event_count {
-                let (name, values) = unique_grouped.get_index(index).unwrap();
-                assert_eq!(*name, format!("event-{index}"));
-                assert_eq!(values.first, format!("value-{index}"));
-                assert!(values.rest.is_empty());
-            }
-
-            let unique_name_count = event_count / 4;
-            let mut repeated = Vec::with_capacity(event_count);
-            for occurrence in 0..4 {
-                for index in 0..unique_name_count {
-                    repeated.push(forwarded(
-                        &format!("event-{index}"),
-                        &format!("value-{occurrence}-{index}"),
-                        if occurrence == 2 {
-                            template::ForwardedEventKind::Element
-                        } else {
-                            template::ForwardedEventKind::Component
-                        },
-                    ));
-                }
-            }
-            let mut repeated_lookups = 0;
-            let repeated_grouped =
-                group_forwarded_events_with_observer(&repeated, || repeated_lookups += 1);
-
-            assert_eq!(repeated_lookups, event_count);
-            assert_eq!(repeated_grouped.len(), unique_name_count);
-            for index in 0..unique_name_count {
-                let (name, values) = repeated_grouped.get_index(index).unwrap();
-                assert_eq!(*name, format!("event-{index}"));
-                assert_eq!(values.first, format!("value-2-{index}"));
-                assert_eq!(values.rest, [format!("value-3-{index}")]);
+    fn forwarded_event_descriptor_defers_overwritten_materializations_at_scale() {
+        let names: Vec<_> = (0..256).map(|index| format!("event-{index}")).collect();
+        let mut forwarded = Vec::with_capacity(1024);
+        for occurrence in 0..4 {
+            for name in &names {
+                forwarded.push(if occurrence == 2 {
+                    mapped(name, template::ForwardedEventMapper::Element)
+                } else {
+                    component(name, "Component")
+                });
             }
         }
+        let template_info = template::TemplateInfo {
+            element_events: forwarded,
+            ..Default::default()
+        };
+        let mut lookups = 0;
+        let mut materializations = 0;
+
+        let output = build_events_str_with_observer(
+            &ExportedNames::default(),
+            &template_info,
+            &ComponentEvents::default(),
+            || lookups += 1,
+            || materializations += 1,
+        );
+
+        assert_eq!(lookups, 1024);
+        assert_eq!(materializations, 512);
+        assert_eq!(output.matches("'event-").count(), 768);
+        assert_eq!(output.matches(":__sveltets_2_unionType(").count(), 256);
     }
 }

--- a/crates/rsvelte_projection/src/svelte2tsx/nodes/component_events.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/nodes/component_events.rs
@@ -1,8 +1,73 @@
 //! The `events` literal of the component export — mirrors
 //! `svelte2tsx/nodes/ComponentEvents.ts`.
 
+use std::fmt::Write as _;
+
+use indexmap::{IndexMap, map::Entry};
+use rustc_hash::FxBuildHasher;
+
 use super::super::script::{ComponentEvents, ExportedNames};
 use super::super::template;
+
+struct ForwardedEventValues<'a> {
+    first: &'a str,
+    rest: Vec<&'a str>,
+}
+
+impl<'a> ForwardedEventValues<'a> {
+    fn new(value: &'a str) -> Self {
+        Self {
+            first: value,
+            rest: Vec::new(),
+        }
+    }
+
+    fn overwrite(&mut self, value: &'a str) {
+        self.first = value;
+        self.rest.clear();
+    }
+
+    fn append(&mut self, value: &'a str) {
+        self.rest.push(value);
+    }
+
+    fn is_single(&self) -> bool {
+        self.rest.is_empty()
+    }
+}
+
+type ForwardedEvents<'a> = IndexMap<&'a str, ForwardedEventValues<'a>, FxBuildHasher>;
+
+fn group_forwarded_events(
+    events: &[(String, String, template::ForwardedEventKind)],
+) -> ForwardedEvents<'_> {
+    group_forwarded_events_with_observer(events, || {})
+}
+
+fn group_forwarded_events_with_observer<'a>(
+    events: &'a [(String, String, template::ForwardedEventKind)],
+    mut observe_lookup: impl FnMut(),
+) -> ForwardedEvents<'a> {
+    let mut grouped: ForwardedEvents<'a> =
+        IndexMap::with_capacity_and_hasher(events.len(), FxBuildHasher);
+    for (name, value, kind) in events {
+        observe_lookup();
+        match grouped.entry(name.as_str()) {
+            Entry::Occupied(mut entry) => match kind {
+                template::ForwardedEventKind::Element => {
+                    entry.get_mut().overwrite(value);
+                }
+                template::ForwardedEventKind::Component => {
+                    entry.get_mut().append(value);
+                }
+            },
+            Entry::Vacant(entry) => {
+                entry.insert(ForwardedEventValues::new(value));
+            }
+        }
+    }
+    grouped
+}
 
 /// Build the `events` object literal for the component export from template info
 /// and component events.
@@ -33,35 +98,17 @@ pub(crate) fn build_events_str(
         //     forwarding component instance contributes a `unionType` member).
         // Key insertion order (first occurrence) is preserved. A single value is
         // emitted plain; multiple values become `__sveltets_2_unionType(...)`.
-        let mut grouped: Vec<(String, Vec<String>)> = Vec::new();
-        for (name, value, kind) in &template_info.element_events {
-            match kind {
-                crate::svelte2tsx::template::ForwardedEventKind::Element => {
-                    if let Some(entry) = grouped.iter_mut().find(|(n, _)| n == name) {
-                        // Plain overwrite (official `set`): a single value.
-                        entry.1 = vec![value.clone()];
-                    } else {
-                        grouped.push((name.clone(), vec![value.clone()]));
-                    }
-                }
-                crate::svelte2tsx::template::ForwardedEventKind::Component => {
-                    if let Some(entry) = grouped.iter_mut().find(|(n, _)| n == name) {
-                        entry.1.push(value.clone());
-                    } else {
-                        grouped.push((name.clone(), vec![value.clone()]));
-                    }
-                }
-            }
-        }
-        for (name, values) in &grouped {
-            if values.len() == 1 {
-                event_parts.push(format!("'{}':{}", name, values[0]));
+        let grouped = group_forwarded_events(&template_info.element_events);
+        for (name, values) in grouped {
+            if values.is_single() {
+                event_parts.push(format!("'{name}':{}", values.first));
             } else {
-                event_parts.push(format!(
-                    "'{}':__sveltets_2_unionType({})",
-                    name,
-                    values.join(", ")
-                ));
+                let mut part = format!("'{name}':__sveltets_2_unionType({}", values.first);
+                for value in values.rest {
+                    write!(part, ", {value}").expect("writing to a String cannot fail");
+                }
+                part.push(')');
+                event_parts.push(part);
             }
         }
         // Add custom events from dispatchers (detected during script processing)
@@ -72,6 +119,157 @@ pub(crate) fn build_events_str(
             "{}".to_string()
         } else {
             format!("{{{}}}", event_parts.join(", "))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn forwarded(
+        name: &str,
+        value: &str,
+        kind: template::ForwardedEventKind,
+    ) -> (String, String, template::ForwardedEventKind) {
+        (name.to_string(), value.to_string(), kind)
+    }
+
+    #[test]
+    fn forwarded_events_preserve_first_key_order_through_overwrite() {
+        let template_info = template::TemplateInfo {
+            element_events: vec![
+                forwarded(
+                    "alpha",
+                    "alpha-component-first",
+                    template::ForwardedEventKind::Component,
+                ),
+                forwarded(
+                    "beta",
+                    "beta-element-first",
+                    template::ForwardedEventKind::Element,
+                ),
+                forwarded(
+                    "gamma",
+                    "gamma-component-first",
+                    template::ForwardedEventKind::Component,
+                ),
+                forwarded(
+                    "alpha",
+                    "alpha-element-overwrite",
+                    template::ForwardedEventKind::Element,
+                ),
+                forwarded(
+                    "beta",
+                    "beta-element-overwrite",
+                    template::ForwardedEventKind::Element,
+                ),
+            ],
+            ..Default::default()
+        };
+
+        assert_eq!(
+            build_events_str(
+                &ExportedNames::default(),
+                &template_info,
+                &ComponentEvents::default()
+            ),
+            "{'alpha':alpha-element-overwrite, 'beta':beta-element-overwrite, \
+             'gamma':gamma-component-first}"
+        );
+    }
+
+    #[test]
+    fn forwarded_component_unions_retain_encounter_order_after_overwrite() {
+        let template_info = template::TemplateInfo {
+            element_events: vec![
+                forwarded(
+                    "alpha",
+                    "alpha-component-before-overwrite",
+                    template::ForwardedEventKind::Component,
+                ),
+                forwarded(
+                    "alpha",
+                    "alpha-element-overwrite",
+                    template::ForwardedEventKind::Element,
+                ),
+                forwarded(
+                    "alpha",
+                    "alpha-component-second",
+                    template::ForwardedEventKind::Component,
+                ),
+                forwarded(
+                    "alpha",
+                    "alpha-component-third",
+                    template::ForwardedEventKind::Component,
+                ),
+            ],
+            ..Default::default()
+        };
+
+        assert_eq!(
+            build_events_str(
+                &ExportedNames::default(),
+                &template_info,
+                &ComponentEvents::default()
+            ),
+            "{'alpha':__sveltets_2_unionType(alpha-element-overwrite, \
+             alpha-component-second, alpha-component-third)}"
+        );
+    }
+
+    #[test]
+    fn forwarded_event_grouping_uses_one_lookup_per_unique_or_repeated_event() {
+        for event_count in [32, 256, 1024] {
+            let unique: Vec<_> = (0..event_count)
+                .map(|index| {
+                    forwarded(
+                        &format!("event-{index}"),
+                        &format!("value-{index}"),
+                        template::ForwardedEventKind::Element,
+                    )
+                })
+                .collect();
+            let mut unique_lookups = 0;
+            let unique_grouped =
+                group_forwarded_events_with_observer(&unique, || unique_lookups += 1);
+
+            assert_eq!(unique_lookups, event_count);
+            assert_eq!(unique_grouped.len(), event_count);
+            for index in 0..event_count {
+                let (name, values) = unique_grouped.get_index(index).unwrap();
+                assert_eq!(*name, format!("event-{index}"));
+                assert_eq!(values.first, format!("value-{index}"));
+                assert!(values.rest.is_empty());
+            }
+
+            let unique_name_count = event_count / 4;
+            let mut repeated = Vec::with_capacity(event_count);
+            for occurrence in 0..4 {
+                for index in 0..unique_name_count {
+                    repeated.push(forwarded(
+                        &format!("event-{index}"),
+                        &format!("value-{occurrence}-{index}"),
+                        if occurrence == 2 {
+                            template::ForwardedEventKind::Element
+                        } else {
+                            template::ForwardedEventKind::Component
+                        },
+                    ));
+                }
+            }
+            let mut repeated_lookups = 0;
+            let repeated_grouped =
+                group_forwarded_events_with_observer(&repeated, || repeated_lookups += 1);
+
+            assert_eq!(repeated_lookups, event_count);
+            assert_eq!(repeated_grouped.len(), unique_name_count);
+            for index in 0..unique_name_count {
+                let (name, values) = repeated_grouped.get_index(index).unwrap();
+                assert_eq!(*name, format!("event-{index}"));
+                assert_eq!(values.first, format!("value-2-{index}"));
+                assert_eq!(values.rest, [format!("value-3-{index}")]);
+            }
         }
     }
 }

--- a/crates/rsvelte_projection/src/svelte2tsx/nodes/component_events.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/nodes/component_events.rs
@@ -38,27 +38,123 @@ impl<'a> ForwardedEventValues<'a> {
 
 type ForwardedEvents<'a> = IndexMap<&'a str, ForwardedEventValues<'a>, FxBuildHasher>;
 
-fn group_forwarded_events_with_observer<'a>(
-    events: &'a [template::ForwardedEvent<'a>],
-    mut observe_lookup: impl FnMut(),
-) -> ForwardedEvents<'a> {
-    let mut grouped: ForwardedEvents<'a> =
-        IndexMap::with_capacity_and_hasher(events.len(), FxBuildHasher);
-    for event in events {
-        observe_lookup();
-        match grouped.entry(event.name) {
-            Entry::Occupied(mut entry) => match event.source {
-                template::ForwardedEventSource::Mapped(_) => {
-                    entry.get_mut().overwrite(event);
+// Eight caps the linear prefix at 36 comparisons while keeping typical event sets map-free.
+const FORWARDED_EVENT_LINEAR_LIMIT: usize = 8;
+
+struct ForwardedEventEntry<'a> {
+    name: &'a str,
+    values: ForwardedEventValues<'a>,
+}
+
+enum GroupedForwardedEvents<'a> {
+    Linear(Vec<ForwardedEventEntry<'a>>),
+    Indexed(ForwardedEvents<'a>),
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum GroupingOperation {
+    LinearComparison,
+    IndexedLookup,
+    Promotion,
+}
+
+impl<'a> GroupedForwardedEvents<'a> {
+    fn new(occurrences: usize) -> Self {
+        Self::Linear(Vec::with_capacity(
+            occurrences.min(FORWARDED_EVENT_LINEAR_LIMIT),
+        ))
+    }
+
+    fn insert(
+        &mut self,
+        event: &'a template::ForwardedEvent<'a>,
+        observe: &mut impl FnMut(GroupingOperation),
+    ) {
+        if let Self::Indexed(grouped) = self {
+            observe(GroupingOperation::IndexedLookup);
+            match grouped.entry(event.name) {
+                Entry::Occupied(mut entry) => merge_forwarded_event(entry.get_mut(), event),
+                Entry::Vacant(entry) => {
+                    entry.insert(ForwardedEventValues::new(event));
                 }
-                template::ForwardedEventSource::Component(_) => {
-                    entry.get_mut().append(event);
-                }
-            },
-            Entry::Vacant(entry) => {
-                entry.insert(ForwardedEventValues::new(event));
+            }
+            return;
+        }
+
+        let Self::Linear(grouped) = self else {
+            unreachable!()
+        };
+        for entry in grouped.iter_mut() {
+            observe(GroupingOperation::LinearComparison);
+            if entry.name == event.name {
+                merge_forwarded_event(&mut entry.values, event);
+                return;
             }
         }
+        if grouped.len() < FORWARDED_EVENT_LINEAR_LIMIT {
+            grouped.push(ForwardedEventEntry {
+                name: event.name,
+                values: ForwardedEventValues::new(event),
+            });
+            return;
+        }
+
+        observe(GroupingOperation::Promotion);
+        let mut indexed =
+            IndexMap::with_capacity_and_hasher(FORWARDED_EVENT_LINEAR_LIMIT + 1, FxBuildHasher);
+        for entry in grouped.drain(..) {
+            indexed.insert(entry.name, entry.values);
+        }
+        indexed.insert(event.name, ForwardedEventValues::new(event));
+        *self = Self::Indexed(indexed);
+    }
+}
+
+enum GroupedForwardedEventsIntoIter<'a> {
+    Linear(std::vec::IntoIter<ForwardedEventEntry<'a>>),
+    Indexed(indexmap::map::IntoIter<&'a str, ForwardedEventValues<'a>>),
+}
+
+impl<'a> Iterator for GroupedForwardedEventsIntoIter<'a> {
+    type Item = (&'a str, ForwardedEventValues<'a>);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self {
+            Self::Linear(entries) => entries.next().map(|entry| (entry.name, entry.values)),
+            Self::Indexed(entries) => entries.next(),
+        }
+    }
+}
+
+impl<'a> IntoIterator for GroupedForwardedEvents<'a> {
+    type Item = (&'a str, ForwardedEventValues<'a>);
+    type IntoIter = GroupedForwardedEventsIntoIter<'a>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        match self {
+            Self::Linear(entries) => GroupedForwardedEventsIntoIter::Linear(entries.into_iter()),
+            Self::Indexed(entries) => GroupedForwardedEventsIntoIter::Indexed(entries.into_iter()),
+        }
+    }
+}
+
+fn merge_forwarded_event<'a>(
+    values: &mut ForwardedEventValues<'a>,
+    event: &'a template::ForwardedEvent<'a>,
+) {
+    match event.source {
+        template::ForwardedEventSource::Mapped(_) => values.overwrite(event),
+        template::ForwardedEventSource::Component(_) => values.append(event),
+    }
+}
+
+fn group_forwarded_events_with_observer<'a>(
+    events: &'a [template::ForwardedEvent<'a>],
+    mut observe: impl FnMut(GroupingOperation),
+) -> GroupedForwardedEvents<'a> {
+    let mut grouped = GroupedForwardedEvents::new(events.len());
+    for event in events {
+        grouped.insert(event, &mut observe);
     }
     grouped
 }
@@ -97,14 +193,14 @@ pub(crate) fn build_events_str(
     template_info: &template::TemplateInfo<'_>,
     events: &ComponentEvents,
 ) -> String {
-    build_events_str_with_observer(exported_names, template_info, events, || {}, || {})
+    build_events_str_with_observer(exported_names, template_info, events, |_| {}, || {})
 }
 
 fn build_events_str_with_observer(
     exported_names: &ExportedNames,
     template_info: &template::TemplateInfo<'_>,
     events: &ComponentEvents,
-    mut observe_lookup: impl FnMut(),
+    mut observe_grouping: impl FnMut(GroupingOperation),
     mut observe_materialization: impl FnMut(),
 ) -> String {
     if exported_names.has_events_type {
@@ -131,7 +227,7 @@ fn build_events_str_with_observer(
         // emitted plain; multiple values become `__sveltets_2_unionType(...)`.
         let grouped = group_forwarded_events_with_observer(
             &template_info.element_events,
-            &mut observe_lookup,
+            &mut observe_grouping,
         );
         for (name, values) in grouped {
             if values.is_single() {
@@ -230,6 +326,111 @@ mod tests {
     }
 
     #[test]
+    fn forwarded_event_grouping_promotes_after_linear_limit() {
+        let names: Vec<_> = (0..=FORWARDED_EVENT_LINEAR_LIMIT)
+            .map(|index| format!("event-{index}"))
+            .collect();
+        let events: Vec<_> = names
+            .iter()
+            .map(|name| mapped(name, template::ForwardedEventMapper::Element))
+            .collect();
+
+        let mut linear_comparisons = 0;
+        let mut indexed_lookups = 0;
+        let mut promotions = 0;
+        let linear = group_forwarded_events_with_observer(
+            &events[..FORWARDED_EVENT_LINEAR_LIMIT],
+            |operation| match operation {
+                GroupingOperation::LinearComparison => linear_comparisons += 1,
+                GroupingOperation::IndexedLookup => indexed_lookups += 1,
+                GroupingOperation::Promotion => promotions += 1,
+            },
+        );
+        assert!(matches!(linear, GroupedForwardedEvents::Linear(_)));
+        assert_eq!(
+            linear_comparisons,
+            FORWARDED_EVENT_LINEAR_LIMIT * (FORWARDED_EVENT_LINEAR_LIMIT - 1) / 2
+        );
+        assert_eq!(indexed_lookups, 0);
+        assert_eq!(promotions, 0);
+
+        let mut linear_comparisons = 0;
+        let mut indexed_lookups = 0;
+        let mut promotions = 0;
+        let indexed = group_forwarded_events_with_observer(&events, |operation| match operation {
+            GroupingOperation::LinearComparison => linear_comparisons += 1,
+            GroupingOperation::IndexedLookup => indexed_lookups += 1,
+            GroupingOperation::Promotion => promotions += 1,
+        });
+        assert!(matches!(indexed, GroupedForwardedEvents::Indexed(_)));
+        assert_eq!(
+            linear_comparisons,
+            FORWARDED_EVENT_LINEAR_LIMIT * (FORWARDED_EVENT_LINEAR_LIMIT + 1) / 2
+        );
+        assert_eq!(indexed_lookups, 0);
+        assert_eq!(promotions, 1);
+        assert_eq!(
+            indexed
+                .into_iter()
+                .map(|(name, _)| name)
+                .collect::<Vec<_>>(),
+            names.iter().map(String::as_str).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn promoted_forwarded_events_preserve_overwrite_and_union_semantics() {
+        let names: Vec<_> = (0..=FORWARDED_EVENT_LINEAR_LIMIT)
+            .map(|index| format!("event-{index}"))
+            .collect();
+        let mut forwarded: Vec<_> = names
+            .iter()
+            .map(|name| mapped(name, template::ForwardedEventMapper::Element))
+            .collect();
+        forwarded.extend([
+            component(&names[0], "Before"),
+            mapped(&names[0], template::ForwardedEventMapper::Body),
+            component(&names[0], "After"),
+        ]);
+        let template_info = template::TemplateInfo {
+            element_events: forwarded,
+            ..Default::default()
+        };
+
+        let output = build_events_str(
+            &ExportedNames::default(),
+            &template_info,
+            &ComponentEvents::default(),
+        );
+        assert!(output.starts_with(
+            "{'event-0':__sveltets_2_unionType(__sveltets_2_mapBodyEvent('event-0'), \
+             __sveltets_2_bubbleEventDef(__sveltets_2_instanceOf(After).$$events_def, 'event-0'))"
+        ));
+        assert!(!output.contains("Before"));
+        for index in 0..=FORWARDED_EVENT_LINEAR_LIMIT {
+            assert_eq!(output.matches(&format!("'event-{index}':")).count(), 1);
+        }
+    }
+
+    #[test]
+    fn duplicate_heavy_forwarded_events_do_not_promote() {
+        let events: Vec<_> = (0..256).map(|_| component("event", "Component")).collect();
+        let mut linear_comparisons = 0;
+        let mut indexed_lookups = 0;
+        let mut promotions = 0;
+        let grouped = group_forwarded_events_with_observer(&events, |operation| match operation {
+            GroupingOperation::LinearComparison => linear_comparisons += 1,
+            GroupingOperation::IndexedLookup => indexed_lookups += 1,
+            GroupingOperation::Promotion => promotions += 1,
+        });
+
+        assert!(matches!(grouped, GroupedForwardedEvents::Linear(_)));
+        assert_eq!(linear_comparisons, events.len() - 1);
+        assert_eq!(indexed_lookups, 0);
+        assert_eq!(promotions, 0);
+    }
+
+    #[test]
     fn forwarded_event_descriptor_defers_overwritten_materializations_at_scale() {
         let names: Vec<_> = (0..256).map(|index| format!("event-{index}")).collect();
         let mut forwarded = Vec::with_capacity(1024);
@@ -246,18 +447,29 @@ mod tests {
             element_events: forwarded,
             ..Default::default()
         };
-        let mut lookups = 0;
+        let mut linear_comparisons = 0;
+        let mut indexed_lookups = 0;
+        let mut promotions = 0;
         let mut materializations = 0;
 
         let output = build_events_str_with_observer(
             &ExportedNames::default(),
             &template_info,
             &ComponentEvents::default(),
-            || lookups += 1,
+            |operation| match operation {
+                GroupingOperation::LinearComparison => linear_comparisons += 1,
+                GroupingOperation::IndexedLookup => indexed_lookups += 1,
+                GroupingOperation::Promotion => promotions += 1,
+            },
             || materializations += 1,
         );
 
-        assert_eq!(lookups, 1024);
+        assert_eq!(
+            linear_comparisons,
+            FORWARDED_EVENT_LINEAR_LIMIT * (FORWARDED_EVENT_LINEAR_LIMIT + 1) / 2
+        );
+        assert_eq!(indexed_lookups, 1024 - FORWARDED_EVENT_LINEAR_LIMIT - 1);
+        assert_eq!(promotions, 1);
         assert_eq!(materializations, 512);
         assert_eq!(output.matches("'event-").count(), 768);
         assert_eq!(output.matches(":__sveltets_2_unionType(").count(), 256);

--- a/crates/rsvelte_projection/src/svelte2tsx/nodes/scripts.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/nodes/scripts.rs
@@ -63,20 +63,16 @@ pub(crate) fn find_instance_imports(
         return Vec::new();
     }
 
-    // Comment spans (start, end) discovered by the parser, sorted by end. Used
-    // to compute each import's leading-comment region the way TS
+    // Parser comments are source-ordered. Keep a monotonic cursor over them to
+    // compute each import's leading-comment region the way TS
     // `getLeadingCommentRanges(node.getFullText())` does — including a TRAILING
     // line comment on the PREVIOUS statement's line (it is leading trivia of the
     // following import and moves up with it). The parser already tokenised
     // strings/regex correctly, so `// …` inside a string is never misread.
-    let comment_spans: Vec<(u32, u32)> = program
-        .comments
-        .iter()
-        .map(|c| (c.span.start, c.span.end))
-        .collect();
-
     let mut imports = Vec::new();
     let bytes = raw_content.as_bytes();
+    let comments = &program.comments;
+    let mut comment_cursor = 0;
     for stmt in program.body.iter() {
         if let oxc::Statement::ImportDeclaration(import) = stmt {
             // All import declarations (including side-effect imports like `import ''`)
@@ -84,39 +80,51 @@ pub(crate) fn find_instance_imports(
             // valid `import` statements with a source clause.
             let start = import.span.start;
             let end = import.span.end;
+            while comment_cursor < comments.len() && comments[comment_cursor].span.end <= start {
+                comment_cursor += 1;
+            }
 
             // Walk backwards over leading trivia, pulling in every comment whose
             // end is reachable from the current start via whitespace only, and
             // stopping at the first non-comment code (the previous token). This
             // mirrors `getLeadingCommentRanges` and pulls a trailing line comment
             // (`import …; // TODO`) into the FOLLOWING import's leading region.
-            let new_start = scan_back_leading_comments(bytes, start as usize, &comment_spans);
+            let new_start =
+                scan_back_leading_comments(bytes, start as usize, comments, comment_cursor);
 
             imports.push((new_start, start, end));
         }
     }
-    imports.sort_by_key(|&(s, _, _)| s);
     imports
 }
 
 /// Walk backwards from `pos` over leading trivia (whitespace + comments),
-/// returning the start of the earliest comment reachable via whitespace-only
-/// gaps. Stops at the first non-comment code. `comment_spans` are parser-
-/// discovered `(start, end)` pairs (so strings/regex never produce false `//`).
-fn scan_back_leading_comments(bytes: &[u8], pos: usize, comment_spans: &[(u32, u32)]) -> u32 {
+/// returning the start of the earliest reachable parser-discovered comment.
+fn scan_back_leading_comments(
+    bytes: &[u8],
+    pos: usize,
+    comments: &[oxc_ast::ast::Comment],
+    comment_cursor: usize,
+) -> u32 {
     let mut cstart = pos as u32;
+    let mut comment_index = comment_cursor;
     loop {
         // Skip whitespace backward.
         let mut p = cstart as usize;
         while p > 0 && matches!(bytes[p - 1], b' ' | b'\t' | b'\n' | b'\r') {
             p -= 1;
         }
-        // A comment ending exactly at `p` is leading trivia of this import.
-        if let Some(&(cs, _)) = comment_spans.iter().find(|&&(_, ce)| ce as usize == p) {
+
+        while comment_index > 0 && comments[comment_index - 1].span.end as usize > p {
+            comment_index -= 1;
+        }
+        if comment_index > 0 && comments[comment_index - 1].span.end as usize == p {
+            let cs = comments[comment_index - 1].span.start;
             if cs >= cstart {
                 break;
             }
             cstart = cs;
+            comment_index -= 1;
         } else {
             break;
         }
@@ -283,5 +291,73 @@ pub(crate) fn expr_contains_await_deep(expr: &oxc_ast::ast::Expression) -> bool 
 
         // Everything else (literals, identifiers, `this`, …) cannot contain await.
         _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use oxc_ast::ast::Comment;
+    use oxc_span::Span;
+    use std::fmt::Write as _;
+
+    fn comment(source: &str, text: &str) -> Comment {
+        let start = source.find(text).unwrap() as u32;
+        Comment {
+            span: Span::new(start, start + text.len() as u32),
+            ..Comment::default()
+        }
+    }
+
+    #[test]
+    fn comment_cursor_keeps_contiguous_leading_trivia() {
+        let source = "const value = 1; // trailing\n/* block */\nimport value from './value';";
+        let comments = [
+            comment(source, "// trailing"),
+            comment(source, "/* block */"),
+        ];
+        let import_start = source.find("import value").unwrap();
+
+        assert_eq!(
+            scan_back_leading_comments(source.as_bytes(), import_start, &comments, comments.len()),
+            comments[0].span.start
+        );
+    }
+
+    #[test]
+    fn comment_cursor_scales_across_ordered_imports() {
+        const IMPORTS: usize = 1_024;
+        let mut source = String::with_capacity(IMPORTS * 40);
+        let mut comments = Vec::with_capacity(IMPORTS);
+        let mut import_starts = Vec::with_capacity(IMPORTS);
+        for index in 0..IMPORTS {
+            let comment_start = source.len() as u32;
+            write!(source, "// import {index}").unwrap();
+            comments.push(Comment {
+                span: Span::new(comment_start, source.len() as u32),
+                ..Comment::default()
+            });
+            source.push('\n');
+            import_starts.push(source.len());
+            writeln!(source, "import v{index} from './m';").unwrap();
+        }
+
+        let mut comment_cursor = 0;
+        for (index, &import_start) in import_starts.iter().enumerate() {
+            while comment_cursor < comments.len()
+                && comments[comment_cursor].span.end <= import_start as u32
+            {
+                comment_cursor += 1;
+            }
+            assert_eq!(
+                scan_back_leading_comments(
+                    source.as_bytes(),
+                    import_start,
+                    &comments,
+                    comment_cursor,
+                ),
+                comments[index].span.start
+            );
+        }
     }
 }

--- a/crates/rsvelte_projection/src/svelte2tsx/nodes/slot.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/nodes/slot.rs
@@ -6,7 +6,7 @@ use std::fmt::Write as _;
 use super::super::template;
 
 /// Build the `slots` object literal for the component export from template info.
-pub(crate) fn build_slots_str(template_info: &template::TemplateInfo) -> String {
+pub(crate) fn build_slots_str(template_info: &template::TemplateInfo<'_>) -> String {
     if template_info.slots.is_empty() {
         "{}".to_string()
     } else {

--- a/crates/rsvelte_projection/src/svelte2tsx/script/component_events.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/script/component_events.rs
@@ -122,11 +122,10 @@ impl ComponentEvents {
 
     /// Get event entries for the return statement, in official insertion order.
     /// Returns (name, value) pairs like ("hi", "__sveltets_2_customEvent").
-    pub fn get_event_entries(&self) -> Vec<(String, String)> {
+    pub fn get_event_entries(&self) -> impl ExactSizeIterator<Item = (&str, &'static str)> {
         self.dispatched_order
             .iter()
-            .map(|name| (name.clone(), "__sveltets_2_customEvent".to_string()))
-            .collect()
+            .map(|name| (name.as_str(), "__sveltets_2_customEvent"))
     }
 
     /// Entries for the public `events.getAll()` API surface: `(name, type)`
@@ -299,12 +298,8 @@ mod tests {
 
     use super::*;
 
-    fn event_names(events: &ComponentEvents) -> Vec<String> {
-        events
-            .get_event_entries()
-            .into_iter()
-            .map(|(name, _)| name)
-            .collect()
+    fn event_names(events: &ComponentEvents) -> Vec<&str> {
+        events.get_event_entries().map(|(name, _)| name).collect()
     }
 
     #[test]

--- a/crates/rsvelte_projection/src/svelte2tsx/script/component_events.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/script/component_events.rs
@@ -4,6 +4,7 @@ use std::collections::HashMap;
 
 use oxc_ast::ast as oxc;
 use oxc_span::GetSpan;
+use rustc_hash::FxHashMap;
 
 use super::ast_utils::binding_pattern_simple_name;
 
@@ -106,84 +107,15 @@ impl ComponentEvents {
         inst_range: Option<(u32, u32)>,
         mod_range: Option<(u32, u32)>,
     ) {
-        let decls = self.dispatcher_decls.clone();
-        if decls.is_empty() {
+        if self.dispatcher_decls.is_empty() {
             return;
         }
-        // Every `<dispatcher>("evt", …)` match across the source, as
-        // `(call_idx, dispatcher_index, event_name)`, in ascending position.
-        let mut matches: Vec<(usize, usize, String)> = Vec::new();
-        let bytes = source.as_bytes();
-        let is_ident = |b: u8| b.is_ascii_alphanumeric() || b == b'_' || b == b'$';
-        for (di, (disp, _)) in decls.iter().enumerate() {
-            let dn = disp.as_bytes();
-            let mut from = 0usize;
-            while let Some(rel) = source[from..].find(disp.as_str()) {
-                let idx = from + rel;
-                from = idx + 1;
-                // Word boundary: not part of a longer identifier / member access.
-                if idx > 0 && (is_ident(bytes[idx - 1]) || bytes[idx - 1] == b'.') {
-                    continue;
-                }
-                let mut p = idx + dn.len();
-                if p < bytes.len() && is_ident(bytes[p]) {
-                    continue;
-                }
-                while p < bytes.len() && (bytes[p] == b' ' || bytes[p] == b'\t') {
-                    p += 1;
-                }
-                if p >= bytes.len() || bytes[p] != b'(' {
-                    continue;
-                }
-                p += 1;
-                while p < bytes.len() && bytes[p].is_ascii_whitespace() {
-                    p += 1;
-                }
-                if p >= bytes.len() || (bytes[p] != b'"' && bytes[p] != b'\'' && bytes[p] != b'`') {
-                    continue;
-                }
-                let quote = bytes[p];
-                p += 1;
-                let name_start = p;
-                while p < bytes.len() && bytes[p] != quote {
-                    p += 1;
-                }
-                if p < bytes.len() {
-                    let evt = &source[name_start..p];
-                    // Only simple identifier-ish names (skip interpolated/dynamic).
-                    if !evt.is_empty() {
-                        matches.push((idx, di, evt.to_string()));
-                    }
-                }
-            }
-        }
-        matches.sort_by_key(|m| m.0);
-
-        let in_range = |idx: usize, r: Option<(u32, u32)>| {
-            r.is_some_and(|(a, b)| idx >= a as usize && idx < b as usize)
-        };
-
-        // Partition into template-first / script-after-decl groups, each kept in
-        // source order, then merge with dedup (first occurrence wins).
-        let mut template_events: Vec<String> = Vec::new();
-        let mut script_events: Vec<String> = Vec::new();
-        for (idx, di, evt) in matches {
-            if in_range(idx, mod_range) {
-                continue; // module dispatches are not counted
-            }
-            if in_range(idx, inst_range) {
-                let decl_pos = decls[di].1;
-                if idx as u32 > decl_pos {
-                    script_events.push(evt);
-                }
-            } else {
-                template_events.push(evt);
-            }
-        }
+        let (template_events, script_events) =
+            scan_dispatch_calls(source, &self.dispatcher_decls, inst_range, mod_range);
         for evt in template_events.into_iter().chain(script_events) {
-            if !self.events.contains_key(&evt) {
-                self.dispatched_order.push(evt.clone());
-                self.add(evt, None);
+            if !self.events.contains_key(evt) {
+                self.dispatched_order.push(evt.to_string());
+                self.add(evt.to_string(), None);
             }
         }
     }
@@ -216,6 +148,108 @@ impl ComponentEvents {
         entries.sort_by(|a, b| a.0.cmp(&b.0));
         entries
     }
+}
+
+fn scan_dispatch_calls<'source>(
+    source: &'source str,
+    decls: &[(String, u32)],
+    inst_range: Option<(u32, u32)>,
+    mod_range: Option<(u32, u32)>,
+) -> (Vec<&'source str>, Vec<&'source str>) {
+    scan_dispatch_calls_with_observer(source, decls, inst_range, mod_range, || {})
+}
+
+fn scan_dispatch_calls_with_observer<'source>(
+    source: &'source str,
+    decls: &[(String, u32)],
+    inst_range: Option<(u32, u32)>,
+    mod_range: Option<(u32, u32)>,
+    mut observe_identifier: impl FnMut(),
+) -> (Vec<&'source str>, Vec<&'source str>) {
+    let mut dispatcher_indices: FxHashMap<&str, (usize, usize)> =
+        FxHashMap::with_capacity_and_hasher(decls.len(), Default::default());
+    let mut next_dispatcher = vec![usize::MAX; decls.len()];
+    for (index, (name, _)) in decls.iter().enumerate() {
+        dispatcher_indices
+            .entry(name.as_str())
+            .and_modify(|(_, tail)| {
+                next_dispatcher[*tail] = index;
+                *tail = index;
+            })
+            .or_insert((index, index));
+    }
+
+    let bytes = source.as_bytes();
+    let is_ident = |b: u8| b.is_ascii_alphanumeric() || b == b'_' || b == b'$';
+    let in_range = |idx: usize, range: Option<(u32, u32)>| {
+        range.is_some_and(|(start, end)| idx >= start as usize && idx < end as usize)
+    };
+    let mut template_events = Vec::new();
+    let mut script_events = Vec::new();
+    let mut idx = 0usize;
+
+    while idx < bytes.len() {
+        if !is_ident(bytes[idx]) {
+            idx += 1;
+            continue;
+        }
+
+        let start = idx;
+        idx += 1;
+        while idx < bytes.len() && is_ident(bytes[idx]) {
+            idx += 1;
+        }
+        observe_identifier();
+
+        if start > 0 && bytes[start - 1] == b'.' {
+            continue;
+        }
+        let Some(&(mut dispatcher_index, _)) = dispatcher_indices.get(&source[start..idx]) else {
+            continue;
+        };
+
+        let mut p = idx;
+        while p < bytes.len() && (bytes[p] == b' ' || bytes[p] == b'\t') {
+            p += 1;
+        }
+        if p >= bytes.len() || bytes[p] != b'(' {
+            continue;
+        }
+        p += 1;
+        while p < bytes.len() && bytes[p].is_ascii_whitespace() {
+            p += 1;
+        }
+        if p >= bytes.len() || (bytes[p] != b'"' && bytes[p] != b'\'' && bytes[p] != b'`') {
+            continue;
+        }
+
+        let quote = bytes[p];
+        p += 1;
+        let name_start = p;
+        while p < bytes.len() && bytes[p] != quote {
+            p += 1;
+        }
+        if p >= bytes.len() || p == name_start || in_range(start, mod_range) {
+            continue;
+        }
+        let event = &source[name_start..p];
+
+        loop {
+            if in_range(start, inst_range) {
+                if start as u32 > decls[dispatcher_index].1 {
+                    script_events.push(event);
+                }
+            } else {
+                template_events.push(event);
+            }
+            dispatcher_index = next_dispatcher[dispatcher_index];
+            if dispatcher_index == usize::MAX {
+                break;
+            }
+        }
+    }
+
+    (template_events, script_events)
 }
 
 /// Detect `createEventDispatcher<Type>()` calls and extract the generic type.
@@ -261,7 +295,17 @@ pub(super) fn detect_create_event_dispatcher(
 
 #[cfg(test)]
 mod tests {
+    use std::fmt::Write as _;
+
     use super::*;
+
+    fn event_names(events: &ComponentEvents) -> Vec<String> {
+        events
+            .get_event_entries()
+            .into_iter()
+            .map(|(name, _)| name)
+            .collect()
+    }
 
     #[test]
     fn test_component_events_empty() {
@@ -276,5 +320,116 @@ mod tests {
         events.add("click".to_string(), Some("MouseEvent".to_string()));
         assert!(!events.is_empty());
         assert_eq!(events.get_event_names(), vec!["click"]);
+    }
+
+    #[test]
+    fn dispatch_scan_preserves_template_script_and_module_ordering() {
+        let source = concat!(
+            "dispatch('template-before');",
+            "<script context=\"module\">dispatch('module');</script>",
+            "<script>",
+            "dispatch('before-declaration');",
+            "const dispatch = createEventDispatcher();",
+            "dispatch('script-after');",
+            "</script>",
+            "<button onclick={() => dispatch('template-after')}></button>",
+        );
+        let module_start = source.find("dispatch('module')").unwrap() as u32;
+        let module_end = module_start + "dispatch('module')".len() as u32;
+        let instance_start = source.find("dispatch('before-declaration')").unwrap() as u32;
+        let instance_end = source.rfind("</script>").unwrap() as u32;
+        let declaration = source.find("const dispatch").unwrap() as u32;
+        let mut events = ComponentEvents::new();
+        events
+            .dispatcher_decls
+            .push(("dispatch".to_string(), declaration));
+
+        events.collect_dispatched_events(
+            source,
+            Some((instance_start, instance_end)),
+            Some((module_start, module_end)),
+        );
+
+        assert_eq!(
+            event_names(&events),
+            vec!["template-before", "template-after", "script-after"]
+        );
+    }
+
+    #[test]
+    fn dispatch_scan_preserves_textual_boundaries_and_quotes() {
+        let source = concat!(
+            "dispatchLong('long');",
+            "longdispatch('prefix');",
+            "object.dispatch('member');",
+            "object. dispatch('spaced-member');",
+            "dispatch\n('newline-before-paren');",
+            "dispatch(\n'single');",
+            "dispatch(\"double\");",
+            "dispatch(`backtick`);",
+            "\"dispatch('inside-string')\";",
+            "/* dispatch('inside-comment') */",
+        );
+        let mut events = ComponentEvents::new();
+        events.dispatcher_decls.push(("dispatch".to_string(), 0));
+
+        events.collect_dispatched_events(source, None, None);
+
+        assert_eq!(
+            event_names(&events),
+            vec![
+                "spaced-member",
+                "single",
+                "double",
+                "backtick",
+                "inside-string",
+                "inside-comment",
+            ]
+        );
+    }
+
+    #[test]
+    fn dispatch_scan_preserves_duplicate_dispatcher_declaration_gates() {
+        let source = " dispatch('first'); dispatch('second'); dispatch('third');";
+        let second = source.find("dispatch('second')").unwrap() as u32;
+        let third = source.find("dispatch('third')").unwrap() as u32;
+        let decls = vec![
+            ("dispatch".to_string(), second),
+            ("dispatch".to_string(), 0),
+            ("dispatch".to_string(), third),
+        ];
+
+        let (_, script_events) =
+            scan_dispatch_calls(source, &decls, Some((0, source.len() as u32)), None);
+
+        assert_eq!(script_events, vec!["first", "second", "third", "third"]);
+    }
+
+    #[test]
+    fn dispatch_scan_visits_large_source_once_for_1_16_and_128_dispatchers() {
+        let mut source = "noise_token ".repeat(16_384);
+        for index in 0..128 {
+            let _ = write!(source, " dispatch{index}('event{index}');");
+        }
+
+        for dispatcher_count in [1, 16, 128] {
+            let decls: Vec<(String, u32)> = (0..dispatcher_count)
+                .map(|index| (format!("dispatch{index}"), 0))
+                .collect();
+            let mut identifiers_visited = 0;
+            let (template_events, script_events) =
+                scan_dispatch_calls_with_observer(&source, &decls, None, None, || {
+                    identifiers_visited += 1;
+                });
+
+            assert_eq!(template_events.len(), dispatcher_count);
+            assert!(script_events.is_empty());
+            assert_eq!(identifiers_visited, 16_384 + 128 * 2);
+            assert_eq!(template_events[0], "event0");
+            assert_eq!(
+                template_events[dispatcher_count - 1],
+                format!("event{}", dispatcher_count - 1)
+            );
+        }
     }
 }

--- a/crates/rsvelte_projection/src/svelte2tsx/script/export_decl.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/script/export_decl.rs
@@ -45,6 +45,7 @@ pub(super) fn handle_export_named_decl(
     emit_jsdoc: bool,
 ) {
     let node_start = export.span.start + offset;
+    let mut cached_leading_doc = None;
 
     // Case 1: export with declaration (export let/const/function/class ...)
     if let Some(ref decl) = export.declaration {
@@ -116,12 +117,15 @@ pub(super) fn handle_export_named_decl(
                         // export so it round-trips into the legacy props return
                         // (`props: { /** @type {boolean} */ visible: visible }`),
                         // mirroring official's `value.doc`.
-                        let leading_doc =
-                            leading_jsdoc_comment(raw_content, export.span.start as usize);
+                        let leading_doc = cached_leading_doc
+                            .get_or_insert_with(|| {
+                                leading_jsdoc_comment(raw_content, export.span.start as usize)
+                            })
+                            .as_ref();
                         if let Some(name) = binding_pattern_simple_name(&declarator.id)
-                            && let Some(ref doc) = leading_doc
+                            && let Some(doc) = leading_doc
                         {
-                            exported_names.set_doc(name, doc.clone());
+                            exported_names.set_doc(name, doc.to_string());
                         }
                         // For multi-declarator let exports (export let a, b, c;),
                         // replace the comma between declarators with `;let `.
@@ -158,9 +162,12 @@ pub(super) fn handle_export_named_decl(
                         // A JSDoc `/** @type {T} */` on the export is a type too,
                         // so a `/** @type {number} */ export let x = 1` widens via
                         // `x = __sveltets_2_any(x)` even with an initializer.
-                        let has_jsdoc_type =
-                            leading_jsdoc_comment(raw_content, export.span.start as usize)
-                                .is_some_and(|d| d.contains("@type"));
+                        let has_jsdoc_type = cached_leading_doc
+                            .get_or_insert_with(|| {
+                                leading_jsdoc_comment(raw_content, export.span.start as usize)
+                            })
+                            .as_deref()
+                            .is_some_and(|doc| doc.contains("@type"));
                         let do_widen = is_prop
                             && (!has_default
                                 || has_type_annotation
@@ -301,13 +308,21 @@ pub(super) fn handle_export_named_decl(
             // not a possible-export, so its declaration doc does not carry over),
             // and `propTypeAssert` is NOT re-run, so no extra widening here.
             if renamed && exported_names.has(&local) {
-                let merged_doc = leading_jsdoc_comment(raw_content, export.span.start as usize);
+                let merged_doc = cached_leading_doc
+                    .get_or_insert_with(|| {
+                        leading_jsdoc_comment(raw_content, export.span.start as usize)
+                    })
+                    .map(str::to_string);
                 exported_names.rename_export_let_in_place(&local, exported.clone(), merged_doc);
                 continue;
             }
 
             let doc = if renamed {
-                leading_jsdoc_comment(raw_content, export.span.start as usize)
+                cached_leading_doc
+                    .get_or_insert_with(|| {
+                        leading_jsdoc_comment(raw_content, export.span.start as usize)
+                    })
+                    .map(str::to_string)
                     .or_else(|| possible.and_then(|p| p.doc.clone()))
             } else {
                 possible.and_then(|p| p.doc.clone())
@@ -360,7 +375,7 @@ pub(super) fn handle_export_named_decl(
 
 /// Return the leading `/** … */` JSDoc comment immediately before `before`
 /// (skipping whitespace), or None. Mirrors official `getLastLeadingDoc`.
-pub(super) fn leading_jsdoc_comment(source: &str, before: usize) -> Option<String> {
+pub(super) fn leading_jsdoc_comment(source: &str, before: usize) -> Option<&str> {
     let bytes = source.as_bytes();
     let before = before.min(bytes.len());
     // Mirror official `getLastLeadingDoc`: walk the leading trivia and return the
@@ -390,7 +405,7 @@ pub(super) fn leading_jsdoc_comment(source: &str, before: usize) -> Option<Strin
             if source[open..p - 2].contains("*/") {
                 return None;
             }
-            return Some(source[open..p].to_string());
+            return Some(&source[open..p]);
         }
         // Otherwise, if the trivia line ending at `p` is a single-line `// …`
         // comment, skip the whole line and keep looking for an earlier block
@@ -460,5 +475,44 @@ mod tests {
 
         assert!(result.exported_names.has("greet"));
         assert!(!result.exported_names.get("greet").unwrap().is_prop);
+    }
+
+    #[test]
+    fn shared_export_doc_reaches_every_declarator() {
+        let source = concat!(
+            "<script>\n",
+            "/** @type {number} */\n",
+            "// @ts-expect-error\n",
+            "export let first = 1, second = 2;\n",
+            "</script>",
+        );
+        let result = run_svelte2tsx(source);
+
+        for name in ["first", "second"] {
+            assert_eq!(
+                result.exported_names.get(name).unwrap().doc.as_deref(),
+                Some("/** @type {number} */")
+            );
+        }
+    }
+
+    #[test]
+    fn shared_export_doc_reaches_every_renamed_specifier() {
+        let source = concat!(
+            "<script>\n",
+            "let first = 1, second = 2;\n",
+            "/** named exports */\n",
+            "// bridge\n",
+            "export { first as one, second as two };\n",
+            "</script>",
+        );
+        let result = run_svelte2tsx(source);
+
+        for name in ["one", "two"] {
+            assert_eq!(
+                result.exported_names.get(name).unwrap().doc.as_deref(),
+                Some("/** named exports */")
+            );
+        }
     }
 }

--- a/crates/rsvelte_projection/src/svelte2tsx/script/exported_names.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/script/exported_names.rs
@@ -384,16 +384,23 @@ impl ExportedNames {
             // `export let foo` is not a prop (it's a runes-mode error), so
             // without a `$props()` call there are no props. Named exports
             // (`export { x as y }`) are likewise not props.
-            let entries: Vec<String> = if self.has_props_rune {
-                self.get_ordered()
-                    .iter()
+            let mut entries = String::from("{");
+            let mut has_entries = false;
+            if self.has_props_rune {
+                for (en, info) in self
+                    .ordered()
                     .filter(|(_, info)| info.is_prop && !info.is_named_export)
-                    .map(|(en, info)| format!("{}: {}", en, info.local_name))
-                    .collect()
-            } else {
-                Vec::new()
-            };
-            if entries.is_empty() {
+                {
+                    if has_entries {
+                        entries.push_str(" , ");
+                    }
+                    has_entries = true;
+                    entries.push_str(en);
+                    entries.push_str(": ");
+                    entries.push_str(&info.local_name);
+                }
+            }
+            if !has_entries {
                 // Reference: addComponentExport.ts `props()` function —
                 // runes mode with no props: TS uses `{} as Record<string, never>`,
                 // JS uses `/** @type {Record<string, never>} */ ({})`.
@@ -403,7 +410,8 @@ impl ExportedNames {
                     "/** @type {Record<string, never>} */ ({})".to_string()
                 };
             }
-            return format!("{{{}}}", entries.join(" , "));
+            entries.push('}');
+            return entries;
         }
         // Legacy `$$Props` type/interface (TS only): mirror official's
         // `uses$$Props` branch — wrap the props in `__sveltets_2_ensureRightProps`
@@ -413,43 +421,28 @@ impl ExportedNames {
             // Mirror official `createReturnElementsType`: each member is prefixed
             // with its leading JSDoc (`addDoc` defaults true), so a `/** … */`
             // comment on the `export let` survives into the `$$Props` type list.
-            let type_entry = |en: &str, info: &ExportedNameInfo| -> String {
-                let optional = if info.has_default || !info.is_let {
-                    "?"
-                } else {
-                    ""
-                };
-                let doc = match &info.doc {
-                    Some(d) => format!("{} ", d),
-                    None => String::new(),
-                };
-                match &info.type_annotation {
-                    Some(ta) => format!("{}{}{}: {}", doc, en, optional, ta),
-                    None => format!("{}{}{}: typeof {}", doc, en, optional, info.local_name),
+            let mut lets = String::new();
+            let mut others = String::new();
+            for (en, info) in self.ordered() {
+                let output = if info.is_let { &mut lets } else { &mut others };
+                if !output.is_empty() {
+                    output.push(',');
                 }
-            };
-            let lets: Vec<String> = self
-                .get_ordered()
-                .iter()
-                .filter(|(_, info)| info.is_let)
-                .map(|(en, info)| type_entry(en, info))
-                .collect();
-            let others: Vec<String> = self
-                .get_ordered()
-                .iter()
-                .filter(|(_, info)| !info.is_let)
-                .map(|(en, info)| type_entry(en, info))
-                .collect();
-            let others_prefix = if others.is_empty() {
-                String::new()
-            } else {
-                format!("{{{}}} & ", others.join(","))
-            };
-            return format!(
-                "{{ ...__sveltets_2_ensureRightProps<{{{}}}>(__sveltets_2_any(\"\") as $$Props)}} as {}$$Props",
-                lets.join(","),
-                others_prefix
+                Self::write_type_entry(output, en, info);
+            }
+            let mut result = String::with_capacity(
+                85 + lets.len() + others.len() + usize::from(!others.is_empty()) * 5,
             );
+            result.push_str("{ ...__sveltets_2_ensureRightProps<{");
+            result.push_str(&lets);
+            result.push_str("}>(__sveltets_2_any(\"\") as $$Props)} as ");
+            if !others.is_empty() {
+                result.push('{');
+                result.push_str(&others);
+                result.push_str("} & ");
+            }
+            result.push_str("$$Props");
+            return result;
         }
         // Mirror official `dontAddTypeDef` (ExportedNames.ts createPropsStr):
         // omit the `as {…}` cast entirely when every export is untyped AND
@@ -459,63 +452,56 @@ impl ExportedNames {
         // up-front because it also gates whether the *value* elements carry the
         // leading JSDoc (official `createReturnElements`: doc when dontAddTypeDef).
         let dont_add_type_def = !is_ts
-            || self.get_ordered().iter().all(|(_, info)| {
-                info.type_annotation.is_none() && info.is_let && !info.has_default
-            });
+            || self
+                .names
+                .values()
+                .all(|info| info.type_annotation.is_none() && info.is_let && !info.has_default);
         // When `dontAddTypeDef`, the props object omits the `as {…}` type assert,
         // so a captured leading JSDoc `/** … */` is emitted before the prop's
         // value element — mirrors official `createReturnElements`.
-        let entries: Vec<String> = self
-            .get_ordered()
-            .iter()
-            .map(|(en, info)| match &info.doc {
-                Some(doc) if dont_add_type_def => format!("{} {}: {}", doc, en, info.local_name),
-                _ => format!("{}: {}", en, info.local_name),
-            })
-            .collect();
-        if entries.is_empty() {
+        if self.names.is_empty() {
             // Reference: ExportedNames.ts createPropsStr — non-runes mode with
             // no props. When `$$props`/`$$restProps` is used, props flattens to
             // a bare `{}`; otherwise TS uses `{} as Record<string, never>` and
             // JS uses `/** @type {Record<string, never>} */ ({})`.
-            if uses_dollar_props {
+            return if uses_dollar_props {
                 "{}".to_string()
             } else if is_ts {
                 "{} as Record<string, never>".to_string()
             } else {
                 "/** @type {Record<string, never>} */ ({})".to_string()
+            };
+        }
+        let mut entries = String::from("{");
+        let mut type_entries = String::new();
+        for (en, info) in self.ordered() {
+            if entries.len() > 1 {
+                entries.push_str(" , ");
             }
-        } else {
-            let base = format!("{{{}}}", entries.join(" , "));
+            if let Some(doc) = &info.doc
+                && dont_add_type_def
+            {
+                entries.push_str(doc);
+                entries.push(' ');
+            }
+            entries.push_str(en);
+            entries.push_str(": ");
+            entries.push_str(&info.local_name);
+
             if is_ts && !dont_add_type_def {
-                // For TS files, add `as {name1?: type, ...}` type assertion
-                let type_entries: Vec<String> = self
-                    .get_ordered()
-                    .iter()
-                    .map(|(en, info)| {
-                        let optional = if info.has_default || !info.is_let {
-                            "?"
-                        } else {
-                            ""
-                        };
-                        // A leading block comment on the export is preserved
-                        // before its type-cast entry (official emits the doc here).
-                        let doc = match &info.doc {
-                            Some(d) => format!("{} ", d),
-                            None => String::new(),
-                        };
-                        if let Some(ref ta) = info.type_annotation {
-                            format!("{}{}{}: {}", doc, en, optional, ta)
-                        } else {
-                            format!("{}{}{}: typeof {}", doc, en, optional, info.local_name)
-                        }
-                    })
-                    .collect();
-                format!("{} as {{{}}}", base, type_entries.join(", "))
-            } else {
-                base
+                if !type_entries.is_empty() {
+                    type_entries.push_str(", ");
+                }
+                Self::write_type_entry(&mut type_entries, en, info);
             }
         }
+        entries.push('}');
+        if is_ts && !dont_add_type_def {
+            entries.push_str(" as {");
+            entries.push_str(&type_entries);
+            entries.push('}');
+        }
+        entries
     }
     pub fn create_exports_str(&self, is_svelte5: bool, is_ts: bool) -> String {
         self.create_exports_str_with_accessors(is_svelte5, false, is_ts)
@@ -530,72 +516,57 @@ impl ExportedNames {
         if !is_svelte5 {
             return String::new();
         }
-        let others: Vec<(&str, &ExportedNameInfo)> = self
-            .get_ordered()
-            .into_iter()
-            .filter(|(_, info)| {
-                // In exports, include:
-                // - Non-let declarations (const, function, class)
-                // - Named exports in runes mode (even if marked as prop from export specifiers)
-                // - When accessors is true, also include `export let` props
-                // BUT exclude props from $props() destructuring (is_prop && !is_named_export)
-
-                // When accessors is true, include all exported let props
-                if accessors && info.is_let {
-                    return true;
-                }
-                if info.is_prop && !info.is_named_export {
-                    return false;
-                }
-                !info.is_let || (self.is_runes_mode() && info.is_named_export)
-            })
-            .collect();
-        if !others.is_empty() {
-            let te: Vec<String> = others
-                .iter()
-                .map(|(en, info)| {
-                    // In TS files, doc comments are included (addDoc = true in JS reference).
-                    // In JS files, addDoc = false — no doc prefix.
-                    let doc_prefix = if is_ts {
-                        match &info.doc {
-                            Some(d) => format!("\n{}", d),
-                            None => String::new(),
-                        }
-                    } else {
-                        String::new()
-                    };
-                    if let Some(ref ta) = info.type_annotation {
-                        format!("{}{}: {}", doc_prefix, en, ta)
-                    } else {
-                        format!("{}{}: typeof {}", doc_prefix, en, info.local_name)
-                    }
-                })
-                .collect();
-            // In runes mode, include values in the exports object — but ONLY for
-            // exports that carry an explicit type annotation. Official's value
-            // call is `createReturnElements(others, false, /*onlyTyped*/ true)`,
-            // which skips any entry without `value.type`. Untyped exports
-            // (`let count = $state(0)`) therefore yield an empty value object,
-            // with the names appearing only in the `as any as { … }` cast.
-            let val_str = if self.is_runes_mode() {
-                let val_entries: Vec<String> = others
-                    .iter()
-                    .filter(|(_, info)| info.type_annotation.is_some())
-                    .map(|(en, info)| format!("{}: {}", en, info.local_name))
-                    .collect();
-                val_entries.join(",")
-            } else {
-                String::new()
-            };
-            if is_ts {
-                format!(
-                    ", exports: {{{}}} as any as {{ {} }}",
-                    val_str,
-                    te.join(",")
-                )
-            } else {
-                format!(", exports: /** @type {{{{{}}}}} */ ({{}})", te.join(","))
+        let runes_mode = self.is_runes_mode();
+        let mut type_entries = String::new();
+        let mut value_entries = String::new();
+        for (en, info) in self
+            .ordered()
+            .filter(|(_, info)| Self::is_export(info, accessors, runes_mode))
+        {
+            if !type_entries.is_empty() {
+                type_entries.push(',');
             }
+            if is_ts && let Some(doc) = &info.doc {
+                type_entries.push('\n');
+                type_entries.push_str(doc);
+            }
+            match &info.type_annotation {
+                Some(type_annotation) => {
+                    type_entries.push_str(en);
+                    type_entries.push_str(": ");
+                    type_entries.push_str(type_annotation);
+                }
+                None => {
+                    type_entries.push_str(en);
+                    type_entries.push_str(": typeof ");
+                    type_entries.push_str(&info.local_name);
+                }
+            }
+
+            // Official's `onlyTyped` value list omits untyped runes exports.
+            if runes_mode && info.type_annotation.is_some() {
+                if !value_entries.is_empty() {
+                    value_entries.push(',');
+                }
+                value_entries.push_str(en);
+                value_entries.push_str(": ");
+                value_entries.push_str(&info.local_name);
+            }
+        }
+        if !type_entries.is_empty() {
+            let mut result = String::with_capacity(40 + value_entries.len() + type_entries.len());
+            if is_ts {
+                result.push_str(", exports: {");
+                result.push_str(&value_entries);
+                result.push_str("} as any as { ");
+                result.push_str(&type_entries);
+                result.push_str(" }");
+            } else {
+                result.push_str(", exports: /** @type {{");
+                result.push_str(&type_entries);
+                result.push_str("}} */ ({})");
+            }
+            result
         } else {
             ", exports: {}".to_string()
         }
@@ -650,16 +621,10 @@ impl ExportedNames {
         if !is_svelte5 {
             return "{}".to_string();
         }
-        // Check if there are actual exports (non-prop declarations)
-        let has_exports = self.get_ordered().iter().any(|(_, info)| {
-            if accessors && info.is_let {
-                return true;
-            }
-            if info.is_prop && !info.is_named_export {
-                return false;
-            }
-            !info.is_let || (self.is_runes_mode() && info.is_named_export)
-        });
+        let runes_mode = self.is_runes_mode();
+        let has_exports = self
+            .ordered()
+            .any(|(_, info)| Self::is_export(info, accessors, runes_mode));
         if has_exports {
             // Return a sentinel that signals "has exports" - the caller
             // will use $$render<gn>().exports instead of {}
@@ -690,16 +655,46 @@ impl ExportedNames {
             })
             .collect()
     }
-    fn get_ordered(&self) -> Vec<(&str, &ExportedNameInfo)> {
+    fn ordered(&self) -> impl Iterator<Item = (&str, &ExportedNameInfo)> {
         self.insertion_order
             .iter()
             .filter_map(|n| self.names.get(n).map(|i| (n.as_str(), i)))
-            .collect()
+    }
+
+    fn is_export(info: &ExportedNameInfo, accessors: bool, runes_mode: bool) -> bool {
+        if accessors && info.is_let {
+            return true;
+        }
+        if info.is_prop && !info.is_named_export {
+            return false;
+        }
+        !info.is_let || (runes_mode && info.is_named_export)
+    }
+
+    fn write_type_entry(output: &mut String, name: &str, info: &ExportedNameInfo) {
+        if let Some(doc) = &info.doc {
+            output.push_str(doc);
+            output.push(' ');
+        }
+        output.push_str(name);
+        if info.has_default || !info.is_let {
+            output.push('?');
+        }
+        output.push_str(": ");
+        match &info.type_annotation {
+            Some(type_annotation) => output.push_str(type_annotation),
+            None => {
+                output.push_str("typeof ");
+                output.push_str(&info.local_name);
+            }
+        }
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use std::fmt::Write;
+
     use super::super::test_support::run_svelte2tsx;
     use super::*;
     use crate::svelte2tsx::svelte2tsx::svelte2tsx;
@@ -839,6 +834,64 @@ mod tests {
             result.code.contains("{} as Record<string, never>"),
             "Runes-mode TS file with no props must use `{{}} as Record<string, never>`, got:\n{}",
             result.code
+        );
+    }
+
+    #[test]
+    fn large_props_output_preserves_insertion_order() {
+        let mut names = ExportedNames::new();
+        let mut expected = String::from("{");
+        for index in 0..256 {
+            let exported = format!("prop_{index:03}");
+            let local = format!("local_{index:03}");
+            names.add_full(
+                exported.clone(),
+                local.clone(),
+                false,
+                None,
+                true,
+                true,
+                false,
+            );
+            if index != 0 {
+                expected.push_str(" , ");
+            }
+            write!(expected, "{exported}: {local}").unwrap();
+        }
+        expected.push('}');
+
+        assert_eq!(names.create_props_str(false, false), expected);
+    }
+
+    #[test]
+    fn large_runes_exports_output_preserves_insertion_order() {
+        let mut names = ExportedNames::new();
+        names.set_uses_runes(true);
+        let mut values = String::new();
+        let mut types = String::new();
+        for index in 0..256 {
+            let exported = format!("export_{index:03}");
+            let local = format!("local_{index:03}");
+            names.add_full(
+                exported.clone(),
+                local.clone(),
+                false,
+                Some("number".to_string()),
+                false,
+                false,
+                true,
+            );
+            if index != 0 {
+                values.push(',');
+                types.push(',');
+            }
+            write!(values, "{exported}: {local}").unwrap();
+            write!(types, "{exported}: number").unwrap();
+        }
+
+        assert_eq!(
+            names.create_exports_str_with_accessors(true, false, true),
+            format!(", exports: {{{values}}} as any as {{ {types} }}")
         );
     }
 }

--- a/crates/rsvelte_projection/src/svelte2tsx/script/mod.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/script/mod.rs
@@ -181,7 +181,8 @@ pub fn process_instance_script(
                                     doc: leading_jsdoc_comment(
                                         raw_content,
                                         var_decl.span.start as usize,
-                                    ),
+                                    )
+                                    .map(str::to_string),
                                 },
                             );
                         } else {
@@ -298,7 +299,8 @@ pub fn process_instance_script(
                                                 doc: leading_jsdoc_comment(
                                                     raw_content,
                                                     var_decl.span.start as usize,
-                                                ),
+                                                )
+                                                .map(str::to_string),
                                             },
                                         );
                                     }

--- a/crates/rsvelte_projection/src/svelte2tsx/template/collect/mod.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/template/collect/mod.rs
@@ -9,14 +9,14 @@ use pattern::{collect_pattern_bindings, expand_object_shorthands};
 use super::attributes::let_::iter_let_directives;
 use super::nodes::slot_element::{dollar_slot_name, get_slot_attr_value, slot_name_for_type};
 use super::utils::expr::get_expression_text;
-use super::{ForwardedEventKind, TemplateInfo};
+use super::{ForwardedEvent, ForwardedEventMapper, ForwardedEventSource, TemplateInfo};
 use crate::ast::arena::ParseArena;
 use crate::svelte2tsx::nodes::runes_detection::TemplateRunesDetector;
 
-pub(super) fn collect_info_from_fragment(
-    fragment: &Fragment,
-    source: &str,
-    info: &mut TemplateInfo,
+pub(super) fn collect_info_from_fragment<'a>(
+    fragment: &'a Fragment<'_>,
+    source: &'a str,
+    info: &mut TemplateInfo<'a>,
     scope: &mut Vec<(String, String)>,
     enclosing: Option<&str>,
     detector: &mut TemplateRunesDetector,
@@ -30,12 +30,12 @@ pub(super) fn collect_info_from_fragment(
 /// Collect forwarded-event + slot-let info for a special element, using
 /// `event_mapper` (`mapWindowEvent` / `mapBodyEvent` / `mapElementEvent`) for
 /// its handler-less `on:` directives.
-fn collect_special_element_info(
-    el: &crate::ast::template::SvelteElement,
-    event_mapper: &str,
+fn collect_special_element_info<'a>(
+    el: &'a crate::ast::template::SvelteElement<'_>,
+    event_mapper: ForwardedEventMapper,
     collect_events: bool,
-    source: &str,
-    info: &mut TemplateInfo,
+    source: &'a str,
+    info: &mut TemplateInfo<'a>,
     scope: &mut Vec<(String, String)>,
     enclosing: Option<&str>,
     detector: &mut TemplateRunesDetector,
@@ -46,10 +46,10 @@ fn collect_special_element_info(
             if let Attribute::OnDirective(on) = attr
                 && on.expression.is_none()
             {
-                let event_name = on.name.to_string();
-                let event_value = format!("__sveltets_2_{}('{}')", event_mapper, event_name);
-                info.element_events
-                    .push((event_name, event_value, ForwardedEventKind::Element));
+                info.element_events.push(ForwardedEvent {
+                    name: on.name.as_str(),
+                    source: ForwardedEventSource::Mapped(event_mapper),
+                });
             }
         }
     }
@@ -69,10 +69,10 @@ fn collect_special_element_info(
 
 /// `enclosing` is the name of the nearest ancestor component, used to build
 /// `let:`-forwarding slot reflections (`__sveltets_2_instanceOf(<Comp>).$$slot_def[…]`).
-fn collect_info_from_node(
-    node: &TemplateNode,
-    source: &str,
-    info: &mut TemplateInfo,
+fn collect_info_from_node<'a>(
+    node: &'a TemplateNode<'_>,
+    source: &'a str,
+    info: &mut TemplateInfo<'a>,
     scope: &mut Vec<(String, String)>,
     enclosing: Option<&str>,
     detector: &mut TemplateRunesDetector,
@@ -112,15 +112,12 @@ fn collect_info_from_node(
                     && on.expression.is_none()
                 {
                     // Event forwarding: on:click (no handler)
-                    let event_name = on.name.to_string();
-                    let event_value = format!("__sveltets_2_mapElementEvent('{}')", event_name);
                     // Element forward → official `bubbledEvents.set` (plain
                     // overwrite); the assembly reduction collapses duplicates.
-                    info.element_events.push((
-                        event_name,
-                        event_value,
-                        ForwardedEventKind::Element,
-                    ));
+                    info.element_events.push(ForwardedEvent {
+                        name: on.name.as_str(),
+                        source: ForwardedEventSource::Mapped(ForwardedEventMapper::Element),
+                    });
                 }
             }
             collect_info_from_fragment(
@@ -139,7 +136,7 @@ fn collect_info_from_node(
         TemplateNode::SvelteWindow(el) => {
             collect_special_element_info(
                 el,
-                "mapWindowEvent",
+                ForwardedEventMapper::Window,
                 true,
                 source,
                 info,
@@ -152,7 +149,7 @@ fn collect_info_from_node(
         TemplateNode::SvelteBody(el) => {
             collect_special_element_info(
                 el,
-                "mapBodyEvent",
+                ForwardedEventMapper::Body,
                 true,
                 source,
                 info,
@@ -169,7 +166,7 @@ fn collect_info_from_node(
         | TemplateNode::SvelteOptions(el) => {
             collect_special_element_info(
                 el,
-                "mapElementEvent",
+                ForwardedEventMapper::Element,
                 true,
                 source,
                 info,
@@ -196,7 +193,7 @@ fn collect_info_from_node(
             );
             collect_special_element_info(
                 el,
-                "mapElementEvent",
+                ForwardedEventMapper::Element,
                 false,
                 source,
                 info,
@@ -217,19 +214,13 @@ fn collect_info_from_node(
                 if let Attribute::OnDirective(on) = attr
                     && on.expression.is_none()
                 {
-                    let event_name = on.name.to_string();
-                    let event_value = format!(
-                        "__sveltets_2_bubbleEventDef(__sveltets_2_instanceOf({}).$$events_def, '{}')",
-                        comp.name, event_name
-                    );
                     // Component forward → official `handleEventHandlerBubble`
                     // concats into the existing entry (`unionType` of each
                     // forwarding instance).
-                    info.element_events.push((
-                        event_name,
-                        event_value,
-                        ForwardedEventKind::Component,
-                    ));
+                    info.element_events.push(ForwardedEvent {
+                        name: on.name.as_str(),
+                        source: ForwardedEventSource::Component(comp.name.as_str()),
+                    });
                 }
             }
             // Collect every slot-consumer `let:` binding for this component into
@@ -270,16 +261,10 @@ fn collect_info_from_node(
                 if let Attribute::OnDirective(on) = attr
                     && on.expression.is_none()
                 {
-                    let event_name = on.name.to_string();
-                    let event_value = format!(
-                        "__sveltets_2_bubbleEventDef(__sveltets_2_instanceOf({}).$$events_def, '{}')",
-                        this_expr, event_name
-                    );
-                    info.element_events.push((
-                        event_name,
-                        event_value,
-                        ForwardedEventKind::Component,
-                    ));
+                    info.element_events.push(ForwardedEvent {
+                        name: on.name.as_str(),
+                        source: ForwardedEventSource::Component(this_expr),
+                    });
                 }
             }
             // `<svelte:component this={X}>` is an InlineComponent: collect its
@@ -436,13 +421,10 @@ fn collect_info_from_node(
                 if let Attribute::OnDirective(on) = attr
                     && on.expression.is_none()
                 {
-                    let event_name = on.name.to_string();
-                    let event_value = format!("__sveltets_2_mapElementEvent('{}')", event_name);
-                    info.element_events.push((
-                        event_name,
-                        event_value,
-                        ForwardedEventKind::Element,
-                    ));
+                    info.element_events.push(ForwardedEvent {
+                        name: on.name.as_str(),
+                        source: ForwardedEventSource::Mapped(ForwardedEventMapper::Element),
+                    });
                 }
             }
             collect_info_from_fragment(

--- a/crates/rsvelte_projection/src/svelte2tsx/template/mod.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/template/mod.rs
@@ -32,23 +32,22 @@ use walk::process_fragment_inplace;
 
 /// Information collected during template processing.
 #[derive(Debug, Default)]
-pub struct TemplateInfo {
+pub struct TemplateInfo<'a> {
     /// Slots used in the component: slot_name -> list of prop strings.
     /// e.g., "default" -> ["a:b", "c:d"]
     pub slots: IndexMap<String, Vec<String>>,
     /// Events forwarded from elements / components (on:event without handler),
-    /// in template-walk order. Each entry carries the kind so the assembly can
+    /// in template-walk order. Each entry carries its source so the assembly can
     /// mirror the official `EventHandler` bubbled-events `Map` semantics: an
     /// `Element` forward does a plain `set` (overwrite), a `Component` forward
     /// concats into the existing entry (`unionType`).
-    /// e.g., "click" -> "__sveltets_2_mapElementEvent('click')"
-    pub element_events: Vec<(String, String, ForwardedEventKind)>,
+    pub element_events: Vec<ForwardedEvent<'a>>,
     /// Slot names for the legacy `$$slots` declaration, collected only when used.
     pub dollar_slot_names: Option<Box<IndexSet<String>>>,
     pub uses_runes: bool,
 }
 
-impl TemplateInfo {
+impl TemplateInfo<'_> {
     fn empty(collect_dollar_slot_names: bool) -> Self {
         Self {
             dollar_slot_names: collect_dollar_slot_names.then(|| Box::new(IndexSet::new())),
@@ -57,17 +56,23 @@ impl TemplateInfo {
     }
 }
 
-/// How a forwarded event (`on:event` with no handler) combines with an existing
-/// entry for the same event name, mirroring the official
-/// `event-handler.ts` `EventHandler` map.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum ForwardedEventKind {
-    /// Element / `svelte:window` / `svelte:body` / `svelte:element` etc. —
-    /// official `bubbledEvents.set(name, expr)` (plain overwrite).
+pub struct ForwardedEvent<'a> {
+    pub name: &'a str,
+    pub source: ForwardedEventSource<'a>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ForwardedEventSource<'a> {
+    Mapped(ForwardedEventMapper),
+    Component(&'a str),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ForwardedEventMapper {
     Element,
-    /// Component / `svelte:component` — official `handleEventHandlerBubble`
-    /// concats into the existing entry.
-    Component,
+    Body,
+    Window,
 }
 
 // =============================================================================
@@ -103,14 +108,14 @@ pub fn process_template_inplace(
 /// This is a pre-pass that walks the AST to collect:
 /// - Slot elements with their props (for the return statement `slots: {...}`)
 /// - Forwarded events (for the return statement `events: {...}`)
-pub fn collect_template_info(
-    ast: &Root,
-    source: &str,
+pub fn collect_template_info<'a>(
+    ast: &'a Root<'_>,
+    source: &'a str,
     collect_dollar_slot_names: bool,
     check_await: bool,
     check_rune_global: bool,
     instance_value_names: &std::collections::HashSet<String>,
-) -> TemplateInfo {
+) -> TemplateInfo<'a> {
     let mut info = TemplateInfo::empty(collect_dollar_slot_names);
     let mut detector =
         TemplateRunesDetector::new(check_await, check_rune_global, instance_value_names);
@@ -134,15 +139,15 @@ pub fn collect_template_info(
     info
 }
 
-pub fn collect_template_info_if_needed(
-    ast: &Root,
-    source: &str,
+pub fn collect_template_info_if_needed<'a>(
+    ast: &'a Root<'_>,
+    source: &'a str,
     collect_dollar_slot_names: bool,
     may_need_template_info: bool,
     check_await: bool,
     check_rune_global: bool,
     instance_value_names: &std::collections::HashSet<String>,
-) -> TemplateInfo {
+) -> TemplateInfo<'a> {
     if may_need_template_info || check_await || check_rune_global {
         collect_template_info(
             ast,
@@ -164,7 +169,11 @@ mod tests {
     use crate::compiler::phases::phase1_parse::{self, ParseOptions};
     use crate::svelte2tsx::utils::source_features::scan_source_features;
 
-    fn collect(source: &str, dollar_slots: bool) -> TemplateInfo {
+    fn with_collected_info(
+        source: &str,
+        dollar_slots: bool,
+        inspect: impl FnOnce(&TemplateInfo<'_>),
+    ) {
         let ast = phase1_parse::parse_script_ts(
             source,
             ParseOptions {
@@ -174,21 +183,23 @@ mod tests {
         )
         .expect("fixture should parse");
         let features = scan_source_features(source);
-        collect_template_info(
+        let info = collect_template_info(
             &ast,
             source,
             dollar_slots,
             features.has_await_word,
             features.may_have_template_rune_global,
             &std::collections::HashSet::new(),
-        )
+        );
+        inspect(&info);
     }
 
-    fn collect_if_needed(
+    fn with_collected_info_if_needed(
         source: &str,
         dollar_slots: bool,
         may_need_template_info: bool,
-    ) -> TemplateInfo {
+        inspect: impl FnOnce(&TemplateInfo<'_>),
+    ) {
         let ast = phase1_parse::parse_script_ts(
             source,
             ParseOptions {
@@ -198,7 +209,7 @@ mod tests {
         )
         .expect("fixture should parse");
         let features = scan_source_features(source);
-        collect_template_info_if_needed(
+        let info = collect_template_info_if_needed(
             &ast,
             source,
             dollar_slots,
@@ -206,7 +217,8 @@ mod tests {
             features.has_await_word,
             features.may_have_template_rune_global,
             &std::collections::HashSet::new(),
-        )
+        );
+        inspect(&info);
     }
 
     fn assert_info_eq(actual: &TemplateInfo, expected: &TemplateInfo) {
@@ -227,12 +239,14 @@ mod tests {
 
     #[test]
     fn slot_summary_ignores_script_and_raw_html_text() {
-        let info = collect(
+        with_collected_info(
             r#"<script>const marker = "<slot>";</script>{@html "<slot>"}<div />"#,
             true,
+            |info| {
+                assert!(info.slots.is_empty());
+                assert_eq!(info.dollar_slot_names, Some(Box::new(IndexSet::new())));
+            },
         );
-        assert!(info.slots.is_empty());
-        assert_eq!(info.dollar_slot_names, Some(Box::new(IndexSet::new())));
     }
 
     #[test]
@@ -242,28 +256,29 @@ mod tests {
 <slot name="named" last={value} />
 <slot name={dynamic} />
 <slot name="pre{dynamic}post" />"#;
-        let info = collect(source, true);
-
-        assert_eq!(
-            info.slots.keys().map(String::as_str).collect::<Vec<_>>(),
-            vec!["named", "default", "undefined"]
-        );
-        let dollar_names = IndexSet::from([
-            "named".to_string(),
-            "default".to_string(),
-            "post".to_string(),
-        ]);
-        assert_eq!(info.dollar_slot_names.as_deref(), Some(&dollar_names));
-        let named = info.slots.get("named").expect("named slot");
-        assert_eq!(named.len(), 1);
-        assert!(named[0].contains("last"));
+        with_collected_info(source, true, |info| {
+            assert_eq!(
+                info.slots.keys().map(String::as_str).collect::<Vec<_>>(),
+                vec!["named", "default", "undefined"]
+            );
+            let dollar_names = IndexSet::from([
+                "named".to_string(),
+                "default".to_string(),
+                "post".to_string(),
+            ]);
+            assert_eq!(info.dollar_slot_names.as_deref(), Some(&dollar_names));
+            let named = info.slots.get("named").expect("named slot");
+            assert_eq!(named.len(), 1);
+            assert!(named[0].contains("last"));
+        });
     }
 
     #[test]
     fn slot_summary_skips_dollar_name_storage_when_unused() {
-        let info = collect("<slot name=\"named\" /><slot />", false);
-        assert_eq!(info.slots.len(), 2);
-        assert!(info.dollar_slot_names.is_none());
+        with_collected_info("<slot name=\"named\" /><slot />", false, |info| {
+            assert_eq!(info.slots.len(), 2);
+            assert!(info.dollar_slot_names.is_none());
+        });
     }
 
     #[test]
@@ -275,9 +290,11 @@ mod tests {
                 true,
             ),
         ] {
-            let gated = collect_if_needed(source, dollar_slots, false);
-            let collected = collect(source, dollar_slots);
-            assert_info_eq(&gated, &collected);
+            with_collected_info_if_needed(source, dollar_slots, false, |gated| {
+                with_collected_info(source, dollar_slots, |collected| {
+                    assert_info_eq(gated, collected);
+                });
+            });
         }
     }
 
@@ -289,9 +306,11 @@ mod tests {
             "<!-- <slot on:click> --><div />",
             r#"<div title="<slot" data-event="on:" />"#,
         ] {
-            let gated = collect_if_needed(source, true, true);
-            let collected = collect(source, true);
-            assert_info_eq(&gated, &collected);
+            with_collected_info_if_needed(source, true, true, |gated| {
+                with_collected_info(source, true, |collected| {
+                    assert_info_eq(gated, collected);
+                });
+            });
         }
     }
 
@@ -309,9 +328,11 @@ mod tests {
             {/if}
             <Component on:change />"#,
         ] {
-            let gated = collect_if_needed(source, true, true);
-            let collected = collect(source, true);
-            assert_info_eq(&gated, &collected);
+            with_collected_info_if_needed(source, true, true, |gated| {
+                with_collected_info(source, true, |collected| {
+                    assert_info_eq(gated, collected);
+                });
+            });
         }
     }
 }

--- a/crates/rsvelte_projection/src/svelte2tsx/template/nodes/inline_component.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/template/nodes/inline_component.rs
@@ -29,9 +29,7 @@ use crate::svelte2tsx::template::utils::expr::{
     extend_expr_end_with_ts_postfix, get_binding_lhs_text, get_expression_end_stripping_ts,
     get_expression_range, get_expression_text, get_set_binding_ranges,
 };
-use crate::svelte2tsx::template::utils::names::{
-    reversed_component_instance_name, reversed_component_name,
-};
+use crate::svelte2tsx::template::utils::names::reversed_component_name;
 use crate::svelte2tsx::template::utils::source::{
     count_tag_to_attr_spaces, find_closing_tag_start, find_opening_tag_end,
 };
@@ -95,7 +93,7 @@ pub(crate) fn handle_component(
     // the official `computeDepth()` in `htmlxtojsx_v2/nodes/InlineComponent.ts`.
     // Two sibling `<A/>` at the same depth both get `$$_A<depth>C`, which is correct —
     // the official tool reuses the same name for components at the same depth.
-    let ctor_var = reversed_component_name(&comp.name, depth);
+    let inst_var = reversed_component_name(&comp.name, depth);
 
     // Find the end of the opening tag
     let opening_tag_end = find_opening_tag_end(source, comp.start, comp.end);
@@ -223,7 +221,6 @@ pub(crate) fn handle_component(
     }
 
     // Build the replacement for the opening tag.
-    let inst_var = reversed_component_instance_name(&comp.name, depth);
     // Component-side `bind:` suffix: type-widener + `$$bindings` marker.
     // Mirrors the JS reference's component branch in
     // `htmlxtojsx_v2/nodes/Binding.ts::handleBinding`:
@@ -295,16 +292,16 @@ pub(crate) fn handle_component(
         };
         (
             format!(
-                " {{ const {} = __sveltets_2_ensureComponent({}); const {} = new {}({{ target: __sveltets_2_any(), props: {{",
-                ctor_var, comp.name, inst_var, ctor_var,
+                " {{ const {}C = __sveltets_2_ensureComponent({}); const {} = new {}C({{ target: __sveltets_2_any(), props: {{",
+                inst_var, comp.name, inst_var, inst_var,
             ),
             format!("}}}});{}{}", component_bind_suffix, on_calls),
         )
     } else {
         (
             format!(
-                " {{ const {} = __sveltets_2_ensureComponent({}); new {}({{ target: __sveltets_2_any(), props: {{",
-                ctor_var, comp.name, ctor_var,
+                " {{ const {}C = __sveltets_2_ensureComponent({}); new {}C({{ target: __sveltets_2_any(), props: {{",
+                inst_var, comp.name, inst_var,
             ),
             "}});".to_string(),
         )
@@ -478,9 +475,6 @@ pub(crate) fn handle_svelte_component(
     let saved_outer_slot = counter.slot_inst.take();
 
     let expr_text = get_expression_text(&comp.expression, source);
-    // Use "svelte:component" as the name for variable naming, with ':' replaced by '_'
-    let scomp_name = "svelte:component".replace(':', "_");
-
     let opening_tag_end = find_opening_tag_end(source, comp.start, comp.end);
 
     // Collect on: directives
@@ -522,8 +516,7 @@ pub(crate) fn handle_svelte_component(
         }
     }
 
-    let ctor_var = reversed_component_name(&scomp_name, depth);
-    let inst_var = reversed_component_instance_name(&scomp_name, depth);
+    let inst_var = reversed_component_name("svelte_component", depth);
     // A `bind:` directive on the component needs the instance variable too: it
     // emits a `inst.$$bindings = 'name'` marker (and a type-widener) after the
     // `new` statement, mirroring `handle_component`.
@@ -584,13 +577,13 @@ pub(crate) fn handle_svelte_component(
             String::new()
         };
         format!(
-            " {{ const {} = __sveltets_2_ensureComponent({}); const {} = new {}({{ target: __sveltets_2_any(), props: {{{}}}}});{}{}",
-            ctor_var, expr_text, inst_var, ctor_var, attrs_str, component_bind_suffix, on_calls
+            " {{ const {}C = __sveltets_2_ensureComponent({}); const {} = new {}C({{ target: __sveltets_2_any(), props: {{{}}}}});{}{}",
+            inst_var, expr_text, inst_var, inst_var, attrs_str, component_bind_suffix, on_calls
         )
     } else {
         format!(
-            " {{ const {} = __sveltets_2_ensureComponent({}); new {}({{ target: __sveltets_2_any(), props: {{{}}}}});",
-            ctor_var, expr_text, ctor_var, attrs_str
+            " {{ const {}C = __sveltets_2_ensureComponent({}); new {}C({{ target: __sveltets_2_any(), props: {{{}}}}});",
+            inst_var, expr_text, inst_var, attrs_str
         )
     };
 

--- a/crates/rsvelte_projection/src/svelte2tsx/template/utils/names.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/template/utils/names.rs
@@ -1,91 +1,66 @@
 //! Generated variable-name helpers, mirroring `htmlxtojsx_v2/utils/node-utils.ts`
 //! and the `InlineComponent.ts` constructor-name scheme.
 
-/// Sanitize a component name for use in variable names.
-///
-/// Mirrors `sanitizePropName` in `htmlxtojsx_v2/utils/node-utils.ts`:
-/// each character that is NOT `[0-9A-Za-z$_]` is replaced with `_`.
-/// Applied BEFORE reversing, so `Foo.Bar` → `Foo_Bar` → reversed `raB_ooF`.
-pub(crate) fn sanitize_prop_name(name: &str) -> String {
-    name.chars()
-        .map(|c| {
-            if c.is_ascii_alphanumeric() || c == '$' || c == '_' {
-                c
-            } else {
-                '_'
-            }
-        })
-        .collect()
-}
+use std::fmt::Write as _;
 
-/// Generate a reversed component constructor variable name.
-///
-/// Mirrors upstream `InlineComponent.ts`:
-///   `this._name = '$$_' + Array.from(sanitizePropName(name)).reverse().join('') + depth`
-///   `const constructorName = this._name + 'C'`
-///
-/// The `depth` (ancestor element/component count, NOT including blocks/root)
-/// replaces the old per-name counter so two `<A/>` at the same level both
-/// get index 0 — `$$_A0C` — matching the official tool.
+/// Generate the shared constructor/instance name; constructors append `C`.
 pub(crate) fn reversed_component_name(name: &str, depth: u32) -> String {
-    let sanitized = sanitize_prop_name(name);
-    let reversed: String = sanitized.chars().rev().collect();
-    format!("$$_{}{}C", reversed, depth)
-}
+    #[cfg(test)]
+    COMPONENT_NAME_DERIVATIONS.with(|count| count.set(count.get() + 1));
 
-/// Generate a reversed component instance variable name.
-///
-/// Like `reversed_component_name` but without the trailing `C` suffix.
-pub(crate) fn reversed_component_instance_name(name: &str, depth: u32) -> String {
-    let sanitized = sanitize_prop_name(name);
-    let reversed: String = sanitized.chars().rev().collect();
-    format!("$$_{}{}", reversed, depth)
+    let mut generated = String::with_capacity(name.len() + 13);
+    generated.push_str("$$_");
+    for c in name.chars().rev() {
+        if c.is_ascii_alphanumeric() || c == '$' || c == '_' {
+            generated.push(c);
+        } else {
+            // Upstream sanitizes UTF-16 code units before reversing.
+            generated.push('_');
+            if c.len_utf16() == 2 {
+                generated.push('_');
+            }
+        }
+    }
+    let _ = write!(generated, "{depth}");
+    generated
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::svelte2tsx::svelte2tsx::{Svelte2TsxOptions, svelte2tsx};
+
+    fn take_derivation_count() -> usize {
+        COMPONENT_NAME_DERIVATIONS.with(|count| count.replace(0))
+    }
 
     #[test]
-    fn test_reversed_component_name() {
-        // Basic cases: depth (not per-name counter) is the suffix.
-        assert_eq!(reversed_component_name("Component", 0), "$$_tnenopmoC0C");
-        // depth=1 → `$$_ooF1C` (same as before, index was already depth in these examples)
-        assert_eq!(reversed_component_name("Foo", 1), "$$_ooF1C");
-        assert_eq!(reversed_component_name("Button", 0), "$$_nottuB0C");
-        // sanitizePropName: '.' is not [0-9A-Za-z$_], replaced with '_' before reversing.
-        // "Foo.Bar" → sanitized "Foo_Bar" → reversed "raB_ooF" → "$$_raB_ooF0C"
-        assert_eq!(reversed_component_name("Foo.Bar", 0), "$$_raB_ooF0C");
-        // Namespaced component: "Namespace:Comp" → "Namespace_Comp" → "pmoC_ecapsemaN" → "$$_pmoC_ecapsemaN0C"
+    fn derives_shared_constructor_and_instance_name() {
+        assert_eq!(reversed_component_name("Component", 0), "$$_tnenopmoC0");
+        assert_eq!(reversed_component_name("Foo.Bar", 1), "$$_raB_ooF1");
         assert_eq!(
-            reversed_component_name("Namespace:Comp", 0),
-            "$$_pmoC_ecapsemaN0C"
+            reversed_component_name("Namespace:Comp", 2),
+            "$$_pmoC_ecapsemaN2"
         );
     }
 
     #[test]
-    fn test_reversed_component_instance_name() {
-        assert_eq!(
-            reversed_component_instance_name("Component", 0),
-            "$$_tnenopmoC0"
-        );
-        assert_eq!(reversed_component_instance_name("Button", 0), "$$_nottuB0");
-        // sanitizePropName applied before reversing for instance names too.
-        assert_eq!(
-            reversed_component_instance_name("Foo.Bar", 0),
-            "$$_raB_ooF0"
-        );
+    fn matches_upstream_utf16_sanitization() {
+        assert_eq!(reversed_component_name("A😀-é.组件$", 42), "$$_$_______A42");
     }
 
     #[test]
-    fn test_sanitize_prop_name() {
-        // Valid chars pass through unchanged.
-        assert_eq!(sanitize_prop_name("Component"), "Component");
-        assert_eq!(sanitize_prop_name("Foo_Bar"), "Foo_Bar");
-        assert_eq!(sanitize_prop_name("$foo"), "$foo");
-        // Invalid chars are replaced with '_'.
-        assert_eq!(sanitize_prop_name("Foo.Bar"), "Foo_Bar");
-        assert_eq!(sanitize_prop_name("svelte:self"), "svelte_self");
-        assert_eq!(sanitize_prop_name("a-b-c"), "a_b_c");
+    fn repeated_components_derive_each_name_once() {
+        let source = "<Repeated />".repeat(512);
+        take_derivation_count();
+        let result = svelte2tsx(&source, Svelte2TsxOptions::default()).unwrap();
+
+        assert_eq!(take_derivation_count(), 512);
+        assert_eq!(result.code.matches("$$_detaepeR0C").count(), 1024);
     }
+}
+
+#[cfg(test)]
+thread_local! {
+    static COMPONENT_NAME_DERIVATIONS: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
 }

--- a/crates/rsvelte_projection/tests/svelte2tsx_entry.rs
+++ b/crates/rsvelte_projection/tests/svelte2tsx_entry.rs
@@ -120,6 +120,19 @@ fn test_svelte2tsx_component() {
 }
 
 #[test]
+fn test_svelte2tsx_mixed_forwarded_event_sources() {
+    let source =
+        "<div on:mix></div><Inner on:mix/><svelte:window on:resize/><svelte:body on:focus/>";
+    let result = svelte2tsx(source, Svelte2TsxOptions::default()).unwrap();
+    assert!(result.code.contains(
+        "events: {'mix':__sveltets_2_unionType(__sveltets_2_mapElementEvent('mix'), \
+         __sveltets_2_bubbleEventDef(__sveltets_2_instanceOf(Inner).$$events_def, 'mix')), \
+         'resize':__sveltets_2_mapWindowEvent('resize'), \
+         'focus':__sveltets_2_mapBodyEvent('focus')}"
+    ));
+}
+
+#[test]
 fn test_svelte2tsx_v5_export() {
     let source = "<h1>hello</h1>";
     let options = Svelte2TsxOptions {


### PR DESCRIPTION
> Stack 4/8  
> Base: `agent/svelte2tsx-release-03-template-analysis` (`02777ada`)  
> Head: `agent/svelte2tsx-release-04-events-exports` (`8dbc1875`)

## Summary

- scan dispatched events once
- keep forwarded-event descriptors borrowed and defer formatting/index
  promotion until emission
- stream ordered exports
- index leading import comments and cache leading export JSDoc
- derive generated component names once

The event path keeps insertion order and uses a compact small-event
representation before promoting to a map. Export, import-trivia, JSDoc, and
generated-name output remain byte-identical.

## Commit scope

- `1ea4768f` perf(svelte2tsx): scan dispatched events once
- `56d27714` perf(svelte2tsx): index forwarded events
- `8e7c6519` perf(svelte2tsx): defer forwarded event formatting
- `f61e95ca` perf(svelte2tsx): defer forwarded event indexing
- `15dd5145` perf(svelte2tsx): stream ordered export output
- `524a4fb0` perf(svelte2tsx): index leading import comments
- `c2807505` perf(svelte2tsx): derive component names once
- `8dbc1875` perf(svelte2tsx): cache leading export docs

## Validation

- [ ] `cargo fmt --check`
- [ ] `cargo clippy -p rsvelte_projection --all-targets --all-features -- -D warnings`
- [ ] `cargo test -p rsvelte_projection --test svelte2tsx_entry`
- [ ] `cargo test -p rsvelte_projection --test svelte2tsx_renamed_export_jsdoc`
- [ ] `cargo test -p rsvelte_projection --test svelte2tsx_fixtures`
- [ ] `cargo test -p rsvelte_projection`

## Stack order

Merge after PR 3. PR 5 is based on this head.
