### PR TITLE
fix(svelte2tsx): move hoisted imports instead of re-synthesizing them (#2112)

### DIFF
--- a/.changeset/hoisted-import-source-map.md
+++ b/.changeset/hoisted-import-source-map.md
@@ -1,0 +1,6 @@
+---
+"@rsvelte/svelte2tsx": patch
+"@rsvelte/svelte-check": patch
+---
+
+Imports hoisted out of a component's instance script now keep the source-map segments of their original span, so a diagnostic on an import in a `.svelte` file is reported on the import's own line instead of line 1. The hoisted text used to be re-synthesized above `$$render()` with the original range blanked out, which left those generated lines with no mapping at all; they are now relocated the way official svelte2tsx's `moveNode` does it. As a side effect the hoisted text is byte-identical to the source, which also fixes multi-line imports losing their continuation-line indentation and leading-comment imports dropping a line.

--- a/compatibility/check-fixtures/svelte-import-diagnostic-line/project/package.json
+++ b/compatibility/check-fixtures/svelte-import-diagnostic-line/project/package.json
@@ -1,0 +1,5 @@
+{
+	"name": "check-fixture-svelte-import-diagnostic-line",
+	"private": true,
+	"type": "module"
+}

--- a/compatibility/check-fixtures/svelte-import-diagnostic-line/project/src/Commented.svelte
+++ b/compatibility/check-fixtures/svelte-import-diagnostic-line/project/src/Commented.svelte
@@ -1,0 +1,10 @@
+<script lang="ts">
+	import { alsoPresent } from './lib/exports';
+
+	// a leading comment travels with the import when it is hoisted
+	import { alsoMissing } from './lib/exports';
+
+	const total = alsoPresent + alsoMissing;
+</script>
+
+<p>{total}</p>

--- a/compatibility/check-fixtures/svelte-import-diagnostic-line/project/src/Plain.svelte
+++ b/compatibility/check-fixtures/svelte-import-diagnostic-line/project/src/Plain.svelte
@@ -1,0 +1,8 @@
+<script lang="ts">
+	import { present } from './lib/exports';
+	import { missing } from './lib/exports';
+
+	const total = present + missing;
+</script>
+
+<p>{total}</p>

--- a/compatibility/check-fixtures/svelte-import-diagnostic-line/project/src/lib/exports.ts
+++ b/compatibility/check-fixtures/svelte-import-diagnostic-line/project/src/lib/exports.ts
@@ -1,0 +1,2 @@
+export const present = 1;
+export const alsoPresent = 2;

--- a/compatibility/check-fixtures/svelte-import-diagnostic-line/project/tsconfig.json
+++ b/compatibility/check-fixtures/svelte-import-diagnostic-line/project/tsconfig.json
@@ -1,0 +1,14 @@
+{
+	"compilerOptions": {
+		"target": "esnext",
+		"module": "esnext",
+		"moduleResolution": "bundler",
+		"strict": true,
+		"skipLibCheck": true,
+		"noEmit": true
+	},
+	"include": [
+		"src/**/*.ts",
+		"src/**/*.svelte"
+	]
+}

--- a/compatibility/check-fixtures/svelte-import-diagnostic-line/scenario.json
+++ b/compatibility/check-fixtures/svelte-import-diagnostic-line/scenario.json
@@ -1,0 +1,8 @@
+{
+	"description": "A `.svelte` component whose failing named import is NOT on the first line of the instance script. svelte2tsx hoists instance-script imports to the top of the shadow, so the diagnostic's position only survives if the hoisted text keeps its source-map segments — it used to be re-synthesized with the original span blanked out, which pinned every import diagnostic to line 1 (#2112). Two importers cover a bare import and one behind a leading comment plus a blank-line group.",
+	"workspace": ".",
+	"tsconfig": "tsconfig.json",
+	"issues": [
+		2112
+	]
+}

--- a/compatibility/check-fixtures/ts-companion-named-import/scenario.json
+++ b/compatibility/check-fixtures/ts-companion-named-import/scenario.json
@@ -1,5 +1,5 @@
 {
-	"description": "A `widget.svelte` component with a same-name `widget.svelte.ts` companion. A `.svelte` specifier means the component and nothing else, so a named import of a companion export through it is TS2614 in official svelte-check — the overlay used to fold the companion's exports into the component shadow and resolve it happily, hiding the error (#2061). The companion's own specifier (`./widget.svelte.js`) must keep working (#751). The importers are plain `.ts` files: the same import from a `.svelte` file lands on the right file but the wrong line, because svelte2tsx emits no source-map segments for the imports it hoists to the top of the shadow.",
+	"description": "A `widget.svelte` component with a same-name `widget.svelte.ts` companion. A `.svelte` specifier means the component and nothing else, so a named import of a companion export through it is TS2614 in official svelte-check — the overlay used to fold the companion's exports into the component shadow and resolve it happily, hiding the error (#2061). The companion's own specifier (`./widget.svelte.js`) must keep working (#751). The importers are plain `.ts` files; `svelte-import-diagnostic-line` covers the `.svelte`-side importer, whose diagnostic position depends on the hoisted imports keeping their source-map segments (#2112).",
 	"tsconfig": "tsconfig.json",
 	"issues": [
 		2061,

--- a/compatibility/check-known-failures.md
+++ b/compatibility/check-known-failures.md
@@ -159,11 +159,11 @@ Green scenarios are load-bearing, not filler — a regression turns them red:
      `.svelte` specifier resolving to nothing (or to a `.js` module the program
      excludes) silently typed as a default-only component.
 
-  The named-import case is covered from plain `.ts` importers only: from a
-  `.svelte` file the diagnostic lands on the right file but on line 1, because
-  svelte2tsx emits no source-map segments for the imports it hoists to the top
-  of the shadow (official's emits one per character). That is a source-map
-  defect, not a resolution one.
+  The named-import case is covered from plain `.ts` importers here; the
+  `.svelte`-side importer lives in `svelte-import-diagnostic-line`, which pins
+  the source-map half of the same story — svelte2tsx used to emit no segments
+  at all for the imports it hoists to the top of the shadow, so every import
+  diagnostic in a component landed on line 1 (#2112).
 
   `ts-paths-non-relative` also pins TypeScript's `${configDir}` template
   (TS 5.5+), which is substituted *before* the check above runs: it must not
@@ -179,6 +179,12 @@ Green scenarios are load-bearing, not filler — a regression turns them red:
 - **`sibling-symlink`** — both cross-package shapes: `src/barrel.svelte` through
   the package `exports` barrel (#782/#805) and `src/deep.svelte` through a bare
   deep specifier (#1900).
+- **`svelte-import-diagnostic-line`** — #2112, the position half of the
+  named-import cluster: a failing import that is not on the instance script's
+  first line, once bare and once behind a leading comment and a blank-line
+  group. svelte2tsx hoists instance imports to the top of the shadow, so these
+  diagnostics only land on the right line while the hoisted text keeps the
+  source-map segments of its original span.
 - **`boundary-elements`** — #1889, fixed by #1906: the overlay follows
   `get_global_types` and prefers the installed svelte's `svelte-html.d.ts` over
   the vendored `svelte-jsx-v4.d.ts`, so element and attribute types track

--- a/crates/rsvelte_projection/src/svelte2tsx/create_render_function.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/create_render_function.rs
@@ -63,7 +63,7 @@ pub(crate) fn create_render_function(
             let module_imports =
                 find_instance_imports(module, source, module_program.expect("module script"));
             let module_hoist_target = match module_imports.last() {
-                Some(&(_, _, last_end)) => mod_content_start + last_end,
+                Some(last) => mod_content_start + last.end,
                 None => mod_content_start,
             };
             // JS reference: `str.appendLeft(snippetHoistTargetForModule, '\n')`

--- a/crates/rsvelte_projection/src/svelte2tsx/nodes/scripts.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/nodes/scripts.rs
@@ -32,19 +32,39 @@ pub(crate) fn find_script_close_tag_start(source: &str, script_end: u32) -> u32 
     script_end
 }
 
-/// Find top-level import declarations in an instance script.
-///
-/// Returns a sorted list of (start, end) positions relative to the script
-/// content (i.e., relative to `script.content_offset`).
-/// Returns `(comments_start, import_start, import_end)` for each top-level
-/// import in `script`. `comments_start <= import_start` — the leading comment
-/// span lets the caller hoist JSDoc / line comments alongside their import,
-/// matching the JS reference's `moveNode` per-comment moves.
+/// A leading comment that travels with its import when the import is hoisted.
+/// Positions are relative to the script content.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct LiftedComment {
+    pub(crate) start: u32,
+    pub(crate) end: u32,
+    /// `/* … */` rather than `// …` — upstream `handleFirstInstanceImport`
+    /// anchors its newline before a leading block comment but after a line one.
+    pub(crate) block: bool,
+    /// A line break follows the comment (TS `CommentRange.hasTrailingNewLine`).
+    pub(crate) has_trailing_newline: bool,
+}
+
+/// A top-level import declaration to hoist above `$$render()`, together with
+/// the leading comments `moveNode` relocates alongside it. All positions are
+/// relative to the script content (i.e. `Script::content_offset`).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct LiftedImport {
+    pub(crate) comments: Vec<LiftedComment>,
+    pub(crate) start: u32,
+    pub(crate) end: u32,
+    /// A blank line separates the import from the preceding token (upstream
+    /// `isNewGroup`), so `moveNode` prefixes the hoisted chunk with a newline.
+    pub(crate) new_group: bool,
+}
+
+/// Find top-level import declarations in an instance script, each with the
+/// leading comment ranges the JS reference's `moveNode` hoists alongside it.
 pub(crate) fn find_instance_imports(
     script: &crate::ast::template::Script,
     source: &str,
     program: &oxc_ast::ast::Program,
-) -> Vec<(u32, u32, u32)> {
+) -> Vec<LiftedImport> {
     let content_start = script.content_offset as usize;
     let script_source = slice_src(source, script.start as usize, script.end as usize);
     let close_tag_offset = script_source
@@ -72,7 +92,7 @@ pub(crate) struct InstanceImportCollector<'a> {
     bytes: &'a [u8],
     comments: &'a [oxc_ast::ast::Comment],
     comment_cursor: usize,
-    imports: Vec<(u32, u32, u32)>,
+    imports: Vec<LiftedImport>,
 }
 
 impl<'a> InstanceImportCollector<'a> {
@@ -106,32 +126,93 @@ impl<'a> InstanceImportCollector<'a> {
             self.comment_cursor += 1;
         }
 
-        let new_start = scan_back_leading_comments(
+        let (first_comment, trivia_start) = scan_back_leading_comments(
             self.bytes,
             start as usize,
             self.comments,
             self.comment_cursor,
         );
+        let comments: Vec<LiftedComment> = self.comments[first_comment..self.comment_cursor]
+            .iter()
+            .map(|comment| LiftedComment {
+                start: comment.span.start,
+                end: comment.span.end,
+                block: !matches!(comment.kind, oxc_ast::ast::CommentKind::Line),
+                has_trailing_newline: comment_has_trailing_newline(
+                    self.bytes,
+                    comment.span.end as usize,
+                ),
+            })
+            .collect();
+        let new_group = counts_as_new_group(self.bytes, trivia_start, start as usize, &comments);
 
-        self.imports.push((new_start, start, end));
+        self.imports.push(LiftedImport {
+            comments,
+            start,
+            end,
+            new_group,
+        });
     }
 
-    pub(crate) fn finish(self) -> Vec<(u32, u32, u32)> {
+    pub(crate) fn finish(self) -> Vec<LiftedImport> {
         self.imports
     }
 }
 
+/// TS `CommentRange.hasTrailingNewLine`: a line break follows the comment, with
+/// only spaces / tabs in between.
+fn comment_has_trailing_newline(bytes: &[u8], end: usize) -> bool {
+    bytes[end..]
+        .iter()
+        .find(|byte| !matches!(byte, b' ' | b'\t'))
+        .is_some_and(|byte| matches!(byte, b'\n' | b'\r'))
+}
+
+/// Upstream `isNewGroup`: two or more line breaks in the import's leading
+/// trivia. Line breaks *inside* a comment are part of the comment token and are
+/// not counted, mirroring the TS scanner's `NewLineTrivia`.
+fn counts_as_new_group(
+    bytes: &[u8],
+    trivia_start: usize,
+    import_start: usize,
+    comments: &[LiftedComment],
+) -> bool {
+    let mut line_breaks = 0usize;
+    let mut position = trivia_start;
+    while position < import_start {
+        if let Some(comment) = comments
+            .iter()
+            .find(|comment| comment.start as usize == position)
+        {
+            position = comment.end as usize;
+            continue;
+        }
+        if bytes[position] == b'\n'
+            || (bytes[position] == b'\r' && bytes.get(position + 1) != Some(&b'\n'))
+        {
+            line_breaks += 1;
+            if line_breaks >= 2 {
+                return true;
+            }
+        }
+        position += 1;
+    }
+    false
+}
+
 /// Walk backwards from `pos` over leading trivia (whitespace + comments),
-/// returning the start of the earliest reachable parser-discovered comment.
+/// returning the index of the earliest reachable parser-discovered comment and
+/// the start of the whole trivia region (TS `node.getFullStart()`).
 fn scan_back_leading_comments(
     bytes: &[u8],
     pos: usize,
     comments: &[oxc_ast::ast::Comment],
     comment_cursor: usize,
-) -> u32 {
+) -> (usize, usize) {
     let mut cstart = pos as u32;
     let mut comment_index = comment_cursor;
-    loop {
+    let mut first_comment = comment_cursor;
+    let trivia_start = loop {
         // Skip whitespace backward.
         let mut p = cstart as usize;
         while p > 0 && matches!(bytes[p - 1], b' ' | b'\t' | b'\n' | b'\r') {
@@ -144,15 +225,16 @@ fn scan_back_leading_comments(
         if comment_index > 0 && comments[comment_index - 1].span.end as usize == p {
             let cs = comments[comment_index - 1].span.start;
             if cs >= cstart {
-                break;
+                break p;
             }
             cstart = cs;
             comment_index -= 1;
+            first_comment = comment_index;
         } else {
-            break;
+            break p;
         }
-    }
-    cstart
+    };
+    (first_comment, trivia_start)
 }
 
 /// Detect whether a script content contains top-level `await` expressions.
@@ -342,8 +424,9 @@ mod tests {
         let import_start = source.find("import value").unwrap();
 
         assert_eq!(
-            scan_back_leading_comments(source.as_bytes(), import_start, &comments, comments.len()),
-            comments[0].span.start
+            scan_back_leading_comments(source.as_bytes(), import_start, &comments, comments.len())
+                .0,
+            0
         );
     }
 
@@ -378,8 +461,9 @@ mod tests {
                     import_start,
                     &comments,
                     comment_cursor,
-                ),
-                comments[index].span.start
+                )
+                .0,
+                index
             );
         }
     }

--- a/crates/rsvelte_projection/src/svelte2tsx/process_instance_script_tag.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/process_instance_script_tag.rs
@@ -10,7 +10,7 @@ use super::nodes::generics::{
     extract_generics_from_script_tag, split_generic_param_names, type_text_references_any,
     type_text_typeof_references_local_value,
 };
-use super::nodes::scripts::{detect_top_level_await, find_script_close_tag_start};
+use super::nodes::scripts::{LiftedImport, detect_top_level_await, find_script_close_tag_start};
 use super::script::ExportedNames;
 use super::svelte2tsx::slice_src;
 
@@ -36,7 +36,7 @@ pub(crate) fn process_instance_script_tag(
     has_module_script: bool,
     has_slot_elements: bool,
     hoistable_snippet_ranges: &[(u32, u32)],
-    imports: &[(u32, u32, u32)],
+    imports: &[LiftedImport],
 ) -> bool {
     let instance = ast.instance.as_ref().unwrap();
     let script_start = instance.start;
@@ -122,16 +122,9 @@ pub(crate) fn process_instance_script_tag(
     };
 
     let has_imports = !imports.is_empty();
-    // Lift imports above $$render(): each import is collected individually
-    // (without leading whitespace) and inserted into the <script> tag
-    // replacement, with the original positions blanked out.
-    let import_text = if has_imports {
-        collect_lifted_imports(imports, source, content_start, str)
-    } else {
-        String::new()
-    };
     // With imports the `\n` separating the type alias from what precedes it
-    // already comes from `import_text`; without them the alias has to carry it.
+    // already comes from the last hoisted import; without them the alias has to
+    // carry it.
     let type_decl_prefix = if has_imports { "" } else { "\n" };
 
     // Build $$ComponentProps type declaration for TS files
@@ -231,28 +224,19 @@ pub(crate) fn process_instance_script_tag(
     // (not part_a) so it lands AFTER any hoisted type/interface
     // declarations — `$$ComponentProps` may reference them, so it has
     // to appear after them in the output.
-    // `import_text` provides its own leading `\n` (or absorbs it
-    // into a leading-line-comment) — see the new-line accounting
-    // above. `part_a` only carries the `;` (which replaces the `<`)
-    // plus an extra `\n` when there is also a module script (mirrors
-    // `'\n' + (hasModuleScript ? '\n' : '')` in
-    // `handleFirstInstanceImport`).
+    // The hoisted imports are relocated chunks (see `lift_imports`), so
+    // `part_a` only carries the `;` that replaces the `<` of `<script>`.
     let mut part_a = String::from(";");
-    if has_imports {
-        if has_module_script {
-            part_a.push('\n');
-        }
-        part_a.push_str(&import_text);
-    }
     // When there are hoistable snippets and a $$ComponentProps typedef to
     // emit before $$render, the typedef must appear BEFORE the snippets in
-    // the output. Because snippets are moved to `sp` (after `part_a`) and
-    // `part_b` is placed after them, we append the typedef to `part_a` so
-    // it lands between the imports and the snippets. A `\n` separator is
-    // also added to match the blank line the JS reference produces.
+    // the output (snippets are moved to `sp`, and `part_b` follows them) but
+    // AFTER the hoisted imports — which are relocated chunks, so with imports
+    // present the typedef has to ride along in the last one's outro instead of
+    // sitting in `part_a`. A `\n` separator matches the blank line the JS
+    // reference produces.
     let ts_component_props_in_part_a =
         !hoistable_snippet_ranges.is_empty() && !ts_component_props_before_render.is_empty();
-    if ts_component_props_in_part_a {
+    if ts_component_props_in_part_a && !has_imports {
         part_a.push('\n');
         part_a.push_str(&ts_component_props_before_render);
     }
@@ -291,15 +275,13 @@ pub(crate) fn process_instance_script_tag(
         trailing_newline
     );
 
-    let has_hoistable_chunks = !hoistable_snippet_ranges.is_empty()
-        || !exported_names.hoistable_type_ranges.is_empty()
-        || !exported_names.dollar_generic_referenced_ranges.is_empty()
-        || exported_names.props_type_arg_hoist.is_some();
     // Split position: right after the `<` of `<script>`. This matches
     // the JS reference's `scriptTag.start + 1`, so moved chunks land
     // between the `;` (from the `<` overwrite) and the function
-    // declaration that replaces the rest of the script tag.
-    let split_pos = if has_hoistable_chunks && content_start > script_start + 1 {
+    // declaration that replaces the rest of the script tag. The JS
+    // reference always splits there (`overwrite(start, start + 1, ';')`
+    // then `overwrite(start + 1, scriptTagEnd, …)`).
+    let split_pos = if content_start > script_start + 1 {
         Some(script_start + 1)
     } else {
         None
@@ -307,6 +289,17 @@ pub(crate) fn process_instance_script_tag(
     if let Some(sp) = split_pos {
         if script_start < sp {
             str.overwrite(script_start, sp, &part_a);
+        }
+        // Imports move first: the JS reference relocates them during the
+        // instance-script walk, before the type/interface hoists, and each
+        // `move` lands before the chunk that still starts at `sp` — so the
+        // relocation order is the output order.
+        lift_imports(imports, source, content_start, sp, has_module_script, str);
+        if ts_component_props_in_part_a && let Some(last) = imports.last() {
+            str.append_left_fmt(
+                content_start + last.end,
+                format_args!("\n{}", ts_component_props_before_render),
+            );
         }
         // Move hoistable type/interface declarations first so they
         // sit BEFORE the snippets in the chunk list, matching the JS
@@ -378,17 +371,20 @@ pub(crate) fn process_instance_script_tag(
             exported_names.props_type_text.as_ref(),
         )
     {
+        // `append_right`, not `append_left`: `preprendStr` attaches to the
+        // character AT `let_pos`, so the declaration must stay behind when the
+        // import that ends there is hoisted away.
         if force_inside_render {
-            str.append_left_fmt(
+            str.append_right(
                 let_pos,
-                format_args!(";type $$ComponentProps =  {};", type_text),
+                &format!(";type $$ComponentProps =  {};", type_text),
             );
         } else {
             // type_already_inserted (auto-generated SvelteKit / fallback type).
             // JS reference wraps in surroundWithIgnoreComments.
-            str.append_left_fmt(
+            str.append_right(
                 let_pos,
-                format_args!(
+                &format!(
                     "/*\u{03A9}ignore_start\u{03A9}*/;type $$ComponentProps = {};/*\u{03A9}ignore_end\u{03A9}*/",
                     type_text
                 ),
@@ -435,142 +431,77 @@ pub(crate) fn process_instance_script_tag(
     has_top_level_await
 }
 
-/// Collect the instance script's top-level imports into the text that will be
-/// spliced above `$$render()`, blanking each original `[leading comments .. import]`
-/// span in `str`.
-fn collect_lifted_imports(
-    imports: &[(u32, u32, u32)],
+/// Hoist the instance script's top-level imports above `$$render()` by
+/// *relocating* their source ranges — mirrors `moveNode` +
+/// `handleFirstInstanceImport`. Moving (rather than copying the text and
+/// blanking the original) is what keeps a source-map segment on every hoisted
+/// character, so a diagnostic on an import resolves back to its real line.
+fn lift_imports(
+    imports: &[LiftedImport],
     source: &str,
     content_start: u32,
+    hoist_target: u32,
+    has_module_script: bool,
     str: &mut MagicString<'_>,
-) -> String {
-    let mut import_text = String::new();
-    for (i, &(comments_start, import_start_rel, import_end)) in imports.iter().enumerate() {
-        let abs_comments_start = comments_start + content_start;
-        let abs_import_start = import_start_rel + content_start;
-        let abs_end = import_end + content_start;
+) {
+    let (Some(first), Some(last)) = (imports.first(), imports.last()) else {
+        return;
+    };
 
-        // Split into the leading comment region and the import
-        // statement itself so they can be processed independently.
-        // The JS reference (`utils/tsAst.ts::moveNode`) moves each
-        // leading comment as its own chunk and drops the trivia
-        // between them; for the first import,
-        // `handleFirstInstanceImport` inserts an extra `\n` either
-        // before a leading multiline comment or before the `import`
-        // keyword.
-        let comments_raw = slice_src(
-            source,
-            abs_comments_start as usize,
-            abs_import_start as usize,
-        );
-        let import_raw = slice_src(source, abs_import_start as usize, abs_end as usize);
+    for import in imports {
+        let start = content_start + import.start;
+        let end = content_start + import.end;
 
-        // Collect leading comment lines while preserving block-comment
-        // interior indentation verbatim.  The JS reference (`moveNode`)
-        // uses `str.move()` which copies source text byte-for-byte, so
-        // `/* … */` inner lines must retain their original leading spaces.
-        // Only the opener line (`/*...`) is fully trimmed (leading indent
-        // is dropped; trailing spaces after `/*` are stripped); all other
-        // block-comment lines are preserved as-is.  Lines that are purely
-        // whitespace outside a block comment are filtered out.
-        let comment_lines: Vec<String> = {
-            let mut lines: Vec<String> = Vec::new();
-            let mut in_block = false;
-            for line in comments_raw.lines() {
-                if in_block {
-                    // Preserve interior indentation verbatim.
-                    if line.contains("*/") {
-                        in_block = false;
-                    }
-                    lines.push(line.to_string());
-                } else {
-                    let trimmed = line.trim();
-                    if trimmed.is_empty() {
-                        continue; // skip whitespace-only lines
-                    }
-                    if trimmed.starts_with("/*") {
-                        // Block-comment opener: trim fully so the
-                        // leading indent and any trailing spaces after
-                        // `/*` are dropped (e.g. `  /*  ` → `/*`).
-                        in_block = !trimmed.contains("*/");
-                        lines.push(trimmed.to_string());
-                    } else {
-                        // Line comment (`//`) or other: fully trim.
-                        lines.push(trimmed.to_string());
-                    }
-                }
-            }
-            lines
-        };
-
-        // Was the last comment on the same line as the `import`
-        // keyword? True when `comments_raw`'s final line is not
-        // whitespace-only — e.g. `/*hi*/import X` keeps the comment
-        // and the import on a single line.
-        let last_comment_inline = !comments_raw.is_empty()
-            && comments_raw
-                .lines()
-                .last()
-                .is_some_and(|l| !l.trim().is_empty());
-
-        let import_text_clean: String = import_raw
-            .lines()
-            .map(|line| line.trim_start())
-            .collect::<Vec<_>>()
-            .join("\n");
-
-        // Preserve gap when this import is part of a separate group
-        // (a blank line in the source between this import and the
-        // previous one).
-        if i > 0 {
-            let prev_end = imports[i - 1].2 + content_start;
-            let between = slice_src(source, prev_end as usize, abs_comments_start as usize);
-            let newline_count = between.chars().filter(|&c| c == '\n').count();
-            if newline_count >= 2 {
-                import_text.push('\n');
+        if import.new_group
+            && !import
+                .comments
+                .iter()
+                .any(|comment| comment.has_trailing_newline)
+        {
+            str.append_right(start, "\n");
+        }
+        for comment in &import.comments {
+            let comment_end = content_start + comment.end;
+            str.move_range(content_start + comment.start, comment_end, hoist_target);
+            if comment.has_trailing_newline {
+                append_newline_to_last_char(str, source, comment_end);
             }
         }
-
-        let first_comment_is_block = comment_lines.first().is_some_and(|c| c.starts_with("/*"));
-        let needs_leading_newline = i == 0 && (comment_lines.is_empty() || first_comment_is_block);
-
-        if needs_leading_newline {
-            import_text.push('\n');
-        }
-        for (idx, line) in comment_lines.iter().enumerate() {
-            import_text.push_str(line);
-            let is_last = idx + 1 == comment_lines.len();
-            if !(is_last && last_comment_inline) {
-                import_text.push('\n');
-            }
-        }
-        if i == 0 && !first_comment_is_block && !comment_lines.is_empty() {
-            // `appendRight(firstImport.getStart(), '\n')` —
-            // separating the trailing leading-line-comment from the
-            // import keyword with an explicit blank line.
-            import_text.push('\n');
-        }
-
-        import_text.push_str(&import_text_clean);
-
-        // Add semicolon to the last import if it doesn't have one
-        if i == imports.len() - 1 {
-            // `.last()` avoids a `len() - 1` underflow when the cleaned
-            // import text is empty (zero-length span edge case).
-            if import_text_clean.as_bytes().last() != Some(&b';') {
-                import_text.push_str(";\n");
-            } else {
-                import_text.push('\n');
-            }
-        } else {
-            import_text.push('\n');
-        }
-
-        // Blank out the original [leading comments .. import] span.
-        // The indentation before the comments stays because it's
-        // outside the captured span.
-        str.overwrite(abs_comments_start, abs_end, "");
+        str.move_range(start, end, hoist_target);
+        append_newline_to_last_char(str, source, end);
     }
 
-    import_text
+    // Separate the hoisted block from the `;` that replaced `<`, and from a
+    // preceding module script.
+    let anchor = match first.comments.first() {
+        Some(comment) if comment.block => comment.start,
+        _ => first.start,
+    };
+    str.append_right(
+        content_start + anchor,
+        if has_module_script { "\n\n" } else { "\n" },
+    );
+
+    // Terminate the last import so auto-imports and completions don't attach to
+    // the generated code that follows it.
+    let last_end = content_start + last.end;
+    let (last_char_start, last_char) = last_char_of(source, last_end);
+    if last_char != ";" {
+        str.overwrite_fmt(last_char_start, last_end, format_args!("{last_char};\n"));
+    }
+}
+
+/// `moveNode`'s `overwrite(end - 1, end, original[end - 1] + '\n')`: the
+/// newline has to sit inside the moved chunk so it travels with it.
+fn append_newline_to_last_char(str: &mut MagicString<'_>, source: &str, end: u32) {
+    let (last_char_start, last_char) = last_char_of(source, end);
+    str.overwrite_fmt(last_char_start, end, format_args!("{last_char}\n"));
+}
+
+fn last_char_of(source: &str, end: u32) -> (u32, &str) {
+    let mut start = end as usize - 1;
+    while !source.is_char_boundary(start) {
+        start -= 1;
+    }
+    (start as u32, &source[start..end as usize])
 }

--- a/crates/rsvelte_projection/src/svelte2tsx/script/mod.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/script/mod.rs
@@ -29,7 +29,7 @@ use oxc_span::GetSpan;
 use crate::ast::template::Script;
 
 use super::magic_string::MagicString;
-use super::nodes::scripts::InstanceImportCollector;
+use super::nodes::scripts::{InstanceImportCollector, LiftedImport};
 use super::svelte2tsx::slice_src;
 use super::utils::lexical::contains_word;
 
@@ -111,7 +111,7 @@ pub fn process_instance_script(
     emit_jsdoc: bool,
     is_dts_mode: bool,
     script_generic_names: &HashSet<String>,
-) -> Vec<(u32, u32, u32)> {
+) -> Vec<LiftedImport> {
     let offset = script.content_offset;
     let mut instance_imports = Vec::new();
     with_parsed_script(parsed, |program, raw_content| {

--- a/crates/rsvelte_projection/tests/svelte2tsx_hoisted_import_map.rs
+++ b/crates/rsvelte_projection/tests/svelte2tsx_hoisted_import_map.rs
@@ -1,0 +1,100 @@
+//! Imports hoisted out of the instance script keep a source-map segment on
+//! every character, so a diagnostic on an import in a `.svelte` file resolves
+//! back to its real line instead of falling through to line 1.
+//!
+//! Regression test for issue #2112: the hoisted lines used to be freshly
+//! synthesized text with the original span blanked out, which emitted no
+//! segments at all.
+
+use rsvelte_projection::svelte2tsx::{Svelte2TsxOptions, Svelte2TsxResult, svelte2tsx};
+
+fn convert(source: &str) -> Svelte2TsxResult {
+    svelte2tsx(
+        source,
+        Svelte2TsxOptions {
+            filename: "A.svelte".to_string(),
+            is_ts_file: true,
+            ..Default::default()
+        },
+    )
+    .expect("svelte2tsx")
+}
+
+/// The generated line index whose text is exactly `text`.
+fn generated_line_of(code: &str, text: &str) -> u32 {
+    code.lines()
+        .position(|line| line == text)
+        .unwrap_or_else(|| panic!("generated code has no line {text:?}:\n{code}")) as u32
+}
+
+/// Assert that `[0, len)` of the generated line maps to `original_line`,
+/// starting at `original_column`, one column at a time.
+fn assert_line_maps_verbatim(
+    result: &Svelte2TsxResult,
+    generated_line: u32,
+    len: u32,
+    original_line: u32,
+    original_column: u32,
+) {
+    let map = sourcemap::SourceMap::from_slice(result.map.as_deref().expect("map").as_bytes())
+        .expect("valid source map");
+    for column in 0..len {
+        let token = map
+            .lookup_token(generated_line, column)
+            .unwrap_or_else(|| panic!("no token at generated column {column}"));
+        assert_eq!(
+            (token.get_src_line(), token.get_src_col()),
+            (original_line, original_column + column),
+            "generated line {generated_line}, column {column}"
+        );
+    }
+}
+
+#[test]
+fn hoisted_import_maps_back_to_its_source_line() {
+    let source =
+        "<script lang=\"ts\">\n  import { Missing } from './other';\n  let x = 1;\n</script>\n";
+    let result = convert(source);
+
+    let hoisted = "import { Missing } from './other';";
+    let generated_line = generated_line_of(&result.code, hoisted);
+    // The `<script>` tag is line 0, so the import sits on original line 1 at
+    // column 2 (past the two-space indent, which stays behind).
+    assert_line_maps_verbatim(&result, generated_line, hoisted.len() as u32, 1, 2);
+}
+
+#[test]
+fn every_hoisted_import_of_a_group_maps_back() {
+    let source = "<script lang=\"ts\">\n  import { a } from './a';\n  import { b } from './b';\n  let x = a + b;\n</script>\n";
+    let result = convert(source);
+
+    for (offset, text) in [
+        (1, "import { a } from './a';"),
+        (2, "import { b } from './b';"),
+    ] {
+        let generated_line = generated_line_of(&result.code, text);
+        assert_line_maps_verbatim(&result, generated_line, text.len() as u32, offset, 2);
+    }
+}
+
+#[test]
+fn hoisted_import_with_a_leading_comment_maps_back() {
+    let source = "<script lang=\"ts\">\n  // why we need it\n  import { a } from './a';\n  let x = a;\n</script>\n";
+    let result = convert(source);
+
+    let hoisted = "import { a } from './a';";
+    let generated_line = generated_line_of(&result.code, hoisted);
+    assert_line_maps_verbatim(&result, generated_line, hoisted.len() as u32, 2, 2);
+}
+
+/// The hoisted import must not be the only thing that moves: the statement that
+/// follows it stays where it was, so its mapping is untouched.
+#[test]
+fn statement_after_a_hoisted_import_keeps_its_mapping() {
+    let source = "<script lang=\"ts\">\n  import { a } from './a';\n  let x = a;\n</script>\n";
+    let result = convert(source);
+
+    let kept = "  let x = a;";
+    let generated_line = generated_line_of(&result.code, kept);
+    assert_line_maps_verbatim(&result, generated_line, kept.len() as u32, 2, 0);
+}


### PR DESCRIPTION
Fixes #2112

## Cause

`collect_lifted_imports` (`crates/rsvelte_projection/src/svelte2tsx/process_instance_script_tag.rs`) hoisted the instance script's top-level imports by **copying their text** into the `<script>`-tag replacement and blanking the original span. Synthesized text has no origin, so those generated lines carried **zero source-map segments** — a diagnostic on an import in a `.svelte` file (TS2305/TS2614 on a named import, say) fell back to line 1.

Official svelte2tsx relocates the node instead (`utils/tsAst.ts::moveNode` → `MagicString.move`), which keeps the chunk and its mappings intact and maps one segment per character.

Distinct from #2066 (there the generated columns were all 0; here the lines had no segments at all).

## Fix

Follow official's structure rather than patching mappings on afterwards:

- `find_instance_imports` now returns a `LiftedImport { comments, start, end, new_group }` per import — the leading comment ranges with TS's `CommentRange.hasTrailingNewLine` / `MultiLineCommentTrivia` flags, plus upstream's `isNewGroup` (>= 2 line breaks in the leading trivia, counted the way the TS scanner counts `NewLineTrivia`).
- New `lift_imports` relocates every leading comment and the import itself to `script.start + 1` with `MagicString::move_range`, reproducing `moveNode`'s trailing-newline overwrites and `handleFirstInstanceImport`'s separating newline + last-import semicolon.
- The `<script>`-tag overwrite is now **always** split at `script.start + 1` (upstream does `overwrite(start, start + 1, ';')` then `overwrite(start + 1, scriptTagEnd, ...)`), so `function $$render() {` gets its own mapping too — previously it was fused into one edited chunk.

Two placements had to follow the relocation:

- the synthesized `;type $$ComponentProps = ...;` for the hoistable-snippet case now rides in the last import's outro, so it still lands between the imports and the snippets;
- the inline `$props()` typedef switches from `append_left` to `append_right`, because upstream's `preprendStr` attaches to the character **at** the position — it has to stay behind when the import ending there is hoisted away.

### Output changes (all toward official)

Because the hoisted text is now copied verbatim, multi-line imports keep their continuation-line indentation and leading-comment imports no longer swallow a line. On a hand-built 25-sample official-vs-rsvelte comparison the generated-text divergences went **13 -> 2**, and the two survivors are pre-existing issues unrelated to imports (snippet-hoist indentation, an `interface` hoist blank line).

## Tests

| Gate | Result |
|---|---|
| `crates/rsvelte_projection/tests/svelte2tsx_hoisted_import_map.rs` (new) | 4 tests; 3 of them fail on `main` |
| `compatibility/check-fixtures/svelte-import-diagnostic-line` (new, Layer-1) | passes; on `main` it produces 4 divergences (`+ERROR ...:1`, `-ERROR ...:3/5`) |
| svelte-check parity gate (`check-verify.mjs`, all scenarios) | 3 known, **0 new, 0 fixed** |
| svelte2tsx TSX-text + source-map corpus gates | 12738 match / **0 ts-mismatch**, 12746 map-valid / **0 map-invalid** (13258 entries: svelte, svelte.dev, bits-ui, flowbite-svelte, melt-ui, shadcn-svelte + 25 more; both ratchets are empty, i.e. hard gates) |
| `svelte2tsx_fixtures` (upstream 254) | 249/254, no regressions, same 5 known failures |
| `cargo test --workspace` | green |
| `cargo fmt` / `cargo clippy --all-targets --all-features -- -D warnings` | clean |

Two corpus regressions surfaced during development (`shadcn-svelte .../data-table.svelte`, `$$ComponentProps` ordering) and are fixed by the two placement changes above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RQSYoh4Wc353KgUnWHjazu
