### PR TITLE
chore(corpus): clean up corpus artifacts by default and guard against a full disk

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,6 +71,19 @@ maps are segmented too differently to diff (byte, decoded-set and lookup-equalit
 than equal to official's — using official only to calibrate the invariants. See
 [scripts/compat-corpus/README.md](scripts/compat-corpus/README.md).
 
+**Corpus artifacts clean themselves up.** A full run writes ~0.57 GiB of regenerable trees per
+checkout (`sources/` 60 MiB, `expected/` 254 MiB, `actual/` 254 MiB), and N parallel agent
+worktrees each hold a set — this filled the dev machine's disk twice. `verify.mjs` therefore
+deletes `expected/` + `actual/` after a **passing** run (`svelte2tsx-verify.mjs` likewise for the
+`-s2t` trees); a **failing** run keeps them so a divergence can still be diffed, as does CI and as
+does `--keep-artifacts`. `compile.mjs` aborts up front when free disk is below
+`180 MiB × targets + 512 MiB`. `pnpm run corpus:clean` reclaims everything regenerable across
+this checkout and every `.claude/worktrees/*` sibling — never the checked-in `*known-failures*`
+ratchets. Because a verify against an absent tree would score every entry `match`, `verify.mjs`
+asserts ≥99% of manifest entries have compiled output before comparing, and refuses
+`--update-baseline` below 12000 corpus entries (the FALSE-SHRINK trap: `--update-baseline` deletes
+every baseline id it did not measure).
+
 The svelte-check diagnostic-parity gate is the odd one out: its unit is a **type-checked project**,
 not per-file text, so module resolution / workspace layout / the `.d.ts` environment are observable
 there and nowhere else. Layer 1 (`check-verify.mjs`, ratchet `check-known-failures.json`) runs

--- a/package.json
+++ b/package.json
@@ -61,6 +61,8 @@
 		"corpus:compile": "node scripts/compat-corpus/compile.mjs",
 		"corpus:verify": "node scripts/compat-corpus/verify.mjs",
 		"corpus:known-failures-check": "node scripts/compat-corpus/known-failures-md-check.mjs",
+		"corpus:clean": "node scripts/compat-corpus/clean.mjs",
+		"corpus:clean:all": "node scripts/compat-corpus/clean.mjs --all",
 		"corpus:compile:dev": "node scripts/compat-corpus/compile.mjs --targets client-dev",
 		"corpus:verify:dev": "node scripts/compat-corpus/verify.mjs --targets client-dev",
 		"corpus:fmt": "node scripts/compat-corpus/fmt.mjs",

--- a/scripts/compat-corpus/README.md
+++ b/scripts/compat-corpus/README.md
@@ -196,6 +196,52 @@ node scripts/compat-corpus/cluster.mjs              # group failures by diff sig
 node scripts/compat-corpus/cluster.mjs --show 'JS client: E:…'   # list ids in a cluster
 ```
 
+### Disk: who deletes the artifacts
+
+A full run writes ~0.57 GiB of regenerable trees per checkout — measured with
+`du -sk` on a 3-target run: `sources/` 60 MiB, `expected/` 254 MiB, `actual/`
+254 MiB (the apparent bytes are ~40% lower; ~42k tiny files plus 21k directories
+round up to 4 KiB blocks). N parallel agent worktrees each hold their own set,
+which is how the machine runs out of disk. The rules, all implemented in
+`artifacts.mjs`:
+
+- **`verify.mjs` deletes `expected/` + `actual/` after a passing run.** Nothing
+  downstream reads them (`svelte2tsx-compile.mjs` and `fmt.mjs` read `sources/`,
+  which is kept), so the producer cleans up instead of the operator remembering.
+  `svelte2tsx-verify.mjs` does the same for `expected-s2t/` + `actual-s2t/`.
+- **A failing run keeps them** — that is when someone diffs `expected/<id>`
+  against `actual/<id>` to attribute a cluster. `--keep-artifacts` (or
+  `CORPUS_KEEP_ARTIFACTS=1`) keeps them unconditionally, `--clean-artifacts`
+  deletes even after a failure.
+- **CI keeps them unconditionally** (`CI` is set): the `Cluster failures` step
+  reads both trees and runs on *any* earlier step's failure, not only verify's.
+- **`compile.mjs` refuses to start** when free disk is below
+  `180 MiB × targets + 512 MiB`. ENOSPC halfway through leaves a half-written
+  tree, and a half-written tree scores as `match` for every entry it never
+  reached.
+- **`pnpm run corpus:clean`** reclaims every regenerable artifact in this
+  checkout *and* in every `.claude/worktrees/*` sibling (`--here` for this
+  checkout only, `--dry-run` to preview, `--all` to also drop the slower-to-
+  rebuild fmt/lint/check stages). It works from an explicit allowlist, so the
+  checked-in `*known-failures*.json` ratchets and their `.md` files are never
+  touched — those are not regenerable from the corpus.
+
+### Guards against a vacuously green run
+
+Deleting the trees makes one pre-existing hazard sharper: `verify.mjs` reads a
+missing output as `""` on both sides, so a verify against an absent tree scores
+every entry `match` — and `--update-baseline` *deletes* every baseline id it did
+not observe failing, silently emptying the ratchets. Two assertions close it:
+
+- `verify.mjs` requires ≥99% of manifest entries to have compiled output on at
+  least one side before it compares anything (the union, because a crashed
+  worker leaves only the rsvelte-side `error.json`). A cleaned or partial tree
+  aborts with exit 2 instead of passing.
+- `--update-baseline` (and `--from-report`) refuse to rewrite a ratchet from
+  fewer than 12000 corpus entries — the corpus is 14025 with every submodule
+  present, so anything far below that is a partial checkout, not a fix.
+  `svelte2tsx-verify.mjs --update-baseline` enforces the same floor.
+
 ## Formatter parity (`fmt.mjs` / `fmt-verify.mjs`)
 
 A second, independent track verifies that **rsvelte-fmt** formats every

--- a/scripts/compat-corpus/artifacts.mjs
+++ b/scripts/compat-corpus/artifacts.mjs
@@ -1,0 +1,130 @@
+/**
+ * Corpus-artifact lifecycle, shared by compile.mjs / verify.mjs /
+ * svelte2tsx-verify.mjs / clean.mjs.
+ *
+ * A full corpus run writes ~0.6 GiB of regenerable trees per checkout
+ * (measured: sources 60 MiB, expected 254 MiB, actual 254 MiB for 14025 entries
+ * × 3 targets), and N parallel agent worktrees each hold their own set. Nothing
+ * used to delete them, so the rule here is: whoever produced a tree deletes it
+ * once the last consumer is done with it.
+ *
+ * Retention rules (see `keepArtifacts`):
+ *   - a FAILING run keeps its trees — that is when someone diffs
+ *     expected/<id> against actual/<id> to attribute a cluster
+ *   - CI always keeps them: the `Cluster failures` step reads both trees, and it
+ *     runs on any earlier step's failure, not just verify's
+ *   - `--keep-artifacts` / CORPUS_KEEP_ARTIFACTS=1 keep them unconditionally
+ *   - `--clean-artifacts` deletes even after a failing run
+ *
+ * The ratchets (`compatibility/*known-failures*.json` and the paired `.md`) are
+ * NOT regenerable from the corpus and are never touched here.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+export const ROOT = path.resolve(__dirname, '../..');
+export const CORPUS = path.join(ROOT, 'compatibility');
+
+const MiB = 1024 * 1024;
+
+/** Output trees written by compile.mjs and consumed by verify.mjs / cluster.mjs. */
+export const OUTPUT_TREES = ['expected', 'actual'];
+/** Output trees written by svelte2tsx-compile.mjs, consumed by svelte2tsx-verify.mjs. */
+export const S2T_TREES = ['expected-s2t', 'actual-s2t'];
+
+/** Everything `corpus:clean` reclaims; every entry is regenerable by re-running a script. */
+export const RECLAIMABLE = [
+	'sources',
+	...OUTPUT_TREES,
+	...S2T_TREES,
+	'manifest.json',
+	'report.json',
+	'report-s2t.json',
+	'cluster.txt',
+	'.oxfmt-ignore-nothing',
+];
+
+/** `--all` additionally drops the fmt and lint stages (slower to rebuild). */
+export const RECLAIMABLE_ALL = [
+	...RECLAIMABLE,
+	'fmt',
+	'fmt-report.json',
+	'lint-sources',
+	'lint-manifest.json',
+	'.lint-rules.json',
+	'.lint-rsvelte-lint.json',
+	'check-report.json',
+	'check-report.tsgo.json',
+	'check-e2e-report.json',
+];
+
+/**
+ * Measured on a full 3-target run: expected + actual = 508 MiB, i.e. ~170 MiB
+ * per target across both trees. Rounded up, plus headroom for the in-place
+ * oxfmt normalization pass verify.mjs runs over the same trees.
+ */
+export const BYTES_PER_TARGET = 180 * MiB;
+export const DISK_HEADROOM = 512 * MiB;
+
+/**
+ * Floor for rewriting a ratchet from a run's results. `--update-baseline`
+ * DELETES every baseline id it did not observe failing, so a run over a partial
+ * corpus silently shrinks the ratchets to whatever it happened to measure. The
+ * corpus is 14025 entries with every submodule present; anything far below that
+ * is a partial checkout, not a fix.
+ */
+export const MIN_FULL_CORPUS_ENTRIES = 12000;
+
+export function keepArtifacts(argv, { failed }) {
+	if (argv.includes('--clean-artifacts')) return false;
+	if (argv.includes('--keep-artifacts')) return true;
+	if (process.env.CORPUS_KEEP_ARTIFACTS) return true;
+	if (process.env.CI) return true;
+	return failed;
+}
+
+/** Delete `names` (relative to compatibility/) unless retention applies. */
+export function cleanupArtifacts(names, argv, { failed, label }) {
+	if (keepArtifacts(argv, { failed })) {
+		if (failed) {
+			console.log(
+				`\n[${label}] artifacts kept for inspection — reclaim with: pnpm run corpus:clean`
+			);
+		}
+		return;
+	}
+	for (const name of names) fs.rmSync(path.join(CORPUS, name), { recursive: true, force: true });
+	console.log(`\n[${label}] removed ${names.join(', ')} (keep them with --keep-artifacts)`);
+}
+
+export function freeBytes(dir) {
+	try {
+		const { bavail, bsize } = fs.statfsSync(dir);
+		return Number(bavail) * Number(bsize);
+	} catch {
+		return null;
+	}
+}
+
+const gib = (n) => `${(n / 1024 / 1024 / 1024).toFixed(2)} GiB`;
+
+/**
+ * Abort before a long run rather than hitting ENOSPC halfway through and leaving
+ * a half-written tree that later scores as `match`.
+ */
+export function requireDiskSpace(required, label) {
+	const free = freeBytes(CORPUS);
+	if (free === null) return;
+	if (free >= required) {
+		console.log(`[${label}] disk: ${gib(free)} free, ~${gib(required)} needed`);
+		return;
+	}
+	console.error(
+		`[${label}] not enough free disk: ${gib(free)} free, ~${gib(required)} needed for this run`
+	);
+	console.error('  reclaim every regenerable corpus tree (all worktrees): pnpm run corpus:clean');
+	process.exit(3);
+}

--- a/scripts/compat-corpus/clean.mjs
+++ b/scripts/compat-corpus/clean.mjs
@@ -1,0 +1,98 @@
+#!/usr/bin/env node
+/**
+ * Reclaim every regenerable corpus artifact, in this checkout AND in every
+ * sibling agent worktree under `.claude/worktrees/` — N parallel worktrees each
+ * holding a full set is how the dev machine actually runs out of disk.
+ *
+ * The checked-in ratchets (`compatibility/*known-failures*.json` and the paired
+ * `.md` files) are never regenerable from the corpus, so they are never touched:
+ * this script only removes names on the explicit allowlist in artifacts.mjs.
+ *
+ * Usage: node scripts/compat-corpus/clean.mjs [--all] [--here] [--dry-run]
+ *   --all      also drop the fmt / lint / check stages (slower to rebuild)
+ *   --here     this checkout only — a sibling worktree may be mid-run
+ *   --dry-run  report what would be freed without deleting
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { execFileSync } from 'node:child_process';
+import { ROOT, RECLAIMABLE, RECLAIMABLE_ALL } from './artifacts.mjs';
+
+const args = process.argv.slice(2);
+const ALL = args.includes('--all');
+const DRY_RUN = args.includes('--dry-run');
+const NAMES = ALL ? RECLAIMABLE_ALL : RECLAIMABLE;
+
+// A typo that put a ratchet on the allowlist would delete an unrecoverable file.
+for (const name of NAMES) {
+	if (name.includes('known-failures') || name.endsWith('.md')) {
+		console.error(`[corpus-clean] refusing to delete tracked ratchet "${name}"`);
+		process.exit(2);
+	}
+}
+
+/** This checkout, the main checkout, and every agent worktree beside it. */
+function checkouts() {
+	const roots = new Set([ROOT]);
+	if (args.includes('--here')) return [...roots];
+	let main = null;
+	try {
+		const commonDir = execFileSync('git', ['rev-parse', '--path-format=absolute', '--git-common-dir'], {
+			cwd: ROOT,
+			encoding: 'utf8',
+		}).trim();
+		main = path.dirname(commonDir);
+		roots.add(main);
+	} catch {
+		main = ROOT;
+	}
+	const worktrees = path.join(main, '.claude/worktrees');
+	if (fs.existsSync(worktrees)) {
+		for (const entry of fs.readdirSync(worktrees, { withFileTypes: true })) {
+			if (entry.isDirectory()) roots.add(path.join(worktrees, entry.name));
+		}
+	}
+	return [...roots].sort();
+}
+
+// Sizes are apparent bytes, so they under-report the real cost of ~42k tiny
+// files; entries may also vanish mid-walk when a parallel worktree is running.
+function bytesOf(target) {
+	const stat = fs.lstatSync(target, { throwIfNoEntry: false });
+	if (!stat) return null;
+	if (!stat.isDirectory()) return stat.size;
+	let total = 0;
+	let entries = [];
+	try {
+		entries = fs.readdirSync(target, { withFileTypes: true });
+	} catch {
+		return total;
+	}
+	for (const entry of entries) total += bytesOf(path.join(target, entry.name)) ?? 0;
+	return total;
+}
+
+let freed = 0;
+for (const root of checkouts()) {
+	const corpus = path.join(root, 'compatibility');
+	if (!fs.existsSync(corpus)) continue;
+	const hits = [];
+	for (const name of NAMES) {
+		const target = path.join(corpus, name);
+		const size = bytesOf(target);
+		if (size === null) continue;
+		hits.push([name, size]);
+		freed += size;
+		if (!DRY_RUN) fs.rmSync(target, { recursive: true, force: true });
+	}
+	if (hits.length) {
+		const mib = (hits.reduce((n, [, s]) => n + s, 0) / 1024 / 1024).toFixed(1);
+		console.log(`[corpus-clean] ${root}: ${hits.length} artifact(s), ${mib} MiB`);
+		for (const [name, size] of hits) console.log(`    ${name} (${(size / 1024 / 1024).toFixed(1)} MiB)`);
+	}
+}
+
+const verb = DRY_RUN ? 'would free' : 'freed';
+console.log(`[corpus-clean] ${verb} ${(freed / 1024 / 1024 / 1024).toFixed(2)} GiB`);
+if (!ALL) console.log('[corpus-clean] (--all also drops the fmt / lint / check stages)');

--- a/scripts/compat-corpus/compile.mjs
+++ b/scripts/compat-corpus/compile.mjs
@@ -26,6 +26,7 @@ import { spawn } from 'node:child_process';
 import { createRequire } from 'node:module';
 import { fileURLToPath } from 'node:url';
 import { selectTargets } from './targets.mjs';
+import { BYTES_PER_TARGET, DISK_HEADROOM, requireDiskSpace } from './artifacts.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '../..');
@@ -160,6 +161,14 @@ if (!FILTER) {
 	fs.rmSync(EXPECTED, { recursive: true, force: true });
 	fs.rmSync(ACTUAL, { recursive: true, force: true });
 }
+
+// After the wipe above, so the figure reflects the space this run really needs.
+// ENOSPC halfway through leaves a half-written tree, and a half-written tree
+// scores as `match` for every entry it never reached.
+requireDiskSpace(
+	(FILTER ? 0 : BYTES_PER_TARGET * TARGETS.length) + DISK_HEADROOM,
+	'compile'
+);
 
 const JOBS = Number(argValue('--jobs', String(Math.max(2, Math.min(8, os.cpus().length - 2)))));
 const startedAt = Date.now();

--- a/scripts/compat-corpus/svelte2tsx-verify.mjs
+++ b/scripts/compat-corpus/svelte2tsx-verify.mjs
@@ -53,6 +53,7 @@ import { execFileSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 import { stripBlankLines, readIf, firstDiffLine } from './normalize.mjs';
 import { mappingViolations } from './sourcemap.mjs';
+import { MIN_FULL_CORPUS_ENTRIES, S2T_TREES, cleanupArtifacts } from './artifacts.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '../..');
@@ -255,6 +256,14 @@ for (const [k, v] of Object.entries({ ...counts, ...mapCounts })) console.log(` 
 console.log(`  report: ${path.relative(ROOT, path.join(CORPUS, 'report-s2t.json'))}`);
 
 if (UPDATE_BASELINE) {
+	// Rewriting from a partial corpus would delete every baseline id it did not
+	// measure, which reads as a ratchet win instead of a missing checkout.
+	if (manifest.length < MIN_FULL_CORPUS_ENTRIES) {
+		console.error(
+			`[s2t-verify] refusing to rewrite baselines from ${manifest.length} corpus entries (expected >= ${MIN_FULL_CORPUS_ENTRIES})`
+		);
+		process.exit(2);
+	}
 	const updates = [[failures, BASELINE_PATH]];
 	// A --baseline run targets some alternate TSX ratchet; rewriting the one real
 	// map ratchet from it would clobber it with that run's narrower results.
@@ -325,8 +334,13 @@ function ratchet(label, entries, file) {
 const tsxRegressed = ratchet('TSX', failures, BASELINE_PATH);
 const mapRegressed = ratchet('source-map', mapFailures, MAP_BASELINE_PATH);
 
-if (tsxRegressed || mapRegressed) process.exit(1);
+if (tsxRegressed || mapRegressed) {
+	cleanupArtifacts(S2T_TREES, args, { failed: true, label: 's2t-verify' });
+	process.exit(1);
+}
 
 if (!failures.length && !mapFailures.length) {
 	console.log('\n[s2t-verify] ✅ all svelte2tsx outputs identical after normalization, all source maps well-formed');
 }
+
+cleanupArtifacts(S2T_TREES, args, { failed: false, label: 's2t-verify' });

--- a/scripts/compat-corpus/verify.mjs
+++ b/scripts/compat-corpus/verify.mjs
@@ -33,7 +33,11 @@
  * baselines from an existing report.json (e.g. downloaded from a CI run), so a
  * new target's baseline can be bootstrapped without a local full run.
  *
- * Usage: node scripts/compat-corpus/verify.mjs [--no-fmt] [--max-print <n>] [--update-baseline [<target>]] [--from-report <path>] [--targets <keys>] [--strict]
+ * A passing run deletes expected/ and actual/ (see artifacts.mjs); a failing run
+ * keeps them so the divergence can be inspected. --keep-artifacts always keeps,
+ * --clean-artifacts always deletes.
+ *
+ * Usage: node scripts/compat-corpus/verify.mjs [--no-fmt] [--max-print <n>] [--update-baseline [<target>]] [--from-report <path>] [--targets <keys>] [--strict] [--keep-artifacts|--clean-artifacts]
  */
 
 import fs from 'node:fs';
@@ -42,6 +46,7 @@ import { execFileSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 import { flattenTemplateHoles, stripBlankLines, readIf, firstDiffLine } from './normalize.mjs';
 import { TARGET_KEYS as ALL_TARGET_KEYS, selectTargets } from './targets.mjs';
+import { MIN_FULL_CORPUS_ENTRIES, OUTPUT_TREES, cleanupArtifacts } from './artifacts.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '../..');
@@ -103,6 +108,19 @@ function partitionFailures(failures) {
 	return byTarget;
 }
 
+// `--update-baseline` DELETES every baseline id this run did not observe
+// failing, so a run over a partial corpus silently shrinks the ratchets to
+// whatever it happened to measure. Refuse unless the run saw the whole corpus.
+function requireFullCorpus(measured, what) {
+	if (measured >= MIN_FULL_CORPUS_ENTRIES) return;
+	console.error(
+		`[verify] refusing to rewrite baselines from ${measured} ${what} (expected >= ${MIN_FULL_CORPUS_ENTRIES})`
+	);
+	console.error('  a partial corpus would delete every baseline entry it did not measure');
+	console.error('  fix: git submodule update --init --depth 1 … && node scripts/compat-corpus/collect.mjs');
+	process.exit(2);
+}
+
 function writeBaselines(byTarget) {
 	console.log();
 	for (const target of TARGETS) {
@@ -117,8 +135,43 @@ function writeBaselines(byTarget) {
 if (FROM_REPORT) {
 	const report = JSON.parse(fs.readFileSync(FROM_REPORT, 'utf8'));
 	console.log(`[verify] deriving baselines from ${path.relative(ROOT, FROM_REPORT)} (${report.failures.length} failures)`);
+	requireFullCorpus(report.total ?? 0, 'entries in the report');
 	writeBaselines(partitionFailures(report.failures));
 	process.exit(0);
+}
+
+// ---- inputs ----------------------------------------------------------------
+
+const manifest = JSON.parse(fs.readFileSync(path.join(CORPUS, 'manifest.json'), 'utf8'));
+
+// A near-empty manifest (partial checkout, failed collect) would make the
+// comparison below pass vacuously instead of catching a real regression.
+const MIN_MANIFEST_ENTRIES = 1000;
+if (manifest.length < MIN_MANIFEST_ENTRIES) {
+	console.error(
+		`[verify] only ${manifest.length} entries in manifest.json (expected >= ${MIN_MANIFEST_ENTRIES}); run \`node scripts/compat-corpus/collect.mjs\` first`,
+	);
+	process.exit(2);
+}
+
+// compile.mjs writes either `<target>.js` or `error.json` for every entry on
+// both sides, so a missing pair means the tree was never compiled (or was
+// cleaned away). Comparing against an absent tree reads both sides as "" and
+// scores every entry `match` — a green run that measured nothing.
+function hasOutputs(tree, id) {
+	if (fs.existsSync(path.join(tree, id, 'error.json'))) return true;
+	return TARGET_KEYS.some((key) => fs.existsSync(path.join(tree, id, `${key}.js`)));
+}
+
+// A crashed worker leaves its one entry with only the rsvelte-side error.json,
+// so coverage is checked against the union rather than demanded per tree.
+const compiled = manifest.filter(({ id }) => hasOutputs(EXPECTED, id) || hasOutputs(ACTUAL, id)).length;
+if (compiled < manifest.length * 0.99) {
+	console.error(
+		`[verify] only ${compiled}/${manifest.length} manifest entries have compiled output for ${TARGET_KEYS.join(', ')}`
+	);
+	console.error('  run: node scripts/compat-corpus/compile.mjs   (outputs are deleted after a green verify)');
+	process.exit(2);
 }
 
 // ---- oxfmt normalization ---------------------------------------------------
@@ -165,18 +218,6 @@ if (!NO_FMT) {
 }
 
 // ---- comparison --------------------------------------------------------------
-
-const manifest = JSON.parse(fs.readFileSync(path.join(CORPUS, 'manifest.json'), 'utf8'));
-
-// A near-empty manifest (partial checkout, failed collect) would make the
-// comparison below pass vacuously instead of catching a real regression.
-const MIN_MANIFEST_ENTRIES = 1000;
-if (manifest.length < MIN_MANIFEST_ENTRIES) {
-	console.error(
-		`[verify] only ${manifest.length} entries in manifest.json (expected >= ${MIN_MANIFEST_ENTRIES}); run \`node scripts/compat-corpus/collect.mjs\` first`,
-	);
-	process.exit(2);
-}
 
 const counts = {
 	match: 0,
@@ -315,9 +356,18 @@ console.log(`  report: ${path.relative(ROOT, path.join(CORPUS, 'report.json'))}`
 const failById = new Map(failures.map((f) => [f.id, f]));
 const failsByTarget = partitionFailures(failures);
 
+// Only compile.mjs and cluster.mjs read these trees; nothing downstream does,
+// so a green run deletes them here instead of leaving ~0.5 GiB per checkout for
+// the operator to remember.
+function finish(code) {
+	cleanupArtifacts(OUTPUT_TREES, args, { failed: code !== 0, label: 'verify' });
+	process.exit(code);
+}
+
 if (UPDATE_BASELINE) {
+	requireFullCorpus(manifest.length, 'corpus entries');
 	writeBaselines(failsByTarget);
-	process.exit(0);
+	finish(0);
 }
 
 const loadBaseline = (p) =>
@@ -372,7 +422,7 @@ if (regressions.length) {
 	}
 }
 
-if (regressions.length || fixedKnown) process.exit(1);
+if (regressions.length || fixedKnown) finish(1);
 
 if (failures.length) {
 	const breakdown = TARGET_KEYS.map((key) => `${key} ${failsByTarget.get(key).size}`).join(', ');
@@ -380,3 +430,5 @@ if (failures.length) {
 } else {
 	console.log('\n[verify] ✅ all corpus outputs identical after normalization');
 }
+
+finish(0);


### PR DESCRIPTION
Corpus runs left `compatibility/{sources,actual,expected}` on disk with nothing to delete them — every operator was expected to remember `rm -rf`. That failed twice in one day, the second time hard enough that the tool harness could not write its own output file and an agent lost an uncommitted fix. This makes the producer clean up after itself, fails early when disk is short, and adds a one-command reclaim.

## Dependency graph (established by reading `.github/workflows/corpus-compat.yml`)

Job **`corpus` (Compiler parity)** — one job, sequential steps:

```
collect.mjs        -> compatibility/sources/ , manifest.json
compile.mjs        <- sources/, manifest.json      -> expected/, actual/   (all 3 targets in ONE pass)
verify.mjs         <- expected/, actual/, manifest.json  -> report.json
svelte2tsx-compile <- sources/, manifest.json      -> expected-s2t/, actual-s2t/
svelte2tsx-verify  <- expected-s2t/, actual-s2t/, sources/, manifest.json -> report-s2t.json
css-prune-sweep    <- (synthetic; own ratchet)
cluster.mjs        <- expected/, actual/, report.json     [if: failure()]
upload-artifact    <- report.json, report-s2t.json, manifest.json, cluster.txt  [if: failure()]
```

Job **`fmt-parity`**: `collect.mjs` -> `fmt.mjs` (reads `sources/`) -> `fmt-verify.mjs`.
Jobs **`lint-parity`**, **`svelte-check`**, **`check-e2e`**: independent, touch none of these trees.

Two consequences that shaped the design:

1. **`sources/` is shared across three consumers** (`compile.mjs`, `svelte2tsx-compile.mjs`, `fmt.mjs`) and is read *after* `verify.mjs` in the same CI job. It is therefore **never** deleted by a verify step — only by the explicit `corpus:clean`.
2. **`cluster.mjs` reads `expected/` + `actual/` under `if: failure()`**, which fires on *any* earlier step's failure — including `svelte2tsx-verify` failing after `verify` passed. So a "delete on green" rule alone would still break clustering in CI. Cleanup is skipped unconditionally when `CI` is set.

Note the targets are **not** a per-target sequence: `compile.mjs` writes `client`, `server` and `client-dev` in one pass into the same `expected/<id>/` directory, and `verify.mjs` reads all three. There is no per-target cleanup point.

## What changed

New `scripts/compat-corpus/artifacts.mjs` owns the policy; `clean.mjs` is the reclaim command.

- **`verify.mjs` deletes `expected/` + `actual/` after a passing run.** `svelte2tsx-verify.mjs` does the same for the `-s2t` trees. A **failing** run keeps them — that is exactly when someone diffs `expected/<id>` against `actual/<id>` to attribute a cluster — and prints the reclaim command. `--keep-artifacts` / `CORPUS_KEEP_ARTIFACTS=1` keep unconditionally; `--clean-artifacts` deletes even after a failure; `CI` keeps unconditionally.
- **`compile.mjs` preflights free disk** and exits 3 below `180 MiB x targets + 512 MiB`. It runs after the existing unfiltered wipe of `expected/`+`actual/`, so the figure reflects the space the run actually needs.
- **`pnpm run corpus:clean`** removes every regenerable artifact in this checkout and in every `.claude/worktrees/*` sibling (`--here`, `--dry-run`, `--all`). It works from an explicit allowlist in `artifacts.mjs`, plus a startup assertion that no allowlist entry contains `known-failures` or ends in `.md`, so the ratchets can never be deleted.

## The FALSE-SHRINK guard (the important part)

`verify.mjs` reads a missing output file as `""` on **both** sides, so a verify against an absent tree scores every entry `match` — and `--update-baseline` *deletes* every baseline id it did not observe failing. That path exists on `main` today; deleting trees by default would make it much easier to walk into. Two assertions close it:

- **Coverage assertion**: before any normalization or comparison, `verify.mjs` requires >=99% of manifest entries to have compiled output (`<target>.js` or `error.json`) on at least one side, and exits 2 otherwise with `run: node scripts/compat-corpus/compile.mjs`. The union rather than per-tree, because a crashed worker legitimately leaves only the rsvelte-side `error.json`. This is checked *before* the oxfmt pass so a cleaned tree fails legibly instead of throwing ENOENT out of `flattenTreeTemplateHoles`.
- **Full-corpus floor**: `--update-baseline` and `--from-report` refuse to rewrite a ratchet from fewer than 12000 corpus entries (the corpus is 14025 with every submodule present). `svelte2tsx-verify.mjs --update-baseline` enforces the same floor, which also catches `--filter` + `--update-baseline`.

## What I measured

`du -sk` on a completed 3-target run in the main checkout (14025 manifest entries):

| tree | allocated | apparent | files | dirs |
|---|---|---|---|---|
| `sources/` | 60.5 MiB | 16.0 MiB | | |
| `expected/` | 254.3 MiB | 140.6 MiB | 42460 | 21201 |
| `actual/` | 253.8 MiB | 140.3 MiB | | |
| **total** | **568.6 MiB** | 296.9 MiB | | |

Allocated is ~1.9x apparent: ~42k tiny files plus 21k directories round up to 4 KiB APFS blocks. The disk budget uses the **allocated** figure — 508 MiB of `expected`+`actual` across 3 targets is ~170 MiB/target, rounded to 180 MiB, plus 512 MiB headroom for the in-place oxfmt normalization pass. With 8 worktrees on the machine, `corpus:clean --dry-run` reported 0.38 GiB reclaimable right now (apparent bytes; ~0.7 GiB allocated).

## Verified

End-to-end `collect` -> `compile --targets server` -> `verify --targets server` on the real corpus, then re-ran `verify` against the cleaned tree to confirm the coverage assertion fires instead of a vacuous pass. Details in a comment below.

## Deliberately not changed

- **`sources/` is never auto-deleted.** Three scripts read it, one of them after `verify.mjs` in the same CI job. Only `corpus:clean` removes it.
- **`collect.mjs`'s `MIN_MANIFEST_ENTRIES = 1000` floor stays.** Agents routinely collect with a partial submodule checkout; raising that floor would break legitimate local runs. The 12000 floor is applied only where it matters — the ratchet *rewrite* path.
- **`fmt/`, `lint-sources/` and the check stages are not auto-cleaned** and are behind `corpus:clean --all`: the fmt oracle is expensive to rebuild (prettier over 14k files) and is CI-cached by svelte.dev SHA.
- **No CI workflow edits.** The `CI` env var is set by GitHub Actions for free, so the corpus job's behaviour is byte-for-byte what it was.
- **`compile.mjs`'s existing wipe of `expected/`+`actual/` is untouched**, as is every ratchet file.

No changeset: `.github/workflows/changeset.yml` (line 25) exempts every type other than `fix`/`feat`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012gQPtKmdY9xwn5fjdwaxK8
