### PR TITLE
fix(compiler): track reactivity loss across awaits in the instance script (#2026)

### DIFF
--- a/.changeset/fix-track-reactivity-loss.md
+++ b/.changeset/fix-track-reactivity-loss.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/compiler": patch
+---
+
+fix(compiler): wrap awaited expressions in a component's instance script with `$.track_reactivity_loss(...)` in dev, honouring `svelte-ignore await_reactivity_loss`

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/ast_state_transform.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/ast_state_transform.rs
@@ -1952,6 +1952,69 @@ impl<'a, 's> StateVarCollector<'a, 's> {
         true
     }
 
+    /// Dev-mode rewrite of `await X` to `(await $.track_reactivity_loss(X))()`,
+    /// mirroring the official compiler's `AwaitExpression` visitor: values read
+    /// inside a reactive expression are noted but not tracked across the await
+    /// boundary. Suppressed by a leading `svelte-ignore await_reactivity_loss`.
+    /// Returns `true` when the expression was rewritten.
+    fn try_rewrite_await_reactivity_loss(&mut self, expr: &AwaitExpression<'_>) -> bool {
+        if !self.dev || self.is_await_reactivity_loss_ignored(expr.span.start) {
+            return false;
+        }
+
+        // Walk the argument so inner state-var refs (and nested awaits)
+        // register their replacements, then drain them into the argument text.
+        self.visit_expression(&expr.argument);
+        let arg_span = expr.argument.span();
+        let arg_text = self.apply_and_drain_inner_replacements(arg_span.start, arg_span.end);
+
+        self.add_replacement(
+            expr.span.start,
+            expr.span.end,
+            format!("(await $.track_reactivity_loss({}))()", arg_text.trim()),
+        );
+        true
+    }
+
+    /// True when the statement enclosing `offset` is preceded by a
+    /// `svelte-ignore` comment naming `await_reactivity_loss`. Upstream reads
+    /// this off the analysis-phase ignore stack; this pass rewrites source
+    /// spans, so it reads the same comment back out of the source text.
+    fn is_await_reactivity_loss_ignored(&self, offset: u32) -> bool {
+        // Start from the top of the await's own line: the statement text to its
+        // left is not a comment and would end the scan immediately.
+        let offset = self.source[..offset as usize]
+            .rfind('\n')
+            .map_or(0, |nl| nl + 1);
+        let before = &self.source[..offset];
+        for line in before.lines().rev() {
+            let line = line.trim();
+            if line.is_empty() {
+                continue;
+            }
+            let Some(comment) = line
+                .strip_prefix("//")
+                .or_else(|| line.strip_prefix("/*").map(|c| c.trim_end_matches("*/")))
+            else {
+                // The first non-comment line above is the start of the
+                // statement itself; anything earlier cannot annotate it.
+                return false;
+            };
+            // A run of comments can carry several `svelte-ignore` lines, so keep
+            // looking when this one names other codes.
+            if crate::compiler::phases::phase2_analyze::utils::extract_svelte_ignore(
+                comment,
+                self.is_runes,
+            )
+            .iter()
+            .any(|c| c == "await_reactivity_loss")
+            {
+                return true;
+            }
+        }
+        false
+    }
+
     /// Walk every argument of a `CallExpression` so inner state-var refs
     /// get `$.get(...)` wrapping, then drain the inner replacements and
     /// return the comma-joined transformed text — the contents that
@@ -2269,6 +2332,14 @@ impl<'a, 's, 'ast> Visit<'ast> for StateVarCollector<'a, 's> {
         // walk to avoid double-visiting the operands.
         if !self.try_rewrite_strict_equals_binary(expr) {
             walk::walk_binary_expression(self, expr);
+        }
+    }
+
+    fn visit_await_expression(&mut self, expr: &AwaitExpression<'ast>) {
+        // Same contract as the binary hook: the helper walks and drains the
+        // argument itself when it matches.
+        if !self.try_rewrite_await_reactivity_loss(expr) {
+            walk::walk_await_expression(self, expr);
         }
     }
 
@@ -3875,6 +3946,8 @@ fn has_state_transform_candidate(script: &str, config: &AstTransformConfig) -> b
     // every BinaryExpression so we only need a byte probe to know
     // whether to enter the AST pass at all.
     let has_strict_equals = config.dev && super::strict_equals_ast::source_has_equality_op(script);
+    // Dev-mode `await X` → `(await $.track_reactivity_loss(X))()` rewrite.
+    let has_await = config.dev && memchr::memmem::find(script.as_bytes(), b"await").is_some();
 
     if !has_state
         && !has_props
@@ -3887,6 +3960,7 @@ fn has_state_transform_candidate(script: &str, config: &AstTransformConfig) -> b
         && !has_props_calls
         && !has_host_calls
         && !has_strict_equals
+        && !has_await
     {
         return false;
     }
@@ -3943,6 +4017,9 @@ fn has_state_transform_candidate(script: &str, config: &AstTransformConfig) -> b
         || (has_props_calls && script_ids.contains("$props"))
         || (has_host_calls && script_ids.contains("$host"))
         || has_strict_equals
+        // `await` is a keyword, not an identifier, so it can only be carried by
+        // its own probe here.
+        || has_await
 }
 
 fn state_assignment_needs_semantic(program: &Program<'_>, state_vars: &FxHashSet<&str>) -> bool {

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
@@ -5987,6 +5987,8 @@ fn transform_instance_script_for_visitors(
         // Dev-mode equality rewrite is now part of the AST pass
         // (replaces `transform_strict_equals` from rune_transforms.rs).
         let has_strict_equals = dev && strict_equals_ast::source_has_equality_op(&result);
+        // Dev-mode `await X` → `(await $.track_reactivity_loss(X))()` rewrite.
+        let has_await = dev && memmem::find(result.as_bytes(), b"await").is_some();
         let has_transforms = !state_vars.is_empty()
             || !prop_assignment_transform_vars.is_empty()
             || !store_sub_vars.is_empty()
@@ -5997,7 +5999,8 @@ fn transform_instance_script_for_visitors(
             || has_derived_calls
             || has_props_calls
             || has_host_calls
-            || has_strict_equals;
+            || has_strict_equals
+            || has_await;
 
         if has_transforms {
             // Collect $derived / $derived.by binding names so AST assignment transforms

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/tests.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/tests.rs
@@ -1576,3 +1576,49 @@ fn template_factory_matches_through_the_dev_add_locations_wrapper() {
         &JsStatement::Raw("var x = $.derived(() => 1);".into())
     ));
 }
+
+/// `svelte-ignore await_reactivity_loss` has no corpus coverage, so pin both
+/// directions here. The suppression also has to survive an unrelated
+/// `svelte-ignore` line sitting between it and the statement.
+///
+/// Runes mode throughout: the instrumentation rides the runes-only AST pass, so
+/// a legacy instance script is not instrumented at all (a known gap).
+#[test]
+fn await_reactivity_loss_is_wrapped_unless_ignored() {
+    let compile = |body: &str| {
+        crate::compiler::compile(
+            &format!("<script>\nlet n = $state(0);\n{body}\n</script>\n<p>{{n}}</p>\n"),
+            crate::compiler::CompileOptions {
+                generate: crate::compiler::GenerateMode::Client,
+                dev: true,
+                filename: Some("await/index.svelte".to_string()),
+                ..Default::default()
+            },
+        )
+        .unwrap()
+        .js
+        .code
+    };
+
+    let wrapped = compile("async function f() {\n\tconst a = await load();\n}");
+    assert!(
+        wrapped.contains("(await $.track_reactivity_loss(load()))()"),
+        "expected the await to be wrapped:\n{wrapped}"
+    );
+
+    let ignored = compile(
+        "async function f() {\n\t// svelte-ignore await_reactivity_loss\n\tconst a = await load();\n}",
+    );
+    assert!(
+        !ignored.contains("track_reactivity_loss") && ignored.contains("await load()"),
+        "expected the await to stay bare:\n{ignored}"
+    );
+
+    let stacked = compile(
+        "async function f() {\n\t// svelte-ignore await_reactivity_loss\n\t// svelte-ignore state_referenced_locally\n\tconst a = await load();\n}",
+    );
+    assert!(
+        !stacked.contains("track_reactivity_loss"),
+        "an unrelated svelte-ignore line must not end the scan:\n{stacked}"
+    );
+}


### PR DESCRIPTION
Fixes #2026.

## Ground truth

Unlike the other clusters in this campaign, this one really is unported — no position bug. `visitors/AwaitExpression.js` rewrites **every** awaited expression in dev so reactivity lost across the await boundary is reported. Confirmed against the official compiler's real output:

| source | dev output |
|---|---|
| `await X` | `(await $.track_reactivity_loss(X))()` |
| `await g(await g())` | recurses innermost-first |
| preceded by `svelte-ignore await_reactivity_loss` | left as a bare `await` |
| `{#await}` block expression | not instrumented (goes through `$.await(…)`) |
| SSR | not instrumented at all |

rsvelte emitted this only for template expressions. A component's instance script had no `AwaitExpression` handler at all, so every `await` in it was emitted bare.

## The fix

A `visit_await_expression` hook in the instance-script AST pass, on the same contract as the existing strict-equals hook: when it matches, the helper walks and drains the argument itself, so the default walk is skipped and operands are not visited twice. Replacing exactly the `AwaitExpression` span keeps precedence intact — `await load() + 1` becomes `(await $.track_reactivity_loss(load()))() + 1`, not a re-association.

The pass has **two** gates — a byte probe, and an identifier check that the probed rune actually appears in the script. `await` is a keyword, not an identifier, so it has to be carried through the second gate by its own flag; without that, a component whose only trigger was `await` still skipped the pass. The new unit test caught exactly this.

`svelte-ignore await_reactivity_loss` suppresses the wrap. Code parsing is delegated to `phase2_analyze::utils::extract_svelte_ignore`, so comma-separated codes and the legacy hyphenated spellings behave as they do everywhere else, and a comment naming *other* codes no longer ends the scan.

## Known residuals

Deliberately out of scope; happy to split any of these into follow-ups.

1. **svelte-ignore is matched by scanning source lines upward.** That cannot see ancestor-node inheritance, a comment on the same line as a block comment, or an annotation attached to a multi-line statement's interior. The correct fix is to carry phase 2's `ignore_stack` into phase 3 rather than re-reading comments — a change well beyond this PR.
2. **Legacy (non-runes) instance scripts, `<script module>` and `.svelte.js` are uninstrumented.** Upstream instruments them. The instrumentation rides the runes-only AST pass (the whole block sits under `if analysis.runes`), so covering legacy means relocating that pass, not extending this hook. The module side is smaller — one collector in `module_dev_tail_ast.rs`, the same shape as the equality one.
3. **`pickled_awaits` (the `$.save` branch) and `for await` are unreachable under default options.** `ForOfStatement.js:14-22` gates `$.for_await_track_reactivity_loss` behind `experimental.async`, and the corpus compiles with defaults, so neither path is exercised here.
4. **`await (load())` keeps its source parens, and comments inside the awaited expression are dropped** — the verbatim-copy-versus-reprint difference this pass shares with the equality rewrite. oxfmt normalization hides it in the corpus. Low.

## Verification

Full corpus, all three targets (14,005 × 3 = 42,015 compilations), oxfmt-normalized:

```
match           11289
error-parity      948
js-mismatch      1768
css-mismatch        0
error-mismatch      0

✅ no regressions (client 0, server 0)
🎉 1879 known failures now PASS (client-dev 1879)
```

Well above the 342 the issue projects — `await` co-occurs with the other dev clusters across a lot of the corpus, so this clears their shared entries too.

Also checked directly against the official compiler over a probe covering statement / declarator / operand / array-element / `if`-test awaits, nesting, `svelte-ignore`, `for await`, and `{#await}` blocks — client and server, `dev: true` and `dev: false`.

New unit tests pin the wrapped and the ignored form, plus the stacked-`svelte-ignore` case, since the corpus contains no `await_reactivity_loss` annotation at all.

One unrelated gap surfaced while probing: rsvelte drops the `// svelte-ignore` comment from **SSR** output. It reproduces at `dev: false`, so it predates this change; noted on #2064.

Code + changeset only; the ratchet shrink is handled in one pass after the campaign's code PRs land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FKkTpzZGaGWWzJvw4BnHJs
