### PR TITLE
Skip discarded template comment AST roundtrip

### DIFF
--- a/.changeset/skip-discarded-template-comment-ast.md
+++ b/.changeset/skip-discarded-template-comment-ast.md
@@ -1,0 +1,8 @@
+---
+"@rsvelte/compiler": patch
+"@rsvelte/svelte2tsx": patch
+"@rsvelte/svelte-check": patch
+---
+
+Reduce svelte2tsx parse time and memory by skipping discarded template
+comment AST conversion when comments are not requested.

--- a/crates/rsvelte_core/src/compiler/phases/1_parse/read/expression.rs
+++ b/crates/rsvelte_core/src/compiler/phases/1_parse/read/expression.rs
@@ -1874,6 +1874,10 @@ fn parse_expression_with_typescript<'a>(
                     );
                 }
 
+                if !crate::ast::arena::comment_capture_active() {
+                    return Some(expr);
+                }
+
                 // Collect leading comments (before the expression)
                 let leading_comments: Vec<Value> = result
                     .program


### PR DESCRIPTION
## Summary

- return the parsed template expression immediately when comment capture is disabled
- skip the comment-only JSON serialize/clone/deserialize roundtrip whose result would be discarded
- preserve root comment collection and public parser behavior whenever comments are requested

This is a four-line fast path in the TypeScript expression reader. Byte spans, diagnostics, and the expression AST itself are unchanged.

## Performance

Fat LTO, one codegen unit, pinned language-tools corpus, 7,500 samples per binary with alternating execution order:

| Base | Paired median | Unpaired median |
|---|---:|---:|
| #1961 | -5.48% | -6.17% |
| #1961 repeat | -5.19% | -5.37% |
| #1965, after rebase | -2.98% | -3.64% |
| #1965 repeat | -2.63% | -2.04% |

After #1965 already removed expression-location work, this change still reduced peak RSS by another 128 KiB (-2.35%) and reduced the binary by 1,808 bytes.

## Validation

- `cargo test -p rsvelte_core`
- `cargo test -p rsvelte_projection`
- pinned language-tools parity after rebase: 249/254, exactly the same five known mismatches
- `cargo clippy --all-targets --all-features -- -D warnings`
- wasm32 check
- `cargo fmt --all -- --check`
