### PR TITLE
fix(compiler): honour svelte-ignore comments inside object and array literals (#2256)

### DIFF
--- a/.changeset/svelte-ignore-comment-attachment.md
+++ b/.changeset/svelte-ignore-comment-attachment.md
@@ -1,0 +1,16 @@
+---
+"@rsvelte/compiler": patch
+---
+
+fix(compiler): honour `svelte-ignore` comments inside object and array literals.
+Phase 1 distributed script comments through a hand-maintained allowlist of
+statement-body fields (`BlockStatement`, `SwitchStatement`, `VariableDeclaration`,
+`ClassBody`, …), so a `// svelte-ignore` in front of an object-literal property,
+an array element or a call argument bound to nothing and suppressed nothing —
+producing warning noise the author had no way to silence. Comment attachment now
+mirrors upstream `add_comments` (`phases/1-parse/acorn.js`): the walk is generic
+and positional, a comment binds to the first node in pre-order that starts after
+it, and that node's whole subtree inherits the ignore. Upstream's trailing-comment
+rules are ported with it, so a comment after the last element of a block or literal,
+or one separated from the previous node by only `,`/`)`/spaces, still belongs to
+the node before it and does not over-suppress the node after it.

--- a/crates/rsvelte_core/src/compiler/phases/1_parse/read/expression.rs
+++ b/crates/rsvelte_core/src/compiler/phases/1_parse/read/expression.rs
@@ -6860,63 +6860,47 @@ fn convert_parsed_program<'ast>(
         // output.
         let mut ignore_comment_map: Vec<(u32, Vec<CompactString>)> = Vec::new();
         let body: Vec<JsNode> = if has_comments && has_ignore {
-            let mut comment_idx = 0;
             let mut body_nodes: Vec<JsNode> = Vec::with_capacity(program.body.len());
 
-            // Pre-compute comment entries (absolute positions + Value) once, used for
-            // distributing comments onto nested statement bodies.
             let comment_entries: Vec<CommentEntry> = all_comments
                 .iter()
                 .map(|comment| {
-                    let comment_start = offset + comment.span.start as usize;
-                    let comment_end = offset + comment.span.end as usize;
+                    let raw_text = content
+                        .get(comment.span.start as usize..comment.span.end as usize)
+                        .unwrap_or("");
                     CommentEntry {
-                        start: comment_start as u32,
-                        end: comment_end as u32,
-                        value: build_comment_value(comment, content, offset),
+                        start: offset as u32 + comment.span.start,
+                        text: CompactString::from(extract_comment_value(raw_text, comment.kind)),
                     }
                 })
                 .collect();
 
-            for stmt in program.body.iter() {
+            let mut attacher = CommentAttacher {
+                comments: &comment_entries,
+                next: 0,
+                content,
+                offset: offset as u32,
+                map: &mut ignore_comment_map,
+            };
+            let last_index = program.body.len().saturating_sub(1);
+
+            for (index, stmt) in program.body.iter().enumerate() {
                 if let Some(stmt_node) =
                     convert_statement_for_program(arena, stmt, offset, line_offsets)
                 {
-                    let stmt_start = stmt.span().start;
-
-                    // Collect comments that appear before this statement (its own leading
-                    // comments).
-                    let mut stmt_leading = Vec::new();
-                    while comment_idx < all_comments.len()
-                        && all_comments[comment_idx].span.end <= stmt_start
-                    {
-                        let comment = all_comments[comment_idx];
-                        stmt_leading.push(build_comment_value(comment, content, offset));
-                        comment_idx += 1;
-                    }
-
-                    // Skip comments that are inside the statement
-                    while comment_idx < all_comments.len()
-                        && all_comments[comment_idx].span.start < stmt.span().end
-                    {
-                        comment_idx += 1;
-                    }
-
-                    // Reproduce the exact comment-attachment the old code used (own leading
-                    // comments + nested distribution) on a throwaway Value, then harvest
-                    // svelte-ignore texts into the map. The statement itself stays TYPED.
-                    if !stmt_leading.is_empty() || !comment_entries.is_empty() {
-                        let mut val = stmt_node.to_value();
-                        if !stmt_leading.is_empty()
-                            && let Value::Object(ref mut obj) = val
-                        {
-                            obj.set_field("leadingComments", Value::Array(stmt_leading));
-                        }
-                        distribute_comments_to_node(&mut val, &comment_entries);
-                        harvest_ignore_comments(&val, &mut ignore_comment_map);
-                    }
-
+                    attacher.visit(
+                        &stmt_node.to_value(),
+                        Some(ParentInfo {
+                            end: Some(end as u32),
+                            is_last_in_body: index == last_index,
+                        }),
+                    );
                     body_nodes.push(stmt_node);
+                } else {
+                    // Type-only statements have no typed node. Upstream binds the
+                    // comments in and before them to TS nodes whose subtree Phase 2
+                    // never visits, so they must not reach the next statement either.
+                    attacher.skip_past(offset as u32 + stmt.span().end);
                 }
             }
 
@@ -7009,161 +6993,168 @@ fn build_comment_value(comment: &oxc_ast::ast::Comment, content: &str, offset: u
     Value::Object(comment_obj)
 }
 
-/// Walk a comment-annotated statement `Value` (after `distribute_comments_to_node`)
-/// and harvest every `svelte-ignore` leading-comment text into `map`, keyed by the
-/// owning node's absolute `start` offset.
-///
-/// Only `svelte-ignore` comments are kept (the sole Phase-2 consumer of statement-level
-/// `leadingComments`); a comment is a candidate when its value text — after leading
-/// whitespace — begins with `svelte-ignore` (a strict superset of the analyze-side
-/// `^\s*svelte-ignore\s` match, so nothing relevant is dropped and non-matching texts
-/// that survive simply extract to zero codes downstream).
-fn harvest_ignore_comments(node: &Value, map: &mut Vec<(u32, Vec<CompactString>)>) {
-    let Value::Object(obj) = node else {
-        return;
-    };
-
-    if let Some(Value::Array(comments)) = obj.get("leadingComments")
-        && let Some(start) = obj.get("start").and_then(|s| s.as_u64())
-    {
-        let kept: Vec<CompactString> = comments
-            .iter()
-            .filter_map(|c| c.get("value").and_then(|v| v.as_str()))
-            .filter(|v| v.trim_start().starts_with("svelte-ignore"))
-            .map(CompactString::from)
-            .collect();
-        if !kept.is_empty() {
-            map.push((start as u32, kept));
-        }
-    }
-
-    // Recurse into every nested object / array so nested `svelte-ignore` comments
-    // (attached by `distribute_comments_to_node`) are harvested too.
-    for value in obj.values() {
-        match value {
-            Value::Object(_) => harvest_ignore_comments(value, map),
-            Value::Array(items) => {
-                for item in items {
-                    harvest_ignore_comments(item, map);
-                }
-            }
-            _ => {}
-        }
-    }
-}
-
-/// A pre-computed comment entry with positions extracted to avoid repeated Value lookups.
+/// A pre-computed comment entry: absolute start offset plus the comment text with
+/// its `//` / `/* */` delimiters stripped.
 struct CommentEntry {
     start: u32,
-    end: u32,
-    value: Value,
+    text: CompactString,
 }
 
-/// Recursively walk a node and distribute comments to any nested statement bodies.
+/// What the walk needs to know about a node's parent to decide trailing-comment
+/// ownership, mirroring the `path.at(-1)` lookups in upstream `add_comments`.
+struct ParentInfo {
+    end: Option<u32>,
+    is_last_in_body: bool,
+}
+
+/// Port of `add_comments` from `phases/1-parse/acorn.js`, reduced to the only
+/// consumer rsvelte has for JS comment attachment: `svelte-ignore` suppression.
 ///
-/// This function operates entirely in-place: it never clones statement Values.
-/// Comments are attached by inserting `leadingComments` directly into existing
-/// statement Map objects via mutable references.
-/// Distribute comments to nested statement bodies. Returns `true` if any
-/// `leadingComments` field was actually inserted (i.e. the node was mutated).
-fn distribute_comments_to_node(node: &mut Value, comments: &[CommentEntry]) -> bool {
-    let Some(obj) = node.as_object_mut() else {
-        return false;
-    };
-    let mut modified = false;
+/// Upstream walks the ESTree tree generically and gives every comment to the first
+/// node (in pre-order) that starts after it, unless a preceding node claims it as a
+/// trailing comment first. Rather than materializing `leadingComments` we record the
+/// `svelte-ignore` texts directly, keyed by the owning node's absolute start offset —
+/// the key Phase 2 looks up while walking the typed AST.
+struct CommentAttacher<'a> {
+    comments: &'a [CommentEntry],
+    next: usize,
+    content: &'a str,
+    offset: u32,
+    map: &'a mut Vec<(u32, Vec<CompactString>)>,
+}
 
-    let node_type = obj
-        .get("type")
-        .and_then(|t| t.as_str())
-        .unwrap_or("")
-        .to_string();
+impl CommentAttacher<'_> {
+    fn visit(&mut self, node: &Value, parent: Option<ParentInfo>) {
+        let Some(obj) = node.as_object() else {
+            return;
+        };
+        let start = obj.get("start").and_then(|v| v.as_u64()).map(|v| v as u32);
+        let end = obj.get("end").and_then(|v| v.as_u64()).map(|v| v as u32);
 
-    // For nodes that contain statement bodies, distribute comments to those bodies.
-    // These are the fields that contain arrays of statements.
-    let body_fields: &[&str] = match node_type.as_str() {
-        "BlockStatement" | "Program" => &["body"],
-        "SwitchCase" => &["consequent"],
-        "SwitchStatement" => &["cases"],
-        "TryStatement" => &["block", "handler", "finalizer"],
-        _ => &[],
-    };
+        if let Some(start) = start {
+            while self
+                .comments
+                .get(self.next)
+                .is_some_and(|comment| comment.start < start)
+            {
+                self.record_leading(start, self.next);
+                self.next += 1;
+            }
+        }
 
-    for &field in body_fields {
-        if let Some(stmts) = obj.get_mut(field).and_then(|v| v.as_array_mut()) {
-            let mut prev_end: u32 = 0;
-            for stmt in stmts.iter_mut() {
-                if let Some(stmt_obj) = stmt.as_object_mut() {
-                    // Check if this statement doesn't already have leadingComments
-                    if !stmt_obj.contains_key("leadingComments") {
-                        let stmt_start =
-                            stmt_obj.get("start").and_then(|s| s.as_u64()).unwrap_or(0) as u32;
+        // Only these parents let their last child swallow the comments that follow it.
+        let last_body_field = match obj.get("type").and_then(|t| t.as_str()).unwrap_or("") {
+            "Program" | "BlockStatement" => Some("body"),
+            "ArrayExpression" => Some("elements"),
+            "ObjectExpression" => Some("properties"),
+            _ => None,
+        };
 
-                        // Use binary search to find the first comment that could be relevant
-                        // (comment.end > prev_end). Comments are sorted by position.
-                        let search_start = comments.partition_point(|c| c.end <= prev_end);
-
-                        let mut leading = Vec::new();
-                        for comment in &comments[search_start..] {
-                            // Once comment end exceeds statement start, no more matches
-                            if comment.end > stmt_start {
-                                break;
-                            }
-                            // Comment must start after previous statement end
-                            if comment.start >= prev_end {
-                                leading.push(comment.value.clone());
-                            }
-                        }
-
-                        if !leading.is_empty() {
-                            stmt_obj.set_field("leadingComments", Value::Array(leading));
-                            modified = true;
+        for (field, value) in obj {
+            if matches!(
+                field.as_str(),
+                "leadingComments" | "trailingComments" | "comments"
+            ) {
+                continue;
+            }
+            match value {
+                Value::Object(_) => {
+                    if is_estree_node(value) {
+                        self.visit(
+                            value,
+                            Some(ParentInfo {
+                                end,
+                                is_last_in_body: false,
+                            }),
+                        );
+                    }
+                }
+                Value::Array(items) => {
+                    let last = items.len().saturating_sub(1);
+                    for (index, item) in items.iter().enumerate() {
+                        if is_estree_node(item) {
+                            self.visit(
+                                item,
+                                Some(ParentInfo {
+                                    end,
+                                    is_last_in_body: last_body_field == Some(field.as_str())
+                                        && index == last,
+                                }),
+                            );
                         }
                     }
-
-                    // Track prev_end for the next iteration
-                    prev_end = stmt_obj.get("end").and_then(|e| e.as_u64()).unwrap_or(0) as u32;
                 }
+                _ => {}
             }
+        }
+
+        self.claim_trailing(end, parent.as_ref());
+    }
+
+    /// Discard every comment that starts before `end` without recording it.
+    fn skip_past(&mut self, end: u32) {
+        while self
+            .comments
+            .get(self.next)
+            .is_some_and(|comment| comment.start < end)
+        {
+            self.next += 1;
         }
     }
 
-    // Recurse into child nodes that might contain nested bodies.
-    // We use &str slices to avoid String allocations.
-    let child_fields: &[&str] = match node_type.as_str() {
-        "FunctionDeclaration" | "FunctionExpression" | "ArrowFunctionExpression" => &["body"],
-        "IfStatement" => &["consequent", "alternate"],
-        "ForStatement" | "ForInStatement" | "ForOfStatement" | "WhileStatement"
-        | "DoWhileStatement" => &["body"],
-        "TryStatement" => &["block", "handler", "finalizer"],
-        "CatchClause" => &["body"],
-        "WithStatement" => &["body"],
-        "LabeledStatement" => &["body"],
-        "SwitchStatement" => &["cases"],
-        "SwitchCase" => &["consequent"],
-        "BlockStatement" | "Program" => &["body"],
-        "ExportNamedDeclaration" | "ExportDefaultDeclaration" => &["declaration"],
-        "VariableDeclaration" => &["declarations"],
-        "ClassDeclaration" | "ClassExpression" => &["body"],
-        "ClassBody" => &["body"],
-        "MethodDefinition" | "PropertyDefinition" => &["value"],
-        _ => &[],
-    };
+    /// Let this node claim the comments that follow it, so they cannot become leading
+    /// comments of a later node.
+    fn claim_trailing(&mut self, end: Option<u32>, parent: Option<&ParentInfo>) {
+        let Some(comment) = self.comments.get(self.next) else {
+            return;
+        };
+        let parent_end = parent.and_then(|p| p.end);
+        if matches!((end, parent_end), (Some(e), Some(pe)) if e == pe) {
+            return;
+        }
 
-    for &field in child_fields {
-        if let Some(child) = obj.get_mut(field) {
-            if child.is_array() {
-                if let Some(items) = child.as_array_mut() {
-                    for item in items {
-                        modified |= distribute_comments_to_node(item, comments);
-                    }
+        if parent.is_some_and(|p| p.is_last_in_body) {
+            while let Some(comment) = self.comments.get(self.next) {
+                if parent_end.is_some_and(|pe| comment.start >= pe) {
+                    break;
                 }
-            } else if child.is_object() {
-                modified |= distribute_comments_to_node(child, comments);
+                self.next += 1;
             }
+        } else if let Some(end) = end
+            && end <= comment.start
+            && self.is_separator_slice(end, comment.start)
+        {
+            self.next += 1;
         }
     }
 
-    modified
+    /// `/^[,) \t]*$/` over the source between a node's end and a comment's start.
+    fn is_separator_slice(&self, from: u32, to: u32) -> bool {
+        let from = from.saturating_sub(self.offset) as usize;
+        let to = to.saturating_sub(self.offset) as usize;
+        self.content
+            .get(from..to)
+            .is_some_and(|slice| slice.chars().all(|c| matches!(c, ',' | ')' | ' ' | '\t')))
+    }
+
+    fn record_leading(&mut self, start: u32, index: usize) {
+        let text = self.comments[index].text.clone();
+        if !text.trim_start().starts_with("svelte-ignore") {
+            return;
+        }
+        match self.map.last_mut() {
+            Some(entry) if entry.0 == start => entry.1.push(text),
+            _ => self.map.push((start, vec![text])),
+        }
+    }
+}
+
+/// Zimmerframe treats any object carrying a string `type` as a node; mirror that.
+fn is_estree_node(value: &Value) -> bool {
+    value
+        .as_object()
+        .and_then(|obj| obj.get("type"))
+        .is_some_and(|t| t.is_string())
 }
 
 /// Convert a statement to JSON value (for program context, no -1 offset adjustment).

--- a/crates/rsvelte_core/tests/svelte_ignore_comment_attachment_2256.rs
+++ b/crates/rsvelte_core/tests/svelte_ignore_comment_attachment_2256.rs
@@ -1,0 +1,254 @@
+//! Regression tests for issue #2256 — a `// svelte-ignore` comment was only
+//! honored in front of a *statement*, because Phase 1 distributed comments to a
+//! hand-maintained allowlist of statement-body fields. Upstream's rule
+//! (`add_comments` in `phases/1-parse/acorn.js`) is positional and type-agnostic:
+//! a comment belongs to the first node in pre-order that starts after it, and the
+//! whole subtree of that node inherits the ignore — unless an earlier node claims
+//! the comment as a *trailing* comment first.
+//!
+//! Both halves matter. Missing the general rule loses suppression inside object
+//! and array literals; missing the trailing-comment rules over-suppresses
+//! warnings that upstream still emits.
+
+use rsvelte_core::{CompileOptions, GenerateMode, compile, compiler::CssMode};
+
+const CODE: &str = "state_referenced_locally";
+
+fn warning_codes(src: &str) -> Vec<String> {
+    compile(
+        src,
+        CompileOptions {
+            filename: Some("T.svelte".into()),
+            generate: GenerateMode::Client,
+            dev: true,
+            css: CssMode::External,
+            ..Default::default()
+        },
+    )
+    .expect("compile")
+    .warnings
+    .into_iter()
+    .map(|w| w.code)
+    .collect()
+}
+
+#[track_caller]
+fn assert_suppressed(src: &str) {
+    let codes = warning_codes(src);
+    assert!(
+        !codes.iter().any(|c| c == CODE),
+        "expected {CODE} to be suppressed, got {codes:?}\n--- source ---\n{src}"
+    );
+}
+
+#[track_caller]
+fn assert_warns(src: &str) {
+    let codes = warning_codes(src);
+    assert!(
+        codes.iter().any(|c| c == CODE),
+        "expected {CODE} to still be emitted, got {codes:?}\n--- source ---\n{src}"
+    );
+}
+
+/// Baseline: without any ignore comment the warning fires, so every
+/// `assert_suppressed` below is testing suppression rather than an absent warning.
+#[test]
+fn baseline_warns_without_ignore() {
+    assert_warns(
+        "<script>\n\tconst { dims } = $props();\n\
+         \tconst opts = $state([{ propertyLevel: dims.length > 0 }]);\n\
+         </script>\n\n{opts.length}\n",
+    );
+}
+
+#[test]
+fn statement_level_ignore_suppresses() {
+    assert_suppressed(
+        "<script>\n\tconst { dims } = $props();\n\n\
+         \t// svelte-ignore state_referenced_locally\n\
+         \tconst statementLevel = dims.length > 0;\n\
+         </script>\n\n{statementLevel}\n",
+    );
+}
+
+/// The issue's repro: the ignore sits in front of an object-literal property.
+#[test]
+fn object_property_ignore_suppresses() {
+    assert_suppressed(
+        "<script>\n\tconst { dims } = $props();\n\n\
+         \tconst opts = $state([\n\t\t{\n\
+         \t\t\t// svelte-ignore state_referenced_locally\n\
+         \t\t\tpropertyLevel: dims.length > 0\n\t\t}\n\t]);\n\
+         </script>\n\n{opts.length}\n",
+    );
+}
+
+#[test]
+fn array_element_ignore_suppresses() {
+    assert_suppressed(
+        "<script>\n\tconst { dims } = $props();\n\n\
+         \tconst opts = $state([\n\
+         \t\t// svelte-ignore state_referenced_locally\n\
+         \t\tdims.length > 0\n\t]);\n\
+         </script>\n\n{opts.length}\n",
+    );
+}
+
+#[test]
+fn call_argument_ignore_suppresses() {
+    assert_suppressed(
+        "<script>\n\tconst { dims } = $props();\n\
+         \tfunction id(a, b) { return a; }\n\n\
+         \tconst opts = id(\n\
+         \t\t// svelte-ignore state_referenced_locally\n\
+         \t\tdims.length > 0,\n\t\t1\n\t);\n\
+         </script>\n\n{opts}\n",
+    );
+}
+
+#[test]
+fn block_comment_form_suppresses() {
+    assert_suppressed(
+        "<script>\n\tconst { dims } = $props();\n\n\
+         \tconst opts = $state([\n\t\t{\n\
+         \t\t\t/* svelte-ignore state_referenced_locally */\n\
+         \t\t\tpropertyLevel: dims.length > 0\n\t\t}\n\t]);\n\
+         </script>\n\n{opts.length}\n",
+    );
+}
+
+#[test]
+fn comma_separated_codes_suppress() {
+    assert_suppressed(
+        "<script>\n\tconst { dims } = $props();\n\n\
+         \tconst opts = $state([\n\t\t{\n\
+         \t\t\t// svelte-ignore await_reactivity_loss, state_referenced_locally\n\
+         \t\t\tpropertyLevel: dims.length > 0\n\t\t}\n\t]);\n\
+         </script>\n\n{opts.length}\n",
+    );
+}
+
+#[test]
+fn class_member_ignore_suppresses() {
+    assert_suppressed(
+        "<script>\n\tconst { dims } = $props();\n\n\
+         \tclass Box {\n\
+         \t\t// svelte-ignore state_referenced_locally\n\
+         \t\tfield = dims.length > 0;\n\n\
+         \t\t// svelte-ignore state_referenced_locally\n\
+         \t\tmethod() {\n\t\t\treturn dims.length;\n\t\t}\n\t}\n\n\
+         \tconst box = new Box();\n\
+         </script>\n\n{box.field}\n",
+    );
+}
+
+/// An ignore on the enclosing declaration covers the whole subtree.
+#[test]
+fn enclosing_declaration_ignore_covers_subtree() {
+    assert_suppressed(
+        "<script>\n\tconst { dims } = $props();\n\n\
+         \t// svelte-ignore state_referenced_locally\n\
+         \tconst opts = $state([\n\t\t{\n\
+         \t\t\tdeep: dims.length > 0\n\t\t}\n\t]);\n\
+         </script>\n\n{opts.length}\n",
+    );
+}
+
+/// An ignore before an object method still covers the method's whole body.
+#[test]
+fn object_method_ignore_covers_body() {
+    assert_suppressed(
+        "<script>\n\tconst { dims } = $props();\n\n\
+         \tconst obj = {\n\
+         \t\t// svelte-ignore state_referenced_locally\n\
+         \t\tcompute() {\n\t\t\treturn dims.length > 0;\n\t\t}\n\t};\n\
+         \tconst v = obj.compute();\n\
+         </script>\n\n{v}\n",
+    );
+}
+
+/// Negative: the ignore belongs to the statement that follows it, not the next one.
+#[test]
+fn ignore_does_not_leak_to_following_statement() {
+    assert_warns(
+        "<script>\n\tconst { dims } = $props();\n\n\
+         \t// svelte-ignore state_referenced_locally\n\
+         \tconst first = 1;\n\
+         \tconst second = dims.length > 0;\n\
+         </script>\n\n{first}{second}\n",
+    );
+}
+
+/// Negative: the ignore belongs to property `a`, so `b` still warns.
+#[test]
+fn ignore_does_not_leak_to_sibling_property() {
+    assert_warns(
+        "<script>\n\tconst { dims } = $props();\n\n\
+         \tconst opts = $state([\n\t\t{\n\
+         \t\t\t// svelte-ignore state_referenced_locally\n\
+         \t\t\ta: 1,\n\t\t\tb: dims.length > 0\n\t\t}\n\t]);\n\
+         </script>\n\n{opts.length}\n",
+    );
+}
+
+/// Negative: a different code must not suppress this warning.
+#[test]
+fn unrelated_code_does_not_suppress() {
+    assert_warns(
+        "<script>\n\tconst { dims } = $props();\n\n\
+         \tconst opts = $state([\n\t\t{\n\
+         \t\t\t// svelte-ignore await_reactivity_loss\n\
+         \t\t\tpropertyLevel: dims.length > 0\n\t\t}\n\t]);\n\
+         </script>\n\n{opts.length}\n",
+    );
+}
+
+/// Negative (upstream trailing rule): only `,`/`)`/spaces/tabs separate the
+/// previous argument from the comment, so the comment is a *trailing* comment of
+/// `1` and never reaches the next argument.
+#[test]
+fn same_line_comment_after_comma_is_trailing_in_call() {
+    assert_warns(
+        "<script>\n\tconst { dims } = $props();\n\
+         \tfunction id(a, b) { return b; }\n\n\
+         \tconst opts = id(1, // svelte-ignore state_referenced_locally\n\
+         \t\tdims.length > 0);\n\
+         </script>\n\n{opts}\n",
+    );
+}
+
+/// Same trailing rule inside an array literal.
+#[test]
+fn same_line_comment_after_comma_is_trailing_in_array() {
+    assert_warns(
+        "<script>\n\tconst { dims } = $props();\n\n\
+         \tconst opts = $state([1, // svelte-ignore state_referenced_locally\n\
+         \t\tdims.length > 0]);\n\
+         </script>\n\n{opts.length}\n",
+    );
+}
+
+/// Negative (upstream `is_last_in_body` rule): a comment after the last statement
+/// of a block belongs to that statement, not to whatever follows the block.
+#[test]
+fn comment_after_last_statement_in_block_does_not_leak_out() {
+    assert_warns(
+        "<script>\n\tconst { dims } = $props();\n\n\
+         \tfunction noop() {\n\t\tlet x = 1;\n\
+         \t\t// svelte-ignore state_referenced_locally\n\t}\n\
+         \tconst after = dims.length > 0;\n\
+         </script>\n\n{after}\n",
+    );
+}
+
+/// The same rule for the last element of an array literal.
+#[test]
+fn comment_after_last_array_element_does_not_leak_out() {
+    assert_warns(
+        "<script>\n\tconst { dims } = $props();\n\n\
+         \tconst list = $state([\n\t\t1\n\
+         \t\t// svelte-ignore state_referenced_locally\n\t]);\n\
+         \tconst after = dims.length > 0;\n\
+         </script>\n\n{list.length}{after}\n",
+    );
+}


### PR DESCRIPTION
Closes #2256

## Root cause

Phase 1 attached JS comments to AST nodes through `distribute_comments_to_node`, a
hand-maintained allowlist of *statement-body* fields (`BlockStatement`, `SwitchStatement`,
`TryStatement`, `VariableDeclaration`, `ClassBody`, …). Anything that is not a statement
body — object-literal properties, array elements, call arguments — had no entry, so a
`// svelte-ignore` in those positions never became a leading comment of the node that
followed it, never reached `Program.ignore_comment_map`, and suppressed nothing.

Upstream's rule (`add_comments` in `phases/1-parse/acorn.js`) has no node-type table at
all: the walk is generic and positional. A comment goes to the first node in pre-order
that starts after it, and Phase 2's ignore stack then covers that node's whole subtree —
unless an earlier node claims the comment as a *trailing* comment first.

## Fix

`distribute_comments_to_node` / `harvest_ignore_comments` are replaced by
`CommentAttacher`, a direct port of upstream `add_comments`, reduced to the single
consumer rsvelte has for JS comment attachment (`svelte-ignore` suppression): it walks
every node generically and records the ignore texts keyed by the owning node's absolute
start, which is exactly what Phase 2 already looks up.

This is the general rule, not a widened allowlist. Both of upstream's trailing-comment
rules are ported with it, because without them the generic rule *over*-suppresses:

* `is_last_in_body` — a comment after the last child of a `Program`/`BlockStatement`/
  `ArrayExpression`/`ObjectExpression` belongs to that child, not to whatever follows the
  block.
* the `/^[,) \t]*$/` separator rule — a comment separated from the previous node by only
  `,`/`)`/spaces/tabs is that node's trailing comment, so `f(1, // svelte-ignore …` does
  **not** cover the next argument.

One rsvelte-specific gap is closed alongside: `convert_statement_for_program` returns
`None` for type-only statements (`type X = …`, `interface`, `import type`), which have no
typed node, so comments inside them used to escape into the next statement. Upstream binds
them to TS nodes whose subtree Phase 2 never visits, so they are now discarded with the
statement.

## Verification

Every shape below was compiled with both the official compiler and rsvelte
(`generate: 'client', dev: true`) and the emitted warning sets compared. **29/29 match.**

| # | Shape | official | rsvelte |
|---|---|---|---|
| 01 | issue repro: statement-level + object-property ignore | none | none |
| 02 | ignore before an array element | none | none |
| 03 | ignore before the first call argument | none | none |
| 04 | ignore before a later call argument (newline before it) | none | none |
| 05 | `/* svelte-ignore … */` block comment in property position | none | none |
| 06 | `// svelte-ignore a, b` comma-separated codes | none | none |
| 07 | ignore before a class field and a class method | none | none |
| 08 | ignore on the enclosing `$state([...])` declaration | none | none |
| 09 | **negative** — must not leak to the next statement | warns | warns |
| 10 | **negative** — must not leak to the sibling property | warns | warns |
| 11 | **negative** — comment after the last statement in a block | warns | warns |
| 12 | ignore before a property of a plain object literal | none | none |
| 13 | **negative** — an unrelated code must not suppress | warns | warns |
| 14 | ignore inside a nested function body | none | none |
| 15 | ignore in an arrow function's returned object literal | none | none |
| 16 | ignore on an array element nested in an object | none | none |
| 17 | **negative** — same-line comment after `,` in a call | warns | warns |
| 18 | **negative** — same-line comment after `,` in an array | warns | warns |
| 19 | **negative** — comment after the last array element | warns | warns |
| 20 | ignore before an object method, covering its body | none | none |
| 21 | dangling comment at the end of a call's arguments | none | none |
| 22 | **negative** — TS: comment inside a `type` alias body | warns | warns |
| 23 | TS: object-property ignore (the repro, `lang="ts"`) | none | none |
| 24 | `<script module>` + instance script, both levels | none | none |
| 25 | **negative** — TS: comment inside an inline type literal | warns | warns |
| 26 | **negative** — TS: comment inside an `interface` body | warns | warns |
| 27 | **negative** — TS: leading comment on a `type` alias | warns | warns |
| 28 | **negative** — TS: leading comment on `import type` | warns | warns |
| 29 | TS: comment inside a generic call's type arguments | none | none |

Additionally, every `.svelte` file under `submodules/svelte/packages/svelte/tests` that
contains a `svelte-ignore` comment (33 files) was compiled with both compilers: **0**
warning-code differences.

New regression suite: `crates/rsvelte_core/tests/svelte_ignore_comment_attachment_2256.rs`
— the positive shapes plus six must-still-warn negatives (next statement, sibling
property, unrelated code, both same-line-after-comma forms, last-in-block and
last-array-element).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017eFcFhr66RJemE7UtF4CNK
