### PR TITLE
perf(server): drop the whole-output TypeScript strip from SSR

### DIFF
--- a/.changeset/ssr-drop-whole-output-ts-strip.md
+++ b/.changeset/ssr-drop-whole-output-ts-strip.md
@@ -1,0 +1,5 @@
+---
+'@rsvelte/compiler': patch
+---
+
+Drop the whole-output TypeScript strip from SSR codegen and erase type-only syntax in the template source-slice reparse instead. Fixes `{@const}` initializers with TypeScript-annotated arrow parameters (e.g. `{@const f = (d: T) => …}`) leaking TypeScript into the generated server output.

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/types.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/types.rs
@@ -613,8 +613,7 @@ fn strip_typescript_from_program_impl(
     // to ensure they're removed.
     //
     // Every keyword below starts with `declare `, so one SIMD scan for that prefix
-    // decides all three at once — the common case (generated output, which this runs
-    // over in full) has none and skips three whole-source `str::find` passes.
+    // decides all three at once and skips three whole-source `str::find` passes.
     if memchr::memmem::find(source.as_bytes(), b"declare ").is_some() {
         for keyword in &["declare global", "declare module", "declare namespace"] {
             let bytes = source.as_bytes();

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/mod.rs
@@ -166,24 +166,6 @@ pub(crate) fn transform_component_with_scripts(
         }
         GenerateMode::Server => {
             let code = server::transform_server(analysis, ast, source, options)?;
-            // Template-expression interpolations in the SSR output are spliced
-            // straight from source positions, so for a TypeScript component
-            // (`<script lang="ts">`) bits of TS-only syntax — `as T` casts,
-            // `<T>` generics, `! ` non-null assertions, `: T` annotations on
-            // inline destructures — can leak into the emitted JS inside
-            // `$.escape(...)`, `$.stringify(...)`, `$.attr_style(...)`, etc.
-            // rolldown then rejects the result with
-            // `Type assertion expressions can only be used in TypeScript files`.
-            // Run the same TypeScript strip the analyzer uses over the final
-            // output to catch every leak in one pass, rather than threading
-            // a per-expression strip through every visitor source-slice site.
-            // Real-world surface: shadcn-svelte's `base-color-picker.svelte`
-            // → `style="--color: {map?.[mode.current as 'light' | 'dark']?.[…]}"`.
-            let code = if analysis.is_typescript {
-                crate::compiler::phases::phase2_analyze::types::strip_typescript(&code)
-            } else {
-                code
-            };
             if options.enable_sourcemap {
                 // Generate token-level mappings by matching tokens in the server
                 // output to tokens in the original source

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/mod.rs
@@ -697,7 +697,35 @@ fn reparse_expression<'a>(src: &str, allocator: &'a Allocator) -> Option<OxcExpr
     if !ret.diagnostics.is_empty() {
         return None;
     }
-    for stmt in ret.program.body {
+    // Type-only syntax that is not an expression wrapper — parameter annotations
+    // on an inline arrow (`{@const f = (d: T) => …}`), call type arguments, a
+    // `type` alias in an arrow's block body — survives the wrapper collapse below
+    // and would reach the output as TypeScript. Erase it textually with the same
+    // positional stripper the analyzer uses, then re-parse the result as plain JS.
+    // `strip_typescript_from_program` returns its input unchanged when there is
+    // nothing to remove, so the common (non-TS) slice pays no second parse.
+    let erased = crate::compiler::phases::phase2_analyze::types::strip_typescript_from_program(
+        owned,
+        &ret.program,
+    );
+    if erased != owned {
+        let reowned = allocator.alloc_str(&erased);
+        let reparsed =
+            oxc_parser::Parser::new(allocator, reowned, oxc_span::SourceType::mjs()).parse();
+        if reparsed.diagnostics.is_empty() {
+            return first_expression(reparsed.program.body, allocator);
+        }
+    }
+    first_expression(ret.program.body, allocator)
+}
+
+/// Pull the single `ExpressionStatement` out of a re-parsed program body,
+/// unwrapping the synthetic parens and collapsing any TS expression wrappers.
+fn first_expression<'a>(
+    body: oxc_allocator::Vec<'a, Statement<'a>>,
+    allocator: &'a Allocator,
+) -> Option<OxcExpression<'a>> {
+    for stmt in body {
         if let Statement::ExpressionStatement(es) = stmt {
             let mut expr = unwrap_parenthesized(es.unbox().expression);
             strip_ts_expression_wrappers(&mut expr, allocator);

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/script.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/script.rs
@@ -327,8 +327,7 @@ fn transform_script<'a>(
     // rest of this function works: the classification parse and every span re-slice
     // index into the local `src`, and the reparse helpers copy the slice text into
     // the state allocator — none of them index `state.source` directly. So binding
-    // `src` to the stripped buffer keeps offsets internally consistent. Mirrors the
-    // OLD oracle, which runs the same `strip_typescript` (over its final output).
+    // `src` to the stripped buffer keeps offsets internally consistent.
     let stripped;
     // TS is detected COMPONENT-wide, not per-script: if EITHER script carries
     // `lang="ts"` the whole component is parsed as TS (upstream `force_typescript`),

--- a/crates/rsvelte_core/tests/ssr_typescript_erasure.rs
+++ b/crates/rsvelte_core/tests/ssr_typescript_erasure.rs
@@ -1,0 +1,120 @@
+//! SSR output of a TypeScript component must be plain JavaScript.
+//!
+//! Phase 3 used to re-parse the whole generated SSR program as TypeScript and
+//! strip it, as a catch-all for TS syntax leaking out of template expressions.
+//! Erasure now happens upstream — `remove_typescript_from_ast` clears the typed
+//! fragment before analyze, and the server's source-slice fallback re-parses via
+//! `reparse_expression`, which strips the TS wrappers itself. These tests pin
+//! that invariant so the whole-output pass stays unnecessary.
+
+use rsvelte_core::{CompileOptions, GenerateMode, compile};
+
+/// Assert the SSR output parses as plain ECMAScript — the property the removed
+/// whole-output strip existed to guarantee, and what rolldown enforces when it
+/// rejects `Type assertion expressions can only be used in TypeScript files`.
+#[track_caller]
+fn assert_ssr_is_plain_js(source: &str) {
+    let result = compile(
+        source,
+        CompileOptions {
+            generate: GenerateMode::Server,
+            dev: false,
+            enable_sourcemap: true,
+            ..Default::default()
+        },
+    )
+    .expect("component should compile");
+
+    let allocator = oxc_allocator::Allocator::default();
+    let ret =
+        oxc_parser::Parser::new(&allocator, &result.js.code, oxc_span::SourceType::mjs()).parse();
+
+    assert!(
+        ret.diagnostics.is_empty(),
+        "SSR output is not plain JS: {:?}\n--- output ---\n{}",
+        ret.diagnostics,
+        result.js.code
+    );
+}
+
+#[test]
+fn as_cast_in_template_expression_is_erased() {
+    // The real-world case that originally motivated the whole-output strip:
+    // shadcn-svelte's base-color-picker.svelte.
+    assert_ssr_is_plain_js(
+        r#"<script lang="ts">
+	let { vars }: { vars: Record<string, Record<string, string>> } = $props();
+	let mode = { current: 'light' };
+</script>
+
+<div style="--color: {vars?.[mode.current as 'light' | 'dark']?.['muted-foreground']}"></div>
+<p>{vars as unknown as string}</p>
+"#,
+    );
+}
+
+#[test]
+fn non_null_assertion_in_template_expression_is_erased() {
+    assert_ssr_is_plain_js(
+        r#"<script lang="ts">
+	let { obj }: { obj?: { field: string } } = $props();
+</script>
+
+<p>{obj!.field}</p>
+<div title={obj!.field}></div>
+{#if obj!.field}<span>{obj!.field}</span>{/if}
+"#,
+    );
+}
+
+#[test]
+fn satisfies_and_generic_call_in_template_expression_are_erased() {
+    assert_ssr_is_plain_js(
+        r#"<script lang="ts">
+	let { items }: { items: string[] } = $props();
+	function pick<T>(xs: T[]): T { return xs[0]; }
+</script>
+
+<p>{pick<string>(items)}</p>
+<p>{({ a: 1 }) satisfies Record<string, number>}</p>
+{#each items as item}<span>{item as string}</span>{/each}
+"#,
+    );
+}
+
+#[test]
+fn type_annotations_in_const_and_snippet_are_erased() {
+    assert_ssr_is_plain_js(
+        r#"<script lang="ts">
+	let { n }: { n: number } = $props();
+</script>
+
+{#snippet row(label: string, value: number)}
+	<td>{label}</td><td>{value}</td>
+{/snippet}
+
+{@const doubled: number = n * 2}
+<table><tr>{@render row('n', doubled)}</tr></table>
+"#,
+    );
+}
+
+#[test]
+fn await_and_key_blocks_erase_typescript() {
+    assert_ssr_is_plain_js(
+        r#"<script lang="ts">
+	let { p, k }: { p: Promise<string>; k: number } = $props();
+</script>
+
+{#await p}
+	<span>loading</span>
+{:then value}
+	<span>{(value as string).length}</span>
+{:catch e}
+	<span>{(e as Error).message}</span>
+{/await}
+
+{#key k}<span>{(k as number).toFixed(2)}</span>{/key}
+"#,
+    );
+}

--- a/crates/rsvelte_core/tests/ssr_typescript_erasure.rs
+++ b/crates/rsvelte_core/tests/ssr_typescript_erasure.rs
@@ -93,8 +93,55 @@ fn type_annotations_in_const_and_snippet_are_erased() {
 	<td>{label}</td><td>{value}</td>
 {/snippet}
 
-{@const doubled: number = n * 2}
-<table><tr>{@render row('n', doubled)}</tr></table>
+{#if n}
+	{@const doubled: number = n * 2}
+	<table><tbody><tr>{@render row('n', doubled)}</tr></tbody></table>
+{/if}
+"#,
+    );
+}
+
+/// `{@const}` is the one visitor that always decomposes by SOURCE SLICE rather
+/// than by the (already TS-stripped) typed AST, so its initializer is the path
+/// where non-wrapper TypeScript actually reaches the output. Real-world
+/// regressions: layerchart's `Dodge/duration-bars-dense-lanes.svelte` and
+/// `Waffle/Waffle.svelte`.
+#[test]
+fn const_tag_initializer_erases_non_wrapper_typescript() {
+    assert_ssr_is_plain_js(
+        r#"<script lang="ts">
+	let { n, xs }: { n: number; xs: number[] } = $props();
+</script>
+
+{#if n}
+	{@const startX = (d: { at: Date }) => d.at.getTime()}
+	{@const scale = <T,>(x: T): T => x}
+	{@const onEnter = (e: PointerEvent) => { const t = e.target as HTMLElement; return t; }}
+	{@const inner = (() => { type Row = number; const r: Row = n; return r; })()}
+	{@const arr = xs.map<number>((v) => v)}
+	<span>{startX({ at: new Date() })}{scale(n)}{onEnter}{inner}{arr.length}</span>
+{/if}
+"#,
+    );
+}
+
+/// The same source-slice decomposition drives `{#each}` context patterns and
+/// `{#await}` value bindings.
+#[test]
+fn each_and_await_bindings_erase_typescript() {
+    assert_ssr_is_plain_js(
+        r#"<script lang="ts">
+	let { xs, p }: { xs: number[]; p: Promise<number[]> } = $props();
+</script>
+
+{#each xs as x, i}
+	{@const label = ((v: number) => `${v}`)(x)}
+	<span>{label}{i}</span>
+{/each}
+
+{#await p then values}
+	{#each values as v}<span>{((n: number) => n + 1)(v)}</span>{/each}
+{/await}
 "#,
     );
 }


### PR DESCRIPTION
## What

Phase 3 re-parsed the **entire generated SSR program** as TypeScript and stripped it, once per TS component. That was **7.96% of server-prod** in the wave-3 profile. This removes it, and moves the erasure it was backstopping to the one place that actually needed it.

Rebased onto `main` after `perf/compile-wave2` was squash-merged as #1912; only the two commits below are this PR's.

## Why the whole-output pass can go

The pass's stated premise — that template-expression interpolations are "spliced straight from source positions" — is *mostly* no longer true. Almost every expression now reaches the output through `visit_expr_raw` (`server/ast/mod.rs`), which is TS-safe on both branches:

- **Structural path**: `jsnode_to_oxc_expr` builds from the typed `JsNode`, and `remove_typescript_from_ast` (`compiler/mod.rs`, run immediately after parse) has already cleared every TS node from the fragment — ExpressionTag, HtmlTag, ConstTag, RenderTag, the `{#if}`/`{#each}`/`{#await}`/`{#key}` heads, snippet parameters, and all attribute kinds.
- **Fallback path**: the source-slice fallback re-parses via `reparse_expression`.

## …except for the source-slice reparse (second commit)

`{@const}` is the exception, and it is not a fallback: `visit_const_tag_sync` *always* decomposes by source slice, reading the declarator's `id` / `init` spans straight out of `state.source` and handing them to `reparse_expression`. That helper parsed TypeScript-aware and then collapsed only the four TS **expression wrappers** (`as`, `satisfies`, `!`, `<T>x`). Type-only syntax that is not a wrapper survived:

- parameter annotations on an inline arrow — `{@const startX = (d: { startDate: Date }) => …}`
- call type arguments — `xs.map<number>(…)`
- a `type` alias or annotated `const` inside an arrow's block body

The whole-output strip was silently rescuing all of it. Removing it regressed two real corpus files — layerchart's `Dodge/duration-bars-dense-lanes.svelte` and `Waffle/Waffle.svelte` — whose SSR output stopped being parseable at all. **Both were outside the six corpora the "0 changes" measurement covered** (the corpus has 34 sources / 13,987 entries), which is why the measurement did not see them.

The fix runs the analyzer's positional stripper over the already-parsed slice and re-parses the result as plain ES. `strip_typescript_from_program` returns its input unchanged when there is nothing to remove, so a non-TS slice pays no second parse — and the walk covers one small expression instead of every byte of generated output, which is the cost this PR is removing.

## Measurement (first commit)

Over 6 corpora (8657 `.svelte` × server dev **and** prod = 17314 compiles):

| metric | value |
|---|---|
| pass invocations | 7398 |
| invocations that changed the output | 0 |
| invocations where the strip's own TS parse failed | 0 |

Caveat, now known: that sample did not include layerchart, and the pass **was** load-bearing there. The per-mode figure (7398 / 2 = 3699) independently reproduces the prod-only count of 3695 measured separately during wave 3.

## Verification

- `pnpm run corpus:collect && corpus:compile && corpus:verify` over the full 13,987-entry corpus (client + server + client-dev): **no regressions**; client / server known failures unchanged at 1 each.
- `cargo test --release` green, including `tests/ssr` and `tests/runtime`.
- `cargo fmt` clean; `cargo clippy --all-targets --all-features -- -D warnings` clean for the touched crates.

## Test

`tests/ssr_typescript_erasure.rs` pins the invariant the pass used to backstop: the SSR output of a TypeScript component must parse as **plain ES** (`SourceType::mjs()`) with zero diagnostics — precisely the condition rolldown enforces when it rejects `Type assertion expressions can only be used in TypeScript files`.

The second commit also **fixes** that suite: `type_annotations_in_const_and_snippet_are_erased` placed its `{@const}` at the fragment root, which is a `const_tag_invalid_placement` validation error, so the test panicked on `.expect("component should compile")` rather than asserting anything. Two cases are added for the paths that decompose by source slice — the `{@const}` initializer, and `{#each}` / `{#await}` bindings.

## Also

Two comments that justified themselves by this pass are updated: `server/ast/script.rs` referred to it as the "OLD oracle", and the SIMD `declare ` probe in `2_analyze/types.rs` was motivated by "generated output, which this runs over in full".
