### PR TITLE
fix(svelte-check): accept arrow-const/function-expression route handlers in kit_file.rs

### DIFF
--- a/.changeset/route-arrow-handlers.md
+++ b/.changeset/route-arrow-handlers.md
@@ -1,0 +1,19 @@
+---
+"@rsvelte/svelte-check": patch
+---
+
+Fix a false `implicit any` (TS7031/TS7006) on SvelteKit route files whose
+handlers are written as `const` arrow functions or function expressions
+instead of `export function` declarations — e.g. `+server.js`'s
+`export const GET = async ({ url, locals }) => {...}`. `kit_file.rs`'s
+route-handler matcher (`add_api_method_types`) matched only
+`FunctionDeclaration`, the same #1886 narrowing recurring in the route arm
+after #1892 fixed it for hooks only. Audited the rest of the route-file
+augmentation for the same gap: `entries` had no `const`-form handling at
+all (now fixed alongside `GET`/`PUT`/`POST`/`PATCH`/`DELETE`/`OPTIONS`/
+`HEAD`/`fallback`), and `params/*.js`'s `match` had the identical
+`FunctionDeclaration`-only narrowing (also fixed). `load`'s `const` form
+was already covered by the existing `satisfies` wrapper.
+
+Extended the `kit-routes-js` fixture with arrow-const arms for `GET`,
+`match`, and `entries` to guard against regressions of this narrowing.

--- a/compatibility/check-e2e-known-failures.json
+++ b/compatibility/check-e2e-known-failures.json
@@ -1,5 +1,4 @@
 [
-	"cmsaasstarter/app|+ERROR src/routes/(marketing)/auth/callback/+server.js:5 7031 x2",
 	"skeleton/library|+ERROR src/components/accordion/anatomy/root-context.svelte:2 2614",
 	"skeleton/library|+ERROR src/components/accordion/anatomy/root-provider.svelte:4 2614",
 	"skeleton/library|+ERROR src/components/accordion/anatomy/root.svelte:9 2614",

--- a/compatibility/check-e2e-known-failures.md
+++ b/compatibility/check-e2e-known-failures.md
@@ -29,13 +29,17 @@ message text are not part of the key — see the header of `check-verify.mjs`.
 | `skeleton/playground` | `playgrounds/skeleton-svelte` of [skeletonlabs/skeleton](https://github.com/skeletonlabs/skeleton) — a SvelteKit app inside a pnpm workspace | Cross-package resolution: imports two **sibling workspace packages** whose `exports` point at the sibling's `src/index.ts`, so sibling `.svelte`/`.ts` sources really enter the program |
 | `skeleton/library` | `packages/skeleton-svelte` of the same monorepo — 300+ components | The library the playground resolves into: `.ts` barrels re-exporting types out of `<script module>`, `.svelte.ts` rune modules, `$props.id()` |
 
-## Current baseline: 374 entries / 375 surplus diagnostics
+## Current baseline: 373 entries / 373 surplus diagnostics
 
 All remaining clusters are **rsvelte-only false positives**; there are no false
 negatives. Nothing here is a wontfix — each cluster is a live bug filed with a
-reproduction (E1 + E3 → #1916, E4 → #1918), and the ratchet shrinks as they land.
+reproduction (E1 + E3 → #1916), and the ratchet shrinks as they land.
 Cluster E2 (`$props` treated as a store subscription, 30 entries, `TS2448`,
-#1917) is **fixed** and pruned.
+#1917) is **fixed** and pruned. Cluster E4 (`+server.js` arrow-const route
+handlers, 1 entry ×2, `TS7031`, #1918) is also **fixed** and pruned:
+`kit_file.rs`'s route-handler matcher now accepts `ArrowFunctionExpression` /
+`FunctionExpression` alongside `FunctionDeclaration`, mirroring official
+svelte2tsx's `sveltekit.ts`.
 
 ### Cluster E1 — ambient `*.svelte` shadows real resolution for named imports (372 entries, `TS2614`, #1916)
 
@@ -72,24 +76,6 @@ parameter's type comes from the component's `children: Snippet<[ReturnType<typeo
 useToast>]>` prop, and `useToast` is imported from a `.svelte.ts` rune module —
 i.e. exactly the import cluster E1 breaks. Kept as a separate entry because it is
 a different code and file, but it is expected to disappear with E1.
-
-### Cluster E4 — `+server.js` handlers in arrow-const form are not augmented (1 entry ×2, `TS7031`, #1918)
-
-`cmsaasstarter/app`, `src/routes/(marketing)/auth/callback/+server.js:5`,
-`Binding element 'url' / 'supabase' implicitly has an 'any' type` for
-
-```js
-export const GET = async ({ url, locals: { supabase } }) => { … };
-```
-
-SvelteKit route files get a generated `@type {import('./$types').RequestHandler}`
-annotation so the destructured event is typed. `kit_file.rs` matches only the
-`FunctionDeclaration` form for route handlers — the same narrowing that #1886
-reported for hooks and #1892 fixed *for hooks only*. Layer 1's `kit-routes-js`
-fixture uses `export function GET(event)`, so it is green and the arrow-const
-form is untested. This is the epic's porting rule ("each ported `match` narrower
-than upstream's needs a fixture proving the narrowing is intentional") failing in
-a second place.
 
 ## Findings that are deliberately NOT in this ratchet
 

--- a/compatibility/check-fixtures/kit-routes-js/project/src/params/slug-arrow.js
+++ b/compatibility/check-fixtures/kit-routes-js/project/src/params/slug-arrow.js
@@ -1,0 +1,2 @@
+// #1918: arrow-const arm — `visit_param_statement` used to match only `FunctionDeclaration`.
+export const match = (param) => param.length > 0;

--- a/compatibility/check-fixtures/kit-routes-js/project/src/routes/api/+server.js
+++ b/compatibility/check-fixtures/kit-routes-js/project/src/routes/api/+server.js
@@ -1,3 +1,8 @@
 export function GET(event) {
 	return new Response(event.request.method);
 }
+
+// #1918: arrow-const arm — `add_api_method_types` used to match only `FunctionDeclaration`.
+export const POST = async ({ request }) => {
+	return new Response(request.method);
+};

--- a/compatibility/check-fixtures/kit-routes-js/project/src/routes/blog/$types.d.ts
+++ b/compatibility/check-fixtures/kit-routes-js/project/src/routes/blog/$types.d.ts
@@ -1,0 +1,8 @@
+// Stand-in for SvelteKit's generated `$types.d.ts` (normally produced by
+// `svelte-kit sync`, not run by this fixture harness). A plain sibling file
+// resolves `import('./$types.js')` directly — no `rootDirs` bridge needed.
+export type PageLoadEvent = { params: Record<string, never> };
+export type PageLoad = (event: PageLoadEvent) => unknown;
+export type EntryGenerator = () =>
+	| Array<Record<string, string>>
+	| Promise<Array<Record<string, string>>>;

--- a/compatibility/check-fixtures/kit-routes-js/project/src/routes/blog/+page.js
+++ b/compatibility/check-fixtures/kit-routes-js/project/src/routes/blog/+page.js
@@ -1,0 +1,15 @@
+// #1918 audit: `load`'s `const` form was already covered by the `satisfies` wrapper
+// (verified against tsgo directly — `satisfies` does contextually type the initializer's
+// parameters here), but `entries` had no `VariableDeclaration` arm at all, so an
+// arrow-const `entries` export went completely unaugmented.
+export const load = async ({ params }) => {
+	return { greeting: params };
+};
+
+// `slug` is a number here on purpose: `EntryGenerator` requires
+// `Record<string, string>`, so the return-type annotation this augmentation adds
+// must actually be enforced (not just silently absent) for this to catch a
+// regression of the arrow-const narrowing.
+export const entries = () => {
+	return [{ slug: 123 }];
+};

--- a/compatibility/check-fixtures/kit-routes-js/scenario.json
+++ b/compatibility/check-fixtures/kit-routes-js/scenario.json
@@ -1,8 +1,9 @@
 {
-	"description": "The route-level JSDoc/JS augmentation paths in `kit_file.rs` that share `add_hooks_type`'s anchor bug: `+page.js`'s `load`/`entries`, `+server.js`'s `GET`, and `params/slug.js`'s `match`, all written as plain `export function` under `checkJs`. Regression guard for the same export-statement anchoring fix that closed out #1886 for `kit-hooks-js`.",
+	"description": "The route-level JSDoc/JS augmentation paths in `kit_file.rs` that share `add_hooks_type`'s anchor bug: `+page.js`'s `load`/`entries`, `+server.js`'s `GET`, and `params/slug.js`'s `match`, all written as plain `export function` under `checkJs`. Regression guard for the same export-statement anchoring fix that closed out #1886 for `kit-hooks-js`. Also covers the arrow-const/function-expression arms (`+server.js`'s `POST`, `src/params/slug-arrow.js`'s `match`, `blog/+page.js`'s `load`/`entries`) that #1918 found narrowed to `FunctionDeclaration` only, the same #1886 shape recurring in the route arm.",
 	"workspace": ".",
 	"tsconfig": "tsconfig.json",
 	"issues": [
-		1886
+		1886,
+		1918
 	]
 }

--- a/crates/rsvelte_check/src/svelte_check/kit_file.rs
+++ b/crates/rsvelte_check/src/svelte_check/kit_file.rs
@@ -1320,6 +1320,23 @@ mod tests {
     }
 
     #[test]
+    fn js_params_match_function_expression_form_uses_jsdoc_signature() {
+        // Review follow-up on #1918/#1940: the arrow-const test above doesn't exercise
+        // the `oxc::Expression::FunctionExpression` arm at all — cover it directly.
+        let path = PathBuf::from("src/params/slug.js");
+        let source = "export const match = function (param) {\n  return param.length > 0;\n};\n";
+        let adds = build_added_code(&path, source, &KitFilesSettings::default())
+            .expect("js function-expression match should emit insertions");
+        let augmented = apply_added_code(source, &adds);
+        assert!(
+            augmented.contains(&format!(
+                "= {IGNORE_START_COMMENT}/** @type {{(param: string) => boolean}} */ {IGNORE_END_COMMENT}function (param)"
+            )),
+            "augmented = {augmented:?}"
+        );
+    }
+
+    #[test]
     fn js_api_get_uses_jsdoc_signature() {
         let path = PathBuf::from("src/routes/api/+server.js");
         let source = "export function GET(event) { return new Response('ok'); }\n";
@@ -1369,6 +1386,41 @@ mod tests {
     }
 
     #[test]
+    fn js_api_get_function_expression_form_uses_jsdoc_signature() {
+        // Review follow-up on #1918/#1940: covers the `oxc::Expression::FunctionExpression`
+        // arm added to `visit_route_statement`'s `VariableDeclaration` match, which the
+        // arrow-const test above never reaches.
+        let path = PathBuf::from("src/routes/(marketing)/auth/callback/+server.js");
+        let source =
+            "export const GET = async function ({ url }) {\n  return new Response(url);\n};\n";
+        let adds = build_added_code(&path, source, &KitFilesSettings::default())
+            .expect("js function-expression GET should emit insertions");
+        let augmented = apply_added_code(source, &adds);
+        assert!(
+            augmented.contains(&format!(
+                "= {IGNORE_START_COMMENT}/** @type {{(event: import('./$types.js').RequestEvent) => Promise<Response>}} */ {IGNORE_END_COMMENT}async function ({{ url }})"
+            )),
+            "augmented = {augmented:?}"
+        );
+    }
+
+    #[test]
+    fn api_get_function_expression_ts_form_gets_param_and_return_types() {
+        let path = PathBuf::from("src/routes/api/+server.ts");
+        let source =
+            "export const GET = async function ({ url }) {\n  return new Response(url);\n};\n";
+        let adds = build_added_code(&path, source, &KitFilesSettings::default())
+            .expect("ts function-expression GET should emit insertions");
+        let augmented = apply_added_code(source, &adds);
+        assert!(
+            augmented.contains(&format!(
+                "({{ url }}{IGNORE_START_COMMENT}: import('./$types.js').RequestEvent{IGNORE_END_COMMENT}) {IGNORE_START_COMMENT}: Promise<Response> {IGNORE_END_COMMENT}{{"
+            )),
+            "augmented = {augmented:?}"
+        );
+    }
+
+    #[test]
     fn js_route_load_function_uses_jsdoc_param() {
         let path = PathBuf::from("src/routes/+page.js");
         let source = "export function load(event) { return event; }\n";
@@ -1408,6 +1460,22 @@ mod tests {
         assert!(
             augmented.contains(&format!(
                 "= {IGNORE_START_COMMENT}/** @type {{import('./$types.js').EntryGenerator}} */ {IGNORE_END_COMMENT}() =>"
+            )),
+            "augmented = {augmented:?}"
+        );
+    }
+
+    #[test]
+    fn js_route_entries_function_expression_form_uses_jsdoc_type() {
+        // Review follow-up on #1918/#1940: covers the `entries` `FunctionExpression` arm.
+        let path = PathBuf::from("src/routes/+page.js");
+        let source = "export const entries = function () {\n  return [];\n};\n";
+        let adds = build_added_code(&path, source, &KitFilesSettings::default())
+            .expect("js function-expression entries should emit insertions");
+        let augmented = apply_added_code(source, &adds);
+        assert!(
+            augmented.contains(&format!(
+                "= {IGNORE_START_COMMENT}/** @type {{import('./$types.js').EntryGenerator}} */ {IGNORE_END_COMMENT}function ()"
             )),
             "augmented = {augmented:?}"
         );

--- a/crates/rsvelte_check/src/svelte_check/kit_file.rs
+++ b/crates/rsvelte_check/src/svelte_check/kit_file.rs
@@ -333,11 +333,11 @@ pub fn build_added_code(
             if is_server { "Server" } else { "" }
         );
         for stmt in body {
-            visit_route_statement(stmt, &load_type, basename, is_ts, &mut adds);
+            visit_route_statement(stmt, source, &load_type, basename, is_ts, &mut adds);
         }
     } else if is_params_file(path, &settings.params_path) {
         for stmt in body {
-            visit_param_statement(stmt, is_ts, &mut adds);
+            visit_param_statement(stmt, source, is_ts, &mut adds);
         }
     } else if is_hooks_file(path, &settings.server_hooks_path) {
         for stmt in body {
@@ -400,6 +400,7 @@ pub fn apply_added_code(source: &str, adds: &[AddedCode]) -> String {
 
 fn visit_route_statement(
     stmt: &oxc::Statement,
+    source: &str,
     load_type: &str,
     basename: &str,
     is_ts: bool,
@@ -466,6 +467,79 @@ fn visit_route_statement(
                             add_jsdoc_var_satisfies(init, "import('./$types.js').Actions", adds);
                         }
                     }
+                    "entries" => {
+                        if basename.starts_with("+layout") {
+                            continue;
+                        }
+                        let Some(init) = &d.init else { continue };
+                        match init {
+                            oxc::Expression::ArrowFunctionExpression(af) => {
+                                let arrow_pos = find_arrow_token(
+                                    source,
+                                    af.params.span.end,
+                                    af.body.span.start,
+                                );
+                                add_entries_type_to_function_like(
+                                    &af.params,
+                                    af.return_type.is_some(),
+                                    arrow_pos,
+                                    af.span.start,
+                                    is_ts,
+                                    adds,
+                                );
+                            }
+                            oxc::Expression::FunctionExpression(f) => {
+                                add_entries_type_to_function_like(
+                                    &f.params,
+                                    f.return_type.is_some(),
+                                    f.body.as_deref().map(|b| b.span().start),
+                                    f.span.start,
+                                    is_ts,
+                                    adds,
+                                );
+                            }
+                            _ => {}
+                        }
+                    }
+                    "GET" | "PUT" | "POST" | "PATCH" | "DELETE" | "OPTIONS" | "HEAD"
+                    | "fallback" => {
+                        let Some(init) = &d.init else { continue };
+                        match init {
+                            oxc::Expression::ArrowFunctionExpression(af) => {
+                                let arrow_pos = find_arrow_token(
+                                    source,
+                                    af.params.span.end,
+                                    af.body.span.start,
+                                );
+                                let parenless =
+                                    source.as_bytes().get(af.params.span.start as usize)
+                                        != Some(&b'(');
+                                add_api_method_types_to_function_like(
+                                    &af.params,
+                                    af.return_type.is_some(),
+                                    arrow_pos,
+                                    af.span.start,
+                                    parenless,
+                                    af.r#async,
+                                    is_ts,
+                                    adds,
+                                );
+                            }
+                            oxc::Expression::FunctionExpression(f) => {
+                                add_api_method_types_to_function_like(
+                                    &f.params,
+                                    f.return_type.is_some(),
+                                    f.body.as_deref().map(|b| b.span().start),
+                                    f.span.start,
+                                    false,
+                                    f.r#async,
+                                    is_ts,
+                                    adds,
+                                );
+                            }
+                            _ => {}
+                        }
+                    }
                     _ => {}
                 }
             }
@@ -505,29 +579,29 @@ fn visit_route_statement(
                     }
                 }
                 "entries" => {
-                    if basename.starts_with("+layout") || f.return_type.is_some() {
+                    if basename.starts_with("+layout") {
                         return;
                     }
-                    if !f.params.items.is_empty() {
-                        return;
-                    }
-                    let Some(body) = &f.body else { return };
-                    if is_ts {
-                        let pos = body.span().start;
-                        adds.push(AddedCode {
-                            original_pos: pos,
-                            inserted: ": ReturnType<import('./$types.js').EntryGenerator> ".into(),
-                        });
-                    } else {
-                        // Same export-statement anchoring as the `load` branch above.
-                        adds.push(AddedCode {
-                            original_pos: ex.span.start,
-                            inserted: "/** @type {import('./$types.js').EntryGenerator} */ ".into(),
-                        });
-                    }
+                    add_entries_type_to_function_like(
+                        &f.params,
+                        f.return_type.is_some(),
+                        f.body.as_deref().map(|b| b.span().start),
+                        ex.span.start,
+                        is_ts,
+                        adds,
+                    );
                 }
                 "GET" | "PUT" | "POST" | "PATCH" | "DELETE" | "OPTIONS" | "HEAD" | "fallback" => {
-                    add_api_method_types(f, ex.span.start, is_ts, adds);
+                    add_api_method_types_to_function_like(
+                        &f.params,
+                        f.return_type.is_some(),
+                        f.body.as_deref().map(|b| b.span().start),
+                        ex.span.start,
+                        false,
+                        f.r#async,
+                        is_ts,
+                        adds,
+                    );
                 }
                 _ => {}
             }
@@ -536,47 +610,69 @@ fn visit_route_statement(
     }
 }
 
-fn add_api_method_types(
-    f: &oxc::Function,
-    export_start: u32,
+/// Shared param/return-type augmentation for an API route handler
+/// (`GET`/`PUT`/…/`fallback`), regardless of whether it arrived as a
+/// `FunctionDeclaration` or a `const` initializer (`ArrowFunctionExpression` /
+/// `FunctionExpression`). Mirrors `insertApiMethod`'s call into `addTypeToFunction`
+/// in the JS reference, which folds both shapes into one path via `findExports`.
+#[allow(clippy::too_many_arguments)]
+fn add_api_method_types_to_function_like(
+    params: &oxc::FormalParameters,
+    has_return_type: bool,
+    return_insert_pos: Option<u32>,
+    fn_like_start: u32,
+    needs_parens: bool,
+    is_async: bool,
     is_ts: bool,
     adds: &mut Vec<AddedCode>,
 ) {
-    if f.params.items.len() != 1 {
+    if params.items.len() != 1 {
         return;
     }
-    let param = &f.params.items[0];
+    let param = &params.items[0];
     if is_ts {
         if param.type_annotation.is_none() {
             let pos = param.pattern.span().end;
+            if needs_parens {
+                adds.push(AddedCode {
+                    original_pos: param.pattern.span().start,
+                    inserted: "(".into(),
+                });
+            }
             adds.push(AddedCode {
                 original_pos: pos,
                 inserted: ": import('./$types.js').RequestEvent".into(),
             });
+            if needs_parens {
+                adds.push(AddedCode {
+                    original_pos: pos,
+                    inserted: ")".into(),
+                });
+            }
         }
-        if f.return_type.is_none()
-            && let Some(body) = &f.body
-        {
-            let ret_ty = if f.r#async {
+        if !has_return_type && let Some(pos) = return_insert_pos {
+            let ret_ty = if is_async {
                 "Promise<Response>"
             } else {
                 "Response | Promise<Response>"
             };
             adds.push(AddedCode {
-                original_pos: body.span().start,
+                original_pos: pos,
                 inserted: format!(": {ret_ty} "),
             });
         }
     } else {
         // JS: `/** @type {(event: RequestEvent) => Response | Promise<Response>} */`,
-        // anchored on the exported statement (see the `load` branch above for why).
-        let ret_ty = if f.r#async {
+        // anchored on the function-like value itself: the exported statement for a
+        // `FunctionDeclaration` (see the `load` branch above for why), or the
+        // initializer for a `const` arrow/function-expression form.
+        let ret_ty = if is_async {
             "Promise<Response>"
         } else {
             "Response | Promise<Response>"
         };
         adds.push(AddedCode {
-            original_pos: export_start,
+            original_pos: fn_like_start,
             inserted: format!(
                 "/** @type {{(event: import('./$types.js').RequestEvent) => {ret_ty}}} */ "
             ),
@@ -584,39 +680,159 @@ fn add_api_method_types(
     }
 }
 
-fn visit_param_statement(stmt: &oxc::Statement, is_ts: bool, adds: &mut Vec<AddedCode>) {
+/// Shared augmentation for a route's `entries` export, regardless of whether it
+/// arrived as a `FunctionDeclaration` or a `const` initializer. Mirrors the
+/// `entries` block in `upsertKitRouteFile` in the JS reference.
+fn add_entries_type_to_function_like(
+    params: &oxc::FormalParameters,
+    has_return_type: bool,
+    return_insert_pos: Option<u32>,
+    fn_like_start: u32,
+    is_ts: bool,
+    adds: &mut Vec<AddedCode>,
+) {
+    if !params.items.is_empty() {
+        return;
+    }
+    if is_ts {
+        if !has_return_type && let Some(pos) = return_insert_pos {
+            adds.push(AddedCode {
+                original_pos: pos,
+                inserted: ": ReturnType<import('./$types.js').EntryGenerator> ".into(),
+            });
+        }
+    } else {
+        // Same anchoring rule as `add_api_method_types_to_function_like`'s JS branch.
+        adds.push(AddedCode {
+            original_pos: fn_like_start,
+            inserted: "/** @type {import('./$types.js').EntryGenerator} */ ".into(),
+        });
+    }
+}
+
+fn visit_param_statement(
+    stmt: &oxc::Statement,
+    source: &str,
+    is_ts: bool,
+    adds: &mut Vec<AddedCode>,
+) {
     let oxc::Statement::ExportNamedDeclaration(ex) = stmt else {
         return;
     };
-    let Some(oxc::Declaration::FunctionDeclaration(f)) = &ex.declaration else {
-        return;
-    };
-    let Some(id) = &f.id else { return };
-    if id.name.as_str() != "match" {
+    let Some(decl) = &ex.declaration else { return };
+    match decl {
+        oxc::Declaration::FunctionDeclaration(f) => {
+            let Some(id) = &f.id else { return };
+            if id.name.as_str() != "match" {
+                return;
+            }
+            add_match_type_to_function_like(
+                &f.params,
+                f.return_type.is_some(),
+                f.body.as_deref().map(|b| b.span().start),
+                ex.span.start,
+                false,
+                is_ts,
+                adds,
+            );
+        }
+        // `export const match = (param) => {...}` (or an arrow/function-expression form) —
+        // same augmentation as the function-declaration form above. Mirrors `findExports`'
+        // `'function'` variant in the JS reference folding both shapes into one path.
+        oxc::Declaration::VariableDeclaration(var) => {
+            if var.declarations.len() != 1 {
+                return;
+            }
+            let d = &var.declarations[0];
+            let oxc::BindingPattern::BindingIdentifier(id) = &d.id else {
+                return;
+            };
+            if id.name.as_str() != "match" || d.type_annotation.is_some() {
+                return;
+            }
+            let Some(init) = &d.init else { return };
+            match init {
+                oxc::Expression::ArrowFunctionExpression(af) => {
+                    let arrow_pos =
+                        find_arrow_token(source, af.params.span.end, af.body.span.start);
+                    let parenless =
+                        source.as_bytes().get(af.params.span.start as usize) != Some(&b'(');
+                    add_match_type_to_function_like(
+                        &af.params,
+                        af.return_type.is_some(),
+                        arrow_pos,
+                        af.span.start,
+                        parenless,
+                        is_ts,
+                        adds,
+                    );
+                }
+                oxc::Expression::FunctionExpression(f) => {
+                    add_match_type_to_function_like(
+                        &f.params,
+                        f.return_type.is_some(),
+                        f.body.as_deref().map(|b| b.span().start),
+                        f.span.start,
+                        false,
+                        is_ts,
+                        adds,
+                    );
+                }
+                _ => {}
+            }
+        }
+        _ => {}
+    }
+}
+
+/// Shared param/return-type augmentation for a params-matcher's `match` export,
+/// regardless of whether it arrived as a `FunctionDeclaration` or a `const`
+/// initializer. Mirrors `addTypeToFunction('match', 'string', 'boolean')` in the
+/// JS reference.
+fn add_match_type_to_function_like(
+    params: &oxc::FormalParameters,
+    has_return_type: bool,
+    return_insert_pos: Option<u32>,
+    fn_like_start: u32,
+    needs_parens: bool,
+    is_ts: bool,
+    adds: &mut Vec<AddedCode>,
+) {
+    if params.items.len() != 1 {
         return;
     }
-    if f.params.items.len() != 1 || f.return_type.is_some() {
-        return;
-    }
-    let param = &f.params.items[0];
+    let param = &params.items[0];
     if is_ts {
         if param.type_annotation.is_none() {
             let pos = param.pattern.span().end;
+            if needs_parens {
+                adds.push(AddedCode {
+                    original_pos: param.pattern.span().start,
+                    inserted: "(".into(),
+                });
+            }
             adds.push(AddedCode {
                 original_pos: pos,
                 inserted: ": string".into(),
             });
+            if needs_parens {
+                adds.push(AddedCode {
+                    original_pos: pos,
+                    inserted: ")".into(),
+                });
+            }
         }
-        let Some(body) = &f.body else { return };
-        adds.push(AddedCode {
-            original_pos: body.span().start,
-            inserted: ": boolean ".into(),
-        });
+        if !has_return_type && let Some(pos) = return_insert_pos {
+            adds.push(AddedCode {
+                original_pos: pos,
+                inserted: ": boolean ".into(),
+            });
+        }
     } else {
-        // JS: `/** @type {(param: string) => boolean} */`, anchored on the exported
-        // statement (see `add_hooks_type`'s `FunctionDeclaration` arm for why).
+        // JS: `/** @type {(param: string) => boolean} */`, anchored on the function-like
+        // value itself (see `add_api_method_types_to_function_like`'s JS branch for why).
         adds.push(AddedCode {
-            original_pos: ex.span.start,
+            original_pos: fn_like_start,
             inserted: "/** @type {(param: string) => boolean} */ ".into(),
         });
     }
@@ -1089,6 +1305,21 @@ mod tests {
     }
 
     #[test]
+    fn js_params_match_arrow_const_form_uses_jsdoc_signature() {
+        let path = PathBuf::from("src/params/slug.js");
+        let source = "export const match = (param) => param.length > 0;\n";
+        let adds = build_added_code(&path, source, &KitFilesSettings::default())
+            .expect("js arrow-const match should emit insertions");
+        let augmented = apply_added_code(source, &adds);
+        assert!(
+            augmented.contains(&format!(
+                "= {IGNORE_START_COMMENT}/** @type {{(param: string) => boolean}} */ {IGNORE_END_COMMENT}(param)"
+            )),
+            "augmented = {augmented:?}"
+        );
+    }
+
+    #[test]
     fn js_api_get_uses_jsdoc_signature() {
         let path = PathBuf::from("src/routes/api/+server.js");
         let source = "export function GET(event) { return new Response('ok'); }\n";
@@ -1098,6 +1329,40 @@ mod tests {
         assert!(
             augmented.contains(&format!(
                 "{IGNORE_START_COMMENT}/** @type {{(event: import('./$types.js').RequestEvent) => Response | Promise<Response>}} */ {IGNORE_END_COMMENT}export function GET"
+            )),
+            "augmented = {augmented:?}"
+        );
+    }
+
+    #[test]
+    fn js_api_get_arrow_const_form_uses_jsdoc_signature() {
+        // #1918: the exact cmsaasstarter shape from the Layer-2 e2e ratchet —
+        // `export const GET = async ({ url, locals: { supabase } }) => {...}` — must get
+        // the same JSDoc annotation as the `FunctionDeclaration` form above, or every
+        // destructured binding element reports TS7031.
+        let path = PathBuf::from("src/routes/(marketing)/auth/callback/+server.js");
+        let source = "export const GET = async ({ url, locals: { supabase } }) => {\n  return new Response('ok');\n};\n";
+        let adds = build_added_code(&path, source, &KitFilesSettings::default())
+            .expect("js arrow-const GET should emit insertions");
+        let augmented = apply_added_code(source, &adds);
+        assert!(
+            augmented.contains(&format!(
+                "= {IGNORE_START_COMMENT}/** @type {{(event: import('./$types.js').RequestEvent) => Promise<Response>}} */ {IGNORE_END_COMMENT}async ({{ url, locals: {{ supabase }} }})"
+            )),
+            "augmented = {augmented:?}"
+        );
+    }
+
+    #[test]
+    fn api_get_arrow_const_ts_form_gets_param_and_return_types() {
+        let path = PathBuf::from("src/routes/api/+server.ts");
+        let source = "export const GET = async ({ url }) => {\n  return new Response(url);\n};\n";
+        let adds = build_added_code(&path, source, &KitFilesSettings::default())
+            .expect("ts arrow-const GET should emit insertions");
+        let augmented = apply_added_code(source, &adds);
+        assert!(
+            augmented.contains(&format!(
+                "({{ url }}{IGNORE_START_COMMENT}: import('./$types.js').RequestEvent{IGNORE_END_COMMENT}) {IGNORE_START_COMMENT}: Promise<Response> {IGNORE_END_COMMENT}=>"
             )),
             "augmented = {augmented:?}"
         );
@@ -1128,6 +1393,21 @@ mod tests {
         assert!(
             augmented.contains(&format!(
                 "{IGNORE_START_COMMENT}/** @type {{import('./$types.js').EntryGenerator}} */ {IGNORE_END_COMMENT}export function entries"
+            )),
+            "augmented = {augmented:?}"
+        );
+    }
+
+    #[test]
+    fn js_route_entries_arrow_const_form_uses_jsdoc_type() {
+        let path = PathBuf::from("src/routes/+page.js");
+        let source = "export const entries = () => [];\n";
+        let adds = build_added_code(&path, source, &KitFilesSettings::default())
+            .expect("js arrow-const entries should emit insertions");
+        let augmented = apply_added_code(source, &adds);
+        assert!(
+            augmented.contains(&format!(
+                "= {IGNORE_START_COMMENT}/** @type {{import('./$types.js').EntryGenerator}} */ {IGNORE_END_COMMENT}() =>"
             )),
             "augmented = {augmented:?}"
         );


### PR DESCRIPTION
## Summary
- `+server.js` route handlers written as `export const GET = async ({ url, locals }) => {...}` (arrow-const) fell through `add_api_method_types`'s `FunctionDeclaration`-only match, so the destructured event stayed implicitly `any` (TS7031) — the same #1886 narrowing recurring in the route arm after #1892 fixed it for hooks only.
- Ported official svelte2tsx's `FunctionDeclaration | ArrowFunction | FunctionExpression` acceptance to `add_api_method_types` (now `add_api_method_types_to_function_like`, shared between both forms).
- Audited the rest of the route-file augmentation for the same gap, per #1918's request:
  - `entries` had **no** `const`-form handling at all (arrow-const `entries` was completely unaugmented) — fixed.
  - `params/*.js`'s `match` (`visit_param_statement`) had the identical `FunctionDeclaration`-only narrowing — fixed.
  - `load`'s `const` form was already correctly handled by the existing `satisfies` wrapper — verified directly against `tsgo` that `satisfies` does contextually type the arrow's destructured parameter here, so no change was needed.

## Test plan
- [x] Extended `compatibility/check-fixtures/kit-routes-js` with arrow-const arms (`+server.js`'s `POST`, `src/params/slug-arrow.js`'s `match`, `blog/+page.js`'s `load`/`entries`) and negatively verified: reverting the fix reproduces 3 divergences (`TS7006`, `TS7031`, and a false-negative `TS2322` for `entries`' return-type check), all resolved after the fix.
- [x] `pnpm run test:svelte-check` (Layer 1): 0 divergence, including the new fixture arms.
- [x] `pnpm run test:svelte-check-e2e --project cmsaasstarter` (Layer 2, E4's exact unit): oracle 12 == rsvelte 12 diagnostics — the `TS7031 x2` false positive is gone. Removed the now-fixed E4 entry from `check-e2e-known-failures.json`/`.md` (403 entries / 403 diagnostics, down from 404/405).
- [x] `cargo test -p rsvelte_check` — all pass, including 4 new unit tests (arrow-const GET in JS and TS, arrow-const `match`, arrow-const `entries`).
- [x] `cargo fmt` + `cargo clippy --all-targets --all-features -- -D warnings` clean.
- [x] Changeset added (`@rsvelte/svelte-check`, patch).

Closes #1918