### PR TITLE
perf(compiler): index shadowed-rune declarations instead of scanning per variable

### DIFF
--- a/.changeset/perf-index-shadowed-rune-decls.md
+++ b/.changeset/perf-index-shadowed-rune-decls.md
@@ -1,0 +1,5 @@
+---
+'@rsvelte/compiler': patch
+---
+
+Index shadowed-rune declarations once per client transform instead of running twelve full-script substring searches per reactive binding. Rune-heavy components were paying O(binding count × script length) here: a component with 40 `$derived` declarations now compiles 50% faster, real-world Svelte files up to 23% faster, and the flowbite-svelte corpus 6.9% faster overall.

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
@@ -6404,50 +6404,97 @@ fn find_matching_paren_bytes(bytes: &[u8], open_pos: usize) -> Option<usize> {
 /// `$.update()` transforms only within that scope.
 fn transform_shadowed_local_state_vars(script: &str, shadowed_vars: &[String]) -> String {
     let mut result = script.to_string();
+    // Every top-level rune binding lands in `shadowed_vars`, so probing the
+    // twelve declaration shapes with a `find` per variable ran
+    // O(shadowed_count × script_len) and dominated transform time on rune-heavy
+    // components. One indexing pass yields the same first-match offsets;
+    // it is refreshed whenever a transform rewrites `result`.
+    let mut decls = index_shadowed_decls(&result);
 
     for var in shadowed_vars {
-        // Find `let VAR = $.state(` or `let VAR = $.derived(` patterns
-        // in the already-transformed output
-        let state_patterns = [
-            format!("let {} = $.state(", var),
-            format!("let {} = $.derived(", var),
-            format!("var {} = $.state(", var),
-            format!("var {} = $.derived(", var),
-            format!("const {} = $.state(", var),
-            format!("const {} = $.derived(", var),
-            format!("let {} = $.state.raw(", var),
-            format!("let {} = $.derived.by(", var),
-            format!("var {} = $.state.raw(", var),
-            format!("var {} = $.derived.by(", var),
-            format!("const {} = $.state.raw(", var),
-            format!("const {} = $.derived.by(", var),
-        ];
+        // Shapes are probed in order and each one searches the *current*
+        // `result`, so the index is refreshed as soon as a rewrite lands.
+        for shape in 0..SHADOWED_DECL_SHAPE_COUNT {
+            let Some(decl_pos) = decls.get(var.as_str()).and_then(|found| found[shape]) else {
+                continue;
+            };
+            // Find the enclosing function body
+            let Some((func_start, func_end)) =
+                find_enclosing_function_body(&result, decl_pos as usize)
+            else {
+                continue;
+            };
+            let func_body = &result[func_start..func_end];
+            let is_state = shape % 2 == 0;
+            let transformed_body = apply_local_state_transforms(func_body, var, is_state);
 
-        for pattern in &state_patterns {
-            if let Some(decl_pos) = result.find(pattern.as_str()) {
-                // Find the enclosing function body
-                if let Some((func_start, func_end)) =
-                    find_enclosing_function_body(&result, decl_pos)
-                {
-                    let func_body = &result[func_start..func_end];
-                    let is_state = memmem::find(pattern.as_bytes(), b"$.state(").is_some()
-                        || memmem::find(pattern.as_bytes(), b"$.state.raw(").is_some();
-                    let transformed_body = apply_local_state_transforms(func_body, var, is_state);
-
-                    if transformed_body != func_body {
-                        result = format!(
-                            "{}{}{}",
-                            &result[..func_start],
-                            transformed_body,
-                            &result[func_end..]
-                        );
-                    }
-                }
+            if transformed_body != func_body {
+                result = format!(
+                    "{}{}{}",
+                    &result[..func_start],
+                    transformed_body,
+                    &result[func_end..]
+                );
+                decls = index_shadowed_decls(&result);
             }
         }
     }
 
     result
+}
+
+/// The `$.…(` markers whose declarations [`transform_shadowed_local_state_vars`]
+/// rewrites, crossed with [`SHADOWED_DECL_KEYWORDS`] to form the twelve shapes.
+const SHADOWED_DECL_MARKERS: [&str; 4] = [
+    " = $.state(",
+    " = $.derived(",
+    " = $.state.raw(",
+    " = $.derived.by(",
+];
+
+const SHADOWED_DECL_KEYWORDS: [&str; 3] = ["let ", "var ", "const "];
+
+const SHADOWED_DECL_SHAPE_COUNT: usize = SHADOWED_DECL_MARKERS.len() * SHADOWED_DECL_KEYWORDS.len();
+
+/// First offset of each `<kw> N = $.…(` declaration shape, keyed by `N`.
+///
+/// The twelve shapes are `let` / `var` / `const` crossed with
+/// [`SHADOWED_DECL_MARKERS`], indexed in the order the original per-variable
+/// `format!` probes used. `N` is the space-delimited token before the marker and
+/// the keyword is matched as a raw substring (no left word boundary), so each
+/// entry is exactly what `result.find(<kw> N = $.…()` would have returned.
+fn index_shadowed_decls(
+    script: &str,
+) -> rustc_hash::FxHashMap<String, [Option<u32>; SHADOWED_DECL_SHAPE_COUNT]> {
+    let mut map: rustc_hash::FxHashMap<String, [Option<u32>; SHADOWED_DECL_SHAPE_COUNT]> =
+        rustc_hash::FxHashMap::default();
+    for (marker_idx, marker) in SHADOWED_DECL_MARKERS.iter().enumerate() {
+        for pos in memmem::find_iter(script.as_bytes(), marker.as_bytes()) {
+            let Some(space) = script[..pos].rfind(' ') else {
+                continue;
+            };
+            let name_start = space + 1;
+            if name_start == pos {
+                continue;
+            }
+            let head = &script[..name_start];
+            let Some(keyword) = SHADOWED_DECL_KEYWORDS
+                .iter()
+                .position(|kw| head.ends_with(kw))
+            else {
+                continue;
+            };
+            let shape = keyword * 2 + marker_idx % 2 + if marker_idx >= 2 { 6 } else { 0 };
+            let pattern_start = (name_start - SHADOWED_DECL_KEYWORDS[keyword].len()) as u32;
+            let entry = map
+                .entry(script[name_start..pos].to_string())
+                .or_insert([None; SHADOWED_DECL_SHAPE_COUNT]);
+            if entry[shape].is_none_or(|first| pattern_start < first) {
+                entry[shape] = Some(pattern_start);
+            }
+        }
+    }
+    map
 }
 
 /// Find the enclosing function body (from `{` to matching `}`) that contains `pos`.


### PR DESCRIPTION
## Summary
`transform_shadowed_local_state_vars` probed the transformed script with up to 12 `format!`-allocated patterns **per reactive variable**, each a full-text `str::find` — O(L×V), the dominant source of superlinear compile cost on rune-heavy components (marginal cost grew 7.5 → 22.7µs per `$derived` declaration at N=1→40).

This replaces the per-variable probes with a single-pass index over the output: one `memmem` scan classifies every ` = $.state(` / ` = $.derived(` / ` = $.state.raw(` / ` = $.derived.by(` site into the same 12 shapes keyed by `(name, shape) → first-match offset`, preserving the original raw-substring-match semantics exactly. The index is rebuilt after each rewrite, so every lookup still observes the *current* output.

## Measured (paired A/B, user CPU, 20+ pairs, order-swapped)
- flowbite corpus (1296 files): **−6.9%** (median)
- rune-heavy real files: NavUl.svelte −22.6%, Input.svelte −17.1%
- synthetic `$derived`×40: **−50.3%**; the marginal-cost curve is now flat (superlinearity eliminated)

## Verification
- 4038 outputs (flowbite 1296 + 50 synthetic × client/client-dev/server) **byte-identical** (sha256, self-built baseline); re-verified on top of origin/main 6d47676c
- `cargo test --release -p rsvelte_core`: 145 suites / 2061 tests green; fmt/clippy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F4m3u9XgyDX4NX1k1aGyG3