### PR TITLE
fix(compiler): resolve SSR `{@const}` shadowing an instance binding through the scope chain

### DIFF
--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/mod.rs
@@ -213,6 +213,17 @@ pub struct ServerTransformState<'a> {
     pub current_scope_index: usize,
 }
 
+/// The render position saved by [`ServerTransformState::enter_template_scope`],
+/// handed back to [`ServerTransformState::restore_scope`] on the way out.
+pub struct SavedScope {
+    /// The scope index in effect before the entered fragment.
+    scope: usize,
+    /// The entered scope, when the node owned one (`None` = nothing changed).
+    entered: Option<usize>,
+    /// `constant_vars` entries the entered scope redeclared, to put back.
+    shadowed_constants: Vec<(String, String)>,
+}
+
 /// One per-fragment async `{@const}` group — the AST mirror of upstream's
 /// `state.async_consts` (`DeclarationTag.js`). `name` is the `$$renderer.run`
 /// result variable (`promises`); `thunks` are the (source, has_await) thunk
@@ -289,31 +300,104 @@ impl<'a> ServerTransformState<'a> {
     }
 
     /// Enter the scope the scope-builder created for the fragment children of
-    /// the template node starting at `node_start`, returning the previous scope
-    /// index to hand back to [`Self::restore_scope`]. Nodes that own no scope
-    /// (or whose scope was not recorded) leave the current one in place, exactly
-    /// like upstream's `set_scope` (`scopes.get(node) ?? state.scope`).
-    pub fn enter_template_scope(&mut self, node_start: u32) -> usize {
-        let saved = self.current_scope_index;
-        if let Some(&idx) = self.analysis.root.template_scope_map.get(&node_start) {
-            self.current_scope_index = idx;
+    /// the template node starting at `node_start`, returning the state to hand
+    /// back to [`Self::restore_scope`]. Nodes that own no scope (or whose scope
+    /// was not recorded) leave the current one in place, exactly like upstream's
+    /// `set_scope` (`scopes.get(node) ?? state.scope`).
+    pub fn enter_template_scope(&mut self, node_start: u32) -> SavedScope {
+        match self
+            .analysis
+            .root
+            .template_scope_map
+            .get(&node_start)
+            .copied()
+        {
+            Some(idx) => self.enter_scope(idx),
+            None => SavedScope {
+                scope: self.current_scope_index,
+                entered: None,
+                shadowed_constants: Vec::new(),
+            },
         }
-        saved
     }
 
     /// Enter an `{#if}`'s `{:else}` scope (an if-block owns two fragment scopes,
     /// so its alternate lives in its own map under the block's start).
-    pub fn enter_if_alternate_scope(&mut self, node_start: u32) -> usize {
-        let saved = self.current_scope_index;
-        if let Some(&idx) = self.analysis.root.if_alternate_scope_map.get(&node_start) {
-            self.current_scope_index = idx;
+    pub fn enter_if_alternate_scope(&mut self, node_start: u32) -> SavedScope {
+        match self
+            .analysis
+            .root
+            .if_alternate_scope_map
+            .get(&node_start)
+            .copied()
+        {
+            Some(idx) => self.enter_scope(idx),
+            None => SavedScope {
+                scope: self.current_scope_index,
+                entered: None,
+                shadowed_constants: Vec::new(),
+            },
         }
-        saved
     }
 
-    /// Restore the scope saved by [`Self::enter_template_scope`].
-    pub fn restore_scope(&mut self, saved: usize) {
-        self.current_scope_index = saved;
+    /// Swap the render position to `idx` and hide every script-level
+    /// `constant_vars` entry the entered scope redeclares with a `{@const}` /
+    /// `{const}` — `constant_vars` is keyed by NAME alone, so a
+    /// `{@const doubled = …}` shadowing an instance `$derived doubled` would
+    /// otherwise keep folding template reads to the outer binding's value.
+    fn enter_scope(&mut self, idx: usize) -> SavedScope {
+        let scope = self.current_scope_index;
+        self.current_scope_index = idx;
+        let mut shadowed_constants = Vec::new();
+        if !self.eval_inputs.constant_vars.is_empty() {
+            for name in self.const_declaration_names(idx) {
+                if let Some(value) = self.eval_inputs.constant_vars.remove(name) {
+                    shadowed_constants.push((name.to_string(), value));
+                }
+            }
+        }
+        SavedScope {
+            scope,
+            entered: Some(idx),
+            shadowed_constants,
+        }
+    }
+
+    /// Restore the scope saved by [`Self::enter_template_scope`], dropping the
+    /// folds the exited scope registered and putting the hidden outer ones back.
+    pub fn restore_scope(&mut self, saved: SavedScope) {
+        self.current_scope_index = saved.scope;
+        if let Some(idx) = saved.entered {
+            for name in self.const_declaration_names(idx) {
+                self.eval_inputs.constant_vars.remove(name);
+            }
+        }
+        for (name, value) in saved.shadowed_constants {
+            self.eval_inputs.constant_vars.insert(name, value);
+        }
+    }
+
+    /// The names scope `idx` declares through a template `{@const}` / `{const}`
+    /// (`BindingKind::Template`). Slot `let:` / each-item / snippet parameters
+    /// are deliberately excluded: rsvelte's scope tree is coarser than
+    /// upstream's for those (one component scope covers every slot body), and
+    /// their fold veto already lives in `slot_let_shadows` / `shadowed_names`.
+    fn const_declaration_names(&self, idx: usize) -> Vec<&'a str> {
+        use crate::compiler::phases::phase2_analyze::scope::BindingKind;
+        let root = &self.analysis.root;
+        let Some(declared) = root.all_scopes.get(idx) else {
+            return Vec::new();
+        };
+        declared
+            .declarations
+            .iter()
+            .filter(|&(_, &binding)| {
+                root.bindings
+                    .get(binding)
+                    .is_some_and(|b| matches!(b.kind, BindingKind::Template))
+            })
+            .map(|(name, _)| name.as_str())
+            .collect()
     }
 
     /// Collect all the names currently shadowed by enclosing snippet / slot
@@ -492,7 +576,7 @@ impl<'a> ServerTransformState<'a> {
             &mut out,
             self.b,
             self.analysis,
-            self.analysis.root.instance_scope_index,
+            self.current_scope_index,
             self.collect_shadowed(),
             self.local_derived_names.clone(),
         );
@@ -508,15 +592,17 @@ impl<'a> ServerTransformState<'a> {
     }
 
     /// Run the read-wrapping pass over an already-built oxc expression in place,
-    /// resolving names against the instance scope. Mirrors `context.visit(...)`'s
-    /// read-rewriting for callers (e.g. `RenderTag`) that decompose a template
-    /// expression by source-slice + re-parse rather than `visit_expr`.
+    /// resolving names against the RENDER POSITION's scope chain (upstream
+    /// `context.state.scope`), so a `{@const}` shadowing an instance `$derived`
+    /// keeps its reads bare. Mirrors `context.visit(...)`'s read-rewriting for
+    /// callers (e.g. `RenderTag`) that decompose a template expression by
+    /// source-slice + re-parse rather than `visit_expr`.
     pub fn wrap_reads_in_place(&self, expr: &mut OxcExpression<'a>) {
         read_wrap::wrap_reads_with_shadows_and_local_derived(
             expr,
             self.b,
             self.analysis,
-            self.analysis.root.instance_scope_index,
+            self.current_scope_index,
             self.collect_shadowed(),
             self.local_derived_names.clone(),
         );

--- a/crates/rsvelte_core/tests/ssr_const_instance_shadow_2144.rs
+++ b/crates/rsvelte_core/tests/ssr_const_instance_shadow_2144.rs
@@ -1,0 +1,143 @@
+//! A `{@const}` / `{const}` that shadows an INSTANCE-script binding must hide
+//! it for both SSR folding and the derived/store read-wrap.
+//!
+//! Issue #2144: `constant_vars` is keyed by name alone, so an instance
+//! `let doubled = $derived(count * 2)` folded into the table kept folding
+//! `{doubled}` reads inside `{#if …}{@const doubled = …}` to the OUTER value;
+//! and `read_wrap` resolved the same read against the instance scope, emitting
+//! the outer accessor call `doubled()`. #2132 fixed the sibling-template-scope
+//! axis only — the instance-script axis needed the same scope chain.
+
+use rsvelte_core::{CompileOptions, GenerateMode, compile};
+
+#[track_caller]
+fn ssr(source: &str) -> String {
+    compile(
+        source,
+        CompileOptions {
+            generate: GenerateMode::Server,
+            ..Default::default()
+        },
+    )
+    .expect("component should compile")
+    .js
+    .code
+}
+
+#[track_caller]
+fn assert_contains_all(source: &str, needles: &[&str]) {
+    let code = ssr(source);
+    for needle in needles {
+        assert!(
+            code.contains(needle),
+            "expected {needle:?} in SSR output:\n{code}"
+        );
+    }
+}
+
+#[track_caller]
+fn assert_contains_none(source: &str, needles: &[&str]) {
+    let code = ssr(source);
+    for needle in needles {
+        assert!(
+            !code.contains(needle),
+            "did not expect {needle:?} in SSR output:\n{code}"
+        );
+    }
+}
+
+const INSTANCE: &str =
+    "<script>\n\tlet count = $state(4);\n\tlet doubled = $derived(count * 2);\n</script>\n";
+
+/// The issue's accessor repro: the `{@const}` value is not foldable, so the
+/// read stays `$.escape(doubled)` — NOT the outer `$derived` accessor call.
+#[test]
+fn const_tag_shadowing_derived_reads_bare() {
+    let source =
+        format!("{INSTANCE}{{#if count}}{{@const doubled = () => 'x'}}<p>{{doubled}}</p>{{/if}}");
+    assert_contains_all(&source, &["$.escape(doubled)"]);
+    assert_contains_none(&source, &["$.escape(doubled())", "<p>8</p>"]);
+}
+
+/// The issue's literal repro: the fold must use the SHADOWING const's value.
+#[test]
+fn const_tag_shadowing_derived_folds_to_inner_value() {
+    let source = format!("{INSTANCE}{{#if count}}{{@const doubled = 7}}<p>{{doubled}}</p>{{/if}}");
+    assert_contains_all(&source, &["<p>7</p>"]);
+    assert_contains_none(&source, &["<p>8</p>", "$.escape(doubled)"]);
+}
+
+/// …and the shadow must not outlive the fragment: the read after `{/if}` folds
+/// to the instance `$derived` again.
+#[test]
+fn shadow_does_not_leak_past_the_block() {
+    let source = format!(
+        "{INSTANCE}{{#if count}}{{@const doubled = 7}}<p>{{doubled}}</p>{{/if}}<span>{{doubled}}</span>"
+    );
+    assert_contains_all(&source, &["<p>7</p>", "<span>8</span>"]);
+}
+
+/// A `{@const}` shadowing an un-updated `$state` binding (the other source of
+/// name-keyed `constant_vars` entries).
+#[test]
+fn const_tag_shadowing_state_reads_bare() {
+    let source = "<script>\n\tlet count = $state(3);\n</script>\n{#if true}{@const count = () => 9}<p>{count}</p>{/if}<span>{count}</span>";
+    assert_contains_all(source, &["$.escape(count)", "<span>3</span>"]);
+    assert_contains_none(source, &["<p>3</p>"]);
+}
+
+/// Attribute position goes through the same read-wrap, so it must not emit the
+/// outer accessor call either.
+#[test]
+fn const_tag_shadow_applies_to_attributes() {
+    let source = format!(
+        "{INSTANCE}{{#if count}}{{@const doubled = () => 1}}<p title={{doubled}}>x</p>{{/if}}"
+    );
+    assert_contains_all(&source, &["$.attr('title', doubled)"]);
+    assert_contains_none(&source, &["doubled()"]);
+}
+
+/// A destructuring `{@const}` binds through a pattern; every bound name shadows.
+#[test]
+fn destructured_const_tag_shadows() {
+    let source = format!(
+        "{INSTANCE}{{#if count}}{{@const {{ doubled }} = {{ doubled: () => 1 }}}}<p>{{doubled}}</p>{{/if}}"
+    );
+    assert_contains_all(&source, &["$.escape(doubled)"]);
+    assert_contains_none(&source, &["<p>8</p>"]);
+}
+
+/// The shadow is nested-scope aware: an element inside the block sees it too.
+#[test]
+fn shadow_reaches_nested_element_children() {
+    let source = format!(
+        "{INSTANCE}{{#if count}}{{@const doubled = () => 1}}<div><p>{{doubled}}</p></div>{{/if}}<span>{{doubled}}</span>"
+    );
+    assert_contains_all(
+        &source,
+        &["<div><p>${$.escape(doubled)}</p></div>", "<span>8</span>"],
+    );
+}
+
+/// Other block types create the same scope: `{#key}` and `{#each}`.
+#[test]
+fn key_and_each_blocks_shadow_too() {
+    let key =
+        format!("{INSTANCE}{{#key count}}{{@const doubled = () => 1}}<p>{{doubled}}</p>{{/key}}");
+    assert_contains_all(&key, &["$.escape(doubled)"]);
+    assert_contains_none(&key, &["<p>8</p>"]);
+
+    let each = format!(
+        "{INSTANCE}{{#each [1] as i}}{{@const doubled = () => i}}<p>{{doubled}}</p>{{/each}}<span>{{doubled}}</span>"
+    );
+    assert_contains_all(&each, &["$.escape(doubled)", "<span>8</span>"]);
+}
+
+/// A `{let x = $derived(…)}` declaration tag declares a LOCAL derived — its
+/// reads still take the getter call, so the shadow must not swallow them.
+#[test]
+fn local_derived_declaration_tag_still_calls_its_getter() {
+    let source =
+        "<div>\n\t{let dt = $derived(Date.parse('2026-10-01T00:00:00Z'))}\n\t{typeof dt}\n</div>";
+    assert_contains_all(source, &["typeof dt()"]);
+}


### PR DESCRIPTION
Fixes #2144

## Reproduced on latest main

#2132 (issue #2059) landed the render position (`current_scope_index`) and wired
it into `server/evaluate.rs`, but the issue's repro still diverges on `main`,
because both defective paths bypass that evaluator:

```svelte
<script>
	let count = $state(0);
	let doubled = $derived(count * 2);
</script>
{#if count}{@const doubled = () => 'shadowed'}<p>{doubled}</p>{/if}
```

- official: `` `<p>${$.escape(doubled)}</p>` ``
- main: `` `<p>0</p>` `` — the read folded to the OUTER `$derived`'s value

## Cause

1. **`flush_sequence`'s `constant_vars` fold** (`server/ast/visitors/shared.rs`)
   short-circuits before any binding resolution, and `constant_vars` is keyed by
   NAME alone. `compute_eval_inputs` folds an un-updated `$state` and a
   statically-evaluable `$derived` into that table, so `doubled -> "0"` survived
   into the shadowing fragment and won.
2. **`read_wrap`** was handed `analysis.root.instance_scope_index`, so
   `Scope::get_binding` started its walk at the instance scope and could not see
   the nearer template declaration — a non-foldable shadow therefore became the
   outer accessor call `doubled()` (visible in attribute position, where nothing
   folds: `$.attr('title', doubled())` vs official `$.attr('title', doubled)`).

The issue's `constant_vars` diagnosis is right; the `evaluate_identifier`
name-union rule is **not** at fault — #2132's `scope_chain_depth` retain already
picks the innermost binding once evaluation is actually reached.

## Fix

Both defects ride on #2132's mechanism rather than patching names:

- `enter_template_scope` / `enter_if_alternate_scope` now return a `SavedScope`.
  Entering a scope **hides** the `constant_vars` entries that scope redeclares
  through a `BindingKind::Template` declaration (`{@const}` / `{const}`), and
  `restore_scope` drops the folds the exited scope registered before putting the
  hidden outer ones back — so the shadow is exactly fragment-scoped and cannot
  leak past `{/if}` / `{/each}` / `{/key}`.
  `let:` / each-item / snippet parameters are deliberately **excluded**:
  rsvelte's scope tree keeps ONE component scope for every slot body (coarser
  than upstream's per-slot scopes), and their fold veto already lives in
  `slot_let_shadows` / `shadowed_names`. Including them regresses
  `component-let-directive` / `component-slot-let-scope-3`, where a named slot
  without `let:count` must still fold the component-level `count`.
- `visit_expr` / `wrap_reads_in_place` resolve reads from `current_scope_index`
  instead of `instance_scope_index`, so `get_binding` walks the real lexical
  chain (upstream `context.state.scope`) and a shadowed name classifies as the
  template binding instead of the instance `$derived` / `$store`. A
  `{let x = $derived(…)}` declaration tag keeps its `BindingKind::Derived`
  binding on that chain, so its reads still take the getter call.

## Verification

- Both issue repros (accessor form and literal-fold form) plus 8 more shapes
  (leak-past-the-block, `$state` shadow, attribute position, destructuring
  `{@const}`, nested element children, `{#key}`, `{#each}`,
  `{let x = $derived}`) are **byte-identical** to `svelte@5.56.8` server output.
- New regression test `crates/rsvelte_core/tests/ssr_const_instance_shadow_2144.rs`
  (9 cases).
- `cargo test --release -p rsvelte_core` — the whole crate is green (SSR 99/99,
  hydration, runtime legacy 1207/1207 + runes 1007/1007, compiler fixtures,
  validator, `ssr_const_scope_2059` 7/7, …).
- Corpus (`svelte` + `pattern` sources, 5153 entries): **server** track
  `js-mismatch 0` / `css-mismatch 0` / `error-mismatch 0`; all three targets show
  **no regressions**. No ratchet entry is attributable to this bug, so none
  shrinks.
- `cargo fmt` + `cargo clippy --all-targets --all-features -- -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RQSYoh4Wc353KgUnWHjazu
