### PR TITLE
fix(svelte2tsx): skip identifiers in a slot expression's computed object key

### DIFF
--- a/.changeset/slot-computed-key-resolution.md
+++ b/.changeset/slot-computed-key-resolution.md
@@ -1,0 +1,11 @@
+---
+"@rsvelte/compiler": patch
+---
+
+fix(svelte2tsx): skip identifiers in a slot expression's computed object key. A
+bare-identifier computed key (`{ [item]: 1 }`) was resolved through the
+`{#each}`/`let:` scope like any other identifier, but official's
+`resolveExpression` never substitutes a key position at all — it only
+descends into a compound key expression (`{ [item + 1]: 1 }`), whose nested
+identifiers resolve normally because the key slot there is not an
+`Identifier` node.

--- a/.changeset/slot-computed-key-resolution.md
+++ b/.changeset/slot-computed-key-resolution.md
@@ -1,5 +1,7 @@
 ---
 "@rsvelte/compiler": patch
+"@rsvelte/svelte2tsx": patch
+"@rsvelte/svelte-check": patch
 ---
 
 fix(svelte2tsx): skip identifiers in a slot expression's computed object key. A

--- a/crates/rsvelte_projection/src/svelte2tsx/template/collect/pattern.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/template/collect/pattern.rs
@@ -176,6 +176,35 @@ pub(super) fn resolve_slot_expression(text: &str, scope: &[(String, String)]) ->
                 prev = c;
                 i += 1;
             }
+            '[' if expect_prop => {
+                // Computed object key (`{ [expr]: value }`). Official's `isObjectKey`
+                // only matches when the `Identifier` node sits directly in the key
+                // slot, so a bare-identifier key (`[item]`) is left untouched while a
+                // compound key expression (`[item + 1]`) has its nested identifiers
+                // resolved as if they weren't in key position at all — mirrored here
+                // by consuming the whole `[…]` span and branching on its shape.
+                let close = find_matching_close(&chars, i, '[', ']');
+                let inner: String = chars[i + 1..close].iter().collect();
+                let trimmed = inner.trim();
+                let is_bare_ident = {
+                    let mut it = trimmed.chars();
+                    match it.next() {
+                        Some(c0) if is_ident_start(c0) => it.all(is_ident),
+                        _ => false,
+                    }
+                };
+                out.push('[');
+                if is_bare_ident {
+                    out.push_str(&inner);
+                } else {
+                    out.push_str(&resolve_slot_expression(&inner, scope));
+                }
+                out.push(']');
+                expect_prop = false;
+                prev2 = prev;
+                prev = ']';
+                i = close + 1;
+            }
             '[' | '(' => {
                 ctx.push(false);
                 expect_prop = false;
@@ -245,8 +274,8 @@ pub(super) fn resolve_slot_expression(text: &str, scope: &[(String, String)]) ->
                 i = j;
             }
             _ => {
-                // Any other char in property position (e.g. `.` of a spread,
-                // a computed-key `[`) means this is not a plain shorthand.
+                // Any other char in property position (e.g. `.` of a spread)
+                // means this is not a plain shorthand.
                 expect_prop = false;
                 out.push(c);
                 prev2 = prev;
@@ -256,4 +285,43 @@ pub(super) fn resolve_slot_expression(text: &str, scope: &[(String, String)]) ->
         }
     }
     out
+}
+
+/// Find the index of the `close` char matching the `open` char at `chars[open_index]`,
+/// skipping over string/template literals so brackets inside them don't count. Only the
+/// depth of `open`/`close` itself is tracked — other bracket kinds nested inside pair up
+/// on their own and never unbalance this count.
+fn find_matching_close(chars: &[char], open_index: usize, open: char, close: char) -> usize {
+    let n = chars.len();
+    let mut depth = 0i32;
+    let mut i = open_index;
+    while i < n {
+        let c = chars[i];
+        if c == '"' || c == '\'' || c == '`' {
+            let quote = c;
+            i += 1;
+            while i < n {
+                let ch = chars[i];
+                i += 1;
+                if ch == '\\' && i < n {
+                    i += 1;
+                    continue;
+                }
+                if ch == quote {
+                    break;
+                }
+            }
+            continue;
+        }
+        if c == open {
+            depth += 1;
+        } else if c == close {
+            depth -= 1;
+            if depth == 0 {
+                return i;
+            }
+        }
+        i += 1;
+    }
+    n.saturating_sub(1)
 }

--- a/crates/rsvelte_projection/tests/svelte2tsx_slot_computed_key_2182.rs
+++ b/crates/rsvelte_projection/tests/svelte2tsx_slot_computed_key_2182.rs
@@ -1,0 +1,74 @@
+//! Regression test for #2182: `resolve_slot_expression`
+//! (`crates/rsvelte_projection/src/svelte2tsx/template/collect/pattern.rs`)
+//! substituted identifiers inside a computed object key (`{ [x]: y }`), whereas
+//! official svelte2tsx's `resolveExpression` (`nodes/slot.ts`) skips a key
+//! position entirely via `isObjectKey` — which fires only when the `Identifier`
+//! node sits directly in the key slot. A bare-identifier computed key
+//! (`[item]`) is therefore left untouched, while a compound key expression
+//! (`[item + 1]`) has its nested identifiers resolved normally, since the key
+//! slot there is a `BinaryExpression`, not an `Identifier`.
+//!
+//! Every expectation below is byte-exact output of official svelte2tsx
+//! (language-tools, parsing with svelte 5.56.8) for the same input.
+
+use rsvelte_projection::svelte2tsx::{Svelte2TsxOptions, svelte2tsx};
+
+fn convert(src: &str) -> String {
+    let opts = Svelte2TsxOptions {
+        filename: "Input.svelte".to_string(),
+        is_ts_file: false,
+        ..Default::default()
+    };
+    svelte2tsx(src, opts).expect("svelte2tsx ok").code
+}
+
+fn assert_contains(code: &str, expected: &str) {
+    assert!(
+        code.contains(expected),
+        "expected output to contain:\n{expected}\n\ngot:\n{code}"
+    );
+}
+
+/// A bare-identifier computed key is never substituted, but its value is.
+#[test]
+fn bare_identifier_computed_key_is_never_substituted() {
+    let code = convert("{#each items as item}\n    <slot a={{ [item]: 1 }} />\n{/each}\n");
+    assert_contains(&code, "slots: {'default': {a:{ [item]: 1 }}}");
+}
+
+/// A compound computed-key expression is not an `Identifier` in key position,
+/// so official's `isObjectKey` never fires on it — its nested identifiers are
+/// resolved exactly as if they weren't in key position at all.
+#[test]
+fn compound_computed_key_expression_resolves_normally() {
+    let code = convert("{#each items as item}\n    <slot a={{ [item + 1]: 1 }} />\n{/each}\n");
+    assert_contains(
+        &code,
+        "slots: {'default': {a:{ [__sveltets_2_unwrapArr(items) + 1]: 1 }}}",
+    );
+}
+
+/// Key and value can reference the same in-scope name independently: the key
+/// occurrence stays untouched, the value occurrence is resolved.
+#[test]
+fn bare_identifier_computed_key_and_matching_value() {
+    let code = convert("{#each items as item}\n    <slot a={{ [item]: item }} />\n{/each}\n");
+    assert_contains(
+        &code,
+        "slots: {'default': {a:{ [item]: __sveltets_2_unwrapArr(items) }}}",
+    );
+}
+
+/// Multiple properties: a compound key resolves its identifier, a bare key
+/// stays put, and both values resolve.
+#[test]
+fn mixed_bare_and_compound_computed_keys() {
+    let code = convert(
+        "{#each items as item}\n    <slot a={{ ['x' + item]: item, [item]: 2 }} />\n{/each}\n",
+    );
+    assert_contains(
+        &code,
+        "slots: {'default': {a:{ ['x' + __sveltets_2_unwrapArr(items)]: \
+         __sveltets_2_unwrapArr(items), [item]: 2 }}}",
+    );
+}


### PR DESCRIPTION
## Summary

`resolve_slot_expression` (`crates/rsvelte_projection/src/svelte2tsx/template/collect/pattern.rs`) substituted identifiers inside a computed object key (`{ [item]: 1 }`), but official svelte2tsx's `SlotHandler.resolveExpression` (`nodes/slot.ts`) never touches a key position at all — `isObjectKey(parent, prop)` fires whenever an `Identifier` node sits directly in the key slot, regardless of whether the property is computed.

- A bare-identifier computed key (`{ [item]: 1 }`) is left untouched, matching official.
- A compound key expression (`{ [item + 1]: 1 }`) is *not* an `Identifier` node itself — the key slot there is a `BinaryExpression` — so its nested identifiers still resolve normally, exactly as official does.

The fix adds a `find_matching_close` bracket-depth scanner so the existing string-scan implementation can consume the whole `[…]` span and branch on whether it's a bare identifier before deciding whether to recurse into `resolve_slot_expression` for the inner expression.

Every expectation in the new test file was verified byte-for-byte against the official svelte2tsx package (language-tools, Svelte 5.56.8) for the same input.

Closes #2182

## Test plan

- [x] `cargo test --release -p rsvelte_projection` — all 253 existing svelte2tsx tests plus the new `svelte2tsx_slot_computed_key_2182.rs` (4 tests) pass, no regressions
- [x] `cargo fmt && cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] New test assertions verified byte-exact against the real official svelte2tsx oracle output

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012gQPtKmdY9xwn5fjdwaxK8