### PR TITLE
Optimize svelte2tsx script close detection

### DIFF
--- a/crates/rsvelte_projection/src/svelte2tsx/svelte2tsx.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/svelte2tsx.rs
@@ -366,6 +366,56 @@ fn remap_forward_segments_oracle(
     remapped
 }
 
+fn contains_exact_script_close_tag(script: &str) -> bool {
+    let bytes = script.as_bytes();
+    let exact = b"</script>";
+    if bytes.len() >= exact.len() && bytes[bytes.len() - exact.len()..].eq_ignore_ascii_case(exact)
+    {
+        return true;
+    }
+
+    // Keep the full scan for malformed parser spans that official svelte2tsx still accepts.
+    bytes
+        .windows(exact.len())
+        .any(|window| window.eq_ignore_ascii_case(exact))
+}
+
+#[cfg(test)]
+mod script_close_tag_tests {
+    use super::contains_exact_script_close_tag;
+
+    fn oracle(script: &str) -> bool {
+        script
+            .as_bytes()
+            .windows(9)
+            .any(|window| window.eq_ignore_ascii_case(b"</script>"))
+    }
+
+    #[test]
+    fn exact_close_tag_fast_path_matches_the_full_scan() {
+        for prefix_len in [0, 1, 8, 64, 4096] {
+            let mut script = "x".repeat(prefix_len);
+            script.push_str("</ScRiPt>");
+            assert!(contains_exact_script_close_tag(&script));
+            assert_eq!(contains_exact_script_close_tag(&script), oracle(&script));
+        }
+    }
+
+    #[test]
+    fn malformed_and_nonterminal_close_tags_match_the_full_scan() {
+        for script in [
+            "",
+            "</script",
+            "</script   >",
+            "before</SCRIPT>after",
+            "before</script>\n",
+            "before<\\/script>after",
+        ] {
+            assert_eq!(contains_exact_script_close_tag(script), oracle(script));
+        }
+    }
+}
+
 /// Convert a Svelte component source to TypeScript/TSX for type checking.
 ///
 /// This is the main entry point for the svelte2tsx module. It:
@@ -624,10 +674,7 @@ pub fn svelte2tsx(
     // does NOT contain the exact ASCII string `</script>` (case-insensitive).
     let has_instance_script = ast.instance.as_ref().is_some_and(|inst| {
         let slice = slice_src(source, inst.start as usize, inst.end as usize);
-        slice
-            .as_bytes()
-            .windows(9)
-            .any(|w| w.eq_ignore_ascii_case(b"</script>"))
+        contains_exact_script_close_tag(slice)
     });
     let has_module_script = ast.module.is_some();
 


### PR DESCRIPTION
## Summary

- check the parser span tail before scanning an instance script for `</script>`
- reduce normal well-formed script-close detection from O(script bytes) to O(1)
- preserve the full case-insensitive scan for malformed/nonterminal spans
- test the fast path against the previous scan oracle

## Performance

Fat-LTO A/B against `main` after #1949 and #1950:

- language-tools corpus, 7,500 samples/binary: **-1.18%** paired median, **-1.02%** unpaired median
- script-heavy source-map fixture, 10,000 samples/binary: **-1.22%** paired median, **-1.17%** unpaired median
- max RSS, 30 paired rounds: **-16 KiB / -0.29%**

## Validation

- full `rsvelte_projection` test suite
- pinned svelte2tsx projection: exact 246/254, same 8 known upstream mismatches
- `wasm32-unknown-unknown` check
- `cargo clippy -p rsvelte_projection --all-targets --all-features -- -D warnings`
- `cargo fmt --check`
- `git diff --check`
