### PR TITLE
Compact MagicString ownership and chunk layout

### DIFF
--- a/crates/rsvelte_projection/src/svelte2tsx/add_component_export.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/add_component_export.rs
@@ -36,7 +36,7 @@ pub(crate) struct ComponentExportParams<'a> {
 /// export itself. The caller appends the returned string to `str`.
 pub(crate) fn add_component_export(
     params: ComponentExportParams<'_>,
-    str: &mut MagicString,
+    str: &mut MagicString<'_>,
 ) -> String {
     let ComponentExportParams {
         ast,

--- a/crates/rsvelte_projection/src/svelte2tsx/create_render_function.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/create_render_function.rs
@@ -28,7 +28,7 @@ pub(crate) fn create_render_function(
     source: &str,
     store_scan: &mut StoreScanContext<'_>,
     options: &Svelte2TsxOptions,
-    str: &mut MagicString,
+    str: &mut MagicString<'_>,
     dollar_decls: &str,
     has_instance_script: bool,
     has_module_script: bool,

--- a/crates/rsvelte_projection/src/svelte2tsx/magic_string.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/magic_string.rs
@@ -520,9 +520,9 @@ impl<'a> MappingState<'a> {
 
 /// A string manipulation class that preserves source positions for source-map
 /// generation.
-pub struct MagicString {
+pub struct MagicString<'source> {
     /// The original source string.
-    original: String,
+    original: &'source str,
     /// Arena of chunks (linked list stored in a Vec).
     chunks: Vec<Chunk>,
     /// Index of the first chunk in the linked list.
@@ -546,13 +546,13 @@ pub struct MagicString {
     outro: String,
 }
 
-impl MagicString {
+impl<'source> MagicString<'source> {
     // -----------------------------------------------------------------
     // Construction
     // -----------------------------------------------------------------
 
     /// Create a new `MagicString` from the given source.
-    pub fn new(source: &str) -> Self {
+    pub fn new(source: &'source str) -> Self {
         let chunk = Chunk::new(0, source.len() as u32);
         let mut by_start: std::collections::BTreeMap<u32, usize> =
             std::collections::BTreeMap::new();
@@ -561,7 +561,7 @@ impl MagicString {
         by_end.insert(source.len() as u32, 0);
 
         Self {
-            original: source.to_string(),
+            original: source,
             chunks: vec![chunk],
             first_chunk: 0,
             last_chunk: 0,
@@ -1003,7 +1003,7 @@ impl MagicString {
             file: options.file,
             sources: vec![source_name.clone()],
             sources_content: if options.include_content {
-                vec![self.original.clone()]
+                vec![self.original.to_string()]
             } else {
                 vec![]
             },
@@ -1042,7 +1042,7 @@ impl MagicString {
             &mut source_map,
             file.as_deref(),
             &source,
-            include_content.then_some(self.original.as_str()),
+            include_content.then_some(self.original),
         );
 
         let mut code = String::with_capacity(code_capacity);
@@ -1104,7 +1104,7 @@ impl MagicString {
         mappings: Option<&mut String>,
         mut forward_segments: Option<&mut Vec<(u32, u32, u32)>>,
     ) {
-        let mut mapping = mappings.map(|mappings| MappingState::new(mappings, &self.original));
+        let mut mapping = mappings.map(|mappings| MappingState::new(mappings, self.original));
         if let Some(code) = &mut code {
             code.push_str(&self.intro);
         }
@@ -1125,7 +1125,7 @@ impl MagicString {
             }
             if let Some(mapping) = &mut mapping {
                 mapping.advance_unmapped(&chunk.intro);
-                mapping.advance_chunk_body(&self.original, chunk, body);
+                mapping.advance_chunk_body(self.original, chunk, body);
                 mapping.advance_unmapped(&chunk.outro);
             }
             if let Some(segments) = &mut forward_segments {
@@ -1148,7 +1148,7 @@ impl MagicString {
     }
 }
 
-impl fmt::Display for MagicString {
+impl fmt::Display for MagicString<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.to_string())
     }
@@ -1221,6 +1221,15 @@ mod tests {
     fn test_basic_to_string() {
         let s = MagicString::new("hello world");
         assert_eq!(s.to_string(), "hello world");
+    }
+
+    #[test]
+    fn borrows_original_source() {
+        let source = String::from("hello world");
+        let s = MagicString::new(&source);
+
+        assert_eq!(s.original.as_ptr(), source.as_ptr());
+        assert_eq!(s.original.len(), source.len());
     }
 
     #[test]
@@ -1481,6 +1490,31 @@ mod tests {
         assert_eq!(map.sources, vec!["input.js".to_string()]);
         assert_eq!(map.sources_content, vec!["hello world".to_string()]);
         assert!(!map.mappings.is_empty());
+    }
+
+    #[test]
+    fn generated_output_and_map_content_outlive_the_source() {
+        let (output, map) = {
+            let source = String::from("hello world");
+            let mut s = MagicString::new(&source);
+            s.overwrite(6, 11, "earth");
+
+            (
+                s.to_string(),
+                s.generate_map(GenerateMapOptions {
+                    file: None,
+                    source: Some("input.svelte".to_string()),
+                    include_content: true,
+                }),
+            )
+        };
+
+        assert_eq!(output, "hello earth");
+        assert_eq!(map.sources_content, vec!["hello world".to_string()]);
+        assert!(
+            map.to_json()
+                .contains("\"sourcesContent\":[\"hello world\"]")
+        );
     }
 
     #[test]

--- a/crates/rsvelte_projection/src/svelte2tsx/magic_string.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/magic_string.rs
@@ -35,12 +35,17 @@ impl ChunkId {
 }
 
 /// A segment of the original string that may have been edited.
+#[repr(C)]
 #[derive(Debug, Clone)]
 struct Chunk {
     /// Original start position in the source (inclusive).
     start: u32,
     /// Original end position in the source (exclusive).
     end: u32,
+    /// Index of the next chunk in the arena (linked-list next pointer).
+    next: Option<ChunkId>,
+    /// Index of the previous chunk in the arena (linked-list prev pointer).
+    previous: Option<ChunkId>,
     /// Replacement content when the chunk has been edited. `None` means
     /// unedited — the effective content is `master_source[start..end]`
     /// and no copy is stored. The previous implementation kept two extra
@@ -51,22 +56,24 @@ struct Chunk {
     intro: String,
     /// Content appended after this chunk (via `append_right` / `prepend_left` on next).
     outro: String,
-    /// Index of the next chunk in the arena (linked-list next pointer).
-    next: Option<ChunkId>,
-    /// Index of the previous chunk in the arena (linked-list prev pointer).
-    previous: Option<ChunkId>,
 }
+
+#[cfg(target_pointer_width = "64")]
+const _: () = assert!(std::mem::size_of::<Chunk>() == 88);
+#[cfg(target_pointer_width = "32")]
+const _: () = assert!(std::mem::size_of::<Chunk>() == 52);
+const _: () = assert!(std::mem::size_of::<Option<ChunkId>>() == 4);
 
 impl Chunk {
     fn new(start: u32, end: u32) -> Self {
         Self {
             start,
             end,
+            next: None,
+            previous: None,
             content: None,
             intro: String::new(),
             outro: String::new(),
-            next: None,
-            previous: None,
         }
     }
 
@@ -109,11 +116,11 @@ impl Chunk {
         let new_chunk = Chunk {
             start: index,
             end: self.end,
+            next: self.next,
+            previous: None, // caller sets this
             content: content_after,
             intro: String::new(),
             outro: std::mem::take(&mut self.outro),
-            next: self.next,
-            previous: None, // caller sets this
         };
 
         self.end = index;
@@ -648,9 +655,9 @@ pub struct MagicString<'source> {
     /// Arena of chunks (linked list stored in a Vec).
     chunks: Vec<Chunk>,
     /// Index of the first chunk in the linked list.
-    first_chunk: usize,
+    first_chunk: ChunkId,
     /// Index of the last chunk in the linked list.
-    last_chunk: usize,
+    last_chunk: ChunkId,
     /// Original-source chunk starts, ordered by position.
     by_start: ChunkStarts,
     /// Content prepended before everything.
@@ -665,6 +672,9 @@ struct ChunkBoundary {
     right: Option<usize>,
 }
 
+#[cfg(target_pointer_width = "64")]
+const _: () = assert!(std::mem::size_of::<MagicString<'_>>() == 128);
+
 impl<'source> MagicString<'source> {
     // -----------------------------------------------------------------
     // Construction
@@ -677,8 +687,8 @@ impl<'source> MagicString<'source> {
         Self {
             original: source,
             chunks: vec![chunk],
-            first_chunk: 0,
-            last_chunk: 0,
+            first_chunk: ChunkId::from_index(0),
+            last_chunk: ChunkId::from_index(0),
             by_start: ChunkStarts::new(),
             intro: String::new(),
             outro: String::new(),
@@ -778,8 +788,8 @@ impl<'source> MagicString<'source> {
         if let Some(old_next_idx) = old_next {
             self.chunks[old_next_idx].previous = Some(new_id);
         }
-        if self.last_chunk == cur {
-            self.last_chunk = new_idx;
+        if self.last_chunk.index() == cur {
+            self.last_chunk = new_id;
         }
 
         let new_idx_u32 = u32::try_from(new_idx).expect("MagicString chunk index exceeds u32");
@@ -1021,30 +1031,30 @@ impl<'source> MagicString<'source> {
         self.link(before_range, after_range);
 
         // Update first/last chunk pointers if needed.
-        if self.first_chunk == first_in_range
+        if self.first_chunk.index() == first_in_range
             && let Some(ar) = after_range
         {
-            self.first_chunk = ar;
+            self.first_chunk = ChunkId::from_index(ar);
         }
-        if self.last_chunk == last_in_range
+        if self.last_chunk.index() == last_in_range
             && let Some(br) = before_range
         {
-            self.last_chunk = br;
+            self.last_chunk = ChunkId::from_index(br);
         }
 
         // Insert at the target position.
         if index == 0 {
             // Insert before the current first chunk.
-            let old_first = self.first_chunk;
+            let old_first = self.first_chunk.index();
             self.link(Some(last_in_range), Some(old_first));
             self.chunks[first_in_range].previous = None;
-            self.first_chunk = first_in_range;
+            self.first_chunk = ChunkId::from_index(first_in_range);
         } else if index == self.original.len() as u32 {
             // Insert after the current last chunk.
-            let old_last = self.last_chunk;
+            let old_last = self.last_chunk.index();
             self.link(Some(old_last), Some(first_in_range));
             self.chunks[last_in_range].next = None;
-            self.last_chunk = last_in_range;
+            self.last_chunk = ChunkId::from_index(last_in_range);
         } else {
             // Insert before the chunk that starts at `index`.
             let target = target_boundary
@@ -1053,8 +1063,8 @@ impl<'source> MagicString<'source> {
             let before_target = self.chunks[target].previous_index();
             self.link(before_target, Some(first_in_range));
             self.link(Some(last_in_range), Some(target));
-            if self.first_chunk == target && before_range.is_none() {
-                self.first_chunk = first_in_range;
+            if self.first_chunk.index() == target && before_range.is_none() {
+                self.first_chunk = ChunkId::from_index(first_in_range);
             }
         }
 
@@ -1174,7 +1184,7 @@ impl<'source> MagicString<'source> {
         let mut estimate = OutputEstimate::default();
         estimate.add_unmapped(&self.intro);
 
-        let mut cur = Some(self.first_chunk);
+        let mut cur = Some(self.first_chunk.index());
         while let Some(chunk_index) = cur {
             let chunk = &self.chunks[chunk_index];
             let body = self.chunk_content(chunk_index);
@@ -1218,7 +1228,7 @@ impl<'source> MagicString<'source> {
         }
 
         let mut generated_bytes = self.intro.len() as u32;
-        let mut cur = Some(self.first_chunk);
+        let mut cur = Some(self.first_chunk.index());
         while let Some(ci) = cur {
             let chunk = &self.chunks[ci];
             let body = self.chunk_content(ci);
@@ -1294,13 +1304,23 @@ fn checked_source_len(len: usize) -> u32 {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::mem::size_of;
+    use std::mem::{align_of, offset_of, size_of};
+
+    type PreviousChunkLayout = (
+        u32,
+        u32,
+        Option<String>,
+        String,
+        String,
+        Option<usize>,
+        Option<usize>,
+    );
 
     fn assert_bidirectional_links(s: &MagicString) {
         let mut forward = Vec::with_capacity(s.chunks.len());
         let mut visited = vec![false; s.chunks.len()];
         let mut expected_previous = None;
-        let mut current = Some(s.first_chunk);
+        let mut current = Some(s.first_chunk.index());
 
         while let Some(index) = current {
             assert!(!visited[index], "cycle at chunk {index}");
@@ -1313,11 +1333,11 @@ mod tests {
         }
 
         assert_eq!(forward.len(), s.chunks.len());
-        assert_eq!(forward.last().copied(), Some(s.last_chunk));
+        assert_eq!(forward.last().copied(), Some(s.last_chunk.index()));
 
         let mut backward = Vec::with_capacity(s.chunks.len());
         let mut expected_next = None;
-        current = Some(s.last_chunk);
+        current = Some(s.last_chunk.index());
         while let Some(index) = current {
             let chunk = &s.chunks[index];
             assert_eq!(chunk.next_index(), expected_next);
@@ -1330,17 +1350,31 @@ mod tests {
     }
 
     #[test]
-    fn chunk_links_have_compact_layout() {
+    fn chunk_layout_compacts_links_and_groups_hot_fields() {
         assert_eq!(size_of::<ChunkId>(), 4);
         assert_eq!(size_of::<Option<ChunkId>>(), 4);
-        assert_eq!(size_of::<[Option<ChunkId>; 2]>(), 8);
+        assert_eq!(offset_of!(Chunk, start), 0);
+        assert_eq!(offset_of!(Chunk, end), 4);
+        assert_eq!(offset_of!(Chunk, next), 8);
+        assert_eq!(offset_of!(Chunk, previous), 12);
+        assert_eq!(offset_of!(Chunk, content), 16);
 
         #[cfg(target_pointer_width = "64")]
-        assert_eq!(size_of::<Chunk>(), 88);
+        {
+            assert_eq!(size_of::<String>(), 24);
+            assert_eq!(size_of::<Option<String>>(), 24);
+            assert_eq!(size_of::<Option<usize>>(), 16);
+            assert_eq!(size_of::<PreviousChunkLayout>(), 112);
+            assert_eq!(size_of::<Chunk>(), 88);
+            assert_eq!(align_of::<Chunk>(), 8);
+            assert_eq!(size_of::<std::collections::BTreeMap<u32, u32>>(), 24);
+            assert_eq!(size_of::<ChunkStarts>(), 32);
+            assert_eq!(size_of::<MagicString<'_>>(), 128);
+        }
     }
 
     #[test]
-    fn chunk_id_round_trips_all_representable_indices() {
+    fn chunk_id_round_trips_representable_indices() {
         assert_eq!(ChunkId::from_index(0).index(), 0);
         let last_index = u32::MAX as usize - 1;
         assert_eq!(ChunkId::from_index(last_index).index(), last_index);
@@ -1734,6 +1768,54 @@ mod tests {
         let output = s.to_string();
         assert_eq!(output.matches('_').count(), DENSE_CHUNK_START_LIMIT);
         assert_eq!(output.matches('!').count(), 1);
+    }
+
+    #[test]
+    fn compact_links_preserve_split_move_and_overwrite_traversal() {
+        let mut s = MagicString::new("abcdefghijkl");
+        s.append_left(3, "|");
+        s.prepend_right(6, "!");
+        s.move_range(6, 9, 0);
+        assert_eq!(s.to_string(), "!ghiabc|defjkl");
+        assert_bidirectional_links(&s);
+
+        s.overwrite(0, 6, "X");
+        assert_eq!(s.to_string(), "!ghiXjkl");
+        assert_eq!(s.forward_segments(), vec![(6, 9, 1), (9, 12, 5)]);
+        assert!(
+            !s.generate_map(GenerateMapOptions::default())
+                .mappings
+                .is_empty()
+        );
+        assert_bidirectional_links(&s);
+    }
+
+    #[cfg(target_pointer_width = "64")]
+    #[test]
+    fn compact_links_reduce_a_1024_chunk_arena_by_24_kib() {
+        const CHUNK_COUNT: usize = 1024;
+        let source = "x".repeat(CHUNK_COUNT);
+        let mut s = MagicString::new(&source);
+        for index in (1..CHUNK_COUNT).rev() {
+            s.append_right(index as u32, "_");
+        }
+
+        assert_eq!(s.chunks.len(), CHUNK_COUNT);
+        let ChunkStarts::Tree(entries) = &s.by_start else {
+            panic!("the reverse-split workload must promote the start index");
+        };
+        assert_eq!(entries.len(), CHUNK_COUNT);
+        assert!(
+            entries
+                .iter()
+                .all(|(&position, &chunk)| s.chunks[chunk as usize].start == position)
+        );
+        let output = s.to_string();
+        assert_eq!(output.len(), CHUNK_COUNT * 2 - 1);
+        assert_eq!(output.matches('_').count(), CHUNK_COUNT - 1);
+        assert_bidirectional_links(&s);
+        assert_eq!(CHUNK_COUNT * size_of::<PreviousChunkLayout>(), 114_688);
+        assert_eq!(CHUNK_COUNT * size_of::<Chunk>(), 90_112);
     }
 
     #[test]

--- a/crates/rsvelte_projection/src/svelte2tsx/magic_string.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/magic_string.rs
@@ -9,9 +9,6 @@ use std::fmt;
 use std::fmt::Write as _;
 use std::num::NonZeroU32;
 
-use rustc_hash::FxHashMap;
-type HashMap<K, V> = FxHashMap<K, V>;
-
 // ---------------------------------------------------------------------------
 // Chunk
 // ---------------------------------------------------------------------------
@@ -570,12 +567,16 @@ pub struct MagicString<'source> {
     /// start is kept here and entries are never removed, so the greatest start
     /// `<= index` is always the chunk that contains `index`.
     by_start: std::collections::BTreeMap<u32, usize>,
-    /// Map from original-source position → chunk index that *ends* at that position.
-    by_end: HashMap<u32, usize>,
     /// Content prepended before everything.
     intro: String,
     /// Content appended after everything.
     outro: String,
+}
+
+#[derive(Clone, Copy, Default)]
+struct ChunkBoundary {
+    left: Option<usize>,
+    right: Option<usize>,
 }
 
 impl<'source> MagicString<'source> {
@@ -589,9 +590,7 @@ impl<'source> MagicString<'source> {
         let chunk = Chunk::new(0, source_len);
         let mut by_start: std::collections::BTreeMap<u32, usize> =
             std::collections::BTreeMap::new();
-        let mut by_end: HashMap<u32, usize> = HashMap::default();
         by_start.insert(0, 0);
-        by_end.insert(source_len, 0);
 
         Self {
             original: source,
@@ -599,7 +598,6 @@ impl<'source> MagicString<'source> {
             first_chunk: 0,
             last_chunk: 0,
             by_start,
-            by_end,
             intro: String::new(),
             outro: String::new(),
         }
@@ -622,47 +620,28 @@ impl<'source> MagicString<'source> {
     // -----------------------------------------------------------------
 
     /// Ensure there is a chunk boundary at the given original position.
-    /// Returns the index of the chunk that *starts* at `index`.
-    ///
-    /// When `index` equals the source length, there is no chunk starting there.
-    /// In that case we return `usize::MAX` as a sentinel — callers that need
-    /// a real start-chunk (like `overwrite`) should not use this value, but
-    /// callers that only need the split side-effect (ensuring `by_end` has an
-    /// entry) are fine.
+    /// Returns the chunks immediately before and after that boundary in
+    /// original-source order.
     ///
     /// If `index` falls outside `[0, original.len()]` we treat it as the
-    /// "nothing to split" sentinel (`usize::MAX`) instead of panicking. This
+    /// "nothing to split" sentinel instead of panicking. This
     /// keeps a misbehaving upstream (e.g. an AST with stale positions) from
     /// crashing the entire compiler in release builds. Debug builds print a
     /// diagnostic so the upstream bug is still surfaced during development.
-    fn split_at(&mut self, index: u32) -> usize {
-        if let Some(&chunk_idx) = self.by_start.get(&index) {
-            return chunk_idx;
-        }
-
-        // If index is at the very end of the source, there is nothing to split.
-        // The last chunk already ends at this position.
-        if index as usize >= self.original.len() {
+    fn split_at(&mut self, index: u32) -> ChunkBoundary {
+        if index as usize > self.original.len() {
             #[cfg(debug_assertions)]
-            if index as usize > self.original.len() {
-                eprintln!(
-                    "split_at({}): position out of range [0, {})",
-                    index,
-                    self.original.len()
-                );
-            }
-            return usize::MAX;
+            eprintln!(
+                "split_at({}): position out of range [0, {})",
+                index,
+                self.original.len()
+            );
+            return ChunkBoundary::default();
         }
 
-        // Find the chunk containing `index` via the sorted start index in
-        // O(log n). `by_start` holds every chunk's start and chunks partition
-        // the source contiguously, so the greatest start `<= index` is the
-        // chunk that contains `index`. (The `by_start.get(&index)` fast-path
-        // above already handled the case where `index` is itself a boundary,
-        // so here `start < index`.) This replaces an O(n) walk from the head
-        // that made repeated splits O(n²).
-        let cur = match self.by_start.range(..=index).next_back() {
-            Some((_, &chunk_idx)) => chunk_idx,
+        let mut starts = self.by_start.range(..=index);
+        let (start, cur) = match starts.next_back() {
+            Some((&start, &chunk_idx)) => (start, chunk_idx),
             None => {
                 #[cfg(debug_assertions)]
                 eprintln!(
@@ -670,12 +649,25 @@ impl<'source> MagicString<'source> {
                     index,
                     self.original.len()
                 );
-                return usize::MAX;
+                return ChunkBoundary::default();
             }
         };
-        // Defensive: confirm `index` really falls strictly inside `cur`. With a
-        // well-formed chunk list this always holds; if not, fall back to the
-        // sentinel rather than producing a corrupt split.
+
+        if start == index {
+            return ChunkBoundary {
+                left: starts.next_back().map(|(_, &chunk_idx)| chunk_idx),
+                right: Some(cur),
+            };
+        }
+
+        // The source-end boundary has no chunk on its right.
+        if index as usize == self.original.len() {
+            return ChunkBoundary {
+                left: Some(cur),
+                right: None,
+            };
+        }
+
         {
             let chunk = &self.chunks[cur];
             if !(index > chunk.start && index < chunk.end) {
@@ -684,7 +676,7 @@ impl<'source> MagicString<'source> {
                     "split_at({}): located chunk [{}, {}) does not strictly contain index",
                     index, chunk.start, chunk.end
                 );
-                return usize::MAX;
+                return ChunkBoundary::default();
             }
         }
 
@@ -705,15 +697,12 @@ impl<'source> MagicString<'source> {
             self.last_chunk = new_idx;
         }
 
-        // Update indices.
         self.by_start.insert(index, new_idx);
-        self.by_end.insert(index, cur);
-        // The end of the new chunk is the old end – already in by_end pointing to cur,
-        // but it should now point to new_idx.
-        let new_end = self.chunks[new_idx].end;
-        self.by_end.insert(new_end, new_idx);
 
-        new_idx
+        ChunkBoundary {
+            left: Some(cur),
+            right: Some(new_idx),
+        }
     }
 
     /// Internal: link chunk `a` → `b` in the linked list.
@@ -745,13 +734,10 @@ impl<'source> MagicString<'source> {
         );
 
         // Ensure chunk boundaries at start and end.
-        self.split_at(start);
+        let start_boundary = self.split_at(start);
         self.split_at(end);
 
-        let first = *self
-            .by_start
-            .get(&start)
-            .expect("overwrite: no chunk at start");
+        let first = start_boundary.right.expect("overwrite: no chunk at start");
 
         // Set the content of the first chunk and blank out subsequent ones.
         self.chunks[first].content = Some(content.to_string());
@@ -794,21 +780,21 @@ impl<'source> MagicString<'source> {
             self.original.len()
         );
 
-        self.split_at(start);
+        let start_boundary = self.split_at(start);
         self.split_at(end);
 
         // Walk by original position (see comment in `overwrite`) so chunks
         // relocated via `move_range` aren't incorrectly cleared.
-        let mut cur_start = start;
-        while cur_start < end {
-            let ci = match self.by_start.get(&cur_start) {
-                Some(&i) => i,
-                None => break,
-            };
+        let mut current = start_boundary.right;
+        while let Some(ci) = current {
             self.chunks[ci].content = Some(String::new());
             self.chunks[ci].intro.clear();
             self.chunks[ci].outro.clear();
-            cur_start = self.chunks[ci].end;
+            let cur_start = self.chunks[ci].end;
+            if cur_start >= end {
+                break;
+            }
+            current = self.by_start.get(&cur_start).copied();
         }
 
         self
@@ -851,10 +837,9 @@ impl<'source> MagicString<'source> {
             return self;
         }
 
-        self.split_at(index);
-        let chunk_idx = *self
-            .by_end
-            .get(&index)
+        let chunk_idx = self
+            .split_at(index)
+            .left
             .expect("append_left: no chunk ending at index");
         self.chunks[chunk_idx].outro.push_str(content);
         self
@@ -877,10 +862,9 @@ impl<'source> MagicString<'source> {
             return self;
         }
 
-        self.split_at(index);
-        let chunk_idx = *self
-            .by_start
-            .get(&index)
+        let chunk_idx = self
+            .split_at(index)
+            .right
             .expect("prepend_right: no chunk at index");
         self.chunks[chunk_idx].intro.insert_str(0, content);
         self
@@ -900,10 +884,9 @@ impl<'source> MagicString<'source> {
             return self;
         }
 
-        self.split_at(index);
-        let chunk_idx = *self
-            .by_end
-            .get(&index)
+        let chunk_idx = self
+            .split_at(index)
+            .left
             .expect("prepend_left: no chunk ending at index");
         self.chunks[chunk_idx].outro.insert_str(0, content);
         self
@@ -922,10 +905,9 @@ impl<'source> MagicString<'source> {
             return self;
         }
 
-        self.split_at(index);
-        let chunk_idx = *self
-            .by_start
-            .get(&index)
+        let chunk_idx = self
+            .split_at(index)
+            .right
             .expect("append_right: no chunk at index");
         self.chunks[chunk_idx].intro.push_str(content);
         self
@@ -939,17 +921,12 @@ impl<'source> MagicString<'source> {
             "move_range: cannot move a range into itself"
         );
 
-        self.split_at(start);
-        self.split_at(end);
-        if index != 0 && index != self.original.len() as u32 {
-            self.split_at(index);
-        }
+        let start_boundary = self.split_at(start);
+        let end_boundary = self.split_at(end);
+        let target_boundary = self.split_at(index);
 
-        let first_in_range = *self
-            .by_start
-            .get(&start)
-            .expect("move_range: no chunk at start");
-        let last_in_range = *self.by_end.get(&end).expect("move_range: no chunk at end");
+        let first_in_range = start_boundary.right.expect("move_range: no chunk at start");
+        let last_in_range = end_boundary.left.expect("move_range: no chunk at end");
 
         let before_range = self.chunks[first_in_range].previous_index();
         let after_range = self.chunks[last_in_range].next_index();
@@ -984,9 +961,8 @@ impl<'source> MagicString<'source> {
             self.last_chunk = last_in_range;
         } else {
             // Insert before the chunk that starts at `index`.
-            let target = *self
-                .by_start
-                .get(&index)
+            let target = target_boundary
+                .right
                 .expect("move_range: no chunk at target index");
             let before_target = self.chunks[target].previous_index();
             self.link(before_target, Some(first_in_range));
@@ -1619,6 +1595,22 @@ mod tests {
                 .is_empty()
         );
         assert_bidirectional_links(&s);
+    }
+
+    #[test]
+    fn repeated_boundary_edits_keep_original_sides_after_move() {
+        let mut s = MagicString::new("abcdef");
+        s.move_range(2, 4, 6);
+        assert_eq!(s.to_string(), "abefcd");
+
+        s.append_left(2, "L");
+        s.append_left(2, "R");
+        s.prepend_left(2, "X");
+        s.prepend_right(2, "P");
+        s.prepend_right(2, "Q");
+        s.append_right(2, "A");
+
+        assert_eq!(s.to_string(), "abXLRefQPAcd");
     }
 
     #[test]

--- a/crates/rsvelte_projection/src/svelte2tsx/magic_string.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/magic_string.rs
@@ -7,6 +7,7 @@
 
 use std::fmt;
 use std::fmt::Write as _;
+use std::num::NonZeroU32;
 
 use rustc_hash::FxHashMap;
 type HashMap<K, V> = FxHashMap<K, V>;
@@ -14,6 +15,27 @@ type HashMap<K, V> = FxHashMap<K, V>;
 // ---------------------------------------------------------------------------
 // Chunk
 // ---------------------------------------------------------------------------
+
+/// A 1-based arena index so `Option<ChunkId>` uses `NonZeroU32`'s null niche.
+#[repr(transparent)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct ChunkId(NonZeroU32);
+
+impl ChunkId {
+    fn from_index(index: usize) -> Self {
+        let one_based = index
+            .checked_add(1)
+            .and_then(|value| u32::try_from(value).ok())
+            .and_then(NonZeroU32::new)
+            .expect("MagicString chunk count exceeds u32::MAX");
+        Self(one_based)
+    }
+
+    #[inline]
+    fn index(self) -> usize {
+        (self.0.get() - 1) as usize
+    }
+}
 
 /// A segment of the original string that may have been edited.
 #[derive(Debug, Clone)]
@@ -33,9 +55,9 @@ struct Chunk {
     /// Content appended after this chunk (via `append_right` / `prepend_left` on next).
     outro: String,
     /// Index of the next chunk in the arena (linked-list next pointer).
-    next: Option<usize>,
+    next: Option<ChunkId>,
     /// Index of the previous chunk in the arena (linked-list prev pointer).
-    previous: Option<usize>,
+    previous: Option<ChunkId>,
 }
 
 impl Chunk {
@@ -54,6 +76,16 @@ impl Chunk {
     #[inline]
     fn is_edited(&self) -> bool {
         self.content.is_some()
+    }
+
+    #[inline]
+    fn next_index(&self) -> Option<usize> {
+        self.next.map(ChunkId::index)
+    }
+
+    #[inline]
+    fn previous_index(&self) -> Option<usize> {
+        self.previous.map(ChunkId::index)
     }
 
     /// Split this chunk at `index` (an original-source position). Returns the new
@@ -553,12 +585,13 @@ impl<'source> MagicString<'source> {
 
     /// Create a new `MagicString` from the given source.
     pub fn new(source: &'source str) -> Self {
-        let chunk = Chunk::new(0, source.len() as u32);
+        let source_len = checked_source_len(source.len());
+        let chunk = Chunk::new(0, source_len);
         let mut by_start: std::collections::BTreeMap<u32, usize> =
             std::collections::BTreeMap::new();
         let mut by_end: HashMap<u32, usize> = HashMap::default();
         by_start.insert(0, 0);
-        by_end.insert(source.len() as u32, 0);
+        by_end.insert(source_len, 0);
 
         Self {
             original: source,
@@ -656,17 +689,17 @@ impl<'source> MagicString<'source> {
         }
 
         // `cur` is the chunk that contains `index` strictly inside it.
-        let old_next = self.chunks[cur].next;
+        let old_next = self.chunks[cur].next_index();
         let mut new_chunk = self.chunks[cur].split(index);
-        new_chunk.previous = Some(cur);
-        new_chunk.next = old_next;
 
         let new_idx = self.chunks.len();
+        let new_id = ChunkId::from_index(new_idx);
+        new_chunk.previous = Some(ChunkId::from_index(cur));
         self.chunks.push(new_chunk);
 
-        self.chunks[cur].next = Some(new_idx);
+        self.chunks[cur].next = Some(new_id);
         if let Some(old_next_idx) = old_next {
-            self.chunks[old_next_idx].previous = Some(new_idx);
+            self.chunks[old_next_idx].previous = Some(new_id);
         }
         if self.last_chunk == cur {
             self.last_chunk = new_idx;
@@ -686,10 +719,10 @@ impl<'source> MagicString<'source> {
     /// Internal: link chunk `a` → `b` in the linked list.
     fn link(&mut self, a: Option<usize>, b: Option<usize>) {
         if let Some(ai) = a {
-            self.chunks[ai].next = b;
+            self.chunks[ai].next = b.map(ChunkId::from_index);
         }
         if let Some(bi) = b {
-            self.chunks[bi].previous = a;
+            self.chunks[bi].previous = a.map(ChunkId::from_index);
         }
     }
 
@@ -908,8 +941,8 @@ impl<'source> MagicString<'source> {
             .expect("move_range: no chunk at start");
         let last_in_range = *self.by_end.get(&end).expect("move_range: no chunk at end");
 
-        let before_range = self.chunks[first_in_range].previous;
-        let after_range = self.chunks[last_in_range].next;
+        let before_range = self.chunks[first_in_range].previous_index();
+        let after_range = self.chunks[last_in_range].next_index();
 
         // Detach the range from its current position.
         self.link(before_range, after_range);
@@ -945,7 +978,7 @@ impl<'source> MagicString<'source> {
                 .by_start
                 .get(&index)
                 .expect("move_range: no chunk at target index");
-            let before_target = self.chunks[target].previous;
+            let before_target = self.chunks[target].previous_index();
             self.link(before_target, Some(first_in_range));
             self.link(Some(last_in_range), Some(target));
             if self.first_chunk == target && before_range.is_none() {
@@ -1079,7 +1112,7 @@ impl<'source> MagicString<'source> {
             if !chunk.is_edited() && chunk.end > chunk.start {
                 estimate.forward_segments = estimate.forward_segments.saturating_add(1);
             }
-            cur = chunk.next;
+            cur = chunk.next_index();
         }
 
         estimate.add_unmapped(&self.outro);
@@ -1136,7 +1169,7 @@ impl<'source> MagicString<'source> {
                 generated_bytes += body.len() as u32;
                 generated_bytes += chunk.outro.len() as u32;
             }
-            cur = chunk.next;
+            cur = chunk.next_index();
         }
 
         if let Some(code) = &mut code {
@@ -1178,6 +1211,10 @@ fn count_utf16(s: &str) -> usize {
     s.chars().map(|c| c.len_utf16()).sum()
 }
 
+fn checked_source_len(len: usize) -> u32 {
+    u32::try_from(len).expect("MagicString source length exceeds u32::MAX bytes")
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -1185,6 +1222,71 @@ fn count_utf16(s: &str) -> usize {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::mem::size_of;
+
+    fn assert_bidirectional_links(s: &MagicString) {
+        let mut forward = Vec::with_capacity(s.chunks.len());
+        let mut visited = vec![false; s.chunks.len()];
+        let mut expected_previous = None;
+        let mut current = Some(s.first_chunk);
+
+        while let Some(index) = current {
+            assert!(!visited[index], "cycle at chunk {index}");
+            visited[index] = true;
+            let chunk = &s.chunks[index];
+            assert_eq!(chunk.previous_index(), expected_previous);
+            forward.push(index);
+            expected_previous = Some(index);
+            current = chunk.next_index();
+        }
+
+        assert_eq!(forward.len(), s.chunks.len());
+        assert_eq!(forward.last().copied(), Some(s.last_chunk));
+
+        let mut backward = Vec::with_capacity(s.chunks.len());
+        let mut expected_next = None;
+        current = Some(s.last_chunk);
+        while let Some(index) = current {
+            let chunk = &s.chunks[index];
+            assert_eq!(chunk.next_index(), expected_next);
+            backward.push(index);
+            expected_next = Some(index);
+            current = chunk.previous_index();
+        }
+
+        assert_eq!(forward.iter().copied().rev().collect::<Vec<_>>(), backward);
+    }
+
+    #[test]
+    fn chunk_links_have_compact_layout() {
+        assert_eq!(size_of::<ChunkId>(), 4);
+        assert_eq!(size_of::<Option<ChunkId>>(), 4);
+        assert_eq!(size_of::<[Option<ChunkId>; 2]>(), 8);
+
+        #[cfg(target_pointer_width = "64")]
+        assert_eq!(size_of::<Chunk>(), 88);
+    }
+
+    #[test]
+    fn chunk_id_round_trips_all_representable_indices() {
+        assert_eq!(ChunkId::from_index(0).index(), 0);
+        let last_index = u32::MAX as usize - 1;
+        assert_eq!(ChunkId::from_index(last_index).index(), last_index);
+    }
+
+    #[cfg(target_pointer_width = "64")]
+    #[test]
+    #[should_panic(expected = "MagicString chunk count exceeds u32::MAX")]
+    fn chunk_id_rejects_an_unrepresentable_index() {
+        ChunkId::from_index(u32::MAX as usize);
+    }
+
+    #[cfg(target_pointer_width = "64")]
+    #[test]
+    #[should_panic(expected = "MagicString source length exceeds u32::MAX bytes")]
+    fn source_length_invariant_rejects_unrepresentable_positions() {
+        checked_source_len(u32::MAX as usize + 1);
+    }
 
     fn assert_bundle_matches_individual_outputs(value: &MagicString) {
         let options = [
@@ -1475,6 +1577,26 @@ mod tests {
         let mut s = MagicString::new("abcdefghij");
         s.move_range(0, 5, 10);
         assert_eq!(s.to_string(), "fghijabcde");
+    }
+
+    #[test]
+    fn split_move_overwrite_preserves_bidirectional_traversal() {
+        let mut s = MagicString::new("abcdefghijkl");
+        s.append_left(3, "|");
+        s.prepend_right(6, "!");
+        s.move_range(6, 9, 0);
+        assert_eq!(s.to_string(), "!ghiabc|defjkl");
+        assert_bidirectional_links(&s);
+
+        s.overwrite(0, 6, "X");
+        assert_eq!(s.to_string(), "!ghiXjkl");
+        assert_eq!(s.forward_segments(), vec![(6, 9, 1), (9, 12, 5)]);
+        assert!(
+            !s.generate_map(GenerateMapOptions::default())
+                .mappings
+                .is_empty()
+        );
+        assert_bidirectional_links(&s);
     }
 
     #[test]

--- a/crates/rsvelte_projection/src/svelte2tsx/magic_string.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/magic_string.rs
@@ -123,6 +123,99 @@ impl Chunk {
     }
 }
 
+#[derive(Debug, Clone, Copy)]
+struct ChunkStart {
+    position: u32,
+    chunk: u32,
+}
+
+// This caps reverse-order dense insertion at 256 KiB of total entry movement.
+const DENSE_CHUNK_START_LIMIT: usize = 256;
+
+enum ChunkStarts {
+    Dense(Vec<ChunkStart>),
+    Tree(std::collections::BTreeMap<u32, u32>),
+}
+
+enum ChunkStartLookup {
+    Boundary { left: Option<usize>, right: usize },
+    Inside(usize),
+    Missing,
+}
+
+impl ChunkStarts {
+    fn new() -> Self {
+        Self::Dense(vec![ChunkStart {
+            position: 0,
+            chunk: 0,
+        }])
+    }
+
+    fn get(&self, position: u32) -> Option<usize> {
+        match self {
+            Self::Dense(entries) => entries
+                .binary_search_by_key(&position, |entry| entry.position)
+                .ok()
+                .map(|slot| entries[slot].chunk as usize),
+            Self::Tree(entries) => entries.get(&position).map(|&chunk| chunk as usize),
+        }
+    }
+
+    fn find(&self, position: u32) -> ChunkStartLookup {
+        match self {
+            Self::Dense(entries) => {
+                match entries.binary_search_by_key(&position, |entry| entry.position) {
+                    Ok(slot) => ChunkStartLookup::Boundary {
+                        left: slot
+                            .checked_sub(1)
+                            .map(|previous| entries[previous].chunk as usize),
+                        right: entries[slot].chunk as usize,
+                    },
+                    Err(0) => ChunkStartLookup::Missing,
+                    Err(slot) => ChunkStartLookup::Inside(entries[slot - 1].chunk as usize),
+                }
+            }
+            Self::Tree(entries) => {
+                let mut starts = entries.range(..=position);
+                match starts.next_back() {
+                    Some((&entry_position, &chunk)) if entry_position == position => {
+                        ChunkStartLookup::Boundary {
+                            left: starts.next_back().map(|(_, &chunk)| chunk as usize),
+                            right: chunk as usize,
+                        }
+                    }
+                    Some((_, &chunk)) => ChunkStartLookup::Inside(chunk as usize),
+                    None => ChunkStartLookup::Missing,
+                }
+            }
+        }
+    }
+
+    fn insert(&mut self, position: u32, chunk: u32) {
+        match self {
+            Self::Tree(entries) => {
+                entries.insert(position, chunk);
+            }
+            Self::Dense(entries) if entries.len() < DENSE_CHUNK_START_LIMIT => {
+                let slot = entries
+                    .binary_search_by_key(&position, |entry| entry.position)
+                    .expect_err("chunk start already indexed");
+                entries.insert(slot, ChunkStart { position, chunk });
+            }
+            Self::Dense(entries) => {
+                let mut tree = std::collections::BTreeMap::new();
+                tree.extend(
+                    std::mem::take(entries)
+                        .into_iter()
+                        .map(|entry| (entry.position, entry.chunk)),
+                );
+                tree.insert(position, chunk);
+                *self = Self::Tree(tree);
+            }
+        }
+    }
+}
+
 // ---------------------------------------------------------------------------
 // SourceMap
 // ---------------------------------------------------------------------------
@@ -558,15 +651,8 @@ pub struct MagicString<'source> {
     first_chunk: usize,
     /// Index of the last chunk in the linked list.
     last_chunk: usize,
-    /// Map from original-source position → chunk index that *starts* at that position.
-    /// Populated lazily via `split_at`. A `BTreeMap` (not a hash map) so
-    /// `split_at` can locate the chunk containing an arbitrary position with an
-    /// O(log n) `range(..=index).next_back()` lookup instead of an O(n) walk
-    /// from the head of the chunk list — the walk made repeated splits on a
-    /// large edited file O(n²) (the dominant svelte2tsx hotspot). Every chunk's
-    /// start is kept here and entries are never removed, so the greatest start
-    /// `<= index` is always the chunk that contains `index`.
-    by_start: std::collections::BTreeMap<u32, usize>,
+    /// Original-source chunk starts, ordered by position.
+    by_start: ChunkStarts,
     /// Content prepended before everything.
     intro: String,
     /// Content appended after everything.
@@ -588,16 +674,12 @@ impl<'source> MagicString<'source> {
     pub fn new(source: &'source str) -> Self {
         let source_len = checked_source_len(source.len());
         let chunk = Chunk::new(0, source_len);
-        let mut by_start: std::collections::BTreeMap<u32, usize> =
-            std::collections::BTreeMap::new();
-        by_start.insert(0, 0);
-
         Self {
             original: source,
             chunks: vec![chunk],
             first_chunk: 0,
             last_chunk: 0,
-            by_start,
+            by_start: ChunkStarts::new(),
             intro: String::new(),
             outro: String::new(),
         }
@@ -619,6 +701,11 @@ impl<'source> MagicString<'source> {
     // Internal helpers
     // -----------------------------------------------------------------
 
+    #[inline]
+    fn chunk_starting_at(&self, index: u32) -> Option<usize> {
+        self.by_start.get(index)
+    }
+
     /// Ensure there is a chunk boundary at the given original position.
     /// Returns the chunks immediately before and after that boundary in
     /// original-source order.
@@ -639,10 +726,15 @@ impl<'source> MagicString<'source> {
             return ChunkBoundary::default();
         }
 
-        let mut starts = self.by_start.range(..=index);
-        let (start, cur) = match starts.next_back() {
-            Some((&start, &chunk_idx)) => (start, chunk_idx),
-            None => {
+        let cur = match self.by_start.find(index) {
+            ChunkStartLookup::Boundary { left, right } => {
+                return ChunkBoundary {
+                    left,
+                    right: Some(right),
+                };
+            }
+            ChunkStartLookup::Inside(chunk) => chunk,
+            ChunkStartLookup::Missing => {
                 #[cfg(debug_assertions)]
                 eprintln!(
                     "split_at({}): no chunk start <= index (source length {})",
@@ -652,13 +744,6 @@ impl<'source> MagicString<'source> {
                 return ChunkBoundary::default();
             }
         };
-
-        if start == index {
-            return ChunkBoundary {
-                left: starts.next_back().map(|(_, &chunk_idx)| chunk_idx),
-                right: Some(cur),
-            };
-        }
 
         // The source-end boundary has no chunk on its right.
         if index as usize == self.original.len() {
@@ -697,7 +782,8 @@ impl<'source> MagicString<'source> {
             self.last_chunk = new_idx;
         }
 
-        self.by_start.insert(index, new_idx);
+        let new_idx_u32 = u32::try_from(new_idx).expect("MagicString chunk index exceeds u32");
+        self.by_start.insert(index, new_idx_u32);
 
         ChunkBoundary {
             left: Some(cur),
@@ -753,8 +839,8 @@ impl<'source> MagicString<'source> {
         // overwrite.
         let mut cur_end = self.chunks[first].end;
         while cur_end < end {
-            let ci = match self.by_start.get(&cur_end) {
-                Some(&i) => i,
+            let ci = match self.chunk_starting_at(cur_end) {
+                Some(i) => i,
                 None => break,
             };
             self.chunks[ci].content = Some(String::new());
@@ -794,7 +880,7 @@ impl<'source> MagicString<'source> {
             if cur_start >= end {
                 break;
             }
-            current = self.by_start.get(&cur_start).copied();
+            current = self.by_start.get(cur_start);
         }
 
         self
@@ -1611,6 +1697,43 @@ mod tests {
         s.append_right(2, "A");
 
         assert_eq!(s.to_string(), "abXLRefQPAcd");
+    }
+
+    #[test]
+    fn packed_chunk_starts_promote_after_bounded_reverse_inserts() {
+        assert_eq!(std::mem::size_of::<ChunkStart>(), 8);
+
+        let source = "x".repeat(DENSE_CHUNK_START_LIMIT + 2);
+        let mut s = MagicString::new(&source);
+        for index in (1..DENSE_CHUNK_START_LIMIT).rev() {
+            s.append_right(index as u32, "_");
+        }
+        let chunk_count = s.chunks.len();
+        s.append_right(128, "!");
+
+        let ChunkStarts::Dense(entries) = &s.by_start else {
+            panic!("repeated boundaries must not promote the dense index");
+        };
+        assert_eq!(entries.len(), chunk_count);
+        assert!(
+            entries
+                .windows(2)
+                .all(|entries| entries[0].position < entries[1].position)
+        );
+        assert!(
+            entries
+                .iter()
+                .all(|entry| s.chunks[entry.chunk as usize].start == entry.position)
+        );
+
+        s.append_right(DENSE_CHUNK_START_LIMIT as u32, "_");
+        let ChunkStarts::Tree(entries) = &s.by_start else {
+            panic!("the first boundary past the dense limit must promote");
+        };
+        assert_eq!(entries.len(), DENSE_CHUNK_START_LIMIT + 1);
+        let output = s.to_string();
+        assert_eq!(output.matches('_').count(), DENSE_CHUNK_START_LIMIT);
+        assert_eq!(output.matches('!').count(), 1);
     }
 
     #[test]

--- a/crates/rsvelte_projection/src/svelte2tsx/magic_string.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/magic_string.rs
@@ -826,6 +826,16 @@ impl<'source> MagicString<'source> {
         self
     }
 
+    /// Append owned content at the very end of the output.
+    pub fn append_str_owned(&mut self, content: String) -> &mut Self {
+        if self.outro.is_empty() {
+            self.outro = content;
+            self
+        } else {
+            self.append_str(&content)
+        }
+    }
+
     /// Insert `content` before the character at `index`, after any previously
     /// prepended content at this position. In the JS API this is called
     /// `appendLeft`.
@@ -1380,6 +1390,18 @@ mod tests {
     fn test_append_str() {
         let mut s = MagicString::new("hello");
         s.append_str(" world");
+        assert_eq!(s.to_string(), "hello world");
+    }
+
+    #[test]
+    fn append_str_owned_reuses_an_empty_outro() {
+        let mut s = MagicString::new("hello");
+        let content = String::from(" world");
+        let content_ptr = content.as_ptr();
+
+        s.append_str_owned(content);
+
+        assert_eq!(s.outro.as_ptr(), content_ptr);
         assert_eq!(s.to_string(), "hello world");
     }
 

--- a/crates/rsvelte_projection/src/svelte2tsx/nodes/snippet_hoisting.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/nodes/snippet_hoisting.rs
@@ -37,7 +37,7 @@ pub(crate) fn hoist_top_level_snippets(
     ast: &Root,
     source: &str,
     exported_names: &ExportedNames,
-    str: &mut MagicString,
+    str: &mut MagicString<'_>,
 ) -> Vec<(u32, u32)> {
     let mut hoistable_snippet_ranges: Vec<(u32, u32)> = Vec::new();
     let mut nonhoistable_snippet_ranges: Vec<(u32, u32)> = Vec::new();

--- a/crates/rsvelte_projection/src/svelte2tsx/nodes/svelte_options.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/nodes/svelte_options.rs
@@ -10,7 +10,7 @@ use super::super::svelte2tsx::slice_src;
 /// Emit the `<svelte:options>` tag as a `svelteHTML.createElement(...)` call.
 /// The parser stores svelte:options in `ast.options` (not in `fragment.nodes`),
 /// so it is handled separately.
-pub(crate) fn emit_svelte_options_element(ast: &Root, source: &str, str: &mut MagicString) {
+pub(crate) fn emit_svelte_options_element(ast: &Root, source: &str, str: &mut MagicString<'_>) {
     let Some(options_node) = ast.options.as_ref() else {
         return;
     };

--- a/crates/rsvelte_projection/src/svelte2tsx/process_instance_script_tag.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/process_instance_script_tag.rs
@@ -32,7 +32,7 @@ pub(crate) fn process_instance_script_tag(
     instance_program: &oxc_ast::ast::Program,
     source: &str,
     options: &Svelte2TsxOptions,
-    str: &mut MagicString,
+    str: &mut MagicString<'_>,
     exported_names: &mut ExportedNames,
     dollar_decls: &str,
     has_module_script: bool,
@@ -442,7 +442,7 @@ fn collect_lifted_imports(
     imports: &[(u32, u32, u32)],
     source: &str,
     content_start: u32,
-    str: &mut MagicString,
+    str: &mut MagicString<'_>,
 ) -> String {
     let mut import_text = String::new();
     for (i, &(comments_start, import_start_rel, import_end)) in imports.iter().enumerate() {

--- a/crates/rsvelte_projection/src/svelte2tsx/script/export_decl.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/script/export_decl.rs
@@ -35,7 +35,7 @@ use super::ExportedNames;
 pub(super) fn handle_export_named_decl(
     export: &oxc::ExportNamedDeclaration,
     offset: u32,
-    str: &mut MagicString,
+    str: &mut MagicString<'_>,
     exported_names: &mut ExportedNames,
     is_instance: bool,
     possible_exports: &HashMap<String, PossibleExport>,

--- a/crates/rsvelte_projection/src/svelte2tsx/script/hoistable_types.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/script/hoistable_types.rs
@@ -785,7 +785,7 @@ pub(super) fn rewrite_interface_to_type_dts(
     iface: &oxc_ast::ast::TSInterfaceDeclaration<'_>,
     raw_content: &str,
     offset: u32,
-    str: &mut MagicString,
+    str: &mut MagicString<'_>,
 ) {
     // 1. `interface` -> `type`
     let iface_kw_start = iface.span.start;

--- a/crates/rsvelte_projection/src/svelte2tsx/script/mod.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/script/mod.rs
@@ -101,7 +101,7 @@ pub fn process_instance_script(
     module_program: Option<&oxc::Program<'_>>,
     source: &str,
     store_scan: &mut StoreScanContext<'_>,
-    str: &mut MagicString,
+    str: &mut MagicString<'_>,
     exported_names: &mut ExportedNames,
     _events: &mut ComponentEvents,
     is_ts: bool,
@@ -720,7 +720,7 @@ pub fn process_module_script(
     script: &Script,
     parsed: &ParsedScript<'_>,
     store_scan: &mut StoreScanContext<'_>,
-    str: &mut MagicString,
+    str: &mut MagicString<'_>,
     exported_names: &mut ExportedNames,
 ) {
     // Module script exports are kept as-is (with the export keyword).

--- a/crates/rsvelte_projection/src/svelte2tsx/script/props_rune.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/script/props_rune.rs
@@ -82,7 +82,7 @@ pub(super) struct PropsRuneInfo {
 pub(super) fn apply_props_typedef(
     info: &PropsRuneInfo,
     offset: u32,
-    str: &mut MagicString,
+    str: &mut MagicString<'_>,
     exported_names: &mut ExportedNames,
     raw_content: &str,
     is_ts: bool,

--- a/crates/rsvelte_projection/src/svelte2tsx/script/reactive.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/script/reactive.rs
@@ -39,7 +39,7 @@ fn is_invalidate_assignment_target(target: &oxc::AssignmentTarget) -> bool {
 pub(super) fn handle_reactive_statement(
     labeled: &oxc::LabeledStatement,
     offset: u32,
-    str: &mut MagicString,
+    str: &mut MagicString<'_>,
     raw_content: &str,
     declared_names: &HashSet<String>,
     reactive_declared_names: &mut HashSet<String>,

--- a/crates/rsvelte_projection/src/svelte2tsx/script/stores.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/script/stores.rs
@@ -732,7 +732,7 @@ pub(super) fn inject_store_subscriptions_with_program(
     module_program: Option<&oxc::Program>,
     offset: u32,
     context: &mut StoreScanContext<'_>,
-    str: &mut MagicString,
+    str: &mut MagicString<'_>,
 ) {
     if !context.has_dollar() {
         return;
@@ -935,7 +935,7 @@ pub(super) fn inject_store_subscriptions_vars_only_with_program(
     program: &oxc::Program,
     offset: u32,
     context: &mut StoreScanContext<'_>,
-    str: &mut MagicString,
+    str: &mut MagicString<'_>,
 ) {
     if !context.has_dollar() {
         return;

--- a/crates/rsvelte_projection/src/svelte2tsx/script/type_assertion.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/script/type_assertion.rs
@@ -9,7 +9,10 @@ use super::script_facts::TypeAssertionFacts;
 /// `handleTypeAssertion` (`nodes/handleTypeAssertion.ts`) surgically — moving the
 /// type after the expression and removing the `<` / `>` — so any inner edits on
 /// the expression (store wraps, etc.) survive untouched.
-pub(super) fn rewrite_type_assertions(assertions: &[TypeAssertionFacts], str: &mut MagicString) {
+pub(super) fn rewrite_type_assertions(
+    assertions: &[TypeAssertionFacts],
+    str: &mut MagicString<'_>,
+) {
     for assertion in assertions {
         // ` as ` before the (moved) type, which lands at the expression end.
         str.append_left(assertion.expr_end, " as ");
@@ -39,7 +42,7 @@ pub(super) fn rewrite_type_assertions(assertions: &[TypeAssertionFacts], str: &m
 /// Note: this targets arrow functions only. `function foo<T>()`, call type
 /// arguments `f<T>()`, and class / interface generics are all unambiguous in
 /// TSX and are left untouched.
-pub(super) fn disambiguate_arrow_type_params(insert_at: &[u32], str: &mut MagicString) {
+pub(super) fn disambiguate_arrow_type_params(insert_at: &[u32], str: &mut MagicString<'_>) {
     for &pos in insert_at {
         str.append_left(pos, ",");
     }

--- a/crates/rsvelte_projection/src/svelte2tsx/svelte2tsx.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/svelte2tsx.rs
@@ -776,7 +776,7 @@ pub fn svelte2tsx(
         &mut str,
     );
 
-    str.append_str(&closing);
+    str.append_str_owned(closing);
 
     let generated = str.generate_bundle(GenerateMapOptions {
         file: None,

--- a/crates/rsvelte_projection/src/svelte2tsx/template/mod.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/template/mod.rs
@@ -90,7 +90,7 @@ pub fn process_template_inplace(
     fragment: &Fragment,
     source: &str,
     _options: &Svelte2TsxOptions,
-    str: &mut MagicString,
+    str: &mut MagicString<'_>,
 ) {
     let mut counter = Counter::new();
     // depth 0 = root fragment; elements and components increment it for their children

--- a/crates/rsvelte_projection/src/svelte2tsx/template/nodes/attach_tag.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/template/nodes/attach_tag.rs
@@ -7,7 +7,7 @@ use crate::svelte2tsx::template::segs::{Seg, segs_push_lit, segs_push_src};
 use crate::svelte2tsx::template::utils::expr::{get_expression_range, get_expression_text};
 
 /// Handle an attach tag: `{@attach expression}`.
-pub(crate) fn handle_attach_tag(tag: &AttachTag, str: &mut MagicString) {
+pub(crate) fn handle_attach_tag(tag: &AttachTag, str: &mut MagicString<'_>) {
     if tag.start >= tag.end {
         return;
     }

--- a/crates/rsvelte_projection/src/svelte2tsx/template/nodes/await_block.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/template/nodes/await_block.rs
@@ -22,7 +22,7 @@ pub(crate) fn handle_await_block(
     block: &AwaitBlock,
     source: &str,
     options: &Svelte2TsxOptions,
-    str: &mut MagicString,
+    str: &mut MagicString<'_>,
     counter: &mut Counter,
     depth: u32,
 ) {

--- a/crates/rsvelte_projection/src/svelte2tsx/template/nodes/comment.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/template/nodes/comment.rs
@@ -10,7 +10,7 @@ use crate::svelte2tsx::template::ctx::with_element_opener_comments;
 /// Handle an HTML comment node.
 ///
 /// Comments are blanked out in the TSX output.
-pub(crate) fn handle_comment(comment: &Comment, str: &mut MagicString) {
+pub(crate) fn handle_comment(comment: &Comment, str: &mut MagicString<'_>) {
     if comment.start >= comment.end {
         return;
     }

--- a/crates/rsvelte_projection/src/svelte2tsx/template/nodes/component_slots.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/template/nodes/component_slots.rs
@@ -230,7 +230,7 @@ pub(crate) fn process_component_children_with_slots(
     has_lets: bool,
     source: &str,
     options: &Svelte2TsxOptions,
-    str: &mut MagicString,
+    str: &mut MagicString<'_>,
     counter: &mut Counter,
     depth: u32,
 ) {
@@ -396,7 +396,7 @@ pub(crate) fn handle_named_slot_element(
     inst_var: &str,
     source: &str,
     options: &Svelte2TsxOptions,
-    str: &mut MagicString,
+    str: &mut MagicString<'_>,
     counter: &mut Counter,
     depth: u32,
 ) {
@@ -468,7 +468,7 @@ pub(crate) fn handle_named_slot_svelte_fragment(
     inst_var: &str,
     source: &str,
     options: &Svelte2TsxOptions,
-    str: &mut MagicString,
+    str: &mut MagicString<'_>,
     counter: &mut Counter,
     depth: u32,
 ) {
@@ -535,7 +535,7 @@ pub(crate) fn handle_named_slot_component(
     inst_var: &str,
     source: &str,
     options: &Svelte2TsxOptions,
-    str: &mut MagicString,
+    str: &mut MagicString<'_>,
     counter: &mut Counter,
     depth: u32,
 ) {

--- a/crates/rsvelte_projection/src/svelte2tsx/template/nodes/const_tag.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/template/nodes/const_tag.rs
@@ -6,7 +6,7 @@ use crate::svelte2tsx::magic_string::MagicString;
 /// Handle a const tag: `{@const declaration}`.
 ///
 /// The const declaration is emitted as a regular `const` statement.
-pub(crate) fn handle_const_tag(tag: &ConstTag, source: &str, str: &mut MagicString) {
+pub(crate) fn handle_const_tag(tag: &ConstTag, source: &str, str: &mut MagicString<'_>) {
     if tag.start >= tag.end {
         return;
     }

--- a/crates/rsvelte_projection/src/svelte2tsx/template/nodes/debug_tag.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/template/nodes/debug_tag.rs
@@ -14,7 +14,7 @@ use crate::svelte2tsx::template::utils::expr::{get_expression_range, get_express
 /// inserted before and after) so per-character source-map segments
 /// resolve diagnostics to the user's identifier position, not the
 /// `{@debug` anchor.
-pub(crate) fn handle_debug_tag(tag: &DebugTag, source: &str, str: &mut MagicString) {
+pub(crate) fn handle_debug_tag(tag: &DebugTag, source: &str, str: &mut MagicString<'_>) {
     if tag.start >= tag.end {
         return;
     }

--- a/crates/rsvelte_projection/src/svelte2tsx/template/nodes/declaration_tag.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/template/nodes/declaration_tag.rs
@@ -15,7 +15,7 @@ use crate::svelte2tsx::template::utils::expr::get_expression_range;
 pub(crate) fn handle_declaration_tag(
     tag: &crate::ast::template::DeclarationTag,
     _source: &str,
-    str: &mut MagicString,
+    str: &mut MagicString<'_>,
 ) {
     if tag.start >= tag.end {
         return;

--- a/crates/rsvelte_projection/src/svelte2tsx/template/nodes/dynamic_element.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/template/nodes/dynamic_element.rs
@@ -28,7 +28,7 @@ pub(crate) fn handle_svelte_dynamic_element(
     el: &SvelteDynamicElement,
     source: &str,
     options: &Svelte2TsxOptions,
-    str: &mut MagicString,
+    str: &mut MagicString<'_>,
     counter: &mut Counter,
     depth: u32,
 ) {

--- a/crates/rsvelte_projection/src/svelte2tsx/template/nodes/each_block.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/template/nodes/each_block.rs
@@ -107,7 +107,7 @@ pub(crate) fn handle_each_block(
     block: &EachBlock,
     source: &str,
     options: &Svelte2TsxOptions,
-    str: &mut MagicString,
+    str: &mut MagicString<'_>,
     counter: &mut Counter,
     depth: u32,
 ) {

--- a/crates/rsvelte_projection/src/svelte2tsx/template/nodes/element.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/template/nodes/element.rs
@@ -37,7 +37,7 @@ pub(crate) fn handle_regular_element(
     el: &RegularElement,
     source: &str,
     options: &Svelte2TsxOptions,
-    str: &mut MagicString,
+    str: &mut MagicString<'_>,
     counter: &mut Counter,
     depth: u32,
 ) {
@@ -280,7 +280,7 @@ pub(crate) fn handle_title_element(
     el: &TitleElement,
     source: &str,
     options: &Svelte2TsxOptions,
-    str: &mut MagicString,
+    str: &mut MagicString<'_>,
     counter: &mut Counter,
     depth: u32,
 ) {

--- a/crates/rsvelte_projection/src/svelte2tsx/template/nodes/if_else_block.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/template/nodes/if_else_block.rs
@@ -18,7 +18,7 @@ pub(crate) fn handle_if_block(
     block: &IfBlock,
     source: &str,
     options: &Svelte2TsxOptions,
-    str: &mut MagicString,
+    str: &mut MagicString<'_>,
     counter: &mut Counter,
     depth: u32,
 ) {

--- a/crates/rsvelte_projection/src/svelte2tsx/template/nodes/inline_component.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/template/nodes/inline_component.rs
@@ -54,7 +54,7 @@ pub(crate) fn handle_component(
     comp: &Component,
     source: &str,
     options: &Svelte2TsxOptions,
-    str: &mut MagicString,
+    str: &mut MagicString<'_>,
     counter: &mut Counter,
     depth: u32,
 ) {
@@ -462,7 +462,7 @@ pub(crate) fn handle_svelte_component(
     comp: &SvelteComponentElement,
     source: &str,
     options: &Svelte2TsxOptions,
-    str: &mut MagicString,
+    str: &mut MagicString<'_>,
     counter: &mut Counter,
     depth: u32,
 ) {
@@ -628,7 +628,7 @@ pub(crate) fn handle_svelte_self(
     el: &SvelteElement,
     source: &str,
     options: &Svelte2TsxOptions,
-    str: &mut MagicString,
+    str: &mut MagicString<'_>,
     counter: &mut Counter,
     depth: u32,
 ) {

--- a/crates/rsvelte_projection/src/svelte2tsx/template/nodes/key_block.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/template/nodes/key_block.rs
@@ -13,7 +13,7 @@ pub(crate) fn handle_key_block(
     block: &KeyBlock,
     source: &str,
     options: &Svelte2TsxOptions,
-    str: &mut MagicString,
+    str: &mut MagicString<'_>,
     counter: &mut Counter,
     depth: u32,
 ) {

--- a/crates/rsvelte_projection/src/svelte2tsx/template/nodes/mustache_tag.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/template/nodes/mustache_tag.rs
@@ -10,7 +10,7 @@ use crate::svelte2tsx::template::utils::expr::get_expression_range;
 ///
 /// Overwrites `{` with empty and `}` with `;` so the expression is preserved
 /// as a statement: `{count}` → `count;`
-pub(crate) fn handle_expression_tag(expr: &ExpressionTag, source: &str, str: &mut MagicString) {
+pub(crate) fn handle_expression_tag(expr: &ExpressionTag, source: &str, str: &mut MagicString<'_>) {
     if expr.start >= expr.end {
         return;
     }

--- a/crates/rsvelte_projection/src/svelte2tsx/template/nodes/raw_mustache_tag.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/template/nodes/raw_mustache_tag.rs
@@ -8,7 +8,7 @@ use crate::svelte2tsx::template::utils::expr::get_expression_range;
 /// Handle an HTML tag: `{@html expression}`.
 ///
 /// The expression needs type checking even though it's raw HTML.
-pub(crate) fn handle_html_tag(html: &HtmlTag, _source: &str, str: &mut MagicString) {
+pub(crate) fn handle_html_tag(html: &HtmlTag, _source: &str, str: &mut MagicString<'_>) {
     if html.start >= html.end {
         return;
     }

--- a/crates/rsvelte_projection/src/svelte2tsx/template/nodes/render_tag.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/template/nodes/render_tag.rs
@@ -15,7 +15,7 @@ use crate::svelte2tsx::template::utils::expr::get_expression_range;
 /// segments inside the snippet expression — a TS diagnostic at e.g.
 /// `foo(1)`'s `1` resolves to its exact `.svelte` column instead of
 /// snapping to the `{@render` anchor.
-pub(crate) fn handle_render_tag(tag: &RenderTag, _source: &str, str: &mut MagicString) {
+pub(crate) fn handle_render_tag(tag: &RenderTag, _source: &str, str: &mut MagicString<'_>) {
     if tag.start >= tag.end {
         return;
     }

--- a/crates/rsvelte_projection/src/svelte2tsx/template/nodes/slot_element.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/template/nodes/slot_element.rs
@@ -23,7 +23,7 @@ pub(crate) fn handle_slot_element(
     el: &SlotElement,
     source: &str,
     options: &Svelte2TsxOptions,
-    str: &mut MagicString,
+    str: &mut MagicString<'_>,
     counter: &mut Counter,
     depth: u32,
 ) {

--- a/crates/rsvelte_projection/src/svelte2tsx/template/nodes/snippet_block.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/template/nodes/snippet_block.rs
@@ -23,7 +23,7 @@ use crate::svelte2tsx::template::walk::process_fragment_inplace;
 /// early-`continue` guards. Component / boundary containers are excluded by
 /// their callers (they treat snippets as implicit props instead), so this is
 /// only invoked for block and plain-element fragments.
-pub(crate) fn hoist_snippet_blocks(fragment: &Fragment, source: &str, str: &mut MagicString) {
+pub(crate) fn hoist_snippet_blocks(fragment: &Fragment, source: &str, str: &mut MagicString<'_>) {
     let mut target_position: Option<u32> = None;
     for node in &fragment.nodes {
         if !matches!(node, TemplateNode::SnippetBlock(_)) {
@@ -71,7 +71,7 @@ pub(crate) fn handle_snippet_block(
     block: &SnippetBlock,
     source: &str,
     options: &Svelte2TsxOptions,
-    str: &mut MagicString,
+    str: &mut MagicString<'_>,
     counter: &mut Counter,
     depth: u32,
 ) {
@@ -91,7 +91,7 @@ pub(crate) fn handle_snippet_block_as_component_prop(
     block: &SnippetBlock,
     source: &str,
     options: &Svelte2TsxOptions,
-    str: &mut MagicString,
+    str: &mut MagicString<'_>,
     counter: &mut Counter,
     depth: u32,
 ) {
@@ -102,7 +102,7 @@ pub(crate) fn handle_snippet_block_inner(
     block: &SnippetBlock,
     source: &str,
     options: &Svelte2TsxOptions,
-    str: &mut MagicString,
+    str: &mut MagicString<'_>,
     counter: &mut Counter,
     as_component_prop: bool,
     // Snippet bodies always start at depth 0 (official resets `element` on

--- a/crates/rsvelte_projection/src/svelte2tsx/template/nodes/special_element.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/template/nodes/special_element.rs
@@ -37,7 +37,7 @@ pub(crate) fn handle_svelte_special_element(
     el: &SvelteElement,
     source: &str,
     options: &Svelte2TsxOptions,
-    str: &mut MagicString,
+    str: &mut MagicString<'_>,
     counter: &mut Counter,
     depth: u32,
 ) {

--- a/crates/rsvelte_projection/src/svelte2tsx/template/nodes/text.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/template/nodes/text.rs
@@ -9,7 +9,7 @@ use crate::svelte2tsx::magic_string::MagicString;
 /// (replaced with empty). Whitespace characters are kept as-is.
 /// If the result is empty but the original text had content, at least 1
 /// space is preserved (to prevent hover artifacts in the language server).
-pub(crate) fn handle_text(text: &Text, _source: &str, str: &mut MagicString) {
+pub(crate) fn handle_text(text: &Text, _source: &str, str: &mut MagicString<'_>) {
     if text.start >= text.end {
         return;
     }

--- a/crates/rsvelte_projection/src/svelte2tsx/template/segs.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/template/segs.rs
@@ -146,7 +146,7 @@ pub(super) fn bake_out_of_order_src(segs: Vec<Seg>, source: &str) -> Vec<Seg> {
 /// - `Src(s, e)` ranges appear in strictly increasing order.
 /// - Each `Src(s, e)` lies within `[range_start, range_end]`.
 pub(super) fn emit_segmented_overwrite(
-    str: &mut MagicString,
+    str: &mut MagicString<'_>,
     range_start: u32,
     range_end: u32,
     segments: &[Seg],

--- a/crates/rsvelte_projection/src/svelte2tsx/template/walk.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/template/walk.rs
@@ -35,7 +35,7 @@ pub(super) fn process_fragment_inplace(
     fragment: &Fragment,
     source: &str,
     options: &Svelte2TsxOptions,
-    str: &mut MagicString,
+    str: &mut MagicString<'_>,
     counter: &mut Counter,
     depth: u32,
 ) {
@@ -49,7 +49,7 @@ pub(super) fn process_node_inplace(
     node: &TemplateNode,
     source: &str,
     options: &Svelte2TsxOptions,
-    str: &mut MagicString,
+    str: &mut MagicString<'_>,
     counter: &mut Counter,
     depth: u32,
 ) {

--- a/crates/rsvelte_projection/src/svelte2tsx/utils/htmlxparser.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/utils/htmlxparser.rs
@@ -86,7 +86,7 @@ pub(crate) fn blank_style_content(source: &str) -> String {
 /// Overwriting their range with `""` truncates any attribute whose source span
 /// covers the range; the joined content is returned for injection into the
 /// `$$render()` body when the file has no top-level script.
-pub(crate) fn remove_orphan_scripts(ast: &Root, source: &str, str: &mut MagicString) -> String {
+pub(crate) fn remove_orphan_scripts(ast: &Root, source: &str, str: &mut MagicString<'_>) -> String {
     let orphan_scripts = find_orphan_scripts(ast, source);
     // Remove orphan scripts from the MagicString (must happen BEFORE
     // process_template_inplace so the overwrite is in place when the template
@@ -107,7 +107,7 @@ pub(crate) fn remove_orphan_scripts(ast: &Root, source: &str, str: &mut MagicStr
 /// blanks any style tag the parser captured in `ast.css`, then always runs a
 /// fallback scanner to catch style tags the parser did not capture (e.g.,
 /// `<style global>`, `<style lang="...">`).
-pub(crate) fn blank_style_tags(ast: &Root, source: &str, str: &mut MagicString) {
+pub(crate) fn blank_style_tags(ast: &Root, source: &str, str: &mut MagicString<'_>) {
     let mut blanked_style_ranges: Vec<(usize, usize)> = Vec::new();
     if let Some(ref css) = ast.css
         && css.start < css.end

--- a/crates/rsvelte_projection/tests/svelte2tsx_entry.rs
+++ b/crates/rsvelte_projection/tests/svelte2tsx_entry.rs
@@ -4,6 +4,17 @@
 use rsvelte_projection::svelte2tsx::{Svelte2TsxOptions, SvelteVersion, svelte2tsx};
 
 #[test]
+fn result_does_not_borrow_the_input_source() {
+    let result = {
+        let source = String::from("<h1>hello</h1>");
+        svelte2tsx(&source, Svelte2TsxOptions::default()).unwrap()
+    };
+
+    assert!(result.code.contains("svelteHTML.createElement(\"h1\","));
+    assert!(result.map.as_deref().is_some_and(|map| !map.is_empty()));
+}
+
+#[test]
 fn test_svelte2tsx_simple_template() {
     let source = "<h1>hello</h1>";
     let result = svelte2tsx(source, Svelte2TsxOptions::default());


### PR DESCRIPTION
> Stack 7/8  
> Base: `agent/svelte2tsx-release-06-source-map-output` (`a34379ed`)  
> Head: `agent/svelte2tsx-release-07-magicstring-layout` (`a57c1944`)

## Summary

- make MagicString borrow the input source while keeping public results owned
- replace wide optional chunk links and root handles with checked compact IDs
- move the already-owned final output buffer into the empty outro
- return split boundaries directly and remove redundant edit indexing
- pack common chunk starts and compact chunk handles

The arena remains append-only and preserves original-position semantics, O(1)
linked traversal, move/overwrite behavior, forward maps, and source maps.

## Commit scope

- `ba0da477` perf(svelte2tsx): borrow MagicString source
- `8bca0bec` perf(svelte2tsx): compact MagicString chunk links
- `807c85f2` perf(svelte2tsx): move final output buffer into MagicString
- `2d488ac8` perf(svelte2tsx): return MagicString split boundaries
- `638ad4ac` perf(svelte2tsx): pack common MagicString chunk starts
- `a57c1944` perf(svelte2tsx): compact MagicString chunk handles

This includes only the accepted integration-resolved variants. It does not
include the broader owned-buffer experiment or compact-map alternatives.

## Validation

- [ ] `cargo fmt --check`
- [ ] `cargo clippy -p rsvelte_projection --all-targets --all-features -- -D warnings`
- [ ] `cargo test -p rsvelte_projection magic_string`
- [ ] `cargo test -p rsvelte_projection --test svelte2tsx_forward_map`
- [ ] `cargo test -p rsvelte_projection --test svelte2tsx_fixtures`
- [ ] `cargo test -p rsvelte_projection`

## Stack order

Merge after PR 6. PR 8 is based on this head.
