### PR TITLE
fix(compiler): copy await trivia into the `track_reactivity_loss` wrap (#2090)

### DIFF
--- a/.changeset/quiet-moons-clap.md
+++ b/.changeset/quiet-moons-clap.md
@@ -1,0 +1,5 @@
+---
+'@rsvelte/compiler': patch
+---
+
+fix(compiler): keep a comment between `await` and its argument in the dev `$.track_reactivity_loss` wrap

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/await_reactivity_loss_ast.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/await_reactivity_loss_ast.rs
@@ -293,11 +293,13 @@ impl<'a, 'src> Visit<'a> for AwaitCollector<'src> {
             return;
         }
 
-        // Copy from just past the `await` keyword, not from the argument: the
-        // trivia between them holds comments that upstream flushes inside the
-        // call, and slicing at the argument would drop them.
+        // Copy the operand region the replacement covers — from just past the
+        // `await` keyword to the expression's own end. Ending at the argument
+        // instead would drop the trivia holding comments upstream flushes
+        // inside the call, and would cut a parenthesized argument short of its
+        // `)` wherever the parse does not preserve parens.
         let arg_start = expr.span.start as usize + "await".len();
-        let arg_text = self.source[arg_start..expr.argument.span().end as usize].trim();
+        let arg_text = self.source[arg_start..expr.span.end as usize].trim();
         let wrap = track_reactivity_loss_wrap(arg_text);
         // The `;` rides inside this edit rather than as an insertion of its own,
         // which `splice`'s innermost-only filter would read as nested.

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/await_reactivity_loss_ast.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/await_reactivity_loss_ast.rs
@@ -293,8 +293,11 @@ impl<'a, 'src> Visit<'a> for AwaitCollector<'src> {
             return;
         }
 
-        let arg_span = expr.argument.span();
-        let arg_text = self.source[arg_span.start as usize..arg_span.end as usize].trim();
+        // Copy from just past the `await` keyword, not from the argument: the
+        // trivia between them holds comments that upstream flushes inside the
+        // call, and slicing at the argument would drop them.
+        let arg_start = expr.span.start as usize + "await".len();
+        let arg_text = self.source[arg_start..expr.argument.span().end as usize].trim();
         let wrap = track_reactivity_loss_wrap(arg_text);
         // The `;` rides inside this edit rather than as an insertion of its own,
         // which `splice`'s innermost-only filter would read as nested.

--- a/crates/rsvelte_core/tests/await_reactivity_loss_comment_2090.rs
+++ b/crates/rsvelte_core/tests/await_reactivity_loss_comment_2090.rs
@@ -49,6 +49,21 @@ fn every_comment_in_the_run_is_kept() {
     );
 }
 
+/// The copied region runs to the `await` expression's own end, so a
+/// parenthesized operand keeps its closing paren however the parse treats
+/// parens — ending the copy at the argument would emit `(load()`.
+#[test]
+fn a_parenthesized_operand_stays_balanced() {
+    let src = "export async function f() {\n\treturn (await (load()))();\n}\n";
+    let out = module(src);
+    assert_contains(&out, "$.track_reactivity_loss((load()))");
+    assert_eq!(
+        out.matches('(').count(),
+        out.matches(')').count(),
+        "unbalanced parens:\n{out}"
+    );
+}
+
 /// Upstream breaks the call across lines for a line comment
 /// (`$.track_reactivity_loss(\n\t// hi\n\tload()\n)`); splicing source text
 /// keeps it on the opening line. oxfmt collapses the two layouts to the same

--- a/crates/rsvelte_core/tests/await_reactivity_loss_comment_2090.rs
+++ b/crates/rsvelte_core/tests/await_reactivity_loss_comment_2090.rs
@@ -49,9 +49,12 @@ fn every_comment_in_the_run_is_kept() {
     );
 }
 
-/// The copied region runs to the `await` expression's own end, so a
-/// parenthesized operand keeps its closing paren however the parse treats
-/// parens — ending the copy at the argument would emit `(load()`.
+/// Preservation guard, not a regression test: this caller parses with
+/// `ParseOptions::default()`, where `preserve_parens` makes the argument span
+/// cover the parens, so it passes on either end bound. It would start
+/// discriminating only under `preserve_parens: false`, which is why the copy
+/// runs to the expression's own end — the read range then equals the written
+/// range by construction rather than by coincidence.
 #[test]
 fn a_parenthesized_operand_stays_balanced() {
     let src = "export async function f() {\n\treturn (await (load()))();\n}\n";

--- a/crates/rsvelte_core/tests/await_reactivity_loss_comment_2090.rs
+++ b/crates/rsvelte_core/tests/await_reactivity_loss_comment_2090.rs
@@ -1,0 +1,71 @@
+//! A comment between `await` and its argument survives the dev
+//! `$.track_reactivity_loss` wrap.
+//!
+//! Upstream rebuilds the expression as `b.call('$.track_reactivity_loss',
+//! argument)` and esrap flushes the comment positionally just before the
+//! argument, so it lands inside the call. rsvelte splices the argument's source
+//! text, which starts at the argument and therefore left the trivia between the
+//! `await` keyword and the argument outside the replaced range — dropping it.
+//!
+//! Expected strings are the official compiler's output.
+
+use rsvelte_core::compiler::ModuleCompileOptions;
+use rsvelte_core::{GenerateMode, compile_module};
+
+fn module(src: &str) -> String {
+    compile_module(
+        src,
+        ModuleCompileOptions {
+            filename: Some("m.svelte.js".to_string()),
+            generate: GenerateMode::Client,
+            dev: true,
+            ..Default::default()
+        },
+    )
+    .expect("compile")
+    .js
+    .code
+}
+
+#[track_caller]
+fn assert_contains(out: &str, expected: &str) {
+    assert!(out.contains(expected), "expected `{expected}`. Got:\n{out}");
+}
+
+const WRAPPED: &str = "(await $.track_reactivity_loss(/* hi */ load()))()";
+
+#[test]
+fn svelte_js_module_keeps_the_comment() {
+    let src = "export async function f() {\n\treturn await /* hi */ load();\n}\n";
+    assert_contains(&module(src), WRAPPED);
+}
+
+#[test]
+fn every_comment_in_the_run_is_kept() {
+    let src = "export async function f() {\n\treturn await /* a */ /* b */ load();\n}\n";
+    assert_contains(
+        &module(src),
+        "(await $.track_reactivity_loss(/* a */ /* b */ load()))()",
+    );
+}
+
+/// Upstream breaks the call across lines for a line comment
+/// (`$.track_reactivity_loss(\n\t// hi\n\tload()\n)`); splicing source text
+/// keeps it on the opening line. oxfmt collapses the two layouts to the same
+/// bytes, so only the comment's survival is pinned here.
+#[test]
+fn a_line_comment_survives() {
+    let src = "export async function f() {\n\treturn await // hi\n\t\tload();\n}\n";
+    let out = module(src);
+    assert_contains(&out, "$.track_reactivity_loss(");
+    assert_contains(&out, "// hi");
+}
+
+/// The wrap is skipped entirely when ignored, so the source is untouched.
+#[test]
+fn an_ignored_await_is_left_alone() {
+    let src = "export async function f() {\n\t// svelte-ignore await_reactivity_loss\n\treturn await /* hi */ load();\n}\n";
+    let out = module(src);
+    assert!(!out.contains("track_reactivity_loss"), "got:\n{out}");
+    assert_contains(&out, "/* hi */");
+}

--- a/crates/rsvelte_core/tests/await_reactivity_loss_comment_2090.rs
+++ b/crates/rsvelte_core/tests/await_reactivity_loss_comment_2090.rs
@@ -79,7 +79,9 @@ fn a_line_comment_survives() {
     assert_contains(&out, "// hi");
 }
 
-/// The wrap is skipped entirely when ignored, so the source is untouched.
+/// Covers the ignore gate rather than the copy: this `await` returns before
+/// reaching the copied range, so the assertion moves when the gate breaks, not
+/// when the end bound changes.
 #[test]
 fn an_ignored_await_is_left_alone() {
     let src = "export async function f() {\n\t// svelte-ignore await_reactivity_loss\n\treturn await /* hi */ load();\n}\n";


### PR DESCRIPTION
Partial fix for #2090 — sub-problem 4, `.svelte.(js|ts)` module path.

## What actually reproduces

Sub-problems 1–3 are confirmed fixed on `main` (`88b8d2b7`); only 4 remains, and it is
**smaller and differently located** than the issue's last comment says.

The issue lists four shapes under sub-problem 4. Each was run through the real corpus
normalizer (`flattenTemplateHoles` → oxfmt → `stripBlankLines`, with
`compatibility/.oxfmtrc.json`, the config `one.mjs` uses). **Three are not gate-visible
under oxfmt 0.62.0**:

| shape | raw | after normalization (oxfmt **0.62.0**) | oxfmt rewrote both sides |
|---|---|---|---|
| `await (load())` keeps parens | differs | MATCH | yes |
| one-lined `for await` / method bodies | differs | MATCH | yes |
| blank line before trailing `export { … }` | **already matched raw** | MATCH | yes |
| **inner comment dropped** | differs | **DIFFERS** — the gate-visible one | yes |
| control: identical inputs | — | MATCH | yes |
| control: `= 1` vs `= 2` | — | DIFFERS | yes |

Three notes on how to read that table, because each row rests on different evidence:

- **The version is load-bearing and was initially wrong.** The first run was made with the
  oxfmt actually installed here — **0.61.0** — while `package.json` pins `^0.62.0` (#2249);
  no install had run since the bump. The table above is a re-run against a freshly
  installed 0.62.0, not an inference from the 0.61 numbers. A MATCH under one formatter
  version does **not** imply a MATCH under another: normalization is applied to each side
  independently, and a more-collapsing normalizer *manufactures* MATCHes rather than
  preserving them. The paren row is the one least entitled to be carried by implication,
  since paren handling is exactly what moves between versions — so it was measured, not
  inherited.
- **"Not gate-visible" is not "equivalent output."** The compiler still emits the divergent
  bytes; normalization is comparison-side only. These return the moment oxfmt's paren or
  layout handling shifts.
- **The controls are what make the MATCH rows mean anything.** oxfmt 0.62 has been observed
  to walk zero files and exit 0, which yields MATCH for any input including one it never
  touched. Each row therefore reports whether oxfmt actually rewrote the text, and the two
  controls show the harness moving in both directions.

The `export { … }` row is the only version-independent one — it already matched **raw**.

So sub-problem 4 reduces to exactly one thing: a comment between `await` and its argument
is dropped.

## Root cause

`await_reactivity_loss_ast.rs` sliced the **argument's own span** for the replacement text:

```rust
let arg_span = expr.argument.span();
let arg_text = self.source[arg_span.start as usize..arg_span.end as usize].trim();
```

`/* hi */` in `await /* hi */ load()` sits between the `await` keyword and the argument, so
it fell outside that slice and was dropped. Upstream rebuilds the node as
`b.call('$.track_reactivity_loss', argument)` and esrap flushes the comment positionally
just before the argument, landing it inside the call — so copying from just past the `await`
keyword is the faithful mirror, not a workaround.

## Not a `.svelte.js` verbatim-copy problem

The issue attributes this to the `.svelte.(js|ts)` path's verbatim source copying and defers
it to the AST-ification thread (#2308). Measured: the comment is dropped in **all four**
script kinds — `.svelte.js`, `<script module>`, runes instance, legacy instance — and
official keeps it in all four. It is the shared await rewrite, not the module path.

## Scope of this PR

Fixes the `.svelte.(js|ts)` module path, verified end to end. The three component script
kinds still drop it **downstream of this pass** — instrumented, the collector now hands back
`(await $.track_reactivity_loss(/* hi */ load()))()` correctly for `<script module>` and the
legacy instance script, and the comment is lost after that; the runes instance script never
reaches this collector at all (it goes through `visitors/expression_converter.rs`, which
builds IR nodes and carries no comments). That is a separate, larger cluster and I am
reporting it rather than half-landing it.

Tests are the official compiler's output: block comment, a run of two comments, a line
comment, and the `svelte-ignore` path (which already passed — the wrap is skipped, so the
source is untouched). Each of the five was classified by mutation rather than by reading, because "guard" is
otherwise a label that absorbs any test that happens to pass on both revisions:

| test | mutant that kills it |
|---|---|
| `svelte_js_module_keeps_the_comment` | the copy's start bound |
| `every_comment_in_the_run_is_kept` | the copy's start bound |
| `a_line_comment_survives` | the copy's start bound |
| `an_ignored_await_is_left_alone` | **the `svelte-ignore` gate** — a different property |
| `a_parenthesized_operand_stays_balanced` | **none currently reachable** |

So it is three discriminating the copy fix, one discriminating the ignore gate, and **one
genuinely inert**. Grouping the last two as "guards" would have hidden that only one of
them is inert: disabling `self.ignored.contains(...)` fails the ignore test, while
reverting the end bound to `expr.argument.span().end` fails nothing at all.

That last row is worth stating plainly: **no test in this suite discriminates the end-bound
change**, because this caller parses with `ParseOptions::default()`, so `preserve_parens`
makes the argument span cover the parens and both bounds slice identical text. The change
is kept on a structural argument, not a tested one — the read range now equals the written
range by construction instead of by coincidence, which is what breaks the day a caller
parses with `preserve_parens: false` (`destructure_transforms.rs:1090`, `:1118` already
do). Unobservable under this caller is not the same as unverifiable: a test constructing
such a caller would discriminate it. The line-comment case pins only the comment's survival, because
upstream breaks the call across lines and a source splice cannot; oxfmt collapses both
layouts to the same bytes, verified directly.

## Ratchet

Not run (disk). This should close `client-dev` entries whose only divergence is a dropped
comment inside an awaited expression in a `.svelte.(js|ts)` module; the two-sided ratchet
will confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## This PR changes component output, gate-invisible — added after review

Letting the comment survive makes an unrelated pre-existing defect observable. On the component `<script module>` path:

```js
official: return (await $.track_reactivity_loss(/* hi */ load()))();
this PR : return ((await $.track_reactivity_loss(/* hi */ load())))();
```

The comment lands in the right place; one redundant paren pair comes with it. Filed as #2381.

**It is not caused by this PR.** The defect lives in `rsvelte_esrap`'s comment-bearing `print_split` path, which the component path already takes on `origin/main`; it is unreachable for this shape today only because the comment is dropped before it gets there. Isolated: present with a comment, absent without.

**Not visible to any corpus gate** — redundant parens are MATCH after `oxfmt` 0.62 + `stripBlankLines`, measured with a control confirming oxfmt rewrote both sides and negative controls in both directions. Recording it here rather than letting it ride silently: a byte divergence only the author knows about is what the ratchet justifications exist to prevent.

Trade taken deliberately: blocking this would keep the *comment* bug live in order to avoid surfacing a *paren* bug.


