### PR TITLE
fix(compiler): memoize a template chunk whose pure-callee call reads a binding

### DIFF
--- a/.changeset/memoize-pure-call-with-binding-deps.md
+++ b/.changeset/memoize-pure-call-with-binding-deps.md
@@ -1,0 +1,12 @@
+---
+'@rsvelte/compiler': patch
+---
+
+Memoize a template chunk whose pure-callee call reads a binding
+
+`{Math.ceil(a / b)}` was folded to a literal instead of being memoized as a
+`$.template_effect` dependency: upstream marks a call `has_call` when the callee
+is impure **or** the expression records any dependency, and every resolved
+identifier is a dependency — even a compile-time-known `const`. The `has_call`
+bail is now also confined to the template expression itself, so a constant still
+folds when it reaches the template through a binding's initializer.

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/utils.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/utils.rs
@@ -3774,10 +3774,14 @@ fn get_literal_value_json(
                             use crate::compiler::phases::phase2_analyze::scope::BindingKind;
                             if !matches!(binding.kind, BindingKind::Derived)
                                 && init.contains("\"type\":")
+                                && INITIAL_EVAL_DEPTH.with(|d| d.get()) < MAX_INITIAL_EVAL_DEPTH
                                 && let Ok(parsed_expr) =
                                     serde_json::from_str::<crate::ast::js::Expression>(init)
                             {
-                                return get_literal_value_json(parsed_expr.as_json(), context);
+                                INITIAL_EVAL_DEPTH.with(|d| d.set(d.get() + 1));
+                                let folded = get_literal_value_json(parsed_expr.as_json(), context);
+                                INITIAL_EVAL_DEPTH.with(|d| d.set(d.get() - 1));
+                                return folded;
                             }
                         }
                         None

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/utils.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/utils.rs
@@ -3532,7 +3532,10 @@ fn get_literal_value_json(
         // `duration ? format(duration) : '--:--'` with `duration === 0`). Mirror
         // that ordering here by refusing to fold any expression whose
         // `has_call` flag is set, so the chunk falls through to memoization.
-        // This subsumes the per-`Math.*` state-arg guard below.
+        // This subsumes the per-`Math.*` state-arg guard below. The depth guard
+        // keeps it to the template expression: `has_call` is that expression's
+        // metadata, and `scope.evaluate` never consults it when it recurses into
+        // a binding's initializer.
         if matches!(
             expr_type,
             "CallExpression"
@@ -3544,7 +3547,8 @@ fn get_literal_value_json(
                 | "MemberExpression"
                 | "SequenceExpression"
                 | "ChainExpression"
-        ) && has_call_json(jv, context)
+        ) && INITIAL_EVAL_DEPTH.with(|d| d.get()) == 0
+            && has_call_json(jv, context)
         {
             return None;
         }
@@ -5564,6 +5568,58 @@ fn arg_contains_state_or_raw_state_binding(
     }
 }
 
+/// Upstream's `dependencies.size > 0` term of the `has_call` rule: Phase 2 adds
+/// every resolved identifier reference to `expression.dependencies`, so a call
+/// with a pure callee is still reactive when the expression reads any binding —
+/// even one whose value is a compile-time-known constant.
+fn references_any_binding_json(json_value: &serde_json::Value, context: &ComponentContext) -> bool {
+    let Some(obj) = json_value.as_object() else {
+        return false;
+    };
+    let Some(expr_type) = obj.get("type").and_then(|v| v.as_str()) else {
+        return false;
+    };
+
+    match expr_type {
+        "Identifier" => obj
+            .get("name")
+            .and_then(|v| v.as_str())
+            .is_some_and(|name| context.state.get_binding(name).is_some()),
+        // A non-computed member/key names a property, not a reference.
+        "MemberExpression" | "Property" => {
+            let (value_key, name_key) = if expr_type == "MemberExpression" {
+                ("object", "property")
+            } else {
+                ("value", "key")
+            };
+            if let Some(value) = obj.get(value_key)
+                && references_any_binding_json(value, context)
+            {
+                return true;
+            }
+            obj.get("computed").and_then(|v| v.as_bool()) == Some(true)
+                && obj
+                    .get(name_key)
+                    .is_some_and(|name| references_any_binding_json(name, context))
+        }
+        _ => {
+            for (_key, val) in obj {
+                if val.is_object() && references_any_binding_json(val, context) {
+                    return true;
+                }
+                if let Some(arr) = val.as_array()
+                    && arr
+                        .iter()
+                        .any(|item| references_any_binding_json(item, context))
+                {
+                    return true;
+                }
+            }
+            false
+        }
+    }
+}
+
 /// Internal helper that processes JSON values directly, avoiding serde_json::from_value overhead.
 /// Returns true for calls that have reactive dependencies, matching the official Svelte compiler
 /// behavior from CallExpression.js:
@@ -5602,6 +5658,7 @@ fn has_call_json(json_value: &serde_json::Value, context: &ComponentContext) -> 
             // argument is a $state variable still gets has_call=true upstream.
             has_reactive_state_json(json_value, context)
                 || arg_contains_state_or_raw_state_binding(json_value, context)
+                || references_any_binding_json(json_value, context)
         }
         "MemberExpression" => {
             if let Some(object) = obj.get("object")


### PR DESCRIPTION
`{Math.ceil(a / b)}` in a template chunk was folded to a literal by rsvelte while
official memoizes it into a `$.template_effect` dependency.

Upstream's `has_call` rule (`2-analyze/visitors/CallExpression.js`) is
`!is_pure(callee) || expression.dependencies.size > 0`, and Phase 2 adds **every**
resolved identifier reference to `dependencies` — including a `const` whose value
is compile-time known. `Math.ceil` is a pure callee, so it is the dependency term
that makes the chunk reactive. rsvelte's `has_call_json` only counted `$state` /
reactive bindings, so the top-level bail in `get_literal_value_json` never fired
and the `Math.*` arm folded the chunk.

The dependency term is what is at issue, not the callee: probing official with
`{Math.ceil(10 / 3)}` (same call, zero dependencies) shows it **does** fold. So
this is not the "any `CallExpression`" conflation that repo knowledge warns about
— Phase 2's narrower non-pure-callee answer is deliberately not reused here.

Two changes, both mirroring upstream:

- `has_call_json`'s pure-callee arm gains upstream's `dependencies.size > 0` term
  (`references_any_binding_json`): any identifier in the call that resolves to a
  binding. Non-computed member properties and object keys are skipped, since they
  name a property rather than a reference — matching Phase 2's `is_reference` gate.
- The `has_call` bail is confined to the template expression. `has_call` is that
  expression's metadata; `scope.evaluate` never consults it when recursing into a
  binding's initializer, so the bail is now skipped under `INITIAL_EVAL_DEPTH > 0`,
  at both initializer-recursion sites.

Without the second change, #2309's fixture would regress: `const rows =
Math.ceil(sprites / cols)` read from a template folds because the call is reached
through `binding.initial`, and the widened `has_call` would otherwise bail there.
The second site (`{const call = Math.max(total, 1) / 2}` in
`tests/print/samples/declaration-tag-division`) was caught by the `client` ratchet
and fixed the same way. Verified both still fold.

### Known limitation (deliberate)

`references_any_binding_json` scopes the dependency test to the call's own
subtree. Upstream's `dependencies` is instead the whole chunk expression's set
*accumulated in visit order*, so it is genuinely order-dependent: upstream
memoizes `{a + Math.ceil(1 / 3)}` (the `a` reference is recorded before the call
is checked) but folds `{Math.ceil(1 / 3) + a}` (it is recorded after). This patch
folds both. Modelling that faithfully needs an ordered pre-order walk that
threads the accumulator through every arm of `has_call_json`; it is left out here
because no corpus entry exercises it and the rewrite would put a much larger
memoization surface at risk for no observed parity gain.

### Verification

- corpus ratchets, with oxfmt normalization, on the rebased tree (14028 entries):
  `client` 0 → 0, `server` 0 → 0, `client-dev` 20 → 20 (no regressions, no stale
  entries — no ratchet or `known-failures.md` change needed)
- `cargo test --release -p rsvelte_core --test runtime --test ssr` green;
  `--test compiler_fixtures` green
- `cargo clippy -p rsvelte_core --all-targets --all-features -- -D warnings` clean

Closes #2330

Reported by @baseballyama; the mechanism was traced while fixing #2309 (PR #2325).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012gQPtKmdY9xwn5fjdwaxK8