### PR TITLE
chore(ci): stop the auto-update workflows from force-pushing over downstream commits

### DIFF
--- a/.github/workflows/auto-update-oxfmt.yml
+++ b/.github/workflows/auto-update-oxfmt.yml
@@ -127,6 +127,21 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
           pr_branch="chore/update-oxfmt-${LATEST_VERSION}"
+
+          # The regenerate-and-force-push below would destroy any commit pushed
+          # to the open PR by hand, so refuse to touch a branch that has them.
+          set +e
+          node scripts/ci/bot-branch-guard.mjs --branch "${pr_branch}" \
+            --what "oxfmt ${LATEST_VERSION}" --report-pr
+          guard_rc=$?
+          set -e
+          if [ "${guard_rc}" -eq 3 ]; then
+            echo "::warning::${pr_branch} carries downstream commits; leaving it untouched."
+            exit 0
+          elif [ "${guard_rc}" -ne 0 ]; then
+            exit "${guard_rc}"
+          fi
+
           git checkout -B "${pr_branch}"
 
           # Bump every caret/tilde-pinned oxfmt range across the workspace.

--- a/.github/workflows/auto-update-submodules.yml
+++ b/.github/workflows/auto-update-submodules.yml
@@ -181,6 +181,21 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
           pr_branch="chore/update-${SUB_NAME}"
+
+          # This branch name carries no version, so every weekly run targets the
+          # same branch — refuse to force over commits pushed to it by hand.
+          set +e
+          node scripts/ci/bot-branch-guard.mjs --branch "${pr_branch}" \
+            --what "${SUB_NAME} ${short_new:-${new:0:12}}" --report-pr
+          guard_rc=$?
+          set -e
+          if [ "${guard_rc}" -eq 3 ]; then
+            echo "::warning::${pr_branch} carries downstream commits; leaving it untouched."
+            exit 0
+          elif [ "${guard_rc}" -ne 0 ]; then
+            exit "${guard_rc}"
+          fi
+
           git checkout -B "${pr_branch}"
 
           # Advance the gitlink to the new commit without checking the

--- a/.github/workflows/auto-update-svelte.yml
+++ b/.github/workflows/auto-update-svelte.yml
@@ -122,6 +122,21 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
           pr_branch="chore/upgrade-svelte-${LATEST_VERSION}"
+
+          # This PR is explicitly finished by hand (fixtures + regressions), so
+          # downstream commits are the expected state — never force over them.
+          set +e
+          node scripts/ci/bot-branch-guard.mjs --branch "${pr_branch}" \
+            --what "Svelte ${LATEST_VERSION}" --report-pr
+          guard_rc=$?
+          set -e
+          if [ "${guard_rc}" -eq 3 ]; then
+            echo "::warning::${pr_branch} carries downstream commits; leaving it untouched."
+            exit 0
+          elif [ "${guard_rc}" -ne 0 ]; then
+            exit "${guard_rc}"
+          fi
+
           git checkout -B "${pr_branch}"
 
           # Advance the svelte gitlink (mode 160000 = gitlink).

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -928,3 +928,16 @@ jobs:
 
       - name: Check vite-plugin-svelte-native VERSION matches submodules/svelte
         run: node scripts/dev/check-vps-version.mjs
+
+  bot-branch-guard:
+    name: Auto-update branch guard
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          submodules: false
+
+      # A guard that only misfires on a cron 24h later needs its own test.
+      - name: Run auto-update branch guard tests
+        run: node scripts/ci/test-bot-branch-guard.mjs

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
 		"test:oxlint-plugin": "node scripts/dev/test-oxlint-plugin.mjs",
 		"build:vps-native": "node scripts/dev/build-vps-native-local.mjs",
 		"check:vps-version": "node scripts/dev/check-vps-version.mjs",
+		"test:bot-branch-guard": "node scripts/ci/test-bot-branch-guard.mjs",
 		"check:lint-types-lock": "node scripts/ci/check-lint-types-lock.mjs",
 		"fix:lint-types-lock": "node scripts/ci/check-lint-types-lock.mjs --fix",
 		"corpus:sync": "git submodule update --init --depth 1 submodules/svelte submodules/svelte.dev submodules/language-tools submodules/bits-ui submodules/flowbite-svelte submodules/melt-ui submodules/shadcn-svelte submodules/sveltestrap submodules/attractions submodules/svelte-ux submodules/smelte submodules/svar-core submodules/svelte-table submodules/powertable submodules/svelte-pivottable submodules/svelte-toast submodules/svelte-sonner submodules/svelte-notifications submodules/svelte-fa submodules/svelte-heroicons submodules/svelte-calendar submodules/date-picker-svelte submodules/svelte-maplibre submodules/layercake submodules/layerchart submodules/svelte-splitpanes submodules/svelte-stepper submodules/svelte-formly submodules/svelte-form-builder submodules/svelte-checkbox submodules/svelte-toggle submodules/svelthree submodules/runed submodules/svelte-toolbelt submodules/cmsaasstarter submodules/skeleton",

--- a/scripts/ci/bot-branch-guard.mjs
+++ b/scripts/ci/bot-branch-guard.mjs
@@ -1,0 +1,330 @@
+#!/usr/bin/env node
+// Decide whether an auto-update workflow may force-push over an existing PR
+// branch, i.e. whether the remote branch still holds nothing but the single
+// commit the bot itself wrote last time.
+//
+// The auto-update workflows regenerate their branch from scratch
+// (`git checkout -B` + one commit) and force-push. When a human has pushed
+// follow-up work to the open PR, that force-push destroys it. This guard is the
+// pre-flight check: it inspects the *remote* branch and reports `safe` only for
+// the exact shape the bot leaves behind.
+//
+// Detection: take `merge-base(origin/<base>, origin/<branch>)` and list every
+// commit on the branch since it. Safe requires
+//   - at most one such commit, and
+//   - that commit is authored AND committed by a known bot identity.
+//
+// Why the merge-base count survives the rebase-onto-a-new-bot-commit case: when
+// a human rebases their work onto the bot's freshly regenerated commit, the
+// branch still contains bot-commit + N human commits since the merge-base with
+// main, so the count is N+1 > 1. A detector that only looked at the branch tip's
+// author, or that only compared the tip against the bot's previous commit, would
+// see a plausible-looking branch and clobber. The author/committer check is the
+// second, independent signal: it catches an amended or hand-rewritten single
+// commit, which the count alone would pass.
+//
+// Everything unclear is blocked, never allowed: an unreadable merge-base (for
+// example a shallow clone too shallow to find one) fails closed.
+//
+// Exit codes: 0 = safe to force-push, 3 = blocked, 1 = error.
+
+import { spawnSync } from 'node:child_process';
+import { appendFileSync } from 'node:fs';
+
+const DEFAULT_BOT_EMAILS = [
+	'41898282+github-actions[bot]@users.noreply.github.com',
+	'github-actions[bot]@users.noreply.github.com',
+];
+
+const EXIT_SAFE = 0;
+const EXIT_ERROR = 1;
+const EXIT_BLOCKED = 3;
+
+function parseArgs(argv) {
+	const opts = {
+		branch: '',
+		base: 'main',
+		remote: 'origin',
+		repo: process.cwd(),
+		botEmails: [],
+		fetch: true,
+		what: '',
+		reportPr: false,
+	};
+	for (let i = 0; i < argv.length; i++) {
+		const arg = argv[i];
+		const next = () => {
+			const v = argv[++i];
+			if (v === undefined) {
+				throw new Error(`missing value for ${arg}`);
+			}
+			return v;
+		};
+		switch (arg) {
+			case '--branch':
+				opts.branch = next();
+				break;
+			case '--base':
+				opts.base = next();
+				break;
+			case '--remote':
+				opts.remote = next();
+				break;
+			case '--repo':
+				opts.repo = next();
+				break;
+			case '--bot-email':
+				opts.botEmails.push(next());
+				break;
+			case '--what':
+				opts.what = next();
+				break;
+			case '--no-fetch':
+				opts.fetch = false;
+				break;
+			case '--report-pr':
+				opts.reportPr = true;
+				break;
+			default:
+				throw new Error(`unknown argument: ${arg}`);
+		}
+	}
+	if (!opts.branch) {
+		throw new Error('--branch is required');
+	}
+	if (opts.botEmails.length === 0) {
+		opts.botEmails = [...DEFAULT_BOT_EMAILS];
+	}
+	return opts;
+}
+
+function git(repo, args) {
+	const res = spawnSync('git', args, { cwd: repo, encoding: 'utf8' });
+	return {
+		ok: res.status === 0,
+		stdout: (res.stdout ?? '').trim(),
+		stderr: (res.stderr ?? '').trim(),
+	};
+}
+
+/**
+ * @returns {{status: 'safe'|'blocked', reason: string, commits: Array<{sha: string, author: string, committer: string, subject: string}>}}
+ */
+export function inspectBranch(opts) {
+	const { repo, remote, base, branch } = opts;
+	const botEmails = new Set(opts.botEmails.map((e) => e.toLowerCase()));
+
+	if (opts.fetch) {
+		// --depth only when already shallow: passing it to a full clone would
+		// shallowify the checkout the caller is about to push from.
+		const shallow = git(repo, ['rev-parse', '--is-shallow-repository']).stdout === 'true';
+		const depth = shallow ? ['--depth=200'] : [];
+		git(repo, [
+			'fetch',
+			'--no-tags',
+			'--quiet',
+			...depth,
+			remote,
+			`+refs/heads/${base}:refs/remotes/${remote}/${base}`,
+		]);
+		git(repo, [
+			'fetch',
+			'--no-tags',
+			'--quiet',
+			...depth,
+			remote,
+			`+refs/heads/${branch}:refs/remotes/${remote}/${branch}`,
+		]);
+	}
+
+	const branchRef = `refs/remotes/${remote}/${branch}`;
+	const baseRef = `refs/remotes/${remote}/${base}`;
+
+	const branchTip = git(repo, ['rev-parse', '--verify', '--quiet', `${branchRef}^{commit}`]);
+	if (!branchTip.ok || !branchTip.stdout) {
+		return {
+			status: 'safe',
+			reason: `remote branch ${remote}/${branch} does not exist yet`,
+			commits: [],
+		};
+	}
+
+	const baseTip = git(repo, ['rev-parse', '--verify', '--quiet', `${baseRef}^{commit}`]);
+	if (!baseTip.ok || !baseTip.stdout) {
+		return {
+			status: 'blocked',
+			reason: `could not resolve ${remote}/${base}; refusing to force-push without a comparison point`,
+			commits: [],
+		};
+	}
+
+	const mergeBase = git(repo, ['merge-base', baseTip.stdout, branchTip.stdout]);
+	if (!mergeBase.ok || !mergeBase.stdout) {
+		return {
+			status: 'blocked',
+			reason: `no merge-base between ${remote}/${base} and ${remote}/${branch} (shallow clone?); refusing to force-push`,
+			commits: [],
+		};
+	}
+
+	const log = git(repo, [
+		'log',
+		'--format=%H %ae %ce %s',
+		`${mergeBase.stdout}..${branchTip.stdout}`,
+	]);
+	if (!log.ok) {
+		return {
+			status: 'blocked',
+			reason: `git log failed: ${log.stderr}`,
+			commits: [],
+		};
+	}
+
+	const commits = log.stdout
+		? log.stdout.split('\n').map((line) => {
+				const [sha, author, committer, ...rest] = line.split(' ');
+				const subject = rest.join(' ');
+				return { sha, author, committer, subject: subject ?? '' };
+			})
+		: [];
+
+	if (commits.length === 0) {
+		return {
+			status: 'safe',
+			reason: `${remote}/${branch} carries no commits beyond ${base}`,
+			commits,
+		};
+	}
+
+	if (commits.length > 1) {
+		return {
+			status: 'blocked',
+			reason: `${remote}/${branch} carries ${commits.length} commits since its merge-base with ${base}; the bot only ever writes one`,
+			commits,
+		};
+	}
+
+	const [only] = commits;
+	const authorIsBot = botEmails.has((only.author ?? '').toLowerCase());
+	const committerIsBot = botEmails.has((only.committer ?? '').toLowerCase());
+	if (!authorIsBot || !committerIsBot) {
+		return {
+			status: 'blocked',
+			reason: `${remote}/${branch} tip ${only.sha.slice(0, 12)} was authored by ${only.author} and committed by ${only.committer}, not the bot`,
+			commits,
+		};
+	}
+
+	return {
+		status: 'safe',
+		reason: `${remote}/${branch} holds only the bot's own commit ${only.sha.slice(0, 12)}`,
+		commits,
+	};
+}
+
+function renderReport(opts, result) {
+	const lines = [];
+	lines.push(`### Auto-update branch left untouched`);
+	lines.push('');
+	lines.push(
+		`A newer ${opts.what || 'upstream version'} is available, but \`${opts.branch}\` was **not** force-pushed:`,
+	);
+	lines.push('');
+	lines.push(`> ${result.reason}`);
+	lines.push('');
+	if (result.commits.length > 0) {
+		lines.push('Commits on the branch since its merge-base with `' + opts.base + '`:');
+		lines.push('');
+		for (const c of result.commits) {
+			lines.push(`- \`${c.sha.slice(0, 12)}\` ${c.subject} — ${c.author}`);
+		}
+		lines.push('');
+	}
+	lines.push(
+		'Rebase or merge the downstream work yourself, or close the PR and delete the branch to let the workflow regenerate it.',
+	);
+	return lines.join('\n');
+}
+
+function gh(args) {
+	const res = spawnSync('gh', args, { encoding: 'utf8' });
+	return {
+		ok: res.status === 0,
+		stdout: (res.stdout ?? '').trim(),
+		stderr: (res.stderr ?? '').trim(),
+	};
+}
+
+function postPrComment(opts, body) {
+	const marker = `<!-- auto-update-guard:${opts.branch}:${opts.what} -->`;
+	const list = gh(['pr', 'list', '--head', opts.branch, '--state', 'open', '--json', 'number']);
+	if (!list.ok) {
+		console.error(`could not list PRs for ${opts.branch}: ${list.stderr}`);
+		return;
+	}
+	let number;
+	try {
+		number = JSON.parse(list.stdout || '[]')[0]?.number;
+	} catch {
+		number = undefined;
+	}
+	if (!number) {
+		return;
+	}
+	const existing = gh(['pr', 'view', String(number), '--json', 'comments']);
+	if (existing.ok) {
+		try {
+			const comments = JSON.parse(existing.stdout || '{}').comments ?? [];
+			// One comment per (branch, version): the cron re-runs daily.
+			if (comments.some((c) => (c.body ?? '').includes(marker))) {
+				console.log(`PR #${number} already carries the guard notice; not commenting again.`);
+				return;
+			}
+		} catch {
+			/* fall through and comment */
+		}
+	}
+	const res = gh(['pr', 'comment', String(number), '--body', `${marker}\n${body}`]);
+	if (res.ok) {
+		console.log(`Commented on PR #${number}.`);
+	} else {
+		console.error(`could not comment on PR #${number}: ${res.stderr}`);
+	}
+}
+
+function main() {
+	let opts;
+	try {
+		opts = parseArgs(process.argv.slice(2));
+	} catch (err) {
+		console.error(`bot-branch-guard: ${err.message}`);
+		return EXIT_ERROR;
+	}
+
+	const result = inspectBranch(opts);
+	console.log(`status=${result.status}: ${result.reason}`);
+	for (const c of result.commits) {
+		console.log(`  ${c.sha.slice(0, 12)} ${c.subject} (author=${c.author} committer=${c.committer})`);
+	}
+
+	if (process.env.GITHUB_OUTPUT) {
+		appendFileSync(process.env.GITHUB_OUTPUT, `status=${result.status}\n`);
+	}
+
+	if (result.status === 'safe') {
+		return EXIT_SAFE;
+	}
+
+	const report = renderReport(opts, result);
+	if (process.env.GITHUB_STEP_SUMMARY) {
+		appendFileSync(process.env.GITHUB_STEP_SUMMARY, `${report}\n`);
+	}
+	if (opts.reportPr) {
+		postPrComment(opts, report);
+	}
+	return EXIT_BLOCKED;
+}
+
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+	process.exit(main());
+}

--- a/scripts/ci/bot-branch-guard.mjs
+++ b/scripts/ci/bot-branch-guard.mjs
@@ -107,6 +107,10 @@ function git(repo, args) {
 	};
 }
 
+function isShallow(repo) {
+	return git(repo, ['rev-parse', '--is-shallow-repository']).stdout === 'true';
+}
+
 /**
  * @returns {{status: 'safe'|'blocked', reason: string, commits: Array<{sha: string, author: string, committer: string, subject: string}>}}
  */
@@ -117,8 +121,7 @@ export function inspectBranch(opts) {
 	if (opts.fetch) {
 		// --depth only when already shallow: passing it to a full clone would
 		// shallowify the checkout the caller is about to push from.
-		const shallow = git(repo, ['rev-parse', '--is-shallow-repository']).stdout === 'true';
-		const depth = shallow ? ['--depth=200'] : [];
+		const depth = isShallow(repo) ? ['--depth=200'] : [];
 		git(repo, [
 			'fetch',
 			'--no-tags',
@@ -158,11 +161,17 @@ export function inspectBranch(opts) {
 		};
 	}
 
-	const mergeBase = git(repo, ['merge-base', baseTip.stdout, branchTip.stdout]);
+	let mergeBase = git(repo, ['merge-base', baseTip.stdout, branchTip.stdout]);
+	if ((!mergeBase.ok || !mergeBase.stdout) && opts.fetch && isShallow(repo)) {
+		// A skipped bump is cheap, but silently skipping every bump because the
+		// CI clone is too shallow to answer is not — pay for the full history once.
+		git(repo, ['fetch', '--no-tags', '--quiet', '--unshallow', remote]);
+		mergeBase = git(repo, ['merge-base', baseTip.stdout, branchTip.stdout]);
+	}
 	if (!mergeBase.ok || !mergeBase.stdout) {
 		return {
 			status: 'blocked',
-			reason: `no merge-base between ${remote}/${base} and ${remote}/${branch} (shallow clone?); refusing to force-push`,
+			reason: `no merge-base between ${remote}/${base} and ${remote}/${branch}; refusing to force-push`,
 			commits: [],
 		};
 	}

--- a/scripts/ci/test-bot-branch-guard.mjs
+++ b/scripts/ci/test-bot-branch-guard.mjs
@@ -165,6 +165,44 @@ test('single commit authored by the bot but amended by a human', ({ work }) => {
 	assert(r.code === 3, `expected blocked on committer mismatch, got ${r.code}: ${r.out}`);
 });
 
+// actions/checkout defaults to fetch-depth: 1, so this is the shape CI actually runs in.
+function shallowClone({ root, origin }) {
+	const shallow = join(root, 'shallow');
+	git(root, ['clone', '--depth=1', `file://${origin}`, shallow]);
+	assert(
+		git(shallow, ['rev-parse', '--is-shallow-repository']) === 'true',
+		'expected a shallow clone',
+	);
+	return shallow;
+}
+
+test('shallow CI clone: bot-only branch is still recognised as safe', (repo) => {
+	const { work } = repo;
+	for (let i = 0; i < 5; i++) {
+		commit(work, { file: `main-${i}.txt`, message: `main work ${i}`, author: 'human' });
+	}
+	git(work, ['push', 'origin', 'main']);
+	git(work, ['checkout', '-B', 'bump', 'main']);
+	commit(work, { file: 'v.txt', message: 'chore(deps): update oxfmt to 0.62.0', author: 'bot' });
+	git(work, ['push', 'origin', 'bump']);
+	const r = runGuard(shallowClone(repo), 'bump');
+	assert(r.code === 0, `expected safe from a shallow clone, got ${r.code}: ${r.out}`);
+});
+
+test('shallow CI clone: downstream commits are still detected', (repo) => {
+	const { work } = repo;
+	for (let i = 0; i < 5; i++) {
+		commit(work, { file: `main-${i}.txt`, message: `main work ${i}`, author: 'human' });
+	}
+	git(work, ['push', 'origin', 'main']);
+	git(work, ['checkout', '-B', 'bump', 'main']);
+	commit(work, { file: 'v.txt', message: 'chore(deps): update oxfmt to 0.62.0', author: 'bot' });
+	commit(work, { file: 'fix.rs', message: 'fix(compiler): hand-written work', author: 'human' });
+	git(work, ['push', 'origin', 'bump']);
+	const r = runGuard(shallowClone(repo), 'bump');
+	assert(r.code === 3, `expected blocked from a shallow clone, got ${r.code}: ${r.out}`);
+});
+
 test('single commit written entirely by a human', ({ work }) => {
 	git(work, ['checkout', '-B', 'bump', 'main']);
 	commit(work, { file: 'v.txt', message: 'chore(deps): update oxfmt to 0.62.0', author: 'human' });

--- a/scripts/ci/test-bot-branch-guard.mjs
+++ b/scripts/ci/test-bot-branch-guard.mjs
@@ -1,0 +1,200 @@
+#!/usr/bin/env node
+// Self-test for scripts/ci/bot-branch-guard.mjs.
+//
+// Builds real git repositories (a bare "origin" plus a working clone) and
+// replays the histories the auto-update workflows actually meet, including the
+// one that destroyed 15 hand-written commits: a bot branch that a human rebased
+// onto a freshly regenerated bot commit. Everything runs offline against local
+// paths, so this is cheap enough to gate every PR.
+
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const GUARD = join(HERE, 'bot-branch-guard.mjs');
+
+const BOT_NAME = 'github-actions[bot]';
+const BOT_EMAIL = '41898282+github-actions[bot]@users.noreply.github.com';
+const HUMAN_NAME = 'A Human';
+const HUMAN_EMAIL = 'human@example.com';
+
+// The repo configures core.hooksPath globally; the throwaway fixtures must not inherit it.
+const CLEAN_GIT_ENV = { GIT_CONFIG_GLOBAL: '/dev/null', GIT_CONFIG_SYSTEM: '/dev/null' };
+
+function git(cwd, args, env = {}) {
+	const res = spawnSync('git', ['-c', 'core.hooksPath=', ...args], {
+		cwd,
+		encoding: 'utf8',
+		env: { ...process.env, ...CLEAN_GIT_ENV, ...env },
+	});
+	if (res.status !== 0) {
+		throw new Error(`git ${args.join(' ')} failed in ${cwd}:\n${res.stderr}`);
+	}
+	return (res.stdout ?? '').trim();
+}
+
+function commit(repo, { file, message, author }) {
+	writeFileSync(join(repo, file), `${message}\n`);
+	git(repo, ['add', file]);
+	const ident =
+		author === 'bot'
+			? { name: BOT_NAME, email: BOT_EMAIL }
+			: { name: HUMAN_NAME, email: HUMAN_EMAIL };
+	git(repo, ['commit', '-m', message], {
+		GIT_AUTHOR_NAME: ident.name,
+		GIT_AUTHOR_EMAIL: ident.email,
+		GIT_COMMITTER_NAME: ident.name,
+		GIT_COMMITTER_EMAIL: ident.email,
+		GIT_AUTHOR_DATE: '2026-01-01T00:00:00Z',
+		GIT_COMMITTER_DATE: '2026-01-01T00:00:00Z',
+	});
+}
+
+/** Fresh origin+clone with a `main` holding one commit. */
+function makeRepo() {
+	const root = mkdtempSync(join(tmpdir(), 'bot-branch-guard-'));
+	const origin = join(root, 'origin.git');
+	const work = join(root, 'work');
+	git(root, ['init', '--bare', '--initial-branch=main', origin]);
+	git(root, ['clone', origin, work]);
+	git(work, ['config', 'user.name', HUMAN_NAME]);
+	git(work, ['config', 'user.email', HUMAN_EMAIL]);
+	commit(work, { file: 'README.md', message: 'initial', author: 'human' });
+	git(work, ['push', 'origin', 'main']);
+	return { root, origin, work };
+}
+
+function runGuard(work, branch, extra = []) {
+	const res = spawnSync(
+		process.execPath,
+		[GUARD, '--repo', work, '--branch', branch, '--base', 'main', ...extra],
+		{
+			cwd: work,
+			encoding: 'utf8',
+			env: { ...process.env, ...CLEAN_GIT_ENV, GITHUB_OUTPUT: '', GITHUB_STEP_SUMMARY: '' },
+		},
+	);
+	return { code: res.status, out: `${res.stdout ?? ''}${res.stderr ?? ''}` };
+}
+
+const cases = [];
+function test(name, fn) {
+	cases.push({ name, fn });
+}
+
+test('remote branch does not exist yet', ({ work }) => {
+	const r = runGuard(work, 'chore/update-oxfmt-0.62.0');
+	assert(r.code === 0, `expected safe, got ${r.code}: ${r.out}`);
+});
+
+test('branch holds only the bot commit', ({ work }) => {
+	git(work, ['checkout', '-B', 'bump']);
+	commit(work, { file: 'v.txt', message: 'chore(deps): update oxfmt to 0.62.0', author: 'bot' });
+	git(work, ['push', 'origin', 'bump']);
+	const r = runGuard(work, 'bump');
+	assert(r.code === 0, `expected safe, got ${r.code}: ${r.out}`);
+});
+
+test('branch is identical to main', ({ work }) => {
+	git(work, ['checkout', '-B', 'bump', 'main']);
+	git(work, ['push', 'origin', 'bump']);
+	const r = runGuard(work, 'bump');
+	assert(r.code === 0, `expected safe, got ${r.code}: ${r.out}`);
+});
+
+test('main advanced while the bot branch stayed put', ({ work }) => {
+	git(work, ['checkout', '-B', 'bump', 'main']);
+	commit(work, { file: 'v.txt', message: 'chore(deps): update oxfmt to 0.62.0', author: 'bot' });
+	git(work, ['push', 'origin', 'bump']);
+	git(work, ['checkout', 'main']);
+	commit(work, { file: 'other.txt', message: 'unrelated main work', author: 'human' });
+	git(work, ['push', 'origin', 'main']);
+	const r = runGuard(work, 'bump');
+	assert(r.code === 0, `expected safe (merge-base, not ancestry), got ${r.code}: ${r.out}`);
+});
+
+test('human pushed a commit on top of the bot commit', ({ work }) => {
+	git(work, ['checkout', '-B', 'bump', 'main']);
+	commit(work, { file: 'v.txt', message: 'chore(deps): update oxfmt to 0.62.0', author: 'bot' });
+	commit(work, { file: 'fix.rs', message: 'fix(compiler): oxc 0.143 AST migration', author: 'human' });
+	git(work, ['push', 'origin', 'bump']);
+	const r = runGuard(work, 'bump');
+	assert(r.code === 3, `expected blocked, got ${r.code}: ${r.out}`);
+	assert(r.out.includes('2 commits'), `expected the count in the reason: ${r.out}`);
+});
+
+// The exact state the next cron run sees after a human rescued their work.
+test('human work rebased onto a newly regenerated bot commit', ({ work }) => {
+	git(work, ['checkout', '-B', 'bump', 'main']);
+	commit(work, { file: 'v.txt', message: 'chore(deps): update oxfmt to 0.62.0', author: 'bot' });
+	const oldBotCommit = git(work, ['rev-parse', 'HEAD']);
+	for (let i = 1; i <= 15; i++) {
+		commit(work, { file: `hand-${i}.rs`, message: `fix(compiler): burn-down step ${i}`, author: 'human' });
+	}
+	git(work, ['push', 'origin', 'bump']);
+
+	// The bot regenerates its commit from main; the human rebases on top of it.
+	git(work, ['checkout', '-B', 'regen', 'main']);
+	commit(work, { file: 'v.txt', message: 'chore(deps): update oxfmt to 0.63.0', author: 'bot' });
+	git(work, ['checkout', 'bump']);
+	git(work, ['rebase', '--onto', 'regen', oldBotCommit, 'bump']);
+	git(work, ['push', '--force', 'origin', 'bump']);
+	assert(
+		git(work, ['rev-list', '--count', `main..bump`]) === '16',
+		'expected 16 commits on the rebased branch',
+	);
+
+	const r = runGuard(work, 'bump');
+	assert(r.code === 3, `expected blocked after rebase, got ${r.code}: ${r.out}`);
+});
+
+test('single commit authored by the bot but amended by a human', ({ work }) => {
+	git(work, ['checkout', '-B', 'bump', 'main']);
+	commit(work, { file: 'v.txt', message: 'chore(deps): update oxfmt to 0.62.0', author: 'bot' });
+	writeFileSync(join(work, 'v.txt'), 'hand-edited\n');
+	git(work, ['add', 'v.txt']);
+	git(work, ['commit', '--amend', '--no-edit'], {
+		GIT_COMMITTER_NAME: HUMAN_NAME,
+		GIT_COMMITTER_EMAIL: HUMAN_EMAIL,
+	});
+	git(work, ['push', '--force', 'origin', 'bump']);
+	const r = runGuard(work, 'bump');
+	assert(r.code === 3, `expected blocked on committer mismatch, got ${r.code}: ${r.out}`);
+});
+
+test('single commit written entirely by a human', ({ work }) => {
+	git(work, ['checkout', '-B', 'bump', 'main']);
+	commit(work, { file: 'v.txt', message: 'chore(deps): update oxfmt to 0.62.0', author: 'human' });
+	git(work, ['push', 'origin', 'bump']);
+	const r = runGuard(work, 'bump');
+	assert(r.code === 3, `expected blocked on author mismatch, got ${r.code}: ${r.out}`);
+});
+
+function assert(cond, msg) {
+	if (!cond) {
+		throw new Error(msg);
+	}
+}
+
+let failed = 0;
+for (const { name, fn } of cases) {
+	const repo = makeRepo();
+	try {
+		fn(repo);
+		console.log(`ok   ${name}`);
+	} catch (err) {
+		failed++;
+		console.error(`FAIL ${name}\n     ${err.message}`);
+	} finally {
+		rmSync(repo.root, { recursive: true, force: true });
+	}
+}
+
+if (failed > 0) {
+	console.error(`\n${failed}/${cases.length} bot-branch-guard tests failed`);
+	process.exit(1);
+}
+console.log(`\n${cases.length}/${cases.length} bot-branch-guard tests passed`);


### PR DESCRIPTION
The auto-update workflows regenerate their PR branch from scratch (`git checkout -B` + one
commit) and then `git push --force`. The branch name is derived from the target version, so
every re-run for the *same* version targets the *same* branch. When a human has pushed work
to the open PR, that force-push destroys it — which is what happened to #2249 (`chore(deps):
update oxfmt to 0.62.0`): the daily 05:47 UTC cron wiped 15 hand-written commits (an oxc
0.143 AST migration plus a codegen burn-down) off the remote. They survived only because an
agent still held them in a local worktree.

## The detection

New pre-flight `scripts/ci/bot-branch-guard.mjs`, run **before** the branch is rebuilt. It
inspects the *remote* branch and reports `safe` only for the exact shape the bot leaves
behind. Take `merge-base(origin/main, origin/<branch>)` and list every commit on the branch
since it; safe requires

1. **at most one such commit**, and
2. that commit is **authored AND committed by a known bot identity**.

Anything else is `blocked` — and anything unreadable (no merge-base, unresolvable base ref,
failing `git log`) is blocked too: the guard fails closed, since the cost of a false block is
a skipped daily bump and the cost of a false pass is destroyed work.

Exit codes: `0` safe, `3` blocked, `1` error.

### Why it survives the rebase-onto-a-new-bot-commit case

That is the state the *next* cron run sees, and it is the one that defeats the obvious
detectors. After a human rescues their work, the branch is `<new bot commit>` + N human
commits — the tip's parentage looks freshly regenerated, and the tip is not the bot's
previous commit either. So:

- "is the tip authored by the bot?" → **passes**, and clobbers.
- "does the tip equal the commit we pushed last time?" → the bot has no memory of that commit
  across runs, and after a rebase it no longer exists on the branch anyway.
- **count since merge-base with `main`** → `N + 1 > 1`. The rebase moved the commits onto a
  new base but did not reduce their number, and the merge-base with `main` is unchanged by
  the rebase. This is the signal that holds.

The author/committer check is the second, independent signal: it catches an amended or
hand-rewritten *single* commit, which the count alone would pass. `merge-base` (not
`origin/main..branch`, not ancestry) is used so a `main` that advanced after the branch was
cut does not read as downstream work.

When blocked, the workflow leaves the branch completely alone and instead writes a job
summary and posts one PR comment per (branch, version) — the marker `<!-- auto-update-guard:… -->`
keeps the daily cron from spamming the thread.

## Verification

`scripts/ci/test-bot-branch-guard.mjs` (wired into CI as `pnpm run test:bot-branch-guard`)
builds real git repositories — a bare "origin" plus a working clone — and replays the actual
histories, offline, in about a second. It runs as its own CI job on every PR. 10 cases:

| case | expected |
|---|---|
| remote branch does not exist yet | safe |
| branch holds only the bot commit | safe |
| branch is identical to `main` | safe |
| `main` advanced while the bot branch stayed put | safe |
| human pushed a commit on top of the bot commit | blocked |
| **human work rebased onto a newly regenerated bot commit** (the #2249 state, 16 commits) | blocked |
| single commit authored by the bot but amended by a human | blocked |
| single commit written entirely by a human | blocked |
| shallow (`fetch-depth: 1`) CI clone, bot-only branch | safe |
| shallow CI clone, downstream commits present | blocked |

The last two matter because `actions/checkout` defaults to `fetch-depth: 1`. The guard fetches
both refs at `--depth=200` when the clone is *already* shallow (never when it is not — that
would shallowify the checkout the workflow is about to push from) and falls back to a single
`--unshallow` if a merge-base still cannot be found, so a shallow runner cannot silently block
every bump forever.

## Workflows audited

`git grep -n 'push --force' .github/` plus a read of every workflow that writes to a branch.

| workflow | verdict |
|---|---|
| `auto-update-oxfmt.yml` | **vulnerable, fixed.** Branch `chore/update-oxfmt-<version>`; force-pushes at what was line 234. This is the one that hit #2249. Guard added. |
| `auto-update-svelte.yml` | **vulnerable, fixed.** Same shape, branch `chore/upgrade-svelte-<version>`. Worse in effect: its own PR body tells a human to push fixture regeneration and regression fixes to the branch, so downstream commits are the *expected* state. Guard added. |
| `auto-update-submodules.yml` | **vulnerable, fixed** — and the worst of the three: its branch (`chore/update-<name>`) carries no version, so *every* weekly run of the matrix targets the same branch regardless of what changed. Guard added. |
| `changeset.yml` | safe — read-only; diffs against the merge-base, never pushes. |
| `release.yml` | safe — pushes are the changesets action's own release branch; no `--force`, and no human is expected to push to it. |
| every other workflow under `.github/workflows/` | safe — no `git push --force` anywhere else (`git grep` returns only the three hits above). |

## Changeset

None. `.github/workflows/changeset.yml:48` requires one only for titles matching
`^(fix|feat)(\(...\))?!?:`. This touches no published package — only workflows and CI
scripts — so the PR is titled `chore(ci):` and is exempt by that rule rather than by the
`skip-changeset` label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
