### PR TITLE
fix(compiler): destructured $derived defaults containing a colon emit invalid JS

### DIFF
--- a/.changeset/fix-derived-destructure-ternary.md
+++ b/.changeset/fix-derived-destructure-ternary.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/compiler": patch
+---
+
+Fix invalid client output for destructured `$derived` properties whose default value contains a colon (ternary, string literal)

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/destructure_transforms.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/destructure_transforms.rs
@@ -1,6 +1,10 @@
 //! Destructuring assignment transformations and IIFE generation.
 
 use super::SCRIPT_ARRAY_COUNTER;
+use oxc_allocator::Allocator;
+use oxc_ast::ast::{Expression, Statement};
+use oxc_parser::{ParseOptions, Parser};
+use oxc_span::SourceType;
 
 pub(super) fn unthunk_string(expr: &str) -> String {
     let trimmed = expr.trim();
@@ -1121,46 +1125,61 @@ pub(super) fn skip_expression(bytes: &[u8], start: usize) -> usize {
 
 /// Check if a string expression is a "simple" expression that doesn't need thunk wrapping.
 ///
-/// Simple expressions: identifiers, literals (numbers, strings, booleans),
-/// arrow functions, function expressions. Does NOT include call expressions,
-/// member expressions, etc.
+/// The string is re-parsed so the answer comes from the expression's real shape —
+/// a purely textual test cannot tell `q ? 1 : 2` (simple) from `q ? a.b : c` (not).
 pub(super) fn string_is_simple_expression(s: &str) -> bool {
     let trimmed = s.trim();
     if trimmed.is_empty() {
         return false;
     }
 
-    // Identifiers: purely alphanumeric + _ + $
-    if trimmed
-        .chars()
-        .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '$')
-    {
-        return true;
+    let allocator = Allocator::default();
+    // Parenthesised so a leading `{` parses as an object literal, not a block.
+    let wrapped = format!("({})", trimmed);
+    let ret = Parser::new(
+        &allocator,
+        &wrapped,
+        SourceType::mjs().with_typescript(true),
+    )
+    .with_options(ParseOptions {
+        preserve_parens: false,
+        ..ParseOptions::default()
+    })
+    .parse();
+    if !ret.diagnostics.is_empty() || ret.program.body.len() != 1 {
+        return false;
     }
-
-    // Numeric literals
-    if trimmed.parse::<f64>().is_ok() {
-        return true;
+    match ret.program.body.first() {
+        Some(Statement::ExpressionStatement(stmt)) => expression_is_simple(&stmt.expression),
+        _ => false,
     }
+}
 
-    // String literals
-    if (trimmed.starts_with('\'') && trimmed.ends_with('\''))
-        || (trimmed.starts_with('"') && trimmed.ends_with('"'))
-    {
-        return true;
+/// Faithful port of the official compiler's `is_simple_expression()` from `utils/ast.js`.
+fn expression_is_simple(expr: &Expression<'_>) -> bool {
+    match expr {
+        Expression::BooleanLiteral(_)
+        | Expression::NullLiteral(_)
+        | Expression::NumericLiteral(_)
+        | Expression::BigIntLiteral(_)
+        | Expression::RegExpLiteral(_)
+        | Expression::StringLiteral(_)
+        | Expression::Identifier(_)
+        | Expression::ArrowFunctionExpression(_)
+        | Expression::FunctionExpression(_) => true,
+        Expression::ConditionalExpression(e) => {
+            expression_is_simple(&e.test)
+                && expression_is_simple(&e.consequent)
+                && expression_is_simple(&e.alternate)
+        }
+        Expression::BinaryExpression(e) => {
+            expression_is_simple(&e.left) && expression_is_simple(&e.right)
+        }
+        Expression::LogicalExpression(e) => {
+            expression_is_simple(&e.left) && expression_is_simple(&e.right)
+        }
+        _ => false,
     }
-
-    // Boolean/null literals
-    if trimmed == "true" || trimmed == "false" || trimmed == "null" || trimmed == "undefined" {
-        return true;
-    }
-
-    // Arrow functions and function expressions
-    if trimmed.starts_with("() =>") || trimmed.starts_with("function") {
-        return true;
-    }
-
-    false
 }
 
 /// Build a `$.fallback(expression, default)` string, applying async thunk wrapping

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/rune_transforms.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/rune_transforms.rs
@@ -970,6 +970,10 @@ pub(super) fn process_nested_pattern_elements(
                     declarations,
                     _array_counter,
                 )?;
+            } else if let Some(eq_pos) = find_default_equals(element) {
+                let name = element[..eq_pos].trim();
+                let fallback = build_fallback_string(&element_access, element[eq_pos + 1..].trim());
+                declarations.push(format!("{} = $.derived(() => {})", name, fallback));
             } else {
                 declarations.push(format!("{} = $.derived(() => {})", element, element_access));
             }
@@ -988,8 +992,10 @@ pub(super) fn process_nested_pattern_elements(
                 }
                 let key = if let Some(colon_pos) = find_derived_property_colon(prop) {
                     prop[..colon_pos].trim()
+                } else if let Some(eq_pos) = find_default_equals(prop) {
+                    prop[..eq_pos].trim()
                 } else {
-                    prop.trim()
+                    prop
                 };
                 if key.starts_with('[') {
                     None
@@ -1044,6 +1050,11 @@ pub(super) fn process_nested_pattern_elements(
                         ));
                     }
                 }
+            } else if let Some(eq_pos) = find_default_equals(prop) {
+                let name = prop[..eq_pos].trim();
+                let member_access = format!("{}.{}", base_expr, name);
+                let fallback = build_fallback_string(&member_access, prop[eq_pos + 1..].trim());
+                declarations.push(format!("{} = $.derived(() => {})", name, fallback));
             } else {
                 declarations.push(format!(
                     "{} = $.derived(() => {}.{})",
@@ -1169,6 +1180,10 @@ pub(super) fn process_derived_array_pattern(
                 declarations,
                 &mut nested_counter,
             )?;
+        } else if let Some(eq_pos) = find_default_equals(element) {
+            let name = element[..eq_pos].trim();
+            let fallback = build_fallback_string(&element_access, element[eq_pos + 1..].trim());
+            declarations.push(format!("{} = $.derived(() => {})", name, fallback));
         } else {
             declarations.push(format!("{} = $.derived(() => {})", element, element_access));
         }
@@ -1231,40 +1246,61 @@ pub(super) fn split_derived_array_elements(inner: &str) -> Vec<String> {
 }
 
 pub(super) fn find_derived_property_colon(prop: &str) -> Option<usize> {
-    let mut depth = 0;
-    for (i, c) in prop.char_indices() {
-        match c {
-            '{' | '[' | '(' => depth += 1,
-            '}' | ']' | ')' => depth -= 1,
-            ':' if depth == 0 => return Some(i),
-            _ => {}
-        }
-    }
-    None
+    scan_property_separators(prop).0
 }
 
 /// Find the position of `=` in a shorthand destructuring property with a default value.
 /// e.g., `animated = false` → Some(9), `animated` → None
 /// Respects nesting so `data = { x: 1 }` finds the top-level `=`.
 pub(super) fn find_default_equals(prop: &str) -> Option<usize> {
-    let mut depth = 0;
+    scan_property_separators(prop).1
+}
+
+/// Byte offsets of a destructuring property's key separator `:` and default-value
+/// `=`, skipping nested patterns, string/template literals and comments.
+///
+/// A property is always `key: value = default`, so the key separator can only
+/// precede the default `=` — scanning the whole property would otherwise mistake a
+/// `:` from the default (a ternary, a string literal) for the key separator.
+fn scan_property_separators(prop: &str) -> (Option<usize>, Option<usize>) {
     let bytes = prop.as_bytes();
+    let mut depth = 0i32;
+    let mut colon = None;
     let mut i = 0;
     while i < bytes.len() {
         match bytes[i] {
+            b'/' if bytes.get(i + 1) == Some(&b'/') => {
+                while i < bytes.len() && bytes[i] != b'\n' {
+                    i += 1;
+                }
+            }
+            b'/' if bytes.get(i + 1) == Some(&b'*') => {
+                i += 2;
+                while i < bytes.len() && !(bytes[i] == b'*' && bytes.get(i + 1) == Some(&b'/')) {
+                    i += 1;
+                }
+                i += 1;
+            }
+            quote @ (b'\'' | b'"' | b'`') => {
+                i += 1;
+                while i < bytes.len() && bytes[i] != quote {
+                    i += if bytes[i] == b'\\' { 2 } else { 1 };
+                }
+            }
             b'{' | b'[' | b'(' => depth += 1,
             b'}' | b']' | b')' => depth -= 1,
+            b':' if depth == 0 && colon.is_none() => colon = Some(i),
             b'=' if depth == 0 => {
-                // Make sure it's not `==` or `=>`
-                if i + 1 < bytes.len() && (bytes[i + 1] == b'=' || bytes[i + 1] == b'>') {
-                    i += 2;
-                    continue;
+                let prev = if i > 0 { bytes[i - 1] } else { 0 };
+                let is_operator = matches!(bytes.get(i + 1), Some(b'=' | b'>'))
+                    || matches!(prev, b'!' | b'<' | b'>' | b'=');
+                if !is_operator {
+                    return (colon, Some(i));
                 }
-                return Some(i);
             }
             _ => {}
         }
         i += 1;
     }
-    None
+    (colon, None)
 }

--- a/crates/rsvelte_core/tests/derived_destructure_ternary_default_1973.rs
+++ b/crates/rsvelte_core/tests/derived_destructure_ternary_default_1973.rs
@@ -1,0 +1,143 @@
+//! Regression test for `let { b = q ? 1 : 2 } = $derived(props)`
+//! (baseballyama/rsvelte#1973).
+//!
+//! The property splitter cut each destructured property at the *first* `:`, so a
+//! ternary default value (or a string literal containing a colon) was mistaken for
+//! a `key: value` rename and the else-branch became the declaration id — emitting
+//! `2 = $.derived(() => $$props.b = q ? 1)`, which does not even parse.
+//!
+//! Expected outputs below were taken from the official Svelte compiler.
+
+use rsvelte_core::{CompileOptions, GenerateMode, compile};
+
+fn compile_client(src: &str) -> String {
+    let result = compile(
+        src,
+        CompileOptions {
+            filename: Some("Test.svelte".to_string()),
+            generate: GenerateMode::Client,
+            dev: false,
+            ..Default::default()
+        },
+    )
+    .expect("compile");
+    result.js.code
+}
+
+#[test]
+fn shorthand_ternary_default() {
+    let out = compile_client(
+        r#"<script>
+	let props = $props();
+	let q = true;
+	let { a, b = q ? 1 : 2 } = $derived(props);
+</script>
+<p>{a}{b}</p>"#,
+    );
+    assert!(
+        out.contains("b = $.derived(() => $.fallback($$props.b, q ? 1 : 2))"),
+        "expected the ternary to stay the fallback default. Got:\n{out}"
+    );
+    assert!(
+        !out.contains("$$props.b = q ? 1"),
+        "the ternary's `:` was still read as the key separator:\n{out}"
+    );
+}
+
+#[test]
+fn renamed_property_ternary_default() {
+    let out = compile_client(
+        r#"<script>
+	let props = $props();
+	let q = true;
+	let { a, b: bb = q ? 1 : 2 } = $derived(props);
+</script>
+<p>{a}{bb}</p>"#,
+    );
+    assert!(
+        out.contains("bb = $.derived(() => $.fallback($$props.b, q ? 1 : 2))"),
+        "expected `bb` to read `b` with the ternary fallback. Got:\n{out}"
+    );
+}
+
+#[test]
+fn nested_pattern_ternary_default() {
+    let out = compile_client(
+        r#"<script>
+	let props = $props();
+	let q = true;
+	let { a, n: { b = q ? 1 : 2 } } = $derived(props);
+</script>
+<p>{a}{b}</p>"#,
+    );
+    assert!(
+        out.contains("b = $.derived(() => $.fallback($$props.n.b, q ? 1 : 2))"),
+        "expected the nested shorthand default to become a fallback. Got:\n{out}"
+    );
+}
+
+#[test]
+fn derived_by_ternary_default() {
+    let out = compile_client(
+        r#"<script>
+	let props = $props();
+	let q = true;
+	let { a, b = q ? 1 : 2 } = $derived.by(() => props);
+</script>
+<p>{a}{b}</p>"#,
+    );
+    assert!(
+        out.contains("b = $.derived(() => $.fallback($.get($$d).b, q ? 1 : 2))"),
+        "expected the `$derived.by` destructure to read through `$$d`. Got:\n{out}"
+    );
+}
+
+#[test]
+fn string_default_containing_colon() {
+    let out = compile_client(
+        r#"<script>
+	let props = $props();
+	let { a, b = 'x:y' } = $derived(props);
+</script>
+<p>{a}{b}</p>"#,
+    );
+    assert!(
+        out.contains("b = $.derived(() => $.fallback($$props.b, 'x:y'))"),
+        "a `:` inside a string default must not split the property. Got:\n{out}"
+    );
+}
+
+#[test]
+fn array_element_ternary_default() {
+    let out = compile_client(
+        r#"<script>
+	let props = $props();
+	let q = true;
+	let [a, b = q ? 1 : 2] = $derived(props);
+</script>
+<p>{a}{b}</p>"#,
+    );
+    assert!(
+        out.contains("b = $.derived(() => $.fallback($.get($$array)[1], q ? 1 : 2))"),
+        "expected the array element default to become a fallback. Got:\n{out}"
+    );
+}
+
+#[test]
+fn non_simple_ternary_default_is_thunked() {
+    // `is_simple_expression` recurses into a ternary's operands, so a member
+    // access in a branch forces the lazy `() => …, true` fallback form.
+    let out = compile_client(
+        r#"<script>
+	let props = $props();
+	let q = true;
+	let o = {};
+	let { a, b = q ? o.x : 2 } = $derived(props);
+</script>
+<p>{a}{b}</p>"#,
+    );
+    assert!(
+        out.contains("b = $.derived(() => $.fallback($$props.b, () => q ? o.x : 2, true))"),
+        "expected the non-simple ternary to be thunked. Got:\n{out}"
+    );
+}


### PR DESCRIPTION
Fixes #1973

## Root cause

`find_derived_property_colon` scanned a destructured property for the **first**
top-level `:` and treated it as the `key: value` separator. For a property whose
*default value* contains a colon — a ternary (`b = q ? 1 : 2`) or a string
literal (`b = 'x:y'`) — that colon is not a key separator, so the property was
split in the middle of the default and the else-branch became the declaration id:

```js
// rsvelte (does not parse)
2 = $.derived(() => $$props.b = q ? 1);
// official
b = $.derived(() => $.fallback($$props.b, q ? 1 : 2));
```

Two secondary defects surfaced while validating the fixed output against the
official compiler:

- `string_is_simple_expression` was a textual heuristic, so once the ternary
  reached `build_fallback_string` it took the lazy `() => …, true` form. Upstream
  `is_simple_expression` recurses into conditional / binary / logical operands, so
  `q ? 1 : 2` is *simple* and must be passed to `$.fallback` directly (while
  `q ? o.x : 2` is not, and stays thunked).
- `process_nested_pattern_elements` (object + array branches) and
  `process_derived_array_pattern` had no shorthand-default handling at all, so
  `{ n: { b = 5 } }` and `[a, b = 5]` emitted the same unparseable
  `b = 5 = $.derived(…)` shape, and the nested `$.exclude_from_object` key list
  contained `"b = 5"` instead of `"b"`.

## Fix

Structural, not a `find(':')` → `rfind(':')` patch:

- `find_derived_property_colon` / `find_default_equals` now share one
  `scan_property_separators` that skips nested patterns, string/template literals
  and comments, and **stops the key-separator search at the default-value `=`**.
  A destructuring property is always `key: value = default`, so a top-level `:`
  after the `=` can only belong to the default.
- `string_is_simple_expression` re-parses the default value with oxc and runs a
  faithful port of upstream's `is_simple_expression` from `utils/ast.js`.
- The two shorthand-default gaps above now mirror
  `process_derived_object_pattern`.

## Verified against the official compiler

| source | output (both) |
| --- | --- |
| `{ a, b = q ? 1 : 2 }` | `b = $.derived(() => $.fallback($$props.b, q ? 1 : 2))` |
| `{ a, b: bb = q ? 1 : 2 }` | `bb = $.derived(() => $.fallback($$props.b, q ? 1 : 2))` |
| `{ a, n: { b = q ? 1 : 2 } }` | `b = $.derived(() => $.fallback($$props.n.b, q ? 1 : 2))` |
| `$derived.by`, ternary default | `b = $.derived(() => $.fallback($.get($$d).b, q ? 1 : 2))` |
| `{ a, b = 'x:y' }` | `b = $.derived(() => $.fallback($$props.b, 'x:y'))` |
| `{ a, b = q ? o.x : 2 }` | `b = $.derived(() => $.fallback($$props.b, () => q ? o.x : 2, true))` |

The `is_simple_expression` port also closes existing divergences on the
destructure-assignment path (`({ y: b = q ? 1 : 2 } = o)`) and on `-1` / `this` /
`/re/g` / `a + b` defaults, all of which rsvelte previously wrapped (or failed to
wrap) differently from upstream. SSR output was already correct and is untouched.

Regression test: `crates/rsvelte_core/tests/derived_destructure_ternary_default_1973.rs`.

## Known remaining divergences (not in scope, filed as follow-ups)

- #2001 — computed / quoted keys emit `obj.[k]` and `obj.'weird-name'` (invalid); official emits `obj[k]` / `obj['weird-name']`, and computed keys are also missing from `$.exclude_from_object`
- #2002 — client codegen drops defaults in destructured `$state(...)` (SSR is correct)
- #2004 — `$.to_array($$props, n)` vs official `$.to_array(props, n)` when array-destructuring a rest-prop binding
- #2005 — `build_fallback_string` does not unthunk `() => f()` → `f` the way `b.thunk` does

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015vkYyTLdbG88CbZ7cjDC34

