### PR TITLE
fix(svelte2tsx): forward default-slot `let:` through `<svelte:component>` (#2103)

### DIFF
--- a/.changeset/svelte2tsx-svelte-component-slot-forwarding.md
+++ b/.changeset/svelte2tsx-svelte-component-slot-forwarding.md
@@ -1,0 +1,15 @@
+---
+"@rsvelte/compiler": patch
+"@rsvelte/svelte2tsx": patch
+"@rsvelte/svelte-check": patch
+---
+
+fix(svelte2tsx): route `<svelte:component>` children through the same slot
+lowering a named component's children take. `handle_svelte_component` walked
+its fragment with `process_fragment_inplace`, so a default-slot `let:` receiver
+(`<div let:x>` / `<svelte:fragment let:x>`) never got its
+`$$slot_def.default` destructuring prologue and every `let:` binding resolved
+as an undeclared identifier in the generated TSX; a `<svelte:fragment
+slot="a">` child likewise kept a plain `"slot":\`a\`,` attribute instead of the
+`$$slot_def["a"]` wrapper. Official svelte2tsx treats `svelte:component` as an
+`InlineComponent`, so slot content forwards the same way there.

--- a/crates/rsvelte_projection/src/svelte2tsx/template/nodes/component_slots.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/template/nodes/component_slots.rs
@@ -228,9 +228,14 @@ pub(crate) fn has_named_slot_children(fragment: &Fragment, source: &str) -> bool
 ///
 /// Returns whether the default-slot block is still open at the closing tag and
 /// so must be closed by the caller's closing-tag overwrite.
+///
+/// Takes the owning node's parts rather than a `&Component` so `<svelte:component>`
+/// (a `SvelteComponentElement`) can share the exact same slot lowering.
 #[must_use]
 pub(crate) fn process_component_children_with_slots(
-    comp: &Component,
+    attributes: &[Attribute],
+    fragment: &Fragment,
+    node_end: u32,
     inst_var: &str,
     has_lets: bool,
     source: &str,
@@ -241,7 +246,7 @@ pub(crate) fn process_component_children_with_slots(
 ) -> bool {
     // Build the default slot destructuring if needed
     let let_destructure = if has_lets {
-        build_let_destructure_string(&comp.attributes, source)
+        build_let_destructure_string(attributes, source)
     } else {
         String::new()
     };
@@ -272,7 +277,7 @@ pub(crate) fn process_component_children_with_slots(
         );
 
         // Find where to insert the block open
-        if let Some(first_node) = comp.fragment.nodes.first() {
+        if let Some(first_node) = fragment.nodes.first() {
             let first_start = first_node.start();
             // Insert the block opening before the first child
             str.append_left(first_start, &block_open);
@@ -280,7 +285,7 @@ pub(crate) fn process_component_children_with_slots(
         default_slot_opened = true;
     }
 
-    for node in &comp.fragment.nodes {
+    for node in &fragment.nodes {
         let is_named_slot = match node {
             TemplateNode::RegularElement(el) => {
                 get_slot_attr_value(&el.attributes, source).is_some()
@@ -395,8 +400,8 @@ pub(crate) fn process_component_children_with_slots(
     if default_slot_opened && has_lets {
         // Find the position to close: after the last node, before the closing tag
         if let Some(end) = prev_end {
-            let closing_tag_start = find_closing_tag_start(source, comp.end);
-            if closing_tag_start < comp.end {
+            let closing_tag_start = find_closing_tag_start(source, node_end);
+            if closing_tag_start < node_end {
                 // The closing tag's own collapsed gaps come first, so the caller
                 // emits this `}` as part of that overwrite.
                 return true;

--- a/crates/rsvelte_projection/src/svelte2tsx/template/nodes/inline_component.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/template/nodes/inline_component.rs
@@ -370,7 +370,9 @@ pub(crate) fn handle_component(
     if has_lets || children_have_named_slots || children_have_default_slot_lets {
         // Process children with slot scoping
         deferred_slot_close = process_component_children_with_slots(
-            comp,
+            &comp.attributes,
+            &comp.fragment,
+            comp.end,
             &inst_var,
             has_lets,
             source,
@@ -680,14 +682,38 @@ pub(crate) fn handle_svelte_component(
     str.overwrite(comp.start, opening_tag_end, &opener);
 
     // Children of svelte:component are at depth+1 (this component is now an
-    // ancestor). Mark the slot context so `slot="x"` children (incl. those
-    // nested in control-flow blocks) lower to `inst.$$slot_def["x"]`.
-    let prev_slot = counter.slot_inst.replace(inst_var.clone());
-    process_fragment_inplace(&comp.fragment, source, options, str, counter, depth + 1);
-    counter.slot_inst = prev_slot;
+    // ancestor). Slot-bearing children take the same lowering as a named
+    // component's (`$$slot_def.default` / `$$slot_def["x"]` blocks); the
+    // component's OWN `let:` block is already in `opener` above, so the helper
+    // is told not to emit it again.
+    let deferred_slot_close = if children_have_named_slots || children_have_default_slot_lets {
+        process_component_children_with_slots(
+            &comp.attributes,
+            &comp.fragment,
+            comp.end,
+            &inst_var,
+            false,
+            source,
+            options,
+            str,
+            counter,
+            depth + 1,
+        )
+    } else {
+        // Mark the slot context so `slot="x"` children nested in control-flow
+        // blocks still lower to `inst.$$slot_def["x"]`.
+        let prev_slot = counter.slot_inst.replace(inst_var.clone());
+        process_fragment_inplace(&comp.fragment, source, options, str, counter, depth + 1);
+        counter.slot_inst = prev_slot;
+        false
+    };
 
     let closing_tag_start = find_closing_tag_start(source, comp.end);
-    let closing_text = if has_lets_scomp { "}}" } else { "}" };
+    let closing_text = if has_lets_scomp || deferred_slot_close {
+        "}}"
+    } else {
+        "}"
+    };
     if closing_tag_start < comp.end {
         // `svelte:component` keeps no name mapping on its closing tag, so its
         // collapsed gaps are all that precede the closers.

--- a/crates/rsvelte_projection/tests/svelte2tsx_svelte_component_slot_2103.rs
+++ b/crates/rsvelte_projection/tests/svelte2tsx_svelte_component_slot_2103.rs
@@ -1,0 +1,113 @@
+//! Regression tests for #2103: `<svelte:component>` children must take the same
+//! slot lowering as a named component's — `handle_svelte_component` used to walk
+//! them with `process_fragment_inplace`, so a default-slot `let:` receiver
+//! (`<div let:x>` / `<svelte:fragment let:x>`) got no `$$slot_def.default`
+//! destructuring prologue and `x` resolved as an undeclared identifier.
+//!
+//! Every expectation below is the byte-exact template body official svelte2tsx
+//! (language-tools, parsing with svelte 5.56.8) emits for the same input.
+
+use rsvelte_projection::svelte2tsx::{Svelte2TsxOptions, svelte2tsx};
+
+fn convert(src: &str) -> String {
+    let opts = Svelte2TsxOptions {
+        filename: "Input.svelte".to_string(),
+        is_ts_file: false,
+        emit_jsdoc: true,
+        ..Default::default()
+    };
+    svelte2tsx(src, opts).expect("svelte2tsx ok").code
+}
+
+fn assert_contains(code: &str, expected: &str) {
+    assert!(
+        code.contains(expected),
+        "expected output to contain:\n{expected}\n\ngot:\n{code}"
+    );
+}
+
+/// The issue's repro: a `<div let:x>` default-slot child destructures from the
+/// `<svelte:component>` instance's `$$slot_def.default`.
+#[test]
+fn default_slot_let_element_child_forwards() {
+    let code = convert("<svelte:component this={Foo}><div let:x>{x}</div></svelte:component>\n");
+    assert_contains(
+        &code,
+        "const $$_tnenopmoc_etlevs0 = new $$_tnenopmoc_etlevs0C({ target: __sveltets_2_any(), props: { children:() => { return __sveltets_2_any(0); },}}); {const {/*\u{03A9}ignore_start\u{03A9}*/$$_$$/*\u{03A9}ignore_end\u{03A9}*/,x,} = $$_tnenopmoc_etlevs0.$$slot_def.default;$$_$$;{ svelteHTML.createElement(\"div\", { });x; }} }",
+    );
+}
+
+/// Same for the `<svelte:fragment let:x>` idiom, including the leading gap the
+/// block-open steals from the wrapped node's own indent.
+#[test]
+fn default_slot_let_fragment_child_forwards() {
+    let code = convert(
+        "<svelte:component this={Foo}>\n\t<svelte:fragment let:x>{x}</svelte:fragment>\n</svelte:component>\n",
+    );
+    assert_contains(
+        &code,
+        "\n\t {const {/*\u{03A9}ignore_start\u{03A9}*/$$_$$/*\u{03A9}ignore_end\u{03A9}*/,x,} = $$_tnenopmoc_etlevs0.$$slot_def.default;$$_$$;{ svelteHTML.createElement(\"svelte:fragment\", { });x; }}\n }",
+    );
+}
+
+/// The component's OWN `let:` block (emitted with the opener) and a child's
+/// forwarded block nest, and both close before the component block.
+#[test]
+fn component_let_and_child_let_nest() {
+    let code = convert(
+        "<svelte:component this={Foo} let:y>\n\t<div let:x>{x}{y}</div>\n</svelte:component>\n",
+    );
+    assert_contains(
+        &code,
+        "}});{const {/*\u{03A9}ignore_start\u{03A9}*/$$_$$/*\u{03A9}ignore_end\u{03A9}*/,y,} = $$_tnenopmoc_etlevs0.$$slot_def.default;$$_$$;\n\t {const {/*\u{03A9}ignore_start\u{03A9}*/$$_$$/*\u{03A9}ignore_end\u{03A9}*/,x,} = $$_tnenopmoc_etlevs0.$$slot_def.default;$$_$$;{ svelteHTML.createElement(\"div\", { });x;y; }}\n }}",
+    );
+}
+
+/// A `<svelte:fragment slot="a" let:x>` child now gets its `$$slot_def["a"]`
+/// wrapper (previously it kept a plain `"slot":`a`,` attribute instead).
+#[test]
+fn named_slot_fragment_child_is_wrapped() {
+    let code = convert(
+        "<svelte:component this={Foo}>\n\t<svelte:fragment slot=\"a\" let:x>{x}</svelte:fragment>\n</svelte:component>\n",
+    );
+    assert_contains(
+        &code,
+        "\n\t {const {/*\u{03A9}ignore_start\u{03A9}*/$$_$$/*\u{03A9}ignore_end\u{03A9}*/,x,} = $$_tnenopmoc_etlevs0.$$slot_def[\"a\"];$$_$$;{ svelteHTML.createElement(\"svelte:fragment\", {  });x; }}\n }",
+    );
+}
+
+/// Named-slot and default-slot siblings each get their own block.
+#[test]
+fn named_and_default_slot_siblings() {
+    let code = convert(
+        "<svelte:component this={Foo}>\n\t<div slot=\"a\" let:x>{x}</div>\n\t<span let:y>{y}</span>\n</svelte:component>\n",
+    );
+    assert_contains(
+        &code,
+        "\n\t {const {/*\u{03A9}ignore_start\u{03A9}*/$$_$$/*\u{03A9}ignore_end\u{03A9}*/,x,} = $$_tnenopmoc_etlevs0.$$slot_def[\"a\"];$$_$$;{ svelteHTML.createElement(\"div\", {  });x; }}\n\t {const {/*\u{03A9}ignore_start\u{03A9}*/$$_$$/*\u{03A9}ignore_end\u{03A9}*/,y,} = $$_tnenopmoc_etlevs0.$$slot_def.default;$$_$$;{ svelteHTML.createElement(\"span\", { });y; }}\n }",
+    );
+}
+
+/// A COMPONENT child's `let:` still binds from its OWN slot def (the #1232
+/// rule): routing `<svelte:component>` children through the slot path must not
+/// re-forward them onto the dynamic component's instance.
+#[test]
+fn component_child_let_still_binds_from_its_own_slot_def() {
+    let code =
+        convert("<svelte:component this={Foo}>\n\t<Bar let:x>{x}</Bar>\n</svelte:component>\n");
+    assert_contains(&code, "$$_raB1.$$slot_def.default");
+    assert!(
+        !code.contains("$$_tnenopmoc_etlevs0.$$slot_def"),
+        "the dynamic component must not carry Bar's let: bindings, got:\n{code}"
+    );
+}
+
+/// Plain default-slot children keep the untouched walk — no spurious block.
+#[test]
+fn plain_children_get_no_slot_block() {
+    let code = convert("<svelte:component this={Foo}>\n\t<div>hello</div>\n</svelte:component>\n");
+    assert!(
+        !code.contains("$$slot_def"),
+        "children without let:/slot= must not open a slot block, got:\n{code}"
+    );
+}


### PR DESCRIPTION
Fixes #2103

## Cause

`handle_svelte_component` walked its fragment with `process_fragment_inplace`
instead of `process_component_children_with_slots`, so `<svelte:component>`
children bypassed the `$$slot_def` lowering entirely:

- a default-slot `let:` receiver (`<div let:x>` / `<svelte:fragment let:x>`)
  got **no** `{const { $$_$$, x, } = inst.$$slot_def.default; $$_$$;` prologue,
  so `x` resolved as an undeclared identifier in the generated TSX;
- a `<svelte:fragment slot="a">` child kept a plain `` "slot":`a`, ``
  attribute instead of being wrapped in the `$$slot_def["a"]` block.

Official svelte2tsx models `svelte:component` as an `InlineComponent`
(`htmlxtojsx_v2/nodes/InlineComponent.ts`), so its slot content forwards
exactly like a named component's.

## Fix

`process_component_children_with_slots` now takes the owning node's
`attributes` / `fragment` / end offset rather than a `&Component`, so
`handle_component` and `handle_svelte_component` share one implementation.
`handle_svelte_component` routes through it whenever a child carries `slot=` or
a default-slot `let:`.

The dynamic component's **own** `let:` block stays where it was (appended to
the opener string) because it must also cover the no-children forms
(`<svelte:component this={C} let:x />` and `<svelte:component this={C} let:x></svelte:component>`),
which never reach the helper — so the helper is told not to re-emit it, and the
returned "default block still open" flag is folded into the closing-tag text.

## Testing

- **Oracle parity**: 20 `<svelte:component>` slot shapes (default-slot `let:`
  on an element / `svelte:fragment`, component-own `let:`, named slot,
  named+default siblings, component children, nested `svelte:component`,
  `svelte:self`, `bind:`/`on:`, self-closing, `{#if}`-nested `slot=`, plain
  children) are now **byte-identical** to official svelte2tsx built from
  `submodules/language-tools` and pinned to svelte 5.56.8. Six of them diverged
  before this change.
- **Regression sweep**: all 64 `.svelte` files under `submodules/svelte` +
  `submodules/language-tools` containing `svelte:component` were converted with
  both tools before and after. No entry regressed; the only output that changed
  is `tests/migrate/samples/svelte-component/input.svelte`, which moved toward
  official (its `<svelte:component><svelte:fragment slot="x" let:comp>` block is
  now correct).
- `cargo test -p rsvelte_projection` — all green, including the 253-fixture
  svelte2tsx suite; `cargo test -p rsvelte_check` green.
- New `crates/rsvelte_projection/tests/svelte2tsx_svelte_component_slot_2103.rs`
  (7 tests) asserts the byte-exact official template bodies, plus the #1232
  invariant (a component child's `let:` still binds from its own slot def) and
  that plain children open no block.
- `compatibility/svelte2tsx-known-failures.json` is already `[]`, so there is
  nothing to shrink.
- `cargo fmt` + `cargo clippy --all-targets --all-features -- -D warnings` clean.

## Out of scope (pre-existing, verified unchanged by this PR)

Found while sweeping; each reproduces identically on `main` and with a plain
component parent, so none belongs here:

- `<Comp><input slot="a" /></Comp>` — rsvelte emits one extra space before the
  `}}` for void / self-closing named-slot elements.
- `<Comp><svelte:fragment slot="x" let:comp={stuff}>` — the stripped-attribute
  space count inside `createElement("svelte:fragment", { … })` is one short when
  a `let:` has a value.
- `<Outer><svelte:component this={Foo} slot="a" /></Outer>` — a
  `SvelteComponent` child with `slot=` is not recognised as a named-slot child
  by the parent (`has_named_slot_children` matches only
  `RegularElement` / `Component` / `SvelteFragment` / `SlotElement` /
  `SvelteElement`), so it is not wrapped in the parent's `$$slot_def["a"]`.

The first two are in the #2105 opener-spacing family; the third is a sibling
gap worth its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
