### PR TITLE
fix(formatter): break the hugged <code> open tag inside <pre> like the oracle

### DIFF
--- a/.changeset/pre-child-hug-open-tag-break.md
+++ b/.changeset/pre-child-hug-open-tag-break.md
@@ -1,0 +1,12 @@
+---
+"@rsvelte/fmt": patch
+---
+
+Break the hugged open tag of an attribute-free child element inside `<pre>` /
+`<textarea>` when its content spans multiple lines, matching prettier. For
+`<pre><code><span>a</span>\n…</code></pre>` the oracle drops the `>` of `<code>`
+onto its own line (`<pre><code\n    ><span>a</span>`) because the first child is
+leading-space-sensitive and borrows the parent's `>`; rsvelte only did this for
+child tags that had attributes, so any attribute-free `<code>` stayed glued. The
+break is still skipped when the content starts with whitespace or the child is a
+block-display element — neither borrows the `>`.

--- a/crates/rsvelte_formatter/src/collapse/pre.rs
+++ b/crates/rsvelte_formatter/src/collapse/pre.rs
@@ -1191,10 +1191,6 @@ pub(super) fn try_fix_pre_child_open_tags(
             if !open.ends_with('>') {
                 continue;
             }
-            // Has no attributes — nothing to break.
-            if !open.contains(' ') {
-                continue;
-            }
             let line_start = out[..cs].rfind('\n').map_or(0, |i| i + 1);
             // Measure the full line (from start through the first `\n` after
             // the open-tag `>`, i.e. including the content that follows `>`).
@@ -1206,9 +1202,23 @@ pub(super) fn try_fix_pre_child_open_tags(
             // multiple lines (its content has a newline) OR the glued open-tag
             // line overflows — a short single-line child (`<code class="x">y</code>`)
             // stays glued.
-            let content_multiline = out.get(open_end..ce).is_some_and(|c| c.contains('\n'));
+            let content = out.get(open_end..ce).unwrap_or("");
+            let content_multiline = content.contains('\n');
             if line.visual_width(tw) <= line_width && !content_multiline {
                 continue; // fits on one line and single-line content — no action
+            }
+            let has_attributes = open.contains(' ');
+            if !has_attributes {
+                // An attribute-free open tag only breaks because its first child
+                // borrows the `>`, which needs an inline tag whose content is
+                // leading-whitespace-sensitive; overflow alone is handled by
+                // `fix_pre_hugged_first_line`.
+                if !content_multiline
+                    || is_block_display(child_name)
+                    || content.starts_with([' ', '\t', '\r', '\n'])
+                {
+                    continue;
+                }
             }
             // Drop `>` to a new indented line.  The indent sits two levels
             // deeper than `<pre>`'s own indent (one for the child element, one

--- a/crates/rsvelte_formatter/tests/markup_preserve_ws.rs
+++ b/crates/rsvelte_formatter/tests/markup_preserve_ws.rs
@@ -72,6 +72,50 @@ fn non_pre_element_still_reindents() {
     assert_eq!(out, "<div>\n  <p>x</p>\n</div>");
 }
 
+#[test]
+fn pre_child_open_tag_breaks_when_content_is_multiline() {
+    let out = fmt("<pre><code><span>a</span>\n<span>b</span>\n</code></pre>");
+    assert_eq!(
+        out,
+        "<pre><code\n    ><span>a</span>\n<span>b</span>\n</code></pre>"
+    );
+}
+
+#[test]
+fn pre_child_open_tag_breaks_for_text_and_expression_content() {
+    assert_eq!(
+        fmt("<pre><code>a\nb\n</code></pre>"),
+        "<pre><code\n    >a\nb\n</code></pre>"
+    );
+    assert_eq!(
+        fmt("<pre><code>{value}\nb\n</code></pre>"),
+        "<pre><code\n    >{value}\nb\n</code></pre>"
+    );
+}
+
+#[test]
+fn pre_child_open_tag_stays_hugged_when_not_borrowed() {
+    // Single-line content: nothing forces the break.
+    assert_eq!(
+        fmt("<pre><code><span>a</span></code></pre>"),
+        "<pre><code><span>a</span></code></pre>"
+    );
+    // Leading whitespace in the content is not borrowed, so the `>` stays.
+    assert_eq!(
+        fmt("<pre><code> a\nb\n</code></pre>"),
+        "<pre><code> a\nb\n</code></pre>"
+    );
+    assert_eq!(
+        fmt("<pre><code>\na\nb\n</code></pre>"),
+        "<pre><code>\na\nb\n</code></pre>"
+    );
+    // A block-display child is not leading-space-sensitive.
+    assert_eq!(
+        fmt("<pre><div>a\nb\n</div></pre>"),
+        "<pre><div>a\nb\n</div></pre>"
+    );
+}
+
 /// The `<pre>`-with-a-block pass re-parses its own sub-format output. That
 /// re-parse must use the same options `format` uses, or it fails and the pass
 /// silently leaves the body unformatted. Neither case is reachable from the


### PR DESCRIPTION
Closes #2244

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012gQPtKmdY9xwn5fjdwaxK8