### PR TITLE
feat(language-server): publish the native server as per-platform packages

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -38,6 +38,11 @@
     ],
     [
       "@rsvelte/language-server",
+      "@rsvelte/language-server-darwin-arm64",
+      "@rsvelte/language-server-darwin-x64",
+      "@rsvelte/language-server-linux-arm64-gnu",
+      "@rsvelte/language-server-linux-x64-gnu",
+      "@rsvelte/language-server-win32-x64-msvc",
       "rsvelte-vscode"
     ]
   ],

--- a/.changeset/native-language-server-platform-packages.md
+++ b/.changeset/native-language-server-platform-packages.md
@@ -1,0 +1,12 @@
+---
+'@rsvelte/language-server': minor
+'@rsvelte/language-server-darwin-arm64': minor
+'@rsvelte/language-server-darwin-x64': minor
+'@rsvelte/language-server-linux-arm64-gnu': minor
+'@rsvelte/language-server-linux-x64-gnu': minor
+'@rsvelte/language-server-win32-x64-msvc': minor
+---
+
+Ship the native Rust `rsvelte-language-server` as per-platform npm packages and prefer it from the `@rsvelte/language-server` launcher.
+
+The launcher's `rsvelte-language-server` bin now resolves the prebuilt binary from the optional `@rsvelte/language-server-<triple>` dependency and execs it, falling back to the bundled JS server when no platform package is installed. `RSVELTE_LANGUAGE_SERVER_BIN` overrides the binary path and `RSVELTE_LANGUAGE_SERVER_JS=1` forces the JS fallback.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -356,6 +356,67 @@ jobs:
           if-no-files-found: error
           retention-days: 7
 
+  # Per-platform rsvelte-language-server builds for @rsvelte/language-server.
+  # Mirrors `build-rsvelte-lint`, including its profile choice: the server
+  # isolates a per-document compiler panic via `catch_unwind`, which only works
+  # when the binary UNWINDS, so it builds with `--profile dist-lsp` (dist's
+  # opt/strip, panic = "unwind"). Output lives under `target/<target>/dist-lsp/`.
+  build-rsvelte-language-server:
+    name: Build rsvelte-language-server (${{ matrix.triple }})
+    if: "${{ startsWith(github.event.head_commit.message, 'chore(release): version packages') }}"
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { os: macos-latest, target: aarch64-apple-darwin, triple: darwin-arm64, ext: '' }
+          - { os: macos-latest, target: x86_64-apple-darwin, triple: darwin-x64, ext: '' }
+          - { os: ubuntu-latest, target: x86_64-unknown-linux-gnu, triple: linux-x64-gnu, ext: '' }
+          - { os: ubuntu-latest, target: aarch64-unknown-linux-gnu, triple: linux-arm64-gnu, ext: '', apt: gcc-aarch64-linux-gnu, linker: aarch64-linux-gnu-gcc }
+          - { os: windows-latest, target: x86_64-pc-windows-msvc, triple: win32-x64-msvc, ext: '.exe' }
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Checkout svelte submodule (shallow)
+        run: git submodule update --init --depth 1 submodules/svelte
+
+      - name: Install cross-compile linker
+        if: matrix.apt
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ${{ matrix.apt }}
+
+      - uses: ./.github/actions/setup-rust
+        with:
+          targets: ${{ matrix.target }}
+
+      - name: Cache cargo registry + target
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          key: ${{ matrix.target }}
+
+      - name: Build rsvelte-language-server
+        shell: bash
+        env:
+          CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: ${{ matrix.linker }}
+        run: cargo build --profile dist-lsp --bin rsvelte-language-server --target ${{ matrix.target }}
+
+      - name: Stage binary
+        shell: bash
+        run: |
+          mkdir -p stage
+          cp "target/${{ matrix.target }}/dist-lsp/rsvelte-language-server${{ matrix.ext }}" \
+             "stage/rsvelte-language-server${{ matrix.ext }}"
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: rsvelte-language-server-${{ matrix.triple }}
+          path: stage/rsvelte-language-server${{ matrix.ext }}
+          if-no-files-found: error
+          retention-days: 7
+
   publish:
     name: Publish
     # Publish only runs on the "Version Packages" merge commit, once the
@@ -363,7 +424,15 @@ jobs:
     # changesets consumed. This is the only path that needs staged binaries.
     if: "${{ startsWith(github.event.head_commit.message, 'chore(release): version packages') }}"
     runs-on: ubuntu-latest
-    needs: [close-version-cycle, build-svelte-check, build-vps-native, build-rsvelte-fmt, build-rsvelte-lint]
+    needs:
+      [
+        close-version-cycle,
+        build-svelte-check,
+        build-vps-native,
+        build-rsvelte-fmt,
+        build-rsvelte-lint,
+        build-rsvelte-language-server,
+      ]
     timeout-minutes: 30
     # Publishing is non-atomic across packages and must never be interrupted.
     concurrency:
@@ -423,6 +492,9 @@ jobs:
 
       - name: Stage rsvelte-lint binaries
         run: pnpm run stage-lint
+
+      - name: Stage rsvelte-language-server binaries
+        run: pnpm run stage-language-server
 
       - name: Stage vps-native binaries
         run: pnpm run stage-vps-native

--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,11 @@ target
 /apps/npm/lint-*/rsvelte-lint.exe
 /apps/npm/lint-*/rsvelte_lint.node
 
+# rsvelte-language-server platform binaries (staged into per-platform npm
+# packages by the release workflow; never committed)
+/apps/npm/language-server-*/rsvelte-language-server
+/apps/npm/language-server-*/rsvelte-language-server.exe
+
 # Playwright MCP
 .playwright-mcp/
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2572,7 +2572,7 @@ dependencies = [
 
 [[package]]
 name = "rsvelte_language_server"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "crossbeam-channel",

--- a/apps/npm/language-server-darwin-arm64/README.md
+++ b/apps/npm/language-server-darwin-arm64/README.md
@@ -1,0 +1,17 @@
+# @rsvelte/language-server-darwin-arm64
+
+Prebuilt [`@rsvelte/language-server`](https://www.npmjs.com/package/@rsvelte/language-server) binary for **macOS arm64** (Apple Silicon).
+
+**Do not install this package directly.** Install the loader package:
+
+```bash
+npm install -D @rsvelte/language-server
+```
+
+The loader will pull in the correct platform binary (this one, if you're on macOS arm64 (Apple Silicon)) via `optionalDependencies` and invoke it transparently.
+
+Part of the [rsvelte](https://github.com/baseballyama/rsvelte) project — a Rust port of the Svelte 5 compiler and surrounding toolchain.
+
+## License
+
+MIT

--- a/apps/npm/language-server-darwin-arm64/package.json
+++ b/apps/npm/language-server-darwin-arm64/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@rsvelte/language-server-darwin-arm64",
+  "version": "0.3.0",
+  "description": "Prebuilt rsvelte-language-server binary for darwin-arm64",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/baseballyama/rsvelte.git",
+    "directory": "apps/npm/language-server-darwin-arm64"
+  },
+  "os": [
+    "darwin"
+  ],
+  "cpu": [
+    "arm64"
+  ],
+  "files": [
+    "rsvelte-language-server"
+  ],
+  "scripts": {
+    "prepack": "chmod +x rsvelte-language-server"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/apps/npm/language-server-darwin-x64/README.md
+++ b/apps/npm/language-server-darwin-x64/README.md
@@ -1,0 +1,17 @@
+# @rsvelte/language-server-darwin-x64
+
+Prebuilt [`@rsvelte/language-server`](https://www.npmjs.com/package/@rsvelte/language-server) binary for **macOS x64** (Intel).
+
+**Do not install this package directly.** Install the loader package:
+
+```bash
+npm install -D @rsvelte/language-server
+```
+
+The loader will pull in the correct platform binary (this one, if you're on macOS x64 (Intel)) via `optionalDependencies` and invoke it transparently.
+
+Part of the [rsvelte](https://github.com/baseballyama/rsvelte) project — a Rust port of the Svelte 5 compiler and surrounding toolchain.
+
+## License
+
+MIT

--- a/apps/npm/language-server-darwin-x64/package.json
+++ b/apps/npm/language-server-darwin-x64/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@rsvelte/language-server-darwin-x64",
+  "version": "0.3.0",
+  "description": "Prebuilt rsvelte-language-server binary for darwin-x64",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/baseballyama/rsvelte.git",
+    "directory": "apps/npm/language-server-darwin-x64"
+  },
+  "os": [
+    "darwin"
+  ],
+  "cpu": [
+    "x64"
+  ],
+  "files": [
+    "rsvelte-language-server"
+  ],
+  "scripts": {
+    "prepack": "chmod +x rsvelte-language-server"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/apps/npm/language-server-linux-arm64-gnu/README.md
+++ b/apps/npm/language-server-linux-arm64-gnu/README.md
@@ -1,0 +1,17 @@
+# @rsvelte/language-server-linux-arm64-gnu
+
+Prebuilt [`@rsvelte/language-server`](https://www.npmjs.com/package/@rsvelte/language-server) binary for **Linux arm64** (glibc).
+
+**Do not install this package directly.** Install the loader package:
+
+```bash
+npm install -D @rsvelte/language-server
+```
+
+The loader will pull in the correct platform binary (this one, if you're on Linux arm64 (glibc)) via `optionalDependencies` and invoke it transparently.
+
+Part of the [rsvelte](https://github.com/baseballyama/rsvelte) project — a Rust port of the Svelte 5 compiler and surrounding toolchain.
+
+## License
+
+MIT

--- a/apps/npm/language-server-linux-arm64-gnu/package.json
+++ b/apps/npm/language-server-linux-arm64-gnu/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@rsvelte/language-server-linux-arm64-gnu",
+  "version": "0.3.0",
+  "description": "Prebuilt rsvelte-language-server binary for linux-arm64-gnu",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/baseballyama/rsvelte.git",
+    "directory": "apps/npm/language-server-linux-arm64-gnu"
+  },
+  "os": [
+    "linux"
+  ],
+  "cpu": [
+    "arm64"
+  ],
+  "files": [
+    "rsvelte-language-server"
+  ],
+  "scripts": {
+    "prepack": "chmod +x rsvelte-language-server"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/apps/npm/language-server-linux-x64-gnu/README.md
+++ b/apps/npm/language-server-linux-x64-gnu/README.md
@@ -1,0 +1,17 @@
+# @rsvelte/language-server-linux-x64-gnu
+
+Prebuilt [`@rsvelte/language-server`](https://www.npmjs.com/package/@rsvelte/language-server) binary for **Linux x64** (glibc).
+
+**Do not install this package directly.** Install the loader package:
+
+```bash
+npm install -D @rsvelte/language-server
+```
+
+The loader will pull in the correct platform binary (this one, if you're on Linux x64 (glibc)) via `optionalDependencies` and invoke it transparently.
+
+Part of the [rsvelte](https://github.com/baseballyama/rsvelte) project — a Rust port of the Svelte 5 compiler and surrounding toolchain.
+
+## License
+
+MIT

--- a/apps/npm/language-server-linux-x64-gnu/package.json
+++ b/apps/npm/language-server-linux-x64-gnu/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@rsvelte/language-server-linux-x64-gnu",
+  "version": "0.3.0",
+  "description": "Prebuilt rsvelte-language-server binary for linux-x64-gnu",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/baseballyama/rsvelte.git",
+    "directory": "apps/npm/language-server-linux-x64-gnu"
+  },
+  "os": [
+    "linux"
+  ],
+  "cpu": [
+    "x64"
+  ],
+  "files": [
+    "rsvelte-language-server"
+  ],
+  "scripts": {
+    "prepack": "chmod +x rsvelte-language-server"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/apps/npm/language-server-win32-x64-msvc/README.md
+++ b/apps/npm/language-server-win32-x64-msvc/README.md
@@ -1,0 +1,17 @@
+# @rsvelte/language-server-win32-x64-msvc
+
+Prebuilt [`@rsvelte/language-server`](https://www.npmjs.com/package/@rsvelte/language-server) binary for **Windows x64** (msvc).
+
+**Do not install this package directly.** Install the loader package:
+
+```bash
+npm install -D @rsvelte/language-server
+```
+
+The loader will pull in the correct platform binary (this one, if you're on Windows x64 (msvc)) via `optionalDependencies` and invoke it transparently.
+
+Part of the [rsvelte](https://github.com/baseballyama/rsvelte) project — a Rust port of the Svelte 5 compiler and surrounding toolchain.
+
+## License
+
+MIT

--- a/apps/npm/language-server-win32-x64-msvc/package.json
+++ b/apps/npm/language-server-win32-x64-msvc/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@rsvelte/language-server-win32-x64-msvc",
+  "version": "0.3.0",
+  "description": "Prebuilt rsvelte-language-server binary for win32-x64 (msvc)",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/baseballyama/rsvelte.git",
+    "directory": "apps/npm/language-server-win32-x64-msvc"
+  },
+  "os": [
+    "win32"
+  ],
+  "cpu": [
+    "x64"
+  ],
+  "files": [
+    "rsvelte-language-server.exe"
+  ],
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/apps/npm/language-server/README.md
+++ b/apps/npm/language-server/README.md
@@ -81,6 +81,18 @@ Most users won't run this directly — the
 bundles and launches it. For other editors, point your LSP client at the
 `rsvelte-language-server` binary with the `--stdio` transport.
 
+## Native server
+
+`rsvelte-language-server` is a launcher. It prefers the prebuilt native (Rust)
+server shipped in the optional `@rsvelte/language-server-<platform>` packages
+and falls back to the bundled JS server when no platform package is installed
+(unsupported platform, or an install that skipped optional dependencies).
+
+| Environment variable | Effect |
+| --- | --- |
+| `RSVELTE_LANGUAGE_SERVER_BIN` | Run this binary instead of the resolved one. |
+| `RSVELTE_LANGUAGE_SERVER_JS=1` | Force the bundled JS server. |
+
 ## License
 
 MIT

--- a/apps/npm/language-server/bin/rsvelte-language-server.mjs
+++ b/apps/npm/language-server/bin/rsvelte-language-server.mjs
@@ -1,0 +1,78 @@
+#!/usr/bin/env node
+// Launcher for `rsvelte-language-server`.
+//
+// It prefers the native Rust server shipped in the optional
+// `@rsvelte/language-server-<triple>` packages and falls back to the bundled
+// JS server (`dist/server.mjs`) when no platform package is installed — so an
+// unsupported platform, or an install that skipped optional dependencies,
+// keeps the capabilities it has today instead of failing outright.
+//
+// Like the @rsvelte/fmt and @rsvelte/lint launchers, this file is never
+// rewritten in place: pnpm bakes a shim interpreter from this file's shebang at
+// link time, so swapping it for a native binary post-install would make that
+// shim feed Mach-O/ELF bytes to Node.
+
+import { spawnSync } from 'node:child_process';
+import { constants as osConstants } from 'node:os';
+import { existsSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+	ensureExecutable,
+	platformPackage,
+	resolvePlatformBinary,
+} from '../lib/resolve.mjs';
+
+const pkgRoot = dirname(dirname(fileURLToPath(import.meta.url)));
+const argv = process.argv.slice(2);
+
+// Escape hatches for editors and debugging: point at a locally built server, or
+// force the JS implementation when the native one misbehaves.
+const override = process.env.RSVELTE_LANGUAGE_SERVER_BIN;
+const forceJs = process.env.RSVELTE_LANGUAGE_SERVER_JS === '1';
+
+let command;
+let args;
+if (override) {
+	command = override;
+	args = argv;
+} else {
+	const native = forceJs ? null : resolvePlatformBinary();
+	if (native) {
+		ensureExecutable(native);
+		command = native;
+		args = argv;
+	} else {
+		const jsServer = join(pkgRoot, 'dist', 'server.mjs');
+		if (!existsSync(jsServer)) {
+			const { triple, pkgName } = platformPackage();
+			console.error(
+				`[@rsvelte/language-server] No server to run: the JS fallback (${jsServer}) is missing and ` +
+					(triple
+						? `the native package "${pkgName}" isn't installed.\nTry reinstalling: npm install --include=optional ${pkgName}`
+						: `platform ${process.platform}-${process.arch} has no prebuilt binary.`),
+			);
+			process.exit(1);
+		}
+		command = process.execPath;
+		args = [jsServer, ...argv];
+	}
+}
+
+const result = spawnSync(command, args, { stdio: 'inherit', windowsHide: true });
+
+if (result.error) {
+	console.error(
+		`[@rsvelte/language-server] Failed to exec ${command}: ${result.error.message}`,
+	);
+	process.exit(1);
+}
+
+// A signal termination leaves `status` null; returning `status ?? 0` would mask
+// the crash as a clean exit.
+if (result.signal) {
+	const signum = osConstants.signals[result.signal];
+	console.error(`[@rsvelte/language-server] ${command} was terminated by ${result.signal}.`);
+	process.exit(typeof signum === 'number' ? 128 + signum : 1);
+}
+process.exit(result.status ?? 0);

--- a/apps/npm/language-server/bin/rsvelte-language-server.mjs
+++ b/apps/npm/language-server/bin/rsvelte-language-server.mjs
@@ -46,11 +46,13 @@ if (override) {
 		const jsServer = join(pkgRoot, 'dist', 'server.mjs');
 		if (!existsSync(jsServer)) {
 			const { triple, pkgName } = platformPackage();
+			const why = forceJs
+				? 'RSVELTE_LANGUAGE_SERVER_JS=1 forced it.'
+				: triple
+					? `the native package "${pkgName}" isn't installed.\nTry reinstalling: npm install --include=optional ${pkgName}`
+					: `platform ${process.platform}-${process.arch} has no prebuilt binary.`;
 			console.error(
-				`[@rsvelte/language-server] No server to run: the JS fallback (${jsServer}) is missing and ` +
-					(triple
-						? `the native package "${pkgName}" isn't installed.\nTry reinstalling: npm install --include=optional ${pkgName}`
-						: `platform ${process.platform}-${process.arch} has no prebuilt binary.`),
+				`[@rsvelte/language-server] No server to run: the JS fallback (${jsServer}) is missing and ${why}`,
 			);
 			process.exit(1);
 		}

--- a/apps/npm/language-server/lib/resolve.mjs
+++ b/apps/npm/language-server/lib/resolve.mjs
@@ -1,0 +1,74 @@
+// Resolution helpers for the @rsvelte/language-server launcher: they find the
+// platform-native `rsvelte-language-server` binary shipped in the optional
+// `@rsvelte/language-server-<triple>` packages.
+//
+// ESM (not `.cjs` like the @rsvelte/fmt / @rsvelte/lint siblings) because this
+// package is `"type": "module"`; the resolution logic itself is identical.
+
+import { chmodSync, constants, statSync } from 'node:fs';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+
+/// Map the current platform/arch to a `@rsvelte/language-server-<triple>`
+/// suffix, or `null` when unsupported. Mirrors the release build matrix.
+export function resolveTriple() {
+	const { platform, arch } = process;
+	if (platform === 'darwin') {
+		if (arch === 'arm64') return 'darwin-arm64';
+		if (arch === 'x64') return 'darwin-x64';
+	} else if (platform === 'linux') {
+		// Node 18+ exposes the runtime glibc version; an empty value means musl.
+		let isMusl = false;
+		try {
+			const header = process.report.getReport().header;
+			isMusl = !header.glibcVersionRuntime;
+		} catch {
+			isMusl = false;
+		}
+		const libc = isMusl ? 'musl' : 'gnu';
+		if (arch === 'x64') return `linux-x64-${libc}`;
+		if (arch === 'arm64') return `linux-arm64-${libc}`;
+	} else if (platform === 'win32') {
+		if (arch === 'x64') return 'win32-x64-msvc';
+	}
+	return null;
+}
+
+/// The platform package name + binary basename for the current platform.
+/// `triple` is `null` when the platform is unsupported.
+export function platformPackage() {
+	const triple = resolveTriple();
+	if (!triple) return { triple: null, pkgName: null, binName: null };
+	const pkgName = `@rsvelte/language-server-${triple}`;
+	const binName =
+		process.platform === 'win32'
+			? 'rsvelte-language-server.exe'
+			: 'rsvelte-language-server';
+	return { triple, pkgName, binName };
+}
+
+/// Resolve the absolute path to the prebuilt native server for this platform,
+/// or `null` when the optional platform package isn't installed.
+export function resolvePlatformBinary() {
+	const { pkgName, binName } = platformPackage();
+	if (!pkgName) return null;
+	try {
+		return require.resolve(`${pkgName}/${binName}`);
+	} catch {
+		return null;
+	}
+}
+
+/// Best-effort `chmod +x` on a POSIX file. No-op on Windows / read-only FS.
+export function ensureExecutable(binPath) {
+	if (process.platform === 'win32') return;
+	try {
+		const mode = statSync(binPath).mode;
+		if (!(mode & constants.S_IXUSR)) {
+			chmodSync(binPath, (mode & 0o777) | 0o111);
+		}
+	} catch {
+		// Not fatal — a later spawn surfaces a clear error if it really can't run.
+	}
+}

--- a/apps/npm/language-server/package.json
+++ b/apps/npm/language-server/package.json
@@ -22,9 +22,11 @@
   ],
   "type": "module",
   "bin": {
-    "rsvelte-language-server": "dist/server.mjs"
+    "rsvelte-language-server": "bin/rsvelte-language-server.mjs"
   },
   "files": [
+    "bin/rsvelte-language-server.mjs",
+    "lib/resolve.mjs",
     "dist/server.mjs",
     "dist/vendor/rsvelte_lint.cjs",
     "dist/vendor/rsvelte_lint_bg.wasm"
@@ -34,6 +36,13 @@
     "typecheck": "tsc --noEmit",
     "test": "node --test \"test/*.test.mjs\"",
     "prepublishOnly": "node -e \"for (const f of ['dist/server.mjs','dist/vendor/rsvelte_lint.cjs','dist/vendor/rsvelte_lint_bg.wasm']) if (!require('fs').existsSync(f)) { console.error('missing '+f+' — run build:language-server first'); process.exit(1) }\""
+  },
+  "optionalDependencies": {
+    "@rsvelte/language-server-darwin-arm64": "workspace:^",
+    "@rsvelte/language-server-darwin-x64": "workspace:^",
+    "@rsvelte/language-server-linux-arm64-gnu": "workspace:^",
+    "@rsvelte/language-server-linux-x64-gnu": "workspace:^",
+    "@rsvelte/language-server-win32-x64-msvc": "workspace:^"
   },
   "dependencies": {
     "vscode-languageserver": "^10.0.0",

--- a/crates/rsvelte_language_server/Cargo.toml
+++ b/crates/rsvelte_language_server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rsvelte_language_server"
-version = "0.1.0"
+version = "0.3.0"
 edition = "2024"
 rust-version = "1.95"
 description = "Language server exposing rsvelte's formatter and linter over LSP"

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
 		"stage-svelte-check": "node scripts/release/stage-svelte-check-binaries.mjs",
 		"stage-fmt": "node scripts/release/stage-fmt-binaries.mjs",
 		"stage-lint": "node scripts/release/stage-lint-binaries.mjs",
+		"stage-language-server": "node scripts/release/stage-language-server-binaries.mjs",
 		"stage-vps-native": "node scripts/release/stage-vps-binaries.mjs",
 		"publish-platform-binaries": "node scripts/release/publish-platform-binaries.mjs",
 		"test:envelope": "node scripts/dev/test-envelope-validation.mjs",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -86,6 +86,32 @@ importers:
       typescript:
         specifier: ^7.0.0
         version: 7.0.2
+    optionalDependencies:
+      '@rsvelte/language-server-darwin-arm64':
+        specifier: workspace:^
+        version: link:../language-server-darwin-arm64
+      '@rsvelte/language-server-darwin-x64':
+        specifier: workspace:^
+        version: link:../language-server-darwin-x64
+      '@rsvelte/language-server-linux-arm64-gnu':
+        specifier: workspace:^
+        version: link:../language-server-linux-arm64-gnu
+      '@rsvelte/language-server-linux-x64-gnu':
+        specifier: workspace:^
+        version: link:../language-server-linux-x64-gnu
+      '@rsvelte/language-server-win32-x64-msvc':
+        specifier: workspace:^
+        version: link:../language-server-win32-x64-msvc
+
+  apps/npm/language-server-darwin-arm64: {}
+
+  apps/npm/language-server-darwin-x64: {}
+
+  apps/npm/language-server-linux-arm64-gnu: {}
+
+  apps/npm/language-server-linux-x64-gnu: {}
+
+  apps/npm/language-server-win32-x64-msvc: {}
 
   apps/npm/lint:
     optionalDependencies:

--- a/scripts/release/publish-platform-binaries.mjs
+++ b/scripts/release/publish-platform-binaries.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 // Publish the platform packages that ship an executable POSIX binary
-// (`@rsvelte/svelte-check-*`, `@rsvelte/fmt-*` and `@rsvelte/lint-*`) via
+// (`@rsvelte/svelte-check-*`, `@rsvelte/fmt-*`, `@rsvelte/lint-*` and
+// `@rsvelte/language-server-*`) via
 // `npm publish` rather than `pnpm publish`.
 //
 // Why: `pnpm pack` (which `pnpm publish` uses) normalises file modes to 0644,
@@ -37,6 +38,10 @@ const platformDirs = [
 	'apps/npm/lint-darwin-x64',
 	'apps/npm/lint-linux-x64-gnu',
 	'apps/npm/lint-linux-arm64-gnu',
+	'apps/npm/language-server-darwin-arm64',
+	'apps/npm/language-server-darwin-x64',
+	'apps/npm/language-server-linux-x64-gnu',
+	'apps/npm/language-server-linux-arm64-gnu',
 ];
 
 const dryRun = process.argv.includes('--dry-run');

--- a/scripts/release/stage-language-server-binaries.mjs
+++ b/scripts/release/stage-language-server-binaries.mjs
@@ -1,0 +1,59 @@
+#!/usr/bin/env node
+// Stage the per-platform rsvelte-language-server artifacts produced by the
+// matrix build into their corresponding `apps/npm/language-server-<triple>/`
+// directories so `pnpm publish` picks them up.
+//
+// Expected layout under the artifact root (default `./artifacts`):
+//
+//   artifacts/
+//     rsvelte-language-server-darwin-arm64/rsvelte-language-server
+//     rsvelte-language-server-darwin-x64/rsvelte-language-server
+//     rsvelte-language-server-linux-x64-gnu/rsvelte-language-server
+//     rsvelte-language-server-linux-arm64-gnu/rsvelte-language-server
+//     rsvelte-language-server-win32-x64-msvc/rsvelte-language-server.exe
+//
+// The artifact directory name mirrors the upload-artifact name used in the
+// release workflow's `build-rsvelte-language-server` job.
+
+import { copyFileSync, chmodSync, existsSync, statSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(here, '../..');
+const artifactRoot = resolve(
+	repoRoot,
+	process.env.LANGUAGE_SERVER_ARTIFACT_ROOT || 'artifacts',
+);
+
+const targets = [
+	{ triple: 'darwin-arm64', binary: 'rsvelte-language-server' },
+	{ triple: 'darwin-x64', binary: 'rsvelte-language-server' },
+	{ triple: 'linux-x64-gnu', binary: 'rsvelte-language-server' },
+	{ triple: 'linux-arm64-gnu', binary: 'rsvelte-language-server' },
+	{ triple: 'win32-x64-msvc', binary: 'rsvelte-language-server.exe' },
+];
+
+let missing = 0;
+for (const { triple, binary } of targets) {
+	const src = resolve(artifactRoot, `rsvelte-language-server-${triple}`, binary);
+	const dest = resolve(repoRoot, `apps/npm/language-server-${triple}`, binary);
+	if (!existsSync(src)) {
+		console.warn(`[stage] missing artifact: ${src}`);
+		missing += 1;
+		continue;
+	}
+	copyFileSync(src, dest);
+	// The platform packages publish via `npm publish`
+	// (`scripts/release/publish-platform-binaries.mjs`), which preserves the
+	// file mode — `pnpm publish` would normalise it back to 0644.
+	if (!binary.endsWith('.exe')) {
+		chmodSync(dest, 0o755);
+	}
+	console.log(`[stage] ${dest} (${statSync(dest).size} bytes)`);
+}
+
+if (missing > 0) {
+	console.error(`[stage] ${missing} artifact(s) missing — refusing to continue`);
+	process.exit(1);
+}

--- a/scripts/release/sync-version.mjs
+++ b/scripts/release/sync-version.mjs
@@ -27,6 +27,9 @@
 //   Without this sync the crate stays at `0.1.0` no matter how many releases
 //   ship, so `rsvelte-fmt --version` would report a stale version that never
 //   matches the published `@rsvelte/fmt` package.
+// - `@rsvelte/language-server` ← `crates/rsvelte_language_server`: the native
+//   server reports `serverInfo.version` from `env!("CARGO_PKG_VERSION")`, which
+//   editors surface, so it must track the npm package it ships in.
 //
 // Each binary's `--version` must match the npm package it ships in.
 
@@ -70,6 +73,11 @@ const MAPPINGS = [
 		npm: 'apps/npm/svelte-check/package.json',
 		cargoToml: 'crates/rsvelte_check/Cargo.toml',
 		lockName: 'rsvelte_check',
+	},
+	{
+		npm: 'apps/npm/language-server/package.json',
+		cargoToml: 'crates/rsvelte_language_server/Cargo.toml',
+		lockName: 'rsvelte_language_server',
 	},
 ];
 


### PR DESCRIPTION
Refs #1761 #1768

## The blocker

There are two language servers: the JS one published as `@rsvelte/language-server`, and `crates/rsvelte_language_server` — the Wave 4 M0 Rust server that is the actual target architecture (document sync, formatting, push diagnostics, completions, hover, code actions, folding, selection ranges, document symbols). The Rust one had **no distribution channel at all**: no per-platform npm packages, no release-workflow job. No editor extension could obtain it, which is why the Zed extension (#2270) has to launch the JS server and can only reach the Rust one through a manual `binary.path` override.

This gives the native server the same channel the repo already uses for `rsvelte-fmt`, `rsvelte-lint` and `svelte-check`, and makes `@rsvelte/language-server` prefer it.

## Survey: what a new native tool needs here

Enumerated from `fmt` / `lint` / `svelte-check` before writing anything:

| Piece | Precedent | This PR |
| --- | --- | --- |
| 5 platform package dirs `apps/npm/<tool>-{darwin-arm64,darwin-x64,linux-arm64-gnu,linux-x64-gnu,win32-x64-msvc}` | `fmt-*`, `lint-*` | `apps/npm/language-server-*` (`package.json` with `os`/`cpu`/`files`/`prepack: chmod +x`, README) |
| Launcher `optionalDependencies: workspace:^` on all five | `apps/npm/fmt/package.json` | `apps/npm/language-server/package.json` |
| `bin` → JS launcher that never rewrites itself (pnpm bakes its shim interpreter from the shebang) | `fmt/bin/rsvelte-fmt` + `lib/resolve.cjs` | `bin/rsvelte-language-server.mjs` + `lib/resolve.mjs` (ESM, since this package is `"type": "module"`; identical resolution logic) |
| Release matrix build job | `build-rsvelte-fmt` / `build-rsvelte-lint` | `build-rsvelte-language-server`, 5 triples, `--profile dist-lsp` |
| Cargo profile | `dist` (fmt), `dist-lint` (lint, needs unwind for `catch_unwind`) | `dist-lsp` **already existed** in the root `Cargo.toml` — the server's worker isolates per-document panics via `catch_unwind`, so it must unwind |
| `needs:` + stage step in `publish` | `pnpm run stage-lint` | `pnpm run stage-language-server` + the job added to `needs` |
| Stage script | `stage-lint-binaries.mjs` | `scripts/release/stage-language-server-binaries.mjs` (+ root `package.json` script) |
| POSIX packages published via `npm publish` (pnpm drops the +x bit) | `publish-platform-binaries.mjs` | 4 POSIX dirs appended (win32 excluded, as for the others) |
| Changesets `fixed` group | one group per tool | the five platform packages joined the existing `@rsvelte/language-server` + `rsvelte-vscode` group |
| `sync-version.mjs` mapping | `@rsvelte/fmt` → `crates/rsvelte_fmt` | `@rsvelte/language-server` → `crates/rsvelte_language_server`; the server reports `serverInfo.version` from `env!("CARGO_PKG_VERSION")`, so it would otherwise report a stale `0.1.0` forever |
| `.gitignore` for staged binaries | `/apps/npm/lint-*/rsvelte-lint` | `/apps/npm/language-server-*/rsvelte-language-server{,.exe}` |
| Crate changes | — | none needed: `[[bin]] name = "rsvelte-language-server"` already exists, and `publish = false` stays (crates.io is not the channel; npm platform packages ship the built binary) |
| `VPS native VERSION drift check` | checks `vite-plugin-svelte-native` VERSION vs `submodules/svelte` | unrelated to these packages; no change |

## Launcher behaviour

`rsvelte-language-server` resolves `@rsvelte/language-server-<triple>/rsvelte-language-server` and execs it, forwarding argv/stdio and propagating exit code / signal (`128 + signum`, so a Rust panic isn't masked as exit 0). When the platform package is absent — unsupported platform, or an install that skipped optional dependencies — it falls back to today's `node dist/server.mjs`, so **nothing regresses for existing users**. Escape hatches: `RSVELTE_LANGUAGE_SERVER_BIN` (explicit path) and `RSVELTE_LANGUAGE_SERVER_JS=1` (force JS).

## What #2270 can do once this lands

After the next release, the Zed extension can depend on `@rsvelte/language-server` and get the **native** server automatically on all five supported platforms — no `binary.path` override, no JS-server-only capability set. The same applies to any other editor client.

## Verified locally

- `node scripts/release/check-changeset-package-names.mjs` — all six names resolve in the workspace.
- `node scripts/release/sync-version.mjs` — now also syncs `rsvelte_language_server` (`0.1.0` → `0.3.0`, mirrored into `Cargo.lock`); committed.
- Launcher resolution: platform-package miss → JS fallback path; `RSVELTE_LANGUAGE_SERVER_BIN` override execs and forwards argv; `platformPackage()` returns the right triple.
- `pnpm install --lockfile-only` — lockfile updated with the five workspace links.

## Left for a follow-up

- **VS Code extension** (`apps/npm/vscode/src/extension.ts`) still hardcodes `dist/server.mjs`; switching it to the launcher/native binary is a separate change (it bundles the server rather than depending on the package).
- No CI job builds the native server on PRs — like the other CLIs, the binary is only produced on the release commit, so the first cross-platform proof arrives with the next release build.
