### PR TITLE
test: throwaway stacked-PR probe (#2405) — do not merge

### DIFF
--- a/.github/STACKED_PR_PROBE.md
+++ b/.github/STACKED_PR_PROBE.md
@@ -1,0 +1,2 @@
+Throwaway probe for #2405: proves a stacked PR now receives the full check set.
+Delete with the branch.

--- a/crates/rsvelte_capi/src/lib.rs
+++ b/crates/rsvelte_capi/src/lib.rs
@@ -848,3 +848,5 @@ fn compile_result_to_json(result: &rsvelte_core::compiler::CompileResult) -> Val
         "metadata": { "runes": result.metadata.runes },
     })
 }
+
+// Throwaway probe line for the stacked-PR CI check; travels with the probe branch.


### PR DESCRIPTION
Throwaway. Base is `fix/2405-stacked-pr-ci`, so this PR is the control for whether the trigger fix actually fires: a stacked PR must now receive the full check set instead of 8 parity jobs. Closing and deleting the branch once the count is recorded on #2406.