### PR TITLE
fix(compiler): strip TS definite-assignment assertions (`let x!: T`)

### DIFF
--- a/.changeset/fix-definite-assignment-strip.md
+++ b/.changeset/fix-definite-assignment-strip.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/compiler": patch
+---
+
+Strip TypeScript definite-assignment assertions (`let x!: T`, `class A { x!: T }`) so they no longer emit invalid JavaScript

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/types.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/types.rs
@@ -714,7 +714,13 @@ fn strip_typescript_from_program_impl(
             // An inline TS type annotation starts with `:` (optionally preceded by
             // whitespace already emitted). If the removed chunk starts with `:`, it
             // is a type annotation — skip comment re-emission for it entirely.
-            let is_inline_type_annotation = removed.trim_start().starts_with(':');
+            // A definite-assignment `!` is spliced together with the annotation
+            // that follows it, so look past it before testing for the sigil.
+            let is_inline_type_annotation = removed
+                .trim_start()
+                .trim_start_matches('!')
+                .trim_start()
+                .starts_with(':');
             if !is_inline_type_annotation
                 && removed.contains('\n')
                 && (removed.contains("/*") || removed.contains("//"))
@@ -1007,6 +1013,9 @@ fn collect_ts_removals_from_class(
                     continue;
                 }
                 if let Some(ref type_ann) = prop.type_annotation {
+                    if prop.definite {
+                        collect_definite_marker_removal(type_ann.span.start, source, removals);
+                    }
                     removals.push((type_ann.span.start, type_ann.span.end));
                 }
                 if let Some(ref accessibility) = prop.accessibility {
@@ -1465,13 +1474,7 @@ fn collect_ts_removals_from_statement(
                 return;
             }
             for decl in &var_decl.declarations {
-                if let Some(ref type_ann) = decl.type_annotation {
-                    removals.push((type_ann.span.start, type_ann.span.end));
-                }
-                collect_ts_removals_from_binding_pattern(&decl.id, source, removals);
-                if let Some(ref init) = decl.init {
-                    collect_ts_removals_from_expression(init, source, removals);
-                }
+                collect_ts_removals_from_declarator(decl, source, removals);
             }
         }
         Statement::ReturnStatement(ret) => {
@@ -1496,13 +1499,7 @@ fn collect_ts_removals_from_statement(
                 && let ForStatementInit::VariableDeclaration(vd) = init
             {
                 for decl in &vd.declarations {
-                    if let Some(ref type_ann) = decl.type_annotation {
-                        removals.push((type_ann.span.start, type_ann.span.end));
-                    }
-                    collect_ts_removals_from_binding_pattern(&decl.id, source, removals);
-                    if let Some(ref i) = decl.init {
-                        collect_ts_removals_from_expression(i, source, removals);
-                    }
+                    collect_ts_removals_from_declarator(decl, source, removals);
                 }
             }
             if let Some(ref test) = for_stmt.test {
@@ -1524,13 +1521,7 @@ fn collect_ts_removals_from_statement(
         Statement::ForOfStatement(for_of) => {
             if let ForStatementLeft::VariableDeclaration(vd) = &for_of.left {
                 for decl in &vd.declarations {
-                    if let Some(ref type_ann) = decl.type_annotation {
-                        removals.push((type_ann.span.start, type_ann.span.end));
-                    }
-                    collect_ts_removals_from_binding_pattern(&decl.id, source, removals);
-                    if let Some(ref init) = decl.init {
-                        collect_ts_removals_from_expression(init, source, removals);
-                    }
+                    collect_ts_removals_from_declarator(decl, source, removals);
                 }
             }
             collect_ts_removals_from_expression(&for_of.right, source, removals);
@@ -1539,13 +1530,7 @@ fn collect_ts_removals_from_statement(
         Statement::ForInStatement(for_in) => {
             if let ForStatementLeft::VariableDeclaration(vd) = &for_in.left {
                 for decl in &vd.declarations {
-                    if let Some(ref type_ann) = decl.type_annotation {
-                        removals.push((type_ann.span.start, type_ann.span.end));
-                    }
-                    collect_ts_removals_from_binding_pattern(&decl.id, source, removals);
-                    if let Some(ref init) = decl.init {
-                        collect_ts_removals_from_expression(init, source, removals);
-                    }
+                    collect_ts_removals_from_declarator(decl, source, removals);
                 }
             }
             collect_ts_removals_from_expression(&for_in.right, source, removals);
@@ -1710,15 +1695,7 @@ fn collect_ts_removals_from_statement(
                                 removals.push((export_decl.span.start, export_decl.span.end));
                             } else {
                                 for decl in &var_decl.declarations {
-                                    if let Some(ref type_ann) = decl.type_annotation {
-                                        removals.push((type_ann.span.start, type_ann.span.end));
-                                    }
-                                    collect_ts_removals_from_binding_pattern(
-                                        &decl.id, source, removals,
-                                    );
-                                    if let Some(ref init) = decl.init {
-                                        collect_ts_removals_from_expression(init, source, removals);
-                                    }
+                                    collect_ts_removals_from_declarator(decl, source, removals);
                                 }
                             }
                         }
@@ -1794,6 +1771,51 @@ fn collect_ts_removals_from_statement(
             removals.push((decl.span.start, decl.span.end));
         }
         _ => {}
+    }
+}
+
+/// Extend a type-annotation removal backwards over a definite-assignment `!`
+/// (`let x!: T`, `class A { x!: T }`). The official compiler deletes the
+/// `definite` flag from the AST, so the marker must not survive into the JS.
+///
+/// `type_ann_start` is the start of the annotation removal, so the pushed range
+/// is contiguous with it and merges into a single splice.
+fn collect_definite_marker_removal(
+    type_ann_start: u32,
+    source: &str,
+    removals: &mut Vec<(u32, u32)>,
+) {
+    let bytes = source.as_bytes();
+    let mut bang = type_ann_start as usize;
+    while bang > 0 && bytes[bang - 1].is_ascii_whitespace() {
+        bang -= 1;
+    }
+    if bang == 0 || bytes[bang - 1] != b'!' {
+        return;
+    }
+    let mut start = bang - 1;
+    while start > 0 && bytes[start - 1].is_ascii_whitespace() {
+        start -= 1;
+    }
+    removals.push((start as u32, type_ann_start));
+}
+
+/// Collect TS removals from a single variable declarator: the type annotation,
+/// the definite-assignment `!`, then the pattern and the initializer.
+fn collect_ts_removals_from_declarator(
+    decl: &oxc_ast::ast::VariableDeclarator,
+    source: &str,
+    removals: &mut Vec<(u32, u32)>,
+) {
+    if let Some(ref type_ann) = decl.type_annotation {
+        if decl.definite {
+            collect_definite_marker_removal(type_ann.span.start, source, removals);
+        }
+        removals.push((type_ann.span.start, type_ann.span.end));
+    }
+    collect_ts_removals_from_binding_pattern(&decl.id, source, removals);
+    if let Some(ref init) = decl.init {
+        collect_ts_removals_from_expression(init, source, removals);
     }
 }
 
@@ -2936,6 +2958,26 @@ let {
                     "Unexpected content between `}}` and `= $props()`: {l:?}\nFull output: {stripped:?}"
                 );
             }
+        }
+    }
+
+    /// A definite-assignment assertion must strip to exactly what the same
+    /// declaration without the `!` strips to — leaving it behind emits
+    /// invalid JS (`let element!;`).
+    #[test]
+    fn definite_assignment_assertion_is_stripped() {
+        for (ts, expected) in [
+            ("let element!: HTMLDivElement;\n", "let element;\n"),
+            ("let element !: HTMLDivElement;\n", "let element;\n"),
+            ("let a!: number, b = 2;\n", "let a, b = 2;\n"),
+            (
+                "for (const x of []) {\n\tlet a!: number;\n}\n",
+                "for (const x of []) {\n\tlet a;\n}\n",
+            ),
+            ("export let a!: number;\n", "export let a;\n"),
+            ("class Foo {\n\tx!: string;\n}\n", "class Foo {\n\tx;\n}\n"),
+        ] {
+            assert_eq!(strip_typescript(ts), expected, "input: {ts:?}");
         }
     }
 }

--- a/crates/rsvelte_core/tests/ts_definite_assignment_strip.rs
+++ b/crates/rsvelte_core/tests/ts_definite_assignment_strip.rs
@@ -1,0 +1,68 @@
+//! Regression test: TS definite-assignment assertions must be erased (issue #1980).
+//!
+//! Bug: `let element!: HTMLDivElement;` had its annotation removed but kept the
+//! `!`, emitting the invalid `let element!;`. That also hid the declarator from
+//! the legacy reactive-`let` rewrite, so the `$.mutable_source()` initializer
+//! upstream emits went missing.
+
+use rsvelte_core::{CompileOptions, GenerateMode, compile, compiler::CssMode};
+
+fn compile_ts(src: &str, generate: GenerateMode) -> String {
+    compile(
+        src,
+        CompileOptions {
+            filename: Some("DefiniteAssign.svelte".to_string()),
+            generate,
+            dev: false,
+            css: CssMode::External,
+            ..Default::default()
+        },
+    )
+    .expect("compile")
+    .js
+    .code
+}
+
+const BIND_THIS: &str = "<script lang=\"ts\">\n\tlet element!: HTMLDivElement;\n</script>\n\n<div bind:this={element}></div>\n";
+
+#[test]
+fn legacy_bind_this_declares_mutable_source() {
+    let out = compile_ts(BIND_THIS, GenerateMode::Client);
+    assert!(!out.contains("element!"), "leftover `!` in:\n{out}");
+    assert!(
+        out.contains("let element = $.mutable_source();"),
+        "expected the legacy `$.mutable_source()` initializer, got:\n{out}"
+    );
+}
+
+#[test]
+fn server_keeps_the_declaration() {
+    let out = compile_ts(BIND_THIS, GenerateMode::Server);
+    assert!(!out.contains("element!"), "leftover `!` in:\n{out}");
+    assert!(
+        out.contains("let element;"),
+        "expected `let element;` to survive, got:\n{out}"
+    );
+}
+
+#[test]
+fn runes_mode_declaration_is_plain() {
+    let src = "<script lang=\"ts\">\n\tlet element!: HTMLDivElement;\n\t$effect(() => console.log(element));\n</script>\n\n<div bind:this={element}></div>\n";
+    let out = compile_ts(src, GenerateMode::Client);
+    assert!(!out.contains("element!"), "leftover `!` in:\n{out}");
+    // Runes mode leaves the binding alone — no `$.mutable_source()` wrapper.
+    assert!(
+        out.contains("let element;"),
+        "expected a plain `let element;`, got:\n{out}"
+    );
+}
+
+#[test]
+fn class_field_definite_assertion_is_stripped() {
+    let src = "<script lang=\"ts\">\n\tclass Foo {\n\t\tx!: string;\n\t}\n\tconsole.log(new Foo());\n</script>\n";
+    for generate in [GenerateMode::Client, GenerateMode::Server] {
+        let out = compile_ts(src, generate);
+        assert!(!out.contains("x!"), "leftover `!` in:\n{out}");
+        assert!(out.contains("class Foo {"), "class dropped:\n{out}");
+    }
+}


### PR DESCRIPTION
Fixes #1980

## Root cause

The TypeScript erasure pass (`crates/rsvelte_core/src/compiler/phases/2_analyze/types.rs`,
`collect_ts_removals_*`) works by collecting source ranges to splice out. For a variable
declarator it removed only `decl.type_annotation`'s span — it never looked at
`decl.definite`, the flag OXC sets for the `!` in `let x!: T`. So the `!` survived:

```js
let element!;   // invalid JS — Rolldown/esbuild abort re-parsing this
```

The official compiler erases TS from the AST and explicitly `delete n.definite`
(`phases/1-parse/remove_typescript_nodes.js`), so the marker can never leak.

The missing `$.mutable_source()` is a **downstream symptom of the same bug**, not a
second defect: the legacy reactive-`let` rewrite is text-based and matches
`let <name>;` / `let <name> =`. `let element!;` matches neither, so the declarator was
passed through verbatim. On the server the leftover `!` made the statement unparseable
and the declaration was dropped entirely. Once the `!` is stripped, the text is
byte-identical to the already-correct `let element: HTMLDivElement;` case and both
outputs match upstream.

`class A { x!: T }` had the same hole (`PropertyDefinition::definite`), emitting `x!;`.

## Changes

- New `collect_definite_marker_removal`: extends the annotation removal backwards over
  the `!` (and any whitespace before it), so it merges into a single contiguous splice
  and `let x!: T` / `let x !: T` both strip to exactly `let x`.
- New `collect_ts_removals_from_declarator`, replacing the five copies of the
  declarator-erasure loop (statement / `for` / `for…of` / `for…in` / `export`), so the
  fix applies uniformly instead of five times.
- Same handling for `PropertyDefinition::definite` (class fields).
- The "don't re-emit comments from inline type annotations" guard now looks past a
  leading `!` before testing for the `:` sigil, since the two removals are now spliced
  together.

## Verification

Desk-checked against the official compiler (svelte 5.56.8) for client **and** server:

| input | before | after (= official) |
|---|---|---|
| `let element!: HTMLDivElement` + `bind:this` (legacy, client) | `let element!;` | `let element = $.mutable_source();` |
| same, server | declaration dropped | `let element;` |
| runes mode | `let element!;` | `let element;` |
| `class Foo { x!: string }` | `x!;` | `x;` |

Tests added:
- `crates/rsvelte_core/tests/ts_definite_assignment_strip.rs` — compiles the issue's
  repro and asserts no leftover `!` plus the legacy `$.mutable_source()` initializer,
  for client/server/runes/class-field.
- A `strip_typescript` unit test covering `let`, spaced `!`, multi-declarator, `for…of`
  body, `export let`, and class fields.

Not fixed here (same family, filed separately): class members still leak the TS
`?` optional marker and the `override` modifier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015vkYyTLdbG88CbZ7cjDC34