### PR TITLE
fix(compiler): report a null prop alias for legacy ownership mutations

### DIFF
--- a/.changeset/ownership-mutation-null-alias.md
+++ b/.changeset/ownership-mutation-null-alias.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/compiler": patch
+---
+
+Pass a `null` prop alias to `$$ownership_validator.mutation(...)` for legacy `export let` props in dev mode, matching the official compiler — the alias is only ever set from a `$props()` destructuring key, so falling back to the variable name diverged for every legacy component.

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/bind_directive.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/bind_directive.rs
@@ -1911,10 +1911,13 @@ fn build_getter_setter_with_primitive(
                             None
                         };
                     if let Some(path) = path {
-                        let prop_alias =
-                            binding.prop_alias.as_ref().unwrap_or(&binding.name).clone();
-                        let mut args =
-                            vec![b::string(&prop_alias), b::array(path), transformed_set];
+                        let mut args = vec![
+                            crate::compiler::phases::phase3_transform::client::visitors::expression_converter::ownership_alias_literal(
+                                binding.prop_alias.clone(),
+                            ),
+                            b::array(path),
+                            transformed_set,
+                        ];
                         // Add source location (line, column) if available
                         let start_pos = original_expr.start().map(|v| v as usize);
                         if let Some(start) = start_pos {

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/expression_converter.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/expression_converter.rs
@@ -4432,7 +4432,7 @@ fn convert_assignment_expression(
     // Wrap with ownership validation if needed
     if let Some((prop_alias, path, source_loc)) = ownership_info {
         use crate::compiler::phases::phase3_transform::js_ast::builders as b;
-        let mut args = vec![b::string(&prop_alias), b::array(path), result];
+        let mut args = vec![ownership_alias_literal(prop_alias), b::array(path), result];
         if let Some((line, col)) = source_loc {
             args.push(b::literal_number(line as f64));
             args.push(b::literal_number(col as f64));
@@ -4565,7 +4565,7 @@ fn comment_has_svelte_ignore(text: &str, code: &str) -> bool {
 pub(crate) fn check_ownership_validation(
     left_json: Option<&Value>,
     context: &ComponentContext,
-) -> Option<(String, Vec<JsExpr>, Option<(usize, usize)>)> {
+) -> Option<(Option<String>, Vec<JsExpr>, Option<(usize, usize)>)> {
     use crate::compiler::phases::phase2_analyze::scope::BindingKind;
 
     let left_val = left_json?;
@@ -4594,7 +4594,9 @@ pub(crate) fn check_ownership_validation(
     // Build the property path
     let path = build_member_path_from_json(left_val, context)?;
 
-    let prop_alias = binding.prop_alias.as_ref().unwrap_or(&binding.name).clone();
+    // Upstream passes `binding.prop_alias` straight through, so a legacy
+    // `export let` prop — which never gets one — reports `null`.
+    let prop_alias = binding.prop_alias.clone();
 
     // Get source location from the root identifier's start position
     let source_loc = get_root_start_position(left_val).and_then(|start| {
@@ -4616,7 +4618,7 @@ fn check_ownership_validation_typed(
     node_start: u32,
     target: &JsNode,
     context: &ComponentContext,
-) -> Option<(String, Vec<JsExpr>, Option<(usize, usize)>)> {
+) -> Option<(Option<String>, Vec<JsExpr>, Option<(usize, usize)>)> {
     if !context.state.dev || !matches!(target, JsNode::MemberExpression { .. }) {
         return None;
     }
@@ -4633,7 +4635,7 @@ fn check_ownership_validation_typed(
 
 /// Wrap `expression` in `$$ownership_validator.mutation(...)` using previously collected info.
 fn wrap_with_ownership_mutation(
-    info: Option<(String, Vec<JsExpr>, Option<(usize, usize)>)>,
+    info: Option<(Option<String>, Vec<JsExpr>, Option<(usize, usize)>)>,
     expression: JsExpr,
     context: &ComponentContext,
 ) -> JsExpr {
@@ -4641,7 +4643,11 @@ fn wrap_with_ownership_mutation(
     let Some((prop_alias, path, source_loc)) = info else {
         return expression;
     };
-    let mut args = vec![b::string(&prop_alias), b::array(path), expression];
+    let mut args = vec![
+        ownership_alias_literal(prop_alias),
+        b::array(path),
+        expression,
+    ];
     if let Some((line, col)) = source_loc {
         args.push(b::literal_number(line as f64));
         args.push(b::literal_number(col as f64));
@@ -4651,6 +4657,16 @@ fn wrap_with_ownership_mutation(
         b::member_path(&context.arena, "$$ownership_validator.mutation"),
         args,
     )
+}
+
+/// `$$ownership_validator.mutation`'s first argument: the prop alias, or `null`
+/// for a binding that has none (`b.literal(binding.prop_alias)` upstream).
+pub(crate) fn ownership_alias_literal(prop_alias: Option<String>) -> JsExpr {
+    use crate::compiler::phases::phase3_transform::js_ast::builders as b;
+    match prop_alias {
+        Some(alias) => b::string(alias),
+        None => b::null(),
+    }
 }
 
 /// Get the start position of the root identifier in a member expression chain.
@@ -6220,7 +6236,7 @@ fn convert_update_expression(
     // Wrap with ownership validation if needed
     if let Some((prop_alias, path, source_loc)) = ownership_info {
         use crate::compiler::phases::phase3_transform::js_ast::builders as b;
-        let mut args = vec![b::string(&prop_alias), b::array(path), result];
+        let mut args = vec![ownership_alias_literal(prop_alias), b::array(path), result];
         if let Some((line, col)) = source_loc {
             args.push(b::literal_number(line as f64));
             args.push(b::literal_number(col as f64));

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/component.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/component.rs
@@ -1795,7 +1795,13 @@ fn process_bind_directive<'a>(
                             context,
                         )
                     {
-                        let mut args = vec![b::string(&prop_alias), b::array(path), wrapped];
+                        let mut args = vec![
+                            crate::compiler::phases::phase3_transform::client::visitors::expression_converter::ownership_alias_literal(
+                                prop_alias,
+                            ),
+                            b::array(path),
+                            wrapped,
+                        ];
                         if let Some((line, col)) = source_loc {
                             args.push(b::literal_number(line as f64));
                             args.push(b::literal_number(col as f64));

--- a/crates/rsvelte_core/tests/dev_ownership_validator_bind_alias.rs
+++ b/crates/rsvelte_core/tests/dev_ownership_validator_bind_alias.rs
@@ -1,0 +1,70 @@
+//! `$$ownership_validator.mutation(...)`'s first argument is `binding.prop_alias`
+//! verbatim (`shared/utils.js:436`), and upstream only ever assigns that alias
+//! from a `$props()` destructuring key — so a legacy `export let` prop mutated
+//! through a `bind:` directive must report `null`, not the variable name.
+//!
+//! The corpus gates compile with `dev: false`, so nothing else covers this.
+
+use rsvelte_core::{CompileOptions, GenerateMode, compile};
+
+fn compile_client_dev(src: &str) -> String {
+    compile(
+        src,
+        CompileOptions {
+            filename: Some("BindAlias.svelte".to_string()),
+            generate: GenerateMode::Client,
+            dev: true,
+            ..Default::default()
+        },
+    )
+    .expect("compile")
+    .js
+    .code
+}
+
+#[test]
+fn legacy_component_bind_member_reports_a_null_alias() {
+    let out = compile_client_dev(
+        r#"<script>
+	import Child from './Child.svelte';
+	export let field = {};
+</script>
+<Child bind:value={field.name} />
+"#,
+    );
+    assert!(
+        out.contains("$ownership_validator.mutation(null, ['field', 'name'],"),
+        "expected a null alias for the legacy prop, got:\n{out}"
+    );
+}
+
+#[test]
+fn runes_component_bind_member_reports_the_props_key() {
+    let out = compile_client_dev(
+        r#"<script>
+	import Child from './Child.svelte';
+	let { 'data-field': field = $bindable({}) } = $props();
+</script>
+<Child bind:value={field.name} />
+"#,
+    );
+    assert!(
+        out.contains("$ownership_validator.mutation('data-field', ['field', 'name'],"),
+        "expected the $props() key as the alias, got:\n{out}"
+    );
+}
+
+#[test]
+fn legacy_element_bind_member_reports_a_null_alias() {
+    let out = compile_client_dev(
+        r#"<script>
+	export let field = {};
+</script>
+<input bind:value={field.name} />
+"#,
+    );
+    assert!(
+        out.contains("$ownership_validator.mutation(null, ['field', 'name'],"),
+        "expected a null alias for the legacy prop, got:\n{out}"
+    );
+}


### PR DESCRIPTION
## What

`$$ownership_validator.mutation(...)` takes `binding.prop_alias` verbatim
(`3-transform/client/visitors/shared/utils.js:436` — `b.literal(binding.prop_alias)`),
and `prop_alias` is only ever assigned from a `$props()` destructuring key
(`2-analyze/visitors/VariableDeclarator.js:120`). A legacy `export let` prop
therefore has none, and the official compiler emits `null`.

rsvelte's `bind:` and typed-codegen paths fell back to `binding.name`, so every
legacy component reported the local variable name instead:

```diff
 $$ownership_validator.mutation(
-  "field",
+  null,
   ["field", "htmlAttributes", "value"],
   field((field().htmlAttributes.value = $$value), true),
   20,
   …
 );
```

The instance-script path already reported `null` (#2247); this closes the same
gap on the two remaining emitters (`check_ownership_validation`, the `bind:`
directive) by threading `Option<String>` through instead of collapsing it early.

## Impact

`compatibility/known-failures.client-dev.json`: **187 → 148** (−39), no
regression on `client` / `server` (both empty). The ratchet itself is left for
the burn-down chore PR, per the low-friction convention in
`compatibility/known-failures.md`.

## Test

`crates/rsvelte_core/tests/dev_ownership_validator_bind_alias.rs` — legacy vs
`$props()`-aliased prop for both the component and element `bind:` paths. The
corpus compile gates run with `dev: false`, so nothing else covers this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014EJ8yjsgEh6CxqJhQoGZHP