### PR TITLE
fix(compiler): anchor the `rest_excludes` hoist on the dev template factory (#2020)

### DIFF
--- a/.changeset/fix-rest-excludes-hoist-order.md
+++ b/.changeset/fix-rest-excludes-hoist-order.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/compiler": patch
+---
+
+fix(compiler): keep the hoisted `rest_excludes` set ahead of the template factory in dev, where the factory is wrapped in `$.add_locations(...)`

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
@@ -2486,25 +2486,37 @@ fn extract_rest_excludes_hoists(code: &mut String) -> Vec<(String, String)> {
 /// `$.from_tree(...)` / `$.with_script(...)`. The `rest_excludes` hoist is
 /// inserted immediately before the first such statement so it lands right after
 /// the imports / module-script preamble, matching upstream's `state.hoisted`
-/// ordering. A dev-mode `$.add_locations(...)` wrapper is intentionally *not*
-/// matched, so those fall through to the `export default` anchor.
+/// ordering. In dev the factory is wrapped in `$.add_locations(...)`, so the
+/// match looks through that wrapper to the factory call it carries.
 fn is_client_template_factory(arena: &super::js_ast::JsArena, stmt: &JsStatement) -> bool {
+    fn callee_name<'a>(
+        arena: &'a super::js_ast::JsArena,
+        expr: &'a JsExpr,
+    ) -> Option<(&'a str, &'a super::js_ast::nodes::JsCallExpression)> {
+        let JsExpr::Call(call) = expr else {
+            return None;
+        };
+        let JsExpr::Member(m) = arena.get_expr(call.callee) else {
+            return None;
+        };
+        if !matches!(arena.get_expr(m.object), JsExpr::Identifier(o) if o == "$") {
+            return None;
+        }
+        match &m.property {
+            super::js_ast::nodes::JsMemberProperty::Identifier(p) => Some((p.as_str(), call)),
+            _ => None,
+        }
+    }
     fn callee_is_factory(arena: &super::js_ast::JsArena, expr: &JsExpr) -> bool {
-        match expr {
-            JsExpr::Call(call) => match arena.get_expr(call.callee) {
-                JsExpr::Member(m) => {
-                    matches!(arena.get_expr(m.object), JsExpr::Identifier(o) if o == "$")
-                        && matches!(
-                            &m.property,
-                            super::js_ast::nodes::JsMemberProperty::Identifier(p)
-                                if matches!(
-                                    p.as_str(),
-                                    "from_html" | "from_svg" | "from_mathml" | "from_tree" | "with_script"
-                                )
-                        )
-                }
-                _ => false,
-            },
+        let Some((name, call)) = callee_name(arena, expr) else {
+            return false;
+        };
+        match name {
+            "from_html" | "from_svg" | "from_mathml" | "from_tree" | "with_script" => true,
+            "add_locations" => call
+                .arguments
+                .first()
+                .is_some_and(|a| callee_is_factory(arena, a)),
             _ => false,
         }
     }
@@ -2527,6 +2539,7 @@ fn stmt_text_has_factory(s: &str) -> bool {
         "= $.from_mathml(",
         "= $.from_tree(",
         "= $.with_script(",
+        "= $.add_locations(",
     ];
     NEEDLES.iter().any(|n| s.contains(n))
 }


### PR DESCRIPTION
Fixes #2020.

## What was actually wrong

The issue reports `$.add_locations` template location metadata as "not emitted". It is emitted, in every entry, with correct position tuples. The divergence is the **order of two hoisted statements**:

```js
// official                                         // rsvelte (before)
var rest_excludes = new Set([…]);                   var root = $.add_locations($.from_html(…), …);
var root = $.add_locations($.from_html(…), …);      var rest_excludes = new Set([…]);
```

Upstream pushes `rest_excludes` onto `state.hoisted` while visiting the instance script, which happens before the template is transformed, so it naturally precedes `var root`. rsvelte builds the hoist afterwards and inserts it before the first module-scope template-factory declaration to reproduce that order.

`is_client_template_factory` only looked one call deep — `$.from_html` / `$.from_svg` / `$.from_mathml` / `$.from_tree` / `$.with_script` as the outermost callee. In dev, `transform_template` wraps the factory:

```js
let call = b.call(`$.from_${namespace}`, …);
if (state.template.contains_script_tag) call = b.call('$.with_script', call);
if (dev) call = b.call('$.add_locations', call, …);
```

so nothing matched, the search fell through to the `export default` anchor, and the hoist landed after `var root` instead of before it. The existing doc comment asserted the `$.add_locations` wrapper was "intentionally not matched", which is what made this look deliberate.

## The fix

Look through the wrapper to the factory it carries, and add the matching needle to the text-statement path. Production is unaffected: there the factory is still the outermost call, so it matches the same branch it always did, and the new `add_locations` arm can only fire on a shape that is exclusively generated under `dev`.

## Verification

Full corpus, all three targets (14,005 entries × 3 = 42,015 compilations), oxfmt-normalized comparison, measured on `d1dda6da`:

```
match           10206
error-parity      948
js-mismatch      2851
css-mismatch        0
error-mismatch      0

✅ no regressions (client 0, server 0, client-dev 2851 known failures remain)
🎉 796 known failures now PASS (client 0, server 0, client-dev 796)
```

`client` and `server` are byte-unchanged, which is the specific risk this fix carried.

796 is well above the ~639 I projected. This cluster has **zero** entries where it is the sole cause — 783 of its 1014 co-occur with the `$.rest_props` dev argument — so it only pays out now that #2024 has landed.

## Baseline commit follows

Code + changeset only, per the merge ordering. The `client-dev` ratchet shrink and the `known-failures.md` updates (retiring both the CD1 and CD4 rows, with the attribution for each) land as a separate commit once #2074 is in, so the ratchet is regenerated exactly once against final main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FKkTpzZGaGWWzJvw4BnHJs