### PR TITLE
fix(compiler): give `<svelte:self>` its real position in $.add_svelte_meta (#2039)

### DIFF
--- a/.changeset/fix-svelte-self-meta-position.md
+++ b/.changeset/fix-svelte-self-meta-position.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/compiler": patch
+---
+
+fix(compiler): give `<svelte:self>` its real source position in the dev `$.add_svelte_meta` call instead of a `1, 0` placeholder

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/component.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/component.rs
@@ -3095,7 +3095,7 @@ fn build_component_meta_stmt(
     let (start, tag_name) = match node {
         ComponentNode::Component(comp) => (comp.start, comp.name.to_string()),
         ComponentNode::SvelteComponent(comp) => (comp.start, "svelte:component".to_string()),
-        ComponentNode::SvelteSelf(_) => (0, "svelte:self".to_string()),
+        ComponentNode::SvelteSelf(comp) => (comp.start, "svelte:self".to_string()),
     };
 
     let (line, col) = super::super::attribute::locate_in_source(source, start as usize);

--- a/crates/rsvelte_core/tests/svelte_self_meta_position_2039.rs
+++ b/crates/rsvelte_core/tests/svelte_self_meta_position_2039.rs
@@ -1,0 +1,51 @@
+//! Regression test for issue #2039 — the dev `$.add_svelte_meta` call around a
+//! `<svelte:self>` instantiation carried `1, 0` instead of the element's real
+//! position, because the `SvelteSelf` arm discarded the node's start offset.
+
+use rsvelte_core::{CompileOptions, GenerateMode, compile, compiler::CssMode};
+
+fn compile_dev(src: &str) -> String {
+    compile(
+        src,
+        CompileOptions {
+            filename: Some("Comp.svelte".to_string()),
+            generate: GenerateMode::Client,
+            dev: true,
+            css: CssMode::External,
+            ..Default::default()
+        },
+    )
+    .expect("compile")
+    .js
+    .code
+}
+
+#[test]
+fn position_follows_the_element_on_its_own_line() {
+    let out = compile_dev("{#if depth > 1}\n\t<svelte:self depth={depth - 1}/>\n{/if}");
+    assert!(out.contains("'component', Comp, 2, 1,"), "in:\n{out}");
+    assert!(!out.contains("Comp, 1, 0,"), "placeholder position in:\n{out}");
+}
+
+#[test]
+fn position_follows_the_element_on_a_shared_line() {
+    let out = compile_dev("{#if depth > 1}<svelte:self depth={depth - 1}/>{/if}");
+    assert!(out.contains("'component', Comp, 1, 15,"), "in:\n{out}");
+}
+
+/// The tag name is still reported as `svelte:self`, not the component's name.
+#[test]
+fn the_component_tag_is_unchanged() {
+    let out = compile_dev("{#if x}\n\t<svelte:self />\n{/if}");
+    assert!(
+        out.contains("{ componentTag: 'svelte:self' }"),
+        "in:\n{out}"
+    );
+}
+
+/// An ordinary component was already correct — guard against regressing it.
+#[test]
+fn a_plain_component_keeps_its_position() {
+    let out = compile_dev("<script>import Input from './Input.svelte';</script>\n<Input />");
+    assert!(out.contains("'component', Comp, 2, 0,"), "in:\n{out}");
+}

--- a/crates/rsvelte_core/tests/svelte_self_meta_position_2039.rs
+++ b/crates/rsvelte_core/tests/svelte_self_meta_position_2039.rs
@@ -24,7 +24,10 @@ fn compile_dev(src: &str) -> String {
 fn position_follows_the_element_on_its_own_line() {
     let out = compile_dev("{#if depth > 1}\n\t<svelte:self depth={depth - 1}/>\n{/if}");
     assert!(out.contains("'component', Comp, 2, 1,"), "in:\n{out}");
-    assert!(!out.contains("Comp, 1, 0,"), "placeholder position in:\n{out}");
+    assert!(
+        !out.contains("Comp, 1, 0,"),
+        "placeholder position in:\n{out}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

In dev, a component instantiation is wrapped in `$.add_svelte_meta(fn, 'component', Comp, line, column, …)` so the dev overlay can attribute it. Every `<svelte:self>` reported `1, 0`:

```js
// {#if depth > 1}\n\t<svelte:self depth={depth - 1}/>\n{/if}
// official
$.add_svelte_meta(() => Comp(node_1, { depth: depth - 1 }), 'component', Comp, 2, 1, { componentTag: 'svelte:self' });
// rsvelte, before
$.add_svelte_meta(() => Comp(node_1, { depth: depth - 1 }), 'component', Comp, 1, 0, { componentTag: 'svelte:self' });
```

## Cause

`build_component_meta_stmt` reads each node's start offset to locate it, but the `SvelteSelf` arm passed a literal `0`:

```rust
ComponentNode::Component(comp) => (comp.start, comp.name.to_string()),
ComponentNode::SvelteComponent(comp) => (comp.start, "svelte:component".to_string()),
ComponentNode::SvelteSelf(_) => (0, "svelte:self".to_string()),   // ← discarded
```

`1, 0` was not an off-by-N, it was offset 0 — the first character of the file. `SvelteElement` carries `start` like the other component nodes, so the arm just has to use it. One line.

## On the issue's other failure shape

The issue lists two shapes. The first — a `{@render}` inside `{#if}` emitting no `$.add_svelte_meta` at all (`pattern/matrix/snippet-hoist/attach-component-scope-in-if.svelte`) — **is already fixed**, by #2057 (issue #2031, the block-local snippet render tag). The issue's own note that it was "likely the same underlying snippet-hoist gap" was right. Verified: that shape now matches.

So this PR closes what remains, and #2039 is complete.

## Verification

- The four repro files named in the issue, compiled with both compilers and compared on their `$.add_svelte_meta` lines — **all match**, including the `19, 1` case in `validator/samples/attribute-quoted` where a plain `Component` at `13, 0` was already correct and only the `<svelte:self>` was wrong.
- Six shapes isolated (own line, shared line, with/without attributes, with/without a `<script>`, plain component control) — all match. The one remaining difference in that set is the *wording* of the `svelte_self_invalid_placement` error for a top-level `<svelte:self>`, which is pre-existing and unrelated.
- New suite `crates/rsvelte_core/tests/svelte_self_meta_position_2039.rs` — 4 tests, including a guard that an ordinary component keeps its position and that the `componentTag` stays `svelte:self`.
- `cargo test --release -p rsvelte_core` — **153 binaries, 2131 tests, 0 failures**.
- `cargo fmt`, `cargo clippy` (changed file warning-free).
- **Full output-equality corpus**: 14,005 entries × 3 targets — `✅ no regressions`, client-dev **914 → 896**.

No ratchet changes — the baseline shrink is being done in one pass after the cluster PRs land.

Fixes #2039

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FKkTpzZGaGWWzJvw4BnHJs