### PR TITLE
fix(compiler): only exempt an event attribute's own arrow from the dev `$.assign` wrap (#2064)

### DIFF
--- a/.changeset/dev-assign-nested-event-arrow.md
+++ b/.changeset/dev-assign-nested-event-arrow.md
@@ -1,0 +1,5 @@
+---
+'@rsvelte/compiler': patch
+---
+
+fix(compiler): only exempt an event attribute's own arrow from the dev `$.assign` wrap

--- a/compatibility/known-failures.client-dev.json
+++ b/compatibility/known-failures.client-dev.json
@@ -1,3 +1,1 @@
-[
-	"runed/sites/docs/src/lib/components/demos/scroll-state.svelte"
-]
+[]

--- a/compatibility/known-failures.md
+++ b/compatibility/known-failures.md
@@ -225,11 +225,23 @@ the equality instrumentation, `$.track_reactivity_loss`, ownership mutation
 validation, `$.tag()` / `$.tag_proxy()`, `console.*` wrapping and the signal
 read/write row — was already empty.
 
-Still over-reaching, and not covered by any corpus entry: the exemption is
-carried by a level flag that stays set for the whole body conversion, so an
-assignment nested *inside* an exempt arrow's body
-(`onclick={() => (a.b = f(() => (c.d = e)))}`) is exempted too. Upstream would
-wrap the inner one.
+Two divergences remain here, both deferred only because **no corpus entry
+reaches them** — each has a check that distinguishes fixing from not, so neither
+is unverifiable:
+
+- **Over-reach.** The exemption is carried by a level flag that stays set for the
+  whole body conversion, so an assignment nested *inside* an exempt arrow's body
+  is exempted too. `onclick={() => (a.b = f(() => (c.d = e)))}` must emit
+  `$.assign(c, 'd'` and must not emit `$.assign(a, 'b'` — one input, both signs.
+  A boolean cannot express upstream's third conjunct, which is the *identity*
+  test `expression === context.path.at(-1)`; the exempt arrow has to be carried
+  by identity, not by a level.
+- **Under-reach, the opposite direction.** Upstream's guard names
+  `SvelteElement` alongside `RegularElement`, but `visit_event_attribute` is
+  reached only from `regular_element.rs`, so `<svelte:element this={tag}
+  onclick={() => (o.x = v)}>` is never exempt and emits
+  `$.assign(o, 'x', '=', v, …)` where upstream emits none. Measured, not
+  inferred.
 
 Counting method, for whoever picks this up: attribute an entry by **comparing
 how many times each helper appears** on each side, never by the first differing

--- a/compatibility/known-failures.md
+++ b/compatibility/known-failures.md
@@ -63,7 +63,7 @@ quoted key dropped in a destructured `$derived`) and #2034 (`$.to_array` arity
 with a rest element) — were resolved by #2036, which mirrored #2010's client
 destructuring fixes onto the server target.
 
-## Client dev (`known-failures.client-dev.json`, 1 entry)
+## Client dev (`known-failures.client-dev.json`, 0 entries)
 
 The `client-dev` target is the `client` target with `dev: true`. It is a
 separate ratchet because `dev` gates 18 client codegen files plus the CSS

--- a/compatibility/known-failures.md
+++ b/compatibility/known-failures.md
@@ -212,18 +212,24 @@ that separator still carry source-map segments.
 
 ### What is left
 
-One entry, contributed by the `runed` / `svelte-toolbelt` enrolment:
-`runed/sites/docs/src/lib/components/demos/scroll-state.svelte` writes
-`onsubmit={preventDefault(() => (scroll.x = x))}`, and rsvelte emits the bare
-`scroll.x = $.get(x)` where upstream wraps it as
-`$.assign(scroll, "x", "=", $.get(x), "…scroll-state.svelte:41:69")`. That is
-the `$.assign` row of #2064 — the coerced-away-proxy dev warning
-(`AssignmentExpression.js:170-236`) — reached here through an assignment nested
-inside a call argument in a template attribute expression. Every other
-dev-helper cluster the enrolment-era table tracked — the equality
-instrumentation, `$.track_reactivity_loss`, ownership mutation validation,
-`$.tag()` / `$.tag_proxy()`, `console.*` wrapping and the signal read/write
-row — is empty.
+Nothing. The last entry — `runed/…/demos/scroll-state.svelte`, which writes
+`onsubmit={preventDefault(() => (scroll.x = x))}` and had rsvelte emitting the
+bare `scroll.x = $.get(x)` where upstream wraps it as
+`$.assign(scroll, "x", "=", $.get(x), "…scroll-state.svelte:41:69")` — is fixed.
+The event-attribute exemption from the coerced-away-proxy dev warning
+(`AssignmentExpression.js:170-236`) was applied to every arrow anywhere in the
+attribute expression, but upstream requires the arrow to *be* that expression
+(`path.at(-2) === 'RegularElement'`), so an arrow passed as a call argument was
+never exempt. Every other dev-helper cluster the enrolment-era table tracked —
+the equality instrumentation, `$.track_reactivity_loss`, ownership mutation
+validation, `$.tag()` / `$.tag_proxy()`, `console.*` wrapping and the signal
+read/write row — was already empty.
+
+Still over-reaching, and not covered by any corpus entry: the exemption is
+carried by a level flag that stays set for the whole body conversion, so an
+assignment nested *inside* an exempt arrow's body
+(`onclick={() => (a.b = f(() => (c.d = e)))}`) is exempted too. Upstream would
+wrap the inner one.
 
 Counting method, for whoever picks this up: attribute an entry by **comparing
 how many times each helper appears** on each side, never by the first differing

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/attribute.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/attribute.rs
@@ -158,8 +158,15 @@ pub fn visit_event_attribute(node: &AttributeNode, context: &mut ComponentContex
     // Set in_event_attribute_handler flag so that coercive assignment transforms
     // ($.assign) are skipped inside event handler arrow functions.
     // Reference: AssignmentExpression.js lines 189-209
+    //
+    // Upstream's exemption is `path.at(-1) === 'ArrowFunctionExpression' &&
+    // path.at(-2) === 'RegularElement'`, so it only covers an arrow that IS the
+    // attribute's expression — `onsubmit={wrap(() => (o.x = v))}` still wraps.
     let saved_in_event_attribute = context.state.in_event_attribute_handler;
-    context.state.in_event_attribute_handler = true;
+    context.state.in_event_attribute_handler = matches!(
+        expr_tag.expression.as_node().node_type(),
+        Some("ArrowFunctionExpression")
+    );
     let handler = build_event_handler(expr_tag, context);
     context.state.in_event_attribute_handler = saved_in_event_attribute;
 

--- a/crates/rsvelte_core/tests/dev_assign_nested_event_arrow_2064.rs
+++ b/crates/rsvelte_core/tests/dev_assign_nested_event_arrow_2064.rs
@@ -1,0 +1,84 @@
+//! Upstream exempts `onclick={() => (obj.x = v)}` from the dev `$.assign` wrap
+//! only when the arrow **is** the event attribute's expression
+//! (`path.at(-1) === 'ArrowFunctionExpression' && path.at(-2) === 'RegularElement'`,
+//! `AssignmentExpression.js`). An arrow nested inside a call argument —
+//! `onsubmit={preventDefault(() => (obj.x = v))}` — is not exempt.
+
+use rsvelte_core::{CompileOptions, GenerateMode, compile};
+
+fn compile_client_dev(src: &str) -> String {
+    compile(
+        src,
+        CompileOptions {
+            filename: Some("Main.svelte".to_string()),
+            generate: GenerateMode::Client,
+            dev: true,
+            ..Default::default()
+        },
+    )
+    .expect("compile")
+    .js
+    .code
+}
+
+#[test]
+fn an_arrow_nested_in_a_call_argument_is_still_wrapped() {
+    let out = compile_client_dev(
+        r#"<script>
+	function preventDefault(fn) {
+		return function (event) {
+			event.preventDefault();
+			fn.call(this, event);
+		};
+	}
+
+	let scroll = $state({ x: 0 });
+	let x = $state(1);
+</script>
+
+<form onsubmit={preventDefault(() => (scroll.x = x))}></form>
+"#,
+    );
+    assert!(
+        out.contains("$.assign(scroll, 'x', '='"),
+        "an arrow inside a call argument is not the attribute expression, so the \
+         assignment must still be wrapped. got:\n{out}"
+    );
+}
+
+/// Pin, not a repro: green before the fix too. It guards the exemption the fix
+/// narrows — the shape that must keep it.
+#[test]
+fn the_attribute_expression_arrow_itself_stays_exempt() {
+    let out = compile_client_dev(
+        r#"<script>
+	let scroll = $state({ x: 0 });
+	let x = $state(1);
+</script>
+
+<button onclick={() => (scroll.x = x)}></button>
+"#,
+    );
+    assert!(
+        !out.contains("$.assign("),
+        "the arrow IS the attribute expression, so it stays exempt. got:\n{out}"
+    );
+}
+
+#[test]
+fn a_nested_arrow_that_is_not_under_an_event_attribute_is_wrapped() {
+    // Pin, not a repro: green before the fix too. Negative control for the
+    // flag's reach — no event attribute is involved at all.
+    let out = compile_client_dev(
+        r#"<script>
+	let scroll = $state({ x: 0 });
+	let x = $state(1);
+	const run = (fn) => fn();
+	const go = () => run(() => (scroll.x = x));
+</script>
+
+<button onclick={go}></button>
+"#,
+    );
+    assert!(out.contains("$.assign(scroll, 'x', '='"), "got:\n{out}");
+}


### PR DESCRIPTION
Closes the last `client-dev` ratchet entry. Part of #2064.

## Re-derived first — the issue is very stale

#2064's title says **~1740 entries**. Its own later comments re-measured that to 133, and
`compatibility/known-failures.client-dev.json` on `main` holds **1**. Of the four causes in
the title, only `$.assign` is still live; and of the eight structural sub-causes in the
2026-08-05 comment, **sub-cause B (17 entries, the largest and the one marked "ready to
implement") was already fixed** by #2316 (`ab2d6361`) — `props_transforms.rs` no longer has
the single `loc_cursor` that comment quotes.

So the one thing actually left is the `$.assign` row.

## The bug

`runed/sites/docs/src/lib/components/demos/scroll-state.svelte`:

```svelte
<form onsubmit={preventDefault(() => (scroll.x = x))}>
```

rsvelte emitted the bare `scroll.x = $.get(x)`; upstream emits
`$.assign(scroll, "x", "=", $.get(x), "…scroll-state.svelte:41:69")`.

`AssignmentExpression.js:183-201` exempts an event handler arrow from the coerced-away-proxy
warning **only when the arrow is the attribute's expression**:

```js
if (path.at(-1) === 'ArrowFunctionExpression' &&
    (path.at(-2) === 'RegularElement' || path.at(-2) === 'SvelteElement')) { … }
```

Here `path.at(-2)` is the `CallExpression`, so the exemption does not apply. rsvelte set
`in_event_attribute_handler` around the **whole** attribute expression, so any arrow anywhere
inside it — including one passed as a call argument — was exempted.

## The fix

One line of condition: set the flag only when the attribute expression is itself an arrow.

Dev-only by construction — the wrap returns early on `!context.state.dev`
(`expression_converter.rs:5115`), so the non-dev `client` target, which is at 0, cannot move.

## Tests

- **Repro** (fails on `main`): the arrow inside a call argument is wrapped.
- **Pin**: `onclick={() => (scroll.x = x)}` — the arrow *is* the attribute expression, stays exempt.
- **Pin**: a nested arrow with no event attribute anywhere is wrapped.

Both pins were green before the fix; they are labelled as pins in the file rather than counted
as repros.

## Ratchet

`known-failures.client-dev.json` goes to `[]` in this PR, as the two-sided ratchet requires. If
the fix does not in fact close that entry, CI will say so — that is the confirmation, not a
local corpus run (disk is tight and the corpus was not run).

## Left over, deliberately

The exemption is carried by a level flag that stays set for the whole body conversion, so an
assignment nested *inside* an exempt arrow's body — `onclick={() => (a.b = f(() => (c.d = e)))}` —
is still exempted, where upstream would wrap the inner one. No corpus entry covers it and I
could not justify shipping an unverifiable second change alongside this one. Recorded in
`known-failures.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
