### PR TITLE
perf(analyze): write an import binding's initial JSON without a Value

### DIFF
--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/scope_builder.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/scope_builder.rs
@@ -1250,15 +1250,30 @@ impl<'a> ScopeBuilder<'a> {
         // Store the ImportDeclaration as a JSON string on binding.initial,
         // matching the official Svelte compiler where binding.initial is the
         // ImportDeclaration AST node.
-        let import_json = serde_json::json!({
-            "type": "ImportDeclaration",
-            "source": { "value": source_val },
-            "specifiers": [{
-                "type": specifier_type,
-                "local": { "name": name }
-            }]
-        });
-        self.bindings[binding_idx].initial = Some(import_json.to_string());
+        //
+        // Written out rather than built with `json!`: the shape is fixed and
+        // only the string ends up being read, so going through a `Value` would
+        // allocate three maps and hash six constant keys per specifier just to
+        // serialize them straight back. `to_string` on the two dynamic values
+        // applies serde_json's own escaping, and `preserve_order` means `json!`
+        // would emit the keys in this same written order.
+        let source_json = serde_json::to_string(source_val).unwrap_or_default();
+        let name_json = serde_json::to_string(&name).unwrap_or_default();
+        let mut import_json = String::with_capacity(
+            r#"{"type":"ImportDeclaration","source":{"value":},"specifiers":[{"type":"","local":{"name":}}]}"#
+                .len()
+                + source_json.len()
+                + specifier_type.len()
+                + name_json.len(),
+        );
+        import_json.push_str(r#"{"type":"ImportDeclaration","source":{"value":"#);
+        import_json.push_str(&source_json);
+        import_json.push_str(r#"},"specifiers":[{"type":""#);
+        import_json.push_str(specifier_type);
+        import_json.push_str(r#"","local":{"name":"#);
+        import_json.push_str(&name_json);
+        import_json.push_str(r#"}}]}"#);
+        self.bindings[binding_idx].initial = Some(import_json);
         self.bindings[binding_idx].initial_node_type = Some("ImportDeclaration".to_string());
         self.bindings[binding_idx].import_source = Some(source_val.to_string());
     }


### PR DESCRIPTION
## Summary
`process_import_specifier_typed` built a `serde_json::Value` tree (3 maps, 6 hashed constant keys) per import specifier only to immediately `.to_string()` it into `Binding.initial`, which stores a JSON *string*. This writes the fixed-shape JSON directly with `String::with_capacity` + `push_str`, escaping only the dynamic values (`source`, `name`) through `serde_json::to_string` so escaping rules stay identical.

Per flowbite compile this deterministically removes 17,172 map constructions, 34,344 constant-key hashes, and 5,724 Value→String serializations. Wall-time effect is below this machine's noise floor (median −0.86%, t=−1.25 over 21 order-swapped pairs) — filed as hygiene with the work-reduction proven by counters.

Context: this was the only surviving item from a sweep of the dispersed string/hash/fmt costs; the other top candidates were already optimal (`Memoizer::generate_id`, `json_escape_str`) or require structural changes disproportionate to their share.

## Verification
- Unit equivalence: hand-written output string-compared against `json!(...).to_string()` across 210 cases (quotes, backslashes, control chars, non-ASCII, empty, all three specifier types) — all identical (compact form)
- **3888 corpus outputs byte-identical** (sha256); lib tests 1336 green; fmt/clippy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F4m3u9XgyDX4NX1k1aGyG3