### PR TITLE
chore(ci): refresh rsvelte_lint_types Cargo.lock after esrap bump

### DIFF
--- a/crates/rsvelte_lint_types/Cargo.lock
+++ b/crates/rsvelte_lint_types/Cargo.lock
@@ -1121,8 +1121,10 @@ dependencies = [
 
 [[package]]
 name = "rsvelte_esrap"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
+ "compact_str 0.10.0",
+ "memchr",
  "oxc_allocator",
  "oxc_ast",
  "oxc_span",


### PR DESCRIPTION
## Summary

- Fixes the failing [Type-aware Lint](https://github.com/baseballyama/rsvelte/actions/runs/30608705762) workflow on `main` (run at 2026-07-31T06:07Z, triggered by e6cd55da / #2044):
  ```
  error: cannot update the lock file .../crates/rsvelte_lint_types/Cargo.lock because --locked was passed to prevent this
  ```
- Root cause: `crates/rsvelte_lint_types` is an isolated Cargo workspace (path-deps on `rsvelte_core` / `rsvelte_lint` / `rsvelte_projection` / `submodules/corsa-bind`) with its own committed `Cargo.lock`. PR #1912 (13013738, "perf(esrap): cut Command-IR overhead in the printer") bumped `rsvelte_esrap` 0.8.0 → 0.9.0 and added `compact_str` / `memchr` dependencies, but that PR's changed paths didn't trigger `type-aware-lint.yml`, so the isolated lockfile never got refreshed and drifted out of sync. The next commit that *did* touch matching paths (e6cd55da, the changesets release commit) surfaced the staleness as a hard `--locked` failure.
- Fix: regenerated `crates/rsvelte_lint_types/Cargo.lock` via `cargo update -w` after `git submodule update --init submodules/corsa-bind`. The only diff is the `rsvelte_esrap` package entry (version `0.8.0` → `0.9.0`, plus its two new deps) — no other package moved.

## Verification

- `cargo metadata --locked` — passes
- `cargo check --all-targets --locked` — passes (~51s)
- `cargo clippy --all-targets --locked -- -D warnings` — passes, no warnings

## Test plan

- [ ] CI: Type-aware Lint workflow goes green on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SfqweP3NTX8WEWvaQmerDZ