### PR TITLE
fix(compiler): count every dev-mode source location in UTF-16 code units (#2099)

### DIFF
--- a/.changeset/fix-utf16-locators.md
+++ b/.changeset/fix-utf16-locators.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/compiler": patch
+---
+
+fix(compiler): count every dev-mode source location in UTF-16 code units. `$.push_element`, `$.apply`, `$.add_svelte_meta` and `$$ownership_validator.mutation` each re-implemented the byte-offset → line/column conversion and counted one column per code point, so an emoji (surrogate pair) earlier on the line reported a column one short of official's `locate-character`. The four duplicates are now a single shared locator alongside the already-correct `$.add_locations` one.

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/props_transforms.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/props_transforms.rs
@@ -3322,21 +3322,7 @@ pub(super) fn find_prop_mutation_location(source: &str, var_name: &str) -> (usiz
         } else {
             relative_offset
         };
-        // Compute line/column from byte offset
-        let mut line = 1usize;
-        let mut col = 0usize;
-        for (i, ch) in source.char_indices() {
-            if i >= offset {
-                break;
-            }
-            if ch == '\n' {
-                line += 1;
-                col = 0;
-            } else {
-                col += 1;
-            }
-        }
-        (line, col)
+        crate::compiler::phases::phase3_transform::utils::locate_in_source(source, offset)
     } else {
         (0, 0)
     }
@@ -3578,6 +3564,32 @@ pub(super) fn split_top_level_args(s: &str) -> Vec<String> {
     }
 
     parts
+}
+
+#[cfg(test)]
+mod prop_mutation_location_tests {
+    use super::{find_prop_mutation_location, wrap_prop_mutation_validation};
+
+    /// Issue #2099: the location reported to `$$ownership_validator.mutation`
+    /// counts columns in UTF-16 code units, so an emoji before the mutation
+    /// shifts it by 2 rather than 1.
+    #[test]
+    fn location_columns_are_utf16_code_units() {
+        let astral = "<script>\nlet { item } = $props();\nfunction go() { /*🎉*/ item.name = 1; }\n</script>";
+        let bmp = astral.replace('🎉', "あ");
+        assert_eq!(find_prop_mutation_location(astral, "item"), (3, 23));
+        assert_eq!(find_prop_mutation_location(&bmp, "item"), (3, 22));
+    }
+
+    #[test]
+    fn mutation_wrapper_carries_the_utf16_column() {
+        let source = "<script>\nlet { item } = $props();\nfunction go() { /*🎉*/ item.name = 1; }\n</script>";
+        let prop_vars = vec![("item".to_string(), "item".to_string())];
+        assert_eq!(
+            wrap_prop_mutation_validation("item().name = 1", &prop_vars, source),
+            "$$ownership_validator.mutation('item', ['item', 'name'], item().name = 1, 3, 23)"
+        );
+    }
 }
 
 #[cfg(test)]

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/transform_template/index.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/transform_template/index.rs
@@ -43,23 +43,9 @@ pub struct Location {
     pub column: usize,
 }
 
-/// Line/column of a byte offset, columns in UTF-16 code units to match
-/// `locate-character`, which indexes the source as a JS string.
 fn locate(source: &str, offset: u32) -> Location {
-    let mut end = (offset as usize).min(source.len());
-    while end > 0 && !source.is_char_boundary(end) {
-        end -= 1;
-    }
-    let mut line = 1usize;
-    let mut column = 0usize;
-    for c in source[..end].chars() {
-        if c == '\n' {
-            line += 1;
-            column = 0;
-        } else {
-            column += c.len_utf16();
-        }
-    }
+    let (line, column) =
+        crate::compiler::phases::phase3_transform::utils::locate_in_source(source, offset as usize);
     Location { line, column }
 }
 

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/types.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/types.rs
@@ -669,7 +669,7 @@ impl<'a> ComponentContext<'a> {
 
         // Dev mode: add location [line, column] as the last argument
         if self.state.dev {
-            use crate::compiler::phases::phase3_transform::client::visitors::attribute::locate_in_source;
+            use crate::compiler::phases::phase3_transform::utils::locate_in_source;
             let (line, col) = locate_in_source(&self.state.analysis.source, elem.start as usize);
             // Ensure we have enough arguments before the location
             // The function signature is: element(node, get_tag, is_svg_or_mathml, callback?, namespace?, location?)

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/attribute.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/attribute.rs
@@ -9,6 +9,7 @@ use crate::compiler::phases::phase3_transform::client::visitors::shared::events:
     build_event, convert_arrow_to_named_function,
 };
 use crate::compiler::phases::phase3_transform::js_ast::nodes::JsExpr;
+use crate::compiler::phases::phase3_transform::utils::locate_in_source;
 #[cfg(test)]
 use crate::compiler::utils::can_delegate_event;
 
@@ -430,27 +431,6 @@ pub fn is_passive_event(name: &str) -> Option<bool> {
     } else {
         None
     }
-}
-
-/// Compute 1-based line and 0-based column from a byte offset in source code.
-/// This matches the behavior of the `locator` function in the official Svelte compiler,
-/// which uses `getLocator(source, { offsetLine: 1 })` from `locate-character`.
-pub fn locate_in_source(source: &str, offset: usize) -> (usize, usize) {
-    let offset = offset.min(source.len());
-    let mut line = 1usize; // 1-based lines (offsetLine: 1)
-    let mut col = 0usize;
-    for (i, ch) in source.char_indices() {
-        if i >= offset {
-            break;
-        }
-        if ch == '\n' {
-            line += 1;
-            col = 0;
-        } else {
-            col += 1;
-        }
-    }
-    (line, col)
 }
 
 /// Check if an expression has side effects.

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/await_block.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/await_block.rs
@@ -141,7 +141,7 @@ pub fn await_block(node: &AwaitBlock, context: &mut ComponentContext) {
 
     // Add svelte metadata
     let stmt = if context.state.dev {
-        use crate::compiler::phases::phase3_transform::client::visitors::attribute::locate_in_source;
+        use crate::compiler::phases::phase3_transform::utils::locate_in_source;
         let (line, col) = locate_in_source(&context.state.analysis.source, node.start as usize);
         super::shared::utils::add_svelte_meta_dev(
             &context.arena,

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/bind_directive.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/bind_directive.rs
@@ -1890,7 +1890,10 @@ fn build_getter_setter_with_primitive(
                         let start_pos = original_expr.start().map(|v| v as usize);
                         if let Some(start) = start_pos {
                             let source = &context.state.analysis.source;
-                            let (line, col) = offset_to_line_col(source, start);
+                            let (line, col) =
+                                crate::compiler::phases::phase3_transform::utils::locate_in_source(
+                                    source, start,
+                                );
                             args.push(b::number(line as f64));
                             args.push(b::number(col as f64));
                         }
@@ -2680,9 +2683,7 @@ pub fn emit_validate_binding(
 
     // Get line/column for the binding
     let (line, col) =
-        crate::compiler::phases::phase3_transform::client::visitors::attribute::locate_in_source(
-            source, start,
-        );
+        crate::compiler::phases::phase3_transform::utils::locate_in_source(source, start);
 
     // If inside a store-backed each block, wrap with $.mark_store_binding()
     // Reference: validate_binding() in shared/utils.js - `state.store_to_invalidate`
@@ -2736,24 +2737,6 @@ fn extract_root_name_from_json(val: &serde_json::Value) -> Option<String> {
         "MemberExpression" => extract_root_name_from_json(obj.get("object")?),
         _ => None,
     }
-}
-
-/// Convert a byte offset to 1-based line and 0-based column.
-fn offset_to_line_col(source: &str, offset: usize) -> (usize, usize) {
-    let mut line = 1;
-    let mut col = 0;
-    for (i, ch) in source.char_indices() {
-        if i >= offset {
-            break;
-        }
-        if ch == '\n' {
-            line += 1;
-            col = 0;
-        } else {
-            col += 1;
-        }
-    }
-    (line, col)
 }
 
 /// Get the root identifier name from an AST Expression (JSON-based).

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/each_block.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/each_block.rs
@@ -577,7 +577,7 @@ pub fn each_block(node: &EachBlock, context: &mut ComponentContext) {
 
     // Add svelte metadata
     let each_statement = if context.state.dev {
-        use crate::compiler::phases::phase3_transform::client::visitors::attribute::locate_in_source;
+        use crate::compiler::phases::phase3_transform::utils::locate_in_source;
         let (line, col) = locate_in_source(&context.state.analysis.source, node.start as usize);
         super::shared::utils::add_svelte_meta_dev(
             &context.arena,

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/expression_converter.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/expression_converter.rs
@@ -4501,7 +4501,8 @@ fn check_ownership_validation(
     let source_loc = get_root_start_position(left_val).and_then(|start| {
         let source = &context.state.analysis.source;
         if !source.is_empty() {
-            Some(super::attribute::locate_in_source(source, start as usize))
+            use crate::compiler::phases::phase3_transform::utils::locate_in_source;
+            Some(locate_in_source(source, start as usize))
         } else {
             None
         }
@@ -4924,9 +4925,7 @@ fn try_coercive_assignment_transform(
     let source = &context.state.analysis.source;
     let filename = &context.state.analysis.filename;
     let (line, col) =
-        crate::compiler::phases::phase3_transform::client::visitors::attribute::locate_in_source(
-            source, start,
-        );
+        crate::compiler::phases::phase3_transform::utils::locate_in_source(source, start);
     let location = format!("{}:{line}:{col}", filename.replace('/', "/\u{200b}"));
 
     Some(b::call(

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/if_block.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/if_block.rs
@@ -322,7 +322,7 @@ pub fn if_block(node: &IfBlock, context: &mut ComponentContext) {
 
     let if_call = b::call(&context.arena, b::member_path(&context.arena, "$.if"), args);
     let if_statement = if context.state.dev {
-        use crate::compiler::phases::phase3_transform::client::visitors::attribute::locate_in_source;
+        use crate::compiler::phases::phase3_transform::utils::locate_in_source;
         let (line, col) = locate_in_source(&context.state.analysis.source, node.start as usize);
         super::shared::utils::add_svelte_meta_dev(
             &context.arena,

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/key_block.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/key_block.rs
@@ -85,7 +85,7 @@ pub fn key_block(node: &KeyBlock, context: &mut ComponentContext) -> TransformRe
         vec![context.state.node.clone(), key_expr, body],
     );
     let key_call_stmt = if context.state.dev {
-        use crate::compiler::phases::phase3_transform::client::visitors::attribute::locate_in_source;
+        use crate::compiler::phases::phase3_transform::utils::locate_in_source;
         let (line, col) = locate_in_source(&context.state.analysis.source, node.start as usize);
         super::shared::utils::add_svelte_meta_dev(
             &context.arena,

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/render_tag.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/render_tag.rs
@@ -200,7 +200,7 @@ pub fn render_tag(node: &RenderTag, context: &mut ComponentContext) -> JsStateme
     let mut statements: Vec<JsStatement> = derived_decls;
     // In dev mode, wrap with $.add_svelte_meta() for render tags
     if context.state.dev {
-        use crate::compiler::phases::phase3_transform::client::visitors::attribute::locate_in_source;
+        use crate::compiler::phases::phase3_transform::utils::locate_in_source;
         let (line, col) = locate_in_source(&context.state.analysis.source, node.start as usize);
         statements.push(super::shared::utils::add_svelte_meta_dev(
             &context.arena,

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/component.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/component.rs
@@ -3098,7 +3098,8 @@ fn build_component_meta_stmt(
         ComponentNode::SvelteSelf(comp) => (comp.start, "svelte:self".to_string()),
     };
 
-    let (line, col) = super::super::attribute::locate_in_source(source, start as usize);
+    let (line, col) =
+        crate::compiler::phases::phase3_transform::utils::locate_in_source(source, start as usize);
 
     super::utils::add_svelte_meta_dev(
         arena,

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/events.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/events.rs
@@ -238,7 +238,7 @@ pub fn build_event_handler(
         // Dev routes the call through `$.apply` so a handler that throws can be
         // reported with the component and the source position of the attribute.
         let (line, column) = match expression.start() {
-            Some(start) => super::super::attribute::locate_in_source(
+            Some(start) => crate::compiler::phases::phase3_transform::utils::locate_in_source(
                 &context.state.analysis.source,
                 start as usize,
             ),

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/visitors/element.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/visitors/element.rs
@@ -327,10 +327,12 @@ fn emit_element_body<'a>(
 
 /// Emit the dev-mode `$.push_element($$renderer, '<name>', <line>, <col>)`
 /// statement into the template buffer. The location is the 1-based line /
-/// 0-based column of `node.start`, computed via the existing (read-only)
-/// `locate_in_source` helper from the legacy server pipeline.
+/// 0-based column of `node.start`, computed via the shared `locate_in_source`.
 fn push_element_dev<'a>(node: &RegularElement, name: &str, state: &mut ServerTransformState<'a>) {
-    let (line, col) = super::shared::locate_in_source(state.source, node.start as usize);
+    let (line, col) = crate::compiler::phases::phase3_transform::utils::locate_in_source(
+        state.source,
+        node.start as usize,
+    );
     let b = state.b;
     let call = b.call(
         "$.push_element",

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/visitors/shared.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/visitors/shared.rs
@@ -1632,27 +1632,6 @@ impl<'a> PromiseOptimiser<'a> {
     }
 }
 
-/// Compute 1-based line number and 0-based column for a byte offset in source.
-/// (Relocated from the deleted text `server/visitors/element.rs` — used by the
-/// dev-mode `$.push_element($$renderer, '<name>', <line>, <col>)` instrumentation.)
-pub(crate) fn locate_in_source(source: &str, offset: usize) -> (usize, usize) {
-    let offset = offset.min(source.len());
-    let mut line = 1usize;
-    let mut col = 0usize;
-    for (i, ch) in source.char_indices() {
-        if i >= offset {
-            break;
-        }
-        if ch == '\n' {
-            line += 1;
-            col = 0;
-        } else {
-            col += 1;
-        }
-    }
-    (line, col)
-}
-
 /// Infer a fragment's namespace from its children (owned-slice variant). If every
 /// direct `RegularElement` child is SVG (or every one MathML) the fragment adopts
 /// that namespace, so whitespace-only text between them is removable. (Relocated

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/utils.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/utils.rs
@@ -1270,9 +1270,58 @@ pub(crate) fn canonicalize_props_call(s: &str) -> Cow<'_, str> {
     REGEX_PROPS_ASSIGN.replace_all(s, "= $$props()")
 }
 
+/// 1-based line and 0-based column for a UTF-8 byte offset into `source`.
+///
+/// The single locator every dev-mode instrumentation site shares
+/// (`$.add_locations`, `$.push_element`, `$.apply`, `$.add_svelte_meta`,
+/// `$$ownership_validator.mutation`). Columns are counted in **UTF-16 code
+/// units** because official runs `getLocator(source, { offsetLine: 1 })` from
+/// `locate-character`, which indexes the source as a JS string — so an astral
+/// character (emoji, surrogate pair) advances the column by 2, not 1.
+pub fn locate_in_source(source: &str, byte_offset: usize) -> (usize, usize) {
+    let mut end = byte_offset.min(source.len());
+    while end > 0 && !source.is_char_boundary(end) {
+        end -= 1;
+    }
+    let mut line = 1usize;
+    let mut column = 0usize;
+    for c in source[..end].chars() {
+        if c == '\n' {
+            line += 1;
+            column = 0;
+        } else {
+            column += c.len_utf16();
+        }
+    }
+    (line, column)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn locate_counts_columns_in_utf16_code_units() {
+        // "🎉" is one code point but two UTF-16 code units, so the `<b>` that
+        // follows it sits at column 2, not column 1.
+        let source = "🎉<b>";
+        let offset = source.find("<b>").unwrap();
+        assert_eq!(locate_in_source(source, offset), (1, 2));
+
+        // BMP multi-byte characters still count as a single column.
+        let source = "あい<b>";
+        let offset = source.find("<b>").unwrap();
+        assert_eq!(locate_in_source(source, offset), (1, 2));
+    }
+
+    #[test]
+    fn locate_resets_column_per_line_and_clamps() {
+        let source = "a🎉\nb🎉c";
+        assert_eq!(locate_in_source(source, source.find('b').unwrap()), (2, 0));
+        assert_eq!(locate_in_source(source, source.find('c').unwrap()), (2, 3));
+        assert_eq!(locate_in_source(source, usize::MAX), (2, 4));
+        assert_eq!(locate_in_source(source, 0), (1, 0));
+    }
 
     #[test]
     fn canonicalize_props_call_collapses_whitespace() {

--- a/crates/rsvelte_core/tests/utf16_locators_2099.rs
+++ b/crates/rsvelte_core/tests/utf16_locators_2099.rs
@@ -1,0 +1,101 @@
+//! Regression tests for issue #2099 — every dev-mode instrumentation site that
+//! reports a source location must count columns in UTF-16 code units, because
+//! official derives them from `locate-character`, which indexes the source as a
+//! JS string. A surrogate-pair character (emoji) therefore advances the column
+//! by 2, not 1.
+//!
+//! Each case compiles the same component twice: once with an astral character
+//! (`🎉`) and once with a BMP character (`あ`) of identical code-point length.
+//! The astral column must be exactly one greater — code-point counting would
+//! make the two equal.
+
+use rsvelte_core::{CompileOptions, GenerateMode, compile};
+
+fn compile_dev(src: &str, generate: GenerateMode) -> String {
+    compile(
+        src,
+        CompileOptions {
+            filename: Some("Probe.svelte".to_string()),
+            generate,
+            dev: true,
+            ..Default::default()
+        },
+    )
+    .expect("component should compile")
+    .js
+    .code
+}
+
+/// Compile both spellings of `template` (with `{CH}` replaced by an astral and a
+/// BMP character) and return the two outputs.
+fn compile_pair(template: &str, generate: GenerateMode) -> (String, String) {
+    (
+        compile_dev(&template.replace("{CH}", "🎉"), generate),
+        compile_dev(&template.replace("{CH}", "あ"), generate),
+    )
+}
+
+#[track_caller]
+fn assert_contains(code: &str, needle: &str) {
+    assert!(code.contains(needle), "expected {needle:?} in:\n{code}");
+}
+
+/// `$.add_locations` — `client/transform_template/index.rs`.
+#[test]
+fn add_locations_columns_are_utf16_code_units() {
+    let (astral, bmp) = compile_pair("<p>{CH}</p><b>x</b>", GenerateMode::Client);
+    assert_contains(&astral, "[[1, 0], [1, 9]]");
+    assert_contains(&bmp, "[[1, 0], [1, 8]]");
+}
+
+/// `$.push_element` — `server/ast/visitors/element.rs`.
+#[test]
+fn push_element_columns_are_utf16_code_units() {
+    let (astral, bmp) = compile_pair("<p>{CH}</p><b>x</b>", GenerateMode::Server);
+    assert_contains(&astral, "$.push_element($$renderer, 'b', 1, 9)");
+    assert_contains(&bmp, "$.push_element($$renderer, 'b', 1, 8)");
+}
+
+/// `$.apply` — the event-handler location built in `client/visitors/attribute.rs`.
+#[test]
+fn apply_event_handler_columns_are_utf16_code_units() {
+    let template = concat!(
+        "<script>let { handler } = $props();</script>\n",
+        "<p>{CH}</p><button onclick={handler}>x</button>"
+    );
+    let (astral, bmp) = compile_pair(template, GenerateMode::Client);
+    assert_contains(
+        &astral,
+        "$.apply(() => $$props.handler, this, $$args, Probe, [2, 26])",
+    );
+    assert_contains(
+        &bmp,
+        "$.apply(() => $$props.handler, this, $$args, Probe, [2, 25])",
+    );
+}
+
+/// `$.add_svelte_meta` — block locations, also via `client/visitors/attribute.rs`.
+#[test]
+fn add_svelte_meta_columns_are_utf16_code_units() {
+    let (astral, bmp) = compile_pair("<p>{CH}</p>{#if x}<i>a</i>{/if}", GenerateMode::Client);
+    assert_contains(&astral, "'if',\n\t\t\tProbe,\n\t\t\t1,\n\t\t\t9\n");
+    assert_contains(&bmp, "'if',\n\t\t\tProbe,\n\t\t\t1,\n\t\t\t8\n");
+}
+
+/// `$$ownership_validator.mutation` — `client/visitors/bind_directive.rs`.
+#[test]
+fn ownership_mutation_columns_are_utf16_code_units() {
+    let template = concat!(
+        "<script>let { obj } = $props();</script>",
+        "<p>{CH}</p><input bind:value={obj.foo} />"
+    );
+    let (astral, bmp) = compile_pair(template, GenerateMode::Client);
+    assert_contains(
+        &astral,
+        "$$ownership_validator.mutation('obj', ['obj', 'foo'], obj().foo = $$value, 1, 68)",
+    );
+    assert_contains(
+        &bmp,
+        "$$ownership_validator.mutation('obj', ['obj', 'foo'], obj().foo = $$value, 1, 67)",
+    );
+}


### PR DESCRIPTION
Fixes #2099

## Problem

PR #2098 fixed the `$.add_locations` locator to count columns in UTF-16 code units, matching `locate-character` (which indexes the source as a JS string). The same byte-offset → line/column conversion was re-implemented independently in four more places, all counting one column per Rust `char` (code point), so each was off by one per preceding surrogate-pair character:

- `3_transform/server/ast/visitors/shared.rs` `locate_in_source` — dev `$.push_element`
- `3_transform/client/visitors/bind_directive.rs` `offset_to_line_col` — `$$ownership_validator.mutation`
- `3_transform/client/props_transforms.rs` (inline, in `find_prop_mutation_location`)
- `3_transform/client/visitors/attribute.rs` `locate_in_source` — `$.apply`, `$.add_svelte_meta`, `$.element`, component/render-tag meta

## Fix

All five sites now go through one shared locator, `crate::compiler::phases::phase3_transform::utils::locate_in_source` (mirrors official's `getLocator(source, { offsetLine: 1 })`: 1-based line, 0-based column in UTF-16 code units). The four duplicate implementations are deleted.

## Verification

Every expected column in the new tests was cross-checked against the official compiler (svelte 5.56.8) on the identical source — all match byte-for-byte.

- `crates/rsvelte_core/tests/utf16_locators_2099.rs` — one compile-level regression test per consumer (`$.add_locations`, `$.push_element`, `$.apply`, `$.add_svelte_meta`, `$$ownership_validator.mutation`). Each compiles the same component twice, once with `🎉` and once with `あ`, and asserts the astral column is exactly one greater — code-point counting would make them equal.
- Unit tests for the shared locator in `3_transform/utils.rs` and for the text-pass consumer in `props_transforms.rs`.
- `cargo test -p rsvelte_core`: all suites pass (runtime needs `RUST_MIN_STACK` in a debug profile, as usual).
- `cargo fmt` + `cargo clippy --all-targets --all-features -- -D warnings`: clean.

## Corpus ratchet

No baseline entry is affected: none of the readable `known-failures.client-dev.json` sources contains an astral character, and the change only ever moves rsvelte's columns *toward* official, so it cannot introduce a regression. The other two targets have empty baselines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)