### PR TITLE
fix(svelte2tsx): honor an instance-script `$$Slots` interface/type override (#2156)

### DIFF
--- a/.changeset/svelte2tsx-slots-type-override.md
+++ b/.changeset/svelte2tsx-slots-type-override.md
@@ -1,0 +1,15 @@
+---
+"@rsvelte/compiler": patch
+"@rsvelte/svelte2tsx": patch
+"@rsvelte/svelte-check": patch
+---
+
+fix(svelte2tsx): honor an instance-script `$$Slots` interface/type override.
+Official `createRenderFunction.ts` builds the component export's `slots:`
+reflection as `uses$$SlotsInterface ? '{} as unknown as $$Slots' : '{…computed…}'`,
+so a component that declares its own `interface $$Slots` / `type $$Slots` is
+type-checked against that declaration instead of the shape inferred from its
+`<slot>` elements. rsvelte already threaded the flag into the
+`__sveltets_2_createCreateSlot<$$Slots>()` binding but always emitted the
+computed literal in the return statement, so consumers saw the inferred slot
+props and any deliberate widening/narrowing in the declaration was lost.

--- a/compatibility/svelte2tsx-fixtures-known-failures.json
+++ b/compatibility/svelte2tsx-fixtures-known-failures.json
@@ -1,7 +1,5 @@
 [
 	"attributes-foreign-ns",
-	"component-slot-$$slot-interface",
-	"component-slot-$$slot-type",
 	"component-slot-inside-await",
 	"component-slot-let-forward",
 	"component-slot-object-key",

--- a/compatibility/svelte2tsx-fixtures-known-failures.md
+++ b/compatibility/svelte2tsx-fixtures-known-failures.md
@@ -25,7 +25,7 @@ UPDATE_S2TSX_FIXTURES_BASELINE=1 cargo test --test svelte2tsx_fixtures
 `STRICT_S2TSX_FIXTURES=1` ignores the baseline entirely (every failure fails),
 which is how you check whether an entry is still needed.
 
-## Current baseline: 14 of 254 (pass rate 94.5%)
+## Current baseline: 12 of 254 (pass rate 95.3%)
 
 ### #2145 note
 
@@ -36,7 +36,7 @@ ever compared the returned `props`/`slots`/`events` reflection again. That's how
 rsvelte/official divergence — `$$slot_def["b"]` vs official's `$$slot_def['b']` — passed
 `component-slot-let-forward-named-slot` despite differing. `return_statement_matches`
 (same file) now independently re-verifies just the return statement through the same
-relaxations, on top of the existing chain. The 9 entries below are pre-existing
+relaxations, on top of the existing chain. The entries below are pre-existing
 divergences this newly surfaced — none are new regressions, and none are related to the
 quoting bug itself (which is fixed in `collect/mod.rs`'s `push_let_reflection_scope`).
 
@@ -83,16 +83,6 @@ quoting bug itself (which is fixed in `collect/mod.rs`'s `push_let_reflection_sc
 - **`ts-await-generics.v5`.** One space after `type $$ComponentProps = { prop?: T };`
   — the fixture has two, rsvelte emits one. Cosmetic in effect, but the gate is
   byte-exact so it is tracked like any other divergence.
-
-### `$$Slots` interface/type override not respected — 2
-
-- **`component-slot-$$slot-interface`**, **`component-slot-$$slot-type`.** When the
-  instance script declares an explicit `interface $$Slots { … }` (or `type $$Slots
-  = { … }`), official's `slots:` reflection becomes `{} as unknown as $$Slots`,
-  deferring entirely to the user's own type instead of the computed shape. rsvelte
-  doesn't detect the declaration and always emits the literal computed slot object
-  (`{'default': {a:b}, 'foo': {b:b}}`). A real, self-contained feature gap — out of
-  scope for #2145 (slot **quoting**, not slot **typing**).
 
 ### `let:`-forwarding slot-let resolution gaps — 3
 

--- a/crates/rsvelte_projection/src/svelte2tsx/add_component_export.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/add_component_export.rs
@@ -85,7 +85,7 @@ pub(crate) fn add_component_export(
     let component_doc = extract_component_documentation(&ast.fragment);
 
     // Build slots string from template info
-    let slots_str = build_slots_str(template_info);
+    let slots_str = build_slots_str(template_info, exported_names.has_slots_type);
 
     // Scan the component for `dispatch("name", …)` call sites of any untyped
     // `createEventDispatcher()` so they surface in the events return. Template

--- a/crates/rsvelte_projection/src/svelte2tsx/nodes/slot.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/nodes/slot.rs
@@ -6,8 +6,16 @@ use std::fmt::Write as _;
 use super::super::template;
 
 /// Build the `slots` object literal for the component export from template info.
-pub(crate) fn build_slots_str(template_info: &template::TemplateInfo<'_>) -> String {
-    if template_info.slots.is_empty() {
+///
+/// An instance-script `interface`/`type $$Slots` declaration replaces the
+/// computed shape entirely so the user's own type is what gets checked.
+pub(crate) fn build_slots_str(
+    template_info: &template::TemplateInfo<'_>,
+    has_slots_type: bool,
+) -> String {
+    if has_slots_type {
+        "{} as unknown as $$Slots".to_string()
+    } else if template_info.slots.is_empty() {
         "{}".to_string()
     } else {
         let mut slot_parts = Vec::new();

--- a/crates/rsvelte_projection/tests/svelte2tsx_slots_type_override_2156.rs
+++ b/crates/rsvelte_projection/tests/svelte2tsx_slots_type_override_2156.rs
@@ -1,0 +1,113 @@
+//! Regression test: an instance-script `interface $$Slots` / `type $$Slots`
+//! declaration overrides the computed `slots:` reflection (issue #2156).
+//!
+//! Official `createRenderFunction.ts` builds `slotsAsDef` as
+//! `uses$$SlotsInterface ? '{} as unknown as $$Slots' : '{…computed…}'`, so the
+//! user's own type is what the component export gets checked against. rsvelte
+//! already threaded the flag into the `__sveltets_2_createCreateSlot<$$Slots>()`
+//! binding but still emitted the computed literal in the return statement.
+
+use rsvelte_projection::svelte2tsx::{Svelte2TsxOptions, svelte2tsx};
+
+fn run(src: &str) -> String {
+    svelte2tsx(
+        src,
+        Svelte2TsxOptions {
+            filename: "Input.svelte".to_string(),
+            is_ts_file: true,
+            ..Default::default()
+        },
+    )
+    .expect("compile")
+    .code
+}
+
+const INTERFACE_SRC: &str = r#"<script lang="ts">
+    interface $$Slots {
+        default: { a: number },
+        foo: { b: number }
+    }
+    let b = 7;
+</script>
+
+<div>
+    <slot a={b} />
+    <slot name="foo" {b} />
+</div>
+"#;
+
+const TYPE_ALIAS_SRC: &str = r#"<script lang="ts">
+    type $$Slots = {
+        default: { a: number },
+        foo: { b: number }
+    }
+    let b = 7;
+</script>
+
+<div>
+    <slot a={b} />
+    <slot name="foo" {b} />
+</div>
+"#;
+
+#[test]
+fn interface_declaration_replaces_computed_slots() {
+    let out = run(INTERFACE_SRC);
+    assert!(
+        out.contains("slots: {} as unknown as $$Slots"),
+        "got:\n{out}"
+    );
+    assert!(!out.contains("'default': {a:b}"), "got:\n{out}");
+    // The createSlot binding keeps its type argument so slot usage is checked
+    // against the declaration too.
+    assert!(
+        out.contains("__sveltets_2_createCreateSlot<$$Slots>()"),
+        "got:\n{out}"
+    );
+}
+
+#[test]
+fn type_alias_declaration_replaces_computed_slots() {
+    let out = run(TYPE_ALIAS_SRC);
+    assert!(
+        out.contains("slots: {} as unknown as $$Slots"),
+        "got:\n{out}"
+    );
+    assert!(!out.contains("'default': {a:b}"), "got:\n{out}");
+}
+
+/// Official applies the override from the declaration alone — no `<slot>` in the
+/// template is required, because `slotsAsDef` is not gated on `slots.size`.
+#[test]
+fn declaration_without_any_slot_element_still_overrides() {
+    let out = run(r#"<script lang="ts">
+    interface $$Slots { default: { a: number } }
+    let b = 7;
+</script>
+
+<div>hi</div>
+"#);
+    assert!(
+        out.contains("slots: {} as unknown as $$Slots"),
+        "got:\n{out}"
+    );
+}
+
+/// Without the declaration the computed literal must be preserved verbatim.
+#[test]
+fn no_declaration_keeps_computed_slots() {
+    let out = run(r#"<script lang="ts">
+    let b = 7;
+</script>
+
+<div>
+    <slot a={b} />
+    <slot name="foo" {b} />
+</div>
+"#);
+    assert!(
+        out.contains("slots: {'default': {a:b}, 'foo': {b:b}}"),
+        "got:\n{out}"
+    );
+    assert!(!out.contains("as unknown as $$Slots"), "got:\n{out}");
+}


### PR DESCRIPTION
Fixes #2156

## Problem

Official `svelte2tsx` picks the component export's `slots:` reflection in
`createRenderFunction.ts` with

```js
const slotsAsDef = uses$$SlotsInterface
    ? '{} as unknown as $$Slots'
    : '{' + /* computed from the <slot> elements */ + '}';
```

so when the instance script declares its own `interface $$Slots { … }` (or
`type $$Slots = { … }`) the computed shape is dropped entirely and the user's
declaration is what the component gets type-checked against.

rsvelte already detected the declaration and threaded it into the
`__sveltets_2_createCreateSlot<$$Slots>()` binding, but `build_slots_str` never
saw the flag, so the return statement always carried the inferred literal
(`slots: {'default': {a:b}, 'foo': {b:b}}`). Any deliberate widening or
narrowing in the declaration was silently lost for consumers of the component.

## Fix

`build_slots_str` now takes `has_slots_type` and returns
`{} as unknown as $$Slots` when set — matching official's unconditional branch
(it is *not* gated on `slots.size`, so a declaration with no `<slot>` element in
the template still overrides).

## Verification

Probed rsvelte against the live official oracle (built from
`submodules/language-tools`) on the two fixtures plus four shapes the fixtures
don't cover — no `<slot>` element in the template, a runes (`$state`) component,
a plain (non-`lang="ts"`) script, and a component that also reads `$$slots`.
All are byte-identical to official after the fix.

- `cargo test -p rsvelte_projection` — green (all test binaries).
- `cargo test -p rsvelte_check` — green.
- Fixture ratchet `compatibility/svelte2tsx-fixtures-known-failures.json`
  shrinks by **2** (`component-slot-$$slot-interface`,
  `component-slot-$$slot-type`): **14 → 12**, pass rate **94.5% → 95.3%**.
  The paired `.md` justification section is removed with them.
- New regression test
  `crates/rsvelte_projection/tests/svelte2tsx_slots_type_override_2156.rs`
  covers `interface`, `type`, declaration-without-any-slot-element, and the
  no-declaration path (computed literal preserved verbatim).
- `cargo fmt --all -- --check` and
  `cargo clippy --all-targets --all-features -- -D warnings` clean.

## Out of scope

Two `$$Slots` edge cases where rsvelte still differs from official are left
untouched — both predate this change and equally affected the already-shipped
`<$$Slots>` type argument:

- Official's instance-script walk is fully recursive, so an `interface $$Slots`
  nested inside a function body also sets the flag; rsvelte only scans
  top-level statements.
- Official's `processModuleScriptTag.ts` *throws* `$$Slots can only be declared
  in the instance script` (same for `$$Props` / `$$Events`); rsvelte implements
  none of those three throws — a separate error-parity gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
