### PR TITLE
Reuse svelte2tsx instance import traversal

### DIFF
--- a/.changeset/reuse-instance-import-traversal.md
+++ b/.changeset/reuse-instance-import-traversal.md
@@ -1,0 +1,8 @@
+---
+"@rsvelte/compiler": patch
+"@rsvelte/svelte2tsx": patch
+"@rsvelte/svelte-check": patch
+---
+
+Reduce svelte2tsx instance-script work by collecting import ranges during the
+existing top-level statement traversal.

--- a/crates/rsvelte_projection/src/svelte2tsx/nodes/scripts.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/nodes/scripts.rs
@@ -45,8 +45,6 @@ pub(crate) fn find_instance_imports(
     source: &str,
     program: &oxc_ast::ast::Program,
 ) -> Vec<(u32, u32, u32)> {
-    use oxc_ast::ast as oxc;
-
     let content_start = script.content_offset as usize;
     let script_source = slice_src(source, script.start as usize, script.end as usize);
     let close_tag_offset = script_source
@@ -63,39 +61,64 @@ pub(crate) fn find_instance_imports(
         return Vec::new();
     }
 
+    let mut collector = InstanceImportCollector::new(raw_content, &program.comments);
+    for stmt in program.body.iter() {
+        collector.push_statement(stmt);
+    }
+    collector.finish()
+}
+
+pub(crate) struct InstanceImportCollector<'a> {
+    bytes: &'a [u8],
+    comments: &'a [oxc_ast::ast::Comment],
+    comment_cursor: usize,
+    imports: Vec<(u32, u32, u32)>,
+}
+
+impl<'a> InstanceImportCollector<'a> {
+    pub(crate) fn new(content: &'a str, comments: &'a [oxc_ast::ast::Comment]) -> Self {
+        Self {
+            bytes: content.as_bytes(),
+            comments,
+            comment_cursor: 0,
+            imports: Vec::new(),
+        }
+    }
+
     // Parser comments are source-ordered. Keep a monotonic cursor over them to
     // compute each import's leading-comment region the way TS
     // `getLeadingCommentRanges(node.getFullText())` does — including a TRAILING
     // line comment on the PREVIOUS statement's line (it is leading trivia of the
     // following import and moves up with it). The parser already tokenised
     // strings/regex correctly, so `// …` inside a string is never misread.
-    let mut imports = Vec::new();
-    let bytes = raw_content.as_bytes();
-    let comments = &program.comments;
-    let mut comment_cursor = 0;
-    for stmt in program.body.iter() {
-        if let oxc::Statement::ImportDeclaration(import) = stmt {
-            // All import declarations (including side-effect imports like `import ''`)
-            // should be lifted. The parser only creates ImportDeclaration nodes for
-            // valid `import` statements with a source clause.
-            let start = import.span.start;
-            let end = import.span.end;
-            while comment_cursor < comments.len() && comments[comment_cursor].span.end <= start {
-                comment_cursor += 1;
-            }
-
-            // Walk backwards over leading trivia, pulling in every comment whose
-            // end is reachable from the current start via whitespace only, and
-            // stopping at the first non-comment code (the previous token). This
-            // mirrors `getLeadingCommentRanges` and pulls a trailing line comment
-            // (`import …; // TODO`) into the FOLLOWING import's leading region.
-            let new_start =
-                scan_back_leading_comments(bytes, start as usize, comments, comment_cursor);
-
-            imports.push((new_start, start, end));
+    pub(crate) fn push_statement(&mut self, stmt: &oxc_ast::ast::Statement) {
+        if let oxc_ast::ast::Statement::ImportDeclaration(import) = stmt {
+            self.push_import(import);
         }
     }
-    imports
+
+    pub(crate) fn push_import(&mut self, import: &oxc_ast::ast::ImportDeclaration) {
+        let start = import.span.start;
+        let end = import.span.end;
+        while self.comment_cursor < self.comments.len()
+            && self.comments[self.comment_cursor].span.end <= start
+        {
+            self.comment_cursor += 1;
+        }
+
+        let new_start = scan_back_leading_comments(
+            self.bytes,
+            start as usize,
+            self.comments,
+            self.comment_cursor,
+        );
+
+        self.imports.push((new_start, start, end));
+    }
+
+    pub(crate) fn finish(self) -> Vec<(u32, u32, u32)> {
+        self.imports
+    }
 }
 
 /// Walk backwards from `pos` over leading trivia (whitespace + comments),

--- a/crates/rsvelte_projection/src/svelte2tsx/process_instance_script_tag.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/process_instance_script_tag.rs
@@ -10,9 +10,7 @@ use super::nodes::generics::{
     extract_generics_from_script_tag, split_generic_param_names, type_text_references_any,
     type_text_typeof_references_local_value,
 };
-use super::nodes::scripts::{
-    detect_top_level_await, find_instance_imports, find_script_close_tag_start,
-};
+use super::nodes::scripts::{detect_top_level_await, find_script_close_tag_start};
 use super::script::ExportedNames;
 use super::svelte2tsx::slice_src;
 
@@ -38,6 +36,7 @@ pub(crate) fn process_instance_script_tag(
     has_module_script: bool,
     has_slot_elements: bool,
     hoistable_snippet_ranges: &[(u32, u32)],
+    imports: &[(u32, u32, u32)],
 ) -> bool {
     let instance = ast.instance.as_ref().unwrap();
     let script_start = instance.start;
@@ -122,15 +121,12 @@ pub(crate) fn process_instance_script_tag(
             .unwrap_or_default()
     };
 
-    // Find import declarations in the instance script content
-    let imports = find_instance_imports(instance, source, instance_program);
-
     let has_imports = !imports.is_empty();
     // Lift imports above $$render(): each import is collected individually
     // (without leading whitespace) and inserted into the <script> tag
     // replacement, with the original positions blanked out.
     let import_text = if has_imports {
-        collect_lifted_imports(&imports, source, content_start, str)
+        collect_lifted_imports(imports, source, content_start, str)
     } else {
         String::new()
     };

--- a/crates/rsvelte_projection/src/svelte2tsx/script/mod.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/script/mod.rs
@@ -29,7 +29,9 @@ use oxc_span::GetSpan;
 use crate::ast::template::Script;
 
 use super::magic_string::MagicString;
+use super::nodes::scripts::InstanceImportCollector;
 use super::svelte2tsx::slice_src;
+use super::utils::lexical::contains_word;
 
 pub use component_events::ComponentEvents;
 pub use exported_names::{ExportedNameInfo, ExportedNames};
@@ -109,10 +111,13 @@ pub fn process_instance_script(
     emit_jsdoc: bool,
     is_dts_mode: bool,
     script_generic_names: &HashSet<String>,
-) {
+) -> Vec<(u32, u32, u32)> {
     let offset = script.content_offset;
+    let mut instance_imports = Vec::new();
     with_parsed_script(parsed, |program, raw_content| {
         let script_facts = ScriptFacts::collect(program, offset, raw_content, true, store_scan);
+        let mut import_collector = contains_word(raw_content.as_bytes(), b"import")
+            .then(|| InstanceImportCollector::new(raw_content, &program.comments));
 
         // Pass 1: collect top-level declared names and possible exports
         let mut possible_exports: HashMap<String, PossibleExport> = HashMap::new();
@@ -209,6 +214,9 @@ pub fn process_instance_script(
                     }
                 }
                 oxc::Statement::ImportDeclaration(import) => {
+                    if let Some(collector) = &mut import_collector {
+                        collector.push_import(import);
+                    }
                     if let Some(ref specifiers) = import.specifiers {
                         for spec in specifiers.iter() {
                             let name = match spec {
@@ -700,7 +708,12 @@ pub fn process_instance_script(
         // anywhere in the instance script — TSX cannot parse the `<X>e` form.
         // Mirrors official `handleTypeAssertion`, applied during the same walk.
         rewrite_type_assertions(&script_facts.type_assertions, str);
+
+        if let Some(collector) = import_collector {
+            instance_imports = collector.finish();
+        }
     });
+    instance_imports
 }
 /// Process a module script block (`<script context="module">`).
 ///

--- a/crates/rsvelte_projection/src/svelte2tsx/svelte2tsx.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/svelte2tsx.rs
@@ -542,8 +542,9 @@ pub fn svelte2tsx(
                 .collect::<std::collections::HashSet<String>>()
         })
         .unwrap_or_default();
+    let mut instance_imports = Vec::new();
     if let (Some(instance), Some(parsed)) = (&ast.instance, &parsed_scripts.instance) {
-        super::script::process_instance_script(
+        instance_imports = super::script::process_instance_script(
             instance,
             parsed,
             parsed_scripts
@@ -759,6 +760,7 @@ pub fn svelte2tsx(
             has_module_script,
             has_slot_elements,
             &hoistable_snippet_ranges,
+            &instance_imports,
         );
     }
 


### PR DESCRIPTION
## Summary
- collect instance import ranges in the existing top-level statement traversal
- preserve the `contains_word(import)` negative fast path
- reuse the same collector for the module-only fallback path
- remove the later full top-level AST traversal before import lifting

## Performance
Fat-LTO A/B against #1970:
- 7,500 samples/binary: paired -0.17%, unpaired -0.29%
- 15,000 samples/binary: paired -0.76%, unpaired -1.11%
- median maximum RSS unchanged (5,472,256 bytes)
- benchmark binary: +16 bytes (10,166,416 bytes)

## Validation
- svelte2tsx compatibility: 249/254, same five pinned upstream baseline failures
- `cargo test -p rsvelte_projection --lib` (245/245)
- `cargo test -p rsvelte_core --lib` (1303 passed, 1 ignored)
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo check -p rsvelte_projection --target wasm32-unknown-unknown`
- `cargo fmt --check`