### PR TITLE
fix(svelte2tsx): route <svelte:options> through the shared opener-gap helper

### DIFF
--- a/.changeset/svelte-options-opener-gap.md
+++ b/.changeset/svelte-options-opener-gap.md
@@ -1,0 +1,7 @@
+---
+"@rsvelte/compiler": patch
+"@rsvelte/svelte2tsx": patch
+"@rsvelte/svelte-check": patch
+---
+
+Route `<svelte:options>`'s opener gap through the shared `opener_spacing` helper so the generated TSX matches official svelte2tsx exactly, including bare boolean attributes like `<svelte:options runes />`.

--- a/crates/rsvelte_projection/src/svelte2tsx/nodes/svelte_options.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/nodes/svelte_options.rs
@@ -2,7 +2,9 @@
 //! stores it in `ast.options` rather than `fragment.nodes`, so it needs its own
 //! emitter.
 
-use crate::ast::template::Root;
+use crate::ast::template::{Attribute, Root};
+use crate::svelte2tsx::template::ctx::ElementOpenerCommentIndex;
+use crate::svelte2tsx::template::utils::opener_spacing::{OpenerCtx, opener_spacing};
 
 use super::super::magic_string::MagicString;
 use super::super::svelte2tsx::slice_src;
@@ -19,14 +21,12 @@ pub(crate) fn emit_svelte_options_element(ast: &Root, source: &str, str: &mut Ma
     }
     // Build attribute string from options attributes
     let mut attrs_parts = Vec::new();
-    let mut has_expression_attr = false;
     for node in &options_node.attributes {
         match &node.value {
             crate::ast::template::AttributeValue::True(_) => {
                 attrs_parts.push(format!("\"{}\":true,", node.name));
             }
             crate::ast::template::AttributeValue::Expression(expr) => {
-                has_expression_attr = true;
                 let expr_text = slice_src(
                     source,
                     expr.expression.start().unwrap_or(0) as usize,
@@ -44,7 +44,6 @@ pub(crate) fn emit_svelte_options_element(ast: &Root, source: &str, str: &mut Ma
                 if parts.len() == 1
                     && let AttributeValuePart::ExpressionTag(expr) = &parts[0]
                 {
-                    has_expression_attr = true;
                     let expr_text = slice_src(
                         source,
                         expr.expression.start().unwrap_or(0) as usize,
@@ -65,7 +64,6 @@ pub(crate) fn emit_svelte_options_element(ast: &Root, source: &str, str: &mut Ma
                                 );
                             }
                             AttributeValuePart::ExpressionTag(expr) => {
-                                has_expression_attr = true;
                                 if let (Some(s), Some(e)) =
                                     (expr.expression.start(), expr.expression.end())
                                 {
@@ -82,38 +80,38 @@ pub(crate) fn emit_svelte_options_element(ast: &Root, source: &str, str: &mut Ma
             }
         }
     }
-    let attrs_str = if attrs_parts.is_empty() {
-        String::new()
-    } else if has_expression_attr {
-        // Expression attributes: preserve source spacing
-        let extra_spaces =
-            count_tag_to_attr_spaces_in_source("svelte:options", options_node.start, source);
-        format!("{}{}", " ".repeat(extra_spaces + 1), attrs_parts.join(""))
-    } else {
-        // Bare boolean attributes only: no extra spacing
+
+    // `svelte:options` is in `LITERAL_NAME_TAGS` (official names it with a plain
+    // string literal), so it contributes no `head` range to the gap replay.
+    let attributes: Vec<Attribute> = options_node
+        .attributes
+        .iter()
+        .map(|node| Attribute::Attribute(node.clone()))
+        .collect();
+    let spacing = opener_spacing(
+        source,
+        options_node.start,
+        "svelte:options",
+        options_node.end,
+        None,
+        &attributes,
+        &ElementOpenerCommentIndex::default(),
+        OpenerCtx {
+            is_element: true,
+            in_component_slot: false,
+            tag_name: "svelte:options",
+            is_slot_tag: false,
+        },
+    );
+    let attrs_str = format!(
+        "{}{}",
+        " ".repeat(spacing.in_attr_object),
         attrs_parts.join("")
-    };
+    );
     let replacement = format!(
-        " {{ svelteHTML.createElement(\"svelte:options\", {{{}}});}}",
+        "{}{{ svelteHTML.createElement(\"svelte:options\", {{{}}});}}",
+        " ".repeat(spacing.before_block),
         attrs_str
     );
     str.overwrite(options_node.start, options_node.end, &replacement);
-}
-
-/// Count whitespace between tag name and first attribute in source.
-fn count_tag_to_attr_spaces_in_source(tag_name: &str, el_start: u32, source: &str) -> usize {
-    let name_end = el_start as usize + 1 + tag_name.len(); // +1 for '<'
-    let bytes = source.as_bytes();
-    let mut count = 0;
-    let mut i = name_end;
-    while i < source.len() {
-        let ch = bytes[i];
-        if ch == b' ' || ch == b'\t' || ch == b'\n' || ch == b'\r' {
-            count += 1;
-            i += 1;
-        } else {
-            break;
-        }
-    }
-    count
 }

--- a/crates/rsvelte_projection/src/svelte2tsx/template/ctx.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/template/ctx.rs
@@ -140,8 +140,11 @@ mod tests {
     }
 }
 
+// `pub(crate)` (not `pub(super)`): `svelte2tsx::nodes::svelte_options` is a
+// sibling of `template`, not a descendant, but still needs to construct an
+// empty index (via `Default`) to call `opener_spacing` outside the main walk.
 #[derive(Default)]
-pub(super) struct ElementOpenerCommentIndex {
+pub(crate) struct ElementOpenerCommentIndex {
     ranges: Vec<(u32, u32)>,
     #[cfg(test)]
     range_visits: std::cell::Cell<usize>,

--- a/crates/rsvelte_projection/src/svelte2tsx/template/mod.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/template/mod.rs
@@ -8,10 +8,13 @@
 
 mod attributes;
 mod collect;
-mod ctx;
+// `pub(crate)`: `svelte2tsx::nodes::svelte_options` is a sibling of `template`,
+// not a descendant, but needs `ElementOpenerCommentIndex` to call `opener_spacing`
+// outside the main walk.
+pub(crate) mod ctx;
 mod nodes;
 mod segs;
-mod utils;
+pub(crate) mod utils;
 mod walk;
 
 use crate::ast::template::{Fragment, Root};

--- a/crates/rsvelte_projection/src/svelte2tsx/template/utils/mod.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/template/utils/mod.rs
@@ -2,5 +2,7 @@
 
 pub(super) mod expr;
 pub(super) mod names;
-pub(super) mod opener_spacing;
+// `pub(crate)`: `svelte2tsx::nodes::svelte_options` is a sibling of `template`,
+// not a descendant, but needs `opener_spacing`/`OpenerCtx` outside the main walk.
+pub(crate) mod opener_spacing;
 pub(super) mod source;

--- a/crates/rsvelte_projection/tests/svelte2tsx_svelte_options_opener_gap_2191.rs
+++ b/crates/rsvelte_projection/tests/svelte2tsx_svelte_options_opener_gap_2191.rs
@@ -1,0 +1,70 @@
+//! Regression test: whitespace / gap accounting around a `<svelte:options>`
+//! opening tag (issue #2191).
+//!
+//! Every expectation is the byte-exact `async () => { … };` body official
+//! svelte2tsx (submodules/language-tools) emits for the same source.
+//! `<svelte:options>` used to compute its own opener spacing by hand instead
+//! of going through the shared `opener_spacing` helper (the same bug class
+//! already fixed for `<svelte:boundary>`), leaving it one space short
+//! whenever it had a bare boolean attribute.
+
+use rsvelte_projection::svelte2tsx::{Svelte2TsxOptions, svelte2tsx};
+
+/// The `async () => { … };` template body, which is where the divergences show.
+fn template_body(source: &str) -> String {
+    let opts = Svelte2TsxOptions {
+        filename: "Input.svelte".to_string(),
+        is_ts_file: false,
+        ..Default::default()
+    };
+    let code = svelte2tsx(source, opts).expect("svelte2tsx").code;
+    let start = code.find("async () => {").expect("template body");
+    let end = code.find("\nreturn { props:").expect("template body end");
+    code[start..end].to_string()
+}
+
+#[test]
+fn bare_boolean_attribute_keeps_the_full_opener_gap() {
+    assert_eq!(
+        template_body("<svelte:options runes />"),
+        "async () => {  { svelteHTML.createElement(\"svelte:options\", {\"runes\":true,});}};"
+    );
+}
+
+#[test]
+fn expression_attribute_moves_the_gap_into_the_attribute_object() {
+    assert_eq!(
+        template_body("<svelte:options runes={true} />"),
+        "async () => { { svelteHTML.createElement(\"svelte:options\", {  \"runes\":true,});}};"
+    );
+}
+
+#[test]
+fn string_attribute_moves_the_gap_into_the_attribute_object() {
+    assert_eq!(
+        template_body("<svelte:options customElement=\"my-el\" />"),
+        concat!(
+            "async () => { { svelteHTML.createElement(\"svelte:options\", ",
+            "{  \"customElement\":`my-el`,});}};"
+        )
+    );
+}
+
+#[test]
+fn mixed_bare_and_string_attributes_move_the_gap_into_the_attribute_object() {
+    assert_eq!(
+        template_body("<svelte:options runes customElement=\"my-el\" />"),
+        concat!(
+            "async () => { { svelteHTML.createElement(\"svelte:options\", ",
+            "{  \"runes\":true,\"customElement\":`my-el`,});}};"
+        )
+    );
+}
+
+#[test]
+fn no_attributes_keeps_the_default_single_space_gap() {
+    assert_eq!(
+        template_body("<svelte:options />"),
+        "async () => { { svelteHTML.createElement(\"svelte:options\", {});}};"
+    );
+}


### PR DESCRIPTION
## Summary

Fixes item 1 of #2191: `<svelte:options runes />` had a one-space-short opener gap because it computed its own opening-tag spacing by hand (`emit_svelte_options_element`) instead of going through the shared `opener_spacing` helper — the same bug class already fixed for `<svelte:boundary>` in #2189.

`svelte:options` is one of official svelte2tsx's `LITERAL_NAME_TAGS` (named with a plain string literal), so it contributes no `head` range to the gap replay; `opener_spacing` is called with `head: None`.

`ElementOpenerCommentIndex` and the `opener_spacing` module are widened from `pub(super)` to `pub(crate)` since `svelte2tsx::nodes::svelte_options` is a sibling of `svelte2tsx::template`, not a descendant.

Verified byte-exact against a freshly-built official svelte2tsx oracle (`submodules/language-tools`, pinned to svelte 5.56.8) for bare boolean attributes, expression attributes, string attributes, mixed attributes, and no attributes — all five cases match exactly.

## Residual (not in this PR)

Per #2191, two further sub-items remain, tracked separately:
2. `{#snippet}` bodies don't get `remove_surrounding_whitespace_nodes` treatment (upstream `legacy.js` applies it there too).
3. `<svelte:boundary slot="x">` inside a component isn't routed through the `$slot_def[...]` wrapper.

## Test plan

- [x] New regression test `crates/rsvelte_projection/tests/svelte2tsx_svelte_options_opener_gap_2191.rs`, byte-exact against the official svelte2tsx oracle, covering bare boolean / expression / string / mixed / no-attribute cases
- [x] `cargo test -p rsvelte_projection` — all green, no regressions
- [x] `cargo fmt` / `cargo clippy -p rsvelte_projection --all-targets --all-features -- -D warnings` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012gQPtKmdY9xwn5fjdwaxK8