### PR TITLE
test: cover carriage returns in the whitespace predicates (#1791)

### DIFF
--- a/crates/rsvelte_core/tests/crlf_whitespace.rs
+++ b/crates/rsvelte_core/tests/crlf_whitespace.rs
@@ -1,0 +1,59 @@
+//! CRLF sources must compile identically to their LF twin, except inside
+//! elements where whitespace is significant.
+//!
+//! The whitespace predicates are ports of official's `/[^ \t\r\n]/`,
+//! `/^[ \t\r\n]+/` and `/[ \t\r\n]+$/`, so `\r` is part of their contract. No
+//! test reached that: every existing input is LF-only, and dropping `\r` from
+//! all twelve `matches!` whitespace sets in `crates/rsvelte_core/src` left the
+//! entire unit-test suite green. It stops being green here — without `\r` a
+//! CRLF text node is no longer whitespace-only, so inter-element whitespace
+//! leaks into the template verbatim instead of collapsing to one space.
+
+use rsvelte_core::{CompileOptions, GenerateMode, compile};
+
+const SOURCE: &str = "<script>\n\tlet name = 'world';\n</script>\n\n<div>\n\t<span>{name}</span>\n\t\n\t<b>a</b>\n\t<i>b</i>\n</div>\n\n<pre>\n  keep   these\n  spaces\n</pre>\n";
+
+fn compile_to_js(source: &str, generate: GenerateMode) -> String {
+    let options = CompileOptions {
+        filename: Some("App.svelte".to_string()),
+        generate,
+        ..Default::default()
+    };
+    compile(source, options)
+        .unwrap_or_else(|e| panic!("compile failed: {e:?}"))
+        .js
+        .code
+}
+
+/// `<pre>` keeps its carriage returns, so the two outputs differ only by the
+/// `\r`s inside it — stripping those must make them identical.
+#[test]
+fn crlf_matches_its_lf_twin_apart_from_significant_whitespace() {
+    for generate in [GenerateMode::Client, GenerateMode::Server] {
+        let lf = compile_to_js(SOURCE, generate);
+        let crlf = compile_to_js(&SOURCE.replace('\n', "\r\n"), generate);
+
+        assert!(
+            crlf.contains('\r'),
+            "the CRLF input must still reach the output via <pre>, or this \
+             test is not exercising carriage returns at all"
+        );
+        assert_eq!(
+            crlf.replace('\r', ""),
+            lf,
+            "{generate:?}: CRLF and LF sources must compile to the same code \
+             once the <pre> carriage returns are removed"
+        );
+    }
+}
+
+/// The whitespace-only text nodes between `</span>`, `<b>` and `<i>` collapse
+/// to a single space. With `\r` missing from the predicates they do not.
+#[test]
+fn crlf_whitespace_only_text_nodes_still_collapse() {
+    let crlf = compile_to_js(&SOURCE.replace('\n', "\r\n"), GenerateMode::Client);
+    assert!(
+        crlf.contains("<b>a</b> <i>b</i>"),
+        "CRLF whitespace between elements must collapse to one space; got:\n{crlf}"
+    );
+}


### PR DESCRIPTION
Closes the CRLF lead from #1791's axis-B sweep. Test-only; **no compiler change** — the guards are
already correct.

## What the sweep found

Twelve `matches!` whitespace sets in `crates/rsvelte_core/src` list `\r`. Dropping `\r` from all
twelve left the entire 1,403-test unit suite green, because every existing input is LF-only: no
test ever produces a value those predicates could reject.

`\r` is load-bearing by spec, not vestigial — `3_transform/utils.rs:142,149,155` document these as
ports of official's `/[^ \t\r\n]/`, `/^[ \t\r\n]+/` and `/[ \t\r\n]+$/`, and nothing upstream
normalises CRLF away.

## The differential experiment

Compiled one component with LF and with CRLF line endings, through official `svelte@5.56.8` (the
version this repo pins) and through rsvelte, client and server:

| | rsvelte vs official, LF | rsvelte vs official, CRLF |
|---|---|---|
| **current code** | MATCH | **MATCH** |
| **12 guards mutated** | MATCH | ***DIFFERS*** |

So: **no bug in shipped behaviour** — rsvelte handles CRLF correctly today and is byte-identical to
official. But the mutation *is* behaviour-changing, which makes this a real coverage gap rather
than dead code. The LF column staying MATCH in both rows confirms the mutation only moves the
CRLF axis.

The divergence is substantial, not cosmetic. Without `\r` a CRLF text node is no longer
whitespace-only, so inter-element whitespace stops collapsing and leaks into the template verbatim:

```
official:  `<div><span></span> <b>a</b> <i>b</i></div> <pre>
mutated:   `<div><span></span>\r\n\t\r\n <b>a</b>\r\n <i>b</i></div>\r\n\r\n <pre>
```

## The tests

Two, covering the three predicates' territory — leading trim, trailing trim, whitespace-only
detection — plus `<pre>`, where whitespace is significant:

- `crlf_matches_its_lf_twin_apart_from_significant_whitespace` — CRLF and LF outputs must be equal
  once the `<pre>` carriage returns are stripped, for both client and server. It also asserts the
  CRLF output *contains* a `\r`, so the test cannot pass by accidentally never exercising them.
- `crlf_whitespace_only_text_nodes_still_collapse` — the direct assertion on collapsing.

Verified three ways, which is the point of the PR:

1. passes on clean code — `2 passed`
2. **fails with all 12 guards mutated** — `0 passed; 2 failed`, both by name
3. passes again after revert — `2 passed`

No fixtures or submodules needed, so it runs in every shard.

## Scope

`test(...)`, no shipped behaviour change, no changeset. One new file. `rustfmt --check` clean.

Remaining axis-B work stays itemised on #1791: 96 of the 108 enumerable guards fall outside this
operator, and the 347 non-`matches!` enum guards are untouched.
