### PR TITLE
fix(compiler): route 12 phase-3 delimiter scans through the shared lexer

### DIFF
--- a/.changeset/phase3-scans-shared-lexer.md
+++ b/.changeset/phase3-scans-shared-lexer.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/compiler": patch
+---
+
+Route the Phase-3 destructuring and SSR-helper delimiter scans through the shared JS lexer, so a bracket, comma, colon or `=` inside a comment, string, template or regex literal no longer moves a depth counter

--- a/crates/rsvelte_core/src/compiler/phases/1_parse/read/expression.rs
+++ b/crates/rsvelte_core/src/compiler/phases/1_parse/read/expression.rs
@@ -7058,16 +7058,14 @@ impl CommentAttacher<'_> {
                 continue;
             }
             match value {
-                Value::Object(_) => {
-                    if is_estree_node(value) {
-                        self.visit(
-                            value,
-                            Some(ParentInfo {
-                                end,
-                                is_last_in_body: false,
-                            }),
-                        );
-                    }
+                Value::Object(_) if is_estree_node(value) => {
+                    self.visit(
+                        value,
+                        Some(ParentInfo {
+                            end,
+                            is_last_in_body: false,
+                        }),
+                    );
                 }
                 Value::Array(items) => {
                     let last = items.len().saturating_sub(1);

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/destructure_transforms.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/destructure_transforms.rs
@@ -6,6 +6,7 @@ use super::rune_transforms::{
     find_derived_property_colon, split_derived_array_elements, split_derived_object_properties,
 };
 use crate::compiler::phases::phase3_transform::js_ast::to_oxc::SINGLE_TARGET_DESTRUCTURE_SEQUENCE_MARKER;
+use crate::compiler::phases::phase3_transform::shared::js_scan::{code_bytes, code_bytes_from};
 use oxc_allocator::Allocator;
 use oxc_ast::ast::{Expression, Statement};
 use oxc_parser::{ParseOptions, Parser};
@@ -452,12 +453,13 @@ pub(super) fn find_and_transform_one_destructure(
 /// `{` of a function body, …) leaves the inner pattern eligible for the
 /// usual destructure-assignment rewrite.
 fn is_inside_enclosing_pattern(statement: &str, pattern_open_byte: usize) -> bool {
-    let bytes = statement.as_bytes();
+    // A backwards walk cannot tell code from a comment or string, so the
+    // lexical state is established by a forward pass first.
+    let code: Vec<(usize, u8)> = code_bytes(statement.as_bytes())
+        .take_while(|&(i, _)| i < pattern_open_byte)
+        .collect();
     let mut depth: i32 = 0;
-    let mut i = pattern_open_byte;
-    while i > 0 {
-        i -= 1;
-        let b = bytes[i];
+    for &(i, b) in code.iter().rev() {
         match b {
             b'}' | b']' => depth += 1,
             b'{' | b'[' => {
@@ -583,44 +585,23 @@ pub(super) fn extract_destructure_targets(pattern: &str) -> Vec<String> {
 /// Split a string on top-level commas (not inside brackets, parens, or strings).
 pub(super) fn split_on_commas(s: &str) -> Vec<String> {
     let mut parts = Vec::new();
-    let mut current = String::new();
     let mut depth = 0;
-    let mut in_string: Option<char> = None;
+    let mut start = 0usize;
 
-    for c in s.chars() {
-        if in_string.is_some() {
-            current.push(c);
-            if Some(c) == in_string {
-                in_string = None;
-            }
-            continue;
-        }
-
+    for (i, c) in code_bytes(s.as_bytes()) {
         match c {
-            '\'' | '"' | '`' => {
-                in_string = Some(c);
-                current.push(c);
+            b'(' | b'[' | b'{' => depth += 1,
+            b')' | b']' | b'}' => depth -= 1,
+            b',' if depth == 0 => {
+                parts.push(s[start..i].to_string());
+                start = i + 1;
             }
-            '(' | '[' | '{' => {
-                depth += 1;
-                current.push(c);
-            }
-            ')' | ']' | '}' => {
-                depth -= 1;
-                current.push(c);
-            }
-            ',' if depth == 0 => {
-                parts.push(current.clone());
-                current.clear();
-            }
-            _ => {
-                current.push(c);
-            }
+            _ => {}
         }
     }
 
-    if !current.is_empty() {
-        parts.push(current);
+    if start < s.len() {
+        parts.push(s[start..].to_string());
     }
 
     parts
@@ -629,21 +610,12 @@ pub(super) fn split_on_commas(s: &str) -> Vec<String> {
 /// Find the position of a top-level colon in a string (not inside brackets or strings).
 pub(super) fn find_top_level_colon(s: &str) -> Option<usize> {
     let mut depth = 0;
-    let mut in_string: Option<char> = None;
 
-    for (i, c) in s.char_indices() {
-        if in_string.is_some() {
-            if Some(c) == in_string {
-                in_string = None;
-            }
-            continue;
-        }
-
+    for (i, c) in code_bytes(s.as_bytes()) {
         match c {
-            '\'' | '"' | '`' => in_string = Some(c),
-            '(' | '[' | '{' => depth += 1,
-            ')' | ']' | '}' => depth -= 1,
-            ':' if depth == 0 => return Some(i),
+            b'(' | b'[' | b'{' => depth += 1,
+            b')' | b']' | b'}' => depth -= 1,
+            b':' if depth == 0 => return Some(i),
             _ => {}
         }
     }
@@ -653,36 +625,21 @@ pub(super) fn find_top_level_colon(s: &str) -> Option<usize> {
 
 /// Find the position of a top-level `=` in a string (not `==` or `===`).
 pub(super) fn find_top_level_equals(s: &str) -> Option<usize> {
+    let bytes = s.as_bytes();
     let mut depth = 0;
-    let mut in_string: Option<char> = None;
-    let mut prev: Option<char> = None;
-    let mut iter = s.char_indices().peekable();
+    let mut prev: Option<u8> = None;
 
-    while let Some((i, c)) = iter.next() {
-        if in_string.is_some() {
-            if Some(c) == in_string {
-                in_string = None;
-            }
-            prev = Some(c);
-            continue;
-        }
-
+    for (i, c) in code_bytes(bytes) {
         match c {
-            '\'' | '"' | '`' => in_string = Some(c),
-            '(' | '[' | '{' => depth += 1,
-            ')' | ']' | '}' => depth -= 1,
-            '=' if depth == 0 => {
-                // Make sure it's not == or ===
-                if iter.peek().map(|&(_, next)| next) == Some('=') {
-                    prev = Some(c);
-                    continue;
+            b'(' | b'[' | b'{' => depth += 1,
+            b')' | b']' | b'}' => depth -= 1,
+            b'=' if depth == 0 => {
+                // Not `==`/`===`, and not the tail of `!=` / `<=` / `>=`.
+                if bytes.get(i + 1) != Some(&b'=')
+                    && !matches!(prev, Some(b'!') | Some(b'<') | Some(b'>'))
+                {
+                    return Some(i);
                 }
-                // Make sure it's not != or <=, >=
-                if matches!(prev, Some('!') | Some('<') | Some('>')) {
-                    prev = Some(c);
-                    continue;
-                }
-                return Some(i);
             }
             _ => {}
         }
@@ -1073,67 +1030,26 @@ pub(super) fn skip_balanced_braces(bytes: &[u8], start: usize) -> usize {
 /// Skip balanced brackets from start (which should be the opening bracket).
 /// Returns position after the closing bracket.
 pub(super) fn skip_balanced(bytes: &[u8], start: usize, open: u8, close: u8) -> usize {
-    let len = bytes.len();
     let mut depth = 0;
-    let mut i = start;
-    let mut in_string: Option<u8> = None;
-
-    while i < len {
-        if let Some(q) = in_string {
-            if bytes[i] == b'\\' {
-                i += 2;
-                continue;
-            }
-            if bytes[i] == q {
-                in_string = None;
-            }
-            i += 1;
-            continue;
-        }
-        if bytes[i] == b'\'' || bytes[i] == b'"' || bytes[i] == b'`' {
-            in_string = Some(bytes[i]);
-            i += 1;
-            continue;
-        }
-        if bytes[i] == open {
+    for (i, c) in code_bytes_from(bytes, start) {
+        if c == open {
             depth += 1;
-        } else if bytes[i] == close {
+        } else if c == close {
             depth -= 1;
             if depth == 0 {
                 return i + 1;
             }
         }
-        i += 1;
     }
-    len
+    bytes.len()
 }
 
 /// Skip an expression (arrow body without braces). Ends at a `,`, `)`, `]`, or `}`
 /// at depth 0, or at end of input.
 pub(super) fn skip_expression(bytes: &[u8], start: usize) -> usize {
-    let len = bytes.len();
     let mut depth = 0usize;
-    let mut i = start;
-    let mut in_string: Option<u8> = None;
-
-    while i < len {
-        if let Some(q) = in_string {
-            if bytes[i] == b'\\' {
-                i += 2;
-                continue;
-            }
-            if bytes[i] == q {
-                in_string = None;
-            }
-            i += 1;
-            continue;
-        }
-        if bytes[i] == b'\'' || bytes[i] == b'"' || bytes[i] == b'`' {
-            in_string = Some(bytes[i]);
-            i += 1;
-            continue;
-        }
-        match bytes[i] {
+    for (i, c) in code_bytes_from(bytes, start) {
+        match c {
             b'(' | b'[' | b'{' => {
                 depth += 1;
             }
@@ -1148,9 +1064,8 @@ pub(super) fn skip_expression(bytes: &[u8], start: usize) -> usize {
             }
             _ => {}
         }
-        i += 1;
     }
-    len
+    bytes.len()
 }
 
 /// Check if a string expression is a "simple" expression that doesn't need thunk wrapping.
@@ -1658,5 +1573,38 @@ mod non_ascii_tests {
         // `!=` is not a top-level assignment; the preceding-char check must run
         // against the correct char even when a multi-byte char sits earlier.
         assert_eq!(find_top_level_equals("café != x"), None);
+    }
+
+    #[test]
+    fn scans_ignore_delimiters_in_comments_and_strings() {
+        use super::{
+            extract_destructure_targets, find_top_level_colon, skip_balanced, skip_expression,
+            split_on_commas,
+        };
+
+        // A comma in a comment or a string is text, not a separator.
+        assert_eq!(split_on_commas("a /* x, y */, b").len(), 2);
+        assert_eq!(split_on_commas("a: ',', b").len(), 2);
+        assert_eq!(split_on_commas("a // one, two\n, b").len(), 2);
+
+        // A colon in a comment or a string does not rename a property.
+        assert_eq!(find_top_level_colon("a /* k: v */"), None);
+        assert_eq!(find_top_level_colon("a = ':'"), None);
+
+        // A brace in a comment or a string does not close the block.
+        let src = b"{ /* } */ a }rest";
+        assert_eq!(skip_balanced(src, 0, b'{', b'}'), src.len() - 4);
+        let src = b"{ a = '}' }rest";
+        assert_eq!(skip_balanced(src, 0, b'{', b'}'), src.len() - 4);
+
+        // A depth-0 comma in a comment does not end the arrow body.
+        let src = b"a /* , */ + b, c";
+        assert_eq!(skip_expression(src, 0), 13);
+
+        // The whole pattern still yields the right targets when commented.
+        assert_eq!(
+            extract_destructure_targets("{ a /* , b */, c }"),
+            vec!["a".to_string(), "c".to_string()]
+        );
     }
 }

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/destructure_transforms.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/destructure_transforms.rs
@@ -633,13 +633,12 @@ pub(super) fn find_top_level_equals(s: &str) -> Option<usize> {
         match c {
             b'(' | b'[' | b'{' => depth += 1,
             b')' | b']' | b'}' => depth -= 1,
-            b'=' if depth == 0 => {
-                // Not `==`/`===`, and not the tail of `!=` / `<=` / `>=`.
-                if bytes.get(i + 1) != Some(&b'=')
-                    && !matches!(prev, Some(b'!') | Some(b'<') | Some(b'>'))
-                {
-                    return Some(i);
-                }
+            // Not `==`/`===`, and not the tail of `!=` / `<=` / `>=`.
+            b'=' if depth == 0
+                && bytes.get(i + 1) != Some(&b'=')
+                && !matches!(prev, Some(b'!') | Some(b'<') | Some(b'>')) =>
+            {
+                return Some(i);
             }
             _ => {}
         }

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/helpers.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/helpers.rs
@@ -5,6 +5,9 @@
 //! to keep the visitor files focused on their specific AST node handling.
 
 use crate::ast::template::Script;
+use crate::compiler::phases::phase3_transform::shared::js_scan::{
+    code_bytes, code_bytes_from, skip_opaque,
+};
 use memchr::memmem;
 use rustc_hash::FxHashMap;
 use std::fmt::Write as _;
@@ -364,24 +367,17 @@ pub(crate) fn skip_string_literal(bytes: &[u8], start: usize) -> usize {
 /// Skip a matched brace pair `{...}` starting at position of `{`.
 fn skip_braces(bytes: &[u8], start: usize) -> usize {
     let mut depth = 1i32;
-    let mut i = start + 1;
-    let len = bytes.len();
-
-    while i < len && depth > 0 {
-        let c = bytes[i];
-        if matches!(c, b'\'' | b'"' | b'`') {
-            i = skip_string_literal(bytes, i);
-            continue;
-        }
+    for (i, c) in code_bytes_from(bytes, start + 1) {
         if c == b'{' {
             depth += 1;
         } else if c == b'}' {
             depth -= 1;
+            if depth == 0 {
+                return i + 1;
+            }
         }
-        i += 1;
     }
-
-    i
+    bytes.len()
 }
 
 /// Transform `await expr` patterns inside an expression to use `$.save()`.
@@ -659,9 +655,8 @@ pub(crate) fn is_valid_js_identifier(name: &str) -> bool {
 fn extract_param_default(rest: &str) -> Option<String> {
     let bytes = rest.as_bytes();
     let mut depth = 0i32;
-    let mut i = 0;
-    while i < bytes.len() {
-        match bytes[i] {
+    for (i, c) in code_bytes(bytes) {
+        match c {
             b'(' | b'[' | b'{' | b'<' => depth += 1,
             b')' | b']' | b'}' | b'>' => depth -= 1,
             b'=' if depth == 0 => {
@@ -674,7 +669,6 @@ fn extract_param_default(rest: &str) -> Option<String> {
             }
             _ => {}
         }
-        i += 1;
     }
     None
 }
@@ -684,14 +678,14 @@ pub(crate) fn strip_ts_type_annotation(param: &str) -> String {
 
     // Handle destructured parameters: { ... }: Type or [ ... ]: Type
     if trimmed.starts_with('{') || trimmed.starts_with('[') {
-        let close_char = if trimmed.starts_with('{') { '}' } else { ']' };
+        let close_char = if trimmed.starts_with('{') { b'}' } else { b']' };
         // Find the matching closing bracket
         let mut depth = 0;
         let mut close_pos = None;
-        for (i, c) in trimmed.char_indices() {
+        for (i, c) in code_bytes(trimmed.as_bytes()) {
             match c {
-                '{' | '[' => depth += 1,
-                '}' | ']' if c == close_char => {
+                b'{' | b'[' => depth += 1,
+                b'}' | b']' if c == close_char => {
                     depth -= 1;
                     if depth == 0 {
                         close_pos = Some(i);
@@ -1122,17 +1116,13 @@ pub(crate) fn try_evaluate_with_constants(
 /// Find the index of a binary + operator (not inside quotes or after another operator).
 fn find_binary_plus(expr: &str) -> Option<usize> {
     let bytes = expr.as_bytes();
-    let mut in_single_quote = false;
-    let mut in_double_quote = false;
     let mut paren_depth = 0;
 
-    for i in 0..bytes.len() {
-        match bytes[i] {
-            b'\'' if !in_double_quote => in_single_quote = !in_single_quote,
-            b'"' if !in_single_quote => in_double_quote = !in_double_quote,
-            b'(' if !in_single_quote && !in_double_quote => paren_depth += 1,
-            b')' if !in_single_quote && !in_double_quote => paren_depth -= 1,
-            b'+' if !in_single_quote && !in_double_quote && paren_depth == 0 => {
+    for (i, c) in code_bytes(bytes) {
+        match c {
+            b'(' => paren_depth += 1,
+            b')' => paren_depth -= 1,
+            b'+' if paren_depth == 0 => {
                 // Make sure it's a binary +, not unary
                 // Check that there's a non-whitespace token before it
                 let before = expr[..i].trim_end();
@@ -1160,17 +1150,13 @@ fn find_binary_plus(expr: &str) -> Option<usize> {
 /// Find the index of a binary - operator (not unary minus).
 fn find_binary_minus(expr: &str) -> Option<usize> {
     let bytes = expr.as_bytes();
-    let mut in_single_quote = false;
-    let mut in_double_quote = false;
     let mut paren_depth = 0;
 
-    for i in 0..bytes.len() {
-        match bytes[i] {
-            b'\'' if !in_double_quote => in_single_quote = !in_single_quote,
-            b'"' if !in_single_quote => in_double_quote = !in_double_quote,
-            b'(' if !in_single_quote && !in_double_quote => paren_depth += 1,
-            b')' if !in_single_quote && !in_double_quote => paren_depth -= 1,
-            b'-' if !in_single_quote && !in_double_quote && paren_depth == 0 => {
+    for (i, c) in code_bytes(bytes) {
+        match c {
+            b'(' => paren_depth += 1,
+            b')' => paren_depth -= 1,
+            b'-' if paren_depth == 0 => {
                 let before = expr[..i].trim_end();
                 if !before.is_empty()
                     && !before.ends_with('+')
@@ -1220,26 +1206,10 @@ pub(crate) fn extract_rune_inner(value: &str, prefix: &str) -> Option<String> {
     let after_prefix = &trimmed[prefix.len()..];
     // Find matching closing paren
     let mut depth = 1i32;
-    let mut in_string = false;
-    let mut string_char = ' ';
-    for (i, c) in after_prefix.char_indices() {
-        if (c == '"' || c == '\'' || c == '`')
-            && (i == 0 || after_prefix.as_bytes()[i - 1] != b'\\')
-        {
-            if !in_string {
-                in_string = true;
-                string_char = c;
-            } else if c == string_char {
-                in_string = false;
-            }
-            continue;
-        }
-        if in_string {
-            continue;
-        }
+    for (i, c) in code_bytes(after_prefix.as_bytes()) {
         match c {
-            '(' | '[' | '{' => depth += 1,
-            ')' | ']' | '}' => {
+            b'(' | b'[' | b'{' => depth += 1,
+            b')' | b']' | b'}' => {
                 depth -= 1;
                 if depth == 0 {
                     let inner = after_prefix[..i].trim().to_string();
@@ -1417,20 +1387,26 @@ fn split_declarators(s: &str) -> Vec<&str> {
     let mut i = 0;
     let len = bytes.len();
 
+    let mut prev: Option<u8> = None;
     while i < len {
+        // A `,` or a bracket inside a comment or a regex literal is text; the
+        // template-literal branch below is kept because `skip_opaque` treats an
+        // interpolation as part of the opaque run.
+        if bytes[i] != b'`'
+            && let Some((next, is_comment)) = skip_opaque(bytes, i, prev)
+        {
+            if !is_comment {
+                prev = Some(b'x');
+            }
+            i = next;
+            continue;
+        }
+        if !bytes[i].is_ascii_whitespace() {
+            prev = Some(bytes[i]);
+        }
         match bytes[i] {
             b'(' | b'[' | b'{' => depth += 1,
             b')' | b']' | b'}' => depth -= 1,
-            b'\'' | b'"' => {
-                let quote = bytes[i];
-                i += 1;
-                while i < len && bytes[i] != quote {
-                    if bytes[i] == b'\\' {
-                        i += 1; // skip escaped char
-                    }
-                    i += 1;
-                }
-            }
             b'`' => {
                 // Template literal - skip to matching backtick
                 i += 1;
@@ -1759,5 +1735,37 @@ mod ts_strip_tests {
             strip_ts_type_annotation("[a, b]: number[] = []"),
             "[a, b] = []"
         );
+    }
+}
+
+#[cfg(test)]
+mod js_scan_tests {
+    use super::{extract_rune_inner, split_declarators, strip_ts_type_annotation};
+
+    #[test]
+    fn scans_ignore_delimiters_in_comments_and_strings() {
+        // A `}` in a comment or a string does not close the destructured pattern.
+        assert_eq!(
+            strip_ts_type_annotation("{ a /* } */, b }: Props"),
+            "{ a /* } */, b }"
+        );
+        assert_eq!(
+            strip_ts_type_annotation("{ a = '}' }: Props"),
+            "{ a = '}' }"
+        );
+
+        // A `)` in a comment or a string does not close the rune call.
+        assert_eq!(
+            extract_rune_inner("$state(/* ) */ 1)", "$state("),
+            Some("/* ) */ 1".to_string())
+        );
+        assert_eq!(
+            extract_rune_inner("$state(')')", "$state("),
+            Some("')'".to_string())
+        );
+
+        // A `,` in a comment does not split the declarator list.
+        assert_eq!(split_declarators("a = 1 /* , */ , b = 2").len(), 2);
+        assert_eq!(split_declarators("a = 1 // x, y\n, b = 2").len(), 2);
     }
 }

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/shared/js_scan.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/shared/js_scan.rs
@@ -6,6 +6,56 @@
 //! spliced an injected `)` into the comment body (#907, #2253). Every such
 //! scanner steps over opaque runs with `skip_opaque` first.
 
+/// Iterator over the *code* bytes of `bytes`: every byte that is not inside a
+/// string, template literal, regex literal or comment, as `(byte index, byte)`.
+///
+/// Multi-byte UTF-8 sequences are yielded byte by byte; every continuation byte
+/// is `>= 0x80`, so a scanner matching ASCII delimiters is unaffected and the
+/// indices stay valid `str` boundaries at the delimiters it does match.
+pub(crate) fn code_bytes(bytes: &[u8]) -> CodeBytes<'_> {
+    code_bytes_from(bytes, 0)
+}
+
+/// `code_bytes`, resuming at `start`. The byte at `start` is treated as the
+/// first byte of a fresh token, so a `/` there reads as a regex literal.
+pub(crate) fn code_bytes_from(bytes: &[u8], start: usize) -> CodeBytes<'_> {
+    CodeBytes {
+        bytes,
+        i: start.min(bytes.len()),
+        prev: None,
+    }
+}
+
+pub(crate) struct CodeBytes<'a> {
+    bytes: &'a [u8],
+    i: usize,
+    prev: Option<u8>,
+}
+
+impl Iterator for CodeBytes<'_> {
+    type Item = (usize, u8);
+
+    fn next(&mut self) -> Option<(usize, u8)> {
+        while self.i < self.bytes.len() {
+            if let Some((next, is_comment)) = skip_opaque(self.bytes, self.i, self.prev) {
+                if !is_comment {
+                    self.prev = Some(b'x');
+                }
+                self.i = next;
+                continue;
+            }
+            let c = self.bytes[self.i];
+            let at = self.i;
+            self.i += 1;
+            if !c.is_ascii_whitespace() {
+                self.prev = Some(c);
+            }
+            return Some((at, c));
+        }
+        None
+    }
+}
+
 /// Does a `/` following `prev` (the last significant code byte) open a regex
 /// literal rather than a division?
 pub(crate) fn slash_starts_regex(prev: Option<u8>) -> bool {


### PR DESCRIPTION
First batch of #2357. A robustness sweep only — **output must not change**.

## What changed

`shared/js_scan.rs` gains a `code_bytes` / `code_bytes_from` iterator: it drives
`skip_opaque` and yields only the bytes that are *code*, i.e. never inside a string,
template literal, regex literal, `//` or `/* */` comment. That turns each hand-rolled
scanner into an ordinary `for (i, c) in code_bytes(...)` loop instead of a private,
usually incomplete, re-implementation of JS lexing.

### `client/destructure_transforms.rs` (18 depth sites → lexer)

- `split_on_commas` — a `,` in a comment or string no longer splits a declarator
  (this is the #2347 shape, one level down).
- `find_top_level_colon`, `find_top_level_equals`
- `skip_balanced` / `skip_balanced_braces`, `skip_expression`
- `is_inside_enclosing_pattern` — a *backwards* walk, so it now takes its lexical
  state from a forward `code_bytes` pass and then reverses; a backwards scan cannot
  establish that state on its own.

### `server/helpers.rs` (30 depth sites → lexer)

- `skip_braces`, `extract_param_default`, `strip_ts_type_annotation`
- `find_binary_plus`, `find_binary_minus` (these only tracked `'` and `"` — no
  templates, no comments, no escapes)
- `extract_rune_inner`
- `split_declarators` — comment and regex runs are now skipped via `skip_opaque`;
  its own template-literal branch is **kept** because `skip_opaque` treats a
  `` `…${…}…` `` run as fully opaque, while this scanner deliberately descends into
  the interpolation. Converting it wholesale would have changed behaviour.

## What I did not convert, and why

- `client/destructure_transforms.rs::find_and_transform_one_destructure` and its
  helper `find_matching_open_bracket` — both are indexed by **char** position
  (`Vec<char>` plus a char→byte offset table shared across the function), so they
  cannot take byte indices from `code_bytes` without converting the whole function.
  Left for a follow-up so this batch stays mechanical.
- `client/destructure_transforms.rs::code_contains_await` and
  `server/helpers.rs::split_declarators`'s template branch — both intentionally
  descend into `${…}` interpolations, which `skip_opaque` does not model. Routing
  them through it would be a behaviour change, not a fix.
- `shared/async_body.rs` (26 sites) — inspected, **not** blind: its main scanner
  `split_top_level_statements` already skips strings, both comment kinds and regex
  literals via its local `skip_string` / `skip_regex` / `regex_allowed_before`. The
  issue's "no comment state" column is a `grep` proxy and is a false positive here.
  The genuinely blind scanners left in it are `has_await_at_depth` and
  `is_function_var_declaration`.
- `client/state_transforms.rs` (40 sites) and `server/transform_legacy.rs` (62
  sites) — not reached in this batch.

## How I established output did not change

- Unit tests added per file, each exercising a delimiter inside a comment **and**
  inside a string — the two shapes this class breaks on:
  `destructure_transforms::non_ascii_tests::scans_ignore_delimiters_in_comments_and_strings`
  and `server::helpers::js_scan_tests::scans_ignore_delimiters_in_comments_and_strings`.
- `cargo test --release -p rsvelte_core --test runtime --test ssr` plus the `--lib`
  tests for both modules.
- The corpus ratchets are the real evidence: `client` and `server` are at **0** and
  `client-dev` at **20** on `main`, so any movement in CI's corpus job means the
  sweep changed behaviour. The expected diff is empty.

Refs #2357 — this is a batch, the epic stays open.