### PR TITLE
fix(compiler): reject `with` statements in component scripts

### DIFF
--- a/crates/rsvelte_core/src/compiler/phases/1_parse/read/expression.rs
+++ b/crates/rsvelte_core/src/compiler/phases/1_parse/read/expression.rs
@@ -6718,29 +6718,75 @@ fn convert_parsed_program<'ast>(
             )
         });
 
-        // OXC accepts Stage-3 `@decorator` syntax even in plain JS; upstream's
-        // acorn (no decorator plugin) raises js_parse_error at the `@` token.
-        // A bare `@` is never legal JS outside decorators, so flag the first
-        // decorator's position. Gated on a cheap byte scan first.
-        if parse_error.is_none() && !is_typescript && content.contains('@') {
+        // OXC has no strict-mode syntax-restriction pass at all, unlike acorn,
+        // which applies one uniformly because every script is parsed with
+        // `sourceType: 'module'` (component scripts are ESM and therefore
+        // always strict — see acorn.js's shared `parse`/`parse_expression_at`/
+        // `parse_statement_at`). Scan for constructs OXC accepts but acorn
+        // would reject, and report whichever occurs first in the source:
+        // acorn is a single-pass, non-recovering parser, so it throws on the
+        // first one it reaches and never sees any that would follow.
+        //
+        // - `@decorator` (Stage-3 syntax OXC accepts even in plain JS; a bare
+        //   `@` is never legal JS outside decorators). TS scripts legitimately
+        //   support decorators, so this one is JS-only.
+        // - `with (...) { ... }` (always a strict-mode violation; TS scripts
+        //   are strict too, so this applies regardless of `is_typescript`).
+        if parse_error.is_none() {
             use oxc_ast_visit::Visit;
-            struct FindDecorator(Option<u32>);
-            impl<'a> Visit<'a> for FindDecorator {
+            struct StrictModeScan {
+                check_decorator: bool,
+                decorator_at: Option<u32>,
+                with_at: Option<u32>,
+            }
+            impl<'a> Visit<'a> for StrictModeScan {
                 fn visit_decorator(&mut self, dec: &oxc_ast::ast::Decorator<'a>) {
-                    if self.0.is_none() {
-                        self.0 = Some(dec.span.start);
+                    if self.check_decorator && self.decorator_at.is_none() {
+                        self.decorator_at = Some(dec.span.start);
                     }
                 }
+                fn visit_with_statement(&mut self, stmt: &oxc_ast::ast::WithStatement<'a>) {
+                    if self.with_at.is_none() {
+                        self.with_at = Some(stmt.span.start);
+                    }
+                    oxc_ast_visit::walk::walk_with_statement(self, stmt);
+                }
             }
-            let mut finder = FindDecorator(None);
-            finder.visit_program(program);
-            if let Some(at) = finder.0 {
-                let pos = at as usize + offset;
-                parse_error = Some(crate::error::ParseError::svelte(
-                    "js_parse_error",
-                    "Unexpected character '@'".to_string(),
-                    (pos, pos),
-                ));
+
+            let check_decorator = !is_typescript && content.contains('@');
+            let check_with = content.contains("with");
+            if check_decorator || check_with {
+                let mut finder = StrictModeScan {
+                    check_decorator,
+                    decorator_at: None,
+                    with_at: None,
+                };
+                finder.visit_program(program);
+
+                let earliest = [
+                    finder
+                        .decorator_at
+                        .map(|at| (at, "Unexpected character '@'".to_string())),
+                    finder.with_at.map(|at| {
+                        (
+                            at,
+                            "'with' in strict mode\nhttps://svelte.dev/e/js_parse_error"
+                                .to_string(),
+                        )
+                    }),
+                ]
+                .into_iter()
+                .flatten()
+                .min_by_key(|(at, _)| *at);
+
+                if let Some((at, message)) = earliest {
+                    let pos = at as usize + offset;
+                    parse_error = Some(crate::error::ParseError::svelte(
+                        "js_parse_error",
+                        message,
+                        (pos, pos),
+                    ));
+                }
             }
         }
 

--- a/crates/rsvelte_core/tests/ts_erasure_visitor_coverage.rs
+++ b/crates/rsvelte_core/tests/ts_erasure_visitor_coverage.rs
@@ -179,14 +179,43 @@ fn namespace_export_declaration_is_left_alone() {
     assert_left_alone("export as namespace Foo;");
 }
 
-/// The official compiler rejects `with` outright (module code is strict), so
-/// there is no upstream output to match here — this only pins that the body is
-/// reached by the walk rather than passed through verbatim.
+/// The official compiler rejects `with` outright: component scripts are ESM
+/// and therefore always strict, and acorn's `sourceType: 'module'` parse
+/// throws `js_parse_error('with' in strict mode)` at the `with` keyword
+/// before TS erasure ever runs (see issue #2054). There is no erased-output
+/// shape to pin here — this asserts the same code/message/span as upstream
+/// instead.
 #[test]
 fn with_statement_body() {
-    assert_erased(
-        "const o = { x: 1 };\n\tconst y: any = 2;\n\tlet x;\n\twith (o) { x = y as any; }\n\tconsole.log(x);",
-        &["x = y"],
-        &["as any"],
+    let body = "const o = { x: 1 };\n\tconst y: any = 2;\n\tlet x;\n\twith (o) { x = y as any; }\n\tconsole.log(x);";
+    let src = format!("<script lang=\"ts\">\n\t{body}\n</script>\n\n<p>ok</p>\n");
+    let with_pos = src.find("with (o)").expect("`with` keyword in source");
+
+    let err = compile(
+        &src,
+        CompileOptions {
+            filename: Some("Erasure.svelte".to_string()),
+            generate: GenerateMode::Client,
+            dev: false,
+            css: CssMode::External,
+            ..Default::default()
+        },
+    )
+    .expect_err("`with` must be rejected, matching the official compiler");
+
+    let rsvelte_core::compiler::CompileError::Parse(rsvelte_core::error::ParseError::SvelteError {
+        code,
+        message,
+        span,
+    }) = err
+    else {
+        panic!("expected a SvelteError, got: {err:?}");
+    };
+
+    assert_eq!(code, "js_parse_error");
+    assert_eq!(
+        message,
+        "'with' in strict mode\nhttps://svelte.dev/e/js_parse_error"
     );
+    assert_eq!(span, (with_pos, with_pos));
 }

--- a/crates/rsvelte_core/tests/with_statement_strict_mode.rs
+++ b/crates/rsvelte_core/tests/with_statement_strict_mode.rs
@@ -1,0 +1,125 @@
+//! Regression test for issue #2054: a `with` statement anywhere in script
+//! content must be rejected exactly like the official compiler rejects it.
+//!
+//! Component scripts (and `.svelte.js`/`.svelte.ts` modules) are ESM and
+//! therefore always strict, so upstream acorn — parsed with
+//! `sourceType: 'module'` — throws `js_parse_error('with' in strict mode)`
+//! at the `with` keyword before Svelte's own analysis ever runs (see
+//! `submodules/svelte/packages/svelte/src/compiler/phases/1-parse/acorn.js`).
+//! `oxc_parser` has no strict-mode syntax-restriction pass at all, so rsvelte
+//! used to accept `with` silently; the fix scans the parsed AST for the first
+//! `WithStatement` and synthesizes the same `js_parse_error`.
+
+use rsvelte_core::{
+    CompileOptions, GenerateMode, ModuleCompileOptions, compile, compile_module,
+    compiler::{CompileError, CssMode},
+    error::ParseError,
+};
+
+#[track_caller]
+fn assert_with_rejected(src: &str) {
+    let with_pos = src.find("with").expect("`with` keyword in source");
+    let err = compile(
+        src,
+        CompileOptions {
+            filename: Some("Test.svelte".to_string()),
+            generate: GenerateMode::Client,
+            dev: false,
+            css: CssMode::External,
+            runes: Some(true),
+            ..Default::default()
+        },
+    )
+    .err()
+    .unwrap_or_else(|| panic!("expected a `with` parse error for {src:?}, but it compiled"));
+
+    let CompileError::Parse(ParseError::SvelteError {
+        code,
+        message,
+        span,
+    }) = err
+    else {
+        panic!("expected a SvelteError for {src:?}, got: {err:?}");
+    };
+
+    assert_eq!(code, "js_parse_error", "for {src:?}");
+    assert_eq!(
+        message, "'with' in strict mode\nhttps://svelte.dev/e/js_parse_error",
+        "for {src:?}"
+    );
+    assert_eq!(span, (with_pos, with_pos), "for {src:?}");
+}
+
+#[test]
+fn with_statement_in_instance_script_is_rejected() {
+    assert_with_rejected("<script>\n  with (x) {}\n</script>");
+}
+
+#[test]
+fn with_statement_in_module_script_is_rejected() {
+    assert_with_rejected("<script module>\n  with (x) {}\n</script>");
+}
+
+#[test]
+fn with_statement_in_typescript_script_is_rejected() {
+    assert_with_rejected("<script lang=\"ts\">\n  with (x) {}\n</script>");
+}
+
+#[test]
+fn with_statement_nested_in_function_is_rejected() {
+    assert_with_rejected("<script>\n  function f() { with (x) {} }\n</script>");
+}
+
+#[test]
+fn with_statement_in_svelte_js_module_is_rejected() {
+    let src = "with (x) {}\n";
+    let with_pos = src.find("with").expect("`with` keyword in source");
+    let err = compile_module(
+        src,
+        ModuleCompileOptions {
+            generate: GenerateMode::Client,
+            filename: Some("test.svelte.js".to_string()),
+            ..Default::default()
+        },
+    )
+    .err()
+    .unwrap_or_else(|| panic!("expected a `with` parse error for {src:?}, but it compiled"));
+
+    let CompileError::Parse(ParseError::SvelteError {
+        code,
+        message,
+        span,
+    }) = err
+    else {
+        panic!("expected a SvelteError for {src:?}, got: {err:?}");
+    };
+
+    assert_eq!(code, "js_parse_error");
+    assert_eq!(
+        message,
+        "'with' in strict mode\nhttps://svelte.dev/e/js_parse_error"
+    );
+    assert_eq!(span, (with_pos, with_pos));
+}
+
+/// The identifier `with` as a substring (e.g. inside a string literal or a
+/// longer identifier like `within`) must not trigger a false positive — only
+/// an actual `WithStatement` node does.
+#[test]
+fn with_substring_does_not_false_positive() {
+    let ok = compile(
+        "<script>\n  let within = 1;\n  let s = 'within the woods';\n  console.log(within, s);\n</script>",
+        CompileOptions {
+            filename: Some("Test.svelte".to_string()),
+            generate: GenerateMode::Client,
+            dev: false,
+            css: CssMode::External,
+            runes: Some(true),
+            ..Default::default()
+        },
+    );
+    assert!(
+        ok.is_ok(),
+        "expected `within`/`'within the woods'` to compile, got: {ok:?}"
+    );
+}


### PR DESCRIPTION
## Summary

Fixes #2054

The official compiler rejects a `with` statement inside `<script>` with a parse error (`js_parse_error`, message `'with' in strict mode`) because component scripts are ESM and therefore always strict mode: upstream acorn is invoked with `sourceType: 'module'` uniformly across every JS entry point (`phases/1-parse/acorn.js`'s `parse` / `parse_expression_at` / `parse_statement_at`), and acorn's `parseWithStatement` throws whenever `this.strict` is true.

rsvelte's script parser (`oxc_parser`) has **no strict-mode syntax-restriction pass at all** — it accepts `with` unconditionally regardless of source type, so rsvelte silently compiled code the official compiler rejects.

### Root cause & fix

`convert_parsed_program` (`crates/rsvelte_core/src/compiler/phases/1_parse/read/expression.rs`) already had a similar one-off check for `@decorator` syntax (another OXC-accepts/acorn-rejects gap). I generalized that into a single AST scan (`StrictModeScan`) that looks for both `Decorator` and `WithStatement` nodes and reports whichever occurs first in the source — mirroring acorn's single-pass, non-recovering behavior, where the first offending construct wins.

Because this lives at the single script-parsing choke point, the fix applies uniformly, with no extra plumbing, to every entry point that funnels through it:
- the instance `<script>`
- `<script module>`
- `<script lang="ts">`
- `.svelte.js` / `.svelte.ts` modules (`compile_module`)

Verified all four against the official compiler's exact `code` / `message` / byte position for a `with` statement, and confirmed the fix doesn't false-positive on `with` as a mere substring (`within`, `'within the woods'`), and doesn't regress the pre-existing decorator check.

### Known follow-up (out of scope here)

While investigating, I confirmed official also rejects several other strict-mode-only constructs that OXC currently accepts silently (octal number literals, `delete` of an unqualified identifier, assignment to `eval`/`arguments`), for the same underlying reason (OXC has no strict-mode validation pass). Those are a materially larger surface (each needs its own acorn-parity investigation) and aren't part of the `with`-statement scope of #2054, so I'm leaving them for a follow-up issue rather than expanding this PR's blast radius.

Also out of scope: `with` nested inside a function body that lives in a *markup* JS expression (e.g. an event handler `onclick={() => { with (x) {} }}` or a `{@const}` body) — official rejects these too, but they're parsed through a completely different expression-parsing pipeline than `<script>` content, so fixing them requires separate work.

## Test plan

- [x] Updated `crates/rsvelte_core/tests/ts_erasure_visitor_coverage.rs`'s `with_statement_body` test (pinned by the issue) to assert the `js_parse_error` / message / span instead of erased output.
- [x] Added `crates/rsvelte_core/tests/with_statement_strict_mode.rs`: instance script, `<script module>`, `<script lang="ts">`, nested-in-function, `.svelte.js` module, and a false-positive guard for `with` as a mere substring.
- [x] `cargo test --release -p rsvelte_core --test compiler_errors --test parser_fixtures --test block_head_parse_errors --test module_compile_error_propagation --test ts_erasure_visitor_coverage --test with_statement_strict_mode` — all pass (145/145 compiler-errors, 27/27 + 81/81 parser modern/legacy, plus the new/updated tests).
- [x] `cargo test --release -p rsvelte_core --test runtime --test ssr` — all pass (runtime legacy 1207/1207, runtime runes 1007/1007, runtime browser 32/32, hydration 79/79, SSR 99/99) — no regressions.
- [x] `cargo fmt` — clean, no changes needed.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)