### PR TITLE
fix(compiler): return byte offsets from two more position scanners (#2378)

### DIFF
--- a/.changeset/index-unit-sweep.md
+++ b/.changeset/index-unit-sweep.md
@@ -1,0 +1,11 @@
+---
+"@rsvelte/compiler": patch
+---
+
+fix(compiler): return byte offsets from two more position scanners
+
+`find_destructuring_pattern_end` and `find_simple_assignment` counted characters
+while their callers sliced the same string by bytes, so a non-ASCII identifier or
+string literal in a destructuring pattern or a `let` initialiser sliced short —
+`let { café } = obj` lost its closing brace — and a multi-byte character straddling
+the offset panicked outright.

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/props_transforms.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/props_transforms.rs
@@ -4384,8 +4384,9 @@ mod pattern_end_unit_tests {
 
     #[test]
     fn pattern_end_is_a_byte_offset() {
-        // Callers slice `&str` with this, so it must be a byte offset.
-        for pattern in ["{ a }", "{ café }", "{ ああ }", "[ あ, い ]"] {
+        // Callers slice `&str` with this, so it must be a byte offset. The
+        // leading-space case is the only one where the trim `base` is non-zero.
+        for pattern in ["{ a }", "{ café }", "{ ああ }", "[ あ, い ]", "  { café }"] {
             let end = find_destructuring_pattern_end(pattern).unwrap();
             assert_eq!(&pattern[..end], pattern, "pattern {pattern:?}");
         }

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/props_transforms.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/props_transforms.rs
@@ -1308,49 +1308,26 @@ pub(super) fn transform_destructured_export_let(
 
 /// Find the end position of a destructuring pattern in `{ ... } = RHS` or `[ ... ] = RHS`.
 /// Returns the position after the closing `}` or `]`.
+/// Byte offset just past the pattern's closing bracket, relative to `s` as passed.
 pub(super) fn find_destructuring_pattern_end(s: &str) -> Option<usize> {
-    let s = s.trim();
-    let first = s.chars().next()?;
-    if first != '{' && first != '[' {
+    let trimmed = s.trim_start();
+    let base = s.len() - trimmed.len();
+    if !matches!(trimmed.as_bytes().first(), Some(b'{' | b'[')) {
         return None;
     }
 
-    let chars: Vec<char> = s.chars().collect();
     let mut depth = 0;
-    let mut i = 0;
-    let mut in_string = false;
-    let mut string_char = ' ';
-
-    while i < chars.len() {
-        if in_string {
-            if chars[i] == '\\' {
-                i += 2;
-                continue;
+    for (i, c) in code_bytes(trimmed.as_bytes()) {
+        match c {
+            b'{' | b'[' => depth += 1,
+            b'}' | b']' => {
+                depth -= 1;
+                if depth == 0 {
+                    return Some(base + i + 1);
+                }
             }
-            if chars[i] == string_char {
-                in_string = false;
-            }
-            i += 1;
-            continue;
+            _ => {}
         }
-
-        if chars[i] == '\'' || chars[i] == '"' || chars[i] == '`' {
-            in_string = true;
-            string_char = chars[i];
-            i += 1;
-            continue;
-        }
-
-        if chars[i] == '{' || chars[i] == '[' {
-            depth += 1;
-        } else if chars[i] == '}' || chars[i] == ']' {
-            depth -= 1;
-            if depth == 0 {
-                return Some(i + 1);
-            }
-        }
-
-        i += 1;
     }
     None
 }
@@ -4398,5 +4375,19 @@ mod props_pattern_span_tests {
         let line = "let { a, b } = $props();";
         let (open, close) = props_pattern_span(line).unwrap();
         assert_eq!(&line[open..=close], "{ a, b }");
+    }
+}
+
+#[cfg(test)]
+mod pattern_end_unit_tests {
+    use super::find_destructuring_pattern_end;
+
+    #[test]
+    fn pattern_end_is_a_byte_offset() {
+        // Callers slice `&str` with this, so it must be a byte offset.
+        for pattern in ["{ a }", "{ café }", "{ ああ }", "[ あ, い ]"] {
+            let end = find_destructuring_pattern_end(pattern).unwrap();
+            assert_eq!(&pattern[..end], pattern, "pattern {pattern:?}");
+        }
     }
 }

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/transform_script.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/transform_script.rs
@@ -6153,39 +6153,24 @@ fn transform_reexported_prop_declarations(
 }
 
 /// Find assignment `=` in a simple declarator (not inside parentheses, brackets, etc.)
+/// Byte offset of the top-level `=`; callers slice `s` with it.
 fn find_simple_assignment(s: &str) -> Option<usize> {
-    let chars: Vec<char> = s.chars().collect();
+    let bytes = s.as_bytes();
     let mut depth = 0;
-    let mut in_string = false;
-    let mut string_char = ' ';
 
-    for (i, &c) in chars.iter().enumerate() {
-        if (c == '"' || c == '\'' || c == '`') && (i == 0 || chars[i - 1] != '\\') {
-            if !in_string {
-                in_string = true;
-                string_char = c;
-            } else if c == string_char {
-                in_string = false;
-            }
-            continue;
-        }
-
-        if in_string {
-            continue;
-        }
-
+    for (i, c) in crate::compiler::phases::phase3_transform::shared::js_scan::code_bytes(bytes) {
         match c {
-            '(' | '[' | '{' => depth += 1,
-            ')' | ']' | '}' => depth -= 1,
-            '=' if depth == 0 => {
-                let prev = if i > 0 { Some(chars[i - 1]) } else { None };
-                let next = chars.get(i + 1).copied();
-                if prev != Some('=')
-                    && prev != Some('!')
-                    && prev != Some('<')
-                    && prev != Some('>')
-                    && next != Some('=')
-                    && next != Some('>')
+            b'(' | b'[' | b'{' => depth += 1,
+            b')' | b']' | b'}' => depth -= 1,
+            b'=' if depth == 0 => {
+                let prev = i.checked_sub(1).map(|k| bytes[k]);
+                let next = bytes.get(i + 1).copied();
+                if prev != Some(b'=')
+                    && prev != Some(b'!')
+                    && prev != Some(b'<')
+                    && prev != Some(b'>')
+                    && next != Some(b'=')
+                    && next != Some(b'>')
                 {
                     return Some(i);
                 }
@@ -7612,5 +7597,24 @@ class Last {
             !out.contains("set value(value)") && !out.contains("set result(value)"),
             "client-shaped setter leaked through:\n{out}"
         );
+    }
+}
+
+#[cfg(test)]
+mod simple_assignment_unit_tests {
+    use super::find_simple_assignment;
+
+    #[test]
+    fn assignment_position_is_a_byte_offset() {
+        for src in ["x = 1", "ああ = 1", "café = 'x'"] {
+            let pos = find_simple_assignment(src).unwrap();
+            assert_eq!(pos, src.find('=').unwrap(), "src {src:?}");
+            assert_eq!(src[..pos].trim(), src.split('=').next().unwrap().trim());
+        }
+    }
+
+    #[test]
+    fn commented_equals_is_not_an_assignment() {
+        assert_eq!(find_simple_assignment("x /* = */ 1"), None);
     }
 }


### PR DESCRIPTION
Sweep for #2378, run as the mechanical check that issue asks for: **does an index escape the function into a caller that uses a different unit?** — not *does this function build a `Vec<char>`*.

## Method

Enumerated every function in `crates/*/src/*.rs` that returns a `usize`-shaped position **and** touches `chars`/`char_indices` — 50 candidates. Classified each producer by index unit (`Vec<char>` / `.chars().enumerate()` → char; `char_indices()` / `as_bytes()` → byte), discarded the ones returning distances or line numbers rather than offsets (`levenshtein`, `levenshtein_distance`, `full_line_comment_lines`), then read **each caller** to see which unit it consumes.

## Found: two more mismatches

| function | returns | caller does | result |
|---|---|---|---|
| `client/props_transforms.rs::find_destructuring_pattern_end` | char index into `Vec<char>` | `decl[..pattern_end]`, `rest[..pattern_end]` | byte slice |
| `server/transform_script.rs::find_simple_assignment` | char index from `chars.iter().enumerate()` | `rest_trimmed[..eq_pos]`, `rest_trimmed[eq_pos + 1..]` | byte slice |

Both now return byte offsets. Repros confirmed failing first — for `find_simple_assignment` by grafting the new tests onto the **pre-fix** function and running them (`Some(5)` vs `None`, and the byte-offset assertion), rather than reasoning that they would have failed.

`let { café } = obj` loses its closing brace (`"{ café "`), so the `= rhs` split fails and the declaration is silently left untransformed. `let { ああ } = obj` straddles the offset and panics. Same two-mode signature as the rest of this class.

`find_destructuring_pattern_end` also returned an offset into a **trimmed** copy while callers sliced the original. Both current callers pass already-trimmed input so the offset is 0 today; the function now adds the trim base so the contract is honest rather than accidentally satisfied.

Both conversions route through `code_bytes`, which also drops the hand-rolled string tracking and gains comment handling — `find_simple_assignment("x /* = */ 1")` previously reported an assignment at the commented `=`.

## Audited and clean, so nobody re-checks them

- `find_destructure_rhs_end` — returns a char index. **Corrected reason:** it is not that all three
  callers wrap it in the `b()` table — `:355` never converts it at all. It compares `rhs_ends`
  against `other.close_pos`, itself a char index (documented as such at `:179`/`:181`), so that
  site is consistent by *staying in char space* rather than by converting. The function is
  char-space end to end: it builds its own `Vec<char>` and indexes `start` into it.
  Its `start` argument is a char index at all three sites, so it is clean on both sides.
- `scan_assignment_rhs_end` — byte-based throughout (`as_bytes()`), caller slices by byte.
- `skip_string_literal` — takes and returns byte offsets over a `bytes` slice.
- `dollar_param_body_range` — takes `chars` and its caller indexes `chars`. Consistent.

## Scope note

This is not the whole class. Per the visibility asymmetry recorded on #2378: a byte position landing *on* a char boundary mis-slices **silently**, and only positions landing mid-character panic — so the reported count measures **reporting**, not prevalence. The sweep above covers producers that return a position *and* mention chars; it does **not** cover positions passed as arguments between functions, nor arithmetic on an offset after it is returned. #2378 should stay open.

`cargo test -p rsvelte_core --lib props_transforms` 15/15, `transform_script` unit tests pass, bare clippy clean with no `-A`, `rustfmt --edition 2024 --check` clean. `--test ssr` / `--test runtime` cannot run here (`Fixtures not found`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Review round

**`base != 0` fixture added** (`30ca832c`). All four original patterns start at the bracket, so
the trim `base` — the only arithmetic this conversion introduced — was zero in every case and
went unexercised. `"  { café }"` joins the same array under the identical assertion. Confirmed
discriminating by dropping the `base` term and re-running: the mutant fails on that pattern and
on no other.

**The corrected clean-reason above changes the sweep's question set.** "Does the caller wrap it?"
is the wrong question for a caller that never slices — and asking only that would wave through a
char-vs-byte **comparison**, which mis-selects silently and never panics. The visibility asymmetry
that made "five instances" a statement about reporting applies here at full strength: panics get
reported, comparisons do not. Recorded on #2378.
