### PR TITLE
fix(compiler): apply non-reassigned $state.raw plain-value optimization at any module scope

### DIFF
--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
@@ -3828,16 +3828,19 @@ pub(crate) fn transform_module_script_runes(
 
     // Extract non-reactive module state vars: $state() variables that are NOT reassigned.
     // In runes mode (immutable=true), non-reassigned $state vars don't need $.state() or $.get().
-    // They only get $.proxy() for objects/arrays. This mirrors the instance-level is_state_source logic.
-    let mut module_non_reactive_vars: Vec<String> = if analysis.immutable {
+    // They only get $.proxy() for objects/arrays. This mirrors the official compiler's
+    // `is_state_source` (`3-transform/client/utils.js`), which gates purely on
+    // `binding.reassigned` — it is applied at every scope during the visitor traversal, not
+    // just the module's top-level scope. `Binding::reassigned` already reflects the true
+    // reassignment analysis (not just "declared with `const`"), so this check covers both
+    // top-level and function-local `let`/`const` `$state`/`$state.raw` locals alike (#2082).
+    let module_non_reactive_vars: Vec<String> = if analysis.immutable {
         analysis
             .root
             .bindings
             .iter()
             .filter(|b| {
-                // Module-level bindings are at scope 0
-                b.scope_index == 0
-                    && matches!(b.kind, BindingKind::State | BindingKind::RawState)
+                matches!(b.kind, BindingKind::State | BindingKind::RawState)
                     && !b.reassigned
                     && !analysis.accessors
             })
@@ -3846,18 +3849,6 @@ pub(crate) fn transform_module_script_runes(
     } else {
         Vec::new()
     };
-
-    // Also include `const` $state variables from any scope as non-reactive.
-    // `const` variables can never be reassigned, so they don't need $.state()/$.get() wrapping.
-    // This is especially important for module files where $state is used inside functions.
-    // NOTE: Only $state vars (is_state=true) qualify. $derived vars always need $.get() wrapping.
-    if analysis.immutable {
-        for (name, is_const, is_state) in &module_state_vars_with_const {
-            if *is_const && *is_state && !module_non_reactive_vars.contains(name) {
-                module_non_reactive_vars.push(name.clone());
-            }
-        }
-    }
 
     // Extract module proxy vars for non-reactive vars
     let module_proxy_vars = extract_proxy_vars(script);

--- a/crates/rsvelte_core/tests/state_raw_module_local_never_reassigned.rs
+++ b/crates/rsvelte_core/tests/state_raw_module_local_never_reassigned.rs
@@ -1,0 +1,114 @@
+//! Regression test for a non-reassigned `$state.raw` local getting optimized
+//! to a plain value, matching the official compiler's `is_state_source`
+//! (`3-transform/client/utils.js`): in runes mode a `state`/`raw_state`
+//! binding that is never reassigned is not a "state source" and skips both
+//! the `$.state(...)` declaration wrapper and `$.get(...)` read wrapping.
+//!
+//! rsvelte previously only applied this optimization to `$state`/`$state.raw`
+//! locals declared at the module's *top level* (plus a `const`-only carve-out
+//! for locals inside functions), so a non-reassigned `let` inside a function
+//! body kept the `$.get(...)` wrapper the official compiler drops. The gate
+//! now keys off `Binding::reassigned` directly — the same signal official
+//! uses — regardless of scope depth or `let`/`const`. (#2082)
+
+use rsvelte_core::GenerateMode;
+use rsvelte_core::compile_module;
+use rsvelte_core::compiler::ModuleCompileOptions;
+
+fn compile_mod_client(src: &str, dev: bool) -> String {
+    let result = compile_module(
+        src,
+        ModuleCompileOptions {
+            filename: Some("x.svelte.js".to_string()),
+            generate: GenerateMode::Client,
+            dev,
+            ..Default::default()
+        },
+    )
+    .expect("compile_module");
+    result.js.code
+}
+
+#[test]
+fn non_reassigned_raw_state_in_nested_function_is_plain_value() {
+    // `items` lives inside the arrow function body (not the module's top
+    // level) and is never reassigned.
+    let src = r#"export const fn = () => {
+  let items = $state.raw([]);
+  return items.length;
+};"#;
+    let out = compile_mod_client(src, false);
+    assert!(
+        out.contains("let items = [];"),
+        "expected the `$state.raw([])` declarator to collapse to a plain `[]`. Got:\n{out}"
+    );
+    assert!(
+        out.contains("return items.length;"),
+        "expected a plain, unwrapped read of `items`. Got:\n{out}"
+    );
+    assert!(
+        !out.contains("$.get(items)") && !out.contains("$.state("),
+        "found reactive wrapping on a never-reassigned `$state.raw` local:\n{out}"
+    );
+}
+
+#[test]
+fn non_reassigned_raw_state_at_module_top_level_is_plain_value() {
+    // Top-level module case — already worked before #2082, kept as a
+    // same-file sibling so the two scopes are covered side by side.
+    let src = r#"let items = $state.raw([]);
+export function len() {
+  return items.length;
+}"#;
+    let out = compile_mod_client(src, false);
+    assert!(
+        out.contains("let items = [];"),
+        "expected the `$state.raw([])` declarator to collapse to a plain `[]`. Got:\n{out}"
+    );
+    assert!(
+        !out.contains("$.get(items)") && !out.contains("$.state("),
+        "found reactive wrapping on a never-reassigned `$state.raw` local:\n{out}"
+    );
+}
+
+#[test]
+fn reassigned_raw_state_in_nested_function_still_reactive() {
+    // Control case: once `items` is reassigned anywhere, it *is* a state
+    // source and must keep the `$.state(...)` / `$.get(...)` wrapping.
+    let src = r#"export const fn = () => {
+  let items = $state.raw([]);
+  items = [1];
+  return items.length;
+};"#;
+    let out = compile_mod_client(src, false);
+    assert!(
+        out.contains("$.state([])"),
+        "expected the reassigned `$state.raw([])` declarator to keep `$.state(...)`. Got:\n{out}"
+    );
+    assert!(
+        out.contains("$.get(items)"),
+        "expected reads of the reassigned local to stay wrapped in `$.get(...)`. Got:\n{out}"
+    );
+}
+
+#[test]
+fn non_reassigned_plain_state_in_nested_function_is_proxied_not_sourced() {
+    // Same optimization, but for bare `$state(...)` (not `.raw`): a
+    // never-reassigned local still gets `$.proxy(...)` for deep reactivity
+    // on objects/arrays, but not the `$.state(...)`/`$.get(...)` source
+    // wrapping — mirroring `create_state_declarator` in
+    // `3-transform/client/visitors/VariableDeclaration.js`.
+    let src = r#"export const fn = () => {
+  let items = $state([]);
+  return items.length;
+};"#;
+    let out = compile_mod_client(src, false);
+    assert!(
+        out.contains("let items = $.proxy([]);"),
+        "expected the non-reassigned `$state([])` declarator to drop to `$.proxy(...)` only. Got:\n{out}"
+    );
+    assert!(
+        !out.contains("$.get(items)") && !out.contains("$.state("),
+        "found `$.state(...)`/`$.get(...)` wrapping on a never-reassigned `$state` local:\n{out}"
+    );
+}

--- a/crates/rsvelte_core/tests/strict_equals_member_after_call.rs
+++ b/crates/rsvelte_core/tests/strict_equals_member_after_call.rs
@@ -14,6 +14,14 @@
 //!
 //! Note the negated form: `!==` emits `$.strict_equals(l, r, false)`, matching
 //! the official compiler, rather than negating the call from outside.
+//!
+//! The `$state.raw` locals below are reassigned (`items = [...]` /
+//! `arr = [...]`) so that reads stay wrapped in `$.get(...)` — a
+//! *non*-reassigned `$state.raw` local is optimized away to a plain value by
+//! the official compiler (and, since #2082, by rsvelte too), which would
+//! defeat the point of this call-wrapped-operand guard. See
+//! `state_raw_module_local_never_reassigned.rs` for that optimization's own
+//! coverage.
 
 use rsvelte_core::GenerateMode;
 use rsvelte_core::compile_module;
@@ -37,6 +45,7 @@ fn compile_mod_client_dev(src: &str) -> String {
 fn neq_after_member_on_tagged_state_call_chain() {
     let src = r#"export const fn = () => {
   let items = $state.raw([]);
+  items = [];
   if (items.length !== 0) items[0];
 };"#;
     let out = compile_mod_client_dev(src);
@@ -62,6 +71,7 @@ fn eq_after_member_on_tagged_state_call_chain() {
     // Mirror case with `===`.
     let src = r#"export const fn = () => {
   let items = $state.raw([]);
+  items = [];
   if (items.length === 0) items[0];
 };"#;
     let out = compile_mod_client_dev(src);
@@ -77,6 +87,7 @@ fn neq_after_bracket_index_chain() {
     // `arr[0].length !== 0` — the chain ends with a bracket-index too.
     let src = r#"export const fn = () => {
   let arr = $state.raw([[1, 2]]);
+  arr = [[3, 4]];
   if (arr[0].length !== 0) arr[0][0];
 };"#;
     let out = compile_mod_client_dev(src);


### PR DESCRIPTION
## Summary

- Official's `is_state_source` (`3-transform/client/utils.js`) gates a `state`/`raw_state` binding purely on `binding.reassigned`, and is applied at every scope the visitor descends into (module top level, inside functions, everywhere). A non-reassigned `$state`/`$state.raw` local is not a "state source": it skips both the `$.state(...)` declaration wrapper and the `$.get(...)` read wrapper.
- rsvelte's module-script text pipeline (`transform_module_script_runes` in `crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs`) approximated this with `b.scope_index == 0` (module top level only) plus a `const`-only carve-out for function-local bindings. A never-reassigned `let` declared inside a function body (e.g. `export const fn = () => { let items = $state.raw([]); ... }`) fell through both checks and kept the `$.get(items)` wrapping that official drops.
- Fix: build `module_non_reactive_vars` directly from `Binding::reassigned` for every `State`/`RawState` binding regardless of scope depth or `let`/`const`, matching official's actual gate. This affects both standalone `.svelte.js`/`.svelte.ts` module compiles and `<script module>` blocks inside `.svelte` files (both go through the same function).

## Root cause

`crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs`, `transform_module_script_runes`: the non-reactive-var filter was scope-restricted (`scope_index == 0`) with a separate `const`-only patch for nested scopes, instead of using the binding's actual `reassigned` flag the way official's `is_state_source` does. The component-instance-script pipeline (`visitors/shared/declarations.rs::add_state_transformers`) was already correct — it rebuilds the transform map per scope during traversal, so this bug was isolated to the text-based module pipeline.

## Fix

Removed the `scope_index == 0` restriction and the redundant `const`-only carve-out; `module_non_reactive_vars` now collects every `State`/`RawState` binding with `!b.reassigned && !analysis.accessors`, at any scope, mirroring official's `is_state_source`.

## Tests

- Updated `crates/rsvelte_core/tests/strict_equals_member_after_call.rs`: its `$state.raw` locals are now reassigned so the call-wrapped-operand (`$.get(items).length !== 0`) regression it guards against still exercises real `$.get(...)`-wrapped output (a non-reassigned raw-state local is now optimized away, which would have defeated the guard).
- Added `crates/rsvelte_core/tests/state_raw_module_local_never_reassigned.rs` covering:
  - non-reassigned `$state.raw` inside a nested function body → plain value (the issue's repro)
  - non-reassigned `$state.raw` at module top level → plain value (pre-existing behavior, kept as a sibling case)
  - reassigned `$state.raw` inside a nested function → still `$.state(...)`/`$.get(...)`
  - non-reassigned bare `$state` inside a nested function → `$.proxy(...)` only, no `$.state(...)`/`$.get(...)`
- Verified byte-for-byte against the real official compiler (`submodules/svelte`, v5.56.8) for all of the above via `compileModule`.

## Test plan

- [x] `cargo test --release -p rsvelte_core --test state_raw_module_local_never_reassigned` — 4/4 pass
- [x] `cargo test --release -p rsvelte_core --test strict_equals_member_after_call` — 5/5 pass
- [x] `cargo test --release -p rsvelte_core --test runtime` (runes/legacy/browser/hydration) — 19/19 pass
- [x] `cargo test --release -p rsvelte_core --test ssr` — 16/16 pass
- [x] `cargo test --release -p rsvelte_core --test module_state_raw_reads --test module_class_field_state_codegen --test module_compile_error_propagation --test module_compile_ts_strip --test module_destructure_state_assign --test compile_module_thread_safety --test server_module_effect_strip` — all pass
- [x] `cargo fmt` — no changes needed
- [x] `cargo clippy --release --all-targets --all-features -- -D warnings` — clean
- Did not run the full corpus known-failures ratchet burn-down: this pattern (non-reassigned `$state.raw` local inside a function body, in a module script) wasn't previously tracked as a known failure (grep of `compatibility/known-failures.client-dev.json` for `raw` turns up unrelated component fixtures), matching the issue's own note that it was "untracked so far."

Fixes #2082

🤖 Generated with [Claude Code](https://claude.com/claude-code)