### PR TITLE
Skip duplicate same-line svelte2tsx location searches

### DIFF
--- a/crates/rsvelte_core/src/compiler/phases/1_parse/parser.rs
+++ b/crates/rsvelte_core/src/compiler/phases/1_parse/parser.rs
@@ -446,10 +446,17 @@ impl<'a> Parser<'a> {
             .saturating_sub(1);
         let start_line_start = self.line_offsets.get(start_line).copied().unwrap_or(0);
 
-        let end_line = self
+        let end_line = if self
             .line_offsets
-            .partition_point(|&offset| offset <= end)
-            .saturating_sub(1);
+            .get(start_line + 1)
+            .is_none_or(|&offset| end < offset)
+        {
+            start_line
+        } else {
+            self.line_offsets
+                .partition_point(|&offset| offset <= end)
+                .saturating_sub(1)
+        };
         let end_line_start = self.line_offsets.get(end_line).copied().unwrap_or(0);
 
         SourceLocation {

--- a/crates/rsvelte_core/tests/directive_attribute_locations.rs
+++ b/crates/rsvelte_core/tests/directive_attribute_locations.rs
@@ -95,7 +95,11 @@ fn directive_locations_cover_the_full_unicode_attribute_names() {
 
 #[test]
 fn missing_directive_names_remain_errors() {
-    for source in ["<div use:></div>", "<div transition:|global></div>"] {
+    for source in [
+        "<div use:></div>",
+        "<div transition:|global></div>",
+        "<div\n  use:\n></div>",
+    ] {
         let error = parse(source, &Allocator::default(), ParseOptions::default())
             .expect_err("missing directive name must fail");
 
@@ -107,4 +111,88 @@ fn missing_directive_names_remain_errors() {
             "unexpected error for {source:?}: {error:?}"
         );
     }
+}
+
+#[test]
+fn multiline_attribute_comments_keep_exact_locations() {
+    let source = "<div /* α\nβ */ on:click></div>";
+    let root = parse(source, &Allocator::default(), ParseOptions::default()).expect("parse");
+
+    assert_eq!(root.comments.len(), 1);
+    let comment = &root.comments[0];
+    assert_eq!(comment.value, " α\nβ ");
+    assert_eq!(
+        (
+            comment.loc.start.line,
+            comment.loc.start.column,
+            comment.loc.start.character,
+        ),
+        (1, 5, 5)
+    );
+    assert_eq!(
+        (
+            comment.loc.end.line,
+            comment.loc.end.column,
+            comment.loc.end.character,
+        ),
+        (2, 5, 16)
+    );
+
+    let TemplateNode::RegularElement(element) = &root.fragment.nodes[0] else {
+        panic!("expected regular element");
+    };
+    let Attribute::OnDirective(on) = &element.attributes[0] else {
+        panic!("expected on directive");
+    };
+    let name_loc = on.name_loc.as_ref().expect("name location");
+    assert_eq!(
+        (
+            name_loc.start.line,
+            name_loc.start.column,
+            name_loc.start.character,
+        ),
+        (2, 6, 17)
+    );
+    assert_eq!(
+        (
+            name_loc.end.line,
+            name_loc.end.column,
+            name_loc.end.character,
+        ),
+        (2, 14, 25)
+    );
+}
+
+#[test]
+fn loose_unterminated_multiline_comments_keep_eof_location() {
+    let source = "<div /* α\n未終了";
+    let root = parse(
+        source,
+        &Allocator::default(),
+        ParseOptions {
+            loose: true,
+            ..ParseOptions::default()
+        },
+    )
+    .expect("loose parse");
+
+    assert_eq!(root.comments.len(), 1);
+    let comment = &root.comments[0];
+    assert_eq!(comment.value, " α\n未終了");
+    assert_eq!(
+        (
+            comment.loc.start.line,
+            comment.loc.start.column,
+            comment.loc.start.character,
+        ),
+        (1, 5, 5)
+    );
+    assert_eq!(
+        (
+            comment.loc.end.line,
+            comment.loc.end.column,
+            comment.loc.end.character,
+        ),
+        (2, 9, source.len() as u32)
+    );
 }


### PR DESCRIPTION
## Summary

- reuse the already-found start line when a parsed name ends before the next
  line offset
- remove the second `partition_point` for ordinary element, attribute, and
  directive name locations
- retain the existing end-line lookup for multiline comments and malformed EOF
  cases

## Performance

Incremental to the directive-location reuse PR using the same fat-LTO runner:

- official 254-fixture svelte2tsx corpus, 5,000 samples: **0.69% faster** paired median
- 990-attribute corpus: effectively neutral (**+0.12%**)
- median peak RSS: unchanged at 5,701,632 bytes

## Validation

- exact Unicode, multiline comment, unterminated EOF, and malformed directive
  location tests
- parser modern/legacy fixtures with the same declared incompatibilities
- `cargo test -p rsvelte_projection`
- exact pinned language-tools fixtures: 246/254, same eight known mismatches
- `cargo check -p rsvelte_projection --target wasm32-unknown-unknown`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
