### PR TITLE
Write svelte2tsx formatted segments without temporary strings

### DIFF
--- a/crates/rsvelte_projection/src/svelte2tsx/template/attributes/attribute.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/template/attributes/attribute.rs
@@ -5,7 +5,7 @@ use super::svg::is_svg_attribute;
 use crate::ast::template::{AttributeNode, AttributeValue, AttributeValuePart};
 use crate::svelte2tsx::svelte2tsx::slice_src;
 use crate::svelte2tsx::template::ctx::ELEMENT_OPENER_COMMENTS;
-use crate::svelte2tsx::template::segs::{Seg, segs_push_lit, segs_push_src};
+use crate::svelte2tsx::template::segs::{Seg, segs_push_fmt, segs_push_lit, segs_push_src};
 use crate::svelte2tsx::template::utils::expr::{get_expression_range, get_expression_text};
 
 /// Format a regular attribute: `name="value"` → `"name":\`value\`,`
@@ -426,20 +426,20 @@ pub(crate) fn format_attribute_node_segments(
             // --* on components: no-value → ""
             // Others: true
             if is_data_attr {
-                segs_push_lit(
+                segs_push_fmt(
                     &mut out,
-                    &format!(
+                    format_args!(
                         "...__sveltets_2_empty({{{leading_comment}\"{}\":true}}),",
                         name
                     ),
                 );
             } else if is_css_prop {
-                segs_push_lit(
+                segs_push_fmt(
                     &mut out,
-                    &format!("...__sveltets_2_cssProp({{\"{}\":\"\"}}),", name),
+                    format_args!("...__sveltets_2_cssProp({{\"{}\":\"\"}}),", name),
                 );
             } else {
-                segs_push_lit(&mut out, &format!("\"{}\":true,", name));
+                segs_push_fmt(&mut out, format_args!("\"{}\":true,", name));
             }
             Some(out)
         }
@@ -497,15 +497,15 @@ pub(crate) fn format_attribute_node_segments(
                         (s, e)
                     };
                     let mut inner: Vec<Seg> = Vec::new();
-                    segs_push_lit(&mut inner, &format!("\"{}\":", name));
+                    segs_push_fmt(&mut inner, format_args!("\"{}\":", name));
                     segs_push_src(&mut inner, s, e);
                     return Some(wrap_segs(inner));
                 }
             } else if is_shorthand {
-                segs_push_lit(&mut out, &format!("{},", name));
+                segs_push_fmt(&mut out, format_args!("{},", name));
             } else {
                 let mut inner: Vec<Seg> = Vec::new();
-                segs_push_lit(&mut inner, &format!("\"{}\":{}", name, expr_text));
+                segs_push_fmt(&mut inner, format_args!("\"{}\":{}", name, expr_text));
                 return Some(wrap_segs(inner));
             }
             Some(out)
@@ -518,7 +518,7 @@ pub(crate) fn format_attribute_node_segments(
             {
                 let range = get_expression_range(&expr.expression);
                 let mut inner: Vec<Seg> = Vec::new();
-                segs_push_lit(&mut inner, &format!("\"{}\":", name));
+                segs_push_fmt(&mut inner, format_args!("\"{}\":", name));
                 if let Some((s, e)) = range {
                     segs_push_src(&mut inner, s, e);
                 } else {
@@ -543,7 +543,7 @@ pub(crate) fn format_attribute_node_segments(
                 && !text.data.trim().is_empty()
                 && is_js_numeric(&text.data)
             {
-                segs_push_lit(&mut out, &format!("\"{}\":", name));
+                segs_push_fmt(&mut out, format_args!("\"{}\":", name));
                 segs_push_src(&mut out, text.start, text.end);
                 segs_push_lit(&mut out, ",");
                 return Some(out);
@@ -561,7 +561,7 @@ pub(crate) fn format_attribute_node_segments(
             });
             if !has_expr && text_is_empty {
                 let mut inner: Vec<Seg> = Vec::new();
-                segs_push_lit(&mut inner, &format!("\"{}\":\"\"", name));
+                segs_push_fmt(&mut inner, format_args!("\"{}\":\"\"", name));
                 return Some(wrap_segs(inner));
             }
 
@@ -590,7 +590,7 @@ pub(crate) fn format_attribute_node_segments(
                 };
                 let needs_escape = data.contains('\\') || (has_backtick && data.contains('\n'));
                 let mut inner: Vec<Seg> = Vec::new();
-                segs_push_lit(&mut inner, &format!("\"{}\":{}", name, quote));
+                segs_push_fmt(&mut inner, format_args!("\"{}\":{}", name, quote));
                 if needs_escape {
                     let json =
                         serde_json::to_string(data).unwrap_or_else(|_| format!("\"{}\"", data));
@@ -598,14 +598,14 @@ pub(crate) fn format_attribute_node_segments(
                 } else {
                     segs_push_src(&mut inner, text.start, text.end);
                 }
-                segs_push_lit(&mut inner, &quote.to_string());
+                segs_push_fmt(&mut inner, format_args!("{quote}"));
                 return Some(wrap_segs(inner));
             }
 
             // Mixed text + expression sequence → template literal. Each
             // `${EXPR}` slot still preserves the expression chunk.
             let mut inner: Vec<Seg> = Vec::new();
-            segs_push_lit(&mut inner, &format!("\"{}\":`", name));
+            segs_push_fmt(&mut inner, format_args!("\"{}\":`", name));
             for part in parts {
                 match part {
                     AttributeValuePart::Text(text) => {

--- a/crates/rsvelte_projection/src/svelte2tsx/template/attributes/binding.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/template/attributes/binding.rs
@@ -4,7 +4,7 @@ use std::fmt::Write as _;
 
 use crate::ast::template::{Attribute, BindDirective};
 use crate::svelte2tsx::svelte2tsx::slice_src;
-use crate::svelte2tsx::template::segs::{Seg, segs_push_lit, segs_push_src};
+use crate::svelte2tsx::template::segs::{Seg, segs_push_fmt, segs_push_lit, segs_push_src};
 use crate::svelte2tsx::template::utils::expr::{
     extend_expr_end_with_ts_postfix, get_binding_lhs_text, get_expression_end_stripping_ts,
     get_expression_range, get_expression_text, get_set_binding_ranges,
@@ -13,7 +13,7 @@ use crate::svelte2tsx::template::utils::expr::{
 /// Structured-bake variant of [`format_bind_directive`].
 pub(crate) fn format_bind_directive_segments(bind: &BindDirective, source: &str) -> Vec<Seg> {
     let mut out = Vec::new();
-    segs_push_lit(&mut out, &format!("\"bind:{}\":", bind.name));
+    segs_push_fmt(&mut out, format_args!("\"bind:{}\":", bind.name));
     if let Some(((gs, ge), (ss, se))) = get_set_binding_ranges(&bind.expression, source) {
         // Svelte 5 function binding on an element: `bind:value={getFn, setFn}`
         // → `"bind:value":__sveltets_2_get_set_binding(getFn, setFn),`

--- a/crates/rsvelte_projection/src/svelte2tsx/template/attributes/event_handler.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/template/attributes/event_handler.rs
@@ -1,7 +1,7 @@
 //! `on:` directives. Mirrors `htmlxtojsx_v2/nodes/EventHandler.ts`.
 
 use crate::ast::template::{Attribute, OnDirective};
-use crate::svelte2tsx::template::segs::{Seg, segs_push_lit, segs_push_src};
+use crate::svelte2tsx::template::segs::{Seg, segs_push_fmt, segs_push_lit, segs_push_src};
 use std::fmt::Write as _;
 
 use crate::svelte2tsx::template::utils::expr::{get_expression_range, get_expression_text};
@@ -42,7 +42,7 @@ pub(crate) fn build_on_calls(
 pub(crate) fn format_on_directive_segments(on: &OnDirective, source: &str) -> Vec<Seg> {
     let mut out = Vec::new();
     if let Some(ref expr) = on.expression {
-        segs_push_lit(&mut out, &format!("\"on:{}\":", on.name));
+        segs_push_fmt(&mut out, format_args!("\"on:{}\":", on.name));
         if let Some((s, e)) = get_expression_range(expr) {
             segs_push_src(&mut out, s, e);
         } else {
@@ -51,7 +51,7 @@ pub(crate) fn format_on_directive_segments(on: &OnDirective, source: &str) -> Ve
         segs_push_lit(&mut out, ",");
     } else {
         // Event forwarding has no expression to preserve.
-        segs_push_lit(&mut out, &format!("\"on:{}\":undefined,", on.name));
+        segs_push_fmt(&mut out, format_args!("\"on:{}\":undefined,", on.name));
     }
     out
 }

--- a/crates/rsvelte_projection/src/svelte2tsx/template/attributes/mod.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/template/attributes/mod.rs
@@ -18,7 +18,7 @@ use crate::ast::template::Attribute;
 use crate::svelte2tsx::svelte2tsx::slice_src;
 use crate::svelte2tsx::template::nodes::attach_tag::format_attach_tag_segments;
 use crate::svelte2tsx::template::segs::{
-    Seg, segs_is_empty, segs_push_lit, segs_push_src, segs_to_string,
+    Seg, segs_is_empty, segs_push_fmt, segs_push_lit, segs_push_src, segs_to_string,
 };
 use crate::svelte2tsx::template::utils::expr::{
     extend_expr_end_with_ts_postfix, get_expression_range, get_expression_text,
@@ -243,7 +243,7 @@ pub(super) fn build_attribute_segments(
                 if !in_slot_context {
                     let mut part: Vec<Seg> = Vec::new();
                     if let Some(ref expr) = let_dir.expression {
-                        segs_push_lit(&mut part, &format!("\"let:{}\":", let_dir.name));
+                        segs_push_fmt(&mut part, format_args!("\"let:{}\":", let_dir.name));
                         if let Some((s, e)) = get_expression_range(expr) {
                             segs_push_src(&mut part, s, e);
                         } else {
@@ -251,7 +251,7 @@ pub(super) fn build_attribute_segments(
                         }
                         segs_push_lit(&mut part, ",");
                     } else {
-                        segs_push_lit(&mut part, &format!("\"let:{}\":true,", let_dir.name));
+                        segs_push_fmt(&mut part, format_args!("\"let:{}\":true,", let_dir.name));
                     }
                     push_with_separator(&mut segs, part);
                     any_pushed = true;
@@ -469,7 +469,7 @@ pub(super) fn build_component_props_segments(
                 }
                 // Component-side bind:foo={expr} → foo:expr, (no quotes,
                 // no `bind:` prefix). Mirrors the JS reference.
-                segs_push_lit(&mut inner, &format!("{}:", bind.name));
+                segs_push_fmt(&mut inner, format_args!("{}:", bind.name));
                 if let Some(((gs, ge), (ss, se))) = get_set_binding_ranges(&bind.expression, source)
                 {
                     // Svelte 5 function binding `bind:foo={getFn, setFn}` →

--- a/crates/rsvelte_projection/src/svelte2tsx/template/segs.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/template/segs.rs
@@ -20,6 +20,7 @@
 
 use crate::svelte2tsx::magic_string::MagicString;
 use crate::svelte2tsx::svelte2tsx::slice_src;
+use std::fmt::{self, Write as _};
 
 /// A piece of the structured bake output. `Lit` is generated text; `Src`
 /// names a source byte range that should be kept as-is.
@@ -38,6 +39,18 @@ pub(super) fn segs_push_lit(segs: &mut Vec<Seg>, s: &str) {
         last.push_str(s);
     } else {
         segs.push(Seg::Lit(s.to_string()));
+    }
+}
+
+/// Push formatted literal text without creating a temporary `String`.
+pub(super) fn segs_push_fmt(segs: &mut Vec<Seg>, args: fmt::Arguments<'_>) {
+    if let Some(Seg::Lit(last)) = segs.last_mut() {
+        let _ = last.write_fmt(args);
+    } else {
+        let text = fmt::format(args);
+        if !text.is_empty() {
+            segs.push(Seg::Lit(text));
+        }
     }
 }
 
@@ -193,6 +206,26 @@ pub(super) fn emit_segmented_overwrite(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn formatted_literal_appends_to_existing_segment() {
+        let mut segs = vec![Seg::Lit("prefix".to_string())];
+
+        segs_push_fmt(&mut segs, format_args!(":{}={}", "name", 42));
+
+        assert_eq!(segs.len(), 1);
+        assert!(matches!(&segs[0], Seg::Lit(text) if text == "prefix:name=42"));
+    }
+
+    #[test]
+    fn formatted_literal_creates_segment_after_source() {
+        let mut segs = vec![Seg::Src(2, 4)];
+
+        segs_push_fmt(&mut segs, format_args!("\"{}\":{},", "value", true));
+
+        assert_eq!(segs.len(), 2);
+        assert!(matches!(&segs[1], Seg::Lit(text) if text == "\"value\":true,"));
+    }
 
     #[test]
     fn test_emit_segmented_overwrite_preserves_src_chunk() {


### PR DESCRIPTION
## Summary

- write `fmt::Arguments` directly into the trailing generated segment
- allocate exactly once when formatting must create a new literal segment
- remove 17 temporary `format!` strings and one equivalent one-character
  `to_string` from attribute/directive lowering

## Performance

Compared with `origin/main` using the same fat-LTO runner:

- official 254-fixture corpus, 5,000 samples: **3.23% faster**
- peak RSS: +16 KiB median (**+0.28%**, allocator-page noise)

This targets the remaining `format_inner`/`fmt::write` hotspot observed after
the comprehensive profile.

## Validation

- focused new-segment and append-to-existing-segment tests
- `cargo test -p rsvelte_projection`
- exact pinned language-tools fixtures: 246/254, same eight known mismatches
- `cargo check -p rsvelte_projection --target wasm32-unknown-unknown`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
