### PR TITLE
fix(compiler): make the reactive-statement assignment scan lexical-aware

### DIFF
--- a/.changeset/reactive-comment-brace-segv.md
+++ b/.changeset/reactive-comment-brace-segv.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/compiler": patch
+---
+
+Fix a stack-overflow crash when a comment containing `}` or `)` appears inside a `$:` reactive block body

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/destructure_transforms.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/destructure_transforms.rs
@@ -566,8 +566,12 @@ pub(super) fn extract_destructure_targets(pattern: &str) -> Vec<String> {
             targets.push(root);
         }
 
-        // Also recurse into nested patterns
-        if part.starts_with('[') || part.starts_with('{') {
+        // Also recurse into nested patterns. Only a *closed* bracket pair is
+        // recursed into: an unbalanced fragment strips nothing, so the callee
+        // would re-derive the identical part and never terminate.
+        if (part.starts_with('[') && part.ends_with(']'))
+            || (part.starts_with('{') && part.ends_with('}'))
+        {
             let nested = extract_destructure_targets(part);
             targets.extend(nested);
         }

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/state_transforms.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/state_transforms.rs
@@ -13,6 +13,7 @@ use super::rune_transforms::{
 };
 use super::{STATE_TMP_COUNTER, get_or_compile_regex};
 use crate::compiler::phases::phase2_analyze::scope::DeclarationKind;
+use crate::compiler::phases::phase3_transform::shared::js_scan::skip_opaque;
 
 // ---------------------------------------------------------------------------
 // Identifier reference detection (lines 7653-8602 of mod.rs)
@@ -852,42 +853,57 @@ pub(super) fn lhs_starts_with_keyword(lhs: &str) -> bool {
 
 /// Find the position of the assignment operator (=) that's not part of ==, ===, !=, !==
 pub(super) fn find_assignment_position(expr: &str) -> Option<usize> {
-    let chars: Vec<char> = expr.chars().collect();
+    let bytes = expr.as_bytes();
     let mut i = 0;
-    let mut depth = 0;
+    let mut depth = 0i32;
+    // Last significant code byte, both for the operator lookbehind and to tell a
+    // regex literal from a division.
+    let mut prev: Option<u8> = None;
 
-    while i < chars.len() {
-        let c = chars[i];
+    while i < bytes.len() {
+        if let Some((next, is_comment)) = skip_opaque(bytes, i, prev) {
+            if !is_comment {
+                prev = Some(b'x');
+            }
+            i = next;
+            continue;
+        }
+        let c = bytes[i];
         match c {
-            '(' | '[' | '{' => depth += 1,
-            ')' | ']' | '}' => depth -= 1,
-            '=' if depth == 0 => {
+            b'(' | b'[' | b'{' => depth += 1,
+            b')' | b']' | b'}' => depth -= 1,
+            b'=' if depth == 0 => {
                 // Check it's not ==, ===, !=, !==, <=, >=, =>,
                 // or compound assignment operators: +=, -=, *=, /=, %=, **=,
                 // <<=, >>=, >>>=, &=, |=, ^=, &&=, ||=, ??=
-                let prev = if i > 0 { Some(chars[i - 1]) } else { None };
-                let next = chars.get(i + 1).copied();
+                let next = bytes.get(i + 1).copied();
 
-                if prev != Some('=')
-                    && prev != Some('!')
-                    && prev != Some('<')
-                    && prev != Some('>')
-                    && prev != Some('+')
-                    && prev != Some('-')
-                    && prev != Some('*')
-                    && prev != Some('/')
-                    && prev != Some('%')
-                    && prev != Some('&')
-                    && prev != Some('|')
-                    && prev != Some('^')
-                    && prev != Some('?')
-                    && next != Some('=')
-                    && next != Some('>')
+                if !matches!(
+                    prev,
+                    Some(
+                        b'=' | b'!'
+                            | b'<'
+                            | b'>'
+                            | b'+'
+                            | b'-'
+                            | b'*'
+                            | b'/'
+                            | b'%'
+                            | b'&'
+                            | b'|'
+                            | b'^'
+                            | b'?'
+                    )
+                ) && next != Some(b'=')
+                    && next != Some(b'>')
                 {
                     return Some(i);
                 }
             }
             _ => {}
+        }
+        if !c.is_ascii_whitespace() {
+            prev = Some(c);
         }
         i += 1;
     }

--- a/crates/rsvelte_core/tests/reactive_block_comment_delimiter_2351.rs
+++ b/crates/rsvelte_core/tests/reactive_block_comment_delimiter_2351.rs
@@ -1,0 +1,37 @@
+//! Issue #2351: a `}` / `)` inside a comment in a `$:` block body crashed the
+//! client compiler.
+
+use rsvelte_core::{CompileOptions, GenerateMode, compile};
+
+fn client(src: &str) -> String {
+    compile(
+        src,
+        CompileOptions {
+            filename: Some("T.svelte".into()),
+            generate: GenerateMode::Client,
+            dev: false,
+            ..Default::default()
+        },
+    )
+    .map(|r| r.js.code)
+    .unwrap_or_else(|e| format!("COMPILE_ERROR: {e:?}"))
+}
+
+#[test]
+fn block_comment_with_brace_in_reactive_block() {
+    let out = client("<script>\n\tlet bar\n\t$: {\n\t\t/* } c */\n\t\tbar = []\n\t}\n</script>");
+    assert!(!out.contains("COMPILE_ERROR"), "{out}");
+    assert!(out.contains("legacy_pre_effect"), "{out}");
+}
+
+#[test]
+fn line_comment_with_brace_in_reactive_block() {
+    let out = client("<script>\n\tlet bar\n\t$: {\n\t\t// } c\n\t\tbar = []\n\t}\n</script>");
+    assert!(!out.contains("COMPILE_ERROR"), "{out}");
+}
+
+#[test]
+fn block_comment_with_paren_in_reactive_block() {
+    let out = client("<script>\n\tlet bar\n\t$: {\n\t\t/* ) c */\n\t\tbar = []\n\t}\n</script>");
+    assert!(!out.contains("COMPILE_ERROR"), "{out}");
+}

--- a/crates/rsvelte_core/tests/reactive_block_comment_delimiter_2351.rs
+++ b/crates/rsvelte_core/tests/reactive_block_comment_delimiter_2351.rs
@@ -17,21 +17,42 @@ fn client(src: &str) -> String {
     .unwrap_or_else(|e| format!("COMPILE_ERROR: {e:?}"))
 }
 
+/// The official compiler emits this for every variant below; before the fix the
+/// process aborted instead.
+const EXPECTED_EFFECT: &str = "$.legacy_pre_effect(() => {}, () => {";
+
+fn assert_matches_official(out: &str) {
+    assert!(!out.contains("COMPILE_ERROR"), "{out}");
+    assert!(out.contains(EXPECTED_EFFECT), "{out}");
+    assert!(out.contains("$.set(bar, []);"), "{out}");
+}
+
 #[test]
 fn block_comment_with_brace_in_reactive_block() {
-    let out = client("<script>\n\tlet bar\n\t$: {\n\t\t/* } c */\n\t\tbar = []\n\t}\n</script>");
-    assert!(!out.contains("COMPILE_ERROR"), "{out}");
-    assert!(out.contains("legacy_pre_effect"), "{out}");
+    assert_matches_official(&client(
+        "<script>\n\tlet bar\n\t$: {\n\t\t/* } c */\n\t\tbar = []\n\t}\n</script>",
+    ));
 }
 
 #[test]
 fn line_comment_with_brace_in_reactive_block() {
-    let out = client("<script>\n\tlet bar\n\t$: {\n\t\t// } c\n\t\tbar = []\n\t}\n</script>");
-    assert!(!out.contains("COMPILE_ERROR"), "{out}");
+    assert_matches_official(&client(
+        "<script>\n\tlet bar\n\t$: {\n\t\t// } c\n\t\tbar = []\n\t}\n</script>",
+    ));
 }
 
 #[test]
 fn block_comment_with_paren_in_reactive_block() {
-    let out = client("<script>\n\tlet bar\n\t$: {\n\t\t/* ) c */\n\t\tbar = []\n\t}\n</script>");
+    assert_matches_official(&client(
+        "<script>\n\tlet bar\n\t$: {\n\t\t/* ) c */\n\t\tbar = []\n\t}\n</script>",
+    ));
+}
+
+/// A `=` inside a string literal is not an assignment either — the same scan
+/// now skips literals, not only comments.
+#[test]
+fn equals_inside_a_string_is_not_an_assignment() {
+    let out = client("<script>\n\tlet bar\n\t$: {\n\t\tbar = ['a=b'];\n\t}\n</script>");
     assert!(!out.contains("COMPILE_ERROR"), "{out}");
+    assert!(out.contains("$.set(bar, ['a=b'])"), "{out}");
 }


### PR DESCRIPTION
Closes #2351

## Diagnosis

The SIGSEGV is **stack exhaustion from unbounded recursion**, not an FFI or memory-safety problem. The crash reproduces in a plain `cargo test` (`thread … has overflowed its stack`), and the macOS crash report names the cycle:

```
extract_destructure_targets   (x N, until the guard page)
transform_reactive_statement
transform_instance_script_for_visitors
transform_client
```

Two defects compose:

1. **What overran.** `client/state_transforms.rs::find_assignment_position` counted `(`/`[`/`{` character by character with no lexical awareness. For the repro body `{ /* } c */ bar = [] }` the `}` **inside the comment** decremented the depth back to 0, so the `=` of `bar = []` was reported as a top-level assignment. `transform_reactive_statement` then took `lhs = "{ /* } c */ bar"` — an unbalanced fragment.

2. **What recursed.** `client/destructure_transforms.rs::extract_destructure_targets` strips the outer brackets only when the string starts *and* ends with a matching pair. The fragment starts with `{` and ends with `r`, so nothing was stripped; `split_on_commas` returned the identical single part; and the `part.starts_with('{')` branch recursed on that same string. No termination condition, no progress — infinite recursion.

That is why all three conditions from the issue are required: `client` (only the client path runs these text transforms), a **reactive block** (only `$:` feeds a `{…}` body into `find_assignment_position`), and a closing delimiter **inside a comment** (without it the depth never returns to 0 and no `=` is reported, so the else-branch handles the block correctly).

## Fix

`find_assignment_position` now steps over comments, strings, template literals and regex literals with the shared `shared::js_scan::skip_opaque` — the same consolidation #2283 applied to five sibling scans; this call site was not among them. It also now returns **byte** offsets: it previously collected `chars()` and returned a char index that every caller sliced with as a byte offset, which was a latent panic on any non-ASCII reactive statement.

`extract_destructure_targets` recurses only into a *closed* bracket pair, so the callee is always strictly shorter than the caller's input. This is the safety net, not the fix — with the scan corrected the malformed fragment is never constructed — but it makes the function structurally unable to diverge on any future caller.

No post-pass string hack; both changes are in the scanners themselves.

## #2347

Not fixed here — different scanner. #2347 is in the `$props()` destructuring / `rest_props` emission path, which does not go through `find_assignment_position`. Left open.

## Test

`crates/rsvelte_core/tests/reactive_block_comment_delimiter_2351.rs` covers all three crashing variants from the issue (`/* } c */`, `// } c`, `/* ) c */`). Every one of them aborts the test binary on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012gQPtKmdY9xwn5fjdwaxK8