### PR TITLE
fix(formatter): honour every depth-0 boundary in an attribute value (#2120)

### DIFF
--- a/.changeset/fmt-attr-multi-boundary.md
+++ b/.changeset/fmt-attr-multi-boundary.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/fmt": patch
+---
+
+fix(fmt): honour every depth-0 boundary in an attribute value. `reindent_attr_with_raw_text` split a multi-line attribute value at the *first* brace-depth-0 tab-led newline and emitted everything after it verbatim, so a value holding two independently wrapping interpolations separated by raw text left the second expression's continuation lines stranded at column 0. The scan now collects every depth-0 newline and re-indents each expression run, matching the oracle's model: a line that begins at depth 0 is literal attribute text (verbatim), a line that begins inside `{…}` is formatter output (gains the attribute indent). Two adjacent divergences fall out of the same model — a regular attribute now keeps the author's inter-interpolation whitespace (only a directive's `fill` text reflows it to the attribute column), and an attribute rendering with no `name=` separator (`{@attach x != null && …}`) is no longer split on a JS operator.

--- a/crates/rsvelte_formatter/src/markup/render_tag.rs
+++ b/crates/rsvelte_formatter/src/markup/render_tag.rs
@@ -63,8 +63,8 @@ pub(super) fn render_multi_line(
             out.push_str(a);
         } else {
             // For expression-led attributes that also contain raw HTML text
-            // continuation lines (tab-indented), re-indent only the JS expression
-            // part and keep the raw text verbatim.
+            // lines, re-indent only the JS continuation lines and keep the raw
+            // text verbatim.
             out.push_str(&reindent_attr_with_raw_text(a, &inner_indent));
         }
     }
@@ -106,22 +106,19 @@ pub(super) fn render_multi_line(
 /// (`style="…"` / `class="a {x}"`) whose interior whitespace is HTML text and
 /// must be kept verbatim — as opposed to a quoted single expression
 /// (`pos="{expr}"`), whose formatted multi-line value still needs re-indenting.
-/// The value part (after the first `=`) must start with `"` but not `"{`.
+/// The value part (after the `name=`) must start with `"` but not `"{`.
 fn is_string_value_attr(a: &str) -> bool {
-    match a.split_once('=') {
-        Some((_, value)) => value.starts_with('"') && !value.starts_with("\"{"),
-        None => false,
-    }
+    let (offset, value) = attr_value(a);
+    offset > 0 && value.starts_with('"') && !value.starts_with("\"{")
 }
 
 /// Where a rendered attribute's newlines sit relative to `{…}` brace depth.
 /// Inside braces a newline is a wrapped continuation of formatted JS; at depth 0
 /// it is literal HTML text between interpolations.
 struct ValueNewlines {
-    /// Byte offset (within the scanned value) of the first depth-0 newline whose
-    /// line carries a leading tab — see [`reindent_attr_with_raw_text`].
-    first_tabbed_at_depth0: Option<usize>,
-    any_at_depth0: bool,
+    /// Byte offsets (within the scanned value) of every depth-0 newline — the
+    /// boundaries at which [`reindent_attr_with_raw_text`] splits.
+    at_depth0: Vec<usize>,
     any_inside_braces: bool,
 }
 
@@ -130,12 +127,10 @@ fn scan_value_newlines(value: &str) -> ValueNewlines {
     let mut quote: Option<u8> = None;
     let mut escaped = false;
     let mut out = ValueNewlines {
-        first_tabbed_at_depth0: None,
-        any_at_depth0: false,
+        at_depth0: Vec::new(),
         any_inside_braces: false,
     };
-    let bytes = value.as_bytes();
-    for (i, &b) in bytes.iter().enumerate() {
+    for (i, &b) in value.as_bytes().iter().enumerate() {
         match quote {
             // Inside a JS string literal: only its own *unescaped* closing
             // delimiter ends it; braces/newlines there are not structural.
@@ -153,12 +148,7 @@ fn scan_value_newlines(value: &str) -> ValueNewlines {
                 b'{' => depth += 1,
                 b'}' => depth -= 1,
                 b'\n' if depth > 0 => out.any_inside_braces = true,
-                b'\n' => {
-                    out.any_at_depth0 = true;
-                    if out.first_tabbed_at_depth0.is_none() && bytes.get(i + 1) == Some(&b'\t') {
-                        out.first_tabbed_at_depth0 = Some(i);
-                    }
-                }
+                b'\n' => out.at_depth0.push(i),
                 _ => {}
             },
         }
@@ -168,10 +158,22 @@ fn scan_value_newlines(value: &str) -> ValueNewlines {
 
 /// Splits a rendered attribute into its value part and that value's offset,
 /// so brace-depth offsets can be mapped back onto the whole attribute.
+///
+/// The `=` only separates a name from a value when everything before it *is* an
+/// attribute name; otherwise the whole rendering is the value. Without that
+/// guard a JS operator (`{@attach x != null && …}`) would be read as the
+/// separator and the expression's own text scanned as if it were markup.
 fn attr_value(a: &str) -> (usize, &str) {
     match a.split_once('=') {
-        Some((name, value)) => (name.len() + 1, value),
-        None => (0, a),
+        Some((name, value))
+            if !name.is_empty()
+                && !name.contains([
+                    ' ', '\t', '\n', '{', '}', '"', '\'', '(', '!', '<', '>', '=',
+                ]) =>
+        {
+            (name.len() + 1, value)
+        }
+        _ => (0, a),
     }
 }
 
@@ -186,26 +188,61 @@ fn is_verbatim_interpolation_value(a: &str) -> bool {
         return false;
     }
     let scan = scan_value_newlines(value);
-    !scan.any_inside_braces && scan.any_at_depth0
+    !scan.any_inside_braces && !scan.at_depth0.is_empty()
 }
 
 /// Re-indent an expression-led attribute (`class="{expr}\nraw-text…"`).
 ///
-/// Raw HTML text the author wrote between interpolations keeps its original
-/// source indentation, so re-indenting it would double-count that indent. It is
-/// recognised by a tab-indented line sitting at brace depth 0: depth 0 is
-/// outside every `{…}`, and formatted JS is only ever tab-indented under
-/// `useTabs` — where it is also always inside braces. Requiring both signals
-/// keeps the tab-indented continuation lines of a multi-line attribute value out
-/// of the raw-text branch, which used to strand them at column 0 (#2058).
+/// A line that *begins* at brace depth 0 is literal HTML text between
+/// interpolations — the oracle prints regular attribute text verbatim, so its
+/// author-written indentation is kept as-is. A line that begins inside `{…}` is
+/// an `oxc_formatter` continuation produced at column 0 and must gain the
+/// attribute indent. Splitting at *every* depth-0 newline (not just the first)
+/// is what lets a second wrapping interpolation after raw text be re-indented
+/// too (#2120): each segment holds one depth-0 line plus that line's own
+/// brace-interior continuations, and `skip_first` leaves the depth-0 line alone.
 fn reindent_attr_with_raw_text(a: &str, prefix: &str) -> String {
     let (value_offset, value) = attr_value(a);
-    match scan_value_newlines(value).first_tabbed_at_depth0 {
-        Some(pos) => {
-            let split_pos = value_offset + pos;
-            let reindented_js = crate::reindent::reindent(&a[..split_pos], prefix, true);
-            format!("{reindented_js}{}", &a[split_pos..])
-        }
-        None => crate::reindent::reindent(a, prefix, true),
+    let boundaries = scan_value_newlines(value).at_depth0;
+    if boundaries.is_empty() {
+        return crate::reindent::reindent(a, prefix, true);
+    }
+    let mut out = String::with_capacity(a.len() + prefix.len() * (boundaries.len() + 1));
+    let mut start = 0;
+    for pos in boundaries {
+        // The newline itself closes the segment it terminates.
+        let end = value_offset + pos + 1;
+        out.push_str(&crate::reindent::reindent(&a[start..end], prefix, true));
+        start = end;
+    }
+    out.push_str(&crate::reindent::reindent(&a[start..], prefix, true));
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{attr_value, reindent_attr_with_raw_text};
+
+    #[test]
+    fn attr_value_splits_only_on_a_real_name_separator() {
+        assert_eq!(attr_value("class=\"a {x}\""), (6, "\"a {x}\""));
+        // A JS operator inside a brace-led attribute is not the separator.
+        assert_eq!(
+            attr_value("{@attach x != null && f(x)}"),
+            (0, "{@attach x != null && f(x)}")
+        );
+        assert_eq!(attr_value("{...rest}"), (0, "{...rest}"));
+    }
+
+    #[test]
+    fn every_expression_run_after_raw_text_is_reindented() {
+        // Two wrapped interpolations separated by raw text: both sets of
+        // continuation lines gain the prefix, both raw-text lines keep their
+        // source indentation (#2120).
+        let a = "title=\"{a\n  ? b\n  : c}\n\traw\n\t{d\n  ? e\n  : f}\"";
+        assert_eq!(
+            reindent_attr_with_raw_text(a, "  "),
+            "title=\"{a\n    ? b\n    : c}\n\traw\n\t{d\n    ? e\n    : f}\""
+        );
     }
 }

--- a/crates/rsvelte_formatter/src/markup/value_sequence.rs
+++ b/crates/rsvelte_formatter/src/markup/value_sequence.rs
@@ -501,37 +501,29 @@ pub(super) fn render_attribute_value_sequence(
             }
         }
     }
-    // An interpolation-led value with a wrapped `{expr}` takes the whole-value
-    // re-indent path in `render_multi_line`, which prepends the attribute indent
-    // to every line. The literal whitespace BETWEEN interpolations still carries
-    // its SOURCE indentation, so that re-indent would double-indent such a line.
-    // Normalise it away (prettier reflows inter-interpolation whitespace to the
-    // attribute column); the downstream re-indent then lands it at exactly the
-    // attribute indent. Values without a wrapped expression stay verbatim.
-    if any_expr_wrapped && out.starts_with('{') {
-        out = normalize_interpolation_value_indent(&out);
+    // A DIRECTIVE's value text prints as a prettier `fill`, whose whitespace is
+    // a break point: the source indentation between two interpolations is
+    // reflowed to the attribute column. (A REGULAR attribute's text is printed
+    // verbatim, so its source indentation is left alone.)
+    if !regular_attr && any_expr_wrapped && out.starts_with('{') {
+        out = normalize_interpolation_value_indent(&out, &indent_str(attr_depth, &options.js));
     }
     Ok(out)
 }
 
-/// Strip the leading horizontal whitespace after a brace-depth-0 newline in an
-/// interpolation-led attribute value body (`{expr}…{expr}`) **only when that
-/// whitespace runs straight into the next interpolation `{`** — i.e. it is
-/// purely structural whitespace between two interpolations. The downstream
-/// whole-value re-indent re-establishes the attribute indent, so this source
-/// indentation must not be carried through (it would be added on top), and
-/// prettier reflows such inter-interpolation whitespace to the attribute column.
+/// Replace the leading horizontal whitespace after a brace-depth-0 newline in a
+/// DIRECTIVE's interpolation-led value body (`{expr}…{expr}`) with `indent`
+/// **only when that whitespace runs straight into the next interpolation `{`** —
+/// i.e. it is purely structural whitespace between two interpolations, which
+/// prettier's `fill` reflows to the attribute column whatever the author wrote.
 ///
-/// Depth-0 lines that carry literal content (`class="{expr}\n\tfoo bar"`) are
-/// left verbatim — that is HTML attribute text whose interior whitespace is
-/// significant and which the oracle preserves as-is. Lines inside `{…}` —
-/// wrapped expression continuations formatted at column 0 — always keep their
-/// relative indent. String / template-literal content is skipped so its braces
+/// Depth-0 lines that carry literal content (`style:x="{expr}\n\tfoo bar"`) are
+/// left verbatim, as are lines inside `{…}` — wrapped expression continuations,
+/// whose relative indent the downstream whole-value re-indent shifts to the
+/// attribute column. String / template-literal content is skipped so its braces
 /// aren't miscounted and its interior newlines (multi-line template quasi) are
-/// left verbatim. The brace/quote scanning mirrors
-/// [`is_verbatim_interpolation_value`], so the verbatim-vs-re-indent decision
-/// and this normalisation agree on depth.
-fn normalize_interpolation_value_indent(value: &str) -> String {
+/// left verbatim.
+fn normalize_interpolation_value_indent(value: &str, indent: &str) -> String {
     let chars: Vec<char> = value.chars().collect();
     let n = chars.len();
     let mut out = String::with_capacity(value.len());
@@ -572,13 +564,14 @@ fn normalize_interpolation_value_indent(value: &str) -> String {
                 '\n' if depth == 0 => {
                     out.push(ch);
                     i += 1;
-                    // Look past horizontal whitespace: strip it only if the next
+                    // Look past horizontal whitespace: reflow it only if the next
                     // non-whitespace character opens another interpolation.
                     let mut j = i;
                     while j < n && (chars[j] == ' ' || chars[j] == '\t') {
                         j += 1;
                     }
                     if j < n && chars[j] == '{' {
+                        out.push_str(indent);
                         i = j;
                     }
                 }
@@ -597,12 +590,12 @@ mod normalize_tests {
     use super::normalize_interpolation_value_indent;
 
     #[test]
-    fn strips_structural_whitespace_before_next_interpolation() {
-        // Whitespace between two interpolations is reflowed by the downstream
-        // re-indent, so its source indentation is removed here.
+    fn reflows_structural_whitespace_before_next_interpolation() {
+        // Whitespace between two interpolations is a `fill` break point, so it
+        // is reflowed to the attribute indent whatever the source held.
         assert_eq!(
-            normalize_interpolation_value_indent("{a}\n      {b}"),
-            "{a}\n{b}"
+            normalize_interpolation_value_indent("{a}\n      {b}", "  "),
+            "{a}\n  {b}"
         );
     }
 
@@ -611,7 +604,7 @@ mod normalize_tests {
         // A depth-0 line carrying literal content (not another interpolation) is
         // significant HTML attribute text and must be left untouched.
         assert_eq!(
-            normalize_interpolation_value_indent("{a}\n      foo bar"),
+            normalize_interpolation_value_indent("{a}\n      foo bar", "  "),
             "{a}\n      foo bar"
         );
     }
@@ -621,8 +614,8 @@ mod normalize_tests {
         // Newlines inside `{…}` (a wrapped expression, depth > 0) are the
         // formatter's own relative indent and are preserved as-is.
         assert_eq!(
-            normalize_interpolation_value_indent("{a\n  ? b\n  : c}\n  {d}"),
-            "{a\n  ? b\n  : c}\n{d}"
+            normalize_interpolation_value_indent("{a\n  ? b\n  : c}\n      {d}", "  "),
+            "{a\n  ? b\n  : c}\n  {d}"
         );
     }
 
@@ -631,7 +624,7 @@ mod normalize_tests {
         // A `{` inside a JS string literal is not an interpolation boundary, so
         // brace depth stays correct and the following literal line is kept.
         assert_eq!(
-            normalize_interpolation_value_indent("{x ?? '{'}\n      foo"),
+            normalize_interpolation_value_indent("{x ?? '{'}\n      foo", "  "),
             "{x ?? '{'}\n      foo"
         );
     }

--- a/crates/rsvelte_formatter/tests/markup_expression_indent.rs
+++ b/crates/rsvelte_formatter/tests/markup_expression_indent.rs
@@ -145,3 +145,121 @@ fn multi_interpolation_value_second_opens_at_attr_indent() {
     let twice = fmt_at_width(&once, 80);
     assert_eq!(once, twice, "not idempotent:\n{once}");
 }
+
+// A directive's value text prints as a prettier `fill`, so the whitespace
+// between two interpolations is a break point: whatever the author wrote is
+// reflowed to the attribute indent (here 6 source spaces → 2).
+#[test]
+fn directive_value_reflows_inter_interpolation_whitespace() {
+    let src = concat!(
+        "<div\n",
+        "  style:transform-origin=\"{verticalAnchor === 'middle'\n",
+        "    ? 'center'\n",
+        "    : verticalAnchor === 'end'\n",
+        "      ? 'bottom'\n",
+        "      : 'top'}\n",
+        "      {textAnchor === 'middle' ? 'center' : textAnchor === 'end' ? 'right' : 'left'}\"\n",
+        ">x</div>\n",
+    );
+    let expected = concat!(
+        "<div\n",
+        "  style:transform-origin=\"{verticalAnchor === 'middle'\n",
+        "    ? 'center'\n",
+        "    : verticalAnchor === 'end'\n",
+        "      ? 'bottom'\n",
+        "      : 'top'}\n",
+        "  {textAnchor === 'middle'\n",
+        "    ? 'center'\n",
+        "    : textAnchor === 'end'\n",
+        "      ? 'right'\n",
+        "      : 'left'}\"\n",
+        ">\n",
+        "  x\n",
+        "</div>\n",
+    );
+    let once = fmt_at_width(src, 80);
+    assert_eq!(once, expected, "directive value reflow:\n{once}");
+    let twice = fmt_at_width(&once, 80);
+    assert_eq!(once, twice, "not idempotent:\n{once}");
+}
+
+// A REGULAR attribute's text prints verbatim, so the source whitespace before a
+// second interpolation survives while that interpolation's own continuation
+// lines still land at the attribute indent + one level.
+#[test]
+fn regular_attribute_value_keeps_inter_interpolation_whitespace() {
+    let src = concat!(
+        "<span title=\"{shortOne}\n",
+        "      {anotherConditionValueHere ? someMuchLongerAlternativeThree : someMuchLongerAlternativeFour}\">x</span>\n",
+    );
+    let expected = concat!(
+        "<span\n",
+        "  title=\"{shortOne}\n",
+        "      {anotherConditionValueHere\n",
+        "    ? someMuchLongerAlternativeThree\n",
+        "    : someMuchLongerAlternativeFour}\">x</span\n",
+        ">\n",
+    );
+    let once = fmt_at_width(src, 80);
+    assert_eq!(once, expected, "regular attribute value indent:\n{once}");
+    let twice = fmt_at_width(&once, 80);
+    assert_eq!(once, twice, "not idempotent:\n{once}");
+}
+
+// #2120: an attribute value holding TWO independently wrapping interpolations
+// separated by raw text. Only the first depth-0 boundary used to be honoured, so
+// the second expression stayed verbatim at column 0; every boundary must be
+// scanned so each expression run is re-indented.
+#[test]
+fn second_wrapped_interpolation_after_raw_text_is_reindented() {
+    let src = concat!(
+        "<span title=\"{someConditionValueXx ? aVeryLongAlternativeOneHere : aVeryLongAlternativeTwoHere}\n",
+        "\traw text\n",
+        "\t{anotherConditionValueHere ? someMuchLongerAlternativeThree : someMuchLongerAlternativeFour}\">x</span>\n",
+    );
+    let expected = concat!(
+        "<span\n",
+        "  title=\"{someConditionValueXx\n",
+        "    ? aVeryLongAlternativeOneHere\n",
+        "    : aVeryLongAlternativeTwoHere}\n",
+        "\traw text\n",
+        "\t{anotherConditionValueHere\n",
+        "    ? someMuchLongerAlternativeThree\n",
+        "    : someMuchLongerAlternativeFour}\">x</span\n",
+        ">\n",
+    );
+    let once = fmt_at_width(src, 80);
+    assert_eq!(once, expected, "second interpolation indent:\n{once}");
+    let twice = fmt_at_width(&once, 80);
+    assert_eq!(once, twice, "not idempotent:\n{once}");
+}
+
+// Three raw-text separated runs: a flat interpolation between two raw-text lines
+// must not swallow the boundary that the trailing wrapped one needs.
+#[test]
+fn every_raw_text_boundary_is_scanned() {
+    let src = concat!(
+        "<span title=\"{someConditionValueXx ? aVeryLongAlternativeOneHere : aVeryLongAlternativeTwoHere}\n",
+        "\traw a\n",
+        "\t{mid}\n",
+        "\traw b\n",
+        "\t{anotherConditionValueHere ? someMuchLongerAlternativeThree : someMuchLongerAlternativeFour}\">x</span>\n",
+    );
+    let expected = concat!(
+        "<span\n",
+        "  title=\"{someConditionValueXx\n",
+        "    ? aVeryLongAlternativeOneHere\n",
+        "    : aVeryLongAlternativeTwoHere}\n",
+        "\traw a\n",
+        "\t{mid}\n",
+        "\traw b\n",
+        "\t{anotherConditionValueHere\n",
+        "    ? someMuchLongerAlternativeThree\n",
+        "    : someMuchLongerAlternativeFour}\">x</span\n",
+        ">\n",
+    );
+    let once = fmt_at_width(src, 80);
+    assert_eq!(once, expected, "multi-boundary attribute indent:\n{once}");
+    let twice = fmt_at_width(&once, 80);
+    assert_eq!(once, twice, "not idempotent:\n{once}");
+}


### PR DESCRIPTION
Fixes #2120

## Problem

`reindent_attr_with_raw_text` split a rendered multi-line attribute value at the **first** brace-depth-0 tab-led newline: everything before it was re-indented as formatter output, everything after was emitted verbatim. An attribute value holding two independently wrapping interpolations separated by raw text therefore left the second expression stranded — its `{` and continuation lines sat at column 0 where the oracle re-indents them.

```svelte
<span title="{longFn1(...)}
	raw text
	{longFn2(argFive, argSix, argSeven, argEight)}">x</span>
```

## Oracle model

Probing oxfmt(`svelte: true`) across 11 shapes shows one consistent rule for a rendered attribute:

- a line that **begins at brace depth 0** is literal attribute text — printed verbatim, author whitespace and all;
- a line that **begins inside `{…}`** is `oxc_formatter` output produced at column 0 — it gains the attribute indent.

The one exception is a **directive** (`style:x="…"`), whose value text prints as a prettier `fill`: there the whitespace between two interpolations is a break point and is reflowed to the attribute column whatever the source held.

## Fix

- `scan_value_newlines` now collects **every** depth-0 newline instead of only the first tab-led one, and `reindent_attr_with_raw_text` re-indents each segment (`skip_first` keeps each depth-0 line verbatim while its brace-interior continuations gain the prefix). This is the #2120 fix proper.
- `normalize_interpolation_value_indent` is now applied only to directive values, and writes the attribute indent rather than stripping to column 0 — the reflow it models is real for `fill` text but not for regular attribute text, which the oracle keeps verbatim.
- `attr_value` only treats `=` as the name/value separator when everything before it is actually an attribute name. Without that guard `{@attach x != null && …}` was split on the JS operator and its expression body scanned as if it were markup (which the boundary change would otherwise have turned into a real regression).

## Verification

Every one of the 11 probe shapes (raw text before/after a wrapping interpolation, three raw-text-separated runs, tab- and space-indented raw text, regular attributes and `style:` directives) is now byte-identical to the oracle, in both `useTabs: true` and `useTabs: false`.

- `cargo test -p rsvelte_formatter` / `-p rsvelte_fmt` / `-p rsvelte_language_server` — all green
- svelte.dev formatter-parity hard gate (`svelte_dev_corpus`, `svelte_dev_markdown`) — green
- ecosystem fmt-parity ratchet: 13,456 included / 13,414 matched / 20 failed — unchanged from the baseline, so no regression and no baseline entry to shrink (the issue shape is absent from the corpus)
- `cargo fmt` + `cargo clippy --all-targets --all-features -- -D warnings` clean

4 regression tests added in `markup_expression_indent.rs` (issue shape, three-run shape, regular-attribute whitespace preservation, directive reflow — each also asserting idempotency) plus 2 unit tests in `render_tag.rs` for the boundary scan and the name/value split.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
