### PR TITLE
fix(compiler): recognise `then`/`catch` after a non-ASCII space in `{#await}` (#2409)

### DIFF
--- a/.changeset/await-ideographic-space.md
+++ b/.changeset/await-ideographic-space.md
@@ -1,0 +1,11 @@
+---
+"@rsvelte/compiler": patch
+---
+
+fix(compiler): recognise `then`/`catch` after a non-ASCII space in `{#await}`
+
+The keyword scan decided word boundaries by casting a raw byte to `char`, which
+decodes UTF-8 as Latin-1. A full-width space before `then` presented its last
+byte as a control character, so the keyword was swallowed into the awaited
+expression and the compiler emitted a call with an empty argument — output that
+does not parse — with the pending and `then` branches transposed.

--- a/crates/rsvelte_core/src/compiler/phases/1_parse/state/tag.rs
+++ b/crates/rsvelte_core/src/compiler/phases/1_parse/state/tag.rs
@@ -1401,20 +1401,19 @@ impl<'a> Parser<'a> {
             // Only honor `then`/`catch` at the top level of the expression
             if paren_depth == 0 && bracket_depth == 0 && brace_depth == 0 {
                 // Require preceding character to be a word-boundary (whitespace or start)
-                let preceded_by_ws = if self.index == expr_start {
-                    true
-                } else {
-                    let prev = self.source.as_bytes()[self.index - 1] as char;
-                    prev.is_whitespace() || prev == ')' || prev == ']'
-                };
+                // A byte here decodes as Latin-1, so `U+3000`'s last byte read as a
+                // control character and the keyword was swallowed into the expression.
+                let preceded_by_ws = self.index == expr_start
+                    || self.source[..self.index]
+                        .chars()
+                        .next_back()
+                        .is_some_and(|c| c.is_whitespace() || c == ')' || c == ']');
                 if preceded_by_ws && self.match_str("then") {
                     let after_idx = self.index + 4;
-                    let is_word_boundary = if after_idx >= self.source.len() {
-                        true
-                    } else {
-                        let next_char = self.source.as_bytes()[after_idx] as char;
-                        next_char.is_whitespace() || next_char == '}'
-                    };
+                    let is_word_boundary = self.source[after_idx.min(self.source.len())..]
+                        .chars()
+                        .next()
+                        .is_none_or(|c| c.is_whitespace() || c == '}');
                     if is_word_boundary {
                         has_then = true;
                         break;
@@ -1422,12 +1421,10 @@ impl<'a> Parser<'a> {
                 }
                 if preceded_by_ws && self.match_str("catch") {
                     let after_idx = self.index + 5;
-                    let is_word_boundary = if after_idx >= self.source.len() {
-                        true
-                    } else {
-                        let next_char = self.source.as_bytes()[after_idx] as char;
-                        next_char.is_whitespace() || next_char == '}'
-                    };
+                    let is_word_boundary = self.source[after_idx.min(self.source.len())..]
+                        .chars()
+                        .next()
+                        .is_none_or(|c| c.is_whitespace() || c == '}');
                     if is_word_boundary {
                         has_catch = true;
                         break;

--- a/crates/rsvelte_core/tests/await_ideographic_space_2409.rs
+++ b/crates/rsvelte_core/tests/await_ideographic_space_2409.rs
@@ -1,0 +1,75 @@
+//! `{#await p　then v}` — a full-width space before `then` is ordinary in
+//! CJK-formatted markup, and `U+3000` is JavaScript whitespace. The keyword scan
+//! decided word boundaries from a raw byte, so the last byte of `U+3000` read as
+//! `U+0080` and `then` was swallowed into the awaited expression.
+
+use rsvelte_core::{CompileOptions, GenerateMode, compile};
+
+fn compile_server(src: &str) -> String {
+    compile(
+        src,
+        CompileOptions {
+            generate: GenerateMode::Server,
+            ..Default::default()
+        },
+    )
+    .expect("compile")
+    .js
+    .code
+}
+
+fn await_component(separator: &str) -> String {
+    format!(
+        "<script>\nlet p = Promise.resolve(1);\n</script>\n\n{{#await p{separator}then v}}\n  <p>{{v}}</p>\n{{/await}}"
+    )
+}
+
+/// The awaited expression must survive. It used to be dropped entirely, leaving
+/// an empty argument slot — output that does not parse.
+#[test]
+fn the_awaited_expression_is_not_dropped() {
+    let out = compile_server(&await_component("\u{3000}"));
+
+    assert!(
+        !out.contains(",\n\t\t,") && !out.contains("$.await($$renderer, ,"),
+        "empty argument slot in the emitted call: {out}"
+    );
+    assert!(
+        out.contains("$.await($$renderer, p,"),
+        "awaited expression missing: {out}"
+    );
+}
+
+/// Separate from the argument itself: a fix that restores the expression while
+/// leaving the branches in the wrong order must still fail.
+#[test]
+fn the_pending_and_then_branches_are_not_transposed() {
+    let out = compile_server(&await_component("\u{3000}"));
+
+    let then_body = out
+        .find("$$renderer.push(`<p>${$.escape(v)}</p>`)")
+        .expect("then body missing");
+    let empty_pending = out.find("() => {}").expect("pending branch missing");
+
+    assert!(
+        empty_pending < then_body,
+        "pending and then arguments are transposed: {out}"
+    );
+}
+
+/// Isolates the defect to the decode: the ASCII separator must be unaffected,
+/// and both forms must agree once the full-width space is read as whitespace.
+#[test]
+fn a_full_width_space_compiles_like_an_ascii_space() {
+    let ascii = compile_server(&await_component(" "));
+    let full_width = compile_server(&await_component("\u{3000}"));
+
+    assert!(
+        ascii.contains("$.await($$renderer, p, () => {}, (v) => {"),
+        "ascii control changed shape: {ascii}"
+    );
+    assert_eq!(
+        ascii, full_width,
+        "full-width separator diverges from ascii"
+    );
+}


### PR DESCRIPTION
Fixes the `tag.rs` half of #2409. **`tag.rs` only** — the other 22 sites in that issue are a
different severity and stay there.

## This is a silent miscompile, not a parse failure

`U+3000` is JavaScript whitespace and `{#await p　then v}` is ordinary CJK-formatted markup.
On `b152751b`, server mode:

```js
// separator U+0020 — correct
$.await($$renderer, p, () => {}, (v) => {
    $$renderer.push(`<p>${$.escape(v)}</p>`);
});

// separator U+3000 — before this PR
$.await(
    $$renderer,
    ,                    // the awaited expression is gone: this does not parse
    () => {
        $$renderer.push(`<p>${$.escape(v)}</p>`);
    },
    () => {}             // and pending / then are transposed
);
```

`compile()` returns `Ok`. No error, no warning.

## Cause

The keyword scan decided word boundaries from a raw byte:

```rust
let prev = self.source.as_bytes()[self.index - 1] as char;
prev.is_whitespace() || prev == ')' || prev == ']'
```

`u8 as char` is a Latin-1 decode. `U+3000` is `E3 80 80`; the byte before `then` is `0x80`, which
becomes `U+0080`, a control character. `is_whitespace()` is false, so `then` is not treated as a
keyword and is absorbed into the awaited expression — which then fails to produce an argument.

Three sites, all in the same scan: the leading check and the trailing checks for `then` and
`catch`. Each now reads a **character**:

```rust
self.source[..self.index].chars().next_back()
self.source[after_idx.min(self.source.len())..].chars().next()
```

### The safety claim, with the enumeration behind it

Slicing `self.source[..self.index]` panics if `self.index` is not a char boundary, where the old
byte indexing could not. "This is safe because `advance` decodes multi-byte sequences" is a claim
about every path that moves `self.index`, so here is the check rather than the assertion:

- `Parser::advance` decodes UTF-8 and steps whole characters.
- `advance_by(n)` sets the index arithmetically and **could** land mid-character. In this scan it
  is called only as `advance_by(4)` / `advance_by(5)` immediately after `match_str("then")` /
  `match_str("catch")` — consuming ASCII keywords that were just matched at the current position,
  so the result is a boundary.
- **The invariant is already load-bearing**: the parser slices `self.source` by an `index`-derived
  bound in **105 places**, including `self.source[self.index..].chars().next()` on its hottest
  path. This change relies on an invariant the parser already depends on everywhere; it does not
  introduce a new class of risk.

`then`/`catch` are ASCII, so `index + 4` / `index + 5` are boundaries too. Both reads are O(1).

## Pins — three, written first and confirmed failing

All three fail on `b152751b`; the third prints the malformed output above.

1. **`the_awaited_expression_is_not_dropped`** — no empty argument slot, and
   `$.await($$renderer, p,` is present.
2. **`the_pending_and_then_branches_are_not_transposed`** — the empty pending arm precedes the
   `then` body. **Deliberately separate from (1)**: a fix that restores the argument while leaving
   the order swapped must still fail.
3. **`a_full_width_space_compiles_like_an_ascii_space`** — asserts the **exact** emitted call for
   the ASCII form, then byte-equality between the two. A structural-validity check would have
   passed on the transposition, so the assertion is on the text.

The ASCII control is what isolates this to the decode rather than to non-ASCII input generally.

## Shippable regardless of the upstream question

#2409 asks whether official Svelte accepts `U+3000` there. That question is still open and this
PR does not settle it — **but emitting `,` as an argument is wrong under either answer**: if
official accepts it, rsvelte must too; if official rejects it, rsvelte must error. Fixing the
malformed output does not foreclose either outcome.

## Verification

- 3 new pins, written before the fix, confirmed failing.
- `cargo test -p rsvelte_core --lib` — 1429 passed, 0 failed.
- `cargo clippy -p rsvelte_core --all-targets --all-features -- -D warnings` — clean, no `-A`.
- `rustfmt --edition 2024 --check` — clean.
- Fixture suites (`parser_fixtures`) do not run locally: `pnpm run generate-fixtures` has not been
  run in this checkout. CI covers them.

## This does **not** close the class — #2409 stays open

Two things a merged #2416 must not be read as fixing:

1. **The other 19 byte-decode sites in #2409** are untouched, by design — different severity, and
   folding them in would gate this behind a larger review. (19, not 22: #2409 scopes 22 and this PR
   fixes three of them. The reconciliation of the four totals circulating for this class, each with
   the command that produced it, is on #2409.)
2. **The same `{#await …　then}` shape exists one layer down in phase 3.**
   `client/state_transforms.rs:378` and `:457` test the character after an identifier against an
   **ASCII-only delimiter whitelist**:

   ```rust
   let next_char = result.as_bytes()[after_ident] as char;
   if next_char != ',' && next_char != ')' && next_char != ' ' && next_char != ':' {
   ```

   Note the cause is different: those comparisons are against ASCII literals, so the *decode* is
   harmless — a non-ASCII byte equals none of them either way. The defect is that the **whitelist
   is incomplete**: a full-width space is a real delimiter and is not listed. Fixing the parse
   layer leaves phase 3 wrong for the same input, and the fix there is not the same fix.

3. **The 83 sites the sweep excluded are unexamined for question 5.** They were cleared on
   "compared only against ASCII literals, so the cast cannot change the answer" — which is true,
   and which answers question 4 only. An ASCII-only *delimiter whitelist* is a different defect and
   is invisible to that query, because there is nothing wrong with the cast to find. Read
   "83 excluded" as **83 cleared against question 4**, not as 83 cleared.

Related: #2409, #2378.


