### PR TITLE
test: fail loudly instead of no-op in three vacuous test paths

### DIFF
--- a/crates/rsvelte_capi/tests/header_invariants.rs
+++ b/crates/rsvelte_capi/tests/header_invariants.rs
@@ -5,7 +5,7 @@
 //! the build script (when RSVELTE_CAPI_CHECK_HEADER=1, in CI).
 
 use std::fmt::Write as _;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 fn header() -> String {
     let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
@@ -13,6 +13,34 @@ fn header() -> String {
         .join("rsvelte.h");
     std::fs::read_to_string(&path)
         .unwrap_or_else(|e| panic!("could not read {}: {e}", path.display()))
+}
+
+/// The committed (git HEAD) header content, not whatever currently sits in
+/// the working tree. `build.rs` overwrites `include/rsvelte.h` with fresh
+/// cbindgen output on every default build (no `RSVELTE_CAPI_CHECK_HEADER`),
+/// which runs before this test — so comparing against the working-tree file
+/// would always pass trivially (freshly-generated vs. freshly-generated).
+/// Comparing against HEAD instead checks the invariant this test actually
+/// claims to check: is the committed header still what cbindgen produces.
+fn committed_header(crate_dir: &Path) -> String {
+    // `git show <rev>:<path>` resolves `<path>` relative to the repo root,
+    // not the `-C` directory — a bare "include/rsvelte.h" silently means
+    // "<repo-root>/include/rsvelte.h" (which doesn't exist) rather than this
+    // crate's header. The `./` prefix is what opts into `-C`-relative
+    // resolution.
+    let output = std::process::Command::new("git")
+        .arg("-C")
+        .arg(crate_dir)
+        .args(["show", "HEAD:./include/rsvelte.h"])
+        .output()
+        .unwrap_or_else(|e| panic!("failed to run `git show HEAD:./include/rsvelte.h`: {e}"));
+    if !output.status.success() {
+        panic!(
+            "could not read committed include/rsvelte.h from git HEAD: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+    String::from_utf8(output.stdout).expect("git show output is UTF-8")
 }
 
 #[test]
@@ -67,8 +95,10 @@ fn header_has_include_guard() {
     assert!(h.contains("#endif"));
 }
 
-/// Re-run cbindgen in-process and verify the committed header exactly
-/// matches it. Belt-and-braces with the build script's check.
+/// Re-run cbindgen in-process and verify the git-committed header exactly
+/// matches it — independent of the build script's own check, and of
+/// whatever the build script may have already rewritten in the working
+/// tree (see `committed_header`).
 #[test]
 fn header_matches_freshly_generated() {
     let crate_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
@@ -83,7 +113,7 @@ fn header_matches_freshly_generated() {
     bindings.write(&mut buf);
     let generated = String::from_utf8(buf).expect("utf-8");
 
-    let committed = header();
+    let committed = committed_header(&crate_dir);
 
     if normalize(&committed) != normalize(&generated) {
         panic!(

--- a/crates/rsvelte_core/tests/validator.rs
+++ b/crates/rsvelte_core/tests/validator.rs
@@ -148,7 +148,14 @@ fn load_validator_fixture(sample_dir: &Path) -> Result<ValidatorFixture, SkipRea
     let expected_warnings: Vec<ExpectedWarning> = if warnings_path.exists() {
         let content = read_fixture_file(&warnings_path)
             .ok_or(SkipReason::MissingInput("readable warnings.json"))?;
-        serde_json::from_str(&content).unwrap_or_default()
+        // A malformed warnings.json must fail loudly, not silently become "expect
+        // zero warnings" — that would make the fixture pass trivially either way.
+        serde_json::from_str(&content).unwrap_or_else(|e| {
+            panic!(
+                "{}: warnings.json is not valid JSON: {e}",
+                warnings_path.display()
+            )
+        })
     } else {
         Vec::new()
     };

--- a/crates/rsvelte_devtools/tests/compatibility_report.rs
+++ b/crates/rsvelte_devtools/tests/compatibility_report.rs
@@ -639,8 +639,18 @@ fn run_validator_tests() -> CategoryResult {
         let errors_path = sample_dir.join("errors.json");
 
         let expected_warnings: Vec<serde_json::Value> = if warnings_path.exists() {
-            let content = read_fixture_file(&warnings_path).unwrap_or_default();
-            serde_json::from_str(&content).unwrap_or_default()
+            // An unreadable or malformed warnings.json must fail loudly, not
+            // silently collapse to "expect zero warnings" (which would make the
+            // fixture pass regardless of what the compiler actually emits).
+            let content = read_fixture_file(&warnings_path).unwrap_or_else(|| {
+                panic!("{}: could not read warnings.json", warnings_path.display())
+            });
+            serde_json::from_str(&content).unwrap_or_else(|e| {
+                panic!(
+                    "{}: warnings.json is not valid JSON: {e}",
+                    warnings_path.display()
+                )
+            })
         } else {
             Vec::new()
         };


### PR DESCRIPTION
## Summary

Part of the inventory work for #1791 (hunting for tests that report PASS while checking nothing). This PR fixes three confirmed vacuous-test paths; a larger follow-up inventory will be posted as a comment on the issue.

- **`crates/rsvelte_capi/tests/header_invariants.rs`**: the test compared the freshly-generated `include/rsvelte.h` in the working tree against... the freshly-generated `include/rsvelte.h` in the working tree, because `build.rs` regenerates that file on every default build before the test runs. It always passed trivially. Fixed to compare cbindgen's fresh output against the **committed** header at `git HEAD`, which is what the test's name and intent actually claim to verify.
- **`crates/rsvelte_core/tests/validator.rs`** and **`crates/rsvelte_devtools/tests/compatibility_report.rs`**: both read `warnings.json` via `.unwrap_or_default()` on both the file read and the JSON parse, so an unreadable or malformed `warnings.json` silently became "expect zero warnings" — a fixture with a broken expectation file would pass no matter what the compiler emitted. Fixed to panic loudly on either failure, matching the repo's stated convention (per the type-aware-lint suite) that a missing/broken precondition fails instead of skipping.

None of these fixes changes user-visible compiler behavior — test-only, no changeset needed.

## Verification

- `cargo fmt` — clean, no other files touched
- Scoped `cargo test --release -p rsvelte_core --test validator` and `-p rsvelte_devtools --test compatibility_report` were run against real fixture data in an earlier pass of this work and passed cleanly (no fixture triggers the new panics), confirming the stricter checks don't regress on real data. Full-workspace `cargo test --release` was not re-run synchronously for this push due to machine build-queue pressure; CI will cover it.

## Follow-up (not in this PR)

A few other vacuous/weak-guard patterns were found during the audit but are deferred (need product-code changes or environment setup, not just test-file edits) — will be posted as a comment on #1791:
- `crates/rsvelte_formatter/tests/svelte_dev_corpus.rs`: the `unparseable` accumulator is printed but has no floor/ceiling assertion bounding it.
- `scripts/compat-corpus/verify.mjs`, `collect.mjs`, and `svelte2tsx-verify.mjs`: no assertion on a minimum `manifest.length` / corpus size (partially mitigated by `collect.mjs`'s existing required-source guard on `submodules/svelte` and `compatibility/pattern-corpus`).
- `scripts/compat-corpus/lint-verify.mjs` was reviewed as a positive counter-example: it already fails loudly (`process.exit(2)`) on missing binary, SARIF parse failure, or zero corpus files found — a good template for the deferred items above.

Refs #1791