### PR TITLE
fix(svelte2tsx): throw when $$Slots/$$Props/$$Events are declared in a module script

### DIFF
--- a/crates/rsvelte_projection/src/svelte2tsx/script/mod.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/script/mod.rs
@@ -732,13 +732,22 @@ pub fn process_instance_script(
 /// * `source` - The original source code
 /// * `str` - The MagicString for source manipulation
 /// * `exported_names` - Accumulator for exported names
+///
+/// # Errors
+///
+/// Mirrors official `processModuleScriptTag.ts`: a top-level `$$Props` /
+/// `$$Slots` / `$$Events` type/interface declaration is only meaningful in the
+/// instance script, so official throws when one is found in `<script
+/// context="module">`. Nested declarations are not checked here (out of
+/// scope — see #2166), matching the instance-script side's top-level-only
+/// `$$Slots`/`$$Props`/`$$Events` detection.
 pub fn process_module_script(
     script: &Script,
     parsed: &ParsedScript<'_>,
     store_scan: &mut StoreScanContext<'_>,
     str: &mut MagicString<'_>,
     exported_names: &mut ExportedNames,
-) {
+) -> Result<(), super::utils::error::Svelte2TsxError> {
     // Module script exports are kept as-is (with the export keyword).
     // They are not component props and do not go into the return statement.
     //
@@ -834,28 +843,36 @@ pub fn process_module_script(
                                 }
                             }
                             oxc::Declaration::TSTypeAliasDeclaration(t) => {
-                                exported_names
-                                    .module_type_names
-                                    .insert(t.id.name.to_string());
+                                let name = t.id.name.to_string();
+                                if is_special_type_name(&name) {
+                                    return Err(sentinel_type_in_module_script_error(&name));
+                                }
+                                exported_names.module_type_names.insert(name);
                             }
                             oxc::Declaration::TSInterfaceDeclaration(iface) => {
-                                exported_names
-                                    .module_type_names
-                                    .insert(iface.id.name.to_string());
+                                let name = iface.id.name.to_string();
+                                if is_special_type_name(&name) {
+                                    return Err(sentinel_type_in_module_script_error(&name));
+                                }
+                                exported_names.module_type_names.insert(name);
                             }
                             _ => {}
                         }
                     }
                 }
                 oxc::Statement::TSTypeAliasDeclaration(t) => {
-                    exported_names
-                        .module_type_names
-                        .insert(t.id.name.to_string());
+                    let name = t.id.name.to_string();
+                    if is_special_type_name(&name) {
+                        return Err(sentinel_type_in_module_script_error(&name));
+                    }
+                    exported_names.module_type_names.insert(name);
                 }
                 oxc::Statement::TSInterfaceDeclaration(iface) => {
-                    exported_names
-                        .module_type_names
-                        .insert(iface.id.name.to_string());
+                    let name = iface.id.name.to_string();
+                    if is_special_type_name(&name) {
+                        return Err(sentinel_type_in_module_script_error(&name));
+                    }
+                    exported_names.module_type_names.insert(name);
                 }
                 // Module-level `namespace X { ... }` and `enum X { ... }`
                 // contribute both a value and a type binding, so an
@@ -880,7 +897,18 @@ pub fn process_module_script(
                 _ => {}
             }
         }
-    });
+        Ok(())
+    })
+}
+
+/// `$$Events`/`$$Slots`/`$$Props` can only be declared in the instance
+/// script — mirrors official `processModuleScriptTag.ts`'s
+/// `throw$$Error`, whose message doesn't distinguish `interface` from
+/// `type`.
+fn sentinel_type_in_module_script_error(name: &str) -> super::utils::error::Svelte2TsxError {
+    super::utils::error::Svelte2TsxError::Script(format!(
+        "{name} can only be declared in the instance script"
+    ))
 }
 
 #[cfg(test)]
@@ -945,6 +973,107 @@ mod tests {
         let source = "<script context=\"module\">\nexport let shared = 0;\n</script>";
         let result = run_svelte2tsx(source);
         assert!(!result.exported_names.has("shared"));
+    }
+
+    // -- $$Slots / $$Props / $$Events must throw in a module script (#2167) --
+    // Mirrors official `processModuleScriptTag.ts`'s `throw$$Error`.
+
+    #[test]
+    fn module_script_interface_dollar_slots_throws() {
+        let source =
+            "<script context=\"module\">\ninterface $$Slots {\n  default: {};\n}\n</script>";
+        let err = svelte2tsx(source, Svelte2TsxOptions::default()).unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            "Script error: $$Slots can only be declared in the instance script"
+        );
+    }
+
+    #[test]
+    fn module_script_type_dollar_slots_throws() {
+        let source = "<script context=\"module\">\ntype $$Slots = {\n  default: {};\n};\n</script>";
+        let err = svelte2tsx(source, Svelte2TsxOptions::default()).unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            "Script error: $$Slots can only be declared in the instance script"
+        );
+    }
+
+    #[test]
+    fn module_script_interface_dollar_props_throws() {
+        let source =
+            "<script context=\"module\">\ninterface $$Props {\n  name: string;\n}\n</script>";
+        let err = svelte2tsx(source, Svelte2TsxOptions::default()).unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            "Script error: $$Props can only be declared in the instance script"
+        );
+    }
+
+    #[test]
+    fn module_script_type_dollar_props_throws() {
+        let source =
+            "<script context=\"module\">\ntype $$Props = {\n  name: string;\n};\n</script>";
+        let err = svelte2tsx(source, Svelte2TsxOptions::default()).unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            "Script error: $$Props can only be declared in the instance script"
+        );
+    }
+
+    #[test]
+    fn module_script_interface_dollar_events_throws() {
+        let source = "<script context=\"module\">\ninterface $$Events {\n  change: CustomEvent;\n}\n</script>";
+        let err = svelte2tsx(source, Svelte2TsxOptions::default()).unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            "Script error: $$Events can only be declared in the instance script"
+        );
+    }
+
+    #[test]
+    fn module_script_type_dollar_events_throws() {
+        let source =
+            "<script context=\"module\">\ntype $$Events = {\n  change: CustomEvent;\n};\n</script>";
+        let err = svelte2tsx(source, Svelte2TsxOptions::default()).unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            "Script error: $$Events can only be declared in the instance script"
+        );
+    }
+
+    #[test]
+    fn module_script_exported_interface_dollar_props_throws() {
+        // `export interface $$Props` in a module script goes through the
+        // `ExportNamedDeclaration`-wrapped branch, not the bare-declaration one.
+        let source = "<script context=\"module\">\nexport interface $$Props {\n  name: string;\n}\n</script>";
+        let err = svelte2tsx(source, Svelte2TsxOptions::default()).unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            "Script error: $$Props can only be declared in the instance script"
+        );
+    }
+
+    #[test]
+    fn instance_script_dollar_slots_dollar_props_dollar_events_unaffected() {
+        // Same three sentinel declarations, but in the INSTANCE script — must
+        // continue to compile without error (pre-existing, non-regressed
+        // behavior; only the module-script side is new in #2167).
+        let source = "<script lang=\"ts\">\n\
+            interface $$Slots {\n  default: {};\n}\n\
+            interface $$Props {\n  name: string;\n}\n\
+            interface $$Events {\n  change: CustomEvent;\n}\n\
+            export let name: string;\n\
+            </script>";
+        let result = svelte2tsx(
+            source,
+            Svelte2TsxOptions {
+                filename: "Component.svelte".to_string(),
+                is_ts_file: true,
+                ..Default::default()
+            },
+        );
+        assert!(result.is_ok());
     }
 
     // -- Mixed instance and module scripts --

--- a/crates/rsvelte_projection/src/svelte2tsx/script/parse.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/script/parse.rs
@@ -46,9 +46,9 @@ impl<'source> ParsedScripts<'source> {
 }
 
 #[inline]
-pub(super) fn with_parsed_script<F>(script: &ParsedScript<'_>, f: F)
+pub(super) fn with_parsed_script<F, R>(script: &ParsedScript<'_>, f: F) -> R
 where
-    F: FnOnce(&oxc::Program, &str),
+    F: FnOnce(&oxc::Program, &str) -> R,
 {
-    f(script.program(), script.source());
+    f(script.program(), script.source())
 }

--- a/crates/rsvelte_projection/src/svelte2tsx/svelte2tsx.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/svelte2tsx.rs
@@ -536,7 +536,7 @@ pub fn svelte2tsx(
             &mut store_scan,
             &mut str,
             &mut exported_names,
-        );
+        )?;
     }
 
     // Step 7: Process instance script (<script>)


### PR DESCRIPTION
## Summary

- Official `processModuleScriptTag.ts` throws `$$Slots can only be declared in the instance script` (and the `$$Props`/`$$Events` equivalents) when one of these sentinel type/interface declarations appears in `<script context="module">`. rsvelte silently accepted all three and dropped them into `module_type_names`, so the compiler diverged from official's error behavior.
- `process_module_script` (`crates/rsvelte_projection/src/svelte2tsx/script/mod.rs`) now returns `Result<(), Svelte2TsxError>` and rejects a top-level `interface`/`type` declaration named `$$Slots`/`$$Props`/`$$Events` (bare or `export`-wrapped) with `Svelte2TsxError::Script("{name} can only be declared in the instance script")`, matching official's message text exactly (`throw$$Error` doesn't distinguish `interface` from `type`).
- `with_parsed_script` (`script/parse.rs`) is generalized from `FnOnce(&Program, &str)` to `FnOnce(&Program, &str) -> R`, so the fallible module-script closure can propagate its `Result` out; the instance-script call site is unaffected (its closure still returns `()`).
- `svelte2tsx()` propagates the new error via `?`.
- Instance-script `$$Slots`/`$$Props`/`$$Events` declarations are unaffected — they remain valid there (pre-existing, unchanged behavior).
- Nested (non-top-level) sentinel declarations are intentionally out of scope, matching #2166, and consistent with the existing instance-script side, which also only inspects top-level statements.

Fixes #2167

## Test plan

- [x] `cargo test -p rsvelte_projection` — full suite green, including 8 new regression tests covering `interface`/`type` forms of all three sentinels (plus an `export interface $$Props` case and an instance-script non-regression case).
- [x] `cargo fmt` (workspace) — no diff beyond the intended files.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean, both for `rsvelte_projection` alone and the whole workspace.
- [x] Verified all downstream crates (`rsvelte_check`, `rsvelte_napi`, `rsvelte`, `rsvelte_devtools`, `rsvelte_lint_bindings`) still build against the new `process_module_script` signature.
- [x] `compatibility/svelte2tsx-known-failures.json` and the check/check-e2e known-failures files are currently empty (0 known failures) — this change only rejects a previously-mishandled, invalid pattern that no passing corpus fixture could have exercised, so no corpus regression is expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)