### PR TITLE
fix(compiler): read class-transform terminators lexically, not by byte hunt (#2253)

### DIFF
--- a/.changeset/ctor-private-state-set-paren.md
+++ b/.changeset/ctor-private-state-set-paren.md
@@ -1,0 +1,40 @@
+---
+"@rsvelte/compiler": patch
+---
+
+Class-field lowering no longer reads a `}`, `)` or `;` that appears inside a
+comment or a literal as code. Two failure modes are fixed.
+
+**Unparseable output.** A `#private` `$state` field assigned from an
+object/array literal that contains a `//` line comment closed the injected
+`$.set(` at the comment's offset — `$.set(this.#x, {\na: s,)// c` — and
+Vite/Rolldown rejected the module with `Parse failure: Unexpected token`. The
+scanner that locates the end of the assigned value treated a `//` at *any*
+bracket depth as the statement's trailing comment, and four sibling scans in the
+method paths took the first `;` anywhere at all, including inside a comment, a
+string or a nested function body.
+
+**Silent content loss.** On the server target the class body's closing brace was
+found with a bare character loop, so a `}` written inside a comment (`// returns
+{ ok, err }`) closed the class early and *every member after it was dropped from
+the output* — no error, no warning, just a class missing its methods. The client
+member scan had the same defect one level down and split a method in two at such
+a comment.
+
+A fifth site: the server treated a class member as a block only when its line
+had a `(`, so a `static { … }` initialization block was never recognised and its
+body was emitted line by line as class fields — each with a `;` appended,
+comment lines included.
+
+All of these scanners now share `shared::js_scan::skip_opaque`, which steps over
+strings, template literals, regex literals and both comment forms in one place;
+a regex such as `{ a: /[});]+/g }` was mis-parsed on every target even with no
+comment involved.
+
+Class lowering also printed its synthesized members at a hard-coded one-level
+indentation, which assumed the class sat one tab deep inside a component
+`<script>`. A top-level `class` in a `.svelte.js` module came out with its
+fields, accessors, constructor and closing brace one tab too deep. Synthesized
+members now follow the class's own source indentation, and a grouped multi-line
+constructor statement keeps the relative indentation of its continuation lines
+instead of being flattened to column 0.

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/class_transforms.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/class_transforms.rs
@@ -7,6 +7,7 @@ use super::REGEX_INVALID_IDENTIFIER_CHARS;
 use super::expression_needs_proxy;
 use crate::compiler::phases::phase1_parse::utils::find_matching_bracket;
 use crate::compiler::phases::phase3_transform::shared::class_body::split_class_members_onto_lines;
+use crate::compiler::phases::phase3_transform::shared::js_scan::skip_opaque;
 
 /// JS-lexical-aware replacement for `find_matching_paren`: given `s` positioned
 /// just after an opening `(`, return the byte offset of the matching `)`,
@@ -98,40 +99,56 @@ fn replace_field_ref_word_boundary(haystack: &str, needle: &str, replacement: &s
 fn net_bracket_depth(line: &str) -> i32 {
     let bytes = line.as_bytes();
     let mut depth = 0i32;
+    let mut prev: Option<u8> = None;
     let mut i = 0;
     while i < bytes.len() {
-        match bytes[i] {
-            b'\'' | b'"' | b'`' => {
-                let quote = bytes[i];
-                i += 1;
-                while i < bytes.len() {
-                    match bytes[i] {
-                        b'\\' => i += 2,
-                        b if b == quote => {
-                            i += 1;
-                            break;
-                        }
-                        _ => i += 1,
-                    }
-                }
-                continue;
+        if let Some((next, is_comment)) = skip_opaque(bytes, i, prev) {
+            if !is_comment {
+                prev = Some(b'x');
             }
-            b'/' if bytes.get(i + 1) == Some(&b'/') => break, // rest of line is a comment
-            b'/' if bytes.get(i + 1) == Some(&b'*') => {
-                i += 2;
-                while i + 1 < bytes.len() && !(bytes[i] == b'*' && bytes[i + 1] == b'/') {
-                    i += 1;
-                }
-                i = (i + 2).min(bytes.len());
-                continue;
-            }
+            i = next;
+            continue;
+        }
+        let c = bytes[i];
+        match c {
             b'(' | b'[' | b'{' => depth += 1,
             b')' | b']' | b'}' => depth -= 1,
             _ => {}
         }
+        if !c.is_ascii_whitespace() {
+            prev = Some(c);
+        }
         i += 1;
     }
     depth
+}
+
+/// Apply `line`'s `{` / `}` to a running class-body nesting depth, clamped at
+/// zero. Braces inside comments and literals do not count — a member scan that
+/// counted them split a method in two at a `// … } …` comment.
+fn advance_brace_depth(line: &str, depth: &mut i32) {
+    let bytes = line.as_bytes();
+    let mut prev: Option<u8> = None;
+    let mut i = 0;
+    while i < bytes.len() {
+        if let Some((next, is_comment)) = skip_opaque(bytes, i, prev) {
+            if !is_comment {
+                prev = Some(b'x');
+            }
+            i = next;
+            continue;
+        }
+        let c = bytes[i];
+        match c {
+            b'{' => *depth += 1,
+            b'}' => *depth = (*depth - 1).max(0),
+            _ => {}
+        }
+        if !c.is_ascii_whitespace() {
+            prev = Some(c);
+        }
+        i += 1;
+    }
 }
 
 /// Does `line` start a multi-line *assignment* — an assignment operator at
@@ -149,42 +166,22 @@ fn is_multiline_assignment_start(line: &str) -> bool {
     }
     let bytes = line.as_bytes();
     let mut depth = 0i32;
+    let mut prev: Option<u8> = None;
     let mut i = 0;
     while i < bytes.len() {
-        match bytes[i] {
-            b'\'' | b'"' | b'`' => {
-                let quote = bytes[i];
-                i += 1;
-                while i < bytes.len() {
-                    match bytes[i] {
-                        b'\\' => i += 2,
-                        b if b == quote => {
-                            i += 1;
-                            break;
-                        }
-                        _ => i += 1,
-                    }
-                }
-                continue;
+        if let Some((next, is_comment)) = skip_opaque(bytes, i, prev) {
+            if !is_comment {
+                prev = Some(b'x');
             }
-            b'/' if bytes.get(i + 1) == Some(&b'/') => break,
-            b'/' if bytes.get(i + 1) == Some(&b'*') => {
-                i += 2;
-                while i + 1 < bytes.len() && !(bytes[i] == b'*' && bytes[i + 1] == b'/') {
-                    i += 1;
-                }
-                i = (i + 2).min(bytes.len());
-                continue;
-            }
+            i = next;
+            continue;
+        }
+        let c = bytes[i];
+        match c {
             b'(' | b'[' | b'{' => depth += 1,
             b')' | b']' | b'}' => depth -= 1,
             b'=' if depth == 0 => {
                 let next = bytes.get(i + 1).copied();
-                let prev = if i > 0 {
-                    bytes.get(i - 1).copied()
-                } else {
-                    None
-                };
                 // A plain or compound (`+=`, `-=`, …) assignment `=`, not the
                 // `==`/`===`/`=>` operators nor the tail of `==`/`!=`/`<=`/`>=`.
                 if next != Some(b'=')
@@ -196,71 +193,84 @@ fn is_multiline_assignment_start(line: &str) -> bool {
             }
             _ => {}
         }
+        if !c.is_ascii_whitespace() {
+            prev = Some(c);
+        }
         i += 1;
     }
     false
 }
 
-/// Split a right-hand-side fragment at its first top-level `;`, returning
-/// `(value, trailing)` where `value` is the assignment expression (trimmed)
-/// and `trailing` is the remainder starting at the `;` (the statement
-/// terminator plus any trailing comment).
+/// The leading run of spaces/tabs of `line`.
+fn leading_whitespace(line: &str) -> &str {
+    let end = line
+        .find(|c: char| c != ' ' && c != '\t')
+        .unwrap_or(line.len());
+    &line[..end]
+}
+
+/// Strip `base` from the start of `line`, falling back to its own leading
+/// whitespace when the line is indented less than `base`.
+fn dedent_line<'a>(line: &'a str, base: &str) -> &'a str {
+    line.strip_prefix(base).unwrap_or_else(|| line.trim_start())
+}
+
+/// Byte offset in `rhs` at which the assigned value ends: the first `;` at
+/// bracket depth 0, the closing bracket of an enclosing group, or the end of
+/// the fragment.
 ///
-/// The line-based class transforms receive a single physical source line,
-/// which can carry a statement terminator and a trailing comment after the
-/// expression — e.g. `getter(); // set the initial value`. Naively trimming a
-/// trailing `;` (`.trim_end_matches(';')`) leaves the inner `;` and the
-/// comment glued onto the value, so `$.set(this.#x, <value>, true)` becomes the
-/// syntactically-broken `$.set(this.#x, getter(); // comment, true)` (issue
-/// #907). Scanning for the first top-level `;` — skipping brackets, strings,
-/// template literals and comments — extracts just `getter()` and preserves the
-/// `; // comment` tail so it can be re-appended after the rewritten statement.
-fn split_rhs_at_top_level_semi(s: &str) -> (&str, &str) {
-    let bytes = s.as_bytes();
+/// Hunting for a bare `;`/`)`/`}` instead is what produced the build-breaking
+/// output in #907 and #2253 — the terminator was found inside a comment or a
+/// literal, the value was truncated there, and the injected `$.set(`'s close
+/// paren landed in the middle of the comment text.
+fn rhs_value_end(rhs: &str) -> usize {
+    let bytes = rhs.as_bytes();
     let mut depth = 0i32;
+    let mut prev: Option<u8> = None;
     let mut i = 0;
     while i < bytes.len() {
-        match bytes[i] {
-            b'\'' | b'"' | b'`' => {
-                // Skip the string/template literal body (handles escapes).
-                let quote = bytes[i];
-                i += 1;
-                while i < bytes.len() {
-                    match bytes[i] {
-                        b'\\' => i += 2,
-                        b if b == quote => {
-                            i += 1;
-                            break;
-                        }
-                        _ => i += 1,
-                    }
-                }
-                continue;
+        // A `//` at depth 0 is the statement's trailing comment, so the value
+        // ends there; anywhere deeper it belongs to the expression and is
+        // skipped like any other opaque run.
+        if depth == 0 && bytes[i] == b'/' && bytes.get(i + 1) == Some(&b'/') {
+            return i;
+        }
+        if let Some((next, is_comment)) = skip_opaque(bytes, i, prev) {
+            if !is_comment {
+                prev = Some(b'x');
             }
-            b'/' if bytes.get(i + 1) == Some(&b'/') => break, // line comment → tail
-            b'/' if bytes.get(i + 1) == Some(&b'*') => {
-                i += 2;
-                while i + 1 < bytes.len() && !(bytes[i] == b'*' && bytes[i + 1] == b'/') {
-                    i += 1;
-                }
-                i = (i + 2).min(bytes.len());
-                continue;
-            }
+            i = next;
+            continue;
+        }
+        let c = bytes[i];
+        match c {
             b'(' | b'[' | b'{' => depth += 1,
-            b')' | b']' | b'}' => depth -= 1,
-            b';' if depth == 0 => return (s[..i].trim(), &s[i..]),
+            b')' | b']' | b'}' => {
+                // A closing bracket we never opened belongs to the enclosing
+                // block, so the value ended before it.
+                if depth == 0 {
+                    return i;
+                }
+                depth -= 1;
+            }
+            b';' if depth == 0 => return i,
             _ => {}
+        }
+        if !c.is_ascii_whitespace() {
+            prev = Some(c);
         }
         i += 1;
     }
-    // No top-level `;` (and no preceding line comment) — the whole fragment is
-    // the value. If we stopped at a line comment, split there so the comment
-    // stays in the trailing slice.
-    if i < bytes.len() && bytes[i] == b'/' {
-        (s[..i].trim_end().trim_end_matches(';').trim(), &s[i..])
-    } else {
-        (s.trim().trim_end_matches(';').trim(), "")
-    }
+    bytes.len()
+}
+
+/// Split a right-hand-side fragment at the end of its value, returning
+/// `(value, trailing)` — the trimmed assignment expression and the remainder
+/// (statement terminator plus any trailing comment), which is re-appended after
+/// the rewritten statement.
+fn split_rhs_at_top_level_semi(s: &str) -> (&str, &str) {
+    let end = rhs_value_end(s);
+    (s[..end].trim().trim_end_matches(';').trim(), &s[end..])
 }
 
 /// Represents a class field with $state or $derived rune.
@@ -297,8 +307,13 @@ pub(super) struct ClassStateField {
 }
 
 /// Emit a transformed class field definition with optional getter/setter.
-pub(super) fn emit_class_field(field: &ClassStateField, all_fields: &[ClassStateField]) -> String {
+pub(super) fn emit_class_field(
+    field: &ClassStateField,
+    all_fields: &[ClassStateField],
+    indent: &str,
+) -> String {
     let mut output = String::new();
+    let body_indent = format!("{}\t", indent);
     let private_name = format!("#{}", field.private_backing_name);
 
     // When a `//` comment preceded this field on its own line in the source,
@@ -316,28 +331,28 @@ pub(super) fn emit_class_field(field: &ClassStateField, all_fields: &[ClassState
         .unwrap_or_default();
 
     if field.constructor_declared {
-        let _ = writeln!(output, "\t\t{};", private_name);
+        let _ = writeln!(output, "{}{};", indent, private_name);
         if !field.is_private {
             let is_derived = field.rune_type == "$derived" || field.rune_type == "$derived.by";
             let is_raw = field.rune_type == "$state.raw" || field.rune_type == "$state.frozen";
             output.push('\n');
             let _ = writeln!(
                 output,
-                "\t\tget {}() {{\n\t\t\treturn $.get(this.{});\n\t\t}}",
-                field.name, private_name
+                "{}get {}() {{\n{}return $.get(this.{});\n{}}}",
+                indent, field.name, body_indent, private_name, indent
             );
             output.push('\n');
             if is_derived || is_raw {
                 let _ = writeln!(
                     output,
-                    "\t\tset {}(value) {{\n\t\t\t$.set(this.{}, value);\n\t\t}}",
-                    field.name, private_name
+                    "{}set {}(value) {{\n{}$.set(this.{}, value);\n{}}}",
+                    indent, field.name, body_indent, private_name, indent
                 );
             } else {
                 let _ = writeln!(
                     output,
-                    "\t\tset {}(value) {{\n\t\t\t$.set(this.{}, value, true);\n\t\t}}",
-                    field.name, private_name
+                    "{}set {}(value) {{\n{}$.set(this.{}, value, true);\n{}}}",
+                    indent, field.name, body_indent, private_name, indent
                 );
             }
         }
@@ -351,43 +366,43 @@ pub(super) fn emit_class_field(field: &ClassStateField, all_fields: &[ClassState
         };
         let _ = writeln!(
             output,
-            "\t\t{} = {}$.state({});",
-            private_name, comment_infix, wrapped_value
+            "{}{} = {}$.state({});",
+            indent, private_name, comment_infix, wrapped_value
         );
         if !field.is_private {
             let getter_name = format_getter_name(&field.name);
             output.push('\n');
             let _ = writeln!(
                 output,
-                "\t\tget {}() {{\n\t\t\treturn $.get(this.{});\n\t\t}}",
-                getter_name, private_name
+                "{}get {}() {{\n{}return $.get(this.{});\n{}}}",
+                indent, getter_name, body_indent, private_name, indent
             );
             output.push('\n');
             let _ = writeln!(
                 output,
-                "\t\tset {}(value) {{\n\t\t\t$.set(this.{}, value, true);\n\t\t}}",
-                getter_name, private_name
+                "{}set {}(value) {{\n{}$.set(this.{}, value, true);\n{}}}",
+                indent, getter_name, body_indent, private_name, indent
             );
         }
     } else if field.rune_type == "$state.raw" || field.rune_type == "$state.frozen" {
         let _ = writeln!(
             output,
-            "\t\t{} = {}$.state({});",
-            private_name, comment_infix, field.value
+            "{}{} = {}$.state({});",
+            indent, private_name, comment_infix, field.value
         );
         if !field.is_private {
             let getter_name = format_getter_name(&field.name);
             output.push('\n');
             let _ = writeln!(
                 output,
-                "\t\tget {}() {{\n\t\t\treturn $.get(this.{});\n\t\t}}",
-                getter_name, private_name
+                "{}get {}() {{\n{}return $.get(this.{});\n{}}}",
+                indent, getter_name, body_indent, private_name, indent
             );
             output.push('\n');
             let _ = writeln!(
                 output,
-                "\t\tset {}(value) {{\n\t\t\t$.set(this.{}, value);\n\t\t}}",
-                getter_name, private_name
+                "{}set {}(value) {{\n{}$.set(this.{}, value);\n{}}}",
+                indent, getter_name, body_indent, private_name, indent
             );
         }
     } else if field.rune_type == "$derived" {
@@ -408,22 +423,22 @@ pub(super) fn emit_class_field(field: &ClassStateField, all_fields: &[ClassState
         };
         let _ = writeln!(
             output,
-            "\t\t{} = {}$.derived({});",
-            private_name, comment_infix, wrapped_value
+            "{}{} = {}$.derived({});",
+            indent, private_name, comment_infix, wrapped_value
         );
         if !field.is_private {
             let getter_name = format_getter_name(&field.name);
             output.push('\n');
             let _ = writeln!(
                 output,
-                "\t\tget {}() {{\n\t\t\treturn $.get(this.{});\n\t\t}}",
-                getter_name, private_name
+                "{}get {}() {{\n{}return $.get(this.{});\n{}}}",
+                indent, getter_name, body_indent, private_name, indent
             );
             output.push('\n');
             let _ = writeln!(
                 output,
-                "\t\tset {}(value) {{\n\t\t\t$.set(this.{}, value);\n\t\t}}",
-                getter_name, private_name
+                "{}set {}(value) {{\n{}$.set(this.{}, value);\n{}}}",
+                indent, getter_name, body_indent, private_name, indent
             );
         }
     } else if field.rune_type == "$derived.by" {
@@ -435,22 +450,22 @@ pub(super) fn emit_class_field(field: &ClassStateField, all_fields: &[ClassState
         let derived_expr = transform_class_methods(&field.value, all_fields);
         let _ = writeln!(
             output,
-            "\t\t{} = {}$.derived({});",
-            private_name, comment_infix, derived_expr
+            "{}{} = {}$.derived({});",
+            indent, private_name, comment_infix, derived_expr
         );
         if !field.is_private {
             let getter_name = format_getter_name(&field.name);
             output.push('\n');
             let _ = writeln!(
                 output,
-                "\t\tget {}() {{\n\t\t\treturn $.get(this.{});\n\t\t}}",
-                getter_name, private_name
+                "{}get {}() {{\n{}return $.get(this.{});\n{}}}",
+                indent, getter_name, body_indent, private_name, indent
             );
             output.push('\n');
             let _ = writeln!(
                 output,
-                "\t\tset {}(value) {{\n\t\t\t$.set(this.{}, value);\n\t\t}}",
-                getter_name, private_name
+                "{}set {}(value) {{\n{}$.set(this.{}, value);\n{}}}",
+                indent, getter_name, body_indent, private_name, indent
             );
         }
     }
@@ -729,6 +744,19 @@ pub(crate) fn transform_class_fields_client(script: &str) -> String {
 
     let class_header = &after_class[..brace_pos + 1];
 
+    // Synthesized members are printed relative to the class's own source
+    // indentation: hard-coding one level made a module-level `class` (column 0)
+    // come out one tab too deep, class body and closing brace alike.
+    let class_indent: String = {
+        let line_start = script[..class_pos].rfind('\n').map_or(0, |p| p + 1);
+        script[line_start..class_pos]
+            .chars()
+            .take_while(|c| *c == ' ' || *c == '\t')
+            .collect()
+    };
+    let member_indent = format!("{}\t", class_indent);
+    let member_body_indent = format!("{}\t\t", class_indent);
+
     // Find the matching closing brace with JS-lexical awareness so a `}` inside
     // a string / template / regex / comment (e.g. `return "}"`) doesn't truncate
     // the class body (H-057).
@@ -972,13 +1000,7 @@ pub(crate) fn transform_class_fields_client(script: &str) -> String {
                         members.push(ClassMember::NonRune(line.to_string()));
                     } else {
                         // Update brace depth for lines going into pending_non_rune.
-                        for ch in trimmed.chars() {
-                            match ch {
-                                '{' => brace_depth += 1,
-                                '}' => brace_depth = (brace_depth - 1).max(0),
-                                _ => {}
-                            }
-                        }
+                        advance_brace_depth(trimmed, &mut brace_depth);
                         pending_non_rune.push(line.to_string());
                     }
                 }
@@ -1135,7 +1157,7 @@ pub(crate) fn transform_class_fields_client(script: &str) -> String {
     // This matches the official Svelte compiler output order.
     for field in &fields {
         if field.constructor_declared && !field.is_private {
-            new_class_body.push_str(&emit_class_field(field, &fields));
+            new_class_body.push_str(&emit_class_field(field, &fields, &member_indent));
         }
     }
 
@@ -1144,7 +1166,7 @@ pub(crate) fn transform_class_fields_client(script: &str) -> String {
         match member {
             ClassMember::RuneField(field_idx) => {
                 let field = &fields[*field_idx];
-                new_class_body.push_str(&emit_class_field(field, &fields));
+                new_class_body.push_str(&emit_class_field(field, &fields, &member_indent));
             }
             ClassMember::NonRune(text) => {
                 if text.trim().is_empty() {
@@ -1164,11 +1186,15 @@ pub(crate) fn transform_class_fields_client(script: &str) -> String {
                 for field in &fields {
                     if field.constructor_declared && field.is_private && !field.had_class_body_decl
                     {
-                        new_class_body.push_str(&emit_class_field(field, &fields));
+                        new_class_body.push_str(&emit_class_field(field, &fields, &member_indent));
                     }
                 }
                 new_class_body.push('\n');
-                let _ = writeln!(new_class_body, "\t\tconstructor({}) {{", constructor_params);
+                let _ = writeln!(
+                    new_class_body,
+                    "{}constructor({}) {{",
+                    member_indent, constructor_params
+                );
 
                 let mut ctor_body = String::new();
                 // Group physical lines into a single statement only when a line
@@ -1179,6 +1205,10 @@ pub(crate) fn transform_class_fields_client(script: &str) -> String {
                 // individually so the `this.#x = …` statements inside the block
                 // are still rewritten.
                 let mut pending = String::new();
+                // Source indentation of the grouped statement's first line, so the
+                // continuation lines keep their nesting relative to it instead of
+                // being flattened to column 0.
+                let mut pending_source_indent = String::new();
                 let mut depth: i32 = 0;
                 for line in constructor_content.lines() {
                     let trimmed = line.trim();
@@ -1188,20 +1218,24 @@ pub(crate) fn transform_class_fields_client(script: &str) -> String {
                         }
                         if is_multiline_assignment_start(trimmed) {
                             pending.push_str(trimmed);
+                            pending_source_indent = leading_whitespace(line).to_string();
                             depth = net_bracket_depth(trimmed);
                         } else {
                             let transformed_line =
                                 transform_constructor_assignment(trimmed, &fields);
-                            let _ = writeln!(ctor_body, "\t\t\t{}", transformed_line);
+                            let _ =
+                                writeln!(ctor_body, "{}{}", member_body_indent, transformed_line);
                         }
                     } else {
                         pending.push('\n');
-                        pending.push_str(trimmed);
+                        pending.push_str(&member_body_indent);
+                        pending.push_str(dedent_line(line, &pending_source_indent));
                         depth += net_bracket_depth(trimmed);
                         if depth <= 0 {
                             let transformed_line =
                                 transform_constructor_assignment(&pending, &fields);
-                            let _ = writeln!(ctor_body, "\t\t\t{}", transformed_line);
+                            let _ =
+                                writeln!(ctor_body, "{}{}", member_body_indent, transformed_line);
                             pending.clear();
                             depth = 0;
                         }
@@ -1209,7 +1243,7 @@ pub(crate) fn transform_class_fields_client(script: &str) -> String {
                 }
                 if !pending.is_empty() {
                     let transformed_line = transform_constructor_assignment(&pending, &fields);
-                    let _ = writeln!(ctor_body, "\t\t\t{}", transformed_line);
+                    let _ = writeln!(ctor_body, "{}{}", member_body_indent, transformed_line);
                 }
 
                 // AST-based pass for `this.#field = …` assignments NESTED inside a
@@ -1257,7 +1291,7 @@ pub(crate) fn transform_class_fields_client(script: &str) -> String {
                     transform_constructor_private_reads(&ctor_transformed, &fields);
                 new_class_body.push_str(&ctor_transformed);
 
-                new_class_body.push_str("\t\t}\n");
+                let _ = writeln!(new_class_body, "{}}}", member_indent);
             }
         }
     }
@@ -1284,19 +1318,19 @@ pub(crate) fn transform_class_fields_client(script: &str) -> String {
         // `new (class {})()(args)` (H-059).
         if after_class_transformed.trim_start().starts_with('(') {
             format!(
-                "{}new ({}\n{}\t}}){}",
-                before_new, class_header, new_class_body, after_class_transformed
+                "{}new ({}\n{}{}}}){}",
+                before_new, class_header, new_class_body, class_indent, after_class_transformed
             )
         } else {
             format!(
-                "{}new ({}\n{}\t}})(){}",
-                before_new, class_header, new_class_body, after_class_transformed
+                "{}new ({}\n{}{}}})(){}",
+                before_new, class_header, new_class_body, class_indent, after_class_transformed
             )
         }
     } else {
         format!(
-            "{}{}\n{}\t}}{}",
-            before_class, class_header, new_class_body, after_class_transformed
+            "{}{}\n{}{}}}{}",
+            before_class, class_header, new_class_body, class_indent, after_class_transformed
         )
     }
 }
@@ -1632,7 +1666,7 @@ pub(super) fn transform_class_methods(content: &str, fields: &[ClassStateField])
                 while let Some(pos) = result.find(&pattern) {
                     let value_start = pos + pattern.len();
                     let rest = &result[value_start..];
-                    let value_end = rest.find(';').unwrap_or(rest.len());
+                    let value_end = rhs_value_end(rest);
                     let value = rest[..value_end].trim();
                     let needs_proxy = field.rune_type == "$state" && expression_needs_proxy(value);
                     let replacement = if needs_proxy {
@@ -1665,7 +1699,7 @@ pub(super) fn transform_class_methods(content: &str, fields: &[ClassStateField])
                 }
                 let value_start = pos + assign_pattern.len();
                 let rest = &result[value_start..];
-                let value_end = rest.find(';').unwrap_or(rest.len());
+                let value_end = rhs_value_end(rest);
                 let value = rest[..value_end].trim();
                 let needs_proxy = field.rune_type == "$state" && expression_needs_proxy(value);
                 let replacement = if needs_proxy {
@@ -1889,7 +1923,7 @@ pub(super) fn transform_class_methods_non_this(
                 while let Some(pos) = result.find(&pattern) {
                     let value_start = pos + pattern.len();
                     let rest = &result[value_start..];
-                    let value_end = rest.find(';').unwrap_or(rest.len());
+                    let value_end = rhs_value_end(rest);
                     let value = rest[..value_end].trim();
                     let replacement = format!(
                         "$.set({}, $.get({}) {} {})",
@@ -1913,7 +1947,7 @@ pub(super) fn transform_class_methods_non_this(
                 }
                 let value_start = pos + assign_pattern.len();
                 let rest = &result[value_start..];
-                let value_end = rest.find(';').unwrap_or(rest.len());
+                let value_end = rhs_value_end(rest);
                 let value = rest[..value_end].trim();
                 let replacement = format!("$.set({}, {})", qualified, value);
                 result = format!(

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/transform_script.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/transform_script.rs
@@ -4680,27 +4680,31 @@ fn update_member_brace_depth(
     paren: &mut i32,
     param_brace: &mut i32,
 ) -> bool {
-    let mut in_str = false;
-    let mut str_ch = ' ';
+    let bytes = line.as_bytes();
     let mut closed = false;
-    for ch in line.chars() {
-        if in_str {
-            if ch == str_ch {
-                in_str = false;
+    let mut prev: Option<u8> = None;
+    let mut i = 0;
+    while i < bytes.len() {
+        // Brackets inside a comment or literal are text: counting them closed a
+        // method body early at a `// … } …` comment and dropped every member
+        // after it (#2253).
+        if let Some((next, is_comment)) =
+            crate::compiler::phases::phase3_transform::shared::js_scan::skip_opaque(bytes, i, prev)
+        {
+            if !is_comment {
+                prev = Some(b'x');
             }
+            i = next;
             continue;
         }
+        let ch = bytes[i];
         match ch {
-            '\'' | '"' | '`' => {
-                in_str = true;
-                str_ch = ch;
-            }
-            '(' | '[' => *paren += 1,
-            ')' | ']' => *paren -= 1,
-            '{' if *paren > 0 => *param_brace += 1,
-            '}' if *paren > 0 => *param_brace -= 1,
-            '{' if *paren == 0 => *depth += 1,
-            '}' if *paren == 0 => {
+            b'(' | b'[' => *paren += 1,
+            b')' | b']' => *paren -= 1,
+            b'{' if *paren > 0 => *param_brace += 1,
+            b'}' if *paren > 0 => *param_brace -= 1,
+            b'{' if *paren == 0 => *depth += 1,
+            b'}' if *paren == 0 => {
                 if *param_brace > 0 {
                     // This `}` closes a brace that was opened inside a param list
                     // (e.g. the `{...}` destructure in `constructor({a,b}) {`).
@@ -4715,6 +4719,10 @@ fn update_member_brace_depth(
             }
             _ => {}
         }
+        if !ch.is_ascii_whitespace() {
+            prev = Some(ch);
+        }
+        i += 1;
     }
     closed
 }
@@ -4890,22 +4898,15 @@ pub(crate) fn transform_class_fields_server(script: &str) -> String {
     let class_header = &after_class[..brace_pos + 1];
 
     let class_body_start = class_pos + brace_pos + 1;
-    let mut brace_depth = 1;
-    let mut class_body_end = class_body_start;
-
-    for (i, c) in script[class_body_start..].char_indices() {
-        match c {
-            '{' => brace_depth += 1,
-            '}' => {
-                brace_depth -= 1;
-                if brace_depth == 0 {
-                    class_body_end = class_body_start + i;
-                    break;
-                }
-            }
-            _ => {}
-        }
-    }
+    // Lexically aware match: a `}` inside a comment, string, template or regex
+    // (e.g. `// returns { ok }`) must not close the class body and silently
+    // delete every member after it (#2253).
+    let class_body_end = crate::compiler::phases::phase1_parse::utils::find_matching_bracket(
+        script,
+        class_body_start,
+        '{',
+    )
+    .unwrap_or(class_body_start);
 
     // The member scan below is line-based, so members sharing a physical line
     // must first be broken apart or everything after the first one is dropped
@@ -5319,7 +5320,15 @@ pub(crate) fn transform_class_fields_server(script: &str) -> String {
             && !trimmed.starts_with("//")
             && !trimmed.starts_with("/*");
 
-        if is_method_start {
+        // A `static { … }` initialization block has no parameter list, so the
+        // method test above (which needs a `(`) never fired and the block's body
+        // was emitted line by line as fields — each with a `;` appended, comment
+        // lines included.
+        let is_static_block_start = trimmed
+            .strip_prefix("static")
+            .is_some_and(|rest| rest.trim_start().starts_with('{'));
+
+        if is_method_start || is_static_block_start {
             in_block = true;
             block_is_arrow_fn = false;
             block_depth = 0;

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/shared/js_scan.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/shared/js_scan.rs
@@ -4,7 +4,7 @@
 //! A `}`, `)` or `;` inside a comment, string, template or regex literal is
 //! text, not code, and reading it as code truncated a value mid-comment and
 //! spliced an injected `)` into the comment body (#907, #2253). Every such
-//! scanner steps over opaque runs with [`skip_opaque`] first.
+//! scanner steps over opaque runs with `skip_opaque` first.
 
 /// Does a `/` following `prev` (the last significant code byte) open a regex
 /// literal rather than a division?

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/shared/js_scan.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/shared/js_scan.rs
@@ -1,0 +1,80 @@
+//! Minimal lexical skipping for the line-based class transforms.
+//!
+//! Those passes count brackets and hunt for statement terminators in raw text.
+//! A `}`, `)` or `;` inside a comment, string, template or regex literal is
+//! text, not code, and reading it as code truncated a value mid-comment and
+//! spliced an injected `)` into the comment body (#907, #2253). Every such
+//! scanner steps over opaque runs with [`skip_opaque`] first.
+
+/// Does a `/` following `prev` (the last significant code byte) open a regex
+/// literal rather than a division?
+pub(crate) fn slash_starts_regex(prev: Option<u8>) -> bool {
+    !matches!(prev, Some(c) if c.is_ascii_alphanumeric()
+        || matches!(c, b'_' | b'$' | b')' | b']' | b'}' | b'\'' | b'"' | b'`'))
+}
+
+/// If a string, template literal, regex literal or comment starts at `i`,
+/// return `(byte just past it, was_a_comment)`. `prev` is the last significant
+/// code byte, needed to tell a regex literal from a division.
+pub(crate) fn skip_opaque(bytes: &[u8], i: usize, prev: Option<u8>) -> Option<(usize, bool)> {
+    match bytes[i] {
+        quote @ (b'\'' | b'"' | b'`') => {
+            let mut j = i + 1;
+            while j < bytes.len() {
+                match bytes[j] {
+                    b'\\' => j += 2,
+                    b if b == quote => {
+                        j += 1;
+                        break;
+                    }
+                    _ => j += 1,
+                }
+            }
+            Some((j.min(bytes.len()), false))
+        }
+        b'/' if bytes.get(i + 1) == Some(&b'/') => {
+            let mut j = i + 2;
+            while j < bytes.len() && bytes[j] != b'\n' {
+                j += 1;
+            }
+            Some((j, true))
+        }
+        b'/' if bytes.get(i + 1) == Some(&b'*') => {
+            let mut j = i + 2;
+            while j + 1 < bytes.len() && !(bytes[j] == b'*' && bytes[j + 1] == b'/') {
+                j += 1;
+            }
+            Some(((j + 2).min(bytes.len()), true))
+        }
+        b'/' if slash_starts_regex(prev) => {
+            let mut j = i + 1;
+            let mut in_class = false;
+            while j < bytes.len() {
+                match bytes[j] {
+                    b'\\' => j += 2,
+                    b'[' => {
+                        in_class = true;
+                        j += 1;
+                    }
+                    b']' if in_class => {
+                        in_class = false;
+                        j += 1;
+                    }
+                    b'/' if !in_class => {
+                        j += 1;
+                        break;
+                    }
+                    // An unterminated "regex" is really a division — leave the
+                    // bytes to the caller rather than swallowing the line.
+                    b'\n' => return None,
+                    _ => j += 1,
+                }
+            }
+            while j < bytes.len() && bytes[j].is_ascii_alphabetic() {
+                j += 1;
+            }
+            Some((j.min(bytes.len()), false))
+        }
+        _ => None,
+    }
+}

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/shared/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/shared/mod.rs
@@ -6,6 +6,7 @@
 pub mod ast_rewrite;
 pub mod async_body;
 pub mod class_body;
+pub mod js_scan;
 pub mod template;
 
 pub use template::*;

--- a/crates/rsvelte_core/tests/ctor_private_state_set_paren_2253.rs
+++ b/crates/rsvelte_core/tests/ctor_private_state_set_paren_2253.rs
@@ -1,0 +1,492 @@
+//! Regression tests for issue #2253 — the `)` that closes the injected
+//! `$.set(...)` for a `#private` `$state` field was emitted at the offset of a
+//! `;`/`}`/`)` that appeared inside a **comment or literal** rather than at the
+//! end of the assigned value.
+//!
+//! The class transforms rewrite these assignments as text. Several of their
+//! scanners counted brackets, or hunted for the statement's `;`, without
+//! stepping over comment bodies, string / template / regex literals, or (in
+//! places) bracket nesting:
+//!
+//!   * `split_rhs_at_top_level_semi` broke at a `//` at *any* depth, so a line
+//!     comment nested inside a multi-line literal truncated the value there —
+//!     the reported bug.
+//!   * four `rest.find(';')` scans in the method / non-`this` paths took the
+//!     first `;` anywhere, including inside a comment, a string or a nested
+//!     function body.
+//!   * the client member scan and the server `update_member_brace_depth`
+//!     counted `{`/`}` character by character, so a `// … } …` line split a
+//!     method in two.
+//!   * the server class transform found the class body's closing `}` with a
+//!     bare char loop, so a `}` in a comment closed the class early and every
+//!     member after it was silently dropped.
+//!
+//! All of them now share `shared::js_scan::skip_opaque`. The emitted module has
+//! to parse in every one of these shapes; before the fix it did not, and
+//! Vite/Rolldown rejected the file with `Parse failure: Unexpected token`.
+//!
+//! The tests also pin the synthesized indentation: class lowering used to print
+//! its members one tab too deep for a module-level class.
+
+use rsvelte_core::compiler::ModuleCompileOptions;
+use rsvelte_core::{GenerateMode, compile_module};
+
+fn compile(src: &str, generate: GenerateMode, dev: bool) -> String {
+    compile_module(
+        src,
+        ModuleCompileOptions {
+            filename: Some("A.svelte.js".to_string()),
+            generate,
+            dev,
+            ..Default::default()
+        },
+    )
+    .expect("compile")
+    .js
+    .code
+}
+
+/// Balanced-bracket check that respects strings, template literals and both
+/// comment forms — a `)` spliced into a comment shows up here as an imbalance.
+fn assert_structurally_valid(code: &str, ctx: &str) {
+    let bytes = code.as_bytes();
+    let mut stack: Vec<u8> = Vec::new();
+    let mut prev: Option<u8> = None;
+    let mut i = 0;
+    while i < bytes.len() {
+        match bytes[i] {
+            b'\'' | b'"' | b'`' => {
+                let quote = bytes[i];
+                i += 1;
+                while i < bytes.len() {
+                    match bytes[i] {
+                        b'\\' => i += 2,
+                        b if b == quote => {
+                            i += 1;
+                            break;
+                        }
+                        _ => i += 1,
+                    }
+                }
+                prev = Some(b'x');
+                continue;
+            }
+            b'/' if bytes.get(i + 1) == Some(&b'/') => {
+                while i < bytes.len() && bytes[i] != b'\n' {
+                    i += 1;
+                }
+                continue;
+            }
+            b'/' if bytes.get(i + 1) == Some(&b'*') => {
+                i += 2;
+                while i + 1 < bytes.len() && !(bytes[i] == b'*' && bytes[i + 1] == b'/') {
+                    i += 1;
+                }
+                i = (i + 2).min(bytes.len());
+                continue;
+            }
+            b'/' if !matches!(prev, Some(c) if c.is_ascii_alphanumeric()
+                || matches!(c, b'_' | b'$' | b')' | b']' | b'}' | b'\'' | b'"' | b'`')) =>
+            {
+                i += 1;
+                let mut in_class = false;
+                while i < bytes.len() {
+                    match bytes[i] {
+                        b'\\' => i += 2,
+                        b'[' => {
+                            in_class = true;
+                            i += 1;
+                        }
+                        b']' if in_class => {
+                            in_class = false;
+                            i += 1;
+                        }
+                        b'/' if !in_class => {
+                            i += 1;
+                            break;
+                        }
+                        b'\n' => break,
+                        _ => i += 1,
+                    }
+                }
+                while i < bytes.len() && bytes[i].is_ascii_alphabetic() {
+                    i += 1;
+                }
+                prev = Some(b'x');
+                continue;
+            }
+            b'(' => stack.push(b')'),
+            b'[' => stack.push(b']'),
+            b'{' => stack.push(b'}'),
+            c @ (b')' | b']' | b'}') => {
+                assert_eq!(stack.pop(), Some(c), "unbalanced bracket ({ctx}):\n{code}");
+            }
+            _ => {}
+        }
+        if !bytes[i].is_ascii_whitespace() {
+            prev = Some(bytes[i]);
+        }
+        i += 1;
+    }
+    assert!(stack.is_empty(), "unclosed brackets ({ctx}):\n{code}");
+}
+
+/// Strip each line's leading indentation. The class re-printer's *indentation*
+/// of a verbatim (non-rune) member is a separate, pre-existing concern; these
+/// tests are about where the injected `)` lands, so they compare the statement
+/// shape rather than its indentation.
+fn dedented(code: &str) -> String {
+    code.lines()
+        .map(str::trim_start)
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+/// Compile for all three targets and require the output to stay well-formed and
+/// to keep the whole class body (the server path used to delete every member
+/// after a `}`-bearing comment).
+fn assert_all_targets_valid(src: &str, ctx: &str, must_contain: &[&str]) {
+    for (generate, dev, label) in [
+        (GenerateMode::Client, false, "client"),
+        (GenerateMode::Client, true, "client-dev"),
+        (GenerateMode::Server, false, "server"),
+    ] {
+        let out = compile(src, generate, dev);
+        assert_structurally_valid(&out, &format!("{ctx} {label}"));
+        for needle in must_contain {
+            assert!(
+                out.contains(needle),
+                "{ctx} {label}: missing {needle} in:\n{out}"
+            );
+        }
+    }
+}
+
+const OBJECT_LITERAL: &str = "export class R {
+\t#x = $state.raw({});
+
+\tconstructor(s) {
+\t\tthis.#x = {
+\t\t\ta: s,
+\t\t\t// c
+\t\t\tb: s
+\t\t};
+\t}
+
+\tm(s) {
+\t\tthis.#x = {
+\t\t\ta: s,
+\t\t\t// c
+\t\t\tb: s
+\t\t};
+\t}
+}
+";
+
+#[test]
+fn constructor_object_literal_with_line_comment_closes_after_the_literal() {
+    let out = compile(OBJECT_LITERAL, GenerateMode::Client, false);
+    assert!(
+        out.contains(
+            "\tconstructor(s) {\n\t\t$.set(this.#x, {\n\t\t\ta: s,\n\t\t\t// c\n\t\t\tb: s\n\t\t});\n\t}"
+        ),
+        "constructor body must close the $.set(...) after the literal:\n{out}"
+    );
+    assert_structurally_valid(&out, "constructor object literal");
+}
+
+/// The constructor and the method must lower to the same statement.
+#[test]
+fn constructor_and_method_agree() {
+    let out = compile(OBJECT_LITERAL, GenerateMode::Client, false);
+    let statement = "$.set(this.#x, {\na: s,\n// c\nb: s\n});";
+    assert_eq!(
+        dedented(&out).matches(statement).count(),
+        2,
+        "constructor and method must produce the same statement:\n{out}"
+    );
+}
+
+#[test]
+fn constructor_array_literal_with_line_comment() {
+    let out = compile(
+        "export class R {
+\t#x = $state.raw([]);
+
+\tconstructor(s) {
+\t\tthis.#x = [
+\t\t\ts,
+\t\t\t// c
+\t\t\ts
+\t\t];
+\t}
+}
+",
+        GenerateMode::Client,
+        false,
+    );
+    assert!(
+        out.contains("\t\t$.set(this.#x, [\n\t\t\ts,\n\t\t\t// c\n\t\t\ts\n\t\t]);"),
+        "array literal RHS must survive the rewrite:\n{out}"
+    );
+    assert_structurally_valid(&out, "constructor array literal");
+}
+
+/// A comment in the last property position (nothing but the closing brace after
+/// it) is the shape most likely to swallow the terminator.
+#[test]
+fn constructor_literal_with_trailing_line_comment_in_last_position() {
+    let out = compile(
+        "export class R {
+\t#x = $state.raw({});
+
+\tconstructor(s) {
+\t\tthis.#x = {
+\t\t\ta: s
+\t\t\t// c
+\t\t};
+\t}
+}
+",
+        GenerateMode::Client,
+        false,
+    );
+    assert!(
+        out.contains("\t\t$.set(this.#x, {\n\t\t\ta: s\n\t\t\t// c\n\t\t});"),
+        "trailing comment must stay inside the literal:\n{out}"
+    );
+    assert_structurally_valid(&out, "trailing comment in last position");
+}
+
+/// A `//` at bracket depth 0 is still the statement's tail, not part of the
+/// value — the guard that #907 added must keep working.
+#[test]
+fn top_level_trailing_comment_is_still_the_tail() {
+    let out = compile(
+        "export class C {
+\t#current = $state();
+\tconstructor(getter) {
+\t\tthis.#current = getter(); // set the initial value
+\t}
+}
+",
+        GenerateMode::Client,
+        false,
+    );
+    assert!(
+        out.contains("$.set(this.#current, getter(), true); // set the initial value"),
+        "the trailing comment must stay outside the $.set(...) call:\n{out}"
+    );
+    assert_structurally_valid(&out, "top-level trailing comment");
+}
+
+/// Compound and logical assignment operators share the same right-hand-side
+/// scan, so they are reachable from the same defect.
+#[test]
+fn compound_and_logical_assignments_keep_nested_comments() {
+    let out = compile(
+        "export class R {
+\t#x = $state.raw({});
+\t#n = $state(0);
+
+\tconstructor(s) {
+\t\tthis.#x ??= {
+\t\t\ta: s,
+\t\t\t// c
+\t\t\tb: s
+\t\t};
+\t\tthis.#n += [
+\t\t\t1,
+\t\t\t// c
+\t\t\t2
+\t\t].length;
+\t}
+}
+",
+        GenerateMode::Client,
+        false,
+    );
+    assert_structurally_valid(&out, "compound/logical assignment");
+    let flat = dedented(&out);
+    assert!(
+        flat.contains("?? {\na: s,\n// c\nb: s\n}, true);"),
+        "logical assignment RHS must survive:\n{out}"
+    );
+    assert!(
+        flat.contains("$.set(this.#n, $.get(this.#n) + [\n1,\n// c\n2\n].length);"),
+        "compound assignment RHS must survive:\n{out}"
+    );
+}
+
+/// The comment *text* contains `}`, `)` and `;`. Every scanner on the way must
+/// treat it as text: the emitted comment has to come out byte-for-byte as
+/// written, and the call has to close after the literal.
+#[test]
+fn a_comment_containing_brackets_and_a_semicolon_is_text() {
+    for host in ["constructor(s)", "m(s)"] {
+        let src = format!(
+            "export class R {{
+\t#x = $state.raw({{}});
+
+\t{host} {{
+\t\tthis.#x = {{
+\t\t\ta: s,
+\t\t\t// }} ) ; c
+\t\t\tb: s
+\t\t}};
+\t}}
+}}
+"
+        );
+        let out = compile(&src, GenerateMode::Client, false);
+        assert!(
+            dedented(&out).contains("$.set(this.#x, {\na: s,\n// } ) ; c\nb: s\n});"),
+            "{host}: the comment text must be untouched and the call closed after the literal:\n{out}"
+        );
+        assert_all_targets_valid(&src, host, &["// } ) ; c"]);
+    }
+}
+
+/// Same shape with a block comment, a string literal, a regex literal and a
+/// nested function body — each carries a `}`/`)`/`;` that is not code.
+#[test]
+fn brackets_and_semicolons_inside_literals_are_not_statement_ends() {
+    let cases: [(&str, &str); 4] = [
+        (
+            "block-comment",
+            "{\n\t\t\ta: s,\n\t\t\t/* } ) ; */\n\t\t\tb: s\n\t\t}",
+        ),
+        ("string", "{ a: 'a) ; } b', b: s }"),
+        ("regex", "{ a: /[});]+/g, b: s }"),
+        (
+            "nested-fn",
+            "{\n\t\t\tf: () => { g(); },\n\t\t\tb: s\n\t\t}",
+        ),
+    ];
+    for (label, rhs) in cases {
+        for host in ["constructor(s)", "m(s)"] {
+            let src = format!(
+                "export class R {{
+\t#x = $state.raw({{}});
+
+\t{host} {{
+\t\tthis.#x = {rhs};
+\t}}
+}}
+"
+            );
+            assert_all_targets_valid(&src, &format!("{label} in {host}"), &["b: s"]);
+        }
+    }
+}
+
+/// The server path found the class body's closing brace with a bare char loop,
+/// so a `}` inside a comment closed the class early and dropped every member
+/// after it. The output still parsed in some shapes — this pins the content.
+#[test]
+fn a_brace_in_a_comment_does_not_truncate_the_class_body() {
+    let src = "export class R {
+\t#x = $state.raw({});
+
+\tm(s) {
+\t\tthis.#x = {
+\t\t\ta: s,
+\t\t\t// } ) ; c
+\t\t\tb: s
+\t\t};
+\t}
+
+\tlast() {
+\t\treturn 42;
+\t}
+}
+";
+    assert_all_targets_valid(src, "class body truncation", &["last()", "return 42"]);
+}
+
+/// A `static { … }` block has no parameter list, so the server's method test
+/// (which needs a `(`) never fired: the block's body was emitted line by line
+/// as class fields, each with a `;` appended — including the comment line,
+/// which swallowed the following property into the comment.
+#[test]
+fn a_static_initialization_block_is_not_emitted_as_fields() {
+    for opener in ["static {\n\t\tconst s = 1;", "static { const s = 1;"] {
+        let src = format!(
+            "export class R {{
+\t#x = $state.raw({{}});
+
+\t{opener}
+\t\tthis.#x = {{
+\t\t\ta: s,
+\t\t\t// }} ) ; c
+\t\t\tb: s
+\t\t}};
+\t}}
+}}
+"
+        );
+        assert_all_targets_valid(&src, "static block", &["// } ) ; c", "b: s"]);
+        let server = compile(&src, GenerateMode::Server, false);
+        assert!(
+            !server.contains("// } ) ; c;"),
+            "a `;` must not be appended inside the comment:\n{server}"
+        );
+        assert!(
+            !server.contains("b: s;"),
+            "a `;` must not be appended to an object property:\n{server}"
+        );
+    }
+}
+
+/// A module-level class is at column 0, so its lowered members belong one tab
+/// deep — not two, as the hard-coded indentation used to emit.
+#[test]
+fn module_level_class_members_are_indented_one_level() {
+    let out = compile(
+        "export class S {
+\tv = $state(0);
+\tasync load() {
+\t\tfor await (const x of gen()) this.v = x;
+\t}
+}
+",
+        GenerateMode::Client,
+        false,
+    );
+    assert!(
+        out.contains("\n\t#v = $.state(0);"),
+        "backing field must sit one tab deep:\n{out}"
+    );
+    assert!(
+        out.contains("\n\tget v() {\n\t\treturn $.get(this.#v);\n\t}"),
+        "getter must sit one tab deep:\n{out}"
+    );
+    assert!(
+        out.contains("\n\tset v(value) {\n\t\t$.set(this.#v, value, true);\n\t}"),
+        "setter must sit one tab deep:\n{out}"
+    );
+    assert!(out.ends_with("\n}"), "class must close at column 0:\n{out}");
+}
+
+/// Dev mode wraps the field in `$.tag(...)` but must not change the shape.
+#[test]
+fn dev_mode_output_is_parseable_too() {
+    let out = compile(OBJECT_LITERAL, GenerateMode::Client, true);
+    assert!(
+        out.contains(
+            "\tconstructor(s) {\n\t\t$.set(this.#x, {\n\t\t\ta: s,\n\t\t\t// c\n\t\t\tb: s\n\t\t});\n\t}"
+        ),
+        "dev-mode constructor body must match:\n{out}"
+    );
+    assert_structurally_valid(&out, "dev mode");
+}
+
+#[test]
+fn server_output_keeps_the_literal_intact() {
+    let out = compile(OBJECT_LITERAL, GenerateMode::Server, false);
+    assert_structurally_valid(&out, "server");
+    assert!(
+        out.contains("// c"),
+        "the nested comment must survive on the server too:\n{out}"
+    );
+}


### PR DESCRIPTION
Closes #2253

## Root cause

The class transforms rewrite private-`$state` assignments as **text**, and
several of their scanners locate brackets and statement terminators by hunting
for a byte. A `}`, `)` or `;` that appears inside a comment or a literal is
text, not code — reading it as code is the whole bug family. Four distinct
scanners had it:

**1. `split_rhs_at_top_level_semi` — the reported bug.** Its `//` arm had no
bracket-depth guard, unlike the neighbouring `;` arm:

```rust
b'/' if bytes.get(i + 1) == Some(&b'/') => break, // line comment → tail
```

A line comment nested inside a multi-line literal was therefore mistaken for
the statement's trailing comment: the value was truncated at the comment's
start offset and the `)` closing the injected `$.set(` was emitted there.

```js
// input                    // before
this.#x = {                 $.set(this.#x, {
	a: s,                   a: s,)// c
	// c                    b: s
	b: s                    };
};
```

The result does not parse — Vite/Rolldown aborts with `Parse failure:
Unexpected token`, so the module cannot be imported at all.

**2. Four `rest.find(';')` scans** in the method / non-`this` paths
(`class_transforms.rs`, the compound-operator and direct-assignment loops,
twice each) took the first `;` *anywhere* — inside a comment, inside a string,
inside a nested function body — and ignored bracket depth entirely. This is
why `// } ) ; c` in a **method** produced `// } )); c` with the real `)` gone,
a shape the constructor fix alone did not touch.

**3. `transform_class_fields_server` — silent content loss, not a parse
error.** It found the class body's closing brace with a bare char loop
(`'{' => depth += 1, '}' => depth -= 1`), no string or comment awareness at
all. A `}` written inside a comment — `// returns { ok, err }`, `// move this
into the if () {} block` — closed the class body early and **every member
after it was deleted from the output**, with no error and no warning. This is
the #2254 failure mode (green build, wrong program) rather than the #2253 one.

**5. `static { … }` blocks (server).** A class member was recognised as a
block only when its line contained a `(`, so a static initialization block fell
through to the *field* emitter: its body was written out line by line with a
`;` appended to each — including the comment line, which then swallowed the
property after it. Found by the coordinator's matrix, which has a
`static-block` host mine did not.

**4. Member-scan brace counters.** The client `parse_section_members` counted
`{`/`}` with `for ch in trimmed.chars()`, and the server's
`update_member_brace_depth` did the same. A `// … } …` line decremented the
depth mid-method, so the scan **split a method in two**; the first half then
had no trailing `;` at all, which is why the `)` landed at the *end* of the
comment line rather than at its `;`.

## Fix

All four now share `phases/3_transform/shared/js_scan.rs::skip_opaque`, which
steps over strings, template literals, **regex literals** and both comment
forms in one place. Regex mattered on its own: `{ a: /[});]+/g }` was
unparseable on every target with no comment involved, so it would have survived
any comment-specific patch.

Two hardenings beyond skipping: `rhs_value_end` also ends the value at a
closing bracket it never opened (so a `;`-less RHS such as
`m() { this.#x = 1 }` no longer swallows the method's `}`), and bracket depth
is now respected at all four assignment sites.

Also fixed, in the same re-printer: synthesized class members were emitted at a
hard-coded one-level indentation, which assumed the class sat one tab deep
inside a component `<script>`. A top-level `class` in a `.svelte.js` module
came out with its fields, accessors, constructor and closing brace one tab too
deep. They now follow the class's own source indentation, and a grouped
multi-line constructor statement keeps the relative indentation of its
continuation lines instead of being flattened to column 0.

## Verification

**Generated matrix** — 264 class shapes (6 hosts × 8 RHS shapes × 5 comment
slots × 3 operators, keeping only shapes whose *input* parses) × 3 targets =
792 comparisons. Invariant: does rsvelte's emitted module parse (acorn,
`sourceType: 'module'`)?

| revision | unparseable / 792 |
|---|---|
| `origin/main` | **354** |
| + comment-depth guard (cause 1) | 354 |
| + four `find(';')` sites (cause 2) | **192** |
| + server class-body brace match (cause 3) | **66** |
| + member-scan brace counters (cause 4) | **0** |

(Cause 1 alone does not move the total because the shapes it fixes are also
broken by causes 2–4; each row is cumulative.)

That matrix had no `static { … }` host. Adding it — both the multi-line form
and the one-line `static { const s = 1;` form — plus the nested-function-body
RHS (`{ f: () => { g(); }, b: s }`) gives **416 cases / 1248 comparisons, still
0 unparseable**. The static-block cell needed cause 5; it was failing on all
three targets before this PR, and causes 1–4 fixed only its two client targets.

**Normalized output parity** against the official compiler over the same 264
cases (oxfmt + blank-line stripping, the corpus gate's normalization):

| revision | differing / 792 |
|---|---|
| `origin/main` | 394 |
| this PR | **100** |

(Re-run after the static-block fix: unchanged at 100, and still no new
differences relative to either the baseline or the preceding commit.)

The remaining 100 are a **strict subset** of the baseline's 394 — `comm -13`
between the two complete lists is empty, so the PR introduces no new
divergence. They are pre-existing shapes unrelated to this bug (constructor
`+=` / `??=` lowering, and block-comment placement inside single-line
literals), and they differ on `origin/main` with or without a comment present.

**Issue repro**, `scripts/compat-corpus/one.mjs` vs the official compiler:

```
A.svelte.js  client-dev  MATCH
A.svelte.js  client      MATCH
A.svelte.js  server      MATCH
```

The issue's second, indentation-only snippet (`class S` with `for await`)
matches too, and the equivalent **component** (`<script>` with the same class)
is a full **raw** (un-normalized) MATCH on `client` and `client-dev`, so
defect (b) is fixed rather than deferred.

`node --check` on the emitted JS for 3 sources × {client, client-dev, server}:
9/9 parse (0/9 for the constructor cases before).

**Regression test**:
`crates/rsvelte_core/tests/ctor_private_state_set_paren_2253.rs`, 13 tests —
pins the exact emitted constructor body (not just "contains `$.set`") and
covers the object literal, an array literal, a comment in the last property
position, a comment whose text contains `}` `)` `;` in both a constructor and a
method, a block comment with the same characters, a string literal, a regex
literal, a nested function body, the compound/logical operators, dev mode, the
server target, class-body truncation (a member declared *after* the offending
comment must survive), a `static { … }` block in both its multi-line and
one-line forms, the module-level indentation, and a negative test that a
depth-0 trailing comment is still treated as the statement tail (#907).

## Known, out of scope

`origin/main` prints a verbatim (non-rune) class member at column 0 in module
output and drops the blank line between class members. Both are pre-existing —
measured on a build of `origin/main` with this PR's changes reverted — and are
untouched here; the corpus gate normalizes both away.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017eFcFhr66RJemE7UtF4CNK
