### PR TITLE
fix(compiler): label destructured $derived / $state declarations in dev (part of #2021)

### DIFF
--- a/.changeset/fix-destructure-tag-labels.md
+++ b/.changeset/fix-destructure-tag-labels.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/compiler": patch
+---
+
+fix(compiler): label destructured `$derived` / `$state` declarations in dev — leaf bindings by name, the `$$array` temps by pattern kind (`[$derived object]` and friends), and legacy destructured state sources by name

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/ast_state_transform.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/ast_state_transform.rs
@@ -42,6 +42,23 @@ thread_local! {
 /// Recursively collect every `BindingIdentifier` name reachable inside a
 /// `BindingPattern`. Used by the props-destructure handler to emit the
 /// `/* $$async_noop:name1,name2 */` async-mode placeholder.
+/// Label the leaf declarators of a destructured `$derived` with their own
+/// binding names. The `$$array` temps are already labelled by pattern kind at
+/// their emit site, and the `$$d` source temp upstream leaves bare, so both are
+/// skipped here.
+fn tag_derived_leaves(declarations: &mut [String]) {
+    for decl in declarations.iter_mut() {
+        let Some((name, init)) = decl.split_once(" = ") else {
+            continue;
+        };
+        if name.starts_with("$$array") || name.starts_with("$$d") || !init.starts_with("$.derived(")
+        {
+            continue;
+        }
+        *decl = format!("{} = $.tag({}, '{}')", name, init, name);
+    }
+}
+
 fn collect_binding_identifier_names(pattern: &BindingPattern<'_>, out: &mut Vec<String>) {
     match pattern {
         BindingPattern::BindingIdentifier(id) => out.push(id.name.to_string()),
@@ -1094,10 +1111,18 @@ impl<'a, 's> StateVarCollector<'a, 's> {
         } else {
             format!("$.to_array({}, {})", tmp_name, element_count)
         };
-        declarations.push(format!(
-            "{} = $.derived(() => {})",
-            array_var, to_array_args
-        ));
+        // The temp holding the iterable is labelled by pattern kind, not by a
+        // binding name — it has none. `collect_state_array_pattern` only ever
+        // runs for a top-level array pattern, so the kind is fixed.
+        let array_init = if self.dev {
+            format!(
+                "$.tag($.derived(() => {}), '[$state iterable]')",
+                to_array_args
+            )
+        } else {
+            format!("$.derived(() => {})", to_array_args)
+        };
+        declarations.push(format!("{} = {}", array_var, array_init));
 
         for (index, elem_opt) in arr.elements.iter().enumerate() {
             let Some(elem) = elem_opt else { continue };
@@ -1294,6 +1319,16 @@ impl<'a, 's> StateVarCollector<'a, 's> {
             base_expr.clone()
         };
 
+        // Upstream labels the `$$array` temps by the *top-level* declarator's
+        // pattern kind, so `let { a: [x] } = $derived(o)` says "object" even for
+        // the inner array (`VariableDeclaration.js:176-186`).
+        let insert_label = self.dev.then(|| {
+            if pattern_text.trim_start().starts_with('[') {
+                "[$derived iterable]"
+            } else {
+                "[$derived object]"
+            }
+        });
         let mut array_counter: usize = 0;
         if process_derived_destructuring_pattern(
             &pattern_text,
@@ -1301,6 +1336,7 @@ impl<'a, 's> StateVarCollector<'a, 's> {
             &member_base,
             &mut declarations,
             &mut array_counter,
+            insert_label,
         )
         .is_none()
         {
@@ -1308,6 +1344,9 @@ impl<'a, 's> StateVarCollector<'a, 's> {
         }
         if declarations.is_empty() {
             return false;
+        }
+        if self.dev {
+            tag_derived_leaves(&mut declarations);
         }
 
         // Replacement covers [pattern_start, init_end] so the keyword and
@@ -1377,6 +1416,16 @@ impl<'a, 's> StateVarCollector<'a, 's> {
         let mut declarations: Vec<String> =
             vec![format!("{} = $.derived({})", d_name, wrapped_source)];
         let base_expr = format!("$.get({})", d_name);
+        // Upstream labels the `$$array` temps by the *top-level* declarator's
+        // pattern kind, so `let { a: [x] } = $derived(o)` says "object" even for
+        // the inner array (`VariableDeclaration.js:176-186`).
+        let insert_label = self.dev.then(|| {
+            if pattern_text.trim_start().starts_with('[') {
+                "[$derived iterable]"
+            } else {
+                "[$derived object]"
+            }
+        });
         let mut array_counter: usize = 0;
         if process_derived_destructuring_pattern(
             &pattern_text,
@@ -1384,6 +1433,7 @@ impl<'a, 's> StateVarCollector<'a, 's> {
             &base_expr,
             &mut declarations,
             &mut array_counter,
+            insert_label,
         )
         .is_none()
         {
@@ -1391,6 +1441,9 @@ impl<'a, 's> StateVarCollector<'a, 's> {
         }
         if declarations.is_empty() {
             return false;
+        }
+        if self.dev {
+            tag_derived_leaves(&mut declarations);
         }
 
         let replacement = declarations.join(",\n\t");

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/ast_state_transform.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/ast_state_transform.rs
@@ -42,23 +42,6 @@ thread_local! {
 /// Recursively collect every `BindingIdentifier` name reachable inside a
 /// `BindingPattern`. Used by the props-destructure handler to emit the
 /// `/* $$async_noop:name1,name2 */` async-mode placeholder.
-/// Label the leaf declarators of a destructured `$derived` with their own
-/// binding names. The `$$array` temps are already labelled by pattern kind at
-/// their emit site, and the `$$d` source temp upstream leaves bare, so both are
-/// skipped here.
-fn tag_derived_leaves(declarations: &mut [String]) {
-    for decl in declarations.iter_mut() {
-        let Some((name, init)) = decl.split_once(" = ") else {
-            continue;
-        };
-        if name.starts_with("$$array") || name.starts_with("$$d") || !init.starts_with("$.derived(")
-        {
-            continue;
-        }
-        *decl = format!("{} = $.tag({}, '{}')", name, init, name);
-    }
-}
-
 fn collect_binding_identifier_names(pattern: &BindingPattern<'_>, out: &mut Vec<String>) {
     match pattern {
         BindingPattern::BindingIdentifier(id) => out.push(id.name.to_string()),
@@ -82,6 +65,39 @@ fn collect_binding_identifier_names(pattern: &BindingPattern<'_>, out: &mut Vec<
             collect_binding_identifier_names(&assign.left, out);
         }
     }
+}
+
+/// Label the leaf declarators of a destructured `$derived` with their own
+/// binding names. The `$$array` temps are already labelled by pattern kind at
+/// their emit site, and the `$$d` source temp upstream leaves bare, so both are
+/// skipped here.
+fn tag_derived_leaves(declarations: &mut [String], dev: bool) {
+    if !dev {
+        return;
+    }
+    for decl in declarations.iter_mut() {
+        let Some((name, init)) = decl.split_once(" = ") else {
+            continue;
+        };
+        if name.starts_with("$$array") || name.starts_with("$$d") || !init.starts_with("$.derived(")
+        {
+            continue;
+        }
+        *decl = format!("{} = $.tag({}, '{}')", name, init, name);
+    }
+}
+
+/// The `$$array` label for a destructured `$derived`. Upstream reads the kind
+/// off the *top-level* declarator, so `let { a: [x] } = $derived(o)` says
+/// "object" even for the inner array (`VariableDeclaration.js:176-186`).
+fn derived_insert_label(dev: bool, pattern_text: &str) -> Option<&'static str> {
+    dev.then(|| {
+        if pattern_text.trim_start().starts_with('[') {
+            "[$derived iterable]"
+        } else {
+            "[$derived object]"
+        }
+    })
 }
 
 /// AST-based should_proxy check, mirroring the official Svelte compiler's `should_proxy()`.
@@ -1113,7 +1129,8 @@ impl<'a, 's> StateVarCollector<'a, 's> {
         };
         // The temp holding the iterable is labelled by pattern kind, not by a
         // binding name — it has none. `collect_state_array_pattern` only ever
-        // runs for a top-level array pattern, so the kind is fixed.
+        // runs for a top-level array pattern, so the kind is fixed; the sibling
+        // form upstream can emit is `'[$state object]'`.
         let array_init = if self.dev {
             format!(
                 "$.tag($.derived(() => {}), '[$state iterable]')",
@@ -1319,16 +1336,7 @@ impl<'a, 's> StateVarCollector<'a, 's> {
             base_expr.clone()
         };
 
-        // Upstream labels the `$$array` temps by the *top-level* declarator's
-        // pattern kind, so `let { a: [x] } = $derived(o)` says "object" even for
-        // the inner array (`VariableDeclaration.js:176-186`).
-        let insert_label = self.dev.then(|| {
-            if pattern_text.trim_start().starts_with('[') {
-                "[$derived iterable]"
-            } else {
-                "[$derived object]"
-            }
-        });
+        let insert_label = derived_insert_label(self.dev, &pattern_text);
         let mut array_counter: usize = 0;
         if process_derived_destructuring_pattern(
             &pattern_text,
@@ -1345,9 +1353,7 @@ impl<'a, 's> StateVarCollector<'a, 's> {
         if declarations.is_empty() {
             return false;
         }
-        if self.dev {
-            tag_derived_leaves(&mut declarations);
-        }
+        tag_derived_leaves(&mut declarations, self.dev);
 
         // Replacement covers [pattern_start, init_end] so the keyword and
         // optional trailing pieces of the VariableDeclaration remain.
@@ -1416,16 +1422,7 @@ impl<'a, 's> StateVarCollector<'a, 's> {
         let mut declarations: Vec<String> =
             vec![format!("{} = $.derived({})", d_name, wrapped_source)];
         let base_expr = format!("$.get({})", d_name);
-        // Upstream labels the `$$array` temps by the *top-level* declarator's
-        // pattern kind, so `let { a: [x] } = $derived(o)` says "object" even for
-        // the inner array (`VariableDeclaration.js:176-186`).
-        let insert_label = self.dev.then(|| {
-            if pattern_text.trim_start().starts_with('[') {
-                "[$derived iterable]"
-            } else {
-                "[$derived object]"
-            }
-        });
+        let insert_label = derived_insert_label(self.dev, &pattern_text);
         let mut array_counter: usize = 0;
         if process_derived_destructuring_pattern(
             &pattern_text,
@@ -1442,9 +1439,7 @@ impl<'a, 's> StateVarCollector<'a, 's> {
         if declarations.is_empty() {
             return false;
         }
-        if self.dev {
-            tag_derived_leaves(&mut declarations);
-        }
+        tag_derived_leaves(&mut declarations, self.dev);
 
         let replacement = declarations.join(",\n\t");
         let start = pattern_span.start;

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
@@ -5581,6 +5581,7 @@ fn transform_instance_script_for_visitors(
                 &transformed,
                 &state_var_names,
                 analysis.immutable,
+                dev,
             )
         } else {
             transformed

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/rune_transforms.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/rune_transforms.rs
@@ -713,6 +713,17 @@ pub(super) fn wrap_state_value(member_access: &str, is_raw: bool, is_skip: bool)
     }
 }
 
+/// Dev-mode `$.tag(<derived>, '<label>')` label for a destructured `$derived`
+/// declarator. `label` is `None` outside dev; the `$$array` temps carry the
+/// declarator-wide `[$derived iterable|object]` kind (they have no name of their
+/// own) while every leaf carries its own binding name.
+fn tag_derived(init: String, label: Option<&str>) -> String {
+    match label {
+        Some(label) => format!("$.tag({}, '{}')", init, label),
+        None => init,
+    }
+}
+
 /// `member_base` is the base expression used for **member reads** (`base.key`),
 /// while `base_expr` is used for the top-level rest's `$.exclude_from_object`.
 /// They differ only when destructuring `$derived(<rest-prop-binding>)`: a
@@ -728,14 +739,29 @@ pub(super) fn process_derived_destructuring_pattern(
     member_base: &str,
     declarations: &mut Vec<String>,
     array_counter: &mut usize,
+    insert_label: Option<&str>,
 ) -> Option<()> {
     let pattern = pattern.trim();
     if pattern.starts_with('{') && pattern.ends_with('}') {
         let inner = &pattern[1..pattern.len() - 1];
-        process_derived_object_pattern(inner, base_expr, member_base, declarations, array_counter)
+        process_derived_object_pattern(
+            inner,
+            base_expr,
+            member_base,
+            declarations,
+            array_counter,
+            insert_label,
+        )
     } else if pattern.starts_with('[') && pattern.ends_with(']') {
         let inner = &pattern[1..pattern.len() - 1];
-        process_derived_array_pattern(inner, base_expr, member_base, declarations, array_counter)
+        process_derived_array_pattern(
+            inner,
+            base_expr,
+            member_base,
+            declarations,
+            array_counter,
+            insert_label,
+        )
     } else {
         None
     }
@@ -830,6 +856,7 @@ pub(super) fn process_derived_object_pattern(
     member_base: &str,
     declarations: &mut Vec<String>,
     array_counter: &mut usize,
+    insert_label: Option<&str>,
 ) -> Option<()> {
     let properties = split_derived_object_properties(inner);
 
@@ -846,7 +873,12 @@ pub(super) fn process_derived_object_pattern(
             let prop_access = derived_prop_access(base_expr, member_base, key);
             if value_pattern.starts_with('[') || value_pattern.starts_with('{') {
                 let (nested_pattern, _default_val) = split_nested_pattern_default(value_pattern);
-                collect_array_helpers_only(nested_pattern, &prop_access, declarations)?;
+                collect_array_helpers_only(
+                    nested_pattern,
+                    &prop_access,
+                    declarations,
+                    insert_label,
+                )?;
             }
         }
     }
@@ -971,6 +1003,7 @@ pub(super) fn collect_array_helpers_only(
     pattern: &str,
     base_expr: &str,
     declarations: &mut Vec<String>,
+    insert_label: Option<&str>,
 ) -> Option<()> {
     let pattern = pattern.trim();
     if pattern.starts_with('[') && pattern.ends_with(']') {
@@ -991,9 +1024,12 @@ pub(super) fn collect_array_helpers_only(
         };
 
         declarations.push(format!(
-            "{} = $.derived(() => {})",
+            "{} = {}",
             array_var,
-            to_array_call(base_expr, &elements)
+            tag_derived(
+                format!("$.derived(() => {})", to_array_call(base_expr, &elements)),
+                insert_label
+            )
         ));
 
         // Recursively collect array helpers from nested patterns
@@ -1004,7 +1040,7 @@ pub(super) fn collect_array_helpers_only(
             }
             let element_access = format!("$.get({})[{}]", array_var, index);
             if element.starts_with('[') || element.starts_with('{') {
-                collect_array_helpers_only(element, &element_access, declarations)?;
+                collect_array_helpers_only(element, &element_access, declarations, insert_label)?;
             }
         }
     } else if pattern.starts_with('{') && pattern.ends_with('}') {
@@ -1022,7 +1058,12 @@ pub(super) fn collect_array_helpers_only(
                 let value_pattern = prop[colon_pos + 1..].trim();
                 let prop_access = derived_prop_access(base_expr, base_expr, key);
                 if value_pattern.starts_with('[') || value_pattern.starts_with('{') {
-                    collect_array_helpers_only(value_pattern, &prop_access, declarations)?;
+                    collect_array_helpers_only(
+                        value_pattern,
+                        &prop_access,
+                        declarations,
+                        insert_label,
+                    )?;
                 }
             }
         }
@@ -1229,6 +1270,7 @@ pub(super) fn process_derived_array_pattern(
     _member_base: &str,
     declarations: &mut Vec<String>,
     _array_counter: &mut usize,
+    insert_label: Option<&str>,
 ) -> Option<()> {
     let elements = split_derived_array_elements(inner);
 
@@ -1247,9 +1289,12 @@ pub(super) fn process_derived_array_pattern(
     };
 
     declarations.push(format!(
-        "{} = $.derived(() => {})",
+        "{} = {}",
         array_var,
-        to_array_call(base_expr, &elements)
+        tag_derived(
+            format!("$.derived(() => {})", to_array_call(base_expr, &elements)),
+            insert_label
+        )
     ));
     for (index, element) in elements.iter().enumerate() {
         let element = element.trim();
@@ -1274,6 +1319,7 @@ pub(super) fn process_derived_array_pattern(
                 &element_access,
                 declarations,
                 &mut nested_counter,
+                insert_label,
             )?;
         } else if let Some(eq_pos) = find_default_equals(element) {
             let name = element[..eq_pos].trim();

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/state_transforms.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/state_transforms.rs
@@ -1270,6 +1270,7 @@ pub(super) fn transform_legacy_destructure_declarations(
     statement: &str,
     legacy_state_var_names: &[String],
     immutable: bool,
+    dev: bool,
 ) -> String {
     // Only look at the first line to determine if this is a destructuring declaration
     let first_line = statement.lines().next().unwrap_or("");
@@ -1399,8 +1400,13 @@ pub(super) fn transform_legacy_destructure_declarations(
                 let member = format!("{}.{}", tmp_name, key);
                 if is_state {
                     parts.push(format!(
-                        "{} = $.mutable_source({}{})",
-                        var_name, member, immutable_arg
+                        "{} = {}",
+                        var_name,
+                        tag_legacy_source(
+                            format!("$.mutable_source({}{})", member, immutable_arg),
+                            var_name,
+                            dev
+                        )
                     ));
                 } else {
                     parts.push(format!("{} = {}", var_name, member));
@@ -1416,8 +1422,13 @@ pub(super) fn transform_legacy_destructure_declarations(
                 let member = format!("{}.{}", tmp_name, var_name);
                 if is_state {
                     parts.push(format!(
-                        "{} = $.mutable_source({}{})",
-                        var_name, member, immutable_arg
+                        "{} = {}",
+                        var_name,
+                        tag_legacy_source(
+                            format!("$.mutable_source({}{})", member, immutable_arg),
+                            var_name,
+                            dev
+                        )
                     ));
                 } else {
                     parts.push(format!("{} = {}", var_name, member));
@@ -1470,8 +1481,13 @@ pub(super) fn transform_legacy_destructure_declarations(
                 let is_state = legacy_state_var_names.contains(&rest_name.to_string());
                 if is_state {
                     parts.push(format!(
-                        "{} = $.mutable_source({}{})",
-                        rest_name, access, immutable_arg
+                        "{} = {}",
+                        rest_name,
+                        tag_legacy_source(
+                            format!("$.mutable_source({}{})", access, immutable_arg),
+                            rest_name,
+                            dev
+                        )
                     ));
                 } else {
                     parts.push(format!("{} = {}", rest_name, access));
@@ -1483,8 +1499,13 @@ pub(super) fn transform_legacy_destructure_declarations(
             let is_state = legacy_state_var_names.contains(&element.to_string());
             if is_state {
                 parts.push(format!(
-                    "{} = $.mutable_source({}{})",
-                    element, access, immutable_arg
+                    "{} = {}",
+                    element,
+                    tag_legacy_source(
+                        format!("$.mutable_source({}{})", access, immutable_arg),
+                        element,
+                        dev
+                    )
                 ));
             } else {
                 parts.push(format!("{} = {}", element, access));

--- a/crates/rsvelte_core/tests/destructure_tag_labels_2021.rs
+++ b/crates/rsvelte_core/tests/destructure_tag_labels_2021.rs
@@ -1,0 +1,115 @@
+//! Regression tests for the destructuring half of issue #2021.
+//!
+//! The label differs by position: a leaf carries its own binding name, while an
+//! `$$array` temp has no name and carries the *top-level* declarator's pattern
+//! kind — so `let { a: [x] } = $derived(o)` says `[$derived object]` even though
+//! the temp itself comes from an array pattern.
+
+use rsvelte_core::{CompileOptions, GenerateMode, compile, compiler::CssMode};
+
+fn compile_client(src: &str, dev: bool) -> String {
+    compile(
+        src,
+        CompileOptions {
+            filename: Some("Comp.svelte".to_string()),
+            generate: GenerateMode::Client,
+            dev,
+            css: CssMode::External,
+            ..Default::default()
+        },
+    )
+    .expect("compile")
+    .js
+    .code
+}
+
+#[test]
+fn derived_object_leaves_carry_their_own_names() {
+    let src =
+        "<script>let o = $state({a:1,b:2}); let { a, b } = $derived(o);</script><p>{a}{b}</p>";
+    let out = compile_client(src, true);
+    assert!(
+        out.contains("$.tag($.derived(() => o.a), 'a')"),
+        "in:\n{out}"
+    );
+    assert!(
+        out.contains("$.tag($.derived(() => o.b), 'b')"),
+        "in:\n{out}"
+    );
+}
+
+#[test]
+fn derived_array_temp_is_labelled_iterable() {
+    let src = "<script>let o = $state([1,2]); let [a, b] = $derived(o);</script><p>{a}{b}</p>";
+    let out = compile_client(src, true);
+    assert!(
+        out.contains("$.tag($.derived(() => $.to_array(o, 2)), '[$derived iterable]')"),
+        "in:\n{out}"
+    );
+    assert!(
+        out.contains("$.tag($.derived(() => $.get($$array)[0]), 'a')"),
+        "in:\n{out}"
+    );
+}
+
+/// The kind comes from the top-level declarator, not from the nested pattern.
+#[test]
+fn nested_array_under_an_object_pattern_says_object() {
+    let src = "<script>let o = $state({a:[1]}); let { a: [x] } = $derived(o);</script><p>{x}</p>";
+    let out = compile_client(src, true);
+    assert!(
+        out.contains("$.tag($.derived(() => $.to_array(o.a, 1)), '[$derived object]')"),
+        "in:\n{out}"
+    );
+}
+
+#[test]
+fn state_array_temp_is_labelled_state_iterable() {
+    let src = "<script>let [x, y] = $state([1, 2]);</script><p>{x}{y}</p>";
+    let out = compile_client(src, true);
+    assert!(
+        out.contains("$.tag($.derived(() => $.to_array(tmp, 2)), '[$state iterable]')"),
+        "in:\n{out}"
+    );
+}
+
+/// The `$$d` source temp of a `$derived.by` destructure stays bare upstream.
+#[test]
+fn derived_by_source_temp_stays_untagged() {
+    let src =
+        "<script>let n = $state(1); let { a } = $derived.by(() => ({ a: n }));</script><p>{a}</p>";
+    let out = compile_client(src, true);
+    assert!(out.contains("$$d = $.derived("), "in:\n{out}");
+    assert!(
+        !out.contains("$$d = $.tag("),
+        "the source temp was labelled in:\n{out}"
+    );
+    assert!(
+        out.contains("$.tag($.derived(() => $.get($$d).a), 'a')"),
+        "in:\n{out}"
+    );
+}
+
+#[test]
+fn legacy_destructured_state_leaves_are_labelled() {
+    let src = "<script>let { p, q } = { p: 1, q: 2 }; function f() { p++; }</script><p>{p}{q}</p>";
+    let out = compile_client(src, true);
+    assert!(
+        out.contains("$.tag($.mutable_source(tmp.p), 'p')"),
+        "in:\n{out}"
+    );
+    // `q` is not a state source, so it stays a plain read.
+    assert!(out.contains("q = tmp.q"), "in:\n{out}");
+}
+
+#[test]
+fn production_emits_no_labels() {
+    for src in [
+        "<script>let o = $state([1,2]); let [a, b] = $derived(o);</script><p>{a}{b}</p>",
+        "<script>let [x, y] = $state([1, 2]);</script><p>{x}{y}</p>",
+        "<script>let { p, q } = { p: 1, q: 2 }; function f() { p++; }</script><p>{p}{q}</p>",
+    ] {
+        let out = compile_client(src, false);
+        assert!(!out.contains("$.tag("), "in:\n{out}");
+    }
+}


### PR DESCRIPTION
**Stacked on #2074** (base branch `fix/2021-dev-tag-labelling`) — it needs the `tag_legacy_source` helper that PR introduces. Rebase onto `main` once #2074 lands.

## Summary

The second slice of #2021: the `$.tag` labels for **destructured** `$derived` / `$state` declarations, plus the legacy destructuring gap the reviewer spotted on #2074.

```js
// official (dev)                                    // rsvelte (before)
$$array = $.tag($.derived(() => $.to_array(o, 2)),   $$array = $.derived(() => $.to_array(o, 2)),
        '[$derived iterable]'),
a = $.tag($.derived(() => $.get($$array)[0]), 'a');  a = $.derived(() => $.get($$array)[0]);
```

## The label is position-dependent — confirmed against the official compiler

This is the part worth reviewing carefully. Every row below was read off real official output, not inferred:

| shape | label |
|---|---|
| destructured leaf | its own binding name |
| `$$array` temp, top-level array pattern | `'[$derived iterable]'` |
| `$$array` temp, top-level **object** pattern | `'[$derived object]'` — **even when the temp itself comes from a nested array**, e.g. `let { a: [x] } = $derived(o)` |
| `$$array` temp, `$state` | `'[$state iterable]'` |
| `$$d` source temp of a `$derived.by` destructure | none — stays bare (**sync only**, see below) |
| legacy destructured **state** leaf | its own name |
| legacy `tmp` / `$$array` intermediates | none |

The third row is the trap: upstream builds the label from `declarator.id.type` — the *top-level* pattern — so the inner array temp inherits "object" (`VariableDeclaration.js:176-186`). A local `is ArrayPattern` test would get it backwards.

### Two things this deliberately does not cover

**The bare `$$d` holds for synchronous deriveds only.** Under `experimental.async` the source temp becomes `$.async_derived(thunk, '[$derived object]', 'C.svelte:1:39')` — the label moves into the call's second argument alongside a source location. rsvelte does not emit that form today; it is a pre-existing gap, untouched here, and none of the corpus entries this PR closes are async.

**Legacy object rest still diverges**, but on statement shape rather than on the label (rsvelte folds the following declaration onto one line). Filed separately; nothing here changes it.

## Implementation notes

- **Leaves are labelled once**, in the post-pass that assembles the declarator list, rather than at each of the sixteen `"{} = $.derived(() => {})"` emit sites. Entries are `<name> = <init>`, so the name is recoverable; `$$array` / `$$d` prefixes are skipped there because they are not name-labelled.
- **The `$$array` label needs the pattern kind**, which the emit sites do not know, so one `Option<&str>` is threaded to the two insert sites (`None` outside dev). It is computed at the two outermost callers, where the top-level pattern text is already in hand.
- `$state` needed no threading: its insert site sits on the visitor, `self.dev` is in scope, and it only ever runs for a top-level array pattern.
- Tagging at the emit sites (rather than re-enabling a post-AST text scan) is deliberate — the existing scanner runs *before* these declarations are emitted, and re-running it afterwards would double-tag the `$state` leaves that `maybe_tag_declarator` already handles.

## Verification

- 18 destructuring shapes compiled with both compilers in dev and compared on their signal lines: **all 13 runes shapes now match** (object, array, array+rest, object+rest, nested object, nested array, object-in-array, array-in-object, defaults, `$derived.by`, and the three `$state` forms).
- New suite `crates/rsvelte_core/tests/destructure_tag_labels_2021.rs` — 7 tests, including the nested-array-says-object case, the untagged `$$d`, and a production-form guard.
- `cargo test --release -p rsvelte_core` — **150 binaries, 2098 tests, 0 failures**.
- `cargo test --lib`, `cargo fmt`, `cargo clippy` (changed files warning-free).
- **Full output-equality corpus**: 14,005 entries × 3 targets — `✅ no regressions`, **91 known failures now pass** (the estimate on #2074 was 59; the extra come from entries whose first divergence was elsewhere).

## Baseline

`known-failures.client-dev.json`: **3718 → 3627**, shrunk by filtering the old list against the current failure set.

## Still open on #2021

The remaining `$.tag` gap is the **class fields** in `.svelte.(js|ts)` modules (~31 entries, labelled `'<ClassName>.<name>'` with the `#` kept only for source-private fields). That is the next and final slice, and will carry `Fixes #2021`.

Four legacy destructuring shapes still diverge, but **not on the label** — see the note above.

Review follow-ups are in the second commit: the misplaced doc comment on `collect_binding_identifier_names` is repaired, the duplicated label computation is folded into `derived_insert_label`, and `tag_derived_leaves` now owns its `dev` check rather than depending on both call sites to guard it.

Part of #2021

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FKkTpzZGaGWWzJvw4BnHJs
