### PR TITLE
fix(compiler): resolve SSR `{@const}` reads through the render position's scope chain

### DIFF
--- a/.changeset/fix-ssr-const-scope-chain.md
+++ b/.changeset/fix-ssr-const-scope-chain.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/compiler": patch
+---
+
+SSR constant folding now resolves a `{@const}` / `{let}` / `let:` binding through the render position's lexical scope chain instead of a flat "every template scope" union, matching upstream's `scope.evaluate`. Two sibling fragments declaring the same name (e.g. `{#if a}…{:else}{@const x = 1}…{/if}{#key k}{@const x = 2}…{/key}`) previously made each read ambiguous, so the branch emitted `$.escape(x)` where the official compiler inlines the literal; the nearest declaration now wins and an out-of-scope read stops resolving at all.

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/scope_builder.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/scope_builder.rs
@@ -350,6 +350,21 @@ impl<'a> ScopeBuilder<'a> {
 
     /// Push a new porous (block-level) child scope and return the old scope index.
     /// Porous scopes inherit the parent's function_depth.
+    /// Record the scope a template node's fragment children live in. The key
+    /// must be UNIQUE per fragment — two fragments sharing a key silently
+    /// overwrite each other and Phase 3 then folds a sibling's `{@const}`
+    /// (issue #2059). Nodes owning several fragments key the extra ones off
+    /// offsets that cannot start a node (`{#await}`'s `+1` / `+2`) or a
+    /// dedicated map (`{#if}`'s alternate).
+    fn register_template_scope(&mut self, key: u32) {
+        let scope = self.current_scope;
+        let previous = self.template_scope_map.insert(key, scope);
+        debug_assert!(
+            previous.is_none(),
+            "template scope key {key} registered twice (scopes {previous:?} and {scope})"
+        );
+    }
+
     fn push_scope(&mut self) -> usize {
         let parent_depth = self.scopes[self.current_scope].function_depth;
         let new_scope = Scope::new_with_depth(Some(self.current_scope), parent_depth);
@@ -2461,8 +2476,7 @@ impl<'a> ScopeBuilder<'a> {
                 self.process_attributes(&component.attributes);
                 // Create a new scope for component children
                 let old_scope = self.push_scope();
-                self.template_scope_map
-                    .insert(component.start, self.current_scope);
+                self.register_template_scope(component.start);
                 // Declare let: directive bindings in the child scope
                 self.declare_let_directive_bindings(&component.attributes);
                 // Visit component children
@@ -2476,8 +2490,7 @@ impl<'a> ScopeBuilder<'a> {
             TemplateNode::SvelteBoundary(elem) => {
                 self.process_attributes(&elem.attributes);
                 let old_scope = self.push_scope();
-                self.template_scope_map
-                    .insert(elem.start, self.current_scope);
+                self.register_template_scope(elem.start);
                 self.visit_fragment(&elem.fragment);
                 self.pop_scope(old_scope);
             }
@@ -2495,8 +2508,7 @@ impl<'a> ScopeBuilder<'a> {
             TemplateNode::SvelteFragment(elem) => {
                 self.process_attributes(&elem.attributes);
                 let old_scope = self.push_scope();
-                self.template_scope_map
-                    .insert(elem.start, self.current_scope);
+                self.register_template_scope(elem.start);
                 self.declare_let_directive_bindings(&elem.attributes);
                 self.visit_fragment(&elem.fragment);
                 self.pop_scope(old_scope);
@@ -2504,8 +2516,7 @@ impl<'a> ScopeBuilder<'a> {
             TemplateNode::SvelteSelf(elem) => {
                 self.process_attributes(&elem.attributes);
                 let old_scope = self.push_scope();
-                self.template_scope_map
-                    .insert(elem.start, self.current_scope);
+                self.register_template_scope(elem.start);
                 self.declare_let_directive_bindings(&elem.attributes);
                 self.visit_fragment(&elem.fragment);
                 self.pop_scope(old_scope);
@@ -2513,8 +2524,7 @@ impl<'a> ScopeBuilder<'a> {
             TemplateNode::SvelteComponent(elem) => {
                 self.process_attributes(&elem.attributes);
                 let old_scope = self.push_scope();
-                self.template_scope_map
-                    .insert(elem.start, self.current_scope);
+                self.register_template_scope(elem.start);
                 self.declare_let_directive_bindings(&elem.attributes);
                 self.visit_fragment(&elem.fragment);
                 self.pop_scope(old_scope);
@@ -2522,8 +2532,7 @@ impl<'a> ScopeBuilder<'a> {
             TemplateNode::SvelteElement(elem) => {
                 self.process_attributes(&elem.attributes);
                 let old_scope = self.push_scope();
-                self.template_scope_map
-                    .insert(elem.start, self.current_scope);
+                self.register_template_scope(elem.start);
                 self.declare_let_directive_bindings(&elem.attributes);
                 self.visit_fragment(&elem.fragment);
                 self.pop_scope(old_scope);
@@ -2535,8 +2544,7 @@ impl<'a> ScopeBuilder<'a> {
             TemplateNode::SlotElement(elem) => {
                 self.process_attributes(&elem.attributes);
                 let old_scope = self.push_scope();
-                self.template_scope_map
-                    .insert(elem.start, self.current_scope);
+                self.register_template_scope(elem.start);
                 self.visit_fragment(&elem.fragment);
                 self.pop_scope(old_scope);
             }
@@ -2552,8 +2560,7 @@ impl<'a> ScopeBuilder<'a> {
 
         // Create a new scope for element children
         let old_scope = self.push_scope();
-        self.template_scope_map
-            .insert(element.start, self.current_scope);
+        self.register_template_scope(element.start);
         // Declare let: directive bindings in the child scope
         self.declare_let_directive_bindings(&element.attributes);
         self.visit_fragment(&element.fragment);
@@ -3209,8 +3216,7 @@ impl<'a> ScopeBuilder<'a> {
 
         // Map the each block's start position to its scope index
         // This allows Phase 2 visitors to set context.scope when entering the each block body
-        self.template_scope_map
-            .insert(block.start, self.current_scope);
+        self.register_template_scope(block.start);
 
         // Declare the item binding(s) - handle destructuring patterns
         if let Some(context) = block.context.as_ref() {
@@ -3388,8 +3394,7 @@ impl<'a> ScopeBuilder<'a> {
         let old_scope = self.push_scope();
         // Register this scope in template_scope_map so that declaration-tag
         // bindings inside the consequent are visible to the server evaluator.
-        self.template_scope_map
-            .insert(block.start, self.current_scope);
+        self.register_template_scope(block.start);
         self.visit_fragment(&block.consequent);
         self.pop_scope(old_scope);
 
@@ -3412,8 +3417,7 @@ impl<'a> ScopeBuilder<'a> {
         if let Some(ref pending) = block.pending {
             let old_scope = self.push_scope();
             // Map block.start to the pending scope so Phase 2 analysis can switch to it
-            self.template_scope_map
-                .insert(block.start, self.current_scope);
+            self.register_template_scope(block.start);
             self.visit_fragment(pending);
             self.pop_scope(old_scope);
         }
@@ -3424,8 +3428,7 @@ impl<'a> ScopeBuilder<'a> {
 
             // Map the await block's start to the then scope for Phase 2 scope lookup
             // We use the then fragment's node positions if available
-            self.template_scope_map
-                .insert(block.start + 1, self.current_scope); // +1 to differentiate from pending
+            self.register_template_scope(block.start + 1); // +1 to differentiate from pending
 
             // Declare the then value binding(s) - handle destructuring patterns
             if let Some(ref value) = block.value {
@@ -3442,8 +3445,7 @@ impl<'a> ScopeBuilder<'a> {
             let old_scope = self.push_scope();
 
             // Map the await block's start to the catch scope
-            self.template_scope_map
-                .insert(block.start + 2, self.current_scope); // +2 to differentiate from then
+            self.register_template_scope(block.start + 2); // +2 to differentiate from then
 
             // Declare the error binding(s) - handle destructuring patterns
             if let Some(ref error) = block.error {
@@ -3465,8 +3467,7 @@ impl<'a> ScopeBuilder<'a> {
         let old_scope = self.push_scope();
         // Register this scope so declaration-tag bindings inside {#key} blocks
         // are visible to the server evaluator's template-scope lookup.
-        self.template_scope_map
-            .insert(block.start, self.current_scope);
+        self.register_template_scope(block.start);
         self.visit_fragment(&block.fragment);
         self.pop_scope(old_scope);
     }
@@ -3495,8 +3496,7 @@ impl<'a> ScopeBuilder<'a> {
         let old_scope = self.push_scope();
 
         // Map the snippet block's start position to its scope index
-        self.template_scope_map
-            .insert(block.start, self.current_scope);
+        self.register_template_scope(block.start);
         // Record that this scope is a snippet-body scope: template declarations
         // made inside it must not be constant-folded from sibling scopes.
         self.snippet_scope_indices.insert(self.current_scope);

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/mod.rs
@@ -204,6 +204,13 @@ pub struct ServerTransformState<'a> {
     /// binding's value, whereas a snippet-param read still folds. Pushed by the
     /// component slot-body builder, popped after.
     pub slot_let_shadows: Vec<rustc_hash::FxHashSet<String>>,
+    /// Index into `analysis.root.all_scopes` of the scope the nodes currently
+    /// being emitted live in — the AST mirror of upstream's `state.scope`
+    /// (`set_scope` in `phases/scope.js`). Every scope-creating template node
+    /// swaps this around its fragment children via [`Self::enter_template_scope`],
+    /// so `scope.evaluate` resolves an identifier through the real lexical chain
+    /// instead of a flat "every template scope" union.
+    pub current_scope_index: usize,
 }
 
 /// One per-fragment async `{@const}` group — the AST mirror of upstream's
@@ -277,7 +284,36 @@ impl<'a> ServerTransformState<'a> {
             attr_optimiser: None,
             shadowed_names: Vec::new(),
             slot_let_shadows: Vec::new(),
+            current_scope_index: analysis.root.instance_scope_index,
         }
+    }
+
+    /// Enter the scope the scope-builder created for the fragment children of
+    /// the template node starting at `node_start`, returning the previous scope
+    /// index to hand back to [`Self::restore_scope`]. Nodes that own no scope
+    /// (or whose scope was not recorded) leave the current one in place, exactly
+    /// like upstream's `set_scope` (`scopes.get(node) ?? state.scope`).
+    pub fn enter_template_scope(&mut self, node_start: u32) -> usize {
+        let saved = self.current_scope_index;
+        if let Some(&idx) = self.analysis.root.template_scope_map.get(&node_start) {
+            self.current_scope_index = idx;
+        }
+        saved
+    }
+
+    /// Enter an `{#if}`'s `{:else}` scope (an if-block owns two fragment scopes,
+    /// so its alternate lives in its own map under the block's start).
+    pub fn enter_if_alternate_scope(&mut self, node_start: u32) -> usize {
+        let saved = self.current_scope_index;
+        if let Some(&idx) = self.analysis.root.if_alternate_scope_map.get(&node_start) {
+            self.current_scope_index = idx;
+        }
+        saved
+    }
+
+    /// Restore the scope saved by [`Self::enter_template_scope`].
+    pub fn restore_scope(&mut self, saved: usize) {
+        self.current_scope_index = saved;
     }
 
     /// Collect all the names currently shadowed by enclosing snippet / slot
@@ -361,10 +397,7 @@ impl<'a> ServerTransformState<'a> {
 
     /// Build the [`EvalCtx`](server::evaluate::EvalCtx) for the SSR
     /// constant-folding port, borrowing this state's analysis / source and the
-    /// precomputed [`EvalInputs`]. The `current_scope_index` is left `None` here
-    /// (snippet-scope tracking is not yet threaded through the AST visitors); a
-    /// `None` simply keeps the historical non-tracked behaviour in
-    /// `template_binding_is_reachable`.
+    /// precomputed [`EvalInputs`].
     pub(crate) fn eval_ctx(
         &self,
     ) -> crate::compiler::phases::phase3_transform::server::evaluate::EvalCtx<'_> {
@@ -374,7 +407,7 @@ impl<'a> ServerTransformState<'a> {
             source: self.source,
             use_async: self.eval_inputs.use_async,
             top_level_blocker_map: &self.eval_inputs.top_level_blocker_map,
-            current_scope_index: None,
+            current_scope_index: Some(self.current_scope_index),
             template_scopes_cache: &self.eval_inputs.template_scopes_cache,
         }
     }

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/tests.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/tests.rs
@@ -417,11 +417,10 @@ fn norm_blocks(s: &str) -> String {
 /// - **effect-statement elision** (`transition-each-4`): `$effect(…)` /
 ///   `$effect.pre(…)` statements inside a template IIFE arrow body are dropped.
 ///
-/// `component-let-directive` is NOT yet matched: it needs per-slot
-/// `scope.evaluate` scope tracking (the AST `eval_ctx` `current_scope_index` is
-/// `None`) so a `<Counter let:count>` named slot folds the component-level
-/// `count` const while the default slot keeps the `let:count` param read — an
-/// orthogonal evaluate-machinery gap.
+/// - **per-slot scope** (`component-let-directive`): `eval_ctx`'s
+///   `current_scope_index` now tracks the render position, so a
+///   `<Counter let:count>` named slot folds the component-level `count` while
+///   the default slot keeps the `let:count` parameter read.
 #[test]
 fn ast_matches_oracle_snippet_dynamic_component_cluster() {
     let fixtures: &[(&str, &str)] = &[

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/visitors/await_block.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/visitors/await_block.rs
@@ -86,7 +86,12 @@ pub fn visit_await_block<'a>(node: &AwaitBlock<'a>, state: &mut ServerTransformS
 
     // Pending callback: `() => { <pending body> }` (thunk of a block).
     let pending_block = match &node.pending {
-        Some(frag) => build_fragment_block(frag, false, state),
+        Some(frag) => {
+            let saved = state.enter_template_scope(node.start);
+            let block = build_fragment_block(frag, false, state);
+            state.restore_scope(saved);
+            block
+        }
         None => state.b.block(vec![]),
     };
     let pending_thunk = state
@@ -107,8 +112,15 @@ pub fn visit_await_block<'a>(node: &AwaitBlock<'a>, state: &mut ServerTransformS
         super::snippet_block::collect_param_pattern_names(v, &mut shadow);
     }
     state.shadowed_names.push(shadow);
+    // The `then` fragment's scope is recorded under `block.start + 1` (an await
+    // block owns three fragment scopes under one start offset).
     let then_block = match &node.then {
-        Some(frag) => build_fragment_block(frag, false, state),
+        Some(frag) => {
+            let saved = state.enter_template_scope(node.start + 1);
+            let block = build_fragment_block(frag, false, state);
+            state.restore_scope(saved);
+            block
+        }
         None => state.b.block(vec![]),
     };
     state.shadowed_names.pop();

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/visitors/component.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/visitors/component.rs
@@ -42,9 +42,8 @@
 //! - LetDirective / scoped slots ARE emitted: a slot whose tag (or, for the
 //!   default slot, the component / a `<svelte:fragment>` child) carries
 //!   `let:x={pattern}` gets a second destructured `{ x: <pattern>, … }` slot-fn
-//!   parameter (`build_component_children` / `lets_to_pattern`). Per-slot scope
-//!   binding (`node.metadata.scopes`) for read-rewriting the slot body is the
-//!   remaining gap — the body renders in the surrounding `state` scope.
+//!   parameter (`build_component_children` / `lets_to_pattern`), and the slot
+//!   body renders in the COMPONENT's scope (写经 `node.metadata.scopes`).
 //! - AttachTag (`@attach`) blocker bookkeeping is skipped.
 //! - custom-CSS `--*` props (`$.css_props`) are skipped.
 //! - async blocker wrapping (`optimiser.render_block`).
@@ -113,6 +112,7 @@ pub fn visit_component<'a>(
         },
         dynamic,
         name_src,
+        node.start,
         state,
     );
 }
@@ -131,6 +131,7 @@ pub fn visit_svelte_component<'a>(
         |s| s.visit_expr(&node.expression),
         true,
         this_src,
+        node.start,
         state,
     );
 }
@@ -149,6 +150,7 @@ pub fn visit_svelte_self<'a>(
         false,
         // `<svelte:self>` is excluded from the name-blocker check upstream.
         None,
+        node.start,
         state,
     );
 }
@@ -169,6 +171,9 @@ fn build_inline_component<'a, 'b>(
     // component name itself reads (`<X/>` / `<svelte:component this={X}/>` where
     // `X` is `$derived(await …)`). `None` for `<svelte:self>` (never blocked).
     name_expr_source: Option<String>,
+    // Start offset of the component node — the `template_scope_map` key of the
+    // scope its child fragment (and `let:` bindings) live in.
+    scope_start: u32,
     state: &mut ServerTransformState<'a>,
 ) {
     let expression = make_expression(state);
@@ -270,6 +275,9 @@ fn build_inline_component<'a, 'b>(
     // Children / slots / snippet props (upstream `shared/component.js` lines
     // 162-295). Returns any hoisted snippet-function declarations that must wrap
     // the component call in a `{ ... }` block.
+    // The child fragment lives in the component's own scope (it holds the
+    // `let:` bindings), so slot bodies resolve identifiers there.
+    let saved_scope = state.enter_template_scope(scope_start);
     let snippet_declarations = build_component_children(
         fragment,
         has_children_prop,
@@ -277,6 +285,7 @@ fn build_inline_component<'a, 'b>(
         &mut groups,
         state,
     );
+    state.restore_scope(saved_scope);
 
     let props_expression = build_props_expression(groups, state);
 
@@ -376,9 +385,6 @@ fn build_inline_component<'a, 'b>(
 /// call in a hoisting block.
 ///
 /// 写经 gaps (KNOWN GAP):
-/// - Per-slot `node.metadata.scopes` are not tracked on the AST pipeline, so the
-///   default-slot body is rendered in the surrounding `state` rather than the
-///   component scope. This only matters for read-rewriting of slot bodies.
 /// - The `$.invalid_default_snippet` error path (a `children` attribute *and* a
 ///   default-slot body) is not emitted; the default body is simply dropped when
 ///   `has_children_prop` is set, matching the common "render tag already used"
@@ -708,7 +714,9 @@ fn build_snippet_declaration<'a>(
     }
     state.shadowed_names.push(shadow);
     // SnippetBlock body IS an `is_text_first` parent.
+    let saved_scope = state.enter_template_scope(snippet.start);
     let body_block = super::shared::build_fragment_body(&snippet.body.nodes, true, true, state);
+    state.restore_scope(saved_scope);
     state.shadowed_names.pop();
     let fn_body = state.b.body(body_block);
     state.b.function_declaration(name, params, fn_body, false)

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/visitors/each_block.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/visitors/each_block.rs
@@ -175,7 +175,9 @@ pub fn visit_each_block<'a>(node: &EachBlock<'a>, state: &mut ServerTransformSta
         state.slot_let_shadows.push(each_shadow);
     }
     // EachBlock body IS an `is_text_first` parent (upstream `clean_nodes`).
+    let saved_scope = state.enter_template_scope(node.start);
     each_body.extend(build_fragment_body(&node.body.nodes, true, false, state));
+    state.restore_scope(saved_scope);
     if pushed_shadow {
         state.slot_let_shadows.pop();
         state.shadowed_names.pop();
@@ -205,7 +207,11 @@ pub fn visit_each_block<'a>(node: &EachBlock<'a>, state: &mut ServerTransformSta
         // EachBlock node, so it IS an `is_text_first` parent (upstream
         // `clean_nodes`: `parent.type === 'EachBlock'`) — a text-first fallback
         // gets a leading `<!---->` anchor, same as the loop body.
+        // rsvelte's scope builder visits the fallback inside the each block's
+        // scope, so enter it here too (the item bindings are shadow-vetoed above).
+        let saved_scope = state.enter_template_scope(node.start);
         let mut fallback_body = build_fragment_body(&fallback.nodes, true, false, state);
+        state.restore_scope(saved_scope);
         let b = state.b;
         let open_else_push = b.stmt(b.call("$$renderer.push", vec![b.string(BLOCK_OPEN_ELSE)]));
         fallback_body.insert(0, open_else_push);

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/visitors/if_block.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/visitors/if_block.rs
@@ -171,8 +171,11 @@ fn build_if_chain<'a>(
     let b = state.b;
     let test = build_test(node, state);
 
-    // Consequent block, with its branch marker unshifted to the front.
+    // Consequent block, with its branch marker unshifted to the front. Its
+    // `{@const}` declarations live in the consequent's own scope.
+    let saved = state.enter_template_scope(node.start);
     let consequent = build_branch_block(&node.consequent, consequent_marker_index, state);
+    state.restore_scope(saved);
 
     // Resolve the alternate.
     let alternate = build_alternate(node, consequent_marker_index + 1, state);
@@ -210,17 +213,22 @@ fn build_alternate<'a>(
     let b = state.b;
 
     if let Some(frag) = node.alternate.as_ref() {
+        // The alternate fragment owns its own scope (an if-block owns two).
+        let saved = state.enter_if_alternate_scope(node.start);
         // A single FLATTENABLE `{:else if}` recurses inline as `else if`.
-        if let Some(nested) = single_elseif(frag)
+        let out = if let Some(nested) = single_elseif(frag)
             && flattens_into(nested, node, state)
         {
-            return build_if_chain(nested, next_marker_index, state);
-        }
-        // Otherwise a terminal `else { <!--[-1--> ... }` — either a real
-        // `{:else}` body, or a NON-flattening else-if (await / new blockers)
-        // living in the fragment as a nested IfBlock that `build_fragment_body`
-        // re-visits, producing its OWN `create_child_block` wrap + `<!--]-->`.
-        return build_branch_block(frag, -1, state);
+            build_if_chain(nested, next_marker_index, state)
+        } else {
+            // Otherwise a terminal `else { <!--[-1--> ... }` — either a real
+            // `{:else}` body, or a NON-flattening else-if (await / new blockers)
+            // living in the fragment as a nested IfBlock that `build_fragment_body`
+            // re-visits, producing its OWN `create_child_block` wrap + `<!--]-->`.
+            build_branch_block(frag, -1, state)
+        };
+        state.restore_scope(saved);
+        return out;
     }
 
     // No alternate at all — upstream still emits `else { $$renderer.push('<!--[-1-->'); }`.

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/visitors/key_block.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/visitors/key_block.rs
@@ -35,9 +35,12 @@ pub fn visit_key_block<'a>(node: &KeyBlock<'a>, state: &mut ServerTransformState
         .template
         .push(TemplateEntry::Literal(EMPTY_COMMENT.to_string()));
 
-    // The body fragment rendered as a `{ ... }` block statement.
+    // The body fragment rendered as a `{ ... }` block statement, in the key
+    // block's own scope (its `{@const}`s must not leak to siblings).
     // KeyBlock body is NOT an `is_text_first` parent.
+    let saved = state.enter_template_scope(node.start);
     let block = build_fragment_block(&node.fragment, false, state);
+    state.restore_scope(saved);
     state.template.push(TemplateEntry::Stmt(block));
 
     // `<!---->` anchor after the body.

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/visitors/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/visitors/mod.rs
@@ -86,7 +86,9 @@ pub fn visit_node<'a>(node: &TemplateNode<'a>, state: &mut ServerTransformState<
             // Port of upstream server `SvelteFragment` — push the visited child
             // fragment as a `{ ... }` block statement.
             // SvelteFragment is NOT an `is_text_first` parent.
+            let saved_scope = state.enter_template_scope(node.start);
             let block = shared::build_fragment_block(&node.fragment, false, state);
+            state.restore_scope(saved_scope);
             state.template.push(TemplateEntry::Stmt(block));
         }
         // `<svelte:window>` / `<svelte:document>` have no upstream server visitor

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/visitors/shared.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/visitors/shared.rs
@@ -105,6 +105,24 @@ pub fn process_children_inner<'a, N: AsRef<TemplateNode<'a>>>(
     is_block_parent: bool,
     state: &mut ServerTransformState<'a>,
 ) {
+    // An element's children live in the element's OWN scope (it holds the
+    // `let:` bindings and any `{@const}` declared among the children), mirroring
+    // upstream `RegularElement.js`'s `scope: scopes.get(node.fragment)`. The
+    // attributes are built by the caller, in the enclosing scope.
+    let saved_scope = parent.map(|el| state.enter_template_scope(el.start));
+    process_children_scoped(nodes, parent, namespace, is_block_parent, state);
+    if let Some(saved) = saved_scope {
+        state.restore_scope(saved);
+    }
+}
+
+fn process_children_scoped<'a, N: AsRef<TemplateNode<'a>>>(
+    nodes: &[N],
+    parent: Option<&RegularElement<'_>>,
+    namespace: &str,
+    is_block_parent: bool,
+    state: &mut ServerTransformState<'a>,
+) {
     // 写经 upstream `RegularElement` `preserve_whitespace: state.preserve_whitespace
     // || name === 'pre' || name === 'textarea'`: STICKY — once an ancestor `<pre>`
     // / `<textarea>` turned it on (recorded in `state.preserve_whitespace`), every

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/visitors/slot_element.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/visitors/slot_element.rs
@@ -117,7 +117,9 @@ pub fn visit_slot_element<'a>(node: &SlotElement<'a>, state: &mut ServerTransfor
         // SnippetBlock / EachBlock / SvelteComponent / SvelteBoundary / Component /
         // SvelteSelf only), so leading text does NOT get a `<!---->` anchor.
         // `b.thunk(BlockStatement)` → `() => { <body> }`.
+        let saved_scope = state.enter_template_scope(node.start);
         let body = build_fragment_body(&node.fragment.nodes, false, true, state);
+        state.restore_scope(saved_scope);
         let params = state.b.params(vec![], None);
         state.b.arrow(params, state.b.body(body), false, false)
     };

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/visitors/snippet_block.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/visitors/snippet_block.rs
@@ -78,7 +78,9 @@ pub fn visit_snippet_block<'a>(node: &SnippetBlock<'a>, state: &mut ServerTransf
     // Body: render the fragment as a `{ ... }` block, then reuse its statements
     // as the function body.
     // SnippetBlock body IS an `is_text_first` parent (upstream `clean_nodes`).
+    let saved_scope = state.enter_template_scope(node.start);
     let body_block = super::shared::build_fragment_body(&node.body.nodes, true, true, state);
+    state.restore_scope(saved_scope);
     let fn_body = b.body(body_block);
 
     state.shadowed_names.pop();

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/visitors/svelte_boundary.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/visitors/svelte_boundary.rs
@@ -117,8 +117,11 @@ pub fn visit_svelte_boundary<'a>(node: &SvelteElement<'a>, state: &mut ServerTra
     //   visit(snippet.body), block_close])`). The real children are skipped.
     // - otherwise → `[push('<!--[-->'), <children block>, push('<!--]-->')]`.
     // SvelteBoundary slot / snippet body IS an `is_text_first` parent.
+    let saved_scope = state.enter_template_scope(node.start);
     let children_body: Vec<Statement<'a>> = if let Some(pending) = pending_snippet {
+        let saved_pending = state.enter_template_scope(pending.start);
         let pending_block = build_fragment_block(&pending.body, true, state);
+        state.restore_scope(saved_pending);
         let b = state.b;
         vec![
             b.stmt(b.call("$$renderer.push", vec![marker(state, BLOCK_OPEN_ELSE)])),
@@ -134,6 +137,7 @@ pub fn visit_svelte_boundary<'a>(node: &SvelteElement<'a>, state: &mut ServerTra
             b.stmt(b.call("$$renderer.push", vec![marker(state, BLOCK_CLOSE)])),
         ]
     };
+    state.restore_scope(saved_scope);
 
     // No `failed` branch → skip the boundary wrapper, push children_body inline.
     if failed_snippet.is_none() && failed_attribute.is_none() {
@@ -245,7 +249,9 @@ fn build_boundary_snippet<'a>(
     }
     let params = b.params(patterns, None);
     // SnippetBlock body IS an `is_text_first` parent.
+    let saved_scope = state.enter_template_scope(snippet.start);
     let body_block = super::shared::build_fragment_body(&snippet.body.nodes, true, true, state);
+    state.restore_scope(saved_scope);
     let fn_body = state.b.body(body_block);
     state.b.function_declaration(name, params, fn_body, false)
 }

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/visitors/svelte_element.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/visitors/svelte_element.rs
@@ -131,7 +131,9 @@ pub fn visit_svelte_element<'a>(
 
     // -- children -----------------------------------------------------------
     // SvelteElement children are NOT an `is_text_first` parent.
+    let saved_scope = state.enter_template_scope(node.start);
     let children_body = build_fragment_body(&node.fragment.nodes, false, false, state);
+    state.restore_scope(saved_scope);
     let b = state.b;
     let children_thunk = if children_body.is_empty() {
         None

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/evaluate.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/evaluate.rs
@@ -9,11 +9,12 @@
 //! `$.stringify(...)`.
 //!
 //! Differences from upstream, by necessity of the text-based architecture:
-//! - Identifier resolution goes through `analysis.root.bindings` (all scopes).
-//!   Because the rsvelte scope tree is not threaded through the server
-//!   visitors, a name is only resolved when EVERY binding with that name
-//!   agrees on the same known value — same-name bindings in different scopes
-//!   (shadowing) therefore safely degrade to "unknown".
+//! - Identifier resolution goes through `analysis.root.bindings` rather than a
+//!   `Scope` object, filtered by the render position's scope chain
+//!   (`EvalCtx::current_scope_index`, threaded by the server visitors) so a
+//!   sibling fragment's `{@const}` is invisible and the nearest declaration
+//!   wins. Without a known render position, a name resolves only when EVERY
+//!   binding with that name agrees on the same known value.
 //! - `binding.initial` is a string: raw source text for literal initials
 //!   (`'world'`, `12`, `true`) or an estree-JSON dump for `$derived` / `@const`
 //!   initials. Both forms are handled.
@@ -757,33 +758,55 @@ impl<'a> EvalCtx<'a> {
     }
 
     /// Whether a template-scope binding declared in `scope_index` is lexically
-    /// reachable from the fragment this generator is emitting.
+    /// reachable from the fragment this generator is emitting — i.e. whether
+    /// `scope_index` is on the scope chain of the render position, mirroring
+    /// upstream's `scope.get(name)` walking `Scope#parent`.
     ///
-    /// Snippet bodies become separate functions in the generated output, so a
-    /// template declaration (`{@const}` / `{const}` / `{let}`) made inside one
-    /// snippet must NOT be substituted into a sibling snippet or the enclosing
-    /// fragment — upstream resolves these through `scope.evaluate`, where the
-    /// binding is simply not on the scope chain. Non-snippet template scopes
-    /// (element / each / component / boundary fragments) keep the historical
-    /// behaviour (the server generator does not track those descents; the
-    /// same-name agreement rule in `evaluate_identifier` covers shadowing).
+    /// A template declaration (`{@const}` / `{const}` / `{let}` / `let:` / each
+    /// item) belongs to exactly one fragment, so a sibling fragment must never
+    /// substitute it: `{#if a}…{:else}{@const x = 1}…{/if}{#key k}{@const x = 2}…{/key}`
+    /// has two unrelated `x` bindings, and each branch must fold its own.
+    ///
+    /// With no known render position (`current_scope_index == None`) the caller
+    /// has no chain to walk, so every template scope stays a candidate and the
+    /// same-name agreement rule in [`Self::evaluate_identifier`] decides.
     fn template_binding_is_reachable(&self, scope_index: usize) -> bool {
         let Some(analysis) = self.analysis else {
             return true;
         };
-        if !analysis.root.snippet_scope_indices.contains(&scope_index) {
-            // Not a snippet-body scope: keep historical (non-tracked) behaviour.
+        let Some(mut current) = self.current_scope_index else {
             return true;
-        }
-        // Walk the scope chain from the current fragment's scope upward.
-        let mut current = self.current_scope_index;
-        while let Some(idx) = current {
-            if idx == scope_index {
+        };
+        loop {
+            if current == scope_index {
                 return true;
             }
-            current = analysis.root.all_scopes.get(idx).and_then(|s| s.parent);
+            match analysis.root.all_scopes.get(current).and_then(|s| s.parent) {
+                Some(parent) => current = parent,
+                None => return false,
+            }
         }
-        false
+    }
+
+    /// Depth of `scope_index` on the render position's scope chain (0 = the
+    /// render position's own scope). `None` when it is not on the chain.
+    /// Used to pick the INNERMOST of several same-named reachable bindings,
+    /// mirroring `scope.get(name)` returning the nearest declaration.
+    fn scope_chain_depth(&self, scope_index: usize) -> Option<u32> {
+        let analysis = self.analysis?;
+        let mut current = self.current_scope_index?;
+        let mut depth = 0u32;
+        loop {
+            if current == scope_index {
+                return Some(depth);
+            }
+            current = analysis
+                .root
+                .all_scopes
+                .get(current)
+                .and_then(|s| s.parent)?;
+            depth += 1;
+        }
     }
 
     /// Resolve an identifier, mirroring upstream's `Identifier` branch.
@@ -886,6 +909,20 @@ impl<'a> EvalCtx<'a> {
             if by_scope.len() < bindings.len() {
                 bindings = by_scope.into_values().collect();
             }
+        }
+
+        // With a known render position the scope chain disambiguates shadowing
+        // exactly like upstream `scope.get(name)`: the NEAREST declaration wins
+        // and the outer ones are invisible. Without one, every candidate stays
+        // and the agreement rule below merges their value sets.
+        if bindings.len() > 1
+            && self.current_scope_index.is_some()
+            && let Some(min_depth) = bindings
+                .iter()
+                .filter_map(|b| self.scope_chain_depth(b.scope_index))
+                .min()
+        {
+            bindings.retain(|b| self.scope_chain_depth(b.scope_index) == Some(min_depth));
         }
 
         if !bindings.is_empty() {

--- a/crates/rsvelte_core/tests/ssr_const_scope_2059.rs
+++ b/crates/rsvelte_core/tests/ssr_const_scope_2059.rs
@@ -1,0 +1,116 @@
+//! SSR constant folding must resolve a `{@const}` through the render position's
+//! LEXICAL SCOPE CHAIN, not through a flat "every template scope" union.
+//!
+//! Issue #2059: two sibling fragments each declaring `{@const x = …}` are
+//! unrelated scopes, so each read folds to its own value. Before the server
+//! visitors threaded `state.scope` (upstream `set_scope`), both bindings were
+//! candidates for every read — first producing the NEIGHBOUR's value, then (once
+//! the alternate scope joined the candidate set) bailing out of folding entirely
+//! and emitting `$.escape(x)` where official emits the literal.
+
+use rsvelte_core::{CompileOptions, GenerateMode, compile};
+
+#[track_caller]
+fn ssr(source: &str) -> String {
+    compile(
+        source,
+        CompileOptions {
+            generate: GenerateMode::Server,
+            ..Default::default()
+        },
+    )
+    .expect("component should compile")
+    .js
+    .code
+}
+
+#[track_caller]
+fn assert_contains_all(source: &str, needles: &[&str]) {
+    let code = ssr(source);
+    for needle in needles {
+        assert!(
+            code.contains(needle),
+            "expected {needle:?} in SSR output:\n{code}"
+        );
+    }
+}
+
+#[track_caller]
+fn assert_contains_none(source: &str, needles: &[&str]) {
+    let code = ssr(source);
+    for needle in needles {
+        assert!(
+            !code.contains(needle),
+            "did not expect {needle:?} in SSR output:\n{code}"
+        );
+    }
+}
+
+/// The issue's repro: an `{:else}` arm and a following `{#key}` block each
+/// declare `x`. Official folds each branch to its own constant.
+#[test]
+fn sibling_const_tags_fold_to_their_own_value() {
+    let source =
+        "{#if a}<p>A</p>{:else}{@const x = 1}<p>{x}</p>{/if}{#key k}{@const x = 2}<p>{x}</p>{/key}";
+    assert_contains_all(source, &["<p>1</p>", "<p>2</p>"]);
+    assert_contains_none(source, &["$.escape(x)"]);
+}
+
+/// The `{#each}`-adjacent variant from the issue (the each block's `{@const}`
+/// must not veto the `{:else}` fold, and vice versa).
+#[test]
+fn each_adjacent_const_tags_fold_to_their_own_value() {
+    let source = "{#if a}<p>A</p>{:else}{@const x = 1}<p>{x}</p>{/if}{#each items as item}{@const x = 2}<p>{x}</p>{/each}";
+    assert_contains_all(source, &["<p>1</p>", "<p>2</p>"]);
+    assert_contains_none(source, &["$.escape(x)"]);
+}
+
+/// Both arms of one `{#if}` are separate scopes too.
+#[test]
+fn if_consequent_and_alternate_consts_are_independent() {
+    let source = "{#if a}{@const x = 'yes'}<p>{x}</p>{:else}{@const x = 'no'}<p>{x}</p>{/if}";
+    assert_contains_all(source, &["<p>yes</p>", "<p>no</p>"]);
+    assert_contains_none(source, &["$.escape(x)"]);
+}
+
+/// An inner `{@const}` SHADOWS the enclosing fragment's same-named one: the
+/// nearest declaration on the chain wins (upstream `scope.get(name)`), rather
+/// than the two merging into an ambiguous value set.
+#[test]
+fn inner_const_shadows_outer_const() {
+    let source = "{#key k}{@const x = 1}<p>{x}</p>{#key k2}{@const x = 2}<p>{x}</p>{/key}{/key}";
+    assert_contains_all(source, &["<p>1</p>", "<p>2</p>"]);
+    assert_contains_none(source, &["$.escape(x)"]);
+}
+
+/// `<svelte:boundary>` children are their own scope too.
+#[test]
+fn boundary_scoped_consts_do_not_cross_siblings() {
+    let source = "<svelte:boundary>{@const x = 1}<p>{x}</p></svelte:boundary><svelte:boundary>{@const x = 2}<p>{x}</p></svelte:boundary>";
+    assert_contains_all(source, &["<p>1</p>", "<p>2</p>"]);
+    assert_contains_none(source, &["$.escape(x)"]);
+}
+
+/// A snippet body's `{@const}` must not be substituted into a sibling snippet.
+#[test]
+fn snippet_consts_do_not_cross_snippets() {
+    let source = "{#snippet a()}{@const x = 1}<p>{x}</p>{/snippet}{#snippet b()}{@const x = 2}<p>{x}</p>{/snippet}{@render a()}{@render b()}";
+    assert_contains_all(source, &["<p>1</p>", "<p>2</p>"]);
+    assert_contains_none(source, &["$.escape(x)"]);
+}
+
+/// A read OUTSIDE any of the declaring fragments resolves to no binding at all,
+/// so it stays dynamic instead of folding to an arbitrary sibling's value.
+#[test]
+fn read_outside_the_declaring_scope_stays_dynamic() {
+    let source = "{#key k}{@const x = 1}<p>{x}</p>{/key}<p>{x}</p>";
+    let code = ssr(source);
+    assert!(
+        code.contains("<p>1</p>"),
+        "in-scope read should fold:\n{code}"
+    );
+    assert!(
+        code.contains("$.escape(x)"),
+        "out-of-scope read should stay dynamic:\n{code}"
+    );
+}


### PR DESCRIPTION
Fixes #2059

## Problem

`3_transform/server/evaluate.rs` treated `template_scope_map.values()` (plus
`if_alternate_scope_map.values()`) as ONE flat set of "template-visible" scopes.
Every `{@const}` / `{let}` / `let:` / each-item binding anywhere in the template
was therefore a candidate for every read, no matter which fragment the read was
in.

```svelte
{#if a}<p>A</p>{:else}{@const x = 1}<p>{x}</p>{/if}{#key k}{@const x = 2}<p>{x}</p>{/key}
```

- official: `<p>1</p>` and `<p>2</p>`
- rsvelte before #2057: `<p>2</p>` in **both** branches (wrong value — the
  `block.end` key collision reported in the issue title)
- rsvelte on `main` (after #2057 moved the alternate scope to its own
  start-keyed map): the wrong-value class is gone, but both `x` bindings are
  still candidates, the scope-insensitive agreement rule bails as ambiguous, and
  each branch emits `$.escape(x)` where official inlines the literal

## Fix

Upstream never has this problem: `phases/scope.js` keys scopes by **Fragment
node identity** and `set_scope` swaps `state.scope` as the walker descends, so
`scope.evaluate` resolves an identifier through `Scope#parent` and simply cannot
see a sibling fragment's declaration.

This PR ports that:

- `ServerTransformState::current_scope_index` tracks the render position (the
  Rust mirror of upstream `state.scope`), swapped by
  `enter_template_scope` / `enter_if_alternate_scope` / `restore_scope` in every
  scope-creating server visitor — element children, component / `svelte:self` /
  `svelte:component` slot bodies, `svelte:element`, `svelte:fragment`,
  `svelte:boundary` (incl. its `pending` / `failed` snippets), `slot`, snippet
  bodies, and the `{#if}` / `{:else}` / `{#each}` (+ fallback) / `{#key}` /
  `{#await}` (pending + then) fragments.
- `EvalCtx::template_binding_is_reachable` now walks that chain for **all**
  template scopes (it was snippet-scopes-only), and a new `scope_chain_depth`
  keeps only the innermost of several same-named reachable bindings — upstream's
  `scope.get(name)` semantics. The old union/agreement rule survives only as the
  fallback for a `None` render position.
- `ScopeBuilder::register_template_scope` replaces the raw `template_scope_map`
  inserts and `debug_assert!`s that each fragment key is registered once, so the
  key-collision class this issue is named after fails loudly instead of silently
  overwriting a scope. (Every insert already keys off a node `start`; `{#await}`
  uses `start + 1` / `start + 2` for `then` / `catch`, offsets no node can start
  at, and `{#if}`'s alternate has its own map.)

Side effect: the `component-let-directive` per-slot-scope gap noted in
`server/ast/tests.rs` and `visitors/component.rs` is closed — a
`<Counter let:count>` named slot now folds the component-level `count` while the
default slot keeps the `let:count` parameter read, matching official byte for
byte. Those stale KNOWN GAP notes are updated.

## Verification

- The issue's repro is byte-identical to `svelte@5.56.8` server output.
- `cargo test --release -p rsvelte_core` — all suites green (SSR 99/99,
  hydration, runtime legacy/runes, compiler fixtures, validator, …).
- New regression test `crates/rsvelte_core/tests/ssr_const_scope_2059.rs`
  (7 cases): sibling `{:else}` + `{#key}`, sibling `{:else}` + `{#each}`,
  the two arms of one `{#if}`, inner-shadows-outer, sibling
  `<svelte:boundary>`s, sibling `{#snippet}`s, and a read outside every
  declaring scope staying dynamic.
- Corpus (`svelte` + `pattern` sources, 5144 entries): **server** and
  **client** tracks both `js-mismatch 0` / `css-mismatch 0` /
  `error-mismatch 0`. `compatibility/known-failures.server.json` is `[]` and
  stays `[]`; no ratchet entry is attributable to this bug, so none shrinks.
- The new `debug_assert` was exercised in a dev-profile run of the `ssr`,
  `compiler_fixtures`, `validator` and `runtime` suites (thousands of
  components) — the uniqueness invariant holds.
- `cargo fmt` + `cargo clippy --all-targets --all-features -- -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RQSYoh4Wc353KgUnWHjazu
