### PR TITLE
fix(compiler): route a legacy `on:` handler through $.apply in dev (#2029)

### DIFF
--- a/.changeset/fix-legacy-on-directive-apply.md
+++ b/.changeset/fix-legacy-on-directive-apply.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/compiler": patch
+---
+
+fix(compiler): route a legacy `on:` event handler through `$.apply` in dev, like the modern `onclick={…}` path already did, so a throwing handler is reported with its component and source position

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/attribute.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/attribute.rs
@@ -455,7 +455,7 @@ pub fn locate_in_source(source: &str, offset: usize) -> (usize, usize) {
 
 /// Check if an expression has side effects.
 /// Matches `has_side_effects` in events.js.
-fn expression_has_side_effects(expr: &crate::ast::js::Expression) -> bool {
+pub(super) fn expression_has_side_effects(expr: &crate::ast::js::Expression) -> bool {
     match expr.node_type() {
         Some("CallExpression" | "NewExpression" | "AssignmentExpression" | "UpdateExpression") => {
             true
@@ -488,7 +488,7 @@ fn json_has_side_effects(value: &serde_json::Value) -> bool {
 
 /// Check if expression is a call with no arguments to an identifier (for remove_parens).
 /// Matches the `remove_parens` check in events.js.
-fn expression_is_removable_call(
+pub(super) fn expression_is_removable_call(
     expr: &crate::ast::js::Expression,
     arena: &crate::ast::arena::ParseArena,
 ) -> bool {

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/events.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/events.rs
@@ -192,23 +192,21 @@ pub fn build_event_handler(
         //   if (!dev && binding?.declaration_kind !== 'import') return handler;
         //
         // i.e. attach the handler directly when (a) it's a function
-        // declaration / hoisted function, or (b) it's any locally-declared
-        // const/let/var binding (the value won't change between mounts), or
-        // (c) it isn't in scope at all (assume a global like `window.alert`
-        // or an untracked helper). Only imports get wrapped in
-        // `function (...$$args) { handler?.apply(this, $$args); }`, which
-        // copes with hot-reload swapping the imported binding.
+        // declaration / hoisted function, or (b) outside dev, any binding that
+        // is not an import — a locally-declared const/let/var whose value will
+        // not change between mounts, or a name that is not in scope at all
+        // (assume a global like `window.alert`). An import gets wrapped so it
+        // copes with hot-reload swapping the binding, and dev wraps everything
+        // else too so a throwing handler can still be reported.
         use crate::compiler::phases::phase2_analyze::scope::DeclarationKind;
-        match context.state.get_binding(name) {
-            Some(binding) if binding.is_function() => return handler,
-            None => return handler,
-            Some(binding) => {
-                let is_import = matches!(binding.declaration_kind, DeclarationKind::Import);
-                if !context.state.options.dev && !is_import {
-                    return handler;
-                }
-                // Falls through to the wrapping path below.
-            }
+        let binding = context.state.get_binding(name);
+        if binding.is_some_and(|b| b.is_function()) {
+            return handler;
+        }
+        if !context.state.options.dev
+            && binding.is_none_or(|b| b.declaration_kind != DeclarationKind::Import)
+        {
+            return handler;
         }
     }
 

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/events.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/events.rs
@@ -236,12 +236,51 @@ pub fn build_event_handler(
 
     // For complex expressions, wrap in a function that calls the expression
     // This handles cases like: onclick={obj.method} or onclick={expr()}
-    // handler?.apply(this, $$args) - use optional chaining for safety
-    let call_expr = b::call(
-        arena,
-        b::optional_member(arena, handler, "apply"),
-        vec![b::this(), b::id("$$args")],
-    );
+    let call_expr = if context.state.dev {
+        // Dev routes the call through `$.apply` so a handler that throws can be
+        // reported with the component and the source position of the attribute.
+        let (line, column) = match expression.start() {
+            Some(start) => super::super::attribute::locate_in_source(
+                &context.state.analysis.source,
+                start as usize,
+            ),
+            None => (0, 0),
+        };
+        let side_effects = super::super::attribute::expression_has_side_effects(expression);
+        let remove_parens = super::super::attribute::expression_is_removable_call(
+            expression,
+            context.state.parse_arena,
+        );
+
+        let mut apply_args = vec![
+            b::thunk(arena, handler),
+            b::this(),
+            b::id("$$args"),
+            b::id(&context.state.analysis.name),
+            b::array(vec![b::number(line as f64), b::number(column as f64)]),
+        ];
+        // The trailing flags are positional, so a set `remove_parens` forces the
+        // `has_side_effects` slot to be filled even when it is false.
+        if side_effects || remove_parens {
+            apply_args.push(if side_effects {
+                b::boolean(true)
+            } else {
+                b::undefined(arena)
+            });
+        }
+        if remove_parens {
+            apply_args.push(b::boolean(true));
+        }
+
+        b::call(arena, b::member_path(arena, "$.apply"), apply_args)
+    } else {
+        // handler?.apply(this, $$args) - use optional chaining for safety
+        b::call(
+            arena,
+            b::optional_member(arena, handler, "apply"),
+            vec![b::this(), b::id("$$args")],
+        )
+    };
 
     b::function_expr(
         None,

--- a/crates/rsvelte_core/tests/legacy_on_directive_apply_2029.rs
+++ b/crates/rsvelte_core/tests/legacy_on_directive_apply_2029.rs
@@ -1,0 +1,89 @@
+//! Regression tests for issue #2029 — the dev `$.apply` event-handler wrapper
+//! was emitted for `onclick={…}` but not for the legacy `on:click={…}` form.
+//!
+//! Upstream builds both through one `build_event_handler`, so the two paths must
+//! agree: a handler that is an inline function or a plain function declaration is
+//! passed straight through, and anything else is wrapped — in dev via `$.apply`,
+//! otherwise via `handler?.apply(this, $$args)`.
+
+use rsvelte_core::{CompileOptions, GenerateMode, compile, compiler::CssMode};
+
+fn compile_client(src: &str, dev: bool) -> String {
+    compile(
+        src,
+        CompileOptions {
+            filename: Some("Comp.svelte".to_string()),
+            generate: GenerateMode::Client,
+            dev,
+            css: CssMode::External,
+            ..Default::default()
+        },
+    )
+    .expect("compile")
+    .js
+    .code
+}
+
+#[test]
+fn legacy_member_handler_uses_apply_in_dev() {
+    let src =
+        "<script>export let selfControl;</script><button on:click={selfControl.toggle}>go</button>";
+    let out = compile_client(src, true);
+    assert!(
+        out.contains("$.apply(() => selfControl().toggle, this, $$args, Comp, [1, 58])"),
+        "in:\n{out}"
+    );
+}
+
+#[test]
+fn legacy_imported_handler_uses_apply_in_dev() {
+    let src = "<script>import { f } from './h.js';</script><button on:click={f}>go</button>";
+    let out = compile_client(src, true);
+    assert!(
+        out.contains("$.apply(() => f, this, $$args, Comp,"),
+        "in:\n{out}"
+    );
+}
+
+/// A call handler is memoized first, and carries the two trailing flags:
+/// `has_side_effects` (it is a call) and `remove_parens` (zero-arg identifier callee).
+#[test]
+fn legacy_call_handler_carries_the_trailing_flags() {
+    let src = "<script>export let cb;</script><button on:click={cb()}>go</button>";
+    let out = compile_client(src, true);
+    assert!(
+        out.contains("$.apply(() => $.get(event_handler), this, $$args, Comp,"),
+        "in:\n{out}"
+    );
+    assert!(
+        out.contains("], true, true)"),
+        "missing trailing flags in:\n{out}"
+    );
+}
+
+#[test]
+fn production_keeps_the_optional_apply_form() {
+    let src =
+        "<script>export let selfControl;</script><button on:click={selfControl.toggle}>go</button>";
+    let out = compile_client(src, false);
+    assert!(
+        out.contains("selfControl().toggle?.apply(this, $$args)"),
+        "in:\n{out}"
+    );
+    assert!(
+        !out.contains("$.apply("),
+        "dev wrapper leaked into production:\n{out}"
+    );
+}
+
+/// Handlers upstream passes straight through must not gain a wrapper.
+#[test]
+fn inline_and_declared_handlers_are_not_wrapped() {
+    for src in [
+        "<script>let n = 0;</script><button on:click={() => n++}>go</button>",
+        "<script>function f() {}</script><button on:click={f}>go</button>",
+    ] {
+        let out = compile_client(src, true);
+        assert!(!out.contains("$.apply("), "handler was wrapped in:\n{out}");
+    }
+}

--- a/crates/rsvelte_core/tests/legacy_on_directive_apply_2029.rs
+++ b/crates/rsvelte_core/tests/legacy_on_directive_apply_2029.rs
@@ -87,3 +87,18 @@ fn inline_and_declared_handlers_are_not_wrapped() {
         assert!(!out.contains("$.apply("), "handler was wrapped in:\n{out}");
     }
 }
+
+/// An identifier that resolves to no binding is a global. Outside dev it is used
+/// as-is, but dev still wraps it — upstream only short-circuits on `!dev`, so the
+/// unbound case must not return early on its own.
+#[test]
+fn unbound_global_handler_is_wrapped_in_dev_only() {
+    let src = "<button on:click={someGlobal}>go</button>";
+    let dev = compile_client(src, true);
+    assert!(
+        dev.contains("$.apply(() => someGlobal, this, $$args, Comp, [1, 18])"),
+        "in:\n{dev}"
+    );
+    let prod = compile_client(src, false);
+    assert!(!prod.contains("$.apply("), "in:\n{prod}");
+}


### PR DESCRIPTION
## Summary

In dev, upstream wraps a non-inline event handler so a handler that throws can be reported with its component and source position:

```js
$.apply(() => selfControl().toggle, this, $$args, Comp, [1, 58]);
```

rsvelte already did this for the modern `onclick={…}` form. The legacy `on:click={…}` form went through a different builder that only had the production shape, so those handlers lost the report:

```js
selfControl().toggle?.apply(this, $$args);   // rsvelte, before
```

## What was actually wrong

The issue describes `$.apply` as unimplemented. It is not — `visitors/attribute.rs` has a faithful port, and **all 12 handler shapes × dev on/off already matched** (inline arrow, inline function expression, function declaration, local `let`, import, member, zero-arg call, call with args, conditional, prop, non-delegated event, assignment).

The gap is that `visitors/shared/events.rs`, which serves the legacy `on:` directive, ends at the production `handler?.apply(this, $$args)`. Upstream builds both forms through one `build_event_handler`, so the two paths have to agree. This adds the dev branch there.

Two details carried over from upstream (`visitors/shared/events.js:137-157`):

- the position is that of the handler expression, not the attribute
- the trailing `has_side_effects` / `remove_parens` flags are **positional**, so a set `remove_parens` has to fill the `has_side_effects` slot even when that is false — visible in `on:click={cb()}`, which emits `…, [1, 49], true, true)`

`expression_has_side_effects` / `expression_is_removable_call` in `attribute.rs` are reused rather than duplicated; they only needed to become `pub(super)`.

## Verification

- 5 legacy `on:` shapes compiled with both compilers and compared: member, zero-arg call (memoized, both flags), reactive local, import, plus the modern form as a control — **all match**.
- The 12-shape × dev on/off survey still passes, so the modern path is unchanged: **24/24**.
- New suite `crates/rsvelte_core/tests/legacy_on_directive_apply_2029.rs` — 5 tests, including the trailing-flags case, a production-form guard, and a guard that inline / declared handlers stay unwrapped.
- `cargo test --release -p rsvelte_core` — **152 binaries, 2122 tests, 0 failures**.
- `cargo fmt`, `cargo clippy` (changed files warning-free).
- **Full output-equality corpus**: 14,005 entries × 3 targets — `✅ no regressions`. Measured before and after on the same branch, the change takes client-dev from **1084 → 1002**, i.e. **82 entries**, matching the 80 `$.apply` first-line divergences the report showed going in.

No ratchet changes — the baseline shrink is being done in one pass after the cluster PRs land.

Fixes #2029

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FKkTpzZGaGWWzJvw4BnHJs