### PR TITLE
fix(compiler): instrument `==` / `!=` and mark negated comparisons with `false` (#2025)

### DIFF
--- a/.changeset/fix-equals-instrumentation.md
+++ b/.changeset/fix-equals-instrumentation.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/compiler": patch
+---
+
+fix(compiler): instrument `==` / `!=` as `$.equals(...)` in dev, and mark the negated comparisons with the trailing `false` argument the official compiler emits instead of an outer `!`

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/ast_state_transform.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/ast_state_transform.rs
@@ -1859,25 +1859,28 @@ impl<'a, 's> StateVarCollector<'a, 's> {
         true
     }
 
-    /// Dev-mode rewrite of `a === b` / `a !== b` BinaryExpressions to
-    /// `$.strict_equals(a, b)` / `!$.strict_equals(a, b)`. Mirrors the
-    /// official Svelte compiler's `BinaryExpression` visitor — runtime
-    /// hook that surfaces signal-vs-proxy comparison footguns to the user.
-    /// Replaces the text-based pass formerly in
+    /// Dev-mode rewrite of the four equality BinaryExpressions into their
+    /// instrumented calls — `$.strict_equals` for `===` / `!==`, `$.equals`
+    /// for `==` / `!=`, with a trailing `false` argument marking the negated
+    /// forms. Mirrors the official Svelte compiler's `BinaryExpression`
+    /// visitor — runtime hook that surfaces signal-vs-proxy comparison
+    /// footguns to the user. Replaces the text-based pass formerly in
     /// `rune_transforms::transform_strict_equals` for component instance
     /// scripts. Returns `true` when the expression was rewritten.
     fn try_rewrite_strict_equals_binary(&mut self, expr: &BinaryExpression<'_>) -> bool {
         if !self.dev {
             return false;
         }
-        let is_neq = match expr.operator {
-            BinaryOperator::StrictEquality => false,
-            BinaryOperator::StrictInequality => true,
+        let (helper, negated) = match expr.operator {
+            BinaryOperator::StrictEquality => ("$.strict_equals", false),
+            BinaryOperator::StrictInequality => ("$.strict_equals", true),
+            BinaryOperator::Equality => ("$.equals", false),
+            BinaryOperator::Inequality => ("$.equals", true),
             _ => return false,
         };
 
         // Walk both operands so inner state-var refs (and nested
-        // `===` / `!==` rewrites) register their replacements, then
+        // equality rewrites) register their replacements, then
         // drain those into the operand-local text. Each drain yields
         // the fully-transformed operand substring that the outer
         // replacement carries verbatim.
@@ -1889,19 +1892,13 @@ impl<'a, 's> StateVarCollector<'a, 's> {
         let left_text = self.apply_and_drain_inner_replacements(left_span.start, left_span.end);
         let right_text = self.apply_and_drain_inner_replacements(right_span.start, right_span.end);
 
-        let replacement = if is_neq {
-            format!(
-                "!$.strict_equals({}, {})",
-                left_text.trim(),
-                right_text.trim()
-            )
-        } else {
-            format!(
-                "$.strict_equals({}, {})",
-                left_text.trim(),
-                right_text.trim()
-            )
-        };
+        let replacement = format!(
+            "{}({}, {}{})",
+            helper,
+            left_text.trim(),
+            right_text.trim(),
+            if negated { ", false" } else { "" }
+        );
 
         self.add_replacement(expr.span.start, expr.span.end, replacement);
         true
@@ -3825,13 +3822,11 @@ fn has_state_transform_candidate(script: &str, config: &AstTransformConfig) -> b
     let has_host_calls = is_runes
         && !store_sub_vars.iter().any(|v| v == "$host")
         && memchr::memmem::find(script.as_bytes(), b"$host").is_some();
-    // Dev-mode `===` / `!==` → `$.strict_equals(...)` rewrite (formerly
-    // `rune_transforms::transform_strict_equals`). The visitor walks
+    // Dev-mode equality → `$.strict_equals(...)` / `$.equals(...)` rewrite
+    // (formerly `rune_transforms::transform_strict_equals`). The visitor walks
     // every BinaryExpression so we only need a byte probe to know
     // whether to enter the AST pass at all.
-    let has_strict_equals = config.dev
-        && (memchr::memmem::find(script.as_bytes(), b"===").is_some()
-            || memchr::memmem::find(script.as_bytes(), b"!==").is_some());
+    let has_strict_equals = config.dev && super::strict_equals_ast::source_has_equality_op(script);
 
     if !has_state
         && !has_props

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
@@ -5978,11 +5978,9 @@ fn transform_instance_script_for_visitors(
             && memmem::find(result.as_bytes(), b"$props").is_some();
         let has_host_calls = !store_sub_vars.iter().any(|v| v == "$host")
             && memmem::find(result.as_bytes(), b"$host").is_some();
-        // Dev-mode `===` / `!==` rewrite is now part of the AST pass
+        // Dev-mode equality rewrite is now part of the AST pass
         // (replaces `transform_strict_equals` from rune_transforms.rs).
-        let has_strict_equals = dev
-            && (memmem::find(result.as_bytes(), b"===").is_some()
-                || memmem::find(result.as_bytes(), b"!==").is_some());
+        let has_strict_equals = dev && strict_equals_ast::source_has_equality_op(&result);
         let has_transforms = !state_vars.is_empty()
             || !prop_assignment_transform_vars.is_empty()
             || !store_sub_vars.is_empty()

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/module_dev_tail_ast.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/module_dev_tail_ast.rs
@@ -51,9 +51,7 @@ pub fn transform_module_dev_tail_ast(source: &str, dev: bool, is_ts: bool) -> Op
     // never match — none of the passes introduce another's marker — so
     // probing the original source is sound across fixed-point iterations.
     let has_effect = memchr::memmem::find(bytes, b"$effect").is_some();
-    let has_strict = dev
-        && (memchr::memmem::find(bytes, b"===").is_some()
-            || memchr::memmem::find(bytes, b"!==").is_some());
+    let has_strict = dev && super::strict_equals_ast::source_has_equality_op(source);
     let has_console = dev && memchr::memmem::find(bytes, b"console.").is_some();
     let has_tag = dev
         && (memchr::memmem::find(bytes, b"$.state").is_some()
@@ -111,6 +109,18 @@ mod tests {
     fn effect_runs_without_dev() {
         let out = transform_module_dev_tail_ast("$effect(() => {});", false, false).unwrap();
         assert_eq!(out, "$.user_effect(() => {});");
+    }
+
+    /// Through the production entry point, not the per-pass test loops: a
+    /// module whose only comparison is loose has no `===` / `!==` bytes, so a
+    /// probe written for the strict pair alone would skip the whole batch.
+    #[test]
+    fn loose_equality_alone_still_enters_the_batch() {
+        let out = transform_module_dev_tail_ast("a == b;", true, false).unwrap();
+        assert_eq!(out, "$.equals(a, b);");
+
+        let out = transform_module_dev_tail_ast("a != b;", true, false).unwrap();
+        assert_eq!(out, "$.equals(a, b, false);");
     }
 
     #[test]

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/strict_equals_ast.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/strict_equals_ast.rs
@@ -8,8 +8,7 @@
 //! That visitor needs heavy infrastructure (drain inner replacements,
 //! interact with state-var rewrites) which module scripts don't —
 //! they have no `$state`, no per-binding tracking. So we get a much
-//! smaller standalone walker here that just does the strict-equals
-//! rewrite.
+//! smaller standalone walker here that just does the equality rewrite.
 //!
 //! Replaces the legacy text-based `rune_transforms::transform_strict_equals`
 //! whose heuristics for "skip if inside a string" (counting quotes)
@@ -66,10 +65,10 @@ fn contains_equality_expr<'a>(expr: &Expression<'a>) -> bool {
     finder.found
 }
 
-/// Collect leaf strict-equals rewrites (`===` / `!==` whose operands
-/// don't themselves contain a strict operator) from a single parse.
-/// Nested cases resolve across fixed-point iterations — the batched
-/// module dev-tail driver drives that loop.
+/// Collect leaf equality rewrites (those whose operands don't themselves
+/// contain an equality operator) from a single parse. Nested cases resolve
+/// across fixed-point iterations — the batched module dev-tail driver drives
+/// that loop.
 pub(super) fn collect_strict_equals_edits(program: &Program<'_>, source: &str) -> Vec<Edit> {
     let mut collector = StrictEqualsCollector {
         source,
@@ -80,10 +79,9 @@ pub(super) fn collect_strict_equals_edits(program: &Program<'_>, source: &str) -
 }
 
 /// Per-call AST visitor: collects `(start, end, replacement_string)`
-/// triples for every BinaryExpression with operator `===` or `!==`
-/// *whose operands are leaf* (don't themselves contain another
-/// `===` / `!==`). Nested cases are handled by the fixed-point
-/// iteration in the caller.
+/// triples for every equality BinaryExpression *whose operands are leaf*
+/// (don't themselves contain another equality operator). Nested cases are
+/// handled by the fixed-point iteration in the caller.
 struct StrictEqualsCollector<'src> {
     source: &'src str,
     replacements: Vec<Edit>,
@@ -207,6 +205,18 @@ mod tests {
     }
 
     #[test]
+    fn relational_operators_survive_a_run_of_the_pass() {
+        // The probe only decides whether to enter; once inside, the visitor has
+        // to leave the non-equality operators untouched.
+        let src = "let f = (x) => x >= 1; let ok = a <= b && c === d;";
+        let out = transform_strict_equals_module_ast(src, false).unwrap();
+        assert_eq!(
+            out,
+            "let f = (x) => x >= 1; let ok = a <= b && $.strict_equals(c, d);"
+        );
+    }
+
+    #[test]
     fn does_not_rewrite_inside_string_literal() {
         // The text-based version had to count quotes; the AST never
         // descends into string literal "contents" so this is safe.
@@ -242,6 +252,9 @@ mod tests {
     fn nested_mixed_equality_both_rewritten() {
         let src = "(a === b) != (c == d)";
         let out = transform_strict_equals_module_ast(src, false).unwrap();
+        // Known divergence: replacements copy operand text, so the source's
+        // parens survive. The official compiler reprints from the AST and emits
+        // `$.equals($.strict_equals(a, b), $.equals(c, d), false)`.
         assert_eq!(
             out,
             "$.equals(($.strict_equals(a, b)), ($.equals(c, d)), false)"

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/strict_equals_ast.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/strict_equals_ast.rs
@@ -1,5 +1,7 @@
-//! AST-based `===` / `!==` → `$.strict_equals(...)` rewrite for module
-//! scripts (`.svelte.js` / `.svelte.ts`) in dev mode.
+//! AST-based equality instrumentation for module scripts (`.svelte.js` /
+//! `.svelte.ts`) in dev mode: `===` / `!==` become `$.strict_equals(...)`
+//! and `==` / `!=` become `$.equals(...)`, the negated forms carrying a
+//! trailing `false` argument.
 //!
 //! Mirrors the rewrite performed inside the component instance script
 //! visitor (`ast_state_transform::try_rewrite_strict_equals_binary`).
@@ -23,9 +25,45 @@ use oxc_syntax::operator::BinaryOperator;
 
 use super::ast_rewrite::Edit;
 
-fn contains_strict_op(s: &str) -> bool {
-    memchr::memmem::find(s.as_bytes(), b"===").is_some()
-        || memchr::memmem::find(s.as_bytes(), b"!==").is_some()
+/// Cheap byte probe gating entry into the AST pass. Every one of `===`, `!==`,
+/// `==` and `!=` contains `==` or `!=`, while `<=` / `>=` / `=>` contain
+/// neither, so this is a tight superset of what the rewrite can act on.
+pub(super) fn source_has_equality_op(s: &str) -> bool {
+    memchr::memmem::find(s.as_bytes(), b"==").is_some()
+        || memchr::memmem::find(s.as_bytes(), b"!=").is_some()
+}
+
+/// The instrumented helper and whether the operator is the negated form,
+/// for the four equality operators the dev rewrite covers.
+fn equality_helper(op: BinaryOperator) -> Option<(&'static str, bool)> {
+    match op {
+        BinaryOperator::StrictEquality => Some(("$.strict_equals", false)),
+        BinaryOperator::StrictInequality => Some(("$.strict_equals", true)),
+        BinaryOperator::Equality => Some(("$.equals", false)),
+        BinaryOperator::Inequality => Some(("$.equals", true)),
+        _ => None,
+    }
+}
+
+/// True when the subtree still holds an equality expression this pass would
+/// rewrite. Deciding this on the AST rather than by scanning the operand text
+/// keeps `==` from matching inside `===` (and `!=` inside `!==`, `<=`, `=>`).
+fn contains_equality_expr<'a>(expr: &Expression<'a>) -> bool {
+    struct Finder {
+        found: bool,
+    }
+    impl<'a> Visit<'a> for Finder {
+        fn visit_binary_expression(&mut self, expr: &BinaryExpression<'a>) {
+            if equality_helper(expr.operator).is_some() {
+                self.found = true;
+                return;
+            }
+            walk::walk_binary_expression(self, expr);
+        }
+    }
+    let mut finder = Finder { found: false };
+    finder.visit_expression(expr);
+    finder.found
 }
 
 /// Collect leaf strict-equals rewrites (`===` / `!==` whose operands
@@ -57,37 +95,29 @@ impl<'a, 'src> Visit<'a> for StrictEqualsCollector<'src> {
         // the tree get a chance to record themselves.
         walk::walk_binary_expression(self, expr);
 
-        let is_neq = match expr.operator {
-            BinaryOperator::StrictEquality => false,
-            BinaryOperator::StrictInequality => true,
-            _ => return,
+        let Some((helper, negated)) = equality_helper(expr.operator) else {
+            return;
         };
+
+        // Defer: if either operand still has an equality operator, leave this
+        // node for the next fixed-point pass to pick up after the inner
+        // rewrites have landed — the replacement copies operand text verbatim.
+        if contains_equality_expr(&expr.left) || contains_equality_expr(&expr.right) {
+            return;
+        }
 
         let left_span = expr.left.span();
         let right_span = expr.right.span();
         let left_text = &self.source[left_span.start as usize..left_span.end as usize];
         let right_text = &self.source[right_span.start as usize..right_span.end as usize];
 
-        // Defer: if either operand still has a strict-equals
-        // operator, leave this node for the next fixed-point pass to
-        // pick up after the inner rewrites have landed.
-        if contains_strict_op(left_text) || contains_strict_op(right_text) {
-            return;
-        }
-
-        let rewrite = if is_neq {
-            format!(
-                "!$.strict_equals({}, {})",
-                left_text.trim(),
-                right_text.trim()
-            )
-        } else {
-            format!(
-                "$.strict_equals({}, {})",
-                left_text.trim(),
-                right_text.trim()
-            )
-        };
+        let rewrite = format!(
+            "{}({}, {}{})",
+            helper,
+            left_text.trim(),
+            right_text.trim(),
+            if negated { ", false" } else { "" }
+        );
 
         self.replacements
             .push((expr.span.start, expr.span.end, rewrite));
@@ -115,7 +145,7 @@ mod tests {
     /// to this pass. Each iteration rewrites only leaf binaries; the loop
     /// re-parses so an outer `(a === b) === c` sees its rewritten operands.
     fn transform_strict_equals_module_ast(source: &str, is_ts: bool) -> Option<String> {
-        if !contains_strict_op(source) {
+        if !source_has_equality_op(source) {
             return None;
         }
         let source_type = if is_ts {
@@ -126,7 +156,7 @@ mod tests {
         let mut current: Option<String> = None;
         loop {
             let src = current.as_deref().unwrap_or(source);
-            if !contains_strict_op(src) {
+            if !source_has_equality_op(src) {
                 break;
             }
             match ast_rewrite::rewrite_once(
@@ -153,14 +183,27 @@ mod tests {
     #[test]
     fn rewrites_strict_inequality() {
         let out = transform_strict_equals_module_ast("a !== b", false).unwrap();
-        assert_eq!(out, "!$.strict_equals(a, b)");
+        assert_eq!(out, "$.strict_equals(a, b, false)");
     }
 
     #[test]
-    fn leaves_loose_equality_alone() {
-        // == and != are handled elsewhere (AST expression converter)
-        assert!(transform_strict_equals_module_ast("a == b", false).is_none());
-        assert!(transform_strict_equals_module_ast("a != b", false).is_none());
+    fn rewrites_loose_equality() {
+        let out = transform_strict_equals_module_ast("a == b", false).unwrap();
+        assert_eq!(out, "$.equals(a, b)");
+    }
+
+    #[test]
+    fn rewrites_loose_inequality() {
+        let out = transform_strict_equals_module_ast("a != b", false).unwrap();
+        assert_eq!(out, "$.equals(a, b, false)");
+    }
+
+    #[test]
+    fn leaves_relational_operators_alone() {
+        // `<=` / `>=` contain neither `==` nor `!=`, so they never enter the pass.
+        assert!(transform_strict_equals_module_ast("a <= b", false).is_none());
+        assert!(transform_strict_equals_module_ast("a >= b", false).is_none());
+        assert!(transform_strict_equals_module_ast("(x) => x", false).is_none());
     }
 
     #[test]
@@ -192,6 +235,16 @@ mod tests {
         assert_eq!(
             out,
             "$.strict_equals(($.strict_equals(a, b)), ($.strict_equals(c, d)))"
+        );
+    }
+
+    #[test]
+    fn nested_mixed_equality_both_rewritten() {
+        let src = "(a === b) != (c == d)";
+        let out = transform_strict_equals_module_ast(src, false).unwrap();
+        assert_eq!(
+            out,
+            "$.equals(($.strict_equals(a, b)), ($.equals(c, d)), false)"
         );
     }
 

--- a/crates/rsvelte_core/tests/strict_equals_member_after_call.rs
+++ b/crates/rsvelte_core/tests/strict_equals_member_after_call.rs
@@ -1,21 +1,19 @@
-//! Regression test for `transform_strict_equals` mangling `X.member !== Y`
+//! Regression test for the dev equality rewrite mangling `X.member !== Y`
 //! when `X` is wrapped in a call expression like `$.get(items)` (which the
 //! dev-mode `$state` lowering produces). (baseballyama/rsvelte#166)
 //!
-//! Bug: `extract_operand_backward` walked the LHS backward looking for the
-//! start of the operand. When it hit a `)`, it parsed the call expression
-//! correctly — but it only did that when the operand *ends* with `)`. For a
-//! member access on a call (`$.get(items).length`), the operand ends with
-//! `h`, not `)`, so the fallback "scan identifier chars" path took over —
-//! and that path stopped at the `)` of `$.get(items)` because `)` is not
-//! an identifier char. The result was `left_expr = ".length"` and the
-//! replacement landed in the middle of the chain:
+//! The original text scanner walked the left operand backward and stopped at
+//! the `)` of `$.get(items)`, because `)` is not an identifier character. It
+//! captured `.length` as the whole operand and spliced the call into the
+//! middle of the chain:
 //!
 //!     $.get(items).length !== 0   →   $.get(items)!$.strict_equals(.length, 0)
 //!
-//! Now the extractor walks the entire chain — peeling off identifier runs
-//! and matched `(...)` / `[...]` groups in turn — so `$.get(items).length`
-//! is returned as a single operand.
+//! Operands now come off the AST, so an operand can no longer be split. These
+//! cases stay as a guard against regressing to a text-based extractor.
+//!
+//! Note the negated form: `!==` emits `$.strict_equals(l, r, false)`, matching
+//! the official compiler, rather than negating the call from outside.
 
 use rsvelte_core::GenerateMode;
 use rsvelte_core::compile_module;
@@ -42,20 +40,20 @@ fn neq_after_member_on_tagged_state_call_chain() {
   if (items.length !== 0) items[0];
 };"#;
     let out = compile_mod_client_dev(src);
-    // The arrow body should test the full member chain — `!$.strict_equals($.get(items).length, 0)`.
+    // The arrow body should test the full member chain.
     assert!(
-        out.contains("!$.strict_equals($.get(items).length, 0)"),
-        "expected `!$.strict_equals($.get(items).length, 0)`. Got:\n{out}"
+        out.contains("$.strict_equals($.get(items).length, 0, false)"),
+        "expected `$.strict_equals($.get(items).length, 0, false)`. Got:\n{out}"
     );
-    // No mangled `!$.strict_equals(.length, ...)` floating around.
+    // No mangled `$.strict_equals(.length, ...)` floating around.
     assert!(
         !out.contains("$.strict_equals(.length"),
         "found mangled `$.strict_equals(.length, …)` — operand was split:\n{out}"
     );
-    // And the `$.get(items)` shouldn't be stranded with a bare `!` either.
+    // Nor a fragment of the chain stranded outside the call.
     assert!(
-        !out.contains("$.get(items)!"),
-        "found stranded `$.get(items)!`:\n{out}"
+        !out.contains("$.get(items).length !==") && !out.contains(").length, 0)$"),
+        "found part of the chain left outside the call:\n{out}"
     );
 }
 
@@ -69,8 +67,8 @@ fn eq_after_member_on_tagged_state_call_chain() {
     let out = compile_mod_client_dev(src);
     assert!(
         out.contains("$.strict_equals($.get(items).length, 0)")
-            && !out.contains("!$.strict_equals($.get(items).length"),
-        "expected `$.strict_equals($.get(items).length, 0)` (no `!`). Got:\n{out}"
+            && !out.contains("$.strict_equals($.get(items).length, 0, false)"),
+        "expected `$.strict_equals($.get(items).length, 0)` (no negation argument). Got:\n{out}"
     );
 }
 
@@ -83,9 +81,9 @@ fn neq_after_bracket_index_chain() {
 };"#;
     let out = compile_mod_client_dev(src);
     assert!(
-        out.contains("!$.strict_equals($.get(arr)[0].length, 0)")
-            || out.contains("!$.strict_equals(($.get(arr))[0].length, 0)"),
-        "expected `!$.strict_equals($.get(arr)[0].length, 0)`. Got:\n{out}"
+        out.contains("$.strict_equals($.get(arr)[0].length, 0, false)")
+            || out.contains("$.strict_equals(($.get(arr))[0].length, 0, false)"),
+        "expected `$.strict_equals($.get(arr)[0].length, 0, false)`. Got:\n{out}"
     );
 }
 
@@ -98,8 +96,8 @@ fn plain_identifier_neq_still_works() {
 };"#;
     let out = compile_mod_client_dev(src);
     assert!(
-        out.contains("!$.strict_equals(a, b)"),
-        "expected `!$.strict_equals(a, b)`. Got:\n{out}"
+        out.contains("$.strict_equals(a, b, false)"),
+        "expected `$.strict_equals(a, b, false)`. Got:\n{out}"
     );
 }
 
@@ -112,7 +110,7 @@ fn call_left_operand_still_works() {
 };"#;
     let out = compile_mod_client_dev(src);
     assert!(
-        out.contains("!$.strict_equals(Math.abs(a), 0)"),
-        "expected `!$.strict_equals(Math.abs(a), 0)`. Got:\n{out}"
+        out.contains("$.strict_equals(Math.abs(a), 0, false)"),
+        "expected `$.strict_equals(Math.abs(a), 0, false)`. Got:\n{out}"
     );
 }


### PR DESCRIPTION
Fixes #2025.

## Ground truth

`visitors/BinaryExpression.js` rewrites all four equality operators in dev, distinguishing the negated form by a **trailing argument** rather than by wrapping the call. Confirmed against the official compiler's real output in `<script module>`, the instance script, and template expressions:

| source | dev output |
|---|---|
| `a === b` | `$.strict_equals(a, b)` |
| `a !== b` | `$.strict_equals(a, b, false)` |
| `a == b` | `$.equals(a, b)` |
| `a != b` | `$.equals(a, b, false)` |

`<`, `>=`, `+` are untouched, and nesting recurses innermost-first: `(a === 1) !== (a == 2)` becomes `$.strict_equals($.strict_equals(a, 1), $.equals(a, 2), false)`.

## What was wrong

The template-expression path already matched this exactly. The **instance-script** and **module-script** paths each handled only the strict pair, and spelled `!==` as `!$.strict_equals(a, b)` — equivalent at runtime, but not what the compiler emits:

```js
// official                                  // rsvelte (before)
const iB = $.strict_equals($.get(a), 1, false);   const iB = !$.strict_equals($.get(a), 1);
const iC = $.equals($.get(a), 1);                 const iC = $.get(a) == 1;
const iD = $.equals($.get(a), 1, false);          const iD = $.get(a) != 1;
```

This is why the cluster looked smaller than it was: 321 entries emitted `$.strict_equals` the *right number of times* and still diverged, so a presence comparison could not see them. Real scope was ~676, not the 327 the issue quotes.

## The fix

Both paths now derive `(helper, negated)` from one table, so the four operators cannot drift apart again.

One thing worth a second look: the module path defers a node whose operands still contain an unrewritten comparison (the replacement copies operand text verbatim, so the inner rewrite has to land first). That test **scanned the operand text** for `===` / `!==` — which cannot be extended to the loose pair, since `==` occurs inside `===` and `!=` inside `!==`. It now asks the AST instead.

The *entry* probe stays a byte scan, just widened: every one of the four operators contains `==` or `!=`, while `<=` / `>=` / `=>` contain neither, so it remains a tight superset. It is now one shared function instead of the same two-needle search copied into three gates.

## Verification

Full corpus, all three targets (14,005 × 3 = 42,015 compilations), oxfmt-normalized:

```
match           10252
error-parity      948
js-mismatch      2805
css-mismatch        0
error-mismatch      0

✅ no regressions (client 0, server 0, client-dev 2805 known failures remain)
🎉 842 known failures now PASS (client 0, server 0, client-dev 842)
```

`client` and `server` byte-unchanged.

Also checked directly against the official compiler over a probe covering all four operators × negation × nesting × string/template literals × `<=` / `=>` / TS, in component client, component SSR, and `compileModule`, at `dev: true` and `dev: false` — every equality form matches.

Unit tests updated: the two that pinned the old `!$.strict_equals` / "loose equality is left alone" behaviour now assert the upstream forms, plus new cases for `==`, `!=`, mixed nesting, and the relational operators staying out of the pass.

## Baseline commit follows

Code + changeset only, per the merge ordering; the ratchet shrink lands separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FKkTpzZGaGWWzJvw4BnHJs