### PR TITLE
ci(corpus): make verify.mjs baseline update flags compose

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -914,6 +914,18 @@ jobs:
       - name: Run vite-plugin-svelte native shim smoke test
         run: pnpm run test:vps-shim
 
+  corpus-verify-flags:
+    name: Corpus verify baseline-flag contract
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          submodules: false
+
+      - name: Check --update-baseline / --update-warning-baseline compose
+        run: node scripts/dev/test-corpus-verify-baseline-flags.mjs
+
   vps-version-check:
     name: VPS native VERSION drift check
     runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
 		"bootstrap-platform-packages": "node scripts/release/bootstrap-platform-packages.mjs",
 		"test:envelope": "node scripts/dev/test-envelope-validation.mjs",
 		"test:parse-envelope": "node scripts/dev/test-parse-envelope-validation.mjs",
+		"test:corpus-verify-flags": "node scripts/dev/test-corpus-verify-baseline-flags.mjs",
 		"test:vps-shim": "node scripts/dev/test-vps-shim.mjs",
 		"test:vps-fixture": "node scripts/dev/test-vps-vite-fixture.mjs",
 		"test:vps": "node scripts/dev/test-vps-shim.mjs && node scripts/dev/test-vps-vite-fixture.mjs",

--- a/scripts/compat-corpus/README.md
+++ b/scripts/compat-corpus/README.md
@@ -171,7 +171,12 @@ dimensions:
 
 Warning comparison needs no normalization, so it is meaningful under `--no-fmt`;
 `--update-warning-baseline` rewrites only the warning ratchets, so a `--no-fmt`
-run (which inflates JS failures) can seed them safely. See
+run (which inflates JS failures) can seed them safely. The two update flags
+**compose**: passing both rewrites both families in one run, each run announces
+which families it will write, and a rewrite run that reaches no write exits `2`
+instead of reporting success (`scripts/dev/test-corpus-verify-baseline-flags.mjs`
+guards this). `--from-report` derives output failures only, so it rejects
+`--update-warning-baseline` rather than ignoring it. See
 [compatibility/warning-known-failures.md](../../compatibility/warning-known-failures.md)
 — including why this gate did not exist until #2281, and the corpus entry that
 proved it was needed.

--- a/scripts/compat-corpus/verify.mjs
+++ b/scripts/compat-corpus/verify.mjs
@@ -66,6 +66,11 @@
  * so a `--no-fmt` run (which inflates JS failures) can seed them without
  * corrupting the output baselines.
  *
+ * The two update flags compose: passing both rewrites both ratchet families in
+ * one run (the families are disjoint). Every run that asks for a rewrite prints
+ * up front which families it will write, and a run that writes nothing is never
+ * reported as a successful rewrite.
+ *
  * Usage: node scripts/compat-corpus/verify.mjs [--no-fmt] [--max-print <n>] [--update-baseline [<target>]] [--update-warning-baseline] [--from-report <path>] [--targets <keys>] [--strict] [--keep-artifacts|--clean-artifacts]
  */
 
@@ -111,6 +116,21 @@ const FROM_REPORT = (() => {
 	return i !== -1 && args[i + 1] ? path.resolve(process.cwd(), args[i + 1]) : null;
 })();
 
+// State an update run's intent before doing any work: the failure mode this
+// guards against is a rewrite that silently writes nothing and still exits 0.
+const UPDATE_FAMILIES = [UPDATE_BASELINE && 'output', UPDATE_WARNING_BASELINE && 'warning'].filter(Boolean);
+if (UPDATE_FAMILIES.length) {
+	console.log(`[verify] rewriting ${UPDATE_FAMILIES.join(' + ')} ratchets for ${TARGET_KEYS.join(', ')}`);
+}
+
+// --from-report reconstructs only the output ratchets, so pairing it with the
+// warning flag would write half of what was asked for.
+if (FROM_REPORT && UPDATE_WARNING_BASELINE) {
+	console.error('[verify] --from-report cannot rewrite the warning ratchets (it derives output failures only)');
+	console.error('  fix: drop --update-warning-baseline, then re-run a full verify with it');
+	process.exit(2);
+}
+
 // --baseline-client <path> / --baseline-server <path> select alternate ratchet
 // files (defaults come from targets.mjs). The corpus is a single unified set,
 // so these are rarely needed — kept for ad-hoc scoped runs.
@@ -151,7 +171,12 @@ function requireFullCorpus(measured, what) {
 	process.exit(2);
 }
 
+// Which ratchet families this run actually wrote, checked against
+// UPDATE_FAMILIES in finish() so a rewrite that reaches no write cannot exit 0.
+const WRITTEN = new Set();
+
 function writeBaselines(byTarget) {
+	WRITTEN.add('output');
 	console.log();
 	for (const target of TARGETS) {
 		if (UPDATE_SCOPE && target.key !== UPDATE_SCOPE) continue;
@@ -482,9 +507,11 @@ const warningRegressions = [];
 const warningFailById = new Map(warningFailures.map((f) => [f.id, f]));
 let warningFixed = 0;
 
-// `--update-baseline` is about the OUTPUT ratchets; leave the warning ones
-// alone so an output burn-down cannot silently absorb a warning regression.
-for (const ratchet of UPDATE_BASELINE ? [] : WARNING_RATCHETS) {
+// `--update-baseline` alone is about the OUTPUT ratchets; leave the warning ones
+// alone so an output burn-down cannot silently absorb a warning regression. Ask
+// for both and both are rewritten.
+const SKIP_WARNING_RATCHETS = UPDATE_BASELINE && !UPDATE_WARNING_BASELINE;
+for (const ratchet of SKIP_WARNING_RATCHETS ? [] : WARNING_RATCHETS) {
 	const byTarget = partitionWarnings(ratchet.kind);
 	for (const target of TARGETS) {
 		const p = path.resolve(CORPUS, ratchet.file(target));
@@ -495,6 +522,7 @@ for (const ratchet of UPDATE_BASELINE ? [] : WARNING_RATCHETS) {
 			// every id the run did not measure.
 			requireFullCorpus(manifest.length, 'corpus entries');
 			fs.writeFileSync(p, JSON.stringify([...ids].sort(), null, '\t') + '\n');
+			WRITTEN.add('warning');
 			console.log(`[verify] ${ratchet.label} baseline: ${ids.size} known -> ${path.relative(ROOT, p)}`);
 			continue;
 		}
@@ -507,7 +535,8 @@ for (const ratchet of UPDATE_BASELINE ? [] : WARNING_RATCHETS) {
 	}
 }
 
-if (UPDATE_WARNING_BASELINE) finish(0);
+// Hand off to the output rewrite below when both were asked for.
+if (UPDATE_WARNING_BASELINE && !UPDATE_BASELINE) finish(0);
 
 // Two-sided, like the output ratchets: a listed entry that already passes fails
 // the run, so the PR that fixes entries re-baselines in the same PR.
@@ -535,6 +564,11 @@ const failsByTarget = partitionFailures(failures);
 // so a green run deletes them here instead of leaving ~0.5 GiB per checkout for
 // the operator to remember.
 function finish(code) {
+	const missed = code === 0 ? UPDATE_FAMILIES.filter((f) => !WRITTEN.has(f)) : [];
+	if (missed.length) {
+		console.error(`\n[verify] ❌ asked to rewrite ${missed.join(' + ')} ratchets but wrote none of them`);
+		code = 2;
+	}
 	cleanupArtifacts(OUTPUT_TREES, args, { failed: code !== 0, label: 'verify' });
 	process.exit(code);
 }

--- a/scripts/dev/test-corpus-verify-baseline-flags.mjs
+++ b/scripts/dev/test-corpus-verify-baseline-flags.mjs
@@ -1,0 +1,149 @@
+#!/usr/bin/env node
+/**
+ * Guards the ratchet-rewrite contract of scripts/compat-corpus/verify.mjs.
+ *
+ * `--update-baseline` and `--update-warning-baseline` rewrite two disjoint
+ * ratchet families. They used to disable each other: passing both wrote NOTHING
+ * and exited 0, so an operator re-baselining an enrolment PR saw a green run and
+ * committed the pre-run ratchets. That is the same failure class the corpus
+ * pipeline exists to prevent — a gate reporting success without doing the work.
+ *
+ * The contract asserted here:
+ *   - the flags compose; both together rewrite both families
+ *   - each alone still rewrites only its own family
+ *   - a deselected target's ratchets are never touched
+ *   - --from-report cannot rewrite the warning family (it derives output only)
+ *   - a rewrite run that writes nothing exits non-zero
+ *
+ * The corpus itself is synthetic: verify.mjs refuses to rewrite below
+ * MIN_FULL_CORPUS_ENTRIES, so the sandbox has to clear that floor, but the
+ * entries can be trivial because this test is about which files get written.
+ *
+ * Usage: node scripts/dev/test-corpus-verify-baseline-flags.mjs
+ */
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, '../..');
+const CORPUS_SCRIPTS = path.join(ROOT, 'scripts/compat-corpus');
+
+const ENTRIES = 12500; // must exceed artifacts.mjs MIN_FULL_CORPUS_ENTRIES
+const SENTINEL = ['sentinel-entry'];
+
+const OUTPUT_RATCHETS = ['known-failures.client.json', 'known-failures.server.json', 'known-failures.client-dev.json'];
+const WARNING_RATCHETS = [
+	'warning-known-failures.client.json',
+	'warning-known-failures.server.json',
+	'warning-known-failures.client-dev.json',
+	'warning-position-known-failures.client.json',
+	'warning-position-known-failures.server.json',
+	'warning-position-known-failures.client-dev.json',
+];
+
+let failed = 0;
+function check(name, ok, detail) {
+	console.log(`${ok ? '  ✓' : '  ✗'} ${name}${ok || !detail ? '' : ` — ${detail}`}`);
+	if (!ok) failed++;
+}
+
+const sandbox = fs.mkdtempSync(path.join(os.tmpdir(), 'verify-flags-'));
+const CORPUS = path.join(sandbox, 'compatibility');
+const VERIFY = path.join(sandbox, 'scripts/compat-corpus/verify.mjs');
+
+function buildSandbox() {
+	fs.mkdirSync(path.join(sandbox, 'scripts/compat-corpus'), { recursive: true });
+	for (const f of ['verify.mjs', 'normalize.mjs', 'targets.mjs', 'artifacts.mjs']) {
+		fs.copyFileSync(path.join(CORPUS_SCRIPTS, f), path.join(sandbox, 'scripts/compat-corpus', f));
+	}
+	const manifest = [];
+	for (let i = 0; i < ENTRIES; i++) {
+		const id = `e${i}`;
+		manifest.push({ id, source: `${id}.svelte` });
+		for (const tree of ['expected', 'actual']) {
+			const dir = path.join(CORPUS, tree, id);
+			fs.mkdirSync(dir, { recursive: true });
+			fs.writeFileSync(path.join(dir, 'client.js'), 'export default 1;\n');
+		}
+	}
+	fs.writeFileSync(path.join(CORPUS, 'manifest.json'), JSON.stringify(manifest));
+}
+
+function seedRatchets() {
+	for (const f of [...OUTPUT_RATCHETS, ...WARNING_RATCHETS]) {
+		fs.writeFileSync(path.join(CORPUS, f), JSON.stringify(SENTINEL, null, '\t') + '\n');
+	}
+}
+
+const isSentinel = (f) => {
+	const p = path.join(CORPUS, f);
+	return fs.existsSync(p) && JSON.parse(fs.readFileSync(p, 'utf8')).length === SENTINEL.length;
+};
+const rewritten = (files) => files.filter((f) => !isSentinel(f));
+const untouched = (files) => files.filter(isSentinel);
+
+function run(...extra) {
+	seedRatchets();
+	return spawnSync(process.execPath, [VERIFY, '--no-fmt', '--keep-artifacts', '--targets', 'client', ...extra], {
+		cwd: sandbox,
+		encoding: 'utf8',
+	});
+}
+
+buildSandbox();
+console.log(`[verify-flags] sandbox: ${sandbox} (${ENTRIES} synthetic entries)`);
+
+console.log('\nboth flags together rewrite both families');
+{
+	const r = run('--update-baseline', '--update-warning-baseline');
+	check('exit 0', r.status === 0, `status ${r.status}\n${r.stderr}`);
+	check('client output ratchet rewritten', !isSentinel('known-failures.client.json'));
+	check('client warning ratchet rewritten', !isSentinel('warning-known-failures.client.json'));
+	check('client warning-position ratchet rewritten', !isSentinel('warning-position-known-failures.client.json'));
+	check('announces both families', /rewriting output \+ warning ratchets/.test(r.stdout), r.stdout.slice(0, 400));
+}
+
+console.log('\n--update-baseline alone leaves the warning family alone');
+{
+	const r = run('--update-baseline');
+	check('exit 0', r.status === 0, `status ${r.status}\n${r.stderr}`);
+	check('client output ratchet rewritten', !isSentinel('known-failures.client.json'));
+	check('all warning ratchets untouched', untouched(WARNING_RATCHETS).length === WARNING_RATCHETS.length, rewritten(WARNING_RATCHETS).join(', '));
+}
+
+console.log('\n--update-warning-baseline alone leaves the output family alone');
+{
+	const r = run('--update-warning-baseline');
+	check('exit 0', r.status === 0, `status ${r.status}\n${r.stderr}`);
+	check('client warning ratchet rewritten', !isSentinel('warning-known-failures.client.json'));
+	check('all output ratchets untouched', untouched(OUTPUT_RATCHETS).length === OUTPUT_RATCHETS.length, rewritten(OUTPUT_RATCHETS).join(', '));
+}
+
+console.log('\ndeselected targets are never rewritten');
+{
+	const r = run('--update-baseline', '--update-warning-baseline');
+	check('exit 0', r.status === 0, `status ${r.status}`);
+	const others = [...OUTPUT_RATCHETS, ...WARNING_RATCHETS].filter((f) => !f.includes('.client.'));
+	check('server / client-dev ratchets untouched', untouched(others).length === others.length, rewritten(others).join(', '));
+}
+
+console.log('\n--from-report refuses the warning flag instead of ignoring it');
+{
+	const report = path.join(sandbox, 'report.json');
+	fs.writeFileSync(report, JSON.stringify({ total: ENTRIES, failures: [] }));
+	const r = run('--from-report', report, '--update-warning-baseline');
+	check('exit 2', r.status === 2, `status ${r.status}`);
+	check('warning ratchets untouched', untouched(WARNING_RATCHETS).length === WARNING_RATCHETS.length);
+}
+
+fs.rmSync(sandbox, { recursive: true, force: true });
+
+if (failed) {
+	console.error(`\n[verify-flags] ❌ ${failed} assertion(s) failed`);
+	process.exit(1);
+}
+console.log('\n[verify-flags] ✅ all assertions passed');


### PR DESCRIPTION
`scripts/compat-corpus/verify.mjs` accepts both `--update-baseline` and `--update-warning-baseline`. Passing them together wrote **nothing** and exited **0**.

Two guards disabled each other:

- `for (const ratchet of UPDATE_BASELINE ? [] : WARNING_RATCHETS)` skipped the whole warning loop whenever the output flag was set, so the `UPDATE_WARNING_BASELINE` write inside it never ran;
- `if (UPDATE_WARNING_BASELINE) finish(0);` then exited before the output-baseline write below it.

Reproduced against a synthetic 12,500-entry corpus before touching the code: all nine ratchets kept their pre-run contents and the run exited 0 with no indication anything had been skipped. Same class as #2335 and #2287 — a gate reporting success without doing the work.

## Contract

The two ratchet families are disjoint, so the flags now **compose**:

| invocation | rewrites |
|---|---|
| `--update-baseline` | output ratchets only (unchanged) |
| `--update-warning-baseline` | warning + warning-position ratchets only (unchanged) |
| both | both families, then exits 0 |
| `--from-report` + `--update-warning-baseline` | **exit 2** — a report carries output failures only |

Made explicit rather than left to the caller:

- every update run prints `[verify] rewriting <families> ratchets for <targets>` before doing any work;
- `finish()` fails with exit 2 if a run was asked to rewrite a family and reached no write — so this bug class cannot silently return.

## Test

`scripts/dev/test-corpus-verify-baseline-flags.mjs` (`pnpm run test:corpus-verify-flags`, new 5-minute CI job) drives the real `verify.mjs` over a synthetic sandbox corpus and asserts all five rows above plus "a deselected target's ratchets are never touched". Negative control: 5 of its assertions fail against the pre-fix script.

Closes #2350

🤖 Generated with [Claude Code](https://claude.com/claude-code)