### PR TITLE
fix(compiler): keep the dev await rewrite from swallowing the next statement

### DIFF
--- a/.changeset/dev-await-and-console-rewrites.md
+++ b/.changeset/dev-await-and-console-rewrites.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/compiler": patch
+---
+
+Keep the dev-mode `await` instrumentation from swallowing the next statement, and single-quote the console method name. `(await $.track_reactivity_loss(x))()` can continue a line where the bare `await x` it replaced could not, so a source relying on ASI folded the following statement into a call; and the method name reaches `$.log_if_contains_state` as a plain literal, which esrap prints single-quoted.

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/ast_state_transform.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/ast_state_transform.rs
@@ -238,6 +238,8 @@ struct StateVarCollector<'a, 's> {
     in_shorthand_property: bool,
     /// Subtrees carrying a `svelte-ignore await_reactivity_loss`.
     await_ignore_ranges: super::await_reactivity_loss_ast::AwaitIgnoreRanges,
+    /// Starts of `await` expressions that are a whole statement relying on ASI.
+    unterminated_await_starts: FxHashSet<u32>,
 
     // --- Phase A-2 fields ---
     /// Prop source variables that need getter/setter wrapping: `prop` -> `prop()`.
@@ -365,6 +367,7 @@ impl<'a, 's> StateVarCollector<'a, 's> {
             scoped_vars: vec![FxHashSet::default()],
             in_shorthand_property: false,
             await_ignore_ranges: Default::default(),
+            unterminated_await_starts: FxHashSet::default(),
             prop_source_vars: prop_source_set,
             non_bindable_prop_vars: non_bindable_set,
             store_sub_vars: store_sub_set,
@@ -1995,11 +1998,11 @@ impl<'a, 's> StateVarCollector<'a, 's> {
         let arg_span = expr.argument.span();
         let arg_text = self.apply_and_drain_inner_replacements(arg_span.start, arg_span.end);
 
-        self.add_replacement(
-            expr.span.start,
-            expr.span.end,
-            format!("(await $.track_reactivity_loss({}))()", arg_text.trim()),
-        );
+        let mut replacement = format!("(await $.track_reactivity_loss({}))()", arg_text.trim());
+        if self.unterminated_await_starts.contains(&expr.span.start) {
+            replacement.push(';');
+        }
+        self.add_replacement(expr.span.start, expr.span.end, replacement);
         true
     }
 
@@ -2316,6 +2319,18 @@ impl<'a, 's, 'ast> Visit<'ast> for StateVarCollector<'a, 's> {
         if !self.try_rewrite_strict_equals_binary(expr) {
             walk::walk_binary_expression(self, expr);
         }
+    }
+
+    fn visit_statements(&mut self, stmts: &oxc_allocator::Vec<'ast, Statement<'ast>>) {
+        for pair in stmts.windows(2) {
+            if let Some(start) = super::await_reactivity_loss_ast::unterminated_await_statement(
+                &pair[0],
+                self.source,
+            ) {
+                self.unterminated_await_starts.insert(start);
+            }
+        }
+        walk::walk_statements(self, stmts);
     }
 
     fn visit_await_expression(&mut self, expr: &AwaitExpression<'ast>) {

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/await_reactivity_loss_ast.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/await_reactivity_loss_ast.rs
@@ -26,6 +26,22 @@ fn track_reactivity_loss_wrap(argument_text: &str) -> String {
     format!("(await $.track_reactivity_loss({argument_text}))()")
 }
 
+/// The start offset of a whole-statement `await` that a following statement
+/// would be folded into once the wrapper's trailing `)()` makes the line
+/// continuable. Restricted to statements with a successor because the same
+/// visitor also runs over expression fragments parsed as one-statement
+/// programs, where a `;` would land in expression position.
+pub(super) fn unterminated_await_statement(stmt: &Statement<'_>, source: &str) -> Option<u32> {
+    let Statement::ExpressionStatement(stmt) = stmt else {
+        return None;
+    };
+    let Expression::AwaitExpression(_) = &stmt.expression else {
+        return None;
+    };
+    let text = &source[stmt.span.start as usize..stmt.span.end as usize];
+    (!text.ends_with(';')).then(|| stmt.expression.span().start)
+}
+
 /// The wrapper keeps an `await` of its own, so the fixed-point loop would wrap
 /// it again on the next iteration; recognising the marker is what makes this
 /// pass idempotent.
@@ -122,6 +138,7 @@ pub(super) fn collect_await_reactivity_loss_edits(
     let mut collector = AwaitCollector {
         source,
         ignored: collect_await_ignore_ranges(program, source, is_runes),
+        unterminated: rustc_hash::FxHashSet::default(),
         edits: Vec::new(),
     };
     collector.visit_program(program);
@@ -131,10 +148,21 @@ pub(super) fn collect_await_reactivity_loss_edits(
 struct AwaitCollector<'src> {
     source: &'src str,
     ignored: AwaitIgnoreRanges,
+    /// Starts of `await` expressions that are a whole statement relying on ASI.
+    unterminated: rustc_hash::FxHashSet<u32>,
     edits: Vec<Edit>,
 }
 
 impl<'a, 'src> Visit<'a> for AwaitCollector<'src> {
+    fn visit_statements(&mut self, stmts: &oxc_allocator::Vec<'a, Statement<'a>>) {
+        for pair in stmts.windows(2) {
+            if let Some(start) = unterminated_await_statement(&pair[0], self.source) {
+                self.unterminated.insert(start);
+            }
+        }
+        walk::walk_statements(self, stmts);
+    }
+
     fn visit_await_expression(&mut self, expr: &AwaitExpression<'a>) {
         walk::walk_await_expression(self, expr);
 
@@ -144,10 +172,11 @@ impl<'a, 'src> Visit<'a> for AwaitCollector<'src> {
 
         let arg_span = expr.argument.span();
         let arg_text = self.source[arg_span.start as usize..arg_span.end as usize].trim();
-        self.edits.push((
-            expr.span.start,
-            expr.span.end,
-            track_reactivity_loss_wrap(arg_text),
-        ));
+        let mut replacement = track_reactivity_loss_wrap(arg_text);
+        if self.unterminated.contains(&expr.span.start) {
+            replacement.push(';');
+        }
+        self.edits
+            .push((expr.span.start, expr.span.end, replacement));
     }
 }

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/console_dev_ast.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/console_dev_ast.rs
@@ -1,5 +1,5 @@
 //! AST-based dev-mode `console.METHOD(args)` →
-//! `console.METHOD(...$.log_if_contains_state("METHOD", args))`
+//! `console.METHOD(...$.log_if_contains_state('METHOD', args))`
 //! wrapping for generated script text — module scripts
 //! (`.svelte.js` / `.svelte.ts`), instance-script statements, and the settled
 //! legacy instance script (whose `$:` bodies no per-statement pass ever sees).
@@ -194,8 +194,10 @@ impl<'a, 'src> Visit<'a> for ConsoleCollector<'src> {
             return;
         }
 
+        // Single quotes: the method name is a plain `b.literal`, which esrap prints
+        // single-quoted, and this text path bypasses the printer.
         let rewrite = format!(
-            "console.{}(...$.log_if_contains_state(\"{}\", {}))",
+            "console.{}(...$.log_if_contains_state('{}', {}))",
             method, method, args_text
         );
         self.replacements
@@ -284,7 +286,7 @@ mod tests {
     #[test]
     fn wraps_console_log_with_identifier() {
         let out = transform_console_calls_dev_ast_for_test("console.log(x);", false).unwrap();
-        assert_eq!(out, "console.log(...$.log_if_contains_state(\"log\", x));");
+        assert_eq!(out, "console.log(...$.log_if_contains_state('log', x));");
     }
 
     #[test]
@@ -293,7 +295,7 @@ mod tests {
             let src = format!("console.{}(x);", method);
             let out = transform_console_calls_dev_ast_for_test(&src, false).unwrap();
             let expected = format!(
-                "console.{}(...$.log_if_contains_state(\"{}\", x));",
+                "console.{}(...$.log_if_contains_state('{}', x));",
                 method, method
             );
             assert_eq!(out, expected, "method {method}");
@@ -369,7 +371,7 @@ mod tests {
         let out = transform_console_calls_dev_fragment("console.log(x); let =;", false, None);
         assert_eq!(
             out.as_deref(),
-            Some("console.log(...$.log_if_contains_state(\"log\", x)); let =;")
+            Some("console.log(...$.log_if_contains_state('log', x)); let =;")
         );
     }
 
@@ -379,7 +381,7 @@ mod tests {
             transform_console_calls_dev_ast_for_test(r#"console.log("x:", x);"#, false).unwrap();
         assert_eq!(
             out,
-            r#"console.log(...$.log_if_contains_state("log", "x:", x));"#
+            r#"console.log(...$.log_if_contains_state('log', "x:", x));"#
         );
     }
 
@@ -401,7 +403,7 @@ mod tests {
         let out = transform_console_calls_dev_ast_for_test(src, false).unwrap();
         assert_eq!(
             out,
-            "let s = `${console.log(...$.log_if_contains_state(\"log\", x))}`;"
+            "let s = `${console.log(...$.log_if_contains_state('log', x))}`;"
         );
     }
 
@@ -412,7 +414,7 @@ mod tests {
         // Both wraps: inner first, then outer wraps the rewritten inner.
         assert_eq!(
             out,
-            "console.log(...$.log_if_contains_state(\"log\", console.warn(...$.log_if_contains_state(\"warn\", x))));"
+            "console.log(...$.log_if_contains_state('log', console.warn(...$.log_if_contains_state('warn', x))));"
         );
     }
 
@@ -420,7 +422,7 @@ mod tests {
     fn ts_source_type_works() {
         let src = "let x: number = 1; console.log(x);";
         let out = transform_console_calls_dev_ast_for_test(src, true).unwrap();
-        assert!(out.contains("$.log_if_contains_state(\"log\", x)"));
+        assert!(out.contains("$.log_if_contains_state('log', x)"));
     }
 
     #[test]
@@ -440,7 +442,7 @@ mod tests {
         let out = transform_console_calls_dev_ast_for_test("console.log(...args);", false).unwrap();
         assert_eq!(
             out,
-            "console.log(...$.log_if_contains_state(\"log\", ...args));"
+            "console.log(...$.log_if_contains_state('log', ...args));"
         );
     }
 }

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/inspect_rune_ast.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/inspect_rune_ast.rs
@@ -187,7 +187,7 @@ mod tests {
             "default inspector was rewritten: {out}"
         );
         assert!(
-            out.contains(r#"console.log(...$.log_if_contains_state("log", b));"#),
+            out.contains(r#"console.log(...$.log_if_contains_state('log', b));"#),
             "the user's own console call should still be wrapped: {out}"
         );
     }

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/module_dev_tail_ast.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/module_dev_tail_ast.rs
@@ -184,7 +184,7 @@ mod tests {
         assert!(out.contains("$.user_effect(() => {});"), "got: {out}");
         assert!(out.contains("$.strict_equals(a, b);"), "got: {out}");
         assert!(
-            out.contains("console.log(...$.log_if_contains_state(\"log\", x));"),
+            out.contains("console.log(...$.log_if_contains_state('log', x));"),
             "got: {out}"
         );
         assert!(

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/props_transforms.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/props_transforms.rs
@@ -3563,7 +3563,7 @@ pub(super) fn transform_console_calls_dev(stmt: &str) -> String {
                 if !args_content.is_empty() && !all_args_are_literals(args_content) {
                     // Transform: console.METHOD(args) -> console.METHOD(...$.log_if_contains_state("METHOD", args))
                     let new_call = format!(
-                        "console.{}(...$.log_if_contains_state(\"{}\", {}))",
+                        "console.{}(...$.log_if_contains_state('{}', {}))",
                         method, method, args_content
                     );
                     let call_end = args_start + args_end + 1; // +1 for closing paren

--- a/crates/rsvelte_core/tests/dev_await_statement_terminator.rs
+++ b/crates/rsvelte_core/tests/dev_await_statement_terminator.rs
@@ -1,0 +1,67 @@
+//! `await f()` cannot continue the preceding line, so a source that leaves the
+//! statement unterminated is fine — but the dev wrapper
+//! `(await $.track_reactivity_loss(f()))()` can, and ASI then folds the next
+//! statement into a call on it. The rewrite has to restore the boundary.
+//!
+//! The corpus gates compile with `dev: false`, so nothing else covers this.
+
+use rsvelte_core::{CompileOptions, GenerateMode, compile};
+
+fn compile_client_dev(src: &str) -> String {
+    compile(
+        src,
+        CompileOptions {
+            filename: Some("Aw.svelte".to_string()),
+            generate: GenerateMode::Client,
+            dev: true,
+            ..Default::default()
+        },
+    )
+    .expect("compile")
+    .js
+    .code
+}
+
+#[test]
+fn consecutive_unterminated_awaits_stay_separate_statements_in_runes_mode() {
+    let out = compile_client_dev(
+        r#"<script>
+	let n = $state(0)
+	async function go() {
+		await fetch('/a')
+		await fetch('/b')
+		n++
+	}
+</script>
+<button onclick={go}>{n}</button>
+"#,
+    );
+    assert!(
+        out.contains("(await $.track_reactivity_loss(fetch('/a')))();"),
+        "the first await should terminate its statement, got:\n{out}"
+    );
+    assert!(
+        !out.contains("))()(await"),
+        "the two awaits must not fold into one call, got:\n{out}"
+    );
+}
+
+#[test]
+fn consecutive_unterminated_awaits_stay_separate_statements_in_legacy_mode() {
+    let out = compile_client_dev(
+        r#"<script>
+	export let n = 0
+	async function go() {
+		await fetch('/a')
+		await fetch('/b')
+		n++
+	}
+</script>
+<button on:click={go}>{n}</button>
+"#,
+    );
+    assert!(
+        !out.contains("))()(await"),
+        "the two awaits must not fold into one call, got:\n{out}"
+    );
+}

--- a/crates/rsvelte_core/tests/dev_console_wrap_quotes.rs
+++ b/crates/rsvelte_core/tests/dev_console_wrap_quotes.rs
@@ -1,0 +1,36 @@
+//! The console method name reaches `$.log_if_contains_state` as a plain
+//! `b.literal` (`CallExpression.js`), which esrap prints single-quoted. The
+//! text-based wrap has to spell it the same way, because a script fragment that
+//! stays raw never reaches the printer to be renormalized.
+//!
+//! The corpus gates compile with `dev: false`, so nothing else covers this.
+
+use rsvelte_core::{CompileOptions, GenerateMode, compile};
+
+#[test]
+fn the_console_method_name_is_single_quoted() {
+    let out = compile(
+        r#"<script>
+	export let value;
+	function go() {
+		console.error(`v ${value}`, { value });
+	}
+</script>
+<button on:click={go}>go</button>
+"#,
+        CompileOptions {
+            filename: Some("Log.svelte".to_string()),
+            generate: GenerateMode::Client,
+            dev: true,
+            ..Default::default()
+        },
+    )
+    .expect("compile")
+    .js
+    .code;
+
+    assert!(
+        out.contains("$.log_if_contains_state('error',"),
+        "expected a single-quoted method name, got:\n{out}"
+    );
+}


### PR DESCRIPTION
Two dev-only text rewrites diverged from the official compiler.

**`await` statement boundary.** `await f()` cannot continue the preceding line, so a source that leaves the statement unterminated parses as two statements. The dev wrapper `(await $.track_reactivity_loss(f()))()` *can* continue a line, so ASI folded the next statement into a call on it:

```js
(await $.track_reactivity_loss(update({ reset: false })))()(await $.track_reactivity_loss(applyAction(result)))();
```

The boundary is now restored — but only when the statement has a successor, because the same visitors also run over expression fragments parsed as one-statement programs, where a `;` would land in expression position and make the output unparseable.

**Console method quoting.** The method name reaches `$.log_if_contains_state` as a plain `b.literal` (`CallExpression.js`), which esrap prints single-quoted. The text path never reaches the printer, so it has to spell it the same way.

`compatibility/known-failures.client-dev.json` shrinks as a result; per the convention in `compatibility/known-failures.md`, the baseline is regenerated in a separate chore PR once the code fixes land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014EJ8yjsgEh6CxqJhQoGZHP