### PR TITLE
fix(compiler): put the dev `...$.legacy_api()` spread first in `$$exports` (#2023)

### DIFF
--- a/.changeset/fix-legacy-api-position.md
+++ b/.changeset/fix-legacy-api-position.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/compiler": patch
+---
+
+fix(compiler): put the dev-mode `...$.legacy_api()` spread first in a legacy component's `$$exports` object instead of last, matching the official compiler

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
@@ -1599,14 +1599,19 @@ fn transform_client_with_visitors(
                 ),
             ));
         } else if options.dev {
-            exports_members.push(b::spread(
-                &context.arena,
-                b::call(
+            // Upstream `unshift`s this one (transform-client.js:345) while the
+            // componentApi: 4 members above are pushed, so it leads the object.
+            exports_members.insert(
+                0,
+                b::spread(
                     &context.arena,
-                    b::member_path(&context.arena, "$.legacy_api"),
-                    vec![],
+                    b::call(
+                        &context.arena,
+                        b::member_path(&context.arena, "$.legacy_api"),
+                        vec![],
+                    ),
                 ),
-            ));
+            );
         }
 
         if !exports_members.is_empty() {


### PR DESCRIPTION
Fixes #2023.

## What was actually wrong

Like #2022, the issue title says the spread "is not emitted". It is — in every one of these entries. It is emitted in the wrong **position**.

Upstream builds the returned object and then, for a legacy-mode component in dev, `unshift`s the spread onto it (`transform-client.js:345`), while the `componentApi: 4` `$set` / `$on` members in the sibling branch are `push`ed. So the spread leads the object and the user's accessors follow. rsvelte pushed it, putting it last:

```js
// official                        // rsvelte (before)
var $$exports = {                  var $$exports = {
  ...$.legacy_api(),                 get isUsingKeyboard() {
  get isUsingKeyboard() {              return isUsingKeyboard;
    return isUsingKeyboard;          },
  },                                 ...$.legacy_api(),
};                                 };
```

## The fix

One call: `exports_members.push(...)` → `exports_members.insert(0, ...)`, in the `dev` branch only. The `componentApi: 4` branch keeps `push`, matching upstream.

`insert(0, …)` is the last mutation of `exports_members` before the object is built, and every getter/setter (including the dedup `pop()` loops) runs earlier, so the spread reliably lands first.

## Verification

Full corpus, all three targets (14,005 entries × 3 = 42,015 compilations), oxfmt-normalized comparison:

```
match            9538
error-parity      948
js-mismatch      3519
css-mismatch        0
error-mismatch      0

✅ no regressions (client 0, server 0, client-dev 3519 known failures remain)
🎉 587 known failures now PASS (client 0, server 0, client-dev 587)
```

`client` and `server` are untouched, as expected for a `dev`-gated branch.

Representative entry `bits-ui/tests/src/tests/utilities/is-using-keyboard/is-using-keyboard-test.svelte` reduces to a byte match; its whole diff was those two lines.

## Baseline commit follows

Per the merge ordering, this PR carries **code + changeset only**. The `client-dev` ratchet shrink (4106 → 3519 measured against the pre-#2072 baseline; the final number will be regenerated against whatever main holds at merge time) and the matching `known-failures.md` CD4 removal land as a separate commit once #2074 is in, so the ratchet is regenerated exactly once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FKkTpzZGaGWWzJvw4BnHJs