### PR TITLE
fix(compiler): number server `$$array` helpers across declarations

### DIFF
--- a/.changeset/fix-server-array-counter-shared.md
+++ b/.changeset/fix-server-array-counter-shared.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/compiler": patch
+---
+
+Fix a server (SSR) codegen bug where two SEPARATE array-pattern destructuring declarations in one script (e.g. `let [a, b] = $state([1, 2]); let [c, d] = $state([3, 4]);`) both emitted a colliding `$$array = $.to_array(...)` temp. The `$$array` counter is now component-wide instead of being reset per declaration, so it deconflicts to `$$array`, `$$array_1`, … like the official compiler's `scope.generate('$$array')`.

--- a/compatibility/pattern-corpus/README.md
+++ b/compatibility/pattern-corpus/README.md
@@ -70,6 +70,7 @@ source with `node scripts/compat-corpus/compile.mjs --filter pattern/`.
 | `2141-snippet-shadow-is-function.svelte` | [#2141](https://github.com/baseballyama/rsvelte/issues/2141) | A block-local `{#snippet}` shadowing a same-named outer `function` still reads as reactive (`is_function()` must resolve to the snippet, not the outer function) |
 | `2162-single-target-destructure-paren.svelte` | [#2162](https://github.com/baseballyama/rsvelte/issues/2162) | A single-target destructuring **assignment** (`({ a } = obj)`, no rest) keeps its wrapping parens — upstream always lowers through a `SequenceExpression`, even with one element, and esrap always self-parenthesizes one |
 | `2177-each-item-destructure-cache.svelte` | [#2177](https://github.com/baseballyama/rsvelte/issues/2177) | A legacy destructuring **assignment** inside a template expression (event handler) whose right-hand side is an each-block item — `should_cache` must be decided from the *visited* RHS (`item` → `$.get(item)`), so it caches into a `$$value` IIFE like upstream instead of staying an uncached sequence / re-reading the item |
+| `2187-server-array-counter.svelte` | [#2187](https://github.com/baseballyama/rsvelte/issues/2187) | Server: two SEPARATE array-pattern `$state(...)` declarations in one script must deconflict their `$.to_array` temp — `$$array`, `$$array_1` — instead of both emitting `$$array` (the counter must be component-wide, not reset per declaration) |
 
 ## `matrix/` — the axes around those repros
 

--- a/compatibility/pattern-corpus/issues/2187-server-array-counter.svelte
+++ b/compatibility/pattern-corpus/issues/2187-server-array-counter.svelte
@@ -1,0 +1,11 @@
+<script>
+	let [a, b] = $state([1, 2]);
+	let [c, d] = $state([3, 4]);
+
+	function inc() {
+		a++;
+		c++;
+	}
+</script>
+
+<button onclick={inc}>{a}{b}{c}{d}</button>

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/mod.rs
@@ -173,6 +173,13 @@ pub struct ServerTransformState<'a> {
     /// `_1`, `_2`, … — so two destructured `$state(...)` declarations deconflict
     /// (`tmp` / `tmp_1`).
     pub state_tmp_counter: usize,
+    /// Monotonic counter for the `$$array` temp generated per `ArrayPattern` in a
+    /// RUNES-mode destructured `$state(...)` / `$state.raw(...)` declaration
+    /// (mirrors upstream `scope.generate('$$array')`). Shared across every
+    /// top-level declaration in the component (not reset per declarator), so a
+    /// SECOND array-pattern declaration is named `$$array_1`, not a colliding
+    /// `$$array`. The first is bare `$$array`, subsequent ones append `_1`, `_2`, …
+    pub array_counter: u32,
     /// Whether the CURRENT children run is the direct children of a
     /// RegularElement / TitleElement (`process_children` `parent.is_some()`).
     /// Mirrors upstream's `AwaitExpression` server visitor parent-walk: an inline
@@ -291,6 +298,7 @@ impl<'a> ServerTransformState<'a> {
             derived_d_counter: 0,
             derived_array_counter: 0,
             state_tmp_counter: 0,
+            array_counter: 0,
             in_element_children: false,
             attr_optimiser: None,
             shadowed_names: Vec::new(),

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/script.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/script.rs
@@ -1643,7 +1643,14 @@ fn lower_variable_declaration<'a>(
                 if matches!(rune, DeclRune::State)
                     && !matches!(pat, oxc_ast::ast::BindingPattern::BindingIdentifier(_))
                 {
-                    create_state_declarators(pat, new_init, state, &mut decls);
+                    // `state.array_counter` is the component-wide counter (not
+                    // reset per statement, since this function runs once PER
+                    // top-level declaration) — copy it out, thread it through the
+                    // call, then write it back (mirrors `wrap_reads_in_statement_
+                    // counted`'s copy-out/write-back around `self.array_counter`).
+                    let mut array_counter = state.array_counter;
+                    create_state_declarators(pat, new_init, state, &mut array_counter, &mut decls);
+                    state.array_counter = array_counter;
                 } else if matches!(rune, DeclRune::Derived | DeclRune::DerivedBy)
                     && !matches!(pat, oxc_ast::ast::BindingPattern::BindingIdentifier(_))
                 {
@@ -1693,10 +1700,15 @@ fn lower_variable_declaration<'a>(
 /// `scope.generate('$$array')`; here the component instance scope has no
 /// `tmp` / `$$array` bindings for these fixtures, so the names are emitted
 /// verbatim (KNOWN GAP: no deconfliction against user-declared `tmp`/`$$array`).
+/// `array_counter` is the CALLER's array-temp counter, threaded (not reset) so a
+/// SECOND destructured-declaration array pattern in the same component is named
+/// `$$array_1`, not a colliding `$$array` (写経 the per-component
+/// `scope.generate('$$array')`).
 fn create_state_declarators<'a>(
     pat: oxc_ast::ast::BindingPattern<'a>,
     value: Option<OxcExpression<'a>>,
     state: &mut ServerTransformState<'a>,
+    array_counter: &mut u32,
     decls: &mut Vec<(oxc_ast::ast::BindingPattern<'a>, Option<OxcExpression<'a>>)>,
 ) {
     // `let tmp = <value>` — deconflict the temp name across the component (mirrors
@@ -1710,12 +1722,11 @@ fn create_state_declarators<'a>(
     let mut paths: Vec<(oxc_ast::ast::BindingPattern<'a>, OxcExpression<'a>)> = Vec::new();
     let mut array_decls: Vec<(String, OxcExpression<'a>)> = Vec::new();
     let tmp_id = b.id(&tmp_name);
-    let mut array_counter: u32 = 0;
     extract_paths(
         pat,
         tmp_id,
         state,
-        &mut array_counter,
+        array_counter,
         &mut paths,
         &mut array_decls,
     );
@@ -3041,9 +3052,14 @@ fn lower_legacy_var_decl<'a>(
                 decls.push((pat, init_expr));
             } else {
                 // Destructured reactive state: `let { a, b } = obj` →
-                // `let tmp = obj, a = tmp.a, b = tmp.b;` (写经
+                // `let tmp = obj, a = tmp.a, b = tmp.b;` (写経
                 // `create_state_declarators`). The synthetic group stays COMBINED.
-                create_state_declarators(pat, init_expr, state, &mut decls);
+                // Reuses THIS function's already-threaded `array_counter` (shared
+                // with the props-destructure and assignment-destructure `$$array`
+                // temps below), so a state destructure sharing a script with
+                // either still deconflicts (写経 the single per-component
+                // `scope.generate('$$array')`).
+                create_state_declarators(pat, init_expr, state, array_counter, &mut decls);
             }
             out.push(b.var_decl_from_pairs(kind, decls));
             continue;

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/tests.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/tests.rs
@@ -4074,6 +4074,54 @@ fn ast_matches_oracle_destructure_state_and_store_init() {
     );
 }
 
+/// Regression for #2187: the server transform's `$$array` counter must be
+/// COMPONENT-WIDE, not reset per declaration — two SEPARATE array-pattern
+/// `$state(...)` declarations in one script must deconflict to `$$array` /
+/// `$$array_1` (写経 the per-component `scope.generate('$$array')`), instead of
+/// both colliding on bare `$$array`. `oracle_dump` (rsvelte's own pre-AST text
+/// pipeline) shares this exact counter-reset bug, so it can't serve as the
+/// oracle here — assert the AST pipeline's literal output instead.
+#[test]
+fn array_counter_is_shared_across_declarations() {
+    let src = "<script>\n\tlet [a, b] = $state([1, 2]);\n\tlet [c, d] = $state([3, 4]);\n</script>\n\n{a}{b}{c}{d}";
+    let out = run(src);
+    assert!(
+        out.contains("$$array = $.to_array(tmp, 2)"),
+        "first array declarator should be the bare `$$array` temp:\n{out}"
+    );
+    assert!(
+        out.contains("$$array_1 = $.to_array(tmp_1, 2)"),
+        "second array declarator should deconflict to `$$array_1`:\n{out}"
+    );
+    assert!(
+        !out.contains("$$array_2"),
+        "only two array patterns were declared, so no `$$array_2` should appear:\n{out}"
+    );
+}
+
+/// Regression for #2187 (LEGACY mode): the same component-wide `$$array`
+/// counter applies when a destructured PROP declaration and a destructured
+/// legacy-reactive-state declaration both contain array patterns in the same
+/// script — the state destructure must continue the counter the props
+/// destructure already advanced, not restart at `$$array`.
+#[test]
+fn array_counter_is_shared_across_legacy_props_and_state_declarations() {
+    let src = "<script>\n\texport let [a, b] = [1, 2];\n\tlet [c, d] = [3, 4];\n\tfunction inc() {\n\t\tc++;\n\t\td++;\n\t}\n</script>\n\n<button onclick={inc}>{a}{b}{c}{d}</button>";
+    let out = run(src);
+    assert!(
+        out.contains("$$array = $.to_array"),
+        "first (props) array declarator should be the bare `$$array` temp:\n{out}"
+    );
+    assert!(
+        out.contains("$$array_1 = $.to_array"),
+        "second (state) array declarator should deconflict to `$$array_1`:\n{out}"
+    );
+    assert!(
+        !out.contains("$$array_2"),
+        "only two array patterns were declared, so no `$$array_2` should appear:\n{out}"
+    );
+}
+
 /// Snippet codegen parity with the `transform_server` oracle for the
 /// runtime-runes snippet cluster — exercising the two server-codegen axes the
 /// AST visitor was missing: VERBATIM parameter emission (destructuring


### PR DESCRIPTION
Fixes #2187

The server transform's destructure expansion restarted its `$$array` helper counter per declaration, so two array-pattern declarations in one script both emitted `$$array` — a name collision. Upstream numbers them `$$array`, `$$array_1`, … via scope-unique naming.

The counter is now threaded through the transform state for the whole script (call-local, no global statics, per the project's parallel-compile constraint), matching upstream output byte-for-byte.

Verified: scoped release suites (`--lib`, `ssr`, `compiler_fixtures`, `server_destructure_divergences_2033_2034`, `legacy_nested_destructure_2139`) all green; new pattern-corpus repro `pattern/issues/2187-server-array-counter.svelte` added.

Note: implementation by the fix-2187 subagent; finalized (tests re-run, commit, PR) by the coordinator after the agent stalled on background-task waits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RQSYoh4Wc353KgUnWHjazu