### PR TITLE
fix(compiler): align $.append_styles / $$ownership_validator preamble order with upstream

### DIFF
--- a/.changeset/tidy-dogs-appear.md
+++ b/.changeset/tidy-dogs-appear.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/compiler": patch
+---
+
+Fix the client preamble emitting `$$ownership_validator` before `$.append_styles` when `css: 'injected'` and dev-mode mutation validation are both active. Upstream unshifts `$$ownership_validator` before it unshifts `$.append_styles`, so the later unshift ends up closer to the front — the correct order is `$.push(...)`, `$.append_styles(...)`, then `$$ownership_validator = ...`. `$.append_styles` is now inserted at the same anchor point as `$$ownership_validator`, in the same call order as upstream's unshifts, instead of being built at an unrelated position in the component body.

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
@@ -1161,18 +1161,11 @@ fn transform_client_with_visitors(
     // of assembly — see below. Upstream unshifts it last so it becomes the
     // first line of the component, before `$.push`.)
 
-    // Add CSS styles injection if needed
-    if analysis.css.has_css && analysis.inject_styles {
-        // $.append_styles($$anchor, $$css)
-        component_body.push(b::stmt(
-            &context.arena,
-            b::call(
-                &context.arena,
-                b::member_path(&context.arena, "$.append_styles"),
-                vec![b::id("$$anchor"), b::id("$$css")],
-            ),
-        ));
-    }
+    // `$.append_styles` is unshifted upstream (transform-client.js lines
+    // 412-421) *after* the `$$ownership_validator` unshift (lines 379-383),
+    // so it lands closer to the front. See the insertion below, anchored at
+    // `preamble_end` alongside `$$ownership_validator`, which reproduces
+    // that call order instead of pushing here out of position.
 
     // Add instance-level snippets
     component_body.extend(instance_level_snippets);
@@ -1689,6 +1682,27 @@ fn transform_client_with_visitors(
         // Upstream unshifts this before `$.push` is unshifted, so it ends up
         // directly after the preamble.
         component_body.insert(preamble_end, ownership_decl);
+    }
+
+    // Add $.append_styles($$anchor, $$css) if needed
+    // Reference: transform-client.js lines 412-421
+    // Upstream unshifts this at the *same* front position as
+    // `$$ownership_validator` above, but its unshift call happens after
+    // (line 412 vs line 379), so it ends up ahead of `$$ownership_validator`
+    // once both land at `preamble_end` — inserting here, after the
+    // ownership-validator insert, reproduces that call order exactly.
+    if analysis.css.has_css && analysis.inject_styles {
+        component_body.insert(
+            preamble_end,
+            b::stmt(
+                &context.arena,
+                b::call(
+                    &context.arena,
+                    b::member_path(&context.arena, "$.append_styles"),
+                    vec![b::id("$$anchor"), b::id("$$css")],
+                ),
+            ),
+        );
     }
 
     // Bind static exports to props so that people can access them with bind:x

--- a/crates/rsvelte_core/src/lib.rs
+++ b/crates/rsvelte_core/src/lib.rs
@@ -38,13 +38,13 @@ pub use compiler::phases::phase1_parse::{ParseOptions, parse, parse_parallel};
 pub use compiler::print::{PrintError, PrintOptions, PrintResult, print};
 #[cfg(feature = "parallel")]
 pub use compiler::{
-    CompileError, CompileOptions, CompileResult, ExperimentalOptions, GenerateMode,
+    CompileError, CompileOptions, CompileResult, CssMode, ExperimentalOptions, GenerateMode,
     ModuleCompileOptions, Warning, WarningFilterFn, compile, compile_batch, compile_both,
     compile_module,
 };
 #[cfg(not(feature = "parallel"))]
 pub use compiler::{
-    CompileError, CompileOptions, CompileResult, ExperimentalOptions, GenerateMode,
+    CompileError, CompileOptions, CompileResult, CssMode, ExperimentalOptions, GenerateMode,
     ModuleCompileOptions, Warning, WarningFilterFn, compile, compile_both, compile_module,
 };
 #[doc(hidden)]

--- a/crates/rsvelte_core/tests/dev_ownership_validator_placement.rs
+++ b/crates/rsvelte_core/tests/dev_ownership_validator_placement.rs
@@ -13,7 +13,7 @@
 //!
 //! The corpus gates compile with `dev: false`, so nothing else covers this.
 
-use rsvelte_core::{CompileOptions, GenerateMode, compile};
+use rsvelte_core::{CompileOptions, CssMode, GenerateMode, compile};
 
 fn compile_client_dev(src: &str) -> String {
     let result = compile(
@@ -103,4 +103,58 @@ fn multiple_bindings_keep_attribute_order_inside_component_callback() {
          in attribute order, got:\n{out}"
     );
     assert_opens_arrow_body(&out, open);
+}
+
+/// Regression test for baseballyama/rsvelte#2073.
+///
+/// When `css: 'injected'` and dev-mode mutation validation are both active,
+/// upstream unshifts `$$ownership_validator` (transform-client.js:379-383)
+/// *before* it unshifts `$.append_styles` (transform-client.js:412-421), so
+/// the later unshift call lands closer to the front: the final preamble
+/// reads `$.push(...)`, `$.append_styles(...)`, `$$ownership_validator = …`.
+/// rsvelte used to build `$.append_styles` at an unrelated point in the
+/// component body (after the binding-group declarations), so it ended up
+/// *after* `$$ownership_validator` instead of before it. No corpus entry
+/// exercised this combination, so nothing caught the divergence.
+///
+/// Reuses the `<Popover.Root bind:open />` shape from the tests above (a
+/// verified `needs_mutation_validation` trigger) plus a `<style>` block to
+/// also set `analysis.inject_styles`.
+#[test]
+fn append_styles_precedes_ownership_validator_when_both_present() {
+    let src = r#"<script>
+	import * as Popover from './popover.js';
+	let { open = $bindable(false) } = $props();
+</script>
+
+<Popover.Root bind:open />
+
+<style>
+	button { color: red; }
+</style>"#;
+    let result = compile(
+        src,
+        CompileOptions {
+            filename: Some("Comp.svelte".to_string()),
+            generate: GenerateMode::Client,
+            dev: true,
+            css: CssMode::Injected,
+            ..Default::default()
+        },
+    )
+    .expect("compile");
+    let out = result.js.code;
+
+    let push = index_of(&out, "$.push(");
+    let append_styles = index_of(&out, "$.append_styles(");
+    let ownership_validator = index_of(
+        &out,
+        "$$ownership_validator = $.create_ownership_validator(",
+    );
+
+    assert!(
+        push < append_styles && append_styles < ownership_validator,
+        "expected `$.push`, then `$.append_styles`, then `$$ownership_validator` \
+         (matching upstream's unshift call order), got:\n{out}"
+    );
 }


### PR DESCRIPTION
## Summary

Fixes #2073

When `css: 'injected'` and dev-mode mutation validation are both active, rsvelte emitted `$$ownership_validator` before `$.append_styles` in the client component preamble — the reverse of upstream's order.

## Root cause

Upstream builds the front of the component body (`transform-client.js`, lines 371-426) via four sequential `unshift` calls onto the same array: store setup, `$$ownership_validator`, `$.append_styles`, then `$.push`. Because each `unshift` lands at the absolute front, a *later* unshift call ends up *closer* to the front. The `$$ownership_validator` unshift (line 379) happens before the `$.append_styles` unshift (line 412), so the final preamble reads:

```js
$.push(...);
$.append_styles(...);
var $$ownership_validator = $.create_ownership_validator(...);
```

rsvelte built `$.append_styles` inline at an unrelated point in the component body (after the binding-group declarations) instead of at the `preamble_end` anchor used for `$$ownership_validator`. This only became observable when both conditions were true simultaneously — no corpus entry exercised that combination, so nothing caught the divergence (found during the #2072 review).

## Fix

Move the `$.append_styles` insertion to the same `preamble_end` anchor as `$$ownership_validator`, inserted *after* it (matching upstream's later unshift call), so it lands ahead of `$$ownership_validator` — reproducing upstream's construction order structurally rather than special-casing the combination with a conditional order hack.

`crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs`:
- Removed the inline `$.append_styles` push that happened right after the binding-group declarations.
- Added the `$.append_styles` insertion at `preamble_end`, right after the existing `$$ownership_validator` insertion (same anchor, later insert call → ends up first).

## Testing

- Added `append_styles_precedes_ownership_validator_when_both_present` to `crates/rsvelte_core/tests/dev_ownership_validator_placement.rs`, reusing the existing `<Popover.Root bind:open />` `needs_mutation_validation` trigger plus a `<style>` block to also set `analysis.inject_styles`. Asserts `$.push` < `$.append_styles` < `$$ownership_validator` in the output.
- Manually verified byte-identical output against the official compiler (`submodules/svelte`) for the issue's repro shape (css:'injected' + dev + `bind:` mutation validation) via the napi binding, modulo the CSS sourcemap data-URI (a separate, already-documented client-map limitation, issue #1781).
- `cargo test --release -p rsvelte_core` for the directly relevant suites: `dev_ownership_validator_placement` (new + existing 2 tests), `compiler_fixtures` (includes the Compiler Snapshot suite), `runtime` (Runtime Runes/Legacy/Browser + Hydration), `ssr` — all pass.
- `cargo fmt` and `cargo clippy --all-targets --all-features -- -D warnings` pass clean.
- No corpus `known-failures` entries reference this combination (`css: 'injected'` is forced off in the corpus harness for component sources), consistent with the issue's note that nothing in the corpus covers it — nothing to shrink there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)