### PR TITLE
fix(svelte2tsx): detect nested $$Slots/$$Events/$$Props declarations

### DIFF
--- a/.changeset/nested-svelte2tsx-special-types.md
+++ b/.changeset/nested-svelte2tsx-special-types.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/compiler": patch
+---
+
+Detect `$$Slots` / `$$Events` / `$$Props` interface and type-alias declarations in svelte2tsx output even when nested inside a function, block, or class body — matching official svelte2tsx's fully recursive instance-script walk instead of only scanning top-level statements.

--- a/crates/rsvelte_projection/src/svelte2tsx/script/mod.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/script/mod.rs
@@ -11,6 +11,7 @@ mod component_events;
 mod export_decl;
 mod exported_names;
 mod hoistable_types;
+mod nested_special_types;
 mod parse;
 mod props_rune;
 mod reactive;
@@ -48,6 +49,7 @@ use hoistable_types::{
     HoistCandidate, hoist_dollar_generic_referenced_types, is_ident_char_for_str,
     is_special_type_name, resolve_hoistable_type_decls, rewrite_interface_to_type_dts,
 };
+use nested_special_types::{apply_special_type_name, scan_nested_special_type_decls};
 use parse::with_parsed_script;
 pub(crate) use parse::{ParsedScript, ParsedScripts};
 use props_rune::{
@@ -384,16 +386,7 @@ pub fn process_instance_script(
                 // Detect $$Slots and $$Events type/interface declarations
                 oxc::Statement::TSInterfaceDeclaration(iface) => {
                     let name = iface.id.name.to_string();
-                    if name == "$$Slots" {
-                        exported_names.has_slots_type = true;
-                    } else if name == "$$Events" {
-                        exported_names.has_events_type = true;
-                        if exported_names.events_type_decl_pos.is_none() {
-                            exported_names.events_type_decl_pos = Some(offset + iface.span.start);
-                        }
-                    } else if name == "$$Props" {
-                        exported_names.uses_dollar_props_type = true;
-                    }
+                    apply_special_type_name(&name, iface.span.start, exported_names, offset);
                     exported_names.instance_type_names.insert(name.clone());
                     if !is_special_type_name(&name) {
                         candidates.push(HoistCandidate {
@@ -414,17 +407,7 @@ pub fn process_instance_script(
                 }
                 oxc::Statement::TSTypeAliasDeclaration(type_alias) => {
                     let name = type_alias.id.name.to_string();
-                    if name == "$$Slots" {
-                        exported_names.has_slots_type = true;
-                    } else if name == "$$Events" {
-                        exported_names.has_events_type = true;
-                        if exported_names.events_type_decl_pos.is_none() {
-                            exported_names.events_type_decl_pos =
-                                Some(offset + type_alias.span.start);
-                        }
-                    } else if name == "$$Props" {
-                        exported_names.uses_dollar_props_type = true;
-                    }
+                    apply_special_type_name(&name, type_alias.span.start, exported_names, offset);
                     exported_names.instance_type_names.insert(name.clone());
                     if !is_special_type_name(&name) {
                         candidates.push(HoistCandidate {
@@ -463,6 +446,13 @@ pub fn process_instance_script(
                 _ => {}
             }
         }
+
+        // Official's walk is fully recursive, so a nested `$$Slots` /
+        // `$$Events` / `$$Props` interface/type-alias still sets the
+        // corresponding flag even though it can never become a hoist
+        // candidate (see nested_special_types.rs). Pass 1 above only visits
+        // top-level statements, so re-scan recursively for the flags alone.
+        scan_nested_special_type_decls(&program.body, exported_names, offset);
 
         // Also collect names declared by reactive statements to avoid
         // treating previously-reactive-declared variables as undeclared.

--- a/crates/rsvelte_projection/src/svelte2tsx/script/nested_special_types.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/script/nested_special_types.rs
@@ -1,0 +1,165 @@
+//! Recursive scan for `$$Slots` / `$$Events` / `$$Props` interface or type-alias
+//! declarations nested inside a function, block, or class body.
+//!
+//! Official svelte2tsx's `processInstanceScriptContent.ts` walk is fully
+//! recursive (`ts.forEachChild`), so `is$$SlotsDeclaration` / `is$$EventsDeclaration`
+//! / `is$$PropsDeclaration` fire at any depth. That walk also runs
+//! `hoistableInterfaces.analyzeInstanceScriptNode`, but only when `parent ===
+//! tsAst` (top-level only) — `HoistableInterfaces.analyzeInstanceScriptNode`
+//! populates the very map that decides hoistability/shadowing, so a nested
+//! declaration never becomes a hoist candidate there either. This module
+//! mirrors only the unconditional half: it must not feed
+//! `instance_type_names` / hoist candidates, which stay top-level-only via the
+//! existing Pass 1 loop in mod.rs.
+
+use oxc_ast::ast as oxc;
+
+use super::exported_names::ExportedNames;
+
+/// Set `has_slots_type` / `has_events_type` / `events_type_decl_pos` /
+/// `uses_dollar_props_type` from a `$$Slots` / `$$Events` / `$$Props`
+/// interface-or-type-alias name, regardless of nesting depth. Shared with
+/// Pass 1's top-level detection in mod.rs so the two never drift.
+pub(super) fn apply_special_type_name(
+    name: &str,
+    span_start: u32,
+    exported_names: &mut ExportedNames,
+    offset: u32,
+) {
+    if name == "$$Slots" {
+        exported_names.has_slots_type = true;
+    } else if name == "$$Events" {
+        exported_names.has_events_type = true;
+        if exported_names.events_type_decl_pos.is_none() {
+            exported_names.events_type_decl_pos = Some(offset + span_start);
+        }
+    } else if name == "$$Props" {
+        exported_names.uses_dollar_props_type = true;
+    }
+}
+
+pub(super) fn scan_nested_special_type_decls(
+    stmts: &[oxc::Statement],
+    exported_names: &mut ExportedNames,
+    offset: u32,
+) {
+    for stmt in stmts {
+        scan_stmt(stmt, exported_names, offset);
+    }
+}
+
+fn scan_stmt(stmt: &oxc::Statement, exported_names: &mut ExportedNames, offset: u32) {
+    match stmt {
+        oxc::Statement::TSInterfaceDeclaration(iface) => {
+            apply_special_type_name(
+                iface.id.name.as_str(),
+                iface.span.start,
+                exported_names,
+                offset,
+            );
+        }
+        oxc::Statement::TSTypeAliasDeclaration(alias) => {
+            apply_special_type_name(
+                alias.id.name.as_str(),
+                alias.span.start,
+                exported_names,
+                offset,
+            );
+        }
+        oxc::Statement::BlockStatement(block) => {
+            scan_nested_special_type_decls(&block.body, exported_names, offset);
+        }
+        oxc::Statement::IfStatement(if_stmt) => {
+            scan_stmt(&if_stmt.consequent, exported_names, offset);
+            if let Some(alt) = &if_stmt.alternate {
+                scan_stmt(alt, exported_names, offset);
+            }
+        }
+        oxc::Statement::WhileStatement(w) => scan_stmt(&w.body, exported_names, offset),
+        oxc::Statement::DoWhileStatement(d) => scan_stmt(&d.body, exported_names, offset),
+        oxc::Statement::ForStatement(f) => scan_stmt(&f.body, exported_names, offset),
+        oxc::Statement::ForOfStatement(f) => scan_stmt(&f.body, exported_names, offset),
+        oxc::Statement::ForInStatement(f) => scan_stmt(&f.body, exported_names, offset),
+        oxc::Statement::LabeledStatement(l) => scan_stmt(&l.body, exported_names, offset),
+        oxc::Statement::TryStatement(t) => {
+            scan_nested_special_type_decls(&t.block.body, exported_names, offset);
+            if let Some(h) = &t.handler {
+                scan_nested_special_type_decls(&h.body.body, exported_names, offset);
+            }
+            if let Some(f) = &t.finalizer {
+                scan_nested_special_type_decls(&f.body, exported_names, offset);
+            }
+        }
+        oxc::Statement::SwitchStatement(s) => {
+            for case in &s.cases {
+                scan_nested_special_type_decls(&case.consequent, exported_names, offset);
+            }
+        }
+        oxc::Statement::FunctionDeclaration(func) => {
+            if let Some(body) = &func.body {
+                scan_nested_special_type_decls(&body.statements, exported_names, offset);
+            }
+        }
+        oxc::Statement::ClassDeclaration(class) => scan_class_body(class, exported_names, offset),
+        oxc::Statement::ExpressionStatement(es) => {
+            scan_expr(&es.expression, exported_names, offset);
+        }
+        oxc::Statement::VariableDeclaration(var_decl) => {
+            for decl in &var_decl.declarations {
+                if let Some(init) = &decl.init {
+                    scan_expr(init, exported_names, offset);
+                }
+            }
+        }
+        oxc::Statement::ReturnStatement(ret) => {
+            if let Some(arg) = &ret.argument {
+                scan_expr(arg, exported_names, offset);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn scan_class_body(class: &oxc::Class, exported_names: &mut ExportedNames, offset: u32) {
+    for member in &class.body.body {
+        match member {
+            oxc::ClassElement::MethodDefinition(method) => {
+                if let Some(body) = &method.value.body {
+                    scan_nested_special_type_decls(&body.statements, exported_names, offset);
+                }
+            }
+            oxc::ClassElement::PropertyDefinition(prop) => {
+                if let Some(value) = &prop.value {
+                    scan_expr(value, exported_names, offset);
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+fn scan_expr(expr: &oxc::Expression, exported_names: &mut ExportedNames, offset: u32) {
+    match expr {
+        oxc::Expression::ArrowFunctionExpression(arrow) => {
+            scan_nested_special_type_decls(&arrow.body.statements, exported_names, offset);
+        }
+        oxc::Expression::FunctionExpression(func) => {
+            if let Some(body) = &func.body {
+                scan_nested_special_type_decls(&body.statements, exported_names, offset);
+            }
+        }
+        oxc::Expression::ClassExpression(class) => scan_class_body(class, exported_names, offset),
+        oxc::Expression::CallExpression(call) => {
+            scan_expr(&call.callee, exported_names, offset);
+            for arg in &call.arguments {
+                match arg {
+                    oxc::Argument::SpreadElement(spread) => {
+                        scan_expr(&spread.argument, exported_names, offset);
+                    }
+                    _ => scan_expr(arg.to_expression(), exported_names, offset),
+                }
+            }
+        }
+        _ => {}
+    }
+}

--- a/crates/rsvelte_projection/tests/svelte2tsx_nested_special_types_2166.rs
+++ b/crates/rsvelte_projection/tests/svelte2tsx_nested_special_types_2166.rs
@@ -1,0 +1,98 @@
+//! Regression test for issue #2166.
+//!
+//! Official svelte2tsx's instance-script walk (`processInstanceScriptContent.ts`)
+//! is fully recursive, so `is$$SlotsDeclaration` / `is$$EventsDeclaration` /
+//! `is$$PropsDeclaration` fire on a `$$Slots` / `$$Events` / `$$Props`
+//! interface or type alias at any nesting depth. rsvelte's Pass 1 loop only
+//! visited top-level statements, so a declaration nested inside a function
+//! body was missed and the corresponding flag never set.
+
+use rsvelte_projection::svelte2tsx::{Svelte2TsxOptions, svelte2tsx};
+
+fn code_of(src: &str, is_ts_file: bool) -> String {
+    let opts = Svelte2TsxOptions {
+        filename: "Input.svelte".to_string(),
+        is_ts_file,
+        ..Default::default()
+    };
+    svelte2tsx(src, opts).expect("svelte2tsx").code
+}
+
+#[test]
+fn a_slots_interface_declared_inside_a_function_is_still_detected() {
+    // Official walks the whole instance script, not just its top level, so a
+    // nested `interface $$Slots` still replaces the computed slots shape.
+    let code = code_of(
+        concat!(
+            "<script lang=\"ts\">\n",
+            "  function setup() {\n",
+            "    interface $$Slots {\n",
+            "      default: {};\n",
+            "    }\n",
+            "  }\n",
+            "</script>\n",
+            "\n<slot name=\"named\" />\n",
+        ),
+        true,
+    );
+
+    assert!(
+        code.contains("{} as unknown as $$Slots"),
+        "expected the nested $$Slots interface to be detected, got: {code}"
+    );
+}
+
+#[test]
+fn an_events_type_alias_declared_inside_a_function_is_still_detected() {
+    // A nested `type $$Events` must still suppress the computed `events:` value
+    // in favor of the user's own type, same as a top-level declaration would.
+    let code = code_of(
+        concat!(
+            "<script lang=\"ts\">\n",
+            "  function setup() {\n",
+            "    type $$Events = {\n",
+            "      hi: CustomEvent<boolean>;\n",
+            "    };\n",
+            "  }\n",
+            "</script>\n",
+        ),
+        true,
+    );
+
+    assert!(
+        code.contains("$$Events"),
+        "expected the nested $$Events type alias to be detected, got: {code}"
+    );
+}
+
+#[test]
+fn a_props_interface_declared_inside_a_function_is_still_detected() {
+    // `uses_dollar_props_type` gates whether an untyped `$$props`/`$$restProps`
+    // usage widens the props type — a nested `$$Props` must suppress that too.
+    let with_nested_props = code_of(
+        concat!(
+            "<script lang=\"ts\">\n",
+            "  function setup() {\n",
+            "    interface $$Props {\n",
+            "      name: string;\n",
+            "    }\n",
+            "  }\n",
+            "  console.log($$props);\n",
+            "</script>\n",
+        ),
+        true,
+    );
+    let without_props_type = code_of(
+        concat!(
+            "<script lang=\"ts\">\n",
+            "  console.log($$props);\n",
+            "</script>\n",
+        ),
+        true,
+    );
+
+    assert_ne!(
+        with_nested_props, without_props_type,
+        "expected the nested $$Props interface to change how $$props is typed"
+    );
+}


### PR DESCRIPTION
## Summary

Official svelte2tsx's instance-script walk (`processInstanceScriptContent.ts`) is fully recursive via `ts.forEachChild`, so `is$$SlotsDeclaration` / `is$$EventsDeclaration` / `is$$PropsDeclaration` fire on a `$$Slots` / `$$Events` / `$$Props` interface or type alias at any nesting depth — not just at the top level of the instance script.

rsvelte's Pass 1 loop in `crates/rsvelte_projection/src/svelte2tsx/script/mod.rs` only scanned top-level statements, so a declaration nested inside a function body (or block/class/etc.) was silently missed and `has_slots_type` / `has_events_type` / `uses_dollar_props_type` never got set, producing incorrect generated TSX (e.g. slot types not narrowed to the user's own `$$Slots` interface).

## Fix

- New module `crates/rsvelte_projection/src/svelte2tsx/script/nested_special_types.rs` adds a recursive scan (`scan_nested_special_type_decls`) that walks statements/expressions (blocks, control flow, try/switch, function and class bodies, call arguments, etc.) looking for `$$Slots`/`$$Events`/`$$Props` interface or type-alias declarations at any depth, applying the same flag-setting logic (`apply_special_type_name`) used by the existing top-level Pass 1 scan.
- Crucially, this mirrors only the *unconditional* half of official's walk. Official also runs `hoistableInterfaces.analyzeInstanceScriptNode`, but only when `parent === tsAst` (top-level only) — that call is what feeds hoist candidates and `instance_type_names`. So the hoisting analysis and hoist-candidate collection in `mod.rs` remain intentionally top-level-only, matching official exactly; only flag detection becomes depth-independent.
- `mod.rs` now calls `scan_nested_special_type_decls` once after the existing top-level Pass 1 loop, and both `TSInterfaceDeclaration`/`TSTypeAliasDeclaration` top-level match arms were refactored to share `apply_special_type_name` with the new module so the two paths can't drift.

## Test plan

- [x] New regression test `crates/rsvelte_projection/tests/svelte2tsx_nested_special_types_2166.rs` covers all three special type names declared inside a nested function body (`$$Slots`, `$$Events`, `$$Props`), following the existing `svelte2tsx_event_dispatcher_2157.rs` fixture conventions.
- [x] `cargo test --release -p rsvelte_projection` — full crate suite passes, no regressions.
- [x] `cargo fmt` — no diff.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean.
- [x] Added changeset (`.changeset/nested-svelte2tsx-special-types.md`).

Closes #2166

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012gQPtKmdY9xwn5fjdwaxK8