### PR TITLE
fix(svelte2tsx): forward default-slot `let:` from every Element kind and through blocks (#2105)

### DIFF
--- a/.changeset/svelte2tsx-default-slot-let-forwarding.md
+++ b/.changeset/svelte2tsx-default-slot-let-forwarding.md
@@ -1,0 +1,19 @@
+---
+"@rsvelte/compiler": patch
+"@rsvelte/svelte2tsx": patch
+"@rsvelte/svelte-check": patch
+---
+
+fix(svelte2tsx): forward a component's default-slot `let:` from every node kind
+official models as an `Element`, and through control-flow blocks. The wrapping
+only covered a direct `RegularElement` / `<svelte:fragment>` child, so
+`<Foo><svelte:element let:x>`, `<Foo><slot let:x>` and any `{#if}` / `{#each}` /
+`{#await}` / `{#key}`-nested `<div let:x>` dropped their `$$slot_def.default`
+prologue and emitted a bogus `"let:x": true` attribute, leaving every `let:`
+binding an undeclared identifier in the generated TSX. A component-direct
+`<style let:x>` no longer leaves an orphaned `$$slot_def` block behind (official
+deletes the whole `<style>` range, block included) nor steals one space from the
+next sibling's indent. `<svelte:fragment>` / `<svelte:boundary>` also stop
+leaking their enclosing component's slot scope into their own children, and a
+block-nested one with a static `slot="name"` now gets the `$$slot_def["name"]`
+wrapper instead of a plain `slot` attribute.

--- a/crates/rsvelte_projection/src/svelte2tsx/template/ctx.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/template/ctx.rs
@@ -103,17 +103,6 @@ pub(super) struct Counter {
     /// so `handle_component` must NOT re-emit them as the component's own
     /// default-slot let block. Consumed once at the top of `handle_component`.
     pub(super) suppress_component_lets: bool,
-    /// Set just before `process_component_children_with_slots` processes a
-    /// default-slot child that carries its OWN `let:` directives (`<div
-    /// let:x>` / `<svelte:fragment let:x>`): official's `Element.
-    /// performTransformation` emits the `$$slot_def.default` destructure as
-    /// part of the SAME `transform()` call as the element's own opening-tag
-    /// rewrite, so the element's leading gap is folded into that destructure's
-    /// block-open rather than the element's own indent. The element/fragment
-    /// handler must therefore force its own computed `before_block` to 0.
-    /// Consumed once at the top of `handle_regular_element` /
-    /// `handle_svelte_special_element`.
-    pub(super) suppress_default_slot_let_indent: bool,
 }
 
 impl Counter {
@@ -124,7 +113,6 @@ impl Counter {
             slot_inst: None,
             named_slot_component_close: false,
             suppress_component_lets: false,
-            suppress_default_slot_let_indent: false,
         }
     }
     pub(super) fn next_slot(&mut self) -> u32 {

--- a/crates/rsvelte_projection/src/svelte2tsx/template/nodes/component_slots.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/template/nodes/component_slots.rs
@@ -104,36 +104,122 @@ pub(crate) fn has_component_slot_children(fragment: &Fragment, source: &str) -> 
     false
 }
 
-/// Check if any *direct* child carries `let:` directives that destructure from
-/// THIS component's `$$slot_def` — i.e. a default-slot let receiver that is an
-/// *element* such as `<svelte:fragment let:a={x}>`, `<div let:foo>` or
-/// `<svelte:element let:foo>`. Such an element child references the parent
-/// component (`Element.addSlotLet` → `this.parent.name`), so the parent needs
-/// the `const $$_inst = new …` form.
+/// The `let:`-bearing attributes of an *element-kind* node — every node official
+/// svelte2tsx models as an `Element` (`Element` / `Slot` / `SlotTemplate` /
+/// `Title` / the `svelte:` meta tags), whose `let:` destructures from the
+/// ENCLOSING component's `$$slot_def` (`Element.addSlotLet` →
+/// `this.parent.name`).
 ///
-/// Component-kind children (`<Child let:foo>`, `<svelte:component let:foo>`,
-/// `<svelte:self let:foo>`) are excluded: their `let:` belongs to their OWN
-/// slot (`InlineComponent.addSlotLet` → `this.name`), so they do NOT force the
-/// parent's instance const. `let:` directives are only meaningful on direct
-/// children of a component, so this does not recurse.
-pub(crate) fn has_default_slot_let_children(fragment: &Fragment, _source: &str) -> bool {
+/// Component-kind nodes (`<Child let:foo>`, `<svelte:component let:foo>`,
+/// `<svelte:self let:foo>`) return `None`: their `let:` belongs to their OWN
+/// slot (`InlineComponent.addSlotLet` → `this.name`).
+fn element_kind_attributes<'a>(node: &'a TemplateNode<'a>) -> Option<&'a [Attribute<'a>]> {
+    match node {
+        TemplateNode::RegularElement(el) => Some(&el.attributes),
+        TemplateNode::SlotElement(el) => Some(&el.attributes),
+        TemplateNode::SvelteElement(el) => Some(&el.attributes),
+        TemplateNode::TitleElement(el) => Some(&el.attributes),
+        TemplateNode::SvelteFragment(el)
+        | TemplateNode::SvelteBoundary(el)
+        | TemplateNode::SvelteHead(el)
+        | TemplateNode::SvelteBody(el)
+        | TemplateNode::SvelteDocument(el)
+        | TemplateNode::SvelteOptions(el)
+        | TemplateNode::SvelteWindow(el) => Some(&el.attributes),
+        _ => None,
+    }
+}
+
+/// Check whether any element-kind node in THIS component's slot scope carries
+/// `let:` directives, and so destructures from the component's `$$slot_def` —
+/// which forces the `const $$_inst = new …` form.
+///
+/// Control-flow blocks are transparent to that scope: official svelte2tsx only
+/// pushes its `element` stack for elements/components, so a `<div let:x>` nested
+/// in `{#if}` / `{#each}` / `{#await}` / `{#key}` still has the component as its
+/// `parent`. This therefore recurses through blocks but NOT into nested
+/// elements/components (each owns its own slot scope) nor `{#snippet}` bodies
+/// (official resets `element` to `undefined` there).
+pub(crate) fn has_default_slot_let_children(fragment: &Fragment) -> bool {
     fragment.nodes.iter().any(|node| {
-        // Only NON-component default-slot children forward their `let:` bindings
-        // to the enclosing component's `$$slot_def.default`. A component child
-        // (`<Child let:x>` / `<svelte:component let:x>` / `<svelte:self let:x>`)
-        // binds `let:x` from its OWN `$$slot_def.default` — its own
-        // `handle_component` emits that destructure — so it must not mark the
-        // parent as needing an instance var. Mirrors official svelte2tsx, where
-        // only `Element`/`SlotElement`/`InlineComponent` *slot content* (not the
-        // inline component's own lets) routes through the parent slot.
-        let attrs = match node {
-            TemplateNode::RegularElement(el) => &el.attributes,
-            TemplateNode::SvelteFragment(f) => &f.attributes,
-            TemplateNode::SvelteElement(e) => &e.attributes,
-            _ => return false,
-        };
-        has_let_directives(attrs)
+        if let Some(attrs) = element_kind_attributes(node) {
+            return has_let_directives(attrs);
+        }
+        match node {
+            TemplateNode::IfBlock(block) => {
+                has_default_slot_let_children(&block.consequent)
+                    || block
+                        .alternate
+                        .as_ref()
+                        .is_some_and(|alt| has_default_slot_let_children(alt))
+            }
+            TemplateNode::EachBlock(block) => {
+                has_default_slot_let_children(&block.body)
+                    || block
+                        .fallback
+                        .as_ref()
+                        .is_some_and(|fb| has_default_slot_let_children(fb))
+            }
+            TemplateNode::AwaitBlock(block) => {
+                block
+                    .pending
+                    .as_ref()
+                    .is_some_and(|p| has_default_slot_let_children(p))
+                    || block
+                        .then
+                        .as_ref()
+                        .is_some_and(|t| has_default_slot_let_children(t))
+                    || block
+                        .catch
+                        .as_ref()
+                        .is_some_and(|c| has_default_slot_let_children(c))
+            }
+            TemplateNode::KeyBlock(block) => has_default_slot_let_children(&block.fragment),
+            _ => false,
+        }
     })
+}
+
+/// The `$$slot_def.default` destructure an element-kind child of a component
+/// emits for its OWN `let:` directives, or `None` when `slot_inst` says this
+/// node is not in a component's slot scope, it has no `let:`, or a static
+/// `slot=` retargets it at a NAMED slot (official's `addSlotName` replaces the
+/// `default` key, so those callers emit the `$$slot_def["…"]` form instead).
+/// Mirrors `Element.performTransformation`'s `slotLetsTransformation`.
+///
+/// The block is emitted by the node's own handler, and therefore *after* the
+/// handler's leading gap — official runs it through the SAME `transform()` call
+/// as the opening-tag rewrite, so the gap precedes the destructure.
+pub(crate) fn default_slot_let_block(
+    attributes: &[Attribute],
+    slot_inst: Option<&String>,
+    source: &str,
+) -> Option<String> {
+    let inst = slot_inst?;
+    if !has_let_directives(attributes) || slot_attr_static_name(attributes).is_some() {
+        return None;
+    }
+    Some(format!(
+        "{{const {{/*\u{03A9}ignore_start\u{03A9}*/$$_$$/*\u{03A9}ignore_end\u{03A9}*/,{}}} = {}.$$slot_def.default;$$_$$;",
+        build_let_destructure_string(attributes, source),
+        inst
+    ))
+}
+
+/// The `$$slot_def["name"]` destructure an element-kind child emits when a
+/// static `slot=` retargets it at a named slot (official `addSlotName`).
+pub(crate) fn named_slot_let_block(
+    attributes: &[Attribute],
+    inst: &str,
+    target_slot: &str,
+    source: &str,
+) -> String {
+    format!(
+        "{{const {{/*\u{03A9}ignore_start\u{03A9}*/$$_$$/*\u{03A9}ignore_end\u{03A9}*/,{}}} = {}.$$slot_def[\"{}\"];$$_$$;",
+        build_let_destructure_string(attributes, source),
+        inst,
+        target_slot
+    )
 }
 
 /// Check if any children have `slot="name"` attributes (named slots).
@@ -247,45 +333,21 @@ pub(crate) fn process_component_children_with_slots(
     counter: &mut Counter,
     depth: u32,
 ) -> bool {
-    // Build the default slot destructuring if needed
-    let let_destructure = if has_lets {
-        build_let_destructure_string(attributes, source)
-    } else {
-        String::new()
-    };
-
-    // Group children into default slot and named slots
-    // For each child, determine if it belongs to a named slot or the default slot
-    // Named slot children get their own $$slot_def blocks
-    // Default slot children are wrapped in a single block with the component's let: destructuring
-
-    // We need to track which children are named slots and process them specially.
-    // The approach: iterate over children, and for each named-slot child, emit
-    // a separate $$slot_def block. Non-named-slot children are part of the default slot.
-    //
-    // The default slot block is opened before the first default slot child and closed
-    // after the last one (or before the first named slot child).
-
-    let mut default_slot_opened = false;
+    // The component's OWN `let:` directives open a single `$$slot_def.default`
+    // block before the first child; it stays open across every child (named-slot
+    // children nest their own `$$slot_def["…"]` block inside it) and is closed
+    // after the last one.
     let mut prev_end: Option<u32> = None;
 
-    // If there are let: directives, we need to open the default slot block
-    // before any children (including text nodes).
-    if has_lets {
-        // We'll open the default slot block at the position of the first child
-        // or immediately after the opening tag
-        let block_open = format!(
-            "{{const {{/*\u{03A9}ignore_start\u{03A9}*/$$_$$/*\u{03A9}ignore_end\u{03A9}*/,{}}} = {}.$$slot_def.default;$$_$$;",
-            let_destructure, inst_var
+    if has_lets && let Some(first_node) = fragment.nodes.first() {
+        str.append_left_fmt(
+            first_node.start(),
+            format_args!(
+                "{{const {{/*\u{03A9}ignore_start\u{03A9}*/$$_$$/*\u{03A9}ignore_end\u{03A9}*/,{}}} = {}.$$slot_def.default;$$_$$;",
+                build_let_destructure_string(attributes, source),
+                inst_var
+            ),
         );
-
-        // Find where to insert the block open
-        if let Some(first_node) = fragment.nodes.first() {
-            let first_start = first_node.start();
-            // Insert the block opening before the first child
-            str.append_left(first_start, &block_open);
-        }
-        default_slot_opened = true;
     }
 
     for node in &fragment.nodes {
@@ -337,78 +399,25 @@ pub(crate) fn process_component_children_with_slots(
                 }
             }
         } else {
-            // Default slot child - process normally
-            // If the default slot block was closed for a named slot, re-open it
-            if has_lets && !default_slot_opened {
-                let block_open = format!(
-                    "{{const {{/*\u{03A9}ignore_start\u{03A9}*/$$_$$/*\u{03A9}ignore_end\u{03A9}*/,{}}} = {}.$$slot_def.default;$$_$$;",
-                    let_destructure, inst_var
-                );
-                str.append_left(node.start(), &block_open);
-                default_slot_opened = true;
-            }
-            // A default-slot child (`<svelte:fragment let:foo>`, `<div let:foo>`)
-            // with no `slot=` but its OWN `let:` directives needs a
-            // `$$slot_def.default` destructure block referencing the ENCLOSING
-            // component — JS reference's Element.performTransformation emits one
-            // whenever the default-slot child has `let:` directives. Wrap the
-            // child so the `let:` bindings are scoped to its body.
-            //
-            // A COMPONENT child (`<Child let:foo>`) is excluded: its `let:foo`
-            // binds from `Child`'s OWN `$$slot_def.default`, which its own
-            // `handle_component` already emits. Routing it through the parent
-            // here would wrongly duplicate the destructure onto the parent
-            // instance (#1232).
-            let fragment_lets = match node {
-                TemplateNode::SvelteFragment(el) if has_let_directives(&el.attributes) => {
-                    Some(el.attributes.as_slice())
-                }
-                TemplateNode::RegularElement(el) if has_let_directives(&el.attributes) => {
-                    Some(el.attributes.as_slice())
-                }
-                _ => None,
-            };
-            let fragment_block_open = if let Some(attributes) = fragment_lets {
-                let destructure = build_let_destructure_string(attributes, source);
-                let block = format!(
-                    "{{const {{/*\u{03A9}ignore_start\u{03A9}*/$$_$$/*\u{03A9}ignore_end\u{03A9}*/,{}}} = {}.$$slot_def.default;$$_$$;",
-                    destructure, inst_var
-                );
-                // Official's `Element.performTransformation` runs the slot-let
-                // destructure through the SAME `transform()` call as the
-                // element/fragment's own opening-tag rewrite, so the leading gap
-                // ahead of `<div`/`<svelte:fragment` is folded into this
-                // block-open instead of the wrapped node's own indent. Compute
-                // that gap here (mirroring the wrapped node's own opener_spacing
-                // call) and tell the handler to suppress it.
-                let before_block = default_slot_let_before_block(node, source, counter);
-                str.append_left_fmt(
-                    node.start(),
-                    format_args!("{}{}", " ".repeat(before_block), block),
-                );
-                counter.suppress_default_slot_let_indent = true;
-                true
-            } else {
-                false
-            };
-            // Mark the component slot context so a `slot="…"` element nested
-            // inside this default-slot child's control-flow blocks (`{#if}` /
-            // `{#each}` / …) is lowered to the named-slot form referencing this
-            // component instance. A nested element/component clears it (each
-            // owns its own slot scope) via `handle_regular_element`'s `take()`.
+            // Default-slot child: mark the component slot context and process
+            // normally. The handler itself emits the `$$slot_def.default`
+            // destructure for the node's OWN `let:` directives (mirroring
+            // `Element.performTransformation`), and the same context reaches an
+            // element nested inside this child's control-flow blocks (`{#if}` /
+            // `{#each}` / …) — which official also treats as a direct slot
+            // consumer, since blocks do not push its `element` stack. A nested
+            // element/component clears it (each owns its own slot scope) via its
+            // handler's `take()`.
             let prev_slot = counter.slot_inst.replace(inst_var.to_string());
             process_node_inplace(node, source, options, str, counter, depth);
             counter.slot_inst = prev_slot;
-            if fragment_block_open {
-                str.append_left(node.end(), "}");
-            }
         }
 
         prev_end = Some(node.end());
     }
 
-    // Close the default slot block if still open
-    if default_slot_opened && has_lets {
+    // Close the component's own default-slot block.
+    if has_lets {
         // Find the position to close: after the last node, before the closing tag
         if let Some(end) = prev_end {
             let closing_tag_start = find_closing_tag_start(source, node_end);
@@ -421,58 +430,6 @@ pub(crate) fn process_component_children_with_slots(
         }
     }
     false
-}
-
-/// The leading gap `handle_regular_element` / `handle_svelte_special_element`
-/// would themselves attribute to the wrapped node's own indent, replayed here
-/// so it can be moved ahead of the default-slot-let block-open instead (see
-/// the call site in `process_component_children_with_slots`). Only
-/// `RegularElement` and `SvelteFragment` reach here — the two node kinds
-/// `has_let_directives` is checked against above.
-fn default_slot_let_before_block(node: &TemplateNode, source: &str, counter: &Counter) -> usize {
-    match node {
-        TemplateNode::RegularElement(el) => {
-            let opening_tag_end =
-                find_opening_tag_end(source, el.start, el.end, el.name.as_str(), &el.attributes);
-            opener_spacing(
-                source,
-                el.start,
-                &el.name,
-                opening_tag_end,
-                Some((el.start + 1, el.start + 1 + el.name.len() as u32)),
-                &el.attributes,
-                &counter.element_opener_comments,
-                OpenerCtx {
-                    is_element: true,
-                    in_component_slot: true,
-                    tag_name: &el.name,
-                    is_slot_tag: false,
-                },
-            )
-            .before_block
-        }
-        TemplateNode::SvelteFragment(el) => {
-            let opening_tag_end =
-                find_opening_tag_end(source, el.start, el.end, el.name.as_str(), &el.attributes);
-            opener_spacing(
-                source,
-                el.start,
-                &el.name,
-                opening_tag_end,
-                None,
-                &el.attributes,
-                &counter.element_opener_comments,
-                OpenerCtx {
-                    is_element: true,
-                    in_component_slot: true,
-                    tag_name: &el.name,
-                    is_slot_tag: false,
-                },
-            )
-            .before_block
-        }
-        _ => 0,
-    }
 }
 
 /// Handle a regular element child with `slot="name"` attribute inside a component.

--- a/crates/rsvelte_projection/src/svelte2tsx/template/nodes/dynamic_element.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/template/nodes/dynamic_element.rs
@@ -13,7 +13,6 @@ use crate::svelte2tsx::template::attributes::binding::{
 use crate::svelte2tsx::template::attributes::build_attributes_string;
 use crate::svelte2tsx::template::attributes::class_style::build_class_style_directive_suffix_segments;
 use crate::svelte2tsx::template::attributes::directive_suffix::build_directive_prefix_suffix;
-use crate::svelte2tsx::template::attributes::let_::build_let_destructure_string;
 use crate::svelte2tsx::template::ctx::Counter;
 use crate::svelte2tsx::template::segs::segs_to_string;
 use crate::svelte2tsx::template::utils::expr::{get_expression_range, get_expression_text};
@@ -21,7 +20,9 @@ use crate::svelte2tsx::template::utils::opener_spacing::{OpenerCtx, opener_spaci
 use crate::svelte2tsx::template::utils::source::{find_closing_tag_start, find_opening_tag_end};
 use crate::svelte2tsx::template::walk::process_fragment_inplace;
 
-use super::component_slots::build_named_slot_element_attrs;
+use super::component_slots::{
+    build_named_slot_element_attrs, default_slot_let_block, named_slot_let_block,
+};
 use super::slot_element::slot_attr_static_name;
 
 /// Handle `<svelte:element this={tag}>`.
@@ -47,13 +48,12 @@ pub(crate) fn handle_svelte_dynamic_element(
         .as_ref()
         .zip(slot_attr_static_name(&el.attributes))
         .map(|(inst, name)| (inst.as_str(), name));
-    let named_slot_block = named_slot.as_ref().map(|(inst, target_slot)| {
-        let let_destructure = build_let_destructure_string(&el.attributes, source);
-        format!(
-            "{{const {{/*\u{03A9}ignore_start\u{03A9}*/$$_$$/*\u{03A9}ignore_end\u{03A9}*/,{}}} = {}.$$slot_def[\"{}\"];$$_$$;",
-            let_destructure, inst, target_slot
-        )
-    });
+    let named_slot_block = named_slot
+        .as_ref()
+        .map(|(inst, target_slot)| named_slot_let_block(&el.attributes, inst, target_slot, source));
+    // `<svelte:element let:x>` is an `Element` in official svelte2tsx, so its
+    // own `let:` forwards through the enclosing component's `$$slot_def.default`.
+    let default_slot_let = default_slot_let_block(&el.attributes, saved_slot.as_ref(), source);
 
     let raw_tag_text = get_expression_text(&el.tag, source);
     // If the `this` attribute value is a plain string literal (this="tag"),
@@ -114,13 +114,18 @@ pub(crate) fn handle_svelte_dynamic_element(
     // The slot-def block sits inside the opening tag's leading whitespace, so it
     // is emitted after the indent rather than before it.
     let indent = " ".repeat(spacing.before_block);
-    if let Some(block) = named_slot_block {
-        str.prepend_left(el.start, &format!("{}{}", indent, block));
-    }
-    let indent = if named_slot.is_some() {
-        String::new()
-    } else {
-        indent
+    let indent = match named_slot_block {
+        Some(block) => {
+            str.prepend_left(el.start, &format!("{}{}", indent, block));
+            String::new()
+        }
+        None => match &default_slot_let {
+            Some(block) => {
+                str.append_left_fmt(el.start, format_args!("{}{}", indent, block));
+                String::new()
+            }
+            None => indent,
+        },
     };
 
     // `use:` / `transition:` / `animate:` directives, same V4 emission as on a
@@ -286,8 +291,9 @@ pub(crate) fn handle_svelte_dynamic_element(
         }
     }
 
-    // Close the named-slot `$$slot_def[...]` wrapper block; restore context.
-    if named_slot.is_some() {
+    // Close the `$$slot_def[...]` / `$$slot_def.default` wrapper block; restore
+    // context.
+    if named_slot.is_some() || default_slot_let.is_some() {
         str.append_left(el.end, "}");
     }
     counter.slot_inst = saved_slot;

--- a/crates/rsvelte_projection/src/svelte2tsx/template/nodes/element.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/template/nodes/element.rs
@@ -21,7 +21,7 @@ use crate::svelte2tsx::template::utils::source::{
 };
 use crate::svelte2tsx::template::walk::process_fragment_inplace;
 
-use super::component_slots::handle_named_slot_element;
+use super::component_slots::{default_slot_let_block, handle_named_slot_element};
 use super::slot_element::{handle_slot_element, slot_attr_static_name};
 use super::snippet_block::hoist_snippet_blocks;
 
@@ -91,6 +91,13 @@ pub(crate) fn handle_regular_element(
         counter.slot_inst = saved_slot;
         return;
     }
+    // Default-slot `let:` receiver (`<div let:x>`): the bindings destructure from
+    // the enclosing component's `$$slot_def.default`, and the block scopes the
+    // element's body. Mirrors `Element.performTransformation`'s
+    // `slotLetsTransformation`. Note this is reached only after the `style`
+    // early-return above, matching official — the `<style>` node's whole range
+    // (block included) is wiped by `handleStyleTag`.
+    let default_slot_let = default_slot_let_block(&el.attributes, saved_slot.as_ref(), source);
 
     // Find the end of the opening tag (after the `>`)
     let opening_tag_end =
@@ -117,7 +124,7 @@ pub(crate) fn handle_regular_element(
         Some(opener_content_start),
     );
 
-    let mut spacing = opener_spacing(
+    let spacing = opener_spacing(
         source,
         el.start,
         &el.name,
@@ -132,13 +139,6 @@ pub(crate) fn handle_regular_element(
             is_slot_tag: false,
         },
     );
-    // A default-slot-let element (`<div let:x>`) has its leading gap folded
-    // into the `$$slot_def.default` destructure emitted by
-    // `process_component_children_with_slots` instead — see
-    // `suppress_default_slot_let_indent`'s doc comment.
-    if std::mem::take(&mut counter.suppress_default_slot_let_indent) {
-        spacing.before_block = 0;
-    }
     if spacing.in_attr_object > 0 {
         let mut padded: Vec<Seg> = Vec::with_capacity(attr_segs.len() + 1);
         padded.push(Seg::Lit(" ".repeat(spacing.in_attr_object)));
@@ -211,7 +211,17 @@ pub(crate) fn handle_regular_element(
     } else {
         String::new()
     };
+    // The slot-let destructure sits *after* the opening tag's leading gap (the
+    // gap is part of the same official `transform()` call), so emit the gap with
+    // it and leave the createElement block unindented.
     let indent = " ".repeat(spacing.before_block);
+    let indent = match &default_slot_let {
+        Some(block) => {
+            str.append_left_fmt(el.start, format_args!("{}{}", indent, block));
+            String::new()
+        }
+        None => indent,
+    };
     let header_lit = if !directive_prefix.is_empty() {
         format!(
             "{}{{{}{{ {}svelteHTML.createElement(\"{}\"{}, {{",
@@ -284,6 +294,9 @@ pub(crate) fn handle_regular_element(
             str.append_left_fmt(el.end, format_args!("}}{}", extra_close));
         }
     }
+    if default_slot_let.is_some() {
+        str.append_left(el.end, "}");
+    }
     // Restore the slot context for following siblings (this element's own
     // children were processed with it cleared, via the `take()` above).
     counter.slot_inst = saved_slot;
@@ -302,13 +315,19 @@ pub(crate) fn handle_title_element(
         return;
     }
 
+    // `<title>` is an `Element` in official svelte2tsx, so it owns its own slot
+    // scope (children must not inherit the component context) and forwards its
+    // own `let:` through the enclosing component's `$$slot_def.default`.
+    let saved_slot = counter.slot_inst.take();
+    let default_slot_let = default_slot_let_block(&el.attributes, saved_slot.as_ref(), source);
+
     let opening_tag_end =
         find_opening_tag_end(source, el.start, el.end, el.name.as_str(), &el.attributes);
     let attrs_str = build_attributes_string(
         &el.attributes,
         source,
         &counter.element_opener_comments,
-        counter.slot_inst.is_some(),
+        saved_slot.is_some(),
     );
 
     let spacing = opener_spacing(
@@ -321,14 +340,22 @@ pub(crate) fn handle_title_element(
         &counter.element_opener_comments,
         OpenerCtx {
             is_element: true,
-            in_component_slot: counter.slot_inst.is_some(),
+            in_component_slot: saved_slot.is_some(),
             tag_name: &el.name,
             is_slot_tag: false,
         },
     );
+    let indent = " ".repeat(spacing.before_block);
+    let indent = match &default_slot_let {
+        Some(block) => {
+            str.append_left_fmt(el.start, format_args!("{}{}", indent, block));
+            String::new()
+        }
+        None => indent,
+    };
     let opener = format!(
         "{}{{ svelteHTML.createElement(\"title\", {{{}{}}});",
-        " ".repeat(spacing.before_block),
+        indent,
         " ".repeat(spacing.in_attr_object),
         attrs_str
     );
@@ -343,4 +370,8 @@ pub(crate) fn handle_title_element(
     } else {
         str.append_left(el.end, " }");
     }
+    if default_slot_let.is_some() {
+        str.append_left(el.end, "}");
+    }
+    counter.slot_inst = saved_slot;
 }

--- a/crates/rsvelte_projection/src/svelte2tsx/template/nodes/inline_component.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/template/nodes/inline_component.rs
@@ -141,7 +141,7 @@ pub(crate) fn handle_component(
     // it likewise needs the `const $$_inst = new …` form. Mirrors official's
     // `Element.addSlotLet` → `performTransformation` referencing
     // `this.parent.name`.
-    let children_have_default_slot_lets = has_default_slot_let_children(&comp.fragment, source);
+    let children_have_default_slot_lets = has_default_slot_let_children(&comp.fragment);
 
     // Named `{#snippet}` blocks that are direct children of a component are
     // passed as *implicit props* (`props: { name: (params) => … }`), not as
@@ -660,7 +660,7 @@ pub(crate) fn handle_svelte_component(
     // `bind:` directives, or children that reference the instance's slot defs
     // (named-slot children anywhere in blocks, or default-slot `let:` receivers).
     let children_have_named_slots = has_named_slot_children(&comp.fragment);
-    let children_have_default_slot_lets = has_default_slot_let_children(&comp.fragment, source);
+    let children_have_default_slot_lets = has_default_slot_let_children(&comp.fragment);
     let needs_inst = has_events
         || has_lets_scomp
         || has_binds

--- a/crates/rsvelte_projection/src/svelte2tsx/template/nodes/slot_element.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/template/nodes/slot_element.rs
@@ -6,13 +6,14 @@ use crate::svelte2tsx::svelte2tsx::Svelte2TsxOptions;
 
 use crate::svelte2tsx::template::attributes::attribute::format_attribute_node;
 use crate::svelte2tsx::template::attributes::binding::format_bind_directive;
-use crate::svelte2tsx::template::attributes::let_::build_let_destructure_string;
 use crate::svelte2tsx::template::attributes::spread::format_spread_attribute;
 use crate::svelte2tsx::template::ctx::Counter;
 use crate::svelte2tsx::template::utils::expr::get_expression_text;
 use crate::svelte2tsx::template::utils::opener_spacing::{OpenerCtx, opener_spacing};
 use crate::svelte2tsx::template::utils::source::{find_closing_tag_start, find_opening_tag_end};
 use crate::svelte2tsx::template::walk::process_fragment_inplace;
+
+use super::component_slots::{default_slot_let_block, named_slot_let_block};
 
 /// Handle `<slot>` element.
 ///
@@ -42,13 +43,12 @@ pub(crate) fn handle_slot_element(
         .as_ref()
         .zip(slot_attr_static_name(&el.attributes))
         .map(|(inst, name)| (inst.as_str(), name));
-    let named_slot_block = named_slot.as_ref().map(|(inst, target_slot)| {
-        let let_destructure = build_let_destructure_string(&el.attributes, source);
-        format!(
-            "{{const {{/*\u{03A9}ignore_start\u{03A9}*/$$_$$/*\u{03A9}ignore_end\u{03A9}*/,{}}} = {}.$$slot_def[\"{}\"];$$_$$;",
-            let_destructure, inst, target_slot
-        )
-    });
+    let named_slot_block = named_slot
+        .as_ref()
+        .map(|(inst, target_slot)| named_slot_let_block(&el.attributes, inst, target_slot, source));
+    // `<slot let:x>` is an `Element` in official svelte2tsx, so its own `let:`
+    // forwards through the enclosing component's `$$slot_def.default`.
+    let default_slot_let = default_slot_let_block(&el.attributes, saved_slot.as_ref(), source);
 
     let opening_tag_end =
         find_opening_tag_end(source, el.start, el.end, el.name.as_str(), &el.attributes);
@@ -93,7 +93,13 @@ pub(crate) fn handle_slot_element(
             str.prepend_left(el.start, &format!("{}{}", indent, block));
             String::new()
         }
-        None => indent,
+        None => match &default_slot_let {
+            Some(block) => {
+                str.append_left_fmt(el.start, format_args!("{}{}", indent, block));
+                String::new()
+            }
+            None => indent,
+        },
     };
     let opener = if bind_this_expr.is_some() {
         format!(
@@ -143,9 +149,9 @@ pub(crate) fn handle_slot_element(
         }
     }
 
-    // Close the named-slot `$$slot_def[...]` wrapper block, then restore the
-    // slot context for following siblings.
-    if named_slot.is_some() {
+    // Close the `$$slot_def[...]` / `$$slot_def.default` wrapper block, then
+    // restore the slot context for following siblings.
+    if named_slot.is_some() || default_slot_let.is_some() {
         str.append_left(el.end, "}");
     }
     counter.slot_inst = saved_slot;

--- a/crates/rsvelte_projection/src/svelte2tsx/template/nodes/snippet_block.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/template/nodes/snippet_block.rs
@@ -187,8 +187,12 @@ pub(crate) fn handle_snippet_block_inner(
         // entering a SnippetBlock, so element/component names inside a snippet
         // body always count depth from the snippet (e.g. `<Child>` directly in
         // a snippet is `$$_…C0C`), regardless of how deeply the snippet itself
-        // is nested in elements / `<svelte:boundary>`.
+        // is nested in elements / `<svelte:boundary>`. That reset also drops the
+        // enclosing component's slot scope, so a `let:`/`slot=` inside the body
+        // is a plain attribute rather than a `$$slot_def` consumer.
+        let saved_slot = counter.slot_inst.take();
         process_fragment_inplace(&block.body, source, options, str, counter, 0);
+        counter.slot_inst = saved_slot;
 
         let body_end = block.body.nodes.last().unwrap().end();
         if body_end < block.end {

--- a/crates/rsvelte_projection/src/svelte2tsx/template/nodes/special_element.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/template/nodes/special_element.rs
@@ -17,6 +17,10 @@ use crate::svelte2tsx::template::utils::opener_spacing::{OpenerCtx, opener_spaci
 use crate::svelte2tsx::template::utils::source::{find_closing_tag_start, find_opening_tag_end};
 use crate::svelte2tsx::template::walk::{process_fragment_inplace, process_node_inplace};
 
+use super::component_slots::{
+    build_named_slot_element_attrs, default_slot_let_block, named_slot_let_block,
+};
+use super::slot_element::slot_attr_static_name;
 use super::snippet_block::handle_snippet_block_as_component_prop;
 
 /// Handle Svelte special elements (svelte:body, svelte:window, etc.).
@@ -44,18 +48,38 @@ pub(crate) fn handle_svelte_special_element(
         return;
     }
 
+    // These are all `Element`s in official svelte2tsx: they own their own slot
+    // scope (children must not inherit the component context) and forward their
+    // own `let:` through the enclosing component's `$$slot_def`, keyed by a
+    // static `slot=` when present.
+    let saved_slot = counter.slot_inst.take();
+    let named_slot: Option<(&str, &str)> = saved_slot
+        .as_ref()
+        .zip(slot_attr_static_name(&el.attributes))
+        .map(|(inst, name)| (inst.as_str(), name));
+    let named_slot_block = named_slot
+        .as_ref()
+        .map(|(inst, target_slot)| named_slot_let_block(&el.attributes, inst, target_slot, source));
+    let default_slot_let = default_slot_let_block(&el.attributes, saved_slot.as_ref(), source);
+
     let opening_tag_end =
         find_opening_tag_end(source, el.start, el.end, el.name.as_str(), &el.attributes);
-    let mut attrs_str = build_attributes_string(
-        &el.attributes,
-        source,
-        &counter.element_opener_comments,
-        counter.slot_inst.is_some(),
-    );
+    // In a named-slot context the `slot` attribute is consumed by the wrapper
+    // block, so build the attributes without it.
+    let mut attrs_str = if named_slot.is_some() {
+        build_named_slot_element_attrs(&el.attributes, source)
+    } else {
+        build_attributes_string(
+            &el.attributes,
+            source,
+            &counter.element_opener_comments,
+            saved_slot.is_some(),
+        )
+    };
 
     // The special `svelte:…` elements name themselves with a literal in the start
     // transformation, so it contributes no source range.
-    let mut spacing = opener_spacing(
+    let spacing = opener_spacing(
         source,
         el.start,
         &el.name,
@@ -65,24 +89,26 @@ pub(crate) fn handle_svelte_special_element(
         &counter.element_opener_comments,
         OpenerCtx {
             is_element: true,
-            in_component_slot: counter.slot_inst.is_some(),
+            in_component_slot: saved_slot.is_some(),
             tag_name: &el.name,
             is_slot_tag: false,
         },
     );
-    // A default-slot-let `<svelte:fragment let:x>` has its leading gap folded
-    // into the `$$slot_def.default` destructure emitted by
-    // `process_component_children_with_slots` instead — see
-    // `suppress_default_slot_let_indent`'s doc comment.
-    if std::mem::take(&mut counter.suppress_default_slot_let_indent) {
-        spacing.before_block = 0;
-    }
     if spacing.in_attr_object > 0 {
         let mut padded = " ".repeat(spacing.in_attr_object);
         padded.push_str(&attrs_str);
         attrs_str = padded;
     }
+    // The slot-let destructure sits *after* the opening tag's leading gap, so
+    // emit the gap with it and leave the createElement block unindented.
     let indent = " ".repeat(spacing.before_block);
+    let indent = match named_slot_block.as_ref().or(default_slot_let.as_ref()) {
+        Some(block) => {
+            str.append_left_fmt(el.start, format_args!("{}{}", indent, block));
+            String::new()
+        }
+        None => indent,
+    };
 
     // `svelte:boundary` treats direct {#snippet} children as implicit props on
     // the `createElement` attrs object — exactly like InlineComponent in the
@@ -254,4 +280,9 @@ pub(crate) fn handle_svelte_special_element(
             str.append_left_fmt(el.end, format_args!("}}{}", extra_close));
         }
     }
+
+    if named_slot.is_some() || default_slot_let.is_some() {
+        str.append_left(el.end, "}");
+    }
+    counter.slot_inst = saved_slot;
 }

--- a/crates/rsvelte_projection/tests/svelte2tsx_slot_let_forwarding_2105.rs
+++ b/crates/rsvelte_projection/tests/svelte2tsx_slot_let_forwarding_2105.rs
@@ -1,0 +1,190 @@
+//! Regression tests for #2105: a component's default-slot `let:` forwarding is
+//! driven by *which node kinds official svelte2tsx models as an `Element`* and
+//! by the fact that control-flow blocks never push its element stack. rsvelte
+//! only wrapped a direct `RegularElement` / `<svelte:fragment>` child, so
+//! `<svelte:element>` / `<slot>` / block-nested elements silently dropped their
+//! `let:` (emitting a bogus `"let:x": true` attribute instead), and a
+//! `<style let:x>` produced an orphaned `$$slot_def` block.
+//!
+//! Every expectation below is the byte-exact template body official svelte2tsx
+//! (language-tools, parsing with svelte 5.56.8) emits for the same input.
+
+use rsvelte_projection::svelte2tsx::{Svelte2TsxOptions, svelte2tsx};
+
+fn convert(src: &str) -> String {
+    let opts = Svelte2TsxOptions {
+        filename: "Input.svelte".to_string(),
+        is_ts_file: false,
+        ..Default::default()
+    };
+    svelte2tsx(src, opts).expect("svelte2tsx ok").code
+}
+
+fn assert_contains(code: &str, expected: &str) {
+    assert!(
+        code.contains(expected),
+        "expected output to contain:\n{expected}\n\ngot:\n{code}"
+    );
+}
+
+/// `<svelte:element>` is an `Element` in official svelte2tsx, so its `let:`
+/// destructures from the enclosing component's `$$slot_def.default`.
+#[test]
+fn svelte_element_child_forwards() {
+    let code = convert("<Foo>\n\t<svelte:element this={tag} let:x>{x}</svelte:element>\n</Foo>\n");
+    assert_contains(
+        &code,
+        "\n\t {const {/*\u{03A9}ignore_start\u{03A9}*/$$_$$/*\u{03A9}ignore_end\u{03A9}*/,x,} = $$_ooF0.$$slot_def.default;$$_$$;{ svelteHTML.createElement(tag, {  });x; }}\n",
+    );
+}
+
+/// So is `<slot>` — which additionally keeps the stripped `let:`'s gap inside
+/// its (otherwise empty) props object.
+#[test]
+fn slot_element_child_forwards() {
+    let code = convert("<Foo>\n\t<slot let:x>{x}</slot>\n</Foo>\n");
+    assert_contains(
+        &code,
+        "\n\t {const {/*\u{03A9}ignore_start\u{03A9}*/$$_$$/*\u{03A9}ignore_end\u{03A9}*/,x,} = $$_ooF0.$$slot_def.default;$$_$$;{ __sveltets_createSlot(\"default\", { });x; }}\n",
+    );
+}
+
+/// Control-flow blocks are transparent to the slot scope (official never pushes
+/// its `element` stack for them), so an `{#each}`-wrapped element still forwards
+/// — and the component still needs the `const $$_inst = new …` form.
+#[test]
+fn each_wrapped_element_forwards() {
+    let code =
+        convert("<Foo>\n\t{#each items as item}\n\t\t<div let:x>{x}</div>\n\t{/each}\n</Foo>\n");
+    assert_contains(&code, "const $$_ooF0 = new $$_ooF0C(");
+    assert_contains(
+        &code,
+        "\n\t\t {const {/*\u{03A9}ignore_start\u{03A9}*/$$_$$/*\u{03A9}ignore_end\u{03A9}*/,x,} = $$_ooF0.$$slot_def.default;$$_$$;{ svelteHTML.createElement(\"div\", { });x; }}\n",
+    );
+}
+
+/// Both arms of an `{#if}` are in the same slot scope.
+#[test]
+fn if_else_wrapped_elements_forward() {
+    let code = convert(
+        "<Foo>\n\t{#if c}\n\t\t<div let:x>{x}</div>\n\t{:else}\n\t\t<span let:y>{y}</span>\n\t{/if}\n</Foo>\n",
+    );
+    assert_contains(
+        &code,
+        "\n\t\t {const {/*\u{03A9}ignore_start\u{03A9}*/$$_$$/*\u{03A9}ignore_end\u{03A9}*/,x,} = $$_ooF0.$$slot_def.default;$$_$$;{ svelteHTML.createElement(\"div\", { });x; }}\n",
+    );
+    assert_contains(
+        &code,
+        "\n\t\t {const {/*\u{03A9}ignore_start\u{03A9}*/$$_$$/*\u{03A9}ignore_end\u{03A9}*/,y,} = $$_ooF0.$$slot_def.default;$$_$$;{ svelteHTML.createElement(\"span\", { });y; }}\n",
+    );
+}
+
+/// Nesting blocks does not end the scope either.
+#[test]
+fn nested_blocks_forward() {
+    let code = convert(
+        "<Foo>\n\t{#each a as b}\n\t\t{#key k}\n\t\t\t<svelte:element this={tag} let:x>{x}</svelte:element>\n\t\t{/key}\n\t{/each}\n</Foo>\n",
+    );
+    assert_contains(
+        &code,
+        "\n\t\t\t {const {/*\u{03A9}ignore_start\u{03A9}*/$$_$$/*\u{03A9}ignore_end\u{03A9}*/,x,} = $$_ooF0.$$slot_def.default;$$_$$;{ svelteHTML.createElement(tag, {  });x; }}\n",
+    );
+}
+
+/// A `<svelte:component>` parent shares the same lowering (#2103).
+#[test]
+fn svelte_component_each_wrapped_forwards() {
+    let code = convert(
+        "<svelte:component this={Foo}>\n\t{#each a as b}\n\t\t<div let:x>{x}</div>\n\t{/each}\n</svelte:component>\n",
+    );
+    assert_contains(
+        &code,
+        "const $$_tnenopmoc_etlevs0 = new $$_tnenopmoc_etlevs0C(",
+    );
+    assert_contains(
+        &code,
+        "\n\t\t {const {/*\u{03A9}ignore_start\u{03A9}*/$$_$$/*\u{03A9}ignore_end\u{03A9}*/,x,} = $$_tnenopmoc_etlevs0.$$slot_def.default;$$_$$;{ svelteHTML.createElement(\"div\", { });x; }}\n",
+    );
+}
+
+/// `<style>` is deleted wholesale by official's `handleStyleTag`, which also
+/// wipes the `$$slot_def` block its `let:` produced — only the instance const
+/// (a side effect of naming the component) survives.
+#[test]
+fn style_child_gets_no_block() {
+    let code = convert("<Foo>\n\t<style let:x></style>\n</Foo>\n");
+    assert_contains(&code, "const $$_ooF0 = new $$_ooF0C(");
+    assert!(
+        !code.contains("$$slot_def"),
+        "a `<style let:x>` must leave no orphaned slot block, got:\n{code}"
+    );
+}
+
+/// …and it must not consume the *next* sibling's leading gap on its way out.
+#[test]
+fn style_child_does_not_steal_sibling_gap() {
+    let code = convert("<Foo>\n\t<style let:x></style>\n\t<div let:y>{y}</div>\n</Foo>\n");
+    assert_contains(
+        &code,
+        "\n\t\n\t {const {/*\u{03A9}ignore_start\u{03A9}*/$$_$$/*\u{03A9}ignore_end\u{03A9}*/,y,} = $$_ooF0.$$slot_def.default;$$_$$;{ svelteHTML.createElement(\"div\", { });y; }}\n",
+    );
+}
+
+/// A `{#snippet}` body is NOT in the component's slot scope (official resets
+/// `element` to `undefined` there), so its `let:` stays a plain attribute.
+#[test]
+fn snippet_body_is_not_forwarded() {
+    let code =
+        convert("<Foo let:z>\n\t{#snippet s()}\n\t\t<div let:y>{y}</div>\n\t{/snippet}\n</Foo>\n");
+    assert_contains(
+        &code,
+        "{ svelteHTML.createElement(\"div\", {\"let:y\":true,});y; }",
+    );
+}
+
+/// An element inside another element owns its own slot scope, so only the outer
+/// one forwards.
+#[test]
+fn nested_element_owns_its_scope() {
+    let code = convert(
+        "<Foo>\n\t<svelte:fragment let:x>\n\t\t<div let:y>{x}{y}</div>\n\t</svelte:fragment>\n</Foo>\n",
+    );
+    assert_contains(
+        &code,
+        "\n\t {const {/*\u{03A9}ignore_start\u{03A9}*/$$_$$/*\u{03A9}ignore_end\u{03A9}*/,x,} = $$_ooF0.$$slot_def.default;$$_$$;{ svelteHTML.createElement(\"svelte:fragment\", { });\n\t\t { svelteHTML.createElement(\"div\", {\"let:y\":true,});x;y; }\n\t }}\n",
+    );
+}
+
+/// `<svelte:boundary>` is an `Element` too.
+#[test]
+fn boundary_child_forwards() {
+    let code = convert("<Foo>\n\t<svelte:boundary let:x>{x}</svelte:boundary>\n</Foo>\n");
+    assert_contains(
+        &code,
+        "\n\t {const {/*\u{03A9}ignore_start\u{03A9}*/$$_$$/*\u{03A9}ignore_end\u{03A9}*/,x,} = $$_ooF0.$$slot_def.default;$$_$$;{ svelteHTML.createElement(\"svelte:boundary\", { });x; }}\n",
+    );
+}
+
+/// A static `slot=` retargets the destructure at the NAMED slot (official's
+/// `addSlotName` replaces the `default` key) and is dropped from the props.
+#[test]
+fn block_nested_named_slot_keys_the_block() {
+    let code = convert(
+        "<Foo>\n\t{#each a as b}\n\t\t<svelte:fragment slot=\"s\" let:x>{x}</svelte:fragment>\n\t{/each}\n</Foo>\n",
+    );
+    assert_contains(
+        &code,
+        "\n\t\t {const {/*\u{03A9}ignore_start\u{03A9}*/$$_$$/*\u{03A9}ignore_end\u{03A9}*/,x,} = $$_ooF0.$$slot_def[\"s\"];$$_$$;{ svelteHTML.createElement(\"svelte:fragment\", {  });x; }}\n",
+    );
+}
+
+/// A `let:` outside any component stays a deprecated plain attribute.
+#[test]
+fn let_outside_a_component_stays_an_attribute() {
+    let code = convert("<div let:x>{x}</div>\n");
+    assert_contains(
+        &code,
+        "{ svelteHTML.createElement(\"div\", {\"let:x\":true,});",
+    );
+    assert!(!code.contains("$$slot_def"), "got:\n{code}");
+}


### PR DESCRIPTION
Fixes #2105

## Why

Official svelte2tsx decides default-slot `let:` forwarding from two facts rsvelte only half-modelled:

1. **Which node kinds get an `Element`** — `Element` / `Slot` / `SlotTemplate` / `Title` / the `svelte:` meta tags. `Let.ts`'s `handleLet` routes to `addSlotLet` whenever `element.parent instanceof InlineComponent`, so *any* of those forwards through the component's `$$slot_def`.
2. **Control-flow blocks never push its `element` stack** (`index.ts` only pushes for `Element` / `InlineComponent`), so a `<div let:x>` inside `{#each}` / `{#if}` / `{#await}` / `{#key}` still has the component as its `parent`.

`process_component_children_with_slots` wrapped only a **direct** `RegularElement` or `<svelte:fragment>` child, so all of these silently dropped their `$$slot_def.default` prologue and emitted a bogus `"let:x": true` attribute — leaving every `let:` binding an undeclared identifier in the generated TSX:

```svelte
<Foo><svelte:element this={tag} let:x>{x}</svelte:element></Foo>
<Foo><slot let:x /></Foo>
<Foo>{#each items as item}<div let:x>{x}</div>{/each}</Foo>
```

The issue's three items:

1. **Unreachable reopen branch** — `default_slot_opened` was never reset, so `if has_lets && !default_slot_opened` was dead code that also lacked #2049's gap-prefix handling.
2. **`svelte:element` / `<slot>` / `{#each}` children not forwarded** — see above (the helper's own doc comment already *claimed* `svelte:element` was covered).
3. **`<style let:x>` orphan block + one-shot flag leak** — a component-direct `<style let:x>` got an orphaned `$$slot_def` block, and because `handle_regular_element` early-returns for `style` before consuming `suppress_default_slot_let_indent`, the flag leaked and stole one gap space from the next sibling.

## What

Emit the destructure **where official emits it** — inside the node's own handler, driven by the existing `counter.slot_inst` scope — instead of in the caller:

- New shared `default_slot_let_block` / `named_slot_let_block` helpers in `component_slots.rs`; each element handler (`element.rs`, `slot_element.rs`, `dynamic_element.rs`, `special_element.rs`, `handle_title_element`) emits its own gap + block and closes it.
- That deletes `default_slot_let_before_block` (which hand-replayed the `opener_spacing` call sites' arguments — the drift risk the issue also flagged) and the one-shot `suppress_default_slot_let_indent` flag it fed, so the leak is gone **by construction**. It also removes the unreachable reopen branch.
- `<style let:x>` now falls out correctly for free: `handle_regular_element`'s `str.remove` early-return wipes the block exactly like official's `handleStyleTag` wipes the range the block was transformed into — and the component still gets its instance const, matching official (naming the component is a side effect of registering the let).
- `has_default_slot_let_children` covers every element-kind node and recurses through control-flow blocks, but **not** into nested elements/components (own slot scope) nor `{#snippet}` bodies (official resets `element` to `undefined`); `handle_snippet_block_inner` clears `slot_inst` for the same reason.
- `<svelte:fragment>` / `<svelte:boundary>` now take and restore `slot_inst` like the other element handlers, so their children stop inheriting the enclosing component's slot scope — and a block-nested one carrying a static `slot="name"` gets the `$$slot_def["name"]` wrapper instead of a plain `slot` attribute.

## Testing

- New `crates/rsvelte_projection/tests/svelte2tsx_slot_let_forwarding_2105.rs` — 13 tests, every expectation the **byte-exact** output of official svelte2tsx (language-tools, parsing with svelte 5.56.8).
- Ad-hoc oracle sweep of ~80 slot/`let:` shapes against the same official build: all sub-cases of this issue now byte-identical.
- `cargo test -p rsvelte_projection` (incl. the 257-entry fixture suite) and `cargo test -p rsvelte_check` green.
- svelte2tsx corpus gate over the `svelte` + `pattern` sources (5153 entries): **4906 match / 103 error-parity / 0 ts-mismatch / 0 map-invalid**.
- `cargo fmt` + `cargo clippy --all-targets --all-features -- -D warnings` clean.

## Out of scope (pre-existing, unrelated)

- `<svelte:self>` as a **slot parent** has no slot lowering at all (neither `let:` nor `slot=` children forward) — a distinct missing feature, not one of #2105's items.
- A top-level `<style>` drops the trailing newline official keeps (reproduces without any `let:`).
- `<svelte:boundary>`'s opening-tag gap accounting differs from official (reproduces at the document root, no component involved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RQSYoh4Wc353KgUnWHjazu
