### PR TITLE
Optimize svelte2tsx source feature scans

### DIFF
--- a/.changeset/consolidate-svelte2tsx-source-features.md
+++ b/.changeset/consolidate-svelte2tsx-source-features.md
@@ -1,0 +1,8 @@
+---
+"@rsvelte/compiler": patch
+"@rsvelte/svelte2tsx": patch
+"@rsvelte/svelte-check": patch
+---
+
+Reduce svelte2tsx source scanning by collecting validation markers in the
+existing source-feature pass.

--- a/crates/rsvelte_projection/src/svelte2tsx/svelte2tsx.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/svelte2tsx.rs
@@ -476,16 +476,16 @@ pub fn svelte2tsx(
     };
     let mut ast = phase1_parse::parse_script_ts(&parse_source, parse_options)?;
     let parsed_scripts = super::script::ParsedScripts::new(&mut ast);
+    let source_features = scan_source_features(source);
 
     // svelte rejects `{@debug expr}` whose arguments are not plain identifiers
     // (`{@debug user.firstname}` / `{@debug a[0]}`) at PARSE time. rsvelte does
     // this in the analyze DebugTag visitor, which svelte2tsx never runs — so
     // replicate it here to preserve error-parity with official svelte2tsx.
-    let (has_debug_marker, has_meta_marker) = validation_markers(source);
-    if has_debug_marker {
+    if source_features.has_debug_marker {
         validate_debug_tag_arguments(&ast, source)?;
     }
-    if has_meta_marker {
+    if source_features.has_meta_marker {
         validate_meta_element_placement(&ast, source)?;
     }
 
@@ -563,7 +563,6 @@ pub fn svelte2tsx(
         );
     }
 
-    let source_features = scan_source_features(source);
     // Step 7.48: Find and remove embedded `<script>` tags (those NOT matching
     // the top-level instance / module script). Mirrors official svelte2tsx's
     // `blankOtherScriptTags` / `str.move` approach.
@@ -870,36 +869,6 @@ pub fn svelte2tsx(
     })
 }
 
-fn validation_markers(source: &str) -> (bool, bool) {
-    let bytes = source.as_bytes();
-    let mut has_debug = false;
-    let mut has_meta = false;
-
-    for index in memchr::memchr2_iter(b'@', b':', bytes) {
-        match bytes[index] {
-            b'@' => {
-                if !has_debug {
-                    has_debug =
-                        index > 0 && bytes.get(index - 1..index + 6) == Some(b"{@debug".as_slice());
-                }
-            }
-            b':' => {
-                if !has_meta {
-                    has_meta = (index >= 7
-                        && bytes.get(index - 7..=index) == Some(b"<svelte:".as_slice()))
-                        || (index >= 3 && bytes.get(index - 3..=index) == Some(b"use:".as_slice()));
-                }
-            }
-            _ => unreachable!(),
-        }
-        if has_debug && has_meta {
-            break;
-        }
-    }
-
-    (has_debug, has_meta)
-}
-
 #[cfg(test)]
 mod source_map_remap_tests {
     use super::*;
@@ -1036,15 +1005,6 @@ mod source_map_remap_tests {
         assert_eq!(
             position_text_edits("abcdef", &[edit(4, 2)]).unwrap_err(),
             expected
-        );
-    }
-
-    #[test]
-    fn validation_markers_remain_set_after_unrelated_candidates() {
-        assert_eq!(validation_markers("{@debug user.name} @"), (true, false));
-        assert_eq!(
-            validation_markers("<div><svelte:window /></div>:"),
-            (false, true)
         );
     }
 

--- a/crates/rsvelte_projection/src/svelte2tsx/utils/source_features.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/utils/source_features.rs
@@ -8,6 +8,8 @@ pub(crate) struct SourceFeatures {
     pub may_have_template_rune_global: bool,
     pub has_await_word: bool,
     pub may_need_template_info: bool,
+    pub has_debug_marker: bool,
+    pub has_meta_marker: bool,
 }
 
 impl SourceFeatures {
@@ -32,8 +34,8 @@ fn scan_source_features_with(
 ) -> SourceFeatures {
     let bytes = source.as_bytes();
     let mut features = SourceFeatures {
-        may_need_template_info: memchr::memmem::find(bytes, b"<slot").is_some()
-            || memchr::memmem::find(bytes, b"on:").is_some(),
+        may_need_template_info: memchr::memmem::find(bytes, b"<slot").is_some(),
+        has_debug_marker: memchr::memmem::find(bytes, b"{@debug").is_some(),
         ..SourceFeatures::default()
     };
     let mut cursor = 0;
@@ -41,11 +43,16 @@ fn scan_source_features_with(
     loop {
         let needs_dollar = !features.dollar_scan_is_complete();
         let needs_await = !features.has_await_word;
-        let offset = match (needs_dollar, needs_await) {
-            (true, true) => memchr::memchr2(b'$', b'a', &bytes[cursor..]),
-            (true, false) => memchr::memchr(b'$', &bytes[cursor..]),
-            (false, true) => memchr::memchr(b'a', &bytes[cursor..]),
-            (false, false) => break,
+        let needs_colon = !features.may_need_template_info || !features.has_meta_marker;
+        let offset = match (needs_dollar, needs_await, needs_colon) {
+            (true, true, true) => memchr::memchr3(b'$', b'a', b':', &bytes[cursor..]),
+            (true, true, false) => memchr::memchr2(b'$', b'a', &bytes[cursor..]),
+            (true, false, true) => memchr::memchr2(b'$', b':', &bytes[cursor..]),
+            (true, false, false) => memchr::memchr(b'$', &bytes[cursor..]),
+            (false, true, true) => memchr::memchr2(b'a', b':', &bytes[cursor..]),
+            (false, true, false) => memchr::memchr(b'a', &bytes[cursor..]),
+            (false, false, true) => memchr::memchr(b':', &bytes[cursor..]),
+            (false, false, false) => break,
         };
         let Some(offset) = offset else {
             break;
@@ -87,6 +94,17 @@ fn scan_source_features_with(
                 let after_ok = after == bytes.len() || !is_ident_char(bytes[after]);
                 features.has_await_word |= before_ok && after_ok;
             }
+            b':' => {
+                if !features.may_need_template_info {
+                    features.may_need_template_info =
+                        position >= 2 && bytes.get(position - 2..=position) == Some(b"on:");
+                }
+                if !features.has_meta_marker {
+                    features.has_meta_marker = (position >= 7
+                        && bytes.get(position - 7..=position) == Some(b"<svelte:"))
+                        || (position >= 3 && bytes.get(position - 3..=position) == Some(b"use:"));
+                }
+            }
             _ => {}
         }
 
@@ -121,6 +139,11 @@ mod tests {
             features.may_need_template_info,
             source.contains("<slot") || source.contains("on:")
         );
+        assert_eq!(features.has_debug_marker, source.contains("{@debug"));
+        assert_eq!(
+            features.has_meta_marker,
+            source.contains("<svelte:") || source.contains("use:")
+        );
     }
 
     #[test]
@@ -152,6 +175,10 @@ mod tests {
             "éawait文",
             "<!-- $$props $state await -->",
             r#"<script>const text = "$$restProps $$slots $effect await";</script>"#,
+            "{@debug user}",
+            "<svelte:window />",
+            "<div use:action />",
+            "on:click",
         ] {
             assert_matches_previous_scans(source);
         }
@@ -162,7 +189,7 @@ mod tests {
         let source = "x$yaz".repeat(1 << 16);
         let expected_candidates = source
             .bytes()
-            .filter(|byte| matches!(byte, b'$' | b'a'))
+            .filter(|byte| matches!(byte, b'$' | b'a' | b':'))
             .count();
         let mut visits = 0;
         let mut previous = None;


### PR DESCRIPTION
## Summary
- collect validation markers in the existing source feature scan
- remove the separate validation-marker traversal
- preserve exact official svelte2tsx output

## Performance
Cumulative fat-LTO A/B against `main` after #1969:
- 7,500 iterations: paired -2.73%, unpaired -2.12%
- 15,000 iterations: paired -1.19%, unpaired -0.47%
- benchmark binary size unchanged (10,166,400 bytes)

Isolated normal-profile A/B:
- 7,500 iterations: paired -0.36%, unpaired +0.21%
- 15,000 iterations: paired -1.30%, unpaired -0.34%

## Validation
- `cargo fmt --check`
- `cargo test -p rsvelte_projection --lib` (245/245)
- svelte2tsx compatibility: 249/254, same five pinned upstream baseline failures
- `cargo test -p rsvelte_core --lib` (1303 passed, 1 ignored)
- strict Clippy across all targets/features
- wasm build