### PR TITLE
Linearize external-import rewrite maps

### DIFF
--- a/crates/rsvelte_projection/src/svelte2tsx/helpers/rewrite_external_imports.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/helpers/rewrite_external_imports.rs
@@ -18,93 +18,198 @@ pub(crate) struct TextRewrite {
     pub(crate) edits: Vec<TextEdit>,
 }
 
-fn parent_dir(path: &str) -> String {
+fn parent_dir(path: &str) -> &str {
     match path.rfind('/') {
-        Some(0) => "/".to_string(),
-        Some(i) => path[..i].to_string(),
-        None => "".to_string(),
+        Some(0) => &path[..1],
+        Some(i) => &path[..i],
+        None => "",
     }
 }
 
-/// POSIX-style `path.resolve(base, rel)` — joins `base` and `rel` and
-/// normalises away `.` / `..` components.
-fn resolve_posix(base: &str, rel: &str) -> String {
-    let abs = base.starts_with('/');
-    let mut parts: Vec<&str> = base
-        .split('/')
-        .filter(|s| !s.is_empty() && *s != ".")
-        .collect();
-    for p in rel.split('/') {
-        if p.is_empty() || p == "." {
-            continue;
-        }
-        if p == ".." {
-            parts.pop();
-        } else {
-            parts.push(p);
-        }
-    }
-    let joined = parts.join("/");
-    if abs { format!("/{}", joined) } else { joined }
+#[derive(Debug, Clone, Copy)]
+struct ComponentRange {
+    start: usize,
+    end: usize,
 }
 
-/// POSIX-style `path.relative(from, to)`.
-fn relative_posix(from: &str, to: &str) -> String {
-    let from_parts: Vec<&str> = from.split('/').filter(|s| !s.is_empty()).collect();
-    let to_parts: Vec<&str> = to.split('/').filter(|s| !s.is_empty()).collect();
-    let common = from_parts
-        .iter()
-        .zip(to_parts.iter())
-        .take_while(|(a, b)| a == b)
-        .count();
-    let mut result: Vec<String> = Vec::new();
-    for _ in common..from_parts.len() {
-        result.push("..".to_string());
+#[derive(Debug, Clone, Copy)]
+struct TargetComponent {
+    truncate_to: usize,
+    range: ComponentRange,
+}
+
+struct PreparedRewritePaths<'a> {
+    source_target: String,
+    source_components: Vec<TargetComponent>,
+    generated_dir: &'a str,
+    generated_components: Vec<ComponentRange>,
+    workspace_dir: &'a str,
+}
+
+impl<'a> PreparedRewritePaths<'a> {
+    fn new(opts: &'a RewriteExternalImportsOptions) -> Self {
+        let source_dir = parent_dir(&opts.source_path);
+        let mut source_target = String::with_capacity(source_dir.len().max(1));
+        let mut source_components = Vec::new();
+        if source_dir.starts_with('/') {
+            source_target.push('/');
+        }
+        for component in source_dir
+            .split('/')
+            .filter(|component| !component.is_empty() && *component != ".")
+        {
+            push_target_component(&mut source_target, &mut source_components, component);
+        }
+
+        let generated_dir = parent_dir(&opts.generated_path);
+        let mut generated_components = Vec::new();
+        let mut offset = 0;
+        for component in generated_dir.split('/') {
+            let start = offset;
+            let end = start + component.len();
+            if !component.is_empty() {
+                generated_components.push(ComponentRange { start, end });
+            }
+            offset = end + 1;
+        }
+
+        Self {
+            source_target,
+            source_components,
+            generated_dir,
+            generated_components,
+            workspace_dir: opts.workspace_path.trim_end_matches('/'),
+        }
     }
-    for p in to_parts.iter().skip(common) {
-        result.push((*p).to_string());
+
+    fn compute_rewrite(&self, specifier: &str, scratch: &mut RewriteScratch) -> Option<usize> {
+        let suffix_start = split_specifier(specifier);
+        let path_part = &specifier[..suffix_start];
+        if !path_part.starts_with("../") {
+            return None;
+        }
+
+        scratch.target.clear();
+        scratch.target.push_str(&self.source_target);
+        scratch.target_components.clear();
+        scratch
+            .target_components
+            .extend_from_slice(&self.source_components);
+        scratch.target.reserve(path_part.len());
+
+        for component in path_part.split('/') {
+            if component.is_empty() || component == "." {
+                continue;
+            }
+            if component == ".." {
+                if let Some(component) = scratch.target_components.pop() {
+                    scratch.target.truncate(component.truncate_to);
+                }
+            } else {
+                push_target_component(
+                    &mut scratch.target,
+                    &mut scratch.target_components,
+                    component,
+                );
+            }
+        }
+
+        if is_within_dir(&scratch.target, self.workspace_dir) {
+            return None;
+        }
+
+        self.write_relative_target(scratch);
+        (scratch.rewritten != path_part).then_some(suffix_start)
     }
-    if result.is_empty() {
-        ".".to_string()
-    } else {
-        result.join("/")
+
+    fn write_relative_target(&self, scratch: &mut RewriteScratch) {
+        let common = self
+            .generated_components
+            .iter()
+            .zip(&scratch.target_components)
+            .take_while(|(generated, target)| {
+                self.generated_dir[generated.start..generated.end]
+                    == scratch.target[target.range.start..target.range.end]
+            })
+            .count();
+
+        scratch.rewritten.clear();
+        scratch
+            .rewritten
+            .reserve(self.generated_dir.len() + scratch.target.len());
+        for _ in common..self.generated_components.len() {
+            push_path_component(&mut scratch.rewritten, "..");
+        }
+        for target in scratch.target_components.iter().skip(common) {
+            push_path_component(
+                &mut scratch.rewritten,
+                &scratch.target[target.range.start..target.range.end],
+            );
+        }
+        if scratch.rewritten.is_empty() {
+            scratch.rewritten.push('.');
+        }
     }
+}
+
+struct RewriteScratch {
+    target: String,
+    target_components: Vec<TargetComponent>,
+    rewritten: String,
+}
+
+impl RewriteScratch {
+    fn new(paths: &PreparedRewritePaths<'_>) -> Self {
+        Self {
+            target: String::with_capacity(paths.source_target.len() + 32),
+            target_components: Vec::with_capacity(paths.source_components.len() + 8),
+            rewritten: String::with_capacity(
+                paths.generated_dir.len() + paths.source_target.len() + 32,
+            ),
+        }
+    }
+}
+
+fn push_target_component(
+    target: &mut String,
+    components: &mut Vec<TargetComponent>,
+    component: &str,
+) {
+    let truncate_to = target.len();
+    if !target.is_empty() && !target.ends_with('/') {
+        target.push('/');
+    }
+    let start = target.len();
+    target.push_str(component);
+    components.push(TargetComponent {
+        truncate_to,
+        range: ComponentRange {
+            start,
+            end: target.len(),
+        },
+    });
+}
+
+fn push_path_component(path: &mut String, component: &str) {
+    if !path.is_empty() {
+        path.push('/');
+    }
+    path.push_str(component);
 }
 
 fn is_within_dir(target: &str, dir: &str) -> bool {
-    let dir = dir.trim_end_matches('/');
-    target == dir || target.starts_with(&format!("{}/", dir))
+    target == dir || (target.starts_with(dir) && target.as_bytes().get(dir.len()) == Some(&b'/'))
 }
 
-fn split_specifier(spec: &str) -> (&str, &str) {
+fn split_specifier(spec: &str) -> usize {
     let q = spec.find('?');
     let h = spec.find('#');
-    let cut = match (q, h) {
-        (None, None) => return (spec, ""),
+    match (q, h) {
+        (None, None) => spec.len(),
         (Some(q), None) => q,
         (None, Some(h)) => h,
         (Some(q), Some(h)) => q.min(h),
-    };
-    (&spec[..cut], &spec[cut..])
-}
-
-fn compute_rewrite(specifier: &str, opts: &RewriteExternalImportsOptions) -> Option<String> {
-    let (path_part, suffix) = split_specifier(specifier);
-    if !path_part.starts_with("../") {
-        return None;
     }
-    let source_dir = parent_dir(&opts.source_path);
-    let generated_dir = parent_dir(&opts.generated_path);
-    let target = resolve_posix(&source_dir, path_part);
-    if is_within_dir(&target, &opts.workspace_path) {
-        return None;
-    }
-    let rewritten = relative_posix(&generated_dir, &target);
-    let full = format!("{}{}", rewritten, suffix);
-    if full == specifier {
-        return None;
-    }
-    Some(full)
 }
 
 #[inline]
@@ -123,6 +228,8 @@ pub(crate) fn rewrite_external_specifiers_in_text(
     text: &str,
     opts: &RewriteExternalImportsOptions,
 ) -> TextRewrite {
+    let paths = PreparedRewritePaths::new(opts);
+    let mut scratch = RewriteScratch::new(&paths);
     let bytes = text.as_bytes();
     let len = bytes.len();
     let mut replacement: Option<String> = None;
@@ -135,15 +242,20 @@ pub(crate) fn rewrite_external_specifiers_in_text(
                                      replacement: &mut Option<String>,
                                      copied: &mut usize| {
         let spec = &text[spec_start..spec_end];
-        if let Some(rewrite) = compute_rewrite(spec, opts) {
+        if let Some(suffix_start) = paths.compute_rewrite(spec, &mut scratch) {
+            let suffix = &spec[suffix_start..];
+            let replacement_len = scratch.rewritten.len() + suffix.len();
+            let replacement_utf16_len =
+                scratch.rewritten.encode_utf16().count() + suffix.encode_utf16().count();
             let out = replacement.get_or_insert_with(|| String::with_capacity(text.len()));
             out.push_str(&text[*copied..spec_start]);
-            out.push_str(&rewrite);
+            out.push_str(&scratch.rewritten);
+            out.push_str(suffix);
             edits.push(TextEdit {
                 start: spec_start as u32,
                 end: spec_end as u32,
-                replacement_len: rewrite.len() as u32,
-                replacement_utf16_len: rewrite.encode_utf16().count() as u32,
+                replacement_len: replacement_len as u32,
+                replacement_utf16_len: replacement_utf16_len as u32,
             });
             *copied = spec_end;
         }
@@ -233,6 +345,96 @@ pub(crate) fn rewrite_external_specifiers_in_text(
 mod tests {
     use super::*;
 
+    fn parent_dir_oracle(path: &str) -> String {
+        match path.rfind('/') {
+            Some(0) => "/".to_string(),
+            Some(i) => path[..i].to_string(),
+            None => "".to_string(),
+        }
+    }
+
+    fn resolve_posix_oracle(base: &str, rel: &str) -> String {
+        let abs = base.starts_with('/');
+        let mut parts: Vec<&str> = base
+            .split('/')
+            .filter(|part| !part.is_empty() && *part != ".")
+            .collect();
+        for part in rel.split('/') {
+            if part.is_empty() || part == "." {
+                continue;
+            }
+            if part == ".." {
+                parts.pop();
+            } else {
+                parts.push(part);
+            }
+        }
+        let joined = parts.join("/");
+        if abs { format!("/{joined}") } else { joined }
+    }
+
+    fn relative_posix_oracle(from: &str, to: &str) -> String {
+        let from_parts: Vec<&str> = from
+            .split('/')
+            .filter(|component| !component.is_empty())
+            .collect();
+        let to_parts: Vec<&str> = to
+            .split('/')
+            .filter(|component| !component.is_empty())
+            .collect();
+        let common = from_parts
+            .iter()
+            .zip(to_parts.iter())
+            .take_while(|(from, to)| from == to)
+            .count();
+        let mut result = Vec::new();
+        for _ in common..from_parts.len() {
+            result.push("..".to_string());
+        }
+        for component in to_parts.iter().skip(common) {
+            result.push((*component).to_string());
+        }
+        if result.is_empty() {
+            ".".to_string()
+        } else {
+            result.join("/")
+        }
+    }
+
+    fn compute_rewrite_oracle(
+        specifier: &str,
+        opts: &RewriteExternalImportsOptions,
+    ) -> Option<String> {
+        let suffix_start = split_specifier(specifier);
+        let path_part = &specifier[..suffix_start];
+        let suffix = &specifier[suffix_start..];
+        if !path_part.starts_with("../") {
+            return None;
+        }
+        let source_dir = parent_dir_oracle(&opts.source_path);
+        let generated_dir = parent_dir_oracle(&opts.generated_path);
+        let target = resolve_posix_oracle(&source_dir, path_part);
+        let workspace_dir = opts.workspace_path.trim_end_matches('/');
+        if target == workspace_dir || target.starts_with(&format!("{workspace_dir}/")) {
+            return None;
+        }
+        let rewritten = relative_posix_oracle(&generated_dir, &target);
+        let full = format!("{rewritten}{suffix}");
+        (full != specifier).then_some(full)
+    }
+
+    fn compute_prepared(specifier: &str, opts: &RewriteExternalImportsOptions) -> Option<String> {
+        let paths = PreparedRewritePaths::new(opts);
+        let mut scratch = RewriteScratch::new(&paths);
+        paths
+            .compute_rewrite(specifier, &mut scratch)
+            .map(|suffix_start| {
+                let mut rewritten = scratch.rewritten;
+                rewritten.push_str(&specifier[suffix_start..]);
+                rewritten
+            })
+    }
+
     fn rewrite_options() -> RewriteExternalImportsOptions {
         RewriteExternalImportsOptions {
             source_path: "/workspace/src/App.svelte".to_string(),
@@ -254,6 +456,250 @@ mod tests {
         let output = rewrite.replacement.unwrap_or(text);
         assert_eq!(output.as_ptr(), original_ptr);
         assert_eq!(output.capacity(), original_capacity);
+    }
+
+    #[test]
+    fn matches_oracle_across_import_counts() {
+        for count in [1, 16, 256, 4096] {
+            let opts = rewrite_options();
+            let mut input = String::new();
+            let mut expected = String::new();
+            let mut expected_edits = Vec::new();
+
+            for index in 0..count {
+                let specifier = match index % 4 {
+                    0 => format!("../../outside/asset-{index}.js?raw#fragment"),
+                    1 => format!("../inside/asset-{index}.js"),
+                    2 => format!("./local/asset-{index}.js"),
+                    _ => format!("../../外部/😀-{index}.js#fragment?raw"),
+                };
+                let (prefix, suffix) = if index % 2 == 0 {
+                    (format!("import value{index} from \""), "\";\n")
+                } else {
+                    (format!("const value{index} = import('"), "');\n")
+                };
+                input.push_str(&prefix);
+                expected.push_str(&prefix);
+                let start = input.len();
+                input.push_str(&specifier);
+                let end = input.len();
+
+                if let Some(rewritten) = compute_rewrite_oracle(&specifier, &opts) {
+                    expected.push_str(&rewritten);
+                    expected_edits.push(TextEdit {
+                        start: start as u32,
+                        end: end as u32,
+                        replacement_len: rewritten.len() as u32,
+                        replacement_utf16_len: rewritten.encode_utf16().count() as u32,
+                    });
+                } else {
+                    expected.push_str(&specifier);
+                }
+                input.push_str(suffix);
+                expected.push_str(suffix);
+            }
+
+            let actual = rewrite_external_specifiers_in_text(&input, &opts);
+            assert_eq!(actual.replacement.as_deref(), Some(expected.as_str()));
+            assert_eq!(actual.edits, expected_edits);
+        }
+    }
+
+    #[test]
+    fn preserves_scanner_detection_set() {
+        let input = concat!(
+            "const literal = \"from '../../outside/literal.js'\";\n",
+            "// import('../../outside/line-comment.js')\n",
+            "/* from '../../outside/block-comment.js' */\n",
+            "perform from \"../../outside/broad-match.js\";\n",
+            "const dynamic = import('../../outside/dynamic.js');\n",
+            "ximport('../../outside/prefixed.js');\n",
+        );
+        let expected = concat!(
+            "const literal = \"from '../../outside/literal.js'\";\n",
+            "// import('../../outside/line-comment.js')\n",
+            "/* from '../../../outside/block-comment.js' */\n",
+            "perform from \"../../../outside/broad-match.js\";\n",
+            "const dynamic = import('../../../outside/dynamic.js');\n",
+            "ximport('../../outside/prefixed.js');\n",
+        );
+
+        let actual = rewrite_external_specifiers_in_text(input, &rewrite_options());
+        assert_eq!(actual.replacement.as_deref(), Some(expected));
+        assert_eq!(actual.edits.len(), 3);
+    }
+
+    #[test]
+    fn preserves_audited_posix_path_semantics() {
+        let cases = [
+            (
+                RewriteExternalImportsOptions {
+                    source_path: "/root/base/../src/App.svelte".to_string(),
+                    generated_path: "/generated/out/App.svelte.tsx".to_string(),
+                    workspace_path: "/elsewhere".to_string(),
+                },
+                "../asset.js",
+                Some("../../root/base/../asset.js"),
+            ),
+            (
+                RewriteExternalImportsOptions {
+                    source_path: "/workspace/src/App.svelte".to_string(),
+                    generated_path: "/workspace/App.svelte.tsx".to_string(),
+                    workspace_path: "/elsewhere".to_string(),
+                },
+                "../?raw#fragment",
+                Some(".?raw#fragment"),
+            ),
+            (
+                RewriteExternalImportsOptions {
+                    source_path: "/workspace/src/App.svelte".to_string(),
+                    generated_path: "/workspace/generated/nested/App.svelte.tsx".to_string(),
+                    workspace_path: "/workspace".to_string(),
+                },
+                "../../workspace-other/asset.js#fragment?raw",
+                Some("../../../workspace-other/asset.js#fragment?raw"),
+            ),
+            (
+                RewriteExternalImportsOptions {
+                    source_path: "/workspace/src/App.svelte".to_string(),
+                    generated_path: "/workspace/generated/App.svelte.tsx".to_string(),
+                    workspace_path: "/workspace".to_string(),
+                },
+                "../../../../outside/asset.js?raw#fragment",
+                Some("../../outside/asset.js?raw#fragment"),
+            ),
+            (
+                RewriteExternalImportsOptions {
+                    source_path: "/workspace/src/App.svelte".to_string(),
+                    generated_path: "/workspace/generated/App.svelte.tsx".to_string(),
+                    workspace_path: "/workspace".to_string(),
+                },
+                "../inside/asset.js",
+                None,
+            ),
+        ];
+
+        for (opts, specifier, expected) in cases {
+            assert_eq!(
+                compute_prepared(specifier, &opts).as_deref(),
+                expected,
+                "{specifier}"
+            );
+            assert_eq!(
+                compute_prepared(specifier, &opts),
+                compute_rewrite_oracle(specifier, &opts),
+                "{specifier}"
+            );
+        }
+    }
+
+    #[test]
+    fn matches_oracle_for_deep_paths() {
+        let source_path = format!(
+            "/workspace/{}/App.svelte",
+            (0..192)
+                .map(|index| format!("source-{index}"))
+                .collect::<Vec<_>>()
+                .join("/")
+        );
+        let generated_path = format!(
+            "/workspace/.generated/{}/App.svelte.tsx",
+            (0..160)
+                .map(|index| format!("generated-{index}"))
+                .collect::<Vec<_>>()
+                .join("/")
+        );
+        let specifier = format!("{}外部/😀.js?raw#fragment", "../".repeat(256));
+        let opts = RewriteExternalImportsOptions {
+            source_path,
+            generated_path,
+            workspace_path: "/unrelated".to_string(),
+        };
+
+        assert_eq!(
+            compute_prepared(&specifier, &opts),
+            compute_rewrite_oracle(&specifier, &opts)
+        );
+    }
+
+    #[test]
+    fn deterministic_paths_match_previous_implementation() {
+        const COMPONENTS: [&str; 7] = ["alpha", "beta", ".", "..", "", "日本", "é"];
+        const WORKSPACES: [&str; 7] = [
+            "/workspace",
+            "/workspace/",
+            "/",
+            "",
+            "/workspace-other",
+            "relative",
+            "日本",
+        ];
+        const SUFFIXES: [&str; 6] = [
+            "",
+            "?raw",
+            "#fragment",
+            "?raw#fragment",
+            "#fragment?raw",
+            "?日本#é",
+        ];
+
+        fn next(state: &mut u64) -> u64 {
+            *state = (*state)
+                .wrapping_mul(6_364_136_223_846_793_005)
+                .wrapping_add(1_442_695_040_888_963_407);
+            *state
+        }
+
+        fn make_path(state: &mut u64, absolute: bool, depth: usize, filename: &str) -> String {
+            let mut path = if absolute {
+                "/".to_string()
+            } else {
+                String::new()
+            };
+            for index in 0..depth {
+                if index != 0 {
+                    path.push('/');
+                }
+                path.push_str(COMPONENTS[next(state) as usize % COMPONENTS.len()]);
+            }
+            if !path.is_empty() && !path.ends_with('/') {
+                path.push('/');
+            }
+            path.push_str(filename);
+            path
+        }
+
+        let mut state = 0x4d59_5df4_d0f3_3173_u64;
+
+        for case in 0..4096 {
+            let source_depth = next(&mut state) as usize % 12;
+            let generated_depth = next(&mut state) as usize % 12;
+            let source_path = make_path(&mut state, case % 3 != 0, source_depth, "App.svelte");
+            let generated_path =
+                make_path(&mut state, case % 5 != 0, generated_depth, "App.svelte.tsx");
+            let workspace_path =
+                WORKSPACES[next(&mut state) as usize % WORKSPACES.len()].to_string();
+            let mut specifier = "../".repeat(next(&mut state) as usize % 8 + 1);
+            let trailing = next(&mut state) as usize % 8;
+            for index in 0..trailing {
+                if index != 0 {
+                    specifier.push('/');
+                }
+                specifier.push_str(COMPONENTS[next(&mut state) as usize % COMPONENTS.len()]);
+            }
+            specifier.push_str(SUFFIXES[next(&mut state) as usize % SUFFIXES.len()]);
+
+            let opts = RewriteExternalImportsOptions {
+                source_path,
+                generated_path,
+                workspace_path,
+            };
+            assert_eq!(
+                compute_prepared(&specifier, &opts),
+                compute_rewrite_oracle(&specifier, &opts),
+                "case {case}: {opts:?}, {specifier:?}"
+            );
+        }
     }
 
     #[test]

--- a/crates/rsvelte_projection/src/svelte2tsx/helpers/rewrite_external_imports.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/helpers/rewrite_external_imports.rs
@@ -14,7 +14,7 @@ pub(crate) struct TextEdit {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct TextRewrite {
-    pub(crate) code: String,
+    pub(crate) replacement: Option<String>,
     pub(crate) edits: Vec<TextEdit>,
 }
 
@@ -118,36 +118,36 @@ fn is_ident_byte_local(b: u8) -> bool {
 }
 
 /// String-level version of `rewrite_external_imports` — same scanner, but
-/// returns a freshly-rewritten `String` instead of mutating a MagicString.
-/// Used for the synthesised `import_text` chunk that is generated from the
-/// original source (not from the MagicString) and therefore needs its own
-/// pass so the hoisted imports also pick up the rewrite.
+/// returns replacement text only when at least one specifier changes.
 pub(crate) fn rewrite_external_specifiers_in_text(
     text: &str,
     opts: &RewriteExternalImportsOptions,
 ) -> TextRewrite {
     let bytes = text.as_bytes();
     let len = bytes.len();
-    let mut out = String::with_capacity(text.len());
+    let mut replacement: Option<String> = None;
     let mut edits = Vec::new();
     let mut copied = 0usize;
     let mut i = 0;
 
-    let mut try_rewrite_specifier =
-        |spec_start: usize, spec_end: usize, out: &mut String, copied: &mut usize| {
-            let spec = &text[spec_start..spec_end];
-            if let Some(rewrite) = compute_rewrite(spec, opts) {
-                out.push_str(&text[*copied..spec_start]);
-                out.push_str(&rewrite);
-                edits.push(TextEdit {
-                    start: spec_start as u32,
-                    end: spec_end as u32,
-                    replacement_len: rewrite.len() as u32,
-                    replacement_utf16_len: rewrite.encode_utf16().count() as u32,
-                });
-                *copied = spec_end;
-            }
-        };
+    let mut try_rewrite_specifier = |spec_start: usize,
+                                     spec_end: usize,
+                                     replacement: &mut Option<String>,
+                                     copied: &mut usize| {
+        let spec = &text[spec_start..spec_end];
+        if let Some(rewrite) = compute_rewrite(spec, opts) {
+            let out = replacement.get_or_insert_with(|| String::with_capacity(text.len()));
+            out.push_str(&text[*copied..spec_start]);
+            out.push_str(&rewrite);
+            edits.push(TextEdit {
+                start: spec_start as u32,
+                end: spec_end as u32,
+                replacement_len: rewrite.len() as u32,
+                replacement_utf16_len: rewrite.encode_utf16().count() as u32,
+            });
+            *copied = spec_end;
+        }
+    };
 
     while i < len {
         let b = bytes[i];
@@ -187,7 +187,7 @@ pub(crate) fn rewrite_external_specifiers_in_text(
                     while spec_end < len && bytes[spec_end] != q {
                         spec_end += 1;
                     }
-                    try_rewrite_specifier(spec_start, spec_end, &mut out, &mut copied);
+                    try_rewrite_specifier(spec_start, spec_end, &mut replacement, &mut copied);
                     i = spec_end + 1;
                     continue;
                 }
@@ -213,7 +213,7 @@ pub(crate) fn rewrite_external_specifiers_in_text(
                         while spec_end < len && bytes[spec_end] != q {
                             spec_end += 1;
                         }
-                        try_rewrite_specifier(spec_start, spec_end, &mut out, &mut copied);
+                        try_rewrite_specifier(spec_start, spec_end, &mut replacement, &mut copied);
                         i = spec_end + 1;
                         continue;
                     }
@@ -223,8 +223,56 @@ pub(crate) fn rewrite_external_specifiers_in_text(
 
         i += 1;
     }
-    if copied < text.len() {
+    if let Some(out) = &mut replacement {
         out.push_str(&text[copied..]);
     }
-    TextRewrite { code: out, edits }
+    TextRewrite { replacement, edits }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn rewrite_options() -> RewriteExternalImportsOptions {
+        RewriteExternalImportsOptions {
+            source_path: "/workspace/src/App.svelte".to_string(),
+            generated_path: "/workspace/.generated/nested/App.svelte.tsx".to_string(),
+            workspace_path: "/workspace".to_string(),
+        }
+    }
+
+    #[test]
+    fn no_op_reuses_the_callers_large_buffer() {
+        let mut text = "const untouched = 1;\n".repeat(65_536);
+        text.push_str("import local from './local.js';\nconst lazy = import('../shared.js');\n");
+        let original_ptr = text.as_ptr();
+        let original_capacity = text.capacity();
+        let rewrite = rewrite_external_specifiers_in_text(&text, &rewrite_options());
+
+        assert!(rewrite.replacement.is_none());
+        assert!(rewrite.edits.is_empty());
+        let output = rewrite.replacement.unwrap_or(text);
+        assert_eq!(output.as_ptr(), original_ptr);
+        assert_eq!(output.capacity(), original_capacity);
+    }
+
+    #[test]
+    fn creates_replacement_and_utf16_aware_edits_when_needed() {
+        let text = "const emoji = '😀';\nimport value from \"../../outside/😀.js?raw#asset\";\n";
+        let original = "../../outside/😀.js?raw#asset";
+        let rewritten = "../../../outside/😀.js?raw#asset";
+        let rewrite = rewrite_external_specifiers_in_text(text, &rewrite_options());
+        let expected = text.replacen(original, rewritten, 1);
+
+        assert_eq!(rewrite.replacement.as_deref(), Some(expected.as_str()));
+        assert_eq!(
+            rewrite.edits,
+            vec![TextEdit {
+                start: text.find(original).unwrap() as u32,
+                end: (text.find(original).unwrap() + original.len()) as u32,
+                replacement_len: rewritten.len() as u32,
+                replacement_utf16_len: rewritten.encode_utf16().count() as u32,
+            }]
+        );
+    }
 }

--- a/crates/rsvelte_projection/src/svelte2tsx/svelte2tsx.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/svelte2tsx.rs
@@ -46,37 +46,59 @@ struct PositionedTextEdit {
     end_col: u32,
 }
 
-fn generated_location(text: &str, offset: u32) -> Result<(u32, u32), String> {
+fn generated_offset(text: &str, offset: u32) -> Result<usize, String> {
     let offset = offset as usize;
     if offset > text.len() || !text.is_char_boundary(offset) {
         return Err(format!(
             "external-import rewrite offset {offset} is not a generated-text boundary"
         ));
     }
-    let prefix = &text[..offset];
-    let line = prefix.bytes().filter(|byte| *byte == b'\n').count() as u32;
-    let line_start = prefix.rfind('\n').map_or(0, |index| index + 1);
-    let column = text[line_start..offset].encode_utf16().count() as u32;
-    Ok((line, column))
+    Ok(offset)
+}
+
+fn advance_generated_location(text: &str, line: &mut u32, column: &mut u32) {
+    for character in text.chars() {
+        if character == '\n' {
+            *line += 1;
+            *column = 0;
+        } else {
+            *column += character.len_utf16() as u32;
+        }
+    }
 }
 
 fn position_text_edits(code: &str, edits: &[TextEdit]) -> Result<Vec<PositionedTextEdit>, String> {
-    edits
-        .iter()
-        .map(|&raw| {
-            let (line, start_col) = generated_location(code, raw.start)?;
-            let (end_line, end_col) = generated_location(code, raw.end)?;
-            if line != end_line {
-                return Err("external-import rewrite unexpectedly spans lines".to_string());
-            }
-            Ok(PositionedTextEdit {
-                raw,
-                line,
-                start_col,
-                end_col,
-            })
-        })
-        .collect()
+    let mut positioned = Vec::with_capacity(edits.len());
+    let mut cursor = 0;
+    let mut line = 0;
+    let mut column = 0;
+
+    for &raw in edits {
+        let start = generated_offset(code, raw.start)?;
+        let end = generated_offset(code, raw.end)?;
+        if start < cursor || end < start {
+            return Err(
+                "external-import rewrite edits are not ordered and non-overlapping".to_string(),
+            );
+        }
+
+        advance_generated_location(&code[cursor..start], &mut line, &mut column);
+        let edit_line = line;
+        let start_col = column;
+        advance_generated_location(&code[start..end], &mut line, &mut column);
+        if line != edit_line {
+            return Err("external-import rewrite unexpectedly spans lines".to_string());
+        }
+        positioned.push(PositionedTextEdit {
+            raw,
+            line: edit_line,
+            start_col,
+            end_col: column,
+        });
+        cursor = end;
+    }
+
+    Ok(positioned)
 }
 
 fn remap_generated_column(line: u32, column: u32, edits: &[PositionedTextEdit]) -> Option<u32> {
@@ -694,7 +716,100 @@ fn validation_markers(source: &str) -> (bool, bool) {
 
 #[cfg(test)]
 mod tests {
-    use super::validation_markers;
+    use super::*;
+
+    fn edit(start: usize, end: usize) -> TextEdit {
+        TextEdit {
+            start: start as u32,
+            end: end as u32,
+            replacement_len: 0,
+            replacement_utf16_len: 0,
+        }
+    }
+
+    #[test]
+    fn positions_edits_in_utf16_columns() {
+        let code = "a😀𐐷e\u{301}z";
+        let start = code.find('😀').unwrap();
+        let end = code.find('z').unwrap();
+        let positioned = position_text_edits(code, &[edit(start, end)]).unwrap();
+
+        assert_eq!(positioned.len(), 1);
+        assert_eq!(positioned[0].line, 0);
+        assert_eq!(positioned[0].start_col, 1);
+        assert_eq!(positioned[0].end_col, 7);
+    }
+
+    #[test]
+    fn positions_multiple_edits_on_the_same_line() {
+        let positioned = position_text_edits("0123456789", &[edit(1, 3), edit(5, 8)]).unwrap();
+
+        assert_eq!(
+            positioned
+                .iter()
+                .map(|edit| (edit.line, edit.start_col, edit.end_col))
+                .collect::<Vec<_>>(),
+            vec![(0, 1, 3), (0, 5, 8)]
+        );
+    }
+
+    #[test]
+    fn only_line_feeds_advance_the_line() {
+        let positioned = position_text_edits("a\rb\r\nc", &[edit(2, 4), edit(5, 6)]).unwrap();
+
+        assert_eq!(
+            positioned
+                .iter()
+                .map(|edit| (edit.line, edit.start_col, edit.end_col))
+                .collect::<Vec<_>>(),
+            vec![(0, 2, 4), (1, 0, 1)]
+        );
+    }
+
+    #[test]
+    fn rejects_edits_that_cross_line_feeds() {
+        assert_eq!(
+            position_text_edits("a\nb", &[edit(1, 3)]).unwrap_err(),
+            "external-import rewrite unexpectedly spans lines"
+        );
+    }
+
+    #[test]
+    fn rejects_non_utf8_boundaries() {
+        assert_eq!(
+            position_text_edits("a😀b", &[edit(2, 5)]).unwrap_err(),
+            "external-import rewrite offset 2 is not a generated-text boundary"
+        );
+        assert_eq!(
+            position_text_edits("a😀b", &[edit(1, 4)]).unwrap_err(),
+            "external-import rewrite offset 4 is not a generated-text boundary"
+        );
+    }
+
+    #[test]
+    fn rejects_out_of_range_offsets() {
+        assert_eq!(
+            position_text_edits("abc", &[edit(1, 4)]).unwrap_err(),
+            "external-import rewrite offset 4 is not a generated-text boundary"
+        );
+    }
+
+    #[test]
+    fn rejects_edits_that_violate_scanner_ordering() {
+        let expected = "external-import rewrite edits are not ordered and non-overlapping";
+        assert_eq!(
+            position_text_edits("abcdef", &[edit(4, 5), edit(2, 3)]).unwrap_err(),
+            expected
+        );
+        assert_eq!(
+            position_text_edits("abcdef", &[edit(1, 4), edit(3, 5)]).unwrap_err(),
+            expected
+        );
+        assert_eq!(
+            position_text_edits("abcdef", &[edit(4, 2)]).unwrap_err(),
+            expected
+        );
+    }
 
     #[test]
     fn validation_markers_remain_set_after_unrelated_candidates() {

--- a/crates/rsvelte_projection/src/svelte2tsx/svelte2tsx.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/svelte2tsx.rs
@@ -101,6 +101,7 @@ fn position_text_edits(code: &str, edits: &[TextEdit]) -> Result<Vec<PositionedT
     Ok(positioned)
 }
 
+#[cfg(test)]
 fn remap_generated_column(line: u32, column: u32, edits: &[PositionedTextEdit]) -> Option<u32> {
     let mut remapped = i64::from(column);
     for edit in edits.iter().filter(|edit| edit.line == line) {
@@ -115,11 +116,83 @@ fn remap_generated_column(line: u32, column: u32, edits: &[PositionedTextEdit]) 
     u32::try_from(remapped).ok()
 }
 
+struct GeneratedColumnRemapper<'a> {
+    edits: &'a [PositionedTextEdit],
+    next_edit: usize,
+    line: Option<u32>,
+    delta: i64,
+}
+
+impl<'a> GeneratedColumnRemapper<'a> {
+    fn new(edits: &'a [PositionedTextEdit]) -> Self {
+        Self {
+            edits,
+            next_edit: 0,
+            line: None,
+            delta: 0,
+        }
+    }
+
+    fn remap(&mut self, line: u32, column: u32) -> Option<u32> {
+        if self.line != Some(line) {
+            self.line = Some(line);
+            self.delta = 0;
+            while self
+                .edits
+                .get(self.next_edit)
+                .is_some_and(|edit| edit.line < line)
+            {
+                self.next_edit += 1;
+            }
+        }
+
+        while let Some(edit) = self.edits.get(self.next_edit) {
+            if edit.line != line || edit.end_col > column {
+                break;
+            }
+            self.delta += i64::from(edit.raw.replacement_utf16_len)
+                - i64::from(edit.end_col - edit.start_col);
+            self.next_edit += 1;
+        }
+
+        if self.edits.get(self.next_edit).is_some_and(|edit| {
+            edit.line == line && column >= edit.start_col && column < edit.end_col
+        }) {
+            return None;
+        }
+
+        u32::try_from(i64::from(column) + self.delta).ok()
+    }
+}
+
+struct GeneratedAnchorRemapper<'a> {
+    columns: GeneratedColumnRemapper<'a>,
+}
+
+impl<'a> GeneratedAnchorRemapper<'a> {
+    fn new(edits: &'a [PositionedTextEdit]) -> Self {
+        Self {
+            columns: GeneratedColumnRemapper::new(edits),
+        }
+    }
+
+    fn remap(&mut self, edit: &PositionedTextEdit) -> Option<u32> {
+        self.columns
+            .remap(edit.line, edit.end_col)
+            .and_then(|end| end.checked_sub(edit.raw.replacement_utf16_len))
+    }
+}
+
 fn remap_source_map(source_map: &str, code: &str, edits: &[TextEdit]) -> Result<String, String> {
     if edits.is_empty() {
         return Ok(source_map.to_string());
     }
     let positioned = position_text_edits(code, edits)?;
+    debug_assert!(
+        positioned
+            .windows(2)
+            .all(|pair| (pair[0].line, pair[0].end_col) <= (pair[1].line, pair[1].start_col))
+    );
     let original = sourcemap::SourceMap::from_slice(source_map.as_bytes())
         .map_err(|error| format!("failed to decode generated source map: {error}"))?;
     let mut builder = SourceMapBuilder::new(original.get_file());
@@ -136,10 +209,9 @@ fn remap_source_map(source_map: &str, code: &str, edits: &[TextEdit]) -> Result<
         }
     }
 
+    let mut remapper = GeneratedColumnRemapper::new(&positioned);
     for token in original.tokens() {
-        let Some(dst_col) =
-            remap_generated_column(token.get_dst_line(), token.get_dst_col(), &positioned)
-        else {
+        let Some(dst_col) = remapper.remap(token.get_dst_line(), token.get_dst_col()) else {
             continue;
         };
         builder.add(
@@ -156,13 +228,12 @@ fn remap_source_map(source_map: &str, code: &str, edits: &[TextEdit]) -> Result<
     // Replacement text is not byte-exact source, but diagnostics inside a
     // rewritten specifier still belong to the original specifier. Anchor each
     // replacement start to the source token that covered the old start.
+    let mut anchor_remapper = GeneratedAnchorRemapper::new(&positioned);
     for edit in &positioned {
-        let Some(source_token) = original.lookup_token(edit.line, edit.start_col) else {
+        let Some(dst_col) = anchor_remapper.remap(edit) else {
             continue;
         };
-        let Some(dst_col) = remap_generated_column(edit.line, edit.end_col, &positioned)
-            .and_then(|end| end.checked_sub(edit.raw.replacement_utf16_len))
-        else {
+        let Some(source_token) = original.lookup_token(edit.line, edit.start_col) else {
             continue;
         };
         builder.add(
@@ -715,8 +786,50 @@ fn validation_markers(source: &str) -> (bool, bool) {
 }
 
 #[cfg(test)]
-mod tests {
+mod source_map_remap_tests {
     use super::*;
+
+    fn positioned_edit(
+        line: u32,
+        start_col: u32,
+        end_col: u32,
+        replacement_utf16_len: u32,
+    ) -> PositionedTextEdit {
+        PositionedTextEdit {
+            raw: TextEdit {
+                start: 0,
+                end: 0,
+                replacement_len: replacement_utf16_len,
+                replacement_utf16_len,
+            },
+            line,
+            start_col,
+            end_col,
+        }
+    }
+
+    fn assert_sweep_matches_oracle(edits: &[PositionedTextEdit]) {
+        let mut remapper = GeneratedColumnRemapper::new(edits);
+        for line in 0..=3 {
+            for column in 0..=9 {
+                assert_eq!(
+                    remapper.remap(line, column),
+                    remap_generated_column(line, column, edits),
+                    "line {line}, column {column}, edits {edits:?}"
+                );
+            }
+        }
+
+        let mut anchor_remapper = GeneratedAnchorRemapper::new(edits);
+        for edit in edits {
+            assert_eq!(
+                anchor_remapper.remap(edit),
+                remap_generated_column(edit.line, edit.end_col, edits)
+                    .and_then(|end| end.checked_sub(edit.raw.replacement_utf16_len)),
+                "anchor edit {edit:?}, edits {edits:?}"
+            );
+        }
+    }
 
     fn edit(start: usize, end: usize) -> TextEdit {
         TextEdit {
@@ -818,5 +931,299 @@ mod tests {
             validation_markers("<div><svelte:window /></div>:"),
             (false, true)
         );
+    }
+
+    #[test]
+    fn generated_column_sweep_matches_oracle_exhaustively() {
+        assert_sweep_matches_oracle(&[]);
+
+        for line in 0..=2 {
+            for start in 0..=5 {
+                for end in start + 1..=7 {
+                    for replacement in 0..=5 {
+                        assert_sweep_matches_oracle(&[positioned_edit(
+                            line,
+                            start,
+                            end,
+                            replacement,
+                        )]);
+                    }
+                }
+            }
+        }
+
+        for first_start in 0..=3 {
+            for first_end in first_start + 1..=5 {
+                for second_start in first_end..=6 {
+                    for second_end in second_start + 1..=7 {
+                        for first_replacement in 0..=3 {
+                            for second_replacement in 0..=3 {
+                                assert_sweep_matches_oracle(&[
+                                    positioned_edit(1, first_start, first_end, first_replacement),
+                                    positioned_edit(
+                                        1,
+                                        second_start,
+                                        second_end,
+                                        second_replacement,
+                                    ),
+                                ]);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        for replacement in 0..=5 {
+            assert_sweep_matches_oracle(&[
+                positioned_edit(0, 1, 4, replacement),
+                positioned_edit(0, 5, 7, 5 - replacement),
+                positioned_edit(2, 0, 2, replacement),
+            ]);
+        }
+    }
+
+    #[test]
+    fn generated_column_sweep_preserves_edit_start_and_end() {
+        let edits = [positioned_edit(0, 2, 5, 1)];
+        let mut remapper = GeneratedColumnRemapper::new(&edits);
+
+        let start = remapper.remap(0, 2);
+        assert_eq!(start, remap_generated_column(0, 2, &edits));
+        assert_eq!(start, None);
+
+        let end = remapper.remap(0, 5);
+        assert_eq!(end, remap_generated_column(0, 5, &edits));
+        assert_eq!(end, Some(3));
+    }
+
+    #[test]
+    fn generated_column_sweep_preserves_u32_boundaries() {
+        let edits = [positioned_edit(0, 0, 1, u32::MAX)];
+        let mut remapper = GeneratedColumnRemapper::new(&edits);
+
+        assert_eq!(remapper.remap(0, 0), None);
+        assert_eq!(remapper.remap(0, 1), Some(u32::MAX));
+        assert_eq!(remapper.remap(0, 2), None);
+
+        let edits = [positioned_edit(0, 0, u32::MAX, 0)];
+        let mut remapper = GeneratedColumnRemapper::new(&edits);
+
+        assert_eq!(remapper.remap(0, 0), None);
+        assert_eq!(remapper.remap(0, u32::MAX), Some(0));
+
+        let edits = [positioned_edit(0, 1, 2, u32::MAX)];
+        let mut anchor_remapper = GeneratedAnchorRemapper::new(&edits);
+        let anchor = anchor_remapper.remap(&edits[0]);
+        assert_eq!(
+            anchor,
+            remap_generated_column(0, 2, &edits).and_then(|end| end.checked_sub(u32::MAX))
+        );
+        assert_eq!(anchor, None);
+    }
+
+    fn encoded_source_map(builder: SourceMapBuilder) -> String {
+        let mut encoded = Vec::new();
+        builder.into_sourcemap().to_writer(&mut encoded).unwrap();
+        String::from_utf8(encoded).unwrap()
+    }
+
+    #[test]
+    fn source_map_anchor_preserves_intermediate_overflow() {
+        let mut original = SourceMapBuilder::new(None);
+        original.add(0, 1, 0, 1, Some("component.svelte"), Some("anchor"), false);
+        let edits = [TextEdit {
+            start: 1,
+            end: 2,
+            replacement_len: u32::MAX,
+            replacement_utf16_len: u32::MAX,
+        }];
+
+        let remapped = remap_source_map(&encoded_source_map(original), "ab", &edits).unwrap();
+        let remapped = sourcemap::SourceMap::from_slice(remapped.as_bytes()).unwrap();
+
+        assert_eq!(remapped.get_token_count(), 0);
+    }
+
+    #[test]
+    fn source_map_sweep_preserves_tokens_anchors_and_metadata() {
+        let code = "a😀bcdef\nuvwxyz";
+        let edits = [
+            TextEdit {
+                start: 1,
+                end: 6,
+                replacement_len: 1,
+                replacement_utf16_len: 1,
+            },
+            TextEdit {
+                start: 7,
+                end: 9,
+                replacement_len: 4,
+                replacement_utf16_len: 4,
+            },
+            TextEdit {
+                start: 12,
+                end: 14,
+                replacement_len: 0,
+                replacement_utf16_len: 0,
+            },
+        ];
+
+        let mut original = SourceMapBuilder::new(Some("generated.tsx"));
+        let source_id = original.add_source("component.svelte");
+        original.set_source_contents(source_id, Some("<p>source</p>"));
+        let ignored_id = original.add_source("ignored.js");
+        original.set_source_contents(ignored_id, Some("ignored"));
+        original.add_to_ignore_list(ignored_id);
+
+        original.add(0, 0, 0, 0, Some("component.svelte"), Some("before"), false);
+        original.add(
+            0,
+            1,
+            10,
+            20,
+            Some("component.svelte"),
+            Some("first_anchor"),
+            true,
+        );
+        original.add(
+            0,
+            2,
+            11,
+            21,
+            Some("component.svelte"),
+            Some("deleted"),
+            false,
+        );
+        original.add(
+            0,
+            4,
+            12,
+            22,
+            Some("component.svelte"),
+            Some("after_first"),
+            false,
+        );
+        original.add(
+            0,
+            5,
+            13,
+            23,
+            Some("ignored.js"),
+            Some("second_anchor"),
+            false,
+        );
+        original.add(
+            0,
+            7,
+            14,
+            24,
+            Some("component.svelte"),
+            Some("after_second"),
+            true,
+        );
+        original.add(
+            1,
+            0,
+            20,
+            30,
+            Some("component.svelte"),
+            Some("next_line"),
+            false,
+        );
+        original.add(
+            1,
+            1,
+            21,
+            31,
+            Some("component.svelte"),
+            Some("empty_anchor"),
+            false,
+        );
+        original.add(
+            1,
+            3,
+            22,
+            32,
+            Some("component.svelte"),
+            Some("after_empty"),
+            false,
+        );
+        original.add(2, 0, 0, 0, None, None, false);
+
+        let remapped = remap_source_map(&encoded_source_map(original), code, &edits).unwrap();
+        let remapped = sourcemap::SourceMap::from_slice(remapped.as_bytes()).unwrap();
+
+        assert_eq!(remapped.get_file(), Some("generated.tsx"));
+        assert_eq!(remapped.get_source_count(), 2);
+        assert_eq!(remapped.get_source(0), Some("component.svelte"));
+        assert_eq!(remapped.get_source_contents(0), Some("<p>source</p>"));
+        assert_eq!(remapped.get_source(1), Some("ignored.js"));
+        assert_eq!(remapped.get_source_contents(1), Some("ignored"));
+        assert_eq!(remapped.ignore_list().copied().collect::<Vec<_>>(), [1]);
+
+        let tokens = remapped.tokens().collect::<Vec<_>>();
+        let find = |name: &str| {
+            tokens
+                .iter()
+                .find(|token| token.get_name() == Some(name))
+                .copied()
+                .unwrap()
+        };
+
+        let first_anchor = find("first_anchor");
+        assert_eq!(
+            (first_anchor.get_dst_line(), first_anchor.get_dst_col()),
+            (0, 1)
+        );
+        assert_eq!(first_anchor.get_source(), Some("component.svelte"));
+        assert_eq!(
+            (first_anchor.get_src_line(), first_anchor.get_src_col()),
+            (10, 20)
+        );
+        assert!(first_anchor.is_range());
+        assert!(
+            !tokens
+                .iter()
+                .any(|token| token.get_name() == Some("deleted"))
+        );
+
+        let after_first = find("after_first");
+        assert_eq!(
+            (after_first.get_dst_line(), after_first.get_dst_col()),
+            (0, 2)
+        );
+
+        let second_anchor = find("second_anchor");
+        assert_eq!(
+            (second_anchor.get_dst_line(), second_anchor.get_dst_col()),
+            (0, 3)
+        );
+        assert_eq!(second_anchor.get_source(), Some("ignored.js"));
+
+        let after_second = find("after_second");
+        assert_eq!(
+            (after_second.get_dst_line(), after_second.get_dst_col()),
+            (0, 7)
+        );
+        assert!(after_second.is_range());
+
+        let empty_anchor = find("empty_anchor");
+        assert_eq!(
+            (empty_anchor.get_dst_line(), empty_anchor.get_dst_col()),
+            (1, 1)
+        );
+        let after_empty = find("after_empty");
+        assert_eq!(
+            (after_empty.get_dst_line(), after_empty.get_dst_col()),
+            (1, 1)
+        );
+
+        assert!(tokens.iter().any(|token| {
+            token.get_dst_line() == 2
+                && token.get_dst_col() == 0
+                && token.get_source().is_none()
+                && token.get_name().is_none()
+        }));
     }
 }

--- a/crates/rsvelte_projection/src/svelte2tsx/svelte2tsx.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/svelte2tsx.rs
@@ -256,7 +256,71 @@ fn remap_source_map(source_map: &str, code: &str, edits: &[TextEdit]) -> Result<
         .map_err(|error| format!("rewritten source map was not UTF-8: {error}"))
 }
 
-fn remap_generated_boundary(offset: u32, edits: &[TextEdit]) -> Option<u32> {
+fn remap_generated_boundary(offset: u32, byte_delta: i64) -> Option<u32> {
+    u32::try_from(i64::from(offset) + byte_delta).ok()
+}
+
+fn edit_byte_delta(edit: &TextEdit) -> i64 {
+    i64::from(edit.replacement_len) - i64::from(edit.end - edit.start)
+}
+
+fn remap_forward_segments(
+    segments: Vec<(u32, u32, u32)>,
+    edits: &[TextEdit],
+) -> Vec<(u32, u32, u32)> {
+    if edits.is_empty() {
+        return segments;
+    }
+    let mut remapped = Vec::with_capacity(segments.len());
+    let mut edit_cursor = 0;
+    let mut byte_delta = 0;
+
+    for (source_start, source_end, generated_start) in segments {
+        let generated_end = generated_start + source_end - source_start;
+        let mut cursor = generated_start;
+
+        while let Some(edit) = edits.get(edit_cursor) {
+            if edit.end > cursor {
+                break;
+            }
+            byte_delta += edit_byte_delta(edit);
+            edit_cursor += 1;
+        }
+
+        while let Some(edit) = edits.get(edit_cursor) {
+            if edit.start >= generated_end {
+                break;
+            }
+
+            let unchanged_end = edit.start.min(generated_end);
+            if cursor < unchanged_end {
+                let source_part_start = source_start + cursor - generated_start;
+                let source_part_end = source_start + unchanged_end - generated_start;
+                if let Some(post_start) = remap_generated_boundary(cursor, byte_delta) {
+                    remapped.push((source_part_start, source_part_end, post_start));
+                }
+            }
+
+            cursor = cursor.max(edit.end.min(generated_end));
+            if edit.end > generated_end {
+                break;
+            }
+            byte_delta += edit_byte_delta(edit);
+            edit_cursor += 1;
+        }
+
+        if cursor < generated_end {
+            let source_part_start = source_start + cursor - generated_start;
+            if let Some(post_start) = remap_generated_boundary(cursor, byte_delta) {
+                remapped.push((source_part_start, source_end, post_start));
+            }
+        }
+    }
+    remapped
+}
+
+#[cfg(test)]
+fn remap_generated_boundary_oracle(offset: u32, edits: &[TextEdit]) -> Option<u32> {
     let mut remapped = i64::from(offset);
     for edit in edits {
         if edit.end <= offset {
@@ -266,7 +330,8 @@ fn remap_generated_boundary(offset: u32, edits: &[TextEdit]) -> Option<u32> {
     u32::try_from(remapped).ok()
 }
 
-fn remap_forward_segments(
+#[cfg(test)]
+fn remap_forward_segments_oracle(
     segments: Vec<(u32, u32, u32)>,
     edits: &[TextEdit],
 ) -> Vec<(u32, u32, u32)> {
@@ -285,7 +350,7 @@ fn remap_forward_segments(
             if cursor < unchanged_end {
                 let source_part_start = source_start + cursor - generated_start;
                 let source_part_end = source_start + unchanged_end - generated_start;
-                if let Some(post_start) = remap_generated_boundary(cursor, edits) {
+                if let Some(post_start) = remap_generated_boundary_oracle(cursor, edits) {
                     remapped.push((source_part_start, source_part_end, post_start));
                 }
             }
@@ -293,7 +358,7 @@ fn remap_forward_segments(
         }
         if cursor < generated_end {
             let source_part_start = source_start + cursor - generated_start;
-            if let Some(post_start) = remap_generated_boundary(cursor, edits) {
+            if let Some(post_start) = remap_generated_boundary_oracle(cursor, edits) {
                 remapped.push((source_part_start, source_end, post_start));
             }
         }
@@ -1225,5 +1290,181 @@ mod source_map_remap_tests {
                 && token.get_source().is_none()
                 && token.get_name().is_none()
         }));
+    }
+}
+
+#[cfg(test)]
+mod forward_map_rewrite_tests {
+    use super::*;
+
+    fn edit(start: u32, end: u32, replacement_len: u32) -> TextEdit {
+        TextEdit {
+            start,
+            end,
+            replacement_len,
+            replacement_utf16_len: replacement_len,
+        }
+    }
+
+    fn interval_layouts(limit: u32) -> Vec<Vec<(u32, u32)>> {
+        fn extend(
+            minimum_start: u32,
+            limit: u32,
+            current: &mut Vec<(u32, u32)>,
+            layouts: &mut Vec<Vec<(u32, u32)>>,
+        ) {
+            layouts.push(current.clone());
+            for start in minimum_start..limit {
+                for end in start + 1..=limit {
+                    current.push((start, end));
+                    extend(end, limit, current, layouts);
+                    current.pop();
+                }
+            }
+        }
+
+        let mut layouts = Vec::new();
+        extend(0, limit, &mut Vec::new(), &mut layouts);
+        layouts
+    }
+
+    fn forward_segments(layout: &[(u32, u32)]) -> Vec<(u32, u32, u32)> {
+        layout
+            .iter()
+            .enumerate()
+            .map(|(index, &(generated_start, generated_end))| {
+                let source_start = 500 + (layout.len() - index) as u32 * 20;
+                (
+                    source_start,
+                    source_start + generated_end - generated_start,
+                    generated_start,
+                )
+            })
+            .collect()
+    }
+
+    fn edit_variants(layout: &[(u32, u32)]) -> Vec<Vec<TextEdit>> {
+        fn extend(
+            layout: &[(u32, u32)],
+            index: usize,
+            current: &mut Vec<TextEdit>,
+            variants: &mut Vec<Vec<TextEdit>>,
+        ) {
+            let Some(&(start, end)) = layout.get(index) else {
+                variants.push(current.clone());
+                return;
+            };
+            let old_len = end - start;
+            let mut replacement_lengths = Vec::with_capacity(4);
+            for replacement_len in [0, 1, old_len, old_len + 2] {
+                if !replacement_lengths.contains(&replacement_len) {
+                    replacement_lengths.push(replacement_len);
+                }
+            }
+            for replacement_len in replacement_lengths {
+                current.push(edit(start, end, replacement_len));
+                extend(layout, index + 1, current, variants);
+                current.pop();
+            }
+        }
+
+        let mut variants = Vec::new();
+        extend(layout, 0, &mut Vec::new(), &mut variants);
+        variants
+    }
+
+    fn next_random(state: &mut u64) -> u32 {
+        *state = state
+            .wrapping_mul(6_364_136_223_846_793_005)
+            .wrapping_add(1_442_695_040_888_963_407);
+        (*state >> 32) as u32
+    }
+
+    fn random_intervals(state: &mut u64, limit: u32) -> Vec<(u32, u32)> {
+        let mut intervals = Vec::new();
+        let mut cursor = next_random(state) % 5;
+        while cursor < limit && intervals.len() < 24 {
+            let remaining = limit - cursor;
+            let len = 1 + next_random(state) % remaining.min(12);
+            let end = cursor + len;
+            intervals.push((cursor, end));
+            cursor = end.saturating_add(next_random(state) % 5);
+        }
+        intervals
+    }
+
+    #[test]
+    fn preserves_boundaries_when_an_edit_crosses_segments_and_gaps() {
+        let segments = vec![(100, 104, 0), (200, 204, 6), (300, 304, 12)];
+        let edits = vec![edit(2, 14, 3)];
+
+        assert_eq!(
+            remap_forward_segments(segments, &edits),
+            vec![(100, 102, 0), (302, 304, 5)]
+        );
+    }
+
+    #[test]
+    fn handles_zero_length_edits_at_equal_boundaries() {
+        let segments = vec![(10, 15, 5), (20, 22, 10)];
+        let edits = vec![edit(5, 5, 3), edit(7, 7, 0), edit(10, 10, 2)];
+
+        assert_eq!(
+            remap_forward_segments(segments, &edits),
+            vec![(10, 12, 8), (12, 15, 10), (20, 22, 15)]
+        );
+    }
+
+    #[test]
+    fn zero_length_segments_and_edits_match_the_oracle() {
+        let segments = vec![(10, 10, 5), (20, 22, 5), (30, 30, 7)];
+        let edits = vec![edit(5, 5, 3), edit(7, 7, 2)];
+
+        assert_eq!(
+            remap_forward_segments(segments.clone(), &edits),
+            vec![(20, 22, 8)]
+        );
+        assert_eq!(
+            remap_forward_segments(segments.clone(), &edits),
+            remap_forward_segments_oracle(segments, &edits)
+        );
+    }
+
+    #[test]
+    fn exhaustive_small_interval_layouts_match_the_oracle() {
+        let layouts = interval_layouts(5);
+        for segment_layout in &layouts {
+            let segments = forward_segments(segment_layout);
+            for edit_layout in &layouts {
+                for edits in edit_variants(edit_layout) {
+                    assert_eq!(
+                        remap_forward_segments(segments.clone(), &edits),
+                        remap_forward_segments_oracle(segments.clone(), &edits),
+                        "segments={segments:?}, edits={edits:?}"
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn deterministic_generated_order_cases_match_the_oracle() {
+        let mut state = 0x5eed_f04d_cafe_babe;
+        for _ in 0..8_192 {
+            let limit = 10 + next_random(&mut state) % 240;
+            let segment_layout = random_intervals(&mut state, limit);
+            let segments = forward_segments(&segment_layout);
+            let edit_layout = random_intervals(&mut state, limit);
+            let edits: Vec<_> = edit_layout
+                .into_iter()
+                .map(|(start, end)| edit(start, end, next_random(&mut state) % 32))
+                .collect();
+
+            assert_eq!(
+                remap_forward_segments(segments.clone(), &edits),
+                remap_forward_segments_oracle(segments.clone(), &edits),
+                "segments={segments:?}, edits={edits:?}"
+            );
+        }
     }
 }

--- a/crates/rsvelte_projection/src/svelte2tsx/svelte2tsx.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/svelte2tsx.rs
@@ -641,10 +641,14 @@ pub fn svelte2tsx(
     let (code, source_map, forward_map) =
         if let Some(ref rewrite_opts) = options.rewrite_external_imports {
             let rewrite = rewrite_external_specifiers_in_text(&code, rewrite_opts);
-            let remapped_source_map = remap_source_map(&source_map, &code, &rewrite.edits)
-                .map_err(Svelte2TsxError::Other)?;
-            let remapped_forward_map = remap_forward_segments(forward_map, &rewrite.edits);
-            (rewrite.code, remapped_source_map, remapped_forward_map)
+            if let Some(rewritten_code) = rewrite.replacement {
+                let remapped_source_map = remap_source_map(&source_map, &code, &rewrite.edits)
+                    .map_err(Svelte2TsxError::Other)?;
+                let remapped_forward_map = remap_forward_segments(forward_map, &rewrite.edits);
+                (rewritten_code, remapped_source_map, remapped_forward_map)
+            } else {
+                (code, source_map, forward_map)
+            }
         } else {
             (code, source_map, forward_map)
         };

--- a/crates/rsvelte_projection/tests/projection_api.rs
+++ b/crates/rsvelte_projection/tests/projection_api.rs
@@ -74,7 +74,8 @@ fn projection_has_bidirectional_exact_byte_mappings_and_frozen_facts() {
 
 #[test]
 fn projection_preserves_mappings_across_external_import_rewrites() {
-    let source = r#"<script>import x from "../../outside.js";</script><p>{x}</p>"#;
+    let source =
+        r#"<script>const emoji = "😀"; import x from "../../outside/😀.js";</script><p>{x}</p>"#;
     let projection = ProjectionEngine::new()
         .project(
             source,
@@ -89,7 +90,7 @@ fn projection_preserves_mappings_across_external_import_rewrites() {
         )
         .expect("project component");
 
-    assert!(projection.code.contains("../../../outside.js"));
+    assert!(projection.code.contains("../../../outside/😀.js"));
     let mappings = projection
         .exact_mappings
         .as_ref()
@@ -101,7 +102,7 @@ fn projection_preserves_mappings_across_external_import_rewrites() {
         &projection.code[offset as usize..offset as usize + 1] == "x"
             && mappings.generated_to_source(offset) == Some(source_x)
     }));
-    let rewritten_specifier = projection.code.find("../../../outside.js").unwrap() as u32;
+    let rewritten_specifier = projection.code.find("../../../outside/😀.js").unwrap() as u32;
     assert_eq!(
         mappings.generated_to_source(rewritten_specifier),
         None,
@@ -127,6 +128,29 @@ fn projection_preserves_mappings_across_external_import_rewrites() {
     assert!(raw.map.is_some());
     assert!(!raw.forward_map.is_empty());
     assert!(raw.map_offset_forward(source_x).is_some());
+}
+
+#[test]
+fn no_op_external_import_rewrite_preserves_projection_output() {
+    let source = r#"<script>import x from "../shared.js";</script><p>{x}</p>"#;
+    let baseline = rsvelte_projection::svelte2tsx::svelte2tsx(source, Svelte2TsxOptions::default())
+        .expect("baseline projection");
+    let with_rewrite = rsvelte_projection::svelte2tsx::svelte2tsx(
+        source,
+        Svelte2TsxOptions {
+            rewrite_external_imports: Some(RewriteExternalImportsOptions {
+                source_path: "/workspace/src/App.svelte".to_string(),
+                generated_path: "/workspace/.generated/nested/App.svelte.tsx".to_string(),
+                workspace_path: "/workspace".to_string(),
+            }),
+            ..Default::default()
+        },
+    )
+    .expect("projection with no-op rewrite");
+
+    assert_eq!(with_rewrite.code, baseline.code);
+    assert_eq!(with_rewrite.map, baseline.map);
+    assert_eq!(with_rewrite.forward_map, baseline.forward_map);
 }
 
 #[test]


### PR DESCRIPTION
> Stack 5/8  
> Base: `agent/svelte2tsx-release-04-events-exports` (`8dbc1875`)  
> Head: `agent/svelte2tsx-release-05-rewrite-maps` (`4eb5e300`)

## Summary

- return existing owned buffers unchanged when external imports need no rewrite
- position edits with one generated-code sweep
- remap source-map tokens and forward-map segments with ordered cursors
- normalize paths and prepare the shared external-import target prefix once

This changes rewrite work from repeated edit scans to linear or
linear-plus-token-lookup passes while preserving UTF-16 columns, replacement
anchors, source metadata, split source ranges, POSIX path behavior, queries,
fragments, and edit order.

## Commit scope

- `c00127e5` perf(svelte2tsx): reuse code when imports stay unchanged
- `0eb343bb` perf(svelte2tsx): position rewrite edits in one sweep
- `b128c8aa` perf(svelte2tsx): sweep source map rewrite edits
- `8a26b5f9` perf(svelte2tsx): sweep forward map rewrite edits
- `4eb5e300` perf(svelte2tsx): prepare external import paths once

## Validation

- [ ] `cargo fmt --check`
- [ ] `cargo clippy -p rsvelte_projection --all-targets --all-features -- -D warnings`
- [ ] `cargo test -p rsvelte_projection --test projection_api`
- [ ] `cargo test -p rsvelte_projection --test svelte2tsx_forward_map`
- [ ] `cargo test -p rsvelte_projection --test svelte2tsx_fixtures`
- [ ] `cargo test -p rsvelte_projection`

## Stack order

Merge after PR 4. PR 6 is based on this head.
