### PR TITLE
fix(compiler): fail loudly on an impossible bracket-offset miss (#2357)

### DIFF
--- a/.changeset/bracket-offset-expect.md
+++ b/.changeset/bracket-offset-expect.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/compiler": patch
+---
+
+fix(compiler): fail loudly on an impossible bracket-offset miss

--- a/.changeset/bracket-offset-expect.md
+++ b/.changeset/bracket-offset-expect.md
@@ -2,4 +2,8 @@
 "@rsvelte/compiler": patch
 ---
 
-fix(compiler): fail loudly on an impossible bracket-offset miss
+chore(compiler): fail loudly on an impossible bracket-offset miss
+
+No behavioural change: the discarded branch is unreachable for any `&str`
+input, so this only replaces a silent `.ok()` discard with a panic that
+names the offset.

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/destructure_transforms.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/destructure_transforms.rs
@@ -220,17 +220,22 @@ pub(super) fn find_and_transform_one_destructure(
 
                 // Walk backwards from position `i` to find the matching open bracket.
                 // The helper works in byte offsets; this loop indexes by char.
-                if let Some(pattern_start) =
-                    find_matching_open_bracket(statement, b(i), open_bracket, close_bracket).map(
-                        |byte| {
-                            // The helper only returns ASCII bracket positions, which
-                            // are always char starts; a miss would be a bug, not input.
-                            byte_offsets
-                                .binary_search(&byte)
-                                .expect("open bracket is a char boundary")
-                        },
-                    )
-                {
+                if let Some(pattern_start) = find_matching_open_bracket(
+                    statement,
+                    b(i),
+                    open_bracket,
+                    close_bracket,
+                )
+                .map(|byte| {
+                    // The helper only returns ASCII bracket positions, which
+                    // are always char starts; a miss would be a bug, not input.
+                    byte_offsets.binary_search(&byte).unwrap_or_else(|_| {
+                        panic!(
+                            "bracket byte offset {byte} is not a char start in a {}-byte statement",
+                            statement.len()
+                        )
+                    })
+                }) {
                     let pattern_str = &statement[b(pattern_start)..b(i + 1)];
                     let rhs_start = j + 1;
 

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/destructure_transforms.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/destructure_transforms.rs
@@ -221,8 +221,15 @@ pub(super) fn find_and_transform_one_destructure(
                 // Walk backwards from position `i` to find the matching open bracket.
                 // The helper works in byte offsets; this loop indexes by char.
                 if let Some(pattern_start) =
-                    find_matching_open_bracket(statement, b(i), open_bracket, close_bracket)
-                        .and_then(|byte| byte_offsets.binary_search(&byte).ok())
+                    find_matching_open_bracket(statement, b(i), open_bracket, close_bracket).map(
+                        |byte| {
+                            // The helper only returns ASCII bracket positions, which
+                            // are always char starts; a miss would be a bug, not input.
+                            byte_offsets
+                                .binary_search(&byte)
+                                .expect("open bracket is a char boundary")
+                        },
+                    )
                 {
                     let pattern_str = &statement[b(pattern_start)..b(i + 1)];
                     let rhs_start = j + 1;

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/destructure_transforms.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/destructure_transforms.rs
@@ -145,6 +145,12 @@ pub(super) fn transform_destructure_assignments_with_props(
 /// This ensures inner/nested destructures (e.g., in the RHS of an outer
 /// destructure) are processed before outer ones, so $$array counter
 /// values match the official compiler output.
+#[cold]
+#[inline(never)]
+fn bracket_offset_miss(byte: usize, len: usize) -> ! {
+    panic!("bracket byte offset {byte} is not a char start in a {len}-byte statement")
+}
+
 pub(super) fn find_and_transform_one_destructure(
     statement: &str,
     store_sub_vars: &[String],
@@ -220,21 +226,14 @@ pub(super) fn find_and_transform_one_destructure(
 
                 // Walk backwards from position `i` to find the matching open bracket.
                 // The helper works in byte offsets; this loop indexes by char.
-                if let Some(pattern_start) = find_matching_open_bracket(
-                    statement,
-                    b(i),
-                    open_bracket,
-                    close_bracket,
-                )
-                .map(|byte| {
-                    // The helper only returns ASCII bracket positions, which
-                    // are always char starts; a miss would be a bug, not input.
-                    byte_offsets.binary_search(&byte).unwrap_or_else(|_| {
-                        panic!(
-                            "bracket byte offset {byte} is not a char start in a {}-byte statement",
-                            statement.len()
-                        )
-                    })
+                let matching_open =
+                    find_matching_open_bracket(statement, b(i), open_bracket, close_bracket);
+                // The helper only returns ASCII bracket positions, which are
+                // always char starts; a miss would be a bug, not input.
+                if let Some(pattern_start) = matching_open.map(|byte| {
+                    byte_offsets
+                        .binary_search(&byte)
+                        .unwrap_or_else(|_| bracket_offset_miss(byte, statement.len()))
                 }) {
                     let pattern_str = &statement[b(pattern_start)..b(i + 1)];
                     let rhs_start = j + 1;

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/state_transforms.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/state_transforms.rs
@@ -914,8 +914,8 @@ pub(super) fn find_assignment_position(expr: &str) -> Option<usize> {
 /// This is used to split ternary expressions like `true_rhs : false_branch`.
 /// The returned position is a **byte** offset: the caller slices `expr` with it.
 pub(super) fn find_colon_at_depth0(expr: &str) -> Option<usize> {
-    // Not `code_bytes`: this scanner descends into `${…}` on purpose, and an
-    // opaque template skip would swallow it. UTF-8 continuation bytes are all
+    // Not `code_bytes`: `${`/`}` move the outer depth here and the bookkeeping is
+    // preserved exactly rather than re-derived. UTF-8 continuation bytes are all
     // >= 0x80, so they never match an ASCII arm.
     let bytes = expr.as_bytes();
     let mut depth = 0;


### PR DESCRIPTION
Follow-up to #2376, which merged while this commit was in flight. Same file family, two small corrections that came out of its review.

**`.ok()` on a `Result` whose `Err` is unreachable is a silent-discard generator.** `byte_offsets.binary_search(&byte).ok()` degraded a would-be-impossible miss into `None`, which discards the destructure candidate without a trace — the exact failure mode #2376 exists to remove, reproduced one line away from the fix that removes it. The helper only ever returns ASCII bracket positions, which are always char starts, so a miss is a bug in the helper rather than a property of the input: `.expect("open bracket is a char boundary")`.

The tell for this shape, worth carrying: **you cannot name an input that produces the `Err`.** It reads as defensive and behaves as suppression.

**The `${…}` carve-out comment stated a reason that is false.** It said an opaque template skip "would swallow the descent, so behaviour would change". Probed on four shapes, the scanner returns the correct colon in every one, because `${` raises the depth and the `:` test is gated on `depth == 0` — it never returns a position inside an interpolation at all.

| input | returned | correct |
|---|---|---|
| `` `${ a }` : x `` | 9 | 9 |
| `` `${ {a:1} }` : x `` | 13 | 13 |
| `` cond ? `${a}` : y `` | 14 | 14 |
| `` `a${b}c` : x `` | 9 | 9 |

The correct reason is **"preserve the depth bookkeeping exactly"**, and the nested case shows why that is not pedantry: the template loop does not count `{` inside an interpolation, so in `` `${ {a:1} }` `` the closing `}` of `{a:1}` consumes the depth that `${` added, and the interpolation's own `}` is then ignored because the `depth > 0` clamp is already false. **The intermediate bookkeeping is wrong in two places and lands on the right answer** — a third accidental cancellation in this epic. Converting the index unit only avoids having to reason about when a counter that is merely accidentally correct coincides with a correct one, which is where this epic's errors have come from.

Tests: 6/6 destructure, 5/5 state, 14/14 props. Bare clippy clean with no `-A`, rustfmt clean.
