### PR TITLE
fix(compiler): transform a shadowed function-local rune through its signal in dev

### DIFF
--- a/.changeset/shadowed-local-rune-dev-tag.md
+++ b/.changeset/shadowed-local-rune-dev-tag.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/compiler": patch
+---
+
+Transform a shadowed function-local `$state` / `$derived` through its signal in dev mode too. The declaration probes matched the literal `<kw> <name> = $.state(` text, but in dev the `$.tag(...)` label wrap already sits between the `=` and the rune call, so the reads and writes in the enclosing function body were left bare.

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
@@ -6685,24 +6685,24 @@ fn transform_shadowed_local_state_vars(script: &str, shadowed_vars: &[String]) -
 
 /// The `$.…(` markers whose declarations [`transform_shadowed_local_state_vars`]
 /// rewrites, crossed with [`SHADOWED_DECL_KEYWORDS`] to form the twelve shapes.
-const SHADOWED_DECL_MARKERS: [&str; 4] = [
-    " = $.state(",
-    " = $.derived(",
-    " = $.state.raw(",
-    " = $.derived.by(",
-];
+const SHADOWED_DECL_MARKERS: [&str; 4] =
+    ["$.state(", "$.derived(", "$.state.raw(", "$.derived.by("];
 
 const SHADOWED_DECL_KEYWORDS: [&str; 3] = ["let ", "var ", "const "];
+
+/// In dev the label wrap sits between the `=` and the rune call, so every
+/// declaration probe has to look through it.
+const SHADOWED_DECL_TAG_WRAPPERS: [&str; 2] = ["$.tag(", "$.tag_proxy("];
 
 const SHADOWED_DECL_SHAPE_COUNT: usize = SHADOWED_DECL_MARKERS.len() * SHADOWED_DECL_KEYWORDS.len();
 
 /// First offset of each `<kw> N = $.…(` declaration shape, keyed by `N`.
 ///
 /// The twelve shapes are `let` / `var` / `const` crossed with
-/// [`SHADOWED_DECL_MARKERS`], indexed in the order the original per-variable
-/// `format!` probes used. `N` is the space-delimited token before the marker and
-/// the keyword is matched as a raw substring (no left word boundary), so each
-/// entry is exactly what `result.find(<kw> N = $.…()` would have returned.
+/// [`SHADOWED_DECL_MARKERS`], optionally through a
+/// [`SHADOWED_DECL_TAG_WRAPPERS`] wrap. `N` is the space-delimited token before
+/// the `=` and the keyword is matched as a raw substring (no left word
+/// boundary).
 fn index_shadowed_decls(
     script: &str,
 ) -> rustc_hash::FxHashMap<String, [Option<u32>; SHADOWED_DECL_SHAPE_COUNT]> {
@@ -6710,11 +6710,21 @@ fn index_shadowed_decls(
         rustc_hash::FxHashMap::default();
     for (marker_idx, marker) in SHADOWED_DECL_MARKERS.iter().enumerate() {
         for pos in memmem::find_iter(script.as_bytes(), marker.as_bytes()) {
-            let Some(space) = script[..pos].rfind(' ') else {
+            let mut before = &script[..pos];
+            for wrapper in SHADOWED_DECL_TAG_WRAPPERS {
+                if let Some(stripped) = before.strip_suffix(wrapper) {
+                    before = stripped;
+                    break;
+                }
+            }
+            let Some(before) = before.strip_suffix(" = ") else {
+                continue;
+            };
+            let Some(space) = before.rfind(' ') else {
                 continue;
             };
             let name_start = space + 1;
-            if name_start == pos {
+            if name_start == before.len() {
                 continue;
             }
             let head = &script[..name_start];
@@ -6727,7 +6737,7 @@ fn index_shadowed_decls(
             let shape = keyword * 2 + marker_idx % 2 + if marker_idx >= 2 { 6 } else { 0 };
             let pattern_start = (name_start - SHADOWED_DECL_KEYWORDS[keyword].len()) as u32;
             let entry = map
-                .entry(script[name_start..pos].to_string())
+                .entry(before[name_start..].to_string())
                 .or_insert([None; SHADOWED_DECL_SHAPE_COUNT]);
             if entry[shape].is_none_or(|first| pattern_start < first) {
                 entry[shape] = Some(pattern_start);
@@ -6854,11 +6864,7 @@ fn apply_local_set_transforms(func_body: &str, var_name: &str) -> String {
         let trimmed = line.trim();
 
         // Skip declaration lines
-        if trimmed.contains(&format!("let {} = $.state(", var_name))
-            || trimmed.contains(&format!("var {} = $.state(", var_name))
-            || trimmed.contains(&format!("let {} = $.derived(", var_name))
-            || trimmed.contains(&format!("var {} = $.derived(", var_name))
-        {
+        if declares_local_rune(trimmed, var_name) {
             lines.push(line.to_string());
             continue;
         }
@@ -6868,6 +6874,24 @@ fn apply_local_set_transforms(func_body: &str, var_name: &str) -> String {
     }
 
     lines.join("\n")
+}
+
+/// Whether `line` is `var_name`'s own signal declaration, with or without the
+/// dev label wrap around the rune call.
+fn declares_local_rune(line: &str, var_name: &str) -> bool {
+    ["let ", "var "].iter().any(|keyword| {
+        let head = format!("{keyword}{var_name} = ");
+        line.match_indices(head.as_str()).any(|(pos, _)| {
+            let mut rest = &line[pos + head.len()..];
+            for wrapper in SHADOWED_DECL_TAG_WRAPPERS {
+                if let Some(stripped) = rest.strip_prefix(wrapper) {
+                    rest = stripped;
+                    break;
+                }
+            }
+            rest.starts_with("$.state(") || rest.starts_with("$.derived(")
+        })
+    })
 }
 
 /// Transform `varName = expr` to `$.set(varName, expr, true)` in a line.

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/scope_analysis.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/scope_analysis.rs
@@ -186,6 +186,15 @@ fn is_state_var_init_expression(expr: &oxc_ast::ast::Expression) -> bool {
     let Expression::CallExpression(call) = expr else {
         return false;
     };
+    // In dev the label wrap sits between the `=` and the rune call.
+    if let Expression::StaticMemberExpression(member) = &call.callee
+        && let Expression::Identifier(obj) = &member.object
+        && obj.name == "$"
+        && matches!(member.property.name.as_str(), "tag" | "tag_proxy")
+        && let Some(inner) = call.arguments.first().and_then(|arg| arg.as_expression())
+    {
+        return is_state_var_init_expression(inner);
+    }
     match &call.callee {
         // Raw rune forms: `$state(...)` / `$derived(...)`.
         Expression::Identifier(id) => matches!(id.name.as_str(), "$state" | "$derived"),

--- a/crates/rsvelte_core/tests/dev_shadowed_local_rune.rs
+++ b/crates/rsvelte_core/tests/dev_shadowed_local_rune.rs
@@ -1,0 +1,99 @@
+//! A rune declared inside a nested function whose name also exists as a
+//! top-level binding is rewritten by scanning the settled script for the
+//! declaration text, and in dev the `$.tag(...)` label wrap sits between the
+//! `=` and the rune call.
+//!
+//! The corpus gates compile with `dev: false`, so nothing else covers this.
+
+use rsvelte_core::{CompileOptions, GenerateMode, compile};
+
+fn compile_client(src: &str, dev: bool) -> String {
+    compile(
+        src,
+        CompileOptions {
+            filename: Some("Main.svelte".to_string()),
+            generate: GenerateMode::Client,
+            dev,
+            ..Default::default()
+        },
+    )
+    .expect("compile")
+    .js
+    .code
+}
+
+const WRAPPED_STATE: &str = r#"<script>
+	function createArray(initial) {
+		let array = $state(initial);
+		return {
+			get value() {
+				return array;
+			},
+			push(entry) {
+				array.push(entry);
+				array = array.slice();
+			}
+		};
+	}
+
+	const array = createArray(['x']);
+</script>
+
+{#each array.value as entry}
+	<p>{entry}</p>
+{/each}
+"#;
+
+#[test]
+fn a_shadowed_state_is_read_and_written_through_its_signal_in_dev() {
+    let out = compile_client(WRAPPED_STATE, true);
+    assert!(out.contains("return $.get(array);"), "got:\n{out}");
+    assert!(out.contains("$.get(array).push(entry);"), "got:\n{out}");
+    assert!(
+        out.contains("$.set(array, $.get(array).slice(), true);"),
+        "got:\n{out}"
+    );
+}
+
+#[test]
+fn dev_and_non_dev_agree_on_the_shadowed_transform() {
+    let dev = compile_client(WRAPPED_STATE, true);
+    let prod = compile_client(WRAPPED_STATE, false);
+    for line in ["return $.get(array);", "$.get(array).push(entry);"] {
+        assert_eq!(
+            dev.contains(line),
+            prod.contains(line),
+            "{line}\ndev:\n{dev}\nprod:\n{prod}"
+        );
+    }
+}
+
+#[test]
+fn a_shadowed_derived_is_read_through_its_signal_in_dev() {
+    let out = compile_client(
+        r#"<script>
+	let count = $state(0);
+	const multiplier = () => {
+		let multiplier = $state(2);
+		let multiple = $derived(count * multiplier);
+
+		return {
+			get count() {
+				return multiple;
+			},
+			inc: () => multiplier++
+		};
+	};
+	const multiplied = multiplier();
+</script>
+
+<span>{multiplied.count}</span>
+"#,
+        true,
+    );
+    assert!(
+        out.contains("$.derived(() => $.get(count) * $.get(multiplier))"),
+        "got:\n{out}"
+    );
+    assert!(out.contains("$.update(multiplier)"), "got:\n{out}");
+}

--- a/crates/rsvelte_core/tests/dev_shadowed_local_rune.rs
+++ b/crates/rsvelte_core/tests/dev_shadowed_local_rune.rs
@@ -88,6 +88,7 @@ fn a_shadowed_derived_is_read_through_its_signal_in_dev() {
 </script>
 
 <span>{multiplied.count}</span>
+<button onclick={() => count++}>increase</button>
 "#,
         true,
     );


### PR DESCRIPTION
A `$state` / `$derived` declared inside a nested function whose name also exists
as a top-level binding is not in `state_vars` (that would wrongly wrap the
top-level references), so `transform_shadowed_local_state_vars` rewrites just
the enclosing function body instead. Three probes locate the declaration by the
literal text `<kw> <name> = $.state(` — and in dev the `$.tag(...)` label wrap
already sits between the `=` and the rune call, so all three missed and the body
was left completely untransformed: `return array` instead of `return
$.get(array)`, `array.push(entry)` instead of `$.get(array).push(entry)`.

The three probes are `index_shadowed_decls` (which declaration shapes exist),
`apply_local_set_transforms`' declaration-line skip, and — the one that hid the
other two — `is_state_var_init_expression`, which decides whether a
function-local binding counts as a state var at all. Each now looks through a
`$.tag(...)` / `$.tag_proxy(...)` wrap.

Clears 3 `client-dev` corpus entries (`wrapped-$state`, `mutation-both`,
`derived-in-expression`). Non-dev output is unchanged: without the wrap the
probes see exactly what they saw before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014EJ8yjsgEh6CxqJhQoGZHP