### PR TITLE
feat(lint): add svelte/no-unused-vars

### DIFF
--- a/.changeset/lint-no-unused-vars.md
+++ b/.changeset/lint-no-unused-vars.md
@@ -1,0 +1,15 @@
+---
+"@rsvelte/lint": patch
+---
+
+Add `svelte/no-unused-vars`, a Svelte-aware unused-variable rule for component
+scripts. ESLint core's `no-unused-vars` and oxlint both stop at the `.svelte`
+boundary, so top-level `<script>` bindings went unchecked unless a project kept
+a Svelte-aware ESLint around. The rule reads the compiler's Phase-2 scope tree,
+so template reads, `$store` auto-subscriptions and `bind:` targets all count as
+uses. It is deliberately conservative: only top-level module/instance-script
+declarations are judged, and props (`export let`, `$props()` destructuring,
+`$$props`/`$$restProps`/`$$slots`), exported declarations, reactive `$:`
+declarations, reassigned/mutated bindings, and names that occur anywhere else
+in the source (covering TypeScript type positions the scope tree does not
+record) are never reported.

--- a/apps/npm/oxlint-plugin/recommended.json
+++ b/apps/npm/oxlint-plugin/recommended.json
@@ -104,6 +104,7 @@
     "svelte/no-unknown-style-directive-property": "warn",
     "svelte/no-unnecessary-state-wrap": "warn",
     "svelte/no-unused-class-name": "warn",
+    "svelte/no-unused-vars": "warn",
     "svelte/no-useless-children-snippet": "warn",
     "svelte/no-useless-mustaches": "warn",
     "svelte/node_invalid_placement_ssr": "warn",

--- a/crates/rsvelte_lint/src/registry.rs
+++ b/crates/rsvelte_lint/src/registry.rs
@@ -219,5 +219,6 @@ pub fn all_script_rules() -> Vec<Box<dyn crate::script::ScriptRule>> {
             crate::rules::no_export_load_in_svelte_module_in_kit_pages::NoExportLoadInSvelteModuleInKitPages,
         ),
         Box::new(crate::rules::infinite_reactive_loop::InfiniteReactiveLoop),
+        Box::new(crate::rules::no_unused_vars::NoUnusedVars),
     ]
 }

--- a/crates/rsvelte_lint/src/rules/mod.rs
+++ b/crates/rsvelte_lint/src/rules/mod.rs
@@ -72,6 +72,7 @@ pub mod no_unused_class_name;
 pub mod no_unused_props;
 #[cfg(feature = "native")] // native-only compile + source-scan meta rule (see above)
 pub mod no_unused_svelte_ignore;
+pub mod no_unused_vars;
 pub mod no_useless_children_snippet;
 pub mod no_useless_mustaches;
 pub mod prefer_class_directive;

--- a/crates/rsvelte_lint/src/rules/no_unused_vars.rs
+++ b/crates/rsvelte_lint/src/rules/no_unused_vars.rs
@@ -1,0 +1,405 @@
+//! `svelte/no-unused-vars` — flag top-level `<script>` bindings that are never
+//! read anywhere in the component (script, template, or `<style>` directives).
+//!
+//! ESLint core's `no-unused-vars` and oxlint both stop at the `.svelte`
+//! boundary, so a component's script variables go unchecked unless a project
+//! keeps a Svelte-aware ESLint around (issue #1732). This rule closes that gap
+//! using the compiler's own Phase-2 scope tree, which already resolves template
+//! reads, `$store` auto-subscriptions and `bind:` targets back to their binding.
+//!
+//! Deliberately conservative — a false positive on a real component is worse
+//! than a miss:
+//!
+//! - only **top-level** module/instance-script bindings are considered (each
+//!   items, snippet params, `let:` directives and function locals live in child
+//!   scopes and are never reported);
+//! - props (`export let`, `$props()` destructuring, `$$props`/`$$restProps`/
+//!   `$$slots`), stores read as `$name`, reactive `$:` declarations, exported
+//!   declarations and reassigned/mutated bindings are all treated as used;
+//! - a name that occurs anywhere else in the source is treated as used, which
+//!   covers reads Phase 2 does not record as references (TypeScript type
+//!   positions, JSDoc `@type`, generics).
+
+use serde_json::Value;
+
+use rsvelte_core::compiler::phases::phase2_analyze::{Binding, BindingKind, DeclarationKind};
+
+use crate::context::LintContext;
+use crate::rule::{Fixable, RuleCategory, RuleConditions, RuleMeta, Severity};
+use crate::script::{ProgramView, ScriptKind, ScriptRule};
+
+pub static META: RuleMeta = RuleMeta {
+    name: "svelte/no-unused-vars",
+    category: RuleCategory::Correctness,
+    fixable: Fixable::No,
+    default_severity: Severity::Warn,
+    conditions: RuleConditions {
+        runes_only: false,
+        legacy_only: false,
+    },
+    type_aware: false,
+    docs: "Disallow top-level `<script>` variables that are never used in the script or the template",
+    options_schema: None,
+};
+
+#[derive(Default)]
+pub struct NoUnusedVars;
+
+impl ScriptRule for NoUnusedVars {
+    fn meta(&self) -> &'static RuleMeta {
+        &META
+    }
+
+    fn check_program(&self, ctx: &mut LintContext, program: &ProgramView<'_>, kind: ScriptKind) {
+        let Some(analysis) = ctx.scope_analysis() else {
+            return;
+        };
+        let root = &analysis.root;
+
+        // Scope 0 is the module script; the instance script gets its own child
+        // scope (see `scope_builder::visit_root`).
+        let target_scope = match kind {
+            ScriptKind::Module => 0,
+            ScriptKind::Instance => root.instance_scope_index,
+        };
+        if kind == ScriptKind::Instance && target_scope == 0 {
+            return;
+        }
+
+        let exported = exported_names(program.value());
+        let source = ctx.source();
+
+        let mut reports: Vec<(u32, String)> = Vec::new();
+        for binding in &root.bindings {
+            if binding.scope_index != target_scope {
+                continue;
+            }
+            let Some(start) = binding.declaration_start else {
+                continue;
+            };
+            if exported.iter().any(|n| n == &binding.name) {
+                continue;
+            }
+            if !is_reportable(binding) {
+                continue;
+            }
+            // A `$name` binding means the store is auto-subscribed somewhere.
+            if root
+                .bindings_by_name
+                .contains_key(&format!("${}", binding.name))
+            {
+                continue;
+            }
+            if binding
+                .references
+                .iter()
+                .any(|r| !r.is_self_declaration && r.start != start)
+            {
+                continue;
+            }
+            if occurs_outside(source, &binding.name, start) {
+                continue;
+            }
+            reports.push((start, binding.name.clone()));
+        }
+
+        reports.sort_unstable();
+        for (start, name) in reports {
+            let end = start + name.len() as u32;
+            ctx.report(start, end, format!("'{name}' is defined but never used."));
+        }
+    }
+}
+
+/// Whether a binding is the kind of declaration this rule judges at all.
+/// Everything Svelte gives an implicit external meaning to (props, stores read
+/// via `$`, reactive declarations, template-owned bindings) is excluded.
+fn is_reportable(binding: &Binding) -> bool {
+    if binding.name.starts_with('$') {
+        return false;
+    }
+    if binding.reassigned || binding.mutated {
+        return false;
+    }
+    if !matches!(
+        binding.declaration_kind,
+        DeclarationKind::Let
+            | DeclarationKind::Const
+            | DeclarationKind::Var
+            | DeclarationKind::Function
+            | DeclarationKind::Import
+    ) {
+        return false;
+    }
+    matches!(
+        binding.kind,
+        BindingKind::Normal
+            | BindingKind::State
+            | BindingKind::RawState
+            | BindingKind::Derived
+            | BindingKind::Static
+    )
+}
+
+/// Names re-exported by this program, in any of the forms that make a
+/// declaration part of the module's public surface.
+fn exported_names(program: &Value) -> Vec<String> {
+    let mut out = Vec::new();
+    let Some(body) = program.get("body").and_then(Value::as_array) else {
+        return out;
+    };
+    for stmt in body {
+        let ty = stmt.get("type").and_then(Value::as_str).unwrap_or("");
+        if !matches!(
+            ty,
+            "ExportNamedDeclaration" | "ExportDefaultDeclaration" | "ExportAllDeclaration"
+        ) {
+            continue;
+        }
+        if let Some(decl) = stmt.get("declaration") {
+            collect_declared_names(decl, &mut out);
+        }
+        if let Some(specs) = stmt.get("specifiers").and_then(Value::as_array) {
+            for spec in specs {
+                if let Some(local) = spec
+                    .get("local")
+                    .and_then(|l| l.get("name"))
+                    .and_then(Value::as_str)
+                {
+                    out.push(local.to_string());
+                }
+            }
+        }
+    }
+    out
+}
+
+fn collect_declared_names(decl: &Value, out: &mut Vec<String>) {
+    match decl.get("type").and_then(Value::as_str) {
+        Some("VariableDeclaration") => {
+            if let Some(decls) = decl.get("declarations").and_then(Value::as_array) {
+                for d in decls {
+                    collect_pattern_names(d.get("id"), out);
+                }
+            }
+        }
+        Some(_) => {
+            if let Some(name) = decl
+                .get("id")
+                .and_then(|i| i.get("name"))
+                .and_then(Value::as_str)
+            {
+                out.push(name.to_string());
+            }
+        }
+        None => {}
+    }
+}
+
+fn collect_pattern_names(pat: Option<&Value>, out: &mut Vec<String>) {
+    let Some(pat) = pat else { return };
+    match pat.get("type").and_then(Value::as_str) {
+        Some("Identifier") => {
+            if let Some(name) = pat.get("name").and_then(Value::as_str) {
+                out.push(name.to_string());
+            }
+        }
+        Some("ObjectPattern") => {
+            if let Some(props) = pat.get("properties").and_then(Value::as_array) {
+                for p in props {
+                    collect_pattern_names(p.get("value").or_else(|| p.get("argument")), out);
+                }
+            }
+        }
+        Some("ArrayPattern") => {
+            if let Some(elems) = pat.get("elements").and_then(Value::as_array) {
+                for e in elems {
+                    collect_pattern_names(Some(e), out);
+                }
+            }
+        }
+        Some("AssignmentPattern") => collect_pattern_names(pat.get("left"), out),
+        Some("RestElement") => collect_pattern_names(pat.get("argument"), out),
+        _ => {}
+    }
+}
+
+/// Whether `name` appears as a standalone identifier anywhere in `source` other
+/// than at `decl_start`. Phase 2 records no reference for reads that the
+/// TypeScript stripper removes (type annotations, generics) or that live in
+/// JSDoc, so a textual hit anywhere else vetoes the report.
+fn occurs_outside(source: &str, name: &str, decl_start: u32) -> bool {
+    let bytes = source.as_bytes();
+    let mut from = 0usize;
+    while let Some(rel) = source[from..].find(name) {
+        let at = from + rel;
+        from = at + name.len();
+        if at as u32 == decl_start {
+            continue;
+        }
+        let before_ok = at == 0 || !is_ident_byte(bytes[at - 1]);
+        let after = at + name.len();
+        let after_ok = after >= bytes.len() || !is_ident_byte(bytes[after]);
+        if before_ok && after_ok {
+            return true;
+        }
+    }
+    false
+}
+
+fn is_ident_byte(b: u8) -> bool {
+    b.is_ascii_alphanumeric() || b == b'_' || b == b'$' || b >= 0x80
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::config::LintConfig;
+    use crate::engine::run_script_rules;
+    use crate::rule::Severity;
+
+    fn unused(src: &str) -> Vec<String> {
+        let config =
+            LintConfig::recommended().with_override("svelte/no-unused-vars", Severity::Warn);
+        run_script_rules(src, "Test.svelte", &config)
+            .into_iter()
+            .filter(|d| d.rule == "svelte/no-unused-vars")
+            .map(|d| d.message)
+            .collect()
+    }
+
+    fn assert_clean(src: &str) {
+        let found = unused(src);
+        assert!(
+            found.is_empty(),
+            "expected no findings, got {found:?}\n--- source ---\n{src}"
+        );
+    }
+
+    fn assert_reports(src: &str, name: &str) {
+        let found = unused(src);
+        assert!(
+            found.iter().any(|m| m.contains(&format!("'{name}'"))),
+            "expected a finding for '{name}', got {found:?}\n--- source ---\n{src}"
+        );
+    }
+
+    #[test]
+    fn reports_unused_top_level_const() {
+        assert_reports(
+            "<script>\n  const unused = 1;\n</script>\n<p>hi</p>",
+            "unused",
+        );
+    }
+
+    #[test]
+    fn reports_unused_import() {
+        assert_reports(
+            "<script>\n  import { tick } from 'svelte';\n</script>\n<p>hi</p>",
+            "tick",
+        );
+    }
+
+    #[test]
+    fn issue_example() {
+        let src = "<script>\n  import { writable } from 'svelte/store';\n\n  const count = writable(0);\n  const current = $count;\n  const unused = 1;\n</script>\n\n<p>{current}</p>";
+        let found = unused(src);
+        assert_eq!(found.len(), 1, "got {found:?}");
+        assert!(found[0].contains("'unused'"), "got {found:?}");
+    }
+
+    #[test]
+    fn legacy_export_let_prop_is_not_unused() {
+        assert_clean("<script>\n  export let name;\n</script>\n<p>hi</p>");
+    }
+
+    #[test]
+    fn props_rune_destructuring_is_not_unused() {
+        assert_clean("<script>\n  let { a, b = 1, ...rest } = $props();\n</script>\n<p>hi</p>");
+    }
+
+    #[test]
+    fn template_only_reference_is_not_unused() {
+        assert_clean("<script>\n  const greeting = 'hi';\n</script>\n<p>{greeting}</p>");
+    }
+
+    #[test]
+    fn dollar_dollar_props_are_not_unused() {
+        assert_clean(
+            "<script>\n  const a = $$props;\n  const b = $$restProps;\n  const c = $$slots;\n</script>\n<p>{a}{b}{c}</p>",
+        );
+    }
+
+    #[test]
+    fn snippet_params_are_not_unused() {
+        assert_clean(
+            "{#snippet row(item, i)}\n  <li>{item}</li>\n{/snippet}\n{@render row('a', 0)}",
+        );
+    }
+
+    #[test]
+    fn each_binding_used_only_in_template_is_not_unused() {
+        assert_clean(
+            "<script>\n  const items = [1, 2];\n</script>\n{#each items as item, i}\n  <li>{item}</li>\n{/each}",
+        );
+    }
+
+    #[test]
+    fn store_auto_subscription_keeps_the_store_used() {
+        assert_clean(
+            "<script>\n  import { writable } from 'svelte/store';\n  const count = writable(0);\n</script>\n<p>{$count}</p>",
+        );
+    }
+
+    #[test]
+    fn bind_target_is_not_unused() {
+        assert_clean("<script>\n  let value = '';\n</script>\n<input bind:value />");
+    }
+
+    #[test]
+    fn exported_module_declaration_is_not_unused() {
+        assert_clean(
+            "<script module>\n  export const VERSION = 1;\n  export function helper() {}\n</script>\n<p>hi</p>",
+        );
+    }
+
+    #[test]
+    fn export_specifier_is_not_unused() {
+        assert_clean("<script module>\n  const a = 1;\n  export { a };\n</script>\n<p>hi</p>");
+    }
+
+    #[test]
+    fn reactive_declaration_is_not_unused() {
+        assert_clean(
+            "<script>\n  export let n;\n  $: doubled = n * 2;\n</script>\n<p>{doubled}</p>",
+        );
+    }
+
+    #[test]
+    fn typescript_type_only_usage_is_not_unused() {
+        assert_clean(
+            "<script lang=\"ts\">\n  type Item = { id: number };\n  let rows: Item[] = [];\n</script>\n<p>{rows.length}</p>",
+        );
+    }
+
+    #[test]
+    fn function_locals_are_not_reported() {
+        assert_clean(
+            "<script>\n  function go() {\n    const scratch = 1;\n  }\n  go();\n</script>\n<p>hi</p>",
+        );
+    }
+
+    #[test]
+    fn state_read_in_template_is_not_unused() {
+        assert_clean("<script>\n  let count = $state(0);\n</script>\n<p>{count}</p>");
+    }
+
+    #[test]
+    fn style_directive_reference_is_not_unused() {
+        assert_clean("<script>\n  const color = 'red';\n</script>\n<p style:color>hi</p>");
+    }
+
+    #[test]
+    fn component_used_only_in_template_is_not_unused() {
+        assert_clean("<script>\n  import Child from './Child.svelte';\n</script>\n<Child />");
+    }
+}

--- a/crates/rsvelte_lint/tests/eslint_plugin_oracle.rs
+++ b/crates/rsvelte_lint/tests/eslint_plugin_oracle.rs
@@ -69,6 +69,10 @@ const NO_FIXTURE_RULES: &[&str] = &[
     // upstream eslint-plugin-svelte fixture dir. Covered by the inline
     // `crate::rules::no_companion_module` unit tests.
     "svelte/no-companion-module-shadow",
+    // `no-unused-vars` is an rsvelte-only rule (issue #1732): eslint-plugin-svelte
+    // has no such rule (upstream defers to ESLint core, which cannot see template
+    // reads). Covered by the inline `crate::rules::no_unused_vars` unit tests.
+    "svelte/no-unused-vars",
 ];
 
 /// Meta-rules whose findings come from the whole-component compile / source-scan

--- a/crates/rsvelte_lint_types/Cargo.lock
+++ b/crates/rsvelte_lint_types/Cargo.lock
@@ -1106,7 +1106,7 @@ dependencies = [
 
 [[package]]
 name = "rsvelte_esrap"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "compact_str",
  "memchr",


### PR DESCRIPTION
Refs #1732

## Scope

The issue asks for **two** checks — undefined variables and unused variables.
This PR ships **only `svelte/no-unused-vars`**, fully done.

`no-undef` is **left out** deliberately: it additionally needs a globals /
environment list (browser, node, es20xx, `svelte/*` ambient names, project-level
`globals` config), and without one it is extremely noisy on real components. A
rule with false positives is worse than no rule, so it stays for a follow-up.

## What the rule does

`svelte/no-unused-vars` flags top-level `<script>` bindings that are never read
anywhere in the component. ESLint core's `no-unused-vars` and oxlint both stop
at the `.svelte` boundary, so these went unchecked unless a project kept a
Svelte-aware ESLint around — exactly the gap the issue describes.

It is implemented as a `ScriptRule` on top of the compiler's **existing** Phase-2
scope tree (`ctx.scope_analysis()` → `ComponentAnalysis::root.bindings`), so
template reads, `$store` auto-subscriptions and `bind:` targets already resolve
back to their binding. No scope analysis is re-implemented, and the rule is pure
analysis (no `svelte_check` / validator dependency), so it works in the wasm
build too.

The issue's example now reports exactly one finding (`unused`), leaving `count`,
`$count` and `current` clean.

## Conservative by construction

A false positive on a real component is worse than a miss, so:

- only **top-level** module/instance-script bindings are judged — each items,
  snippet params, `let:` directives and function locals live in child scopes and
  are never reported;
- props (`export let`, `$props()` destructuring, `$$props`/`$$restProps`/
  `$$slots`), stores read as `$name`, reactive `$:` declarations, exported
  declarations (`export const`, `export function`, `export { x }`) and
  reassigned/mutated bindings all count as used;
- a name that occurs anywhere else in the source vetoes the report — this covers
  reads Phase 2 does not record as references (TypeScript type positions, JSDoc
  `@type`, generics).

## Tests

19 inline tests in `crates/rsvelte_lint/src/rules/no_unused_vars.rs`, written
false-positive-matrix first: every Svelte-specific bullet above has a case that
must NOT report (legacy props, `$props()` destructuring, template-only reads,
`$$props`/`$$restProps`/`$$slots`, snippet params, `{#each … as x}`, store `$`
auto-subscription, `bind:` targets, exported module declarations, `export { x }`,
`$:` declarations, TS type-only usage, function locals, `$state` read from the
template, `style:` directives, template-only component imports).

The rule is rsvelte-only (eslint-plugin-svelte has no such rule — upstream defers
to ESLint core, which cannot see template reads), so it is added to
`NO_FIXTURE_RULES` in the fixture-coverage gate with that reason, alongside the
existing `svelte/no-companion-module-shadow` precedent. Because the lint parity
corpus intersects rsvelte's rule set with the plugin's, the new rule is outside
that universe and cannot add entries to the shrink-only
`compatibility/lint-known-failures.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012gQPtKmdY9xwn5fjdwaxK8