### PR TITLE
fix(compiler): count `add_locations` columns in UTF-16 code units (#2030)

### DIFF
--- a/.changeset/fix-add-locations-column-utf16.md
+++ b/.changeset/fix-add-locations-column-utf16.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/compiler": patch
+---
+
+fix(compiler): count `$.add_locations` columns in UTF-16 code units instead of bytes, so a non-ASCII character earlier on the line no longer shifts the reported position

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/transform_template/index.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/transform_template/index.rs
@@ -43,6 +43,26 @@ pub struct Location {
     pub column: usize,
 }
 
+/// Line/column of a byte offset, columns in UTF-16 code units to match
+/// `locate-character`, which indexes the source as a JS string.
+fn locate(source: &str, offset: u32) -> Location {
+    let mut end = (offset as usize).min(source.len());
+    while end > 0 && !source.is_char_boundary(end) {
+        end -= 1;
+    }
+    let mut line = 1usize;
+    let mut column = 0usize;
+    for c in source[..end].chars() {
+        if c == '\n' {
+            line += 1;
+            column = 0;
+        } else {
+            column += c.len_utf16();
+        }
+    }
+    Location { line, column }
+}
+
 /// Build location metadata for template nodes.
 fn build_locations(nodes: &[Node], locator: &Locator) -> JsExpr {
     let mut array_elements = Vec::new();
@@ -160,26 +180,7 @@ pub fn transform_template<'a>(
             loc
         } else {
             let source = state.analysis.source.clone();
-            auto_locator = Box::new(move |offset: u32| {
-                // Columns count UTF-16 code units, matching `locate-character`,
-                // which indexes the source as a JS string. Counting bytes puts
-                // every non-ASCII character earlier on the line into the column.
-                let mut end = (offset as usize).min(source.len());
-                while end > 0 && !source.is_char_boundary(end) {
-                    end -= 1;
-                }
-                let mut line = 1usize;
-                let mut col = 0usize;
-                for c in source[..end].chars() {
-                    if c == '\n' {
-                        line += 1;
-                        col = 0;
-                    } else {
-                        col += c.len_utf16();
-                    }
-                }
-                Location { line, column: col }
-            });
+            auto_locator = Box::new(move |offset: u32| locate(&source, offset));
             &auto_locator
         };
         let locations = build_locations(&state.template.nodes, loc_ref);
@@ -236,5 +237,26 @@ mod tests {
         assert_eq!(Namespace::Html.as_str(), "html");
         assert_eq!(Namespace::Svg.as_str(), "svg");
         assert_eq!(Namespace::Mathml.as_str(), "mathml");
+    }
+
+    /// Column of the `<p>` in each source, i.e. how much of the line precedes it.
+    fn column_of_p(source: &str) -> usize {
+        locate(source, source.find("<p>").unwrap() as u32).column
+    }
+
+    #[test]
+    fn columns_count_utf16_code_units() {
+        assert_eq!(column_of_p("ab<p>"), 2, "ascii");
+        assert_eq!(column_of_p("aé<p>"), 2, "2-byte char is one unit");
+        assert_eq!(column_of_p("a’<p>"), 2, "3-byte char is one unit");
+        // The discriminating case: a surrogate pair is one code point but two
+        // UTF-16 units, so a code-point count would report 2 here.
+        assert_eq!(column_of_p("a🎉<p>"), 3, "surrogate pair is two units");
+    }
+
+    #[test]
+    fn newlines_reset_the_column() {
+        let loc = locate("a🎉\nbc<p>", "a🎉\nbc<p>".find("<p>").unwrap() as u32);
+        assert_eq!((loc.line, loc.column), (2, 2));
     }
 }

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/transform_template/index.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/transform_template/index.rs
@@ -161,16 +161,21 @@ pub fn transform_template<'a>(
         } else {
             let source = state.analysis.source.clone();
             auto_locator = Box::new(move |offset: u32| {
-                let offset = offset as usize;
-                let bytes = source.as_bytes();
+                // Columns count UTF-16 code units, matching `locate-character`,
+                // which indexes the source as a JS string. Counting bytes puts
+                // every non-ASCII character earlier on the line into the column.
+                let mut end = (offset as usize).min(source.len());
+                while end > 0 && !source.is_char_boundary(end) {
+                    end -= 1;
+                }
                 let mut line = 1usize;
                 let mut col = 0usize;
-                for &byte in bytes.iter().take(offset.min(bytes.len())) {
-                    if byte == b'\n' {
+                for c in source[..end].chars() {
+                    if c == '\n' {
                         line += 1;
                         col = 0;
                     } else {
-                        col += 1;
+                        col += c.len_utf16();
                     }
                 }
                 Location { line, column: col }


### PR DESCRIPTION
Fixes #2030.

## Root cause

The dev template locator walked the source **byte by byte**:

```rust
for &byte in bytes.iter().take(offset) {
    if byte == b'\n' { line += 1; col = 0; } else { col += 1; }
}
```

so every non-ASCII character to the left of an element pushed its reported column out by that character's extra byte count. Upstream derives the same position with `locate-character`, which indexes the source as a JS string, so columns are **UTF-16 code units**.

That explains the varying offset the issue noticed — it is not a constant base offset, it is one unit per extra byte:

| source | official | rsvelte (before) |
|---|---|---|
| `We’ll never share your details. Read our <a …>` (`’` = 3 bytes) | `[8, 43]` | `[8, 45]` |
| a line with one 2-byte character | `[3, 16]` | `[3, 17]` |

Only the auto-locator was affected; all five `transform_template` call sites pass `locator: None`, so there is no second code path to fix.

## Verification

Checked against the official compiler:

| case | result |
|---|---|
| ASCII only | match |
| 2-byte (`é`) | match |
| 3-byte (`’`) | match |
| 4-byte (emoji, astral) | match |
| CJK | match |
| several non-ASCII on one line | match |
| non-ASCII on an earlier line | match |
| the three `flowbite-svelte` files named in the issue | match |

The astral case is the one that pins the unit. `é`, `’` and CJK all have one code point and one UTF-16 unit, so they pass under a code-point count too; a surrogate pair is one code point and **two** units, so only that case distinguishes the two. Unit tests assert it directly (`"a🎉<p>"` → column 3, not 2), with the locator extracted so the unit is assertable without compiling a component.

`legacy.rs` already carries a UTF-16 position table for the same reason, which is independent corroboration.

### Corpus, measured as base vs. this change on the same commit (`128b5af0`)

```
base client-dev failures : 1013
with client-dev failures : 1004
FIXED by this change     : 9
BROKEN by this change    : 0
```

`client` and `server` unchanged (0 failures either side). The nine:

```
flowbite-svelte/src/routes/admin-dashboard/(no-sidebar)/Footer.svelte
flowbite-svelte/src/routes/admin-dashboard/(sidebar)/Footer.svelte
flowbite-svelte/src/routes/docs-examples/components/forms/Helper.svelte
flowbite-svelte/src/routes/docs-examples/extend/clipboard-manager/+page.svelte
flowbite-svelte/src/routes/docs-examples/forms/input-field/HelperText.svelte
skeleton/sites/skeleton.dev/src/components/ui/header/search.svelte
skeleton/sites/themes.skeleton.dev/src/lib/components/generator/Preview/PreviewTypography.svelte
svelte.dev/apps/svelte.dev/content/docs/svelte/98-reference/21-svelte-reactivity.md/12.svelte
… and one more
```

That is the PR's own contribution, not a cumulative figure — the ratchet is deliberately stale during this campaign, so the "known failures now PASS" line a single run prints includes already-merged work.

Code + changeset only; the ratchet shrink is handled in one pass after the campaign's code PRs land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FKkTpzZGaGWWzJvw4BnHJs
