### PR TITLE
Stream svelte2tsx component return output

### DIFF
--- a/.changeset/stream-svelte2tsx-component-return.md
+++ b/.changeset/stream-svelte2tsx-component-return.md
@@ -1,0 +1,8 @@
+---
+"@rsvelte/compiler": patch
+"@rsvelte/svelte2tsx": patch
+"@rsvelte/svelte-check": patch
+---
+
+Reduce svelte2tsx transformation overhead by streaming the component return
+object into its output buffer.

--- a/crates/rsvelte_projection/src/svelte2tsx/add_component_export.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/add_component_export.rs
@@ -126,11 +126,15 @@ pub(crate) fn add_component_export(
         + 256;
     let mut closing = String::with_capacity(common_capacity);
     closing.push_str("};\n");
-    let _ = writeln!(
-        closing,
-        "return {{ props: {}{}{}, slots: {}, events: {} }}}}",
-        props_str, exports_str, bindings_str, slots_str, events_str,
-    );
+    closing.push_str("return { props: ");
+    closing.push_str(&props_str);
+    closing.push_str(&exports_str);
+    closing.push_str(&bindings_str);
+    closing.push_str(", slots: ");
+    closing.push_str(&slots_str);
+    closing.push_str(", events: ");
+    closing.push_str(&events_str);
+    closing.push_str(" }}\n");
 
     // component_doc is emitted immediately before each component const/class
     // declaration below (mirroring upstream addComponentExport.ts which places


### PR DESCRIPTION
Streams the common component return object directly into the existing output buffer, avoiding formatting machinery for five dynamic strings while preserving byte-identical output.

Benchmarks on the pinned language-tools corpus:
- fat-LTO 7,500 samples: paired -1.28%, unpaired -1.40%
- fat-LTO 15,000 samples: paired -0.73%, unpaired -0.46%
- binary size unchanged

Validation:
- svelte2tsx 249/254, same five known baseline mismatches
- rsvelte_projection 246/246 unit tests
- rsvelte_core lib 1303 passed, 1 ignored
- cargo fmt check
- strict clippy with all targets and features
- wasm32 check

Includes patch changesets for compiler, svelte2tsx, and svelte-check.