### PR TITLE
Skip unused svelte2tsx export metadata

### DIFF
--- a/.changeset/skip-unused-export-inventory.md
+++ b/.changeset/skip-unused-export-inventory.md
@@ -1,0 +1,7 @@
+---
+"@rsvelte/compiler": patch
+"@rsvelte/svelte2tsx": patch
+"@rsvelte/svelte-check": patch
+---
+
+Skip unused local export metadata collection during Svelte-to-TypeScript projection.

--- a/crates/rsvelte_projection/src/svelte2tsx/script/ast_utils.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/script/ast_utils.rs
@@ -154,16 +154,13 @@ pub(super) fn module_export_name_to_string(name: &oxc::ModuleExportName) -> Stri
     }
 }
 
-/// Pre-pass: collect EVERY top-level declared binding name in the instance
-/// script before rune detection runs. Official `svelte2tsx` resolves a
-/// `$name` reference as a store auto-subscription (NOT the `$state`/`$derived`/
-/// `$effect` rune) whenever `name` is a declared binding, using the COMPLETE
-/// top-level scope. So `let state = $state(0)` must see its own `state` as
-/// declared (→ legacy), while `let x = $state(0)` stays runes. Without this
-/// pre-pass `declared_names` was still empty when a declarator's own
-/// initializer was checked, over-detecting runes. Mirrors upstream
-/// `ImplicitStoreValues` / `checkGlobalsForRunes`.
-pub(super) fn collect_top_level_declared_names(body: &[oxc::Statement]) -> HashSet<String> {
+pub(super) struct TopLevelDeclarations {
+    pub names: HashSet<String>,
+    pub has_local_export_specifiers: bool,
+}
+
+/// Collect the complete rune-detection scope and whether export metadata is observable.
+pub(super) fn collect_top_level_declarations(body: &[oxc::Statement]) -> TopLevelDeclarations {
     fn add_binding(pattern: &oxc::BindingPattern, names: &mut HashSet<String>) {
         if let oxc::BindingPattern::BindingIdentifier(id) = pattern {
             names.insert(id.name.to_string());
@@ -198,6 +195,7 @@ pub(super) fn collect_top_level_declared_names(body: &[oxc::Statement]) -> HashS
     }
 
     let mut names = HashSet::new();
+    let mut has_local_export_specifiers = false;
     for stmt in body {
         match stmt {
             oxc::Statement::VariableDeclaration(vd) => add_var(vd, &mut names),
@@ -238,6 +236,7 @@ pub(super) fn collect_top_level_declared_names(body: &[oxc::Statement]) -> HashS
                 }
             }
             oxc::Statement::ExportNamedDeclaration(ex) => {
+                has_local_export_specifiers |= ex.source.is_none() && !ex.specifiers.is_empty();
                 if let Some(decl) = &ex.declaration {
                     add_declaration(decl, &mut names);
                 }
@@ -245,7 +244,10 @@ pub(super) fn collect_top_level_declared_names(body: &[oxc::Statement]) -> HashS
             _ => {}
         }
     }
-    names
+    TopLevelDeclarations {
+        names,
+        has_local_export_specifiers,
+    }
 }
 
 /// Extract all identifier names from a binding pattern (for destructuring support).
@@ -367,7 +369,7 @@ mod tests {
     use oxc_parser::Parser;
     use oxc_span::SourceType;
 
-    use super::{binding_pattern_simple_name, oxc};
+    use super::{binding_pattern_simple_name, collect_top_level_declarations, oxc};
 
     #[test]
     fn simple_binding_name_borrows_the_ast_identifier() {
@@ -387,5 +389,24 @@ mod tests {
             name.as_ptr(),
             identifier.name.as_str().as_ptr()
         ));
+    }
+
+    #[test]
+    fn top_level_declarations_distinguish_local_export_specifiers() {
+        for (source, expected) in [
+            ("let value = 1; export { value };", true),
+            ("let value = 1; export { value as renamed };", true),
+            ("export { value } from './module.js';", false),
+            ("export let value = 1;", false),
+        ] {
+            let allocator = Allocator::default();
+            let parsed = Parser::new(&allocator, source, SourceType::mjs()).parse();
+
+            assert_eq!(
+                collect_top_level_declarations(&parsed.program.body).has_local_export_specifiers,
+                expected,
+                "{source}"
+            );
+        }
     }
 }

--- a/crates/rsvelte_projection/src/svelte2tsx/script/mod.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/script/mod.rs
@@ -38,7 +38,7 @@ pub use exported_names::{ExportedNameInfo, ExportedNames};
 pub(super) use stores::{StoreScanContext, collect_module_import_store_declarations};
 
 use ast_utils::{
-    binding_pattern_simple_name, collect_top_level_declared_names, declarator_has_boolean_init,
+    binding_pattern_simple_name, collect_top_level_declarations, declarator_has_boolean_init,
     extract_all_names_from_binding_pattern,
 };
 use component_events::detect_create_event_dispatcher;
@@ -125,8 +125,10 @@ pub fn process_instance_script(
         // disambiguation (`$state` rune vs `$`-prefixed store of a declared
         // `state`) sees the complete scope — incl. a name declared by the very
         // statement whose initializer we're checking. See
-        // collect_top_level_declared_names.
-        let declared_names: HashSet<String> = collect_top_level_declared_names(&program.body);
+        // collect_top_level_declarations.
+        let top_level = collect_top_level_declarations(&program.body);
+        let declared_names = top_level.names;
+        let collect_possible_exports = top_level.has_local_export_specifiers;
         // Top-level `type` / `interface` declarations that may be hoistable
         // out of `function $$render()`. Resolved (with `instance_value_names`
         // and `module_*_names`) into `hoistable_type_ranges` after Pass 1.
@@ -162,6 +164,9 @@ pub fn process_instance_script(
                         ) {
                             props_rune_infos.push(info);
                         }
+                        if !collect_possible_exports {
+                            continue;
+                        }
                         if let oxc::BindingPattern::BindingIdentifier(id) = &declarator.id {
                             let name = id.name.to_string();
                             let ta_text = declarator.type_annotation.as_ref().and_then(|ta| {
@@ -175,7 +180,7 @@ pub fn process_instance_script(
                                 }
                             });
                             possible_exports.insert(
-                                name.to_owned(),
+                                name,
                                 PossibleExport {
                                     is_let,
                                     has_init: declarator.init.is_some(),
@@ -275,6 +280,9 @@ pub fn process_instance_script(
                             oxc::Declaration::VariableDeclaration(var_decl) => {
                                 // Only `let` is a reactive prop; `var`/`const` are
                                 // exports (mirror official isLet === NodeFlags.Let).
+                                if !collect_possible_exports {
+                                    continue;
+                                }
                                 let is_let =
                                     matches!(var_decl.kind, oxc::VariableDeclarationKind::Let);
                                 for declarator in var_decl.declarations.iter() {


### PR DESCRIPTION
## Summary

- detect local export specifiers during the existing top-level declaration prepass
- skip `possible_exports` name allocation, type-text copying, JSDoc scans, and HashMap insertion when no local specifier can observe that metadata
- preserve the existing path for `export { local }` and add focused gate coverage

This follows the official `ExportedNames` flow: possible declarations are only observed while handling a named local export declaration.

## Performance

The fixed CodSpeed svelte2tsx workload has no local export specifiers across its ten projects, so this removes metadata collection for roughly 57 variable bindings and more than 50 leading-JSDoc probes per full workload.

## Validation

Local validation was intentionally limited to `rustfmt` and `git diff --check`; build, test, compatibility, and CodSpeed validation are delegated to CI.