### PR TITLE
fix(svelte2tsx): move a default-slot let: element's leading gap ahead of its prologue

### DIFF
--- a/.changeset/default-slot-let-gap-space.md
+++ b/.changeset/default-slot-let-gap-space.md
@@ -1,0 +1,16 @@
+---
+"@rsvelte/compiler": patch
+"@rsvelte/svelte2tsx": patch
+"@rsvelte/svelte-check": patch
+---
+
+fix(svelte2tsx): move a default-slot `let:` element's leading gap space ahead
+of its `$$slot_def.default` destructure. Upstream's `Element.
+performTransformation` runs the destructure through the SAME `transform()`
+call as the element's own opening-tag rewrite, so the element's leading gap
+lands before the destructure instead of before the element itself. rsvelte
+inserted the destructure with no leading space and left the gap on the
+element, so `<Foo><div let:x>{x}</div></Foo>` produced
+`;{const {…,x,} = …$$slot_def.default;$$_$$; { svelteHTML.createElement(…`
+(extra space before the element) instead of upstream's
+`; {const {…,x,} = …$$slot_def.default;$$_$$;{ svelteHTML.createElement(…`.

--- a/crates/rsvelte_projection/src/svelte2tsx/template/ctx.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/template/ctx.rs
@@ -103,6 +103,17 @@ pub(super) struct Counter {
     /// so `handle_component` must NOT re-emit them as the component's own
     /// default-slot let block. Consumed once at the top of `handle_component`.
     pub(super) suppress_component_lets: bool,
+    /// Set just before `process_component_children_with_slots` processes a
+    /// default-slot child that carries its OWN `let:` directives (`<div
+    /// let:x>` / `<svelte:fragment let:x>`): official's `Element.
+    /// performTransformation` emits the `$$slot_def.default` destructure as
+    /// part of the SAME `transform()` call as the element's own opening-tag
+    /// rewrite, so the element's leading gap is folded into that destructure's
+    /// block-open rather than the element's own indent. The element/fragment
+    /// handler must therefore force its own computed `before_block` to 0.
+    /// Consumed once at the top of `handle_regular_element` /
+    /// `handle_svelte_special_element`.
+    pub(super) suppress_default_slot_let_indent: bool,
 }
 
 impl Counter {
@@ -113,6 +124,7 @@ impl Counter {
             slot_inst: None,
             named_slot_component_close: false,
             suppress_component_lets: false,
+            suppress_default_slot_let_indent: false,
         }
     }
     pub(super) fn next_slot(&mut self) -> u32 {

--- a/crates/rsvelte_projection/src/svelte2tsx/template/nodes/component_slots.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/template/nodes/component_slots.rs
@@ -358,7 +358,19 @@ pub(crate) fn process_component_children_with_slots(
                     "{{const {{/*\u{03A9}ignore_start\u{03A9}*/$$_$$/*\u{03A9}ignore_end\u{03A9}*/,{}}} = {}.$$slot_def.default;$$_$$;",
                     destructure, inst_var
                 );
-                str.append_left(node.start(), &block);
+                // Official's `Element.performTransformation` runs the slot-let
+                // destructure through the SAME `transform()` call as the
+                // element/fragment's own opening-tag rewrite, so the leading gap
+                // ahead of `<div`/`<svelte:fragment` is folded into this
+                // block-open instead of the wrapped node's own indent. Compute
+                // that gap here (mirroring the wrapped node's own opener_spacing
+                // call) and tell the handler to suppress it.
+                let before_block = default_slot_let_before_block(node, source, counter);
+                str.append_left_fmt(
+                    node.start(),
+                    format_args!("{}{}", " ".repeat(before_block), block),
+                );
+                counter.suppress_default_slot_let_indent = true;
                 true
             } else {
                 false
@@ -393,6 +405,58 @@ pub(crate) fn process_component_children_with_slots(
         }
     }
     false
+}
+
+/// The leading gap `handle_regular_element` / `handle_svelte_special_element`
+/// would themselves attribute to the wrapped node's own indent, replayed here
+/// so it can be moved ahead of the default-slot-let block-open instead (see
+/// the call site in `process_component_children_with_slots`). Only
+/// `RegularElement` and `SvelteFragment` reach here — the two node kinds
+/// `has_let_directives` is checked against above.
+fn default_slot_let_before_block(node: &TemplateNode, source: &str, counter: &Counter) -> usize {
+    match node {
+        TemplateNode::RegularElement(el) => {
+            let opening_tag_end =
+                find_opening_tag_end(source, el.start, el.end, el.name.as_str(), &el.attributes);
+            opener_spacing(
+                source,
+                el.start,
+                &el.name,
+                opening_tag_end,
+                Some((el.start + 1, el.start + 1 + el.name.len() as u32)),
+                &el.attributes,
+                &counter.element_opener_comments,
+                OpenerCtx {
+                    is_element: true,
+                    in_component_slot: true,
+                    tag_name: &el.name,
+                    is_slot_tag: false,
+                },
+            )
+            .before_block
+        }
+        TemplateNode::SvelteFragment(el) => {
+            let opening_tag_end =
+                find_opening_tag_end(source, el.start, el.end, el.name.as_str(), &el.attributes);
+            opener_spacing(
+                source,
+                el.start,
+                &el.name,
+                opening_tag_end,
+                None,
+                &el.attributes,
+                &counter.element_opener_comments,
+                OpenerCtx {
+                    is_element: true,
+                    in_component_slot: true,
+                    tag_name: &el.name,
+                    is_slot_tag: false,
+                },
+            )
+            .before_block
+        }
+        _ => 0,
+    }
 }
 
 /// Handle a regular element child with `slot="name"` attribute inside a component.

--- a/crates/rsvelte_projection/src/svelte2tsx/template/nodes/element.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/template/nodes/element.rs
@@ -117,7 +117,7 @@ pub(crate) fn handle_regular_element(
         Some(opener_content_start),
     );
 
-    let spacing = opener_spacing(
+    let mut spacing = opener_spacing(
         source,
         el.start,
         &el.name,
@@ -132,6 +132,13 @@ pub(crate) fn handle_regular_element(
             is_slot_tag: false,
         },
     );
+    // A default-slot-let element (`<div let:x>`) has its leading gap folded
+    // into the `$$slot_def.default` destructure emitted by
+    // `process_component_children_with_slots` instead — see
+    // `suppress_default_slot_let_indent`'s doc comment.
+    if std::mem::take(&mut counter.suppress_default_slot_let_indent) {
+        spacing.before_block = 0;
+    }
     if spacing.in_attr_object > 0 {
         let mut padded: Vec<Seg> = Vec::with_capacity(attr_segs.len() + 1);
         padded.push(Seg::Lit(" ".repeat(spacing.in_attr_object)));

--- a/crates/rsvelte_projection/src/svelte2tsx/template/nodes/special_element.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/template/nodes/special_element.rs
@@ -55,7 +55,7 @@ pub(crate) fn handle_svelte_special_element(
 
     // The special `svelte:…` elements name themselves with a literal in the start
     // transformation, so it contributes no source range.
-    let spacing = opener_spacing(
+    let mut spacing = opener_spacing(
         source,
         el.start,
         &el.name,
@@ -70,6 +70,13 @@ pub(crate) fn handle_svelte_special_element(
             is_slot_tag: false,
         },
     );
+    // A default-slot-let `<svelte:fragment let:x>` has its leading gap folded
+    // into the `$$slot_def.default` destructure emitted by
+    // `process_component_children_with_slots` instead — see
+    // `suppress_default_slot_let_indent`'s doc comment.
+    if std::mem::take(&mut counter.suppress_default_slot_let_indent) {
+        spacing.before_block = 0;
+    }
     if spacing.in_attr_object > 0 {
         let mut padded = " ".repeat(spacing.in_attr_object);
         padded.push_str(&attrs_str);

--- a/crates/rsvelte_projection/tests/svelte2tsx_entry.rs
+++ b/crates/rsvelte_projection/tests/svelte2tsx_entry.rs
@@ -815,3 +815,51 @@ fn test_async_only_in_inner_function_is_not_top_level() {
         "await inside inner async function must NOT emit $$$render; got:\n{code}"
     );
 }
+
+/// A default-slot child that carries its OWN `let:` directives (`<div
+/// let:x>`, `<svelte:fragment let:x>`) has its `$$slot_def.default`
+/// destructure emitted through the SAME `transform()` call as its own
+/// opening-tag rewrite in the official `Element.performTransformation` — so
+/// the element's leading gap is folded into that destructure's block-open
+/// instead of the element's own indent. Every expectation below is the
+/// byte-exact output of the official svelte2tsx (issue #2049).
+#[test]
+fn default_slot_let_forwarding_matches_the_official_gap_collapsing() {
+    for (source, expected) in [
+        (
+            "<Foo><div let:x>{x}</div></Foo>",
+            "}}); {const {/*\u{03A9}ignore_start\u{03A9}*/$$_$$/*\u{03A9}ignore_end\u{03A9}*/,x,} = $$_ooF0.$$slot_def.default;$$_$$;{ svelteHTML.createElement(\"div\", { });x; }} Foo}",
+        ),
+        (
+            "<Foo><div let:x /></Foo>",
+            "}});  {const {/*\u{03A9}ignore_start\u{03A9}*/$$_$$/*\u{03A9}ignore_end\u{03A9}*/,x,} = $$_ooF0.$$slot_def.default;$$_$$;{ svelteHTML.createElement(\"div\", { });}} Foo}",
+        ),
+        (
+            "<Foo><span let:x>{x}</span></Foo>",
+            "}}); {const {/*\u{03A9}ignore_start\u{03A9}*/$$_$$/*\u{03A9}ignore_end\u{03A9}*/,x,} = $$_ooF0.$$slot_def.default;$$_$$;{ svelteHTML.createElement(\"span\", { });x; }} Foo}",
+        ),
+        (
+            "<Foo let:y><div let:x>{x}</div></Foo>",
+            "}});{const {/*\u{03A9}ignore_start\u{03A9}*/$$_$$/*\u{03A9}ignore_end\u{03A9}*/,y,} = $$_ooF0.$$slot_def.default;$$_$$; {const {/*\u{03A9}ignore_start\u{03A9}*/$$_$$/*\u{03A9}ignore_end\u{03A9}*/,x,} = $$_ooF0.$$slot_def.default;$$_$$;{ svelteHTML.createElement(\"div\", { });x; }} }Foo}",
+        ),
+        (
+            "<Foo><svelte:fragment let:x>{x}</svelte:fragment></Foo>",
+            "}}); {const {/*\u{03A9}ignore_start\u{03A9}*/$$_$$/*\u{03A9}ignore_end\u{03A9}*/,x,} = $$_ooF0.$$slot_def.default;$$_$$;{ svelteHTML.createElement(\"svelte:fragment\", { });x; }} Foo}",
+        ),
+        (
+            "<Foo><div let:a let:b>{a}{b}</div></Foo>",
+            "}}); {const {/*\u{03A9}ignore_start\u{03A9}*/$$_$$/*\u{03A9}ignore_end\u{03A9}*/,a,b,} = $$_ooF0.$$slot_def.default;$$_$$;{ svelteHTML.createElement(\"div\", {  });a;b; }} Foo}",
+        ),
+        (
+            "<Foo><Bar><div let:x>{x}</div></Bar></Foo>",
+            "props: {children:() => { return __sveltets_2_any(0); },}}); {const {/*\u{03A9}ignore_start\u{03A9}*/$$_$$/*\u{03A9}ignore_end\u{03A9}*/,x,} = $$_raB1.$$slot_def.default;$$_$$;{ svelteHTML.createElement(\"div\", { });x; }} Bar} Foo}",
+        ),
+    ] {
+        let result = svelte2tsx(source, Svelte2TsxOptions::default()).unwrap();
+        assert!(
+            result.code.contains(expected),
+            "{source:?}\n  expected to contain {expected:?}\n  got:\n{}",
+            result.code
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #2049 — when an element in a component's default slot carries `let:`, its leading gap space was emitted after the `$$slot_def.default` destructuring prologue, while official svelte2tsx emits it before (the prologue is issued inside the same `transform()` as the element's own open tag, so the gap collapses ahead of it).

The `fragment_lets` branch in `component_slots.rs` now computes the target node's `opener_spacing().before_block` up front, prefixes it to the block string, and sets a one-shot `suppress_default_slot_let_indent` flag (same pattern as `suppress_component_lets`) that `element.rs` / `special_element.rs` consume to zero their own indent. The issue's suspicion about the reopen branch turned out wrong — it is unreachable dead code (measured + control-flow verified), left untouched and filed in #2105.

## Verification

- Byte-compared against official svelte2tsx: 8 shapes by the implementer, 25 by an independent reviewer (deep nesting to 3 levels, `svelte:fragment`, consecutive let-siblings, text/comment prefixes, tabs, spreads). Real-file sweep over all 308 `let:`-bearing `.svelte` files in submodules: official-parity 175 → 188, 0 regressions.
- svelte2tsx corpus gate: all outputs identical, all maps well-formed (gap moved between insertion sides of the same position, so columns are unchanged).
- `cargo test -p rsvelte_projection` green (new table-driven parity test); `cargo +1.97 clippy -- -D warnings` / `fmt --check` clean.
- Pre-existing gaps found nearby are filed: #2103 (`svelte:component` children bypass forwarding), #2105 (unreachable reopen branch, `svelte:element`/`slot`/`{#each}` forwarding, `<style let:x>` orphan block + flag leak).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SfqweP3NTX8WEWvaQmerDZ