### PR TITLE
fix(svelte2tsx): port the official opening- and closing-tag whitespace accounting

### DIFF
--- a/.changeset/svelte2tsx-tag-whitespace-accounting.md
+++ b/.changeset/svelte2tsx-tag-whitespace-accounting.md
@@ -1,0 +1,14 @@
+---
+"@rsvelte/compiler": patch
+"@rsvelte/svelte2tsx": patch
+"@rsvelte/svelte-check": patch
+---
+
+fix(svelte2tsx): reproduce upstream's opening- and closing-tag whitespace
+accounting. Upstream lowers a tag by moving every kept source range to the end
+of the transformed range, collapsing each run of characters between two kept
+ranges to a single space; those spaces are observable in the output. rsvelte
+emitted a fixed single space instead, so `<div {...attributes}>` produced
+`{ ...attributes,}` where upstream produces `{...attributes,}`. Also rewrite
+`{:else}` character-by-character (`}else{`, no inserted spaces) and stop
+treating `{:else}{#if …}` as an `{:else if}`.

--- a/crates/rsvelte_projection/src/svelte2tsx/template/attributes/attribute.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/template/attributes/attribute.rs
@@ -981,7 +981,7 @@ mod tests {
 
         assert!(
             out.contains(
-                "{ \"disabled\":true,\"title\":`plain`,\"count\":value,\
+                "{        \"disabled\":true,\"title\":`plain`,\"count\":value,\
                  \"mixed\":`pre ${value} post`,\
                  ...__sveltets_2_empty({\"data-id\":`7`}),value,}"
             ),

--- a/crates/rsvelte_projection/src/svelte2tsx/template/attributes/class_style.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/template/attributes/class_style.rs
@@ -36,9 +36,8 @@ pub(crate) fn class_style_directive_seg(attr: &Attribute, source: &str) -> Optio
     let mut out: Vec<Seg> = Vec::new();
     match attr {
         Attribute::ClassDirective(class) => {
-            // `class:xx={expr}` → ` expr;` — type-check the toggle
+            // `class:xx={expr}` → `expr;` — type-check the toggle
             // expression as a standalone statement.
-            segs_push_lit(&mut out, " ");
             if let Some((s, e)) = get_expression_range(&class.expression) {
                 segs_push_src(&mut out, s, e);
             } else {
@@ -47,8 +46,8 @@ pub(crate) fn class_style_directive_seg(attr: &Attribute, source: &str) -> Optio
             segs_push_lit(&mut out, ";");
         }
         Attribute::StyleDirective(style) => {
-            // `style:xx={expr}` → ` __sveltets_2_ensureType(String, Number, expr);`
-            segs_push_lit(&mut out, " __sveltets_2_ensureType(String, Number, ");
+            // `style:xx={expr}` → `__sveltets_2_ensureType(String, Number, expr);`
+            segs_push_lit(&mut out, "__sveltets_2_ensureType(String, Number, ");
             match &style.value {
                 AttributeValue::True(_) => {
                     // Shorthand `style:color` → `…, color);` (implicit

--- a/crates/rsvelte_projection/src/svelte2tsx/template/attributes/mod.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/template/attributes/mod.rs
@@ -19,7 +19,7 @@ use crate::svelte2tsx::svelte2tsx::slice_src;
 use crate::svelte2tsx::template::ctx::ElementOpenerCommentIndex;
 use crate::svelte2tsx::template::nodes::attach_tag::format_attach_tag_segments;
 use crate::svelte2tsx::template::segs::{
-    Seg, segs_is_empty, segs_push_fmt, segs_push_lit, segs_push_src, segs_to_string,
+    Seg, segs_push_fmt, segs_push_lit, segs_push_src, segs_to_string,
 };
 use crate::svelte2tsx::template::utils::expr::{
     extend_expr_end_with_ts_postfix, get_expression_range, get_expression_text,
@@ -279,17 +279,9 @@ pub(super) fn build_attribute_segments(
         splice_trailing_segs(&mut segs, &trailing);
     }
 
-    if any_pushed && !segs_is_empty(&segs) {
-        // Leading single space: `{ "attr":val,}` (not `{"attr":val,}`).
-        // Inserted as a fresh first Lit so callers can replace/pad it
-        // without disturbing the inner segments.
-        let mut padded: Vec<Seg> = Vec::with_capacity(segs.len() + 1);
-        padded.push(Seg::Lit(" ".to_string()));
-        padded.extend(segs);
-        padded
-    } else {
-        segs
-    }
+    // The leading whitespace inside `{ … }` is not per-attribute: it is the
+    // opening tag's collapsed source gaps, counted by `opener_spacing`.
+    segs
 }
 
 /// Build the attributes/props string for a component, excluding `on:` directives.
@@ -305,8 +297,6 @@ pub(super) fn build_component_props_string(
     comments: &ElementOpenerCommentIndex,
 ) -> String {
     let mut parts: Vec<String> = Vec::new();
-    let mut has_on_directives = false;
-    let mut let_count = 0u32;
 
     for attr in attributes {
         match attr {
@@ -358,7 +348,6 @@ pub(super) fn build_component_props_string(
             }
             Attribute::OnDirective(_) => {
                 // Excluded from component props - handled as $on() calls
-                has_on_directives = true;
             }
             Attribute::ClassDirective(class) => {
                 parts.push(format_class_directive(class, source));
@@ -377,9 +366,7 @@ pub(super) fn build_component_props_string(
                 }
             }
             Attribute::LetDirective(_) => {
-                // Let directives don't produce props but add a space to match
-                // JS svelte2tsx whitespace behavior
-                let_count += 1;
+                // Let directives don't produce props
             }
             Attribute::AnimateDirective(_) => {
                 // Animate directives don't produce TSX output
@@ -399,23 +386,7 @@ pub(super) fn build_component_props_string(
         splice_trailing_text(last, &trailing_attr_comment_text(end, source, comments));
     }
 
-    let result = parts.join("");
-    let let_spaces = " ".repeat(let_count as usize);
-    if result.is_empty() {
-        if has_on_directives && let_count == 0 {
-            // When only on: directives were filtered out, add a space inside the
-            // empty braces to match JS svelte2tsx output: `props: { }`
-            " ".to_string()
-        } else if let_count > 0 {
-            // Each let: directive adds a space to match JS svelte2tsx whitespace
-            let_spaces
-        } else {
-            result
-        }
-    } else {
-        // Add let: directive spaces before the regular props
-        format!(" {}{}", let_spaces, result)
-    }
+    parts.join("")
 }
 
 /// Structured-bake variant of [`build_component_props_string`]. Same
@@ -429,8 +400,6 @@ pub(super) fn build_component_props_segments(
     drop_slot: bool,
 ) -> Vec<Seg> {
     let mut inner: Vec<Seg> = Vec::with_capacity(attributes.len().saturating_mul(2));
-    let mut has_on_directives = false;
-    let mut let_count = 0u32;
 
     let extend_segs = |dst: &mut Vec<Seg>, src: Vec<Seg>| {
         for s in src {
@@ -507,7 +476,7 @@ pub(super) fn build_component_props_segments(
                 segs_push_lit(&mut inner, ",");
             }
             Attribute::OnDirective(_) => {
-                has_on_directives = true;
+                // Excluded from component props - handled as $on() calls.
             }
             Attribute::ClassDirective(_) | Attribute::StyleDirective(_) => {
                 // `class:`/`style:` directives are element-only. Official
@@ -521,7 +490,7 @@ pub(super) fn build_component_props_segments(
                 // the `new …({...})` call (see build_component_directive_suffix).
             }
             Attribute::LetDirective(_) => {
-                let_count += 1;
+                // Let directives don't produce props.
             }
             Attribute::AnimateDirective(_) => {
                 // animate: lowers to an ensureAnimation suffix, not a prop.
@@ -538,19 +507,5 @@ pub(super) fn build_component_props_segments(
         splice_trailing_segs(&mut inner, &trailing);
     }
 
-    let let_spaces = " ".repeat(let_count as usize);
-    if segs_is_empty(&inner) {
-        if has_on_directives && let_count == 0 {
-            vec![Seg::Lit(" ".to_string())]
-        } else if let_count > 0 {
-            vec![Seg::Lit(let_spaces)]
-        } else {
-            Vec::new()
-        }
-    } else {
-        let mut out: Vec<Seg> = Vec::with_capacity(inner.len() + 1);
-        out.push(Seg::Lit(format!(" {}", let_spaces)));
-        out.extend(inner);
-        out
-    }
+    inner
 }

--- a/crates/rsvelte_projection/src/svelte2tsx/template/nodes/component_slots.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/template/nodes/component_slots.rs
@@ -19,6 +19,7 @@ use crate::svelte2tsx::template::attributes::spread::format_spread_attribute;
 use crate::svelte2tsx::template::attributes::transition::format_transition_directive;
 use crate::svelte2tsx::template::ctx::{Counter, TemplateNodeExt};
 use crate::svelte2tsx::template::segs::segs_to_string;
+use crate::svelte2tsx::template::utils::opener_spacing::{OpenerCtx, opener_spacing};
 use crate::svelte2tsx::template::utils::source::{find_closing_tag_start, find_opening_tag_end};
 use crate::svelte2tsx::template::walk::{process_fragment_inplace, process_node_inplace};
 
@@ -224,6 +225,10 @@ pub(crate) fn has_named_slot_children(fragment: &Fragment, source: &str) -> bool
 /// This handles:
 /// - Default slot wrapping with `let:` destructuring
 /// - Named slot wrapping with `slot="name"` children
+///
+/// Returns whether the default-slot block is still open at the closing tag and
+/// so must be closed by the caller's closing-tag overwrite.
+#[must_use]
 pub(crate) fn process_component_children_with_slots(
     comp: &Component,
     inst_var: &str,
@@ -233,7 +238,7 @@ pub(crate) fn process_component_children_with_slots(
     str: &mut MagicString<'_>,
     counter: &mut Counter,
     depth: u32,
-) {
+) -> bool {
     // Build the default slot destructuring if needed
     let let_destructure = if has_lets {
         build_let_destructure_string(&comp.attributes, source)
@@ -380,12 +385,14 @@ pub(crate) fn process_component_children_with_slots(
         if let Some(end) = prev_end {
             let closing_tag_start = find_closing_tag_start(source, comp.end);
             if closing_tag_start < comp.end {
-                str.append_left(closing_tag_start, "}");
-            } else {
-                str.append_left(end, "}");
+                // The closing tag's own collapsed gaps come first, so the caller
+                // emits this `}` as part of that overwrite.
+                return true;
             }
+            str.append_left(end, "}");
         }
     }
+    false
 }
 
 /// Handle a regular element child with `slot="name"` attribute inside a component.
@@ -424,13 +431,33 @@ pub(crate) fn handle_named_slot_element(
         source,
     );
 
+    let spacing = opener_spacing(
+        source,
+        el.start,
+        &el.name,
+        opening_tag_end,
+        Some((el.start + 1, el.start + 1 + el.name.len() as u32)),
+        &el.attributes,
+        &counter.element_opener_comments,
+        OpenerCtx {
+            is_element: true,
+            in_component_slot: true,
+            tag_name: &el.name,
+            is_slot_tag: false,
+        },
+    );
     // NOTE: the `let:foo={bar}` binding is reflected purely via the slot-def
     // destructure (`{ …, foo: bar } = …$$slot_def["…"]`); official emits NO
     // separate `bar;` reflection statement (that would duplicate the `{bar}`
     // content expression).
     let opener = format!(
-        "{}{{ svelteHTML.createElement(\"{}\", {{{}}});{}",
-        block_open, el.name, attrs_str, class_style_suffix
+        "{}{}{{ svelteHTML.createElement(\"{}\", {{{}{}}});{}",
+        " ".repeat(spacing.before_block),
+        block_open,
+        el.name,
+        " ".repeat(spacing.in_attr_object),
+        attrs_str,
+        class_style_suffix
     );
     str.overwrite(el.start, opening_tag_end, &opener);
 
@@ -551,7 +578,32 @@ pub(crate) fn handle_named_slot_component(
     );
 
     // Insert the block opener before the component
-    str.append_left(comp.start, &block_open);
+    // The component's own leading gaps precede the `$$slot_def[…]` prologue, so
+    // they are emitted here (`handle_component` skips them for this path).
+    let spacing = opener_spacing(
+        source,
+        comp.start,
+        &comp.name,
+        find_opening_tag_end(source, comp.start, comp.end, &comp.name, &comp.attributes),
+        source[comp.start as usize..]
+            .find(comp.name.as_str())
+            .map(|o| {
+                let start = comp.start + o as u32;
+                (start, start + comp.name.len() as u32)
+            }),
+        &comp.attributes,
+        &counter.element_opener_comments,
+        OpenerCtx {
+            is_element: false,
+            in_component_slot: true,
+            tag_name: &comp.name,
+            is_slot_tag: false,
+        },
+    );
+    str.append_left_fmt(
+        comp.start,
+        format_args!("{}{}", " ".repeat(spacing.before_block), block_open),
+    );
 
     // Process the component normally. Suppress its component-name reference at
     // the close so we can emit it *outside* the component's own block (matching
@@ -566,7 +618,8 @@ pub(crate) fn handle_named_slot_component(
     // close the named-slot block.
     let closing_tag_start = find_closing_tag_start(source, comp.end);
     if closing_tag_start < comp.end {
-        str.append_left_fmt(comp.end, format_args!(" {}}}", comp.name));
+        // The closing tag's gaps were emitted by the component's own overwrite.
+        str.append_left_fmt(comp.end, format_args!("{}}}", comp.name));
     } else {
         str.append_left(comp.end, "}");
     }
@@ -619,10 +672,5 @@ pub(crate) fn build_named_slot_element_attrs(attributes: &[Attribute], source: &
         }
     }
 
-    let result = parts.join("");
-    if result.is_empty() {
-        result
-    } else {
-        format!(" {}", result)
-    }
+    parts.join("")
 }

--- a/crates/rsvelte_projection/src/svelte2tsx/template/nodes/dynamic_element.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/template/nodes/dynamic_element.rs
@@ -17,6 +17,7 @@ use crate::svelte2tsx::template::attributes::let_::build_let_destructure_string;
 use crate::svelte2tsx::template::ctx::Counter;
 use crate::svelte2tsx::template::segs::segs_to_string;
 use crate::svelte2tsx::template::utils::expr::{get_expression_range, get_expression_text};
+use crate::svelte2tsx::template::utils::opener_spacing::{OpenerCtx, opener_spacing};
 use crate::svelte2tsx::template::utils::source::{find_closing_tag_start, find_opening_tag_end};
 use crate::svelte2tsx::template::walk::process_fragment_inplace;
 
@@ -45,14 +46,13 @@ pub(crate) fn handle_svelte_dynamic_element(
     let named_slot: Option<(String, String)> = saved_slot.as_ref().and_then(|inst| {
         get_slot_attr_value(&el.attributes, source).map(|name| (inst.clone(), name))
     });
-    if let Some((ref inst, ref target_slot)) = named_slot {
+    let named_slot_block = named_slot.as_ref().map(|(inst, target_slot)| {
         let let_destructure = build_let_destructure_string(&el.attributes, source);
-        let block_open = format!(
+        format!(
             "{{const {{/*\u{03A9}ignore_start\u{03A9}*/$$_$$/*\u{03A9}ignore_end\u{03A9}*/,{}}} = {}.$$slot_def[\"{}\"];$$_$$;",
             let_destructure, inst, target_slot
-        );
-        str.prepend_left(el.start, &block_open);
-    }
+        )
+    });
 
     let raw_tag_text = get_expression_text(&el.tag, source);
     // If the `this` attribute value is a plain string literal (this="tag"),
@@ -86,6 +86,40 @@ pub(crate) fn handle_svelte_dynamic_element(
             &counter.element_opener_comments,
             saved_slot.is_some(),
         )
+    };
+
+    // `<svelte:element this={tag}>` names itself with the tag expression; a
+    // literal `this="div"` is emitted as a string and keeps no source range.
+    let tag_range = if tag_text.starts_with('"') {
+        None
+    } else {
+        get_expression_range(&el.tag)
+    };
+    let spacing = opener_spacing(
+        source,
+        el.start,
+        &el.name,
+        opening_tag_end,
+        tag_range,
+        &el.attributes,
+        &counter.element_opener_comments,
+        OpenerCtx {
+            is_element: true,
+            in_component_slot: saved_slot.is_some(),
+            tag_name: &el.name,
+            is_slot_tag: false,
+        },
+    );
+    // The slot-def block sits inside the opening tag's leading whitespace, so it
+    // is emitted after the indent rather than before it.
+    let indent = " ".repeat(spacing.before_block);
+    if let Some(block) = named_slot_block {
+        str.prepend_left(el.start, &format!("{}{}", indent, block));
+    }
+    let indent = if named_slot.is_some() {
+        String::new()
+    } else {
+        indent
     };
 
     // `use:` / `transition:` / `animate:` directives, same V4 emission as on a
@@ -123,15 +157,12 @@ pub(crate) fn handle_svelte_dynamic_element(
             .ends_with("/>")
             || crate::compiler::utils::is_void_element(&el.name));
 
-    let attrs_self = if attrs_str.is_empty() {
-        "  "
+    let attrs_inner = if spacing.in_attr_object > 0 {
+        let mut padded = " ".repeat(spacing.in_attr_object);
+        padded.push_str(&attrs_str);
+        padded
     } else {
-        &attrs_str
-    };
-    let attrs_open = if attrs_str.is_empty() {
-        " "
-    } else {
-        &attrs_str
+        attrs_str
     };
     // With directives an extra inner block scope wraps the createElement so the
     // action declarations (in `directive_prefix`) are in scope: ` {<prefix>{ … }}`.
@@ -224,19 +255,21 @@ pub(crate) fn handle_svelte_dynamic_element(
     if is_self_closing {
         // Self-closing: outer block, optional inner directive block, close both.
         let opener = format!(
-            " {{{}{}{}{}}}",
+            "{}{{{}{}{}{}}}",
+            indent,
             directive_prefix,
             inner_open,
-            create(attrs_self),
+            create(&attrs_inner),
             inner_close
         );
         str.overwrite(el.start, el.end, &opener);
     } else {
         let opener = format!(
-            " {{{}{}{}",
+            "{}{{{}{}{}",
+            indent,
             directive_prefix,
             inner_open,
-            create(attrs_open)
+            create(&attrs_inner)
         );
         str.overwrite(el.start, opening_tag_end, &opener);
 

--- a/crates/rsvelte_projection/src/svelte2tsx/template/nodes/element.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/template/nodes/element.rs
@@ -14,9 +14,8 @@ use crate::svelte2tsx::template::attributes::directive_suffix::{
 };
 use crate::svelte2tsx::template::attributes::{build_attribute_segments, build_attributes_string};
 use crate::svelte2tsx::template::ctx::Counter;
-use crate::svelte2tsx::template::segs::{
-    Seg, bake_out_of_order_src, emit_segmented_overwrite, segs_is_empty, segs_trim_start,
-};
+use crate::svelte2tsx::template::segs::{Seg, bake_out_of_order_src, emit_segmented_overwrite};
+use crate::svelte2tsx::template::utils::opener_spacing::{OpenerCtx, opener_spacing};
 use crate::svelte2tsx::template::utils::source::{
     closing_tag_name_matches, find_closing_tag_start, find_opening_tag_end,
 };
@@ -118,16 +117,24 @@ pub(crate) fn handle_regular_element(
         Some(opener_content_start),
     );
 
-    // Official always emits exactly ONE inherent space after the `{` of the
-    // attribute object, regardless of the source whitespace between the tag name
-    // and the first attribute (verified: `<button onclick>`, `<button  onclick>`,
-    // `<button\n\tonclick>` all → `{ "onclick":… }`). oxfmt normalises this away
-    // for valid output, but a raw top-level-await component keeps it exact.
-    let attrs_empty_before_pad = segs_is_empty(&attr_segs);
-    if !el.attributes.is_empty() && !attrs_empty_before_pad {
-        segs_trim_start(&mut attr_segs);
+    let spacing = opener_spacing(
+        source,
+        el.start,
+        &el.name,
+        opening_tag_end,
+        Some((el.start + 1, opener_content_start)),
+        &el.attributes,
+        &counter.element_opener_comments,
+        OpenerCtx {
+            is_element: true,
+            in_component_slot: saved_slot.is_some(),
+            tag_name: &el.name,
+            is_slot_tag: false,
+        },
+    );
+    if spacing.in_attr_object > 0 {
         let mut padded: Vec<Seg> = Vec::with_capacity(attr_segs.len() + 1);
-        padded.push(Seg::Lit(" ".to_string()));
+        padded.push(Seg::Lit(" ".repeat(spacing.in_attr_object)));
         padded.extend(attr_segs);
         attr_segs = padded;
     }
@@ -187,13 +194,6 @@ pub(crate) fn handle_regular_element(
         &el.name,
     );
 
-    // When all surviving props are empty but a `bind:` / `class:` / `style:`
-    // directive was stripped, JS reference still leaves whitespace inside
-    // `{ }`. Add a single space so `createElement("div", { })` matches.
-    if segs_is_empty(&attr_segs) && !segs_is_empty(&suffix_segs) {
-        attr_segs.push(Seg::Lit(" ".into()));
-    }
-
     // Build the opener as a `Vec<Seg>` (header lit + attr segs + trailer
     // lit) and apply via `emit_segmented_overwrite`. Action declarations
     // (if any) are emitted *before* the inner `{ … createElement(…); … }`
@@ -204,15 +204,16 @@ pub(crate) fn handle_regular_element(
     } else {
         String::new()
     };
+    let indent = " ".repeat(spacing.before_block);
     let header_lit = if !directive_prefix.is_empty() {
         format!(
-            " {{{}{{ {}svelteHTML.createElement(\"{}\"{}, {{",
-            directive_prefix, element_var_decl, el.name, actions_arg,
+            "{}{{{}{{ {}svelteHTML.createElement(\"{}\"{}, {{",
+            indent, directive_prefix, element_var_decl, el.name, actions_arg,
         )
     } else {
         format!(
-            " {{ {}svelteHTML.createElement(\"{}\"{}, {{",
-            element_var_decl, el.name, actions_arg,
+            "{}{{ {}svelteHTML.createElement(\"{}\"{}, {{",
+            indent, element_var_decl, el.name, actions_arg,
         )
     };
     // The trailer closes the props object + createElement call (`}});`), then
@@ -303,8 +304,25 @@ pub(crate) fn handle_title_element(
         counter.slot_inst.is_some(),
     );
 
+    let spacing = opener_spacing(
+        source,
+        el.start,
+        &el.name,
+        opening_tag_end,
+        Some((el.start + 1, el.start + 1 + el.name.len() as u32)),
+        &el.attributes,
+        &counter.element_opener_comments,
+        OpenerCtx {
+            is_element: true,
+            in_component_slot: counter.slot_inst.is_some(),
+            tag_name: &el.name,
+            is_slot_tag: false,
+        },
+    );
     let opener = format!(
-        " {{ svelteHTML.createElement(\"title\", {{{}}});",
+        "{}{{ svelteHTML.createElement(\"title\", {{{}{}}});",
+        " ".repeat(spacing.before_block),
+        " ".repeat(spacing.in_attr_object),
         attrs_str
     );
     str.overwrite(el.start, opening_tag_end, &opener);

--- a/crates/rsvelte_projection/src/svelte2tsx/template/nodes/if_else_block.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/template/nodes/if_else_block.rs
@@ -119,9 +119,11 @@ pub(crate) fn handle_if_block(
             block.end
         };
 
-        // Check if the alternate is an elseif
-        let has_elseif =
-            alternate.nodes.len() == 1 && matches!(alternate.nodes[0], TemplateNode::IfBlock(_));
+        // Check if the alternate is an elseif. `{:else}{#if …}{/if}` also nests a
+        // lone IfBlock, so the node's own `elseif` flag decides (upstream reads
+        // `ifBlock.elseif`), not the shape of the alternate.
+        let has_elseif = alternate.nodes.len() == 1
+            && matches!(&alternate.nodes[0], TemplateNode::IfBlock(nested) if nested.elseif);
 
         if has_elseif {
             // Don't insert anything between consequent end and the nested
@@ -158,8 +160,26 @@ pub(crate) fn handle_if_block(
                 ((p + 1).min(bytes.len())) as u32
             };
 
-            // Overwrite {:else} with `} else {`
-            str.overwrite(consequent_end, alternate_start, "} else {");
+            // Mirror `htmlxtojsx_v2/nodes/IfElseBlock.ts::handleElse`: unlike the
+            // `elseif` header (which uses the literal `} else if (`, spaces
+            // included), the plain `{:else}` tag is rewritten character-by-character
+            // — the opening `{` becomes `}`, the closing `}` becomes `{`, and the
+            // `:` is dropped — leaving `else` (and any surrounding source
+            // whitespace) untouched in between. For the common `{:else}` spelling
+            // this produces `}else{`, with no inserted spaces.
+            //
+            // The three positions are found by scanning *backwards* from the else
+            // branch's start, as upstream does: a forward scan from the consequent
+            // would run into a nested block's own braces first.
+            let else_close = source[..alternate_start as usize].rfind('}');
+            let colon = else_close.and_then(|end| source[..end].rfind(":else"));
+            let else_open = colon.and_then(|word| source[..word].rfind('{'));
+            if let (Some(else_open), Some(colon), Some(else_close)) = (else_open, colon, else_close)
+            {
+                str.overwrite(else_open as u32, else_open as u32 + 1, "}");
+                str.overwrite(else_close as u32, else_close as u32 + 1, "{");
+                str.remove(colon as u32, colon as u32 + 1);
+            }
 
             // Hoist alternate-branch snippets above sibling declarations too.
             hoist_snippet_blocks(alternate, source, str);

--- a/crates/rsvelte_projection/src/svelte2tsx/template/nodes/inline_component.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/template/nodes/inline_component.rs
@@ -22,17 +22,16 @@ use crate::svelte2tsx::template::attributes::{
     build_component_props_segments, build_component_props_string,
 };
 use crate::svelte2tsx::template::ctx::Counter;
-use crate::svelte2tsx::template::segs::{
-    Seg, bake_out_of_order_src, emit_segmented_overwrite, segs_is_empty, segs_trim_start,
-};
+use crate::svelte2tsx::template::segs::{Seg, bake_out_of_order_src, emit_segmented_overwrite};
 use crate::svelte2tsx::template::utils::expr::{
     extend_expr_end_with_ts_postfix, get_binding_lhs_text, get_expression_end_stripping_ts,
     get_expression_range, get_expression_text, get_set_binding_ranges,
 };
 use crate::svelte2tsx::template::utils::names::reversed_component_name;
-use crate::svelte2tsx::template::utils::source::{
-    count_tag_to_attr_spaces, find_closing_tag_start, find_opening_tag_end,
+use crate::svelte2tsx::template::utils::opener_spacing::{
+    OpenerCtx, closing_tag_spacing, opener_spacing,
 };
+use crate::svelte2tsx::template::utils::source::{find_closing_tag_start, find_opening_tag_end};
 use crate::svelte2tsx::template::walk::{process_fragment_inplace, process_node_inplace};
 
 use super::component_slots::{
@@ -41,6 +40,22 @@ use super::component_slots::{
 };
 use super::slot_element::get_slot_attr_value;
 use super::snippet_block::handle_snippet_block_as_component_prop;
+
+/// The `</Component>` → `Component}` mapping upstream keeps for the closing tag.
+/// The `svelte:` tags keep nothing there, and neither does a component whose
+/// closing tag is missing.
+fn component_closing_name_range(
+    name: &str,
+    closing_tag_start: u32,
+    node_end: u32,
+) -> Option<(u32, u32)> {
+    (!name.starts_with("svelte:") && closing_tag_start != node_end).then(|| {
+        (
+            closing_tag_start + 2,
+            closing_tag_start + 2 + name.len() as u32,
+        )
+    })
+}
 
 /// Handle a Svelte component: `<Component ...>`.
 ///
@@ -185,50 +200,57 @@ pub(crate) fn handle_component(
     );
 
     // Add extra whitespace to match JS svelte2tsx position-preserving behavior
-    let attrs_empty_before_pad = segs_is_empty(&attr_segs);
-    if !comp.attributes.is_empty() && !attrs_empty_before_pad {
-        let extra_spaces = count_tag_to_attr_spaces(&comp.name, comp.start, source);
-        if extra_spaces >= 1 {
-            let total_spaces = extra_spaces + 1;
-            segs_trim_start(&mut attr_segs);
-            let mut padded: Vec<Seg> = Vec::with_capacity(attr_segs.len() + 1);
-            padded.push(Seg::Lit(" ".repeat(total_spaces)));
-            padded.extend(attr_segs);
-            attr_segs = padded;
-        }
+    let name_start = source[comp.start as usize..]
+        .find(comp.name.as_str())
+        .map_or(comp.start + 1, |o| comp.start + o as u32);
+    let spacing = opener_spacing(
+        source,
+        comp.start,
+        &comp.name,
+        opening_tag_end,
+        Some((name_start, name_start + comp.name.len() as u32)),
+        &comp.attributes,
+        &counter.element_opener_comments,
+        OpenerCtx {
+            is_element: false,
+            in_component_slot: named_slot_close,
+            tag_name: &comp.name,
+            is_slot_tag: false,
+        },
+    );
+    if spacing.in_attr_object > 0 {
+        let mut padded: Vec<Seg> = Vec::with_capacity(attr_segs.len() + 1);
+        padded.push(Seg::Lit(" ".repeat(spacing.in_attr_object)));
+        padded.extend(attr_segs);
+        attr_segs = padded;
     }
+    // A named-slot child's `$$slot_def[…]` prologue is emitted by the caller
+    // ahead of this block, and takes the leading gaps with it.
+    let block_indent = if named_slot_close {
+        String::new()
+    } else {
+        " ".repeat(spacing.before_block)
+    };
 
     // Add children prop for Svelte 5 if component has children. Inserted
     // at the beginning of the props object, AFTER any leading whitespace
     // from the attribute spacing (when applicable).
     if is_svelte5 && has_children {
         let children_text = "children:() => { return __sveltets_2_any(0); },";
-        if segs_is_empty(&attr_segs) {
-            attr_segs = vec![Seg::Lit(children_text.to_string())];
-        } else if has_lets || children_have_named_slots {
-            // Slot let-forwarding owns the leading whitespace already.
-            segs_trim_start(&mut attr_segs);
-            let mut prefixed: Vec<Seg> = Vec::with_capacity(attr_segs.len() + 1);
-            prefixed.push(Seg::Lit(children_text.to_string()));
-            prefixed.extend(attr_segs);
-            attr_segs = prefixed;
-        } else {
-            // Has other attrs: insert children between the leading whitespace
-            // `Lit` and the first attribute.
-            let mut leading_ws = String::new();
-            if let Some(Seg::Lit(first)) = attr_segs.first_mut() {
-                let trimmed = first.trim_start_matches(|c: char| c.is_whitespace());
-                leading_ws.push_str(&first[..first.len() - trimmed.len()]);
-                *first = trimmed.to_string();
-                if first.is_empty() {
-                    attr_segs.remove(0);
-                }
+        // Insert between the leading whitespace `Lit` and the first attribute.
+        let mut leading_ws = String::new();
+        if let Some(Seg::Lit(first)) = attr_segs.first_mut() {
+            let trimmed = first.trim_start_matches(|c: char| c.is_whitespace());
+            leading_ws.push_str(&first[..first.len() - trimmed.len()]);
+            *first = trimmed.to_string();
+            if first.is_empty() {
+                attr_segs.remove(0);
             }
-            let mut prefixed: Vec<Seg> = Vec::with_capacity(attr_segs.len() + 2);
-            prefixed.push(Seg::Lit(format!("{}{}", leading_ws, children_text)));
-            prefixed.extend(attr_segs);
-            attr_segs = prefixed;
         }
+        let mut prefixed: Vec<Seg> = Vec::with_capacity(attr_segs.len() + 2);
+        prefixed.push(Seg::Lit(format!("{}{}", leading_ws, children_text)));
+        prefixed.extend(attr_segs);
+        attr_segs = prefixed;
     }
 
     // Build the replacement for the opening tag.
@@ -303,16 +325,16 @@ pub(crate) fn handle_component(
         };
         (
             format!(
-                " {{ const {}C = __sveltets_2_ensureComponent({}); const {} = new {}C({{ target: __sveltets_2_any(), props: {{",
-                inst_var, comp.name, inst_var, inst_var,
+                "{}{{ const {}C = __sveltets_2_ensureComponent({}); const {} = new {}C({{ target: __sveltets_2_any(), props: {{",
+                block_indent, inst_var, comp.name, inst_var, inst_var,
             ),
             format!("}}}});{}{}", component_bind_suffix, on_calls),
         )
     } else {
         (
             format!(
-                " {{ const {}C = __sveltets_2_ensureComponent({}); new {}C({{ target: __sveltets_2_any(), props: {{",
-                inst_var, comp.name, inst_var,
+                "{}{{ const {}C = __sveltets_2_ensureComponent({}); new {}C({{ target: __sveltets_2_any(), props: {{",
+                block_indent, inst_var, comp.name, inst_var,
             ),
             "}});".to_string(),
         )
@@ -344,9 +366,10 @@ pub(crate) fn handle_component(
     let is_self_closing = closing_tag_start >= comp.end;
 
     // Handle children with slot awareness
+    let mut deferred_slot_close = false;
     if has_lets || children_have_named_slots || children_have_default_slot_lets {
         // Process children with slot scoping
-        process_component_children_with_slots(
+        deferred_slot_close = process_component_children_with_slots(
             comp,
             &inst_var,
             has_lets,
@@ -435,9 +458,11 @@ pub(crate) fn handle_component(
         .iter()
         .any(|n| !matches!(n, TemplateNode::Text(t) if t.start >= t.end));
     let needs_inline_block = has_lets && !has_children_for_block;
+    // Body of the `let:` scope block, without the `}` that closes it — upstream
+    // closes it from the closing-tag transform, i.e. after that tag's gaps.
     let inline_block = if needs_inline_block {
         format!(
-            "{{const {{/*\u{03A9}ignore_start\u{03A9}*/$$_$$/*\u{03A9}ignore_end\u{03A9}*/,{}}} = {}.$$slot_def.default;$$_$$;}}",
+            "{{const {{/*\u{03A9}ignore_start\u{03A9}*/$$_$$/*\u{03A9}ignore_end\u{03A9}*/,{}}} = {}.$$slot_def.default;$$_$$;",
             build_let_destructure_string(&comp.attributes, source),
             inst_var
         )
@@ -452,19 +477,35 @@ pub(crate) fn handle_component(
             // bindings have a scope.
             str.append_left(closing_tag_start, &inline_block);
         }
+        let spaces = " ".repeat(closing_tag_spacing(
+            closing_tag_start,
+            comp.end,
+            component_closing_name_range(&comp.name, closing_tag_start, comp.end),
+        ));
+        let slot_close = if needs_inline_block || deferred_slot_close {
+            "}"
+        } else {
+            ""
+        };
         if named_slot_close {
             // Close just this component's block; the named-slot caller emits
             // the component-name reference + the named-slot-block close after.
-            str.overwrite(closing_tag_start, comp.end, " }");
+            str.overwrite_fmt(
+                closing_tag_start,
+                comp.end,
+                format_args!("{}{}}}", spaces, slot_close),
+            );
         } else {
             str.overwrite_fmt(
                 closing_tag_start,
                 comp.end,
-                format_args!(" {}}}", comp.name),
+                format_args!("{}{}{}}}", spaces, slot_close, comp.name),
             );
         }
     } else if needs_inline_block {
-        str.append_left_fmt(comp.end, format_args!("{}{}}}", inline_block, comp.name));
+        // A self-closing tag has no `</Component>` for upstream to map, so the
+        // name is never referenced here — only the `let:` scope and block close.
+        str.append_left_fmt(comp.end, format_args!("{}}}}}", inline_block));
     } else {
         str.append_left(comp.end, "}");
     }
@@ -507,14 +548,25 @@ pub(crate) fn handle_svelte_component(
         build_component_props_string(&comp.attributes, source, &counter.element_opener_comments);
 
     // Add extra whitespace to match JS svelte2tsx position-preserving behavior
-    if !comp.attributes.is_empty() && !attrs_str.is_empty() {
-        let extra_spaces = count_tag_to_attr_spaces("svelte:component", comp.start, source);
-        if extra_spaces >= 1 {
-            let total_spaces = extra_spaces + 1;
-            let mut padded = " ".repeat(total_spaces);
-            padded.push_str(attrs_str.trim_start());
-            attrs_str = padded;
-        }
+    let scomp_spacing = opener_spacing(
+        source,
+        comp.start,
+        &comp.name,
+        opening_tag_end,
+        get_expression_range(&comp.expression),
+        &comp.attributes,
+        &counter.element_opener_comments,
+        OpenerCtx {
+            is_element: false,
+            in_component_slot: false,
+            tag_name: &comp.name,
+            is_slot_tag: false,
+        },
+    );
+    if scomp_spacing.in_attr_object > 0 {
+        let mut padded = " ".repeat(scomp_spacing.in_attr_object);
+        padded.push_str(&attrs_str);
+        attrs_str = padded;
     }
 
     // Check if component has meaningful children for Svelte 5 children prop
@@ -527,15 +579,8 @@ pub(crate) fn handle_svelte_component(
     if is_svelte5 && has_children {
         let children_text = "children:() => { return __sveltets_2_any(0); },";
         let trimmed = attrs_str.trim_start();
-        if trimmed.is_empty() {
-            attrs_str = children_text.to_string();
-        } else {
-            let leading_ws: String = attrs_str
-                .chars()
-                .take_while(|c| c.is_whitespace())
-                .collect();
-            attrs_str = format!("{}{}{}", leading_ws, children_text, trimmed);
-        }
+        let leading_ws = &attrs_str[..attrs_str.len() - trimmed.len()];
+        attrs_str = format!("{}{}{}", leading_ws, children_text, trimmed);
     }
 
     let inst_var = reversed_component_name("svelte_component", depth);
@@ -599,13 +644,24 @@ pub(crate) fn handle_svelte_component(
             String::new()
         };
         format!(
-            " {{ const {}C = __sveltets_2_ensureComponent({}); const {} = new {}C({{ target: __sveltets_2_any(), props: {{{}}}}});{}{}",
-            inst_var, expr_text, inst_var, inst_var, attrs_str, component_bind_suffix, on_calls
+            "{}{{ const {}C = __sveltets_2_ensureComponent({}); const {} = new {}C({{ target: __sveltets_2_any(), props: {{{}}}}});{}{}",
+            " ".repeat(scomp_spacing.before_block),
+            inst_var,
+            expr_text,
+            inst_var,
+            inst_var,
+            attrs_str,
+            component_bind_suffix,
+            on_calls
         )
     } else {
         format!(
-            " {{ const {}C = __sveltets_2_ensureComponent({}); new {}C({{ target: __sveltets_2_any(), props: {{{}}}}});",
-            inst_var, expr_text, inst_var, attrs_str
+            "{}{{ const {}C = __sveltets_2_ensureComponent({}); new {}C({{ target: __sveltets_2_any(), props: {{{}}}}});",
+            " ".repeat(scomp_spacing.before_block),
+            inst_var,
+            expr_text,
+            inst_var,
+            attrs_str
         )
     };
 
@@ -633,7 +689,14 @@ pub(crate) fn handle_svelte_component(
     let closing_tag_start = find_closing_tag_start(source, comp.end);
     let closing_text = if has_lets_scomp { "}}" } else { "}" };
     if closing_tag_start < comp.end {
-        str.overwrite(closing_tag_start, comp.end, closing_text);
+        // `svelte:component` keeps no name mapping on its closing tag, so its
+        // collapsed gaps are all that precede the closers.
+        let spaces = " ".repeat(closing_tag_spacing(closing_tag_start, comp.end, None));
+        str.overwrite_fmt(
+            closing_tag_start,
+            comp.end,
+            format_args!("{}{}", spaces, closing_text),
+        );
     } else {
         str.append_left(comp.end, closing_text);
     }
@@ -713,15 +776,33 @@ pub(crate) fn handle_svelte_self(
         );
     }
 
+    // `svelte:self` emits its opener as a pure string, so it contributes no
+    // source range before the attribute list.
+    let self_spacing = opener_spacing(
+        source,
+        el.start,
+        &el.name,
+        opening_tag_end,
+        None,
+        &el.attributes,
+        &counter.element_opener_comments,
+        OpenerCtx {
+            is_element: false,
+            in_component_slot: false,
+            tag_name: &el.name,
+            is_slot_tag: false,
+        },
+    );
     let props_inner = if prop_parts.is_empty() {
-        " ".to_string()
+        " ".repeat(self_spacing.in_attr_object)
     } else {
-        let extra_spaces = count_tag_to_attr_spaces(&el.name, el.start, source);
-        if extra_spaces >= 1 {
-            format!("{}{}", " ".repeat(extra_spaces + 1), prop_parts.join(""))
-        } else {
-            format!(" {}", prop_parts.join(""))
-        }
+        // `svelte:self` emits its opener as a pure string, so it contributes no
+        // source range before the attribute list.
+        format!(
+            "{}{}",
+            " ".repeat(self_spacing.in_attr_object),
+            prop_parts.join("")
+        )
     };
 
     let needs_inst_var = has_on_directives || has_lets;
@@ -735,11 +816,17 @@ pub(crate) fn handle_svelte_self(
 
     let create_call = if let Some(ref name) = var_name {
         format!(
-            " {{ const {} = __sveltets_2_createComponentAny({{{}}});",
-            name, props_inner
+            "{}{{ const {} = __sveltets_2_createComponentAny({{{}}});",
+            " ".repeat(self_spacing.before_block),
+            name,
+            props_inner
         )
     } else {
-        format!(" {{ __sveltets_2_createComponentAny({{{}}});", props_inner)
+        format!(
+            "{}{{ __sveltets_2_createComponentAny({{{}}});",
+            " ".repeat(self_spacing.before_block),
+            props_inner
+        )
     };
 
     let mut opener = create_call;
@@ -786,5 +873,12 @@ pub(crate) fn handle_svelte_self(
     // svelte:self is a component → children at depth+1.
     process_fragment_inplace(&el.fragment, source, options, str, counter, depth + 1);
     let trailing = if has_lets { "}}" } else { "}" };
-    str.overwrite(closing_tag_start, el.end, trailing);
+    // `svelte:self` keeps no name mapping on its closing tag, so its collapsed
+    // gaps are all that precede the closers.
+    let spaces = " ".repeat(closing_tag_spacing(closing_tag_start, el.end, None));
+    str.overwrite_fmt(
+        closing_tag_start,
+        el.end,
+        format_args!("{}{}", spaces, trailing),
+    );
 }

--- a/crates/rsvelte_projection/src/svelte2tsx/template/nodes/slot_element.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/template/nodes/slot_element.rs
@@ -10,6 +10,7 @@ use crate::svelte2tsx::template::attributes::let_::build_let_destructure_string;
 use crate::svelte2tsx::template::attributes::spread::format_spread_attribute;
 use crate::svelte2tsx::template::ctx::Counter;
 use crate::svelte2tsx::template::utils::expr::get_expression_text;
+use crate::svelte2tsx::template::utils::opener_spacing::{OpenerCtx, opener_spacing};
 use crate::svelte2tsx::template::utils::source::{find_closing_tag_start, find_opening_tag_end};
 use crate::svelte2tsx::template::walk::process_fragment_inplace;
 
@@ -40,14 +41,13 @@ pub(crate) fn handle_slot_element(
     let named_slot: Option<(String, String)> = saved_slot.as_ref().and_then(|inst| {
         get_slot_attr_value(&el.attributes, source).map(|name| (inst.clone(), name))
     });
-    if let Some((ref inst, ref target_slot)) = named_slot {
+    let named_slot_block = named_slot.as_ref().map(|(inst, target_slot)| {
         let let_destructure = build_let_destructure_string(&el.attributes, source);
-        let block_open = format!(
+        format!(
             "{{const {{/*\u{03A9}ignore_start\u{03A9}*/$$_$$/*\u{03A9}ignore_end\u{03A9}*/,{}}} = {}.$$slot_def[\"{}\"];$$_$$;",
             let_destructure, inst, target_slot
-        );
-        str.prepend_left(el.start, &block_open);
-    }
+        )
+    });
 
     let opening_tag_end =
         find_opening_tag_end(source, el.start, el.end, el.name.as_str(), &el.attributes);
@@ -58,31 +58,54 @@ pub(crate) fn handle_slot_element(
     // Check for bind:this directive
     let bind_this_expr = get_bind_this_expr(&el.attributes, source);
 
-    // Build slot props string (excluding `name` attribute and `bind:this`).
-    // Official emits a leading space inside a non-empty props object
-    // (`{ "message":… }`); empty stays `{}`. oxfmt normalises this for valid
-    // output, but a top-level-await slot is emitted raw, where the space matters.
-    // Note: `build_slot_props_string` already prepends a space to non-empty
-    // results, so we must NOT add another space here in the format string.
+    // Build slot props string (excluding the `name` attribute and `bind:this`).
     let slot_props = build_slot_props_string(&el.attributes, source);
-    let slot_props_obj = if slot_props.is_empty() {
+    // `__sveltets_createSlot("name"` keeps the source range of a static slot
+    // name; a defaulted (absent) name is a literal and keeps none.
+    let name_range = get_slot_name_range(&el.attributes);
+    let spacing = opener_spacing(
+        source,
+        el.start,
+        &el.name,
+        opening_tag_end,
+        name_range,
+        &el.attributes,
+        &counter.element_opener_comments,
+        OpenerCtx {
+            is_element: true,
+            in_component_slot: saved_slot.is_some(),
+            tag_name: &el.name,
+            is_slot_tag: true,
+        },
+    );
+    let slot_props_obj = if slot_props.is_empty() && spacing.in_attr_object == 0 {
         "{}".to_string()
     } else {
-        format!("{{{}}}", slot_props)
+        format!("{{{}{}}}", " ".repeat(spacing.in_attr_object), slot_props)
     };
 
-    // Build the slot call
+    // The slot-def block sits inside the opening tag's leading whitespace, so it
+    // is emitted after the indent rather than before it.
+    let indent = " ".repeat(spacing.before_block);
+    let indent = match named_slot_block {
+        Some(block) => {
+            str.prepend_left(el.start, &format!("{}{}", indent, block));
+            String::new()
+        }
+        None => indent,
+    };
     let opener = if bind_this_expr.is_some() {
         format!(
-            " {{ const $$_slot{} = __sveltets_createSlot(\"{}\", {});",
+            "{}{{ const $$_slot{} = __sveltets_createSlot(\"{}\", {});",
+            indent,
             counter.next_slot(),
             slot_name,
             slot_props_obj
         )
     } else {
         format!(
-            " {{ __sveltets_createSlot(\"{}\", {});",
-            slot_name, slot_props_obj
+            "{}{{ __sveltets_createSlot(\"{}\", {});",
+            indent, slot_name, slot_props_obj
         )
     };
     str.overwrite(el.start, opening_tag_end, &opener);
@@ -181,6 +204,23 @@ pub(crate) fn dollar_slot_name(attributes: &[Attribute]) -> String {
         }
     }
     slot_name
+}
+
+/// Source range of the `<slot name=…>` value that the start transformation
+/// keeps (`surroundWith(str, [slotName.start, slotName.end], '"', '"')`); `None`
+/// when the name defaults, which official emits as a literal.
+fn get_slot_name_range(attributes: &[Attribute]) -> Option<(u32, u32)> {
+    attributes.iter().find_map(|attr| match attr {
+        Attribute::Attribute(node) if node.name == "name" => match &node.value {
+            AttributeValue::Sequence(parts) => parts.first().map(|part| match part {
+                AttributeValuePart::Text(text) => (text.start, text.end),
+                AttributeValuePart::ExpressionTag(tag) => (tag.start, tag.end),
+            }),
+            AttributeValue::Expression(tag) => Some((tag.start, tag.end)),
+            AttributeValue::True(_) => None,
+        },
+        _ => None,
+    })
 }
 
 pub(crate) fn get_slot_name(attributes: &[Attribute], source: &str) -> String {
@@ -285,16 +325,7 @@ pub(crate) fn build_slot_props_string(attributes: &[Attribute], source: &str) ->
         }
     }
 
-    let result = parts.join("");
-    if result.is_empty() {
-        // Empty props: `{}` (no space)
-        String::new()
-    } else {
-        // Slot props go inside `{<props>}`. Official preserves the source
-        // whitespace between `<slot` and the first attribute (always at least
-        // one space) as a leading space after `{`, e.g. `{ "message":… }`.
-        format!(" {result}")
-    }
+    parts.join("")
 }
 
 /// Get the static `slot="name"` attribute value from an element's attributes.

--- a/crates/rsvelte_projection/src/svelte2tsx/template/nodes/special_element.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/template/nodes/special_element.rs
@@ -13,9 +13,8 @@ use crate::svelte2tsx::template::attributes::binding::{
 use crate::svelte2tsx::template::attributes::build_attributes_string;
 use crate::svelte2tsx::template::attributes::directive_suffix::build_directive_prefix_suffix;
 use crate::svelte2tsx::template::ctx::Counter;
-use crate::svelte2tsx::template::utils::source::{
-    count_tag_to_attr_spaces, find_closing_tag_start, find_opening_tag_end,
-};
+use crate::svelte2tsx::template::utils::opener_spacing::{OpenerCtx, opener_spacing};
+use crate::svelte2tsx::template::utils::source::{find_closing_tag_start, find_opening_tag_end};
 use crate::svelte2tsx::template::walk::{process_fragment_inplace, process_node_inplace};
 
 use super::snippet_block::handle_snippet_block_as_component_prop;
@@ -54,16 +53,29 @@ pub(crate) fn handle_svelte_special_element(
         counter.slot_inst.is_some(),
     );
 
-    // Add extra whitespace to match JS svelte2tsx position-preserving behavior
-    if !el.attributes.is_empty() && !attrs_str.is_empty() {
-        let extra_spaces = count_tag_to_attr_spaces(&el.name, el.start, source);
-        if extra_spaces >= 1 {
-            let total_spaces = extra_spaces + 1;
-            let mut padded = " ".repeat(total_spaces);
-            padded.push_str(attrs_str.trim_start());
-            attrs_str = padded;
-        }
+    // The special `svelte:…` elements name themselves with a literal in the start
+    // transformation, so it contributes no source range.
+    let spacing = opener_spacing(
+        source,
+        el.start,
+        &el.name,
+        opening_tag_end,
+        None,
+        &el.attributes,
+        &counter.element_opener_comments,
+        OpenerCtx {
+            is_element: true,
+            in_component_slot: counter.slot_inst.is_some(),
+            tag_name: &el.name,
+            is_slot_tag: false,
+        },
+    );
+    if spacing.in_attr_object > 0 {
+        let mut padded = " ".repeat(spacing.in_attr_object);
+        padded.push_str(&attrs_str);
+        attrs_str = padded;
     }
+    let indent = " ".repeat(spacing.before_block);
 
     // `svelte:boundary` treats direct {#snippet} children as implicit props on
     // the `createElement` attrs object — exactly like InlineComponent in the
@@ -87,8 +99,8 @@ pub(crate) fn handle_svelte_special_element(
         //   <non-snippet children>
         // }
         let opener = format!(
-            " {{ svelteHTML.createElement(\"{}\", {{{}",
-            el.name, attrs_str
+            "{}{{ svelteHTML.createElement(\"{}\", {{{}",
+            indent, el.name, attrs_str
         );
         str.overwrite(el.start, opening_tag_end, &opener);
 
@@ -201,12 +213,13 @@ pub(crate) fn handle_svelte_special_element(
         // declarations), closed by a matching extra `}` after the children.
         let opener = if directive_prefix.is_empty() {
             format!(
-                " {{ {}svelteHTML.createElement(\"{}\", {{{}}});{}{}",
-                element_var_decl, el.name, attrs_str, bind_suffix, directive_suffix
+                "{}{{ {}svelteHTML.createElement(\"{}\", {{{}}});{}{}",
+                indent, element_var_decl, el.name, attrs_str, bind_suffix, directive_suffix
             )
         } else {
             format!(
-                " {{{}{{ {}svelteHTML.createElement(\"{}\"{}, {{{}}});{}{}",
+                "{}{{{}{{ {}svelteHTML.createElement(\"{}\"{}, {{{}}});{}{}",
+                indent,
                 directive_prefix,
                 element_var_decl,
                 el.name,

--- a/crates/rsvelte_projection/src/svelte2tsx/template/segs.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/template/segs.rs
@@ -76,37 +76,6 @@ pub(super) fn segs_to_string(segs: &[Seg], source: &str) -> String {
     out
 }
 
-/// Returns true when no `Src` is present and every `Lit` is empty.
-pub(super) fn segs_is_empty(segs: &[Seg]) -> bool {
-    segs.iter().all(|s| match s {
-        Seg::Lit(t) => t.is_empty(),
-        Seg::Src(_, _) => false,
-    })
-}
-
-/// Trim leading whitespace from the very first textual position in `segs`
-/// (across leading whitespace-only `Lit` segments). Returns the resulting
-/// vector with its head normalized — used by the element-opener leading
-/// whitespace bookkeeping.
-pub(super) fn segs_trim_start(segs: &mut Vec<Seg>) {
-    while let Some(first) = segs.first_mut() {
-        match first {
-            Seg::Lit(s) => {
-                let trimmed = s.trim_start_matches(|c: char| c.is_whitespace());
-                if trimmed.is_empty() {
-                    segs.remove(0);
-                    continue;
-                }
-                if trimmed.len() != s.len() {
-                    *s = trimmed.to_string();
-                }
-                break;
-            }
-            Seg::Src(_, _) => break,
-        }
-    }
-}
-
 /// Reorder-safe pre-pass for [`emit_segmented_overwrite`], which requires
 /// `Seg::Src` ranges to appear in ascending source order (a MagicString can
 /// only overwrite left-to-right). When a later segment references an earlier

--- a/crates/rsvelte_projection/src/svelte2tsx/template/utils/mod.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/template/utils/mod.rs
@@ -2,4 +2,5 @@
 
 pub(super) mod expr;
 pub(super) mod names;
+pub(super) mod opener_spacing;
 pub(super) mod source;

--- a/crates/rsvelte_projection/src/svelte2tsx/template/utils/opener_spacing.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/template/utils/opener_spacing.rs
@@ -1,0 +1,535 @@
+//! Leading whitespace of the generated attribute/props object literal.
+//!
+//! Official svelte2tsx rewrites an opening tag with MagicString moves
+//! (`htmlxtojsx_v2/utils/node-utils.ts::transform`): every kept source range is
+//! moved to the end of the opener, and each run of source characters *between*
+//! two kept ranges is collapsed to a single space that is moved there too —
+//! ahead of the attribute chunks, because the gap moves run before the deferred
+//! attribute moves. Those spaces therefore surface directly after the `, {` that
+//! opens the attribute object, and their count is observable in the output
+//! (`<div a="1" b="2">` → `createElement("div", {   "a":…`).
+//!
+//! rsvelte assembles the opener from segments rather than moves, so it has to
+//! reproduce that count. This module models the kept ranges official would emit
+//! for an opening tag and replays `transform`'s gap bookkeeping over them.
+
+use crate::ast::template::{Attribute, AttributeValue, AttributeValuePart, BindDirective};
+use crate::svelte2tsx::template::attributes::attribute::{
+    leading_attr_comment_segs, trailing_attr_comment_segs,
+};
+use crate::svelte2tsx::template::ctx::ElementOpenerCommentIndex;
+use crate::svelte2tsx::template::segs::Seg;
+use crate::svelte2tsx::template::utils::expr::{
+    extend_expr_end_with_ts_postfix, get_expression_end_stripping_ts, get_expression_range,
+    get_set_binding_ranges,
+};
+
+type Range = (u32, u32);
+
+/// `oneWayBindingAttributes` in `htmlxtojsx_v2/nodes/Binding.ts`.
+const ONE_WAY_BINDINGS: [&str; 10] = [
+    "clientWidth",
+    "clientHeight",
+    "offsetWidth",
+    "offsetHeight",
+    "duration",
+    "seeking",
+    "ended",
+    "readyState",
+    "naturalWidth",
+    "naturalHeight",
+];
+
+/// `oneWayBindingAttributesNotOnElement` in `htmlxtojsx_v2/nodes/Binding.ts`.
+const ONE_WAY_BINDINGS_NOT_ON_ELEMENT: [&str; 7] = [
+    "contentRect",
+    "contentBoxSize",
+    "borderBoxSize",
+    "devicePixelContentBoxSize",
+    "buffered",
+    "played",
+    "seekable",
+];
+
+/// The lowering context that decides how individual attributes are emitted.
+#[derive(Clone, Copy)]
+pub(crate) struct OpenerCtx<'a> {
+    /// `Element` (HTML tag, `svelte:head`/`window`/…, `slot`, `svelte:element`)
+    /// as opposed to `InlineComponent` (component, `svelte:component`,
+    /// `svelte:self`). Several attribute handlers branch on this.
+    pub is_element: bool,
+    /// The node is slot content of an enclosing component, so `slot="…"` and
+    /// `let:…` are lowered into the slot prologue instead of the attribute list.
+    pub in_component_slot: bool,
+    /// Tag name as written (`input` enables the `bind:group` special case).
+    pub tag_name: &'a str,
+    /// `<slot>`: its `name` attribute is consumed by the start transformation.
+    pub is_slot_tag: bool,
+}
+
+/// The two space runs an opening tag leaves behind.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct OpenerSpacing {
+    /// Gaps that stay where they were, ahead of the generated `{ …createElement`.
+    pub before_block: usize,
+    /// Gaps moved to the end of the opener, which land right after the `{` that
+    /// opens the attribute/props object.
+    pub in_attr_object: usize,
+}
+
+/// Whitespace official svelte2tsx leaves around an opening tag's lowering.
+///
+/// `head` is the source range the element's `getStartTransformation()`
+/// contributes (the tag name for a regular element, the `svelte:element` tag
+/// expression, the `<slot>` name, the component name); `None` for the special
+/// `svelte:head`/`window`/`body`/`options`/`fragment` elements and
+/// `svelte:self`, which emit a pure string there.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn opener_spacing(
+    source: &str,
+    node_start: u32,
+    tag_name: &str,
+    transform_end: u32,
+    head: Option<Range>,
+    attributes: &[Attribute],
+    comments: &ElementOpenerCommentIndex,
+    ctx: OpenerCtx,
+) -> OpenerSpacing {
+    let tag_name_end = node_start + 1 + tag_name.len() as u32;
+    let mut ranges: Vec<Range> = Vec::with_capacity(attributes.len() * 2 + 2);
+    if let Some(range) = head {
+        ranges.push(range);
+    }
+    // `Element`/`InlineComponent` constructor: the whitespace right after the
+    // tag name is kept (and marks the delete destination) so deleted characters
+    // still map onto the attribute object.
+    let delete_dest = source
+        .as_bytes()
+        .get(tag_name_end as usize)
+        .filter(|b| b.is_ascii_whitespace())
+        .map(|_| {
+            ranges.push((tag_name_end, tag_name_end + 1));
+            tag_name_end
+        });
+
+    let last = attributes.len().saturating_sub(1);
+    for (index, attr) in attributes.iter().enumerate() {
+        push_attribute_ranges(&mut ranges, attr, source, comments, index == last, &ctx);
+    }
+
+    count_gaps(node_start, transform_end, delete_dest, &ranges)
+}
+
+/// Spaces upstream leaves ahead of a closing tag's lowering.
+///
+/// `performTransformation` runs a second `transform` over `</name…>`, so the
+/// same gaps collapse there. That array carries no delete marker, so no gap is
+/// ever moved and all of them land before the generated `}`. `name_range` is the
+/// `</Component>` → `Component}` mapping an `InlineComponent` keeps; elements and
+/// the `svelte:` tags keep nothing and always collapse to a single space.
+pub(crate) fn closing_tag_spacing(
+    closing_tag_start: u32,
+    node_end: u32,
+    name_range: Option<Range>,
+) -> usize {
+    let ranges: Vec<Range> = name_range.into_iter().collect();
+    count_gaps(closing_tag_start, node_end, None, &ranges).before_block
+}
+
+/// Replay of `transform`'s move/removal bookkeeping. Each run of source
+/// characters between two kept ranges collapses to one space; whether that
+/// space is moved to the end of the opener or stays in place decides which side
+/// of the generated `{ …createElement(` it ends up on.
+fn count_gaps(start: u32, end: u32, delete_dest: Option<u32>, ranges: &[Range]) -> OpenerSpacing {
+    // A transformation is skipped as a move when it is zero-length, but it still
+    // counts for the "does another transformation start here?" lookup that
+    // decides whether a range swallows the character after it.
+    let starts: Vec<u32> = ranges.iter().map(|&(s, _)| s).collect();
+    let mut moves: Vec<Range> = Vec::with_capacity(ranges.len());
+    for &(t_start, t_end) in ranges.iter() {
+        if t_start == t_end {
+            continue;
+        }
+        let t_end = if t_end + 1 < end && !starts.contains(&t_end) {
+            t_end + 1
+        } else {
+            t_end
+        };
+        // Ranges past the opener (implicit snippet props reach into the
+        // children) never produce a gap space and `transform` rewinds past them.
+        if t_start < end {
+            moves.push((t_start, t_end));
+        }
+    }
+    moves.sort_by_key(|&(s, _)| s);
+    let mut spacing = OpenerSpacing {
+        before_block: 0,
+        in_attr_object: 0,
+    };
+    // A gap only travels to the end of the opener when a delete destination was
+    // recorded (the tag name is followed by whitespace) and it sits past it.
+    let moved = |remove_start: u32| {
+        delete_dest.is_some_and(|dest| remove_start > dest) && remove_start < end
+    };
+    let mut remove_start = start;
+    for &(m_start, m_end) in &moves {
+        if remove_start < m_start && m_start < end {
+            if moved(remove_start) {
+                spacing.in_attr_object += 1;
+            } else {
+                spacing.before_block += 1;
+            }
+        }
+        remove_start = m_end;
+    }
+    if remove_start < end {
+        // The first character after the last kept range is deleted outright.
+        remove_start += 1;
+    }
+    if remove_start < end {
+        if moved(remove_start) && remove_start + 1 < end {
+            spacing.in_attr_object += 1;
+        } else {
+            spacing.before_block += 1;
+        }
+    }
+    spacing
+}
+
+/// Kept source ranges for one attribute, mirroring the `htmlxtojsx_v2/nodes/*`
+/// handler that lowers it.
+fn push_attribute_ranges(
+    out: &mut Vec<Range>,
+    attr: &Attribute,
+    source: &str,
+    comments: &ElementOpenerCommentIndex,
+    is_last: bool,
+    ctx: &OpenerCtx,
+) {
+    // Both skip paths below bail before upstream reaches
+    // `getLeadingCommentTransformation`, so they contribute no comment ranges.
+    if let Attribute::Attribute(node) = attr {
+        // `<slot name="…">` is consumed by the start transformation.
+        if ctx.is_slot_tag && node.name == "name" {
+            return;
+        }
+        if node.name == "slot"
+            && ctx.in_component_slot
+            && let AttributeValue::Sequence(parts) = &node.value
+            && let [AttributeValuePart::Text(text)] = parts.as_slice()
+        {
+            // `addSlotName` keeps only the slot name text.
+            out.push((text.start, text.end));
+            return;
+        }
+    }
+    push_comment_ranges(
+        out,
+        attribute_start(attr),
+        attribute_end(attr),
+        source,
+        comments,
+        is_last,
+    );
+
+    match attr {
+        Attribute::Attribute(node) => {
+            if let AttributeValue::Expression(tag) = &node.value
+                && tag.start == node.start + 1
+            {
+                // Shorthand `{name}`: the name IS the mapped expression.
+                if let Some((s, e)) = get_expression_range(&tag.expression) {
+                    out.push(if s == e {
+                        (s.saturating_sub(1), e)
+                    } else {
+                        (s, e)
+                    });
+                }
+                return;
+            }
+            out.push((node.start, node.start + node.name.len() as u32));
+            match &node.value {
+                AttributeValue::True(_) => {}
+                AttributeValue::Expression(tag) => {
+                    if let Some((s, e)) = get_expression_range(&tag.expression) {
+                        let e = extend_expr_end_with_ts_postfix(source, e, node.end);
+                        out.push(with_trailing_property_access(source, s, e));
+                    }
+                }
+                AttributeValue::Sequence(parts) => match parts.as_slice() {
+                    [] => {}
+                    [AttributeValuePart::Text(text)] => {
+                        if text.start == text.end {
+                            // `attr=""` maps onto the quotes so the position stays.
+                            out.push((text.start.saturating_sub(1), text.end + 1));
+                        } else {
+                            out.push((text.start, text.end));
+                        }
+                    }
+                    [AttributeValuePart::ExpressionTag(tag)] => {
+                        if let Some((s, e)) = get_expression_range(&tag.expression) {
+                            out.push(with_trailing_property_access(source, s, e));
+                        }
+                    }
+                    parts => {
+                        let first = value_part_start(&parts[0]);
+                        let last = value_part_end(&parts[parts.len() - 1]);
+                        out.push((first, last));
+                    }
+                },
+            }
+        }
+        Attribute::SpreadAttribute(spread) => {
+            out.push((spread.start + 1, spread.end - 1));
+        }
+        Attribute::AttachTag(attach) => {
+            if let Some(range) = get_expression_range(&attach.expression) {
+                out.push(range);
+            }
+        }
+        Attribute::BindDirective(bind) => push_binding_ranges(out, bind, source, ctx),
+        Attribute::OnDirective(on) => {
+            let name_start = directive_name_start(source, on.start);
+            out.push((name_start, name_start + on.name.len() as u32));
+            if let Some(expr) = &on.expression
+                && let Some((s, e)) = get_expression_range(expr)
+            {
+                out.push(with_trailing_property_access(source, s, e));
+            }
+        }
+        Attribute::ClassDirective(class) => {
+            if let Some((s, e)) = get_expression_range(&class.expression) {
+                out.push(with_trailing_property_access(source, s, e));
+            }
+        }
+        Attribute::StyleDirective(style) => match &style.value {
+            AttributeValue::True(_) => {
+                out.push((directive_name_start(source, style.start), style.end));
+            }
+            AttributeValue::Expression(tag) => {
+                out.push((tag.start + 1, tag.end - 1));
+            }
+            AttributeValue::Sequence(parts) => match parts.as_slice() {
+                [] => out.push((directive_name_start(source, style.start), style.end)),
+                [AttributeValuePart::Text(text)] => out.push((text.start, text.end)),
+                [AttributeValuePart::ExpressionTag(tag)] => out.push((tag.start + 1, tag.end - 1)),
+                parts => out.push((
+                    value_part_start(&parts[0]),
+                    value_part_end(&parts[parts.len() - 1]),
+                )),
+            },
+        },
+        Attribute::TransitionDirective(transition) => {
+            let name_start = directive_name_start(source, transition.start);
+            out.push((name_start, name_start + transition.name.len() as u32));
+            if let Some(expr) = &transition.expression
+                && let Some((s, e)) = get_expression_range(expr)
+            {
+                out.push(with_trailing_property_access(source, s, e));
+            }
+        }
+        Attribute::AnimateDirective(animate) => {
+            let name_start = directive_name_start(source, animate.start);
+            out.push((name_start, name_start + animate.name.len() as u32));
+            if let Some(expr) = &animate.expression
+                && let Some((s, e)) = get_expression_range(expr)
+            {
+                out.push(with_trailing_property_access(source, s, e));
+            }
+        }
+        Attribute::UseDirective(use_dir) => {
+            let name_start = directive_name_start(source, use_dir.start);
+            out.push((name_start, name_start + use_dir.name.len() as u32));
+            if let Some(expr) = &use_dir.expression
+                && let Some((s, e)) = get_expression_range(expr)
+            {
+                out.push(with_trailing_property_access(source, s, e));
+            }
+        }
+        Attribute::LetDirective(let_dir) => {
+            let name_start = let_dir.start + 4; // `let:`
+            let is_slot_let = !ctx.is_element || ctx.in_component_slot;
+            if is_slot_let {
+                out.push((name_start, name_start + let_dir.name.len() as u32));
+            } else {
+                // A `let:` outside a component is lowered as a plain attribute,
+                // whose name range covers the `let:` prefix too.
+                out.push((let_dir.start, name_start + let_dir.name.len() as u32));
+            }
+            if let Some(expr) = &let_dir.expression
+                && let Some(range) = get_expression_range(expr)
+            {
+                out.push(range);
+            }
+        }
+    }
+}
+
+fn push_binding_ranges(out: &mut Vec<Range>, bind: &BindDirective, source: &str, ctx: &OpenerCtx) {
+    let Some((expr_start, expr_end)) = get_expression_range(&bind.expression) else {
+        return;
+    };
+    let get_set = get_set_binding_ranges(&bind.expression, source);
+    let stripped_end =
+        get_expression_end_stripping_ts(&bind.expression, source).unwrap_or(expr_end);
+
+    // `appendOneWayBinding`: `expr = <assignment>;`, with the stripped-off TS
+    // annotation re-emitted as a second range.
+    let push_one_way = |out: &mut Vec<Range>| {
+        out.push((expr_start, stripped_end));
+        if stripped_end < expr_end {
+            out.push((stripped_end, expr_end));
+        }
+    };
+
+    if bind.name == "this" {
+        match get_set {
+            Some((_, set)) => out.push(set),
+            None => push_one_way(out),
+        }
+        return;
+    }
+
+    if get_set.is_none() && ctx.is_element {
+        if bind.name == "group" && ctx.tag_name == "input" {
+            push_one_way(out);
+            return;
+        }
+        if ONE_WAY_BINDINGS.contains(&bind.name.as_str()) {
+            push_one_way(out);
+            return;
+        }
+        if ONE_WAY_BINDINGS_NOT_ON_ELEMENT.contains(&bind.name.as_str()) {
+            out.push((expr_start, stripped_end));
+            return;
+        }
+    }
+
+    let name_start = bind.start + 5; // `bind:`
+    // The `svelteHTML` typings namespace (the default) keeps the `bind:` prefix
+    // in the emitted property name on elements, which widens the name range.
+    let preserve_bind = ctx.is_element;
+    if expr_start == name_start {
+        // Shorthand `bind:value`.
+        if preserve_bind {
+            out.push(with_trailing_property_access(source, expr_start, expr_end));
+        } else {
+            // The name IS the expression; there is no separate value.
+            out.push((expr_start, expr_end));
+        }
+        return;
+    }
+    let equals = source[..=expr_start as usize].rfind('=').unwrap_or(0) as u32;
+    out.push((
+        if preserve_bind {
+            bind.start
+        } else {
+            name_start
+        },
+        equals,
+    ));
+    match get_set {
+        Some((get, set)) => {
+            out.push(get);
+            out.push(with_trailing_property_access(source, set.0, set.1));
+        }
+        None => out.push(with_trailing_property_access(source, expr_start, expr_end)),
+    }
+}
+
+/// `getLeadingCommentTransformation` / `getTrailingCommentTransformation`.
+fn push_comment_ranges(
+    out: &mut Vec<Range>,
+    attr_start: u32,
+    attr_end: u32,
+    source: &str,
+    comments: &ElementOpenerCommentIndex,
+    is_last: bool,
+) {
+    if comments.is_empty() {
+        return;
+    }
+    let mut segs = leading_attr_comment_segs(attr_start, source, comments);
+    if is_last {
+        segs.extend(trailing_attr_comment_segs(attr_end, source, comments));
+    }
+    out.extend(segs.into_iter().filter_map(|seg| match seg {
+        Seg::Src(s, e) => Some((s, e)),
+        Seg::Lit(_) => None,
+    }));
+}
+
+/// Position right after the `:` that separates a directive's kind from its name.
+fn directive_name_start(source: &str, node_start: u32) -> u32 {
+    source[node_start as usize..]
+        .find(':')
+        .map_or(node_start, |offset| node_start + offset as u32 + 1)
+}
+
+/// `withTrailingPropertyAccess`: a member access left dangling behind the parsed
+/// expression (an artifact of svelte2tsx's pre-parse) is pulled back in.
+fn with_trailing_property_access(source: &str, start: u32, end: u32) -> Range {
+    let bytes = source.as_bytes();
+    let mut i = end as usize;
+    while i < bytes.len() {
+        let ch = bytes[i];
+        if ch.is_ascii_whitespace() {
+            i += 1;
+            continue;
+        }
+        if ch == b'.' {
+            return (start, i as u32 + 1);
+        }
+        if ch == b'?' && bytes.get(i + 1) == Some(&b'.') {
+            return (start, i as u32 + 2);
+        }
+        break;
+    }
+    (start, end)
+}
+
+fn value_part_start(part: &AttributeValuePart) -> u32 {
+    match part {
+        AttributeValuePart::Text(text) => text.start,
+        AttributeValuePart::ExpressionTag(tag) => tag.start,
+    }
+}
+
+fn value_part_end(part: &AttributeValuePart) -> u32 {
+    match part {
+        AttributeValuePart::Text(text) => text.end,
+        AttributeValuePart::ExpressionTag(tag) => tag.end,
+    }
+}
+
+fn attribute_start(attr: &Attribute) -> u32 {
+    match attr {
+        Attribute::Attribute(node) => node.start,
+        Attribute::SpreadAttribute(spread) => spread.start,
+        Attribute::AttachTag(attach) => attach.start,
+        Attribute::BindDirective(bind) => bind.start,
+        Attribute::OnDirective(on) => on.start,
+        Attribute::ClassDirective(class) => class.start,
+        Attribute::StyleDirective(style) => style.start,
+        Attribute::TransitionDirective(transition) => transition.start,
+        Attribute::AnimateDirective(animate) => animate.start,
+        Attribute::UseDirective(use_dir) => use_dir.start,
+        Attribute::LetDirective(let_dir) => let_dir.start,
+    }
+}
+
+fn attribute_end(attr: &Attribute) -> u32 {
+    match attr {
+        Attribute::Attribute(node) => node.end,
+        Attribute::SpreadAttribute(spread) => spread.end,
+        Attribute::AttachTag(attach) => attach.end,
+        Attribute::BindDirective(bind) => bind.end,
+        Attribute::OnDirective(on) => on.end,
+        Attribute::ClassDirective(class) => class.end,
+        Attribute::StyleDirective(style) => style.end,
+        Attribute::TransitionDirective(transition) => transition.end,
+        Attribute::AnimateDirective(animate) => animate.end,
+        Attribute::UseDirective(use_dir) => use_dir.end,
+        Attribute::LetDirective(let_dir) => let_dir.end,
+    }
+}

--- a/crates/rsvelte_projection/src/svelte2tsx/template/utils/source.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/template/utils/source.rs
@@ -3,31 +3,6 @@
 use crate::ast::template::Attribute;
 use crate::svelte2tsx::template::attributes::attribute_end;
 
-/// Count the number of whitespace characters between the tag name and the
-/// first attribute in the opening tag source. This preserves whitespace
-/// that the JS svelte2tsx would keep via MagicString in-place editing.
-///
-/// For `<Test b="6" />`, returns 1 (the space between `Test` and `b`).
-/// For `<div class="foo">`, returns 1.
-/// For `<Component\n  prop>`, returns 3 (newline + 2 spaces).
-pub(crate) fn count_tag_to_attr_spaces(tag_name: &str, el_start: u32, source: &str) -> usize {
-    let name_end = el_start as usize + 1 + tag_name.len(); // +1 for '<'
-    let bytes = source.as_bytes();
-    let mut count = 0;
-    let mut i = name_end;
-    let end = source.len();
-    while i < end {
-        let ch = bytes[i];
-        if ch == b' ' || ch == b'\t' || ch == b'\n' || ch == b'\r' {
-            count += 1;
-            i += 1;
-        } else {
-            break;
-        }
-    }
-    count
-}
-
 /// Find the end of the opening tag (position after the closing `>`).
 ///
 /// Scans from the last retained attribute (or the tag name when there are no

--- a/crates/rsvelte_projection/tests/svelte2tsx_class_style_directive.rs
+++ b/crates/rsvelte_projection/tests/svelte2tsx_class_style_directive.rs
@@ -39,13 +39,13 @@ fn class_and_style_directives_are_not_props_keys() {
 
     // The props object is empty for this element.
     assert!(
-        out.contains("svelteHTML.createElement(\"div\", { });"),
+        out.contains("svelteHTML.createElement(\"div\", {  });"),
         "expected empty props object, got:\n{out}"
     );
 
     // class: lowers to a bare expression statement; style: to ensureType.
     assert!(
-        out.contains("); on;"),
+        out.contains(");on;"),
         "class: expr statement missing:\n{out}"
     );
     assert!(
@@ -66,7 +66,7 @@ fn class_shorthand_directive_is_not_props_key() {
         "class: shorthand leaked into props:\n{out}"
     );
     assert!(
-        out.contains("); active;"),
+        out.contains(");active;"),
         "class: shorthand statement missing:\n{out}"
     );
 }
@@ -101,7 +101,7 @@ fn class_style_alongside_real_attributes() {
         "class: directive leaked into props:\n{out}"
     );
     assert!(
-        out.contains("); on;"),
+        out.contains(");on;"),
         "class: expr statement missing:\n{out}"
     );
 }

--- a/crates/rsvelte_projection/tests/svelte2tsx_entry.rs
+++ b/crates/rsvelte_projection/tests/svelte2tsx_entry.rs
@@ -94,6 +94,165 @@ fn test_svelte2tsx_if_block() {
     );
 }
 
+/// `{:else}` (no `if`) must rewrite to `}else{` with no inserted spaces —
+/// `handleElse` in the JS reference rewrites the tag character-by-character
+/// (`{`→`}`, `}`→`{`, drop the `:`), it never appends a literal `'} else {'`.
+/// `{:else if}`, by contrast, keeps its spaces (`} else if (`) — that literal
+/// IS hardcoded upstream.
+#[test]
+fn plain_else_rewrites_without_inserted_spaces() {
+    let result = svelte2tsx("{#if a}{b}{:else}{c}{/if}", Svelte2TsxOptions::default()).unwrap();
+    assert!(
+        result.code.contains("if(a){b;}else{c;}"),
+        "got:\n{}",
+        result.code
+    );
+}
+
+#[test]
+fn else_if_keeps_its_hardcoded_spaces() {
+    let result = svelte2tsx(
+        "{#if a}{b}{:else if c}{d}{/if}",
+        Svelte2TsxOptions::default(),
+    )
+    .unwrap();
+    assert!(
+        result.code.contains("if(a){b;} else if (c){d;}"),
+        "got:\n{}",
+        result.code
+    );
+}
+
+/// `{:else}` followed by a nested `{#if}` also nests a lone `IfBlock` in the
+/// alternate, but it is not an `{:else if}` — the tag still has to be rewritten.
+#[test]
+fn plain_else_wrapping_a_nested_if_is_not_an_else_if() {
+    let result = svelte2tsx(
+        "{#if x}a{:else}{#if y}b{:else}c{/if}{/if}",
+        Svelte2TsxOptions::default(),
+    )
+    .unwrap();
+    assert!(
+        result.code.contains("if(x){ }else{if(y){ }else{ }}"),
+        "got:\n{}",
+        result.code
+    );
+}
+
+/// The whitespace inside an element's attribute object (and ahead of its block)
+/// is not a fixed single space: it is the opening tag's source characters that
+/// no transformation kept, each run collapsed to one space by upstream's
+/// `transform` helper. Every expectation below is the byte-exact output of the
+/// official svelte2tsx in `submodules/language-tools`.
+#[test]
+fn opener_whitespace_matches_the_official_gap_collapsing() {
+    for (source, expected) in [
+        // Gaps inside the opener land after the `{` of the attribute object.
+        ("<div {...attributes}>x</div>", "\"div\", {...attributes,}"),
+        ("<div a=\"1\">x</div>", "\"div\", { \"a\":`1`,}"),
+        ("<div a>x</div>", "\"div\", {\"a\":true,}"),
+        (
+            "<div a=\"1\" b=\"2\">x</div>",
+            "\"div\", {   \"a\":`1`,\"b\":`2`,}",
+        ),
+        (
+            "<div class=\"a\" {...attributes}>x</div>",
+            "\"div\", {  \"class\":`a`,...attributes,}",
+        ),
+        ("<Foo {...attributes} />", "props: { ...attributes,}"),
+        ("<Foo  {...attributes} />", "props: {  ...attributes,}"),
+        ("<Foo {...a} b={1} />", "props: {   ...a,\"b\":1,}"),
+        ("<Foo\n  {...attributes}\n/>", "props: {  ...attributes,}"),
+        (
+            "<svelte:element this={tag} {...attributes}>x</svelte:element>",
+            "createElement(tag, {  ...attributes,}",
+        ),
+        (
+            "<slot x={1} />",
+            "__sveltets_createSlot(\"default\", {  \"x\":1,}",
+        ),
+        (
+            "<slot name=\"a\" x={1} />",
+            "__sveltets_createSlot(\"a\", {    \"x\":1,}",
+        ),
+        ("<title a=\"1\">x</title>", "\"title\", { \"a\":`1`,}"),
+        (
+            "<svelte:element this=\"div\" a=\"1\">x</svelte:element>",
+            "\"div\", {  \"a\":`1`,}",
+        ),
+        (
+            "<Foo><div slot=\"a\" let:v>{v}</div></Foo>",
+            "$$_$$;{ svelteHTML.createElement(\"div\", {  });",
+        ),
+        // Directives keep their gaps even though they contribute no props.
+        ("<div transition:fade>y</div>", "\"div\", { });"),
+        ("<div transition:fade={{d:1}}>y</div>", "\"div\", {  });"),
+        ("<Foo on:click={h} />", "props: {   }});"),
+        ("<svelte:self />", "__sveltets_2_createComponentAny({});"),
+        // Gaps that are never moved stay ahead of the generated block.
+        ("<button\n  {...attributes}\n>x</button>", "  { svelteHTML"),
+        ("<div a={ 1 }>x</div>", "  { svelteHTML"),
+        (
+            "<Foo><span slot=\"a\">y</span></Foo>",
+            "props: {}}); {const {",
+        ),
+    ] {
+        let result = svelte2tsx(source, Svelte2TsxOptions::default()).unwrap();
+        assert!(
+            result.code.contains(expected),
+            "{source:?}\n  expected to contain {expected:?}\n  got:\n{}",
+            result.code
+        );
+    }
+}
+
+/// `performTransformation` runs a second `transform` over the closing tag, so the
+/// same gaps collapse there. A component keeps a `</Component>` → `Component}`
+/// mapping in the middle of that range, which splits it into two gaps; every
+/// other tag keeps nothing and always collapses to a single space. Whatever
+/// closes a `let:` scope goes after those gaps, not before. Every expectation
+/// below is the byte-exact output of the official svelte2tsx.
+#[test]
+fn closing_tag_whitespace_matches_the_official_gap_collapsing() {
+    for (source, expected) in [
+        ("<Foo></Foo>", "props: {}}); Foo}"),
+        ("<Foo></Foo  >", "props: {}});  Foo}"),
+        ("<Foo></Foo   >", "props: {}});  Foo}"),
+        ("<div></div   >", "\"div\", {}); }"),
+        ("<Foo let:x></Foo>", "$$slot_def.default;$$_$$; }Foo}"),
+        ("<Foo let:x></Foo  >", "$$slot_def.default;$$_$$;  }Foo}"),
+        ("<Foo let:x>y</Foo>", "$$slot_def.default;$$_$$;  }Foo}"),
+        (
+            "<svelte:self></svelte:self>",
+            "__sveltets_2_createComponentAny({}); }",
+        ),
+        (
+            "<svelte:component this={C}></svelte:component>",
+            "props: { }}); }",
+        ),
+        (
+            "<Foo><Bar slot=\"a\">y</Bar></Foo>",
+            "__sveltets_2_any(0); },}});  }Bar} Foo}",
+        ),
+        // A self-closing tag has no `</Component>` to map, so the name is never
+        // referenced — only the `let:` scope and block closers.
+        ("<Foo let:x />", "$$slot_def.default;$$_$$;}}"),
+        ("<Foo let:x let:y />", "$$_$$;}}"),
+        ("<Foo also=\"1\" let:x />", "$$slot_def.default;$$_$$;}}"),
+        (
+            "<Foo let:x={a} />",
+            "x:a,} = $$_ooF0.$$slot_def.default;$$_$$;}}",
+        ),
+    ] {
+        let result = svelte2tsx(source, Svelte2TsxOptions::default()).unwrap();
+        assert!(
+            result.code.contains(expected),
+            "{source:?}\n  expected to contain {expected:?}\n  got:\n{}",
+            result.code
+        );
+    }
+}
+
 #[test]
 fn test_svelte2tsx_each_block() {
     let source = "{#each items as item}<p>{item}</p>{/each}";


### PR DESCRIPTION
## Summary

Fixes #1946 — svelte2tsx output diverged from the official implementation in a whitespace-only class (`} else {` vs `}else{`, `{ ...spread,}` vs `{...spread,}`, and related opening/closing-tag spacing).

Upstream lowers an opening tag with MagicString moves (`htmlxtojsx_v2/utils/node-utils.ts::transform`): every kept source range is moved to the end of the opener, and each run of source characters between two kept ranges collapses to a single space. Those spaces are observable — the ones that travel with the moves land right after the `{` that opens the attribute/props object, the ones that stay put land ahead of the generated block. rsvelte emitted fixed single spaces plus per-attribute ad-hoc spacers instead.

- New `template/utils/opener_spacing.rs` models the ranges each `htmlxtojsx_v2/nodes/*` handler keeps and replays `transform`'s gap bookkeeping; every opener emitter now uses it. The ad-hoc spacers (`build_attribute_segments` / `build_component_props_segments` / `build_slot_props_string`, `let_spaces` / `has_on_directives` corrections, `class:` / `style:` statement spacers) are dropped.
- Closing tags get the same treatment: official runs `transform` over the end tag too (`InlineComponent.performTransformation`'s `endTransformation`), where nothing is moved, only `InlineComponent` keeps a name range, and the `let:`-scope `}` comes after the gap spaces. Previously rsvelte hardcoded a single space and placed the scope `}` before it.
- `{:else}` is rewritten character-by-character (`{`→`}`, `}`→`{`, drop the `:`) scanning backwards, as upstream `handleElse` does, instead of being replaced by a literal `} else {`. The `elseif` decision now uses the node's own flag — `{:else}{#if …}` previously misclassified as `{:else if}` and produced invalid TSX.
- Also fixed en route: self-closing component + `let:` wrongly injected the component name (`}Foo}}` vs official `}}}`), pre-existing.

## Verification

- Byte-compared against the official svelte2tsx (`submodules/language-tools`, svelte pinned to 5.56.8) over ~920 opening/closing-tag shapes across seven matrices — all whitespace divergences gone; remaining diffs are unrelated pre-existing classes tracked in #2046 / #2049.
- `cargo test --workspace`: 286 suites green. svelte2tsx fixtures unchanged (249 pass / 5 known).
- svelte2tsx corpus gate: 13440 matches / 0 mismatches (unchanged — this class was absorbed by comparison-side normalization, hence invisible to the gate, as the issue notes).
- Reviewed in two passes (opening-tag port, closing-tag delta); both review P2 findings are fixed in this PR; out-of-scope findings filed as #2046 / #2049.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SfqweP3NTX8WEWvaQmerDZ