### PR TITLE
fix(compiler): proxy `&&` state initializers and read private class-field state via `$.get`

### DIFF
--- a/.changeset/state-proxy-logical-and-private-field-reads.md
+++ b/.changeset/state-proxy-logical-and-private-field-reads.md
@@ -1,0 +1,14 @@
+---
+'@rsvelte/compiler': patch
+---
+
+fix(compiler): proxy `$state(a && b)` initializers and read private class-field state through `$.get`
+
+Two silent reactivity bugs in the client output:
+
+- a `$state` initializer whose top-level operator was `&&` was not wrapped in
+  `$.proxy(...)`, so mutations to nested properties of the held value did not
+  trigger updates (`||` and `??` were already handled).
+- a `$state` private class field read inside a nested function in a constructor
+  was rewritten to `this.#field.v.…` instead of `$.get(this.#field).…`, so the
+  read was never registered as a dependency.

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/class_transforms.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/class_transforms.rs
@@ -2229,18 +2229,6 @@ pub(super) fn transform_constructor_assignment(line: &str, fields: &[ClassStateF
                         );
                     }
                 }
-
-                // Handle member access on private state field: this.#name.prop = value
-                // -> this.#name.v.prop = value (in constructor, we use .v for direct access)
-                // Reference: MemberExpression.js - in constructor for $state fields, use .v
-                let member_pattern = format!("this.#{}.", field.name);
-                if result.contains(&member_pattern)
-                    && (field.rune_type == "$state" || field.rune_type == "$state.raw")
-                {
-                    let with_v = format!("this.#{}.v.", field.private_backing_name);
-                    result = result.replace(&member_pattern, &with_v);
-                    return result;
-                }
             }
         }
     }

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/expression_utils.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/expression_utils.rs
@@ -1677,10 +1677,10 @@ pub(super) fn expression_needs_proxy(expr: &str) -> bool {
         return true;
     }
 
-    // Logical expressions with || or ?? always need proxy.
+    // Logical expressions with ||, && or ?? always need proxy.
     // In the official Svelte compiler, LogicalExpression is not in the
     // should_proxy whitelist, so it always returns true regardless of operands.
-    // e.g., `pData ?? defaultValue`, `expr || fallback`
+    // e.g., `pData ?? defaultValue`, `expr || fallback`, `a === undefined && !b`
     if contains_top_level_logical(trimmed) {
         return true;
     }
@@ -1974,9 +1974,13 @@ pub(super) fn contains_top_level_logical(expr: &str) -> bool {
             b')' | b']' | b'}' if depth > 0 => {
                 depth -= 1;
             }
-            // Any top-level || or ?? means the expression is a LogicalExpression,
+            // Any top-level ||, && or ?? means the expression is a LogicalExpression,
             // which always needs proxy in the official Svelte compiler.
             b'|' if depth == 0 && i + 1 < bytes.len() && bytes[i + 1] == b'|' => {
+                return true;
+            }
+            // A single `&` is a bitwise BinaryExpression, which never needs proxy.
+            b'&' if depth == 0 && i + 1 < bytes.len() && bytes[i + 1] == b'&' => {
                 return true;
             }
             b'?' if depth == 0 && i + 1 < bytes.len() && bytes[i + 1] == b'?' => {

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/private_v_suffix_ast.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/private_v_suffix_ast.rs
@@ -22,7 +22,6 @@
 //!   `$.update_pre(` first-arg.
 //! - Assignment LHS (`this.#count = ...`).
 //! - Argument of an UpdateExpression (`this.#count++`).
-//! - `.object` of an enclosing member chain (`this.#count.foo`).
 //!
 //! `==` / `===` ARE wrapped (reads), matching text behaviour.
 //!
@@ -177,17 +176,15 @@ impl<'a, 'ast> Visit<'ast> for PrivateVSuffixCollector<'a> {
     }
 
     fn visit_static_member_expression(&mut self, member: &StaticMemberExpression<'ast>) {
-        if let Expression::PrivateFieldExpression(pf) = &member.object {
+        // Only `<qualified>.v` is skipped: that is this pass's own output, and the
+        // fixed-point loop re-parses it. Any other property (`this.#count.length`)
+        // is a read whose object still has to be wrapped.
+        if member.property.name == "v"
+            && let Expression::PrivateFieldExpression(pf) = &member.object
+        {
             self.push_skip(pf.as_ref());
         }
         walk::walk_static_member_expression(self, member);
-    }
-
-    fn visit_computed_member_expression(&mut self, member: &ComputedMemberExpression<'ast>) {
-        if let Expression::PrivateFieldExpression(pf) = &member.object {
-            self.push_skip(pf.as_ref());
-        }
-        walk::walk_computed_member_expression(self, member);
     }
 
     fn visit_call_expression(&mut self, call: &CallExpression<'ast>) {
@@ -232,6 +229,34 @@ mod tests {
             out,
             "let x = this.#count.v;\nrAF(() => $.get(this.#count));"
         );
+    }
+
+    #[test]
+    fn member_chain_read_appends_v_to_the_field() {
+        let src = "console.log(this.#count.length);";
+        let out = transform_private_v_suffix_ast(src, &ssv(&["this.#count"])).unwrap();
+        assert_eq!(out, "console.log(this.#count.v.length);");
+    }
+
+    #[test]
+    fn nested_function_member_chain_read_uses_get() {
+        let src = "rAF(() => this.#count.includes(k));";
+        let out = transform_private_v_suffix_ast(src, &ssv(&["this.#count"])).unwrap();
+        assert_eq!(out, "rAF(() => $.get(this.#count).includes(k));");
+    }
+
+    #[test]
+    fn computed_member_read_appends_v_to_the_field() {
+        let src = "let x = this.#count[0];";
+        let out = transform_private_v_suffix_ast(src, &ssv(&["this.#count"])).unwrap();
+        assert_eq!(out, "let x = this.#count.v[0];");
+    }
+
+    #[test]
+    fn member_write_target_appends_v_to_the_field() {
+        let src = "this.#count.length = 0;";
+        let out = transform_private_v_suffix_ast(src, &ssv(&["this.#count"])).unwrap();
+        assert_eq!(out, "this.#count.v.length = 0;");
     }
 
     #[test]

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/private_v_suffix_ast.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/private_v_suffix_ast.rs
@@ -299,9 +299,10 @@ mod tests {
     }
 
     #[test]
-    fn deeper_member_chain_left_alone() {
+    fn deeper_member_chain_wraps_the_field() {
         let src = "let x = this.#count.foo;";
-        assert!(transform_private_v_suffix_ast(src, &ssv(&["this.#count"])).is_none());
+        let out = transform_private_v_suffix_ast(src, &ssv(&["this.#count"])).unwrap();
+        assert_eq!(out, "let x = this.#count.v.foo;");
     }
 
     #[test]

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/tests.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/tests.rs
@@ -1320,6 +1320,59 @@ export function useStore(pData) {
 }
 
 #[test]
+fn test_module_state_with_logical_and_gets_proxy() {
+    let source = r#"
+export function resource(initialValue, lazy) {
+  let loading = $state(initialValue === undefined && !lazy);
+  return { get loading() { return loading; } };
+}
+"#;
+
+    let result = crate::compiler::compile_module(
+        source,
+        crate::compiler::ModuleCompileOptions {
+            filename: Some("test.svelte.js".to_string()),
+            ..Default::default()
+        },
+    )
+    .unwrap();
+    let code = &result.js.code;
+
+    assert!(
+        code.contains("$.proxy(initialValue === undefined && !lazy)"),
+        "$state(a && b) should be wrapped with $.proxy(): {}",
+        code
+    );
+}
+
+#[test]
+fn test_module_state_with_bitwise_and_no_proxy() {
+    // `&` is a BinaryExpression, which upstream `should_proxy` never proxies.
+    let source = r#"
+export function useFlags(a, b) {
+  let flags = $state(a & b);
+  return { get flags() { return flags; } };
+}
+"#;
+
+    let result = crate::compiler::compile_module(
+        source,
+        crate::compiler::ModuleCompileOptions {
+            filename: Some("test.svelte.js".to_string()),
+            ..Default::default()
+        },
+    )
+    .unwrap();
+    let code = &result.js.code;
+
+    assert!(
+        !code.contains("$.proxy("),
+        "$state(a & b) must not be wrapped with $.proxy(): {}",
+        code
+    );
+}
+
+#[test]
 fn test_module_state_literal_no_proxy() {
     // Ensure that simple literals are NOT wrapped with $.proxy()
     let source = r#"


### PR DESCRIPTION
Closes #2302
Closes #2303

Both reported by @MathiasWP while enrolling `runed` / `svelte-toolbelt` into the compat corpus (#2310). Thanks!

The two are **independent** root causes that happen to surface in the same two files.

### #2302 — missing `$.proxy` wrapper

The `.svelte.js` / `.svelte.ts` module path decides `should_proxy` with a text sniff
(`expression_needs_proxy`). Its top-level-logical detector recognised `||` and `??` but
not `&&`, so `$state(initialValue === undefined && !lazy)` fell through to `false`.
Upstream's `should_proxy` whitelists only `Literal` / `TemplateLiteral` / arrow / function /
`UnaryExpression` / `BinaryExpression` / `undefined` — `LogicalExpression` is not on it, so
every `&&` initializer is proxied. A lone `&` stays unproxied (it is a `BinaryExpression`).

```js
// before                       // after (== official)
let loading = a === void 0 && !b;   let loading = $.proxy(a === void 0 && !b);
```

### #2303 — `.v` instead of `$.get(...)`

A constructor statement containing `this.#field.` was rewritten by a blind
`String::replace` to `this.#field.v.`, ignoring nesting. Upstream's `MemberExpression`
visitor only emits `.v` while `state.in_constructor` holds and `$.get(node)` otherwise,
and `in_constructor` is cleared on entering a nested function. The AST pass
(`private_v_suffix_ast`) already tracks that depth correctly, but never saw member chains:
its idempotency guard skipped *any* private field that was the `.object` of a member
expression, not just its own `X.v` output.

So the text replace is dropped, and the guard is narrowed to `property === "v"` — which
also fixes plain member-chain reads (`this.#a.length` at constructor depth 0 was previously
left untouched instead of becoming `this.#a.v.length`).

```js
// before                                  // after (== official)
if (!this.#pressedKeys.v.includes(key))    if (!$.get(this.#pressedKeys).includes(key))
```

### Verification

`runed/packages/runed/src/lib/utilities/{resource/resource,pressed-keys/pressed-keys}.svelte.ts`
now byte-match official on **all three** targets (client, server, client-dev). Unit tests
added for both paths; corpus ratchets re-measured on top of `origin/main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012gQPtKmdY9xwn5fjdwaxK8