### PR TITLE
fix(css): union {@render} site ancestors when pruning snippet-declared elements

### DIFF
--- a/.changeset/css-render-site-ancestry.md
+++ b/.changeset/css-render-site-ancestry.md
@@ -1,0 +1,12 @@
+---
+"@rsvelte/compiler": patch
+"@rsvelte/lint": patch
+"@rsvelte/check": patch
+---
+
+CSS pruning now models `{@render}` call sites. A `{#snippet}`-declared element's
+real DOM ancestors are the union of the ancestors of every site that renders the
+snippet, not its lexical parent chain, so rules such as `.foo > .a { … }` whose
+`.a` only ever appears in a snippet rendered under a different ancestor are
+marked unused like the official compiler does. Previously the structural ancestor
+check bailed out entirely whenever the component contained a snippet.

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/types.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/types.rs
@@ -2199,6 +2199,18 @@ pub struct DomStructure {
     /// All elements in the template, with their relationships
     pub elements: Vec<CssDomElement>,
     pub general_siblings_linked: bool,
+    /// `{@render name(...)}` call sites, keyed by snippet name. A snippet-declared
+    /// element's real DOM ancestors are the union of its sites' ancestors.
+    pub snippet_render_sites: FxHashMap<String, Vec<CssRenderSite>>,
+}
+
+/// A `{@render}` call site: where the snippet body is spliced into the DOM.
+#[derive(Debug, Clone)]
+pub struct CssRenderSite {
+    /// Enclosing element index, `None` at the fragment root.
+    pub parent_idx: Option<usize>,
+    /// Innermost `{#snippet}` the call site itself sits in, if any.
+    pub snippet_name: Option<String>,
 }
 
 /// Certainty level of sibling relationships.
@@ -2265,9 +2277,9 @@ pub struct CssDomElement {
     /// Whether this element has a dynamic tag name (svelte:element)
     /// When true, any type selector matches this element
     pub is_dynamic_tag: bool,
-    /// Whether this element sits inside a `{#snippet}` declaration — its real
-    /// DOM ancestors are the render sites, not its lexical `parent_idx`.
-    pub in_snippet: bool,
+    /// Innermost enclosing `{#snippet}` name — its real DOM ancestors are that
+    /// snippet's render sites, not its lexical `parent_idx`.
+    pub snippet_name: Option<String>,
     /// Whether this element can be immediately preceded by an opaque boundary
     /// (slot, render tag, component) - used for :global(X) + Y detection
     pub prev_is_opaque_boundary: bool,

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/mod.rs
@@ -599,6 +599,17 @@ impl<'a> VisitorContext<'a> {
         self.dom_element_stack.last().copied()
     }
 
+    /// Name of the innermost enclosing `{#snippet}`, if any.
+    pub fn current_snippet_name(&self) -> Option<String> {
+        self.fragment_owner_stack
+            .iter()
+            .rev()
+            .find_map(|o| match o {
+                FragmentOwnerType::SnippetBlock(_, name) => Some(name.clone()),
+                _ => None,
+            })
+    }
+
     /// Push ignore codes onto the stack.
     /// This is called when entering a node with preceding svelte-ignore comments.
     pub fn push_ignore(&mut self, ignores: Vec<String>) {

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/regular_element.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/regular_element.rs
@@ -1027,10 +1027,7 @@ pub fn visit<'a, 'b: 'a>(
             has_content: !element.fragment.nodes.is_empty(),
             has_opaque_content,
             is_dynamic_tag: false,
-            in_snippet: context
-                .fragment_owner_stack
-                .iter()
-                .any(|o| matches!(o, super::FragmentOwnerType::SnippetBlock(..))),
+            snippet_name: context.current_snippet_name(),
             prev_is_opaque_boundary: false,
             prev_has_opaque_boundary: false,
         };

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/render_tag.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/render_tag.rs
@@ -110,6 +110,21 @@ pub fn visit(tag: &mut RenderTag, context: &mut VisitorContext) -> Result<(), An
     // content, so mark this as an opaque boundary for sibling detection.
     context.analysis.css.has_opaque_elements = true;
 
+    if let Some(name) = callee_name {
+        let site = crate::compiler::phases::phase2_analyze::types::CssRenderSite {
+            parent_idx: context.current_parent_idx(),
+            snippet_name: context.current_snippet_name(),
+        };
+        context
+            .analysis
+            .css
+            .dom_structure
+            .snippet_render_sites
+            .entry(name.to_string())
+            .or_default()
+            .push(site);
+    }
+
     // Validate arguments - no spread elements allowed
     for arg in arguments {
         if matches!(arg, JsNode::SpreadElement { .. }) {

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/snippet_block.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/snippet_block.rs
@@ -28,6 +28,31 @@ pub fn visit<'a, 'b: 'a>(
     // Validate and register the snippet
     validate_snippet(block, context)?;
 
+    // A snippet declared directly inside a component is rendered by that
+    // component, so the component's position is one of its render sites.
+    if matches!(
+        context.path.last(),
+        Some(
+            TemplateNode::Component(_)
+                | TemplateNode::SvelteComponent(_)
+                | TemplateNode::SvelteSelf(_)
+        )
+    ) && let Some(name) = super::shared::snippets::get_snippet_name(block)
+    {
+        let site = super::super::types::CssRenderSite {
+            parent_idx: context.current_parent_idx(),
+            snippet_name: context.current_snippet_name(),
+        };
+        context
+            .analysis
+            .css
+            .dom_structure
+            .snippet_render_sites
+            .entry(name)
+            .or_default()
+            .push(site);
+    }
+
     // Validate block is not empty (warn if only whitespace)
     // Reference: SnippetBlock.js L14 - validate_block_not_empty(node.body, context)
     if let Some(warning) = validate_block_not_empty(Some(&block.body))? {

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/svelte_element.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/svelte_element.rs
@@ -119,10 +119,7 @@ pub fn visit<'a, 'b: 'a>(
             has_content: !element.fragment.nodes.is_empty(),
             has_opaque_content: false,
             is_dynamic_tag: true,
-            in_snippet: context
-                .fragment_owner_stack
-                .iter()
-                .any(|o| matches!(o, super::FragmentOwnerType::SnippetBlock(..))),
+            snippet_name: context.current_snippet_name(),
             prev_is_opaque_boundary: false,
             prev_has_opaque_boundary: false,
         };

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/css.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/css.rs
@@ -2813,7 +2813,9 @@ fn structural_ancestry_is_lexical(ctx: &CssContext) -> bool {
 /// outside the element's `{#snippet}` body, in which case the union of the
 /// parents of every `{@render}` site of that snippet (upstream
 /// `get_ancestor_elements` breaking the path walk at a `SnippetBlock`).
-fn effective_parents(ctx: &CssContext, el_idx: usize) -> Vec<usize> {
+/// `None` when a snippet's render sites are unknown, in which case callers must
+/// stay conservative rather than treat the ancestor set as empty.
+fn effective_parents(ctx: &CssContext, el_idx: usize) -> Option<Vec<usize>> {
     let el = &ctx.dom_structure.elements[el_idx];
     let mut out = Vec::new();
     let mut seen: FxHashSet<&str> = FxHashSet::default();
@@ -2823,10 +2825,10 @@ fn effective_parents(ctx: &CssContext, el_idx: usize) -> Vec<usize> {
         el.snippet_name.as_deref(),
         &mut seen,
         &mut out,
-    );
+    )?;
     out.sort_unstable();
     out.dedup();
-    out
+    Some(out)
 }
 
 fn expand_effective_parents<'a>(
@@ -2835,22 +2837,20 @@ fn expand_effective_parents<'a>(
     snippet: Option<&'a str>,
     seen: &mut FxHashSet<&'a str>,
     out: &mut Vec<usize>,
-) {
+) -> Option<()> {
     if let Some(p) = parent_idx
         && ctx.dom_structure.elements[p].snippet_name.as_deref() == snippet
     {
         out.push(p);
-        return;
+        return Some(());
     }
     // The lexical walk left the snippet body (or hit the root): continue from
     // wherever the snippet is rendered.
-    let Some(name) = snippet else { return };
+    let Some(name) = snippet else { return Some(()) };
     if !seen.insert(name) {
-        return;
+        return Some(());
     }
-    let Some(sites) = ctx.dom_structure.snippet_render_sites.get(name) else {
-        return;
-    };
+    let sites = ctx.dom_structure.snippet_render_sites.get(name)?;
     for site in sites {
         expand_effective_parents(
             ctx,
@@ -2858,8 +2858,9 @@ fn expand_effective_parents<'a>(
             site.snippet_name.as_deref(),
             seen,
             out,
-        );
+        )?;
     }
+    Some(())
 }
 
 /// True when a descendant/child chain (subject last) can be evaluated by the
@@ -3563,7 +3564,10 @@ fn structural_ancestors_satisfy_links(
     let prev = &rels[link_idx - 1];
     let elements = &ctx.dom_structure.elements;
     if combinator == ">" {
-        effective_parents(ctx, el_idx).into_iter().any(|p| {
+        let Some(parents) = effective_parents(ctx, el_idx) else {
+            return true;
+        };
+        parents.into_iter().any(|p| {
             structural_element_matches_compound(&elements[p], prev)
                 && structural_ancestors_satisfy_links(rels, link_idx - 1, p, ctx)
         })
@@ -3576,7 +3580,9 @@ fn structural_ancestors_satisfy_links(
                 && structural_ancestors_satisfy_links(rels, link_idx - 1, sibling_idx, ctx)
         })
     } else {
-        let mut queue = effective_parents(ctx, el_idx);
+        let Some(mut queue) = effective_parents(ctx, el_idx) else {
+            return true;
+        };
         let mut visited: FxHashSet<usize> = queue.iter().copied().collect();
         while let Some(p) = queue.pop() {
             if structural_element_matches_compound(&elements[p], prev)
@@ -3584,7 +3590,10 @@ fn structural_ancestors_satisfy_links(
             {
                 return true;
             }
-            for next in effective_parents(ctx, p) {
+            let Some(nexts) = effective_parents(ctx, p) else {
+                return true;
+            };
+            for next in nexts {
                 if visited.insert(next) {
                     queue.push(next);
                 }

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/css.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/css.rs
@@ -2798,15 +2798,68 @@ fn global_inner_complex_rels(rel: &Value) -> Option<&Vec<Value>> {
     complex.get("children").and_then(|c| c.as_array())
 }
 
-/// True when the lexical `parent_idx` walk models the real DOM ancestry: a
-/// `{#snippet}`-declared element's real ancestors are its `{@render}` sites and
-/// `<selectedcontent>` mirrors the selected option's subtree — neither is
-/// reachable from `parent_idx`.
+/// True when the structural ancestor walk models the real DOM ancestry.
+/// `{#snippet}` bodies are handled by `effective_parents` (which follows the
+/// `{@render}` sites), but `<selectedcontent>` mirrors the selected option's
+/// subtree and is still unreachable from `parent_idx`.
 fn structural_ancestry_is_lexical(ctx: &CssContext) -> bool {
     !ctx.dom_structure
         .elements
         .iter()
-        .any(|el| el.in_snippet || el.tag_name.eq_ignore_ascii_case("selectedcontent"))
+        .any(|el| el.tag_name.eq_ignore_ascii_case("selectedcontent"))
+}
+
+/// The DOM parents of `el_idx`: its lexical parent, unless that parent lies
+/// outside the element's `{#snippet}` body, in which case the union of the
+/// parents of every `{@render}` site of that snippet (upstream
+/// `get_ancestor_elements` breaking the path walk at a `SnippetBlock`).
+fn effective_parents(ctx: &CssContext, el_idx: usize) -> Vec<usize> {
+    let el = &ctx.dom_structure.elements[el_idx];
+    let mut out = Vec::new();
+    let mut seen: FxHashSet<&str> = FxHashSet::default();
+    expand_effective_parents(
+        ctx,
+        el.parent_idx,
+        el.snippet_name.as_deref(),
+        &mut seen,
+        &mut out,
+    );
+    out.sort_unstable();
+    out.dedup();
+    out
+}
+
+fn expand_effective_parents<'a>(
+    ctx: &'a CssContext,
+    parent_idx: Option<usize>,
+    snippet: Option<&'a str>,
+    seen: &mut FxHashSet<&'a str>,
+    out: &mut Vec<usize>,
+) {
+    if let Some(p) = parent_idx
+        && ctx.dom_structure.elements[p].snippet_name.as_deref() == snippet
+    {
+        out.push(p);
+        return;
+    }
+    // The lexical walk left the snippet body (or hit the root): continue from
+    // wherever the snippet is rendered.
+    let Some(name) = snippet else { return };
+    if !seen.insert(name) {
+        return;
+    }
+    let Some(sites) = ctx.dom_structure.snippet_render_sites.get(name) else {
+        return;
+    };
+    for site in sites {
+        expand_effective_parents(
+            ctx,
+            site.parent_idx,
+            site.snippet_name.as_deref(),
+            seen,
+            out,
+        );
+    }
 }
 
 /// True when a descendant/child chain (subject last) can be evaluated by the
@@ -3510,11 +3563,10 @@ fn structural_ancestors_satisfy_links(
     let prev = &rels[link_idx - 1];
     let elements = &ctx.dom_structure.elements;
     if combinator == ">" {
-        let Some(p) = elements[el_idx].parent_idx else {
-            return false;
-        };
-        structural_element_matches_compound(&elements[p], prev)
-            && structural_ancestors_satisfy_links(rels, link_idx - 1, p, ctx)
+        effective_parents(ctx, el_idx).into_iter().any(|p| {
+            structural_element_matches_compound(&elements[p], prev)
+                && structural_ancestors_satisfy_links(rels, link_idx - 1, p, ctx)
+        })
     } else if combinator == "+" || combinator == "~" {
         // A sibling link searches the previous-sibling relation, not ancestry —
         // `visit_possible_siblings` already models the `+`/`~` adjacency/generality
@@ -3524,14 +3576,19 @@ fn structural_ancestors_satisfy_links(
                 && structural_ancestors_satisfy_links(rels, link_idx - 1, sibling_idx, ctx)
         })
     } else {
-        let mut parent = elements[el_idx].parent_idx;
-        while let Some(p) = parent {
+        let mut queue = effective_parents(ctx, el_idx);
+        let mut visited: FxHashSet<usize> = queue.iter().copied().collect();
+        while let Some(p) = queue.pop() {
             if structural_element_matches_compound(&elements[p], prev)
                 && structural_ancestors_satisfy_links(rels, link_idx - 1, p, ctx)
             {
                 return true;
             }
-            parent = elements[p].parent_idx;
+            for next in effective_parents(ctx, p) {
+                if visited.insert(next) {
+                    queue.push(next);
+                }
+            }
         }
         false
     }

--- a/crates/rsvelte_core/tests/css_chain_ancestry_guard_1735.rs
+++ b/crates/rsvelte_core/tests/css_chain_ancestry_guard_1735.rs
@@ -117,17 +117,34 @@ fn no_snippet_ancestor_chain_still_evaluated() {
     assert_pruned(&pruned);
 }
 
-/// Known limitation (issue #1735): the official compiler prunes this rule
-/// because the only render site of the `.a` pair is `<section>`, not `.foo`.
-/// rsvelte's `dom_structure` has no `{@render}`-site model, so the prune check
-/// stays conservative and keeps the rule. This is a pre-existing over-keep, not
-/// a regression from the `Chain` resolution — the same output is produced with
-/// the `Chain` path disabled entirely.
+/// The only render site of the `.a` pair is `<section>`, not `.foo`, so the
+/// ancestor constraint can never hold and the rule is pruned.
 #[test]
-fn snippet_rendered_under_mismatched_ancestor_over_kept() {
+fn snippet_rendered_under_mismatched_ancestor_pruned() {
     let out = css("<div class=\"foo\"><span>irrelevant</span></div>\n\
          {#snippet pair()}\n  <div class=\"a\"></div><div class=\"a\"></div>\n{/snippet}\n\
          <section>\n  {@render pair()}\n</section>\n\
          <style>.foo > .a { & + & { color: red; } }</style>");
+    assert_pruned(&out);
+}
+
+/// The same mismatch without any `&`/sibling chain: a lone snippet-declared
+/// `.a` rendered under `<section>` cannot satisfy `.foo > .a`.
+#[test]
+fn snippet_render_site_ancestry_simple_chain_pruned() {
+    let out = css("<div class=\"foo\"><span>irrelevant</span></div>\n\
+         {#snippet one()}\n  <div class=\"a\"></div>\n{/snippet}\n\
+         <section>\n  {@render one()}\n</section>\n\
+         <style>.foo > .a { color: red; }</style>");
+    assert_pruned(&out);
+}
+
+/// …but when a render site *is* under `.foo`, the union of sites keeps it.
+#[test]
+fn snippet_render_site_union_keeps_matching_site() {
+    let out = css("<div class=\"foo\">{@render one()}</div>\n\
+         {#snippet one()}\n  <div class=\"a\"></div>\n{/snippet}\n\
+         <section>\n  {@render one()}\n</section>\n\
+         <style>.foo > .a { color: red; }</style>");
     assert_kept(&out);
 }


### PR DESCRIPTION
Closes #1735