### PR TITLE
fix(changesets): correct package name rsvelte-check -> @rsvelte/svelte-check

### DIFF
--- a/.changeset/typescript-7-native-tsc.md
+++ b/.changeset/typescript-7-native-tsc.md
@@ -1,5 +1,5 @@
 ---
-"rsvelte-check": patch
+"@rsvelte/svelte-check": patch
 ---
 
 Make `--tsgo` mean "type-check with the TypeScript 7 native compiler", matching


### PR DESCRIPTION
The `typescript-7-native-tsc` changeset referenced `rsvelte-check`, which is not a workspace package name, so `changeset version` failed in the release CI ([failing run](https://github.com/baseballyama/rsvelte/actions/runs/30511755070/job/90775479939)). The package is `@rsvelte/svelte-check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013JDTA8RC6ix1bneHLUKdnV