### PR TITLE
fix(compiler): do not constant-fold an equality comparison in dev

### DIFF
--- a/.changeset/dev-equality-not-constant-folded.md
+++ b/.changeset/dev-equality-not-constant-folded.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/compiler": patch
+---
+
+Stop constant-folding an equality comparison in dev mode. Upstream evaluates the *converted* expression, and in dev the `BinaryExpression` visitor has already rewritten `===` / `!==` / `==` / `!=` into a `$.strict_equals` / `$.equals` call, so `{1 === 1}` stays a call instead of folding to the literal `'true'`.

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/utils.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/utils.rs
@@ -3937,6 +3937,15 @@ fn get_literal_value_complex(
         }
         "BinaryExpression" => {
             let operator = obj.get("operator").and_then(|v| v.as_str())?;
+
+            // Upstream evaluates the *converted* expression, and in dev the
+            // `BinaryExpression` visitor has already turned an equality into a
+            // `$.strict_equals` / `$.equals` call — which never evaluates to a
+            // known value, so the chunk stays a call instead of folding.
+            if context.state.options.dev && matches!(operator, "===" | "!==" | "==" | "!=") {
+                return None;
+            }
+
             let left = obj.get("left")?;
             let right = obj.get("right")?;
 

--- a/crates/rsvelte_core/tests/dev_equality_not_folded.rs
+++ b/crates/rsvelte_core/tests/dev_equality_not_folded.rs
@@ -1,0 +1,42 @@
+//! Upstream constant-folds a template chunk by running `scope.evaluate()` on
+//! the *converted* expression. In dev the `BinaryExpression` visitor has
+//! already rewritten an equality into `$.strict_equals` / `$.equals`, so the
+//! chunk is a call and never folds — `{1 === 1}` stays a call rather than
+//! becoming the literal `'true'`.
+//!
+//! The corpus gates compile with `dev: false`, so nothing else covers this.
+
+use rsvelte_core::{CompileOptions, GenerateMode, compile};
+
+fn compile_client(src: &str, dev: bool) -> String {
+    compile(
+        src,
+        CompileOptions {
+            filename: Some("Eq.svelte".to_string()),
+            generate: GenerateMode::Client,
+            dev,
+            ..Default::default()
+        },
+    )
+    .expect("compile")
+    .js
+    .code
+}
+
+#[test]
+fn a_static_equality_stays_a_call_in_dev() {
+    let out = compile_client("<h1>{1 === 1}</h1>", true);
+    assert!(
+        out.contains("$.strict_equals(1, 1)"),
+        "expected the dev call, got:\n{out}"
+    );
+}
+
+#[test]
+fn a_static_equality_still_folds_outside_dev() {
+    let out = compile_client("<h1>{1 === 1}</h1>", false);
+    assert!(
+        out.contains("'true'"),
+        "expected the folded literal, got:\n{out}"
+    );
+}


### PR DESCRIPTION
`build_template_chunk` folds a chunk by running `scope.evaluate()` on the expression it just **built** — and in dev the `BinaryExpression` visitor has already turned `===` / `!==` / `==` / `!=` into a `$.strict_equals` / `$.equals` call, which never evaluates to a known value.

`get_literal_value` folded the *source* expression instead, so `<h1>{1 === 1}</h1>` compiled to `h1.textContent = 'true'` where the official compiler emits `h1.textContent = $.strict_equals(1, 1)`. Non-dev output is unchanged.

`compatibility/known-failures.client-dev.json` shrinks as a result; per the convention in `compatibility/known-failures.md`, the baseline is regenerated in a separate chore PR once the code fixes land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014EJ8yjsgEh6CxqJhQoGZHP