### PR TITLE
Reuse parsed svelte2tsx directive locations

### DIFF
--- a/crates/rsvelte_core/src/compiler/phases/1_parse/state/element.rs
+++ b/crates/rsvelte_core/src/compiler/phases/1_parse/state/element.rs
@@ -16,6 +16,7 @@ use memchr::memmem;
 use memchr::{memchr, memchr3};
 use smallvec::SmallVec;
 
+use crate::ast::SourceLocation;
 use crate::ast::js::Expression;
 use crate::ast::template::{
     AttributeNode, AttributeValue, AttributeValuePart, Comment, Component, ExpressionTag, Fragment,
@@ -1342,7 +1343,7 @@ impl<'a> Parser<'a> {
             let prefix = &name.as_bytes()[..colon_pos];
             match prefix {
                 b"on" => {
-                    return self.parse_on_directive(start, &name, name_start, name_end);
+                    return self.parse_on_directive(start, &name, name_loc, name_end);
                 }
                 b"bind" => {
                     return self.parse_bind_directive(start, &name, name_start, name_end);
@@ -1404,7 +1405,7 @@ impl<'a> Parser<'a> {
         &mut self,
         start: usize,
         full_name: &str,
-        name_start: usize,
+        name_loc: Option<SourceLocation>,
         name_end: usize,
     ) -> ParseResult<Option<crate::ast::Attribute<'a>>> {
         // Extract event name and modifiers from "on:click|preventDefault"
@@ -1418,8 +1419,6 @@ impl<'a> Parser<'a> {
         } else {
             (CompactString::from(after_on), SmallVec::new())
         };
-
-        let name_loc = self.create_name_loc_optional(name_start, name_end);
 
         // Parse the value (expression)
         let (expression, end_pos) = if self.eat_optional("=") {

--- a/crates/rsvelte_core/src/compiler/phases/1_parse/state/element.rs
+++ b/crates/rsvelte_core/src/compiler/phases/1_parse/state/element.rs
@@ -1346,25 +1346,26 @@ impl<'a> Parser<'a> {
                     return self.parse_on_directive(start, &name, name_loc, name_end);
                 }
                 b"bind" => {
-                    return self.parse_bind_directive(start, &name, name_start, name_end);
+                    return self.parse_bind_directive(start, &name, name_start, name_loc, name_end);
                 }
                 b"use" => {
-                    return self.parse_use_directive(start, &name, name_start, name_end);
+                    return self.parse_use_directive(start, &name, name_loc, name_end);
                 }
                 b"class" => {
-                    return self.parse_class_directive(start, &name, name_start, name_end);
+                    return self
+                        .parse_class_directive(start, &name, name_start, name_loc, name_end);
                 }
                 b"style" => {
-                    return self.parse_style_directive(start, &name, name_start, name_end);
+                    return self.parse_style_directive(start, &name, name_loc, name_end);
                 }
                 b"transition" | b"in" | b"out" => {
-                    return self.parse_transition_directive(start, &name, name_start, name_end);
+                    return self.parse_transition_directive(start, &name, name_loc, name_end);
                 }
                 b"animate" => {
-                    return self.parse_animate_directive(start, &name, name_start, name_end);
+                    return self.parse_animate_directive(start, &name, name_loc, name_end);
                 }
                 b"let" => {
-                    return self.parse_let_directive(start, &name, name_start, name_end);
+                    return self.parse_let_directive(start, &name, name_loc, name_end);
                 }
                 _ => {} // Not a directive, fall through to normal attribute
             }
@@ -1487,6 +1488,7 @@ impl<'a> Parser<'a> {
         start: usize,
         full_name: &str,
         name_start: usize,
+        name_loc: Option<SourceLocation>,
         name_end: usize,
     ) -> ParseResult<Option<crate::ast::Attribute<'a>>> {
         // Extract property name and modifiers from "bind:value|modifier"
@@ -1500,8 +1502,6 @@ impl<'a> Parser<'a> {
         } else {
             (after_bind, SmallVec::new())
         };
-
-        let name_loc = self.create_name_loc_optional(name_start, name_end);
 
         // Parse the value (expression)
         let (expression, end_pos) = if self.eat_optional("=") {
@@ -1595,7 +1595,7 @@ impl<'a> Parser<'a> {
         &mut self,
         start: usize,
         full_name: &str,
-        name_start: usize,
+        name_loc: Option<SourceLocation>,
         name_end: usize,
     ) -> ParseResult<Option<crate::ast::Attribute<'a>>> {
         let action_name = &full_name[4..]; // Skip "use:"
@@ -1608,8 +1608,6 @@ impl<'a> Parser<'a> {
                 (start, name_end),
             ));
         }
-
-        let name_loc = self.create_name_loc_optional(name_start, name_end);
 
         let (expression, end_pos) = if self.eat_optional("=") {
             self.skip_whitespace();
@@ -1681,6 +1679,7 @@ impl<'a> Parser<'a> {
         start: usize,
         full_name: &str,
         name_start: usize,
+        name_loc: Option<SourceLocation>,
         name_end: usize,
     ) -> ParseResult<Option<crate::ast::Attribute<'a>>> {
         let class_name = &full_name[6..]; // Skip "class:"
@@ -1693,8 +1692,6 @@ impl<'a> Parser<'a> {
                 (start, name_end),
             ));
         }
-
-        let name_loc = self.create_name_loc_optional(name_start, name_end);
 
         let had_value = self.eat_optional("=");
         let expression = if had_value {
@@ -1759,7 +1756,7 @@ impl<'a> Parser<'a> {
         &mut self,
         start: usize,
         full_name: &str,
-        name_start: usize,
+        name_loc: Option<SourceLocation>,
         name_end: usize,
     ) -> ParseResult<Option<crate::ast::Attribute<'a>>> {
         // Extract property name and modifiers from "style:color|important"
@@ -1773,8 +1770,6 @@ impl<'a> Parser<'a> {
         } else {
             (after_style, SmallVec::new())
         };
-
-        let name_loc = self.create_name_loc_optional(name_start, name_end);
 
         let has_value = self.eat_optional("=");
         let value = if has_value {
@@ -1946,7 +1941,7 @@ impl<'a> Parser<'a> {
         &mut self,
         start: usize,
         full_name: &str,
-        name_start: usize,
+        name_loc: Option<SourceLocation>,
         name_end: usize,
     ) -> ParseResult<Option<crate::ast::Attribute<'a>>> {
         // Determine type and extract name with modifiers
@@ -1973,8 +1968,6 @@ impl<'a> Parser<'a> {
                 (start, name_end),
             ));
         }
-
-        let name_loc = self.create_name_loc_optional(name_start, name_end);
 
         let (expression, end_pos) = if self.eat_optional("=") {
             self.skip_whitespace();
@@ -2057,11 +2050,10 @@ impl<'a> Parser<'a> {
         &mut self,
         start: usize,
         full_name: &str,
-        name_start: usize,
+        name_loc: Option<SourceLocation>,
         name_end: usize,
     ) -> ParseResult<Option<crate::ast::Attribute<'a>>> {
         let animate_name = &full_name[8..]; // Skip "animate:"
-        let name_loc = self.create_name_loc_optional(name_start, name_end);
 
         let had_value = self.eat_optional("=");
         let expression = if had_value {
@@ -2116,11 +2108,10 @@ impl<'a> Parser<'a> {
         &mut self,
         start: usize,
         full_name: &str,
-        name_start: usize,
+        name_loc: Option<SourceLocation>,
         name_end: usize,
     ) -> ParseResult<Option<crate::ast::Attribute<'a>>> {
         let let_name = &full_name[4..]; // Skip "let:"
-        let name_loc = self.create_name_loc_optional(name_start, name_end);
 
         let had_value = self.eat_optional("=");
         let expression = if had_value {

--- a/crates/rsvelte_core/tests/directive_attribute_locations.rs
+++ b/crates/rsvelte_core/tests/directive_attribute_locations.rs
@@ -1,0 +1,110 @@
+use oxc_allocator::Allocator;
+use rsvelte_core::ast::{Attribute, SourceLocation, TemplateNode};
+use rsvelte_core::error::ParseError;
+use rsvelte_core::{ParseOptions, parse};
+
+fn location_text<'a>(source: &'a str, loc: Option<&SourceLocation>) -> &'a str {
+    let loc = loc.expect("name location");
+    &source[loc.start.character as usize..loc.end.character as usize]
+}
+
+#[test]
+fn directive_locations_cover_the_full_unicode_attribute_names() {
+    let source = concat!(
+        "<div // line α\n",
+        "  bind:value|group={value}\n",
+        "  /* block β */ use:動作={action}\n",
+        "  class:有効={active}\n",
+        "  style:色|important=\"red\"\n",
+        "  transition:遷移|global={params}\n",
+        "  animate:反転={params}\n",
+        "  let:項目={item}\n",
+        "></div>"
+    );
+    let root = parse(source, &Allocator::default(), ParseOptions::default()).expect("parse");
+
+    assert_eq!(root.comments.len(), 2);
+    assert_eq!(root.comments[0].value, " line α");
+    assert_eq!(root.comments[1].value, " block β ");
+
+    let TemplateNode::RegularElement(element) = &root.fragment.nodes[0] else {
+        panic!("expected regular element");
+    };
+    assert_eq!(element.attributes.len(), 7);
+
+    let Attribute::BindDirective(bind) = &element.attributes[0] else {
+        panic!("expected bind directive");
+    };
+    assert_eq!(bind.name, "value");
+    assert_eq!(bind.modifiers[0], "group");
+    assert_eq!(
+        location_text(source, bind.name_loc.as_ref()),
+        "bind:value|group"
+    );
+
+    let Attribute::UseDirective(action) = &element.attributes[1] else {
+        panic!("expected use directive");
+    };
+    assert_eq!(action.name, "動作");
+    assert_eq!(location_text(source, action.name_loc.as_ref()), "use:動作");
+
+    let Attribute::ClassDirective(class) = &element.attributes[2] else {
+        panic!("expected class directive");
+    };
+    assert_eq!(class.name, "有効");
+    assert_eq!(location_text(source, class.name_loc.as_ref()), "class:有効");
+
+    let Attribute::StyleDirective(style) = &element.attributes[3] else {
+        panic!("expected style directive");
+    };
+    assert_eq!(style.name, "色");
+    assert_eq!(style.modifiers[0], "important");
+    assert_eq!(
+        location_text(source, style.name_loc.as_ref()),
+        "style:色|important"
+    );
+
+    let Attribute::TransitionDirective(transition) = &element.attributes[4] else {
+        panic!("expected transition directive");
+    };
+    assert_eq!(transition.name, "遷移");
+    assert_eq!(transition.modifiers[0], "global");
+    assert_eq!(
+        location_text(source, transition.name_loc.as_ref()),
+        "transition:遷移|global"
+    );
+
+    let Attribute::AnimateDirective(animate) = &element.attributes[5] else {
+        panic!("expected animate directive");
+    };
+    assert_eq!(animate.name, "反転");
+    assert_eq!(
+        location_text(source, animate.name_loc.as_ref()),
+        "animate:反転"
+    );
+
+    let Attribute::LetDirective(let_directive) = &element.attributes[6] else {
+        panic!("expected let directive");
+    };
+    assert_eq!(let_directive.name, "項目");
+    assert_eq!(
+        location_text(source, let_directive.name_loc.as_ref()),
+        "let:項目"
+    );
+}
+
+#[test]
+fn missing_directive_names_remain_errors() {
+    for source in ["<div use:></div>", "<div transition:|global></div>"] {
+        let error = parse(source, &Allocator::default(), ParseOptions::default())
+            .expect_err("missing directive name must fail");
+
+        assert!(
+            matches!(
+                error,
+                ParseError::SvelteError { ref code, .. } if code == "directive_missing_name"
+            ),
+            "unexpected error for {source:?}: {error:?}"
+        );
+    }
+}

--- a/crates/rsvelte_core/tests/on_directive_attribute_header.rs
+++ b/crates/rsvelte_core/tests/on_directive_attribute_header.rs
@@ -1,0 +1,55 @@
+use oxc_allocator::Allocator;
+use rsvelte_core::ast::{Attribute, TemplateNode};
+use rsvelte_core::error::ParseError;
+use rsvelte_core::{ParseOptions, parse};
+
+#[test]
+fn unicode_name_comments_and_modifiers_preserve_attribute_header() {
+    let source =
+        "<button // line α\n\t/* block β */ on:東京|once|capture|trusted={handler}></button>";
+    let root = parse(source, &Allocator::default(), ParseOptions::default()).expect("parse");
+
+    assert_eq!(root.comments.len(), 2);
+    assert_eq!(root.comments[0].value, " line α");
+    assert_eq!(root.comments[1].value, " block β ");
+
+    let TemplateNode::RegularElement(element) = &root.fragment.nodes[0] else {
+        panic!("expected regular element");
+    };
+    let Attribute::OnDirective(directive) = &element.attributes[0] else {
+        panic!("expected on directive");
+    };
+
+    assert_eq!(directive.name, "東京");
+    assert_eq!(
+        directive
+            .modifiers
+            .iter()
+            .map(|modifier| modifier.as_str())
+            .collect::<Vec<_>>(),
+        ["once", "capture", "trusted"]
+    );
+
+    let loc = directive.name_loc.as_ref().expect("name location");
+    assert_eq!(loc.start.line, 2);
+    assert_eq!(loc.end.line, 2);
+    assert_eq!(
+        &source[loc.start.character as usize..loc.end.character as usize],
+        "on:東京|once|capture|trusted"
+    );
+}
+
+#[test]
+fn plain_string_event_handler_remains_invalid() {
+    let error = parse(
+        r#"<button on:click="handler"></button>"#,
+        &Allocator::default(),
+        ParseOptions::default(),
+    )
+    .expect_err("plain directive value must fail");
+
+    assert!(matches!(
+        error,
+        ParseError::SvelteError { ref code, .. } if code == "directive_invalid_value"
+    ));
+}


### PR DESCRIPTION
## Summary

- pass the attribute-name location already built by `parse_attribute` into
  `on:`, `bind:`, `use:`, `class:`, `style:`, transition, animate, and `let:`
  directive parsers
- remove 16 redundant line-offset `partition_point` searches without changing
  spans, modifier parsing, synthesized identifier ranges, or diagnostics
- mirror upstream's reuse of the single parsed tag location

## Performance

Compared with the validated comprehensive branch using the same fat-LTO runner:

- official 254-fixture svelte2tsx corpus, 5,000 samples: **1.05% faster** paired median
- median peak RSS: +32 KiB (**+0.58%**, allocator-page noise)

The generic 990-attribute corpus is not directive-heavy and remained effectively
neutral (+0.43%).

## Validation

- focused location tests for every affected directive, including Unicode,
  multiline comments, modifiers, and malformed missing-name paths
- parser modern/legacy fixtures with the same declared incompatibilities
- compiler error fixtures
- `cargo test -p rsvelte_projection`
- exact pinned language-tools fixtures: 246/254, same eight known mismatches
- `cargo check -p rsvelte_projection --target wasm32-unknown-unknown`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
