### PR TITLE
fix(svelte2tsx): mirror official whitespace/gap accounting for `<style>` and `<svelte:boundary>` (#2172)

### DIFF
--- a/.changeset/svelte2tsx-whitespace-gap-parity.md
+++ b/.changeset/svelte2tsx-whitespace-gap-parity.md
@@ -1,0 +1,19 @@
+---
+"@rsvelte/compiler": patch
+"@rsvelte/svelte2tsx": patch
+"@rsvelte/svelte-check": patch
+---
+
+fix(svelte2tsx): mirror official whitespace/gap accounting for `<style>` and
+`<svelte:boundary>`. Blanking a `<style>` tag also swallowed the whitespace that
+followed it, so a top-level `<style>…</style>\n` lost its trailing newline
+(`async () => {};` instead of `async () => {\n};`); upstream `handleStyleTag`
+removes exactly the node range. And `<svelte:boundary>` was lowered with the
+literal-name start transformation, whereas upstream `Element.ts` only
+special-cases `svelte:options` / `head` / `window` / `body` / `fragment` and
+lets everything else keep the tag name as a source range — one more kept range,
+so the props object gets two spaces of gap instead of one. Because the Svelte-4
+AST conversion drops a whitespace-only first/last `Text` child of a boundary,
+`computeStartTagEnd` also lands on the first real child (folding the `\n\t`
+before it into the opener) and a content-bearing first/last `Text` has its data
+trimmed before being blanked.

--- a/crates/rsvelte_projection/src/svelte2tsx/template/nodes/special_element.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/template/nodes/special_element.rs
@@ -15,13 +15,105 @@ use crate::svelte2tsx::template::attributes::directive_suffix::build_directive_p
 use crate::svelte2tsx::template::ctx::Counter;
 use crate::svelte2tsx::template::utils::opener_spacing::{OpenerCtx, opener_spacing};
 use crate::svelte2tsx::template::utils::source::{find_closing_tag_start, find_opening_tag_end};
-use crate::svelte2tsx::template::walk::{process_fragment_inplace, process_node_inplace};
+use crate::svelte2tsx::template::walk::process_node_inplace;
+
+use super::text::handle_text_trimmed;
 
 use super::component_slots::{
     build_named_slot_element_attrs, default_slot_let_block, named_slot_let_block,
 };
 use super::slot_element::slot_attr_static_name;
 use super::snippet_block::handle_snippet_block_as_component_prop;
+
+/// The `svelte:` tags upstream `Element.ts` names with a plain string literal in
+/// `getStartTransformation` / the `_name` switch. Everything else — including
+/// `svelte:boundary` and `svelte:document` — falls through to the `default`
+/// branch, which keeps the tag name as a *source range*; that extra kept range
+/// changes the gap arithmetic in `transform`.
+const LITERAL_NAME_TAGS: [&str; 5] = [
+    "svelte:options",
+    "svelte:head",
+    "svelte:window",
+    "svelte:body",
+    "svelte:fragment",
+];
+
+/// `legacy.js::remove_surrounding_whitespace_nodes`, which the Svelte-4 AST
+/// conversion applies to `<svelte:boundary>` children (and `{#snippet}` bodies)
+/// but to no other element: a whitespace-only first/last `Text` child is dropped
+/// from the array svelte2tsx walks, and a content-bearing one has its `data`
+/// trimmed while keeping its source range.
+#[derive(Clone, Copy, Default)]
+struct SurroundingWhitespace {
+    drop_first: bool,
+    trim_first: bool,
+    drop_last: bool,
+    trim_last: bool,
+}
+
+impl SurroundingWhitespace {
+    fn of(nodes: &[TemplateNode]) -> Self {
+        let classify = |node: Option<&TemplateNode>| match node {
+            Some(TemplateNode::Text(text)) => {
+                if text.data.chars().all(char::is_whitespace) {
+                    (true, false)
+                } else {
+                    (false, true)
+                }
+            }
+            _ => (false, false),
+        };
+        let (drop_first, trim_first) = classify(nodes.first());
+        let (drop_last, trim_last) = classify(nodes.last());
+        Self {
+            drop_first,
+            trim_first,
+            drop_last,
+            trim_last,
+        }
+    }
+
+    /// Start of the first child that survives, i.e. upstream
+    /// `computeStartTagEnd`'s `children[0].start`.
+    fn first_kept_start(&self, nodes: &[TemplateNode]) -> Option<u32> {
+        let kept = if self.drop_first { &nodes[1..] } else { nodes };
+        kept.first().map(node_start)
+    }
+}
+
+fn node_start(node: &TemplateNode) -> u32 {
+    use TemplateNode as N;
+    match node {
+        N::Text(n) => n.start,
+        N::Comment(n) => n.start,
+        N::ExpressionTag(n) => n.start,
+        N::HtmlTag(n) => n.start,
+        N::ConstTag(n) => n.start,
+        N::DeclarationTag(n) => n.start,
+        N::DebugTag(n) => n.start,
+        N::RenderTag(n) => n.start,
+        N::AttachTag(n) => n.start,
+        N::IfBlock(n) => n.start,
+        N::EachBlock(n) => n.start,
+        N::AwaitBlock(n) => n.start,
+        N::KeyBlock(n) => n.start,
+        N::SnippetBlock(n) => n.start,
+        N::RegularElement(n) => n.start,
+        N::Component(n) => n.start,
+        N::SvelteComponent(n) => n.start,
+        N::SvelteElement(n) => n.start,
+        N::TitleElement(n) => n.start,
+        N::SlotElement(n) => n.start,
+        N::SvelteOptions(n)
+        | N::SvelteBody(n)
+        | N::SvelteDocument(n)
+        | N::SvelteFragment(n)
+        | N::SvelteBoundary(n)
+        | N::SvelteHead(n)
+        | N::SvelteSelf(n)
+        | N::SvelteWindow(n) => n.start,
+    }
+}
 
 /// Handle Svelte special elements (svelte:body, svelte:window, etc.).
 ///
@@ -62,8 +154,22 @@ pub(crate) fn handle_svelte_special_element(
         .map(|(inst, target_slot)| named_slot_let_block(&el.attributes, inst, target_slot, source));
     let default_slot_let = default_slot_let_block(&el.attributes, saved_slot.as_ref(), source);
 
-    let opening_tag_end =
-        find_opening_tag_end(source, el.start, el.end, el.name.as_str(), &el.attributes);
+    let is_boundary = el.name == "svelte:boundary";
+    let whitespace = if is_boundary {
+        SurroundingWhitespace::of(&el.fragment.nodes)
+    } else {
+        SurroundingWhitespace::default()
+    };
+    // `computeStartTagEnd` ends the opener transform at the first child, so
+    // source between `>` and that child is collapsed. Only `<svelte:boundary>`
+    // can have a gap there — every other element keeps its leading whitespace as
+    // a `Text` child that starts right after the `>`.
+    let opening_tag_end = whitespace
+        .first_kept_start(&el.fragment.nodes)
+        .filter(|_| whitespace.drop_first)
+        .unwrap_or_else(|| {
+            find_opening_tag_end(source, el.start, el.end, el.name.as_str(), &el.attributes)
+        });
     // In a named-slot context the `slot` attribute is consumed by the wrapper
     // block, so build the attributes without it.
     let mut attrs_str = if named_slot.is_some() {
@@ -77,14 +183,16 @@ pub(crate) fn handle_svelte_special_element(
         )
     };
 
-    // The special `svelte:…` elements name themselves with a literal in the start
-    // transformation, so it contributes no source range.
+    // Only the `LITERAL_NAME_TAGS` name themselves with a string in the start
+    // transformation; the rest keep the tag name as a source range.
+    let head = (!LITERAL_NAME_TAGS.contains(&el.name.as_str()))
+        .then(|| (el.start + 1, el.start + 1 + el.name.len() as u32));
     let spacing = opener_spacing(
         source,
         el.start,
         &el.name,
         opening_tag_end,
-        None,
+        head,
         &el.attributes,
         &counter.element_opener_comments,
         OpenerCtx {
@@ -144,7 +252,7 @@ pub(crate) fn handle_svelte_special_element(
         let mut anchor = opening_tag_end;
         let mut last_snippet_end: Option<u32> = None;
 
-        for node in &el.fragment.nodes {
+        for (index, node) in el.fragment.nodes.iter().enumerate() {
             if let TemplateNode::SnippetBlock(s) = node {
                 if s.start >= s.end {
                     continue;
@@ -162,7 +270,17 @@ pub(crate) fn handle_svelte_special_element(
             } else {
                 // Non-snippet children live AFTER the createElement call;
                 // svelte:boundary is an ancestor element → depth+1.
-                process_node_inplace(node, source, options, str, counter, depth + 1);
+                process_child(
+                    node,
+                    index,
+                    &el.fragment.nodes,
+                    whitespace,
+                    source,
+                    options,
+                    str,
+                    counter,
+                    depth + 1,
+                );
             }
         }
 
@@ -266,7 +384,19 @@ pub(crate) fn handle_svelte_special_element(
 
         // Special svelte elements (svelte:head, svelte:body, etc.) are element
         // nodes → children at depth+1, consistent with RegularElement treatment.
-        process_fragment_inplace(&el.fragment, source, options, str, counter, depth + 1);
+        for (index, node) in el.fragment.nodes.iter().enumerate() {
+            process_child(
+                node,
+                index,
+                &el.fragment.nodes,
+                whitespace,
+                source,
+                options,
+                str,
+                counter,
+                depth + 1,
+            );
+        }
 
         let extra_close = if directive_prefix.is_empty() { "" } else { "}" };
         let closing_tag_start = find_closing_tag_start(source, el.end);
@@ -285,4 +415,35 @@ pub(crate) fn handle_svelte_special_element(
         str.append_left(el.end, "}");
     }
     counter.slot_inst = saved_slot;
+}
+
+/// Dispatch one child, applying the `<svelte:boundary>` whitespace surgery: a
+/// dropped node is never visited (so its source survives verbatim) and a
+/// trimmed one is blanked from its shortened `data`.
+#[allow(clippy::too_many_arguments)]
+fn process_child(
+    node: &TemplateNode,
+    index: usize,
+    nodes: &[TemplateNode],
+    whitespace: SurroundingWhitespace,
+    source: &str,
+    options: &Svelte2TsxOptions,
+    str: &mut MagicString<'_>,
+    counter: &mut Counter,
+    depth: u32,
+) {
+    if let TemplateNode::Text(text) = node {
+        let is_first = index == 0;
+        let is_last = index + 1 == nodes.len();
+        if (is_first && whitespace.drop_first) || (is_last && whitespace.drop_last) {
+            return;
+        }
+        let trim_start = is_first && whitespace.trim_first;
+        let trim_end = is_last && whitespace.trim_last;
+        if trim_start || trim_end {
+            handle_text_trimmed(text, str, trim_start, trim_end);
+            return;
+        }
+    }
+    process_node_inplace(node, source, options, str, counter, depth);
 }

--- a/crates/rsvelte_projection/src/svelte2tsx/template/nodes/text.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/template/nodes/text.rs
@@ -10,8 +10,31 @@ use crate::svelte2tsx::magic_string::MagicString;
 /// If the result is empty but the original text had content, at least 1
 /// space is preserved (to prevent hover artifacts in the language server).
 pub(crate) fn handle_text(text: &Text, _source: &str, str: &mut MagicString<'_>) {
+    handle_text_trimmed(text, str, false, false);
+}
+
+/// `handle_text` for a node whose `data` the Svelte-4 AST conversion trimmed.
+///
+/// `legacy.js::remove_surrounding_whitespace_nodes` strips the leading /
+/// trailing whitespace off the first / last `Text` child of a
+/// `<svelte:boundary>` or a `{#snippet}` body without moving its `start`/`end`,
+/// so svelte2tsx blanks the whole source range but computes the replacement
+/// from the trimmed data.
+pub(crate) fn handle_text_trimmed(
+    text: &Text,
+    str: &mut MagicString<'_>,
+    trim_start: bool,
+    trim_end: bool,
+) {
     if text.start >= text.end {
         return;
+    }
+    let mut data: &str = &text.data;
+    if trim_start {
+        data = data.trim_start();
+    }
+    if trim_end {
+        data = data.trim_end();
     }
     // Mirror JS reference (`htmlxtojsx_v2/nodes/Text.ts`) exactly: it inspects
     // `node.data` — the *decoded* inner text (HTML entities resolved, e.g.
@@ -24,10 +47,10 @@ pub(crate) fn handle_text(text: &Text, _source: &str, str: &mut MagicString<'_>)
     // range for `&nbsp;` is the literal `&nbsp;`, which is invalid JS and made
     // oxfmt reject the whole output. The decoded U+00A0 is a JS whitespace
     // character, so it formats away cleanly like any other whitespace.
-    if text.data.is_empty() {
+    if data.is_empty() {
         return;
     }
-    let mut replacement: String = text.data.chars().filter(|c| c.is_whitespace()).collect();
+    let mut replacement: String = data.chars().filter(|c| c.is_whitespace()).collect();
     if replacement.is_empty() {
         replacement = " ".to_string();
     }

--- a/crates/rsvelte_projection/src/svelte2tsx/utils/htmlxparser.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/utils/htmlxparser.rs
@@ -136,19 +136,10 @@ pub(crate) fn blank_style_tags(ast: &Root, source: &str, str: &mut MagicString<'
                 .any(|w| w.eq_ignore_ascii_case(b"</style>"))
         };
         if has_proper_style_close {
-            // Also blank any trailing whitespace after the style tag
-            let mut blank_end = css.end;
-            let bytes = source.as_bytes();
-            while (blank_end as usize) < bytes.len() {
-                let b = bytes[blank_end as usize];
-                if b == b' ' || b == b'\t' || b == b'\n' || b == b'\r' {
-                    blank_end += 1;
-                } else {
-                    break;
-                }
-            }
-            str.overwrite(css.start, blank_end, "");
-            blanked_style_ranges.push((css.start as usize, blank_end as usize));
+            // `handleStyleTag` removes exactly the node range — whitespace
+            // around the tag survives into the template body.
+            str.overwrite(css.start, css.end, "");
+            blanked_style_ranges.push((css.start as usize, css.end as usize));
         }
     }
     {
@@ -205,16 +196,7 @@ pub(crate) fn blank_style_tags(ast: &Root, source: &str, str: &mut MagicString<'
                     && let Some(close_off) = source[abs_start..].find("</style>")
                 {
                     let abs_end = abs_start + close_off + 8; // 8 = len("</style>")
-                    let mut blank_end = abs_end as u32;
-                    while (blank_end as usize) < bytes.len() {
-                        let b = bytes[blank_end as usize];
-                        if b == b' ' || b == b'\t' || b == b'\n' || b == b'\r' {
-                            blank_end += 1;
-                        } else {
-                            break;
-                        }
-                    }
-                    str.overwrite(abs_start as u32, blank_end, "");
+                    str.overwrite(abs_start as u32, abs_end as u32, "");
                     search_from = abs_end;
                     continue;
                 }

--- a/crates/rsvelte_projection/tests/svelte2tsx_whitespace_parity_2172.rs
+++ b/crates/rsvelte_projection/tests/svelte2tsx_whitespace_parity_2172.rs
@@ -1,0 +1,167 @@
+//! Regression test: whitespace / gap accounting around a top-level `<style>`
+//! and a `<svelte:boundary>` opening tag (issue #2172).
+//!
+//! Every expectation is the byte-exact `async () => { … };` body official
+//! svelte2tsx (submodules/language-tools) emits for the same source.
+
+use rsvelte_projection::svelte2tsx::{Svelte2TsxOptions, svelte2tsx};
+
+/// The `async () => { … };` template body, which is where the divergences show.
+fn template_body(source: &str) -> String {
+    let opts = Svelte2TsxOptions {
+        filename: "Input.svelte".to_string(),
+        is_ts_file: false,
+        ..Default::default()
+    };
+    let code = svelte2tsx(source, opts).expect("svelte2tsx").code;
+    let start = code.find("async () => {").expect("template body");
+    let end = code.find("\nreturn { props:").expect("template body end");
+    code[start..end].to_string()
+}
+
+#[test]
+fn top_level_style_keeps_the_whitespace_around_it() {
+    // `handleStyleTag` removes exactly the node range, so the newline after
+    // `</style>` survives into the template body.
+    assert_eq!(
+        template_body("<style>\n\tp { color: red; }\n</style>\n"),
+        "async () => {\n};"
+    );
+    assert_eq!(template_body("<style></style>"), "async () => {};");
+    assert_eq!(template_body("<style></style>\n\n"), "async () => {\n\n};");
+    assert_eq!(template_body("<style></style>  "), "async () => {  };");
+}
+
+#[test]
+fn style_between_elements_keeps_both_sides() {
+    assert_eq!(
+        template_body("<p>x</p>\n<style>p{color:red}</style>\n"),
+        "async () => { { svelteHTML.createElement(\"p\", {});  }\n\n};"
+    );
+    assert_eq!(
+        template_body("<style>p{color:red}</style>\n<p>x</p>\n"),
+        "async () => {\n { svelteHTML.createElement(\"p\", {});  }\n};"
+    );
+}
+
+#[test]
+fn style_the_parser_does_not_capture_keeps_the_whitespace_around_it() {
+    // `<style lang="…">` is not in `ast.css`, so the fallback scanner blanks it.
+    assert_eq!(
+        template_body("<style lang=\"scss\">\n\tp { color: red; }\n</style>\n"),
+        "async () => {\n};"
+    );
+}
+
+#[test]
+fn boundary_opener_keeps_the_default_start_transformation_gaps() {
+    // `svelte:boundary` is not one of the `svelte:` tags upstream names with a
+    // string literal, so the tag name stays a kept source range and the props
+    // gap widens by one space.
+    assert_eq!(
+        template_body("<svelte:boundary onerror={handler}>\n\t<p>hi</p>\n</svelte:boundary>\n"),
+        concat!(
+            "async () => { { svelteHTML.createElement(\"svelte:boundary\", {  \"onerror\":handler,}); ",
+            "{ svelteHTML.createElement(\"p\", {});  }\n }\n};"
+        )
+    );
+    assert_eq!(
+        template_body(
+            "<svelte:boundary onerror={handler} foo=\"bar\">\n\t<p>hi</p>\n</svelte:boundary>\n"
+        ),
+        concat!(
+            "async () => { { svelteHTML.createElement(\"svelte:boundary\", ",
+            "{    \"onerror\":handler,\"foo\":`bar`,}); ",
+            "{ svelteHTML.createElement(\"p\", {});  }\n }\n};"
+        )
+    );
+}
+
+#[test]
+fn boundary_folds_a_dropped_leading_whitespace_child_into_the_opener() {
+    // `remove_surrounding_whitespace_nodes` drops the whitespace-only first
+    // child, so `computeStartTagEnd` lands on the `<p>` and the `\n\t` is eaten.
+    assert_eq!(
+        template_body("<svelte:boundary>\n\t<p>hi</p>\n</svelte:boundary>\n"),
+        concat!(
+            "async () => {  { svelteHTML.createElement(\"svelte:boundary\", {}); ",
+            "{ svelteHTML.createElement(\"p\", {});  }\n }\n};"
+        )
+    );
+    assert_eq!(
+        template_body("<svelte:boundary>\n\t{value}\n</svelte:boundary>\n"),
+        "async () => {  { svelteHTML.createElement(\"svelte:boundary\", {});value;\n }\n};"
+    );
+    assert_eq!(
+        template_body("<svelte:boundary>\n\t{#if x}\n\t\t<p>a</p>\n\t{/if}\n</svelte:boundary>\n"),
+        concat!(
+            "async () => {  { svelteHTML.createElement(\"svelte:boundary\", {});if(x){\n\t\t ",
+            "{ svelteHTML.createElement(\"p\", {});  }\n\t}\n }\n};"
+        )
+    );
+}
+
+#[test]
+fn boundary_trims_a_content_bearing_first_and_last_text_child() {
+    // The same conversion trims (rather than drops) a `Text` child that carries
+    // content, which changes the blanked-out replacement `handleText` computes.
+    assert_eq!(
+        template_body("<svelte:boundary>\n\thello\n</svelte:boundary>\n"),
+        "async () => { { svelteHTML.createElement(\"svelte:boundary\", {});  }\n};"
+    );
+    assert_eq!(
+        template_body("<svelte:boundary>\n\ta{x}b\n</svelte:boundary>\n"),
+        "async () => { { svelteHTML.createElement(\"svelte:boundary\", {}); x;  }\n};"
+    );
+    assert_eq!(
+        template_body("<svelte:boundary>\n\ta\n\t<p>x</p>\n\tb\n</svelte:boundary>\n"),
+        concat!(
+            "async () => { { svelteHTML.createElement(\"svelte:boundary\", {});\n\t ",
+            "{ svelteHTML.createElement(\"p\", {});  }\n\t }\n};"
+        )
+    );
+}
+
+#[test]
+fn boundary_snippet_children_stay_implicit_props_after_the_fold() {
+    assert_eq!(
+        template_body(
+            "<svelte:boundary>\n\t{#snippet failed(e, reset)}\n\t\t<button onclick={reset}>x</button>\n\t{/snippet}\n</svelte:boundary>\n"
+        ),
+        concat!(
+            "async () => {  { svelteHTML.createElement(\"svelte:boundary\", ",
+            "{failed:(e, reset) => { async ()/*Ωignore_positionΩ*/ => {\n\t\t ",
+            "{ svelteHTML.createElement(\"button\", { \"onclick\":reset,});  }\n\t};",
+            "return __sveltets_2_any(0)},});\n }\n};"
+        )
+    );
+}
+
+#[test]
+fn boundary_without_children_keeps_the_closing_tag_lookup() {
+    assert_eq!(
+        template_body("<svelte:boundary></svelte:boundary>\n"),
+        "async () => { { svelteHTML.createElement(\"svelte:boundary\", {}); }\n};"
+    );
+    assert_eq!(
+        template_body("<svelte:boundary />\n"),
+        "async () => { { svelteHTML.createElement(\"svelte:boundary\", {});}\n};"
+    );
+    // A whitespace-only child is dropped, so it is never visited and survives.
+    assert_eq!(
+        template_body("<svelte:boundary>\n\t\n</svelte:boundary>\n"),
+        "async () => { { svelteHTML.createElement(\"svelte:boundary\", {});\n\t\n }\n};"
+    );
+}
+
+#[test]
+fn bare_await_pending_arm_keeps_its_gap() {
+    assert_eq!(
+        template_body("{#await p}\n\t<p>loading</p>\n{/await}\n"),
+        "async () => {  { \n\t { svelteHTML.createElement(\"p\", {});  }\nawait (p);}\n};"
+    );
+    assert_eq!(
+        template_body("{#await p}x{/await}"),
+        "async () => {  {  await (p);}};"
+    );
+}


### PR DESCRIPTION
Fixes #2172

Two MagicString-span divergences from official svelte2tsx, both surfacing as
stray or missing whitespace inside the generated `async () => { … };` template
body. Item 3 of the issue (the bare `{#await}` pending-arm gap) was already
fixed by #2181 — reproduced on `origin/main` as byte-identical to official, and
locked in with a guard test here.

### 1. Top-level `<style>` lost the whitespace after it

`blank_style_tags` extended the blanked range past `</style>` through every
following space/tab/newline, on both the `ast.css` path and the fallback
scanner for tags the parser does not capture (`<style lang="…">`,
`<style global>`). Upstream `handleStyleTag` is just
`str.remove(node.start, node.end)`, so the whitespace around the tag survives
into the template body:

| source | official | rsvelte (before) |
|---|---|---|
| `<style>…</style>\n` | `async () => {\n};` | `async () => {};` |
| `<style></style>\n\n` | `async () => {\n\n};` | `async () => {};` |
| `<p>x</p>\n<style>…</style>\n` | `…}\n\n};` | `…}\n};` |

### 2. `<svelte:boundary>` opening tag

Two upstream behaviours were missing.

**The start transformation.** `Element.ts::getStartTransformation` only
special-cases `svelte:options` / `head` / `window` / `body` / `fragment` with a
string-literal tag name. `svelte:boundary` (and `svelte:document`) falls through
to the `default` branch, which keeps the tag name as a **source range**. That is
one more kept range for `transform` to move, so the collapsed gap that lands
inside the props object is two spaces, not one:

```
official: { svelteHTML.createElement("svelte:boundary", {  "onerror":handler,});
rsvelte:  { svelteHTML.createElement("svelte:boundary", { "onerror":handler,});
```

**The children view.** `legacy.js::remove_surrounding_whitespace_nodes` runs on
a `SvelteBoundary`'s children (and nothing else except `{#snippet}` bodies)
when the Svelte-4 AST svelte2tsx consumes is built. A whitespace-only first /
last `Text` child is dropped from the array, and a content-bearing one has its
`data` trimmed while keeping its source range. Both are observable:

- `computeStartTagEnd` returns `children[0].start`, so with the leading
  whitespace node gone the opener transform runs to the first real child and
  folds the `\n\t` into the opener — official emits
  `…{});{ svelteHTML.createElement("p", …` on one line where rsvelte kept
  `…{});\n\t { svelteHTML.createElement("p", …`.
- `handleText` computes its blank-out replacement from the trimmed `data`, so
  `<svelte:boundary>\n\thello\n</svelte:boundary>` collapses to a single space
  instead of `\n\t\n`.

A dropped node is never visited by the walker at all, so its source survives
verbatim — `process_child` skips it rather than blanking it, matching that.

## Verification

- New `crates/rsvelte_projection/tests/svelte2tsx_whitespace_parity_2172.rs`
  (9 tests): every expectation is the byte-exact body official svelte2tsx emits
  for the same source, including a guard for the bare `{#await}` gap.
- Differential sweep against the official oracle
  (`submodules/language-tools/packages/svelte2tsx`, svelte pinned to the
  mirrored 5.56.8) over all **5,253** `.svelte` files in
  `submodules/{svelte,language-tools}`: byte-identical outputs go
  **4,218 → 4,529**, with **0** regressions (the new divergence set is a strict
  subset of the old one).
- `cargo test -p rsvelte_projection` green; the svelte2tsx fixture ratchet is
  unchanged at 249/254 with the same 5 known failures (none of them became
  fixable, so no baseline to shrink).
- `cargo test -p rsvelte_check` green.
- `cargo fmt` + `cargo clippy --all-targets --all-features -- -D warnings` clean.

## Out of scope (found while sweeping, filed as follow-ups in the issue thread)

- `<svelte:options runes />` has the same one-space-short opener gap; it is
  emitted by its own hand-rolled `emit_svelte_options_element` rather than
  `opener_spacing`.
- A `{#snippet}` body's first/last `Text` child is not whitespace-trimmed
  (`remove_surrounding_whitespace_nodes` applies there too), and a root/element
  snippet's hoist site is one space short.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RQSYoh4Wc353KgUnWHjazu
