### PR TITLE
fix(svelte2tsx): trim snippet bodies and route boundary named slots

### DIFF
--- a/.changeset/snippet-body-trim-boundary-slot.md
+++ b/.changeset/snippet-body-trim-boundary-slot.md
@@ -1,0 +1,7 @@
+---
+"@rsvelte/compiler": patch
+"@rsvelte/svelte2tsx": patch
+"@rsvelte/svelte-check": patch
+---
+
+Apply `remove_surrounding_whitespace_nodes` to `{#snippet}` bodies and reproduce upstream's opener gap for the standalone snippet form, and route `<svelte:boundary slot="x">` inside a component through the `$$slot_def[...]` wrapper so the generated TSX matches official svelte2tsx.

--- a/crates/rsvelte_projection/src/svelte2tsx/template/nodes/component_slots.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/template/nodes/component_slots.rs
@@ -247,6 +247,10 @@ pub(crate) fn has_named_slot_children(fragment: &Fragment) -> bool {
             TemplateNode::SvelteElement(el) if slot_attr_static_name(&el.attributes).is_some() => {
                 return true;
             }
+            // `<svelte:boundary slot="name">` is an `Element` upstream too.
+            TemplateNode::SvelteBoundary(el) if slot_attr_static_name(&el.attributes).is_some() => {
+                return true;
+            }
             // `<svelte:component this={expr} slot="name">` and `<svelte:self
             // slot="name">` are `InlineComponent`s in official svelte2tsx
             // (same as a named `<Component slot="name">`), so they forward

--- a/crates/rsvelte_projection/src/svelte2tsx/template/nodes/snippet_block.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/template/nodes/snippet_block.rs
@@ -5,8 +5,8 @@ use crate::svelte2tsx::magic_string::MagicString;
 use crate::svelte2tsx::svelte2tsx::Svelte2TsxOptions;
 
 use crate::svelte2tsx::template::ctx::{Counter, TemplateNodeExt};
-use crate::svelte2tsx::template::utils::expr::get_expression_text;
-use crate::svelte2tsx::template::walk::process_fragment_inplace;
+use crate::svelte2tsx::template::nodes::special_element::process_fragment_trimmed;
+use crate::svelte2tsx::template::utils::expr::{get_expression_range, get_expression_text};
 
 /// Hoist `{#snippet}` blocks to the top of their containing block/element.
 ///
@@ -98,6 +98,30 @@ pub(crate) fn handle_snippet_block_as_component_prop(
     handle_snippet_block_inner(block, source, options, str, counter, true, depth);
 }
 
+/// Upstream reaches the standalone form through `transform()`, which turns the
+/// gap in front of the moved name into one space and then collapses whatever is
+/// left before `}` into a second one — so a snippet whose header ends flush
+/// against `}` gets a single space and every other shape gets two.
+fn opener_pad(block: &SnippetBlock, source: &str) -> &'static str {
+    let anchor = block
+        .parameters
+        .last()
+        .or(Some(&block.expression))
+        .and_then(get_expression_range)
+        .map(|(_, end)| end as usize);
+    let Some(mut kept_end) = anchor else {
+        return " ";
+    };
+    let Some(rel) = source.get(kept_end..).and_then(|rest| rest.find('}')) else {
+        return " ";
+    };
+    let close = kept_end + rel + 1;
+    if kept_end < close - 1 {
+        kept_end += 1;
+    }
+    if close - kept_end >= 2 { "  " } else { " " }
+}
+
 pub(crate) fn handle_snippet_block_inner(
     block: &SnippetBlock,
     source: &str,
@@ -160,20 +184,19 @@ pub(crate) fn handle_snippet_block_inner(
             name_text, params_text
         )
     } else if use_ts_syntax {
-        // Single leading space (the overwrite replaces `{#snippet ` whose leading
-        // `{` becomes the space) — matches official; oxfmt normalises it for
-        // valid output, but a top-level-await component is emitted raw.
         format!(
-            " const {}/*\u{03A9}ignore_position\u{03A9}*/ = {}({})/*\u{03A9}ignore_start\u{03A9}*/: ReturnType<import('svelte').Snippet>/*\u{03A9}ignore_end\u{03A9}*/ => {{ async ()/*\u{03A9}ignore_position\u{03A9}*/ => {{",
-            name_text, type_params_str, params_text
+            "{}const {}/*\u{03A9}ignore_position\u{03A9}*/ = {}({})/*\u{03A9}ignore_start\u{03A9}*/: ReturnType<import('svelte').Snippet>/*\u{03A9}ignore_end\u{03A9}*/ => {{ async ()/*\u{03A9}ignore_position\u{03A9}*/ => {{",
+            opener_pad(block, source),
+            name_text,
+            type_params_str,
+            params_text
         )
     } else {
-        // JSDoc emission uses one fewer leading space (the `/** @returns */`
-        // marker takes the visual slot otherwise occupied by the TS `:` and
-        // its surrounding `/*Ωignore*/` comments).
         format!(
-            " const {}/*\u{03A9}ignore_position\u{03A9}*/ = /** @returns {{ReturnType<import('svelte').Snippet>}} */ ({}) => {{ async ()/*\u{03A9}ignore_position\u{03A9}*/ => {{",
-            name_text, params_text
+            "{}const {}/*\u{03A9}ignore_position\u{03A9}*/ = /** @returns {{ReturnType<import('svelte').Snippet>}} */ ({}) => {{ async ()/*\u{03A9}ignore_position\u{03A9}*/ => {{",
+            opener_pad(block, source),
+            name_text,
+            params_text
         )
     };
     let closing = if as_component_prop {
@@ -191,7 +214,7 @@ pub(crate) fn handle_snippet_block_inner(
         // enclosing component's slot scope, so a `let:`/`slot=` inside the body
         // is a plain attribute rather than a `$$slot_def` consumer.
         let saved_slot = counter.slot_inst.take();
-        process_fragment_inplace(&block.body, source, options, str, counter, 0);
+        process_fragment_trimmed(&block.body.nodes, source, options, str, counter, 0);
         counter.slot_inst = saved_slot;
 
         let body_end = block.body.nodes.last().unwrap().end();

--- a/crates/rsvelte_projection/src/svelte2tsx/template/nodes/special_element.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/template/nodes/special_element.rs
@@ -417,6 +417,23 @@ pub(crate) fn handle_svelte_special_element(
     counter.slot_inst = saved_slot;
 }
 
+/// Walk a fragment whose surrounding whitespace `legacy.js` removes.
+pub(super) fn process_fragment_trimmed(
+    nodes: &[TemplateNode],
+    source: &str,
+    options: &Svelte2TsxOptions,
+    str: &mut MagicString<'_>,
+    counter: &mut Counter,
+    depth: u32,
+) {
+    let whitespace = SurroundingWhitespace::of(nodes);
+    for (index, node) in nodes.iter().enumerate() {
+        process_child(
+            node, index, nodes, whitespace, source, options, str, counter, depth,
+        );
+    }
+}
+
 /// Dispatch one child, applying the `<svelte:boundary>` whitespace surgery: a
 /// dropped node is never visited (so its source survives verbatim) and a
 /// trimmed one is blanked from its shortened `data`.

--- a/crates/rsvelte_projection/tests/svelte2tsx_snippet_boundary_2191.rs
+++ b/crates/rsvelte_projection/tests/svelte2tsx_snippet_boundary_2191.rs
@@ -1,0 +1,64 @@
+use rsvelte_projection::svelte2tsx::{Svelte2TsxOptions, svelte2tsx};
+
+fn convert(src: &str) -> String {
+    let opts = Svelte2TsxOptions {
+        filename: "Input.svelte".to_string(),
+        is_ts_file: false,
+        ..Default::default()
+    };
+    svelte2tsx(src, opts).expect("svelte2tsx ok").code
+}
+
+fn assert_contains(src: &str, expected: &str) {
+    let code = convert(src);
+    assert!(
+        code.contains(expected),
+        "source {src:?}\nexpected fragment:\n{expected}\nactual:\n{code}"
+    );
+}
+
+/// `legacy.js` strips the snippet body's surrounding whitespace nodes, so
+/// `{#snippet foo()}  text  {/snippet}` keeps a single space around the body.
+#[test]
+fn snippet_body_surrounding_whitespace_is_removed() {
+    assert_contains(
+        "{#snippet foo(bar)}  text  {/snippet}\n",
+        "=> { async ()/*\u{03A9}ignore_position\u{03A9}*/ => { };return __sveltets_2_any(0)};",
+    );
+    assert_contains(
+        "{#snippet foo()}\n{/snippet}\n",
+        "=> { async ()/*\u{03A9}ignore_position\u{03A9}*/ => {\n};return __sveltets_2_any(0)};",
+    );
+}
+
+/// Upstream's `transform()` leaves one space in front of the moved name and a
+/// second one only when something else remains before `}`.
+#[test]
+fn snippet_opener_gap_matches_upstream() {
+    assert_contains("{#snippet foo(bar)}  text  {/snippet}\n", "=> { const foo");
+    assert_contains("{#snippet foo()}  text  {/snippet}\n", "=> {  const foo");
+    assert_contains("{#snippet foo() }  text  {/snippet}\n", "=> {  const foo");
+    assert_contains("{#snippet foo(bar) }\n{/snippet}\n", "=> {  const foo");
+}
+
+#[test]
+fn boundary_with_slot_attribute_uses_slot_def() {
+    assert_contains(
+        "<Comp>\n<svelte:boundary slot=\"a\">hi</svelte:boundary>\n</Comp>\n",
+        "const $$_pmoC0 = new $$_pmoC0C({ target: __sveltets_2_any(), props: {children:() => { return __sveltets_2_any(0); },}});\n {const {/*\u{03A9}ignore_start\u{03A9}*/$$_$$/*\u{03A9}ignore_end\u{03A9}*/,} = $$_pmoC0.$$slot_def[\"a\"];$$_$$;{ svelteHTML.createElement(\"svelte:boundary\", { });  }}\n Comp}",
+    );
+    assert_contains(
+        "<Comp>\n<svelte:boundary slot=\"a\" let:x>hi</svelte:boundary>\n</Comp>\n",
+        "{const {/*\u{03A9}ignore_start\u{03A9}*/$$_$$/*\u{03A9}ignore_end\u{03A9}*/,x,} = $$_pmoC0.$$slot_def[\"a\"];$$_$$;{ svelteHTML.createElement(\"svelte:boundary\", {  });  }}",
+    );
+}
+
+/// Without a static `slot=` the boundary stays a plain element — no instance
+/// binding, no wrapper.
+#[test]
+fn boundary_without_slot_attribute_is_unchanged() {
+    assert_contains(
+        "<Comp>\n<svelte:boundary>hi</svelte:boundary>\n</Comp>\n",
+        "new $$_pmoC0C({ target: __sveltets_2_any(), props: {children:() => { return __sveltets_2_any(0); },}});\n { svelteHTML.createElement(\"svelte:boundary\", {});  }\n Comp}",
+    );
+}


### PR DESCRIPTION
Closes #2191 (items 2 and 3; item 1 landed in #2220).

## Item 2 — `{#snippet}` body whitespace + opener gap

Upstream svelte2tsx consumes the Svelte-4 legacy AST, and `legacy.js` applies
`removeSurroundingWhitespaceNodes` to a `SnippetBlock` body just like it does for
key/each/if blocks and `<svelte:boundary>`. rsvelte walked the body untrimmed, so the
generated arrow body kept whitespace upstream had dropped.

The standalone form also reaches its header through upstream's `transform()`, which turns the
gap in front of the moved name into one space and then collapses whatever is left before `}`
into a second one. So `{#snippet foo(bar)}` gets one leading space while `{#snippet foo()}`
and `{#snippet foo(bar) }` get two. The implicit-prop (component child) path bypasses
`transform()` and is deliberately untouched.

## Item 3 — `<svelte:boundary slot="x">` inside a component

`has_named_slot_children` enumerated every element/component kind except `SvelteBoundary`.
That predicate is the gate that forces the parent component's `const $$_pmoC0 = new
$$_pmoC0C(…)` instance binding and routes children through
`process_component_children_with_slots` (which sets `counter.slot_inst`). A boundary carrying
a static `slot=` therefore never entered a slot context, so the already-correct
`named_slot_let_block` / `build_named_slot_element_attrs` code in `special_element.rs` was
dead: the `$$slot_def["x"]` wrapper was missing and the `slot` attribute leaked into the
element's attribute object. Adding the one arm fixes all three symptoms; `special_element.rs`
needed no behavioural change.

A boundary without a static `slot=` is unaffected (covered by a control test).

## Verification

Expected output for every case was taken from real upstream `svelte2tsx@0.7.59` running
against `svelte@5.56.8` (`{ filename: 'Input.svelte', isTsFile: false, mode: 'ts', namespace:
'html', version: '5' }`), and the new
`crates/rsvelte_projection/tests/svelte2tsx_snippet_boundary_2191.rs` asserts those byte-exact
fragments. `cargo test -p rsvelte_projection` and `cargo clippy -p rsvelte_projection
--all-targets --all-features -- -D warnings` are clean; no ratchet entries added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012gQPtKmdY9xwn5fjdwaxK8
