### PR TITLE
fix(compiler): honour analysis-phase svelte-ignore for await instrumentation

### DIFF
--- a/.changeset/await-reactivity-loss-ignore-stack.md
+++ b/.changeset/await-reactivity-loss-ignore-stack.md
@@ -1,0 +1,13 @@
+---
+"@rsvelte/compiler": patch
+---
+
+fix(compiler): honour analysis-phase `svelte-ignore` for await instrumentation.
+The dev-mode `$.track_reactivity_loss` rewrite recognised
+`svelte-ignore await_reactivity_loss` by scanning the lines above the `await`,
+so it missed every form upstream honours through the analysis-phase ignore
+stack: a comment on an enclosing node, a comment on a multi-line statement whose
+`await` lands on a later line, and a same-line block comment. The suppression is
+now computed the way upstream's acorn comment attachment plus `ignore_map` does
+— a leading comment binds to the outermost node that starts after it and the
+whole subtree of that node inherits the ignore.

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/ast_state_transform.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/ast_state_transform.rs
@@ -236,6 +236,8 @@ struct StateVarCollector<'a, 's> {
     /// When inside a shorthand property like `{ foo }`, the IdentifierReference
     /// for `foo` needs special handling: `{ foo: $.get(foo) }`.
     in_shorthand_property: bool,
+    /// Subtrees carrying a `svelte-ignore await_reactivity_loss`.
+    await_ignore_ranges: super::await_reactivity_loss_ast::AwaitIgnoreRanges,
 
     // --- Phase A-2 fields ---
     /// Prop source variables that need getter/setter wrapping: `prop` -> `prop()`.
@@ -362,6 +364,7 @@ impl<'a, 's> StateVarCollector<'a, 's> {
             replacements_sorted: true,
             scoped_vars: vec![FxHashSet::default()],
             in_shorthand_property: false,
+            await_ignore_ranges: Default::default(),
             prop_source_vars: prop_source_set,
             non_bindable_prop_vars: non_bindable_set,
             store_sub_vars: store_sub_set,
@@ -2001,11 +2004,18 @@ impl<'a, 's> StateVarCollector<'a, 's> {
     }
 
     fn is_await_reactivity_loss_ignored(&self, offset: u32) -> bool {
-        super::await_reactivity_loss_ast::await_reactivity_loss_ignored(
+        self.await_ignore_ranges.contains(offset)
+    }
+
+    fn collect_await_ignore_ranges(&mut self, program: &Program<'_>) {
+        if !self.dev || !super::await_reactivity_loss_ast::source_has_await(self.source) {
+            return;
+        }
+        self.await_ignore_ranges = super::await_reactivity_loss_ast::collect_await_ignore_ranges(
+            program,
             self.source,
-            offset,
             self.is_runes,
-        )
+        );
     }
 
     /// Walk every argument of a `CallExpression` so inner state-var refs
@@ -4550,6 +4560,7 @@ fn collect_state_var_replacements(
         config.exported_names,
     );
     collector.semantic = semantic_ret.as_ref().map(|ret| &ret.semantic);
+    collector.collect_await_ignore_ranges(program);
     collector.visit_program(program);
     collector.replacements
 }
@@ -4587,6 +4598,7 @@ fn collect_state_var_replacements_without_semantic_scan(
         config.analysis,
         config.exported_names,
     );
+    collector.collect_await_ignore_ranges(program);
     for statement in &program.body {
         if !projected_statement_is_type_only(statement) {
             collector.visit_statement(statement);

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/await_reactivity_loss_ast.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/await_reactivity_loss_ast.rs
@@ -7,6 +7,7 @@
 //! that every one of those scripts walks, so the rewrite itself is one piece of
 //! logic here too; only the batch it rides in differs per script kind.
 
+use oxc_ast::AstKind;
 use oxc_ast::ast::*;
 use oxc_ast_visit::Visit;
 use oxc_ast_visit::walk;
@@ -39,38 +40,74 @@ fn is_track_reactivity_loss_call(expr: &Expression<'_>) -> bool {
         && matches!(&member.object, Expression::Identifier(id) if id.name == "$")
 }
 
-/// True when the statement enclosing `offset` is preceded by a `svelte-ignore`
-/// comment naming `await_reactivity_loss`. Upstream reads this off the
-/// analysis-phase ignore stack; these passes rewrite source spans, so they read
-/// the same comment back out of the script text.
-pub(super) fn await_reactivity_loss_ignored(source: &str, offset: u32, is_runes: bool) -> bool {
-    // Start from the top of the await's own line: the statement text to its
-    // left is not a comment and would end the scan immediately.
-    let offset = source[..offset as usize].rfind('\n').map_or(0, |nl| nl + 1);
-    let before = &source[..offset];
-    for line in before.lines().rev() {
-        let line = line.trim();
-        if line.is_empty() {
-            continue;
-        }
-        let Some(comment) = line
-            .strip_prefix("//")
-            .or_else(|| line.strip_prefix("/*").map(|c| c.trim_end_matches("*/")))
-        else {
-            // The first non-comment line above is the start of the
-            // statement itself; anything earlier cannot annotate it.
-            return false;
-        };
-        // A run of comments can carry several `svelte-ignore` lines, so keep
-        // looking when this one names other codes.
-        if crate::compiler::phases::phase2_analyze::utils::extract_svelte_ignore(comment, is_runes)
+/// Source spans whose whole subtree carries a `svelte-ignore
+/// await_reactivity_loss`, mirroring upstream's analysis-phase ignore stack:
+/// a leading comment binds to the outermost node starting after it, and every
+/// descendant of that node inherits the ignore — so one interval per annotated
+/// node is all the stack ever expresses.
+#[derive(Default)]
+pub(super) struct AwaitIgnoreRanges(Vec<(u32, u32)>);
+
+impl AwaitIgnoreRanges {
+    pub(super) fn contains(&self, offset: u32) -> bool {
+        self.0
             .iter()
-            .any(|c| c == "await_reactivity_loss")
-        {
-            return true;
+            .any(|&(start, end)| offset >= start && offset < end)
+    }
+}
+
+pub(super) fn collect_await_ignore_ranges(
+    program: &Program<'_>,
+    source: &str,
+    is_runes: bool,
+) -> AwaitIgnoreRanges {
+    let mut scan = IgnoreScan {
+        comments: &program.comments,
+        cursor: 0,
+        source,
+        is_runes,
+        ranges: Vec::new(),
+    };
+    scan.visit_program(program);
+    AwaitIgnoreRanges(scan.ranges)
+}
+
+struct IgnoreScan<'src, 'c> {
+    comments: &'c [Comment],
+    cursor: usize,
+    source: &'src str,
+    is_runes: bool,
+    ranges: Vec<(u32, u32)>,
+}
+
+impl<'a> Visit<'a> for IgnoreScan<'_, '_> {
+    fn enter_node(&mut self, kind: AstKind<'a>) {
+        let span = kind.span();
+        let mut ignored = false;
+        // Pre-order arrival makes every still-unconsumed comment before this
+        // node's start one of its leading comments, as upstream's acorn
+        // attachment pass computes them.
+        while let Some(comment) = self.comments.get(self.cursor) {
+            if comment.span.start >= span.start {
+                break;
+            }
+            self.cursor += 1;
+            let content = comment.content_span();
+            let text = &self.source[content.start as usize..content.end as usize];
+            if crate::compiler::phases::phase2_analyze::utils::extract_svelte_ignore(
+                text,
+                self.is_runes,
+            )
+            .iter()
+            .any(|code| code == "await_reactivity_loss")
+            {
+                ignored = true;
+            }
+        }
+        if ignored {
+            self.ranges.push((span.start, span.end));
         }
     }
-    false
 }
 
 /// Collect the `await X` → `(await $.track_reactivity_loss(X))()` edits from a
@@ -84,7 +121,7 @@ pub(super) fn collect_await_reactivity_loss_edits(
 ) -> Vec<Edit> {
     let mut collector = AwaitCollector {
         source,
-        is_runes,
+        ignored: collect_await_ignore_ranges(program, source, is_runes),
         edits: Vec::new(),
     };
     collector.visit_program(program);
@@ -93,7 +130,7 @@ pub(super) fn collect_await_reactivity_loss_edits(
 
 struct AwaitCollector<'src> {
     source: &'src str,
-    is_runes: bool,
+    ignored: AwaitIgnoreRanges,
     edits: Vec<Edit>,
 }
 
@@ -101,9 +138,7 @@ impl<'a, 'src> Visit<'a> for AwaitCollector<'src> {
     fn visit_await_expression(&mut self, expr: &AwaitExpression<'a>) {
         walk::walk_await_expression(self, expr);
 
-        if is_track_reactivity_loss_call(&expr.argument)
-            || await_reactivity_loss_ignored(self.source, expr.span.start, self.is_runes)
-        {
+        if is_track_reactivity_loss_call(&expr.argument) || self.ignored.contains(expr.span.start) {
             return;
         }
 

--- a/crates/rsvelte_core/tests/module_dev_await_instrumentation.rs
+++ b/crates/rsvelte_core/tests/module_dev_await_instrumentation.rs
@@ -120,6 +120,68 @@ fn svelte_ignore_suppresses_the_wrap() {
     }
 }
 
+/// Upstream attaches a leading comment to the outermost node that starts after
+/// it and inherits the ignore through that node's whole subtree, so a comment on
+/// an enclosing declaration suppresses every `await` inside it.
+#[test]
+fn svelte_ignore_on_an_ancestor_node_suppresses_the_wrap() {
+    let out = compile_svelte_js(
+        "// svelte-ignore await_reactivity_loss\nexport async function f() {\n\tconst r = await g();\n\treturn r;\n}",
+        true,
+    );
+    assert!(
+        !out.contains("$.track_reactivity_loss"),
+        "expected the ancestor-level ignore to suppress the wrap. Got:\n{out}"
+    );
+}
+
+/// The `await` lands several lines below the comment because the annotated
+/// statement spans multiple lines.
+#[test]
+fn svelte_ignore_on_a_multiline_statement_suppresses_the_wrap() {
+    let out = compile_svelte_js(
+        "export async function f() {\n\t// svelte-ignore await_reactivity_loss\n\tconst r = [\n\t\tawait g()\n\t];\n\treturn r;\n}",
+        true,
+    );
+    assert!(
+        !out.contains("$.track_reactivity_loss"),
+        "expected the multi-line statement's ignore to suppress the wrap. Got:\n{out}"
+    );
+}
+
+#[test]
+fn same_line_block_comment_svelte_ignore_suppresses_the_wrap() {
+    for src in [
+        "export async function f() {\n\tconst r = /* svelte-ignore await_reactivity_loss */ await g();\n\treturn r;\n}",
+        "export async function f() {\n\t/* svelte-ignore await_reactivity_loss */ const r = await g();\n\treturn r;\n}",
+    ] {
+        let out = compile_svelte_js(src, true);
+        assert!(
+            !out.contains("$.track_reactivity_loss"),
+            "expected the same-line block comment to suppress the wrap. In:\n{src}\nGot:\n{out}"
+        );
+    }
+}
+
+/// The same three forms through the runes instance-script path, which reaches
+/// the rewrite from `ast_state_transform` rather than a tail batch.
+#[test]
+fn instance_script_honours_the_ancestor_and_block_comment_forms() {
+    for script in [
+        "// svelte-ignore await_reactivity_loss\n\tasync function f() {\n\t\treturn await g();\n\t}",
+        "\tasync function f() {\n\t\t// svelte-ignore await_reactivity_loss\n\t\tconst r = [\n\t\t\tawait g()\n\t\t];\n\t\treturn r;\n\t}",
+        "\tasync function f() {\n\t\tconst r = /* svelte-ignore await_reactivity_loss */ await g();\n\t\treturn r;\n\t}",
+    ] {
+        let src =
+            format!("<script>\n\tlet count = $state(0);\n{script}\n</script>\n\n<p>{{count}}</p>");
+        let out = compile_component(&src, true);
+        assert!(
+            !out.contains("$.track_reactivity_loss"),
+            "expected the ignore to suppress the wrap. In:\n{src}\nGot:\n{out}"
+        );
+    }
+}
+
 #[test]
 fn svelte_ignore_naming_other_codes_does_not_suppress() {
     let out = compile_svelte_js(


### PR DESCRIPTION
Refs #2090 (item 3 only; items 1/2 landed in #2175 / #2180, item 4 is out of scope).

Dev-mode `$.track_reactivity_loss` instrumentation recognised
`svelte-ignore await_reactivity_loss` by scanning source lines upward from the
`await`, which only ever matched a line comment sitting directly above the
`await`'s own line. Upstream instead reads the analysis-phase ignore stack:
acorn attaches a leading comment to the outermost node that starts after it, and
`ignore_map` lets every descendant of that node inherit the ignore.

The scan is replaced by that same computation, done over the oxc parse the pass
already has: a pre-order `enter_node` walk consumes `program.comments` in source
order, and the span of any node whose leading comments name the code becomes an
ignored interval. Because the ignore is inherited by the whole subtree, one
interval per annotated node expresses everything the stack does, so no stack is
needed at the query site. Both consumers are switched over — the batched tail
collector (`<script module>` / `.svelte.(js|ts)` / legacy instance) and the runes
instance-script path in `ast_state_transform`.

## Sub-cases covered

All three named in the issue reproduced on `main` and are fixed here:

- **ancestor-node comments** — the comment sits on an enclosing node (e.g. above
  `export async function f() { … await g() … }`).
- **multi-line statements** — the comment leads the statement but the `await`
  lands on a later line (e.g. `const r = [\n\tawait g()\n];`).
- **same-line block comments** — both `const r = /* svelte-ignore … */ await g();`
  (attaches to the `AwaitExpression` itself) and
  `/* svelte-ignore … */ const r = await g();` (attaches to the declaration).

Each is asserted through both the module path and the runes instance-script path
in `crates/rsvelte_core/tests/module_dev_await_instrumentation.rs`; the existing
assertions (plain line comment, comma form, other-code non-suppression,
idempotence, non-dev) are unchanged and still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012gQPtKmdY9xwn5fjdwaxK8