### PR TITLE
fix(compiler): label an anonymous class's state field `[class].name` in dev (#2021)

### DIFF
--- a/.changeset/fix-anonymous-class-tag-label.md
+++ b/.changeset/fix-anonymous-class-tag-label.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/compiler": patch
+---
+
+fix(compiler): label a state field of an anonymous class `[class].name` in dev, matching upstream, instead of `Unknown.name`

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/tag_class_field_ast.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/tag_class_field_ast.rs
@@ -180,11 +180,12 @@ fn walk_expression_for_classes<'a>(
 }
 
 fn handle_class<'a>(class: &Class<'a>, source: &str, replacements: &mut Vec<(u32, u32, String)>) {
+    // Upstream's fallback for a class with no id (`ClassBody.js:82`).
     let class_name = class
         .id
         .as_ref()
         .map(|i| i.name.as_str())
-        .unwrap_or("Unknown");
+        .unwrap_or("[class]");
 
     let originally_public = compute_originally_public(class, source);
 
@@ -592,11 +593,10 @@ mod tests {
     }
 
     #[test]
-    fn anonymous_class_uses_unknown() {
-        // Class expression with no id — label uses "Unknown".
+    fn anonymous_class_uses_the_upstream_placeholder() {
         let src = "let C = class { #x = $.state(0); };";
         let out = wrap_state_derived_with_tag_class_fields_ast(src).unwrap();
-        assert!(out.contains("'Unknown.#x'"));
+        assert!(out.contains("'[class].#x'"), "got: {out}");
     }
 
     #[test]

--- a/crates/rsvelte_core/tests/class_field_tag_label_2021.rs
+++ b/crates/rsvelte_core/tests/class_field_tag_label_2021.rs
@@ -1,0 +1,75 @@
+//! Regression tests for the class-field half of issue #2021 — the dev `$.tag`
+//! label of a class state field.
+//!
+//! The label is `<class>.<name>`, where the name is the one written in the
+//! source: the `#` survives for a genuinely private field, but a public field is
+//! backed by a generated private key and still labelled with its public name
+//! (`ClassBody.js:82-90`). A class with no id falls back to `[class]`.
+
+use rsvelte_core::compiler::ModuleCompileOptions;
+use rsvelte_core::{GenerateMode, compile_module};
+
+fn compile_dev(src: &str) -> String {
+    compile_module(
+        src,
+        ModuleCompileOptions {
+            filename: Some("store.svelte.js".to_string()),
+            generate: GenerateMode::Client,
+            dev: true,
+            ..Default::default()
+        },
+    )
+    .expect("compile")
+    .js
+    .code
+}
+
+#[test]
+fn private_field_keeps_its_hash() {
+    let out =
+        compile_dev("export class Foo { #count = $state(0); get c() { return this.#count; } }");
+    assert!(
+        out.contains("$.tag($.state(0), 'Foo.#count')"),
+        "in:\n{out}"
+    );
+}
+
+#[test]
+fn public_field_is_labelled_with_its_public_name() {
+    let out = compile_dev("export class Foo { count = $state(0); }");
+    assert!(out.contains("$.tag($.state(0), 'Foo.count')"), "in:\n{out}");
+    assert!(!out.contains("'Foo.#count'"), "in:\n{out}");
+}
+
+#[test]
+fn anonymous_class_falls_back_to_the_upstream_placeholder() {
+    let out = compile_dev("export default class { count = $state(0); }");
+    assert!(
+        out.contains("$.tag($.state(0), '[class].count')"),
+        "in:\n{out}"
+    );
+    assert!(!out.contains("Unknown."), "in:\n{out}");
+}
+
+#[test]
+fn a_named_class_expression_uses_its_own_name() {
+    let out = compile_dev("export const K = class Named { x = $state(0); };");
+    assert!(out.contains("$.tag($.state(0), 'Named.x')"), "in:\n{out}");
+}
+
+#[test]
+fn production_emits_no_label() {
+    let out = compile_module(
+        "export class Foo { count = $state(0); }",
+        ModuleCompileOptions {
+            filename: Some("store.svelte.js".to_string()),
+            generate: GenerateMode::Client,
+            dev: false,
+            ..Default::default()
+        },
+    )
+    .expect("compile")
+    .js
+    .code;
+    assert!(!out.contains("$.tag("), "in:\n{out}");
+}


### PR DESCRIPTION
## Summary

The last `$.tag` label divergence of #2021. When a class has no id, upstream falls back to `[class]` (`ClassBody.js:82`); rsvelte said `Unknown`.

```js
// export default class { count = $state(0); }
// official
#count = $.tag($.state(0), '[class].count');
// rsvelte (before)
#count = $.tag($.state(0), 'Unknown.count');
```

## What the survey found — the class-field work was mostly already correct

Before writing anything I compared 13 class shapes against the official compiler. `tag_class_field_ast.rs` already gets the hard parts right:

| shape | label | status |
|---|---|---|
| `class Foo { #count = $state(0) }` | `'Foo.#count'` | already matched |
| `class Foo { count = $state(0) }` | `'Foo.count'` | already matched |
| `class Named` as an expression | `'Named.x'` | already matched |
| `$state.raw`, no-initialiser, two classes, component-local classes | — | already matched |
| anonymous class | `'[class].count'` | **fixed here** |

In particular the "drop the `#` when the field was written public" heuristic — which looked suspicious — is **correct**: upstream labels with the source-written key, and a public field is backed by a *generated* private key, so reading the `#` off the emitted key would be wrong. Confirmed against real output, and now pinned by tests.

## What is left is not a labelling bug — please file it separately

Four shapes still diverge, and none of them are about the label:

```js
// export class Foo { n = $state(1); d = $derived(this.n * 2); }
// official: emits #d plus its get/set accessors
#d = $.tag($.derived(() => this.n * 2), 'Foo.d');
// rsvelte: the field, its getter and its setter are all absent
```

**`$derived` class fields — and fields of a class nested inside another class — are dropped from the output entirely, in `dev: false` too.** That is a correctness bug in the class lowering, not dev instrumentation: the emitted class simply has no `d` accessor. It is out of scope for #2021 and deserves its own issue; I did not touch it.

The tagger itself is already ready for those fields — `tag_class_field_ast.rs` has a unit test showing `class C { #x = $.derived(() => 1) }` → `$.tag($.derived(() => 1), 'C.#x')` — so once the lowering emits them, they will be labelled with no further work.

## Verification

- 13 class shapes (modules and components) × official — **all match** except the four blocked on the missing-field bug above.
- New suite `crates/rsvelte_core/tests/class_field_tag_label_2021.rs` — 5 tests covering private, public, anonymous, named-expression and the production form.
- The `tag_class_field_ast` unit test that asserted `Unknown` is updated.
- `cargo test --release -p rsvelte_core` — **150 binaries, 2102 tests, 0 failures**.
- `cargo test --lib`, `cargo fmt`, `cargo clippy` (changed files warning-free).
- **Full output-equality corpus**: 14,005 entries × 3 targets — `✅ no regressions`.

No ratchet changes: the baseline shrink is being done in one pass after the cluster PRs land.

Fixes #2021

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FKkTpzZGaGWWzJvw4BnHJs