### PR TITLE
Polish documentation website

### DIFF
--- a/apps/playground/package.json
+++ b/apps/playground/package.json
@@ -18,7 +18,8 @@
 	},
 	"dependencies": {
 		"@monaco-editor/loader": "^1.7.0",
-		"monaco-editor": "^0.56.0"
+		"monaco-editor": "^0.56.0",
+		"shiki": "^4.4.2"
 	},
 	"devDependencies": {
 		"@sveltejs/adapter-static": "^3.0.8",

--- a/apps/playground/pnpm-lock.yaml
+++ b/apps/playground/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       monaco-editor:
         specifier: ^0.56.0
         version: 0.56.0
+      shiki:
+        specifier: ^4.4.2
+        version: 4.4.2
     devDependencies:
       '@sveltejs/adapter-static':
         specifier: ^3.0.8
@@ -127,56 +130,48 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@oxfmt/binding-linux-arm64-musl@0.62.0':
     resolution: {integrity: sha512-lk25fAl7KWaLWVJcW0CHEXB7QlQZtx5eDkjpaGMK0hzXTjUe0Wmlu8IKuFHoviSOcEJedRTs4VE/506VqGxGew==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@oxfmt/binding-linux-ppc64-gnu@0.62.0':
     resolution: {integrity: sha512-SFyNqHQLwySceWNLhiSldx7wPXRAzP0L0WcW9GegP3uWrpZGJiZlQO85NbHAFPEfxR9PhZ9qSnZryEh7+v+4Gw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@oxfmt/binding-linux-riscv64-gnu@0.62.0':
     resolution: {integrity: sha512-KYj55C1ywJfHo6+aKDuEmUtVEdJALsC5GwayDGsI6FGz2GxFqNr/mA8nxVsNbJzm7sE5MRqTQ9ziImSzhYXysA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@oxfmt/binding-linux-riscv64-musl@0.62.0':
     resolution: {integrity: sha512-BhZDNo5GOU5nC378RhD0/XpvaEBHsH3HLgJp8YZX3A0InC7oivzA63HsRmiXFLtLSHAstEVrDf6fbC7Rs8Jh/A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@oxfmt/binding-linux-s390x-gnu@0.62.0':
     resolution: {integrity: sha512-UyAFmyHkgSgUJ/wOM4p3U8AC2yAFvRH5PNBs7TnK0fObTT/XSWcdr/lAzPSWaekHaZFaMeFZyk9n93Joq3J93A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@oxfmt/binding-linux-x64-gnu@0.62.0':
     resolution: {integrity: sha512-1iYMP0leytWazFubD/WnINJuIrzRPuoL1aWEJdlGezEzDbTxcd29R4r8IUzP2oWeKst5V02uMJgR2NILlPlG6w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@oxfmt/binding-linux-x64-musl@0.62.0':
     resolution: {integrity: sha512-4rA/URtJSTVNVAQz6Q8wf7SaRvOXVy+TizriT9hs/Y1XhLR/R+92uWKRQG8yFWRAIEBbFHJ6WevQcl/G9SXEfw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@oxfmt/binding-openharmony-arm64@0.62.0':
     resolution: {integrity: sha512-mSZuFHU2ar1KLUjXpI2QBQcJ1VsOB3mOCgQXuXCpKs19dgh4u+OaovNfrWDfiJb+ihJ2+f7YFcaO9bS2dlTCXA==}
@@ -249,56 +244,48 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@oxlint/binding-linux-arm64-musl@1.77.0':
     resolution: {integrity: sha512-LSbwuRKiNCenPDcbARqAZ5RfBy7gmj7vOvfJRLeCDU3gFtSxWbhv/+VTlaUqzUhNj1gFLHB8h7ALnxa/Az6z6g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@oxlint/binding-linux-ppc64-gnu@1.77.0':
     resolution: {integrity: sha512-QWdcH31mXEUe5Nq1s0CfCpceaKjIo9uZtwDjAuL681g1axf+5x8xrg/eXWaw//4NCxYZ4V4e5Hu5tvdR+pTBlg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@oxlint/binding-linux-riscv64-gnu@1.77.0':
     resolution: {integrity: sha512-GnOfYgJxbcElOiPZaDFDl406ONddwvOWk2jvAAAEjwAl4GofNoHF+/HHUIBYa6bFCArlcGPi0XjC4cU1pkgF/Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@oxlint/binding-linux-riscv64-musl@1.77.0':
     resolution: {integrity: sha512-AyEMTUCf0xY+hHF+IxqXFQIX0yQOIR8ykpY0lJNOw9xYqOzUX8dyZfRvlG0RfXwuQn2eonf/8NrMmDSZJjdqsA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@oxlint/binding-linux-s390x-gnu@1.77.0':
     resolution: {integrity: sha512-sPLzEcNvxd/oyVQ5oZo92CiHkFkpBeRop13E/P3TPY+hZfXHKCOWKI70TE2RYwMKFJDc20EMjH16L7NZICtKTw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@oxlint/binding-linux-x64-gnu@1.77.0':
     resolution: {integrity: sha512-1Oh2ssH2L7lwyvkdSqaMUfsGfwU2Wfvew+obBUYjRVqhpBcUpwnsPSEr1IzVi9XqkuY10geiLsNKecqaZC34Dw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@oxlint/binding-linux-x64-musl@1.77.0':
     resolution: {integrity: sha512-0j/2wRgNGO+Qj/M1uu/p57h/hFTTWWcfie0ufkbabeus2s5+/QqkCflnMOwLLN5m2GsNeWp4xdl4cPa4n7QCOQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@oxlint/binding-openharmony-arm64@1.77.0':
     resolution: {integrity: sha512-BJ/j54qS0usEnyDkLYURMj2iiD9h5Cyy+ppzeMSXBGRXaGRNWnj1Mw14NqWMR5E/PzdgB30OOCCzLzbRoduafw==}
@@ -362,42 +349,36 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.2.1':
     resolution: {integrity: sha512-Sm41FyCeXqmYcERoYOCbGIL5hNfd8w9LQ7Y61Bev48HkcjaJqV/iiVOaiDxjVTRMS+QKrZmD8cfPt4uMVnvM+A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.2.1':
     resolution: {integrity: sha512-2x+WhXTGl9yJYPbltW/BSEPTVz9OIWQyER4N+gJEDWkkn904eRcBzELqh/Hf7K0w/ubGbKNMv0ZC+94QK/IFEg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.2.1':
     resolution: {integrity: sha512-eEjmQpuRQayHPWWnywaWHkFT3ToPbP3RYy42VVd/B9aBGDA+Ol25EIWHxKQST3IiWJjikCWUF7KtbfqwZrzVwQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.2.1':
     resolution: {integrity: sha512-/Orga1fZYkLc/56jBICcHrKchl8Z2UKdDSr3LG9ToWO1lQ6a4Livk9Xz+9WN91zsz5QR3XQz2NNoSDEvP6qadw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.2.1':
     resolution: {integrity: sha512-xxBJRL+0q0Kce7orznGWLuylHDY65vuARXZRpX+hPdv+DqK2c3NlCsVA98tlWzWNEE7yPqA/1NQ5nnCrj49Y5A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.2.1':
     resolution: {integrity: sha512-M6AdXIXw3s+/8XpKMzdGDEXGS1S7kwUsy+rcTIUIOx5Ge4nXKCtAFHFV9YKkXvGcC5WMoTjAteLzlsQROVI0Yw==}
@@ -423,6 +404,37 @@ packages:
 
   '@rolldown/pluginutils@1.0.1':
     resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
+
+  '@shikijs/core@4.4.2':
+    resolution: {integrity: sha512-StyzbAyxg2/tBGf78gwbBkGyeQ73lf8UiJArFaQhTQIDqQOCKPCQFanvrs4/Yv3Yfyc+ONInJM6K+FMIf+P+kA==}
+    engines: {node: '>=20'}
+
+  '@shikijs/engine-javascript@4.4.2':
+    resolution: {integrity: sha512-MnIkeqWdVPUWsxlx8gKLVCJFTsqrQJgpTPBPpQwaFeJ56lOnJxj5aN2LUFnfxUEcvOQuNocmbaMnVrCEln6rkw==}
+    engines: {node: '>=20'}
+
+  '@shikijs/engine-oniguruma@4.4.2':
+    resolution: {integrity: sha512-GLhowz1+jixjz+wiZ3wMnOn1jTxiFCGl2PkXufivbnwPHKuyw1AYqu5/hbWhZZ2oAb0NP05WUJhYeigY14drnw==}
+    engines: {node: '>=20'}
+
+  '@shikijs/langs@4.4.2':
+    resolution: {integrity: sha512-8DfeusD+Zdv/eYIDdXyJTUnSMHt+aAWjAOCXV20HNGAHRlInXpG8wh421v6B91WOm9TFwRLN+b/LG5F2NAIojg==}
+    engines: {node: '>=20'}
+
+  '@shikijs/primitive@4.4.2':
+    resolution: {integrity: sha512-l6fQQKsOMlz72n38fztmSgZ76MO6KSWuw8o+GJ+FhmqrpC9pIOJNQNXGgbb5yX2AwpzlEHwsaLPnk/8o4Fm+rA==}
+    engines: {node: '>=20'}
+
+  '@shikijs/themes@4.4.2':
+    resolution: {integrity: sha512-H0CFoL07ddDC2Dd6EdrPYNkRhUR6YCkJlnuYFceYYUJJA5TIm2b5B33qqiDYryBExgbKMndFJPb2u1gTuqO37g==}
+    engines: {node: '>=20'}
+
+  '@shikijs/types@4.4.2':
+    resolution: {integrity: sha512-PFYitV4vpDr/iPCIhnHp+Q4ftic5N5VeNJ3KQ1O8gn3h2ar8qgwMAXF7tq4m1CWaMS60fV4VqF6vfnWH4F7vqQ==}
+    engines: {node: '>=20'}
+
+  '@shikijs/vscode-textmate@10.0.2':
+    resolution: {integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==}
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
@@ -469,8 +481,17 @@ packages:
   '@types/estree@1.0.9':
     resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
 
+  '@types/hast@3.0.5':
+    resolution: {integrity: sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g==}
+
+  '@types/mdast@4.0.4':
+    resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
+
   '@types/trusted-types@2.0.7':
     resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
+
+  '@types/unist@3.0.3':
+    resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
 
   '@typescript/typescript-aix-ppc64@7.0.2':
     resolution: {integrity: sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==}
@@ -592,6 +613,9 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@ungap/structured-clone@1.3.3':
+    resolution: {integrity: sha512-60YRaenCQcVjYEKOcG824+DRGGIQ3VKErcBoAEDJZz5bKIs2ZG+X/H9Nk+Q6EVkwJk5QNApxbrc5QtBSwtrXAg==}
+
   acorn@8.17.0:
     resolution: {integrity: sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==}
     engines: {node: '>=0.4.0'}
@@ -610,9 +634,21 @@ packages:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
     engines: {node: '>= 0.4'}
 
+  ccount@2.0.1:
+    resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
+
+  character-entities-html4@2.1.0:
+    resolution: {integrity: sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==}
+
+  character-entities-legacy@3.0.0:
+    resolution: {integrity: sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==}
+
   clsx@2.1.1:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
+
+  comma-separated-tokens@2.0.3:
+    resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
 
   cookie@0.6.0:
     resolution: {integrity: sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==}
@@ -622,12 +658,19 @@ packages:
     resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
     engines: {node: '>=0.10.0'}
 
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
+
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
 
   devalue@5.8.2:
     resolution: {integrity: sha512-DObPPAfdtFbXjxLqK8s2Xk9ZuWz5+ZoFEhC7J76es4GU/rEiXwHTmbImoCdyoCOcBH1UF3+Cz6Z2sYD4hyl5TA==}
+
+  devlop@1.1.0:
+    resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
 
   dompurify@3.4.8:
     resolution: {integrity: sha512-yb1cEmaOum7wFvOCSQxyfgVlv5D47Rc30iZWoMpbDIWTnJ6grDDQyu2KFJzB2k7u0pMuJcQ1zphH//fFnw2tjQ==}
@@ -656,6 +699,15 @@ packages:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
+
+  hast-util-to-html@9.0.5:
+    resolution: {integrity: sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==}
+
+  hast-util-whitespace@3.0.0:
+    resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
+
+  html-void-elements@3.0.0:
+    resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
 
   is-reference@3.0.3:
     resolution: {integrity: sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw==}
@@ -699,28 +751,24 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.33.0:
     resolution: {integrity: sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.33.0:
     resolution: {integrity: sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.33.0:
     resolution: {integrity: sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.33.0:
     resolution: {integrity: sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==}
@@ -749,6 +797,24 @@ packages:
     engines: {node: '>= 18'}
     hasBin: true
 
+  mdast-util-to-hast@13.2.1:
+    resolution: {integrity: sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==}
+
+  micromark-util-character@2.1.1:
+    resolution: {integrity: sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==}
+
+  micromark-util-encode@2.0.1:
+    resolution: {integrity: sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==}
+
+  micromark-util-sanitize-uri@2.0.1:
+    resolution: {integrity: sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==}
+
+  micromark-util-symbol@2.0.1:
+    resolution: {integrity: sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==}
+
+  micromark-util-types@2.0.2:
+    resolution: {integrity: sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==}
+
   monaco-editor@0.56.0:
     resolution: {integrity: sha512-sXboRm3BeBeLm938eaiyLMe0OxzfXIlZvbv4ir/jVgQy1zDhWjgmny0WoN45fuDKhCCQsYMbBJrv/A6jd8aCUg==}
 
@@ -764,6 +830,12 @@ packages:
   obug@2.1.4:
     resolution: {integrity: sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==}
     engines: {node: '>=12.20.0'}
+
+  oniguruma-parser@0.12.2:
+    resolution: {integrity: sha512-6HVa5oIrgMC6aA6WF6XyyqbhRPJrKR02L20+2+zpDtO5QAzGHAUGw5TKQvwi5vctNnRHkJYmjAhRVQF2EKdTQw==}
+
+  oniguruma-to-es@4.3.6:
+    resolution: {integrity: sha512-csuQ9x3Yr0cEIs/Zgx/OEt9iBw9vqIunAPQkx19R/fiMq2oGVTgcMqO/V3Ybqefr1TBvosI6jU539ksaBULJyA==}
 
   oxfmt@0.62.0:
     resolution: {integrity: sha512-vxgGHTmnDU9j4CX7dDBLzxgmHxfda/yPcgJkGCMUSCwRmz+euo/V08xXLNgXTeqAB9Fhf3Pe2nO1RNKLCVgphQ==}
@@ -802,6 +874,18 @@ packages:
     resolution: {integrity: sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==}
     engines: {node: ^10 || ^12 || >=14}
 
+  property-information@7.2.0:
+    resolution: {integrity: sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==}
+
+  regex-recursion@6.0.2:
+    resolution: {integrity: sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==}
+
+  regex-utilities@2.3.0:
+    resolution: {integrity: sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==}
+
+  regex@6.1.0:
+    resolution: {integrity: sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==}
+
   rolldown@1.2.1:
     resolution: {integrity: sha512-4FKJhg8d3OiyQOA6Q1Q0hoFFpW9/OoX+VsHzpECsdsIZoOArrAK90gl59YK/Z+gnDel45bgJZK03ozH/9bCqEw==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -809,6 +893,10 @@ packages:
 
   set-cookie-parser@3.1.2:
     resolution: {integrity: sha512-5/r/lTwbJ3zQ+qwdUFZYeRNqda7P5HD8zQKqlSjdGt1/S0cjLAphHusj4Y58ahDtWn/g32xrIS58/ikOvwl0Lw==}
+
+  shiki@4.4.2:
+    resolution: {integrity: sha512-P8F/dFhRevaw2uSdeIYlq/5SXZNY85DPtmXQ947gD1Zj2JqO5AkNvVVBar0Me9JkFx3uzVud/qOtP5ek9NEQGA==}
+    engines: {node: '>=20'}
 
   sirv@3.0.2:
     resolution: {integrity: sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==}
@@ -818,8 +906,14 @@ packages:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
 
+  space-separated-tokens@2.0.2:
+    resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
+
   state-local@1.0.7:
     resolution: {integrity: sha512-HTEHMNieakEnoe33shBYcZ7NX83ACUjCu8c40iOGEZsngj9zRnkqS9j1pqQPXwobB0ZcVTk27REb7COQ0UR59w==}
+
+  stringify-entities@4.0.4:
+    resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
 
   svelte@5.56.8:
     resolution: {integrity: sha512-PY8LOw7xP6c8IOiVqdo0sbbZVYhXRSfklOQLAUyGBKqjTX0wx/z4l/9J+PmBpmlLnxzEb1NqltxQ5/wZme/Cmg==}
@@ -837,6 +931,9 @@ packages:
     resolution: {integrity: sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==}
     engines: {node: '>=6'}
 
+  trim-lines@3.0.1:
+    resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
+
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
@@ -844,6 +941,27 @@ packages:
     resolution: {integrity: sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==}
     engines: {node: '>=16.20.0'}
     hasBin: true
+
+  unist-util-is@6.0.1:
+    resolution: {integrity: sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==}
+
+  unist-util-position@5.0.0:
+    resolution: {integrity: sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==}
+
+  unist-util-stringify-position@4.0.0:
+    resolution: {integrity: sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==}
+
+  unist-util-visit-parents@6.0.2:
+    resolution: {integrity: sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==}
+
+  unist-util-visit@5.1.0:
+    resolution: {integrity: sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==}
+
+  vfile-message@4.0.3:
+    resolution: {integrity: sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==}
+
+  vfile@6.0.3:
+    resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
 
   vite@8.2.0:
     resolution: {integrity: sha512-pn+CFpM0lwDeKwmOq1ZaBK/9sjorZcgqxki6MbY/jPEVd9vichIlmlD4HmQ5wdP5EgqQCFRaACBxMC7uEGc6lQ==}
@@ -898,6 +1016,9 @@ packages:
 
   zimmerframe@1.1.4:
     resolution: {integrity: sha512-B58NGBEoc8Y9MWWCQGl/gq9xBCe4IiKM0a2x7GZdQKOW5Exr8S1W24J6OgM1njK8xCRGvAJIL/MxXHf6SkmQKQ==}
+
+  zwitch@2.0.4:
+    resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
 snapshots:
 
@@ -1116,6 +1237,46 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.1': {}
 
+  '@shikijs/core@4.4.2':
+    dependencies:
+      '@shikijs/primitive': 4.4.2
+      '@shikijs/types': 4.4.2
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.5
+      hast-util-to-html: 9.0.5
+
+  '@shikijs/engine-javascript@4.4.2':
+    dependencies:
+      '@shikijs/types': 4.4.2
+      '@shikijs/vscode-textmate': 10.0.2
+      oniguruma-to-es: 4.3.6
+
+  '@shikijs/engine-oniguruma@4.4.2':
+    dependencies:
+      '@shikijs/types': 4.4.2
+      '@shikijs/vscode-textmate': 10.0.2
+
+  '@shikijs/langs@4.4.2':
+    dependencies:
+      '@shikijs/types': 4.4.2
+
+  '@shikijs/primitive@4.4.2':
+    dependencies:
+      '@shikijs/types': 4.4.2
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.5
+
+  '@shikijs/themes@4.4.2':
+    dependencies:
+      '@shikijs/types': 4.4.2
+
+  '@shikijs/types@4.4.2':
+    dependencies:
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.5
+
+  '@shikijs/vscode-textmate@10.0.2': {}
+
   '@standard-schema/spec@1.1.0': {}
 
   '@sveltejs/acorn-typescript@1.0.11(acorn@8.17.0)':
@@ -1168,7 +1329,17 @@ snapshots:
 
   '@types/estree@1.0.9': {}
 
+  '@types/hast@3.0.5':
+    dependencies:
+      '@types/unist': 3.0.3
+
+  '@types/mdast@4.0.4':
+    dependencies:
+      '@types/unist': 3.0.3
+
   '@types/trusted-types@2.0.7': {}
+
+  '@types/unist@3.0.3': {}
 
   '@typescript/typescript-aix-ppc64@7.0.2':
     optional: true
@@ -1230,6 +1401,8 @@ snapshots:
   '@typescript/typescript-win32-x64@7.0.2':
     optional: true
 
+  '@ungap/structured-clone@1.3.3': {}
+
   acorn@8.17.0: {}
 
   acorn@8.18.0: {}
@@ -1238,15 +1411,29 @@ snapshots:
 
   axobject-query@4.1.0: {}
 
+  ccount@2.0.1: {}
+
+  character-entities-html4@2.1.0: {}
+
+  character-entities-legacy@3.0.0: {}
+
   clsx@2.1.1: {}
+
+  comma-separated-tokens@2.0.3: {}
 
   cookie@0.6.0: {}
 
   deepmerge@4.3.1: {}
 
+  dequal@2.0.3: {}
+
   detect-libc@2.1.2: {}
 
   devalue@5.8.2: {}
+
+  devlop@1.1.0:
+    dependencies:
+      dequal: 2.0.3
 
   dompurify@3.4.8:
     optionalDependencies:
@@ -1264,6 +1451,26 @@ snapshots:
 
   fsevents@2.3.3:
     optional: true
+
+  hast-util-to-html@9.0.5:
+    dependencies:
+      '@types/hast': 3.0.5
+      '@types/unist': 3.0.3
+      ccount: 2.0.1
+      comma-separated-tokens: 2.0.3
+      hast-util-whitespace: 3.0.0
+      html-void-elements: 3.0.0
+      mdast-util-to-hast: 13.2.1
+      property-information: 7.2.0
+      space-separated-tokens: 2.0.2
+      stringify-entities: 4.0.4
+      zwitch: 2.0.4
+
+  hast-util-whitespace@3.0.0:
+    dependencies:
+      '@types/hast': 3.0.5
+
+  html-void-elements@3.0.0: {}
 
   is-reference@3.0.3:
     dependencies:
@@ -1328,6 +1535,35 @@ snapshots:
 
   marked@14.0.0: {}
 
+  mdast-util-to-hast@13.2.1:
+    dependencies:
+      '@types/hast': 3.0.5
+      '@types/mdast': 4.0.4
+      '@ungap/structured-clone': 1.3.3
+      devlop: 1.1.0
+      micromark-util-sanitize-uri: 2.0.1
+      trim-lines: 3.0.1
+      unist-util-position: 5.0.0
+      unist-util-visit: 5.1.0
+      vfile: 6.0.3
+
+  micromark-util-character@2.1.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-encode@2.0.1: {}
+
+  micromark-util-sanitize-uri@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-encode: 2.0.1
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-symbol@2.0.1: {}
+
+  micromark-util-types@2.0.2: {}
+
   monaco-editor@0.56.0:
     dependencies:
       dompurify: 3.4.8
@@ -1338,6 +1574,14 @@ snapshots:
   nanoid@3.3.16: {}
 
   obug@2.1.4: {}
+
+  oniguruma-parser@0.12.2: {}
+
+  oniguruma-to-es@4.3.6:
+    dependencies:
+      oniguruma-parser: 0.12.2
+      regex: 6.1.0
+      regex-recursion: 6.0.2
 
   oxfmt@0.62.0(svelte@5.56.8):
     dependencies:
@@ -1396,6 +1640,18 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  property-information@7.2.0: {}
+
+  regex-recursion@6.0.2:
+    dependencies:
+      regex-utilities: 2.3.0
+
+  regex-utilities@2.3.0: {}
+
+  regex@6.1.0:
+    dependencies:
+      regex-utilities: 2.3.0
+
   rolldown@1.2.1:
     dependencies:
       '@oxc-project/types': 0.142.0
@@ -1419,6 +1675,17 @@ snapshots:
 
   set-cookie-parser@3.1.2: {}
 
+  shiki@4.4.2:
+    dependencies:
+      '@shikijs/core': 4.4.2
+      '@shikijs/engine-javascript': 4.4.2
+      '@shikijs/engine-oniguruma': 4.4.2
+      '@shikijs/langs': 4.4.2
+      '@shikijs/themes': 4.4.2
+      '@shikijs/types': 4.4.2
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.5
+
   sirv@3.0.2:
     dependencies:
       '@polka/url': 1.0.0-next.29
@@ -1427,7 +1694,14 @@ snapshots:
 
   source-map-js@1.2.1: {}
 
+  space-separated-tokens@2.0.2: {}
+
   state-local@1.0.7: {}
+
+  stringify-entities@4.0.4:
+    dependencies:
+      character-entities-html4: 2.1.0
+      character-entities-legacy: 3.0.0
 
   svelte@5.56.8:
     dependencies:
@@ -1459,6 +1733,8 @@ snapshots:
 
   totalist@3.0.1: {}
 
+  trim-lines@3.0.1: {}
+
   tslib@2.8.1:
     optional: true
 
@@ -1485,6 +1761,39 @@ snapshots:
       '@typescript/typescript-win32-arm64': 7.0.2
       '@typescript/typescript-win32-x64': 7.0.2
 
+  unist-util-is@6.0.1:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-position@5.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-stringify-position@4.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-visit-parents@6.0.2:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
+
+  unist-util-visit@5.1.0:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
+      unist-util-visit-parents: 6.0.2
+
+  vfile-message@4.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-stringify-position: 4.0.0
+
+  vfile@6.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      vfile-message: 4.0.3
+
   vite@8.2.0:
     dependencies:
       lightningcss: 1.33.0
@@ -1500,3 +1809,5 @@ snapshots:
       vite: 8.2.0
 
   zimmerframe@1.1.4: {}
+
+  zwitch@2.0.4: {}

--- a/apps/playground/src/app.html
+++ b/apps/playground/src/app.html
@@ -1,39 +1,39 @@
 <!doctype html>
 <html lang="en">
-	<head>
-		<meta charset="utf-8" />
-		<link rel="icon" href="%sveltekit.assets%/favicon.png" />
-		<meta name="viewport" content="width=device-width, initial-scale=1" />
-		<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
-		<meta name="theme-color" content="#0e1116" media="(prefers-color-scheme: dark)" />
-		<title>rsvelte — the Svelte ecosystem, in Rust</title>
-		<script>
-			// Resolve theme before first paint to avoid a flash of the wrong palette.
-			// Order: explicit `?theme=…` query (used for shareable links and CI
-			// screenshots), then localStorage, then OS preference.
-			(function () {
-				try {
-					var t = null;
-					var qs = window.location && window.location.search;
-					if (qs) {
-						var m = qs.match(/[?&]theme=(light|dark)\b/);
-						if (m) t = m[1];
-					}
-					if (t !== 'light' && t !== 'dark') {
-						t = localStorage.getItem('rsvelte:theme');
-					}
-					if (t !== 'light' && t !== 'dark') {
-						t = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
-					}
-					document.documentElement.setAttribute('data-theme', t);
-				} catch (_) {
-					document.documentElement.setAttribute('data-theme', 'light');
-				}
-			})();
-		</script>
-		%sveltekit.head%
-	</head>
-	<body data-sveltekit-preload-data="hover">
-		<div style="display: contents">%sveltekit.body%</div>
-	</body>
+  <head>
+    <meta charset="utf-8" />
+    <link rel="icon" href="%sveltekit.assets%/favicon.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+    <meta name="theme-color" content="#0d1117" media="(prefers-color-scheme: dark)" />
+    <title>rsvelte · Svelte tooling in Rust</title>
+    <script>
+      // Resolve theme before first paint to avoid a flash of the wrong palette.
+      // Order: explicit `?theme=…` query (used for shareable links and CI
+      // screenshots), then localStorage, then OS preference.
+      (function () {
+        try {
+          var t = null;
+          var qs = window.location && window.location.search;
+          if (qs) {
+            var m = qs.match(/[?&]theme=(light|dark)\b/);
+            if (m) t = m[1];
+          }
+          if (t !== "light" && t !== "dark") {
+            t = localStorage.getItem("rsvelte:theme");
+          }
+          if (t !== "light" && t !== "dark") {
+            t = window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+          }
+          document.documentElement.setAttribute("data-theme", t);
+        } catch (_) {
+          document.documentElement.setAttribute("data-theme", "light");
+        }
+      })();
+    </script>
+    %sveltekit.head%
+  </head>
+  <body data-sveltekit-preload-data="hover">
+    <div style="display: contents">%sveltekit.body%</div>
+  </body>
 </html>

--- a/apps/playground/src/lib/components/CodeBlock.svelte
+++ b/apps/playground/src/lib/components/CodeBlock.svelte
@@ -8,7 +8,33 @@
 	let { code, lang = 'text', caption }: Props = $props();
 
 	let copied = $state(false);
+	let highlighted = $state('');
 	let resetTimer: ReturnType<typeof setTimeout>;
+	let renderSequence = 0;
+
+	const languageAliases: Record<string, string> = {
+		sh: 'bash',
+		shell: 'bash',
+		javascript: 'js',
+		typescript: 'ts'
+	};
+
+	$effect(() => {
+		const source = code;
+		const language = languageAliases[lang] ?? lang;
+		const sequence = ++renderSequence;
+		highlighted = '';
+
+		void (async () => {
+			try {
+				const { highlightCode } = await import('$lib/highlight');
+				const html = await highlightCode(source, language || 'text');
+				if (sequence === renderSequence) highlighted = html;
+			} catch {
+				// The plain-code fallback remains readable if a language is not in the web bundle.
+			}
+		})();
+	});
 
 	async function copy(): Promise<void> {
 		try {
@@ -30,7 +56,11 @@
 			{copied ? 'Copied' : 'Copy'}
 		</button>
 	</figcaption>
-	<pre><code>{code}</code></pre>
+	{#if highlighted}
+		<div class="highlight">{@html highlighted}</div>
+	{:else}
+		<pre class="fallback"><code>{code}</code></pre>
+	{/if}
 </figure>
 
 <style>
@@ -83,18 +113,31 @@
 		border-color: var(--ok);
 	}
 
-	pre {
+	.fallback,
+	.highlight :global(.shiki) {
 		margin: 0;
 		padding: 0.85rem 0.9rem;
 		overflow-x: auto;
 		font-family: 'JetBrains Mono', ui-monospace, monospace;
 		font-size: 0.8rem;
 		line-height: 1.6;
-		color: var(--editor-ink);
+		tab-size: 2;
 	}
 
-	code {
+	.fallback {
+		color: var(--editor-ink);
+		background: var(--editor-bg);
+	}
+
+	.highlight :global(.shiki code),
+	.fallback code {
 		font-family: inherit;
 		white-space: pre;
+	}
+
+	:global(html[data-theme='dark']) .highlight :global(.shiki),
+	:global(html[data-theme='dark']) .highlight :global(.shiki span) {
+		color: var(--shiki-dark) !important;
+		background-color: var(--shiki-dark-bg) !important;
 	}
 </style>

--- a/apps/playground/src/lib/components/DocsSidebar.svelte
+++ b/apps/playground/src/lib/components/DocsSidebar.svelte
@@ -1,0 +1,87 @@
+<script lang="ts">
+	import { base } from '$app/paths';
+	import { GUIDES } from '$lib/docs';
+
+	interface Props {
+		current?: string;
+	}
+
+	let { current = '' }: Props = $props();
+</script>
+
+<aside class="sidebar">
+	<nav aria-label="Documentation navigation">
+		<div class="group">
+			<p>Getting started</p>
+			<a class:current={current === 'introduction'} href="{base}/">Introduction</a>
+			<a class:current={current === 'overview'} href="{base}/docs">Overview</a>
+		</div>
+
+		<div class="group">
+			<p>Toolchain</p>
+			{#each GUIDES as guide (guide.id)}
+				<a class:current={current === guide.id} href="{base}/docs/{guide.id}">{guide.title}</a>
+			{/each}
+		</div>
+
+		<div class="group">
+			<p>Project</p>
+			<a class:current={current === 'playground'} href="{base}/playground">Playground</a>
+			<a class:current={current === 'compatibility'} href="{base}/progress">Compatibility</a>
+			<a class:current={current === 'benchmark'} href="{base}/benchmark">Benchmarks</a>
+		</div>
+	</nav>
+</aside>
+
+<style>
+	.sidebar {
+		padding: 2rem 1.25rem 4rem 1rem;
+		border-right: 1px solid var(--rule);
+	}
+
+	nav {
+		position: sticky;
+		top: 5rem;
+		display: flex;
+		flex-direction: column;
+		gap: 1.75rem;
+	}
+
+	.group {
+		display: flex;
+		flex-direction: column;
+		gap: 0.1rem;
+	}
+
+	.group p {
+		margin: 0 0 0.4rem 0.65rem;
+		font-size: 0.75rem;
+		font-weight: 650;
+		color: var(--ink);
+	}
+
+	a {
+		padding: 0.38rem 0.65rem;
+		border-radius: 5px;
+		font-size: 0.84rem;
+		line-height: 1.35;
+		color: var(--ink-soft);
+	}
+
+	a:hover {
+		background: var(--paper);
+		color: var(--ink);
+	}
+
+	a.current {
+		background: color-mix(in srgb, var(--accent) 10%, var(--bg));
+		color: var(--accent);
+		font-weight: 600;
+	}
+
+	@media (max-width: 860px) {
+		.sidebar {
+			display: none;
+		}
+	}
+</style>

--- a/apps/playground/src/lib/components/DocsToc.svelte
+++ b/apps/playground/src/lib/components/DocsToc.svelte
@@ -1,0 +1,60 @@
+<script lang="ts">
+	interface TocItem {
+		label: string;
+		href: string;
+	}
+
+	interface Props {
+		items: TocItem[];
+	}
+
+	let { items }: Props = $props();
+</script>
+
+<aside class="toc">
+	<nav aria-label="On this page">
+		<p>On this page</p>
+		{#each items as item (item.href)}
+			<a href={item.href}>{item.label}</a>
+		{/each}
+	</nav>
+</aside>
+
+<style>
+	.toc {
+		padding: 2rem 1rem 3rem 1.5rem;
+		border-left: 1px solid var(--rule);
+	}
+
+	nav {
+		position: sticky;
+		top: 5rem;
+		display: flex;
+		flex-direction: column;
+		gap: 0.15rem;
+	}
+
+	p {
+		margin: 0 0 0.55rem;
+		font-size: 0.75rem;
+		font-weight: 650;
+		color: var(--ink);
+	}
+
+	a {
+		padding: 0.25rem 0;
+		font-size: 0.78rem;
+		line-height: 1.4;
+		color: var(--ink-soft);
+	}
+
+	a:hover {
+		color: var(--accent);
+	}
+
+	@media (max-width: 1120px) {
+		.toc {
+			display: none;
+		}
+	}
+</style>

--- a/apps/playground/src/lib/components/Eyebrow.svelte
+++ b/apps/playground/src/lib/components/Eyebrow.svelte
@@ -18,7 +18,7 @@
 		letterSpacing = '0.08em',
 		marginBottom = '0',
 		ruleWidth = '24px',
-		uppercase = true
+		uppercase = false,
 	}: Props = $props();
 </script>
 
@@ -28,26 +28,18 @@
 		? 'uppercase'
 		: 'none'};"
 >
-	<span class="rule"></span>{@render children()}
+	{@render children()}
 </p>
 
 <style>
 	.eyebrow {
-		display: inline-flex;
-		align-items: center;
-		gap: var(--eyebrow-gap);
-		font-family: 'JetBrains Mono', monospace;
-		font-size: var(--eyebrow-font-size);
-		letter-spacing: var(--eyebrow-letter-spacing);
-		text-transform: var(--eyebrow-text-transform);
-		color: var(--rust);
-		margin: 0 0 var(--eyebrow-margin-bottom);
-	}
-
-	.eyebrow .rule {
 		display: inline-block;
-		width: var(--eyebrow-rule-width);
-		height: 1px;
-		background: var(--rust);
+		font-family: var(--font-ui);
+		font-size: var(--eyebrow-font-size);
+		font-weight: 600;
+		letter-spacing: 0;
+		text-transform: var(--eyebrow-text-transform);
+		color: var(--ink-soft);
+		margin: 0 0 var(--eyebrow-margin-bottom);
 	}
 </style>

--- a/apps/playground/src/lib/components/Guide.svelte
+++ b/apps/playground/src/lib/components/Guide.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
 	import { base } from '$app/paths';
-	import type { Guide } from '$lib/docs';
+	import { GUIDES, type Guide } from '$lib/docs';
+	import DocsSidebar from '$lib/components/DocsSidebar.svelte';
+	import DocsToc from '$lib/components/DocsToc.svelte';
 	import SiteNav from '$lib/components/SiteNav.svelte';
 	import SiteFooter from '$lib/components/SiteFooter.svelte';
 	import CodeBlock from '$lib/components/CodeBlock.svelte';
@@ -11,100 +13,147 @@
 	}
 
 	let { guide }: Props = $props();
+
+	const sectionId = (title: string): string =>
+		title
+			.toLowerCase()
+			.replace(/[^a-z0-9]+/g, '-')
+			.replace(/(^-|-$)/g, '');
+
+	const guideIndex = $derived(GUIDES.findIndex((item) => item.id === guide.id));
+	const previousGuide = $derived(guideIndex > 0 ? GUIDES[guideIndex - 1] : null);
+	const nextGuide = $derived(guideIndex < GUIDES.length - 1 ? GUIDES[guideIndex + 1] : null);
+	const toc = $derived(
+		guide.sections.map((section) => ({
+			label: section.title,
+			href: `#${sectionId(section.title)}`,
+		})),
+	);
 </script>
 
 <div class="page">
 	<SiteNav active="docs" />
 
-	<main class="wrap">
-		<nav class="crumbs" aria-label="Breadcrumb">
-			<a href="{base}/docs">Docs</a>
-			<span aria-hidden="true">/</span>
-			<span class="here">{guide.title}</span>
-		</nav>
+	<div class="docs-shell">
+		<DocsSidebar current={guide.id} />
 
-		<header class="head">
-			<Eyebrow gap="0.6rem" fontSize="0.72rem" letterSpacing="0.06em" ruleWidth="20px" uppercase={false}
-				>{guide.pkg}</Eyebrow
-			>
-			<h1 class="title">{guide.title}</h1>
-			<p class="dropin">drop-in for <code>{guide.dropInFor}</code></p>
-			<p class="tagline">{guide.tagline}</p>
+		<main class="wrap">
+			<nav class="crumbs" aria-label="Breadcrumb">
+				<a href="{base}/docs">Docs</a>
+				<span aria-hidden="true">/</span>
+				<span class="here">{guide.title}</span>
+			</nav>
 
-			<div class="actions">
-				{#if guide.runnable}
-					<a class="btn primary" href="{base}/playground?tool={guide.id}">Open in playground →</a>
-				{:else}
-					<span class="btn disabled" title="This tool can't run in a browser">
-						Not runnable in browser
-					</span>
-				{/if}
-			</div>
+			<header class="head">
+				<Eyebrow
+					gap="0.6rem"
+					fontSize="0.72rem"
+					letterSpacing="0.06em"
+					ruleWidth="20px"
+					uppercase={false}>{guide.pkg}</Eyebrow
+				>
+				<h1 class="title">{guide.title}</h1>
+				<p class="dropin">drop-in for <code>{guide.dropInFor}</code></p>
+				<p class="tagline">{guide.tagline}</p>
 
-			<div class="install">
-				<CodeBlock code={guide.install} lang="bash" caption="install" />
-			</div>
-		</header>
-
-		<div class="sections">
-			{#each guide.sections as section (section.title)}
-				<section class="sec">
-					<h2 class="sec-title">{section.title}</h2>
-
-					{#if section.body}
-						{#each section.body as p (p)}
-							<p class="prose">{p}</p>
-						{/each}
+				<div class="actions">
+					{#if guide.runnable}
+						<a class="btn primary" href="{base}/playground?tool={guide.id}">Open in playground →</a>
+					{:else}
+						<span class="btn disabled" title="This tool can't run in a browser">
+							Not runnable in browser
+						</span>
 					{/if}
+				</div>
 
-					{#if section.list}
-						<ul class="bullets">
-							{#each section.list as item (item)}
-								<li>{item}</li>
+				<div class="install">
+					<CodeBlock code={guide.install} lang="bash" caption="install" />
+				</div>
+			</header>
+
+			<div class="sections">
+				{#each guide.sections as section (section.title)}
+					<section class="sec" id={sectionId(section.title)}>
+						<h2 class="sec-title">{section.title}</h2>
+
+						{#if section.body}
+							{#each section.body as p (p)}
+								<p class="prose">{p}</p>
 							{/each}
-						</ul>
-					{/if}
+						{/if}
 
-					{#if section.code}
-						<div class="code">
-							<CodeBlock
-								code={section.code.code}
-								lang={section.code.lang}
-								caption={section.code.caption}
-							/>
-						</div>
-					{/if}
+						{#if section.list}
+							<ul class="bullets">
+								{#each section.list as item (item)}
+									<li>{item}</li>
+								{/each}
+							</ul>
+						{/if}
 
-					{#if section.table}
-						<div class="table-wrap">
-							<table>
-								<thead>
-									<tr>
-										{#each section.table.head as h (h)}
-											<th>{h}</th>
-										{/each}
-									</tr>
-								</thead>
-								<tbody>
-									{#each section.table.rows as row, i (i)}
+						{#if section.code}
+							<div class="code">
+								<CodeBlock
+									code={section.code.code}
+									lang={section.code.lang}
+									caption={section.code.caption}
+								/>
+							</div>
+						{/if}
+
+						{#if section.table}
+							<div class="table-wrap">
+								<table>
+									<thead>
 										<tr>
-											{#each row as cell, j (j)}
-												{#if j === 0}
-													<td><code>{cell}</code></td>
-												{:else}
-													<td>{cell}</td>
-												{/if}
+											{#each section.table.head as h (h)}
+												<th>{h}</th>
 											{/each}
 										</tr>
-									{/each}
-								</tbody>
-							</table>
-						</div>
-					{/if}
-				</section>
-			{/each}
-		</div>
-	</main>
+									</thead>
+									<tbody>
+										{#each section.table.rows as row, i (i)}
+											<tr>
+												{#each row as cell, j (j)}
+													{#if j === 0}
+														<td><code>{cell}</code></td>
+													{:else}
+														<td>{cell}</td>
+													{/if}
+												{/each}
+											</tr>
+										{/each}
+									</tbody>
+								</table>
+							</div>
+						{/if}
+					</section>
+				{/each}
+			</div>
+
+			<nav class="page-nav" aria-label="Documentation pages">
+				{#if previousGuide}
+					<a href="{base}/docs/{previousGuide.id}">
+						<span>Previous</span>
+						<strong>← {previousGuide.title}</strong>
+					</a>
+				{:else}
+					<a href="{base}/docs">
+						<span>Previous</span>
+						<strong>← Overview</strong>
+					</a>
+				{/if}
+
+				{#if nextGuide}
+					<a href="{base}/docs/{nextGuide.id}">
+						<span>Next</span>
+						<strong>{nextGuide.title} →</strong>
+					</a>
+				{/if}
+			</nav>
+		</main>
+
+		<DocsToc items={toc} />
+	</div>
 
 	<SiteFooter />
 </div>
@@ -116,20 +165,28 @@
 		flex-direction: column;
 	}
 
-	.wrap {
+	.docs-shell {
 		flex: 1;
 		width: 100%;
-		max-width: 56rem;
+		max-width: 1440px;
 		margin: 0 auto;
-		padding: clamp(1.4rem, 3vh, 2.2rem) clamp(1rem, 4vw, 2rem) 3rem;
+		display: grid;
+		grid-template-columns: 230px minmax(0, 52rem) 200px;
+		justify-content: center;
+	}
+
+	.wrap {
+		width: 100%;
+		min-width: 0;
+		padding: 3.5rem clamp(2rem, 5vw, 4rem) 5rem;
 	}
 
 	.crumbs {
 		display: flex;
 		align-items: center;
 		gap: 0.5rem;
-		font-family: 'JetBrains Mono', monospace;
-		font-size: 0.72rem;
+		font-family: var(--font-ui);
+		font-size: 0.78rem;
 		color: var(--ink-faint);
 		margin-bottom: 1.4rem;
 	}
@@ -140,8 +197,8 @@
 	}
 
 	.crumbs a:hover {
-		color: var(--ink);
-		border-bottom-color: var(--ink);
+		color: var(--accent);
+		border-bottom-color: var(--accent);
 	}
 
 	.crumbs .here {
@@ -149,9 +206,11 @@
 	}
 
 	.title {
-		font-weight: 800;
-		font-size: clamp(1.8rem, 4vw, 2.6rem);
-		letter-spacing: -0.025em;
+		font-family: var(--font-ui);
+		font-weight: 700;
+		font-size: clamp(2.25rem, 5vw, 3.25rem);
+		line-height: 1.12;
+		letter-spacing: -0.035em;
 		color: var(--ink);
 		margin: 0.5rem 0 0.3rem;
 	}
@@ -163,7 +222,7 @@
 	}
 
 	.dropin code {
-		font-family: 'JetBrains Mono', monospace;
+		font-family: var(--font-code);
 		font-size: 0.82rem;
 		color: var(--ink);
 		background: var(--paper-2);
@@ -172,8 +231,9 @@
 	}
 
 	.tagline {
+		font-family: var(--font-ui);
 		font-size: 1.02rem;
-		line-height: 1.65;
+		line-height: 1.7;
 		color: var(--ink-soft);
 		max-width: 42rem;
 		margin: 0 0 1.2rem;
@@ -191,7 +251,7 @@
 		font-size: 0.88rem;
 		font-weight: 600;
 		padding: 0.5rem 1rem;
-		border-radius: 5px;
+		border-radius: 6px;
 		border: 1px solid transparent;
 	}
 
@@ -221,9 +281,14 @@
 		gap: 2.2rem;
 	}
 
+	.sec {
+		scroll-margin-top: 5rem;
+	}
+
 	.sec-title {
-		font-size: 1.2rem;
-		font-weight: 700;
+		font-family: var(--font-ui);
+		font-size: 1.4rem;
+		font-weight: 650;
 		letter-spacing: -0.01em;
 		color: var(--ink);
 		margin: 0 0 0.7rem;
@@ -232,7 +297,8 @@
 	}
 
 	.prose {
-		font-size: 0.95rem;
+		font-family: var(--font-ui);
+		font-size: 0.98rem;
 		line-height: 1.7;
 		color: var(--ink-soft);
 		margin: 0 0 0.7rem;
@@ -302,5 +368,50 @@
 		font-family: 'JetBrains Mono', monospace;
 		font-size: 0.8rem;
 		color: var(--ink);
+	}
+
+	.page-nav {
+		display: grid;
+		grid-template-columns: 1fr 1fr;
+		gap: 2rem;
+		margin-top: 3.5rem;
+		padding-top: 1.25rem;
+		border-top: 1px solid var(--rule);
+	}
+
+	.page-nav a {
+		display: flex;
+		flex-direction: column;
+		align-items: flex-start;
+	}
+
+	.page-nav a:last-child {
+		align-items: flex-end;
+	}
+
+	.page-nav span {
+		font-size: 0.72rem;
+		color: var(--ink-faint);
+	}
+
+	.page-nav strong {
+		font-size: 0.88rem;
+		font-weight: 600;
+		color: var(--accent);
+	}
+
+	@media (max-width: 1120px) {
+		.docs-shell {
+			grid-template-columns: 230px minmax(0, 1fr);
+		}
+	}
+
+	@media (max-width: 800px) {
+		.docs-shell {
+			grid-template-columns: 1fr;
+		}
+		.wrap {
+			padding-inline: clamp(1rem, 5vw, 2.5rem);
+		}
 	}
 </style>

--- a/apps/playground/src/lib/components/SectionHead.svelte
+++ b/apps/playground/src/lib/components/SectionHead.svelte
@@ -15,81 +15,62 @@
 		num,
 		children,
 		lede,
-		columns = 2,
-		padding = 'clamp(3.5rem, 8vh, 5.5rem) clamp(1rem, 4vw, 2.5rem) clamp(1.4rem, 3vh, 2.4rem)',
+		padding = '3rem 1.5rem 1.25rem',
 		marginBottom = '0',
-		fontSize = 'clamp(1.65rem, 3.2vw, 2.6rem)'
+		fontSize = '1.5rem',
 	}: Props = $props();
 </script>
 
 <div
 	class="section-head"
-	style="--sh-columns: {columns === 3
-		? 'auto 1fr auto'
-		: 'auto 1fr'}; --sh-padding: {padding}; --sh-margin-bottom: {marginBottom}; --sh-font-size: {fontSize};"
+	data-section={num}
+	style="--sh-padding: {padding}; --sh-margin-bottom: {marginBottom}; --sh-font-size: {fontSize};"
 >
-	<span class="num">{num}</span>
 	<h2>{@render children()}</h2>
 	{#if lede}{@render lede()}{/if}
 </div>
 
 <style>
 	.section-head {
-		max-width: 1080px;
+		max-width: 1120px;
 		margin: 0 auto var(--sh-margin-bottom);
 		padding: var(--sh-padding);
 		display: grid;
-		grid-template-columns: var(--sh-columns);
-		gap: 0.4rem 1.4rem;
-		align-items: baseline;
-	}
-
-	.num {
-		grid-row: 1;
-		grid-column: 1;
-		font-family: 'JetBrains Mono', monospace;
-		font-size: 0.7rem;
-		letter-spacing: 0.18em;
-		color: var(--rust);
+		grid-template-columns: minmax(14rem, 0.7fr) minmax(0, 1.3fr);
+		gap: 1rem 4rem;
+		align-items: start;
 	}
 
 	h2 {
-		grid-row: 1;
-		grid-column: 2;
-		font-family: 'Hanken Grotesk', sans-serif;
-		font-weight: 700;
+		font-family: var(--font-ui);
+		font-weight: 650;
 		font-size: var(--sh-font-size);
-		line-height: 1.1;
-		letter-spacing: -0.022em;
-		margin: 0;
+		line-height: 1.25;
+		letter-spacing: -0.025em;
 		color: var(--ink);
 	}
 
 	h2 :global(em) {
-		font-style: italic;
-		color: var(--svelte);
-		font-weight: 700;
+		font-style: normal;
+		color: inherit;
 	}
 
 	.section-head > :global(.lede) {
-		grid-row: 2;
-		grid-column: 2;
-		margin-top: 0.7rem;
+		font-family: var(--font-ui);
+		font-size: 0.95rem;
+		line-height: 1.65;
+		color: var(--ink-soft);
 	}
 
 	.section-head > :global(.clear-filter) {
-		grid-row: 1;
-		grid-column: 3;
+		justify-self: start;
 	}
 
-	@media (max-width: 880px) {
+	@media (max-width: 760px) {
 		.section-head {
-			grid-template-columns: auto 1fr;
-		}
-
-		.section-head > :global(.clear-filter) {
-			grid-column: 1 / -1;
-			justify-self: start;
+			grid-template-columns: 1fr;
+			gap: 0.65rem;
+			padding-inline: 1rem;
 		}
 	}
 </style>

--- a/apps/playground/src/lib/components/SiteFooter.svelte
+++ b/apps/playground/src/lib/components/SiteFooter.svelte
@@ -1,72 +1,62 @@
-<footer class="foot">
+<script lang="ts">
+	import { base } from '$app/paths';
+</script>
+
+<footer class="footer">
 	<div class="inner">
-		<div class="mark">
-			<svg viewBox="0 0 24 24" width="16" height="16" fill="none" aria-hidden="true">
-				<path d="M19 8 13 18l-2-4 6-10 2 4Z" fill="var(--svelte)" />
-				<path d="M5 16 11 6l2 4-6 10-2-4Z" fill="var(--rust)" />
-			</svg>
-			<span>rsvelte</span>
-		</div>
-		<div class="meta">
-			<span>MIT licensed</span>
-			<span class="sep">·</span>
-			<span>Mirrors <a href="https://github.com/sveltejs/svelte" target="_blank" rel="noopener">sveltejs/svelte</a></span>
-			<span class="sep">·</span>
-			<a href="https://github.com/baseballyama/rsvelte" target="_blank" rel="noopener">
-				github.com/baseballyama/rsvelte
-			</a>
-		</div>
+		<p>rsvelte is an independent Rust port of the Svelte compiler and toolchain.</p>
+		<nav aria-label="Footer navigation">
+			<a href="{base}/docs">Docs</a>
+			<a href="{base}/playground">Playground</a>
+			<a href="{base}/progress">Compatibility</a>
+			<a href="https://github.com/baseballyama/rsvelte" target="_blank" rel="noopener">GitHub</a>
+		</nav>
 	</div>
 </footer>
 
 <style>
-	.foot {
+	.footer {
 		border-top: 1px solid var(--rule);
 		background: var(--paper);
 	}
 
 	.inner {
-		max-width: 1080px;
+		max-width: 1120px;
 		margin: 0 auto;
-		padding: 1.4rem clamp(1rem, 4vw, 2.5rem);
+		padding: 2rem 1.5rem;
 		display: flex;
+		align-items: center;
 		justify-content: space-between;
-		align-items: center;
-		gap: 1rem;
-		flex-wrap: wrap;
+		gap: 2rem;
 	}
 
-	.mark {
-		display: inline-flex;
-		align-items: center;
-		gap: 0.45rem;
-		font-weight: 700;
-		font-size: 0.95rem;
-		color: var(--ink);
-	}
-
-	.meta {
-		display: inline-flex;
-		align-items: center;
-		gap: 0.55rem;
-		font-family: 'JetBrains Mono', monospace;
-		font-size: 0.74rem;
+	p {
+		font-size: 0.82rem;
 		color: var(--ink-soft);
+	}
+
+	nav {
+		display: flex;
 		flex-wrap: wrap;
+		gap: 1.25rem;
 	}
 
-	.meta .sep {
-		opacity: 0.5;
-	}
-
-	.meta a {
+	a {
+		font-size: 0.82rem;
+		font-weight: 500;
 		color: var(--ink-soft);
-		text-decoration: underline;
-		text-decoration-thickness: 1px;
-		text-underline-offset: 3px;
 	}
 
-	.meta a:hover {
-		color: var(--svelte);
+	a:hover {
+		color: var(--accent);
+	}
+
+	@media (max-width: 700px) {
+		.inner {
+			align-items: flex-start;
+			flex-direction: column;
+			gap: 1rem;
+			padding-inline: 1rem;
+		}
 	}
 </style>

--- a/apps/playground/src/lib/components/SiteNav.svelte
+++ b/apps/playground/src/lib/components/SiteNav.svelte
@@ -6,13 +6,11 @@
 	type Active = 'home' | 'docs' | 'playground' | 'progress' | 'benchmark';
 
 	interface Props {
-		// Each page passes its own slug so the link gets the `active` style
-		// even when SvelteKit's `page.url` isn't reachable (e.g. during SSR
-		// in some contexts).
 		active?: Active;
 	}
 
 	let { active }: Props = $props();
+	let menuOpen = $state(false);
 
 	const isActive = (slug: Active): boolean => {
 		if (active) return active === slug;
@@ -25,85 +23,116 @@
 	const current = $derived(themeStore.current);
 </script>
 
-<nav class="nav">
-	<a href="{base}/" class="brand" aria-label="rsvelte home">
-		<span class="mark" aria-hidden="true">
-			<svg viewBox="0 0 24 24" width="20" height="20" fill="none">
-				<path d="M19 8 13 18l-2-4 6-10 2 4Z" fill="var(--svelte)" />
-				<path d="M5 16 11 6l2 4-6 10-2-4Z" fill="var(--rust)" />
-			</svg>
-		</span>
-		<span class="brand-text">rsvelte</span>
-	</a>
-
-	<div class="links">
-		<a href="{base}/docs" class:active={isActive('docs')}>Docs</a>
-		<a href="{base}/playground" class:active={isActive('playground')}>Playground</a>
-		<a href="{base}/progress" class:active={isActive('progress')}>Compatibility</a>
-		<a href="{base}/benchmark" class:active={isActive('benchmark')}>Benchmark</a>
-		<a href="https://github.com/baseballyama/rsvelte" target="_blank" rel="noopener" class="gh">
-			GitHub <span class="ext" aria-hidden="true">↗</span>
+<header class="site-header">
+	<nav class="nav" aria-label="Main navigation">
+		<a href="{base}/" class="brand" aria-label="rsvelte home">
+			<span class="mark" aria-hidden="true">
+				<svg viewBox="0 0 24 24" width="20" height="20" fill="none">
+					<path d="M19 8 13 18l-2-4 6-10 2 4Z" fill="var(--svelte)" />
+					<path d="M5 16 11 6l2 4-6 10-2-4Z" fill="var(--rust)" />
+				</svg>
+			</span>
+			<span>rsvelte</span>
 		</a>
+
 		<button
 			type="button"
-			class="theme-toggle"
-			aria-label="Toggle dark mode"
-			aria-pressed={current === 'dark'}
-			title="{current === 'dark' ? 'Switch to light' : 'Switch to dark'} mode"
-			onclick={() => themeStore.toggle()}
+			class="menu-toggle"
+			aria-label="Toggle navigation"
+			aria-expanded={menuOpen}
+			onclick={() => (menuOpen = !menuOpen)}
 		>
-			<span class="theme-icon" aria-hidden="true">
+			<span></span><span></span><span></span>
+		</button>
+
+		<div class="links" class:open={menuOpen}>
+			<a href="{base}/docs" class:active={isActive('docs')} onclick={() => (menuOpen = false)}>Docs</a>
+			<a
+				href="{base}/playground"
+				class:active={isActive('playground')}
+				onclick={() => (menuOpen = false)}>Playground</a
+			>
+			<a
+				href="{base}/progress"
+				class:active={isActive('progress')}
+				onclick={() => (menuOpen = false)}>Compatibility</a
+			>
+			<a
+				href="{base}/benchmark"
+				class:active={isActive('benchmark')}
+				onclick={() => (menuOpen = false)}>Benchmark</a
+			>
+			<a
+				class="external-link"
+				href="https://github.com/baseballyama/rsvelte"
+				target="_blank"
+				rel="noopener noreferrer"
+				aria-label="GitHub (opens in a new tab)"
+				onclick={() => (menuOpen = false)}
+			>
+				<span>GitHub</span>
+				<svg viewBox="0 0 16 16" width="14" height="14" fill="none" aria-hidden="true">
+					<path d="M9 2.5h4.5V7M13 3 7.5 8.5" />
+					<path d="M11.5 8.5v3a2 2 0 0 1-2 2h-6a2 2 0 0 1-2-2v-6a2 2 0 0 1 2-2h3" />
+				</svg>
+			</a>
+			<button
+				type="button"
+				class="theme-toggle"
+				aria-label="Toggle dark mode"
+				aria-pressed={current === 'dark'}
+				title="{current === 'dark' ? 'Switch to light' : 'Switch to dark'} mode"
+				onclick={() => themeStore.toggle()}
+			>
 				{#if current === 'dark'}
-					<svg viewBox="0 0 24 24" width="16" height="16" fill="none">
-						<circle cx="12" cy="12" r="4" fill="currentColor" />
-						<g stroke="currentColor" stroke-width="1.6" stroke-linecap="round">
-							<path d="M12 3v2" />
-							<path d="M12 19v2" />
-							<path d="M3 12h2" />
-							<path d="M19 12h2" />
-							<path d="m5.6 5.6 1.4 1.4" />
-							<path d="m17 17 1.4 1.4" />
-							<path d="m5.6 18.4 1.4-1.4" />
-							<path d="m17 7 1.4-1.4" />
-						</g>
+					<svg viewBox="0 0 24 24" width="18" height="18" fill="none" aria-hidden="true">
+						<circle cx="12" cy="12" r="3.5" fill="currentColor" />
+						<path d="M12 2.5v2M12 19.5v2M2.5 12h2M19.5 12h2M5.3 5.3l1.4 1.4M17.3 17.3l1.4 1.4M5.3 18.7l1.4-1.4M17.3 6.7l1.4-1.4" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" />
 					</svg>
 				{:else}
-					<svg viewBox="0 0 24 24" width="16" height="16" fill="none">
-						<path
-							d="M20 14.5A8 8 0 0 1 9.5 4a7.5 7.5 0 1 0 10.5 10.5Z"
-							fill="currentColor"
-						/>
+					<svg viewBox="0 0 24 24" width="18" height="18" fill="none" aria-hidden="true">
+						<path d="M20 14.5A8 8 0 0 1 9.5 4a7.5 7.5 0 1 0 10.5 10.5Z" fill="currentColor" />
 					</svg>
 				{/if}
-			</span>
-		</button>
-	</div>
-</nav>
+			</button>
+		</div>
+	</nav>
+</header>
 
 <style>
-	.nav {
+	.site-header {
 		position: sticky;
 		top: 0;
-		z-index: 30;
+		z-index: 50;
+		background: color-mix(in srgb, var(--bg) 94%, transparent);
+		border-bottom: 1px solid var(--rule);
+		backdrop-filter: blur(10px);
+	}
+
+	.nav {
+		height: 60px;
+		max-width: 1180px;
+		margin: 0 auto;
+		padding: 0 1.5rem;
 		display: flex;
 		align-items: center;
 		justify-content: space-between;
 		gap: 2rem;
-		padding: 0.9rem clamp(1rem, 4vw, 2.5rem);
-		background: color-mix(in srgb, var(--bg) 88%, transparent);
-		border-bottom: 1px solid var(--rule);
-		backdrop-filter: saturate(150%) blur(6px);
-		-webkit-backdrop-filter: saturate(150%) blur(6px);
 	}
 
 	.brand {
 		display: inline-flex;
 		align-items: center;
-		gap: 0.55rem;
+		gap: 0.6rem;
+		font-size: 1rem;
+		font-weight: 650;
+		letter-spacing: -0.015em;
 		color: var(--ink);
 	}
 
 	.mark {
+		--svelte: #ff3e00;
+		--rust: #5c6773;
 		display: inline-flex;
 		align-items: center;
 		justify-content: center;
@@ -111,86 +140,119 @@
 		height: 24px;
 	}
 
-	.brand-text {
-		font-weight: 700;
-		font-size: 1rem;
-		letter-spacing: -0.01em;
+	:global(:root[data-theme='dark']) .mark {
+		--svelte: #ff6a39;
+		--rust: #8b96a2;
 	}
 
 	.links {
+		height: 100%;
 		display: flex;
 		align-items: center;
-		gap: clamp(0.6rem, 2vw, 1.6rem);
-		font-size: 0.92rem;
-		font-weight: 500;
+		gap: 0.25rem;
 	}
 
-	.links a {
-		color: var(--ink-soft);
-		padding: 0.25rem 0;
-		border-bottom: 1px solid transparent;
-		transition:
-			color 0.18s,
-			border-color 0.18s;
-	}
-
-	.links a:hover,
-	.links a.active {
-		color: var(--ink);
-		border-bottom-color: var(--ink);
-	}
-
-	.links .gh {
-		display: inline-flex;
-		align-items: center;
-		gap: 0.3rem;
-	}
-
-	.links .ext {
-		font-size: 0.85em;
-		opacity: 0.6;
-	}
-
+	.links a,
 	.theme-toggle {
 		display: inline-flex;
 		align-items: center;
 		justify-content: center;
-		width: 32px;
-		height: 32px;
-		padding: 0;
-		margin-left: 0.2rem;
-		background: transparent;
-		border: 1px solid var(--rule-strong);
-		border-radius: 4px;
+		height: 34px;
+		padding: 0 0.75rem;
+		border-radius: 6px;
+		font-size: 0.86rem;
+		font-weight: 500;
 		color: var(--ink-soft);
-		cursor: pointer;
-		transition:
-			color 0.18s,
-			border-color 0.18s,
-			background 0.18s;
 	}
 
+	.links a:hover,
+	.links a.active,
 	.theme-toggle:hover {
-		color: var(--ink);
-		border-color: var(--ink);
 		background: var(--paper);
+		color: var(--ink);
 	}
 
-	.theme-icon {
-		display: inline-flex;
-		line-height: 0;
+	.links a.active {
+		font-weight: 600;
 	}
 
-	@media (max-width: 640px) {
-		.links {
-			gap: 0.7rem;
-			font-size: 0.84rem;
+	.links .external-link {
+		gap: 0.35rem;
+	}
+
+	.external-link svg {
+		flex: none;
+		stroke: currentColor;
+		stroke-width: 1.35;
+		stroke-linecap: round;
+		stroke-linejoin: round;
+	}
+
+	.theme-toggle,
+	.menu-toggle {
+		border: 0;
+		background: transparent;
+		cursor: pointer;
+	}
+
+	.theme-toggle {
+		width: 34px;
+		padding: 0;
+		margin-left: 0.25rem;
+	}
+
+	.menu-toggle {
+		display: none;
+		width: 36px;
+		height: 36px;
+		padding: 8px;
+		color: var(--ink-soft);
+	}
+
+	.menu-toggle span {
+		display: block;
+		height: 1px;
+		margin: 4px 0;
+		background: currentColor;
+	}
+
+	@media (max-width: 820px) {
+		.nav {
+			padding-inline: 1rem;
 		}
-		/* Keep the primary destinations (Docs, Playground) on phones;
-		   Compatibility + Benchmark are reachable from the home page. */
-		.links a:nth-child(3),
-		.links a:nth-child(4) {
+
+		.menu-toggle {
+			display: block;
+		}
+
+		.links {
 			display: none;
+			position: absolute;
+			top: 60px;
+			left: 0;
+			right: 0;
+			height: auto;
+			padding: 0.75rem 1rem 1rem;
+			background: var(--bg);
+			border-bottom: 1px solid var(--rule);
+			flex-direction: column;
+			align-items: stretch;
+		}
+
+		.links.open {
+			display: flex;
+		}
+
+		.links a,
+		.theme-toggle {
+			justify-content: flex-start;
+			width: 100%;
+			height: 42px;
+			padding: 0 0.75rem;
+		}
+
+		.theme-toggle {
+			margin: 0;
 		}
 	}
 </style>

--- a/apps/playground/src/lib/docs.ts
+++ b/apps/playground/src/lib/docs.ts
@@ -44,7 +44,7 @@ const compiler: Guide = {
 	dropInFor: 'svelte/compiler',
 	tagline:
 		'The whole compile pipeline — parse, analyze, transform — for client, SSR and hydration, with output that matches the official compiler across the in-scope test suite.',
-	install: 'npm i @rsvelte/compiler',
+	install: 'pnpm add @rsvelte/compiler',
 	runnable: true,
 	sections: [
 		{
@@ -95,7 +95,7 @@ const svelte2tsx: Guide = {
 	dropInFor: 'svelte2tsx',
 	tagline:
 		'Turns a .svelte component into the TSX shadow file the TypeScript checker reads, with column-accurate source maps.',
-	install: 'npm i @rsvelte/svelte2tsx',
+	install: 'pnpm add @rsvelte/svelte2tsx',
 	runnable: true,
 	sections: [
 		{
@@ -146,7 +146,7 @@ const fmt: Guide = {
 	dropInFor: 'prettier-plugin-svelte',
 	tagline:
 		'A Rust-native formatter for .svelte files — in-process, with no Node startup and no Prettier doc-IR round-trip. JS / TS go through oxc_formatter; CSS routes to oxfmt.',
-	install: 'npm i -D @rsvelte/fmt',
+	install: 'pnpm add -D @rsvelte/fmt',
 	runnable: true,
 	sections: [
 		{
@@ -205,7 +205,7 @@ const svelteCheck: Guide = {
 	dropInFor: 'svelte-check',
 	tagline:
 		'The project type-checker CLI. A Rust walker + svelte2tsx overlay drives tsc — or Microsoft\'s native tsgo with --tsgo — for the TypeScript half; diagnostics map back to .svelte positions. Watch + incremental cache included.',
-	install: 'npm i -D @rsvelte/svelte-check',
+	install: 'pnpm add -D @rsvelte/svelte-check',
 	runnable: false,
 	sections: [
 		{
@@ -265,7 +265,7 @@ const vitePlugin: Guide = {
 	dropInFor: '@sveltejs/vite-plugin-svelte',
 	tagline:
 		'A fork of the Vite plugin whose every transform / HMR / preprocess call routes through the rsvelte compiler over NAPI. Your vite.config.js does not change.',
-	install: 'npm i -D @rsvelte/vite-plugin-svelte',
+	install: 'pnpm add -D @rsvelte/vite-plugin-svelte',
 	runnable: false,
 	sections: [
 		{

--- a/apps/playground/src/lib/ecosystem.ts
+++ b/apps/playground/src/lib/ecosystem.ts
@@ -24,7 +24,7 @@ export interface EcoComponent {
 	originalUrl: string;
 	/** Link to the rsvelte package source (optional). */
 	pkgUrl?: string;
-	/** npm install id, when published. */
+	/** Package identifier, when published. */
 	install?: string;
 	status: EcoStatus;
 	/** Short, plain-language description of what it does. */
@@ -52,7 +52,7 @@ export const shipped: EcoComponent[] = [
 		dropInFor: 'svelte/compiler',
 		originalUrl: 'https://svelte.dev/docs/svelte/svelte-compiler',
 		pkgUrl: 'https://github.com/baseballyama/rsvelte/tree/main/apps/npm/compiler',
-		install: 'npm i @rsvelte/compiler',
+		install: 'pnpm add @rsvelte/compiler',
 		status: 'shipped',
 		blurb:
 			'The whole compile pipeline — parse, analyze, transform — for client, SSR and hydration. Output matches the official compiler across the in-scope test suite.',
@@ -64,7 +64,7 @@ export const shipped: EcoComponent[] = [
 		dropInFor: 'svelte2tsx',
 		originalUrl: 'https://github.com/sveltejs/language-tools/tree/master/packages/svelte2tsx',
 		pkgUrl: 'https://github.com/baseballyama/rsvelte/tree/main/apps/npm/svelte2tsx',
-		install: 'npm i @rsvelte/svelte2tsx',
+		install: 'pnpm add @rsvelte/svelte2tsx',
 		status: 'shipped',
 		blurb:
 			'Turns a .svelte component into the TSX shadow file the TypeScript checker reads, with column-accurate source maps.',
@@ -76,7 +76,7 @@ export const shipped: EcoComponent[] = [
 		dropInFor: 'svelte-check',
 		originalUrl: 'https://github.com/sveltejs/language-tools/tree/master/packages/svelte-check',
 		pkgUrl: 'https://github.com/baseballyama/rsvelte/tree/main/apps/npm/svelte-check',
-		install: 'npm i -D @rsvelte/svelte-check',
+		install: 'pnpm add -D @rsvelte/svelte-check',
 		status: 'shipped',
 		blurb:
 			'The project type-checker CLI. A Rust walker + overlay drives tsc or the native tsgo for the TypeScript half; diagnostics map back to .svelte positions. Watch + incremental cache included.',
@@ -88,7 +88,7 @@ export const shipped: EcoComponent[] = [
 		dropInFor: 'prettier-plugin-svelte',
 		originalUrl: 'https://github.com/sveltejs/prettier-plugin-svelte',
 		pkgUrl: 'https://github.com/baseballyama/rsvelte/tree/main/apps/npm/fmt',
-		install: 'npm i -D @rsvelte/fmt',
+		install: 'pnpm add -D @rsvelte/fmt',
 		status: 'shipped',
 		blurb:
 			'A Rust-native formatter for .svelte files — in-process, with no Node startup and no Prettier doc-IR round-trip. Routes .js / .ts / .css to oxfmt, with both pipelines running in parallel.',
@@ -100,7 +100,7 @@ export const shipped: EcoComponent[] = [
 		dropInFor: '@sveltejs/vite-plugin-svelte',
 		originalUrl: 'https://github.com/sveltejs/vite-plugin-svelte',
 		pkgUrl: 'https://github.com/baseballyama/rsvelte/tree/main/apps/npm/vite-plugin-svelte',
-		install: 'npm i -D @rsvelte/vite-plugin-svelte',
+		install: 'pnpm add -D @rsvelte/vite-plugin-svelte',
 		status: 'shipped',
 		blurb:
 			'A fork of the Vite plugin whose every transform / HMR / preprocess call routes through the rsvelte compiler over NAPI. Your vite.config.js does not change.',
@@ -111,7 +111,7 @@ export const shipped: EcoComponent[] = [
 		dropInFor: 'svelte-language-server',
 		originalUrl: 'https://github.com/sveltejs/language-tools/tree/master/packages/language-server',
 		pkgUrl: 'https://github.com/baseballyama/rsvelte/tree/main/apps/npm/language-server',
-		install: 'npm i @rsvelte/language-server',
+		install: 'pnpm add @rsvelte/language-server',
 		status: 'shipped',
 		blurb:
 			'The editor LSP — diagnostics, hover, completion, rename — backed by the rsvelte compiler + svelte2tsx. Ships as the `rsvelte` VS Code extension (Marketplace + Open VSX) and as a standalone package.',

--- a/apps/playground/src/lib/highlight.ts
+++ b/apps/playground/src/lib/highlight.ts
@@ -1,0 +1,22 @@
+import { createHighlighterCore } from 'shiki/core';
+import { createJavaScriptRegexEngine } from 'shiki/engine/javascript';
+import bash from 'shiki/dist/langs/bash.mjs';
+import diff from 'shiki/dist/langs/diff.mjs';
+import javascript from 'shiki/dist/langs/javascript.mjs';
+import json from 'shiki/dist/langs/json.mjs';
+import typescript from 'shiki/dist/langs/typescript.mjs';
+import githubDark from 'shiki/dist/themes/github-dark.mjs';
+import githubLight from 'shiki/dist/themes/github-light.mjs';
+
+const highlighter = createHighlighterCore({
+	themes: [githubLight, githubDark],
+	langs: [bash, diff, javascript, json, typescript],
+	engine: createJavaScriptRegexEngine()
+});
+
+export async function highlightCode(code: string, lang: string): Promise<string> {
+	return (await highlighter).codeToHtml(code, {
+		lang,
+		themes: { light: 'github-light', dark: 'github-dark' }
+	});
+}

--- a/apps/playground/src/routes/+layout.svelte
+++ b/apps/playground/src/routes/+layout.svelte
@@ -8,115 +8,117 @@
 	let { children }: Props = $props();
 </script>
 
-<svelte:head>
-	<link rel="preconnect" href="https://fonts.googleapis.com" />
-	<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="anonymous" />
-	<link
-		href="https://fonts.googleapis.com/css2?family=Hanken+Grotesk:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;700&display=swap"
-		rel="stylesheet"
-	/>
-</svelte:head>
-
 {@render children()}
 
 <style>
 	:global(*) {
 		box-sizing: border-box;
-		margin: 0;
-		padding: 0;
 	}
 
 	:global(html) {
 		scroll-behavior: smooth;
 	}
 
-	/* =================================================================
-	   THEME TOKENS — light (default)
-	   =================================================================
-	   Anything off-white/colored on the site should resolve through one
-	   of these names. Dark mode just overrides the same names in the
-	   `data-theme="dark"` block below, so pages never need to special-case.
-	*/
+	:global(body),
+	:global(h1),
+	:global(h2),
+	:global(h3),
+	:global(p),
+	:global(dl),
+	:global(dd),
+	:global(figure) {
+		margin: 0;
+	}
+
 	:global(:root),
 	:global(:root[data-theme='light']) {
 		--bg: #ffffff;
-		--paper: #f7f8fa;
+		--paper: #f6f8fa;
 		--paper-2: #eef1f4;
-		--ink: #0f1419;
-		--ink-soft: #4a5560;
-		--ink-faint: #8b96a2;
-		--rule: #e7eaee;
-		--rule-strong: #d2d7dd;
-		--selection: #ffe0cc;
+		--ink: #1f2328;
+		--ink-soft: #59636e;
+		--ink-faint: #818b98;
+		--rule: #d8dee4;
+		--rule-strong: #afb8c1;
+		--selection: #ffd2c2;
+		--accent: #ff3e00;
+		--accent-hover: #d63300;
+		--chrome: #ffffff;
+		--chrome-ink: #1f2328;
+		--chrome-soft: #59636e;
 
-		--svelte: #ff3e00;
-		--svelte-hover: #e83700;
-		/* Single accent is the Svelte orange; the former "rust" hue is now a
-		   restrained cool slate so eyebrows / labels read as neutral. */
-		--rust: #5c6773;
-		--rust-soft: #8b96a2;
+		--font-display: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+		--font-ui: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+		--font-code: ui-monospace, 'SFMono-Regular', Consolas, 'Liberation Mono', monospace;
 
-		--ok: #1f9d55;
-		--warn: #b07a00;
-		--bad: #d23a1f;
+		--svelte: var(--accent);
+		--svelte-hover: var(--accent-hover);
+		--rust: #8250df;
+		--rust-soft: #a475d9;
+		--ok: #1a7f37;
+		--warn: #9a6700;
+		--bad: #cf222e;
 
-		/* Editor / monaco surface — cool off-white in light, lifted ink in dark */
-		--editor-bg: #f7f8fa;
-		--editor-ink: #0f1419;
-
-		/* Blueprint-grid hairline, used for subtle technical backgrounds. */
-		--grid: #eceff3;
-
-		/* AST/code syntax highlighting (AstViewer, Monaco token map). */
-		--syntax-key: #5a3a8a;
-		--syntax-string: #7a4520;
-		--syntax-number: #2e5a3a;
+		--editor-bg: #f6f8fa;
+		--editor-ink: #1f2328;
+		--grid: #eaeef2;
+		--syntax-key: #8250df;
+		--syntax-string: #0a3069;
+		--syntax-number: #0550ae;
+		--code-bg: #24292f;
+		--code-ink: #f6f8fa;
+		--code-muted: #8c959f;
 
 		color-scheme: light;
 	}
 
 	:global(:root[data-theme='dark']) {
-		--bg: #0e1116;
+		--bg: #0d1117;
 		--paper: #161b22;
-		--paper-2: #1c232c;
-		--ink: #e6edf3;
-		--ink-soft: #9aa7b4;
-		--ink-faint: #6b7681;
-		--rule: #232b34;
-		--rule-strong: #313b45;
-		--selection: #5a2a10;
+		--paper-2: #21262d;
+		--ink: #f0f3f6;
+		--ink-soft: #b1bac4;
+		--ink-faint: #7d8590;
+		--rule: #30363d;
+		--rule-strong: #484f58;
+		--selection: #773018;
+		--accent: #ff5a24;
+		--accent-hover: #ff7a4d;
+		--chrome: #0d1117;
+		--chrome-ink: #f0f3f6;
+		--chrome-soft: #b1bac4;
 
-		--svelte: #ff6a39;
-		--svelte-hover: #ff855c;
-		--rust: #8b96a2;
-		--rust-soft: #6b7681;
-
+		--svelte: var(--accent);
+		--svelte-hover: var(--accent-hover);
+		--rust: #d2a8ff;
+		--rust-soft: #bc8cff;
 		--ok: #3fb950;
-		--warn: #e0b240;
-		--bad: #f0613f;
+		--warn: #d29922;
+		--bad: #f85149;
 
-		--editor-bg: #0f141a;
-		--editor-ink: #e6edf3;
-
-		--grid: #1a212a;
-
-		--syntax-key: #b19be0;
-		--syntax-string: #d9a66e;
-		--syntax-number: #8ccc95;
+		--editor-bg: #161b22;
+		--editor-ink: #f0f3f6;
+		--grid: #21262d;
+		--syntax-key: #d2a8ff;
+		--syntax-string: #a5d6ff;
+		--syntax-number: #79c0ff;
+		--code-bg: #161b22;
+		--code-ink: #f0f3f6;
+		--code-muted: #7d8590;
 
 		color-scheme: dark;
 	}
 
 	:global(body) {
-		font-family: 'Hanken Grotesk', ui-sans-serif, -apple-system, BlinkMacSystemFont, sans-serif;
+		min-width: 320px;
+		margin: 0;
+		font-family: var(--font-ui);
+		font-size: 16px;
+		line-height: 1.5;
 		background: var(--bg);
 		color: var(--ink);
-		line-height: 1.6;
 		-webkit-font-smoothing: antialiased;
 		-moz-osx-font-smoothing: grayscale;
-		transition:
-			background-color 0.2s ease,
-			color 0.2s ease;
 	}
 
 	:global(a) {
@@ -124,21 +126,19 @@
 		text-decoration: none;
 	}
 
+	:global(button),
+	:global(input),
+	:global(select),
+	:global(textarea) {
+		font: inherit;
+	}
+
 	:global(code),
 	:global(pre) {
-		font-family: 'JetBrains Mono', ui-monospace, 'SF Mono', Menlo, monospace;
+		font-family: var(--font-code);
 	}
 
 	:global(::selection) {
 		background: var(--selection);
-		color: var(--ink);
-	}
-
-	/* Don't animate theme transitions on first paint or for users who
-	   asked the OS not to. */
-	@media (prefers-reduced-motion: reduce) {
-		:global(body) {
-			transition: none;
-		}
 	}
 </style>

--- a/apps/playground/src/routes/+page.svelte
+++ b/apps/playground/src/routes/+page.svelte
@@ -1,395 +1,164 @@
 <script lang="ts">
 	import { base } from '$app/paths';
 	import { onMount } from 'svelte';
-	import type { BenchmarkResults } from '$lib/types/benchmark';
 	import type { TestResults } from '$lib/types/test-results';
-	import SiteNav from '$lib/components/SiteNav.svelte';
+	import { GUIDES } from '$lib/docs';
+	import CodeBlock from '$lib/components/CodeBlock.svelte';
+	import DocsSidebar from '$lib/components/DocsSidebar.svelte';
+	import DocsToc from '$lib/components/DocsToc.svelte';
 	import SiteFooter from '$lib/components/SiteFooter.svelte';
-	import EcoCard from '$lib/components/EcoCard.svelte';
-	import Eyebrow from '$lib/components/Eyebrow.svelte';
-	import SectionHead from '$lib/components/SectionHead.svelte';
-	import { shipped, planned, delegated, counts } from '$lib/ecosystem';
+	import SiteNav from '$lib/components/SiteNav.svelte';
 
-	let bench = $state<BenchmarkResults | null>(null);
 	let tests = $state<TestResults | null>(null);
-	let animated = $state(false);
 
 	onMount(async () => {
 		try {
-			const [b, t] = await Promise.all([
-				fetch(`${base}/benchmark-results.json`).then((r) => (r.ok ? r.json() : null)),
-				fetch(`${base}/test-results.json`).then((r) => (r.ok ? r.json() : null))
-			]);
-			bench = b;
-			tests = t;
+			const response = await fetch(`${base}/test-results.json`);
+			tests = response.ok ? await response.json() : null;
 		} catch {
-			bench = null;
 			tests = null;
 		}
-		requestAnimationFrame(() => (animated = true));
 	});
 
-	const formatDuration = (ms: number): string => {
-		if (ms < 1) return `${(ms * 1000).toFixed(0)}μs`;
-		if (ms < 1000) return `${ms.toFixed(1)} ms`;
-		return `${(ms / 1000).toFixed(2)} s`;
-	};
-
-	const formatThroughput = (v: number): string => {
-		if (v >= 1_000_000) return `${(v / 1_000_000).toFixed(1)}M`;
-		if (v >= 1000) return `${(v / 1000).toFixed(1)}k`;
-		return `${Math.round(v)}`;
-	};
-
-	const formatDate = (iso: string): string =>
-		new Date(iso).toLocaleString('en-US', { year: 'numeric', month: 'short', day: 'numeric' });
-
-	// The measured tools across the toolchain — each multi-threaded
-	// rsvelte vs. its official JavaScript counterpart on the same corpus.
-	const toolchain = $derived.by(() => {
-		if (!bench) return [];
-		const list = [
-			{ label: 'svelte/compiler', sub: 'full pipeline', x: bench.speedup.multiThreadVsJs },
-			{ label: 'parser', sub: 'phase 1, isolated', x: bench.parse.speedup.multiThreadVsJs }
-		];
-		if (bench.svelte2tsx) {
-			list.push({ label: 'svelte2tsx', sub: '.svelte → .tsx', x: bench.svelte2tsx.speedup.multiThreadVsJs });
-		}
-		if (bench.fmt) {
-			list.push({ label: 'fmt', sub: 'formatter vs prettier', x: bench.fmt.speedup.multiThreadVsJs });
-		}
-		if (bench.svelteCheck) {
-			list.push({ label: 'svelte-check', sub: 'project type-check', x: bench.svelteCheck.speedup.multiThreadVsJs });
-		}
-		return list;
-	});
-
-	const maxSpeedup = $derived(toolchain.reduce((m, t) => Math.max(m, t.x), 0));
-
-	const compat = $derived.by(() => {
-		if (!tests) return null;
-		const inScope = tests.summary.total - tests.summary.skipped;
-		return {
-			passed: tests.summary.passed,
-			inScope,
-			pct: tests.summary.percentage,
-			commit: tests.commit_sha
-		};
-	});
-
-	// Curated compatibility highlights — counts pulled live from the report.
-	const HIGHLIGHTS = [
-		{ id: 'runtime-legacy', label: 'runtime / legacy', sub: 'svelte 4 parity' },
-		{ id: 'runtime-runes', label: 'runtime / runes', sub: '$state / $derived / $effect' },
-		{ id: 'validator', label: 'validator + a11y', sub: 'warnings & errors' },
-		{ id: 'css', label: 'css', sub: ':global / scoping / keyframes' },
-		{ id: 'hydration', label: 'hydration', sub: 'resume server markup' },
-		{ id: 'compiler-errors', label: 'compiler errors', sub: 'parse & semantic checks' }
+	const inScopeTests = $derived(tests ? tests.summary.total - tests.summary.skipped : null);
+	const toc = [
+		{ label: 'Installation', href: '#installation' },
+		{ label: 'Using the compiler', href: '#using-the-compiler' },
+		{ label: 'Packages', href: '#packages' },
+		{ label: 'Project status', href: '#project-status' },
 	];
 
-	const specs = $derived(
-		HIGHLIGHTS.map((h) => {
-			const cat = tests?.categories.find((c) => c.id === h.id);
-			return {
-				label: h.label,
-				sub: h.sub,
-				passed: cat ? cat.passed : null,
-				total: cat ? cat.total - cat.skipped : null,
-				pct: cat ? cat.percentage : null
-			};
-		})
-	);
+	const usage = `import { compile } from '@rsvelte/compiler';
 
-	const why = [
-		{
-			n: '01',
-			h: 'Parallel by default.',
-			p: 'Files fan out across rayon worker threads. The parser is thread-safe; phase outputs pass directly through without re-parsing.'
-		},
-		{
-			n: '02',
-			h: 'Compact memory.',
-			p: 'u32 source positions, compact_str on hot paths, AST nodes shaped to keep cache lines warm under real workloads.'
-		},
-		{
-			n: '03',
-			h: 'One stack, end to end.',
-			p: 'Compiler, svelte2tsx, svelte-check and fmt share the same Rust AST and OXC foundation — no JS hop between the tools in your build.'
-		}
-	];
+const result = compile(source, {
+  filename: 'App.svelte',
+  generate: 'client'
+});`;
 </script>
 
 <svelte:head>
-	<title>rsvelte · the Svelte ecosystem, in Rust</title>
+	<title>Introduction · rsvelte</title>
 	<meta
 		name="description"
-		content="A Rust port of the Svelte ecosystem — compiler, svelte2tsx, svelte-check, fmt and vite-plugin-svelte as drop-in replacements. Same surface, identical output, up to 282× faster."
+		content="Get started with rsvelte, a Rust implementation of the Svelte compiler and developer tooling."
 	/>
 </svelte:head>
 
-<div class="page" class:in={animated}>
-	<SiteNav active="home" />
+<div class="page">
+	<SiteNav active="docs" />
 
-	<header class="hero">
-		<img class="hero-logo" src="{base}/logo.png" alt="rsvelte" width="96" height="96" />
+	<div class="docs-shell">
+		<DocsSidebar current="introduction" />
 
-		<Eyebrow marginBottom="1.6rem">Svelte ecosystem · written in Rust</Eyebrow>
+		<main class="article">
+			<nav class="breadcrumbs" aria-label="Breadcrumb">
+				<span>Documentation</span>
+				<span aria-hidden="true">/</span>
+				<span>Introduction</span>
+			</nav>
 
-		<h1 class="title">
-			The Svelte ecosystem,<br />rewritten in <span class="ink-rust">Rust</span>.
-		</h1>
-
-		<p class="lede">
-			Drop-in replacements for the tools you already run — the compiler, <code>svelte2tsx</code>,
-			<code>svelte-check</code>, <code>fmt</code>, the Vite plugin. Same surface, identical output, up to
-			<span class="ink-svelte">{bench ? Math.round(maxSpeedup) : 282}×</span> faster.
-		</p>
-
-		<div class="cta">
-			<a href="#ecosystem" class="btn btn-primary">
-				Explore the ecosystem <span aria-hidden="true">↓</span>
-			</a>
-			<a href="{base}/playground" class="btn btn-ghost">
-				Open playground <span aria-hidden="true">→</span>
-			</a>
-		</div>
-
-		<p class="install">
-			<span class="prompt">$</span> pnpm add <span class="pkg">@rsvelte/compiler</span>
-		</p>
-	</header>
-
-	<section class="perf" id="performance">
-		<SectionHead num="01">
-			Fast across the <em>whole</em> toolchain.
-			{#snippet lede()}
-				<p class="lede">
-					Speed is the point. Every tool is benchmarked against its official
-					<code>svelte/*</code> counterpart — same machine, same corpus, full pipeline: parse,
-					analyze, codegen.
+			<header class="article-head">
+				<h1>Introduction</h1>
+				<p class="lead">
+					rsvelte is a Rust implementation of the Svelte compiler and related developer tooling.
 				</p>
-			{/snippet}
-		</SectionHead>
+			</header>
 
-		<div class="perf-grid">
-			<figure class="bars">
-				<figcaption>
-					<span class="bars-title">Compile · full pipeline</span>
-					<span class="bars-sub"
-						>{bench ? `${bench.testFilesCount.toLocaleString('en-US')} .svelte files` : '—'}</span
-					>
-				</figcaption>
+			<p>
+				The project follows the official Svelte compiler implementation and aims to provide
+				compatible APIs and output. You can use the compiler from Node.js, WebAssembly, or native
+				bindings, and adopt the supporting tools independently.
+			</p>
 
-				{#if bench}
-					{@const max = Math.max(
-						bench.javascript.durationMs,
-						bench.rustSingleThread.durationMs,
-						bench.rustMultiThread.durationMs
-					)}
-					{@const rows = [
-						{ k: 'svelte/compiler', tone: 'js', sub: 'JavaScript', dur: bench.javascript.durationMs },
-						{ k: 'rsvelte / single', tone: 'rs', sub: 'no parallelism', dur: bench.rustSingleThread.durationMs },
-						{ k: 'rsvelte / multi', tone: 'rm', sub: 'rayon fan-out', dur: bench.rustMultiThread.durationMs }
-					]}
-					<div class="bar-list">
-						{#each rows as r, i (r.k)}
-							<div class="bar-row" style="--i: {i};">
-								<div class="bar-meta">
-									<span class="bar-k">{r.k}</span>
-									<span class="bar-s">{r.sub}</span>
-								</div>
-								<div class="bar-graph">
-									<span class="bar-track">
-										<span class="bar-fill bar-{r.tone}" style="--w: {(r.dur / max) * 100}%;"></span>
-									</span>
-									<span class="bar-t">{formatDuration(r.dur)}</span>
-								</div>
-							</div>
-						{/each}
-					</div>
-				{:else}
-					<div class="bars-empty">
-						<p>Benchmark data not loaded.</p>
-					</div>
-				{/if}
-
-				<div class="bars-foot">
-					<span>Lower is better</span>
-					<span class="dot-sep">·</span>
-					<span>{bench ? `recorded ${formatDate(bench.generatedAt)}` : ''}</span>
-					{#if bench}
-						<span class="dot-sep">·</span>
-						<span><code>{bench.commitSha}</code></span>
-					{/if}
-				</div>
-			</figure>
-
-			<aside class="toolchain">
-				<p class="toolchain-k">Multi-threaded vs. official JS</p>
-				{#if toolchain.length}
-					<ul class="toolchain-list">
-						{#each toolchain as t (t.label)}
-							<li class="toolchain-row">
-								<span class="tc-meta">
-									<span class="tc-name">{t.label}</span>
-									<span class="tc-sub">{t.sub}</span>
-								</span>
-								<span class="tc-x">{t.x.toFixed(t.x >= 50 ? 0 : 1)}<span class="x">×</span></span>
-							</li>
-						{/each}
-					</ul>
-				{:else}
-					<p class="toolchain-empty">—</p>
-				{/if}
-				<a class="toolchain-link" href="{base}/benchmark">
-					Full breakdown <span aria-hidden="true">→</span>
-				</a>
+			<aside class="callout">
+				<strong>Compatibility target</strong>
+				<p>
+					rsvelte is tested against the upstream <code>sveltejs/svelte</code> fixture suite. See the
+					<a href="{base}/progress">compatibility report</a> for the current results.
+				</p>
 			</aside>
-		</div>
-	</section>
 
-	<section class="eco" id="ecosystem">
-		<SectionHead num="02">
-			Not just a <em>compiler</em>.
-			{#snippet lede()}
-				<p class="lede">
-					rsvelte ports the hot path of every common Svelte workflow. {counts.shipped} drop-in
-					packages ship today — each a byte-for-byte replacement for its upstream tool — with
-					{counts.planned} more planned and {counts.delegated} deliberately delegated to the wider
-					<a class="link" href="https://oxc.rs/" target="_blank" rel="noopener">OXC</a> toolchain.
+			<section id="installation">
+				<h2>Installation</h2>
+				<p>Install the compiler package with your package manager:</p>
+				<CodeBlock code="pnpm add @rsvelte/compiler" lang="bash" />
+				<p>
+					Other rsvelte packages can be installed separately. They do not require migrating the
+					entire toolchain at once.
 				</p>
-			{/snippet}
-		</SectionHead>
+			</section>
 
-		<h3 class="eco-tier">Shipped <span class="eco-tier-n">· usable today</span></h3>
-		<div class="eco-grid">
-			{#each shipped as c (c.name)}
-				<EcoCard {c} compact />
-			{/each}
-		</div>
-
-		{#if planned.length > 0}
-			<h3 class="eco-tier">Planned <span class="eco-tier-n">· on the roadmap</span></h3>
-			<div class="eco-grid">
-				{#each planned as c (c.name)}
-					<EcoCard {c} compact />
-				{/each}
-			</div>
-		{/if}
-
-		{#if delegated.length > 0}
-			<h3 class="eco-tier">Delegated <span class="eco-tier-n">· routed to OXC / JS</span></h3>
-			<div class="eco-grid">
-				{#each delegated as c (c.name)}
-					<EcoCard {c} compact />
-				{/each}
-			</div>
-		{/if}
-	</section>
-
-	<section class="dropin">
-		<SectionHead num="03">
-			One import. <em>No flags.</em>
-			{#snippet lede()}
-				<p class="lede">
-					No bundler plugin to rewrite, no compiler flag to flip. The same
-					<code>compile()</code>, <code>parse()</code>, <code>preprocess()</code> — or swap the Vite
-					plugin and leave your <code>vite.config.js</code> untouched.
+			<section id="using-the-compiler">
+				<h2>Using the compiler</h2>
+				<p>
+					The compiler package exposes the familiar Svelte compiler interface. Change the import and
+					keep the existing compile options:
 				</p>
-			{/snippet}
-		</SectionHead>
+				<CodeBlock code={usage} lang="js" />
+				<p>
+					For browser use, initialize the WebAssembly module before the first compiler call. The
+					<a href="{base}/docs/compiler">compiler guide</a> covers both environments.
+				</p>
+			</section>
 
-		<figure class="diff">
-			<figcaption>
-				<span class="diff-file">build.config.js</span>
-			</figcaption>
-			<pre><code><span class="d-line d-minus"><span class="d-sig">-</span> import * as svelte from <span class="d-str">'svelte/compiler'</span>;</span>
-<span class="d-line d-plus"><span class="d-sig">+</span> import * as svelte from <span class="d-str">'@rsvelte/compiler'</span>;</span></code></pre>
-		</figure>
-	</section>
+			<section id="packages">
+				<h2>Packages</h2>
+				<p>The shipped packages cover the compiler and the common Svelte development workflow.</p>
 
-	<section class="compat">
-		<SectionHead num="04">
-			Verified against the <em>official</em> suite.
-			{#snippet lede()}
-				<p class="lede">
-					{#if compat}
-						<span class="big-pct">{compat.passed.toLocaleString('en-US')} / {compat.inScope.toLocaleString('en-US')}</span>
-						in-scope fixtures from <code>sveltejs/svelte</code> — {compat.pct.toFixed(1)}%. Full
-						breakdown on the <a class="link" href="{base}/progress">compatibility page</a>.
+				<div class="table-wrap">
+					<table>
+						<thead>
+							<tr>
+								<th>Package</th>
+								<th>Replaces</th>
+								<th>Browser</th>
+							</tr>
+						</thead>
+						<tbody>
+							{#each GUIDES as guide (guide.id)}
+								<tr>
+									<td>
+										<a href="{base}/docs/{guide.id}">{guide.title}</a>
+										<code>{guide.pkg}</code>
+									</td>
+									<td><code>{guide.dropInFor}</code></td>
+									<td>{guide.runnable ? 'Yes' : 'CLI only'}</td>
+								</tr>
+							{/each}
+						</tbody>
+					</table>
+				</div>
+			</section>
+
+			<section id="project-status">
+				<h2>Project status</h2>
+				<p>
+					{#if tests && inScopeTests !== null}
+						The current report has {tests.summary.passed.toLocaleString('en-US')} of {inScopeTests.toLocaleString(
+							'en-US',
+						)} in-scope fixtures passing ({tests.summary.percentage.toFixed(1)}%).
 					{:else}
-						Every category of the official <code>sveltejs/svelte</code> suite, run locally. Full
-						breakdown on the <a class="link" href="{base}/progress">compatibility page</a>.
+						Compatibility results are generated from the official Svelte test suite.
 					{/if}
 				</p>
-			{/snippet}
-		</SectionHead>
+				<ul>
+					<li><a href="{base}/progress">Review compatibility by test category</a></li>
+					<li><a href="{base}/benchmark">Review compiler and toolchain benchmarks</a></li>
+					<li><a href="{base}/playground">Try browser-compatible packages</a></li>
+				</ul>
+			</section>
 
-		<dl class="spec-list">
-			{#each specs as s, i (s.label)}
-				<div class="spec-row" style="--i: {i};">
-					<dt class="spec-k">{s.label}</dt>
-					<dd class="spec-v">
-						<span class="spec-n"
-							>{s.passed !== null ? s.passed.toLocaleString('en-US') : '—'}<span class="spec-n-sep"
-								>/</span
-							><span class="spec-n-tot">{s.total !== null ? s.total.toLocaleString('en-US') : '—'}</span></span
-						>
-						<span class="spec-s">{s.sub}</span>
-						<span class="spec-pct"
-							>{s.pct !== null ? Math.round(s.pct) : '—'}<span class="dim">%</span></span
-						>
-					</dd>
-				</div>
-			{/each}
-		</dl>
-	</section>
+			<nav class="page-nav" aria-label="Documentation pages">
+				<span></span>
+				<a href="{base}/docs">
+					<span>Next</span>
+					<strong>Overview →</strong>
+				</a>
+			</nav>
+		</main>
 
-	<section class="capi">
-		<SectionHead num="05">
-			Not just <em>Node.js</em>.
-			{#snippet lede()}
-				<p class="lede">
-					A stable C ABI ships alongside the NAPI build — one shared library, one header, UTF-8
-					JSON in/out. Drive the same compiler from any language with a C FFI.
-				</p>
-			{/snippet}
-		</SectionHead>
-
-		<ul class="capi-langs">
-			<li><span class="capi-tag">C / C++</span><span>include <code>rsvelte.h</code></span></li>
-			<li><span class="capi-tag">Go</span><span>cgo</span></li>
-			<li><span class="capi-tag">Python</span><span>ctypes / cffi</span></li>
-			<li><span class="capi-tag">Ruby</span><span>stdlib <code>fiddle</code></span></li>
-			<li><span class="capi-tag">PHP</span><span>built-in <code>FFI</code> (7.4+)</span></li>
-			<li><span class="capi-tag">Zig</span><span><code>@cImport</code></span></li>
-			<li><span class="capi-tag">Java / Kotlin</span><span>FFM API (JDK 22+)</span></li>
-			<li><span class="capi-tag">.NET</span><span><code>LibraryImport</code></span></li>
-		</ul>
-
-		<p class="capi-foot">
-			Smoke-tested in CI across Linux, macOS and Windows. See the
-			<a class="link" href="https://github.com/baseballyama/rsvelte/tree/main/crates/rsvelte_capi"
-				><code>crates/rsvelte_capi</code></a
-			> for the full API and per-language quick start.
-		</p>
-	</section>
-
-	<section class="why">
-		<SectionHead num="06">Why it's fast.</SectionHead>
-
-		<div class="why-list">
-			{#each why as w (w.h)}
-				<article class="why-row">
-					<span class="why-n">{w.n}</span>
-					<div class="why-body">
-						<h3>{w.h}</h3>
-						<p>{w.p}</p>
-					</div>
-				</article>
-			{/each}
-		</div>
-	</section>
+		<DocsToc items={toc} />
+	</div>
 
 	<SiteFooter />
 </div>
@@ -397,761 +166,222 @@
 <style>
 	.page {
 		min-height: 100vh;
-	}
-
-	code,
-	pre {
-		font-family: 'JetBrains Mono', ui-monospace, 'SF Mono', Menlo, monospace;
-	}
-
-	/* HERO */
-	.hero {
-		max-width: 1080px;
-		margin: 0 auto;
-		padding: clamp(4rem, 12vh, 7rem) clamp(1rem, 4vw, 2.5rem) clamp(3rem, 6vh, 4.5rem);
-	}
-
-	.hero-logo {
-		display: block;
-		width: clamp(72px, 9vw, 96px);
-		height: auto;
-		margin: 0 0 1.8rem;
-		border-radius: 16px;
-	}
-
-	.title {
-		font-family: 'Hanken Grotesk', sans-serif;
-		font-weight: 800;
-		font-size: clamp(2.3rem, 6.2vw, 4.6rem);
-		line-height: 1.02;
-		letter-spacing: -0.03em;
-		color: var(--ink);
-		margin: 0;
-	}
-
-	.ink-rust {
-		color: var(--rust);
-		font-style: italic;
-		font-weight: 700;
-	}
-
-	.ink-svelte {
-		color: var(--svelte);
-	}
-
-	.lede {
-		font-size: clamp(1.05rem, 1.3vw, 1.2rem);
-		max-width: 54ch;
-		color: var(--ink-soft);
-		margin: 1.6rem 0 0;
-	}
-
-	.lede code {
-		background: var(--paper);
-		color: var(--ink);
-		padding: 0.08em 0.4em;
-		border-radius: 3px;
-		font-size: 0.88em;
-		border: 1px solid var(--rule);
-	}
-
-	.cta {
 		display: flex;
-		gap: 0.65rem;
-		flex-wrap: wrap;
-		margin-top: 2.4rem;
+		flex-direction: column;
 	}
 
-	.btn {
-		display: inline-flex;
+	.docs-shell {
+		flex: 1;
+		width: 100%;
+		max-width: 1440px;
+		margin: 0 auto;
+		display: grid;
+		grid-template-columns: 230px minmax(0, 52rem) 200px;
+		justify-content: center;
+	}
+
+	.article {
+		min-width: 0;
+		padding: 3rem clamp(2rem, 5vw, 4rem) 5rem;
+	}
+
+	.breadcrumbs {
+		display: flex;
 		align-items: center;
 		gap: 0.5rem;
-		padding: 0.78rem 1.25rem;
-		font-family: 'Hanken Grotesk', sans-serif;
-		font-weight: 600;
-		font-size: 0.95rem;
-		border-radius: 4px;
-		border: 1px solid transparent;
-		transition:
-			background 0.18s,
-			color 0.18s,
-			border-color 0.18s;
-	}
-
-	.btn span {
-		transition: transform 0.18s;
-	}
-
-	.btn:hover span {
-		transform: translateX(3px);
-	}
-
-	.btn-primary {
-		background: var(--svelte);
-		color: #fff;
-	}
-
-	.btn-primary:hover {
-		background: var(--svelte-hover);
-	}
-
-	.btn-ghost {
-		background: transparent;
-		color: var(--ink);
-		border-color: var(--rule-strong);
-	}
-
-	.btn-ghost:hover {
-		border-color: var(--ink);
-	}
-
-	.install {
-		font-family: 'JetBrains Mono', monospace;
-		font-size: 0.9rem;
-		color: var(--ink-soft);
-		margin-top: 2.2rem;
-		padding-top: 1.5rem;
-		border-top: 1px solid var(--rule);
-		max-width: 36rem;
-	}
-
-	.install .prompt {
-		color: var(--svelte);
-		margin-right: 0.6em;
-	}
-
-	.install .pkg {
-		color: var(--rust);
-	}
-
-	/* PERF */
-	.perf {
-		background: var(--paper);
-		border-block: 1px solid var(--rule);
-	}
-
-	.compat .lede code,
-	.perf .lede code {
-		font-family: 'JetBrains Mono', monospace;
-		font-size: 0.78em;
-		font-weight: 500;
-		padding: 0.1em 0.45em;
-		background: var(--bg);
-		border: 1px solid var(--rule);
-		border-radius: 3px;
-		vertical-align: 0.05em;
-	}
-
-	.perf-grid {
-		max-width: 1080px;
-		margin: 0 auto;
-		padding: 0 clamp(1rem, 4vw, 2.5rem) clamp(4rem, 8vh, 6rem);
-		display: grid;
-		grid-template-columns: minmax(0, 1.5fr) minmax(0, 1fr);
-		gap: clamp(1.5rem, 3vw, 2.5rem);
-		align-items: start;
-	}
-
-	.bars {
-		background: var(--bg);
-		border: 1px solid var(--rule);
-		border-radius: 6px;
-		overflow: hidden;
-	}
-
-	.bars figcaption {
-		display: flex;
-		align-items: baseline;
-		justify-content: space-between;
-		padding: 0.9rem 1.25rem;
-		border-bottom: 1px solid var(--rule);
-	}
-
-	.bars-title {
-		font-weight: 600;
-		font-size: 0.92rem;
-		color: var(--ink);
-	}
-
-	.bars-sub {
-		font-family: 'JetBrains Mono', monospace;
-		font-size: 0.72rem;
-		color: var(--ink-soft);
-	}
-
-	.bar-list {
-		padding: 1.2rem 1.25rem 0.4rem;
-		display: flex;
-		flex-direction: column;
-		gap: 1.05rem;
-	}
-
-	.bar-row {
-		display: grid;
-		grid-template-columns: minmax(10rem, 11rem) 1fr;
-		gap: 1.2rem;
-		align-items: center;
-	}
-
-	.bar-meta {
-		display: flex;
-		flex-direction: column;
-		gap: 0.15rem;
-		min-width: 0;
-	}
-
-	.bar-k {
-		font-family: 'JetBrains Mono', monospace;
+		margin-bottom: 1.4rem;
 		font-size: 0.78rem;
-		font-weight: 500;
-		color: var(--ink);
-		letter-spacing: -0.01em;
-	}
-
-	.bar-s {
-		font-family: 'JetBrains Mono', monospace;
-		font-size: 0.66rem;
 		color: var(--ink-faint);
-		letter-spacing: 0.02em;
 	}
 
-	.bar-graph {
-		display: grid;
-		grid-template-columns: 1fr auto;
-		align-items: center;
-		gap: 0.85rem;
-	}
-
-	.bar-track {
-		display: block;
-		height: 10px;
-		background: var(--paper);
-		border: 1px solid var(--rule);
-		border-radius: 999px;
-		overflow: hidden;
-	}
-
-	.bar-fill {
-		display: block;
-		height: 100%;
-		width: 0;
-		border-radius: inherit;
-		transition: width 0.9s cubic-bezier(0.22, 1, 0.36, 1);
-		transition-delay: calc(0.12s * var(--i, 0) + 0.15s);
-	}
-
-	.page.in .bar-fill {
-		width: var(--w);
-	}
-
-	.bar-js {
-		background: linear-gradient(
-			90deg,
-			color-mix(in srgb, var(--ink-faint) 70%, transparent),
-			var(--ink-faint)
-		);
-	}
-
-	.bar-rs {
-		background: linear-gradient(90deg, var(--rust-soft), var(--rust));
-	}
-
-	.bar-rm {
-		background: linear-gradient(90deg, var(--rust-soft), var(--svelte));
-	}
-
-	.bar-t {
-		font-family: 'JetBrains Mono', monospace;
-		font-size: 0.82rem;
-		color: var(--ink);
-		font-variant-numeric: tabular-nums;
-		min-width: 5.5rem;
-		text-align: right;
-	}
-
-	.bars-foot {
-		display: flex;
-		align-items: center;
-		gap: 0.55rem;
-		flex-wrap: wrap;
-		padding: 0.85rem 1.25rem 1rem;
-		font-family: 'JetBrains Mono', monospace;
-		font-size: 0.7rem;
-		color: var(--ink-faint);
-		border-top: 1px solid var(--rule);
-		margin-top: 0.6rem;
-	}
-
-	.bars-foot code {
+	.breadcrumbs span:last-child {
 		color: var(--ink-soft);
 	}
 
-	.dot-sep {
-		opacity: 0.5;
+	.article-head {
+		padding-bottom: 1rem;
 	}
 
-	.bars-empty {
-		padding: 2rem 1.25rem;
-		font-family: 'JetBrains Mono', monospace;
-		font-size: 0.85rem;
-		color: var(--ink-faint);
-	}
-
-	/* TOOLCHAIN SPEEDUP LIST */
-	.toolchain {
-		background: var(--bg);
-		border: 1px solid var(--rule);
-		border-radius: 6px;
-		padding: 1.1rem 1.25rem 1.25rem;
-		display: flex;
-		flex-direction: column;
-		gap: 0.2rem;
-	}
-
-	.toolchain-k {
-		font-family: 'JetBrains Mono', monospace;
-		font-size: 0.66rem;
-		letter-spacing: 0.12em;
-		text-transform: uppercase;
-		color: var(--ink-faint);
-		margin: 0 0 0.5rem;
-	}
-
-	.toolchain-list {
-		list-style: none;
-		margin: 0;
-		padding: 0;
-	}
-
-	.toolchain-row {
-		display: flex;
-		align-items: baseline;
-		justify-content: space-between;
-		gap: 1rem;
-		padding: 0.7rem 0;
-		border-bottom: 1px solid var(--rule);
-	}
-
-	.toolchain-row:first-child {
-		border-top: 1px solid var(--rule);
-	}
-
-	.tc-meta {
-		display: flex;
-		flex-direction: column;
-		gap: 0.1rem;
-		min-width: 0;
-	}
-
-	.tc-name {
-		font-family: 'JetBrains Mono', monospace;
-		font-size: 0.8rem;
-		color: var(--ink);
-	}
-
-	.tc-sub {
-		font-family: 'JetBrains Mono', monospace;
-		font-size: 0.66rem;
-		color: var(--ink-faint);
-	}
-
-	.tc-x {
-		font-family: 'Hanken Grotesk', sans-serif;
-		font-weight: 800;
-		font-size: 1.45rem;
-		line-height: 1;
-		letter-spacing: -0.03em;
-		color: var(--svelte);
-		font-variant-numeric: tabular-nums;
-	}
-
-	.tc-x .x {
-		font-family: 'JetBrains Mono', monospace;
-		font-weight: 500;
-		font-size: 0.42em;
-		margin-left: 0.1em;
-		color: var(--svelte);
-		opacity: 0.7;
-	}
-
-	.toolchain-empty {
-		font-family: 'JetBrains Mono', monospace;
-		color: var(--ink-faint);
-		padding: 1rem 0;
-	}
-
-	.toolchain-link {
-		margin-top: 0.9rem;
-		font-family: 'JetBrains Mono', monospace;
-		font-size: 0.78rem;
-		color: var(--ink-soft);
-		display: inline-flex;
-		align-items: center;
-		gap: 0.4rem;
-		transition: color 0.18s;
-	}
-
-	.toolchain-link span {
-		transition: transform 0.18s;
-	}
-
-	.toolchain-link:hover {
-		color: var(--svelte);
-	}
-
-	.toolchain-link:hover span {
-		transform: translateX(3px);
-	}
-
-	/* ECOSYSTEM */
-	.eco {
-		max-width: 1080px;
-		margin: 0 auto;
-		/* Bottom breathing room (previously provided by the removed `.eco-foot`). */
-		padding-bottom: clamp(2rem, 4vh, 3rem);
-		/* Anchor target from the hero CTA — offset so the heading isn't hidden
-		   under the sticky nav. */
-		scroll-margin-top: 5rem;
-	}
-
-	.eco-grid {
-		max-width: 1080px;
-		margin: 0 auto;
-		padding: 0 clamp(1rem, 4vw, 2.5rem);
-		display: grid;
-		grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
-		gap: 1rem;
-	}
-
-	/* Sub-group heading inside the ecosystem section (Shipped / Planned /
-	   Delegated). */
-	.eco-tier {
-		max-width: 1080px;
-		margin: 1.8rem auto 0.8rem;
-		padding: 0 clamp(1rem, 4vw, 2.5rem);
-		font-family: 'Hanken Grotesk', sans-serif;
+	h1 {
+		font-size: clamp(2.25rem, 5vw, 3.25rem);
 		font-weight: 700;
-		font-size: 0.95rem;
-		letter-spacing: -0.01em;
-		color: var(--ink);
+		line-height: 1.12;
+		letter-spacing: -0.035em;
 	}
 
-	.eco-tier:first-of-type {
-		margin-top: 0;
-	}
-
-	.eco-tier-n {
-		font-weight: 500;
-		color: var(--ink-faint);
-	}
-
-	/* DROP-IN */
-	.dropin {
-		max-width: 1080px;
-		margin: 0 auto;
-	}
-
-	.diff {
-		max-width: 680px;
-		margin: 0 auto clamp(2.5rem, 6vh, 4rem);
-		background: var(--paper);
-		border: 1px solid var(--rule);
-		border-radius: 6px;
-		font-family: 'JetBrains Mono', monospace;
-		overflow: hidden;
-	}
-
-	.diff figcaption {
-		display: flex;
-		align-items: center;
-		justify-content: space-between;
-		padding: 0.65rem 1rem;
-		border-bottom: 1px solid var(--rule);
-		font-size: 0.72rem;
-		letter-spacing: 0.04em;
-		color: var(--ink-faint);
-	}
-
-	.diff-file {
+	.lead {
+		margin-top: 0.8rem;
+		font-size: 1.12rem;
+		line-height: 1.65;
 		color: var(--ink-soft);
 	}
 
-	.diff pre {
-		margin: 0;
-		padding: 0.9rem 1.15rem;
-		font-size: 0.88rem;
-		line-height: 1.75;
-	}
-
-	.d-line {
-		display: block;
-		padding: 0.1rem 0;
-	}
-
-	.d-sig {
-		display: inline-block;
-		width: 1.2em;
-		opacity: 0.65;
-	}
-
-	.d-minus {
-		color: var(--bad);
-	}
-
-	.d-plus {
-		color: var(--ok);
-		background: color-mix(in srgb, var(--ok) 8%, transparent);
-	}
-
-	.d-str {
-		color: var(--rust);
-	}
-
-	/* CAPI (Beyond Node.js) */
-	.capi {
-		max-width: 1080px;
-		margin: 0 auto clamp(4rem, 10vh, 7rem);
-		padding: 0 clamp(1rem, 4vw, 2.5rem);
-	}
-
-	.capi-langs {
-		display: grid;
-		grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
-		gap: 0.6rem 1.5rem;
-		list-style: none;
-		padding: 0;
-		margin: 0 auto clamp(1.5rem, 3vh, 2rem);
-		max-width: 880px;
-		font-size: 0.92rem;
-		color: var(--ink-soft);
-	}
-
-	.capi-langs li {
-		display: flex;
-		align-items: baseline;
-		gap: 0.65rem;
-		padding: 0.55rem 0;
-		border-bottom: 1px solid var(--rule);
-	}
-
-	.capi-tag {
-		font-family: 'JetBrains Mono', monospace;
-		font-size: 0.78rem;
-		letter-spacing: 0.02em;
-		color: var(--ink);
-		min-width: 7rem;
-		font-weight: 600;
-	}
-
-	.capi-langs code {
-		font-family: 'JetBrains Mono', monospace;
-		font-size: 0.85em;
-		color: var(--ink);
-	}
-
-	.capi-foot {
-		text-align: center;
-		font-size: 0.88rem;
-		color: var(--ink-faint);
-		max-width: 720px;
-		margin: 0 auto;
-	}
-
-	/* COMPAT */
-	.compat {
-		max-width: 1080px;
-		margin: 0 auto;
-	}
-
-	.big-pct {
-		font-family: 'Hanken Grotesk', sans-serif;
-		font-weight: 800;
-		color: var(--ink);
-		letter-spacing: -0.01em;
-	}
-
-	.spec-list {
-		max-width: 1080px;
-		margin: 0 auto clamp(2.5rem, 5vh, 3.5rem);
-		padding: 0 clamp(1rem, 4vw, 2.5rem);
-	}
-
-	.spec-row {
-		display: grid;
-		grid-template-columns: minmax(10rem, 14rem) 1fr;
-		gap: 1.4rem;
-		align-items: baseline;
-		padding: 1rem 0;
-		border-bottom: 1px solid var(--rule);
-		opacity: 0;
-		transform: translateY(6px);
-		transition:
-			opacity 0.55s cubic-bezier(0.22, 1, 0.36, 1),
-			transform 0.55s cubic-bezier(0.22, 1, 0.36, 1);
-		transition-delay: calc(0.05s * var(--i, 0));
-	}
-
-	.page.in .spec-row {
-		opacity: 1;
-		transform: none;
-	}
-
-	.spec-row:first-child {
-		border-top: 1px solid var(--rule);
-	}
-
-	.spec-k {
-		font-weight: 600;
+	.article > p,
+	section > p {
 		font-size: 0.98rem;
-		color: var(--ink);
-		letter-spacing: -0.005em;
-	}
-
-	.spec-v {
-		display: flex;
-		align-items: baseline;
-		gap: 0.85rem;
-		margin: 0;
-		min-width: 0;
-	}
-
-	/* The percentage is the last child of the value <dd>; push it to the row's
-	   right edge so the layout matches the old 3-column grid. */
-	.spec-pct {
-		margin-left: auto;
-		padding-left: 0.85rem;
-		font-family: 'JetBrains Mono', monospace;
-		font-size: 0.82rem;
-		color: var(--ink);
-		font-variant-numeric: tabular-nums;
-	}
-
-	.spec-n {
-		font-family: 'Hanken Grotesk', sans-serif;
-		font-weight: 700;
-		font-size: 1.15rem;
-		color: var(--ink);
-		font-variant-numeric: tabular-nums;
-		letter-spacing: -0.015em;
-	}
-
-	.spec-n-sep {
-		color: var(--ink-faint);
-		margin: 0 0.18em;
-	}
-
-	.spec-n-tot {
-		color: var(--ink-soft);
-		font-size: 0.82em;
-	}
-
-	.spec-s {
-		font-family: 'JetBrains Mono', monospace;
-		font-size: 0.74rem;
+		line-height: 1.75;
 		color: var(--ink-soft);
 	}
 
-	.spec-pct .dim {
-		color: var(--ink-faint);
+	.article > p {
+		margin-top: 0.75rem;
 	}
 
-	.link {
-		color: var(--svelte);
+	.article a,
+	section a {
+		color: var(--accent);
 		text-decoration: underline;
 		text-decoration-thickness: 1px;
 		text-underline-offset: 3px;
 	}
 
-	.link:hover {
-		color: var(--svelte-hover);
+	.article code {
+		font-size: 0.84em;
 	}
 
-	/* WHY */
-	.why {
-		max-width: 1080px;
-		margin: 0 auto;
+	.callout {
+		margin-top: 1.5rem;
+		padding: 1rem 1.1rem;
+		border: 1px solid color-mix(in srgb, var(--accent) 35%, var(--rule));
+		border-left: 3px solid var(--accent);
+		border-radius: 5px;
+		background: color-mix(in srgb, var(--accent) 5%, var(--bg));
 	}
 
-	.why-list {
-		max-width: 1080px;
-		margin: 0 auto;
-		padding: 0 clamp(1rem, 4vw, 2.5rem) clamp(4rem, 8vh, 6rem);
-		display: grid;
-		gap: 0;
+	.callout strong {
+		font-size: 0.88rem;
 	}
 
-	.why-row {
-		display: grid;
-		grid-template-columns: minmax(2.5rem, 4rem) 1fr;
-		gap: 1.5rem;
-		padding: 1.6rem 0;
+	.callout p {
+		margin-top: 0.3rem;
+		font-size: 0.88rem;
+		line-height: 1.6;
+		color: var(--ink-soft);
+	}
+
+	section {
+		padding-top: 2.5rem;
+		scroll-margin-top: 5rem;
+	}
+
+	h2 {
+		margin-bottom: 0.75rem;
+		padding-bottom: 0.45rem;
 		border-bottom: 1px solid var(--rule);
-		align-items: start;
+		font-size: 1.4rem;
+		font-weight: 650;
+		line-height: 1.3;
+		letter-spacing: -0.02em;
 	}
 
-	.why-row:first-child {
+	section :global(.block) {
+		margin: 1rem 0;
+	}
+
+	.table-wrap {
+		margin-top: 1rem;
+		overflow-x: auto;
+		border: 1px solid var(--rule);
+		border-radius: 6px;
+	}
+
+	table {
+		width: 100%;
+		border-collapse: collapse;
+		font-size: 0.84rem;
+	}
+
+	th,
+	td {
+		padding: 0.65rem 0.8rem;
+		border-bottom: 1px solid var(--rule);
+		text-align: left;
+		vertical-align: top;
+	}
+
+	th {
+		background: var(--paper);
+		font-size: 0.75rem;
+		font-weight: 650;
+		color: var(--ink);
+	}
+
+	td {
+		color: var(--ink-soft);
+	}
+
+	tbody tr:last-child td {
+		border-bottom: 0;
+	}
+
+	td:first-child a {
+		display: block;
+		font-weight: 600;
+		color: var(--ink);
+		text-decoration: none;
+	}
+
+	td:first-child a:hover {
+		color: var(--accent);
+	}
+
+	td:first-child code {
+		display: block;
+		margin-top: 0.2rem;
+		color: var(--ink-faint);
+	}
+
+	ul {
+		margin: 0.75rem 0 0;
+		padding-left: 1.25rem;
+	}
+
+	li {
+		padding: 0.2rem 0;
+		font-size: 0.94rem;
+		color: var(--ink-soft);
+	}
+
+	.page-nav {
+		display: grid;
+		grid-template-columns: 1fr 1fr;
+		margin-top: 3.5rem;
+		padding-top: 1.25rem;
 		border-top: 1px solid var(--rule);
 	}
 
-	.why-n {
-		font-family: 'JetBrains Mono', monospace;
+	.page-nav a {
+		justify-self: end;
+		display: flex;
+		flex-direction: column;
+		align-items: flex-end;
+		text-decoration: none;
+	}
+
+	.page-nav span {
 		font-size: 0.72rem;
-		letter-spacing: 0.16em;
-		color: var(--rust);
+		color: var(--ink-faint);
 	}
 
-	.why-body h3 {
-		font-family: 'Hanken Grotesk', sans-serif;
-		font-weight: 700;
-		font-size: 1.18rem;
-		letter-spacing: -0.015em;
-		color: var(--ink);
-		margin: 0 0 0.45rem;
+	.page-nav strong {
+		font-size: 0.88rem;
+		font-weight: 600;
+		color: var(--accent);
 	}
 
-	.why-body p {
-		font-size: 0.97rem;
-		color: var(--ink-soft);
-		margin: 0;
-		max-width: 64ch;
+	@media (max-width: 1120px) {
+		.docs-shell {
+			grid-template-columns: 230px minmax(0, 1fr);
+		}
 	}
 
-	/* RESPONSIVE */
-	@media (max-width: 880px) {
-		.perf-grid {
+	@media (max-width: 860px) {
+		.docs-shell {
 			grid-template-columns: 1fr;
 		}
-		.spec-row {
-			grid-template-columns: 1fr;
-			gap: 0.4rem 1rem;
-		}
-	}
 
-	@media (max-width: 640px) {
-		.bar-row {
-			grid-template-columns: 1fr;
-			gap: 0.5rem;
-		}
-		.bar-meta {
-			flex-direction: row;
-			align-items: baseline;
-			gap: 0.6rem;
-		}
-	}
-
-	@media (prefers-reduced-motion: reduce) {
-		.bar-fill,
-		.spec-row,
-		.btn span {
-			transition: none !important;
-		}
-		.spec-row {
-			opacity: 1 !important;
-			transform: none !important;
-		}
-		.page.in .bar-fill {
-			width: var(--w);
-			transition: none !important;
+		.article {
+			padding-inline: clamp(1rem, 5vw, 2.5rem);
 		}
 	}
 </style>

--- a/apps/playground/src/routes/benchmark/+page.svelte
+++ b/apps/playground/src/routes/benchmark/+page.svelte
@@ -1,356 +1,241 @@
 <script lang="ts">
-	import { onMount } from 'svelte';
+	import { base } from '$app/paths';
 	import type { PageData } from './$types';
 	import type { BenchmarkTaskResults } from '$lib/types/benchmark';
-	import SiteNav from '$lib/components/SiteNav.svelte';
+	import CodeBlock from '$lib/components/CodeBlock.svelte';
 	import SiteFooter from '$lib/components/SiteFooter.svelte';
-	import Eyebrow from '$lib/components/Eyebrow.svelte';
-	import SectionHead from '$lib/components/SectionHead.svelte';
-	import '$lib/styles/terminal-code.css';
+	import SiteNav from '$lib/components/SiteNav.svelte';
 
 	let { data }: { data: PageData } = $props();
 
 	type TaskId = 'full' | 'full-ssr' | 'parse' | 'svelte2tsx' | 'fmt' | 'lint' | 'svelte-check';
+	type TaskGroup = 'compiler' | 'ecosystem';
 
-	// `animationTime` is the elapsed wall-clock ms since the run started.
-	// Each bar across every task shows `min(animationTime, this.durationMs)`,
-	// so all three breakdowns fill in parallel at their *actual* measured
-	// speeds — the slow JS bar is still inching forward when the multi-
-	// threaded rsvelte bar has already crossed the finish line.
-	let animationTime = $state(0);
-	let isAnimating = $state(false);
-	let animationComplete = $state(false);
-
-	// Hard ceiling for the wall-clock animation so very fast tasks (e.g. the
-	// parser-only run can finish in ~150 ms) don't blink past unreadably and
-	// very slow ones (full-pipeline JS at ~1 s) don't drag the user. We stop
-	// once the slowest bar across every task is done OR 4 s, whichever
-	// comes first.
-	const ANIMATION_HARD_CAP_MS = 4000;
+	type TaskRow = {
+		id: TaskId;
+		label: string;
+		description: string;
+		group: TaskGroup;
+		baseline: string;
+		data: BenchmarkTaskResults;
+	};
 
 	const formatDate = (iso: string): string =>
-		new Date(iso).toLocaleString('en-US', { year: 'numeric', month: 'short', day: 'numeric' });
+		new Date(iso).toLocaleDateString('en-US', {
+			year: 'numeric',
+			month: 'short',
+			day: 'numeric'
+		});
 
 	const formatDuration = (ms: number): string => {
-		if (ms < 1) return `${(ms * 1000).toFixed(1)}μs`;
+		if (ms < 1) return `${(ms * 1000).toFixed(1)} μs`;
 		if (ms < 1000) return `${ms.toFixed(1)} ms`;
 		return `${(ms / 1000).toFixed(2)} s`;
 	};
 
-	const formatThroughput = (v: number): string => {
-		if (v >= 1_000_000) return `${(v / 1_000_000).toFixed(1)}M`;
-		if (v >= 1000) return `${(v / 1000).toFixed(1)}k`;
-		return v.toFixed(0);
-	};
-
-	// Which tier a task belongs to: the core compiler itself, or the
-	// surrounding ecosystem tooling built on top of it.
-	type TaskGroup = 'compiler' | 'ecosystem';
-
-	type TaskPanel = {
-		id: TaskId;
-		label: string;
-		sub: string;
-		group: TaskGroup;
-		// Name of the JavaScript tool this task is benchmarked against.
-		baseline: string;
-		data: BenchmarkTaskResults;
-		filesCount?: number;
-	};
-
-	const tasks: TaskPanel[] = $derived.by(() => {
+	const tasks: TaskRow[] = $derived.by(() => {
 		if (!data.results) return [];
 		const r = data.results;
-		const list: TaskPanel[] = [
-			{ id: 'full', label: 'Compile (CSR)', sub: 'parse / analyze / codegen → DOM', group: 'compiler', baseline: 'svelte/compiler', data: r }
+		const rows: TaskRow[] = [
+			{
+				id: 'full',
+				label: 'Compile (client)',
+				description: 'Parse, analyze, and generate DOM code',
+				group: 'compiler',
+				baseline: 'svelte/compiler',
+				data: r
+			}
 		];
-		// SSR compile — optional (older JSON snapshots predate it).
+
 		if (r.compileServer) {
-			list.push({
+			rows.push({
 				id: 'full-ssr',
-				label: 'Compile (SSR)',
-				sub: 'parse / analyze / codegen → HTML',
+				label: 'Compile (server)',
+				description: 'Parse, analyze, and generate HTML',
 				group: 'compiler',
 				baseline: 'svelte/compiler',
 				data: r.compileServer
 			});
 		}
-		list.push({ id: 'parse', label: 'Parser only', sub: 'phase 1, isolated', group: 'compiler', baseline: 'svelte/compiler', data: r.parse });
+
+		rows.push({
+			id: 'parse',
+			label: 'Parse only',
+			description: 'Compiler phase 1 in isolation',
+			group: 'compiler',
+			baseline: 'svelte/compiler',
+			data: r.parse
+		});
+
 		if (r.svelte2tsx) {
-			list.push({
+			rows.push({
 				id: 'svelte2tsx',
 				label: 'svelte2tsx',
-				sub: '.svelte → .tsx generation',
+				description: 'Generate TypeScript from Svelte source',
 				group: 'ecosystem',
 				baseline: 'svelte2tsx',
 				data: r.svelte2tsx
 			});
 		}
 		if (r.fmt) {
-			list.push({
+			rows.push({
 				id: 'fmt',
 				label: 'Format',
-				sub: 'formatter · .svelte sources',
+				description: 'Format Svelte source files',
 				group: 'ecosystem',
 				baseline: 'prettier-plugin-svelte',
 				data: r.fmt
 			});
 		}
 		if (r.lint) {
-			list.push({
+			rows.push({
 				id: 'lint',
 				label: 'Lint',
-				sub: `linter · ${r.lint.rulesCount} shared rules`,
+				description: `${r.lint.rulesCount} rules shared by both implementations`,
 				group: 'ecosystem',
-				baseline: 'eslint + eslint-plugin-svelte',
+				baseline: 'eslint-plugin-svelte',
 				data: r.lint
 			});
 		}
 		if (r.svelteCheck) {
-			list.push({
+			rows.push({
 				id: 'svelte-check',
 				label: 'svelte-check',
-				sub: `CLI · ${r.svelteCheck.filesCount.toLocaleString('en-US')}-file workspace`,
+				description: `${r.svelteCheck.filesCount.toLocaleString('en-US')}-file workspace`,
 				group: 'ecosystem',
 				baseline: 'svelte-check',
-				data: r.svelteCheck,
-				filesCount: r.svelteCheck.filesCount
+				data: r.svelteCheck
 			});
 		}
-		return list;
+
+		return rows;
 	});
 
-	// Tasks split into the two tiers shown as separate sections on the page.
-	const taskGroups: { key: TaskGroup; title: string; sub: string }[] = [
-		{ key: 'compiler', title: 'Compiler', sub: 'the rsvelte core — Svelte source → JS' },
-		{ key: 'ecosystem', title: 'Ecosystem', sub: 'tooling built on the compiler' }
+	const groups: { key: TaskGroup; title: string; description: string }[] = [
+		{ key: 'compiler', title: 'Compiler', description: 'Core Svelte compilation tasks.' },
+		{ key: 'ecosystem', title: 'Ecosystem tools', description: 'Tools built around the compiler.' }
 	];
+
 	const tasksByGroup = $derived(
-		taskGroups
-			.map((g) => ({ ...g, items: tasks.filter((t) => t.group === g.key) }))
-			.filter((g) => g.items.length > 0)
+		groups
+			.map((group) => ({ ...group, rows: tasks.filter((task) => task.group === group.key) }))
+			.filter((group) => group.rows.length > 0)
 	);
 
-	const headlineSpeedups: { id: TaskId; label: string; sub: string; x: number; precision: number }[] = $derived(
-		tasks.map((t) => ({
-			id: t.id,
-			label: t.label,
-			sub: t.sub,
-			x: t.data.speedup.multiThreadVsJs,
-			precision: t.data.speedup.multiThreadVsJs >= 50 ? 0 : 1
-		}))
-	);
-
-	const maxHeadlineSpeedup = $derived(
-		headlineSpeedups.reduce((m, s) => Math.max(m, s.x), 0)
-	);
-
-	const getMaxDuration = (r: BenchmarkTaskResults): number =>
-		Math.max(r.javascript.durationMs, r.rustSingleThread.durationMs, r.rustMultiThread.durationMs);
-
-	const getAnimatedWidth = (r: BenchmarkTaskResults, duration: number): number => {
-		const maxDuration = getMaxDuration(r);
-		if (animationComplete) return (duration / maxDuration) * 100;
-		const filled = Math.min(animationTime, duration);
-		return (filled / maxDuration) * 100;
-	};
-
-	const getAnimatedTime = (duration: number): number => {
-		if (animationComplete) return duration;
-		return Math.min(animationTime, duration);
-	};
-
-	const startAnimation = () => {
-		if (isAnimating || tasks.length === 0) return;
-		isAnimating = true;
-		animationComplete = false;
-		animationTime = 0;
-		// Run until the slowest bar across *every* visible task is done,
-		// so users still see fast bars finish early and the slow JS bar
-		// crawl on.
-		const slowest = Math.max(...tasks.map((t) => getMaxDuration(t.data)));
-		const finishAt = Math.min(slowest, ANIMATION_HARD_CAP_MS);
-		const start = performance.now();
-		const tick = () => {
-			const elapsed = performance.now() - start;
-			animationTime = elapsed;
-			if (elapsed >= finishAt) {
-				animationTime = finishAt;
-				isAnimating = false;
-				animationComplete = true;
-				return;
-			}
-			requestAnimationFrame(tick);
-		};
-		requestAnimationFrame(tick);
-	};
-
-	onMount(() => {
-		if (data.results) setTimeout(startAnimation, 250);
-	});
+	const generateData = `cargo build --release
+pnpm run generate-benchmark
+pnpm run dev:docs`;
 </script>
 
 <svelte:head>
 	<title>Benchmark · rsvelte</title>
 	<meta
 		name="description"
-		content="Compilation speed benchmark — rsvelte (Rust, single + multi-threaded) against the official svelte/compiler."
+		content="Compilation speed benchmark — rsvelte against the official Svelte compiler and ecosystem tools."
 	/>
 </svelte:head>
 
 <div class="page">
 	<SiteNav active="benchmark" />
 
-	{#if data.error}
-		<section class="empty">
-			<Eyebrow marginBottom="1.4rem">Benchmark · unavailable</Eyebrow>
-			<h1>No benchmark data yet.</h1>
-			<p class="lede">{data.error}</p>
-			<pre class="empty-code"><code><span class="c-cmt"># From the repo root</span>
-<span class="c-prompt">$</span> cargo build <span class="c-flag">--release</span>
-<span class="c-prompt">$</span> node scripts/bench/run-benchmark.mjs &gt; apps/playground/static/benchmark-results.json</code></pre>
-		</section>
-	{:else if data.results}
-		{@const r = data.results}
+	<main class="report">
+		{#if data.error}
+			<nav class="breadcrumbs" aria-label="Breadcrumb">
+				<a href="{base}/">Documentation</a><span>/</span><span>Benchmark</span>
+			</nav>
+			<h1>Benchmark data is unavailable</h1>
+			<p class="intro">{data.error}</p>
+			<div class="command"><CodeBlock code={generateData} lang="bash" caption="Terminal" /></div>
+		{:else if data.results}
+			{@const r = data.results}
 
-		<header class="hero">
-			<Eyebrow marginBottom="1.4rem"
-				>Across the Svelte toolchain · multi-threaded vs official JS</Eyebrow
-			>
+			<header class="report-header">
+				<nav class="breadcrumbs" aria-label="Breadcrumb">
+					<a href="{base}/">Documentation</a><span>/</span><span>Benchmark</span>
+				</nav>
+				<h1>Benchmark</h1>
+				<p class="intro">
+					Results from running the official JavaScript tools and rsvelte against the same source
+					corpus. Lower durations are better.
+				</p>
 
-			<h1 class="title">
-				Up to <span class="ink-svelte">{maxHeadlineSpeedup.toFixed(0)}×</span> faster across the
-				Svelte toolchain.
-			</h1>
-
-			<dl class="hero-meta">
-				<div>
-					<dt>Corpus</dt>
-					<dd>{r.testFilesCount.toLocaleString('en-US')} .svelte files</dd>
-				</div>
-				{#if r.runner}
+				<dl class="metadata">
 					<div>
-						<dt>Machine</dt>
-						<dd>
-							{r.runner.cpus}-core {r.runner.arch}
-							<span class="hero-meta-aside">· {r.runner.label}</span>
-						</dd>
+						<dt>Corpus</dt>
+						<dd>{r.testFilesCount.toLocaleString('en-US')} Svelte files</dd>
 					</div>
-				{/if}
-				<div>
-					<dt>Recorded</dt>
-					<dd>{formatDate(r.generatedAt)}</dd>
-				</div>
-				<div>
-					<dt>Commit</dt>
-					<dd><code>{r.commitSha}</code></dd>
-				</div>
-			</dl>
-		</header>
-
-		<section class="stats">
-			{#each headlineSpeedups as s (s.id)}
-				<article class="stat">
-					<span class="stat-k">{s.label}</span>
-					<span class="stat-n">
-						{s.x.toFixed(s.precision)}<span class="stat-x">×</span>
-					</span>
-					<span class="stat-s">{s.sub}</span>
-				</article>
-			{/each}
-		</section>
-
-		<section class="chart">
-			<header class="chart-head">
-				<div class="chart-head-meta">
-					<h2 class="chart-title">Per-phase breakdown</h2>
-					<p class="chart-sub">Lower is better · same machine, same corpus</p>
-				</div>
-				<button class="replay" onclick={startAnimation} disabled={isAnimating}>
-					<span class="replay-i" aria-hidden="true">↻</span>
-					Replay
-				</button>
+					{#if r.runner}
+						<div>
+							<dt>Machine</dt>
+							<dd>{r.runner.cpus}-core {r.runner.arch} · {r.runner.label}</dd>
+						</div>
+					{/if}
+					<div>
+						<dt>Recorded</dt>
+						<dd>{formatDate(r.generatedAt)}</dd>
+					</div>
+					<div>
+						<dt>Commit</dt>
+						<dd><code>{r.commitSha}</code></dd>
+					</div>
+				</dl>
 			</header>
 
-			<div class="task-groups">
+			<section class="results" aria-labelledby="results-heading">
+				<h2 id="results-heading">Results</h2>
+				<p class="section-description">
+					Each duration is the total time for the corpus. Speedup compares multi-threaded rsvelte
+					with the JavaScript baseline.
+				</p>
+
 				{#each tasksByGroup as group (group.key)}
-					<div class="task-group">
-						<div class="task-group-head">
-							<span class="task-group-title">{group.title}</span>
-							<span class="task-group-sub">{group.sub}</span>
+					<section class="result-group" aria-labelledby="{group.key}-heading">
+						<div class="group-heading">
+							<h3 id="{group.key}-heading">{group.title}</h3>
+							<p>{group.description}</p>
 						</div>
-						<div class="task-grid">
-							{#each group.items as task (task.id)}
-								{@const t = task.data}
-								<article class="task-panel">
-									<header class="task-panel-head">
-										<div class="task-panel-meta">
-											<span class="task-panel-label">{task.label}</span>
-											<span class="task-panel-sub">{task.sub}</span>
-										</div>
-										<span class="task-panel-speedup">
-											<span class="task-panel-speedup-k">multi · </span>
-											<span class="task-panel-speedup-n">
-												{t.speedup.multiThreadVsJs.toFixed(1)}<span class="x">×</span>
-											</span>
-											<span class="task-panel-speedup-sep">·</span>
-											<span class="task-panel-speedup-st">
-												single {t.speedup.singleThreadVsJs.toFixed(1)}×
-											</span>
-										</span>
-									</header>
-									<div class="bars">
-										{#each [
-											{ name: task.baseline, sub: 'JavaScript', dur: t.javascript.durationMs, tone: 'js' },
-											{ name: 'rsvelte / single', sub: 'no parallelism', dur: t.rustSingleThread.durationMs, tone: 'rs' },
-											{ name: 'rsvelte / multi', sub: 'rayon fan-out', dur: t.rustMultiThread.durationMs, tone: 'rm' }
-										] as bar (bar.name)}
-											<div class="bar-row">
-												<div class="bar-meta">
-													<span class="bar-name">{bar.name}</span>
-													<span class="bar-sub">{bar.sub}</span>
-												</div>
-												<div class="bar-graph">
-													<span class="bar-track">
-														<span
-															class="bar-fill bar-{bar.tone}"
-															style="width: {getAnimatedWidth(t, bar.dur)}%;"
-														></span>
-													</span>
-													<span class="bar-time">
-														{formatDuration(getAnimatedTime(bar.dur))}
-													</span>
-												</div>
-											</div>
-										{/each}
-									</div>
-								</article>
-							{/each}
+						<div class="table-scroll">
+							<table>
+								<caption class="visually-hidden">{group.title} benchmark results</caption>
+								<thead>
+									<tr>
+										<th scope="col">Task</th>
+										<th scope="col">JavaScript</th>
+										<th scope="col">rsvelte, single thread</th>
+										<th scope="col">rsvelte, multi-thread</th>
+										<th scope="col">Speedup</th>
+									</tr>
+								</thead>
+								<tbody>
+									{#each group.rows as task (task.id)}
+										<tr>
+											<th scope="row">
+												<span class="task-name">{task.label}</span>
+												<span class="task-description">{task.description}</span>
+											</th>
+											<td>
+												<span class="duration">{formatDuration(task.data.javascript.durationMs)}</span>
+												<span class="implementation">{task.baseline}</span>
+											</td>
+											<td>{formatDuration(task.data.rustSingleThread.durationMs)}</td>
+											<td>{formatDuration(task.data.rustMultiThread.durationMs)}</td>
+											<td class="speedup">{task.data.speedup.multiThreadVsJs.toFixed(1)}×</td>
+										</tr>
+									{/each}
+								</tbody>
+							</table>
 						</div>
-					</div>
+					</section>
 				{/each}
-			</div>
-		</section>
+			</section>
 
-		<section class="repro">
-			<SectionHead num="02" padding="0" marginBottom="1.6rem" fontSize="clamp(1.6rem, 3vw, 2.4rem)"
-				>Reproduce it yourself.</SectionHead
-			>
-			<figure class="diff">
-				<figcaption>
-					<span class="diff-file">your-shell</span>
-				</figcaption>
-				<pre><code><span class="c-cmt"># 1. Build the Rust compiler in release mode</span>
-<span class="c-prompt">$</span> cargo build <span class="c-flag">--release</span>
-
-<span class="c-cmt"># 2. Run the corpus benchmark (compile / parse / svelte2tsx / fmt / lint / svelte-check)</span>
-<span class="c-prompt">$</span> pnpm run generate-benchmark
-
-<span class="c-cmt"># 3. View the report locally</span>
-<span class="c-prompt">$</span> pnpm run dev:docs</code></pre>
-			</figure>
-		</section>
-	{/if}
+			<section class="reproduce" aria-labelledby="reproduce-heading">
+				<h2 id="reproduce-heading">Run the benchmark locally</h2>
+				<p>Generate a fresh result file and open this report in the local documentation site.</p>
+				<div class="command"><CodeBlock code={generateData} lang="bash" caption="Terminal" /></div>
+			</section>
+		{/if}
+	</main>
 
 	<SiteFooter />
 </div>
@@ -360,504 +245,237 @@
 		min-height: 100vh;
 	}
 
-	code,
-	pre {
-		font-family: 'JetBrains Mono', ui-monospace, 'SF Mono', Menlo, monospace;
-	}
-
-	/* HERO */
-	.hero {
-		max-width: 1080px;
+	.report {
+		width: min(100% - 2rem, 1100px);
 		margin: 0 auto;
-		padding: clamp(3.5rem, 9vh, 5.5rem) clamp(1rem, 4vw, 2.5rem) clamp(2rem, 4vh, 3rem);
+		padding: 2.75rem 0 5rem;
 	}
 
-	.title {
-		font-family: 'Hanken Grotesk', sans-serif;
-		font-weight: 800;
-		font-size: clamp(2rem, 4.6vw, 3.4rem);
-		line-height: 1.05;
-		letter-spacing: -0.025em;
-		color: var(--ink);
-		margin: 0;
-		max-width: 22ch;
-	}
-
-	.ink-svelte {
-		color: var(--svelte);
-		font-style: italic;
-		font-weight: 800;
-	}
-
-	.hero-meta {
+	.breadcrumbs {
 		display: flex;
-		flex-wrap: wrap;
-		gap: 2.5rem;
-		margin-top: 2rem;
-		padding-top: 1.4rem;
+		gap: 0.45rem;
+		align-items: center;
+		margin-bottom: 1.4rem;
+		font-size: 0.8rem;
+		color: var(--ink-faint);
+	}
+
+	.breadcrumbs a {
+		color: var(--ink-soft);
+		text-decoration: none;
+	}
+
+	.breadcrumbs a:hover {
+		color: var(--accent);
+		text-decoration: underline;
+	}
+
+	h1,
+	h2,
+	h3,
+	p {
+		margin-top: 0;
+	}
+
+	h1 {
+		margin-bottom: 0.7rem;
+		font-size: clamp(2rem, 4vw, 2.75rem);
+		line-height: 1.15;
+		letter-spacing: -0.035em;
+	}
+
+	.intro {
+		max-width: 68ch;
+		margin-bottom: 0;
+		font-size: 1rem;
+		line-height: 1.65;
+		color: var(--ink-soft);
+	}
+
+	.metadata {
+		display: grid;
+		grid-template-columns: repeat(4, minmax(0, 1fr));
+		gap: 1.5rem;
+		margin: 2rem 0 0;
+		padding: 1.1rem 0;
+		border-top: 1px solid var(--rule);
+		border-bottom: 1px solid var(--rule);
+	}
+
+	.metadata dt {
+		margin-bottom: 0.25rem;
+		font-size: 0.75rem;
+		font-weight: 600;
+		color: var(--ink-faint);
+	}
+
+	.metadata dd {
+		margin: 0;
+		font-size: 0.82rem;
+		line-height: 1.45;
+		color: var(--ink);
+	}
+
+	.metadata code {
+		font-family: var(--font-code);
+	}
+
+	.results {
+		margin-top: 3.5rem;
+	}
+
+	h2 {
+		margin-bottom: 0.45rem;
+		font-size: 1.45rem;
+		letter-spacing: -0.02em;
+	}
+
+	.section-description,
+	.reproduce > p {
+		max-width: 70ch;
+		margin-bottom: 1.8rem;
+		font-size: 0.9rem;
+		line-height: 1.6;
+		color: var(--ink-soft);
+	}
+
+	.result-group + .result-group {
+		margin-top: 2.5rem;
+	}
+
+	.group-heading {
+		display: flex;
+		align-items: baseline;
+		gap: 0.75rem;
+		margin-bottom: 0.65rem;
+	}
+
+	.group-heading h3 {
+		margin-bottom: 0;
+		font-size: 1rem;
+	}
+
+	.group-heading p {
+		margin-bottom: 0;
+		font-size: 0.8rem;
+		color: var(--ink-faint);
+	}
+
+	.table-scroll {
+		overflow-x: auto;
+		border: 1px solid var(--rule);
+		border-radius: 6px;
+		background: var(--bg);
+	}
+
+	table {
+		width: 100%;
+		min-width: 720px;
+		border-collapse: collapse;
+		font-size: 0.82rem;
+		font-variant-numeric: tabular-nums;
+	}
+
+	th,
+	td {
+		padding: 0.8rem 0.9rem;
+		border-bottom: 1px solid var(--rule);
+		text-align: right;
+		vertical-align: top;
+		white-space: nowrap;
+	}
+
+	thead th {
+		background: var(--paper);
+		font-family: var(--font-ui);
+		font-size: 0.72rem;
+		font-weight: 600;
+		line-height: 1.35;
+		color: var(--ink-soft);
+		white-space: normal;
+	}
+
+	th:first-child,
+	td:first-child {
+		text-align: left;
+	}
+
+	tbody th {
+		width: 30%;
+		font-weight: 500;
+		white-space: normal;
+	}
+
+	tbody tr:last-child th,
+	tbody tr:last-child td {
+		border-bottom: 0;
+	}
+
+	.task-name,
+	.task-description,
+	.implementation {
+		display: block;
+	}
+
+	.task-description,
+	.implementation {
+		margin-top: 0.2rem;
+		font-size: 0.7rem;
+		font-weight: 400;
+		line-height: 1.45;
+		color: var(--ink-faint);
+	}
+
+	.duration {
+		display: block;
+	}
+
+	.speedup {
+		font-weight: 650;
+		color: var(--ok);
+	}
+
+	tbody tr:hover {
+		background: color-mix(in srgb, var(--paper) 55%, transparent);
+	}
+
+	.reproduce {
+		margin-top: 4rem;
+		padding-top: 2.5rem;
 		border-top: 1px solid var(--rule);
 	}
 
-	.hero-meta > div {
-		display: flex;
-		flex-direction: column;
-		gap: 0.18rem;
-	}
-
-	.hero-meta dt {
-		font-family: 'JetBrains Mono', monospace;
-		font-size: 0.66rem;
-		letter-spacing: 0.14em;
-		text-transform: uppercase;
-		color: var(--ink-faint);
-	}
-
-	.hero-meta dd {
-		font-family: 'JetBrains Mono', monospace;
-		font-size: 0.86rem;
-		color: var(--ink);
-		margin: 0;
-	}
-
-	.hero-meta code {
-		font-size: 0.92em;
-		color: var(--rust);
-	}
-
-	.hero-meta-aside {
-		color: var(--ink-faint);
-		font-size: 0.82em;
-	}
-
-	/* STATS */
-	.stats {
-		max-width: 1080px;
-		margin: 0 auto;
-		padding: 0 clamp(1rem, 4vw, 2.5rem) clamp(2rem, 4vh, 3rem);
-		display: grid;
-		grid-template-columns: repeat(4, minmax(0, 1fr));
-		gap: 0.7rem;
-	}
-
-	.stat {
-		background: var(--bg);
-		border: 1px solid var(--rule);
-		border-radius: 6px;
-		padding: 1.05rem 1.2rem 1.2rem;
-		display: flex;
-		flex-direction: column;
-		gap: 0.5rem;
-	}
-
-	.stat-k {
-		font-family: 'JetBrains Mono', monospace;
-		font-size: 0.7rem;
-		letter-spacing: 0.06em;
-		text-transform: uppercase;
-		color: var(--ink-soft);
-	}
-
-	.stat-n {
-		font-family: 'Hanken Grotesk', sans-serif;
-		font-weight: 800;
-		font-size: clamp(1.9rem, 3vw, 2.5rem);
-		line-height: 1;
-		letter-spacing: -0.03em;
-		color: var(--ink);
-		font-variant-numeric: tabular-nums;
-		display: inline-flex;
-		align-items: baseline;
-	}
-
-	.stat-x {
-		font-family: 'JetBrains Mono', monospace;
-		font-weight: 500;
-		font-size: 0.42em;
-		margin-left: 0.18em;
-		color: var(--ink-faint);
-		letter-spacing: 0.04em;
-	}
-
-	.stat-s {
-		font-size: 0.82rem;
-		color: var(--ink-soft);
-	}
-
-	/* CHART */
-	.chart {
-		max-width: 1080px;
-		margin: 0 auto;
-		padding: 0 clamp(1rem, 4vw, 2.5rem);
-	}
-
-	.chart-head {
-		display: flex;
-		align-items: center;
-		justify-content: space-between;
-		gap: 1rem;
-		flex-wrap: wrap;
-		padding: 0 0.1rem 1rem;
-	}
-
-	.chart-head-meta {
-		display: flex;
-		flex-direction: column;
-		gap: 0.25rem;
-	}
-
-	.chart-title {
-		font-family: 'Hanken Grotesk', sans-serif;
-		font-weight: 700;
-		font-size: clamp(1.2rem, 2.2vw, 1.5rem);
-		line-height: 1.1;
-		letter-spacing: -0.015em;
-		color: var(--ink);
-		margin: 0;
-	}
-
-	.chart-sub {
-		font-family: 'JetBrains Mono', monospace;
-		font-size: 0.72rem;
-		color: var(--ink-soft);
-		margin: 0;
-	}
-
-	.task-groups {
-		display: flex;
-		flex-direction: column;
-		gap: 1.6rem;
-	}
-
-	.task-group {
-		display: flex;
-		flex-direction: column;
-		gap: 0.7rem;
-	}
-
-	.task-group-head {
-		display: flex;
-		align-items: baseline;
-		gap: 0.6rem;
-		flex-wrap: wrap;
-		padding-bottom: 0.5rem;
-		border-bottom: 1px solid var(--rule);
-	}
-
-	.task-group-title {
-		font-size: 0.95rem;
-		font-weight: 600;
-		letter-spacing: -0.01em;
-	}
-
-	.task-group-sub {
-		font-size: 0.78rem;
-		color: var(--ink-faint);
-	}
-
-	/* Responsive grid: as many ~26rem columns as fit, collapsing to a single
-	   column on narrow / mobile viewports. Halves the scroll on desktop. */
-	.task-grid {
-		display: grid;
-		grid-template-columns: repeat(auto-fit, minmax(min(100%, 26rem), 1fr));
-		gap: 1rem;
-		align-items: start;
-	}
-
-	.task-panel {
-		background: var(--bg);
-		border: 1px solid var(--rule);
-		border-radius: 6px;
-		overflow: hidden;
-	}
-
-	.task-panel-head {
-		display: flex;
-		align-items: baseline;
-		justify-content: space-between;
-		gap: 1rem;
-		flex-wrap: wrap;
-		padding: 0.9rem 1.2rem;
-		background: var(--paper);
-		border-bottom: 1px solid var(--rule);
-	}
-
-	.task-panel-meta {
-		display: flex;
-		flex-direction: column;
-		gap: 0.18rem;
-	}
-
-	.task-panel-label {
-		font-family: 'Hanken Grotesk', sans-serif;
-		font-weight: 700;
-		font-size: 0.98rem;
-		color: var(--ink);
-		letter-spacing: -0.005em;
-	}
-
-	.task-panel-sub {
-		font-family: 'JetBrains Mono', monospace;
-		font-size: 0.7rem;
-		color: var(--ink-faint);
-	}
-
-	.task-panel-speedup {
-		display: inline-flex;
-		align-items: baseline;
-		gap: 0.4rem;
-		font-family: 'JetBrains Mono', monospace;
-		font-size: 0.72rem;
-		color: var(--ink-soft);
-	}
-
-	.task-panel-speedup-k {
-		color: var(--ink-faint);
-		letter-spacing: 0.04em;
-	}
-
-	.task-panel-speedup-n {
-		font-family: 'Hanken Grotesk', sans-serif;
-		font-weight: 700;
-		font-size: 0.95rem;
-		color: var(--rust);
-		font-variant-numeric: tabular-nums;
-		display: inline-flex;
-		align-items: baseline;
-	}
-
-	.task-panel-speedup-n .x {
-		font-family: 'JetBrains Mono', monospace;
-		font-weight: 500;
-		font-size: 0.72em;
-		margin-left: 0.06em;
-		color: var(--rust);
-		opacity: 0.75;
-	}
-
-	.task-panel-speedup-sep {
-		color: var(--ink-faint);
-	}
-
-	.task-panel-speedup-st {
-		font-family: 'JetBrains Mono', monospace;
-		font-size: 0.74rem;
-		color: var(--ink-soft);
-	}
-
-	.replay {
-		align-self: center;
-		background: transparent;
-		border: 1px solid var(--rule-strong);
-		color: var(--ink);
-		padding: 0.45rem 0.85rem;
-		border-radius: 4px;
-		font-family: 'JetBrains Mono', monospace;
-		font-size: 0.76rem;
-		cursor: pointer;
-		display: inline-flex;
-		align-items: center;
-		gap: 0.4rem;
-		transition: border-color 0.18s, background 0.18s;
-	}
-
-	.replay:hover:not(:disabled) {
-		border-color: var(--ink);
-		background: var(--paper);
-	}
-
-	.replay:disabled {
-		opacity: 0.5;
-		cursor: not-allowed;
-	}
-
-	.bars {
-		padding: 1.1rem 1.2rem 1.2rem;
-		display: flex;
-		flex-direction: column;
-		gap: 1rem;
-	}
-
-	.bar-row {
-		display: grid;
-		grid-template-columns: minmax(11rem, 12rem) 1fr;
-		gap: 1.2rem;
-		align-items: center;
-	}
-
-	.bar-meta {
-		display: flex;
-		flex-direction: column;
-		gap: 0.15rem;
-	}
-
-	.bar-name {
-		font-family: 'JetBrains Mono', monospace;
-		font-size: 0.82rem;
-		font-weight: 500;
-		color: var(--ink);
-	}
-
-	.bar-sub {
-		font-family: 'JetBrains Mono', monospace;
-		font-size: 0.66rem;
-		color: var(--ink-faint);
-	}
-
-	.bar-graph {
-		display: grid;
-		grid-template-columns: 1fr auto;
-		gap: 0.85rem;
-		align-items: center;
-	}
-
-	.bar-track {
-		display: block;
-		height: 12px;
-		background: var(--paper);
-		border: 1px solid var(--rule);
-		border-radius: 999px;
-		overflow: hidden;
-	}
-
-	.bar-fill {
-		display: block;
-		height: 100%;
-		border-radius: inherit;
-		transition: width 60ms linear;
-	}
-
-	.bar-js {
-		background: linear-gradient(90deg, color-mix(in srgb, var(--ink-faint) 70%, transparent), var(--ink-faint));
-	}
-
-	.bar-rs {
-		background: linear-gradient(90deg, var(--rust-soft), var(--rust));
-	}
-
-	.bar-rm {
-		background: linear-gradient(90deg, var(--rust-soft), var(--svelte));
-	}
-
-	.bar-time {
-		font-family: 'JetBrains Mono', monospace;
-		font-size: 0.84rem;
-		color: var(--ink);
-		font-variant-numeric: tabular-nums;
-		min-width: 5.5rem;
-		text-align: right;
-	}
-
-	/* REPRO */
-	.repro {
-		max-width: 1080px;
-		margin: 0 auto;
-		padding: clamp(3.5rem, 7vh, 5rem) clamp(1rem, 4vw, 2.5rem) clamp(4rem, 8vh, 6rem);
-	}
-
-	.diff {
+	.command {
 		max-width: 720px;
-		background: var(--paper);
-		border: 1px solid var(--rule);
-		border-radius: 6px;
+	}
+
+	.visually-hidden {
+		position: absolute;
+		width: 1px;
+		height: 1px;
+		padding: 0;
+		margin: -1px;
 		overflow: hidden;
-		font-family: 'JetBrains Mono', monospace;
+		clip: rect(0 0 0 0);
+		white-space: nowrap;
+		border: 0;
 	}
 
-	.diff figcaption {
-		display: flex;
-		justify-content: space-between;
-		align-items: center;
-		padding: 0.65rem 1rem;
-		border-bottom: 1px solid var(--rule);
-		font-size: 0.72rem;
-		color: var(--ink-faint);
-		letter-spacing: 0.04em;
-	}
+	@media (max-width: 760px) {
+		.report {
+			padding-top: 2rem;
+		}
 
-	.diff-file {
-		color: var(--ink-soft);
-	}
-
-	.diff pre {
-		margin: 0;
-		padding: 1rem 1.2rem;
-		font-size: 0.85rem;
-		line-height: 1.7;
-	}
-
-	/* EMPTY */
-	.empty {
-		max-width: 1080px;
-		margin: 0 auto;
-		padding: clamp(4rem, 10vh, 7rem) clamp(1rem, 4vw, 2.5rem);
-	}
-
-	.empty h1 {
-		font-family: 'Hanken Grotesk', sans-serif;
-		font-weight: 700;
-		font-size: clamp(2rem, 4.6vw, 3rem);
-		line-height: 1.05;
-		letter-spacing: -0.025em;
-		color: var(--ink);
-		margin: 0 0 1rem;
-	}
-
-	.empty .lede {
-		font-size: 1.05rem;
-		color: var(--ink-soft);
-		max-width: 56ch;
-		margin: 0 0 1.5rem;
-	}
-
-	.empty-code {
-		max-width: 640px;
-		background: var(--paper);
-		border: 1px solid var(--rule);
-		border-radius: 6px;
-		padding: 1rem 1.2rem;
-		font-family: 'JetBrains Mono', monospace;
-		font-size: 0.85rem;
-		color: var(--ink);
-		line-height: 1.7;
-		overflow-x: auto;
-	}
-
-	/* RESPONSIVE */
-	@media (max-width: 880px) {
-		.stats {
+		.metadata {
 			grid-template-columns: repeat(2, minmax(0, 1fr));
 		}
-	}
 
-	@media (max-width: 640px) {
-		.stats {
-			grid-template-columns: 1fr;
+		.group-heading {
+			display: block;
 		}
-		.bar-row {
-			grid-template-columns: 1fr;
-			gap: 0.5rem;
-		}
-		.bar-meta {
-			flex-direction: row;
-			align-items: baseline;
-			gap: 0.6rem;
-		}
-		.chart-head {
-			flex-direction: column;
-			align-items: flex-start;
-		}
-		.replay {
-			align-self: flex-end;
-		}
-		.task-panel-head {
-			flex-direction: column;
-			align-items: flex-start;
-		}
-	}
 
-	@media (prefers-reduced-motion: reduce) {
-		.bar-fill {
-			transition: none !important;
+		.group-heading p {
+			margin-top: 0.2rem;
 		}
 	}
 </style>

--- a/apps/playground/src/routes/docs/+page.svelte
+++ b/apps/playground/src/routes/docs/+page.svelte
@@ -1,54 +1,132 @@
 <script lang="ts">
 	import { base } from '$app/paths';
 	import { GUIDES } from '$lib/docs';
-	import SiteNav from '$lib/components/SiteNav.svelte';
+	import CodeBlock from '$lib/components/CodeBlock.svelte';
+	import DocsSidebar from '$lib/components/DocsSidebar.svelte';
+	import DocsToc from '$lib/components/DocsToc.svelte';
 	import SiteFooter from '$lib/components/SiteFooter.svelte';
-	import Eyebrow from '$lib/components/Eyebrow.svelte';
+	import SiteNav from '$lib/components/SiteNav.svelte';
+
+	const toc = [
+		{ label: 'Choosing a package', href: '#choosing-a-package' },
+		{ label: 'Migration', href: '#migration' },
+		{ label: 'Runtime environments', href: '#runtime-environments' },
+	];
+
+	const migration = `- import { compile } from 'svelte/compiler';
++ import { compile } from '@rsvelte/compiler';`;
+
+	const packageUses: Record<string, string> = {
+		compiler: 'Compile Svelte components for client and server.',
+		svelte2tsx: 'Generate TypeScript shadow files from Svelte components.',
+		fmt: 'Format .svelte files.',
+		'svelte-check': 'Type-check Svelte projects from the command line.',
+		'vite-plugin-svelte': 'Compile Svelte applications with Vite.',
+	};
 </script>
 
 <svelte:head>
-	<title>Docs · rsvelte</title>
+	<title>Overview · rsvelte</title>
 	<meta
 		name="description"
-		content="Usage guides for the rsvelte packages — the compiler, svelte2tsx, the formatter, svelte-check and the Vite plugin."
+		content="An overview of the rsvelte compiler, formatter, type-checker, and Vite integration packages."
 	/>
 </svelte:head>
 
 <div class="page">
 	<SiteNav active="docs" />
 
-	<main class="wrap">
-		<header class="head">
-			<Eyebrow gap="0.6rem" fontSize="0.72rem" letterSpacing="0.06em" ruleWidth="20px"
-				>Documentation</Eyebrow
-			>
-			<h1 class="title">Guides</h1>
-			<p class="lede">
-				One guide per core package in the rsvelte toolchain — install, API, examples and flags.
-				Three of them (compiler, svelte2tsx, fmt) also run live in the
-				<a href="{base}/playground">playground</a>.
-			</p>
-		</header>
+	<div class="docs-shell">
+		<DocsSidebar current="overview" />
 
-		<div class="grid">
-			{#each GUIDES as guide (guide.id)}
-				<a class="card" href="{base}/docs/{guide.id}">
-					<div class="card-head">
-						<h2 class="card-title">{guide.title}</h2>
-						{#if guide.runnable}
-							<span class="badge run">runs in browser</span>
-						{:else}
-							<span class="badge cli">CLI only</span>
-						{/if}
+		<main class="article">
+			<nav class="breadcrumbs" aria-label="Breadcrumb">
+				<a href="{base}/">Documentation</a>
+				<span aria-hidden="true">/</span>
+				<span>Overview</span>
+			</nav>
+
+			<header class="article-head">
+				<h1>Overview</h1>
+				<p class="lead">
+					rsvelte is split into packages that correspond to the standard Svelte development tools.
+				</p>
+			</header>
+
+			<p>
+				Start with the compiler or Vite plugin for application builds. The formatter,
+				<code>svelte2tsx</code>, and <code>svelte-check</code> packages can be adopted separately.
+			</p>
+
+			<section id="choosing-a-package">
+				<h2>Choosing a package</h2>
+				<div class="table-wrap">
+					<table>
+						<thead>
+							<tr>
+								<th>Tool</th>
+								<th>Use it for</th>
+								<th>Package</th>
+							</tr>
+						</thead>
+						<tbody>
+							{#each GUIDES as guide (guide.id)}
+								<tr>
+									<td><a href="{base}/docs/{guide.id}">{guide.title}</a></td>
+									<td>{packageUses[guide.id]}</td>
+									<td><code>{guide.pkg}</code></td>
+								</tr>
+							{/each}
+						</tbody>
+					</table>
+				</div>
+			</section>
+
+			<section id="migration">
+				<h2>Migration</h2>
+				<p>
+					The packages follow their upstream interfaces. In many cases migration is limited to the
+					package name:
+				</p>
+				<CodeBlock code={migration} lang="diff" />
+				<p>
+					Read the package guide before switching a production project. It documents environment
+					setup and any APIs that are specific to the rsvelte distribution.
+				</p>
+			</section>
+
+			<section id="runtime-environments">
+				<h2>Runtime environments</h2>
+				<dl class="environment-list">
+					<div>
+						<dt>Node.js</dt>
+						<dd>Native NAPI packages are used by the Vite plugin and command-line tools.</dd>
 					</div>
-					<code class="pkg">{guide.pkg}</code>
-					<p class="blurb">{guide.tagline}</p>
-					<p class="dropin">drop-in for <code>{guide.dropInFor}</code></p>
-					<span class="more">Read guide →</span>
+					<div>
+						<dt>Browser</dt>
+						<dd>The compiler, formatter, linter, and svelte2tsx are available through WebAssembly.</dd>
+					</div>
+					<div>
+						<dt>Native</dt>
+						<dd>A stable C ABI is available for integrations outside the JavaScript ecosystem.</dd>
+					</div>
+				</dl>
+			</section>
+
+			<nav class="page-nav" aria-label="Documentation pages">
+				<a href="{base}/">
+					<span>Previous</span>
+					<strong>← Introduction</strong>
 				</a>
-			{/each}
-		</div>
-	</main>
+				<a href="{base}/docs/compiler">
+					<span>Next</span>
+					<strong>Compiler →</strong>
+				</a>
+			</nav>
+		</main>
+
+		<DocsToc items={toc} />
+	</div>
 
 	<SiteFooter />
 </div>
@@ -60,127 +138,197 @@
 		flex-direction: column;
 	}
 
-	.wrap {
+	.docs-shell {
 		flex: 1;
 		width: 100%;
-		max-width: 64rem;
+		max-width: 1440px;
 		margin: 0 auto;
-		padding: clamp(1.6rem, 4vh, 2.6rem) clamp(1rem, 4vw, 2rem) 3rem;
-	}
-
-	.title {
-		font-weight: 800;
-		font-size: clamp(2rem, 5vw, 3rem);
-		letter-spacing: -0.03em;
-		color: var(--ink);
-		margin: 0.4rem 0 0.6rem;
-	}
-
-	.lede {
-		font-size: 1.05rem;
-		line-height: 1.65;
-		color: var(--ink-soft);
-		max-width: 44rem;
-		margin: 0;
-	}
-
-	.lede a {
-		color: var(--svelte);
-		border-bottom: 1px solid currentColor;
-	}
-
-	.grid {
-		margin-top: 2.2rem;
 		display: grid;
-		grid-template-columns: repeat(auto-fill, minmax(17rem, 1fr));
-		gap: 1rem;
+		grid-template-columns: 230px minmax(0, 52rem) 200px;
+		justify-content: center;
 	}
 
-	.card {
-		display: flex;
-		flex-direction: column;
-		gap: 0.5rem;
-		padding: 1.1rem 1.1rem 1rem;
-		border: 1px solid var(--rule);
-		border-radius: 8px;
-		background: var(--bg);
-		transition:
-			border-color 0.18s,
-			transform 0.18s,
-			box-shadow 0.18s;
+	.article {
+		min-width: 0;
+		padding: 3rem clamp(2rem, 5vw, 4rem) 5rem;
 	}
 
-	.card:hover {
-		border-color: var(--rule-strong);
-		transform: translateY(-2px);
-		box-shadow: 0 6px 20px -12px rgba(0, 0, 0, 0.25);
-	}
-
-	.card-head {
+	.breadcrumbs {
 		display: flex;
 		align-items: center;
-		justify-content: space-between;
 		gap: 0.5rem;
-	}
-
-	.card-title {
-		font-size: 1.15rem;
-		font-weight: 700;
-		letter-spacing: -0.01em;
-		color: var(--ink);
-		margin: 0;
-	}
-
-	.badge {
-		font-family: 'JetBrains Mono', monospace;
-		font-size: 0.6rem;
-		letter-spacing: 0.04em;
-		text-transform: uppercase;
-		padding: 0.2rem 0.45rem;
-		border-radius: 999px;
-		white-space: nowrap;
-	}
-
-	.badge.run {
-		color: var(--svelte);
-		background: color-mix(in srgb, var(--svelte) 12%, transparent);
-	}
-
-	.badge.cli {
+		margin-bottom: 1.4rem;
+		font-size: 0.78rem;
 		color: var(--ink-faint);
-		background: var(--paper-2);
 	}
 
-	.pkg {
-		font-family: 'JetBrains Mono', monospace;
-		font-size: 0.74rem;
+	.breadcrumbs a {
 		color: var(--ink-soft);
 	}
 
-	.blurb {
-		font-size: 0.88rem;
+	.breadcrumbs a:hover {
+		color: var(--accent);
+	}
+
+	.article-head {
+		padding-bottom: 1rem;
+	}
+
+	h1 {
+		font-size: clamp(2.25rem, 5vw, 3.25rem);
+		font-weight: 700;
+		line-height: 1.12;
+		letter-spacing: -0.035em;
+	}
+
+	.lead {
+		margin-top: 0.8rem;
+		font-size: 1.12rem;
+		line-height: 1.65;
+		color: var(--ink-soft);
+	}
+
+	.article > p,
+	section > p {
+		font-size: 0.98rem;
+		line-height: 1.75;
+		color: var(--ink-soft);
+	}
+
+	.article > p {
+		margin-top: 0.75rem;
+	}
+
+	.article code {
+		font-size: 0.84em;
+	}
+
+	section {
+		padding-top: 2.5rem;
+		scroll-margin-top: 5rem;
+	}
+
+	h2 {
+		margin-bottom: 0.75rem;
+		padding-bottom: 0.45rem;
+		border-bottom: 1px solid var(--rule);
+		font-size: 1.4rem;
+		font-weight: 650;
+		line-height: 1.3;
+		letter-spacing: -0.02em;
+	}
+
+	section :global(.block) {
+		margin: 1rem 0;
+	}
+
+	.table-wrap {
+		overflow-x: auto;
+		border: 1px solid var(--rule);
+		border-radius: 6px;
+	}
+
+	table {
+		width: 100%;
+		border-collapse: collapse;
+		font-size: 0.82rem;
+	}
+
+	th,
+	td {
+		padding: 0.65rem 0.8rem;
+		border-bottom: 1px solid var(--rule);
+		text-align: left;
+		vertical-align: top;
+	}
+
+	th {
+		background: var(--paper);
+		font-size: 0.75rem;
+		font-weight: 650;
+		color: var(--ink);
+	}
+
+	td {
+		line-height: 1.5;
+		color: var(--ink-soft);
+	}
+
+	tbody tr:last-child td {
+		border-bottom: 0;
+	}
+
+	td a {
+		font-weight: 600;
+		color: var(--accent);
+	}
+
+	.environment-list {
+		border-top: 1px solid var(--rule);
+	}
+
+	.environment-list > div {
+		display: grid;
+		grid-template-columns: 8rem minmax(0, 1fr);
+		gap: 1.5rem;
+		padding: 0.8rem 0;
+		border-bottom: 1px solid var(--rule);
+	}
+
+	dt {
+		font-size: 0.9rem;
+		font-weight: 600;
+	}
+
+	dd {
+		font-size: 0.9rem;
 		line-height: 1.55;
 		color: var(--ink-soft);
-		margin: 0;
-		flex: 1;
 	}
 
-	.dropin {
-		font-size: 0.76rem;
-		color: var(--ink-faint);
-		margin: 0;
+	.page-nav {
+		display: grid;
+		grid-template-columns: 1fr 1fr;
+		gap: 2rem;
+		margin-top: 3.5rem;
+		padding-top: 1.25rem;
+		border-top: 1px solid var(--rule);
 	}
 
-	.dropin code {
-		font-family: 'JetBrains Mono', monospace;
+	.page-nav a {
+		display: flex;
+		flex-direction: column;
+		align-items: flex-start;
+	}
+
+	.page-nav a:last-child {
+		align-items: flex-end;
+	}
+
+	.page-nav span {
 		font-size: 0.72rem;
-		color: var(--ink-soft);
+		color: var(--ink-faint);
 	}
 
-	.more {
-		font-size: 0.82rem;
+	.page-nav strong {
+		font-size: 0.88rem;
 		font-weight: 600;
-		color: var(--svelte);
-		margin-top: 0.2rem;
+		color: var(--accent);
+	}
+
+	@media (max-width: 1120px) {
+		.docs-shell {
+			grid-template-columns: 230px minmax(0, 1fr);
+		}
+	}
+
+	@media (max-width: 860px) {
+		.docs-shell {
+			grid-template-columns: 1fr;
+		}
+
+		.article {
+			padding-inline: clamp(1rem, 5vw, 2.5rem);
+		}
 	}
 </style>

--- a/apps/playground/src/routes/playground/+page.svelte
+++ b/apps/playground/src/routes/playground/+page.svelte
@@ -25,7 +25,6 @@
 	import AstViewer from '$lib/components/AstViewer.svelte';
 	import CodeBlock from '$lib/components/CodeBlock.svelte';
 	import SiteNav from '$lib/components/SiteNav.svelte';
-	import Eyebrow from '$lib/components/Eyebrow.svelte';
 
 	let tool = $state<ToolId>('compiler');
 	let input = $state(DEFAULT_EXAMPLE);
@@ -283,16 +282,16 @@
 
 	const lintCount = $derived(lintDiagnostics.length);
 
-	const tabs = $derived<{ id: OutputTab; label: string; sub: string }[]>([
-		{ id: 'result', label: 'Result', sub: 'iframe preview' },
-		{ id: 'js', label: 'JS output', sub: 'compiled .js' },
-		{ id: 'css', label: 'CSS output', sub: 'scoped styles' },
-		{ id: 'ast', label: 'AST', sub: 'svelte AST · JSON' }
+	const tabs = $derived<{ id: OutputTab; label: string }[]>([
+		{ id: 'result', label: 'Result' },
+		{ id: 'js', label: 'JavaScript' },
+		{ id: 'css', label: 'CSS' },
+		{ id: 'ast', label: 'AST' }
 	]);
 
 	const cliFor = (id: ToolId): { lang: string; code: string } => {
 		if (id === 'svelte-check') {
-			return { lang: 'bash', code: 'npm i -D @rsvelte/svelte-check\nrsvelte-check --watch' };
+			return { lang: 'bash', code: 'pnpm add -D @rsvelte/svelte-check\nrsvelte-check --watch' };
 		}
 		return {
 			lang: 'js',
@@ -313,54 +312,49 @@
 	<SiteNav active="playground" />
 
 	<header class="play-head">
-		<div class="play-head-l">
-			<Eyebrow gap="0.6rem" fontSize="0.7rem" letterSpacing="0.1em" ruleWidth="20px"
-				>Live · WASM-compiled</Eyebrow
-			>
+		<div class="play-summary">
+			<nav class="breadcrumbs" aria-label="Breadcrumb">
+				<a href="{base}/">Documentation</a><span>/</span><span>Playground</span>
+			</nav>
 			<h1 class="title">Playground</h1>
-			{#if version}
-				<span class="version">v{version}</span>
-			{/if}
+			<p class="play-description">
+				Edit a Svelte component and inspect the generated output.{#if version}
+					<span class="version">rsvelte {version}</span>{/if}
+			</p>
 		</div>
 
-		<div class="head-r">
-			<div class="tool-switch" role="tablist" aria-label="Tool">
-				{#each TOOLS as t (t.id)}
-					<button
-						role="tab"
-						aria-selected={tool === t.id}
-						class:active={tool === t.id}
-						class:muted={!t.runnable}
-						title={t.tagline}
-						onclick={() => selectTool(t.id)}
-					>
-						{t.label}
-						{#if !t.runnable}<span class="cli-dot" aria-hidden="true">CLI</span>{/if}
-					</button>
-				{/each}
-			</div>
+		{#if currentTool.runnable}
+			<button
+				class="share"
+				class:copied
+				onclick={copyShareLink}
+				title="Copy a link to this code"
+			>
+				{copied ? 'Link copied' : 'Share'}
+			</button>
+		{/if}
 
-			{#if currentTool.runnable}
+		<div class="tool-switch" role="tablist" aria-label="Tool">
+			{#each TOOLS as t (t.id)}
 				<button
-					class="share"
-					class:copied
-					onclick={copyShareLink}
-					title="Copy a link to this code"
+					role="tab"
+					aria-selected={tool === t.id}
+					class:active={tool === t.id}
+					class:muted={!t.runnable}
+					title={t.tagline}
+					onclick={() => selectTool(t.id)}
 				>
-					{copied ? 'Link copied' : 'Share'}
+					{t.label}
 				</button>
-			{/if}
+			{/each}
 		</div>
 	</header>
 
 	{#if currentTool.runnable}
 		<main class="workspace">
-			<!-- LEFT — source editor -->
 			<section class="panel panel-input">
 				<header class="panel-head">
-					<span class="panel-num">01</span>
-					<h2 class="panel-title">Source <em>.svelte</em></h2>
-					<span class="panel-meta">debounced 300 ms</span>
+					<h2 class="panel-title">App.svelte</h2>
 				</header>
 				<div class="panel-body editor-host">
 					{#if wasmReady}
@@ -376,7 +370,6 @@
 				</div>
 			</section>
 
-			<!-- RIGHT — output, depends on the active tool -->
 			<section class="panel panel-output">
 				{#if tool === 'compiler'}
 					<header class="panel-head tab-head" role="tablist" aria-label="Output tab">
@@ -388,8 +381,7 @@
 								aria-selected={activeTab === t.id}
 								onclick={() => (activeTab = t.id)}
 							>
-								<span class="tab-label">{t.label}</span>
-								<span class="tab-sub">{t.sub}</span>
+								{t.label}
 							</button>
 						{/each}
 						<div class="head-aside" role="radiogroup" aria-label="Compilation mode">
@@ -403,8 +395,7 @@
 					</header>
 				{:else if tool === 'svelte2tsx'}
 					<header class="panel-head">
-						<span class="panel-num">02</span>
-						<h2 class="panel-title">TSX <em>shadow</em></h2>
+						<h2 class="panel-title">TSX output</h2>
 						<div class="head-aside">
 							<button class:active={tsxMode === 'ts'} onclick={() => (tsxMode = 'ts')}>ts</button>
 							<button class:active={tsxMode === 'dts'} onclick={() => (tsxMode = 'dts')}>
@@ -414,16 +405,14 @@
 					</header>
 				{:else if tool === 'fmt'}
 					<header class="panel-head">
-						<span class="panel-num">02</span>
-						<h2 class="panel-title">Formatted <em>output</em></h2>
+						<h2 class="panel-title">Formatted source</h2>
 						<button class="apply" disabled={!fmtChanged} onclick={applyFormatted}>
 							Apply to source
 						</button>
 					</header>
 				{:else if tool === 'lint'}
 					<header class="panel-head">
-						<span class="panel-num">02</span>
-						<h2 class="panel-title">Lint <em>diagnostics</em></h2>
+						<h2 class="panel-title">Lint diagnostics</h2>
 						<span class="panel-meta">{lintCount === 1 ? '1 finding' : `${lintCount} findings`}</span>
 					</header>
 				{/if}
@@ -528,43 +517,27 @@
 
 				<footer class="panel-foot">
 					{#if tool === 'compiler'}
-						<span>
-							<span class="dim">compile</span>
-							<strong>{stats.compileTime.toFixed(2)}<span class="unit">ms</span></strong>
-						</span>
-						<span>
-							<span class="dim">js</span>
-							<strong>{formatBytes(stats.outputSize)}</strong>
-						</span>
+						<span>Compile: {stats.compileTime.toFixed(2)} ms</span>
+						<span>Output: {formatBytes(stats.outputSize)}</span>
 					{:else if tool === 'svelte2tsx'}
-						<span><span class="dim">props</span> <strong>{tsxNames.length}</strong></span>
+						<span>{tsxNames.length} exported {tsxNames.length === 1 ? 'prop' : 'props'}</span>
 					{:else if tool === 'fmt'}
-						<span>
-							<span class="dim">status</span>
-							<strong>{fmtChanged ? 'reformatted' : 'already formatted'}</strong>
-						</span>
+						<span>{fmtChanged ? 'Formatting changes available' : 'Source is formatted'}</span>
 						{#if fmtVersion}
-							<span><span class="dim">format</span> <strong>v{fmtVersion}</strong></span>
+							<span>Formatter {fmtVersion}</span>
 						{/if}
-						<span class="note">&lt;style&gt; left verbatim in-browser</span>
 					{:else if tool === 'lint'}
-						<span><span class="dim">findings</span> <strong>{lintCount}</strong></span>
+						<span>{lintCount} {lintCount === 1 ? 'finding' : 'findings'}</span>
 					{/if}
 					<span class="grow"></span>
-					<span class="status-dot" class:ok={wasmReady && !error} class:err={!!error}></span>
-					<span class="status-text">
-						{#if !wasmReady}Initialising{:else if error}Error{:else}Live{/if}
-					</span>
+					<span>{#if !wasmReady}Loading{:else if error}Error{:else}Ready{/if}</span>
 				</footer>
 			</section>
 		</main>
 	{:else}
-		<!-- Non-runnable tools: explain why and link the guide + CLI -->
 		<main class="explainer">
 			<div class="explain-card">
-				<Eyebrow gap="0.6rem" fontSize="0.7rem" letterSpacing="0.1em" ruleWidth="20px"
-					>{currentTool.pkg}</Eyebrow
-				>
+				<p class="package-name">{currentTool.pkg}</p>
 				<h2 class="explain-title">{currentTool.label} can't run in a browser</h2>
 				<p class="explain-body">{currentTool.cantRunReason}</p>
 				<div class="explain-actions">
@@ -590,60 +563,71 @@
 		font-family: 'JetBrains Mono', ui-monospace, 'SF Mono', Menlo, monospace;
 	}
 
-	/* PAGE HEAD */
 	.play-head {
-		max-width: 100%;
+		max-width: 1440px;
 		margin: 0 auto;
 		width: 100%;
-		padding: clamp(1.4rem, 3vh, 2rem) clamp(1rem, 3vw, 2rem) clamp(0.8rem, 2vh, 1.2rem);
-		display: flex;
-		align-items: center;
-		justify-content: space-between;
-		flex-wrap: wrap;
-		gap: 1.2rem;
-	}
-
-	.play-head-l {
-		display: flex;
-		align-items: baseline;
-		gap: 1rem;
-		flex-wrap: wrap;
+		box-sizing: border-box;
+		padding: 2.75rem clamp(1rem, 3vw, 2rem) 1rem;
+		display: grid;
+		grid-template-columns: minmax(0, 1fr) auto;
+		align-items: end;
+		gap: 1rem 2rem;
 	}
 
 	.title {
-		font-family: 'Hanken Grotesk', sans-serif;
-		font-weight: 800;
-		font-size: clamp(1.5rem, 2.5vw, 2rem);
-		letter-spacing: -0.025em;
+		font-family: var(--font-ui);
+		font-weight: 700;
+		font-size: clamp(2rem, 4vw, 2.75rem);
+		line-height: 1.15;
+		letter-spacing: -0.035em;
 		color: var(--ink);
 		margin: 0;
 	}
 
-	.version {
-		font-family: 'JetBrains Mono', monospace;
-		font-size: 0.74rem;
-		color: var(--rust);
-		padding: 0.2rem 0.5rem;
-		border: 1px solid currentColor;
-		border-radius: 2px;
-		line-height: 1;
+	.play-description {
+		max-width: 68ch;
+		margin: 0.7rem 0 0;
+		font-size: 1rem;
+		line-height: 1.65;
+		color: var(--ink-soft);
 	}
 
-	.head-r {
-		display: inline-flex;
+	.breadcrumbs {
+		display: flex;
+		gap: 0.45rem;
 		align-items: center;
-		gap: 0.6rem;
-		flex-wrap: wrap;
+		margin-bottom: 1.4rem;
+		font-size: 0.8rem;
+		color: var(--ink-faint);
 	}
 
-	/* SHARE */
+	.breadcrumbs a {
+		color: var(--ink-soft);
+		text-decoration: none;
+	}
+
+	.breadcrumbs a:hover {
+		color: var(--accent);
+		text-decoration: underline;
+	}
+
+	.version {
+		margin-left: 0.55rem;
+		font-family: var(--font-code);
+		font-size: 0.72rem;
+		color: var(--ink-faint);
+	}
+
 	.share {
-		font-family: 'JetBrains Mono', monospace;
-		font-size: 0.76rem;
-		padding: 0.45rem 0.85rem;
+		grid-column: 2;
+		grid-row: 1;
+		font-family: var(--font-ui);
+		font-size: 0.78rem;
+		padding: 0.42rem 0.8rem;
 		border: 1px solid var(--rule-strong);
-		border-radius: 6px;
-		background: var(--paper);
+		border-radius: 4px;
+		background: var(--bg);
 		color: var(--ink-soft);
 		cursor: pointer;
 		white-space: nowrap;
@@ -663,32 +647,28 @@
 		border-color: var(--ok);
 	}
 
-	/* TOOL SWITCHER */
 	.tool-switch {
-		display: inline-flex;
-		flex-wrap: wrap;
-		gap: 0.3rem;
-		padding: 0.25rem;
-		border: 1px solid var(--rule-strong);
-		border-radius: 6px;
-		background: var(--paper);
+		grid-column: 1 / -1;
+		display: grid;
+		grid-template-columns: repeat(6, minmax(0, 1fr));
+		gap: 0;
+		width: 100%;
+		border-bottom: 1px solid var(--rule);
 	}
 
 	.tool-switch button {
-		display: inline-flex;
-		align-items: center;
-		gap: 0.4rem;
-		font-family: 'JetBrains Mono', monospace;
-		font-size: 0.76rem;
-		padding: 0.4rem 0.7rem;
+		font-family: var(--font-ui);
+		font-size: 0.78rem;
+		font-weight: 500;
+		padding: 0.45rem 0.7rem;
 		background: transparent;
 		border: 0;
-		border-radius: 4px;
+		border-bottom: 2px solid transparent;
+		margin-bottom: -1px;
 		color: var(--ink-soft);
 		cursor: pointer;
-		transition:
-			background 0.16s,
-			color 0.16s;
+		text-align: center;
+		white-space: nowrap;
 	}
 
 	.tool-switch button:hover {
@@ -696,29 +676,19 @@
 	}
 
 	.tool-switch button.active {
-		background: var(--bg);
 		color: var(--ink);
-		box-shadow: 0 1px 3px rgba(0, 0, 0, 0.12);
+		border-bottom-color: var(--accent);
 	}
 
-	.tool-switch button.active.muted {
-		color: var(--ink-soft);
-	}
-
-	.cli-dot {
-		font-size: 0.56rem;
-		letter-spacing: 0.06em;
+	.tool-switch button.muted:not(.active) {
 		color: var(--ink-faint);
-		border: 1px solid var(--rule-strong);
-		border-radius: 999px;
-		padding: 0.05rem 0.3rem;
 	}
 
-	/* WORKSPACE — two equal columns, full width */
 	.workspace {
-		max-width: 100%;
+		max-width: 1440px;
 		margin: 0 auto;
 		width: 100%;
+		box-sizing: border-box;
 		padding: 0 clamp(1rem, 3vw, 2rem) clamp(1.5rem, 4vh, 2.5rem);
 		display: grid;
 		grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
@@ -734,7 +704,7 @@
 		min-width: 0;
 		background: var(--bg);
 		border: 1px solid var(--rule);
-		border-radius: 6px;
+		border-radius: 4px;
 		overflow: hidden;
 	}
 
@@ -753,27 +723,14 @@
 		flex-shrink: 0;
 	}
 
-	.panel-num {
-		font-family: 'JetBrains Mono', monospace;
-		font-size: 0.66rem;
-		letter-spacing: 0.16em;
-		color: var(--rust);
-	}
-
 	.panel-title {
-		font-family: 'Hanken Grotesk', sans-serif;
-		font-weight: 700;
+		font-family: var(--font-ui);
+		font-weight: 650;
 		font-size: 0.92rem;
 		letter-spacing: -0.01em;
 		color: var(--ink);
 		margin: 0;
 		flex: 1;
-	}
-
-	.panel-title em {
-		font-style: italic;
-		color: var(--svelte);
-		font-weight: 700;
 	}
 
 	.panel-meta {
@@ -782,7 +739,6 @@
 		color: var(--ink-faint);
 	}
 
-	/* small inline button groups in panel heads (mode / ts-dts) */
 	.head-aside {
 		display: inline-flex;
 		border: 1px solid var(--rule-strong);
@@ -815,8 +771,9 @@
 	}
 
 	.head-aside button.active {
-		background: var(--ink);
-		color: var(--bg);
+		background: var(--paper);
+		box-shadow: inset 0 -2px var(--accent);
+		color: var(--ink);
 	}
 
 	.apply {
@@ -841,7 +798,6 @@
 		cursor: not-allowed;
 	}
 
-	/* RIGHT-PANEL TABS */
 	.tab-head {
 		gap: 0;
 		padding: 0;
@@ -851,22 +807,17 @@
 	.tab {
 		flex: 1;
 		min-width: 0;
-		display: flex;
-		flex-direction: column;
-		gap: 0.12rem;
-		align-items: flex-start;
-		padding: 0.6rem 0.95rem;
+		padding: 0.72rem 0.95rem;
 		background: transparent;
 		border: 0;
 		border-right: 1px solid var(--rule);
 		border-bottom: 1px solid transparent;
+		font-family: var(--font-ui);
+		font-size: 0.8rem;
+		font-weight: 550;
 		color: var(--ink-soft);
 		cursor: pointer;
 		text-align: left;
-		transition:
-			background 0.18s,
-			color 0.18s,
-			border-color 0.18s;
 	}
 
 	.tab:hover {
@@ -878,23 +829,6 @@
 		background: var(--bg);
 		color: var(--ink);
 		border-bottom-color: var(--svelte);
-	}
-
-	.tab-label {
-		font-family: 'Hanken Grotesk', sans-serif;
-		font-weight: 600;
-		font-size: 0.86rem;
-		letter-spacing: -0.005em;
-	}
-
-	.tab-sub {
-		font-family: 'JetBrains Mono', monospace;
-		font-size: 0.62rem;
-		color: var(--ink-faint);
-	}
-
-	.tab.active .tab-sub {
-		color: var(--ink-soft);
 	}
 
 	.tab-head .head-aside {
@@ -1099,56 +1033,15 @@
 		gap: 1rem;
 		padding: 0.55rem 0.9rem;
 		font-family: 'JetBrains Mono', monospace;
-		font-size: 0.76rem;
-		color: var(--ink);
+		font-size: 0.7rem;
+		color: var(--ink-soft);
 		background: var(--paper);
 		border-top: 1px solid var(--rule);
 		flex-shrink: 0;
 	}
 
-	.panel-foot .dim {
-		color: var(--ink-faint);
-		margin-right: 0.4em;
-	}
-
-	.panel-foot strong {
-		font-weight: 600;
-		color: var(--ink);
-	}
-
-	.panel-foot .note {
-		color: var(--ink-faint);
-		font-size: 0.7rem;
-	}
-
-	.unit {
-		font-weight: 400;
-		color: var(--ink-soft);
-		margin-left: 0.15em;
-	}
-
 	.grow {
 		flex: 1;
-	}
-
-	.status-dot {
-		display: inline-block;
-		width: 7px;
-		height: 7px;
-		border-radius: 999px;
-		background: var(--ink-faint);
-	}
-
-	.status-dot.ok {
-		background: var(--ok);
-	}
-
-	.status-dot.err {
-		background: var(--bad);
-	}
-
-	.status-text {
-		color: var(--ink-soft);
 	}
 
 	/* NON-RUNNABLE TOOL EXPLAINER */
@@ -1163,19 +1056,23 @@
 	.explain-card {
 		width: 100%;
 		max-width: 40rem;
-		border: 1px solid var(--rule);
-		border-radius: 10px;
-		background: var(--bg);
-		padding: clamp(1.4rem, 3vw, 2.2rem);
+		padding: clamp(1rem, 3vw, 2rem) 0;
+	}
+
+	.package-name {
+		margin: 0 0 0.55rem;
+		font-family: var(--font-code);
+		font-size: 0.75rem;
+		color: var(--ink-faint);
 	}
 
 	.explain-title {
-		font-family: 'Hanken Grotesk', sans-serif;
-		font-weight: 800;
+		font-family: var(--font-ui);
+		font-weight: 700;
 		font-size: clamp(1.3rem, 3vw, 1.7rem);
 		letter-spacing: -0.02em;
 		color: var(--ink);
-		margin: 0.5rem 0 0.7rem;
+		margin: 0 0 0.7rem;
 	}
 
 	.explain-body {
@@ -1209,6 +1106,10 @@
 
 	/* RESPONSIVE */
 	@media (max-width: 880px) {
+		.tool-switch {
+			grid-template-columns: repeat(3, minmax(0, 1fr));
+		}
+
 		.workspace {
 			grid-template-columns: 1fr;
 		}
@@ -1222,6 +1123,16 @@
 		.tab {
 			flex: 1 1 50%;
 			border-bottom: 1px solid var(--rule);
+		}
+	}
+
+	@media (max-width: 520px) {
+		.play-head {
+			grid-template-columns: minmax(0, 1fr) auto;
+		}
+
+		.tool-switch {
+			grid-template-columns: repeat(2, minmax(0, 1fr));
 		}
 	}
 </style>

--- a/apps/playground/src/routes/progress/+page.svelte
+++ b/apps/playground/src/routes/progress/+page.svelte
@@ -1,12 +1,9 @@
 <script lang="ts">
 	import { base } from '$app/paths';
 	import type { PageData } from './$types';
-	import type { TestCase } from '$lib/types/test-results';
-	import SiteNav from '$lib/components/SiteNav.svelte';
+	import CodeBlock from '$lib/components/CodeBlock.svelte';
 	import SiteFooter from '$lib/components/SiteFooter.svelte';
-	import Eyebrow from '$lib/components/Eyebrow.svelte';
-	import SectionHead from '$lib/components/SectionHead.svelte';
-	import '$lib/styles/terminal-code.css';
+	import SiteNav from '$lib/components/SiteNav.svelte';
 
 	let { data }: { data: PageData } = $props();
 
@@ -18,29 +15,30 @@
 		selectedCategoryId = selectedCategoryId === categoryId ? null : categoryId;
 	};
 
-	const formatDate = (isoString: string): string => {
-		const date = new Date(isoString);
-		return date.toLocaleString('en-US', {
+	const formatDate = (isoString: string): string =>
+		new Date(isoString).toLocaleString('en-US', {
 			year: 'numeric',
 			month: 'short',
 			day: 'numeric',
 			hour: '2-digit',
 			minute: '2-digit'
 		});
-	};
 
 	const allTests = $derived(
-		(data.results?.categories ?? []).flatMap((cat) =>
-			cat.tests.map((test) => ({
+		(data.results?.categories ?? []).flatMap((category) =>
+			category.tests.map((test) => ({
 				...test,
-				categoryId: cat.id,
-				categoryName: cat.name
+				categoryId: category.id,
+				categoryName: category.name
 			}))
 		)
 	);
 
 	const categoryOptions = $derived(
-		(data.results?.categories ?? []).map((cat) => ({ id: cat.id, name: cat.name }))
+		(data.results?.categories ?? []).map((category) => ({
+			id: category.id,
+			name: category.name
+		}))
 	);
 
 	const filteredTests = $derived(
@@ -49,232 +47,222 @@
 				if (selectedCategoryId && test.categoryId !== selectedCategoryId) return false;
 				if (statusFilter !== 'all' && test.status !== statusFilter) return false;
 				if (searchQuery) {
-					const q = searchQuery.toLowerCase();
-					return test.name.toLowerCase().includes(q) || test.categoryName.toLowerCase().includes(q);
+					const query = searchQuery.toLowerCase();
+					return (
+						test.name.toLowerCase().includes(query) ||
+						test.categoryName.toLowerCase().includes(query)
+					);
 				}
 				return true;
 			})
 			.sort((a, b) => {
 				const order = { fail: 0, skip: 1, pass: 2 };
-				const diff = order[a.status] - order[b.status];
-				if (diff !== 0) return diff;
-				return a.name.localeCompare(b.name);
+				return order[a.status] - order[b.status] || a.name.localeCompare(b.name);
 			})
 	);
 
-	const statusGlyph = (status: TestCase['status']): string =>
-		status === 'pass' ? '●' : status === 'fail' ? '✕' : '○';
+	const filtersActive = $derived(
+		selectedCategoryId !== null || searchQuery.length > 0 || statusFilter !== 'all'
+	);
+
+	const resetFilters = () => {
+		selectedCategoryId = null;
+		searchQuery = '';
+		statusFilter = 'all';
+	};
+
+	const generateData =
+		'cargo run --release -p rsvelte_devtools --bin test_reporter -- --output apps/playground/static/test-results.json';
 </script>
 
 <svelte:head>
 	<title>Compatibility · rsvelte</title>
 	<meta
 		name="description"
-		content="Live compatibility report — every category of the official Svelte test suite run against rsvelte."
+		content="Compatibility results from running the official Svelte test suite against rsvelte."
 	/>
 </svelte:head>
 
 <div class="page">
 	<SiteNav active="progress" />
 
-	{#if data.error}
-		<section class="empty">
-			<Eyebrow marginBottom="1.4rem">Compatibility · unavailable</Eyebrow>
-			<h1>Test results not generated.</h1>
-			<p class="lede">{data.error}</p>
-			<pre class="empty-code"><code
-					><span class="c-cmt"># From the repo root</span>
-<span class="c-prompt">$</span> cargo run <span class="c-flag"
-						>--release -p rsvelte_devtools --bin</span
-					> test_reporter <span class="c-op">--</span> <span class="c-op">\</span>
-    <span class="c-flag">--output</span> apps/playground/static/test-results.json</code
-				></pre>
-		</section>
-	{:else if data.results}
-		{@const r = data.results}
+	<main class="report">
+		{#if data.error}
+			<nav class="breadcrumbs" aria-label="Breadcrumb">
+				<a href="{base}/">Documentation</a><span>/</span><span>Compatibility</span>
+			</nav>
+			<h1>Compatibility data is unavailable</h1>
+			<p class="intro">{data.error}</p>
+			<div class="command"><CodeBlock code={generateData} lang="bash" caption="Terminal" /></div>
+		{:else if data.results}
+			{@const r = data.results}
 
-		<header class="hero">
-			<Eyebrow marginBottom="1.4rem">Compatibility · live report</Eyebrow>
+			<header class="report-header">
+				<nav class="breadcrumbs" aria-label="Breadcrumb">
+					<a href="{base}/">Documentation</a><span>/</span><span>Compatibility</span>
+				</nav>
+				<h1>Compatibility</h1>
+				<p class="intro">
+					Results from running rsvelte against the official Svelte compiler fixtures. Skipped
+					fixtures are outside the current project scope.
+				</p>
 
-			<h1 class="title">
-				<span class="ink-svelte">{Math.round(r.summary.percentage)}%</span> of the official
-				<code>sveltejs/svelte</code> suite, passing.
-			</h1>
-
-			<dl class="hero-meta">
-				<div>
-					<dt>In-scope passing</dt>
-					<dd>
-						<span class="big">{r.summary.passed.toLocaleString('en-US')}</span>
-						<span class="dim"
-							>/ {(r.summary.total - r.summary.skipped).toLocaleString('en-US')}</span
-						>
-					</dd>
-				</div>
-				<div>
-					<dt>Categories</dt>
-					<dd>
-						<span class="big">{r.categories.length}</span>
-						<span class="dim">official suites</span>
-					</dd>
-				</div>
-				{#if r.summary.skipped > 0}
+				<dl class="metadata">
 					<div>
-						<dt>Out of scope</dt>
-						<dd>
-							<span class="big">{r.summary.skipped.toLocaleString('en-US')}</span>
-							<span class="dim">skipped fixtures</span>
-						</dd>
+						<dt>Passing</dt>
+						<dd>{r.summary.passed.toLocaleString('en-US')} / {(r.summary.total - r.summary.skipped).toLocaleString('en-US')}</dd>
 					</div>
-				{/if}
-				<div>
-					<dt>Recorded</dt>
-					<dd class="mono">{formatDate(r.generated_at)}</dd>
-				</div>
-				<div>
-					<dt>Against</dt>
-					<dd class="mono"><code>sveltejs/svelte@{r.commit_sha}</code></dd>
-				</div>
-			</dl>
-		</header>
+					<div>
+						<dt>Compatibility</dt>
+						<dd>{r.summary.percentage.toFixed(1)}%</dd>
+					</div>
+					<div>
+						<dt>Recorded</dt>
+						<dd>{formatDate(r.generated_at)}</dd>
+					</div>
+					<div>
+						<dt>Upstream commit</dt>
+						<dd><code>{r.commit_sha}</code></dd>
+					</div>
+				</dl>
+			</header>
 
-		<section class="spec">
-			<SectionHead
-				num="01"
-				columns={3}
-				padding="clamp(3rem, 7vh, 4.5rem) clamp(1rem, 4vw, 2.5rem) clamp(1.4rem, 3vh, 2rem)"
-			>
-				Every <em>category</em>, verified.
-				{#snippet lede()}
-					<p class="lede">
-						Click any row to filter the fixture list below. Numbers reflect the official Svelte
-						test fixtures run locally against <code>{r.commit_sha}</code>.
-					</p>
-				{/snippet}
-			</SectionHead>
+			<section class="categories" aria-labelledby="categories-heading">
+				<h2 id="categories-heading">Test suites</h2>
+				<p class="section-description">
+					Select a suite to filter the fixture list. Passing counts exclude skipped fixtures.
+				</p>
 
-			<div class="spec-list">
-				{#each r.categories as cat, i (cat.id)}
-					<button
-						class="spec-row"
-						class:active={selectedCategoryId === cat.id}
-						style="--i: {i};"
-						onclick={() => toggleCategory(cat.id)}
-					>
-						<span class="spec-k">{cat.name}</span>
-						<span class="spec-v">
-							<span class="spec-n">
-								{cat.passed}<span class="spec-n-sep">/</span><span class="spec-n-tot"
-									>{cat.total - cat.skipped}</span
+				<div class="table-scroll">
+					<table class="category-table">
+						<caption class="visually-hidden">Compatibility by test suite</caption>
+						<thead>
+							<tr>
+								<th scope="col">Suite</th>
+								<th scope="col">Passing</th>
+								<th scope="col">Skipped</th>
+								<th scope="col">Result</th>
+							</tr>
+						</thead>
+						<tbody>
+							{#each r.categories as category (category.id)}
+								<tr class:selected={selectedCategoryId === category.id}>
+									<th scope="row">
+						<button
+							type="button"
+							class="category-button"
+											aria-pressed={selectedCategoryId === category.id}
+											onclick={() => toggleCategory(category.id)}
+										>
+											{category.name}
+										</button>
+									</th>
+									<td>{category.passed.toLocaleString('en-US')} / {(category.total - category.skipped).toLocaleString('en-US')}</td>
+									<td>{category.skipped ? category.skipped.toLocaleString('en-US') : '—'}</td>
+									<td>
+										<span class:passing={category.failed === 0} class:failing={category.failed > 0}>
+											{category.failed === 0 ? 'Pass' : `${category.failed} failing`}
+										</span>
+									</td>
+								</tr>
+							{/each}
+						</tbody>
+					</table>
+				</div>
+			</section>
+
+			<section class="fixtures" aria-labelledby="fixtures-heading">
+				<div class="fixture-heading">
+					<div>
+						<h2 id="fixtures-heading">Fixtures</h2>
+						<p class="section-description" aria-live="polite">
+							Showing {filteredTests.length.toLocaleString('en-US')} of {allTests.length.toLocaleString('en-US')} fixtures.
+						</p>
+					</div>
+					{#if filtersActive}
+						<button type="button" class="reset-filters" onclick={resetFilters}>Reset filters</button>
+					{/if}
+				</div>
+
+				<div class="filters">
+					<label class="field search">
+						<span>Search</span>
+						<span class="search-control">
+							<svg viewBox="0 0 16 16" aria-hidden="true">
+								<circle cx="7" cy="7" r="4.25"></circle>
+								<path d="m10.25 10.25 3 3"></path>
+							</svg>
+							<input type="search" placeholder="Fixture or suite name" bind:value={searchQuery} />
+						</span>
+					</label>
+					<label class="field suite-select">
+						<span>Suite</span>
+						<span class="select-control">
+							<select bind:value={selectedCategoryId}>
+								<option value={null}>All suites</option>
+								{#each categoryOptions as option (option.id)}
+									<option value={option.id}>{option.name}</option>
+								{/each}
+							</select>
+							<svg class="select-chevron" viewBox="0 0 16 16" aria-hidden="true">
+								<path d="m4 6 4 4 4-4"></path>
+							</svg>
+						</span>
+					</label>
+					<div class="status-filter" role="group" aria-label="Status filter">
+						<span class="filter-label">Status</span>
+						<div class="status-buttons">
+							{#each [
+								{ value: 'all', label: 'All' },
+								{ value: 'pass', label: 'Pass' },
+								{ value: 'fail', label: 'Fail' },
+								{ value: 'skip', label: 'Skipped' }
+							] as option (option.value)}
+								<button
+									type="button"
+									class:active={statusFilter === option.value}
+									aria-pressed={statusFilter === option.value}
+									onclick={() => (statusFilter = option.value as typeof statusFilter)}
 								>
-							</span>
-							<span class="spec-s">
-								{#if cat.skipped > 0}
-									{cat.skipped} skipped — out of scope
-								{:else if cat.percentage >= 100}
-									all fixtures green
-								{:else}
-									{cat.total - cat.passed - cat.skipped} regressions
-								{/if}
-							</span>
-						</span>
-						<span class="spec-bar">
-							<span class="bar-track">
-								<span
-									class="bar-fill"
-									class:warn={cat.percentage < 100 && cat.percentage >= 50}
-									class:bad={cat.percentage < 50}
-									style="width: {Math.max(2, cat.percentage)}%;"
-								></span>
-							</span>
-							<span class="spec-pct">{Math.round(cat.percentage)}<span class="dim">%</span></span>
-						</span>
-					</button>
-				{/each}
-			</div>
-		</section>
-
-		<section class="fixtures">
-			<SectionHead
-				num="02"
-				columns={3}
-				padding="clamp(3rem, 7vh, 4.5rem) clamp(1rem, 4vw, 2.5rem) clamp(1.4rem, 3vh, 2rem)"
-			>
-				The <em>full</em> fixture list.
-				{#snippet lede()}
-					{#if selectedCategoryId}
-						<button class="clear-filter" onclick={() => (selectedCategoryId = null)}>
-							<span aria-hidden="true">←</span> Clear filter
-						</button>
-					{/if}
-				{/snippet}
-			</SectionHead>
-
-			<div class="filters">
-				<label class="search">
-					<span class="search-sigil" aria-hidden="true">⌕</span>
-					<input type="text" placeholder="Filter by name or category…" bind:value={searchQuery} />
-				</label>
-				<label class="cat-select">
-					<span class="cat-select-label">Category</span>
-					<select bind:value={selectedCategoryId}>
-						<option value={null}>All categories</option>
-						{#each categoryOptions as opt (opt.id)}
-							<option value={opt.id}>{opt.name}</option>
-						{/each}
-					</select>
-				</label>
-				<div class="status-tabs">
-					<button class:active={statusFilter === 'all'} onclick={() => (statusFilter = 'all')}
-						>All</button
-					>
-					<button class:active={statusFilter === 'pass'} onclick={() => (statusFilter = 'pass')}
-						><span class="dot pass"></span>Pass</button
-					>
-					<button class:active={statusFilter === 'fail'} onclick={() => (statusFilter = 'fail')}
-						><span class="dot fail"></span>Fail</button
-					>
-					<button class:active={statusFilter === 'skip'} onclick={() => (statusFilter = 'skip')}
-						><span class="dot skip"></span>Skip</button
-					>
-				</div>
-			</div>
-
-			<div class="fix-table">
-				<div class="fix-thead">
-					<span>Fixture</span>
-					<span>Category</span>
-					<span>Status</span>
-				</div>
-				<div class="fix-tbody">
-					{#each filteredTests as test (test.categoryId + '/' + test.name)}
-						<div
-							class="fix-row"
-							class:fail={test.status === 'fail'}
-							class:skip={test.status === 'skip'}
-						>
-							<span class="fix-name" title={test.name}>{test.name}</span>
-							<span class="fix-cat">{test.categoryName}</span>
-							<span class="fix-status">
-								<span class="fix-glyph">{statusGlyph(test.status)}</span>
-								<span>{test.status}</span>
-							</span>
-							{#if test.error_message || test.skip_reason}
-								<p class="fix-msg">{test.error_message || test.skip_reason}</p>
-							{/if}
+									{option.label}
+								</button>
+							{/each}
 						</div>
-					{/each}
-					{#if filteredTests.length === 0}
-						<div class="fix-empty">No fixtures match.</div>
-					{/if}
+					</div>
 				</div>
-				<div class="fix-foot">
-					<span>{filteredTests.length.toLocaleString('en-US')}</span>
-					<span class="dim">/ {allTests.length.toLocaleString('en-US')} fixtures</span>
+
+				<div class="table-scroll fixture-table-wrap">
+					<table class="fixture-table">
+						<caption class="visually-hidden">Filtered fixture compatibility results</caption>
+						<thead>
+							<tr>
+								<th scope="col">Fixture</th>
+								<th scope="col">Suite</th>
+								<th scope="col">Status</th>
+							</tr>
+						</thead>
+						<tbody>
+							{#each filteredTests as test (test.categoryId + '/' + test.name)}
+								<tr>
+									<th scope="row">
+										<span class="fixture-name">{test.name}</span>
+										{#if test.error_message || test.skip_reason}
+											<span class="fixture-message">{test.error_message || test.skip_reason}</span>
+										{/if}
+									</th>
+									<td>{test.categoryName}</td>
+									<td><span class="test-status status-{test.status}">{test.status === 'skip' ? 'Skipped' : test.status === 'pass' ? 'Pass' : 'Fail'}</span></td>
+								</tr>
+							{/each}
+							{#if filteredTests.length === 0}
+								<tr><td class="no-results" colspan="3">No fixtures match these filters.</td></tr>
+							{/if}
+						</tbody>
+					</table>
 				</div>
-			</div>
-		</section>
-	{/if}
+			</section>
+		{/if}
+	</main>
 
 	<SiteFooter />
 </div>
@@ -284,647 +272,445 @@
 		min-height: 100vh;
 	}
 
-	code,
-	pre {
-		font-family: 'JetBrains Mono', ui-monospace, 'SF Mono', Menlo, monospace;
-	}
-
-	.mono {
-		font-family: 'JetBrains Mono', monospace;
-	}
-
-	/* HERO */
-	.hero {
-		max-width: 1080px;
+	.report {
+		width: min(100% - 2rem, 1100px);
 		margin: 0 auto;
-		padding: clamp(3.5rem, 9vh, 5.5rem) clamp(1rem, 4vw, 2.5rem) clamp(2rem, 4vh, 3rem);
+		padding: 2.75rem 0 5rem;
 	}
 
-	.title {
-		font-family: 'Hanken Grotesk', sans-serif;
-		font-weight: 800;
-		font-size: clamp(2rem, 4.6vw, 3.4rem);
-		line-height: 1.06;
-		letter-spacing: -0.025em;
-		color: var(--ink);
-		margin: 0;
-		max-width: 28ch;
-	}
-
-	.title code {
-		font-family: 'JetBrains Mono', monospace;
-		font-size: 0.7em;
-		font-weight: 500;
-		padding: 0.06em 0.42em;
-		background: var(--paper);
-		border: 1px solid var(--rule);
-		border-radius: 4px;
-		color: var(--ink);
-		vertical-align: 0.08em;
-	}
-
-	.ink-svelte {
-		color: var(--svelte);
-		font-style: italic;
-		font-weight: 800;
-	}
-
-	.hero-meta {
+	.breadcrumbs {
 		display: flex;
-		flex-wrap: wrap;
-		gap: 2rem 2.4rem;
-		margin-top: 2rem;
-		padding-top: 1.4rem;
-		border-top: 1px solid var(--rule);
-	}
-
-	.hero-meta > div {
-		display: flex;
-		flex-direction: column;
-		gap: 0.3rem;
-	}
-
-	.hero-meta dt {
-		font-family: 'JetBrains Mono', monospace;
-		font-size: 0.66rem;
-		letter-spacing: 0.14em;
-		text-transform: uppercase;
+		gap: 0.45rem;
+		align-items: center;
+		margin-bottom: 1.4rem;
+		font-size: 0.8rem;
 		color: var(--ink-faint);
 	}
 
-	.hero-meta dd {
-		display: inline-flex;
-		align-items: baseline;
-		gap: 0.45rem;
+	.breadcrumbs a {
+		color: var(--ink-soft);
+		text-decoration: none;
+	}
+
+	.breadcrumbs a:hover {
+		color: var(--accent);
+		text-decoration: underline;
+	}
+
+	h1,
+	h2,
+	p {
+		margin-top: 0;
+	}
+
+	h1 {
+		margin-bottom: 0.7rem;
+		font-size: clamp(2rem, 4vw, 2.75rem);
+		line-height: 1.15;
+		letter-spacing: -0.035em;
+	}
+
+	.intro {
+		max-width: 70ch;
+		margin-bottom: 0;
+		font-size: 1rem;
+		line-height: 1.65;
+		color: var(--ink-soft);
+	}
+
+	.metadata {
+		display: grid;
+		grid-template-columns: repeat(4, minmax(0, 1fr));
+		gap: 1.5rem;
+		margin: 2rem 0 0;
+		padding: 1.1rem 0;
+		border-top: 1px solid var(--rule);
+		border-bottom: 1px solid var(--rule);
+	}
+
+	.metadata dt {
+		margin-bottom: 0.25rem;
+		font-size: 0.75rem;
+		font-weight: 600;
+		color: var(--ink-faint);
+	}
+
+	.metadata dd {
 		margin: 0;
-		font-size: 0.95rem;
+		font-size: 0.82rem;
+		line-height: 1.45;
 		color: var(--ink);
 	}
 
-	.hero-meta .big {
-		font-family: 'Hanken Grotesk', sans-serif;
-		font-weight: 800;
-		font-size: 1.6rem;
-		font-variant-numeric: tabular-nums;
-		line-height: 1;
+	.metadata code,
+	.fixture-message {
+		font-family: var(--font-code);
+	}
+
+	.categories,
+	.fixtures {
+		margin-top: 3.5rem;
+	}
+
+	h2 {
+		margin-bottom: 0.45rem;
+		font-size: 1.45rem;
 		letter-spacing: -0.02em;
 	}
 
-	.hero-meta .dim {
-		font-family: 'JetBrains Mono', monospace;
-		font-size: 0.78rem;
+	.section-description {
+		max-width: 72ch;
+		margin-bottom: 1.25rem;
+		font-size: 0.9rem;
+		line-height: 1.55;
 		color: var(--ink-soft);
 	}
 
-	.hero-meta code {
-		color: var(--rust);
-		font-size: 0.88em;
-	}
-
-	/* SPEC / CATEGORIES */
-	.spec {
-		max-width: 1080px;
-		margin: 0 auto;
-	}
-
-	.spec .lede {
-		font-size: clamp(1rem, 1.2vw, 1.1rem);
-		color: var(--ink-soft);
-		max-width: 64ch;
-	}
-
-	.spec .lede code {
-		font-size: 0.88em;
-		padding: 0.06em 0.4em;
-		background: var(--paper);
+	.table-scroll {
+		overflow-x: auto;
 		border: 1px solid var(--rule);
-		border-radius: 3px;
-		color: var(--rust);
+		border-radius: 6px;
+		background: var(--bg);
 	}
 
-	.spec-list {
-		padding: 0 clamp(1rem, 4vw, 2.5rem) clamp(2.5rem, 5vh, 3.5rem);
-	}
-
-	.spec-row {
-		display: grid;
-		grid-template-columns: minmax(10rem, 14rem) minmax(0, 1fr) minmax(10rem, 14rem);
-		gap: 1.4rem;
-		align-items: baseline;
+	table {
 		width: 100%;
-		padding: 1rem 0;
-		border: 0;
-		border-bottom: 1px solid var(--rule);
-		background: transparent;
-		text-align: left;
-		font: inherit;
-		color: inherit;
-		cursor: pointer;
-		opacity: 0;
-		transform: translateY(6px);
-		animation: rowIn 0.55s cubic-bezier(0.22, 1, 0.36, 1) forwards;
-		animation-delay: calc(0.04s * var(--i, 0) + 0.05s);
-		transition: padding-left 0.2s ease;
-	}
-
-	.spec-row:first-child {
-		border-top: 1px solid var(--rule);
-	}
-
-	.spec-row:hover {
-		padding-left: 0.4rem;
-	}
-
-	.spec-row.active {
-		padding-left: 0.6rem;
-		background: color-mix(in srgb, var(--svelte) 5%, transparent);
-		border-left: 2px solid var(--svelte);
-	}
-
-	@keyframes rowIn {
-		to {
-			opacity: 1;
-			transform: none;
-		}
-	}
-
-	.spec-k {
-		font-weight: 600;
-		font-size: 0.98rem;
-		color: var(--ink);
-		letter-spacing: -0.005em;
-	}
-
-	.spec-v {
-		display: flex;
-		align-items: baseline;
-		gap: 0.85rem;
-		min-width: 0;
-	}
-
-	.spec-n {
-		font-family: 'Hanken Grotesk', sans-serif;
-		font-weight: 700;
-		font-size: 1.2rem;
-		color: var(--ink);
-		font-variant-numeric: tabular-nums;
-		letter-spacing: -0.015em;
-	}
-
-	.spec-n-sep {
-		color: var(--ink-faint);
-		margin: 0 0.1em;
-	}
-
-	.spec-n-tot {
-		color: var(--ink-soft);
-		font-size: 0.78em;
-	}
-
-	.spec-s {
-		font-family: 'JetBrains Mono', monospace;
-		font-size: 0.74rem;
-		color: var(--ink-soft);
-	}
-
-	.spec-bar {
-		display: flex;
-		align-items: center;
-		gap: 0.7rem;
-	}
-
-	.bar-track {
-		flex: 1;
-		height: 6px;
-		background: var(--paper);
-		border: 1px solid var(--rule);
-		border-radius: 999px;
-		overflow: hidden;
-		display: block;
-	}
-
-	.bar-fill {
-		display: block;
-		height: 100%;
-		background: var(--svelte);
-		transform-origin: left;
-		width: 0;
-		animation: barIn 0.8s cubic-bezier(0.22, 1, 0.36, 1) forwards;
-		animation-delay: calc(0.04s * var(--i, 0) + 0.25s);
-	}
-
-	.bar-fill.warn {
-		background: var(--warn);
-	}
-
-	.bar-fill.bad {
-		background: var(--bad);
-	}
-
-	@keyframes barIn {
-		from {
-			transform: scaleX(0);
-		}
-		to {
-			transform: scaleX(1);
-		}
-	}
-
-	.spec-pct {
-		font-family: 'JetBrains Mono', monospace;
+		border-collapse: collapse;
 		font-size: 0.82rem;
-		color: var(--ink);
 		font-variant-numeric: tabular-nums;
-		min-width: 3.4rem;
-		text-align: right;
 	}
 
-	.spec-pct .dim {
-		color: var(--ink-faint);
+	th,
+	td {
+		padding: 0.75rem 0.9rem;
+		border-bottom: 1px solid var(--rule);
+		text-align: left;
+		vertical-align: top;
 	}
 
-	/* FIXTURES */
-	.fixtures {
-		max-width: 1080px;
-		margin: 0 auto;
-		padding-bottom: clamp(4rem, 8vh, 6rem);
-	}
-
-	.clear-filter {
-		justify-self: end;
-		align-self: center;
-		background: transparent;
-		border: 1px solid var(--rule-strong);
-		border-radius: 4px;
-		padding: 0.45rem 0.85rem;
-		font-family: 'JetBrains Mono', monospace;
-		font-size: 0.74rem;
-		color: var(--ink);
-		cursor: pointer;
-		display: inline-flex;
-		align-items: center;
-		gap: 0.4em;
-		transition:
-			background 0.18s,
-			color 0.18s,
-			border-color 0.18s;
-	}
-
-	.clear-filter:hover {
-		background: var(--ink);
-		color: var(--bg);
-		border-color: var(--ink);
-	}
-
-	.filters {
-		max-width: 1080px;
-		margin: 0 auto 1.4rem;
-		padding: 0 clamp(1rem, 4vw, 2.5rem);
-		display: flex;
-		gap: 0.75rem;
-		flex-wrap: wrap;
-		align-items: stretch;
-	}
-
-	.search {
-		flex: 1;
-		min-width: 14rem;
-		display: flex;
-		align-items: center;
-		gap: 0.65rem;
-		padding: 0 1rem;
-		background: var(--bg);
-		border: 1px solid var(--rule-strong);
-		border-radius: 4px;
-		font-family: 'JetBrains Mono', monospace;
-	}
-
-	.search:focus-within {
-		border-color: var(--svelte);
-		outline: 2px solid color-mix(in srgb, var(--svelte) 30%, transparent);
-		outline-offset: -1px;
-	}
-
-	.search-sigil {
-		color: var(--ink-faint);
-		font-size: 1rem;
-	}
-
-	.search input {
-		flex: 1;
-		padding: 0.7rem 0;
-		background: transparent;
-		border: 0;
-		font: inherit;
-		font-size: 0.86rem;
-		color: var(--ink);
-	}
-
-	.search input:focus {
-		outline: none;
-	}
-
-	.search input::placeholder {
-		color: var(--ink-faint);
-	}
-
-	.cat-select {
-		display: inline-flex;
-		align-items: stretch;
-		border: 1px solid var(--rule-strong);
-		border-radius: 4px;
-		background: var(--bg);
-		overflow: hidden;
-		font-family: 'JetBrains Mono', monospace;
-	}
-
-	.cat-select:focus-within {
-		border-color: var(--svelte);
-		outline: 2px solid color-mix(in srgb, var(--svelte) 30%, transparent);
-		outline-offset: -1px;
-	}
-
-	.cat-select-label {
-		display: inline-flex;
-		align-items: center;
-		padding: 0 0.85rem;
+	thead th {
 		background: var(--paper);
-		border-right: 1px solid var(--rule);
-		font-size: 0.66rem;
-		letter-spacing: 0.18em;
-		text-transform: uppercase;
-		color: var(--ink-faint);
-	}
-
-	.cat-select select {
-		padding: 0.5rem 2rem 0.5rem 0.85rem;
-		background: var(--bg)
-			url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='10' height='6' viewBox='0 0 10 6'><path fill='none' stroke='%23808080' stroke-width='1.4' d='M1 1l4 4 4-4'/></svg>")
-			right 0.7rem center / 10px 6px no-repeat;
-		border: 0;
-		font: inherit;
-		font-size: 0.78rem;
-		color: var(--ink);
-		cursor: pointer;
-		appearance: none;
-		-webkit-appearance: none;
-		max-width: 16rem;
-		text-overflow: ellipsis;
-	}
-
-	.cat-select select:focus {
-		outline: none;
-	}
-
-	.status-tabs {
-		display: flex;
-		gap: 0;
-		border: 1px solid var(--rule-strong);
-		border-radius: 4px;
-		background: var(--bg);
-		overflow: hidden;
-	}
-
-	.status-tabs button {
-		font-family: 'JetBrains Mono', monospace;
 		font-size: 0.72rem;
-		letter-spacing: 0.06em;
-		padding: 0 1rem;
-		background: transparent;
-		border: 0;
+		font-weight: 600;
 		color: var(--ink-soft);
-		cursor: pointer;
-		display: inline-flex;
-		align-items: center;
-		gap: 0.45em;
-		border-right: 1px solid var(--rule);
-		transition:
-			color 0.2s ease,
-			background 0.2s ease;
 	}
 
-	.status-tabs button:last-child {
-		border-right: 0;
+	tbody th {
+		font-weight: 500;
 	}
 
-	.status-tabs button:hover {
-		color: var(--ink);
-	}
-
-	.status-tabs button.active {
-		background: var(--ink);
-		color: var(--bg);
-	}
-
-	.dot {
-		display: inline-block;
-		width: 6px;
-		height: 6px;
-		border-radius: 999px;
-	}
-
-	.dot.pass {
-		background: var(--ok);
-	}
-
-	.dot.fail {
-		background: var(--bad);
-	}
-
-	.dot.skip {
-		background: var(--warn);
-	}
-
-	.fix-table {
-		max-width: 1080px;
-		margin: 0 auto;
-		padding: 0 clamp(1rem, 4vw, 2.5rem);
-	}
-
-	.fix-thead {
-		display: grid;
-		grid-template-columns: 1fr 12rem 7rem;
-		gap: 1rem;
-		padding: 0.7rem 1rem;
-		font-family: 'JetBrains Mono', monospace;
-		font-size: 0.66rem;
-		letter-spacing: 0.18em;
-		text-transform: uppercase;
-		color: var(--ink-faint);
-		background: var(--paper);
-		border: 1px solid var(--rule);
-		border-top-left-radius: 6px;
-		border-top-right-radius: 6px;
+	tbody tr:last-child th,
+	tbody tr:last-child td {
 		border-bottom: 0;
 	}
 
-	.fix-tbody {
-		max-height: 540px;
-		overflow-y: auto;
-		font-variant-numeric: tabular-nums;
-		border-inline: 1px solid var(--rule);
-		background: var(--bg);
+	.category-table {
+		min-width: 620px;
 	}
 
-	.fix-row {
-		display: grid;
-		grid-template-columns: 1fr 12rem 7rem;
-		gap: 1rem;
-		padding: 0.65rem 1rem;
-		font-family: 'JetBrains Mono', monospace;
-		font-size: 0.8rem;
-		border-bottom: 1px solid var(--rule);
-		align-items: center;
+	.category-table th:first-child {
+		width: 48%;
 	}
 
-	.fix-row:hover {
-		background: var(--paper);
+	.category-table tr.selected {
+		background: color-mix(in srgb, var(--accent) 6%, transparent);
+		box-shadow: inset 2px 0 var(--accent);
 	}
 
-	.fix-name {
+	.category-button {
+		display: block;
+		width: 100%;
+		padding: 0;
+		border: 0;
+		background: none;
+		font: inherit;
+		font-weight: 550;
 		color: var(--ink);
-		overflow: hidden;
-		text-overflow: ellipsis;
-		white-space: nowrap;
+		text-align: left;
+		cursor: pointer;
 	}
 
-	.fix-cat {
-		color: var(--ink-soft);
-		font-size: 0.76rem;
+	.category-button:hover {
+		color: var(--accent);
+		text-decoration: underline;
 	}
 
-	.fix-status {
-		display: inline-flex;
-		align-items: center;
-		gap: 0.45em;
+	.category-button:focus-visible {
+		outline: 2px solid var(--accent);
+		outline-offset: 3px;
+		border-radius: 2px;
+	}
+
+	.passing {
 		color: var(--ok);
 	}
 
-	.fix-row.fail .fix-status {
-		color: var(--bad);
+	.failing,
+	.status-fail {
+		color: var(--danger);
 	}
 
-	.fix-row.skip .fix-status {
-		color: var(--warn);
-	}
-
-	.fix-glyph {
-		font-size: 0.9em;
-		line-height: 1;
-	}
-
-	.fix-msg {
-		grid-column: 1 / -1;
-		margin: 0.4rem 0 0;
-		padding: 0.55rem 0.7rem;
-		background: var(--paper);
-		font-family: 'JetBrains Mono', monospace;
-		font-size: 0.74rem;
-		color: var(--ink-soft);
-		white-space: pre-wrap;
-		word-break: break-word;
-		border-left: 2px solid var(--rule-strong);
-	}
-
-	.fix-row.fail .fix-msg {
-		border-left-color: var(--bad);
-	}
-
-	.fix-row.skip .fix-msg {
-		border-left-color: var(--warn);
-	}
-
-	.fix-empty {
-		padding: 3rem 1rem;
-		text-align: center;
-		color: var(--ink-faint);
-		font-family: 'JetBrains Mono', monospace;
-		font-size: 0.82rem;
-	}
-
-	.fix-foot {
-		padding: 0.7rem 1rem;
-		background: var(--paper);
-		border: 1px solid var(--rule);
-		border-top: 0;
-		border-bottom-left-radius: 6px;
-		border-bottom-right-radius: 6px;
-		font-family: 'JetBrains Mono', monospace;
-		font-size: 0.78rem;
-		color: var(--ink);
+	.fixture-heading {
 		display: flex;
-		gap: 0.5em;
+		align-items: start;
+		justify-content: space-between;
+		gap: 1rem;
 	}
 
-	.fix-foot .dim {
+	.reset-filters {
+		height: 2rem;
+		padding: 0 0.7rem;
+		border: 1px solid var(--rule-strong);
+		border-radius: 5px;
+		background: var(--bg);
+		font: inherit;
+		font-size: 0.8rem;
 		color: var(--ink-soft);
+		cursor: pointer;
 	}
 
-	/* EMPTY */
-	.empty {
-		max-width: 1080px;
-		margin: 0 auto;
-		padding: clamp(4rem, 10vh, 7rem) clamp(1rem, 4vw, 2.5rem);
-	}
-
-	.empty h1 {
-		font-family: 'Hanken Grotesk', sans-serif;
-		font-weight: 700;
-		font-size: clamp(2rem, 4.6vw, 3rem);
-		line-height: 1.05;
-		letter-spacing: -0.025em;
+	.reset-filters:hover {
+		border-color: var(--ink-faint);
+		background: var(--paper);
 		color: var(--ink);
+	}
+
+	.filters {
+		display: grid;
+		grid-template-columns: minmax(220px, 1fr) minmax(170px, 0.55fr) auto;
+		gap: 1rem;
+		align-items: end;
 		margin: 0 0 1rem;
 	}
 
-	.empty .lede {
-		font-size: 1.05rem;
+	.field,
+	.status-filter {
+		display: flex;
+		flex-direction: column;
+		gap: 0.35rem;
+	}
+
+	.field > span:first-child,
+	.filter-label {
+		font-size: 0.72rem;
+		font-weight: 600;
 		color: var(--ink-soft);
-		max-width: 56ch;
-		margin: 0 0 1.5rem;
 	}
 
-	.empty-code {
-		max-width: 700px;
-		background: var(--paper);
-		border: 1px solid var(--rule);
-		border-radius: 6px;
-		padding: 1rem 1.2rem;
-		font-family: 'JetBrains Mono', monospace;
-		font-size: 0.85rem;
+	.search-control,
+	.select-control {
+		position: relative;
+		display: block;
+	}
+
+	input,
+	select {
+		width: 100%;
+		height: 2.5rem;
+		box-sizing: border-box;
+		padding: 0 0.7rem;
+		border: 1px solid var(--rule-strong);
+		border-radius: 5px;
+		background: var(--bg);
+		font: inherit;
+		font-size: 0.82rem;
 		color: var(--ink);
-		line-height: 1.7;
-		overflow-x: auto;
 	}
 
-	/* RESPONSIVE */
-	@media (max-width: 880px) {
-		.spec-row {
-			grid-template-columns: 1fr auto;
-			gap: 0.4rem 1rem;
+	input[type='search'] {
+		padding-left: 2.1rem;
+	}
+
+	.search-control svg,
+	.select-chevron {
+		position: absolute;
+		top: 50%;
+		pointer-events: none;
+		transform: translateY(-50%);
+		color: var(--ink-faint);
+	}
+
+	.search-control svg {
+		left: 0.65rem;
+		width: 1rem;
+		height: 1rem;
+		fill: none;
+		stroke: currentColor;
+		stroke-linecap: round;
+		stroke-width: 1.25;
+	}
+
+	select {
+		appearance: none;
+		padding-right: 2.25rem;
+		cursor: pointer;
+	}
+
+	.select-chevron {
+		right: 0.65rem;
+		width: 1rem;
+		height: 1rem;
+		fill: none;
+		stroke: currentColor;
+		stroke-linecap: round;
+		stroke-linejoin: round;
+		stroke-width: 1.5;
+	}
+
+	input:focus,
+	select:focus {
+		outline: 2px solid color-mix(in srgb, var(--accent) 45%, transparent);
+		outline-offset: 2px;
+		border-color: var(--accent);
+	}
+
+	.reset-filters:focus-visible,
+	.status-buttons button:focus-visible {
+		position: relative;
+		z-index: 1;
+		outline: 2px solid var(--accent);
+		outline-offset: 2px;
+	}
+
+	.status-buttons {
+		display: flex;
+		height: 2.5rem;
+		border: 1px solid var(--rule-strong);
+		border-radius: 5px;
+		overflow: hidden;
+	}
+
+	.status-buttons button {
+		padding: 0 0.65rem;
+		border: 0;
+		border-right: 1px solid var(--rule);
+		background: var(--bg);
+		font: inherit;
+		font-size: 0.78rem;
+		color: var(--ink-soft);
+		cursor: pointer;
+	}
+
+	.status-buttons button:last-child {
+		border-right: 0;
+	}
+
+	.status-buttons button:hover {
+		color: var(--ink);
+		background: var(--paper);
+	}
+
+	.status-buttons button.active {
+		background: var(--paper);
+		box-shadow: inset 0 -2px var(--accent);
+		color: var(--ink);
+		font-weight: 600;
+	}
+
+	.fixture-table-wrap {
+		max-height: 650px;
+		overflow: auto;
+		scrollbar-gutter: stable;
+	}
+
+	.fixture-table {
+		min-width: 720px;
+	}
+
+	.fixture-table thead {
+		position: sticky;
+		top: 0;
+		z-index: 1;
+	}
+
+	.fixture-table th:first-child {
+		width: 55%;
+	}
+
+	.fixture-name,
+	.fixture-message {
+		display: block;
+	}
+
+	.fixture-message {
+		margin-top: 0.3rem;
+		font-size: 0.7rem;
+		font-weight: 400;
+		line-height: 1.45;
+		color: var(--ink-faint);
+		white-space: pre-wrap;
+	}
+
+	.test-status {
+		font-family: var(--font-ui);
+		font-weight: 550;
+		text-transform: capitalize;
+	}
+
+	.status-pass {
+		color: var(--ok);
+	}
+
+	.status-skip {
+		color: var(--ink-faint);
+	}
+
+	.no-results {
+		padding: 2rem;
+		text-align: center;
+		color: var(--ink-faint);
+	}
+
+	.command {
+		max-width: 760px;
+		margin-top: 1.5rem;
+	}
+
+	.visually-hidden {
+		position: absolute;
+		width: 1px;
+		height: 1px;
+		padding: 0;
+		margin: -1px;
+		overflow: hidden;
+		clip: rect(0 0 0 0);
+		white-space: nowrap;
+		border: 0;
+	}
+
+	@media (max-width: 820px) {
+		.metadata {
+			grid-template-columns: repeat(2, minmax(0, 1fr));
 		}
-		.spec-v {
+
+		.filters {
+			grid-template-columns: 1fr 1fr;
+		}
+
+		.status-filter {
 			grid-column: 1 / -1;
 		}
-		.spec-bar {
-			grid-column: 1 / -1;
+
+		.status-buttons {
+			align-self: flex-start;
 		}
-		.fix-thead,
-		.fix-row {
+	}
+
+	@media (max-width: 560px) {
+		.report {
+			padding-top: 2rem;
+		}
+
+		.filters {
 			grid-template-columns: 1fr;
-			gap: 0.3rem;
 		}
-		.fix-thead {
-			display: none;
-		}
-	}
 
-	@media (prefers-reduced-motion: reduce) {
-		.spec-row,
-		.bar-fill {
-			animation: none !important;
-			opacity: 1 !important;
-			transform: none !important;
+		.status-filter {
+			grid-column: auto;
+		}
+
+		.fixture-heading {
+			display: block;
 		}
 	}
 </style>

--- a/apps/playground/static/favicon.svg
+++ b/apps/playground/static/favicon.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="20" height="20" fill="none">
+  <style>
+    :root { --svelte: #ff3e00; --rust: #5c6773; }
+    @media (prefers-color-scheme: dark) { :root { --svelte: #ff6a39; --rust: #8b96a2; } }
+  </style>
+  <path d="M19 8 13 18l-2-4 6-10 2 4Z" fill="var(--svelte)"/>
+  <path d="M5 16 11 6l2 4-6 10-2-4Z" fill="var(--rust)"/>
+</svg>


### PR DESCRIPTION
Non-AI comment: I did a polish of the rsvelte website to give a better first impression. The current design screams "AI-generated", and IMO this project deserves a better reputation than being "ai-generated slop" (i totally not agree on this, but you know, some people are still conservative on this), and making the website look more like something you find elsewhere in the echosystem is one way to make people realise that this is a project that is serious.

I also saw this issue, and can easily change the logo if wanted: https://github.com/baseballyama/rsvelte/issues/2295

Let me know about the changes, this is just my personal UI polish. 

## Summary

Polish the documentation website with a calmer, more conventional visual system. The new style is intentionally less AI-looking and aligns more closely with modern documentation websites while retaining rsvelte's Svelte ecosystem identity.

- Replaces the highly decorative layouts with familiar documentation navigation, content hierarchy, tables, and controls
- Uses Svelte orange as the primary accent across the site
- Brings the playground, compatibility report, and benchmark report into the same cohesive design system
- Improves responsive behavior across desktop, tablet, and mobile layouts

## Honourable mentions

- Restores the rsvelte logo in the header and uses it as the favicon
- Adds Shiki-powered syntax highlighting for code blocks
- Standardizes installation commands around pnpm
- Refines compatibility filters with consistent sizing, focus states, reset behavior, search affordance, and a custom dropdown chevron
- Presents benchmark results in conventional data tables with green speedup values and better tablet sizing
- Adds documentation sidebar and table-of-contents navigation
- Adds an external-link indicator to the GitHub navigation item
- Improves light and dark theme consistency and accessibility semantics

## Verification

- `pnpm --dir apps/playground lint`
- `RUSTUP_TOOLCHAIN=1.97.1 pnpm --dir apps/playground build`
- `git diff --check origin/main...HEAD`
- Visual review in light and dark themes at desktop and tablet widths
