### PR TITLE
fix(svelte2tsx): use shared build_on_calls for <svelte:self> $on() emission

### DIFF
--- a/.changeset/svelte-self-on-call-trailing-space.md
+++ b/.changeset/svelte-self-on-call-trailing-space.md
@@ -1,0 +1,12 @@
+---
+"@rsvelte/compiler": patch
+"@rsvelte/svelte2tsx": patch
+"@rsvelte/svelte-check": patch
+---
+
+fix(svelte2tsx): drop the trailing space after `<svelte:self>`'s generated
+`$on(...)` calls. `handle_svelte_self` reimplemented event-call emission
+with a bespoke loop that appended `'); '` instead of `');'`, diverging from
+official's `InlineComponent.addEvent` and from rsvelte's own
+`handle_component`, which already reuses the shared `build_on_calls` helper.
+`handle_svelte_self` now calls the same helper.

--- a/crates/rsvelte_projection/src/svelte2tsx/template/nodes/inline_component.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/template/nodes/inline_component.rs
@@ -935,15 +935,10 @@ pub(crate) fn handle_svelte_self(
     let mut opener = create_call;
 
     // Inline `$on()` registration immediately after the const declaration.
+    // Shared with `handle_component` so the emitted call text (no trailing
+    // space before the next statement) matches official's `addEvent`.
     if let Some(ref name) = var_name {
-        for on in &on_directives {
-            if let Some(ref expr) = on.expression {
-                let expr_text = get_expression_text(expr, source);
-                let _ = write!(opener, "{}.$on(\"{}\", {}); ", name, on.name, expr_text);
-            } else {
-                let _ = write!(opener, "{}.$on(\"{}\", () => {{}}); ", name, on.name);
-            }
-        }
+        opener.push_str(&build_on_calls(name, &on_directives, source));
     }
 
     // `let:` directives become a `{const { $$_$$, name, ... } = inst.$$slot_def.default; $$_$$;`

--- a/crates/rsvelte_projection/tests/svelte2tsx_svelte_self_on_calls_2171.rs
+++ b/crates/rsvelte_projection/tests/svelte2tsx_svelte_self_on_calls_2171.rs
@@ -1,0 +1,50 @@
+//! Regression test for #2171 (gap 3): `<svelte:self>` used to emit its
+//! `on:` directives via a bespoke inline loop that appended a trailing
+//! space after each `$on(...)` call (`');  '` instead of `');'`), diverging
+//! from official svelte2tsx's `InlineComponent.addEvent`, which joins calls
+//! with no separator. `handle_component` already reused the shared
+//! `build_on_calls` helper for this; `handle_svelte_self` now does too.
+
+use rsvelte_projection::svelte2tsx::{Svelte2TsxOptions, svelte2tsx};
+
+fn convert(src: &str) -> String {
+    let opts = Svelte2TsxOptions {
+        filename: "Input.svelte".to_string(),
+        is_ts_file: false,
+        ..Default::default()
+    };
+    svelte2tsx(src, opts).expect("svelte2tsx ok").code
+}
+
+#[test]
+fn svelte_self_on_call_has_no_trailing_space() {
+    let code = convert("<script>\n let handler;\n</script>\n<svelte:self on:click={handler} />\n");
+    assert!(
+        code.contains(r#"$$_svelteself0.$on("click", handler);}"#),
+        "expected no trailing space before the closing brace, got:\n{code}"
+    );
+    assert!(
+        !code.contains(r#"handler); }"#),
+        "found a trailing-space `$on` call, got:\n{code}"
+    );
+}
+
+#[test]
+fn svelte_self_forwarded_event_has_no_trailing_space() {
+    let code = convert("<svelte:self on:click />\n");
+    assert!(
+        code.contains(r#"$$_svelteself0.$on("click", () => {});}"#),
+        "expected no trailing space before the closing brace, got:\n{code}"
+    );
+}
+
+#[test]
+fn svelte_self_multiple_events_join_without_extra_spaces() {
+    let code = convert(
+        "<script>\n let a; let b;\n</script>\n<svelte:self on:click={a} on:keydown={b} />\n",
+    );
+    assert!(
+        code.contains(r#"$$_svelteself0.$on("click", a);$$_svelteself0.$on("keydown", b);}"#),
+        "expected consecutive $on calls joined with no extra space, got:\n{code}"
+    );
+}


### PR DESCRIPTION
## Summary
- `<svelte:self>` reimplemented `on:` directive → `$on(...)` emission with a bespoke inline loop that left a trailing space after each call (`');  '` instead of `');'`), diverging from official svelte2tsx's `InlineComponent.addEvent` and from rsvelte's own `handle_component`, which already reuses the shared `build_on_calls` helper (`template/attributes/event_handler.rs`).
- `handle_svelte_self` (`crates/rsvelte_projection/src/svelte2tsx/template/nodes/inline_component.rs`) now calls the same shared helper, so `$on(...)` calls are joined with no separator, matching official output byte-for-byte.

This addresses gap 3 of #2171 only. Gaps 1 (`bind:` directives not getting Svelte-5 `$bindings` marker treatment) and 2 (named `{#snippet}` children not relocated into implicit prop-def-destructured props) are separate, larger changes and are tracked for a follow-up PR.

## Test plan
- [x] New regression tests in `crates/rsvelte_projection/tests/svelte2tsx_svelte_self_on_calls_2171.rs` (single event, forwarded event, multiple events) — all pass
- [x] `cargo test -p rsvelte_projection --test svelte2tsx_fixtures` — pass (ratchet unaffected)
- [x] `cargo fmt`

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

https://claude.ai/code/session_012gQPtKmdY9xwn5fjdwaxK8