### PR TITLE
fix(compiler): match official wording for svelte_self_invalid_placement

### DIFF
--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/shared/special_element.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/shared/special_element.rs
@@ -36,7 +36,7 @@ pub fn validate_special_element_placement(
             if context.block_depth == 0 && context.component_depth == 0 => {
                 return Err(AnalysisError::validation(
                     "svelte_self_invalid_placement",
-                    "`<svelte:self>` components can only exist inside {#if}, {#each}, {#snippet} blocks or component `children` snippets",
+                    "`<svelte:self>` components can only exist inside `{#if}` blocks, `{#each}` blocks, `{#snippet}` blocks or slots passed to components\nhttps://svelte.dev/e/svelte_self_invalid_placement",
                 ));
             }
         _ => {}

--- a/crates/rsvelte_core/tests/svelte_self_invalid_placement_message_2111.rs
+++ b/crates/rsvelte_core/tests/svelte_self_invalid_placement_message_2111.rs
@@ -1,0 +1,33 @@
+//! Regression test for issue #2111 — `svelte_self_invalid_placement`'s message
+//! text had drifted from the official compiler's wording (`{#if}, {#each},
+//! {#snippet} blocks or component `children` snippets` instead of the official
+//! `` `{#if}` blocks, `{#each}` blocks, `{#snippet}` blocks or slots passed to
+//! components ``). Mirrors `packages/svelte/src/compiler/errors.js` /
+//! `tests/compiler-errors/samples/self-reference/_config.js` in the Svelte
+//! submodule.
+
+use rsvelte_core::compiler::AnalysisError;
+use rsvelte_core::{CompileError, CompileOptions, GenerateMode, compile};
+
+const EXPECTED_MESSAGE: &str = "`<svelte:self>` components can only exist inside `{#if}` blocks, `{#each}` blocks, `{#snippet}` blocks or slots passed to components\nhttps://svelte.dev/e/svelte_self_invalid_placement";
+
+#[test]
+fn message_matches_official_wording() {
+    let result = compile(
+        "<svelte:self/>",
+        CompileOptions {
+            filename: Some("main.svelte".to_string()),
+            generate: GenerateMode::Client,
+            ..Default::default()
+        },
+    );
+
+    let err = result.expect_err("top-level <svelte:self> must be rejected");
+    match err {
+        CompileError::Analysis(AnalysisError::ValidationWithCode { code, message }) => {
+            assert_eq!(code, "svelte_self_invalid_placement");
+            assert_eq!(message, EXPECTED_MESSAGE);
+        }
+        other => panic!("expected an AnalysisError::ValidationWithCode, got: {other:?}"),
+    }
+}


### PR DESCRIPTION
## Summary

The validator error for a top-level `<svelte:self>` diverged from the official compiler's wording:

- official: `` `<svelte:self>` components can only exist inside `{#if}` blocks, `{#each}` blocks, `{#snippet}` blocks or slots passed to components ``
- rsvelte (before): `` `<svelte:self>` components can only exist inside {#if}, {#each}, {#snippet} blocks or component `children` snippets ``

Fixed `crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/shared/special_element.rs` to match `submodules/svelte/packages/svelte/src/compiler/errors.js`'s `svelte_self_invalid_placement` exactly, including the trailing `https://svelte.dev/e/svelte_self_invalid_placement` URL (the project convention documented in `crates/rsvelte_core/src/error/mod.rs`).

Added a regression test (`crates/rsvelte_core/tests/svelte_self_invalid_placement_message_2111.rs`) asserting the full error code + message text, since the existing `compiler_errors`/`validator` fixture suites only assert the error **code**, not the message text — so this drift wasn't previously caught.

Fixes #2111

## Test plan

- [x] `cargo test --release --test compiler_errors` — 145/145 passed
- [x] `cargo test --release --test validator` — passed
- [x] `cargo test --release --test svelte_self_invalid_placement_message_2111` — passed (new regression test)
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RQSYoh4Wc353KgUnWHjazu