### PR TITLE
fix(compiler): read a computed ownership path element through its transform

### DIFF
--- a/.changeset/ownership-path-read-transform.md
+++ b/.changeset/ownership-path-read-transform.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/compiler": patch
+---
+
+Read a computed ownership-path element through its transform in dev, so a slot-let / each-block index reaches `$$ownership_validator.mutation` as `$.get(index)` and a store as `store()`

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/bind_directive.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/bind_directive.rs
@@ -1912,7 +1912,9 @@ fn build_getter_setter_with_primitive(
                             // Official sets this before building the path, so an unbuildable
                             // path still emits the `$$ownership_validator` preamble.
                             context.state.needs_mutation_validation.set(true);
-                            build_ast_member_path(original_expr)
+                            build_ast_member_path(original_expr, &|name: &str| {
+                                read_computed_path_element(name, context)
+                            })
                         } else {
                             None
                         };
@@ -2805,9 +2807,12 @@ fn get_ast_root_identifier(expr: &Expression) -> Option<String> {
 // Mirrors validate_mutation()'s path-building while-loop (shared/utils.js): any property that
 // isn't a plain Literal/Identifier (e.g. `obj[a.b]`) aborts the whole wrap rather than skipping
 // just that segment, so we return None here and the caller must leave the mutation unwrapped.
-fn build_ast_member_path(expr: &Expression) -> Option<Vec<JsExpr>> {
+fn build_ast_member_path(
+    expr: &Expression,
+    read_computed: &dyn Fn(&str) -> JsExpr,
+) -> Option<Vec<JsExpr>> {
     let mut path = Vec::new();
-    build_ast_member_path_recursive(expr.as_json(), &mut path).then_some(path)
+    build_ast_member_path_recursive(expr.as_json(), &mut path, read_computed).then_some(path)
 }
 
 /// `validate_mutation()` applied to the setter synthesized for `bind:this={obj.foo}`.
@@ -2837,7 +2842,11 @@ fn validate_bind_this_mutation(
     // Official sets this before building the path, so an unbuildable path still
     // emits the `$$ownership_validator` preamble.
     context.state.needs_mutation_validation.set(true);
-    let Some(path) = build_ast_member_path(expression) else {
+    // Identity, not `read_computed_path_element`: `build_bind_this` hands the
+    // setter its own parameters, so an each-block index reaches this path as a
+    // plain binding rather than through its outer signal transform.
+    let Some(path) = build_ast_member_path(expression, &|name| JsExpr::Identifier(name.into()))
+    else {
         return set;
     };
 
@@ -2857,7 +2866,25 @@ fn validate_bind_this_mutation(
     )
 }
 
-fn build_ast_member_path_recursive(val: &serde_json::Value, path: &mut Vec<JsExpr>) -> bool {
+/// A computed path element is a *read* of that binding, so it carries the same
+/// transform an ordinary reference would (`$.get(i)` for an each-block index,
+/// `store()` for a store).
+fn read_computed_path_element(name: &str, context: &ComponentContext) -> JsExpr {
+    let id = JsExpr::Identifier(name.into());
+    match context.state.transform.get(name) {
+        Some(transform) => match transform.read {
+            Some(read_fn) => read_fn(&context.arena, id),
+            None => id,
+        },
+        None => id,
+    }
+}
+
+fn build_ast_member_path_recursive(
+    val: &serde_json::Value,
+    path: &mut Vec<JsExpr>,
+    read_computed: &dyn Fn(&str) -> JsExpr,
+) -> bool {
     let obj = match val.as_object() {
         Some(o) => o,
         None => return true,
@@ -2866,7 +2893,7 @@ fn build_ast_member_path_recursive(val: &serde_json::Value, path: &mut Vec<JsExp
         Some("MemberExpression") => {
             // Recurse into object first
             if let Some(object) = obj.get("object")
-                && !build_ast_member_path_recursive(object, path)
+                && !build_ast_member_path_recursive(object, path, read_computed)
             {
                 return false;
             }
@@ -2888,7 +2915,7 @@ fn build_ast_member_path_recursive(val: &serde_json::Value, path: &mut Vec<JsExp
                 "Identifier" => {
                     if let Some(name) = prop_obj.get("name").and_then(|n| n.as_str()) {
                         if computed {
-                            path.push(b::id(name));
+                            path.push(read_computed(name));
                         } else {
                             path.push(b::string(name));
                         }

--- a/crates/rsvelte_core/tests/dev_ownership_path_transform.rs
+++ b/crates/rsvelte_core/tests/dev_ownership_path_transform.rs
@@ -1,0 +1,60 @@
+//! `validate_mutation()` builds a computed path element through the binding's
+//! own read transform (`transform?.read ? transform.read(left.property) :
+//! left.property`, `shared/utils.js`), so an each-block index reaches the
+//! ownership validator as `$.get(index)` and not as a bare reference to a
+//! signal.
+//!
+//! The corpus gates compile with `dev: false`, so nothing else covers this.
+
+use rsvelte_core::{CompileOptions, GenerateMode, compile};
+
+fn compile_client_dev(src: &str) -> String {
+    compile(
+        src,
+        CompileOptions {
+            filename: Some("Own.svelte".to_string()),
+            generate: GenerateMode::Client,
+            dev: true,
+            ..Default::default()
+        },
+    )
+    .expect("compile")
+    .js
+    .code
+}
+
+#[test]
+fn a_computed_path_element_goes_through_its_read_transform() {
+    let out = compile_client_dev(
+        r#"<script>
+	import Nested from './Nested.svelte';
+
+	export let letters = ['a', 'b', 'c'];
+</script>
+
+<Nested items={letters} let:index>
+	<input bind:value={letters[index]}>
+</Nested>
+"#,
+    );
+    assert!(
+        out.contains(r#"['letters', $.get(index)]"#),
+        "the slot-let index should be read through its transform, got:\n{out}"
+    );
+}
+
+#[test]
+fn a_static_path_element_stays_a_literal() {
+    let out = compile_client_dev(
+        r#"<script>
+	export let form;
+</script>
+
+<input bind:value={form.name}>
+"#,
+    );
+    assert!(
+        out.contains(r#"['form', 'name']"#),
+        "a non-computed member should stay a string literal, got:\n{out}"
+    );
+}


### PR DESCRIPTION
## What

`validate_mutation()` builds a computed member-path element through the
binding's own read transform:

```js
path.unshift(transform?.read ? transform.read(left.property) : left.property);
```

(`phases/3-transform/client/visitors/shared/utils.js`)

rsvelte pushed the bare identifier, so `$$ownership_validator.mutation` was
handed the *signal* where upstream hands it the signal's value:

```js
// bind:value={letters[index]} with `let:index` from a component slot
- ["letters", index],
+ ["letters", $.get(index)],
```

The same applies to a store used as a computed key, which upstream reads as
`prop()`.

## The one place it must not apply

`build_bind_this` gives the setter it synthesizes its own parameters, so an
each-block index arrives there as a plain binding rather than through the outer
signal transform — upstream emits `($$value, j) => …mutation(null, ['divs', j], …)`.
`validate_bind_this_mutation` therefore passes identity. Measured, not assumed:
routing that call site through the transform too regressed
`binding-this-each-key` and `binding-this-with-context`.

## Measurement

Full corpus (14025 entries × 3 targets), `verify.mjs` with the oxfmt
normalization CI uses, at `35f40930` + this change:

```
js-mismatch 91 -> 82   (client 0, server 0)
✅ no regressions
```

The 9 cleared entries are the whole "signal read/write" row of the client-dev
cluster table.

## Test

`crates/rsvelte_core/tests/dev_ownership_path_transform.rs` — the corpus gates
compile with `dev: false`, so nothing else covers this.

Per the convention in `compatibility/known-failures.md`, the baseline is
regenerated in a separate chore PR (#2285) once the code fixes land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014EJ8yjsgEh6CxqJhQoGZHP