### PR TITLE
perf(compiler): resolve char offsets once in prop-read rewriting instead of per character

### DIFF
--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/props_transforms.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/props_transforms.rs
@@ -122,6 +122,9 @@ pub(super) fn transform_prop_reads_in_expr(expr: &str, prop_vars: &[String]) -> 
 
         let mut new_result = String::with_capacity(result.len() * 2);
         let chars: Vec<char> = result.chars().collect();
+        // Resolving char index → byte offset with `char_indices().nth(i)` inside the
+        // per-character loop below is quadratic in the expression length.
+        let char_offsets: Vec<usize> = result.char_indices().map(|(b, _)| b).collect();
         #[cfg(feature = "measure-prop-reads")]
         crate::measure_prop_reads::record_pass(chars.len());
         let mut i = 0;
@@ -191,11 +194,7 @@ pub(super) fn transform_prop_reads_in_expr(expr: &str, prop_vars: &[String]) -> 
             }
 
             // Check if we're at the start of the identifier
-            let remaining = &result[result
-                .char_indices()
-                .nth(i)
-                .map(|(idx, _)| idx)
-                .unwrap_or(i)..];
+            let remaining = &result[char_offsets.get(i).copied().unwrap_or(i)..];
             if remaining.starts_with(prop_name) {
                 // Check character before (must be non-identifier char or start of string)
                 let before_ok = if i == 0 {
@@ -259,11 +258,7 @@ pub(super) fn transform_prop_reads_in_expr(expr: &str, prop_vars: &[String]) -> 
                 // After transform_prop_update_expressions runs, we get $.update_prop(x)
                 // and we must not convert x to x() inside that call
                 let is_inside_update_call = {
-                    let prefix_str = &result[..result
-                        .char_indices()
-                        .nth(i)
-                        .map(|(idx, _)| idx)
-                        .unwrap_or(i)];
+                    let prefix_str = &result[..char_offsets.get(i).copied().unwrap_or(i)];
                     prefix_str.ends_with("$.update_prop(")
                         || prefix_str.ends_with("$.update_pre_prop(")
                         || prefix_str.ends_with("$.update_prop(")
@@ -275,11 +270,7 @@ pub(super) fn transform_prop_reads_in_expr(expr: &str, prop_vars: &[String]) -> 
                 // where propName is a prop source (getter function) that's equivalent to the
                 // derived computation. In this case we must NOT append `()`.
                 let is_sole_derived_arg = {
-                    let prefix_str = &result[..result
-                        .char_indices()
-                        .nth(i)
-                        .map(|(idx, _)| idx)
-                        .unwrap_or(i)];
+                    let prefix_str = &result[..char_offsets.get(i).copied().unwrap_or(i)];
                     if prefix_str.ends_with("$.derived(") {
                         // Check that after the identifier is just `)` (possibly preceded by whitespace)
                         let mut k = after_idx;


### PR DESCRIPTION
Closes #2322 (partially — see "what remains").

## The mechanism

`transform_prop_reads_in_expr` (`client/props_transforms.rs`) walks the expression
character by character over a `Vec<char>`, and at **every** position resolved the
current char index back to a byte offset with

```rust
let remaining = &result[result.char_indices().nth(i).map(|(idx, _)| idx).unwrap_or(i)..];
```

`char_indices().nth(i)` is O(i), so the loop is O(n²) in the expression length — per
prop var. Two more `char_indices().nth(i)` calls sit on the identifier-match path.
The offsets are now resolved once per pass into a `Vec<usize>` and indexed in O(1).

This is a per-character re-scan of the whole text, structurally the same bug class as
`transform_shadowed_local_state_vars`' full-script `find`s, but a different site.

The reason it shows up as "quadratic in *script* size" rather than in `$:` count:
`svelte-ux`'s `Button.svelte` has 5 `$:` statements, but one of them
(`$: _class = cls(…)`, line 44) spans to the end of the script — ~16 KB of the
17.2 KB instance script is a *single* reactive statement. Its RHS is fed to
`transform_prop_reads_in_expr` whole.

## Measurement

Deterministic scaling fixture: one `$: _class = cls(<N lines>)` referencing 4 `export
let` props, N ∈ {25, 50, 100, 200, 400, 800}, compiled through
`compile_profile --shipped --dump-rows`, in-process `hrtime`, `script_text` column.
n = 6 sizes, single machine, same binary flags before/after.

| script bytes | before (ms) | after (ms) | ratio |
|---:|---:|---:|---:|
|  2,156 |    4.41 |   0.55 |  8.0x |
|  4,056 |   16.65 |   1.53 | 10.9x |
|  7,856 |   63.69 |   5.00 | 12.8x |
| 15,756 |  257.56 |  16.83 | 15.3x |
| 31,556 | 1012.41 |  61.83 | 16.4x |
| 63,156 | 4145.21 | 239.94 | 17.3x |

Log-log slope of `script_text` vs script bytes, fitted on all n = 6 points:

* before: **2.027** (successive-doubling ratios 3.78, 3.83, 4.04, 3.93, 4.09)
* after: **1.799** (2.76, 3.27, 3.37, 3.67, 3.88)

Speed-up ratio spread: 8.0x–17.3x, monotonically increasing with size (as expected for
removing an O(n²) term). Median 14.0x.

Whole-project `--shipped --only=svelte-ux` (198 real files, no synthetic ones):
`script_text` exponent vs script bytes **2.061 → 1.897**, and the reported
`script_text` total drops from 502 ms to 375 ms on the same population.

## What remains

The exponent is still ~1.8 after this change, so **there is at least one more
quadratic term in the same path** (the remaining per-identifier backward scans —
`is_shadowed_by_function_param`, `is_explicit_property_key`, `is_arrow_param_binding`
— are each O(n) and fire once per matched identifier, which is itself O(n)). This PR
removes the dominant term (the one that ran on *every* character rather than every
match); the residual is worth a follow-up but is 17x smaller in absolute terms at
63 KB.

## Who is actually affected

Narrow, and worth stating plainly. This path only fires for **legacy (non-runes)
components with a physically large `$:` statement**. Of the six shipped projects in
`compile_profile --shipped`, only `svelte-ux` triggers it at all; `shadcn-svelte`,
`layerchart`, `flowbite-svelte`, `bits-ui` and `skeleton` never reach
`reactive_stmt` in any meaningful quantity — modern large Svelte projects have
essentially zero `$:`. It is also **not** on the svelte-rs performance-gap
population (large `flowbite` files), so this is not a gap-closing change.

It is a real half-second-class cost for the users who do have big legacy reactive
blocks, and the cost is *super*linear, so it gets worse the bigger their file is —
but it is a distribution tail, not an average.

## Output equality

Pure index-arithmetic change; the resolved byte offset is identical
(`char_indices().nth(i)` and `char_offsets[i]` are the same value for all
`i < chars.len()`, and the loop condition guarantees that).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012gQPtKmdY9xwn5fjdwaxK8
