### PR TITLE
Build Linux svelte-check releases with validated PGO

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,7 +96,7 @@ jobs:
           - { os: ubuntu-latest, target: aarch64-unknown-linux-gnu, triple: linux-arm64-gnu, ext: '', apt: gcc-aarch64-linux-gnu, linker: aarch64-linux-gnu-gcc }
           - { os: windows-latest, target: x86_64-pc-windows-msvc, triple: win32-x64-msvc, ext: '.exe' }
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 30
+    timeout-minutes: ${{ matrix.triple == 'linux-x64-gnu' && 60 || 30 }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -117,11 +117,21 @@ jobs:
         with:
           key: ${{ matrix.target }}
 
+      - name: Install LLVM profile tools
+        if: matrix.triple == 'linux-x64-gnu'
+        run: rustup component add llvm-tools-preview
+
       - name: Build svelte-check
+        if: matrix.triple != 'linux-x64-gnu'
         shell: bash
         env:
           CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: ${{ matrix.linker }}
         run: cargo build --profile dist -p rsvelte_check --bin svelte_check --target ${{ matrix.target }}
+
+      - name: Build svelte-check with PGO
+        if: matrix.triple == 'linux-x64-gnu'
+        shell: bash
+        run: scripts/release/build-svelte-check-pgo.sh
 
       - name: Stage binary
         shell: bash

--- a/benches/corpus/09-typescript-generics.svelte
+++ b/benches/corpus/09-typescript-generics.svelte
@@ -1,0 +1,79 @@
+<script module lang="ts">
+	export type Row = {
+		id: string;
+		label: string;
+		active?: boolean;
+	};
+</script>
+
+<script lang="ts" generics="T extends Row">
+	type Props = {
+		rows: T[];
+		initial?: T | null;
+		onselect?: (row: T) => void;
+	};
+
+	let { rows, initial = null, onselect = () => {} }: Props = $props();
+	let query = $state('');
+	let selected = $state<T | null>(initial);
+	let visible = $derived(
+		rows.filter(
+			(row): row is T =>
+				row.active !== false && row.label.toLowerCase().includes(query.toLowerCase())
+		)
+	);
+
+	function choose(row: T) {
+		selected = row;
+		onselect(row);
+	}
+</script>
+
+{#snippet result(row: T, index: number)}
+	<button
+		class:selected={selected?.id === row.id}
+		aria-pressed={selected?.id === row.id}
+		onclick={() => choose(row)}
+	>
+		<span>{index + 1}. {row.label}</span>
+		<small>{row.id as string}</small>
+	</button>
+{/snippet}
+
+<section>
+	<label>
+		Filter
+		<input bind:value={query} />
+	</label>
+
+	{#if visible.length}
+		<div class="results">
+			{#each visible as row, index (row.id)}
+				{@render result(row, index)}
+			{/each}
+		</div>
+	{:else}
+		<p>No typed rows match.</p>
+	{/if}
+</section>
+
+<style>
+	section {
+		display: grid;
+		gap: 0.75rem;
+	}
+
+	.results {
+		display: grid;
+		gap: 0.25rem;
+	}
+
+	button {
+		display: flex;
+		justify-content: space-between;
+	}
+
+	button.selected {
+		font-weight: 700;
+	}
+</style>

--- a/benches/corpus/README.md
+++ b/benches/corpus/README.md
@@ -42,6 +42,7 @@ prefix so iteration order is deterministic.
 | `06-css-heavy.svelte`       | runes  | nested + `:global` CSS, keyframes, `class:`/`style:` directives |
 | `07-snippets.svelte`        | runes  | `{#snippet}` / `{@render}`, `{@const}`, snippet props |
 | `08-control-flow.svelte`    | runes  | `{#if}`/`{#each}`/`{#await}`/`{#key}` mix, `{@html}` |
+| `09-typescript-generics.svelte` | runes + TS | generic `$props`, typed snippets/callbacks, type assertions |
 
 Synthetic *scale* inputs (large, deterministic, generated in-code) live in the
 bench files themselves, not here — they're pure functions, so they're stable

--- a/scripts/release/build-svelte-check-pgo.sh
+++ b/scripts/release/build-svelte-check-pgo.sh
@@ -1,0 +1,194 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+export LC_ALL=C
+
+readonly TARGET="x86_64-unknown-linux-gnu"
+readonly PROFILE="dist"
+readonly TRAINING_PASSES="${PGO_TRAINING_PASSES:-3}"
+readonly TRAINING_REPLICAS="${PGO_TRAINING_REPLICAS:-64}"
+
+dry_run=false
+if [[ "${1:-}" == "--dry-run" ]]; then
+  dry_run=true
+  shift
+fi
+if (( $# != 0 )); then
+  echo "usage: $0 [--dry-run]" >&2
+  exit 2
+fi
+
+die() {
+  echo "build-svelte-check-pgo: $*" >&2
+  exit 1
+}
+
+is_positive_integer() {
+  [[ "$1" =~ ^[1-9][0-9]*$ ]]
+}
+
+is_positive_integer "$TRAINING_PASSES" || die "PGO_TRAINING_PASSES must be a positive integer"
+(( TRAINING_PASSES >= 2 )) || die "PGO_TRAINING_PASSES must be at least 2"
+is_positive_integer "$TRAINING_REPLICAS" || die "PGO_TRAINING_REPLICAS must be a positive integer"
+
+readonly SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+readonly REPO_ROOT="$(cd -- "$SCRIPT_DIR/../.." && pwd)"
+readonly CORPUS_DIR="$REPO_ROOT/benches/corpus"
+readonly OUTPUT_PATH="${PGO_OUTPUT_PATH:-$REPO_ROOT/target/$TARGET/$PROFILE/svelte_check}"
+
+[[ -d "$CORPUS_DIR" ]] || die "benchmark corpus is missing: $CORPUS_DIR"
+if [[ -n "${RUSTFLAGS:-}" || -n "${CARGO_ENCODED_RUSTFLAGS:-}" ]]; then
+  die "RUSTFLAGS and CARGO_ENCODED_RUSTFLAGS must be unset"
+fi
+
+if ! $dry_run; then
+  [[ "$(uname -s)" == "Linux" ]] || die "PGO release builds require Linux"
+  [[ "$(uname -m)" == "x86_64" ]] || die "PGO release builds require x86_64"
+fi
+
+readonly WORK_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/rsvelte-check-pgo.XXXXXXXX")"
+readonly GENERATE_TARGET_DIR="$WORK_ROOT/target-generate"
+readonly USE_TARGET_DIR="$WORK_ROOT/target-use"
+readonly PROFILE_DIR="$WORK_ROOT/profiles"
+readonly TRAINING_WORKSPACE="$WORK_ROOT/training-workspace"
+readonly MERGED_PROFILE="$WORK_ROOT/merged.profdata"
+readonly CORPUS_MANIFEST="$WORK_ROOT/corpus.sha256"
+
+cleanup() {
+  rm -rf -- "$WORK_ROOT"
+}
+trap cleanup EXIT
+
+mkdir -p "$GENERATE_TARGET_DIR" "$USE_TARGET_DIR" "$PROFILE_DIR" "$TRAINING_WORKSPACE"
+
+run() {
+  printf '+'
+  printf ' %q' "$@"
+  printf '\n'
+  if ! $dry_run; then
+    "$@"
+  fi
+}
+
+remove_work_dir() {
+  local path="$1"
+  [[ "$path" == "$WORK_ROOT/"* ]] || die "refusing to remove path outside PGO work root: $path"
+  run rm -rf -- "$path"
+}
+
+hash_file() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" | awk '{print $1}'
+  elif command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "$1" | awk '{print $1}'
+  else
+    die "sha256sum or shasum is required"
+  fi
+}
+
+shopt -s nullglob
+corpus_files=("$CORPUS_DIR"/*.svelte)
+shopt -u nullglob
+(( ${#corpus_files[@]} > 0 )) || die "benchmark corpus contains no .svelte files"
+
+for source in "${corpus_files[@]}"; do
+  printf '%s  %s\n' "$(hash_file "$source")" "$(basename -- "$source")" >> "$CORPUS_MANIFEST"
+done
+readonly CORPUS_HASH="$(hash_file "$CORPUS_MANIFEST")"
+
+for (( replica = 0; replica < TRAINING_REPLICAS; replica++ )); do
+  printf -v replica_dir '%s/replica-%04d' "$TRAINING_WORKSPACE" "$replica"
+  mkdir -p "$replica_dir"
+  cp "${corpus_files[@]}" "$replica_dir/"
+done
+readonly TRAINING_FILE_COUNT=$(( ${#corpus_files[@]} * TRAINING_REPLICAS ))
+
+readonly RUST_HOST="$(rustc -vV | sed -n 's/^host: //p')"
+readonly RUST_SYSROOT="$(rustc --print sysroot)"
+readonly LLVM_PROFDATA="$RUST_SYSROOT/lib/rustlib/$RUST_HOST/bin/llvm-profdata"
+if ! $dry_run; then
+  [[ "$RUST_HOST" == "$TARGET" ]] || die "Rust host must be $TARGET, got $RUST_HOST"
+  [[ -x "$LLVM_PROFDATA" ]] || die "llvm-profdata is missing; install llvm-tools-preview"
+fi
+
+readonly CARGO_BUILD=(
+  cargo build
+  --profile "$PROFILE"
+  -p rsvelte_check
+  --bin svelte_check
+  --target "$TARGET"
+)
+readonly GENERATE_FLAGS="-Cprofile-generate=$PROFILE_DIR"
+readonly USE_FLAGS="-Cprofile-use=$MERGED_PROFILE"$'\x1f'"-Cllvm-args=-pgo-warn-missing-function"
+readonly INSTRUMENTED_BINARY="$GENERATE_TARGET_DIR/$TARGET/$PROFILE/svelte_check"
+readonly OPTIMIZED_BINARY="$USE_TARGET_DIR/$TARGET/$PROFILE/svelte_check"
+
+cd "$REPO_ROOT"
+run env \
+  "CARGO_TARGET_DIR=$GENERATE_TARGET_DIR" \
+  "CARGO_ENCODED_RUSTFLAGS=$GENERATE_FLAGS" \
+  "${CARGO_BUILD[@]}"
+
+for (( pass = 1; pass <= TRAINING_PASSES; pass++ )); do
+  remove_work_dir "$TRAINING_WORKSPACE/.svelte-check"
+  if $dry_run; then
+    printf '+ LLVM_PROFILE_FILE=%q %q' "$PROFILE_DIR/svelte-check-%m-%p.profraw" "$INSTRUMENTED_BINARY"
+    printf ' %q' \
+      --workspace "$TRAINING_WORKSPACE" \
+      --emit-overlay \
+      --no-type-check \
+      --no-tsconfig \
+      --output machine
+    printf ' >/dev/null\n'
+  else
+    LLVM_PROFILE_FILE="$PROFILE_DIR/svelte-check-%m-%p.profraw" \
+      "$INSTRUMENTED_BINARY" \
+      --workspace "$TRAINING_WORKSPACE" \
+      --emit-overlay \
+      --no-type-check \
+      --no-tsconfig \
+      --output machine \
+      >/dev/null
+  fi
+done
+
+if $dry_run; then
+  profraw_files=("$PROFILE_DIR/svelte-check-<module>-<pid>.profraw")
+else
+  shopt -s nullglob
+  profraw_files=("$PROFILE_DIR"/*.profraw)
+  shopt -u nullglob
+  (( ${#profraw_files[@]} > 0 )) || die "instrumented training produced no .profraw files"
+fi
+
+run "$LLVM_PROFDATA" merge --output "$MERGED_PROFILE" "${profraw_files[@]}"
+remove_work_dir "$GENERATE_TARGET_DIR"
+if ! $dry_run && [[ -e "$GENERATE_TARGET_DIR" ]]; then
+  die "generation target was not removed before the profile-use build"
+fi
+
+run env \
+  "CARGO_TARGET_DIR=$USE_TARGET_DIR" \
+  "CARGO_ENCODED_RUSTFLAGS=$USE_FLAGS" \
+  "${CARGO_BUILD[@]}"
+
+run mkdir -p "$(dirname -- "$OUTPUT_PATH")"
+run cp "$OPTIMIZED_BINARY" "$OUTPUT_PATH"
+run chmod 755 "$OUTPUT_PATH"
+
+if ! $dry_run && [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+  llvm_profdata_version="$("$LLVM_PROFDATA" --version)"
+  llvm_profdata_version="${llvm_profdata_version%%$'\n'*}"
+  {
+    echo "### svelte-check PGO build"
+    echo
+    echo "- Target: \`$TARGET\`"
+    echo "- Profile: \`$PROFILE\`"
+    echo "- Rust: \`$(rustc --version)\`"
+    echo "- Cargo: \`$(cargo --version)\`"
+    echo "- llvm-profdata: \`$llvm_profdata_version\`"
+    echo "- Corpus SHA-256: \`$CORPUS_HASH\`"
+    echo "- Training inputs: $TRAINING_FILE_COUNT files (${#corpus_files[@]} sources × $TRAINING_REPLICAS replicas)"
+    echo "- Training passes: $TRAINING_PASSES"
+  } >> "$GITHUB_STEP_SUMMARY"
+fi

--- a/scripts/release/build-svelte-check-pgo.sh
+++ b/scripts/release/build-svelte-check-pgo.sh
@@ -131,37 +131,66 @@ run env \
 
 for (( pass = 1; pass <= TRAINING_PASSES; pass++ )); do
   remove_work_dir "$TRAINING_WORKSPACE/.svelte-check"
+  printf -v training_output '%s/training-pass-%02d.out' "$WORK_ROOT" "$pass"
   if $dry_run; then
-    printf '+ LLVM_PROFILE_FILE=%q %q' "$PROFILE_DIR/svelte-check-%m-%p.profraw" "$INSTRUMENTED_BINARY"
+    printf '+ LLVM_PROFILE_FILE=%q %q' \
+      "$PROFILE_DIR/svelte-check-pass-$pass-%m-%p.profraw" \
+      "$INSTRUMENTED_BINARY"
     printf ' %q' \
       --workspace "$TRAINING_WORKSPACE" \
       --emit-overlay \
       --no-type-check \
       --no-tsconfig \
       --output machine
-    printf ' >/dev/null\n'
+    printf ' >%q\n' "$training_output"
   else
-    LLVM_PROFILE_FILE="$PROFILE_DIR/svelte-check-%m-%p.profraw" \
+    if ! LLVM_PROFILE_FILE="$PROFILE_DIR/svelte-check-pass-$pass-%m-%p.profraw" \
       "$INSTRUMENTED_BINARY" \
       --workspace "$TRAINING_WORKSPACE" \
       --emit-overlay \
       --no-type-check \
       --no-tsconfig \
       --output machine \
-      >/dev/null
+      >"$training_output"; then
+      sed -n '1,120p' "$training_output" >&2
+      die "training pass $pass failed"
+    fi
+    if ! grep -Eq "^[0-9]+ COMPLETED ${TRAINING_FILE_COUNT} FILES " "$training_output"; then
+      sed -n '1,120p' "$training_output" >&2
+      die "training pass $pass did not check all $TRAINING_FILE_COUNT inputs"
+    fi
   fi
 done
 
 if $dry_run; then
-  profraw_files=("$PROFILE_DIR/svelte-check-<module>-<pid>.profraw")
+  profraw_files=("$PROFILE_DIR/svelte-check-pass-<pass>-<module>-<pid>.profraw")
 else
   shopt -s nullglob
   profraw_files=("$PROFILE_DIR"/*.profraw)
   shopt -u nullglob
-  (( ${#profraw_files[@]} > 0 )) || die "instrumented training produced no .profraw files"
+  (( ${#profraw_files[@]} >= TRAINING_PASSES )) ||
+    die "instrumented training produced fewer profiles than passes"
+  for profile in "${profraw_files[@]}"; do
+    [[ -s "$profile" ]] || die "instrumented training produced an empty profile: $profile"
+  done
 fi
 
-run "$LLVM_PROFDATA" merge --output "$MERGED_PROFILE" "${profraw_files[@]}"
+run "$LLVM_PROFDATA" merge --failure-mode=any --output "$MERGED_PROFILE" "${profraw_files[@]}"
+profile_function_count=
+profile_total_count=
+if ! $dry_run; then
+  profile_summary="$("$LLVM_PROFDATA" show "$MERGED_PROFILE")"
+  profile_function_count="$(
+    awk '$1 == "Total" && $2 == "functions:" { print $3; exit }' <<<"$profile_summary"
+  )"
+  profile_total_count="$(
+    awk '$1 == "Total" && $2 == "count:" { print $3; exit }' <<<"$profile_summary"
+  )"
+  is_positive_integer "$profile_function_count" ||
+    die "merged profile contains no instrumented functions"
+  is_positive_integer "$profile_total_count" ||
+    die "merged profile contains no execution counts"
+fi
 remove_work_dir "$GENERATE_TARGET_DIR"
 if ! $dry_run && [[ -e "$GENERATE_TARGET_DIR" ]]; then
   die "generation target was not removed before the profile-use build"
@@ -190,5 +219,7 @@ if ! $dry_run && [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
     echo "- Corpus SHA-256: \`$CORPUS_HASH\`"
     echo "- Training inputs: $TRAINING_FILE_COUNT files (${#corpus_files[@]} sources × $TRAINING_REPLICAS replicas)"
     echo "- Training passes: $TRAINING_PASSES"
+    echo "- Profiled functions: $profile_function_count"
+    echo "- Total profile count: $profile_total_count"
   } >> "$GITHUB_STEP_SUMMARY"
 fi


### PR DESCRIPTION
## Summary

- build the published Linux x64 `svelte-check` binary with LLVM instrumentation PGO
- train cold svelte2tsx overlay generation on a deterministic replicated corpus
- add a TypeScript/generic component so the training set covers TS-specific svelte2tsx paths
- fail the release if a training pass checks fewer files than expected or emits missing/empty profile data
- report the corpus hash, training size, profiled function count, and aggregate profile count in the job summary

## Audit notes

- generation and profile-use builds use separate temporary target directories
- the generation target is removed before the final build to bound disk usage
- the final binary is copied to the existing `target/x86_64-unknown-linux-gnu/dist/svelte_check` staging contract
- LLVM tools come from the same pinned Rust toolchain that performs both builds
- non-Linux-x64 release matrix legs are unchanged

## Validation

- `cargo fmt --all -- --check`
- `bash -n scripts/release/build-svelte-check-pgo.sh`
- release workflow parsed as YAML
- default and overridden `--dry-run` paths
- invalid argument/environment failure cases
- mocked Linux orchestration success, incomplete-file-count rejection, and empty-profile rejection
- current-source debug `svelte-check` smoke: 18/18 replicated inputs checked and 18 overlays emitted
- `git diff --check`

The local PGO/fat-LTO build was intentionally not run; the actual instrumented dist build remains confined to the Linux x64 release runner.
