### PR TITLE
perf(compiler): index the prop-read rewriter's per-identifier backward scans (#2342)

### DIFF
--- a/.changeset/prop-read-guard-index.md
+++ b/.changeset/prop-read-guard-index.md
@@ -1,0 +1,16 @@
+---
+"@rsvelte/compiler": patch
+---
+
+Remove the residual quadratic term in prop-read rewriting
+
+`transform_prop_reads_in_expr` asked three questions per matched identifier — shadowed by
+a function parameter, an explicit object-literal property key, an arrow-function parameter
+binding — and each was answered by a backward scan that could run to the start of the
+expression. Matches are themselves O(n), so the guards were O(n) work fired O(n) times:
+the term left over after the `char_indices().nth(i)` fix.
+
+A bracket-event index, built in the same walk that already produces the rewriter's
+character vector and byte offsets, answers those questions in O(log m). On a scaling
+fixture (one `$: _class = cls(…)` over four props) compile time drops 1.5x at 2.8 KB to
+24.9x at 89 KB, and the fitted log-log slope of time against size falls from 1.73 to 0.92.

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/expression_utils.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/expression_utils.rs
@@ -3,6 +3,8 @@
 use memchr::memmem;
 use std::fmt::Write as _;
 
+use super::scan_index::ScanIndex;
+
 /// Collapse a multi-line expression to a single line, matching esrap's behavior.
 /// Strip TypeScript generic type parameters from rune calls.
 /// Converts `$state<SomeType>(...)` → `$state(...)` and `$derived<T>(...)` → `$derived(...)`.
@@ -819,11 +821,238 @@ pub(super) fn is_shadowed_by_for_loop_var(
     false
 }
 
+/// Compares an index answer against the backward scan it replaces, so agreement
+/// has a denominator instead of only a failure count. Off unless
+/// `RSVELTE_INDEX_ORACLE` is set.
+fn oracle_check(answer: bool, by_scan: impl FnOnce() -> bool) {
+    if super::super::profile::index_oracle_enabled() {
+        super::super::profile::record_index_oracle(answer == by_scan());
+    }
+}
+
 pub(super) fn is_shadowed_by_function_param(
+    index: &ScanIndex,
     chars: &[char],
     var_start: usize,
     var_name: &str,
 ) -> bool {
+    let answer = is_shadowed_by_function_param_indexed(index, chars, var_start, var_name);
+    oracle_check(answer, || {
+        is_shadowed_by_function_param_by_scan(chars, var_start, var_name)
+    });
+    answer
+}
+
+fn is_shadowed_by_function_param_indexed(
+    index: &ScanIndex,
+    chars: &[char],
+    var_start: usize,
+    var_name: &str,
+) -> bool {
+    let var_len = var_name.len();
+
+    // Concise arrow bodies: `(a, b) => expr` and `(a, b) => (expr)`.
+    if let Some(arrow) = enclosing_concise_arrow(index, chars, var_start)
+        && arrow_params_contain(index, chars, arrow, var_name, var_len)
+    {
+        return true;
+    }
+
+    // Enclosing block scopes, innermost first.
+    let mut brace = index.enclosing_brace(var_start);
+    while let Some(open) = brace {
+        brace = index.enclosing_brace(open);
+        // `${` opens a template interpolation, not a scope.
+        if open > 0 && chars[open - 1] == '$' {
+            continue;
+        }
+        if block_declares_param(index, chars, open, var_name, var_len) {
+            return true;
+        }
+    }
+
+    false
+}
+
+/// The `=>` of the arrow function whose *body* directly contains `var_start`, as
+/// the backward scan in [`is_shadowed_by_function_param_by_scan`] locates it:
+/// walk outwards through call parentheses, stopping at the first brace (any
+/// nesting), the first `=>` at the current parenthesis level, or a grouping `(`.
+fn enclosing_concise_arrow(index: &ScanIndex, chars: &[char], var_start: usize) -> Option<usize> {
+    let mut pos = var_start;
+    loop {
+        let brace = index.prev_brace(pos);
+        let arrow = index.prev_arrow(pos);
+        let open = index.enclosing_paren(pos);
+        // Whichever candidate sits closest to `pos` is the one a right-to-left
+        // scan reaches first.
+        let nearest = [brace, arrow, open].into_iter().flatten().max()?;
+
+        if Some(nearest) == brace {
+            return None;
+        }
+        if Some(nearest) == arrow {
+            return Some(nearest);
+        }
+
+        // A `(` at the current level: `=> (` is an arrow body in parentheses, a
+        // call/member `(` is skipped over, anything else ends the scan.
+        let mut before = nearest;
+        while before > 0 && chars[before - 1].is_whitespace() {
+            before -= 1;
+        }
+        if before >= 2 && chars[before - 1] == '>' && chars[before - 2] == '=' {
+            return Some(before - 1);
+        }
+        if before > 0 && (is_identifier_char(chars[before - 1]) || chars[before - 1] == ')') {
+            pos = nearest;
+            continue;
+        }
+        return None;
+    }
+}
+
+/// Whether the parameter list of the arrow whose `>` sits at `arrow` binds `var_name`.
+fn arrow_params_contain(
+    index: &ScanIndex,
+    chars: &[char],
+    arrow: usize,
+    var_name: &str,
+    var_len: usize,
+) -> bool {
+    let mut k = arrow - 1; // at '='
+    while k > 0 && chars[k - 1].is_whitespace() {
+        k -= 1;
+    }
+    if k > 0 && chars[k - 1] == ')' {
+        let close_idx = k - 1;
+        if let Some(open) = index.opener_of(close_idx) {
+            return param_list_binds(&chars[open + 1..close_idx], var_name, var_len);
+        }
+        return false;
+    }
+    if k > 0 && is_identifier_char(chars[k - 1]) {
+        // Single param arrow: `x => expr`
+        let end = k;
+        let mut start = k;
+        while start > 0 && is_identifier_char(chars[start - 1]) {
+            start -= 1;
+        }
+        let param: String = chars[start..end].iter().collect();
+        return param == var_name;
+    }
+    false
+}
+
+/// Whether `params` (the text between a parameter list's parentheses) contains
+/// `var_name` as a standalone identifier — `(_, count)`, `(count)`, `(count = d)`.
+fn param_list_binds(params: &[char], var_name: &str, var_len: usize) -> bool {
+    let mut k = 0;
+    while k < params.len() {
+        while k < params.len() && params[k].is_whitespace() {
+            k += 1;
+        }
+        if k + var_len <= params.len() {
+            let potential: String = params[k..k + var_len].iter().collect();
+            if potential == var_name {
+                let before_ok = k == 0 || !is_identifier_char(params[k - 1]);
+                let after_ok =
+                    k + var_len >= params.len() || !is_identifier_char(params[k + var_len]);
+                if before_ok && after_ok {
+                    return true;
+                }
+            }
+        }
+        k += 1;
+    }
+    false
+}
+
+/// Whether the block opening at `brace` is a function body binding `var_name`.
+fn block_declares_param(
+    index: &ScanIndex,
+    chars: &[char],
+    brace: usize,
+    var_name: &str,
+    var_len: usize,
+) -> bool {
+    // Skip whitespace before the {
+    let mut j = brace;
+    while j > 0 && chars[j - 1].is_whitespace() {
+        j -= 1;
+    }
+
+    // Arrow functions with a parenthesized object body: `(params) => ({…})`
+    if j > 0 && chars[j - 1] == '(' {
+        let mut k = j - 1;
+        while k > 0 && chars[k - 1].is_whitespace() {
+            k -= 1;
+        }
+        if k >= 2 && chars[k - 2] == '=' && chars[k - 1] == '>' {
+            j = k - 2;
+            while j > 0 && chars[j - 1].is_whitespace() {
+                j -= 1;
+            }
+        }
+    }
+
+    // Also skip `=>` for arrow functions: `(params) => {`
+    if j >= 2 && chars[j - 2] == '=' && chars[j - 1] == '>' {
+        j -= 2;
+        while j > 0 && chars[j - 1].is_whitespace() {
+            j -= 1;
+        }
+    }
+
+    // A `)` here would be the end of a parameter list.
+    if j == 0 || chars[j - 1] != ')' {
+        return false;
+    }
+    let close_paren_idx = j - 1;
+    let Some(open_idx) = index.opener_of(close_paren_idx) else {
+        return false;
+    };
+    if !param_list_binds(&chars[open_idx + 1..close_paren_idx], var_name, var_len) {
+        return false;
+    }
+
+    // The variable is in the parentheses — now confirm they are a parameter list
+    // and not a control-flow head.
+    let mut m = open_idx;
+    while m > 0 && chars[m - 1].is_whitespace() {
+        m -= 1;
+    }
+
+    for keyword in ["if", "while", "for", "switch", "with", "catch"] {
+        let kw_len = keyword.len();
+        if m >= kw_len {
+            let prefix: String = chars[m - kw_len..m].iter().collect();
+            if prefix == keyword && (m == kw_len || !is_identifier_char(chars[m - kw_len - 1])) {
+                return false;
+            }
+        }
+    }
+
+    if m > 0 {
+        if m >= 8 {
+            let prefix: String = chars[m - 8..m].iter().collect();
+            if prefix == "function" {
+                return true;
+            }
+        }
+        // A method definition like `update(count) {`.
+        if is_identifier_char(chars[m - 1]) {
+            return true;
+        }
+    }
+
+    // Bare `(…)` is only a function when an `=>` separates it from the block;
+    // otherwise it is grouping.
+    let between: String = chars[close_paren_idx + 1..brace].iter().collect();
+    between.trim().starts_with("=>")
+}
+
+fn is_shadowed_by_function_param_by_scan(chars: &[char], var_start: usize, var_name: &str) -> bool {
     // Strategy: scan backwards from var_start to find the nearest enclosing function scope.
     // If we find a function with this variable as a parameter, it's shadowed.
     // We need to track brace depth to understand scope nesting.
@@ -1141,6 +1370,7 @@ pub(super) fn is_shadowed_by_function_param(
 /// The variable should NOT be wrapped with $.get() if it's a shorthand property name,
 /// because `{ $.get(foo) }` is invalid JavaScript.
 pub(super) fn is_shorthand_object_property(
+    index: &ScanIndex,
     chars: &[char],
     var_start: usize,
     var_len: usize,
@@ -1165,7 +1395,7 @@ pub(super) fn is_shorthand_object_property(
 
     // Now we need to verify this is inside an object literal
     // by checking what's before the variable.
-    is_object_literal_property_position(chars, var_start)
+    is_object_literal_property_position(index, chars, var_start)
 }
 
 /// Check if a variable at the given position is the KEY of an explicit
@@ -1178,7 +1408,12 @@ pub(super) fn is_shorthand_object_property(
 /// object-literal-context check is shared via
 /// [`is_object_literal_property_position`], which also excludes ternary
 /// `cond ? a : b` (there `a` is not preceded by `{`/`,`).
-pub(super) fn is_explicit_property_key(chars: &[char], var_start: usize, var_len: usize) -> bool {
+pub(super) fn is_explicit_property_key(
+    index: &ScanIndex,
+    chars: &[char],
+    var_start: usize,
+    var_len: usize,
+) -> bool {
     let var_end = var_start + var_len;
 
     // Skip whitespace after the variable.
@@ -1197,13 +1432,70 @@ pub(super) fn is_explicit_property_key(chars: &[char], var_start: usize, var_len
         return false;
     }
 
-    is_object_literal_property_position(chars, var_start)
+    is_object_literal_property_position(index, chars, var_start)
 }
 
 /// Shared backward heuristic: returns true when the identifier at `var_start`
 /// sits in object-literal property position — preceded (ignoring whitespace)
 /// by `{` or `,` inside an object literal (not a block statement or array).
-fn is_object_literal_property_position(chars: &[char], var_start: usize) -> bool {
+fn is_object_literal_property_position(
+    index: &ScanIndex,
+    chars: &[char],
+    var_start: usize,
+) -> bool {
+    let mut j = var_start;
+    while j > 0 && chars[j - 1].is_whitespace() {
+        j -= 1;
+    }
+    if j == 0 {
+        return false;
+    }
+
+    let answer = match chars[j - 1] {
+        '{' => {
+            let mut m = j - 1;
+            while m > 0 && chars[m - 1].is_whitespace() {
+                m -= 1;
+            }
+            if m == 0 {
+                // `{` at the very start of the expression: an object literal (say
+                // inside `$derived()` arguments) or a block statement such as
+                // `$: { tasks, tasks_touched++; }`. Only the latter has a
+                // semicolon at the group's own depth.
+                !index.leading_brace_has_semicolon()
+            } else {
+                let before = chars[m - 1];
+                // `n` is the tail of `return`, spelled out just below.
+                matches!(
+                    before,
+                    '=' | ':' | '(' | '[' | ',' | '?' | '|' | '&' | '!' | 'n'
+                ) || (m >= 6 && chars[m - 6..m].iter().collect::<String>() == "return")
+            }
+        }
+        ',' => {
+            // Object or array element? Whichever enclosing bracket sits closest
+            // decides; each bracket kind is matched independently, as the scan
+            // this replaces counted them.
+            let at = j - 1;
+            let brace = index.enclosing_brace(at);
+            let bracket = index.enclosing_bracket(at);
+            let paren = index.enclosing_paren(at);
+            [brace, bracket, paren]
+                .into_iter()
+                .flatten()
+                .max()
+                .is_some_and(|nearest| Some(nearest) == brace)
+        }
+        _ => false,
+    };
+
+    oracle_check(answer, || {
+        is_object_literal_property_position_by_scan(chars, var_start)
+    });
+    answer
+}
+
+fn is_object_literal_property_position_by_scan(chars: &[char], var_start: usize) -> bool {
     let mut j = var_start;
     // Skip whitespace before the variable
     while j > 0 && chars[j - 1].is_whitespace() {

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
@@ -41,6 +41,7 @@ mod reactive_update_ast;
 mod read_only_props_ast;
 mod rest_prop_member_access_ast;
 mod rune_transforms;
+mod scan_index;
 mod scope_analysis;
 mod state_assigns_combined_ast;
 mod state_call_ast;

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/props_transforms.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/props_transforms.rs
@@ -8,7 +8,7 @@ use crate::compiler::phases::phase2_analyze::ComponentAnalysis;
 use crate::compiler::phases::phase2_analyze::scope::BindingKind;
 use crate::compiler::phases::phase3_transform::shared::js_scan::skip_opaque;
 
-use super::scan_index::ScanIndex;
+use super::scan_index::{ScanIndex, ScanIndexBuilder};
 use super::{
     extract_destructured_prop_names, find_matching_paren, get_or_compile_regex,
     is_explicit_property_key, is_inside_string_literal, is_shadowed_by_function_param,
@@ -188,13 +188,22 @@ pub(super) fn transform_prop_reads_in_expr(expr: &str, prop_vars: &[String]) -> 
         // Match the identifier and check the context manually
 
         let mut new_result = String::with_capacity(result.len() * 2);
-        let chars: Vec<char> = result.chars().collect();
-        // Resolving char index → byte offset with `char_indices().nth(i)` inside the
-        // per-character loop below is quadratic in the expression length.
-        let char_offsets: Vec<usize> = result.char_indices().map(|(b, _)| b).collect();
-        // Same reason: the identifier guards below each used to answer "what
-        // encloses this position?" with their own backward scan, once per match.
-        let index = ScanIndex::new(&chars);
+        // One walk feeds all three: the char vector the loop indexes, the byte
+        // offsets (resolving those with `char_indices().nth(i)` inside the
+        // per-character loop below was quadratic in the expression length), and
+        // the index the identifier guards consult instead of each running their
+        // own backward scan once per match.
+        let mut chars: Vec<char> = Vec::with_capacity(result.len());
+        let mut char_offsets: Vec<usize> = Vec::with_capacity(result.len());
+        let mut builder = ScanIndexBuilder::new();
+        let mut prev = None;
+        for (offset, c) in result.char_indices() {
+            char_offsets.push(offset);
+            builder.feed(chars.len(), c, prev);
+            chars.push(c);
+            prev = Some(c);
+        }
+        let index = builder.finish(&chars);
         #[cfg(feature = "measure-prop-reads")]
         crate::measure_prop_reads::record_pass(chars.len());
         let mut i = 0;

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/props_transforms.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/props_transforms.rs
@@ -8,6 +8,7 @@ use crate::compiler::phases::phase2_analyze::ComponentAnalysis;
 use crate::compiler::phases::phase2_analyze::scope::BindingKind;
 use crate::compiler::phases::phase3_transform::shared::js_scan::skip_opaque;
 
+use super::scan_index::ScanIndex;
 use super::{
     extract_destructured_prop_names, find_matching_paren, get_or_compile_regex,
     is_explicit_property_key, is_inside_string_literal, is_shadowed_by_function_param,
@@ -19,7 +20,72 @@ use super::{
 /// …`. Such positions declare a new local that shadows a like-named prop and
 /// must not be wrapped as a prop read. Mirrors the `in_param_position` guard the
 /// AST version (`prop_source_reads_ast`) applies.
-fn is_arrow_param_binding(chars: &[char], var_start: usize, var_len: usize) -> bool {
+fn is_arrow_param_binding(
+    index: &ScanIndex,
+    chars: &[char],
+    var_start: usize,
+    var_len: usize,
+) -> bool {
+    let answer = is_arrow_param_binding_indexed(index, chars, var_start, var_len);
+    if super::super::profile::index_oracle_enabled() {
+        super::super::profile::record_index_oracle(
+            answer == is_arrow_param_binding_by_scan(chars, var_start, var_len),
+        );
+    }
+    answer
+}
+
+fn is_arrow_param_binding_indexed(
+    index: &ScanIndex,
+    chars: &[char],
+    var_start: usize,
+    var_len: usize,
+) -> bool {
+    let after = var_start + var_len;
+
+    // `name => …`  (single param, no parens)
+    {
+        let mut k = after;
+        while k < chars.len() && chars[k].is_whitespace() {
+            k += 1;
+        }
+        if k + 1 < chars.len() && chars[k] == '=' && chars[k + 1] == '>' {
+            return true;
+        }
+    }
+
+    // `( … name … ) => …`. A `;` at the same nesting level rules out a parameter
+    // list, and the enclosing bracket has to be a `(` rather than an array or
+    // object literal.
+    if index.prev_semicolon(var_start).is_some() {
+        return false;
+    }
+    let Some(open) = index.enclosing_any(var_start).filter(|&o| chars[o] == '(') else {
+        return false;
+    };
+
+    // Must be at a parameter *name* position (preceded by `(` or `,`), not a
+    // default-value expression like `(a = prop) =>` where `prop` is a read.
+    let mut p = var_start;
+    while p > 0 && chars[p - 1].is_whitespace() {
+        p -= 1;
+    }
+    if !(p == 0 || chars[p - 1] == '(' || chars[p - 1] == ',') {
+        return false;
+    }
+
+    // matching `)` then `=>`
+    let Some(close) = index.closer_of(open).filter(|&c| chars[c] == ')') else {
+        return false;
+    };
+    let mut k = close + 1;
+    while k < chars.len() && chars[k].is_whitespace() {
+        k += 1;
+    }
+    k + 1 < chars.len() && chars[k] == '=' && chars[k + 1] == '>'
+}
+
+fn is_arrow_param_binding_by_scan(chars: &[char], var_start: usize, var_len: usize) -> bool {
     let after = var_start + var_len;
 
     // `name => …`  (single param, no parens)
@@ -126,6 +192,9 @@ pub(super) fn transform_prop_reads_in_expr(expr: &str, prop_vars: &[String]) -> 
         // Resolving char index → byte offset with `char_indices().nth(i)` inside the
         // per-character loop below is quadratic in the expression length.
         let char_offsets: Vec<usize> = result.char_indices().map(|(b, _)| b).collect();
+        // Same reason: the identifier guards below each used to answer "what
+        // encloses this position?" with their own backward scan, once per match.
+        let index = ScanIndex::new(&chars);
         #[cfg(feature = "measure-prop-reads")]
         crate::measure_prop_reads::record_pass(chars.len());
         let mut i = 0;
@@ -284,35 +353,41 @@ pub(super) fn transform_prop_reads_in_expr(expr: &str, prop_vars: &[String]) -> 
                     }
                 };
 
-                // Check if this identifier is shadowed by a function parameter
-                let is_shadowed = is_shadowed_by_function_param(&chars, i, prop_name);
-
-                // Check if this identifier is an explicit object-literal property
-                // KEY (`{ foo: bar }`). A key is not a value read and must not be
-                // wrapped — `{ foo(): bar }` is invalid JS. (Shorthand `{ foo }`
-                // is handled below by expanding to `{ foo: foo() }`.)
-                let is_property_key = is_explicit_property_key(&chars, i, prop_name.len());
-
-                // Check if this identifier is the BINDING in an arrow-function
-                // parameter list (`name =>`, `(a, name) =>`). That declares a new
-                // local shadowing the prop and must not be wrapped as a read —
-                // `(name()) =>` is invalid syntax.
-                let is_arrow_param = is_arrow_param_binding(&chars, i, prop_name.len());
+                // The remaining guards are the expensive ones, so they sit behind
+                // the cheap character checks rather than beside them:
+                // - shadowed by a function parameter;
+                // - an explicit object-literal property KEY (`{ foo: bar }`),
+                //   which is not a value read — `{ foo(): bar }` is invalid JS
+                //   (shorthand `{ foo }` is expanded to `{ foo: foo() }` below);
+                // - the BINDING in an arrow-function parameter list (`name =>`,
+                //   `(a, name) =>`), which declares a new local shadowing the
+                //   prop — `(name()) =>` is invalid syntax.
+                // Under the oracle every guard is asked at every candidate
+                // position, not only where the cheap checks let the question
+                // through, so the comparison covers the guards themselves rather
+                // than the subset of call sites that survive short-circuiting.
+                if super::super::profile::index_oracle_enabled() {
+                    is_shadowed_by_function_param(&index, &chars, i, prop_name);
+                    is_explicit_property_key(&index, &chars, i, prop_name.len());
+                    is_arrow_param_binding(&index, &chars, i, prop_name.len());
+                    is_shorthand_object_property(&index, &chars, i, prop_name.len());
+                }
 
                 if before_ok
                     && after_ok
                     && !is_update_target
                     && !is_assignment_target
                     && !is_inside_update_call
-                    && !is_shadowed
                     && !is_sole_derived_arg
-                    && !is_property_key
-                    && !is_arrow_param
+                    && !is_shadowed_by_function_param(&index, &chars, i, prop_name)
+                    && !is_explicit_property_key(&index, &chars, i, prop_name.len())
+                    && !is_arrow_param_binding(&index, &chars, i, prop_name.len())
                 {
                     // Check if this is a shorthand property in an object literal.
                     // e.g., `{ value }` should become `{ value: value() }` not `{ value() }`
                     // because `{ value() }` is a method definition, not a property.
-                    let is_shorthand = is_shorthand_object_property(&chars, i, prop_name.len());
+                    let is_shorthand =
+                        is_shorthand_object_property(&index, &chars, i, prop_name.len());
 
                     if is_shorthand {
                         // Expand shorthand: { foo } -> { foo: foo() }

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/scan_index.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/scan_index.rs
@@ -1,0 +1,209 @@
+//! One-pass bracket/token index over the `Vec<char>` the identifier rewriters walk.
+//!
+//! The rewriters ask the same handful of "what encloses this position?" questions
+//! once per *matched identifier*, and each question used to be answered by a
+//! backward scan that could run to the start of the expression — O(n) work fired
+//! O(n) times. Building this index costs one forward pass per rewrite pass, the
+//! same order as materializing the `Vec<char>` itself, and answers each question
+//! in O(1) (or O(nesting depth) for the enclosing-scope chains).
+//!
+//! The scans this replaces track their own depth counters, and those counters
+//! clamp at zero rather than going negative. That is exactly a forward stack that
+//! pops only when non-empty, which is how the stacks below are maintained — so
+//! the answers agree even on unbalanced text. `RSVELTE_INDEX_ORACLE` runs both
+//! routes and compares them.
+
+/// Sentinel for "no such position"; `u32::MAX` cannot be a real index because the
+/// rewriters only run on expression text far below 4 GiB.
+const NONE: u32 = u32::MAX;
+
+pub(super) struct ScanIndex {
+    /// Innermost enclosing `{`, pairing braces only.
+    encl_brace: Vec<u32>,
+    /// Innermost enclosing `[`, pairing square brackets only.
+    encl_bracket: Vec<u32>,
+    /// Innermost enclosing `(`, pairing parentheses only.
+    encl_paren: Vec<u32>,
+    /// Innermost enclosing `(`/`[`/`{` when any closer pops any opener, which is
+    /// how the arrow-parameter scan counts depth.
+    encl_any: Vec<u32>,
+    /// For each opening bracket, the closer that popped it under that same
+    /// type-agnostic pairing.
+    close_any: Vec<u32>,
+    /// For each `)`, its matching `(` under parenthesis-only pairing.
+    open_paren: Vec<u32>,
+    /// Nearest `{` or `}` before each position, at any nesting.
+    prev_brace_any: Vec<u32>,
+    /// Nearest `=>` (index of the `>`) before each position at the same
+    /// parenthesis nesting level.
+    prev_arrow: Vec<u32>,
+    /// Nearest `;` before each position at the same type-agnostic nesting level.
+    prev_semi: Vec<u32>,
+    /// When the first non-whitespace character is `{`, whether that group holds a
+    /// `;` at its own depth — the object-literal-vs-block-statement test.
+    leading_brace_has_semicolon: Option<bool>,
+}
+
+impl ScanIndex {
+    pub(super) fn new(chars: &[char]) -> Self {
+        let n = chars.len();
+        let mut encl_brace = vec![NONE; n + 1];
+        let mut encl_bracket = vec![NONE; n + 1];
+        let mut encl_paren = vec![NONE; n + 1];
+        let mut encl_any = vec![NONE; n + 1];
+        let mut close_any = vec![NONE; n];
+        let mut open_paren = vec![NONE; n];
+        let mut prev_brace_any = vec![NONE; n + 1];
+        let mut prev_arrow = vec![NONE; n + 1];
+        let mut prev_semi = vec![NONE; n + 1];
+
+        let mut brace_stack: Vec<u32> = Vec::new();
+        let mut bracket_stack: Vec<u32> = Vec::new();
+        // Each parenthesis frame restores the enclosing level's last `=>`, and
+        // each type-agnostic frame restores its last `;`, on close.
+        let mut paren_stack: Vec<(u32, u32)> = Vec::new();
+        let mut any_stack: Vec<(u32, u32)> = Vec::new();
+        let mut cur_arrow = NONE;
+        let mut cur_semi = NONE;
+        let mut cur_brace = NONE;
+
+        for i in 0..n {
+            encl_brace[i] = brace_stack.last().copied().unwrap_or(NONE);
+            encl_bracket[i] = bracket_stack.last().copied().unwrap_or(NONE);
+            encl_paren[i] = paren_stack.last().map_or(NONE, |&(p, _)| p);
+            encl_any[i] = any_stack.last().map_or(NONE, |&(p, _)| p);
+            prev_brace_any[i] = cur_brace;
+            prev_arrow[i] = cur_arrow;
+            prev_semi[i] = cur_semi;
+
+            let pos = i as u32;
+            match chars[i] {
+                '{' => {
+                    brace_stack.push(pos);
+                    any_stack.push((pos, cur_semi));
+                    cur_semi = NONE;
+                    cur_brace = pos;
+                }
+                '[' => {
+                    bracket_stack.push(pos);
+                    any_stack.push((pos, cur_semi));
+                    cur_semi = NONE;
+                }
+                '(' => {
+                    paren_stack.push((pos, cur_arrow));
+                    cur_arrow = NONE;
+                    any_stack.push((pos, cur_semi));
+                    cur_semi = NONE;
+                }
+                '}' | ']' | ')' => {
+                    if chars[i] == '}' {
+                        brace_stack.pop();
+                        cur_brace = pos;
+                    } else if chars[i] == ']' {
+                        bracket_stack.pop();
+                    } else if let Some((open, saved)) = paren_stack.pop() {
+                        open_paren[i] = open;
+                        cur_arrow = saved;
+                    }
+                    if let Some((open, saved)) = any_stack.pop() {
+                        close_any[open as usize] = pos;
+                        cur_semi = saved;
+                    }
+                }
+                ';' => cur_semi = pos,
+                '>' if i > 0 && chars[i - 1] == '=' => cur_arrow = pos,
+                _ => {}
+            }
+        }
+        encl_brace[n] = brace_stack.last().copied().unwrap_or(NONE);
+        encl_bracket[n] = bracket_stack.last().copied().unwrap_or(NONE);
+        encl_paren[n] = paren_stack.last().map_or(NONE, |&(p, _)| p);
+        encl_any[n] = any_stack.last().map_or(NONE, |&(p, _)| p);
+        prev_brace_any[n] = cur_brace;
+        prev_arrow[n] = cur_arrow;
+        prev_semi[n] = cur_semi;
+
+        Self {
+            encl_brace,
+            encl_bracket,
+            encl_paren,
+            encl_any,
+            close_any,
+            open_paren,
+            prev_brace_any,
+            prev_arrow,
+            prev_semi,
+            leading_brace_has_semicolon: leading_brace_has_semicolon(chars),
+        }
+    }
+
+    /// Innermost `{` still open before `pos`. Passing a `{`'s own index walks one
+    /// step outwards, so the enclosing-scope chain is a loop over this.
+    pub(super) fn enclosing_brace(&self, pos: usize) -> Option<usize> {
+        unwrap_idx(self.encl_brace[pos])
+    }
+
+    pub(super) fn enclosing_bracket(&self, pos: usize) -> Option<usize> {
+        unwrap_idx(self.encl_bracket[pos])
+    }
+
+    pub(super) fn enclosing_paren(&self, pos: usize) -> Option<usize> {
+        unwrap_idx(self.encl_paren[pos])
+    }
+
+    pub(super) fn enclosing_any(&self, pos: usize) -> Option<usize> {
+        unwrap_idx(self.encl_any[pos])
+    }
+
+    /// The closer that ends the bracket group opened at `open`.
+    pub(super) fn closer_of(&self, open: usize) -> Option<usize> {
+        unwrap_idx(self.close_any[open])
+    }
+
+    /// The `(` matching the `)` at `close`.
+    pub(super) fn opener_of(&self, close: usize) -> Option<usize> {
+        unwrap_idx(self.open_paren[close])
+    }
+
+    pub(super) fn prev_brace(&self, pos: usize) -> Option<usize> {
+        unwrap_idx(self.prev_brace_any[pos])
+    }
+
+    pub(super) fn prev_arrow(&self, pos: usize) -> Option<usize> {
+        unwrap_idx(self.prev_arrow[pos])
+    }
+
+    pub(super) fn prev_semicolon(&self, pos: usize) -> Option<usize> {
+        unwrap_idx(self.prev_semi[pos])
+    }
+
+    pub(super) fn leading_brace_has_semicolon(&self) -> bool {
+        self.leading_brace_has_semicolon.unwrap_or(false)
+    }
+}
+
+fn unwrap_idx(raw: u32) -> Option<usize> {
+    (raw != NONE).then_some(raw as usize)
+}
+
+fn leading_brace_has_semicolon(chars: &[char]) -> Option<bool> {
+    let first = chars.iter().position(|c| !c.is_whitespace())?;
+    if chars[first] != '{' {
+        return None;
+    }
+    let mut depth = 0i32;
+    for &ch in &chars[first..] {
+        match ch {
+            '{' => depth += 1,
+            '}' => {
+                depth -= 1;
+                if depth == 0 {
+                    break;
+                }
+            }
+            ';' if depth == 1 => return Some(true),
+            _ => {}
+        }
+    }
+    Some(false)
+}

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/scan_index.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/scan_index.rs
@@ -3,9 +3,12 @@
 //! The rewriters ask the same handful of "what encloses this position?" questions
 //! once per *matched identifier*, and each question used to be answered by a
 //! backward scan that could run to the start of the expression — O(n) work fired
-//! O(n) times. Building this index costs one forward pass per rewrite pass, the
-//! same order as materializing the `Vec<char>` itself, and answers each question
-//! in O(1) (or O(nesting depth) for the enclosing-scope chains).
+//! O(n) times. This index is built in one forward pass per rewrite pass and
+//! answers each question in O(log m), where m counts only the characters that can
+//! change an answer (`{}[]();` and `=>`). Storing a row per *character* instead
+//! would be simpler but costs more to build than the scans it replaces: real
+//! expressions are a few percent brackets, and the rewriter runs the pass once
+//! per prop var.
 //!
 //! The scans this replaces track their own depth counters, and those counters
 //! clamp at zero rather than going negative. That is exactly a forward stack that
@@ -17,164 +20,229 @@
 /// rewriters only run on expression text far below 4 GiB.
 const NONE: u32 = u32::MAX;
 
-pub(super) struct ScanIndex {
+/// Nesting state after the event character at `at` has been processed. A query
+/// for position `p` reads the last row with `at < p`.
+#[derive(Clone, Copy)]
+struct Row {
+    at: u32,
     /// Innermost enclosing `{`, pairing braces only.
-    encl_brace: Vec<u32>,
+    encl_brace: u32,
     /// Innermost enclosing `[`, pairing square brackets only.
-    encl_bracket: Vec<u32>,
+    encl_bracket: u32,
     /// Innermost enclosing `(`, pairing parentheses only.
-    encl_paren: Vec<u32>,
+    encl_paren: u32,
     /// Innermost enclosing `(`/`[`/`{` when any closer pops any opener, which is
     /// how the arrow-parameter scan counts depth.
-    encl_any: Vec<u32>,
-    /// For each opening bracket, the closer that popped it under that same
-    /// type-agnostic pairing.
-    close_any: Vec<u32>,
-    /// For each `)`, its matching `(` under parenthesis-only pairing.
-    open_paren: Vec<u32>,
-    /// Nearest `{` or `}` before each position, at any nesting.
-    prev_brace_any: Vec<u32>,
-    /// Nearest `=>` (index of the `>`) before each position at the same
-    /// parenthesis nesting level.
-    prev_arrow: Vec<u32>,
-    /// Nearest `;` before each position at the same type-agnostic nesting level.
-    prev_semi: Vec<u32>,
+    encl_any: u32,
+    /// Nearest `{` or `}`, at any nesting.
+    prev_brace: u32,
+    /// Nearest `=>` (index of the `>`) at the same parenthesis nesting level.
+    prev_arrow: u32,
+    /// Nearest `;` at the same type-agnostic nesting level.
+    prev_semi: u32,
+    /// For an opening bracket, the closer that popped it under type-agnostic
+    /// pairing; for a `)`, its matching `(` under parenthesis-only pairing.
+    partner: u32,
+}
+
+const EMPTY: Row = Row {
+    at: 0,
+    encl_brace: NONE,
+    encl_bracket: NONE,
+    encl_paren: NONE,
+    encl_any: NONE,
+    prev_brace: NONE,
+    prev_arrow: NONE,
+    prev_semi: NONE,
+    partner: NONE,
+};
+
+pub(super) struct ScanIndex {
+    rows: Vec<Row>,
     /// When the first non-whitespace character is `{`, whether that group holds a
     /// `;` at its own depth — the object-literal-vs-block-statement test.
     leading_brace_has_semicolon: Option<bool>,
 }
 
-impl ScanIndex {
-    pub(super) fn new(chars: &[char]) -> Self {
-        let n = chars.len();
-        let mut encl_brace = vec![NONE; n + 1];
-        let mut encl_bracket = vec![NONE; n + 1];
-        let mut encl_paren = vec![NONE; n + 1];
-        let mut encl_any = vec![NONE; n + 1];
-        let mut close_any = vec![NONE; n];
-        let mut open_paren = vec![NONE; n];
-        let mut prev_brace_any = vec![NONE; n + 1];
-        let mut prev_arrow = vec![NONE; n + 1];
-        let mut prev_semi = vec![NONE; n + 1];
+/// Accumulates the index while the caller walks the text, so the rewriter can
+/// build its `Vec<char>`, its byte offsets and this index in one pass instead of
+/// three. An index built in a pass of its own costs more than the scans it
+/// replaces on the small expressions that dominate real components.
+pub(super) struct ScanIndexBuilder {
+    rows: Vec<Row>,
+    // Each frame carries the row index of its opener so the partner link can be
+    // filled in on close, plus the enclosing level's `=>` / `;` to restore.
+    brace_stack: Vec<u32>,
+    bracket_stack: Vec<u32>,
+    paren_stack: Vec<(u32, u32)>,
+    any_stack: Vec<(u32, usize, u32)>,
+    state: Row,
+}
 
-        let mut brace_stack: Vec<u32> = Vec::new();
-        let mut bracket_stack: Vec<u32> = Vec::new();
-        // Each parenthesis frame restores the enclosing level's last `=>`, and
-        // each type-agnostic frame restores its last `;`, on close.
-        let mut paren_stack: Vec<(u32, u32)> = Vec::new();
-        let mut any_stack: Vec<(u32, u32)> = Vec::new();
-        let mut cur_arrow = NONE;
-        let mut cur_semi = NONE;
-        let mut cur_brace = NONE;
+impl ScanIndexBuilder {
+    pub(super) fn new() -> Self {
+        Self {
+            rows: Vec::new(),
+            brace_stack: Vec::new(),
+            bracket_stack: Vec::new(),
+            paren_stack: Vec::new(),
+            any_stack: Vec::new(),
+            state: EMPTY,
+        }
+    }
 
-        for i in 0..n {
-            encl_brace[i] = brace_stack.last().copied().unwrap_or(NONE);
-            encl_bracket[i] = bracket_stack.last().copied().unwrap_or(NONE);
-            encl_paren[i] = paren_stack.last().map_or(NONE, |&(p, _)| p);
-            encl_any[i] = any_stack.last().map_or(NONE, |&(p, _)| p);
-            prev_brace_any[i] = cur_brace;
-            prev_arrow[i] = cur_arrow;
-            prev_semi[i] = cur_semi;
-
+    /// Feeds the character at `i`, whose predecessor is `prev`.
+    pub(super) fn feed(&mut self, i: usize, c: char, prev: Option<char>) {
+        let Self {
+            rows,
+            brace_stack,
+            bracket_stack,
+            paren_stack,
+            any_stack,
+            state,
+        } = self;
+        {
             let pos = i as u32;
-            match chars[i] {
-                '{' => {
-                    brace_stack.push(pos);
-                    any_stack.push((pos, cur_semi));
-                    cur_semi = NONE;
-                    cur_brace = pos;
-                }
-                '[' => {
-                    bracket_stack.push(pos);
-                    any_stack.push((pos, cur_semi));
-                    cur_semi = NONE;
-                }
-                '(' => {
-                    paren_stack.push((pos, cur_arrow));
-                    cur_arrow = NONE;
-                    any_stack.push((pos, cur_semi));
-                    cur_semi = NONE;
+            let mut partner = NONE;
+            match c {
+                '{' | '[' | '(' => {
+                    any_stack.push((pos, rows.len(), state.prev_semi));
+                    state.prev_semi = NONE;
+                    state.encl_any = pos;
+                    match c {
+                        '{' => {
+                            brace_stack.push(pos);
+                            state.encl_brace = pos;
+                            state.prev_brace = pos;
+                        }
+                        '[' => {
+                            bracket_stack.push(pos);
+                            state.encl_bracket = pos;
+                        }
+                        _ => {
+                            paren_stack.push((pos, state.prev_arrow));
+                            state.prev_arrow = NONE;
+                            state.encl_paren = pos;
+                        }
+                    }
                 }
                 '}' | ']' | ')' => {
-                    if chars[i] == '}' {
-                        brace_stack.pop();
-                        cur_brace = pos;
-                    } else if chars[i] == ']' {
-                        bracket_stack.pop();
-                    } else if let Some((open, saved)) = paren_stack.pop() {
-                        open_paren[i] = open;
-                        cur_arrow = saved;
+                    if let Some((_, row, saved_semi)) = any_stack.pop() {
+                        rows[row].partner = pos;
+                        state.prev_semi = saved_semi;
                     }
-                    if let Some((open, saved)) = any_stack.pop() {
-                        close_any[open as usize] = pos;
-                        cur_semi = saved;
+                    state.encl_any = any_stack.last().map_or(NONE, |&(p, ..)| p);
+                    match c {
+                        '}' => {
+                            brace_stack.pop();
+                            state.encl_brace = brace_stack.last().copied().unwrap_or(NONE);
+                            state.prev_brace = pos;
+                        }
+                        ']' => {
+                            bracket_stack.pop();
+                            state.encl_bracket = bracket_stack.last().copied().unwrap_or(NONE);
+                        }
+                        _ => {
+                            if let Some((open, saved_arrow)) = paren_stack.pop() {
+                                partner = open;
+                                state.prev_arrow = saved_arrow;
+                            }
+                            state.encl_paren = paren_stack.last().map_or(NONE, |&(p, _)| p);
+                        }
                     }
                 }
-                ';' => cur_semi = pos,
-                '>' if i > 0 && chars[i - 1] == '=' => cur_arrow = pos,
-                _ => {}
+                ';' => state.prev_semi = pos,
+                '>' if prev == Some('=') => state.prev_arrow = pos,
+                _ => return,
             }
+            rows.push(Row {
+                at: pos,
+                partner,
+                ..*state
+            });
         }
-        encl_brace[n] = brace_stack.last().copied().unwrap_or(NONE);
-        encl_bracket[n] = bracket_stack.last().copied().unwrap_or(NONE);
-        encl_paren[n] = paren_stack.last().map_or(NONE, |&(p, _)| p);
-        encl_any[n] = any_stack.last().map_or(NONE, |&(p, _)| p);
-        prev_brace_any[n] = cur_brace;
-        prev_arrow[n] = cur_arrow;
-        prev_semi[n] = cur_semi;
+    }
 
-        Self {
-            encl_brace,
-            encl_bracket,
-            encl_paren,
-            encl_any,
-            close_any,
-            open_paren,
-            prev_brace_any,
-            prev_arrow,
-            prev_semi,
-            leading_brace_has_semicolon: leading_brace_has_semicolon(chars),
+    pub(super) fn finish(self, chars: &[char]) -> ScanIndex {
+        let rows = self.rows;
+        let leading_brace_has_semicolon = leading_brace(chars).map(|open| {
+            // The block-statement test: a `;` directly inside the leading group,
+            // i.e. one whose enclosing brace is that group rather than a nested one.
+            rows.iter()
+                .any(|r| chars[r.at as usize] == ';' && r.encl_brace as usize == open)
+        });
+        ScanIndex {
+            rows,
+            leading_brace_has_semicolon,
         }
+    }
+}
+
+impl ScanIndex {
+    pub(super) fn new(chars: &[char]) -> Self {
+        let mut builder = ScanIndexBuilder::new();
+        let mut prev = None;
+        for (i, &c) in chars.iter().enumerate() {
+            builder.feed(i, c, prev);
+            prev = Some(c);
+        }
+        builder.finish(chars)
+    }
+
+    /// Nesting state for a query at `pos`, i.e. considering only `chars[..pos]`.
+    fn state_at(&self, pos: usize) -> &Row {
+        let idx = self.rows.partition_point(|r| (r.at as usize) < pos);
+        if idx == 0 {
+            &EMPTY
+        } else {
+            &self.rows[idx - 1]
+        }
+    }
+
+    /// The row for the event character at `pos`, if `pos` holds one.
+    fn row_at(&self, pos: usize) -> Option<&Row> {
+        let idx = self.rows.partition_point(|r| (r.at as usize) < pos);
+        self.rows.get(idx).filter(|r| r.at as usize == pos)
     }
 
     /// Innermost `{` still open before `pos`. Passing a `{`'s own index walks one
     /// step outwards, so the enclosing-scope chain is a loop over this.
     pub(super) fn enclosing_brace(&self, pos: usize) -> Option<usize> {
-        unwrap_idx(self.encl_brace[pos])
+        unwrap_idx(self.state_at(pos).encl_brace)
     }
 
     pub(super) fn enclosing_bracket(&self, pos: usize) -> Option<usize> {
-        unwrap_idx(self.encl_bracket[pos])
+        unwrap_idx(self.state_at(pos).encl_bracket)
     }
 
     pub(super) fn enclosing_paren(&self, pos: usize) -> Option<usize> {
-        unwrap_idx(self.encl_paren[pos])
+        unwrap_idx(self.state_at(pos).encl_paren)
     }
 
     pub(super) fn enclosing_any(&self, pos: usize) -> Option<usize> {
-        unwrap_idx(self.encl_any[pos])
+        unwrap_idx(self.state_at(pos).encl_any)
     }
 
     /// The closer that ends the bracket group opened at `open`.
     pub(super) fn closer_of(&self, open: usize) -> Option<usize> {
-        unwrap_idx(self.close_any[open])
+        self.row_at(open).and_then(|r| unwrap_idx(r.partner))
     }
 
     /// The `(` matching the `)` at `close`.
     pub(super) fn opener_of(&self, close: usize) -> Option<usize> {
-        unwrap_idx(self.open_paren[close])
+        self.row_at(close).and_then(|r| unwrap_idx(r.partner))
     }
 
     pub(super) fn prev_brace(&self, pos: usize) -> Option<usize> {
-        unwrap_idx(self.prev_brace_any[pos])
+        unwrap_idx(self.state_at(pos).prev_brace)
     }
 
     pub(super) fn prev_arrow(&self, pos: usize) -> Option<usize> {
-        unwrap_idx(self.prev_arrow[pos])
+        unwrap_idx(self.state_at(pos).prev_arrow)
     }
 
     pub(super) fn prev_semicolon(&self, pos: usize) -> Option<usize> {
-        unwrap_idx(self.prev_semi[pos])
+        unwrap_idx(self.state_at(pos).prev_semi)
     }
 
     pub(super) fn leading_brace_has_semicolon(&self) -> bool {
@@ -186,24 +254,8 @@ fn unwrap_idx(raw: u32) -> Option<usize> {
     (raw != NONE).then_some(raw as usize)
 }
 
-fn leading_brace_has_semicolon(chars: &[char]) -> Option<bool> {
+/// Position of the leading `{`, when the first non-whitespace character is one.
+fn leading_brace(chars: &[char]) -> Option<usize> {
     let first = chars.iter().position(|c| !c.is_whitespace())?;
-    if chars[first] != '{' {
-        return None;
-    }
-    let mut depth = 0i32;
-    for &ch in &chars[first..] {
-        match ch {
-            '{' => depth += 1,
-            '}' => {
-                depth -= 1;
-                if depth == 0 {
-                    break;
-                }
-            }
-            ';' if depth == 1 => return Some(true),
-            _ => {}
-        }
-    }
-    Some(false)
+    (chars[first] == '{').then_some(first)
 }

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/store_transforms.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/store_transforms.rs
@@ -3,6 +3,7 @@
 use memchr::memmem;
 use rustc_hash::FxHashSet;
 
+use super::scan_index::ScanIndex;
 use super::{find_matching_paren, is_shorthand_object_property};
 
 /// Transform store assignments in client-side code.
@@ -368,6 +369,7 @@ pub(super) fn transform_store_reads_client(line: &str, store_sub_vars: &[String]
         // But avoid replacing function calls that already have ()
         let mut new_result = String::with_capacity(result.len() * 2);
         let chars: Vec<char> = result.chars().collect();
+        let index = ScanIndex::new(&chars);
         let mut char_byte_offsets: Vec<usize> = result.char_indices().map(|(i, _)| i).collect();
         char_byte_offsets.push(result.len());
         let mut i = 0;
@@ -493,7 +495,7 @@ pub(super) fn transform_store_reads_client(line: &str, store_sub_vars: &[String]
                         new_result.push_str(store_sub);
                         i += store_sub.len();
                         continue;
-                    } else if is_shorthand_object_property(&chars, i, store_sub.len()) {
+                    } else if is_shorthand_object_property(&index, &chars, i, store_sub.len()) {
                         // Shorthand object property: `{ $width }` -> `{ $width: $width() }`.
                         // Emitting `{ $width() }` is invalid (method shorthand), so expand
                         // like the prop-read path, keeping the leading `$` in the key.


### PR DESCRIPTION
Closes #2342.

## The mechanism

`transform_prop_reads_in_expr` walks the expression once per prop var and, wherever the
text starts with the prop name, asks three questions:

- `is_shadowed_by_function_param` — is this a parameter of an enclosing function?
- `is_explicit_property_key` — is it the `foo` of `{ foo: bar }`?
- `is_arrow_param_binding` — is it a binding in an arrow parameter list?

Each was answered by a **backward scan** that could run to the start of the expression.
Matched identifiers are themselves O(n) across the per-prop passes, so the guards were
O(n) work fired O(n) times — the term #2339 left behind.

Two changes:

1. **`ScanIndex`** (new `client/scan_index.rs`) answers "what encloses this position?"
   without a scan. `is_shorthand_object_property` — also used by `store_transforms` —
   shares it.
2. The guards move **behind** the cheap character checks in the `&&` chain rather than
   being computed beside them, so a candidate rejected by its neighbouring characters no
   longer pays for them at all.

### Why the index can be trusted to agree

The scans track their own depth counters, and those counters **clamp at zero** rather
than going negative (`'{' => if depth > 0 { depth -= 1 } else { … }`). That is exactly a
forward stack that pops only when non-empty, which is how the index's stacks are
maintained — so the two routes agree even on unbalanced text. Each bracket kind is
matched the way its scan matched it: brace-only, bracket-only and paren-only stacks for
the object-literal test, a type-agnostic stack for the arrow-parameter test.

### Why it is a *bracket-event* index, not a row per character

The first version stored a row per character. It fixed the asymptotics but was **~6%
slower end to end on svelte-ux's `Button.svelte`** — the one shipped file the issue names
as a real trigger — because the pass runs once per prop var and real expressions are only
a few percent brackets. The index now stores a row only where an answer can change
(`{}[]();` and `=>`) and binary-searches it, and `ScanIndexBuilder` feeds off the walk
that already builds the rewriter's `Vec<char>` and byte offsets, so three passes over the
text become one.

## Output equality

`RSVELTE_INDEX_ORACLE` (the existing convention from `client/mod.rs`) runs both routes
and compares every answer, so agreement has a denominator instead of only a failure
count. Under the oracle the guards are asked at **every** candidate position, not only
where short-circuiting lets the question through, so the comparison covers the guards
themselves rather than the surviving call sites.

| population | files | compiles | oracle checks | mismatches |
|---|---:|---:|---:|---:|
| every checked-out `submodules/*`, client + client-dev + server | 13,079 | 36,847 | 39,408 | **0** |

Also:

- `cargo test --release` (workspace): **4,373 passed, 0 failed**
- corpus gate (14,028 entries × 3 targets): `js-mismatch 0`, "all corpus outputs identical
  after normalization", no warning regressions

## Measurement

Paired A/B throughout: the two binaries run **back to back**, and the reported figure is
the median of the per-pair ratio — not min-of-N, which inflates an improvement by ~1.7x
on a shared machine. Whole-`compile()`, in-process `hrtime`.

**Scaling fixture** — one `$: _class = cls(<4N lines>)` over four `export let` props,
N ∈ {25, 50, 100, 200, 400, 800}, median of 5 pairs:

| file bytes | before (ms) | after (ms) | ratio |
|---:|---:|---:|---:|
|  2,761 |   1.51 |  1.04 |  1.5x |
|  5,386 |   4.09 |  1.76 |  2.3x |
| 10,636 |  12.23 |  3.27 |  3.7x |
| 21,836 |  42.20 |  6.31 |  6.7x |
| 44,236 | 157.59 | 12.57 | 12.6x |
| 89,036 | 611.62 | 24.52 | 24.9x |

Fitted log-log slope of time against size, all n = 6 points: **1.731 → 0.917**. The ratio
rises monotonically with size, which is the signature of removing a quadratic term rather
than shaving a constant.

**Real code** — the populations that decide whether this is worth shipping:

| population | n pairs | ratio (median) |
|---|---:|---:|
| svelte-ux `Button.svelte` (18 KB, the real trigger) | 7 | **1.029** |
| `compile_profile --shipped` `script_text`, 5,879 files | 7 | 0.992 (range 0.975–1.045) |

So: a large asymptotic win on inputs bigger than anything shipped, a small real win on
the one shipped file that triggers the path, and no measurable change on the shipped
population as a whole.

## Who is affected

Unchanged from #2339, and worth restating rather than implying more: only **legacy
(non-runes) components with a physically large `$:` statement** reach this path. Modern
large Svelte projects have essentially zero `$:`, and this is not on the svelte-rs
performance-gap population, so it closes no competitive gap. The issue filed it as a
tail-of-a-tail; the measurements above agree with that assessment.

Note on method: before/after are separate binaries, so ~5% of code-layout effect is mixed
into every ratio here. It does not change any conclusion at these effect sizes, but it is
the reason the two real-code rows should be read as "no regression" rather than as a
precise gain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WhzBu6eT1ai7ZRaq8DrJhN
