### PR TITLE
Optimize svelte2tsx whole-word searches

### DIFF
--- a/crates/rsvelte_projection/src/svelte2tsx/utils/lexical.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/utils/lexical.rs
@@ -15,32 +15,17 @@ pub(crate) fn contains_word(haystack: &[u8], needle: &[u8]) -> bool {
     if needle.is_empty() || haystack.len() < needle.len() {
         return false;
     }
-    let first = needle[0];
-    let mut i = 0;
-    while i + needle.len() <= haystack.len() {
-        let off = match memchr::memchr(first, &haystack[i..]) {
-            Some(o) => o,
-            None => return false,
-        };
-        let pos = i + off;
-        if pos + needle.len() > haystack.len() {
-            return false;
+    let finder = memchr::memmem::Finder::new(needle);
+    let mut search = 0;
+    while let Some(offset) = finder.find(&haystack[search..]) {
+        let pos = search + offset;
+        let before_ok = pos == 0 || !is_ident_char(haystack[pos - 1]);
+        let after = pos + needle.len();
+        let after_ok = after == haystack.len() || !is_ident_char(haystack[after]);
+        if before_ok && after_ok {
+            return true;
         }
-        if &haystack[pos..pos + needle.len()] == needle {
-            let before_ok = pos == 0
-                || !(haystack[pos - 1].is_ascii_alphanumeric()
-                    || haystack[pos - 1] == b'_'
-                    || haystack[pos - 1] == b'$');
-            let after = pos + needle.len();
-            let after_ok = after == haystack.len()
-                || !(haystack[after].is_ascii_alphanumeric()
-                    || haystack[after] == b'_'
-                    || haystack[after] == b'$');
-            if before_ok && after_ok {
-                return true;
-            }
-        }
-        i = pos + 1;
+        search = pos + 1;
     }
     false
 }
@@ -181,6 +166,37 @@ pub(crate) fn lexical_identifiers_in_expressions(text: &str) -> Vec<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn contains_word_checks_every_match_and_identifier_boundary() {
+        assert!(contains_word(b"await", b"await"));
+        assert!(contains_word(b"x;await()", b"await"));
+        assert!(contains_word(b"xawait await", b"await"));
+        assert!(!contains_word(b"xawait", b"await"));
+        assert!(!contains_word(b"awaited", b"await"));
+        assert!(!contains_word(b"$await _await", b"await"));
+        assert!(!contains_word(b"", b"await"));
+        assert!(!contains_word(b"await", b""));
+    }
+
+    #[test]
+    fn contains_word_matches_identifier_boundaries_for_every_byte() {
+        for needle in [b"await".as_slice(), b"import", b"function"] {
+            let mut haystack = [0; 10];
+            haystack[1..needle.len() + 1].copy_from_slice(needle);
+            for before in u8::MIN..=u8::MAX {
+                haystack[0] = before;
+                for after in u8::MIN..=u8::MAX {
+                    haystack[needle.len() + 1] = after;
+                    assert_eq!(
+                        contains_word(&haystack[..needle.len() + 2], needle),
+                        !is_ident_char(before) && !is_ident_char(after),
+                        "needle={needle:?}, before={before}, after={after}"
+                    );
+                }
+            }
+        }
+    }
 
     #[test]
     fn lexical_identifiers_in_expressions_only_reads_brace_blocks() {


### PR DESCRIPTION
## Summary

- use one reusable `memchr::memmem::Finder` per whole-word search
- retain the exact ASCII identifier-boundary semantics
- cover repeated matches and every possible byte before/after `await`, `import`, and `function`

The previous loop used a first-byte `memchr` and compared the full needle at every candidate. The packed-pair search used by `memmem` rejects false candidates more efficiently on the source and script spans where `contains_word` appears in the profile.

## Performance

Fat LTO, one codegen unit, pinned language-tools corpus, alternating execution order:

| Base | Samples per binary | Paired median | Unpaired median |
|---|---:|---:|---:|
| #1954 | 7,500 | -0.95% | -0.48% |
| #1954 repeat | 7,500 | -0.33% | -0.38% |
| #1954 extended | 15,000 | -0.87% | -0.67% |
| #1955, after rebase | 15,000 | -0.57% | -0.58% |

Peak RSS was unchanged before the rebase and +32 KiB (+0.58%) in two post-rebase 50-round measurements. `Finder` is stack-only and the binary grows by 160 bytes; the RSS difference is consistent with additional touched code pages rather than heap growth.

## Validation

- exhaustive boundary oracle: 196,608 cases
- `cargo test -p rsvelte_projection`
- pinned language-tools parity after rebase: 249/254, exactly the same five known mismatches
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo check -p rsvelte_projection --target wasm32-unknown-unknown`
- `cargo fmt --all -- --check`
