### PR TITLE
Skip unused svelte2tsx expression locations

### DIFF
--- a/.changeset/skip-svelte2tsx-expression-locations.md
+++ b/.changeset/skip-svelte2tsx-expression-locations.md
@@ -1,0 +1,8 @@
+---
+"@rsvelte/compiler": patch
+"@rsvelte/svelte2tsx": patch
+"@rsvelte/svelte-check": patch
+---
+
+Reduce svelte2tsx parse time and memory by skipping unused expression
+location objects.

--- a/crates/rsvelte_projection/src/svelte2tsx/svelte2tsx.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/svelte2tsx.rs
@@ -467,7 +467,7 @@ pub fn svelte2tsx(
     let parse_options = ParseOptions {
         modern: true,
         loose: false,
-        skip_expression_loc: false,
+        skip_expression_loc: true,
         defer_script_parse: true,
         force_typescript: false,
         lenient_script: false,


### PR DESCRIPTION
## Summary

- set `skip_expression_loc: true` for the svelte2tsx parse path
- avoid the full-source newline offset table and per-expression location construction/binary searches
- retain byte spans, parser diagnostics, and every AST field consumed by projection

The projection crate has no expression `.loc` reads. Public parser behavior and compiler paths that request locations are unchanged.

## Performance

Fat LTO, one codegen unit, pinned language-tools corpus, 7,500 samples per binary with alternating execution order:

| Base | Paired median | Unpaired median |
|---|---:|---:|
| 0.9.7 main before #1961 | -6.88% | -6.61% |
| repeat | -6.85% | -5.90% |
| #1961, after rebase | -5.95% | -5.86% |

Peak RSS after rebase was -128 KiB (-2.30%). Binary size is unchanged.

## Validation

- `cargo test -p rsvelte_projection`
- core library tests: 1,303 passed, 1 ignored
- pinned language-tools parity after rebase: 249/254, exactly the same five known mismatches
- `cargo clippy --all-targets --all-features -- -D warnings`
- wasm32 projection check
- `cargo fmt --all -- --check`

The broader core integration run reached `audit_skipped`, which requires generated release-main fixtures absent from the worktree; this was environmental rather than a test failure.
