### PR TITLE
Use derived_safe_equal for legacy render tag memoization

### DIFF
--- a/.changeset/fix-render-tag-legacy-memoization.md
+++ b/.changeset/fix-render-tag-legacy-memoization.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/compiler": patch
+---
+
+Emit `$.derived_safe_equal` for memoized `{@render}` arguments in legacy (non-runes) mode.

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/render_tag.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/render_tag.rs
@@ -68,6 +68,11 @@ pub fn render_tag(node: &RenderTag, context: &mut ComponentContext) -> JsStateme
     // duplicate `$0` when a render tag has both an awaited arg and a call arg —
     // the `let $0` would shadow the async callback param `$0` (H-099).
     let mut placeholder_index: usize = 0;
+    let derived_fn = if context.state.analysis.runes {
+        "$.derived"
+    } else {
+        "$.derived_safe_equal"
+    };
     let args: Vec<JsExpr> = raw_args
         .iter()
         .enumerate()
@@ -121,7 +126,7 @@ pub fn render_tag(node: &RenderTag, context: &mut ComponentContext) -> JsStateme
                         &id_name,
                         Some(b::call(
                             &context.arena,
-                            b::member_path(&context.arena, "$.derived"),
+                            b::member_path(&context.arena, derived_fn),
                             vec![b::thunk(&context.arena, built)],
                         )),
                     ));

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/render_tag.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/render_tag.rs
@@ -113,7 +113,8 @@ pub fn render_tag(node: &RenderTag, context: &mut ComponentContext) -> JsStateme
                     ),
                 )
             } else {
-                // If the argument expression has a call, we need to memoize it with $.derived()
+                // If the argument expression has a call, memoize it with
+                // $.derived (runes) / $.derived_safe_equal (legacy)
                 let has_call_from_expr = render_tag_has_call(arg);
                 if template_metadata.has_call() || has_call_from_expr {
                     // Draw from the same `$N` counter as async placeholders so a

--- a/crates/rsvelte_core/tests/render_tag_legacy_memoization.rs
+++ b/crates/rsvelte_core/tests/render_tag_legacy_memoization.rs
@@ -1,0 +1,60 @@
+//! Issue #1974: a memoized `{@render}` argument must use `$.derived_safe_equal`
+//! in legacy (non-runes) mode and `$.derived` in runes mode, mirroring
+//! upstream `RenderTag.js`'s `memoizer.deriveds(analysis.runes)`.
+
+use rsvelte_core::{CompileOptions, GenerateMode, compile};
+
+fn client(src: &str) -> String {
+    compile(
+        src,
+        CompileOptions {
+            filename: Some("T.svelte".into()),
+            generate: GenerateMode::Client,
+            dev: false,
+            ..Default::default()
+        },
+    )
+    .expect("compile")
+    .js
+    .code
+}
+
+const LEGACY: &str = r#"<script>
+	export let data;
+	function log(d) { return d; }
+</script>
+{#snippet row(x)}<p>{x}</p>{/snippet}
+{@render row(log(data))}"#;
+
+const RUNES: &str = r#"<script>
+	let { data } = $props();
+	function log(d) { return d; }
+</script>
+{#snippet row(x)}<p>{x}</p>{/snippet}
+{@render row(log(data))}"#;
+
+#[test]
+fn legacy_render_tag_argument_uses_derived_safe_equal() {
+    let out = client(LEGACY);
+    assert!(
+        out.contains("$.derived_safe_equal("),
+        "legacy memoized render-tag argument must use $.derived_safe_equal, got:\n{out}"
+    );
+    assert!(
+        !out.contains("$.derived("),
+        "legacy memoized render-tag argument must not use $.derived, got:\n{out}"
+    );
+}
+
+#[test]
+fn runes_render_tag_argument_uses_derived() {
+    let out = client(RUNES);
+    assert!(
+        out.contains("$.derived("),
+        "runes memoized render-tag argument must use $.derived, got:\n{out}"
+    );
+    assert!(
+        !out.contains("derived_safe_equal"),
+        "runes memoized render-tag argument must not use $.derived_safe_equal, got:\n{out}"
+    );
+}


### PR DESCRIPTION
Fixes #1974

## Root cause

`crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/render_tag.rs` hardcoded `$.derived` when memoizing a `{@render}` argument that contains a call (`has_call`). Upstream `RenderTag.js` builds those declarations through `memoizer.deriveds(context.state.analysis.runes)`, and `Memoizer#deriveds` picks `runes ? '$.derived' : '$.derived_safe_equal'`. So a non-runes (legacy) component got `$.derived` where the official compiler emits `$.derived_safe_equal` — a real semantic difference, since `derived_safe_equal` uses `safe_not_equal` so mutated objects/arrays still notify.

## Change

- Thread `context.state.analysis.runes` into the memoized-argument declaration, matching the existing sibling-visitor pattern (`regular_element.rs`, `const_tag.rs`, `await_block.rs`, `shared/component.rs`).
- Add a patch changeset.

## Verification (desk check)

Legacy component with a call argument:

```svelte
<script>
	export let data;
	function log(d) { return d; }
</script>
{#snippet row(x)}<p>{x}</p>{/snippet}
{@render row(log(data))}
```

now yields `let $0 = $.derived_safe_equal(() => log(data));`, matching official output; runes components are unchanged (`$.derived`).

Existing tests stay green by inspection: `crates/rsvelte_core/tests/snippet_param_destructuring.rs::render_tag_async_and_call_args_share_one_counter` compiles with `runes: Some(true)` so it still asserts `$.derived(bar)`, and `crates/rsvelte_core/tests/render_tag_placeholder_counter.rs` asserts the prefix `let $1 = $.derived`, which `$.derived_safe_equal` still satisfies. Full build/test is delegated to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015vkYyTLdbG88CbZ7cjDC34