### PR TITLE
Write svelte2tsx projection edits without temporary strings

### DIFF
--- a/crates/rsvelte_projection/src/svelte2tsx/magic_string.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/magic_string.rs
@@ -879,6 +879,23 @@ impl<'source> MagicString<'source> {
         self
     }
 
+    pub fn overwrite_fmt(&mut self, start: u32, end: u32, args: fmt::Arguments<'_>) -> &mut Self {
+        if start >= end {
+            return self;
+        }
+        self.overwrite(start, end, "");
+        let chunk_idx = self
+            .chunk_starting_at(start)
+            .expect("overwrite_fmt: no chunk at start");
+        self.chunks[chunk_idx]
+            .content
+            .as_mut()
+            .expect("overwrite_fmt: chunk was not edited")
+            .write_fmt(args)
+            .expect("writing to String cannot fail");
+        self
+    }
+
     /// Remove the content in `[start, end)`.
     pub fn remove(&mut self, start: u32, end: u32) -> &mut Self {
         assert!(start < end, "remove: start must be < end");
@@ -951,6 +968,30 @@ impl<'source> MagicString<'source> {
             .left
             .expect("append_left: no chunk ending at index");
         self.chunks[chunk_idx].outro.push_str(content);
+        self
+    }
+
+    pub fn append_left_fmt(&mut self, index: u32, args: fmt::Arguments<'_>) -> &mut Self {
+        assert!(
+            (index as usize) <= self.original.len(),
+            "append_left_fmt: index out of range"
+        );
+
+        if index == 0 {
+            self.intro
+                .write_fmt(args)
+                .expect("writing to String cannot fail");
+            return self;
+        }
+
+        let chunk_idx = self
+            .split_at(index)
+            .left
+            .expect("append_left_fmt: no chunk ending at index");
+        self.chunks[chunk_idx]
+            .outro
+            .write_fmt(args)
+            .expect("writing to String cannot fail");
         self
     }
 
@@ -1452,6 +1493,13 @@ mod tests {
     }
 
     #[test]
+    fn test_overwrite_fmt() {
+        let mut s = MagicString::new("hello world");
+        s.overwrite_fmt(0, 5, format_args!("{} {}", "good", "day"));
+        assert_eq!(s.to_string(), "good day world");
+    }
+
+    #[test]
     fn test_overwrite_middle() {
         let mut s = MagicString::new("hello world");
         s.overwrite(6, 11, "earth");
@@ -1518,6 +1566,13 @@ mod tests {
         let mut s = MagicString::new("hello world");
         s.append_left(5, " cruel");
         assert_eq!(s.to_string(), "hello cruel world");
+    }
+
+    #[test]
+    fn test_append_left_fmt() {
+        let mut s = MagicString::new("hello world");
+        s.append_left_fmt(5, format_args!(" {} {}", "wide", 2));
+        assert_eq!(s.to_string(), "hello wide 2 world");
     }
 
     #[test]

--- a/crates/rsvelte_projection/src/svelte2tsx/process_instance_script_tag.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/process_instance_script_tag.rs
@@ -369,10 +369,10 @@ pub(crate) fn process_instance_script_tag(
         }
         str.overwrite(sp, content_start, &part_b);
     } else if script_start < content_start {
-        str.overwrite(
+        str.overwrite_fmt(
             script_start,
             content_start,
-            &format!("{}{}", part_a, part_b),
+            format_args!("{}{}", part_a, part_b),
         );
     }
 
@@ -382,17 +382,22 @@ pub(crate) fn process_instance_script_tag(
             exported_names.props_type_text.as_ref(),
         )
     {
-        let snippet = if force_inside_render {
-            format!(";type $$ComponentProps =  {};", type_text)
+        if force_inside_render {
+            str.append_left_fmt(
+                let_pos,
+                format_args!(";type $$ComponentProps =  {};", type_text),
+            );
         } else {
             // type_already_inserted (auto-generated SvelteKit / fallback type).
             // JS reference wraps in surroundWithIgnoreComments.
-            format!(
-                "/*\u{03A9}ignore_start\u{03A9}*/;type $$ComponentProps = {};/*\u{03A9}ignore_end\u{03A9}*/",
-                type_text
-            )
-        };
-        str.append_left(let_pos, &snippet);
+            str.append_left_fmt(
+                let_pos,
+                format_args!(
+                    "/*\u{03A9}ignore_start\u{03A9}*/;type $$ComponentProps = {};/*\u{03A9}ignore_end\u{03A9}*/",
+                    type_text
+                ),
+            );
+        }
     }
 
     // Overwrite `</script>` with slot declaration + `async () => {`.
@@ -409,14 +414,13 @@ pub(crate) fn process_instance_script_tag(
             } else {
                 ""
             };
-            let slot_decl = format!(
-                "\n/*\u{03A9}ignore_start\u{03A9}*/;const __sveltets_createSlot = __sveltets_2_createCreateSlot{}();/*\u{03A9}ignore_end\u{03A9}*/;",
-                slot_generic
-            );
-            str.overwrite(
+            str.overwrite_fmt(
                 content_end,
                 script_end,
-                &format!("{}\nasync () => {{", slot_decl),
+                format_args!(
+                    "\n/*\u{03A9}ignore_start\u{03A9}*/;const __sveltets_createSlot = __sveltets_2_createCreateSlot{}();/*\u{03A9}ignore_end\u{03A9}*/;\nasync () => {{",
+                    slot_generic
+                ),
             );
         } else {
             str.overwrite(content_end, script_end, ";\nasync () => {");

--- a/crates/rsvelte_projection/src/svelte2tsx/script/export_decl.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/script/export_decl.rs
@@ -228,31 +228,31 @@ pub(super) fn handle_export_named_decl(
                                 && !use_jsdoc
                             {
                                 // Combined: type annotation + widener, one block.
-                                str.append_left(
+                                str.append_left_fmt(
                                     id_end,
-                                    &format!(
+                                    format_args!(
                                         "/*\u{03A9}ignore_start\u{03A9}*/: {kit}; {name} = __sveltets_2_any({name});/*\u{03A9}ignore_end\u{03A9}*/"
                                     ),
                                 );
                             } else {
                                 if do_widen {
-                                    str.append_left(
+                                    str.append_left_fmt(
                                         widen_pos,
-                                        &format!(
+                                        format_args!(
                                             "/*\u{03A9}ignore_start\u{03A9}*/;{name} = __sveltets_2_any({name});/*\u{03A9}ignore_end\u{03A9}*/"
                                         ),
                                     );
                                 }
                                 if let Some(kit) = kit_type {
                                     if use_jsdoc {
-                                        str.append_left(
+                                        str.append_left_fmt(
                                             id_start,
-                                            &format!("/** @type {{{}}} */ ", kit),
+                                            format_args!("/** @type {{{}}} */ ", kit),
                                         );
                                     } else {
-                                        str.append_left(
+                                        str.append_left_fmt(
                                             id_end,
-                                            &format!(
+                                            format_args!(
                                                 "/*\u{03A9}ignore_start\u{03A9}*/: {}/*\u{03A9}ignore_end\u{03A9}*/",
                                                 kit
                                             ),

--- a/crates/rsvelte_projection/src/svelte2tsx/template/nodes/await_block.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/template/nodes/await_block.rs
@@ -109,12 +109,14 @@ pub(crate) fn handle_await_block(
                         (false, true) => "await (",
                     },
                 );
-                let suffix = if !value_text.is_empty() {
-                    format!(");{{ const {} = $$_value; ", value_text)
+                if !value_text.is_empty() {
+                    str.append_left_fmt(
+                        expr_end,
+                        format_args!(");{{ const {} = $$_value; ", value_text),
+                    );
                 } else {
-                    ");".to_string()
-                };
-                str.append_left(expr_end, &suffix);
+                    str.append_left(expr_end, ");");
+                }
                 if prev_end < then_start {
                     str.overwrite(prev_end, then_start, "");
                 }
@@ -127,19 +129,19 @@ pub(crate) fn handle_await_block(
                 // `try { ` wrapper when a catch/error is present (see above).
                 let try_prefix = if has_catch { "try { " } else { "" };
                 if !value_text.is_empty() {
-                    str.overwrite(
+                    str.overwrite_fmt(
                         prev_end,
                         then_start,
-                        &format!(
+                        format_args!(
                             "{}const $$_value = await ({});{{ const {} = $$_value; ",
                             try_prefix, expr_text, value_text
                         ),
                     );
                 } else {
-                    str.overwrite(
+                    str.overwrite_fmt(
                         prev_end,
                         then_start,
-                        &format!("{}const $$_value = await ({});{{ ", try_prefix, expr_text),
+                        format_args!("{}const $$_value = await ({});{{ ", try_prefix, expr_text),
                     );
                 }
             }
@@ -164,19 +166,19 @@ pub(crate) fn handle_await_block(
                 // `{:then value}` binding opened one), then open the catch.
                 let close_before_catch = if value_text.is_empty() { "}" } else { "}}" };
                 if !error_text.is_empty() {
-                    str.overwrite(
+                    str.overwrite_fmt(
                         then_end,
                         catch_start,
-                        &format!(
+                        format_args!(
                             "{} catch($$_e) {{ const {} = __sveltets_2_any();",
                             close_before_catch, error_text
                         ),
                     );
                 } else {
-                    str.overwrite(
+                    str.overwrite_fmt(
                         then_end,
                         catch_start,
-                        &format!("{} catch($$_e) {{ ", close_before_catch),
+                        format_args!("{} catch($$_e) {{ ", close_before_catch),
                     );
                 }
 
@@ -253,7 +255,11 @@ pub(crate) fn handle_await_block(
                     str.overwrite(catch_end, block.end, "}}");
                 }
             } else if pending_end < block.end {
-                str.overwrite(pending_end, block.end, &format!("await ({});}}", expr_text));
+                str.overwrite_fmt(
+                    pending_end,
+                    block.end,
+                    format_args!("await ({});}}", expr_text),
+                );
             }
         }
     } else if has_then {
@@ -315,10 +321,10 @@ pub(crate) fn handle_await_block(
                 str.append_left(expr_end, &header_suffix);
             }
         } else {
-            str.overwrite(
+            str.overwrite_fmt(
                 block.start,
                 then_start,
-                &format!("{}{}{}", header_prefix, expr_text, header_suffix),
+                format_args!("{}{}{}", header_prefix, expr_text, header_suffix),
             );
         }
 
@@ -340,10 +346,10 @@ pub(crate) fn handle_await_block(
             };
 
             if !error_text.is_empty() {
-                str.overwrite(
+                str.overwrite_fmt(
                     then_end,
                     catch_start,
-                    &format!(
+                    format_args!(
                         "{}}} catch($$_e) {{ const {} = __sveltets_2_any();",
                         value_close, error_text
                     ),
@@ -351,10 +357,10 @@ pub(crate) fn handle_await_block(
             } else {
                 // Close the value block (only when there's a `{:then value}`
                 // binding) + `try`, then open the catch. Always emit `($$_e)`.
-                str.overwrite(
+                str.overwrite_fmt(
                     then_end,
                     catch_start,
-                    &format!("{}}} catch($$_e) {{ ", value_close),
+                    format_args!("{}}} catch($$_e) {{ ", value_close),
                 );
             }
 
@@ -376,11 +382,10 @@ pub(crate) fn handle_await_block(
             // empty-then-body case (then_end == block.end: the overwrite from
             // expr_end to block.end already consumed that region, so we must
             // append rather than overwrite a zero-length range).
-            let close = format!("{}}}", value_close);
             if then_end < block.end {
-                str.overwrite(then_end, block.end, &close);
+                str.overwrite_fmt(then_end, block.end, format_args!("{}}}", value_close));
             } else {
-                str.append_left(block.end, &close);
+                str.append_left_fmt(block.end, format_args!("{}}}", value_close));
             }
         }
     } else if has_catch {
@@ -411,19 +416,19 @@ pub(crate) fn handle_await_block(
                 str.append_left(expr_end, &header_suffix);
             }
         } else if !error_text.is_empty() {
-            str.overwrite(
+            str.overwrite_fmt(
                 block.start,
                 catch_start,
-                &format!(
+                format_args!(
                     "   {{ try {{ await ({});}} catch($$_e) {{ const {} = __sveltets_2_any();",
                     expr_text, error_text
                 ),
             );
         } else {
-            str.overwrite(
+            str.overwrite_fmt(
                 block.start,
                 catch_start,
-                &format!("   {{ try {{ await ({});}} catch($$_e) {{ ", expr_text),
+                format_args!("   {{ try {{ await ({});}} catch($$_e) {{ ", expr_text),
             );
         }
 
@@ -451,10 +456,10 @@ pub(crate) fn handle_await_block(
                 str.append_left(expr_end, ");}");
             }
         } else {
-            str.overwrite(
+            str.overwrite_fmt(
                 block.start,
                 block.end,
-                &format!("{{ await ({});}}", expr_text),
+                format_args!("{{ await ({});}}", expr_text),
             );
         }
     }

--- a/crates/rsvelte_projection/src/svelte2tsx/template/nodes/component_slots.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/template/nodes/component_slots.rs
@@ -564,7 +564,7 @@ pub(crate) fn handle_named_slot_component(
     // close the named-slot block.
     let closing_tag_start = find_closing_tag_start(source, comp.end);
     if closing_tag_start < comp.end {
-        str.append_left(comp.end, &format!(" {}}}", comp.name));
+        str.append_left_fmt(comp.end, format_args!(" {}}}", comp.name));
     } else {
         str.append_left(comp.end, "}");
     }

--- a/crates/rsvelte_projection/src/svelte2tsx/template/nodes/element.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/template/nodes/element.rs
@@ -254,7 +254,7 @@ pub(crate) fn handle_regular_element(
         .ends_with("/>");
     let is_void = crate::compiler::utils::is_void_element(&el.name);
     if is_void || is_self_closing_source {
-        str.append_left(el.end, &format!("}}{}", extra_close));
+        str.append_left_fmt(el.end, format_args!("}}{}", extra_close));
     } else {
         let closing_tag_start = find_closing_tag_start(source, el.end);
         // An auto-closed element (`<p><p>`, `<li><li>`, …) has NO `</name>` at
@@ -266,9 +266,13 @@ pub(crate) fn handle_regular_element(
             && closing_tag_name_matches(source, closing_tag_start, &el.name)
         {
             // Non-self-closing: preserve space before closing brace
-            str.overwrite(closing_tag_start, el.end, &format!(" }}{}", extra_close));
+            str.overwrite_fmt(
+                closing_tag_start,
+                el.end,
+                format_args!(" }}{}", extra_close),
+            );
         } else {
-            str.append_left(el.end, &format!("}}{}", extra_close));
+            str.append_left_fmt(el.end, format_args!("}}{}", extra_close));
         }
     }
     // Restore the slot context for following siblings (this element's own

--- a/crates/rsvelte_projection/src/svelte2tsx/template/nodes/if_else_block.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/template/nodes/if_else_block.rs
@@ -90,7 +90,11 @@ pub(crate) fn handle_if_block(
                 str.append_left(consequent_start, ")");
             }
         } else {
-            str.overwrite(block.start, consequent_start, &format!("if({})", test_text));
+            str.overwrite_fmt(
+                block.start,
+                consequent_start,
+                format_args!("if({})", test_text),
+            );
         }
         // Insert opening brace
         str.append_left(consequent_start, "{");

--- a/crates/rsvelte_projection/src/svelte2tsx/template/nodes/inline_component.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/template/nodes/inline_component.rs
@@ -451,10 +451,14 @@ pub(crate) fn handle_component(
             // the component-name reference + the named-slot-block close after.
             str.overwrite(closing_tag_start, comp.end, " }");
         } else {
-            str.overwrite(closing_tag_start, comp.end, &format!(" {}}}", comp.name));
+            str.overwrite_fmt(
+                closing_tag_start,
+                comp.end,
+                format_args!(" {}}}", comp.name),
+            );
         }
     } else if needs_inline_block {
-        str.append_left(comp.end, &format!("{}{}}}", inline_block, comp.name));
+        str.append_left_fmt(comp.end, format_args!("{}{}}}", inline_block, comp.name));
     } else {
         str.append_left(comp.end, "}");
     }

--- a/crates/rsvelte_projection/src/svelte2tsx/template/nodes/key_block.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/template/nodes/key_block.rs
@@ -55,7 +55,7 @@ pub(crate) fn handle_key_block(
             str.append_left(expr_end, "; {");
         }
     } else {
-        str.overwrite(block.start, content_start, &format!("{expr_text}; {{"));
+        str.overwrite_fmt(block.start, content_start, format_args!("{expr_text}; {{"));
     }
 
     // Process children

--- a/crates/rsvelte_projection/src/svelte2tsx/template/nodes/slot_element.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/template/nodes/slot_element.rs
@@ -94,10 +94,10 @@ pub(crate) fn handle_slot_element(
     if closing_tag_start < el.end {
         if let Some(ref bind_expr) = bind_this_expr {
             // For bind:this, assign the slot variable: `s = $$_slot0;}
-            str.overwrite(
+            str.overwrite_fmt(
                 closing_tag_start,
                 el.end,
-                &format!("{} = $$_slot{};}}", bind_expr, counter.last_slot()),
+                format_args!("{} = $$_slot{};}}", bind_expr, counter.last_slot()),
             );
         } else {
             str.overwrite(closing_tag_start, el.end, " }");
@@ -106,10 +106,10 @@ pub(crate) fn handle_slot_element(
         // Self-closing slot
         if let Some(ref bind_expr) = bind_this_expr {
             let slot_idx = counter.last_slot();
-            str.overwrite(
+            str.overwrite_fmt(
                 el.end - 2, // rewrite the `/>` portion
                 el.end,
-                &format!("{} = $$_slot{};}}", bind_expr, slot_idx),
+                format_args!("{} = $$_slot{};}}", bind_expr, slot_idx),
             );
         } else {
             // Self-closing without bind:this - just close the block

--- a/crates/rsvelte_projection/src/svelte2tsx/template/nodes/special_element.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/template/nodes/special_element.rs
@@ -224,9 +224,13 @@ pub(crate) fn handle_svelte_special_element(
         let extra_close = if directive_prefix.is_empty() { "" } else { "}" };
         let closing_tag_start = find_closing_tag_start(source, el.end);
         if closing_tag_start < el.end {
-            str.overwrite(closing_tag_start, el.end, &format!(" }}{}", extra_close));
+            str.overwrite_fmt(
+                closing_tag_start,
+                el.end,
+                format_args!(" }}{}", extra_close),
+            );
         } else {
-            str.append_left(el.end, &format!("}}{}", extra_close));
+            str.append_left_fmt(el.end, format_args!("}}{}", extra_close));
         }
     }
 }


### PR DESCRIPTION
## Summary

- add formatted-write entry points to `MagicString`
- write projection lowering fragments directly into edits instead of allocating
  temporary `format!` strings and copying them again
- cover element/component, if/key/await, slot, script, and export paths without
  changing generated output or source-map boundaries

## Performance

Compared with the validated comprehensive branch using the same fat-LTO runner:

- official 254-fixture svelte2tsx corpus, 5,000 samples: **1.16% faster** paired median
- median peak RSS: unchanged at 5,668,864 bytes

## Validation

- focused MagicString tests: 60 passed
- `cargo test -p rsvelte_projection`
- exact pinned language-tools fixtures: 246/254, same eight known mismatches
- `cargo check -p rsvelte_projection --target wasm32-unknown-unknown`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
