### PR TITLE
fix(svelte-check): give an aliased rune module its own exact `paths` entry

### DIFF
--- a/.changeset/aliased-rune-module-paths-override.md
+++ b/.changeset/aliased-rune-module-paths-override.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/svelte-check": patch
+---
+
+fix(svelte-check): resolve a rune module imported through a `paths` alias (`$lib/state.svelte` for a real `state.svelte.ts`). Its `.d.svelte.ts` ESM bridge was reachable only through `rootDirs`, which TypeScript applies to relative specifiers alone, so under `moduleResolution: nodenext` the specifier fell through to the ambient `declare module '*.svelte'` and every named import errored with TS2614. The bridge now also gets an exact `compilerOptions.paths` override, with a sibling `.svelte` component still winning the specifier.

--- a/compatibility/check-fixtures/ts-aliased-rune-module-nodenext/project/pkg-a/package.json
+++ b/compatibility/check-fixtures/ts-aliased-rune-module-nodenext/project/pkg-a/package.json
@@ -1,0 +1,6 @@
+{
+	"name": "pkg-a",
+	"private": true,
+	"version": "0.0.0",
+	"type": "module"
+}

--- a/compatibility/check-fixtures/ts-aliased-rune-module-nodenext/project/pkg-a/src/consumer.svelte
+++ b/compatibility/check-fixtures/ts-aliased-rune-module-nodenext/project/pkg-a/src/consumer.svelte
@@ -1,0 +1,15 @@
+<script lang="ts">
+	import List from '$lib/anatomy/list.svelte';
+	import DataTable from '$libs/components/data-table.svelte';
+	import { useProvider } from '$lib/modules/provider.svelte';
+	import theme, { tokens } from '$lib/modules/theme.svelte';
+	import makeState, { shared } from '$libs/modules/state.svelte';
+	import Widget from '$lib/anatomy/widget.svelte';
+
+	const rows = [useProvider()];
+</script>
+
+<List {rows} />
+<DataTable rows={[{ id: 'a' }]} />
+<Widget label="w" />
+<p>{theme.name}{tokens.length}{shared.count}{makeState().count}</p>

--- a/compatibility/check-fixtures/ts-aliased-rune-module-nodenext/project/pkg-a/src/lib/anatomy/list.svelte
+++ b/compatibility/check-fixtures/ts-aliased-rune-module-nodenext/project/pkg-a/src/lib/anatomy/list.svelte
@@ -1,0 +1,13 @@
+<script lang="ts" generics="T extends { size: number }">
+	interface Props {
+		rows: T[];
+	}
+
+	let { rows }: Props = $props();
+</script>
+
+<ul>
+	{#each rows as row}
+		<li>{row.size}</li>
+	{/each}
+</ul>

--- a/compatibility/check-fixtures/ts-aliased-rune-module-nodenext/project/pkg-a/src/lib/anatomy/widget.svelte
+++ b/compatibility/check-fixtures/ts-aliased-rune-module-nodenext/project/pkg-a/src/lib/anatomy/widget.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+	let { label }: { label: string } = $props();
+</script>
+
+<span>{label}</span>

--- a/compatibility/check-fixtures/ts-aliased-rune-module-nodenext/project/pkg-a/src/lib/anatomy/widget.svelte.ts
+++ b/compatibility/check-fixtures/ts-aliased-rune-module-nodenext/project/pkg-a/src/lib/anatomy/widget.svelte.ts
@@ -1,0 +1,1 @@
+export const widgetDefaults = { label: 'widget' };

--- a/compatibility/check-fixtures/ts-aliased-rune-module-nodenext/project/pkg-a/src/lib/modules/provider.svelte.ts
+++ b/compatibility/check-fixtures/ts-aliased-rune-module-nodenext/project/pkg-a/src/lib/modules/provider.svelte.ts
@@ -1,0 +1,3 @@
+export function useProvider() {
+	return { size: 1 };
+}

--- a/compatibility/check-fixtures/ts-aliased-rune-module-nodenext/project/pkg-a/src/lib/modules/theme.svelte.ts
+++ b/compatibility/check-fixtures/ts-aliased-rune-module-nodenext/project/pkg-a/src/lib/modules/theme.svelte.ts
@@ -1,0 +1,3 @@
+export const tokens = ['a', 'b'];
+
+export default { name: 'default-theme' };

--- a/compatibility/check-fixtures/ts-aliased-rune-module-nodenext/project/pkg-a/src/plain.ts
+++ b/compatibility/check-fixtures/ts-aliased-rune-module-nodenext/project/pkg-a/src/plain.ts
@@ -1,0 +1,11 @@
+import { useProvider } from '$lib/modules/provider.svelte';
+import theme, { tokens } from '$lib/modules/theme.svelte';
+import makeState, { shared } from '$libs/modules/state.svelte';
+import type { RowShape } from '$libs/components/data-table.svelte';
+import type Widget from '$lib/anatomy/widget.svelte';
+
+export const size: number = useProvider().size + tokens.length;
+export const themeName: string = theme.name;
+export const count: number = shared.count + makeState().count;
+export const emptyRow: RowShape = { id: '' };
+export let widget: Widget | null = null;

--- a/compatibility/check-fixtures/ts-aliased-rune-module-nodenext/project/pkg-a/tsconfig.json
+++ b/compatibility/check-fixtures/ts-aliased-rune-module-nodenext/project/pkg-a/tsconfig.json
@@ -1,0 +1,28 @@
+{
+	"compilerOptions": {
+		"module": "nodenext",
+		"moduleResolution": "nodenext",
+		"target": "es2022",
+		"lib": [
+			"es2022",
+			"dom"
+		],
+		"strict": true,
+		"skipLibCheck": true,
+		"noEmit": true,
+		"isolatedModules": true,
+		"verbatimModuleSyntax": true,
+		"paths": {
+			"$lib/*": [
+				"./src/lib/*"
+			],
+			"$libs/*": [
+				"../pkg-libs/*"
+			]
+		}
+	},
+	"include": [
+		"src",
+		"../pkg-libs/**/*.svelte"
+	]
+}

--- a/compatibility/check-fixtures/ts-aliased-rune-module-nodenext/project/pkg-libs/components/data-table.svelte
+++ b/compatibility/check-fixtures/ts-aliased-rune-module-nodenext/project/pkg-libs/components/data-table.svelte
@@ -1,0 +1,19 @@
+<script module lang="ts">
+	export interface RowShape {
+		id: string;
+	}
+</script>
+
+<script lang="ts" generics="T extends RowShape">
+	interface Props {
+		rows: T[];
+	}
+
+	let { rows }: Props = $props();
+</script>
+
+<ul>
+	{#each rows as row}
+		<li>{row.id}</li>
+	{/each}
+</ul>

--- a/compatibility/check-fixtures/ts-aliased-rune-module-nodenext/project/pkg-libs/modules/state.svelte.ts
+++ b/compatibility/check-fixtures/ts-aliased-rune-module-nodenext/project/pkg-libs/modules/state.svelte.ts
@@ -1,0 +1,5 @@
+export const shared = { count: 0 };
+
+export default function makeState(): { count: number } {
+	return { count: 0 };
+}

--- a/compatibility/check-fixtures/ts-aliased-rune-module-nodenext/project/pkg-libs/package.json
+++ b/compatibility/check-fixtures/ts-aliased-rune-module-nodenext/project/pkg-libs/package.json
@@ -1,0 +1,6 @@
+{
+	"name": "libs",
+	"private": true,
+	"version": "0.0.0",
+	"type": "module"
+}

--- a/compatibility/check-fixtures/ts-aliased-rune-module-nodenext/project/pnpm-workspace.yaml
+++ b/compatibility/check-fixtures/ts-aliased-rune-module-nodenext/project/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+packages:
+  - 'pkg-a'
+  - 'pkg-libs'

--- a/compatibility/check-fixtures/ts-aliased-rune-module-nodenext/scenario.json
+++ b/compatibility/check-fixtures/ts-aliased-rune-module-nodenext/scenario.json
@@ -1,0 +1,8 @@
+{
+	"description": "Rune modules (`x.svelte.ts`) imported through a tsconfig `paths` alias (`$lib/x.svelte`) under ESM-mode resolution (`moduleResolution: nodenext` in a `\"type\": \"module\"` package), from both a plain .ts file and a .svelte file, in-workspace and across an aliased sibling package. Covers #1942: #1941's `.d.svelte.ts` bridge is only reachable through `rootDirs`, which TypeScript applies to relative specifiers only, and the exact-`paths` overrides of #1888 enumerate real `.svelte` components alone — so an aliased rune module still fell through to the ambient `*.svelte` wildcard.",
+	"workspace": "pkg-a",
+	"tsconfig": "tsconfig.json",
+	"issues": [
+		1942
+	]
+}

--- a/compatibility/check-known-failures.md
+++ b/compatibility/check-known-failures.md
@@ -80,6 +80,16 @@ Green scenarios are load-bearing, not filler — a regression turns them red:
   `.svelte.tsx` shadow and has to carry the same types. Both arms cover a
   component, a generic component and two `.svelte.ts` rune modules (one with a
   default export), imported from a plain `.ts` barrel and from a `.svelte` file.
+- **`ts-aliased-rune-module-nodenext`** — #1942, the intersection the two
+  scenarios above each miss by one axis: the rune modules of
+  `ts-relative-import-nodenext` reached through the `paths` aliases of
+  `ts-aliased-import`. #1916's `.d.svelte.ts` bridge is reachable only via
+  `rootDirs`, which TypeScript applies to *relative* specifiers alone, and
+  #1888's exact-`paths` overrides enumerated real `.svelte` components alone —
+  so `$lib/state.svelte` still fell through to the ambient wildcard. Covers both
+  alias kinds (in-workspace `$lib/*` and an aliased sibling package `$libs/*`),
+  both importer kinds, and a `.svelte` component whose `.svelte.ts` companion
+  must not steal the specifier from it.
 - **`kit-hooks-fn-ts`**, **`kit-hooks-arrow-ts`**, **`kit-hooks-satisfies-ts`**,
   **`kit-hooks-js`** — one matrix covering every `handle`/`handleError`/
   `handleFetch`/`reroute` declaration shape:

--- a/crates/rsvelte_check/src/svelte_check/overlay.rs
+++ b/crates/rsvelte_check/src/svelte_check/overlay.rs
@@ -286,6 +286,7 @@ pub fn materialize_overlay_with(
         .iter()
         .map(|pkg| (pkg.real_dir.clone(), pkg.mirror_dir.clone()))
         .collect();
+    let mut module_bridges: Vec<(PathBuf, PathBuf)> = Vec::new();
     for pkg in &external {
         emit_external_shadows(
             pkg,
@@ -294,9 +295,13 @@ pub fn materialize_overlay_with(
             svelte_resolver.as_ref(),
             &ext_root_dir_pairs,
         )?;
-        emit_svelte_module_bridges(&pkg.real_dir, &pkg.mirror_dir, &[])?;
+        module_bridges.extend(emit_svelte_module_bridges(
+            &pkg.real_dir,
+            &pkg.mirror_dir,
+            &[],
+        )?);
     }
-    emit_svelte_module_bridges(workspace, &emit_dir, ignore)?;
+    module_bridges.extend(emit_svelte_module_bridges(workspace, &emit_dir, ignore)?);
 
     let mut entries = Vec::with_capacity(files.len());
     let mut augments: Vec<CompanionAugment> = Vec::new();
@@ -466,11 +471,13 @@ pub fn materialize_overlay_with(
     // `.tsx` — TS prefers an exact `paths` match over a wildcard pattern, and
     // since the resolved target no longer ends in `.svelte`, the ambient
     // wildcard is never consulted at all, applying regardless of which kind
-    // of file does the importing.
+    // of file does the importing. `module_bridges` gets the same entry for
+    // each rune module, whose `.d.svelte.ts` twin `rootDirs` alone cannot
+    // reach through a non-relative specifier (#1942).
     let alias_path_overrides = tsconfig_path
         .map(|tsconfig| {
             let alias_prefixes = resolve_paths_alias_prefixes(tsconfig);
-            compute_alias_path_overrides(&entries, &external, &alias_prefixes)
+            compute_alias_path_overrides(&entries, &external, &module_bridges, &alias_prefixes)
         })
         .unwrap_or_default();
 
@@ -1319,6 +1326,13 @@ fn rebase_spec(spec: &str, base_dir: &Path, cache_dir: &Path) -> String {
     }
 }
 
+/// Resolve symlinks where the path exists, and leave it untouched where it
+/// does not — so two paths that name the same file compare equal even when one
+/// side reached it through a symlinked temp dir.
+fn canonicalized(path: &Path) -> PathBuf {
+    path.canonicalize().unwrap_or_else(|_| path.to_path_buf())
+}
+
 /// Make `path` absolute by anchoring relative paths on the current working
 /// directory, then normalise `.`/`..` lexically. No filesystem access
 /// beyond reading the CWD, so it works for not-yet-created paths.
@@ -1630,40 +1644,50 @@ fn resolve_paths_alias_dirs_abs(tsconfig_path: &Path) -> Vec<PathBuf> {
 /// entry redirects the specifier straight to a file that doesn't end in
 /// `.svelte`, so the wildcard is never consulted, regardless of which kind of
 /// file does the importing.
+///
+/// `module_bridges` extends the same treatment to `<base>.svelte.ts` rune
+/// modules, whose specifier is likewise `<base>.svelte`: their
+/// [`write_esm_bridge`] twin is only reachable through `rootDirs`, and
+/// TypeScript applies `rootDirs` to RELATIVE specifiers alone, so an aliased
+/// rune module fell through to the same ambient wildcard even after #1941
+/// (#1942).
 fn compute_alias_path_overrides(
     entries: &[OverlayEntry],
     external: &[ExternalPackage],
+    module_bridges: &[(PathBuf, PathBuf)],
     alias_prefixes: &[(String, PathBuf)],
 ) -> Vec<(String, PathBuf)> {
     if alias_prefixes.is_empty() {
         return Vec::new();
     }
-    // (real source path, shadow .tsx path) for every discovered .svelte file.
-    let mut candidates: Vec<(&Path, PathBuf)> = entries
+    // (path the specifier names, overlay file it must resolve to), the former
+    // pre-canonicalized to compare against a canonicalized alias target dir.
+    let mut candidates: Vec<(PathBuf, PathBuf)> = entries
         .iter()
-        .map(|e| (e.source_path.as_path(), e.tsx_path.clone()))
+        .map(|e| (canonicalized(&e.source_path), e.tsx_path.clone()))
         .collect();
     for pkg in external {
         for abs_source in &pkg.svelte_files {
             let rel = safe_relative(abs_source, &pkg.real_dir);
             let tsx_path = pkg.mirror_dir.join(append_extension(&rel, ".tsx"));
-            candidates.push((abs_source.as_path(), tsx_path));
+            candidates.push((canonicalized(abs_source), tsx_path));
         }
+    }
+    // A rune module's specifier is its path minus the `.ts`/`.js`. Emission
+    // already dropped every module a sibling `.svelte` component shadows, so
+    // these can never outrank a component entry above.
+    for (module, bridge) in module_bridges {
+        candidates.push((canonicalized(module).with_extension(""), bridge.clone()));
     }
 
     let mut out = Vec::new();
     let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
-    for (real_source, tsx_path) in &candidates {
-        let real_canon = real_source
-            .canonicalize()
-            .unwrap_or_else(|_| real_source.to_path_buf());
+    for (real_canon, tsx_path) in &candidates {
         // Longest target-dir prefix wins when aliases nest.
         let best = alias_prefixes
             .iter()
             .filter_map(|(prefix, target_dir)| {
-                let target_canon = target_dir
-                    .canonicalize()
-                    .unwrap_or_else(|_| target_dir.clone());
+                let target_canon = canonicalized(target_dir);
                 real_canon
                     .strip_prefix(&target_canon)
                     .ok()
@@ -1770,11 +1794,16 @@ fn write_esm_bridge(path: &Path, content: &str, only_if_missing: bool) -> io::Re
 ///
 /// These bridges have no manifest entry to prune them by, so the mirror is also
 /// swept for ones whose source module has since been deleted or renamed.
+///
+/// Returns the `(rune module, bridge)` pairs it kept, for
+/// [`compute_alias_path_overrides`] to turn into exact `paths` entries — the
+/// skip and `.ts`-over-`.js` rules above are exactly the ones an alias
+/// specifier has to follow too (#1942).
 fn emit_svelte_module_bridges(
     root: &Path,
     mirror_dir: &Path,
     ignore: &[String],
-) -> Result<(), OverlayError> {
+) -> Result<Vec<(PathBuf, PathBuf)>, OverlayError> {
     let mut modules = super::walker::find_svelte_suffixed_modules(root, ignore);
     // `x.svelte.ts` and `x.svelte.js` share one bridge path; TypeScript probes
     // `.ts` first, so let it win.
@@ -1783,6 +1812,7 @@ fn emit_svelte_module_bridges(
         (is_js, p.clone())
     });
     let mut written: std::collections::HashSet<PathBuf> = std::collections::HashSet::new();
+    let mut kept: Vec<(PathBuf, PathBuf)> = Vec::new();
     for module in &modules {
         if module.with_extension("").is_file() {
             continue;
@@ -1814,9 +1844,10 @@ fn emit_svelte_module_bridges(
             let _ = writeln!(content, "export {{ default }} from \"{spec}\";");
         }
         fs::write(&bridge, content)?;
+        kept.push((module.clone(), bridge));
     }
     prune_orphaned_module_bridges(mirror_dir, &written);
-    Ok(())
+    Ok(kept)
 }
 
 /// Drop `.d.svelte.ts` files under `mirror_dir` that this run did not write and
@@ -3654,6 +3685,71 @@ mod tests {
         assert!(
             target.ends_with("Button.svelte.tsx"),
             "override does not point at the shadow: {target}"
+        );
+
+        let _ = fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn overlay_tsconfig_adds_exact_paths_override_for_an_aliased_rune_module() {
+        // #1942: #1941's `.d.svelte.ts` bridge is reachable only through
+        // `rootDirs`, which TypeScript applies to relative specifiers alone, so
+        // `$lib/state.svelte` needs an exact `paths` entry of its own.
+        let tmp = std::env::temp_dir().join(format!("svc_alias_rune_{}", std::process::id()));
+        let _ = fs::remove_dir_all(&tmp);
+        fs::create_dir_all(tmp.join("src/lib")).unwrap();
+        fs::write(
+            tmp.join("tsconfig.json"),
+            "{\"compilerOptions\":{\"paths\":{\"$lib/*\":[\"./src/lib/*\"]}}}",
+        )
+        .unwrap();
+        fs::write(
+            tmp.join("src/lib/state.svelte.ts"),
+            "export const shared = 1;\nexport default {};\n",
+        )
+        .unwrap();
+        // A rune module OUTSIDE every alias target contributes no entry.
+        fs::write(tmp.join("src/loose.svelte.ts"), "export const loose = 1;\n").unwrap();
+        // A component shadows its own companion, so the specifier must keep
+        // resolving to the component — the companion has no bridge to claim it.
+        fs::write(tmp.join("src/lib/Pair.svelte"), "<div></div>").unwrap();
+        fs::write(
+            tmp.join("src/lib/Pair.svelte.ts"),
+            "export const pair = 1;\n",
+        )
+        .unwrap();
+
+        let files = vec![tmp.join("src/lib/Pair.svelte")];
+        let tsconfig = tmp.join("tsconfig.json");
+        let layout = materialize_overlay_with(&tmp, &files, Some(&tsconfig), false, &[]).unwrap();
+
+        let cfg: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(&layout.overlay_tsconfig).unwrap()).unwrap();
+        let paths = &cfg["compilerOptions"]["paths"];
+
+        let target = paths["$lib/state.svelte"][0]
+            .as_str()
+            .unwrap_or_else(|| panic!("no exact override for $lib/state.svelte:\n{paths}"));
+        assert!(
+            target.ends_with("state.d.svelte.ts"),
+            "override does not point at the ESM bridge: {target}"
+        );
+        assert!(
+            Path::new(target).is_file(),
+            "override points at a file that was never emitted: {target}"
+        );
+
+        let pair = paths["$lib/Pair.svelte"][0]
+            .as_str()
+            .unwrap_or_else(|| panic!("no exact override for $lib/Pair.svelte:\n{paths}"));
+        assert!(
+            pair.ends_with("Pair.svelte.tsx"),
+            "the companion outranked its own component: {pair}"
+        );
+
+        assert!(
+            paths.get("$lib/loose.svelte").is_none(),
+            "a module outside the alias target got an entry:\n{paths}"
         );
 
         let _ = fs::remove_dir_all(&tmp);


### PR DESCRIPTION
## Summary

Fixes #1942 — under ESM-mode resolution (`moduleResolution: nodenext` + `"type": "module"`), an aliased import of a rune module (`$lib/state.svelte` naming a real `state.svelte.ts`) fell through to the ambient `declare module '*.svelte'`, erroring named imports with TS2614. #1941's `.d.svelte.ts` bridge is only reachable through `rootDirs`, which TypeScript applies to relative specifiers alone, and #1888's exact-`paths` overrides enumerated real `.svelte` components alone — the alias + rune-module intersection fell between them.

`emit_svelte_module_bridges` now returns the `(module, bridge)` pairs it actually wrote, and `compute_alias_path_overrides` adds one exact `paths` entry per rune module under an alias target. Reusing emission's own output carries its precedence rules for free: a module shadowed by a sibling `.svelte` component is absent (the component keeps the specifier), and `.ts` already won over `.js`.

New Layer-1 fixture `ts-aliased-rune-module-nodenext` (pnpm workspace, in-workspace `$lib/*` + aliased sibling-package `$libs/*`, `.ts` and `.svelte` importers, named/default rune modules, companion-shadowed component), written repro-first: 6 divergences before the fix (TS2614 ×6, TS2554 ×2), 0 after.

## Verification

- `node scripts/compat-corpus/check-verify.mjs`: all 17 scenarios, 0 divergences (reviewer independently re-verified, including reverting the fix to reproduce the 6 divergences and restoring it).
- `cargo test -p rsvelte_check`: green (131 unit + integration suites).
- `cargo +1.97 clippy -- -D warnings` / `cargo fmt --check`: clean.
- Pre-existing divergences observed nearby are filed as #2061 (out of scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SfqweP3NTX8WEWvaQmerDZ