### PR TITLE
fix(compiler): lower the `$inspect` rune in dev outside the state pass (#2040)

### DIFF
--- a/.changeset/fix-inspect-rune-dev.md
+++ b/.changeset/fix-inspect-rune-dev.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/compiler": patch
+---
+
+fix(compiler): lower the `$inspect` rune in dev when it is the only rune in a component, and in `.svelte.js` module scripts — both previously emitted `$inspect(...)` verbatim, which throws `ReferenceError` at runtime

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/ast_state_transform.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/ast_state_transform.rs
@@ -3948,6 +3948,10 @@ fn has_state_transform_candidate(script: &str, config: &AstTransformConfig) -> b
     let has_strict_equals = config.dev && super::strict_equals_ast::source_has_equality_op(script);
     // Dev-mode `await X` → `(await $.track_reactivity_loss(X))()` rewrite.
     let has_await = config.dev && memchr::memmem::find(script.as_bytes(), b"await").is_some();
+    // Dev-mode `$inspect(...)` → `$.inspect(...)`; without its own probe the
+    // rewrite only fires once some other rune has opened the pass.
+    let has_inspect =
+        config.dev && config.is_runes && super::inspect_rune_ast::source_has_inspect_rune(script);
 
     if !has_state
         && !has_props
@@ -3961,6 +3965,7 @@ fn has_state_transform_candidate(script: &str, config: &AstTransformConfig) -> b
         && !has_host_calls
         && !has_strict_equals
         && !has_await
+        && !has_inspect
     {
         return false;
     }
@@ -4020,6 +4025,7 @@ fn has_state_transform_candidate(script: &str, config: &AstTransformConfig) -> b
         // `await` is a keyword, not an identifier, so it can only be carried by
         // its own probe here.
         || has_await
+        || has_inspect
 }
 
 fn state_assignment_needs_semantic(program: &Program<'_>, state_vars: &FxHashSet<&str>) -> bool {

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/ast_state_transform.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/ast_state_transform.rs
@@ -2618,12 +2618,19 @@ impl<'a, 's, 'ast> Visit<'ast> for StateVarCollector<'a, 's> {
                 self.visit_argument(cb_arg);
                 let cb_span = cb_arg.span();
                 let cb_text = self.apply_and_drain_inner_replacements(cb_span.start, cb_span.end);
+                let inspector = if cb_arg
+                    .as_expression()
+                    .is_none_or(super::inspect_rune_ast::needs_parens)
+                {
+                    format!("({cb_text})")
+                } else {
+                    cb_text
+                };
                 self.add_replacement(
                     expr.span.start,
                     expr.span.end,
                     format!(
-                        "$.inspect(() => [{}], (...$$args) => ({})(...$$args))",
-                        args_text, cb_text
+                        "$.inspect(() => [{args_text}], (...$$args) => {inspector}(...$$args))"
                     ),
                 );
                 return;

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/inspect_rune_ast.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/inspect_rune_ast.rs
@@ -28,7 +28,7 @@ pub(super) fn source_has_inspect_rune(s: &str) -> bool {
 
 /// An inspector that is not already a plain reference has to be parenthesised
 /// before it can be invoked — `((t, v) => …)(...$$args)`.
-fn needs_parens(expr: &Expression<'_>) -> bool {
+pub(super) fn needs_parens(expr: &Expression<'_>) -> bool {
     !matches!(
         expr,
         Expression::Identifier(_)
@@ -58,11 +58,12 @@ impl<'src> InspectCollector<'src> {
     }
 
     /// `() => [arg, arg, …]` built from a `$inspect(...)` call's arguments.
+    /// Slices each argument's own span so a `...spread` survives — narrowing to
+    /// `as_expression()` would drop it from the array.
     fn args_thunk(&self, call: &CallExpression<'_>) -> String {
         let args = call
             .arguments
             .iter()
-            .filter_map(|a| a.as_expression())
             .map(|a| self.text(a.span()))
             .collect::<Vec<_>>()
             .join(", ");
@@ -115,5 +116,79 @@ impl<'a, 'src> Visit<'a> for InspectCollector<'src> {
         }
 
         walk::walk_call_expression(self, expr);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::module_dev_tail_ast::transform_module_dev_tail_ast;
+
+    /// Through the production entry point, so the gate is exercised too.
+    fn lower(source: &str) -> Option<String> {
+        transform_module_dev_tail_ast(source, true, false)
+    }
+
+    #[test]
+    fn lowers_the_bare_rune() {
+        assert_eq!(
+            lower("$inspect(a);").unwrap(),
+            "$.inspect(() => [a], (...$$args) => console.log(...$$args), true);"
+        );
+    }
+
+    #[test]
+    fn lowers_multiple_arguments() {
+        assert_eq!(
+            lower("$inspect(a, b);").unwrap(),
+            "$.inspect(() => [a, b], (...$$args) => console.log(...$$args), true);"
+        );
+    }
+
+    #[test]
+    fn keeps_a_spread_argument() {
+        assert_eq!(
+            lower("$inspect(a, ...b, 3);").unwrap(),
+            "$.inspect(() => [a, ...b, 3], (...$$args) => console.log(...$$args), true);"
+        );
+    }
+
+    #[test]
+    fn with_a_named_inspector_is_called_directly() {
+        assert_eq!(
+            lower("$inspect(a).with(fn);").unwrap(),
+            "$.inspect(() => [a], (...$$args) => fn(...$$args));"
+        );
+        assert_eq!(
+            lower("$inspect(a).with(obj.fn);").unwrap(),
+            "$.inspect(() => [a], (...$$args) => obj.fn(...$$args));"
+        );
+    }
+
+    #[test]
+    fn with_an_inline_inspector_is_parenthesised() {
+        assert_eq!(
+            lower("$inspect(a).with((t, v) => log(t, v));").unwrap(),
+            "$.inspect(() => [a], (...$$args) => ((t, v) => log(t, v))(...$$args));"
+        );
+    }
+
+    #[test]
+    fn does_not_touch_a_rune_shaped_string() {
+        assert!(lower(r#"let s = "$inspect(a)";"#).is_none());
+    }
+
+    #[test]
+    fn the_generated_default_inspector_is_not_re_wrapped() {
+        // The console collector runs in the same batch; its skip for
+        // `console.log(...$$args)` has to hold for what this pass just emitted.
+        let out = lower("$inspect(a);\nconsole.log(b);").unwrap();
+        assert!(
+            out.contains("(...$$args) => console.log(...$$args), true)"),
+            "default inspector was rewritten: {out}"
+        );
+        assert!(
+            out.contains(r#"console.log(...$.log_if_contains_state("log", b));"#),
+            "the user's own console call should still be wrapped: {out}"
+        );
     }
 }

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/inspect_rune_ast.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/inspect_rune_ast.rs
@@ -1,0 +1,119 @@
+//! AST-based dev-mode `$inspect` lowering for module scripts
+//! (`.svelte.js` / `.svelte.ts`).
+//!
+//! Mirrors `transform_inspect_rune` in the official compiler's
+//! `visitors/CallExpression.js`:
+//!
+//! ```text
+//! $inspect(a, b)          -> $.inspect(() => [a, b], (...$$args) => console.log(...$$args), true)
+//! $inspect(a).with(cb)    -> $.inspect(() => [a], (...$$args) => cb(...$$args))
+//! ```
+//!
+//! The component instance script gets this from the state-transform visitor;
+//! module scripts had no equivalent, so the rune survived into the output and
+//! threw `ReferenceError: $inspect is not defined` when the module ran.
+//! Non-dev removal stays where it is, in the text pass in `mod.rs`.
+
+use oxc_ast::ast::*;
+use oxc_ast_visit::Visit;
+use oxc_ast_visit::walk;
+use oxc_span::GetSpan;
+
+use super::ast_rewrite::Edit;
+
+/// Cheap byte probe gating entry into the AST pass.
+pub(super) fn source_has_inspect_rune(s: &str) -> bool {
+    memchr::memmem::find(s.as_bytes(), b"$inspect").is_some()
+}
+
+/// An inspector that is not already a plain reference has to be parenthesised
+/// before it can be invoked — `((t, v) => …)(...$$args)`.
+fn needs_parens(expr: &Expression<'_>) -> bool {
+    !matches!(
+        expr,
+        Expression::Identifier(_)
+            | Expression::StaticMemberExpression(_)
+            | Expression::ComputedMemberExpression(_)
+            | Expression::ParenthesizedExpression(_)
+    )
+}
+
+pub(super) fn collect_inspect_rune_edits(program: &Program<'_>, source: &str) -> Vec<Edit> {
+    let mut collector = InspectCollector {
+        source,
+        replacements: Vec::new(),
+    };
+    collector.visit_program(program);
+    collector.replacements
+}
+
+struct InspectCollector<'src> {
+    source: &'src str,
+    replacements: Vec<Edit>,
+}
+
+impl<'src> InspectCollector<'src> {
+    fn text(&self, span: oxc_span::Span) -> &'src str {
+        self.source[span.start as usize..span.end as usize].trim()
+    }
+
+    /// `() => [arg, arg, …]` built from a `$inspect(...)` call's arguments.
+    fn args_thunk(&self, call: &CallExpression<'_>) -> String {
+        let args = call
+            .arguments
+            .iter()
+            .filter_map(|a| a.as_expression())
+            .map(|a| self.text(a.span()))
+            .collect::<Vec<_>>()
+            .join(", ");
+        format!("() => [{args}]")
+    }
+}
+
+impl<'a, 'src> Visit<'a> for InspectCollector<'src> {
+    fn visit_call_expression(&mut self, expr: &CallExpression<'a>) {
+        // `$inspect(args).with(cb)` — match the outer call first so the inner
+        // `$inspect(args)` is not rewritten separately.
+        if expr.arguments.len() == 1
+            && let Expression::StaticMemberExpression(member) = &expr.callee
+            && member.property.name == "with"
+            && let Expression::CallExpression(inner) = &member.object
+            && let Expression::Identifier(callee) = &inner.callee
+            && callee.name == "$inspect"
+            && let Some(cb) = expr.arguments[0].as_expression()
+        {
+            let cb_text = self.text(cb.span());
+            let inspector = if needs_parens(cb) {
+                format!("({cb_text})")
+            } else {
+                cb_text.to_string()
+            };
+            self.replacements.push((
+                expr.span.start,
+                expr.span.end,
+                format!(
+                    "$.inspect({}, (...$$args) => {}(...$$args))",
+                    self.args_thunk(inner),
+                    inspector
+                ),
+            ));
+            return;
+        }
+
+        if let Expression::Identifier(callee) = &expr.callee
+            && callee.name == "$inspect"
+        {
+            self.replacements.push((
+                expr.span.start,
+                expr.span.end,
+                format!(
+                    "$.inspect({}, (...$$args) => console.log(...$$args), true)",
+                    self.args_thunk(expr)
+                ),
+            ));
+            return;
+        }
+
+        walk::walk_call_expression(self, expr);
+    }
+}

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
@@ -16,6 +16,7 @@ mod destructure_transforms;
 mod effect_rune_ast;
 mod expression_utils;
 mod formatting;
+mod inspect_rune_ast;
 mod legacy_state_member_mutate_ast;
 mod local_assign_ast;
 mod module_dev_tail_ast;
@@ -5989,6 +5990,9 @@ fn transform_instance_script_for_visitors(
         let has_strict_equals = dev && strict_equals_ast::source_has_equality_op(&result);
         // Dev-mode `await X` → `(await $.track_reactivity_loss(X))()` rewrite.
         let has_await = dev && memmem::find(result.as_bytes(), b"await").is_some();
+        // Dev-mode `$inspect(...)` → `$.inspect(...)`; see the matching probe in
+        // `ast_state_transform`. This block already sits under `analysis.runes`.
+        let has_inspect = dev && inspect_rune_ast::source_has_inspect_rune(&result);
         let has_transforms = !state_vars.is_empty()
             || !prop_assignment_transform_vars.is_empty()
             || !store_sub_vars.is_empty()
@@ -6000,7 +6004,8 @@ fn transform_instance_script_for_visitors(
             || has_props_calls
             || has_host_calls
             || has_strict_equals
-            || has_await;
+            || has_await
+            || has_inspect;
 
         if has_transforms {
             // Collect $derived / $derived.by binding names so AST assignment transforms

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/module_dev_tail_ast.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/module_dev_tail_ast.rs
@@ -58,7 +58,9 @@ pub fn transform_module_dev_tail_ast(source: &str, dev: bool, is_ts: bool) -> Op
             || memchr::memmem::find(bytes, b"$.derived").is_some()
             || memchr::memmem::find(bytes, b"$.proxy").is_some());
 
-    if !has_effect && !has_strict && !has_console && !has_tag {
+    let has_inspect = dev && super::inspect_rune_ast::source_has_inspect_rune(source);
+
+    if !has_effect && !has_strict && !has_console && !has_tag && !has_inspect {
         return None;
     }
 
@@ -88,6 +90,11 @@ pub fn transform_module_dev_tail_ast(source: &str, dev: bool, is_ts: bool) -> Op
             }
             if has_tag {
                 edits.extend(super::tag_declarator_ast::collect_tag_declarator_edits(
+                    program, src,
+                ));
+            }
+            if has_inspect {
+                edits.extend(super::inspect_rune_ast::collect_inspect_rune_edits(
                     program, src,
                 ));
             }


### PR DESCRIPTION
Fixes #2040.

This one is not a formatting divergence — the emitted dev module references a global `$inspect`, so **running it throws `ReferenceError: $inspect is not defined`**. Production compiles the rune away, which is why no `dev: false` target ever caught it.

## Root cause

The `$inspect` → `$.inspect` rewrite was already implemented, but only inside the instance-script state transform. That pass has **two** gates:

1. a byte probe for the runes it knows about, and
2. an identifier check that the probed rune actually appears in the script.

Neither mentioned `$inspect`. So the rewrite only ran when some *other* rune had already opened the pass — `let a = $state(0); $inspect(a)` worked, `let m = new SvelteMap(); $inspect(m)` did not. Module scripts (`.svelte.js`) had no lowering at all.

Finding gate 2 took instrumenting: the first gate reported `has_transforms=true` while `visit_call_expression` was never entered, which is what pointed past the obvious fix.

## The fix

- `$inspect` added to both gates.
- New `inspect_rune_ast.rs` collector for module scripts, wired into `module_dev_tail_ast` alongside the existing equality / console / tag collectors. It mirrors `transform_inspect_rune`:
  ```
  $inspect(a, b)        -> $.inspect(() => [a, b], (...$$args) => console.log(...$$args), true)
  $inspect(a).with(cb)  -> $.inspect(() => [a], (...$$args) => cb(...$$args))
  ```
  with the inspector parenthesised when it is not already a plain reference, matching upstream's `((t, v) => …)(...$$args)` versus `fn(...$$args)`.

Production is unaffected — the non-dev text paths strip the rune already, and both were verified byte-identical.

## Verification

All three entries the issue names now match the official compiler, at `dev: true` and `dev: false`:

- `runtime-runes/samples/inspect-map-set/main.svelte` (no other rune)
- `runtime-runes/samples/class-private-fields-reassigned-this/main.svelte`
- `validator/samples/runes-conflicting-store-in-module/input.svelte.js` (module path)

Plus a shape probe over `$inspect(a)`, `$inspect(a, b)`, `.with(arrow)` and `.with(identifier)` across the component and module paths.

Full corpus, all three targets (14,005 × 3), oxfmt-normalized:

```
match           11536
error-parity      948
js-mismatch      1520
css-mismatch        0
error-mismatch      0

✅ no regressions (client 0, server 0)
🎉 2127 known failures now PASS (client-dev 2127)
```

The corpus number is large because the client-dev ratchet has been deliberately held at 3647 entries during this campaign, so the verify run reports the accumulated effect of every dev-cluster fix merged since (#2074/#2075/#2076/#2077/#2079/#2084/#2085), not this PR alone. This PR's own contribution is bounded by the ≤32 baseline entries whose source mentions `$inspect` (the issue's own count for the ReferenceError cluster is 3); the consolidated ratchet burn-down lands in a follow-up chore PR.

### Known residual

`.with((t,v) => …)` keeps the callback's source spacing — `(t,v)` where the official compiler reprints `(t, v)`. Same verbatim-copy-versus-reprint property as the equality rewrite, absorbed by oxfmt in the corpus.

Code + changeset only; the ratchet shrink is handled in one pass after the campaign's code PRs land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FKkTpzZGaGWWzJvw4BnHJs
