### PR TITLE
Speed up case-insensitive svelte2tsx tag scans

### DIFF
--- a/.changeset/fast-svelte2tsx-tag-search.md
+++ b/.changeset/fast-svelte2tsx-tag-search.md
@@ -1,0 +1,8 @@
+---
+"@rsvelte/compiler": patch
+"@rsvelte/svelte2tsx": patch
+"@rsvelte/svelte-check": patch
+---
+
+Reduce svelte2tsx source scanning overhead for common lowercase style and
+script tags.

--- a/crates/rsvelte_projection/src/svelte2tsx/utils/htmlxparser.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/utils/htmlxparser.rs
@@ -26,6 +26,15 @@ fn find_ci(haystack: &[u8], from: usize, needle: &[u8]) -> Option<usize> {
 
     let first_lower = needle[0].to_ascii_lowercase();
     let first_upper = needle[0].to_ascii_uppercase();
+    if needle.len() == 1 {
+        let offset = if first_lower == first_upper {
+            memchr::memchr(first_lower, &haystack[from..])
+        } else {
+            memchr::memchr2(first_lower, first_upper, &haystack[from..])
+        }?;
+        return Some(from + offset);
+    }
+
     let mut search = from;
     while search <= last_start {
         let candidates = &haystack[search..=last_start];
@@ -34,11 +43,12 @@ fn find_ci(haystack: &[u8], from: usize, needle: &[u8]) -> Option<usize> {
         } else {
             memchr::memchr2(first_lower, first_upper, candidates)
         }?;
-        let candidate = search + offset;
-        if haystack[candidate..candidate + needle.len()].eq_ignore_ascii_case(needle) {
-            return Some(candidate);
+        let candidate_start = search + offset;
+        let candidate = &haystack[candidate_start..candidate_start + needle.len()];
+        if candidate == needle || candidate.eq_ignore_ascii_case(needle) {
+            return Some(candidate_start);
         }
-        search = candidate + 1;
+        search += offset + 1;
     }
     None
 }


### PR DESCRIPTION
## Summary
- return directly from one-byte case-insensitive searches such as the style-tag closing delimiter
- accept the common exact lowercase tag match before ASCII case folding
- preserve mixed-case matching and byte offsets

## Validation
- rustfmt
- git diff --check
- existing focused tests cover lowercase, mixed-case, partial candidates, UTF-8 offsets, and start offsets
- build, tests, compatibility, and performance delegated to CI
- CodSpeed comparison is the performance authority for this PR