### PR TITLE
fix(fmt): route collapse-pass indent grows through IndentUnit instead of hardcoded spaces

### DIFF
--- a/.changeset/fmt-pre-block-hardcoded-space-indent.md
+++ b/.changeset/fmt-pre-block-hardcoded-space-indent.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/fmt": patch
+---
+
+fix(fmt): route every collapse-pass indent grow through the real `IndentUnit` instead of a hardcoded two-space string. Several `collapse/*.rs` block-break helpers built their `inner_indent` with `format!("{indent}  ")`, which under `useTabs` mixed literal spaces into an otherwise all-tab document. A deeper related bug in `<pre>` block reformatting (`reformat_pre_inner`) let the internal sub-format inherit the outer tab style while its re-indent pass still measured depth by counting leading `' '` bytes, silently leaving the sub-format's own tab prefix embedded and prepending a second, wrongly-computed indent in front of it. Both are fixed: the sweep now always appends `indent_config(options)`'s unit, and the `<pre>` sub-format is forced to a space-based internal working representation so its re-indent math is always correct, with the final output choosing tabs vs spaces per line (verbatim source style for element-direct `<pre>` markup, the document's configured style for reformatted internals) exactly like oxfmt.

--- a/crates/rsvelte_formatter/src/collapse/breaks.rs
+++ b/crates/rsvelte_formatter/src/collapse/breaks.rs
@@ -37,9 +37,10 @@ pub(super) fn collect_break_block_non_ws_prefix(
     out: &str,
     fragment: &Fragment,
     line_width: usize,
-    tw: usize,
+    options: &FormatOptions,
     edits: &mut Vec<(u32, u32, String)>,
 ) {
+    let tw = tab_width(options);
     for (node_idx, node) in fragment.nodes.iter().enumerate() {
         // A `<!-- prettier-ignore -->`d node and its whole subtree stay verbatim.
         if crate::prettier_ignore::preceded_by_prettier_ignore(&fragment.nodes, node_idx) {
@@ -81,7 +82,8 @@ pub(super) fn collect_break_block_non_ws_prefix(
                             let close = out.get(last_end..end).unwrap_or("");
                             let content = out.get(first_start..last_end).unwrap_or("");
                             if open.ends_with('>') && !content.is_empty() {
-                                let inner_indent = format!("{ws_indent}  ");
+                                let (indent_unit, _) = indent_config(options);
+                                let inner_indent = format!("{ws_indent}{indent_unit}");
                                 let broken =
                                     format!("{open}\n{inner_indent}{content}\n{ws_indent}{close}");
                                 if broken != whole {
@@ -92,11 +94,11 @@ pub(super) fn collect_break_block_non_ws_prefix(
                         }
                     }
                 }
-                collect_break_block_non_ws_prefix(out, &e.fragment, line_width, tw, edits);
+                collect_break_block_non_ws_prefix(out, &e.fragment, line_width, options, edits);
             }
             _ => {
                 for child in child_fragments(node) {
-                    collect_break_block_non_ws_prefix(out, child, line_width, tw, edits);
+                    collect_break_block_non_ws_prefix(out, child, line_width, options, edits);
                 }
             }
         }
@@ -196,6 +198,7 @@ pub(super) fn try_break_content_tag_block(
     options: &FormatOptions,
 ) -> Option<(u32, u32, String)> {
     let tw = tab_width(options);
+    let (indent_unit, _) = indent_config(options);
     if !is_block_display(tag) {
         return None;
     }
@@ -247,7 +250,7 @@ pub(super) fn try_break_content_tag_block(
         if !indent.bytes().all(|b| b == b' ' || b == b'\t') {
             return None;
         }
-        let inner_indent = format!("{indent}  ");
+        let inner_indent = format!("{indent}{indent_unit}");
         // The last line of `open` ends with `>`, e.g. `    >`.
         // When the `>` is already on its own line (the last line of `open` is
         // purely whitespace + `>`), prettier's block-element behaviour always
@@ -298,7 +301,7 @@ pub(super) fn try_break_content_tag_block(
     if !indent.bytes().all(|b| b == b' ' || b == b'\t') {
         return None;
     }
-    let inner_indent = format!("{indent}  ");
+    let inner_indent = format!("{indent}{indent_unit}");
 
     let inner = span.get(kw_lead..span.len() - kw_trail)?.trim();
     let width = line_width.saturating_sub(inner_indent.visual_width(tw) + kw_lead + kw_trail);
@@ -334,8 +337,9 @@ pub(super) fn try_break_block_overflow(
     end: u32,
     fragment: &Fragment,
     line_width: usize,
-    tw: usize,
+    options: &FormatOptions,
 ) -> Option<(u32, u32, String)> {
+    let tw = tab_width(options);
     if !is_block_display(tag) {
         return None;
     }
@@ -411,7 +415,8 @@ pub(super) fn try_break_block_overflow(
     if !indent.bytes().all(|b| b == b' ' || b == b'\t') {
         return None;
     }
-    let inner_indent = format!("{indent}  ");
+    let (indent_unit, _) = indent_config(options);
+    let inner_indent = format!("{indent}{indent_unit}");
 
     let broken = format!("{open}\n{inner_indent}{content}\n{indent}{close}");
     (broken != whole).then_some((start, end, broken))
@@ -441,10 +446,12 @@ pub(super) fn try_break_block_multiline_content(
     start: u32,
     end: u32,
     fragment: &Fragment,
+    options: &FormatOptions,
 ) -> Option<(u32, u32, String)> {
     if !is_block_display(tag) {
         return None;
     }
+    let (indent_unit, _) = indent_config(options);
 
     let (s, e) = (start as usize, end as usize);
     let whole = out.get(s..e)?;
@@ -510,7 +517,7 @@ pub(super) fn try_break_block_multiline_content(
         if !indent.bytes().all(|b| b == b' ' || b == b'\t') {
             return None;
         }
-        let inner_indent = format!("{indent}  ");
+        let inner_indent = format!("{indent}{indent_unit}");
 
         let broken = format!("{open}\n{inner_indent}{content}\n{indent}{close}");
         return (broken != whole).then_some((start, end, broken));
@@ -537,7 +544,7 @@ pub(super) fn try_break_block_multiline_content(
     if !indent.bytes().all(|b| b == b' ' || b == b'\t') {
         return None;
     }
-    let inner_indent = format!("{indent}  ");
+    let inner_indent = format!("{indent}{indent_unit}");
 
     let broken = format!("{open}\n{inner_indent}{content}\n{indent}{close}");
     (broken != whole).then_some((start, end, broken))

--- a/crates/rsvelte_formatter/src/collapse/collect.rs
+++ b/crates/rsvelte_formatter/src/collapse/collect.rs
@@ -254,7 +254,7 @@ pub(super) fn collect(
                     elem.end,
                     &elem.fragment,
                     line_width,
-                    tab_width(options),
+                    options,
                 ) {
                     edits.push(edit);
                 } else if let Some(edit) = try_break_block_multiline_content(
@@ -263,6 +263,7 @@ pub(super) fn collect(
                     elem.start,
                     elem.end,
                     &elem.fragment,
+                    options,
                 ) {
                     edits.push(edit);
                 } else {
@@ -488,12 +489,7 @@ pub(super) fn collect(
             }
             TemplateNode::EachBlock(blk) => {
                 if let Some(edit) = try_hug_block_inline_body(
-                    out,
-                    blk.start,
-                    blk.end,
-                    &blk.body,
-                    line_width,
-                    tab_width(options),
+                    out, blk.start, blk.end, &blk.body, line_width, options,
                 ) {
                     edits.push(edit);
                 } else {
@@ -521,7 +517,7 @@ pub(super) fn collect(
                     blk.end,
                     &blk.fragment,
                     line_width,
-                    tab_width(options),
+                    options,
                 ) {
                     edits.push(edit);
                 } else {

--- a/crates/rsvelte_formatter/src/collapse/hug.rs
+++ b/crates/rsvelte_formatter/src/collapse/hug.rs
@@ -190,8 +190,9 @@ pub(super) fn try_hug_block_inline_body(
     end: u32,
     body: &Fragment,
     line_width: usize,
-    tw: usize,
+    options: &FormatOptions,
 ) -> Option<(u32, u32, String)> {
+    let tw = tab_width(options);
     let (s, e) = (start as usize, end as usize);
     let whole = out.get(s..e)?;
     // Only a block that currently renders entirely on one line.
@@ -222,7 +223,8 @@ pub(super) fn try_hug_block_inline_body(
         return None; // fits on one line
     }
     let prefix = out.get(s..elem_start)?; // block open tag (+ no leading ws)
-    let hug = format!("{prefix}{open_nb}>{content}</{tag}\n{indent}  >{close}");
+    let (indent_unit, _) = indent_config(options);
+    let hug = format!("{prefix}{open_nb}>{content}</{tag}\n{indent}{indent_unit}>{close}");
     (hug != whole).then_some((start, end, hug))
 }
 

--- a/crates/rsvelte_formatter/src/collapse/mod.rs
+++ b/crates/rsvelte_formatter/src/collapse/mod.rs
@@ -222,7 +222,7 @@ pub(crate) fn collapse_pure_text_elements(
         &result,
         &tree.as_ref().unwrap_or(&root).fragment,
         line_width,
-        tw,
+        options,
         &mut edits1e,
     );
     if !edits1e.is_empty() {
@@ -245,7 +245,7 @@ pub(crate) fn collapse_pure_text_elements(
         &result,
         &tree.as_ref().unwrap_or(&root).fragment,
         line_width,
-        tw,
+        options,
         &mut edits1f,
     );
     if !edits1f.is_empty() {

--- a/crates/rsvelte_formatter/src/collapse/open_tag.rs
+++ b/crates/rsvelte_formatter/src/collapse/open_tag.rs
@@ -16,14 +16,15 @@ use super::*;
 /// - The element's content starts with whitespace (`hug_start=false`).
 ///
 /// The broken form uses the line's leading-whitespace as `indent` and
-/// `indent + "  "` as `inner_indent` for attributes.
+/// `indent + `[`indent_config`]`'s unit` as `inner_indent` for attributes.
 pub(super) fn collect_break_inline_open_tag(
     out: &str,
     fragment: &Fragment,
     line_width: usize,
-    tw: usize,
+    options: &FormatOptions,
     edits: &mut Vec<(u32, u32, String)>,
 ) {
+    let tw = tab_width(options);
     for (node_idx, node) in fragment.nodes.iter().enumerate() {
         // A `<!-- prettier-ignore -->`d node and its whole subtree stay verbatim.
         if crate::prettier_ignore::preceded_by_prettier_ignore(&fragment.nodes, node_idx) {
@@ -67,7 +68,7 @@ pub(super) fn collect_break_inline_open_tag(
                         e.end,
                         &e.fragment,
                         line_width,
-                        tw,
+                        options,
                     )
                 {
                     // A whole-element edit (`edit.1 == e.end`) rewrites the tag
@@ -83,7 +84,7 @@ pub(super) fn collect_break_inline_open_tag(
                         continue;
                     }
                 }
-                collect_break_inline_open_tag(out, &e.fragment, line_width, tw, edits);
+                collect_break_inline_open_tag(out, &e.fragment, line_width, options, edits);
             }
             TemplateNode::Component(c) => {
                 let mut whole_element = false;
@@ -95,18 +96,18 @@ pub(super) fn collect_break_inline_open_tag(
                     c.end,
                     &c.fragment,
                     line_width,
-                    tw,
+                    options,
                 ) {
                     whole_element = edit.1 == c.end;
                     edits.push(edit);
                 }
                 if !whole_element {
-                    collect_break_inline_open_tag(out, &c.fragment, line_width, tw, edits);
+                    collect_break_inline_open_tag(out, &c.fragment, line_width, options, edits);
                 }
             }
             _ => {
                 for child in child_fragments(node) {
-                    collect_break_inline_open_tag(out, child, line_width, tw, edits);
+                    collect_break_inline_open_tag(out, child, line_width, options, edits);
                 }
             }
         }
@@ -124,8 +125,9 @@ pub(super) fn try_break_inline_open_tag(
     elem_end: u32,
     fragment: &Fragment,
     line_width: usize,
-    tw: usize,
+    options: &FormatOptions,
 ) -> Option<(u32, u32, String)> {
+    let tw = tab_width(options);
     // Must have attributes to break. Zero-attribute elements in hug_start=true
     // contexts can't be broken safely without tree-level indent information.
     if attrs.is_empty() {
@@ -170,7 +172,8 @@ pub(super) fn try_break_inline_open_tag(
         .find(|(_, c)| !c.is_whitespace())
         .map_or(before.len(), |(i, _)| i);
     let indent = &before[..ws_end];
-    let inner_indent = format!("{indent}  ");
+    let (indent_unit, _) = indent_config(options);
+    let inner_indent = format!("{indent}{indent_unit}");
 
     // Collect attribute texts; bail on any multi-line attribute.
     let mut attr_texts: Vec<&str> = Vec::with_capacity(attrs.len());

--- a/crates/rsvelte_formatter/src/collapse/pre.rs
+++ b/crates/rsvelte_formatter/src/collapse/pre.rs
@@ -199,9 +199,11 @@ pub(super) fn collapse_text_only_spans(s: &str, narrowed_width: usize) -> String
 /// `content_depth` is the nesting depth of the element's children. The content is
 /// formatted standalone at a width narrowed by `content_depth` levels (so embedded
 /// JS / blocks break exactly as they would at their real column), then every line
-/// is re-indented out to its real depth — using TABS for whitespace that is the
-/// direct child of an element (oxfmt preserves it) and SPACES for block bodies and
-/// formatted internals (attributes, JS, wrapped open tags).
+/// is re-indented out to its real depth — using the `<pre>` source's own tab/space
+/// style for whitespace that is the direct child of an element (oxfmt preserves it
+/// verbatim), and the document's configured indent style for block bodies and
+/// formatted internals (attributes, JS, wrapped open tags), which are freshly
+/// generated rather than preserved.
 pub(super) fn reformat_pre_inner(
     out: &str,
     elem: &rsvelte_core::ast::template::RegularElement,
@@ -221,10 +223,9 @@ pub(super) fn reformat_pre_inner(
     let inner_end = elem.start as usize + close_rel;
     let raw_inner = out.get(inner_start..inner_end)?;
 
-    // Element-direct whitespace inside `<pre>` is preserved verbatim by oxfmt, so
-    // it only becomes tabs when the SOURCE indented with tabs. A `<pre>` whose
-    // body is space-indented keeps spaces throughout (block-tag lines included),
-    // so don't regenerate its element-direct lines as tabs.
+    // Whitespace inside `<pre>` is preserved verbatim by oxfmt, so the reformatted
+    // structure below only becomes tabs when the SOURCE indented with tabs. A
+    // `<pre>` whose body is space-indented keeps spaces throughout.
     let pre_uses_tabs = raw_inner.lines().any(|l| l.starts_with('\t'));
 
     let iw = options.js.indent_width.value() as usize;
@@ -232,7 +233,7 @@ pub(super) fn reformat_pre_inner(
     // Format the children standalone, but narrowed so a depth-0 layout matches the
     // breaks at the real `content_depth`.
     //
-    // Element-direct children of `<pre>` are re-indented with TABS (1 char each)
+    // Under `useTabs`, `<pre>` content is re-indented with TABS (1 char each)
     // rather than spaces (`iw` chars each).  The sub-format sees space indentation,
     // so a line at sub-depth D appears as `D*iw` chars, but in the final output the
     // tab-indented prefix uses only `D + content_depth` chars (one per tab level).
@@ -257,6 +258,17 @@ pub(super) fn reformat_pre_inner(
         .max(20);
     let mut sub_opts = options.clone();
     sub_opts.js.line_width = oxc_formatter_core::LineWidth::try_from(narrowed as u16).ok()?;
+    // The re-indent pass below (`spaces / iw`) only understands space-based
+    // indentation columns — it strips leading `' '` and measures depth by byte
+    // count, then re-emits either spaces or (for element-direct lines) tabs at
+    // the real depth. Under `useTabs` the sub-format would otherwise inherit the
+    // outer tab style and hand back tab-indented lines that `trim_start_matches(' ')`
+    // can't see through, leaving their original tab prefix embedded verbatim and
+    // getting a second, wrongly-computed indent prepended in front of it (mixed
+    // space+tab output, #2151). Force spaces for this internal working
+    // representation regardless of the caller's style; the final loop below is
+    // what decides tabs vs spaces in the real output.
+    sub_opts.js.indent_style = oxc_formatter_core::IndentStyle::Space;
     let formatted =
         with_pre_content(|| crate::format(raw_inner.trim_matches(['\n', '\r']), &sub_opts)).ok()?;
     let formatted = formatted.trim_end_matches('\n');
@@ -322,13 +334,21 @@ pub(super) fn reformat_pre_inner(
     };
 
     // Determine which line-starts in `formatted` are element-direct whitespace
-    // (→ tabs). Everything else stays spaces.
+    // (→ verbatim source style). Everything else is reformatted structure (block
+    // bodies, wrapped attributes, wrapped JS) and follows the document's
+    // configured indent style, not the `<pre>` source's own tab usage.
     let sub_root = parse_formatted(formatted)?;
     let mut tab_lines: HashSet<usize> = HashSet::new();
     collect_pre_tab_lines(formatted, &sub_root.fragment, true, &mut tab_lines);
+    let configured_tabs = options.js.indent_style.is_tab();
 
-    // Re-indent every line: shift by `content_depth` levels; tab-marked lines use
-    // tabs, the rest use spaces.
+    // Re-indent every line: shift by `content_depth` levels. `formatted` is
+    // always space-indented (the sub-format was forced to `IndentStyle::Space`
+    // above) regardless of the caller's real style, so `spaces / iw` always
+    // yields the correct depth; only the final CHARACTER differs per line:
+    // element-direct lines are preserved verbatim (tabs only when the SOURCE
+    // used tabs), everything else follows the document's configured style
+    // (tabs only under `useTabs`) — matching oxfmt exactly (#2151).
     let mut result = String::new();
     let mut offset = 0usize;
     let mut first_line = true;
@@ -344,7 +364,12 @@ pub(super) fn reformat_pre_inner(
             if !trimmed.is_empty() {
                 let spaces = line.len() - trimmed.len();
                 let real_depth = spaces / iw + content_depth;
-                if pre_uses_tabs && tab_lines.contains(&offset) {
+                let use_tabs = if tab_lines.contains(&offset) {
+                    pre_uses_tabs
+                } else {
+                    configured_tabs
+                };
+                if use_tabs {
                     for _ in 0..real_depth {
                         result.push('\t');
                     }
@@ -395,9 +420,11 @@ pub(super) fn reformat_pre_inner(
 }
 
 /// Collect the line-start byte offsets in `formatted` whose indentation is
-/// element-direct whitespace (preserved as tabs by oxfmt inside `<pre>`): a node
-/// whose parent fragment belongs to a regular element, plus every element's own
-/// closing-tag line. Block bodies (parent is a block) keep spaces.
+/// element-direct whitespace (preserved verbatim by oxfmt inside `<pre>`, so it
+/// uses the `<pre>` source's own tab/space style): a node whose parent fragment
+/// belongs to a regular element, plus every element's own closing-tag line.
+/// Block bodies (parent is a block) and reformatted internals are NOT element-
+/// direct — the caller renders those in the document's configured indent style.
 pub(super) fn collect_pre_tab_lines(
     formatted: &str,
     fragment: &Fragment,

--- a/crates/rsvelte_formatter/tests/tab_visual_width.rs
+++ b/crates/rsvelte_formatter/tests/tab_visual_width.rs
@@ -103,3 +103,65 @@ fn tab_indent_respects_the_print_width_boundary() {
         );
     }
 }
+
+/// #2151: when a collapse pass grows the indent by one level to break an
+/// overflowing block onto its own line, the new level must be the real
+/// `IndentUnit` (a tab), never a hardcoded literal two-space string — several
+/// `collapse/*.rs` block-break helpers built their `inner_indent` with
+/// `format!("{indent}  ")`, which mixed spaces into an otherwise all-tab
+/// document. General invariant: no line's leading indent may contain a space
+/// once the whole document is tab-indented.
+#[test]
+fn tab_indent_block_break_grows_by_a_tab_not_two_spaces() {
+    let src = "<div>\n\t{#if condition}<p>a very long paragraph of text that will overflow the line</p>{/if}\n</div>\n";
+    let out = format(src, &options(IndentStyle::Tab, 40, 4)).expect("format ok");
+    assert!(out.contains('\n'), "expected the block to break:\n{out}");
+    for line in out.lines() {
+        let indent_end = line
+            .find(|c: char| c != '\t' && c != ' ')
+            .unwrap_or(line.len());
+        let indent = &line[..indent_end];
+        assert!(
+            !indent.contains(' '),
+            "tab-indented output must never mix a literal space into its leading indent: {line:?}\n{out}"
+        );
+    }
+}
+
+/// #2151: `<pre>` content that mixes reformatted structure (a `{#if}` block) with
+/// element-direct markup must not leak literal spaces into an otherwise
+/// tab-indented document. Reduced from svelte.dev's `AstView.svelte`: an
+/// `<AstNode>` self-closing component nested inside a `<ul>` that is itself
+/// inside an `{#if}` consequent, all inside `<pre><code>`. Asserted against the
+/// exact oracle (oxfmt + prettier-plugin-svelte) output.
+#[test]
+fn tab_indent_pre_block_reformat_does_not_mix_spaces_into_tabs() {
+    let src = "<div class=\"ast-view\">\n\t<pre>\n\t\t<code>\n\t\t\t{#if typeof ast === \"object\"}\n\t\t\t\t<ul>\n\t\t\t\t\t<AstNode value={ast} />\n\t\t\t\t</ul>\n\t\t\t{:else}\n\t\t\t\t<p>No AST available</p>\n\t\t\t{/if}\n\t\t</code>\n\t</pre>\n</div>\n";
+
+    let out = format(src, &options(IndentStyle::Tab, 100, 4)).expect("format ok");
+    assert_eq!(
+        out, src,
+        "already-tab-indented, already-fitting <pre> content must round-trip verbatim"
+    );
+}
+
+/// #2151 companion: the same `<pre>`-with-block source, but the DOCUMENT's
+/// configured style is spaces (the common case) while the `<pre>` body itself
+/// was hand-indented with tabs. oxfmt preserves the `<pre>`'s own element-direct
+/// markup (`<code>`, `{#if}`, `<AstNode>`, the block's close tags) verbatim in
+/// tabs, but renders reformatted internals — the `{#if}` block body and wrapped
+/// attributes — in the document's configured (space) style. This is the inverse
+/// of the previous test and guards the `configured_tabs` branch in
+/// `reformat_pre_inner`, not just the `pre_uses_tabs` one.
+#[test]
+fn space_indent_pre_block_reformat_keeps_element_direct_tabs_and_configured_spaces() {
+    let src = "<div class=\"ast-view\">\n\t<pre>\n\t\t<code>\n\t\t\t{#if typeof ast === \"object\"}\n\t\t\t\t<ul>\n\t\t\t\t\t<AstNode value={ast} />\n\t\t\t\t</ul>\n\t\t\t{:else}\n\t\t\t\t<p>No AST available</p>\n\t\t\t{/if}\n\t\t</code>\n\t</pre>\n</div>\n";
+
+    let out = format(src, &options(IndentStyle::Space, 80, 2)).expect("format ok");
+    assert_eq!(
+        out,
+        "<div class=\"ast-view\">\n  <pre>\n\t\t<code>\n\t\t\t{#if typeof ast === \"object\"}\n        <ul>\n\t\t\t\t\t<AstNode value={ast} />\n\t\t\t\t</ul>\n      {:else}\n        <p>No AST available</p>\n      {/if}\n\t\t</code>\n\t</pre>\n</div>\n",
+        "element-direct <pre> lines stay in the source's own tabs; reformatted \
+         block-body lines follow the document's configured (space) style"
+    );
+}


### PR DESCRIPTION
Fixes #2151

## Problem

PR #2150 introduced `IndentUnit` so width measurement charges an indentation tab `tabWidth` columns instead of 1, but a separate class of bug in the same neighborhood survived: several `collapse/*.rs` block-break helpers build a deeper indent level by literally appending two spaces to the current indent string (`format!("{indent}  ")`) instead of the real `IndentUnit`. Under `useTabs` this mixes literal spaces into an otherwise all-tab document — the repro from the issue, svelte.dev's `packages/repl/src/lib/Output/AstView.svelte`, comes back as `"        \t\t<ul>"` where the oracle (oxfmt + prettier-plugin-svelte) emits `"\t\t\t\t<ul>"`.

Fixing the six `breaks.rs` sites (plus one each in `open_tag.rs` and `hug.rs`) surfaced a second, deeper bug specific to `<pre>` blocks that contain a Svelte block (`reformat_pre_inner`): it recursively re-formats the `<pre>` body standalone, and its re-indent pass measures each line's depth by counting leading `' '` bytes (`spaces / iw`). That assumes the recursive sub-format is space-indented, but the sub-format actually inherited the *outer* document's tab style — so under `useTabs` the sub-format came back tab-indented, `trim_start_matches(' ')` couldn't see through the leading tabs, and the re-indent pass silently left the sub-format's own tab prefix embedded while prepending a second, wrongly-computed indent in front of it. That's the actual root cause of the mixed output in the issue.

## Fix

- Sweep every `format!("{indent}  ")` (and the one `hug.rs` equivalent) in `crates/rsvelte_formatter/src/collapse/{breaks,open_tag,hug}.rs` to instead append `indent_config(options)`'s real unit string, threading `options`/an already-derived `indent_unit` into the functions that needed it (`collect_break_block_non_ws_prefix`, `try_break_block_overflow`, `try_break_block_multiline_content`, `try_break_inline_open_tag` + its collector, `try_hug_block_inline_body`).
- `reformat_pre_inner` (`pre.rs`): force the recursive sub-format's `indent_style` to `Space` regardless of the caller's real style, so the existing `spaces / iw` depth math is always correct. The final re-indent loop then picks the output character per line: element-direct `<pre>` markup (preserved verbatim by oxfmt) uses the `<pre>` source's own tab/space style, while reformatted internals (block bodies, wrapped attributes, wrapped JS) follow the document's *configured* indent style — matching oxfmt exactly in both `useTabs` and default (space) documents.

## Verification

| Check | Result |
|---|---|
| `AstView.svelte` @ `useTabs:true, tabWidth:4, printWidth:100` vs oracle | byte-identical (was `"        \t\t<ul>"` vs `"\t\t\t\t<ul>"`) |
| svelte.dev 557 `.svelte` components @ `useTabs:true, tabWidth:4, printWidth:100` vs oracle | **0 unexpected divergences** (1 remaining hit is the pre-existing, already-`fmt-oracle-excluded.json`-listed oxfmt CSS-path bug in `docs/[topic]/[...path]/+layout.svelte`) |
| Same 557 files @ the canonical corpus config (`tabWidth:2`, spaces) vs oracle | same single pre-existing exclusion, **0 regressions** — spaces-mode output unaffected |
| `cargo test -p rsvelte_formatter` | pass (incl. 2 new regression tests + 2 general-invariant tests in `tab_visual_width.rs`) |
| `cargo test -p rsvelte_fmt` | pass |
| `cargo test -p rsvelte_language_server` | pass |
| `svelte_dev_corpus_parity` (hard gate) | pass |
| `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings` (whole workspace) | clean |

`compatibility/fmt-known-failures.json` is unchanged: spaces-mode output is byte-identical, so no entry can newly pass and none regress.

## Regression tests

`crates/rsvelte_formatter/tests/tab_visual_width.rs`:
- `tab_indent_pre_block_reformat_does_not_mix_spaces_into_tabs` — the `AstView.svelte`-reduced repro, asserted to round-trip verbatim under `useTabs`.
- `space_indent_pre_block_reformat_keeps_element_direct_tabs_and_configured_spaces` — the same source under the default (space) style, asserting element-direct `<pre>` lines stay in the source's own tabs while reformatted block-body lines follow the configured space style.
- `tab_indent_block_break_grows_by_a_tab_not_two_spaces` — general invariant that a tab-indented document's block-break output never mixes a literal space into any line's leading indent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RQSYoh4Wc353KgUnWHjazu
