### PR TITLE
fix(svelte2tsx): demote snippet children to props when let: is present

### DIFF
--- a/.changeset/svelte2tsx-let-snippet-demotion.md
+++ b/.changeset/svelte2tsx-let-snippet-demotion.md
@@ -1,6 +1,7 @@
 ---
 "@rsvelte/compiler": patch
 "@rsvelte/svelte2tsx": patch
+"@rsvelte/svelte-check": patch
 ---
 
 An inline component's direct `{#snippet}` child is now demoted to a component

--- a/.changeset/svelte2tsx-let-snippet-demotion.md
+++ b/.changeset/svelte2tsx-let-snippet-demotion.md
@@ -1,0 +1,13 @@
+---
+"@rsvelte/compiler": patch
+"@rsvelte/svelte2tsx": patch
+---
+
+An inline component's direct `{#snippet}` child is now demoted to a component
+prop even when the component also carries a `let:` directive or has other
+named-slot children, matching official svelte2tsx. rsvelte previously gated
+the snippet-to-prop relocation off whenever `let:` (or a named-slot child) was
+present and fell back to emitting the snippet as a standalone block-scoped
+`const foo = …` declaration instead — official always demotes the snippet and
+independently emits the `let:` / named-slot `$$slot_def` destructure alongside
+it. Applies to named components, `<svelte:component>`, and `<svelte:self>`.

--- a/crates/rsvelte_projection/src/svelte2tsx/template/nodes/component_slots.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/template/nodes/component_slots.rs
@@ -331,6 +331,7 @@ pub(crate) fn process_component_children_with_slots(
     node_end: u32,
     inst_var: &str,
     has_lets: bool,
+    open_default_slot_block: bool,
     source: &str,
     options: &Svelte2TsxOptions,
     str: &mut MagicString<'_>,
@@ -340,10 +341,18 @@ pub(crate) fn process_component_children_with_slots(
     // The component's OWN `let:` directives open a single `$$slot_def.default`
     // block before the first child; it stays open across every child (named-slot
     // children nest their own `$$slot_def["…"]` block inside it) and is closed
-    // after the last one.
+    // after the last one. When a direct `{#snippet}` child was already demoted to
+    // a component prop, the caller emits this opening text itself right after the
+    // relocated prop (mirrors official's `snippetPropVariablesDeclaration` then
+    // `defaultSlotLetTransformation` ordering) — signalled via `open_default_slot_block`
+    // — since inserting it at `first_node.start()` here would land inside the
+    // moved snippet chunk if that snippet happens to be the fragment's first node.
     let mut prev_end: Option<u32> = None;
 
-    if has_lets && let Some(first_node) = fragment.nodes.first() {
+    if has_lets
+        && open_default_slot_block
+        && let Some(first_node) = fragment.nodes.first()
+    {
         str.append_left_fmt(
             first_node.start(),
             format_args!(
@@ -355,6 +364,15 @@ pub(crate) fn process_component_children_with_slots(
     }
 
     for node in &fragment.nodes {
+        // A direct `{#snippet}` child is always demoted to a component prop by
+        // the caller (mirrors official's unconditional `parentComponent` check),
+        // never processed as slot-scoped content, so it takes no part here beyond
+        // marking its end for the block-close position below.
+        if matches!(node, TemplateNode::SnippetBlock(s) if s.start < s.end) {
+            prev_end = Some(node.end());
+            continue;
+        }
+
         let is_named_slot = match node {
             TemplateNode::RegularElement(el) => slot_attr_static_name(&el.attributes).is_some(),
             TemplateNode::Component(child_comp) => {

--- a/crates/rsvelte_projection/src/svelte2tsx/template/nodes/inline_component.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/template/nodes/inline_component.rs
@@ -199,17 +199,16 @@ pub(crate) fn handle_component(
     // passed as *implicit props* (`props: { name: (params) => … }`), not as
     // standalone `const name = …` declarations, so that TypeScript both
     // satisfies required snippet props and contextually types the snippet's
-    // parameters from the prop's `Snippet<[T]>` type (#780). This relocation is
-    // only wired through the simple-children path; when the component also uses
-    // `let:` / named slots the children go through `process_component_children_with_slots`,
-    // which owns its own block scoping, so the snippets stay standalone there.
-    let use_snippet_props =
-        !(has_lets || children_have_named_slots || children_have_default_slot_lets)
-            && comp
-                .fragment
-                .nodes
-                .iter()
-                .any(|n| matches!(n, TemplateNode::SnippetBlock(_)));
+    // parameters from the prop's `Snippet<[T]>` type (#780). Official demotes a
+    // snippet child unconditionally (`parentComponent` in `htmlxtojsx_v2/index.ts`
+    // checks only "is this a direct child of an InlineComponent", never `let:` /
+    // named-slot presence), so this relocation always applies alongside — not
+    // instead of — the `let:` / named-slot children processing below (#2171).
+    let use_snippet_props = comp
+        .fragment
+        .nodes
+        .iter()
+        .any(|n| matches!(n, TemplateNode::SnippetBlock(s) if s.start < s.end));
 
     // An instance variable is needed when:
     // - there are on: directives
@@ -364,23 +363,16 @@ pub(crate) fn handle_component(
 
     // Handle children with slot awareness
     let mut deferred_slot_close = false;
-    if has_lets || children_have_named_slots || children_have_default_slot_lets {
-        // Process children with slot scoping
-        deferred_slot_close = process_component_children_with_slots(
-            &comp.attributes,
-            &comp.fragment,
-            comp.end,
-            &inst_var,
-            has_lets,
-            source,
-            options,
-            str,
-            counter,
-            depth + 1,
-        );
-    } else if use_snippet_props {
-        // Process children, turning each direct `{#snippet}` child into an
-        // implicit prop relocated into the still-open `props: { … }` object.
+    if use_snippet_props {
+        // Every direct `{#snippet}` child is demoted to an implicit prop
+        // relocated into the still-open `props: { … }` object, unconditionally —
+        // mirrors official, which never gates this on `let:` / named-slot
+        // presence (#2171). Any remaining (non-snippet) children still need the
+        // `let:` / named-slot slot-scoping below, so they're left untouched here
+        // when that's needed and handed to `process_component_children_with_slots`
+        // afterward instead of being processed inline.
+        let needs_slot_pass =
+            has_lets || children_have_named_slots || children_have_default_slot_lets;
         //
         // `move_range(s.start, s.end, anchor)` detaches the transformed snippet
         // chunk and re-links it immediately before the chunk that *starts* at
@@ -409,7 +401,7 @@ pub(crate) fn handle_component(
                     str.move_range(s.start, s.end, anchor);
                 }
                 last_snippet_end = Some(s.end);
-            } else {
+            } else if !needs_slot_pass {
                 // Children of a component are at depth+1 (this component is the ancestor)
                 process_node_inplace(node, source, options, str, counter, depth + 1);
             }
@@ -430,7 +422,23 @@ pub(crate) fn handle_component(
                 inst_var
             )
         };
-        let closing = format!("{trailer_lit}{prop_def_suffix}");
+        // When the component also has its own `let:` directives, the
+        // `$$slot_def.default` destructure is appended right here (mirrors
+        // official's `snippetPropVariablesDeclaration` immediately followed by
+        // `defaultSlotLetTransformation`), rather than left to
+        // `process_component_children_with_slots` — which would otherwise try to
+        // insert it at the fragment's first child, landing inside the (now moved)
+        // snippet chunk if that snippet was the first child.
+        let own_default_let_open = if has_lets {
+            format!(
+                "{{const {{/*\u{03A9}ignore_start\u{03A9}*/$$_$$/*\u{03A9}ignore_end\u{03A9}*/,{}}} = {}.$$slot_def.default;$$_$$;",
+                build_let_destructure_string(&comp.attributes, source),
+                inst_var
+            )
+        } else {
+            String::new()
+        };
+        let closing = format!("{trailer_lit}{prop_def_suffix}{own_default_let_open}");
         // Close the props object right after the last relocated snippet.
         match last_snippet_end {
             Some(end) => {
@@ -442,6 +450,39 @@ pub(crate) fn handle_component(
                 str.prepend_right(opening_tag_end, &closing);
             }
         }
+        if needs_slot_pass {
+            // Process the remaining (non-snippet) children with slot scoping;
+            // the default-slot-let block was already opened above, so tell it
+            // not to open another one.
+            deferred_slot_close = process_component_children_with_slots(
+                &comp.attributes,
+                &comp.fragment,
+                comp.end,
+                &inst_var,
+                has_lets,
+                false,
+                source,
+                options,
+                str,
+                counter,
+                depth + 1,
+            );
+        }
+    } else if has_lets || children_have_named_slots || children_have_default_slot_lets {
+        // Process children with slot scoping
+        deferred_slot_close = process_component_children_with_slots(
+            &comp.attributes,
+            &comp.fragment,
+            comp.end,
+            &inst_var,
+            has_lets,
+            true,
+            source,
+            options,
+            str,
+            counter,
+            depth + 1,
+        );
     } else {
         // Simple children processing: this component is now an ancestor → depth+1.
         process_fragment_inplace(&comp.fragment, source, options, str, counter, depth + 1);
@@ -622,16 +663,15 @@ pub(crate) fn handle_svelte_component(
     // (named-slot children anywhere in blocks, or default-slot `let:` receivers).
     let children_have_named_slots = has_named_slot_children(&comp.fragment);
     let children_have_default_slot_lets = has_default_slot_let_children(&comp.fragment);
-    // Direct `{#snippet}` children become implicit props (mirroring
-    // `handle_component`), but only on the simple-children path — the slot paths
-    // own their own block scoping.
-    let use_snippet_props =
-        !(has_lets_scomp || children_have_named_slots || children_have_default_slot_lets)
-            && comp
-                .fragment
-                .nodes
-                .iter()
-                .any(|n| matches!(n, TemplateNode::SnippetBlock(_)));
+    // Direct `{#snippet}` children become implicit props unconditionally
+    // (mirroring `handle_component` — official never gates this on `let:` /
+    // named-slot presence, #2171), applying alongside whichever children-path
+    // (slot-scoped or simple) the rest of the children take.
+    let use_snippet_props = comp
+        .fragment
+        .nodes
+        .iter()
+        .any(|n| matches!(n, TemplateNode::SnippetBlock(s) if s.start < s.end));
     let needs_inst = has_events
         || has_lets_scomp
         || has_binds
@@ -676,14 +716,20 @@ pub(crate) fn handle_svelte_component(
 
     // Slot let-forwarding: `{const { $$_$$, prop, } = inst.$$slot_def.default; $$_$$;`
     // Mirrors `defaultSlotLetTransformation` in the JS reference's
-    // `htmlxtojsx_v2/nodes/InlineComponent.ts`.
-    if has_lets_scomp {
-        let destructure = build_let_destructure_string(&comp.attributes, source);
-        let _ = write!(
-            opener,
+    // `htmlxtojsx_v2/nodes/InlineComponent.ts`. When the snippet-props path also
+    // applies, this text is appended after the relocated props close instead (see
+    // below) so it lands after — not inside — the still-open props object.
+    let own_default_let_open = if has_lets_scomp {
+        format!(
             "{{const {{/*\u{03A9}ignore_start\u{03A9}*/$$_$$/*\u{03A9}ignore_end\u{03A9}*/,{}}} = {}.$$slot_def.default;$$_$$;",
-            destructure, inst_var
-        );
+            build_let_destructure_string(&comp.attributes, source),
+            inst_var
+        )
+    } else {
+        String::new()
+    };
+    if !use_snippet_props {
+        opener.push_str(&own_default_let_open);
     }
 
     str.overwrite(comp.start, opening_tag_end, &opener);
@@ -693,21 +739,16 @@ pub(crate) fn handle_svelte_component(
     // component's (`$$slot_def.default` / `$$slot_def["x"]` blocks); the
     // component's OWN `let:` block is already in `opener` above, so the helper
     // is told not to emit it again.
-    let deferred_slot_close = if children_have_named_slots || children_have_default_slot_lets {
-        process_component_children_with_slots(
-            &comp.attributes,
-            &comp.fragment,
-            comp.end,
-            &inst_var,
-            false,
-            source,
-            options,
-            str,
-            counter,
-            depth + 1,
-        )
-    } else if use_snippet_props {
-        let prev_slot = counter.slot_inst.replace(inst_var.clone());
+    let deferred_slot_close = if use_snippet_props {
+        // A direct `{#snippet}` child is always demoted to a prop, regardless of
+        // `let:` / named-slot children (#2171); any remaining children still need
+        // slot-scoping, handled below instead of inline when that applies.
+        let needs_slot_pass = children_have_named_slots || children_have_default_slot_lets;
+        let prev_slot = if needs_slot_pass {
+            None
+        } else {
+            Some(counter.slot_inst.replace(inst_var.clone()))
+        };
         let mut anchor = opening_tag_end;
         let mut last_snippet_end: Option<u32> = None;
         let mut snippet_names: Vec<String> = Vec::new();
@@ -726,11 +767,13 @@ pub(crate) fn handle_svelte_component(
                     str.move_range(s.start, s.end, anchor);
                 }
                 last_snippet_end = Some(s.end);
-            } else {
+            } else if !needs_slot_pass {
                 process_node_inplace(node, source, options, str, counter, depth + 1);
             }
         }
-        counter.slot_inst = prev_slot;
+        if let Some(prev) = prev_slot {
+            counter.slot_inst = prev;
+        }
         let prop_def_suffix = if snippet_names.is_empty() {
             String::new()
         } else {
@@ -740,7 +783,7 @@ pub(crate) fn handle_svelte_component(
                 inst_var
             )
         };
-        let closing = format!("{trailer_lit}{prop_def_suffix}");
+        let closing = format!("{trailer_lit}{prop_def_suffix}{own_default_let_open}");
         match last_snippet_end {
             Some(end) => {
                 str.append_left(end, &closing);
@@ -749,7 +792,37 @@ pub(crate) fn handle_svelte_component(
                 str.prepend_right(opening_tag_end, &closing);
             }
         }
-        false
+        if needs_slot_pass {
+            process_component_children_with_slots(
+                &comp.attributes,
+                &comp.fragment,
+                comp.end,
+                &inst_var,
+                false,
+                true,
+                source,
+                options,
+                str,
+                counter,
+                depth + 1,
+            )
+        } else {
+            false
+        }
+    } else if children_have_named_slots || children_have_default_slot_lets {
+        process_component_children_with_slots(
+            &comp.attributes,
+            &comp.fragment,
+            comp.end,
+            &inst_var,
+            false,
+            true,
+            source,
+            options,
+            str,
+            counter,
+            depth + 1,
+        )
     } else {
         // Mark the slot context so `slot="x"` children nested in control-flow
         // blocks still lower to `inst.$$slot_def["x"]`.
@@ -925,15 +998,15 @@ pub(crate) fn handle_svelte_self(
     // `$$slot_def`, which forces the `const $$_svelteselfN = …` form.
     let children_have_named_slots = has_named_slot_children(&el.fragment);
     let children_have_default_slot_lets = has_default_slot_let_children(&el.fragment);
-    // Direct `{#snippet}` children become implicit props, but only on the simple
-    // children path — the slot paths own their own block scoping.
-    let use_snippet_props =
-        !(has_lets || children_have_named_slots || children_have_default_slot_lets)
-            && el
-                .fragment
-                .nodes
-                .iter()
-                .any(|n| matches!(n, TemplateNode::SnippetBlock(_)));
+    // Direct `{#snippet}` children become implicit props unconditionally
+    // (mirroring `handle_component` — official never gates this on `let:` /
+    // named-slot presence, #2171), applying alongside whichever children-path
+    // (slot-scoped or simple) the rest of the children take.
+    let use_snippet_props = el
+        .fragment
+        .nodes
+        .iter()
+        .any(|n| matches!(n, TemplateNode::SnippetBlock(s) if s.start < s.end));
     let has_bindings = el
         .attributes
         .iter()
@@ -993,17 +1066,23 @@ pub(crate) fn handle_svelte_self(
     // `let:` directives become a `{const { $$_$$, name, ... } = inst.$$slot_def.default; $$_$$;`
     // block right after the create call, with a matching `}` at the end.
     // Mirrors the JS reference's `defaultSlotLetTransformation` in
-    // `htmlxtojsx_v2/nodes/InlineComponent.ts`.
-    if has_lets {
+    // `htmlxtojsx_v2/nodes/InlineComponent.ts`. When the snippet-props path also
+    // applies, this text is appended after the relocated props close instead (see
+    // below) so it lands after — not inside — the still-open props object.
+    let own_default_let_open = if has_lets {
         let destructure = build_let_destructure_string(&el.attributes, source);
         let inst_name = var_name
             .as_ref()
             .expect("let: directive requires an instance variable name");
-        let _ = write!(
-            opener,
+        format!(
             "{{const {{/*\u{03A9}ignore_start\u{03A9}*/$$_$$/*\u{03A9}ignore_end\u{03A9}*/,{}}} = {}.$$slot_def.default;$$_$$;",
             destructure, inst_name
-        );
+        )
+    } else {
+        String::new()
+    };
+    if !use_snippet_props {
+        opener.push_str(&own_default_let_open);
     }
 
     if !has_closing_tag {
@@ -1022,27 +1101,19 @@ pub(crate) fn handle_svelte_self(
     // take the same lowering as a named component's (`$$slot_def.default` /
     // `$$slot_def["x"]` blocks); this node's OWN `let:` block is already in
     // `opener` above, so the helper is told not to emit it again.
-    let deferred_slot_close = if children_have_named_slots || children_have_default_slot_lets {
-        let inst_var = var_name
-            .as_deref()
-            .expect("slot-consuming children require an instance variable name");
-        process_component_children_with_slots(
-            &el.attributes,
-            &el.fragment,
-            el.end,
-            inst_var,
-            false,
-            source,
-            options,
-            str,
-            counter,
-            depth + 1,
-        )
-    } else if use_snippet_props {
+    let deferred_slot_close = if use_snippet_props {
+        // A direct `{#snippet}` child is always demoted to a prop, regardless of
+        // `let:` / named-slot children (#2171); any remaining children still need
+        // slot-scoping, handled below instead of inline when that applies.
         let inst_var = var_name
             .as_deref()
             .expect("snippet props require an instance variable name");
-        counter.slot_inst = var_name.clone();
+        let needs_slot_pass = children_have_named_slots || children_have_default_slot_lets;
+        if needs_slot_pass {
+            counter.slot_inst = None;
+        } else {
+            counter.slot_inst = var_name.clone();
+        }
         // A snippet already sitting at the anchor is in place — moving it would
         // be a forbidden self-move — so the anchor just advances past it.
         let mut anchor = opening_tag_end;
@@ -1061,7 +1132,7 @@ pub(crate) fn handle_svelte_self(
                     str.move_range(s.start, s.end, anchor);
                 }
                 last_snippet_end = Some(s.end);
-            } else {
+            } else if !needs_slot_pass {
                 process_node_inplace(node, source, options, str, counter, depth + 1);
             }
         }
@@ -1077,7 +1148,7 @@ pub(crate) fn handle_svelte_self(
                 inst_var
             )
         };
-        let closing = format!("{trailer_lit}{prop_def_suffix}");
+        let closing = format!("{trailer_lit}{prop_def_suffix}{own_default_let_open}");
         match last_snippet_end {
             Some(end) => {
                 str.append_left(end, &closing);
@@ -1086,7 +1157,40 @@ pub(crate) fn handle_svelte_self(
                 str.prepend_right(opening_tag_end, &closing);
             }
         }
-        false
+        if needs_slot_pass {
+            process_component_children_with_slots(
+                &el.attributes,
+                &el.fragment,
+                el.end,
+                inst_var,
+                false,
+                true,
+                source,
+                options,
+                str,
+                counter,
+                depth + 1,
+            )
+        } else {
+            false
+        }
+    } else if children_have_named_slots || children_have_default_slot_lets {
+        let inst_var = var_name
+            .as_deref()
+            .expect("slot-consuming children require an instance variable name");
+        process_component_children_with_slots(
+            &el.attributes,
+            &el.fragment,
+            el.end,
+            inst_var,
+            false,
+            true,
+            source,
+            options,
+            str,
+            counter,
+            depth + 1,
+        )
     } else {
         // Still publish the slot context (as `handle_svelte_component` does) so
         // a descendant that reaches for `$$slot_def` without being detected

--- a/crates/rsvelte_projection/tests/svelte2tsx_svelte_component_snippet_props_2228.rs
+++ b/crates/rsvelte_projection/tests/svelte2tsx_svelte_component_snippet_props_2228.rs
@@ -1,8 +1,9 @@
 //! `<svelte:component>` is an inline component upstream, so its direct
 //! `{#snippet}` children are demoted to implicit props anchored by a
 //! `$$prop_def` destructure — exactly like a named component's and
-//! `<svelte:self>`'s. The `let:` / named-slot paths keep their own block
-//! scoping and must not demote.
+//! `<svelte:self>`'s. This demotion is unconditional: it applies alongside —
+//! not instead of — `let:` / named-slot children, which keep their own block
+//! scoping independently (#2171).
 
 use rsvelte_projection::svelte2tsx::{Svelte2TsxOptions, svelte2tsx};
 
@@ -46,24 +47,35 @@ fn svelte_component_multiple_snippet_children_become_props() {
 }
 
 #[test]
-fn svelte_component_slot_lets_keep_the_slot_path() {
-    // `let:` scoping owns the children, so snippets stay plain block children.
+fn svelte_component_let_snippet_is_still_demoted_to_a_prop() {
+    // Official demotes a `{#snippet}` child to a component prop even when `let:`
+    // is present — the two transformations are independent and both apply (#2171).
     let code = convert(
         "<script>\n let C;\n</script>\n<svelte:component this={C} let:item>\n{#snippet foo(a)}<p>{a}</p>{/snippet}\n{item}\n</svelte:component>\n",
     );
     assert!(
-        !code.contains("$$prop_def"),
-        "the let: path must not demote snippets, got:\n{code}"
+        code.contains("const {foo} = $$_tnenopmoc_etlevs0.$$prop_def;"),
+        "the let: path must still demote snippets, got:\n{code}"
+    );
+    assert!(
+        code.contains("$$_tnenopmoc_etlevs0.$$slot_def.default;"),
+        "the let: destructure must still be emitted, got:\n{code}"
     );
 }
 
 #[test]
-fn svelte_component_named_slot_children_keep_the_slot_path() {
+fn svelte_component_named_slot_children_still_demote_snippets() {
+    // A snippet sibling of a named-slot child is still demoted to a prop; the
+    // named-slot child keeps its own `$$slot_def["x"]` block independently (#2171).
     let code = convert(
         "<script>\n let C;\n</script>\n<svelte:component this={C}>\n<div slot=\"x\" let:item>{item}</div>\n{#snippet foo(a)}<p>{a}</p>{/snippet}\n</svelte:component>\n",
     );
     assert!(
-        !code.contains("$$prop_def"),
-        "the named-slot path must not demote snippets, got:\n{code}"
+        code.contains("const {foo} = $$_tnenopmoc_etlevs0.$$prop_def;"),
+        "the named-slot path must still demote snippets, got:\n{code}"
+    );
+    assert!(
+        code.contains("$$_tnenopmoc_etlevs0.$$slot_def[\"x\"];"),
+        "the named-slot destructure must still be emitted, got:\n{code}"
     );
 }

--- a/crates/rsvelte_projection/tests/svelte2tsx_svelte_self_bindings_2171.rs
+++ b/crates/rsvelte_projection/tests/svelte2tsx_svelte_self_bindings_2171.rs
@@ -68,13 +68,33 @@ fn svelte_self_snippet_children_become_props() {
 }
 
 #[test]
-fn svelte_self_slot_lets_keep_the_slot_path() {
-    // `let:` scoping owns the children, so snippets stay plain block children.
+fn svelte_self_let_snippet_is_still_demoted_to_a_prop() {
+    // Official demotes a `{#snippet}` child to a component prop even when `let:`
+    // is present — the two transformations are independent and both apply (#2171).
     let code = convert(
         "<svelte:self let:item>\n{#snippet foo(a)}<p>{a}</p>{/snippet}\n{item}\n</svelte:self>\n",
     );
     assert!(
-        !code.contains("$$prop_def"),
-        "the let: path must not demote snippets, got:\n{code}"
+        code.contains("const {foo} = $$_svelteself0.$$prop_def;"),
+        "the let: path must still demote snippets, got:\n{code}"
+    );
+    assert!(
+        code.contains("$$_svelteself0.$$slot_def.default;"),
+        "the let: destructure must still be emitted, got:\n{code}"
+    );
+}
+
+#[test]
+fn named_component_let_snippet_is_demoted_to_a_prop() {
+    // Not a `<svelte:self>`-only gap: any inline component's `{#snippet}` child
+    // is demoted to a prop even with `let:` present, mirroring official (#2171).
+    let code = convert("<Foo let:item>\n{#snippet foo(a)}<p>{a}</p>{/snippet}\n{item}\n</Foo>\n");
+    assert!(
+        code.contains("const {foo} = $$_ooF0.$$prop_def;"),
+        "the let: path must still demote snippets, got:\n{code}"
+    );
+    assert!(
+        code.contains("$$_ooF0.$$slot_def.default;"),
+        "the let: destructure must still be emitted, got:\n{code}"
     );
 }


### PR DESCRIPTION
## Summary

- Official svelte2tsx demotes a direct `{#snippet}` child of an inline component to a component prop **unconditionally** — the `parentComponent` check in `htmlxtojsx_v2/index.ts` only tests "is this a direct child of an `InlineComponent`", never `let:` / named-slot presence (`InlineComponent.ts`'s `performTransformation` emits `snippetPropVariablesDeclaration` and `defaultSlotLetTransformation`/named-slot destructures together, not either/or).
- rsvelte instead gated the snippet-to-prop relocation (`use_snippet_props`) off whenever the component had `let:` directives or named-slot/default-slot-let children, falling back to a standalone block-scoped `const foo = …` declaration for the snippet in that case — diverging from official.
- Found while verifying #2171 — the existing test `svelte_self_slot_lets_keep_the_slot_path` asserted this divergent (wrong) behavior as intended; it's updated (renamed to `svelte_self_let_snippet_is_still_demoted_to_a_prop`) along with the equivalent `<svelte:component>` tests in `svelte2tsx_svelte_component_snippet_props_2228.rs`, and a new named-component case is added.
- Fixes named components, `<svelte:component>`, and `<svelte:self>` alike (all three share `process_component_children_with_slots`), including the combined "snippet + named-slot sibling" case, verified byte-for-byte against a real `svelte2tsx@0.7.59` + `svelte@5.56.8` oracle.

## Test plan

- [x] Reproduced the gap against a real `svelte2tsx@0.7.59` oracle before implementing (not the repo's own tests, which encoded the divergence)
- [x] `cargo test -p rsvelte_projection --test svelte2tsx_svelte_self_bindings_2171`
- [x] `cargo test -p rsvelte_projection --test svelte2tsx_svelte_component_snippet_props_2228`
- [x] `cargo test -p rsvelte_projection --test svelte2tsx_fixtures` (253/253)
- [x] Plus 16 other targeted svelte2tsx snippet/slot/let test files (component_snippet_children, snippet_component_prop, snippet_param_type, snippet_prop_def_anchor, snippet_boundary_2191, slot_let_1232, slot_let_forwarding_2105, svelte_component_snippet_props_2228, svelte_self_on_calls_2171, svelte_self_slot_parent_2160, let_directive_stream, slot_bind_counter, svelte_component_named_slot_2136, svelte_component_slot_2103, slot_computed_key_2182, slot_summary, slots_reflection_2161, slots_type_override_2156)
- [x] `cargo clippy -p rsvelte_projection --all-targets --all-features -- -D warnings`
- [x] Re-ran `node scripts/compat-corpus/svelte2tsx-verify.mjs --update-baseline` (full corpus, submodules freshly populated) — no diff; `svelte2tsx-known-failures.json` / `svelte2tsx-map-known-failures.json` stayed at 0 known failures
- [x] `UPDATE_S2TSX_FIXTURES_BASELINE=1 cargo test -p rsvelte_projection --test svelte2tsx_fixtures` — no diff to `svelte2tsx-fixtures-known-failures.json`

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

https://claude.ai/code/session_012gQPtKmdY9xwn5fjdwaxK8