### PR TITLE
ci: streamline GitHub Actions

### DIFF
--- a/.github/actions/setup-node-pnpm/action.yml
+++ b/.github/actions/setup-node-pnpm/action.yml
@@ -1,0 +1,33 @@
+name: Setup Node.js and pnpm
+description: Install the pinned Node.js and pnpm toolchains with optional dependency caching
+
+inputs:
+  node-version:
+    description: Node.js version
+    default: '24'
+  cache:
+    description: Cache the pnpm store
+    default: 'false'
+  cache-dependency-path:
+    description: Lockfiles used to key the pnpm store cache
+    default: 'pnpm-lock.yaml'
+
+runs:
+  using: composite
+  steps:
+    - name: Install pnpm
+      uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+
+    - name: Setup Node.js
+      if: inputs.cache != 'true'
+      uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+      with:
+        node-version: ${{ inputs.node-version }}
+
+    - name: Setup Node.js
+      if: inputs.cache == 'true'
+      uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+      with:
+        node-version: ${{ inputs.node-version }}
+        cache: pnpm
+        cache-dependency-path: ${{ inputs.cache-dependency-path }}

--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -1,0 +1,46 @@
+name: Setup Rust
+description: Install the pinned Rust toolchain and optional CI tooling
+
+inputs:
+  toolchain:
+    description: Rust toolchain version
+    default: '1.97.1'
+  components:
+    description: Comma-separated rustup components
+    default: ''
+  targets:
+    description: Comma-separated rustup targets
+    default: ''
+  mold:
+    description: Install mold as the default linker
+    default: 'false'
+  nextest:
+    description: Install cargo-nextest
+    default: 'false'
+  wasm-pack:
+    description: Install wasm-pack
+    default: 'false'
+
+runs:
+  using: composite
+  steps:
+    - name: Install Rust
+      uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master
+      with:
+        toolchain: ${{ inputs.toolchain }}
+        components: ${{ inputs.components }}
+        targets: ${{ inputs.targets }}
+
+    - name: Setup mold linker
+      if: inputs.mold == 'true'
+      uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444 # v1
+
+    - name: Install cargo-nextest
+      if: inputs.nextest == 'true'
+      uses: taiki-e/install-action@nextest
+
+    - name: Install wasm-pack
+      if: inputs.wasm-pack == 'true'
+      uses: jetli/wasm-pack-action@0d096b08b4e5a7de8c28de67e11e945404e9eefa # v0.4.0
+      with:
+        version: 'v0.15.0'

--- a/.github/workflows/auto-update-oxfmt.yml
+++ b/.github/workflows/auto-update-oxfmt.yml
@@ -54,19 +54,11 @@ jobs:
           submodules: false
           token: ${{ secrets.GH_PAT || github.token }}
 
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        with:
-          node-version: '24'
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+      - uses: ./.github/actions/setup-node-pnpm
 
       # Needed to regenerate Cargo.lock against the new oxc rev (see the oxc-rev
       # sync step). Resolution only; nothing is compiled here.
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master
-        with:
-          toolchain: 1.97.1
+      - uses: ./.github/actions/setup-rust
 
       - name: Read currently pinned oxfmt version
         id: current

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -19,6 +19,9 @@ on:
     types: [opened, synchronize, reopened, labeled]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
@@ -51,10 +54,7 @@ jobs:
         with:
           submodules: false
 
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master
-        with:
-          toolchain: 1.97.1
+      - uses: ./.github/actions/setup-rust
 
       - name: Cache cargo registry + target
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
@@ -65,6 +65,7 @@ jobs:
           # forever. Saving on failure preserves the compiled `target/` even
           # if a later step fails.
           cache-on-failure: true
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Run criterion
         # ONE `cargo bench` invocation that compiles *and* measures.

--- a/.github/workflows/capi.yml
+++ b/.github/workflows/capi.yml
@@ -33,6 +33,9 @@ on:
       - '.github/workflows/capi.yml'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
@@ -90,10 +93,7 @@ jobs:
       - name: Checkout svelte submodule (shallow)
         run: git submodule update --init --depth 1 submodules/svelte
 
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master
-        with:
-          toolchain: 1.97.1
+      - uses: ./.github/actions/setup-rust
 
       # Without this every run recompiles the whole oxc_* dependency graph
       # in release mode from scratch (the bulk of the build time). The
@@ -103,6 +103,7 @@ jobs:
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           shared-key: capi-${{ matrix.os }}
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       # Build twice on purpose: the first run regenerates the header
       # into include/rsvelte.h (build script writes when env var unset),

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+  pull-requests: write
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
@@ -13,6 +17,15 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   RUSTFLAGS: -Dwarnings
+  CARGO_INCREMENTAL: "0"
+  CARGO_PROFILE_DEV_DEBUG: "0"
+  CARGO_PROFILE_TEST_DEBUG: "0"
+  # CI validates behavior, not distribution-binary throughput. Release artifacts
+  # keep the workspace's fat-LTO profiles in release.yml.
+  CARGO_PROFILE_RELEASE_LTO: "off"
+  CARGO_PROFILE_RELEASE_CODEGEN_UNITS: "16"
+  CARGO_PROFILE_DIST_LINT_LTO: "off"
+  CARGO_PROFILE_DIST_LINT_CODEGEN_UNITS: "16"
 
 jobs:
   fmt:
@@ -22,10 +35,8 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master
+      - uses: ./.github/actions/setup-rust
         with:
-          toolchain: 1.97.1
           components: rustfmt
 
       - name: Check formatting
@@ -42,13 +53,10 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - name: Install pnpm
-        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
-
-      - name: Setup Node.js
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+      - uses: ./.github/actions/setup-node-pnpm
         with:
-          node-version: '24'
+          cache: 'true'
+          cache-dependency-path: apps/playground/pnpm-lock.yaml
 
       - name: Check playground lockfile is in sync
         working-directory: apps/playground
@@ -61,16 +69,19 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          submodules: true
+          submodules: false
 
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master
+      - name: Checkout svelte submodule (shallow)
+        run: git submodule update --init --depth 1 submodules/svelte
+
+      - uses: ./.github/actions/setup-rust
         with:
-          toolchain: 1.97.1
           components: clippy
 
       - name: Cache cargo registry + target
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Run clippy
         run: cargo clippy --all-targets --all-features -- -D warnings
@@ -82,10 +93,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master
-        with:
-          toolchain: 1.97.1
+      - uses: ./.github/actions/setup-rust
 
       - name: Check compiler-only graph and package leaf
         run: scripts/ci/check-embeddable-core.sh
@@ -147,33 +155,17 @@ jobs:
       - name: Checkout needed submodules (shallow)
         run: git submodule update --init --depth 1 submodules/svelte submodules/language-tools submodules/eslint-plugin-svelte submodules/esrap
 
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master
+      - uses: ./.github/actions/setup-rust
         with:
-          toolchain: 1.97.1
+          mold: 'true'
+          nextest: 'true'
 
-      # mold is a drop-in faster linker. The test build links ~150 separate
-      # integration-test binaries (one per tests/*.rs), so link time is a real
-      # chunk of the cold/changed-crate build. `make-default: true` replaces the
-      # system `cc` linker transparently, so no RUSTFLAGS change is needed and
-      # the rust-cache key is unaffected.
-      - name: Setup mold linker
-        uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444 # v1
-
-      # nextest runs every test from every binary in a single global process
-      # pool, instead of `cargo test`'s one-binary-at-a-time serial harness —
-      # a ~2x wall-clock win on this suite. Installed as a prebuilt binary so
-      # there's no compile cost.
-      - name: Install cargo-nextest
-        uses: taiki-e/install-action@nextest
-
-      - name: Setup Node.js
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+      - uses: ./.github/actions/setup-node-pnpm
         with:
-          node-version: '24'
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+          cache: 'true'
+          cache-dependency-path: |
+            submodules/svelte/pnpm-lock.yaml
+            submodules/language-tools/pnpm-lock.yaml
 
       - name: Resolve Svelte submodule SHA
         id: svelte-sha
@@ -240,6 +232,8 @@ jobs:
 
       - name: Cache cargo registry + target
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       # NOTE: the oxfmt install + svelte.dev formatter-parity corpus generation
       # (~130 s on a cold macOS runner) used to live here, but the only tests
@@ -318,26 +312,20 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          submodules: true
+          submodules: false
 
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master
+      - name: Checkout svelte submodule (shallow)
+        run: git submodule update --init --depth 1 submodules/svelte
+
+      - uses: ./.github/actions/setup-rust
         with:
-          toolchain: 1.97.1
+          mold: 'true'
+          nextest: 'true'
 
-      - name: Setup mold linker
-        uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444 # v1
-
-      - name: Install cargo-nextest
-        uses: taiki-e/install-action@nextest
-
-      - name: Setup Node.js
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+      - uses: ./.github/actions/setup-node-pnpm
         with:
-          node-version: '24'
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+          cache: 'true'
+          cache-dependency-path: submodules/svelte/pnpm-lock.yaml
 
       - name: Resolve Svelte submodule SHA
         id: svelte-sha
@@ -413,16 +401,10 @@ jobs:
       - name: Checkout svelte submodule (shallow)
         run: git submodule update --init --depth 1 submodules/svelte
 
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master
+      - uses: ./.github/actions/setup-rust
         with:
-          toolchain: 1.97.1
-
-      - name: Setup mold linker
-        uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444 # v1
-
-      - name: Install cargo-nextest
-        uses: taiki-e/install-action@nextest
+          mold: 'true'
+          nextest: 'true'
 
       - name: Cache cargo registry + target
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
@@ -461,16 +443,10 @@ jobs:
       - name: Checkout svelte submodule (shallow)
         run: git submodule update --init --depth 1 submodules/svelte
 
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master
+      - uses: ./.github/actions/setup-rust
         with:
-          toolchain: 1.97.1
-
-      - name: Setup mold linker
-        uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444 # v1
-
-      - name: Install cargo-nextest
-        uses: taiki-e/install-action@nextest
+          mold: 'true'
+          nextest: 'true'
 
       - name: Cache cargo registry + target
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
@@ -504,24 +480,12 @@ jobs:
       - name: Checkout svelte + svelte.dev submodules (shallow)
         run: git submodule update --init --depth 1 submodules/svelte submodules/svelte.dev
 
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master
+      - uses: ./.github/actions/setup-rust
         with:
-          toolchain: 1.97.1
+          mold: 'true'
+          nextest: 'true'
 
-      - name: Setup mold linker
-        uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444 # v1
-
-      - name: Install cargo-nextest
-        uses: taiki-e/install-action@nextest
-
-      - name: Setup Node.js
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        with:
-          node-version: '24'
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+      - uses: ./.github/actions/setup-node-pnpm
 
       - name: Install oxfmt for the formatter parity corpus
         # Isolated install (avoids a full monorepo `pnpm install`) that provides
@@ -608,14 +572,13 @@ jobs:
           OXFMT_BIN: ${{ runner.temp }}/fmt-oracle/node_modules/.bin/oxfmt
           RSVELTE_FMT_TW_TEST_DIR: ${{ runner.temp }}/tw-oracle
 
-  # Builds the lint wasm (nodejs target) + the native rsvelte-fmt binary, bundles
-  # @rsvelte/language-server, and runs its headless LSP smoke tests (formatting
-  # matches rsvelte-fmt; diagnostics match the lint wasm) plus the lint→Diagnostic
-  # unit tests. Also typechecks + bundles the VS Code extension.
-  language-server:
-    name: Language server
+  # The language tooling and oxlint integrations use independent artifacts.
+  # Keeping them in separate jobs avoids serializing the three expensive WASM /
+  # NAPI builds on the same runner.
+  language-server-tests:
+    name: Language server tests
     runs-on: ubuntu-latest
-    timeout-minutes: 25
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -625,50 +588,27 @@ jobs:
       - name: Checkout svelte submodule (shallow)
         run: git submodule update --init --depth 1 submodules/svelte
 
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master
+      - uses: ./.github/actions/setup-rust
         with:
-          toolchain: 1.97.1
           targets: wasm32-unknown-unknown
+          mold: 'true'
+          wasm-pack: 'true'
 
-      - name: Setup mold linker
-        uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444 # v1
-
-      - name: Install wasm-pack
-        uses: jetli/wasm-pack-action@0d096b08b4e5a7de8c28de67e11e945404e9eefa # v0.4.0
+      - uses: ./.github/actions/setup-node-pnpm
         with:
-          version: 'v0.15.0'
-
-      - name: Setup Node.js
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        with:
-          node-version: '24'
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+          cache: 'true'
 
       - name: Cache cargo registry + target
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
-          shared-key: language-server
+          shared-key: language-tooling
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
       - name: Build lint wasm (nodejs target)
         run: pnpm run build:wasm:lint-node
-
-      # @rsvelte/oxlint-plugin runs on the web-target wasm published as
-      # @rsvelte/compiler (pkg/). Build it, regenerate the plugin's recommended
-      # config from the live rule catalog, then run the oxlint E2E.
-      - name: Build core wasm (web target) for oxlint-plugin
-        run: pnpm run build:wasm:core
-
-      # @rsvelte/svelte2tsx wraps the same web-target wasm (pkg/). Its test's
-      # `pretest` links @rsvelte/compiler at pkg/, then asserts the public
-      # `svelte2tsx()` is synchronous (matching upstream).
-      - name: Run @rsvelte/svelte2tsx tests (sync API)
-        run: pnpm --filter @rsvelte/svelte2tsx run test
 
       # apps/npm/svelte-check/bin/svelte-check.cjs (the npm launcher) had zero
       # tests (#1897 Layer 4 CI hygiene). Its smoke test drives the launcher
@@ -679,23 +619,6 @@ jobs:
 
       - name: Run @rsvelte/svelte-check smoke test (npm launcher)
         run: pnpm --filter @rsvelte/svelte-check run test
-
-      - name: Generate oxlint-plugin recommended config
-        run: pnpm run build:oxlint-plugin
-
-      # recommended.json is generated from the live rule catalog but committed
-      # (it ships in the npm package without a build step). Fail if the
-      # committed copy has drifted from the catalog.
-      - name: Check oxlint-plugin recommended config is in sync
-        run: git diff --exit-code apps/npm/oxlint-plugin/recommended.json
-
-      # Build the native NAPI addon for the host triple so the plugin's
-      # native-first engine path is exercised (the E2E asserts `engine=native`).
-      - name: Build rsvelte-lint NAPI addon (host)
-        run: pnpm run build:lint-native
-
-      - name: Run oxlint-plugin E2E (native + wasm paths)
-        run: pnpm run test:oxlint-plugin
 
       - name: Build native rsvelte-fmt
         run: cargo build -p rsvelte_fmt --bin rsvelte-fmt
@@ -710,6 +633,75 @@ jobs:
         run: |
           pnpm --filter rsvelte-vscode run typecheck
           pnpm --filter rsvelte-vscode run build
+
+  oxlint-plugin:
+    name: Oxlint plugin
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          submodules: false
+
+      - name: Checkout svelte submodule (shallow)
+        run: git submodule update --init --depth 1 submodules/svelte
+
+      - uses: ./.github/actions/setup-rust
+        with:
+          targets: wasm32-unknown-unknown
+          mold: 'true'
+          wasm-pack: 'true'
+
+      - uses: ./.github/actions/setup-node-pnpm
+        with:
+          cache: 'true'
+
+      - name: Cache cargo registry + target
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          shared-key: language-tooling
+          save-if: 'false'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build core wasm
+        run: pnpm run build:wasm:core
+
+      - name: Run @rsvelte/svelte2tsx tests
+        run: pnpm --filter @rsvelte/svelte2tsx run test
+
+      - name: Generate oxlint-plugin recommended config
+        run: pnpm run build:oxlint-plugin
+
+      - name: Check oxlint-plugin recommended config is in sync
+        run: git diff --exit-code apps/npm/oxlint-plugin/recommended.json
+
+      - name: Build rsvelte-lint NAPI addon
+        run: pnpm run build:lint-native
+
+      - name: Run oxlint-plugin E2E
+        run: pnpm run test:oxlint-plugin
+
+  language-tooling:
+    name: Language server
+    needs: [language-server-tests, oxlint-plugin]
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
+    steps:
+      - name: Verify language tooling jobs passed
+        shell: bash
+        env:
+          LANGUAGE_SERVER: ${{ needs.language-server-tests.result }}
+          OXLINT_PLUGIN: ${{ needs.oxlint-plugin.result }}
+        run: |
+          echo "language-server-tests: $LANGUAGE_SERVER"
+          echo "oxlint-plugin: $OXLINT_PLUGIN"
+          if [[ "$LANGUAGE_SERVER" != "success" || "$OXLINT_PLUGIN" != "success" ]]; then
+            echo "::error::One or more language tooling jobs did not succeed."
+            exit 1
+          fi
 
   # Single required status check that fans the sharded `Test` matrix and the
   # dedicated heavy-test jobs back into one signal: branch protection can require
@@ -749,20 +741,19 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          submodules: true
+          submodules: false
 
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master
+      - name: Checkout fixture submodules (shallow)
+        run: git submodule update --init --depth 1 submodules/svelte submodules/language-tools
+
+      - uses: ./.github/actions/setup-rust
+
+      - uses: ./.github/actions/setup-node-pnpm
         with:
-          toolchain: 1.97.1
-
-      - name: Setup Node.js
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        with:
-          node-version: '24'
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+          cache: 'true'
+          cache-dependency-path: |
+            submodules/svelte/pnpm-lock.yaml
+            submodules/language-tools/pnpm-lock.yaml
 
       - name: Resolve Svelte submodule SHA
         id: svelte-sha
@@ -805,6 +796,8 @@ jobs:
 
       - name: Cache cargo registry + target
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Generate compatibility report
         run: pnpm run compatibility-report
@@ -879,15 +872,17 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          submodules: true
+          submodules: false
 
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master
-        with:
-          toolchain: 1.97.1
+      - name: Checkout svelte submodule (shallow)
+        run: git submodule update --init --depth 1 submodules/svelte
+
+      - uses: ./.github/actions/setup-rust
 
       - name: Cache cargo registry + target
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Build documentation
         run: cargo doc --no-deps
@@ -910,26 +905,19 @@ jobs:
       - name: Checkout svelte submodule (shallow)
         run: git submodule update --init --depth 1 submodules/svelte
 
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master
+      - uses: ./.github/actions/setup-rust
         with:
-          toolchain: 1.97.1
+          mold: 'true'
 
-      - name: Setup mold linker
-        uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444 # v1
-
-      - name: Setup Node.js
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+      - uses: ./.github/actions/setup-node-pnpm
         with:
-          node-version: '24'
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+          cache: 'true'
 
       - name: Cache cargo registry + target
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           shared-key: vps-shim
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -947,7 +935,10 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          submodules: true
+          submodules: false
+
+      - name: Checkout svelte submodule (shallow)
+        run: git submodule update --init --depth 1 submodules/svelte
 
       - name: Check vite-plugin-svelte-native VERSION matches submodules/svelte
         run: node scripts/dev/check-vps-version.mjs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -572,11 +572,8 @@ jobs:
           OXFMT_BIN: ${{ runner.temp }}/fmt-oracle/node_modules/.bin/oxfmt
           RSVELTE_FMT_TW_TEST_DIR: ${{ runner.temp }}/tw-oracle
 
-  # The language tooling and oxlint integrations use independent artifacts.
-  # Keeping them in separate jobs avoids serializing the three expensive WASM /
-  # NAPI builds on the same runner.
-  language-server-tests:
-    name: Language server tests
+  language-server:
+    name: Language server
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -601,7 +598,7 @@ jobs:
       - name: Cache cargo registry + target
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
-          shared-key: language-tooling
+          shared-key: language-server
           save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Install dependencies
@@ -609,6 +606,12 @@ jobs:
 
       - name: Build lint wasm (nodejs target)
         run: pnpm run build:wasm:lint-node
+
+      - name: Build core wasm
+        run: pnpm run build:wasm:core
+
+      - name: Run @rsvelte/svelte2tsx tests
+        run: pnpm --filter @rsvelte/svelte2tsx run test
 
       # apps/npm/svelte-check/bin/svelte-check.cjs (the npm launcher) had zero
       # tests (#1897 Layer 4 CI hygiene). Its smoke test drives the launcher
@@ -619,6 +622,18 @@ jobs:
 
       - name: Run @rsvelte/svelte-check smoke test (npm launcher)
         run: pnpm --filter @rsvelte/svelte-check run test
+
+      - name: Generate oxlint-plugin recommended config
+        run: pnpm run build:oxlint-plugin
+
+      - name: Check oxlint-plugin recommended config is in sync
+        run: git diff --exit-code apps/npm/oxlint-plugin/recommended.json
+
+      - name: Build rsvelte-lint NAPI addon
+        run: pnpm run build:lint-native
+
+      - name: Run oxlint-plugin E2E
+        run: pnpm run test:oxlint-plugin
 
       - name: Build native rsvelte-fmt
         run: cargo build -p rsvelte_fmt --bin rsvelte-fmt
@@ -633,75 +648,6 @@ jobs:
         run: |
           pnpm --filter rsvelte-vscode run typecheck
           pnpm --filter rsvelte-vscode run build
-
-  oxlint-plugin:
-    name: Oxlint plugin
-    runs-on: ubuntu-latest
-    timeout-minutes: 20
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          submodules: false
-
-      - name: Checkout svelte submodule (shallow)
-        run: git submodule update --init --depth 1 submodules/svelte
-
-      - uses: ./.github/actions/setup-rust
-        with:
-          targets: wasm32-unknown-unknown
-          mold: 'true'
-          wasm-pack: 'true'
-
-      - uses: ./.github/actions/setup-node-pnpm
-        with:
-          cache: 'true'
-
-      - name: Cache cargo registry + target
-        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
-        with:
-          shared-key: language-tooling
-          save-if: 'false'
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Build core wasm
-        run: pnpm run build:wasm:core
-
-      - name: Run @rsvelte/svelte2tsx tests
-        run: pnpm --filter @rsvelte/svelte2tsx run test
-
-      - name: Generate oxlint-plugin recommended config
-        run: pnpm run build:oxlint-plugin
-
-      - name: Check oxlint-plugin recommended config is in sync
-        run: git diff --exit-code apps/npm/oxlint-plugin/recommended.json
-
-      - name: Build rsvelte-lint NAPI addon
-        run: pnpm run build:lint-native
-
-      - name: Run oxlint-plugin E2E
-        run: pnpm run test:oxlint-plugin
-
-  language-tooling:
-    name: Language server
-    needs: [language-server-tests, oxlint-plugin]
-    if: always()
-    runs-on: ubuntu-latest
-    timeout-minutes: 1
-    steps:
-      - name: Verify language tooling jobs passed
-        shell: bash
-        env:
-          LANGUAGE_SERVER: ${{ needs.language-server-tests.result }}
-          OXLINT_PLUGIN: ${{ needs.oxlint-plugin.result }}
-        run: |
-          echo "language-server-tests: $LANGUAGE_SERVER"
-          echo "oxlint-plugin: $OXLINT_PLUGIN"
-          if [[ "$LANGUAGE_SERVER" != "success" || "$OXLINT_PLUGIN" != "success" ]]; then
-            echo "::error::One or more language tooling jobs did not succeed."
-            exit 1
-          fi
 
   # Single required status check that fans the sharded `Test` matrix and the
   # dedicated heavy-test jobs back into one signal: branch protection can require

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -39,10 +39,7 @@ jobs:
         with:
           submodules: false
 
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master
-        with:
-          toolchain: 1.97.1
+      - uses: ./.github/actions/setup-rust
 
       - name: Cache cargo registry + target
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
@@ -51,6 +48,7 @@ jobs:
           # Save the warm `target/` even when a later step fails so a single
           # flake doesn't force a cold rebuild on every subsequent run.
           cache-on-failure: true
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Install cargo-codspeed
         # cargo-codspeed isn't carried by taiki-e/install-action, so build it

--- a/.github/workflows/corpus-compat.yml
+++ b/.github/workflows/corpus-compat.yml
@@ -158,18 +158,9 @@ jobs:
       - name: Checkout corpus source submodules (shallow)
         run: git submodule update --init --depth 1 submodules/svelte submodules/svelte.dev submodules/language-tools submodules/bits-ui submodules/flowbite-svelte submodules/melt-ui submodules/shadcn-svelte submodules/sveltestrap submodules/attractions submodules/svelte-ux submodules/smelte submodules/svar-core submodules/svelte-table submodules/powertable submodules/svelte-pivottable submodules/svelte-toast submodules/svelte-sonner submodules/svelte-notifications submodules/svelte-fa submodules/svelte-heroicons submodules/svelte-calendar submodules/date-picker-svelte submodules/svelte-maplibre submodules/layercake submodules/layerchart submodules/svelte-splitpanes submodules/svelte-stepper submodules/svelte-formly submodules/svelte-form-builder submodules/svelte-checkbox submodules/svelte-toggle submodules/svelthree submodules/cmsaasstarter
 
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master
-        with:
-          toolchain: 1.97.1
+      - uses: ./.github/actions/setup-rust
 
-      - name: Setup Node.js
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        with:
-          node-version: '24'
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+      - uses: ./.github/actions/setup-node-pnpm
 
       - name: Install root dependencies (oxfmt)
         run: pnpm install --frozen-lockfile --ignore-scripts
@@ -218,6 +209,7 @@ jobs:
           # preserves the compiled `target/` and breaks that deadlock (mirrors
           # the same fix in benchmark.yml).
           cache-on-failure: true
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Build rsvelte NAPI binding
         run: |
@@ -270,24 +262,17 @@ jobs:
       - name: Checkout corpus source submodules (shallow)
         run: git submodule update --init --depth 1 submodules/svelte submodules/svelte.dev submodules/bits-ui submodules/flowbite-svelte submodules/melt-ui submodules/shadcn-svelte submodules/sveltestrap submodules/attractions submodules/svelte-ux submodules/smelte submodules/svar-core submodules/svelte-table submodules/powertable submodules/svelte-pivottable submodules/svelte-toast submodules/svelte-sonner submodules/svelte-notifications submodules/svelte-fa submodules/svelte-heroicons submodules/svelte-calendar submodules/date-picker-svelte submodules/svelte-maplibre submodules/layercake submodules/layerchart submodules/svelte-splitpanes submodules/svelte-stepper submodules/svelte-formly submodules/svelte-form-builder submodules/svelte-checkbox submodules/svelte-toggle submodules/svelthree submodules/cmsaasstarter
 
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master
-        with:
-          toolchain: 1.97.1
+      - uses: ./.github/actions/setup-rust
 
-      - name: Setup Node.js
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        with:
-          node-version: '24'
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+      - uses: ./.github/actions/setup-node-pnpm
 
       - name: Install root dependencies (oxfmt)
         run: pnpm install --frozen-lockfile --ignore-scripts
 
       - name: Cache cargo
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Build rsvelte-fmt
         run: cargo build --release -p rsvelte_fmt
@@ -304,7 +289,7 @@ jobs:
           echo "sources=$(git submodule status submodules/svelte submodules/svelte.dev submodules/bits-ui submodules/flowbite-svelte submodules/melt-ui submodules/shadcn-svelte submodules/sveltestrap submodules/attractions submodules/svelte-ux submodules/smelte submodules/svar-core submodules/svelte-table submodules/powertable submodules/svelte-pivottable submodules/svelte-toast submodules/svelte-sonner submodules/svelte-notifications submodules/svelte-fa submodules/svelte-heroicons submodules/svelte-calendar submodules/date-picker-svelte submodules/svelte-maplibre submodules/layercake submodules/layerchart submodules/svelte-splitpanes submodules/svelte-stepper submodules/svelte-formly submodules/svelte-form-builder submodules/svelte-checkbox submodules/svelte-toggle submodules/svelthree submodules/cmsaasstarter | awk '{print $1}' | sort | git hash-object --stdin)" >> "$GITHUB_OUTPUT"
 
       # The oracle depends only on the pins + oxfmt version + oracle config, so
-      # cache it: only the first run per pin pays the ~6k oxfmt invocations.
+      # cache it: only the first run per pin pays the batched oracle build.
       - name: Cache fmt oracle
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
@@ -346,21 +331,14 @@ jobs:
         # production-source breadth.
         run: git submodule update --init --depth 1 submodules/eslint-plugin-svelte submodules/svelte-eslint-parser submodules/bits-ui submodules/flowbite-svelte submodules/melt-ui submodules/shadcn-svelte
 
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master
-        with:
-          toolchain: 1.97.1
+      - uses: ./.github/actions/setup-rust
 
-      - name: Setup Node.js
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        with:
-          node-version: '24'
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+      - uses: ./.github/actions/setup-node-pnpm
 
       - name: Cache cargo
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Build rsvelte-lint
         # `--profile dist-lint` (release optimization + `panic = "unwind"`) so the
@@ -403,23 +381,15 @@ jobs:
       # No submodules: the oracle is the published `svelte-check` package, and
       # the scenarios are committed mini-projects under compatibility/check-fixtures.
 
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master
-        with:
-          toolchain: 1.97.1
+      - uses: ./.github/actions/setup-rust
 
-      - name: Setup Node.js
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        with:
-          node-version: '24'
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+      - uses: ./.github/actions/setup-node-pnpm
 
       - name: Cache cargo
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           shared-key: check-parity
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Build rsvelte-check
         run: cargo build --release -p rsvelte_check
@@ -464,21 +434,14 @@ jobs:
       - name: Checkout e2e project submodules (shallow)
         run: git submodule update --init --depth 1 submodules/cmsaasstarter submodules/skeleton
 
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master
-        with:
-          toolchain: 1.97.1
+      - uses: ./.github/actions/setup-rust
 
-      - name: Setup Node.js
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        with:
-          node-version: '24'
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+      - uses: ./.github/actions/setup-node-pnpm
 
       - name: Cache cargo
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Build rsvelte-check
         run: cargo build --release -p rsvelte_check

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -12,6 +12,9 @@ on:
     types: [opened, synchronize, reopened, labeled]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
@@ -36,21 +39,21 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          submodules: true
+          submodules: false
 
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master
+      - name: Checkout test submodules (shallow)
+        run: git submodule update --init --depth 1 submodules/svelte submodules/svelte.dev submodules/language-tools submodules/eslint-plugin-svelte submodules/esrap submodules/svelte-switch-case submodules/svelte-preprocess-sass
+
+      - uses: ./.github/actions/setup-rust
         with:
-          toolchain: 1.97.1
           components: llvm-tools-preview
 
-      - name: Setup Node.js
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+      - uses: ./.github/actions/setup-node-pnpm
         with:
-          node-version: '24'
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+          cache: 'true'
+          cache-dependency-path: |
+            submodules/svelte/pnpm-lock.yaml
+            submodules/language-tools/pnpm-lock.yaml
 
       - name: Resolve Svelte submodule SHA
         id: svelte-sha
@@ -65,6 +68,8 @@ jobs:
 
       - name: Cache cargo registry + target
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov

--- a/.github/workflows/crates-io-packages.yml
+++ b/.github/workflows/crates-io-packages.yml
@@ -57,8 +57,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - name: Install Rust MSRV
-        uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master
+      - uses: ./.github/actions/setup-rust
         with:
           toolchain: "1.97"
 
@@ -66,6 +65,7 @@ jobs:
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           key: crates-io-msrv
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Check package policy
         run: node scripts/ci/check-crates-io-packages.mjs

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -10,15 +10,15 @@ permissions:
   pages: write
   id-token: write
 
-concurrency:
-  group: pages
-  cancel-in-progress: false
-
 jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    # Supersede stale builds without interrupting the atomic Pages deployment.
+    concurrency:
+      group: pages-build
+      cancel-in-progress: true
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -34,21 +34,17 @@ jobs:
       - name: Checkout svelte submodule (shallow)
         run: git submodule update --init --depth 1 submodules/svelte
 
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master
+      - uses: ./.github/actions/setup-rust
         with:
-          toolchain: 1.97.1
+          wasm-pack: 'true'
 
       - name: Cache cargo registry + target
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
-      - name: Setup Node.js
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+      - uses: ./.github/actions/setup-node-pnpm
         with:
-          node-version: '24'
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+          cache: 'true'
+          cache-dependency-path: apps/playground/pnpm-lock.yaml
 
       # NOTE: the docs dashboard's `apps/playground/static/test-results.json`
       # is the *committed* file — it is NOT regenerated here. Regenerating it
@@ -69,9 +65,6 @@ jobs:
       # on a machine with enough cores to exercise the multi-thread path
       # (GitHub-hosted runners top out at low core counts, so they can't
       # show the parallelism gains we care about), then commit the file.
-
-      - name: Install wasm-pack
-        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
 
       - name: Build WASM (compiler + svelte2tsx + lint)
         # Built from rsvelte_lint_bindings, which links rsvelte_core's compiler +
@@ -97,13 +90,6 @@ jobs:
           mkdir -p apps/npm/vite-plugin-svelte-native-linux-x64-gnu
           cp target/release/librsvelte_napi.so \
              apps/npm/vite-plugin-svelte-native-linux-x64-gnu/rsvelte.node
-
-      - name: Setup pnpm cache for playground
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        with:
-          node-version: '24'
-          cache: 'pnpm'
-          cache-dependency-path: apps/playground/pnpm-lock.yaml
 
       - name: Install playground dependencies
         # apps/playground/pnpm-workspace.yaml marks the playground as its own
@@ -139,6 +125,9 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     needs: build
+    concurrency:
+      group: pages-deploy
+      cancel-in-progress: false
     steps:
       - name: Deploy to GitHub Pages
         id: deployment

--- a/.github/workflows/publish-vscode.yml
+++ b/.github/workflows/publish-vscode.yml
@@ -69,27 +69,15 @@ jobs:
       - name: Checkout svelte submodule (shallow)
         run: git submodule update --init --depth 1 submodules/svelte
 
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master
+      - uses: ./.github/actions/setup-rust
         with:
-          toolchain: 1.97.1
           targets: wasm32-unknown-unknown
+          mold: 'true'
+          wasm-pack: 'true'
 
-      - name: Setup mold linker
-        uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444 # v1
-
-      - name: Install wasm-pack
-        uses: jetli/wasm-pack-action@0d096b08b4e5a7de8c28de67e11e945404e9eefa # v0.4.0
+      - uses: ./.github/actions/setup-node-pnpm
         with:
-          version: 'v0.15.0'
-
-      - name: Setup Node.js
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        with:
-          node-version: '24'
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+          cache: 'true'
 
       - name: Cache cargo registry + target
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1

--- a/.github/workflows/release-capi.yml
+++ b/.github/workflows/release-capi.yml
@@ -30,6 +30,10 @@ on:
 permissions:
   contents: write   # gh release create / upload
 
+concurrency:
+  group: release-capi-${{ github.ref }}
+  cancel-in-progress: false
+
 env:
   CARGO_TERM_COLOR: always
 
@@ -52,16 +56,17 @@ jobs:
         with:
           submodules: false
 
+      - name: Checkout svelte submodule (shallow)
+        run: git submodule update --init --depth 1 submodules/svelte
+
       - name: Install cross-compile linker
         if: matrix.apt
         run: |
           sudo apt-get update
           sudo apt-get install -y ${{ matrix.apt }}
 
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master
+      - uses: ./.github/actions/setup-rust
         with:
-          toolchain: 1.97.1
           targets: ${{ matrix.target }}
 
       - name: Cache cargo registry + target

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,22 +12,6 @@ permissions:
   pull-requests: write
   id-token: write
 
-concurrency:
-  group: release-${{ github.ref }}
-  # Only the "Version Packages" merge (the publish run) cancels older queued
-  # runs. This kills any in-flight regular-commit run that is about to
-  # re-open the version PR on stale state (the race that produced #554).
-  # Regular pushes keep cancel-in-progress: false so they never abort an
-  # in-flight publish — npm publish is per-package, so a mid-flight cancel
-  # can leave us with versions bumped in package.json but never published
-  # to the registry.
-  # The expression is quoted so the literal colon in the predicate
-  # string ('chore(release): version packages') doesn't confuse the
-  # YAML parser. GitHub Actions still evaluates `${{ }}` inside the
-  # string and `cancel-in-progress` accepts the resulting `'true'` /
-  # `'false'` literal.
-  cancel-in-progress: "${{ startsWith(github.event.head_commit.message, 'chore(release): version packages') }}"
-
 jobs:
   # Fast path: open / refresh the "Version Packages" PR. The version cycle
   # never stages binaries (changeset version only bumps package.json/CHANGELOG
@@ -43,6 +27,9 @@ jobs:
     if: "${{ !startsWith(github.event.head_commit.message, 'chore(release): version packages') }}"
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    concurrency:
+      group: release-version-pr-${{ github.ref }}
+      cancel-in-progress: true
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -50,13 +37,9 @@ jobs:
           # which packages need releasing.
           fetch-depth: 0
 
-      - name: Setup Node.js
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+      - uses: ./.github/actions/setup-node-pnpm
         with:
-          node-version: '24'
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+          cache: 'true'
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -74,6 +57,19 @@ jobs:
           title: 'chore(release): version packages'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  close-version-cycle:
+    name: Close version cycle
+    if: "${{ startsWith(github.event.head_commit.message, 'chore(release): version packages') }}"
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    # A publish commit must supersede an in-flight updater before it can reopen
+    # the version PR from stale state.
+    concurrency:
+      group: release-version-pr-${{ github.ref }}
+      cancel-in-progress: true
+    steps:
+      - run: echo "Version PR merged; publishing the approved release set."
 
   # Per-platform svelte-check binary builds. Each job uploads its rsvelte
   # `svelte-check` artifact; the `release` job below downloads them all and
@@ -100,16 +96,17 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
+      - name: Checkout svelte submodule (shallow)
+        run: git submodule update --init --depth 1 submodules/svelte
+
       - name: Install cross-compile linker
         if: matrix.apt
         run: |
           sudo apt-get update
           sudo apt-get install -y ${{ matrix.apt }}
 
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master
+      - uses: ./.github/actions/setup-rust
         with:
-          toolchain: 1.97.1
           targets: ${{ matrix.target }}
 
       - name: Cache cargo registry + target
@@ -172,16 +169,17 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
+      - name: Checkout svelte submodule (shallow)
+        run: git submodule update --init --depth 1 submodules/svelte
+
       - name: Install cross-compile linker
         if: matrix.apt
         run: |
           sudo apt-get update
           sudo apt-get install -y ${{ matrix.apt }}
 
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master
+      - uses: ./.github/actions/setup-rust
         with:
-          toolchain: 1.97.1
           targets: ${{ matrix.target }}
 
       - name: Cache cargo registry + target
@@ -235,16 +233,17 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
+      - name: Checkout svelte submodule (shallow)
+        run: git submodule update --init --depth 1 submodules/svelte
+
       - name: Install cross-compile linker
         if: matrix.apt
         run: |
           sudo apt-get update
           sudo apt-get install -y ${{ matrix.apt }}
 
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master
+      - uses: ./.github/actions/setup-rust
         with:
-          toolchain: 1.97.1
           targets: ${{ matrix.target }}
 
       - name: Cache cargo registry + target
@@ -298,16 +297,17 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
+      - name: Checkout svelte submodule (shallow)
+        run: git submodule update --init --depth 1 submodules/svelte
+
       - name: Install cross-compile linker
         if: matrix.apt
         run: |
           sudo apt-get update
           sudo apt-get install -y ${{ matrix.apt }}
 
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master
+      - uses: ./.github/actions/setup-rust
         with:
-          toolchain: 1.97.1
           targets: ${{ matrix.target }}
 
       - name: Cache cargo registry + target
@@ -363,8 +363,12 @@ jobs:
     # changesets consumed. This is the only path that needs staged binaries.
     if: "${{ startsWith(github.event.head_commit.message, 'chore(release): version packages') }}"
     runs-on: ubuntu-latest
-    needs: [build-svelte-check, build-vps-native, build-rsvelte-fmt, build-rsvelte-lint]
+    needs: [close-version-cycle, build-svelte-check, build-vps-native, build-rsvelte-fmt, build-rsvelte-lint]
     timeout-minutes: 30
+    # Publishing is non-atomic across packages and must never be interrupted.
+    concurrency:
+      group: release-publish-${{ github.ref }}
+      cancel-in-progress: false
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -372,21 +376,18 @@ jobs:
           # which packages need releasing.
           fetch-depth: 0
 
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master
+      - name: Checkout svelte submodule (shallow)
+        run: git submodule update --init --depth 1 submodules/svelte
+
+      - uses: ./.github/actions/setup-rust
         with:
-          toolchain: 1.97.1
           targets: wasm32-unknown-unknown
+          wasm-pack: 'true'
 
       - name: Cache cargo registry + target
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           key: wasm32-unknown-unknown
-
-      - name: Install wasm-pack
-        uses: jetli/wasm-pack-action@0d096b08b4e5a7de8c28de67e11e945404e9eefa # v0.4.0
-        with:
-          version: 'v0.15.0'
 
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0

--- a/.github/workflows/site-benchmark.yml
+++ b/.github/workflows/site-benchmark.yml
@@ -53,23 +53,18 @@ jobs:
       - name: Checkout svelte + language-tools submodules
         run: git submodule update --init --depth 1 submodules/svelte submodules/language-tools
 
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master
+      - uses: ./.github/actions/setup-rust
+
+      - uses: ./.github/actions/setup-node-pnpm
         with:
-          toolchain: 1.97.1
+          cache: 'true'
 
-      - name: Setup Node.js
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        with:
-          node-version: '24'
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
-
-      - name: Resolve Svelte submodule SHA
-        id: svelte-sha
+      - name: Resolve benchmark submodule SHAs
+        id: baseline-shas
         shell: bash
-        run: echo "sha=$(git submodule status submodules/svelte | awk '{print $1}' | sed 's/^[+-]//')" >> "$GITHUB_OUTPUT"
+        run: |
+          echo "svelte=$(git submodule status submodules/svelte | awk '{print $1}' | sed 's/^[+-]//')" >> "$GITHUB_OUTPUT"
+          echo "language_tools=$(git submodule status submodules/language-tools | awk '{print $1}' | sed 's/^[+-]//')" >> "$GITHUB_OUTPUT"
 
       # The JS baselines (svelte/compiler, svelte2tsx, language-server,
       # svelte-check) are rollup/tsc build outputs that run-benchmark.mjs
@@ -92,7 +87,7 @@ jobs:
             submodules/language-tools/packages/language-server/dist
             submodules/language-tools/packages/svelte-check/dist
             scripts/compat-corpus/lint-oracle/node_modules
-          key: js-baselines-v2-${{ runner.os }}-${{ runner.arch }}-${{ steps.svelte-sha.outputs.sha }}-${{ hashFiles('.gitmodules', 'scripts/compat-corpus/lint-oracle/package.json') }}
+          key: js-baselines-v3-${{ runner.os }}-${{ runner.arch }}-${{ steps.baseline-shas.outputs.svelte }}-${{ steps.baseline-shas.outputs.language_tools }}-${{ hashFiles('submodules/svelte/pnpm-lock.yaml', 'submodules/language-tools/pnpm-lock.yaml', 'scripts/compat-corpus/lint-oracle/package.json') }}
 
       # prettier + prettier-plugin-svelte (the JS `fmt` baseline) resolve from
       # the repo-root node_modules.

--- a/.github/workflows/type-aware-lint.yml
+++ b/.github/workflows/type-aware-lint.yml
@@ -54,14 +54,10 @@ jobs:
           # Only the two submodules this suite needs, checked out shallow below.
           submodules: false
 
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master
+      - uses: ./.github/actions/setup-rust
         with:
-          toolchain: 1.97.1
           components: rustfmt, clippy
-
-      - name: Setup mold linker
-        uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444 # v1
+          mold: 'true'
 
       # MUST come before the cache step: rust-cache runs `cargo metadata` to
       # build its key, and the crate path-depends on corsa-bind. Without the
@@ -77,6 +73,7 @@ jobs:
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           workspaces: crates/rsvelte_lint_types
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:

--- a/scripts/compat-corpus/fmt.mjs
+++ b/scripts/compat-corpus/fmt.mjs
@@ -9,21 +9,15 @@
  *   compatibility/fmt/oracle/<id>   oxfmt with `svelte: true` (prettier-plugin-svelte
  *                                   for the Svelte structure + oxc for embedded JS/CSS)
  *   compatibility/fmt/actual/<id>   rsvelte-fmt (rsvelte_formatter for the structure,
- *                                   oxfmt for embedded <style>) — the exact same layering,
- *                                   so a diff isolates rsvelte's Svelte-structure formatting.
+ *                                   oxc for embedded JS/CSS)
  *
  * Both pipelines format embedded JS/CSS with the same oxc engine, so any
  * surviving byte difference is a real Svelte-structure divergence. The
  * comparison + ratchet lives in fmt-verify.mjs.
  *
- * The `actual` pass runs rsvelte-fmt with `--no-native-css`: rsvelte-fmt now
- * formats embedded <style> in-process via `oxc_formatter_css` by default, but
- * that Rust crate is pinned to an oxc git rev that need not byte-match the npm
- * `oxfmt` the oracle uses (e.g. long CSS-value wrapping differs). Forcing the
- * oxfmt-subprocess path keeps *both* sides on the identical oxfmt binary, so the
- * corpus stays a pure Svelte-structure diff (its stated purpose) rather than a
- * CSS-engine-version diff. Native-CSS parity is covered by the formatter/CLI
- * unit tests instead.
+ * The actual tree is formatted in one directory invocation. Native CSS parity
+ * with oxfmt is covered separately, and keeping styles in-process avoids a
+ * subprocess per component.
  *
  * The oracle depends only on (svelte sha, svelte.dev sha, oxfmt version, config
  * hash); it is cached and skipped on re-runs unless those change or `--force` is
@@ -42,7 +36,7 @@
  * Env:
  *   OXFMT_BIN          oxfmt launcher (default: node_modules/.bin/oxfmt)
  *   RSVELTE_FMT_BIN    rsvelte-fmt binary (default: target/release/rsvelte-fmt)
- *   FMT_CORPUS_JOBS    parallel workers (default: cpus-2, clamped 2..8)
+ *   FMT_CORPUS_JOBS    parallel oracle workers (default: cpus-2, clamped 2..8)
  */
 
 import fs from 'node:fs';
@@ -72,6 +66,7 @@ const ONLY_ORACLE = args.includes('--oracle');
 const ONLY_ACTUAL = args.includes('--actual');
 const ONLY_FILE = args.includes('--only') ? args[args.indexOf('--only') + 1] : undefined;
 const JOBS = Math.max(2, Math.min(8, Number(process.env.FMT_CORPUS_JOBS) || os.cpus().length - 2));
+const ORACLE_BATCH_SIZE = 256;
 
 function fail(msg) {
 	console.error(`[fmt] ${msg}`);
@@ -86,9 +81,9 @@ function gitSha(dir) {
 	});
 }
 
-function exec(bin, argv, stdin) {
+function exec(bin, argv, stdin, options = {}) {
 	return new Promise((resolve) => {
-		const child = execFile(bin, argv, { maxBuffer: 64 * 1024 * 1024 }, (err, stdout, stderr) => {
+		const child = execFile(bin, argv, { maxBuffer: 64 * 1024 * 1024, ...options }, (err, stdout, stderr) => {
 			if (err && err.code === 'ENOENT') resolve({ ok: false, enoent: true, err: err.message });
 			else if (err) resolve({ ok: false, out: stdout, err: (stderr || err.message || '').trim() });
 			else resolve({ ok: true, out: stdout, stderr: (stderr || '').trim() });
@@ -121,16 +116,31 @@ function oneLine(s) {
 	return (s || '').replace(/\s+/g, ' ').trim().slice(0, 200);
 }
 
-function writeTree(dir, id, content) {
-	const dest = path.join(dir, id);
+function copyTreeFile(from, to, id) {
+	const dest = path.join(to, id);
 	fs.mkdirSync(path.dirname(dest), { recursive: true });
-	fs.writeFileSync(dest, content);
+	fs.copyFileSync(path.join(from, id), dest);
 }
 
-/** The .svelte basename oxfmt/rsvelte-fmt see as the stdin filename. */
 function stdinName(id) {
 	const base = path.basename(id);
 	return base.endsWith('.svelte') ? base : 'input.svelte';
+}
+
+function chunks(items, size) {
+	const result = [];
+	for (let i = 0; i < items.length; i += size) result.push(items.slice(i, i + size));
+	return result;
+}
+
+function rejectedIds(diagnostic, stage, batch) {
+	const batchSet = new Set(batch);
+	const ids = new Set();
+	for (const match of diagnostic.matchAll(/\[([^\]\r\n]+)\]/g)) {
+		const id = path.relative(stage, match[1]);
+		if (batchSet.has(id)) ids.add(id);
+	}
+	return ids;
 }
 
 async function main() {
@@ -170,25 +180,60 @@ async function main() {
 		fs.rmSync(ORACLE, { recursive: true, force: true });
 		const includedSet = [];
 		const skipList = [];
-		await pool(components, async ({ id }) => {
-			const source = fs.readFileSync(path.join(SOURCES, id), 'utf8');
-			const res = await exec(OXFMT_BIN, ['-c', OXFMT_CONFIG, '--stdin-filepath', stdinName(id)], source);
-			if (res.enoent) fail(`oxfmt not found at ${OXFMT_BIN}`);
-			if (!res.ok) {
-				skipList.push({ id, reason: oneLine(res.err) || 'oxfmt rejected' });
-				return;
+		const stage = fs.mkdtempSync(path.join(os.tmpdir(), 'oxfmt-corpus-'));
+		try {
+			const ids = components.map(({ id }) => id);
+			for (const id of ids) copyTreeFile(SOURCES, stage, id);
+
+			// Most files are valid, so format them in large batches. oxfmt reports
+			// rejected paths; bisect only when a diagnostic lacks path metadata.
+			async function formatBatch(batch) {
+				const paths = batch.map((id) => path.join(stage, id));
+				const res = await exec(OXFMT_BIN, ['-c', OXFMT_CONFIG, ...paths]);
+				if (res.enoent) fail(`oxfmt not found at ${OXFMT_BIN}`);
+				const error = !res.ok || /error/i.test(res.stderr);
+				if (!error) {
+					includedSet.push(...batch);
+					return;
+				}
+				const diagnostic = res.err || res.stderr || '';
+				const rejected = rejectedIds(diagnostic, stage, batch);
+				if (rejected.size) {
+					for (const id of rejected) {
+						skipList.push({
+							id,
+							reason: oneLine(diagnostic).replaceAll(`${stage}${path.sep}`, ''),
+						});
+					}
+					const remaining = batch.filter((id) => !rejected.has(id));
+					if (remaining.length) await formatBatch(remaining);
+					return;
+				}
+				if (batch.length === 1) {
+					const reason = oneLine(diagnostic) || 'oxfmt rejected';
+					skipList.push({ id: batch[0], reason });
+					return;
+				}
+				const middle = Math.ceil(batch.length / 2);
+				await formatBatch(batch.slice(0, middle));
+				await formatBatch(batch.slice(middle));
 			}
-			// oxfmt leaves an unparseable embedded <script>/<style> verbatim and
-			// logs the error to stderr while exiting 0. Such a block is not valid,
-			// formattable Svelte — exclude it rather than treat the unformatted
-			// output as a parity target (mirrors generate-fmt-corpus.mjs).
-			if (/error/i.test(res.stderr)) {
-				skipList.push({ id, reason: `oxfmt stderr: ${oneLine(res.stderr)}` });
-				return;
-			}
-			writeTree(ORACLE, id, res.out);
-			includedSet.push(id);
-		});
+
+			await pool(chunks(ids, ORACLE_BATCH_SIZE), formatBatch);
+			const stdinFallbacks = includedSet.filter((id) =>
+				fs.readFileSync(path.join(SOURCES, id), 'utf8').includes('/** ('),
+			);
+			await pool(stdinFallbacks, async (id) => {
+				// oxfmt attaches this parser-directed comment differently for
+				// file arguments; preserve the established stdin oracle.
+				const source = fs.readFileSync(path.join(SOURCES, id), 'utf8');
+				const res = await exec(OXFMT_BIN, ['-c', OXFMT_CONFIG, '--stdin-filepath', stdinName(id)], source);
+				if (res.ok) fs.writeFileSync(path.join(stage, id), res.out);
+			});
+			for (const id of includedSet) copyTreeFile(stage, ORACLE, id);
+		} finally {
+			fs.rmSync(stage, { recursive: true, force: true });
+		}
 		included = includedSet.sort();
 		skips = skipList.sort((a, b) => a.id.localeCompare(b.id));
 		fs.mkdirSync(FMT, { recursive: true });
@@ -215,41 +260,39 @@ async function main() {
 			console.log(`[fmt] actual: --only ${path.relative(ROOT, ONLY_FILE)} → ${targets.length} of ${included.length}`);
 		} else {
 			fs.rmSync(ACTUAL, { recursive: true, force: true });
-			console.log(`[fmt] actual: rsvelte-fmt over ${targets.length} components | ${JOBS} jobs`);
+			console.log(`[fmt] actual: rsvelte-fmt over ${targets.length} components`);
 		}
-		const errors = [];
-		await pool(targets, async (id) => {
-			const source = fs.readFileSync(path.join(SOURCES, id), 'utf8');
-			const res = await exec(
-				RSVELTE_FMT_BIN,
-				// `--no-native-css`: format embedded <style> via the oxfmt subprocess
-				// (same binary as the oracle), not the pinned-rev native CSS engine —
-				// see the header comment.
-				[
-					'--stdin',
-					'--stdin-filepath',
-					stdinName(id),
-					'-c',
-					OXFMT_CONFIG,
-					'--oxfmt-bin',
-					OXFMT_BIN,
-					'--no-native-css',
-				],
-				source,
-			);
-			if (res.enoent) fail(`rsvelte-fmt not found at ${RSVELTE_FMT_BIN}`);
-			if (!res.ok) {
-				// A formatter error (parse failure / panic) is a real divergence:
-				// write the raw source so fmt-verify records a mismatch, and note it.
-				errors.push({ id, reason: oneLine(res.err) });
-				writeTree(ACTUAL, id, source);
-				return;
+		if (targets.length) {
+			// Stage outside the repository because compatibility/fmt is gitignored,
+			// and rsvelte-fmt intentionally honors gitignore during directory walks.
+			const stage = fs.mkdtempSync(path.join(os.tmpdir(), 'rsvelte-fmt-corpus-'));
+			try {
+				for (const id of targets) copyTreeFile(SOURCES, stage, id);
+				const res = await exec(
+					RSVELTE_FMT_BIN,
+					// One directory invocation keeps markup, scripts, and styles in
+					// process instead of starting rsvelte-fmt and oxfmt per file.
+					['.', '-c', OXFMT_CONFIG, '--oxfmt-bin', OXFMT_BIN],
+					undefined,
+					{ cwd: stage },
+				);
+				if (res.enoent) fail(`rsvelte-fmt not found at ${RSVELTE_FMT_BIN}`);
+				if (!res.ok) {
+					// Per-file formatter errors leave those staged sources unchanged,
+					// so copying the tree still records them as parity mismatches.
+					console.log(`[fmt] actual: rsvelte-fmt reported errors (recorded as mismatches):`);
+					const diagnostics = (res.err || '')
+						.split('\n')
+						.filter((line) => line.startsWith('rsvelte-fmt: ') && !line.includes(' formatted '));
+					for (const line of diagnostics.slice(0, 10)) {
+						console.log(`  ${oneLine(line.replaceAll(`${stage}${path.sep}`, ''))}`);
+					}
+					if (!diagnostics.length) console.log(`  ${oneLine(res.err) || 'unknown formatter error'}`);
+				}
+				for (const id of targets) copyTreeFile(stage, ACTUAL, id);
+			} finally {
+				fs.rmSync(stage, { recursive: true, force: true });
 			}
-			writeTree(ACTUAL, id, res.out);
-		});
-		if (errors.length) {
-			console.log(`[fmt] actual: ${errors.length} rsvelte-fmt errors (recorded as mismatches):`);
-			for (const e of errors.slice(0, 10)) console.log(`  - ${e.id}: ${e.reason}`);
 		}
 	}
 }


### PR DESCRIPTION
## Summary

- centralize pinned Rust, Node.js, pnpm, mold, nextest, and wasm-pack setup in reusable local composite actions
- shorten PR feedback by disabling release-only LTO/debug/incremental work and replacing recursive submodule checkout with shallow targeted checkout
- batch formatter-corpus oracle and actual generation instead of spawning formatters once per component
- keep PR jobs read-only against the large Rust caches, fix benchmark cache invalidation, and preserve coverage inputs with targeted submodules
- separate cancellable Pages builds from non-cancellable deploys, and serialize release/version-PR work without allowing npm or C API publishing to be interrupted

## Why

GitHub Actions history showed several independent sources of latency:

- the former `Language server` job serialized three expensive WASM/NAPI builds and took about 11m40s in a representative successful run
- a cold formatter oracle started oxfmt once per file and consumed about 36 minutes in the full corpus job
- recursive submodule checkout cost roughly 48–78 seconds in jobs that only use `svelte`
- PR jobs continually wrote multi-gigabyte Rust caches while the repository cache was near its 10 GiB limit, evicting the small formatter oracle cache
- workflow-level release concurrency allowed version-PR updates to race while also making publish cancellation unsafe

## Impact

- language tooling retains its stable required-check name and shared cache while skipping distribution-only LTO work
- validation builds retain release artifacts' behavior while skipping distribution-only link optimization in CI
- cold formatter generation is batched; on the Svelte + svelte.dev subset, 6,269 components (6,098 included) completed oracle + actual generation in 86.7 seconds locally with oxfmt 0.61.0
- stale docs builds are cancelled without interrupting an active deployment
- release binaries still use the repository's full distribution profiles and now initialize the Svelte submodule so embedded version metadata is accurate

## Validation

- `actionlint v1.7.12` across all workflows
- parsed all 20 workflow/action YAML files
- `node --check scripts/compat-corpus/fmt.mjs`
- `cargo fmt --all --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- CI-profile `cargo build --profile dist-lint -p rsvelte_lint --bin rsvelte-lint`
- formatter parity with oxfmt 0.61.0 over 6,098 included Svelte/svelte.dev components: no new regressions
- sampled legacy stdin vs batched output byte-for-byte across 66 components, including parser-comment fallbacks

No changeset is included because the change only affects CI infrastructure and internal corpus orchestration.
