### PR TITLE
fix(compiler): name only arrow event handlers in dev

### DIFF
--- a/.changeset/dev-arrow-event-handler-names.md
+++ b/.changeset/dev-arrow-event-handler-names.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/compiler": patch
+---
+
+Name only arrow-function event handlers in dev mode, matching the official compiler's `dev && handler.type === 'ArrowFunctionExpression'` guard. Naming a non-arrow handler consumed a `scope.generate()` slot, which shifted every later identifier sharing the prefix — including element variables, since `<input on:input>` draws `input` from the same counter.

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/on_directive.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/on_directive.rs
@@ -83,8 +83,11 @@ pub fn on_directive(node: &OnDirective, context: &mut ComponentContext) -> JsExp
         None
     };
 
-    // In dev mode, convert arrow function handlers to named functions for better stack traces
-    let handler = if context.state.options.dev {
+    // In dev mode, convert arrow function handlers to named functions for better
+    // stack traces. Naming only an arrow matters beyond the shape: upstream's
+    // `dev && handler.type === 'ArrowFunctionExpression'` guard means a bubble
+    // handler never consumes a name, so the next arrow keeps the lower suffix.
+    let handler = if context.state.options.dev && matches!(handler, JsExpr::Arrow(_)) {
         let name = context.state.memoizer.generate_id(&node.name);
         crate::compiler::phases::phase3_transform::client::visitors::shared::events::convert_arrow_to_named_function(handler, name.into())
     } else {

--- a/crates/rsvelte_core/tests/dev_event_handler_naming.rs
+++ b/crates/rsvelte_core/tests/dev_event_handler_naming.rs
@@ -1,0 +1,69 @@
+//! `build_event()` names a handler only when it is an arrow function
+//! (`dev && handler.type === 'ArrowFunctionExpression'`, `shared/events.js`).
+//! Naming a non-arrow handler burns a `scope.generate()` slot, which shifts
+//! every later suffix that shares the prefix — including the element variables,
+//! since `<input on:input>` draws `input` from the same counter.
+//!
+//! The corpus gates compile with `dev: false`, so nothing else covers this.
+
+use rsvelte_core::{CompileOptions, GenerateMode, compile};
+
+fn compile_client_dev(src: &str) -> String {
+    compile(
+        src,
+        CompileOptions {
+            filename: Some("Ev.svelte".to_string()),
+            generate: GenerateMode::Client,
+            dev: true,
+            ..Default::default()
+        },
+    )
+    .expect("compile")
+    .js
+    .code
+}
+
+#[test]
+fn a_non_arrow_on_directive_handler_consumes_no_name() {
+    let out = compile_client_dev(
+        r#"<script>
+	export let handler;
+	let count = 0;
+</script>
+<button on:click={handler}>a</button>
+<button on:click={() => count++}>b</button>
+"#,
+    );
+    assert!(
+        out.contains("function click()"),
+        "the arrow handler should take the unsuffixed name, got:\n{out}"
+    );
+    assert!(
+        !out.contains("function click_1()"),
+        "the non-arrow handler must not consume `click`, got:\n{out}"
+    );
+}
+
+#[test]
+fn a_non_arrow_on_directive_handler_leaves_the_element_variable_alone() {
+    let out = compile_client_dev(
+        r#"<script>
+	export let handler;
+</script>
+{#if true}
+	<input on:input={handler} />
+{/if}
+{#if true}
+	<input on:input={handler} />
+{/if}
+"#,
+    );
+    assert!(
+        out.contains("var input_1 = "),
+        "the second element should be `input_1`, got:\n{out}"
+    );
+    assert!(
+        !out.contains("var input_2 = "),
+        "no name should have been burned on the non-arrow handlers, got:\n{out}"
+    );
+}


### PR DESCRIPTION
`build_event()` upstream guards the generated handler name behind `dev && handler.type === 'ArrowFunctionExpression'` (`shared/events.js`), so a handler that is already a function expression consumes no `scope.generate()` slot. `on_directive.rs` named it anyway, which shifted every later suffix sharing the prefix — including the element variables, since `<input on:input>` draws `input` from the same counter. `attribute.rs` and the special-element path in `types.rs` already had the guard.

Visible as `function click_2()` where the official compiler emits `function click()`, and `var input_2 = root_1()` where it emits `var input_1`.

`compatibility/known-failures.client-dev.json` shrinks as a result; per the convention in `compatibility/known-failures.md`, the baseline is regenerated in a separate chore PR once the code fixes land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014EJ8yjsgEh6CxqJhQoGZHP