### PR TITLE
fix(svelte2tsx): strip instance-script re-exports like official (#2113)

### DIFF
--- a/.changeset/svelte2tsx-instance-reexport.md
+++ b/.changeset/svelte2tsx-instance-reexport.md
@@ -1,0 +1,14 @@
+---
+"@rsvelte/compiler": patch
+"@rsvelte/svelte2tsx": patch
+"@rsvelte/svelte-check": patch
+---
+
+fix(svelte2tsx): remove a re-export (`export { x } from './mod'`) from a
+component's instance script instead of leaving it inside the generated
+`$$render()` body. Upstream `ExportedNames.handleExportDeclaration` keys off
+`ts.isNamedExports(exportClause)` alone and never inspects `moduleSpecifier`,
+so every named export clause — with or without a `from` — is stripped and
+recorded as an export. rsvelte skipped the clause whenever a module specifier
+was present, emitting an `export … from` inside a function body: invalid TSX
+(TS1233) that made svelte-check discard *all* diagnostics for the file.

--- a/compatibility/check-fixtures/ts-instance-reexport/project/package.json
+++ b/compatibility/check-fixtures/ts-instance-reexport/project/package.json
@@ -1,0 +1,1 @@
+{ "name": "ts-instance-reexport", "private": true, "type": "module" }

--- a/compatibility/check-fixtures/ts-instance-reexport/project/src/lib/helper.ts
+++ b/compatibility/check-fixtures/ts-instance-reexport/project/src/lib/helper.ts
@@ -1,0 +1,3 @@
+export function helper(): number {
+	return 1;
+}

--- a/compatibility/check-fixtures/ts-instance-reexport/project/src/reexport.svelte
+++ b/compatibility/check-fixtures/ts-instance-reexport/project/src/reexport.svelte
@@ -1,0 +1,9 @@
+<script lang="ts">
+	import { helper } from './lib/helper.js';
+
+	export { helper } from './lib/helper.js';
+
+	const label: string = helper();
+</script>
+
+<span>{label}</span>

--- a/compatibility/check-fixtures/ts-instance-reexport/project/tsconfig.json
+++ b/compatibility/check-fixtures/ts-instance-reexport/project/tsconfig.json
@@ -1,0 +1,12 @@
+{
+	"compilerOptions": {
+		"module": "nodenext",
+		"moduleResolution": "nodenext",
+		"target": "es2022",
+		"lib": ["es2022", "dom"],
+		"strict": true,
+		"skipLibCheck": true,
+		"noEmit": true
+	},
+	"include": ["src"]
+}

--- a/compatibility/check-fixtures/ts-instance-reexport/scenario.json
+++ b/compatibility/check-fixtures/ts-instance-reexport/scenario.json
@@ -1,0 +1,7 @@
+{
+	"description": "A component whose instance script re-exports a symbol from another module (`export { helper } from './lib/helper.js'`). svelte2tsx must strip that statement the way official does — leaving it in place puts an `export … from` inside the generated `$$render()` function, which is TS1233 (invalid TSX), and rsvelte-check then discards EVERY diagnostic for the file (#2113). The real type error below the re-export is what proves diagnostics still flow.",
+	"tsconfig": "tsconfig.json",
+	"issues": [
+		2113
+	]
+}

--- a/crates/rsvelte_projection/src/svelte2tsx/script/export_decl.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/script/export_decl.rs
@@ -23,7 +23,8 @@ use super::ExportedNames;
 /// - `export const MAX = 10;` (non-prop)
 /// - `export function fn() {}` (non-prop)
 /// - `export class Foo {}` (non-prop)
-/// - `export { a, b as c };` (re-exports with specifiers)
+/// - `export { a, b as c };` (exports with specifiers)
+/// - `export { a } from './mod';` (re-export; the module specifier is ignored)
 ///
 /// The `export` keyword is removed from the source via MagicString, and the
 /// exported names are recorded in `exported_names`.
@@ -280,8 +281,12 @@ pub(super) fn handle_export_named_decl(
         }
     }
 
-    // Case 2: export with specifiers (export { a, b as c };)
-    if !export.specifiers.is_empty() && export.source.is_none() {
+    // Case 2: an export clause with no declaration. Official
+    // `handleExportDeclaration` keys off `ts.isNamedExports(exportClause)` alone
+    // and never looks at `moduleSpecifier`, so a re-export (`export { a } from
+    // './mod'`) is stripped too — left in place it would put an `export … from`
+    // inside `$$render()`, which is not valid TSX (TS1233).
+    if export.declaration.is_none() {
         let node_end = export.span.end + offset;
         str.overwrite(node_start, node_end, "");
         for spec in export.specifiers.iter() {

--- a/crates/rsvelte_projection/tests/svelte2tsx_reexport_2113.rs
+++ b/crates/rsvelte_projection/tests/svelte2tsx_reexport_2113.rs
@@ -1,0 +1,131 @@
+//! Regression test for issue #2113.
+//!
+//! A re-export in the *instance* script (`export { x } from './mod'`) used to be
+//! left verbatim inside the generated `$$render()` body, which is not valid TSX
+//! (TS1233 "An export declaration can only be used at the top level of a
+//! module"). svelte-check then classified the whole overlay as invalid and
+//! dropped every diagnostic for the component.
+//!
+//! Official `ExportedNames.handleExportDeclaration` keys off
+//! `ts.isNamedExports(exportClause)` only — it never inspects `moduleSpecifier`
+//! — so a re-export is removed from the script and recorded like any other
+//! named export. The expectations below are the official svelte2tsx output for
+//! the same input.
+
+use rsvelte_projection::svelte2tsx::{Svelte2TsxOptions, svelte2tsx};
+
+fn to_tsx(src: &str) -> String {
+    let opts = Svelte2TsxOptions {
+        filename: "Input.svelte".to_string(),
+        is_ts_file: false,
+        ..Default::default()
+    };
+    svelte2tsx(src, opts).expect("svelte2tsx").code
+}
+
+/// The generated `$$render()` body must never contain an `export … from`.
+fn assert_no_export_from(out: &str) {
+    let body_end = out.find("\nasync () =>").unwrap_or(out.len());
+    let body = &out[..body_end];
+    assert!(
+        !body.contains("export "),
+        "an `export` statement survived into the $$render() body:\n{out}"
+    );
+}
+
+#[test]
+fn named_reexport_is_hoisted_out_of_render_body() {
+    let out = to_tsx("<script>\n  export { x } from './mod';\n</script>\n\n<p>hi</p>\n");
+
+    assert_no_export_from(&out);
+    assert!(out.contains("props: {x: x}"), "{out}");
+    assert!(
+        out.contains("exports: /** @type {{x: typeof x}} */ ({})"),
+        "{out}"
+    );
+}
+
+#[test]
+fn renamed_reexport_keeps_official_local_to_exported_mapping() {
+    let out = to_tsx("<script>\n  export { x as y } from './mod';\n</script>\n\n<p>hi</p>\n");
+
+    assert_no_export_from(&out);
+    // Official renders `identifierText || key` : `key`, i.e. exported : local.
+    assert!(out.contains("props: {y: x}"), "{out}");
+    assert!(
+        out.contains("exports: /** @type {{y: typeof x}} */ ({})"),
+        "{out}"
+    );
+}
+
+#[test]
+fn reexport_mixes_with_plain_named_exports_in_source_order() {
+    let out = to_tsx(concat!(
+        "<script>\n",
+        "  let local = 1;\n",
+        "  export { local };\n",
+        "  export { x, y as z } from './mod';\n",
+        "</script>\n",
+        "\n<p>hi</p>\n",
+    ));
+
+    assert_no_export_from(&out);
+    assert!(out.contains("props: {local: local , x: x , z: y}"), "{out}");
+    assert!(
+        out.contains("exports: /** @type {{x: typeof x,z: typeof y}} */ ({})"),
+        "{out}"
+    );
+    assert!(
+        out.contains("__sveltets_2_partial(['local','x','z']"),
+        "{out}"
+    );
+}
+
+#[test]
+fn type_only_reexport_is_removed_like_official() {
+    // Official does not special-case `export type { … } from` either: the
+    // statement is removed and `T` is recorded as an export.
+    let out = to_tsx("<script>\n  export type { T } from './mod';\n</script>\n\n<p>hi</p>\n");
+
+    assert_no_export_from(&out);
+    assert!(out.contains("props: {T: T}"), "{out}");
+}
+
+#[test]
+fn empty_export_clauses_are_removed() {
+    for src in [
+        "<script>\n  export {} from './mod';\n</script>\n",
+        "<script>\n  export {};\n</script>\n",
+    ] {
+        let out = to_tsx(src);
+        assert_no_export_from(&out);
+        assert!(
+            out.contains("props: /** @type {Record<string, never>} */ ({})"),
+            "{out}"
+        );
+    }
+}
+
+#[test]
+fn reexport_of_a_local_let_still_widens_and_stays_a_prop() {
+    // `let x` exists locally, so the specifier resolves to the possible-export
+    // and the entry stays `isLet` (prop, not a class export) — same as official.
+    let out = to_tsx("<script>\n  let x = 1;\n  export { x as y } from './mod';\n</script>\n");
+
+    assert_no_export_from(&out);
+    assert!(out.contains("props: {y: x}"), "{out}");
+    assert!(out.contains("exports: {}"), "{out}");
+}
+
+#[test]
+fn module_script_reexport_is_left_verbatim() {
+    // Module scripts are real modules: official never touches their exports.
+    let out = to_tsx(concat!(
+        "<script context=\"module\">\n",
+        "  export { x } from './mod';\n",
+        "</script>\n",
+        "<script>\n  let a = 1;\n</script>\n",
+    ));
+
+    assert!(out.contains("export { x } from './mod';"), "{out}");
+}


### PR DESCRIPTION
Fixes #2113

## Cause

`handle_export_named_decl` (`crates/rsvelte_projection/src/svelte2tsx/script/export_decl.rs`) only removed an export clause when it had **no** module specifier:

```rust
if !export.specifiers.is_empty() && export.source.is_none() {
```

So `export { x } from './mod'` in a component's *instance* script fell through untouched and was copied verbatim into the generated `$$render()` body:

```tsx
;function $$render() {
  export { x } from './mod';   // TS1233
;
```

An export declaration is only legal at the top level of a module, so the whole overlay became syntactically invalid TSX. `rsvelte-check` then emitted `overlay-invalid-tsx` / `tsgo-semantics-suppressed` and discarded the file's real diagnostics — one re-export line disabled type checking for the entire component.

Official `ExportedNames.handleExportDeclaration` gates purely on `ts.isNamedExports(exportClause)` and **never** inspects `moduleSpecifier`, so it strips the statement and records the specifiers as exports whether or not a `from` is present.

## Fix

Key Case 2 on `export.declaration.is_none()` — i.e. "this is a named-export clause" — exactly like upstream. Everything downstream (possible-export lookup, JSDoc carry-over, `__sveltets_2_any` widening, renamed-export in-place merge) is untouched and already matched upstream for the source-less form.

This also brings the previously-skipped `export {}` / `export {} from '…'` empty clauses into parity (upstream removes those too).

Verified byte-for-byte against official `svelte2tsx` (built from `submodules/language-tools`, svelte 5.56.8) for:

| input (instance script) | before | after |
|---|---|---|
| `export { x } from './mod'` | left verbatim (TS1233) | ✅ identical to official |
| `export { x as y } from './mod'` | left verbatim | ✅ `props: {y: x}` |
| `export { x, y as z } from './mod'` mixed with `export { local }` | left verbatim | ✅ `props: {local: local , x: x , z: y}` |
| `export type { T } from './mod'` | left verbatim | ✅ removed, `T` recorded |
| `export {}` / `export {} from './mod'` | left verbatim | ✅ removed |
| `let x = 1; export { x as y } from './mod'` | left verbatim | ✅ stays a prop, `exports: {}` |
| module-script `export { x } from './mod'` | verbatim | unchanged (correct — module scripts are real modules) |

## Related shapes checked (no change)

`export * from './mod'` and `export * as ns from './mod'` are `ExportAllDeclaration`, not `ExportNamedDeclaration`, and upstream does **not** handle them: `ts.isNamedExports(undefined)` makes official `svelte2tsx` *throw* (`Cannot read properties of undefined (reading 'kind')`) on `export * from` in an instance script, and it leaves `export * as ns from` verbatim (so official also emits TS1233 there). Deliberately left as-is rather than diverging from upstream — neither form occurs anywhere in the corpus (`submodules/**/*.svelte` has exactly two re-exports, both in module scripts), so the byte-parity gate is unaffected.

## Tests

- `crates/rsvelte_projection/tests/svelte2tsx_reexport_2113.rs` — 7 new cases, expectations taken from official `svelte2tsx` output.
- `compatibility/check-fixtures/ts-instance-reexport/` — new Layer-1 svelte-check scenario reproducing the end-to-end symptom. Confirmed it *fails* without the fix:
  ```
  + ERROR src/reexport.svelte:1 overlay-invalid-tsx
  + ERROR src/reexport.svelte:4 1233
  + WARNING :1 tsgo-semantics-suppressed
  ```
  and passes with it (`oracle 1, rsvelte 1`).
- `cargo test` (full workspace): green, no failures.
- svelte2tsx fixture ratchet: `249/254`, `✅ no regressions (5 known failures remain)` — unchanged.
- `check-verify.mjs` (all 25 scenarios): `3 current, 3 known (0 new, 0 fixed)` — no new divergences.
- svelte2tsx corpus ratchet `compatibility/svelte2tsx-known-failures.json`: nothing to shrink; no corpus source contains an instance-script re-export.
- `cargo fmt --check` and `cargo clippy --all-targets --all-features -- -D warnings`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
