### PR TITLE
fix(svelte2tsx): quote let:-forwarding $$slot_def like official, tighten fixture comparator

### DIFF
--- a/compatibility/svelte2tsx-fixtures-known-failures.json
+++ b/compatibility/svelte2tsx-fixtures-known-failures.json
@@ -1,7 +1,16 @@
 [
 	"attributes-foreign-ns",
+	"component-slot-$$slot-interface",
+	"component-slot-$$slot-type",
+	"component-slot-inside-await",
+	"component-slot-let-forward",
+	"component-slot-object-key",
+	"event-dispatcher-events",
+	"event-dispatcher-events-alias",
 	"module-snippet-component-instance-reference.v5",
 	"ts-await-generics.v5",
+	"ts-event-dispatchers",
+	"ts-event-dispatchers-same-event",
 	"ts-runes-hoistable-props-false-6.v5",
 	"ts-type-assertion"
 ]

--- a/compatibility/svelte2tsx-fixtures-known-failures.md
+++ b/compatibility/svelte2tsx-fixtures-known-failures.md
@@ -25,7 +25,20 @@ UPDATE_S2TSX_FIXTURES_BASELINE=1 cargo test --test svelte2tsx_fixtures
 `STRICT_S2TSX_FIXTURES=1` ignores the baseline entirely (every failure fails),
 which is how you check whether an entry is still needed.
 
-## Current baseline: 5 of 254 (pass rate 98.0%)
+## Current baseline: 14 of 254 (pass rate 94.5%)
+
+### #2145 note
+
+Until this PR, `relaxed_compare`'s `strip_return_statement` stage deleted the whole
+`return {…}` statement outright (not just the differing trailing
+`class __sveltets_Render<T> { … }` wrapper it exists to bridge), so nothing downstream
+ever compared the returned `props`/`slots`/`events` reflection again. That's how a real
+rsvelte/official divergence — `$$slot_def["b"]` vs official's `$$slot_def['b']` — passed
+`component-slot-let-forward-named-slot` despite differing. `return_statement_matches`
+(same file) now independently re-verifies just the return statement through the same
+relaxations, on top of the existing chain. The 9 entries below are pre-existing
+divergences this newly surfaced — none are new regressions, and none are related to the
+quoting bug itself (which is fixed in `collect/mod.rs`'s `push_let_reflection_scope`).
 
 ### Harness gap — 1
 
@@ -70,3 +83,44 @@ which is how you check whether an entry is still needed.
 - **`ts-await-generics.v5`.** One space after `type $$ComponentProps = { prop?: T };`
   — the fixture has two, rsvelte emits one. Cosmetic in effect, but the gate is
   byte-exact so it is tracked like any other divergence.
+
+### `$$Slots` interface/type override not respected — 2
+
+- **`component-slot-$$slot-interface`**, **`component-slot-$$slot-type`.** When the
+  instance script declares an explicit `interface $$Slots { … }` (or `type $$Slots
+  = { … }`), official's `slots:` reflection becomes `{} as unknown as $$Slots`,
+  deferring entirely to the user's own type instead of the computed shape. rsvelte
+  doesn't detect the declaration and always emits the literal computed slot object
+  (`{'default': {a:b}, 'foo': {b:b}}`). A real, self-contained feature gap — out of
+  scope for #2145 (slot **quoting**, not slot **typing**).
+
+### `let:`-forwarding slot-let resolution gaps — 3
+
+- **`component-slot-inside-await`**, **`component-slot-let-forward`**,
+  **`component-slot-object-key`.** Three different `let:`/slot-forwarding
+  destructuring shapes rsvelte resolves incompletely: a `let:whatever={{ bla }}`
+  nested-destructure binding on a forwarded component slot; an `{#await …then
+  value}` binding threaded into a nested named slot; and an `{#each}` binding used
+  as both an object *key* and *value* inside a forwarded slot prop (rsvelte
+  incorrectly substitutes the resolved expression into the key position too,
+  e.g. `{item:...}` becomes `{__sveltets_2_unwrapArr(items):...}`). All three sit
+  squarely in the `let:`-forwarding resolution logic (`push_let_reflection_scope`
+  neighbourhood / `TemplateScope.resolveLet` equivalent) that issue #2105 owns —
+  left untouched here per that PR's explicit scope boundary.
+
+### `createEventDispatcher` event-name/type inference gaps — 4
+
+- **`event-dispatcher-events`**, **`event-dispatcher-events-alias`.** `dispatch(bla,
+  false)` where `bla` is a local `const bla = 'bye'` — official statically resolves
+  the dispatched event name through the `const` binding to add `'bye'` to the
+  `events:` reflection; rsvelte only recognizes a string literal passed directly as
+  `dispatch()`'s first argument, not one flowing through a traced local constant.
+  (`-alias` is the same gap through an aliased `import { createEventDispatcher as
+  foo }`.)
+
+- **`ts-event-dispatchers`**, **`ts-event-dispatchers-same-event`.** Multiple
+  `createEventDispatcher<T>()` calls in one component (`dispatch1`/`dispatch2`/
+  `dispatch3`, each with its own generic event-type parameter) — official unions
+  every one via a separate `...__sveltets_2_toEventTypings<T>()` spread per
+  dispatcher; rsvelte only emits one. A distinct, self-contained event-typing
+  feature gap, unrelated to #2145.

--- a/crates/rsvelte_projection/src/svelte2tsx/template/collect/mod.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/template/collect/mod.rs
@@ -447,7 +447,7 @@ fn collect_info_from_node<'a>(
 ///
 /// For a `let:x` directive associated with component `<C>`'s slot `slot_name`,
 /// any later reference to the bound name inside the slotted content resolves to
-/// `__sveltets_2_instanceOf(C).$$slot_def["<slot>"].x` instead of the bare name.
+/// `__sveltets_2_instanceOf(C).$$slot_def['<slot>'].x` instead of the bare name.
 /// Mirrors official `SlotHandler.resolveLet` / `getResolveExpressionStrForLet`.
 /// Returns how many entries were pushed (to pop afterwards).
 fn push_let_reflection_scope(
@@ -467,7 +467,7 @@ fn push_let_reflection_scope(
             .and_then(|e| expression_simple_identifier(e, source))
             .unwrap_or_else(|| ld.name.to_string());
         let value = format!(
-            "__sveltets_2_instanceOf({}).$$slot_def[\"{}\"].{}",
+            "__sveltets_2_instanceOf({}).$$slot_def['{}'].{}",
             component, slot_name, ld.name
         );
         scope.push((binding, value));

--- a/crates/rsvelte_projection/tests/common/svelte2tsx.rs
+++ b/crates/rsvelte_projection/tests/common/svelte2tsx.rs
@@ -108,7 +108,17 @@ fn build_options(sample_name: &str, sample_dir: &Path, svelte_filename: &str) ->
 // Relaxed comparison chain
 // =========================================================================
 
+/// #2145: the structural chain below (`relaxed_compare_structural`) can
+/// declare a match purely on the strength of the surrounding `$$render`
+/// body, even when the `return {…}` statement it discards along the way
+/// (`strip_return_statement`) genuinely diverges — see
+/// `return_statement_matches` for why and how that's independently
+/// re-checked here.
 fn relaxed_compare(actual: &str, expected: &str) -> bool {
+    relaxed_compare_structural(actual, expected) && return_statement_matches(actual, expected)
+}
+
+fn relaxed_compare_structural(actual: &str, expected: &str) -> bool {
     let expect_cut = expected
         .rfind("\n\nexport default class")
         .or_else(|| expected.rfind("\nexport const "))
@@ -473,6 +483,113 @@ fn strip_return_statement(text: &str) -> String {
     }
 }
 
+/// Slices out just the `return { … }` object literal, bounded by its own
+/// matching brace (`find_balanced_end`) rather than running to the end of
+/// `text` — a generics fixture has a trailing
+/// `class __sveltets_Render<T> { props() … }` wrapper after the return
+/// statement that must not be swept in. `None` when there's no `return {`,
+/// or its braces never balance.
+fn extract_return_statement(text: &str) -> Option<&str> {
+    let pos = text
+        .rfind("\nreturn {")
+        .map(|p| p + 1)
+        .or_else(|| text.rfind("return {"))?;
+    let brace_start = pos + "return ".len();
+    let end_offset = find_balanced_end(&text[brace_start..])?;
+    Some(&text[pos..brace_start + end_offset])
+}
+
+/// #2145 gate: `strip_return_statement` above (the last stage before the
+/// pure-whitespace fallbacks) discards the whole `return {…}` statement, so
+/// a real content divergence inside the returned `props`/`slots`/`events`
+/// reflection — e.g. rsvelte's `$$slot_def["b"]` vs official's
+/// `$$slot_def['b']` — can pass a fixture purely because everything ELSE in
+/// the `$$render` body matches. This independently re-verifies just the
+/// return statement on top of the (otherwise unmodified) chain above,
+/// applying the SAME relaxations that chain already applies — in the same
+/// one-sided way, e.g. `strip_as_type_assertion` only ever runs on the
+/// `expected` side there, matching a real syntax gap between a legacy
+/// `expectedv2.ts` fixture's TS `as X` casts and rsvelte's v5-shaped output
+/// — so an already-tolerated gap still passes, but a genuine mismatch now
+/// fails the fixture instead of being silently dropped.
+fn return_statement_matches(actual: &str, expected: &str) -> bool {
+    let (Some(actual_return), Some(expected_return)) = (
+        extract_return_statement(actual),
+        extract_return_statement(expected),
+    ) else {
+        // No return statement on (at least) one side — nothing to re-verify;
+        // the structural chain above is the sole verdict for this fixture.
+        return true;
+    };
+
+    macro_rules! try_eq {
+        ($a:expr, $e:expr) => {
+            if $a == $e {
+                return true;
+            }
+        };
+    }
+
+    let a = strip_v5_additions(actual_return);
+    let e = strip_v5_additions(expected_return);
+    try_eq!(a, e);
+
+    let e = strip_as_type_assertion(&e);
+    try_eq!(a, e);
+
+    let a = normalize_attr_whitespace(&a);
+    let e = normalize_attr_whitespace(&e);
+    try_eq!(a, e);
+
+    let a = collapse_spaces(&a);
+    let e = collapse_spaces(&e);
+    try_eq!(a, e);
+
+    let a = normalize_props_type(&a);
+    let e = normalize_props_type(&e);
+    try_eq!(a, e);
+
+    let a = normalize_template_literals(&a);
+    let e = normalize_template_literals(&e);
+    try_eq!(a, e);
+
+    let a = normalize_all_whitespace(&a);
+    let e = normalize_all_whitespace(&e);
+    try_eq!(a, e);
+
+    let a = expand_prop_shorthand(&a);
+    let e = expand_prop_shorthand(&e);
+    try_eq!(a, e);
+
+    let a = normalize_semicolons(&a);
+    let e = normalize_semicolons(&e);
+    try_eq!(a, e);
+
+    let a = strip_call_generics(&a);
+    let e = strip_call_generics(&e);
+    try_eq!(a, e);
+
+    let a = strip_ignore_markers(&a);
+    let e = strip_ignore_markers(&e);
+    try_eq!(a, e);
+
+    let a = strip_css_prop_wrappers(&a);
+    let e = strip_css_prop_wrappers(&e);
+    try_eq!(a, e);
+
+    // `strip_as_type_assertion` above is one-sided (`expected` only), mirroring
+    // the main chain's assumption that rsvelte's actual output favors JSDoc
+    // `@type` casts over TS `as X` ones. A TS-lang (`ts-*`) fixture's `props`
+    // reflection legitimately carries a real `as {…}` cast on BOTH sides,
+    // synthesized from each side's own inferred prop type shape (property
+    // order / optionality can differ innocuously) — so also try dropping it
+    // from `actual` before finally requiring a byte match.
+    let a = strip_as_type_assertion(&a);
+    try_eq!(a, e);
+
+    strip_all_whitespace(&a) == strip_all_whitespace(&e)
+}
+
 fn normalize_props_type(text: &str) -> String {
     use regex::Regex;
     let mut result = text.to_string();
@@ -570,6 +687,18 @@ fn find_balanced_end(text: &str) -> Option<usize> {
             if ch == string_char && (i == 0 || bytes[i - 1] != b'\\') {
                 in_string = false;
             }
+        } else if ch == '/' && bytes.get(i + 1) == Some(&b'*') {
+            // A `/** @type {…} */` JSDoc cast is common right where this is
+            // called from (`, exports: /** @type {{foo: number}} */ ({})`):
+            // its own `{…}` is brace-balanced on its own, so without this
+            // skip the scan below would stop at the comment's closing `}`
+            // instead of the value's, truncating mid-comment.
+            i += 2;
+            while i + 1 < bytes.len() && !(bytes[i] == b'*' && bytes[i + 1] == b'/') {
+                i += 1;
+            }
+            i = (i + 2).min(bytes.len());
+            continue;
         } else {
             match ch {
                 '"' | '\'' | '`' => {

--- a/crates/rsvelte_projection/tests/svelte2tsx_slot_value0_rule.rs
+++ b/crates/rsvelte_projection/tests/svelte2tsx_slot_value0_rule.rs
@@ -153,16 +153,14 @@ fn interpolated_slot_attribute_keeps_lets_on_the_default_slot_block() {
 // --- `let:` scope resolution (official `getSlotName`'s `value[0].raw`) ---
 
 /// The laxer of the two `slot=` rules: the JSX block above stays on the default
-/// slot, yet the same child's `let:x` is typed against slot `a`. (Official spells
-/// the index with single quotes here; that quoting difference is tracked apart
-/// from this rule.)
+/// slot, yet the same child's `let:x` is typed against slot `a`.
 #[test]
 fn let_bindings_of_an_interpolated_slot_child_resolve_against_the_first_part() {
     let code = tsx(
         "<script>import Comp from './C.svelte'; let b='x';</script>\n<Comp><div slot=\"a{b}c\" let:x><slot name=\"s\" p={x} /></div></Comp>",
     );
     assert!(
-        code.contains("p:__sveltets_2_instanceOf(Comp).$$slot_def[\"a\"].x"),
+        code.contains("p:__sveltets_2_instanceOf(Comp).$$slot_def['a'].x"),
         "{code}"
     );
 }


### PR DESCRIPTION
## Summary

- `getSingleSlotDef` in official svelte2tsx spells the `let:`-forwarding
  `$$slot_def` member access with **single quotes**
  (`__sveltets_2_instanceOf(C).$$slot_def['b'].a`). rsvelte's
  `push_let_reflection_scope` (`crates/rsvelte_projection/src/svelte2tsx/template/collect/mod.rs`)
  emitted **double quotes** instead. Fixed to match.
- That divergence was invisible to the svelte2tsx fixture suite
  (`crates/rsvelte_projection/tests/svelte2tsx_fixtures.rs`, 254 upstream
  samples) because `relaxed_compare`'s `strip_return_statement` stage deletes
  the whole `return {…}` statement (the `props`/`slots`/`events` reflection)
  before the final whitespace-only fallback ever runs — so
  `component-slot-let-forward-named-slot` "passed" despite the mismatch.
  Added `return_statement_matches` in
  `crates/rsvelte_projection/tests/common/svelte2tsx.rs`, which
  independently re-verifies just the return statement through the *same*
  relaxations the existing chain already applies, layered on top of the
  otherwise-unmodified chain (`relaxed_compare_structural`).
- Tightening this also caught a pre-existing bug in the shared
  `find_balanced_end` helper: a `/** @type {{foo: T}} */` JSDoc cast's own
  nested braces were mistaken for the value's closing brace, truncating the
  stripped text mid-comment. Fixed by skipping `/* … */` comments while
  scanning.
- Tightening surfaced 9 previously-masked, **pre-existing** divergences
  unrelated to the quoting bug itself:
  - `$$Slots` interface/type override not respected (2 fixtures)
  - `let:`-forwarding resolution gaps — left untouched, in scope of #2105 (3 fixtures)
  - `createEventDispatcher` event-name/type inference gaps (4 fixtures)

  These are recorded in `compatibility/svelte2tsx-fixtures-known-failures.{json,md}`
  with a written justification each, per the ratchet's rules — not silently
  left tolerated. Baseline: 5 → 14 of 254 known failures (98.0% → 94.5% pass
  rate), all *newly surfaced*, none newly broken.

## Test plan

- [x] `cargo test -p rsvelte_projection --test svelte2tsx_fixtures` — green
      (94.5%, 9 pre-existing gaps newly surfaced and ratcheted with
      justification, zero regressions)
- [x] `cargo test -p rsvelte_projection` (full crate, incl. the 254-fixture
      suite and all unit tests) — green, 257+ tests passing
- [x] Verified byte-for-byte against the official svelte2tsx oracle for
      `component-slot-let-forward-named-slot`'s `$$slot_def['b'].a`
- [x] `cargo fmt`
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean

Fixes #2145

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RQSYoh4Wc353KgUnWHjazu