### PR TITLE
fix(compiler): lower a legacy destructure assignment whose targets are only props (#2163)

### DIFF
--- a/compatibility/pattern-corpus/issues/2163-legacy-props-only-destructure.svelte
+++ b/compatibility/pattern-corpus/issues/2163-legacy-props-only-destructure.svelte
@@ -1,0 +1,23 @@
+<script>
+	export let a = 1;
+	export let b = 2;
+	export let rest = {};
+	export let pair = [3, 4];
+	const obj = { a: 3, b: 4 };
+
+	function f() {
+		({ a, b } = obj);
+	}
+
+	function g() {
+		({ a, ...rest } = obj);
+	}
+
+	function h() {
+		[a, b] = pair;
+	}
+</script>
+
+<button onclick={f}>{a}{b}</button>
+<button onclick={g}>{Object.keys(rest).length}</button>
+<button onclick={h}>{a}{b}</button>

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/destructure_transforms.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/destructure_transforms.rs
@@ -68,10 +68,13 @@ pub(super) fn transform_destructure_assignments(
 /// Transform destructure assignments, with knowledge of prop variables.
 ///
 /// `prop_vars` are variable names that will be transformed to function calls
-/// (e.g., `numbers` → `numbers()` for prop getters). When the RHS of a
-/// destructuring is a prop variable, we must use the IIFE form (with `$$value`
-/// caching) because the official compiler visits the RHS first, transforming it
-/// to a CallExpression, and then checks `should_cache = value.type !== 'Identifier'`.
+/// (e.g., `numbers` → `numbers()` for prop getters). They matter twice: a prop
+/// *target* makes the destructure eligible for the expansion just like a state
+/// or store target (upstream routes every extracted path through the ordinary
+/// assignment lowering), and a prop on the *right-hand side* forces the IIFE
+/// form (with `$$value` caching) because the official compiler visits the RHS
+/// first, turning it into a CallExpression, and then checks
+/// `should_cache = value.type !== 'Identifier'`.
 pub(super) fn transform_destructure_assignments_with_props(
     statement: &str,
     state_vars: &[String],
@@ -99,15 +102,16 @@ pub(super) fn transform_destructure_assignments_with_props(
     let state_set: rustc_hash::FxHashSet<&str> = state_vars.iter().map(|s| s.as_str()).collect();
     let store_set: rustc_hash::FxHashSet<&str> =
         store_sub_vars.iter().map(|s| s.as_str()).collect();
+    let prop_set: rustc_hash::FxHashSet<&str> = prop_vars.iter().map(|s| s.as_str()).collect();
 
     // Process the statement, looking for destructure assignments.
     // We scan for patterns and replace them with IIFEs.
     while let Some(transformed) = find_and_transform_one_destructure(
         &result,
         store_sub_vars,
-        prop_vars,
         &state_set,
         &store_set,
+        &prop_set,
     ) {
         result = transformed;
     }
@@ -130,9 +134,9 @@ pub(super) fn transform_destructure_assignments_with_props(
 pub(super) fn find_and_transform_one_destructure(
     statement: &str,
     store_sub_vars: &[String],
-    prop_vars: &[String],
     state_set: &rustc_hash::FxHashSet<&str>,
     store_set: &rustc_hash::FxHashSet<&str>,
+    prop_set: &rustc_hash::FxHashSet<&str>,
 ) -> Option<String> {
     let chars: Vec<char> = statement.chars().collect();
     let len = chars.len();
@@ -258,10 +262,15 @@ pub(super) fn find_and_transform_one_destructure(
                     // Extract target identifiers from the pattern
                     let targets = extract_destructure_targets(pattern_str);
 
-                    // Check if any target is a reactive variable
-                    let has_reactive_target = targets
-                        .iter()
-                        .any(|t| state_set.contains(t.as_str()) || store_set.contains(t.as_str()));
+                    // Check if any target needs the lowered form. Upstream's
+                    // `visit_assignment_expression` routes every extracted path
+                    // through the normal assignment lowering, so a prop target
+                    // (`a = …` → `a(…)`) counts exactly like a state or store one.
+                    let has_reactive_target = targets.iter().any(|t| {
+                        state_set.contains(t.as_str())
+                            || store_set.contains(t.as_str())
+                            || prop_set.contains(t.as_str())
+                    });
 
                     if !has_reactive_target {
                         i = j + 1;
@@ -371,8 +380,7 @@ pub(super) fn find_and_transform_one_destructure(
 
     // Check if RHS will become a function call
     let rhs_trimmed = rhs_str.trim();
-    let rhs_will_be_call = prop_vars.iter().any(|p| p == rhs_trimmed)
-        || store_sub_vars.iter().any(|s| s == rhs_trimmed);
+    let rhs_will_be_call = prop_set.contains(rhs_trimmed) || store_set.contains(rhs_trimmed);
 
     // Generate the IIFE replacement
     let iife = generate_destructure_iife(

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
@@ -5479,11 +5479,19 @@ fn transform_instance_script_for_visitors(
         // because it decomposes destructure patterns into individual assignments that those
         // transforms can then process.
         // Corresponds to visit_assignment_expression in shared/assignments.js.
-        // Skip if no state vars or store sub vars to destructure against
-        let transformed = if state_vars.is_empty() && store_sub_vars.is_empty() {
+        // Skip if there is no reactive target (state / store / prop) to destructure against
+        let transformed = if state_vars.is_empty()
+            && store_sub_vars.is_empty()
+            && prop_assignment_transform_vars.is_empty()
+        {
             transformed
         } else {
-            transform_destructure_assignments(&transformed, state_vars, store_sub_vars)
+            transform_destructure_assignments_with_props(
+                &transformed,
+                state_vars,
+                store_sub_vars,
+                prop_assignment_transform_vars,
+            )
         };
 
         // Transform state variable assignments to $.set()

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/reactive_transforms.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/reactive_transforms.rs
@@ -477,9 +477,11 @@ pub(super) fn transform_reactive_statement(
         } else if (lhs.starts_with('[') || lhs.starts_with('{')) && {
             // Check if the LHS contains reactive targets that need destructure expansion
             let targets = extract_destructure_targets(lhs);
-            targets
-                .iter()
-                .any(|t| state_vars.contains(t) || store_sub_vars.contains(t))
+            targets.iter().any(|t| {
+                state_vars.contains(t)
+                    || store_sub_vars.contains(t)
+                    || prop_assignment_transform_vars.contains(t)
+            })
         } {
             // Destructure assignment with reactive targets - expand to IIFE
             // Pass prop_assignment_transform_vars so that if the RHS is a prop variable

--- a/crates/rsvelte_core/tests/legacy_props_only_destructure_2163.rs
+++ b/crates/rsvelte_core/tests/legacy_props_only_destructure_2163.rs
@@ -1,0 +1,138 @@
+//! Regression tests for issue #2163 — a legacy destructuring *assignment* whose
+//! targets are only props.
+//!
+//! Upstream's `visit_assignment_expression`
+//! (`3-transform/shared/assignments.js`) routes every path returned by
+//! `extract_paths` through the ordinary assignment lowering, so a prop target
+//! (`a = …` → `a(…)`) makes the destructure just as much a candidate for the
+//! sequence / IIFE expansion as a `$state` or store target. rsvelte only counted
+//! state and store targets, so a props-only pattern was left verbatim and the
+//! prop-read pass then wrapped the pattern's binding positions
+//! (`({ a(), b() } = obj)`, not even valid JavaScript).
+
+use rsvelte_core::{CompileOptions, GenerateMode, compile, compiler::CssMode};
+
+fn compile_client(src: &str) -> String {
+    compile(
+        src,
+        CompileOptions {
+            filename: Some("Comp.svelte".to_string()),
+            generate: GenerateMode::Client,
+            css: CssMode::External,
+            ..Default::default()
+        },
+    )
+    .expect("compile")
+    .js
+    .code
+}
+
+/// Collapse the sequence expression the printer spreads over several lines so a
+/// single `assert!` can pin the whole lowering.
+fn flat(code: &str) -> String {
+    code.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+#[test]
+fn object_pattern_of_props_becomes_a_sequence_of_setter_calls() {
+    let src = r#"<script>
+	export let a = 1;
+	export let b = 2;
+	const obj = { a: 3, b: 4 };
+	function f() { ({ a, b } = obj); }
+</script>
+<button onclick={f}>{a} {b}</button>"#;
+    let out = flat(&compile_client(src));
+    assert!(out.contains("(a(obj.a), b(obj.b));"), "in:\n{out}");
+    assert!(!out.contains("} = obj"), "in:\n{out}");
+}
+
+#[test]
+fn array_pattern_of_props_uses_the_to_array_iife() {
+    let src = r#"<script>
+	export let a = 1;
+	export let b = 2;
+	const arr = [3, 4];
+	function f() { [a, b] = arr; }
+</script>
+<button onclick={f}>{a} {b}</button>"#;
+    let out = flat(&compile_client(src));
+    assert!(
+        out.contains(
+            "((arr) => { var $$array = $.to_array(arr, 2); a($$array[0]); b($$array[1]); })(arr);"
+        ),
+        "in:\n{out}"
+    );
+}
+
+/// A rest target is an ordinary extracted path, so a props-only pattern with a
+/// rest still stays a plain sequence.
+#[test]
+fn rest_target_of_a_props_only_pattern_keeps_the_sequence() {
+    let src = r#"<script>
+	export let a = 1;
+	export let rest = {};
+	const obj = { a: 3, b: 4 };
+	function f() { ({ a, ...rest } = obj); }
+</script>
+<button onclick={f}>{a} {JSON.stringify(rest)}</button>"#;
+    let out = flat(&compile_client(src));
+    assert!(
+        out.contains("(a(obj.a), rest($.exclude_from_object(obj, ['a'])));"),
+        "in:\n{out}"
+    );
+}
+
+/// Literal / numeric / computed keys and pattern defaults go through the same
+/// shared helpers the state path uses.
+#[test]
+fn literal_computed_keys_and_defaults_of_props_only_patterns() {
+    let src = r#"<script>
+	const key = 'd';
+	export let a = 1;
+	export let bc = 0;
+	export let three = 0;
+	export let dee = 0;
+	const obj = { a: 1 };
+	function f() { ({ a = 5, 'b-c': bc, 3: three, [key]: dee } = obj); }
+</script>
+<button onclick={f}>{a} {bc} {three} {dee}</button>"#;
+    let out = flat(&compile_client(src));
+    assert!(out.contains("a($.fallback(obj.a, 5))"), "in:\n{out}");
+    assert!(out.contains("bc(obj['b-c'])"), "in:\n{out}");
+    assert!(out.contains("three(obj[3])"), "in:\n{out}");
+    assert!(out.contains("dee(obj[key])"), "in:\n{out}");
+}
+
+/// A props-only destructure in a `$:` statement takes the same expansion.
+#[test]
+fn props_only_destructure_in_a_reactive_statement() {
+    let src = r#"<script>
+	export let a = 1;
+	export let b = 2;
+	export let src = { a: 3, b: 4 };
+	$: ({ a, b } = src);
+</script>
+<p>{a} {b}</p>"#;
+    let out = flat(&compile_client(src));
+    // `src` is a prop, so the visited right-hand side is a call — upstream then
+    // caches it in `$$value`.
+    assert!(
+        out.contains("(($$value) => { a($$value.a); b($$value.b); })(src());"),
+        "in:\n{out}"
+    );
+}
+
+/// Mixing a prop target with a `$state` one keeps both lowerings side by side.
+#[test]
+fn mixed_prop_and_state_targets_are_both_lowered() {
+    let src = r#"<script>
+	export let a = 1;
+	let s = 0;
+	const obj = { a: 3, s: 4 };
+	function f() { ({ a, s } = obj); }
+</script>
+<button onclick={f}>{a} {s}</button>"#;
+    let out = flat(&compile_client(src));
+    assert!(out.contains("(a(obj.a), $.set(s, obj.s));"), "in:\n{out}");
+}


### PR DESCRIPTION
Fixes #2163

## Cause

`find_and_transform_one_destructure()` — the scanner behind the legacy
destructuring **assignment** expansion (`({ a, b } = obj)`) — decided whether a
pattern was worth lowering by asking whether any of its targets was a `$state`
variable or a store subscription:

```rust
let has_reactive_target = targets
    .iter()
    .any(|t| state_set.contains(t.as_str()) || store_set.contains(t.as_str()));
```

Props were missing from that test, and the instance-script call site never even
passed them (`transform_destructure_assignments(&transformed, state_vars,
store_sub_vars)`), so a pattern whose targets are *only* props was skipped
entirely. Upstream's `visit_assignment_expression`
(`3-transform/shared/assignments.js`) draws no such distinction: it runs
`extract_paths` and routes **every** path through the ordinary assignment
lowering, where a prop target becomes a setter call exactly like a state target
becomes `$.set`.

Skipping the expansion did not merely lose the prop calls. The pattern survived
into the prop-*read* pass, which then wrapped the binding positions themselves,
emitting code that does not even parse:

```js
function f() { ({ a(), b() } = obj); }   // rsvelte, before
function f() { [a(), b()] = arr; }       // rsvelte, before (array form)
```

Mixed patterns were fine: a single `$state` or store target was enough to turn
`has_reactive_target` on, and every path — props included — was then lowered
correctly. Only the props-only case fell through.

## Fix

- `has_reactive_target` also counts prop targets, mirroring upstream's "every
  extracted path goes through the assignment lowering".
- The instance-script call site passes `prop_assignment_transform_vars`
  (`transform_destructure_assignments_with_props`), and its early-out now
  requires all three sets to be empty.
- `transform_reactive_statement`'s destructure branch (`$: ({ a, b } = src)`)
  gets the same target test.
- Prop names are hoisted into an `FxHashSet` once per statement like the state
  and store names already were, so the now-redundant `prop_vars` slice parameter
  of `find_and_transform_one_destructure` is gone (the `should_cache` check
  reuses the set).

## Before / after

```svelte
<script>
	export let a = 1;
	export let rest = {};
	const obj = { a: 3, b: 4 };
	function f() { ({ a, ...rest } = obj); }
</script>
```

Before — no prop call at all, and the output is not valid JavaScript:

```js
function f() { ({ a(), ...rest() } = obj); }
```

After — byte-identical to the official compiler:

```js
function f() {
  (a(obj.a), rest($.exclude_from_object(obj, ["a"])));
}
```

## Verification

- A repro matrix (object / array, rest / no rest, identifier + quoted + numeric
  + computed keys, pattern defaults, props-only / props+`$state` / props+store,
  bindable prop, read-only prop, member target, `$:` statement, runes-mode
  `$props()`) diffed against the official compiler on all three corpus targets —
  every case is byte-identical on client, server and client-dev.
- New regression suite
  `crates/rsvelte_core/tests/legacy_props_only_destructure_2163.rs` (6 tests);
  `legacy_assignment_destructure_2138.rs` and `legacy_destructure_rest_2078.rs`
  still pass.
- `cargo test --release -p rsvelte_core` green.
- Corpus (svelte + pattern, the sources available locally): no regressions,
  client / server ratchets stay empty, client-dev unchanged (268).
- New pattern-corpus repro
  `pattern/issues/2163-legacy-props-only-destructure.svelte` matches on client /
  server / client-dev.

## Out of scope

`should_cache` is still keyed off the *unvisited* right-hand side for state
reads, so a destructure whose RHS is an each-block item
(`() => (({ a, b } = item))`, visited to `$.get(item)`) stays a sequence where
upstream caches it in a `$$value` IIFE. That divergence is pre-existing and
reproduces identically with `$state` targets, so it is unrelated to this fix.
Parenthesised patterns (#2162) and nested patterns (#2139) are likewise
untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
