### PR TITLE
fix(compiler): strip TS optional markers (`x?: T`) and `override` on class members

### DIFF
--- a/.changeset/fix-ts-optional-override-strip.md
+++ b/.changeset/fix-ts-optional-override-strip.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/compiler": patch
+---
+
+Strip the TypeScript optional marker (`x?: T`, `m?(): void`) and the `override` modifier from class members, which previously leaked into the generated JS and made it unparseable

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/types.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/types.rs
@@ -714,11 +714,12 @@ fn strip_typescript_from_program_impl(
             // An inline TS type annotation starts with `:` (optionally preceded by
             // whitespace already emitted). If the removed chunk starts with `:`, it
             // is a type annotation — skip comment re-emission for it entirely.
-            // A definite-assignment `!` is spliced together with the annotation
-            // that follows it, so look past it before testing for the sigil.
+            // A definite-assignment `!` / optional `?` marker is spliced together
+            // with the annotation that follows it, so look past it before testing
+            // for the sigil.
             let is_inline_type_annotation = removed
                 .trim_start()
-                .trim_start_matches('!')
+                .trim_start_matches(['!', '?'])
                 .trim_start()
                 .starts_with(':');
             if !is_inline_type_annotation
@@ -988,17 +989,21 @@ fn collect_ts_removals_from_class(
                     removals.push((method.span.start, method.span.end));
                     continue;
                 }
+                let key_span = method.key.span();
+                let modifiers = oxc_span::Span::new(method.span.start, key_span.start);
                 if let Some(ref accessibility) = method.accessibility {
                     remove_keyword_from_source(
-                        match accessibility {
-                            oxc_ast::ast::TSAccessibility::Public => "public",
-                            oxc_ast::ast::TSAccessibility::Private => "private",
-                            oxc_ast::ast::TSAccessibility::Protected => "protected",
-                        },
-                        method.span,
+                        accessibility_keyword(accessibility),
+                        modifiers,
                         source,
                         removals,
                     );
+                }
+                if method.r#override {
+                    remove_keyword_from_source("override", modifiers, source, removals);
+                }
+                if method.optional {
+                    collect_optional_marker_removal(key_span.end, source, removals);
                 }
                 collect_ts_removals_from_function(&method.value, source, removals);
             }
@@ -1018,20 +1023,24 @@ fn collect_ts_removals_from_class(
                     }
                     removals.push((type_ann.span.start, type_ann.span.end));
                 }
+                let key_span = prop.key.span();
+                let modifiers = oxc_span::Span::new(prop.span.start, key_span.start);
                 if let Some(ref accessibility) = prop.accessibility {
                     remove_keyword_from_source(
-                        match accessibility {
-                            oxc_ast::ast::TSAccessibility::Public => "public",
-                            oxc_ast::ast::TSAccessibility::Private => "private",
-                            oxc_ast::ast::TSAccessibility::Protected => "protected",
-                        },
-                        prop.span,
+                        accessibility_keyword(accessibility),
+                        modifiers,
                         source,
                         removals,
                     );
                 }
                 if prop.readonly {
-                    remove_keyword_from_source("readonly", prop.span, source, removals);
+                    remove_keyword_from_source("readonly", modifiers, source, removals);
+                }
+                if prop.r#override {
+                    remove_keyword_from_source("override", modifiers, source, removals);
+                }
+                if prop.optional {
+                    collect_optional_marker_removal(key_span.end, source, removals);
                 }
                 if let Some(ref value) = prop.value {
                     collect_ts_removals_from_expression(value, source, removals);
@@ -1043,6 +1052,40 @@ fn collect_ts_removals_from_class(
                 }
             }
             _ => {}
+        }
+    }
+}
+
+fn accessibility_keyword(accessibility: &oxc_ast::ast::TSAccessibility) -> &'static str {
+    match accessibility {
+        oxc_ast::ast::TSAccessibility::Public => "public",
+        oxc_ast::ast::TSAccessibility::Private => "private",
+        oxc_ast::ast::TSAccessibility::Protected => "protected",
+    }
+}
+
+/// Remove the TS optional marker `?` that follows a class member's key
+/// (`x?: T`, `m?(): void`). Only whitespace and a computed key's closing `]` may
+/// sit between the key and the marker, so a `?` elsewhere in the member (inside
+/// a string value, say) can never match.
+fn collect_optional_marker_removal(key_end: u32, source: &str, removals: &mut Vec<(u32, u32)>) {
+    let bytes = source.as_bytes();
+    let mut pos = key_end as usize;
+    let mut start = pos;
+    let mut seen_bracket = false;
+    while pos < bytes.len() {
+        match bytes[pos] {
+            b'?' => {
+                removals.push((start as u32, pos as u32 + 1));
+                return;
+            }
+            b']' if !seen_bracket => {
+                seen_bracket = true;
+                pos += 1;
+                start = pos;
+            }
+            b if b.is_ascii_whitespace() => pos += 1,
+            _ => return,
         }
     }
 }
@@ -2976,6 +3019,45 @@ let {
             ),
             ("export let a!: number;\n", "export let a;\n"),
             ("class Foo {\n\tx!: string;\n}\n", "class Foo {\n\tx;\n}\n"),
+        ] {
+            assert_eq!(strip_typescript(ts), expected, "input: {ts:?}");
+        }
+    }
+
+    /// TS optional markers and the `override` modifier on class members are
+    /// erased by the official compiler; leaving them behind emits invalid JS
+    /// (`x?;`, `override x = 2`).
+    #[test]
+    fn optional_marker_and_override_modifier_are_stripped() {
+        for (ts, expected) in [
+            ("class Foo {\n\tx?: string;\n}\n", "class Foo {\n\tx;\n}\n"),
+            ("class Foo {\n\tx?;\n}\n", "class Foo {\n\tx;\n}\n"),
+            ("class Foo {\n\tx ?: string;\n}\n", "class Foo {\n\tx;\n}\n"),
+            (
+                "class Foo {\n\t['k']?: number;\n}\n",
+                "class Foo {\n\t['k'];\n}\n",
+            ),
+            (
+                "class Foo {\n\tm?(): void {}\n}\n",
+                "class Foo {\n\tm() {}\n}\n",
+            ),
+            (
+                "class Bar extends B {\n\toverride x = 2;\n}\n",
+                "class Bar extends B {\n\tx = 2;\n}\n",
+            ),
+            (
+                "class Bar extends B {\n\toverride m(): void {}\n}\n",
+                "class Bar extends B {\n\tm() {}\n}\n",
+            ),
+            (
+                "class Bar extends B {\n\tpublic override readonly z: string = 'override';\n}\n",
+                "class Bar extends B {\n\tz = 'override';\n}\n",
+            ),
+            // A member whose value merely mentions the keyword must survive intact.
+            (
+                "class Foo {\n\ts = 'override';\n\tt = 'readonly';\n}\n",
+                "class Foo {\n\ts = 'override';\n\tt = 'readonly';\n}\n",
+            ),
         ] {
             assert_eq!(strip_typescript(ts), expected, "input: {ts:?}");
         }

--- a/crates/rsvelte_core/tests/ts_optional_override_strip.rs
+++ b/crates/rsvelte_core/tests/ts_optional_override_strip.rs
@@ -1,0 +1,67 @@
+//! Regression test: the TS optional marker `?` and the `override` modifier on
+//! class members must be erased (issue #1992).
+//!
+//! Bug: `x?: string` / `m?(): void {}` kept the `?` and `override x = 2` kept the
+//! modifier, emitting invalid JS that the bundler cannot re-parse.
+
+use rsvelte_core::{CompileOptions, GenerateMode, compile, compiler::CssMode};
+
+fn compile_ts(src: &str, generate: GenerateMode) -> String {
+    compile(
+        src,
+        CompileOptions {
+            filename: Some("OptionalOverride.svelte".to_string()),
+            generate,
+            dev: false,
+            css: CssMode::External,
+            ..Default::default()
+        },
+    )
+    .expect("compile")
+    .js
+    .code
+}
+
+const SOURCE: &str = "<script lang=\"ts\">\n\tclass Foo {\n\t\tx?: string;\n\t\ty?;\n\t\tm?(): void {}\n\t}\n\tclass B {\n\t\tx = 1;\n\t\tm() {}\n\t}\n\tclass Bar extends B {\n\t\toverride x = 2;\n\t\toverride m(): void {}\n\t\tpublic override readonly z: string = 'override';\n\t\ts = 'override';\n\t}\n\tconsole.log(new Foo(), new Bar());\n</script>\n";
+
+#[test]
+fn optional_markers_are_stripped() {
+    for generate in [GenerateMode::Client, GenerateMode::Server] {
+        let out = compile_ts(SOURCE, generate);
+        for leftover in ["x?", "y?", "m?"] {
+            assert!(!out.contains(leftover), "leftover `?` in:\n{out}");
+        }
+        for expected in ["x;", "y;", "m() {}"] {
+            assert!(out.contains(expected), "missing `{expected}` in:\n{out}");
+        }
+    }
+}
+
+#[test]
+fn override_modifiers_are_stripped() {
+    for generate in [GenerateMode::Client, GenerateMode::Server] {
+        let out = compile_ts(SOURCE, generate);
+        for leftover in ["override x", "override m", "override readonly", "public "] {
+            assert!(
+                !out.contains(leftover),
+                "leftover modifier `{leftover}` in:\n{out}"
+            );
+        }
+        for expected in ["x = 2;", "z = 'override';"] {
+            assert!(out.contains(expected), "missing `{expected}` in:\n{out}");
+        }
+    }
+}
+
+/// The keyword search must be bounded to the modifiers before the key, so a
+/// member whose value merely contains `'override'` is left alone.
+#[test]
+fn override_inside_a_string_literal_survives() {
+    for generate in [GenerateMode::Client, GenerateMode::Server] {
+        let out = compile_ts(SOURCE, generate);
+        assert!(
+            out.contains("s = 'override';"),
+            "string literal was mangled in:\n{out}"
+        );
+    }
+}


### PR DESCRIPTION
Fixes #1992

> **Base branch note:** this targets `fix/1980-definite-assignment` (PR #1991) because it
> builds on that PR's `collect_definite_marker_removal` work in the same file. Retarget to
> `main` once #1991 lands.

## Root cause

The TypeScript erasure pass (`crates/rsvelte_core/src/compiler/phases/2_analyze/types.rs`)
splices TS-only source ranges out of the script text. For class members it collected the
type annotation, `accessibility`, `readonly` and (since #1991) `definite` — but never the
two remaining TS-only bits OXC records on `MethodDefinition` / `PropertyDefinition`:
`optional` (the `?` in `x?: T`, `m?(): void`) and `r#override`. Both are deleted from the
AST by the official compiler (`phases/1-parse/remove_typescript_nodes.js`), so they can
never leak there. rsvelte emitted:

```js
class Foo { x?; m?() {} }                 // invalid JS
class Bar extends B { override x = 2; }   // invalid JS
```

Same class of hard build failure as #1980 — the bundler re-parses the compiler output.

## Changes

- `collect_optional_marker_removal`: removes the `?` that follows a member key. The scan
  accepts only whitespace and a computed key's closing `]` between the key and the marker
  and bails on anything else, so a `?` elsewhere in the member can never match. It also
  swallows the whitespace before the marker, so `x ?: T` strips to exactly `x`.
- `override` erasure for both `MethodDefinition` and `PropertyDefinition`.
- Keyword searches are now bounded to the modifier region (`member.span.start ..
  key.span().start`) instead of the whole member span. Modifiers always precede the key,
  so this is equivalent for the existing `accessibility` / `readonly` callers while making
  `override` safe against a member value like `s = 'override'`.
- The "don't re-emit comments from inline type annotations" guard looks past a leading `?`
  as well as `!`, since the marker removal merges into the annotation splice.
- `accessibility_keyword` helper, replacing the two copies of the accessibility `match`.

## Verification

Expected output taken from the official compiler (svelte 5.56.4) run directly under node,
client **and** server:

| input | before | after (= official) |
|---|---|---|
| `x?: string` | `x?;` | `x;` |
| `y?` | `y?;` | `y;` |
| `m?(): void {}` | `m?() {}` | `m() {}` |
| `['k']?: number` | `['k']?;` | `['k'];` |
| `override x = 2` | `override x = 2;` | `x = 2;` |
| `public override readonly z: string = 'override'` | leaked modifiers | `z = 'override';` |
| `s = 'override'` | — | unchanged |

Tests added:

- `crates/rsvelte_core/tests/ts_optional_override_strip.rs` — compiles the issue's repro
  for client and server and asserts no leftover `?` / `override`, plus that a value
  containing the string `'override'` survives intact.
- A `strip_typescript` unit test covering `x?: T`, bare `x?`, spaced `x ?: T`, a computed
  key, an optional method, `override` on field and method, the stacked
  `public override readonly` case, and the string-literal control.

## Upstream-parity sweep

Audited the whole text pass against `remove_typescript_nodes.js`. Everything else the
official visitor deletes is already handled here or errors earlier in phase 1 (decorators,
`accessor` fields, constructor parameter properties, enums, namespaces). Eight *further*
gaps of the same family did turn up — tagged-template substitutions, dynamic `import()`,
destructuring assignment targets, `extends (Base as any)`, computed class-member keys,
non-declaration `for` init / `for…of` targets, and `with` — each verified against the
official compiler. They are independent of this fix and are filed as #1999 rather than
expanded into this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015vkYyTLdbG88CbZ7cjDC34
