### PR TITLE
Optimize unmapped source-map UTF-16 scans

### DIFF
--- a/.changeset/optimize-unmapped-utf16-scan.md
+++ b/.changeset/optimize-unmapped-utf16-scan.md
@@ -1,0 +1,8 @@
+---
+"@rsvelte/compiler": patch
+"@rsvelte/svelte2tsx": patch
+"@rsvelte/svelte-check": patch
+---
+
+Reduce svelte2tsx source-map overhead by scanning unmapped UTF-8 content once
+while updating generated UTF-16 columns.

--- a/crates/rsvelte_projection/src/svelte2tsx/magic_string.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/magic_string.rs
@@ -635,23 +635,24 @@ impl<'a> MappingState<'a> {
             return;
         }
 
-        if content.is_ascii() {
-            let mut line_start = 0;
-            for newline in memchr::memchr_iter(b'\n', content.as_bytes()) {
-                self.generated_column += (newline - line_start) as i64;
-                self.advance_line();
-                line_start = newline + 1;
+        let mut generated_column = self.generated_column;
+        let mut starts_line = false;
+        // Valid UTF-8 contributes one unit per leading byte and one extra for astral leads.
+        for &byte in content.as_bytes() {
+            match byte {
+                b'\n' => {
+                    self.mappings.push(';');
+                    generated_column = 0;
+                    starts_line = true;
+                }
+                0x00..=0x7f | 0xc0..=0xef => generated_column += 1,
+                0xf0..=0xff => generated_column += 2,
+                _ => {}
             }
-            self.generated_column += (content.len() - line_start) as i64;
-            return;
         }
-
-        for ch in content.chars() {
-            if ch == '\n' {
-                self.advance_line();
-            } else {
-                self.generated_column += ch.len_utf16() as i64;
-            }
+        self.generated_column = generated_column;
+        if starts_line {
+            self.first_segment_on_line = true;
         }
     }
 


### PR DESCRIPTION
Scans valid UTF-8 bytes once while advancing unmapped source-map state, updating generated UTF-16 columns without a separate ASCII/non-ASCII character path. Newline mapping output remains incremental and byte-identical.

Benchmarks on the pinned language-tools corpus:
- cumulative fat-LTO 7,500 samples after PR #1968: paired -3.47%, unpaired -3.32%
- prior fat-LTO 7,500 samples: paired -1.04%, unpaired -0.95%
- prior fat-LTO 15,000 samples: paired -1.65%, unpaired -1.58%
- two independent initial repeats: paired -2.24% and -2.21%
- binary size -176 bytes on the cumulative build

Validation:
- svelte2tsx 249/254, same five known baseline mismatches
- rsvelte_projection library tests
- rsvelte_core library tests
- targeted MagicString tests after the final rebase
- cargo fmt check
- strict clippy with all targets and features
- wasm32 check

Includes patch changesets for compiler, svelte2tsx, and svelte-check.