### PR TITLE
fix(compiler): label legacy state sources with $.tag in dev (part of #2021)

### DIFF
--- a/.changeset/fix-legacy-mutable-source-tag.md
+++ b/.changeset/fix-legacy-mutable-source-tag.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/compiler": patch
+---
+
+fix(compiler): label legacy state sources with `$.tag($.mutable_source(…), 'name')` in dev, so `$inspect.trace()` and devtools can name them

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
@@ -5594,7 +5594,12 @@ fn transform_instance_script_for_visitors(
         //   `let a = $.mutable_source();\nlet b = $.mutable_source();`
         // and then wrap_state_vars_in_expr correctly skips them since each starts with `let `.
         let transformed = if !analysis.runes && !legacy_state_vars.is_empty() {
-            transform_legacy_state_declarations(&transformed, legacy_state_vars, analysis.immutable)
+            transform_legacy_state_declarations(
+                &transformed,
+                legacy_state_vars,
+                analysis.immutable,
+                dev,
+            )
         } else {
             transformed
         };

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/state_transforms.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/state_transforms.rs
@@ -1547,6 +1547,19 @@ pub(super) fn extract_legacy_destructure_var_names(pattern: &str) -> Vec<String>
     names
 }
 
+/// Dev-mode `$.tag(<source>, '<name>')` label for a legacy state source.
+///
+/// Only declarations reaching this emitter are tagged: `legacy_reactive`
+/// sources (`$: x = …`) are built as AST elsewhere and upstream leaves those
+/// untagged even though they print the same `$.mutable_source()` call.
+fn tag_legacy_source(call: String, name: &str, dev: bool) -> String {
+    if dev {
+        format!("$.tag({}, '{}')", call, name)
+    } else {
+        call
+    }
+}
+
 /// Transform legacy state declarations to $.mutable_source() calls.
 ///
 /// In legacy (non-runes) mode, variables that are promoted to State kind
@@ -1561,6 +1574,7 @@ pub(super) fn transform_legacy_state_declarations(
     line: &str,
     legacy_state_vars: &[(String, Option<String>, DeclarationKind)],
     immutable: bool,
+    dev: bool,
 ) -> String {
     if legacy_state_vars.is_empty() {
         return line.to_string();
@@ -1575,7 +1589,7 @@ pub(super) fn transform_legacy_state_declarations(
     if !is_destructure_expansion && let Some(split_lines) = split_multi_declarator(line) {
         let transformed_lines: Vec<String> = split_lines
             .iter()
-            .map(|l| transform_legacy_state_declarations(l, legacy_state_vars, immutable))
+            .map(|l| transform_legacy_state_declarations(l, legacy_state_vars, immutable, dev))
             .collect();
         return transformed_lines.join("\n");
     }
@@ -1643,11 +1657,17 @@ pub(super) fn transform_legacy_state_declarations(
                     let expr = after[..expr_end].trim().trim_end_matches(';').trim();
 
                     // Build the replacement
-                    let replacement = if immutable {
-                        format!("{} {} = $.mutable_source({}, true)", keyword, var, expr)
+                    let call = if immutable {
+                        format!("$.mutable_source({}, true)", expr)
                     } else {
-                        format!("{} {} = $.mutable_source({})", keyword, var, expr)
+                        format!("$.mutable_source({})", expr)
                     };
+                    let replacement = format!(
+                        "{} {} = {}",
+                        keyword,
+                        var,
+                        tag_legacy_source(call, var, dev)
+                    );
 
                     // Replace the declaration
                     result = format!(
@@ -1707,11 +1727,17 @@ pub(super) fn transform_legacy_state_declarations(
                         let after = &after_raw[ws..];
                         let expr_end = find_statement_end_client(after);
                         let expr = after[..expr_end].trim().trim_end_matches(';').trim();
-                        let replacement = if immutable {
-                            format!("{} {} = $.mutable_source({}, true)", keyword, var, expr)
+                        let call = if immutable {
+                            format!("$.mutable_source({}, true)", expr)
                         } else {
-                            format!("{} {} = $.mutable_source({})", keyword, var, expr)
+                            format!("$.mutable_source({})", expr)
                         };
+                        let replacement = format!(
+                            "{} {} = {}",
+                            keyword,
+                            var,
+                            tag_legacy_source(call, var, dev)
+                        );
                         result = format!(
                             "{}{}{}",
                             &result[..pos],
@@ -1744,11 +1770,17 @@ pub(super) fn transform_legacy_state_declarations(
 
                     // Build the replacement - no initial value, so pass nothing to $.mutable_source()
                     // (upstream emits `void 0`, not the `undefined` identifier).
-                    let replacement = if immutable {
-                        format!("{} {} = $.mutable_source(void 0, true);", keyword, var)
+                    let call = if immutable {
+                        "$.mutable_source(void 0, true)".to_string()
                     } else {
-                        format!("{} {} = $.mutable_source();", keyword, var)
+                        "$.mutable_source()".to_string()
                     };
+                    let replacement = format!(
+                        "{} {} = {};",
+                        keyword,
+                        var,
+                        tag_legacy_source(call, var, dev)
+                    );
 
                     // Replace the declaration
                     result = format!(
@@ -1813,11 +1845,17 @@ pub(super) fn transform_legacy_state_declarations(
                         let after = &result[after_eq..];
                         let expr_end = find_statement_end_client(after);
                         let expr = after[..expr_end].trim().trim_end_matches(';').trim();
-                        let replacement = if immutable {
-                            format!("{} {} = $.mutable_source({}, true)", keyword, var, expr)
+                        let call = if immutable {
+                            format!("$.mutable_source({}, true)", expr)
                         } else {
-                            format!("{} {} = $.mutable_source({})", keyword, var, expr)
+                            format!("$.mutable_source({})", expr)
                         };
+                        let replacement = format!(
+                            "{} {} = {}",
+                            keyword,
+                            var,
+                            tag_legacy_source(call, var, dev)
+                        );
                         result = format!(
                             "{}{}{}",
                             &result[..pos],
@@ -1861,7 +1899,7 @@ mod non_ascii_tests {
         // `let x: Café = 0` — the `=` sits past a multi-byte char in the type
         // annotation; slicing must use byte offsets (no panic).
         let vars = vec![("x".to_string(), None, DeclarationKind::Let)];
-        let out = transform_legacy_state_declarations("let x: Café = 0", &vars, false);
+        let out = transform_legacy_state_declarations("let x: Café = 0", &vars, false, false);
         assert!(out.contains("$.mutable_source(0)"), "got: {out}");
     }
 }

--- a/crates/rsvelte_core/tests/legacy_state_tag_2021.rs
+++ b/crates/rsvelte_core/tests/legacy_state_tag_2021.rs
@@ -1,0 +1,82 @@
+//! Regression tests for the legacy half of issue #2021 — in `dev: true` a legacy
+//! state source is labelled with its declaration name.
+//!
+//! `$: x = …` sources print the same `$.mutable_source()` call but must stay
+//! untagged: upstream builds them separately (`transform-client.js:213-219`) and
+//! never labels them.
+
+use rsvelte_core::{CompileOptions, GenerateMode, compile, compiler::CssMode};
+
+fn compile_client(src: &str, dev: bool) -> String {
+    compile(
+        src,
+        CompileOptions {
+            filename: Some("Comp.svelte".to_string()),
+            generate: GenerateMode::Client,
+            dev,
+            css: CssMode::External,
+            ..Default::default()
+        },
+    )
+    .expect("compile")
+    .js
+    .code
+}
+
+const WITH_INIT: &str = "<script>let count = 0; function inc() { count++; }</script><button onclick={inc}>{count}</button>";
+const WITHOUT_INIT: &str = "<script>let count; function inc() { count = 1; }</script><button onclick={inc}>{count}</button>";
+const REACTIVE: &str =
+    "<script>let n = 0; $: doubled = n * 2; function f() { n++; }</script><p>{doubled}</p>";
+
+#[test]
+fn initialised_source_is_tagged_in_dev() {
+    let out = compile_client(WITH_INIT, true);
+    assert!(
+        out.contains("$.tag($.mutable_source(0), 'count')"),
+        "missing the dev label in:\n{out}"
+    );
+}
+
+#[test]
+fn uninitialised_source_is_tagged_in_dev() {
+    let out = compile_client(WITHOUT_INIT, true);
+    assert!(
+        out.contains("$.tag($.mutable_source(), 'count')"),
+        "missing the dev label in:\n{out}"
+    );
+}
+
+#[test]
+fn immutable_keeps_its_second_argument_inside_the_tag() {
+    let src = "<script>let count = 0; function inc() { count++; }</script><svelte:options immutable />{count}";
+    let out = compile_client(src, true);
+    assert!(
+        out.contains("$.tag($.mutable_source(0, true), 'count')"),
+        "wrong shape in:\n{out}"
+    );
+}
+
+/// `$: x = …` is a `legacy_reactive` binding, emitted elsewhere and never tagged.
+#[test]
+fn reactive_declaration_source_stays_untagged() {
+    let out = compile_client(REACTIVE, true);
+    assert!(
+        out.contains("const doubled = $.mutable_source();"),
+        "the reactive source was rewritten in:\n{out}"
+    );
+    assert!(
+        !out.contains("'doubled'"),
+        "the reactive source picked up a label in:\n{out}"
+    );
+}
+
+#[test]
+fn production_emits_no_label() {
+    for src in [WITH_INIT, WITHOUT_INIT, REACTIVE] {
+        let out = compile_client(src, false);
+        assert!(
+            !out.contains("$.tag("),
+            "production picked up a dev label in:\n{out}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

In `dev: true` upstream wraps every reactive source in `$.tag(source, '<name>')` so `$inspect.trace()` and devtools can name it. This ports the **legacy `$.mutable_source`** half — the issue's headline example:

```js
// official (dev)
let count = $.tag($.mutable_source(0), 'count');

// rsvelte (before)
let count = $.mutable_source(0);
```

**This is a partial fix, so it says `Part of #2021` rather than `Fixes`.** Measurements and the exact remaining work are below.

## Why the tag goes at the emitter, not in the text scan

rsvelte already has a post-pass (`wrap_state_derived_with_tag`) that scans for `$.state(` / `$.derived(` / `$.proxy(` declarations, and adding `$.mutable_source(` to its table looks like the one-line fix. It is wrong: `$: x = …` produces a `legacy_reactive` binding that upstream emits as `const x = $.mutable_source()` and **never tags** (`transform-client.js:213-219`), and after printing it is textually indistinguishable from an untagged legacy state source.

So the tag is applied in `transform_legacy_state_declarations` (4 emit sites), which only ever sees real state declarations. `legacy_reactive` sources are built as AST in `client/mod.rs` and never pass through it. There is a regression test for exactly this.

## Verification

Every legacy shape compiled with both compilers, `dev` on and off, comparing the `$.mutable_source` / `$.tag` lines — **14/14 identical**: initialised, uninitialised, `immutable` (the `, true` argument stays inside the tag), `const` state, `$:` reactive (stays untagged), reactive + state together, and store subscriptions.

- New suite `crates/rsvelte_core/tests/legacy_state_tag_2021.rs` — 5 tests, including the untagged-`legacy_reactive` guard and a production-form guard.
- `cargo test --release -p rsvelte_core` — **148 binaries, 2086 tests, 0 failures**.
- `cargo test --lib`, `cargo fmt`, `cargo clippy` (changed files warning-free).
- **Full output-equality corpus**: 14,005 entries × 3 targets, oxfmt-inclusive verify — `✅ no regressions`, **388 known failures now pass**.

## Baseline

`known-failures.client-dev.json`: **4106 → 3718** (rebased onto #2071, which had already taken it from 4565 to 4106; the 388 are unchanged by that rebase). Shrunk by filtering the old list against the current failure set (shrink-only by construction, `--update-baseline` not used); a second verify against the shrunk list reports no regressions.

`known-failures.md` halves the CD2 row (628 → 240) and records the label forms below; the table now sums to 3382 + 336 residue = 3718.

## What is left in #2021 (measured, not guessed)

After this change the report still has **99** first-line divergences that mention `$.tag`, in two independent sub-gaps:

| remaining | shape | where |
|---|---|---|
| **59** | destructured `$derived` / `$state`: the leaf declarators and the `$$array` inserts are untagged | `client/rune_transforms.rs` — `process_derived_object_pattern` (827), `process_nested_pattern_elements` (1035), `process_derived_array_pattern` (1223); none currently take `dev` |
| **31** | class fields in `.svelte.(js\|ts)` modules | `ClassBody.js:82-90` upstream; `tag_class_field_ast.rs` here |
| — | **legacy** top-level destructuring (`let { a, b } = obj` in a non-runes component) gets no label at all: `transform_legacy_destructure_declarations` takes no `dev`. Upstream labels only the state leaves — `a = $.tag($.mutable_source(tmp.a), 'a')` — leaving the `tmp` / `$$array` intermediates bare | `client/state_transforms.rs:1269` |

**The label is not the declarator name in either of these.** Confirmed against the official compiler rather than read off the source, because the form differs per branch:

| shape | label |
|---|---|
| `#count = $state(0)` in `class Foo` | `'Foo.#count'` — the `#` is kept |
| `count = $state(0)` in `class Foo` | `'Foo.count'` — public name, even though the emitted field is the generated `#count` |
| the same in an anonymous class | `'[class].count'` |
| `$$array` insert, array pattern | `'[$derived iterable]'` / `'[$state iterable]'` |
| `$$array` insert, object pattern | `'[$derived object]'` |
| destructured leaf | the leaf's own name |
| `{@const d = …}` | `'d'` |
| `{@const { a, b } = …}` | `'[@const]'` |

I stopped here deliberately rather than folding both in: destructuring codegen is the area flagged in `known-failures.md` as having caused wide regressions before, and each sub-gap needs its own emitter change plus its own corpus measurement. Happy to take either as a follow-up — say which.

Part of #2021

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FKkTpzZGaGWWzJvw4BnHJs

