### PR TITLE
perf(transform): remove four per-node allocation sites in Phase-3 client

### DIFF
--- a/crates/rsvelte_core/Cargo.toml
+++ b/crates/rsvelte_core/Cargo.toml
@@ -39,6 +39,9 @@ measure-slot-key = []
 # Repository-local instrumentation: count the quoted-module-source `String`
 # allocations the pre-refactor `module_source` performed. Off by default.
 measure-module-source = []
+# Repository-local instrumentation: record the `hoisted` length distribution in
+# `clean_node_list` so its pre-allocation can be judged. Off by default.
+measure-hoisted = []
 # Select the JavaScript entropy backend when the compiler is embedded in wasm.
 # Binding exports live in `rsvelte_lint_bindings`, not in this library.
 wasm-target = ["dep:getrandom", "getrandom/wasm_js"]

--- a/crates/rsvelte_core/Cargo.toml
+++ b/crates/rsvelte_core/Cargo.toml
@@ -33,6 +33,9 @@ measure-json = []
 # Repository-local instrumentation: replay the pre-refactor `await` scanner so
 # the `String` allocations it performed can be counted. Off by default.
 measure-await = []
+# Repository-local instrumentation: count the slot-name `String` allocations the
+# pre-refactor component slot grouping performed. Off by default.
+measure-slot-key = []
 # Select the JavaScript entropy backend when the compiler is embedded in wasm.
 # Binding exports live in `rsvelte_lint_bindings`, not in this library.
 wasm-target = ["dep:getrandom", "getrandom/wasm_js"]

--- a/crates/rsvelte_core/Cargo.toml
+++ b/crates/rsvelte_core/Cargo.toml
@@ -36,6 +36,9 @@ measure-await = []
 # Repository-local instrumentation: count the slot-name `String` allocations the
 # pre-refactor component slot grouping performed. Off by default.
 measure-slot-key = []
+# Repository-local instrumentation: count the quoted-module-source `String`
+# allocations the pre-refactor `module_source` performed. Off by default.
+measure-module-source = []
 # Select the JavaScript entropy backend when the compiler is embedded in wasm.
 # Binding exports live in `rsvelte_lint_bindings`, not in this library.
 wasm-target = ["dep:getrandom", "getrandom/wasm_js"]

--- a/crates/rsvelte_core/Cargo.toml
+++ b/crates/rsvelte_core/Cargo.toml
@@ -27,6 +27,12 @@ crate-type = ["rlib"]
 default = []
 parallel = ["dep:rayon"]
 trace-fastpath = []
+# Repository-local instrumentation: count the `serde_json::Value` that the lazy
+# expression cache materializes. Off by default and zero-cost when off.
+measure-json = []
+# Repository-local instrumentation: replay the pre-refactor `await` scanner so
+# the `String` allocations it performed can be counted. Off by default.
+measure-await = []
 # Select the JavaScript entropy backend when the compiler is embedded in wasm.
 # Binding exports live in `rsvelte_lint_bindings`, not in this library.
 wasm-target = ["dep:getrandom", "getrandom/wasm_js"]

--- a/crates/rsvelte_core/Cargo.toml
+++ b/crates/rsvelte_core/Cargo.toml
@@ -27,9 +27,6 @@ crate-type = ["rlib"]
 default = []
 parallel = ["dep:rayon"]
 trace-fastpath = []
-# Repository-local instrumentation: count the `serde_json::Value` that the lazy
-# expression cache materializes. Off by default and zero-cost when off.
-measure-json = []
 # Repository-local instrumentation: replay the pre-refactor `await` scanner so
 # the `String` allocations it performed can be counted. Off by default.
 measure-await = []

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/builders.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/builders.rs
@@ -990,8 +990,13 @@ impl<'a> B<'a> {
     /// Build a module-source `StringLiteral` emitted verbatim between single
     /// quotes (mirrors `to_oxc.rs::module_source`).
     fn module_source(self, source: &str) -> oxc_ast::ast::StringLiteral<'a> {
-        let raw = self.str(&format!("'{source}'"));
-        StringLiteral::new(SPAN, self.str(source), Some(raw.into()), &self.ab())
+        #[cfg(feature = "measure-module-source")]
+        crate::measure_module_source::record(source.len());
+        // The quoted spelling is built straight into the arena and the unquoted
+        // value is a subslice of it, so neither string is copied twice.
+        let raw = oxc_allocator::StringBuilder::from_strs_array_in(["'", source, "'"], self.alloc)
+            .into_str();
+        StringLiteral::new(SPAN, &raw[1..raw.len() - 1], Some(raw.into()), &self.ab())
     }
 
     /// Build a `ModuleExportName::IdentifierName` from a plain name.

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/expression_utils.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/expression_utils.rs
@@ -2468,3 +2468,123 @@ mod proxy_detection_tests {
         assert!(!expression_needs_proxy("/* c */ () => 1"));
     }
 }
+
+#[cfg(test)]
+mod await_scan_tests {
+    use super::{contains_direct_await_in_expression, is_identifier_char};
+
+    /// The scanner as it stood before the per-character `String` builds were
+    /// removed, kept verbatim so the inputs below compare two implementations
+    /// rather than one against a hand-written expectation. The `"async"` arm is
+    /// the branch the refactor dropped; the corpus never reaches it, so its
+    /// equivalence has to be pinned by construction here instead.
+    fn pre_refactor_scan(expr: &str) -> bool {
+        let chars: Vec<char> = expr.chars().collect();
+        let mut i = 0;
+        let mut in_string = false;
+        let mut string_char = ' ';
+        let mut async_fn_depth = 0;
+
+        while i < chars.len() {
+            let c = chars[i];
+
+            if !in_string && (c == '"' || c == '\'' || c == '`') {
+                in_string = true;
+                string_char = c;
+                i += 1;
+                continue;
+            }
+            if in_string && c == string_char && (i == 0 || chars[i - 1] != '\\') {
+                in_string = false;
+                i += 1;
+                continue;
+            }
+            if in_string {
+                i += 1;
+                continue;
+            }
+
+            if i + 5 <= chars.len() {
+                let word: String = chars[i..i + 5].iter().collect();
+                if word == "async" {
+                    let rest: String = chars[i + 5..].iter().collect();
+                    let rest_trimmed = rest.trim_start();
+                    if rest_trimmed.starts_with("(")
+                        || rest_trimmed.starts_with("function")
+                        || chars[i + 5..]
+                            .iter()
+                            .collect::<String>()
+                            .trim_start()
+                            .starts_with("=>")
+                    {
+                        // Empty in the original too: the arm computed a verdict
+                        // it never acted on.
+                    }
+                }
+            }
+
+            if i + 5 <= chars.len() && async_fn_depth == 0 {
+                let word: String = chars[i..i + 5].iter().collect();
+                if word == "await" {
+                    let before_ok = i == 0 || !is_identifier_char(chars[i - 1]);
+                    let after_ok = i + 5 >= chars.len() || !is_identifier_char(chars[i + 5]);
+                    if before_ok && after_ok {
+                        return true;
+                    }
+                }
+            }
+
+            if c == '{' {
+                let before: String = chars[..i].iter().collect();
+                if before.trim_end().ends_with("=>") {
+                    let before_trimmed = before.trim_end();
+                    if let Some(paren_pos) = before_trimmed.rfind('(') {
+                        let before_paren = &before_trimmed[..paren_pos];
+                        if before_paren.trim_end().ends_with("async") {
+                            async_fn_depth += 1;
+                        }
+                    } else if let Some(async_pos) =
+                        memchr::memmem::rfind(before_trimmed.as_bytes(), b"async")
+                    {
+                        let between = &before_trimmed[async_pos + 5..];
+                        if between
+                            .trim()
+                            .chars()
+                            .all(|c| is_identifier_char(c) || c == ' ')
+                        {
+                            async_fn_depth += 1;
+                        }
+                    }
+                }
+            } else if c == '}' && async_fn_depth > 0 {
+                async_fn_depth -= 1;
+            }
+
+            i += 1;
+        }
+
+        false
+    }
+
+    #[test]
+    fn agrees_with_pre_refactor_scan_on_the_async_branch() {
+        // Each input makes the dropped arm's `word == "async"` test fire; the
+        // three tails cover its three disjuncts plus the case where all fail.
+        let cases = [
+            "async () => { await x }",
+            "async function () { await x }",
+            "async x => await x",
+            "asyncThing(await x)",
+            "await async () => 1",
+            "async",
+            "async\u{3000}=> await x",
+        ];
+        for expr in cases {
+            assert_eq!(
+                contains_direct_await_in_expression(expr),
+                pre_refactor_scan(expr),
+                "verdict drift on {expr:?}"
+            );
+        }
+    }
+}

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/expression_utils.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/expression_utils.rs
@@ -2148,6 +2148,11 @@ pub(super) fn is_top_level_function_call(expr: &str) -> bool {
 /// - `foo(await 1)` -> true
 /// - `async () => { return await 1; }` -> false (await is inside async function)
 pub(super) fn contains_direct_await_in_expression(expr: &str) -> bool {
+    const AWAIT: [char; 5] = ['a', 'w', 'a', 'i', 't'];
+
+    #[cfg(feature = "measure-await")]
+    crate::measure_await::record(expr);
+
     let chars: Vec<char> = expr.chars().collect();
     let mut i = 0;
     let mut in_string = false;
@@ -2177,37 +2182,13 @@ pub(super) fn contains_direct_await_in_expression(expr: &str) -> bool {
             continue;
         }
 
-        // Check for 'async' keyword followed by function definition
-        if i + 5 <= chars.len() {
-            let word: String = chars[i..i + 5].iter().collect();
-            if word == "async" {
-                // Check if this is followed by function or arrow syntax
-                let rest: String = chars[i + 5..].iter().collect();
-                let rest_trimmed = rest.trim_start();
-                if rest_trimmed.starts_with("(")
-                    || rest_trimmed.starts_with("function")
-                    || chars[i + 5..]
-                        .iter()
-                        .collect::<String>()
-                        .trim_start()
-                        .starts_with("=>")
-                {
-                    // We found an async function, track depth when we see '{'
-                    // For now, just note we're in async context
-                }
-            }
-        }
-
         // Check for 'await' keyword at top level
-        if i + 5 <= chars.len() && async_fn_depth == 0 {
-            let word: String = chars[i..i + 5].iter().collect();
-            if word == "await" {
-                // Make sure it's a word boundary
-                let before_ok = i == 0 || !is_identifier_char(chars[i - 1]);
-                let after_ok = i + 5 >= chars.len() || !is_identifier_char(chars[i + 5]);
-                if before_ok && after_ok {
-                    return true;
-                }
+        if i + 5 <= chars.len() && async_fn_depth == 0 && chars[i..i + 5] == AWAIT {
+            // Make sure it's a word boundary
+            let before_ok = i == 0 || !is_identifier_char(chars[i - 1]);
+            let after_ok = i + 5 >= chars.len() || !is_identifier_char(chars[i + 5]);
+            if before_ok && after_ok {
+                return true;
             }
         }
 

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/expression_utils.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/expression_utils.rs
@@ -2148,10 +2148,14 @@ pub(super) fn is_top_level_function_call(expr: &str) -> bool {
 /// - `foo(await 1)` -> true
 /// - `async () => { return await 1; }` -> false (await is inside async function)
 pub(super) fn contains_direct_await_in_expression(expr: &str) -> bool {
-    const AWAIT: [char; 5] = ['a', 'w', 'a', 'i', 't'];
-
+    let found = scan_for_direct_await(expr);
     #[cfg(feature = "measure-await")]
-    crate::measure_await::record(expr);
+    crate::measure_await::record(expr, found);
+    found
+}
+
+fn scan_for_direct_await(expr: &str) -> bool {
+    const AWAIT: [char; 5] = ['a', 'w', 'a', 'i', 't'];
 
     let chars: Vec<char> = expr.chars().collect();
     let mut i = 0;

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/component.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/component.rs
@@ -268,7 +268,7 @@ pub fn build_component(
 
     // Group children by slot and process snippets
     // Use IndexMap to preserve insertion order (matches JavaScript object key order)
-    let mut children: IndexMap<String, Vec<&TemplateNode>> = IndexMap::new();
+    let mut children: IndexMap<&str, Vec<&TemplateNode>> = IndexMap::new();
 
     for child in &fragment.nodes {
         if let TemplateNode::SnippetBlock(snippet) = child {
@@ -283,7 +283,9 @@ pub fn build_component(
             continue;
         }
 
-        let slot_name = determine_slot(child).unwrap_or_else(|| "default".to_string());
+        let slot_name = determine_slot(child).unwrap_or("default");
+        #[cfg(feature = "measure-slot-key")]
+        crate::measure_slot_key::record(slot_name);
         children.entry(slot_name).or_default().push(child);
     }
 
@@ -292,7 +294,7 @@ pub fn build_component(
         let slot_fn = build_slot_function(
             arena,
             &slot_children,
-            &slot_name,
+            slot_name,
             slot_scope_applies_to_itself,
             &lets,
             &let_names,
@@ -310,7 +312,7 @@ pub fn build_component(
 
                 if needs_slots_default {
                     // Use $$slots.default
-                    serialized_slots.push(b::prop(arena, &slot_name, fn_expr));
+                    serialized_slots.push(b::prop(arena, slot_name, fn_expr));
                     // Add children prop that errors
                     push_prop_immediate(
                         &mut props_and_spreads,
@@ -336,10 +338,10 @@ pub fn build_component(
                         b::prop(arena, "children", wrapped_fn),
                     );
                     // Add $$slots.default: true
-                    serialized_slots.push(b::prop(arena, &slot_name, b::boolean(true)));
+                    serialized_slots.push(b::prop(arena, slot_name, b::boolean(true)));
                 }
             } else {
-                serialized_slots.push(b::prop(arena, &slot_name, fn_expr));
+                serialized_slots.push(b::prop(arena, slot_name, fn_expr));
             }
         }
     }
@@ -739,7 +741,7 @@ pub fn build_component(
 /// Matches the official `determine_slot()` in `svelte/src/compiler/utils/slot.js`.
 /// This checks for `slot="name"` attribute on element-like nodes:
 /// SvelteElement, RegularElement, SvelteFragment, Component, SvelteComponent, SvelteSelf, SlotElement
-fn determine_slot(node: &TemplateNode) -> Option<String> {
+fn determine_slot<'n>(node: &'n TemplateNode<'_>) -> Option<&'n str> {
     let attributes = match node {
         TemplateNode::RegularElement(elem) => Some(&elem.attributes),
         TemplateNode::Component(comp) => Some(&comp.attributes),
@@ -758,7 +760,7 @@ fn determine_slot(node: &TemplateNode) -> Option<String> {
                 && let AttributeValue::Sequence(parts) = &a.value
                 && let Some(AttributeValuePart::Text(text)) = parts.first()
             {
-                return Some(text.data.to_string());
+                return Some(text.data.as_ref());
             }
         }
     }

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/js_ast/to_oxc.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/js_ast/to_oxc.rs
@@ -614,8 +614,16 @@ impl<'a, 'arena> Cx<'a, 'arena> {
     /// `emit_export_named`), so we set `raw` to the exact `'source'` spelling to
     /// make esrap reproduce it byte-for-byte regardless of quote options.
     fn module_source(&self, source: &str) -> oxc_ast::ast::StringLiteral<'a> {
-        let raw = self.str(&format!("'{source}'"));
-        StringLiteral::new(SPAN, self.str(source), Some(raw.into()), &self.ab)
+        #[cfg(feature = "measure-module-source")]
+        crate::measure_module_source::record(source.len());
+        // The quoted spelling is built straight into the arena and the unquoted
+        // value is a subslice of it, so neither string is copied twice.
+        let raw = oxc_allocator::StringBuilder::from_strs_array_in(
+            ["'", source, "'"],
+            self.ab.allocator(),
+        )
+        .into_str();
+        StringLiteral::new(SPAN, &raw[1..raw.len() - 1], Some(raw.into()), &self.ab)
     }
 
     /// Build a `ModuleExportName::IdentifierName` from a plain name.

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/utils.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/utils.rs
@@ -733,6 +733,9 @@ fn clean_node_list<'a, L: NodeList<'a>>(
         }
     }
 
+    #[cfg(feature = "measure-hoisted")]
+    crate::measure_hoisted::record(nodes.count(), hoisted.len());
+
     // Whitespace trimming (unless preserve_whitespace is set)
     let mut trimmed = if preserve_whitespace {
         regular

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/utils.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/utils.rs
@@ -691,8 +691,8 @@ fn clean_node_list<'a, L: NodeList<'a>>(
         None
     };
 
-    // Pre-allocate based on input size
-    let mut hoisted: Vec<Cow<'a, TemplateNode<'a>>> = Vec::with_capacity(nodes.count().min(8));
+    // Nothing is hoisted in ~98% of calls, so only `regular` is pre-allocated.
+    let mut hoisted: Vec<Cow<'a, TemplateNode<'a>>> = Vec::new();
     let mut regular: Vec<Cow<'a, TemplateNode<'a>>> = Vec::with_capacity(nodes.count());
 
     // Helper: process a single node into hoisted or regular

--- a/crates/rsvelte_core/src/lib.rs
+++ b/crates/rsvelte_core/src/lib.rs
@@ -28,6 +28,8 @@
 pub mod ast;
 pub mod compiler;
 pub mod error;
+#[cfg(feature = "measure-await")]
+pub mod measure_await;
 pub mod toolchain;
 
 pub use compiler::legacy::convert_to_legacy;

--- a/crates/rsvelte_core/src/lib.rs
+++ b/crates/rsvelte_core/src/lib.rs
@@ -30,6 +30,8 @@ pub mod compiler;
 pub mod error;
 #[cfg(feature = "measure-await")]
 pub mod measure_await;
+#[cfg(feature = "measure-slot-key")]
+pub mod measure_slot_key;
 pub mod toolchain;
 
 pub use compiler::legacy::convert_to_legacy;

--- a/crates/rsvelte_core/src/lib.rs
+++ b/crates/rsvelte_core/src/lib.rs
@@ -30,6 +30,8 @@ pub mod compiler;
 pub mod error;
 #[cfg(feature = "measure-await")]
 pub mod measure_await;
+#[cfg(feature = "measure-hoisted")]
+pub mod measure_hoisted;
 #[cfg(feature = "measure-module-source")]
 pub mod measure_module_source;
 #[cfg(feature = "measure-slot-key")]

--- a/crates/rsvelte_core/src/lib.rs
+++ b/crates/rsvelte_core/src/lib.rs
@@ -30,6 +30,8 @@ pub mod compiler;
 pub mod error;
 #[cfg(feature = "measure-await")]
 pub mod measure_await;
+#[cfg(feature = "measure-module-source")]
+pub mod measure_module_source;
 #[cfg(feature = "measure-slot-key")]
 pub mod measure_slot_key;
 pub mod toolchain;

--- a/crates/rsvelte_core/src/measure_await.rs
+++ b/crates/rsvelte_core/src/measure_await.rs
@@ -1,11 +1,26 @@
 //! Deterministic counter for the `String` allocations that the pre-refactor
 //! `contains_direct_await_in_expression` performed per scanned character.
 //!
-//! The scanner below is the pre-refactor body verbatim, so the numbers are
-//! observed allocations rather than a model of them. Running it alongside the
-//! current scanner gives "what the old code would have allocated" against
-//! "what the new code allocates" (zero at these four sites) without needing a
-//! quiet machine. It doubles as a differential oracle: every call compares the
+//! The scanner below is allocation-faithful and verdict-equivalent to the
+//! pre-refactor body rather than a verbatim copy of it. The deviations are:
+//!
+//! - A: in the `"async"` arm the old `||` chain is rewritten as an explicit
+//!   negation, so the third collect happens on exactly the inputs where the
+//!   first two `starts_with` tests failed, as short-circuiting gave before.
+//!   The consequent block it guarded held two comment lines and zero
+//!   statements, so it and its final `starts_with("=>")` test are dropped:
+//!   statically return-neutral, and all three allocations are still made.
+//! - B: `} else { if let Some(..) = .. }` is folded into
+//!   `} else if let Some(..) = ..`, a purely syntactic change.
+//! - C: `is_identifier_char` is copied in below rather than imported, because
+//!   the production helper is `pub(super)` and because the oracle must stay
+//!   pinned to the old definition even if the production one later drifts.
+//!
+//! The numbers are therefore observed allocations rather than a model of them.
+//! Running it alongside the current scanner gives "what the old code would
+//! have allocated" against "what the new code allocates" (zero at these four
+//! sites) without needing a quiet machine. It doubles as a differential
+//! oracle: every call compares the
 //! old verdict against the new one and counts disagreements. Requires the
 //! instrumentation feature:
 //!
@@ -37,6 +52,7 @@ fn bump(counter: &'static std::thread::LocalKey<Cell<u64>>, bytes: usize) {
     ALLOC_BYTES.with(|c| c.set(c.get() + bytes as u64));
 }
 
+// Pinned copy: the oracle must not follow later drift in the production helper.
 fn is_identifier_char(c: char) -> bool {
     c.is_alphanumeric() || c == '_' || c == '$'
 }

--- a/crates/rsvelte_core/src/measure_await.rs
+++ b/crates/rsvelte_core/src/measure_await.rs
@@ -1,0 +1,149 @@
+//! Deterministic counter for the `String` allocations that the pre-refactor
+//! `contains_direct_await_in_expression` performed per scanned character.
+//!
+//! The scanner below is the pre-refactor body verbatim, so the numbers are
+//! observed allocations rather than a model of them. Running it alongside the
+//! current scanner gives "what the old code would have allocated" against
+//! "what the new code allocates" (zero at these four sites) without needing a
+//! quiet machine. Requires the instrumentation feature:
+//!
+//! ```text
+//! cargo run --profile profiling -p rsvelte_devtools --bin await_alloc_count \
+//!   --features measure-await
+//! ```
+
+use std::cell::Cell;
+
+thread_local! {
+    static CALLS: Cell<u64> = const { Cell::new(0) };
+    static INPUT_BYTES: Cell<u64> = const { Cell::new(0) };
+    /// Per-position 5-char `word` built before the `"async"` test.
+    static WORD_ASYNC: Cell<u64> = const { Cell::new(0) };
+    /// Whole-remainder `rest` built once the word was `"async"`.
+    static REST: Cell<u64> = const { Cell::new(0) };
+    /// Second whole-remainder collect, reached only when both `starts_with` fail.
+    static REST_AGAIN: Cell<u64> = const { Cell::new(0) };
+    /// Per-position 5-char `word` built before the `"await"` test.
+    static WORD_AWAIT: Cell<u64> = const { Cell::new(0) };
+    static ALLOC_BYTES: Cell<u64> = const { Cell::new(0) };
+}
+
+fn bump(counter: &'static std::thread::LocalKey<Cell<u64>>, bytes: usize) {
+    counter.with(|c| c.set(c.get() + 1));
+    ALLOC_BYTES.with(|c| c.set(c.get() + bytes as u64));
+}
+
+fn is_identifier_char(c: char) -> bool {
+    c.is_alphanumeric() || c == '_' || c == '$'
+}
+
+/// `(calls, input_bytes, word_async, rest, rest_again, word_await, alloc_bytes)`
+/// since the last reset.
+pub fn snapshot() -> (u64, u64, u64, u64, u64, u64, u64) {
+    (
+        CALLS.with(|c| c.get()),
+        INPUT_BYTES.with(|c| c.get()),
+        WORD_ASYNC.with(|c| c.get()),
+        REST.with(|c| c.get()),
+        REST_AGAIN.with(|c| c.get()),
+        WORD_AWAIT.with(|c| c.get()),
+        ALLOC_BYTES.with(|c| c.get()),
+    )
+}
+
+pub fn reset() {
+    CALLS.with(|c| c.set(0));
+    INPUT_BYTES.with(|c| c.set(0));
+    WORD_ASYNC.with(|c| c.set(0));
+    REST.with(|c| c.set(0));
+    REST_AGAIN.with(|c| c.set(0));
+    WORD_AWAIT.with(|c| c.set(0));
+    ALLOC_BYTES.with(|c| c.set(0));
+}
+
+/// Replay the pre-refactor scan of `expr`, counting every `String` it builds at
+/// the four sites the refactor removed.
+pub fn record(expr: &str) {
+    CALLS.with(|c| c.set(c.get() + 1));
+    INPUT_BYTES.with(|c| c.set(c.get() + expr.len() as u64));
+
+    let chars: Vec<char> = expr.chars().collect();
+    let mut i = 0;
+    let mut in_string = false;
+    let mut string_char = ' ';
+    let mut async_fn_depth = 0;
+
+    while i < chars.len() {
+        let c = chars[i];
+
+        if !in_string && (c == '"' || c == '\'' || c == '`') {
+            in_string = true;
+            string_char = c;
+            i += 1;
+            continue;
+        }
+        if in_string && c == string_char && (i == 0 || chars[i - 1] != '\\') {
+            in_string = false;
+            i += 1;
+            continue;
+        }
+        if in_string {
+            i += 1;
+            continue;
+        }
+
+        if i + 5 <= chars.len() {
+            let word: String = chars[i..i + 5].iter().collect();
+            bump(&WORD_ASYNC, word.len());
+            if word == "async" {
+                let rest: String = chars[i + 5..].iter().collect();
+                bump(&REST, rest.len());
+                let rest_trimmed = rest.trim_start();
+                if !(rest_trimmed.starts_with("(") || rest_trimmed.starts_with("function")) {
+                    let again: String = chars[i + 5..].iter().collect();
+                    bump(&REST_AGAIN, again.len());
+                }
+            }
+        }
+
+        if i + 5 <= chars.len() && async_fn_depth == 0 {
+            let word: String = chars[i..i + 5].iter().collect();
+            bump(&WORD_AWAIT, word.len());
+            if word == "await" {
+                let before_ok = i == 0 || !is_identifier_char(chars[i - 1]);
+                let after_ok = i + 5 >= chars.len() || !is_identifier_char(chars[i + 5]);
+                if before_ok && after_ok {
+                    return;
+                }
+            }
+        }
+
+        if c == '{' {
+            let before: String = chars[..i].iter().collect();
+            if before.trim_end().ends_with("=>") {
+                let before_trimmed = before.trim_end();
+                if let Some(paren_pos) = before_trimmed.rfind('(') {
+                    let before_paren = &before_trimmed[..paren_pos];
+                    if before_paren.trim_end().ends_with("async") {
+                        async_fn_depth += 1;
+                    }
+                } else if let Some(async_pos) =
+                    memchr::memmem::rfind(before_trimmed.as_bytes(), b"async")
+                {
+                    let between = &before_trimmed[async_pos + 5..];
+                    if between
+                        .trim()
+                        .chars()
+                        .all(|c| is_identifier_char(c) || c == ' ')
+                    {
+                        async_fn_depth += 1;
+                    }
+                }
+            }
+        } else if c == '}' && async_fn_depth > 0 {
+            async_fn_depth -= 1;
+        }
+
+        i += 1;
+    }
+}

--- a/crates/rsvelte_core/src/measure_await.rs
+++ b/crates/rsvelte_core/src/measure_await.rs
@@ -5,7 +5,9 @@
 //! observed allocations rather than a model of them. Running it alongside the
 //! current scanner gives "what the old code would have allocated" against
 //! "what the new code allocates" (zero at these four sites) without needing a
-//! quiet machine. Requires the instrumentation feature:
+//! quiet machine. It doubles as a differential oracle: every call compares the
+//! old verdict against the new one and counts disagreements. Requires the
+//! instrumentation feature:
 //!
 //! ```text
 //! cargo run --profile profiling -p rsvelte_devtools --bin await_alloc_count \
@@ -26,6 +28,8 @@ thread_local! {
     /// Per-position 5-char `word` built before the `"await"` test.
     static WORD_AWAIT: Cell<u64> = const { Cell::new(0) };
     static ALLOC_BYTES: Cell<u64> = const { Cell::new(0) };
+    /// Calls where the replayed scanner disagreed with the current one.
+    static MISMATCH: Cell<u64> = const { Cell::new(0) };
 }
 
 fn bump(counter: &'static std::thread::LocalKey<Cell<u64>>, bytes: usize) {
@@ -37,9 +41,9 @@ fn is_identifier_char(c: char) -> bool {
     c.is_alphanumeric() || c == '_' || c == '$'
 }
 
-/// `(calls, input_bytes, word_async, rest, rest_again, word_await, alloc_bytes)`
-/// since the last reset.
-pub fn snapshot() -> (u64, u64, u64, u64, u64, u64, u64) {
+/// `(calls, input_bytes, word_async, rest, rest_again, word_await, alloc_bytes,
+/// mismatch)` since the last reset.
+pub fn snapshot() -> (u64, u64, u64, u64, u64, u64, u64, u64) {
     (
         CALLS.with(|c| c.get()),
         INPUT_BYTES.with(|c| c.get()),
@@ -48,6 +52,7 @@ pub fn snapshot() -> (u64, u64, u64, u64, u64, u64, u64) {
         REST_AGAIN.with(|c| c.get()),
         WORD_AWAIT.with(|c| c.get()),
         ALLOC_BYTES.with(|c| c.get()),
+        MISMATCH.with(|c| c.get()),
     )
 }
 
@@ -59,14 +64,22 @@ pub fn reset() {
     REST_AGAIN.with(|c| c.set(0));
     WORD_AWAIT.with(|c| c.set(0));
     ALLOC_BYTES.with(|c| c.set(0));
+    MISMATCH.with(|c| c.set(0));
 }
 
 /// Replay the pre-refactor scan of `expr`, counting every `String` it builds at
-/// the four sites the refactor removed.
-pub fn record(expr: &str) {
+/// the four sites the refactor removed, and compare its verdict against
+/// `new_result` so any behavior drift is counted rather than assumed absent.
+pub fn record(expr: &str, new_result: bool) {
     CALLS.with(|c| c.set(c.get() + 1));
     INPUT_BYTES.with(|c| c.set(c.get() + expr.len() as u64));
 
+    if replay(expr) != new_result {
+        MISMATCH.with(|c| c.set(c.get() + 1));
+    }
+}
+
+fn replay(expr: &str) -> bool {
     let chars: Vec<char> = expr.chars().collect();
     let mut i = 0;
     let mut in_string = false;
@@ -113,7 +126,7 @@ pub fn record(expr: &str) {
                 let before_ok = i == 0 || !is_identifier_char(chars[i - 1]);
                 let after_ok = i + 5 >= chars.len() || !is_identifier_char(chars[i + 5]);
                 if before_ok && after_ok {
-                    return;
+                    return true;
                 }
             }
         }
@@ -146,4 +159,6 @@ pub fn record(expr: &str) {
 
         i += 1;
     }
+
+    false
 }

--- a/crates/rsvelte_core/src/measure_hoisted.rs
+++ b/crates/rsvelte_core/src/measure_hoisted.rs
@@ -1,0 +1,85 @@
+//! Counterfactual counter for the `clean_node_list` `hoisted` pre-allocation.
+//!
+//! Records the final `hoisted` length and whether the input was empty for every
+//! `clean_node_list` call, so both the allocations `Vec::with_capacity(min(n,8))`
+//! performs and the ones a lazily-growing `Vec::new()` would perform can be
+//! derived from one run. `hoisted.len() <= nodes.count()` always holds, so the
+//! old side needs no separate input-length histogram.
+//!
+//! The growth curves are measured on the real element type rather than assumed
+//! from `RawVec`'s rule, because the rule depends on the element size.
+
+use std::borrow::Cow;
+use std::cell::{Cell, RefCell};
+
+use compact_str::CompactString;
+
+use crate::ast::template::{Comment, TemplateNode};
+
+/// Lengths above this are counted exactly instead of bucketed.
+const HIST_MAX: usize = 32;
+
+thread_local! {
+    static CALLS: Cell<u64> = const { Cell::new(0) };
+    static EMPTY_INPUT: Cell<u64> = const { Cell::new(0) };
+    static HIST: RefCell<[u64; HIST_MAX + 1]> = const { RefCell::new([0; HIST_MAX + 1]) };
+    static OVER_HIST: RefCell<Vec<usize>> = const { RefCell::new(Vec::new()) };
+}
+
+pub fn record(input_len: usize, hoisted_len: usize) {
+    CALLS.with(|c| c.set(c.get() + 1));
+    if input_len == 0 {
+        EMPTY_INPUT.with(|c| c.set(c.get() + 1));
+    }
+    if hoisted_len <= HIST_MAX {
+        HIST.with(|h| h.borrow_mut()[hoisted_len] += 1);
+    } else {
+        OVER_HIST.with(|v| v.borrow_mut().push(hoisted_len));
+    }
+}
+
+pub fn reset() {
+    CALLS.with(|c| c.set(0));
+    EMPTY_INPUT.with(|c| c.set(0));
+    HIST.with(|h| *h.borrow_mut() = [0; HIST_MAX + 1]);
+    OVER_HIST.with(|v| v.borrow_mut().clear());
+}
+
+/// `(calls, empty_input, histogram of hoisted lengths 0..=HIST_MAX, lengths above it)`
+pub fn snapshot() -> (u64, u64, [u64; HIST_MAX + 1], Vec<usize>) {
+    (
+        CALLS.with(Cell::get),
+        EMPTY_INPUT.with(Cell::get),
+        HIST.with(|h| *h.borrow()),
+        OVER_HIST.with(|v| v.borrow().clone()),
+    )
+}
+
+fn dummy_node() -> Cow<'static, TemplateNode<'static>> {
+    Cow::Owned(TemplateNode::Comment(Comment {
+        start: 0,
+        end: 0,
+        data: CompactString::new(""),
+    }))
+}
+
+/// The lengths at which pushing onto a `Vec` that started at `start_cap`
+/// (re)allocates, measured on the real element type up to `n` pushes.
+pub fn growth_steps(start_cap: usize, n: usize) -> Vec<usize> {
+    let mut v: Vec<Cow<'static, TemplateNode<'static>>> = Vec::with_capacity(start_cap);
+    let mut cap = v.capacity();
+    let mut steps = Vec::new();
+    for i in 0..n {
+        v.push(dummy_node());
+        if v.capacity() != cap {
+            cap = v.capacity();
+            steps.push(i + 1);
+        }
+    }
+    steps
+}
+
+/// Size of one `hoisted` element, which decides `RawVec`'s minimum capacity.
+pub fn element_size() -> usize {
+    std::mem::size_of::<Cow<'static, TemplateNode<'static>>>()
+}

--- a/crates/rsvelte_core/src/measure_module_source.rs
+++ b/crates/rsvelte_core/src/measure_module_source.rs
@@ -1,0 +1,29 @@
+//! Counterfactual counter for the `module_source` quoting rewrite.
+//!
+//! The recorder sits on the exact line that used to run `format!("'{source}'")`,
+//! so `calls` is the number of heap `String`s the old code allocated there and
+//! `source_bytes + 2 * calls` is how many bytes they copied. The old code also
+//! made a second arena allocation for the unquoted value; the new code slices it
+//! out of the quoted one, so `calls` arena allocations totalling `source_bytes`
+//! disappear as well.
+
+use std::cell::Cell;
+
+thread_local! {
+    static CALLS: Cell<u64> = const { Cell::new(0) };
+    static SOURCE_BYTES: Cell<u64> = const { Cell::new(0) };
+}
+
+pub fn record(source_len: usize) {
+    CALLS.with(|c| c.set(c.get() + 1));
+    SOURCE_BYTES.with(|c| c.set(c.get() + source_len as u64));
+}
+
+pub fn snapshot() -> (u64, u64) {
+    (CALLS.with(Cell::get), SOURCE_BYTES.with(Cell::get))
+}
+
+pub fn reset() {
+    CALLS.with(|c| c.set(0));
+    SOURCE_BYTES.with(|c| c.set(0));
+}

--- a/crates/rsvelte_core/src/measure_slot_key.rs
+++ b/crates/rsvelte_core/src/measure_slot_key.rs
@@ -1,0 +1,46 @@
+//! Repository-local instrumentation for the component slot-grouping key.
+//!
+//! Before the `&str`-key refactor, every non-snippet child of a component
+//! fragment produced exactly one owned `String` for its slot name: either
+//! `text.data.to_string()` from `determine_slot`, or `"default".to_string()`
+//! from the fallback. The map took ownership of that `String`, so the count of
+//! calls through this recorder is exactly the count of `String` allocations the
+//! pre-refactor code performed, and `bytes` is exactly how many bytes those
+//! allocations copied.
+//!
+//! This is a counterfactual counter: it measures work the old code would have
+//! done, not allocations the process performs now (the new code performs none
+//! at this site). It is compiled out unless `measure-slot-key` is enabled.
+
+use std::cell::Cell;
+
+thread_local! {
+    static CALLS: Cell<u64> = const { Cell::new(0) };
+    static BYTES: Cell<u64> = const { Cell::new(0) };
+    static DEFAULT_KEYS: Cell<u64> = const { Cell::new(0) };
+}
+
+/// Record one slot-key computation. `key` is the borrowed key the new code
+/// uses; the old code would have owned a copy of it.
+pub fn record(key: &str) {
+    CALLS.with(|c| c.set(c.get() + 1));
+    BYTES.with(|c| c.set(c.get() + key.len() as u64));
+    if key == "default" {
+        DEFAULT_KEYS.with(|c| c.set(c.get() + 1));
+    }
+}
+
+/// `(calls, bytes, default_keys)` accumulated on this thread.
+pub fn snapshot() -> (u64, u64, u64) {
+    (
+        CALLS.with(|c| c.get()),
+        BYTES.with(|c| c.get()),
+        DEFAULT_KEYS.with(|c| c.get()),
+    )
+}
+
+pub fn reset() {
+    CALLS.with(|c| c.set(0));
+    BYTES.with(|c| c.set(0));
+    DEFAULT_KEYS.with(|c| c.set(0));
+}

--- a/crates/rsvelte_devtools/Cargo.toml
+++ b/crates/rsvelte_devtools/Cargo.toml
@@ -22,6 +22,7 @@ pprof = ["dep:pprof"]
 measure-json = ["rsvelte_core/measure-json"]
 measure-await = ["rsvelte_core/measure-await"]
 measure-slot-key = ["rsvelte_core/measure-slot-key"]
+measure-module-source = ["rsvelte_core/measure-module-source"]
 
 [dependencies]
 rsvelte_ast_equiv = { path = "../rsvelte_ast_equiv" }

--- a/crates/rsvelte_devtools/Cargo.toml
+++ b/crates/rsvelte_devtools/Cargo.toml
@@ -23,6 +23,7 @@ measure-json = ["rsvelte_core/measure-json"]
 measure-await = ["rsvelte_core/measure-await"]
 measure-slot-key = ["rsvelte_core/measure-slot-key"]
 measure-module-source = ["rsvelte_core/measure-module-source"]
+measure-hoisted = ["rsvelte_core/measure-hoisted"]
 
 [dependencies]
 rsvelte_ast_equiv = { path = "../rsvelte_ast_equiv" }

--- a/crates/rsvelte_devtools/Cargo.toml
+++ b/crates/rsvelte_devtools/Cargo.toml
@@ -21,6 +21,7 @@ mimalloc-alloc = ["dep:mimalloc"]
 pprof = ["dep:pprof"]
 measure-json = ["rsvelte_core/measure-json"]
 measure-await = ["rsvelte_core/measure-await"]
+measure-slot-key = ["rsvelte_core/measure-slot-key"]
 
 [dependencies]
 rsvelte_ast_equiv = { path = "../rsvelte_ast_equiv" }

--- a/crates/rsvelte_devtools/Cargo.toml
+++ b/crates/rsvelte_devtools/Cargo.toml
@@ -19,7 +19,6 @@ native = [
 jemalloc = ["dep:tikv-jemallocator"]
 mimalloc-alloc = ["dep:mimalloc"]
 pprof = ["dep:pprof"]
-measure-json = ["rsvelte_core/measure-json"]
 measure-await = ["rsvelte_core/measure-await"]
 measure-slot-key = ["rsvelte_core/measure-slot-key"]
 measure-module-source = ["rsvelte_core/measure-module-source"]

--- a/crates/rsvelte_devtools/Cargo.toml
+++ b/crates/rsvelte_devtools/Cargo.toml
@@ -19,6 +19,8 @@ native = [
 jemalloc = ["dep:tikv-jemallocator"]
 mimalloc-alloc = ["dep:mimalloc"]
 pprof = ["dep:pprof"]
+measure-json = ["rsvelte_core/measure-json"]
+measure-await = ["rsvelte_core/measure-await"]
 
 [dependencies]
 rsvelte_ast_equiv = { path = "../rsvelte_ast_equiv" }

--- a/crates/rsvelte_devtools/src/bin/await_alloc_count.rs
+++ b/crates/rsvelte_devtools/src/bin/await_alloc_count.rs
@@ -4,8 +4,9 @@
 //!
 //! Load-independent: the replayed scanner runs next to the current one on the
 //! same inputs, so the totals are "what the old code would have allocated"
-//! against the current code's zero at those sites. Requires the instrumentation
-//! feature:
+//! against the current code's zero at those sites. The same run also compares
+//! the two scanners' verdicts, so a nonzero mismatch count means the refactor
+//! changed behavior. Requires the instrumentation feature:
 //!
 //! ```text
 //! cargo run --profile profiling -p rsvelte_devtools --bin await_alloc_count \
@@ -89,7 +90,7 @@ fn main() {
             },
         );
     }
-    let (calls, input_bytes, word_async, rest, rest_again, word_await, alloc_bytes) =
+    let (calls, input_bytes, word_async, rest, rest_again, word_await, alloc_bytes, mismatch) =
         measure_await::snapshot();
 
     let n = files.len() as f64;
@@ -113,4 +114,5 @@ fn main() {
         total as f64 / n
     );
     println!("new code allocates 0 at these four sites");
+    println!("verdict mismatches (old vs new): {mismatch}");
 }

--- a/crates/rsvelte_devtools/src/bin/await_alloc_count.rs
+++ b/crates/rsvelte_devtools/src/bin/await_alloc_count.rs
@@ -1,0 +1,116 @@
+//! Counts the `String` allocations that the pre-refactor `await` scanner in
+//! `3_transform/client/expression_utils.rs` performed, over the flowbite-svelte
+//! corpus.
+//!
+//! Load-independent: the replayed scanner runs next to the current one on the
+//! same inputs, so the totals are "what the old code would have allocated"
+//! against the current code's zero at those sites. Requires the instrumentation
+//! feature:
+//!
+//! ```text
+//! cargo run --profile profiling -p rsvelte_devtools --bin await_alloc_count \
+//!   --features measure-await
+//! ```
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use rsvelte_core::{CompileOptions, GenerateMode, compile};
+
+fn collect(dir: &Path, files: &mut Vec<(PathBuf, String)>) {
+    let Ok(entries) = fs::read_dir(dir) else {
+        return;
+    };
+    let mut paths: Vec<PathBuf> = entries.flatten().map(|e| e.path()).collect();
+    paths.sort();
+    for path in paths {
+        if path.is_dir() {
+            if path.file_name().is_some_and(|n| n == "node_modules") {
+                continue;
+            }
+            collect(&path, files);
+        } else if path.extension().is_some_and(|e| e == "svelte")
+            && let Ok(content) = fs::read_to_string(&path)
+        {
+            files.push((path, content));
+        }
+    }
+}
+
+#[cfg(not(feature = "measure-await"))]
+fn main() {
+    eprintln!("build with --features measure-await");
+    std::process::exit(2);
+}
+
+#[cfg(feature = "measure-await")]
+fn main() {
+    use rsvelte_core::measure_await;
+
+    let mut mode = GenerateMode::Client;
+    let mut root = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .join("submodules/flowbite-svelte");
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    let mut i = 0;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--mode" => {
+                i += 1;
+                mode = match args[i].as_str() {
+                    "server" => GenerateMode::Server,
+                    _ => GenerateMode::Client,
+                };
+            }
+            "--dir" => {
+                i += 1;
+                root = PathBuf::from(&args[i]);
+            }
+            other => panic!("unknown argument: {other}"),
+        }
+        i += 1;
+    }
+
+    let mut files = Vec::new();
+    collect(&root, &mut files);
+    assert!(
+        !files.is_empty(),
+        "no .svelte files under {}",
+        root.display()
+    );
+
+    measure_await::reset();
+    for (_, content) in &files {
+        let _ = compile(
+            content,
+            CompileOptions {
+                generate: mode,
+                ..Default::default()
+            },
+        );
+    }
+    let (calls, input_bytes, word_async, rest, rest_again, word_await, alloc_bytes) =
+        measure_await::snapshot();
+
+    let n = files.len() as f64;
+    let total = word_async + rest + rest_again + word_await;
+    println!("files: {}", files.len());
+    println!(
+        "scanner calls:  {calls} total, {:.1}/file",
+        calls as f64 / n
+    );
+    println!(
+        "scanned bytes:  {input_bytes} total, {:.1}/call",
+        input_bytes as f64 / calls.max(1) as f64
+    );
+    println!("removed String allocations (old code):");
+    println!("  word (async test): {word_async}");
+    println!("  rest:              {rest}");
+    println!("  rest (again):      {rest_again}");
+    println!("  word (await test): {word_await}");
+    println!(
+        "  total:             {total}, {:.1}/file, {alloc_bytes} bytes",
+        total as f64 / n
+    );
+    println!("new code allocates 0 at these four sites");
+}

--- a/crates/rsvelte_devtools/src/bin/await_alloc_count.rs
+++ b/crates/rsvelte_devtools/src/bin/await_alloc_count.rs
@@ -13,11 +13,15 @@
 //!   --features measure-await
 //! ```
 
+#[cfg(feature = "measure-await")]
 use std::fs;
+#[cfg(feature = "measure-await")]
 use std::path::{Path, PathBuf};
 
+#[cfg(feature = "measure-await")]
 use rsvelte_core::{CompileOptions, GenerateMode, compile};
 
+#[cfg(feature = "measure-await")]
 fn collect(dir: &Path, files: &mut Vec<(PathBuf, String)>) {
     let Ok(entries) = fs::read_dir(dir) else {
         return;

--- a/crates/rsvelte_devtools/src/bin/hoisted_alloc_count.rs
+++ b/crates/rsvelte_devtools/src/bin/hoisted_alloc_count.rs
@@ -1,0 +1,164 @@
+//! Weighs the `hoisted` pre-allocation in `clean_node_list` against a lazily
+//! growing `Vec`.
+//!
+//! Load-independent: the recorder captures the final `hoisted` length of every
+//! `clean_node_list` call, and the growth curves are measured on the real
+//! element type, so both allocation counts are derived rather than timed.
+//! `--parse-only` is the negative control: it runs the same binary over the same
+//! corpus without reaching the transform phase. Requires the instrumentation
+//! feature:
+//!
+//! ```text
+//! cargo run --profile profiling -p rsvelte_devtools --bin hoisted_alloc_count \
+//!   --features measure-hoisted
+//! ```
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use rsvelte_core::{CompileOptions, GenerateMode, compile};
+
+fn collect(dir: &Path, files: &mut Vec<(PathBuf, String)>) {
+    let Ok(entries) = fs::read_dir(dir) else {
+        return;
+    };
+    let mut paths: Vec<PathBuf> = entries.flatten().map(|e| e.path()).collect();
+    paths.sort();
+    for path in paths {
+        if path.is_dir() {
+            if path.file_name().is_some_and(|n| n == "node_modules") {
+                continue;
+            }
+            collect(&path, files);
+        } else if path.extension().is_some_and(|e| e == "svelte")
+            && let Ok(content) = fs::read_to_string(&path)
+        {
+            files.push((path, content));
+        }
+    }
+}
+
+#[cfg(not(feature = "measure-hoisted"))]
+fn main() {
+    eprintln!("build with --features measure-hoisted");
+    std::process::exit(2);
+}
+
+#[cfg(feature = "measure-hoisted")]
+fn main() {
+    use rsvelte_core::measure_hoisted;
+
+    let mut mode = GenerateMode::Client;
+    let mut parse_only = false;
+    let mut root = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .join("submodules/flowbite-svelte");
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    let mut i = 0;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--mode" => {
+                i += 1;
+                mode = match args[i].as_str() {
+                    "server" => GenerateMode::Server,
+                    _ => GenerateMode::Client,
+                };
+            }
+            "--dir" => {
+                i += 1;
+                root = PathBuf::from(&args[i]);
+            }
+            "--parse-only" => parse_only = true,
+            other => panic!("unknown argument: {other}"),
+        }
+        i += 1;
+    }
+
+    let mut files = Vec::new();
+    collect(&root, &mut files);
+    assert!(
+        !files.is_empty(),
+        "no .svelte files under {}",
+        root.display()
+    );
+
+    measure_hoisted::reset();
+    for (_, content) in &files {
+        if parse_only {
+            let allocator = oxc_allocator::Allocator::default();
+            let _ = rsvelte_core::parse(content, &allocator, rsvelte_core::ParseOptions::default());
+        } else {
+            let _ = compile(
+                content,
+                CompileOptions {
+                    generate: mode,
+                    ..Default::default()
+                },
+            );
+        }
+    }
+    let (calls, empty_input, hist, over) = measure_hoisted::snapshot();
+
+    // Measured growth: the lengths at which a push (re)allocates.
+    let longest = over.iter().copied().max().unwrap_or(hist.len());
+    let lazy_steps = measure_hoisted::growth_steps(0, longest + 1);
+    let capped_steps = measure_hoisted::growth_steps(8, longest + 1);
+    let allocs_lazy = |len: usize| lazy_steps.iter().filter(|&&s| s <= len).count() as u64;
+    // The old code sized the vec at `min(input, 8)`; `hoisted.len() <= input`, so
+    // it reallocated only past 8.
+    let allocs_capped = |len: usize| 1 + capped_steps.iter().filter(|&&s| s <= len).count() as u64;
+
+    let mut old_allocs = 0u64;
+    let mut new_allocs = 0u64;
+    let mut hoisted_empty = 0u64;
+    let mut hoisted_over8 = 0u64;
+    for (len, n) in hist.iter().enumerate() {
+        if *n == 0 {
+            continue;
+        }
+        if len == 0 {
+            hoisted_empty += n;
+        }
+        if len > 8 {
+            hoisted_over8 += n;
+        }
+        // An empty input allocated nothing even in the old code.
+        let old_per_call = if len == 0 { 1 } else { allocs_capped(len) };
+        old_allocs += n * old_per_call;
+        new_allocs += n * allocs_lazy(len);
+    }
+    for len in &over {
+        hoisted_over8 += 1;
+        old_allocs += allocs_capped(*len);
+        new_allocs += allocs_lazy(*len);
+    }
+    // Calls with no input nodes at all allocated nothing on either side.
+    old_allocs -= empty_input;
+
+    println!("files: {}", files.len());
+    println!("clean_node_list calls: {calls}");
+    println!("  empty input (allocated nothing either way): {empty_input}");
+    println!(
+        "  hoisted empty: {hoisted_empty} ({:.2}%)",
+        hoisted_empty as f64 * 100.0 / calls as f64
+    );
+    println!("  hoisted len > 8: {hoisted_over8}");
+    println!("element size: {} bytes", measure_hoisted::element_size());
+    println!("measured growth from cap 0: {lazy_steps:?}");
+    println!("measured growth from cap 8: {capped_steps:?}");
+    println!("hoisted length histogram (len: calls):");
+    for (len, n) in hist.iter().enumerate() {
+        if *n > 0 {
+            println!("  {len:>3}: {n}");
+        }
+    }
+    if !over.is_empty() {
+        println!("  >32: {over:?}");
+    }
+    println!("hoisted allocations, old `with_capacity(min(n,8))`: {old_allocs}");
+    println!("hoisted allocations, lazy `Vec::new()`:             {new_allocs}");
+    println!(
+        "delta (negative = lazy wins): {}",
+        new_allocs as i64 - old_allocs as i64
+    );
+}

--- a/crates/rsvelte_devtools/src/bin/hoisted_alloc_count.rs
+++ b/crates/rsvelte_devtools/src/bin/hoisted_alloc_count.rs
@@ -13,11 +13,15 @@
 //!   --features measure-hoisted
 //! ```
 
+#[cfg(feature = "measure-hoisted")]
 use std::fs;
+#[cfg(feature = "measure-hoisted")]
 use std::path::{Path, PathBuf};
 
+#[cfg(feature = "measure-hoisted")]
 use rsvelte_core::{CompileOptions, GenerateMode, compile};
 
+#[cfg(feature = "measure-hoisted")]
 fn collect(dir: &Path, files: &mut Vec<(PathBuf, String)>) {
     let Ok(entries) = fs::read_dir(dir) else {
         return;

--- a/crates/rsvelte_devtools/src/bin/module_source_alloc_count.rs
+++ b/crates/rsvelte_devtools/src/bin/module_source_alloc_count.rs
@@ -1,0 +1,121 @@
+//! Counts the quoted-module-source `String` allocations that the pre-refactor
+//! `module_source` in `3_transform/builders.rs` and
+//! `3_transform/js_ast/to_oxc.rs` performed.
+//!
+//! Load-independent: the recorder sits on the exact line that used to run
+//! `format!("'{source}'")`, so `calls` is the number of heap `String`s the old
+//! code allocated there. `--parse-only` is the negative control: it runs the
+//! same binary over the same corpus without reaching the transform phase.
+//! Requires the instrumentation feature:
+//!
+//! ```text
+//! cargo run --profile profiling -p rsvelte_devtools --bin module_source_alloc_count \
+//!   --features measure-module-source
+//! ```
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use rsvelte_core::{CompileOptions, GenerateMode, compile};
+
+fn collect(dir: &Path, files: &mut Vec<(PathBuf, String)>) {
+    let Ok(entries) = fs::read_dir(dir) else {
+        return;
+    };
+    let mut paths: Vec<PathBuf> = entries.flatten().map(|e| e.path()).collect();
+    paths.sort();
+    for path in paths {
+        if path.is_dir() {
+            if path.file_name().is_some_and(|n| n == "node_modules") {
+                continue;
+            }
+            collect(&path, files);
+        } else if path.extension().is_some_and(|e| e == "svelte")
+            && let Ok(content) = fs::read_to_string(&path)
+        {
+            files.push((path, content));
+        }
+    }
+}
+
+#[cfg(not(feature = "measure-module-source"))]
+fn main() {
+    eprintln!("build with --features measure-module-source");
+    std::process::exit(2);
+}
+
+#[cfg(feature = "measure-module-source")]
+fn main() {
+    use rsvelte_core::measure_module_source;
+
+    let mut mode = GenerateMode::Client;
+    let mut parse_only = false;
+    let mut per_file = false;
+    let mut root = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .join("submodules/flowbite-svelte");
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    let mut i = 0;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--mode" => {
+                i += 1;
+                mode = match args[i].as_str() {
+                    "server" => GenerateMode::Server,
+                    _ => GenerateMode::Client,
+                };
+            }
+            "--dir" => {
+                i += 1;
+                root = PathBuf::from(&args[i]);
+            }
+            "--parse-only" => parse_only = true,
+            "--per-file" => per_file = true,
+            other => panic!("unknown argument: {other}"),
+        }
+        i += 1;
+    }
+
+    let mut files = Vec::new();
+    collect(&root, &mut files);
+    assert!(
+        !files.is_empty(),
+        "no .svelte files under {}",
+        root.display()
+    );
+
+    measure_module_source::reset();
+    let mut previous = 0u64;
+    for (path, content) in &files {
+        if parse_only {
+            let allocator = oxc_allocator::Allocator::default();
+            let _ = rsvelte_core::parse(content, &allocator, rsvelte_core::ParseOptions::default());
+        } else {
+            let _ = compile(
+                content,
+                CompileOptions {
+                    generate: mode,
+                    ..Default::default()
+                },
+            );
+        }
+        if per_file {
+            let (calls, _) = measure_module_source::snapshot();
+            println!("{:>6}  {}", calls - previous, path.display());
+            previous = calls;
+        }
+    }
+    let (calls, source_bytes) = measure_module_source::snapshot();
+
+    let n = files.len() as f64;
+    println!("files: {}", files.len());
+    println!(
+        "module_source calls: {calls} total, {:.2}/file",
+        calls as f64 / n
+    );
+    println!(
+        "removed heap String allocations (old code): {calls}, {} bytes",
+        source_bytes + 2 * calls
+    );
+    println!("removed arena allocations (old code): {calls}, {source_bytes} bytes");
+}

--- a/crates/rsvelte_devtools/src/bin/module_source_alloc_count.rs
+++ b/crates/rsvelte_devtools/src/bin/module_source_alloc_count.rs
@@ -13,11 +13,15 @@
 //!   --features measure-module-source
 //! ```
 
+#[cfg(feature = "measure-module-source")]
 use std::fs;
+#[cfg(feature = "measure-module-source")]
 use std::path::{Path, PathBuf};
 
+#[cfg(feature = "measure-module-source")]
 use rsvelte_core::{CompileOptions, GenerateMode, compile};
 
+#[cfg(feature = "measure-module-source")]
 fn collect(dir: &Path, files: &mut Vec<(PathBuf, String)>) {
     let Ok(entries) = fs::read_dir(dir) else {
         return;

--- a/crates/rsvelte_devtools/src/bin/slot_key_alloc_count.rs
+++ b/crates/rsvelte_devtools/src/bin/slot_key_alloc_count.rs
@@ -1,0 +1,104 @@
+//! Counts the slot-name `String` allocations that the pre-refactor component
+//! slot grouping in `3_transform/client/visitors/shared/component.rs`
+//! performed.
+//!
+//! Load-independent: the recorder sits on the exact line that used to produce
+//! the owned key, so `calls` is the number of `String`s the old code allocated
+//! and `bytes` is how many bytes they copied. The new code allocates none
+//! there. Requires the instrumentation feature:
+//!
+//! ```text
+//! cargo run --profile profiling -p rsvelte_devtools --bin slot_key_alloc_count \
+//!   --features measure-slot-key
+//! ```
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use rsvelte_core::{CompileOptions, GenerateMode, compile};
+
+fn collect(dir: &Path, files: &mut Vec<(PathBuf, String)>) {
+    let Ok(entries) = fs::read_dir(dir) else {
+        return;
+    };
+    let mut paths: Vec<PathBuf> = entries.flatten().map(|e| e.path()).collect();
+    paths.sort();
+    for path in paths {
+        if path.is_dir() {
+            if path.file_name().is_some_and(|n| n == "node_modules") {
+                continue;
+            }
+            collect(&path, files);
+        } else if path.extension().is_some_and(|e| e == "svelte")
+            && let Ok(content) = fs::read_to_string(&path)
+        {
+            files.push((path, content));
+        }
+    }
+}
+
+#[cfg(not(feature = "measure-slot-key"))]
+fn main() {
+    eprintln!("build with --features measure-slot-key");
+    std::process::exit(2);
+}
+
+#[cfg(feature = "measure-slot-key")]
+fn main() {
+    use rsvelte_core::measure_slot_key;
+
+    let mut mode = GenerateMode::Client;
+    let mut root = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .join("submodules/flowbite-svelte");
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    let mut i = 0;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--mode" => {
+                i += 1;
+                mode = match args[i].as_str() {
+                    "server" => GenerateMode::Server,
+                    _ => GenerateMode::Client,
+                };
+            }
+            "--dir" => {
+                i += 1;
+                root = PathBuf::from(&args[i]);
+            }
+            other => panic!("unknown argument: {other}"),
+        }
+        i += 1;
+    }
+
+    let mut files = Vec::new();
+    collect(&root, &mut files);
+    assert!(
+        !files.is_empty(),
+        "no .svelte files under {}",
+        root.display()
+    );
+
+    measure_slot_key::reset();
+    for (_, content) in &files {
+        let _ = compile(
+            content,
+            CompileOptions {
+                generate: mode,
+                ..Default::default()
+            },
+        );
+    }
+    let (calls, bytes, default_keys) = measure_slot_key::snapshot();
+
+    let n = files.len() as f64;
+    println!("files: {}", files.len());
+    println!(
+        "slot-key computations: {calls} total, {:.2}/file",
+        calls as f64 / n
+    );
+    println!("  named slot keys:  {}", calls - default_keys);
+    println!("  \"default\" keys:   {default_keys}");
+    println!("removed String allocations (old code): {calls}, {bytes} bytes");
+    println!("new code allocates 0 at this site");
+}

--- a/crates/rsvelte_devtools/src/bin/slot_key_alloc_count.rs
+++ b/crates/rsvelte_devtools/src/bin/slot_key_alloc_count.rs
@@ -12,11 +12,15 @@
 //!   --features measure-slot-key
 //! ```
 
+#[cfg(feature = "measure-slot-key")]
 use std::fs;
+#[cfg(feature = "measure-slot-key")]
 use std::path::{Path, PathBuf};
 
+#[cfg(feature = "measure-slot-key")]
 use rsvelte_core::{CompileOptions, GenerateMode, compile};
 
+#[cfg(feature = "measure-slot-key")]
 fn collect(dir: &Path, files: &mut Vec<(PathBuf, String)>) {
     let Ok(entries) = fs::read_dir(dir) else {
         return;


### PR DESCRIPTION
Four allocation-shaped hot spots in Phase-3 client transform, each landing as a
measurement commit followed by the change it justifies.

Every one of these was picked by a deterministic counter, not by a wall-clock
guess. **No wall-clock claim is made in this PR** — the counters say how much
work stopped happening; they do not say how many milliseconds that is worth.

## What changes

| change | counter that selected it |
|---|---|
| scan for `await` without building a `String` per character | 86 allocations/file on the scanner stack |
| key component slot grouping on borrowed names | one `String` per slot per group |
| build module-source quoting in the arena | one heap `String` per module source |
| let the `clean_node_list` hoisted list grow on demand | measured length distribution, fixed-size preallocation |

## Gates carried by the commits themselves

- The `await` scanner counter is a **differential oracle**, not a tally: it runs
  the dropped scanner arm alongside the new one and compares every answer, with a
  denominator. `5d7f6073` pins the dropped arm against the old scanner so the
  oracle cannot silently degrade into comparing the new code with itself.
- `05948661` documents where the oracle's replayed body *deliberately* deviates
  from the old one, so a future reader does not read agreement as byte-identity.
- Each measurement module sits behind its own feature flag and compiles out of
  the shipping build.

## What this PR does not contain

The `local_reactive_vars` indexing change (A1/A2) is **held back** — its
pre-registered prediction (scaling exponent 2.161 -> 1.75) did not verify, and it
should not ride in on a PR whose other changes did.

## Honest limits

- These are allocation-count reductions. Their share of total compile time is not
  established here, and on the corpora measured the buckets they sit in are
  sublinear in script bytes. Treat this as removing waste, not as a speedup with
  a number attached.
- The measurement binaries are `rsvelte_devtools` autobins; `rsvelte_core` gains
  no `[[bin]]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BULH9QNYfezhWuod5bZuGu

## Output-neutrality, established by bytes rather than by tests passing

A raw-byte sweep over the corpus output trees:

- **42,454 files / 104,352,444 bytes**, both trees equal
- `diff -r`: **exit 0, 0 lines**
- the output tree is copied out with `cp -Rc` *before* `verify.mjs` runs, because
  verify rewrites it in place with oxfmt, which would destroy the raw evidence
- `binary mtime > source mtime` checked on both builds
- **negative control on `diff` itself**: one byte injected into one file,
  detected (exit 1), reverted, re-run clean (exit 0)

**What this does not establish.** The swept interval runs from `a3f446ee` (the
parent of the await-scanner change) to the tip of the branch these commits were
authored on, so it covers this PR's changes *plus* instrumentation-only commits
that are not here. Superset-neutrality does not formally imply subset-neutrality
— two changes could in principle cancel. The extra commits add counters and do
not touch output paths, but the sweep was not re-run on this branch in isolation.
