### PR TITLE
fix(compiler): resolve a block-local snippet over a same-named outer binding in is_function() checks

### DIFF
--- a/.changeset/fix-snippet-shadow-is-function.md
+++ b/.changeset/fix-snippet-shadow-is-function.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/compiler": patch
+---
+
+A client-side attribute expression, event handler, or `{@const}`/`$derived` compile-time-known check that reads a block-local `{#snippet}` shadowing a same-named outer binding (a plain script-level `function`, `let`, or `$derived` — not a prop) now resolves to the snippet instead of the outer binding. Upstream's `Binding#is_function()` always returns `false` for a snippet, so the read is treated as having state; rsvelte's `get_binding` walks a root scope that is intentionally polluted with every scope's declarations for backward compatibility and prefers whichever declaration was merged in first, which could resolve to the outer (non-snippet) binding and wrongly skip the `$.template_effect` wrap or the dev-mode `$.apply` event-handler wrap.

--- a/compatibility/pattern-corpus/README.md
+++ b/compatibility/pattern-corpus/README.md
@@ -63,6 +63,7 @@ source with `node scripts/compat-corpus/compile.mjs --filter pattern/`.
 | `2013-state-destructure-quoted-key.svelte` | [#2013](https://github.com/baseballyama/rsvelte/issues/2013) | Quoted key in a destructured `$state(...)` needs bracket member access |
 | `2014-derived-array-rest-arity.svelte` | [#2014](https://github.com/baseballyama/rsvelte/issues/2014) | An array pattern ending in a rest element passes **no length** to `$.to_array` |
 | `2060-const-shadow-textcontent.svelte` | [#2060](https://github.com/baseballyama/rsvelte/issues/2060) | A `{@const}` **shadowing** a component-scope binding must resolve to the `{@const}`, so the read stays a static `textContent` assignment |
+| `2141-snippet-shadow-is-function.svelte` | [#2141](https://github.com/baseballyama/rsvelte/issues/2141) | A block-local `{#snippet}` shadowing a same-named outer `function` still reads as reactive (`is_function()` must resolve to the snippet, not the outer function) |
 
 ## `matrix/` — the axes around those repros
 

--- a/compatibility/pattern-corpus/issues/2141-snippet-shadow-is-function.svelte
+++ b/compatibility/pattern-corpus/issues/2141-snippet-shadow-is-function.svelte
@@ -1,0 +1,12 @@
+<script>
+	function greeting() {
+		return 'outer';
+	}
+
+	let open = $state(true);
+</script>
+
+{#if open}
+	{#snippet greeting()}<b>hi</b>{/snippet}
+	<div data-x={greeting}>x</div>
+{/if}

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/attribute.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/attribute.rs
@@ -280,8 +280,12 @@ pub fn build_event_handler(
 
     // Check if it's an identifier
     if let JsExpr::Identifier(name) = &js_expr {
-        // Check if this identifier refers to a function in the scope
-        let binding = context.state.get_binding(name);
+        // Check if this identifier refers to a function in the scope.
+        // `resolve_shadowing_snippet_binding` (not a plain `get_binding`) so a
+        // block-local `{#snippet}` that shadows a same-named outer function
+        // correctly resolves to the snippet — see its doc comment for why
+        // `get_binding` alone can't be trusted here.
+        let binding = crate::compiler::phases::phase3_transform::client::visitors::shared::utils::resolve_shadowing_snippet_binding(name, context);
 
         if let Some(binding) = &binding {
             // If the binding's initial value is a function, use it as-is

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/events.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/events.rs
@@ -199,7 +199,11 @@ pub fn build_event_handler(
         // copes with hot-reload swapping the binding, and dev wraps everything
         // else too so a throwing handler can still be reported.
         use crate::compiler::phases::phase2_analyze::scope::DeclarationKind;
-        let binding = context.state.get_binding(name);
+        // `resolve_shadowing_snippet_binding` (not a plain `get_binding`) so a
+        // block-local `{#snippet}` that shadows a same-named outer function
+        // correctly resolves to the snippet — see its doc comment for why
+        // `get_binding` alone can't be trusted here.
+        let binding = super::utils::resolve_shadowing_snippet_binding(name, context);
         if binding.is_some_and(|b| b.is_function()) {
             return handler;
         }

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/utils.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/utils.rs
@@ -4611,6 +4611,55 @@ fn initial_is_non_reactive(binding: &Binding, context: &ComponentContext) -> boo
     })
 }
 
+/// Resolve the binding a template identifier read actually refers to,
+/// correcting for `get_binding`'s root-scope pollution (see its own doc
+/// comment) when a block-local `{#snippet}` shadows a same-named outer
+/// binding that is NOT a prop — a plain script-level `function` / `let`, or a
+/// `$derived`. `shadow_snippet_declarations` (`client::utils`) already
+/// records every such shadowed name in `shadowed_prop_names` (despite the
+/// name, it covers ANY outer binding a fragment's snippets shadow, not just
+/// props) and strips it from `transform`, so a shadowed prop/store still
+/// resolves correctly here via the "always reactive" `BindingKind` branch
+/// below. A shadowed plain function does not: `get_binding` returns the
+/// outer function's binding, whose `is_function()` is `true`, so the read
+/// wrongly skips the `$.template_effect` wrap that the local snippet (whose
+/// `is_function()` is always `false`, matching upstream's
+/// `Binding#is_function`) requires.
+///
+/// `ScopeRoot::binding_at_reference` (added for #2060/#2143) covers this same
+/// class of bug more precisely, by replaying Phase 2's scope-correct
+/// resolution for the exact reference position — prefer it wherever a source
+/// position is available (see `has_reactive_state_json` /
+/// `is_expression_known_json`). This name-based fallback remains the only
+/// option for `build_event_handler` (`shared/events.rs`, `attribute.rs`),
+/// which resolve an already-converted `JsExpr::Identifier` that carries no
+/// source position.
+pub fn resolve_shadowing_snippet_binding<'a>(
+    name: &str,
+    context: &'a ComponentContext,
+) -> Option<&'a Binding> {
+    let direct = context.state.get_binding(name);
+    let is_snippet_binding = |b: &Binding| {
+        matches!(b.kind, BindingKind::Normal)
+            && b.initial_node_type.as_deref() == Some("SnippetBlock")
+    };
+    if direct.is_some_and(is_snippet_binding) || !context.state.shadowed_prop_names.contains(name) {
+        return direct;
+    }
+    context
+        .state
+        .scope_root
+        .bindings_by_name
+        .get(name)
+        .and_then(|idxs| {
+            idxs.iter().rev().find_map(|&i| {
+                let b = context.state.scope_root.bindings.get(i as usize)?;
+                is_snippet_binding(b).then_some(b)
+            })
+        })
+        .or(direct)
+}
+
 /// Internal helper that processes JSON values directly, avoiding serde_json::from_value overhead.
 /// This eliminates expensive cloning and deserialization in recursive calls.
 fn has_reactive_state_json(json_value: &serde_json::Value, context: &ComponentContext) -> bool {
@@ -5846,7 +5895,22 @@ fn is_expression_known_json(json_value: &serde_json::Value, context: &ComponentC
                 if name == "undefined" {
                     return true;
                 }
-                if let Some(binding) = context.state.get_binding(name) {
+                // Prefer `binding_at_reference` (the exact binding Phase 2 resolved
+                // this reference to — see its doc comment) over a plain
+                // `get_binding`, which walks the root-scope-polluted map and can
+                // return an outer binding shadowed by a template declaration
+                // (`{@const}`, `{#snippet}`, ...).
+                if let Some(binding) = obj
+                    .get("start")
+                    .and_then(|v| v.as_u64())
+                    .and_then(|start| {
+                        context
+                            .state
+                            .scope_root
+                            .binding_at_reference(name, start as u32)
+                    })
+                    .or_else(|| context.state.get_binding(name))
+                {
                     use crate::compiler::phases::phase2_analyze::scope::BindingKind;
 
                     // Props are never known (external values)

--- a/crates/rsvelte_core/tests/attribute_snippet_shadow_is_function_2141.rs
+++ b/crates/rsvelte_core/tests/attribute_snippet_shadow_is_function_2141.rs
@@ -1,0 +1,185 @@
+//! Regression tests for issue #2141 — an attribute expression that reads a
+//! block-local `{#snippet}` binding must be wrapped in `$.template_effect`,
+//! even when the snippet shadows a same-named outer binding.
+//!
+//! Upstream's `Binding#is_function()` (`scope.js`) returns `false` for a
+//! binding whose `initial` is a `SnippetBlock`, so a snippet read is always
+//! treated as having state. rsvelte's `Binding::is_function()` already
+//! mirrors that (a `{#snippet}` binding never gets `initial_is_function`
+//! set), but `ComponentClientTransformState::get_binding` resolves an
+//! identifier through a "root scope" that is deliberately polluted with
+//! every scope's declarations for backward compatibility, preferring
+//! whichever declaration was merged in first (see its doc comment in
+//! `2_analyze/scope.rs`). When a block-local `{#snippet}` shadows a
+//! same-named outer binding that isn't a prop/store (a plain script-level
+//! `function`, `let`, or `$derived`), that root lookup returns the *outer*
+//! binding instead of the snippet, so `is_function()` — and everything
+//! downstream that depends on it (the `$.template_effect` wrap, the dev-mode
+//! event-handler `$.apply` wrap, `{@const}`/`$derived` compile-time-known
+//! folding) — is computed against the wrong binding.
+//!
+//! `resolve_shadowing_snippet_binding` in `client/visitors/shared/utils.rs`
+//! fixes this by re-resolving to the snippet binding whenever the read site
+//! is inside a fragment that shadows the name (tracked by
+//! `shadowed_prop_names`, populated for every `{#snippet}` a fragment
+//! declares — not just prop shadows, despite the name) and the direct
+//! `get_binding` result isn't already the snippet.
+
+use rsvelte_core::{CompileOptions, GenerateMode, compile, compiler::CssMode};
+
+fn compile_js(src: &str, dev: bool) -> String {
+    compile(
+        src,
+        CompileOptions {
+            filename: Some("Test.svelte".to_string()),
+            generate: GenerateMode::Client,
+            dev,
+            css: CssMode::External,
+            ..Default::default()
+        },
+    )
+    .expect("compile")
+    .js
+    .code
+}
+
+/// Baseline (no shadowing): a plain block-local snippet read in an attribute
+/// is already wrapped correctly — this must keep passing.
+#[test]
+fn unshadowed_snippet_read_is_wrapped() {
+    let src = r#"{#if true}
+	{#snippet greeting()}<b>hi</b>{/snippet}
+	<div data-x={greeting}>x</div>
+{/if}"#;
+    let out = compile_js(src, false);
+    assert!(
+        out.contains("$.template_effect(() => $.set_attribute(div, 'data-x', greeting))"),
+        "expected a template_effect wrap in:\n{out}"
+    );
+}
+
+/// The issue's core repro: a block-local `{#snippet}` shadows a same-named
+/// outer JS `function` declared in `<script>`. The attribute read must
+/// resolve to the (always-reactive) snippet, not the (is_function() == true)
+/// outer function, and stay wrapped in `$.template_effect`.
+#[test]
+fn snippet_shadowing_an_outer_function_is_still_wrapped() {
+    let src = r#"<script>
+	function greeting() { return 'outer'; }
+	let open = $state(true);
+</script>
+{#if open}
+	{#snippet greeting()}<b>hi</b>{/snippet}
+	<div data-x={greeting}>x</div>
+{/if}"#;
+    let out = compile_js(src, false);
+    assert!(
+        out.contains("$.template_effect(() => $.set_attribute(div, 'data-x', greeting))"),
+        "expected a template_effect wrap in:\n{out}"
+    );
+    assert!(
+        !out.contains("$.set_attribute(div, 'data-x', greeting);\n\t\t\t$.append"),
+        "the attribute was emitted unwrapped (static) in:\n{out}"
+    );
+}
+
+/// Same shadowing, but the outer binding is a `let` bound to an arrow
+/// function rather than a `function` declaration.
+#[test]
+fn snippet_shadowing_an_outer_arrow_function_let_is_still_wrapped() {
+    let src = r#"<script>
+	let greeting = () => 'outer';
+	let open = $state(true);
+</script>
+{#if open}
+	{#snippet greeting()}<b>hi</b>{/snippet}
+	<div data-x={greeting}>x</div>
+{/if}"#;
+    let out = compile_js(src, false);
+    assert!(
+        out.contains("$.template_effect(() => $.set_attribute(div, 'data-x', greeting))"),
+        "expected a template_effect wrap in:\n{out}"
+    );
+}
+
+/// A block-local snippet shadowing an outer `$derived` whose value is
+/// compile-time "known" (a literal): the snippet is still always reactive,
+/// so the shadowed read must not fold away as static.
+#[test]
+fn snippet_shadowing_a_known_derived_is_still_wrapped() {
+    let src = r#"<script>
+	let greeting = $derived('outer');
+	let open = $state(true);
+</script>
+{#if open}
+	{#snippet greeting()}<b>hi</b>{/snippet}
+	<div data-x={greeting}>x</div>
+{/if}"#;
+    let out = compile_js(src, false);
+    assert!(
+        out.contains("$.template_effect(() => $.set_attribute(div, 'data-x', greeting))"),
+        "expected a template_effect wrap in:\n{out}"
+    );
+}
+
+/// Dev-mode event handlers take a different, `is_function()`-gated codegen
+/// path (`events.rs::build_event_handler`): a real function binding attaches
+/// the handler directly, but a shadowing snippet must still go through the
+/// full `$.apply(...)` dev wrap so a throwing handler is reported correctly.
+#[test]
+fn snippet_shadowing_an_outer_function_still_apply_wraps_the_dev_handler() {
+    let src = r#"<script>
+	function greeting() { return 'outer'; }
+	let open = $state(true);
+</script>
+{#if open}
+	{#snippet greeting()}<b>hi</b>{/snippet}
+	<button onclick={greeting}>x</button>
+{/if}"#;
+    let out = compile_js(src, true);
+    assert!(
+        out.contains("$.apply(() => greeting, this, $$args, Test,"),
+        "expected the dev $.apply wrap in:\n{out}"
+    );
+}
+
+/// Same dev-mode event-handler check, but through the `on:click` directive
+/// path (`on_directive.rs`, which shares `events.rs::build_event_handler`
+/// with the `onclick=` attribute path above).
+#[test]
+fn snippet_shadowing_an_outer_function_still_apply_wraps_the_dev_on_directive() {
+    let src = r#"<script>
+	function greeting() { return 'outer'; }
+	let open = $state(true);
+</script>
+{#if open}
+	{#snippet greeting()}<b>hi</b>{/snippet}
+	<button on:click={greeting}>x</button>
+{/if}"#;
+    let out = compile_js(src, true);
+    assert!(
+        out.contains("$.apply(() => greeting, this, $$args, Test,"),
+        "expected the dev $.apply wrap in:\n{out}"
+    );
+}
+
+/// A snippet shadowing a prop must keep resolving correctly too (regression
+/// guard alongside #2067 / PR #2140, which fixed the analogous `{@render}`
+/// callee resolution using a different mechanism, `shadow_snippet_declarations`).
+#[test]
+fn snippet_shadowing_a_prop_read_in_an_attribute_is_still_wrapped() {
+    let src = r#"<script>
+	let { row } = $props();
+	let open = $state(true);
+</script>
+{#if open}{#snippet row()}<b>local</b>{/snippet}<p title={typeof row}>x</p>{/if}"#;
+    let out = compile_js(src, false);
+    assert!(
+        out.contains("$.template_effect(() => $.set_attribute(p, 'title', typeof row))"),
+        "expected a template_effect wrap in:\n{out}"
+    );
+    assert!(
+        !out.contains("$$props.row"),
+        "the prop binding still won in:\n{out}"
+    );
+}


### PR DESCRIPTION
## Summary

Fixes #2141

- Root cause: `Binding::is_function()` itself already matches official's `scope.js` `Binding#is_function` exactly (it returns `false` for a `{#snippet}` binding — verified against every `initial_is_function`/`declare_binding` call site in `2_analyze/scope_builder.rs`). The bug is in what gets resolved *before* `is_function()` is called: `ComponentClientTransformState::get_binding` (client `types.rs`) walks a "root scope" that is intentionally polluted with every scope's declarations for backward compatibility (see its doc comment in `2_analyze/scope.rs`), and the merge (`crates/rsvelte_core/src/compiler/phases/2_analyze/mod.rs`) prefers whichever declaration was inserted first — the instance-script scope, processed before template scopes.
- So when a block-local `{#snippet greeting()}` shadows an outer `<script>` `function greeting() {}` (or `let greeting = () => …` / `let greeting = $derived(…)`), a read of `greeting` inside that block resolved to the **outer** binding, not the snippet. `is_function()` on that outer binding is `true` (it's a real JS function), so the read was wrongly treated as non-reactive — skipping the `$.template_effect` wrap for attributes, and taking the "attach handler directly" fast path instead of the dev-mode `$.apply(...)` wrap for event handlers.
- PR #2140 (issue #2067) hit the analogous problem for **props** shadowed by a block-local snippet, and fixed it with `shadow_snippet_declarations`, which strips the outer name from the `transform` rewrite map and records it in `shadowed_prop_names`. That fix happens to also produce the right *answer* when a prop or store is shadowed (they're "always reactive" regardless of which binding wins), which is why the prop-shadow case already passed before this change — but it doesn't correct the underlying `get_binding` resolution, so a shadowed plain function/derived still resolved wrong.

**Rebase note:** #2143 (issue #2060, merged after this PR was first opened) landed a more general fix for the same root cause — `ScopeRoot::binding_at_reference` replays Phase 2's scope-correct resolution for a reference's exact source position, and is now wired into `has_reactive_state_json` and (by this PR) `is_expression_known_json`. That already resolves the `{#snippet}`-shadowing-a-function/derived case for every call site that has a source position, so this PR's own `resolve_shadowing_snippet_binding` helper — originally added at 4 call sites — was minimized down to the 2 call sites that don't have one (see below).

## Fix

`resolve_shadowing_snippet_binding` (`client/visitors/shared/utils.rs`): given a name and the current transform context, it calls `get_binding` and, if the name is marked shadowed (`shadowed_prop_names`, already populated per-fragment by `shadow_snippet_declarations` for *every* name a fragment's snippets declare) but the direct result isn't already the snippet, re-resolves via `bindings_by_name` to the actual snippet binding.

After rebasing on #2143, this is only still needed at the two call sites that resolve an already-converted `JsExpr::Identifier` with no source position to feed `binding_at_reference`:
- `client/visitors/shared/events.rs::build_event_handler` — the `on:click` directive's dev-mode `$.apply` wrap.
- `client/visitors/attribute.rs::build_event_handler` — the same check for the `onclick=` attribute path (a separate port of the same official function).

`has_reactive_state_json` (the `$.template_effect` wrap decision) and `is_expression_known_json` (the `{@const}`/`$derived` compile-time-known fold) now use `binding_at_reference` directly (`by_position.or_else(|| context.state.get_binding(name))`), matching the pattern #2143 already established, with no separate fallback needed.

## Test plan

- [x] New regression suite `crates/rsvelte_core/tests/attribute_snippet_shadow_is_function_2141.rs` (7 tests): unshadowed baseline, snippet shadowing a `function`/arrow-`let`/known-`$derived`, dev-mode `$.apply` wrap via both the `onclick=` attribute and `on:click` directive paths, and the pre-existing prop-shadow case from #2067/#2140.
- [x] New pattern-corpus fixture `compatibility/pattern-corpus/issues/2141-snippet-shadow-is-function.svelte`, verified byte-identical to official for **client**, **client-dev**, and **server** via `node scripts/compat-corpus/one.mjs pattern/issues/2141-snippet-shadow-is-function.svelte --target <t>`.
- [x] Full svelte+pattern corpus compile+verify (`corpus:collect` → `compile.mjs --filter pattern/` / `--filter svelte/` → `verify.mjs`): 0 regressions for client and server; client-dev's pre-existing known-failure count is unaffected (no `--update-baseline` run — this worktree has only the `svelte`/`pattern` corpus sources synced, not the full real-world-project list, so a baseline rewrite here would falsely appear to shrink `known-failures.client-dev.json` for sources that are simply absent, not fixed).
- [x] `cargo test --release -p rsvelte_core` (full crate, all suites): all green.
- [x] `cargo test --release -p rsvelte_core --test render_tag_snippet_shadows_binding_2067 --test utf16_locators_2099`: still green (no regression on #2067/#2140 or #2099).
- [x] `cargo fmt` / `cargo clippy --all-targets --all-features -- -D warnings`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RQSYoh4Wc353KgUnWHjazu