### PR TITLE
fix(compiler): build the legacy destructured object rest with `$.exclude_from_object` (#2078)

### DIFF
--- a/.changeset/fix-legacy-object-rest-exclude-from-object.md
+++ b/.changeset/fix-legacy-object-rest-exclude-from-object.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/compiler": patch
+---
+
+Legacy (non-runes) destructured declarations now lower an object rest as `$.exclude_from_object(tmp, [keys])` like the official compiler, instead of reading a non-existent `tmp.rest` property — and a rest bound to state keeps its `$.mutable_source` wrapper (plus the dev `$.tag` label). The same expansion also stopped dropping pattern defaults (`{ a = 1 }` / `[a = 1]` now emit `$.fallback(...)`) and stopped emitting invalid member reads for literal and computed keys (`tmp['b-c']`, `tmp[3]`, `tmp[key]`).

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/state_transforms.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/state_transforms.rs
@@ -3,11 +3,13 @@
 use memchr::memmem;
 use rustc_hash::FxHashSet;
 
+use super::destructure_transforms::build_fallback_string;
 use super::expression_utils::{
     byte_pos_to_char_index, find_statement_end_client, is_shadowed_by_for_loop_var,
 };
 use super::rune_transforms::{
-    find_derived_property_colon, split_derived_array_elements, split_derived_object_properties,
+    derived_prop_access, exclude_key_literal, find_default_equals, find_derived_property_colon,
+    split_derived_array_elements, split_derived_object_properties,
 };
 use super::{SCRIPT_ARRAY_COUNTER, STATE_TMP_COUNTER, get_or_compile_regex};
 use crate::compiler::phases::phase2_analyze::scope::DeclarationKind;
@@ -1375,6 +1377,26 @@ pub(super) fn transform_legacy_destructure_declarations(
         let props = split_derived_object_properties(inner);
         let mut parts = vec![format!("{} = {}", tmp_name, expr)];
 
+        let has_rest = props.iter().any(|prop| prop.trim().starts_with("..."));
+        let excluded_keys: Vec<String> = props
+            .iter()
+            .filter(|_| has_rest)
+            .filter_map(|prop| {
+                let prop = prop.trim();
+                if prop.is_empty() || prop.starts_with("...") {
+                    return None;
+                }
+                let key = if let Some(colon_pos) = find_derived_property_colon(prop) {
+                    prop[..colon_pos].trim()
+                } else if let Some(eq_pos) = find_default_equals(prop) {
+                    prop[..eq_pos].trim()
+                } else {
+                    prop
+                };
+                Some(exclude_key_literal(key))
+            })
+            .collect();
+
         for prop in &props {
             let prop = prop.trim();
             if prop.is_empty() {
@@ -1383,56 +1405,57 @@ pub(super) fn transform_legacy_destructure_declarations(
 
             if let Some(rest_name) = prop.strip_prefix("...") {
                 let rest_name = rest_name.trim();
-                parts.push(format!("{} = {}.{}", rest_name, tmp_name, rest_name));
+                let access = format!(
+                    "$.exclude_from_object({}, [{}])",
+                    tmp_name,
+                    excluded_keys.join(", ")
+                );
+                if legacy_state_var_names.contains(&rest_name.to_string()) {
+                    parts.push(format!(
+                        "{} = {}",
+                        rest_name,
+                        tag_legacy_source(
+                            format!("$.mutable_source({}{})", access, immutable_arg),
+                            rest_name,
+                            dev
+                        )
+                    ));
+                } else {
+                    parts.push(format!("{} = {}", rest_name, access));
+                }
                 continue;
             }
 
-            if let Some(colon_pos) = find_derived_property_colon(prop) {
-                let key = prop[..colon_pos].trim();
-                let value_part = prop[colon_pos + 1..].trim();
-                let var_name = if let Some(eq_pos) = value_part.find('=') {
-                    value_part[..eq_pos].trim()
-                } else {
-                    value_part
-                };
+            let (explicit_key, value_part) = match find_derived_property_colon(prop) {
+                Some(colon_pos) => (Some(prop[..colon_pos].trim()), prop[colon_pos + 1..].trim()),
+                None => (None, prop),
+            };
+            let (var_name, default_val) = match find_default_equals(value_part) {
+                Some(eq_pos) => (
+                    value_part[..eq_pos].trim(),
+                    Some(value_part[eq_pos + 1..].trim()),
+                ),
+                None => (value_part, None),
+            };
+            let key = explicit_key.unwrap_or(var_name);
 
-                let is_state = legacy_state_var_names.contains(&var_name.to_string());
-                let member = format!("{}.{}", tmp_name, key);
-                if is_state {
-                    parts.push(format!(
-                        "{} = {}",
+            let member = derived_prop_access(tmp_name.as_str(), tmp_name.as_str(), key);
+            let access = match default_val {
+                Some(default_val) => build_fallback_string(&member, default_val),
+                None => member,
+            };
+            if legacy_state_var_names.contains(&var_name.to_string()) {
+                parts.push(format!(
+                    "{} = {}",
+                    var_name,
+                    tag_legacy_source(
+                        format!("$.mutable_source({}{})", access, immutable_arg),
                         var_name,
-                        tag_legacy_source(
-                            format!("$.mutable_source({}{})", member, immutable_arg),
-                            var_name,
-                            dev
-                        )
-                    ));
-                } else {
-                    parts.push(format!("{} = {}", var_name, member));
-                }
+                        dev
+                    )
+                ));
             } else {
-                let var_name = if let Some(eq_pos) = prop.find('=') {
-                    prop[..eq_pos].trim()
-                } else {
-                    prop
-                };
-
-                let is_state = legacy_state_var_names.contains(&var_name.to_string());
-                let member = format!("{}.{}", tmp_name, var_name);
-                if is_state {
-                    parts.push(format!(
-                        "{} = {}",
-                        var_name,
-                        tag_legacy_source(
-                            format!("$.mutable_source({}{})", member, immutable_arg),
-                            var_name,
-                            dev
-                        )
-                    ));
-                } else {
-                    parts.push(format!("{} = {}", var_name, member));
-                }
+                parts.push(format!("{} = {}", var_name, access));
             }
         }
 
@@ -1495,20 +1518,27 @@ pub(super) fn transform_legacy_destructure_declarations(
                 continue;
             }
 
-            let access = format!("$.get({})[{}]", array_var, i);
-            let is_state = legacy_state_var_names.contains(&element.to_string());
-            if is_state {
+            let (var_name, default_val) = match find_default_equals(element) {
+                Some(eq_pos) => (element[..eq_pos].trim(), Some(element[eq_pos + 1..].trim())),
+                None => (element, None),
+            };
+            let member = format!("$.get({})[{}]", array_var, i);
+            let access = match default_val {
+                Some(default_val) => build_fallback_string(&member, default_val),
+                None => member,
+            };
+            if legacy_state_var_names.contains(&var_name.to_string()) {
                 parts.push(format!(
                     "{} = {}",
-                    element,
+                    var_name,
                     tag_legacy_source(
                         format!("$.mutable_source({}{})", access, immutable_arg),
-                        element,
+                        var_name,
                         dev
                     )
                 ));
             } else {
-                parts.push(format!("{} = {}", element, access));
+                parts.push(format!("{} = {}", var_name, access));
             }
         }
 
@@ -1532,19 +1562,14 @@ pub(super) fn extract_legacy_destructure_var_names(pattern: &str) -> Vec<String>
             }
             if let Some(rest_name) = prop.strip_prefix("...") {
                 names.push(rest_name.trim().to_string());
-            } else if let Some(colon_pos) = find_derived_property_colon(prop) {
-                let value_part = prop[colon_pos + 1..].trim();
-                let var_name = if let Some(eq_pos) = value_part.find('=') {
-                    value_part[..eq_pos].trim()
-                } else {
-                    value_part
-                };
-                names.push(var_name.to_string());
             } else {
-                let var_name = if let Some(eq_pos) = prop.find('=') {
-                    prop[..eq_pos].trim()
-                } else {
-                    prop
+                let value_part = match find_derived_property_colon(prop) {
+                    Some(colon_pos) => prop[colon_pos + 1..].trim(),
+                    None => prop,
+                };
+                let var_name = match find_default_equals(value_part) {
+                    Some(eq_pos) => value_part[..eq_pos].trim(),
+                    None => value_part,
                 };
                 names.push(var_name.to_string());
             }
@@ -1560,12 +1585,35 @@ pub(super) fn extract_legacy_destructure_var_names(pattern: &str) -> Vec<String>
             if let Some(rest_name) = el.strip_prefix("...") {
                 names.push(rest_name.trim().to_string());
             } else {
-                names.push(el.to_string());
+                let var_name = match find_default_equals(el) {
+                    Some(eq_pos) => el[..eq_pos].trim(),
+                    None => el,
+                };
+                names.push(var_name.to_string());
             }
         }
     }
 
     names
+}
+
+/// Whether a statement is the chained `<keyword> tmp = expr, … ` expansion built
+/// by `transform_legacy_destructure_declarations`; those must not be split into
+/// one declaration per declarator, because the later ones read the `tmp` /
+/// `$$array` helpers declared alongside them.
+fn is_legacy_destructure_expansion(line: &str) -> bool {
+    if memmem::find(line.as_bytes(), b"$.mutable_source(").is_none() {
+        return false;
+    }
+    let trimmed = line.trim_start();
+    let after_keyword = ["let ", "const ", "var "]
+        .iter()
+        .find_map(|kw| trimmed.strip_prefix(kw));
+    let Some(rest) = after_keyword.and_then(|rest| rest.trim_start().strip_prefix("tmp")) else {
+        return false;
+    };
+    let rest = rest.trim_start_matches(|c: char| c == '_' || c.is_ascii_digit());
+    rest.trim_start().starts_with('=')
 }
 
 /// Dev-mode `$.tag(<source>, '<name>')` label for a legacy state source.
@@ -1605,9 +1653,9 @@ pub(super) fn transform_legacy_state_declarations(
     // Split into individual declarations first to handle each one separately.
     // BUT skip declarations produced by transform_legacy_destructure_declarations
     // (which chain `tmp = expr, foo = $.mutable_source(tmp.foo), ...` and must stay chained).
-    let is_destructure_expansion = memmem::find(line.as_bytes(), b"$.mutable_source(tmp").is_some()
-        || memmem::find(line.as_bytes(), b"$.mutable_source(tmp_").is_some();
-    if !is_destructure_expansion && let Some(split_lines) = split_multi_declarator(line) {
+    if !is_legacy_destructure_expansion(line)
+        && let Some(split_lines) = split_multi_declarator(line)
+    {
         let transformed_lines: Vec<String> = split_lines
             .iter()
             .map(|l| transform_legacy_state_declarations(l, legacy_state_vars, immutable, dev))

--- a/crates/rsvelte_core/tests/legacy_destructure_rest_2078.rs
+++ b/crates/rsvelte_core/tests/legacy_destructure_rest_2078.rs
@@ -1,0 +1,134 @@
+//! Regression tests for issue #2078 — the legacy (non-runes) `tmp`-based
+//! destructuring expansion.
+//!
+//! Upstream builds it with `extract_paths`, so an object rest reads
+//! `$.exclude_from_object(tmp, [<keys>])` (never `tmp.rest`), every path keeps
+//! its `$.mutable_source` / `$.tag` wrapping when the binding is state, and the
+//! whole expansion stays a single chained declaration.
+
+use rsvelte_core::{CompileOptions, GenerateMode, compile, compiler::CssMode};
+
+fn compile_client(src: &str, dev: bool) -> String {
+    compile(
+        src,
+        CompileOptions {
+            filename: Some("Comp.svelte".to_string()),
+            generate: GenerateMode::Client,
+            dev,
+            css: CssMode::External,
+            ..Default::default()
+        },
+    )
+    .expect("compile")
+    .js
+    .code
+}
+
+const OBJECT_REST: &str = r#"<script>
+	let { a, b, ...rest } = { a: 1, b: 2, c: 3 };
+	function f() {
+		a++;
+		rest = { ...rest, z: 1 };
+	}
+</script>
+<button onclick={f}>{a} {b} {JSON.stringify(rest)}</button>"#;
+
+#[test]
+fn state_object_rest_uses_exclude_from_object_and_mutable_source() {
+    let out = compile_client(OBJECT_REST, false);
+    assert!(
+        out.contains("rest = $.mutable_source($.exclude_from_object(tmp, ['a', 'b']))"),
+        "in:\n{out}"
+    );
+    assert!(!out.contains("rest = tmp.rest"), "in:\n{out}");
+}
+
+#[test]
+fn state_object_rest_is_labelled_in_dev() {
+    let out = compile_client(OBJECT_REST, true);
+    assert!(
+        out.contains(
+            "rest = $.tag($.mutable_source($.exclude_from_object(tmp, ['a', 'b'])), 'rest')"
+        ),
+        "in:\n{out}"
+    );
+}
+
+#[test]
+fn non_state_object_rest_stays_a_plain_exclude_from_object() {
+    let src = r#"<script>
+	let { a, ...rest } = { a: 1, c: 3 };
+	function f() {
+		a++;
+	}
+</script>
+<button onclick={f}>{a} {JSON.stringify(rest)}</button>"#;
+    let out = compile_client(src, false);
+    assert!(
+        out.contains("rest = $.exclude_from_object(tmp, ['a'])"),
+        "in:\n{out}"
+    );
+}
+
+/// Upstream's key list is built with `b.literal(...)`: identifier and literal
+/// keys become string literals, any other computed key becomes `String(<expr>)`.
+/// The member reads keep bracket notation for the same non-identifier keys.
+#[test]
+fn computed_and_literal_keys_are_lowered_like_upstream() {
+    let src = r#"<script>
+	const key = 'd';
+	let { a, 'b-c': bc, 3: three, [key]: dee, e = 7, ...rest } = { a: 1 };
+	function f() {
+		bc++;
+		rest = {};
+	}
+</script>
+<button onclick={f}>{a} {bc} {three} {dee} {e} {JSON.stringify(rest)}</button>"#;
+    let out = compile_client(src, false);
+    assert!(
+        out.contains(
+            "rest = $.mutable_source($.exclude_from_object(tmp, ['a', 'b-c', '3', String(key), 'e']))"
+        ),
+        "in:\n{out}"
+    );
+    assert!(
+        out.contains("bc = $.mutable_source(tmp['b-c'])"),
+        "in:\n{out}"
+    );
+    assert!(out.contains("three = tmp[3]"), "in:\n{out}");
+    assert!(out.contains("dee = tmp[key]"), "in:\n{out}");
+    assert!(out.contains("e = $.fallback(tmp.e, 7)"), "in:\n{out}");
+}
+
+#[test]
+fn array_pattern_default_becomes_a_fallback() {
+    let src = r#"<script>
+	let [a = 9, b] = [1, 2];
+	function f() {
+		a++;
+	}
+</script>
+<button onclick={f}>{a} {b}</button>"#;
+    let out = compile_client(src, false);
+    assert!(
+        out.contains("a = $.mutable_source($.fallback($.get($$array)[0], 9))"),
+        "in:\n{out}"
+    );
+}
+
+/// The later declarators read the `tmp` / `$$array` helpers declared beside
+/// them, so the expansion must not be split into one statement per declarator.
+#[test]
+fn array_expansion_stays_one_chained_declaration() {
+    let src = r#"<script>
+	let [a, b, ...rest] = [1, 2, 3];
+	function f() {
+		a++;
+	}
+</script>
+<button onclick={f}>{a} {b} {JSON.stringify(rest)}</button>"#;
+    let out = compile_client(src, false);
+    assert!(out.contains("let tmp = [1, 2, 3],"), "in:\n{out}");
+    assert!(!out.contains("let $$array"), "in:\n{out}");
+    assert!(out.contains("rest = $.get($$array).slice(2)"), "in:\n{out}");
+}


### PR DESCRIPTION
Fixes #2078

## Cause

`transform_legacy_destructure_declarations()` — the legacy (non-runes) `tmp`-based
expansion of a destructured declaration that contains state — special-cased an
object rest element with `parts.push(format!("{} = {}.{}", rest_name, tmp_name, rest_name))`
and then `continue`d. So it both invented a `tmp.rest` property read that does not
exist and skipped the `is_state` check below it, losing `$.mutable_source` (and,
in dev, `$.tag`).

Upstream builds the same expansion from `extract_paths()` (`utils/ast.js`), where
an `ObjectPattern` rest becomes `$.exclude_from_object(<expression>, [<keys>])` and
is pushed as an ordinary path — so `create_state_declarators()` wraps it in
`mutable_source(...)` like every other leaf when the binding is `state`.

## Fix

All in `crates/rsvelte_core/src/compiler/phases/3_transform/client/state_transforms.rs`.

- The object rest now emits `$.exclude_from_object(tmp, [<keys>])` and goes through
  the same state / `$.tag` wrapping as the other properties. The key list reuses the
  existing `exclude_key_literal()` helper, so identifier and literal keys become
  string literals and any other computed key becomes `String(<expr>)`, matching
  upstream's `b.literal(...)` / `b.call('String', key)` build.

Two adjacent divergences in the same expansion, which the rest fix exposed — a
`{ 'b-c': x, ...rest }` pattern used to emit the syntactically invalid
`x = tmp.'b-c'` right next to the now-correct exclude list:

- Non-identifier keys now use bracket notation (`tmp['b-c']`, `tmp[3]`, `tmp[key]`)
  via the shared `derived_prop_access()`, mirroring upstream's
  `b.member(expression, prop.key, prop.computed || prop.key.type !== 'Identifier')`.
- Pattern defaults are no longer dropped: `{ e = 7 }` / `[a = 9]` now emit
  `$.fallback(tmp.e, 7)` / `$.fallback($.get($$array)[0], 9)`, upstream's
  `AssignmentPattern` → `build_fallback` step.

And one guard that the above made reachable:

- `transform_legacy_state_declarations()` recognised the expansion by sniffing for
  the literal `$.mutable_source(tmp`, which never matched an array pattern
  (`$.mutable_source($.get($$array)[0])`) nor an object whose only state leaf is the
  rest. Those were split into one `let` per declarator, leaving the later ones
  referencing `tmp` / `$$array` helpers declared in a different statement. It now
  checks that the statement is the `<keyword> tmp… = ` chain instead.

## Horizontal check

Compared against the official compiler with `scripts/compat-corpus/one.mjs`,
byte-identical both with and without oxfmt normalization, for `client`, `client-dev`
and `server`: rest in `$state` / `$derived` destructuring, `$props()`, `{#each}`
patterns and `{#snippet}` parameters all already matched upstream and are unaffected.

Two unrelated pre-existing gaps turned up while checking and are **not** touched here,
because each needs its own issue:

- A legacy *assignment* destructure whose targets are state (`({ a, ...rest } = obj)`
  inside a function) drops the `$.set(...)` wrapping and the prop call, and mis-quotes
  literal keys in its own exclude list — a different code path
  (`destructure_transforms.rs`).
- A legacy declaration with a *nested* pattern (`let { a: { b }, ...rest } = obj`) is
  not expanded at all, because the state check never sees the inner name; upstream's
  `_extract_paths` recurses. Making the string-based expansion recursive is a bigger
  change than this fix.

## Tests

- New `crates/rsvelte_core/tests/legacy_destructure_rest_2078.rs` — state / non-state
  object rest, the dev `$.tag` label, computed + literal keys, array defaults, and the
  chained-declaration invariant.
- `cargo test --release -p rsvelte_core` green.
- Corpus `client` / `client-dev` verify: no regressions. Nothing currently in the
  ratchets is resolved by this change, so no baseline shrinks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
