### PR TITLE
ci: detect and prevent rsvelte_lint_types lock drift

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,36 @@ jobs:
         working-directory: apps/playground
         run: pnpm install --frozen-lockfile --lockfile-only
 
+  lint-types-lock:
+    name: Lint-types lockfile
+    # `crates/rsvelte_lint_types` is its own Cargo workspace, so nothing in the
+    # root workspace re-resolves its lock and any in-repo crate version bump
+    # staleifies it silently. The only job that consumes it (type-aware-lint,
+    # `--locked`) is path-filtered to the lint crates, so the breakage lands on
+    # an unrelated later PR. Resolve-only — no compilation, no target dir.
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          submodules: false
+
+      - name: Checkout corsa-bind submodule (shallow)
+        run: git submodule update --init --depth 1 submodules/corsa-bind
+
+      - uses: ./.github/actions/setup-rust
+
+      # Read-only reuse of the type-aware-lint workspace cache for ~/.cargo/git
+      # (the oxc patch source); a miss only costs a fetch.
+      - name: Restore cargo registry + git cache
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          workspaces: crates/rsvelte_lint_types
+          save-if: 'false'
+
+      - name: Check rsvelte_lint_types lockfile is in sync
+        run: node scripts/ci/check-lint-types-lock.mjs --require-resolve
+
   clippy:
     name: Clippy
     runs-on: ubuntu-latest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -261,6 +261,15 @@ skipping. Do not point it at `$TSGO_BIN`: that names a batch `tsc`/`tsgo` for
 `.github/workflows/type-aware-lint.yml` runs fmt + clippy + the suite on changes to
 the crate, weekly, and on dispatch.
 
+Because it is a separate workspace, its `Cargo.lock` is never re-resolved by the root
+`cargo test` — any in-repo crate version bump (a Changesets release, a manual
+`rsvelte_esrap` bump) staleifies it, and the `--locked` suite above only notices on the
+next PR that happens to touch the lint crates. The `Lint-types lockfile` job in `ci.yml`
+runs `scripts/ci/check-lint-types-lock.mjs` on **every** PR (resolution only — no
+compilation) so drift fails on the PR that introduces it; `pnpm run fix:lint-types-lock`
+repairs it. `pnpm run version-packages` re-runs the same check after `sync-version`, so a
+release PR cannot ship a stale pin.
+
 ## Quick Reference
 
 ### Adding Features

--- a/package.json
+++ b/package.json
@@ -53,6 +53,8 @@
 		"test:oxlint-plugin": "node scripts/dev/test-oxlint-plugin.mjs",
 		"build:vps-native": "node scripts/dev/build-vps-native-local.mjs",
 		"check:vps-version": "node scripts/dev/check-vps-version.mjs",
+		"check:lint-types-lock": "node scripts/ci/check-lint-types-lock.mjs",
+		"fix:lint-types-lock": "node scripts/ci/check-lint-types-lock.mjs --fix",
 		"corpus:sync": "git submodule update --init --depth 1 submodules/svelte submodules/svelte.dev submodules/language-tools submodules/bits-ui submodules/flowbite-svelte submodules/melt-ui submodules/shadcn-svelte submodules/sveltestrap submodules/attractions submodules/svelte-ux submodules/smelte submodules/svar-core submodules/svelte-table submodules/powertable submodules/svelte-pivottable submodules/svelte-toast submodules/svelte-sonner submodules/svelte-notifications submodules/svelte-fa submodules/svelte-heroicons submodules/svelte-calendar submodules/date-picker-svelte submodules/svelte-maplibre submodules/layercake submodules/layerchart submodules/svelte-splitpanes submodules/svelte-stepper submodules/svelte-formly submodules/svelte-form-builder submodules/svelte-checkbox submodules/svelte-toggle submodules/svelthree submodules/cmsaasstarter submodules/skeleton",
 		"corpus:collect": "node scripts/compat-corpus/collect.mjs",
 		"corpus:compile": "node scripts/compat-corpus/compile.mjs",
@@ -86,7 +88,7 @@
 		"check-e2e-corpus:update": "node scripts/compat-corpus/check-e2e-verify.mjs --update",
 		"test:svelte-check-e2e": "pnpm run check-e2e-corpus:sync && cargo build --release -p rsvelte_check && pnpm run check-corpus:oracle-install && pnpm run check-e2e-corpus:verify",
 		"changeset": "changeset",
-		"version-packages": "changeset version && pnpm run sync-version",
+		"version-packages": "changeset version && pnpm run sync-version && pnpm run check:lint-types-lock",
 		"release": "pnpm run sync-version && pnpm run build:wasm && pnpm run finalize-pkg && pnpm run publish-platform-binaries && pnpm run build:language-server && changeset publish"
 	},
 	"devDependencies": {

--- a/scripts/ci/check-lint-types-lock.mjs
+++ b/scripts/ci/check-lint-types-lock.mjs
@@ -1,0 +1,152 @@
+#!/usr/bin/env node
+// Guard `crates/rsvelte_lint_types/Cargo.lock` against drift.
+//
+// That crate is its own Cargo workspace (it path-depends on
+// `submodules/corsa-bind`), so nothing in the root workspace ever re-resolves
+// its lock. Every in-repo crate version bump — a Changesets release, a manual
+// `rsvelte_esrap` bump — silently staleifies it, and the only job that consumes
+// it (`type-aware-lint.yml`, `--locked`) is path-filtered to the lint crates.
+// The drift therefore detonates on an unrelated later PR instead of the one
+// that introduced it. This check runs on every PR so it fails at introduction.
+//
+// Two layers:
+//   1. text audit (no cargo, no submodule): every in-repo crate pinned in the
+//      lock must match its `crates/<name>/Cargo.toml` `[package].version`.
+//   2. resolution (`cargo metadata --locked`): ground truth, catches dependency
+//      graph / requirement / oxc-patch / corsa-bind drift too. Skipped when
+//      `submodules/corsa-bind` is absent unless `--require-resolve` is passed.
+
+import { execFileSync } from 'node:child_process';
+import { existsSync, readFileSync, readdirSync, writeFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join, resolve } from 'node:path';
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '../..');
+const manifest = 'crates/rsvelte_lint_types/Cargo.toml';
+const lockRel = 'crates/rsvelte_lint_types/Cargo.lock';
+const lockPath = resolve(repoRoot, lockRel);
+const corsaBind = resolve(repoRoot, 'submodules/corsa-bind');
+
+const argv = new Set(process.argv.slice(2));
+const fix = argv.has('--fix');
+const requireResolve = argv.has('--require-resolve');
+
+const FIX_HINT = [
+	'Fix it with:',
+	'',
+	'    git submodule update --init --depth 1 submodules/corsa-bind',
+	'    pnpm run fix:lint-types-lock',
+	'',
+	'then commit the updated crates/rsvelte_lint_types/Cargo.lock.',
+].join('\n');
+
+function packageField(contents, field) {
+	const match = contents.match(
+		new RegExp(`\\[package\\][\\s\\S]*?\\n${field}\\s*=\\s*"([^"]+)"`),
+	);
+	return match?.[1];
+}
+
+// name -> version for every crate under `crates/`.
+function inRepoCrateVersions() {
+	const versions = new Map();
+	const cratesDir = join(repoRoot, 'crates');
+	for (const entry of readdirSync(cratesDir, { withFileTypes: true })) {
+		if (!entry.isDirectory()) continue;
+		const tomlPath = join(cratesDir, entry.name, 'Cargo.toml');
+		if (!existsSync(tomlPath)) continue;
+		const contents = readFileSync(tomlPath, 'utf8');
+		const name = packageField(contents, 'name');
+		const version = packageField(contents, 'version');
+		if (name && version) versions.set(name, version);
+	}
+	return versions;
+}
+
+function lockEntryRe(name) {
+	return new RegExp(`(\\[\\[package\\]\\]\\nname = "${name}"\\nversion = ")([^"]+)(")`);
+}
+
+function auditPins(lockText) {
+	const drifted = [];
+	for (const [name, version] of inRepoCrateVersions()) {
+		const match = lockText.match(lockEntryRe(name));
+		if (!match) continue; // crate simply isn't in this workspace's graph
+		if (match[2] !== version) drifted.push({ name, pinned: match[2], actual: version });
+	}
+	return drifted;
+}
+
+function syncPins(lockText, drifted) {
+	let out = lockText;
+	for (const { name, actual } of drifted) {
+		out = out.replace(lockEntryRe(name), `$1${actual}$3`);
+	}
+	return out;
+}
+
+function runCargoMetadata(locked) {
+	const args = ['metadata', '--format-version', '1', '--manifest-path', manifest];
+	if (locked) args.push('--locked');
+	execFileSync('cargo', args, {
+		cwd: repoRoot,
+		stdio: ['ignore', 'ignore', 'inherit'],
+	});
+}
+
+let lockText = readFileSync(lockPath, 'utf8');
+const drifted = auditPins(lockText);
+
+if (fix) {
+	if (drifted.length > 0) {
+		lockText = syncPins(lockText, drifted);
+		writeFileSync(lockPath, lockText);
+		for (const { name, pinned, actual } of drifted) {
+			console.log(`  ${name}: ${pinned} -> ${actual}`);
+		}
+	}
+	if (existsSync(corsaBind) && readdirSync(corsaBind).length > 0) {
+		runCargoMetadata(false);
+		console.log(`Re-resolved ${lockRel}.`);
+	} else {
+		console.log(
+			`submodules/corsa-bind is not checked out — pins synced textually only.\n` +
+				`Run \`git submodule update --init --depth 1 submodules/corsa-bind\` and re-run to fully re-resolve.`,
+		);
+	}
+	process.exit(0);
+}
+
+if (drifted.length > 0) {
+	console.error(`${lockRel} is stale: it pins in-repo crate versions that no longer exist.\n`);
+	for (const { name, pinned, actual } of drifted) {
+		console.error(`  ${name}: lock pins ${pinned}, crates/ declares ${actual}`);
+	}
+	console.error(`\n${FIX_HINT}`);
+	process.exit(1);
+}
+
+const haveCorsaBind = existsSync(corsaBind) && readdirSync(corsaBind).length > 0;
+if (!haveCorsaBind) {
+	if (requireResolve) {
+		console.error(
+			'submodules/corsa-bind is not checked out, so the lock cannot be resolved.\n' +
+				'Run: git submodule update --init --depth 1 submodules/corsa-bind',
+		);
+		process.exit(1);
+	}
+	console.log(`${lockRel} pins match crates/ (resolution check skipped: no corsa-bind).`);
+	process.exit(0);
+}
+
+try {
+	runCargoMetadata(true);
+} catch {
+	console.error(
+		`\n${lockRel} is out of date — \`cargo metadata --locked\` above refused to update it.\n` +
+			`Something in the root workspace changed the resolution for this out-of-workspace crate.\n\n${FIX_HINT}`,
+	);
+	process.exit(1);
+}
+
+console.log(`${lockRel} is up to date.`);


### PR DESCRIPTION
## The trap

`crates/rsvelte_lint_types` is **its own Cargo workspace** — it path-depends on `submodules/corsa-bind`, so the root `cargo test` / `fmt` / `clippy` never build it and nothing in the root workspace ever re-resolves its `Cargo.lock`.

That lock pins in-repo crates (`rsvelte_core`, `rsvelte_esrap`, …). **Every version bump of an in-repo crate silently staleifies it.** The only job that consumes it — `type-aware-lint.yml`, `cargo clippy/test --locked` — is path-filtered to `crates/rsvelte_lint*`, so the drift is *not* detected when it is introduced. It detonates on the next unrelated PR that happens to touch those paths:

```
error: cannot update the lock file .../crates/rsvelte_lint_types/Cargo.lock
       because --locked was passed to prevent this
```

Evidence this recurs:

- **PR #2263** went red on this; the culprit was `052eb2fa` (esrap `0.9.0` → `0.10.0`), merged hours earlier and entirely unrelated to the failing PR.
- **`7f0b4131`** `chore(lint-types): refresh Cargo.lock for the corsa-bind 1.5.0 bump` — the same trap, paid down by hand.

`scripts/release/sync-version.mjs` already mirrors changeset-managed crate versions into the secondary lock, so the *release* path was covered. The hole is every other bump path (a hand-rolled `rsvelte_esrap` bump, a corsa-bind bump, a dependency added to `rsvelte_core`) — none of which run that script.

## The fix

**Detect at introduction.** New `scripts/ci/check-lint-types-lock.mjs`, run by a new always-on `Lint-types lockfile` job in `ci.yml`. Resolution only — no compilation, no target dir; just a shallow `submodules/corsa-bind` (5.2 MB, public, no credentials) and `cargo metadata --locked`.

Two layers:

1. **Text audit** (no cargo, no submodule): every in-repo crate pinned in the lock must match its `crates/<name>/Cargo.toml` `[package].version`. This is the exact `052eb2fa` class, and it names the offending crate directly.
2. **Resolution** (`cargo metadata --locked`): ground truth. Also catches dependency-graph, requirement, oxc-patch-rev and corsa-bind drift that layer 1 cannot see.

Both failure paths print the exact fix command:

```
    git submodule update --init --depth 1 submodules/corsa-bind
    pnpm run fix:lint-types-lock
```

`pnpm run fix:lint-types-lock` syncs the pins textually and then re-resolves via `cargo metadata` when the submodule is present (so it works even without it, for the common case).

**Prevent at the bump.** `pnpm run version-packages` now runs `check:lint-types-lock` after `sync-version`, turning the existing secondary-lock handling into a verified invariant instead of a hopeful one — a release PR can no longer ship a stale pin.

`type-aware-lint.yml`'s path trigger is deliberately left alone: the new job always runs, so widening the expensive suite's trigger would only add cost.

## Proof the guard fires

Reproduced the CI failure first, on unmodified `main`, by restoring the pre-`052eb2fa` pin in the secondary lock:

```
$ cargo metadata --locked --manifest-path crates/rsvelte_lint_types/Cargo.toml
error: cannot update the lock file .../crates/rsvelte_lint_types/Cargo.lock
       because --locked was passed to prevent this
```

Then, with the same staleification, the new check:

```
crates/rsvelte_lint_types/Cargo.lock is stale: it pins in-repo crate versions that no longer exist.

  rsvelte_esrap: lock pins 0.9.0, crates/ declares 0.10.0

Fix it with:

    git submodule update --init --depth 1 submodules/corsa-bind
    pnpm run fix:lint-types-lock

then commit the updated crates/rsvelte_lint_types/Cargo.lock.
```

`pnpm run fix:lint-types-lock` restored the lock to byte-identical committed state (clean `git status`), and the check went green.

Layer 2 verified separately with a drift layer 1 cannot see (removing a `dev-dependency` from `rsvelte_lint_types/Cargo.toml`): the check surfaced cargo's `--locked` refusal followed by the same fix hint. Reverted; clean tree passes.

The lock on current `main` is already up to date — `f016d187` (#2263) carried the one-line refresh — so no lock change is needed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012gQPtKmdY9xwn5fjdwaxK8
