### PR TITLE
fix(compiler): fail loudly on an impossible bracket-offset miss (#2357)

### DIFF
--- a/.changeset/colon-depth0-byte-offset.md
+++ b/.changeset/colon-depth0-byte-offset.md
@@ -1,0 +1,11 @@
+---
+"@rsvelte/compiler": patch
+---
+
+fix(compiler): return a byte offset from `find_colon_at_depth0`
+
+The ternary-branch analysis in `check_identifier_in_statement` sliced its right-hand
+side with the position this returned, but the scan counted characters. A ternary
+whose true branch assigns a non-ASCII string literal — `cond ? x = "ああa" : x = y` —
+panicked with "byte index is not a char boundary". The scan also read a `:` written
+inside a comment as the branch separator.

--- a/.changeset/destructure-bracket-lexical.md
+++ b/.changeset/destructure-bracket-lexical.md
@@ -1,0 +1,10 @@
+---
+"@rsvelte/compiler": patch
+---
+
+fix(compiler): match destructuring brackets lexically
+
+`find_matching_open_bracket` walked backwards counting every `{`/`[` it saw,
+including ones inside string literals and comments. A destructuring assignment
+whose pattern carried a brace in a default value (`{ a = "}" } = obj`) or in a
+comment failed to find its opening bracket and was left untransformed.

--- a/.changeset/props-pattern-span-lexical.md
+++ b/.changeset/props-pattern-span-lexical.md
@@ -1,0 +1,12 @@
+---
+"@rsvelte/compiler": patch
+---
+
+fix(compiler): find the `$props()` pattern braces lexically
+
+`transform_props_destructuring` located the destructuring pattern with a raw
+`find('{')` / `rfind('}')`, so a JSDoc type annotation ahead of it —
+`let /** @type {Props} */ { a, b } = $props()`, idiomatic in JavaScript Svelte
+components — made the scan start at the annotation's brace and parse
+`Props} */ { a, b` as the prop list. A `}` in a trailing comment moved the
+closing brace the same way.

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/destructure_transforms.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/destructure_transforms.rs
@@ -218,9 +218,11 @@ pub(super) fn find_and_transform_one_destructure(
                 let close_bracket = c;
                 let open_bracket = if c == ']' { '[' } else { '{' };
 
-                // Walk backwards from position `i` to find the matching open bracket
+                // Walk backwards from position `i` to find the matching open bracket.
+                // The helper works in byte offsets; this loop indexes by char.
                 if let Some(pattern_start) =
-                    find_matching_open_bracket(statement, i, open_bracket, close_bracket)
+                    find_matching_open_bracket(statement, b(i), open_bracket, close_bracket)
+                        .and_then(|byte| byte_offsets.binary_search(&byte).ok())
                 {
                     let pattern_str = &statement[b(pattern_start)..b(i + 1)];
                     let rhs_start = j + 1;
@@ -481,24 +483,24 @@ fn is_inside_enclosing_pattern(statement: &str, pattern_open_byte: usize) -> boo
 }
 
 /// Find the matching opening bracket, respecting nesting and strings.
+/// `close_pos` and the returned position are **byte** offsets.
 pub(super) fn find_matching_open_bracket(
     s: &str,
     close_pos: usize,
     open_bracket: char,
     close_bracket: char,
 ) -> Option<usize> {
-    let chars: Vec<char> = s.chars().collect();
+    let (open, close) = (open_bracket as u8, close_bracket as u8);
+    // Collect forward so opaque runs are skipped, then walk the code bytes back.
+    let code: Vec<(usize, u8)> = code_bytes(s.as_bytes())
+        .take_while(|(i, _)| *i < close_pos)
+        .collect();
+
     let mut depth = 1;
-    let mut i = close_pos;
-
-    // Walk backwards
-    while i > 0 {
-        i -= 1;
-        let c = chars[i];
-
-        if c == close_bracket {
+    for &(i, c) in code.iter().rev() {
+        if c == close {
             depth += 1;
-        } else if c == open_bracket {
+        } else if c == open {
             depth -= 1;
             if depth == 0 {
                 return Some(i);
@@ -1605,5 +1607,30 @@ mod non_ascii_tests {
             extract_destructure_targets("{ a /* , b */, c }"),
             vec!["a".to_string(), "c".to_string()]
         );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn matching_open_bracket_ignores_string_contents() {
+        // `{ a = "}" } = obj` — the default value's `}` is text, not a closer.
+        let s = r#"{ a = "}" } = obj"#;
+        assert_eq!(find_matching_open_bracket(s, 10, '{', '}'), Some(0));
+    }
+
+    #[test]
+    fn matching_open_bracket_ignores_comment_contents() {
+        let s = "{ a, /* } */ b } = obj";
+        let close = s.rfind('}').unwrap();
+        assert_eq!(find_matching_open_bracket(s, close, '{', '}'), Some(0));
+    }
+
+    #[test]
+    fn matching_open_bracket_still_matches_nested() {
+        let s = "{ a: { b } } = obj";
+        assert_eq!(find_matching_open_bracket(s, 11, '{', '}'), Some(0));
     }
 }

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/destructure_transforms.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/destructure_transforms.rs
@@ -221,8 +221,15 @@ pub(super) fn find_and_transform_one_destructure(
                 // Walk backwards from position `i` to find the matching open bracket.
                 // The helper works in byte offsets; this loop indexes by char.
                 if let Some(pattern_start) =
-                    find_matching_open_bracket(statement, b(i), open_bracket, close_bracket)
-                        .and_then(|byte| byte_offsets.binary_search(&byte).ok())
+                    find_matching_open_bracket(statement, b(i), open_bracket, close_bracket).map(
+                        |byte| {
+                            // The helper only returns ASCII bracket positions, which
+                            // are always char starts; a miss would be a bug, not input.
+                            byte_offsets
+                                .binary_search(&byte)
+                                .expect("open bracket is a char boundary")
+                        },
+                    )
                 {
                     let pattern_str = &statement[b(pattern_start)..b(i + 1)];
                     let rhs_start = j + 1;

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/props_transforms.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/props_transforms.rs
@@ -6,7 +6,7 @@ use std::fmt::Write as _;
 
 use crate::compiler::phases::phase2_analyze::ComponentAnalysis;
 use crate::compiler::phases::phase2_analyze::scope::BindingKind;
-use crate::compiler::phases::phase3_transform::shared::js_scan::skip_opaque;
+use crate::compiler::phases::phase3_transform::shared::js_scan::{code_bytes, skip_opaque};
 
 use super::scan_index::{ScanIndex, ScanIndexBuilder};
 use super::{
@@ -2572,6 +2572,21 @@ pub(super) fn strip_js_comments(code: &str) -> String {
 ///
 /// Multiple prop declarations are combined into a single `let` statement with
 /// comma-separated declarators, matching the official compiler output format.
+/// Byte span of the destructuring pattern's braces. A `/** @type {Props} */`
+/// annotation puts braces ahead of the pattern, so only code positions count.
+fn props_pattern_span(trimmed: &str) -> Option<(usize, usize)> {
+    let mut open = None;
+    let mut close = None;
+    for (i, c) in code_bytes(trimmed.as_bytes()) {
+        match c {
+            b'{' if open.is_none() => open = Some(i),
+            b'}' => close = Some(i),
+            _ => {}
+        }
+    }
+    Some((open?, close?))
+}
+
 pub(super) fn transform_props_destructuring(
     line: &str,
     prop_source_vars: &[String],
@@ -2635,8 +2650,7 @@ pub(super) fn transform_props_destructuring(
     }
 
     // Extract the part between { and }
-    let open_brace = trimmed.find('{')?;
-    let close_brace = trimmed.rfind('}')?;
+    let (open_brace, close_brace) = props_pattern_span(trimmed)?;
     let props_str = &trimmed[open_brace + 1..close_brace];
 
     // Parse each prop - collect declarators for combining into a single `let` statement
@@ -4357,5 +4371,32 @@ mod split_declarators_tests {
             transform_prop_reads_in_expr("cond ? active : 0", &["active".to_string()]),
             "cond ? active() : 0"
         );
+    }
+}
+
+#[cfg(test)]
+mod props_pattern_span_tests {
+    use super::props_pattern_span;
+
+    #[test]
+    fn jsdoc_type_braces_are_not_the_pattern() {
+        // `let /** @type {Props} */ { a, b } = $props();` — idiomatic in JS Svelte.
+        let line = "let /** @type {Props} */ { a, b } = $props();";
+        let (open, close) = props_pattern_span(line).unwrap();
+        assert_eq!(&line[open..=close], "{ a, b }");
+    }
+
+    #[test]
+    fn trailing_comment_brace_is_not_the_closer() {
+        let line = "let { a } = $props(); // }";
+        let (open, close) = props_pattern_span(line).unwrap();
+        assert_eq!(&line[open..=close], "{ a }");
+    }
+
+    #[test]
+    fn plain_pattern_is_unchanged() {
+        let line = "let { a, b } = $props();";
+        let (open, close) = props_pattern_span(line).unwrap();
+        assert_eq!(&line[open..=close], "{ a, b }");
     }
 }

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/state_transforms.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/state_transforms.rs
@@ -912,37 +912,54 @@ pub(super) fn find_assignment_position(expr: &str) -> Option<usize> {
 
 /// Find the position of a `:` at depth 0 in an expression.
 /// This is used to split ternary expressions like `true_rhs : false_branch`.
+/// The returned position is a **byte** offset: the caller slices `expr` with it.
 pub(super) fn find_colon_at_depth0(expr: &str) -> Option<usize> {
-    let chars: Vec<char> = expr.chars().collect();
+    // Not `code_bytes`: this scanner descends into `${…}` on purpose, and an
+    // opaque template skip would swallow it. UTF-8 continuation bytes are all
+    // >= 0x80, so they never match an ASCII arm.
+    let bytes = expr.as_bytes();
     let mut depth = 0;
     let mut i = 0;
 
-    while i < chars.len() {
-        match chars[i] {
-            '(' | '[' | '{' => depth += 1,
-            ')' | ']' | '}' => depth -= 1,
-            ':' if depth == 0 => return Some(i),
-            '\'' | '"' => {
-                // Skip string literals
-                let quote = chars[i];
+    while i < bytes.len() {
+        match bytes[i] {
+            b'(' | b'[' | b'{' => depth += 1,
+            b')' | b']' | b'}' => depth -= 1,
+            b':' if depth == 0 => return Some(i),
+            b'/' if bytes.get(i + 1) == Some(&b'/') => {
+                i += 2;
+                while i < bytes.len() && bytes[i] != b'\n' {
+                    i += 1;
+                }
+                continue;
+            }
+            b'/' if bytes.get(i + 1) == Some(&b'*') => {
+                i += 2;
+                while i < bytes.len() && !(bytes[i] == b'*' && bytes.get(i + 1) == Some(&b'/')) {
+                    i += 1;
+                }
                 i += 1;
-                while i < chars.len() && chars[i] != quote {
-                    if chars[i] == '\\' && i + 1 < chars.len() {
+            }
+            quote @ (b'\'' | b'"') => {
+                // Skip string literals
+                i += 1;
+                while i < bytes.len() && bytes[i] != quote {
+                    if bytes[i] == b'\\' && i + 1 < bytes.len() {
                         i += 1;
                     }
                     i += 1;
                 }
             }
-            '`' => {
+            b'`' => {
                 // Skip template literals
                 i += 1;
-                while i < chars.len() && chars[i] != '`' {
-                    if chars[i] == '$' && i + 1 < chars.len() && chars[i + 1] == '{' {
+                while i < bytes.len() && bytes[i] != b'`' {
+                    if bytes[i] == b'$' && bytes.get(i + 1) == Some(&b'{') {
                         depth += 1;
                         i += 1;
-                    } else if chars[i] == '}' && depth > 0 {
+                    } else if bytes[i] == b'}' && depth > 0 {
                         depth -= 1;
-                    } else if chars[i] == '\\' && i + 1 < chars.len() {
+                    } else if bytes[i] == b'\\' && i + 1 < bytes.len() {
                         i += 1;
                     }
                     i += 1;
@@ -1839,5 +1856,32 @@ mod non_ascii_tests {
         let vars = vec![("x".to_string(), None, DeclarationKind::Let)];
         let out = transform_legacy_state_declarations("let x: Café = 0", &vars, false, false);
         assert!(out.contains("$.mutable_source(0)"), "got: {out}");
+    }
+}
+
+#[cfg(test)]
+mod colon_depth0_tests {
+    use super::*;
+
+    #[test]
+    fn colon_position_is_a_byte_offset() {
+        // The caller slices `&str` with this, so it must be a byte offset.
+        let expr = "\"ああa\" : x";
+        let pos = find_colon_at_depth0(expr).unwrap();
+        assert_eq!(pos, expr.find(':').unwrap());
+    }
+
+    #[test]
+    fn colon_in_comment_is_not_depth0() {
+        assert_eq!(find_colon_at_depth0("a /* : */ : b"), Some(10));
+        assert_eq!(find_colon_at_depth0("a // : b"), None);
+    }
+
+    #[test]
+    fn ternary_branch_split_survives_non_ascii() {
+        let re = regex::Regex::new(r"\bcomponent\b").unwrap();
+        // `cond ? component = "ああa" : component = other`
+        let stmt = "cond ? component = \"ああa\" : component = other";
+        let _ = check_identifier_in_statement(stmt, "component", &re);
     }
 }

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/state_transforms.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/state_transforms.rs
@@ -914,8 +914,8 @@ pub(super) fn find_assignment_position(expr: &str) -> Option<usize> {
 /// This is used to split ternary expressions like `true_rhs : false_branch`.
 /// The returned position is a **byte** offset: the caller slices `expr` with it.
 pub(super) fn find_colon_at_depth0(expr: &str) -> Option<usize> {
-    // Not `code_bytes`: this scanner descends into `${…}` on purpose, and an
-    // opaque template skip would swallow it. UTF-8 continuation bytes are all
+    // Not `code_bytes`: `${`/`}` move the outer depth here and the bookkeeping is
+    // preserved exactly rather than re-derived. UTF-8 continuation bytes are all
     // >= 0x80, so they never match an ASCII arm.
     let bytes = expr.as_bytes();
     let mut depth = 0;


### PR DESCRIPTION
Follow-up to #2376, which merged while this commit was in flight. Same file family, two small corrections that came out of its review.

**`.ok()` on a `Result` whose `Err` is unreachable is a silent-discard generator.** `byte_offsets.binary_search(&byte).ok()` degraded a would-be-impossible miss into `None`, which discards the destructure candidate without a trace — the exact failure mode #2376 exists to remove, reproduced one line away from the fix that removes it. The helper only ever returns ASCII bracket positions, which are always char starts, so a miss is a bug in the helper rather than a property of the input: `.expect("open bracket is a char boundary")`.

The tell for this shape, worth carrying: **you cannot name an input that produces the `Err`.** It reads as defensive and behaves as suppression.

**The `${…}` carve-out comment stated a reason that is false.** It said an opaque template skip "would swallow the descent, so behaviour would change". Probed on four shapes, the scanner returns the correct colon in every one, because `${` raises the depth and the `:` test is gated on `depth == 0` — it never returns a position inside an interpolation at all.

| input | returned | correct |
|---|---|---|
| `` `${ a }` : x `` | 9 | 9 |
| `` `${ {a:1} }` : x `` | 13 | 13 |
| `` cond ? `${a}` : y `` | 14 | 14 |
| `` `a${b}c` : x `` | 9 | 9 |

The correct reason is **"preserve the depth bookkeeping exactly"**, and the nested case shows why that is not pedantry: the template loop does not count `{` inside an interpolation, so in `` `${ {a:1} }` `` the closing `}` of `{a:1}` consumes the depth that `${` added, and the interpolation's own `}` is then ignored because the `depth > 0` clamp is already false. **The intermediate bookkeeping is wrong in two places and lands on the right answer** — a third accidental cancellation in this epic. Converting the index unit only avoids having to reason about when a counter that is merely accidentally correct coincides with a correct one, which is where this epic's errors have come from.

Tests: 6/6 destructure, 5/5 state, 14/14 props. Bare clippy clean with no `-A`, rustfmt clean.
