### PR TITLE
fix(compiler): match `$` in rune declaration names in `.svelte.js` modules

### DIFF
--- a/.changeset/module-dollar-in-rune-var-name.md
+++ b/.changeset/module-dollar-in-rune-var-name.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/compiler": patch
+---
+
+Recognise `$state` / `$derived` declarations in `.svelte.(js|ts)` modules whose variable name contains a `$` (e.g. `const delay$ = $derived(...)`), so their reads are unwrapped to `$.get(delay$)` on the client and `delay$()` on the server instead of leaking the raw signal.

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
@@ -125,7 +125,8 @@ pub(super) static REGEX_STATE_DERIVED_VAR: LazyLock<Regex> = LazyLock::new(|| {
     // (`x[key]`) and writes (`x = next`) are never rewritten through
     // `$.get`/`$.set`, so consumers see the raw source object instead of
     // the value (see baseballyama/rsvelte#143).
-    Regex::new(r"(let|const|var)\s+(\w+)(?:\s*:[^=\n]*)?\s*=\s*\$(?:state(?:\.raw|\.frozen)?|derived(?:\.by)?)(?:<[^(]*>)?\s*\(").unwrap()
+    // `$` is a JS identifier character, so names like `delay$` must be captured too.
+    Regex::new(r"(let|const|var)\s+([\w$]+)(?:\s*:[^=\n]*)?\s*=\s*\$(?:state(?:\.raw|\.frozen)?|derived(?:\.by)?)(?:<[^(]*>)?\s*\(").unwrap()
 });
 
 // Regex for sanitizing identifier names - replaces invalid identifier characters

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/tests.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/tests.rs
@@ -1675,3 +1675,41 @@ fn await_reactivity_loss_is_wrapped_unless_ignored() {
         "an unrelated svelte-ignore line must not end the scan:\n{stacked}"
     );
 }
+
+#[test]
+fn module_derived_name_containing_dollar_is_unwrapped() {
+    let source = r#"
+export function useInterval(callback, delay) {
+	const delay$ = $derived(typeof delay === 'function' ? delay() : delay);
+	let intervalId;
+	function start() { intervalId = setInterval(callback, delay$); }
+	return { start };
+}
+"#;
+
+    let compile = |generate| {
+        crate::compiler::compile_module(
+            source,
+            crate::compiler::ModuleCompileOptions {
+                generate,
+                filename: Some("use-interval.svelte.js".to_string()),
+                ..Default::default()
+            },
+        )
+        .unwrap()
+        .js
+        .code
+    };
+
+    let client = compile(crate::compiler::GenerateMode::Client);
+    assert!(
+        client.contains("setInterval(callback, $.get(delay$))"),
+        "derived read should be unwrapped on the client:\n{client}"
+    );
+
+    let server = compile(crate::compiler::GenerateMode::Server);
+    assert!(
+        server.contains("setInterval(callback, delay$())"),
+        "derived read should be called on the server:\n{server}"
+    );
+}


### PR DESCRIPTION
Closes #2301

A `$state` / `$derived` declaration in a `.svelte.(js|ts)` module is discovered by
`extract_local_reactive_vars`, whose regex captured the variable name with `(\w+)`.
`\w` is `[0-9A-Za-z_]`, so a name containing `$` — a perfectly valid JS identifier
character — never matched. The binding was therefore never registered as reactive and
none of its reads were rewritten:

```js
const delay$ = $derived(typeof delay === 'function' ? delay() : delay);
…
intervalId = setInterval(runCallback, delay$);          // rsvelte (before)
intervalId = setInterval(runCallback, $.get(delay$));   // official (client)
intervalId = setInterval(runCallback, delay$());        // official (server)
```

The fix widens the capture to `([\w$]+)`. The server module path runs the client module
transform and then lowers `$.get(x)` → `x()`, so both targets are fixed by the one change.

The issue title says "call argument", but the trigger is not the call position — the
`$` in the identifier is. Every read position was affected equally (assignment RHS,
binary operand, template literal, call argument); the corpus diff just happened to
surface the call-argument ones. `runed`'s `use-debounce` / `use-interval` name their
derived values `wait$` / `delay$`, which is why the whole convention was broken.

Severity is production correctness: `setTimeout(fn, delay$)` receives a signal object
where a number is expected, coerces to `NaN`, and is treated as `0` — a debounce or
interval silently loses its delay.

Adjacent to but distinct from #2323: that one is the `bind:` setter target in the
component transform; this one is the module-path rune declaration scanner. No overlap
in code or in repro.

Reported by @MathiasWP while enrolling `runed` / `svelte-toolbelt` into the compat corpus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012gQPtKmdY9xwn5fjdwaxK8
