### PR TITLE
fix(fmt): apply `singleAttributePerLine` to block-child elements and `<script>`/`<style>` tags

### DIFF
--- a/.changeset/single-attribute-per-line-secondary-paths.md
+++ b/.changeset/single-attribute-per-line-secondary-paths.md
@@ -1,0 +1,10 @@
+---
+"@rsvelte/fmt": patch
+---
+
+Honour `singleAttributePerLine` in the two tag printers that ignored it. An element
+whose children are a whitespace-separated run of `{#if}` / `{@render}` nodes is
+re-printed by a separate doc path that joined attributes with a soft `line`, so the
+option was silently dropped; and the top-level `<script>` / `<style>` open tag only
+wrapped when it overflowed the print width. Both now break every attribute onto its
+own line for multi-attribute tags, matching `prettier-plugin-svelte`.

--- a/crates/rsvelte_formatter/src/collapse/children_port.rs
+++ b/crates/rsvelte_formatter/src/collapse/children_port.rs
@@ -309,7 +309,7 @@ pub(super) fn try_children_port(
 
     // Build the ElementLayout from the AST, recursively converting each child via
     // the faithful port (`node_to_child` bails on any unsupported child).
-    let attrs = build_attrs_concat(out, attributes)?;
+    let attrs = build_attrs_concat(out, attributes, options)?;
     let mut children: Vec<Child> = Vec::with_capacity(fragment.nodes.len());
     for n in &fragment.nodes {
         children.push(node_to_child(out, n, line_width, options)?);

--- a/crates/rsvelte_formatter/src/collapse/doc_build.rs
+++ b/crates/rsvelte_formatter/src/collapse/doc_build.rs
@@ -129,7 +129,7 @@ pub(super) fn build_inline_element_doc(
     options: &FormatOptions,
 ) -> Option<crate::doc::Doc> {
     use crate::children::{Child, ElementLayout, build_element_doc};
-    let attrs = build_attrs_concat(out, &e.attributes)?;
+    let attrs = build_attrs_concat(out, &e.attributes, options)?;
     let mut children: Vec<Child> = Vec::with_capacity(e.fragment.nodes.len());
     for n in &e.fragment.nodes {
         children.push(node_to_child(out, n, line_width, options)?);
@@ -155,7 +155,7 @@ pub(super) fn build_component_doc(
     options: &FormatOptions,
 ) -> Option<crate::doc::Doc> {
     use crate::children::{Child, ElementLayout, build_element_doc};
-    let attrs = build_attrs_concat(out, &c.attributes)?;
+    let attrs = build_attrs_concat(out, &c.attributes, options)?;
     let mut children: Vec<Child> = Vec::with_capacity(c.fragment.nodes.len());
     for n in &c.fragment.nodes {
         children.push(node_to_child(out, n, line_width, options)?);
@@ -184,11 +184,19 @@ pub(super) fn build_component_doc(
 pub(super) fn build_attrs_concat(
     out: &str,
     attrs: &[rsvelte_core::ast::template::Attribute],
+    options: &FormatOptions,
 ) -> Option<crate::doc::Doc> {
     use crate::doc::Doc;
     if attrs.is_empty() {
         return Some(Doc::Text(String::new()));
     }
+    // prettier's `attributeLine`: `singleAttributePerLine` joins a multi-attribute
+    // tag with `hardline` instead of `line`, so the tag breaks regardless of width.
+    let sep = if options.single_attribute_per_line && attrs.len() > 1 {
+        Doc::Hardline
+    } else {
+        Doc::Line
+    };
     let mut parts: Vec<Doc> = Vec::with_capacity(attrs.len() * 2);
     for attr in attrs {
         let (as_, ae) = attribute_span(attr);
@@ -196,7 +204,7 @@ pub(super) fn build_attrs_concat(
         if atext.contains('\n') {
             return None;
         }
-        parts.push(Doc::Line);
+        parts.push(sep.clone());
         parts.push(Doc::Text(atext.to_string()));
     }
     Some(Doc::Concat(parts))

--- a/crates/rsvelte_formatter/src/script.rs
+++ b/crates/rsvelte_formatter/src/script.rs
@@ -245,11 +245,15 @@ pub(crate) fn format_open_tag(
     let normalized = normalize_open_tag(tag);
     let line_width = options.js.line_width.value() as usize;
     let indent_width = options.js.indent_width.value() as usize;
-    let result = if normalized.len() > line_width {
-        // The normalized flat tag overflows the print width — wrap each
-        // attribute onto its own line at one level of indent (the top-level
-        // `<script>` / `<style>` block is always at depth 0).
-        wrap_script_open_tag(&normalized, indent_width).unwrap_or(normalized)
+    // The wrapped form puts each attribute on its own line at one level of indent
+    // (the top-level `<script>` / `<style>` block is always at depth 0). It is used
+    // when the flat tag overflows the print width, and — like prettier's
+    // `attributeLine` — whenever `singleAttributePerLine` meets >1 attribute.
+    let wrapped = wrap_script_open_tag(&normalized, indent_width);
+    let force_single_attr =
+        options.single_attribute_per_line && wrapped.as_ref().is_some_and(|(_, n)| *n > 1);
+    let result = if normalized.len() > line_width || force_single_attr {
+        wrapped.map_or(normalized, |(tag, _)| tag)
     } else {
         normalized
     };
@@ -269,8 +273,9 @@ pub(crate) fn format_open_tag(
 /// >
 /// ```
 ///
-/// Returns `None` when the tag can't be parsed (e.g. no attributes).
-fn wrap_script_open_tag(tag: &str, indent_width: usize) -> Option<String> {
+/// Returns the wrapped tag and its attribute count, or `None` when the tag can't
+/// be parsed (e.g. no attributes).
+fn wrap_script_open_tag(tag: &str, indent_width: usize) -> Option<(String, usize)> {
     // Strip the leading `<` and trailing `>`.
     let inner = tag.strip_prefix('<')?.strip_suffix('>')?;
     // Split tag name from attributes. Tag name is everything up to the first
@@ -338,7 +343,7 @@ fn wrap_script_open_tag(tag: &str, indent_width: usize) -> Option<String> {
         out.push_str(attr);
     }
     out.push_str("\n>");
-    Some(out)
+    Some((out, attrs.len()))
 }
 
 /// Normalize whitespace and quote styles in a `<script …>` / `<style …>` open

--- a/crates/rsvelte_formatter/tests/options.rs
+++ b/crates/rsvelte_formatter/tests/options.rs
@@ -46,6 +46,63 @@ fn single_attribute_per_line_default_off_stays_flat() {
     assert_eq!(out, "<div class=\"a\" id=\"b\" role=\"c\"></div>\n");
 }
 
+#[test]
+fn single_attribute_per_line_breaks_over_block_children() {
+    let opts = FormatOptions {
+        single_attribute_per_line: true,
+        ..FormatOptions::default()
+    };
+    for child in [
+        "{#if y}z{/if}",
+        "{@render kids()}",
+        "{#each xs as x}{x}{/each}",
+    ] {
+        let out = fmt(
+            &format!("<div class=\"a\" id=\"b\">\n  {child}\n</div>\n"),
+            &opts,
+        );
+        assert_eq!(
+            out,
+            format!("<div\n  class=\"a\"\n  id=\"b\"\n>\n  {child}\n</div>\n"),
+            "child: {child}"
+        );
+    }
+}
+
+#[test]
+fn single_attribute_per_line_breaks_script_and_style_tags() {
+    let opts = FormatOptions {
+        single_attribute_per_line: true,
+        ..FormatOptions::default()
+    };
+    let out = fmt(
+        "<script lang=\"ts\" module>\n  let a = 1;\n</script>\n",
+        &opts,
+    );
+    assert_eq!(
+        out,
+        "<script\n  lang=\"ts\"\n  module\n>\n  let a = 1;\n</script>\n"
+    );
+    let out = fmt(
+        "<style lang=\"postcss\" global>\n  a {\n    color: red;\n  }\n</style>\n",
+        &opts,
+    );
+    assert!(
+        out.starts_with("<style\n  lang=\"postcss\"\n  global\n>\n"),
+        "style tag not broken:\n{out}"
+    );
+}
+
+#[test]
+fn single_attribute_per_line_keeps_single_attr_script_inline() {
+    let opts = FormatOptions {
+        single_attribute_per_line: true,
+        ..FormatOptions::default()
+    };
+    let out = fmt("<script lang=\"ts\">\n  let a = 1;\n</script>\n", &opts);
+    assert_eq!(out, "<script lang=\"ts\">\n  let a = 1;\n</script>\n");
+}
+
 // ─── svelteAllowShorthand ────────────────────────────────────────────────
 
 #[test]


### PR DESCRIPTION
`singleAttributePerLine` was consulted by the main open-tag printer but not by two
secondary tag-printing paths, so the same option produced two different layouts in
one file.

**#2296 — elements whose children are a `{#if}` / `{@render}` block run.**
`collapse::children_port` re-prints such an element from its own Doc model (it owns
the whitespace-separated block-run shape). `build_attrs_concat` joined attributes
with a soft `line`, which the group then kept flat, discarding the option. Other
constructs (`{#each}`, `{#key}`, elements) never enter this path, which is why only
these two child kinds were affected. It now uses `hardline` for multi-attribute tags,
mirroring prettier-plugin-svelte's `attributeLine`.

**#2297 — top-level `<script>` / `<style>` open tags.** `script::format_open_tag`
already had a wrapping form but only reached for it when the flat tag exceeded the
print width. It now also wraps when `singleAttributePerLine` meets more than one
attribute.

Both verified byte-for-byte against an `oxfmt(svelte: true)` oracle run on the
issues' exact repros. Regression tests added to
`crates/rsvelte_formatter/tests/options.rs`.

Closes #2296
Closes #2297

Thanks to @nmontavon for both reports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012gQPtKmdY9xwn5fjdwaxK8
