### PR TITLE
test(compat-corpus): fail loudly on empty manifests and excess unparseable files

### DIFF
--- a/crates/rsvelte_formatter/tests/svelte_dev_corpus.rs
+++ b/crates/rsvelte_formatter/tests/svelte_dev_corpus.rs
@@ -295,6 +295,18 @@ fn svelte_dev_corpus_parity() {
         }
     }
 
+    // Unparseable samples are excused from the parity gate below, so an
+    // unbounded count would let a parser regression that breaks nearly every
+    // sample look green here. Ceiling is well above the current baseline (0)
+    // to leave room for normal corpus drift.
+    const MAX_UNPARSEABLE: usize = 20;
+    assert!(
+        unparseable.len() <= MAX_UNPARSEABLE,
+        "{} unparseable sample(s) exceeds the ceiling of {MAX_UNPARSEABLE} — this usually \
+         means a parser regression, not isolated embedded-code gaps",
+        unparseable.len(),
+    );
+
     if !failures.is_empty() {
         // Hard gate: every sample must match the oxfmt(svelte:true) oracle.
         // FMT_CORPUS_SHOW raises the per-run cap for burndown analysis.

--- a/scripts/compat-corpus/collect.mjs
+++ b/scripts/compat-corpus/collect.mjs
@@ -181,3 +181,11 @@ for (const src of SOURCES) {
 manifest.sort((a, b) => (a.id < b.id ? -1 : 1));
 fs.writeFileSync(path.join(CORPUS, 'manifest.json'), JSON.stringify(manifest, null, '\t') + '\n');
 console.log(`[collect] total: ${manifest.length} corpus entries -> ${path.relative(ROOT, OUT)}`);
+
+// A near-empty manifest would make every downstream verify.mjs comparison
+// pass vacuously instead of catching a real regression.
+const MIN_MANIFEST_ENTRIES = 1000;
+if (manifest.length < MIN_MANIFEST_ENTRIES) {
+	console.error(`[collect] only ${manifest.length} corpus entries collected (expected >= ${MIN_MANIFEST_ENTRIES})`);
+	process.exit(2);
+}

--- a/scripts/compat-corpus/svelte2tsx-verify.mjs
+++ b/scripts/compat-corpus/svelte2tsx-verify.mjs
@@ -80,6 +80,16 @@ const manifest = JSON.parse(fs.readFileSync(path.join(CORPUS, 'manifest.json'), 
 	(e) => e.kind === 'component'
 );
 
+// A near-empty manifest (partial checkout, failed collect) would make the
+// comparison below pass vacuously instead of catching a real regression.
+const MIN_MANIFEST_ENTRIES = 1000;
+if (manifest.length < MIN_MANIFEST_ENTRIES) {
+	console.error(
+		`[svelte2tsx-verify] only ${manifest.length} component entries in manifest.json (expected >= ${MIN_MANIFEST_ENTRIES}); run \`node scripts/compat-corpus/collect.mjs\` first`,
+	);
+	process.exit(2);
+}
+
 // map.json carries the generated line lengths the mappings were built against,
 // so this gate never reads index.tsx — which oxfmt rewrites in place, leaving it
 // inconsistent with the map on any later re-run.

--- a/scripts/compat-corpus/verify.mjs
+++ b/scripts/compat-corpus/verify.mjs
@@ -167,6 +167,16 @@ if (!NO_FMT) {
 
 const manifest = JSON.parse(fs.readFileSync(path.join(CORPUS, 'manifest.json'), 'utf8'));
 
+// A near-empty manifest (partial checkout, failed collect) would make the
+// comparison below pass vacuously instead of catching a real regression.
+const MIN_MANIFEST_ENTRIES = 1000;
+if (manifest.length < MIN_MANIFEST_ENTRIES) {
+	console.error(
+		`[verify] only ${manifest.length} entries in manifest.json (expected >= ${MIN_MANIFEST_ENTRIES}); run \`node scripts/compat-corpus/collect.mjs\` first`,
+	);
+	process.exit(2);
+}
+
 const counts = {
 	match: 0,
 	'error-parity': 0,


### PR DESCRIPTION
Refs #1791