### PR TITLE
fix(compiler): lower legacy destructuring assignments through the upstream path (#2138)

### DIFF
--- a/.changeset/fix-legacy-assignment-destructure-exclude-keys.md
+++ b/.changeset/fix-legacy-assignment-destructure-exclude-keys.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/compiler": patch
+---
+
+Legacy (non-runes) destructuring *assignments* (`({ a, ...rest } = obj)`) now lower like the official compiler: an object pattern with an identifier right-hand side stays a plain sequence instead of being wrapped in a `$$value` IIFE, literal and computed keys read `obj['b-c']` / `obj[3]` / `obj[key]` instead of the unparseable `obj.'b-c'`, and the `$.exclude_from_object` key list uses upstream's `b.literal(...)` / `String(<expr>)` form instead of re-quoting the source text (`''b-c''`, `'[key]'`). The invalid member reads used to make the downstream AST pass bail, dropping every `$.set` / prop call in the statement.

--- a/compatibility/pattern-corpus/README.md
+++ b/compatibility/pattern-corpus/README.md
@@ -63,6 +63,7 @@ source with `node scripts/compat-corpus/compile.mjs --filter pattern/`.
 | `2013-state-destructure-quoted-key.svelte` | [#2013](https://github.com/baseballyama/rsvelte/issues/2013) | Quoted key in a destructured `$state(...)` needs bracket member access |
 | `2014-derived-array-rest-arity.svelte` | [#2014](https://github.com/baseballyama/rsvelte/issues/2014) | An array pattern ending in a rest element passes **no length** to `$.to_array` |
 | `2060-const-shadow-textcontent.svelte` | [#2060](https://github.com/baseballyama/rsvelte/issues/2060) | A `{@const}` **shadowing** a component-scope binding must resolve to the `{@const}`, so the read stays a static `textContent` assignment |
+| `2138-legacy-assignment-destructure-rest.svelte` | [#2138](https://github.com/baseballyama/rsvelte/issues/2138) | A legacy destructuring **assignment** with quoted / computed keys and a rest — bracket member reads, an `$.exclude_from_object` key list built like `b.literal(...)`, and no `$$value` IIFE for an identifier right-hand side |
 | `2141-snippet-shadow-is-function.svelte` | [#2141](https://github.com/baseballyama/rsvelte/issues/2141) | A block-local `{#snippet}` shadowing a same-named outer `function` still reads as reactive (`is_function()` must resolve to the snippet, not the outer function) |
 
 ## `matrix/` — the axes around those repros

--- a/compatibility/pattern-corpus/issues/2138-legacy-assignment-destructure-rest.svelte
+++ b/compatibility/pattern-corpus/issues/2138-legacy-assignment-destructure-rest.svelte
@@ -1,0 +1,14 @@
+<script>
+	const k = 'd';
+	let a = 1;
+	let w = 0;
+	let d = 0;
+	let r = {};
+	const obj = { a: 1 };
+
+	function f() {
+		({ a, 'weird-name': w, [k]: d, ...r } = obj);
+	}
+</script>
+
+<button onclick={f}>{a}{w}{d}{Object.keys(r).length}</button>

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/destructure_transforms.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/destructure_transforms.rs
@@ -1,6 +1,7 @@
 //! Destructuring assignment transformations and IIFE generation.
 
 use super::SCRIPT_ARRAY_COUNTER;
+use super::rune_transforms::{derived_prop_access, exclude_from_object_keys};
 use oxc_allocator::Allocator;
 use oxc_ast::ast::{Expression, Statement};
 use oxc_parser::{ParseOptions, Parser};
@@ -766,21 +767,6 @@ pub(super) fn find_destructure_rhs_end(statement: &str, start: usize) -> usize {
     end
 }
 
-/// Generate a member access expression for a destructuring key.
-/// For computed keys like `[expr]`, generates `obj[expr]` (bracket notation).
-/// For static keys like `prop`, generates `obj.prop` (dot notation).
-pub(super) fn member_access(obj: &str, key: &str) -> String {
-    if key.starts_with('[') && key.ends_with(']') {
-        // Computed property key: obj[expr]
-        // Strip the outer brackets to get the expression
-        let expr = &key[1..key.len() - 1];
-        format!("{}[{}]", obj, expr)
-    } else {
-        // Static property key: obj.prop
-        format!("{}.{}", obj, key)
-    }
-}
-
 /// Check if a generated code string contains `await` as a keyword (not inside string literals).
 ///
 /// This is used to determine if a destructuring IIFE needs to be async.
@@ -1463,9 +1449,11 @@ pub(super) fn generate_destructure_iife(
                 if p.is_empty() {
                     return true;
                 }
-                // No rest elements
-                if p.starts_with("...") {
-                    return false;
+                // A rest element is an ordinary path upstream — `$.exclude_from_object`
+                // needs no `$$value` — so only a nested rest target forces the IIFE.
+                if let Some(rest_target) = p.strip_prefix("...") {
+                    let rest_target = rest_target.trim();
+                    return !rest_target.starts_with('[') && !rest_target.starts_with('{');
                 }
                 // If key-value, target must be simple identifier (no nested patterns)
                 if let Some(colon_pos) = find_top_level_colon(p) {
@@ -1514,47 +1502,55 @@ pub(super) fn generate_destructure_iife(
                 if part.is_empty() {
                     continue;
                 }
-                let (key, target_with_default) = if let Some(colon_pos) = find_top_level_colon(part)
-                {
+
+                let (target, access) = if let Some(rest_target) = part.strip_prefix("...") {
                     (
-                        part[..colon_pos].trim().to_string(),
-                        part[colon_pos + 1..].trim().to_string(),
+                        rest_target.trim().to_string(),
+                        format!(
+                            "$.exclude_from_object({}, [{}])",
+                            rhs_str,
+                            exclude_from_object_keys(&parts).join(", ")
+                        ),
                     )
                 } else {
-                    // Shorthand: {x} or {x = default} means key=x
-                    let name = if let Some(eq_pos) = find_top_level_equals(part) {
-                        part[..eq_pos].trim().to_string()
-                    } else {
-                        part.to_string()
+                    let (key, target_with_default) =
+                        if let Some(colon_pos) = find_top_level_colon(part) {
+                            (
+                                part[..colon_pos].trim().to_string(),
+                                part[colon_pos + 1..].trim().to_string(),
+                            )
+                        } else {
+                            // Shorthand: {x} or {x = default} means key=x
+                            let name = if let Some(eq_pos) = find_top_level_equals(part) {
+                                part[..eq_pos].trim().to_string()
+                            } else {
+                                part.to_string()
+                            };
+                            (name.clone(), part.to_string())
+                        };
+
+                    // Split target from default value
+                    let (target, default_val) =
+                        if let Some(eq_pos) = find_top_level_equals(&target_with_default) {
+                            (
+                                target_with_default[..eq_pos].trim().to_string(),
+                                Some(target_with_default[eq_pos + 1..].trim().to_string()),
+                            )
+                        } else {
+                            (target_with_default.clone(), None)
+                        };
+
+                    let member = derived_prop_access(rhs_str, rhs_str, &key);
+                    let access = match &default_val {
+                        Some(default_val) => build_fallback_string(&member, default_val),
+                        None => member,
                     };
-                    (name.clone(), part.to_string())
+                    (target, access)
                 };
-
-                // Split target from default value
-                let (target, default_val) =
-                    if let Some(eq_pos) = find_top_level_equals(&target_with_default) {
-                        (
-                            target_with_default[..eq_pos].trim().to_string(),
-                            Some(target_with_default[eq_pos + 1..].trim().to_string()),
-                        )
-                    } else {
-                        (target_with_default.clone(), None)
-                    };
-
-                let access = format!("{}.{}", rhs_str, key);
 
                 // Check if the target is a store subscription variable ($storeName)
                 if store_sub_vars.contains(&target) && target.starts_with('$') {
-                    let store_name = &target[1..]; // Remove the $ prefix
-                    if let Some(default_val) = &default_val {
-                        let fallback = build_fallback_string(&access, default_val);
-                        assignments.push(format!("$.store_set({}, {})", store_name, fallback));
-                    } else {
-                        assignments.push(format!("$.store_set({}, {})", store_name, access));
-                    }
-                } else if let Some(default_val) = &default_val {
-                    let fallback = build_fallback_string(&access, default_val);
-                    assignments.push(format!("{} = {}", target, fallback));
+                    assignments.push(format!("$.store_set({}, {})", &target[1..], access));
                 } else {
                     assignments.push(format!("{} = {}", target, access));
                 }
@@ -1587,31 +1583,10 @@ pub(super) fn generate_destructure_iife(
 
             if let Some(rest_target) = part.strip_prefix("...") {
                 // Rest element: ...rest = $.exclude_from_object($$value, [keys...])
-                let rest_target = rest_target.trim();
-                let keys: Vec<String> = parts
-                    .iter()
-                    .filter(|p| !p.trim().starts_with("..."))
-                    .map(|p| {
-                        let p = p.trim();
-                        // Extract the key name
-                        if let Some(colon_pos) = find_top_level_colon(p) {
-                            let key = p[..colon_pos].trim();
-                            format!("'{}'", key)
-                        } else {
-                            // Shorthand or just identifier with possible default
-                            let name = if let Some(eq_pos) = find_top_level_equals(p) {
-                                p[..eq_pos].trim()
-                            } else {
-                                p
-                            };
-                            format!("'{}'", name)
-                        }
-                    })
-                    .collect();
                 body_lines.push(format!(
                     "\t{} = $.exclude_from_object($$value, [{}]);",
-                    rest_target,
-                    keys.join(", ")
+                    rest_target.trim(),
+                    exclude_from_object_keys(&parts).join(", ")
                 ));
             } else if let Some(colon_pos) = find_top_level_colon(part) {
                 // Key-value pair: key: target
@@ -1619,8 +1594,10 @@ pub(super) fn generate_destructure_iife(
                 let target = part[colon_pos + 1..].trim();
 
                 // Handle default value
-                // Use member_access to handle computed property keys like [expr]
-                let value_access = member_access("$$value", key);
+                // `derived_prop_access` keeps bracket notation for computed and
+                // literal keys, like upstream's `b.member(…, prop.computed ||
+                // prop.key.type !== 'Identifier')`.
+                let value_access = derived_prop_access("$$value", "$$value", key);
                 if let Some(eq_pos) = find_top_level_equals(target) {
                     let actual_target = target[..eq_pos].trim();
                     let default_val = target[eq_pos + 1..].trim();

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/rune_transforms.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/rune_transforms.rs
@@ -850,6 +850,29 @@ fn quote_exclude_key(value: &str) -> String {
     format!("'{}'", escape_js_string(value))
 }
 
+/// The `$.exclude_from_object(base, [<keys>])` key list of an object pattern's
+/// non-rest properties, shared by the legacy declaration and assignment
+/// destructuring expansions so both subtract exactly the keys upstream does.
+pub(super) fn exclude_from_object_keys<S: AsRef<str>>(props: &[S]) -> Vec<String> {
+    props
+        .iter()
+        .filter_map(|prop| {
+            let prop = prop.as_ref().trim();
+            if prop.is_empty() || prop.starts_with("...") {
+                return None;
+            }
+            let key = if let Some(colon_pos) = find_derived_property_colon(prop) {
+                prop[..colon_pos].trim()
+            } else if let Some(eq_pos) = find_default_equals(prop) {
+                prop[..eq_pos].trim()
+            } else {
+                prop
+            };
+            Some(exclude_key_literal(key))
+        })
+        .collect()
+}
+
 pub(super) fn process_derived_object_pattern(
     inner: &str,
     base_expr: &str,

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/state_transforms.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/state_transforms.rs
@@ -8,8 +8,8 @@ use super::expression_utils::{
     byte_pos_to_char_index, find_statement_end_client, is_shadowed_by_for_loop_var,
 };
 use super::rune_transforms::{
-    derived_prop_access, exclude_key_literal, find_default_equals, find_derived_property_colon,
-    split_derived_array_elements, split_derived_object_properties,
+    derived_prop_access, exclude_from_object_keys, find_default_equals,
+    find_derived_property_colon, split_derived_array_elements, split_derived_object_properties,
 };
 use super::{SCRIPT_ARRAY_COUNTER, STATE_TMP_COUNTER, get_or_compile_regex};
 use crate::compiler::phases::phase2_analyze::scope::DeclarationKind;
@@ -1378,24 +1378,11 @@ pub(super) fn transform_legacy_destructure_declarations(
         let mut parts = vec![format!("{} = {}", tmp_name, expr)];
 
         let has_rest = props.iter().any(|prop| prop.trim().starts_with("..."));
-        let excluded_keys: Vec<String> = props
-            .iter()
-            .filter(|_| has_rest)
-            .filter_map(|prop| {
-                let prop = prop.trim();
-                if prop.is_empty() || prop.starts_with("...") {
-                    return None;
-                }
-                let key = if let Some(colon_pos) = find_derived_property_colon(prop) {
-                    prop[..colon_pos].trim()
-                } else if let Some(eq_pos) = find_default_equals(prop) {
-                    prop[..eq_pos].trim()
-                } else {
-                    prop
-                };
-                Some(exclude_key_literal(key))
-            })
-            .collect();
+        let excluded_keys: Vec<String> = if has_rest {
+            exclude_from_object_keys(&props)
+        } else {
+            Vec::new()
+        };
 
         for prop in &props {
             let prop = prop.trim();

--- a/crates/rsvelte_core/tests/legacy_assignment_destructure_2138.rs
+++ b/crates/rsvelte_core/tests/legacy_assignment_destructure_2138.rs
@@ -1,0 +1,158 @@
+//! Regression tests for issue #2138 — the legacy (non-runes) destructuring
+//! *assignment* expansion (`({ a, ...rest } = obj)`).
+//!
+//! Upstream lowers it through `extract_paths` too (`visit_assignment_expression`
+//! in `3-transform/shared/assignments.js`), so an object pattern with an
+//! identifier right-hand side stays a plain sequence — the `$$value` IIFE is
+//! reserved for `inserts.length > 0 || should_cache` — the rest reads
+//! `$.exclude_from_object(<rhs>, [<keys>])`, and every key keeps upstream's
+//! `b.literal(...)` / `b.call('String', key)` form.
+
+use rsvelte_core::{CompileOptions, GenerateMode, compile, compiler::CssMode};
+
+fn compile_client(src: &str) -> String {
+    compile(
+        src,
+        CompileOptions {
+            filename: Some("Comp.svelte".to_string()),
+            generate: GenerateMode::Client,
+            css: CssMode::External,
+            ..Default::default()
+        },
+    )
+    .expect("compile")
+    .js
+    .code
+}
+
+/// Collapse the sequence expression the printer spreads over several lines so a
+/// single `assert!` can pin the whole lowering.
+fn flat(code: &str) -> String {
+    code.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+#[test]
+fn object_rest_with_identifier_rhs_is_a_sequence_not_an_iife() {
+    let src = r#"<script>
+	let a = 1, b = 2, rest = {};
+	const obj = { a: 1, b: 2, c: 3 };
+	function f() { ({ a, b, ...rest } = obj); }
+</script>
+<button onclick={f}>{a} {b} {JSON.stringify(rest)}</button>"#;
+    let out = flat(&compile_client(src));
+    assert!(
+        out.contains(
+            "( $.set(a, obj.a), $.set(b, obj.b), $.set(rest, $.exclude_from_object(obj, ['a', 'b'])) );"
+        ),
+        "in:\n{out}"
+    );
+    assert!(!out.contains("$$value"), "in:\n{out}");
+}
+
+/// Upstream caches the value in `$$value` only when it is not an identifier.
+#[test]
+fn object_rest_with_call_rhs_keeps_the_iife() {
+    let src = r#"<script>
+	let a = 1, rest = {};
+	function get() { return { a: 1, c: 3 }; }
+	function f() { ({ a, ...rest } = get()); }
+</script>
+<button onclick={f}>{a} {JSON.stringify(rest)}</button>"#;
+    let out = flat(&compile_client(src));
+    assert!(
+        out.contains(
+            "(($$value) => { $.set(a, $$value.a); $.set(rest, $.exclude_from_object($$value, ['a'])); })(get());"
+        ),
+        "in:\n{out}"
+    );
+}
+
+/// The key list is built with `b.literal(...)` (identifier and `Literal` keys
+/// become string literals, any other computed key becomes `String(<expr>)`),
+/// while the member reads keep bracket notation for the same keys. Getting
+/// either wrong used to emit unparseable code (`obj.'b-c'`, `''b-c''`), which
+/// made the downstream AST pass bail and drop every `$.set` in the statement.
+#[test]
+fn literal_and_computed_keys_are_lowered_like_upstream() {
+    let src = r#"<script>
+	const key = 'd';
+	let a = 1, bc = 0, three = 0, dee = 0, rest = {};
+	const obj = { a: 1 };
+	function f() { ({ a, 'b-c': bc, 3: three, [key]: dee, ...rest } = obj); }
+</script>
+<button onclick={f}>{a} {bc} {three} {dee} {JSON.stringify(rest)}</button>"#;
+    let out = flat(&compile_client(src));
+    assert!(out.contains("$.set(bc, obj['b-c'])"), "in:\n{out}");
+    assert!(out.contains("$.set(three, obj[3])"), "in:\n{out}");
+    assert!(out.contains("$.set(dee, obj[key])"), "in:\n{out}");
+    assert!(
+        out.contains("$.set(rest, $.exclude_from_object(obj, ['a', 'b-c', '3', String(key)]))"),
+        "in:\n{out}"
+    );
+}
+
+#[test]
+fn store_and_prop_targets_keep_their_setters_next_to_a_rest() {
+    let store = r#"<script>
+	import { writable } from 'svelte/store';
+	const s1 = writable(0);
+	let rest = {};
+	const obj = { s1: 1, c: 2 };
+	function f() { ({ s1: $s1, ...rest } = obj); }
+</script>
+<button onclick={f}>{$s1} {JSON.stringify(rest)}</button>"#;
+    let out = flat(&compile_client(store));
+    assert!(
+        out.contains(
+            "( $.store_set(s1, obj.s1), $.set(rest, $.exclude_from_object(obj, ['s1'])) );"
+        ),
+        "in:\n{out}"
+    );
+
+    let prop = r#"<script>
+	export let a = 1;
+	let rest = {};
+	const obj = { a: 1, c: 2 };
+	function f() { ({ a, ...rest } = obj); }
+</script>
+<button onclick={f}>{a} {JSON.stringify(rest)}</button>"#;
+    let out = flat(&compile_client(prop));
+    assert!(
+        out.contains("(a(obj.a), $.set(rest, $.exclude_from_object(obj, ['a'])));"),
+        "in:\n{out}"
+    );
+}
+
+/// A pattern default is `$.fallback(...)`, and a non-standalone destructure ends
+/// the sequence with the right-hand side so the expression still has a value.
+#[test]
+fn defaults_and_non_standalone_destructures_match_upstream() {
+    let src = r#"<script>
+	let a = 1, rest = {};
+	const obj = { c: 2 };
+	function f() { ({ a = 5, ...rest } = obj); }
+</script>
+<button onclick={f}>{a} {JSON.stringify(rest)}</button>"#;
+    let out = flat(&compile_client(src));
+    assert!(
+        out.contains(
+            "( $.set(a, $.fallback(obj.a, 5)), $.set(rest, $.exclude_from_object(obj, ['a'])) );"
+        ),
+        "in:\n{out}"
+    );
+
+    let src = r#"<script>
+	let a = 1, rest = {};
+	const obj = { a: 1, c: 2 };
+	let out = null;
+	function f() { out = ({ a, ...rest } = obj); }
+</script>
+<button onclick={f}>{a} {JSON.stringify(rest)} {JSON.stringify(out)}</button>"#;
+    let out = flat(&compile_client(src));
+    assert!(
+        out.contains(
+            "$.set(out, ( $.set(a, obj.a), $.set(rest, $.exclude_from_object(obj, ['a'])), obj ));"
+        ),
+        "in:\n{out}"
+    );
+}


### PR DESCRIPTION
Fixes #2138

## Cause

`generate_destructure_iife()` — the legacy (non-runes) expansion of a
destructuring **assignment** (`({ a, ...rest } = obj)`, the sibling of the
declaration path fixed in #2137) — built its member reads and its own
`$.exclude_from_object` key list straight from the pattern's source text:

- `format!("{}.{}", rhs, key)` / `member_access("$$value", key)` for the reads,
  so a literal or computed key produced `obj.'b-c'`, `$$value.3`, `obj.[key]`;
- `format!("'{}'", key)` for the key list, so the same keys came out re-quoted
  (`''b-c''`, `'[key]'`) instead of upstream's decoded literal / `String(<expr>)`.

The invalid member reads are what made `$.set` disappear: the statement no
longer parses, so the downstream AST pass (`transform_state_assigns_ast`, and
the prop-assignment pass next to it) returns `None` and the text is emitted
verbatim — every `$.set(...)` and prop call in that statement is lost, not just
the offending one.

Separately, the sequence-vs-IIFE choice rejected any rest element. Upstream
(`visit_assignment_expression`, `3-transform/shared/assignments.js`) only caches
the value in a `$$value` IIFE when `inserts.length > 0 || should_cache`;
`inserts` come from array patterns and `should_cache` from a non-identifier
right-hand side, so a rest is an ordinary `extract_paths` path and
`({ a, ...rest } = obj)` stays a plain sequence.

## Fix

- Member reads go through the shared `derived_prop_access()`, mirroring
  upstream's `b.member(expression, prop.key, prop.computed || prop.key.type !==
  'Identifier')`.
- The key list is now built by one shared `exclude_from_object_keys()` helper
  (in `rune_transforms.rs`, over the existing `exclude_key_literal()`), which the
  declaration path from #2137 now calls too instead of keeping its own inline copy.
- A rest element no longer forces the IIFE — only a nested rest target
  (`...{ z }`) does, which this PR does not otherwise touch.

`member_access()` is deleted; `derived_prop_access()` is a strict superset.

## Before / after

```svelte
<script>
	const key = 'd';
	let a = 1, bc = 0, three = 0, dee = 0, rest = {};
	const obj = { a: 1 };
	function f() { ({ a, 'b-c': bc, 3: three, [key]: dee, ...rest } = obj); }
</script>
```

Before — no `$.set` anywhere, invalid reads, re-quoted keys:

```js
function f() { (($$value) => {
	a = $$value.a;
	bc = $$value.'b-c';
	three = $$value.3;
	dee = $$value[key];
	rest = $.exclude_from_object($$value, ['a', ''b-c'', '3', '[key]']);
})(obj); }
```

After — byte-identical to the official compiler:

```js
function f() {
	(
		$.set(a, obj.a),
		$.set(bc, obj['b-c']),
		$.set(three, obj[3]),
		$.set(dee, obj[key]),
		$.set(rest, $.exclude_from_object(obj, ['a', 'b-c', '3', String(key)]))
	);
}
```

## Verification

- 30 hand-written repros (object / array, rest / no rest, identifier and
  literal / numeric / computed keys, `$state` / store / prop / member targets,
  standalone and in-expression, reactive statement, each-block, runes mode)
  diffed against the official compiler on all three corpus targets: every case
  the issue covers is now byte-identical.
- New regression suite `crates/rsvelte_core/tests/legacy_assignment_destructure_2138.rs`;
  `legacy_destructure_rest_2078.rs` still passes.
- `cargo test --release -p rsvelte_core` for runtime, ssr, compiler_fixtures,
  compiler_errors, css, validator, parser_fixtures, print, preprocess,
  sourcemaps, sourcemaps_gate — all green.
- Corpus (svelte + pattern, the sources available locally): no regressions,
  client / server ratchets stay empty, client-dev unchanged.
- New pattern-corpus repro `pattern/issues/2138-legacy-assignment-destructure-rest.svelte`
  matches on client / server / client-dev and is fmt-parity identical.

## Out of scope

Nested patterns (`({ a: { b: x } } = obj)`) are #2139 and untouched. Two
neighbouring divergences these repros surfaced are pre-existing and unrelated to
this code path: a single-element sequence loses its parens
(`({ a } = obj)` → `$.set(a, obj.a);` vs upstream `($.set(a, obj.a));`, the
redundant-paren swallow in `ast_state_transform.rs`), and a destructuring
assignment whose targets are *only* props is never recognised as reactive at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
