### PR TITLE
chore(release): add a bootstrap publisher for brand-new platform packages

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -145,6 +145,10 @@ Use the `Agent` tool for substantial work — feature implementation, multi-file
 - Run `cargo fmt && cargo clippy --all-targets --all-features -- -D warnings` before committing
 - Push immediately after committing
 - Releases are automated via Changesets Release PRs
+- A **brand-new** platform package cannot be published by CI: npm OIDC trusted publishing
+  only works for a name that already exists. Bootstrap it once with
+  `pnpm run bootstrap-platform-packages -- --run <ci-run-id> --yes`, attach the trusted
+  publisher on npmjs.com, then re-run the release
 
 ### Maintaining This File
 

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
 		"stage-language-server": "node scripts/release/stage-language-server-binaries.mjs",
 		"stage-vps-native": "node scripts/release/stage-vps-binaries.mjs",
 		"publish-platform-binaries": "node scripts/release/publish-platform-binaries.mjs",
+		"bootstrap-platform-packages": "node scripts/release/bootstrap-platform-packages.mjs",
 		"test:envelope": "node scripts/dev/test-envelope-validation.mjs",
 		"test:parse-envelope": "node scripts/dev/test-parse-envelope-validation.mjs",
 		"test:vps-shim": "node scripts/dev/test-vps-shim.mjs",

--- a/scripts/release/bootstrap-platform-packages.mjs
+++ b/scripts/release/bootstrap-platform-packages.mjs
@@ -1,0 +1,192 @@
+#!/usr/bin/env node
+// One-shot manual publish for platform packages whose *name* does not yet
+// exist on the registry.
+//
+// Why this exists: the release workflow publishes through npm OIDC trusted
+// publishing, and a trusted publisher can only be configured for a package
+// that already exists. The very first version of a brand-new platform package
+// therefore fails with `404 Not Found - PUT` (release run 31025504084: the
+// five `@rsvelte/language-server-*` packages added by #2272), which aborts
+// `publish-platform-binaries.mjs` before `changeset publish` ever runs and
+// leaves the release half-shipped.
+//
+// This script closes that gap once per new package name, from a maintainer's
+// machine with a classic/granular npm token that may create packages:
+//
+//   1. pulls each platform binary from the artifacts of a completed CI run
+//      (they cannot all be cross-built locally),
+//   2. stages it into `apps/npm/<pkg>/` exactly like
+//      `stage-language-server-binaries.mjs` does, preserving the +x bit,
+//   3. publishes with plain `npm publish` — no `--provenance`, which requires
+//      the OIDC token this path exists to work around.
+//
+// Afterwards, attach the trusted publisher to each new package on npmjs.com
+// and re-run the release: `publish-platform-binaries.mjs` skips versions that
+// are already published, so a re-run is idempotent.
+//
+// Usage:
+//   node scripts/release/bootstrap-platform-packages.mjs --run <run-id>
+//   node scripts/release/bootstrap-platform-packages.mjs --run <run-id> --yes
+//
+// Without `--yes` it stages and runs `npm publish --dry-run`, printing exactly
+// what would be published. Publishing is irreversible — npm does not allow
+// unpublishing a version after 72 hours — so the real publish is opt-in.
+
+import { spawnSync } from 'node:child_process';
+import { chmodSync, copyFileSync, existsSync, mkdtempSync, readFileSync, rmSync, statSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { fileURLToPath } from 'node:url';
+import { dirname, join, resolve } from 'node:path';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(here, '../..');
+
+// Each entry maps a workspace package directory to the CI artifact that holds
+// its binary. Artifact names mirror the `upload-artifact` names in
+// `.github/workflows/release.yml`.
+const GROUPS = {
+	'language-server': [
+		{ dir: 'apps/npm/language-server-darwin-arm64', artifact: 'rsvelte-language-server-darwin-arm64', binary: 'rsvelte-language-server' },
+		{ dir: 'apps/npm/language-server-darwin-x64', artifact: 'rsvelte-language-server-darwin-x64', binary: 'rsvelte-language-server' },
+		{ dir: 'apps/npm/language-server-linux-x64-gnu', artifact: 'rsvelte-language-server-linux-x64-gnu', binary: 'rsvelte-language-server' },
+		{ dir: 'apps/npm/language-server-linux-arm64-gnu', artifact: 'rsvelte-language-server-linux-arm64-gnu', binary: 'rsvelte-language-server' },
+		{ dir: 'apps/npm/language-server-win32-x64-msvc', artifact: 'rsvelte-language-server-win32-x64-msvc', binary: 'rsvelte-language-server.exe' },
+	],
+};
+
+const argv = process.argv.slice(2);
+
+function flag(name) {
+	return argv.includes(`--${name}`);
+}
+
+function option(name) {
+	const i = argv.indexOf(`--${name}`);
+	if (i === -1) return undefined;
+	const value = argv[i + 1];
+	if (value === undefined || value.startsWith('--')) {
+		fail(`--${name} requires a value`);
+	}
+	return value;
+}
+
+function fail(message) {
+	console.error(`[bootstrap] ${message}`);
+	process.exit(1);
+}
+
+const runId = option('run');
+const groupName = option('group') ?? 'language-server';
+const publishForReal = flag('yes');
+const otp = option('otp');
+
+if (flag('help') || !runId) {
+	console.log(readFileSync(fileURLToPath(import.meta.url), 'utf8').split('\n').filter((l) => l.startsWith('//')).join('\n'));
+	process.exit(runId ? 0 : 1);
+}
+
+const targets = GROUPS[groupName];
+if (!targets) {
+	fail(`unknown --group "${groupName}" (known: ${Object.keys(GROUPS).join(', ')})`);
+}
+
+function run(command, args, options = {}) {
+	return spawnSync(command, args, { encoding: 'utf8', ...options });
+}
+
+function requireTool(command, args) {
+	const result = run(command, args, { stdio: ['ignore', 'pipe', 'pipe'] });
+	if (result.error || result.status !== 0) {
+		fail(`\`${command} ${args.join(' ')}\` failed — is ${command} installed and authenticated?`);
+	}
+	return result.stdout.trim();
+}
+
+function isAlreadyPublished(name, version) {
+	const result = run('npm', ['view', `${name}@${version}`, 'version'], { stdio: ['ignore', 'pipe', 'pipe'] });
+	return result.status === 0 && result.stdout.trim() === version;
+}
+
+requireTool('gh', ['auth', 'status']);
+// Only the real publish needs an npm session; a dry run must stay runnable
+// (and reviewable) without one.
+if (publishForReal) {
+	console.log(`[bootstrap] npm user: ${requireTool('npm', ['whoami'])}`);
+}
+console.log(`[bootstrap] source run: ${runId}`);
+console.log(`[bootstrap] mode: ${publishForReal ? 'PUBLISH' : 'dry-run (pass --yes to publish)'}`);
+
+// Refuse to bootstrap a package that already exists: this script publishes
+// without provenance, so using it on an established package would silently
+// downgrade that version's supply-chain metadata compared with every other
+// version of the same package.
+const plan = [];
+for (const target of targets) {
+	const absDir = resolve(repoRoot, target.dir);
+	if (!existsSync(absDir)) fail(`missing package directory: ${target.dir}`);
+	const { name, version } = JSON.parse(readFileSync(join(absDir, 'package.json'), 'utf8'));
+	if (isAlreadyPublished(name, version)) {
+		console.log(`[bootstrap] ${name}@${version} already published — skipping`);
+		continue;
+	}
+	const exists = run('npm', ['view', name, 'name'], { stdio: ['ignore', 'pipe', 'pipe'] }).status === 0;
+	if (exists) {
+		fail(
+			`${name} already exists on the registry — do not bootstrap it. ` +
+				`Publish it from CI so the tarball keeps its provenance attestation.`,
+		);
+	}
+	plan.push({ ...target, absDir, name, version });
+}
+
+if (plan.length === 0) {
+	console.log('[bootstrap] nothing to do — every package in this group is published.');
+	process.exit(0);
+}
+
+const staging = mkdtempSync(join(tmpdir(), 'rsvelte-bootstrap-'));
+let failures = 0;
+try {
+	for (const target of plan) {
+		const dest = join(staging, target.artifact);
+		const download = run('gh', ['run', 'download', runId, '--repo', 'baseballyama/rsvelte', '-n', target.artifact, '-D', dest], {
+			stdio: 'inherit',
+		});
+		if (download.status !== 0) {
+			fail(`failed to download artifact "${target.artifact}" from run ${runId} (expired?)`);
+		}
+		const src = join(dest, target.binary);
+		if (!existsSync(src)) fail(`artifact "${target.artifact}" does not contain ${target.binary}`);
+		const staged = join(target.absDir, target.binary);
+		copyFileSync(src, staged);
+		if (!target.binary.endsWith('.exe')) chmodSync(staged, 0o755);
+		console.log(`[bootstrap] staged ${target.dir}/${target.binary} (${statSync(staged).size} bytes)`);
+	}
+
+	for (const target of plan) {
+		console.log(`[bootstrap] publishing ${target.name}@${target.version}${publishForReal ? '' : ' (dry-run)'}`);
+		const args = ['publish', '--access', 'public'];
+		if (!publishForReal) args.push('--dry-run');
+		if (otp) args.push('--otp', otp);
+		const result = run('npm', args, { cwd: target.absDir, stdio: 'inherit' });
+		if (result.status !== 0) {
+			console.error(`[bootstrap] FAILED: ${target.name}@${target.version} (exit ${result.status})`);
+			failures += 1;
+		}
+	}
+} finally {
+	rmSync(staging, { recursive: true, force: true });
+}
+
+if (failures > 0) {
+	console.error(`[bootstrap] ${failures} package(s) failed`);
+	process.exit(1);
+}
+
+if (publishForReal) {
+	console.log('\n[bootstrap] done. Next:');
+	console.log('  1. On npmjs.com, add the trusted publisher (baseballyama/rsvelte, release.yml) to each package above.');
+	console.log('  2. Re-run the Release workflow — already-published versions are skipped.');
+} else {
+	console.log('\n[bootstrap] dry run only — nothing was published. Re-run with --yes to publish.');
+}


### PR DESCRIPTION
## Why

Release run [31025504084](https://github.com/baseballyama/rsvelte/actions/runs/31025504084) failed:

```
npm error 404 Not Found - PUT https://registry.npmjs.org/@rsvelte%2flanguage-server-darwin-arm64
```

npm OIDC trusted publishing can only publish to a package name that **already exists** — a trusted publisher is configured per package. The five `@rsvelte/language-server-*` platform packages added by #2272 were brand new, so their first version could not be published from CI. `publish-platform-binaries.mjs` exited 1, `changeset publish` never ran, and the release shipped only the platform packages that already existed.

## What

`scripts/release/bootstrap-platform-packages.mjs` — a one-shot manual publisher for new platform package names:

1. pulls each platform binary from a completed CI run's artifacts (they cannot all be cross-built locally),
2. stages it into `apps/npm/<pkg>/` like `stage-language-server-binaries.mjs` does, preserving the `+x` bit,
3. publishes with plain `npm publish` — no `--provenance`, which needs the OIDC token this path works around.

Guards:

- **dry-run by default**; the real publish requires `--yes` (a publish is irreversible after 72h).
- **refuses a package that already exists** on the registry, so it can't be used to sneak a provenance-less version into an established package. Those must publish from CI.
- skips versions already on the registry, so re-running is idempotent.
- `npm whoami` is only required for `--yes`, keeping the dry run reviewable without a session.

## Usage

```
pnpm run bootstrap-platform-packages -- --run 31025504084          # preview
pnpm run bootstrap-platform-packages -- --run 31025504084 --yes    # publish
```

Then attach the trusted publisher to each new package on npmjs.com and re-run the Release workflow.

## Verification

Dry run on this branch (`origin/main`, version 0.4.0) staged and packed all five packages:

| package | tarball | unpacked |
|---|---|---|
| `language-server-darwin-arm64` | 6.7 MB | 15.9 MB |
| `language-server-darwin-x64` | 7.0 MB | 17.1 MB |
| `language-server-linux-x64-gnu` | 7.3 MB | 17.5 MB |
| `language-server-linux-arm64-gnu` | 6.9 MB | 15.6 MB |
| `language-server-win32-x64-msvc` | 7.5 MB | 19.5 MB |

Note `win32-x64-msvc` is included here even though `publish-platform-binaries.mjs` excludes it — that exclusion is about mode bits, but the *name* is equally new, so `changeset publish` would have 404'd on it next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017eFcFhr66RJemE7UtF4CNK