### PR TITLE
fix(compiler): split do/while, labeled, debugger and bare-block statements in the async server body

### DIFF
--- a/.changeset/server-async-body-statement-shapes.md
+++ b/.changeset/server-async-body-statement-shapes.md
@@ -1,0 +1,9 @@
+---
+"@rsvelte/compiler": patch
+---
+
+Fix the async server instance-body split for `do…while`, labeled, `debugger` and
+bare-block statements, plus brace-less `if … else` chains. These shapes used to
+produce a thunk array that the compiler could not parse back, which quietly
+degraded the component to an un-split instance body. Such a rejection is now a
+compile error in every build profile rather than silently wrong output.

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/mod.rs
@@ -223,6 +223,10 @@ pub struct ServerTransformState<'a> {
     /// Leading-comment regions registered by the script transform, replayed onto
     /// a synthetic buffer at print time. See [`comments`].
     pub comments: comments::ChunkRegistry,
+    /// Set when [`Self::reparse_program`] rejected text this compiler generated.
+    /// The instance body cannot be reconstructed after that, so assembly aborts
+    /// instead of shipping a component whose `<script>` silently did nothing.
+    pub reparse_failure: std::cell::RefCell<Option<String>>,
 }
 
 /// The render position saved by [`ServerTransformState::enter_template_scope`],
@@ -310,6 +314,7 @@ impl<'a> ServerTransformState<'a> {
             slot_let_shadows: Vec::new(),
             current_scope_index: analysis.root.instance_scope_index,
             comments: comments::ChunkRegistry::default(),
+            reparse_failure: std::cell::RefCell::new(None),
         }
     }
 
@@ -713,53 +718,28 @@ impl<'a> ServerTransformState<'a> {
     /// Re-parse a whole program `src` into the state allocator, returning ALL
     /// its top-level statements. Used by the async instance-body transform to
     /// rehome the sync/async-split TEXT (`var …; var $$promises = …`) emitted by
-    /// `transform_async_body` back into oxc statements. Returns an empty vec on
-    /// a parse failure.
+    /// `transform_async_body` back into oxc statements. Records a failure and
+    /// returns an empty vec on a parse failure.
     pub fn reparse_program(&self, src: &str) -> Vec<Statement<'a>> {
         let owned = self.allocator.alloc_str(src.trim());
         let ret =
             oxc_parser::Parser::new(self.allocator, owned, oxc_span::SourceType::mjs()).parse();
         comment_stats::bump::REPARSE_PROGRAM_CALLS(1);
-        // `src` is our own generated text, so a rejection is a compiler bug and
-        // not a user error — and it erases the whole instance body. Two
-        // channels, because the two audiences want different things:
-        //
-        // * the test suite should fail, since that is where this is actionable.
-        //   CI runs `cargo nextest run --profile ci` (no `--release`), so
-        //   `debug_assertions` is on and this fires there.
-        // * a library consumer should not get stderr they cannot suppress, so
-        //   the release-build report sits behind an env var like the other
-        //   diagnostics on this path.
-        //
-        // Measured 0 rejections in 43 `reparse_program` calls over the official
-        // runtime corpus, so neither channel is expected to fire today. The
-        // point is that the next regression is not silent.
-        debug_assert!(
-            ret.diagnostics.is_empty(),
-            "server reparse_program rejected generated source ({} diagnostics); \
-             instance body dropped: {}",
-            ret.diagnostics.len(),
-            ret.diagnostics
-                .iter()
-                .map(|d| d.message.to_string())
-                .collect::<Vec<_>>()
-                .join("; ")
-        );
         if !ret.diagnostics.is_empty() {
             comment_stats::bump::REPARSE_PROGRAM_DIAG_DROPS(1);
-            if *REPARSE_PROGRAM_DEBUG {
-                let line = format!(
-                    "rsvelte: server reparse_program rejected generated source ({} diagnostics); \
-                     instance body dropped: {}\n",
-                    ret.diagnostics.len(),
-                    ret.diagnostics
-                        .iter()
-                        .map(|d| d.message.to_string())
-                        .collect::<Vec<_>>()
-                        .join("; ")
-                );
-                let _ = std::io::Write::write_all(&mut std::io::stderr().lock(), line.as_bytes());
-            }
+            // `src` is our own generated text, so a rejection is a compiler bug,
+            // and continuing would ship a component whose instance body silently
+            // did nothing — fail the compile in every build profile instead.
+            *self.reparse_failure.borrow_mut() = Some(format!(
+                "server async instance-body reparse rejected compiler-generated source \
+                 ({} diagnostics): {}",
+                ret.diagnostics.len(),
+                ret.diagnostics
+                    .iter()
+                    .map(|d| d.message.to_string())
+                    .collect::<Vec<_>>()
+                    .join("; ")
+            ));
             return Vec::new();
         }
         ret.program.body.into_iter().collect()
@@ -994,15 +974,16 @@ fn should_inject_props_full(
 ///   (upstream lines 274-301) — these don't need the template, so they're real.
 /// - `export default function <Name>($$renderer, $$props) { <prologue> }`
 ///
-/// Returns `Some(printed_code)`, or `None` only if assembly is impossible
-/// (currently never — kept as `Option` to match the seam's future fallibility).
+/// Returns the printed code, or `Err(message)` when assembly is impossible —
+/// currently only when [`ServerTransformState::reparse_program`] rejected text
+/// this compiler generated.
 pub fn server_component_ast<'a>(
     analysis: &'a ComponentAnalysis,
     ast: &'a Root,
     source: &'a str,
     options: &'a CompileOptions,
     allocator: &'a Allocator,
-) -> Option<String> {
+) -> Result<String, String> {
     let mut state = ServerTransformState::new(analysis, options, source, &ast.arena, allocator);
 
     // Precompute the SSR constant-folding inputs (`constant_vars` /
@@ -1486,6 +1467,10 @@ See https://svelte.dev/docs/svelte/v5-migration-guide#Components-are-no-longer-c
         program_body.insert(insert_at, filename_stmt);
     }
 
+    if let Some(message) = state.reparse_failure.borrow_mut().take() {
+        return Err(message);
+    }
+
     let mut program = b.program(program_body);
     // `main`'s `record_esrap_server` timed the bare `rsvelte_esrap::print` that
     // used to stand here. Comment preservation replaces that call, so the timer
@@ -1498,14 +1483,8 @@ See https://svelte.dev/docs/svelte/v5-migration-guide#Components-are-no-longer-c
         crate::compiler::phases::phase3_transform::profile::timer_elapsed(_t),
     );
     comment_stats::dump();
-    Some(code)
+    Ok(code)
 }
-
-/// Report a `reparse_program` rejection on stderr in a release build. Off by
-/// default: this is a library, and a consumer cannot suppress what we write to
-/// their stderr. `debug_assert!` covers the case where someone can act on it.
-static REPARSE_PROGRAM_DEBUG: std::sync::LazyLock<bool> =
-    std::sync::LazyLock::new(|| std::env::var_os("RSVELTE_SERVER_REPARSE_DEBUG").is_some());
 
 #[cfg(test)]
 mod tests;

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/tests.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/tests.rs
@@ -3841,8 +3841,8 @@ fn compile_both(source: &str) -> Outcome {
         server_component_ast(&analysis, ast, source, &options, &allocator)
     }));
     let new_out = match new_out {
-        Ok(Some(s)) => s,
-        Ok(None) => return Outcome::NewNone,
+        Ok(Ok(s)) => s,
+        Ok(Err(_)) => return Outcome::NewNone,
         Err(_) => return Outcome::Panic("new"),
     };
 

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/mod.rs
@@ -49,18 +49,13 @@ pub fn transform_server(
     // once with `rsvelte_esrap` — zero text post-processing. This replaced the
     // legacy text `ServerCodeGenerator` (deleted) after reaching byte-parity
     // across the curated runtime / `compiler_fixtures` / `ssr` suites and a net
-    // corpus improvement. The pipeline never returns `None` for a parseable
-    // component; a `None` (only on an internal assembly failure) surfaces as an
-    // error rather than silently falling back.
+    // corpus improvement. An internal assembly failure surfaces as an error
+    // rather than silently falling back.
     SERVER_OXC_ALLOCATOR.with(|cell| {
         let mut allocator = cell.borrow_mut();
         allocator.reset();
-        match ast::server_component_ast(analysis, ast, _source, options, &allocator) {
-            Some(code) => Ok(code),
-            None => Err(TransformError::CodeGen(
-                "server AST pipeline produced no output".to_string(),
-            )),
-        }
+        ast::server_component_ast(analysis, ast, _source, options, &allocator)
+            .map_err(TransformError::CodeGen)
     })
 }
 

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/shared/async_body.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/shared/async_body.rs
@@ -1629,7 +1629,10 @@ fn split_top_level_statements(script: &str) -> Vec<String> {
                             || rest_after.starts_with("catch\n")
                             || rest_after.starts_with("finally ")
                             || rest_after.starts_with("finally{")
-                            || rest_after.starts_with("finally\n");
+                            || rest_after.starts_with("finally\n")
+                            // `do { … } while (…)` — the `while` closes the `do`.
+                            || (starts_with_keyword(stmt_so_far, "do")
+                                && starts_with_keyword(rest_after, "while"));
                         // An `else` (or `else if`) following the closing brace of
                         // an `if` consequent continues the same statement — it
                         // must not be split off, or it becomes an orphan `else`
@@ -1667,7 +1670,14 @@ fn split_top_level_statements(script: &str) -> Vec<String> {
         }
 
         // Semicolon at top level marks end of statement
-        if ch == b';' && brace_depth == 0 && paren_depth == 0 && bracket_depth == 0 {
+        if ch == b';'
+            && brace_depth == 0
+            && paren_depth == 0
+            && bracket_depth == 0
+            // A brace-less `if (a) x = 1; else …` / `do x++; while (…)` keeps
+            // going: splitting here would orphan the `else` / `while` clause.
+            && !continues_after_semicolon(script, i + 1, script[stmt_start..=i].trim())
+        {
             let stmt = script[stmt_start..=i].trim().to_string();
             if !stmt.is_empty() {
                 statements.push(stmt);
@@ -1710,6 +1720,48 @@ fn split_top_level_statements(script: &str) -> Vec<String> {
     }
 
     statements
+}
+
+/// True when `s` begins with the bare keyword `kw` (followed by a non-identifier
+/// character), rather than an identifier that merely starts with those letters.
+fn starts_with_keyword(s: &str, kw: &str) -> bool {
+    s.trim_start().strip_prefix(kw).is_some_and(|after| {
+        after.is_empty()
+            || after.starts_with(|c: char| !c.is_alphanumeric() && c != '_' && c != '$')
+    })
+}
+
+/// True when the token at `pos` continues the statement `stmt_so_far` that the
+/// top-level `;` just ended — a brace-less `if`/`else` chain, or the `while`
+/// clause of a brace-less `do`.
+fn continues_after_semicolon(script: &str, pos: usize, stmt_so_far: &str) -> bool {
+    let rest = script[pos.min(script.len())..].trim_start();
+    if starts_with_keyword(rest, "else") {
+        return true;
+    }
+    starts_with_keyword(stmt_so_far, "do") && starts_with_keyword(rest, "while")
+}
+
+/// True when `s` is a labeled statement (`outer: for (…) {…}`). Ruled out for a
+/// ternary, whose `:` can never follow the leading identifier directly.
+fn is_labeled_statement(s: &str) -> bool {
+    let s = s.trim_start();
+    let mut chars = s.char_indices();
+    let Some((_, first)) = chars.next() else {
+        return false;
+    };
+    if !(first.is_alphabetic() || first == '_' || first == '$') {
+        return false;
+    }
+    let mut end = s.len();
+    for (i, c) in chars {
+        if !(c.is_alphanumeric() || c == '_' || c == '$') {
+            end = i;
+            break;
+        }
+    }
+    let rest = s[end..].trim_start();
+    rest.starts_with(':') && !rest.starts_with("::")
 }
 
 /// Check if the text after position `pos` starts a new statement keyword.
@@ -1948,6 +2000,15 @@ fn is_expression_statement(s: &str) -> bool {
     {
         // "throw" is a statement, not an expression
         // But it CAN be wrapped in a block thunk
+        return false;
+    }
+    // A bare block, a `do`/`debugger` statement and a labeled statement are all
+    // statements only: thunking them as `() => void (…)` would not parse.
+    if s.starts_with('{')
+        || starts_with_keyword(s, "do")
+        || starts_with_keyword(s, "debugger")
+        || is_labeled_statement(s)
+    {
         return false;
     }
     true

--- a/crates/rsvelte_core/tests/server_async_reparse_2315.rs
+++ b/crates/rsvelte_core/tests/server_async_reparse_2315.rs
@@ -1,0 +1,57 @@
+//! Issue #2315: statement shapes that the text-based async-body split used to
+//! emit as unparseable thunks. The reparse rejection silently degraded to an
+//! un-split instance body; now it is a hard compile error, and none of these
+//! shapes reject any more.
+
+use rsvelte_core::{CompileOptions, ExperimentalOptions, GenerateMode, compile};
+
+fn ssr_async(tail: &str) -> String {
+    let src =
+        format!("<script>\nlet a = await fetch('x');\nlet n = 0;\n{tail}\n</script>\n{{a}}{{n}}");
+    compile(
+        &src,
+        CompileOptions {
+            filename: Some("T.svelte".into()),
+            generate: GenerateMode::Server,
+            dev: false,
+            experimental: ExperimentalOptions { r#async: true },
+            ..Default::default()
+        },
+    )
+    .map(|r| r.js.code)
+    .unwrap_or_else(|e| format!("COMPILE_ERROR: {e:?}"))
+}
+
+/// The generated thunk array must itself be valid JS — assert the shape survived
+/// into the run array rather than falling back to an un-split body.
+fn assert_split(tail: &str, needle: &str) {
+    let out = ssr_async(tail);
+    assert!(!out.contains("COMPILE_ERROR"), "{tail}\n{out}");
+    assert!(out.contains("$$renderer.run("), "not split:\n{out}");
+    assert!(out.contains(needle), "missing `{needle}`:\n{out}");
+}
+
+#[test]
+fn do_while_keeps_its_while_clause() {
+    assert_split("do { n++; } while (n < 3);", "while (n < 3)");
+}
+
+#[test]
+fn labeled_statement_is_thunked_as_a_block() {
+    assert_split("outer: for (const q of [1]) { n += q; }", "outer:");
+}
+
+#[test]
+fn debugger_statement_is_thunked_as_a_block() {
+    assert_split("debugger;", "debugger");
+}
+
+#[test]
+fn bare_block_is_thunked_as_a_block() {
+    assert_split("{ n = 1; }", "n = 1");
+}
+
+#[test]
+fn braceless_if_else_stays_one_statement() {
+    assert_split("if (a) n = 1; else n = 2;", "else n = 2");
+}


### PR DESCRIPTION
Closes #2315

## What was achieved

**(1) Reproduced.** Five statement shapes make `ServerTransformState::reparse_program`
reject, all reachable from ordinary code with `experimental.async` on and a top-level
`await` in `<script>`:

| shape | oxc diagnostic |
|---|---|
| `do { n++; } while (n < 3);` | `Unexpected token` |
| `outer: for (const q of [1]) { … }` | ``Expected `,` or `)` but found `:` `` |
| `debugger;` | `Unexpected token` |
| `{ n = 1; }` (bare block) | ``Expected `,` or `}` but found `;` `` |
| `if (a) n = 1; else n = 2;` | `Unexpected token` |

The degradation is not literally an empty body: `transform_instance` falls through to
the un-split body when `reparse_program` returns empty, so what shipped was a
component whose `<script>` was never split for async — the awaited values never
resolve through `$$renderer.run`, with no diagnostic. Silently wrong either way.

**(2) The failure is loud in every profile.** The `debug_assert!` + env-gated stderr
pair is replaced by a real error: `reparse_program` records the diagnostics on the
transform state, `server_component_ast` returns `Result<String, String>`, and
`transform_server` maps it to `TransformError::CodeGen`. That mirrors what the seam
already documented for an internal assembly failure ("surfaces as an error rather
than silently falling back") and drops `RSVELTE_SERVER_REPARSE_DEBUG`.

**(3) The underlying rejections are fixed.** Two causes, both in the text-based
`shared/async_body.rs` split:

- `split_top_level_statements` ended a statement at a top-level `}` or `;` without
  checking for a continuation clause. Added: `while` continues a `do`, and `else`
  continues a brace-less `if` after a `;` (the `}` case already handled
  `else`/`catch`/`finally`).
- `is_expression_statement` treated anything not in a short keyword list as an
  expression, so a bare block, `do`, `debugger` and a labeled statement were thunked
  as `() => void (…)`. They are statements only, and now take the block-thunk path.

## Tests

`crates/rsvelte_core/tests/server_async_reparse_2315.rs` — the five shapes above, each
asserting the body is still split (`$$renderer.run(`) and the construct survived.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012gQPtKmdY9xwn5fjdwaxK8
