### PR TITLE
fix(compiler): use the rootDir-relative filename in dev location strings

### DIFF
--- a/.changeset/dev-location-filename.md
+++ b/.changeset/dev-location-filename.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/compiler": patch
+---
+
+Use the whole `rootDir`-relative filename in dev-mode location strings. `ComponentAnalysis::filename` held only the basename, so `$inspect.trace()` labels and `$.assign()` locations reported `main.svelte` where the official compiler reports the full path (with `/` sanitized to `/​`).

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/types.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/types.rs
@@ -1484,7 +1484,8 @@ pub struct ComponentAnalysis {
     /// Component name (derived from filename)
     pub name: String,
 
-    /// Original filename (e.g., "main.svelte") used for dev-mode source locations
+    /// Upstream's `state.filename`: slash-normalized and made `rootDir`-relative,
+    /// used verbatim in dev-mode source locations.
     pub filename: String,
 
     /// Whether the component uses runes
@@ -1664,30 +1665,7 @@ impl ComponentAnalysis {
             .filename
             .as_ref()
             .filter(|f| *f != "(unknown)")
-            .map(|f| {
-                // Only allocate if backslashes are present
-                let fname_owned;
-                let fname: &str = if f.contains('\\') {
-                    fname_owned = f.replace('\\', "/");
-                    &fname_owned
-                } else {
-                    f
-                };
-                if let Some(ref root_dir) = options.root_dir {
-                    // Only allocate if backslashes are present in root_dir
-                    let rd_owned;
-                    let rd: &str = if root_dir.contains('\\') {
-                        rd_owned = root_dir.replace('\\', "/");
-                        &rd_owned
-                    } else {
-                        root_dir
-                    };
-                    if let Some(stripped) = fname.strip_prefix(rd) {
-                        return stripped.trim_start_matches('/').to_string();
-                    }
-                }
-                fname.to_string()
-            })
+            .map(|f| normalize_filename(f, options.root_dir.as_deref()))
             .unwrap_or_else(|| "main.svelte".to_string());
         let filename_hash = crate::compiler::phases::phase3_transform::css::generate_raw_hash(
             &filename_hash_source,
@@ -1703,16 +1681,7 @@ impl ComponentAnalysis {
             filename: options
                 .filename
                 .as_ref()
-                .map(|f| {
-                    // Extract just the basename (e.g., "main.svelte" from "/path/to/main.svelte")
-                    f.rsplit('/')
-                        .next()
-                        .unwrap_or(f)
-                        .rsplit('\\')
-                        .next()
-                        .unwrap_or(f)
-                        .to_string()
-                })
+                .map(|f| normalize_filename(f, options.root_dir.as_deref()))
                 .unwrap_or_else(|| "Component".to_string()),
             runes: initial_runes,
             runes_explicitly_set: options.runes,
@@ -1965,6 +1934,32 @@ impl ComponentAnalysis {
         // TODO: Analyze for keyframes and :global selectors
         Ok(())
     }
+}
+
+/// Slash-normalize a filename and make it `root_dir`-relative.
+/// Matches `reset()` + `adjust()` in `compiler/state.js`.
+fn normalize_filename(filename: &str, root_dir: Option<&str>) -> String {
+    // Only allocate when backslashes are actually present.
+    let fname_owned;
+    let fname: &str = if filename.contains('\\') {
+        fname_owned = filename.replace('\\', "/");
+        &fname_owned
+    } else {
+        filename
+    };
+    if let Some(root_dir) = root_dir {
+        let rd_owned;
+        let rd: &str = if root_dir.contains('\\') {
+            rd_owned = root_dir.replace('\\', "/");
+            &rd_owned
+        } else {
+            root_dir
+        };
+        if let Some(stripped) = fname.strip_prefix(rd) {
+            return stripped.trim_start_matches('/').to_string();
+        }
+    }
+    fname.to_string()
 }
 
 /// Derive component name from filename.

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/ast_state_transform.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/ast_state_transform.rs
@@ -1920,6 +1920,8 @@ impl<'a, 's> StateVarCollector<'a, 's> {
                 .and_then(|src| find_trace_source_location(before_block_post, src, default_label));
             match (source_pos, self.filename) {
                 (Some((line, col)), Some(filename)) => {
+                    // `locate_node()` runs the path through `sanitize_location()`.
+                    let filename = filename.replace('/', "/\u{200b}");
                     format!("() => '{} ({}:{}:{})'", default_label, filename, line, col)
                 }
                 _ => format!("() => '{}'", default_label),

--- a/crates/rsvelte_core/tests/dev_location_filename.rs
+++ b/crates/rsvelte_core/tests/dev_location_filename.rs
@@ -1,0 +1,52 @@
+//! Dev-mode location strings come from `locate_node()`, which prints
+//! `state.filename` — the whole `rootDir`-relative path, run through
+//! `sanitize_location()` (`/` → `/\u{200b}`) — not just the basename.
+//!
+//! The corpus gates compile with `dev: false`, so nothing else covers this.
+
+use rsvelte_core::{CompileOptions, GenerateMode, compile};
+
+fn compile_client_dev(src: &str, filename: &str, root_dir: Option<&str>) -> String {
+    compile(
+        src,
+        CompileOptions {
+            filename: Some(filename.to_string()),
+            root_dir: root_dir.map(str::to_string),
+            generate: GenerateMode::Client,
+            dev: true,
+            ..Default::default()
+        },
+    )
+    .expect("compile")
+    .js
+    .code
+}
+
+const TRACE_SRC: &str = r#"<script>
+	let obj = $state({ a: 1 });
+	function f() {
+		$inspect.trace();
+		obj.a;
+	}
+	f();
+</script>
+<p>{obj.a}</p>
+"#;
+
+#[test]
+fn the_trace_label_carries_the_whole_relative_path() {
+    let out = compile_client_dev(TRACE_SRC, "sub/dir/Tr.svelte", None);
+    assert!(
+        out.contains("'f (sub/\u{200b}dir/\u{200b}Tr.svelte:3:1)'"),
+        "expected the sanitized relative path in the trace label, got:\n{out}"
+    );
+}
+
+#[test]
+fn the_trace_label_is_relative_to_root_dir() {
+    let out = compile_client_dev(TRACE_SRC, "/repo/sub/Tr.svelte", Some("/repo"));
+    assert!(
+        out.contains("'f (sub/\u{200b}Tr.svelte:3:1)'"),
+        "expected the path to be made rootDir-relative, got:\n{out}"
+    );
+}


### PR DESCRIPTION
`locate_node()` prints `state.filename`, which `reset()` + `adjust()` leave as the **whole** path made relative to `rootDir`; `sanitize_location()` then rewrites `/` to `/​`. `ComponentAnalysis::filename` kept only the basename, so `$inspect.trace()` labels and `$.assign()` locations named `main.svelte` instead of the path — and the sanitize step already present in the `$.assign` builder had nothing left to rewrite.

`normalize_filename()` now does the `reset()` + `adjust()` normalization in one place; the CSS-hash source, which open-coded the same logic, reuses it.

`compatibility/known-failures.client-dev.json` shrinks as a result; per the convention in `compatibility/known-failures.md`, the baseline is regenerated in a separate chore PR once the code fixes land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014EJ8yjsgEh6CxqJhQoGZHP