### PR TITLE
fix(formatter): keep prose fill running across prettier-ignore'd inline nodes

### DIFF
--- a/.changeset/prettier-ignore-inline-fill.md
+++ b/.changeset/prettier-ignore-inline-fill.md
@@ -1,0 +1,9 @@
+---
+"@rsvelte/fmt": patch
+---
+
+Keep prose fill running across `<!-- prettier-ignore -->`'d inline nodes. An ignore comment
+glued directly to a single-line inline node (e.g. `text <!-- prettier-ignore --><b>a  b</b>
+more text`) used to end the prose run, so the whole surrounding paragraph was emitted on one
+unwrapped line. The pair is now treated as a single verbatim atom of the fill: its own source
+is still preserved byte-for-byte, but the text around it reflows normally.

--- a/crates/rsvelte_formatter/src/collapse/doc_build.rs
+++ b/crates/rsvelte_formatter/src/collapse/doc_build.rs
@@ -274,6 +274,26 @@ pub(super) fn content_tag_breakable_doc(
     }]))
 }
 
+/// Source of the `[<!-- prettier-ignore -->, ignored node]` pair at `i` when the
+/// comment is glued directly to a single-line node: prettier keeps filling the
+/// surrounding prose across such a pair, printing only its source verbatim.
+pub(super) fn inline_ignore_atom<'a>(
+    out: &'a str,
+    nodes: &[TemplateNode],
+    i: usize,
+) -> Option<&'a str> {
+    let comment = nodes.get(i)?;
+    if !crate::prettier_ignore::is_prettier_ignore_comment(comment) {
+        return None;
+    }
+    let ignored = nodes.get(i + 1)?;
+    if node_end(comment) != node_start(ignored) {
+        return None;
+    }
+    let span = out.get(node_start(comment) as usize..node_end(ignored) as usize)?;
+    (!span.contains('\n')).then_some(span)
+}
+
 // `use_word_first`: when true, a trailing text node that follows a non-void
 // inline element and starts with a space is converted to word-first format.
 // Only pass `true` from `try_fill_run` where the element fits flat in context.
@@ -291,15 +311,39 @@ pub(super) fn build_children_doc_nodes(
     // inline element carries a leading `line` (prettier's
     // `handleWhitespaceOfPrevTextNode`).
     let mut ws_prev = false;
+    // Set after an inline `<!-- prettier-ignore -->` atom so its ignored node is
+    // not printed a second time.
+    let mut skip_ignored = false;
+    // Set after an inline atom so the following text keeps filling in the same
+    // `Fill` — the atom is one of its (unbreakable) words, not a sibling doc.
+    let mut merge_into_fill = false;
 
     for (i, node) in nodes.iter().enumerate() {
+        if skip_ignored {
+            skip_ignored = false;
+            continue;
+        }
+        if let Some(atom) = inline_ignore_atom(out, nodes, i) {
+            let part = Doc::Text(atom.to_string());
+            match docs.last_mut() {
+                Some(Doc::Fill(parts)) => parts.push(part),
+                _ if ws_prev => docs.push(Doc::Fill(vec![Doc::Line, part])),
+                _ => docs.push(Doc::Fill(vec![part])),
+            }
+            ws_prev = false;
+            skip_ignored = true;
+            merge_into_fill = true;
+            continue;
+        }
+        let merge_prev_fill = std::mem::take(&mut merge_into_fill);
         match node {
             TemplateNode::Text(t) => {
                 ws_prev = false;
                 let txt = out.get(t.start as usize..t.end as usize)?;
                 let trim_left = i == 0;
                 let trim_right = i == n - 1;
-                let prev_inline = i > 0 && is_inline_regular_element(&nodes[i - 1]);
+                let prev_inline =
+                    i > 0 && !merge_prev_fill && is_inline_regular_element(&nodes[i - 1]);
                 let next_inline = i + 1 < n && is_inline_regular_element(&nodes[i + 1]);
                 let mut tl = trim_left;
                 let mut tr = trim_right;
@@ -453,11 +497,13 @@ pub(super) fn build_children_doc_nodes(
                     && prev_is_phrasing_inline
                     && next_is_not_element
                     && txt.chars().filter(|&c| c == '\n').count() == 1;
-                if use_soft_break {
+                if use_soft_break && !merge_prev_fill {
                     docs.push(Doc::Line);
                 } else {
                     let parts = split_text_to_docs(txt, tl, tr);
-                    if ws_only {
+                    if let (true, Some(Doc::Fill(prev))) = (merge_prev_fill, docs.last_mut()) {
+                        prev.extend(parts);
+                    } else if ws_only {
                         // Whitespace-only separator (between mustaches / atoms): emit
                         // the bare `line`(s) so they break with the surrounding
                         // element group (prettier's `splitTextToDocs` returns a bare

--- a/crates/rsvelte_formatter/src/collapse/fill.rs
+++ b/crates/rsvelte_formatter/src/collapse/fill.rs
@@ -103,18 +103,27 @@ pub(super) fn fill_inline_runs(
     while i < nodes.len() {
         // A `<!-- prettier-ignore -->`d node must never join a run (it — and its
         // whole subtree — stays verbatim): treat it as a run boundary so it's
-        // skipped here and left for `collect`'s own per-node guard.
-        if crate::prettier_ignore::preceded_by_prettier_ignore(nodes, i)
-            || !is_run_member(out, &nodes[i])
+        // skipped here and left for `collect`'s own per-node guard. The one
+        // exception is an ignore comment glued to an inline node mid-prose: that
+        // pair joins the run as a single verbatim atom.
+        if inline_ignore_atom(out, nodes, i).is_none()
+            && (crate::prettier_ignore::preceded_by_prettier_ignore(nodes, i)
+                || !is_run_member(out, &nodes[i]))
         {
             i += 1;
             continue;
         }
         let mut j = i;
-        while j < nodes.len()
-            && is_run_member(out, &nodes[j])
-            && !crate::prettier_ignore::preceded_by_prettier_ignore(nodes, j)
-        {
+        while j < nodes.len() {
+            if inline_ignore_atom(out, nodes, j).is_some() {
+                j += 2;
+                continue;
+            }
+            if !is_run_member(out, &nodes[j])
+                || crate::prettier_ignore::preceded_by_prettier_ignore(nodes, j)
+            {
+                break;
+            }
             j += 1;
         }
         if let Some(edit) = try_fill_run(
@@ -450,15 +459,25 @@ pub(super) fn try_fill_mixed(
     let whole = out.get(s..e)?;
     // Must be mixed (at least one non-text child) and entirely inline.
     let mut has_non_text = false;
-    for n in &fragment.nodes {
-        if !matches!(n, TemplateNode::Text(_)) {
-            has_non_text = true;
-            // A comment always sits on its own line(s) — never fill it inline
-            // with the surrounding prose. Leave the whole fragment to the
-            // indent pass (which keeps the comment on its own line).
-            if matches!(n, TemplateNode::Comment(_)) || !is_inline_node(n) {
-                return None;
-            }
+    let mut ignored_idx = None;
+    for (i, n) in fragment.nodes.iter().enumerate() {
+        if matches!(n, TemplateNode::Text(_)) {
+            continue;
+        }
+        has_non_text = true;
+        // An ignore comment glued to an inline node is one verbatim atom of the
+        // prose, so the fill flows across it; any OTHER comment sits on its own
+        // line(s) — never fill it inline with the surrounding prose, leave the
+        // whole fragment to the indent pass (which keeps it on its own line).
+        if inline_ignore_atom(out, &fragment.nodes, i).is_some() {
+            ignored_idx = Some(i + 1);
+            continue;
+        }
+        if ignored_idx == Some(i) {
+            continue;
+        }
+        if matches!(n, TemplateNode::Comment(_)) || !is_inline_node(n) {
+            return None;
         }
     }
     if !has_non_text {

--- a/crates/rsvelte_formatter/tests/prettier_ignore.rs
+++ b/crates/rsvelte_formatter/tests/prettier_ignore.rs
@@ -64,6 +64,51 @@ fn ignore_before_overflowing_open_tag_stays_verbatim() {
     assert_parity(source, expected);
 }
 
+// An ignore comment glued to an inline node is one verbatim atom of the prose,
+// so the fill must keep running across it instead of ending the run there.
+// Asserted structurally, not byte-exactly: rsvelte's wrap columns for prose
+// around ANY inline child still differ from the prettier oracle, and that gap
+// reproduces with a plain `<b>` and no ignore comment at all.
+fn assert_fill_flows_across(source: &str, atom: &str, first_word: &str, last_word: &str) {
+    let out = format(source, &FormatOptions::default()).expect("format ok");
+    assert!(
+        out.contains(atom),
+        "ignored node must stay verbatim:\n{out}"
+    );
+    assert!(
+        !out.lines()
+            .any(|l| l.contains(first_word) && l.contains(last_word)),
+        "prose must reflow across the ignored node:\n{out}"
+    );
+    assert_eq!(
+        format(&out, &FormatOptions::default()).expect("format ok"),
+        out,
+        "formatting must be idempotent"
+    );
+}
+
+#[test]
+fn prose_wraps_across_ignored_inline_node() {
+    let source = "<p>alpha beta gamma delta epsilon zeta eta theta iota kappa lambda mu nu xi omicron pi rho sigma tau upsilon <!-- prettier-ignore --><b>x   y</b> tail words here that keep going on and on for a while longer</p>\n";
+    assert_fill_flows_across(
+        source,
+        "<!-- prettier-ignore --><b>x   y</b>",
+        "alpha",
+        "longer",
+    );
+}
+
+#[test]
+fn prose_after_ignored_inline_node_wraps() {
+    let source = "<p>Lead in text <!-- prettier-ignore --><span   class=\"x\">kept</span> then a very long stretch of prose that must be wrapped by the fill algorithm at the print width.</p>\n";
+    assert_fill_flows_across(
+        source,
+        "<!-- prettier-ignore --><span   class=\"x\">kept</span>",
+        "Lead",
+        "width.",
+    );
+}
+
 #[test]
 fn ignore_before_component_with_wrapped_open_tag_stays_verbatim() {
     let source = r#"<!-- prettier-ignore -->


### PR DESCRIPTION
Refs #2068