### PR TITLE
fix(compiler): unwrap each-item reads in switch discriminants (#2254)

### DIFF
--- a/.changeset/switch-and-class-expression-transforms.md
+++ b/.changeset/switch-and-class-expression-transforms.md
@@ -1,0 +1,20 @@
+---
+"@rsvelte/compiler": patch
+---
+
+Client output now applies the read/store transforms inside `switch` statements
+and class expressions. A `{#each}` item read used as a `switch` discriminant
+(`switch (item.value)`), as a `case` test (`case item.value:`), as a class
+expression field initializer (`class { f = item.value }`) or as a class
+expression computed method key (`class { [item.value]() {} }`) was emitted
+against the raw signal instead of `$.get(item)`, so the value was `undefined`
+and no `case` ever matched — silently, in production builds as well as dev. The
+recursive transform walk had no `switch` arm (the catch-all cloned the statement
+verbatim) and listed class expressions among the terminal "nothing to transform"
+nodes. Because that same walk marks the each-index binding as used and registers
+store getters, the omission also dropped the `i` parameter from the `$.each`
+callback and skipped the `$.store_get` getter whenever the binding was read only
+from one of those positions, turning an undefined `$store` read into a
+`ReferenceError`. Separately, the store-subscription pre-scan classified any
+`$store` followed by `:` as an object property key, which misfired on
+`case $store:`; a `case` test is now recognised as a value expression.

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/store_subscriptions.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/store_subscriptions.rs
@@ -616,7 +616,8 @@ fn dollar_param_body_range(
 /// A ternary consequent (`cond ? $x : y`) is also `$x` followed by `:`, but `$x`
 /// there is a real reference, not a property key. Such a `$x` is preceded
 /// (ignoring whitespace) by `?`, which never precedes a property key in a runtime
-/// object literal, so we exclude it (issue #1229).
+/// object literal, so we exclude it (issue #1229). A `switch` case test
+/// (`case $x:`) is excluded for the same reason.
 fn is_dollar_ident_object_property_key(
     chars: &[char],
     ident_start: usize,
@@ -648,6 +649,17 @@ fn is_dollar_ident_object_property_key(
         }
         if k >= 0 && chars[k as usize] == '?' {
             return false;
+        }
+        // Exclude a `switch` case test: `case $x:` is a value expression, not a
+        // property key.
+        if k >= 3 {
+            let pos = k as usize;
+            if chars[pos - 3..=pos].iter().collect::<String>() == "case" {
+                let before = if pos >= 4 { chars[pos - 4] } else { ' ' };
+                if !before.is_alphanumeric() && before != '_' && before != '$' {
+                    return false;
+                }
+            }
         }
         return true;
     }

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/utils.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/utils.rs
@@ -1415,7 +1415,39 @@ pub fn apply_transforms_to_expression_with_shadowed(
             })
         }
 
-        // Expressions that don't need transformation
+        JsExpr::Class(class) => {
+            // The class binding name is in scope inside its own body.
+            let mut class_scope = local_scope.clone();
+            if let Some(id) = &class.id {
+                class_scope.add_shadowed(id.to_string());
+            }
+            JsExpr::Class(JsClassExpression {
+                id: class.id.clone(),
+                super_class: class.super_class.map(|sc| {
+                    context
+                        .arena
+                        .alloc_expr(apply_transforms_to_expression_with_shadowed(
+                            context.arena.get_expr(sc),
+                            context,
+                            &class_scope,
+                        ))
+                }),
+                body: JsClassBody {
+                    body: class
+                        .body
+                        .body
+                        .iter()
+                        .map(|member| {
+                            apply_transforms_to_class_member(member, context, &class_scope)
+                        })
+                        .collect(),
+                },
+            })
+        }
+
+        // Expressions that don't need transformation. `Chain` and `Void` are only
+        // ever synthesized by the builders around already-transformed subtrees,
+        // never produced from user source, so recursing would transform twice.
         JsExpr::Literal(_)
         | JsExpr::This
         | JsExpr::Super
@@ -1423,7 +1455,6 @@ pub fn apply_transforms_to_expression_with_shadowed(
         | JsExpr::ImportExpression { .. }
         | JsExpr::Raw(_)
         | JsExpr::OpaqueIdentifier(_)
-        | JsExpr::Class(_)
         | JsExpr::Chain(_)
         | JsExpr::Void(_) => expr.clone(),
 
@@ -1626,6 +1657,88 @@ fn transform_computed_indices_only(
     }
 }
 
+/// Apply transforms to a class member (field initializer, method, static block).
+fn apply_transforms_to_class_member(
+    member: &JsClassMember,
+    context: &ComponentContext,
+    local_scope: &LocalScope,
+) -> JsClassMember {
+    let transform_key = |key: &JsPropertyKey, computed: bool| match key {
+        JsPropertyKey::Computed(key_expr) if computed => {
+            JsPropertyKey::Computed(context.arena.alloc_expr(
+                apply_transforms_to_expression_with_shadowed(
+                    context.arena.get_expr(*key_expr),
+                    context,
+                    local_scope,
+                ),
+            ))
+        }
+        other => other.clone(),
+    };
+
+    match member {
+        JsClassMember::Method(method) => {
+            let mut method_scope = local_scope.clone();
+            for param in &method.value.params {
+                extract_pattern_names_to_scope(param, &mut method_scope);
+            }
+            register_block_local_vars(&method.value.body.body, &context.arena, &mut method_scope);
+            JsClassMember::Method(JsMethodDefinition {
+                key: transform_key(&method.key, method.computed),
+                value: JsFunctionExpression {
+                    id: method.value.id.clone(),
+                    params: method.value.params.clone(),
+                    body: JsBlockStatement {
+                        body: method
+                            .value
+                            .body
+                            .body
+                            .iter()
+                            .map(|s| {
+                                apply_transforms_to_statement_with_shadowed(
+                                    s,
+                                    context,
+                                    &method_scope,
+                                )
+                            })
+                            .collect(),
+                    },
+                    is_async: method.value.is_async,
+                    is_generator: method.value.is_generator,
+                },
+                kind: method.kind,
+                computed: method.computed,
+                is_static: method.is_static,
+            })
+        }
+        JsClassMember::Property(prop) => JsClassMember::Property(JsPropertyDefinition {
+            key: transform_key(&prop.key, prop.computed),
+            value: prop.value.map(|v| {
+                context
+                    .arena
+                    .alloc_expr(apply_transforms_to_expression_with_shadowed(
+                        context.arena.get_expr(v),
+                        context,
+                        local_scope,
+                    ))
+            }),
+            computed: prop.computed,
+            is_static: prop.is_static,
+        }),
+        JsClassMember::StaticBlock(block) => {
+            let mut block_scope = local_scope.clone();
+            register_block_local_vars(&block.body, &context.arena, &mut block_scope);
+            JsClassMember::StaticBlock(JsBlockStatement {
+                body: block
+                    .body
+                    .iter()
+                    .map(|s| apply_transforms_to_statement_with_shadowed(s, context, &block_scope))
+                    .collect(),
+            })
+        }
+    }
+}
+
 /// Apply transforms to a statement recursively with local scope tracking.
 fn apply_transforms_to_statement_with_shadowed(
     stmt: &JsStatement,
@@ -1791,6 +1904,46 @@ fn apply_transforms_to_statement_with_shadowed(
                 test: transformed_test,
                 update: transformed_update,
                 body: transformed_body,
+            })
+        }
+
+        JsStatement::Switch(switch_stmt) => {
+            // All cases share one lexical scope, so `let`/`const` declared in any
+            // consequent shadows outer transforms for the whole switch body.
+            let mut switch_scope = local_scope.clone();
+            for case in &switch_stmt.cases {
+                register_block_local_vars(&case.consequent, &context.arena, &mut switch_scope);
+            }
+            let transform_in_switch = |e: &JsExpr| {
+                apply_transforms_to_expression_with_shadowed(e, context, &switch_scope)
+            };
+            JsStatement::Switch(JsSwitchStatement {
+                // The discriminant is evaluated in the enclosing scope.
+                discriminant: context.arena.alloc_expr(transform_expr(
+                    context.arena.get_expr(switch_stmt.discriminant),
+                )),
+                cases: switch_stmt
+                    .cases
+                    .iter()
+                    .map(|case| JsSwitchCase {
+                        test: case.test.map(|t| {
+                            context
+                                .arena
+                                .alloc_expr(transform_in_switch(context.arena.get_expr(t)))
+                        }),
+                        consequent: case
+                            .consequent
+                            .iter()
+                            .map(|s| {
+                                apply_transforms_to_statement_with_shadowed(
+                                    s,
+                                    context,
+                                    &switch_scope,
+                                )
+                            })
+                            .collect(),
+                    })
+                    .collect(),
             })
         }
 

--- a/crates/rsvelte_core/tests/switch_and_class_expr_transforms_2254.rs
+++ b/crates/rsvelte_core/tests/switch_and_class_expr_transforms_2254.rs
@@ -1,0 +1,257 @@
+//! Regression tests for issue #2254 — the client transform's recursive
+//! "apply transforms" walk over the generated JS tree had two holes, so every
+//! expression sitting in one of them escaped the read/store rewrites entirely.
+//!
+//! `apply_transforms_to_statement_with_shadowed` had no `JsStatement::Switch`
+//! arm (the catch-all cloned the statement verbatim), and
+//! `apply_transforms_to_expression_with_shadowed` listed `JsExpr::Class`
+//! among the terminal "nothing to transform" variants. The four affected
+//! positions are the switch discriminant, a `case` test, a class-expression
+//! field initializer and a class-expression computed method key.
+//!
+//! Because the each-index `used` flag and the store-getter registration are
+//! both set from inside that same walk, the omission also dropped the `i`
+//! parameter from the `$.each` callback and skipped the `$.store_get` getter —
+//! not just the `$.get(...)` unwrap.
+//!
+//! A third, independent cause sat in the store-subscription pre-scan: a
+//! `$store` reference followed by `:` was classified as an object property key,
+//! which misfires on `case $store:`.
+
+use rsvelte_core::{CompileOptions, GenerateMode, compile};
+
+fn client(src: &str, dev: bool) -> String {
+    compile(
+        src,
+        CompileOptions {
+            filename: Some("T.svelte".to_string()),
+            generate: GenerateMode::Client,
+            dev,
+            runes: Some(true),
+            ..Default::default()
+        },
+    )
+    .expect("compile")
+    .js
+    .code
+}
+
+fn server(src: &str) -> String {
+    compile(
+        src,
+        CompileOptions {
+            filename: Some("T.svelte".to_string()),
+            generate: GenerateMode::Server,
+            dev: false,
+            runes: Some(true),
+            ..Default::default()
+        },
+    )
+    .expect("compile")
+    .js
+    .code
+}
+
+/// Wrap `body` in an each block whose item is read from inside a click handler.
+fn each_item_handler(body: &str) -> String {
+    format!(
+        "<script>\n\tconst items = $state([{{ value: 'a' }}]);\n\
+         \tconst {{ sink, other }} = $props();\n</script>\n\n\
+         {{#each items as item (item.value)}}\n\
+         \t<button onclick={{() => {{\n{body}\n\t}}}}>x</button>\n\
+         {{/each}}\n"
+    )
+}
+
+/// Same, but with an index binding that is referenced only from `body`.
+fn each_index_handler(body: &str) -> String {
+    format!(
+        "<script>\n\tconst items = $state([{{ value: 'a' }}]);\n\
+         \tconst {{ sink, other }} = $props();\n</script>\n\n\
+         {{#each items as item, i (item.value)}}\n\
+         \t<button onclick={{() => {{\n{body}\n\t}}}}>x</button>\n\
+         {{/each}}\n"
+    )
+}
+
+fn store_handler(body: &str) -> String {
+    format!(
+        "<script>\n\timport {{ writable }} from 'svelte/store';\n\
+         \tconst s = writable(1);\n\
+         \tconst {{ sink, other }} = $props();\n</script>\n\n\
+         <button onclick={{() => {{\n{body}\n}}}}>x</button>\n"
+    )
+}
+
+fn assert_contains(out: &str, needle: &str) {
+    assert!(out.contains(needle), "expected `{needle}` in:\n{out}");
+}
+
+fn assert_missing(out: &str, needle: &str) {
+    assert!(!out.contains(needle), "unexpected `{needle}` in:\n{out}");
+}
+
+// ---------------------------------------------------------------------------
+// Cluster A — the each-item read must be unwrapped with `$.get(...)`.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn switch_discriminant_unwraps_each_item() {
+    let src = each_item_handler("switch (item.value) { case 'a': sink(1); }");
+    for dev in [false, true] {
+        let out = client(&src, dev);
+        assert_contains(&out, "switch ($.get(item).value)");
+        assert_missing(&out, "switch (item.value)");
+    }
+}
+
+#[test]
+fn switch_case_test_unwraps_each_item() {
+    let src = each_item_handler("switch (other) { case item.value: sink(1); }");
+    for dev in [false, true] {
+        let out = client(&src, dev);
+        assert_contains(&out, "case $.get(item).value:");
+        assert_missing(&out, "case item.value:");
+    }
+}
+
+#[test]
+fn class_expression_field_initializer_unwraps_each_item() {
+    let src = each_item_handler("sink(class { f = item.value; });");
+    for dev in [false, true] {
+        let out = client(&src, dev);
+        assert_contains(&out, "f = $.get(item).value");
+        assert_missing(&out, "f = item.value");
+    }
+}
+
+#[test]
+fn class_expression_computed_method_key_unwraps_each_item() {
+    let src = each_item_handler("sink(class { [item.value]() {} });");
+    for dev in [false, true] {
+        let out = client(&src, dev);
+        assert_contains(&out, "[$.get(item).value]()");
+        assert_missing(&out, "[item.value]()");
+    }
+}
+
+/// A class *method body* is a plain function body; its reads must be unwrapped
+/// too, and a parameter of the same name must still shadow the each item.
+#[test]
+fn class_expression_method_body_unwraps_and_shadows() {
+    let src = each_item_handler("sink(class { m() { sink(item.value); } });");
+    let out = client(&src, false);
+    assert_contains(&out, "sink($.get(item).value)");
+
+    let shadowed = each_item_handler("sink(class { m(item) { sink(item.value); } });");
+    let out = client(&shadowed, false);
+    assert_missing(&out, "$.get(item).value");
+}
+
+/// A `let` declared in a case consequent shadows the each item for the whole
+/// switch body (all cases share one lexical scope).
+#[test]
+fn switch_case_local_declaration_shadows_each_item() {
+    let src = each_item_handler("switch (other) { case 1: { let item = 1; sink(item); } }");
+    let out = client(&src, false);
+    assert_missing(&out, "sink($.get(item))");
+}
+
+// ---------------------------------------------------------------------------
+// Cluster B — the each-index binding must survive as a callback parameter when
+// it is referenced only from one of the four positions.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn each_index_survives_switch_discriminant() {
+    let src = each_index_handler("switch (i) { case 0: sink(1); }");
+    for dev in [false, true] {
+        let out = client(&src, dev);
+        assert_contains(&out, "$$anchor, item, i");
+        assert_contains(&out, "switch ($.get(i))");
+    }
+}
+
+#[test]
+fn each_index_survives_switch_case_test() {
+    let src = each_index_handler("switch (other) { case i: sink(1); }");
+    for dev in [false, true] {
+        let out = client(&src, dev);
+        assert_contains(&out, "$$anchor, item, i");
+        assert_contains(&out, "case $.get(i):");
+    }
+}
+
+#[test]
+fn each_index_survives_class_expression_field() {
+    let src = each_index_handler("sink(class { f = i; });");
+    for dev in [false, true] {
+        let out = client(&src, dev);
+        assert_contains(&out, "$$anchor, item, i");
+        assert_contains(&out, "f = $.get(i)");
+    }
+}
+
+#[test]
+fn each_index_survives_class_expression_computed_key() {
+    let src = each_index_handler("sink(class { [i]() {} });");
+    for dev in [false, true] {
+        let out = client(&src, dev);
+        assert_contains(&out, "$$anchor, item, i");
+        assert_contains(&out, "[$.get(i)]()");
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Cluster C — store auto-subscription must be created for a `$store` read in
+// these positions (a missing getter is a hard `ReferenceError` at runtime).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn store_subscription_created_for_switch_discriminant() {
+    let src = store_handler("switch ($s) { case 1: sink(1); }");
+    assert_contains(&client(&src, false), "$.store_get(s, '$s', $$stores)");
+    assert_contains(&client(&src, true), "$.store_get(s, '$s', $$stores)");
+    assert_contains(&server(&src), "$$store_subs");
+}
+
+#[test]
+fn store_subscription_created_for_switch_case_test() {
+    let src = store_handler("switch (other) { case $s: sink(1); }");
+    let out = client(&src, false);
+    assert_contains(&out, "$.store_get(s, '$s', $$stores)");
+    assert_contains(&out, "case $s():");
+
+    let dev = client(&src, true);
+    assert_contains(&dev, "$.validate_store(s, 's')");
+    assert_contains(&server(&src), "$$store_subs");
+}
+
+/// The `case $x:` carve-out must not resurrect a genuine object property key.
+#[test]
+fn object_property_key_is_still_not_a_store_reference() {
+    let src = store_handler("sink({ $s: 1 });");
+    assert_missing(&client(&src, false), "$.store_get");
+}
+
+// ---------------------------------------------------------------------------
+// Anchors: positions the matrix found already correct must stay correct.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn if_and_while_tests_still_unwrap_each_item() {
+    let src = each_item_handler(
+        "if (item.value === 'a') sink(1);\n\t\twhile (item.value === 'never') break;",
+    );
+    let out = client(&src, false);
+    assert_contains(&out, "if ($.get(item).value === 'a')");
+    assert_contains(&out, "while ($.get(item).value === 'never')");
+}
+
+#[test]
+fn throw_and_return_still_unwrap_each_item() {
+    let src = each_item_handler("if (other) throw item.value;\n\t\treturn item.value;");
+    let out = client(&src, false);
+    assert_contains(&out, "throw $.get(item).value");
+    assert_contains(&out, "return $.get(item).value");
+}


### PR DESCRIPTION
Closes #2254

## Symptom

Inside an `{#each}` block, an each-item read used as a `switch` discriminant was emitted against the raw signal object instead of `$.get(item)`, so the discriminant was `undefined` and no `case` ever matched. Every sibling reference in the same function (`if`, `while`, …) was unwrapped correctly. This reproduced with `dev: false` too, so `vite build` succeeded and the app silently took the wrong branch — no error, no warning.

A generated differential shape matrix (7 binding kinds × 47 syntactic positions × 3 targets) run by the coordinating session showed the same hole in three more positions, plus two further symptoms of it:

| position | official | rsvelte (before) |
|---|---|---|
| `SwitchStatement.discriminant` | `switch ($.get(item).value) {` | `switch (item.value) {` |
| `SwitchCase.test` | `case $.get(item).value:` | `case item.value:` |
| class-expression field initializer | `f = $.get(item).value;` | `f = item.value;` |
| class-expression computed method key | `[$.get(item).value]() {}` | `[item.value]() {}` |

When the each-**index** binding was read *only* from one of those four positions, rsvelte judged it unreferenced and dropped it from the `$.each` callback signature (`($$anchor, item)` instead of `($$anchor, item, i)`). And when a `$store` was read only from a `case` test, no auto-subscription was created at all (`$s` undefined → `ReferenceError`, and on the server no `$$store_subs`).

## Root cause

Two independent causes, both in walks that enumerate child fields per node type.

**1 (four positions + index survival + store getter in the discriminant).** The client transform's recursive rewrite in `3_transform/client/visitors/shared/utils.rs`:

- `apply_transforms_to_statement_with_shadowed` had **no `JsStatement::Switch` arm**; the trailing `_ => stmt.clone()` cloned the whole switch verbatim, so neither the discriminant nor any case test nor any consequent statement was ever visited.
- `apply_transforms_to_expression_with_shadowed` listed **`JsExpr::Class(_)` among the terminal "expressions that don't need transformation"**, so a class expression's field initializers, computed keys and method bodies were cloned verbatim.

That single walk does three jobs at once — it rewrites reads to `$.get(...)`, it sets `state.each_index_used` from its `JsExpr::Identifier` arm, and it resolves store references — which is why the omission produced all three symptoms rather than only the missing unwrap. Upstream has no `SwitchStatement` visitor at all; the discriminant is transformed by the ordinary generic zimmerframe descent, so the fix is to make the walk descend, not to special-case `switch`.

**2 (store subscription in a `case` test) — genuinely separate.** The store-subscription pre-scan (`2_analyze/store_subscriptions.rs`) is a source-text scanner, and `is_dollar_ident_object_property_key` classified any `$store` followed by `:` as an object property key (`{ $s: 1 }`). That misfires on `case $s:`. It already carved out the ternary consequent (`cond ? $x : y`, #1229); a `case` test is now carved out the same way. Confirmed separate by bisection: after fix 1, `switch ($s)` matched but `case $s:` still did not.

## Fields audited

Descent was checked for every field of every node type reachable from an event-handler body in this walk. **Broken and fixed:** `SwitchStatement.discriminant`, `SwitchCase.test`, `SwitchCase.consequent`, `ClassExpression.superClass`, `PropertyDefinition.value`, `PropertyDefinition.key` (computed), `MethodDefinition.key` (computed), `MethodDefinition.value` (method body), `StaticBlock.body`.

**Verified already correct** (matrix found no divergence, and the arms exist): `if`/`while`/`do-while` tests, `for` init/test/update/body, `for-of`/`for-in` left/right/body, `return.argument`, `throw.argument`, array elements, object values, object computed keys, call arguments, member object/computed property, optional member, conditional test/consequent/alternate, logical/binary operands, unary/typeof argument, assignment LHS/RHS, sequence expressions, template-literal expressions, tagged-template tag + expressions, `await` argument, arrow/function bodies, default parameters, spread arguments, `try`/`catch`/`finally` bodies, destructuring defaults, labeled-statement body.

`JsExpr::Chain` and `JsExpr::Void` remain in the terminal list **deliberately**: they are only ever synthesized by `js_ast::builders` around already-transformed subtrees (never produced from user source by the expression converter), so recursing into them would transform twice. Probed empirically — `void item.value`, `item?.value` and `item?.value?.[item.value]` all `MATCH` because the converter lowers them to `Unary` / `Member`.

Scoping is mirrored too: all `case` clauses share one lexical scope (so a `let` in any consequent shadows the each item across the whole switch body), the class binding name is in scope inside its own body, and method parameters shadow.

## Verification

One-file differ against the official compiler (`scripts/compat-corpus/one.mjs`), all `MATCH` on **`client`, `client-dev` and `server`** for: the issue repro; `case item.value:`; `class { f = item.value }`; `class { [item.value]() {} }`; the each-index variants of all four; and the `case $s:` store case. Every one of these produced a diff before the change.

New regression test `crates/rsvelte_core/tests/switch_and_class_expr_transforms_2254.rs` — 15 tests covering the four positions × {each-item read, each-index survival, store subscription} in both dev and prod, plus scope anchors (case-local `let` shadowing, method-parameter shadowing, `{ $s: 1 }` still not a store ref) and "still correct" anchors (`if`/`while` tests, `throw`/`return` arguments).

`cargo test -p rsvelte_core --release`, `cargo fmt --all` and `cargo clippy --all-targets --all-features -- -D warnings` run locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017eFcFhr66RJemE7UtF4CNK
