### PR TITLE
fix(fmt): keep spread-argument calls flat and reindent block-body call continuations in block headers

### DIFF
--- a/.changeset/block-header-call-args-shapes.md
+++ b/.changeset/block-header-call-args-shapes.md
@@ -1,0 +1,10 @@
+---
+"@rsvelte/fmt": patch
+---
+
+Fix two block-header formatting divergences from the oracle. A call with a spread final
+argument (e.g. `{#each list.getGrid(alpha, ...rest) as m}`) was mistaken for a call-chain
+break and split across lines; it now stays on one line like every other block header. A
+call whose only multi-line argument is an arrow function with a block body (e.g.
+`{#if useEffect(() => { run(); }, [depA, depB])}`) now reindents its continuation lines to
+the header's own depth instead of OXC's column-0 output.

--- a/crates/rsvelte_formatter/src/expression/splice.rs
+++ b/crates/rsvelte_formatter/src/expression/splice.rs
@@ -450,7 +450,16 @@ pub(super) fn push_bare_expression(
             // keeps the expanded-arg spacing: `fn( a, b )`.
             collapsed
         } else {
-            formatted
+            // A block body (e.g. `() => { stmt; }`) always prints multi-line
+            // regardless of width, and `removeLines` can't collapse real statements
+            // onto one line either — it stays broken, but nested at the header's
+            // own depth rather than OXC's column-0 output.
+            let cont_indent = if options.js.indent_style.is_tab() {
+                "\t".repeat(depth)
+            } else {
+                " ".repeat(depth * indent_width)
+            };
+            crate::reindent::reindent(&formatted, &cont_indent, true)
         }
     } else {
         formatted

--- a/crates/rsvelte_formatter/src/expression/text.rs
+++ b/crates/rsvelte_formatter/src/expression/text.rs
@@ -174,10 +174,12 @@ pub(super) fn compute_header_suffix_len(source: &str, expr_end: usize) -> usize 
 /// This distinguishes call-chain breaks (hardlines in prettier, kept by removeLines)
 /// from argument-wrapping breaks (softlines in prettier, removed by removeLines).
 pub(super) fn is_method_chain_break(multi: &str) -> bool {
-    multi
-        .lines()
-        .skip(1)
-        .any(|line| line.trim_start().starts_with('.'))
+    multi.lines().skip(1).any(|line| {
+        let trimmed = line.trim_start();
+        // A spread argument (`...rest`) also starts with `.` — exclude it so an
+        // expanded-args break isn't mistaken for a call-chain break.
+        trimmed.starts_with('.') && !trimmed.starts_with("...")
+    })
 }
 
 pub(super) fn outer_parens_match(inner: &str) -> bool {

--- a/crates/rsvelte_formatter/tests/block_header_call_args.rs
+++ b/crates/rsvelte_formatter/tests/block_header_call_args.rs
@@ -272,3 +272,67 @@ fn each_header_settles_iterable_before_key() {
         "{#each wrap(inner({ a: 1, b: 2 }), { c: 3 }) as item (getRows({ limit: 20 }))}"
     );
 }
+
+// #2070: a spread final argument is not a grouped-layout call, so the oracle
+// keeps the header on one line even when OXC's multi-line rendering of the
+// call would otherwise look like a chain break.
+#[test]
+fn spread_final_argument_keeps_header_on_one_line() {
+    let src = concat!(
+        "<script>\n",
+        "\tlet alpha = 1;\n",
+        "\tlet restOfTheArguments = [];\n",
+        "\tlet someCalleeNameHere = { getGrid: (a, ...r) => [] };\n",
+        "</script>\n",
+        "\n",
+        "{#if a}\n",
+        "\t{#if b}\n",
+        "\t\t{#each someCalleeNameHere.getGrid(alpha, ...restOfTheArguments) as m, id (id)}\n",
+        "\t\t\t<div>{m}</div>\n",
+        "\t\t{/each}\n",
+        "\t{/if}\n",
+        "{/if}\n",
+    );
+    assert_eq!(
+        header_of(&fmt(src)),
+        "{#each someCalleeNameHere.getGrid(alpha, ...restOfTheArguments) as m, id (id)}"
+    );
+}
+
+// #2070: a call with an arrow-function block-body argument (e.g. an effect
+// hook) prints multi-line regardless of width; the continuation lines must
+// nest at the header's own indent depth, not OXC's column-0 output.
+#[test]
+fn arrow_block_body_argument_reindents_continuation_to_header_depth() {
+    let src = concat!(
+        "<script>\n",
+        "\tlet depA = 1;\n",
+        "\tlet depB = 2;\n",
+        "\tfunction run() {}\n",
+        "\tfunction useEffect(fn, deps) {}\n",
+        "</script>\n",
+        "\n",
+        "{#if a}\n",
+        "\t{#if b}\n",
+        "\t\t{#if useEffect(() => { run(); }, [depA, depB])}\n",
+        "\t\t\t<div>x</div>\n",
+        "\t\t{/if}\n",
+        "\t{/if}\n",
+        "{/if}\n",
+    );
+    let out = fmt(src);
+    let block = out
+        .lines()
+        .skip_while(|l| !l.trim_start().starts_with("{#if useEffect"))
+        .take_while(|l| !l.trim_start().starts_with("<div>x</div>"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    assert_eq!(
+        block,
+        concat!(
+            "    {#if useEffect(() => {\n",
+            "      run();\n",
+            "    }, [depA, depB])}"
+        )
+    );
+}


### PR DESCRIPTION
## Summary
- A spread final argument in a call inside a block header (e.g. `{#each list.getGrid(alpha, ...rest) as m}`) was misidentified as a call-chain break by `is_method_chain_break`, causing rsvelte to split the header across lines where the oracle keeps it on one line.
- A call whose only multi-line argument is an arrow function with a block body (e.g. `{#if useEffect(() => { run(); }, [depA, depB])}`) now reindents its continuation lines to the header's own indent depth via `push_bare_expression`, instead of leaving OXC's column-0 output as-is.

Neither shape occurs in the current fmt parity corpus (13446 entries, 0 regressions), so `compatibility/fmt-known-failures.json` needed no edits.

## Test plan
- [x] Added two regression tests to `crates/rsvelte_formatter/tests/block_header_call_args.rs` covering both shapes; all 16 tests in the file pass.
- [x] `cargo fmt` (no diff) and `cargo clippy --all-targets --all-features -- -D warnings` (clean) before committing.

Closes #2070

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012gQPtKmdY9xwn5fjdwaxK8