### PR TITLE
Let main CodSpeed baselines finish

### DIFF
--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -9,7 +9,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
- keep pull-request CodSpeed runs cancel-on-update
- allow an in-progress main baseline to finish when another commit lands on main
- prevent continuous merges from starving the baseline required for PR comparisons

## Validation
- git diff --check
- workflow expression reviewed against GitHub Actions event_name semantics