### PR TITLE
fix(svelte2tsx): transform `<svelte:self>` bindings and snippet children like a component

### DIFF
--- a/.changeset/svelte-self-bindings-and-snippet-props.md
+++ b/.changeset/svelte-self-bindings-and-snippet-props.md
@@ -1,0 +1,7 @@
+---
+"@rsvelte/compiler": patch
+"@rsvelte/svelte2tsx": patch
+"@rsvelte/svelte-check": patch
+---
+
+Transform `<svelte:self>` `bind:` directives and `{#snippet}` children like a named component's: two-way bindings now emit a plain prop plus the `$$bindings` marker and setter type-widener instead of the DOM `"bind:value"` form, `bind:this` assigns the component instance, and direct snippet children are demoted to props anchored by a `$$prop_def` destructure.

--- a/crates/rsvelte_projection/src/svelte2tsx/template/attributes/binding.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/template/attributes/binding.rs
@@ -51,6 +51,42 @@ pub(crate) fn format_bind_directive(bind: &BindDirective, source: &str) -> Strin
     format!("\"bind:{}\":{},", bind.name, expr_text)
 }
 
+/// Component-side prop text for a `bind:` directive: `foo:expr,`, or the
+/// shorthand `expr,` when written as bare `bind:foo`. `bind:this` contributes
+/// no prop (it is applied as an assignment after the create call). Mirrors the
+/// `InlineComponent` branch of upstream `Binding.ts`.
+pub(crate) fn format_component_bind_directive(
+    bind: &BindDirective,
+    source: &str,
+) -> Option<String> {
+    if bind.name == "this" {
+        return None;
+    }
+    let expr_range = get_expression_range(&bind.expression);
+    let get_set = get_set_binding_ranges(&bind.expression, source);
+    let is_shorthand = get_set.is_none()
+        && expr_range.is_some_and(|(s, _)| s == bind.start + "bind:".len() as u32);
+    if let Some((s, e)) = expr_range
+        && is_shorthand
+    {
+        return Some(format!("{},", slice_src(source, s as usize, e as usize)));
+    }
+    let value = if let Some(((gs, ge), (ss, se))) = get_set {
+        format!(
+            "__sveltets_2_get_set_binding({},{})",
+            slice_src(source, gs as usize, ge as usize),
+            slice_src(source, ss as usize, se as usize),
+        )
+    } else if let Some((s, e)) = expr_range {
+        // Keep a trailing TS postfix the parser narrowed out of the span.
+        let e = extend_expr_end_with_ts_postfix(source, e, bind.end);
+        slice_src(source, s as usize, e as usize).to_string()
+    } else {
+        get_expression_text(&bind.expression, source).to_string()
+    };
+    Some(format!("{}:{},", bind.name, value))
+}
+
 /// One-way HTML element bindings whose value reflects an element property
 /// (`clientWidth`, etc.). Mirrors the JS reference's `oneWayBindingAttributes`
 /// in `htmlxtojsx_v2/nodes/Binding.ts`.

--- a/crates/rsvelte_projection/src/svelte2tsx/template/nodes/inline_component.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/template/nodes/inline_component.rs
@@ -10,7 +10,7 @@ use crate::svelte2tsx::magic_string::MagicString;
 use crate::svelte2tsx::svelte2tsx::{Svelte2TsxOptions, SvelteVersion, slice_src};
 
 use crate::svelte2tsx::template::attributes::attribute::format_attribute_node;
-use crate::svelte2tsx::template::attributes::binding::format_bind_directive;
+use crate::svelte2tsx::template::attributes::binding::format_component_bind_directive;
 use crate::svelte2tsx::template::attributes::class_style::build_class_style_directive_suffix_segments;
 use crate::svelte2tsx::template::attributes::directive_suffix::build_component_directive_suffix;
 use crate::svelte2tsx::template::attributes::event_handler::{build_on_calls, get_on_directives};
@@ -41,6 +41,58 @@ use super::component_slots::{
 };
 use super::slot_element::slot_attr_static_name;
 use super::snippet_block::handle_snippet_block_as_component_prop;
+
+/// Post-create-call statements every inline component emits for its `bind:`
+/// directives: the `bind:this` assignment plus, per two-way binding, a setter
+/// type-widener and the `$$bindings` marker.
+fn build_component_bind_suffix(attributes: &[Attribute], source: &str, inst_var: &str) -> String {
+    let mut out = String::new();
+    for attr in attributes {
+        let Attribute::BindDirective(bind) = attr else {
+            continue;
+        };
+        if bind.name == "this" {
+            // `bind:this={getFn, setFn}` (Svelte 5 function binding) calls the
+            // setter with the instance instead of assigning to it.
+            if let Some((_, (ss, se))) = get_set_binding_ranges(&bind.expression, source) {
+                let _ = write!(
+                    out,
+                    "({})({});",
+                    slice_src(source, ss as usize, se as usize),
+                    inst_var
+                );
+            } else {
+                // A trailing TS assertion the parser stripped off the LHS moves
+                // onto the RHS instance var: `pane = $$_inst as Pane;`.
+                let expr_text = get_binding_lhs_text(&bind.expression, source);
+                let postfix = get_expression_range(&bind.expression)
+                    .map(|(_, e)| {
+                        let ge =
+                            get_expression_end_stripping_ts(&bind.expression, source).unwrap_or(e);
+                        let ee = extend_expr_end_with_ts_postfix(source, e, bind.end);
+                        slice_src(source, ge as usize, ee as usize)
+                    })
+                    .unwrap_or("");
+                let _ = write!(out, "{} = {}{};", expr_text, inst_var, postfix);
+            }
+            continue;
+        }
+        if get_set_binding_ranges(&bind.expression, source).is_some() {
+            // A get/set pair is already type-checked through
+            // `__sveltets_2_get_set_binding(...)` in the props literal, so the
+            // type-widener is skipped.
+            let _ = write!(out, "{}.$$bindings = '{}';", inst_var, bind.name);
+            continue;
+        }
+        let expr_text = get_binding_lhs_text(&bind.expression, source);
+        let _ = write!(
+            out,
+            "/*\u{03A9}ignore_start\u{03A9}*/() => {} = __sveltets_2_any(null);/*\u{03A9}ignore_end\u{03A9}*/{}.$$bindings = '{}';",
+            expr_text, inst_var, bind.name
+        );
+    }
+    out
+}
 
 /// The `</Component>` → `Component}` mapping upstream keeps for the closing tag.
 /// The `svelte:` tags keep nothing there, and neither does a component whose
@@ -261,63 +313,7 @@ pub(crate) fn handle_component(
     //   `() => expr = __sveltets_2_any(null); inst.$$bindings = 'name';`
     // is appended (as ignore-wrapped statements) for every non-`bind:this`
     // binding on a component.
-    let component_bind_suffix = {
-        let mut out = String::new();
-        for attr in &comp.attributes {
-            if let Attribute::BindDirective(bind) = attr {
-                if bind.name == "this" {
-                    // `bind:this={getFn, setFn}` (Svelte 5 function binding) calls
-                    // the setter with the instance: `(setFn)(inst);` (mirrors
-                    // Binding.ts). Plain `bind:this={x}` → `x = inst;`.
-                    if let Some((_, (ss, se))) = get_set_binding_ranges(&bind.expression, source) {
-                        let _ = write!(
-                            out,
-                            "({})({});",
-                            slice_src(source, ss as usize, se as usize),
-                            inst_var
-                        );
-                    } else {
-                        // The assignment LHS strips a trailing TS assertion
-                        // (`getEnd`); a `bind:this={consolePane as Pane}` postfix
-                        // moves onto the RHS instance var:
-                        // `consolePane = $$_inst as Pane;` — same as the element
-                        // `bind:this` path (mirrors Binding.ts appending
-                        // `[getEnd, expression.end]` after the assignment).
-                        let expr_text = get_binding_lhs_text(&bind.expression, source);
-                        let postfix = get_expression_range(&bind.expression)
-                            .map(|(_, e)| {
-                                let ge = get_expression_end_stripping_ts(&bind.expression, source)
-                                    .unwrap_or(e);
-                                let ee = extend_expr_end_with_ts_postfix(source, e, bind.end);
-                                slice_src(source, ge as usize, ee as usize)
-                            })
-                            .unwrap_or("");
-                        let _ = write!(out, "{} = {}{};", expr_text, inst_var, postfix);
-                    }
-                    continue;
-                }
-                if get_set_binding_ranges(&bind.expression, source).is_some() {
-                    // Function binding `bind:foo={getFn, setFn}`: the get/set
-                    // pair is already type-checked via
-                    // `__sveltets_2_get_set_binding(...)` in the props literal,
-                    // so the `() => expr = __sveltets_2_any(null)` type-widener
-                    // is skipped (mirrors the `if (!isGetSetBinding)` guard in
-                    // upstream `handleBinding`). Only the `$$bindings` marker
-                    // is emitted.
-                    let _ = write!(out, "{}.$$bindings = '{}';", inst_var, bind.name);
-                    continue;
-                }
-                // Setter type-widener: LHS strips a trailing TS assertion.
-                let expr_text = get_binding_lhs_text(&bind.expression, source);
-                let _ = write!(
-                    out,
-                    "/*\u{03A9}ignore_start\u{03A9}*/() => {} = __sveltets_2_any(null);/*\u{03A9}ignore_end\u{03A9}*/{}.$$bindings = '{}';",
-                    expr_text, inst_var, bind.name
-                );
-            }
-        }
-        out
-    };
+    let component_bind_suffix = build_component_bind_suffix(&comp.attributes, source, &inst_var);
     let (header_lit, trailer_lit) = if needs_instance {
         let on_calls = if has_events {
             build_on_calls(&inst_var, &on_directives, source)
@@ -620,42 +616,7 @@ pub(crate) fn handle_svelte_component(
         .attributes
         .iter()
         .any(|a| matches!(a, Attribute::BindDirective(_)));
-    // Build the bind suffix (same shape as `handle_component`'s
-    // `component_bind_suffix`).
-    let component_bind_suffix = {
-        let mut out = String::new();
-        for attr in &comp.attributes {
-            if let Attribute::BindDirective(bind) = attr {
-                if bind.name == "this" {
-                    // LHS strips a trailing TS assertion; a postfix moves onto the
-                    // RHS instance var (mirrors Binding.ts / the element path).
-                    let bexpr = get_binding_lhs_text(&bind.expression, source);
-                    let postfix = get_expression_range(&bind.expression)
-                        .map(|(_, e)| {
-                            let ge = get_expression_end_stripping_ts(&bind.expression, source)
-                                .unwrap_or(e);
-                            let ee = extend_expr_end_with_ts_postfix(source, e, bind.end);
-                            slice_src(source, ge as usize, ee as usize)
-                        })
-                        .unwrap_or("");
-                    let _ = write!(out, "{} = {}{};", bexpr, inst_var, postfix);
-                    continue;
-                }
-                if get_set_binding_ranges(&bind.expression, source).is_some() {
-                    let _ = write!(out, "{}.$$bindings = '{}';", inst_var, bind.name);
-                    continue;
-                }
-                // Setter type-widener: LHS strips a trailing TS assertion.
-                let bexpr = get_binding_lhs_text(&bind.expression, source);
-                let _ = write!(
-                    out,
-                    "/*\u{03A9}ignore_start\u{03A9}*/() => {} = __sveltets_2_any(null);/*\u{03A9}ignore_end\u{03A9}*/{}.$$bindings = '{}';",
-                    bexpr, inst_var, bind.name
-                );
-            }
-        }
-        out
-    };
+    let component_bind_suffix = build_component_bind_suffix(&comp.attributes, source, &inst_var);
     // Need an instance variable when there are `on:` events, `let:` directives,
     // `bind:` directives, or children that reference the instance's slot defs
     // (named-slot children anywhere in blocks, or default-slot `let:` receivers).
@@ -844,7 +805,12 @@ pub(crate) fn handle_svelte_self(
                     }
                 }
                 Attribute::BindDirective(bind) => {
-                    prop_parts.push(format_bind_directive(bind, source));
+                    // `<svelte:self>` is an inline component upstream, so a
+                    // binding is a plain prop (`value:x,`), never the element
+                    // form (`"bind:value":x,`).
+                    if let Some(s) = format_component_bind_directive(bind, source) {
+                        prop_parts.push(s);
+                    }
                 }
                 _ => {}
             },
@@ -900,10 +866,25 @@ pub(crate) fn handle_svelte_self(
     // `$$slot_def`, which forces the `const $$_svelteselfN = …` form.
     let children_have_named_slots = has_named_slot_children(&el.fragment);
     let children_have_default_slot_lets = has_default_slot_let_children(&el.fragment);
+    // Direct `{#snippet}` children become implicit props, but only on the simple
+    // children path — the slot paths own their own block scoping.
+    let use_snippet_props =
+        !(has_lets || children_have_named_slots || children_have_default_slot_lets)
+            && el
+                .fragment
+                .nodes
+                .iter()
+                .any(|n| matches!(n, TemplateNode::SnippetBlock(_)));
+    let has_bindings = el
+        .attributes
+        .iter()
+        .any(|a| matches!(a, Attribute::BindDirective(_)));
     let needs_inst_var = has_on_directives
         || has_lets
         || children_have_named_slots
-        || children_have_default_slot_lets;
+        || children_have_default_slot_lets
+        || use_snippet_props
+        || has_bindings;
     // Use depth as the instance variable index, mirroring official InlineComponent.ts
     // `this._name = '$$_svelteself' + this.computeDepth()`.
     let var_name = if needs_inst_var {
@@ -922,23 +903,32 @@ pub(crate) fn handle_svelte_self(
     };
     let create_call = if let Some(ref name) = var_name {
         format!(
-            "{}{{ const {} = __sveltets_2_createComponentAny({{{}}});",
+            "{}{{ const {} = __sveltets_2_createComponentAny({{{}",
             block_indent, name, props_inner
         )
     } else {
         format!(
-            "{}{{ __sveltets_2_createComponentAny({{{}}});",
+            "{}{{ __sveltets_2_createComponentAny({{{}",
             block_indent, props_inner
         )
     };
 
-    let mut opener = create_call;
+    // Closes the props object, then the `bind:` statements and the `$on()`
+    // registrations — the same order official's transformation array emits.
+    let trailer_lit = match var_name {
+        Some(ref name) => format!(
+            "}});{}{}",
+            build_component_bind_suffix(&el.attributes, source, name),
+            build_on_calls(name, &on_directives, source)
+        ),
+        None => "});".to_string(),
+    };
 
-    // Inline `$on()` registration immediately after the const declaration.
-    // Shared with `handle_component` so the emitted call text (no trailing
-    // space before the next statement) matches official's `addEvent`.
-    if let Some(ref name) = var_name {
-        opener.push_str(&build_on_calls(name, &on_directives, source));
+    let mut opener = create_call;
+    // The snippet-prop path leaves the props object open so the relocated
+    // `{#snippet}` props can be appended inside it.
+    if !use_snippet_props {
+        opener.push_str(&trailer_lit);
     }
 
     // `let:` directives become a `{const { $$_$$, name, ... } = inst.$$slot_def.default; $$_$$;`
@@ -989,6 +979,55 @@ pub(crate) fn handle_svelte_self(
             counter,
             depth + 1,
         )
+    } else if use_snippet_props {
+        let inst_var = var_name
+            .as_deref()
+            .expect("snippet props require an instance variable name");
+        counter.slot_inst = var_name.clone();
+        // A snippet already sitting at the anchor is in place — moving it would
+        // be a forbidden self-move — so the anchor just advances past it.
+        let mut anchor = opening_tag_end;
+        let mut last_snippet_end: Option<u32> = None;
+        let mut snippet_names: Vec<String> = Vec::new();
+        for node in &el.fragment.nodes {
+            if let TemplateNode::SnippetBlock(s) = node {
+                if s.start >= s.end {
+                    continue;
+                }
+                snippet_names.push(get_expression_text(&s.expression, source).to_string());
+                handle_snippet_block_as_component_prop(s, source, options, str, counter, depth + 1);
+                if s.start == anchor {
+                    anchor = s.end;
+                } else {
+                    str.move_range(s.start, s.end, anchor);
+                }
+                last_snippet_end = Some(s.end);
+            } else {
+                process_node_inplace(node, source, options, str, counter, depth + 1);
+            }
+        }
+        counter.slot_inst = None;
+        // Destructuring from `$$prop_def` anchors each snippet's contextual
+        // `Snippet<[Args]>` parameter types.
+        let prop_def_suffix = if snippet_names.is_empty() {
+            String::new()
+        } else {
+            format!(
+                "/*\u{03A9}ignore_start\u{03A9}*/const {{{}}} = {}.$$prop_def;/*\u{03A9}ignore_end\u{03A9}*/",
+                snippet_names.join(", "),
+                inst_var
+            )
+        };
+        let closing = format!("{trailer_lit}{prop_def_suffix}");
+        match last_snippet_end {
+            Some(end) => {
+                str.append_left(end, &closing);
+            }
+            None => {
+                str.prepend_right(opening_tag_end, &closing);
+            }
+        }
+        false
     } else {
         // Still publish the slot context (as `handle_svelte_component` does) so
         // a descendant that reaches for `$$slot_def` without being detected

--- a/crates/rsvelte_projection/tests/svelte2tsx_svelte_self_bindings_2171.rs
+++ b/crates/rsvelte_projection/tests/svelte2tsx_svelte_self_bindings_2171.rs
@@ -1,0 +1,80 @@
+//! `<svelte:self>` is an inline component upstream, so its `bind:` directives
+//! and `{#snippet}` children must be transformed exactly like a named
+//! component's: two-way bindings become plain props plus a `$$bindings` marker,
+//! `bind:this` assigns the instance, and direct snippet children are demoted to
+//! props anchored by a `$$prop_def` destructure.
+
+use rsvelte_projection::svelte2tsx::{Svelte2TsxOptions, svelte2tsx};
+
+fn convert(src: &str) -> String {
+    let opts = Svelte2TsxOptions {
+        filename: "Input.svelte".to_string(),
+        is_ts_file: false,
+        ..Default::default()
+    };
+    svelte2tsx(src, opts).expect("svelte2tsx ok").code
+}
+
+#[test]
+fn svelte_self_two_way_binding_emits_bindings_marker() {
+    let code = convert("<script>\n let x;\n</script>\n<svelte:self bind:value={x} />\n");
+    assert!(
+        !code.contains("\"bind:value\""),
+        "binding must not use the DOM element form, got:\n{code}"
+    );
+    assert!(
+        code.contains("value:x,"),
+        "expected the binding as a plain component prop, got:\n{code}"
+    );
+    assert!(
+        code.contains("() => x = __sveltets_2_any(null);"),
+        "expected the setter type-widener, got:\n{code}"
+    );
+    assert!(
+        code.contains("$$_svelteself0.$$bindings = 'value';"),
+        "expected the $$bindings marker, got:\n{code}"
+    );
+}
+
+#[test]
+fn svelte_self_bind_this_assigns_the_instance() {
+    let code = convert("<script>\n let el;\n</script>\n<svelte:self bind:this={el} />\n");
+    assert!(
+        !code.contains("\"bind:this\"") && !code.contains("this:el"),
+        "bind:this must not become a prop, got:\n{code}"
+    );
+    assert!(
+        code.contains("el = $$_svelteself0;"),
+        "expected the instance assignment, got:\n{code}"
+    );
+}
+
+#[test]
+fn svelte_self_shorthand_binding_keeps_the_marker() {
+    let code = convert("<script>\n let value;\n</script>\n<svelte:self bind:value />\n");
+    assert!(
+        code.contains("$$_svelteself0.$$bindings = 'value';"),
+        "expected the $$bindings marker for the shorthand form, got:\n{code}"
+    );
+}
+
+#[test]
+fn svelte_self_snippet_children_become_props() {
+    let code = convert("<svelte:self>\n{#snippet foo(a)}<p>{a}</p>{/snippet}\n</svelte:self>\n");
+    assert!(
+        code.contains("const {foo} = $$_svelteself0.$$prop_def;"),
+        "expected the snippet to be demoted to a prop, got:\n{code}"
+    );
+}
+
+#[test]
+fn svelte_self_slot_lets_keep_the_slot_path() {
+    // `let:` scoping owns the children, so snippets stay plain block children.
+    let code = convert(
+        "<svelte:self let:item>\n{#snippet foo(a)}<p>{a}</p>{/snippet}\n{item}\n</svelte:self>\n",
+    );
+    assert!(
+        !code.contains("$$prop_def"),
+        "the let: path must not demote snippets, got:\n{code}"
+    );
+}


### PR DESCRIPTION
Closes the two remaining `<svelte:self>` gaps from #2171 (gap 3 shipped in #2221).

Upstream `InlineComponent.ts` handles named components, `<svelte:component>` and `<svelte:self>` in one class — the only `svelte:self`-specific branch is the `$$_svelteself` name prefix and `__sveltets_2_createComponentAny({` vs `new {Name}({`. rsvelte forked that into three functions, and `handle_svelte_self` was a minimal copy that never got the bindings / snippet-props work.

**Gap 1 — `bind:` directives.** `<svelte:self bind:value={x} />` emitted the DOM element form `"bind:value":x,` with no instance const, no setter type-widener and no `$$bindings` marker, and `bind:this` became a prop instead of an instance assignment. Bindings now go through `format_component_bind_directive` (extracted alongside the element formatter), and a new shared `build_component_bind_suffix` emits the post-create statements for all three handlers.

**Gap 2 — `{#snippet}` children.** Direct snippet children stayed standalone `const foo = ...` declarations, so their parameters lost the contextual `Snippet<[Args]>` types. They are now relocated into the props object and anchored by a `/*Ωignore_startΩ*/const {foo} = $$_svelteself0.$$prop_def;/*Ωignore_endΩ*/` destructure, mirroring `handle_component`. As upstream, the demotion is gated off when `let:` directives or slotted children own the child scope.

Deduplicating the bind suffix also fixes `<svelte:component bind:this={get, set} />`, which previously assigned to the get/set pair instead of calling the setter with the instance.

Known remaining: `handle_svelte_component` still has no snippet-props demotion (gap 2 equivalent); tracked separately.

**Tests:** new `crates/rsvelte_projection/tests/svelte2tsx_svelte_self_bindings_2171.rs` (5 cases, verified failing at HEAD before the fix). Full `cargo test -p rsvelte_projection` and `cargo clippy -p rsvelte_projection --all-targets --all-features -- -D warnings` are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012gQPtKmdY9xwn5fjdwaxK8