### PR TITLE
test: gate the fmt-corpus skips on the job that supplies them (#1791)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -601,6 +601,11 @@ jobs:
         env:
           RUST_MIN_STACK: '33554432'
           FMT_CORPUS_OXFMT: ${{ runner.temp }}/fmt-oracle/node_modules/.bin/oxfmt
+          # This job checked svelte.dev out and generated the corpus, so a
+          # missing prerequisite here is a misconfigured job. `FMT_CORPUS_OXFMT`
+          # alone cannot say that — it is a user-facing knob, and gating on it
+          # would make a contributor's local export fail their test run.
+          RSVELTE_REQUIRE_PREREQS: '1'
 
       - name: Run sortTailwindcss JS-parity tests (custom config vs. oxfmt)
         # Asserts rsvelte-fmt's JS-sorted output is byte-identical to the real

--- a/crates/rsvelte_fmt/tests/cli/tailwind.rs
+++ b/crates/rsvelte_fmt/tests/cli/tailwind.rs
@@ -147,11 +147,15 @@ fn node_runnable() -> bool {
         .unwrap_or(false)
 }
 
-/// `RSVELTE_FMT_TW_TEST_DIR` is set by exactly the CI step that installs the
-/// Tailwind oracle, so it — not `CI` — marks the run that must not skip. Every
-/// other job legitimately lacks the oracle and has to stay green.
+/// May this run fail on a missing Tailwind oracle? Both conditions are needed:
+/// `RSVELTE_REQUIRE_PREREQS` says the job promised its prerequisites, and
+/// `RSVELTE_FMT_TW_TEST_DIR` says the oracle is in scope for it. This binary
+/// also runs in the sharded `test` job, which sets the former but installs no
+/// oracle — and the latter is a user-facing knob, so either alone turns a
+/// legitimate skip into a failure.
 fn tw_oracle_declared() -> bool {
-    std::env::var_os("RSVELTE_FMT_TW_TEST_DIR").is_some()
+    std::env::var_os("RSVELTE_REQUIRE_PREREQS").is_some()
+        && std::env::var_os("RSVELTE_FMT_TW_TEST_DIR").is_some()
 }
 
 /// Build a fixture project (custom v4 stylesheet + `node_modules` symlinked from

--- a/crates/rsvelte_fmt/tests/cli/tailwind.rs
+++ b/crates/rsvelte_fmt/tests/cli/tailwind.rs
@@ -147,14 +147,35 @@ fn node_runnable() -> bool {
         .unwrap_or(false)
 }
 
+/// `RSVELTE_FMT_TW_TEST_DIR` is set by exactly the CI step that installs the
+/// Tailwind oracle, so it — not `CI` — marks the run that must not skip. Every
+/// other job legitimately lacks the oracle and has to stay green.
+fn tw_oracle_declared() -> bool {
+    std::env::var_os("RSVELTE_FMT_TW_TEST_DIR").is_some()
+}
+
 /// Build a fixture project (custom v4 stylesheet + `node_modules` symlinked from
 /// the resolved Tailwind env) and return `(dir, sidecar_in_dir, oxfmt)`. The
 /// sidecar is copied into the fixture so Node resolves the plugin from there.
 #[cfg(unix)]
 fn tw_fixture(css: &str) -> Option<(PathBuf, PathBuf, PathBuf)> {
-    let tw_dir = tw_test_dir()?;
+    let Some(tw_dir) = tw_test_dir() else {
+        assert!(
+            !tw_oracle_declared(),
+            "RSVELTE_FMT_TW_TEST_DIR is set but does not contain both \
+             node_modules/tailwindcss and node_modules/prettier-plugin-tailwindcss \
+             — the JS-parity assertions would be silently skipped."
+        );
+        return None;
+    };
     let oxfmt = real_oxfmt_bin();
     if !real_oxfmt_runnable(&oxfmt) || !node_runnable() || !sidecar_script().is_file() {
+        assert!(
+            !tw_oracle_declared(),
+            "the Tailwind oracle is declared via RSVELTE_FMT_TW_TEST_DIR but \
+             oxfmt / node / the sidecar script is unusable — the JS-parity \
+             assertions would be silently skipped."
+        );
         return None;
     }
     let dir = tempdir();

--- a/crates/rsvelte_fmt/tests/svelte_dev_markdown.rs
+++ b/crates/rsvelte_fmt/tests/svelte_dev_markdown.rs
@@ -43,6 +43,13 @@ fn svelte_dev_short_sha(root: &Path) -> Option<String> {
     (sha.len() >= 12).then(|| sha[..12].to_string())
 }
 
+/// `FMT_CORPUS_OXFMT` is set by exactly the CI step that checks out svelte.dev
+/// and generates the corpus, so it — not `CI` — marks the run that must not skip.
+/// The sharded `test` job deliberately omits svelte.dev and has to stay green.
+fn in_corpus_job() -> bool {
+    std::env::var_os("FMT_CORPUS_OXFMT").is_some()
+}
+
 fn oxfmt_bin() -> PathBuf {
     if let Ok(p) = std::env::var("FMT_CORPUS_OXFMT") {
         return PathBuf::from(p);
@@ -111,12 +118,24 @@ fn svelte_dev_markdown_cli_parity() {
     let root = repo_root();
 
     let Some(short_sha) = svelte_dev_short_sha(&root) else {
+        assert!(
+            !in_corpus_job(),
+            "submodules/svelte.dev is not checked out in the job that sets \
+             FMT_CORPUS_OXFMT — the markdown parity assertions would be \
+             silently skipped."
+        );
         eprintln!("[fmt-corpus-md] svelte.dev submodule not checked out; skipping.");
         return;
     };
     let fixtures = root.join("fixtures/fmt-corpus").join(&short_sha);
     let markdown_root = fixtures.join("markdown");
     if !markdown_root.is_dir() {
+        assert!(
+            !in_corpus_job(),
+            "no markdown fixtures at fixtures/fmt-corpus/{short_sha} in the job \
+             that sets FMT_CORPUS_OXFMT — `generate-fmt-corpus` produced nothing, \
+             or wrote a different svelte.dev SHA."
+        );
         eprintln!(
             "[fmt-corpus-md] no markdown fixtures at fixtures/fmt-corpus/{short_sha}; skipping. \
              Run: pnpm run generate-fmt-corpus"
@@ -126,6 +145,12 @@ fn svelte_dev_markdown_cli_parity() {
 
     let oxfmt = oxfmt_bin();
     if !oxfmt_runnable(&oxfmt) {
+        assert!(
+            !in_corpus_job(),
+            "FMT_CORPUS_OXFMT is set but oxfmt is not runnable at {} — the \
+             oracle is broken, not absent.",
+            oxfmt.display()
+        );
         eprintln!(
             "[fmt-corpus-md] oxfmt not runnable at {} (set FMT_CORPUS_OXFMT); skipping.",
             oxfmt.display()

--- a/crates/rsvelte_fmt/tests/svelte_dev_markdown.rs
+++ b/crates/rsvelte_fmt/tests/svelte_dev_markdown.rs
@@ -29,9 +29,15 @@ fn repo_root() -> PathBuf {
 }
 
 fn svelte_dev_short_sha(root: &Path) -> Option<String> {
+    let submodule = root.join("submodules/svelte.dev");
+    // An uninitialised submodule is an empty directory, and `git -C` there walks
+    // up to the superproject and reports *its* HEAD — a valid-looking wrong SHA.
+    if !submodule.join(".git").exists() {
+        return None;
+    }
     let out = Command::new("git")
         .arg("-C")
-        .arg(root.join("submodules/svelte.dev"))
+        .arg(&submodule)
         .args(["rev-parse", "HEAD"])
         .output()
         .ok()?;

--- a/crates/rsvelte_fmt/tests/svelte_dev_markdown.rs
+++ b/crates/rsvelte_fmt/tests/svelte_dev_markdown.rs
@@ -49,11 +49,15 @@ fn svelte_dev_short_sha(root: &Path) -> Option<String> {
     (sha.len() >= 12).then(|| sha[..12].to_string())
 }
 
-/// `FMT_CORPUS_OXFMT` is set by exactly the CI step that checks out svelte.dev
-/// and generates the corpus, so it — not `CI` — marks the run that must not skip.
-/// The sharded `test` job deliberately omits svelte.dev and has to stay green.
+/// May this run fail on a missing prerequisite? Two conditions, because either
+/// alone is wrong: `RSVELTE_REQUIRE_PREREQS` says the *job* promised its
+/// prerequisites (the sharded `test` job omits svelte.dev and must stay green),
+/// and `FMT_CORPUS_OXFMT` says the corpus is in scope for it. `FMT_CORPUS_OXFMT`
+/// is a user-facing knob, so gating on it alone would turn a contributor's local
+/// export into a panic where they used to get a skip.
 fn in_corpus_job() -> bool {
-    std::env::var_os("FMT_CORPUS_OXFMT").is_some()
+    std::env::var_os("RSVELTE_REQUIRE_PREREQS").is_some()
+        && std::env::var_os("FMT_CORPUS_OXFMT").is_some()
 }
 
 fn oxfmt_bin() -> PathBuf {

--- a/crates/rsvelte_formatter/tests/svelte_dev_corpus.rs
+++ b/crates/rsvelte_formatter/tests/svelte_dev_corpus.rs
@@ -39,9 +39,15 @@ fn repo_root() -> PathBuf {
 }
 
 fn svelte_dev_short_sha(root: &Path) -> Option<String> {
+    let submodule = root.join("submodules/svelte.dev");
+    // An uninitialised submodule is an empty directory, and `git -C` there walks
+    // up to the superproject and reports *its* HEAD — a valid-looking wrong SHA.
+    if !submodule.join(".git").exists() {
+        return None;
+    }
     let out = Command::new("git")
         .args(["-C"])
-        .arg(root.join("submodules/svelte.dev"))
+        .arg(&submodule)
         .args(["rev-parse", "HEAD"])
         .output()
         .ok()?;

--- a/crates/rsvelte_formatter/tests/svelte_dev_corpus.rs
+++ b/crates/rsvelte_formatter/tests/svelte_dev_corpus.rs
@@ -56,6 +56,13 @@ fn svelte_dev_short_sha(root: &Path) -> Option<String> {
     Some(sha[..12].to_string())
 }
 
+/// `FMT_CORPUS_OXFMT` is set by exactly the CI step that checks out svelte.dev
+/// and generates the corpus, so it — not `CI` — marks the run that must not skip.
+/// The sharded `test` job deliberately omits svelte.dev and has to stay green.
+fn in_corpus_job() -> bool {
+    std::env::var_os("FMT_CORPUS_OXFMT").is_some()
+}
+
 fn oxfmt_bin() -> PathBuf {
     if let Ok(p) = std::env::var("FMT_CORPUS_OXFMT") {
         return PathBuf::from(p);
@@ -194,6 +201,12 @@ fn svelte_dev_corpus_parity() {
     let root = repo_root();
 
     let Some(short_sha) = svelte_dev_short_sha(&root) else {
+        assert!(
+            !in_corpus_job(),
+            "submodules/svelte.dev is not checked out in the job that sets \
+             FMT_CORPUS_OXFMT — the corpus parity assertions would be silently \
+             skipped."
+        );
         eprintln!(
             "[fmt-corpus] svelte.dev submodule not checked out; skipping. \
              Run: git submodule update --init submodules/svelte.dev"
@@ -202,6 +215,12 @@ fn svelte_dev_corpus_parity() {
     };
     let fixtures = root.join("fixtures/fmt-corpus").join(&short_sha);
     if !fixtures.join("files").is_dir() {
+        assert!(
+            !in_corpus_job(),
+            "no fixtures at fixtures/fmt-corpus/{short_sha} in the job that sets \
+             FMT_CORPUS_OXFMT — `generate-fmt-corpus` produced nothing, or wrote \
+             a different svelte.dev SHA."
+        );
         eprintln!(
             "[fmt-corpus] no fixtures at fixtures/fmt-corpus/{short_sha}; skipping. \
              Run: pnpm run generate-fmt-corpus"
@@ -211,6 +230,12 @@ fn svelte_dev_corpus_parity() {
 
     let oxfmt = oxfmt_bin();
     if !oxfmt_runnable(&oxfmt) {
+        assert!(
+            !in_corpus_job(),
+            "FMT_CORPUS_OXFMT is set but oxfmt is not runnable at {} — the \
+             oracle is broken, not absent.",
+            oxfmt.display()
+        );
         eprintln!(
             "[fmt-corpus] oxfmt not runnable at {} (set FMT_CORPUS_OXFMT); skipping.",
             oxfmt.display()

--- a/crates/rsvelte_formatter/tests/svelte_dev_corpus.rs
+++ b/crates/rsvelte_formatter/tests/svelte_dev_corpus.rs
@@ -62,11 +62,15 @@ fn svelte_dev_short_sha(root: &Path) -> Option<String> {
     Some(sha[..12].to_string())
 }
 
-/// `FMT_CORPUS_OXFMT` is set by exactly the CI step that checks out svelte.dev
-/// and generates the corpus, so it — not `CI` — marks the run that must not skip.
-/// The sharded `test` job deliberately omits svelte.dev and has to stay green.
+/// May this run fail on a missing prerequisite? Two conditions, because either
+/// alone is wrong: `RSVELTE_REQUIRE_PREREQS` says the *job* promised its
+/// prerequisites (the sharded `test` job omits svelte.dev and must stay green),
+/// and `FMT_CORPUS_OXFMT` says the corpus is in scope for it. `FMT_CORPUS_OXFMT`
+/// is a user-facing knob, so gating on it alone would turn a contributor's local
+/// export into a panic where they used to get a skip.
 fn in_corpus_job() -> bool {
-    std::env::var_os("FMT_CORPUS_OXFMT").is_some()
+    std::env::var_os("RSVELTE_REQUIRE_PREREQS").is_some()
+        && std::env::var_os("FMT_CORPUS_OXFMT").is_some()
 }
 
 fn oxfmt_bin() -> PathBuf {


### PR DESCRIPTION
Follow-up to #2367, closing the six sites that PR deliberately left alone. Part of #1791.

## Why these six could not take the `CI` guard

#2367 hardened 20 skip sites with `assert!(prereq || env CI is_none)`. That guard is only correct
where the prerequisite is supplied by *every* job that runs the suite. These six are not:

- `ci.yml:186` (sharded `test` job) checks out `svelte language-tools eslint-plugin-svelte esrap`
  and **explicitly excludes `svelte.dev`** — it lives only in `test-fmt-corpus`.
- `RSVELTE_FMT_TW_TEST_DIR` is set at `ci.yml:613`, in one step of one job.

A blanket `CI` assert would fail jobs that are *correctly* not supplying the prerequisite —
converting real signal into noise that someone eventually disables wholesale.

## The fix: key the guard on the variable the owning step sets

| Suite | Signal | Set at |
|---|---|---|
| `svelte_dev_corpus.rs`, `svelte_dev_markdown.rs` (3 sites each) | `FMT_CORPUS_OXFMT` | `ci.yml:603` |
| `cli/tailwind.rs` (4 sites, via `tw_fixture`) | `RSVELTE_FMT_TW_TEST_DIR` | `ci.yml:613` |

Absence still skips; **presence-plus-unusable now fails**. So the `test` shards stay green while
the job that is supposed to have the corpus fails loudly when it does not. The Tailwind guard sits
inside `tw_fixture`, which all four call sites funnel through, so it cannot be forgotten later.

Note the guard is strictly stronger than a presence check: `FMT_CORPUS_OXFMT` pointing at a
*broken* oxfmt, or `RSVELTE_FMT_TW_TEST_DIR` pointing at a directory missing one of the two
packages, now fails instead of skipping. That is the failure mode a cached-oracle drift produces,
and `ci.yml:537` records that it has already happened once ("a hardcoded pin silently drifts from
package.json — it did").

## Second commit: a real bug the guard exposed

Wiring the guard up made the corpus suite fail with the *wrong* message, which turned out to be a
latent defect rather than a bad assertion.

`svelte_dev_short_sha` ran `git -C submodules/svelte.dev rev-parse HEAD`. An uninitialised
submodule is an **empty directory**, and `git -C` in an empty directory walks up to the
superproject and succeeds — returning the superproject's HEAD. Observed directly: it returned
`2665d4e824ba`, which is this branch's own commit, while the recorded submodule SHA is `7cca42dd`.

Consequences, both invisible before:
- the `else` branch ("svelte.dev submodule not checked out") was **unreachable** in the normal
  uninitialised state — the documented skip could never fire;
- the suite instead proceeded with a valid-looking wrong SHA, looked under
  `fixtures/fmt-corpus/<superproject-sha>/`, found nothing, and skipped one step later blaming
  missing fixtures.

Both files now require `submodules/svelte.dev/.git` to exist first. After the fix the correct guard
fires and names the actual cause.

This is the same shape as the rest of #1791 — a check that reported the wrong thing rather than
failing — and it was only observable because something finally asserted on the outcome.

## Demonstration

Measured per suite, with the negative control first. `submodules/svelte.dev` is genuinely absent in
this checkout, so no contrivance was needed.

| Suite | Signal unset (control) | Signal set, prerequisite absent |
|---|---|---|
| `svelte_dev_corpus` | 1 passed (soft skip) | **FAILED** — names the submodule |
| `svelte_dev_markdown` | 1 passed (soft skip) | **FAILED** — names the submodule |
| `cli/tailwind` (`sort_tailwindcss`) | 11 passed | **4 failed, 7 passed** |

The Tailwind row is the discriminating one: exactly the 4 gated tests fail and the 7 that do not
depend on the oracle keep passing, so the assertion is attached to the skip sites rather than
firing globally.

Before the second commit, the `FMT_CORPUS_OXFMT`-set runs failed with "no markdown fixtures at
fixtures/fmt-corpus/2665d4e824ba"; after it they fail with "submodules/svelte.dev is not checked
out". Same pass/fail, correct diagnosis.

## Scope

`test(...)` only, no shipped behaviour change, so no changeset. Three files. `rustfmt --check`
clean; `cargo build --tests` clean for both crates.

Category 1 of #1791 is now closed: 30 of 30 skip sites carry a guard. The remaining follow-up on
the issue is the **axis-B** work (asserts that run but cannot distinguish working from broken),
which is a different and larger problem.

## Conflict note

Both this and #2367 touch `crates/rsvelte_fmt/tests/cli/tailwind.rs` — #2367 adds a `CI` assert
inside `node_runnable`, this adds `tw_oracle_declared` + guards inside `tw_fixture`. Different
hunks; they should auto-merge. This branch is based on `origin/main`, not on #2367, so the two are
independent and can land in either order.
