### PR TITLE
fix(esrap): keep redundant parens only for a leading comment

### DIFF
--- a/.changeset/paren-comment-doubling.md
+++ b/.changeset/paren-comment-doubling.md
@@ -1,0 +1,5 @@
+---
+'@rsvelte/compiler': patch
+---
+
+fix(esrap): keep a redundant paren pair only for a comment that leads the parenthesized expression, so `(await $.track_reactivity_loss(/* c */ load()))()` no longer prints a doubled pair

--- a/.changeset/paren-comment-doubling.md
+++ b/.changeset/paren-comment-doubling.md
@@ -2,4 +2,10 @@
 '@rsvelte/compiler': patch
 ---
 
-fix(esrap): keep a redundant paren pair only for a comment that leads the parenthesized expression, so `(await $.track_reactivity_loss(/* c */ load()))()` no longer prints a doubled pair
+fix(esrap): keep a redundant paren pair only for a comment that *leads* the
+parenthesized expression. A comment deeper inside is already bracketed by that
+expression's own syntax, and keeping the parens for it doubled the pair a parent
+adds from precedence — `(await $.track_reactivity_loss(/* c */ load()))()` printed
+as `((await $.track_reactivity_loss(/* c */ load())))()`, and an object-literal
+arrow body as `() => (({ … }))`. `rsvelte_esrap` is released as 0.10.2 and
+`rsvelte_core` pins the new exact requirement.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2508,7 +2508,7 @@ dependencies = [
 
 [[package]]
 name = "rsvelte_esrap"
-version = "0.10.1"
+version = "0.10.2"
 dependencies = [
  "compact_str 0.10.0",
  "memchr",

--- a/crates/rsvelte_core/Cargo.toml
+++ b/crates/rsvelte_core/Cargo.toml
@@ -73,7 +73,7 @@ oxc_ast = { version = "0.143", features = ["serialize"] }
 oxc_span = "0.143"
 oxc_diagnostics = "0.143"
 oxc_codegen = "0.143"
-rsvelte_esrap = { version = "=0.10.1", path = "../rsvelte_esrap" }
+rsvelte_esrap = { version = "=0.10.2", path = "../rsvelte_esrap" }
 oxc_syntax = "0.143"
 oxc_semantic = "0.143"
 

--- a/crates/rsvelte_core/tests/await_reactivity_loss_comment_2090.rs
+++ b/crates/rsvelte_core/tests/await_reactivity_loss_comment_2090.rs
@@ -49,17 +49,17 @@ fn every_comment_in_the_run_is_kept() {
     );
 }
 
-/// Preservation guard, not a regression test: this caller parses with
-/// `ParseOptions::default()`, where `preserve_parens` makes the argument span
-/// cover the parens, so it passes on either end bound. It would start
-/// discriminating only under `preserve_parens: false`, which is why the copy
-/// runs to the expression's own end — the read range then equals the written
-/// range by construction rather than by coincidence.
+/// The operand's own parens do NOT survive: esrap prints from the AST and
+/// recomputes parenthesisation from precedence, so a redundant `(load())`
+/// collapses to `load()` — official does the same. What this pins is the
+/// surrounding shape, where the source's trailing call and the wrap's own
+/// `()` stack into `…()()`; the balance check then catches a splice that
+/// reads and writes different ranges.
 #[test]
 fn a_parenthesized_operand_stays_balanced() {
     let src = "export async function f() {\n\treturn (await (load()))();\n}\n";
     let out = module(src);
-    assert_contains(&out, "$.track_reactivity_loss((load()))");
+    assert_contains(&out, "return (await $.track_reactivity_loss(load()))()();");
     assert_eq!(
         out.matches('(').count(),
         out.matches(')').count(),

--- a/crates/rsvelte_esrap/Cargo.toml
+++ b/crates/rsvelte_esrap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rsvelte_esrap"
-version = "0.10.1"
+version = "0.10.2"
 edition = "2024"
 rust-version = "1.95"
 description = "A Rust port of esrap — prints an oxc AST to JavaScript with esrap's exact layout"

--- a/crates/rsvelte_esrap/src/printer.rs
+++ b/crates/rsvelte_esrap/src/printer.rs
@@ -563,7 +563,7 @@ impl<'opt> Printer<'opt> {
 
     /// Whether any source comment starts within `[start, end)` — used to decide
     /// if an unwrapped `ParenthesizedExpression` must keep its literal parens to
-    /// bracket an interior comment (`(/*c*/ x)`).
+    /// bracket a comment that leads its inner expression (`(/*c*/ x)`).
     fn comment_in_span(&self, start: u32, end: u32) -> bool {
         self.comments
             .iter()
@@ -2133,11 +2133,15 @@ impl<'opt> Printer<'opt> {
                 //
                 // Two exceptions keep the literal parens:
                 //
-                // 1. A comment inside the paren span: dropping the parens would
-                //    leave the interior comment dangling (`return (/*c*/ x)`,
-                //    `return (// hey\n x)`). The comment is flushed as a leading
-                //    comment of the inner expression, so the parens must stay to
-                //    bracket it as in the source.
+                // 1. A comment between the `(` and the inner expression:
+                //    dropping the parens would leave it dangling (`return (/*c*/
+                //    x)`, `return (// hey\n x)`). The comment is flushed as a
+                //    leading comment of the inner expression, so the parens must
+                //    stay to bracket it as in the source. The window stops at the
+                //    inner expression's start — a comment anywhere deeper is
+                //    already bracketed by that expression's own syntax, and
+                //    keeping the parens for it doubles those a parent adds from
+                //    precedence (`(await f(/*c*/ x))()` → `((await f(/*c*/ x)))()`).
                 // 2. A sequence: `(a, b)` parses as `Paren(Sequence)`, and the
                 //    `SequenceExpression` visitor already emits its own
                 //    surrounding parens, so the paren layer is dropped to avoid
@@ -2148,7 +2152,7 @@ impl<'opt> Printer<'opt> {
                     self.print_expression(&p.expression, ctx);
                 // No `has_loc` guard needed: every comment offset is >= `loc_base`
                 // by construction, so a synthesized span never contains one.
-                } else if self.comment_in_span(p.span.start, p.span.end) {
+                } else if self.comment_in_span(p.span.start, p.expression.span().start) {
                     ctx.write("(");
                     self.print_expression(&p.expression, ctx);
                     ctx.write(")");

--- a/crates/rsvelte_esrap/tests/compat.rs
+++ b/crates/rsvelte_esrap/tests/compat.rs
@@ -65,3 +65,26 @@ fn ts_module_and_mapped_type() {
         "declare module \"svelte\" {\n}\n\ntype M = {[K in keyof JSON]: K};"
     );
 }
+
+/// oxc preserves explicit parens as a `ParenthesizedExpression`; acorn (esrap's
+/// own parser) elides them, so the printer unwraps them and lets precedence
+/// re-add what the grammar needs. The one case that must keep its literal parens
+/// is a comment *leading* the inner expression, which would otherwise dangle.
+/// A comment deeper inside is already bracketed by that expression's own syntax:
+/// keeping the parens for it doubles the pair a parent adds from precedence.
+/// Oracle: the Svelte compiler (esrap 2.x) on the equivalent module sources.
+#[test]
+fn redundant_parens_survive_only_for_a_leading_comment() {
+    // Leading comment — parens stay.
+    assert_eq!(print_src("f((/* c */ x));", false), "f((/* c */ x));");
+    // Comment deeper inside — parens go, and the argument keeps the comment.
+    assert_eq!(print_src("f((g(/* c */ x)));", false), "f(g(/* c */ x));");
+    // No comment at all — parens go.
+    assert_eq!(print_src("f((x));", false), "f(x);");
+    // The doubling this guards against: the callee's parens come from
+    // precedence, so the paren node must not add a second pair.
+    assert_eq!(
+        print_src("async function f() {\n\t(await g(/* c */ x))();\n}", false),
+        "async function f() {\n\t(await g(/* c */ x))();\n}"
+    );
+}

--- a/crates/rsvelte_lint_types/Cargo.lock
+++ b/crates/rsvelte_lint_types/Cargo.lock
@@ -1106,7 +1106,7 @@ dependencies = [
 
 [[package]]
 name = "rsvelte_esrap"
-version = "0.10.1"
+version = "0.10.2"
 dependencies = [
  "compact_str",
  "memchr",


### PR DESCRIPTION
## What broke

`main` is red. `Coverage` (run 31119636222, `a8a653d5`) fails with three real test failures in `crates/rsvelte_core/tests/await_reactivity_loss_comment_2090.rs`:

```
expected `(await $.track_reactivity_loss(/* hi */ load()))()`. Got:
	return ((await $.track_reactivity_loss(/* hi */ load())))();
```

(The other red runs on `main` right now — `CI`, `Deploy Docs`, `C ABI`, `crates.io packages` — are the ongoing GitHub Actions outage, `Failed to resolve action download info. Error: Service Unavailable`, and are unrelated.)

## Why

Two PRs merged within a minute of each other and interacted:

- #2372 emits the dev-mode `await X` wrap as spliced **text**: `(await $.track_reactivity_loss(X))()`.
- #2380 routed the client `.svelte.(js|ts)` module through **esrap**, which re-parses each generated chunk with oxc.

oxc preserves explicit parens as a `ParenthesizedExpression`; acorn (esrap's own parser) elides them, so the printer unwraps paren nodes and lets precedence re-add whatever the grammar needs. It kept a node's literal parens whenever **any** comment fell inside its span — and the spliced wrap's span contains the user's comment. So the pair was emitted twice: once by the paren node, once by the callee's precedence rule.

## Fix

Narrow the window to `[paren.start, inner.start)`. A comment *leading* the inner expression is the only one that dangles if the parens go (`return (/*c*/ x)`); a comment deeper inside is already bracketed by that expression's own syntax.

## Verification

**Unit level.** 15 paren/comment shapes through the official compiler (`compileModule`, dev, client) vs rsvelte:

| | diverging from official |
|---|---|
| before | 9 / 15 |
| after | **3 / 15** |

The 3 that remain — `(/* c */ a + b) * 2`, `(/* c */ a, b)`, and an arrow body whose comment official drops — **diverged before this change too**, confirmed by re-running the same probe against `origin/main`'s printer as a control. They are the same doubling family (a paren kept for a genuine leading comment, plus a pair the parent adds) and want a separate fix; not widening this PR.

**Corpus level.** Built the NAPI binding from each printer and compiled the whole corpus twice. **106 outputs change.** Every one moves *toward* official:

| | of the 106 changed outputs |
|---|---|
| byte-identical to official, before | **0** |
| byte-identical to official, after | **68** |
| moved closer to official | **106** |
| moved further from official | **0** |

Real shipping code hits this. `bits-ui`'s `checkbox.svelte.ts`, for example:

```diff
-	#props = $.derived(() => (({     // main
+	#props = $.derived(() => ({      // this PR, == official
```

**The corpus gate cannot see any of it.** `pnpm run corpus:verify` passes with byte-identical numbers on both printers (`match 13183`, `js-mismatch 0`, same 599 known warning failures) — the comparison-side oxfmt normalization collapses `(({…}))` and `({…})` to the same bytes. The corpus also contains zero instances of `track_reactivity_loss(` followed by a comment, so it could not have caught the break either. `await_reactivity_loss_comment_2090` is the only gate that sees this, which is exactly why it is the one that went red.

**Suite.** Full workspace: 410 suites green, 0 failures. `cargo fmt` + `clippy --all-targets --all-features -D warnings` clean.

Newly pinned: `crates/rsvelte_esrap/tests/compat.rs::redundant_parens_survive_only_for_a_leading_comment` — leading comment keeps the parens, deeper comment drops them, and the `(await g(/* c */ x))()` callee shape stays single.

## One corrected expectation

`a_parenthesized_operand_stays_balanced` asserted `$.track_reactivity_loss((load()))`, under a docstring claiming the expected strings are the official compiler's output. That one was not: official recomputes parenthesisation from the AST and prints `load()`. It passed only because the pre-#2380 text splice copied the source bytes verbatim. Repointed at official's actual output, `return (await $.track_reactivity_loss(load()))()();`, with the docstring corrected to say what the test does and does not catch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q94UFSt4NWQ7JpZMaeAoMT
