### PR TITLE
fix(compiler): match destructuring brackets lexically (#2357)

### DIFF
--- a/.changeset/colon-depth0-byte-offset.md
+++ b/.changeset/colon-depth0-byte-offset.md
@@ -1,0 +1,11 @@
+---
+"@rsvelte/compiler": patch
+---
+
+fix(compiler): return a byte offset from `find_colon_at_depth0`
+
+The ternary-branch analysis in `check_identifier_in_statement` sliced its right-hand
+side with the position this returned, but the scan counted characters. A ternary
+whose true branch assigns a non-ASCII string literal — `cond ? x = "ああa" : x = y` —
+panicked with "byte index is not a char boundary". The scan also read a `:` written
+inside a comment as the branch separator.

--- a/.changeset/destructure-bracket-lexical.md
+++ b/.changeset/destructure-bracket-lexical.md
@@ -1,0 +1,10 @@
+---
+"@rsvelte/compiler": patch
+---
+
+fix(compiler): match destructuring brackets lexically
+
+`find_matching_open_bracket` walked backwards counting every `{`/`[` it saw,
+including ones inside string literals and comments. A destructuring assignment
+whose pattern carried a brace in a default value (`{ a = "}" } = obj`) or in a
+comment failed to find its opening bracket and was left untransformed.

--- a/.changeset/props-pattern-span-lexical.md
+++ b/.changeset/props-pattern-span-lexical.md
@@ -1,0 +1,12 @@
+---
+"@rsvelte/compiler": patch
+---
+
+fix(compiler): find the `$props()` pattern braces lexically
+
+`transform_props_destructuring` located the destructuring pattern with a raw
+`find('{')` / `rfind('}')`, so a JSDoc type annotation ahead of it —
+`let /** @type {Props} */ { a, b } = $props()`, idiomatic in JavaScript Svelte
+components — made the scan start at the annotation's brace and parse
+`Props} */ { a, b` as the prop list. A `}` in a trailing comment moved the
+closing brace the same way.

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/destructure_transforms.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/destructure_transforms.rs
@@ -218,9 +218,11 @@ pub(super) fn find_and_transform_one_destructure(
                 let close_bracket = c;
                 let open_bracket = if c == ']' { '[' } else { '{' };
 
-                // Walk backwards from position `i` to find the matching open bracket
+                // Walk backwards from position `i` to find the matching open bracket.
+                // The helper works in byte offsets; this loop indexes by char.
                 if let Some(pattern_start) =
-                    find_matching_open_bracket(statement, i, open_bracket, close_bracket)
+                    find_matching_open_bracket(statement, b(i), open_bracket, close_bracket)
+                        .and_then(|byte| byte_offsets.binary_search(&byte).ok())
                 {
                     let pattern_str = &statement[b(pattern_start)..b(i + 1)];
                     let rhs_start = j + 1;
@@ -481,24 +483,24 @@ fn is_inside_enclosing_pattern(statement: &str, pattern_open_byte: usize) -> boo
 }
 
 /// Find the matching opening bracket, respecting nesting and strings.
+/// `close_pos` and the returned position are **byte** offsets.
 pub(super) fn find_matching_open_bracket(
     s: &str,
     close_pos: usize,
     open_bracket: char,
     close_bracket: char,
 ) -> Option<usize> {
-    let chars: Vec<char> = s.chars().collect();
+    let (open, close) = (open_bracket as u8, close_bracket as u8);
+    // Collect forward so opaque runs are skipped, then walk the code bytes back.
+    let code: Vec<(usize, u8)> = code_bytes(s.as_bytes())
+        .take_while(|(i, _)| *i < close_pos)
+        .collect();
+
     let mut depth = 1;
-    let mut i = close_pos;
-
-    // Walk backwards
-    while i > 0 {
-        i -= 1;
-        let c = chars[i];
-
-        if c == close_bracket {
+    for &(i, c) in code.iter().rev() {
+        if c == close {
             depth += 1;
-        } else if c == open_bracket {
+        } else if c == open {
             depth -= 1;
             if depth == 0 {
                 return Some(i);
@@ -1605,5 +1607,30 @@ mod non_ascii_tests {
             extract_destructure_targets("{ a /* , b */, c }"),
             vec!["a".to_string(), "c".to_string()]
         );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn matching_open_bracket_ignores_string_contents() {
+        // `{ a = "}" } = obj` — the default value's `}` is text, not a closer.
+        let s = r#"{ a = "}" } = obj"#;
+        assert_eq!(find_matching_open_bracket(s, 10, '{', '}'), Some(0));
+    }
+
+    #[test]
+    fn matching_open_bracket_ignores_comment_contents() {
+        let s = "{ a, /* } */ b } = obj";
+        let close = s.rfind('}').unwrap();
+        assert_eq!(find_matching_open_bracket(s, close, '{', '}'), Some(0));
+    }
+
+    #[test]
+    fn matching_open_bracket_still_matches_nested() {
+        let s = "{ a: { b } } = obj";
+        assert_eq!(find_matching_open_bracket(s, 11, '{', '}'), Some(0));
     }
 }

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/props_transforms.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/props_transforms.rs
@@ -6,7 +6,7 @@ use std::fmt::Write as _;
 
 use crate::compiler::phases::phase2_analyze::ComponentAnalysis;
 use crate::compiler::phases::phase2_analyze::scope::BindingKind;
-use crate::compiler::phases::phase3_transform::shared::js_scan::skip_opaque;
+use crate::compiler::phases::phase3_transform::shared::js_scan::{code_bytes, skip_opaque};
 
 use super::scan_index::{ScanIndex, ScanIndexBuilder};
 use super::{
@@ -2572,6 +2572,21 @@ pub(super) fn strip_js_comments(code: &str) -> String {
 ///
 /// Multiple prop declarations are combined into a single `let` statement with
 /// comma-separated declarators, matching the official compiler output format.
+/// Byte span of the destructuring pattern's braces. A `/** @type {Props} */`
+/// annotation puts braces ahead of the pattern, so only code positions count.
+fn props_pattern_span(trimmed: &str) -> Option<(usize, usize)> {
+    let mut open = None;
+    let mut close = None;
+    for (i, c) in code_bytes(trimmed.as_bytes()) {
+        match c {
+            b'{' if open.is_none() => open = Some(i),
+            b'}' => close = Some(i),
+            _ => {}
+        }
+    }
+    Some((open?, close?))
+}
+
 pub(super) fn transform_props_destructuring(
     line: &str,
     prop_source_vars: &[String],
@@ -2635,8 +2650,7 @@ pub(super) fn transform_props_destructuring(
     }
 
     // Extract the part between { and }
-    let open_brace = trimmed.find('{')?;
-    let close_brace = trimmed.rfind('}')?;
+    let (open_brace, close_brace) = props_pattern_span(trimmed)?;
     let props_str = &trimmed[open_brace + 1..close_brace];
 
     // Parse each prop - collect declarators for combining into a single `let` statement
@@ -4357,5 +4371,32 @@ mod split_declarators_tests {
             transform_prop_reads_in_expr("cond ? active : 0", &["active".to_string()]),
             "cond ? active() : 0"
         );
+    }
+}
+
+#[cfg(test)]
+mod props_pattern_span_tests {
+    use super::props_pattern_span;
+
+    #[test]
+    fn jsdoc_type_braces_are_not_the_pattern() {
+        // `let /** @type {Props} */ { a, b } = $props();` — idiomatic in JS Svelte.
+        let line = "let /** @type {Props} */ { a, b } = $props();";
+        let (open, close) = props_pattern_span(line).unwrap();
+        assert_eq!(&line[open..=close], "{ a, b }");
+    }
+
+    #[test]
+    fn trailing_comment_brace_is_not_the_closer() {
+        let line = "let { a } = $props(); // }";
+        let (open, close) = props_pattern_span(line).unwrap();
+        assert_eq!(&line[open..=close], "{ a }");
+    }
+
+    #[test]
+    fn plain_pattern_is_unchanged() {
+        let line = "let { a, b } = $props();";
+        let (open, close) = props_pattern_span(line).unwrap();
+        assert_eq!(&line[open..=close], "{ a, b }");
     }
 }

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/state_transforms.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/state_transforms.rs
@@ -912,37 +912,54 @@ pub(super) fn find_assignment_position(expr: &str) -> Option<usize> {
 
 /// Find the position of a `:` at depth 0 in an expression.
 /// This is used to split ternary expressions like `true_rhs : false_branch`.
+/// The returned position is a **byte** offset: the caller slices `expr` with it.
 pub(super) fn find_colon_at_depth0(expr: &str) -> Option<usize> {
-    let chars: Vec<char> = expr.chars().collect();
+    // Not `code_bytes`: this scanner descends into `${…}` on purpose, and an
+    // opaque template skip would swallow it. UTF-8 continuation bytes are all
+    // >= 0x80, so they never match an ASCII arm.
+    let bytes = expr.as_bytes();
     let mut depth = 0;
     let mut i = 0;
 
-    while i < chars.len() {
-        match chars[i] {
-            '(' | '[' | '{' => depth += 1,
-            ')' | ']' | '}' => depth -= 1,
-            ':' if depth == 0 => return Some(i),
-            '\'' | '"' => {
-                // Skip string literals
-                let quote = chars[i];
+    while i < bytes.len() {
+        match bytes[i] {
+            b'(' | b'[' | b'{' => depth += 1,
+            b')' | b']' | b'}' => depth -= 1,
+            b':' if depth == 0 => return Some(i),
+            b'/' if bytes.get(i + 1) == Some(&b'/') => {
+                i += 2;
+                while i < bytes.len() && bytes[i] != b'\n' {
+                    i += 1;
+                }
+                continue;
+            }
+            b'/' if bytes.get(i + 1) == Some(&b'*') => {
+                i += 2;
+                while i < bytes.len() && !(bytes[i] == b'*' && bytes.get(i + 1) == Some(&b'/')) {
+                    i += 1;
+                }
                 i += 1;
-                while i < chars.len() && chars[i] != quote {
-                    if chars[i] == '\\' && i + 1 < chars.len() {
+            }
+            quote @ (b'\'' | b'"') => {
+                // Skip string literals
+                i += 1;
+                while i < bytes.len() && bytes[i] != quote {
+                    if bytes[i] == b'\\' && i + 1 < bytes.len() {
                         i += 1;
                     }
                     i += 1;
                 }
             }
-            '`' => {
+            b'`' => {
                 // Skip template literals
                 i += 1;
-                while i < chars.len() && chars[i] != '`' {
-                    if chars[i] == '$' && i + 1 < chars.len() && chars[i + 1] == '{' {
+                while i < bytes.len() && bytes[i] != b'`' {
+                    if bytes[i] == b'$' && bytes.get(i + 1) == Some(&b'{') {
                         depth += 1;
                         i += 1;
-                    } else if chars[i] == '}' && depth > 0 {
+                    } else if bytes[i] == b'}' && depth > 0 {
                         depth -= 1;
-                    } else if chars[i] == '\\' && i + 1 < chars.len() {
+                    } else if bytes[i] == b'\\' && i + 1 < bytes.len() {
                         i += 1;
                     }
                     i += 1;
@@ -1839,5 +1856,32 @@ mod non_ascii_tests {
         let vars = vec![("x".to_string(), None, DeclarationKind::Let)];
         let out = transform_legacy_state_declarations("let x: Café = 0", &vars, false, false);
         assert!(out.contains("$.mutable_source(0)"), "got: {out}");
+    }
+}
+
+#[cfg(test)]
+mod colon_depth0_tests {
+    use super::*;
+
+    #[test]
+    fn colon_position_is_a_byte_offset() {
+        // The caller slices `&str` with this, so it must be a byte offset.
+        let expr = "\"ああa\" : x";
+        let pos = find_colon_at_depth0(expr).unwrap();
+        assert_eq!(pos, expr.find(':').unwrap());
+    }
+
+    #[test]
+    fn colon_in_comment_is_not_depth0() {
+        assert_eq!(find_colon_at_depth0("a /* : */ : b"), Some(10));
+        assert_eq!(find_colon_at_depth0("a // : b"), None);
+    }
+
+    #[test]
+    fn ternary_branch_split_survives_non_ascii() {
+        let re = regex::Regex::new(r"\bcomponent\b").unwrap();
+        // `cond ? component = "ああa" : component = other`
+        let stmt = "cond ? component = \"ああa\" : component = other";
+        let _ = check_identifier_in_statement(stmt, "component", &re);
     }
 }


### PR DESCRIPTION
Batch (b) of #2357, based on `origin/main` — independent of #2366/#2370, no stacking needed since it touches a different file.

`find_matching_open_bracket` in `client/destructure_transforms.rs` walked backwards from a closing bracket counting every `{`/`[`/`}`/`]` it passed, with **no** string, comment or regex handling at all. A destructuring assignment whose pattern carries a bracket inside a string or comment therefore never finds its opener, `find_and_transform_one_destructure` discards the candidate, and the statement is left untransformed.

Both repros confirmed failing before the fix:

```rust
find_matching_open_bracket(r#"{ a = "}" } = obj"#, 10, '{', '}')   // None, want Some(0)
find_matching_open_bracket("{ a, /* } */ b } = obj", 15, '{', '}') // None, want Some(0)
```

The first is ordinary JavaScript — a destructuring default value containing a brace. Both now return `Some(0)`. A third test pins that genuine nesting (`{ a: { b } } = obj`) still resolves to the outer bracket; it passed before and after and is a guard, not a repro.

**Interface change.** This is the `Vec<char>` cluster the epic flagged as unswept, so the conversion is the whole-function kind rather than a `code_bytes` swap: `close_pos` and the return value are now **byte** offsets, because `code_bytes` yields byte offsets and threading char indices through it would reintroduce exactly the char/byte mixing that has already produced three bugs in this epic. The single caller indexes by char, so it converts on the way in with the `b()` table it already builds, and on the way out with a `binary_search` over the same `byte_offsets` vector — no new mapping state.

The backward walk collects `code_bytes` forward and iterates the result in reverse, the same shape used for the reverse scanners in #2366.

Not addressed here, and worth its own look: the helper rebuilt a `Vec<char>` of the whole statement on **every** call and is called once per candidate bracket, so it was O(n) allocation fired O(n) times. The new version still collects a vector per call. That is a performance question with the same shape as #2342, and it should be measured rather than assumed — I have not measured it and am not claiming an improvement.

`cargo test -p rsvelte_core --lib destructure_transforms::tests` 3/3. `cargo clippy -p rsvelte_core --all-targets --all-features -- -D warnings` clean, no `-A`. `--test ssr` / `--test runtime` cannot run here (`Fixtures not found`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

**Update: `find_colon_at_depth0` settled — it is reachable, and it panics.** (`00aa2e15`)

This was the epic's one "suspected but unconverted for want of a reaching input" entry. The input exists:

```rust
check_identifier_in_statement("cond ? component = \"ああa\" : component = other", "component", &re)
// panicked: end byte index 7 is not a char boundary; it is inside 'あ' (bytes 5..8)
```

`find_colon_at_depth0` counted **characters**; its single caller (`state_transforms.rs:748`) slices `rhs` with the result, i.e. by **bytes**. The two agree only while the expression is ASCII. This is a compiler panic, not a mis-slice, so it is a harder failure than the other instances of this class — the ternary branch just has to contain a non-ASCII string literal before the `:`.

Three tests, all confirmed failing first: the byte-offset contract, the panic through the real caller, and a `:` written inside a comment being read as the branch separator.

**The `${…}` carve-out applies here and I did not convert this one to `code_bytes`.** The scanner descends into `${…}` deliberately — it increments `depth` on `${` and decrements on the matching `}` — so an opaque template skip would change behaviour. Instead the loop keeps its hand-rolled structure and only changes its index unit from char to byte, with comment handling added by hand. UTF-8 continuation bytes are all `>= 0x80`, so they never match an ASCII arm and the `_ => {}` case absorbs them.

**On accidental compensation** (asked explicitly): there is none to preserve in either function. `find_matching_open_bracket`'s char index was consumed as a char index throughout, so converting it to bytes required converting the boundary and nothing downstream depended on the old unit. `find_colon_at_depth0`'s char index was consumed as a *byte* index by its only caller — the units never matched, so there was no working compensation, only a latent panic. In neither case did the old indexing make something incidentally correct.


---

**Update: (c) added — `transform_props_destructuring`'s raw `find('{')` / `rfind('}')`.** (`111ab248`)

Re-derived from the code rather than from the epic's text, and the realistic trigger is better than the one the epic implied. It is not an exotic string edge case — it is **JSDoc**:

```js
let /** @type {Props} */ { a, b } = $props();
```

which is idiomatic in JavaScript (non-TypeScript) Svelte 5 components. `find('{')` returns the brace in `{Props}`, so the extracted prop list is `Props} */ { a, b` and every declarator parsed from it is garbage. A `}` in a trailing comment moves the closing brace the same way.

Because `transform_props_destructuring` needs a `ComponentAnalysis` (no `Default`) and so is awkward to call from a unit test, I first extracted the two lines into `props_pattern_span` as a **pure no-op** keeping `find`/`rfind`, confirmed the two repros fail against that, and only then made the body lexical. The third test (a plain `{ a, b }` pattern) passed throughout and is a guard, not a repro.

Three commits on this branch now, each a separate defect in the same file family:
| commit | function | defect |
|---|---|---|
| `6104c03e` | `find_matching_open_bracket` | counted brackets inside strings/comments |
| `00aa2e15` | `find_colon_at_depth0` | returned a char index into a byte slice (**panic**) |
| `111ab248` | `props_pattern_span` | located the pattern with a blind `find`/`rfind` |

`cargo test -p rsvelte_core --lib props_transforms` 14/14, `destructure_transforms::tests` 3/3, `state_transforms` 5/5. Bare clippy clean, `rustfmt --edition 2024 --check` clean.


---

**Correction to the `${…}` justification above, and to the reason I gave for it.** (`0d0c405c`)

The sentence I originally wrote — "an opaque template skip would swallow the descent, so behaviour would change" — is **not accurate**, and since it will be read as precedent by later batches it is worth correcting with the measurement rather than leaving.

What `find_colon_at_depth0` actually does: it never returns a position *inside* an interpolation, because `${` raises the depth and the `:` test is gated on `depth == 0`. The `${`/`}` pair only moves the **outer** depth, and cancels when balanced. Probed on four shapes, all returning the correct colon:

| input | returned | correct |
|---|---|---|
| `` `${ a }` : x `` | 9 | 9 |
| `` `${ {a:1} }` : x `` | 13 | 13 |
| `` cond ? `${a}` : y `` | 14 | 14 |
| `` `a${b}c` : x `` | 9 | 9 |

The nested case is the interesting one and it exposes a second accidental cancellation: the template loop does **not** count `{` inside an interpolation, so `{a:1}`'s closing `}` consumes the depth that `${` added, and the interpolation's own `}` is then ignored because the `depth > 0` clamp is already false. The intermediate bookkeeping is wrong in two places and lands on the right answer.

So the honest reason to keep the hand-rolled loop is **"preserve the depth bookkeeping exactly"**, not "the descent would be lost". A `code_bytes` conversion would very likely agree on balanced input — but establishing *when* the two coincide requires reasoning about a counter that is only accidentally correct, and this epic's own record is that such reasoning is where the errors come from. Keeping the loop and changing only the index unit avoids the question entirely.

**Also addressed: the `.ok()` nit.** `byte_offsets.binary_search(&byte).ok()` degraded a would-be-impossible miss into `None`, which discards the destructure candidate silently — precisely the failure mode this sweep exists to remove, reproduced one line away from the fix. It is now `.expect("open bracket is a char boundary")`: the helper only ever returns ASCII bracket positions, which are always char starts, so a miss is a bug in the helper rather than a property of the input and should fail loudly.
