### PR TITLE
fix(compiler): let a block-local {#snippet} shadow a same-named binding (#2067)

### DIFF
--- a/.changeset/render-tag-snippet-shadows-binding.md
+++ b/.changeset/render-tag-snippet-shadows-binding.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/compiler": patch
+---
+
+A `{#snippet}` declared inside a block now shadows a same-named outer binding for the whole fragment, matching upstream's scope rules. `{#each items as item}{#snippet row()}…{/snippet}{@render row()}{/each}` next to a `let { row } = $props()` emitted the prop read `$$props.row($$anchor)` on the client (a `TypeError` when the prop is not passed) and the derived read `row()($$renderer)` on the server; both now call the local snippet directly.

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/utils.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/utils.rs
@@ -5,10 +5,42 @@
 //!
 //! Corresponds to `svelte/packages/svelte/src/compiler/phases/3-transform/client/utils.js`.
 
+use crate::ast::template::TemplateNode;
 use crate::compiler::phases::phase2_analyze::scope::Binding;
 use crate::compiler::phases::phase2_analyze::scope::BindingKind;
 use crate::compiler::phases::phase2_analyze::types::ComponentAnalysis;
 use rustc_hash::FxHashSet;
+
+/// Let the `{#snippet}` blocks a fragment declares shadow the inherited reads of
+/// the same name, so identifiers inside that fragment resolve to the snippet.
+///
+/// Mirrors `get_transform` in
+/// `svelte/packages/svelte/src/compiler/phases/3-transform/client/utils.js`,
+/// which deletes every `normal`-kind declaration of the scope being entered from
+/// the inherited transform map. In a template fragment those `normal`
+/// declarations are exactly the snippet names (`scope.declare(node.expression,
+/// 'normal', 'function', node)` in `scope.js`). `shadowed_prop_names` covers the
+/// same ground for the non-source-prop shortcut in `expression_converter`, which
+/// resolves `$$props.x` straight from the binding instead of the transform map.
+pub fn shadow_snippet_declarations(
+    nodes: &[TemplateNode<'_>],
+    transform: &mut im::HashMap<
+        String,
+        crate::compiler::phases::phase3_transform::client::types::IdentifierTransform,
+    >,
+    transform_deep_read: &mut im::HashMap<String, ()>,
+    shadowed_prop_names: &mut im::HashSet<String>,
+) {
+    for node in nodes {
+        if let TemplateNode::SnippetBlock(snippet) = node
+            && let Some(name) = snippet.expression.name()
+        {
+            transform.remove(name);
+            transform_deep_read.remove(name);
+            shadowed_prop_names.insert(name.to_string());
+        }
+    }
+}
 
 /// Check if `text` contains any identifier that appears in `vars`.
 ///

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/fragment.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/fragment.rs
@@ -134,6 +134,16 @@ pub fn fragment(
     let mut body: Vec<JsStatement> = Vec::new();
     let mut close: Option<JsStatement> = None;
 
+    let mut fragment_transform = context.state.transform.clone();
+    let mut fragment_transform_deep_read = context.state.transform_deep_read.clone();
+    let mut fragment_shadowed_prop_names = context.state.shadowed_prop_names.clone();
+    crate::compiler::phases::phase3_transform::client::utils::shadow_snippet_declarations(
+        &node.nodes,
+        &mut fragment_transform,
+        &mut fragment_transform_deep_read,
+        &mut fragment_shadowed_prop_names,
+    );
+
     // Create new state for this fragment
     // Use Memoizer::with_parent_conflicts to inherit conflicts from the parent,
     // ensuring variable names don't collide between outer and inner scopes (e.g., nested IfBlocks)
@@ -156,8 +166,8 @@ pub fn fragment(
         let_directives: Vec::new(),
         node: context.state.node.clone(),
         memoizer: Memoizer::with_parent_conflicts(&context.state.memoizer),
-        transform: context.state.transform.clone(),
-        transform_deep_read: context.state.transform_deep_read.clone(),
+        transform: fragment_transform,
+        transform_deep_read: fragment_transform_deep_read,
         events: indexmap::IndexSet::default(), // Start empty, merge back later
         metadata: ComponentMetadata {
             namespace: namespace.clone(),
@@ -208,7 +218,7 @@ pub fn fragment(
         destructure_array_counter: context.state.destructure_array_counter.clone(),
         needs_props_from_events: context.state.needs_props_from_events.clone(),
         hidden_let_bindings: context.state.hidden_let_bindings.clone(),
-        shadowed_prop_names: context.state.shadowed_prop_names.clone(),
+        shadowed_prop_names: fragment_shadowed_prop_names,
         blocker_map: context.state.blocker_map.clone(),
         blocker_map_primary_names: context.state.blocker_map_primary_names.clone(),
         extra_blocker_indices: Vec::new(),

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/regular_element.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/regular_element.rs
@@ -951,6 +951,18 @@ pub fn visit_regular_element(
         }
     }
 
+    // `{#snippet}` children shadow a same-named outer binding for the whole
+    // element fragment, exactly as they do for a block fragment (see
+    // `client::utils::shadow_snippet_declarations`).
+    let saved_transform_deep_read = context.state.transform_deep_read.clone();
+    let saved_shadowed_props = context.state.shadowed_prop_names.clone();
+    crate::compiler::phases::phase3_transform::client::utils::shadow_snippet_declarations(
+        &node.fragment.nodes,
+        &mut context.state.transform,
+        &mut context.state.transform_deep_read,
+        &mut context.state.shadowed_prop_names,
+    );
+
     // Propagate preserve_whitespace to child processing so that `pre`/`textarea`
     // whitespace is preserved for ExpressionTag/Text content within nested elements.
     // This mirrors the official compiler's state spread:
@@ -1319,6 +1331,8 @@ pub fn visit_regular_element(
     context.state.consts = saved_child_consts;
     context.state.scope = saved_scope;
     context.state.transform = saved_transform;
+    context.state.transform_deep_read = saved_transform_deep_read;
+    context.state.shadowed_prop_names = saved_shadowed_props;
     if has_declarations {
         context.state.async_consts = saved_async_consts;
     }

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/visitors/component.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/visitors/component.rs
@@ -399,6 +399,14 @@ fn build_component_children<'a, 'b>(
     let mut snippet_declarations: Vec<Statement<'a>> = Vec::new();
     let mut serialized_slots: Vec<ObjectPropertyKind<'a>> = Vec::new();
 
+    // A component's `{#snippet}` children are lifted out into props, so the slot
+    // bodies never see them through `process_children_inner`'s own frame — push
+    // the shadow here so a sibling `{@render row()}` still resolves to the local
+    // snippet instead of a same-named outer `$derived` / store.
+    state
+        .shadowed_names
+        .push(super::shared::fragment_snippet_names(&fragment.nodes));
+
     // Group non-snippet children by slot name (default vs `slot="name"`).
     // Snippet blocks are handled inline (they become named props + `$$slots`).
     let mut default_children: Vec<&'b TemplateNode<'a>> = Vec::new();
@@ -535,6 +543,7 @@ fn build_component_children<'a, 'b>(
         push_prop(groups, state.b.init("$$slots", slots_obj));
     }
 
+    state.shadowed_names.pop();
     snippet_declarations
 }
 

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/visitors/shared.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/visitors/shared.rs
@@ -64,6 +64,21 @@ pub enum TemplateEntry<'a> {
     HoistableDecl(Statement<'a>),
 }
 
+/// The names declared by the `{#snippet}` blocks directly inside a fragment.
+pub fn fragment_snippet_names<'a, N: AsRef<TemplateNode<'a>>>(
+    nodes: &[N],
+) -> rustc_hash::FxHashSet<String> {
+    let mut out = rustc_hash::FxHashSet::default();
+    for node in nodes {
+        if let TemplateNode::SnippetBlock(snippet) = node.as_ref()
+            && let Some(name) = snippet.expression.name()
+        {
+            out.insert(name.to_string());
+        }
+    }
+    out
+}
+
 /// Port of upstream `process_children`: walk a slice of sibling template nodes,
 /// joining adjacent Text / Comment / ExpressionTag siblings into a single
 /// [`TemplateEntry::Template`] and recursing into element/block children.
@@ -142,6 +157,14 @@ pub fn process_children_inner<'a, N: AsRef<TemplateNode<'a>>>(
         Some(v) => v,
         None => nodes.iter().map(|n| n.as_ref()).collect(),
     };
+
+    // 写经 upstream `get_transform`: the `{#snippet}` blocks a fragment declares
+    // are `normal` bindings in its scope, so they shadow a same-named outer
+    // `$derived` / store for the whole fragment — `{@render row()}` next to a
+    // local `{#snippet row()}` must not be read-wrapped into `row()()`.
+    state
+        .shadowed_names
+        .push(fragment_snippet_names(&iter_nodes));
 
     let mut hoisted: Vec<&TemplateNode> = Vec::new();
     let mut filtered: Vec<&TemplateNode> = Vec::new();
@@ -351,6 +374,7 @@ pub fn process_children_inner<'a, N: AsRef<TemplateNode<'a>>>(
         }
     }
     flush_sequence(&sequence, state);
+    state.shadowed_names.pop();
     state.in_element_children = saved_in_element;
     state.namespace = saved_namespace;
 }

--- a/crates/rsvelte_core/tests/render_tag_snippet_shadows_binding_2067.rs
+++ b/crates/rsvelte_core/tests/render_tag_snippet_shadows_binding_2067.rs
@@ -1,0 +1,151 @@
+//! Regression tests for issue #2067 — a `{#snippet}` declared inside a block
+//! must shadow a same-named outer binding for the whole fragment.
+//!
+//! Upstream declares the snippet name as a `normal` binding in the fragment's
+//! scope (`scope.js` `SnippetBlock`), and `get_transform` drops every `normal`
+//! declaration of a scope from the inherited read-transform map when the client
+//! walker enters it. rsvelte kept the outer entry, so `{@render row()}` next to
+//! a block-local `{#snippet row()}` emitted the prop read `$$props.row(...)`
+//! (client) or the derived read `row()(...)` (server).
+
+use rsvelte_core::{CompileOptions, GenerateMode, compile, compiler::CssMode};
+
+fn compile_js(src: &str, generate: GenerateMode) -> String {
+    compile(
+        src,
+        CompileOptions {
+            filename: Some("Test.svelte".to_string()),
+            generate,
+            dev: false,
+            css: CssMode::External,
+            ..Default::default()
+        },
+    )
+    .expect("compile")
+    .js
+    .code
+}
+
+/// The issue's repro.
+const EACH_SHADOWS_PROP: &str = r#"<script>
+	let { row } = $props();
+	let items = [1];
+</script>
+{#each items as item}{#snippet row()}<b>{item}</b>{/snippet}{@render row()}{/each}"#;
+
+#[test]
+fn block_local_snippet_wins_over_a_same_named_prop() {
+    let out = compile_js(EACH_SHADOWS_PROP, GenerateMode::Client);
+    assert!(
+        out.contains("row($$anchor)"),
+        "expected the local snippet to be called in:\n{out}"
+    );
+    assert!(
+        !out.contains("$$props.row"),
+        "the prop binding still won in:\n{out}"
+    );
+}
+
+/// Every read of the shadowed name inside the fragment is affected, not just the
+/// `{@render}` callee.
+#[test]
+fn snippet_shadows_the_prop_for_other_expressions_too() {
+    let src = r#"<script>
+	let { row } = $props();
+	let open = $state(true);
+</script>
+{#if open}{#snippet row()}<b>local</b>{/snippet}<p title={typeof row}>x</p>{/if}"#;
+    let out = compile_js(src, GenerateMode::Client);
+    assert!(
+        !out.contains("$$props.row"),
+        "the prop binding still won in:\n{out}"
+    );
+}
+
+/// The shadowing region is the fragment, so an element's `{#snippet}` child only
+/// shadows inside that element.
+#[test]
+fn snippet_inside_an_element_shadows_within_that_element() {
+    let src = r#"<script>
+	let { row } = $props();
+	let open = $state(true);
+</script>
+{#if open}<div>{#snippet row()}<b>local</b>{/snippet}{@render row()}</div>{/if}"#;
+    let out = compile_js(src, GenerateMode::Client);
+    assert!(
+        out.contains("row(node_1)") || out.contains("row(node)"),
+        "expected the local snippet to be called in:\n{out}"
+    );
+    assert!(
+        !out.contains("$$props.row"),
+        "the prop binding still won in:\n{out}"
+    );
+}
+
+/// Server: the shadowed name must not be read-wrapped as a `$derived` getter.
+#[test]
+fn server_snippet_shadows_a_same_named_derived() {
+    let src = r#"<script>
+	let base = $state(1);
+	let row = $derived(base + 1);
+	let open = $state(true);
+</script>
+{#if open}{#snippet row()}<b>local</b>{/snippet}{@render row()}{/if}"#;
+    let out = compile_js(src, GenerateMode::Server);
+    assert!(
+        out.contains("row($$renderer)"),
+        "expected a direct snippet call in:\n{out}"
+    );
+    assert!(
+        !out.contains("row()($$renderer)"),
+        "the derived read-wrap still applied in:\n{out}"
+    );
+}
+
+/// Server: a component's `{#snippet}` children are lifted into props, so the
+/// slot body needs the shadow pushed by the component visitor.
+#[test]
+fn server_component_child_snippet_shadows_a_same_named_derived() {
+    let src = r#"<script>
+	import Child from './Child.svelte';
+	let base = $state(1);
+	let row = $derived(base + 1);
+</script>
+<Child>{#snippet row()}<b>local</b>{/snippet}{@render row()}</Child>"#;
+    let out = compile_js(src, GenerateMode::Server);
+    assert!(
+        !out.contains("row()($$renderer)"),
+        "the derived read-wrap still applied in:\n{out}"
+    );
+}
+
+/// A prop snippet with no local `{#snippet}` of that name must keep resolving to
+/// the prop — the shadow is scoped to fragments that actually declare it.
+#[test]
+fn a_prop_snippet_without_a_local_declaration_is_untouched() {
+    let src = r#"<script>
+	let { row } = $props();
+	let open = $state(true);
+</script>
+{#if open}{@render row()}{/if}"#;
+    let out = compile_js(src, GenerateMode::Client);
+    assert!(
+        out.contains("$$props.row"),
+        "the prop snippet stopped resolving to the prop in:\n{out}"
+    );
+}
+
+/// A sibling branch that does not declare the snippet keeps the prop.
+#[test]
+fn sibling_branch_without_the_snippet_keeps_the_prop() {
+    let src = r#"<script>
+	let { row } = $props();
+	let open = $state(true);
+</script>
+{#if open}{#snippet row()}<b>local</b>{/snippet}{@render row()}{:else}{@render row()}{/if}"#;
+    let out = compile_js(src, GenerateMode::Client);
+    assert!(
+        out.contains("$$props.row"),
+        "the alternate branch lost the prop resolution in:\n{out}"
+    );
+}


### PR DESCRIPTION
Fixes #2067

## Cause

Upstream `scope.js` declares a snippet name as a **`normal`** binding in the enclosing fragment's scope, and `get_transform` (`3-transform/client/utils.js`) deletes every `normal` declaration of a scope from the inherited read-transform map as the walker enters it. That is the entire mechanism by which a block-local `{#snippet}` shadows a same-named prop / `$derived` / each-item.

rsvelte never dropped the inherited entry, so a read of the shadowed name inside the fragment kept the outer lowering:

```svelte
<script>
	let { row } = $props();
	let items = [1];
</script>
{#each items as item}{#snippet row()}<b>{item}</b>{/snippet}{@render row()}{/each}
```

- client — official `row($$anchor)`, rsvelte `$$props.row($$anchor)`
- server, with `let row = $derived(…)` instead of the prop — official `row($$renderer)`, rsvelte `row()($$renderer)`

The client symptom is not confined to the `{@render}` callee: every read of the name in that fragment was affected (attribute values, `{#if}` conditions, values passed to a child component). After #2057 the client form also became a direct call, so it now throws a `TypeError` when the prop is not passed — and using a same-named `{#snippet}` as the fallback for a prop snippet is a practical pattern.

## Fix

Port the shadowing rule rather than special-casing the render tag.

- `client/utils.rs::shadow_snippet_declarations` — the `get_transform` analogue. In a template fragment the `normal` declarations are exactly the `{#snippet}` names, so it drops those from `transform` / `transform_deep_read`. It also adds them to `shadowed_prop_names`, because the non-source-prop shortcut in `expression_converter` builds `$$props.x` straight from the binding instead of going through the transform map — that is the path that produced `$$props.row`.
- Applied in `client/visitors/fragment.rs` (where a fragment forks its child transform state) and in `client/visitors/regular_element.rs` (element children do not route through `fragment()`), with save/restore in the element case.
- Server: `process_children_inner` pushes a per-fragment `shadowed_names` frame, which suppresses the `$derived` / store read-wrap for the same region. The component visitor pushes its own frame because a component's `{#snippet}` children are lifted into props *before* the slot bodies are walked, so they are not visible to the slot's own frame.

## Tests

- New `crates/rsvelte_core/tests/render_tag_snippet_shadows_binding_2067.rs` (7 cases): the issue repro, non-render-tag reads of the shadowed name, an element-scoped snippet, the server `$derived` and component-child variants, and two negative cases (a prop snippet with no local declaration, and a sibling `{:else}` branch that does not declare it — both must keep resolving to the prop).
- Byte-parity battery of 22 shadowing shapes × {client, server} × {prod, dev} against the official compiler: **34 outputs newly byte-identical, 0 regressions**. The residual diffs are pre-existing and unrelated (server-dev `$.prevent_snippet_stringification` / `$.validate_snippet_args`, and a `$`-prefixed snippet name that rsvelte rejects as `dollar_prefix_invalid`).
- `cargo test --release -p rsvelte_core` — all 154 test binaries pass; `-p rsvelte_projection` passes.
- Corpus (svelte + pattern sources, 5144 entries): client/server **0 mismatches** (both ratchets are empty and stay empty); client-dev no regressions. No ratchet entry becomes fixable by this change, so the baselines are untouched.
- `cargo fmt --all --check` and `cargo clippy --all-targets --all-features -- -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RQSYoh4Wc353KgUnWHjazu