### PR TITLE
fix(compiler): guard member properties in the legacy `$:` compound-assignment scan (#2373)

### DIFF
--- a/.changeset/wild-pugs-brush.md
+++ b/.changeset/wild-pugs-brush.md
@@ -1,0 +1,15 @@
+---
+'@rsvelte/compiler': patch
+---
+
+Apply the member-property guard to compound assignment in the legacy server
+`$:` reorder scanner. `extract_simple_assignments` recorded `x` for
+`$: obj.x += 1` while recording nothing for `$: obj.x = 1` and `$: obj.x++`,
+which invented a reactive dependency and hoisted the statement above any `$:`
+that reads a plain `x`. Upstream's `AssignmentExpression` visitor takes the same
+branch for every operator and records no target for a member expression.
+
+No change to emitted output: the text scanner is reachable only from the
+declaration-tag script path, where a `$:` statement cannot occur, and SSR
+reactive ordering runs through the AST port of `order_reactive_statements`,
+which was already correct for these shapes.

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/transform_legacy.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/transform_legacy.rs
@@ -1559,8 +1559,8 @@ fn extract_simple_assignments(code: &str) -> Vec<String> {
             }
             let ident: String = chars[start..i].iter().collect();
 
-            // A member property (`foo.x = …` / `foo.x++`) is not a declared
-            // variable: the assignment mutates the *base object*, not the
+            // A member property (`foo.x = …` / `foo.x += …` / `foo.x++`) is not
+            // a declared variable: the assignment mutates the *base object*, not the
             // property. Recording the property would create a false reactive
             // dependency for any statement that reads an identifier of that
             // name (e.g. `$: { if (x) … }` spuriously depending on
@@ -1618,7 +1618,11 @@ fn extract_simple_assignments(code: &str) -> Vec<String> {
                 if matches!(op, '+' | '-' | '*' | '/' | '%' | '&' | '|' | '^') {
                     // Check it's not `==` following
                     let after_eq = chars.get(j + 2).copied().unwrap_or('\0');
-                    if after_eq != '=' && !is_reactive_keyword(&ident) && !vars.contains(&ident) {
+                    if after_eq != '='
+                        && !is_member_prop
+                        && !is_reactive_keyword(&ident)
+                        && !vars.contains(&ident)
+                    {
                         vars.push(ident.clone());
                     }
                 }
@@ -2254,4 +2258,43 @@ fn split_destructuring_properties_ssr(s: &str) -> Vec<&str> {
     }
     result.push(&s[start..]);
     result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn member_assignment_targets_are_not_recorded() {
+        // Upstream's `AssignmentExpression` visitor takes the same branch for
+        // every operator, and `extract_identifiers` yields nothing for a
+        // member-expression target, so no operator records the property.
+        assert!(extract_simple_assignments("obj.x = 1;").is_empty());
+        assert!(extract_simple_assignments("obj.x += 1;").is_empty());
+        assert!(extract_simple_assignments("a.b.c *= 2;").is_empty());
+        assert!(extract_simple_assignments("obj.x++;").is_empty());
+    }
+
+    #[test]
+    fn compound_member_assignment_does_not_reorder() {
+        let out = reorder_reactive_statements_after_functions(
+            "\tlet a = 1;\n\t$: a = x * 2;\n\t$: obj.x += 1;\n",
+        );
+        assert_eq!(out, "\tlet a = 1;\n\t$: a = x * 2;\n\t$: obj.x += 1;");
+    }
+
+    #[test]
+    fn compound_identifier_assignment_still_reorders() {
+        let out = reorder_reactive_statements_after_functions(
+            "\tlet a = 1;\n\t$: a = x * 2;\n\t$: x += 1;\n",
+        );
+        assert_eq!(out, "\tlet a = 1;\n\t$: x += 1;\n\t$: a = x * 2;");
+    }
+
+    #[test]
+    fn plain_identifier_assignment_targets_are_recorded() {
+        assert_eq!(extract_simple_assignments("x = 1;"), vec!["x"]);
+        assert_eq!(extract_simple_assignments("x += 1;"), vec!["x"]);
+        assert_eq!(extract_simple_assignments("x++;"), vec!["x"]);
+    }
 }

--- a/crates/rsvelte_core/tests/legacy_reactive_member_compound_2373.rs
+++ b/crates/rsvelte_core/tests/legacy_reactive_member_compound_2373.rs
@@ -1,0 +1,101 @@
+//! Upstream parity pins for `$:` statements whose only assignment target is a
+//! member expression. A member assignment mutates the *base object*, so
+//! upstream records no assignment target at all for it and leaves the statement
+//! in source order — regardless of the operator.
+//!
+//! These are **guards, not discriminating tests**: SSR reactive ordering runs
+//! through the AST port of `order_reactive_statements` in
+//! `server/ast/script.rs`, which already agrees with upstream here, so every
+//! case below passes both before and after the compound-assignment guard was
+//! added to `transform_legacy::extract_simple_assignments`. That text scanner
+//! is only reachable from the declaration-tag script path, where a `$:`
+//! statement cannot occur; its own behaviour is covered by unit tests in
+//! `transform_legacy.rs`. What these pin is that the live path keeps matching
+//! upstream for these shapes.
+
+use rsvelte_core::{CompileOptions, GenerateMode, compile};
+
+fn compile_component(src: &str, mode: GenerateMode) -> String {
+    compile(
+        src,
+        CompileOptions {
+            filename: Some("App.svelte".to_string()),
+            generate: mode,
+            ..Default::default()
+        },
+    )
+    .expect("compile")
+    .js
+    .code
+}
+
+fn assert_order(out: &str, first: &str, second: &str) {
+    let a = out
+        .find(first)
+        .unwrap_or_else(|| panic!("missing `{first}` in:\n{out}"));
+    let b = out
+        .find(second)
+        .unwrap_or_else(|| panic!("missing `{second}` in:\n{out}"));
+    assert!(a < b, "`{first}` must precede `{second}`, got:\n{out}");
+}
+
+const COMPOUND_MEMBER: &str = r#"<script>
+	let x = 1;
+	let obj = { x: 0 };
+	let a = 0;
+	$: a = x * 2;
+	$: obj.x += 1;
+</script>
+
+<p>{a} {obj.x}</p>
+"#;
+
+const PLAIN_MEMBER: &str = r#"<script>
+	let x = 1;
+	let obj = { x: 0 };
+	let a = 0;
+	$: a = x * 2;
+	$: obj.x = 1;
+</script>
+
+<p>{a} {obj.x}</p>
+"#;
+
+const MEMBER_UPDATE: &str = r#"<script>
+	let x = 1;
+	let obj = { x: 0 };
+	let a = 0;
+	$: a = x * 2;
+	$: obj.x++;
+</script>
+
+<p>{a} {obj.x}</p>
+"#;
+
+const COMPOUND_IDENT: &str = r#"<script>
+	let x = 1;
+	let a = 0;
+	$: a = x * 2;
+	$: x += 1;
+</script>
+
+<p>{a} {x}</p>
+"#;
+
+#[test]
+fn member_assignment_keeps_source_order_server() {
+    for (src, member) in [
+        (COMPOUND_MEMBER, "obj.x += 1"),
+        (PLAIN_MEMBER, "obj.x = 1"),
+        (MEMBER_UPDATE, "obj.x++"),
+    ] {
+        let out = compile_component(src, GenerateMode::Server);
+        assert_order(&out, "a = x * 2", member);
+    }
+}
+
+#[test]
+fn identifier_assignment_still_hoists_server() {
+    let out = compile_component(COMPOUND_IDENT, GenerateMode::Server);
+    assert_order(&out, "x += 1", "a = x * 2");
+}


### PR DESCRIPTION
Fixes #2373.

## What

`extract_simple_assignments` in `crates/rsvelte_core/src/compiler/phases/3_transform/server/transform_legacy.rs`
applied its `is_member_prop` guard to the `=` and `++`/`--` branches but not to
the compound-assignment branch, so `$: obj.x += 1` claimed to assign `x`:

```rust
extract_simple_assignments("obj.x = 1")  // []
extract_simple_assignments("obj.x += 1") // ["x"]  <-- before
extract_simple_assignments("obj.x += 1") // []     <-- after
```

The recorded name becomes a node in `sort_reactive_statements_topologically`'s
declared-variable map, so any `$:` statement reading a plain `x` gained a
dependency edge on the member statement and was pushed below it.

## Upstream reference

`submodules/svelte/packages/svelte/src/compiler/phases/2-analyze/visitors/AssignmentExpression.js`
lines 10-24. The visitor does **not** branch on `node.operator` — every
assignment operator takes the same path — and the target goes through
`extract_identifiers(node.left)`, whose `unwrap_pattern`
(`utils/ast.js:89-138`) pushes a `MemberExpression` and then filters it out by
`node.type === 'Identifier'`. So upstream records nothing into
`reactive_statement.assignments` for a member target under any operator, and
`order_reactive_statements` (`phases/2-analyze/index.js:1273-1334`) therefore
never builds an edge from it.

Verified against the pinned official compiler (5.56.8): for
`$: a = x * 2; $: obj.x += 1;` official SSR keeps source order.

## Tests

**Discriminating** (unit tests in `transform_legacy.rs`; both fail on the
pre-fix function, output below):

- `member_assignment_targets_are_not_recorded` — kills the mutant that drops
  `!is_member_prop` from the compound branch.
  ```
  assertion failed: extract_simple_assignments("obj.x += 1;").is_empty()
  ```
- `compound_member_assignment_does_not_reorder` — same mutant, at the level of
  the observable consequence.
  ```
  assertion `left == right` failed
    left: "\tlet a = 1;\n\t$: obj.x += 1;\n\t$: a = x * 2;"
   right: "\tlet a = 1;\n\t$: a = x * 2;\n\t$: obj.x += 1;"
  ```

**Discriminating in the opposite direction** (they fail if the compound branch
is disabled outright rather than guarded — verified by running that mutant):

- `plain_identifier_assignment_targets_are_recorded` (`left: []`, `right: ["x"]`)
- `compound_identifier_assignment_still_reorders`

**Guards, explicitly labelled as such** in
`crates/rsvelte_core/tests/legacy_reactive_member_compound_2373.rs`: they pass
before and after. The mechanism that makes them inert is that SSR reactive
ordering goes through the AST port of `order_reactive_statements` in
`server/ast/script.rs`, not through the text scanner this PR changes. They pin
that the live path keeps agreeing with upstream for `obj.x = …`, `obj.x += …`,
`obj.x++` and `x += …`.

## Found but not fixed

1. **The changed text path is dead code in the shipping pipeline.**
   `extract_simple_assignments` is reachable only via
   `extract_reactive_lhs_vars` → `sort_reactive_statements_topologically` →
   `sort_reactive_in_place` → `reorder_reactive_statements_after_functions`,
   whose only caller is `transform_script.rs:266` inside
   `transform_script_content_inner`; that function's only entry
   (`transform_script_content_with_imports_and_derived`) has exactly one caller,
   `server/ast/visitors/declaration_tag.rs:346`, which passes a single
   declaration-tag body — where a top-level `$:` cannot appear. Evidence: an
   instrumented build printing on `has_reactive == true` produced **0** hits
   across the 18 `rsvelte_core` integration suites that contain `$:` sources (42
   tests), with a positive control confirming the probe fires when the function
   is called directly. That is why this PR claims no output change; it also
   means #2373's stated blocker (needing corpus evidence that `client`/`server`
   output moves) no longer applies. Deleting the ~450 lines of now-unreachable
   legacy text reorder machinery is a separate change and is left out
   deliberately.
2. **`$: obj.x++` diverges from upstream in the same function, in the opposite
   direction.** Upstream's `UpdateExpression` visitor uses
   `object(node.argument)` and records the *base object* (`obj`), whereas the
   `=`/`+=` path records nothing. rsvelte records nothing in all three cases.
   Left alone: it is a different defect, adds edges rather than removing them,
   and is unobservable for the same reachability reason.

## Checks

- `cargo fmt --all`, `cargo clippy --all-targets --all-features -- -D warnings` clean.
- `cargo test -p rsvelte_core --lib`, `--test ssr`, `--test compiler_fixtures`,
  `--test compiler_errors`, `--test runtime` (release), plus the 18 `$:`-bearing
  integration suites.
