### PR TITLE
fix(release): reject changesets naming packages outside the workspace

### DIFF
--- a/.changeset/changeset-package-name-guard.md
+++ b/.changeset/changeset-package-name-guard.md
@@ -1,0 +1,9 @@
+---
+"@rsvelte/compiler": patch
+---
+
+Fix a changeset that named the non-existent package `@rsvelte/check` instead of
+`@rsvelte/svelte-check`, which broke the Release workflow's release-plan assembly
+on `main` and blocked every release. The Changeset CI gate now validates that
+every package named in a pending changeset actually exists in the pnpm workspace,
+so this class of typo fails on the PR instead of on `main`.

--- a/.changeset/css-render-site-ancestry.md
+++ b/.changeset/css-render-site-ancestry.md
@@ -1,7 +1,7 @@
 ---
 "@rsvelte/compiler": patch
 "@rsvelte/lint": patch
-"@rsvelte/check": patch
+"@rsvelte/svelte-check": patch
 ---
 
 CSS pruning now models `{@render}` call sites. A `{#snippet}`-declared element's

--- a/.github/workflows/changeset.yml
+++ b/.github/workflows/changeset.yml
@@ -73,6 +73,14 @@ jobs:
           echo "Found changeset(s):"
           echo "$added"
 
+      - name: Validate changeset package names
+        env:
+          SKIP: ${{ contains(github.event.pull_request.labels.*.name, 'skip-changeset') }}
+        shell: bash
+        # A changeset naming a non-existent package passes review and only fails
+        # later, on main, where it blocks every release until fixed.
+        run: node scripts/release/check-changeset-package-names.mjs
+
       - name: Require consumer changesets for shared-core changes
         env:
           SKIP: ${{ contains(github.event.pull_request.labels.*.name, 'skip-changeset') }}

--- a/scripts/release/check-changeset-package-names.mjs
+++ b/scripts/release/check-changeset-package-names.mjs
@@ -1,0 +1,174 @@
+#!/usr/bin/env node
+// Guard: a changeset naming a package that is not in the pnpm workspace is not
+// rejected by `changeset add`/review — it detonates later, on `main`, when the
+// Release workflow tries to assemble a release plan:
+//
+//   🦋  error Error: Found changeset css-render-site-ancestry for package
+//       @rsvelte/check which is not in the workspace
+//
+// That failure blocks every subsequent release until someone lands a fix, so
+// the name must be validated on the PR instead. Names are checked against the
+// `name` field of every workspace package.json, resolved from the
+// pnpm-workspace.yaml globs so a new workspace glob needs no change here.
+//
+// Bypass with the `skip-changeset` label (same as the sibling guards), which
+// sets SKIP=true.
+
+import { readFileSync, readdirSync, existsSync, statSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
+
+function workspaceGlobs() {
+  const text = readFileSync(path.join(repoRoot, 'pnpm-workspace.yaml'), 'utf8');
+  const globs = [];
+  let inPackages = false;
+  for (const raw of text.split('\n')) {
+    const line = raw.replace(/#.*$/, '').trimEnd();
+    if (/^packages:\s*$/.test(line)) {
+      inPackages = true;
+      continue;
+    }
+    if (inPackages) {
+      const m = line.match(/^\s*-\s*['"]?([^'"\s]+)['"]?\s*$/);
+      if (m) globs.push(m[1]);
+      else if (line.trim() !== '') break;
+    }
+  }
+  return globs;
+}
+
+// Only the shapes pnpm-workspace.yaml actually uses here: a literal directory
+// or a single trailing `*` segment. Anything else is reported rather than
+// silently narrowing the valid-name set.
+function expandGlob(glob) {
+  const segments = glob.split('/');
+  let dirs = [repoRoot];
+  for (const segment of segments) {
+    if (segment === '**') throw new Error(`unsupported workspace glob: ${glob}`);
+    const next = [];
+    for (const dir of dirs) {
+      if (segment === '*') {
+        if (!existsSync(dir)) continue;
+        for (const entry of readdirSync(dir)) {
+          const child = path.join(dir, entry);
+          if (statSync(child).isDirectory()) next.push(child);
+        }
+      } else {
+        const child = path.join(dir, segment);
+        if (existsSync(child) && statSync(child).isDirectory()) next.push(child);
+      }
+    }
+    dirs = next;
+  }
+  return dirs;
+}
+
+function workspacePackages() {
+  const names = new Set();
+  for (const glob of workspaceGlobs()) {
+    for (const dir of expandGlob(glob)) {
+      const manifest = path.join(dir, 'package.json');
+      if (!existsSync(manifest)) continue;
+      const { name } = JSON.parse(readFileSync(manifest, 'utf8'));
+      if (name) names.add(name);
+    }
+  }
+  return names;
+}
+
+function changesetEntries() {
+  const dir = path.join(repoRoot, '.changeset');
+  const entries = [];
+  for (const file of readdirSync(dir)) {
+    if (!file.endsWith('.md') || file === 'README.md') continue;
+    const text = readFileSync(path.join(dir, file), 'utf8');
+    const m = text.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+    if (!m) continue;
+    for (const line of m[1].split('\n')) {
+      const pkg = line.match(/^\s*["']?(@?[^"':]+)["']?\s*:/);
+      if (pkg) entries.push({ file: `.changeset/${file}`, pkg: pkg[1].trim() });
+    }
+  }
+  return entries;
+}
+
+function distance(a, b) {
+  let prev = Array.from({ length: b.length + 1 }, (_, i) => i);
+  for (let i = 1; i <= a.length; i++) {
+    const row = [i];
+    for (let j = 1; j <= b.length; j++) {
+      row[j] = Math.min(
+        prev[j] + 1,
+        row[j - 1] + 1,
+        prev[j - 1] + (a[i - 1] === b[j - 1] ? 0 : 1),
+      );
+    }
+    prev = row;
+  }
+  return prev[b.length];
+}
+
+const unscoped = (name) => name.replace(/^@[^/]+\//, '');
+
+function closestMatch(name, known) {
+  const bare = unscoped(name);
+  let best = null;
+  let bestScore = Infinity;
+  for (const candidate of known) {
+    const other = unscoped(candidate);
+    const raw = distance(name, candidate);
+    // A dropped/added name part ("check" vs "svelte-check") costs more edits
+    // than an unrelated short name, so containment outranks raw edit distance.
+    const contains = bare.includes(other) || other.includes(bare);
+    const score = contains ? Math.min(raw, 1) + other.length / 1000 : raw;
+    if (score < bestScore) {
+      bestScore = score;
+      best = candidate;
+    }
+  }
+  // Beyond half the name's length the "suggestion" is noise, not a typo fix.
+  return bestScore <= Math.max(3, Math.ceil(name.length / 2)) ? best : null;
+}
+
+function main() {
+  if (process.env.SKIP === 'true') {
+    console.log('skip-changeset label present — skipping changeset package-name check.');
+    return;
+  }
+
+  const known = workspacePackages();
+  const entries = changesetEntries();
+
+  if (entries.length === 0) {
+    console.log('No pending changesets to validate.');
+    return;
+  }
+
+  const bad = entries.filter((e) => !known.has(e.pkg));
+
+  console.log(`Validating ${entries.length} changeset package reference(s) against the workspace:`);
+  for (const { file, pkg } of entries) {
+    console.log(`  ${known.has(pkg) ? '✓' : '✗'} ${pkg}  (${file})`);
+  }
+
+  if (bad.length > 0) {
+    for (const { file, pkg } of bad) {
+      const suggestion = closestMatch(pkg, known);
+      console.error(
+        `::error file=${file}::${file} names "${pkg}", which is not a package in this ` +
+          `workspace.` +
+          (suggestion ? ` Did you mean "${suggestion}"?` : '') +
+          ` The Release workflow fails with "Found changeset <name> for package ${pkg} ` +
+          `which is not in the workspace" and no Release PR can be produced until it is ` +
+          `fixed. Use the exact "name" field from the package's package.json.`,
+      );
+    }
+    process.exit(1);
+  }
+
+  console.log('All changeset package names exist in the workspace. ✓');
+}
+
+main();


### PR DESCRIPTION
## The breakage

The `Release` workflow on `main` fails at "Create or refresh Release Pull Request":

```
🦋  error Error: Found changeset css-render-site-ancestry for package @rsvelte/check which is not in the workspace
    at mapGetOrThrow (@changesets/assemble-release-plan)
```

No Release PR can be produced until this is fixed, so every release is blocked.

## Changesets corrected

- `.changeset/css-render-site-ancestry.md` — `@rsvelte/check` → `@rsvelte/svelte-check`

That was the only offender. A sweep of every file in `.changeset/` (16 package
references across 13 changesets) against the actual workspace package list — the
`name` field of every `package.json` matched by the `pnpm-workspace.yaml` globs —
found no others. Verified by `changeset status`, which now assembles a release plan
cleanly (24 packages to be bumped at patch).

Note: PR #2264 carries the same wrong name in its own changeset and must correct it
before merge (commented there).

## The new guard

The Changeset gate previously only checked that a changeset **exists** and that
required packages are **named** — never that the names are **real**. A typo therefore
passed review and detonated on `main`.

`scripts/release/check-changeset-package-names.mjs` (new, a sibling of
`check-core-consumer-changesets.mjs` and wired into `.github/workflows/changeset.yml`
as a "Validate changeset package names" step) resolves the workspace package set from
the `pnpm-workspace.yaml` globs and fails if any pending changeset names something
outside it. Honours the `skip-changeset` label like its siblings.

The error names the offending file, the bad package name, and the closest valid match:

```
::error file=.changeset/zz-scratch-guard-proof.md::.changeset/zz-scratch-guard-proof.md names
"@rsvelte/check", which is not a package in this workspace. Did you mean "@rsvelte/svelte-check"?
The Release workflow fails with "Found changeset <name> for package @rsvelte/check which is not
in the workspace" and no Release PR can be produced until it is fixed. Use the exact "name" field
from the package's package.json.
```

Suggestion ranking puts name-part containment ahead of raw edit distance — plain
Levenshtein scored `@rsvelte/fmt` closer to `@rsvelte/check` than the correct
`@rsvelte/svelte-check`, since a dropped name part costs more edits than an unrelated
short name.

### Proof the guard fires

1. Clean tree → exit 0, `All changeset package names exist in the workspace. ✓`
2. Scratch changeset naming `@rsvelte/check` and `@rsvelte/totally-bogus-xyz` → exit 1,
   one `::error file=…::` per bad name, with the suggestion above (and no suggestion for
   `@rsvelte/totally-bogus-xyz`, which is beyond the noise threshold).
3. Scratch file removed → exit 0 again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012gQPtKmdY9xwn5fjdwaxK8
