### PR TITLE
fix(svelte2tsx): wrap svelte:component/svelte:self named-slot children in $$slot_def

### DIFF
--- a/.changeset/svelte2tsx-svelte-component-named-slot.md
+++ b/.changeset/svelte2tsx-svelte-component-named-slot.md
@@ -1,0 +1,15 @@
+---
+"@rsvelte/compiler": patch
+"@rsvelte/svelte2tsx": patch
+"@rsvelte/svelte-check": patch
+---
+
+fix(svelte2tsx): wrap a `<svelte:component>` / `<svelte:self>` named-slot
+child (`<svelte:component this={Inner} slot="a" />`) in the parent's
+`$$slot_def["a"]` block. `has_named_slot_children` (and the parallel
+`is_named_slot` check in `process_component_children_with_slots`) never
+matched `SvelteComponent` / `SvelteSelf` nodes, so such a child fell through
+to the plain fragment walk instead of the named-slot lowering — unlike
+official svelte2tsx, which models both as `InlineComponent` and forwards them
+exactly like a named `<Component slot="a">` child. Found while fixing #2103
+(PR #2135).

--- a/crates/rsvelte_projection/src/svelte2tsx/template/attributes/mod.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/template/attributes/mod.rs
@@ -295,14 +295,20 @@ pub(super) fn build_component_props_string(
     attributes: &[Attribute],
     source: &str,
     comments: &ElementOpenerCommentIndex,
+    drop_slot: bool,
 ) -> String {
     let mut parts: Vec<String> = Vec::new();
 
     for attr in attributes {
         match attr {
             Attribute::Attribute(node) => {
-                // Skip the `slot` attribute on components (it's for named slot targeting)
-                if node.name == "slot" {
+                // `slot="foo"` stays a normal prop EXCEPT when this node is
+                // being named-slot-routed by its parent component, where the
+                // attribute is consumed by the `$$slot_def[...]` wrapper
+                // instead (mirrors `build_component_props_segments`'s
+                // `drop_slot`, and official's `element.parent instanceof
+                // InlineComponent` check in `handleAttribute`).
+                if node.name == "slot" && drop_slot {
                     continue;
                 }
                 // is_element=false: --* attrs are wrapped with __sveltets_2_cssProp

--- a/crates/rsvelte_projection/src/svelte2tsx/template/nodes/component_slots.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/template/nodes/component_slots.rs
@@ -3,7 +3,7 @@
 
 use crate::ast::template::{
     Attribute, AttributeValue, AttributeValuePart, Component, Fragment, RegularElement,
-    SvelteElement, TemplateNode,
+    SvelteComponentElement, SvelteElement, TemplateNode,
 };
 use crate::svelte2tsx::magic_string::MagicString;
 use crate::svelte2tsx::svelte2tsx::{Svelte2TsxOptions, slice_src};
@@ -19,11 +19,12 @@ use crate::svelte2tsx::template::attributes::spread::format_spread_attribute;
 use crate::svelte2tsx::template::attributes::transition::format_transition_directive;
 use crate::svelte2tsx::template::ctx::{Counter, TemplateNodeExt};
 use crate::svelte2tsx::template::segs::segs_to_string;
+use crate::svelte2tsx::template::utils::expr::get_expression_range;
 use crate::svelte2tsx::template::utils::opener_spacing::{OpenerCtx, opener_spacing};
 use crate::svelte2tsx::template::utils::source::{find_closing_tag_start, find_opening_tag_end};
 use crate::svelte2tsx::template::walk::{process_fragment_inplace, process_node_inplace};
 
-use super::inline_component::handle_component;
+use super::inline_component::{handle_component, handle_svelte_component, handle_svelte_self};
 use super::slot_element::slot_attr_static_name;
 use crate::svelte2tsx::template::attributes::action::format_use_directive;
 
@@ -160,6 +161,18 @@ pub(crate) fn has_named_slot_children(fragment: &Fragment) -> bool {
             TemplateNode::SvelteElement(el) if slot_attr_static_name(&el.attributes).is_some() => {
                 return true;
             }
+            // `<svelte:component this={expr} slot="name">` and `<svelte:self
+            // slot="name">` are `InlineComponent`s in official svelte2tsx
+            // (same as a named `<Component slot="name">`), so they forward
+            // into the parent's `$$slot_def[...]` the same way (#2136).
+            TemplateNode::SvelteComponent(sc)
+                if slot_attr_static_name(&sc.attributes).is_some() =>
+            {
+                return true;
+            }
+            TemplateNode::SvelteSelf(el) if slot_attr_static_name(&el.attributes).is_some() => {
+                return true;
+            }
             // Control-flow blocks are transparent to slot distribution: a
             // `<div slot="foo">` nested inside `{#if}` / `{#each}` / `{#await}`
             // / `{#key}` still targets the component's named slot (official
@@ -282,6 +295,8 @@ pub(crate) fn process_component_children_with_slots(
                 slot_attr_static_name(&child_comp.attributes).is_some()
             }
             TemplateNode::SvelteFragment(el) => slot_attr_static_name(&el.attributes).is_some(),
+            TemplateNode::SvelteComponent(sc) => slot_attr_static_name(&sc.attributes).is_some(),
+            TemplateNode::SvelteSelf(el) => slot_attr_static_name(&el.attributes).is_some(),
             _ => false,
         };
 
@@ -304,6 +319,16 @@ pub(crate) fn process_component_children_with_slots(
                 }
                 TemplateNode::SvelteFragment(el) => {
                     handle_named_slot_svelte_fragment(
+                        el, inst_var, source, options, str, counter, depth,
+                    );
+                }
+                TemplateNode::SvelteComponent(sc) => {
+                    handle_named_slot_svelte_component(
+                        sc, inst_var, source, options, str, counter, depth,
+                    );
+                }
+                TemplateNode::SvelteSelf(el) => {
+                    handle_named_slot_svelte_self(
                         el, inst_var, source, options, str, counter, depth,
                     );
                 }
@@ -678,6 +703,118 @@ pub(crate) fn handle_named_slot_component(
     } else {
         str.append_left(comp.end, "}");
     }
+}
+
+/// Handle a `<svelte:component this={expr} slot="name">` child inside a parent
+/// component. Official svelte2tsx models `svelte:component` as an
+/// `InlineComponent`, so a named-slot child of that kind forwards through the
+/// exact same `$$slot_def[...]` lowering as a named component
+/// (`handle_named_slot_component`) — see #2136.
+pub(crate) fn handle_named_slot_svelte_component(
+    comp: &SvelteComponentElement,
+    inst_var: &str,
+    source: &str,
+    options: &Svelte2TsxOptions,
+    str: &mut MagicString<'_>,
+    counter: &mut Counter,
+    depth: u32,
+) {
+    let slot_name = slot_attr_static_name(&comp.attributes).unwrap_or_default();
+    let let_destructure = build_let_destructure_string(&comp.attributes, source);
+
+    let block_open = format!(
+        "{{const {{/*\u{03A9}ignore_start\u{03A9}*/$$_$$/*\u{03A9}ignore_end\u{03A9}*/,{}}} = {}.$$slot_def[\"{}\"];$$_$$;",
+        let_destructure, inst_var, slot_name
+    );
+
+    // The `this={expr}` range stands in for the "name" head `handle_component`
+    // uses (`svelte:component` has no literal component-name token), same as
+    // `handle_svelte_component`'s own spacing computation.
+    let opening_tag_end =
+        find_opening_tag_end(source, comp.start, comp.end, &comp.name, &comp.attributes);
+    let spacing = opener_spacing(
+        source,
+        comp.start,
+        &comp.name,
+        opening_tag_end,
+        get_expression_range(&comp.expression),
+        &comp.attributes,
+        &counter.element_opener_comments,
+        OpenerCtx {
+            is_element: false,
+            in_component_slot: true,
+            tag_name: &comp.name,
+            is_slot_tag: false,
+        },
+    );
+    str.append_left_fmt(
+        comp.start,
+        format_args!("{}{}", " ".repeat(spacing.before_block), block_open),
+    );
+
+    // Process the node normally; suppress its own `slot=` prop / default-slot
+    // `let:` emission — both are consumed by the block open above.
+    counter.named_slot_component_close = true;
+    counter.suppress_component_lets = true;
+    handle_svelte_component(comp, source, options, str, counter, depth);
+
+    // `svelte:component` keeps no name mapping on its closing tag (unlike a
+    // named component) — just close the named-slot block.
+    str.append_left(comp.end, "}");
+}
+
+/// Handle a `<svelte:self slot="name">` child inside a parent component.
+/// Official svelte2tsx models `svelte:self` as an `InlineComponent` too, so it
+/// forwards through the same lowering as `handle_named_slot_svelte_component`
+/// (#2136).
+pub(crate) fn handle_named_slot_svelte_self(
+    el: &SvelteElement,
+    inst_var: &str,
+    source: &str,
+    options: &Svelte2TsxOptions,
+    str: &mut MagicString<'_>,
+    counter: &mut Counter,
+    depth: u32,
+) {
+    let slot_name = slot_attr_static_name(&el.attributes).unwrap_or_default();
+    let let_destructure = build_let_destructure_string(&el.attributes, source);
+
+    let block_open = format!(
+        "{{const {{/*\u{03A9}ignore_start\u{03A9}*/$$_$$/*\u{03A9}ignore_end\u{03A9}*/,{}}} = {}.$$slot_def[\"{}\"];$$_$$;",
+        let_destructure, inst_var, slot_name
+    );
+
+    // `svelte:self` emits its opener as a pure string (no source range head),
+    // same as `handle_svelte_self`'s own spacing computation.
+    let opening_tag_end =
+        find_opening_tag_end(source, el.start, el.end, el.name.as_str(), &el.attributes);
+    let spacing = opener_spacing(
+        source,
+        el.start,
+        &el.name,
+        opening_tag_end,
+        None,
+        &el.attributes,
+        &counter.element_opener_comments,
+        OpenerCtx {
+            is_element: false,
+            in_component_slot: true,
+            tag_name: &el.name,
+            is_slot_tag: false,
+        },
+    );
+    str.append_left_fmt(
+        el.start,
+        format_args!("{}{}", " ".repeat(spacing.before_block), block_open),
+    );
+
+    counter.named_slot_component_close = true;
+    counter.suppress_component_lets = true;
+    handle_svelte_self(el, source, options, str, counter, depth);
+
+    // `svelte:self` keeps no name mapping on its closing tag — just close the
+    // named-slot block.
+    str.append_left(el.end, "}");
 }
 
 /// Build attribute string for a named slot element, excluding `slot` and `let:` directives.

--- a/crates/rsvelte_projection/src/svelte2tsx/template/nodes/inline_component.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/template/nodes/inline_component.rs
@@ -35,8 +35,9 @@ use crate::svelte2tsx::template::utils::source::{find_closing_tag_start, find_op
 use crate::svelte2tsx::template::walk::{process_fragment_inplace, process_node_inplace};
 
 use super::component_slots::{
-    handle_named_slot_component, has_component_slot_children, has_default_slot_let_children,
-    has_named_slot_children, process_component_children_with_slots,
+    handle_named_slot_component, handle_named_slot_svelte_component, handle_named_slot_svelte_self,
+    has_component_slot_children, has_default_slot_let_children, has_named_slot_children,
+    process_component_children_with_slots,
 };
 use super::slot_element::slot_attr_static_name;
 use super::snippet_block::handle_snippet_block_as_component_prop;
@@ -532,6 +533,28 @@ pub(crate) fn handle_svelte_component(
     // slot context (restored at the end for following siblings).
     let saved_outer_slot = counter.slot_inst.take();
 
+    // Nested named-slot routing: a static `slot="x"` svelte:component reached
+    // through a parent component's default-slot body (e.g. inside `{#if}` /
+    // `{#each}`) is wrapped in the parent's `$$slot_def["x"]` block — same as
+    // the direct-child path (`handle_named_slot_svelte_component`), mirroring
+    // `handle_component`'s equivalent check. `named_slot_component_close`
+    // guards against re-entering when we are already the routed inner call.
+    if !counter.named_slot_component_close
+        && let Some(ref inst) = saved_outer_slot
+        && slot_attr_static_name(&comp.attributes).is_some()
+    {
+        let inst = inst.clone();
+        handle_named_slot_svelte_component(comp, &inst, source, options, str, counter, depth);
+        counter.slot_inst = saved_outer_slot;
+        return;
+    }
+
+    // When processed as a named-slot child, suppress the `slot=` prop and the
+    // component's own default-slot `let:` block (the caller already consumed
+    // both into the `$$slot_def[...]` destructure ahead of this opener).
+    let named_slot_close = std::mem::take(&mut counter.named_slot_component_close);
+    let suppress_lets = std::mem::take(&mut counter.suppress_component_lets);
+
     let expr_text = get_expression_text(&comp.expression, source);
     let opening_tag_end = find_opening_tag_end(
         source,
@@ -546,8 +569,12 @@ pub(crate) fn handle_svelte_component(
     let has_events = !on_directives.is_empty();
 
     // Build attribute/props string (excluding on: directives)
-    let mut attrs_str =
-        build_component_props_string(&comp.attributes, source, &counter.element_opener_comments);
+    let mut attrs_str = build_component_props_string(
+        &comp.attributes,
+        source,
+        &counter.element_opener_comments,
+        named_slot_close,
+    );
 
     // Add extra whitespace to match JS svelte2tsx position-preserving behavior
     let scomp_spacing = opener_spacing(
@@ -560,7 +587,7 @@ pub(crate) fn handle_svelte_component(
         &counter.element_opener_comments,
         OpenerCtx {
             is_element: false,
-            in_component_slot: false,
+            in_component_slot: named_slot_close,
             tag_name: &comp.name,
             is_slot_tag: false,
         },
@@ -574,7 +601,7 @@ pub(crate) fn handle_svelte_component(
     // Check if component has meaningful children for Svelte 5 children prop
     let has_children = has_component_slot_children(&comp.fragment, source);
     let is_svelte5 = matches!(options.version, SvelteVersion::V5);
-    let has_lets_scomp = has_let_directives(&comp.attributes);
+    let has_lets_scomp = !suppress_lets && has_let_directives(&comp.attributes);
     // Emit the synthetic `children` prop whenever there is default-slot content,
     // even alongside `let:` directives — matching handle_component (which has no
     // such guard). The `let:` destructure is emitted independently below.
@@ -639,6 +666,14 @@ pub(crate) fn handle_svelte_component(
         || has_binds
         || children_have_named_slots
         || children_have_default_slot_lets;
+    // A named-slot child's `$$slot_def[…]` prologue is emitted by the caller
+    // ahead of this block, and takes the leading gaps with it (mirrors
+    // `handle_component`'s `block_indent`).
+    let block_indent = if named_slot_close {
+        String::new()
+    } else {
+        " ".repeat(scomp_spacing.before_block)
+    };
     let mut opener = if needs_inst {
         let on_calls = if has_events {
             build_on_calls(&inst_var, &on_directives, source)
@@ -647,7 +682,7 @@ pub(crate) fn handle_svelte_component(
         };
         format!(
             "{}{{ const {}C = __sveltets_2_ensureComponent({}); const {} = new {}C({{ target: __sveltets_2_any(), props: {{{}}}}});{}{}",
-            " ".repeat(scomp_spacing.before_block),
+            block_indent,
             inst_var,
             expr_text,
             inst_var,
@@ -659,11 +694,7 @@ pub(crate) fn handle_svelte_component(
     } else {
         format!(
             "{}{{ const {}C = __sveltets_2_ensureComponent({}); new {}C({{ target: __sveltets_2_any(), props: {{{}}}}});",
-            " ".repeat(scomp_spacing.before_block),
-            inst_var,
-            expr_text,
-            inst_var,
-            attrs_str
+            block_indent, inst_var, expr_text, inst_var, attrs_str
         )
     };
 
@@ -747,6 +778,31 @@ pub(crate) fn handle_svelte_self(
         return;
     }
 
+    // This node's children own their own slot scope: clear any inherited slot
+    // context (restored at the end for following siblings).
+    let saved_outer_slot = counter.slot_inst.take();
+
+    // Nested named-slot routing: a static `slot="x"` svelte:self reached
+    // through a parent component's default-slot body (e.g. inside `{#if}` /
+    // `{#each}`) is wrapped in the parent's `$$slot_def["x"]` block — same as
+    // the direct-child path (`handle_named_slot_svelte_self`), mirroring
+    // `handle_component`'s equivalent check.
+    if !counter.named_slot_component_close
+        && let Some(ref inst) = saved_outer_slot
+        && slot_attr_static_name(&el.attributes).is_some()
+    {
+        let inst = inst.clone();
+        handle_named_slot_svelte_self(el, &inst, source, options, str, counter, depth);
+        counter.slot_inst = saved_outer_slot;
+        return;
+    }
+
+    // When processed as a named-slot child, suppress the `slot=` prop and the
+    // node's own default-slot `let:` block (the caller already consumed both
+    // into the `$$slot_def[...]` destructure ahead of this opener).
+    let named_slot_close = std::mem::take(&mut counter.named_slot_component_close);
+    let suppress_lets = std::mem::take(&mut counter.suppress_component_lets);
+
     let opening_tag_end =
         find_opening_tag_end(source, el.start, el.end, el.name.as_str(), &el.attributes);
     let closing_tag_start = find_closing_tag_start(source, el.end);
@@ -755,7 +811,7 @@ pub(crate) fn handle_svelte_self(
     // Separate on: + let: directives from regular attributes
     let mut has_on_directives = false;
     let mut on_directives = Vec::new();
-    let has_lets = has_let_directives(&el.attributes);
+    let has_lets = !suppress_lets && has_let_directives(&el.attributes);
     let mut prop_parts = Vec::new();
 
     for attr in &el.attributes {
@@ -769,6 +825,13 @@ pub(crate) fn handle_svelte_self(
             }
             _ => match attr {
                 Attribute::Attribute(node) => {
+                    // `slot="foo"` stays a normal prop EXCEPT when this node
+                    // is being named-slot-routed by its parent component,
+                    // where the attribute is consumed by the
+                    // `$$slot_def[...]` wrapper instead.
+                    if node.name == "slot" && named_slot_close {
+                        continue;
+                    }
                     // `<svelte:self>` is component-like (`__sveltets_2_createComponentAny`),
                     // so apply --* CSS-prop wrapping, not data-* element wrapping.
                     if let Some(s) = format_attribute_node(node, source, false) {
@@ -814,7 +877,7 @@ pub(crate) fn handle_svelte_self(
         &counter.element_opener_comments,
         OpenerCtx {
             is_element: false,
-            in_component_slot: false,
+            in_component_slot: named_slot_close,
             tag_name: &el.name,
             is_slot_tag: false,
         },
@@ -840,18 +903,23 @@ pub(crate) fn handle_svelte_self(
         None
     };
 
+    // A named-slot child's `$$slot_def[…]` prologue is emitted by the caller
+    // ahead of this block, and takes the leading gaps with it (mirrors
+    // `handle_svelte_component`'s `block_indent`).
+    let block_indent = if named_slot_close {
+        String::new()
+    } else {
+        " ".repeat(self_spacing.before_block)
+    };
     let create_call = if let Some(ref name) = var_name {
         format!(
             "{}{{ const {} = __sveltets_2_createComponentAny({{{}}});",
-            " ".repeat(self_spacing.before_block),
-            name,
-            props_inner
+            block_indent, name, props_inner
         )
     } else {
         format!(
             "{}{{ __sveltets_2_createComponentAny({{{}}});",
-            " ".repeat(self_spacing.before_block),
-            props_inner
+            block_indent, props_inner
         )
     };
 
@@ -892,6 +960,7 @@ pub(crate) fn handle_svelte_self(
         let trailing = if has_lets { "}}" } else { "}" };
         let combined = format!("{}{}", opener, trailing);
         str.overwrite(el.start, el.end, &combined);
+        counter.slot_inst = saved_outer_slot;
         return;
     }
 
@@ -907,4 +976,7 @@ pub(crate) fn handle_svelte_self(
         el.end,
         format_args!("{}{}", spaces, trailing),
     );
+
+    // Restore the slot context for following siblings.
+    counter.slot_inst = saved_outer_slot;
 }

--- a/crates/rsvelte_projection/tests/svelte2tsx_svelte_component_named_slot_2136.rs
+++ b/crates/rsvelte_projection/tests/svelte2tsx_svelte_component_named_slot_2136.rs
@@ -1,0 +1,119 @@
+//! Regression tests for #2136: `has_named_slot_children` (and the parallel
+//! `is_named_slot` check in `process_component_children_with_slots`) never
+//! matched `SvelteComponent` (`<svelte:component>`) or `SvelteSelf`
+//! (`<svelte:self>`) children, so a `<svelte:component slot="a">` /
+//! `<svelte:self slot="a">` child of a component was never wrapped in the
+//! parent's `$$slot_def["a"]` block — unlike official svelte2tsx, which
+//! models both as `InlineComponent` and forwards them exactly like a named
+//! `<Component slot="a">` child. Found while fixing #2103 (PR #2135).
+//!
+//! Every expectation below is the byte-exact template body official svelte2tsx
+//! (language-tools, parsing with svelte 5.56.8) emits for the same input.
+
+use rsvelte_projection::svelte2tsx::{Svelte2TsxOptions, svelte2tsx};
+
+fn convert(src: &str) -> String {
+    let opts = Svelte2TsxOptions {
+        filename: "Input.svelte".to_string(),
+        is_ts_file: false,
+        emit_jsdoc: true,
+        ..Default::default()
+    };
+    svelte2tsx(src, opts).expect("svelte2tsx ok").code
+}
+
+fn assert_contains(code: &str, expected: &str) {
+    assert!(
+        code.contains(expected),
+        "expected output to contain:\n{expected}\n\ngot:\n{code}"
+    );
+}
+
+/// The issue's exact repro: a `<svelte:component slot="a">` child of a
+/// component is wrapped in the parent's `$$slot_def["a"]` block.
+#[test]
+fn svelte_component_named_slot_child_is_wrapped() {
+    let code = convert("<Outer><svelte:component this={Inner} slot=\"a\" /></Outer>\n");
+    assert_contains(
+        &code,
+        "{const {/*\u{03A9}ignore_start\u{03A9}*/$$_$$/*\u{03A9}ignore_end\u{03A9}*/,} = $$_retuO0.$$slot_def[\"a\"];$$_$$;{ const $$_tnenopmoc_etlevs1C = __sveltets_2_ensureComponent(Inner); new $$_tnenopmoc_etlevs1C({ target: __sveltets_2_any(), props: {   }});}} Outer}",
+    );
+}
+
+/// A `<svelte:component slot="a" let:x>` child's own `let:` is destructured
+/// from the PARENT's `$$slot_def["a"]` (not the dynamic component's own
+/// `$$slot_def.default`), same as a named component's `let:` would be.
+#[test]
+fn svelte_component_named_slot_child_with_let() {
+    let code = convert(
+        "<Outer><svelte:component this={Inner} slot=\"a\" let:x>{x}</svelte:component></Outer>\n",
+    );
+    assert_contains(
+        &code,
+        "{const {/*\u{03A9}ignore_start\u{03A9}*/$$_$$/*\u{03A9}ignore_end\u{03A9}*/,x,} = $$_retuO0.$$slot_def[\"a\"];$$_$$;{ const $$_tnenopmoc_etlevs1C = __sveltets_2_ensureComponent(Inner); new $$_tnenopmoc_etlevs1C({ target: __sveltets_2_any(), props: {   children:() => { return __sveltets_2_any(0); },}});x; }} Outer}",
+    );
+}
+
+/// Same bug, `<svelte:self>` flavor: official models it as an `InlineComponent`
+/// too, so it forwards through the identical lowering.
+#[test]
+fn svelte_self_named_slot_child_is_wrapped() {
+    let code = convert(
+        "<script>\n import Outer from './Outer.svelte';\n</script>\n<Outer><svelte:self slot=\"a\" /></Outer>\n",
+    );
+    assert_contains(
+        &code,
+        "{const {/*\u{03A9}ignore_start\u{03A9}*/$$_$$/*\u{03A9}ignore_end\u{03A9}*/,} = $$_retuO0.$$slot_def[\"a\"];$$_$$;{ __sveltets_2_createComponentAny({  });}} Outer}",
+    );
+}
+
+#[test]
+fn svelte_self_named_slot_child_with_let() {
+    let code = convert(
+        "<script>\n import Outer from './Outer.svelte';\n</script>\n<Outer><svelte:self slot=\"a\" let:x>{x}</svelte:self></Outer>\n",
+    );
+    assert_contains(
+        &code,
+        "{const {/*\u{03A9}ignore_start\u{03A9}*/$$_$$/*\u{03A9}ignore_end\u{03A9}*/,x,} = $$_retuO0.$$slot_def[\"a\"];$$_$$;{ __sveltets_2_createComponentAny({  children:() => { return __sveltets_2_any(0); },});x; }} Outer}",
+    );
+}
+
+/// A `slot="a"` target nested inside a control-flow block (`{#if}`) still
+/// routes to the parent's `$$slot_def["a"]`, mirroring the existing
+/// `Component` self-detection path (`handle_component`'s `saved_outer_slot`
+/// check) that `handle_svelte_component` now shares.
+#[test]
+fn svelte_component_named_slot_child_nested_in_if_block() {
+    let code =
+        convert("<Outer>{#if true}<svelte:component this={Inner} slot=\"a\" />{/if}</Outer>\n");
+    assert_contains(
+        &code,
+        "if(true){ {const {/*\u{03A9}ignore_start\u{03A9}*/$$_$$/*\u{03A9}ignore_end\u{03A9}*/,} = $$_retuO0.$$slot_def[\"a\"];$$_$$;{ const $$_tnenopmoc_etlevs1C = __sveltets_2_ensureComponent(Inner); new $$_tnenopmoc_etlevs1C({ target: __sveltets_2_any(), props: {   }});}}} Outer}",
+    );
+}
+
+/// A `slot="a"` attribute on `<svelte:component>` OUTSIDE of a component
+/// parent (official's `element.parent instanceof InlineComponent` guard) is
+/// NOT slot routing — it stays a plain `"slot":` prop, same as official. This
+/// guards the `drop_slot` conditional the fix threads through
+/// `build_component_props_string`.
+#[test]
+fn svelte_component_slot_attr_outside_component_stays_a_prop() {
+    let code = convert("<div><svelte:component this={Inner} slot=\"a\" /></div>\n");
+    assert_contains(&code, "\"slot\":`a`,");
+    assert!(
+        !code.contains("$$slot_def"),
+        "no enclosing component means no slot routing, got:\n{code}"
+    );
+}
+
+/// Plain (non-slotted) `<svelte:component>` / `<svelte:self>` children are
+/// unaffected — no spurious `$$slot_def` wrapping.
+#[test]
+fn plain_children_get_no_slot_block() {
+    let code = convert("<Outer><svelte:component this={Inner} /></Outer>\n");
+    assert!(
+        !code.contains("$$slot_def"),
+        "children without slot= must not open a slot block, got:\n{code}"
+    );
+}


### PR DESCRIPTION
## Summary

Fixes #2136.

- `has_named_slot_children` (and the parallel `is_named_slot` check in `process_component_children_with_slots`) never matched `SvelteComponent` (`<svelte:component>`) or `SvelteSelf` (`<svelte:self>`) nodes. So:
  ```svelte
  <Outer><svelte:component this={Inner} slot="a" /></Outer>
  ```
  compiled the `<svelte:component>` child as a plain fragment node instead of wrapping it in the parent's `$$slot_def["a"]` block. Official svelte2tsx models `svelte:component`/`svelte:self` as `InlineComponent`, so a named-slot child of that kind forwards through the exact same lowering as a named `<Component slot="a">` child.
- Added `handle_named_slot_svelte_component` / `handle_named_slot_svelte_self` (mirroring the existing `handle_named_slot_component`) and wired the direct-child dispatch in `process_component_children_with_slots`.
- Extended `handle_svelte_component` / `handle_svelte_self` with the same nested-in-control-flow self-detection `handle_component` already has (a `slot="x"` target reached through `{#if}`/`{#each}` still routes to the parent's `$$slot_def["x"]`), and threaded `drop_slot`/`in_component_slot` so the `slot=` attribute is only stripped from props when actually routed (kept as a plain prop when the enclosing element isn't a component, matching official's `element.parent instanceof InlineComponent` check).
- Found while fixing #2103 (PR #2135).

## Test plan

- [x] Added `crates/rsvelte_projection/tests/svelte2tsx_svelte_component_named_slot_2136.rs` (7 tests): the issue's exact repro, `let:` forwarding, `<svelte:self>` equivalents, nested-in-`{#if}` routing, and a guard that `slot=` stays a plain prop outside a component parent.
- [x] `cargo test -p rsvelte_projection` — all pass (including the existing 253-fixture `svelte2tsx_fixtures` suite and the #2103 regression tests, unaffected).
- [x] Verified every new/changed output byte-for-byte against the official svelte2tsx oracle (`submodules/language-tools`, built and pinned to svelte 5.56.8) for a matrix of cases: no-let, `let:`, events, `bind:`, children, self-closing, nested `{#if}`, and the non-component-parent `slot=` retention case.
- [x] Ran the corpus svelte2tsx output-parity gate (`node scripts/compat-corpus/svelte2tsx-compile.mjs` + `svelte2tsx-verify.mjs`) against the `svelte` submodule + `pattern-corpus` sources (~5100 entries): `match 4897, error-parity 103, ts-mismatch 0, error-mismatch 0, missing 0` — no regressions.
- [x] `cargo fmt` + `cargo clippy --all-targets --all-features -- -D warnings` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RQSYoh4Wc353KgUnWHjazu