### PR TITLE
perf(compiler): stop rescanning the statement body once per reactive variable

### DIFF
--- a/.changeset/identifier-boundary-without-regex.md
+++ b/.changeset/identifier-boundary-without-regex.md
@@ -1,0 +1,17 @@
+---
+"@rsvelte/compiler": patch
+---
+
+Answer the identifier-boundary question without a regex
+
+`body_references_identifier` compiled-and-cached one boundary regex per reactive
+variable and then ran it over the stripped statement body, once per (`$:`
+statement × variable) pair. The pattern only ever asked three things — is the
+byte after the name an identifier byte, is the byte before one, and is a leading
+`.` a member access or the tail of a spread — so a matcher that asks them
+directly replaces it. Overlapping occurrences stay reachable because the scan
+advances by one byte, not by the match length.
+
+On carbon-components-svelte this regex was 70% of the remaining time in
+`extract_reactive_statement_deps`; its share of total compile time drops from
+19.6% to 6.0%.

--- a/.changeset/reactive-deps-substring-gate.md
+++ b/.changeset/reactive-deps-substring-gate.md
@@ -1,0 +1,19 @@
+---
+"@rsvelte/compiler": patch
+---
+
+Rule a reactive variable out with one scan before rewriting the statement body
+
+`extract_reactive_statement_deps` asks `body_references_identifier` and
+`is_assigned_anywhere_in_body` once per (`$:` statement × reactive variable)
+pair, and each answer copied and rescanned the whole statement body three
+times — or formatted and searched twenty patterns. Almost every pair is a miss,
+and a name absent from the raw body is absent from every stripped derivative of
+it, because the strips only blank or delete bytes. One substring scan now
+settles those. The three strips also borrow instead of copying when they have
+nothing to strip.
+
+On carbon-components-svelte, whose components are legacy (173 of 287 files
+carry a `$:` line), this was 48.7% of total compile time; the corpus this had
+been profiled against carries no `$:` at all. Compiling the 287 components
+drops from 366-380 ms to 268-279 ms.

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
@@ -5354,12 +5354,14 @@ fn transform_instance_script_for_visitors(
             let _reactive_guard = super::profile::ReactiveStmtGuard(_reactive_start);
             // Extract assignment targets and dependencies from the raw statement
             // for topological sorting (matching official compiler's order_reactive_statements)
+            let _rs_deps_start = super::profile::timer_start();
             let (assigned_vars, dep_vars) = extract_reactive_statement_deps(
                 &statement,
                 state_vars,
                 prop_assignment_transform_vars,
                 store_sub_vars,
             );
+            super::profile::record_rs_deps(super::profile::timer_elapsed(_rs_deps_start));
 
             let var_state_vars: Vec<String> = legacy_state_vars
                 .iter()
@@ -5375,6 +5377,7 @@ fn transform_instance_script_for_visitors(
                 .map(|v| v.as_slice())
                 .unwrap_or(&[]);
             *reactive_ordinal += 1;
+            let _rs_body_start = super::profile::timer_start();
             let transformed = transform_reactive_statement(
                 &statement,
                 state_vars,
@@ -5388,6 +5391,8 @@ fn transform_instance_script_for_visitors(
                 analysis,
                 &prop_invalidate_bodies,
             );
+            super::profile::record_rs_body(super::profile::timer_elapsed(_rs_body_start));
+            let _rs_assign_start = super::profile::timer_start();
             // Also apply state assignment transformations to the reactive statement body
             // This handles cases like: `$: selected ? component = Sub : component = banana`
             // where state variables are assigned inside conditional expressions.
@@ -5401,6 +5406,7 @@ fn transform_instance_script_for_visitors(
                 &non_proxy_vars,
             )
             .unwrap_or(transformed);
+            super::profile::record_rs_assigns(super::profile::timer_elapsed(_rs_assign_start));
             // Collect reactive statements to append at end (matching official compiler behavior
             // which appends all reactive statements after the rest of instance body code)
             let mut reactive_code = transformed;

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/props_transforms.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/props_transforms.rs
@@ -182,6 +182,13 @@ pub(super) fn transform_prop_reads_in_expr(expr: &str, prop_vars: &[String]) -> 
     let mut result = expr.to_string();
 
     for prop_name in prop_vars {
+        // The walk below pushes every character it reads, so a name that does
+        // not occur rebuilds the expression unchanged -- at the cost of a
+        // `Vec<char>`, an offset table, a scan index and a `String` per name.
+        if memmem::find(result.as_bytes(), prop_name.as_bytes()).is_none() {
+            continue;
+        }
+
         // Use word boundary matching to replace identifier references
         // But avoid replacing function calls that already have ()
         // Note: Rust's regex crate doesn't support lookahead, so we use a different approach:

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/reactive_transforms.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/reactive_transforms.rs
@@ -1,5 +1,7 @@
 //! Reactive statement handling and state mutation transformations.
 
+use memchr::memmem;
+
 use crate::compiler::phases::phase2_analyze::ComponentAnalysis;
 
 use super::{
@@ -106,6 +108,12 @@ pub(super) fn extract_reactive_statement_deps(
 /// Check if a variable is assigned anywhere in a code body (including nested blocks).
 /// Detects `var = ...`, `var += ...`, `var++`, `var--`, `++var`, `--var` patterns.
 pub(super) fn is_assigned_anywhere_in_body(body: &str, var_name: &str) -> bool {
+    // Every pattern below contains `var_name`, so one SIMD scan rules them all
+    // out at once instead of formatting and searching twenty of them.
+    if memmem::find(body.as_bytes(), var_name.as_bytes()).is_none() {
+        return false;
+    }
+
     // Check for update expressions: `var++`, `var--`, `++var`, `--var`
     let pp = format!("{}++", var_name);
     let mm = format!("{}--", var_name);

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/state_transforms.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/state_transforms.rs
@@ -3,6 +3,7 @@
 use memchr::memmem;
 use rustc_hash::FxHashSet;
 
+use super::STATE_TMP_COUNTER;
 use super::destructure_transforms::{ArrayHelperRead, extract_destructure_paths};
 use super::expression_utils::{
     byte_pos_to_char_index, find_statement_end_client, is_shadowed_by_for_loop_var,
@@ -11,7 +12,6 @@ use super::rune_transforms::{
     find_default_equals, find_derived_property_colon, split_derived_array_elements,
     split_derived_object_properties,
 };
-use super::{STATE_TMP_COUNTER, get_or_compile_regex};
 use crate::compiler::phases::phase2_analyze::scope::DeclarationKind;
 use crate::compiler::phases::phase3_transform::shared::js_scan::{
     code_bytes, code_bytes_from, skip_opaque,
@@ -39,44 +39,7 @@ pub(super) fn body_references_identifier(body: &str, identifier: &str) -> bool {
         return false;
     }
 
-    // The Rust regex crate does NOT support lookbehind assertions.
-    // We use alternation-based boundary matching instead:
-    //   (^|[^a-zA-Z0-9_$])identifier([^a-zA-Z0-9_$]|$)
-    //
-    // This handles two important cases:
-    // 1. `$foo` (store subscriptions) - `\b` doesn't work because `$` is not a word char.
-    //    e.g., "bar = $foo" must match `$foo` but NOT "bar = $foobar"
-    // 2. For plain identifiers like `count`, we must NOT match `count` inside `$count`.
-    //    e.g., `$count * 2` - `count` should NOT be considered a dependency here
-    //    because `$count` already tracks the store subscription.
-    let escaped = regex::escape(identifier);
-    // Use alternation boundary for ALL identifiers (both `$foo` and `count`)
-    // to correctly handle the `$`-prefixed store subscription case.
-    // Also exclude `.` from valid preceding characters to avoid matching property
-    // accesses like `obj.prop` when checking for standalone `prop` references.
-    //
-    // EXCEPTION: the `$$`-prefixed compiler specials (`$$props` / `$$restProps` /
-    // `$$slots`) are never member-access targets, but they DO appear after a `.`
-    // in a spread — `{ ...$$restProps }`. Excluding `.` there made
-    // `body_references_identifier(body, "$$restProps")` miss the spread, so a
-    // `$: x = { ...$$restProps }` reactive statement dropped its
-    // `$.deep_read_state($$restProps)` dependency (emitting `() => {}`). Allow a
-    // leading `.` for `$$`-names so the spread form is detected.
-    let preceding = if identifier.starts_with("$$") {
-        r"[^a-zA-Z0-9_$]"
-    } else {
-        // Exclude `.` so member access (`obj.prop`) does not match a standalone
-        // `prop`, but DO allow a spread prefix (`...prop`): three dots before the
-        // name are a read, not a member access (`$: x = f(...prop)` reads `prop`).
-        // The regex crate has no lookbehind, so add `...` as an explicit
-        // alternative in the leading-boundary group.
-        r"[^a-zA-Z0-9_$\.]|\.\.\."
-    };
-    let pattern = format!(r"(^|{}){}([^a-zA-Z0-9_$]|$)", preceding, escaped);
-    let re = match get_or_compile_regex(&pattern) {
-        Some(re) => re,
-        None => return false,
-    };
+    let matcher = IdentifierMatcher::new(identifier);
 
     // Before checking, strip out function/arrow bodies that shadow the identifier
     // as a parameter. This prevents false positives where a function parameter
@@ -96,12 +59,83 @@ pub(super) fn body_references_identifier(body: &str, identifier: &str) -> bool {
     let stripped_body = strip_object_property_keys(&stripped_body);
 
     // Check if identifier appears in the stripped body at all
-    if !re.is_match(&stripped_body) {
+    if !matcher.is_match(&stripped_body) {
         return false;
     }
 
     // Use the recursive check that handles if/else, blocks, and compound statements
-    body_references_identifier_recursive(stripped_body.trim(), identifier, &re)
+    body_references_identifier_recursive(stripped_body.trim(), identifier, &matcher)
+}
+
+/// Whether an identifier occurs in a body as a standalone reference.
+///
+/// This used to be a regex, rebuilt from a formatted pattern for every
+/// (statement, variable) pair the dependency scan asks about; escaping the name,
+/// formatting the pattern and hashing it to reach the cache was 70% of that
+/// scan's cost. The rule it encodes needs no engine:
+///
+/// - `(^|[^a-zA-Z0-9_$])name([^a-zA-Z0-9_$]|$)` for the `$$`-prefixed compiler
+///   specials, which are never member-access targets but do appear after a `.`
+///   in a spread (`{ ...$$restProps }`)
+/// - the same with `.` also excluded before the name for every other identifier,
+///   so `obj.prop` does not match a standalone `prop` — except for a spread
+///   prefix (`f(...prop)`), which reads it
+pub(super) struct IdentifierMatcher<'a> {
+    identifier: &'a str,
+    /// `$$`-names accept a `.` immediately before them; the rest do not.
+    allows_leading_dot: bool,
+}
+
+impl<'a> IdentifierMatcher<'a> {
+    pub(super) fn new(identifier: &'a str) -> Self {
+        Self {
+            identifier,
+            allows_leading_dot: identifier.starts_with("$$"),
+        }
+    }
+
+    pub(super) fn is_match(&self, text: &str) -> bool {
+        let needle = self.identifier.as_bytes();
+        if needle.is_empty() {
+            return false;
+        }
+        let bytes = text.as_bytes();
+        let mut from = 0;
+        // Advancing by one keeps overlapping occurrences reachable, which a
+        // non-overlapping iterator would skip.
+        while let Some(offset) = memmem::find(&bytes[from..], needle) {
+            let start = from + offset;
+            let end = start + needle.len();
+            if self.boundaries_hold(bytes, start, end) {
+                return true;
+            }
+            from = start + 1;
+        }
+        false
+    }
+
+    fn boundaries_hold(&self, bytes: &[u8], start: usize, end: usize) -> bool {
+        // A UTF-8 continuation byte is never one of the ASCII characters the
+        // classes below list, so comparing bytes answers the same question the
+        // char classes did.
+        if end < bytes.len() && continues_identifier(bytes[end]) {
+            return false;
+        }
+        if start == 0 {
+            return true;
+        }
+        let before = bytes[start - 1];
+        if !continues_identifier(before) && (self.allows_leading_dot || before != b'.') {
+            return true;
+        }
+        // `...name` is a spread, which reads the name rather than accessing it
+        // as a member.
+        !self.allows_leading_dot && start >= 3 && &bytes[start - 3..start] == b"..."
+    }
+}
+
+fn continues_identifier(byte: u8) -> bool {
+    byte.is_ascii_alphanumeric() || byte == b'_' || byte == b'$'
 }
 
 /// Byte just past the comment or regex literal starting at `i`, plus whether it
@@ -594,7 +628,7 @@ pub(super) fn strip_function_scopes_that_shadow<'a>(
 pub(super) fn body_references_identifier_recursive(
     body: &str,
     identifier: &str,
-    re: &regex::Regex,
+    re: &IdentifierMatcher<'_>,
 ) -> bool {
     let trimmed = body.trim();
 
@@ -689,7 +723,7 @@ pub(super) fn body_references_identifier_recursive(
 pub(super) fn body_references_identifier_in_statements(
     content: &str,
     identifier: &str,
-    re: &regex::Regex,
+    re: &IdentifierMatcher<'_>,
 ) -> bool {
     // Split by semicolons and newlines, but be careful with nested blocks
     // Simple approach: scan for statements at depth 0
@@ -726,7 +760,7 @@ pub(super) fn body_references_identifier_in_statements(
 pub(super) fn check_identifier_in_statement(
     stmt: &str,
     identifier: &str,
-    re: &regex::Regex,
+    re: &IdentifierMatcher<'_>,
 ) -> bool {
     if !re.is_match(stmt) {
         return false;
@@ -1922,8 +1956,57 @@ mod colon_depth0_tests {
     }
 
     #[test]
+    fn identifier_matcher_agrees_with_the_regex_it_replaced() {
+        // The pattern this matcher encodes, kept here so the two can be
+        // compared rather than the rule being restated in prose.
+        fn reference_regex(identifier: &str) -> regex::Regex {
+            let preceding = if identifier.starts_with("$$") {
+                r"[^a-zA-Z0-9_$]"
+            } else {
+                r"[^a-zA-Z0-9_$\.]|\.\.\."
+            };
+            regex::Regex::new(&format!(
+                r"(^|{}){}([^a-zA-Z0-9_$]|$)",
+                preceding,
+                regex::escape(identifier)
+            ))
+            .unwrap()
+        }
+
+        let cases = [
+            ("count", "count + 1"),
+            ("count", "$count * 2"),
+            ("count", "counter + 1"),
+            ("count", "obj.count"),
+            ("count", "f(...count)"),
+            ("count", "a.b.count"),
+            ("count", "{ count }"),
+            ("count", "count"),
+            ("count", ""),
+            ("count", "\u{3042}count\u{3042}"),
+            ("count", "acount"),
+            ("count", "count.value"),
+            ("$foo", "bar = $foo"),
+            ("$foo", "bar = $foobar"),
+            ("$$restProps", "{ ...$$restProps }"),
+            ("$$restProps", "$$restPropsX"),
+            ("$$props", "a.$$props"),
+            ("x", "xx x xx"),
+            ("aa", "aaa"),
+            ("aa", "aa"),
+        ];
+        for (identifier, text) in cases {
+            assert_eq!(
+                IdentifierMatcher::new(identifier).is_match(text),
+                reference_regex(identifier).is_match(text),
+                "identifier {identifier:?} in {text:?}"
+            );
+        }
+    }
+
+    #[test]
     fn ternary_branch_split_survives_non_ascii() {
-        let re = regex::Regex::new(r"\bcomponent\b").unwrap();
+        let re = IdentifierMatcher::new("component");
         // `cond ? component = "ああa" : component = other`
         let stmt = "cond ? component = \"ああa\" : component = other";
         let _ = check_identifier_in_statement(stmt, "component", &re);

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/state_transforms.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/state_transforms.rs
@@ -32,6 +32,13 @@ use crate::compiler::phases::phase3_transform::shared::js_scan::{
 /// For block bodies like `{ c = a + b; count = count + 1; }`, we check each statement
 /// within the block.
 pub(super) fn body_references_identifier(body: &str, identifier: &str) -> bool {
+    // Every strip below only blanks or deletes characters, so a name absent from
+    // the raw body is absent from all of them. Callers ask this once per
+    // (statement, reactive variable) pair, and almost every pair is a miss.
+    if memmem::find(body.as_bytes(), identifier.as_bytes()).is_none() {
+        return false;
+    }
+
     // The Rust regex crate does NOT support lookbehind assertions.
     // We use alternation-based boundary matching instead:
     //   (^|[^a-zA-Z0-9_$])identifier([^a-zA-Z0-9_$]|$)
@@ -117,11 +124,11 @@ fn skip_slash_run(bytes: &[u8], i: usize, prev: Option<u8>) -> Option<(usize, bo
 ///
 /// This prevents false identifier matches inside literal text, e.g., `<circle>` in
 /// a template literal won't match the variable name `circle`.
-pub(super) fn strip_string_literal_text(code: &str) -> String {
+pub(super) fn strip_string_literal_text(code: &str) -> std::borrow::Cow<'_, str> {
     // Fast path: if no string delimiters exist, return as-is
     // Uses memchr3 for SIMD-accelerated search of all three delimiters at once
     if memchr::memchr3(b'\'', b'"', b'`', code.as_bytes()).is_none() {
-        return code.to_string();
+        return std::borrow::Cow::Borrowed(code);
     }
 
     // Work with bytes for performance (string literal delimiters are all ASCII)
@@ -264,7 +271,9 @@ pub(super) fn strip_string_literal_text(code: &str) -> String {
         }
     }
 
-    String::from_utf8(result).unwrap_or_else(|_| code.to_string())
+    String::from_utf8(result)
+        .map(std::borrow::Cow::Owned)
+        .unwrap_or(std::borrow::Cow::Borrowed(code))
 }
 
 /// Strip non-shorthand, non-computed object property keys from code.
@@ -277,7 +286,12 @@ pub(super) fn strip_string_literal_text(code: &str) -> String {
 /// - `{ key: value }` -> `{     value }` (non-shorthand key blanked)
 /// - `{ key }` -> `{ key }` (shorthand preserved)
 /// - `{ [expr]: value }` -> `{ [expr]: value }` (computed preserved)
-pub(super) fn strip_object_property_keys(code: &str) -> String {
+pub(super) fn strip_object_property_keys(code: &str) -> std::borrow::Cow<'_, str> {
+    // A key can only be blanked at a `:`, and the two `Vec<char>` below cost four
+    // bytes per source byte, so the absence of one is worth checking for.
+    if memchr::memchr(b':', code.as_bytes()).is_none() {
+        return std::borrow::Cow::Borrowed(code);
+    }
     let chars: Vec<char> = code.chars().collect();
     let len = chars.len();
     let mut result: Vec<char> = chars.clone();
@@ -349,7 +363,7 @@ pub(super) fn strip_object_property_keys(code: &str) -> String {
         i += 1;
     }
 
-    result.into_iter().collect()
+    std::borrow::Cow::Owned(result.into_iter().collect())
 }
 
 /// Strip out function/arrow expression bodies where the identifier is declared as a parameter.
@@ -360,7 +374,17 @@ pub(super) fn strip_object_property_keys(code: &str) -> String {
 /// - `function (a) { ... }` -> `                   `
 /// - `(a) => { ... }` -> `              `
 /// - `(a) => expr` -> `            `
-pub(super) fn strip_function_scopes_that_shadow(body: &str, identifier: &str) -> String {
+pub(super) fn strip_function_scopes_that_shadow<'a>(
+    body: &'a str,
+    identifier: &str,
+) -> std::borrow::Cow<'a, str> {
+    // Only a `function` keyword or an arrow can introduce a shadowing parameter,
+    // and the common reactive body has neither.
+    if memmem::find(body.as_bytes(), b"function").is_none()
+        && memmem::find(body.as_bytes(), b"=>").is_none()
+    {
+        return std::borrow::Cow::Borrowed(body);
+    }
     let mut result = body.to_string();
 
     // Pattern: `function identifier(params) { body }` or `function (params) { body }`
@@ -562,7 +586,7 @@ pub(super) fn strip_function_scopes_that_shadow(body: &str, identifier: &str) ->
         }
     }
 
-    result
+    std::borrow::Cow::Owned(result)
 }
 
 /// Recursively check if an identifier is read (not just assigned to) in a body of code.

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/store_transforms.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/store_transforms.rs
@@ -365,6 +365,12 @@ pub(super) fn transform_store_reads_client(line: &str, store_sub_vars: &[String]
     let mut result = line.to_string();
 
     for store_sub in store_sub_vars {
+        // The walk below copies every character it does not match, so a name
+        // that does not occur rebuilds the line unchanged.
+        if memmem::find(result.as_bytes(), store_sub.as_bytes()).is_none() {
+            continue;
+        }
+
         // Use word boundary matching to replace identifier references
         // But avoid replacing function calls that already have ()
         let mut new_result = String::with_capacity(result.len() * 2);

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/profile.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/profile.rs
@@ -120,6 +120,11 @@ pub struct ScriptTextBreakdown {
     /// The legacy `$:` reactive-statement branch.
     pub reactive_stmt: Duration,
     pub reactive_calls: u64,
+    /// `reactive_stmt` split three ways: dependency extraction, the body
+    /// rewrite, and the state-assignment AST pass that follows it.
+    pub rs_deps: Duration,
+    pub rs_body: Duration,
+    pub rs_assigns: Duration,
     /// Reactive-statement append plus the runes-mode AST transforms.
     pub ast_transforms: Duration,
     /// Shadowed-local post-pass and dev-mode instrumentation.
@@ -207,6 +212,9 @@ thread_local! {
     static ST_RUNES: Cell<Duration> = const { Cell::new(Duration::ZERO) };
     static ST_REACTIVE_STMT: Cell<Duration> = const { Cell::new(Duration::ZERO) };
     static ST_REACTIVE_CALLS: Cell<u64> = const { Cell::new(0) };
+    static ST_RS_DEPS: Cell<Duration> = const { Cell::new(Duration::ZERO) };
+    static ST_RS_BODY: Cell<Duration> = const { Cell::new(Duration::ZERO) };
+    static ST_RS_ASSIGNS: Cell<Duration> = const { Cell::new(Duration::ZERO) };
     static ST_PARENT_CALLS: Cell<u64> = const { Cell::new(0) };
     static ST_DEPTH: Cell<u64> = const { Cell::new(0) };
     static ST_NESTED_ENTRIES: Cell<u64> = const { Cell::new(0) };
@@ -450,6 +458,21 @@ impl Drop for ReactiveStmtGuard {
 }
 
 #[inline]
+pub fn record_rs_deps(d: Duration) {
+    ST_RS_DEPS.with(|c| c.set(c.get() + d));
+}
+
+#[inline]
+pub fn record_rs_body(d: Duration) {
+    ST_RS_BODY.with(|c| c.set(c.get() + d));
+}
+
+#[inline]
+pub fn record_rs_assigns(d: Duration) {
+    ST_RS_ASSIGNS.with(|c| c.set(c.get() + d));
+}
+
+#[inline]
 pub fn record_st_prenormalize(d: Duration) {
     ST_PRENORMALIZE.with(|c| c.set(c.get() + d));
     ST_CALLS.with(|c| c.set(c.get() + 1));
@@ -488,6 +511,9 @@ pub fn take_script_text_breakdown() -> ScriptTextBreakdown {
         runes: ST_RUNES.with(|c| c.replace(Duration::ZERO)),
         reactive_stmt: ST_REACTIVE_STMT.with(|c| c.replace(Duration::ZERO)),
         reactive_calls: ST_REACTIVE_CALLS.with(|c| c.replace(0)),
+        rs_deps: ST_RS_DEPS.with(|c| c.replace(Duration::ZERO)),
+        rs_body: ST_RS_BODY.with(|c| c.replace(Duration::ZERO)),
+        rs_assigns: ST_RS_ASSIGNS.with(|c| c.replace(Duration::ZERO)),
         entries: ST_ENTRIES.with(|c| c.replace(0)),
         parent_calls: ST_PARENT_CALLS.with(|c| c.replace(0)),
         nested_entries: ST_NESTED_ENTRIES.with(|c| c.replace(0)),

--- a/crates/rsvelte_devtools/src/bin/compile_profile.rs
+++ b/crates/rsvelte_devtools/src/bin/compile_profile.rs
@@ -263,6 +263,13 @@ fn main() {
         ("  process_accum", ms(st.process_accumulated)),
         ("    runes_xform", ms(st.runes)),
         ("    reactive_stmt", ms(st.reactive_stmt)),
+        ("      rs_deps", ms(st.rs_deps)),
+        ("      rs_body", ms(st.rs_body)),
+        ("      rs_assigns", ms(st.rs_assigns)),
+        (
+            "      rs_rest",
+            residual(st.reactive_stmt, &[st.rs_deps, st.rs_body, st.rs_assigns]),
+        ),
         (
             "    pa_rest",
             residual(st.process_accumulated, &[st.runes, st.reactive_stmt]),
@@ -666,6 +673,13 @@ const SHIPPED_PROJECTS: [&str; 6] = [
 
 fn collect_files() -> Vec<(String, String)> {
     let base = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..");
+    // A corpus outside the repo (a pinned upstream checkout) is the only way to
+    // profile the projects the published benchmark uses but we do not vendor.
+    if let Some(dir) = std::env::args().find_map(|a| a.strip_prefix("--dir=").map(str::to_owned)) {
+        let mut files = Vec::new();
+        collect_svelte_files(&PathBuf::from(dir), &mut files);
+        return files;
+    }
     if std::env::args().any(|a| a == "--shipped") {
         // `--only=a,b` / `--skip=a,b` narrow the set, so a share that turns out
         // to sit in one project can be attributed to it instead of guessed at.


### PR DESCRIPTION
`extract_reactive_statement_deps` asks two questions — "does this statement body
reference this reactive variable" and "does it assign to it" — once per (`$:`
statement x reactive variable) pair. Each answer copied and rescanned the whole
body three times, formatted and searched twenty patterns, or compiled and ran a
boundary regex. Almost every pair is a miss.

Four commits, each a no-op by construction:

1. **One scan rules a variable out.** Every strip in `body_references_identifier`
   only blanks or deletes bytes, so a name absent from the raw body is absent from
   all of them; every pattern in `is_assigned_anywhere_in_body` contains the name.
   A single `memmem` scan settles both. The three strips also borrow instead of
   copying when they have nothing to strip.
2. **No per-name rebuild on a miss.** `transform_prop_reads_in_expr` and
   `transform_store_reads_client` walk and re-emit the whole text once per name;
   a name that does not occur rebuilds it unchanged, at the cost of a `Vec<char>`,
   an offset table, a scan index and a `String`.
3. **No regex.** The pattern only asked whether the byte after the name is an
   identifier byte, whether the byte before is, and whether a leading `.` is a
   member access or the tail of a spread. `IdentifierMatcher` asks those directly;
   the scan advances by one byte so overlapping occurrences stay reachable. A test
   reconstructs the regex it replaced and asserts they agree on 20 cases,
   including `obj.count`, `f(...count)`, `$count`, and non-ASCII names.

## Measurement

carbon-components-svelte v0.110.2, 287 components, client target. Interleaved
paired runs, branch point vs tip, 8 pairs:

| arm | median |
| --- | ---: |
| branch point | 1128.2 ms |
| tip | 752.0 ms |

**-33.3%**, and the tip wins all 8 pairs. The machine was under load ~116, which
inflates both arms; on a quiet machine the same binaries measure 363.7-382.0 ms
and 247.0 ms, the same -33%.

Attribution: `extract_reactive_statement_deps` was 48.7% of total compile time
here and is now 6.0%.

## Scope

This is the legacy `$:` path only, and it is client-only — the server transform
does not call these functions. It moves nothing on runes code: the corpus this
compiler had been profiled against (flowbite, 1296 files) contains **zero** files
with a `$:` line, which is why a hotspot worth half of compile time stayed
invisible. carbon carries one in 173 of 287.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
