### PR TITLE
fix(compiler): resolve dev console arguments against the generated program's own consts

### DIFF
--- a/.changeset/console-wrap-nested-const-scope.md
+++ b/.changeset/console-wrap-nested-const-scope.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/compiler": patch
+---
+
+Resolve a dev console argument against the generated program's own `const` declarations. The script text passes only had the component analysis, which carries no binding for a name declared inside a nested function, so `const m = \`…\`; console.log(m)` in a `.svelte.(js|ts)` module was wrapped in `$.log_if_contains_state` even though upstream's `scope.evaluate` resolves `m` to a string and emits the plain call.

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/console_dev_ast.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/console_dev_ast.rs
@@ -33,7 +33,9 @@ use oxc_span::{GetSpan, SourceType};
 use crate::compiler::phases::phase2_analyze::ComponentAnalysis;
 
 use super::ast_rewrite::{self, Edit};
-use super::console_wrap::{CONSOLE_METHODS, shape_can_be_unknown};
+use super::console_wrap::{
+    CONSOLE_METHODS, LocalConsts, collect_local_consts, shape_can_be_unknown,
+};
 
 thread_local! {
     static MODULE_CONSOLE_ALLOC: RefCell<Allocator> = RefCell::new(Allocator::default());
@@ -115,6 +117,7 @@ pub(super) fn collect_console_edits(
     let mut collector = ConsoleCollector {
         source,
         analysis,
+        locals: collect_local_consts(program, analysis),
         replacements: Vec::new(),
     };
     collector.visit_program(program);
@@ -124,6 +127,7 @@ pub(super) fn collect_console_edits(
 struct ConsoleCollector<'src> {
     source: &'src str,
     analysis: Option<&'src ComponentAnalysis>,
+    locals: LocalConsts,
     replacements: Vec<Edit>,
 }
 
@@ -167,7 +171,7 @@ impl<'a, 'src> Visit<'a> for ConsoleCollector<'src> {
         if !call
             .arguments
             .iter()
-            .any(|arg| arg_can_be_unknown(arg, self.analysis))
+            .any(|arg| arg_can_be_unknown(arg, self.analysis, &self.locals))
         {
             return;
         }
@@ -264,12 +268,16 @@ fn args_contain_unwrapped_console_call(s: &str) -> bool {
 
 /// Upstream's per-argument half of the wrap test: a `SpreadElement` always
 /// forces the wrap, everything else goes through the shape lattice.
-fn arg_can_be_unknown(arg: &Argument<'_>, analysis: Option<&ComponentAnalysis>) -> bool {
+fn arg_can_be_unknown(
+    arg: &Argument<'_>,
+    analysis: Option<&ComponentAnalysis>,
+    locals: &LocalConsts,
+) -> bool {
     match arg {
         Argument::SpreadElement(_) => true,
         _ => arg
             .as_expression()
-            .is_none_or(|expr| shape_can_be_unknown(expr, analysis)),
+            .is_none_or(|expr| shape_can_be_unknown(expr, analysis, Some(locals))),
     }
 }
 
@@ -300,6 +308,26 @@ mod tests {
             );
             assert_eq!(out, expected, "method {method}");
         }
+    }
+
+    #[test]
+    fn skips_identifier_bound_to_a_nested_const_template_literal() {
+        let src = "export const f = (a) => {\n\tconst m = `x ${a}`;\n\tconsole.log(m);\n};";
+        assert!(transform_console_calls_dev_ast_for_test(src, false).is_none());
+    }
+
+    #[test]
+    fn wraps_identifier_whose_const_initializer_is_itself_unknown() {
+        let src = "export const f = (a) => {\n\tconst m = a.b;\n\tconsole.log(m);\n};";
+        let out = transform_console_calls_dev_ast_for_test(src, false).unwrap();
+        assert!(out.contains("$.log_if_contains_state('log', m)"));
+    }
+
+    #[test]
+    fn wraps_identifier_declared_more_than_once() {
+        let src = "const m = `x`;\nexport const f = (m) => {\n\tconsole.log(m);\n};";
+        let out = transform_console_calls_dev_ast_for_test(src, false).unwrap();
+        assert!(out.contains("$.log_if_contains_state('log', m)"));
     }
 
     #[test]

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/console_wrap.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/console_wrap.rs
@@ -19,6 +19,11 @@
 //! operator branch that upstream resolves to a `STRING` / `NUMBER` / boolean
 //! value set without consulting a binding.
 
+use oxc_ast::ast::{
+    BindingIdentifier, BindingPattern, Program, VariableDeclarationKind, VariableDeclarator,
+};
+use oxc_ast_visit::{Visit, walk};
+use rustc_hash::FxHashMap;
 use serde_json::Value;
 
 use crate::compiler::phases::phase2_analyze::ComponentAnalysis;
@@ -68,14 +73,87 @@ pub(super) fn args_need_wrap(args: &[Value], analysis: &ComponentAnalysis) -> bo
     })
 }
 
+/// The generated program's own `const` declarations, indexed by name.
+///
+/// `analysis` only carries root / instance / template bindings, so a name bound
+/// inside a nested function — the common case in a `.svelte.(js|ts)` module —
+/// resolves nowhere and errs toward `UNKNOWN`. Upstream's `scope.get(name)`
+/// reaches it, so the text passes rebuild the same reach from the parsed
+/// program.
+#[derive(Default)]
+pub(super) struct LocalConsts {
+    /// Names declared exactly once in the whole program by a `const` declarator
+    /// with an initializer, mapped to that initializer's verdict. A name
+    /// declared more than once is absent: the text alone cannot say which
+    /// declaration a reference reaches.
+    verdicts: FxHashMap<String, bool>,
+}
+
+pub(super) fn collect_local_consts(
+    program: &Program<'_>,
+    analysis: Option<&ComponentAnalysis>,
+) -> LocalConsts {
+    let mut collector = ConstCollector {
+        analysis,
+        counts: FxHashMap::default(),
+        verdicts: FxHashMap::default(),
+    };
+    collector.visit_program(program);
+    let ConstCollector {
+        counts,
+        mut verdicts,
+        ..
+    } = collector;
+    verdicts.retain(|name, _| counts.get(name) == Some(&1));
+    LocalConsts { verdicts }
+}
+
+struct ConstCollector<'an> {
+    analysis: Option<&'an ComponentAnalysis>,
+    counts: FxHashMap<String, u32>,
+    verdicts: FxHashMap<String, bool>,
+}
+
+impl<'a> Visit<'a> for ConstCollector<'_> {
+    fn visit_binding_identifier(&mut self, it: &BindingIdentifier<'a>) {
+        *self.counts.entry(it.name.to_string()).or_insert(0) += 1;
+    }
+
+    fn visit_variable_declarator(&mut self, it: &VariableDeclarator<'a>) {
+        walk::walk_variable_declarator(self, it);
+        if !matches!(it.kind, VariableDeclarationKind::Const) {
+            return;
+        }
+        let BindingPattern::BindingIdentifier(id) = &it.id else {
+            return;
+        };
+        let Some(init) = &it.init else {
+            return;
+        };
+        // No `locals` while building the index: a chained `const a = b` stays
+        // unresolved rather than depending on visit order.
+        self.verdicts.insert(
+            id.name.to_string(),
+            shape_can_be_unknown(init, self.analysis, None),
+        );
+    }
+}
+
 /// Whether a bare identifier left in generated code can still evaluate to
-/// `UNKNOWN`. Resolution is restricted to names the component declares exactly
-/// once: with a shadowing declaration in play, the generated text alone cannot
-/// say which of them this reference reaches, and guessing could suppress a wrap
-/// upstream emits.
-fn identifier_can_be_unknown(name: &str, analysis: Option<&ComponentAnalysis>) -> bool {
+/// `UNKNOWN`. Resolution is restricted to names declared exactly once: with a
+/// shadowing declaration in play, the generated text alone cannot say which of
+/// them this reference reaches, and guessing could suppress a wrap upstream
+/// emits.
+fn identifier_can_be_unknown(
+    name: &str,
+    analysis: Option<&ComponentAnalysis>,
+    locals: Option<&LocalConsts>,
+) -> bool {
     if name == "undefined" {
         return false;
+    }
+    if let Some(&verdict) = locals.and_then(|l| l.verdicts.get(name)) {
+        return verdict;
     }
     let Some(analysis) = analysis else {
         return true;
@@ -100,11 +178,12 @@ fn identifier_can_be_unknown(name: &str, analysis: Option<&ComponentAnalysis>) -
 pub(super) fn shape_can_be_unknown(
     expr: &oxc_ast::ast::Expression<'_>,
     analysis: Option<&ComponentAnalysis>,
+    locals: Option<&LocalConsts>,
 ) -> bool {
     use oxc_ast::ast::Expression as E;
     use oxc_syntax::operator::UnaryOperator;
 
-    let recur = |e: &E<'_>| shape_can_be_unknown(e, analysis);
+    let recur = |e: &E<'_>| shape_can_be_unknown(e, analysis, locals);
     match expr {
         E::StringLiteral(_)
         | E::NumericLiteral(_)
@@ -117,7 +196,7 @@ pub(super) fn shape_can_be_unknown(
         | E::ArrowFunctionExpression(_)
         | E::FunctionExpression(_)
         | E::ClassExpression(_) => false,
-        E::Identifier(id) => identifier_can_be_unknown(&id.name, analysis),
+        E::Identifier(id) => identifier_can_be_unknown(&id.name, analysis, locals),
         E::UnaryExpression(u) => !matches!(
             u.operator,
             UnaryOperator::LogicalNot
@@ -139,7 +218,7 @@ pub(super) fn shape_can_be_unknown(
         // has already evaluated the original `BinaryExpression` to `{true,
         // false}`, and reads of a `$state` declaration to `$.get(name)`.
         E::CallExpression(call) => match state_read_operand(call) {
-            Some(name) => identifier_can_be_unknown(name, analysis),
+            Some(name) => identifier_can_be_unknown(name, analysis, locals),
             None => !is_never_unknown_call(&call.callee),
         },
         _ => true,


### PR DESCRIPTION
Closes #2306

Reported by @MathiasWP.

**The report's polarity is inverted.** rsvelte does not *miss* the `$.log_if_contains_state` wrap — it emits one where official emits the plain call, so the fix is the opposite of what the issue asks for:

```js
// official
console.log(m);
// rsvelte (before)
console.log(...$.log_if_contains_state("log", m));
```

## Cause

Upstream wraps a `console.*` call only when some argument's `scope.evaluate(arg).has_unknown` holds. `scope.evaluate` resolves an `Identifier` through `scope.get(name)` and, for an un-updated binding with an initializer, evaluates that initializer — a `TemplateLiteral` contributes `STRING` and never `UNKNOWN`.

rsvelte's script paths rewrite *generated* JS text, so they use `console_wrap::shape_can_be_unknown`, the scope-free half of the same lattice. That half already returns `false` for a `TemplateLiteral`, but the reported shape is

```ts
const m = `console.error was called with args ${args.concat(", ")}`;
console.log(m);
```

where the argument is a bare `Identifier`. `identifier_can_be_unknown` resolved only against `ComponentAnalysis`, which carries root / instance / template bindings — `m` is declared inside a nested arrow function, so the lookup missed and the predicate erred toward `UNKNOWN`.

## Fix

`collect_local_consts` indexes the parsed generated program's own `const` declarators (name → the initializer's shape verdict) and `identifier_can_be_unknown` consults it first, reconstructing the reach of upstream's `scope.get(name)`. Restricted to `const` so `binding.updated` is false by construction, and to names declared exactly once in the program so a shadowing declaration still errs toward the wrap — the same direction the predicate already erred in.

## Not fixed here

#2307 (`/* @__PURE__ */` on a default parameter initializer) is left open; it is an independent printer-side divergence with a much larger blast radius. Details in a comment on that issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012gQPtKmdY9xwn5fjdwaxK8