### PR TITLE
fix(compiler): match official wording for validator diagnostics

### DIFF
--- a/.changeset/validator-message-wording.md
+++ b/.changeset/validator-message-wording.md
@@ -1,0 +1,14 @@
+---
+"@rsvelte/compiler": patch
+---
+
+Align several validator/a11y diagnostic message bodies with the official compiler. The
+element name and the ARIA role were swapped in
+`a11y_no_interactive_element_to_noninteractive_role` and
+`a11y_no_noninteractive_element_to_interactive_role`; the "did you mean" suggestions for
+unknown ARIA attributes and roles are now full sentences; `a11y_missing_attribute` picks
+its article and joins candidates like upstream; ARIA token / token-list values are quoted
+and joined with `or`; an invalid node placement under the immediate parent is now worded
+"cannot be a (direct) child of" instead of "cannot be a descendant of"; and reactive
+declarations in a module script report that they "only exist" at the top level of the
+instance script.

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/diagnostics_test.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/diagnostics_test.rs
@@ -34,7 +34,7 @@ const WARNING_HANDWRITTEN_CALLS: usize = 7;
 /// FNV-1a 64 of `"<code>\t<message>\n"` for every entry `dump_all()` produces, in the
 /// fixed order below. Pinned from this PR; if it legitimately changes, update it to the
 /// value printed in the assertion failure after confirming the new wording is correct.
-const DIAGNOSTICS_DIGEST: u64 = 0xc8f8_0792_df41_fb82;
+const DIAGNOSTICS_DIGEST: u64 = 0x3dd5_24b4_b8b4_c97d;
 
 fn fnv1a64(bytes: &[u8]) -> u64 {
     let mut hash: u64 = 0xcbf2_9ce4_8422_2325;

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/regular_element.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/regular_element.rs
@@ -942,9 +942,18 @@ pub fn visit<'a, 'b: 'a>(
                     continue;
                 }
 
+                // Upstream routes the immediate parent through
+                // `is_tag_valid_with_parent`, which words it as a child relation.
+                let relation = if !is_direct_parent {
+                    "a descendant of"
+                } else if is_direct_only_disallowed(ancestor_name) {
+                    "a direct child of"
+                } else {
+                    "a child of"
+                };
                 let message = format!(
-                    "`<{}>` cannot be a descendant of `<{}>`",
-                    element.name, ancestor_name
+                    "`<{}>` cannot be {} `<{}>`",
+                    element.name, relation, ancestor_name
                 );
 
                 // Check if there's a block between us and this ancestor

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/shared/a11y/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/shared/a11y/mod.rs
@@ -231,8 +231,8 @@ pub fn check_element(node: &RegularElement, ancestor_names: &[String]) -> Vec<w:
                                 || is_presentation_role(current_role))
                         {
                             warnings.push(w::a11y_no_interactive_element_to_noninteractive_role(
-                                current_role,
                                 &node.name,
+                                current_role,
                             ));
                         }
 
@@ -248,16 +248,16 @@ pub fn check_element(node: &RegularElement, ancestor_names: &[String]) -> Vec<w:
                                 if !exceptions.contains(&current_role) {
                                     warnings.push(
                                         w::a11y_no_noninteractive_element_to_interactive_role(
-                                            current_role,
                                             &node.name,
+                                            current_role,
                                         ),
                                     );
                                 }
                             } else {
                                 warnings.push(
                                     w::a11y_no_noninteractive_element_to_interactive_role(
-                                        current_role,
                                         &node.name,
+                                        current_role,
                                     ),
                                 );
                             }
@@ -949,24 +949,18 @@ fn warn_missing_attribute(
     context: Option<&str>,
 ) {
     let name = context.unwrap_or(element_name);
-    let article = if attributes.len() == 1 {
-        if attributes[0] == "href" || REGEX_STARTS_WITH_VOWEL.is_match(attributes[0]) {
-            "an"
-        } else {
-            "a"
-        }
+    let article = if attributes[0] == "href" || REGEX_STARTS_WITH_VOWEL.is_match(attributes[0]) {
+        "an"
     } else {
-        ""
+        "a"
     };
 
     let sequence = if attributes.len() == 1 {
         attributes[0].to_string()
-    } else if attributes.len() == 2 {
-        format!("{} or {}", attributes[0], attributes[1])
     } else {
         let last = attributes.last().unwrap();
         let rest = &attributes[..attributes.len() - 1];
-        format!("{}, or {}", rest.join(", "), last)
+        format!("{} or {}", rest.join(", "), last)
     };
 
     warnings.push(w::a11y_missing_attribute(name, article, &sequence));
@@ -977,6 +971,12 @@ fn warn_missing_attribute(
 /// - ["a"] -> "a"
 /// - ["a", "b"] -> "a or b"
 /// - ["a", "b", "c"] -> "a, b or c"
+fn quoted_value_list(values: &[&str]) -> String {
+    let quoted: Vec<String> = values.iter().map(|v| format!("\"{}\"", v)).collect();
+    let refs: Vec<&str> = quoted.iter().map(String::as_str).collect();
+    list(&refs, "or")
+}
+
 fn list(strings: &[&str], conjunction: &str) -> String {
     match strings.len() {
         0 => String::new(),
@@ -1059,21 +1059,17 @@ fn validate_aria_attribute_value(
             }
             AriaPropertyType::Token => {
                 if let Some(valid_values) = schema.values {
-                    let values_list: Vec<String> =
-                        valid_values.iter().map(|v| format!("\"{}\"", v)).collect();
                     warnings.push(w::a11y_incorrect_aria_attribute_type_token(
                         name,
-                        &values_list.join(", "),
+                        &quoted_value_list(valid_values),
                     ));
                 }
             }
             AriaPropertyType::TokenList => {
                 if let Some(valid_values) = schema.values {
-                    let values_list: Vec<String> =
-                        valid_values.iter().map(|v| format!("\"{}\"", v)).collect();
                     warnings.push(w::a11y_incorrect_aria_attribute_type_tokenlist(
                         name,
-                        &values_list.join(", "),
+                        &quoted_value_list(valid_values),
                     ));
                 }
             }
@@ -1128,11 +1124,9 @@ fn validate_aria_attribute_value(
                     .iter()
                     .any(|v| v.to_lowercase() == lowercase_value)
                 {
-                    let values_list: Vec<String> =
-                        valid_values.iter().map(|v| format!("\"{}\"", v)).collect();
                     warnings.push(w::a11y_incorrect_aria_attribute_type_token(
                         name,
-                        &values_list.join(", "),
+                        &quoted_value_list(valid_values),
                     ));
                 }
             }
@@ -1149,11 +1143,9 @@ fn validate_aria_attribute_value(
                     })
                     .collect();
                 if !invalid_tokens.is_empty() {
-                    let values_list: Vec<String> =
-                        valid_values.iter().map(|v| format!("\"{}\"", v)).collect();
                     warnings.push(w::a11y_incorrect_aria_attribute_type_tokenlist(
                         name,
-                        &values_list.join(", "),
+                        &quoted_value_list(valid_values),
                     ));
                 }
             }

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/warnings.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/warnings.rs
@@ -70,7 +70,7 @@ diagnostics! {
     attribute_global_event_reference(name: &str) => "You are referencing `globalThis.{}`. Did you forget to declare a variable with that name?\nhttps://svelte.dev/e/attribute_global_event_reference", name;
 
     /// Reactive declaration is invalid placement (not at the top level of an instance script)
-    reactive_declaration_invalid_placement() => "Reactive declarations are only valid at the top level of the instance script";
+    reactive_declaration_invalid_placement() => "Reactive declarations only exist at the top level of the instance script";
 
     // Performance warnings
 
@@ -333,7 +333,7 @@ pub fn state_referenced_locally(
 pub fn a11y_unknown_aria_attribute(attribute: &str, suggestion: Option<&str>) -> AnalysisWarning {
     let message = if let Some(suggestion) = suggestion {
         format!(
-            "Unknown aria attribute 'aria-{}' (did you mean '{}'?)\nhttps://svelte.dev/e/a11y_unknown_aria_attribute",
+            "Unknown aria attribute 'aria-{}'. Did you mean '{}'?\nhttps://svelte.dev/e/a11y_unknown_aria_attribute",
             attribute, suggestion
         )
     } else {
@@ -349,7 +349,7 @@ pub fn a11y_unknown_aria_attribute(attribute: &str, suggestion: Option<&str>) ->
 pub fn a11y_unknown_role(role: &str, suggestion: Option<&str>) -> AnalysisWarning {
     let message = if let Some(suggestion) = suggestion {
         format!(
-            "Unknown role '{}' (did you mean '{}'?)\nhttps://svelte.dev/e/a11y_unknown_role",
+            "Unknown role '{}'. Did you mean '{}'?\nhttps://svelte.dev/e/a11y_unknown_role",
             role, suggestion
         )
     } else {

--- a/crates/rsvelte_core/tests/validator_message_wording.rs
+++ b/crates/rsvelte_core/tests/validator_message_wording.rs
@@ -1,0 +1,100 @@
+//! Validator/a11y diagnostics whose message bodies used to diverge from the
+//! official compiler (argument order, articles, list joining and wording).
+
+use rsvelte_core::{CompileOptions, compile};
+
+fn messages(src: &str) -> Vec<String> {
+    compile(
+        src,
+        CompileOptions {
+            filename: Some("T.svelte".into()),
+            ..Default::default()
+        },
+    )
+    .expect("compile failed")
+    .warnings
+    .into_iter()
+    .map(|w| w.message.lines().next().unwrap_or_default().to_string())
+    .collect()
+}
+
+fn assert_message(src: &str, expected: &str) {
+    let msgs = messages(src);
+    assert!(msgs.iter().any(|m| m == expected), "{msgs:?}");
+}
+
+#[test]
+fn interactive_element_to_noninteractive_role_names_element_first() {
+    assert_message(
+        "<a href=\"test\" role=\"article\">link</a>",
+        "`<a>` cannot have role 'article'",
+    );
+}
+
+#[test]
+fn noninteractive_element_to_interactive_role_names_element_first() {
+    assert_message(
+        "<h1 role=\"tab\">x</h1>",
+        "Non-interactive element `<h1>` cannot have interactive role 'tab'",
+    );
+}
+
+#[test]
+fn unknown_aria_attribute_suggestion_is_a_sentence() {
+    assert_message(
+        "<input type=\"image\" aria-labeledby=\"foo\">",
+        "Unknown aria attribute 'aria-labeledby'. Did you mean 'labelledby'?",
+    );
+}
+
+#[test]
+fn missing_attribute_lists_candidates_without_oxford_comma() {
+    assert_message(
+        "<input type=\"image\" aria-labeledby=\"foo\">",
+        "`<input type=\"image\">` element should have an alt, aria-label or aria-labelledby attribute",
+    );
+}
+
+#[test]
+fn aria_tokenlist_values_are_quoted_and_joined_with_or() {
+    assert_message(
+        "<div aria-relevant=\"foobar\"></div>",
+        "The value of 'aria-relevant' must be a space-separated list of one or more of \"additions\", \"all\", \"removals\" or \"text\"",
+    );
+}
+
+#[test]
+fn aria_token_values_are_quoted_and_joined_with_or() {
+    assert_message(
+        "<div aria-sort=\"foobar\"></div>",
+        "The value of 'aria-sort' must be exactly one of \"ascending\", \"descending\", \"none\" or \"other\"",
+    );
+}
+
+#[test]
+fn invalid_placement_under_the_direct_parent_says_child() {
+    let msgs = messages("<div><form>{#if foo}<form><input /></form>{/if}</form></div>");
+    assert!(
+        msgs.iter()
+            .any(|m| m.starts_with("`<form>` cannot be a child of `<form>`.")),
+        "{msgs:?}"
+    );
+}
+
+#[test]
+fn invalid_placement_under_a_grandparent_says_descendant() {
+    let msgs = messages("<div><form>{#if foo}<div><form><input /></form></div>{/if}</form></div>");
+    assert!(
+        msgs.iter()
+            .any(|m| m.starts_with("`<form>` cannot be a descendant of `<form>`.")),
+        "{msgs:?}"
+    );
+}
+
+#[test]
+fn module_level_reactive_declaration_says_only_exist() {
+    assert_message(
+        "<script module>\n\tlet num = 2;\n\tlet square;\n\t$: square = num * num;\n</script>",
+        "Reactive declarations only exist at the top level of the instance script",
+    );
+}


### PR DESCRIPTION
Fixes validator/a11y diagnostics whose **message bodies** diverged from the official
compiler (spans were already correct). Every wording below was checked character for
character against `submodules/svelte/packages/svelte/src/compiler/warnings.js`,
`src/html-tree-validation.js` and the upstream `warnings.json` fixtures.

## Fixes

1. **`a11y_no_interactive_element_to_noninteractive_role`** — the element name and the role
   were passed in the wrong order, so `<a href role="article">` reported
   "``<article>`` cannot have role 'a'" instead of "``<a>`` cannot have role 'article'".
2. **`a11y_no_noninteractive_element_to_interactive_role`** — the same swap, not previously
   catalogued; both call sites fixed.
3. **`a11y_unknown_aria_attribute` / `a11y_unknown_role`** — the suggestion is a separate
   sentence upstream (`Unknown aria attribute 'aria-labeledby'. Did you mean 'labelledby'?`).
   `unknown_code`'s parenthesized lowercase form is upstream-correct and was left alone.
4. **`a11y_missing_attribute`** — the article (`a`/`an`) and the candidate joining now mirror
   upstream, giving "should have an alt, aria-label or aria-labelledby attribute".
5. **ARIA token / token-list values** — the valid values are quoted and joined through the
   existing upstream-faithful `list(.., "or")` helper (no Oxford comma) instead of a bare
   `", "` join.
6. **`node_invalid_placement` for the immediate parent** — rsvelte's `is_tag_valid_with_parent`
   only implements the `only` rules, so `direct`/`descendant` violations fell into the ancestor
   loop, which hardcoded "cannot be a descendant of". The relation word is now chosen the way
   upstream does: "a direct child of" for `direct`-rule parents, "a child of" for the immediate
   parent otherwise, "a descendant of" only for grandparents and above.
7. **`reactive_declaration_invalid_placement`** — "are only valid" -> "only exist".

## Tests

New `crates/rsvelte_core/tests/validator_message_wording.rs` (9 tests) asserts each message
body, including both the direct-child and the grandparent placement wordings. All divergences
were reproduced before fixing. `validator`, `a11y_validator_fixes`,
`svelte_self_invalid_placement_message_2111` and `compiler_errors` stay green.

## Ratchet

`compatibility/validator-known-failures.json` exists on neither `origin/main` nor this branch
(it ships with the still-open PR #2225), so there was nothing to shrink here. The lint parity
ratchet contains only `svelte/sort-attributes` entries and is unaffected.

Refs #1850

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012gQPtKmdY9xwn5fjdwaxK8
