### PR TITLE
Reserve svelte2tsx component export output

### DIFF
--- a/crates/rsvelte_projection/src/svelte2tsx/add_component_export.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/add_component_export.rs
@@ -115,7 +115,16 @@ pub(crate) fn add_component_export(
     // Build events string from template info and component events
     let events_str = build_events_str(exported_names, template_info, events);
 
-    let mut closing = String::new();
+    let component_doc_len = component_doc.as_deref().map_or(0, str::len);
+    let common_capacity = props_str.len()
+        + exports_str.len()
+        + bindings_str.len()
+        + slots_str.len()
+        + events_str.len()
+        + safe_name.len() * 4
+        + component_doc_len
+        + 256;
+    let mut closing = String::with_capacity(common_capacity);
     closing.push_str("};\n");
     let _ = writeln!(
         closing,


### PR DESCRIPTION
## Summary

- compute a common-case lower bound for the appended component-export output
- reserve that capacity before the first write
- avoid repeated growth and copying from the previous empty `String`

The estimate includes the already-built props, exports, bindings, slots, events, component name, and documentation plus the fixed common-path syntax. Generic and uncommon branches can still grow normally when needed.

## Performance

Fat LTO, one codegen unit, pinned language-tools corpus, alternating execution order:

| Base | Samples per binary | Paired median | Unpaired median |
|---|---:|---:|---:|
| #1954 | 7,500 | -0.78% | -0.46% |
| #1954 repeat | 7,500 | -1.01% | -0.56% |
| #1956, after rebase | 15,000 | -0.56% | -0.50% |

The optimized binary is 32 bytes smaller. Peak RSS was +16 KiB (+0.29%) at both tested bases; this is one page of allocator/process variance, while the change reduces rather than adds output-buffer allocations.

## Validation

- pinned language-tools parity after rebase: 249/254, exactly the same five known mismatches
- `cargo test -p rsvelte_projection`
- `cargo fmt --all -- --check`
