### PR TITLE
ci: fail when a ratchet lists entries that already pass

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,7 +58,9 @@ rsvelte for CSR, SSR **and** dev-mode CSR (the three targets declared in
 `scripts/compat-corpus/targets.mjs`). Outputs must be byte-identical after comparison-side normalization
 (oxfmt + blank-line stripping — never compiler post-passes). To grow the corpus, add a submodule
 plus a line to `corpus-sources.json`. CI ratchet: `compatibility/known-failures.{client,server,client-dev}.json`
-may only shrink, and each remaining failure is justified in `compatibility/known-failures.md`. The
+may only shrink, and each remaining failure is justified in `compatibility/known-failures.md`. Every
+ratchet is two-sided: a new failure **and** a listed entry that already passes both fail CI, so the PR
+that fixes entries must re-baseline in the same PR instead of leaving a backlog for a later one. The
 same directory holds three sibling shrink-only ratchets, each with per-entry justification in a paired
 `.md`: the formatter-parity gate (`fmt-known-failures.json` / `fmt-oracle-excluded.json`), the
 svelte2tsx output-parity gate (`svelte2tsx-known-failures.json`), and the lint output-parity gate

--- a/compatibility/fmt-known-failures.json
+++ b/compatibility/fmt-known-failures.json
@@ -7,7 +7,6 @@
 	"powertable/app/src/lib/components/PowerTable.svelte",
 	"powertable/app/src/routes/examples/+layout.svelte",
 	"skeleton/sites/plus.skeleton.dev/src/routes/(app)/content/blocks/+page.svelte",
-	"skeleton/sites/skeleton.dev/src/components/landing-page/design-system.svelte",
 	"skeleton/sites/skeleton.dev/src/components/ui/header/theme.svelte",
 	"skeleton/sites/skeleton.dev/src/components/ui/preview.svelte",
 	"skeleton/sites/themes.skeleton.dev/src/lib/components/generator/Controls/ControlsColors.svelte",

--- a/compatibility/fmt-known-failures.md
+++ b/compatibility/fmt-known-failures.md
@@ -5,7 +5,7 @@ The formatter-parity corpus formats every `.svelte` component with both
 Svelte structure + oxc for embedded JS/CSS — rsvelte-fmt's exact layering) and
 requires **byte-identical** output. The ratchet may only shrink.
 
-**Current baseline: 20 entries**, concentrated in real-world corpus repos
+**Current baseline: 19 entries**, concentrated in real-world corpus repos
 (skeleton, layerchart, svelte-ux, layercake, cmsaasstarter, and a long tail).
 Oracle-bug / invalid-input / migrate cases are NOT here — those are permanently
 excluded in `fmt-oracle-excluded.json` (see `fmt-oracle-excluded.md`). Every
@@ -16,7 +16,7 @@ entries are the seed set from enrolling `submodules/skeleton` in the corpus
 a cluster (9 into the new Cluster 9, 2 into the new Cluster 10, the other 6 into
 existing Clusters 1/2/3).
 
-## Cluster 1 — close-tag-dangle / open-tag hugging for inline & void children (4)
+## Cluster 1 — close-tag-dangle / open-tag hugging for inline & void children (3)
 
 The most common failure. Prettier prints whitespace-sensitive inline elements
 (`<a>`, `<span>`, `<title>`, a `<pre><code>` pair, small inline components
@@ -64,11 +64,11 @@ are gone from the baseline: PR #1877's real-world-layout width fix, already
 on `main` before this corpus expansion, cleared both; this doc just hadn't
 caught up.)
 
-The 4th member (`skeleton/sites/skeleton.dev/src/components/landing-page/
-design-system.svelte`) is the `<pre><code>` shape again: the `<code>` open tag's
-`>` must dangle onto the child's line when the child is a multi-line template
-literal (`<code\n  >{`…`}</code\n>`), which is one shape past the three
-`<pre><code>` hug rules already ported.
+A 4th member (`skeleton/sites/skeleton.dev/src/components/landing-page/
+design-system.svelte`) — the `<pre><code>` shape where the `<code>` open tag's
+`>` must dangle onto a multi-line template-literal child — is gone from the
+baseline: the three ported `<pre><code>` hug rules reach it after all, and this
+doc had not caught up.
 
 ## Cluster 2 — attribute/style/directive value break-point selection (8)
 

--- a/crates/rsvelte_core/tests/sourcemaps_gate.rs
+++ b/crates/rsvelte_core/tests/sourcemaps_gate.rs
@@ -1020,7 +1020,7 @@ fn sourcemap_gate() {
 
     if !fixed.is_empty() {
         println!(
-            "\n🎉 {} ratchet entries now pass — shrink \
+            "\n❌ {} ratchet entries already pass — the ratchet is stale; shrink \
              compatibility/sourcemap-known-failures.json:",
             fixed.len()
         );
@@ -1047,5 +1047,11 @@ fn sourcemap_gate() {
         regressions.is_empty(),
         "{} source-map regressions (not in compatibility/sourcemap-known-failures.json)",
         regressions.len()
+    );
+    // A stale ratchet hides regressions inside a large, normal-looking "now pass" delta.
+    assert!(
+        fixed.is_empty(),
+        "{} stale entries in compatibility/sourcemap-known-failures.json (they already pass)",
+        fixed.len()
     );
 }

--- a/scripts/compat-corpus/README.md
+++ b/scripts/compat-corpus/README.md
@@ -147,10 +147,15 @@ Pipeline stages (all idempotent, everything under `compatibility/` except
    `compatibility/known-failures.client.json` (CSR),
    `compatibility/known-failures.server.json` (SSR) and
    `compatibility/known-failures.client-dev.json` (CSR with `dev: true`) — all
-   checked in, all may only shrink. Exits non-zero only on a **regression** (a
-   `(id, target)` pair that diverges but is absent from that target's baseline).
+   checked in, all may only shrink. Exits non-zero on a **regression** (a
+   `(id, target)` pair that diverges but is absent from that target's baseline)
+   **and on a stale ratchet** (a baseline entry that already passes) — a PR that
+   fixes entries must re-baseline in the same PR, so a later PR never absorbs a
+   backlog of "now PASS" entries that a real regression could hide inside.
    `--update-baseline` rewrites every baseline from the current run;
-   `--update-baseline <target>` rewrites only that target's file.
+   `--update-baseline <target>` rewrites only that target's file. Every sibling
+   ratchet below (fmt, svelte2tsx + its map, lint, check, check-e2e, and the
+   Rust `sourcemaps_gate`) enforces the same two-sided rule.
 
 The compared targets (their `generate` / `dev` options, whether CSS is compared,
 and which baseline file they ratchet against) are declared once in

--- a/scripts/compat-corpus/check-e2e-verify.mjs
+++ b/scripts/compat-corpus/check-e2e-verify.mjs
@@ -238,13 +238,16 @@ function main() {
 		console.error(
 			`\n  (+ = rsvelte-only, - = official-only; details in ${path.relative(ROOT, REPORT)})`
 		);
-		process.exit(1);
 	}
+	// Staleness is fatal: a large "already fixed" delta on a later PR reads as
+	// normal noise, so a real regression can hide inside it.
 	if (removed.length > 0) {
-		console.log(
-			`[check-e2e] ✅ ${removed.length} divergence(s) fixed — run with --update to prune check-e2e-known-failures.json`
-		);
+		console.error(`\n[check-e2e] ❌ ${removed.length} ratchet entries no longer diverge — the ratchet is stale.`);
+		for (const d of removed.slice(0, SHOW)) console.error('  ' + d);
+		if (removed.length > SHOW) console.error(`  … and ${removed.length - SHOW} more`);
+		console.error('\n  fix: node scripts/compat-corpus/check-e2e-verify.mjs --update');
 	}
+	if (added.length > 0 || removed.length > 0) process.exit(1);
 	console.log('[check-e2e] ✅ no new divergences');
 }
 

--- a/scripts/compat-corpus/check-verify.mjs
+++ b/scripts/compat-corpus/check-verify.mjs
@@ -272,13 +272,16 @@ function main() {
 		console.error(
 			`\n  (+ = rsvelte-only, - = official-only; details in ${path.relative(ROOT, REPORT)})`
 		);
-		process.exit(1);
 	}
+	// Staleness is fatal: a large "already fixed" delta on a later PR reads as
+	// normal noise, so a real regression can hide inside it.
 	if (removed.length > 0) {
-		console.log(
-			`[check-verify] ✅ ${removed.length} divergence(s) fixed — run with --update to prune check-known-failures.json`
-		);
+		console.error(`\n[check-verify] ❌ ${removed.length} ratchet entries no longer diverge — the ratchet is stale.`);
+		for (const d of removed.slice(0, SHOW)) console.error('  ' + d);
+		if (removed.length > SHOW) console.error(`  … and ${removed.length - SHOW} more`);
+		console.error('\n  fix: node scripts/compat-corpus/check-verify.mjs --update');
 	}
+	if (added.length > 0 || removed.length > 0) process.exit(1);
 	console.log('[check-verify] ✅ no new divergences');
 }
 

--- a/scripts/compat-corpus/fmt-verify.mjs
+++ b/scripts/compat-corpus/fmt-verify.mjs
@@ -177,13 +177,22 @@ const baseline = new Set(
 );
 const failingIds = new Set(failures.map((f) => f.id));
 const regressions = failures.filter((f) => !baseline.has(f.id));
-const fixedKnown = [...baseline].filter((id) => !failingIds.has(id));
+// Entries with no oracle in this run were never compared (the carried-over
+// not-locally-checkable set), so they are not evidence of staleness.
+const fixedKnown = [...baseline].filter(
+  (id) => !failingIds.has(id) && fs.existsSync(path.join(ORACLE, id)),
+);
 
+// A stale ratchet hides regressions inside a large, normal-looking "now PASS"
+// delta on whichever later PR happens to re-measure, so it is fatal.
 if (fixedKnown.length) {
   console.log(
-    `\n[fmt-verify] 🎉 ${fixedKnown.length} known failures now PASS — shrink the baseline:`,
+    `\n[fmt-verify] ❌ ${fixedKnown.length} baseline entries already PASS — the ratchet is stale.`,
   );
-  console.log("  node scripts/compat-corpus/fmt-verify.mjs --update-baseline");
+  for (const id of fixedKnown.slice(0, MAX_PRINT)) console.log(`  - ${id}`);
+  if (fixedKnown.length > MAX_PRINT)
+    console.log(`  … and ${fixedKnown.length - MAX_PRINT} more`);
+  console.log("\n  fix: node scripts/compat-corpus/fmt-verify.mjs --update-baseline");
 }
 
 if (regressions.length) {
@@ -195,8 +204,9 @@ if (regressions.length) {
     if (f.detail?.expected !== undefined) console.log(`      oracle: ${f.detail.expected}`);
     if (f.detail?.actual !== undefined) console.log(`      actual: ${f.detail.actual}`);
   }
-  process.exit(1);
 }
+
+if (regressions.length || fixedKnown.length) process.exit(1);
 
 if (failures.length) {
   console.log(

--- a/scripts/compat-corpus/lint-verify.mjs
+++ b/scripts/compat-corpus/lint-verify.mjs
@@ -216,13 +216,16 @@ function main() {
 		console.error(`\n[lint-verify] ❌ ${added.length} NEW divergence(s) from eslint-plugin-svelte:`);
 		for (const d of added.slice(0, SHOW)) console.error('  ' + d.replace(/\t/g, ' '));
 		if (added.length > SHOW) console.error(`  … and ${added.length - SHOW} more`);
-		process.exit(1);
 	}
+	// Staleness is fatal: a large "already fixed" delta on a later PR reads as
+	// normal noise, so a real regression can hide inside it.
 	if (removed.length > 0) {
-		console.log(
-			`[lint-verify] ✅ ${removed.length} divergence(s) fixed — run with --update to prune known-failures.json`
-		);
+		console.error(`\n[lint-verify] ❌ ${removed.length} ratchet entries no longer diverge — the ratchet is stale.`);
+		for (const d of removed.slice(0, SHOW)) console.error('  ' + d.replace(/\t/g, ' '));
+		if (removed.length > SHOW) console.error(`  … and ${removed.length - SHOW} more`);
+		console.error('\n  fix: node scripts/compat-corpus/lint-verify.mjs --update');
 	}
+	if (added.length > 0 || removed.length > 0) process.exit(1);
 	console.log('[lint-verify] ✅ no new divergences');
 }
 

--- a/scripts/compat-corpus/svelte2tsx-verify.mjs
+++ b/scripts/compat-corpus/svelte2tsx-verify.mjs
@@ -280,8 +280,8 @@ if (counts.match > 0 && mapCounts['map-valid'] + mapCounts['map-invalid'] === 0)
 
 /**
  * Ratchet `entries` against the checked-in baseline at `file`: report entries
- * that newly fail, and nudge to shrink the baseline when known ones now pass.
- * Returns true when there is a regression.
+ * that newly fail, and entries that already pass (a stale ratchet).
+ * Returns true when either makes the gate fail.
  */
 function ratchet(label, entries, file) {
 	const baseline = new Set(!STRICT && fs.existsSync(file) ? JSON.parse(fs.readFileSync(file, 'utf8')) : []);
@@ -289,9 +289,13 @@ function ratchet(label, entries, file) {
 	const fixedKnown = [...baseline].filter((id) => !failingIds.has(id));
 	const regressions = entries.filter((f) => !baseline.has(f.id));
 
+	// Staleness is fatal: a big "now PASS" delta on a later PR looks like normal
+	// noise, so a real regression can hide inside it.
 	if (fixedKnown.length) {
-		console.log(`\n[s2t-verify] 🎉 ${fixedKnown.length} known ${label} failures now PASS — shrink the baseline:`);
-		console.log('  node scripts/compat-corpus/svelte2tsx-verify.mjs --no-fmt --update-baseline');
+		console.log(`\n[s2t-verify] ❌ ${fixedKnown.length} ${label} baseline entries already PASS — the ratchet is stale.`);
+		for (const id of fixedKnown.slice(0, MAX_PRINT)) console.log(`  - ${id}`);
+		if (fixedKnown.length > MAX_PRINT) console.log(`  … and ${fixedKnown.length - MAX_PRINT} more`);
+		console.log('\n  fix: node scripts/compat-corpus/svelte2tsx-verify.mjs --no-fmt --update-baseline');
 	}
 
 	if (regressions.length) {
@@ -308,6 +312,8 @@ function ratchet(label, entries, file) {
 		}
 		return true;
 	}
+
+	if (fixedKnown.length) return true;
 
 	if (entries.length) {
 		console.log(`\n[s2t-verify] ✅ no ${label} regressions (${entries.length} known failures remain)`);

--- a/scripts/compat-corpus/verify.mjs
+++ b/scripts/compat-corpus/verify.mjs
@@ -22,12 +22,12 @@
  *   - compatibility/known-failures.server.json      (SSR / server target)
  *   - compatibility/known-failures.client-dev.json  (CSR with `dev: true`)
  * Each lists the entry ids whose output diverges for that target. Verification
- * exits non-zero only when a (id, target) pair NOT in its baseline fails (a
- * regression) — known failures are tolerated and burned down over time (see
+ * exits non-zero when a (id, target) pair NOT in its baseline fails (a
+ * regression) AND when a baseline still lists a pair that now passes (a stale
+ * ratchet) — known failures are tolerated and burned down over time (see
  * compatibility/known-failures.md for the root-cause writeup of each entry).
- * When previously-known failures now pass, a reminder to shrink the relevant
- * baseline is printed (use --update-baseline to rewrite the files from current
- * results; `--update-baseline <target>` rewrites only that target's file).
+ * Both are fixed with --update-baseline, which rewrites the files from current
+ * results; `--update-baseline <target>` rewrites only that target's file.
  *
  * --from-report <path> skips normalization/comparison entirely and derives the
  * baselines from an existing report.json (e.g. downloaded from a CI run), so a
@@ -51,7 +51,8 @@ const ACTUAL = path.join(CORPUS, 'actual');
 
 const args = process.argv.slice(2);
 const NO_FMT = args.includes('--no-fmt');
-const MAX_PRINT = Number(args[args.indexOf('--max-print') + 1] || 20);
+// Without the flag the lookup lands on args[0], which is another flag: fall back.
+const MAX_PRINT = args.includes('--max-print') ? Number(args[args.indexOf('--max-print') + 1]) || 20 : 20;
 const UPDATE_BASELINE = args.includes('--update-baseline');
 const STRICT = args.includes('--strict'); // ignore the baseline: any failure fails
 const TARGETS = selectTargets(args);
@@ -338,13 +339,24 @@ const fixedByTarget = TARGET_KEYS.map((key) => [
 ]);
 const fixedKnown = fixedByTarget.reduce((n, [, ids]) => n + ids.length, 0);
 
+// A ratchet that still lists passing entries is stale, and staleness is fatal:
+// a large "now PASS" delta on the next PR is indistinguishable from noise, so a
+// real regression can hide inside it.
 if (fixedKnown) {
 	const breakdown = fixedByTarget.map(([key, ids]) => `${key} ${ids.length}`).join(', ');
-	console.log(`\n[verify] 🎉 ${fixedKnown} known failures now PASS (${breakdown}) — shrink the baselines:`);
+	console.log(`\n[verify] ❌ ${fixedKnown} baseline entries already PASS (${breakdown}) — the ratchet is stale.`);
+	let shown = 0;
+	for (const [key, ids] of fixedByTarget) {
+		for (const id of ids) {
+			if (shown++ >= MAX_PRINT) break;
+			console.log(`  - ${id} (${key})`);
+		}
+	}
+	if (fixedKnown > MAX_PRINT) console.log(`  … and ${fixedKnown - MAX_PRINT} more`);
 	// A target-scoped run only measured those targets, so the suggested rewrite
 	// must stay scoped too — otherwise it would empty the unmeasured baselines.
 	const scope = TARGET_KEYS.length === ALL_TARGET_KEYS.length ? '' : ` --targets ${TARGET_KEYS.join(',')}`;
-	console.log(`  node scripts/compat-corpus/verify.mjs --no-fmt${scope} --update-baseline`);
+	console.log(`\n  fix: node scripts/compat-corpus/verify.mjs --no-fmt${scope} --update-baseline`);
 }
 
 if (regressions.length) {
@@ -358,8 +370,9 @@ if (regressions.length) {
 			if (d.actual !== undefined) console.log(`        actual:   ${d.actual}`);
 		}
 	}
-	process.exit(1);
 }
+
+if (regressions.length || fixedKnown) process.exit(1);
 
 if (failures.length) {
 	const breakdown = TARGET_KEYS.map((key) => `${key} ${failsByTarget.get(key).size}`).join(', ');


### PR DESCRIPTION
## Root cause

`known-failures.client-dev.json` drifts because **every ratchet gate is one-sided**.

`scripts/compat-corpus/verify.mjs` computed `fixedKnown` (baseline entries that now pass) and
only `console.log`-ed a nudge. The single `process.exit(1)` lived *inside* the
`if (regressions.length)` block, so "N known failures now PASS" left the exit code at 0.
That is why the same line was seen accompanying a red run: those runs also had a NEW failure,
which is what actually failed them.

Evidence — merged PR #2261 (`fix(compiler): report a null prop alias for legacy ownership
mutations`), its own `Compiler parity` job (run `30994362026`, job `92267769732`,
conclusion **success**):

```
[verify] 🎉 39 known failures now PASS (client 0, server 0, client-dev 39) — shrink the baselines:
[verify] ✅ no regressions (client 0, server 0, client-dev 148 known failures remain …)
```

Same picture on #2278's run `31004700195` (job `92301666072`, **success**): 39 now PASS,
141 remaining — plus `[fmt-verify] 🎉 1 known failures now PASS` in the green Formatter-parity
job. So the backlog is carried forward untouched by every green PR until one re-baselines and
absorbs the lot.

**The motivating sequence.** Three consecutive re-baselines each found staleness the previous
one had missed, and all of it was invisible because the gate exited 0:

- #2285 re-baselined on a base predating #2282, so three `$.strict_equals` entries survived it
  and had to be cleaned up by the *next* PR.
- #2250 re-baselined again (ratchet 85).
- #2291 re-baselined again, 91 → 46 on base `94764029`.

A PR whose entire purpose is re-baselining can still leave staleness behind if it measures on
the wrong base. That is exactly what this gate turns from invisible into a hard failure.

Hypotheses ruled out:

- **Not** `continue-on-error` / a swallowed exit code — the steps are bare `run:` lines.
- **Not** a path filter — the `pull_request` filter includes `crates/**`, and the jobs did run.
- **Not** a subset of targets / different normalization — CI runs all three targets and reports
  `client-dev 148`, matching a local full run.
- **Not** an admin override — the runs were genuinely green.

Separately worth noting: the `main` ruleset has **no required status checks** (only `deletion`
+ `non_fast_forward`), so nothing outside auto-merge etiquette forces `Corpus Compat` green
before a merge. That is a repo-settings decision for the owner, not a file change, and this
PR-level gate stands on its own regardless.

## What the fix guarantees

Every ratchet becomes two-sided — a listed entry that already passes fails the run, prints the
offending ids, and names the exact command to fix it:

| Gate | file | shared the flaw |
|---|---|---|
| compiler CSR/SSR/CSR-dev | `verify.mjs` | yes — fixed (all three targets, target-scoped runs stay scoped) |
| formatter parity | `fmt-verify.mjs` | yes — fixed |
| svelte2tsx TSX **and** source map | `svelte2tsx-verify.mjs` | yes — fixed (both ratchets, via the shared `ratchet()`) |
| lint parity | `lint-verify.mjs` | yes — fixed |
| svelte-check parity | `check-verify.mjs` | yes — fixed |
| svelte-check e2e parity | `check-e2e-verify.mjs` | yes — fixed |
| source maps | `crates/rsvelte_core/tests/sourcemaps_gate.rs` | yes — fixed (`fixed` is now asserted empty) |

Notes:

- `fmt-verify` deliberately carries over baseline ids whose oracle is absent from the local
  parity set; those are excluded from the stale set so the documented macOS/Linux carry-over
  does not turn into a false failure.
- A PR cannot dodge the gate by not touching `compatibility/`: the `Corpus Compat` path filter
  triggers on `crates/**`, `Cargo.lock`, `scripts/compat-corpus/**` and the submodule pins, and
  the sourcemap gate is a plain `cargo test`.
- Also fixes `MAX_PRINT` in `verify.mjs`: `Number(args[i + 1] || 20)` evaluated to `NaN`
  whenever `--max-print` was absent but another flag was present (e.g. `--no-fmt`), and
  `slice(0, NaN)` is empty — so a real regression list could print zero entries.
- Consequence: the PR that fixes entries must re-baseline **in that PR**, so deltas stay small
  and a real regression can no longer hide inside a large, normal-looking "now PASS" delta.

## The gate proving itself

The first CI run of this branch failed `Formatter parity` (run `31011731212`, job
`92325369377`) with exactly the pre-existing staleness the old gate had been printing green:

```
[fmt-verify] ❌ 1 baseline entries already PASS — the ratchet is stale.
  - skeleton/sites/skeleton.dev/src/components/landing-page/design-system.svelte
  fix: node scripts/compat-corpus/fmt-verify.mjs --update-baseline
```

## Re-baseline commit

Kept as a **separate commit** from the gate change so the diff shows plainly which entries the
new gate forced out. The fmt entry above is removed surgically from
`fmt-known-failures.json` + its justification in the paired `.md`, **not** via
`--update-baseline`: `scripts/compat-corpus/README.md` (lines 239-248) forbids rewriting that
baseline from macOS, because Linux CI includes ~13 loose-declaration-tag entries macOS `oxfmt`
skips and a macOS rewrite would silently drop them.

Attribution: none of the ratchet entries removed here are this PR's own work — they are
pre-existing staleness that the new gate is the first thing to report. If a compiler PR merges
between the re-baseline this branch sits on (#2291, `71398d28`) and this run, its residue lands
in this commit too; that is the gate working, and the alternative — another wrong-base
measurement — is strictly worse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012gQPtKmdY9xwn5fjdwaxK8
