### PR TITLE
Shorten svelte2tsx opening tag scans

### DIFF
--- a/.changeset/shorten-opening-tag-scans.md
+++ b/.changeset/shorten-opening-tag-scans.md
@@ -1,0 +1,8 @@
+---
+"@rsvelte/compiler": patch
+"@rsvelte/svelte2tsx": patch
+"@rsvelte/svelte-check": patch
+---
+
+Reduce svelte2tsx opening-tag scans by starting after the final parsed
+attribute.

--- a/crates/rsvelte_projection/src/svelte2tsx/template/attributes/mod.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/template/attributes/mod.rs
@@ -38,7 +38,7 @@ use spread::{format_spread_attribute, format_spread_attribute_segments};
 use transition::format_transition_directive;
 
 /// End offset of an attribute or directive in the element opener.
-fn attribute_end(attr: &Attribute) -> u32 {
+pub(super) fn attribute_end(attr: &Attribute) -> u32 {
     match attr {
         Attribute::Attribute(n) => n.end,
         Attribute::SpreadAttribute(n) => n.end,

--- a/crates/rsvelte_projection/src/svelte2tsx/template/nodes/component_slots.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/template/nodes/component_slots.rs
@@ -412,7 +412,8 @@ pub(crate) fn handle_named_slot_element(
     // Build attributes string excluding `slot` and `let:` directives
     let attrs_str = build_named_slot_element_attrs(&el.attributes, source);
 
-    let opening_tag_end = find_opening_tag_end(source, el.start, el.end);
+    let opening_tag_end =
+        find_opening_tag_end(source, el.start, el.end, el.name.as_str(), &el.attributes);
 
     // class:/style: directives lower to statements after createElement
     // (`class:bar` → ` bar;`), same as a regular element. The `let:` binding
@@ -483,7 +484,8 @@ pub(crate) fn handle_named_slot_svelte_fragment(
         let_destructure, inst_var, slot_name
     );
 
-    let opening_tag_end = find_opening_tag_end(source, el.start, el.end);
+    let opening_tag_end =
+        find_opening_tag_end(source, el.start, el.end, el.name.as_str(), &el.attributes);
     let closing_tag_start = find_closing_tag_start(source, el.end);
     let has_closing_tag = closing_tag_start < el.end;
 

--- a/crates/rsvelte_projection/src/svelte2tsx/template/nodes/dynamic_element.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/template/nodes/dynamic_element.rs
@@ -73,7 +73,8 @@ pub(crate) fn handle_svelte_dynamic_element(
     } else {
         raw_tag_text.to_string()
     };
-    let opening_tag_end = find_opening_tag_end(source, el.start, el.end);
+    let opening_tag_end =
+        find_opening_tag_end(source, el.start, el.end, el.name.as_str(), &el.attributes);
     // In a named-slot context the `slot` attribute is consumed by the wrapper
     // block, so build the attributes without it.
     let attrs_str = if named_slot.is_some() {

--- a/crates/rsvelte_projection/src/svelte2tsx/template/nodes/element.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/template/nodes/element.rs
@@ -94,7 +94,8 @@ pub(crate) fn handle_regular_element(
     }
 
     // Find the end of the opening tag (after the `>`)
-    let opening_tag_end = find_opening_tag_end(source, el.start, el.end);
+    let opening_tag_end =
+        find_opening_tag_end(source, el.start, el.end, el.name.as_str(), &el.attributes);
 
     // Build attribute segments. Source-bearing expressions become
     // `Seg::Src` so the resulting overwrite leaves them as unedited
@@ -293,7 +294,8 @@ pub(crate) fn handle_title_element(
         return;
     }
 
-    let opening_tag_end = find_opening_tag_end(source, el.start, el.end);
+    let opening_tag_end =
+        find_opening_tag_end(source, el.start, el.end, el.name.as_str(), &el.attributes);
     let attrs_str = build_attributes_string(
         &el.attributes,
         source,

--- a/crates/rsvelte_projection/src/svelte2tsx/template/nodes/inline_component.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/template/nodes/inline_component.rs
@@ -96,7 +96,13 @@ pub(crate) fn handle_component(
     let inst_var = reversed_component_name(&comp.name, depth);
 
     // Find the end of the opening tag
-    let opening_tag_end = find_opening_tag_end(source, comp.start, comp.end);
+    let opening_tag_end = find_opening_tag_end(
+        source,
+        comp.start,
+        comp.end,
+        comp.name.as_str(),
+        &comp.attributes,
+    );
 
     // Collect on: directives and let: directives
     let on_directives = get_on_directives(&comp.attributes);
@@ -484,7 +490,13 @@ pub(crate) fn handle_svelte_component(
     let saved_outer_slot = counter.slot_inst.take();
 
     let expr_text = get_expression_text(&comp.expression, source);
-    let opening_tag_end = find_opening_tag_end(source, comp.start, comp.end);
+    let opening_tag_end = find_opening_tag_end(
+        source,
+        comp.start,
+        comp.end,
+        comp.name.as_str(),
+        &comp.attributes,
+    );
 
     // Collect on: directives
     let on_directives = get_on_directives(&comp.attributes);
@@ -646,7 +658,8 @@ pub(crate) fn handle_svelte_self(
         return;
     }
 
-    let opening_tag_end = find_opening_tag_end(source, el.start, el.end);
+    let opening_tag_end =
+        find_opening_tag_end(source, el.start, el.end, el.name.as_str(), &el.attributes);
     let closing_tag_start = find_closing_tag_start(source, el.end);
     let has_closing_tag = closing_tag_start < el.end;
 

--- a/crates/rsvelte_projection/src/svelte2tsx/template/nodes/slot_element.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/template/nodes/slot_element.rs
@@ -49,7 +49,8 @@ pub(crate) fn handle_slot_element(
         str.prepend_left(el.start, &block_open);
     }
 
-    let opening_tag_end = find_opening_tag_end(source, el.start, el.end);
+    let opening_tag_end =
+        find_opening_tag_end(source, el.start, el.end, el.name.as_str(), &el.attributes);
 
     // Extract the slot name from attributes (default: "default")
     let slot_name = get_slot_name(&el.attributes, source);

--- a/crates/rsvelte_projection/src/svelte2tsx/template/nodes/special_element.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/template/nodes/special_element.rs
@@ -45,7 +45,8 @@ pub(crate) fn handle_svelte_special_element(
         return;
     }
 
-    let opening_tag_end = find_opening_tag_end(source, el.start, el.end);
+    let opening_tag_end =
+        find_opening_tag_end(source, el.start, el.end, el.name.as_str(), &el.attributes);
     let mut attrs_str = build_attributes_string(
         &el.attributes,
         source,

--- a/crates/rsvelte_projection/src/svelte2tsx/template/utils/source.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/template/utils/source.rs
@@ -1,5 +1,8 @@
 //! Raw-source scanners for tag positions that the AST does not record.
 
+use crate::ast::template::Attribute;
+use crate::svelte2tsx::template::attributes::attribute_end;
+
 /// Count the number of whitespace characters between the tag name and the
 /// first attribute in the opening tag source. This preserves whitespace
 /// that the JS svelte2tsx would keep via MagicString in-place editing.
@@ -27,11 +30,25 @@ pub(crate) fn count_tag_to_attr_spaces(tag_name: &str, el_start: u32, source: &s
 
 /// Find the end of the opening tag (position after the closing `>`).
 ///
-/// Scans from `start` looking for the first `>` that is not inside a string
-/// or expression. Returns the position after the `>`.
-pub(crate) fn find_opening_tag_end(source: &str, start: u32, element_end: u32) -> u32 {
+/// Scans from the last retained attribute (or the tag name when there are no
+/// attributes) for the first `>` that is not inside a string or expression.
+/// Returns the position after the `>`.
+pub(crate) fn find_opening_tag_end(
+    source: &str,
+    element_start: u32,
+    element_end: u32,
+    tag_name: &str,
+    attributes: &[Attribute],
+) -> u32 {
     let bytes = source.as_bytes();
-    let start = start as usize;
+    let tag_name_end = element_start.saturating_add(1 + tag_name.len() as u32);
+    let scan_start = attributes.last().map_or(tag_name_end, attribute_end);
+    let scan_start = if scan_start >= tag_name_end && scan_start <= element_end {
+        scan_start
+    } else {
+        element_start
+    };
+    let start = scan_start as usize;
     let end = element_end as usize;
     let mut i = start;
     let mut in_string = None::<u8>; // tracks quote char
@@ -122,4 +139,159 @@ pub(crate) fn find_closing_tag_start(source: &str, end: u32) -> u32 {
     }
 
     end as u32
+}
+
+#[cfg(test)]
+mod tests {
+    use super::find_opening_tag_end;
+    use crate::ast::template::TemplateNode;
+    use crate::compiler::phases::phase1_parse::{self, ParseOptions};
+
+    fn opening_tag_end(source: &str) -> u32 {
+        let ast = phase1_parse::parse_script_ts(
+            source,
+            ParseOptions {
+                modern: true,
+                ..Default::default()
+            },
+        )
+        .expect("source should parse");
+        let node = ast.fragment.nodes.first().expect("element");
+
+        macro_rules! find_for {
+            ($element:expr) => {
+                find_opening_tag_end(
+                    source,
+                    $element.start,
+                    $element.end,
+                    $element.name.as_str(),
+                    &$element.attributes,
+                )
+            };
+        }
+
+        match node {
+            TemplateNode::RegularElement(element) => find_for!(element),
+            TemplateNode::Component(element) => find_for!(element),
+            TemplateNode::TitleElement(element) => find_for!(element),
+            TemplateNode::SlotElement(element) => find_for!(element),
+            TemplateNode::SvelteBody(element)
+            | TemplateNode::SvelteDocument(element)
+            | TemplateNode::SvelteFragment(element)
+            | TemplateNode::SvelteBoundary(element)
+            | TemplateNode::SvelteHead(element)
+            | TemplateNode::SvelteSelf(element)
+            | TemplateNode::SvelteWindow(element) => find_for!(element),
+            TemplateNode::SvelteComponent(element) => find_for!(element),
+            TemplateNode::SvelteElement(element) => find_for!(element),
+            other => panic!("expected element, got {other:?}"),
+        }
+    }
+
+    fn expected_opening_tag_end(source: &str) -> u32 {
+        let before_close = source.rfind("</").unwrap_or(source.len());
+        (source[..before_close].rfind('>').expect("opening tag") + 1) as u32
+    }
+
+    fn assert_opening_tag_end(source: &str) {
+        assert_eq!(
+            opening_tag_end(source),
+            expected_opening_tag_end(source),
+            "{source}"
+        );
+    }
+
+    #[test]
+    fn starts_after_every_retained_attribute_kind() {
+        for source in [
+            "<div></div>",
+            "<div disabled></div>",
+            r#"<div title="a > b"></div>"#,
+            "<div title='a > b'></div>",
+            r#"<div title="before {a > b} after"></div>"#,
+            "<div data={a > b}></div>",
+            "<div data={{ nested: a > b }}></div>",
+            r#"<div data={'a \\\\' > b ? a : b}></div>"#,
+            "<div data={`value ${a > b}`}></div>",
+            "<div data={a /* > } ' */ > b}></div>",
+            "<div data={/}/.test(value) && a > b}></div>",
+            "<div {...(a > b ? left : right)}></div>",
+            "<div {@attach node => node.value > 0}></div>",
+            "<input bind:value={a > b ? a : b}>",
+            "<div on:click={() => a > b}></div>",
+            "<div class:active={a > b}></div>",
+            "<div style:color={a > b ? 'red' : 'blue'}></div>",
+            "<div transition:fade={{ duration: a > b ? a : b }}></div>",
+            "<div animate:flip={{ duration: a > b ? a : b }}></div>",
+            "<div use:action={a > b ? left : right}></div>",
+            "<Component let:item={a > b ? a : b}></Component>",
+            "<Component prop={a > b ? a : b} />",
+            r#"<div title="日本語 > 終"></div>"#,
+        ] {
+            assert_opening_tag_end(source);
+        }
+    }
+
+    #[test]
+    fn skips_comments_before_the_last_attribute_and_scans_trailing_comments() {
+        for source in [
+            r#"<div first /* > " ' { } */ second></div>"#,
+            "<div first // > \" ' { }\n second></div>",
+            "<div first /* trailing comment */ ></div>",
+            "<div first // trailing comment\n></div>",
+        ] {
+            assert_opening_tag_end(source);
+        }
+    }
+
+    #[test]
+    fn filtered_this_attribute_remains_in_the_scanned_suffix() {
+        for source in [
+            "<svelte:component this={Components[a > b ? 0 : 1]}></svelte:component>",
+            "<svelte:component foo this={Components[a > b ? 0 : 1]}></svelte:component>",
+            "<svelte:component this={Components[a > b ? 0 : 1]} foo></svelte:component>",
+            r#"<svelte:element this="section"></svelte:element>"#,
+            "<svelte:element foo this={a > b ? 'section' : 'div'}></svelte:element>",
+            "<svelte:element this={a > b ? 'section' : 'div'} foo></svelte:element>",
+        ] {
+            assert_opening_tag_end(source);
+        }
+    }
+
+    #[test]
+    fn supports_each_element_handler_shape() {
+        for source in [
+            r#"<div data-value=">"></div>"#,
+            r#"<Component data-value=">"></Component>"#,
+            r#"<title data-value=">"></title>"#,
+            r#"<slot data-value=">"></slot>"#,
+            r#"<svelte:body data-value=">"></svelte:body>"#,
+            r#"<svelte:self data-value=">"></svelte:self>"#,
+            r#"<svelte:component this={Component} data-value=">"></svelte:component>"#,
+            r#"<svelte:element this="div" data-value=">"></svelte:element>"#,
+        ] {
+            assert_opening_tag_end(source);
+        }
+    }
+
+    #[test]
+    fn malformed_openers_are_rejected_before_the_source_scan() {
+        for source in [
+            r#"<div title="unterminated"#,
+            "<div data={unterminated",
+            "<div disabled",
+        ] {
+            assert!(
+                phase1_parse::parse_script_ts(
+                    source,
+                    ParseOptions {
+                        modern: true,
+                        ..Default::default()
+                    },
+                )
+                .is_err(),
+                "{source}"
+            );
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- start opening-tag scans after the final parsed attribute
- fall back to the tag-name boundary when no attributes are retained
- reuse the exhaustive attribute-span helper across all ten element handlers
- preserve dynamic `this` suffix scanning and existing scanner semantics

## Performance
Fat-LTO A/B against #1972:
- 7,500 samples/binary: paired -1.91%, unpaired -2.22%
- 15,000 samples/binary: paired -0.93%, unpaired -1.31%
- benchmark binary size unchanged (10,166,224 bytes)
- median max RSS: +32,768 bytes (+0.60% fixed process-level page delta)

The speed win is repeatable and substantially larger than the fixed RSS delta; no per-file or per-node allocation was added.

## Validation
- targeted tests cover every attribute/directive kind, quoted `>`, nested expressions, regex/comments, self-closing tags, dynamic `this`, all handler shapes, and malformed openers
- svelte2tsx compatibility: 249/254, same five pinned upstream baseline failures
- `cargo test -p rsvelte_projection --lib` (250/250)
- `cargo test -p rsvelte_core --lib` (1303 passed, 1 ignored)
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo check -p rsvelte_projection --target wasm32-unknown-unknown`
- `cargo fmt --check`