### PR TITLE
fix(compiler): resolve a `{@const}` shadowing an outer binding by position (#2060)

### DIFF
--- a/.changeset/const-shadow-textcontent.md
+++ b/.changeset/const-shadow-textcontent.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/compiler": patch
+---
+
+A `{@const}` that shadows a component-scope binding now resolves to the `{@const}` in the client transform. Previously the reactivity check looked the name up in the (root-scope-polluted) binding table and found the outer binding, so a compile-time-known `{@const}` read emitted an extra `$.template_effect` + `$.set_text` where the official compiler assigns `textContent` once, and a `{@const}` shadowing a **prop** was even rewritten to `$$props.<name>` — reading the wrong variable.

--- a/compatibility/pattern-corpus/README.md
+++ b/compatibility/pattern-corpus/README.md
@@ -62,6 +62,7 @@ source with `node scripts/compat-corpus/compile.mjs --filter pattern/`.
 | `2012-state-destructure-rest.svelte` | [#2012](https://github.com/baseballyama/rsvelte/issues/2012) | Object rest in a destructured `$state(...)` becomes `$.exclude_from_object` |
 | `2013-state-destructure-quoted-key.svelte` | [#2013](https://github.com/baseballyama/rsvelte/issues/2013) | Quoted key in a destructured `$state(...)` needs bracket member access |
 | `2014-derived-array-rest-arity.svelte` | [#2014](https://github.com/baseballyama/rsvelte/issues/2014) | An array pattern ending in a rest element passes **no length** to `$.to_array` |
+| `2060-const-shadow-textcontent.svelte` | [#2060](https://github.com/baseballyama/rsvelte/issues/2060) | A `{@const}` **shadowing** a component-scope binding must resolve to the `{@const}`, so the read stays a static `textContent` assignment |
 
 ## `matrix/` — the axes around those repros
 
@@ -192,6 +193,25 @@ formatter fixed point while the parsed `data` is still a bare `\f`.
 | `in-if-block.svelte` | form-feed run inside an `{#if}` block |
 | `in-each-block.svelte` | form-feed run inside an `{#each}` block |
 | `svg-text.svelte` | form feed inside an SVG `<text>` element |
+
+### `const-shadow/` — `{@const}` shadowing an outer binding (around #2060)
+
+Declaring block (`{#if}` / `{:else}` / `{#each}` / `{#key}` / `{#await}` /
+`{#snippet}` / `<svelte:boundary>`) × declaration form (identifier /
+destructured) × shadowed binding kind (`$state` / prop). The shadowed name is
+read as an element's only child, so the resolution decides between a static
+`textContent` assignment and a `$.template_effect`.
+
+| File | Point on the axis |
+|---|---|
+| `if-both-branches.svelte` | a `{@const}` in each of `{#if}` and `{:else}` |
+| `each-body.svelte` | `{@const}` in an `{#each}` body, over the loop variable |
+| `key-block.svelte` | `{@const}` inside `{#key}`, keyed on the shadowed binding |
+| `await-then-body.svelte` | `{@const}` in an `{#await … then}` body |
+| `snippet-body.svelte` | `{@const}` inside a `{#snippet}` |
+| `boundary-children.svelte` | `{@const}` in `<svelte:boundary>` children |
+| `destructured-const.svelte` | destructuring `{@const { value } = …}` |
+| `shadows-prop.svelte` | the shadowed binding is a **prop** (the read must not become `$$props.x`) |
 
 ## Adding a file
 

--- a/compatibility/pattern-corpus/issues/2060-const-shadow-textcontent.svelte
+++ b/compatibility/pattern-corpus/issues/2060-const-shadow-textcontent.svelte
@@ -1,0 +1,10 @@
+<script>
+	let value = $state(0);
+</script>
+
+<button onclick={() => value++}>{value}</button>
+
+{#if value >= 0}
+	{@const value = () => 'shadowed'}
+	<p>{value}</p>
+{/if}

--- a/compatibility/pattern-corpus/matrix/const-shadow/await-then-body.svelte
+++ b/compatibility/pattern-corpus/matrix/const-shadow/await-then-body.svelte
@@ -1,0 +1,11 @@
+<script>
+	let value = $state(0);
+	let promise = Promise.resolve(1);
+</script>
+
+<button onclick={() => value++}>{value}</button>
+
+{#await promise then result}
+	{@const value = () => result}
+	<p>{value}</p>
+{/await}

--- a/compatibility/pattern-corpus/matrix/const-shadow/boundary-children.svelte
+++ b/compatibility/pattern-corpus/matrix/const-shadow/boundary-children.svelte
@@ -1,0 +1,10 @@
+<script>
+	let value = $state(0);
+</script>
+
+<button onclick={() => value++}>{value}</button>
+
+<svelte:boundary>
+	{@const value = () => 'boundary'}
+	<p>{value}</p>
+</svelte:boundary>

--- a/compatibility/pattern-corpus/matrix/const-shadow/destructured-const.svelte
+++ b/compatibility/pattern-corpus/matrix/const-shadow/destructured-const.svelte
@@ -1,0 +1,11 @@
+<script>
+	let value = $state(0);
+	let point = { value: () => 'shadowed' };
+</script>
+
+<button onclick={() => value++}>{value}</button>
+
+{#if value >= 0}
+	{@const { value } = point}
+	<p>{value}</p>
+{/if}

--- a/compatibility/pattern-corpus/matrix/const-shadow/each-body.svelte
+++ b/compatibility/pattern-corpus/matrix/const-shadow/each-body.svelte
@@ -1,0 +1,11 @@
+<script>
+	let value = $state(0);
+	let rows = [1, 2];
+</script>
+
+<button onclick={() => value++}>{value}</button>
+
+{#each rows as row}
+	{@const value = () => row}
+	<p>{value}</p>
+{/each}

--- a/compatibility/pattern-corpus/matrix/const-shadow/if-both-branches.svelte
+++ b/compatibility/pattern-corpus/matrix/const-shadow/if-both-branches.svelte
@@ -1,0 +1,13 @@
+<script>
+	let value = $state(0);
+</script>
+
+<button onclick={() => value++}>{value}</button>
+
+{#if value}
+	{@const value = () => 'consequent'}
+	<p>{value}</p>
+{:else}
+	{@const value = () => 'alternate'}
+	<p>{value}</p>
+{/if}

--- a/compatibility/pattern-corpus/matrix/const-shadow/key-block.svelte
+++ b/compatibility/pattern-corpus/matrix/const-shadow/key-block.svelte
@@ -1,0 +1,10 @@
+<script>
+	let value = $state(0);
+</script>
+
+<button onclick={() => value++}>{value}</button>
+
+{#key value}
+	{@const value = () => 'keyed'}
+	<p>{value}</p>
+{/key}

--- a/compatibility/pattern-corpus/matrix/const-shadow/shadows-prop.svelte
+++ b/compatibility/pattern-corpus/matrix/const-shadow/shadows-prop.svelte
@@ -1,0 +1,10 @@
+<script>
+	let { title } = $props();
+</script>
+
+<h1>{title}</h1>
+
+{#if title}
+	{@const title = () => 'shadowed'}
+	<p>{title}</p>
+{/if}

--- a/compatibility/pattern-corpus/matrix/const-shadow/snippet-body.svelte
+++ b/compatibility/pattern-corpus/matrix/const-shadow/snippet-body.svelte
@@ -1,0 +1,12 @@
+<script>
+	let value = $state(0);
+</script>
+
+<button onclick={() => value++}>{value}</button>
+
+{#snippet row()}
+	{@const value = () => 'snippet'}
+	<p>{value}</p>
+{/snippet}
+
+{@render row()}

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/scope.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/scope.rs
@@ -62,6 +62,12 @@ pub struct ScopeRoot {
     /// O(bindings) linear scan (`bindings.iter().position/any(|b| b.name == ...)`)
     /// can instead go through this map and scan only same-named entries.
     pub bindings_by_name: FxHashMap<String, SmallVec<[u32; 1]>>,
+    /// Lazily built map from a reference's source start offset to the binding
+    /// index it resolved to during analysis. Phase 3 never switches its scope
+    /// for template blocks, so a name-based lookup there picks an outer binding
+    /// whenever a template declaration shadows one; this map replays the
+    /// scope-correct resolution Phase 2 already performed.
+    pub(crate) reference_bindings: std::cell::OnceCell<FxHashMap<u32, u32>>,
 }
 
 impl ScopeRoot {
@@ -79,7 +85,25 @@ impl ScopeRoot {
             snippet_scope_indices: FxHashSet::default(),
             conflicts: FxHashSet::default(),
             bindings_by_name: FxHashMap::default(),
+            reference_bindings: std::cell::OnceCell::new(),
         }
+    }
+
+    /// Resolve the binding that the reference starting at `start` was bound to
+    /// during analysis, verifying the name matches so a stale/synthesized span
+    /// falls back to the caller's name-based lookup.
+    pub fn binding_at_reference(&self, name: &str, start: u32) -> Option<&Binding> {
+        let map = self.reference_bindings.get_or_init(|| {
+            let mut map: FxHashMap<u32, u32> = FxHashMap::default();
+            for (idx, binding) in self.bindings.iter().enumerate() {
+                for reference in &binding.references {
+                    map.insert(reference.start, idx as u32);
+                }
+            }
+            map
+        });
+        let binding = self.bindings.get(*map.get(&start)? as usize)?;
+        (binding.name == name).then_some(binding)
     }
 
     /// Push a binding and record its index in `bindings_by_name`, keeping the

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/scope_builder.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/scope_builder.rs
@@ -343,6 +343,7 @@ impl<'a> ScopeBuilder<'a> {
                 snippet_scope_indices: self.snippet_scope_indices,
                 conflicts,
                 bindings_by_name: self.bindings_by_name,
+                reference_bindings: std::cell::OnceCell::new(),
             },
             self.validation_errors,
         )

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/const_tag.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/const_tag.rs
@@ -117,6 +117,11 @@ pub fn const_tag(node: &ConstTag, context: &mut ComponentContext) {
             .transform_deep_read
             .insert(id_name.clone(), ());
 
+        // The `{@const}` shadows any outer same-named prop, so reads must go
+        // through the `$.get(name)` transform above instead of being rewritten
+        // to `$$props.name` (mirrors the `let:` / each-item shadowing).
+        context.state.shadowed_prop_names.insert(id_name.clone());
+
         // Extract referenced variable names from init expression for blocker detection
         let init_refs = extract_refs_from_json_expr(&parsed.init_expr);
 
@@ -295,6 +300,7 @@ pub fn const_tag(node: &ConstTag, context: &mut ComponentContext) {
                 .state
                 .transform_deep_read
                 .insert(id_name.clone(), ());
+            context.state.shadowed_prop_names.insert(id_name.clone());
         }
     }
 }

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/utils.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/utils.rs
@@ -4643,6 +4643,30 @@ fn has_reactive_state_json(json_value: &serde_json::Value, context: &ComponentCo
                     }
                 }
 
+                // Replay Phase 2's scope-correct resolution for this reference.
+                // A template declaration (`{@const}` / `{#await}`) that shadows a
+                // component-scope binding is invisible to the name-based lookups
+                // below, which would report the outer (reactive) binding and
+                // force an unnecessary template_effect. `let:` bindings are
+                // excluded: their reactivity is decided by whether the directive's
+                // transform is installed (see the `BindingKind::Let` arm below),
+                // not by the binding itself.
+                let by_position = obj
+                    .get("start")
+                    .and_then(|v| v.as_u64())
+                    .and_then(|start| {
+                        context
+                            .state
+                            .scope_root
+                            .binding_at_reference(name, start as u32)
+                    })
+                    .filter(|b| {
+                        !matches!(
+                            b.kind,
+                            crate::compiler::phases::phase2_analyze::scope::BindingKind::Let
+                        )
+                    });
+
                 // Check if identifier has a transform registered (e.g., @const, snippet parameter)
                 // Identifiers with transforms are derived values that need reactive tracking,
                 // BUT only if the transform has is_reactive=true.
@@ -4659,32 +4683,8 @@ fn has_reactive_state_json(json_value: &serde_json::Value, context: &ComponentCo
                     // Resolve the binding this reference actually refers to. `get_binding`
                     // walks the root-scope-polluted map, which prefers an OUTER same-named
                     // binding; when an in-scope `{@const}` shadows it, that resolves to the
-                    // outer binding instead of the `{@const}`. `transform_deep_read` marks a
-                    // `{@const}` (Template) whose transform is currently active, so in that
-                    // case re-resolve to the shadowing Template binding to check its kind.
-                    let resolved = {
-                        let direct = context.state.get_binding(name);
-                        let is_shadowed_normal = direct
-                            .is_some_and(|b| matches!(b.kind, BindingKind::Normal))
-                            && context.state.transform_deep_read.contains_key(name);
-                        if is_shadowed_normal {
-                            context
-                                .state
-                                .scope_root
-                                .bindings_by_name
-                                .get(name)
-                                .and_then(|idxs| {
-                                    idxs.iter().rev().find_map(|&i| {
-                                        let b =
-                                            context.state.scope_root.bindings.get(i as usize)?;
-                                        matches!(b.kind, BindingKind::Template).then_some(b)
-                                    })
-                                })
-                                .or(direct)
-                        } else {
-                            direct
-                        }
-                    };
+                    // outer binding instead of the `{@const}`.
+                    let resolved = by_position.or_else(|| context.state.get_binding(name));
 
                     // Check if this is a Derived binding - if so, skip the early return
                     // and fall through to the detailed binding kind check below.
@@ -4716,7 +4716,7 @@ fn has_reactive_state_json(json_value: &serde_json::Value, context: &ComponentCo
                         return transform.is_reactive;
                     }
                 }
-                if let Some(binding) = context.state.get_binding(name) {
+                if let Some(binding) = by_position.or_else(|| context.state.get_binding(name)) {
                     use crate::compiler::phases::phase2_analyze::scope::BindingKind;
 
                     // Match Svelte's logic from Identifier.js (lines 95-101):


### PR DESCRIPTION
Fixes #2060

## Cause

Phase 3 never switches `state.scope` when it descends into a template block, so
`has_reactive_state_json` (the client "can this text be assigned statically?"
check) resolved an identifier **by name**. With the root scope polluted by every
child-scope declaration, a name that a `{@const}` shadows resolved to the *outer*
binding instead:

```svelte
<script>
	let x = $state(1);
</script>

{#if true}
	{@const x = 2}
	<p>{x}</p>
{/if}
```

`{x}` is the `{@const}` — its value is compile-time known, so official emits
`p.textContent = $.get(x)` with a `<p></p>` template. rsvelte saw the outer
`$state` binding, called the read reactive, and emitted `$.child` + `$.reset` +
`$.template_effect(() => $.set_text(...))` with a `<p> </p>` template.

An existing guard covered exactly one shape (outer binding of kind `Normal`, via
`transform_deep_read`), which is why the divergence only showed up against
`$state` / `$derived` / prop outers. A second, related shape falls out of the
same root cause: when the shadowed binding is a **prop**, `convert_identifier`
rewrote the read to `$$props.x`, reading the wrong variable entirely.

## Fix

Phase 2 already resolves every reference against the real scope chain and records
it on the binding, so Phase 3 does not need to re-derive scoping — it just needs
to *replay* that resolution. `ScopeRoot::binding_at_reference(name, start)` looks
the reference up by its source start offset through a map built lazily from
`Binding::references` (name-checked, so a synthesized/stale span falls back to the
old name lookup). `has_reactive_state_json` uses it for both of its binding
lookups, and the ad-hoc `transform_deep_read` special case is deleted.

`let:` bindings are deliberately excluded from the position path: in this port a
`let:` read's reactivity comes from whether the directive's transform is
installed (the `BindingKind::Let` arm), not from the binding — resolving them by
position regressed `<Tabs let:selected>` + `<Tab {selected}>` in the corpus.

`const_tag` also registers its names in `shadowed_prop_names` (mirroring the
`let:` / each-item shadowing already there), so a `{@const}` over a prop name
reads `$.get(x)` instead of `$$props.x`.

## Tests

New pattern-corpus entries (dual-compiled client / server / client-dev against
the official compiler, and they also flow through the fmt and svelte2tsx parity
gates):

- `issues/2060-const-shadow-textcontent.svelte`
- `matrix/const-shadow/` — declaring block (`{#if}`/`{:else}`, `{#each}`,
  `{#key}`, `{#await}`, `{#snippet}`, `<svelte:boundary>`) × declaration form
  (identifier / destructured) × shadowed kind (`$state` / prop)

Verified that 7 of the 9 fail on client with the code change reverted and pass
with it; the remaining two (`snippet-body`, `destructured-const`) already went
through shadow-aware paths and pin that the change keeps them green.

- `cargo test --release` — whole workspace green
- `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings` — clean
- Corpus (14,015 entries × 3 targets, all sources synced): **no regressions**;
  compiler / fmt / svelte2tsx (text + map) gates all green

## Follow-up found while checking horizontally (not in this PR)

The **server** generator has the same family of defect via different helpers
(name-keyed `constant_vars` folding + `evaluate_identifier`'s union rule). Both
are pre-existing and independent of the client path touched here:

```svelte
<script>
	let count = $state(0);
	let doubled = $derived(count * 2);
</script>
{#if count}
	{@const doubled = () => 'shadowed'}
	<p>{doubled}</p>
{/if}
```

emits `$.escape(doubled())` — the outer `$derived` accessor — where official
emits `$.escape(doubled)`. With a literal `{@const}` the shadowed read instead
folds to the *outer* binding's value. Worth its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RQSYoh4Wc353KgUnWHjazu
