### PR TITLE
Apply the project's rsvelte-lint.json to editor diagnostics

### DIFF
--- a/.changeset/lint-config-in-editor.md
+++ b/.changeset/lint-config-in-editor.md
@@ -1,0 +1,23 @@
+---
+"@rsvelte/compiler": minor
+"@rsvelte/language-server": minor
+"rsvelte-vscode": minor
+---
+
+feat(language-server): apply the project's `rsvelte-lint.json` to editor diagnostics
+
+The linter runs as wasm and has no filesystem, so `json_api::lint` hardcoded the
+`recommended` preset: every rule ran at its default severity and no project
+config could change that. In a codebase that has never been linted with rsvelte
+— or one whose Svelte rules are already tuned in ESLint — that meant thousands
+of unsuppressable warnings, and turning `rsvelte.lint.enable` off was the only
+way out.
+
+The server now discovers `rsvelte-lint.json` / `.rsvelte-lintrc.json` by walking
+up from the document's directory (the same file, in the same order, that the
+`rsvelte-lint` CLI resolves) and passes it to the new
+`lint_with_config(source, filename, config)` wasm export, so the editor reports
+what CI does. Resolved configs are cached and dropped when a config file is
+saved. A config that can't be read or parsed is reported to the client's log and
+the recommended preset is used, so a typo never leaves the editor without
+diagnostics.

--- a/apps/npm/language-server/README.md
+++ b/apps/npm/language-server/README.md
@@ -18,7 +18,8 @@ toolchain.
 - **Diagnostics** — push diagnostics from the bundled
   [`rsvelte_lint`](https://github.com/baseballyama/rsvelte/tree/main/crates/rsvelte_lint)
   engine (compiled to wasm, vendored in the package — no extra install). Runs on
-  open, on change (300 ms debounced), and on save.
+  open, on change (300 ms debounced), and on save. The rule set comes from the
+  project's own [`rsvelte-lint.json`](#lint-configuration).
 
 That's the full v1 surface — hover, completion, go-to-definition, rename,
 find-references, and TypeScript diagnostics are **not** implemented. Those
@@ -36,6 +37,38 @@ The server reads these from the client's `rsvelte.*` configuration:
 | `rsvelte.format.enable` | `true` | Enable formatting via `rsvelte-fmt`. |
 | `rsvelte.lint.enable` | `true` | Enable linting via the bundled engine. |
 | `rsvelte.rsvelteFmtPath` | `""` | Explicit path to a `rsvelte-fmt` binary (overrides resolution). |
+
+## Lint configuration
+
+Severities and rule options come from a `rsvelte-lint.json` (or
+`.rsvelte-lintrc.json`), discovered by walking up from the document's directory
+— the same file, in the same order, that the
+[`rsvelte-lint`](https://www.npmjs.com/package/@rsvelte/lint) CLI resolves, so
+the editor reports what CI does. With no config file, every rule runs at its
+default severity (the `recommended` preset); to start from nothing and opt in,
+use `"extends": ["none"]`:
+
+```json
+{
+  "extends": ["recommended"],
+  "rules": {
+    "svelte/no-at-html-tags": "error",
+    "svelte/no-unused-class-name": "off",
+    "svelte/button-has-type": ["warn", { "submit": true, "reset": false }]
+  }
+}
+```
+
+See the
+[CLI's configuration reference](https://www.npmjs.com/package/@rsvelte/lint#configuration)
+for the full shape. An ESLint config is deliberately **not** read: importing it
+is opt-in on the CLI (`--config-from-eslint`), and a server that read it on its
+own would report a different rule set than the same project's CI. A config that
+can't be read or parsed is reported to the client's log and the recommended
+preset is used, so a typo never leaves the editor without diagnostics.
+
+Resolved configs are cached for the life of the server; they are dropped when a
+config file is saved through the client, and on `workspace/didChangeConfiguration`.
 
 ## Usage
 

--- a/apps/npm/language-server/build.mjs
+++ b/apps/npm/language-server/build.mjs
@@ -50,6 +50,7 @@ await build({
   entryPoints: [
     join(root, "src", "diagnostics.ts"),
     join(root, "src", "format.ts"),
+    join(root, "src", "lintConfig.ts"),
   ],
   outdir: join(distDir, "lib"),
   outExtension: { ".js": ".mjs" },

--- a/apps/npm/language-server/src/lint.ts
+++ b/apps/npm/language-server/src/lint.ts
@@ -13,7 +13,7 @@ import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
 interface LintModule {
-  lint(source: string, filename: string): string;
+  lint_with_config(source: string, filename: string, config: string): string;
   lint_version(): string;
 }
 
@@ -39,12 +39,20 @@ function load(): LintModule | null {
   }
 }
 
-/** Run the linter, returning its raw JSON string. `null` if wasm is missing. */
-export function runLint(source: string, filename: string): string | null {
+/**
+ * Run the linter under `config` (a `rsvelte-lint.json` document; `""` selects
+ * the recommended preset), returning its raw JSON string. `null` if wasm is
+ * missing.
+ */
+export function runLint(
+  source: string,
+  filename: string,
+  config: string,
+): string | null {
   const m = load();
   if (!m) return null;
   try {
-    return m.lint(source, filename);
+    return m.lint_with_config(source, filename, config);
   } catch {
     return null;
   }

--- a/apps/npm/language-server/src/lintConfig.ts
+++ b/apps/npm/language-server/src/lintConfig.ts
@@ -1,0 +1,109 @@
+/**
+ * Discovery of the `rsvelte-lint.json` governing a document.
+ *
+ * The linter runs as wasm and has no filesystem of its own, so the config file
+ * the `rsvelte-lint` CLI would discover is located and read here, then handed
+ * to `lint_with_config`. An ESLint config is deliberately *not* consulted:
+ * importing it is opt-in on the CLI (`--config-from-eslint`), and a server that
+ * read it on its own would report a different rule set in the editor than the
+ * same project's CI does.
+ */
+
+import { basename, dirname, join } from "node:path";
+import { readFileSync } from "node:fs";
+
+/** Config file names, in the order a directory is probed. */
+const CONFIG_NAMES = ["rsvelte-lint.json", ".rsvelte-lintrc.json"];
+
+export interface ResolvedLintConfig {
+  /**
+   * Config document, or `""` when no config file governs the directory — and
+   * when one does but is unusable, which leaves the linter on the recommended
+   * preset rather than without diagnostics.
+   */
+  text: string;
+  /** Path of the config file that was read, or `null` when there is none. */
+  path: string | null;
+}
+
+const NO_CONFIG: ResolvedLintConfig = { text: "", path: null };
+
+/**
+ * Discovery walks to the filesystem root, so it is cached per starting
+ * directory rather than redone on every keystroke.
+ */
+const cache = new Map<string, ResolvedLintConfig>();
+
+/** Whether saving this path invalidates resolved configs. */
+export function isLintConfigPath(path: string): boolean {
+  return CONFIG_NAMES.includes(basename(path));
+}
+
+export function clearLintConfigCache(): void {
+  cache.clear();
+}
+
+/**
+ * The config governing documents in `dir`, discovered upward from it.
+ * `onError` reports an unusable config, and fires only when the config is
+ * actually resolved — not on every cache hit behind it.
+ */
+export function resolveLintConfig(
+  dir: string,
+  onError?: (message: string) => void,
+): ResolvedLintConfig {
+  const cached = cache.get(dir);
+  if (cached) return cached;
+
+  const found = discover(dir);
+  cache.set(dir, found.config);
+  if (found.error) onError?.(`${found.config.path}: ${found.error}`);
+  return found.config;
+}
+
+interface Discovery {
+  config: ResolvedLintConfig;
+  error: string | null;
+}
+
+function discover(start: string): Discovery {
+  let dir = start;
+  for (;;) {
+    for (const name of CONFIG_NAMES) {
+      const found = read(join(dir, name));
+      if (found) return found;
+    }
+    const parent = dirname(dir);
+    if (parent === dir) return { config: NO_CONFIG, error: null };
+    dir = parent;
+  }
+}
+
+/**
+ * `null` when the file does not exist. An unusable config is reported rather
+ * than skipped, so the search stops at the file the CLI would also have used.
+ */
+function read(path: string): Discovery | null {
+  let text: string;
+  try {
+    text = readFileSync(path, "utf8");
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === "ENOENT" || code === "ENOTDIR") return null;
+    return { config: { text: "", path }, error: String(err) };
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch (err) {
+    return { config: { text: "", path }, error: String(err) };
+  }
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    return {
+      config: { text: "", path },
+      error: "lint config must be a JSON object",
+    };
+  }
+  return { config: { text, path }, error: null };
+}

--- a/apps/npm/language-server/src/server.ts
+++ b/apps/npm/language-server/src/server.ts
@@ -22,6 +22,11 @@ import { dirname } from "node:path";
 import { lintJsonToDiagnostics } from "./diagnostics.js";
 import { formatWithRsvelteFmt, resolveRsvelteFmt } from "./format.js";
 import { lintVersion, runLint } from "./lint.js";
+import {
+  clearLintConfigCache,
+  isLintConfigPath,
+  resolveLintConfig,
+} from "./lintConfig.js";
 
 interface RsvelteSettings {
   format: { enable: boolean };
@@ -104,10 +109,10 @@ async function refreshSettings(): Promise<void> {
 
 connection.onDidChangeConfiguration(async () => {
   await refreshSettings();
-  // Re-lint every open document under the new settings.
-  for (const doc of documents.all()) {
-    scheduleLint(doc, 0);
-  }
+  // A `rsvelte-lint.json` edit reaches the server as a configuration change
+  // too, so the resolved configs are dropped along with the client settings.
+  clearLintConfigCache();
+  relintOpenDocuments();
 });
 
 // ── Formatting ──────────────────────────────────────────────────────────────
@@ -153,14 +158,34 @@ async function lintDocument(doc: TextDocument): Promise<void> {
     connection.sendDiagnostics({ uri: doc.uri, diagnostics: [] });
     return;
   }
-  const json = runLint(doc.getText(), docFsPath(doc.uri));
+  const fsPath = docFsPath(doc.uri);
+  const config = resolveLintConfig(dirname(fsPath), (message) =>
+    connection.console.warn(message),
+  );
+  const json = runLint(doc.getText(), fsPath, config.text);
   const diagnostics = json ? lintJsonToDiagnostics(json) : [];
   connection.sendDiagnostics({ uri: doc.uri, diagnostics });
 }
 
+/** Re-lint every open document, e.g. after the rule set behind them changed. */
+function relintOpenDocuments(): void {
+  for (const doc of documents.all()) {
+    scheduleLint(doc, 0);
+  }
+}
+
 documents.onDidOpen((e) => scheduleLint(e.document, 0));
 documents.onDidChangeContent((e) => scheduleLint(e.document));
-documents.onDidSave((e) => scheduleLint(e.document, 0));
+documents.onDidSave((e) => {
+  // With no `didChangeWatchedFiles` registration, a config saved through the
+  // client is the only config edit the server can observe.
+  if (isLintConfigPath(docFsPath(e.document.uri))) {
+    clearLintConfigCache();
+    relintOpenDocuments();
+    return;
+  }
+  scheduleLint(e.document, 0);
+});
 
 documents.onDidClose((e) => {
   const timer = debounceTimers.get(e.document.uri);

--- a/apps/npm/language-server/test/lintConfig.test.mjs
+++ b/apps/npm/language-server/test/lintConfig.test.mjs
@@ -1,0 +1,111 @@
+// Unit tests for `rsvelte-lint.json` discovery.
+// Imports the esbuild-emitted ESM lib (run `pnpm run build` first).
+
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, test } from "node:test";
+
+import {
+  clearLintConfigCache,
+  isLintConfigPath,
+  resolveLintConfig,
+} from "../dist/lib/lintConfig.mjs";
+
+const RULES_OFF = '{ "rules": { "svelte/no-at-html-tags": "off" } }';
+
+let root;
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), "rsvelte-ls-lint-config-"));
+  clearLintConfigCache();
+});
+
+afterEach(() => {
+  rmSync(root, { recursive: true, force: true });
+});
+
+/** Resolve while collecting the messages passed to `onError`. */
+function resolve(dir) {
+  const errors = [];
+  const config = resolveLintConfig(dir, (message) => errors.push(message));
+  return { ...config, errors };
+}
+
+test("no config anywhere above the directory resolves to the recommended preset", () => {
+  const resolved = resolve(root);
+  assert.equal(resolved.text, "");
+  assert.equal(resolved.path, null);
+  assert.deepEqual(resolved.errors, []);
+});
+
+test("finds a config in an ancestor directory", () => {
+  writeFileSync(join(root, "rsvelte-lint.json"), RULES_OFF);
+  const nested = join(root, "src", "lib");
+  mkdirSync(nested, { recursive: true });
+
+  const resolved = resolve(nested);
+  assert.equal(resolved.text, RULES_OFF);
+  assert.equal(resolved.path, join(root, "rsvelte-lint.json"));
+  assert.deepEqual(resolved.errors, []);
+});
+
+test("the nearest config wins", () => {
+  writeFileSync(join(root, "rsvelte-lint.json"), RULES_OFF);
+  const nested = join(root, "src");
+  mkdirSync(nested);
+  writeFileSync(join(nested, "rsvelte-lint.json"), '{ "extends": ["none"] }');
+
+  assert.equal(resolve(nested).path, join(nested, "rsvelte-lint.json"));
+});
+
+test("rsvelte-lint.json wins over .rsvelte-lintrc.json in one directory", () => {
+  writeFileSync(join(root, "rsvelte-lint.json"), RULES_OFF);
+  writeFileSync(join(root, ".rsvelte-lintrc.json"), '{ "extends": ["none"] }');
+
+  assert.equal(resolve(root).path, join(root, "rsvelte-lint.json"));
+});
+
+test(".rsvelte-lintrc.json is discovered too", () => {
+  writeFileSync(join(root, ".rsvelte-lintrc.json"), RULES_OFF);
+
+  assert.equal(resolve(root).text, RULES_OFF);
+});
+
+test("a malformed config is reported and falls back to the recommended preset", () => {
+  const path = join(root, "rsvelte-lint.json");
+  writeFileSync(path, "{ not json");
+
+  const resolved = resolve(root);
+  assert.equal(resolved.text, "");
+  assert.equal(resolved.path, path);
+  assert.equal(resolved.errors.length, 1);
+  assert.ok(resolved.errors[0].startsWith(`${path}: `));
+  assert.match(resolved.errors[0], /JSON/);
+});
+
+test("a non-object config is reported", () => {
+  writeFileSync(join(root, "rsvelte-lint.json"), "[]");
+
+  assert.match(resolve(root).errors[0], /JSON object$/);
+});
+
+test("a resolved config is cached, and its error reported only once", () => {
+  writeFileSync(join(root, "rsvelte-lint.json"), "{ not json");
+  assert.equal(resolve(root).errors.length, 1);
+  assert.deepEqual(resolve(root).errors, []);
+
+  writeFileSync(join(root, "rsvelte-lint.json"), RULES_OFF);
+  assert.equal(resolve(root).text, "");
+
+  clearLintConfigCache();
+  assert.equal(resolve(root).text, RULES_OFF);
+});
+
+test("recognises the config file names", () => {
+  assert.ok(isLintConfigPath(join(root, "rsvelte-lint.json")));
+  assert.ok(isLintConfigPath(join(root, ".rsvelte-lintrc.json")));
+  assert.ok(!isLintConfigPath(join(root, "App.svelte")));
+  assert.ok(!isLintConfigPath(join(root, "rsvelte-lint.jsonc")));
+});

--- a/apps/npm/language-server/test/server.test.mjs
+++ b/apps/npm/language-server/test/server.test.mjs
@@ -4,10 +4,11 @@
 
 import assert from "node:assert/strict";
 import { spawn, spawnSync } from "node:child_process";
-import { existsSync } from "node:fs";
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { createRequire } from "node:module";
+import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import { after, before, test } from "node:test";
 
 const here = dirname(fileURLToPath(import.meta.url));
@@ -175,6 +176,32 @@ test("diagnostics match the lint wasm output", async () => {
     assert.equal(d.range.start.character, e.column, `start.char[${i}]`);
     assert.equal(d.range.end.line, e.endLine - 1, `end.line[${i}]`);
     assert.equal(d.range.end.character, e.endColumn, `end.char[${i}]`);
+  }
+});
+
+test("a rsvelte-lint.json governs the rule set", async () => {
+  const configured = mkdtempSync(join(tmpdir(), "rsvelte-ls-configured-"));
+  const plain = mkdtempSync(join(tmpdir(), "rsvelte-ls-plain-"));
+  writeFileSync(
+    join(configured, "rsvelte-lint.json"),
+    '{ "rules": { "svelte/no-at-html-tags": "off" } }',
+  );
+  const source = "<div>{@html x}</div>\n";
+  const has = (diags) => diags.some((d) => d.code === "svelte/no-at-html-tags");
+
+  try {
+    const plainUri = pathToFileURL(join(plain, "App.svelte")).href;
+    const plainP = waitDiagnostics(plainUri);
+    openDoc(plainUri, "svelte", source);
+    assert.ok(has(await plainP), "the rule fires without a config");
+
+    const configuredUri = pathToFileURL(join(configured, "App.svelte")).href;
+    const configuredP = waitDiagnostics(configuredUri);
+    openDoc(configuredUri, "svelte", source);
+    assert.ok(!has(await configuredP), "the config turns the rule off");
+  } finally {
+    rmSync(configured, { recursive: true, force: true });
+    rmSync(plain, { recursive: true, force: true });
   }
 });
 

--- a/apps/npm/lint/README.md
+++ b/apps/npm/lint/README.md
@@ -121,6 +121,12 @@ Run `--list-rules` to see every native rule's id, category, default severity,
 and whether it's autofixable; rules with an options schema are marked
 `(options)`.
 
+The same file drives editor diagnostics: `@rsvelte/language-server` and the
+[rsvelte VS Code extension](https://marketplace.visualstudio.com/items?itemName=baseballyama.rsvelte-vscode)
+discover it by walking up from the file being linted, so the editor and CI agree
+on the rule set. `files` / `ignores` stay CLI-only — an editor lints the
+document it is handed.
+
 ## Migrating from ESLint
 
 `rsvelte-lint` ships as a **complement** to `eslint-plugin-svelte` first, not

--- a/apps/npm/vscode/README.md
+++ b/apps/npm/vscode/README.md
@@ -71,6 +71,30 @@ doesn't conflict with the official Svelte extension):
 | `rsvelte.lint.enable` | `true` | Enable linting via the bundled engine. |
 | `rsvelte.rsvelteFmtPath` | `""` | Explicit path to a `rsvelte-fmt` binary. |
 
+## Lint configuration
+
+Which rules run, at what severity, comes from a `rsvelte-lint.json` (or
+`.rsvelte-lintrc.json`) in your project — the same file the
+[`rsvelte-lint`](https://www.npmjs.com/package/@rsvelte/lint) CLI reads, found
+by walking up from the file being linted, so the editor reports what CI does:
+
+```json
+{
+  "rules": {
+    "svelte/no-unused-class-name": "off",
+    "svelte/no-at-html-tags": "error"
+  }
+}
+```
+
+Without one, every rule runs at its default severity — noisy in a codebase that
+has never been linted with rsvelte. Start from nothing with
+`"extends": ["none"]` and opt rules in, or turn off the ones your project
+already covers elsewhere (e.g. via `eslint-plugin-svelte`). Saving the config
+applies it immediately. See the
+[configuration reference](https://www.npmjs.com/package/@rsvelte/lint#configuration)
+for the full shape.
+
 ## License
 
 MIT. The bundled grammars, snippets and language configurations are copied from

--- a/crates/rsvelte_lint/src/json_api.rs
+++ b/crates/rsvelte_lint/src/json_api.rs
@@ -1,7 +1,7 @@
 //! Engine-only JSON diagnostic API, shared by every out-of-process binding.
 //!
 //! Both the wasm export and the NAPI export (in `rsvelte_lint_bindings`) are
-//! thin wrappers over the two functions here, so a native (`.node`) and a wasm
+//! thin wrappers over the functions here, so a native (`.node`) and a wasm
 //! consumer see **byte-identical JSON**. This path is `svelte_check`-free:
 //! it runs the native rule engine ([`run_native_rules`]
 //! and [`run_script_rules`](crate::engine::run_script_rules)) plus the
@@ -56,7 +56,24 @@ fn compile_error_code(e: &CompileError) -> String {
 /// `[{ "severity", "line", "column", "endLine", "endColumn", "code", "message" }]`.
 /// Lines are 1-indexed, columns 0-indexed (UTF-16), matching `rsvelte check`.
 pub fn lint(source: &str, filename: &str) -> String {
-    let config = LintConfig::recommended();
+    lint_with(source, filename, &LintConfig::recommended())
+}
+
+/// [`lint`] under the caller's own config document — the text of a
+/// `rsvelte-lint.json`, which a host without filesystem access (the wasm build)
+/// cannot discover for itself. An empty document selects the recommended
+/// preset; an invalid one falls back to it, since a config error must not leave
+/// the caller without diagnostics.
+pub fn lint_with_config(source: &str, filename: &str, config_json: &str) -> String {
+    let config = if config_json.trim().is_empty() {
+        LintConfig::recommended()
+    } else {
+        LintConfig::from_json_str(config_json).unwrap_or_else(|_| LintConfig::recommended())
+    };
+    lint_with(source, filename, &config)
+}
+
+fn lint_with(source: &str, filename: &str, config: &LintConfig) -> String {
     let line_index = LineIndex::new(source);
     let suppressions = Suppressions::collect(source);
     let mut entries: Vec<Entry> = Vec::new();
@@ -111,9 +128,9 @@ pub fn lint(source: &str, filename: &str) -> String {
 
     // 2. Native rules (template walk) + script-AST rules. No filesystem here, so
     // no path is threaded (any filesystem-aware rule no-ops).
-    let native = run_native_rules(source, filename, &config, None)
+    let native = run_native_rules(source, filename, config, None)
         .into_iter()
-        .chain(crate::engine::run_script_rules(source, filename, &config));
+        .chain(crate::engine::run_script_rules(source, filename, config));
     for d in native {
         let (l, c) = line_index.position(d.start);
         if suppressions.is_suppressed(&d.rule, l) {
@@ -217,4 +234,57 @@ pub fn lint_rules() -> String {
     }
 
     serde_json::to_string(&arr).unwrap_or_else(|_| "[]".to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SOURCE: &str = "<div>{@html x}</div>";
+
+    fn codes(json: &str) -> Vec<String> {
+        serde_json::from_str::<Vec<serde_json::Value>>(json)
+            .unwrap()
+            .into_iter()
+            .map(|e| e["code"].as_str().unwrap().to_string())
+            .collect()
+    }
+
+    #[test]
+    fn an_empty_config_matches_the_recommended_preset() {
+        assert_eq!(
+            lint_with_config(SOURCE, "App.svelte", ""),
+            lint(SOURCE, "App.svelte")
+        );
+    }
+
+    #[test]
+    fn a_config_turns_a_rule_off() {
+        assert!(
+            codes(&lint(SOURCE, "App.svelte"))
+                .iter()
+                .any(|c| c == "svelte/no-at-html-tags")
+        );
+
+        let json = lint_with_config(
+            SOURCE,
+            "App.svelte",
+            r#"{ "rules": { "svelte/no-at-html-tags": "off" } }"#,
+        );
+        assert!(!codes(&json).iter().any(|c| c == "svelte/no-at-html-tags"));
+    }
+
+    #[test]
+    fn extends_none_silences_every_rule() {
+        let json = lint_with_config(SOURCE, "App.svelte", r#"{ "extends": ["none"] }"#);
+        assert_eq!(codes(&json), Vec::<String>::new());
+    }
+
+    #[test]
+    fn an_invalid_config_falls_back_to_the_recommended_preset() {
+        assert_eq!(
+            lint_with_config(SOURCE, "App.svelte", "{ not json"),
+            lint(SOURCE, "App.svelte")
+        );
+    }
 }

--- a/crates/rsvelte_lint_bindings/src/wasm.rs
+++ b/crates/rsvelte_lint_bindings/src/wasm.rs
@@ -1,7 +1,8 @@
-//! Browser entry point for the playground.
+//! Browser entry point for the playground, also vendored into
+//! `@rsvelte/language-server` (wasm-pack `nodejs` target).
 //!
-//! Exposes `lint(source, filename)` and `lint_rules()`, thin `#[wasm_bindgen]`
-//! wrappers over the engine-only `rsvelte_lint::json_api` functions (shared
+//! Exposes `lint(source, filename)`, `lint_with_config(…)` and `lint_rules()`,
+//! thin `#[wasm_bindgen]` wrappers over the engine-only `json_api` functions (shared
 //! verbatim with the NAPI export, so native and wasm return byte-identical
 //! JSON). The rsvelte_core compiler's own wasm exports (`parse_svelte`,
 //! `compile_client`, `compile_server`, `version`) are linked in transitively
@@ -16,6 +17,14 @@ use wasm_bindgen::prelude::*;
 #[wasm_bindgen]
 pub fn lint(source: &str, filename: &str) -> String {
     rsvelte_lint::json_api::lint(source, filename)
+}
+
+/// [`lint`] under the text of a `rsvelte-lint.json`. Wasm has no filesystem, so
+/// the host (the language server) discovers the config file and passes its
+/// contents in; `""` selects the recommended preset.
+#[wasm_bindgen]
+pub fn lint_with_config(source: &str, filename: &str, config: &str) -> String {
+    rsvelte_lint::json_api::lint_with_config(source, filename, config)
 }
 
 /// The rsvelte-lint crate version (for the playground UI).


### PR DESCRIPTION
## Problem

The editor linter had no configuration path at all. `json_api::lint` — the one
entry point the wasm/NAPI bindings expose, and the one the language server calls
— hardcoded `LintConfig::recommended()`, so every rule ran at its default
severity and nothing a project wrote could change it. `rsvelte-lint.json`,
`.rsvelte-lintrc.json`, an oxlint config: all ignored. The extension already
restarts the server when a `rsvelte-lint.json` is saved (`RESTART_ON_SAVE_PATTERNS`),
which only made the gap harder to spot — the restart happens, the config still
does nothing.

The result on a codebase that has never been linted with rsvelte, measured with
the extension's own bundled wasm over a real Svelte app (1,402 components):

```
14,860 diagnostics (14,740 warning / 120 error)
  10,102  svelte/no-unused-class-name      ← every utility-CSS class, already
                                             allow-listed in the project's ESLint config
   1,804  svelte/consistent-selector-style
   1,430  svelte/block-lang
     614  svelte/no-at-const-tags
     312  svelte/no-inline-styles
     ...
```

None of it suppressible short of `rsvelte.lint.enable: false`, which turns off
the compiler and a11y diagnostics too. The Rust `rsvelte_language_server` crate
already discovers a config (`crates/rsvelte_language_server/src/lint.rs`); the
server that actually ships in the extension is the wasm-backed TS one, which did
not.

## Change

- `rsvelte_lint::json_api::lint_with_config(source, filename, config_json)` —
  `lint` under a caller-supplied config document. `""` selects the recommended
  preset; an unparsable document falls back to it, because a config error must
  not leave a caller without diagnostics. `lint` is now a thin wrapper, so its
  output is unchanged.
- The same function as a `#[wasm_bindgen]` export. Wasm has no filesystem, so
  the host discovers the file and passes its text in.
- `@rsvelte/language-server` resolves `rsvelte-lint.json` / `.rsvelte-lintrc.json`
  by walking up from the document's directory — the same names, in the same
  order, as the CLI, so the editor reports what CI does. An ESLint config is
  deliberately not read (importing it is opt-in on the CLI via
  `--config-from-eslint`).
- Resolution is cached per directory and dropped when a config file is saved
  through the client, or on `workspace/didChangeConfiguration` (mirroring the
  Rust server's `ClearCaches`). An unusable config is reported to the client log
  once per resolution, not once per keystroke.

Behaviour with no config file in the tree is byte-identical to before.

## Tests

- `crates/rsvelte_lint/src/json_api.rs` — empty config ≡ `lint`, a rule turned
  off, `extends: ["none"]` silences everything, invalid config ≡ `lint`.
- `apps/npm/language-server/test/lintConfig.test.mjs` — ancestor discovery,
  nearest-wins, filename precedence, malformed / non-object reporting, cache and
  its single-report guarantee.
- `apps/npm/language-server/test/server.test.mjs` — end-to-end over stdio: the
  same component reports `svelte/no-at-html-tags` in a directory without a
  config and not in one whose `rsvelte-lint.json` turns it off.
