### PR TITLE
fix(compiler): trim trailing comments from `$props()` destructuring declarators

### DIFF
--- a/.changeset/props-declarator-trailing-comment.md
+++ b/.changeset/props-declarator-trailing-comment.md
@@ -1,0 +1,14 @@
+---
+"@rsvelte/compiler": patch
+---
+
+Trim trailing comments from `$props()` destructuring declarators
+
+A `//` comment between the last entry of a `$props()` pattern and its closing brace
+stayed glued to the declarator text, so the `= $.rest_props($$props, rest_excludes)`
+initializer the client transform appends landed *inside* the comment. The result still
+parsed — no error, no warning — but the rest binding was declared and never assigned, so
+every forwarded attribute silently disappeared at runtime. The declarator splitter was
+already comment-aware; only its caller was, and only for *leading* comments. Both ends of
+each declarator are now trimmed lexically through `shared::js_scan::skip_opaque`, which
+steps over strings, template literals, regexes and both comment forms.

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/props_transforms.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/props_transforms.rs
@@ -6,6 +6,7 @@ use std::fmt::Write as _;
 
 use crate::compiler::phases::phase2_analyze::ComponentAnalysis;
 use crate::compiler::phases::phase2_analyze::scope::BindingKind;
+use crate::compiler::phases::phase3_transform::shared::js_scan::skip_opaque;
 
 use super::{
     extract_destructured_prop_names, find_matching_paren, get_or_compile_regex,
@@ -2245,6 +2246,51 @@ fn strip_bindable_wrapper(s: &str) -> Option<&str> {
     rest.strip_prefix('(')?.strip_suffix(')')
 }
 
+/// Drop the comments that bracket a `$props()` declarator. A trailing `//` one
+/// would otherwise stay glued to the binding name and swallow the initializer
+/// this helper appends after it.
+fn trim_declarator_comments(s: &str) -> &str {
+    let bytes = s.as_bytes();
+    let mut comments: Vec<(usize, usize)> = Vec::new();
+    let mut prev: Option<u8> = None;
+    let mut i = 0;
+    while i < bytes.len() {
+        if let Some((next, is_comment)) = skip_opaque(bytes, i, prev) {
+            if is_comment {
+                comments.push((i, next));
+            } else {
+                prev = next.checked_sub(1).and_then(|k| bytes.get(k)).copied();
+            }
+            i = next;
+            continue;
+        }
+        if !bytes[i].is_ascii_whitespace() {
+            prev = Some(bytes[i]);
+        }
+        i += 1;
+    }
+
+    let mut start = 0;
+    let mut end = s.len();
+    loop {
+        let slice = &s[start..end];
+        let lo = start + (slice.len() - slice.trim_start().len());
+        let hi = lo + s[lo..end].trim_end().len();
+        if lo == hi {
+            return "";
+        }
+        if let Some(&(_, e)) = comments.iter().find(|&&(st, _)| st == lo) {
+            start = e;
+            end = hi;
+        } else if let Some(&(st, _)) = comments.iter().find(|&&(_, e)| e == hi) {
+            start = lo;
+            end = st;
+        } else {
+            return &s[lo..hi];
+        }
+    }
+}
+
 /// Split declarators by comma, handling nested braces, brackets, parens, and
 /// string / template literals.
 ///
@@ -2530,36 +2576,7 @@ pub(super) fn transform_props_destructuring(
             continue;
         }
 
-        // Strip leading comment lines (e.g., `// eslint-disable-next-line ...`)
-        // These can appear before prop names in destructuring patterns and must not
-        // be included in the prop name string.
-        let prop_part = {
-            let mut s = prop_part;
-            loop {
-                if s.starts_with("//") {
-                    // Single-line comment: skip to end of line
-                    if let Some(newline_pos) = s.find('\n') {
-                        s = s[newline_pos + 1..].trim();
-                        continue;
-                    } else {
-                        // Entire prop_part is a comment - skip it
-                        s = "";
-                        break;
-                    }
-                } else if s.starts_with("/*") {
-                    // Block comment: skip to closing */
-                    if let Some(end_pos) = s.find("*/") {
-                        s = s[end_pos + 2..].trim();
-                        continue;
-                    } else {
-                        s = "";
-                        break;
-                    }
-                }
-                break;
-            }
-            s
-        };
+        let prop_part = trim_declarator_comments(prop_part);
         if prop_part.is_empty() {
             continue;
         }

--- a/crates/rsvelte_core/tests/props_declarator_comment_2347.rs
+++ b/crates/rsvelte_core/tests/props_declarator_comment_2347.rs
@@ -1,0 +1,123 @@
+//! Regression tests for issue #2347 — a `//` comment sitting between the last
+//! entry of a `$props()` destructuring pattern and its closing `}` stayed glued
+//! to the declarator text, so the `= $.rest_props(...)` initializer the client
+//! transform appends landed *inside* the comment. The output still parsed, so
+//! nothing caught it: `props` was declared and never assigned, and every
+//! forwarded attribute silently vanished at runtime.
+//!
+//! The declarator splitter was already comment-aware; its caller only stripped
+//! *leading* comments from each part. Both ends are now trimmed lexically via
+//! `shared::js_scan::skip_opaque`.
+
+use rsvelte_core::compiler::CompileOptions;
+use rsvelte_core::{GenerateMode, compile};
+
+fn client(src: &str, dev: bool) -> String {
+    compile(
+        src,
+        CompileOptions {
+            filename: Some("Input.svelte".to_string()),
+            generate: GenerateMode::Client,
+            dev,
+            ..Default::default()
+        },
+    )
+    .expect("compile")
+    .js
+    .code
+}
+
+const REST_TRAILING_LINE_COMMENT: &str = r#"<script>
+	let {
+		class: className,
+		...props
+	// c
+	} = $props();
+</script>
+
+<div class={className} {...props}></div>
+"#;
+
+#[test]
+fn rest_props_initializer_survives_a_trailing_line_comment() {
+    for dev in [false, true] {
+        let code = client(REST_TRAILING_LINE_COMMENT, dev);
+        assert!(
+            code.contains("let props = $.rest_props($$props,"),
+            "dev={dev}: rest_props initializer was swallowed:\n{code}"
+        );
+        assert!(
+            !code.contains("// c = $.rest_props"),
+            "dev={dev}: initializer emitted inside the comment:\n{code}"
+        );
+    }
+}
+
+#[test]
+fn named_prop_survives_a_trailing_line_comment() {
+    let code = client(
+        r#"<script>
+	let {
+		value
+	// c
+	} = $props();
+</script>
+
+<p>{value}</p>
+"#,
+        false,
+    );
+    assert!(
+        !code.contains("// c"),
+        "the comment leaked into the prop declaration:\n{code}"
+    );
+    assert!(
+        code.contains("$$props.value"),
+        "prop name was not recovered:\n{code}"
+    );
+}
+
+#[test]
+fn trailing_block_comment_is_trimmed_too() {
+    let code = client(
+        r#"<script>
+	let {
+		class: className,
+		...props /* c */
+	} = $props();
+</script>
+
+<div class={className} {...props}></div>
+"#,
+        false,
+    );
+    assert!(
+        code.contains("let props = $.rest_props($$props,"),
+        "block-comment form regressed:\n{code}"
+    );
+}
+
+#[test]
+fn leading_comment_is_still_stripped() {
+    let code = client(
+        r#"<script>
+	let {
+		// eslint-disable-next-line
+		class: className,
+		...props
+	} = $props();
+</script>
+
+<div class={className} {...props}></div>
+"#,
+        false,
+    );
+    assert!(
+        code.contains("'class'"),
+        "leading-comment declarator lost its prop name:\n{code}"
+    );
+    assert!(
+        code.contains("let props = $.rest_props($$props,"),
+        "leading-comment form regressed:\n{code}"
+    );
+}


### PR DESCRIPTION
Closes #2347

## Root cause — not a missed `skip_opaque` site

The task framed this as a possible seventh hand-rolled delimiter scan. It is not.
`split_declarators` in `client/props_transforms.rs` **is already comment-aware**: it tracks
`//` and `/* */` state so a comma inside a comment does not split the declarator list. The
bug is one level up, in its caller `transform_props_destructuring`, which stripped
**leading** comments from each declarator with a small hand-rolled loop and never stripped
**trailing** ones.

For the reported input the last declarator is `...props\n\t// c`. The rest branch does
`strip_prefix("...").trim()`, gets the binding name `props\n// c`, and appends
`" = $.rest_props($$props, [...])"` — putting the initializer inside the line comment:

```js
let props;
var // c = $.rest_props($$props, rest_excludes)
	div = root();
```

That parses, so nothing catches it. `props` is `undefined`, `{...undefined}` spreads
nothing, and every forwarded attribute silently disappears at runtime.

The leading-comment loop is replaced by `trim_declarator_comments`, which lexes the
declarator once through `shared/js_scan.rs::skip_opaque` (strings, template literals,
regexes, both comment forms), records the comment spans, then peels comments off **both**
ends until neither end is one. Client output is now byte-identical to official's
`let props = $.rest_props($$props, rest_excludes);`.

Regression test `crates/rsvelte_core/tests/props_declarator_comment_2347.rs`: the reported
shape in dev and non-dev, the same shape on a named (non-rest) prop, the `/* */` variant,
and a leading-comment case pinning the pre-existing behaviour.

## Inventory: remaining non-`skip_opaque` delimiter scans in `3_transform/`

Using `depth += 1` / `depth -= 1` as the proxy for a hand-rolled bracket scan:
**33 files hold ~200 such sites, and only 2 files route any of them through
`skip_opaque`.** The class is nowhere near closed — #2351 was the sixth site *fixed*, not
the sixth that *exists*.

Columns: `depth ±= 1` sites / mentions `skip_opaque` / has any comment tracking of its own /
has any string-or-quote tracking of its own.

| sites | `skip_opaque` | own comment state | own string state | file |
|---:|---:|:---:|:---:|---|
| 84 | 1 | yes | yes | `server/transform_script.rs` |
| 62 | 0 | **no** | yes | `server/transform_legacy.rs` |
| 54 | 0 | yes | yes | `client/expression_utils.rs` |
| 40 | 0 | **no** | yes | `client/state_transforms.rs` |
| 38 | 0 | yes | yes | `client/props_transforms.rs` (this PR) |
| 30 | 0 | **no** | yes | `server/helpers.rs` |
| 26 | 0 | **no** | yes | `shared/async_body.rs` |
| 22 | 0 | yes | yes | `client/mod.rs` |
| 18 | 0 | **no** | yes | `client/destructure_transforms.rs` |
| 12 | 0 | yes | yes | `server/transform_store.rs` |
| 9 | 6 | yes | yes | `client/class_transforms.rs` (the #2253/#2351 site) |
| 8 | 0 | **no** | yes | `client/rune_transforms.rs` |
| 6 | 0 | **no** | yes | `server/mod.rs` |
| 6 | 0 | **no** | yes | `client/visitors/declaration_tag.rs` |
| 6 | 0 | **no** | **no** | `server/ast/visitors/declaration_tag.rs` |
| 6 | 0 | **no** | **no** | `client/ast_state_transform.rs` |
| 5 | 0 | yes | yes | `client/reactive_transforms.rs` |
| 4 | 0 | yes | yes | `client/formatting.rs` |
| 4 | 0 | **no** | yes | `client/visitors/await_block.rs` |
| 4 | 0 | **no** | yes | `client/store_transforms.rs` |
| 4 | 0 | **no** | **no** | `server/await_save_ast.rs` |
| 4 | 0 | **no** | **no** | `server/ast/visitors/const_tag.rs` |
| 4 | 0 | **no** | **no** | `client/private_v_suffix_ast.rs` |
| 4 | 0 | **no** | **no** | `client/private_member_mutate_root_ast.rs` |
| 3 | 0 | **no** | yes | `css.rs` |
| 2 | 0 | **no** | yes | `shared/class_body.rs` |
| 2 | 0 | **no** | yes | `client/state_reads_ast.rs` |
| 2 | 0 | **no** | yes | `client/read_only_props_ast.rs` |
| 2 | 0 | **no** | yes | `mod.rs` |
| 2 | 0 | **no** | yes | `js_ast/codegen.rs` |
| 2 | 0 | **no** | **no** | `server/ast/visitors/shared.rs` |
| 2 | 0 | **no** | **no** | `client/assign_dev_ast.rs` |
| 1 | 0 | **no** | yes | `server/evaluate.rs` |

Reproduce:

```sh
grep -rlE 'depth (\+|-)= 1' crates/rsvelte_core/src/compiler/phases/3_transform/ \
  | while read f; do echo "$(grep -cE 'depth (\+|-)= 1' "$f") $(grep -c skip_opaque "$f") $f"; done \
  | sort -rn
```

Two caveats on reading it:

1. **"own comment state" does not mean safe.** `props_transforms.rs` has comment tracking
   and still shipped #2347, because the tracking lived in the splitter and the bug lived in
   the caller. The unit that must be lexically aware is the whole pipeline from source text
   to emitted text, not any single scan inside it. A file-level audit will therefore miss
   this shape of bug; the seam between two scans is where it lives.
2. **The rows with no comment state at all are the mechanical candidates.** Largest first:
   `server/transform_legacy.rs` (62), `client/state_transforms.rs` (40),
   `server/helpers.rs` (30), `shared/async_body.rs` (26),
   `client/destructure_transforms.rs` (18). None were audited here. A sweep converting them
   is how the class gets closed rather than whittled, and deserves its own issue.

Also spotted, not fixed: `transform_props_destructuring` locates the pattern with
`trimmed.find('{')` / `trimmed.rfind('}')` — raw char searches, so a `{` or `}` inside a
comment or string anywhere in the declaration moves them. Same family, belongs in the sweep.

## Second bug from the #2351 investigation

Filed as #2355 rather than fixed here. rsvelte keeps a comment inside a `$:` block body in
the generated `$.legacy_pre_effect` body where official drops it. The handed-over diagnosis
(that `strip_reactive_statement_comments` handles only trailing comments) turns out to be
**wrong** — that function already has passing unit tests for exactly this shape
(`drops_comments_inside_a_reactive_block`, `drops_comments_inside_a_reactive_if_block`), so
the real question is why the comment never reaches it. #2355 records that correction so the
next person does not patch a function that is already correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
