### PR TITLE
fix(fmt): charge an indentation tab `tabWidth` columns in every width measurement (#2119)

### DIFF
--- a/.changeset/fmt-usetabs-visual-width.md
+++ b/.changeset/fmt-usetabs-visual-width.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/fmt": patch
+---
+
+fix(fmt): charge an indentation tab `tabWidth` columns when measuring print width. Prettier's `generateIndent` counts one indent tab as `tabWidth` columns, but every fit decision in the formatter measured it with `UnicodeWidthStr::width`, which returns 1 — so under `useTabs` a depth-`n` indent under-counted by `(tabWidth - 1) * n` columns and prose fills, open-tag breaks and `{expr}` splits all fired later than the oracle's. All ~60 width call sites now go through one shared `visual_width(s, tab_width)` helper (and the doc printer carries its indent unit's real column cost), which leaves space-indented output byte-identical.

--- a/crates/rsvelte_formatter/src/children.rs
+++ b/crates/rsvelte_formatter/src/children.rs
@@ -674,6 +674,7 @@ fn compute_no_hug_separators(
 mod tests {
     use super::*;
     use crate::doc::{Doc, print, propagate_breaks};
+    use crate::width::IndentUnit;
 
     #[test]
     fn bracket_same_line_flag_is_restored_after_a_panic() {
@@ -688,13 +689,25 @@ mod tests {
 
     /// A single text node's `splitTextToDocs` output is its own `fill`.
     fn render_fill(docs: Vec<Doc>, width: usize) -> String {
-        print(&propagate_breaks(Doc::Fill(docs)), width, "  ", 0, 0)
+        print(
+            &propagate_breaks(Doc::Fill(docs)),
+            width,
+            IndentUnit::new("  ", 2),
+            0,
+            0,
+        )
     }
 
     /// `print_children` returns the parent element body — a concat the element's
     /// `group` wraps (NOT a fill); text children are fills inside it.
     fn render_children(docs: Vec<Doc>, width: usize) -> String {
-        print(&propagate_breaks(Doc::Group(docs)), width, "  ", 0, 0)
+        print(
+            &propagate_breaks(Doc::Group(docs)),
+            width,
+            IndentUnit::new("  ", 2),
+            0,
+            0,
+        )
     }
 
     #[test]
@@ -751,7 +764,13 @@ mod tests {
     }
 
     fn render_el(doc: Doc, width: usize) -> String {
-        print(&propagate_breaks(doc), width, "  ", 0, 0)
+        print(
+            &propagate_breaks(doc),
+            width,
+            IndentUnit::new("  ", 2),
+            0,
+            0,
+        )
     }
 
     fn el(name: &str, children: Vec<Child>, is_inline: bool) -> Doc {
@@ -903,7 +922,7 @@ mod tests {
             self_closing: false,
             omit_softline_allowed: false,
         });
-        let printed = print(&propagate_breaks(doc), 80, "  ", 1, 2);
+        let printed = print(&propagate_breaks(doc), 80, IndentUnit::new("  ", 2), 1, 2);
         let expected = "<div slot=\"noResults\">\n    This is a custom text that<br /> will be shown when there are<br /> no rows to\n    display\n  </div>";
         assert_eq!(printed, expected);
     }
@@ -931,7 +950,7 @@ mod tests {
             omit_softline_allowed: false,
         });
         // Nested one level (p at indent 2 → content indent 4).
-        let printed = print(&propagate_breaks(doc), 80, "  ", 1, 2);
+        let printed = print(&propagate_breaks(doc), 80, IndentUnit::new("  ", 2), 1, 2);
         let expected = "<p class=\"meta\">\n    <a href=\"#/item/{item.id}\">{comment_text()}</a> by {item.user}\n    {item.time_ago}\n  </p>";
         assert_eq!(printed, expected);
     }
@@ -969,7 +988,13 @@ mod tests {
             self_closing: false,
             omit_softline_allowed: false,
         });
-        let printed = print(&propagate_breaks(strong), 80, "  ", 1, 2);
+        let printed = print(
+            &propagate_breaks(strong),
+            80,
+            IndentUnit::new("  ", 2),
+            1,
+            2,
+        );
         let expected = "<strong\n    >Notice for <a href=\"https://sapper.svelte.dev/\" target=\"_blank\">Sapper</a> user:</strong\n  >";
         assert_eq!(printed, expected);
     }
@@ -1019,7 +1044,7 @@ mod tests {
             self_closing: false,
             omit_softline_allowed: false,
         });
-        let printed = print(&propagate_breaks(div), 80, "  ", 0, 0);
+        let printed = print(&propagate_breaks(div), 80, IndentUnit::new("  ", 2), 0, 0);
         let expected = "<div class=\"shadow-sm p-3 mb-3 rounded\">\n  <strong\n    >Notice for <a href=\"https://sapper.svelte.dev/\" target=\"_blank\">Sapper</a> user:</strong\n  > You may need to install the component as a devDependency:\n</div>";
         assert_eq!(printed, expected);
     }

--- a/crates/rsvelte_formatter/src/collapse/breaks.rs
+++ b/crates/rsvelte_formatter/src/collapse/breaks.rs
@@ -37,6 +37,7 @@ pub(super) fn collect_break_block_non_ws_prefix(
     out: &str,
     fragment: &Fragment,
     line_width: usize,
+    tw: usize,
     edits: &mut Vec<(u32, u32, String)>,
 ) {
     for (node_idx, node) in fragment.nodes.iter().enumerate() {
@@ -63,8 +64,8 @@ pub(super) fn collect_break_block_non_ws_prefix(
                     };
                     // Only act when the whole element is on one line and overflows.
                     let whole = out.get(s..end).unwrap_or("");
-                    let column = indent.width() + 1; // +1 for the `>` char
-                    if !whole.contains('\n') && column + whole.width() > line_width {
+                    let column = indent.visual_width(tw) + 1; // +1 for the `>` char
+                    if !whole.contains('\n') && column + whole.visual_width(tw) > line_width {
                         // Find first and last non-whitespace children.
                         if let (Some(first_child), Some(last_child)) = (
                             e.fragment.nodes.iter().find(
@@ -91,11 +92,11 @@ pub(super) fn collect_break_block_non_ws_prefix(
                         }
                     }
                 }
-                collect_break_block_non_ws_prefix(out, &e.fragment, line_width, edits);
+                collect_break_block_non_ws_prefix(out, &e.fragment, line_width, tw, edits);
             }
             _ => {
                 for child in child_fragments(node) {
-                    collect_break_block_non_ws_prefix(out, child, line_width, edits);
+                    collect_break_block_non_ws_prefix(out, child, line_width, tw, edits);
                 }
             }
         }
@@ -114,6 +115,7 @@ pub(super) fn try_break_inline_content_tag(
     line_width: usize,
     options: &FormatOptions,
 ) -> Option<(u32, u32, String)> {
+    let tw = tab_width(options);
     let es = node_start(node) as usize;
     let ee = node_end(node) as usize;
     let span = out.get(es..ee)?; // `{expr}`
@@ -123,7 +125,7 @@ pub(super) fn try_break_inline_content_tag(
     let line_start = out[..es].rfind('\n').map_or(0, |i| i + 1);
     let line_end = out[ee..].find('\n').map_or(out.len(), |i| ee + i);
     let line = out.get(line_start..line_end)?;
-    if line.width() <= line_width {
+    if line.visual_width(tw) <= line_width {
         return None; // line fits — nothing to break
     }
     // Break only the RIGHTMOST mustache on the overflowing line: breaking it pulls
@@ -146,11 +148,11 @@ pub(super) fn try_break_inline_content_tag(
     {
         return None;
     }
-    let _start_col = current_column(out, es as u32);
+    let _start_col = current_column(out, es as u32, tw);
     // Continuation lands at the line's own indent + one level.
     let indent = &out[line_start..es];
     let lead_ws: String = indent.chars().take_while(|c| c.is_whitespace()).collect();
-    let cont_cols = lead_ws.width();
+    let cont_cols = lead_ws.visual_width(tw);
     let inner = span.get(1..span.len() - 1)?.trim();
     // Force OXC to break the expression at the MINIMUM narrowing: use
     // `width = single_line_len - 1` (one char narrower than the flat form).
@@ -163,7 +165,7 @@ pub(super) fn try_break_inline_content_tag(
     // as small as 13, causing `df.format(date.end.toDate(getLocalTimeZone()))`
     // to break all the way down to `toDate(\n  getLocalTimeZone(),\n)` instead
     // of the expected `df.format(\n  date.end.toDate(getLocalTimeZone()),\n)`.
-    let single_line_len = UnicodeWidthStr::width(inner);
+    let single_line_len = inner.visual_width(tw);
     let width = single_line_len.saturating_sub(1).max(1);
     let wrapped =
         crate::expression::reformat_content_at_width(inner, options, width, cont_cols).ok()?;
@@ -193,6 +195,7 @@ pub(super) fn try_break_content_tag_block(
     line_width: usize,
     options: &FormatOptions,
 ) -> Option<(u32, u32, String)> {
+    let tw = tab_width(options);
     if !is_block_display(tag) {
         return None;
     }
@@ -255,7 +258,8 @@ pub(super) fn try_break_content_tag_block(
         let open_last_line = open.rsplit('\n').next().unwrap_or(open);
         let gt_on_own_line = open_last_line.trim_start_matches([' ', '\t']) == ">";
         if !gt_on_own_line {
-            let glued_width = open_last_line.width() + span.width() + close.width();
+            let glued_width =
+                open_last_line.visual_width(tw) + span.visual_width(tw) + close.visual_width(tw);
             if glued_width <= line_width {
                 return None; // fits on the attr+`>` line — leave as-is
             }
@@ -268,12 +272,12 @@ pub(super) fn try_break_content_tag_block(
         // attribute and the `>`.
         let open_without_gt = open[..open.len() - 1].trim_end();
         let inner = span.get(kw_lead..span.len() - kw_trail)?.trim();
-        let width = line_width.saturating_sub(inner_indent.width() + kw_lead + kw_trail);
+        let width = line_width.saturating_sub(inner_indent.visual_width(tw) + kw_lead + kw_trail);
         let wrapped = crate::expression::reformat_content_at_width(
             inner,
             options,
             width,
-            inner_indent.width(),
+            inner_indent.visual_width(tw),
         )
         .ok()?;
         let kw_prefix = &span[..kw_lead];
@@ -283,8 +287,9 @@ pub(super) fn try_break_content_tag_block(
         return (broken != whole).then_some((start, end, broken));
     }
 
-    let column = current_column(out, start);
-    if column + open.width() + span.width() + close.width() <= line_width {
+    let column = current_column(out, start, tw);
+    if column + open.visual_width(tw) + span.visual_width(tw) + close.visual_width(tw) <= line_width
+    {
         return None; // fits on one line
     }
 
@@ -296,10 +301,14 @@ pub(super) fn try_break_content_tag_block(
     let inner_indent = format!("{indent}  ");
 
     let inner = span.get(kw_lead..span.len() - kw_trail)?.trim();
-    let width = line_width.saturating_sub(inner_indent.width() + kw_lead + kw_trail);
-    let wrapped =
-        crate::expression::reformat_content_at_width(inner, options, width, inner_indent.width())
-            .ok()?;
+    let width = line_width.saturating_sub(inner_indent.visual_width(tw) + kw_lead + kw_trail);
+    let wrapped = crate::expression::reformat_content_at_width(
+        inner,
+        options,
+        width,
+        inner_indent.visual_width(tw),
+    )
+    .ok()?;
     let kw_prefix = &span[..kw_lead]; // `{@html ` / `{`
     let new_tag = format!("{kw_prefix}{wrapped}}}");
     let broken = format!("{open}\n{inner_indent}{new_tag}\n{indent}{close}");
@@ -325,6 +334,7 @@ pub(super) fn try_break_block_overflow(
     end: u32,
     fragment: &Fragment,
     line_width: usize,
+    tw: usize,
 ) -> Option<(u32, u32, String)> {
     if !is_block_display(tag) {
         return None;
@@ -357,8 +367,8 @@ pub(super) fn try_break_block_overflow(
 
     if !has_flow_block_child {
         // Must overflow.
-        let column = current_column(out, start);
-        if column + whole.width() <= line_width {
+        let column = current_column(out, start, tw);
+        if column + whole.visual_width(tw) <= line_width {
             return None;
         }
     }

--- a/crates/rsvelte_formatter/src/collapse/children_port.rs
+++ b/crates/rsvelte_formatter/src/collapse/children_port.rs
@@ -192,6 +192,8 @@ pub(super) fn try_children_port(
     options: &FormatOptions,
 ) -> Option<Option<(u32, u32, String)>> {
     use crate::children::{Child, ElementLayout, build_element_doc};
+
+    let tw = tab_width(options);
     let (tag, attributes, fragment, start, end, is_inline, self_closing) = match node {
         TemplateNode::RegularElement(e) => (
             e.name.as_str(),
@@ -301,9 +303,9 @@ pub(super) fn try_children_port(
     let base_level = if options.js.indent_style.is_tab() {
         ws_len
     } else {
-        indent.width() / width
+        indent.visual_width(tw) / width
     };
-    let start_col = current_column(out, start);
+    let start_col = current_column(out, start, tw);
 
     // Build the ElementLayout from the AST, recursively converting each child via
     // the faithful port (`node_to_child` bails on any unsupported child).
@@ -324,7 +326,13 @@ pub(super) fn try_children_port(
         omit_softline_allowed: omit_softline_allowed(out, end),
     });
     let doc = crate::doc::propagate_breaks(doc);
-    let printed = crate::doc::print(&doc, line_width, unit.as_str(), base_level, start_col);
+    let printed = crate::doc::print(
+        &doc,
+        line_width,
+        IndentUnit::new(unit.as_str(), tw),
+        base_level,
+        start_col,
+    );
 
     // Corruption guard: the non-whitespace content must be byte-identical (the
     // port only ever changes whitespace/line breaks, never content). If it isn't,

--- a/crates/rsvelte_formatter/src/collapse/collect.rs
+++ b/crates/rsvelte_formatter/src/collapse/collect.rs
@@ -254,6 +254,7 @@ pub(super) fn collect(
                     elem.end,
                     &elem.fragment,
                     line_width,
+                    tab_width(options),
                 ) {
                     edits.push(edit);
                 } else if let Some(edit) = try_break_block_multiline_content(
@@ -486,9 +487,14 @@ pub(super) fn collect(
                 }
             }
             TemplateNode::EachBlock(blk) => {
-                if let Some(edit) =
-                    try_hug_block_inline_body(out, blk.start, blk.end, &blk.body, line_width)
-                {
+                if let Some(edit) = try_hug_block_inline_body(
+                    out,
+                    blk.start,
+                    blk.end,
+                    &blk.body,
+                    line_width,
+                    tab_width(options),
+                ) {
                     edits.push(edit);
                 } else {
                     collect(out, &blk.body, line_width, true, options, edits);
@@ -509,9 +515,14 @@ pub(super) fn collect(
                 }
             }
             TemplateNode::KeyBlock(blk) => {
-                if let Some(edit) =
-                    try_hug_block_inline_body(out, blk.start, blk.end, &blk.fragment, line_width)
-                {
+                if let Some(edit) = try_hug_block_inline_body(
+                    out,
+                    blk.start,
+                    blk.end,
+                    &blk.fragment,
+                    line_width,
+                    tab_width(options),
+                ) {
                     edits.push(edit);
                 } else {
                     collect(out, &blk.fragment, line_width, true, options, edits);
@@ -541,6 +552,7 @@ pub(super) fn try_collapse(
     options: &FormatOptions,
     node: Option<&TemplateNode>,
 ) -> Option<(u32, u32, String)> {
+    let tw = tab_width(options);
     let (s, e) = (start as usize, end as usize);
     let whole = out.get(s..e)?;
     // Pure text: every child is a Text node.
@@ -646,8 +658,8 @@ pub(super) fn try_collapse(
     }
     one_line.push_str(close);
 
-    let column = current_column(out, start);
-    if !one_line.contains('\n') && column + one_line.width() <= line_width {
+    let column = current_column(out, start, tw);
+    if !one_line.contains('\n') && column + one_line.visual_width(tw) <= line_width {
         return (one_line != whole).then_some((start, end, one_line));
     }
 
@@ -743,7 +755,10 @@ pub(super) fn try_collapse(
                 }
                 return None;
             }
-            let last_line_width = last_open_line.width() + collapsed.width() + 2 + tag.width();
+            let last_line_width = last_open_line.visual_width(tw)
+                + collapsed.visual_width(tw)
+                + 2
+                + tag.visual_width(tw);
             if last_line_width <= line_width {
                 // Fits: keep the `>` glued to the last attribute line.
                 let result = format!("{open}{collapsed}</{tag}\n{close_indent}>");
@@ -762,7 +777,11 @@ pub(super) fn try_collapse(
             } else {
                 open_no_bracket
             };
-            let hug_width = inner_indent.width() + 1 + collapsed.width() + 2 + tag.width();
+            let hug_width = inner_indent.visual_width(tw)
+                + 1
+                + collapsed.visual_width(tw)
+                + 2
+                + tag.visual_width(tw);
             if hug_width <= line_width {
                 let hug = format!("{prefix}\n{inner_indent}>{collapsed}</{tag}\n{close_indent}>");
                 return (hug != whole).then_some((start, end, hug));
@@ -771,15 +790,21 @@ pub(super) fn try_collapse(
             // across multiple lines at the inner indent level.
             // First line: `  >word1 word2…` (1 char for `>` reduces avail)
             // Continuation lines: `  word3 word4…`
-            let first_avail = line_width.saturating_sub(inner_indent.width() + 1).max(1);
-            let cont_avail = line_width.saturating_sub(inner_indent.width()).max(1);
+            let first_avail = line_width
+                .saturating_sub(inner_indent.visual_width(tw) + 1)
+                .max(1);
+            let cont_avail = line_width
+                .saturating_sub(inner_indent.visual_width(tw))
+                .max(1);
             let mut fill_lines: Vec<String> = Vec::new();
             let mut cur = String::new();
             let avail_for = |n: usize| if n == 0 { first_avail } else { cont_avail };
             for word in collapsed.split_whitespace() {
                 if cur.is_empty() {
                     cur.push_str(word);
-                } else if cur.width() + 1 + word.width() <= avail_for(fill_lines.len()) {
+                } else if cur.visual_width(tw) + 1 + word.visual_width(tw)
+                    <= avail_for(fill_lines.len())
+                {
                     cur.push(' ');
                     cur.push_str(word);
                 } else {
@@ -832,15 +857,23 @@ pub(super) fn try_collapse(
         } else {
             0
         };
-        let same_line_width =
-            column + open.width() + collapsed.width() + 2 + tag.width() + trailing_edge_extra;
+        let same_line_width = column
+            + open.visual_width(tw)
+            + collapsed.visual_width(tw)
+            + 2
+            + tag.visual_width(tw)
+            + trailing_edge_extra;
         if same_line_width <= line_width {
             let result = format!("{open}{collapsed}</{tag}\n{indent}>");
             return (result != whole).then_some((start, end, result));
         }
         // Inner-indent hug: open tag wraps so `>` moves to the next indented line
         // and content glues directly to it: `<a\n  href="…"\n  >text</a\n>`.
-        let hug_width = inner_indent.width() + 1 + collapsed.width() + 2 + tag.width();
+        let hug_width = inner_indent.visual_width(tw)
+            + 1
+            + collapsed.visual_width(tw)
+            + 2
+            + tag.visual_width(tw);
         if hug_width > line_width {
             // Content is too long even for the hug path (no single line fits).
             // Use Doc IR to express prettier's `hugStart && hugEnd` with a `Fill`
@@ -894,12 +927,12 @@ pub(super) fn try_collapse(
                             .take_while(|&b| b == b' ' || b == b'\t')
                             .count()
                     } else {
-                        indent.width() / indent_width
+                        indent.visual_width(tw) / indent_width
                     };
                     let printed = crate::doc::print(
                         &elem_doc,
                         line_width,
-                        indent_unit.as_str(),
+                        IndentUnit::new(indent_unit.as_str(), tw),
                         base_level,
                         column,
                     );
@@ -936,11 +969,13 @@ pub(super) fn try_collapse(
     }
     let (indent_unit_tc, _) = indent_config(options);
     let inner_indent = format!("{indent}{indent_unit_tc}");
-    let avail = line_width.saturating_sub(inner_indent.width()).max(1);
+    let avail = line_width
+        .saturating_sub(inner_indent.visual_width(tw))
+        .max(1);
 
     let mut broken = String::with_capacity(whole.len() + 8);
     broken.push_str(open);
-    for line in fill(&collapsed, avail) {
+    for line in fill(&collapsed, avail, tw) {
         broken.push('\n');
         broken.push_str(&inner_indent);
         broken.push_str(&line);

--- a/crates/rsvelte_formatter/src/collapse/doc_build.rs
+++ b/crates/rsvelte_formatter/src/collapse/doc_build.rs
@@ -255,7 +255,8 @@ pub(super) fn content_tag_breakable_doc(
     // inner width, mirroring `try_break_inline_content_tag`); continuation lines
     // carry oxc's own relative indent measured from column 0, which the `RawExpr`
     // printer offsets by the current indent level.
-    let width = UnicodeWidthStr::width(flat_inner.as_str())
+    let width = flat_inner
+        .visual_width(tab_width(options))
         .saturating_sub(1)
         .max(1);
     let broken_inner =
@@ -643,7 +644,7 @@ pub(super) fn build_self_closing_component_doc(
         Doc::Text("/>".to_string()), // no leading space: the `dedent(line)` provides it
     ]);
     // Guard: the flat print must match the verbatim span (trimmed).
-    let flat = crate::doc::print(&doc, 999999, "  ", 0, 0);
+    let flat = crate::doc::print(&doc, 999999, IndentUnit::new("  ", 2), 0, 0);
     if flat.trim() != span.trim() {
         return None;
     }
@@ -699,7 +700,7 @@ pub(super) fn build_self_closing_regular_doc(
     // Guard: the flat form must equal the canonical single-line `<tag a b c />`
     // so this never changes bytes when the element already fits on one line.
     let expected = format!("<{tag} {flat_attrs} />");
-    let flat = crate::doc::print(&doc, 999_999, "  ", 0, 0);
+    let flat = crate::doc::print(&doc, 999_999, IndentUnit::new("  ", 2), 0, 0);
     if flat != expected {
         return None;
     }
@@ -753,7 +754,7 @@ pub(super) fn build_void_element_doc(
     } else {
         format!("<{tag} {flat_attrs} />")
     };
-    let flat = crate::doc::print(&doc, 999_999, "  ", 0, 0);
+    let flat = crate::doc::print(&doc, 999_999, IndentUnit::new("  ", 2), 0, 0);
     if flat != expected {
         return None;
     }
@@ -948,7 +949,8 @@ pub(super) fn element_doc(out: &str, node: &TemplateNode) -> Option<crate::doc::
                         // so leading/trailing space differences don't cause a spurious
                         // mismatch — the surrounding `>` / `</{tag}` wrappers are
                         // structural and don't vary.
-                        let flat_body = crate::doc::print(&body, 1_000_000, "  ", 0, 0);
+                        let flat_body =
+                            crate::doc::print(&body, 1_000_000, IndentUnit::new("  ", 2), 0, 0);
                         if flat_body.trim() == content.trim() {
                             // Re-inject leading/trailing whitespace that
                             // `build_children_doc_nodes` trims from the first/last
@@ -1022,7 +1024,7 @@ pub(super) fn element_doc(out: &str, node: &TemplateNode) -> Option<crate::doc::
             // 0-regression: only switch when the body prints flat-identically to
             // `content` (modulo boundary trimming by build_children_doc_nodes).
             let inner_body_doc = build_children_doc(out, &e.fragment).and_then(|body| {
-                let flat_body = crate::doc::print(&body, 1_000_000, "  ", 0, 0);
+                let flat_body = crate::doc::print(&body, 1_000_000, IndentUnit::new("  ", 2), 0, 0);
                 if flat_body.trim() == content.trim() {
                     let recursive_content = Doc::Concat(vec![
                         Doc::Text(">".to_string()),

--- a/crates/rsvelte_formatter/src/collapse/fill.rs
+++ b/crates/rsvelte_formatter/src/collapse/fill.rs
@@ -146,6 +146,7 @@ pub(super) fn try_fill_run(
     allow_elem_expr_collapse: bool,
     options: &FormatOptions,
 ) -> Option<(u32, u32, String)> {
+    let tw = tab_width(options);
     let (indent_unit, indent_width) = indent_config(options);
     // Trim whitespace-only edge text nodes — the surrounding layout owns them.
     let mut lo = 0;
@@ -274,7 +275,7 @@ pub(super) fn try_fill_run(
     if non_ws_prefix && !is_close_tag_prefix {
         return None;
     }
-    let indent_cols = indent.width();
+    let indent_cols = indent.visual_width(tw);
     // For close-tag prefixes, derive base_level from just the whitespace bytes
     // before the `>` or `> ` tail, not from indent_cols (which includes the tag
     // characters). This ensures continuation lines align with the parent element's
@@ -347,8 +348,14 @@ pub(super) fn try_fill_run(
         _ => content_doc,
     };
     // Flat width (a hardline forces multi-line).
-    let flat = crate::doc::print_flat(&content_doc, 1_000_000, indent_unit.as_str(), base_level, 0);
-    if !flat.contains('\n') && indent_cols + flat.width() <= line_width {
+    let flat = crate::doc::print_flat(
+        &content_doc,
+        1_000_000,
+        IndentUnit::new(indent_unit.as_str(), tw),
+        base_level,
+        0,
+    );
+    if !flat.contains('\n') && indent_cols + flat.visual_width(tw) <= line_width {
         // Fits on one line — collapse to the flat form. The input run may itself
         // be multi-line (e.g. root-level prose written one word per line), and
         // prettier reflows prose that fits onto a single line, so we must emit the
@@ -363,7 +370,7 @@ pub(super) fn try_fill_run(
     let printed_raw = crate::doc::print(
         &content_doc,
         line_width,
-        indent_unit.as_str(),
+        IndentUnit::new(indent_unit.as_str(), tw),
         base_level,
         indent_cols,
     );
@@ -392,7 +399,7 @@ pub(super) fn try_fill_run(
     // the collapse has no useful layout to offer; return None so the
     // element-level passes (try_collapse / try_hug_mixed) own the elements
     // individually.
-    if !printed.contains('\n') && indent_cols + printed.width() > line_width {
+    if !printed.contains('\n') && indent_cols + printed.visual_width(tw) > line_width {
         return None;
     }
     (printed != whole).then_some((s as u32, e as u32, printed))
@@ -400,13 +407,13 @@ pub(super) fn try_fill_run(
 
 /// Greedy word-wrap `text` into lines no wider than `width` (each line keeps at
 /// least one word). Mirrors prettier's fill for inline text content.
-pub(super) fn fill(text: &str, width: usize) -> Vec<String> {
+pub(super) fn fill(text: &str, width: usize, tw: usize) -> Vec<String> {
     let mut lines = Vec::new();
     let mut cur = String::new();
     for word in text.split(' ').filter(|w| !w.is_empty()) {
         if cur.is_empty() {
             cur.push_str(word);
-        } else if cur.width() + 1 + word.width() <= width {
+        } else if cur.visual_width(tw) + 1 + word.visual_width(tw) <= width {
             cur.push(' ');
             cur.push_str(word);
         } else {
@@ -438,6 +445,7 @@ pub(super) fn try_fill_mixed(
     line_width: usize,
     options: &FormatOptions,
 ) -> Option<(u32, u32, String)> {
+    let tw = tab_width(options);
     let (s, e) = (start as usize, end as usize);
     let whole = out.get(s..e)?;
     // Must be mixed (at least one non-text child) and entirely inline.
@@ -494,7 +502,7 @@ pub(super) fn try_fill_mixed(
             .take_while(|&b| b == b' ' || b == b'\t')
             .count()
     } else {
-        inner_indent.width() / indent_width
+        inner_indent.visual_width(tw) / indent_width
     };
 
     // Decide flat-vs-break from the element's *flat* width, not the laid-out
@@ -503,8 +511,14 @@ pub(super) fn try_fill_mixed(
     // content all-flat (a huge width) to measure: a `hardline` (a source blank
     // line) still forces a newline, so flat content with a `\n` is inherently
     // multi-line and must break.
-    let flat = crate::doc::print_flat(&content_doc, 1_000_000, indent_unit.as_str(), base_level, 0);
-    let column = current_column(out, start);
+    let flat = crate::doc::print_flat(
+        &content_doc,
+        1_000_000,
+        IndentUnit::new(indent_unit.as_str(), tw),
+        base_level,
+        0,
+    );
+    let column = current_column(out, start, tw);
 
     // A non-text child that is already multi-line in the output forces the content
     // to break: the fill cannot keep that child on one line, so its surrounding
@@ -537,7 +551,8 @@ pub(super) fn try_fill_mixed(
         // Multi-line source (boundary whitespace is newline + indent) is left alone —
         // the indent pass owns those elements.
         if is_block_display(tag) && (had_lead || had_trail) && !raw.contains('\n') {
-            let element_one_line = column + open.width() + flat.width() + close.width();
+            let element_one_line =
+                column + open.visual_width(tw) + flat.visual_width(tw) + close.visual_width(tw);
             if element_one_line <= line_width {
                 let one_line = format!("{open}{flat}{close}");
                 return (one_line != whole).then_some((start, end, one_line));
@@ -556,7 +571,8 @@ pub(super) fn try_fill_mixed(
                 |n| !matches!(n, TemplateNode::Text(t) if crate::is_blank_text(t.data.as_ref())),
             )
             .count();
-        let element_one_line = column + open.width() + flat.width() + close.width();
+        let element_one_line =
+            column + open.visual_width(tw) + flat.visual_width(tw) + close.visual_width(tw);
         if is_block_display(tag) && non_ws_child_count > 1 && element_one_line > line_width {
             // Fall through to the doc-print break path below.
         } else {
@@ -565,7 +581,8 @@ pub(super) fn try_fill_mixed(
     }
 
     if !flat.contains('\n') && !has_multiline_child {
-        let element_one_line = column + open.width() + flat.width() + close.width();
+        let element_one_line =
+            column + open.visual_width(tw) + flat.visual_width(tw) + close.visual_width(tw);
         // A block element (or overflowing component with prose content) puts its
         // content on its own line; an inline HTML element would instead hug, so
         // leave those. Components with block-like (newline-bounded) content that
@@ -591,9 +608,9 @@ pub(super) fn try_fill_mixed(
     let mut printed = crate::doc::print(
         &content_doc,
         line_width,
-        indent_unit.as_str(),
+        IndentUnit::new(indent_unit.as_str(), tw),
         base_level,
-        inner_indent.width(),
+        inner_indent.visual_width(tw),
     );
 
     // Post-pass: a trailing content mustache `{call(...)}` that is glued to the
@@ -614,18 +631,21 @@ pub(super) fn try_fill_mixed(
             .and_then(|s| s.strip_suffix('}'))
             .map(str::trim)
             .unwrap_or("");
-        let mcol = inner_indent.width() + printed.width().saturating_sub(mspan.width());
+        let mcol = inner_indent.visual_width(tw)
+            + printed
+                .visual_width(tw)
+                .saturating_sub(mspan.visual_width(tw));
         // Only a call / member chain (not an object / array / arrow literal) wraps
         // by breaking its own internals; leave those to other paths.
         let wrappable =
             !inner.is_empty() && !inner.contains("=>") && !inner.starts_with(['{', '[']);
-        if glued_after_nonspace && wrappable && mcol + mspan.width() > line_width {
+        if glued_after_nonspace && wrappable && mcol + mspan.visual_width(tw) > line_width {
             let w = line_width.saturating_sub(mcol + 2); // `{` + `}`
             if let Ok(wrapped) = crate::expression::reformat_content_at_width(
                 inner,
                 options,
                 w,
-                inner_indent.width(),
+                inner_indent.visual_width(tw),
             ) && wrapped.contains('\n')
             {
                 let head = &printed[..printed.len() - mspan.len()];

--- a/crates/rsvelte_formatter/src/collapse/hug.rs
+++ b/crates/rsvelte_formatter/src/collapse/hug.rs
@@ -190,6 +190,7 @@ pub(super) fn try_hug_block_inline_body(
     end: u32,
     body: &Fragment,
     line_width: usize,
+    tw: usize,
 ) -> Option<(u32, u32, String)> {
     let (s, e) = (start as usize, end as usize);
     let whole = out.get(s..e)?;
@@ -217,7 +218,7 @@ pub(super) fn try_hug_block_inline_body(
     if !indent.bytes().all(|b| b == b' ' || b == b'\t') {
         return None;
     }
-    if indent.width() + whole.width() <= line_width {
+    if indent.visual_width(tw) + whole.visual_width(tw) <= line_width {
         return None; // fits on one line
     }
     let prefix = out.get(s..elem_start)?; // block open tag (+ no leading ws)
@@ -245,6 +246,7 @@ pub(super) fn try_hug_mixed(
     line_width: usize,
     options: &FormatOptions,
 ) -> Option<(u32, u32, String)> {
+    let tw = tab_width(options);
     let (indent_unit_hm, indent_width_hm) = indent_config(options);
     // Inline elements hug (prettier's `blockElements` excludes button/input/…),
     // so only true block elements and raw-text elements are ineligible.
@@ -417,7 +419,7 @@ pub(super) fn try_hug_mixed(
     {
         return None;
     }
-    let column = current_column(out, start);
+    let column = current_column(out, start, tw);
 
     let line_start = out[..s].rfind('\n').map_or(0, |i| i + 1);
     let indent = out.get(line_start..s)?;
@@ -489,9 +491,9 @@ pub(super) fn try_hug_mixed(
         // element's real start column) in that case so we don't incorrectly
         // collapse elements whose merged line would exceed `line_width`.
         let glued = if non_ws_prefix {
-            column + 1 + raw.width() + 2 + tag.width()
+            column + 1 + raw.visual_width(tw) + 2 + tag.visual_width(tw)
         } else {
-            last_line.width() + 1 + raw.width() + 2 + tag.width()
+            last_line.visual_width(tw) + 1 + raw.visual_width(tw) + 2 + tag.visual_width(tw)
         };
         if glued <= line_width {
             let result = format!("{onb}>{raw}</{tag}\n{ws_indent}>");
@@ -516,7 +518,8 @@ pub(super) fn try_hug_mixed(
         // tag `</tag` (prettier's `group(['>', body, '</tag'])`) so the printer's fits
         // lookahead counts its width — otherwise a child whose own attrs fit but
         // overflow once the close tag is appended never breaks.
-        let inner_line = inner_indent.width() + 1 + raw.width() + 2 + tag.width();
+        let inner_line =
+            inner_indent.visual_width(tw) + 1 + raw.visual_width(tw) + 2 + tag.visual_width(tw);
         if !raw_trail_ws_only
             && inner_line > line_width
             && !raw.contains('\n')
@@ -528,7 +531,7 @@ pub(super) fn try_hug_mixed(
                     .take_while(|&b| b == b' ' || b == b'\t')
                     .count()
             } else {
-                inner_indent.width() / indent_width_hm
+                inner_indent.visual_width(tw) / indent_width_hm
             };
             let measured = crate::doc::Doc::Group(vec![
                 crate::doc::Doc::Text(">".to_string()),
@@ -538,9 +541,9 @@ pub(super) fn try_hug_mixed(
             let printed_full = crate::doc::print(
                 &measured,
                 line_width,
-                indent_unit_hm.as_str(),
+                IndentUnit::new(indent_unit_hm.as_str(), tw),
                 base_level,
-                inner_indent.width(),
+                inner_indent.visual_width(tw),
             );
             if printed_full.contains('\n') {
                 let result2 = format!("{onb}\n{inner_indent}{printed_full}\n{ws_indent}>");
@@ -557,19 +560,19 @@ pub(super) fn try_hug_mixed(
         // to break.
         let body_opt = build_children_doc(out, fragment);
         if let Some(body) = body_opt {
-            let inner_col = inner_indent.width() + 1; // column after the `>`
+            let inner_col = inner_indent.visual_width(tw) + 1; // column after the `>`
             let base_level = if options.js.indent_style.is_tab() {
                 inner_indent
                     .bytes()
                     .take_while(|&b| b == b' ' || b == b'\t')
                     .count()
             } else {
-                inner_indent.width() / indent_width_hm
+                inner_indent.visual_width(tw) / indent_width_hm
             };
             let printed = crate::doc::print(
                 &body,
                 line_width,
-                indent_unit_hm.as_str(),
+                IndentUnit::new(indent_unit_hm.as_str(), tw),
                 base_level,
                 inner_col,
             );
@@ -590,10 +593,11 @@ pub(super) fn try_hug_mixed(
         //   - The raw content (all on one line) ends with `>`.
         //   - Removing the trailing `>` makes the inner line fit.
         //   - The result differs from the current form.
-        let full_inner = inner_indent.width() + 1 + raw.width() + 2 + tag.width();
+        let full_inner =
+            inner_indent.visual_width(tw) + 1 + raw.visual_width(tw) + 2 + tag.visual_width(tw);
         if full_inner > line_width && !raw.contains('\n') && raw.ends_with('>') {
             let raw_deferred = &raw[..raw.len() - 1]; // trim the trailing `>`
-            let deferred_inner = inner_indent.width() + 1 + raw_deferred.width();
+            let deferred_inner = inner_indent.visual_width(tw) + 1 + raw_deferred.visual_width(tw);
             if deferred_inner <= line_width {
                 let result3 = format!(
                     "{onb}\n{inner_indent}>{raw_deferred}\n{inner_indent}></{tag}\n{ws_indent}>"
@@ -606,7 +610,8 @@ pub(super) fn try_hug_mixed(
         return None;
     }
 
-    let element_one_line = column + open.width() + raw.width() + close.width();
+    let element_one_line =
+        column + open.visual_width(tw) + raw.visual_width(tw) + close.visual_width(tw);
     if element_one_line <= line_width && !has_flow_block {
         return None; // fits as-is (and no forced break needed)
     }
@@ -659,12 +664,12 @@ pub(super) fn try_hug_mixed(
             .take_while(|&b| b == b' ' || b == b'\t')
             .count()
     } else {
-        ws_indent.width() / indent_width_hm
+        ws_indent.visual_width(tw) / indent_width_hm
     };
     let printed = crate::doc::print(
         &elem_doc,
         line_width,
-        indent_unit_hm.as_str(),
+        IndentUnit::new(indent_unit_hm.as_str(), tw),
         level,
         column,
     );

--- a/crates/rsvelte_formatter/src/collapse/mod.rs
+++ b/crates/rsvelte_formatter/src/collapse/mod.rs
@@ -16,10 +16,10 @@
 
 use rsvelte_core::ast::template::{Fragment, Root, TemplateNode};
 use rsvelte_core::{ParseOptions, parse};
-use unicode_width::UnicodeWidthStr;
 
 use crate::error::FormatError;
 use crate::options::FormatOptions;
+use crate::width::{IndentUnit, VisualWidth, tab_width};
 
 mod breaks;
 mod children_port;
@@ -106,7 +106,7 @@ pub(crate) fn collapse_pure_text_elements(
         && !out.contains("<textarea")
         && !out
             .lines()
-            .any(|l| UnicodeWidthStr::width(l) > options.js.line_width.value() as usize)
+            .any(|l| l.visual_width(tab_width(options)) > options.js.line_width.value() as usize)
     {
         return Ok(out.to_string());
     }
@@ -143,6 +143,7 @@ pub(crate) fn collapse_pure_text_elements(
         return Ok(out.to_string());
     };
     let line_width = options.js.line_width.value() as usize;
+    let tw = tab_width(options);
 
     // `tree` always reflects `result`. Each pass re-parses ONLY after it actually
     // edits the text — a pass that makes no edits leaves the string (and thus its
@@ -221,6 +222,7 @@ pub(crate) fn collapse_pure_text_elements(
         &result,
         &tree.as_ref().unwrap_or(&root).fragment,
         line_width,
+        tw,
         &mut edits1e,
     );
     if !edits1e.is_empty() {
@@ -243,6 +245,7 @@ pub(crate) fn collapse_pure_text_elements(
         &result,
         &tree.as_ref().unwrap_or(&root).fragment,
         line_width,
+        tw,
         &mut edits1f,
     );
     if !edits1f.is_empty() {
@@ -262,6 +265,7 @@ pub(crate) fn collapse_pure_text_elements(
         &result,
         &tree.as_ref().unwrap_or(&root).fragment,
         line_width,
+        tw,
         &mut edits1g,
     );
     if !edits1g.is_empty() {

--- a/crates/rsvelte_formatter/src/collapse/open_tag.rs
+++ b/crates/rsvelte_formatter/src/collapse/open_tag.rs
@@ -21,6 +21,7 @@ pub(super) fn collect_break_inline_open_tag(
     out: &str,
     fragment: &Fragment,
     line_width: usize,
+    tw: usize,
     edits: &mut Vec<(u32, u32, String)>,
 ) {
     for (node_idx, node) in fragment.nodes.iter().enumerate() {
@@ -47,6 +48,7 @@ pub(super) fn collect_break_inline_open_tag(
                         e.start,
                         e.end,
                         line_width,
+                        tw,
                     )
                 {
                     edits.push(edit);
@@ -65,6 +67,7 @@ pub(super) fn collect_break_inline_open_tag(
                         e.end,
                         &e.fragment,
                         line_width,
+                        tw,
                     )
                 {
                     // A whole-element edit (`edit.1 == e.end`) rewrites the tag
@@ -80,7 +83,7 @@ pub(super) fn collect_break_inline_open_tag(
                         continue;
                     }
                 }
-                collect_break_inline_open_tag(out, &e.fragment, line_width, edits);
+                collect_break_inline_open_tag(out, &e.fragment, line_width, tw, edits);
             }
             TemplateNode::Component(c) => {
                 let mut whole_element = false;
@@ -92,17 +95,18 @@ pub(super) fn collect_break_inline_open_tag(
                     c.end,
                     &c.fragment,
                     line_width,
+                    tw,
                 ) {
                     whole_element = edit.1 == c.end;
                     edits.push(edit);
                 }
                 if !whole_element {
-                    collect_break_inline_open_tag(out, &c.fragment, line_width, edits);
+                    collect_break_inline_open_tag(out, &c.fragment, line_width, tw, edits);
                 }
             }
             _ => {
                 for child in child_fragments(node) {
-                    collect_break_inline_open_tag(out, child, line_width, edits);
+                    collect_break_inline_open_tag(out, child, line_width, tw, edits);
                 }
             }
         }
@@ -120,6 +124,7 @@ pub(super) fn try_break_inline_open_tag(
     elem_end: u32,
     fragment: &Fragment,
     line_width: usize,
+    tw: usize,
 ) -> Option<(u32, u32, String)> {
     // Must have attributes to break. Zero-attribute elements in hug_start=true
     // contexts can't be broken safely without tree-level indent information.
@@ -149,7 +154,7 @@ pub(super) fn try_break_inline_open_tag(
     let line = out.get(line_start..line_end)?;
 
     // Line must overflow.
-    if line.width() <= line_width {
+    if line.visual_width(tw) <= line_width {
         return None;
     }
 
@@ -254,7 +259,7 @@ pub(super) fn try_break_inline_open_tag(
         // Check if Option B fits: `{before}<tag attr1 attrN` (no `>`) ≤ line_width.
         // We use the open_tag minus the trailing `>` character.
         let open_tag_without_angle = open_tag.strip_suffix('>')?;
-        let option_b_prefix_len = before.width() + open_tag_without_angle.width();
+        let option_b_prefix_len = before.visual_width(tw) + open_tag_without_angle.visual_width(tw);
 
         let broken = if option_b_prefix_len <= line_width {
             // Option B: keep `<tag attrs` on the current line, break at `>`.
@@ -312,6 +317,7 @@ pub(super) fn try_break_empty_block_open_tag(
     elem_start: u32,
     elem_end: u32,
     line_width: usize,
+    tw: usize,
 ) -> Option<(u32, u32, String)> {
     let s = elem_start as usize;
 
@@ -332,7 +338,7 @@ pub(super) fn try_break_empty_block_open_tag(
     let line = out.get(line_start..line_end)?;
 
     // Line must overflow.
-    if line.width() <= line_width {
+    if line.visual_width(tw) <= line_width {
         return None;
     }
 
@@ -371,6 +377,7 @@ pub(super) fn collect_recollapse_open_tag(
     out: &str,
     fragment: &Fragment,
     line_width: usize,
+    tw: usize,
     edits: &mut Vec<(u32, u32, String)>,
 ) {
     for (node_idx, node) in fragment.nodes.iter().enumerate() {
@@ -390,10 +397,11 @@ pub(super) fn collect_recollapse_open_tag(
                     e.start,
                     &e.fragment,
                     line_width,
+                    tw,
                 ) {
                     edits.push(edit);
                 }
-                collect_recollapse_open_tag(out, &e.fragment, line_width, edits);
+                collect_recollapse_open_tag(out, &e.fragment, line_width, tw, edits);
             }
             TemplateNode::Component(c) => {
                 if let Some(edit) = try_recollapse_open_tag(
@@ -403,14 +411,15 @@ pub(super) fn collect_recollapse_open_tag(
                     c.start,
                     &c.fragment,
                     line_width,
+                    tw,
                 ) {
                     edits.push(edit);
                 }
-                collect_recollapse_open_tag(out, &c.fragment, line_width, edits);
+                collect_recollapse_open_tag(out, &c.fragment, line_width, tw, edits);
             }
             _ => {
                 for child in child_fragments(node) {
-                    collect_recollapse_open_tag(out, child, line_width, edits);
+                    collect_recollapse_open_tag(out, child, line_width, tw, edits);
                 }
             }
         }
@@ -424,6 +433,7 @@ pub(super) fn try_recollapse_open_tag(
     elem_start: u32,
     fragment: &Fragment,
     line_width: usize,
+    tw: usize,
 ) -> Option<(u32, u32, String)> {
     if attrs.is_empty() {
         return None;
@@ -478,8 +488,8 @@ pub(super) fn try_recollapse_open_tag(
     single_line.push('>');
 
     // Check if single-line form fits at the element's current column.
-    let col = before.width();
-    if col + single_line.width() > line_width {
+    let col = before.visual_width(tw);
+    if col + single_line.visual_width(tw) > line_width {
         return None;
     }
 

--- a/crates/rsvelte_formatter/src/collapse/pre.rs
+++ b/crates/rsvelte_formatter/src/collapse/pre.rs
@@ -838,6 +838,7 @@ pub(super) fn try_break_pre_content_tag(
     line_width: usize,
     options: &FormatOptions,
 ) -> Option<(u32, u32, String)> {
+    let tw = tab_width(options);
     // Exactly one child, an expression tag (the only content-tag kind that
     // appears glued inside `<pre>` / `<textarea>` in practice).
     if fragment.nodes.len() != 1 {
@@ -859,8 +860,9 @@ pub(super) fn try_break_pre_content_tag(
     if open.contains('\n') || span.contains('\n') || span.len() <= 2 {
         return None;
     }
-    let column = current_column(out, start);
-    if column + open.width() + span.width() + close.width() <= line_width {
+    let column = current_column(out, start, tw);
+    if column + open.visual_width(tw) + span.visual_width(tw) + close.visual_width(tw) <= line_width
+    {
         return None; // fits on one line
     }
     let line_start = out[..s].rfind('\n').map_or(0, |i| i + 1);
@@ -871,11 +873,11 @@ pub(super) fn try_break_pre_content_tag(
     // Continuation lines sit one indent level past the element; the expression
     // formatter adds its own level for the broken binary on top of that.
     let iw = options.js.indent_width.value() as usize;
-    let cont_cols = indent.width() + iw;
+    let cont_cols = indent.visual_width(tw) + iw;
     let inner = span.get(1..span.len() - 1)?.trim(); // strip the `{` … `}`
     // Force the top-level expression to break: the last line carries `}</pre>`,
     // which oxc can't see, so narrow the width by that glued suffix.
-    let suffix = 1 + close.width(); // `}` + `</tag>`
+    let suffix = 1 + close.visual_width(tw); // `}` + `</tag>`
     let width = line_width.saturating_sub(cont_cols + suffix).max(1);
     let wrapped =
         crate::expression::reformat_content_at_width(inner, options, width, cont_cols).ok()?;
@@ -907,6 +909,7 @@ pub(super) fn try_break_pre_own_attrs(
     line_width: usize,
     options: &FormatOptions,
 ) -> Option<(u32, u32, String)> {
+    let tw = tab_width(options);
     let (s, e) = (start as usize, end as usize);
     let whole = out.get(s..e)?;
     // Only single-line elements.
@@ -919,8 +922,8 @@ pub(super) fn try_break_pre_own_attrs(
     if !indent.bytes().all(|b| b == b' ' || b == b'\t') {
         return None;
     }
-    let column = indent.width();
-    if column + whole.width() <= line_width {
+    let column = indent.visual_width(tw);
+    if column + whole.visual_width(tw) <= line_width {
         return None;
     }
     // Prefer breaking a child element's open tag over the `<pre>`'s own attrs:
@@ -1082,17 +1085,18 @@ pub(super) fn try_fix_pre_child_open_tags(
     line_width: usize,
     options: &FormatOptions,
 ) -> Vec<(u32, u32, String)> {
+    let tw = tab_width(options);
     let mut edits = Vec::new();
     // Determine the `<pre>` element's leading indent column.
     let pre_s = pre_start as usize;
     let pre_line_start = out[..pre_s].rfind('\n').map_or(0, |i| i + 1);
     let pre_leading = &out[pre_line_start..pre_s];
     let pre_indent_col = if pre_leading.bytes().all(|b| b == b' ' || b == b'\t') {
-        pre_leading.width()
+        pre_leading.visual_width(tw)
     } else {
         // `<pre>` does not start at the beginning of its line (e.g. it directly
         // follows another element). Use its actual column.
-        current_column(out, pre_start)
+        current_column(out, pre_start, tw)
     };
     let iw = options.js.indent_width.value() as usize;
 
@@ -1143,7 +1147,7 @@ pub(super) fn try_fix_pre_child_open_tags(
             // line overflows — a short single-line child (`<code class="x">y</code>`)
             // stays glued.
             let content_multiline = out.get(open_end..ce).is_some_and(|c| c.contains('\n'));
-            if line.width() <= line_width && !content_multiline {
+            if line.visual_width(tw) <= line_width && !content_multiline {
                 continue; // fits on one line and single-line content — no action
             }
             // Drop `>` to a new indented line.  The indent sits two levels

--- a/crates/rsvelte_formatter/src/collapse/tests.rs
+++ b/crates/rsvelte_formatter/src/collapse/tests.rs
@@ -247,7 +247,7 @@ fn hug_close_tag_width_drives_inner_component_break() {
     let body = || Doc::Concat(vec![Doc::Text("Clear ".to_string()), icon()]);
 
     // Body alone from col 15 ends at 78 <= 80: the Icon must stay flat.
-    let a = print(&body(), 80, "  ", 7, 15);
+    let a = print(&body(), 80, IndentUnit::new("  ", 2), 7, 15);
     assert_eq!(
         a,
         "Clear <Icon data={TrashIcon} class=\"text-surface-content/50\" />"
@@ -261,7 +261,7 @@ fn hug_close_tag_width_drives_inner_component_break() {
         body(),
         Doc::Text("</button".to_string()),
     ]);
-    let b = print(&measured, 80, "  ", 7, 14);
+    let b = print(&measured, 80, IndentUnit::new("  ", 2), 7, 14);
     let expected = "\
 >Clear <Icon
                 data={TrashIcon}

--- a/crates/rsvelte_formatter/src/collapse/util.rs
+++ b/crates/rsvelte_formatter/src/collapse/util.rs
@@ -151,10 +151,10 @@ pub(super) fn text_end(node: &TemplateNode) -> Option<u32> {
 }
 
 /// Visual column where `pos` sits (width of its line's prefix).
-pub(super) fn current_column(out: &str, pos: u32) -> usize {
+pub(super) fn current_column(out: &str, pos: u32, tab_width: usize) -> usize {
     let pos = pos as usize;
     let line_start = out[..pos].rfind('\n').map_or(0, |i| i + 1);
-    out[line_start..pos].width()
+    out[line_start..pos].visual_width(tab_width)
 }
 
 /// Elements whose default CSS display is block / list-item — prettier trims the

--- a/crates/rsvelte_formatter/src/doc.rs
+++ b/crates/rsvelte_formatter/src/doc.rs
@@ -8,7 +8,7 @@
 //! between an inline hug and a fresh-line break depends on column-aware
 //! measurement of the surrounding content.
 
-use unicode_width::UnicodeWidthStr;
+use crate::width::{IndentUnit, VisualWidth};
 
 // Several variants below (`Literalline`, `ForcedGroup`, `Dedent`, `BreakParent`)
 // and `propagate_breaks` are the IR scaffolding for the prettier-plugin-svelte
@@ -71,7 +71,7 @@ enum Mode {
 pub(crate) fn print(
     doc: &Doc,
     width: usize,
-    unit: &str,
+    unit: IndentUnit,
     base_indent: usize,
     start_col: usize,
 ) -> String {
@@ -84,7 +84,7 @@ pub(crate) fn print(
 pub(crate) fn print_flat(
     doc: &Doc,
     width: usize,
-    unit: &str,
+    unit: IndentUnit,
     base_indent: usize,
     start_col: usize,
 ) -> String {
@@ -102,7 +102,7 @@ enum Cmd<'a> {
 fn print_inner(
     doc: &Doc,
     width: usize,
-    unit: &str,
+    unit: IndentUnit,
     base_indent: usize,
     start_col: usize,
     start_mode: Mode,
@@ -115,13 +115,13 @@ fn print_inner(
         let (ind, mode, d) = match cmd {
             Cmd::Doc(ind, mode, d) => (ind, mode, d),
             Cmd::Fill(ind, mode, ps) => {
-                print_fill(ind, mode, ps, width, pos, &mut cmds);
+                print_fill(ind, mode, ps, width, pos, unit, &mut cmds);
                 continue;
             }
         };
         match d {
             Doc::Text(s) => {
-                pos += text_width(s);
+                pos += s.visual_width(unit.tab_width());
                 out.push_str(s);
             }
             Doc::Concat(ps) => {
@@ -162,12 +162,12 @@ fn print_inner(
             }
             Doc::RawExpr { flat, broken } => {
                 if mode == Mode::Flat || broken.len() <= 1 {
-                    pos += text_width(flat);
+                    pos += flat.visual_width(unit.tab_width());
                     out.push_str(flat);
                 } else {
                     let mut lines = broken.iter();
                     if let Some(first) = lines.next() {
-                        pos += text_width(first);
+                        pos += first.visual_width(unit.tab_width());
                         out.push_str(first);
                     }
                     for line in lines {
@@ -175,13 +175,13 @@ fn print_inner(
                         out.push('\n');
                         let pad_width = push_indent(&mut out, unit, ind);
                         out.push_str(line);
-                        pos = pad_width + text_width(line);
+                        pos = pad_width + line.visual_width(unit.tab_width());
                     }
                 }
             }
             Doc::BreakParent => {} // consumed by propagate_breaks; prints nothing
             Doc::Group(ps) => {
-                let flat = fits(width as isize - pos as isize, &cmds, ps);
+                let flat = fits(width as isize - pos as isize, &cmds, ps, unit);
                 let m = if flat { Mode::Flat } else { Mode::Break };
                 for p in ps.iter().rev() {
                     cmds.push(Cmd::Doc(ind, m, p));
@@ -211,6 +211,7 @@ fn print_fill<'a>(
     ps: &'a [Doc],
     width: usize,
     pos: usize,
+    unit: IndentUnit,
     cmds: &mut Vec<Cmd<'a>>,
 ) {
     if ps.is_empty() {
@@ -221,7 +222,7 @@ fn print_fill<'a>(
     // (an element) would make every word "not fit" and break the prose one word
     // per line.
     let remaining = width as isize - pos as isize;
-    let content_fits = fits(remaining, &[], &ps[..1]);
+    let content_fits = fits(remaining, &[], &ps[..1], unit);
     if ps.len() <= 2 {
         let m = if content_fits {
             Mode::Flat
@@ -235,7 +236,7 @@ fn print_fill<'a>(
     }
     // The content–separator–content triple is contiguous, so it can be measured
     // in place.
-    let pair_fits = fits(remaining, &[], &ps[..3]);
+    let pair_fits = fits(remaining, &[], &ps[..3], unit);
     cmds.push(Cmd::Fill(ind, mode, &ps[2..]));
     let content = &ps[0];
     let ws = &ps[1];
@@ -256,7 +257,7 @@ fn print_fill<'a>(
 /// of prettier's `doc.js` `fits`: a soft `line` defers a pending space that is
 /// only charged when a following string is emitted (so a trailing `line` costs
 /// nothing), and a hard/break line ends the measurement successfully.
-fn fits(mut remaining: isize, rest_stack: &[Cmd], next: &[Doc]) -> bool {
+fn fits(mut remaining: isize, rest_stack: &[Cmd], next: &[Doc], unit: IndentUnit) -> bool {
     // Measurement never mutates the tree, so the whole walk borrows: cloning a
     // `Doc` here would deep-copy the entire measured subtree (and every entry
     // pulled off `rest_stack`) on every group, which dominated `print`.
@@ -295,7 +296,7 @@ fn fits(mut remaining: isize, rest_stack: &[Cmd], next: &[Doc]) -> bool {
                         remaining -= 1;
                         has_pending_space = false;
                     }
-                    remaining -= text_width(s) as isize;
+                    remaining -= s.visual_width(unit.tab_width()) as isize;
                 }
             }
             // A pre-formatted interpolation. In `Flat` mode it is measured by
@@ -314,7 +315,7 @@ fn fits(mut remaining: isize, rest_stack: &[Cmd], next: &[Doc]) -> bool {
                         if has_pending_space {
                             remaining -= 1;
                         }
-                        remaining -= text_width(head) as isize;
+                        remaining -= head.visual_width(unit.tab_width()) as isize;
                     }
                     return remaining >= 0;
                 }
@@ -323,7 +324,7 @@ fn fits(mut remaining: isize, rest_stack: &[Cmd], next: &[Doc]) -> bool {
                         remaining -= 1;
                         has_pending_space = false;
                     }
-                    remaining -= text_width(flat) as isize;
+                    remaining -= flat.visual_width(unit.tab_width()) as isize;
                 }
             }
             Doc::Concat(ps)
@@ -365,25 +366,13 @@ fn fits(mut remaining: isize, rest_stack: &[Cmd], next: &[Doc]) -> bool {
     }
 }
 
-/// Display width of `s`, with a fast path for the printable-ASCII case that
-/// dominates markup (where one byte is exactly one column). Anything outside
-/// `0x20..0x7f` — control characters, which [`UnicodeWidthStr::width`] counts as
-/// zero, and every non-ASCII scalar — falls back to the full computation.
-fn text_width(s: &str) -> usize {
-    if s.bytes().all(|b| (0x20..0x7f).contains(&b)) {
-        s.len()
-    } else {
-        s.width()
-    }
-}
-
 /// Append `level` copies of `unit` without materialising an intermediate
 /// `String` (this runs on every emitted line break).
-fn push_indent(out: &mut String, unit: &str, level: usize) -> usize {
+fn push_indent(out: &mut String, unit: IndentUnit, level: usize) -> usize {
     for _ in 0..level {
-        out.push_str(unit);
+        out.push_str(unit.as_str());
     }
-    text_width(unit) * level
+    unit.columns() * level
 }
 
 fn trim_trailing_blanks(out: &mut String) {
@@ -460,7 +449,7 @@ mod tests {
     use super::*;
 
     fn p(doc: Doc, width: usize) -> String {
-        print(&doc, width, "  ", 0, 0)
+        print(&doc, width, IndentUnit::new("  ", 2), 0, 0)
     }
 
     #[test]
@@ -506,7 +495,7 @@ mod tests {
         // width 20 forces the fill's Line to break before the wide RawExpr, then
         // the RawExpr itself prints broken with its continuation at indent 0.
         assert_eq!(
-            print(&doc, 20, "  ", 0, 0),
+            print(&doc, 20, IndentUnit::new("  ", 2), 0, 0),
             "lead\n{averylongidentifier +\n  anotherlongidentifier}"
         );
     }

--- a/crates/rsvelte_formatter/src/expression/collect.rs
+++ b/crates/rsvelte_formatter/src/expression/collect.rs
@@ -1,5 +1,4 @@
 use rsvelte_core::ast::template::{Fragment, TemplateNode};
-use unicode_width::UnicodeWidthStr;
 
 use super::call_args;
 use super::declaration::format_pattern_source;
@@ -13,6 +12,7 @@ use super::splice::{
 use super::width::format_inline_expression;
 use crate::error::FormatError;
 use crate::options::FormatOptions;
+use crate::width::{VisualWidth, tab_width};
 
 /// The each-key source between its delimiter parens, or `None` when the block
 /// has no key. Used to measure how much the key widens the header line.
@@ -68,6 +68,7 @@ fn collect_node_edits(
     options: &FormatOptions,
     edits: &mut Vec<(u32, u32, String)>,
 ) -> Result<(), FormatError> {
+    let tw = tab_width(options);
     let child_depth = depth + 1;
     match node {
         TemplateNode::ExpressionTag(tag) => {
@@ -317,9 +318,9 @@ fn collect_node_edits(
                                     let full_width = options.js.line_width.value() as usize;
                                     let flat_width = depth
                                         * options.js.indent_width.value() as usize
-                                        + UnicodeWidthStr::width(prefix)
+                                        + prefix.visual_width(tw)
                                         + "(".len()
-                                        + UnicodeWidthStr::width(formatted.as_str())
+                                        + formatted.visual_width(tw)
                                         + ")}".len();
                                     // The oracle settles the header's groups left to
                                     // right, so the key is measured against whatever

--- a/crates/rsvelte_formatter/src/expression/declaration.rs
+++ b/crates/rsvelte_formatter/src/expression/declaration.rs
@@ -1,11 +1,11 @@
 use oxc_formatter::format_program;
 use oxc_parser::Parser;
 use oxc_span::SourceType;
-use unicode_width::UnicodeWidthStr;
 
 use super::formatter_parse_options;
 use crate::error::FormatError;
 use crate::options::FormatOptions;
+use crate::width::{VisualWidth, tab_width};
 
 /// Format the body of a `{@const <decl>}` tag — the `<decl>` is the body of a
 /// `const` variable declaration (`<binding>[: Type] = <init>`).
@@ -81,7 +81,7 @@ pub(super) fn format_const_declaration(
     let formatted = format_at(full_width.saturating_sub(lead))?;
     // `{@const ` (8) + body + `}` (1) at column `lead`.
     let formatted = if !formatted.contains('\n')
-        && lead + 9 + UnicodeWidthStr::width(formatted.as_str()) > full_width
+        && lead + 9 + formatted.visual_width(tab_width(options)) > full_width
     {
         format_at(full_width.saturating_sub(lead + 2))?
     } else {

--- a/crates/rsvelte_formatter/src/expression/directive.rs
+++ b/crates/rsvelte_formatter/src/expression/directive.rs
@@ -1,12 +1,12 @@
 use oxc_parser::Parser;
 use oxc_span::SourceType;
 use rsvelte_core::ast::js::Expression;
-use unicode_width::UnicodeWidthStr;
 
 use super::splice::split_leading_line_comments;
 use super::{format_attribute_value_expression, formatter_parse_options};
 use crate::error::FormatError;
 use crate::options::FormatOptions;
+use crate::width::{VisualWidth, tab_width};
 
 /// Format a directive value `{ EXPR }` by slicing the full brace interior
 /// from the source, where `value_end` is the offset just past the closing
@@ -200,6 +200,8 @@ pub(crate) fn format_function_binding(
 ) -> Result<Option<String>, FormatError> {
     use oxc_span::GetSpan;
 
+    let tw = tab_width(options);
+
     let Some(inner) = directive_brace_inner(source, expr, value_end) else {
         return Ok(None);
     };
@@ -287,7 +289,7 @@ pub(crate) fn format_function_binding(
     // extra `comment + 2` columns (2 for the parens) in the width check.
     let inline = members.join(", ");
     let comment_prefix_cols = leading_block_comment
-        .map(|(c, _)| UnicodeWidthStr::width(c) + 1 /* space */)
+        .map(|(c, _)| c.visual_width(tw) + 1 /* space */)
         .unwrap_or(0);
     // +2 for outer parens when there is a comment, +0 otherwise.
     let outer_parens_cols = if leading_block_comment.is_some() {
@@ -299,7 +301,7 @@ pub(crate) fn format_function_binding(
         + 1  // opening `{`
         + comment_prefix_cols
         + outer_parens_cols
-        + UnicodeWidthStr::width(inline.as_str())
+        + inline.visual_width(tw)
         + 1; // closing `}`
     if !any_multiline && inline_cols <= line_width {
         return Ok(Some(if let Some((comment, _)) = leading_block_comment {
@@ -322,7 +324,7 @@ pub(crate) fn format_function_binding(
     };
     let inner_indent_cols = (attr_depth + 1) * indent_width;
     let inline_on_one_line =
-        !any_multiline && inner_indent_cols + UnicodeWidthStr::width(inline.as_str()) <= line_width;
+        !any_multiline && inner_indent_cols + inline.visual_width(tw) <= line_width;
 
     // When there is a leading block comment, include it on the first line.
     let mut out = if let Some((comment, _)) = leading_block_comment {

--- a/crates/rsvelte_formatter/src/expression/format_core.rs
+++ b/crates/rsvelte_formatter/src/expression/format_core.rs
@@ -6,12 +6,12 @@ use oxc_ast_visit::{Visit, walk};
 use oxc_formatter::{QuoteStyle, format_program};
 use oxc_parser::Parser;
 use oxc_span::{GetSpan, SourceType};
-use unicode_width::UnicodeWidthStr;
 
 use super::formatter_parse_options;
 use super::text::{strip_leading_paren_pair, strip_outer_parens};
 use crate::error::FormatError;
 use crate::options::FormatOptions;
+use crate::width::{VisualWidth, tab_width};
 
 /// Format a single JS expression source at `line_width`. Wraps in parens to
 /// force expression context (so object literals like `{a:1}` aren't parsed as
@@ -407,7 +407,12 @@ pub(super) fn format_expr_core(
     // leaving oxc's form is the safe choice.
     let formatted = if !use_const_wrapper && program_has_as_or_satisfies_union(&parser_ret.program)
     {
-        reflow_flat_as_satisfies_unions(&formatted, line_width.value() as usize, source_type)
+        reflow_flat_as_satisfies_unions(
+            &formatted,
+            line_width.value() as usize,
+            tab_width(options),
+            source_type,
+        )
     } else {
         formatted
     };
@@ -524,6 +529,7 @@ fn is_multi_member_union(ty: &TSType<'_>) -> bool {
 fn reflow_flat_as_satisfies_unions(
     formatted: &str,
     budget: usize,
+    tw: usize,
     source_type: SourceType,
 ) -> String {
     let union_spans = as_satisfies_union_spans(formatted, source_type);
@@ -556,7 +562,7 @@ fn reflow_flat_as_satisfies_unions(
         };
         if anchored
             && let Some((flat_line, consumed)) =
-                try_flatten_union_block(&lines, &line_start, i + 1, budget, &covered_by_union)
+                try_flatten_union_block(tw, &lines, &line_start, i + 1, budget, &covered_by_union)
         {
             out.push(line.to_string());
             out.push(flat_line);
@@ -606,6 +612,7 @@ fn as_satisfies_union_spans(formatted: &str, source_type: SourceType) -> Vec<(us
 /// Try to read a leading-`|` union block starting at line `start`. On success
 /// returns the single flattened line and how many source lines it consumed.
 fn try_flatten_union_block(
+    tw: usize,
     lines: &[&str],
     line_start: &[usize],
     start: usize,
@@ -661,7 +668,7 @@ fn try_flatten_union_block(
 
     let flat_body = members.join(" | ");
     let flat_line = format!("{indent}{flat_body}");
-    if UnicodeWidthStr::width(flat_line.as_str()) > budget {
+    if flat_line.visual_width(tw) > budget {
         return None;
     }
     Some((flat_line, n))

--- a/crates/rsvelte_formatter/src/expression/splice.rs
+++ b/crates/rsvelte_formatter/src/expression/splice.rs
@@ -4,7 +4,6 @@ use rsvelte_core::ast::arena::try_with_current_serialize_arena;
 use rsvelte_core::ast::js::Expression;
 use rsvelte_core::ast::template::ExpressionTag;
 use rsvelte_core::ast::typed_expr::JsNode;
-use unicode_width::UnicodeWidthStr;
 
 use super::call_args;
 use super::declaration::{
@@ -22,6 +21,7 @@ use super::width::{
 use super::{format_expression_source, format_pattern_source, formatter_parse_options};
 use crate::error::FormatError;
 use crate::options::FormatOptions;
+use crate::width::{VisualWidth, tab_width};
 
 // ─── Splice strategies ──────────────────────────────────────────────────
 
@@ -159,8 +159,10 @@ pub(super) fn push_expression_tag(
             let line_start = source[..tag.start as usize]
                 .rfind('\n')
                 .map_or(0, |index| index + 1);
-            let source_column =
-                UnicodeWidthStr::width(source.get(line_start..tag.start as usize).unwrap_or(""));
+            let source_column = source
+                .get(line_start..tag.start as usize)
+                .unwrap_or("")
+                .visual_width(tab_width(options));
             let indent = depth * options.js.indent_width.value() as usize;
             source_column.saturating_sub(indent) + 1
         } else {
@@ -453,7 +455,7 @@ pub(super) fn push_bare_expression(
     } else {
         formatted
     };
-    let expression_width = UnicodeWidthStr::width(formatted.as_str());
+    let expression_width = formatted.visual_width(tab_width(options));
     // `sibling_expansion` is the width a not-yet-settled expression later on the
     // header line gains from its own grouped calls — the `{#each}` key, measured
     // at its widest while the iterable ahead of it is being judged.

--- a/crates/rsvelte_formatter/src/expression/text.rs
+++ b/crates/rsvelte_formatter/src/expression/text.rs
@@ -157,7 +157,7 @@ pub(super) fn compute_header_suffix_len(source: &str, expr_end: usize) -> usize 
                 '"' | '\'' | '`' => quote = Some(character),
                 '{' | '(' | '[' => depth += 1,
                 '}' if depth == 0 => {
-                    return UnicodeWidthStr::width(&tail[..scanned_bytes]);
+                    return crate::width::text_width(&tail[..scanned_bytes]);
                 }
                 '}' | ')' | ']' if depth > 0 => depth -= 1,
                 '\n' => return 0,
@@ -576,4 +576,3 @@ pub(crate) fn expand_obj_arg_call(s: &str, indent_width: usize) -> Option<String
         Some(result)
     }
 }
-use unicode_width::UnicodeWidthStr;

--- a/crates/rsvelte_formatter/src/expression/width.rs
+++ b/crates/rsvelte_formatter/src/expression/width.rs
@@ -1,8 +1,7 @@
-use unicode_width::UnicodeWidthStr;
-
 use super::format_core::format_expr_core;
 use crate::error::FormatError;
 use crate::options::FormatOptions;
+use crate::width::{VisualWidth, tab_width};
 
 // ─── Expression formatter ───────────────────────────────────────────────
 
@@ -165,8 +164,11 @@ pub(super) fn format_content_expression_with_prefix(
     // width so OXC breaks it the same way prettier-plugin-svelte does.
     // `overhead` = prefix_lead (e.g. `{@render ` = 9) + 1 (closing `}`).
     let overhead = prefix_lead + 1;
-    let first_line_width =
-        UnicodeWidthStr::width(formatted.lines().next().unwrap_or(formatted.as_str()));
+    let first_line_width = formatted
+        .lines()
+        .next()
+        .unwrap_or(formatted.as_str())
+        .visual_width(tab_width(options));
     let formatted = if lead + overhead + first_line_width > full_width {
         let narrowed2 = full_width.saturating_sub(lead + overhead);
         let lw2 = oxc_formatter_core::LineWidth::try_from(narrowed2.max(1) as u16)

--- a/crates/rsvelte_formatter/src/indent.rs
+++ b/crates/rsvelte_formatter/src/indent.rs
@@ -16,10 +16,10 @@
 
 use oxc_formatter::JsFormatOptions;
 use rsvelte_core::ast::template::{Fragment, IfBlock, TemplateNode};
-use unicode_width::UnicodeWidthStr;
 
 use crate::error::FormatError;
 use crate::options::FormatOptions;
+use crate::width::{VisualWidth, tab_width};
 
 /// `child_depth` is the indent level at which this fragment's children
 /// render. The root call uses `0`. Recursing into an element's
@@ -93,6 +93,7 @@ fn collect_indent_edits_inner(
 
     if has_block_children {
         let child_indent = indent_for_level(child_depth, &options.js);
+        let tw = tab_width(options);
         // The last whitespace returns to the *parent's* depth — one
         // less than the children's. The root has no enclosing parent,
         // so use an empty indent (just a newline).
@@ -122,7 +123,7 @@ fn collect_indent_edits_inner(
         let has_non_expression_block_child = fragment.nodes.iter().any(|n| {
             is_indent_provoking(n)
                 && !matches!(n, TemplateNode::ExpressionTag(_))
-                && !is_inline_level_node(n, source, child_indent.width(), options)
+                && !is_inline_level_node(n, source, child_indent.visual_width(tw), options)
         });
 
         // prettier-plugin-svelte's `forceBreakContent`: when any child is a
@@ -760,7 +761,8 @@ fn is_inline_level_node(
     // and breaks later.
     let flat = source.get(start as usize..end as usize).unwrap_or("");
     let line_width = options.js.line_width.value() as usize;
-    !flat.contains('\n') && indent_width + flat.width() <= line_width
+    let tw = tab_width(options);
+    !flat.contains('\n') && indent_width + flat.visual_width(tw) <= line_width
 }
 
 fn is_indent_provoking(node: &TemplateNode) -> bool {

--- a/crates/rsvelte_formatter/src/lib.rs
+++ b/crates/rsvelte_formatter/src/lib.rs
@@ -27,6 +27,7 @@ mod sort_order;
 mod style;
 mod style_css;
 mod tailwind_sort;
+mod width;
 
 pub use error::FormatError;
 pub use json::{JsonVariant, format_json_source};

--- a/crates/rsvelte_formatter/src/markup/attribute.rs
+++ b/crates/rsvelte_formatter/src/markup/attribute.rs
@@ -7,8 +7,8 @@ use super::directive::{
     format_expression_at, format_expression_at_extra, render_directive_value,
     render_directive_value_narrow, render_modifiers, render_spread,
 };
-use super::util::visual_width;
 use super::value::{render_attribute_node, render_attribute_value_for_directive};
+use crate::width::{VisualWidth, tab_width};
 
 // ─── attribute rendering ────────────────────────────────────────────────
 
@@ -19,6 +19,7 @@ pub(super) fn render_attribute(
     attr_depth: usize,
     narrow_value: bool,
 ) -> Result<String, FormatError> {
+    let tw = tab_width(options);
     match attr {
         Attribute::Attribute(node) => {
             render_attribute_node(node, source, options, attr_depth, narrow_value)
@@ -32,7 +33,7 @@ pub(super) fn render_attribute(
                 && !inner.contains('\n')
                 && attr_depth * options.js.indent_width.value() as usize
                     + ATTACH_PREFIX.len()
-                    + visual_width(&inner)
+                    + inner.visual_width(tw)
                     + 1
                     > options.js.line_width.value() as usize
             {
@@ -53,7 +54,7 @@ pub(super) fn render_attribute(
             // sequence expression) renders without outer parens and breaks its
             // braces onto their own lines when the members don't fit (#795b).
             let lead_cols = attr_depth * options.js.indent_width.value() as usize
-                + visual_width(&format!("bind:{}{modifiers}=", d.name));
+                + format!("bind:{}{modifiers}=", d.name).visual_width(tw);
             if let Some(value) = crate::expression::format_function_binding(
                 source,
                 &d.expression,
@@ -78,7 +79,7 @@ pub(super) fn render_attribute(
             // counted separately). Narrowing by this prefix once the open tag has
             // wrapped makes a long value break where prettier-plugin-svelte does
             // (#795) — matching `style:` / `on:` / `use:` etc.
-            let prefix = visual_width("class:") + visual_width(d.name.as_str()) + 1;
+            let prefix = "class:".visual_width(tw) + d.name.as_str().visual_width(tw) + 1;
             let inner = render_directive_value_narrow(
                 source,
                 &d.expression,
@@ -100,7 +101,7 @@ pub(super) fn render_attribute(
             let modifiers = render_modifiers(&d.modifiers);
             if let Some(expr) = &d.expression {
                 // prefix = "on:" + name + modifiers + "=" (the `{` is counted separately)
-                let prefix = 3 + visual_width(d.name.as_str()) + visual_width(&modifiers) + 1;
+                let prefix = 3 + d.name.as_str().visual_width(tw) + modifiers.visual_width(tw) + 1;
                 let inner = render_directive_value_narrow(
                     source,
                     expr,
@@ -125,10 +126,10 @@ pub(super) fn render_attribute(
             };
             let modifiers = render_modifiers(&d.modifiers);
             if let Some(expr) = &d.expression {
-                let prefix = visual_width(pfx_kw)
+                let prefix = pfx_kw.visual_width(tw)
                     + 1
-                    + visual_width(d.name.as_str())
-                    + visual_width(&modifiers)
+                    + d.name.as_str().visual_width(tw)
+                    + modifiers.visual_width(tw)
                     + 1;
                 let inner = render_directive_value_narrow(
                     source,
@@ -147,7 +148,7 @@ pub(super) fn render_attribute(
         Attribute::AnimateDirective(d) => {
             if let Some(expr) = &d.expression {
                 // "animate:" + name + "="
-                let prefix = 8 + visual_width(d.name.as_str()) + 1;
+                let prefix = 8 + d.name.as_str().visual_width(tw) + 1;
                 let inner = render_directive_value_narrow(
                     source,
                     expr,
@@ -165,7 +166,7 @@ pub(super) fn render_attribute(
         Attribute::UseDirective(d) => {
             if let Some(expr) = &d.expression {
                 // "use:" + name + "="
-                let prefix = 4 + visual_width(d.name.as_str()) + 1;
+                let prefix = 4 + d.name.as_str().visual_width(tw) + 1;
                 let inner = render_directive_value_narrow(
                     source,
                     expr,
@@ -183,9 +184,9 @@ pub(super) fn render_attribute(
         Attribute::StyleDirective(d) => {
             let modifiers = render_modifiers(&d.modifiers);
             // Columns before the value's `{`: `style:` + name + modifiers + `=`.
-            let prefix = visual_width("style:")
-                + visual_width(d.name.as_str())
-                + visual_width(&modifiers)
+            let prefix = "style:".visual_width(tw)
+                + d.name.as_str().visual_width(tw)
+                + modifiers.visual_width(tw)
                 + 1;
             let value = render_attribute_value_for_directive(
                 &d.value,

--- a/crates/rsvelte_formatter/src/markup/directive.rs
+++ b/crates/rsvelte_formatter/src/markup/directive.rs
@@ -6,8 +6,8 @@ use crate::expression::format_attribute_value_expression;
 use crate::options::FormatOptions;
 
 use super::attribute::minimal_break_extra;
-use super::util::visual_width;
 use super::value::is_shallow_value;
+use crate::width::{VisualWidth, tab_width};
 
 pub(super) fn render_spread(
     spread: &SpreadAttribute,
@@ -87,12 +87,13 @@ pub(super) fn render_directive_value_narrow(
     narrow_value: bool,
     prefix: usize,
 ) -> Result<String, FormatError> {
+    let tw = tab_width(options);
     let formatted = render_directive_value(source, expr, value_end, options, attr_depth)?;
     if narrow_value && !formatted.contains('\n') {
         let indent_cols = attr_depth * options.js.indent_width.value() as usize;
         let line_width = options.js.line_width.value() as usize;
         // `{` + formatted + `}` = 1 brace on each side
-        if indent_cols + prefix + 1 + visual_width(&formatted) + 1 > line_width {
+        if indent_cols + prefix + 1 + formatted.visual_width(tw) + 1 > line_width {
             // For shallow (non-block) values use `prefix + 1` (the `{` counts
             // against the first-line budget and the value has no multi-line
             // continuation, so narrowing by the full prefix + brace is safe).
@@ -118,7 +119,7 @@ pub(super) fn render_directive_value_narrow(
                 prefix + 1
             } else if is_expr_arrow {
                 let base_width = line_width.saturating_sub(indent_cols);
-                minimal_break_extra(base_width, visual_width(&formatted))
+                minimal_break_extra(base_width, formatted.visual_width(tw))
             } else {
                 prefix.saturating_sub(indent_width)
             };

--- a/crates/rsvelte_formatter/src/markup/open_tag.rs
+++ b/crates/rsvelte_formatter/src/markup/open_tag.rs
@@ -1,6 +1,6 @@
+use crate::width::VisualWidth;
 use rsvelte_core::ast::js::Expression;
 use rsvelte_core::ast::template::Attribute;
-use unicode_width::UnicodeWidthStr;
 
 use crate::error::FormatError;
 use crate::options::FormatOptions;
@@ -11,7 +11,6 @@ use super::elements::{is_block_element, is_html_block_display_element, is_void_e
 use super::render_tag::{render_multi_line, render_one_line};
 use super::util::{
     attribute_span, find_open_tag_end, indent_str, indent_visual_width, is_self_closing_inner,
-    visual_width,
 };
 
 /// Push one edit covering the element's open tag span (from `<` to the
@@ -94,6 +93,7 @@ pub(super) fn push_open_tag(
     options: &FormatOptions,
     edits: &mut Vec<(u32, u32, String)>,
 ) -> Result<bool, FormatError> {
+    let tw = crate::width::tab_width(options);
     let Some(open_tag_end) = find_open_tag_end(source, element_start, attributes) else {
         return Ok(false);
     };
@@ -235,7 +235,7 @@ pub(super) fn push_open_tag(
                 .map_or(0, |i| i + 1);
             let source_col = source
                 .get(line_start..element_start as usize)
-                .map_or(0, |prefix| prefix.width());
+                .map_or(0, |prefix| prefix.visual_width(tw));
             std::cmp::max(depth_indent_width, source_col)
         } else {
             depth_indent_width
@@ -253,7 +253,7 @@ pub(super) fn push_open_tag(
     // A `//` line comment can't share a line with the closing `>` (it would
     // comment out the rest of the tag), so any line comment forces the
     // multi-line shape.
-    let open_one_line_width = leading_indent_width + visual_width(&one_liner);
+    let open_one_line_width = leading_indent_width + one_liner.visual_width(tw);
     // When the element hugs its content (an inline element whose first child
     // touches the `>`), the closing `>` of the open tag moves down to the hugged
     // content line (`<button …attrs`\n`  >text</button`\n`>`). So the attribute
@@ -369,7 +369,7 @@ pub(super) fn push_open_tag(
         let last_line = glued.rsplit('\n').next().unwrap_or("");
         let close_width = tag_name.len() + 3; // "</" + name + ">"
         // Keep gluing (hug_open = true) only when it fits; otherwise dangle.
-        visual_width(last_line) + close_width <= line_width
+        last_line.visual_width(tw) + close_width <= line_width
     } else {
         hug_open
     };

--- a/crates/rsvelte_formatter/src/markup/util.rs
+++ b/crates/rsvelte_formatter/src/markup/util.rs
@@ -1,6 +1,5 @@
 use oxc_formatter::JsFormatOptions;
 use rsvelte_core::ast::template::Attribute;
-use unicode_width::UnicodeWidthStr;
 
 pub(super) fn indent_str(level: usize, js_opts: &JsFormatOptions) -> String {
     if js_opts.indent_style.is_tab() {
@@ -15,15 +14,6 @@ pub(super) fn indent_str(level: usize, js_opts: &JsFormatOptions) -> String {
 /// them).
 pub(super) fn indent_visual_width(level: usize, js_opts: &JsFormatOptions) -> usize {
     level * js_opts.indent_width.value() as usize
-}
-
-/// Visual width of a rendered string, matching how `oxfmt` / prettier measure
-/// line length: East Asian Wide and Fullwidth characters (CJK text, fullwidth
-/// punctuation, …) count as two columns and combining marks as zero. Counting
-/// bare `chars()` under-measured CJK-heavy open tags, so they never crossed
-/// `printWidth` and never wrapped even when `oxfmt` would (#762).
-pub(super) fn visual_width(s: &str) -> usize {
-    UnicodeWidthStr::width(s)
 }
 
 // ─── source-scan helpers ────────────────────────────────────────────────

--- a/crates/rsvelte_formatter/src/markup/value.rs
+++ b/crates/rsvelte_formatter/src/markup/value.rs
@@ -6,8 +6,8 @@ use crate::error::FormatError;
 use crate::expression::format_attribute_value_expression;
 use crate::options::FormatOptions;
 
-use super::util::visual_width;
 use super::value_sequence::render_attribute_value_sequence;
+use crate::width::{VisualWidth, tab_width};
 
 /// Return the source text of an `ExpressionTag`'s inner expression, without
 /// the surrounding `{`/`}`.
@@ -89,6 +89,7 @@ fn render_single_expression_value(
     attr_depth: usize,
     narrow_value: bool,
 ) -> Result<String, FormatError> {
+    let tw = tab_width(options);
     if inner_src.is_empty() {
         return Ok(format!("{}={{}}", node.name));
     }
@@ -140,7 +141,7 @@ fn render_single_expression_value(
     //     Using `prefix - indent_width` as extra_lead would over-narrow the budget
     //     and wrongly break inner expressions for deep objects like
     //     `classes={{ input: styles.fn({ prop: clsx(a, b) }) }}`.
-    let prefix = visual_width(node.name.as_str()) + 2;
+    let prefix = node.name.as_str().visual_width(tw) + 2;
     let indent_width = options.js.indent_width.value() as usize;
     let formatted = format_attribute_value_expression(inner_src, options, attr_depth, 0)?;
     let formatted = if narrow_value {
@@ -153,7 +154,7 @@ fn render_single_expression_value(
             // column beyond the value — counting `{` again here would over-report
             // the width by one and wrongly break a value that fills exactly to the
             // print width (an 80-column `disabledDates={[…]}` line).
-            if indent_cols + prefix + visual_width(&formatted) + 1 > line_width {
+            if indent_cols + prefix + formatted.visual_width(tw) + 1 > line_width {
                 if is_shallow_value(inner_src) {
                     // For a shallow expression (call / ternary / binary / logical chain),
                     // first try re-formatting with `extra_lead = prefix`.  If that
@@ -181,7 +182,7 @@ fn render_single_expression_value(
                             let prefix_first =
                                 prefix_result.lines().next().unwrap_or("").trim_end();
                             let prefix_total =
-                                indent_cols + prefix + visual_width(prefix_first) + 1;
+                                indent_cols + prefix + prefix_first.visual_width(tw) + 1;
                             if prefix_total <= line_width {
                                 return Ok(format!("{}={{{prefix_result}}}", node.name));
                             }
@@ -197,7 +198,7 @@ fn render_single_expression_value(
                         // The `prefix` narrowing forced a break. Try widening to
                         // `single_line_len` to give inner content more room.
                         let base_width = line_width.saturating_sub(indent_cols);
-                        let single_line_len = visual_width(&formatted);
+                        let single_line_len = formatted.visual_width(tw);
                         let extra_lead = base_width.saturating_sub(single_line_len);
                         if extra_lead < prefix {
                             // Widening would give more room — try the wider result.
@@ -238,7 +239,7 @@ fn render_single_expression_value(
                     // that over-narrows the body when `prefix` is large (e.g. a
                     // 15-char attribute name like `onValueChange`).
                     let base_width = line_width.saturating_sub(indent_cols);
-                    let inline_len = visual_width(&formatted);
+                    let inline_len = formatted.visual_width(tw);
                     let inline_total = indent_cols + prefix + 1 + inline_len + 1;
                     let arrow_extra = if inline_total > line_width + 1 {
                         // Overflow >= 2: use tight narrowing to force the arrow break
@@ -255,7 +256,7 @@ fn render_single_expression_value(
                     // The `format_attribute_value_expression` API uses extra_lead,
                     // so convert: narrowed = full_width − indent_cols − extra_lead,
                     // meaning extra_lead = full_width − indent_cols − (inline_len − 1).
-                    let inline_len = visual_width(&formatted);
+                    let inline_len = formatted.visual_width(tw);
                     // full_width − indent_cols is the budget without extra_lead
                     let base_width = line_width.saturating_sub(indent_cols);
                     // extra_lead that yields narrowed = inline_len − 1
@@ -269,7 +270,7 @@ fn render_single_expression_value(
             // Multi-line shallow: check the first line to decide whether to
             // re-format with extra_lead.
             let first_line = formatted.lines().next().unwrap_or("").trim_end();
-            let first_line_total = indent_cols + prefix + visual_width(first_line) + 1;
+            let first_line_total = indent_cols + prefix + first_line.visual_width(tw) + 1;
             if first_line_total > line_width {
                 let overflow = first_line_total - line_width;
                 let tighter = format_attribute_value_expression(
@@ -337,6 +338,7 @@ pub(super) fn render_attribute_node(
     attr_depth: usize,
     narrow_value: bool,
 ) -> Result<String, FormatError> {
+    let tw = tab_width(options);
     match &node.value {
         AttributeValue::True(_) => Ok(node.name.to_string()),
         AttributeValue::Expression(tag) => {
@@ -389,7 +391,7 @@ pub(super) fn render_attribute_node(
             }
 
             // Columns before the value body on the first line: `name="`.
-            let name_prefix = visual_width(node.name.as_str()) + 2;
+            let name_prefix = node.name.as_str().visual_width(tw) + 2;
             let body = render_attribute_value_sequence(
                 parts,
                 source,
@@ -425,6 +427,7 @@ pub(super) fn render_attribute_value_for_directive(
     narrow_value: bool,
     prefix: usize,
 ) -> Result<String, FormatError> {
+    let tw = tab_width(options);
     match value {
         AttributeValue::True(_) => Ok(String::new()),
         AttributeValue::Expression(tag) => {
@@ -441,7 +444,7 @@ pub(super) fn render_attribute_value_for_directive(
             let line_width = options.js.line_width.value() as usize;
             let formatted = if narrow_value
                 && !formatted.contains('\n')
-                && indent_cols + prefix + 1 + visual_width(&formatted) + 1 > line_width
+                && indent_cols + prefix + 1 + formatted.visual_width(tw) + 1 > line_width
             {
                 format_attribute_value_expression(inner_src, options, attr_depth, prefix + 1)?
             } else {
@@ -469,7 +472,7 @@ pub(super) fn render_attribute_value_for_directive(
                     let line_width = options.js.line_width.value() as usize;
                     let formatted = if narrow_value
                         && !formatted.contains('\n')
-                        && indent_cols + prefix + 1 + visual_width(&formatted) + 1 > line_width
+                        && indent_cols + prefix + 1 + formatted.visual_width(tw) + 1 > line_width
                     {
                         format_attribute_value_expression(
                             inner_src,

--- a/crates/rsvelte_formatter/src/markup/value_sequence.rs
+++ b/crates/rsvelte_formatter/src/markup/value_sequence.rs
@@ -10,8 +10,9 @@ use crate::expression::{
 use crate::options::FormatOptions;
 
 use super::attribute::minimal_break_extra;
-use super::util::{indent_str, visual_width};
+use super::util::indent_str;
 use super::value::{expression_tag_inner, is_shallow_value};
+use crate::width::{VisualWidth, tab_width};
 
 /// Build the Doc for one literal-text chunk of a REGULAR quoted attribute
 /// value, plus its flat visual width. prettier-plugin-svelte emits regular
@@ -21,8 +22,8 @@ use super::value::{expression_tag_inner, is_shallow_value};
 /// non-breaking `Text`; all breaking happens inside the interpolation groups.
 /// (Style-directive values differ — their text IS a `fill` — and are excluded
 /// from this path.)
-fn attr_text_chunk_doc(raw: &str) -> (Doc, usize) {
-    (Doc::Text(raw.to_string()), visual_width(raw))
+fn attr_text_chunk_doc(raw: &str, tw: usize) -> (Doc, usize) {
+    (Doc::Text(raw.to_string()), raw.visual_width(tw))
 }
 
 /// Whole-value Doc model for a REGULAR quoted attribute value: format the
@@ -53,6 +54,7 @@ fn render_value_sequence_doc(
     attr_depth: usize,
     name_prefix: usize,
 ) -> Result<Option<String>, FormatError> {
+    let tw = tab_width(options);
     let interp_count = parts
         .iter()
         .filter(|p| matches!(p, AttributeValuePart::ExpressionTag(_)))
@@ -85,7 +87,7 @@ fn render_value_sequence_doc(
     for part in parts {
         match part {
             AttributeValuePart::Text(t) => {
-                let (doc, w) = attr_text_chunk_doc(t.raw.as_ref());
+                let (doc, w) = attr_text_chunk_doc(t.raw.as_ref(), tw);
                 docs.push(doc);
                 col += w;
             }
@@ -98,14 +100,14 @@ fn render_value_sequence_doc(
                 }
                 let flat_inner = format_attribute_value_expression_flat(inner, &opts_sq)?;
                 let flat = format!("{{{flat_inner}}}");
-                let flat_w = visual_width(&flat);
+                let flat_w = flat.visual_width(tw);
                 // The enclosing group decides *whether* this interpolation
                 // breaks (measuring its trailing tail); the `broken` form only
                 // supplies the *shape*. Force the break at the narrower of (a)
                 // the real width available at this column and (b) one column
                 // under the flat form (guarantees at least the top-level
                 // operator splits even when the overflow is trailing-caused).
-                let flat_inner_w = visual_width(&flat_inner);
+                let flat_inner_w = flat_inner.visual_width(tw);
                 let broken_width = line_width
                     .saturating_sub(col)
                     .min(flat_inner_w.saturating_sub(1))
@@ -176,7 +178,7 @@ fn render_value_sequence_doc(
     let out = doc_print(
         &propagate_breaks(Doc::Concat(docs)),
         width,
-        &unit,
+        crate::width::IndentUnit::new(&unit, crate::width::tab_width(options)),
         base_indent,
         start_col,
     );
@@ -192,6 +194,7 @@ pub(super) fn render_attribute_value_sequence(
     narrow_value: bool,
     regular_attr: bool,
 ) -> Result<String, FormatError> {
+    let tw = tab_width(options);
     // Whole-value Doc model, used only once the open tag is known to wrap (the
     // single-line pass renders flat anyway) and only for REGULAR attributes —
     // style/other directive values print their text as a prettier `fill` (a
@@ -251,9 +254,9 @@ pub(super) fn render_attribute_value_sequence(
                     // value the logical indent still applies.
                     let value_is_multiline = out.contains('\n');
                     let lead_cols = if value_is_multiline {
-                        visual_width(on_line)
+                        on_line.visual_width(tw)
                     } else {
-                        name_prefix + visual_width(on_line)
+                        name_prefix + on_line.visual_width(tw)
                     };
                     // `format_attribute_value_expression` narrows the print width by
                     // `attr_depth` indent levels. For a multi-line string value the
@@ -275,10 +278,10 @@ pub(super) fn render_attribute_value_sequence(
                             AttributeValuePart::Text(t) => {
                                 let raw = t.raw.as_ref();
                                 if let Some(nl) = raw.find('\n') {
-                                    trailing_cols += visual_width(&raw[..nl]);
+                                    trailing_cols += raw[..nl].visual_width(tw);
                                     break;
                                 }
-                                trailing_cols += visual_width(raw);
+                                trailing_cols += raw.visual_width(tw);
                             }
                             // A following interpolation continues the same line; its
                             // width is unknown here, so (as before) count it as 0.
@@ -347,7 +350,7 @@ pub(super) fn render_attribute_value_sequence(
                                         line_width_val.saturating_sub(effective_indent);
                                     let force_extra = minimal_break_extra(
                                         base_width,
-                                        visual_width(first_pass.as_str()),
+                                        first_pass.as_str().visual_width(tw),
                                     );
                                     let forced = format_attribute_value_expression(
                                         inner_src,
@@ -372,7 +375,7 @@ pub(super) fn render_attribute_value_sequence(
                             let total = effective_indent
                                 + lead_cols
                                 + 1
-                                + visual_width(first_pass.as_str())
+                                + first_pass.as_str().visual_width(tw)
                                 + 1
                                 + trailing_cols
                                 + 1;
@@ -413,7 +416,7 @@ pub(super) fn render_attribute_value_sequence(
                                         line_width_val.saturating_sub(effective_indent);
                                     let force_extra = minimal_break_extra(
                                         base_width,
-                                        visual_width(first_pass.as_str()),
+                                        first_pass.as_str().visual_width(tw),
                                     );
                                     let forced = format_attribute_value_expression(
                                         inner_src,

--- a/crates/rsvelte_formatter/src/script.rs
+++ b/crates/rsvelte_formatter/src/script.rs
@@ -6,6 +6,7 @@ use rsvelte_core::ast::template::Script;
 
 use crate::error::FormatError;
 use crate::options::FormatOptions;
+use crate::width::VisualWidth;
 
 /// Format a standalone JS/TS source file in-process via `oxc_formatter` — the
 /// same engine `oxfmt` uses for `.ts`/`.js`, so the output is byte-identical
@@ -204,7 +205,8 @@ pub(crate) fn format_nested_script(
     // Narrow the width by the final nesting so wrap decisions match the indented
     // result (mirrors `format_script`'s one-level narrowing, generalised).
     let mut js = options.js.clone();
-    let narrow = (body_indent.len() as u16).min(js.line_width.value().saturating_sub(1));
+    let narrow = (body_indent.visual_width(crate::width::tab_width(options)) as u16)
+        .min(js.line_width.value().saturating_sub(1));
     let nested_width = js.line_width.value().saturating_sub(narrow);
     js.line_width = oxc_formatter_core::LineWidth::try_from(nested_width).unwrap_or(js.line_width);
     let formatted = format_program(allocator, &parser_ret.program, js, None)

--- a/crates/rsvelte_formatter/src/style.rs
+++ b/crates/rsvelte_formatter/src/style.rs
@@ -11,10 +11,10 @@
 
 use rsvelte_core::ast::css::StyleSheet;
 use rsvelte_core::ast::template::{Fragment, TemplateNode};
-use unicode_width::UnicodeWidthStr;
 
 use crate::error::FormatError;
 use crate::options::FormatOptions;
+use crate::width::{VisualWidth, tab_width};
 
 /// Format the content of `<style>` elements that appear *inside* the markup
 /// (e.g. a nested `<div><style>…</style></div>` or a `<style>` in
@@ -255,7 +255,7 @@ fn indent_unit(options: &FormatOptions) -> String {
 /// gets a usable width.
 fn css_width(options: &FormatOptions, body_indent: &str) -> usize {
     let full = options.js.line_width.value() as usize;
-    full.saturating_sub(UnicodeWidthStr::width(body_indent))
+    full.saturating_sub(body_indent.visual_width(tab_width(options)))
         .max(20)
 }
 

--- a/crates/rsvelte_formatter/src/width.rs
+++ b/crates/rsvelte_formatter/src/width.rs
@@ -1,0 +1,109 @@
+//! Print-width measurement shared by every fit / wrap decision.
+//!
+//! Prettier measures a line in two pieces. Its indentation is accounted by
+//! `generateIndent`, whose `addTabs` charges `options.tabWidth` columns per tab;
+//! everything else goes through `getStringWidth`, which counts East Asian Wide /
+//! Fullwidth scalars as two columns and control characters as zero.
+//! [`UnicodeWidthStr::width`] alone reproduces only the second half, so under
+//! `useTabs` a depth-`n` indent under-counts by `(tabWidth - 1) * n` columns and
+//! every fit decision fires late (#2119). [`VisualWidth::visual_width`] applies
+//! both rules at once, which is exact for the formatter's own output because a
+//! tab can only ever reach it as indentation.
+
+use unicode_width::UnicodeWidthStr;
+
+use crate::options::FormatOptions;
+
+/// Columns a tab occupies: prettier's `tabWidth`, which doubles as the
+/// space-indent width. Zero-guarded so a degenerate config can't collapse every
+/// indent to nothing.
+pub(crate) fn tab_width(options: &FormatOptions) -> usize {
+    match options.js.indent_width.value() as usize {
+        0 => 1,
+        w => w,
+    }
+}
+
+/// Width of `s` ignoring tabs, with a fast path for the printable-ASCII case
+/// that dominates markup (where one byte is exactly one column).
+pub(crate) fn text_width(s: &str) -> usize {
+    if s.bytes().all(|b| (0x20..0x7f).contains(&b)) {
+        s.len()
+    } else {
+        s.width()
+    }
+}
+
+pub(crate) trait VisualWidth {
+    /// Display width of `self`, charging every tab `tab_width` columns.
+    fn visual_width(&self, tab_width: usize) -> usize;
+}
+
+impl VisualWidth for str {
+    fn visual_width(&self, tab_width: usize) -> usize {
+        // Printable ASCII (which excludes `\t`) is one column per byte — the same
+        // single scan `text_width` would do, so the hot path costs nothing extra.
+        let bytes = self.as_bytes();
+        if bytes.iter().all(|b| (0x20..0x7f).contains(b)) {
+            return bytes.len();
+        }
+        if !bytes.contains(&b'\t') {
+            return self.width();
+        }
+        let mut segments = 0;
+        let mut width = 0;
+        for segment in self.split('\t') {
+            segments += 1;
+            width += text_width(segment);
+        }
+        width + (segments - 1) * tab_width
+    }
+}
+
+/// One indentation level: the string it appends and the columns prettier charges
+/// for it. Bundled so a printer can never pair a tab unit with a one-column
+/// measurement.
+#[derive(Clone, Copy)]
+pub(crate) struct IndentUnit<'a> {
+    unit: &'a str,
+    columns: usize,
+    tab_width: usize,
+}
+
+impl<'a> IndentUnit<'a> {
+    pub(crate) fn new(unit: &'a str, tab_width: usize) -> Self {
+        Self {
+            unit,
+            columns: unit.visual_width(tab_width),
+            tab_width,
+        }
+    }
+
+    pub(crate) fn as_str(&self) -> &'a str {
+        self.unit
+    }
+
+    pub(crate) fn columns(&self) -> usize {
+        self.columns
+    }
+
+    pub(crate) fn tab_width(&self) -> usize {
+        self.tab_width
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tabs_cost_tab_width_and_other_scalars_keep_prettier_widths() {
+        assert_eq!("".visual_width(4), 0);
+        assert_eq!("abc".visual_width(4), 3);
+        assert_eq!("\t".visual_width(4), 4);
+        assert_eq!("\t\t\t".visual_width(4), 12);
+        assert_eq!("\t\tabc".visual_width(2), 7);
+        // East Asian Wide scalars still count two columns.
+        assert_eq!("\t日本".visual_width(4), 8);
+    }
+}

--- a/crates/rsvelte_formatter/tests/tab_visual_width.rs
+++ b/crates/rsvelte_formatter/tests/tab_visual_width.rs
@@ -1,0 +1,105 @@
+//! `useTabs` print-width accounting (#2119).
+//!
+//! Prettier's `generateIndent` charges an indentation tab `tabWidth` columns, so
+//! a tab-indented document must make exactly the same fit decisions as the
+//! equivalent space-indented one. Measuring a tab as a single column made every
+//! wrap fire `(tabWidth - 1) * depth` columns late.
+
+use rsvelte_formatter::{
+    FormatOptions, IndentStyle, IndentWidth, JsFormatOptions, LineWidth, format,
+};
+
+fn options(indent_style: IndentStyle, print_width: u16, tab_width: u8) -> FormatOptions {
+    FormatOptions {
+        js: JsFormatOptions {
+            indent_style,
+            indent_width: IndentWidth::try_from(tab_width).expect("valid indent width"),
+            line_width: LineWidth::try_from(print_width).expect("valid print width"),
+            ..JsFormatOptions::new()
+        },
+        ..FormatOptions::default()
+    }
+}
+
+/// Re-indent tab-indented output with `tab_width` spaces per leading tab, which
+/// is exactly the column budget prettier charges for it.
+fn tabs_to_columns(out: &str, tab_width: usize) -> String {
+    out.lines()
+        .map(|line| {
+            let tabs = line.bytes().take_while(|b| *b == b'\t').count();
+            format!("{}{}", " ".repeat(tabs * tab_width), &line[tabs..])
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+/// The oracle (oxfmt + prettier-plugin-svelte) wraps this prose after `dog`; with
+/// a one-column tab the 12-column indent counted as 3 and `and keeps` still fit.
+#[test]
+fn tab_indent_wraps_prose_at_the_same_column_as_a_space_indent() {
+    let src = "<div>\n\t<div>\n\t\t<div>\n\t\t\t<p>\n\t\t\t\tThe quick brown fox jumps over the lazy dog and keeps running far away.\n\t\t\t</p>\n\t\t</div>\n\t</div>\n</div>\n";
+
+    let tabs = format(src, &options(IndentStyle::Tab, 60, 4)).expect("format ok");
+    assert_eq!(
+        tabs,
+        "<div>\n\t<div>\n\t\t<div>\n\t\t\t<p>\n\t\t\t\tThe quick brown fox jumps over the lazy dog\n\t\t\t\tand keeps running far away.\n\t\t\t</p>\n\t\t</div>\n\t</div>\n</div>\n",
+        "tab-indented prose must wrap where the oracle wraps"
+    );
+}
+
+/// An open tag whose attributes overflow only once the tab indent is charged its
+/// real width.
+#[test]
+fn tab_indent_breaks_an_open_tag_at_the_same_column_as_a_space_indent() {
+    let src = "<div>\n\t<div>\n\t\t<div>\n\t\t\t<span class=\"alpha beta\" title=\"hello there\" id=\"widget\">ok</span>\n\t\t</div>\n\t</div>\n</div>\n";
+
+    let tabs = format(src, &options(IndentStyle::Tab, 60, 4)).expect("format ok");
+    assert_eq!(
+        tabs,
+        "<div>\n\t<div>\n\t\t<div>\n\t\t\t<span\n\t\t\t\tclass=\"alpha beta\"\n\t\t\t\ttitle=\"hello there\"\n\t\t\t\tid=\"widget\">ok</span\n\t\t\t>\n\t\t</div>\n\t</div>\n</div>\n",
+        "a tab-indented open tag must break where the oracle breaks"
+    );
+}
+
+/// Layout invariant across the two indent styles: with the same `tabWidth`, tab
+/// and space indentation buy the same number of columns, so the documents must
+/// agree line for line once the tabs are expanded.
+#[test]
+fn tab_and_space_indentation_produce_the_same_layout() {
+    let cases = [
+        "<div>\n\t<div>\n\t\t<div>\n\t\t\t<p>\n\t\t\t\tThe quick brown fox jumps over the lazy dog and keeps running far away.\n\t\t\t</p>\n\t\t</div>\n\t</div>\n</div>\n",
+        "<div>\n\t<div>\n\t\t<div>\n\t\t\t<span class=\"alpha beta\" title=\"hello there\" id=\"widget\">ok</span>\n\t\t</div>\n\t</div>\n</div>\n",
+        "<ul>\n\t<li>\n\t\t<a href=\"/some/fairly/long/path\">a link whose text keeps going and going</a>\n\t</li>\n</ul>\n",
+    ];
+
+    for (tab_width, print_width) in [(2u8, 60u16), (4, 60), (4, 80), (8, 80)] {
+        for src in cases {
+            let tabs = format(src, &options(IndentStyle::Tab, print_width, tab_width))
+                .expect("tab format ok");
+            let spaces = format(src, &options(IndentStyle::Space, print_width, tab_width))
+                .expect("space format ok");
+            assert_eq!(
+                tabs_to_columns(&tabs, tab_width as usize),
+                tabs_to_columns(&spaces, tab_width as usize),
+                "tabWidth={tab_width} printWidth={print_width} diverged for:\n{src}"
+            );
+        }
+    }
+}
+
+/// Exact print-width boundary: the deepest text line must end at `printWidth`
+/// and never one column past it.
+#[test]
+fn tab_indent_respects_the_print_width_boundary() {
+    // Depth 2 (8 columns at tabWidth 4) + `<p>`-nested text at depth 3 (12 columns).
+    let src = "<div>\n\t<div>\n\t\t<p>\n\t\t\taaaa bbbb cccc dddd eeee ffff gggg hhhh iiii jjjj kkkk\n\t\t</p>\n\t</div>\n</div>\n";
+    let out = format(src, &options(IndentStyle::Tab, 40, 4)).expect("format ok");
+    for line in out.lines() {
+        let tabs = line.bytes().take_while(|b| *b == b'\t').count();
+        let columns = tabs * 4 + line[tabs..].chars().count();
+        assert!(
+            columns <= 40 || line[tabs..].split(' ').count() == 1,
+            "line exceeds printWidth 40 ({columns} columns): {line:?}\n{out}"
+        );
+    }
+}


### PR DESCRIPTION
Fixes #2119

## Problem

Prettier measures a line in two pieces: its indentation goes through `generateIndent`, whose `addTabs` charges **`options.tabWidth` columns per tab**, and everything else through `getStringWidth`. rsvelte-fmt only reproduced the second half — every fit decision called `UnicodeWidthStr::width`, which returns **1** for `\t`.

So under `useTabs` a depth-`n` indent under-counted by `(tabWidth - 1) * n` columns, and every line-fitting decision fired late: prose fills wrapped past `printWidth`, deep open tags never broke their attributes, `{expr}` never split. Measured on svelte.dev's 557 components at `useTabs:true, tabWidth:4, printWidth:100`: **27 divergences** from the oxfmt + prettier-plugin-svelte oracle (spaces mode was already byte-identical, which is why the corpus — pinned at tabWidth 2 / spaces — never gated this).

## Fix

A single shared helper instead of ~60 ad-hoc `str::width()` / `UnicodeWidthStr::width()` calls:

- **`crates/rsvelte_formatter/src/width.rs`** (new) — `VisualWidth::visual_width(s, tab_width)` applies both prettier rules at once (tab → `tabWidth`, East Asian Wide → 2, other control chars → prettier's `getStringWidth` behaviour), keeping the printable-ASCII fast path so the hot path still does one byte scan. Plus `tab_width(&FormatOptions)` and `IndentUnit`, which pairs an indent string with the columns prettier charges for it — so a tab unit can never again be paired with a one-column measurement.
- **`doc.rs`** — `print` / `print_flat` / `fits` / `print_fill` / `push_indent` now take that `IndentUnit`. This matters beyond indentation: a `RawExpr`'s broken continuation lines carry oxc's own (tab) indent, which the printer was also mis-measuring.
- Every remaining site swept: `collapse/{mod,util,fill,hug,breaks,collect,open_tag,pre,children_port,doc_build}.rs`, `indent.rs`, `markup/*`, `expression/*`, `script.rs`, `style.rs`. Functions that had no `FormatOptions` in scope take an explicit tab-width argument.
- Two related tab bugs fixed on the way: `script.rs` narrowed the nested-`<script>` print width by the indent's **byte length** (`"\t\t".len() == 2`), and `style.rs`'s `css_width` measured the `<style>` body indent the same way.
- `markup::util::visual_width` is gone — it was a second, tab-blind copy of the same idea.

## Verification

| Check | Result |
|---|---|
| svelte.dev 557 components @ `useTabs:true, tabWidth:4, printWidth:100` vs oracle | **27 → 2 divergences**; one of the two (`docs/[topic]/[...path]/+layout.svelte`) is an already-listed `fmt-oracle-excluded.json` oxfmt CSS-path bug, so **1 real** remains (`AstView.svelte`, an unrelated spaces-emitted-where-tabs-expected indent-*string* bug, not a width bug) |
| Spaces-mode regression: base vs fixed binary over **5018 `.svelte` files** (`submodules/svelte` + `submodules/svelte.dev`) at the canonical corpus config | **0 differing** — byte-identical |
| `cargo test -p rsvelte_formatter` | pass (incl. the new `tab_visual_width.rs`) |
| `cargo test -p rsvelte_fmt` | pass |
| `svelte_dev_corpus_parity` (hard gate, files + markdown blocks + Stage-3 CLI) | pass |
| `cargo test -p rsvelte_language_server` | pass |
| `cargo fmt`, `cargo clippy --all-targets --all-features -- -D warnings` | clean |

`compatibility/fmt-known-failures.json` is unchanged: spaces-mode output is byte-identical, so no entry can newly pass and none regress.

## Regression tests

`crates/rsvelte_formatter/tests/tab_visual_width.rs`:

- prose wrapping and open-tag breaking at a depth-3 tab indent, asserted against the exact oracle output;
- a cross-style invariant — with the same `tabWidth`, tab and space indentation must produce the same layout once tabs are expanded — over 3 documents × 4 `(tabWidth, printWidth)` combinations;
- a `printWidth` boundary check that no tab-indented line exceeds the budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
