### PR TITLE
fix(compiler): keep class members that share a source line (#2087)

### DIFF
--- a/.changeset/fix-same-line-class-members.md
+++ b/.changeset/fix-same-line-class-members.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/compiler": patch
+---
+
+fix(compiler): keep class members that share a source line — `class Foo { n = $state(1); d = $derived(this.n * 2); }` used to drop the `$derived` backing field and its accessors from the emitted class

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/class_transforms.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/class_transforms.rs
@@ -6,6 +6,7 @@ use std::fmt::Write as _;
 use super::REGEX_INVALID_IDENTIFIER_CHARS;
 use super::expression_needs_proxy;
 use crate::compiler::phases::phase1_parse::utils::find_matching_bracket;
+use crate::compiler::phases::phase3_transform::shared::class_body::split_class_members_onto_lines;
 
 /// JS-lexical-aware replacement for `find_matching_paren`: given `s` positioned
 /// just after an opening `(`, return the byte offset of the matching `)`,
@@ -735,7 +736,11 @@ pub(crate) fn transform_class_fields_client(script: &str) -> String {
     let class_body_end =
         find_matching_bracket(script, class_body_start, '{').unwrap_or(class_body_start);
 
-    let class_body = &script[class_body_start..class_body_end];
+    // The member scan below is line-based, so members sharing a physical line
+    // must first be broken apart or everything after the first one is dropped
+    // (issue #2087).
+    let normalized_body = split_class_members_onto_lines(&script[class_body_start..class_body_end]);
+    let class_body: &str = &normalized_body;
 
     // Parse constructor info
     let mut constructor_content = String::new();
@@ -2325,5 +2330,57 @@ export class Counter {
             out.contains("#modified"),
             "modified should be transformed to private backing field:\n{out}"
         );
+    }
+
+    #[test]
+    fn single_line_class_lowers_every_rune_field() {
+        // Issue #2087: everything after the first rune field on a physical line
+        // used to be discarded, so `#d` and its accessors never reached the output.
+        let script = "export class Foo { n = $state(1); d = $derived(this.n * 2); }";
+        let out = transform_class_fields_client(script);
+        for expected in [
+            "#n = $.state(1)",
+            "get n()",
+            "set n(value)",
+            "#d = $.derived(",
+            "get d()",
+            "set d(value)",
+        ] {
+            assert!(out.contains(expected), "missing {expected}:\n{out}");
+        }
+    }
+
+    #[test]
+    fn single_line_nested_class_lowers_every_rune_field() {
+        let script = "class Outer { a = $state(1); b = $derived(this.a); }\nclass Inner { c = $state(2); d = $derived(this.c); }";
+        let out = transform_class_fields_client(script);
+        for expected in ["#b = $.derived(", "#d = $.derived(", "get b()", "get d()"] {
+            assert!(out.contains(expected), "missing {expected}:\n{out}");
+        }
+    }
+
+    #[test]
+    fn single_line_nested_class_expression_field_is_not_swallowed() {
+        // The nested class body must be broken open too, otherwise the outer
+        // scan reads `inner = class Inner { c = $state(2)` as a single field and
+        // lowers `inner` to the INNER field's value.
+        let script = "class Outer { a = $state(1); inner = class Inner { c = $state(2); e = $derived(this.c * 3); }; }";
+        let out = transform_class_fields_client(script);
+        assert!(out.contains("#a = $.state(1)"), "missing #a:\n{out}");
+        assert!(
+            !out.contains("#inner = $.state("),
+            "inner swallowed:\n{out}"
+        );
+        assert!(out.contains("#c = $.state(2)"), "missing #c:\n{out}");
+        assert!(out.contains("#e = $.derived("), "missing #e:\n{out}");
+    }
+
+    #[test]
+    fn same_line_members_survive_alongside_methods() {
+        let script = "class Foo { n = $state(1); get twice() { return this.n * 2 } d = $derived(this.n + 1); }";
+        let out = transform_class_fields_client(script);
+        assert!(out.contains("#n = $.state(1)"), "missing #n:\n{out}");
+        assert!(out.contains("get twice()"), "method dropped:\n{out}");
+        assert!(out.contains("#d = $.derived("), "missing #d:\n{out}");
     }
 }

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/transform_script.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/transform_script.rs
@@ -9,6 +9,7 @@ use super::transform_legacy::transform_export_let_declarations;
 use super::transform_store::{
     transform_store_assignments, transform_store_destructure_assignments,
 };
+use crate::compiler::phases::phase3_transform::shared::class_body::split_class_members_onto_lines;
 use memchr::memmem;
 use rustc_hash::FxHashSet;
 use std::fmt::Write as _;
@@ -4906,7 +4907,11 @@ pub(crate) fn transform_class_fields_server(script: &str) -> String {
         }
     }
 
-    let class_body = &script[class_body_start..class_body_end];
+    // The member scan below is line-based, so members sharing a physical line
+    // must first be broken apart or everything after the first one is dropped
+    // (issue #2087).
+    let normalized_body = split_class_members_onto_lines(&script[class_body_start..class_body_end]);
+    let class_body: &str = &normalized_body;
 
     #[derive(Debug, Clone)]
     enum ClassMember {

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/shared/class_body.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/shared/class_body.rs
@@ -1,0 +1,384 @@
+//! Normalising a class body so the line-based class-field lowering can see
+//! every member.
+//!
+//! Both the client and server field transforms scan a class body line by line,
+//! so any member sharing a physical line with a preceding one is invisible to
+//! them and silently disappears from the output (issue #2087). Breaking those
+//! members apart up front is what makes the scan total.
+
+use memchr::memmem;
+
+use crate::compiler::phases::phase1_parse::utils::find_matching_bracket;
+
+/// Skip a `'`/`"` string literal starting at `i`, returning the index just past
+/// its closing quote (or end of line / input for an unterminated literal).
+fn skip_quoted(s: &str, i: usize) -> usize {
+    let bytes = s.as_bytes();
+    let quote = bytes[i];
+    let mut j = i + 1;
+    while j < bytes.len() {
+        match bytes[j] {
+            b'\\' => j += 2,
+            b'\n' => return j,
+            b if b == quote => return j + 1,
+            _ => j += 1,
+        }
+    }
+    bytes.len()
+}
+
+/// Skip a template literal starting at the backtick at `i`, returning the index
+/// just past its closing backtick. `${…}` interpolations are skipped whole, so
+/// braces / semicolons inside them are never seen as member boundaries.
+fn skip_template(s: &str, i: usize) -> usize {
+    let bytes = s.as_bytes();
+    let mut j = i + 1;
+    while j < bytes.len() {
+        match bytes[j] {
+            b'\\' => j += 2,
+            b'`' => return j + 1,
+            b'$' if bytes.get(j + 1) == Some(&b'{') => {
+                j = find_matching_bracket(s, j + 2, '{')
+                    .map(|e| e + 1)
+                    .unwrap_or(bytes.len());
+            }
+            _ => j += 1,
+        }
+    }
+    bytes.len()
+}
+
+/// Is a `/` at `prev` (the last non-whitespace byte before it) the start of a
+/// regex literal rather than a division operator?
+fn slash_starts_regex(prev: Option<u8>) -> bool {
+    match prev {
+        None => true,
+        // Non-ASCII bytes are identifier continuations, never operators.
+        Some(b) => {
+            !(b.is_ascii_alphanumeric() || !b.is_ascii() || matches!(b, b'_' | b'$' | b')' | b']'))
+        }
+    }
+}
+
+fn is_ident_byte(c: char) -> bool {
+    c.is_alphanumeric() || c == '_' || c == '$'
+}
+
+/// Does `s` end with the standalone keyword `kw` (not the tail of a longer identifier)?
+fn ends_with_keyword(s: &str, kw: &str) -> bool {
+    s.ends_with(kw) && !s[..s.len() - kw.len()].ends_with(is_ident_byte)
+}
+
+/// Only the tail of the source before a `{` can be its header; bounding the
+/// window keeps the header checks O(1) per brace on large class bodies.
+fn header_window(prefix: &str) -> &str {
+    const MAX: usize = 512;
+    if prefix.len() <= MAX {
+        return prefix;
+    }
+    let mut start = prefix.len() - MAX;
+    while !prefix.is_char_boundary(start) {
+        start += 1;
+    }
+    &prefix[start..]
+}
+
+/// Does the source immediately preceding a `{` make it the opening brace of a
+/// class body — `class {`, `class Foo {`, `class Foo extends Bar {` — rather
+/// than a method body, block statement or object literal?
+fn brace_opens_class_body(prefix: &str) -> bool {
+    let mut p = header_window(prefix).trim_end();
+    if ends_with_keyword(p, "class") {
+        return true;
+    }
+    // `extends <expr>` between the (optional) name and the brace.
+    let mut search = p.len();
+    while let Some(idx) = p[..search].rfind("extends") {
+        if ends_with_keyword(&p[..idx + 7], "extends") && !p[idx + 7..].starts_with(is_ident_byte) {
+            p = p[..idx].trim_end();
+            break;
+        }
+        search = idx;
+    }
+    if ends_with_keyword(p, "class") {
+        return true;
+    }
+    // Optional class name.
+    let p = p.trim_end_matches(is_ident_byte).trim_end();
+    ends_with_keyword(p, "class")
+}
+
+/// Does the source immediately preceding a `{` make it the opening brace of a
+/// `constructor(…)` body? Constructor bodies carry rune declarations
+/// (`this.x = $state(…)`) that are scanned line by line as well.
+fn brace_opens_constructor_body(prefix: &str) -> bool {
+    let p = header_window(prefix).trim_end();
+    if !p.ends_with(')') {
+        return false;
+    }
+    let bytes = p.as_bytes();
+    let mut depth = 0i32;
+    let mut i = p.len();
+    while i > 0 {
+        i -= 1;
+        match bytes[i] {
+            b')' => depth += 1,
+            b'(' => {
+                depth -= 1;
+                if depth == 0 {
+                    return ends_with_keyword(p[..i].trim_end(), "constructor");
+                }
+            }
+            _ => {}
+        }
+    }
+    false
+}
+
+/// Given the offset just past a member terminator, return the offset at which a
+/// line break must be inserted and the offset of the next member's first byte —
+/// or `None` when nothing else shares the line.
+fn member_break_at(s: &str, pos: usize) -> Option<(usize, usize)> {
+    let line_end = s[pos..].find('\n').map_or(s.len(), |p| pos + p);
+    let mut cut = pos;
+    loop {
+        let rest = &s[cut..line_end];
+        let trimmed = rest.trim_start();
+        // Nothing else on this line, a trailing `//` comment, or a terminator
+        // still to come — no member is hiding behind this boundary.
+        if trimmed.is_empty()
+            || trimmed.starts_with("//")
+            || trimmed.starts_with([';', ',', ')', ']', '}'])
+        {
+            return None;
+        }
+        // A `/* … */` comment trailing the member that just ended stays with it.
+        if let Some(inner) = trimmed.strip_prefix("/*") {
+            cut = line_end - inner.len() + inner.find("*/")? + 2;
+            continue;
+        }
+        return Some((cut, line_end - trimmed.len()));
+    }
+}
+
+/// Is everything from `start` up to the next newline (or the end of `s`) blank?
+fn rest_of_line_is_blank(s: &str, start: usize) -> bool {
+    s[start..]
+        .split('\n')
+        .next()
+        .is_none_or(|l| l.trim().is_empty())
+}
+
+/// The run of spaces / tabs that opens the line beginning at `line_start`.
+fn leading_indent(s: &str, line_start: usize) -> &str {
+    let rest = &s[line_start..];
+    let len = rest
+        .find(|c: char| !matches!(c, ' ' | '\t'))
+        .unwrap_or(rest.len());
+    &rest[..len]
+}
+
+/// Break class-body members that share a physical source line onto separate
+/// lines, so the line-based member scan sees exactly one member per line.
+///
+/// Without this, `class A { n = $state(1); d = $derived(this.n) }` parses the
+/// first field and silently discards the rest of the line — the `$derived`
+/// backing field and its accessors never reach the output (issue #2087).
+///
+/// A boundary that is already followed by a line break (or only by a trailing
+/// `//` comment) is left alone, so conventionally formatted source is returned
+/// byte-for-byte unchanged.
+pub(crate) fn split_class_members_onto_lines(class_body: &str) -> std::borrow::Cow<'_, str> {
+    let bytes = class_body.as_bytes();
+    let mut out = String::new();
+    // Everything before `copied` has already been flushed into `out`.
+    let mut copied = 0usize;
+    let mut line_start = 0usize;
+    let mut prev_non_ws: Option<u8> = None;
+    let mut i = 0usize;
+
+    while i < bytes.len() {
+        let b = bytes[i];
+        // A boundary is the offset just past a member terminator: a top-level
+        // `;`, or the `}` closing a top-level member body.
+        let mut boundary: Option<usize> = None;
+        match b {
+            b'\n' => {
+                line_start = i + 1;
+                i += 1;
+                continue;
+            }
+            b'\'' | b'"' => {
+                i = skip_quoted(class_body, i);
+                prev_non_ws = Some(b'"');
+                continue;
+            }
+            b'`' => {
+                i = skip_template(class_body, i);
+                prev_non_ws = Some(b'`');
+                continue;
+            }
+            b'/' if bytes.get(i + 1) == Some(&b'/') => {
+                i = memmem::find(&bytes[i..], b"\n").map_or(bytes.len(), |p| i + p);
+                continue;
+            }
+            b'/' if bytes.get(i + 1) == Some(&b'*') => {
+                i = memmem::find(&bytes[i + 2..], b"*/").map_or(bytes.len(), |p| i + p + 4);
+                continue;
+            }
+            b'/' if slash_starts_regex(prev_non_ws) => {
+                let mut j = i + 1;
+                while j < bytes.len() {
+                    match bytes[j] {
+                        b'\\' => j += 2,
+                        b'[' => {
+                            // A `/` inside a character class does not end the regex.
+                            j += 1;
+                            while j < bytes.len() && bytes[j] != b']' {
+                                j += if bytes[j] == b'\\' { 2 } else { 1 };
+                            }
+                            j += 1;
+                        }
+                        b'/' | b'\n' => break,
+                        _ => j += 1,
+                    }
+                }
+                i = (j + 1).min(bytes.len());
+                prev_non_ws = Some(b'/');
+                continue;
+            }
+            b'(' | b'[' | b'{' => {
+                let close = find_matching_bracket(class_body, i + 1, b as char);
+                let end = close.map_or(bytes.len(), |e| e + 1);
+                // Only a `}` closing a member body ends a member; `)` / `]` do not.
+                if b == b'{' {
+                    boundary = Some(end);
+                    // A nested class body needs the same one-member-per-line
+                    // shape, and its braces must not share a line with members
+                    // either — the outer scan reads them as plain source lines.
+                    // A constructor body is scanned line by line as well.
+                    if let Some(inner_end) = close.filter(|&e| e > i + 1)
+                        && (brace_opens_class_body(&class_body[..i])
+                            || brace_opens_constructor_body(&class_body[..i]))
+                    {
+                        let inner_start = i + 1;
+                        let inner = &class_body[inner_start..inner_end];
+                        let indent = leading_indent(class_body, line_start);
+                        let mut rebuilt = String::new();
+                        if !rest_of_line_is_blank(inner, 0) {
+                            rebuilt.push('\n');
+                            rebuilt.push_str(indent);
+                            rebuilt.push('\t');
+                        }
+                        rebuilt.push_str(&split_class_members_onto_lines(inner));
+                        if !inner
+                            .rsplit('\n')
+                            .next()
+                            .is_none_or(|l| l.trim().is_empty())
+                        {
+                            rebuilt.push('\n');
+                            rebuilt.push_str(indent);
+                        }
+                        if rebuilt != inner {
+                            out.push_str(&class_body[copied..inner_start]);
+                            out.push_str(&rebuilt);
+                            copied = inner_end;
+                        }
+                    }
+                }
+                prev_non_ws = Some(bytes[end.saturating_sub(1)]);
+                i = end;
+            }
+            b';' => {
+                boundary = Some(i + 1);
+                prev_non_ws = Some(b';');
+                i += 1;
+            }
+            _ => {
+                if !b.is_ascii_whitespace() {
+                    prev_non_ws = Some(b);
+                }
+                i += 1;
+            }
+        }
+
+        let Some(pos) = boundary else { continue };
+        let Some((cut, next)) = member_break_at(class_body, pos) else {
+            continue;
+        };
+        out.push_str(&class_body[copied..cut]);
+        out.push('\n');
+        out.push_str(leading_indent(class_body, line_start));
+        copied = next;
+        i = next;
+    }
+
+    if copied == 0 {
+        return std::borrow::Cow::Borrowed(class_body);
+    }
+    out.push_str(&class_body[copied..]);
+    std::borrow::Cow::Owned(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{brace_opens_class_body, split_class_members_onto_lines};
+
+    #[test]
+    fn conventionally_formatted_class_body_is_not_resplit() {
+        for body in [
+            "\n\tvalue = 1;\n\tother = 2;\n",
+            "\n\tfoo() {\n\t\treturn 1;\n\t}\n\n\tbar = 2;\n",
+            "\n\tx = { a: 1 };\n\tf = () => {\n\t\treturn 1;\n\t};\n",
+            "\n\tre = /[};]+/g;\n\ttpl = `a;${b({ c: 1 })};d`;\n",
+            "\n\tn = 1; // trailing comment\n",
+        ] {
+            assert!(
+                matches!(
+                    split_class_members_onto_lines(body),
+                    std::borrow::Cow::Borrowed(_)
+                ),
+                "body was rewritten:\n{body}"
+            );
+        }
+    }
+
+    #[test]
+    fn same_line_members_are_split() {
+        assert_eq!(
+            split_class_members_onto_lines("\tn = $state(1); d = $derived(n * 2);\n"),
+            "\tn = $state(1);\n\td = $derived(n * 2);\n"
+        );
+        assert_eq!(
+            split_class_members_onto_lines("\tfoo() { return 1 } d = $derived(1);\n"),
+            "\tfoo() { return 1 }\n\td = $derived(1);\n"
+        );
+        // A `;` inside a string / template / regex / nested block is not a boundary.
+        assert_eq!(
+            split_class_members_onto_lines("\ts = 'a; b'; t = `c;${d};e`; u = /;/;\n"),
+            "\ts = 'a; b';\n\tt = `c;${d};e`;\n\tu = /;/;\n"
+        );
+    }
+
+    #[test]
+    fn brace_opens_class_body_recognises_class_headers() {
+        for prefix in [
+            "class ",
+            "\tclass Foo ",
+            "x = class ",
+            "class Foo extends Bar ",
+            "x = class extends mixin(Base) ",
+        ] {
+            assert!(brace_opens_class_body(prefix), "{prefix:?}");
+        }
+        for prefix in [
+            "\tfoo() ",
+            "\tif (x) ",
+            "\tx = ",
+            "\tsubclass ",
+            "\tclassy Foo ",
+        ] {
+            assert!(!brace_opens_class_body(prefix), "{prefix:?}");
+        }
+    }
+}

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/shared/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/shared/mod.rs
@@ -5,6 +5,7 @@
 
 pub mod ast_rewrite;
 pub mod async_body;
+pub mod class_body;
 pub mod template;
 
 pub use template::*;

--- a/crates/rsvelte_core/tests/class_fields_same_line_2087.rs
+++ b/crates/rsvelte_core/tests/class_fields_same_line_2087.rs
@@ -1,0 +1,126 @@
+//! Regression tests for issue #2087 — class members that share a physical
+//! source line.
+//!
+//! Class-field lowering scans the class body line by line, so a member written
+//! after another one on the same line used to be discarded entirely: neither the
+//! private backing field nor its accessors reached the output, and reading the
+//! field at runtime returned `undefined`.
+
+use rsvelte_core::compiler::ModuleCompileOptions;
+use rsvelte_core::{GenerateMode, compile_module};
+
+fn compile(src: &str, generate: GenerateMode) -> String {
+    compile_module(
+        src,
+        ModuleCompileOptions {
+            filename: Some("store.svelte.js".to_string()),
+            generate,
+            dev: false,
+            ..Default::default()
+        },
+    )
+    .expect("compile")
+    .js
+    .code
+}
+
+#[test]
+fn derived_after_state_on_one_line_is_lowered_for_the_client() {
+    let out = compile(
+        "export class Foo { n = $state(1); d = $derived(this.n * 2); }",
+        GenerateMode::Client,
+    );
+    for expected in [
+        "#n = $.state(1)",
+        "get n()",
+        "set n(value)",
+        "#d = $.derived(",
+        "get d()",
+        "set d(value)",
+    ] {
+        assert!(out.contains(expected), "missing {expected} in:\n{out}");
+    }
+}
+
+#[test]
+fn derived_after_state_on_one_line_is_lowered_for_the_server() {
+    let out = compile(
+        "export class Foo { n = $state(1); d = $derived(this.n * 2); }",
+        GenerateMode::Server,
+    );
+    assert!(out.contains("#d = $.derived("), "missing #d in:\n{out}");
+    assert!(out.contains("get d()"), "missing getter in:\n{out}");
+}
+
+#[test]
+fn several_runes_on_one_line_all_survive() {
+    let out = compile(
+        "export class Foo { a = $state(1); r = $state.raw([]); b = $derived.by(() => this.a); c = $derived(this.a + 1); }",
+        GenerateMode::Client,
+    );
+    for expected in [
+        "#a = $.state(",
+        "#r = $.state(",
+        "#b = $.derived(",
+        "#c = $.derived(",
+    ] {
+        assert!(out.contains(expected), "missing {expected} in:\n{out}");
+    }
+}
+
+#[test]
+fn a_method_between_two_fields_on_one_line_keeps_all_three() {
+    let out = compile(
+        "export class Foo { n = $state(1); get twice() { return this.n * 2 } d = $derived(this.n + 1); }",
+        GenerateMode::Client,
+    );
+    assert!(out.contains("#n = $.state(1)"), "missing #n in:\n{out}");
+    assert!(out.contains("get twice()"), "method dropped in:\n{out}");
+    assert!(out.contains("#d = $.derived("), "missing #d in:\n{out}");
+}
+
+#[test]
+fn a_one_line_nested_class_expression_keeps_its_own_fields() {
+    let out = compile(
+        "export class Outer { a = $state(1); inner = class Inner { c = $state(2); e = $derived(this.c * 3); }; }",
+        GenerateMode::Client,
+    );
+    assert!(out.contains("#a = $.state(1)"), "missing #a in:\n{out}");
+    assert!(
+        !out.contains("#inner = $.state("),
+        "the outer field took the inner field's value in:\n{out}"
+    );
+    assert!(out.contains("#c = $.state(2)"), "missing #c in:\n{out}");
+    assert!(out.contains("#e = $.derived("), "missing #e in:\n{out}");
+}
+
+#[test]
+fn constructor_declarations_on_one_line_all_survive() {
+    let out = compile(
+        "export class Foo { constructor() { this.n = $state(1); this.d = $derived(this.n * 2); } }",
+        GenerateMode::Client,
+    );
+    assert!(
+        out.contains("this.#n = $.state(1)"),
+        "missing #n in:\n{out}"
+    );
+    assert!(
+        out.contains("this.#d = $.derived("),
+        "missing #d in:\n{out}"
+    );
+    assert!(out.contains("get d()"), "missing accessor in:\n{out}");
+}
+
+#[test]
+fn a_semicolon_inside_a_literal_is_not_a_member_boundary() {
+    let out = compile(
+        "export class Foo { s = $state('a; b'); t = $state(`c;${1};d`); r = $state(/[};]+/g); }",
+        GenerateMode::Client,
+    );
+    assert!(out.contains("$.state('a; b')"), "string split in:\n{out}");
+    assert!(
+        out.contains("$.state(`c;${1};d`)"),
+        "template split in:\n{out}"
+    );
+    assert!(out.contains("$.state(/[};]+/g)"), "regex split in:\n{out}");
+}


### PR DESCRIPTION
Fixes #2087

## Problem

Class-field lowering scans a class body **line by line**, so a member written after another one on the same physical line is invisible to it and is discarded outright:

```js
export class Foo { n = $state(1); d = $derived(this.n * 2); }
```

`parse_state_field` matches `n = $state(1)` and silently throws away the rest of the line, so neither `#d = $.derived(…)` nor its `get d()` / `set d(value)` accessors reach the output. Reading `instance.d` returns `undefined` — in dev and in prod.

The same line-based scan runs over **nested class bodies** and **constructor bodies**, so the bug reproduces there too:

```js
class Outer { a = $state(1); inner = class Inner { c = $state(2); e = $derived(this.c * 3); }; }
class Foo { constructor() { this.n = $state(1); this.d = $derived(this.n * 2); } }
```

In the nested-class-expression case it is worse than a drop: the outer scan reads `inner = class Inner { c = $state(2)` as one field and lowers `inner` to the **inner** field's value.

The server transform (`transform_class_fields_server`) has an identical line-based scan and the same failure — visible in the `.svelte.js` module target.

## Fix

Normalise the class body **before** the scan (new `shared/class_body.rs`, used by both the client and the server transform): break members apart at top-level `;` / `}` boundaries, descending into nested class bodies and constructor bodies. Strings, template literals (including `${…}`), regex literals and comments are skipped lexically, so a `;` inside them is never a boundary.

The normaliser is a **strict no-op for conventionally formatted source**: a boundary already followed by a line break — or only by a trailing `//` comment — is left alone, and the function returns `Cow::Borrowed`. A unit test pins that, and a scan of the available corpus sources found **0** class bodies with same-line members, matching the issue's own scan of all 14,005 corpus entries. The known-failure ratchets therefore need no change (`known-failures.client.json` / `.server.json` are empty and stay empty).

## Verification

* `official vs rsvelte` output comparison over a 28-shape × {component, module} × {client, server, client-dev} matrix (168 combinations): every plain one-line multi-field class, `$state.raw` / `$derived.by` / private / mixed-with-methods / nested-class / constructor-declared / literal-with-`;` shape now matches byte-for-byte after oxfmt normalisation. The 20 remaining divergences all reproduce identically when the same class is written multi-line, so they are pre-existing gaps unrelated to this fix (server nested-class lowering, the `$.tag` label of a quoted field name, comment preservation).
* `crates/rsvelte_core/tests/class_fields_same_line_2087.rs` — 7 new end-to-end regression tests through `compile_module` (client + server).
* Unit tests for the normaliser: no-op on conventional formatting, correct splits, and `brace_opens_class_body` header recognition.
* `cargo test --release -p rsvelte_core` over runtime / ssr / compiler_fixtures / compiler_errors / css / validator / print / parser_fixtures / preprocess / sourcemaps / the class suites / compile_both_parity.
* `cargo fmt --check` and `cargo clippy --all-targets --all-features -- -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
