### PR TITLE
perf(compiler): stop analysis rebuilding a line table the parser opted out of

### DIFF
--- a/crates/rsvelte_core/src/ast/template.rs
+++ b/crates/rsvelte_core/src/ast/template.rs
@@ -62,6 +62,11 @@ pub struct Root<'a> {
     /// Arena for JsNode instances. Stores all expression sub-nodes contiguously.
     #[serde(skip)]
     pub arena: crate::ast::arena::ParseArena,
+    /// `ParseOptions::skip_expression_loc` as it was when this tree was parsed.
+    /// Analysis finishes the deferred script/expression parses, so it has to
+    /// make the same `loc` decision the parser did rather than a fresh one.
+    #[serde(skip)]
+    pub skip_expression_loc: bool,
 }
 
 /// A JavaScript-style comment captured during parsing.

--- a/crates/rsvelte_core/src/compiler/mod.rs
+++ b/crates/rsvelte_core/src/compiler/mod.rs
@@ -895,6 +895,10 @@ pub fn compile_module(
         },
         options: None,
         comments: Vec::new(),
+        // This module's program is already parsed, so the flag only decides
+        // whether analysis rebuilds a line table it would not use; keep the
+        // pre-existing behaviour for the `.svelte.js` path.
+        skip_expression_loc: false,
         instance: None,
         module: Some(Box::new(crate::ast::template::Script {
             node_type: crate::ast::template::ScriptType::Script,

--- a/crates/rsvelte_core/src/compiler/mod.rs
+++ b/crates/rsvelte_core/src/compiler/mod.rs
@@ -541,8 +541,7 @@ pub(crate) fn prepare_and_analyze<'source>(
     ),
     CompileError,
 > {
-    let line_offsets =
-        phases::phase1_parse::compute_line_offsets(source, ast.skip_expression_loc);
+    let line_offsets = phases::phase1_parse::compute_line_offsets(source, ast.skip_expression_loc);
 
     // Resolve lazy expressions (deferred template expressions). If any
     // expression has a parse error, return it immediately.

--- a/crates/rsvelte_core/src/compiler/mod.rs
+++ b/crates/rsvelte_core/src/compiler/mod.rs
@@ -541,7 +541,8 @@ pub(crate) fn prepare_and_analyze<'source>(
     ),
     CompileError,
 > {
-    let line_offsets = phases::phase1_parse::compute_line_offsets(source, false);
+    let line_offsets =
+        phases::phase1_parse::compute_line_offsets(source, ast.skip_expression_loc);
 
     // Resolve lazy expressions (deferred template expressions). If any
     // expression has a parse error, return it immediately.

--- a/crates/rsvelte_core/src/compiler/phases/1_parse/state/fragment.rs
+++ b/crates/rsvelte_core/src/compiler/phases/1_parse/state/fragment.rs
@@ -242,6 +242,7 @@ impl<'a> Parser<'a> {
             },
             instance: self.instance_script.take().map(Box::new),
             module: self.module_script.take().map(Box::new),
+            skip_expression_loc: self.options.skip_expression_loc,
             parse_warnings: std::mem::take(&mut self.parse_warnings),
             source: None,
             arena: std::mem::take(&mut self.arena),

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/mod.rs
@@ -72,7 +72,10 @@ pub fn analyze_component(
     // Ensure deferred script parsing is completed before analysis.
     // During parse(), script content is stored as raw text for performance.
     // Here we invoke OXC to produce the full AST into the Root's arena.
-    let line_offsets = crate::compiler::phases::phase1_parse::compute_line_offsets(source, false);
+    let line_offsets = crate::compiler::phases::phase1_parse::compute_line_offsets(
+        source,
+        ast.skip_expression_loc,
+    );
     // Resolve deferred lazy expressions in template AST
     // If any expression has a parse error, return it immediately
     if let Some(parse_err) =


### PR DESCRIPTION
## Summary
The compile path parses with `skip_expression_loc: true`, so the parser itself attaches no `Loc` — but the compile pipeline then rebuilt the full line-offset table anyway and fed it to lazy-expression resolution and script parsing, boxing a `Loc` onto **97,732 JS nodes across the flowbite corpus** (measured) purely as garbage: `JsNode.loc` is write-only inside the compiler.

Two commits:
1. Record the parse-time decision on `Root` (`#[serde(skip)] skip_expression_loc`) and honour it in analysis. Callers that want locs (the `parse()` ESTree API, `rsvelte_lint` — both parse with `skip_expression_loc: false`) are unaffected.
2. Honour it on the compile path's own `compute_line_offsets` call too (`prepare_and_analyze`) — the first commit alone was proven a no-op on the compile path by the counter below, because compile resolves lazy expressions and scripts *before* analysis runs.

## Measured (deterministic counter, flowbite 1296 files)
- `Box<Loc>` allocations on the compile path: **97,732 → 0** (with `RSVELTE_FORCE_LOC=1` restoring the old behaviour as the control: 97,732)

## Verification
- **3888 corpus outputs byte-identical** (sha256; re-verified *after* the behaviour-changing commit, clean build with instrumentation stripped)
- Audited all loc consumers before the change: warnings/parse errors carry byte offsets (never `JsNode.loc`); every Phase-2/3 JSON walker skips the `"loc"` key; esrap's `node.loc` is the separate oxc-span channel; lint/`parse()` unaffected by construction
- Local full-suite runs were repeatedly killed by memory pressure on the dev machine; CI is the authoritative test gate for this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F4m3u9XgyDX4NX1k1aGyG3