### PR TITLE
fix(ci): stop a later push to main from cancelling the release publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -424,9 +424,13 @@ jobs:
     # changesets consumed. This is the only path that needs staged binaries.
     if: "${{ startsWith(github.event.head_commit.message, 'chore(release): version packages') }}"
     runs-on: ubuntu-latest
+    # Deliberately NOT `needs: close-version-cycle`: that job shares the
+    # cancel-in-progress group with `version-pr` so it can supersede an
+    # in-flight updater, which also means any later push to main cancels it —
+    # and a cancelled dependency would skip this job, silently dropping the
+    # release (run 31063492582).
     needs:
       [
-        close-version-cycle,
         build-svelte-check,
         build-vps-native,
         build-rsvelte-fmt,


### PR DESCRIPTION
## Symptom

Release run [31063492582](https://github.com/baseballyama/rsvelte/actions/runs/31063492582) — triggered by merging the Version Packages PR #2319 — did not publish:

```
Close version cycle: completed/cancelled
Publish:             skipped
```

Nothing failed. The release just disappeared.

## Cause

`close-version-cycle` sits in the same concurrency group as `version-pr`:

```yaml
concurrency:
  group: release-version-pr-${{ github.ref }}
  cancel-in-progress: true
```

That is deliberate — a publish commit must supersede an in-flight updater before it can reopen the version PR from stale state. But concurrency cancellation is symmetric: the moment any *later* push to main starts its `version-pr` job, it cancels the release run's `close-version-cycle`.

`publish` had `close-version-cycle` in its `needs`, so a cancelled dependency skipped it.

`publish` itself is correctly protected (`cancel-in-progress: false`, with the comment "Publishing is non-atomic across packages and must never be interrupted") — but that guarantee was defeated through a dependency that had no such protection. Merging a single PR shortly after the Version Packages PR is enough to drop a release, every time.

## Fix

Drop `close-version-cycle` from `publish`'s `needs`.

`close-version-cycle` is a bare `echo` — it has no outputs and produces no state `publish` consumes. Its only job is to occupy the concurrency group so it cancels an older in-flight `version-pr`. That still happens; `publish` simply no longer inherits its cancellability.

`publish` keeps its own guard on the same condition (`if: startsWith(github.event.head_commit.message, 'chore(release): version packages')`), so it still runs only on a version-packages commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017eFcFhr66RJemE7UtF4CNK