### PR TITLE
Optimize svelte2tsx source-map position scans

### DIFF
--- a/crates/rsvelte_projection/src/svelte2tsx/magic_string.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/magic_string.rs
@@ -546,10 +546,12 @@ impl<'a> MappingState<'a> {
             Err(index) => index - 1,
         };
         let line_start = self.original_line_starts[line];
-        let column = original[line_start..offset]
-            .chars()
-            .map(char::len_utf16)
-            .sum::<usize>();
+        let column_source = &original[line_start..offset];
+        let column = if column_source.is_ascii() {
+            column_source.len()
+        } else {
+            column_source.chars().map(char::len_utf16).sum::<usize>()
+        };
         (line as i64, column as i64)
     }
 
@@ -1341,11 +1343,7 @@ impl fmt::Display for MagicString<'_> {
 /// Compute byte offsets of line starts (the offset of the first character on each line).
 fn line_starts(s: &str) -> Vec<usize> {
     let mut starts = vec![0usize];
-    for (i, ch) in s.char_indices() {
-        if ch == '\n' {
-            starts.push(i + 1);
-        }
-    }
+    starts.extend(memchr::memchr_iter(b'\n', s.as_bytes()).map(|index| index + 1));
     starts
 }
 


### PR DESCRIPTION
## Summary

- use `memchr` to index original-source line feeds during source-map generation
- use byte length directly for ASCII original-column slices
- preserve the existing UTF-16 scalar path for non-ASCII slices

## Performance

Fat-LTO A/B against `main` after #1948:

- language-tools corpus, 5,000 samples/binary: **-2.83%** paired median, **-2.09%** unpaired median
- max RSS, 30 paired rounds: **0 bytes / 0%**

## Validation

- full `rsvelte_projection` test suite
- pinned svelte2tsx projection: exact 246/254, same 8 known upstream mismatches
- `wasm32-unknown-unknown` check
- workspace Clippy with all targets/features and warnings denied
- `cargo fmt --check`
- `git diff --check`
