### PR TITLE
chore(ci): stop the lint-types lock check from passing when it cannot resolve

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
 		"check-e2e-corpus:update": "node scripts/compat-corpus/check-e2e-verify.mjs --update",
 		"test:svelte-check-e2e": "pnpm run check-e2e-corpus:sync && cargo build --release -p rsvelte_check && pnpm run check-corpus:oracle-install && pnpm run check-e2e-corpus:verify",
 		"changeset": "changeset",
-		"version-packages": "changeset version && pnpm run sync-version && pnpm run check:lint-types-lock",
+		"version-packages": "changeset version && pnpm run sync-version && node scripts/ci/check-lint-types-lock.mjs --allow-unresolved",
 		"release": "pnpm run sync-version && pnpm run build:wasm && pnpm run finalize-pkg && pnpm run publish-platform-binaries && pnpm run build:language-server && changeset publish"
 	},
 	"devDependencies": {

--- a/scripts/ci/check-lint-types-lock.mjs
+++ b/scripts/ci/check-lint-types-lock.mjs
@@ -13,8 +13,18 @@
 //   1. text audit (no cargo, no submodule): every in-repo crate pinned in the
 //      lock must match its `crates/<name>/Cargo.toml` `[package].version`.
 //   2. resolution (`cargo metadata --locked`): ground truth, catches dependency
-//      graph / requirement / oxc-patch / corsa-bind drift too. Skipped when
-//      `submodules/corsa-bind` is absent unless `--require-resolve` is passed.
+//      graph / requirement / oxc-patch / corsa-bind drift too.
+//
+// Layer 2 needs `submodules/corsa-bind` checked out. If it's missing this
+// script inits it itself (public repo, shallow, ~3s) rather than silently
+// falling back to layer 1 alone — a text-pin match is not evidence the lock
+// resolves, and reporting it as a pass previously let a 15-entry oxc-rev
+// drift through undetected on every machine that hadn't run
+// `git submodule update --init submodules/corsa-bind`. If resolution still
+// cannot happen (no network, no cargo), that is reported as a distinct,
+// non-passing outcome — never printed or exit-coded like a real pass — unless
+// the caller opted in with `--allow-unresolved` (used by `version-packages`,
+// which must not hard-fail on infra flakiness; see that script for why).
 
 import { execFileSync } from 'node:child_process';
 import { existsSync, readFileSync, readdirSync, writeFileSync } from 'node:fs';
@@ -29,12 +39,16 @@ const corsaBind = resolve(repoRoot, 'submodules/corsa-bind');
 
 const argv = new Set(process.argv.slice(2));
 const fix = argv.has('--fix');
-const requireResolve = argv.has('--require-resolve');
+// `--require-resolve` is still accepted (ci.yml passes it) but is now a
+// no-op: resolution is attempted by default via the self-init below.
+const allowUnresolved = argv.has('--allow-unresolved');
+
+const SUBMODULE_INIT_CMD = 'git submodule update --init submodules/corsa-bind';
 
 const FIX_HINT = [
 	'Fix it with:',
 	'',
-	'    git submodule update --init --depth 1 submodules/corsa-bind',
+	`    ${SUBMODULE_INIT_CMD}`,
 	'    pnpm run fix:lint-types-lock',
 	'',
 	'then commit the updated crates/rsvelte_lint_types/Cargo.lock.',
@@ -94,6 +108,51 @@ function runCargoMetadata(locked) {
 	});
 }
 
+function haveCorsaBind() {
+	return existsSync(corsaBind) && readdirSync(corsaBind).length > 0;
+}
+
+// Shallow + public: cheap enough (~3s measured) to attempt unconditionally
+// instead of asking every caller to remember a manual setup step.
+function ensureCorsaBind() {
+	if (haveCorsaBind()) return { ok: true };
+	try {
+		execFileSync('git', ['submodule', 'update', '--init', '--depth', '1', 'submodules/corsa-bind'], {
+			cwd: repoRoot,
+			stdio: ['ignore', 'ignore', 'pipe'],
+		});
+		return { ok: true };
+	} catch (err) {
+		const detail = err.stderr ? err.stderr.toString().trim().split('\n')[0] : err.message;
+		return { ok: false, reason: `could not check out submodules/corsa-bind (${detail})` };
+	}
+}
+
+function cargoAvailable() {
+	try {
+		execFileSync('cargo', ['--version'], { stdio: 'ignore' });
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+// The one outcome that must never be mistaken for "the lock is fine": layer 2
+// (the only layer that catches dependency-graph / oxc-patch drift) did not
+// run at all. `--allow-unresolved` is the only way to make this exit 0.
+function reportUnresolved(reason) {
+	const detail =
+		`${lockRel}: resolution NOT verified — ${reason}.\n` +
+		`Only the in-repo version-pin text audit ran; dependency-graph / oxc-patch drift would NOT be caught.\n` +
+		`Enable it with: ${SUBMODULE_INIT_CMD}`;
+	if (allowUnresolved) {
+		console.log(`SKIPPED (not a pass): ${detail}`);
+		process.exit(0);
+	}
+	console.error(detail);
+	process.exit(1);
+}
+
 let lockText = readFileSync(lockPath, 'utf8');
 const drifted = auditPins(lockText);
 
@@ -105,13 +164,15 @@ if (fix) {
 			console.log(`  ${name}: ${pinned} -> ${actual}`);
 		}
 	}
-	if (existsSync(corsaBind) && readdirSync(corsaBind).length > 0) {
+	const corsa = ensureCorsaBind();
+	if (corsa.ok) {
 		runCargoMetadata(false);
 		console.log(`Re-resolved ${lockRel}.`);
 	} else {
 		console.log(
-			`submodules/corsa-bind is not checked out — pins synced textually only.\n` +
-				`Run \`git submodule update --init --depth 1 submodules/corsa-bind\` and re-run to fully re-resolve.`,
+			`Could not re-resolve ${lockRel} — ${corsa.reason}.\n` +
+				`Pins were synced textually only; dependency-graph / oxc-patch drift may remain.\n` +
+				`Run \`${SUBMODULE_INIT_CMD}\` and re-run to fully re-resolve.`,
 		);
 	}
 	process.exit(0);
@@ -126,18 +187,10 @@ if (drifted.length > 0) {
 	process.exit(1);
 }
 
-const haveCorsaBind = existsSync(corsaBind) && readdirSync(corsaBind).length > 0;
-if (!haveCorsaBind) {
-	if (requireResolve) {
-		console.error(
-			'submodules/corsa-bind is not checked out, so the lock cannot be resolved.\n' +
-				'Run: git submodule update --init --depth 1 submodules/corsa-bind',
-		);
-		process.exit(1);
-	}
-	console.log(`${lockRel} pins match crates/ (resolution check skipped: no corsa-bind).`);
-	process.exit(0);
-}
+const corsa = ensureCorsaBind();
+if (!corsa.ok) reportUnresolved(corsa.reason);
+
+if (!cargoAvailable()) reportUnresolved('cargo is not installed / not on PATH');
 
 try {
 	runCargoMetadata(true);

--- a/scripts/compat-corpus/css-prune-sweep.mjs
+++ b/scripts/compat-corpus/css-prune-sweep.mjs
@@ -497,9 +497,9 @@ if (CHECK) {
 	const regressions = divergedIds.filter((id) => !baseline.has(id));
 	const fixed = [...baseline].filter((id) => !divergedIds.includes(id));
 	if (fixed.length) {
-		console.log(`\n[css-prune-sweep] ${fixed.length} baseline divergences now fixed — shrink the ratchet:`);
-		for (const id of fixed.slice(0, 20)) console.log(`  - ${id}`);
-		console.log('  run: node scripts/compat-corpus/css-prune-sweep.mjs --update-baseline');
+		console.error(`\n[css-prune-sweep] ${fixed.length} baseline divergences now fixed — the ratchet is stale:`);
+		for (const id of fixed.slice(0, 20)) console.error(`  - ${id}`);
+		console.error('  fix: node scripts/compat-corpus/css-prune-sweep.mjs --update-baseline');
 	}
 	if (regressions.length) {
 		console.error(`\n[css-prune-sweep] ${regressions.length} NEW prune divergence(s) (regressions):`);
@@ -507,8 +507,11 @@ if (CHECK) {
 			const d = diverged.find((x) => x.id === id);
 			console.error(`  - ${id}  [${d.verdict}]`);
 		}
-		process.exit(1);
 	}
+	// Staleness is fatal, same as the other corpus ratchets: an "already
+	// fixed" delta left unmerged on a later PR reads as normal noise, so a
+	// real regression could hide inside it.
+	if (regressions.length > 0 || fixed.length > 0) process.exit(1);
 	console.log(`\n[css-prune-sweep] no regressions (${divergedIds.length} known divergences)`);
 	process.exit(0);
 }


### PR DESCRIPTION
## Summary

`scripts/ci/check-lint-types-lock.mjs` has two layers: a cargo-free text
audit (in-repo pins vs `crates/<name>/Cargo.toml`) and `cargo metadata
--locked` as ground truth. When `submodules/corsa-bind` is absent — the
normal state of a fresh worktree — the ground-truth layer couldn't run, and
the script **silently degraded to the text audit alone and printed a pass
with exit 0**.

This reproduced for real today: it printed `crates/rsvelte_lint_types/Cargo.lock
pins match crates/ (resolution check skipped: no corsa-bind).` and exited 0
while the lock held 15 entries pinning a stale oxc revision. Only CI's own
`Lint-types lockfile` job — which explicitly checks out corsa-bind before
running — caught the drift.

### What the degraded path used to report

```
crates/rsvelte_lint_types/Cargo.lock pins match crates/ (resolution check skipped: no corsa-bind).
```
Exit code **0** — indistinguishable in exit code from a real pass, and the
message didn't say how to get a real check.

### What it reports now

- **Default** (`pnpm run check:lint-types-lock`, `--require-resolve`): the
  script now **self-inits** `submodules/corsa-bind` (public, shallow clone,
  ~3s measured) before checking, so resolution actually runs in the vast
  majority of invocations — local or CI. If resolution genuinely can't
  happen (no network, no `cargo` on `PATH`), it now exits **1** with:
  ```
  crates/rsvelte_lint_types/Cargo.lock: resolution NOT verified — <reason>.
  Only the in-repo version-pin text audit ran; dependency-graph / oxc-patch drift would NOT be caught.
  Enable it with: git submodule update --init submodules/corsa-bind
  ```
- **`--allow-unresolved`** (new flag, used only by `version-packages`): same
  message, prefixed `SKIPPED (not a pass):`, but exits **0** — this is the
  only way to get a zero exit without a real resolution, and it's an
  explicit opt-in rather than an accidental default.
- **`--fix`**: also self-inits now, so `pnpm run fix:lint-types-lock` gets a
  real re-resolve instead of a "textually only" fallback whenever corsa-bind
  was missing.

A real drift (text-pin mismatch, or `cargo metadata --locked` refusing to
update the lock) still always exits 1, regardless of `--allow-unresolved` —
that flag only tolerates "couldn't check," never "found a problem."

### Call sites verified

- `.github/workflows/ci.yml`'s `Lint-types lockfile` job (`--require-resolve`) —
  unchanged behavior; it already checks out corsa-bind itself, and
  `--require-resolve` is now a documented no-op (self-init covers it).
- `pnpm run version-packages` (`changeset version && sync-version && ...`) —
  now calls the script directly with `--allow-unresolved` instead of via
  `pnpm run check:lint-types-lock`, so a release PR still gets a real check
  whenever the release runner has network (it does), but can never be
  blocked by an environment that can't self-init/resolve. This matters
  because `release.yml`'s `version-pr` job intentionally has **no** Rust
  toolchain setup and no submodule checkout — a documented design choice to
  keep that job decoupled from Rust/cargo flakiness after a past incident
  (comment in `release.yml`: "Decoupling it means a flaky crates.io download
  in one build leg can no longer block the version PR").
- `pnpm run fix:lint-types-lock` — repair path, still exits 0 always (it's a
  repair tool, not a gate); message now distinguishes a full re-resolve from
  a textual-only sync.

### Verification (actually reproduced the failure)

With `submodules/corsa-bind` deinitialized:
- **Old script**: printed `pins match crates/ (resolution check skipped: no
  corsa-bind).` and exited **0** — confirmed the bug.
- **New script, default invocation**: self-inited corsa-bind and ran the
  real `cargo metadata --locked` check, printing `... is up to date.` and
  exiting **0** (~2.3s total, submodule init included) — a real pass this
  time, not a skip.
- **New script, `cargo` removed from `PATH`** (corsa-bind present): exits
  **1** with the "resolution NOT verified" message; with
  `--allow-unresolved`, exits **0** prefixed `SKIPPED (not a pass):`.
- Text-audit drift path re-verified unchanged: mutating an in-repo pin in
  the lock still fails with the original "is stale" message and exit 1.
- `--fix` re-verified: re-resolves for real when corsa-bind is present.

## Wider check: other silent-pass gates

Searched `scripts/` and `.github/workflows/*.yml` for the same shape (a
`catch` that logs and continues, a missing-tool branch that returns
success, `|| true`, a ratchet that doesn't fail on staleness).

**Fixed in this PR** (small, precedented, verified by `node --check` +
reasoning from the three sibling implementations — not by a live corpus
run, since that needs a built NAPI binding):
- `scripts/compat-corpus/css-prune-sweep.mjs` `--check` mode (CI: `corpus-compat.yml:251`) —
  logged stale ("now fixed") ratchet entries as a suggestion but only
  `process.exit(1)`'d on new regressions, never on staleness. Its three
  sibling ratchets (`lint-verify.mjs:228`, `check-verify.mjs:284`,
  `check-e2e-verify.mjs:250`) already treat staleness as fatal (established
  by #2287). Brought this one in line.

**Listed, not fixed** (out of scope for this PR — lower severity or needs
more context than a 45-minute budget allows to change safely):
- `scripts/dev/check-vps-version.mjs:20-23` — same shape as the bug this PR
  fixes: no-ops (prints a skip message, exit 0) when `submodules/svelte`
  isn't checked out. Its own comment already documents this as intentional
  ("not every contributor/CI job initializes it"). Lower risk in practice
  because `.github/workflows/ci.yml`'s `vps-version-check` job explicitly
  checks out the submodule first (`ci.yml:926-930`), but any local run or a
  future CI job that reuses the script without that step gets a false pass.
- `scripts/release/publish-vscode.mjs:169-170` — an Open VSX publish failure
  is caught and logged as "continuing" rather than failing the job. This
  looks like an intentional secondary-publisher fallback rather than a bug,
  but it does mean an Open VSX outage never fails CI; flagging for a
  maintainer call.
- Already-known relatives per project history, not re-audited in depth here:
  `verify.mjs`'s empty-output-scores-as-match bug (fixed by #2335 with a
  ≥99% coverage floor), the formatter corpus reporting "running 0 tests"
  when the oracle corpus is absent, and `oxfmt`-dependent Rust tests
  no-op'ing when `oxfmt` is missing.

## Test plan

- [x] Reproduced the old bug: corsa-bind absent → old script prints
      misleading "skipped" message but exits 0.
- [x] Confirmed new default behavior self-inits + performs a real
      `cargo metadata --locked` check, exit 0 on a genuine pass.
- [x] Confirmed new default behavior exits 1 with a distinct message when
      resolution is truly impossible (`cargo` removed from `PATH`).
- [x] Confirmed `--allow-unresolved` downgrades that same case to exit 0
      with an unmistakable `SKIPPED (not a pass):` prefix.
- [x] Confirmed the text-pin drift path (real problem) still exits 1
      regardless of any flag.
- [x] Confirmed `--fix` still exits 0 and now re-resolves for real.
- [x] `node --check` on both modified `.mjs` files.
- [ ] CI (not watched per task instructions — will be checked async).

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

https://claude.ai/code/session_012gQPtKmdY9xwn5fjdwaxK8