### PR TITLE
fix(compiler): mirror clean_nodes whitespace chaining in static templates

### DIFF
--- a/.changeset/fix-adjacent-comment-whitespace.md
+++ b/.changeset/fix-adjacent-comment-whitespace.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/compiler": patch
+---
+
+Fix whitespace collapsing around removed HTML comments inside nested static elements so the client template matches the official compiler

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/fragment.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/fragment.rs
@@ -10,7 +10,9 @@ use crate::compiler::phases::phase3_transform::client::types::*;
 use crate::compiler::phases::phase3_transform::client::visitors::shared::utils::build_template_chunk;
 use crate::compiler::phases::phase3_transform::js_ast::builders as b;
 use crate::compiler::phases::phase3_transform::js_ast::nodes::*;
-use crate::compiler::phases::phase3_transform::utils::is_svelte_whitespace_only;
+use crate::compiler::phases::phase3_transform::utils::{
+    is_svelte_whitespace_only, replace_leading_whitespace, replace_trailing_whitespace,
+};
 use std::borrow::Cow;
 
 /// NON_STATIC_PROPERTIES - properties that cannot be set statically
@@ -790,61 +792,14 @@ fn push_static_element_to_template_inner(
                     .map(|i| i + 1)
                     .unwrap_or(0);
 
-                let raw_range = &children[start..end.max(start)];
-                // Pre-pass: when comments are being removed, merge consecutive text
-                // nodes that are only separated by removed comments. This avoids
-                // double-spacing where each side independently collapses to a single
-                // space.
-                let merged_range: Vec<TemplateNode> = if preserve_comments {
-                    raw_range.to_vec()
-                } else {
-                    let mut out: Vec<TemplateNode> = Vec::with_capacity(raw_range.len());
-                    let mut pending_text: Option<crate::ast::template::Text> = None;
-                    for child in raw_range.iter() {
-                        match child {
-                            TemplateNode::Comment(_) => {
-                                // Skip — but keep pending_text alive so the next text
-                                // will merge with it.
-                            }
-                            TemplateNode::Text(t) => {
-                                if let Some(prev) = pending_text.take() {
-                                    // Merge: combine prev.data + t.data (and raw)
-                                    let mut merged = prev.clone();
-                                    let mut new_data = prev.data.to_string();
-                                    new_data.push_str(&t.data);
-                                    merged.data = Cow::Owned(new_data);
-                                    let mut new_raw = prev.raw.to_string();
-                                    new_raw.push_str(&t.raw);
-                                    merged.raw = Cow::Owned(new_raw);
-                                    pending_text = Some(merged);
-                                } else {
-                                    pending_text = Some(t.clone());
-                                }
-                            }
-                            other => {
-                                if let Some(t) = pending_text.take() {
-                                    out.push(TemplateNode::Text(t));
-                                }
-                                out.push(other.clone());
-                            }
-                        }
-                    }
-                    if let Some(t) = pending_text.take() {
-                        out.push(TemplateNode::Text(t));
-                    }
-                    out
-                };
-                let range: &[TemplateNode] = &merged_range;
-                // Collect non-comment children indices for boundary trimming
-                let meaningful_indices: Vec<usize> = range
-                    .iter()
-                    .enumerate()
-                    .filter(|(_, c)| preserve_comments || !matches!(c, TemplateNode::Comment(_)))
-                    .map(|(i, _)| i)
-                    .collect();
+                let range = &children[start..end.max(start)];
+                let last_idx = range.len().saturating_sub(1);
 
-                let first_meaningful = meaningful_indices.first().copied();
-                let last_meaningful = meaningful_indices.last().copied();
+                // 写经 `clean_nodes` (utils.js:223-251): each text node's leading run is
+                // dropped only when the *preceding* node's already-rewritten data still
+                // ends in whitespace. A text emptied that way stays in the chain with no
+                // trailing whitespace, so the next one contributes its own single space.
+                let mut prev_ends_with_whitespace = false;
 
                 for (i, child) in range.iter().enumerate() {
                     if !preserve_comments && matches!(child, TemplateNode::Comment(_)) {
@@ -853,68 +808,31 @@ fn push_static_element_to_template_inner(
                     // Trim/collapse whitespace from text nodes to match clean_nodes behavior
                     if let TemplateNode::Text(text) = child {
                         let ws = |c: char| c == ' ' || c == '\t' || c == '\n' || c == '\r';
-                        let mut data = text.data.to_string();
-                        let mut raw = text.raw.to_string();
-                        if Some(i) == first_meaningful {
-                            // First text: trim leading whitespace entirely
-                            let trimmed = data.trim_start_matches(ws);
-                            if trimmed.len() < data.len() {
-                                let start = data.len() - trimmed.len();
-                                data.drain(..start);
-                            }
-                            let trimmed = raw.trim_start_matches(ws);
-                            if trimmed.len() < raw.len() {
-                                let start = raw.len() - trimmed.len();
-                                raw.drain(..start);
-                            }
-                        } else {
-                            // Non-first text: collapse leading whitespace to single space
-                            let trimmed_data = data.trim_start_matches(ws);
-                            if trimmed_data.len() < data.len() && !trimmed_data.is_empty() {
-                                let start = data.len() - trimmed_data.len();
-                                data.drain(..start);
-                                data.insert(0, ' ');
-                            } else if trimmed_data.is_empty() && !data.is_empty() {
-                                data.clear();
-                                data.push(' ');
-                            }
-                            let trimmed_raw = raw.trim_start_matches(ws);
-                            if trimmed_raw.len() < raw.len() && !trimmed_raw.is_empty() {
-                                let start = raw.len() - trimmed_raw.len();
-                                raw.drain(..start);
-                                raw.insert(0, ' ');
-                            } else if trimmed_raw.is_empty() && !raw.is_empty() {
-                                raw.clear();
-                                raw.push(' ');
-                            }
+                        let mut data: &str = &text.data;
+                        let mut raw: &str = &text.raw;
+
+                        // `regular[0]` / `regular.at(-1)` lose their outer whitespace runs
+                        if i == 0 {
+                            data = data.trim_start_matches(ws);
+                            raw = raw.trim_start_matches(ws);
                         }
-                        if Some(i) == last_meaningful {
-                            // Last text: trim trailing whitespace entirely
-                            let trimmed = data.trim_end_matches(ws);
-                            data.truncate(trimmed.len());
-                            let trimmed = raw.trim_end_matches(ws);
-                            raw.truncate(trimmed.len());
-                        } else {
-                            // Non-last text: collapse trailing whitespace to single space
-                            let trimmed_data = data.trim_end_matches(ws);
-                            if trimmed_data.len() < data.len() && !trimmed_data.is_empty() {
-                                let new_len = trimmed_data.len();
-                                data.truncate(new_len);
-                                data.push(' ');
-                            } else if trimmed_data.is_empty() && !data.is_empty() {
-                                data.clear();
-                                data.push(' ');
-                            }
-                            let trimmed_raw = raw.trim_end_matches(ws);
-                            if trimmed_raw.len() < raw.len() && !trimmed_raw.is_empty() {
-                                let new_len = trimmed_raw.len();
-                                raw.truncate(new_len);
-                                raw.push(' ');
-                            } else if trimmed_raw.is_empty() && !raw.is_empty() {
-                                raw.clear();
-                                raw.push(' ');
-                            }
+                        if i == last_idx {
+                            data = data.trim_end_matches(ws);
+                            raw = raw.trim_end_matches(ws);
                         }
+
+                        let leading = if prev_ends_with_whitespace { "" } else { " " };
+                        let data = replace_trailing_whitespace(
+                            &replace_leading_whitespace(data, leading),
+                            " ",
+                        );
+                        let raw = replace_trailing_whitespace(
+                            &replace_leading_whitespace(raw, leading),
+                            " ",
+                        );
+
+                        prev_ends_with_whitespace = data.ends_with(ws);
+
                         // Skip whitespace-only text that would collapse to just space
                         // in SVG namespace (can_remove_entirely logic)
                         if !data.is_empty()
@@ -945,6 +863,7 @@ fn push_static_element_to_template_inner(
                             );
                         }
                     } else {
+                        prev_ends_with_whitespace = false;
                         push_static_element_to_template_inner(
                             child,
                             template,

--- a/crates/rsvelte_core/tests/comment_whitespace_run_1975.rs
+++ b/crates/rsvelte_core/tests/comment_whitespace_run_1975.rs
@@ -1,0 +1,138 @@
+//! Regression tests for issue #1975 — the whitespace run around two adjacent
+//! removed HTML comments collapsed to one space (`</header> <button`) instead of
+//! the two the official compiler emits (`</header>  <button`), but only when the
+//! comments' parent element was itself nested.
+//!
+//! Root cause: the client static-template builder
+//! (`push_static_element_to_template_inner`) re-implemented `clean_nodes`'
+//! whitespace rules with a "merge text nodes separated by removed comments"
+//! pre-pass plus positional first/last trimming. Upstream instead keeps every
+//! text node in the list and decides each node's leading run from the *previous*
+//! node's already-rewritten data: the middle text is emptied (its prev ends with
+//! whitespace) but stays in the chain, so the following text no longer sees a
+//! whitespace-ending prev and contributes its own space. Nesting mattered because
+//! only a nested element goes through the static builder; the fragment's root
+//! element is emitted by the regular-element visitor, which uses the shared
+//! `clean_nodes` and was already correct.
+
+use rsvelte_core::{CompileOptions, GenerateMode, compile, compiler::CssMode};
+
+fn template(src: &str, preserve_comments: bool) -> String {
+    compile(
+        src,
+        CompileOptions {
+            filename: Some("T.svelte".to_string()),
+            generate: GenerateMode::Client,
+            dev: false,
+            css: CssMode::External,
+            runes: Some(true),
+            preserve_comments,
+            ..Default::default()
+        },
+    )
+    .expect("compile")
+    .js
+    .code
+}
+
+fn assert_template(src: &str, expected: &str) {
+    let out = template(src, false);
+    assert!(
+        out.contains(expected),
+        "expected template to contain:\n{expected}\ngot:\n{out}"
+    );
+}
+
+/// `<outer><div>…</div></outer>`: the `<div>` is emitted by the static-template
+/// builder. Upstream keeps two spaces.
+#[test]
+fn two_adjacent_comments_keep_two_spaces_when_nested() {
+    let src = "<outer>\n\t<div>\n\t\t<header>h</header>\n\t\t<!-- a -->\n\t\t<!-- b -->\n\t\t<button>b</button>\n\t</div>\n</outer>\n";
+    assert_template(
+        src,
+        "<outer><div><header>h</header>  <button>b</button></div></outer>",
+    );
+    let out = template(src, false);
+    assert!(
+        !out.contains("</header> <button>"),
+        "the run must not collapse to a single space, got:\n{out}"
+    );
+}
+
+/// Control: the same markup with `<div>` as the fragment's root element already
+/// matched upstream (it goes through the regular-element visitor).
+#[test]
+fn two_adjacent_comments_keep_two_spaces_at_root() {
+    assert_template(
+        "<div>\n\t<header>h</header>\n\t<!-- a -->\n\t<!-- b -->\n\t<button>b</button>\n</div>\n",
+        "<div><header>h</header>  <button>b</button></div>",
+    );
+}
+
+/// One comment leaves two text nodes: the second is emptied, so a single space
+/// survives.
+#[test]
+fn single_comment_collapses_to_one_space_when_nested() {
+    assert_template(
+        "<outer>\n\t<div>\n\t\t<header>h</header>\n\t\t<!-- a -->\n\t\t<button>b</button>\n\t</div>\n</outer>\n",
+        "<outer><div><header>h</header> <button>b</button></div></outer>",
+    );
+}
+
+/// Three comments leave four text nodes, alternating space / empty — still two
+/// spaces, not three.
+#[test]
+fn three_adjacent_comments_keep_two_spaces_when_nested() {
+    let src = "<outer>\n\t<div>\n\t\t<header>h</header>\n\t\t<!-- a -->\n\t\t<!-- b -->\n\t\t<!-- c -->\n\t\t<button>b</button>\n\t</div>\n</outer>\n";
+    assert_template(
+        src,
+        "<outer><div><header>h</header>  <button>b</button></div></outer>",
+    );
+    let out = template(src, false);
+    assert!(
+        !out.contains("</header>   <button>"),
+        "the run must not grow to three spaces, got:\n{out}"
+    );
+}
+
+/// Text on both sides of a removed comment: the merge pre-pass used to fuse the
+/// two text nodes and keep their raw indentation verbatim.
+#[test]
+fn text_around_single_comment_collapses_to_one_space() {
+    assert_template(
+        "<outer>\n\t<div>\n\t\ttext\n\t\t<!-- a -->\n\t\tmore\n\t</div>\n</outer>\n",
+        "<outer><div>text more</div></outer>",
+    );
+}
+
+#[test]
+fn text_around_two_comments_keeps_two_spaces() {
+    assert_template(
+        "<outer>\n\t<div>\n\t\ttext\n\t\t<!-- a -->\n\t\t<!-- b -->\n\t\tmore\n\t</div>\n</outer>\n",
+        "<outer><div>text  more</div></outer>",
+    );
+}
+
+#[test]
+fn inline_text_and_comments_collapse_to_one_space() {
+    assert_template(
+        "<outer>\n\t<div>\n\t\tx<!-- a -->  <!-- b -->  y\n\t</div>\n</outer>\n",
+        "<outer><div>x y</div></outer>",
+    );
+}
+
+/// With `preserveComments`, the comments stay in the list as non-text nodes, so
+/// every whitespace run keeps exactly one space.
+#[test]
+fn preserved_comments_keep_single_spaces() {
+    let out = template(
+        "<outer>\n\t<div>\n\t\t<header>h</header>\n\t\t<!-- a -->\n\t\t<!-- b -->\n\t\t<button>b</button>\n\t</div>\n</outer>\n",
+        true,
+    );
+    assert!(
+        out.contains(
+            "<outer><div><header>h</header> <!-- a --> <!-- b --> <button>b</button></div></outer>"
+        ),
+        "got:\n{out}"
+    );
+}


### PR DESCRIPTION
Fixes #1975

## Root cause

The whitespace run around removed HTML comments only diverged when the comments' parent element was **nested**, because nesting selects a different code path:

- The fragment's **root** element is emitted by the regular-element visitor, which uses the shared `clean_nodes` / `trim_whitespace` in `phases/3_transform/utils.rs` — already faithful to upstream.
- A **nested** static element is inlined into the template string by `push_static_element_to_template_inner` (`3_transform/client/visitors/shared/fragment.rs`), which carried its **own** re-implementation of the `clean_nodes` whitespace rules.

That re-implementation was structurally different from upstream (`3-transform/utils.js:223-251`):

1. a pre-pass that **merged consecutive text nodes separated by removed comments** into one node, and
2. positional `first_meaningful` / `last_meaningful` trimming instead of upstream's `prev`-driven state machine.

Upstream never merges. It walks `regular` (comments already dropped) and rewrites each text node **in place**, choosing the leading replacement from whether the *previous* node's already-rewritten `data` still ends with whitespace:

```js
const prev_is_text_ending_with_whitespace =
    prev?.type === 'Text' && regex_ends_with_whitespaces.test(prev.data);
node.data = node.data.replace(regex_starts_with_whitespaces, prev_is_text_ending_with_whitespace ? '' : ' ');
...
node.data = node.data.replace(regex_ends_with_whitespaces, ' ');
if (node.data && ...) trimmed.push(node);
```

For `</header> <!--a--> <!--b--> <button>` the three surviving text nodes resolve to `" "`, `""`, `" "`: the middle one is emptied (its prev ends with whitespace) but **stays in the chain** with no trailing whitespace, so the third text no longer sees a whitespace-ending prev and contributes its own space. Hence `</header>  <button` (two spaces). The merge pre-pass fused all three into one node, yielding a single space.

The same pre-pass was also wrong whenever real text surrounded a comment — it kept the raw source indentation verbatim (`text\n\t\t\n\t\tmore` instead of `text more`).

## Fix

`push_static_element_to_template_inner` now mirrors upstream's algorithm directly: no merge pre-pass, boundary trimming applied to the range's first/last node, and a `prev_ends_with_whitespace` carry that skips over removed comments and resets on non-text nodes. `replace_leading_whitespace` / `replace_trailing_whitespace` from `3_transform/utils.rs` are reused so the two implementations share the same primitives. Net −81 lines.

## Verification (desk-checked against `svelte/compiler` v5.56.8)

Every case below was compiled with the official compiler and hand-traced through the new code; the previous behaviour was confirmed with the current build.

| case (parent nested unless noted) | official | before | after |
|---|---|---|---|
| 1 comment between elements | `</header> <button>` | ✅ | ✅ |
| **2 adjacent comments** | `</header>  <button>` | ❌ 1 space | ✅ |
| 3 adjacent comments | `</header>  <button>` | ❌ 1 space | ✅ |
| 2 adjacent comments, parent = root element | `</header>  <button>` | ✅ | ✅ |
| `text <!--a--> more` | `text more` | ❌ `text\n\t\t\n\t\tmore` | ✅ |
| `text <!--a--> <!--b--> more` | `text  more` | ❌ raw indentation | ✅ |
| `x<!--a-->  <!--b-->  y` | `x y` | ❌ `x    y` | ✅ |
| `preserveComments: true` | `</header> <!-- a --> <!-- b --> <button>` | ✅ | ✅ |

All eight are pinned as a regression test in `crates/rsvelte_core/tests/comment_whitespace_run_1975.rs`.

## Notes

- `compatibility/known-failures.client.json` on `main` is empty; the C3 seed lives on the unmerged `chore/1924-skeleton-corpus` branch (#1964) and can be dropped there once this lands.
- Out of scope, found while investigating: the same static builder's `can_remove_entirely` check drops whitespace-only text inside an SVG `<text>` element, where upstream keeps it (`parent.name !== 'text'` exception). Reproduces at root **and** nested, so it is a separate divergence — filed as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015vkYyTLdbG88CbZ7cjDC34
