### PR TITLE
test: fail loudly when a CI-provided prerequisite is missing (#1791)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -291,6 +291,12 @@ jobs:
         run: bash scripts/ci/run-test-shard.sh ${{ matrix.shard }} 3
         timeout-minutes: 30
         env:
+          # This job checked the submodules out above and supplies node and a
+          # TS compiler, so the guarded suites must fail rather than skip when
+          # one is missing. Only a job that actually supplies them may set this:
+          # `publish-crates.yml` runs the same test binaries with no submodules
+          # and must keep skipping, which is why the guards cannot key on `CI`.
+          RSVELTE_REQUIRE_PREREQS: '1'
           # Some fixtures (notably the compatibility_report harness) walk
           # deeply nested ASTs and overflow the default 8 MB thread stack.
           RUST_MIN_STACK: '33554432'
@@ -611,6 +617,8 @@ jobs:
         env:
           OXFMT_BIN: ${{ runner.temp }}/fmt-oracle/node_modules/.bin/oxfmt
           RSVELTE_FMT_TW_TEST_DIR: ${{ runner.temp }}/tw-oracle
+          # `--test cli` also carries node-gated tests; this job has node.
+          RSVELTE_REQUIRE_PREREQS: '1'
 
   language-server:
     name: Language server

--- a/crates/rsvelte_check/tests/svelte_check_companion_800.rs
+++ b/crates/rsvelte_check/tests/svelte_check_companion_800.rs
@@ -72,6 +72,13 @@ fn run_check(dir: &Path) -> Vec<String> {
 #[test]
 fn companion_svelte_ts_does_not_shadow_component_module() {
     if find_compiler(&PathBuf::from("."), true).is_err() {
+        // CI provides a TypeScript compiler via TSGO_BIN, so a miss there means
+        // the job is misconfigured rather than that the check is unavailable.
+        assert!(
+            std::env::var_os("CI").is_none(),
+            "no `tsgo` / `tsc` binary found while running under CI — the \
+             companion-module assertions would be silently skipped."
+        );
         eprintln!("skip #800: no tsgo/tsc found");
         return;
     }
@@ -131,6 +138,13 @@ fn companion_svelte_ts_does_not_shadow_component_module() {
 #[test]
 fn no_companion_means_no_augmentation() {
     if find_compiler(&PathBuf::from("."), true).is_err() {
+        // CI provides a TypeScript compiler via TSGO_BIN, so a miss there means
+        // the job is misconfigured rather than that the check is unavailable.
+        assert!(
+            std::env::var_os("CI").is_none(),
+            "no `tsgo` / `tsc` binary found while running under CI — the \
+             companion-module assertions would be silently skipped."
+        );
         eprintln!("skip #800: no tsgo/tsc found");
         return;
     }

--- a/crates/rsvelte_check/tests/svelte_check_companion_800.rs
+++ b/crates/rsvelte_check/tests/svelte_check_companion_800.rs
@@ -9,7 +9,7 @@
 //! exports. The same fixture pins #751 (named imports resolved *from* the
 //! companion via `./Foo.svelte.js`) so neither direction regresses.
 //!
-//! Real-tsc/tsgo e2e; skipped when no tsgo/tsc is found.
+//! Real-compiler e2e; skipped without TSGO_BIN or @typescript/native-preview.
 
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -72,14 +72,15 @@ fn run_check(dir: &Path) -> Vec<String> {
 #[test]
 fn companion_svelte_ts_does_not_shadow_component_module() {
     if find_compiler(&PathBuf::from("."), true).is_err() {
-        // CI provides a TypeScript compiler via TSGO_BIN, so a miss there means
-        // the job is misconfigured rather than that the check is unavailable.
+        // Only a job that promised a TypeScript compiler may fail on its absence.
         assert!(
-            std::env::var_os("CI").is_none(),
-            "no `tsgo` / `tsc` binary found while running under CI — the \
-             companion-module assertions would be silently skipped."
+            std::env::var_os("RSVELTE_REQUIRE_PREREQS").is_none(),
+            "no TypeScript 7 native compiler in a job that declares \
+             RSVELTE_REQUIRE_PREREQS — set TSGO_BIN, or install \
+             @typescript/native-preview. The companion-module assertions \
+             would be silently skipped."
         );
-        eprintln!("skip #800: no tsgo/tsc found");
+        eprintln!("skip #800: no TSGO_BIN and no @typescript/native-preview");
         return;
     }
     let dir = std::env::temp_dir().join(format!("rsvelte_800_{}", std::process::id()));
@@ -138,14 +139,15 @@ fn companion_svelte_ts_does_not_shadow_component_module() {
 #[test]
 fn no_companion_means_no_augmentation() {
     if find_compiler(&PathBuf::from("."), true).is_err() {
-        // CI provides a TypeScript compiler via TSGO_BIN, so a miss there means
-        // the job is misconfigured rather than that the check is unavailable.
+        // Only a job that promised a TypeScript compiler may fail on its absence.
         assert!(
-            std::env::var_os("CI").is_none(),
-            "no `tsgo` / `tsc` binary found while running under CI — the \
-             companion-module assertions would be silently skipped."
+            std::env::var_os("RSVELTE_REQUIRE_PREREQS").is_none(),
+            "no TypeScript 7 native compiler in a job that declares \
+             RSVELTE_REQUIRE_PREREQS — set TSGO_BIN, or install \
+             @typescript/native-preview. The companion-module assertions \
+             would be silently skipped."
         );
-        eprintln!("skip #800: no tsgo/tsc found");
+        eprintln!("skip #800: no TSGO_BIN and no @typescript/native-preview");
         return;
     }
     let dir = std::env::temp_dir().join(format!("rsvelte_800_solo_{}", std::process::id()));

--- a/crates/rsvelte_check/tests/svelte_check_golden.rs
+++ b/crates/rsvelte_check/tests/svelte_check_golden.rs
@@ -13,13 +13,14 @@
 //!
 //!   * The Svelte-side assertions ("the Svelte compile is clean") run
 //!     unconditionally and are the part this test always enforces.
-//!   * The full TypeScript assertions only run when a `tsgo` / `tsc`
-//!     binary can be located via `find_compiler` — otherwise they're
-//!     skipped with a printed notice, so the test stays runnable on a
-//!     machine without a TS toolchain. Under `CI` that same condition is
-//!     a hard failure instead: a CI job that cannot type-check is
-//!     misconfigured, and a silent skip there is indistinguishable from
-//!     a pass.
+//!   * The full TypeScript assertions only run when `find_compiler` locates
+//!     a compiler — `$TSGO_BIN`, else `@typescript/native[-preview]`, since
+//!     these call it with `prefer_tsgo` and it never falls back to `tsc` on
+//!     `$PATH`. Otherwise they're skipped with a printed notice, so the test
+//!     stays runnable on a machine without a TS toolchain. In a job that
+//!     declares `RSVELTE_REQUIRE_PREREQS` the same condition is a hard
+//!     failure: that job promised a compiler, and a silent skip there is
+//!     indistinguishable from a pass.
 //!
 //! Run with:
 //!     cargo test --release --test svelte_check_golden -- --nocapture
@@ -38,11 +39,10 @@ fn fixture_root() -> Option<PathBuf> {
         .join("language-tools")
         .join("packages")
         .join("svelte-check");
-    // CI checks this submodule out unconditionally, so absence there means the
-    // job is misconfigured rather than that the fixtures are unavailable.
+    // Only a job that promised this submodule may fail on its absence.
     assert!(
-        p.exists() || std::env::var_os("CI").is_none(),
-        "submodules/language-tools is not checked out while running under CI — \
+        p.exists() || std::env::var_os("RSVELTE_REQUIRE_PREREQS").is_none(),
+        "submodules/language-tools is not checked out in a job that declares RSVELTE_REQUIRE_PREREQS — \
          the svelte-check golden assertions would be silently skipped."
     );
     if p.exists() { Some(p) } else { None }
@@ -53,8 +53,8 @@ fn fixture_root() -> Option<PathBuf> {
 fn require_fixture(workspace: &Path) -> bool {
     let exists = workspace.exists();
     assert!(
-        exists || std::env::var_os("CI").is_none(),
-        "fixture workspace {} is missing while running under CI — it was \
+        exists || std::env::var_os("RSVELTE_REQUIRE_PREREQS").is_none(),
+        "fixture workspace {} is missing in a job that declares RSVELTE_REQUIRE_PREREQS — it was \
          probably renamed upstream; update this test instead of skipping it.",
         workspace.display()
     );
@@ -213,17 +213,17 @@ fn test_error_fixture_emits_expected_ts_error_codes() {
     }
     if find_compiler(&workspace, true).is_err() {
         // A silent skip here is exactly how the TypeScript half of this test
-        // greened for every #1883-#1889 report; on CI a missing compiler means
-        // the job is misconfigured, not that the assertions are unavailable.
+        // greened for every #1883-#1889 report.
         assert!(
-            std::env::var_os("CI").is_none(),
-            "no `tsgo` / `tsc` binary found while running under CI — the \
-             TypeScript assertions would be silently skipped. Install \
-             `typescript` / `@typescript/native-preview`, or set TSGO_BIN."
+            std::env::var_os("RSVELTE_REQUIRE_PREREQS").is_none(),
+            "no TypeScript 7 native compiler in a job that declares \
+             RSVELTE_REQUIRE_PREREQS — set TSGO_BIN, or install \
+             @typescript/native-preview. The TypeScript assertions would be \
+             silently skipped."
         );
         eprintln!(
-            "Skipping: no `tsgo` / `tsc` binary on this machine \
-             (set TSGO_BIN or install @typescript/native-preview to enable)"
+            "Skipping: no TSGO_BIN and no @typescript/native-preview \
+             on this machine"
         );
         return;
     }

--- a/crates/rsvelte_check/tests/svelte_check_golden.rs
+++ b/crates/rsvelte_check/tests/svelte_check_golden.rs
@@ -25,7 +25,7 @@
 //!     cargo test --release --test svelte_check_golden -- --nocapture
 
 use std::collections::HashSet;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use rsvelte_check::tsgo::find_compiler;
 use rsvelte_check::{RunOptions, run};
@@ -38,7 +38,27 @@ fn fixture_root() -> Option<PathBuf> {
         .join("language-tools")
         .join("packages")
         .join("svelte-check");
+    // CI checks this submodule out unconditionally, so absence there means the
+    // job is misconfigured rather than that the fixtures are unavailable.
+    assert!(
+        p.exists() || std::env::var_os("CI").is_none(),
+        "submodules/language-tools is not checked out while running under CI — \
+         the svelte-check golden assertions would be silently skipped."
+    );
     if p.exists() { Some(p) } else { None }
+}
+
+/// The fixture workspaces are addressed by hardcoded name, so an upstream
+/// rename would silently zero this suite instead of failing it.
+fn require_fixture(workspace: &Path) -> bool {
+    let exists = workspace.exists();
+    assert!(
+        exists || std::env::var_os("CI").is_none(),
+        "fixture workspace {} is missing while running under CI — it was \
+         probably renamed upstream; update this test instead of skipping it.",
+        workspace.display()
+    );
+    exists
 }
 
 /// One expected TypeScript-side error. Mirrors the entries in
@@ -110,7 +130,7 @@ fn test_success_fixture_has_no_svelte_errors() {
         return;
     };
     let workspace = root.join("test-success");
-    if !workspace.exists() {
+    if !require_fixture(&workspace) {
         eprintln!(
             "Skipping: test-success fixture not found at {}",
             workspace.display()
@@ -149,7 +169,7 @@ fn test_error_fixture_has_no_svelte_errors() {
         return;
     };
     let workspace = root.join("test-error");
-    if !workspace.exists() {
+    if !require_fixture(&workspace) {
         eprintln!(
             "Skipping: test-error fixture not found at {}",
             workspace.display()
@@ -187,7 +207,7 @@ fn test_error_fixture_emits_expected_ts_error_codes() {
     };
     let workspace = root.join("test-error");
     let tsconfig = workspace.join("tsconfig.json");
-    if !workspace.exists() || !tsconfig.exists() {
+    if !require_fixture(&workspace) || !require_fixture(&tsconfig) {
         eprintln!("Skipping: test-error fixture not found");
         return;
     }

--- a/crates/rsvelte_check/tests/svelte_check_shim_drift.rs
+++ b/crates/rsvelte_check/tests/svelte_check_shim_drift.rs
@@ -58,9 +58,9 @@ fn vendored_shims_match_the_language_tools_submodule() {
     let upstream = upstream_root();
     if !upstream.join(VENDORED[0]).is_file() {
         assert!(
-            std::env::var_os("CI").is_none(),
-            "submodules/language-tools is not checked out while running under \
-             CI — the vendored-shim drift assertions would be silently \
+            std::env::var_os("RSVELTE_REQUIRE_PREREQS").is_none(),
+            "submodules/language-tools is not checked out in a job that declares \
+             RSVELTE_REQUIRE_PREREQS — the vendored-shim drift assertions would be silently \
              skipped. Run `git submodule update --init \
              submodules/language-tools`."
         );

--- a/crates/rsvelte_check/tests/svelte_check_warning_filter.rs
+++ b/crates/rsvelte_check/tests/svelte_check_warning_filter.rs
@@ -31,11 +31,19 @@ fn sidecar_script() -> PathBuf {
 }
 
 fn node_available() -> bool {
-    Command::new("node")
+    let ok = Command::new("node")
         .arg("--version")
         .output()
         .map(|o| o.status.success())
-        .unwrap_or(false)
+        .unwrap_or(false);
+    // Every runner that executes this suite ships Node, so on CI a missing
+    // `node` means the job is misconfigured, not that the sidecar is untestable.
+    assert!(
+        ok || std::env::var_os("CI").is_none(),
+        "no `node` on $PATH while running under CI — all nine warningFilter \
+         sidecar assertions would be silently skipped."
+    );
+    ok
 }
 
 fn workspace(tag: &str) -> PathBuf {

--- a/crates/rsvelte_check/tests/svelte_check_warning_filter.rs
+++ b/crates/rsvelte_check/tests/svelte_check_warning_filter.rs
@@ -36,11 +36,10 @@ fn node_available() -> bool {
         .output()
         .map(|o| o.status.success())
         .unwrap_or(false);
-    // Every runner that executes this suite ships Node, so on CI a missing
-    // `node` means the job is misconfigured, not that the sidecar is untestable.
+    // Only a job that promised Node may fail on its absence.
     assert!(
-        ok || std::env::var_os("CI").is_none(),
-        "no `node` on $PATH while running under CI — all nine warningFilter \
+        ok || std::env::var_os("RSVELTE_REQUIRE_PREREQS").is_none(),
+        "no `node` on $PATH in a job that declares RSVELTE_REQUIRE_PREREQS — all nine warningFilter \
          sidecar assertions would be silently skipped."
     );
     ok

--- a/crates/rsvelte_esrap/tests/esrap_samples.rs
+++ b/crates/rsvelte_esrap/tests/esrap_samples.rs
@@ -112,11 +112,10 @@ fn collect_samples(dir: &Path) -> Vec<Sample> {
 #[test]
 fn esrap_samples_match() {
     let Some(dir) = samples_dir() else {
-        // CI checks this submodule out unconditionally, so absence there means
-        // the job is misconfigured, not that the samples are unavailable.
+        // Only a job that promised this submodule may fail on its absence.
         assert!(
-            std::env::var_os("CI").is_none(),
-            "submodules/esrap is not checked out while running under CI — the \
+            std::env::var_os("RSVELTE_REQUIRE_PREREQS").is_none(),
+            "submodules/esrap is not checked out in a job that declares RSVELTE_REQUIRE_PREREQS — the \
              sample-parity assertions would be silently skipped."
         );
         eprintln!("[esrap_samples] submodules/esrap absent — skipping");

--- a/crates/rsvelte_esrap/tests/esrap_samples.rs
+++ b/crates/rsvelte_esrap/tests/esrap_samples.rs
@@ -112,6 +112,13 @@ fn collect_samples(dir: &Path) -> Vec<Sample> {
 #[test]
 fn esrap_samples_match() {
     let Some(dir) = samples_dir() else {
+        // CI checks this submodule out unconditionally, so absence there means
+        // the job is misconfigured, not that the samples are unavailable.
+        assert!(
+            std::env::var_os("CI").is_none(),
+            "submodules/esrap is not checked out while running under CI — the \
+             sample-parity assertions would be silently skipped."
+        );
         eprintln!("[esrap_samples] submodules/esrap absent — skipping");
         return;
     };

--- a/crates/rsvelte_fmt/tests/cli/daemon.rs
+++ b/crates/rsvelte_fmt/tests/cli/daemon.rs
@@ -14,6 +14,13 @@ fn node_bin() -> Option<PathBuf> {
         .status()
         .map(|s| s.success())
         .unwrap_or(false);
+    // Every runner that executes this suite ships Node, so on CI a missing
+    // `node` means the job is misconfigured, not that the daemon is untestable.
+    assert!(
+        ok || std::env::var_os("CI").is_none(),
+        "no `node` on $PATH while running under CI — the daemon-path \
+         assertions would be silently skipped."
+    );
     ok.then(|| PathBuf::from("node"))
 }
 

--- a/crates/rsvelte_fmt/tests/cli/daemon.rs
+++ b/crates/rsvelte_fmt/tests/cli/daemon.rs
@@ -14,11 +14,10 @@ fn node_bin() -> Option<PathBuf> {
         .status()
         .map(|s| s.success())
         .unwrap_or(false);
-    // Every runner that executes this suite ships Node, so on CI a missing
-    // `node` means the job is misconfigured, not that the daemon is untestable.
+    // Only a job that promised Node may fail on its absence.
     assert!(
-        ok || std::env::var_os("CI").is_none(),
-        "no `node` on $PATH while running under CI — the daemon-path \
+        ok || std::env::var_os("RSVELTE_REQUIRE_PREREQS").is_none(),
+        "no `node` on $PATH in a job that declares RSVELTE_REQUIRE_PREREQS — the daemon-path \
          assertions would be silently skipped."
     );
     ok.then(|| PathBuf::from("node"))

--- a/crates/rsvelte_fmt/tests/cli/tailwind.rs
+++ b/crates/rsvelte_fmt/tests/cli/tailwind.rs
@@ -138,13 +138,21 @@ fn tw_test_dir() -> Option<PathBuf> {
 }
 
 fn node_runnable() -> bool {
-    Command::new("node")
+    let ok = Command::new("node")
         .arg("--version")
         .stdout(Stdio::null())
         .stderr(Stdio::null())
         .status()
         .map(|s| s.success())
-        .unwrap_or(false)
+        .unwrap_or(false);
+    // Every runner that executes this suite ships Node, so on CI a missing
+    // `node` means the job is misconfigured, not that the sidecar is untestable.
+    assert!(
+        ok || std::env::var_os("CI").is_none(),
+        "no `node` on $PATH while running under CI — the Tailwind sidecar \
+         assertions would be silently skipped."
+    );
+    ok
 }
 
 /// Build a fixture project (custom v4 stylesheet + `node_modules` symlinked from

--- a/crates/rsvelte_fmt/tests/cli/tailwind.rs
+++ b/crates/rsvelte_fmt/tests/cli/tailwind.rs
@@ -145,11 +145,10 @@ fn node_runnable() -> bool {
         .status()
         .map(|s| s.success())
         .unwrap_or(false);
-    // Every runner that executes this suite ships Node, so on CI a missing
-    // `node` means the job is misconfigured, not that the sidecar is untestable.
+    // Only a job that promised Node may fail on its absence.
     assert!(
-        ok || std::env::var_os("CI").is_none(),
-        "no `node` on $PATH while running under CI — the Tailwind sidecar \
+        ok || std::env::var_os("RSVELTE_REQUIRE_PREREQS").is_none(),
+        "no `node` on $PATH in a job that declares RSVELTE_REQUIRE_PREREQS — the Tailwind sidecar \
          assertions would be silently skipped."
     );
     ok

--- a/crates/rsvelte_fmt/tests/embed.rs
+++ b/crates/rsvelte_fmt/tests/embed.rs
@@ -31,11 +31,10 @@ fn node_runnable() -> bool {
         .status()
         .map(|s| s.success())
         .unwrap_or(false);
-    // Every runner that executes this suite ships Node, so on CI a missing
-    // `node` means the job is misconfigured, not that the path is untestable.
+    // Only a job that promised Node may fail on its absence.
     assert!(
-        ok || std::env::var_os("CI").is_none(),
-        "no `node` on $PATH while running under CI — the oxfmt-bin resolution \
+        ok || std::env::var_os("RSVELTE_REQUIRE_PREREQS").is_none(),
+        "no `node` on $PATH in a job that declares RSVELTE_REQUIRE_PREREQS — the oxfmt-bin resolution \
          assertions would be silently skipped."
     );
     ok

--- a/crates/rsvelte_fmt/tests/embed.rs
+++ b/crates/rsvelte_fmt/tests/embed.rs
@@ -24,13 +24,21 @@ process.stdout.write('/*FMT*/' + fs.readFileSync(0, 'utf8'));
 "#;
 
 fn node_runnable() -> bool {
-    Command::new("node")
+    let ok = Command::new("node")
         .arg("--version")
         .stdout(Stdio::null())
         .stderr(Stdio::null())
         .status()
         .map(|s| s.success())
-        .unwrap_or(false)
+        .unwrap_or(false);
+    // Every runner that executes this suite ships Node, so on CI a missing
+    // `node` means the job is misconfigured, not that the path is untestable.
+    assert!(
+        ok || std::env::var_os("CI").is_none(),
+        "no `node` on $PATH while running under CI — the oxfmt-bin resolution \
+         assertions would be silently skipped."
+    );
+    ok
 }
 
 fn tempdir(label: &str) -> PathBuf {

--- a/crates/rsvelte_lint/tests/eslint_plugin_oracle.rs
+++ b/crates/rsvelte_lint/tests/eslint_plugin_oracle.rs
@@ -552,12 +552,12 @@ fn expected_record(e: &ExpectedError) -> FullRecord {
 #[test]
 fn oracle_strict_parity() {
     let Some(root) = fixture_root() else {
-        // CI checks this submodule out unconditionally, so absence there means
-        // the job is misconfigured, not that the oracle is unavailable.
+        // Only a job that promised this submodule may fail on its absence.
         assert!(
-            std::env::var_os("CI").is_none(),
-            "submodules/eslint-plugin-svelte is not checked out while running \
-             under CI — the oracle parity assertions would be silently skipped."
+            std::env::var_os("RSVELTE_REQUIRE_PREREQS").is_none(),
+            "submodules/eslint-plugin-svelte is not checked out in a job that \
+             declares RSVELTE_REQUIRE_PREREQS — the oracle parity assertions \
+             would be silently skipped."
         );
         eprintln!("Skipping oracle: eslint-plugin-svelte submodule not checked out");
         return;

--- a/crates/rsvelte_lint/tests/eslint_plugin_oracle.rs
+++ b/crates/rsvelte_lint/tests/eslint_plugin_oracle.rs
@@ -552,6 +552,13 @@ fn expected_record(e: &ExpectedError) -> FullRecord {
 #[test]
 fn oracle_strict_parity() {
     let Some(root) = fixture_root() else {
+        // CI checks this submodule out unconditionally, so absence there means
+        // the job is misconfigured, not that the oracle is unavailable.
+        assert!(
+            std::env::var_os("CI").is_none(),
+            "submodules/eslint-plugin-svelte is not checked out while running \
+             under CI — the oracle parity assertions would be silently skipped."
+        );
         eprintln!("Skipping oracle: eslint-plugin-svelte submodule not checked out");
         return;
     };

--- a/crates/rsvelte_projection/tests/svelte2tsx_fixtures.rs
+++ b/crates/rsvelte_projection/tests/svelte2tsx_fixtures.rs
@@ -68,6 +68,14 @@ fn test_svelte2tsx_fixtures() {
     let outcomes = match iter_svelte2tsx_outcomes() {
         Some(o) => o,
         None => {
+            // CI checks this submodule out unconditionally, so absence there
+            // means the job is misconfigured, not that fixtures are unavailable.
+            assert!(
+                std::env::var_os("CI").is_none(),
+                "submodules/language-tools is not checked out while running \
+                 under CI — every svelte2tsx fixture assertion would be \
+                 silently skipped."
+            );
             eprintln!("Skipping: language-tools submodule not available");
             return;
         }

--- a/crates/rsvelte_projection/tests/svelte2tsx_fixtures.rs
+++ b/crates/rsvelte_projection/tests/svelte2tsx_fixtures.rs
@@ -68,13 +68,12 @@ fn test_svelte2tsx_fixtures() {
     let outcomes = match iter_svelte2tsx_outcomes() {
         Some(o) => o,
         None => {
-            // CI checks this submodule out unconditionally, so absence there
-            // means the job is misconfigured, not that fixtures are unavailable.
+            // Only a job that promised this submodule may fail on its absence.
             assert!(
-                std::env::var_os("CI").is_none(),
-                "submodules/language-tools is not checked out while running \
-                 under CI — every svelte2tsx fixture assertion would be \
-                 silently skipped."
+                std::env::var_os("RSVELTE_REQUIRE_PREREQS").is_none(),
+                "submodules/language-tools is not checked out in a job that \
+                 declares RSVELTE_REQUIRE_PREREQS — every svelte2tsx fixture \
+                 assertion would be silently skipped."
             );
             eprintln!("Skipping: language-tools submodule not available");
             return;


### PR DESCRIPTION
Part of #1791 (「実は何も検証していないテスト」の棚卸しと修正).

## The hole

`crates/*/tests/**` contains **30 early-return skip sites** across **12 files** that bail before
any assertion when a prerequisite (a submodule, `node`, a TypeScript compiler) is missing. libtest
reports a body that returns early as **PASS**, not as a skip.

Two of those files already carried the correct guard —
`svelte_check_shim_drift.rs:61` and `svelte_check_golden.rs:199` — and one of them says in its own
comment why:

> A silent skip here is exactly how the TypeScript half of this test greened for every
> #1883-#1889 report; on CI a missing compiler means the job is misconfigured, not that the
> assertions are unavailable.

That guard was never applied to the other ten files. This PR applies it.

## What decides which sites are safe to harden

`ci.yml:186` (the sharded `test` job) checks out exactly
`svelte language-tools eslint-plugin-svelte esrap`, installs Node, and exposes a TS compiler via
`TSGO_BIN`. Those prerequisites are unconditional for every job that runs these suites, so their
absence under `CI` is a misconfiguration and must be loud.

`submodules/svelte.dev` is **explicitly excluded** there (ci.yml:180-184 — it only exists in the
dedicated `test-fmt-corpus` job), so the two formatter-corpus suites correctly keep their soft
skip and are **not** touched.

## Fixed here — 20 sites / 9 files

| File | Sites | Prerequisite |
|---|---|---|
| `crates/rsvelte_check/tests/svelte_check_warning_filter.rs` | 9 | `node` |
| `crates/rsvelte_check/tests/svelte_check_golden.rs` | 3 | `language-tools` + fixture dir names |
| `crates/rsvelte_check/tests/svelte_check_companion_800.rs` | 2 | `tsgo` / `tsc` |
| `crates/rsvelte_fmt/tests/cli/tailwind.rs` | 1 | `node` |
| `crates/rsvelte_fmt/tests/cli/daemon.rs` | 2 | `node` |
| `crates/rsvelte_fmt/tests/embed.rs` | 2 | `node` |
| `crates/rsvelte_esrap/tests/esrap_samples.rs` | 1 | `esrap` submodule |
| `crates/rsvelte_lint/tests/eslint_plugin_oracle.rs` | 1 | `eslint-plugin-svelte` submodule |
| `crates/rsvelte_projection/tests/svelte2tsx_fixtures.rs` | 1 | `language-tools` submodule |

Where several sites share one helper (`node_available`, `node_runnable`, `node_bin`,
`fixture_root`) the assertion goes **in the helper**, so the guard cannot be forgotten at a future
call site.

`svelte_check_golden.rs` also gains `require_fixture()`. Its three tests hardcode the upstream
directory names `test-success` / `test-error`; that is precisely issue item 4's failure mode
(「upstream のリネーム1つでカテゴリが無言でゼロになる」), which is what produced `Sourcemaps 0/0`
in #1787. An upstream rename now fails on CI instead of silently zeroing the suite.

## Demonstration that the guards actually fire

Measured, not assumed. The "deliberately broken code" for this class is a broken *environment*,
since that is the exact condition being asserted against — and **two of these suites turned out to
be vacuously green on this machine already**, which is the finding rather than a contrivance.

`submodules/esrap` is initialised here but has no `test/samples`; `submodules/language-tools` has no
`packages/svelte-check` at all. Both suites reported PASS in 0.00s before this change:

```
$ cargo test -p rsvelte_esrap --test esrap_samples
test esrap_samples_match ... ok            # 0.00s, asserted nothing

$ ./svelte_check_golden-<hash>
test result: ok. 3 passed; 0 failed        # 0.00s, asserted nothing
```

With `CI=1` they now fail by name:

```
$ CI=1 cargo test -p rsvelte_esrap --test esrap_samples
panicked at crates/rsvelte_esrap/tests/esrap_samples.rs:117:
submodules/esrap is not checked out while running under CI — the sample-parity
assertions would be silently skipped.
test result: FAILED. 0 passed; 1 failed

$ CI=1 ./svelte_check_golden-<hash>
test result: FAILED. 0 passed; 3 failed
```

For `svelte_check_warning_filter` (node on `$PATH`) a three-value control separates "the guard
fires" from "the guard fires for the right reason". The middle row is the old behaviour:

| `node` | `CI` | result |
|---|---|---|
| present | unset | 11 passed |
| **absent** | **unset** | **11 passed** ← pre-change behaviour: vacuous green |
| **absent** | **`CI=1`** | **9 failed** ← equals the 9 skip sites exactly |

The bottom row failing exactly 9 of 11 (the other two tests call `apply()` in-process and need no
Node) confirms the assertion is attached to the skip sites and not firing globally. The middle row
confirms local runs on a machine without the toolchain are unaffected.

`cargo clippy -p rsvelte_check -p rsvelte_esrap -p rsvelte_fmt -p rsvelte_lint -p rsvelte_projection
--all-targets --all-features -- -D warnings` is clean, with no `-A` suppressions.

## Deliberately NOT fixed (itemised for follow-ups on #1791)

1. **`crates/rsvelte_fmt/tests/svelte_dev_markdown.rs:114`** and
   **`crates/rsvelte_formatter/tests/svelte_dev_corpus.rs:196`** — gated on `submodules/svelte.dev`,
   which the main `test` job deliberately does not check out. A blanket `CI` assert would be wrong;
   these need a job-scoped variable (e.g. assert on `FMT_CORPUS_OXFMT` being set) instead. **This is
   the highest-value remaining item** — it is the only one where the prerequisite is genuinely
   absent in some CI jobs and present in others, which is the condition under which a wrong guard
   is worse than none.
2. **`crates/rsvelte_fmt/tests/cli/tailwind.rs:204,239,470,503`** — gated on
   `RSVELTE_FMT_TW_TEST_DIR`, set only at `ci.yml:613`. Same job-scoped shape as (1). The `node`
   half of this file is fixed here; the Tailwind-env half is not.
3. **`STRICT_S2TSX_FIXTURES` / `STRICT_SOURCEMAPS`** — opt-in strictness flags that appear in no
   workflow, `package.json`, or script. These are not vacuous-pass bugs (the non-strict path still
   ratchets), but they are dead switches worth either wiring up or deleting.

## False positive I am retracting

`crates/rsvelte_projection/tests/svelte2tsx_fixtures.rs:36` reads its ratchet with a
`let Ok(text) = ... else { return BTreeSet::new() }`. This looks like the `unwrap_or_default()`
shape from issue item 7, but it is **not** a vacuous pass: an empty baseline makes every known
failure count as a *new* regression, so a missing ratchet fails loudly rather than greening. Only
the skip at line 71 in that file was a real defect.

Also worth recording as a genuine negative: a full sweep of `scripts/**/*.mjs` (70 files, ~25 of
them actual gates) found **no** surviving zero-match-passes-silently harness. PRs #2234 and #2245
closed that population, and the remaining `?? []` baseline reads all fail in the strict direction.

## Scope

`test(...)` only — no shipped behaviour changes, so no changeset. Nine test files, +97/-10.
