### PR TITLE
docs: scope the profiler's phase split as not the production one

### DIFF
--- a/.claude/skills/perf-loop/SKILL.md
+++ b/.claude/skills/perf-loop/SKILL.md
@@ -239,7 +239,6 @@ static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 ```bash
 # ベースライン（必須）
 ./scripts/bench/bench.sh --quick      # JS vs Rust 単線比較
-./scripts/bench/bench.sh --profile    # parse / analyze / transform 内訳
 ./scripts/bench/bench.sh --criterion  # 統計的マイクロベンチ
 
 # プロファイル（samply 推奨）
@@ -248,9 +247,24 @@ samply record ./target/profiling/profiler --file path/to/large.svelte --iteratio
 # macOS なら Instruments も可
 instruments -t "Time Profiler" ./target/profiling/profiler -- --file path/to/large.svelte --iterations 100
 
+# フェーズ別の内訳（用途限定 — 直下の警告を読むこと）
+./scripts/bench/bench.sh --profile
+
 # 回帰確認（速さより正しさ）
 cargo test --release
 ```
+
+> **`--profile` と `profiler` バイナリの数字を、フェーズ配分の根拠に使わないこと。**
+>
+> `profiler.rs` は `analyze_component` / `transform_component` を**手組みで直接呼びます**。本番の入口（`Toolchain::prepare` + `PreparedComponent::compile`）とは経路が違い、少なくとも次が食い違います:
+>
+> - 本番が渡す retained script を通さないため、本番には無い再パースが計測に入る
+> - 本番が呼ぶ TypeScript 除去と `<svelte:options>` のマージを実行しない（**その分が分母から欠ける**）
+> - `include_sourcemap_content` などの引数が本番と別の値で固定される
+>
+> **「parse : analyze : transform = X : Y : Z」の形の主張には使えません。** シェアが本番と違います。
+>
+> **samply / Instruments での使用は問題ありません。** あちらが見るのは同一バイナリ内の相対的なホットスポットで、本番との経路一致を前提にしていないからです。**用途で切り分けてください。**
 
 ### 7.2 既知の大物ボトルネック（rsvelte 固有）
 
@@ -382,7 +396,7 @@ cd svelte && USE_RSVELTE=true npx vitest run \
 
 1. `$ARGUMENTS` が `continue` → 直近の perf log を読み、次のループを開始
 2. `$ARGUMENTS` が関数名・モジュール名 → そこに焦点を絞ってループ
-3. `$ARGUMENTS` が空 → 全体を `--profile` で計測し、上位 5 ホットスポットを提示
+3. `$ARGUMENTS` が空 → 全体を samply で計測し、上位 5 ホットスポットを提示（§7.1 の警告により、`--profile` のフェーズ内訳はここで使わない）
 4. **必ず順序を守る**: baseline → profile → 仮説提示（ユーザー確認）→ 変更 → test → 再計測 → keep/revert 判定
 5. 各イテレーション後に **数値と判定をユーザーに報告**。1 イテレーション 1 メッセージを目安に
 6. 3 周ごとに、達成した数値と次の候補ホットスポットを要約する

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -201,11 +201,18 @@ Quick refs:
 ```bash
 scripts/bench/bench.sh --quick          # ~30s comparison vs official compiler
 scripts/bench/bench.sh --criterion      # full criterion run (HTML reports under target/criterion/)
-scripts/bench/bench.sh --profile path/to/component.svelte
+scripts/bench/bench.sh --profile path/to/component.svelte   # hot-spot search only, see below
 ```
+
+`--profile` reports a per-phase breakdown, but that breakdown does not match
+the compiler's production path: the profiler calls the phase functions
+directly, which skips work the shipped compiler does and adds work it does
+not. Use it to find which functions are hot; do not use its shares to argue
+how time divides between parse, analyze, and transform.
 
 Benchmarks are not yet enforced in CI, so any performance-sensitive change
 should be validated locally and the result mentioned in the PR description.
+Prefer `--quick` and `--criterion` for numbers you intend to quote.
 
 ## Commit and PR conventions
 

--- a/crates/rsvelte_devtools/src/bin/profiler.rs
+++ b/crates/rsvelte_devtools/src/bin/profiler.rs
@@ -1,5 +1,23 @@
 //! Development profiler for compiler performance and detailed metrics.
 //!
+//! The per-phase numbers are not the production split. This binary calls
+//! `analyze_component` and `transform_component` directly rather than going
+//! through `Toolchain::prepare` + `PreparedComponent::compile`, which diverges
+//! from the shipped compiler in three ways:
+//!
+//! - the retained script the production path hands over already parsed is not
+//!   threaded through, so a parse the shipped compiler does not perform lands
+//!   in the measurement
+//! - TypeScript removal and `<svelte:options>` merging are never called, so
+//!   that work is missing from the denominator
+//! - arguments such as `include_sourcemap_content` are fixed at values the
+//!   production entry does not use
+//!
+//! So `--phase` and the phase shares in `--output json` cannot support a claim
+//! of the form "parse : analyze : transform = X : Y : Z". Sampling profilers
+//! (samply, Instruments) over this binary are unaffected: those rank hot
+//! functions within one binary and do not assume the path matches production.
+//!
 //! Usage:
 //!
 //! ```text

--- a/scripts/bench/bench.sh
+++ b/scripts/bench/bench.sh
@@ -5,6 +5,9 @@
 #   ./scripts/bench/bench.sh              # Run full JS vs Rust comparison
 #   ./scripts/bench/bench.sh --criterion  # Run Criterion micro-benchmarks
 #   ./scripts/bench/bench.sh --profile    # Run profiler on a single large file
+#                                         # (hotspot identification only — its phase
+#                                         #  breakdown does not match the production
+#                                         #  path; see run_profile below)
 #   ./scripts/bench/bench.sh --quick      # Quick single-threaded-only comparison
 #
 # Prerequisites:
@@ -80,10 +83,17 @@ run_criterion() {
     ok "Criterion benchmarks complete. See target/criterion/ for HTML reports."
 }
 
+# The profiler calls the phase functions directly instead of going through the
+# production entry point, so it skips work the shipped compiler does (TypeScript
+# removal, `<svelte:options>` merging) and adds work it does not (re-parsing a
+# script the production path hands over already parsed). Its per-phase numbers
+# are therefore not the production split. Use it to find hot functions, not to
+# apportion time between phases.
 run_profile() {
     local file="${1:-}"
     log "Building profiler..."
     cargo build --release -p rsvelte_devtools --bin profiler 2>&1 | tail -1
+    warn "Per-phase numbers below are NOT the production split (hotspot use only)."
 
     if [ -n "$file" ]; then
         log "Profiling: $file"
@@ -176,7 +186,8 @@ case "${1:-}" in
         echo ""
         echo "  (no args)    Full JS vs Rust comparison benchmark"
         echo "  --criterion  Criterion micro-benchmarks (per-phase)"
-        echo "  --profile    Profiler with per-phase breakdown"
+        echo "  --profile    Profiler, for finding hot functions"
+        echo "               (its per-phase breakdown is not the production split)"
         echo "  --quick      Quick single-threaded-only summary"
         echo "  --help       Show this help"
         ;;


### PR DESCRIPTION
`profiler.rs` calls the phase functions directly instead of going through the
production entry point. It skips work the shipped compiler does (TypeScript
removal, `<svelte:options>` merging) and adds work it does not (re-parsing a
script the production path hands over already parsed), so its per-phase shares
are not the shipped split. The binary and the `--profile` flag stay — a sampling
profiler over the same binary still ranks hot functions correctly, because that
ranks within one binary rather than apportioning time across phases.

Documentation only. No code path changes.

## Why the doc comment alone would not have reached anyone

`.claude/skills/perf-loop/SKILL.md` listed `bench.sh --profile` among three
**mandatory** baselines, described as the parse/analyze/transform breakdown, and
its workflow step told the reader to profile with it. A comment inside the binary
is read after the command has already been run, so the skill and CONTRIBUTING are
where the scoping has to live.

## Scope check

Every tracked file at `origin/main` (1933 files) was searched, against the ref
rather than a working tree so the denominator is the current `main`:

```
bench.sh --profile   pointers, after this PR:
  .claude/skills/perf-loop/SKILL.md   under the warning block, marked "用途限定"
  CONTRIBUTING.md                     "hot-spot search only, see below"
  scripts/bench/bench.sh              its own usage line

remaining skill references are all --quick:
  full-code-review/SKILL.md, implementation-checklist.md, upgrade-svelte/SKILL.md
```

## A related finding, recorded here rather than acted on

The same sweep covered the other two hand-rolled phase profilers. Patterns tried
were the binary names, their hyphenated spellings, `--bin` launch forms,
`bench.sh` / `scripts/bench`, and the wording of the output ("phase", "per-phase",
"フェーズ", "phase breakdown").

```
corpus_profile    0 references / 1933 tracked files
compile_profile   3 references, all self-description or cross-reference
profiler          6 references                          ← positive control
```

The `profiler` row is what makes the zero meaningful: the same pattern set
returns non-zero elsewhere, so `corpus_profile`'s zero is not an artifact of
searching badly. Nothing launches `crates/rsvelte_core/src/bin/corpus_profile.rs`
and no document points at it, yet it is an autobin under `rsvelte_core` and so
builds with the crate. Removing it belongs with the wider split cleanup, not
here.

One inaccurate comment is also left for a follow-up, because the file it lives in
is being edited by another PR: `3_transform/profile.rs` says these timers are
consumed "only" by `compile_profile.rs`, but `corpus_profile.rs` consumes them
too (lines 40, 98, 218, 260).
