### PR TITLE
fix(compiler): drop redundant parens from module-script equality operands (#2081)

### DIFF
--- a/.changeset/module-equality-operand-parens.md
+++ b/.changeset/module-equality-operand-parens.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/compiler": patch
+---
+
+fix(compiler): drop redundant parentheses from dev equality instrumentation operands in module scripts — `export const x = (a === b) != (c == d);` now emits `$.equals($.strict_equals(a, b), $.equals(c, d), false)` like the official compiler instead of `$.equals(($.strict_equals(a, b)), ($.equals(c, d)), false)`

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/strict_equals_ast.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/strict_equals_ast.rs
@@ -65,6 +65,21 @@ fn contains_equality_expr<'a>(expr: &Expression<'a>) -> bool {
     finder.found
 }
 
+/// Source text of an operand as it should appear in the helper call's argument
+/// list. Official visits the operand and lets esrap reprint it, so parentheses
+/// written in the source never survive; a sequence expression is the only shape
+/// that needs them back, because a bare comma would split the argument list.
+fn operand_text(source: &str, expr: &Expression<'_>) -> String {
+    let inner = expr.without_parentheses();
+    let span = inner.span();
+    let text = source[span.start as usize..span.end as usize].trim();
+    if matches!(inner, Expression::SequenceExpression(_)) {
+        format!("({text})")
+    } else {
+        text.to_string()
+    }
+}
+
 /// Collect leaf equality rewrites (those whose operands don't themselves
 /// contain an equality operator) from a single parse. Nested cases resolve
 /// across fixed-point iterations — the batched module dev-tail driver drives
@@ -104,16 +119,11 @@ impl<'a, 'src> Visit<'a> for StrictEqualsCollector<'src> {
             return;
         }
 
-        let left_span = expr.left.span();
-        let right_span = expr.right.span();
-        let left_text = &self.source[left_span.start as usize..left_span.end as usize];
-        let right_text = &self.source[right_span.start as usize..right_span.end as usize];
-
         let rewrite = format!(
             "{}({}, {}{})",
             helper,
-            left_text.trim(),
-            right_text.trim(),
+            operand_text(self.source, &expr.left),
+            operand_text(self.source, &expr.right),
             if negated { ", false" } else { "" }
         );
 
@@ -244,7 +254,7 @@ mod tests {
         // Outer wraps the two inner rewrites
         assert_eq!(
             out,
-            "$.strict_equals(($.strict_equals(a, b)), ($.strict_equals(c, d)))"
+            "$.strict_equals($.strict_equals(a, b), $.strict_equals(c, d))"
         );
     }
 
@@ -252,13 +262,36 @@ mod tests {
     fn nested_mixed_equality_both_rewritten() {
         let src = "(a === b) != (c == d)";
         let out = transform_strict_equals_module_ast(src, false).unwrap();
-        // Known divergence: replacements copy operand text, so the source's
-        // parens survive. The official compiler reprints from the AST and emits
-        // `$.equals($.strict_equals(a, b), $.equals(c, d), false)`.
         assert_eq!(
             out,
-            "$.equals(($.strict_equals(a, b)), ($.equals(c, d)), false)"
+            "$.equals($.strict_equals(a, b), $.equals(c, d), false)"
         );
+    }
+
+    #[test]
+    fn operand_parens_are_dropped() {
+        // Official reprints the operand from the AST, so source parens vanish.
+        for (src, expected) in [
+            ("((a)) === b", "$.strict_equals(a, b)"),
+            ("(a + b) === (c * d)", "$.strict_equals(a + b, c * d)"),
+            ("(a = b) === c", "$.strict_equals(a = b, c)"),
+            ("(a ? b : c) === d", "$.strict_equals(a ? b : c, d)"),
+            ("(() => 1) === z", "$.strict_equals(() => 1, z)"),
+            ("({ a: 1 }) === z", "$.strict_equals({ a: 1 }, z)"),
+        ] {
+            let out = transform_strict_equals_module_ast(src, false).unwrap();
+            assert_eq!(out, expected, "source: {src}");
+        }
+    }
+
+    #[test]
+    fn sequence_operand_keeps_one_pair_of_parens() {
+        // A bare comma would split the helper's argument list.
+        let out = transform_strict_equals_module_ast("(a, b) === c", false).unwrap();
+        assert_eq!(out, "$.strict_equals((a, b), c)");
+
+        let out = transform_strict_equals_module_ast("a === ((b, c))", false).unwrap();
+        assert_eq!(out, "$.strict_equals(a, (b, c))");
     }
 
     #[test]

--- a/crates/rsvelte_core/tests/module_equality_operand_parens.rs
+++ b/crates/rsvelte_core/tests/module_equality_operand_parens.rs
@@ -1,0 +1,89 @@
+//! Regression test for redundant parentheses surviving the dev equality
+//! instrumentation in module scripts (baseballyama/rsvelte#2081).
+//!
+//! `compile_module` rewrites the source as text, so an operand used to be
+//! spliced verbatim — under `preserve_parens` that carried the source's
+//! parentheses into the helper call (`$.equals(($.strict_equals(a, b)), …)`).
+//! Official visits the operand and lets esrap reprint it, so the parentheses
+//! are gone. The expectations below are the official compiler's output.
+
+use rsvelte_core::GenerateMode;
+use rsvelte_core::compile_module;
+use rsvelte_core::compiler::ModuleCompileOptions;
+
+fn compile_mod_client_dev(src: &str) -> String {
+    compile_module(
+        src,
+        ModuleCompileOptions {
+            filename: Some("x.svelte.js".to_string()),
+            generate: GenerateMode::Client,
+            dev: true,
+            ..Default::default()
+        },
+    )
+    .expect("compile_module")
+    .js
+    .code
+}
+
+#[track_caller]
+fn assert_emits(src: &str, expected: &str) {
+    let out = compile_mod_client_dev(src);
+    assert!(
+        out.contains(expected),
+        "expected `{expected}` for `{src}`. Got:\n{out}"
+    );
+}
+
+#[test]
+fn nested_equality_operands_lose_their_parens() {
+    assert_emits(
+        "export const x = (a === b) != (c == d);",
+        "$.equals($.strict_equals(a, b), $.equals(c, d), false)",
+    );
+    assert_emits(
+        "export const y = (a === b) === (c === d);",
+        "$.strict_equals($.strict_equals(a, b), $.strict_equals(c, d))",
+    );
+}
+
+#[test]
+fn redundant_operand_parens_are_dropped() {
+    assert_emits("export const a1 = ((a)) === b;", "$.strict_equals(a, b)");
+    assert_emits(
+        "export const a2 = (a + b) === (c * d);",
+        "$.strict_equals(a + b, c * d)",
+    );
+    assert_emits(
+        "export const a3 = (a = b) === c;",
+        "$.strict_equals(a = b, c)",
+    );
+    assert_emits(
+        "export const a4 = (a ? b : c) === d;",
+        "$.strict_equals(a ? b : c, d)",
+    );
+    assert_emits(
+        "export const a5 = ({ a: 1 }) === z;",
+        "$.strict_equals({ a: 1 }, z)",
+    );
+}
+
+#[test]
+fn sequence_operands_keep_the_parens_they_need() {
+    // A bare comma would split the helper's argument list, so this is the one
+    // operand shape official parenthesises too.
+    assert_emits(
+        "export const s1 = (a, b) === c;",
+        "$.strict_equals((a, b), c)",
+    );
+    assert_emits(
+        "export const s2 = a === ((b, c));",
+        "$.strict_equals(a, (b, c))",
+    );
+}
+
+#[test]
+fn state_reads_inside_a_parenthesised_operand_still_lower() {
+    let src = "export const fn = () => {\n  let n = $state.raw(0);\n  n = 1;\n  return (n + 1) === 2;\n};";
+    assert_emits(src, "$.strict_equals($.get(n) + 1, 2)");
+}


### PR DESCRIPTION
Fixes #2081

## Problem

The dev-mode equality instrumentation for module scripts (`.svelte.js` / `.svelte.ts`) rewrites the script as **text**: it replaces the span of each equality `BinaryExpression` with a `$.strict_equals(...)` / `$.equals(...)` call whose arguments are the operands' source text, spliced verbatim.

The module tail parses with `ParseOptions::default()`, i.e. `preserve_parens: true`, so an operand's span *includes* the parentheses written in the source. Official visits the operand and lets esrap reprint it, so those parentheses never survive:

```js
// export const x = (a === b) != (c == d);

// official
export const x = $.equals($.strict_equals(a, b), $.equals(c, d), false);
// rsvelte (before)
export const x = $.equals(($.strict_equals(a, b)), ($.equals(c, d)), false);
```

Nested equality is the loudest case (each fixed-point iteration re-parses, and the previous iteration's rewrite is now sitting inside the source parens), but any parenthesised operand hit it: `(a + b) === c`, `((a)) === b`, `(a = b) === c`, `(a ? b : c) === d`.

The corpus gate cannot see this — comparison-side oxfmt normalization drops redundant parens — but it is what users get in their dev bundles.

## Fix

`strict_equals_ast::operand_text` now takes the operand off `Expression::without_parentheses()` and re-adds a single pair of parentheses only for a `SequenceExpression`, where a bare comma would otherwise split the helper's argument list. A sweep of operand shapes through the official compiler confirms that is the only shape esrap parenthesises in call-argument position (`(a, b) === c` → `$.strict_equals((a, b), c)`; everything from `a = b` through `{ a: 1 }`, `() => 1`, `class {}`, `void 0` prints bare).

Component instance scripts and template expressions were already correct — their output is reprinted from the AST at the end of the pipeline — so this is module-script only, and no shared helper was worth extracting.

### Deliberately out of scope

Redundant parentheses that are *not* an equality operand still survive in module scripts, because the module path is a text pipeline and official reprints the whole program. This is not equality-specific and reproduces with `dev: false`:

```js
// export const p = (a > b) && (c < d);
// official: export const p = a > b && c < d;
// rsvelte:  export const p = (a > b) && (c < d);
```

That belongs to the module-script AST epic (#2089), not here.

## Verification

- Reproducer from the issue is now byte-identical to official through the NAPI binding, along with `((a)) === b`, `(a + b) === (c * d)`, `(a = b) === c`, `(a ? b : c) === d`, `({ a: 1 }) === z`, `(a, b) === c`, `a === ((b, c))` and the nested `(a === b) === (c === d)` form.
- `cargo test --release -p rsvelte_core` — full suite green (all test binaries + doctests).
- New tests: 6 unit tests in `strict_equals_ast.rs` (two updated to the official shape) plus an end-to-end `crates/rsvelte_core/tests/module_equality_operand_parens.rs` driving `compile_module`, including a `$state.raw` case proving state reads inside a parenthesised operand still lower to `$.get(n) + 1`.
- Corpus (`svelte` + in-repo `pattern` sources; the other submodules are CI's job): all three targets show **no regressions**. Nothing to shrink in `compatibility/known-failures.client-dev.json` — 0 of its entries present in this run flipped, matching the issue's note that the gate is blind to this class.
- `cargo fmt` + `cargo clippy --all-targets --all-features -- -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
