### PR TITLE
test: make more silently-vacuous tests fail loudly

### DIFF
--- a/crates/rsvelte_check/tests/svelte_check_warning_filter.rs
+++ b/crates/rsvelte_check/tests/svelte_check_warning_filter.rs
@@ -87,6 +87,7 @@ fn run_without_sidecar(dir: &Path, args: &[&str]) -> Output {
 #[test]
 fn function_warning_filter_drops_matching_warning() {
     if !node_available() {
+        eprintln!("[warning-filter] no `node` on $PATH; skipping.");
         return;
     }
     let dir = workspace("drop");
@@ -113,6 +114,7 @@ fn function_warning_filter_drops_matching_warning() {
 #[test]
 fn falsy_non_false_return_drops_warning() {
     if !node_available() {
+        eprintln!("[warning-filter] no `node` on $PATH; skipping.");
         return;
     }
     // Svelte uses a truthiness test (`if (!warning_filter(w)) return;`), so a
@@ -142,6 +144,7 @@ fn falsy_non_false_return_drops_warning() {
 #[test]
 fn function_warning_filter_keeps_non_matching_warning() {
     if !node_available() {
+        eprintln!("[warning-filter] no `node` on $PATH; skipping.");
         return;
     }
     let dir = workspace("keep");
@@ -216,6 +219,7 @@ fn missing_sidecar_fails_open_with_note() {
 #[test]
 fn broken_config_fails_open() {
     if !node_available() {
+        eprintln!("[warning-filter] no `node` on $PATH; skipping.");
         return;
     }
     // The static probe sees a function-shaped warningFilter, but the config
@@ -240,6 +244,7 @@ fn broken_config_fails_open() {
 #[test]
 fn warning_filter_wins_over_compiler_warnings_error_promotion() {
     if !node_available() {
+        eprintln!("[warning-filter] no `node` on $PATH; skipping.");
         return;
     }
     // A warning the filter rejects must be *gone* before `--compiler-warnings
@@ -338,7 +343,10 @@ const FAKE_SIDECAR: &str = r#"
 
 #[test]
 fn apply_drops_rejected_warning_keeps_others() {
-    let Some(node) = node_bin() else { return };
+    let Some(node) = node_bin() else {
+        eprintln!("[warning-filter] no `node` on $PATH; skipping.");
+        return;
+    };
     let (env, script) = env_with_script(node, FAKE_SIDECAR, DEFAULT_TIMEOUT);
     let mut diags = vec![warn("drop_me"), warn("keep_me")];
     apply(&env, Path::new("svelte.config.js"), &mut diags);
@@ -349,7 +357,10 @@ fn apply_drops_rejected_warning_keeps_others() {
 
 #[test]
 fn apply_hung_sidecar_times_out_and_keeps_all() {
-    let Some(node) = node_bin() else { return };
+    let Some(node) = node_bin() else {
+        eprintln!("[warning-filter] no `node` on $PATH; skipping.");
+        return;
+    };
     let (env, script) = env_with_script(
         node,
         "setInterval(() => {}, 1000);",
@@ -363,7 +374,10 @@ fn apply_hung_sidecar_times_out_and_keeps_all() {
 
 #[test]
 fn apply_malformed_response_keeps_all() {
-    let Some(node) = node_bin() else { return };
+    let Some(node) = node_bin() else {
+        eprintln!("[warning-filter] no `node` on $PATH; skipping.");
+        return;
+    };
     let (env, script) = env_with_script(
         node,
         "process.stdout.write('not framed json');",
@@ -377,7 +391,10 @@ fn apply_malformed_response_keeps_all() {
 
 #[test]
 fn apply_leaves_non_svelte_and_error_diagnostics_untouched() {
-    let Some(node) = node_bin() else { return };
+    let Some(node) = node_bin() else {
+        eprintln!("[warning-filter] no `node` on $PATH; skipping.");
+        return;
+    };
     // Even a filter that drops everything must not remove errors / ts diags.
     let sidecar = r#"
         const M = '\x00<<rsvelte-warning-filter>>\x00';

--- a/crates/rsvelte_esrap/tests/esrap_samples.rs
+++ b/crates/rsvelte_esrap/tests/esrap_samples.rs
@@ -124,6 +124,11 @@ fn esrap_samples_match() {
     let mut passed = 0;
     let samples = collect_samples(&dir);
     let total = samples.len();
+    assert!(
+        total > 0,
+        "no esrap samples found under {} — upstream layout changed?",
+        dir.display()
+    );
 
     for sample in &samples {
         if let Some(only) = &only


### PR DESCRIPTION
Refs #1791

Next sweep after #2234 (which fixed empty-manifest guards in `verify.mjs`/`collect.mjs`/`svelte2tsx-verify.mjs` and an unparseable-count ceiling in `svelte_dev_corpus.rs`). This PR hunts for more tests that report PASS while checking nothing.

## Candidates investigated → proven vacuous? → fix applied

| Candidate | Proven vacuous? | Fix applied |
|---|---|---|
| `crates/rsvelte_check/tests/svelte_check_warning_filter.rs` — 9 tests (`function_warning_filter_drops_matching_warning`, `falsy_non_false_return_drops_warning`, `function_warning_filter_keeps_non_matching_warning`, `broken_config_fails_open`, `warning_filter_wins_over_compiler_warnings_error_promotion`, `apply_drops_rejected_warning_keeps_others`, `apply_hung_sidecar_times_out_and_keeps_all`, `apply_malformed_response_keeps_all`, `apply_leaves_non_svelte_and_error_diagnostics_untouched`) silently `return` when `node` is absent | **Yes** — stripped `node` from `$PATH` and re-ran: all 9 report `ok` with zero output, no skip signal anywhere | Added `eprintln!("[warning-filter] no \`node\` on $PATH; skipping.")` before each early return, matching the convention already used by `svelte_check_companion_800.rs` in the same crate. Re-ran with `node` present: no spurious skip lines, all still pass. |
| `crates/rsvelte_esrap/tests/esrap_samples.rs::esrap_samples_match` — no floor on the discovered sample count before iterating | **Yes** — temporarily emptied `submodules/esrap/test/samples`: the test printed `[esrap_samples] 0/0 matched (0 known-failing)` and reported `ok` (also reproduced non-destructively via `ESRAP_SAMPLES_ONLY=<bogus>`, which drove the post-filter count to `0/97 matched` and still passed) | Added `assert!(total > 0, "no esrap samples found under {} — upstream layout changed?", dir.display())` right after collecting samples (before the `ESRAP_SAMPLES_ONLY` debug filter is applied, so the debug knob still works). Re-ran with the samples dir emptied: now panics with the new message. Restored the samples dir and re-ran: passes cleanly (100 samples). |
| `scripts/compat-corpus/fmt-verify.mjs` — checked for a missing manifest-size floor (item 9 in the issue) | **No — already fixed** | `fmt-verify.mjs:72-76` already has a `included.length < 1000` guard; no change needed. |
| `crates/rsvelte_core/tests/sourcemaps.rs` `STRICT_SOURCEMAPS` env var (item 6 in the issue) | **No — already resolved** | `STRICT_SOURCEMAPS` no longer exists in the codebase (removed in earlier cleanup); the file now uses a grow-only `MIN_SOURCEMAP_FIXTURES` floor instead. |
| `crates/rsvelte_check/tests/svelte_check_companion_800.rs`, `svelte_check_golden.rs`, `svelte_check_shim_drift.rs`, `rsvelte_fmt/tests/embed.rs`, `rsvelte_fmt/tests/cli/daemon.rs`, `rsvelte_fmt/tests/cli/tailwind.rs` — other tool-availability no-op gates | **No** | Each already prints a loud skip/`eprintln!` line (and `shim_drift.rs` additionally panics under `CI`), so they already satisfy "skip is defensible, silent pass is not." Left untouched. |
| `crates/rsvelte/tests/facade_projection_api.rs` / `runtime_api.rs` — `changed.iter().all(|key| key != &default)` | **No** | `changed` is a fixed-length array literal (10 hardcoded entries), not data that can degrade to empty at runtime. Not vacuous. |
| `crates/rsvelte_check/tests/svelte_check_warning_filter.rs::apply_leaves_non_svelte_and_error_diagnostics_untouched` — `assert!(diags.iter().all(...))` on possibly-empty `diags` | **No** | Immediately preceded by `assert_eq!(diags.len(), 2)`, which already anchors the collection to a non-trivial size. |

## Verification

- `cargo fmt` — clean, only the two touched files.
- `cargo clippy -p rsvelte_check --all-targets --all-features -- -D warnings` — clean.
- `cargo clippy -p rsvelte_esrap --all-targets --all-features -- -D warnings` — clean.
- Each fix was verified to actually fire: forced the degenerate condition (no `node` on `PATH`; emptied esrap samples dir), confirmed the new signal/panic appears, then reverted and confirmed normal runs still pass with no regressions.
- Did not touch any `compatibility/*known-failures*` ratchet.

No changeset needed (`test:` prefix bypasses the gate; no user-visible behavior change).
