### PR TITLE
docs(compiler): stop naming a single consumer of the Phase 3 timers

### DIFF
--- a/crates/rsvelte_core/src/compiler/phases/3_transform/profile.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/profile.rs
@@ -8,15 +8,16 @@
 //! per-file instrumentation overhead is ~100–200ns, negligible against
 //! Phase 3's ~60µs/file budget.
 //!
-//! Only `rsvelte_devtools/bin/compile_profile.rs` consumes these timers today.
+//! Only the native profiling binaries read these accumulators back — the
+//! compile pipeline never does, so the timers cannot affect compiler output.
 
 use std::cell::Cell;
 use std::time::Duration;
 
 // `std::time::Instant::now()` traps on `wasm32-unknown-unknown` (no system
 // clock — see std::sys::time::unsupported). The profile instrumentation
-// below is consumed only by native devtools (`rsvelte_devtools/bin/compile_profile.rs`), but
-// the call sites live in shared compile paths, so the Instant calls would
+// below is consumed only by the native profiling binaries, but the call
+// sites live in shared compile paths, so the Instant calls would
 // fire from the WASM playground and crash the page. Provide a WASM-safe
 // shim that returns a unit "instant" with a zero-cost elapsed so the
 // instrumented sites stay compile-target-portable without #[cfg] noise.


### PR DESCRIPTION
`3_transform/profile.rs` claimed `compile_profile.rs` was the only consumer of the Phase 3 timers. It is not, and the block comment above the WASM shim repeated the same single name.

Enumerated with `git ls-files` as the denominator (1938 tracked files), matching on the API names rather than the module path — the path pattern `transform::profile` misses `corpus_profile.rs`, which imports through the `phase3_transform` re-export alias:

```
$ git ls-files -z | xargs -0 grep -ln -E '\btake_(breakdown|index_oracle|esrap_breakdown)\b'
crates/rsvelte_core/src/bin/corpus_profile.rs
crates/rsvelte_core/src/compiler/phases/3_transform/profile.rs   (the definitions)
crates/rsvelte_devtools/src/bin/compile_profile.rs
crates/rsvelte_devtools/src/bin/esrap_share.rs
```

Three consumers, not one.

Rather than fix the count — which goes stale again the next time a profiling binary is added or removed — the comment now states the invariant that actually matters and is checkable: **nothing on the compile path reads these accumulators back, so the timers cannot affect compiler output.** Verified the same way:

```
$ git ls-files -z | xargs -0 grep -ln -E '\btake_(breakdown|index_oracle|esrap_breakdown)\b' \
    | grep -v '/bin/' | grep -v '3_transform/profile.rs'
(none)
```

Comments only — no code change.

## Checks

- `cargo fmt -p rsvelte_core -- --check` clean.
- No local clippy run. The workspace enables three `deny` lints (`unsafe_op_in_unsafe_fn`, `undocumented_unsafe_blocks`, `format_push_string`) and no pedantic/`doc_markdown` set, none of which a comment can trip; the new text contains no backticked paths, so there are no intra-doc links to break. Stating this rather than claiming a verification I did not run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BULH9QNYfezhWuod5bZuGu