### PR TITLE
fix(compiler): fold constants reaching a template through a non-literal initializer

### DIFF
--- a/.changeset/fold-non-literal-binding-initials.md
+++ b/.changeset/fold-non-literal-binding-initials.md
@@ -1,0 +1,10 @@
+---
+"@rsvelte/compiler": patch
+---
+
+Fold constants that reach a template through a non-literal initializer. A `const`
+whose initializer is a call, binary or conditional expression (`const rows =
+Math.ceil(sprites / cols)`) is now evaluated at compile time when it is read from
+a template chunk, so `style="background-size: {64 * rows}px"` emits the folded
+literal instead of a reactive interpolation — matching the official compiler on
+client, dev-client and server output.

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/variable_declarator.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/variable_declarator.rs
@@ -965,7 +965,8 @@ fn init_needs_expr_json(init: &JsNode) -> bool {
         JsNode::TemplateLiteral { expressions, .. } => !expressions.is_empty(),
         JsNode::BinaryExpression { .. }
         | JsNode::UnaryExpression { .. }
-        | JsNode::ConditionalExpression { .. } => true,
+        | JsNode::ConditionalExpression { .. }
+        | JsNode::CallExpression { .. } => true,
         _ => false,
     }
 }

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/utils.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/utils.rs
@@ -3816,6 +3816,13 @@ fn get_literal_value_json(
     }
 }
 
+/// Mirrors upstream `get_global_keypath`, which yields a rune keypath only when
+/// the name is unbound: in legacy mode `$state` is the store subscription of an
+/// imported `state`, not a rune.
+fn is_rune_callee(name: &str, context: &ComponentContext) -> bool {
+    context.state.analysis.runes && context.state.get_binding(name).is_none()
+}
+
 const MAX_INITIAL_EVAL_DEPTH: u8 = 8;
 
 thread_local! {
@@ -3930,7 +3937,11 @@ fn get_literal_value_complex(
                 }
 
                 // Fix C: $state.raw(arg) — MemberExpression callee with object=$state, property=raw
-                if obj_type == "Identifier" && obj_name == "$state" && prop_name == "raw" {
+                if obj_type == "Identifier"
+                    && obj_name == "$state"
+                    && prop_name == "raw"
+                    && is_rune_callee(obj_name, context)
+                {
                     let args = obj.get("arguments").and_then(|a| a.as_array());
                     if let Some(args) = args
                         && let Some(first_arg) = args.first()
@@ -3947,7 +3958,8 @@ fn get_literal_value_complex(
             let callee_type = callee.get("type").and_then(|t| t.as_str())?;
             if callee_type == "Identifier" {
                 let rune_name = callee.get("name").and_then(|n| n.as_str()).unwrap_or("");
-                if matches!(rune_name, "$state" | "$derived") {
+                if matches!(rune_name, "$state" | "$derived") && is_rune_callee(rune_name, context)
+                {
                     let args = obj.get("arguments").and_then(|a| a.as_array());
                     if let Some(args) = args
                         && let Some(first_arg) = args.first()
@@ -6245,7 +6257,9 @@ fn is_expression_known_json(json_value: &serde_json::Value, context: &ComponentC
                 // $state(arg) / $derived(arg)
                 if callee_type == Some("Identifier") {
                     let rune_name = callee.get("name").and_then(|n| n.as_str()).unwrap_or("");
-                    if matches!(rune_name, "$state" | "$derived") {
+                    if matches!(rune_name, "$state" | "$derived")
+                        && is_rune_callee(rune_name, context)
+                    {
                         if let Some(args) = obj.get("arguments").and_then(|a| a.as_array())
                             && let Some(first_arg) = args.first()
                         {
@@ -6268,7 +6282,10 @@ fn is_expression_known_json(json_value: &serde_json::Value, context: &ComponentC
                         .and_then(|p| p.get("name"))
                         .and_then(|n| n.as_str())
                         .unwrap_or("");
-                    if obj_name == "$state" && prop_name == "raw" {
+                    if obj_name == "$state"
+                        && prop_name == "raw"
+                        && is_rune_callee(obj_name, context)
+                    {
                         if let Some(args) = obj.get("arguments").and_then(|a| a.as_array())
                             && let Some(first_arg) = args.first()
                         {

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/utils.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/utils.rs
@@ -3655,6 +3655,23 @@ fn get_literal_value_json(
                     }
                 }
 
+                // A non-literal initializer is kept as AST JSON rather than in
+                // `initial`; upstream's `scope.evaluate` recurses into the init
+                // node whatever its shape, so mirror that before giving up.
+                {
+                    use crate::compiler::phases::phase2_analyze::scope::BindingKind;
+                    if binding.initial.is_none()
+                        && !matches!(binding.kind, BindingKind::Derived)
+                        && INITIAL_EVAL_DEPTH.with(|d| d.get()) < MAX_INITIAL_EVAL_DEPTH
+                        && let Some(init_json) = binding.init_expr_json_parsed()
+                    {
+                        INITIAL_EVAL_DEPTH.with(|d| d.set(d.get() + 1));
+                        let folded = get_literal_value_json(init_json, context);
+                        INITIAL_EVAL_DEPTH.with(|d| d.set(d.get() - 1));
+                        return folded;
+                    }
+                }
+
                 // Check if we have a known initial value (stored as source string)
                 let init = binding.initial.as_ref()?;
                 // Parse simple string literals like 'world' or "world"
@@ -3797,6 +3814,13 @@ fn get_literal_value_json(
             _ => None,
         }
     }
+}
+
+const MAX_INITIAL_EVAL_DEPTH: u8 = 8;
+
+thread_local! {
+    /// Caps mutually-referential initializers (`const a = b; const b = a;`).
+    static INITIAL_EVAL_DEPTH: std::cell::Cell<u8> = const { std::cell::Cell::new(0) };
 }
 
 /// Format an `f64` the way JS `String(n)` would for a known constant fold:

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/evaluate.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/evaluate.rs
@@ -1075,6 +1075,14 @@ impl<'a> EvalCtx<'a> {
             if matches!(binding.kind, Normal) && self.binding_initial_is_props_id(&binding.name) {
                 return Evaluation::single(EvalValue::StringMarker);
             }
+            // A non-literal initializer is kept as AST JSON instead; upstream's
+            // `scope.evaluate` recurses into the init node whatever its shape.
+            if !matches!(binding.kind, Derived)
+                && depth < MAX_DEPTH
+                && let Some(init_json) = binding.init_expr_json_parsed()
+            {
+                return self.evaluate_estree(init_json, depth + 1);
+            }
             return Evaluation::unknown();
         };
 


### PR DESCRIPTION
Closes #2309

Reported by @MathiasWP while enrolling `runed` / `svelte-toolbelt` into the compat corpus.

## What was wrong

`runed/sites/docs/src/lib/components/demos/animation-frames.svelte`:

```svelte
const sprites = 10;
const sheetCols = 3;
const sheetRows = Math.ceil(sprites / sheetCols);
...
style="background-size: {64 * sheetCols}px {64 * sheetRows}px;"
```

Official folds both chunks (`background-size: 192px 256px`); rsvelte folded only
the first and emitted `${64 * sheetRows}px` for the second.

Root cause: Phase 2 stores `binding.initial` only for *literal* initializers.
A non-literal one is kept separately as AST JSON in `binding.init_expr_json`,
gated by `init_needs_expr_json`, which did not include `CallExpression` — and
neither the client evaluator (`get_literal_value_json`, Identifier arm) nor the
server evaluator (`evaluate_binding_initial`) ever consulted that JSON. So any
identifier with a non-literal initializer resolved to "unknown" and stayed
reactive. Upstream's `scope.evaluate` recurses into `binding.initial` whatever
the node shape (`phases/scope.js`), so this mirrors that.

Three changes, all in the evaluation path:

- `init_needs_expr_json`: accept `CallExpression` (`Math.ceil(...)` is in
  upstream's known-function table).
- client `get_literal_value_json`, Identifier arm: when `initial` is absent, fall
  back to `init_expr_json_parsed()` and recurse (depth-capped for cyclic
  initializers).
- server `evaluate_binding_initial`: same fallback before returning unknown.

Both fallbacks skip `$derived` bindings, whose runtime value is the signal read,
not the compile-time initializer.

## Verification

`scripts/compat-corpus/one.mjs` on the reported file: `client`, `server` and
`client-dev` all MATCH (previously `client` / `client-dev` diverged as reported,
and `server` diverged the same way).

## Not in this PR — #2308

#2308 (`server`: `+=` not expanded) reproduces, but the direction in the issue
title is inverted: the source is `runs = runs + 1` and it is **rsvelte** that
contracts it to `runs += 1`. Details in a comment on the issue; the fix needs the
`.svelte.js` module path to stop guessing, which is a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012gQPtKmdY9xwn5fjdwaxK8