### PR TITLE
fix(compiler): treat an ASI boundary as a `$:` statement start (#2355)

### DIFF
--- a/.changeset/olive-pianos-smoke.md
+++ b/.changeset/olive-pianos-smoke.md
@@ -1,0 +1,5 @@
+---
+'@rsvelte/compiler': patch
+---
+
+fix(compiler): recognize a `$:` label after an ASI statement boundary when stripping reactive-statement comments

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/formatting.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/formatting.rs
@@ -276,6 +276,13 @@ fn reactive_statement_spans(source: &str) -> Vec<(usize, usize)> {
             after_last_code = end;
             continue;
         }
+        // Bracket depth is what confines the scan to the script's top level;
+        // `reactive_statement_end` maintains it only while inside a statement.
+        match c {
+            b'{' | b'(' | b'[' => scan.depth += 1,
+            b'}' | b')' | b']' => scan.depth = scan.depth.saturating_sub(1),
+            _ => {}
+        }
         scan.note_code(c);
         i += 1;
         after_last_code = i;
@@ -1331,6 +1338,51 @@ mod reactive_comment_tests {
         assert_eq!(strip_reactive_statement_comments(source), source);
     }
 
+    /// The ASI accept side, on the other token classes that can end an
+    /// expression — a bare `?` is not the only byte that has to be rejected.
+    #[test]
+    fn any_token_that_can_end_an_expression_opens_a_statement() {
+        for predecessor in ["f()", "xs[0]", "y", "1", "_x", "$x", "'s'", "`t`"] {
+            let source = format!("{predecessor}\n$: {{\n\t// inner\n\ty = 1;\n}}\n");
+            let expected = format!("{predecessor}\n$: {{\n\t\n\ty = 1;\n}}\n");
+            assert_eq!(
+                strip_reactive_statement_comments(&source),
+                expected,
+                "predecessor: {predecessor}"
+            );
+        }
+    }
+
+    /// The ASI reject side: an operator cannot end an expression, so the next
+    /// line continues it rather than starting a labeled statement.
+    #[test]
+    fn an_operator_does_not_open_a_statement() {
+        for predecessor in ["let y = c ?", "let y = a +", "let y =", "let y = a,"] {
+            let source = format!("{predecessor}\n/* keep */\n$: 1;\n");
+            assert_eq!(
+                strip_reactive_statement_comments(&source),
+                source,
+                "predecessor: {predecessor}"
+            );
+        }
+    }
+
+    /// The newline term: without a line terminator there is no ASI, so the
+    /// `$:` cannot be a statement start however its predecessor ends.
+    #[test]
+    fn a_same_line_predecessor_does_not_open_a_statement() {
+        let source = "let y = a $: /* keep */ 1;\n";
+        assert_eq!(strip_reactive_statement_comments(source), source);
+    }
+
+    /// `$` is an ordinary object key, and `,` sits at bracket depth — upstream
+    /// only treats a `$:` at the script's top level as reactive.
+    #[test]
+    fn an_object_literal_key_is_not_a_reactive_statement() {
+        let source = "let o = {\n\ta: 1,\n\t/* keep */\n\t$: 2\n};\n";
+        assert_eq!(strip_reactive_statement_comments(source), source);
+    }
+
     #[test]
     fn drops_comments_inside_a_reactive_if_block() {
         let out = strip_reactive_statement_comments(
@@ -1357,9 +1409,12 @@ mod reactive_comment_tests {
         assert_kept("let a = 'a // not a comment';\n// kept\nlet b = 1;\n");
     }
 
+    /// Upstream bails on `context.path.length > 1`, so even a `$:` — not just a
+    /// label that could never be confused for one — is plain inside a function.
     #[test]
     fn a_label_inside_a_function_body_is_not_a_reactive_statement() {
         assert_kept("function f() {\n\t// kept\n\tlab: for (;;) break lab;\n}\n");
+        assert_kept("function f() {\n\tlet a = 1\n\t$: {\n\t\t/* keep */\n\t\ta = 2;\n\t}\n}\n");
     }
 
     #[test]

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/formatting.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/formatting.rs
@@ -267,7 +267,7 @@ fn reactive_statement_spans(source: &str) -> Vec<(usize, usize)> {
         if c == b'$'
             && bytes.get(i + 1) == Some(&b':')
             && scan.depth == 0
-            && matches!(scan.last_code, None | Some(b';') | Some(b'{') | Some(b'}'))
+            && statement_can_begin(&scan, bytes, after_last_code, i)
         {
             let end = reactive_statement_end(source, &mut scan, i + 2);
             let end = extend_over_trailing_comment(source, end);
@@ -289,6 +289,22 @@ fn reactive_statement_spans(source: &str) -> Vec<(usize, usize)> {
             (if has_successor { label } else { leading }, end)
         })
         .collect()
+}
+
+/// Whether a statement can begin at `at`, `after_last_code` being the byte just
+/// past the preceding code token. Besides the explicit boundaries, automatic
+/// semicolon insertion makes a line terminator after a token that can end an
+/// expression one too — `let bar` followed by a `$:` line is a labeled
+/// statement just as much as `let bar;` is.
+fn statement_can_begin(scan: &JsScan, bytes: &[u8], after_last_code: usize, at: usize) -> bool {
+    match scan.last_code {
+        None | Some(b';') | Some(b'{') | Some(b'}') => true,
+        Some(c) => {
+            (c.is_ascii_alphanumeric()
+                || matches!(c, b'_' | b'$' | b')' | b']' | b'\'' | b'"' | b'`'))
+                && bytes[after_last_code..at].contains(&b'\n')
+        }
+    }
 }
 
 /// Byte just past the end of the reactive statement whose body starts at
@@ -1301,6 +1317,18 @@ mod reactive_comment_tests {
     fn drops_comments_inside_a_reactive_block() {
         let out = strip_reactive_statement_comments("$: {\n\t// inner\n\ty = 1;\n}\n");
         assert_eq!(out, "$: {\n\t\n\ty = 1;\n}\n");
+    }
+
+    #[test]
+    fn drops_comments_after_a_semicolon_less_predecessor() {
+        let out = strip_reactive_statement_comments("let y\n$: {\n\t// inner\n\ty = 1;\n}\n");
+        assert_eq!(out, "let y\n$: {\n\t\n\ty = 1;\n}\n");
+    }
+
+    #[test]
+    fn a_conditional_consequent_is_not_a_reactive_statement() {
+        let source = "let y = c ?\n/* keep */\n$: 1;\n";
+        assert_eq!(strip_reactive_statement_comments(source), source);
     }
 
     #[test]

--- a/crates/rsvelte_core/tests/legacy_pre_effect_comment_2355.rs
+++ b/crates/rsvelte_core/tests/legacy_pre_effect_comment_2355.rs
@@ -1,0 +1,43 @@
+//! A comment inside a `$:` statement body is dropped: upstream rewrites the
+//! reactive statement into a synthesized `$.legacy_pre_effect(...)` call, so
+//! comments attached to the original statement have no node to re-home onto.
+//!
+//! Expected outputs are the official Svelte compiler's, verbatim.
+
+use rsvelte_core::{CompileOptions, GenerateMode, compile};
+
+fn client(name: &str, source: &str) -> String {
+    compile(
+        source,
+        CompileOptions {
+            generate: GenerateMode::Client,
+            filename: Some(format!("{name}/index.svelte")),
+            ..Default::default()
+        },
+    )
+    .expect("compile")
+    .js
+    .code
+}
+
+const EXPECTED: &str = "import 'svelte/internal/disclose-version';\nimport 'svelte/internal/flags/legacy';\nimport * as $ from 'svelte/internal/client';\n\nexport default function Comment_block($$anchor, $$props) {\n\t$.push($$props, false);\n\n\tlet bar = $.mutable_source();\n\n\t$.legacy_pre_effect(() => {}, () => {\n\t\t$.set(bar, []);\n\t});\n\n\t$.legacy_pre_effect_reset();\n\t$.pop();\n}";
+
+#[test]
+fn block_comment_inside_a_reactive_block_is_dropped() {
+    let source = "<script>\n\tlet bar\n\t$: {\n\t\t/* c */\n\t\tbar = []\n\t}\n</script>\n";
+    assert_eq!(client("comment_block", source), EXPECTED);
+}
+
+#[test]
+fn line_comment_inside_a_reactive_block_is_dropped() {
+    let source = "<script>\n\tlet bar\n\t$: {\n\t\t// c\n\t\tbar = []\n\t}\n</script>\n";
+    assert_eq!(client("comment_block", source), EXPECTED);
+}
+
+/// A `$:` whose predecessor already ends in `;` was recognized before; the ASI
+/// shape must reach the same output.
+#[test]
+fn a_semicolon_terminated_predecessor_behaves_the_same() {
+    let source = "<script>\n\tlet bar;\n\t$: {\n\t\t/* c */\n\t\tbar = []\n\t}\n</script>\n";
+    assert_eq!(client("comment_block", source), EXPECTED);
+}


### PR DESCRIPTION
Fixes #2355.

## Root cause

Not the printer. `strip_reactive_statement_comments` **is** the path the comment takes —
the theory in the issue that it never sees the comment is wrong; what is wrong is that
the scanner never recognizes the statement.

`reactive_statement_spans` (`3_transform/client/formatting.rs`) only accepted a `$:` as a
reactive statement when the preceding code byte was one of `None | ';' | '{' | '}'`:

```rust
&& matches!(scan.last_code, None | Some(b';') | Some(b'{') | Some(b'}'))
```

The repro's predecessor is `let bar` with no semicolon, so `last_code` is `r` — the guard
fails, no span is recorded, and nothing is stripped. Every existing unit test for the
stripper happens to terminate its predecessor with `;`, which is why they all pass while
the repro fails.

Automatic semicolon insertion makes a line terminator after a token that can end an
expression a statement boundary too, so the guard now also accepts that.

## Verification

Divergence confirmed to survive the corpus normalizer: oxfmt 0.62 preserves the comment in
the `expected` output, so the gate sees it (checked against `main` at `8c7851ca`, i.e. after
the 0.61 → 0.62 bump).

New tests (`crates/rsvelte_core/tests/legacy_pre_effect_comment_2355.rs`) assert the official
compiler's byte-for-byte output for the `/* c */` and `// c` forms, plus the `;`-terminated
shape that already worked; a unit test in `formatting.rs` covers the scanner directly and a
negative one pins that a conditional consequent (`c ?` / newline / `$: 1`) is still not
mistaken for a label.

## Known divergence left in place

When a statement **survives after** the reactive one, upstream re-homes the comment
positionally onto that successor (and, for a `$: if (…) {}`, prints it a second time inside
the effect, because the `if` block still has a source location). rsvelte's text stripper
cannot move a comment, so that shape stays divergent — as it already was for the
`;`-terminated form. Out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
