### PR TITLE
Thread the opener-comment index through svelte2tsx

### DIFF
--- a/crates/rsvelte_projection/src/svelte2tsx/svelte2tsx.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/svelte2tsx.rs
@@ -561,12 +561,16 @@ pub fn svelte2tsx(
     let uses_dollar_rest_props = source_features.uses_dollar_rest_props;
     let uses_dollar_slots = source_features.uses_dollar_slots;
 
-    // Step 9: Process template nodes in-place via MagicString. Publish the
-    // element-opener comment ranges first so attribute emission can re-attach
-    // them as leading comments (mirrors official `attr.leadingComments`).
-    template::set_element_opener_comments(ast.comments.iter().map(|c| (c.start, c.end)).collect());
-    template::process_template_inplace(&ast.fragment, source, &options, &mut str);
-    template::clear_element_opener_comments();
+    // Step 9: Process template nodes in-place via MagicString.
+    template::process_template_inplace(
+        &ast.fragment,
+        source,
+        &options,
+        &mut str,
+        ast.comments
+            .iter()
+            .map(|comment| (comment.start, comment.end)),
+    );
 
     // Step 9.1: Hoist top-level `{#snippet}` blocks.
     //

--- a/crates/rsvelte_projection/src/svelte2tsx/template/attributes/attribute.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/template/attributes/attribute.rs
@@ -6,9 +6,7 @@ use std::borrow::Cow;
 use super::svg::is_svg_attribute;
 use crate::ast::template::{AttributeNode, AttributeValue, AttributeValuePart};
 use crate::svelte2tsx::svelte2tsx::slice_src;
-#[cfg(test)]
-use crate::svelte2tsx::template::ctx::record_element_opener_comment_range_visits;
-use crate::svelte2tsx::template::ctx::with_element_opener_comments;
+use crate::svelte2tsx::template::ctx::ElementOpenerCommentIndex;
 use crate::svelte2tsx::template::segs::{Seg, segs_push_fmt, segs_push_lit, segs_push_src};
 use crate::svelte2tsx::template::utils::expr::{get_expression_range, get_expression_text};
 
@@ -245,122 +243,135 @@ pub(crate) fn transform_attribute_case<'a>(
 /// `attr_start`: any comments immediately before it (only whitespace between)
 /// become `[\n]?<comment-source>…\n` (mirrors official getLeadingComment +
 /// getLeadingCommentTransformation). Empty when there are none.
-pub(crate) fn leading_attr_comment_segs(attr_start: u32, source: &str) -> Vec<Seg> {
-    with_element_opener_comments(|comments| {
-        if comments.is_empty() {
-            return Vec::new();
+pub(crate) fn leading_attr_comment_segs(
+    attr_start: u32,
+    source: &str,
+    comments: &ElementOpenerCommentIndex,
+) -> Vec<Seg> {
+    if comments.is_empty() {
+        return Vec::new();
+    }
+    let candidates = comments.ending_at_or_before(attr_start);
+    let mut from = candidates.len();
+    let mut search_end = attr_start;
+    for &(comment_start, comment_end) in candidates.iter().rev() {
+        #[cfg(test)]
+        comments.record_range_visits(1);
+        if source
+            .get(comment_end as usize..search_end as usize)
+            .is_some_and(|between| between.chars().all(char::is_whitespace))
+        {
+            from -= 1;
+            search_end = comment_start;
+        } else {
+            break;
         }
-        let mut leading: Vec<(u32, u32)> = Vec::new();
-        let mut search_end = attr_start;
-        for &(comment_start, comment_end) in comments.ending_at_or_before(attr_start).iter().rev() {
-            #[cfg(test)]
-            record_element_opener_comment_range_visits(1);
-            if source
-                .get(comment_end as usize..search_end as usize)
-                .is_some_and(|between| between.chars().all(char::is_whitespace))
-            {
-                leading.push((comment_start, comment_end));
-                search_end = comment_start;
-            } else {
-                break;
-            }
+    }
+    let leading = &candidates[from..];
+    if leading.is_empty() {
+        return Vec::new();
+    }
+    let mut out = Vec::new();
+    for &(cs, ce) in leading {
+        let region = slice_src(source, cs.saturating_sub(100) as usize, cs as usize);
+        if region.trim_end_matches([' ', '\t']).ends_with('\n') {
+            segs_push_lit(&mut out, "\n");
         }
-        if leading.is_empty() {
-            return Vec::new();
-        }
-        leading.reverse();
-        let mut out = Vec::new();
-        for (cs, ce) in &leading {
-            let region = slice_src(source, cs.saturating_sub(100) as usize, *cs as usize);
-            if region.trim_end_matches([' ', '\t']).ends_with('\n') {
-                segs_push_lit(&mut out, "\n");
-            }
-            segs_push_src(&mut out, *cs, *ce);
-        }
-        segs_push_lit(&mut out, "\n");
-        out
-    })
+        segs_push_src(&mut out, cs, ce);
+    }
+    segs_push_lit(&mut out, "\n");
+    out
 }
 
 /// Source ranges of the comments that sit between `attr_end` and the `>` of the
 /// enclosing opening tag, with only whitespace (and an optional self-closing
 /// `/`) around them. Mirrors official `handleTrailingEndComment`; the caller is
 /// responsible for only asking about the element's *last* attribute.
-fn trailing_attr_comments(attr_end: u32, source: &str) -> Vec<(u32, u32)> {
+fn trailing_attr_comments<'a>(
+    attr_end: u32,
+    source: &str,
+    comments: &'a ElementOpenerCommentIndex,
+) -> &'a [(u32, u32)] {
     let Some(rel) = source.get(attr_end as usize..).and_then(|s| s.find('>')) else {
-        return Vec::new();
+        return &[];
     };
     let tag_end = attr_end + rel as u32;
-    with_element_opener_comments(|comments| {
-        let mut trailing: Vec<(u32, u32)> = Vec::new();
-        let mut search_start = attr_end;
-        for &(comment_start, comment_end) in comments.starting_at_or_after(attr_end) {
-            #[cfg(test)]
-            record_element_opener_comment_range_visits(1);
-            if comment_end > tag_end {
-                break;
-            }
-            if !slice_src(source, search_start as usize, comment_start as usize)
-                .chars()
-                .all(char::is_whitespace)
-            {
-                break;
-            }
-            trailing.push((comment_start, comment_end));
-            search_start = comment_end;
+    let candidates = comments.starting_at_or_after(attr_end);
+    let mut count = 0;
+    let mut search_start = attr_end;
+    for &(comment_start, comment_end) in candidates {
+        #[cfg(test)]
+        comments.record_range_visits(1);
+        if comment_end > tag_end {
+            break;
         }
-        if trailing.is_empty() {
-            return Vec::new();
-        }
-        // Anything other than whitespace and an optional `/` up to `>` means the
-        // comments are not the last thing in the opener — bail like official.
-        let rest = slice_src(source, search_start as usize, tag_end as usize);
-        if !rest.chars().all(|ch| ch.is_whitespace() || ch == '/') || rest.matches('/').count() > 1
+        if !slice_src(source, search_start as usize, comment_start as usize)
+            .chars()
+            .all(char::is_whitespace)
         {
-            return Vec::new();
+            break;
         }
-        trailing
-    })
+        count += 1;
+        search_start = comment_end;
+    }
+    if count == 0 {
+        return &[];
+    }
+    // Anything other than whitespace and an optional `/` up to `>` means the
+    // comments are not the last thing in the opener — bail like official.
+    let rest = slice_src(source, search_start as usize, tag_end as usize);
+    if !rest.chars().all(|ch| ch.is_whitespace() || ch == '/') || rest.matches('/').count() > 1 {
+        return &[];
+    }
+    &candidates[..count]
 }
 
 /// Build the trailing-comment suffix segs for the last attribute of an element
 /// opener: each comment becomes `[\n| ]<comment-source>`, closed by a final
 /// `\n` (mirrors official `getTrailingCommentTransformation`). Empty when there
 /// are none.
-pub(crate) fn trailing_attr_comment_segs(attr_end: u32, source: &str) -> Vec<Seg> {
-    let trailing = trailing_attr_comments(attr_end, source);
+pub(crate) fn trailing_attr_comment_segs(
+    attr_end: u32,
+    source: &str,
+    comments: &ElementOpenerCommentIndex,
+) -> Vec<Seg> {
+    let trailing = trailing_attr_comments(attr_end, source, comments);
     if trailing.is_empty() {
         return Vec::new();
     }
     let mut out = Vec::new();
-    for (cs, ce) in &trailing {
-        let region = slice_src(source, cs.saturating_sub(100) as usize, *cs as usize);
+    for &(cs, ce) in trailing {
+        let region = slice_src(source, cs.saturating_sub(100) as usize, cs as usize);
         if region.trim_end_matches([' ', '\t']).ends_with('\n') {
             segs_push_lit(&mut out, "\n");
         } else {
             segs_push_lit(&mut out, " ");
         }
-        segs_push_src(&mut out, *cs, *ce);
+        segs_push_src(&mut out, cs, ce);
     }
     segs_push_lit(&mut out, "\n");
     out
 }
 
 /// String variant of [`trailing_attr_comment_segs`] for the component props path.
-pub(crate) fn trailing_attr_comment_text(attr_end: u32, source: &str) -> String {
-    let trailing = trailing_attr_comments(attr_end, source);
+pub(crate) fn trailing_attr_comment_text(
+    attr_end: u32,
+    source: &str,
+    comments: &ElementOpenerCommentIndex,
+) -> String {
+    let trailing = trailing_attr_comments(attr_end, source, comments);
     if trailing.is_empty() {
         return String::new();
     }
     let mut out = String::new();
-    for (cs, ce) in &trailing {
-        let region = slice_src(source, cs.saturating_sub(100) as usize, *cs as usize);
+    for &(cs, ce) in trailing {
+        let region = slice_src(source, cs.saturating_sub(100) as usize, cs as usize);
         out.push(if region.trim_end_matches([' ', '\t']).ends_with('\n') {
             '\n'
         } else {
             ' '
         });
-        out.push_str(slice_src(source, *cs as usize, *ce as usize));
+        out.push_str(slice_src(source, cs as usize, ce as usize));
     }
     out.push('\n');
     out
@@ -378,11 +389,12 @@ pub(crate) fn trailing_attr_comment_text(attr_end: u32, source: &str) -> String 
 pub(crate) fn format_attribute_node_segments(
     node: &AttributeNode,
     source: &str,
+    comments: &ElementOpenerCommentIndex,
     is_element: bool,
     tag: &str,
     leading_comment: &str,
 ) -> Option<Vec<Seg>> {
-    let leading = leading_attr_comment_segs(node.start, source);
+    let leading = leading_attr_comment_segs(node.start, source, comments);
     let is_data_attr =
         is_element && node.name.starts_with("data-") && !node.name.starts_with("data-sveltekit-");
     let is_css_prop = !is_element && node.name.starts_with("--");
@@ -647,10 +659,6 @@ pub(crate) fn format_attribute_node_segments(
 mod tests {
     use super::*;
     use crate::svelte2tsx::svelte2tsx::{Svelte2TsxOptions, svelte2tsx};
-    use crate::svelte2tsx::template::ctx::{
-        clear_element_opener_comments, element_opener_comment_range_visits,
-        reset_element_opener_comment_range_visits, set_element_opener_comments,
-    };
     use crate::svelte2tsx::template::segs::segs_to_string;
     use std::fmt::Write as _;
 
@@ -707,12 +715,14 @@ mod tests {
             source_range(source, "/* first */"),
         ];
         let attr_start = source.find("foo").unwrap() as u32;
-        set_element_opener_comments(ranges);
+        let comments = ElementOpenerCommentIndex::new(ranges);
 
-        let actual = segs_to_string(&leading_attr_comment_segs(attr_start, source), source);
+        let actual = segs_to_string(
+            &leading_attr_comment_segs(attr_start, source, &comments),
+            source,
+        );
 
         assert_eq!(actual, "\n/* first */\n// second\n");
-        clear_element_opener_comments();
     }
 
     #[test]
@@ -723,12 +733,11 @@ mod tests {
             source_range(source, "/* first */"),
         ];
         let attr_end = source.find("foo").unwrap() as u32 + "foo".len() as u32;
-        set_element_opener_comments(ranges);
+        let comments = ElementOpenerCommentIndex::new(ranges);
 
-        let actual = trailing_attr_comment_text(attr_end, source);
+        let actual = trailing_attr_comment_text(attr_end, source, &comments);
 
         assert_eq!(actual, " /* first */\n/* second */\n");
-        clear_element_opener_comments();
     }
 
     #[test]
@@ -737,14 +746,19 @@ mod tests {
         let comment = source_range(source, "/* between */");
         let first_start = source.find("first").unwrap() as u32;
         let second_start = source.find("second").unwrap() as u32;
-        set_element_opener_comments(vec![comment]);
+        let comments = ElementOpenerCommentIndex::new([comment]);
 
-        let first = segs_to_string(&leading_attr_comment_segs(first_start, source), source);
-        let second = segs_to_string(&leading_attr_comment_segs(second_start, source), source);
+        let first = segs_to_string(
+            &leading_attr_comment_segs(first_start, source, &comments),
+            source,
+        );
+        let second = segs_to_string(
+            &leading_attr_comment_segs(second_start, source, &comments),
+            source,
+        );
 
         assert_eq!(first, "");
         assert_eq!(second, "/* between */\n");
-        clear_element_opener_comments();
     }
 
     #[test]
@@ -766,21 +780,23 @@ mod tests {
         source.push('>');
 
         ranges.reverse();
-        set_element_opener_comments(ranges.clone());
-        reset_element_opener_comment_range_visits();
+        let comments = ElementOpenerCommentIndex::new(ranges.iter().copied());
+        comments.reset_range_visits();
 
         for attr_start in attr_starts {
-            let actual = segs_to_string(&leading_attr_comment_segs(attr_start, &source), &source);
+            let actual = segs_to_string(
+                &leading_attr_comment_segs(attr_start, &source, &comments),
+                &source,
+            );
             let expected = leading_comment_oracle(attr_start, &source, &ranges);
             assert_eq!(actual, expected);
         }
 
-        let visits = element_opener_comment_range_visits();
+        let visits = comments.range_visits();
         assert!(
             visits <= ATTRIBUTE_COUNT * 2,
             "binary-bounded queries should inspect only adjacent ranges: {visits} visits"
         );
-        clear_element_opener_comments();
     }
 
     // Tests for data-* and --* attribute wrapping rules.

--- a/crates/rsvelte_projection/src/svelte2tsx/template/attributes/mod.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/template/attributes/mod.rs
@@ -16,6 +16,7 @@ pub(super) mod transition;
 
 use crate::ast::template::Attribute;
 use crate::svelte2tsx::svelte2tsx::slice_src;
+use crate::svelte2tsx::template::ctx::ElementOpenerCommentIndex;
 use crate::svelte2tsx::template::nodes::attach_tag::format_attach_tag_segments;
 use crate::svelte2tsx::template::segs::{
     Seg, segs_is_empty, segs_push_fmt, segs_push_lit, segs_push_src, segs_to_string,
@@ -115,18 +116,27 @@ fn splice_trailing_text(part: &mut String, trailing: &str) {
 pub(super) fn build_attributes_string(
     attributes: &[Attribute],
     source: &str,
+    comments: &ElementOpenerCommentIndex,
     in_slot_context: bool,
 ) -> String {
-    build_attributes_string_with_tag(attributes, source, "", in_slot_context)
+    build_attributes_string_with_tag(attributes, source, comments, "", in_slot_context)
 }
 
 pub(super) fn build_attributes_string_with_tag(
     attributes: &[Attribute],
     source: &str,
+    comments: &ElementOpenerCommentIndex,
     parent_tag: &str,
     in_slot_context: bool,
 ) -> String {
-    let segs = build_attribute_segments(attributes, source, parent_tag, in_slot_context, None);
+    let segs = build_attribute_segments(
+        attributes,
+        source,
+        comments,
+        parent_tag,
+        in_slot_context,
+        None,
+    );
     segs_to_string(&segs, source)
 }
 
@@ -142,6 +152,7 @@ pub(super) fn build_attributes_string_with_tag(
 pub(super) fn build_attribute_segments(
     attributes: &[Attribute],
     source: &str,
+    comments: &ElementOpenerCommentIndex,
     parent_tag: &str,
     in_slot_context: bool,
     opener_content_start: Option<u32>,
@@ -182,9 +193,9 @@ pub(super) fn build_attribute_segments(
                     }
                     _ => "",
                 };
-                if let Some(part) =
-                    format_attribute_node_segments(node, source, true, parent_tag, leading)
-                {
+                if let Some(part) = format_attribute_node_segments(
+                    node, source, comments, true, parent_tag, leading,
+                ) {
                     push_with_separator(&mut segs, part);
                     any_pushed = true;
                 }
@@ -266,7 +277,7 @@ pub(super) fn build_attribute_segments(
     }
 
     if any_pushed && let Some(end) = opener_trailing_comment_range(attributes) {
-        let trailing = trailing_attr_comment_segs(end, source);
+        let trailing = trailing_attr_comment_segs(end, source, comments);
         splice_trailing_segs(&mut segs, &trailing);
     }
 
@@ -290,7 +301,11 @@ pub(super) fn build_attribute_segments(
 ///
 /// When `on:` directives are present but filtered out, a space is added inside
 /// the empty braces to match the JS svelte2tsx output: `props: { }`.
-pub(super) fn build_component_props_string(attributes: &[Attribute], source: &str) -> String {
+pub(super) fn build_component_props_string(
+    attributes: &[Attribute],
+    source: &str,
+    comments: &ElementOpenerCommentIndex,
+) -> String {
     let mut parts: Vec<String> = Vec::new();
     let mut has_on_directives = false;
     let mut let_count = 0u32;
@@ -383,7 +398,7 @@ pub(super) fn build_component_props_string(attributes: &[Attribute], source: &st
     if let Some(end) = opener_trailing_comment_range(attributes)
         && let Some(last) = parts.last_mut()
     {
-        splice_trailing_text(last, &trailing_attr_comment_text(end, source));
+        splice_trailing_text(last, &trailing_attr_comment_text(end, source, comments));
     }
 
     let result = parts.join("");
@@ -412,6 +427,7 @@ pub(super) fn build_component_props_string(attributes: &[Attribute], source: &st
 pub(super) fn build_component_props_segments(
     attributes: &[Attribute],
     source: &str,
+    comments: &ElementOpenerCommentIndex,
     drop_slot: bool,
 ) -> Vec<Seg> {
     let mut inner: Vec<Seg> = Vec::new();
@@ -440,7 +456,9 @@ pub(super) fn build_component_props_segments(
                 // is_element=false: --* attrs get __sveltets_2_cssProp wrapping
                 // inside format_attribute_node_segments (mirrors Attribute.ts).
                 // Components preserve attribute-name case, so the tag is unused.
-                if let Some(part) = format_attribute_node_segments(node, source, false, "", "") {
+                if let Some(part) =
+                    format_attribute_node_segments(node, source, comments, false, "", "")
+                {
                     extend_segs(&mut inner, part);
                 }
             }
@@ -522,7 +540,7 @@ pub(super) fn build_component_props_segments(
     }
 
     if let Some(end) = opener_trailing_comment_range(attributes) {
-        let trailing = trailing_attr_comment_segs(end, source);
+        let trailing = trailing_attr_comment_segs(end, source, comments);
         splice_trailing_segs(&mut inner, &trailing);
     }
 

--- a/crates/rsvelte_projection/src/svelte2tsx/template/ctx.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/template/ctx.rs
@@ -80,6 +80,7 @@ impl TemplateNodeExt for TemplateNode<'_> {
 /// Counter for generated template variable names.
 pub(super) struct Counter {
     slot: u32,
+    pub(super) element_opener_comments: ElementOpenerCommentIndex,
     /// When set (to a component instance var), a `slot="name"` element/component
     /// encountered while processing that component's children — at any depth
     /// inside `{#each}`/`{#if}`/etc. control-flow blocks — is lowered to the
@@ -105,9 +106,10 @@ pub(super) struct Counter {
 }
 
 impl Counter {
-    pub(super) fn new() -> Self {
+    pub(super) fn new(element_opener_comments: impl IntoIterator<Item = (u32, u32)>) -> Self {
         Self {
             slot: 0,
+            element_opener_comments: ElementOpenerCommentIndex::new(element_opener_comments),
             slot_inst: None,
             named_slot_component_close: false,
             suppress_component_lets: false,
@@ -129,7 +131,7 @@ mod tests {
 
     #[test]
     fn slot_counter_is_monotonic() {
-        let mut counter = Counter::new();
+        let mut counter = Counter::new([]);
 
         assert_eq!(counter.next_slot(), 0);
         assert_eq!(counter.next_slot(), 1);
@@ -141,10 +143,13 @@ mod tests {
 #[derive(Default)]
 pub(super) struct ElementOpenerCommentIndex {
     ranges: Vec<(u32, u32)>,
+    #[cfg(test)]
+    range_visits: std::cell::Cell<usize>,
 }
 
 impl ElementOpenerCommentIndex {
-    fn new(mut ranges: Vec<(u32, u32)>) -> Self {
+    pub(super) fn new(ranges: impl IntoIterator<Item = (u32, u32)>) -> Self {
+        let mut ranges: Vec<_> = ranges.into_iter().collect();
         if !ranges.windows(2).all(|pair| pair[0].0 <= pair[1].0) {
             ranges.sort_unstable_by_key(|&(start, _)| start);
         }
@@ -152,7 +157,11 @@ impl ElementOpenerCommentIndex {
             ranges.windows(2).all(|pair| pair[0].1 <= pair[1].0),
             "element-opener comment ranges must not overlap"
         );
-        Self { ranges }
+        Self {
+            ranges,
+            #[cfg(test)]
+            range_visits: std::cell::Cell::new(0),
+        }
     }
 
     pub(super) fn is_empty(&self) -> bool {
@@ -185,48 +194,19 @@ impl ElementOpenerCommentIndex {
         }
         &self.ranges[from..to]
     }
-}
 
-thread_local! {
-    /// Source ranges of comments found inside element opening tags (between
-    /// attributes), set per-compile so attribute emission can re-attach them as
-    /// leading comments. Mirrors official `attr.leadingComments`.
-    static ELEMENT_OPENER_COMMENTS: std::cell::RefCell<ElementOpenerCommentIndex> =
-        std::cell::RefCell::new(ElementOpenerCommentIndex::default());
     #[cfg(test)]
-    static ELEMENT_OPENER_COMMENT_RANGE_VISITS: std::cell::Cell<usize> =
-        const { std::cell::Cell::new(0) };
-}
+    pub(super) fn record_range_visits(&self, count: usize) {
+        self.range_visits.set(self.range_visits.get() + count);
+    }
 
-/// Set the element-opener comment ranges for the current compile (read-only).
-pub(crate) fn set_element_opener_comments(ranges: Vec<(u32, u32)>) {
-    ELEMENT_OPENER_COMMENTS.with(|comments| {
-        *comments.borrow_mut() = ElementOpenerCommentIndex::new(ranges);
-    });
-}
+    #[cfg(test)]
+    pub(super) fn reset_range_visits(&self) {
+        self.range_visits.set(0);
+    }
 
-/// Clear the element-opener comment ranges after a compile.
-pub(crate) fn clear_element_opener_comments() {
-    ELEMENT_OPENER_COMMENTS.with(|comments| comments.borrow_mut().ranges.clear());
-}
-
-pub(super) fn with_element_opener_comments<T>(
-    f: impl FnOnce(&ElementOpenerCommentIndex) -> T,
-) -> T {
-    ELEMENT_OPENER_COMMENTS.with(|comments| f(&comments.borrow()))
-}
-
-#[cfg(test)]
-pub(super) fn record_element_opener_comment_range_visits(count: usize) {
-    ELEMENT_OPENER_COMMENT_RANGE_VISITS.with(|visits| visits.set(visits.get() + count));
-}
-
-#[cfg(test)]
-pub(super) fn reset_element_opener_comment_range_visits() {
-    ELEMENT_OPENER_COMMENT_RANGE_VISITS.with(|visits| visits.set(0));
-}
-
-#[cfg(test)]
-pub(super) fn element_opener_comment_range_visits() -> usize {
-    ELEMENT_OPENER_COMMENT_RANGE_VISITS.with(std::cell::Cell::get)
+    #[cfg(test)]
+    pub(super) fn range_visits(&self) -> usize {
+        self.range_visits.get()
+    }
 }

--- a/crates/rsvelte_projection/src/svelte2tsx/template/mod.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/template/mod.rs
@@ -23,7 +23,6 @@ use super::nodes::runes_detection::TemplateRunesDetector;
 use super::svelte2tsx::Svelte2TsxOptions;
 use ctx::Counter;
 
-pub(crate) use ctx::{clear_element_opener_comments, set_element_opener_comments};
 use walk::process_fragment_inplace;
 
 // =============================================================================
@@ -91,8 +90,9 @@ pub fn process_template_inplace(
     source: &str,
     _options: &Svelte2TsxOptions,
     str: &mut MagicString<'_>,
+    element_opener_comments: impl IntoIterator<Item = (u32, u32)>,
 ) {
-    let mut counter = Counter::new();
+    let mut counter = Counter::new(element_opener_comments);
     // depth 0 = root fragment; elements and components increment it for their children
     process_fragment_inplace(fragment, source, _options, str, &mut counter, 0);
 
@@ -233,7 +233,7 @@ mod tests {
         let fragment = Fragment::default();
         let options = Svelte2TsxOptions::default();
         let mut str = MagicString::new("");
-        process_template_inplace(&fragment, "", &options, &mut str);
+        process_template_inplace(&fragment, "", &options, &mut str, []);
         assert_eq!(str.to_string(), "");
     }
 

--- a/crates/rsvelte_projection/src/svelte2tsx/template/nodes/comment.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/template/nodes/comment.rs
@@ -2,10 +2,7 @@
 
 use crate::ast::template::Comment;
 use crate::svelte2tsx::magic_string::MagicString;
-
-#[cfg(test)]
-use crate::svelte2tsx::template::ctx::record_element_opener_comment_range_visits;
-use crate::svelte2tsx::template::ctx::with_element_opener_comments;
+use crate::svelte2tsx::template::ctx::ElementOpenerCommentIndex;
 
 /// Handle an HTML comment node.
 ///
@@ -19,35 +16,32 @@ pub(crate) fn handle_comment(comment: &Comment, str: &mut MagicString<'_>) {
 
 /// Comments (from the per-compile set) whose source range lies fully within
 /// `[start, end)`, sorted by start. Used to preserve `{/* c */ expr}` comments.
-pub(crate) fn comments_in_opener_range(start: u32, end: u32) -> Vec<(u32, u32)> {
+pub(crate) fn comments_in_opener_range(
+    comments: &ElementOpenerCommentIndex,
+    start: u32,
+    end: u32,
+) -> &[(u32, u32)] {
     if start >= end {
-        return Vec::new();
+        return &[];
     }
-    with_element_opener_comments(|comments| {
-        let contained = comments.contained_in(start, end);
-        #[cfg(test)]
-        record_element_opener_comment_range_visits(contained.len());
-        contained.to_vec()
-    })
+    let contained = comments.contained_in(start, end);
+    #[cfg(test)]
+    comments.record_range_visits(contained.len());
+    contained
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::svelte2tsx::template::ctx::{
-        clear_element_opener_comments, element_opener_comment_range_visits,
-        reset_element_opener_comment_range_visits, set_element_opener_comments,
-    };
 
     #[test]
     fn opener_range_query_is_sorted_and_excludes_boundary_crossing_comments() {
-        set_element_opener_comments(vec![(45, 49), (30, 42), (20, 25), (5, 9)]);
-        reset_element_opener_comment_range_visits();
+        let comments = ElementOpenerCommentIndex::new([(45, 49), (30, 42), (20, 25), (5, 9)]);
+        comments.reset_range_visits();
 
-        let actual = comments_in_opener_range(10, 40);
+        let actual = comments_in_opener_range(&comments, 10, 40);
 
-        assert_eq!(actual, vec![(20, 25)]);
-        assert_eq!(element_opener_comment_range_visits(), 1);
-        clear_element_opener_comments();
+        assert_eq!(actual, [(20, 25)]);
+        assert_eq!(comments.range_visits(), 1);
     }
 }

--- a/crates/rsvelte_projection/src/svelte2tsx/template/nodes/dynamic_element.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/template/nodes/dynamic_element.rs
@@ -79,7 +79,12 @@ pub(crate) fn handle_svelte_dynamic_element(
     let attrs_str = if named_slot.is_some() {
         build_named_slot_element_attrs(&el.attributes, source)
     } else {
-        build_attributes_string(&el.attributes, source, saved_slot.is_some())
+        build_attributes_string(
+            &el.attributes,
+            source,
+            &counter.element_opener_comments,
+            saved_slot.is_some(),
+        )
     };
 
     // `use:` / `transition:` / `animate:` directives, same V4 emission as on a

--- a/crates/rsvelte_projection/src/svelte2tsx/template/nodes/element.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/template/nodes/element.rs
@@ -111,6 +111,7 @@ pub(crate) fn handle_regular_element(
     let mut attr_segs = build_attribute_segments(
         &el.attributes,
         source,
+        &counter.element_opener_comments,
         &el.name,
         saved_slot.is_some(),
         Some(opener_content_start),
@@ -289,7 +290,12 @@ pub(crate) fn handle_title_element(
     }
 
     let opening_tag_end = find_opening_tag_end(source, el.start, el.end);
-    let attrs_str = build_attributes_string(&el.attributes, source, counter.slot_inst.is_some());
+    let attrs_str = build_attributes_string(
+        &el.attributes,
+        source,
+        &counter.element_opener_comments,
+        counter.slot_inst.is_some(),
+    );
 
     let opener = format!(
         " {{ svelteHTML.createElement(\"title\", {{{}}});",

--- a/crates/rsvelte_projection/src/svelte2tsx/template/nodes/inline_component.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/template/nodes/inline_component.rs
@@ -171,7 +171,12 @@ pub(crate) fn handle_component(
     // When this component is named-slot-routed (`named_slot_close`), its static
     // `slot="…"` attribute is consumed by the `$$slot_def[…]` wrapper, so drop it
     // from the props object; otherwise (root, or dynamic `slot={…}`) keep it.
-    let mut attr_segs = build_component_props_segments(&comp.attributes, source, named_slot_close);
+    let mut attr_segs = build_component_props_segments(
+        &comp.attributes,
+        source,
+        &counter.element_opener_comments,
+        named_slot_close,
+    );
 
     // Add extra whitespace to match JS svelte2tsx position-preserving behavior
     let attrs_empty_before_pad = segs_is_empty(&attr_segs);
@@ -482,7 +487,8 @@ pub(crate) fn handle_svelte_component(
     let has_events = !on_directives.is_empty();
 
     // Build attribute/props string (excluding on: directives)
-    let mut attrs_str = build_component_props_string(&comp.attributes, source);
+    let mut attrs_str =
+        build_component_props_string(&comp.attributes, source, &counter.element_opener_comments);
 
     // Add extra whitespace to match JS svelte2tsx position-preserving behavior
     if !comp.attributes.is_empty() && !attrs_str.is_empty() {

--- a/crates/rsvelte_projection/src/svelte2tsx/template/nodes/mustache_tag.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/template/nodes/mustache_tag.rs
@@ -4,13 +4,19 @@ use crate::ast::template::ExpressionTag;
 use crate::svelte2tsx::magic_string::MagicString;
 
 use super::comment::comments_in_opener_range;
+use crate::svelte2tsx::template::ctx::ElementOpenerCommentIndex;
 use crate::svelte2tsx::template::utils::expr::get_expression_range;
 
 /// Handle an expression tag: `{expression}`.
 ///
 /// Overwrites `{` with empty and `}` with `;` so the expression is preserved
 /// as a statement: `{count}` → `count;`
-pub(crate) fn handle_expression_tag(expr: &ExpressionTag, source: &str, str: &mut MagicString<'_>) {
+pub(crate) fn handle_expression_tag(
+    expr: &ExpressionTag,
+    source: &str,
+    str: &mut MagicString<'_>,
+    comments: &ElementOpenerCommentIndex,
+) {
     if expr.start >= expr.end {
         return;
     }
@@ -19,7 +25,7 @@ pub(crate) fn handle_expression_tag(expr: &ExpressionTag, source: &str, str: &mu
         // Leading: keep any `{/* c */ expr}` comments between the `{` and the
         // expression (official preserves them, stripping only the `{` and a
         // wrapping `(`). Strip from `{` up to the first such comment.
-        let lead_keep = comments_in_opener_range(expr.start, expr_start)
+        let lead_keep = comments_in_opener_range(comments, expr.start, expr_start)
             .first()
             .map(|&(cs, _)| cs)
             .unwrap_or(expr_start);
@@ -53,7 +59,8 @@ pub(crate) fn handle_expression_tag(expr: &ExpressionTag, source: &str, str: &mu
             // Trailing: keep any `{expr /* c */}` comments between the expression
             // and `}` (emit `;` right after the expression, strip a wrapping `)`
             // and the `}`).
-            let trailing = comments_in_opener_range(expr_end, close.saturating_sub(1) as u32);
+            let trailing =
+                comments_in_opener_range(comments, expr_end, close.saturating_sub(1) as u32);
             match (trailing.first(), trailing.last()) {
                 (Some(&(first_cs, _)), Some(&(_, last_ce))) => {
                     if expr_end < first_cs {

--- a/crates/rsvelte_projection/src/svelte2tsx/template/nodes/special_element.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/template/nodes/special_element.rs
@@ -46,8 +46,12 @@ pub(crate) fn handle_svelte_special_element(
     }
 
     let opening_tag_end = find_opening_tag_end(source, el.start, el.end);
-    let mut attrs_str =
-        build_attributes_string(&el.attributes, source, counter.slot_inst.is_some());
+    let mut attrs_str = build_attributes_string(
+        &el.attributes,
+        source,
+        &counter.element_opener_comments,
+        counter.slot_inst.is_some(),
+    );
 
     // Add extra whitespace to match JS svelte2tsx position-preserving behavior
     if !el.attributes.is_empty() && !attrs_str.is_empty() {

--- a/crates/rsvelte_projection/src/svelte2tsx/template/walk.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/template/walk.rs
@@ -56,7 +56,9 @@ pub(super) fn process_node_inplace(
     match node {
         TemplateNode::Text(text) => handle_text(text, source, str),
         TemplateNode::Comment(comment) => handle_comment(comment, str),
-        TemplateNode::ExpressionTag(expr) => handle_expression_tag(expr, source, str),
+        TemplateNode::ExpressionTag(expr) => {
+            handle_expression_tag(expr, source, str, &counter.element_opener_comments)
+        }
         TemplateNode::HtmlTag(html) => handle_html_tag(html, source, str),
         TemplateNode::ConstTag(tag) => handle_const_tag(tag, source, str),
         TemplateNode::DeclarationTag(tag) => handle_declaration_tag(tag, source, str),


### PR DESCRIPTION
> Stack 8/8  
> Base: `agent/svelte2tsx-release-07-magicstring-layout` (`a57c1944`)  
> Head: `agent/svelte2tsx-comprehensive-wave16` (`59a12069`)

## Summary

- thread the normalized element-opener comment index from the top-level
  svelte2tsx conversion through template processing
- share the index across attribute and node lowering
- preserve opener-comment ordering and whitespace behavior after all preceding
  template and MagicString changes

This is intentionally a one-commit integration layer. The earlier topic-branch
version predates intervening template and MagicString work; this accepted commit
contains the conflict-resolved final form.

## Commit scope

- `59a12069` Thread opener comment index through svelte2tsx

## Validation

- [ ] `cargo fmt --check`
- [ ] `cargo clippy --all-targets --all-features -- -D warnings`
- [ ] `cargo test -p rsvelte_projection --test svelte2tsx_entry`
- [ ] `cargo test -p rsvelte_projection --test svelte2tsx_multibyte_comment_boundary`
- [ ] `cargo test -p rsvelte_projection --test svelte2tsx_fixtures`
- [ ] `cargo test -p rsvelte_projection`
- [ ] `pnpm run compatibility-report`
- [ ] `pnpm run corpus:s2t:compile`
- [ ] `pnpm run corpus:s2t:verify`

## Stack order

Merge last, after PR 7 and the full final-stack parity gates pass.
