### PR TITLE
fix(svelte2tsx): close the three slots-reflection resolver gaps (#2161)

### DIFF
--- a/.changeset/svelte2tsx-slots-reflection-resolver.md
+++ b/.changeset/svelte2tsx-slots-reflection-resolver.md
@@ -1,0 +1,17 @@
+---
+"@rsvelte/compiler": patch
+"@rsvelte/svelte2tsx": patch
+"@rsvelte/svelte-check": patch
+---
+
+fix(svelte2tsx): close the three slots-reflection resolver gaps. A destructuring
+`let:` value (`let:whatever={{ bla }}`) bound only the directive's own name, so
+every leaf identifier stayed unresolved in the `slots` reflection instead of
+resolving through `(({ bla }) => bla)(…$$slot_def['default'].whatever)`; slot-prop
+resolution substituted identifiers by token without tracking object-literal
+context, so an in-scope name in object **key** position (and inside a string
+literal) was rewritten too (`{ item: … }` became
+`{ __sveltets_2_unwrapArr(items): … }`); and a `{:catch e}` binding was not typed
+as `__sveltets_2_any({})`. The `{#await}` opening-tag padding is now derived from
+official `transform`'s collapsed-gap count (`2 + then + catch` spaces) rather than
+a constant, which also fixes the bare and pending-only shapes.

--- a/compatibility/svelte2tsx-fixtures-known-failures.json
+++ b/compatibility/svelte2tsx-fixtures-known-failures.json
@@ -1,8 +1,5 @@
 [
 	"attributes-foreign-ns",
-	"component-slot-inside-await",
-	"component-slot-let-forward",
-	"component-slot-object-key",
 	"module-snippet-component-instance-reference.v5",
 	"ts-await-generics.v5",
 	"ts-runes-hoistable-props-false-6.v5",

--- a/compatibility/svelte2tsx-fixtures-known-failures.md
+++ b/compatibility/svelte2tsx-fixtures-known-failures.md
@@ -25,7 +25,7 @@ UPDATE_S2TSX_FIXTURES_BASELINE=1 cargo test --test svelte2tsx_fixtures
 `STRICT_S2TSX_FIXTURES=1` ignores the baseline entirely (every failure fails),
 which is how you check whether an entry is still needed.
 
-## Current baseline: 8 of 254 (pass rate 96.9%)
+## Current baseline: 5 of 254 (pass rate 98.0%)
 
 ### #2145 note
 
@@ -84,16 +84,13 @@ quoting bug itself (which is fixed in `collect/mod.rs`'s `push_let_reflection_sc
   — the fixture has two, rsvelte emits one. Cosmetic in effect, but the gate is
   byte-exact so it is tracked like any other divergence.
 
-### `let:`-forwarding slot-let resolution gaps — 3
+### Removed by #2161
 
-- **`component-slot-inside-await`**, **`component-slot-let-forward`**,
-  **`component-slot-object-key`.** Three different `let:`/slot-forwarding
-  destructuring shapes rsvelte resolves incompletely: a `let:whatever={{ bla }}`
-  nested-destructure binding on a forwarded component slot; an `{#await …then
-  value}` binding threaded into a nested named slot; and an `{#each}` binding used
-  as both an object *key* and *value* inside a forwarded slot prop (rsvelte
-  incorrectly substitutes the resolved expression into the key position too,
-  e.g. `{item:...}` becomes `{__sveltets_2_unwrapArr(items):...}`). All three sit
-  squarely in the `let:`-forwarding resolution logic (`push_let_reflection_scope`
-  neighbourhood / `TemplateScope.resolveLet` equivalent) that issue #2105 owns —
-  left untouched here per that PR's explicit scope boundary.
+`component-slot-inside-await`, `component-slot-let-forward` and
+`component-slot-object-key` were the three slots-reflection resolver gaps; all
+three now pass. `resolve_slot_expression` (`collect/pattern.rs`) folds the
+shorthand expansion and the scope substitution into one object-aware scan so an
+object *key* is never substituted, `push_context_binding` (`collect/mod.rs`)
+resolves destructuring `let:`/`then`/`catch` contexts through
+`((<pattern>) => name)(<resolved>)`, and the `{#await}` opener padding is derived
+from official `transform`'s gap count instead of a constant.

--- a/crates/rsvelte_projection/src/svelte2tsx/template/collect/mod.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/template/collect/mod.rs
@@ -4,7 +4,7 @@
 mod pattern;
 
 use crate::ast::template::{Attribute, AttributeValue, AttributeValuePart, Fragment, TemplateNode};
-use pattern::{collect_pattern_bindings, expand_object_shorthands};
+use pattern::{collect_pattern_bindings, resolve_slot_expression};
 
 use super::attributes::let_::iter_let_directives;
 use super::nodes::slot_element::{slot_consumer_name, slot_name_for_type};
@@ -310,31 +310,22 @@ fn collect_info_from_node<'a>(
             // The collection is resolved in the PARENT scope (the each context is
             // not yet bound) — mirrors official EachBlock →
             // `resolveExpression(initExpression, scope.parent)`. A simple
-            // identifier context binds to `__sveltets_2_unwrapArr(coll)`; a
-            // destructuring context (`{ value, id }` / `[a, b]`) binds each leaf
-            // identifier to `((<pattern>) => name)(__sveltets_2_unwrapArr(coll))`,
-            // mirroring `SlotHandler.resolveDestructuringAssignment`. (The fallback
-            // is outside the each scope.)
-            let pushed = if let Some(ctx) = block.context.as_ref() {
-                let coll = resolve_in_scope(get_expression_text(&block.expression, source), scope);
-                let unwrapped = format!("__sveltets_2_unwrapArr({})", coll);
-                if let Some(name) = expression_simple_identifier(ctx, source) {
-                    scope.push((name, unwrapped));
-                    1usize
-                } else {
-                    let pattern = get_expression_text(ctx, source);
-                    let mut count = 0usize;
-                    for name in collect_pattern_bindings(pattern) {
-                        scope.push((
-                            name.clone(),
-                            format!("(({}) => {})({})", pattern, name, unwrapped),
-                        ));
-                        count += 1;
-                    }
-                    count
+            // identifier context binds to `__sveltets_2_unwrapArr(coll)`.
+            // (The fallback is outside the each scope.)
+            let pushed = match block.context.as_ref() {
+                Some(ctx) => {
+                    let coll = resolve_slot_expression(
+                        get_expression_text(&block.expression, source),
+                        scope,
+                    );
+                    push_context_binding(
+                        ctx,
+                        source,
+                        &format!("__sveltets_2_unwrapArr({})", coll),
+                        scope,
+                    )
                 }
-            } else {
-                0usize
+                None => 0,
             };
             collect_info_from_fragment(
                 &block.body,
@@ -364,22 +355,39 @@ fn collect_info_from_node<'a>(
                 // `{#await promise then value}` binds `value` to
                 // `__sveltets_2_unwrapPromiseLike(promise)` for slot props in the
                 // then-branch (mirrors official slot scope resolution).
-                let pushed = block
-                    .value
-                    .as_ref()
-                    .and_then(|v| expression_simple_identifier(v, source))
-                    .map(|name| {
-                        let promise = get_expression_text(&block.expression, source);
-                        scope.push((name, format!("__sveltets_2_unwrapPromiseLike({})", promise)));
-                    })
-                    .is_some();
+                let pushed = match block.value.as_ref() {
+                    Some(value) => {
+                        let promise = resolve_slot_expression(
+                            get_expression_text(&block.expression, source),
+                            scope,
+                        );
+                        push_context_binding(
+                            value,
+                            source,
+                            &format!("__sveltets_2_unwrapPromiseLike({})", promise),
+                            scope,
+                        )
+                    }
+                    None => 0,
+                };
                 collect_info_from_fragment(then, source, info, scope, enclosing, detector, arena);
-                if pushed {
+                for _ in 0..pushed {
                     scope.pop();
                 }
             }
             if let Some(ref catch) = block.catch {
+                // Official `getResolveExpressionStr` types a `{:catch e}` binding
+                // as `__sveltets_2_any({})` — the error is untyped.
+                let pushed = match block.error.as_ref() {
+                    Some(error) => {
+                        push_context_binding(error, source, "__sveltets_2_any({})", scope)
+                    }
+                    None => 0,
+                };
                 collect_info_from_fragment(catch, source, info, scope, enclosing, detector, arena);
+                for _ in 0..pushed {
+                    scope.pop();
+                }
             }
         }
         TemplateNode::KeyBlock(block) => {
@@ -459,19 +467,22 @@ fn push_let_reflection_scope(
 ) -> usize {
     let mut pushed = 0;
     for ld in iter_let_directives(attributes) {
-        // The locally bound name: `let:name={n}` binds `n`; shorthand `let:name`
-        // binds `name`. The reflected property is always the directive name.
-        let binding = ld
-            .expression
-            .as_ref()
-            .and_then(|e| expression_simple_identifier(e, source))
-            .unwrap_or_else(|| ld.name.to_string());
+        // The reflected property is always the directive name.
         let value = format!(
             "__sveltets_2_instanceOf({}).$$slot_def['{}'].{}",
             component, slot_name, ld.name
         );
-        scope.push((binding, value));
-        pushed += 1;
+        // The locally bound name: `let:name={n}` binds `n`; shorthand `let:name`
+        // binds `name`. A destructuring value (`let:whatever={{ bla }}` /
+        // `let:x={[a, b]}`) instead binds each leaf identifier through the
+        // pattern, mirroring official `resolveDestructuringAssignmentForLet`.
+        match ld.expression.as_ref() {
+            None => {
+                scope.push((ld.name.to_string(), value));
+                pushed += 1;
+            }
+            Some(expr) => pushed += push_context_binding(expr, source, &value, scope),
+        }
     }
     pushed
 }
@@ -485,7 +496,7 @@ fn push_let_reflection_scope(
 /// scope: the component's own `let:` directives bind its DEFAULT slot, and every
 /// direct child carrying a static `slot="x"` contributes its `let:` directives
 /// keyed to slot `x`. They are pushed in document order (default first), so for a
-/// name bound by several slots the LAST binding wins (`resolve_in_scope` searches
+/// name bound by several slots the LAST binding wins (`resolve_slot_expression` searches
 /// from the end), exactly like `TemplateScope.inits.set(name, …)` overwriting.
 /// The scope spans the WHOLE component subtree (popped by the caller on leave),
 /// so a `let:`-bound name is resolvable from any nested slot/element, not only the
@@ -542,45 +553,32 @@ fn node_slot_consumer_attributes<'a>(node: &'a TemplateNode<'a>) -> Option<&'a [
     }
 }
 
-/// Resolve a value expression through the template scope: each `{#each}`
-/// context variable (and `let:`-forwarded slot binding) is substituted (as a
-/// whole identifier token) with its resolved form — e.g. an each context
-/// becomes `__sveltets_2_unwrapArr(<collection>)` and a `let:`-forwarded name
-/// becomes `__sveltets_2_instanceOf(<Comp>).$$slot_def[...]` — so the slot
-/// type reflects the array element / forwarded type, both for a bare value
-/// (`{item}`) and inside an expression (`item={process(data)}`). Mirrors
-/// official `SlotHandler.resolveExpression`'s identifier overwrite pass.
-fn resolve_in_scope(value: &str, scope: &[(String, String)]) -> String {
-    if scope.is_empty() {
-        return value.to_string();
+/// Bind a block context (`{#each … as CTX}`, `{#await … then CTX}`, `{:catch
+/// CTX}`) in the slot-reflection scope, where `resolved` is the context's typed
+/// form. A simple identifier binds to `resolved` directly; a destructuring
+/// context (`{ value, id }` / `[a, b]`) binds each leaf identifier to
+/// `((<pattern>) => name)(<resolved>)`, mirroring official
+/// `SlotHandler.resolveDestructuringAssignment`. Returns the number pushed.
+fn push_context_binding(
+    context: &crate::ast::js::Expression,
+    source: &str,
+    resolved: &str,
+    scope: &mut Vec<(String, String)>,
+) -> usize {
+    if let Some(name) = expression_simple_identifier(context, source) {
+        scope.push((name, resolved.to_string()));
+        return 1;
     }
-    let chars: Vec<char> = value.chars().collect();
-    let is_ident = |c: char| c.is_alphanumeric() || c == '_' || c == '$';
-    let mut out = String::with_capacity(value.len());
-    let mut i = 0usize;
-    while i < chars.len() {
-        let c = chars[i];
-        // Start of an identifier token (not a member-access tail or a
-        // continuation of a longer identifier)?
-        let starts_ident = (c.is_alphabetic() || c == '_' || c == '$')
-            && (i == 0 || (!is_ident(chars[i - 1]) && chars[i - 1] != '.'));
-        if starts_ident {
-            let mut j = i + 1;
-            while j < chars.len() && is_ident(chars[j]) {
-                j += 1;
-            }
-            let token: String = chars[i..j].iter().collect();
-            match scope.iter().rev().find(|(name, _)| name == &token) {
-                Some((_, expr)) => out.push_str(expr),
-                None => out.push_str(&token),
-            }
-            i = j;
-        } else {
-            out.push(c);
-            i += 1;
-        }
+    let pattern = get_expression_text(context, source);
+    let mut count = 0usize;
+    for name in collect_pattern_bindings(pattern) {
+        scope.push((
+            name.clone(),
+            format!("(({}) => {})({})", pattern, name, resolved),
+        ));
+        count += 1;
     }
-    out
+    count
 }
 
 /// Collect slot prop entries from a <slot> element's attributes.
@@ -590,11 +588,7 @@ fn collect_slot_prop_entries(
     source: &str,
     scope: &[(String, String)],
 ) -> Vec<String> {
-    // Expand object-literal shorthands first (mirrors official
-    // `resolveExpression`'s objectShortHands pass), then substitute in-scope
-    // identifiers. A non-object expression is returned unchanged by the expander.
-    let resolve =
-        |value: &str| -> String { resolve_in_scope(&expand_object_shorthands(value), scope) };
+    let resolve = |value: &str| -> String { resolve_slot_expression(value, scope) };
     let mut props = Vec::new();
     for attr in attributes {
         // `<slot {...slotProps}>` spreads the props object into the slot type:
@@ -608,7 +602,7 @@ fn collect_slot_prop_entries(
         // (`{...obj.data}`) has `name === undefined` and emits `...undefined`.
         if let Attribute::SpreadAttribute(spread) = attr {
             let name = match expression_simple_identifier(&spread.expression, source) {
-                Some(id) => resolve_in_scope(&id, scope),
+                Some(id) => resolve_slot_expression(&id, scope),
                 None => "undefined".to_string(),
             };
             props.push(format!("...{}", name));

--- a/crates/rsvelte_projection/src/svelte2tsx/template/collect/pattern.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/template/collect/pattern.rs
@@ -93,21 +93,32 @@ pub(super) fn collect_pattern_bindings(src: &str) -> Vec<String> {
     out
 }
 
-/// Expand object-literal property shorthands in a slot-prop expression, e.g.
-/// `{ scale: $scale, setScale }` → `{ scale: $scale, setScale:setScale }`.
+/// Resolve a slot-prop expression through the template scope, mirroring official
+/// `SlotHandler.resolveExpression` (svelte2tsx `nodes/slot.ts`).
 ///
-/// Official `SlotHandler.resolveExpression` (svelte2tsx `nodes/slot.ts`) walks
-/// the expression and, for every object-value shorthand identifier, does
-/// `appendLeft(end, ':' + value)` so the generated `$$slot_def` type carries a
-/// real `key: value` entry. In the svelte2tsx parse path the per-expression
-/// arena yields no children (`expr.as_json()` is empty), so — like
-/// `get_set_binding_ranges` — this is done by a string scan instead of an AST
-/// walk. The scan only ever inserts inside object literals (an expression with
-/// no `{ … }` is returned untouched), so non-object slot props are unaffected.
-pub(super) fn expand_object_shorthands(text: &str) -> String {
+/// Official walks the expression AST and overwrites every `Identifier` with its
+/// scope resolution — an `{#each}` context becomes `__sveltets_2_unwrapArr(coll)`,
+/// a `let:`-forwarded name becomes `__sveltets_2_instanceOf(C).$$slot_def[…]` —
+/// except for three positions it deliberately leaves alone: a member-access
+/// property (`isMember`), an object-literal KEY (`isObjectKey`) and the value of
+/// an object shorthand (`isObjectValueShortHand`), which instead gets
+/// `appendLeft(end, ':' + value)` so `{ x }` becomes `{ x:<resolved> }`.
+///
+/// In the svelte2tsx parse path the per-expression arena yields no children
+/// (`expr.as_json()` is empty), so — like `get_set_binding_ranges` — this is a
+/// string scan instead of an AST walk. Tracking the object-literal context is
+/// what keeps a key out of the substitution set; string and template literals are
+/// copied verbatim for the same reason.
+pub(super) fn resolve_slot_expression(text: &str, scope: &[(String, String)]) -> String {
     let chars: Vec<char> = text.chars().collect();
     let is_ident_start = |c: char| c.is_alphabetic() || c == '_' || c == '$';
     let is_ident = |c: char| c.is_alphanumeric() || c == '_' || c == '$';
+    let resolve = |name: &str| -> String {
+        match scope.iter().rev().find(|(bound, _)| bound == name) {
+            Some((_, expr)) => expr.clone(),
+            None => name.to_string(),
+        }
+    };
     let mut out = String::with_capacity(text.len());
     // Context stack: `true` = object literal (property keys expected after
     // `{` / `,`), `false` = array / call / block / group.
@@ -199,25 +210,34 @@ pub(super) fn expand_object_shorthands(text: &str) -> String {
                 out.push(c);
                 i += 1;
             }
-            c if expect_prop && is_ident_start(c) => {
-                // Read the candidate property key identifier.
+            // Start of an identifier token — not a member-access tail (`.prop`)
+            // and not the continuation of a longer identifier.
+            c if is_ident_start(c)
+                && (i == 0 || (!is_ident(chars[i - 1]) && chars[i - 1] != '.')) =>
+            {
                 let mut j = i + 1;
                 while j < n && is_ident(chars[j]) {
                     j += 1;
                 }
                 let ident: String = chars[i..j].iter().collect();
-                // Look ahead, skipping whitespace, to the next meaningful char.
-                let mut k = j;
-                while k < n && chars[k].is_whitespace() {
-                    k += 1;
-                }
-                let next = chars.get(k).copied().unwrap_or('\0');
-                out.push_str(&ident);
-                // A bare identifier followed by `,` or `}` is a true shorthand
-                // (`{ foo }`). `key: …`, method `foo() {}`, etc. are not.
-                if next == ',' || next == '}' || next == '\0' {
-                    out.push(':');
+                if expect_prop {
+                    // Look ahead, skipping whitespace, to the next meaningful char.
+                    let mut k = j;
+                    while k < n && chars[k].is_whitespace() {
+                        k += 1;
+                    }
+                    let next = chars.get(k).copied().unwrap_or('\0');
+                    // The key itself is never substituted. A bare identifier
+                    // followed by `,` or `}` is a true shorthand (`{ foo }`) and
+                    // gains the resolved value; `key: …`, method `foo() {}`, etc.
+                    // are keys only.
                     out.push_str(&ident);
+                    if next == ',' || next == '}' || next == '\0' {
+                        out.push(':');
+                        out.push_str(&resolve(&ident));
+                    }
+                } else {
+                    out.push_str(&resolve(&ident));
                 }
                 expect_prop = false;
                 prev2 = prev;

--- a/crates/rsvelte_projection/src/svelte2tsx/template/nodes/await_block.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/template/nodes/await_block.rs
@@ -42,6 +42,14 @@ pub(crate) fn handle_await_block(
     let has_then = block.then.is_some();
     let has_catch = block.catch.is_some();
 
+    // Official `handleAwait` re-assembles the whole block at `{/await}` and
+    // leaves every collapsed source gap behind as exactly ONE space, so the
+    // opener padding is a gap COUNT, not a constant: the opener and the trailer
+    // are always one gap each, and every `then` / `catch` clause adds the gap of
+    // its own marker. (A pending block contributes none — it sits flush against
+    // the promise expression.)
+    let open_pad = " ".repeat(2 + usize::from(has_then) + usize::from(has_catch));
+
     let value_text = block
         .value
         .as_ref()
@@ -87,7 +95,7 @@ pub(crate) fn handle_await_block(
             // travels with the expression.
             if let Some((expr_start, expr_end)) = get_expression_range(&block.expression) {
                 str.move_range(expr_start, expr_end, prev_end);
-                str.overwrite(block.start, expr_start, "   { ");
+                str.overwrite_fmt(block.start, expr_start, format_args!("{}{{ ", open_pad));
                 if expr_end < pending_start {
                     str.overwrite(expr_end, pending_start, "");
                 }
@@ -124,7 +132,7 @@ pub(crate) fn handle_await_block(
             } else {
                 // Parser couldn't span the expression — fall back to
                 // the original monolithic bake.
-                str.overwrite(block.start, pending_start, "   { ");
+                str.overwrite_fmt(block.start, pending_start, format_args!("{}{{ ", open_pad));
                 process_fragment_inplace(pending, source, options, str, counter, depth);
                 // `try { ` wrapper when a catch/error is present (see above).
                 let try_prefix = if has_catch { "try { " } else { "" };
@@ -223,7 +231,7 @@ pub(crate) fn handle_await_block(
 
             // Opening `{ ` — consume the `{#await PROMISE}` opener (PROMISE is
             // re-emitted as `await(...)` after the pending body).
-            str.overwrite(block.start, pending_start, "   { ");
+            str.overwrite_fmt(block.start, pending_start, format_args!("{}{{ ", open_pad));
             process_fragment_inplace(pending, source, options, str, counter, depth);
 
             if let Some(ref catch) = block.catch {
@@ -285,36 +293,24 @@ pub(crate) fn handle_await_block(
         // elements provide their own block). `value_close` is the matching `}`
         // for the value scope, emitted by the close logic below.
         let value_close = if value_text.is_empty() { "" } else { "}" };
-        let (header_prefix, header_suffix) = if has_catch {
-            (
-                if value_text.is_empty() {
-                    "   { try { await ("
-                } else {
-                    "   { try { const $$_value = await ("
-                },
-                if !value_text.is_empty() {
-                    format!(");{{ const {} = $$_value; ", value_text)
-                } else {
-                    ");".to_string()
-                },
-            )
+        let header_prefix = format!(
+            "{}{{ {}{}await (",
+            open_pad,
+            if has_catch { "try { " } else { "" },
+            if value_text.is_empty() {
+                ""
+            } else {
+                "const $$_value = "
+            },
+        );
+        let header_suffix = if value_text.is_empty() {
+            ");".to_string()
         } else {
-            (
-                if value_text.is_empty() {
-                    "   { await ("
-                } else {
-                    "   { const $$_value = await ("
-                },
-                if !value_text.is_empty() {
-                    format!(");{{ const {} = $$_value; ", value_text)
-                } else {
-                    ");".to_string()
-                },
-            )
+            format!(");{{ const {} = $$_value; ", value_text)
         };
 
         if let Some((expr_start, expr_end)) = get_expression_range(&block.expression) {
-            str.overwrite(block.start, expr_start, header_prefix);
+            str.overwrite(block.start, expr_start, &header_prefix);
             if expr_end < then_start {
                 str.overwrite(expr_end, then_start, &header_suffix);
             } else {
@@ -397,38 +393,27 @@ pub(crate) fn handle_await_block(
             block.end
         };
 
-        let (header_prefix, header_suffix) = (
-            "   { try { await (",
-            if !error_text.is_empty() {
-                format!(
-                    ");}} catch($$_e) {{ const {} = __sveltets_2_any();",
-                    error_text
-                )
-            } else {
-                ");} catch($$_e) { ".to_string()
-            },
-        );
+        let header_prefix = format!("{}{{ try {{ await (", open_pad);
+        let header_suffix = if !error_text.is_empty() {
+            format!(
+                ");}} catch($$_e) {{ const {} = __sveltets_2_any();",
+                error_text
+            )
+        } else {
+            ");} catch($$_e) { ".to_string()
+        };
         if let Some((expr_start, expr_end)) = get_expression_range(&block.expression) {
-            str.overwrite(block.start, expr_start, header_prefix);
+            str.overwrite(block.start, expr_start, &header_prefix);
             if expr_end < catch_start {
                 str.overwrite(expr_end, catch_start, &header_suffix);
             } else {
                 str.append_left(expr_end, &header_suffix);
             }
-        } else if !error_text.is_empty() {
-            str.overwrite_fmt(
-                block.start,
-                catch_start,
-                format_args!(
-                    "   {{ try {{ await ({});}} catch($$_e) {{ const {} = __sveltets_2_any();",
-                    expr_text, error_text
-                ),
-            );
         } else {
             str.overwrite_fmt(
                 block.start,
                 catch_start,
-                format_args!("   {{ try {{ await ({});}} catch($$_e) {{ ", expr_text),
+                format_args!("{}{}{}", header_prefix, expr_text, header_suffix),
             );
         }
 
@@ -449,7 +434,11 @@ pub(crate) fn handle_await_block(
         // always awaited, so the `await` keyword must be present (it was
         // previously dropped, emitting `{EXPR;}`).
         if let Some((expr_start, expr_end)) = get_expression_range(&block.expression) {
-            str.overwrite(block.start, expr_start, "{ await (");
+            str.overwrite_fmt(
+                block.start,
+                expr_start,
+                format_args!("{}{{ await (", open_pad),
+            );
             if expr_end < block.end {
                 str.overwrite(expr_end, block.end, ");}");
             } else {
@@ -459,7 +448,7 @@ pub(crate) fn handle_await_block(
             str.overwrite_fmt(
                 block.start,
                 block.end,
-                format_args!("{{ await ({});}}", expr_text),
+                format_args!("{}{{ await ({});}}", open_pad, expr_text),
             );
         }
     }

--- a/crates/rsvelte_projection/tests/svelte2tsx_slots_reflection_2161.rs
+++ b/crates/rsvelte_projection/tests/svelte2tsx_slots_reflection_2161.rs
@@ -1,0 +1,184 @@
+//! Regression tests for #2161: the slots-reflection resolver
+//! (`push_let_reflection_scope` / `resolve_slot_expression`, official
+//! `SlotHandler.resolve*` + `TemplateScope`).
+//!
+//! Three gaps: a destructuring `let:`/`then`/`catch` context bound only its
+//! directive name (so the leaf identifiers stayed unresolved), an identifier in
+//! object-**key** position was substituted like a value, and the `{#await}`
+//! opener padding was a constant where official derives it from a gap count.
+//!
+//! Every expectation below is byte-exact output of official svelte2tsx
+//! (language-tools, parsing with svelte 5.56.8) for the same input.
+
+use rsvelte_projection::svelte2tsx::{Svelte2TsxOptions, svelte2tsx};
+
+fn convert(src: &str) -> String {
+    let opts = Svelte2TsxOptions {
+        filename: "Input.svelte".to_string(),
+        is_ts_file: false,
+        ..Default::default()
+    };
+    svelte2tsx(src, opts).expect("svelte2tsx ok").code
+}
+
+fn assert_contains(code: &str, expected: &str) {
+    assert!(
+        code.contains(expected),
+        "expected output to contain:\n{expected}\n\ngot:\n{code}"
+    );
+}
+
+/// `let:whatever={{ bla }}` binds `bla`, not `whatever`, and official resolves
+/// it through a destructuring arrow (`resolveDestructuringAssignmentForLet`).
+#[test]
+fn let_object_destructure_resolves_through_arrow() {
+    let code = convert(
+        "<Component let:name={n} let:thing let:whatever={{ bla }}>\n    <slot {n} {thing} {bla} />\n</Component>\n",
+    );
+    assert_contains(
+        &code,
+        "slots: {'default': {n:__sveltets_2_instanceOf(Component).$$slot_def['default'].name, \
+         thing:__sveltets_2_instanceOf(Component).$$slot_def['default'].thing, \
+         bla:(({ bla }) => bla)(__sveltets_2_instanceOf(Component).$$slot_def['default'].whatever)}}",
+    );
+}
+
+/// Array patterns bind every leaf, each through its own arrow.
+#[test]
+fn let_array_destructure_resolves_every_leaf() {
+    let code = convert(
+        "<Component let:pair={[first, second]}>\n    <slot a={first} b={second} />\n</Component>\n",
+    );
+    assert_contains(
+        &code,
+        "slots: {'default': \
+         {a:(([first, second]) => first)(__sveltets_2_instanceOf(Component).$$slot_def['default'].pair), \
+         b:(([first, second]) => second)(__sveltets_2_instanceOf(Component).$$slot_def['default'].pair)}}",
+    );
+}
+
+/// A renamed key (`{ a: renamed }`) binds the RHS only.
+#[test]
+fn let_renamed_key_destructure_binds_the_value() {
+    let code =
+        convert("<Component let:obj={{ a: renamed }}>\n    <slot v={renamed} />\n</Component>\n");
+    assert_contains(
+        &code,
+        "slots: {'default': {v:(({ a: renamed }) => renamed)\
+         (__sveltets_2_instanceOf(Component).$$slot_def['default'].obj)}}",
+    );
+}
+
+/// An in-scope name used as an object KEY stays a key; only values (and the
+/// appended shorthand value) are substituted.
+#[test]
+fn object_key_is_never_substituted() {
+    let code = convert(
+        "{#each items as item}\n    <slot a={item} b={{ item }} c={{ item: 'abc' }.item} \
+         d={{ item: item }} e={$item} f=\"{$item}\" {...g} {...item}>Hello</slot>\n{/each}\n",
+    );
+    assert_contains(
+        &code,
+        "slots: {'default': {a:__sveltets_2_unwrapArr(items), b:{ item:__sveltets_2_unwrapArr(items) }, \
+         c:{ item: 'abc' }.item, d:{ item: __sveltets_2_unwrapArr(items) }, e:$item, f:$item, ...g, \
+         ...__sveltets_2_unwrapArr(items)}}",
+    );
+}
+
+/// Nested objects/arrays keep the key/value split at every depth, and a member
+/// property (`item.item`) is left alone.
+#[test]
+fn nested_object_shorthand_resolves_values_only() {
+    let code = convert(
+        "{#each items as item}\n    <slot a={{ x: { item }, y: [item], z: item.item }} />\n{/each}\n",
+    );
+    assert_contains(
+        &code,
+        "slots: {'default': {a:{ x: { item:__sveltets_2_unwrapArr(items) }, \
+         y: [__sveltets_2_unwrapArr(items)], z: __sveltets_2_unwrapArr(items).item }}}",
+    );
+}
+
+/// String and template literals are copied verbatim — their contents are not
+/// identifiers, so they must never be substituted.
+#[test]
+fn string_literals_are_not_substituted() {
+    let code = convert(
+        "{#each items as item}\n    <slot a={'item'} b={`item`} c={\"item\"} d={item} />\n{/each}\n",
+    );
+    assert_contains(
+        &code,
+        "slots: {'default': {a:'item', b:`item`, c:\"item\", d:__sveltets_2_unwrapArr(items)}}",
+    );
+}
+
+/// `{#await … then}` / `{:catch}` destructuring contexts resolve through the
+/// same arrow, over `__sveltets_2_unwrapPromiseLike` / `__sveltets_2_any({})`.
+#[test]
+fn await_then_destructure_resolves_through_arrow() {
+    let code = convert(
+        "{#await promise2 then { b }}\n    <slot name=\"second\" a={b}>Hello</slot>\n{/await}\n",
+    );
+    assert_contains(
+        &code,
+        "slots: {'second': {a:(({ b }) => b)(__sveltets_2_unwrapPromiseLike(promise2))}}",
+    );
+}
+
+#[test]
+fn await_catch_binding_is_any() {
+    let code = convert(
+        "{#await promise then value}\n    <slot a={value}>Hello</slot>\n{:catch err}\n    \
+         <slot name=\"err\" err={err}>Hello</slot>\n{/await}\n",
+    );
+    assert_contains(
+        &code,
+        "slots: {'default': {a:__sveltets_2_unwrapPromiseLike(promise)}, 'err': {err:__sveltets_2_any({})}}",
+    );
+}
+
+#[test]
+fn await_catch_destructure_resolves_through_arrow() {
+    let code = convert(
+        "{#await promise catch { message }}\n    <slot m={message}>Hello</slot>\n{/await}\n",
+    );
+    assert_contains(
+        &code,
+        "slots: {'default': {m:(({ message }) => message)(__sveltets_2_any({}))}}",
+    );
+}
+
+/// Official re-assembles the block at `{/await}` and leaves one space per
+/// collapsed source gap, so the opener padding grows with each clause: 2 for a
+/// bare/pending-only block, +1 for `then`, +1 for `catch`.
+#[test]
+fn await_opener_padding_counts_clauses() {
+    for (src, opener) in [
+        (
+            "{#await promise}{/await}\n",
+            "async () => {  { await (promise);}",
+        ),
+        (
+            "{#await promise}\n    <p>waiting</p>\n{/await}\n",
+            "async () => {  { ",
+        ),
+        (
+            "{#await promise then value}\n    <slot a={value} />\n{/await}\n",
+            "async () => {   { const $$_value = await (promise);",
+        ),
+        (
+            "{#await promise catch err}\n    <slot e={err} />\n{/await}\n",
+            "async () => {   { try { await (promise);",
+        ),
+        (
+            "{#await promise then value}\n    <slot a={value} />\n{:catch err}\n    <p>{err}</p>\n{/await}\n",
+            "async () => {    { try { const $$_value = await (promise);",
+        ),
+        (
+            "{#await promise}\n    <p>x</p>\n{:then value}\n    <slot a={value} />\n{:catch err}\n    <p>{err}</p>\n{/await}\n",
+            "async () => {    { ",
+        ),
+    ] {
+        assert_contains(&convert(src), opener);
+    }
+}


### PR DESCRIPTION
Fixes #2161.

The three remaining `let:`-forwarding entries in
`compatibility/svelte2tsx-fixtures-known-failures.json` were all in the **slots
reflection typing** subsystem (`push_let_reflection_scope` / official
`SlotHandler.resolve*` + `TemplateScope`), not in the `$$slot_def` template
emitter fixed by #2159.

## The three gaps

**1. `component-slot-let-forward` — destructuring `let:` values.**
`push_let_reflection_scope` asked `expression_simple_identifier` for the bound
name and fell back to the *directive* name when the value was not a bare
identifier. So `let:whatever={{ bla }}` bound `whatever`, and `{bla}` in the
slotted content resolved to nothing:

```diff
-bla:bla
+bla:(({ bla }) => bla)(__sveltets_2_instanceOf(Component).$$slot_def['default'].whatever)
```

Official runs the value through `extract_identifiers` and
`resolveDestructuringAssignmentForLet`, binding every leaf through a
destructuring arrow. The new `push_context_binding` does the same and is shared
by `let:`, `{#await … then}` and `{:catch}` — the last two had the identical hole
(`{#await p then { b }}` and `{:catch { message }}` bound nothing), and `{:catch
e}` was additionally not typed as `__sveltets_2_any({})` per official
`getResolveExpressionStr`.

**2. `component-slot-object-key` — key-position substitution.**
Slot-prop resolution was two string passes: `expand_object_shorthands` then
`resolve_in_scope`, the latter substituting every identifier token with no idea
of its syntactic position. Official's `resolveExpression` walks the AST and
skips three positions — member property, object **key**, and the shorthand value
(which gets `appendLeft(end, ':' + value)` instead of an overwrite):

```diff
-b:{ __sveltets_2_unwrapArr(items):__sveltets_2_unwrapArr(items) }, c:{ __sveltets_2_unwrapArr(items): 'abc' }.item
+b:{ item:__sveltets_2_unwrapArr(items) },                          c:{ item: 'abc' }.item
```

The two passes are now one `resolve_slot_expression` scan that tracks the
object-literal context, so the key is left alone and the shorthand still gains
its resolved value. Folding them also fixes a latent bug the split had: string
and template literals were copied verbatim by the expander but then scanned by
the resolver, so `<slot a={'item'}>` inside `{#each items as item}` emitted
`a:'__sveltets_2_unwrapArr(items)'`.

**3. `component-slot-inside-await` — the opener gap.**
This turned out to be fixable rather than re-homed. Official `handleAwait` moves
every source range to `{/await}` and re-assembles the block there, leaving each
collapsed gap behind as exactly **one space** — so the padding before the opening
`{` is a gap *count*, not a constant. rsvelte hardcoded three spaces everywhere.
The count is `2 + then + catch`: one gap for the opener, one for the trailer, and
one per clause marker (a pending block contributes none, sitting flush against
the promise expression). That also corrects the bare and pending-only shapes,
which were off by one in the other direction.

## Verification

- Fixture ratchet **8 → 5**; upstream suite **246/254 → 249/254** (97.6% → 98.0%).
  `STRICT_S2TSX_FIXTURES=1` leaves only the four unrelated pre-existing entries
  plus the harness-gap one.
- 26 hand-written await/slot shapes — every `pending`/`then`/`catch` combination,
  with and without a value binding, plus object-key / nested-shorthand /
  string-literal / spread / renamed-key cases — diffed byte-for-byte against
  official `svelte2tsx` (language-tools, svelte 5.56.8): **0 diffs**. Ten of them
  are kept as `crates/rsvelte_projection/tests/svelte2tsx_slots_reflection_2161.rs`.
- Real-world svelte2tsx corpus (svelte + svelte.dev + bits-ui + flowbite-svelte +
  melt-ui + shadcn-svelte + pattern corpus, 9,995 entries): `match 9846`,
  `ts-mismatch 0`, `error-mismatch 0`, all source maps well-formed.
- `cargo test -p rsvelte_projection -p rsvelte_check -p rsvelte_language_server`
  green; `cargo fmt` + `cargo clippy --all-targets --all-features -- -D warnings`
  clean; `pnpm run corpus:known-failures-check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
