### PR TITLE
chore(corpus): add a CI check for known-failures.md / JSON count drift

### DIFF
--- a/.github/workflows/corpus-compat.yml
+++ b/.github/workflows/corpus-compat.yml
@@ -156,6 +156,14 @@ jobs:
         with:
           submodules: false
 
+      # Cheap and needs none of the corpus/build setup below, so it runs
+      # first and fails fast: the JSON ratchets are CI-enforced (shrink-only),
+      # but the prose header counts and the client-dev cluster-table residue
+      # in known-failures.md are hand-maintained and drift silently otherwise
+      # (#2062).
+      - name: Verify known-failures.md matches the JSON ratchets
+        run: node scripts/compat-corpus/known-failures-md-check.mjs
+
       - name: Checkout corpus source submodules (shallow)
         run: git submodule update --init --depth 1 submodules/svelte submodules/svelte.dev submodules/language-tools submodules/bits-ui submodules/flowbite-svelte submodules/melt-ui submodules/shadcn-svelte submodules/sveltestrap submodules/attractions submodules/svelte-ux submodules/smelte submodules/svar-core submodules/svelte-table submodules/powertable submodules/svelte-pivottable submodules/svelte-toast submodules/svelte-sonner submodules/svelte-notifications submodules/svelte-fa submodules/svelte-heroicons submodules/svelte-calendar submodules/date-picker-svelte submodules/svelte-maplibre submodules/layercake submodules/layerchart submodules/svelte-splitpanes submodules/svelte-stepper submodules/svelte-formly submodules/svelte-form-builder submodules/svelte-checkbox submodules/svelte-toggle submodules/svelthree submodules/cmsaasstarter submodules/skeleton
 

--- a/compatibility/known-failures.md
+++ b/compatibility/known-failures.md
@@ -12,6 +12,15 @@ The ratchet (`corpus-compat.yml`) fails only on an `(id, target)` pair not in th
 baseline — the lists may only shrink, never grow. Each accepted entry must be
 justified in this file.
 
+The JSON files are CI-enforced this way, but the header counts and (for
+client-dev) the cluster-table residue below are hand-maintained prose and were
+not checked anywhere, so a burn-down PR could update the JSON without keeping
+this file's numbers in sync (#2062, drift from #2048). `corpus-compat.yml` now
+runs `scripts/compat-corpus/known-failures-md-check.mjs` first, which fails
+the job if a header count (or the client-dev "attributed to a cluster" /
+"remaining" reconciliation, when that sentence is present) stops matching the
+JSON array length.
+
 The five skeleton seeds from #1924 are gone (#2017): #1973 (fixed by #1996),
 #1974 (fixed by #1988), #1975 (fixed by #1993). All three divergences the
 checked-in pattern corpus (#2019) surfaced are gone too: the two SSR

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
 		"corpus:collect": "node scripts/compat-corpus/collect.mjs",
 		"corpus:compile": "node scripts/compat-corpus/compile.mjs",
 		"corpus:verify": "node scripts/compat-corpus/verify.mjs",
+		"corpus:known-failures-check": "node scripts/compat-corpus/known-failures-md-check.mjs",
 		"corpus:compile:dev": "node scripts/compat-corpus/compile.mjs --targets client-dev",
 		"corpus:verify:dev": "node scripts/compat-corpus/verify.mjs --targets client-dev",
 		"corpus:fmt": "node scripts/compat-corpus/fmt.mjs",

--- a/scripts/compat-corpus/known-failures-md-check.mjs
+++ b/scripts/compat-corpus/known-failures-md-check.mjs
@@ -1,0 +1,89 @@
+#!/usr/bin/env node
+/**
+ * Guards against `compatibility/known-failures.md` drifting from the JSON
+ * ratchets it documents. The JSON files are CI-enforced (shrink-only,
+ * `verify.mjs`), but the prose header counts and the client-dev
+ * "attributed to a cluster" / "remaining" reconciliation are hand-maintained
+ * and were not checked anywhere — a burn-down PR that updates one of the
+ * three `known-failures.*.json` files without updating the matching header
+ * (or the residue arithmetic) silently drifts out of sync (#2062, drift from
+ * #2048: the client-dev cluster table + residue summed to 3 less than the
+ * JSON's actual entry count).
+ *
+ * Checks, per `known-failures.{client,server,client-dev}.json`:
+ *   1. The `## <Name> (\`known-failures.X.json\`, N entries)` header count
+ *      matches the JSON array length exactly.
+ *   2. (client-dev only, best-effort) If the "NNN entries are attributed to
+ *      a cluster; the remaining MMM" reconciliation sentence is present,
+ *      NNN + MMM must equal the JSON array length. The table itself is not
+ *      parsed — its columns are allowed to overlap by design (an entry can
+ *      diverge in more than one dev helper) — so the sentence is the only
+ *      place the *distinct* entry count is asserted, and only that is
+ *      checked. Not finding the sentence is not an error: the doc's format
+ *      has already been rewritten wholesale once (#2115) and is free to
+ *      change again, as long as whatever replaces it stays close enough to
+ *      re-derive a check.
+ *
+ * Usage: node scripts/compat-corpus/known-failures-md-check.mjs
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, '../..');
+const CORPUS = path.join(ROOT, 'compatibility');
+const MD_PATH = path.join(CORPUS, 'known-failures.md');
+
+const md = fs.readFileSync(MD_PATH, 'utf8');
+let failed = false;
+
+const TARGETS = ['client', 'server', 'client-dev'];
+
+const jsonLengths = new Map();
+for (const target of TARGETS) {
+	const p = path.join(CORPUS, `known-failures.${target}.json`);
+	jsonLengths.set(target, JSON.parse(fs.readFileSync(p, 'utf8')).length);
+}
+
+// Header count check, e.g.:
+//   ## Client dev (`known-failures.client-dev.json`, 896 entries)
+for (const target of TARGETS) {
+	const re = new RegExp('`known-failures\\.' + target.replace('-', '\\-') + '\\.json`,\\s*([\\d,]+)\\s+entr(?:y|ies)');
+	const m = md.match(re);
+	if (!m) {
+		console.error(`[known-failures-md-check] could not find the header count for "${target}" in known-failures.md`);
+		failed = true;
+		continue;
+	}
+	const headerCount = Number(m[1].replace(/,/g, ''));
+	const actual = jsonLengths.get(target);
+	if (headerCount !== actual) {
+		console.error(
+			`[known-failures-md-check] known-failures.md header says ${headerCount} entries for "${target}", but known-failures.${target}.json has ${actual}`,
+		);
+		failed = true;
+	}
+}
+
+// Best-effort client-dev reconciliation: "NNN entries are attributed to a
+// cluster; the remaining MMM ...". Only enforced when the sentence is found.
+const reconcile = md.match(/([\d,]+)\s+entries are attributed to a cluster;\s*the remaining\s*\*{0,2}([\d,]+)\*{0,2}/);
+if (reconcile) {
+	const attributed = Number(reconcile[1].replace(/,/g, ''));
+	const residue = Number(reconcile[2].replace(/,/g, ''));
+	const actual = jsonLengths.get('client-dev');
+	if (attributed + residue !== actual) {
+		console.error(
+			`[known-failures-md-check] client-dev reconciliation sentence says ${attributed} + ${residue} = ${attributed + residue}, but known-failures.client-dev.json has ${actual} entries`,
+		);
+		failed = true;
+	}
+}
+
+if (failed) {
+	console.error('\n[known-failures-md-check] update compatibility/known-failures.md to match the JSON ratchets above.');
+	process.exit(1);
+}
+console.log('[known-failures-md-check] known-failures.md counts match the JSON ratchets.');


### PR DESCRIPTION
## Summary

Issue #2062 reported that PR #2048 grew `known-failures.client-dev.json` from
4563 to 4566 (3 new pattern-corpus entries falling into pre-existing
dev-only clusters) without updating the cluster table / residue in
`compatibility/known-failures.md`, leaving `4302 + 261 = 4563 ≠ 4566`.

**That specific drift no longer exists on `main`.** Tracing the history:

- #2057 (merged after #2062 was filed) fixed the `#2031` entries and, as a
  side effect, moved the residue from 261 → 263, landing on
  `4302 + 263 = 4565` — matching the header's `4565 entries` exactly.
- #2115's later full rewrite of the client-dev section (896 entries) uses a
  different table shape (`under-emits` / `over-emits` per helper, which
  intentionally overlap across rows) plus a reconciliation sentence: *"732
  entries are attributed to a cluster; the remaining **164**..."* —
  `732 + 164 = 896`, matching the header and `known-failures.client-dev.json`'s
  actual length.
- Verified all three headers against `jq length` on their JSON files:
  `client` 0/0, `server` 0/0, `client-dev` 896/896.

So there is nothing left to renumber. What *is* still true is the root
cause named in the issue: **the JSON files are CI-enforced (shrink-only
ratchet), but the prose header counts and the client-dev residue arithmetic
in the `.md` are hand-maintained and nothing checked them** — this is what
let the original drift happen and go unnoticed across a PR.

## Fix

Add `scripts/compat-corpus/known-failures-md-check.mjs`:
- Asserts every `## ... (\`known-failures.X.json\`, N entries)` header
  matches `known-failures.X.json`'s actual array length, for all three
  targets.
- Best-effort: when the client-dev "`NNN` entries are attributed to a
  cluster; the remaining `MMM`" reconciliation sentence is present, asserts
  `NNN + MMM` equals the JSON length. Not finding the sentence is not an
  error — the table's shape has already been rewritten wholesale once
  (#2115) and is free to change again.

Wired as the **first** step of `corpus-compat.yml`'s `corpus` job, right
after checkout — it needs none of the submodule/cargo build setup, so it
fails fast on drift instead of waiting ~6 minutes for the full corpus run.
Also exposed as `pnpm run corpus:known-failures-check` for local use.

I deliberately did not try to make the check parse the client-dev cluster
table's per-row numbers: those columns (`under-emits` / `over-emits`) are
allowed to overlap by design (one entry can diverge in more than one dev
helper), so there is no "sum the table" invariant to assert there — only
the reconciliation sentence states the deduplicated total, which is what's
checked.

## Test plan

- [x] `node scripts/compat-corpus/known-failures-md-check.mjs` passes on
      current `main`
- [x] Manually confirmed the header-mismatch branch fires (edited a copy of
      the header count and re-ran the regex extraction)
- [x] `jq length` on all three `known-failures.*.json` matches their
      headers in `known-failures.md` (0, 0, 896)
- [ ] CI (`corpus-compat.yml`) — this PR's own run exercises the new step

Fixes #2062

🤖 Generated with [Claude Code](https://claude.com/claude-code)