### PR TITLE
Reuse borrowed svelte2tsx generics attributes

### DIFF
--- a/.changeset/reuse-svelte2tsx-generics.md
+++ b/.changeset/reuse-svelte2tsx-generics.md
@@ -1,0 +1,8 @@
+---
+"@rsvelte/compiler": patch
+"@rsvelte/svelte2tsx": patch
+"@rsvelte/svelte-check": patch
+---
+
+Reduce generic component projection overhead by borrowing and reusing the
+instance script generics attribute.

--- a/crates/rsvelte_projection/src/svelte2tsx/nodes/generics.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/nodes/generics.rs
@@ -175,7 +175,7 @@ fn extract_param_name(param: &str) -> String {
 }
 
 /// Extract the `generics` attribute value from a script tag text.
-pub(crate) fn extract_generics_from_script_tag(tag_text: &str) -> Option<String> {
+pub(crate) fn extract_generics_from_script_tag(tag_text: &str) -> Option<&str> {
     if let Some(pos) = tag_text.find("generics=") {
         let after = &tag_text[pos + 9..];
         let trimmed = after.trim_start();
@@ -183,7 +183,7 @@ pub(crate) fn extract_generics_from_script_tag(tag_text: &str) -> Option<String>
             if quote_char == '"' || quote_char == '\'' {
                 let content = &trimmed[1..];
                 if let Some(end) = content.find(quote_char) {
-                    return Some(content[..end].to_string());
+                    return Some(&content[..end]);
                 }
             } else {
                 // Unquoted value: take until whitespace or `>`
@@ -191,7 +191,7 @@ pub(crate) fn extract_generics_from_script_tag(tag_text: &str) -> Option<String>
                     .find(|c: char| c.is_whitespace() || c == '>')
                     .unwrap_or(trimmed.len());
                 if end > 0 {
-                    return Some(trimmed[..end].to_string());
+                    return Some(&trimmed[..end]);
                 }
             }
         }
@@ -207,6 +207,27 @@ mod tests {
 
     fn set(names: &[&str]) -> HashSet<String> {
         names.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn extracts_borrowed_quoted_generics() {
+        assert_eq!(
+            extract_generics_from_script_tag(r#"<script lang="ts" generics="T extends string">"#),
+            Some("T extends string")
+        );
+        assert_eq!(
+            extract_generics_from_script_tag("<script generics='T, U'>"),
+            Some("T, U")
+        );
+    }
+
+    #[test]
+    fn distinguishes_empty_and_absent_generics() {
+        assert_eq!(
+            extract_generics_from_script_tag(r#"<script generics="">"#),
+            Some("")
+        );
+        assert_eq!(extract_generics_from_script_tag("<script>"), None);
     }
 
     #[test]

--- a/crates/rsvelte_projection/src/svelte2tsx/process_instance_script_tag.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/process_instance_script_tag.rs
@@ -7,8 +7,7 @@ use crate::ast::template::Root;
 use super::interfaces::{Svelte2TsxMode, Svelte2TsxOptions};
 use super::magic_string::MagicString;
 use super::nodes::generics::{
-    extract_generics_from_script_tag, split_generic_param_names, type_text_references_any,
-    type_text_typeof_references_local_value,
+    split_generic_param_names, type_text_references_any, type_text_typeof_references_local_value,
 };
 use super::nodes::scripts::{detect_top_level_await, find_script_close_tag_start};
 use super::script::ExportedNames;
@@ -30,6 +29,7 @@ pub(crate) fn process_instance_script_tag(
     instance_program: &oxc_ast::ast::Program,
     source: &str,
     options: &Svelte2TsxOptions,
+    generics_param: Option<&str>,
     str: &mut MagicString<'_>,
     exported_names: &mut ExportedNames,
     dollar_decls: &str,
@@ -80,15 +80,11 @@ pub(crate) fn process_instance_script_tag(
     }
     let async_prefix = if has_top_level_await { "async " } else { "" };
 
-    // Detect `generics` attribute on the script tag
-    let script_tag_text = slice_src(source, script_start as usize, content_start as usize);
-    let generics_param = extract_generics_from_script_tag(script_tag_text);
     let use_jsdoc_generics = options.emit_jsdoc && !options.is_ts_file;
     // For JS files emitting JSDoc, the generics live on a `/** @template T */`
     // line *before* `function $$render()`, not as `<T>` on the function.
     let template_comment = if use_jsdoc_generics {
         generics_param
-            .as_ref()
             .filter(|g| !g.is_empty())
             .map(|g| format!("\n/** @template {} */\n", g))
             .unwrap_or_default()
@@ -105,7 +101,6 @@ pub(crate) fn process_instance_script_tag(
         String::new()
     } else {
         generics_param
-            .as_ref()
             .map(|g| {
                 if options.is_ts_file {
                     // TS files: no ignore markers around generics
@@ -157,7 +152,6 @@ pub(crate) fn process_instance_script_tag(
             // Check if type references generics from $$render
             let has_generic_dep = !render_generics.is_empty()
                 && generics_param
-                    .as_ref()
                     .map(|g| {
                         // Extract generic param names and check if any appear in the type
                         split_generic_param_names(g)

--- a/crates/rsvelte_projection/src/svelte2tsx/svelte2tsx.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/svelte2tsx.rs
@@ -545,20 +545,17 @@ pub fn svelte2tsx(
         .and_then(|s| s.to_str())
         .unwrap_or("")
         .to_string();
-    let script_generic_names: std::collections::HashSet<String> = ast
-        .instance
-        .as_ref()
-        .map(|instance| {
-            let tag_text = slice_src(
-                source,
-                instance.start as usize,
-                instance.content_offset as usize,
-            );
-            extract_generics_from_script_tag(tag_text)
-        })
-        .unwrap_or_default()
+    let instance_generics = ast.instance.as_ref().and_then(|instance| {
+        let tag_text = slice_src(
+            source,
+            instance.start as usize,
+            instance.content_offset as usize,
+        );
+        extract_generics_from_script_tag(tag_text)
+    });
+    let script_generic_names: std::collections::HashSet<String> = instance_generics
         .map(|raw| {
-            split_generic_param_names(&raw)
+            split_generic_param_names(raw)
                 .into_iter()
                 .collect::<std::collections::HashSet<String>>()
         })
@@ -750,17 +747,7 @@ pub fn svelte2tsx(
         template_info.dollar_slot_names.as_deref(),
     );
 
-    // Detect generics attribute from the script tag (available for component export)
-    let mut generics_attribute: Option<String> = None;
-    if has_instance_script {
-        let instance = ast.instance.as_ref().unwrap();
-        let script_tag_text = slice_src(
-            source,
-            instance.start as usize,
-            instance.content_offset as usize,
-        );
-        generics_attribute = extract_generics_from_script_tag(script_tag_text);
-    }
+    let generics_attribute = has_instance_script.then_some(instance_generics).flatten();
 
     // Phase 2: Overwrite instance script tags and lift imports. Split into its
     // own module, but it must still run before Phase 3's moves — see the
@@ -775,6 +762,7 @@ pub fn svelte2tsx(
                 .program(),
             source,
             &options,
+            generics_attribute,
             &mut str,
             &mut exported_names,
             &dollar_decls,
@@ -840,7 +828,7 @@ pub fn svelte2tsx(
             template_info: &template_info,
             exported_names: &exported_names,
             events: &mut events,
-            generics_attribute: generics_attribute.as_deref(),
+            generics_attribute,
             has_slot_elements,
             has_top_level_await,
             uses_dollar_props,

--- a/crates/rsvelte_projection/tests/svelte2tsx_generics_reuse.rs
+++ b/crates/rsvelte_projection/tests/svelte2tsx_generics_reuse.rs
@@ -1,0 +1,76 @@
+use rsvelte_projection::svelte2tsx::{Svelte2TsxOptions, svelte2tsx};
+
+fn project(source: &str, is_ts_file: bool, emit_jsdoc: bool) -> String {
+    svelte2tsx(
+        source,
+        Svelte2TsxOptions {
+            filename: "Generic.svelte".into(),
+            is_ts_file,
+            emit_jsdoc,
+            ..Default::default()
+        },
+    )
+    .expect("svelte2tsx")
+    .code
+}
+
+#[test]
+fn quoted_ts_generics_reach_render_export_and_hoist_checks() {
+    for quote in ['"', '\''] {
+        let source = format!(
+            "<script lang=\"ts\" generics={quote}T extends string{quote}>\n\
+             type Local<U> = {{ value: U }};\n\
+             let {{ item }}: {{ item: Local<T> }} = $props();\n\
+             </script>\n<span>{{item.value}}</span>"
+        );
+        let code = project(&source, true, false);
+        let render = code.find("function $$render<T extends string>()").unwrap();
+        let local = code.find("type Local<U>").unwrap();
+
+        assert!(
+            local > render,
+            "generic-dependent type escaped $$render:\n{code}"
+        );
+        assert!(
+            code.contains("class __sveltets_Render<T extends string>"),
+            "component export lost generics:\n{code}"
+        );
+        assert!(
+            code.contains("item: Local<T>"),
+            "generic-dependent prop lost its type:\n{code}"
+        );
+    }
+}
+
+#[test]
+fn jsdoc_generics_emit_template_without_ts_render_syntax() {
+    let code = project(
+        "<script generics='T extends object'>\n/** @type {T} */\nexport let value;\n</script>",
+        false,
+        true,
+    );
+
+    assert!(
+        code.contains("/** @template T extends object */\nfunction $$render()"),
+        "missing JSDoc generic template:\n{code}"
+    );
+    assert!(
+        !code.contains("function $$render<T"),
+        "JSDoc output used TypeScript render generics:\n{code}"
+    );
+}
+
+#[test]
+fn empty_and_absent_generics_keep_their_existing_shapes() {
+    let empty = project(r#"<script lang="ts" generics=""></script>"#, true, false);
+    let absent = project(r#"<script lang="ts"></script>"#, true, false);
+
+    assert!(
+        empty.contains("function $$render<>()"),
+        "empty generics attribute changed meaning:\n{empty}"
+    );
+    assert!(
+        absent.contains("function $$render()") && !absent.contains("function $$render<"),
+        "absent generics attribute changed meaning:\n{absent}"
+    );
+}


### PR DESCRIPTION
## Summary
- borrow the instance script generics attribute instead of allocating its value
- extract it once and reuse it for generic-name collection, render generation, and component export
- preserve the existing malformed-instance-script gate
- add exact coverage for TypeScript, JSDoc, empty, absent, and both quote styles

## Validation
- rustfmt
- git diff --check
- build, tests, compatibility, and performance delegated to CI
- CodSpeed comparison is the performance authority for this PR