### PR TITLE
fix(compiler): transform read references inside `bind:` setter targets

### DIFF
--- a/.changeset/olive-eels-swim.md
+++ b/.changeset/olive-eels-swim.md
@@ -1,0 +1,11 @@
+---
+'@rsvelte/compiler': patch
+---
+
+fix(compiler): apply read transforms inside `bind:` setter assignment targets
+
+A component binding whose expression is a member expression with a plain
+(non-state, non-prop) root emitted its setter target untransformed, so an
+each-block destructuring thunk used as a computed key was written as `key`
+instead of `key()` — the write landed on a property keyed by the thunk
+function rather than by its value.

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/component.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/component.rs
@@ -1852,21 +1852,17 @@ fn process_bind_directive<'a>(
                     )]
                 }
             } else {
-                // Root is not state or prop - check if it has a transform
-                let has_transform = transform.is_some_and(|t| t.read.is_some());
-                if has_transform {
-                    let assignment = b::assign(
+                // Upstream falls through to `context.next()`, which visits the whole
+                // assignment target — inner references (an each-block thunk in a
+                // computed key) carry read transforms even when the root has none.
+                vec![b::stmt(
+                    &context.arena,
+                    b::assign(
                         &context.arena,
                         transformed_expression.clone(),
                         b::id("$$value"),
-                    );
-                    vec![b::stmt(&context.arena, assignment)]
-                } else {
-                    vec![b::stmt(
-                        &context.arena,
-                        b::assign(&context.arena, raw_expression.clone(), b::id("$$value")),
-                    )]
-                }
+                    ),
+                )]
             }
         } else {
             vec![b::stmt(


### PR DESCRIPTION
Closes #2305

A component binding whose expression is a member expression with a plain (non-state, non-prop, non-store) root built its generated `set value($$value)` body from the **raw** expression instead of the transformed one. Inner references therefore kept their source form, so an each-block destructuring thunk used as a computed key was emitted as `key` rather than `key()`:

```js
set value($$value) {
-   params.fields[key()] = $$value;   // official
+   params.fields[key] = $$value;     // rsvelte (before)
},
```

The getter already used the transformed expression, which is why only the write side was wrong — the assignment landed on a property keyed by the stringified thunk function, so the intended field never updated. That made this a **production** correctness bug, not just an output-parity one.

Upstream's `AssignmentExpression` visitor returns `null` from `build_assignment` for this shape and falls through to `context.next()`, which visits the whole assignment target. The `has_transform` check this replaces only looked at the member **root**, so a transform on a nested reference was dropped.

Reported by @MathiasWP while enrolling `runed` / `svelte-toolbelt` into the compat corpus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012gQPtKmdY9xwn5fjdwaxK8