### PR TITLE
ci: run the blocking gates on pull requests to any base (#2405)

### DIFF
--- a/.github/workflows/capi.yml
+++ b/.github/workflows/capi.yml
@@ -23,8 +23,8 @@ on:
       - 'Cargo.toml'
       - 'Cargo.lock'
       - '.github/workflows/capi.yml'
+  # Unfiltered: see ci.yml.
   pull_request:
-    branches: [main]
     paths:
       - 'crates/rsvelte_capi/**'
       - 'crates/rsvelte_core/**'

--- a/.github/workflows/changeset.yml
+++ b/.github/workflows/changeset.yml
@@ -9,8 +9,8 @@ name: Changeset Gate
 # re-trigger the gate, since the default `pull_request` trigger types
 # (`opened`/`synchronize`/`reopened`) don't include `labeled`.
 on:
+  # Unfiltered: see ci.yml.
   pull_request:
-    branches: [main]
     types: [opened, synchronize, reopened, labeled, unlabeled]
 
 concurrency:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,9 @@ name: CI
 on:
   push:
     branches: [main]
+  # Unfiltered: a PR stacked on another branch must still run these gates,
+  # otherwise it reports green having run none of them.
   pull_request:
-    branches: [main]
 
 permissions:
   contents: read


### PR DESCRIPTION
Closes #2405.

A PR whose base is not `main` matched **none** of the blocking workflows, because each declared
`pull_request: branches: [main]`. It therefore displayed **green having run no tests, no clippy
and no fmt.** The only tell was counting its checks against a base-`main` PR: #2370 had **8**,
#2389 had **35**, at the same moment.

## Which option, and what failure mode it optimises against

Two candidates were on the issue. I took **dropping the filter** rather than **a required job that
detects the reduction**, on one piece of evidence:

**Stacked PRs are 0.29% of the population** — 5 of 1741 merged PRs, full history. So the cost
argument that would favour the cheaper option does not exist at this volume; the extra runner time
is five PRs' worth over nine months.

That leaves only the failure mode. The detector makes the reduction **visible**; dropping the
filter makes it **impossible**. The defect being fixed is precisely that a reduction *was* visible
— in the check count — and nobody looked, for nine months. Optimising for "impossible" over
"visible" is the whole lesson of the bug.

## Scope: the three blocking gates, not everything

| workflow | change | why |
|---|---|---|
| `ci.yml` | filter dropped | `Format`, `Clippy`, `Test unit/core/runtime/server`, `Embeddable core`, lockfile gates |
| `capi.yml` | filter dropped | `C ABI`, a real gate; keeps its `paths:` filter |
| `changeset.yml` | filter dropped | `Changeset`, a real gate |
| `coverage.yml`, `benchmark.yml`, `codspeed.yml` | **unchanged** | expensive and informational, and already label-gated behind job-level `if:` — running them on stacked PRs adds queue load without adding a gate |

`push: branches: [main]` is **kept everywhere.** Removing that too would run CI on every branch
push and multiply a queue that is already saturated.

## Concurrency: checked, not assumed

The group is `${{ github.workflow }}-${{ github.head_ref || github.ref }}` in all three.
`github.head_ref` is the PR's **head** branch, and a parent and its child necessarily have
different heads (`…-batch2` vs `…-batch4`), so they land in different groups and cannot cancel
each other. Pushing the parent's branch cancels only the parent's own in-flight run, which is the
intended supersede. GitHub does not re-run a PR when its *base* branch is pushed, so the child is
not triggered by parent activity either.

This mattered: trading a silent gap for a silent cancellation would have been a worse bug, because
`CANCELLED` reads as a failure and gets re-run rather than investigated.

## Verification is a check count, not this diff

The thing being fixed is *a check that does not run*, so a workflow diff cannot demonstrate it —
the symptom of failure is indistinguishable from success by construction. A throwaway PR stacked
on **this branch** is the control; its count is reported in a comment below. GitHub evaluates
`on.pull_request.branches` against the workflow file in the PR's merge ref, so a PR based here
sees the fixed triggers.

## Historical exposure: 5 of 1741, none of them untested

| PR | base | merged |
|---|---|---|
| #10, #11, #12 | `review/tier-1-5-fixes` → `-1-6-` → `-1-7-` | 2026-05-03 |
| #1267 | `feat/corpus-burndown-2` | 2026-06-27 |
| #1913 | `perf/compile-wave2` | 2026-07-30 |

None put untested code on `main`. `ci.yml`'s `pull_request:` declares no `types:`, so it defaults
to `[opened, synchronize, reopened]` — merging a child into its parent branch pushes that branch,
synchronizes the **parent** PR, and runs full CI on the combination. All five had a parent
targeting `main`. What was lost is review signal at the child PR, not coverage.

**0.29% is scope evidence for how to fix this, not evidence that it is small.** Coverage arriving
later at a different PR is not the same as the signal being right where the decision is made — a
child PR showing green having never run `Format`, `Clippy` or any `Test` job is a defect whatever
the parent's run covers, because the reviewer is looking at the child.

Two merge orders remain available while this lands, and they are safe for different reasons:

- **Child into parent first** — the parent PR synchronizes and runs full CI on the combination,
  with nothing to remember. *Assumes you are not squash-merging*: under squash this produces one
  commit on `main` carrying both changes under one title.
- **Parent to `main` first** — the child auto-retargets and, after a push or manual re-run, gets
  the full check set on top of the merged parent. Stronger verification and one commit per change.
  *Assumes someone re-runs*, since retargeting is not a `synchronize` event; the mitigation is that
  the miss is visible in the check count rather than silent.

This repo squash-merges, so the second is being used, with the count as the gate.



## What this does **not** change

This alters what runs on every future PR, so the boundaries are worth stating rather than
inferring.

**1. `coverage.yml`, `benchmark.yml`, `codspeed.yml` remain base-filtered — by choice, not by
oversight.** They are expensive, informational, and already gated behind job-level `if:`/label
conditions, so running them on stacked PRs would add queue load without adding a gate. If a
stacked PR needs coverage numbers, the label mechanism still works once it targets `main`.

**2. "CI now runs" is not "CI now blocks".** Verified against the repo, not assumed:

```
GET /repos/baseballyama/rsvelte/branches/main/protection  →  404 Branch not protected
GET /repos/baseballyama/rsvelte/rulesets/16341833         →  rules: deletion, non_fast_forward
```

The `main` ruleset carries **no `required_status_checks` rule at all**. So nothing here is
enforced on any PR, stacked or not — a red `Test unit` is still merge-able by anyone who clicks
through it. What this PR fixes is that the checks now **exist and report** on a stacked PR; it
does not make them binding, because they are not binding anywhere.

That is an owner-level setting rather than something a workflow file can reach, so it is out of
scope here — but a reader who takes "the gates now run on stacked PRs" as "stacked PRs are now
gated" would be wrong in a way that matters.
