### PR TITLE
fix(svelte2tsx): apply official's `value[0]` rule to every slot-name path (#2100)

### DIFF
--- a/.changeset/svelte2tsx-slot-value0-rule.md
+++ b/.changeset/svelte2tsx-slot-value0-rule.md
@@ -1,0 +1,18 @@
+---
+"@rsvelte/compiler": patch
+"@rsvelte/svelte2tsx": patch
+"@rsvelte/svelte-check": patch
+---
+
+fix(svelte2tsx): apply official's `value[0]` rule to every slot-name path.
+Official svelte2tsx only ever reads the FIRST part of a slot-name attribute
+value; rsvelte concatenated all `Text` parts (or kept the last one), so
+`<slot name="a{b}c">` produced `slots: { undefined: {} }` instead of
+`{ 'a': {} }`, `$$slots` keyed on `c` instead of `a`, and
+`<Comp><div slot="a{b}c">` was lowered to a `$$slot_def["ac"]` wrapper that
+official does not emit. The three sibling paths now mirror their own upstream
+rule: `slots`/`$$slots` use `nameAttr.value[0].raw` (shared map),
+`let:`-binding scope resolution uses `getSlotName`'s `value[0].raw`, and the
+`$$slot_def[…]` lowering uses `attributeValueIsOfType(value, 'Text')` — so an
+interpolated or dynamic `slot=` stays an ordinary attribute and is no longer
+dropped from the generated props.

--- a/crates/rsvelte_projection/src/svelte2tsx/template/collect/mod.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/template/collect/mod.rs
@@ -7,7 +7,7 @@ use crate::ast::template::{Attribute, AttributeValue, AttributeValuePart, Fragme
 use pattern::{collect_pattern_bindings, expand_object_shorthands};
 
 use super::attributes::let_::iter_let_directives;
-use super::nodes::slot_element::{dollar_slot_name, get_slot_attr_value, slot_name_for_type};
+use super::nodes::slot_element::{slot_consumer_name, slot_name_for_type};
 use super::utils::expr::get_expression_text;
 use super::{ForwardedEvent, ForwardedEventMapper, ForwardedEventSource, TemplateInfo};
 use crate::ast::arena::ParseArena;
@@ -81,14 +81,15 @@ fn collect_info_from_node<'a>(
     detector.observe(node, source, arena);
     match node {
         TemplateNode::SlotElement(el) => {
-            if let Some(names) = &mut info.dollar_slot_names {
-                let name = dollar_slot_name(&el.attributes);
-                names.insert(name);
-            }
             // Collect slot name and props. The `slots` *type* key uses
             // `undefined` for a dynamic name (`<slot name="{foo}">`), unlike the
             // `__sveltets_createSlot("{foo}", …)` call which keeps the raw text.
+            // Official derives the legacy `$$slots` declaration from the very
+            // same map, so both must use `slot_name_for_type`.
             let slot_name = slot_name_for_type(&el.attributes);
+            if let Some(names) = &mut info.dollar_slot_names {
+                names.insert(slot_name.clone());
+            }
             let slot_props = collect_slot_prop_entries(&el.attributes, source, scope);
             // Official `SlotHandler.handleSlot` does `this.slots.set(name, …)`:
             // a later `<slot name=X>` REPLACES the earlier def for X (it does not
@@ -502,12 +503,15 @@ fn push_component_slot_consumer_lets(
 ) -> usize {
     // Default-slot lets: `let:` directly on the component tag.
     let mut pushed = push_let_reflection_scope(own_attributes, comp_type, "default", source, scope);
-    // Named-slot lets: each direct child with a static `slot="x"` attribute.
+    // Named-slot lets: each direct child whose `slot=` value STARTS with text.
+    // Official reads `value[0].raw` here (`getSlotName`), a laxer rule than the
+    // JSX lowering's — `slot="a{b}c"` types its `let:` against slot `a` while
+    // the same child's JSX block stays on the default slot.
     for child in children {
         if let Some(child_attrs) = node_slot_consumer_attributes(child)
-            && let Some(slot_name) = get_slot_attr_value(child_attrs, source)
+            && let Some(slot_name) = slot_consumer_name(child_attrs)
         {
-            pushed += push_let_reflection_scope(child_attrs, comp_type, &slot_name, source, scope);
+            pushed += push_let_reflection_scope(child_attrs, comp_type, slot_name, source, scope);
         }
     }
     pushed

--- a/crates/rsvelte_projection/src/svelte2tsx/template/mod.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/template/mod.rs
@@ -257,15 +257,17 @@ mod tests {
 <slot name={dynamic} />
 <slot name="pre{dynamic}post" />"#;
         with_collected_info(source, true, |info| {
+            // `name="pre{dynamic}post"` keys on `value[0].raw` (`pre`), and the
+            // `$$slots` declaration is built from the very same map.
+            let names = vec!["named", "default", "undefined", "pre"];
             assert_eq!(
                 info.slots.keys().map(String::as_str).collect::<Vec<_>>(),
-                vec!["named", "default", "undefined"]
+                names
             );
-            let dollar_names = IndexSet::from([
-                "named".to_string(),
-                "default".to_string(),
-                "post".to_string(),
-            ]);
+            let dollar_names: IndexSet<String> = names
+                .into_iter()
+                .map(str::to_string)
+                .collect::<IndexSet<_>>();
             assert_eq!(info.dollar_slot_names.as_deref(), Some(&dollar_names));
             let named = info.slots.get("named").expect("named slot");
             assert_eq!(named.len(), 1);

--- a/crates/rsvelte_projection/src/svelte2tsx/template/nodes/component_slots.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/template/nodes/component_slots.rs
@@ -24,7 +24,7 @@ use crate::svelte2tsx::template::utils::source::{find_closing_tag_start, find_op
 use crate::svelte2tsx::template::walk::{process_fragment_inplace, process_node_inplace};
 
 use super::inline_component::handle_component;
-use super::slot_element::get_slot_attr_value;
+use super::slot_element::slot_attr_static_name;
 use crate::svelte2tsx::template::attributes::action::format_use_directive;
 
 /// True if `attributes` contains a `slot` attribute whose value is anything
@@ -136,38 +136,28 @@ pub(crate) fn has_default_slot_let_children(fragment: &Fragment, _source: &str) 
 }
 
 /// Check if any children have `slot="name"` attributes (named slots).
-pub(crate) fn has_named_slot_children(fragment: &Fragment, source: &str) -> bool {
+pub(crate) fn has_named_slot_children(fragment: &Fragment) -> bool {
     for node in &fragment.nodes {
         match node {
-            TemplateNode::RegularElement(el)
-                if get_slot_attr_value(&el.attributes, source).is_some() =>
-            {
+            TemplateNode::RegularElement(el) if slot_attr_static_name(&el.attributes).is_some() => {
                 return true;
             }
-            TemplateNode::Component(comp)
-                if get_slot_attr_value(&comp.attributes, source).is_some() =>
-            {
+            TemplateNode::Component(comp) if slot_attr_static_name(&comp.attributes).is_some() => {
                 return true;
             }
             // `<svelte:fragment slot="name" let:foo>` is the Svelte 4 idiom
             // for distributing children into a named slot — it shows up here
             // as `SvelteFragment`. Treat it like the others.
-            TemplateNode::SvelteFragment(el)
-                if get_slot_attr_value(&el.attributes, source).is_some() =>
-            {
+            TemplateNode::SvelteFragment(el) if slot_attr_static_name(&el.attributes).is_some() => {
                 return true;
             }
             // `<slot slot="name">` forwards a `<slot>` into the parent
             // component's named slot.
-            TemplateNode::SlotElement(el)
-                if get_slot_attr_value(&el.attributes, source).is_some() =>
-            {
+            TemplateNode::SlotElement(el) if slot_attr_static_name(&el.attributes).is_some() => {
                 return true;
             }
             // `<svelte:element this={tag} slot="name">` targets a named slot.
-            TemplateNode::SvelteElement(el)
-                if get_slot_attr_value(&el.attributes, source).is_some() =>
-            {
+            TemplateNode::SvelteElement(el) if slot_attr_static_name(&el.attributes).is_some() => {
                 return true;
             }
             // Control-flow blocks are transparent to slot distribution: a
@@ -178,20 +168,20 @@ pub(crate) fn has_named_slot_children(fragment: &Fragment, source: &str) -> bool
             // nested elements/components (which own their own slot scope) or
             // `{#snippet}` bodies (snippet props, not slots).
             TemplateNode::IfBlock(block)
-                if has_named_slot_children(&block.consequent, source)
+                if has_named_slot_children(&block.consequent)
                     || block
                         .alternate
                         .as_ref()
-                        .is_some_and(|alt| has_named_slot_children(alt, source)) =>
+                        .is_some_and(|alt| has_named_slot_children(alt)) =>
             {
                 return true;
             }
             TemplateNode::EachBlock(block)
-                if has_named_slot_children(&block.body, source)
+                if has_named_slot_children(&block.body)
                     || block
                         .fallback
                         .as_ref()
-                        .is_some_and(|fb| has_named_slot_children(fb, source)) =>
+                        .is_some_and(|fb| has_named_slot_children(fb)) =>
             {
                 return true;
             }
@@ -199,19 +189,19 @@ pub(crate) fn has_named_slot_children(fragment: &Fragment, source: &str) -> bool
                 if block
                     .pending
                     .as_ref()
-                    .is_some_and(|p| has_named_slot_children(p, source))
+                    .is_some_and(|p| has_named_slot_children(p))
                     || block
                         .then
                         .as_ref()
-                        .is_some_and(|t| has_named_slot_children(t, source))
+                        .is_some_and(|t| has_named_slot_children(t))
                     || block
                         .catch
                         .as_ref()
-                        .is_some_and(|c| has_named_slot_children(c, source)) =>
+                        .is_some_and(|c| has_named_slot_children(c)) =>
             {
                 return true;
             }
-            TemplateNode::KeyBlock(block) if has_named_slot_children(&block.fragment, source) => {
+            TemplateNode::KeyBlock(block) if has_named_slot_children(&block.fragment) => {
                 return true;
             }
             _ => {}
@@ -282,15 +272,11 @@ pub(crate) fn process_component_children_with_slots(
 
     for node in &comp.fragment.nodes {
         let is_named_slot = match node {
-            TemplateNode::RegularElement(el) => {
-                get_slot_attr_value(&el.attributes, source).is_some()
-            }
+            TemplateNode::RegularElement(el) => slot_attr_static_name(&el.attributes).is_some(),
             TemplateNode::Component(child_comp) => {
-                get_slot_attr_value(&child_comp.attributes, source).is_some()
+                slot_attr_static_name(&child_comp.attributes).is_some()
             }
-            TemplateNode::SvelteFragment(el) => {
-                get_slot_attr_value(&el.attributes, source).is_some()
-            }
+            TemplateNode::SvelteFragment(el) => slot_attr_static_name(&el.attributes).is_some(),
             _ => false,
         };
 
@@ -471,7 +457,7 @@ pub(crate) fn handle_named_slot_element(
     counter: &mut Counter,
     depth: u32,
 ) {
-    let slot_name = get_slot_attr_value(&el.attributes, source).unwrap_or_default();
+    let slot_name = slot_attr_static_name(&el.attributes).unwrap_or_default();
     let let_destructure = build_let_destructure_string(&el.attributes, source);
 
     // Build the slot def block opener
@@ -564,7 +550,7 @@ pub(crate) fn handle_named_slot_svelte_fragment(
     counter: &mut Counter,
     depth: u32,
 ) {
-    let slot_name = get_slot_attr_value(&el.attributes, source).unwrap_or_default();
+    let slot_name = slot_attr_static_name(&el.attributes).unwrap_or_default();
     let let_destructure = build_let_destructure_string(&el.attributes, source);
 
     // Leading ` ` matches the JS reference, which produces
@@ -632,7 +618,7 @@ pub(crate) fn handle_named_slot_component(
     counter: &mut Counter,
     depth: u32,
 ) {
-    let slot_name = get_slot_attr_value(&comp.attributes, source).unwrap_or_default();
+    let slot_name = slot_attr_static_name(&comp.attributes).unwrap_or_default();
     let let_destructure = build_let_destructure_string(&comp.attributes, source);
 
     // Build the slot def block opener

--- a/crates/rsvelte_projection/src/svelte2tsx/template/nodes/dynamic_element.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/template/nodes/dynamic_element.rs
@@ -22,7 +22,7 @@ use crate::svelte2tsx::template::utils::source::{find_closing_tag_start, find_op
 use crate::svelte2tsx::template::walk::process_fragment_inplace;
 
 use super::component_slots::build_named_slot_element_attrs;
-use super::slot_element::get_slot_attr_value;
+use super::slot_element::slot_attr_static_name;
 
 /// Handle `<svelte:element this={tag}>`.
 pub(crate) fn handle_svelte_dynamic_element(
@@ -43,9 +43,10 @@ pub(crate) fn handle_svelte_dynamic_element(
     // attribute. Take the context so the element's own children don't inherit
     // it; restore it for following siblings.
     let saved_slot = counter.slot_inst.take();
-    let named_slot: Option<(String, String)> = saved_slot.as_ref().and_then(|inst| {
-        get_slot_attr_value(&el.attributes, source).map(|name| (inst.clone(), name))
-    });
+    let named_slot: Option<(&str, &str)> = saved_slot
+        .as_ref()
+        .zip(slot_attr_static_name(&el.attributes))
+        .map(|(inst, name)| (inst.as_str(), name));
     let named_slot_block = named_slot.as_ref().map(|(inst, target_slot)| {
         let let_destructure = build_let_destructure_string(&el.attributes, source);
         format!(

--- a/crates/rsvelte_projection/src/svelte2tsx/template/nodes/element.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/template/nodes/element.rs
@@ -22,7 +22,7 @@ use crate::svelte2tsx::template::utils::source::{
 use crate::svelte2tsx::template::walk::process_fragment_inplace;
 
 use super::component_slots::handle_named_slot_element;
-use super::slot_element::{get_slot_attr_value, handle_slot_element};
+use super::slot_element::{handle_slot_element, slot_attr_static_name};
 use super::snippet_block::hoist_snippet_blocks;
 
 /// Handle a regular HTML element.
@@ -85,7 +85,7 @@ pub(crate) fn handle_regular_element(
     // restore it afterwards for the following siblings.
     let saved_slot = counter.slot_inst.take();
     if let Some(ref inst) = saved_slot
-        && get_slot_attr_value(&el.attributes, source).is_some()
+        && slot_attr_static_name(&el.attributes).is_some()
     {
         handle_named_slot_element(el, inst, source, options, str, counter, depth);
         counter.slot_inst = saved_slot;

--- a/crates/rsvelte_projection/src/svelte2tsx/template/nodes/inline_component.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/template/nodes/inline_component.rs
@@ -38,7 +38,7 @@ use super::component_slots::{
     handle_named_slot_component, has_component_slot_children, has_default_slot_let_children,
     has_named_slot_children, process_component_children_with_slots,
 };
-use super::slot_element::get_slot_attr_value;
+use super::slot_element::slot_attr_static_name;
 use super::snippet_block::handle_snippet_block_as_component_prop;
 
 /// The `</Component>` → `Component}` mapping upstream keeps for the closing tag.
@@ -92,7 +92,7 @@ pub(crate) fn handle_component(
     // already the routed inner `handle_component` call.
     if !counter.named_slot_component_close
         && let Some(ref inst) = saved_outer_slot
-        && get_slot_attr_value(&comp.attributes, source).is_some()
+        && slot_attr_static_name(&comp.attributes).is_some()
     {
         let inst = inst.clone();
         handle_named_slot_component(comp, &inst, source, options, str, counter, depth);
@@ -132,7 +132,7 @@ pub(crate) fn handle_component(
     let has_children = has_component_slot_children(&comp.fragment, source);
 
     // Check if any children have named slots with let: directives
-    let children_have_named_slots = has_named_slot_children(&comp.fragment, source);
+    let children_have_named_slots = has_named_slot_children(&comp.fragment);
 
     // A default-slot child carrying `let:` directives (e.g.
     // `<svelte:fragment let:a={x}>…`) destructures from
@@ -630,7 +630,7 @@ pub(crate) fn handle_svelte_component(
     // Need an instance variable when there are `on:` events, `let:` directives,
     // `bind:` directives, or children that reference the instance's slot defs
     // (named-slot children anywhere in blocks, or default-slot `let:` receivers).
-    let children_have_named_slots = has_named_slot_children(&comp.fragment, source);
+    let children_have_named_slots = has_named_slot_children(&comp.fragment);
     let children_have_default_slot_lets = has_default_slot_let_children(&comp.fragment, source);
     let needs_inst = has_events
         || has_lets_scomp

--- a/crates/rsvelte_projection/src/svelte2tsx/template/nodes/slot_element.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/template/nodes/slot_element.rs
@@ -38,9 +38,10 @@ pub(crate) fn handle_slot_element(
     // referencing the enclosing component instance. Take the context so the
     // slot's own fallback children don't inherit it; restore it for siblings.
     let saved_slot = counter.slot_inst.take();
-    let named_slot: Option<(String, String)> = saved_slot.as_ref().and_then(|inst| {
-        get_slot_attr_value(&el.attributes, source).map(|name| (inst.clone(), name))
-    });
+    let named_slot: Option<(&str, &str)> = saved_slot
+        .as_ref()
+        .zip(slot_attr_static_name(&el.attributes))
+        .map(|(inst, name)| (inst.as_str(), name));
     let named_slot_block = named_slot.as_ref().map(|(inst, target_slot)| {
         let let_destructure = build_let_destructure_string(&el.attributes, source);
         format!(
@@ -59,7 +60,7 @@ pub(crate) fn handle_slot_element(
     let bind_this_expr = get_bind_this_expr(&el.attributes, source);
 
     // Build slot props string (excluding the `name` attribute and `bind:this`).
-    let slot_props = build_slot_props_string(&el.attributes, source);
+    let slot_props = build_slot_props_string(&el.attributes, source, named_slot.is_some());
     // `__sveltets_createSlot("name"` keeps the source range of a static slot
     // name; a defaulted (absent) name is a literal and keeps none.
     let name_range = get_slot_name_range(&el.attributes);
@@ -150,60 +151,67 @@ pub(crate) fn handle_slot_element(
     counter.slot_inst = saved_slot;
 }
 
-/// Extract the slot name from a `<slot>` element's attributes.
-/// Returns "default" if no `name` attribute is present.
-/// Slot name used as the **type** key in the component's `slots: { … }` return.
-/// A static `name="header"` yields `header`; a missing name yields `default`; a
-/// dynamic `name="{foo}"` (or `name={foo}`) yields the literal `undefined`
-/// (official emits `slots: { undefined: {} }` for a non-static slot name).
-pub(crate) fn slot_name_for_type(attributes: &[Attribute]) -> String {
-    for attr in attributes {
-        if let Attribute::Attribute(node) = attr
-            && node.name == "name"
-        {
-            match &node.value {
-                AttributeValue::Sequence(parts) => {
-                    // Dynamic if any part is an expression tag.
-                    if parts
-                        .iter()
-                        .any(|p| matches!(p, AttributeValuePart::ExpressionTag(_)))
-                    {
-                        return "undefined".to_string();
-                    }
-                    let mut name = String::new();
-                    for part in parts {
-                        if let AttributeValuePart::Text(text) = part {
-                            name.push_str(&text.raw);
-                        }
-                    }
-                    if !name.is_empty() {
-                        return name;
-                    }
-                }
-                AttributeValue::Expression(_) => return "undefined".to_string(),
-                _ => {}
-            }
-        }
-    }
-    "default".to_string()
+/// Official's `value[0]`: the FIRST part of an attribute value. Every official
+/// slot-name path reads only this part and ignores the rest — `slot.ts`'s
+/// `nameAttr.value[0].raw`, `Element.ts`'s `slotName`, `svelteAst.ts`'s
+/// `getSlotName` and `Attribute.ts`'s `attributeValueIsOfType(value, 'Text')` —
+/// so `name="a{b}c"` is the slot `a`, never the concatenation `ac`.
+enum FirstValuePart<'a> {
+    /// `value[0].type === 'Text'`; carries `value[0].raw`.
+    Text(&'a str),
+    /// `value[0]` is an expression, whose `.raw` is `undefined` in official.
+    Expression,
 }
 
-pub(crate) fn dollar_slot_name(attributes: &[Attribute]) -> String {
-    // The legacy declaration uses the last static text part, unlike the slot type key.
-    let mut slot_name = "default".to_string();
-    for attr in attributes {
-        if let Attribute::Attribute(node) = attr
-            && node.name == "name"
-            && let AttributeValue::Sequence(parts) = &node.value
-        {
-            for part in parts {
-                if let AttributeValuePart::Text(text) = part {
-                    slot_name = text.raw.to_string();
-                }
-            }
-        }
+/// `value[0]` of the attribute named `name`, or `None` when the attribute is
+/// absent or boolean (`<slot name>` — official reads `undefined` there and
+/// throws while dereferencing `.raw`; rsvelte degrades to the default instead).
+fn first_value_part<'a>(attributes: &'a [Attribute], name: &str) -> Option<FirstValuePart<'a>> {
+    attributes.iter().find_map(|attr| match attr {
+        Attribute::Attribute(node) if node.name == name => match &node.value {
+            AttributeValue::Sequence(parts) => parts.first().map(|part| match part {
+                AttributeValuePart::Text(text) => FirstValuePart::Text(&text.raw),
+                AttributeValuePart::ExpressionTag(_) => FirstValuePart::Expression,
+            }),
+            AttributeValue::Expression(_) => Some(FirstValuePart::Expression),
+            AttributeValue::True(_) => None,
+        },
+        _ => None,
+    })
+}
+
+/// Slot name used as the **type** key in the component's `slots: { … }` return
+/// and in the legacy `$$slots` declaration — official `SlotHandler.handleSlot`'s
+/// `nameAttr ? nameAttr.value[0].raw : 'default'`.
+///
+/// A static `name="header"` yields `header`, `name="a{b}c"` yields `a` (only
+/// `value[0]` counts), a missing name yields `default`, and a `value[0]` that is
+/// an expression yields the literal `undefined` (official stringifies its
+/// `undefined` `.raw` into the key). An empty name keeps rsvelte's `default`
+/// fallback: official's `''` key pairs with a syntactically broken
+/// `__sveltets_createSlot(, …)` call, and `get_slot_name` already declines to
+/// reproduce that.
+pub(crate) fn slot_name_for_type(attributes: &[Attribute]) -> String {
+    match first_value_part(attributes, "name") {
+        Some(FirstValuePart::Text(raw)) if !raw.is_empty() => raw.to_string(),
+        Some(FirstValuePart::Expression) => "undefined".to_string(),
+        _ => "default".to_string(),
     }
-    slot_name
+}
+
+/// Target slot of a component child's `slot=` attribute for the **scope**
+/// resolution that types `let:` bindings (official `utils/svelteAst.ts`'s
+/// `getSlotName`, read by `SlotHandler.getSlotConsumerOfComponent`).
+///
+/// This is `value[0].raw`, so `slot="a{b}c"` resolves `let:` against slot `a`
+/// even though the JSX lowering keeps the same child in the *default* slot —
+/// official really does apply two different rules here, see
+/// [`slot_attr_static_name`].
+pub(crate) fn slot_consumer_name<'a>(attributes: &'a [Attribute]) -> Option<&'a str> {
+    match first_value_part(attributes, "slot") {
+        Some(FirstValuePart::Text(raw)) => Some(raw),
+        _ => None,
+    }
 }
 
 /// Source range of the `<slot name=…>` value's first value part (official's
@@ -254,19 +262,25 @@ pub(crate) fn get_bind_this_expr<'a>(
 
 /// Build the props string for a `<slot>` element.
 ///
-/// Excludes the `name` attribute and `bind:this` directive.
+/// Excludes the `name` attribute and `bind:this` directive. `drop_slot_attr`
+/// additionally drops `slot=`, which happens only when the attribute was
+/// consumed by an enclosing `$$slot_def["x"]` wrapper — official's
+/// `handleAttribute` returns early for `slot=` under exactly that condition, so
+/// an unforwarded `slot=` (dynamic, interpolated, or outside a component) stays
+/// an ordinary slot prop.
 /// Format matches `__sveltets_createSlot("name", { props })`.
-pub(crate) fn build_slot_props_string(attributes: &[Attribute], source: &str) -> String {
+pub(crate) fn build_slot_props_string(
+    attributes: &[Attribute],
+    source: &str,
+    drop_slot_attr: bool,
+) -> String {
     let mut parts: Vec<String> = Vec::new();
 
     for attr in attributes {
         match attr {
             Attribute::Attribute(node) => {
                 // Skip the `name` attribute - it determines the slot name, not a prop.
-                // Skip `slot` too — on a `<slot slot="x">` forward it targets the
-                // enclosing component's named slot (consumed by the
-                // `$$slot_def["x"]` wrapper), it is not a slot prop.
-                if node.name == "name" || node.name == "slot" {
+                if node.name == "name" || (node.name == "slot" && drop_slot_attr) {
                     continue;
                 }
                 // Slot props are neither DOM-element props nor component props;
@@ -296,37 +310,24 @@ pub(crate) fn build_slot_props_string(attributes: &[Attribute], source: &str) ->
     parts.join("")
 }
 
-/// Get the static `slot="name"` attribute value from an element's attributes.
-/// Returns None if no `slot` attribute is present, or if its value is a dynamic
-/// expression (`slot={foo}`).
+/// Target slot of an element's `slot=` attribute for the **JSX** lowering, or
+/// `None` when the attribute is absent or not a named-slot marker.
 ///
-/// Official svelte2tsx only treats a `slot` attribute as a named-slot marker
-/// when its value is static `Text` (`attributeValueIsOfType(attr.value, 'Text')`
-/// in `htmlxtojsx_v2/nodes/Attribute.ts`). A dynamic `slot={foo}` is emitted as
-/// an ordinary attribute (`{ slot: foo }`) and does NOT trigger the
-/// `$$slot_def[...]` lowering or the component-instance const.
-pub(crate) fn get_slot_attr_value(attributes: &[Attribute], _source: &str) -> Option<String> {
-    for attr in attributes {
-        if let Attribute::Attribute(node) = attr
-            && node.name == "slot"
-        {
-            match &node.value {
-                AttributeValue::Sequence(parts) => {
-                    let mut name = String::new();
-                    for part in parts {
-                        if let AttributeValuePart::Text(text) = part {
-                            name.push_str(&text.raw);
-                        }
-                    }
-                    if !name.is_empty() {
-                        return Some(name);
-                    }
-                }
-                // Dynamic `slot={foo}` is a regular attribute, not a named slot.
-                AttributeValue::Expression(_) => {}
-                _ => {}
-            }
-        }
-    }
-    None
+/// Official svelte2tsx only treats `slot=` as a marker when the whole value is a
+/// single `Text` part (`attributeValueIsOfType(attr.value, 'Text')` in
+/// `htmlxtojsx_v2/nodes/Attribute.ts`). A dynamic `slot={foo}` *and* an
+/// interpolated `slot="a{b}c"` are both emitted as ordinary attributes and do
+/// NOT trigger the `$$slot_def[...]` lowering or the component-instance const —
+/// unlike [`slot_consumer_name`], which reads `value[0]` for the same attribute.
+pub(crate) fn slot_attr_static_name<'a>(attributes: &'a [Attribute]) -> Option<&'a str> {
+    attributes.iter().find_map(|attr| match attr {
+        Attribute::Attribute(node) if node.name == "slot" => match &node.value {
+            AttributeValue::Sequence(parts) => match parts.as_slice() {
+                [AttributeValuePart::Text(text)] => Some(text.raw.as_ref()),
+                _ => None,
+            },
+            _ => None,
+        },
+        _ => None,
+    })
 }

--- a/crates/rsvelte_projection/tests/svelte2tsx_slot_summary.rs
+++ b/crates/rsvelte_projection/tests/svelte2tsx_slot_summary.rs
@@ -13,8 +13,10 @@ fn dollar_slots_uses_collected_static_dynamic_and_duplicate_name_order() {
 <slot name="pre{dynamic}post" />"#;
     let result = svelte2tsx(source, Svelte2TsxOptions::default()).expect("project");
 
+    // `$$slots` shares official's `slots` map, whose key is `value[0].raw` — so
+    // `name="pre{dynamic}post"` contributes `pre`, not `post` (#2100).
     assert!(result.code.contains(
-        "let $$slots = __sveltets_2_slotsType({'named': '', 'default': '', 'post': ''});"
+        "let $$slots = __sveltets_2_slotsType({'named': '', 'default': '', 'undefined': '', 'pre': ''});"
     ));
     let named = result
         .code

--- a/crates/rsvelte_projection/tests/svelte2tsx_slot_value0_rule.rs
+++ b/crates/rsvelte_projection/tests/svelte2tsx_slot_value0_rule.rs
@@ -1,0 +1,176 @@
+//! Official svelte2tsx never looks past `value[0]` of a slot-name attribute, so
+//! an interpolated `name="a{b}c"` / `slot="a{b}c"` is decided by its FIRST value
+//! part alone (#2100). Three sibling paths read that value with two different
+//! rules, and rsvelte used to apply a third (concatenate every `Text` part):
+//!
+//! * `slot.ts`'s `nameAttr.value[0].raw` — the `slots: { … }` type key and the
+//!   `$$slots` declaration built from the same map;
+//! * `svelteAst.ts`'s `getSlotName` (`value[0].raw`) — the slot a child's `let:`
+//!   bindings are typed against;
+//! * `Attribute.ts`'s `attributeValueIsOfType(value, 'Text')` (a SINGLE `Text`
+//!   part) — whether `slot=` lowers to a `$$slot_def[…]` wrapper at all.
+//!
+//! Every expectation below was taken from official svelte2tsx (svelte 5.56.8).
+
+use rsvelte_projection::svelte2tsx::{Svelte2TsxOptions, svelte2tsx};
+
+fn tsx(source: &str) -> String {
+    svelte2tsx(source, Svelte2TsxOptions::default())
+        .expect("project")
+        .code
+}
+
+// --- `slots: { … }` type key + `$$slots` (official `nameAttr.value[0].raw`) ---
+
+#[test]
+fn slots_type_key_uses_the_first_value_part() {
+    let code = tsx("<script>let b = 'x';</script>\n<slot name=\"a{b}c\" />");
+    assert!(code.contains("slots: {'a': {}}"), "{code}");
+}
+
+#[test]
+fn slots_type_key_is_undefined_when_the_first_value_part_is_an_expression() {
+    for source in [
+        "<script>let n = 'x';</script>\n<slot name={n} />",
+        "<script>let b = 'x';</script>\n<slot name=\"{b}c\" />",
+    ] {
+        let code = tsx(source);
+        assert!(code.contains("slots: {'undefined': {}}"), "{code}");
+    }
+}
+
+#[test]
+fn dollar_slots_shares_the_slots_type_keys() {
+    let code = tsx("<script>let b = 'x';\n$$slots;</script>\n<slot name=\"a{b}c\" />");
+    assert!(
+        code.contains("let $$slots = __sveltets_2_slotsType({'a': ''});"),
+        "{code}"
+    );
+
+    let code = tsx("<script>let n = 'x';\n$$slots;</script>\n<slot name={n} />");
+    assert!(
+        code.contains("let $$slots = __sveltets_2_slotsType({'undefined': ''});"),
+        "{code}"
+    );
+}
+
+#[test]
+fn two_slots_sharing_a_first_value_part_collapse_to_one_key() {
+    let code = tsx(
+        "<script>let b='x';\n$$slots;</script>\n<slot name=\"a{b}c\" /><slot name=\"a{b}d\" />",
+    );
+    assert!(
+        code.contains("let $$slots = __sveltets_2_slotsType({'a': ''});"),
+        "{code}"
+    );
+}
+
+/// Official reads `value[0].raw` unconditionally, so a boolean `<slot name>`
+/// throws and `<slot name="">` emits a syntactically broken
+/// `__sveltets_createSlot(, …)`. rsvelte keeps its `default` fallback there
+/// rather than reproducing broken output — the same call this file's sibling
+/// `get_slot_name` already makes.
+#[test]
+fn degenerate_slot_names_stay_on_the_default_fallback() {
+    for source in ["<slot name />", "<slot name=\"\" />"] {
+        let code = tsx(source);
+        assert!(
+            code.contains("__sveltets_createSlot(\"default\","),
+            "{code}"
+        );
+        assert!(code.contains("slots: {'default': {}}"), "{code}");
+    }
+}
+
+// --- `slot=` lowering (official `attributeValueIsOfType(value, 'Text')`) ---
+
+#[test]
+fn interpolated_slot_attribute_is_a_plain_attribute_not_a_named_slot() {
+    let code = tsx(
+        "<script>import Comp from './C.svelte'; let b='x';</script>\n<Comp><div slot=\"a{b}c\">hi</div></Comp>",
+    );
+    assert!(!code.contains("$$slot_def"), "{code}");
+    assert!(
+        code.contains("svelteHTML.createElement(\"div\", { \"slot\":`a${b}c`,});"),
+        "{code}"
+    );
+}
+
+#[test]
+fn interpolated_slot_attribute_on_a_slot_element_keeps_the_slot_prop() {
+    let code = tsx(
+        "<script>import Comp from './C.svelte'; let b='x';</script>\n<Comp><slot slot=\"a{b}c\" /></Comp>",
+    );
+    assert!(!code.contains("$$slot_def"), "{code}");
+    assert!(
+        code.contains("__sveltets_createSlot(\"default\", {  \"slot\":`a${b}c`,});"),
+        "{code}"
+    );
+}
+
+#[test]
+fn dynamic_slot_attribute_on_a_slot_element_keeps_the_slot_prop() {
+    let code = tsx(
+        "<script>import Comp from './C.svelte'; let n='x';</script>\n<Comp><slot slot={n} /></Comp>",
+    );
+    assert!(!code.contains("$$slot_def"), "{code}");
+    assert!(
+        code.contains("__sveltets_createSlot(\"default\", {  \"slot\":n,});"),
+        "{code}"
+    );
+}
+
+/// An unforwarded `slot=` is an ordinary slot prop: outside a component nothing
+/// consumes it, so even a plain static value survives.
+#[test]
+fn slot_attribute_outside_a_component_stays_a_slot_prop() {
+    let code = tsx("<slot slot=\"a\" />");
+    assert!(
+        code.contains("__sveltets_createSlot(\"default\", {  \"slot\":`a`,});"),
+        "{code}"
+    );
+    assert!(code.contains("slots: {'default': {slot:\"a\"}}"), "{code}");
+}
+
+/// A single EMPTY `Text` part still satisfies official's rule, so `slot=""`
+/// really does target the `""` slot.
+#[test]
+fn empty_slot_attribute_is_still_a_named_slot() {
+    let code =
+        tsx("<script>import Comp from './C.svelte';</script>\n<Comp><div slot=\"\">x</div></Comp>");
+    assert!(code.contains("$$_pmoC0.$$slot_def[\"\"];"), "{code}");
+}
+
+#[test]
+fn interpolated_slot_attribute_keeps_lets_on_the_default_slot_block() {
+    let code = tsx(
+        "<script>import Comp from './C.svelte'; let b='x';</script>\n<Comp><div slot=\"a{b}c\" let:x>{x}</div></Comp>",
+    );
+    assert!(code.contains("$$_pmoC0.$$slot_def.default;"), "{code}");
+    assert!(!code.contains("$$slot_def[\"ac\"]"), "{code}");
+}
+
+// --- `let:` scope resolution (official `getSlotName`'s `value[0].raw`) ---
+
+/// The laxer of the two `slot=` rules: the JSX block above stays on the default
+/// slot, yet the same child's `let:x` is typed against slot `a`. (Official spells
+/// the index with single quotes here; that quoting difference is tracked apart
+/// from this rule.)
+#[test]
+fn let_bindings_of_an_interpolated_slot_child_resolve_against_the_first_part() {
+    let code = tsx(
+        "<script>import Comp from './C.svelte'; let b='x';</script>\n<Comp><div slot=\"a{b}c\" let:x><slot name=\"s\" p={x} /></div></Comp>",
+    );
+    assert!(
+        code.contains("p:__sveltets_2_instanceOf(Comp).$$slot_def[\"a\"].x"),
+        "{code}"
+    );
+}
+
+#[test]
+fn let_bindings_of_a_dynamic_slot_child_resolve_to_nothing() {
+    let code = tsx(
+        "<script>import Comp from './C.svelte'; let n='x';</script>\n<Comp><div slot={n} let:x><slot name=\"s\" p={x} /></div></Comp>",
+    );
+    assert!(code.contains("slots: {'s': {p:x}}"), "{code}");
+}


### PR DESCRIPTION
Fixes #2100

## Cause

Official svelte2tsx never looks past `value[0]` of a slot-name attribute value.
Three sibling paths read one, and between them official applies exactly **two**
rules:

| path | official rule | source |
|---|---|---|
| `slots: { … }` type key **and** the legacy `$$slots` declaration (built from the same `slots` map) | `nameAttr.value[0].raw` | `svelte2tsx/nodes/slot.ts::handleSlot` + `createRenderFunction.ts` |
| the slot a child's `let:` bindings are typed against | `value[0].raw` | `utils/svelteAst.ts::getSlotName` |
| whether `slot=` lowers to a `$$slot_def[…]` wrapper at all | value is a **single** `Text` part | `htmlxtojsx_v2/nodes/Attribute.ts` (`attributeValueIsOfType(value, 'Text')`) |

rsvelte applied a third rule everywhere — concatenate every `Text` part (and,
for `$$slots`, keep the *last* one) — which diverged in five measured ways:

1. `<slot name="a{b}c" />` → official `slots: {'a': {}}`, rsvelte `{'undefined': {}}`
2. `$$slots` with `name="a{b}c"` → official `{'a': ''}`, rsvelte `{'c': ''}`; with `name={n}` → official `{'undefined': ''}`, rsvelte `{'default': ''}`
3. `<Comp><slot slot="a{b}c" /></Comp>` → official leaves it a plain attribute (`"slot":`a${b}c`,`), rsvelte emitted `$$slot_def["ac"]` and dropped the prop
4. `<Comp><slot slot={n} /></Comp>` → official keeps `"slot":n,`, rsvelte dropped it
5. `<Comp><div slot="">x</div></Comp>` → official targets slot `""`, rsvelte treated it as a plain attribute

## Fix

`crates/rsvelte_projection/src/svelte2tsx/template/nodes/slot_element.rs`

* One shared `value[0]` accessor (`first_value_part`) backing all slot-name reads.
* `slot_name_for_type` → `value[0].raw`, or the literal `undefined` when `value[0]` is an expression. The `$$slots` collection now reuses this instead of the deleted `dollar_slot_name` (which read the *last* `Text` part), matching official's single `slots` map.
* `get_slot_attr_value` split into the two official readers it was conflating:
  * `slot_consumer_name` — `value[0].raw`, for the `let:` scope resolution;
  * `slot_attr_static_name` — single-`Text`-part only, for the `$$slot_def[…]` lowering and every "is this a named-slot child" predicate.
* `build_slot_props_string` drops `slot=` only when a wrapper actually consumed it, so an unforwarded `slot=` (dynamic, interpolated, or outside a component) stays a slot prop.

### Deliberate deviation

`<slot name>` makes official throw (`value[0]` is `undefined`) and `<slot name="">`
makes it emit a syntactically broken `__sveltets_createSlot(, …)`. rsvelte keeps
its valid `default` fallback there — the same call `get_slot_name` already made
in #2046. Issue #2100 flags this as a policy call.

## Tests

* New `crates/rsvelte_projection/tests/svelte2tsx_slot_value0_rule.rs` (13 tests), every expectation taken from official svelte2tsx built against svelte 5.56.8.
* Updated the two tests that asserted the old concatenating behaviour (`template/mod.rs`, `svelte2tsx_slot_summary.rs`).
* Oracle diff over 43 hand-built cases: **22 diverging → 8**, and each remaining one is either the documented deviation above or an out-of-scope issue (below).
* 5,256-file sweep of the `submodules/svelte` + `submodules/language-tools` test corpora: **zero** output change (no such file contains an interpolated slot name — consistent with #2100's note), so no corpus-ratchet movement; `compatibility/svelte2tsx-known-failures.json` is already `[]`.
* `cargo test --workspace` green (253/253 svelte2tsx fixtures included); `cargo fmt --check` + `cargo clippy --all-targets --all-features -- -D warnings` clean.

## Out of scope (found while measuring, not fixed here)

* **`$$slot_def` quoting in the return type.** Official's `getSingleSlotDef` emits `__sveltets_2_instanceOf(C).$$slot_def['b'].x` (single quotes); rsvelte emits `["b"]`. Pre-existing, unrelated to `value[0]`, and currently masked by the fixture runner's relaxed comparator.
* **`<slot name={n} let:x />`** — official emits `"let:x":true,` in the slot props, rsvelte drops it. #2100 lists this under "separate area"; it belongs to the #2049/#2105 `let:`-forwarding family.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
