### PR TITLE
fix(compiler): wrap an awaited `for...of` iterable in `$.for_await_track_reactivity_loss`

### DIFF
--- a/.changeset/for-await-track-reactivity-loss.md
+++ b/.changeset/for-await-track-reactivity-loss.md
@@ -1,0 +1,5 @@
+---
+'@rsvelte/compiler': patch
+---
+
+Wrap an awaited `for…of` loop's iterable in `$.for_await_track_reactivity_loss(...)` in dev mode under `experimental.async`, matching the official compiler's `ForOfStatement` visitor. Applies to runes and legacy instance scripts, `<script module>` and `.svelte.(js|ts)` modules, and is suppressed by `svelte-ignore await_reactivity_loss`.

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/ast_state_transform.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/ast_state_transform.rs
@@ -2042,6 +2042,36 @@ impl<'a, 's> StateVarCollector<'a, 's> {
         true
     }
 
+    /// Dev-mode rewrite of `for await (… of X)` to
+    /// `for await (… of $.for_await_track_reactivity_loss(X))`, mirroring the
+    /// official compiler's `ForOfStatement` visitor. Returns `true` when the
+    /// statement was rewritten (the caller then skips the default walk).
+    fn try_rewrite_for_await_reactivity_loss(&mut self, stmt: &ForOfStatement<'_>) -> bool {
+        if !self.dev
+            || !super::await_reactivity_loss_ast::is_for_await_instrumentable(
+                stmt,
+                self.analysis.is_some_and(|a| a.experimental_async),
+                self.is_await_reactivity_loss_ignored(stmt.span.start),
+            )
+        {
+            return false;
+        }
+
+        self.visit_for_statement_left(&stmt.left);
+        self.visit_expression(&stmt.right);
+        let right_span = stmt.right.span();
+        let right_text = self.apply_and_drain_inner_replacements(right_span.start, right_span.end);
+        self.add_replacement(
+            right_span.start,
+            right_span.end,
+            super::await_reactivity_loss_ast::for_await_track_reactivity_loss_wrap(
+                right_text.trim(),
+            ),
+        );
+        self.visit_statement(&stmt.body);
+        true
+    }
+
     fn is_await_reactivity_loss_ignored(&self, offset: u32) -> bool {
         self.await_ignore_ranges.contains(offset)
     }
@@ -2371,6 +2401,12 @@ impl<'a, 's, 'ast> Visit<'ast> for StateVarCollector<'a, 's> {
         // argument itself when it matches.
         if !self.try_rewrite_await_reactivity_loss(expr) {
             walk::walk_await_expression(self, expr);
+        }
+    }
+
+    fn visit_for_of_statement(&mut self, stmt: &ForOfStatement<'ast>) {
+        if !self.try_rewrite_for_await_reactivity_loss(stmt) {
+            walk::walk_for_of_statement(self, stmt);
         }
     }
 

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/await_reactivity_loss_ast.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/await_reactivity_loss_ast.rs
@@ -26,6 +26,57 @@ fn track_reactivity_loss_wrap(argument_text: &str) -> String {
     format!("(await $.track_reactivity_loss({argument_text}))()")
 }
 
+/// The dev wrapper upstream builds in `visitors/ForOfStatement.js`.
+pub(super) fn for_await_track_reactivity_loss_wrap(iterable_text: &str) -> String {
+    format!("$.for_await_track_reactivity_loss({iterable_text})")
+}
+
+/// Whether upstream's `ForOfStatement` visitor would wrap this loop's iterable.
+pub(super) fn is_for_await_instrumentable(
+    stmt: &ForOfStatement<'_>,
+    experimental_async: bool,
+    ignored: bool,
+) -> bool {
+    stmt.r#await
+        && experimental_async
+        && !ignored
+        && !is_for_await_track_reactivity_loss_call(&stmt.right)
+}
+
+/// Whether `expr` is an `await` this pass will itself rewrite in full.
+fn awaits_over_the_whole_span(expr: &Expression<'_>, ignore: &AwaitIgnoreRanges) -> bool {
+    let Expression::AwaitExpression(expr) = expr else {
+        return false;
+    };
+    !is_track_reactivity_loss_call(&expr.argument)
+        && !is_destructuring_iife_call(&expr.argument)
+        && !ignore.contains(expr.span.start)
+}
+
+fn for_await_edit(
+    stmt: &ForOfStatement<'_>,
+    source: &str,
+    experimental_async: bool,
+    ignore: &AwaitIgnoreRanges,
+) -> Option<Edit> {
+    if !is_for_await_instrumentable(stmt, experimental_async, ignore.contains(stmt.span.start)) {
+        return None;
+    }
+    // A bare awaited iterable produces an `await` edit over the very same span,
+    // which the splice's strict-containment check cannot order; let that one
+    // land and re-collect this loop over the settled expression.
+    if awaits_over_the_whole_span(&stmt.right, ignore) {
+        return None;
+    }
+    let span = stmt.right.span();
+    let text = source[span.start as usize..span.end as usize].trim();
+    Some((
+        span.start,
+        span.end,
+        for_await_track_reactivity_loss_wrap(text),
+    ))
+}
+
 /// Whether `stmt`'s last token is an expression, so that a following line
 /// opening with `(` continues it instead of starting a statement of its own.
 /// A source `await` can never continue a line, but the wrapper this pass builds
@@ -76,13 +127,22 @@ pub(super) fn separator_positions(
 /// it again on the next iteration; recognising the marker is what makes this
 /// pass idempotent.
 fn is_track_reactivity_loss_call(expr: &Expression<'_>) -> bool {
+    is_internal_call(expr, "track_reactivity_loss")
+}
+
+/// The `for await` wrapper is likewise re-collected by the fixed-point loop.
+pub(super) fn is_for_await_track_reactivity_loss_call(expr: &Expression<'_>) -> bool {
+    is_internal_call(expr, "for_await_track_reactivity_loss")
+}
+
+fn is_internal_call(expr: &Expression<'_>, name: &str) -> bool {
     let Expression::CallExpression(call) = expr.without_parentheses() else {
         return false;
     };
     let Expression::StaticMemberExpression(member) = &call.callee else {
         return false;
     };
-    member.property.name == "track_reactivity_loss"
+    member.property.name == name
         && matches!(&member.object, Expression::Identifier(id) if id.name == "$")
 }
 
@@ -182,11 +242,13 @@ pub(super) fn collect_await_reactivity_loss_edits(
     program: &Program<'_>,
     source: &str,
     is_runes: bool,
+    experimental_async: bool,
 ) -> Vec<Edit> {
     let mut collector = AwaitCollector {
         source,
         ignored: collect_await_ignore_ranges(program, source, is_runes),
         separators: rustc_hash::FxHashMap::default(),
+        experimental_async,
         edits: Vec::new(),
     };
     collector.visit_program(program);
@@ -198,6 +260,9 @@ struct AwaitCollector<'src> {
     ignored: AwaitIgnoreRanges,
     /// Statement start → end of the statement a `;` has to separate it from.
     separators: rustc_hash::FxHashMap<u32, u32>,
+    /// Upstream's `ForOfStatement` wrap is gated on `experimental.async`; the
+    /// `AwaitExpression` one is not.
+    experimental_async: bool,
     edits: Vec<Edit>,
 }
 
@@ -206,6 +271,16 @@ impl<'a, 'src> Visit<'a> for AwaitCollector<'src> {
         self.separators
             .extend(separator_positions(stmts, self.source));
         walk::walk_statements(self, stmts);
+    }
+
+    fn visit_for_of_statement(&mut self, stmt: &ForOfStatement<'a>) {
+        walk::walk_for_of_statement(self, stmt);
+
+        if let Some(edit) =
+            for_await_edit(stmt, self.source, self.experimental_async, &self.ignored)
+        {
+            self.edits.push(edit);
+        }
     }
 
     fn visit_await_expression(&mut self, expr: &AwaitExpression<'a>) {

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/instance_dev_tail_ast.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/instance_dev_tail_ast.rs
@@ -69,6 +69,7 @@ pub(super) fn transform_legacy_instance_dev_tail_ast(
     // across fixed-point iterations.
     let has_equality = super::strict_equals_ast::source_has_equality_op(source);
     let has_await = super::await_reactivity_loss_ast::source_has_await(source);
+    let experimental_async = analysis.is_some_and(|a| a.experimental_async);
     // The per-statement loop in `mod.rs` never sees a `$:` body — it is folded
     // into a `$.legacy_pre_effect(...)` call afterwards — so the console wrap
     // has to be re-collected over the settled script.
@@ -95,7 +96,10 @@ pub(super) fn transform_legacy_instance_dev_tail_ast(
                 // hyphenated code spellings.
                 edits.extend(
                     super::await_reactivity_loss_ast::collect_await_reactivity_loss_edits(
-                        program, src, false,
+                        program,
+                        src,
+                        false,
+                        experimental_async,
                     ),
                 );
             }

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/module_dev_tail_ast.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/module_dev_tail_ast.rs
@@ -70,6 +70,7 @@ pub(super) fn transform_module_dev_tail_ast(
 
     let has_inspect = dev && super::inspect_rune_ast::source_has_inspect_rune(source);
     let has_await = dev && super::await_reactivity_loss_ast::source_has_await(source);
+    let experimental_async = analysis.is_some_and(|a| a.experimental_async);
 
     if !has_effect && !has_strict && !has_console && !has_tag && !has_inspect && !has_await {
         return None;
@@ -114,7 +115,10 @@ pub(super) fn transform_module_dev_tail_ast(
             if has_await {
                 edits.extend(
                     super::await_reactivity_loss_ast::collect_await_reactivity_loss_edits(
-                        program, src, is_runes,
+                        program,
+                        src,
+                        is_runes,
+                        experimental_async,
                     ),
                 );
             }

--- a/crates/rsvelte_core/tests/dev_for_await_reactivity_loss.rs
+++ b/crates/rsvelte_core/tests/dev_for_await_reactivity_loss.rs
@@ -1,0 +1,138 @@
+//! Dev-mode `for await (… of X)` instrumentation.
+//!
+//! Upstream's `visitors/ForOfStatement.js` wraps an awaited loop's iterable in
+//! `$.for_await_track_reactivity_loss(X)` when `dev` and `experimental.async`
+//! are both on. rsvelte only instrumented `AwaitExpression`, so awaited
+//! `for…of` loops stayed bare in every script kind. The expectations below are
+//! the official compiler's output.
+
+use rsvelte_core::compiler::ModuleCompileOptions;
+use rsvelte_core::{CompileOptions, ExperimentalOptions, GenerateMode, compile, compile_module};
+
+fn compile_component(src: &str, dev: bool, r#async: bool) -> String {
+    compile(
+        src,
+        CompileOptions {
+            filename: Some("Main.svelte".to_string()),
+            generate: GenerateMode::Client,
+            dev,
+            experimental: ExperimentalOptions { r#async },
+            ..Default::default()
+        },
+    )
+    .expect("compile")
+    .js
+    .code
+}
+
+fn compile_svelte_js(src: &str, dev: bool, r#async: bool) -> String {
+    compile_module(
+        src,
+        ModuleCompileOptions {
+            filename: Some("store.svelte.js".to_string()),
+            generate: GenerateMode::Client,
+            dev,
+            experimental: ExperimentalOptions { r#async },
+            ..Default::default()
+        },
+    )
+    .expect("compile")
+    .js
+    .code
+}
+
+const WRAPPED: &str = "for await (const x of $.for_await_track_reactivity_loss(gen())) {";
+
+#[track_caller]
+fn assert_contains(out: &str, expected: &str) {
+    assert!(out.contains(expected), "expected `{expected}`. Got:\n{out}");
+}
+
+#[track_caller]
+fn assert_absent(out: &str, unexpected: &str) {
+    assert!(
+        !out.contains(unexpected),
+        "unexpected `{unexpected}`. Got:\n{out}"
+    );
+}
+
+const MODULE_LOOP: &str =
+    "export async function run() {\n\tfor await (const x of gen()) {\n\t\tuse(x);\n\t}\n}\n";
+
+#[test]
+fn svelte_js_module_loop_is_instrumented() {
+    assert_contains(&compile_svelte_js(MODULE_LOOP, true, true), WRAPPED);
+}
+
+#[test]
+fn prod_leaves_the_loop_bare() {
+    assert_absent(
+        &compile_svelte_js(MODULE_LOOP, false, true),
+        "for_await_track_reactivity_loss",
+    );
+}
+
+#[test]
+fn without_experimental_async_the_loop_stays_bare() {
+    assert_absent(
+        &compile_svelte_js(MODULE_LOOP, true, false),
+        "for_await_track_reactivity_loss",
+    );
+}
+
+#[test]
+fn svelte_ignore_suppresses_the_loop_wrap() {
+    let src = "export async function run() {\n\t// svelte-ignore await_reactivity_loss\n\tfor await (const x of gen()) {\n\t\tuse(x);\n\t}\n}\n";
+    assert_absent(
+        &compile_svelte_js(src, true, true),
+        "for_await_track_reactivity_loss",
+    );
+}
+
+#[test]
+fn a_plain_for_of_is_never_wrapped() {
+    let src = "export function run() {\n\tfor (const x of gen()) {\n\t\tuse(x);\n\t}\n}\n";
+    assert_absent(
+        &compile_svelte_js(src, true, true),
+        "for_await_track_reactivity_loss",
+    );
+}
+
+#[test]
+fn the_wrap_is_applied_exactly_once() {
+    let out = compile_svelte_js(MODULE_LOOP, true, true);
+    assert_eq!(
+        out.matches("$.for_await_track_reactivity_loss").count(),
+        1,
+        "got:\n{out}"
+    );
+}
+
+#[test]
+fn script_module_loop_is_instrumented() {
+    let src = format!("<script module>\n{MODULE_LOOP}</script>\n\n<p>hi</p>");
+    assert_contains(&compile_component(&src, true, true), WRAPPED);
+}
+
+#[test]
+fn runes_instance_loop_is_instrumented() {
+    let src = "<script>\n\tlet a = $state(0);\n\tasync function f() {\n\t\tfor await (const x of gen()) {\n\t\t\tuse(x);\n\t\t}\n\t}\n</script>\n";
+    assert_contains(&compile_component(src, true, true), WRAPPED);
+}
+
+#[test]
+fn legacy_instance_loop_is_instrumented() {
+    let src = "<script>\n\texport let a;\n\tasync function f() {\n\t\tfor await (const x of gen()) {\n\t\t\tuse(x);\n\t\t}\n\t}\n</script>\n";
+    assert_contains(&compile_component(src, true, true), WRAPPED);
+}
+
+/// The iterable is instrumented as an `await` first, then the loop wraps the
+/// settled expression — the nesting the fixed-point splice has to converge on.
+#[test]
+fn an_awaited_iterable_gets_both_wraps() {
+    let src = "export async function run() {\n\tfor await (const x of await gen()) {\n\t\tuse(x);\n\t}\n}\n";
+    assert_contains(
+        &compile_svelte_js(src, true, true),
+        "$.for_await_track_reactivity_loss((await $.track_reactivity_loss(gen()))())",
+    );
+}


### PR DESCRIPTION
Re-checking #2255 and #2090 against current `main` found both already closed by earlier work (#2175, #2180, #2240, #2332) — see the issue comments for the per-sub-case verdict. What is **not** covered anywhere is the sibling helper in the same upstream visitor family: `visitors/ForOfStatement.js`.

Upstream wraps an awaited loop's iterable when `dev` **and** `experimental.async` are on:

```js
for await (const x of $.for_await_track_reactivity_loss(gen())) { … }
```

rsvelte only ported `visitors/AwaitExpression.js`, so `$.for_await_track_reactivity_loss` had zero occurrences in the whole tree and every `for await` loop stayed bare in dev. Like the `await` case this is not purely cosmetic: the helper is an async generator wrapper, so its absence changes how many microtasks the loop takes per iteration in addition to silencing the dev reactivity-loss warning.

The wrap is collected in the existing shared `await_reactivity_loss_ast` visitor (so it rides the same batched parse and the same analysis-phase `svelte-ignore` ranges) and in `ast_state_transform`'s runes-instance visitor, covering all four script kinds: runes instance, legacy instance, `<script module>` and `.svelte.(js|ts)`.

One ordering subtlety: for `for await (… of await gen())` the loop edit and the `await` edit span exactly the same source range, which the splice's *strict*-containment check cannot order — so the loop edit is deferred to the next fixed-point iteration and lands over the settled expression, matching upstream's `$.for_await_track_reactivity_loss((await $.track_reactivity_loss(gen()))())`.

`crates/rsvelte_core/tests/dev_for_await_reactivity_loss.rs` (10 tests) pins each script kind, the `dev` / `experimental.async` / plain-`for…of` negatives, the `svelte-ignore` suppression, single application, and the nested case — all expectations taken from `svelte/compiler` 5.56.8 output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012gQPtKmdY9xwn5fjdwaxK8