### PR TITLE
fix(compiler): eleven dev-mode instrumentation divergences

### DIFF
--- a/.changeset/dev-assign-async-lazy-getter.md
+++ b/.changeset/dev-assign-async-lazy-getter.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/compiler": patch
+---
+
+Hoist the `await` out of an `$.assign_async` lazy getter and instrument it

--- a/.changeset/dev-assign-component-in-element.md
+++ b/.changeset/dev-assign-component-in-element.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/compiler": patch
+---
+
+Keep the dev `$.assign` coerced-proxy warning on a component-prop arrow when the component is nested inside an element

--- a/.changeset/dev-assign-site-consumed.md
+++ b/.changeset/dev-assign-site-consumed.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/compiler": patch
+---
+
+Stop an untransformed `$.assign` site from lending its position to a later twin

--- a/.changeset/dev-await-open-statement-separator.md
+++ b/.changeset/dev-await-open-statement-separator.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/compiler": patch
+---
+
+Separate a wrapped `await` statement from any preceding statement ASI left open

--- a/.changeset/dev-bind-setter-ownership.md
+++ b/.changeset/dev-bind-setter-ownership.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/compiler": patch
+---
+
+Validate a component `bind:` setter that mutates a member of a non-bindable prop in dev

--- a/.changeset/dev-console-wrap-shadowing.md
+++ b/.changeset/dev-console-wrap-shadowing.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/compiler": patch
+---
+
+Resolve a shadowed name through the scope chain a script reference sees when deciding whether to wrap a dev `console.*` call

--- a/.changeset/dev-css-pruned-selector-map.md
+++ b/.changeset/dev-css-pruned-selector-map.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/compiler": patch
+---
+
+Map the selectors of a partially pruned rule in the injected stylesheet's dev source map

--- a/.changeset/dev-destructured-async-assignment.md
+++ b/.changeset/dev-destructured-async-assignment.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/compiler": patch
+---
+
+Stop instrumenting the generated IIFE of an async destructuring assignment in dev

--- a/.changeset/dev-destructuring-default-equality.md
+++ b/.changeset/dev-destructuring-default-equality.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/compiler": patch
+---
+
+Apply the dev equality instrumentation to a `$derived` destructuring default

--- a/.changeset/dev-inspect-trace-label.md
+++ b/.changeset/dev-inspect-trace-label.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/compiler": patch
+---
+
+Ignore comments when locating the function a `$inspect.trace()` label points at

--- a/.changeset/dev-ownership-invalidate-sequence.md
+++ b/.changeset/dev-ownership-invalidate-sequence.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/compiler": patch
+---
+
+Put the legacy `$.invalidate_inner_signals` sequence inside the dev ownership-mutation wrap instead of around it

--- a/.changeset/dev-state-tag-proxy.md
+++ b/.changeset/dev-state-tag-proxy.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/compiler": patch
+---
+
+Label a proxied `$state` initializer with `$.tag_proxy` in dev, including one declared in a template handler body and one whose value is an equality comparison

--- a/compatibility/known-failures.client-dev.json
+++ b/compatibility/known-failures.client-dev.json
@@ -1,7 +1,6 @@
 [
 	"flowbite-svelte/src/routes/utils/CompoAttributesViewer.svelte",
 	"skeleton/packages/skeleton-svelte/src/components/portal/anatomy/root.svelte",
-	"svar-core/site/src/Demo.svelte",
 	"svelte-ux/packages/svelte-ux/src/lib/components/MultiSelect.svelte",
 	"svelte.dev/apps/svelte.dev/content/docs/svelte/02-runes/07-$inspect.md/3.svelte",
 	"svelte/documentation/docs/02-runes/07-$inspect.md/3.svelte",
@@ -10,7 +9,6 @@
 	"svelte/packages/svelte/tests/runtime-runes/samples/destructure-async-assignments/main.svelte",
 	"svelte/packages/svelte/tests/runtime-runes/samples/event-attribute-delegation-6/main.svelte",
 	"svelte/packages/svelte/tests/runtime-runes/samples/proxy-coercive-assignment-warning/main.svelte",
-	"svelte/packages/svelte/tests/runtime-runes/samples/state-in-template/main.svelte",
 	"svelte/packages/svelte/tests/server-side-rendering/samples/css-injected-options-minify/main.svelte",
 	"svelthree/src/lib/components/WebGLRenderer.svelte"
 ]

--- a/compatibility/known-failures.client-dev.json
+++ b/compatibility/known-failures.client-dev.json
@@ -1,6 +1,5 @@
 [
 	"flowbite-svelte/src/routes/utils/CompoAttributesViewer.svelte",
-	"skeleton/packages/skeleton-svelte/src/components/portal/anatomy/root.svelte",
 	"svelte-ux/packages/svelte-ux/src/lib/components/MultiSelect.svelte",
 	"svelte.dev/apps/svelte.dev/content/docs/svelte/02-runes/07-$inspect.md/3.svelte",
 	"svelte/documentation/docs/02-runes/07-$inspect.md/3.svelte",

--- a/compatibility/known-failures.client-dev.json
+++ b/compatibility/known-failures.client-dev.json
@@ -1,8 +1,5 @@
 [
-	"flowbite-svelte/src/routes/utils/CompoAttributesViewer.svelte",
-	"svelte-ux/packages/svelte-ux/src/lib/components/MultiSelect.svelte",
 	"svelte/packages/svelte/tests/runtime-runes/samples/assignment-value-stale-lazy-rhs-async/main.svelte",
-	"svelte/packages/svelte/tests/runtime-runes/samples/destructure-async-assignments/main.svelte",
 	"svelte/packages/svelte/tests/runtime-runes/samples/proxy-coercive-assignment-warning/main.svelte",
 	"svelte/packages/svelte/tests/server-side-rendering/samples/css-injected-options-minify/main.svelte",
 	"svelthree/src/lib/components/WebGLRenderer.svelte"

--- a/compatibility/known-failures.client-dev.json
+++ b/compatibility/known-failures.client-dev.json
@@ -2,8 +2,6 @@
 	"flowbite-svelte/src/routes/utils/CompoAttributesViewer.svelte",
 	"skeleton/packages/skeleton-svelte/src/components/portal/anatomy/root.svelte",
 	"svar-core/site/src/Demo.svelte",
-	"svelte-form-builder/src/lib/Form/PropertyPanel/PropertyPanelComponentSpecific/PropertyPanelChoiceCheckboxRadioSpecific.svelte",
-	"svelte-form-builder/src/lib/Form/PropertyPanel/PropertyPanelTooltip.svelte",
 	"svelte-ux/packages/svelte-ux/src/lib/components/MultiSelect.svelte",
 	"svelte.dev/apps/svelte.dev/content/docs/svelte/02-runes/07-$inspect.md/3.svelte",
 	"svelte.dev/apps/svelte.dev/src/routes/tutorial/[...slug]/Controls.svelte",

--- a/compatibility/known-failures.client-dev.json
+++ b/compatibility/known-failures.client-dev.json
@@ -1,10 +1,8 @@
 [
 	"flowbite-svelte/src/routes/utils/CompoAttributesViewer.svelte",
 	"svelte-ux/packages/svelte-ux/src/lib/components/MultiSelect.svelte",
-	"svelte/packages/svelte/tests/runtime-legacy/samples/module-context-export/Foo.svelte",
 	"svelte/packages/svelte/tests/runtime-runes/samples/assignment-value-stale-lazy-rhs-async/main.svelte",
 	"svelte/packages/svelte/tests/runtime-runes/samples/destructure-async-assignments/main.svelte",
-	"svelte/packages/svelte/tests/runtime-runes/samples/event-attribute-delegation-6/main.svelte",
 	"svelte/packages/svelte/tests/runtime-runes/samples/proxy-coercive-assignment-warning/main.svelte",
 	"svelte/packages/svelte/tests/server-side-rendering/samples/css-injected-options-minify/main.svelte",
 	"svelthree/src/lib/components/WebGLRenderer.svelte"

--- a/compatibility/known-failures.client-dev.json
+++ b/compatibility/known-failures.client-dev.json
@@ -4,8 +4,6 @@
 	"svar-core/site/src/Demo.svelte",
 	"svelte-ux/packages/svelte-ux/src/lib/components/MultiSelect.svelte",
 	"svelte.dev/apps/svelte.dev/content/docs/svelte/02-runes/07-$inspect.md/3.svelte",
-	"svelte.dev/apps/svelte.dev/src/routes/tutorial/[...slug]/Controls.svelte",
-	"svelte.dev/packages/repl/src/lib/Input/ComponentSelector.svelte",
 	"svelte/documentation/docs/02-runes/07-$inspect.md/3.svelte",
 	"svelte/packages/svelte/tests/runtime-legacy/samples/module-context-export/Foo.svelte",
 	"svelte/packages/svelte/tests/runtime-runes/samples/assignment-value-stale-lazy-rhs-async/main.svelte",

--- a/compatibility/known-failures.client-dev.json
+++ b/compatibility/known-failures.client-dev.json
@@ -1,8 +1,6 @@
 [
 	"flowbite-svelte/src/routes/utils/CompoAttributesViewer.svelte",
 	"svelte-ux/packages/svelte-ux/src/lib/components/MultiSelect.svelte",
-	"svelte.dev/apps/svelte.dev/content/docs/svelte/02-runes/07-$inspect.md/3.svelte",
-	"svelte/documentation/docs/02-runes/07-$inspect.md/3.svelte",
 	"svelte/packages/svelte/tests/runtime-legacy/samples/module-context-export/Foo.svelte",
 	"svelte/packages/svelte/tests/runtime-runes/samples/assignment-value-stale-lazy-rhs-async/main.svelte",
 	"svelte/packages/svelte/tests/runtime-runes/samples/destructure-async-assignments/main.svelte",

--- a/compatibility/known-failures.client-dev.json
+++ b/compatibility/known-failures.client-dev.json
@@ -1,8 +1,6 @@
 [
 	"flowbite-svelte/src/routes/utils/CompoAttributesViewer.svelte",
 	"skeleton/packages/skeleton-svelte/src/components/portal/anatomy/root.svelte",
-	"skeleton/sites/themes.skeleton.dev/src/lib/components/generator/Controls/Controls.svelte",
-	"skeleton/sites/themes.skeleton.dev/src/lib/components/generator/Controls/ControlsColors.svelte",
 	"svar-core/site/src/Demo.svelte",
 	"svelte-form-builder/src/lib/Form/PropertyPanel/PropertyPanelComponentSpecific/PropertyPanelChoiceCheckboxRadioSpecific.svelte",
 	"svelte-form-builder/src/lib/Form/PropertyPanel/PropertyPanelTooltip.svelte",

--- a/compatibility/known-failures.client-dev.json
+++ b/compatibility/known-failures.client-dev.json
@@ -1,6 +1,1 @@
-[
-	"svelte/packages/svelte/tests/runtime-runes/samples/assignment-value-stale-lazy-rhs-async/main.svelte",
-	"svelte/packages/svelte/tests/runtime-runes/samples/proxy-coercive-assignment-warning/main.svelte",
-	"svelte/packages/svelte/tests/server-side-rendering/samples/css-injected-options-minify/main.svelte",
-	"svelthree/src/lib/components/WebGLRenderer.svelte"
-]
+[]

--- a/compatibility/known-failures.md
+++ b/compatibility/known-failures.md
@@ -46,7 +46,7 @@ quoted key dropped in a destructured `$derived`) and #2034 (`$.to_array` arity
 with a rest element) — were resolved by #2036, which mirrored #2010's client
 destructuring fixes onto the server target.
 
-## Client dev (`known-failures.client-dev.json`, 9 entries)
+## Client dev (`known-failures.client-dev.json`, 7 entries)
 
 The `client-dev` target is the `client` target with `dev: true`. It is a
 separate ratchet because `dev` gates 18 client codegen files plus the CSS
@@ -169,6 +169,13 @@ Locating the traced function past a comment took it to 9. The `$inspect.trace()`
 label carries `locate_node(fn)`, which rsvelte finds by scanning backwards from
 the call — and a comment between the function head and the call answered for it.
 
+Resolving a shadowed name through the scope chain a script reference actually
+sees took it to 7. Two things fed the `console.*` wrap's `scope.evaluate`
+lookup the wrong binding: a legacy instance declaration wrote its initializer
+onto a same-named module binding (the write resolved through the root scope's
+declarations only), and a template binding — an each item — stayed a candidate
+for a reference inside the instance script.
+
 ### How the counts below are derived
 
 The enrolment-era table attributed each entry by its **first differing line**.
@@ -184,7 +191,6 @@ each side, which separates the two directions and cannot be fooled by order:
 | Cluster | under-emits | over-emits | Upstream emitter (`phases/3-transform/client/`) | Issue |
 |---|---:|---:|---|---|
 | `$.track_reactivity_loss(...)` | 0 | 3 | `visitors/AwaitExpression.js` | #2064 |
-| `console.*` wrapping | 0 | 2 | `visitors/CallExpression.js` | #2064 |
 
 The ownership row is now empty as well: the preamble half went first, then the
 call-site half, once every prop-rooted `bind:` setter reached
@@ -199,7 +205,7 @@ the two halves that had no equivalent on the JSON expression path (the value
 must be used, and the component-prop exemption only covers a component that is
 a `Fragment` child).
 
-5 entries are attributed to a cluster; the remaining **4** show no
+3 entries are attributed to a cluster; the remaining **4** show no
 difference in any dev helper: 1 is a statement missing from a legacy `$:` body, 1 is the ` /* (unused) ` marker's own
 mapping in a minified stylesheet and 2 are one-off shapes (an `$.assign`
 location, an `$.assign_async` wrap). All are tracked in #2064. The legacy `bind:` `function get()/set()` shape was 47

--- a/compatibility/known-failures.md
+++ b/compatibility/known-failures.md
@@ -46,7 +46,7 @@ quoted key dropped in a destructured `$derived`) and #2034 (`$.to_array` arity
 with a rest element) — were resolved by #2036, which mirrored #2010's client
 destructuring fixes onto the server target.
 
-## Client dev (`known-failures.client-dev.json`, 12 entries)
+## Client dev (`known-failures.client-dev.json`, 11 entries)
 
 The `client-dev` target is the `client` target with `dev: true`. It is a
 separate ratchet because `dev` gates 18 client codegen files plus the CSS
@@ -161,6 +161,10 @@ therefore proxies (an arithmetic `BinaryExpression` still does not); and a
 `$state` declared inside a template handler body reaches the expression
 converter, which had no way back to the declarator's name.
 
+Instrumenting a `$derived` destructuring default took it to 11. The pattern's
+source text was lifted verbatim before the walk reached it, so a default value
+never got the dev equality rewrite any other expression gets.
+
 ### How the counts below are derived
 
 The enrolment-era table attributed each entry by its **first differing line**.
@@ -175,7 +179,6 @@ each side, which separates the two directions and cannot be fooled by order:
 
 | Cluster | under-emits | over-emits | Upstream emitter (`phases/3-transform/client/`) | Issue |
 |---|---:|---:|---|---|
-| equality instrumentation | 1 | 0 | `visitors/BinaryExpression.js` | #2064 |
 | `$.track_reactivity_loss(...)` | 0 | 3 | `visitors/AwaitExpression.js` | #2064 |
 | `console.*` wrapping | 0 | 2 | `visitors/CallExpression.js` | #2064 |
 
@@ -192,7 +195,7 @@ the two halves that had no equivalent on the JSON expression path (the value
 must be used, and the component-prop exemption only covers a component that is
 a `Fragment` child).
 
-6 entries are attributed to a cluster; the remaining **6** show no
+5 entries are attributed to a cluster; the remaining **6** show no
 difference in any dev helper: 2 are a `$.trace` label's line:column, 1 is a
 statement missing from a legacy `$:` body, 1 is the ` /* (unused) ` marker's own
 mapping in a minified stylesheet and 2 are one-off shapes (an `$.assign`

--- a/compatibility/known-failures.md
+++ b/compatibility/known-failures.md
@@ -46,7 +46,7 @@ quoted key dropped in a destructured `$derived`) and #2034 (`$.to_array` arity
 with a rest element) — were resolved by #2036, which mirrored #2010's client
 destructuring fixes onto the server target.
 
-## Client dev (`known-failures.client-dev.json`, 20 entries)
+## Client dev (`known-failures.client-dev.json`, 18 entries)
 
 The `client-dev` target is the `client` target with `dev: true`. It is a
 separate ratchet because `dev` gates 18 client codegen files plus the CSS
@@ -137,6 +137,12 @@ took it to 20. That half of upstream's condition had no equivalent there, so a
 bare assignment statement inside an `{@attach}` block body was wrapped even
 though its value is discarded.
 
+Restricting the component-prop exemption to a component that is a `Fragment`
+child took it to 18. Upstream spells it `path.at(-2) === 'Component' &&
+path.at(-3) === 'Fragment'`, and an element's children are the one container it
+does not visit through a `Fragment` node, so a component nested in an element
+keeps the wrap.
+
 ### How the counts below are derived
 
 The enrolment-era table attributed each entry by its **first differing line**.
@@ -151,7 +157,6 @@ each side, which separates the two directions and cannot be fooled by order:
 
 | Cluster | under-emits | over-emits | Upstream emitter (`phases/3-transform/client/`) | Issue |
 |---|---:|---:|---|---|
-| `$.assign` / `$.assign_async` | 2 | 2 | `visitors/AssignmentExpression.js` | #2064 |
 | equality instrumentation | 1 | 0 | `visitors/BinaryExpression.js` | #2064 |
 | `$.track_reactivity_loss(...)` | 0 | 3 | `visitors/AwaitExpression.js` | #2064 |
 | ownership mutation validation | 2 | 0 | `transform-client.js`, `visitors/shared/{component,utils}.js` | #2027 |
@@ -168,7 +173,12 @@ The signal read/write row is now empty: `$state` reassignment is resolved per
 binding rather than per name, so same-named `$state` locals in sibling scopes no
 longer share one classification and lose their `$.state(...)` wrapper.
 
-12 entries are attributed to a cluster; the remaining **8** show no
+The `$.assign` row is now empty too: its condition is fully ported, including
+the two halves that had no equivalent on the JSON expression path (the value
+must be used, and the component-prop exemption only covers a component that is
+a `Fragment` child).
+
+10 entries are attributed to a cluster; the remaining **8** show no
 difference in any dev helper: 2 are a `$.trace` label's line:column, 2 are
 redundant parentheses around an ownership wrapper, 1 is a statement missing
 from a legacy `$:` body, 1 is the ` /* (unused) ` marker's own mapping in a
@@ -179,19 +189,6 @@ hands the element `bind:` path the unthunked getter body plus the setter body,
 so `dev` can emit upstream's named accessors (`BindDirective.js:46-54`). The
 component `bind:` path keeps consuming the same bodies for its object-literal
 `get`/`set` methods.
-
-### What is left of the `$.assign` row
-
-`$.assign(object, 'prop', operator, value, location)` is upstream's dev warning
-for a coerced-away proxy (`AssignmentExpression.js:170-236`): it fires only when
-the assignment's *value* is used (`path.at(-1) !== 'ExpressionStatement'`), the
-operator is non-coercive, and the right-hand side is not a known primitive.
-rsvelte emits it from the template paths (`expression_converter`, `attribute`)
-but has no collector on the instance / module script paths, so a `(obj.prop =
-value)` written inside a script — most often inside a `new Promise((resolve) =>
-…)` — stays bare. The location argument is what makes this more than a copy of
-`instance_dev_tail_ast`'s other collectors: it is a position in the *original*
-`.svelte` source, and those passes run over already-settled transform output.
 
 ### What is left of the equality and await rows
 

--- a/compatibility/known-failures.md
+++ b/compatibility/known-failures.md
@@ -46,7 +46,7 @@ quoted key dropped in a destructured `$derived`) and #2034 (`$.to_array` arity
 with a rest element) — were resolved by #2036, which mirrored #2010's client
 destructuring fixes onto the server target.
 
-## Client dev (`known-failures.client-dev.json`, 4 entries)
+## Client dev (`known-failures.client-dev.json`, 0 entries)
 
 The `client-dev` target is the `client` target with `dev: true`. It is a
 separate ratchet because `dev` gates 18 client codegen files plus the CSS
@@ -181,20 +181,24 @@ await …` is lowered to `await (async ($$value) => { … })(…)`, and the dev
 `await` pass wrapped that generated call as well as the source `await` it was
 built around — upstream destructures after a single instrumented `await`.
 
+Four last fixes took it to 0. `build_assignment` hands the `await` it adds to
+`context.visit`, so `$.assign_async(…)` is instrumented like any other `await`
+while `arrow` (`utils/builders.js`) collapses the lazy getter it wraps back to a
+synchronous `() => x()`. A site the transform decision rejects still has to be
+spent, or a later identical member chain reports its position. The dev `await`
+wrapper opens with `(`, so it continues *any* statement ASI left open — not just
+another wrapped `await`, which is all the previous check covered. And in a
+partially pruned selector list the `/* (unused) ` markers are `prependRight` /
+`appendRight` insertions while the separator before a pruned selector goes
+through `overwrite`, which keeps the chunk it replaces — so both selectors and
+that separator still carry source-map segments.
+
 ### What is left
 
-Every dev-helper cluster the enrolment-era table tracked — `$.assign`, the
-equality instrumentation, `$.track_reactivity_loss`, ownership mutation
-validation, `$.tag()` / `$.tag_proxy()`, `console.*` wrapping and the signal
-read/write row — is now empty: no remaining entry emits any of them a different
-number of times from upstream.
-
-The 4 that remain show no dev-helper difference at all. One is a statement
-missing from a legacy `$:` body, one is the ` /* (unused) ` marker's own mapping
-in a minified stylesheet (upstream inserts it with `overwrite`, which consumes
-the separator it replaces and emits a segment — the skip-only alignment in
-`css.rs` cannot express that), and two are one-off shapes: an `$.assign`
-location and an `$.assign_async` wrap. All are tracked in #2064.
+Nothing. All three targets are at 0, and every dev-helper cluster the
+enrolment-era table tracked — `$.assign`, the equality instrumentation,
+`$.track_reactivity_loss`, ownership mutation validation, `$.tag()` /
+`$.tag_proxy()`, `console.*` wrapping and the signal read/write row — is empty.
 
 Counting method, for whoever picks this up: attribute an entry by **comparing
 how many times each helper appears** on each side, never by the first differing

--- a/compatibility/known-failures.md
+++ b/compatibility/known-failures.md
@@ -46,7 +46,7 @@ quoted key dropped in a destructured `$derived`) and #2034 (`$.to_array` arity
 with a rest element) — were resolved by #2036, which mirrored #2010's client
 destructuring fixes onto the server target.
 
-## Client dev (`known-failures.client-dev.json`, 7 entries)
+## Client dev (`known-failures.client-dev.json`, 4 entries)
 
 The `client-dev` target is the `client` target with `dev: true`. It is a
 separate ratchet because `dev` gates 18 client codegen files plus the CSS
@@ -176,126 +176,33 @@ onto a same-named module binding (the write resolved through the root scope's
 declarations only), and a template binding — an each item — stayed a candidate
 for a reference inside the instance script.
 
-### How the counts below are derived
+Leaving the async-destructuring IIFE uninstrumented took it to 4. `[a, b] =
+await …` is lowered to `await (async ($$value) => { … })(…)`, and the dev
+`await` pass wrapped that generated call as well as the source `await` it was
+built around — upstream destructures after a single instrumented `await`.
 
-The enrolment-era table attributed each entry by its **first differing line**.
-That is a trap this campaign hit four times: a pure statement **reordering**
-reports as the helper on the expected side being *absent*, so a positioning bug
-reads as an unported feature. #2020, #2022 and #2023 were all filed as "not
-emitted" and all turned out to be emitted in the right number and the wrong
-place.
+### What is left
 
-The table is now derived by **comparing how many times each helper appears** on
-each side, which separates the two directions and cannot be fooled by order:
+Every dev-helper cluster the enrolment-era table tracked — `$.assign`, the
+equality instrumentation, `$.track_reactivity_loss`, ownership mutation
+validation, `$.tag()` / `$.tag_proxy()`, `console.*` wrapping and the signal
+read/write row — is now empty: no remaining entry emits any of them a different
+number of times from upstream.
 
-| Cluster | under-emits | over-emits | Upstream emitter (`phases/3-transform/client/`) | Issue |
-|---|---:|---:|---|---|
-| `$.track_reactivity_loss(...)` | 0 | 3 | `visitors/AwaitExpression.js` | #2064 |
+The 4 that remain show no dev-helper difference at all. One is a statement
+missing from a legacy `$:` body, one is the ` /* (unused) ` marker's own mapping
+in a minified stylesheet (upstream inserts it with `overwrite`, which consumes
+the separator it replaces and emits a segment — the skip-only alignment in
+`css.rs` cannot express that), and two are one-off shapes: an `$.assign`
+location and an `$.assign_async` wrap. All are tracked in #2064.
 
-The ownership row is now empty as well: the preamble half went first, then the
-call-site half, once every prop-rooted `bind:` setter reached
-`validate_mutation`.
+Counting method, for whoever picks this up: attribute an entry by **comparing
+how many times each helper appears** on each side, never by the first differing
+line. A pure statement **reordering** reports as the helper on the expected side
+being *absent*, so a positioning bug reads as an unported feature — #2020, #2022
+and #2023 were all filed as "not emitted" and all turned out to be emitted in
+the right number and the wrong place.
 
-The signal read/write row is now empty: `$state` reassignment is resolved per
-binding rather than per name, so same-named `$state` locals in sibling scopes no
-longer share one classification and lose their `$.state(...)` wrapper.
-
-The `$.assign` row is now empty too: its condition is fully ported, including
-the two halves that had no equivalent on the JSON expression path (the value
-must be used, and the component-prop exemption only covers a component that is
-a `Fragment` child).
-
-3 entries are attributed to a cluster; the remaining **4** show no
-difference in any dev helper: 1 is a statement missing from a legacy `$:` body, 1 is the ` /* (unused) ` marker's own
-mapping in a minified stylesheet and 2 are one-off shapes (an `$.assign`
-location, an `$.assign_async` wrap). All are tracked in #2064. The legacy `bind:` `function get()/set()` shape was 47
-entries of that residue and is fixed: `build_each_block_accessor_parts` now
-hands the element `bind:` path the unthunked getter body plus the setter body,
-so `dev` can emit upstream's named accessors (`BindDirective.js:46-54`). The
-component `bind:` path keeps consuming the same bodies for its object-literal
-`get`/`set` methods.
-
-### What is left of the equality and await rows
-
-Both rewrites ride the instance-script AST pass, which sat under
-`if analysis.runes` — so a legacy (non-runes) component was never instrumented
-at all. #2116 gave the legacy path its own entry point into the same two
-AST collectors (`instance_dev_tail_ast`), which cleared 257 entries and left
-every `track_reactivity_loss` under-emit module-side (197 in a component's
-`<script module>`, 18 in a `.svelte.(js|ts)`). #2090 closed those by adding the
-same `await` collector to `module_dev_tail_ast`'s batch, clearing a further 212
-entries:
-
-| | legacy component | runes component | `<script module>` | module script |
-|---|---:|---:|---:|---:|
-| equality under-emits | 0 | 1 | 0 | 0 |
-| `track_reactivity_loss` under-emits | 0 | 0 | 0 | 0 |
-
-Both instrumentations are now emitted for every script kind; only over-emits
-remain. The three `track_reactivity_loss` over-emits are all the *destructured*
-async assignment shape (`[a, b] = await …`): rsvelte lowers it to an async IIFE
-and instruments the IIFE call as well as the inner `await`, where upstream
-destructures after a single wrapped `await`. That is a lowering-shape
-difference, not an instrumentation gap — #2064 long-tail.
-
-The one equality residual is likewise not an instrumentation gap: it is a
-`$props()` destructuring default that the runes AST pass emits as generated
-`$.fallback(...)` text and never re-visits — #2064 long-tail. The three
-constant-folded template expressions (`{1 === 1}` → `"true"`) that used to sit
-in this row are fixed.
-
-### What is left of the `$.tag()` row
-
-The #2021 series covered every declaration shape reachable from the legacy and
-runes script passes; the last one was an uninitialized legacy source with no
-trailing semicolon (`let sub` on its own line, which is what a `bind:this`
-target or a stripped TypeScript annotation leaves), whose emitter built the
-`$.mutable_source()` call without the dev label.
-
-The 2 remaining under-emits are both `$.tag_proxy` and neither is a labelling
-gap. One is a `$state(…)` declared *inside a template event handler*, which the
-declarator tag pass never sees because it walks script statements, not template
-expressions. The other is `$state(a === b)`: upstream calls `should_proxy` on
-the **already-visited** initialiser, so the dev-only `$.strict_equals(…)`
-rewrite turns a `BinaryExpression` (never proxied) into a `CallExpression`
-(proxied), and rsvelte decides before that rewrite. Both are #2064 long-tail.
-
-### What is left of the `console.*` row
-
-The row was 68 under / 73 over: two ad-hoc predicates decided the wrap, and
-neither was upstream's `scope.evaluate(arg).has_unknown`. #2028 routed both onto
-the `Evaluation` lattice already ported for the server transform, and gave the
-template path (event handlers, `{expr}`, `$:` bodies) a decision at all — it had
-none, which was every under-emit.
-
-The 2 remaining over-emits are both *shadowing*: the generated text the script
-pass rewrites has no scope chain, so an identifier is only resolved when the
-component declares that name exactly once. `<script module>`'s `foo` next to the
-instance script's `foo`, and a `$state` `method` next to an `{#each}`-destructured
-`method`, therefore stay conservative. Resolving them needs a scope-carrying
-rewrite of the script path — #2064 long-tail.
-
-### What is left of the ownership row
-
-The 2 remaining under-emits are both `bind:this={prop[expr]}` on an element
-inside an `{#each}`: the setter upstream builds is
-`($$value, j) => $$ownership_validator.mutation(null, ['divs', j], …)`, whose
-path tail is the each-block index *expression*, not a literal member name.
-rsvelte's `bind:this` path wraps only the non-parameterised setter shape, so the
-each-scoped one falls through — #2064 long-tail.
-
-### What is left of the signal read/write row
-
-The 7 under-emits are all a computed path element inside an already-emitted
-`$$ownership_validator.mutation(...)`. Upstream builds that element through the
-binding's own read transform (`transform?.read ? transform.read(left.property) :
-left.property`, `shared/utils.js`), so a slot-let / each-block index arrives as
-`$.get(index)` and a store as `prop()`; rsvelte pushes the bare identifier.
-
-**#1981 is confirmed absent.** The run contains zero
-`$$ownership_validator.binding(` divergences, so the #1989 fix holds across the
-whole corpus. The ownership row above is a *different* gap (mutation tracking,
-not bindings) that only this lane could surface.
 
 ## Hard-cluster warnings for future work
 

--- a/compatibility/known-failures.md
+++ b/compatibility/known-failures.md
@@ -46,7 +46,7 @@ quoted key dropped in a destructured `$derived`) and #2034 (`$.to_array` arity
 with a rest element) — were resolved by #2036, which mirrored #2010's client
 destructuring fixes onto the server target.
 
-## Client dev (`known-failures.client-dev.json`, 18 entries)
+## Client dev (`known-failures.client-dev.json`, 16 entries)
 
 The `client-dev` target is the `client` target with `dev: true`. It is a
 separate ratchet because `dev` gates 18 client codegen files plus the CSS
@@ -143,6 +143,12 @@ path.at(-3) === 'Fragment'`, and an element's children are the one container it
 does not visit through a `Fragment` node, so a component nested in an element
 keeps the wrap.
 
+Nesting the legacy `$.invalidate_inner_signals` sequence inside the ownership
+wrap took it to 16. Upstream builds that sequence in `build_assignment` and
+hands the result to `validate_mutation`, so it is the wrap's third argument;
+rsvelte's text pass matched only the `prop(...)` call and left the sequence
+around the wrap instead.
+
 ### How the counts below are derived
 
 The enrolment-era table attributed each entry by its **first differing line**.
@@ -178,12 +184,11 @@ the two halves that had no equivalent on the JSON expression path (the value
 must be used, and the component-prop exemption only covers a component that is
 a `Fragment` child).
 
-10 entries are attributed to a cluster; the remaining **8** show no
-difference in any dev helper: 2 are a `$.trace` label's line:column, 2 are
-redundant parentheses around an ownership wrapper, 1 is a statement missing
-from a legacy `$:` body, 1 is the ` /* (unused) ` marker's own mapping in a
-minified stylesheet and 2 are one-off shapes (an `$.assign` location, an
-`$.assign_async` wrap). All are tracked in #2064. The legacy `bind:` `function get()/set()` shape was 47
+10 entries are attributed to a cluster; the remaining **6** show no
+difference in any dev helper: 2 are a `$.trace` label's line:column, 1 is a
+statement missing from a legacy `$:` body, 1 is the ` /* (unused) ` marker's own
+mapping in a minified stylesheet and 2 are one-off shapes (an `$.assign`
+location, an `$.assign_async` wrap). All are tracked in #2064. The legacy `bind:` `function get()/set()` shape was 47
 entries of that residue and is fixed: `build_each_block_accessor_parts` now
 hands the element `bind:` path the unthunked getter body plus the setter body,
 so `dev` can emit upstream's named accessors (`BindDirective.js:46-54`). The

--- a/compatibility/known-failures.md
+++ b/compatibility/known-failures.md
@@ -46,7 +46,7 @@ quoted key dropped in a destructured `$derived`) and #2034 (`$.to_array` arity
 with a rest element) — were resolved by #2036, which mirrored #2010's client
 destructuring fixes onto the server target.
 
-## Client dev (`known-failures.client-dev.json`, 11 entries)
+## Client dev (`known-failures.client-dev.json`, 9 entries)
 
 The `client-dev` target is the `client` target with `dev: true`. It is a
 separate ratchet because `dev` gates 18 client codegen files plus the CSS
@@ -165,6 +165,10 @@ Instrumenting a `$derived` destructuring default took it to 11. The pattern's
 source text was lifted verbatim before the walk reached it, so a default value
 never got the dev equality rewrite any other expression gets.
 
+Locating the traced function past a comment took it to 9. The `$inspect.trace()`
+label carries `locate_node(fn)`, which rsvelte finds by scanning backwards from
+the call — and a comment between the function head and the call answered for it.
+
 ### How the counts below are derived
 
 The enrolment-era table attributed each entry by its **first differing line**.
@@ -195,9 +199,8 @@ the two halves that had no equivalent on the JSON expression path (the value
 must be used, and the component-prop exemption only covers a component that is
 a `Fragment` child).
 
-5 entries are attributed to a cluster; the remaining **6** show no
-difference in any dev helper: 2 are a `$.trace` label's line:column, 1 is a
-statement missing from a legacy `$:` body, 1 is the ` /* (unused) ` marker's own
+5 entries are attributed to a cluster; the remaining **4** show no
+difference in any dev helper: 1 is a statement missing from a legacy `$:` body, 1 is the ` /* (unused) ` marker's own
 mapping in a minified stylesheet and 2 are one-off shapes (an `$.assign`
 location, an `$.assign_async` wrap). All are tracked in #2064. The legacy `bind:` `function get()/set()` shape was 47
 entries of that residue and is fixed: `build_each_block_accessor_parts` now

--- a/compatibility/known-failures.md
+++ b/compatibility/known-failures.md
@@ -46,7 +46,7 @@ quoted key dropped in a destructured `$derived`) and #2034 (`$.to_array` arity
 with a rest element) — were resolved by #2036, which mirrored #2010's client
 destructuring fixes onto the server target.
 
-## Client dev (`known-failures.client-dev.json`, 14 entries)
+## Client dev (`known-failures.client-dev.json`, 12 entries)
 
 The `client-dev` target is the `client` target with `dev: true`. It is a
 separate ratchet because `dev` gates 18 client codegen files plus the CSS
@@ -154,6 +154,13 @@ Validating every prop-rooted `bind:` setter mutation took it to 14.
 mutation itself is wrapped, so a runes non-bindable prop — which assigns the
 member directly, with no `prop(…, true)` call around it — needs the wrap too.
 
+Labelling every proxied `$state` initializer took it to 12.
+`create_state_declarator` decides on the **visited** expression, so in dev an
+`a === b` initializer has already become a `$.strict_equals(...)` call and
+therefore proxies (an arithmetic `BinaryExpression` still does not); and a
+`$state` declared inside a template handler body reaches the expression
+converter, which had no way back to the declarator's name.
+
 ### How the counts below are derived
 
 The enrolment-era table attributed each entry by its **first differing line**.
@@ -170,7 +177,6 @@ each side, which separates the two directions and cannot be fooled by order:
 |---|---:|---:|---|---|
 | equality instrumentation | 1 | 0 | `visitors/BinaryExpression.js` | #2064 |
 | `$.track_reactivity_loss(...)` | 0 | 3 | `visitors/AwaitExpression.js` | #2064 |
-| `$.tag()` / `$.tag_proxy()` | 2 | 0 | `visitors/VariableDeclaration.js` | #2064 |
 | `console.*` wrapping | 0 | 2 | `visitors/CallExpression.js` | #2064 |
 
 The ownership row is now empty as well: the preamble half went first, then the
@@ -186,7 +192,7 @@ the two halves that had no equivalent on the JSON expression path (the value
 must be used, and the component-prop exemption only covers a component that is
 a `Fragment` child).
 
-8 entries are attributed to a cluster; the remaining **6** show no
+6 entries are attributed to a cluster; the remaining **6** show no
 difference in any dev helper: 2 are a `$.trace` label's line:column, 1 is a
 statement missing from a legacy `$:` body, 1 is the ` /* (unused) ` marker's own
 mapping in a minified stylesheet and 2 are one-off shapes (an `$.assign`

--- a/compatibility/known-failures.md
+++ b/compatibility/known-failures.md
@@ -46,7 +46,7 @@ quoted key dropped in a destructured `$derived`) and #2034 (`$.to_array` arity
 with a rest element) — were resolved by #2036, which mirrored #2010's client
 destructuring fixes onto the server target.
 
-## Client dev (`known-failures.client-dev.json`, 16 entries)
+## Client dev (`known-failures.client-dev.json`, 14 entries)
 
 The `client-dev` target is the `client` target with `dev: true`. It is a
 separate ratchet because `dev` gates 18 client codegen files plus the CSS
@@ -149,6 +149,11 @@ hands the result to `validate_mutation`, so it is the wrap's third argument;
 rsvelte's text pass matched only the `prop(...)` call and left the sequence
 around the wrap instead.
 
+Validating every prop-rooted `bind:` setter mutation took it to 14.
+`validate_mutation` gates on the *root binding* being a prop, not on whether the
+mutation itself is wrapped, so a runes non-bindable prop — which assigns the
+member directly, with no `prop(…, true)` call around it — needs the wrap too.
+
 ### How the counts below are derived
 
 The enrolment-era table attributed each entry by its **first differing line**.
@@ -165,15 +170,12 @@ each side, which separates the two directions and cannot be fooled by order:
 |---|---:|---:|---|---|
 | equality instrumentation | 1 | 0 | `visitors/BinaryExpression.js` | #2064 |
 | `$.track_reactivity_loss(...)` | 0 | 3 | `visitors/AwaitExpression.js` | #2064 |
-| ownership mutation validation | 2 | 0 | `transform-client.js`, `visitors/shared/{component,utils}.js` | #2027 |
 | `$.tag()` / `$.tag_proxy()` | 2 | 0 | `visitors/VariableDeclaration.js` | #2064 |
 | `console.*` wrapping | 0 | 2 | `visitors/CallExpression.js` | #2064 |
 
-The ownership row splits into two halves: entries missing the
-`$.create_ownership_validator($$props)` preamble entirely, and entries that have
-it but under-emit call sites. The preamble half is now empty; both survivors
-emit their `$$ownership_validator.binding(...)` calls and are missing exactly one
-`$$ownership_validator.mutation(...)` each.
+The ownership row is now empty as well: the preamble half went first, then the
+call-site half, once every prop-rooted `bind:` setter reached
+`validate_mutation`.
 
 The signal read/write row is now empty: `$state` reassignment is resolved per
 binding rather than per name, so same-named `$state` locals in sibling scopes no
@@ -184,7 +186,7 @@ the two halves that had no equivalent on the JSON expression path (the value
 must be used, and the component-prop exemption only covers a component that is
 a `Fragment` child).
 
-10 entries are attributed to a cluster; the remaining **6** show no
+8 entries are attributed to a cluster; the remaining **6** show no
 difference in any dev helper: 2 are a `$.trace` label's line:column, 1 is a
 statement missing from a legacy `$:` body, 1 is the ` /* (unused) ` marker's own
 mapping in a minified stylesheet and 2 are one-off shapes (an `$.assign`

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/variable_declarator.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/variable_declarator.rs
@@ -91,6 +91,22 @@ fn collect_ignore_codes_from_parent(context: &VisitorContext) -> Vec<String> {
 // ---------------------------------------------------------------------------
 
 /// Visit a variable declarator (typed JsNode path).
+/// The instance scope's own declaration of `name`, for an instance-script
+/// declarator whose position lookup missed. `context.scope` is the root scope
+/// there, so the chain lookup would otherwise answer with a same-named
+/// module-script binding and write this initializer onto it.
+fn instance_scope_binding(context: &super::VisitorContext<'_>, name: &str) -> Option<usize> {
+    if !matches!(context.ast_type, super::AstType::Instance) {
+        return None;
+    }
+    let root = &context.analysis.root;
+    root.all_scopes
+        .get(root.instance_scope_index)?
+        .declarations
+        .get(name)
+        .copied()
+}
+
 pub fn visit_typed(node: &JsNode, context: &mut VisitorContext) -> Result<(), AnalysisError> {
     let JsNode::VariableDeclarator { id, init, .. } = node else {
         return Ok(());
@@ -437,6 +453,7 @@ fn visit_runes_mode_typed(
                 .analysis
                 .root
                 .find_binding_by_declaration_start(&path.name, path.start)
+                .or_else(|| instance_scope_binding(context, &path.name))
                 .or_else(|| context.analysis.root.get_binding(&path.name, context.scope))
                 .or_else(|| context.analysis.root.find_binding_any_scope(&path.name));
             if let Some(binding_idx) = binding_idx {
@@ -914,13 +931,21 @@ fn visit_non_runes_mode_typed(
     let id_is_plain_identifier_typed = matches!(id_node, JsNode::Identifier { .. });
     if let Some(init) = init_node {
         for path in &paths {
-            if let Some(&binding_idx) = context
+            let binding_idx = context
                 .analysis
                 .root
-                .scope
-                .declarations
-                .get(path.name.as_str())
-            {
+                .find_binding_by_declaration_start(&path.name, path.start)
+                .or_else(|| instance_scope_binding(context, &path.name))
+                .or_else(|| {
+                    context
+                        .analysis
+                        .root
+                        .scope
+                        .declarations
+                        .get(path.name.as_str())
+                        .copied()
+                });
+            if let Some(binding_idx) = binding_idx {
                 let binding = &mut context.analysis.root.bindings[binding_idx];
                 binding.initial = extract_literal_string_typed(init);
                 // Keep the init AST for a non-literal but potentially

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/assign_dev_ast.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/assign_dev_ast.rs
@@ -89,6 +89,35 @@ impl<'a> Visit<'a> for AsyncScan {
     fn visit_class(&mut self, _: &Class<'a>) {}
 }
 
+/// The value `arrow` (`utils/builders.js`) hoists out of a lazy getter, turning
+/// `async () => await x()` back into `() => x()`. Upstream decides on the
+/// unvisited right-hand side, so the `$.track_reactivity_loss` wrapper this pass
+/// already sees around the `await` has to be looked through.
+fn hoistable_await_argument<'a, 'b>(expr: &'b Expression<'a>) -> Option<&'b Expression<'a>> {
+    let argument = match expr.without_parentheses() {
+        Expression::AwaitExpression(await_expr) => &await_expr.argument,
+        Expression::CallExpression(call) if call.arguments.is_empty() => {
+            let Expression::AwaitExpression(await_expr) = call.callee.without_parentheses() else {
+                return None;
+            };
+            let Expression::CallExpression(wrap) = await_expr.argument.without_parentheses() else {
+                return None;
+            };
+            let Expression::StaticMemberExpression(member) = &wrap.callee else {
+                return None;
+            };
+            if member.property.name != "track_reactivity_loss"
+                || !matches!(&member.object, Expression::Identifier(id) if id.name == "$")
+            {
+                return None;
+            }
+            wrap.arguments.first()?.as_expression()?
+        }
+        _ => return None,
+    };
+    (!is_expression_async(argument)).then_some(argument)
+}
+
 /// One element of a member chain, as both sides can compare it: a written name,
 /// or a computed access whose expression only has to be a computed access on
 /// the other side too.
@@ -172,17 +201,9 @@ impl<'a> Visit<'a> for AssignCollector<'_> {
     fn visit_assignment_expression(&mut self, assign: &AssignmentExpression<'a>) {
         walk::walk_assignment_expression(self, assign);
 
-        if self.statement_expressions.contains(&assign.span.start)
-            && !self.concise_arrow_bodies.contains(&assign.span.start)
-        {
-            return;
-        }
         let Some(operator) = non_coercive(assign.operator) else {
             return;
         };
-        if is_known_primitive(&assign.right) {
-            return;
-        }
         let mut path = Vec::new();
         let slice = |span: oxc_span::Span| &self.source[span.start as usize..span.end as usize];
         let (root, object_span, property) = match &assign.left {
@@ -210,9 +231,18 @@ impl<'a> Visit<'a> for AssignCollector<'_> {
             }
             _ => return,
         };
+        // Consumed before the decision below, not after: two identical member
+        // chains in one script are told apart only by which site is still
+        // unused, so a site the decision rejects still has to be spent.
         let Some((line, column)) = self.sites.take(&root, &path, operator) else {
             return;
         };
+        if is_known_primitive(&assign.right)
+            || (self.statement_expressions.contains(&assign.span.start)
+                && !self.concise_arrow_bodies.contains(&assign.span.start))
+        {
+            return;
+        }
 
         let object = slice(object_span);
         let right = slice(assign.right.span());
@@ -221,24 +251,36 @@ impl<'a> Visit<'a> for AssignCollector<'_> {
         // awaiting getter has to be awaited back through `$.assign_async`.
         let needs_lazy_getter = operator != "=";
         let needs_async = needs_lazy_getter && is_expression_async(&assign.right);
+        let hoisted = needs_async
+            .then(|| hoistable_await_argument(&assign.right))
+            .flatten();
         let value = match (needs_lazy_getter, needs_async) {
             (false, _) => right.to_string(),
             (true, false) => format!("() => {right}"),
-            (true, true) => format!("async () => {right}"),
+            (true, true) => match hoisted {
+                Some(argument) => format!("() => {}", slice(argument.span())),
+                None => format!("async () => {right}"),
+            },
         };
         let callee = if needs_async {
-            "await $.assign_async"
+            "$.assign_async"
         } else {
             "$.assign"
         };
-        self.edits.push((
-            assign.span.start,
-            assign.span.end,
-            format!(
-                "{callee}({object}, {property}, '{operator}', {value}, '{}:{line}:{column}')",
-                self.filename
-            ),
-        ));
+        let call = format!(
+            "{callee}({object}, {property}, '{operator}', {value}, '{}:{line}:{column}')",
+            self.filename
+        );
+        // `build_assignment` hands the `await` it adds to `context.visit`, so the
+        // `AwaitExpression` visitor instruments it in the same pass; here that
+        // pass has already run over the script.
+        let replacement = if needs_async {
+            format!("(await $.track_reactivity_loss({call}))()")
+        } else {
+            call
+        };
+        self.edits
+            .push((assign.span.start, assign.span.end, replacement));
     }
 }
 

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/ast_state_transform.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/ast_state_transform.rs
@@ -1298,10 +1298,14 @@ impl<'a, 's> StateVarCollector<'a, 's> {
         let wrapped_source = self.apply_and_drain_inner_replacements(arg_span.start, arg_span.end);
 
         // Extract the destructured pattern's source text — the recursive
-        // text helper walks this string.
+        // text helper walks this string. Walk it first so a default value
+        // carries the same rewrites any other expression would (the dev
+        // equality instrumentation, above all); binding names are visited as
+        // declarations, not references, so they stay untouched.
         let pattern_span = declarator.id.span();
+        self.visit_binding_pattern(&declarator.id);
         let pattern_text =
-            self.source[pattern_span.start as usize..pattern_span.end as usize].to_string();
+            self.apply_and_drain_inner_replacements(pattern_span.start, pattern_span.end);
         let pattern_text = pattern_text.trim().to_string();
 
         let mut declarations: Vec<String> = Vec::new();

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/ast_state_transform.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/ast_state_transform.rs
@@ -113,7 +113,11 @@ fn derived_insert_label(dev: bool, pattern_text: &str) -> Option<&'static str> {
 /// For Identifier nodes, looks up the non_proxy_vars list (which contains variables
 /// with known non-proxyable initial values).
 /// For all other expression types (CallExpression, MemberExpression, etc.), returns `true`.
-fn should_proxy_ast(expr: &Expression<'_>, non_proxy_vars: &[String]) -> bool {
+///
+/// `dev` reflects whether the caller decides on the *visited* expression, as
+/// `create_state_declarator` does — by then the dev equality rewrite has turned
+/// an `a === b` initializer into a `$.strict_equals(...)` call.
+fn should_proxy_ast(expr: &Expression<'_>, non_proxy_vars: &[String], dev: bool) -> bool {
     match expr {
         Expression::BooleanLiteral(_)
         | Expression::NullLiteral(_)
@@ -125,13 +129,26 @@ fn should_proxy_ast(expr: &Expression<'_>, non_proxy_vars: &[String]) -> bool {
         Expression::ArrowFunctionExpression(_) => false,
         Expression::FunctionExpression(_) => false,
         Expression::UnaryExpression(_) => false,
-        Expression::BinaryExpression(_) => false,
+        Expression::BinaryExpression(binary) => {
+            use oxc_syntax::operator::BinaryOperator;
+            dev && matches!(
+                binary.operator,
+                BinaryOperator::StrictEquality
+                    | BinaryOperator::StrictInequality
+                    | BinaryOperator::Equality
+                    | BinaryOperator::Inequality
+            )
+        }
         // TypeScript casts: unwrap and recurse on the inner expression.
-        Expression::TSAsExpression(e) => should_proxy_ast(&e.expression, non_proxy_vars),
-        Expression::TSSatisfiesExpression(e) => should_proxy_ast(&e.expression, non_proxy_vars),
-        Expression::TSNonNullExpression(e) => should_proxy_ast(&e.expression, non_proxy_vars),
-        Expression::TSTypeAssertion(e) => should_proxy_ast(&e.expression, non_proxy_vars),
-        Expression::TSInstantiationExpression(e) => should_proxy_ast(&e.expression, non_proxy_vars),
+        Expression::TSAsExpression(e) => should_proxy_ast(&e.expression, non_proxy_vars, dev),
+        Expression::TSSatisfiesExpression(e) => {
+            should_proxy_ast(&e.expression, non_proxy_vars, dev)
+        }
+        Expression::TSNonNullExpression(e) => should_proxy_ast(&e.expression, non_proxy_vars, dev),
+        Expression::TSTypeAssertion(e) => should_proxy_ast(&e.expression, non_proxy_vars, dev),
+        Expression::TSInstantiationExpression(e) => {
+            should_proxy_ast(&e.expression, non_proxy_vars, dev)
+        }
         Expression::Identifier(ident) => {
             if ident.name == "undefined" {
                 return false;
@@ -144,7 +161,7 @@ fn should_proxy_ast(expr: &Expression<'_>, non_proxy_vars: &[String]) -> bool {
         }
         // ParenthesizedExpression: check inner expression
         Expression::ParenthesizedExpression(paren) => {
-            should_proxy_ast(&paren.expression, non_proxy_vars)
+            should_proxy_ast(&paren.expression, non_proxy_vars, dev)
         }
         // SequenceExpression (comma): upstream `should_proxy` does NOT whitelist
         // SequenceExpression, so it falls through to `return true` — a comma
@@ -838,7 +855,7 @@ impl<'a, 's> StateVarCollector<'a, 's> {
         let (needs_proxy, is_explicit_undefined) = if let Some(arg) = call.arguments.first() {
             let arg_expr = arg.as_expression();
             let needs_proxy = arg_expr
-                .map(|e| should_proxy_ast(e, self.non_proxy_vars))
+                .map(|e| should_proxy_ast(e, self.non_proxy_vars, self.dev))
                 .unwrap_or(false);
             let is_undef = matches!(
                 arg_expr,
@@ -2800,7 +2817,11 @@ impl<'a, 's, 'ast> Visit<'ast> for StateVarCollector<'a, 's> {
                             && self
                                 .ident_rhs_site_decision(&expr.right)
                                 .unwrap_or_else(|| {
-                                    should_proxy_ast(&expr.right, self.reassign_non_proxy_vars)
+                                    should_proxy_ast(
+                                        &expr.right,
+                                        self.reassign_non_proxy_vars,
+                                        false,
+                                    )
                                 });
 
                         let replacement = if needs_proxy {
@@ -2843,7 +2864,11 @@ impl<'a, 's, 'ast> Visit<'ast> for StateVarCollector<'a, 's> {
                             && self
                                 .ident_rhs_site_decision(&expr.right)
                                 .unwrap_or_else(|| {
-                                    should_proxy_ast(&expr.right, self.reassign_non_proxy_vars)
+                                    should_proxy_ast(
+                                        &expr.right,
+                                        self.reassign_non_proxy_vars,
+                                        false,
+                                    )
                                 });
 
                         let replacement = if needs_proxy {

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/ast_state_transform.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/ast_state_transform.rs
@@ -20,7 +20,7 @@ use oxc_span::Span;
 use oxc_syntax::operator::{AssignmentOperator, BinaryOperator, UpdateOperator};
 use oxc_syntax::scope::ScopeFlags;
 use oxc_syntax::scope::ScopeId;
-use rustc_hash::FxHashSet;
+use rustc_hash::{FxHashMap, FxHashSet};
 
 use super::destructure_transforms::{
     ArrayHelperRead, build_fallback_string, extract_destructure_paths, js_number_to_string,
@@ -256,7 +256,8 @@ struct StateVarCollector<'a, 's> {
     /// Subtrees carrying a `svelte-ignore await_reactivity_loss`.
     await_ignore_ranges: super::await_reactivity_loss_ast::AwaitIgnoreRanges,
     /// Starts of `await` expressions that are a whole statement relying on ASI.
-    unterminated_await_starts: FxHashSet<u32>,
+    /// Statement start → end of the statement a `;` has to separate it from.
+    await_separators: FxHashMap<u32, u32>,
 
     // --- Phase A-2 fields ---
     /// Prop source variables that need getter/setter wrapping: `prop` -> `prop()`.
@@ -384,7 +385,7 @@ impl<'a, 's> StateVarCollector<'a, 's> {
             scoped_vars: vec![FxHashSet::default()],
             in_shorthand_property: false,
             await_ignore_ranges: Default::default(),
-            unterminated_await_starts: FxHashSet::default(),
+            await_separators: FxHashMap::default(),
             prop_source_vars: prop_source_set,
             non_bindable_prop_vars: non_bindable_set,
             store_sub_vars: store_sub_set,
@@ -2024,11 +2025,20 @@ impl<'a, 's> StateVarCollector<'a, 's> {
         let arg_span = expr.argument.span();
         let arg_text = self.apply_and_drain_inner_replacements(arg_span.start, arg_span.end);
 
-        let mut replacement = format!("(await $.track_reactivity_loss({}))()", arg_text.trim());
-        if self.unterminated_await_starts.contains(&expr.span.start) {
-            replacement.push(';');
-        }
-        self.add_replacement(expr.span.start, expr.span.end, replacement);
+        let wrap = format!("(await $.track_reactivity_loss({}))()", arg_text.trim());
+        // The `;` rides inside this replacement rather than being appended to
+        // the statement before it, which may have no replacement of its own.
+        let (start, replacement) = match self.await_separators.get(&expr.span.start) {
+            Some(&prev_end) => (
+                prev_end,
+                format!(
+                    ";{}{wrap}",
+                    &self.source[prev_end as usize..expr.span.start as usize]
+                ),
+            ),
+            None => (expr.span.start, wrap),
+        };
+        self.add_replacement(start, expr.span.end, replacement);
         true
     }
 
@@ -2348,14 +2358,11 @@ impl<'a, 's, 'ast> Visit<'ast> for StateVarCollector<'a, 's> {
     }
 
     fn visit_statements(&mut self, stmts: &oxc_allocator::Vec<'ast, Statement<'ast>>) {
-        for pair in stmts.windows(2) {
-            if let Some(start) = super::await_reactivity_loss_ast::unterminated_await_statement(
-                &pair[0],
+        self.await_separators
+            .extend(super::await_reactivity_loss_ast::separator_positions(
+                stmts,
                 self.source,
-            ) {
-                self.unterminated_await_starts.insert(start);
-            }
-        }
+            ));
         walk::walk_statements(self, stmts);
     }
 

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/ast_state_transform.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/ast_state_transform.rs
@@ -2011,7 +2011,10 @@ impl<'a, 's> StateVarCollector<'a, 's> {
     /// boundary. Suppressed by a leading `svelte-ignore await_reactivity_loss`.
     /// Returns `true` when the expression was rewritten.
     fn try_rewrite_await_reactivity_loss(&mut self, expr: &AwaitExpression<'_>) -> bool {
-        if !self.dev || self.is_await_reactivity_loss_ignored(expr.span.start) {
+        if !self.dev
+            || self.is_await_reactivity_loss_ignored(expr.span.start)
+            || super::await_reactivity_loss_ast::is_destructuring_iife_call(&expr.argument)
+        {
             return false;
         }
 

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/await_reactivity_loss_ast.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/await_reactivity_loss_ast.rs
@@ -26,20 +26,50 @@ fn track_reactivity_loss_wrap(argument_text: &str) -> String {
     format!("(await $.track_reactivity_loss({argument_text}))()")
 }
 
-/// The start offset of a whole-statement `await` that a following statement
-/// would be folded into once the wrapper's trailing `)()` makes the line
-/// continuable. Restricted to statements with a successor because the same
-/// visitor also runs over expression fragments parsed as one-statement
-/// programs, where a `;` would land in expression position.
-pub(super) fn unterminated_await_statement(stmt: &Statement<'_>, source: &str) -> Option<u32> {
-    let Statement::ExpressionStatement(stmt) = stmt else {
-        return None;
+/// Whether `stmt`'s last token is an expression, so that a following line
+/// opening with `(` continues it instead of starting a statement of its own.
+/// A source `await` can never continue a line, but the wrapper this pass builds
+/// can, so every such boundary has to be restored.
+fn ends_in_open_expression(stmt: &Statement<'_>, source: &str) -> bool {
+    let unterminated = |span: oxc_span::Span| {
+        !source[span.start as usize..span.end as usize]
+            .trim_end()
+            .ends_with(';')
     };
-    let Expression::AwaitExpression(_) = &stmt.expression else {
-        return None;
-    };
-    let text = &source[stmt.span.start as usize..stmt.span.end as usize];
-    (!text.ends_with(';')).then(|| stmt.expression.span().start)
+    match stmt {
+        Statement::ExpressionStatement(stmt) => unterminated(stmt.span),
+        Statement::VariableDeclaration(decl) => unterminated(decl.span),
+        Statement::ReturnStatement(stmt) => unterminated(stmt.span),
+        Statement::ThrowStatement(stmt) => unterminated(stmt.span),
+        Statement::IfStatement(stmt) => {
+            ends_in_open_expression(stmt.alternate.as_ref().unwrap_or(&stmt.consequent), source)
+        }
+        Statement::ForStatement(stmt) => ends_in_open_expression(&stmt.body, source),
+        Statement::ForInStatement(stmt) => ends_in_open_expression(&stmt.body, source),
+        Statement::ForOfStatement(stmt) => ends_in_open_expression(&stmt.body, source),
+        Statement::WhileStatement(stmt) => ends_in_open_expression(&stmt.body, source),
+        Statement::LabeledStatement(stmt) => ends_in_open_expression(&stmt.body, source),
+        _ => false,
+    }
+}
+
+/// The end offset of the statement a wrapped `await` statement has to be
+/// separated from, keyed by that statement's start. Only a statement that
+/// *begins* with the `await` grows a leading `(`, and only a predecessor left
+/// open by ASI can absorb it.
+pub(super) fn separator_positions(
+    stmts: &oxc_allocator::Vec<'_, Statement<'_>>,
+    source: &str,
+) -> Vec<(u32, u32)> {
+    stmts
+        .windows(2)
+        .filter_map(|pair| {
+            let Statement::ExpressionStatement(next) = &pair[1] else {
+                return None;
+            };
+            ends_in_open_expression(&pair[0], source).then(|| (next.span.start, pair[0].span().end))
+        })
+        .collect()
 }
 
 /// The wrapper keeps an `await` of its own, so the fixed-point loop would wrap
@@ -156,7 +186,7 @@ pub(super) fn collect_await_reactivity_loss_edits(
     let mut collector = AwaitCollector {
         source,
         ignored: collect_await_ignore_ranges(program, source, is_runes),
-        unterminated: rustc_hash::FxHashSet::default(),
+        separators: rustc_hash::FxHashMap::default(),
         edits: Vec::new(),
     };
     collector.visit_program(program);
@@ -166,18 +196,15 @@ pub(super) fn collect_await_reactivity_loss_edits(
 struct AwaitCollector<'src> {
     source: &'src str,
     ignored: AwaitIgnoreRanges,
-    /// Starts of `await` expressions that are a whole statement relying on ASI.
-    unterminated: rustc_hash::FxHashSet<u32>,
+    /// Statement start → end of the statement a `;` has to separate it from.
+    separators: rustc_hash::FxHashMap<u32, u32>,
     edits: Vec<Edit>,
 }
 
 impl<'a, 'src> Visit<'a> for AwaitCollector<'src> {
     fn visit_statements(&mut self, stmts: &oxc_allocator::Vec<'a, Statement<'a>>) {
-        for pair in stmts.windows(2) {
-            if let Some(start) = unterminated_await_statement(&pair[0], self.source) {
-                self.unterminated.insert(start);
-            }
-        }
+        self.separators
+            .extend(separator_positions(stmts, self.source));
         walk::walk_statements(self, stmts);
     }
 
@@ -193,11 +220,19 @@ impl<'a, 'src> Visit<'a> for AwaitCollector<'src> {
 
         let arg_span = expr.argument.span();
         let arg_text = self.source[arg_span.start as usize..arg_span.end as usize].trim();
-        let mut replacement = track_reactivity_loss_wrap(arg_text);
-        if self.unterminated.contains(&expr.span.start) {
-            replacement.push(';');
-        }
-        self.edits
-            .push((expr.span.start, expr.span.end, replacement));
+        let wrap = track_reactivity_loss_wrap(arg_text);
+        // The `;` rides inside this edit rather than as an insertion of its own,
+        // which `splice`'s innermost-only filter would read as nested.
+        let (start, replacement) = match self.separators.get(&expr.span.start) {
+            Some(&prev_end) => (
+                prev_end,
+                format!(
+                    ";{}{wrap}",
+                    &self.source[prev_end as usize..expr.span.start as usize]
+                ),
+            ),
+            None => (expr.span.start, wrap),
+        };
+        self.edits.push((start, expr.span.end, replacement));
     }
 }

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/await_reactivity_loss_ast.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/await_reactivity_loss_ast.rs
@@ -56,6 +56,24 @@ fn is_track_reactivity_loss_call(expr: &Expression<'_>) -> bool {
         && matches!(&member.object, Expression::Identifier(id) if id.name == "$")
 }
 
+/// The `await (async ($$value) => { … })(…)` an async destructuring assignment
+/// is lowered to. Upstream destructures after a single instrumented `await`, so
+/// this call — which rsvelte generates *after* the source `await` was already
+/// wrapped — has no counterpart to instrument.
+pub(super) fn is_destructuring_iife_call(expr: &Expression<'_>) -> bool {
+    let Expression::CallExpression(call) = expr.without_parentheses() else {
+        return false;
+    };
+    let Expression::ArrowFunctionExpression(arrow) = call.callee.without_parentheses() else {
+        return false;
+    };
+    arrow.r#async
+        && matches!(
+            arrow.params.items.first().map(|param| &param.pattern),
+            Some(BindingPattern::BindingIdentifier(id)) if id.name == "$$value"
+        )
+}
+
 /// Source spans whose whole subtree carries a `svelte-ignore
 /// await_reactivity_loss`, mirroring upstream's analysis-phase ignore stack:
 /// a leading comment binds to the outermost node starting after it, and every
@@ -166,7 +184,10 @@ impl<'a, 'src> Visit<'a> for AwaitCollector<'src> {
     fn visit_await_expression(&mut self, expr: &AwaitExpression<'a>) {
         walk::walk_await_expression(self, expr);
 
-        if is_track_reactivity_loss_call(&expr.argument) || self.ignored.contains(expr.span.start) {
+        if is_track_reactivity_loss_call(&expr.argument)
+            || is_destructuring_iife_call(&expr.argument)
+            || self.ignored.contains(expr.span.start)
+        {
             return;
         }
 

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/console_wrap.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/console_wrap.rs
@@ -44,7 +44,11 @@ pub(super) const CONSOLE_METHODS: &[&str] = &[
 /// Run `f` with an `EvalCtx` wired to `analysis` — the client transform has no
 /// `{@const}` table, no async blockers and no single render position, so every
 /// other field is inert.
-fn with_eval_ctx<R>(analysis: &ComponentAnalysis, f: impl FnOnce(&EvalCtx<'_>) -> R) -> R {
+fn with_eval_ctx<R>(
+    analysis: &ComponentAnalysis,
+    current_scope_index: Option<usize>,
+    f: impl FnOnce(&EvalCtx<'_>) -> R,
+) -> R {
     let constant_vars = rustc_hash::FxHashMap::default();
     let blocker_map = rustc_hash::FxHashMap::default();
     let template_scopes_cache = std::cell::OnceCell::new();
@@ -54,7 +58,7 @@ fn with_eval_ctx<R>(analysis: &ComponentAnalysis, f: impl FnOnce(&EvalCtx<'_>) -
         source: &analysis.source,
         use_async: false,
         top_level_blocker_map: &blocker_map,
-        current_scope_index: None,
+        current_scope_index,
         template_scopes_cache: &template_scopes_cache,
     })
 }
@@ -65,7 +69,7 @@ pub(super) fn args_need_wrap(args: &[Value], analysis: &ComponentAnalysis) -> bo
     if args.is_empty() {
         return false;
     }
-    with_eval_ctx(analysis, |ctx| {
+    with_eval_ctx(analysis, None, |ctx| {
         args.iter().any(|arg| {
             arg.get("type").and_then(|t| t.as_str()) == Some("SpreadElement")
                 || ctx.evaluate_estree(arg, 0).has_unknown()
@@ -140,10 +144,10 @@ impl<'a> Visit<'a> for ConstCollector<'_> {
 }
 
 /// Whether a bare identifier left in generated code can still evaluate to
-/// `UNKNOWN`. Resolution is restricted to names declared exactly once: with a
-/// shadowing declaration in play, the generated text alone cannot say which of
-/// them this reference reaches, and guessing could suppress a wrap upstream
-/// emits.
+/// `UNKNOWN`. Shadowing declarations are left to `evaluate_identifier`, whose
+/// agreement rule unions the candidates' value sets — so a name the generated
+/// text cannot resolve stays unknown, which is the direction that keeps a wrap
+/// upstream emits.
 fn identifier_can_be_unknown(
     name: &str,
     analysis: Option<&ComponentAnalysis>,
@@ -158,10 +162,9 @@ fn identifier_can_be_unknown(
     let Some(analysis) = analysis else {
         return true;
     };
-    if analysis.root.bindings_by_name.get(name).map(|b| b.len()) != Some(1) {
-        return true;
-    }
-    with_eval_ctx(analysis, |ctx| {
+    // Resolve from the instance scope: this pass only ever sees script text, so
+    // a same-named template binding (an each item, say) is not in scope.
+    with_eval_ctx(analysis, Some(analysis.root.instance_scope_index), |ctx| {
         ctx.evaluate_identifier(name, 0).has_unknown()
     })
 }

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/expression_utils.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/expression_utils.rs
@@ -1427,7 +1427,11 @@ pub(super) fn find_trace_source_location(
 ) -> Option<(usize, usize)> {
     // Find $inspect.trace() in source and then find the enclosing function/arrow
     if let Some(trace_pos) = memmem::find(source.as_bytes(), b"$inspect.trace(") {
-        let before = &source[..trace_pos];
+        // The scans below read backwards for code punctuation, so prose in a
+        // comment between the function head and the trace call would otherwise
+        // answer for it.
+        let before = blank_comments(&source[..trace_pos]);
+        let before = before.as_str();
 
         // Walk backwards past whitespace and the opening { to find the arrow =>
         // or function keyword
@@ -1465,6 +1469,53 @@ pub(super) fn find_trace_source_location(
         }
     }
     None
+}
+
+/// Replace every comment byte with a space, keeping newlines and byte offsets,
+/// so a backward scan for code cannot land inside prose.
+fn blank_comments(source: &str) -> String {
+    let bytes = source.as_bytes();
+    let mut out = bytes.to_vec();
+    let mut i = 0;
+    while i < bytes.len() {
+        match bytes[i] {
+            quote @ (b'\'' | b'"' | b'`') => {
+                i += 1;
+                while i < bytes.len() {
+                    if bytes[i] == b'\\' {
+                        i += 2;
+                        continue;
+                    }
+                    let closed = bytes[i] == quote;
+                    i += 1;
+                    if closed {
+                        break;
+                    }
+                }
+            }
+            b'/' if bytes.get(i + 1) == Some(&b'/') => {
+                while i < bytes.len() && bytes[i] != b'\n' {
+                    out[i] = b' ';
+                    i += 1;
+                }
+            }
+            b'/' if bytes.get(i + 1) == Some(&b'*') => {
+                let start = i;
+                i += 2;
+                while i + 1 < bytes.len() && !(bytes[i] == b'*' && bytes[i + 1] == b'/') {
+                    i += 1;
+                }
+                i = (i + 2).min(bytes.len());
+                for byte in &mut out[start..i] {
+                    if *byte != b'\n' {
+                        *byte = b' ';
+                    }
+                }
+            }
+            _ => i += 1,
+        }
+    }
+    String::from_utf8(out).unwrap_or_else(|_| source.to_string())
 }
 
 /// Find the matching opening parenthesis for a closing `)` at the given position.

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/props_transforms.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/props_transforms.rs
@@ -3317,6 +3317,11 @@ pub(super) fn wrap_prop_mutation_validation(
 
             // The full original expression is the entire prop(prop().member = value, true) call
             let end_pos = inner_start + close_byte_pos + 1; // +1 for closing paren
+            // Upstream builds the `$.invalidate_inner_signals` sequence first and
+            // passes the whole thing to `validate_mutation`, so the sequence has to
+            // go inside the wrap rather than around it.
+            let (abs_start, end_pos) = expand_to_invalidate_sequence(&result, abs_start, end_pos)
+                .unwrap_or((abs_start, end_pos));
             let full_original_expr = result[abs_start..end_pos].to_string();
 
             // Each mutation reports its own source position.
@@ -3350,6 +3355,34 @@ pub(super) fn wrap_prop_mutation_validation(
     }
 
     result
+}
+
+/// The span of `(<mutation>, $.invalidate_inner_signals(…))` around the
+/// `prop(...)` call at `start..end`, when a legacy indirect binding put one there.
+fn expand_to_invalidate_sequence(text: &str, start: usize, end: usize) -> Option<(usize, usize)> {
+    let open = text[..start].trim_end().len().checked_sub(1)?;
+    if text.as_bytes()[open] != b'(' {
+        return None;
+    }
+    let rest = text[end..].trim_start().strip_prefix(',')?;
+    if !rest.trim_start().starts_with("$.invalidate_inner_signals") {
+        return None;
+    }
+    let mut depth = 0i32;
+    for (offset, ch) in text[open..].char_indices() {
+        match ch {
+            '(' | '[' | '{' => depth += 1,
+            ')' | ']' | '}' => {
+                depth -= 1;
+                if depth == 0 {
+                    let close = open + offset + 1;
+                    return (close > end).then_some((open, close));
+                }
+            }
+            _ => {}
+        }
+    }
+    None
 }
 
 /// One mutation of a prop as it is written in the source.

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/types.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/types.rs
@@ -1891,6 +1891,13 @@ pub struct ComponentClientTransformState<'a> {
     /// exempts every such arrow body from the `$.assign` wrap, not just event ones.
     pub in_component_attribute: bool,
 
+    /// Whether the node being visited sits directly in a `RegularElement`'s
+    /// children. Upstream's component exemption above is spelled
+    /// `path.at(-2) === 'Component' && path.at(-3) === 'Fragment'`, and an
+    /// element's children are the one container it does not visit through a
+    /// `Fragment` node — so a component nested in an element is *not* exempt.
+    pub parent_is_regular_element: bool,
+
     /// One-shot token mirroring upstream's `path.at(-1) !== 'ExpressionStatement'`
     /// guard: set just before converting the direct expression child of an
     /// `ExpressionStatement`, consumed (and cleared) by the assignment visitor so
@@ -2203,6 +2210,7 @@ impl<'a> ComponentClientTransformState<'a> {
             in_direct_assignment_lhs: false,
             in_bind_directive: false,
             in_component_attribute: false,
+            parent_is_regular_element: false,
             assignment_is_statement: false,
             in_event_attribute_handler: false,
             event_handler_arrow_body_level: 0,

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/types.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/types.rs
@@ -1898,6 +1898,11 @@ pub struct ComponentClientTransformState<'a> {
     /// `Fragment` node — so a component nested in an element is *not* exempt.
     pub parent_is_regular_element: bool,
 
+    /// Name of the declarator whose `$state(...)` initializer is being converted.
+    /// `create_state_declarator` (`VariableDeclaration.js`) labels the proxy with
+    /// it, and the expression converter has no other way back to the pattern.
+    pub state_declarator_name: Option<String>,
+
     /// One-shot token mirroring upstream's `path.at(-1) !== 'ExpressionStatement'`
     /// guard: set just before converting the direct expression child of an
     /// `ExpressionStatement`, consumed (and cleared) by the assignment visitor so
@@ -2211,6 +2216,7 @@ impl<'a> ComponentClientTransformState<'a> {
             in_bind_directive: false,
             in_component_attribute: false,
             parent_is_regular_element: false,
+            state_declarator_name: None,
             assignment_is_statement: false,
             in_event_attribute_handler: false,
             event_handler_arrow_body_level: 0,

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/expression_converter.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/expression_converter.rs
@@ -2219,6 +2219,26 @@ fn should_proxy_json(value: &Value) -> bool {
     }
 }
 
+/// Whether `value` is a direct `$state(...)` call — the only initializer shape
+/// `create_state_declarator` labels.
+fn is_state_rune_call(value: &Value, context: &ComponentContext) -> bool {
+    value
+        .as_object()
+        .filter(|obj| obj.get("type").and_then(|t| t.as_str()) == Some("CallExpression"))
+        .and_then(|obj| get_rune_from_call(obj, context))
+        .is_some_and(|rune| rune == "$state")
+}
+
+/// Typed counterpart of [`is_state_rune_call`].
+fn is_state_rune_call_jsnode(node: &JsNode, pa: &ParseArena, context: &ComponentContext) -> bool {
+    let JsNode::CallExpression { callee, .. } = node else {
+        return false;
+    };
+    let callee_node = pa.get_js_node(*callee);
+    is_potential_rune_call(callee_node, context)
+        && get_rune_from_call_jsnode(callee_node, pa, context).is_some_and(|rune| rune == "$state")
+}
+
 /// Transform a rune call expression.
 ///
 /// This mirrors the official Svelte compiler's CallExpression.js visitor.
@@ -2277,7 +2297,7 @@ fn transform_rune_call(
 
                 // For $state (not $state.raw), wrap with $.proxy() if the value is an object/array
                 if rune == "$state" && should_proxy_json(arg_value) {
-                    JsExpr::Call(JsCallExpression {
+                    let proxied = JsExpr::Call(JsCallExpression {
                         callee: context.arena.alloc_expr(JsExpr::Member(JsMemberExpression {
                             object: context.arena.alloc_expr(JsExpr::Identifier("$".into())),
                             property: JsMemberProperty::Identifier("proxy".into()),
@@ -2286,7 +2306,23 @@ fn transform_rune_call(
                         })),
                         arguments: vec![converted],
                         optional: false,
-                    })
+                    });
+                    match context.state.state_declarator_name.take() {
+                        Some(name) if context.state.dev => JsExpr::Call(JsCallExpression {
+                            callee: context.arena.alloc_expr(JsExpr::Member(JsMemberExpression {
+                                object: context.arena.alloc_expr(JsExpr::Identifier("$".into())),
+                                property: JsMemberProperty::Identifier("tag_proxy".into()),
+                                computed: false,
+                                optional: false,
+                            })),
+                            arguments: vec![
+                                proxied,
+                                JsExpr::Literal(JsLiteral::String(name.into())),
+                            ],
+                            optional: false,
+                        }),
+                        _ => proxied,
+                    }
                 } else {
                     // Primitives or $state.raw: just return the value as-is
                     converted
@@ -3791,7 +3827,15 @@ fn convert_statement(stmt: &Value, context: &mut ComponentContext) -> Option<JsS
                             // In ESTree, `init: null` means no initializer (e.g., `let x;`).
                             // We must filter out JSON null so we don't generate `let x = null;`.
                             let init = decl_obj.get("init").filter(|i| !i.is_null()).map(|i| {
+                                let saved_state_declarator_name =
+                                    context.state.state_declarator_name.take();
+                                if let JsPattern::Identifier(ref name) = pattern
+                                    && is_state_rune_call(i, context)
+                                {
+                                    context.state.state_declarator_name = Some(name.to_string());
+                                }
                                 let __tmp = convert_json_value(i, context);
+                                context.state.state_declarator_name = saved_state_declarator_name;
                                 context.arena.alloc_expr(__tmp)
                             });
                             Some(JsVariableDeclarator {
@@ -6217,7 +6261,16 @@ fn convert_statement_from_jsnode(
                             }
                         }
                         let init_expr = init.map(|i| {
-                            let __tmp = convert_js_node(pa.get_js_node(i), context);
+                            let init_node = pa.get_js_node(i);
+                            let saved_state_declarator_name =
+                                context.state.state_declarator_name.take();
+                            if let JsPattern::Identifier(ref name) = pattern
+                                && is_state_rune_call_jsnode(init_node, pa, context)
+                            {
+                                context.state.state_declarator_name = Some(name.to_string());
+                            }
+                            let __tmp = convert_js_node(init_node, context);
+                            context.state.state_declarator_name = saved_state_declarator_name;
                             context.arena.alloc_expr(__tmp)
                         });
                         Some(JsVariableDeclarator {

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/fragment.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/fragment.rs
@@ -190,6 +190,7 @@ pub fn fragment(
         in_direct_assignment_lhs: false,
         in_bind_directive: false,
         in_component_attribute: false,
+        parent_is_regular_element: false,
         assignment_is_statement: false,
         in_event_attribute_handler: false,
         event_handler_arrow_body_level: 0,

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/fragment.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/fragment.rs
@@ -191,6 +191,7 @@ pub fn fragment(
         in_bind_directive: false,
         in_component_attribute: false,
         parent_is_regular_element: false,
+        state_declarator_name: None,
         assignment_is_statement: false,
         in_event_attribute_handler: false,
         event_handler_arrow_body_level: 0,

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/regular_element.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/regular_element.rs
@@ -1113,6 +1113,8 @@ pub fn visit_regular_element(
         // while `context` is reborrowed mutably by the `process_children`
         // closure. The arena outlives this borrow; traversal is single-threaded.
         let arena_ref2 = unsafe { &*(&context.arena as *const _) };
+        let saved_parent_is_regular_element = context.state.parent_is_regular_element;
+        context.state.parent_is_regular_element = true;
         process_children(
             &cleaned.trimmed,
             |is_text| {
@@ -1129,6 +1131,7 @@ pub fn visit_regular_element(
             false, // Not an element - we're processing into a fragment
             context,
         );
+        context.state.parent_is_regular_element = saved_parent_is_regular_element;
 
         // Capture the init/update/after_update statements from processing children
         let child_init = std::mem::take(&mut context.state.init);
@@ -1261,6 +1264,8 @@ pub fn visit_regular_element(
         // while `context` is reborrowed mutably by the `process_children`
         // closure. The arena outlives this borrow; traversal is single-threaded.
         let arena_ref3 = unsafe { &*(&context.arena as *const _) };
+        let saved_parent_is_regular_element = context.state.parent_is_regular_element;
+        context.state.parent_is_regular_element = true;
         process_children(
             &cleaned.trimmed,
             |is_text| {
@@ -1274,6 +1279,7 @@ pub fn visit_regular_element(
             true, // is_element
             context,
         );
+        context.state.parent_is_regular_element = saved_parent_is_regular_element;
 
         // Reset after processing children if needed
         // A reset is only needed if any child would actually advance the hydrate_node cursor.

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/component.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/component.rs
@@ -1305,6 +1305,46 @@ fn is_snippet_identifier(value: &AttributeValue, context: &ComponentContext) -> 
 }
 
 /// Process a bind directive.
+/// `validate_mutation` (`shared/utils.js:390`) for a `bind:` setter body — the
+/// directive never reaches the assignment visitor that normally applies it.
+fn validate_bind_setter_mutation(
+    expression: JsExpr,
+    bind: &BindDirective<'_>,
+    ignored_codes: &[String],
+    context: &mut ComponentContext,
+) -> JsExpr {
+    use crate::compiler::phases::phase3_transform::client::visitors::expression_converter::{
+        check_ownership_validation, ownership_alias_literal,
+    };
+
+    if !context.state.dev
+        || ignored_codes
+            .iter()
+            .any(|code| code == "ownership_invalid_mutation")
+    {
+        return expression;
+    }
+    let Some((prop_alias, path, source_loc)) =
+        check_ownership_validation(Some(bind.expression.as_json()), context)
+    else {
+        return expression;
+    };
+    let mut args = vec![
+        ownership_alias_literal(prop_alias),
+        b::array(path),
+        expression,
+    ];
+    if let Some((line, col)) = source_loc {
+        args.push(b::literal_number(line as f64));
+        args.push(b::literal_number(col as f64));
+    }
+    b::call(
+        &context.arena,
+        b::member_path(&context.arena, "$$ownership_validator.mutation"),
+        args,
+    )
+}
+
 fn process_bind_directive<'a>(
     bind: &BindDirective<'a>,
     context: &mut ComponentContext,
@@ -1788,41 +1828,7 @@ fn process_bind_directive<'a>(
                 let wrapped = crate::compiler::phases::phase3_transform::client::visitors::expression_converter::wrap_with_legacy_invalidate(
                     call, &root_name, context,
                 );
-                // Dev mode: wrap prop member mutations with the ownership validator too,
-                // mirroring the generic AssignmentExpression path (validate_mutation in
-                // utils.js), since bind: directives never flow through that visitor.
-                let mutation_ignored = ignored_codes
-                    .iter()
-                    .any(|c| c == "ownership_invalid_mutation");
-                let wrapped = if context.state.dev && !mutation_ignored {
-                    if let Some((prop_alias, path, source_loc)) =
-                        crate::compiler::phases::phase3_transform::client::visitors::expression_converter::check_ownership_validation(
-                            Some(bind.expression.as_json()),
-                            context,
-                        )
-                    {
-                        let mut args = vec![
-                            crate::compiler::phases::phase3_transform::client::visitors::expression_converter::ownership_alias_literal(
-                                prop_alias,
-                            ),
-                            b::array(path),
-                            wrapped,
-                        ];
-                        if let Some((line, col)) = source_loc {
-                            args.push(b::literal_number(line as f64));
-                            args.push(b::literal_number(col as f64));
-                        }
-                        b::call(
-                            &context.arena,
-                            b::member_path(&context.arena, "$$ownership_validator.mutation"),
-                            args,
-                        )
-                    } else {
-                        wrapped
-                    }
-                } else {
-                    wrapped
-                };
+                let wrapped = validate_bind_setter_mutation(wrapped, bind, ignored_codes, context);
                 vec![b::stmt(&context.arena, wrapped)]
             } else if is_state {
                 if context.state.analysis.runes {
@@ -1833,6 +1839,8 @@ fn process_bind_directive<'a>(
                         transformed_expression.clone(),
                         b::id("$$value"),
                     );
+                    let assignment =
+                        validate_bind_setter_mutation(assignment, bind, ignored_codes, context);
                     vec![b::stmt(&context.arena, assignment)]
                 } else {
                     // In legacy mode, wrap in $.mutate():
@@ -1855,14 +1863,14 @@ fn process_bind_directive<'a>(
                 // Upstream falls through to `context.next()`, which visits the whole
                 // assignment target — inner references (an each-block thunk in a
                 // computed key) carry read transforms even when the root has none.
-                vec![b::stmt(
+                let assignment = b::assign(
                     &context.arena,
-                    b::assign(
-                        &context.arena,
-                        transformed_expression.clone(),
-                        b::id("$$value"),
-                    ),
-                )]
+                    transformed_expression.clone(),
+                    b::id("$$value"),
+                );
+                let assignment =
+                    validate_bind_setter_mutation(assignment, bind, ignored_codes, context);
+                vec![b::stmt(&context.arena, assignment)]
             }
         } else {
             vec![b::stmt(

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/component.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/component.rs
@@ -983,7 +983,7 @@ fn process_on_directive(
     // outlives this borrow and traversal is single-threaded (no aliasing).
     let arena_local = unsafe { &*(&context.arena as *const _) };
     let saved_in_component_attribute = context.state.in_component_attribute;
-    context.state.in_component_attribute = true;
+    context.state.in_component_attribute = !context.state.parent_is_regular_element;
     let mut handler = build_event_handler(
         arena_local,
         on_directive.expression.as_ref(),
@@ -1142,7 +1142,7 @@ fn process_regular_attribute(
     // The closure is invoked for each chunk's transformed expression.
     let arena_ptr = (&context.arena) as *const _;
     let saved_in_component_attribute = context.state.in_component_attribute;
-    context.state.in_component_attribute = true;
+    context.state.in_component_attribute = !context.state.parent_is_regular_element;
     let result = build_attribute_value(&attr.value, context, |value, metadata| {
         let has_await = metadata.has_await();
         let has_state = metadata.has_state();
@@ -2306,6 +2306,8 @@ fn visit_slot_children(
 
     // Save the current state
     // This mirrors Fragment.js which creates a new state with fresh consts, init, update, etc.
+    let saved_parent_is_regular_element =
+        std::mem::take(&mut context.state.parent_is_regular_element);
     let saved_init = std::mem::take(&mut context.state.init);
     let saved_update = std::mem::take(&mut context.state.update);
     let saved_after_update = std::mem::take(&mut context.state.after_update);
@@ -2834,6 +2836,7 @@ fn visit_slot_children(
     context.state.node = saved_node;
     context.state.is_standalone = saved_is_standalone;
     context.state.metadata.namespace = saved_namespace;
+    context.state.parent_is_regular_element = saved_parent_is_regular_element;
 
     result
 }

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/css.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/css.rs
@@ -934,15 +934,34 @@ fn emit_selector(
     let emitted = produced.as_bytes();
     let mut runs: Vec<(usize, usize, usize)> = Vec::new();
     let (mut i, mut j) = (0usize, 0usize);
-    while j < emitted.len() {
-        for inserted in [where_modifier.as_bytes(), modifier.as_bytes()] {
-            if emitted[j..].starts_with(inserted) && !src[i..].starts_with(inserted) {
+    'emitted: while j < emitted.len() {
+        // `prependRight` / `appendRight` / `appendLeft` insertions carry no
+        // segment of their own, so they only move the generated cursor.
+        for inserted in [
+            where_modifier.as_bytes(),
+            modifier.as_bytes(),
+            b"/* (unused) ".as_slice(),
+            b"*/".as_slice(),
+        ] {
+            if !inserted.is_empty()
+                && emitted[j..].starts_with(inserted)
+                && !src[i..].starts_with(inserted)
+            {
                 j += inserted.len();
-                break;
+                continue 'emitted;
             }
         }
-        if j >= emitted.len() {
-            break;
+        // The separator before a pruned selector goes through `overwrite`,
+        // which keeps the chunk it replaces — so the replacement's first byte
+        // carries that separator's position.
+        if emitted[j..].starts_with(b" /* (unused) ") && i < src.len() && src[i] == b',' {
+            runs.push((j, i, 1));
+            j += " /* (unused) ".len();
+            i += 1;
+            while i < src.len() && src[i].is_ascii_whitespace() {
+                i += 1;
+            }
+            continue;
         }
         if i < src.len() && src[i] == emitted[j] {
             match runs.last_mut() {

--- a/crates/rsvelte_core/tests/dev_assign_async_lazy_getter.rs
+++ b/crates/rsvelte_core/tests/dev_assign_async_lazy_getter.rs
@@ -1,0 +1,86 @@
+//! `build_assignment` builds `await $.assign_async(...)` and hands it to
+//! `context.visit`, so the `await` it adds gets the same
+//! `$.track_reactivity_loss` instrumentation any source `await` does — while
+//! `arrow` (`utils/builders.js`) collapses the lazy getter it wraps back to a
+//! synchronous `() => x()`.
+//!
+//! The corpus gates compile with `dev: false`, so nothing else covers this.
+
+use rsvelte_core::{CompileOptions, GenerateMode, compile};
+
+fn compile_client_dev(src: &str) -> String {
+    compile(
+        src,
+        CompileOptions {
+            filename: Some("Main.svelte".to_string()),
+            generate: GenerateMode::Client,
+            dev: true,
+            ..Default::default()
+        },
+    )
+    .expect("compile")
+    .js
+    .code
+}
+
+#[test]
+fn the_generated_await_is_instrumented_and_the_getter_is_synchronous() {
+    let out = compile_client_dev(
+        r#"<script>
+	let cache = $state({});
+
+	async function go() {
+		const value = cache.value ??= await get_value();
+	}
+
+	function get_value() {
+		return 42;
+	}
+</script>
+
+<button onclick={go}>go</button>
+"#,
+    );
+
+    assert!(
+        out.contains("await $.track_reactivity_loss($.assign_async("),
+        "got:\n{out}"
+    );
+    assert!(out.contains("() => get_value()"), "got:\n{out}");
+    assert!(!out.contains("async () =>"), "got:\n{out}");
+}
+
+#[test]
+fn a_getter_with_a_nested_await_stays_asynchronous() {
+    let out = compile_client_dev(
+        r#"<script>
+	let cache = $state({});
+
+	async function go() {
+		const value = cache.value ??= await outer(await inner());
+	}
+</script>
+
+<button onclick={go}>go</button>
+"#,
+    );
+
+    assert!(out.contains("$.assign_async("), "got:\n{out}");
+    assert!(out.contains("async () =>"), "got:\n{out}");
+}
+
+#[test]
+fn an_untransformed_site_does_not_lend_its_position_to_a_later_twin() {
+    let out = compile_client_dev(
+        r#"<script>
+	let { opacity = 0.5 } = $props();
+
+	const fixed = (node) => node.style.opacity = 0.5;
+
+	const unknown = (node) => node.style.opacity = opacity;
+</script>
+"#,
+    );
+
+    assert!(out.contains("Main.svelte:6:27"), "got:\n{out}");
+}

--- a/crates/rsvelte_core/tests/dev_assign_component_in_element.rs
+++ b/crates/rsvelte_core/tests/dev_assign_component_in_element.rs
@@ -1,0 +1,69 @@
+//! Upstream exempts a component-prop arrow from the dev `$.assign` wrap only
+//! when the component itself is a `Fragment` child
+//! (`path.at(-2) === 'Component' && path.at(-3) === 'Fragment'`,
+//! `AssignmentExpression.js`). An element's children are the one container it
+//! does not visit through a `Fragment` node, so a component nested in an
+//! element keeps the wrap.
+//!
+//! The corpus gates compile with `dev: false`, so nothing else covers this.
+
+use rsvelte_core::{CompileOptions, GenerateMode, compile};
+
+fn compile_client_dev(src: &str) -> String {
+    compile(
+        src,
+        CompileOptions {
+            filename: Some("Main.svelte".to_string()),
+            generate: GenerateMode::Client,
+            dev: true,
+            ..Default::default()
+        },
+    )
+    .expect("compile")
+    .js
+    .code
+}
+
+const SCRIPT: &str =
+    "<script>\n\timport Foo from './Foo.svelte';\n\tlet obj = $state({ p: 0 });\n</script>\n";
+
+#[test]
+fn a_component_directly_in_a_fragment_keeps_its_arrow_bare() {
+    let out = compile_client_dev(&format!("{SCRIPT}<Foo onX={{(e) => (obj.p = e.v)}} />\n"));
+    assert!(!out.contains("$.assign("), "got:\n{out}");
+}
+
+#[test]
+fn a_component_nested_in_an_element_is_wrapped() {
+    let out = compile_client_dev(&format!(
+        "{SCRIPT}<div><Foo onX={{(e) => (obj.p = e.v)}} /></div>\n"
+    ));
+    assert!(out.contains("$.assign("), "got:\n{out}");
+}
+
+#[test]
+fn a_block_inside_an_element_is_a_fragment_again() {
+    let out = compile_client_dev(&format!(
+        "{SCRIPT}<div>{{#if obj.p}}<Foo onX={{(e) => (obj.p = e.v)}} />{{/if}}</div>\n"
+    ));
+    assert!(!out.contains("$.assign("), "got:\n{out}");
+}
+
+#[test]
+fn slot_content_inside_an_element_is_a_fragment_again() {
+    let out = compile_client_dev(&format!(
+        "{SCRIPT}<div><Foo><Foo onX={{(e) => (obj.p = e.v)}} /></Foo></div>\n"
+    ));
+    assert!(!out.contains("$.assign("), "got:\n{out}");
+}
+
+#[test]
+fn a_legacy_on_directive_follows_the_same_rule() {
+    let bare = compile_client_dev(&format!("{SCRIPT}<Foo on:x={{(e) => (obj.p = e.v)}} />\n"));
+    assert!(!bare.contains("$.assign("), "got:\n{bare}");
+
+    let wrapped = compile_client_dev(&format!(
+        "{SCRIPT}<div><Foo on:x={{(e) => (obj.p = e.v)}} /></div>\n"
+    ));
+    assert!(wrapped.contains("$.assign("), "got:\n{wrapped}");
+}

--- a/crates/rsvelte_core/tests/dev_await_statement_terminator.rs
+++ b/crates/rsvelte_core/tests/dev_await_statement_terminator.rs
@@ -65,3 +65,46 @@ fn consecutive_unterminated_awaits_stay_separate_statements_in_legacy_mode() {
         "the two awaits must not fold into one call, got:\n{out}"
     );
 }
+
+#[test]
+fn an_open_statement_before_the_wrapper_is_separated() {
+    let out = compile_client_dev(
+        r#"<script>
+	export let n = 0
+	function log() {}
+	async function go() {
+		if (n) log()
+
+		await fetch('/a')
+		n++
+	}
+</script>
+<button on:click={go}>{n}</button>
+"#,
+    );
+    assert!(
+        out.contains("if (n()) log();"),
+        "the `if` body must be terminated, got:\n{out}"
+    );
+}
+
+#[test]
+fn a_closed_statement_before_the_wrapper_is_left_alone() {
+    let out = compile_client_dev(
+        r#"<script>
+	export let n = 0
+	function log() {}
+	async function go() {
+		if (n) { log() }
+		await fetch('/a')
+		n++
+	}
+</script>
+<button on:click={go}>{n}</button>
+"#,
+    );
+    assert!(
+        out.contains("}\n\n\t\t(await"),
+        "a block needs no terminator, got:\n{out}"
+    );
+}

--- a/crates/rsvelte_core/tests/dev_bind_setter_ownership.rs
+++ b/crates/rsvelte_core/tests/dev_bind_setter_ownership.rs
@@ -1,0 +1,61 @@
+//! A component `bind:` whose expression is a member of a prop still goes
+//! through `validate_mutation` (`shared/utils.js:390`) — it gates on the root
+//! binding being a prop, not on whether the mutation itself is wrapped. A
+//! non-bindable prop in runes mode assigns the member directly, and that bare
+//! assignment is what the ownership wrap receives.
+//!
+//! The corpus gates compile with `dev: false`, so nothing else covers this.
+
+use rsvelte_core::{CompileOptions, GenerateMode, compile};
+
+fn compile_client_dev(src: &str) -> String {
+    compile(
+        src,
+        CompileOptions {
+            filename: Some("Main.svelte".to_string()),
+            generate: GenerateMode::Client,
+            dev: true,
+            ..Default::default()
+        },
+    )
+    .expect("compile")
+    .js
+    .code
+}
+
+#[test]
+fn a_runes_prop_member_bind_setter_is_validated() {
+    let out = compile_client_dev(
+        r#"<script>
+	import Checkbox from './Checkbox.svelte';
+
+	let { workspace } = $props();
+</script>
+
+<Checkbox bind:checked={workspace.vim} />
+"#,
+    );
+    assert!(
+        out.contains("$$ownership_validator.mutation("),
+        "got:\n{out}"
+    );
+    assert!(out.contains("['workspace', 'vim']"), "got:\n{out}");
+}
+
+#[test]
+fn a_state_member_bind_setter_is_not() {
+    let out = compile_client_dev(
+        r#"<script>
+	import Checkbox from './Checkbox.svelte';
+
+	let options = $state({ vim: false });
+</script>
+
+<Checkbox bind:checked={options.vim} />
+"#,
+    );
+    assert!(
+        !out.contains("$$ownership_validator.mutation("),
+        "got:\n{out}"
+    );
+}

--- a/crates/rsvelte_core/tests/dev_console_wrap_shadowing.rs
+++ b/crates/rsvelte_core/tests/dev_console_wrap_shadowing.rs
@@ -1,0 +1,65 @@
+//! `CallExpression.js` wraps a `console.*` call only when some argument's
+//! `scope.evaluate` can be unknown. Resolution has to follow the scope chain a
+//! script reference actually sees: a same-named template binding is not in
+//! scope there, and an instance declaration shadows the module one.
+//!
+//! The corpus gates compile with `dev: false`, so nothing else covers this.
+
+use rsvelte_core::{CompileOptions, GenerateMode, compile};
+
+fn compile_client_dev(src: &str) -> String {
+    compile(
+        src,
+        CompileOptions {
+            filename: Some("Main.svelte".to_string()),
+            generate: GenerateMode::Client,
+            dev: true,
+            ..Default::default()
+        },
+    )
+    .expect("compile")
+    .js
+    .code
+}
+
+#[test]
+fn an_instance_local_shadowing_a_module_export_keeps_its_own_value() {
+    let out = compile_client_dev(
+        "<script module>\n\texport const foo = 42;\n</script>\n\n<script>\n\tlet foo = 100;\n\n\tconsole.log(foo);\n</script>\n",
+    );
+    assert!(!out.contains("$.log_if_contains_state"), "got:\n{out}");
+}
+
+#[test]
+fn an_each_item_does_not_shadow_a_script_reference() {
+    let out = compile_client_dev(
+        r#"<script>
+	let method = $state('method');
+
+	function submitPay() {
+		console.log(method);
+	}
+
+	let methods = [{ method: 1 }];
+</script>
+
+{#each methods as { method }}
+	<button onclick={submitPay}>{method}</button>
+{/each}
+"#,
+    );
+    assert!(!out.contains("$.log_if_contains_state"), "got:\n{out}");
+}
+
+#[test]
+fn an_unknown_argument_is_still_wrapped() {
+    let out = compile_client_dev(
+        r#"<script>
+	let { value } = $props();
+
+	console.log(value);
+</script>
+"#,
+    );
+    assert!(out.contains("$.log_if_contains_state"), "got:\n{out}");
+}

--- a/crates/rsvelte_core/tests/dev_css_sourcemap.rs
+++ b/crates/rsvelte_core/tests/dev_css_sourcemap.rs
@@ -86,3 +86,26 @@ fn a_custom_element_carries_the_map_too() {
     );
     assert!(map.contains("\"mappings\":\";AAKA,"), "got:\n{map}");
 }
+
+#[test]
+fn a_partially_pruned_selector_list_keeps_its_segments() {
+    let map = injected_css(
+        r#"<svelte:options css="injected" />
+
+<div class="foo">foo</div>
+
+<style>
+	.foo, .unused {
+		color: green;
+	}
+</style>
+"#,
+    );
+    // `overwrite` replaces the separator before the pruned selector, so the
+    // ` /* (unused) ` it writes still carries that separator's position, and
+    // both selectors keep segments of their own.
+    assert!(
+        map.contains("\"mappings\":\";AAKA,CAAC,kBAAI,aAAE,SAAO,CAAC;AACf,EAAE,YAAY;AACd;\""),
+        "got:\n{map}"
+    );
+}

--- a/crates/rsvelte_core/tests/dev_destructured_async_assignment.rs
+++ b/crates/rsvelte_core/tests/dev_destructured_async_assignment.rs
@@ -1,0 +1,41 @@
+//! An async destructuring assignment is lowered to
+//! `await (async ($$value) => { … })(…)`. Upstream destructures after a single
+//! instrumented `await`, so only the source `await` carries
+//! `$.track_reactivity_loss` — the generated call has no counterpart.
+//!
+//! The corpus gates compile with `dev: false`, so nothing else covers this.
+
+use rsvelte_core::{CompileOptions, GenerateMode, compile};
+
+#[test]
+fn only_the_source_await_is_instrumented() {
+    let out = compile(
+        r#"<script>
+	let a = $state(0);
+	let b = $state(0);
+
+	const update = async () => {
+		[a, b] = [1, await Promise.resolve(2)];
+	};
+</script>
+
+<button onclick={update}>{a}{b}</button>
+"#,
+        CompileOptions {
+            filename: Some("Main.svelte".to_string()),
+            generate: GenerateMode::Client,
+            dev: true,
+            ..Default::default()
+        },
+    )
+    .expect("compile")
+    .js
+    .code;
+
+    assert!(out.contains("await (async ($$value) =>"), "got:\n{out}");
+    assert_eq!(
+        out.matches("$.track_reactivity_loss").count(),
+        1,
+        "got:\n{out}"
+    );
+}

--- a/crates/rsvelte_core/tests/dev_destructuring_default_equality.rs
+++ b/crates/rsvelte_core/tests/dev_destructuring_default_equality.rs
@@ -1,0 +1,34 @@
+//! A destructuring default is an ordinary expression to upstream, so the dev
+//! equality instrumentation (`BinaryExpression.js`) reaches it. rsvelte lifted
+//! the pattern's source text verbatim, which skipped every rewrite.
+//!
+//! The corpus gates compile with `dev: false`, so nothing else covers this.
+
+use rsvelte_core::{CompileOptions, GenerateMode, compile};
+
+#[test]
+fn a_derived_destructuring_default_is_instrumented() {
+    let out = compile(
+        r#"<script>
+	const props = $props();
+	const { target = typeof window === 'undefined' ? undefined : document.body } = $derived(props);
+</script>
+
+{target}
+"#,
+        CompileOptions {
+            filename: Some("Main.svelte".to_string()),
+            generate: GenerateMode::Client,
+            dev: true,
+            ..Default::default()
+        },
+    )
+    .expect("compile")
+    .js
+    .code;
+
+    assert!(
+        out.contains("$.strict_equals(typeof window, 'undefined')"),
+        "got:\n{out}"
+    );
+}

--- a/crates/rsvelte_core/tests/dev_inspect_trace_label.rs
+++ b/crates/rsvelte_core/tests/dev_inspect_trace_label.rs
@@ -1,0 +1,39 @@
+//! The `$inspect.trace()` label carries `locate_node(fn)` — the position of the
+//! enclosing function, which upstream reads off the AST
+//! (`2-analyze/visitors/CallExpression.js`). rsvelte finds it by scanning
+//! backwards from the call, so a comment in between used to answer for the
+//! function head.
+//!
+//! The corpus gates compile with `dev: false`, so nothing else covers this.
+
+use rsvelte_core::{CompileOptions, GenerateMode, compile};
+
+#[test]
+fn a_comment_before_the_trace_call_does_not_move_the_label() {
+    let out = compile(
+        r#"<script>
+	let count = $state(0);
+
+	$effect(() => {
+		// $inspect.trace must be the first statement of a function body
+		$inspect.trace();
+		count;
+	});
+</script>
+"#,
+        CompileOptions {
+            filename: Some("Main.svelte".to_string()),
+            generate: GenerateMode::Client,
+            dev: true,
+            ..Default::default()
+        },
+    )
+    .expect("compile")
+    .js
+    .code;
+
+    assert!(
+        out.contains("'$effect(...) (Main.svelte:4:9)'"),
+        "got:\n{out}"
+    );
+}

--- a/crates/rsvelte_core/tests/dev_ownership_invalidate_sequence.rs
+++ b/crates/rsvelte_core/tests/dev_ownership_invalidate_sequence.rs
@@ -1,0 +1,58 @@
+//! A prop that carries legacy indirect bindings gets its mutation paired with
+//! `$.invalidate_inner_signals(...)` in a sequence, and upstream builds that
+//! sequence *before* `validate_mutation` wraps it — so the sequence is the
+//! wrap's third argument, not its parent (`AssignmentExpression.js:139-166`).
+//!
+//! The corpus gates compile with `dev: false`, so nothing else covers this.
+
+use rsvelte_core::{CompileOptions, GenerateMode, compile};
+
+#[test]
+fn the_invalidate_sequence_sits_inside_the_ownership_wrap() {
+    let out = compile(
+        r#"<script>
+	export let field;
+	let selectId = 'a';
+
+	function reset() {
+		field.attributes = {};
+	}
+</script>
+
+<button onclick={reset}>reset</button>
+
+<select id={selectId} bind:value={field.attributes.position}>
+	<option value="top">top</option>
+</select>
+"#,
+        CompileOptions {
+            filename: Some("Main.svelte".to_string()),
+            generate: GenerateMode::Client,
+            dev: true,
+            ..Default::default()
+        },
+    )
+    .expect("compile")
+    .js
+    .code;
+
+    let head = "$$ownership_validator.mutation(";
+    let start = out.find(head).expect("no ownership wrap") + head.len();
+    let invalidate = out[start..]
+        .find("$.invalidate_inner_signals")
+        .expect("no invalidate wrap");
+    let mut depth = 0i32;
+    let arguments_end = out[start..]
+        .char_indices()
+        .find(|(_, ch)| {
+            match ch {
+                '(' | '[' | '{' => depth += 1,
+                ')' | ']' | '}' => depth -= 1,
+                _ => {}
+            }
+            depth < 0
+        })
+        .map(|(offset, _)| offset)
+        .expect("unterminated wrap");
+    assert!(invalidate < arguments_end, "got:\n{out}");
+}

--- a/crates/rsvelte_core/tests/dev_state_tag_proxy.rs
+++ b/crates/rsvelte_core/tests/dev_state_tag_proxy.rs
@@ -1,0 +1,79 @@
+//! `create_state_declarator` (`VariableDeclaration.js`) labels a proxied
+//! `$state` initializer with `$.tag_proxy(value, name)`, and it decides on the
+//! *visited* expression — so in dev an `a === b` initializer has already become
+//! a `$.strict_equals(...)` call and therefore proxies.
+//!
+//! The corpus gates compile with `dev: false`, so nothing else covers this.
+
+use rsvelte_core::{CompileOptions, GenerateMode, compile};
+
+fn compile_client(src: &str, dev: bool) -> String {
+    compile(
+        src,
+        CompileOptions {
+            filename: Some("Main.svelte".to_string()),
+            generate: GenerateMode::Client,
+            dev,
+            ..Default::default()
+        },
+    )
+    .expect("compile")
+    .js
+    .code
+}
+
+#[test]
+fn an_equality_initializer_proxies_in_dev_only() {
+    let src = r#"<script>
+	const isStandalone = $state(window.self === window.top);
+</script>
+
+{isStandalone}
+"#;
+    let dev = compile_client(src, true);
+    assert!(
+        dev.contains(
+            "$.tag_proxy($.proxy($.strict_equals(window.self, window.top)), 'isStandalone')"
+        ),
+        "got:\n{dev}"
+    );
+
+    let prod = compile_client(src, false);
+    assert!(!prod.contains("$.proxy("), "got:\n{prod}");
+}
+
+#[test]
+fn an_arithmetic_initializer_never_proxies() {
+    let out = compile_client(
+        r#"<script>
+	const total = $state(1 + 2);
+</script>
+
+{total}
+"#,
+        true,
+    );
+    assert!(!out.contains("$.proxy("), "got:\n{out}");
+}
+
+#[test]
+fn a_state_declared_in_a_handler_body_is_tagged() {
+    let out = compile_client(
+        r#"<script>
+	import { SvelteSet } from 'svelte/reactivity';
+
+	const set = new SvelteSet();
+</script>
+
+<button onclick={() => {
+	const entry = $state({ name: 'a' });
+	set.add(entry);
+}}>add</button>
+"#,
+        true,
+    );
+    assert!(
+        out.contains("$.tag_proxy($.proxy({ name: 'a' }), 'entry')"),
+        "got:\n{out}"
+    );
+}


### PR DESCRIPTION
Burns the `client-dev` corpus ratchet from 18 to **0**. `client` and `server` stay at 0 — no non-dev target changed.

Each fix mirrors the official compiler; every one is covered by a test, because the corpus gates compile with `dev: false` and nothing else exercises these paths.

- **`$.assign` component exemption** — upstream spells it `path.at(-2) === 'Component' && path.at(-3) === 'Fragment'`, and an element's children are the one container it does not visit through a `Fragment`, so a component nested in an element keeps the wrap.
- **`$.invalidate_inner_signals` sequence** — upstream builds it in `build_assignment` and hands the result to `validate_mutation`, so it belongs *inside* the ownership wrap, not around it.
- **`bind:` setter ownership** — `validate_mutation` gates on the root binding being a prop, not on whether the mutation itself is wrapped, so a runes non-bindable prop needs the wrap too.
- **`$.tag_proxy` label** — `create_state_declarator` decides on the *visited* initializer, and a `$state` declared inside a template handler reaches the expression converter, which had no way back to the declarator's name.
- **`$derived` destructuring default** — the pattern's source text was lifted before the walk reached it, so a default value never got the dev equality rewrite.
- **`$inspect.trace()` label** — a comment between the function head and the call answered for `locate_node(fn)`.
- **`console.*` wrap** — resolve a shadowed name through the scope chain a script reference actually sees: an instance declaration was writing its initializer onto a same-named module binding, and an each item stayed a candidate for a script reference.
- **async destructuring** — `[a, b] = await …` lowers to `await (async ($$value) => { … })(…)`; upstream destructures after a single instrumented `await`, so the generated call is not wrapped.
- **`$.assign_async` lazy getter** — `build_assignment` hands the `await` it adds to `context.visit`, so it is instrumented like any other, and `arrow` (`utils/builders.js`) collapses the getter back to a synchronous `() => x()`.
- **`$.assign` site pairing** — a site the transform decision rejects still has to be spent, or a later identical member chain reports its position.
- **`await` statement separator** — the dev wrapper opens with `(`, so it continues *any* statement ASI left open, not just another wrapped `await`.
- **dev CSS source map** — in a partially pruned selector list the `/* (unused) ` markers are `prependRight` / `appendRight` insertions while the separator before a pruned selector goes through `overwrite`, which keeps the chunk it replaces, so both selectors and that separator still carry segments.

Corpus after the change (14028 entries × 3 targets): `js-mismatch 0`, `css-mismatch 0`, `error-mismatch 0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014EJ8yjsgEh6CxqJhQoGZHP