### PR TITLE
chore(corpus): extract shared target descriptors (pure refactor)

### DIFF
--- a/scripts/compat-corpus/README.md
+++ b/scripts/compat-corpus/README.md
@@ -135,7 +135,17 @@ Pipeline stages (all idempotent, everything under `compatibility/` except
    `compatibility/known-failures.server.json` (SSR) — both checked in, both may
    only shrink. Exits non-zero only on a **regression** (a `(id, target)` pair
    that diverges but is absent from that target's baseline).
-   `--update-baseline` rewrites both files from the current run.
+   `--update-baseline` rewrites every baseline from the current run;
+   `--update-baseline <target>` rewrites only that target's file.
+
+The compared targets (their `generate` / `dev` options, whether CSS is compared,
+and which baseline file they ratchet against) are declared once in
+`targets.mjs`; `compile.mjs` / `verify.mjs` / `one.mjs` / `cluster.mjs` all
+iterate that list, so adding a target is a one-line change plus its baseline.
+
+`verify.mjs --from-report <path>` skips normalization and comparison and derives
+the baselines from an existing `report.json` — e.g. one downloaded from a CI
+run, so a new target's baseline can be bootstrapped without a local full run.
 
 Debugging helpers:
 

--- a/scripts/compat-corpus/cluster.mjs
+++ b/scripts/compat-corpus/cluster.mjs
@@ -10,6 +10,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { stripBlankLines, readIf } from './normalize.mjs';
+import { TARGET_KEYS } from './targets.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '../..');
@@ -62,7 +63,7 @@ for (const f of report.failures) {
 		continue;
 	}
 	let foundReal = false;
-	for (const target of ['client', 'server']) {
+	for (const target of TARGET_KEYS) {
 		const exp = readIf(path.join(CORPUS, 'expected', f.id, `${target}.js`));
 		const act = readIf(path.join(CORPUS, 'actual', f.id, `${target}.js`));
 		if (exp == null || act == null || exp === act) continue;

--- a/scripts/compat-corpus/compile.mjs
+++ b/scripts/compat-corpus/compile.mjs
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
 /**
  * Compile every corpus entry (see collect.mjs) with BOTH the official Svelte
- * compiler (from submodules/svelte) and rsvelte (NAPI binding), for both
- * generate targets (client = CSR, server = SSR), writing the outputs to:
+ * compiler (from submodules/svelte) and rsvelte (NAPI binding), for every
+ * target in targets.mjs (client = CSR, server = SSR), writing the outputs to:
  *
  *   compatibility/expected/<id>/{client.js,server.js,client.css,error.json}
  *   compatibility/actual/<id>/{...same...}
@@ -24,6 +24,7 @@ import os from 'node:os';
 import { spawn } from 'node:child_process';
 import { createRequire } from 'node:module';
 import { fileURLToPath } from 'node:url';
+import { TARGETS, TARGET_KEYS } from './targets.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '../..');
@@ -91,8 +92,8 @@ if (args.includes('--worker')) {
 		return { code, message: message.split('\n')[0] };
 	};
 
-	function compileOne(compiler, kind, source, id, generate) {
-		const options = { generate, dev: false, filename: id };
+	function compileOne(compiler, kind, source, id, target) {
+		const options = { generate: target.generate, dev: target.dev, filename: id };
 		if (kind === 'component') options.css = 'external';
 		try {
 			const result =
@@ -105,19 +106,22 @@ if (args.includes('--worker')) {
 		}
 	}
 
+	function compileAll(compiler, kind, source, id) {
+		return TARGETS.map((target) => [target, compileOne(compiler, kind, source, id, target)]);
+	}
+
 	function writeOutputs(baseDir, id, results) {
 		const dir = path.join(baseDir, id);
 		fs.mkdirSync(dir, { recursive: true });
 		const errors = {};
-		for (const target of ['client', 'server']) {
-			const r = results[target];
+		for (const [target, r] of results) {
 			if (r.error) {
-				errors[target] = r.error;
+				errors[target.key] = r.error;
 				continue;
 			}
-			fs.writeFileSync(path.join(dir, `${target}.js`), r.js);
-			if (target === 'client' && r.css != null) {
-				fs.writeFileSync(path.join(dir, 'client.css'), r.css);
+			fs.writeFileSync(path.join(dir, `${target.key}.js`), r.js);
+			if (target.css && r.css != null) {
+				fs.writeFileSync(path.join(dir, `${target.key}.css`), r.css);
 			}
 		}
 		if (Object.keys(errors).length) {
@@ -129,14 +133,8 @@ if (args.includes('--worker')) {
 		const { id, kind } = manifest[i];
 		console.log(`IDX ${i}`);
 		const source = prepareSource(id, fs.readFileSync(path.join(CORPUS, 'sources', id), 'utf8'));
-		writeOutputs(EXPECTED, id, {
-			client: compileOne(svelte, kind, source, id, 'client'),
-			server: compileOne(svelte, kind, source, id, 'server'),
-		});
-		writeOutputs(ACTUAL, id, {
-			client: compileOne(rsvelte, kind, source, id, 'client'),
-			server: compileOne(rsvelte, kind, source, id, 'server'),
-		});
+		writeOutputs(EXPECTED, id, compileAll(svelte, kind, source, id));
+		writeOutputs(ACTUAL, id, compileAll(rsvelte, kind, source, id));
 	}
 	process.exit(0);
 }
@@ -168,10 +166,8 @@ function recordPanic(i) {
 	const dir = path.join(ACTUAL, id);
 	fs.mkdirSync(dir, { recursive: true });
 	const err = { code: 'rust_panic', message: 'rsvelte compiler panicked (process aborted)' };
-	fs.writeFileSync(
-		path.join(dir, 'error.json'),
-		JSON.stringify({ client: err, server: err }, null, '\t') + '\n'
-	);
+	const errors = Object.fromEntries(TARGET_KEYS.map((key) => [key, err]));
+	fs.writeFileSync(path.join(dir, 'error.json'), JSON.stringify(errors, null, '\t') + '\n');
 }
 
 function runRange(start, end) {

--- a/scripts/compat-corpus/one.mjs
+++ b/scripts/compat-corpus/one.mjs
@@ -21,6 +21,7 @@ import { execFileSync, spawnSync } from 'node:child_process';
 import { createRequire } from 'node:module';
 import { fileURLToPath } from 'node:url';
 import { flattenTemplateHoles, stripBlankLines } from './normalize.mjs';
+import { TARGETS, TARGET_KEYS } from './targets.mjs';
 
 const require = createRequire(import.meta.url);
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -62,8 +63,8 @@ const svelte = await import(
 );
 const rsvelte = require(path.join(ROOT, '.corpus-cache/rsvelte.node'));
 
-function compileOne(compiler, generate) {
-	const options = { generate, dev: false, filename: id };
+function compileOne(compiler, target) {
+	const options = { generate: target.generate, dev: target.dev, filename: id };
 	if (kind === 'component') options.css = 'external';
 	try {
 		const r = kind === 'component' ? compiler.compile(source, options) : compiler.compileModule(source, options);
@@ -93,8 +94,14 @@ function fmt(code, name) {
 	return stripBlankLines(out);
 }
 
-for (const target of targetArg ? [targetArg] : ['client', 'server']) {
-	console.log(`\n========== ${target} ==========`);
+const selected = targetArg ? TARGETS.filter((t) => t.key === targetArg) : TARGETS;
+if (!selected.length) {
+	console.error(`[one] unknown --target "${targetArg}" (known: ${TARGET_KEYS.join(', ')})`);
+	process.exit(2);
+}
+
+for (const target of selected) {
+	console.log(`\n========== ${target.key} ==========`);
 	const e = compileOne(svelte, target);
 	const a = compileOne(rsvelte, target);
 	if (e.error || a.error) {
@@ -104,7 +111,8 @@ for (const target of targetArg ? [targetArg] : ['client', 'server']) {
 	}
 	const ef = fmt(e.js, 'e');
 	const af = fmt(a.js, 'a');
-	if (ef === af && (e.css ?? '') === (a.css ?? '')) {
+	const cssDiffers = target.css && (e.css ?? '') !== (a.css ?? '');
+	if (ef === af && !cssDiffers) {
 		console.log('MATCH');
 		continue;
 	}
@@ -118,7 +126,7 @@ for (const target of targetArg ? [targetArg] : ['client', 'server']) {
 		fs.unlinkSync(tmpE);
 		fs.unlinkSync(tmpA);
 	}
-	if ((e.css ?? '') !== (a.css ?? '')) {
+	if (cssDiffers) {
 		console.log('--- css expected\n' + e.css + '\n--- css actual\n' + a.css);
 	}
 }

--- a/scripts/compat-corpus/targets.mjs
+++ b/scripts/compat-corpus/targets.mjs
@@ -1,0 +1,19 @@
+/**
+ * The compile targets the output-equality corpus compares, shared by
+ * compile.mjs / verify.mjs / one.mjs / cluster.mjs so a target is added in one
+ * place instead of four hardcoded `['client', 'server']` lists.
+ *
+ * Each descriptor drives:
+ *   - key       output basename (`<key>.js`, `<key>.css`) and the target label
+ *               used in report.json details / error.json keys
+ *   - generate  the `generate` compile option
+ *   - dev       the `dev` compile option
+ *   - css       whether CSS output is compared for this target
+ *   - baseline  the ratchet file (relative to compatibility/) for this target
+ */
+export const TARGETS = [
+	{ key: 'client', generate: 'client', dev: false, css: true, baseline: 'known-failures.client.json' },
+	{ key: 'server', generate: 'server', dev: false, css: false, baseline: 'known-failures.server.json' },
+];
+
+export const TARGET_KEYS = TARGETS.map((t) => t.key);

--- a/scripts/compat-corpus/verify.mjs
+++ b/scripts/compat-corpus/verify.mjs
@@ -13,8 +13,8 @@
  *
  * Writes compatibility/report.json.
  *
- * Ratchet baselines (checked in), one per target so CSR and SSR are tracked
- * independently:
+ * Ratchet baselines (checked in), one per target (see targets.mjs) so CSR and
+ * SSR are tracked independently:
  *   - compatibility/known-failures.client.json  (CSR / client target)
  *   - compatibility/known-failures.server.json  (SSR / server target)
  * Each lists the entry ids whose output diverges for that target. Verification
@@ -22,10 +22,14 @@
  * regression) — known failures are tolerated and burned down over time (see
  * compatibility/known-failures.md for the root-cause writeup of each entry).
  * When previously-known failures now pass, a reminder to shrink the relevant
- * baseline is printed (use --update-baseline to rewrite both files from
- * current results).
+ * baseline is printed (use --update-baseline to rewrite the files from current
+ * results; `--update-baseline <target>` rewrites only that target's file).
  *
- * Usage: node scripts/compat-corpus/verify.mjs [--no-fmt] [--max-print <n>] [--update-baseline] [--strict]
+ * --from-report <path> skips normalization/comparison entirely and derives the
+ * baselines from an existing report.json (e.g. downloaded from a CI run), so a
+ * new target's baseline can be bootstrapped without a local full run.
+ *
+ * Usage: node scripts/compat-corpus/verify.mjs [--no-fmt] [--max-print <n>] [--update-baseline [<target>]] [--from-report <path>] [--strict]
  */
 
 import fs from 'node:fs';
@@ -33,6 +37,7 @@ import path from 'node:path';
 import { execFileSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 import { flattenTemplateHoles, stripBlankLines, astEquivalent, readIf, firstDiffLine } from './normalize.mjs';
+import { TARGETS, TARGET_KEYS } from './targets.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '../..');
@@ -45,15 +50,65 @@ const NO_FMT = args.includes('--no-fmt');
 const MAX_PRINT = Number(args[args.indexOf('--max-print') + 1] || 20);
 const UPDATE_BASELINE = args.includes('--update-baseline');
 const STRICT = args.includes('--strict'); // ignore the baseline: any failure fails
+
+// `--update-baseline <target>` limits the rewrite to one target; bare
+// `--update-baseline` rewrites every target's baseline (the historical
+// behaviour).
+const UPDATE_SCOPE = (() => {
+	const next = args[args.indexOf('--update-baseline') + 1];
+	if (!UPDATE_BASELINE || !next || next.startsWith('--')) return null;
+	if (!TARGET_KEYS.includes(next)) {
+		console.error(`[verify] unknown --update-baseline target "${next}" (known: ${TARGET_KEYS.join(', ')})`);
+		process.exit(2);
+	}
+	return next;
+})();
+
+const FROM_REPORT = (() => {
+	const i = args.indexOf('--from-report');
+	return i !== -1 && args[i + 1] ? path.resolve(process.cwd(), args[i + 1]) : null;
+})();
+
 // --baseline-client <path> / --baseline-server <path> select alternate ratchet
-// files (defaults: known-failures.{client,server}.json). The corpus is a single
-// unified set, so these are rarely needed — kept for ad-hoc scoped runs.
-function baselineArg(flag, fallback) {
-	const i = args.indexOf(flag);
-	return path.resolve(CORPUS, i !== -1 ? args[i + 1] : fallback);
+// files (defaults come from targets.mjs). The corpus is a single unified set,
+// so these are rarely needed — kept for ad-hoc scoped runs.
+function baselinePath(target) {
+	const i = args.indexOf(`--baseline-${target.key}`);
+	return path.resolve(CORPUS, i !== -1 ? args[i + 1] : target.baseline);
 }
-const BASELINE_CLIENT = baselineArg('--baseline-client', 'known-failures.client.json');
-const BASELINE_SERVER = baselineArg('--baseline-server', 'known-failures.server.json');
+
+// Partition failures by target so every target ratchets independently. Every
+// failure detail carries a target (css mismatches are client-only), so an entry
+// that diverges on two targets lands in both sets.
+function partitionFailures(failures) {
+	const byTarget = new Map(TARGET_KEYS.map((key) => [key, new Set()]));
+	for (const f of failures) {
+		for (const d of f.details) {
+			const set = byTarget.get(d.target);
+			if (set) set.add(f.id);
+			else console.warn(`[verify] ignoring failure detail for unknown target "${d.target}" (${f.id})`);
+		}
+	}
+	return byTarget;
+}
+
+function writeBaselines(byTarget) {
+	console.log();
+	for (const target of TARGETS) {
+		if (UPDATE_SCOPE && target.key !== UPDATE_SCOPE) continue;
+		const ids = byTarget.get(target.key);
+		const p = baselinePath(target);
+		fs.writeFileSync(p, JSON.stringify([...ids].sort(), null, '\t') + '\n');
+		console.log(`[verify] baseline updated: ${ids.size} known failures -> ${path.relative(ROOT, p)}`);
+	}
+}
+
+if (FROM_REPORT) {
+	const report = JSON.parse(fs.readFileSync(FROM_REPORT, 'utf8'));
+	console.log(`[verify] deriving baselines from ${path.relative(ROOT, FROM_REPORT)} (${report.failures.length} failures)`);
+	writeBaselines(partitionFailures(report.failures));
+	process.exit(0);
+}
 
 // ---- oxfmt normalization ---------------------------------------------------
 
@@ -114,7 +169,8 @@ for (const { id } of manifest) {
 	let verdict = 'match';
 	const details = [];
 
-	for (const target of ['client', 'server']) {
+	for (const targetDef of TARGETS) {
+		const target = targetDef.key;
 		const e = expErr[target];
 		const a = actErr[target];
 		if (e && a) {
@@ -149,9 +205,9 @@ for (const { id } of manifest) {
 			verdict = 'js-mismatch';
 			details.push({ target, kind: 'js', ...firstDiffLine(expJs, actJs) });
 		}
-		if (target === 'client') {
-			const expCss = readIf(path.join(expDir, 'client.css'));
-			const actCss = readIf(path.join(actDir, 'client.css'));
+		if (targetDef.css) {
+			const expCss = readIf(path.join(expDir, `${target}.css`));
+			const actCss = readIf(path.join(actDir, `${target}.css`));
 			if ((expCss ?? '') !== (actCss ?? '')) {
 				if (verdict === 'match') verdict = 'css-mismatch';
 				details.push({ target, kind: 'css', ...firstDiffLine(expCss ?? '', actCss ?? '') });
@@ -177,47 +233,36 @@ console.log('\n[verify] results:');
 for (const [k, v] of Object.entries(counts)) console.log(`  ${k.padEnd(16)} ${v}`);
 console.log(`  report: ${path.relative(ROOT, path.join(CORPUS, 'report.json'))}`);
 
-// Partition failures by target so CSR (client) and SSR (server) ratchet
-// independently. Every failure detail carries a target (css mismatches are
-// client-only), so an entry that diverges on both targets lands in both sets.
 const failById = new Map(failures.map((f) => [f.id, f]));
-const clientFails = new Set();
-const serverFails = new Set();
-for (const f of failures) {
-	for (const d of f.details) {
-		if (d.target === 'client') clientFails.add(f.id);
-		else if (d.target === 'server') serverFails.add(f.id);
-	}
-}
+const failsByTarget = partitionFailures(failures);
 
 if (UPDATE_BASELINE) {
-	const writeBaseline = (p, ids) => {
-		fs.writeFileSync(p, JSON.stringify([...ids].sort(), null, '\t') + '\n');
-		console.log(`[verify] baseline updated: ${ids.size} known failures -> ${path.relative(ROOT, p)}`);
-	};
-	console.log();
-	writeBaseline(BASELINE_CLIENT, clientFails);
-	writeBaseline(BASELINE_SERVER, serverFails);
+	writeBaselines(failsByTarget);
 	process.exit(0);
 }
 
 const loadBaseline = (p) =>
 	new Set(!STRICT && fs.existsSync(p) ? JSON.parse(fs.readFileSync(p, 'utf8')) : []);
-const clientBaseline = loadBaseline(BASELINE_CLIENT);
-const serverBaseline = loadBaseline(BASELINE_SERVER);
+const baselines = new Map(TARGETS.map((t) => [t.key, loadBaseline(baselinePath(t))]));
 
 // A regression is a (id, target) pair failing while absent from that target's
 // baseline.
 const regressions = [];
-for (const id of clientFails) if (!clientBaseline.has(id)) regressions.push({ id, target: 'client' });
-for (const id of serverFails) if (!serverBaseline.has(id)) regressions.push({ id, target: 'server' });
+for (const key of TARGET_KEYS) {
+	for (const id of failsByTarget.get(key)) {
+		if (!baselines.get(key).has(id)) regressions.push({ id, target: key });
+	}
+}
 
-const fixedClient = [...clientBaseline].filter((id) => !clientFails.has(id));
-const fixedServer = [...serverBaseline].filter((id) => !serverFails.has(id));
-const fixedKnown = fixedClient.length + fixedServer.length;
+const fixedByTarget = TARGET_KEYS.map((key) => [
+	key,
+	[...baselines.get(key)].filter((id) => !failsByTarget.get(key).has(id)),
+]);
+const fixedKnown = fixedByTarget.reduce((n, [, ids]) => n + ids.length, 0);
 
 if (fixedKnown) {
-	console.log(`\n[verify] 🎉 ${fixedKnown} known failures now PASS (client ${fixedClient.length}, server ${fixedServer.length}) — shrink the baselines:`);
+	const breakdown = fixedByTarget.map(([key, ids]) => `${key} ${ids.length}`).join(', ');
+	console.log(`\n[verify] 🎉 ${fixedKnown} known failures now PASS (${breakdown}) — shrink the baselines:`);
 	console.log('  node scripts/compat-corpus/verify.mjs --no-fmt --update-baseline');
 }
 
@@ -236,7 +281,8 @@ if (regressions.length) {
 }
 
 if (failures.length) {
-	console.log(`\n[verify] ✅ no regressions (client ${clientFails.size}, server ${serverFails.size} known failures remain — see compatibility/known-failures.md)`);
+	const breakdown = TARGET_KEYS.map((key) => `${key} ${failsByTarget.get(key).size}`).join(', ');
+	console.log(`\n[verify] ✅ no regressions (${breakdown} known failures remain — see compatibility/known-failures.md)`);
 } else {
 	console.log('\n[verify] ✅ all corpus outputs identical after normalization');
 }


### PR DESCRIPTION
Pure refactor, no behaviour change. Groundwork for the planned `client-dev`
compile lane (a dev-mode target would otherwise mean editing four scripts and
remembering two hardcoded `{ client, server }` literals).

## What

New `scripts/compat-corpus/targets.mjs` declares the compared targets once:

```js
export const TARGETS = [
  { key: 'client', generate: 'client', dev: false, css: true,  baseline: 'known-failures.client.json' },
  { key: 'server', generate: 'server', dev: false, css: false, baseline: 'known-failures.server.json' },
];
export const TARGET_KEYS = TARGETS.map((t) => t.key);
```

`compile.mjs` / `verify.mjs` / `one.mjs` / `cluster.mjs` now iterate that list
instead of their own `['client', 'server']`:

- **compile.mjs** — `compileOne` takes a target descriptor (`generate` / `dev`
  from it); output filenames become `<key>.js` / `<key>.css` (CSS gated on
  `target.css`); `recordPanic`'s hardcoded `{ client: err, server: err }` is
  built from `TARGET_KEYS`, so a future dev-only panic can't be misattributed.
- **verify.mjs** — the failure partition was an `if (client) … else if (server)`
  chain that silently dropped any other target; it is now
  `new Map(TARGET_KEYS.map((k) => [k, new Set()]))` with a warning on an unknown
  target. Baseline paths, the regression scan and the summary breakdowns are all
  driven by `TARGETS`. CSS comparison is gated on `target.css` rather than
  `target === 'client'`.
- **one.mjs / cluster.mjs** — target loops from `TARGETS` / `TARGET_KEYS`;
  `one.mjs --target <unknown>` now errors instead of passing a bogus `generate`
  through to the compiler.

Two new verify flags fall out of the descriptor list:

- `--update-baseline <target>` scopes the rewrite to one baseline (bare
  `--update-baseline` still rewrites every one, as before).
- `--from-report <path>` derives baselines from an existing `report.json` (e.g.
  downloaded from a CI run) using the same partition function, so a new target's
  baseline can be bootstrapped without a local full corpus run.

## Equivalence

No ratchet file, CI step or output path changes; `report.json` should be
byte-identical.

- Target iteration order is unchanged (`client` then `server`) everywhere:
  compile, error.json key insertion, report details, regression list, summary.
- Output filenames are unchanged: `client` → `client.js` / `client.css`,
  `server` → `server.js`, and `server` keeps `css: false` (server CSS was never
  written or compared before either).
- The two summary lines still render exactly as before — `(client N, server M)`
  is now built by joining `` `${key} ${n}` ``.
- `--baseline-client` / `--baseline-server` overrides still resolve the same way.
- Smoke-tested `--from-report` (including the unknown-target warning path and
  `--update-baseline server` scoping) against a synthetic report; `node --check`
  passes on all five files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015vkYyTLdbG88CbZ7cjDC34
