### PR TITLE
fix(svelte2tsx): use the verbatim source slice for a dynamic slot name

### DIFF
--- a/.changeset/svelte2tsx-slot-name-verbatim.md
+++ b/.changeset/svelte2tsx-slot-name-verbatim.md
@@ -1,0 +1,13 @@
+---
+"@rsvelte/compiler": patch
+"@rsvelte/svelte2tsx": patch
+"@rsvelte/svelte-check": patch
+---
+
+fix(svelte2tsx): key `<slot name={expr}>`'s `__sveltets_createSlot(...)` call
+with the verbatim source text of the `name` attribute's value node, braces and
+inner whitespace included, instead of re-serializing the expression. Upstream's
+`surroundWith` wraps the raw `[start, end]` source slice in quotes rather than
+printing the parsed expression, so `name={n}` must produce `"{n}"`, not `"n"`.
+Also stop concatenating multi-part attribute values (`name="a{b}c"`) — upstream
+only ever reads `value[0]`.

--- a/crates/rsvelte_projection/src/svelte2tsx/template/nodes/slot_element.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/template/nodes/slot_element.rs
@@ -206,9 +206,10 @@ pub(crate) fn dollar_slot_name(attributes: &[Attribute]) -> String {
     slot_name
 }
 
-/// Source range of the `<slot name=…>` value that the start transformation
-/// keeps (`surroundWith(str, [slotName.start, slotName.end], '"', '"')`); `None`
-/// when the name defaults, which official emits as a literal.
+/// Source range of the `<slot name=…>` value's first value part (official's
+/// `value[0]`), verbatim-sliced by both `get_slot_name` (the emitted
+/// `__sveltets_createSlot` key) and `opener_spacing` (whitespace accounting);
+/// `None` when the name defaults, which official emits as a literal.
 fn get_slot_name_range(attributes: &[Attribute]) -> Option<(u32, u32)> {
     attributes.iter().find_map(|attr| match attr {
         Attribute::Attribute(node) if node.name == "name" => match &node.value {
@@ -224,49 +225,16 @@ fn get_slot_name_range(attributes: &[Attribute]) -> Option<(u32, u32)> {
 }
 
 pub(crate) fn get_slot_name(attributes: &[Attribute], source: &str) -> String {
-    for attr in attributes {
-        if let Attribute::Attribute(node) = attr
-            && node.name == "name"
-        {
-            match &node.value {
-                AttributeValue::Sequence(parts) => {
-                    // name="header" → parts is a single Text
-                    let mut name = String::new();
-                    for part in parts {
-                        if let AttributeValuePart::Text(text) = part {
-                            name.push_str(&text.raw);
-                        }
-                    }
-                    if !name.is_empty() {
-                        return name;
-                    }
-                    // Quoted mustache value, e.g. `name='{foo}'`: official uses
-                    // the raw source text of the value verbatim as the slot-name
-                    // string (`__sveltets_createSlot("{foo}", …)`). Slice from the
-                    // first to the last value part.
-                    if let (Some(first), Some(last)) = (parts.first(), parts.last()) {
-                        let start = match first {
-                            AttributeValuePart::Text(t) => t.start,
-                            AttributeValuePart::ExpressionTag(e) => e.start,
-                        } as usize;
-                        let end = match last {
-                            AttributeValuePart::Text(t) => t.end,
-                            AttributeValuePart::ExpressionTag(e) => e.end,
-                        } as usize;
-                        if start < end && end <= source.len() {
-                            return source[start..end].to_string();
-                        }
-                    }
-                }
-                AttributeValue::Expression(expr) => {
-                    // name={expr} - use the expression text
-                    return get_expression_text(&expr.expression, source).to_string();
-                }
-                _ => {}
-            }
-        }
-    }
-    "default".to_string()
+    // Official only ever looks at `value[0]` (`nodes/Element.ts`'s `slotName`),
+    // then slices its verbatim source range — including the braces of an
+    // ExpressionTag and any inner whitespace — rather than re-serializing an
+    // expression or concatenating multiple value parts.
+    get_slot_name_range(attributes)
+        .and_then(|(start, end)| {
+            let (start, end) = (start as usize, end as usize);
+            (start < end && end <= source.len()).then(|| source[start..end].to_string())
+        })
+        .unwrap_or_else(|| "default".to_string())
 }
 
 /// Get the `bind:this` expression text from a slot element's attributes.

--- a/crates/rsvelte_projection/tests/svelte2tsx_slot_name_verbatim.rs
+++ b/crates/rsvelte_projection/tests/svelte2tsx_slot_name_verbatim.rs
@@ -1,0 +1,81 @@
+//! `<slot name={expr}>` must key `__sveltets_createSlot(...)` with the verbatim
+//! source text of the value node (braces and inner whitespace included), the
+//! same way official svelte2tsx's `surroundWith(str, [slotName.start,
+//! slotName.end], '"', '"')` does in `htmlxtojsx_v2/nodes/Element.ts`. Only
+//! re-serializing the expression (dropping the braces / normalizing
+//! whitespace) is a divergence (#2046).
+
+use rsvelte_projection::svelte2tsx::{Svelte2TsxOptions, svelte2tsx};
+
+fn create_slot_call(source: &str) -> String {
+    let result = svelte2tsx(source, Svelte2TsxOptions::default()).expect("project");
+    let start = result
+        .code
+        .find("__sveltets_createSlot(")
+        .expect("createSlot call");
+    let rest = &result.code[start..];
+    let end = rest.find(");").map(|i| i + 2).unwrap_or(rest.len());
+    rest[..end].to_string()
+}
+
+#[test]
+fn dynamic_identifier_name_keeps_braces() {
+    assert_eq!(
+        create_slot_call("<slot name={n}></slot>"),
+        "__sveltets_createSlot(\"{n}\", { });"
+    );
+}
+
+#[test]
+fn member_expression_name_keeps_braces() {
+    assert_eq!(
+        create_slot_call("<slot name={expr.complex}></slot>"),
+        "__sveltets_createSlot(\"{expr.complex}\", { });"
+    );
+}
+
+#[test]
+fn binary_expression_name_keeps_braces() {
+    assert_eq!(
+        create_slot_call("<slot name={n + 1}></slot>"),
+        "__sveltets_createSlot(\"{n + 1}\", { });"
+    );
+}
+
+#[test]
+fn inner_whitespace_is_preserved_verbatim() {
+    assert_eq!(
+        create_slot_call("<slot name={ n }></slot>"),
+        "__sveltets_createSlot(\"{ n }\", { });"
+    );
+}
+
+#[test]
+fn static_string_name_is_unquoted() {
+    assert_eq!(
+        create_slot_call("<slot name=\"static\"></slot>"),
+        "__sveltets_createSlot(\"static\", { });"
+    );
+}
+
+#[test]
+fn quoted_mustache_name_matches_dynamic_form() {
+    assert_eq!(
+        create_slot_call("<slot name=\"{n}\"></slot>"),
+        "__sveltets_createSlot(\"{n}\", { });"
+    );
+}
+
+#[test]
+fn mixed_text_and_expression_only_uses_the_first_value_part() {
+    // Official only ever reads `value[0]` — a later ExpressionTag/Text part in
+    // the same attribute is not concatenated in, even though it's dropped.
+    assert_eq!(
+        create_slot_call("<slot name=\"a{b}c\"></slot>"),
+        "__sveltets_createSlot(\"a\", {  });"
+    );
+    assert_eq!(
+        create_slot_call("<slot name=\"{b}c\"></slot>"),
+        "__sveltets_createSlot(\"{b}\", { });"
+    );
+}


### PR DESCRIPTION
## Summary

Fixes #2046 — for a dynamic slot name `<slot name={n}>`, official svelte2tsx wraps the attribute value's first part's raw source in quotes (`Element.ts` slot case + `surroundWith`), emitting `__sveltets_createSlot("{n}", …)`. rsvelte re-serialized the extracted expression, emitting `"n"` (dropping the braces, interior whitespace, and — for multi-part values like `name="a{b}c"` — concatenating parts official ignores).

`get_slot_name` now slices the `value[0]` range verbatim, delegating range determination to the existing `get_slot_name_range` so the spacing computation and the emitted key can never drift apart.

## Verification

- Byte-compared against official svelte2tsx over 10 shapes by the implementer and 25 by an independent reviewer (interior whitespace, template literals, ternaries that produce official's broken-JS output faithfully, multi-part values, non-ASCII, comments, multi-line expressions, `let:`/`bind:this` combos): the `__sveltets_createSlot` call is identical in all of them.
- New unit suite `tests/svelte2tsx_slot_name_verbatim.rs` (7 shapes) — no corpus source contains a dynamic slot name, so these tests are the only guard for the class.
- `cargo test -p rsvelte_projection` / `cargo test -p rsvelte_check`: green. svelte2tsx corpus gate: all outputs identical.
- `cargo +1.97 clippy -- -D warnings` / `cargo fmt --check`: clean.
- Pre-existing sibling-path divergences (slots type, `$$slots`, `slot=` forwarding — all ignoring `value[0]`) are filed as #2100.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SfqweP3NTX8WEWvaQmerDZ