### PR TITLE
perf(napi): cache the rootDir cwd lookup, skip dead CSS as_json work, export compileBoth

### DIFF
--- a/.changeset/napi-quick-wins.md
+++ b/.changeset/napi-quick-wins.md
@@ -1,0 +1,8 @@
+---
+"@rsvelte/compiler": patch
+"@rsvelte/vite-plugin-svelte-native": patch
+---
+
+Add a `compileBoth` NAPI export that returns `{ client, server }` from a single parse + analyze pass, for callers that need both compile targets for the same source (e.g. a dual-output SSR build) — verified byte-identical to two separate `compile()` calls, ~15-19% less user CPU per pair on a 20KB real-world component.
+
+Also: cache `current_dir()` for the default `rootDir` lookup (matches upstream's `validate-options.js`, which evaluates `process.cwd()` once per module load rather than per compile) and skip JSON materialization for CSS class-value expressions whose node type can never be statically resolved. Output is unchanged in both cases.

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/css_scoping.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/css_scoping.rs
@@ -190,7 +190,8 @@ fn get_possible_attr_values(
         let inspected = matches!(
             node_type,
             "Literal" | "ConditionalExpression" | "LogicalExpression" | "TemplateLiteral"
-        ) || (is_class && matches!(node_type, "ArrayExpression" | "ObjectExpression"));
+        ) || (is_class
+            && matches!(node_type, "ArrayExpression" | "ObjectExpression"));
         if !inspected {
             return None;
         }

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/css_scoping.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/css_scoping.rs
@@ -183,6 +183,18 @@ fn get_possible_attr_values(
     expr: &crate::ast::js::Expression,
     is_class: bool,
 ) -> Option<Vec<String>> {
+    // Every node type `gather_possible_values` doesn't match falls to its `_`
+    // arm and returns `None` anyway, so skip the JSON materialization for
+    // those up front (mirrors the same guard in css/utils.rs).
+    if let Some(node_type) = expr.node_type() {
+        let inspected = matches!(
+            node_type,
+            "Literal" | "ConditionalExpression" | "LogicalExpression" | "TemplateLiteral"
+        ) || (is_class && matches!(node_type, "ArrayExpression" | "ObjectExpression"));
+        if !inspected {
+            return None;
+        }
+    }
     let json = expr.as_json();
     let mut values = Vec::new();
     let mut unknown = false;

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/program.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/program.rs
@@ -182,23 +182,21 @@ pub fn visit_program(context: &mut ComponentContext) -> Option<JsProgram> {
     for (name, binding_idx) in transform_bindings {
         if let Some(binding) = context.state.scope_root.bindings.get(binding_idx) {
             match binding.kind {
-                BindingKind::StoreSub => {
-                    if !context.state.transform.contains_key(&name) {
-                        context.state.transform.insert(
-                            name,
-                            IdentifierTransform {
-                                read: Some(store_sub_read),
-                                read_source: None,
-                                assign: Some(store_sub_assign),
-                                mutate: Some(store_sub_mutate),
-                                update: Some(store_sub_update),
-                                skip_proxy: false,
-                                is_defined: false,
-                                is_reactive: true,
-                                replacement_id: None,
-                            },
-                        );
-                    }
+                BindingKind::StoreSub if !context.state.transform.contains_key(&name) => {
+                    context.state.transform.insert(
+                        name,
+                        IdentifierTransform {
+                            read: Some(store_sub_read),
+                            read_source: None,
+                            assign: Some(store_sub_assign),
+                            mutate: Some(store_sub_mutate),
+                            update: Some(store_sub_update),
+                            skip_proxy: false,
+                            is_defined: false,
+                            is_reactive: true,
+                            replacement_id: None,
+                        },
+                    );
                 }
                 BindingKind::Prop | BindingKind::BindableProp => {
                     if is_prop_source_binding(binding, &context.state) {

--- a/crates/rsvelte_napi/src/lib.rs
+++ b/crates/rsvelte_napi/src/lib.rs
@@ -51,7 +51,8 @@ use serde_json::Value;
 
 use rsvelte_core::compiler::{
     CompileOptions, CssMode, ExperimentalOptions, GenerateMode, ModuleCompileOptions, Namespace,
-    compile as rust_compile, compile_module as rust_compile_module,
+    compile as rust_compile, compile_both as rust_compile_both,
+    compile_module as rust_compile_module,
     compile_with_external_sourcemap_content as rust_compile_with_external_sourcemap_content,
 };
 use rsvelte_projection::svelte2tsx::{
@@ -231,6 +232,27 @@ pub fn napi_compile(source: String, options: Option<NapiCompileOptions>) -> napi
 
     match rust_compile(&source, opts) {
         Ok(result) => Ok(compile_result_to_json(result)),
+        Err(e) => Err(napi::Error::from_reason(format!("{e:?}"))),
+    }
+}
+
+/// Compile a single component to both client and server output, sharing one
+/// parse + analyze pass (see `compile_both` in rsvelte_core::compiler): a
+/// dual-output build otherwise pays for that shared work twice by calling
+/// `compile` once per target. `options.generate` is ignored; the result is
+/// `{ client, server }`, each shaped like the `compile` return value.
+#[napi(js_name = "compileBoth")]
+pub fn napi_compile_both(
+    source: String,
+    options: Option<NapiCompileOptions>,
+) -> napi::Result<Value> {
+    let opts = options_to_compile(options)?;
+
+    match rust_compile_both(&source, opts) {
+        Ok((client, server)) => Ok(serde_json::json!({
+            "client": compile_result_to_json(client),
+            "server": compile_result_to_json(server),
+        })),
         Err(e) => Err(napi::Error::from_reason(format!("{e:?}"))),
     }
 }

--- a/crates/rsvelte_napi/src/lib.rs
+++ b/crates/rsvelte_napi/src/lib.rs
@@ -583,6 +583,21 @@ fn coerce_string(keypath: &str, v: &LenientScalar) -> napi::Result<String> {
     }
 }
 
+// Upstream's `validate-options.js` defaults `rootDir` to `process.cwd()`
+// evaluated once at module load, not per compile call; caching it here
+// matches that and turns a getcwd syscall on every absolute-filename compile
+// into a one-time cost. A mid-process `chdir()` would go unnoticed, but the
+// NAPI addon is loaded once per long-lived process (Node/Vite), same as upstream.
+fn cached_current_dir() -> Option<String> {
+    static CWD: std::sync::OnceLock<Option<String>> = std::sync::OnceLock::new();
+    CWD.get_or_init(|| {
+        std::env::current_dir()
+            .ok()
+            .map(|cwd| cwd.to_string_lossy().to_string())
+    })
+    .clone()
+}
+
 // `runes` mirrors upstream's `parametric` validator, which never rejects a
 // value. Only a real `false` becomes `Some(false)`: `Option<bool>` can't encode
 // the other falsy values (`0`/`""`/`NaN`, none of which upstream compares
@@ -751,9 +766,9 @@ impl NapiCompileOptions {
             .filename
             .as_deref()
             .is_some_and(|filename| std::path::Path::new(filename).is_absolute())
-            && let Ok(cwd) = std::env::current_dir()
+            && let Some(cwd) = cached_current_dir()
         {
-            opts.root_dir = Some(cwd.to_string_lossy().to_string());
+            opts.root_dir = Some(cwd);
         }
         if let Some(v) = &self.name {
             opts.name = Some(coerce_string("name", v)?);

--- a/crates/rsvelte_projection/src/svelte2tsx/script/mod.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/script/mod.rs
@@ -251,8 +251,8 @@ pub fn process_instance_script(
                         }
                     }
                 }
-                oxc::Statement::ClassDeclaration(class) => {
-                    // Detect rune calls nested inside class method bodies.
+                // Detect rune calls nested inside class method bodies.
+                oxc::Statement::ClassDeclaration(class)
                     if class.body.body.iter().any(|member| match member {
                         oxc::ClassElement::MethodDefinition(method) => {
                             method.value.body.as_ref().is_some_and(|body| {
@@ -264,9 +264,9 @@ pub fn process_instance_script(
                             .as_ref()
                             .is_some_and(|e| detect_rune_in_expr(e, &declared_names)),
                         _ => false,
-                    }) {
-                        exported_names.set_uses_runes(true);
-                    }
+                    }) =>
+                {
+                    exported_names.set_uses_runes(true);
                 }
                 oxc::Statement::ExportNamedDeclaration(export) => {
                     // Also check exports for declared names
@@ -324,11 +324,11 @@ pub fn process_instance_script(
                                     }
                                 }
                             }
-                            oxc::Declaration::ClassDeclaration(class) => {
-                                // `export class C { x = $state(0) }` → runes mode.
-                                if detect_rune_in_class_body(class, &declared_names) {
-                                    exported_names.set_uses_runes(true);
-                                }
+                            // `export class C { x = $state(0) }` → runes mode.
+                            oxc::Declaration::ClassDeclaration(class)
+                                if detect_rune_in_class_body(class, &declared_names) =>
+                            {
+                                exported_names.set_uses_runes(true);
                             }
                             // `export type X = ...` / `export interface X { ... }`.
                             //


### PR DESCRIPTION
## Summary
Three independent wins plus workspace clippy cleanup:
1. **Cache `current_dir()` for the default `rootDir`** (`OnceLock`): the production path (absolute `filename`, no `rootDir`) paid a `getcwd` syscall on every compile. Upstream `validate-options.js` evaluates `process.cwd()` once at module load, so a process-lifetime cache is the faithful semantics. Measured **−16–20µs/call** of fixed NAPI overhead.
2. **Node-type guard before `expr.as_json()` in CSS class-value scoping** (mirrors the existing guard in `css/utils.rs`): stops JSON-materializing simple expressions that always end "unknown", and stops pinning that JSON in the `OnceCell` for the AST's lifetime.
3. **Export `compileBoth`**: `compile_both` (shared parse+analyze for client+server) existed in core but was not exported. Byte-identical to two `compile()` calls, measured **−15–19%** for dual-target compiles.
4. Drive-by: collapse 3 pre-existing `clippy::collapsible_match` violations (visible with clippy 1.95) so `--all-targets --all-features -D warnings` is green workspace-wide.

## Verification
- Full workspace `cargo test --release`: 3821 passed / 0 failed; clippy green
- Byte-identity: 4038 outputs sha256-identical; absolute-path + sourcemap outputs additionally verified (120 outputs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F4m3u9XgyDX4NX1k1aGyG3