### PR TITLE
Stream common Svelte 5 component exports

### DIFF
--- a/.changeset/stream-common-svelte5-exports.md
+++ b/.changeset/stream-common-svelte5-exports.md
@@ -1,0 +1,7 @@
+---
+"@rsvelte/compiler": patch
+"@rsvelte/svelte2tsx": patch
+"@rsvelte/svelte-check": patch
+---
+
+Reduce svelte2tsx formatting overhead for common Svelte 5 component exports.

--- a/crates/rsvelte_projection/src/svelte2tsx/add_component_export.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/add_component_export.rs
@@ -77,7 +77,9 @@ pub(crate) fn add_component_export(
         options.is_ts_file,
     );
     let bindings_str = exported_names.create_bindings_str(is_svelte5);
-    let safe_name = format!("{}__SvelteComponent_", component_name);
+    let mut safe_name = String::with_capacity(component_name.len() + "__SvelteComponent_".len());
+    safe_name.push_str(component_name);
+    safe_name.push_str("__SvelteComponent_");
 
     // Extract @component documentation from HTML comments
     let component_doc = extract_component_documentation(&ast.fragment);
@@ -237,21 +239,21 @@ pub(crate) fn add_component_export(
                         closing.push_str(doc);
                         closing.push('\n');
                     }
-                    let _ = writeln!(
-                        closing,
-                        "export const {} = __sveltets_2_fn_component({});",
-                        safe_name, render_call
+                    closing.push_str("export const ");
+                    closing.push_str(&safe_name);
+                    closing.push_str(" = __sveltets_2_fn_component(");
+                    closing.push_str(render_call);
+                    closing.push_str(");\n");
+                    closing.push_str(
+                        "/*\u{03A9}ignore_start\u{03A9}*//** @typedef {ReturnType<typeof ",
                     );
-                    let _ = writeln!(
-                        closing,
-                        "/*\u{03A9}ignore_start\u{03A9}*//** @typedef {{ReturnType<typeof {}>}} {} */",
-                        safe_name, safe_name
-                    );
-                    let _ = write!(
-                        closing,
-                        "/*\u{03A9}ignore_end\u{03A9}*/export default {};",
-                        safe_name
-                    );
+                    closing.push_str(&safe_name);
+                    closing.push_str(">} ");
+                    closing.push_str(&safe_name);
+                    closing.push_str(" */\n");
+                    closing.push_str("/*\u{03A9}ignore_end\u{03A9}*/export default ");
+                    closing.push_str(&safe_name);
+                    closing.push(';');
                 } else if has_generics {
                     // Runes + generics: `__sveltets_2_fn_component($$render())`
                     // discards `T` ($$render is called without `<T>` and the
@@ -307,21 +309,19 @@ pub(crate) fn add_component_export(
                         closing.push_str(doc);
                         closing.push('\n');
                     }
-                    let _ = writeln!(
-                        closing,
-                        "const {} = __sveltets_2_fn_component({});",
-                        safe_name, render_call
-                    );
-                    let _ = writeln!(
-                        closing,
-                        "/*\u{03A9}ignore_start\u{03A9}*/type {} = ReturnType<typeof {}>;",
-                        safe_name, safe_name
-                    );
-                    let _ = write!(
-                        closing,
-                        "/*\u{03A9}ignore_end\u{03A9}*/export default {};",
-                        safe_name
-                    );
+                    closing.push_str("const ");
+                    closing.push_str(&safe_name);
+                    closing.push_str(" = __sveltets_2_fn_component(");
+                    closing.push_str(render_call);
+                    closing.push_str(");\n");
+                    closing.push_str("/*\u{03A9}ignore_start\u{03A9}*/type ");
+                    closing.push_str(&safe_name);
+                    closing.push_str(" = ReturnType<typeof ");
+                    closing.push_str(&safe_name);
+                    closing.push_str(">;\n");
+                    closing.push_str("/*\u{03A9}ignore_end\u{03A9}*/export default ");
+                    closing.push_str(&safe_name);
+                    closing.push(';');
                 }
             } else if has_generics {
                 // Generics component export: __sveltets_Render + $$IsomorphicComponent
@@ -470,7 +470,11 @@ pub(crate) fn add_component_export(
                     closing.push_str(doc);
                     closing.push('\n');
                 }
-                let _ = write!(closing, "const {} = {}(", safe_name, component_fn);
+                closing.push_str("const ");
+                closing.push_str(&safe_name);
+                closing.push_str(" = ");
+                closing.push_str(component_fn);
+                closing.push('(');
                 write_prop_def(
                     &mut closing,
                     exported_names,
@@ -479,16 +483,14 @@ pub(crate) fn add_component_export(
                     render_call,
                 );
                 closing.push_str(");\n");
-                let _ = writeln!(
-                    closing,
-                    "/*\u{03A9}ignore_start\u{03A9}*/type {} = InstanceType<typeof {}>;",
-                    safe_name, safe_name
-                );
-                let _ = write!(
-                    closing,
-                    "/*\u{03A9}ignore_end\u{03A9}*/export default {};",
-                    safe_name
-                );
+                closing.push_str("/*\u{03A9}ignore_start\u{03A9}*/type ");
+                closing.push_str(&safe_name);
+                closing.push_str(" = InstanceType<typeof ");
+                closing.push_str(&safe_name);
+                closing.push_str(">;\n");
+                closing.push_str("/*\u{03A9}ignore_end\u{03A9}*/export default ");
+                closing.push_str(&safe_name);
+                closing.push(';');
             }
         }
     }

--- a/crates/rsvelte_projection/tests/svelte2tsx_component_export_format.rs
+++ b/crates/rsvelte_projection/tests/svelte2tsx_component_export_format.rs
@@ -1,0 +1,63 @@
+use rsvelte_projection::svelte2tsx::{Svelte2TsxOptions, svelte2tsx};
+
+fn project(source: &str, filename: &str, is_ts_file: bool, emit_jsdoc: bool) -> String {
+    svelte2tsx(
+        source,
+        Svelte2TsxOptions {
+            filename: filename.into(),
+            is_ts_file,
+            emit_jsdoc,
+            ..Default::default()
+        },
+    )
+    .expect("svelte2tsx")
+    .code
+}
+
+#[test]
+fn runes_ts_component_export_suffix_is_exact() {
+    let code = project(
+        r#"<script lang="ts">let count = $state(0);</script>"#,
+        "RunesTs.svelte",
+        true,
+        false,
+    );
+
+    assert!(code.ends_with(
+        "const RunesTs__SvelteComponent_ = __sveltets_2_fn_component($$render());\n\
+         /*Ωignore_startΩ*/type RunesTs__SvelteComponent_ = ReturnType<typeof RunesTs__SvelteComponent_>;\n\
+         /*Ωignore_endΩ*/export default RunesTs__SvelteComponent_;"
+    ));
+}
+
+#[test]
+fn runes_jsdoc_component_export_suffix_is_exact() {
+    let code = project(
+        "<script>let count = $state(0);</script>",
+        "RunesJs.svelte",
+        false,
+        true,
+    );
+
+    assert!(code.ends_with(
+        "export const RunesJs__SvelteComponent_ = __sveltets_2_fn_component($$render());\n\
+         /*Ωignore_startΩ*//** @typedef {ReturnType<typeof RunesJs__SvelteComponent_>} RunesJs__SvelteComponent_ */\n\
+         /*Ωignore_endΩ*/export default RunesJs__SvelteComponent_;"
+    ));
+}
+
+#[test]
+fn legacy_v5_component_export_suffix_is_exact() {
+    let code = project(
+        r#"<script lang="ts">export let count: number;</script>"#,
+        "Legacy.svelte",
+        true,
+        false,
+    );
+
+    assert!(code.ends_with(
+        "const Legacy__SvelteComponent_ = __sveltets_2_isomorphic_component(__sveltets_2_with_any_event($$render()));\n\
+         /*Ωignore_startΩ*/type Legacy__SvelteComponent_ = InstanceType<typeof Legacy__SvelteComponent_>;\n\
+         /*Ωignore_endΩ*/export default Legacy__SvelteComponent_;"
+    ));
+}


### PR DESCRIPTION
## Summary

- build the reusable component-safe name with one exactly sized `String`
- stream the three common non-generic Svelte 5 component-export suffixes directly
- preserve generic and Svelte 4 formatting paths unchanged
- add exact suffix tests for runes TypeScript, runes JSDoc, and legacy V5 exports

## Performance

Compared with merged #1983 using fat LTO and one codegen unit on the 254-file language-tools corpus:

- 2,000 samples per binary: paired **-2.63%**, unpaired **-2.39%**
- 7,500 samples per binary: paired **-1.66%**, unpaired **-1.58%**
- 15,000 samples per binary: paired **-2.58%**, unpaired **-2.00%**
- benchmark runner size: unchanged at **10,166,048 bytes**
- median max RSS over 100 alternating rounds: **5,455,872 -> 5,488,640 bytes** (**+32 KiB / +0.60%**)

The RSS result is a fixed two-page process-level difference. This change adds no heap allocation: it replaces formatting machinery while producing the same `String` values and capacity. The speedup and equal binary size were stable across repeated measurements.

## Validation

- `cargo test -p rsvelte_projection --lib`: 252 passed
- new exact-output tests: 3 passed
- async, V4, and generic guard tests: 6 passed
- `cargo test -p rsvelte_projection --test svelte2tsx_fixtures -- --nocapture`: 249/254, same five known failures
- `cargo test -p rsvelte_core --lib`: 1303 passed, 1 ignored
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo check -p rsvelte_projection --target wasm32-unknown-unknown`
- `cargo fmt --all -- --check`
- `git diff --check`
