### PR TITLE
fix(compiler): stop contracting plain `$state` assignments in server modules (#2308)

### DIFF
--- a/.changeset/module-server-state-assignment.md
+++ b/.changeset/module-server-state-assignment.md
@@ -1,0 +1,5 @@
+---
+'@rsvelte/compiler': patch
+---
+
+fix(compiler): stop contracting plain `$state` assignments in server modules

--- a/compatibility/known-failures.md
+++ b/compatibility/known-failures.md
@@ -47,13 +47,16 @@ and #2343 (the spurious `$.set` proxy flag for a `BinaryExpression`). #2307
 (spurious `/* @__PURE__ */`) is comment-only, so the AST-structural comparator
 does not see it at all; it burns down with the esrap comment epic (#2336).
 
-## Server (`known-failures.server.json`, 1 entry)
+## Server (`known-failures.server.json`, 0 entries)
 
-The one entry is #2308, from the `runed` / `svelte-toolbelt` enrolment:
-`watch.test.svelte.ts` writes `runs = runs + 1` and rsvelte **contracts** it to
+The last entry was #2308, from the `runed` / `svelte-toolbelt` enrolment:
+`watch.test.svelte.ts` writes `runs = runs + 1` and rsvelte **contracted** it to
 `runs += 1` (that direction, not the reverse). The `.svelte.(js|ts)` server path
-round-trips through the client transform, which rewrites the assignment, and the
-server printer has no way back to the source form.
+round-trips through the client transform, which rewrote the assignment, so the
+operator was already gone before the server printer ran. Fixed by lowering
+`$state` to its bare initializer *before* the client transform, so state
+bindings on this path are never signal-wrapped and nothing has to be
+reconstructed.
 
 Its previous sole entry was the SSR half of the same #2031 divergence (the extra
 `<!---->` the dynamic form pushes), fixed by the same change.

--- a/compatibility/known-failures.server.json
+++ b/compatibility/known-failures.server.json
@@ -1,3 +1,1 @@
-[
-	"runed/packages/runed/src/lib/utilities/watch/watch.test.svelte.ts"
-]
+[]

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/mod.rs
@@ -109,6 +109,17 @@ pub fn transform_server_module(
     // (mirrors the instance-script path + upstream server CallExpression visitor).
     let source_without_effects = source_without_effects.replace("$effect.tracking()", "false");
 
+    // Lower `$state` to its bare initializer BEFORE the client transform, the way
+    // upstream's server `VariableDeclaration` visitor does. Otherwise the client
+    // transform signal-wraps the binding and collapses both `x = x + 1` and
+    // `x += 1` to the same `$.set(x, $.get(x) + 1)`, losing the operator that
+    // `post_process_for_server` would have to restore.
+    let source_without_effects = rune_call_ast::transform_rune_calls_combined(
+        &source_without_effects,
+        &["$state(", "$state.raw(", "$state.eager("],
+    )
+    .unwrap_or(source_without_effects);
+
     // Transform rune calls using the same infrastructure as client modules.
     let transformed =
         super::client::transform_module_source_for_module(&source_without_effects, analysis, false);

--- a/crates/rsvelte_core/tests/module_server_state_assignment_2308.rs
+++ b/crates/rsvelte_core/tests/module_server_state_assignment_2308.rs
@@ -65,6 +65,10 @@ fn plain_assignment_to_state_is_not_contracted() {
     );
 }
 
+/// Regression pin, not a repro: this shape was already green before the fix,
+/// because the client transform's `$.set` folded straight back to a compound
+/// assignment. It only guards against the fix over-reaching in the other
+/// direction.
 #[test]
 fn genuine_compound_assignment_to_state_is_preserved() {
     let src = r#"export function t() {
@@ -84,5 +88,104 @@ fn genuine_compound_assignment_to_state_is_preserved() {
     assert!(
         out.contains("runs *= 2"),
         "`runs *= 2` must stay verbatim. Got:\n{out}"
+    );
+}
+
+// The pre-pass rewrites every unshadowed `$state` / `$state.raw` / `$state.eager`
+// call, not only declarator initialisers — upstream's server `CallExpression`
+// visitor does the same. The tests below fix the edges of that reach. Only
+// `state_raw_and_state_eager_lower_like_state` fails before the fix; the rest
+// are pins against over-reach and are green on both sides.
+
+/// Pin: `$state.snapshot` is a member callee the pre-pass must not match.
+#[test]
+fn state_snapshot_is_not_stripped() {
+    let src = r#"export function s() {
+	let a = $state({ x: 1 });
+	function snap() { return $state.snapshot(a); }
+	return snap;
+}
+"#;
+    let out = compile_mod_server(src);
+    assert!(
+        out.contains("$.snapshot(a)"),
+        "`$state.snapshot` must lower to `$.snapshot`, not be stripped. Got:\n{out}"
+    );
+    assert!(
+        out.contains("let a = { x: 1 }"),
+        "the `$state` declarator must still lower. Got:\n{out}"
+    );
+}
+
+/// Repro: `$state.eager(0)` was emitted verbatim on the server before the fix —
+/// a call to an undefined `$state`.
+#[test]
+fn state_raw_and_state_eager_lower_like_state() {
+    let src = r#"export function s() {
+	let raw = $state.raw({ a: 1 });
+	let eager = $state.eager(0);
+	function f() {
+		raw = { a: 2 };
+		eager = eager + 1;
+	}
+	return f;
+}
+"#;
+    let out = compile_mod_server(src);
+    assert!(
+        out.contains("let raw = { a: 1 }") && out.contains("let eager = 0"),
+        "`$state.raw` / `$state.eager` must lower to the bare initializer. Got:\n{out}"
+    );
+    assert!(
+        out.contains("eager = eager + 1"),
+        "a plain assignment to `$state.eager` must stay verbatim. Got:\n{out}"
+    );
+    assert!(
+        !out.contains("$state."),
+        "no `$state.*` call may survive. Got:\n{out}"
+    );
+}
+
+/// Pin: class fields are pre-lowered earlier, so the new pass must be a no-op here.
+#[test]
+fn class_field_state_still_lowers_to_a_plain_field() {
+    let src = r#"export class Box {
+	value = $state(0);
+	bump() { this.value = this.value + 1; }
+}
+"#;
+    let out = compile_mod_server(src);
+    assert!(
+        out.contains("value = 0"),
+        "a class `$state` field must lower to a plain public field. Got:\n{out}"
+    );
+    assert!(
+        out.contains("this.value = this.value + 1"),
+        "the field assignment must stay verbatim. Got:\n{out}"
+    );
+    assert!(
+        !out.contains("#value"),
+        "the server must not privatize the field. Got:\n{out}"
+    );
+}
+
+/// Pin: `$derived` keeps its signal on the server, so lowering `$state` around
+/// it must not disturb the wrapping.
+#[test]
+fn derived_reading_a_state_binding_still_wraps() {
+    let src = r#"export function s() {
+	let a = $state(1);
+	let b = $derived(a * 2);
+	return () => b;
+}
+"#;
+    let out = compile_mod_server(src);
+    assert!(
+        out.contains("let a = 1"),
+        "the `$state` binding must lower to a plain variable. Got:\n{out}"
+    );
+    assert!(
+        out.contains("$.derived(() => a * 2)"),
+        "`$derived` must still wrap, reading the now-plain `a`. Got:\n{out}"
     );
 }

--- a/crates/rsvelte_core/tests/module_server_state_assignment_2308.rs
+++ b/crates/rsvelte_core/tests/module_server_state_assignment_2308.rs
@@ -1,0 +1,88 @@
+//! `compileModule(generate: 'server')` must leave assignments to `$state`
+//! bindings verbatim — the server has no signals, so `runs = runs + 1` stays
+//! `runs = runs + 1` and is never contracted to `runs += 1`.
+
+use rsvelte_core::GenerateMode;
+use rsvelte_core::compile_module;
+use rsvelte_core::compiler::ModuleCompileOptions;
+
+fn compile_mod_server(src: &str) -> String {
+    let result = compile_module(
+        src,
+        ModuleCompileOptions {
+            filename: Some("in.svelte.js".to_string()),
+            generate: GenerateMode::Server,
+            dev: false,
+            ..Default::default()
+        },
+    )
+    .expect("compile_module");
+    result.js.code
+}
+
+#[test]
+fn plain_assignment_to_state_is_not_contracted() {
+    let src = r#"export function t() {
+	let runs = $state(0);
+	let plain = 0;
+	function f() {
+		runs = runs + 1;
+		plain = plain + 1;
+		runs = runs - 2;
+		runs = 1 + runs;
+	}
+	return f;
+}
+"#;
+    let out = compile_mod_server(src);
+
+    assert!(
+        out.contains("runs = runs + 1"),
+        "`runs = runs + 1` must stay verbatim. Got:\n{out}"
+    );
+    assert!(
+        out.contains("runs = runs - 2"),
+        "`runs = runs - 2` must stay verbatim. Got:\n{out}"
+    );
+    // Negative controls: the non-state binding and the right-operand form were
+    // already correct and must not move.
+    assert!(
+        out.contains("plain = plain + 1"),
+        "`plain = plain + 1` must stay verbatim. Got:\n{out}"
+    );
+    assert!(
+        out.contains("runs = 1 + runs"),
+        "`runs = 1 + runs` must stay verbatim. Got:\n{out}"
+    );
+    assert!(
+        !out.contains("+=") && !out.contains("-="),
+        "no assignment may be contracted. Got:\n{out}"
+    );
+    // No client signal plumbing may survive on the server module path.
+    assert!(
+        !out.contains("$.set(") && !out.contains("$.get("),
+        "server modules must not emit `$.set` / `$.get` for state. Got:\n{out}"
+    );
+}
+
+#[test]
+fn genuine_compound_assignment_to_state_is_preserved() {
+    let src = r#"export function t() {
+	let runs = $state(0);
+	function f() {
+		runs += 1;
+		runs *= 2;
+	}
+	return f;
+}
+"#;
+    let out = compile_mod_server(src);
+    assert!(
+        out.contains("runs += 1"),
+        "`runs += 1` must stay verbatim. Got:\n{out}"
+    );
+    assert!(
+        out.contains("runs *= 2"),
+        "`runs *= 2` must stay verbatim. Got:\n{out}"
+    );
+}


### PR DESCRIPTION
Fixes #2308.

## What was wrong

On the `server` target, a `.svelte.(js|ts)` module rewrote `runs = runs + 1` into
`runs += 1` whenever `runs` was a `$state` binding. Official leaves it verbatim.

`transform_server_module` runs the **client** module transform and then undoes it in
`post_process_for_server`. The client transform lowers *both* `runs += 1` and
`runs = runs + 1` to the identical text `$.set(runs, $.get(runs) + 1)` — the operator is
destroyed before the server undo pass ever sees it. `recompact_compound_set` therefore had
nothing left to decide from and always guessed "compound".

## The fix

Stop destroying the operator instead of tuning the guess. `$state` / `$state.raw` /
`$state.eager` are now lowered to their bare initializer **before** the client transform
runs. State bindings are then not reactive on this path, no `$.set` / `$.get` is emitted
for them, and no assignment has to be reconstructed.

This reuses the existing scope-aware `rune_call_ast::transform_rune_calls_combined`, the same
locator the component server path already uses, so shadowing (`function g($state) { $state(1) }`)
and rune-shaped text inside string literals are resolved structurally.

`#2317` lowered `$state` **declarations** on this path; this extends it to the **assignment**
path it did not reach.

## Why rewriting *every* call is the upstream algorithm, not over-reach

The pass matches any unshadowed `$state` / `$state.raw` / `$state.eager` call, not only
declarator initialisers. That is deliberate, and it mirrors two upstream visitors, not one:

- `3-transform/server/visitors/VariableDeclaration.js:136-138` — a state rune in a declarator
  emits `b.declarator(declarator.id, value)`, i.e. just the first argument.
- `3-transform/server/visitors/CallExpression.js:39-50` — **wherever else** the call occurs,
  `$state` / `$state.raw` return `node.arguments[0] ?? b.void0` and `$state.eager` returns
  `node.arguments[0]`.

The same file (`:52`) maps `$state.snapshot` to `$.snapshot` rather than stripping it, which is why
`$state.snapshot` is excluded here: that exclusion is upstream behaviour, not a carve-out.

## Tests

Two of the six fail before the fix; four are pins against the pre-pass over-reaching, green
on both sides and labelled as such in the file. This split was measured by re-running the
suite against the unmodified `server/mod.rs`, not reasoned about.

**Repros (fail on `main`)**
- `runs = runs + 1` / `runs = runs - 2` contracted to compound form
- `$state.eager(0)` emitted **verbatim** — a call to an undefined `$state` — in a
  `.svelte.js` module on the server

**Pins (green on both sides)**
- `plain = plain + 1` (non-state binding) and `runs = 1 + runs` (state on the right) unchanged
- `runs += 1` / `runs *= 2` genuinely compound, still preserved
- `$state.snapshot` survives as `$.snapshot`
- a class `$state` field stays a plain public field, not privatized
- `$derived` still wraps, reading the now-plain state binding

## Known gap, pre-existing and untouched

`function g($state) { return $state(1); }` in a `.svelte.js` module still emits `return 1;`
on the server. The new pass resolves that shadowing correctly; the *downstream* client
module transform rewrites it textually afterwards. Same for a rune-shaped string literal.
Both are the string-based module path, out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
