### PR TITLE
fix(svelte-check): resolve relative companion-hijacked and withheld-JS `.svelte` specifiers like official (#2061)

### DIFF
--- a/.changeset/overlay-relative-companion-and-withheld-js.md
+++ b/.changeset/overlay-relative-companion-and-withheld-js.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/svelte-check": patch
+---
+
+Two `.svelte`-specifier resolutions the overlay could not previously answer the way official svelte-check does now match it. A **relative** `./Foo.svelte` written in a plain `.ts`/`.js` file that has a same-named `Foo.svelte.ts` companion next to it used to resolve to the companion — TypeScript probes the importer's own directory before `rootDirs` can offer the component shadow, and `paths` never applies to a relative specifier — so a named import of the companion's exports silently succeeded where official reports `TS2614`. Such an importer is now mirrored into the overlay as a blanked *import probe* (everything but the hijacked import declarations replaced with spaces, so every position survives) and the import is re-resolved from there. Separately, a `Foo.svelte.js` rune module in a project without `allowJs` is deliberately left without a bridge, which under `node16`/`nodenext` left its specifier resolving to nothing at all (`TS2307`); the overlay now restates what official reports for a module it withholds — `TS7016`, or nothing when `noImplicitAny` is off.

--- a/compatibility/check-fixtures/js-rune-module-without-allow-js-loose/project/package.json
+++ b/compatibility/check-fixtures/js-rune-module-without-allow-js-loose/project/package.json
@@ -1,0 +1,1 @@
+{ "name": "js-rune-module-without-allow-js-loose", "private": true, "type": "module" }

--- a/compatibility/check-fixtures/js-rune-module-without-allow-js-loose/project/src/App.svelte
+++ b/compatibility/check-fixtures/js-rune-module-without-allow-js-loose/project/src/App.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+	let { label }: { label: string } = $props();
+</script>
+
+<p>{label}</p>

--- a/compatibility/check-fixtures/js-rune-module-without-allow-js-loose/project/src/lib/counter.svelte.js
+++ b/compatibility/check-fixtures/js-rune-module-without-allow-js-loose/project/src/lib/counter.svelte.js
@@ -1,0 +1,5 @@
+export const counter = { count: 0 };
+
+export default function makeCounter() {
+	return { count: 0 };
+}

--- a/compatibility/check-fixtures/js-rune-module-without-allow-js-loose/project/src/plain.ts
+++ b/compatibility/check-fixtures/js-rune-module-without-allow-js-loose/project/src/plain.ts
@@ -1,0 +1,3 @@
+import { counter } from './lib/counter.svelte';
+
+export const n = counter.count;

--- a/compatibility/check-fixtures/js-rune-module-without-allow-js-loose/project/tsconfig.json
+++ b/compatibility/check-fixtures/js-rune-module-without-allow-js-loose/project/tsconfig.json
@@ -1,0 +1,12 @@
+{
+	"compilerOptions": {
+		"module": "nodenext",
+		"moduleResolution": "nodenext",
+		"target": "es2022",
+		"lib": ["es2022", "dom"],
+		"strict": false,
+		"skipLibCheck": true,
+		"noEmit": true
+	},
+	"include": ["src"]
+}

--- a/compatibility/check-fixtures/js-rune-module-without-allow-js-loose/scenario.json
+++ b/compatibility/check-fixtures/js-rune-module-without-allow-js-loose/scenario.json
@@ -1,0 +1,7 @@
+{
+	"description": "`js-rune-module-without-allow-js-nodenext` with `noImplicitAny` off. The `.svelte.js` rune module is still left out of the program, and official svelte-check — which resolves the specifier onto it — reports nothing at all rather than TS7016. Pins the other half of the replay the overlay owes for a module it deliberately withholds (#2061).",
+	"tsconfig": "tsconfig.json",
+	"issues": [
+		2061
+	]
+}

--- a/compatibility/check-fixtures/js-rune-module-without-allow-js-nodenext/scenario.json
+++ b/compatibility/check-fixtures/js-rune-module-without-allow-js-nodenext/scenario.json
@@ -1,5 +1,5 @@
 {
-	"description": "The ESM-mode arm of `js-rune-module-without-allow-js`. Known-divergent: `moduleResolution: nodenext` substitutes no extension, so `./lib/counter.svelte` cannot reach `counter.svelte.js` at all and rsvelte reports TS2307 where official reports TS7016 — official's `resolveModuleNames` hook forces the pre-ESM algorithm for `.svelte` specifiers, which a stock compiler over an on-disk overlay cannot do (#2061). The wrong-but-plausible TS2614 this used to be is gone either way.",
+	"description": "The ESM-mode arm of `js-rune-module-without-allow-js`. `moduleResolution: nodenext` substitutes no extension, so `./lib/counter.svelte` cannot reach `counter.svelte.js` at all — and the overlay deliberately withholds the module's bridge, since a bridge forwards no names and would turn official's TS7016 into a wrong TS2614. Having withheld it, the overlay replays what official's `resolveModuleNames` hook reports for it (#2061).",
 	"tsconfig": "tsconfig.json",
 	"issues": [
 		2061

--- a/compatibility/check-fixtures/ts-companion-named-import-bundler/scenario.json
+++ b/compatibility/check-fixtures/ts-companion-named-import-bundler/scenario.json
@@ -1,5 +1,5 @@
 {
-	"description": "The companion split of `ts-companion-named-import` under node10/bundler resolution, reached by a RELATIVE specifier from a plain `.ts` file. Known-divergent: TypeScript substitutes extensions in the importer's own directory, so `./widget.svelte` lands on the real `widget.svelte.ts` before `rootDirs` or `paths` can offer the component shadow. Official svelte-check resolves `.svelte` specifiers in its own `resolveModuleNames` hook and reports TS2614; a stock compiler driven over an on-disk overlay has no such hook (#2061).",
+	"description": "The companion split of `ts-companion-named-import` under node10/bundler resolution, reached by a RELATIVE specifier from a plain `.ts` file — the one shape neither a `paths` override nor a shadow-side specifier rewrite can reach, since TypeScript probes the importer's own directory first and lands on the real `widget.svelte.ts`. The overlay answers it by re-resolving the import from a blanked mirror probe, which is where official's `resolveModuleNames` hook gets its TS2614 (#2061).",
 	"tsconfig": "tsconfig.json",
 	"issues": [
 		2061

--- a/compatibility/check-fixtures/ts-companion-named-import-probe-scope/project/package.json
+++ b/compatibility/check-fixtures/ts-companion-named-import-probe-scope/project/package.json
@@ -1,0 +1,1 @@
+{ "name": "ts-companion-named-import-probe-scope", "private": true, "type": "module" }

--- a/compatibility/check-fixtures/ts-companion-named-import-probe-scope/project/src/lib/widget.svelte
+++ b/compatibility/check-fixtures/ts-companion-named-import-probe-scope/project/src/lib/widget.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+	let { label }: { label: string } = $props();
+</script>
+
+<span>{label}</span>

--- a/compatibility/check-fixtures/ts-companion-named-import-probe-scope/project/src/lib/widget.svelte.ts
+++ b/compatibility/check-fixtures/ts-companion-named-import-probe-scope/project/src/lib/widget.svelte.ts
@@ -1,0 +1,3 @@
+export function helper(): number {
+	return 1;
+}

--- a/compatibility/check-fixtures/ts-companion-named-import-probe-scope/project/src/relative.ts
+++ b/compatibility/check-fixtures/ts-companion-named-import-probe-scope/project/src/relative.ts
@@ -1,0 +1,4 @@
+import { helper } from './lib/widget.svelte';
+
+export const used: number = helper();
+export const bad: number = 'not a number';

--- a/compatibility/check-fixtures/ts-companion-named-import-probe-scope/project/tsconfig.json
+++ b/compatibility/check-fixtures/ts-companion-named-import-probe-scope/project/tsconfig.json
@@ -1,0 +1,13 @@
+{
+	"compilerOptions": {
+		"module": "esnext",
+		"moduleResolution": "bundler",
+		"target": "es2022",
+		"lib": ["es2022", "dom"],
+		"strict": true,
+		"noUnusedLocals": true,
+		"skipLibCheck": true,
+		"noEmit": true
+	},
+	"include": ["src"]
+}

--- a/compatibility/check-fixtures/ts-companion-named-import-probe-scope/scenario.json
+++ b/compatibility/check-fixtures/ts-companion-named-import-probe-scope/scenario.json
@@ -1,0 +1,7 @@
+{
+	"description": "A plain `.ts` file whose relative `./lib/widget.svelte` is hijacked by a sibling `widget.svelte.ts` companion, checked alongside an unrelated type error and `noUnusedLocals`. The overlay re-resolves that import from a blanked mirror probe (#2061), so this pins the probe's scope: the companion TS2614 is reported once, the unrelated TS2322 is reported once (not doubled by the probe), and the probe's own elided body provokes no `declared but never read`.",
+	"tsconfig": "tsconfig.json",
+	"issues": [
+		2061
+	]
+}

--- a/compatibility/check-known-failures.json
+++ b/compatibility/check-known-failures.json
@@ -1,5 +1,1 @@
-[
-	"js-rune-module-without-allow-js-nodenext|+ERROR src/plain.ts:1 2307",
-	"js-rune-module-without-allow-js-nodenext|-ERROR src/plain.ts:1 7016",
-	"ts-companion-named-import-bundler|-ERROR src/relative.ts:1 2614"
-]
+[]

--- a/compatibility/check-known-failures.md
+++ b/compatibility/check-known-failures.md
@@ -38,47 +38,34 @@ found, split the ratchet then (a `.tsgo.json` sibling, same shrink-only +
 per-entry-justification convention) rather than papering over it in the shared
 file.
 
-## Current baseline: 3 entries — the two resolution-hook cases of #2061
+## Current baseline: 0 entries — full parity
 
-```
-js-rune-module-without-allow-js-nodenext|+ERROR src/plain.ts:1 2307
-js-rune-module-without-allow-js-nodenext|-ERROR src/plain.ts:1 7016
-ts-companion-named-import-bundler|-ERROR src/relative.ts:1 2614
-```
+Every scenario agrees with official `svelte-check` diagnostic-for-diagnostic, so
+this is a **hard gate**: any divergence at all fails CI. The sections below
+document what each scenario is guarding, since a green scenario only earns its
+keep by turning red when the thing it covers regresses.
 
-Both scenarios pin the same architectural boundary, and neither is burnable
-without crossing it. Official svelte-check resolves `.svelte` specifiers inside
-its own `resolveModuleNames` hook (`module-loader.ts`); rsvelte-check drives a
-stock `tsc`/`tsgo` over an on-disk overlay and has no hook to install, so where
-TypeScript's own resolution disagrees with upstream's, the overlay can only
-supply files and `paths`/`rootDirs` entries — never override a lookup that
-already succeeded.
+The last three entries were the two resolution-hook cases of #2061, closed by
+giving the overlay two ways to answer for a specifier TypeScript's own
+resolution routes elsewhere:
 
 - **`ts-companion-named-import-bundler`** — a relative `./widget.svelte` from a
-  plain `.ts` file under node10/bundler resolution. TypeScript substitutes
-  extensions in the *importer's own* directory, so it finds the user's real
-  `widget.svelte.ts` companion before `rootDirs` (consulted only after a failed
-  lookup) or `paths` (never applied to relative specifiers) can offer the
-  component shadow. The companion genuinely exports `helper`, so no file we emit
-  can make the import fail. From a `.svelte` importer and through an alias — the
-  two shapes the overlay *can* reach — the TS2614 now matches official, which is
-  what `ts-companion-named-import` covers.
+  plain `.ts` file under node10/bundler resolution. TypeScript probes the
+  importer's own directory first and finds the user's real `widget.svelte.ts`
+  companion there, where official's `svelteSys` answers the very first probe
+  (`widget.d.svelte.ts`) with "yes, the component". `paths` never applies to a
+  relative specifier and `rootDirs` only offers the mirror after the importer's
+  own directory came up empty, so the overlay instead mirrors the importer as a
+  blanked *import probe* (`<stem>.rsvelte-import-probe.ts`, everything but the
+  hijacked import declarations blanked in place) and re-resolves the import from
+  there.
 - **`js-rune-module-without-allow-js-nodenext`** — `./lib/counter.svelte` for a
-  `counter.svelte.js` with `allowJs` off. ESM-mode resolution substitutes no
-  extension, so the `.js` is unreachable and rsvelte reports TS2307 where
-  official's hook forces the pre-ESM algorithm and reports TS7016. The node10 /
-  bundler arm (`js-rune-module-without-allow-js`) matches exactly.
-
-Burning either down means giving rsvelte-check a resolution hook — i.e. driving
-the compiler through an API rather than a directory — which is a different
-product decision, not a bug fix. Until then these two are the honest record of
-where the on-disk overlay ends.
-
-Every other scenario agrees with official `svelte-check` diagnostic-for-
-diagnostic, so this stays a **hard gate**: any divergence outside the three
-entries above fails CI. The sections below document what each scenario is
-guarding, since a green scenario only earns its keep by turning red when the
-thing it covers regresses.
+  `counter.svelte.js` with `allowJs` off. The overlay deliberately withholds that
+  module's `.d.svelte.ts` bridge (a bridge would forward no names and turn
+  official's TS7016 into a wrong TS2614), and ESM-mode resolution substitutes no
+  extension, so the specifier reached nothing and TypeScript said TS2307. Having
+  withheld the file, the overlay now restates what official reports for it:
+  TS7016, or nothing at all when `noImplicitAny` is off.
 
 ## Previously: 0 entries / 0 surplus diagnostics — full parity
 
@@ -173,9 +160,18 @@ Green scenarios are load-bearing, not filler — a regression turns them red:
   spec uses it too, with an orphan `.ts` file (nothing imports it) as the
   canary: it enters the program through that `include` alone.
 
-  The two known-divergent arms of this cluster are
-  `ts-companion-named-import-bundler` and
-  `js-rune-module-without-allow-js-nodenext` — see the baseline section above.
+  The two arms this cluster used to be divergent on —
+  `ts-companion-named-import-bundler` (a *relative* companion-hijacked specifier
+  from a plain `.ts` file, answered by the import probe) and
+  `js-rune-module-without-allow-js-nodenext` (an ESM-mode specifier landing on a
+  withheld `.svelte.js` module, answered by replaying official's TS7016) — are
+  described in the baseline section above. Two more scenarios pin the edges
+  those two fixes introduce:
+  **`ts-companion-named-import-probe-scope`** checks that the probe answers for
+  its import declarations and nothing else (the file's unrelated `TS2322` is
+  reported once, not twice, and the elided body provokes no `noUnusedLocals`
+  complaint), and **`js-rune-module-without-allow-js-loose`** that the replay
+  reports *nothing* when `noImplicitAny` is off, which is what official does.
 - **`sibling-symlink`** — both cross-package shapes: `src/barrel.svelte` through
   the package `exports` barrel (#782/#805) and `src/deep.svelte` through a bare
   deep specifier (#1900).
@@ -206,4 +202,4 @@ existing scenario means rsvelte-check now disagrees with the official checker
 somewhere it previously did not, which is the exact failure mode this gate
 exists to catch. The only admissible addition is a *new* scenario that documents
 a divergence the product already had and cannot fix at its current architecture
-— with the reason written down above, as the two #2061 entries are.
+— with the reason written down above.

--- a/crates/rsvelte_check/src/svelte_check/mapper.rs
+++ b/crates/rsvelte_check/src/svelte_check/mapper.rs
@@ -10,7 +10,7 @@ use sourcemap::SourceMap;
 
 use super::diagnostic::{Diagnostic, DiagnosticSeverity, Position, Range};
 use super::kit_file::AddedCode;
-use super::overlay::{KitOverlayEntry, OverlayEntry, OverlayLayout};
+use super::overlay::{ImportProbeEntry, KitOverlayEntry, OverlayEntry, OverlayLayout};
 use super::tsgo::RawTsDiagnostic;
 
 /// Precomputed lookup for one overlay entry: parsed source map plus
@@ -61,6 +61,28 @@ pub fn is_syntactic_ts_code(code: &str) -> bool {
         .and_then(|n| n.parse::<u32>().ok())
         .map(|n| (1000..2000).contains(&n) && !SEMANTIC_TS_1XXX_CODES.contains(&n))
         .unwrap_or(false)
+}
+
+/// The numeric part of a `TS1234` diagnostic code.
+fn ts_error_number(code: &str) -> Option<u32> {
+    code.strip_prefix("TS").and_then(|n| n.parse::<u32>().ok())
+}
+
+/// The three spellings a raw diagnostic can name `path` by: absolute,
+/// canonicalised, and relative to the compiler's cwd (= the workspace).
+fn path_keys(path: &Path, workspace: &Path) -> Vec<PathBuf> {
+    let mut keys = vec![path.to_path_buf()];
+    if let Ok(canon) = path.canonicalize() {
+        keys.push(canon);
+    }
+    if let Ok(rel) = path.strip_prefix(workspace) {
+        keys.push(rel.to_path_buf());
+    }
+    keys
+}
+
+fn in_any_span(spans: &[(usize, usize)], offset: usize) -> bool {
+    spans.iter().any(|(s, e)| offset >= *s && offset < *e)
 }
 
 /// svelte2tsx wraps the synthesised helper code it emits for type-checking
@@ -198,6 +220,24 @@ pub fn map_tsgo_diagnostics(
         kit_source_paths.insert(canon);
         kit_source_paths.insert(entry.source_path.clone());
     }
+    // Import probes (`<stem>.rsvelte-import-probe.<ext>`) re-resolve a plain
+    // module's hijacked `.svelte` imports from inside the mirror. The probe owns
+    // exactly the declarations it kept: its diagnostics there are reported at
+    // the source's own (identical) position, and the source's own inside the
+    // same ranges are dropped as the resolution the overlay exists to correct.
+    let mut by_probe: HashMap<PathBuf, &ImportProbeEntry> = HashMap::new();
+    let mut probe_spans: HashMap<PathBuf, &[(usize, usize)]> = HashMap::new();
+    for entry in &overlay.import_probes {
+        for key in path_keys(&entry.out_path, workspace) {
+            by_probe.insert(key, entry);
+        }
+        for key in path_keys(&entry.source_path, workspace) {
+            probe_spans.insert(key, &entry.spans);
+        }
+    }
+    // Source text per probed file, read on demand to turn a diagnostic's
+    // line/column into the byte offset the spans are recorded in.
+    let mut probe_texts: HashMap<PathBuf, String> = HashMap::new();
     // Shadows for imported external packages live under `<cache>/ext/<n>/`.
     // Diagnostics landing on those files are library *internals* — official
     // svelte-check never type-checks a node_modules `.svelte` as a reported
@@ -244,6 +284,44 @@ pub fn map_tsgo_diagnostics(
         // injected kit mirror is the authoritative version (see above).
         if kit_source_paths.contains(&canon) || kit_source_paths.contains(&absolute) {
             continue;
+        }
+        let probe_match = by_probe
+            .get(&canon)
+            .copied()
+            .or_else(|| by_probe.get(&absolute).copied())
+            .or_else(|| by_probe.get(&diag.file).copied());
+        if let Some(entry) = probe_match {
+            let text = probe_texts
+                .entry(entry.source_path.clone())
+                .or_insert_with(|| std::fs::read_to_string(&entry.source_path).unwrap_or_default());
+            let off = line_col_to_byte_offset(text, diag.line as usize, diag.column as usize);
+            // 6xxx are the "declared but never read" family, which the elided
+            // body provokes by construction — the source is where that is
+            // decided, and it is checked in full.
+            let unused = matches!(ts_error_number(&diag.code), Some(6000..=6999));
+            if unused || !in_any_span(&entry.spans, off) {
+                continue;
+            }
+            out.push(passthrough(diag, &entry.source_path, workspace));
+            continue;
+        }
+        if let Some(spans) = probe_spans
+            .get(&canon)
+            .or_else(|| probe_spans.get(&absolute))
+            .or_else(|| probe_spans.get(&diag.file))
+        {
+            let path = if absolute.is_file() {
+                &absolute
+            } else {
+                &canon
+            };
+            let text = probe_texts
+                .entry(path.clone())
+                .or_insert_with(|| std::fs::read_to_string(path).unwrap_or_default());
+            let off = line_col_to_byte_offset(text, diag.line as usize, diag.column as usize);
+            if in_any_span(spans, off) {
+                continue;
+            }
         }
         let kit_match = by_kit
             .get(&canon)
@@ -594,6 +672,9 @@ mod tests {
             overlay_tsconfig: workspace.join(".svelte-check").join("tsconfig.json"),
             entries: Vec::new(),
             kit_entries: Vec::new(),
+            import_probes: Vec::new(),
+            withheld_js_modules: Vec::new(),
+            no_implicit_any: false,
         }
     }
 

--- a/crates/rsvelte_check/src/svelte_check/overlay.rs
+++ b/crates/rsvelte_check/src/svelte_check/overlay.rs
@@ -265,6 +265,20 @@ pub struct KitOverlayEntry {
     pub added_code: Vec<AddedCode>,
 }
 
+/// One plain `.ts` / `.js` source mirrored into the overlay with everything
+/// but its hijacked `.svelte` import declarations blanked out (see
+/// [`emit_import_probes`]). Positions are preserved byte for byte, so a
+/// diagnostic on the probe is reported at the source's own line and column.
+#[derive(Debug, Clone)]
+pub struct ImportProbeEntry {
+    pub source_path: PathBuf,
+    pub out_path: PathBuf,
+    /// Byte ranges of the kept import declarations, in the source's own
+    /// coordinates. The probe owns exactly these ranges: the source's own
+    /// diagnostics inside them are dropped in favour of the probe's.
+    pub spans: Vec<(usize, usize)>,
+}
+
 #[derive(Debug, Clone)]
 pub struct OverlayLayout {
     pub workspace: PathBuf,
@@ -273,6 +287,13 @@ pub struct OverlayLayout {
     pub overlay_tsconfig: PathBuf,
     pub entries: Vec<OverlayEntry>,
     pub kit_entries: Vec<KitOverlayEntry>,
+    pub import_probes: Vec<ImportProbeEntry>,
+    /// `<base>.svelte.js` rune modules deliberately left without a
+    /// `.d.svelte.ts` bridge (see [`emit_svelte_module_bridges`]).
+    pub withheld_js_modules: Vec<PathBuf>,
+    /// Whether the project type-checks with `noImplicitAny`, which decides
+    /// what official reports for those withheld modules.
+    pub no_implicit_any: bool,
 }
 
 #[derive(Debug)]
@@ -330,6 +351,19 @@ pub fn materialize_overlay_with_kit(
         materialize_overlay_with(workspace, svelte_files, tsconfig_path, incremental, ignore)?;
     layout.kit_entries = materialize_kit_files(workspace, &layout.emit_dir, kit_files, settings)?;
     materialize_kit_types(workspace, &layout.emit_dir, kit_files)?;
+    // A kit file already has a mirror copy at its own path, which resolves its
+    // `.svelte` imports from inside the mirror exactly as a probe would — a
+    // second copy of the same import would only report it twice.
+    layout.import_probes.retain(|probe| {
+        let mirrored = layout
+            .kit_entries
+            .iter()
+            .any(|kit| kit.source_path == probe.source_path);
+        if mirrored {
+            let _ = fs::remove_file(&probe.out_path);
+        }
+        !mirrored
+    });
     Ok(layout)
 }
 
@@ -402,6 +436,7 @@ pub fn materialize_overlay_with(
         .collect();
     let allow_js = resolve_allow_js(tsconfig_path);
     let mut module_bridges: Vec<(PathBuf, PathBuf)> = Vec::new();
+    let mut withheld_js_modules: Vec<PathBuf> = Vec::new();
     for pkg in &external {
         emit_external_shadows(
             pkg,
@@ -416,10 +451,15 @@ pub fn materialize_overlay_with(
             &pkg.mirror_dir,
             &[],
             allow_js,
+            &mut withheld_js_modules,
         )?);
     }
     module_bridges.extend(emit_svelte_module_bridges(
-        workspace, &emit_dir, ignore, allow_js,
+        workspace,
+        &emit_dir,
+        ignore,
+        allow_js,
+        &mut withheld_js_modules,
     )?);
 
     let mut entries = Vec::with_capacity(files.len());
@@ -558,6 +598,13 @@ pub fn materialize_overlay_with(
     }
     let has_augments = write_companion_augmentation(&cache_dir, &augments)?;
 
+    let import_probes = emit_import_probes(
+        workspace,
+        &emit_dir,
+        ignore,
+        &components_hijacked_by_a_companion(&abs_files),
+    )?;
+
     // Materialise the selected svelte2tsx shims into the cache dir so the
     // overlay tsconfig can reference them by a stable relative path — a
     // standalone rsvelte install has no `node_modules/svelte2tsx` to read.
@@ -619,6 +666,9 @@ pub fn materialize_overlay_with(
         overlay_tsconfig,
         entries,
         kit_entries: Vec::new(),
+        import_probes,
+        withheld_js_modules,
+        no_implicit_any: resolve_no_implicit_any(tsconfig_path),
     })
 }
 
@@ -1662,6 +1712,25 @@ fn resolve_allow_js(tsconfig_path: Option<&Path>) -> bool {
         .unwrap_or(false)
 }
 
+/// Nearest-definition-wins `compilerOptions.noImplicitAny`, falling back to
+/// `strict` and then to TypeScript's `false` default. Each option is resolved
+/// on its own chain, since an explicit `noImplicitAny` in a child overrides a
+/// `strict` in the base.
+fn resolve_no_implicit_any(tsconfig_path: Option<&Path>) -> bool {
+    let Some(path) = tsconfig_path else {
+        return false;
+    };
+    let chain = extends_chain(path);
+    let read = |key: &str| {
+        chain
+            .iter()
+            .find_map(|(_, parsed)| parsed.get("compilerOptions")?.get(key)?.as_bool())
+    };
+    read("noImplicitAny")
+        .or_else(|| read("strict"))
+        .unwrap_or(false)
+}
+
 /// The `target` the overlay tsconfig should force, or `None` to leave the inherited value alone (already ES2015+, so the `extends` chain provides it).
 fn resolve_forced_target(original: Option<&Path>) -> Option<&'static str> {
     match resolve_effective_target(original)
@@ -2251,7 +2320,10 @@ fn write_esm_bridge(path: &Path, content: &str, only_if_missing: bool) -> io::Re
 /// of the program at all, so official svelte-check resolves the specifier to it
 /// and reports TS7016 ("could not find a declaration file"). A bridge only
 /// replaces that with a wrong error — `export *` of an untyped module forwards
-/// no names, so every named import fails with TS2614 instead (#2061).
+/// no names, so every named import fails with TS2614 instead (#2061). Those
+/// skips are collected into `withheld` so
+/// [`replay_withheld_js_module_diagnostics`] can restate what official says
+/// about them.
 ///
 /// These bridges have no manifest entry to prune them by, so the mirror is also
 /// swept for ones whose source module has since been deleted or renamed.
@@ -2265,6 +2337,7 @@ fn emit_svelte_module_bridges(
     mirror_dir: &Path,
     ignore: &[String],
     allow_js: bool,
+    withheld: &mut Vec<PathBuf>,
 ) -> Result<Vec<(PathBuf, PathBuf)>, OverlayError> {
     let mut modules = super::walker::find_svelte_suffixed_modules(root, ignore);
     // `x.svelte.ts` and `x.svelte.js` share one bridge path; TypeScript probes
@@ -2283,6 +2356,7 @@ fn emit_svelte_module_bridges(
             && module.extension().and_then(|e| e.to_str()) == Some("js")
             && !module.with_extension("d.ts").is_file()
         {
+            withheld.push(module.clone());
             continue;
         }
         let rel = safe_relative(module, root);
@@ -2343,6 +2417,241 @@ fn prune_orphaned_module_bridges(mirror_dir: &Path, written: &std::collections::
         }
         let _ = fs::remove_file(&bridge);
     }
+}
+
+/// Infix marking a file under the mirror as an [`emit_import_probes`] probe.
+/// It has to differ from the source's own basename: a probe is a *blanked*
+/// copy, so a mirror file resolving `./relative` to it instead of the real
+/// module would see none of its exports.
+pub(super) const IMPORT_PROBE_INFIX: &str = ".rsvelte-import-probe";
+
+/// Components whose own `.svelte` specifier TypeScript hands to a same-named
+/// companion module instead, where official svelte-check hands it to the
+/// component.
+///
+/// Resolving `./Foo.svelte` from the importer's own directory, TypeScript
+/// probes `Foo.d.svelte.ts` (the `allowArbitraryExtensions` form) and then
+/// `Foo.svelte.ts` / `.tsx` / `.js`, so a real companion wins. Official's
+/// `svelteSys.fileExists` answers the first probe with "yes" whenever
+/// `Foo.svelte` exists — unless a real declaration (`Foo.svelte.d.ts` or
+/// `Foo.d.svelte.ts`) sits there, which it lets take precedence (#2061).
+fn components_hijacked_by_a_companion(abs_files: &[PathBuf]) -> std::collections::HashSet<PathBuf> {
+    let sibling = |component: &Path, suffix: &str| -> PathBuf {
+        let mut p = component.as_os_str().to_os_string();
+        p.push(suffix);
+        PathBuf::from(p)
+    };
+    let real_declaration = |component: &Path| -> bool {
+        let Some(stem) = component.file_stem().and_then(|s| s.to_str()) else {
+            return false;
+        };
+        sibling(component, ".d.ts").is_file()
+            || component
+                .with_file_name(format!("{stem}.d.svelte.ts"))
+                .is_file()
+    };
+    let mut out = std::collections::HashSet::new();
+    for component in abs_files {
+        if real_declaration(component) {
+            continue;
+        }
+        if [".ts", ".tsx", ".js", ".jsx"]
+            .iter()
+            .any(|ext| sibling(component, ext).is_file())
+        {
+            out.insert(normalize_abs(component));
+        }
+    }
+    out
+}
+
+/// Mirror every plain `.ts` / `.js` source whose relative `.svelte` specifier
+/// is hijacked by a companion module (see [`components_hijacked_by_a_companion`])
+/// into `<emit_dir>`, with everything but those import declarations blanked out.
+///
+/// A `.svelte` importer can be steered by rewriting the specifier as the shadow
+/// is generated, and a non-relative one by an exact `paths` entry, but a
+/// relative specifier in a file we do not own is beyond both: `paths` never
+/// applies to it and `rootDirs` only offers the mirror *after* the importer's
+/// own directory came up empty, which it does not. Re-resolving the same import
+/// from inside the mirror — where the component's `.d.svelte.ts` bridge is the
+/// only candidate — is what makes the compiler agree with official's
+/// `resolveModuleNames` hook. Blanking the rest keeps the probe answerable for
+/// nothing but the import it exists to test, and preserves every byte position
+/// so its diagnostics are reported where the user wrote them.
+fn emit_import_probes(
+    workspace: &Path,
+    emit_dir: &Path,
+    ignore: &[String],
+    hijacked: &std::collections::HashSet<PathBuf>,
+) -> Result<Vec<ImportProbeEntry>, OverlayError> {
+    let mut written: std::collections::HashSet<PathBuf> = std::collections::HashSet::new();
+    let mut out: Vec<ImportProbeEntry> = Vec::new();
+    if !hijacked.is_empty() {
+        for source in super::walker::find_probeable_modules(workspace, ignore) {
+            let Ok(text) = fs::read_to_string(&source) else {
+                continue;
+            };
+            if !text.contains(".svelte") {
+                continue;
+            }
+            let spans = hijacked_import_spans(&text, &source, hijacked);
+            if spans.is_empty() {
+                continue;
+            }
+            let rel = safe_relative(&source, workspace);
+            let Some(probe) = import_probe_path(&emit_dir.join(&rel)) else {
+                continue;
+            };
+            if let Some(parent) = probe.parent() {
+                fs::create_dir_all(parent)?;
+            }
+            fs::write(&probe, blank_outside(&text, &spans))?;
+            written.insert(probe.clone());
+            out.push(ImportProbeEntry {
+                source_path: source,
+                out_path: probe,
+                spans,
+            });
+        }
+    }
+    prune_orphaned_import_probes(emit_dir, &written);
+    Ok(out)
+}
+
+/// `<dir>/<stem>.<ext>` → `<dir>/<stem>.rsvelte-import-probe.<ext>`.
+fn import_probe_path(mirrored: &Path) -> Option<PathBuf> {
+    let name = mirrored.file_name()?.to_str()?;
+    let (stem, ext) = name.rsplit_once('.')?;
+    Some(mirrored.with_file_name(format!("{stem}{IMPORT_PROBE_INFIX}.{ext}")))
+}
+
+/// Byte ranges of `text`'s top-level `import` / `export … from` declarations
+/// whose specifier is a relative `.svelte` path landing on a `hijacked`
+/// component.
+fn hijacked_import_spans(
+    text: &str,
+    source: &Path,
+    hijacked: &std::collections::HashSet<PathBuf>,
+) -> Vec<(usize, usize)> {
+    let Some(source_dir) = source.parent().map(absolutize) else {
+        return Vec::new();
+    };
+    let source_type = SourceType::from_path(source).unwrap_or_default();
+    let allocator = Allocator::default();
+    let parsed = OxcParser::new(&allocator, text, source_type).parse();
+    let mut spans: Vec<(usize, usize)> = Vec::new();
+    let mut take = |specifier: &str, span: oxc_span::Span| {
+        if !specifier.starts_with('.') || !specifier.ends_with(".svelte") {
+            return;
+        }
+        if hijacked.contains(&normalize_abs(&source_dir.join(specifier))) {
+            spans.push((span.start as usize, span.end as usize));
+        }
+    };
+    for stmt in &parsed.program.body {
+        match stmt {
+            oxc::Statement::ImportDeclaration(decl) => take(&decl.source.value, decl.span),
+            oxc::Statement::ExportNamedDeclaration(decl) => {
+                if let Some(src) = &decl.source {
+                    take(&src.value, decl.span);
+                }
+            }
+            oxc::Statement::ExportAllDeclaration(decl) => take(&decl.source.value, decl.span),
+            _ => {}
+        }
+    }
+    spans
+}
+
+/// Replace every byte outside `spans` with a space, newlines excepted, so the
+/// result parses as just those declarations while every retained byte keeps its
+/// original line and column.
+fn blank_outside(text: &str, spans: &[(usize, usize)]) -> String {
+    let mut out = String::with_capacity(text.len());
+    for (offset, ch) in text.char_indices() {
+        let kept =
+            ch == '\n' || ch == '\r' || spans.iter().any(|(s, e)| offset >= *s && offset < *e);
+        if kept {
+            out.push(ch);
+        } else {
+            out.extend(std::iter::repeat_n(' ', ch.len_utf8()));
+        }
+    }
+    out
+}
+
+/// Drop probes under `emit_dir` this run did not write — their source has
+/// since lost the import (or the companion) that called for one.
+fn prune_orphaned_import_probes(emit_dir: &Path, written: &std::collections::HashSet<PathBuf>) {
+    for probe in super::walker::find_import_probes(emit_dir) {
+        if !written.contains(&probe) {
+            let _ = fs::remove_file(&probe);
+        }
+    }
+}
+
+/// Restate what official svelte-check reports for a `.svelte` specifier that
+/// lands on a `.svelte.js` rune module the overlay deliberately left without a
+/// bridge (see [`emit_svelte_module_bridges`]).
+///
+/// Under ESM-mode resolution the specifier reaches nothing at all, so the
+/// compiler says TS2307. Official forces the pre-ESM algorithm for `.svelte`
+/// specifiers, finds the untyped `.js`, and says TS7016 — or, without
+/// `noImplicitAny`, says nothing. Having withheld the file, the overlay owes
+/// the user that answer (#2061).
+pub(crate) fn replay_withheld_js_module_diagnostics(
+    diagnostics: &mut Vec<Diagnostic>,
+    withheld: &[PathBuf],
+    no_implicit_any: bool,
+) {
+    if withheld.is_empty() {
+        return;
+    }
+    let withheld: std::collections::HashSet<PathBuf> =
+        withheld.iter().map(|p| normalize_abs(p)).collect();
+    diagnostics.retain_mut(|diag| {
+        if diag.code.as_deref() != Some("TS2307") {
+            return true;
+        }
+        let Some(specifier) = quoted_module_name(&diag.message) else {
+            return true;
+        };
+        if !specifier.starts_with('.') || !specifier.ends_with(".svelte") {
+            return true;
+        }
+        let Some(dir) = diag.file.parent().map(absolutize) else {
+            return true;
+        };
+        let base = normalize_abs(&dir.join(specifier));
+        let Some(module) = [".js", ".jsx"]
+            .iter()
+            .map(|ext| {
+                let mut p = base.as_os_str().to_os_string();
+                p.push(ext);
+                PathBuf::from(p)
+            })
+            .find(|p| withheld.contains(p))
+        else {
+            return true;
+        };
+        if !no_implicit_any {
+            return false;
+        }
+        diag.code = Some("TS7016".into());
+        diag.message = format!(
+            "Could not find a declaration file for module '{specifier}'. '{}' implicitly has an 'any' type.",
+            module.display()
+        );
+        true
+    });
+}
+
+/// The first single-quoted run in a TypeScript diagnostic message — the module
+/// name in `Cannot find module 'X' or its corresponding type declarations.`
+fn quoted_module_name(message: &str) -> Option<&str> {
+    let rest = message.split_once('\'')?.1;
+    rest.split_once('\'').map(|(name, _)| name)
 }
 
 fn module_has_default(path: &Path) -> bool {
@@ -4587,6 +4896,144 @@ mod tests {
         assert!(bridge.is_file(), "allowJs must restore the bridge");
 
         let _ = fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn a_companion_hijacked_relative_import_gets_a_blanked_probe() {
+        // #2061: TypeScript resolves `./widget.svelte` in the importer's own
+        // directory, where the real companion wins; official hands the same
+        // specifier to the component. Re-resolving it from the mirror, where
+        // only the component's bridge exists, is what makes the two agree.
+        let tmp = std::env::temp_dir().join(format!("svc_probe_{}", std::process::id()));
+        let _ = fs::remove_dir_all(&tmp);
+        fs::create_dir_all(tmp.join("src/lib")).unwrap();
+        fs::write(tmp.join("src/lib/widget.svelte"), "<p>hi</p>\n").unwrap();
+        fs::write(
+            tmp.join("src/lib/widget.svelte.ts"),
+            "export const helper = 1;\n",
+        )
+        .unwrap();
+        fs::write(
+            tmp.join("src/relative.ts"),
+            "import { helper } from './lib/widget.svelte';\nexport const m = helper;\n",
+        )
+        .unwrap();
+        fs::write(tmp.join("src/unrelated.ts"), "export const k = 1;\n").unwrap();
+        fs::write(tmp.join("tsconfig.json"), "{\"compilerOptions\":{}}").unwrap();
+
+        let files = vec![tmp.join("src/lib/widget.svelte")];
+        let layout =
+            materialize_overlay_with(&tmp, &files, Some(&tmp.join("tsconfig.json")), false, &[])
+                .unwrap();
+
+        assert_eq!(layout.import_probes.len(), 1, "only the hijacked importer");
+        let probe = &layout.import_probes[0];
+        assert_eq!(probe.source_path, tmp.join("src/relative.ts"));
+        let text = fs::read_to_string(&probe.out_path).unwrap();
+        assert_eq!(
+            text, "import { helper } from './lib/widget.svelte';\n                        \n",
+            "everything but the hijacked declaration is blanked in place"
+        );
+
+        // Lose the companion and the specifier is no longer hijacked, so the
+        // probe has to disappear with it.
+        fs::remove_file(tmp.join("src/lib/widget.svelte.ts")).unwrap();
+        let layout =
+            materialize_overlay_with(&tmp, &files, Some(&tmp.join("tsconfig.json")), false, &[])
+                .unwrap();
+        assert!(layout.import_probes.is_empty());
+        assert!(!probe.out_path.exists(), "stale probe must be swept");
+
+        let _ = fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn a_real_declaration_keeps_the_specifier_on_the_companion() {
+        // Official's `svelteSys` lets a hand-written `Foo.svelte.d.ts` take
+        // precedence over the component, so there is nothing to re-resolve.
+        let tmp = std::env::temp_dir().join(format!("svc_probe_dts_{}", std::process::id()));
+        let _ = fs::remove_dir_all(&tmp);
+        fs::create_dir_all(tmp.join("src")).unwrap();
+        fs::write(tmp.join("src/widget.svelte"), "<p>hi</p>\n").unwrap();
+        fs::write(
+            tmp.join("src/widget.svelte.ts"),
+            "export const helper = 1;\n",
+        )
+        .unwrap();
+        fs::write(
+            tmp.join("src/widget.svelte.d.ts"),
+            "export declare const helper: number;\n",
+        )
+        .unwrap();
+        fs::write(
+            tmp.join("src/relative.ts"),
+            "import { helper } from './widget.svelte';\nexport const m = helper;\n",
+        )
+        .unwrap();
+        fs::write(tmp.join("tsconfig.json"), "{\"compilerOptions\":{}}").unwrap();
+
+        let layout = materialize_overlay_with(
+            &tmp,
+            &[tmp.join("src/widget.svelte")],
+            Some(&tmp.join("tsconfig.json")),
+            false,
+            &[],
+        )
+        .unwrap();
+        assert!(layout.import_probes.is_empty());
+
+        let _ = fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn a_withheld_js_module_replays_official_answer() {
+        // #2061: TS2307 is what an ESM-mode specifier gets when the bridge is
+        // withheld; official resolves it onto the untyped `.js` instead.
+        let diag = |file: &str, code: &str, message: &str| Diagnostic {
+            file: PathBuf::from(file),
+            severity: DiagnosticSeverity::Error,
+            code: Some(code.into()),
+            message: message.into(),
+            range: None,
+            source: "ts",
+        };
+        let withheld = vec![PathBuf::from("/ws/src/lib/counter.svelte.js")];
+        let cannot_find = |spec: &str| {
+            format!("Cannot find module '{spec}' or its corresponding type declarations.")
+        };
+
+        let mut diagnostics = vec![
+            diag(
+                "/ws/src/plain.ts",
+                "TS2307",
+                &cannot_find("./lib/counter.svelte"),
+            ),
+            diag(
+                "/ws/src/plain.ts",
+                "TS2307",
+                &cannot_find("./lib/gone.svelte"),
+            ),
+            diag("/ws/src/plain.ts", "TS2322", "unrelated"),
+        ];
+        replay_withheld_js_module_diagnostics(&mut diagnostics, &withheld, true);
+        assert_eq!(diagnostics.len(), 3);
+        assert_eq!(diagnostics[0].code.as_deref(), Some("TS7016"));
+        assert_eq!(
+            diagnostics[0].message,
+            "Could not find a declaration file for module './lib/counter.svelte'. \
+             '/ws/src/lib/counter.svelte.js' implicitly has an 'any' type."
+        );
+        assert_eq!(diagnostics[1].code.as_deref(), Some("TS2307"));
+        assert_eq!(diagnostics[2].code.as_deref(), Some("TS2322"));
+
+        // Without `noImplicitAny` official says nothing at all.
+        let mut diagnostics = vec![diag(
+            "/ws/src/plain.ts",
+            "TS2307",
+            &cannot_find("./lib/counter.svelte"),
+        )];
+        replay_withheld_js_module_diagnostics(&mut diagnostics, &withheld, false);
+        assert!(diagnostics.is_empty());
     }
 
     #[test]

--- a/crates/rsvelte_check/src/svelte_check/runner.rs
+++ b/crates/rsvelte_check/src/svelte_check/runner.rs
@@ -387,7 +387,12 @@ fn run_type_check_phase(
     };
     match run_tsgo(&binary, &layout.overlay_tsconfig, workspace) {
         Ok(raw) => {
-            let mapped = map_tsgo_diagnostics(&raw, layout, workspace);
+            let mut mapped = map_tsgo_diagnostics(&raw, layout, workspace);
+            overlay::replay_withheld_js_module_diagnostics(
+                &mut mapped.diagnostics,
+                &layout.withheld_js_modules,
+                layout.no_implicit_any,
+            );
             // Before merging tsgo's output, guard against the silent
             // false-negative in #728: a syntactically-invalid generated
             // overlay makes TypeScript suppress every SEMANTIC diagnostic

--- a/crates/rsvelte_check/src/svelte_check/walker.rs
+++ b/crates/rsvelte_check/src/svelte_check/walker.rs
@@ -55,6 +55,56 @@ pub fn find_svelte_suffixed_modules(root: &Path, filter_paths: &[String]) -> Vec
     out
 }
 
+/// Extensions a plain TypeScript / JavaScript module can carry.
+const JS_TS_EXTENSIONS: [&str; 8] = ["ts", "tsx", "mts", "cts", "js", "jsx", "mjs", "cjs"];
+
+/// Find every plain `.ts` / `.js` module under `root` that could carry a
+/// relative `.svelte` import the overlay has to re-resolve — i.e. everything
+/// except the `<name>.svelte.<ext>` rune modules, which reach their component
+/// through their own bridge instead. Same pruning as [`find_svelte_files`].
+pub fn find_probeable_modules(root: &Path, filter_paths: &[String]) -> Vec<PathBuf> {
+    let mut out: Vec<PathBuf> = Vec::new();
+    for entry in pruned_walk(root, filter_paths).flatten() {
+        if !entry.file_type().is_file() {
+            continue;
+        }
+        let name = entry.file_name().to_string_lossy().into_owned();
+        if name.contains(".svelte.") || name.ends_with(".d.ts") {
+            continue;
+        }
+        if entry
+            .path()
+            .extension()
+            .is_some_and(|e| JS_TS_EXTENSIONS.iter().any(|k| e == *k))
+        {
+            out.push(entry.into_path());
+        }
+    }
+    out.sort();
+    out
+}
+
+/// Find every import probe the overlay has previously written under `mirror`.
+pub fn find_import_probes(mirror: &Path) -> Vec<PathBuf> {
+    let mut out: Vec<PathBuf> = Vec::new();
+    for entry in WalkDir::new(mirror)
+        .follow_links(false)
+        .into_iter()
+        .flatten()
+    {
+        if entry.file_type().is_file()
+            && entry
+                .file_name()
+                .to_string_lossy()
+                .contains(super::overlay::IMPORT_PROBE_INFIX)
+        {
+            out.push(entry.into_path());
+        }
+    }
+    out.sort();
+    out
+}
+
 /// The shared traversal both finders use: skip `node_modules`, hidden
 /// directories and any user-supplied ignore fragment.
 fn pruned_walk(


### PR DESCRIPTION
Fixes #2061.

#2114 closed the bulk of this issue and pinned the last two sub-cases as ratcheted scenarios, on the grounds that both need official's `resolveModuleNames` hook. Re-reading upstream's `svelte-sys.ts` against a probe-order trace of TypeScript's own resolver shows the boundary sits one step further out than that: official's virtual path is `Foo.d.svelte.ts` (the `allowArbitraryExtensions` form), which TypeScript probes **first**, and `svelteSys.fileExists` answers it with "yes, the component" whenever `Foo.svelte` exists. So the disagreement is only ever about *which directory the import is resolved from* — something an on-disk overlay can control after all.

### 1. Relative companion-hijacked specifier (`ts-companion-named-import-bundler`)

`import { helper } from './lib/widget.svelte'` in a plain `.ts` file with a sibling `widget.svelte.ts`. TypeScript probes the importer's own directory (`widget.d.svelte.ts` → miss, `widget.svelte.ts` → hit), so it lands on the companion; official lands on the component and reports `TS2614`. `paths` never applies to a relative specifier and `rootDirs` only offers the mirror after the importer's own directory came up empty — which it does not.

The overlay now mirrors such an importer as a blanked **import probe**, `<stem>.rsvelte-import-probe.<ext>`, holding only the hijacked import declarations with every other byte replaced by a space (newlines kept, so line/column survive exactly). Resolved from inside the mirror, the component's `.d.svelte.ts` bridge is the only candidate, and the compiler reaches official's answer on its own. The probe owns exactly the declarations it kept: diagnostics on it are reported at the source's own position, the source's own inside those ranges are dropped, and the `6xxx` "declared but never read" family the elided body provokes is discarded.

A distinct basename is required rather than a plain mirror copy — a mirror file resolving `./relative` to a *blanked* module would see none of its exports. Kit files are skipped, since their existing mirror copy already resolves from the same directory.

The trigger is narrow by construction (a `.svelte` component with a same-named `.ts`/`.tsx`/`.js`/`.jsx` sibling and no hand-written declaration): it does not occur once across bits-ui, melt-ui, shadcn-svelte, flowbite-svelte, layerchart, svelte-maplibre or sveltejs/svelte, so the workspace walk it guards is skipped outright in every one of them.

### 2. Withheld `.svelte.js` rune module (`js-rune-module-without-allow-js-nodenext`)

`counter.svelte.js` with `allowJs` off gets no `.d.svelte.ts` bridge on purpose — a bridge forwards no names and would turn official's `TS7016` into a wrong `TS2614`. Under `node16`/`nodenext` no extension is substituted either, so the specifier reached nothing and the compiler said `TS2307`. Having withheld the file, the overlay now restates what official reports for it: `TS7016` with official's message, or **nothing at all** when `noImplicitAny` is off, which is what official does there.

### Testing

- `compatibility/check-known-failures.json` is back to **0 entries**; all 28 Layer-1 scenarios match official diagnostic-for-diagnostic on both the `tsc` and `tsgo` legs.
- Both previously-ratcheted fixtures are the regression guards; reverting either fix turns them red (verified).
- Two new scenarios pin the edges the fixes introduce: `ts-companion-named-import-probe-scope` (the probe answers for its imports and nothing else — the file's unrelated `TS2322` is reported once, not twice, and `noUnusedLocals` stays quiet) and `js-rune-module-without-allow-js-loose` (the replay reports nothing without `noImplicitAny`). Both also fail without the fix.
- `cargo test -p rsvelte_check`, `cargo fmt`, `cargo clippy --all-targets --all-features -- -D warnings` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
