### PR TITLE
fix(fmt): stop mistaking tab-indented formatted JS for raw attribute text

### DIFF
--- a/.changeset/tab-indent-multiline-attribute.md
+++ b/.changeset/tab-indent-multiline-attribute.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/fmt": patch
+---
+
+fix(fmt): re-indent multi-line attribute values correctly under `useTabs`. A multi-line attribute value (an arrow handler, a `bind:` getter/setter pair, an object literal) is formatted at column 0 and re-indented to the attribute column afterwards, but the re-indent treated every line starting with a tab as verbatim raw HTML text. That holds only while the embedded JS is space-indented — with `useTabs: true` the formatted JS is tab-indented too, so the value's continuation lines were left at column 0 and the closing `}}` lost the element's nesting depth entirely. The raw-text boundary is now the value's `{…}` brace depth instead of a leading tab, which also stops a tab-indented template literal from being mistaken for raw text.

--- a/crates/rsvelte_formatter/src/markup/render_tag.rs
+++ b/crates/rsvelte_formatter/src/markup/render_tag.rs
@@ -114,23 +114,28 @@ fn is_string_value_attr(a: &str) -> bool {
     }
 }
 
-/// Whether an interpolation-led string value (`name="{…}…"`) has newlines that
-/// are *all* literal HTML text (brace-depth 0, between interpolations) rather
-/// than a wrapped `{expr}` continuation — so it can be emitted verbatim to
-/// preserve source whitespace. False for no-newline values or any newline inside
-/// `{…}` (brace-depth > 0), which take the re-indent path.
-fn is_verbatim_interpolation_value(a: &str) -> bool {
-    let Some((_, value)) = a.split_once('=') else {
-        return false;
-    };
-    if !value.starts_with("\"{") {
-        return false;
-    }
+/// Where a rendered attribute's newlines sit relative to `{…}` brace depth.
+/// Inside braces a newline is a wrapped continuation of formatted JS; at depth 0
+/// it is literal HTML text between interpolations.
+struct ValueNewlines {
+    /// Byte offset (within the scanned value) of the first depth-0 newline whose
+    /// line carries a leading tab — see [`reindent_attr_with_raw_text`].
+    first_tabbed_at_depth0: Option<usize>,
+    any_at_depth0: bool,
+    any_inside_braces: bool,
+}
+
+fn scan_value_newlines(value: &str) -> ValueNewlines {
     let mut depth: i32 = 0;
     let mut quote: Option<u8> = None;
     let mut escaped = false;
-    let mut saw_newline_at_depth0 = false;
-    for &b in value.as_bytes() {
+    let mut out = ValueNewlines {
+        first_tabbed_at_depth0: None,
+        any_at_depth0: false,
+        any_inside_braces: false,
+    };
+    let bytes = value.as_bytes();
+    for (i, &b) in bytes.iter().enumerate() {
         match quote {
             // Inside a JS string literal: only its own *unescaped* closing
             // delimiter ends it; braces/newlines there are not structural.
@@ -147,36 +152,60 @@ fn is_verbatim_interpolation_value(a: &str) -> bool {
                 b'\'' | b'"' | b'`' if depth > 0 => quote = Some(b),
                 b'{' => depth += 1,
                 b'}' => depth -= 1,
-                // Inside `{…}` a newline is a wrapped continuation (re-indent);
-                // at depth 0 it is literal text (verbatim).
-                b'\n' if depth > 0 => return false,
-                b'\n' => saw_newline_at_depth0 = true,
+                b'\n' if depth > 0 => out.any_inside_braces = true,
+                b'\n' => {
+                    out.any_at_depth0 = true;
+                    if out.first_tabbed_at_depth0.is_none() && bytes.get(i + 1) == Some(&b'\t') {
+                        out.first_tabbed_at_depth0 = Some(i);
+                    }
+                }
                 _ => {}
             },
         }
     }
-    saw_newline_at_depth0
+    out
+}
+
+/// Splits a rendered attribute into its value part and that value's offset,
+/// so brace-depth offsets can be mapped back onto the whole attribute.
+fn attr_value(a: &str) -> (usize, &str) {
+    match a.split_once('=') {
+        Some((name, value)) => (name.len() + 1, value),
+        None => (0, a),
+    }
+}
+
+/// Whether an interpolation-led string value (`name="{…}…"`) has newlines that
+/// are *all* literal HTML text (brace-depth 0, between interpolations) rather
+/// than a wrapped `{expr}` continuation — so it can be emitted verbatim to
+/// preserve source whitespace. False for no-newline values or any newline inside
+/// `{…}` (brace-depth > 0), which take the re-indent path.
+fn is_verbatim_interpolation_value(a: &str) -> bool {
+    let (_, value) = attr_value(a);
+    if !value.starts_with("\"{") {
+        return false;
+    }
+    let scan = scan_value_newlines(value);
+    !scan.any_inside_braces && scan.any_at_depth0
 }
 
 /// Re-indent an expression-led attribute (`class="{expr}\nraw-text…"`).
 ///
-/// OXC always formats JS with spaces (never tabs). When an attribute starts with
-/// a JS expression (`"{`) but also has continuation lines that start with a tab
-/// (`\n\t`), those tab-indented lines are raw HTML attribute text — not formatted
-/// JS — and must be kept verbatim. Split the attribute at the first `\n\t` and
-/// re-indent only the expression part; append the raw text as-is.
-///
-/// Falls back to `reindent(a, prefix, true)` when no `\n\t` is found (pure JS
-/// attribute — the normal path).
+/// Raw HTML text the author wrote between interpolations keeps its original
+/// source indentation, so re-indenting it would double-count that indent. It is
+/// recognised by a tab-indented line sitting at brace depth 0: depth 0 is
+/// outside every `{…}`, and formatted JS is only ever tab-indented under
+/// `useTabs` — where it is also always inside braces. Requiring both signals
+/// keeps the tab-indented continuation lines of a multi-line attribute value out
+/// of the raw-text branch, which used to strand them at column 0 (#2058).
 fn reindent_attr_with_raw_text(a: &str, prefix: &str) -> String {
-    // Find the first occurrence of a newline followed by a tab — this marks the
-    // boundary between formatted JS and raw source text.
-    if let Some(split_pos) = a.find("\n\t") {
-        let js_part = &a[..split_pos];
-        let raw_part = &a[split_pos..]; // starts with "\n\t…"
-        let reindented_js = crate::reindent::reindent(js_part, prefix, true);
-        format!("{reindented_js}{raw_part}")
-    } else {
-        crate::reindent::reindent(a, prefix, true)
+    let (value_offset, value) = attr_value(a);
+    match scan_value_newlines(value).first_tabbed_at_depth0 {
+        Some(pos) => {
+            let split_pos = value_offset + pos;
+            let reindented_js = crate::reindent::reindent(&a[..split_pos], prefix, true);
+            format!("{reindented_js}{}", &a[split_pos..])
+        }
+        None => crate::reindent::reindent(a, prefix, true),
     }
 }

--- a/crates/rsvelte_formatter/tests/indent.rs
+++ b/crates/rsvelte_formatter/tests/indent.rs
@@ -1,4 +1,6 @@
-use rsvelte_formatter::{FormatOptions, IndentStyle, IndentWidth, JsFormatOptions, format};
+use rsvelte_formatter::{
+    FormatOptions, IndentStyle, IndentWidth, JsFormatOptions, LineWidth, format,
+};
 
 #[test]
 fn default_options_indent_with_two_spaces() {
@@ -118,4 +120,62 @@ fn block_body_inline_child_fit_uses_display_width() {
         !out.contains("/> {label}"),
         "expected the wide Icon to break away from the trailing text:\n{out}"
     );
+}
+
+// ─── #2058: multi-line attribute values under `useTabs` ──────────────────
+//
+// A multi-line attribute value is formatted at column 0 and re-indented to the
+// attribute column afterwards. That re-indent used to treat any line starting
+// with a tab as verbatim raw HTML text, which is true only while the embedded
+// JS is space-indented — under `useTabs` the formatted JS is tab-indented too,
+// so every continuation line was left at column 0. Expectations below are the
+// oxfmt(`svelte: true`) oracle's output for the user's config (#2058).
+
+fn tab_opts() -> FormatOptions {
+    FormatOptions {
+        js: JsFormatOptions {
+            indent_style: IndentStyle::Tab,
+            indent_width: IndentWidth::try_from(4).expect("4 is valid"),
+            line_width: LineWidth::try_from(100).expect("100 is valid"),
+            ..JsFormatOptions::new()
+        },
+        ..FormatOptions::default()
+    }
+}
+
+#[test]
+fn tab_indent_reindents_multiline_arrow_attribute() {
+    let src = "<div class=\"wrap\">\n\t<div class=\"panel\">\n\t\t<div class=\"inner\">\n\t\t\t<SvelteFlow\n\t\t\t\tfitView\n\t\t\t\tonmove={(_event, viewport) => {\n\t\t\t\t\tgraph.activeDocument.viewport = { ...viewport };\n\t\t\t\t}}\n\t\t\t/>\n\t\t</div>\n\t</div>\n</div>\n";
+    let out = format(src, &tab_opts()).expect("format ok");
+    assert_eq!(out, src);
+}
+
+#[test]
+fn tab_indent_reindents_multiline_bind_getter_setter() {
+    let src = "<div>\n\t<div>\n\t\t<Comp\n\t\t\tbind:value={\n\t\t\t\t() => internalValueForTheBinding,\n\t\t\t\t(v) => {\n\t\t\t\t\tinternalValueForTheBinding = v;\n\t\t\t\t}\n\t\t\t}\n\t\t/>\n\t</div>\n</div>\n";
+    let out = format(src, &tab_opts()).expect("format ok");
+    assert_eq!(out, src);
+}
+
+#[test]
+fn tab_indent_reindents_multiline_object_attribute() {
+    let src = "<div>\n\t<div>\n\t\t<div>\n\t\t\t<Chart\n\t\t\t\tconfig={{\n\t\t\t\t\tkind: \"line\",\n\t\t\t\t\tpadding: { top: 10, right: 20, bottom: 30, left: 40 },\n\t\t\t\t\tanimate: true,\n\t\t\t\t}}\n\t\t\t/>\n\t\t</div>\n\t</div>\n</div>\n";
+    let out = format(src, &tab_opts()).expect("format ok");
+    assert_eq!(out, src);
+}
+
+#[test]
+fn tab_indent_reindents_multiline_arrow_beside_long_string_attribute() {
+    let src = "<div>\n\t<div>\n\t\t<button\n\t\t\tclass=\"a very long list of utility classes that will definitely not fit on one line at all\"\n\t\t\tonclick={async () => {\n\t\t\t\tawait save();\n\t\t\t\ttoast.show(\"saved\");\n\t\t\t}}\n\t\t>\n\t\t\tSave\n\t\t</button>\n\t</div>\n</div>\n";
+    let out = format(src, &tab_opts()).expect("format ok");
+    assert_eq!(out, src);
+}
+
+/// The interior of a template literal is program text, not indentation: it must
+/// survive the re-indent verbatim even though its lines start with tabs.
+#[test]
+fn tab_indent_keeps_template_literal_interior_verbatim() {
+    let src = "<div>\n\t<div>\n\t\t<Comp\n\t\t\ttemplate={`\n\tfirst line of the template literal\n\tsecond line of the template literal\n`}\n\t\t/>\n\t</div>\n</div>\n";
+    let out = format(src, &tab_opts()).expect("format ok");
+    assert_eq!(out, src);
 }


### PR DESCRIPTION
## Summary

Fixes #2058 (user report) — with `useTabs: true`, multi-line arrow bodies (and `bind:` getter/setters, object literals) inside attribute values collapsed to column 0 and their closing `}}` lost the element's nesting depth.

`reindent_attr_with_raw_text` treated any tab-led line as raw HTML text (splitting at the first `\n\t` and emitting the rest verbatim). That assumption only holds while embedded JS is space-indented; under `useTabs` the formatted JS is tab-indented too, so the split fired on the value's own first continuation line. The raw-text test is now narrowed to **brace-depth 0 AND tab-led** — depth 0 is outside any `{…}`, which is the only place genuine raw text can live, while formatted JS is always inside braces. Trigger is `useTabs` alone (tabWidth / printWidth / nesting depth irrelevant — measured matrix).

## Verification

- User's shape (deep nesting + `onmove` arrow, tabWidth 4 / printWidth 100) now byte-matches the oxfmt 0.61.0 oracle; parent commit reproduces the reported column-0 collapse.
- svelte.dev 553-component sweep at `useTabs:true, 4, 100`: 78 → 27 diffs; the 27 residuals are a separate class (tab visual width counted as 1 column, ~60 `str::width()` sites) filed as #2119 with its guard-gap note. Spaces mode is byte-invariant (1 known diff unchanged).
- Fmt parity corpus: 13446 entries, failed 20, zero regressions (reviewer re-generated actuals and diffed the id sets — identical). svelte.dev hard gates both green (run for real).
- 5 new oracle-derived regression tests (`tests/indent.rs`), 4 of which fail before the fix; reviewer independently probed counter-example shapes (template-literal tabs, orphan `}` in raw text, real multi-line string attributes) — all byte-match the oracle.
- `cargo test -p rsvelte_formatter --release` / `-p rsvelte_fmt --release` green; `cargo +1.97 clippy -- -D warnings` / `fmt --check` clean.
- Pre-existing single-split limitation (second multi-line expression after raw text stays verbatim) filed as #2120.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SfqweP3NTX8WEWvaQmerDZ