### PR TITLE
fix(svelte2tsx): lower slots for `<svelte:self>` as a slot parent (#2160)

### DIFF
--- a/.changeset/svelte2tsx-svelte-self-slot-parent.md
+++ b/.changeset/svelte2tsx-svelte-self-slot-parent.md
@@ -1,0 +1,17 @@
+---
+"@rsvelte/compiler": patch
+"@rsvelte/svelte2tsx": patch
+"@rsvelte/svelte-check": patch
+---
+
+fix(svelte2tsx): lower slots for `<svelte:self>` as a slot parent. Official
+svelte2tsx models `<svelte:self>` as an `InlineComponent`, so its children are
+slot consumers of that node, but rsvelte performed no lowering there at all:
+`<svelte:self><div slot="a">` kept a bogus `"slot":`a`` prop instead of the
+`$$slot_def["a"]` wrapper, `<svelte:self><div let:x>` kept a bogus
+`"let:x":true` prop instead of the `$$slot_def.default` destructure (leaving
+every `let:` binding an undeclared identifier), and the `$$_svelteselfN`
+instance const was never declared. Named-slot children reached through
+`{#if}` / `{#each}` / `{#await}` / `{#key}` now forward too, and a
+`<svelte:self>` that is itself a named-slot child keeps both levels of
+wrapper.

--- a/crates/rsvelte_projection/src/svelte2tsx/template/nodes/inline_component.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/template/nodes/inline_component.rs
@@ -894,7 +894,16 @@ pub(crate) fn handle_svelte_self(
         )
     };
 
-    let needs_inst_var = has_on_directives || has_lets;
+    // `<svelte:self>` is an `InlineComponent` upstream, so its children are slot
+    // consumers of THIS node: named-slot children (anywhere inside control-flow
+    // blocks) and default-slot `let:` receivers destructure from its
+    // `$$slot_def`, which forces the `const $$_svelteselfN = …` form.
+    let children_have_named_slots = has_named_slot_children(&el.fragment);
+    let children_have_default_slot_lets = has_default_slot_let_children(&el.fragment);
+    let needs_inst_var = has_on_directives
+        || has_lets
+        || children_have_named_slots
+        || children_have_default_slot_lets;
     // Use depth as the instance variable index, mirroring official InlineComponent.ts
     // `this._name = '$$_svelteself' + this.computeDepth()`.
     let var_name = if needs_inst_var {
@@ -965,9 +974,40 @@ pub(crate) fn handle_svelte_self(
     }
 
     str.overwrite(el.start, opening_tag_end, &opener);
-    // svelte:self is a component → children at depth+1.
-    process_fragment_inplace(&el.fragment, source, options, str, counter, depth + 1);
-    let trailing = if has_lets { "}}" } else { "}" };
+    // svelte:self is a component → children at depth+1. Slot-bearing children
+    // take the same lowering as a named component's (`$$slot_def.default` /
+    // `$$slot_def["x"]` blocks); this node's OWN `let:` block is already in
+    // `opener` above, so the helper is told not to emit it again.
+    let deferred_slot_close = if children_have_named_slots || children_have_default_slot_lets {
+        let inst_var = var_name
+            .as_deref()
+            .expect("slot-consuming children require an instance variable name");
+        process_component_children_with_slots(
+            &el.attributes,
+            &el.fragment,
+            el.end,
+            inst_var,
+            false,
+            source,
+            options,
+            str,
+            counter,
+            depth + 1,
+        )
+    } else {
+        // Still publish the slot context (as `handle_svelte_component` does) so
+        // a descendant that reaches for `$$slot_def` without being detected
+        // above cannot fall back to the *enclosing* component's instance.
+        counter.slot_inst = var_name.clone();
+        process_fragment_inplace(&el.fragment, source, options, str, counter, depth + 1);
+        counter.slot_inst = None;
+        false
+    };
+    let trailing = if has_lets || deferred_slot_close {
+        "}}"
+    } else {
+        "}"
+    };
     // `svelte:self` keeps no name mapping on its closing tag, so its collapsed
     // gaps are all that precede the closers.
     let spaces = " ".repeat(closing_tag_spacing(closing_tag_start, el.end, None));

--- a/crates/rsvelte_projection/tests/svelte2tsx_svelte_self_slot_parent_2160.rs
+++ b/crates/rsvelte_projection/tests/svelte2tsx_svelte_self_slot_parent_2160.rs
@@ -1,0 +1,187 @@
+//! Regression tests for #2160: `<svelte:self>` is an `InlineComponent` in
+//! official svelte2tsx, so its children are slot consumers of THAT node —
+//! named `slot=` children get a `$$slot_def["…"]` wrapper and default-slot
+//! `let:` receivers get a `$$slot_def.default` destructure, both keyed on the
+//! `$$_svelteselfN` instance. rsvelte performed no slot lowering at all there,
+//! leaving `slot=` / `let:` as bogus props (`"slot":`a`,` / `"let:x":true,`)
+//! and never declaring the instance const.
+//!
+//! Every expectation below is the byte-exact template body official svelte2tsx
+//! (language-tools, parsing with svelte 5.56.8) emits for the same input.
+
+use rsvelte_projection::svelte2tsx::{Svelte2TsxOptions, svelte2tsx};
+
+fn convert(src: &str) -> String {
+    let opts = Svelte2TsxOptions {
+        filename: "Input.svelte".to_string(),
+        is_ts_file: false,
+        ..Default::default()
+    };
+    svelte2tsx(src, opts).expect("svelte2tsx ok").code
+}
+
+fn assert_contains(code: &str, expected: &str) {
+    assert!(
+        code.contains(expected),
+        "expected output to contain:\n{expected}\n\ngot:\n{code}"
+    );
+}
+
+/// A default-slot `let:` receiver destructures from `<svelte:self>`'s own
+/// `$$slot_def.default`, which forces the `const $$_svelteself0 = …` form.
+#[test]
+fn default_slot_let_child_forwards() {
+    let code = convert("<svelte:self>\n\t<div let:x>{x}</div>\n</svelte:self>\n");
+    assert_contains(
+        &code,
+        "{ const $$_svelteself0 = __sveltets_2_createComponentAny({children:() => { return __sveltets_2_any(0); },});",
+    );
+    assert_contains(
+        &code,
+        "\n\t {const {/*\u{03A9}ignore_start\u{03A9}*/$$_$$/*\u{03A9}ignore_end\u{03A9}*/,x,} = $$_svelteself0.$$slot_def.default;$$_$$;{ svelteHTML.createElement(\"div\", { });x; }}\n",
+    );
+}
+
+/// `<svelte:fragment let:x>` is an `Element` upstream, so it forwards the same way.
+#[test]
+fn default_slot_let_fragment_child_forwards() {
+    let code =
+        convert("<svelte:self>\n\t<svelte:fragment let:x>{x}</svelte:fragment>\n</svelte:self>\n");
+    assert_contains(
+        &code,
+        "\n\t {const {/*\u{03A9}ignore_start\u{03A9}*/$$_$$/*\u{03A9}ignore_end\u{03A9}*/,x,} = $$_svelteself0.$$slot_def.default;$$_$$;{ svelteHTML.createElement(\"svelte:fragment\", { });x; }}\n",
+    );
+}
+
+/// A static `slot="a"` child is wrapped in `$$slot_def["a"]` and loses the
+/// `slot` prop (which the wrapper consumed).
+#[test]
+fn named_slot_element_child_is_wrapped() {
+    let code = convert("<svelte:self>\n\t<div slot=\"a\">hi</div>\n</svelte:self>\n");
+    assert_contains(
+        &code,
+        "{ const $$_svelteself0 = __sveltets_2_createComponentAny({});",
+    );
+    assert_contains(
+        &code,
+        "\n\t {const {/*\u{03A9}ignore_start\u{03A9}*/$$_$$/*\u{03A9}ignore_end\u{03A9}*/,} = $$_svelteself0.$$slot_def[\"a\"];$$_$$;{ svelteHTML.createElement(\"div\", { });  }}\n",
+    );
+    assert!(
+        !code.contains("\"slot\":`a`"),
+        "slot= must not stay a prop:\n{code}"
+    );
+}
+
+/// Component-kind named-slot children (`<Child slot="a">`, `<svelte:self
+/// slot="a">`) route through the same `$$slot_def["…"]` lowering.
+#[test]
+fn named_slot_component_children_are_wrapped() {
+    let code = convert("<svelte:self>\n\t<Child slot=\"a\" />\n</svelte:self>\n");
+    assert_contains(
+        &code,
+        "\n\t {const {/*\u{03A9}ignore_start\u{03A9}*/$$_$$/*\u{03A9}ignore_end\u{03A9}*/,} = $$_svelteself0.$$slot_def[\"a\"];$$_$$;{ const $$_dlihC1C = __sveltets_2_ensureComponent(Child); new $$_dlihC1C({ target: __sveltets_2_any(), props: {  }});}}\n",
+    );
+
+    let nested = convert("<svelte:self>\n\t<svelte:self slot=\"a\" />\n</svelte:self>\n");
+    assert_contains(
+        &nested,
+        "\n\t {const {/*\u{03A9}ignore_start\u{03A9}*/$$_$$/*\u{03A9}ignore_end\u{03A9}*/,} = $$_svelteself0.$$slot_def[\"a\"];$$_$$;{ __sveltets_2_createComponentAny({  });}}\n",
+    );
+}
+
+/// A named-slot child that also carries `let:` folds both into one wrapper,
+/// while a sibling default-slot `let:` receiver keeps the `.default` key.
+#[test]
+fn named_and_default_slot_siblings() {
+    let code = convert(
+        "<svelte:self>\n\t<div slot=\"a\" let:x>{x}</div>\n\t<span let:y>{y}</span>\n</svelte:self>\n",
+    );
+    assert_contains(
+        &code,
+        "\n\t {const {/*\u{03A9}ignore_start\u{03A9}*/$$_$$/*\u{03A9}ignore_end\u{03A9}*/,x,} = $$_svelteself0.$$slot_def[\"a\"];$$_$$;{ svelteHTML.createElement(\"div\", {  });x; }}\n",
+    );
+    assert_contains(
+        &code,
+        "\n\t {const {/*\u{03A9}ignore_start\u{03A9}*/$$_$$/*\u{03A9}ignore_end\u{03A9}*/,y,} = $$_svelteself0.$$slot_def.default;$$_$$;{ svelteHTML.createElement(\"span\", { });y; }}\n",
+    );
+}
+
+/// Control-flow blocks are transparent to the slot scope, so a block-nested
+/// child still forwards.
+#[test]
+fn block_nested_children_forward() {
+    let named = convert(
+        "<svelte:self>\n\t{#if c}\n\t\t<div slot=\"a\">hi</div>\n\t{/if}\n</svelte:self>\n",
+    );
+    assert_contains(
+        &named,
+        "\n\t\t {const {/*\u{03A9}ignore_start\u{03A9}*/$$_$$/*\u{03A9}ignore_end\u{03A9}*/,} = $$_svelteself0.$$slot_def[\"a\"];$$_$$;{ svelteHTML.createElement(\"div\", { });  }}\n",
+    );
+
+    let lets = convert(
+        "<svelte:self>\n\t{#each items as item}\n\t\t<div let:x>{x}</div>\n\t{/each}\n</svelte:self>\n",
+    );
+    assert_contains(
+        &lets,
+        "\n\t\t {const {/*\u{03A9}ignore_start\u{03A9}*/$$_$$/*\u{03A9}ignore_end\u{03A9}*/,x,} = $$_svelteself0.$$slot_def.default;$$_$$;{ svelteHTML.createElement(\"div\", { });x; }}\n",
+    );
+}
+
+/// `<svelte:self>`'s OWN `let:` opens one `$$slot_def.default` block around
+/// every child, and a named-slot child nests its own wrapper inside it — so
+/// the closing tag emits both `}`s.
+#[test]
+fn own_let_wraps_named_slot_child() {
+    let code = convert("<svelte:self let:z>\n\t{z}\n\t<div slot=\"a\">hi</div>\n</svelte:self>\n");
+    assert_contains(
+        &code,
+        "{ const $$_svelteself0 = __sveltets_2_createComponentAny({ children:() => { return __sveltets_2_any(0); },});{const {/*\u{03A9}ignore_start\u{03A9}*/$$_$$/*\u{03A9}ignore_end\u{03A9}*/,z,} = $$_svelteself0.$$slot_def.default;$$_$$;\n",
+    );
+    assert_contains(
+        &code,
+        "\n\t {const {/*\u{03A9}ignore_start\u{03A9}*/$$_$$/*\u{03A9}ignore_end\u{03A9}*/,} = $$_svelteself0.$$slot_def[\"a\"];$$_$$;{ svelteHTML.createElement(\"div\", { });  }}\n }}\n",
+    );
+}
+
+/// A `<svelte:self slot="a">` that is itself a slot parent keeps both
+/// levels: the enclosing component's `$$slot_def["a"]` and its own
+/// `$$slot_def["b"]`, keyed on the depth-numbered instance.
+#[test]
+fn svelte_self_is_both_slot_child_and_slot_parent() {
+    let code = convert(
+        "<Foo>\n\t<svelte:self slot=\"a\">\n\t\t<div slot=\"b\">hi</div>\n\t</svelte:self>\n</Foo>\n",
+    );
+    assert_contains(
+        &code,
+        "\n\t {const {/*\u{03A9}ignore_start\u{03A9}*/$$_$$/*\u{03A9}ignore_end\u{03A9}*/,} = $$_ooF0.$$slot_def[\"a\"];$$_$$;{ const $$_svelteself1 = __sveltets_2_createComponentAny({ });\n",
+    );
+    assert_contains(
+        &code,
+        "\n\t\t {const {/*\u{03A9}ignore_start\u{03A9}*/$$_$$/*\u{03A9}ignore_end\u{03A9}*/,} = $$_svelteself1.$$slot_def[\"b\"];$$_$$;{ svelteHTML.createElement(\"div\", { });  }}\n\t }}\n",
+    );
+}
+
+/// Two named slots each get their own wrapper.
+#[test]
+fn two_named_slot_children() {
+    let code = convert(
+        "<svelte:self>\n\t<div slot=\"a\">A</div>\n\t<div slot=\"b\">B</div>\n</svelte:self>\n",
+    );
+    assert_contains(&code, "= $$_svelteself0.$$slot_def[\"a\"];");
+    assert_contains(&code, "= $$_svelteself0.$$slot_def[\"b\"];");
+}
+
+/// Plain children still get no instance const and no slot block — the
+/// lowering must stay opt-in.
+#[test]
+fn plain_children_get_no_slot_block() {
+    let code = convert("<svelte:self>\n\thello\n</svelte:self>\n");
+    assert_contains(
+        &code,
+        "{ __sveltets_2_createComponentAny({children:() => { return __sveltets_2_any(0); },});",
+    );
+    assert!(
+        !code.contains("$$slot_def"),
+        "unexpected slot block:\n{code}"
+    );
+}


### PR DESCRIPTION
Fixes #2160

## Cause

Official svelte2tsx models `<svelte:self>` as an `InlineComponent` (`InlineComponent.ts` branches only on the *create call* — `__sveltets_2_createComponentAny` vs `new …C(…)` — and shares `addSlotName` / `addSlotLet` with every other component). rsvelte's `handle_svelte_self` never joined the slot-forwarding path that `handle_component` and `handle_svelte_component` share (unified in #2135, extended in #2148 / #2159): it computed neither `has_named_slot_children` nor `has_default_slot_let_children`, never called `process_component_children_with_slots`, and never published `counter.slot_inst`.

So `<svelte:self>` as a slot **parent** produced no lowering at all:

| input | official | rsvelte (before) |
|---|---|---|
| `<svelte:self><div slot="a">` | `{const {$$_$$,} = $$_svelteself0.$$slot_def["a"];$$_$$;{ svelteHTML.createElement("div", { }); …` | `{ svelteHTML.createElement("div", { "slot":`a`,}); …` |
| `<svelte:self><div let:x>` | `{const {$$_$$,x,} = $$_svelteself0.$$slot_def.default;$$_$$;{ … }` | `{ svelteHTML.createElement("div", {"let:x":true,}); …` |

The `let:` case is the damaging one — every `let:` binding stayed an **undeclared identifier** in the generated TSX, so `svelte-check` reported a spurious "Cannot find name" on each use. The `$$_svelteselfN` instance const was also never declared, because `needs_inst_var` only looked at `on:` / `let:` on the node itself.

## Fix

`handle_svelte_self` now takes exactly the shape `handle_svelte_component` already has:

- `needs_inst_var` additionally covers `has_named_slot_children` / `has_default_slot_let_children`, so the `const $$_svelteselfN = …` form is emitted when a child destructures from its `$$slot_def`;
- children route through `process_component_children_with_slots` (with `has_lets = false`, since the node's own `let:` block is already in the opener) when any child consumes the slot defs, otherwise through `process_fragment_inplace` with `slot_inst` published;
- the closing tag emits the second `}` when the helper defers the default-slot close.

Blocks stay transparent (`{#if}` / `{#each}` / `{#await}` / `{#key}`-nested children forward), and a `<svelte:self slot="a">` that is itself a slot parent keeps both levels of wrapper.

## Verification

- **Byte-parity vs the official oracle** (language-tools built against svelte 5.56.8): a 50-case shape matrix over `let:` / static `slot=` / both / `{#if}`/`{#each}`/`{#await}`/`{#key}`-nested / own-`let:` + named child / `<svelte:self>` nested inside a component slot / `<svelte:fragment>` / `<slot>` / `<svelte:element>` / `<Child slot=…>` / `<svelte:self slot=…>` / multi-named / self-closing. All slot-related cases now match byte-for-byte (0 mismatches; before the fix every one of them diverged).
- **New regression suite** `crates/rsvelte_projection/tests/svelte2tsx_svelte_self_slot_parent_2160.rs` (10 tests), every expectation copied byte-exact from the official output.
- **No corpus movement**: `s2t` output before vs after is byte-identical across **all 13,626 collected corpus components** (svelte + svelte.dev + the 30 real-world submodules + pattern-corpus), so no ratchet entry moves in either direction.
- `cargo test -p rsvelte_projection` green (incl. all 257 svelte2tsx fixtures), `cargo test -p rsvelte_check` green, `cargo fmt` + `cargo clippy --all-targets --all-features -- -D warnings` clean.

## Out of scope (confirmed still reproducing)

The two items noted in the same sweep on #2160 are untouched here and reproduce independently of `<svelte:self>`:

- **top-level `<style>` trailing newline** — `<style>…</style>\n` alone yields `async () => {\n};` officially, `async () => {};` in rsvelte (the newline that followed `</style>` is dropped with the deleted range).
- **`<svelte:boundary>` opening-tag gap** — `<svelte:boundary onerror={h}>\n\t<div>hi</div>` yields `svelteHTML.createElement("svelte:boundary", {  "onerror":h,}); { svelteHTML.createElement("div", {});` officially (two-space props gap, body folded onto the opener line); rsvelte emits one space and keeps the `\n\t` before the child.

Also surfaced by the matrix and independent of slots (all pre-existing, none introduced here): `bind:` on `<svelte:self>` stays a raw `"bind:value":value,` prop instead of `value,` + `$$bindings`; a `{#snippet}` child of `<svelte:self>` is not lowered to a component prop; `$on(…)` gains one trailing space; a bare `{#await p}` pending arm loses one space of gap (reproduces with no component at all).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
