### PR TITLE
test(esrap): close the env knobs that hollow out the esrap ratchets (#1791 items 4, 6)

### DIFF
--- a/.changeset/esrap-prereq-guards.md
+++ b/.changeset/esrap-prereq-guards.md
@@ -1,0 +1,13 @@
+---
+"@rsvelte/compiler": patch
+---
+
+chore(esrap): bump `rsvelte_esrap` to 0.10.2 for a test-only change
+
+No shipped behaviour changes. The only edit under `crates/rsvelte_esrap/src/` is inside
+`#[cfg(test)] mod internal_tests`, which cannot appear in a published artifact: the golden
+conformance test now fails instead of skipping when `submodules/svelte` is absent or
+`ESRAP_ORACLE_DIR` has replaced the corpus its `EXACT_FLOOR` ratchet was calibrated on.
+
+The bump exists only because `check-esrap-version-bump.mjs` keys on any path under
+`src/`, and `rsvelte_core` pins `rsvelte_esrap` exactly, so the pin has to advance with it.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -496,6 +496,9 @@ jobs:
         timeout-minutes: 15
         env:
           RUST_MIN_STACK: '33554432'
+          # This job checks the svelte submodule out above, so a `--lib` suite
+          # that skips itself for a missing prerequisite is a misconfigured job.
+          RSVELTE_REQUIRE_PREREQS: '1'
 
       # `parallel` is off by default, so the run above compiles neither
       # `compile_batch`'s rayon path nor the tests that pin its per-item panic
@@ -506,6 +509,7 @@ jobs:
         timeout-minutes: 15
         env:
           RUST_MIN_STACK: '33554432'
+          RSVELTE_REQUIRE_PREREQS: '1'
 
   # The two svelte.dev formatter-parity corpus tests (~100 s each: they format
   # every .svelte file + markdown code block from svelte.dev and diff against an

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2508,7 +2508,7 @@ dependencies = [
 
 [[package]]
 name = "rsvelte_esrap"
-version = "0.10.1"
+version = "0.10.2"
 dependencies = [
  "compact_str 0.10.0",
  "memchr",

--- a/crates/rsvelte_core/Cargo.toml
+++ b/crates/rsvelte_core/Cargo.toml
@@ -73,7 +73,7 @@ oxc_ast = { version = "0.143", features = ["serialize"] }
 oxc_span = "0.143"
 oxc_diagnostics = "0.143"
 oxc_codegen = "0.143"
-rsvelte_esrap = { version = "=0.10.1", path = "../rsvelte_esrap" }
+rsvelte_esrap = { version = "=0.10.2", path = "../rsvelte_esrap" }
 oxc_syntax = "0.143"
 oxc_semantic = "0.143"
 

--- a/crates/rsvelte_esrap/Cargo.toml
+++ b/crates/rsvelte_esrap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rsvelte_esrap"
-version = "0.10.1"
+version = "0.10.2"
 edition = "2024"
 rust-version = "1.95"
 description = "A Rust port of esrap — prints an oxc AST to JavaScript with esrap's exact layout"

--- a/crates/rsvelte_esrap/src/internal_tests/golden.rs
+++ b/crates/rsvelte_esrap/src/internal_tests/golden.rs
@@ -103,7 +103,22 @@ fn reprint(source: &str) -> Option<Reprint> {
 
 #[test]
 fn golden_roundtrip_ratchet() {
+    // `EXACT_FLOOR` is calibrated against the committed `_expected` snapshots,
+    // so an external corpus satisfies it while measuring a different population.
+    assert!(
+        !using_external_oracle() || std::env::var_os("RSVELTE_REQUIRE_PREREQS").is_none(),
+        "ESRAP_ORACLE_DIR replaces the conformance corpus in a job that declares \
+         RSVELTE_REQUIRE_PREREQS — the EXACT_FLOOR ratchet would no longer measure \
+         the corpus it was calibrated on."
+    );
+
     let Some(dir) = samples_dir() else {
+        // Only a job that promised this submodule may fail on its absence.
+        assert!(
+            std::env::var_os("RSVELTE_REQUIRE_PREREQS").is_none(),
+            "submodules/svelte is not checked out in a job that declares \
+             RSVELTE_REQUIRE_PREREQS — the EXACT_FLOOR ratchet would be silently skipped."
+        );
         eprintln!("snapshot samples not found (submodule not initialised); skipping golden test");
         return;
     };

--- a/crates/rsvelte_esrap/tests/esrap_samples.rs
+++ b/crates/rsvelte_esrap/tests/esrap_samples.rs
@@ -125,6 +125,14 @@ fn esrap_samples_match() {
     let verbose = std::env::var("ESRAP_SAMPLES_VERBOSE").is_ok();
     let only = std::env::var("ESRAP_SAMPLES_ONLY").ok();
 
+    // Filtered-out samples can never reach the KNOWN_FAILURES reconciliation
+    // below, so a narrowed run reports green having checked one entry.
+    assert!(
+        only.is_none() || std::env::var_os("RSVELTE_REQUIRE_PREREQS").is_none(),
+        "ESRAP_SAMPLES_ONLY narrows the run to a single sample in a job that declares \
+         RSVELTE_REQUIRE_PREREQS — the KNOWN_FAILURES ratchet would be hollowed out."
+    );
+
     let mut unexpected_fail = Vec::new();
     let mut unexpected_pass = Vec::new();
     let mut passed = 0;

--- a/crates/rsvelte_lint_types/Cargo.lock
+++ b/crates/rsvelte_lint_types/Cargo.lock
@@ -1106,7 +1106,7 @@ dependencies = [
 
 [[package]]
 name = "rsvelte_esrap"
-version = "0.10.1"
+version = "0.10.2"
 dependencies = [
  "compact_str",
  "memchr",


### PR DESCRIPTION
Part of #1791 (items 4 and 6).

## Item 4 was already done — and it demonstrably works

The issue names `crates/rsvelte_core/tests/compatibility_report.rs` and eight hardcoded
`if !input_path.exists() { continue }` sites. Checking the tree rather than the text:

- The file **no longer lives at that path** — it is `crates/rsvelte_devtools/tests/compatibility_report.rs`.
- All **8** runners named by the issue (parser, snapshot, css, validator, compiler-errors,
  sourcemaps/runtime, print, preprocess) now build a `FixtureCoverage` ledger and call
  `assert_coverage`, added by `1dae9f66` ("test: fail fixture suites that measure nothing
  (#1791 items 3, 4)", #1813). `FixtureCoverage::assert` enforces four things: `found > 0`,
  no `MissingInput` skips, `ran + justified == found`, and a grow-only `min_ran` floor.
- It is wired, not merely written: `ci.yml`'s `compatibility-report` job runs
  `pnpm run compatibility-report`, which opts the `#[ignore]`d test back in with `--ignored`.

I did not take that on trust. **Three mutations, applied to this branch, run, and reverted:**

| # | mutation | result |
|---|---|---|
| **M1** | `sourcemaps.rs::load_input`: `input.svelte` → `main.svelte` — the original defect verbatim | **kills**: `sourcemaps: 29 of 29 sample(s) were dropped because an expected input file is missing` |
| **M2** | delete one generated fixture dir (`fixtures/*/sourcemaps/effects`) | **kills**, and on a *different* assertion: `only 28 fixture(s) ran, floor is 29` |
| **M3** | `compatibility_report.rs`: entry-point list `["main.svelte", "input.svelte"]` → `["main.svelte"]` — the literal historical bug, in the file the issue names | **kills**: same missing-input assert, via `assert_coverage` |

M1 and M2 land on different assertions, so the missing-input axis and the grow-only-floor axis
discriminate independently. M3 confirms the guard fires in the *named* file and through
`assert_coverage`'s own tally arithmetic, not just in the shared helper. Before `1dae9f66` all
three printed `Sourcemaps 0/0` and passed.

**No code change for item 4.** It is fixed; this PR records the proof.

## Item 6 — one of the four bullets was still half-open

Checked each bullet against the tree:

- **`STRICT_SOURCEMAPS`** — **0 hits repo-wide.** It was deleted by `c39bad65`, i.e. by **#1787
  itself**, the PR whose review filed this issue. The bullet was stale on the day it was written.
- **`RSVELTE_CAPI_CHECK_HEADER`** — not "never set": `capi.yml:118` and `release-capi.yml:109`
  set it. The separate local-defeat concern is gone too — `header_invariants.rs` compares against
  `git show HEAD:./include/rsvelte.h`, so `build.rs` overwriting the working-tree header cannot
  neutralise it (`af6a6d8c`, #2223).
- **`RSVELTE_FMT_TW_TEST_DIR`** — set by `ci.yml:624`, guarded by `RSVELTE_REQUIRE_PREREQS`.
- **esrap** — **only half fixed.** `cf911651` (#2367) added a `RSVELTE_REQUIRE_PREREQS` guard to
  `esrap_samples.rs`'s *submodule-absence* path, but the issue's esrap bullet names two holes and
  the other one was untouched.

### What this PR actually changes

Three holes of the exact item-6 shape — "a check an env var can hollow out":

1. `esrap_samples.rs` — `ESRAP_SAMPLES_ONLY` `continue`s past every non-matching sample, and a
   filtered-out sample can never appear in `unexpected_pass`. A narrowed run therefore reports
   green having reconciled the `KNOWN_FAILURES` ratchet against exactly one entry.
2. `golden.rs` — the submodule-absence early return had **no** prereq guard (missed by #2367,
   which only covered the sibling file), so a missing `submodules/svelte` silently retires the
   `EXACT_FLOOR = 72` ratchet.
3. `golden.rs` — `ESRAP_ORACLE_DIR` swaps the whole conformance corpus while `EXACT_FLOOR`, which
   is calibrated against the committed `_expected` snapshots, keeps being asserted. Point it at a
   large easy corpus and `exact >= 72` passes while measuring a different population.

Each follows the pattern #2367 established: the check is refused only in a job that *declares* it
supplies the prerequisite, so a contributor without submodules still skips.

### The guard would have been inert without wiring it

`golden.rs` is a `#[cfg(test)] mod internal_tests` — it runs under `--lib`, in the **`test-unit`**
job, and that job never set `RSVELTE_REQUIRE_PREREQS`. Writing the assert alone would have changed
nothing. So `ci.yml` now sets it on `test-unit`'s two steps, which is the only behaviour change
here that a PR can trip over.

**What will newly break a PR that previously passed:** before this change **zero** `--lib` tests
consulted `RSVELTE_REQUIRE_PREREQS` (0 hits under `crates/**/src/**`), so turning it on in
`test-unit` enforces exactly one new thing: `golden_roundtrip_ratchet` now **fails** instead of
printing `skipping golden test` when `submodules/svelte` is absent — i.e. if the
`Checkout svelte submodule (shallow)` step is removed, renamed, or fails, or if the upstream
`tests/snapshot/samples` path moves. That previously passed and silently retired the
`EXACT_FLOOR` ratchet. Enabling the env broke no existing test: `cargo test --workspace --lib`
with `RSVELTE_REQUIRE_PREREQS=1` is green.

The `ESRAP_SAMPLES_ONLY` / `ESRAP_ORACLE_DIR` assertions are **GUARDs, not new coverage** — no CI
job sets either knob, so they pass before and after and are inert until someone misconfigures a
job. They are labelled as such here rather than in comments to keep the comment budget on WHY.

### Mutation table (item 6)

Each applied to this branch, run, reverted.

| # | mutation | result |
|---|---|---|
| **M4** | remove `submodules/svelte/.../snapshot/samples`, `RSVELTE_REQUIRE_PREREQS=1` | **kills**: `submodules/svelte is not checked out in a job that declares RSVELTE_REQUIRE_PREREQS` |
| **M4c** | same, env **unset** (negative control) | **passes, skipping** — the asymmetry is the point; contributors without submodules are unaffected |
| **M5** | `ESRAP_ORACLE_DIR=<a real dir>` + env on | **kills**: `ESRAP_ORACLE_DIR replaces the conformance corpus …` |
| **M6** | `ESRAP_SAMPLES_ONLY=sequences` + env on | **kills**: `ESRAP_SAMPLES_ONLY narrows the run to a single sample …` |
| **C1** | env on, all prerequisites present, both suites | **passes** — the guards do not fire spuriously |

M4c and C1 matter as much as the kills: a guard that fired unconditionally would also "kill" M4
through M6 while breaking every contributor without submodules.

## Deliberately left out

`sourcemaps.rs`'s `TestResult::passed()` still reads
`client_js_passed.unwrap_or(true) && server_js_passed.unwrap_or(true)`, which is the shape the
issue flags ("no map emitted at all still passes"). It is **not** reachable today:
`load_sourcemap_fixture` returns `Err(SkipReason::Justified)` when both expected outputs are
absent, so every fixture that reaches `passed()` has at least one `Some`. An assertion there would
pin an invariant already enforced structurally one function above — a pure guard on a
currently-impossible state. Reporting it rather than adding it.

## The version bump, and the option that looks free

`check-esrap-version-bump.mjs` keys on any path under `crates/rsvelte_esrap/src/`, and
`internal_tests/` lives there, so this test-only change trips it. Resolved the honest way:
`rsvelte_esrap` 0.10.1 -> 0.10.2, `rsvelte_core`'s exact pin with it, both lockfiles
(`crates/rsvelte_lint_types/Cargo.lock` re-resolves too), and a changeset that says outright
that the only change is test code.

**The tempting alternative was to move `internal_tests/` out of `src/` into `tests/`, and it
should be rejected on principle, not just on effort.** `golden.rs` uses `crate::printer::Printer`
and `crate::{PrintOptions, command, context::Context}` — all private. Moving it means making
crate internals `pub` to satisfy a *release* gate. That inverts the dependency: the gate exists
to make version drift visible, and this would buy silence by permanently widening the public API
to avoid a one-line bump. A permanent API cost is never the right price for a one-time release
cost. It looks free, which is why it is worth writing down.

The narrow, exact way to stop paying this — excluding `src/internal_tests/` by path, and why a
general `#[cfg(test)]` detector is *not* safely decidable — is filed separately as #2417.

## Changeset

One `patch` for `@rsvelte/compiler`, required by the version bump above and by nothing else.
No shipped behaviour changes: the only edit under `crates/rsvelte_esrap/src/` is inside
`#[cfg(test)] mod internal_tests`, which cannot reach a published artifact. The rest of the PR
is a test file and one CI env var.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

