### PR TITLE
fix(svelte2tsx): match official createEventDispatcher event names and typing (#2157)

### DIFF
--- a/.changeset/svelte2tsx-event-dispatcher-typing.md
+++ b/.changeset/svelte2tsx-event-dispatcher-typing.md
@@ -1,0 +1,6 @@
+---
+"@rsvelte/svelte2tsx": patch
+"@rsvelte/svelte-check": patch
+---
+
+`createEventDispatcher` event names and typings now match official svelte2tsx. The dispatcher factory is recognised through the local name the `svelte` import binds it to, so `import { createEventDispatcher as foo }` works (and a same-named local that was never imported no longer counts); every typed `createEventDispatcher<T>()` in a component contributes its own `...__sveltets_2_toEventTypings<T>()` spread instead of only the last one, with a name declared by two of them degrading to `CustomEvent<any>` and gaining a `customEvent` entry; and `dispatch(name)` resolves `name` through a string constant declared earlier in the instance script. Dispatchers declared inside a function are tracked too, and the `events.getAll()` API surface now includes the events a typed dispatcher declares.

--- a/compatibility/svelte2tsx-fixtures-known-failures.json
+++ b/compatibility/svelte2tsx-fixtures-known-failures.json
@@ -3,12 +3,8 @@
 	"component-slot-inside-await",
 	"component-slot-let-forward",
 	"component-slot-object-key",
-	"event-dispatcher-events",
-	"event-dispatcher-events-alias",
 	"module-snippet-component-instance-reference.v5",
 	"ts-await-generics.v5",
-	"ts-event-dispatchers",
-	"ts-event-dispatchers-same-event",
 	"ts-runes-hoistable-props-false-6.v5",
 	"ts-type-assertion"
 ]

--- a/compatibility/svelte2tsx-fixtures-known-failures.md
+++ b/compatibility/svelte2tsx-fixtures-known-failures.md
@@ -25,7 +25,7 @@ UPDATE_S2TSX_FIXTURES_BASELINE=1 cargo test --test svelte2tsx_fixtures
 `STRICT_S2TSX_FIXTURES=1` ignores the baseline entirely (every failure fails),
 which is how you check whether an entry is still needed.
 
-## Current baseline: 12 of 254 (pass rate 95.3%)
+## Current baseline: 8 of 254 (pass rate 96.9%)
 
 ### #2145 note
 
@@ -97,20 +97,3 @@ quoting bug itself (which is fixed in `collect/mod.rs`'s `push_let_reflection_sc
   squarely in the `let:`-forwarding resolution logic (`push_let_reflection_scope`
   neighbourhood / `TemplateScope.resolveLet` equivalent) that issue #2105 owns —
   left untouched here per that PR's explicit scope boundary.
-
-### `createEventDispatcher` event-name/type inference gaps — 4
-
-- **`event-dispatcher-events`**, **`event-dispatcher-events-alias`.** `dispatch(bla,
-  false)` where `bla` is a local `const bla = 'bye'` — official statically resolves
-  the dispatched event name through the `const` binding to add `'bye'` to the
-  `events:` reflection; rsvelte only recognizes a string literal passed directly as
-  `dispatch()`'s first argument, not one flowing through a traced local constant.
-  (`-alias` is the same gap through an aliased `import { createEventDispatcher as
-  foo }`.)
-
-- **`ts-event-dispatchers`**, **`ts-event-dispatchers-same-event`.** Multiple
-  `createEventDispatcher<T>()` calls in one component (`dispatch1`/`dispatch2`/
-  `dispatch3`, each with its own generic event-type parameter) — official unions
-  every one via a separate `...__sveltets_2_toEventTypings<T>()` spread per
-  dispatcher; rsvelte only emits one. A distinct, self-contained event-typing
-  feature gap, unrelated to #2145.

--- a/crates/rsvelte_projection/src/svelte2tsx/nodes/component_events.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/nodes/component_events.rs
@@ -209,12 +209,10 @@ fn build_events_str_with_observer(
         let mut event_parts = Vec::new();
         // Official `toDefString` order: typed-dispatcher event typings FIRST,
         // then bubbled/forwarded events, then untyped-dispatch customEvents.
-        // Add generic event typing from createEventDispatcher<Type>() first.
-        if let Some(ref generic_type) = events.dispatcher_generic_type {
-            event_parts.push(format!(
-                "...__sveltets_2_toEventTypings<{}>()",
-                generic_type
-            ));
+        // Add generic event typing from createEventDispatcher<Type>() first —
+        // one spread per typed dispatcher, in declaration order.
+        for generic_type in &events.dispatcher_generic_types {
+            event_parts.push(format!("...__sveltets_2_toEventTypings<{generic_type}>()"));
         }
         // Add element events (forwarded), reducing them exactly like the
         // official `EventHandler` bubbled-events `Map` (event-handler.ts):

--- a/crates/rsvelte_projection/src/svelte2tsx/script/component_events.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/script/component_events.rs
@@ -3,10 +3,13 @@
 use std::collections::HashMap;
 
 use oxc_ast::ast as oxc;
+use oxc_ast_visit::Visit;
 use oxc_span::GetSpan;
 use rustc_hash::FxHashMap;
 
-use super::ast_utils::binding_pattern_simple_name;
+use super::ast_utils::{
+    binding_pattern_simple_name, module_export_name_to_string, property_key_to_string,
+};
 
 /// Tracks events declared by a component.
 ///
@@ -20,9 +23,10 @@ pub struct ComponentEvents {
     events: HashMap<String, EventInfo>,
     /// Whether the component forwards all events (uses `$$restProps` with event handlers).
     pub forwards_all_events: bool,
-    /// Generic type text from `createEventDispatcher<Type>()`, if any.
-    /// Used to generate `{...__sveltets_2_toEventTypings<Type>()}` in the events return.
-    pub dispatcher_generic_type: Option<String>,
+    /// Generic type text of every TYPED `createEventDispatcher<Type>()`, in
+    /// declaration order. Official emits one
+    /// `...__sveltets_2_toEventTypings<Type>()` spread per typed dispatcher.
+    pub dispatcher_generic_types: Vec<String>,
     /// Locally-created, *untyped* event dispatchers
     /// (`const dispatch = createEventDispatcher()`) as `(name, decl_pos)` where
     /// `decl_pos` is the dispatcher declarator's absolute position in `source`.
@@ -32,11 +36,9 @@ pub struct ComponentEvents {
     /// dispatcher was already registered during its in-order AST walk — i.e.
     /// the call appears AFTER the declaration — so `decl_pos` is the order gate.
     pub dispatcher_decls: Vec<(String, u32)>,
-    /// Dispatched event names in official insertion order: template
-    /// `dispatch(...)` calls first (collected as `EventHandler` callees during
-    /// the template walk, surfaced when the dispatcher declaration is reached),
-    /// then instance-script `dispatch(...)` calls that appear after the
-    /// declaration. Preserved (not sorted) for the `events:` return.
+    /// Event names that reach the `events:` return as
+    /// `'name': __sveltets_2_customEvent`, in official insertion order — see
+    /// `collect_dispatched_events` for how that order is reconstructed.
     dispatched_order: Vec<String>,
     /// Absolute source positions (end of the `createEventDispatcher` callee, just
     /// before its `(`) of every UNTYPED `createEventDispatcher()` call. When a
@@ -44,6 +46,44 @@ pub struct ComponentEvents {
     /// prepends `<__sveltets_2_CustomEvents<$$Events>>` here so the untyped
     /// dispatcher picks up the declared event typings.
     pub dispatcher_typing_inject_pos: Vec<u32>,
+    /// Local name `createEventDispatcher` is imported under. Official refuses to
+    /// treat any call as a dispatcher factory until an `import … from 'svelte'`
+    /// binds it, so an alias counts and a same-named local does not.
+    event_dispatcher_import: Option<String>,
+    /// `const x = 'literal'` bindings (any nesting level) in walk order, so a
+    /// `dispatch(x)` whose first argument is a traced constant resolves.
+    string_vars: Vec<StringVar>,
+    /// Event additions recorded during the script walk, replayed in source order
+    /// together with the scanned `dispatch(...)` call sites.
+    pending: Vec<PendingEvent>,
+}
+
+/// A `const x = 'literal'` binding, keyed by its absolute declaration position:
+/// official only resolves `dispatch(x)` against declarations its walk already
+/// passed.
+#[derive(Debug, Clone)]
+struct StringVar {
+    name: String,
+    value: String,
+    pos: u32,
+}
+
+#[derive(Debug, Clone)]
+struct PendingEvent {
+    /// Absolute source position the addition happens at in official's walk.
+    pos: u32,
+    name: String,
+    kind: PendingKind,
+}
+
+#[derive(Debug, Clone)]
+enum PendingKind {
+    /// A member of a typed dispatcher's `<{…}>` literal — contributes typing
+    /// only; it reaches the `events:` customEvent list solely by colliding with
+    /// an already-registered name.
+    TypedMember(Option<String>),
+    /// A `dispatch('name', …)` call site.
+    Dispatched,
 }
 
 /// Metadata about a single component event.
@@ -56,19 +96,34 @@ pub struct EventInfo {
 impl ComponentEvents {
     /// Create a new empty `ComponentEvents`.
     pub fn new() -> Self {
-        Self {
-            events: HashMap::new(),
-            forwards_all_events: false,
-            dispatcher_generic_type: None,
-            dispatcher_decls: Vec::new(),
-            dispatched_order: Vec::new(),
-            dispatcher_typing_inject_pos: Vec::new(),
-        }
+        Self::default()
     }
 
     /// Add an event declaration.
     pub fn add(&mut self, name: String, detail_type: Option<String>) {
         self.events.insert(name, EventInfo { detail_type });
+    }
+
+    /// Official `ComponentEventsFromEventsMap.addToEvents`: a repeated name
+    /// falls back to `CustomEvent<any>` AND joins the dispatched set, which is
+    /// what makes two typed dispatchers declaring the same event also emit a
+    /// `'name': __sveltets_2_customEvent` entry.
+    fn add_to_events(&mut self, name: &str, detail_type: Option<String>) {
+        if self.events.contains_key(name) {
+            self.events
+                .insert(name.to_owned(), EventInfo { detail_type: None });
+            self.push_dispatched(name);
+        } else {
+            self.events
+                .insert(name.to_owned(), EventInfo { detail_type });
+        }
+    }
+
+    /// Mirrors the official `dispatchedEvents` `Set`: insertion-ordered, unique.
+    fn push_dispatched(&mut self, name: &str) {
+        if !self.dispatched_order.iter().any(|known| known == name) {
+            self.dispatched_order.push(name.to_owned());
+        }
     }
 
     /// Get all event names.
@@ -84,19 +139,21 @@ impl ComponentEvents {
     }
 
     /// Scan `source` for `<dispatcher>("eventName", …)` call sites of every
-    /// recorded untyped dispatcher and add each event name in official insertion
-    /// order. Mirrors `ComponentEventsFromEventsMap`:
+    /// recorded untyped dispatcher and replay every event addition in official
+    /// insertion order. Mirrors `ComponentEventsFromEventsMap`:
     ///
     /// * **Template** `dispatch(...)` calls (those OUTSIDE the instance/module
     ///   `<script>` regions) are collected as `EventHandler` callees during the
-    ///   template walk and surfaced (regardless of source order) when the
-    ///   dispatcher declaration is reached — so they come FIRST, in template
-    ///   source order.
+    ///   template walk and surfaced (regardless of their own source order) when
+    ///   the dispatcher declaration is reached, so they order by that
+    ///   declaration's position.
     /// * **Instance-script** `dispatch(...)` calls are only counted when they
     ///   appear AFTER the dispatcher declaration in the in-order AST walk
     ///   (`checkIfCallExpressionIsDispatch` requires the dispatcher to already
     ///   be registered) — so each call's position must exceed its dispatcher's
-    ///   `decl_pos`. These come after the template events, in script order.
+    ///   `decl_pos`.
+    /// * **Typed** dispatcher members recorded by the script walk are replayed
+    ///   at their declaration's position, interleaved with the above.
     ///
     /// `inst_range` / `mod_range` are the `[content_start, end)` byte spans of
     /// the instance and module `<script>` elements (module dispatch calls are
@@ -107,15 +164,46 @@ impl ComponentEvents {
         inst_range: Option<(u32, u32)>,
         mod_range: Option<(u32, u32)>,
     ) {
-        if self.dispatcher_decls.is_empty() {
+        let mut pending = std::mem::take(&mut self.pending);
+        if !self.dispatcher_decls.is_empty() {
+            let (template_events, script_events) = scan_dispatch_calls(
+                source,
+                &self.dispatcher_decls,
+                &self.string_vars,
+                inst_range,
+                mod_range,
+            );
+            // A template call surfaces at the declaration that claims it, so it
+            // orders against the script by the declaration's position.
+            for (name, dispatcher_index) in template_events {
+                pending.push(PendingEvent {
+                    pos: self.dispatcher_decls[dispatcher_index].1,
+                    name: name.to_owned(),
+                    kind: PendingKind::Dispatched,
+                });
+            }
+            for (name, pos) in script_events {
+                pending.push(PendingEvent {
+                    pos,
+                    name: name.to_owned(),
+                    kind: PendingKind::Dispatched,
+                });
+            }
+        }
+        if pending.is_empty() {
             return;
         }
-        let (template_events, script_events) =
-            scan_dispatch_calls(source, &self.dispatcher_decls, inst_range, mod_range);
-        for evt in template_events.into_iter().chain(script_events) {
-            if !self.events.contains_key(evt) {
-                self.dispatched_order.push(evt.to_string());
-                self.add(evt.to_string(), None);
+
+        pending.sort_by_key(|entry| entry.pos);
+        for entry in pending {
+            match entry.kind {
+                PendingKind::TypedMember(detail_type) => {
+                    self.add_to_events(&entry.name, detail_type)
+                }
+                PendingKind::Dispatched => {
+                    self.add_to_events(&entry.name, None);
+                    self.push_dispatched(&entry.name);
+                }
             }
         }
     }
@@ -149,22 +237,38 @@ impl ComponentEvents {
     }
 }
 
+/// Template hits carry the index of the dispatcher declaration that claims them;
+/// script hits carry the call's own absolute position.
+type DispatchScan<'source> = (Vec<(&'source str, usize)>, Vec<(&'source str, u32)>);
+
 fn scan_dispatch_calls<'source>(
     source: &'source str,
     decls: &[(String, u32)],
+    string_vars: &'source [StringVar],
     inst_range: Option<(u32, u32)>,
     mod_range: Option<(u32, u32)>,
-) -> (Vec<&'source str>, Vec<&'source str>) {
-    scan_dispatch_calls_with_observer(source, decls, inst_range, mod_range, || {})
+) -> DispatchScan<'source> {
+    scan_dispatch_calls_with_observer(source, decls, string_vars, inst_range, mod_range, || {})
+}
+
+/// The value of `name` as official's `stringVars` map would hold it when the
+/// walk reaches `before` — the newest declaration the walk already passed.
+fn lookup_string_var<'a>(string_vars: &'a [StringVar], name: &str, before: u32) -> Option<&'a str> {
+    string_vars
+        .iter()
+        .rev()
+        .find(|var| var.pos < before && var.name == name)
+        .map(|var| var.value.as_str())
 }
 
 fn scan_dispatch_calls_with_observer<'source>(
     source: &'source str,
     decls: &[(String, u32)],
+    string_vars: &'source [StringVar],
     inst_range: Option<(u32, u32)>,
     mod_range: Option<(u32, u32)>,
     mut observe_identifier: impl FnMut(),
-) -> (Vec<&'source str>, Vec<&'source str>) {
+) -> DispatchScan<'source> {
     let mut dispatcher_indices: FxHashMap<&str, (usize, usize)> =
         FxHashMap::with_capacity_and_hasher(decls.len(), Default::default());
     let mut next_dispatcher = vec![usize::MAX; decls.len()];
@@ -218,28 +322,56 @@ fn scan_dispatch_calls_with_observer<'source>(
         while p < bytes.len() && bytes[p].is_ascii_whitespace() {
             p += 1;
         }
-        if p >= bytes.len() || (bytes[p] != b'"' && bytes[p] != b'\'' && bytes[p] != b'`') {
+        if p >= bytes.len() || in_range(start, mod_range) {
             continue;
         }
+        let in_instance_script = in_range(start, inst_range);
 
-        let quote = bytes[p];
-        p += 1;
-        let name_start = p;
-        while p < bytes.len() && bytes[p] != quote {
+        let event = if bytes[p] == b'"' || bytes[p] == b'\'' || bytes[p] == b'`' {
+            let quote = bytes[p];
             p += 1;
-        }
-        if p >= bytes.len() || p == name_start || in_range(start, mod_range) {
+            let name_start = p;
+            while p < bytes.len() && bytes[p] != quote {
+                p += 1;
+            }
+            if p >= bytes.len() || p == name_start {
+                continue;
+            }
+            &source[name_start..p]
+        } else if in_instance_script
+            && (bytes[p].is_ascii_alphabetic() || bytes[p] == b'_' || bytes[p] == b'$')
+        {
+            // `dispatch(bla, …)` where `bla` is a traced string constant. Only in
+            // the instance script: the template collects callee arguments through
+            // `EventHandler`, which reads a literal `.value` and never resolves
+            // identifiers.
+            let ident_start = p;
+            while p < bytes.len() && is_ident(bytes[p]) {
+                p += 1;
+            }
+            let identifier = &source[ident_start..p];
+            while p < bytes.len() && bytes[p].is_ascii_whitespace() {
+                p += 1;
+            }
+            // Official requires the WHOLE first argument to be the identifier.
+            if p >= bytes.len() || (bytes[p] != b',' && bytes[p] != b')') {
+                continue;
+            }
+            match lookup_string_var(string_vars, identifier, start as u32) {
+                Some(value) => value,
+                None => continue,
+            }
+        } else {
             continue;
-        }
-        let event = &source[name_start..p];
+        };
 
         loop {
-            if in_range(start, inst_range) {
+            if in_instance_script {
                 if start as u32 > decls[dispatcher_index].1 {
-                    script_events.push(event);
+                    script_events.push((event, start as u32));
                 }
             } else {
-                template_events.push(event);
+                template_events.push((event, dispatcher_index));
             }
             dispatcher_index = next_dispatcher[dispatcher_index];
             if dispatcher_index == usize::MAX {
@@ -251,45 +383,138 @@ fn scan_dispatch_calls_with_observer<'source>(
     (template_events, script_events)
 }
 
-/// Detect `createEventDispatcher<Type>()` calls and extract the generic type.
-///
-/// Records the type text (e.g. `{a: A}`) in the events struct for use
-/// in the return statement's events field.
-pub(super) fn detect_create_event_dispatcher(
-    declarator: &oxc::VariableDeclarator,
+/// Walk the instance script in source order to collect everything official's
+/// `ComponentEvents` learns while walking it: which local name
+/// `createEventDispatcher` is imported under, the dispatchers instantiated from
+/// it (typed and untyped, at any nesting level) and the string constants a
+/// `dispatch(x)` can resolve through.
+pub(super) fn collect_event_dispatcher_facts<'a>(
+    program: &oxc::Program<'a>,
     raw_content: &str,
     events: &mut ComponentEvents,
     content_offset: u32,
 ) {
-    if let Some(ref init) = declarator.init
-        && let oxc::Expression::CallExpression(call) = init
-        && let oxc::Expression::Identifier(ref callee) = call.callee
-        && callee.name == "createEventDispatcher"
-    {
-        // Check for type arguments: createEventDispatcher<Type>()
-        if let Some(ref type_args) = call.type_arguments
-            && let Some(first_param) = type_args.params.first()
+    EventDispatcherCollector {
+        events,
+        raw_content,
+        content_offset,
+    }
+    .visit_program(program);
+}
+
+struct EventDispatcherCollector<'e, 'r> {
+    events: &'e mut ComponentEvents,
+    raw_content: &'r str,
+    content_offset: u32,
+}
+
+impl EventDispatcherCollector<'_, '_> {
+    /// Source text of `span`, mirroring upstream's `node.getText()`.
+    fn text(&self, span: oxc_span::Span) -> Option<String> {
+        let (start, end) = (span.start as usize, span.end as usize);
+        (start < end && end <= self.raw_content.len())
+            .then(|| self.raw_content[start..end].to_owned())
+    }
+
+    /// Official `checkIfIsStringLiteralDeclaration`.
+    fn note_string_literal_declaration(&mut self, declarator: &oxc::VariableDeclarator<'_>) {
+        if let Some(name) = binding_pattern_simple_name(&declarator.id)
+            && let Some(oxc::Expression::StringLiteral(literal)) = declarator.init.as_ref()
         {
-            let start = first_param.span().start as usize;
-            let end = first_param.span().end as usize;
-            if start < end && end <= raw_content.len() {
-                let type_text = raw_content[start..end].to_string();
-                events.dispatcher_generic_type = Some(type_text);
-            }
-        } else if let Some(name) = binding_pattern_simple_name(&declarator.id) {
-            // Untyped dispatcher: record its name + absolute declaration position
-            // (`content_offset + declarator.span.start`) so `dispatch("name")`
-            // call sites can be scanned — and order-gated against this position —
-            // to populate the events return.
-            let decl_pos = content_offset + declarator.span.start;
-            events.dispatcher_decls.push((name.to_owned(), decl_pos));
-            // Record the callee end (before `(`) so a `$$Events` interface can
-            // inject `<__sveltets_2_CustomEvents<$$Events>>` onto the untyped call.
-            events
-                .dispatcher_typing_inject_pos
-                .push(content_offset + callee.span.end);
+            self.events.string_vars.push(StringVar {
+                name: name.to_owned(),
+                value: literal.value.to_string(),
+                pos: self.content_offset + declarator.span.start,
+            });
         }
     }
+
+    /// Official `checkIfDeclarationInstantiatedEventDispatcher`.
+    fn note_dispatcher_declaration(&mut self, declarator: &oxc::VariableDeclarator<'_>) {
+        let Some(name) = binding_pattern_simple_name(&declarator.id) else {
+            return;
+        };
+        let Some(oxc::Expression::CallExpression(call)) = declarator.init.as_ref() else {
+            return;
+        };
+        let oxc::Expression::Identifier(callee) = &call.callee else {
+            return;
+        };
+        if self.events.event_dispatcher_import.as_deref() != Some(callee.name.as_str()) {
+            return;
+        }
+
+        let decl_pos = self.content_offset + declarator.span.start;
+        let typing = call
+            .type_arguments
+            .as_ref()
+            .and_then(|arguments| arguments.params.first());
+        let Some(typing) = typing else {
+            // Untyped dispatcher: record its name + declaration position so
+            // `dispatch("name")` call sites can be scanned and order-gated
+            // against it, plus the callee end (before `(`) so a `$$Events`
+            // interface can inject `<__sveltets_2_CustomEvents<$$Events>>`.
+            self.events
+                .dispatcher_decls
+                .push((name.to_owned(), decl_pos));
+            self.events
+                .dispatcher_typing_inject_pos
+                .push(self.content_offset + callee.span.end);
+            return;
+        };
+
+        if let Some(typing_text) = self.text(typing.span()) {
+            self.events.dispatcher_generic_types.push(typing_text);
+        }
+        // Only an inline type literal exposes its event names; a named type is
+        // spread verbatim and stays opaque to the event map.
+        if let oxc::TSType::TSTypeLiteral(literal) = typing {
+            for member in literal.members.iter() {
+                if let oxc::TSSignature::TSPropertySignature(signature) = member
+                    && let Some(event_name) = property_key_to_string(&signature.key)
+                {
+                    let detail = signature
+                        .type_annotation
+                        .as_ref()
+                        .and_then(|annotation| self.text(annotation.type_annotation.span()));
+                    self.events.pending.push(PendingEvent {
+                        pos: decl_pos,
+                        name: event_name,
+                        kind: PendingKind::TypedMember(detail),
+                    });
+                }
+            }
+        }
+    }
+}
+
+impl<'a> Visit<'a> for EventDispatcherCollector<'_, '_> {
+    fn visit_import_declaration(&mut self, it: &oxc::ImportDeclaration<'a>) {
+        if self.events.event_dispatcher_import.is_none() {
+            self.events.event_dispatcher_import = event_dispatcher_import_local(it);
+        }
+    }
+
+    fn visit_variable_declarator(&mut self, it: &oxc::VariableDeclarator<'a>) {
+        self.note_string_literal_declaration(it);
+        self.note_dispatcher_declaration(it);
+        oxc_ast_visit::walk::walk_variable_declarator(self, it);
+    }
+}
+
+/// Official `checkIfImportIsEventDispatcher`: the local name a named
+/// `import … from 'svelte'` binds `createEventDispatcher` to, alias included.
+fn event_dispatcher_import_local(node: &oxc::ImportDeclaration<'_>) -> Option<String> {
+    if node.source.value != "svelte" {
+        return None;
+    }
+    node.specifiers.as_ref()?.iter().find_map(|specifier| {
+        let oxc::ImportDeclarationSpecifier::ImportSpecifier(specifier) = specifier else {
+            return None;
+        };
+        (module_export_name_to_string(&specifier.imported) == "createEventDispatcher")
+            .then(|| specifier.local.name.to_string())
+    })
 }
 
 #[cfg(test)]
@@ -395,9 +620,15 @@ mod tests {
         ];
 
         let (_, script_events) =
-            scan_dispatch_calls(source, &decls, Some((0, source.len() as u32)), None);
+            scan_dispatch_calls(source, &decls, &[], Some((0, source.len() as u32)), None);
 
-        assert_eq!(script_events, vec!["first", "second", "third", "third"]);
+        assert_eq!(
+            script_events
+                .iter()
+                .map(|(name, _)| *name)
+                .collect::<Vec<_>>(),
+            vec!["first", "second", "third", "third"]
+        );
     }
 
     #[test]
@@ -413,16 +644,16 @@ mod tests {
                 .collect();
             let mut identifiers_visited = 0;
             let (template_events, script_events) =
-                scan_dispatch_calls_with_observer(&source, &decls, None, None, || {
+                scan_dispatch_calls_with_observer(&source, &decls, &[], None, None, || {
                     identifiers_visited += 1;
                 });
 
             assert_eq!(template_events.len(), dispatcher_count);
             assert!(script_events.is_empty());
             assert_eq!(identifiers_visited, 16_384 + 128 * 2);
-            assert_eq!(template_events[0], "event0");
+            assert_eq!(template_events[0].0, "event0");
             assert_eq!(
-                template_events[dispatcher_count - 1],
+                template_events[dispatcher_count - 1].0,
                 format!("event{}", dispatcher_count - 1)
             );
         }

--- a/crates/rsvelte_projection/src/svelte2tsx/script/mod.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/script/mod.rs
@@ -41,7 +41,7 @@ use ast_utils::{
     binding_pattern_simple_name, collect_top_level_declared_names, declarator_has_boolean_init,
     extract_all_names_from_binding_pattern,
 };
-use component_events::detect_create_event_dispatcher;
+use component_events::collect_event_dispatcher_facts;
 use export_decl::{handle_export_named_decl, leading_jsdoc_comment};
 use exported_names::PossibleExport;
 use hoistable_types::{
@@ -116,6 +116,11 @@ pub fn process_instance_script(
     let mut instance_imports = Vec::new();
     with_parsed_script(parsed, |program, raw_content| {
         let script_facts = ScriptFacts::collect(program, offset, raw_content, true, store_scan);
+        // Official refuses to recognise a dispatcher without an import binding
+        // `createEventDispatcher`, so its absence rules out every event fact.
+        if contains_word(raw_content.as_bytes(), b"createEventDispatcher") {
+            collect_event_dispatcher_facts(program, raw_content, _events, offset);
+        }
         let mut import_collector = contains_word(raw_content.as_bytes(), b"import")
             .then(|| InstanceImportCollector::new(raw_content, &program.comments));
 
@@ -149,8 +154,6 @@ pub fn process_instance_script(
                     for declarator in var_decl.declarations.iter() {
                         detect_runes_call(declarator, exported_names, &declared_names);
                         detect_props_rune_oxc(declarator, exported_names, raw_content);
-                        // Detect createEventDispatcher<Type>() calls
-                        detect_create_event_dispatcher(declarator, raw_content, _events, offset);
                         // Collect $props() info for typedef generation (one per
                         // `$props()` destructure).
                         if let Some(info) = collect_props_rune_info(

--- a/crates/rsvelte_projection/tests/svelte2tsx_event_dispatcher_2157.rs
+++ b/crates/rsvelte_projection/tests/svelte2tsx_event_dispatcher_2157.rs
@@ -1,0 +1,215 @@
+//! Regression test for issue #2157.
+//!
+//! `createEventDispatcher` handling diverged from official svelte2tsx in three
+//! ways: the factory was matched by its literal name instead of the local name
+//! the `svelte` import binds (so an alias was invisible), only the LAST typed
+//! dispatcher's `<T>` reached the `events:` spread, and a `dispatch(name)` whose
+//! argument is a traced string constant was ignored. The expectations below are
+//! the official `ComponentEventsFromEventsMap` behaviour.
+
+use rsvelte_projection::svelte2tsx::{Svelte2TsxOptions, svelte2tsx};
+
+fn events_of(src: &str, is_ts_file: bool) -> String {
+    let opts = Svelte2TsxOptions {
+        filename: "Input.svelte".to_string(),
+        is_ts_file,
+        ..Default::default()
+    };
+    let out = svelte2tsx(src, opts).expect("svelte2tsx").code;
+    let start = out.find(", events: ").expect("events in return") + ", events: ".len();
+    let end = out[start..].find(" }}\n").expect("end of return") + start;
+    out[start..end].to_string()
+}
+
+#[test]
+fn aliased_create_event_dispatcher_import_is_recognised() {
+    let events = events_of(
+        concat!(
+            "<script>\n",
+            "  import { createEventDispatcher as foo } from 'svelte';\n",
+            "  const dispatch = foo();\n",
+            "  dispatch('hi', true);\n",
+            "</script>\n",
+        ),
+        false,
+    );
+
+    assert_eq!(events, "{'hi': __sveltets_2_customEvent}");
+}
+
+#[test]
+fn dispatcher_factory_must_come_from_the_svelte_import() {
+    // No import at all, and an import from another module, both leave the local
+    // `createEventDispatcher` unrecognised — official keys off the import.
+    for src in [
+        concat!(
+            "<script>\n",
+            "  const dispatch = createEventDispatcher();\n",
+            "  dispatch('hi');\n",
+            "</script>\n",
+        ),
+        concat!(
+            "<script>\n",
+            "  import { createEventDispatcher } from './local';\n",
+            "  const dispatch = createEventDispatcher();\n",
+            "  dispatch('hi');\n",
+            "</script>\n",
+        ),
+    ] {
+        assert_eq!(events_of(src, false), "{}");
+    }
+}
+
+#[test]
+fn dispatch_resolves_a_traced_string_constant() {
+    let events = events_of(
+        concat!(
+            "<script>\n",
+            "  import { createEventDispatcher } from 'svelte';\n",
+            "  const dispatch = createEventDispatcher();\n",
+            "  function bye() {\n",
+            "    const bla = 'bye';\n",
+            "    dispatch(bla, false);\n",
+            "  }\n",
+            "</script>\n",
+        ),
+        false,
+    );
+
+    assert_eq!(events, "{'bye': __sveltets_2_customEvent}");
+}
+
+#[test]
+fn traced_constant_is_only_visible_after_its_declaration() {
+    // Official reads `stringVars` as its walk goes, so a constant declared after
+    // the call site is not yet known.
+    let events = events_of(
+        concat!(
+            "<script>\n",
+            "  import { createEventDispatcher } from 'svelte';\n",
+            "  const dispatch = createEventDispatcher();\n",
+            "  dispatch(bla, false);\n",
+            "  const bla = 'bye';\n",
+            "</script>\n",
+        ),
+        false,
+    );
+
+    assert_eq!(events, "{}");
+}
+
+#[test]
+fn a_non_identifier_first_argument_is_not_traced() {
+    let events = events_of(
+        concat!(
+            "<script>\n",
+            "  import { createEventDispatcher } from 'svelte';\n",
+            "  const bla = 'bye';\n",
+            "  const dispatch = createEventDispatcher();\n",
+            "  dispatch(bla.length, false);\n",
+            "  dispatch(other, false);\n",
+            "</script>\n",
+        ),
+        false,
+    );
+
+    assert_eq!(events, "{}");
+}
+
+#[test]
+fn a_template_dispatch_never_resolves_an_identifier() {
+    // The template collects callee arguments through `EventHandler`, which only
+    // reads a literal `.value` — identifiers stay unresolved there.
+    let events = events_of(
+        concat!(
+            "<script>\n",
+            "  import { createEventDispatcher } from 'svelte';\n",
+            "  const bla = 'bye';\n",
+            "  const dispatch = createEventDispatcher();\n",
+            "</script>\n",
+            "\n<button on:click={() => dispatch(bla)}></button>\n",
+        ),
+        false,
+    );
+
+    assert_eq!(events, "{}");
+}
+
+#[test]
+fn every_typed_dispatcher_contributes_its_own_event_typings() {
+    let events = events_of(
+        concat!(
+            "<script>\n",
+            "  import { createEventDispatcher } from 'svelte';\n",
+            "  const dispatch1 = createEventDispatcher<{hi: boolean;}>();\n",
+            "  const dispatch2 = createEventDispatcher<{btn: string;}>();\n",
+            "</script>\n",
+        ),
+        true,
+    );
+
+    assert_eq!(
+        events,
+        "{...__sveltets_2_toEventTypings<{hi: boolean;}>(), \
+         ...__sveltets_2_toEventTypings<{btn: string;}>()}"
+    );
+}
+
+#[test]
+fn an_event_declared_by_two_typed_dispatchers_also_becomes_a_custom_event() {
+    // Official `addToEvents` degrades a repeated name to `CustomEvent<any>` and
+    // puts it in the dispatched set, so it gains a `customEvent` entry too.
+    let events = events_of(
+        concat!(
+            "<script>\n",
+            "  import { createEventDispatcher } from 'svelte';\n",
+            "  const dispatch1 = createEventDispatcher<{hi: boolean;}>();\n",
+            "  const dispatch2 = createEventDispatcher<{hi: string;}>();\n",
+            "</script>\n",
+        ),
+        true,
+    );
+
+    assert_eq!(
+        events,
+        "{...__sveltets_2_toEventTypings<{hi: boolean;}>(), \
+         ...__sveltets_2_toEventTypings<{hi: string;}>(), \
+         'hi': __sveltets_2_customEvent}"
+    );
+}
+
+#[test]
+fn a_typed_dispatchers_own_dispatch_calls_are_not_scanned() {
+    // Official only tracks call sites of dispatchers WITHOUT a typing.
+    let events = events_of(
+        concat!(
+            "<script>\n",
+            "  import { createEventDispatcher } from 'svelte';\n",
+            "  const dispatch = createEventDispatcher<{hi: boolean;}>();\n",
+            "  dispatch('nope', true);\n",
+            "</script>\n",
+        ),
+        true,
+    );
+
+    assert_eq!(events, "{...__sveltets_2_toEventTypings<{hi: boolean;}>()}");
+}
+
+#[test]
+fn a_dispatcher_declared_inside_a_function_is_still_tracked() {
+    // Official walks the whole instance script, not just its top level.
+    let events = events_of(
+        concat!(
+            "<script>\n",
+            "  import { createEventDispatcher } from 'svelte';\n",
+            "  function setup() {\n",
+            "    const dispatch = createEventDispatcher();\n",
+            "    dispatch('hi', true);\n",
+            "  }\n",
+            "</script>\n",
+        ),
+        false,
+    );
+
+    assert_eq!(events, "{'hi': __sveltets_2_customEvent}");
+}


### PR DESCRIPTION
Fixes #2157

## Why

PR #2155 tightened the svelte2tsx fixture comparator so the `return { … }`
reflection is compared again. That surfaced four `createEventDispatcher`
fixtures, pinned in `compatibility/svelte2tsx-fixtures-known-failures.json`:
`event-dispatcher-events`, `event-dispatcher-events-alias`,
`ts-event-dispatchers`, `ts-event-dispatchers-same-event`.

## Root cause

`ComponentEvents` diverged from official
`svelte2tsx/src/svelte2tsx/nodes/ComponentEvents.ts` in four independent ways:

1. **The factory was matched by its literal name.** Official
   `checkIfImportIsEventDispatcher` records the *local* name an
   `import … from 'svelte'` binds `createEventDispatcher` to and
   `checkIfDeclarationInstantiatedEventDispatcher` compares the callee against
   *that*. rsvelte compared `callee.name == "createEventDispatcher"`, so
   `import { createEventDispatcher as foo }` was invisible (and a same-named
   local that was never imported was wrongly counted).
2. **Only one typed dispatcher survived.** `dispatcher_generic_type` was an
   `Option<String>` that each `createEventDispatcher<T>()` overwrote; official
   keeps an array and emits one `...__sveltets_2_toEventTypings<T>()` spread per
   dispatcher.
3. **`addToEvents`'s collision rule was missing.** When a name is registered
   twice official degrades it to `CustomEvent<any>` *and* adds it to the
   dispatched set — which is how two typed dispatchers declaring the same event
   also produce a `'name': __sveltets_2_customEvent` entry.
4. **`dispatch(x)` never resolved a traced constant.** Official's `stringVars`
   map records every `const x = 'literal'` the walk passes (at any nesting
   level) and `checkIfCallExpressionIsDispatch` resolves an identifier first
   argument through it.

## Fix

`crates/rsvelte_projection/src/svelte2tsx/script/component_events.rs`:

- New source-order `Visit` walk over the instance script
  (`collect_event_dispatcher_facts`) collecting exactly what official's walk
  learns: the imported local name, dispatcher declarations (typed and untyped,
  at any nesting level, gated on an identifier binding like official) and the
  string constants. It is skipped entirely when the script does not mention
  `createEventDispatcher` — without that import official recognises nothing.
- `dispatcher_generic_type` → `dispatcher_generic_types: Vec<String>`, one
  spread per typed dispatcher in declaration order.
- `add_to_events` / `push_dispatched` mirror official's `addToEvents` and the
  `dispatchedEvents` set, and every event addition (typed members, template
  calls surfaced at their dispatcher declaration, instance-script calls) is
  replayed in source-position order so the collision rule sees the same history
  official's single walk does.
- The dispatch-call scanner accepts an identifier first argument in the
  instance script and resolves it against the string constants visible at that
  position. The template deliberately does not resolve identifiers — official's
  `EventHandler` only reads a literal `.value` there.

## Testing

- `compatibility/svelte2tsx-fixtures-known-failures.json`: **12 → 8** entries
  (the 4 `createEventDispatcher` entries removed, with their justification
  section dropped from the paired `.md`; `corpus:known-failures-check` passes).
  Fixture suite: 242/254 → 246/254. Counts are relative to `main` after #2165
  (issue #2156), which this branch is rebased on.
- New `crates/rsvelte_projection/tests/svelte2tsx_event_dispatcher_2157.rs` —
  10 cases covering the alias import, the import requirement, traced-constant
  resolution (incl. declaration-order and non-identifier-argument negatives),
  the template's refusal to resolve identifiers, multiple typed dispatchers, the
  same-event collision, typed dispatchers' own calls being ignored, and a
  dispatcher declared inside a function. **Every expectation was verified
  byte-for-byte against official `svelte2tsx` built from
  `submodules/language-tools`**, not against rsvelte's own output.
- The four fixtures' `events:` blocks are byte-identical to the official
  `expectedv2.ts` oracle.
- `cargo test --release --workspace` green; `cargo fmt` + `cargo clippy
  --all-targets --all-features -- -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
