### PR TITLE
fix(compiler): keep a single-target destructuring assignment's parens

### DIFF
--- a/compatibility/pattern-corpus/README.md
+++ b/compatibility/pattern-corpus/README.md
@@ -65,6 +65,7 @@ source with `node scripts/compat-corpus/compile.mjs --filter pattern/`.
 | `2060-const-shadow-textcontent.svelte` | [#2060](https://github.com/baseballyama/rsvelte/issues/2060) | A `{@const}` **shadowing** a component-scope binding must resolve to the `{@const}`, so the read stays a static `textContent` assignment |
 | `2138-legacy-assignment-destructure-rest.svelte` | [#2138](https://github.com/baseballyama/rsvelte/issues/2138) | A legacy destructuring **assignment** with quoted / computed keys and a rest — bracket member reads, an `$.exclude_from_object` key list built like `b.literal(...)`, and no `$$value` IIFE for an identifier right-hand side |
 | `2141-snippet-shadow-is-function.svelte` | [#2141](https://github.com/baseballyama/rsvelte/issues/2141) | A block-local `{#snippet}` shadowing a same-named outer `function` still reads as reactive (`is_function()` must resolve to the snippet, not the outer function) |
+| `2162-single-target-destructure-paren.svelte` | [#2162](https://github.com/baseballyama/rsvelte/issues/2162) | A single-target destructuring **assignment** (`({ a } = obj)`, no rest) keeps its wrapping parens — upstream always lowers through a `SequenceExpression`, even with one element, and esrap always self-parenthesizes one |
 
 ## `matrix/` — the axes around those repros
 

--- a/compatibility/pattern-corpus/issues/2162-single-target-destructure-paren.svelte
+++ b/compatibility/pattern-corpus/issues/2162-single-target-destructure-paren.svelte
@@ -1,0 +1,10 @@
+<script>
+  let a = 1;
+  const obj = { a: 1 };
+
+  function f() {
+    ({ a } = obj);
+  }
+</script>
+
+<button onclick={f}>{a}</button>

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/ast_state_transform.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/ast_state_transform.rs
@@ -33,6 +33,7 @@ use super::rune_transforms::{process_derived_destructuring_pattern, wrap_state_v
 use super::{DERIVED_TMP_COUNTER, SCRIPT_ARRAY_COUNTER, STATE_TMP_COUNTER, VAR_STATE_VARS};
 use crate::compiler::phases::phase2_analyze::ComponentAnalysis;
 use crate::compiler::phases::phase2_analyze::types::ScriptProjection;
+use crate::compiler::phases::phase3_transform::js_ast::to_oxc::SINGLE_TARGET_DESTRUCTURE_SEQUENCE_MARKER;
 use crate::compiler::phases::phase3_transform::shared::template::escape_js_string;
 
 thread_local! {
@@ -3594,7 +3595,17 @@ impl<'a, 's> StateVarCollector<'a, 's> {
 
         if is_simple_ident {
             if assignments.len() == 1 {
-                Some(assignments.into_iter().next().unwrap())
+                // Upstream always lowers through `b.sequence(assignments)` — a real
+                // `SequenceExpression`, unconditionally, even with one element — and
+                // esrap always self-parenthesizes a `SequenceExpression`. The marker
+                // call keeps that "must be a sequence" decision alive across the
+                // eventual raw-text reparse. See
+                // `SINGLE_TARGET_DESTRUCTURE_SEQUENCE_MARKER`.
+                Some(format!(
+                    "{}({})",
+                    SINGLE_TARGET_DESTRUCTURE_SEQUENCE_MARKER,
+                    assignments.into_iter().next().unwrap()
+                ))
             } else {
                 Some(format!("({})", assignments.join(", ")))
             }

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/destructure_transforms.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/destructure_transforms.rs
@@ -2,6 +2,7 @@
 
 use super::SCRIPT_ARRAY_COUNTER;
 use super::rune_transforms::{derived_prop_access, exclude_from_object_keys};
+use crate::compiler::phases::phase3_transform::js_ast::to_oxc::SINGLE_TARGET_DESTRUCTURE_SEQUENCE_MARKER;
 use oxc_allocator::Allocator;
 use oxc_ast::ast::{Expression, Statement};
 use oxc_parser::{ParseOptions, Parser};
@@ -1570,7 +1571,17 @@ pub(super) fn generate_destructure_iife(
             }
 
             if assignments.len() == 1 {
-                return format!("({})", assignments[0]);
+                // Upstream always lowers through `b.sequence(assignments)` — a real
+                // `SequenceExpression`, unconditionally, even with one element — and
+                // esrap always self-parenthesizes a `SequenceExpression`. A bare
+                // `(assignment)` would reparse as a plain (non-sequence) expression
+                // and lose those parens downstream; the marker call preserves the
+                // "must be a sequence" decision through the reparse. See
+                // `SINGLE_TARGET_DESTRUCTURE_SEQUENCE_MARKER`.
+                return format!(
+                    "{}({})",
+                    SINGLE_TARGET_DESTRUCTURE_SEQUENCE_MARKER, assignments[0]
+                );
             } else {
                 // Single-line comma expression format.
                 // IMPORTANT: Must be single-line because downstream processing in

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/js_ast/to_oxc.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/js_ast/to_oxc.rs
@@ -145,6 +145,49 @@ impl<'a> VisitMut<'a> for ShiftSpans {
     }
 }
 
+/// Rebuilds any `SINGLE_TARGET_DESTRUCTURE_SEQUENCE_MARKER(expr)` call — however
+/// deeply nested — into a one-element `SequenceExpression`. See the marker's doc
+/// comment and [`Cx::restore_single_target_destructure_sequences`].
+struct SingleTargetSequenceRebuilder<'a, 'x> {
+    ab: &'x AstBuilder<'a>,
+}
+
+impl<'a, 'x> VisitMut<'a> for SingleTargetSequenceRebuilder<'a, 'x> {
+    fn visit_expression(&mut self, expr: &mut Expression<'a>) {
+        oxc_ast_visit::walk_mut::walk_expression(self, expr);
+
+        let is_marker_call = matches!(
+            expr,
+            Expression::CallExpression(call)
+                if call.arguments.len() == 1
+                    && !call.arguments[0].is_spread()
+                    && matches!(
+                        &call.callee,
+                        Expression::Identifier(id)
+                            if id.name == SINGLE_TARGET_DESTRUCTURE_SEQUENCE_MARKER
+                    )
+        );
+        if !is_marker_call {
+            return;
+        }
+
+        expr.replace_with(|e| {
+            let Expression::CallExpression(mut call) = e else {
+                unreachable!()
+            };
+            let arg = call.arguments.pop().unwrap();
+            // `is_spread()` was checked above, so this conversion cannot fail.
+            let inner =
+                Expression::try_from(arg).unwrap_or_else(|()| unreachable!("checked above"));
+            Expression::SequenceExpression(SequenceExpression::boxed(
+                SPAN,
+                ArenaVec::from_value_in(inner, self.ab),
+                self.ab,
+            ))
+        });
+    }
+}
+
 /// The unified comment coordinate space for a reassembled program.
 struct Synth {
     /// Whether this pass places comments (`false` for the probe pass).
@@ -201,6 +244,25 @@ impl Synth {
         self.max_span = self.max_span.max(end);
     }
 }
+
+/// Marker callee wrapping a single-target destructuring-assignment collapse
+/// (`({ a } = obj)` → `a = obj.a`) so the "this must reprint as a
+/// `SequenceExpression`" decision survives the raw-text reparse. Upstream's
+/// `visit_assignment_expression` (`shared/assignments.js`) always lowers a
+/// destructuring assignment through `b.sequence(assignments)` — an ESTree
+/// `SequenceExpression` *unconditionally*, even for a single assignment — and
+/// esrap's `SequenceExpression` printer always self-parenthesizes, `(expr)`,
+/// regardless of element count. rsvelte's client transform generates this
+/// lowering as plain source text; a single-assignment collapse re-parses to a
+/// bare (non-sequence) expression, which every downstream printer correctly
+/// treats as redundantly parenthesized (matching upstream's behavior for any
+/// plain, user-written `(x = 1)`, where the parens really are dropped) and
+/// removes — silently losing upstream's parens for the destructuring case.
+/// Wrapping the single assignment in a call to this marker keeps the
+/// "force sequence" decision attached to the generated text itself;
+/// [`Cx::restore_single_target_destructure_sequences`] finds the marker call
+/// after reparse and rebuilds the real single-element `SequenceExpression`.
+pub(crate) const SINGLE_TARGET_DESTRUCTURE_SEQUENCE_MARKER: &str = "__rsvelte_seq1";
 
 /// Conversion context: holds the oxc [`AstBuilder`] and the IR arena used to
 /// resolve [`ExprId`] handles.
@@ -1116,6 +1178,7 @@ impl<'a, 'arena> Cx<'a, 'arena> {
     fn parse_raw_statements(&self, code: &str) -> Option<Vec<Statement<'a>>> {
         let mut stmts = self.parse_chunk(code.trim())?;
         self.restore_legacy_pre_effect_deps(&mut stmts);
+        self.restore_single_target_destructure_sequences(&mut stmts);
         Some(stmts)
     }
 
@@ -1165,6 +1228,19 @@ impl<'a, 'arena> Cx<'a, 'arena> {
                     &self.ab,
                 ))
             });
+        }
+    }
+
+    /// See [`SINGLE_TARGET_DESTRUCTURE_SEQUENCE_MARKER`]. Unlike
+    /// [`Cx::restore_legacy_pre_effect_deps`] (which only ever sits at the top
+    /// of its own dedicated chunk), a destructuring-assignment collapse can be
+    /// nested arbitrarily deep (inside a function body, a block, another
+    /// expression, …), so this walks the whole chunk rather than just its
+    /// top-level statements.
+    fn restore_single_target_destructure_sequences(&self, stmts: &mut [Statement<'a>]) {
+        let mut rebuilder = SingleTargetSequenceRebuilder { ab: &self.ab };
+        for stmt in stmts {
+            rebuilder.visit_statement(stmt);
         }
     }
 

--- a/crates/rsvelte_core/tests/legacy_destructure_paren_2162.rs
+++ b/crates/rsvelte_core/tests/legacy_destructure_paren_2162.rs
@@ -1,0 +1,131 @@
+//! Regression tests for issue #2162 — a single-target destructuring
+//! assignment (`({ a } = obj)`, no rest) loses its wrapping parentheses.
+//!
+//! Upstream's `visit_assignment_expression` (`3-transform/shared/assignments.js`)
+//! always lowers a reactive destructuring assignment through
+//! `b.sequence(assignments)` — a real ESTree `SequenceExpression`,
+//! *unconditionally*, even for a single assignment — and esrap's
+//! `SequenceExpression` printer always self-parenthesizes regardless of
+//! element count, so a single-target collapse still prints as
+//! `($.set(a, obj.a));`. rsvelte previously collapsed a single target to a
+//! bare (non-sequence) expression, which a later reparse/print stage
+//! correctly treats as a redundant, droppable paren (matching upstream's
+//! *actual* behavior for a plain, user-written `(x = 1)` — those parens
+//! really are dropped) — silently losing upstream's parens for the
+//! destructuring case specifically.
+
+use rsvelte_core::{CompileOptions, GenerateMode, compile, compiler::CssMode};
+
+fn compile_client(src: &str, dev: bool) -> String {
+    compile(
+        src,
+        CompileOptions {
+            filename: Some("Comp.svelte".to_string()),
+            generate: GenerateMode::Client,
+            css: CssMode::External,
+            dev,
+            ..Default::default()
+        },
+    )
+    .expect("compile")
+    .js
+    .code
+}
+
+fn flat(code: &str) -> String {
+    code.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+const LEGACY_STATE_SRC: &str = r#"<script>
+	let a = 1;
+	const obj = { a: 1 };
+	function f() {
+		({ a } = obj);
+	}
+</script>
+<button onclick={f}>{a}</button>"#;
+
+#[test]
+fn legacy_single_target_state_destructure_keeps_parens() {
+    let out = flat(&compile_client(LEGACY_STATE_SRC, false));
+    assert!(out.contains("($.set(a, obj.a));"), "in:\n{out}");
+}
+
+const RUNES_STATE_SRC: &str = r#"<script>
+	let a = $state(1);
+	const obj = { a: 1 };
+	function f() {
+		({ a } = obj);
+	}
+</script>
+<button onclick={f}>{a}</button>"#;
+
+#[test]
+fn runes_single_target_state_destructure_keeps_parens() {
+    let out = flat(&compile_client(RUNES_STATE_SRC, false));
+    assert!(out.contains("($.set(a, obj.a, true));"), "in:\n{out}");
+}
+
+const RUNES_PROP_SRC: &str = r#"<script>
+	let { foo = $bindable(1) } = $props();
+	const obj = { foo: 1 };
+	function f() {
+		({ foo } = obj);
+	}
+</script>
+<button onclick={f}>{foo}</button>"#;
+
+#[test]
+fn runes_single_target_prop_destructure_keeps_parens() {
+    let out = flat(&compile_client(RUNES_PROP_SRC, false));
+    assert!(out.contains("(foo(obj.foo));"), "in:\n{out}");
+}
+
+/// A plain, user-written redundant paren around a *non-destructuring*
+/// assignment is NOT a `SequenceExpression` upstream, so it still loses its
+/// parens — the destructuring case above must not overcorrect this one.
+#[test]
+fn plain_assignment_redundant_parens_still_drop() {
+    let src = r#"<script>
+	let x = 1;
+	function f() {
+		(x = 5);
+	}
+</script>
+<button onclick={f}>{x}</button>"#;
+    let out = flat(&compile_client(src, false));
+    assert!(out.contains("$.set(x, 5);"), "in:\n{out}");
+    assert!(!out.contains("($.set(x, 5));"), "in:\n{out}");
+}
+
+/// The marker text used internally to force the single-element
+/// `SequenceExpression` rebuild must never leak into emitted output.
+#[test]
+fn marker_never_leaks_into_output() {
+    for src in [LEGACY_STATE_SRC, RUNES_STATE_SRC, RUNES_PROP_SRC] {
+        for dev in [false, true] {
+            let out = compile_client(src, dev);
+            assert!(!out.contains("rsvelte_seq"), "marker leaked in:\n{out}");
+        }
+    }
+}
+
+/// A multi-target destructure (real comma syntax) must keep working exactly
+/// as before — it already round-trips through a genuine multi-element
+/// `SequenceExpression`, so this is a no-op path for the #2162 fix.
+#[test]
+fn multi_target_state_destructure_is_unaffected() {
+    let src = r#"<script>
+	let a = 1, b = 2, rest = {};
+	const obj = { a: 1, b: 2, c: 3 };
+	function f() { ({ a, b, ...rest } = obj); }
+</script>
+<button onclick={f}>{a} {b} {JSON.stringify(rest)}</button>"#;
+    let out = flat(&compile_client(src, false));
+    assert!(
+        out.contains(
+            "( $.set(a, obj.a), $.set(b, obj.b), $.set(rest, $.exclude_from_object(obj, ['a', 'b'])) );"
+        ),
+        "in:\n{out}"
+    );
+}


### PR DESCRIPTION
## Summary

`({ a } = obj)` (a single-target, no-rest reactive destructuring assignment)
was losing its wrapping parentheses on the client target — rsvelte emitted
`$.set(a, obj.a);` where upstream emits `($.set(a, obj.a));`.

**Root cause**: upstream's `visit_assignment_expression`
(`3-transform/shared/assignments.js`) always lowers a reactive destructuring
assignment through `b.sequence(assignments)` — a real ESTree
`SequenceExpression`, *unconditionally*, even for a single assignment — and
esrap's `SequenceExpression` printer always self-parenthesizes regardless of
element count. rsvelte instead collapsed a single target to a bare
(non-sequence) expression. A later reparse/print stage then correctly treats
a lone parenthesized expression as redundant (matching upstream's *actual*
behavior for a plain, user-written `(x = 1)`, where the parens really are
dropped) and strips it — silently losing upstream's parens for the
destructuring case specifically. This affected both legacy and runes mode,
and both state-var and bindable-prop targets (multi-target destructures were
unaffected — they already round-trip through genuine comma syntax, which
self-parenthesizes naturally).

**Fix**: since a single-element `SequenceExpression` can't be written as
valid, re-parseable JS source text, the single-target collapse is now wrapped
in a synthetic marker call (`__rsvelte_seq1(...)`) that survives every
intermediate text pass unmodified (visitors that don't special-case the
marker simply recurse into its argument via the default walk). `js_ast::to_oxc`
rebuilds the real single-element `SequenceExpression` after the final reparse
— reusing rsvelte_esrap's existing, already upstream-accurate
`SequenceExpression`-preserves-its-parens printer logic, so no printer changes
were needed. This follows the same precedent already used for the
`$.legacy_pre_effect` single-dependency thunk (`to_oxc::restore_legacy_pre_effect_deps`,
#1783), generalized to a full recursive walk since a destructuring collapse can be
nested arbitrarily deep (a top-level-only scan, sufficient for the thunk case,
isn't enough here).

## Test plan

- [x] New regression suite `crates/rsvelte_core/tests/legacy_destructure_paren_2162.rs`
      (6 tests): legacy state var, runes state var, runes bindable prop, a
      negative case confirming a *plain* redundant-paren assignment still
      drops its parens, a marker-leak guard, and a multi-target no-op check.
- [x] `cargo test --release -p rsvelte_core` — full suite green (0 failures).
- [x] `legacy_assignment_destructure_2138` / `legacy_destructure_rest_2078` — still pass.
- [x] New pattern-corpus fixture `compatibility/pattern-corpus/issues/2162-single-target-destructure-paren.svelte`,
      byte-identical to official for client / server / client-dev
      (`node scripts/compat-corpus/one.mjs pattern/issues/2162-single-target-destructure-paren.svelte`).
- [x] Full `svelte` + `pattern` corpus verify: **no regressions** (client 0,
      server 0, client-dev 268 pre-existing known failures remain,
      unrelated). Also surfaces 628 client-dev known-failures now passing
      (not banked into the ratchet baseline here, to avoid an unrelated,
      unreviewed diff and any conflict with other in-flight client-dev work —
      left for a follow-up `--update-baseline` pass).
- [x] `cargo fmt` / `cargo clippy --all-targets --all-features -- -D warnings` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RQSYoh4Wc353KgUnWHjazu