### PR TITLE
fix(compiler): keep a comment between `await` and its operand in a runes instance script (#2375)

### DIFF
--- a/.changeset/runes-await-comment.md
+++ b/.changeset/runes-await-comment.md
@@ -1,0 +1,10 @@
+---
+"@rsvelte/compiler": patch
+---
+
+fix(compiler): keep a comment between `await` and its operand in a runes instance script
+
+Dev-mode client output wrapped `await X` as `(await $.track_reactivity_loss(X))()`
+by copying the operand from the argument's own span, which begins past any
+comment separating it from the `await` keyword. The copy now starts just past
+the keyword, matching what upstream preserves by passing the visited node.

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/ast_state_transform.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/ast_state_transform.rs
@@ -2022,8 +2022,12 @@ impl<'a, 's> StateVarCollector<'a, 's> {
         // Walk the argument so inner state-var refs (and nested awaits)
         // register their replacements, then drain them into the argument text.
         self.visit_expression(&expr.argument);
-        let arg_span = expr.argument.span();
-        let arg_text = self.apply_and_drain_inner_replacements(arg_span.start, arg_span.end);
+        // Copy from just past the `await` keyword, not from the argument's own
+        // start: the trivia between them holds comments upstream keeps inside
+        // the call. Widening only the start is safe because the drained inner
+        // replacements are re-based on whatever start is passed here.
+        let arg_start = expr.span.start + "await".len() as u32;
+        let arg_text = self.apply_and_drain_inner_replacements(arg_start, expr.span.end);
 
         let wrap = format!("(await $.track_reactivity_loss({}))()", arg_text.trim());
         // The `;` rides inside this replacement rather than being appended to

--- a/crates/rsvelte_core/tests/track_loss_comment_runes_instance_2375.rs
+++ b/crates/rsvelte_core/tests/track_loss_comment_runes_instance_2375.rs
@@ -1,0 +1,77 @@
+//! A comment between `await` and its operand must survive the dev-mode
+//! `(await $.track_reactivity_loss(X))()` wrap in a **runes** instance script.
+//!
+//! The runes script does not reach `await_reactivity_loss_ast`'s collector; it
+//! is rewritten by `ast_state_transform::try_rewrite_await_reactivity_loss`,
+//! which copied the operand from the argument's own span and so began past any
+//! trivia the `await` keyword was separated from it by. Expectations are the
+//! official compiler's bytes.
+
+use rsvelte_core::{CompileOptions, GenerateMode, compile};
+
+fn dev_client(src: &str) -> String {
+    compile(
+        src,
+        CompileOptions {
+            filename: Some("T.svelte".into()),
+            generate: GenerateMode::Client,
+            dev: true,
+            ..Default::default()
+        },
+    )
+    .expect("compile")
+    .js
+    .code
+}
+
+fn runes(body: &str) -> String {
+    dev_client(&format!(
+        "<script>\n{body}\tlet x = $state(1);\n</script>\n<p>{{x}}</p>"
+    ))
+}
+
+// The assertions below pin the comment's placement inside the call — the
+// property this pass owns — and stop short of the paren pairs around the
+// `await`. Official emits `return (await $.track_reactivity_loss(/* hi */
+// load()))();` with one pair; the comment-bearing esrap print path emits three
+// here, which is #2381 in `rsvelte_esrap`, reachable only once a comment is
+// kept at all.
+#[test]
+fn a_block_comment_before_the_operand_is_kept() {
+    let out = runes("\tasync function f() {\n\t\treturn await /* hi */ load();\n\t}\n");
+    assert!(
+        out.contains("$.track_reactivity_loss(/* hi */ load())"),
+        "got: {out}"
+    );
+}
+
+#[test]
+fn every_comment_in_the_run_is_kept() {
+    let out = runes("\tasync function f() {\n\t\treturn await /* a */ /* b */ load();\n\t}\n");
+    assert!(
+        out.contains("$.track_reactivity_loss(/* a */ /* b */ load())"),
+        "got: {out}"
+    );
+}
+
+#[test]
+fn a_line_comment_survives() {
+    let out = runes("\tasync function f() {\n\t\treturn await // hi\n\t\t\tload();\n\t}\n");
+    assert!(
+        out.contains("// hi"),
+        "the line comment was dropped; got: {out}"
+    );
+}
+
+/// Discriminates the `svelte-ignore` gate, not the copy bound: with the gate
+/// removed this shape gains a wrap it must not have.
+#[test]
+fn an_ignored_await_is_left_alone() {
+    let out = runes(
+        "\tasync function f() {\n\t\t// svelte-ignore await_reactivity_loss\n\t\treturn await /* hi */ load();\n\t}\n",
+    );
+    assert!(
+        !out.contains("track_reactivity_loss"),
+        "the ignored await was wrapped; got: {out}"
+    );
+}


### PR DESCRIPTION
Fixes #2375 (partially — see "What this does not fix").

## What was actually wrong

The issue records **two mechanisms**, and I retracted mechanism A myself before
starting. Re-measured at `origin/main` = `cf911651` by instrumenting every
`$.track_reactivity_loss` emission site, the real picture is:

| script kind | path taken | status |
|---|---|---|
| legacy instance | `instance_dev_tail_ast` → `await_reactivity_loss_ast` collector | fixed by **#2372** (already open) |
| `<script module>` | `module_dev_tail_ast` → same collector | fixed by **#2372** |
| **runes instance** | **`ast_state_transform::try_rewrite_await_reactivity_loss`** | **fixed here** |

Two corrections to the issue:

- **Mechanism A was not "lost downstream".** The collector's own edit already
  lacked the comment; the loss was *inside* the pass #2372 changed, not after
  it. Applying #2372's bound to `origin/main` makes both those kinds keep the
  comment, confirmed by direct measurement.
- **Mechanism B named the wrong site.** `visitors/expression_converter.rs:477`
  never executes for any of the three kinds — an `eprintln!` there produced no
  output. B's *observation* (the runes script never reaches the collector) is
  correct; the wrap is built by a **second copy** of the same logic at
  `ast_state_transform.rs:2028`, which the issue does not mention.

So it is one defect duplicated across two files, not two mechanisms.

## The fix

`try_rewrite_await_reactivity_loss` sliced the operand from
`expr.argument.span()`, which begins *after* any comment separating the operand
from `await`. It now starts just past the keyword — the same bound #2372 uses
in the collector. Widening only the start is safe because
`apply_and_drain_inner_replacements` re-bases the drained inner replacements on
whatever start it is given.

Upstream reference:
`submodules/svelte/packages/svelte/src/compiler/phases/3-transform/client/visitors/AwaitExpression.js:11-21`
— upstream hands `b.call('$.track_reactivity_loss', argument)` the *visited
node*, so comments ride along with its `loc`; rsvelte copies source text, which
is why the bound is load-bearing.

## Tests

`crates/rsvelte_core/tests/track_loss_comment_runes_instance_2375.rs`.
Run against unfixed code, three of the four fail with the real divergence:

```
return (await $.track_reactivity_loss(load()))();     // rsvelte
return (await $.track_reactivity_loss(/* hi */ load()))();   // official
```

`an_ignored_await_is_left_alone` passes on both sides — it is a guard for a
**different** property (the `svelte-ignore await_reactivity_loss` gate), which
is what kills it; it does not discriminate the copy bound.

## What this does not fix

Once the comment is kept, this shape reaches `rsvelte_esrap`'s comment-bearing
print path and picks up redundant parens — **#2381**:

```
official: return (await $.track_reactivity_loss(/* hi */ load()))();
rsvelte : return (((await $.track_reactivity_loss(/* hi */ load()))))();
```

Note #2381's repro shows **two** paren pairs on the `<script module>` path; the
runes path shows **three**. The fix for that lives in
`crates/rsvelte_esrap/src/printer.rs`, which another agent holds, so this PR
touches only `client/ast_state_transform.rs`. The assertions here pin the
comment's placement inside the call and deliberately stop short of the paren
count, with the upstream bytes written out in the test file so the gap is
explicit and greppable.

## Gate visibility

Measured through the real normalizer (`flattenTemplateHoles` → oxfmt 0.62.0 →
`stripBlankLines`, `compatibility/.oxfmtrc.json`, with a control confirming
oxfmt rewrote both sides):

| | vs official |
|---|---|
| before this PR | **DIFFER** — the gate sees it |
| after this PR | **MATCH** |

So `client-dev` can see this change. Worth stating plainly: the residual #2381
parens are *absorbed* by oxfmt, so merging this before #2381 converts a
gate-visible divergence into a gate-invisible one. `client-dev` is at 0 known
failures, which means no corpus entry carries this shape at all — consistent
with it being an interaction shape the collected corpus does not sample.
