### PR TITLE
fix(corpus): make the css-prune sweep assert it compared the whole grid

### DIFF
--- a/scripts/compat-corpus/css-prune-sweep.mjs
+++ b/scripts/compat-corpus/css-prune-sweep.mjs
@@ -44,6 +44,9 @@ const ROOT = path.resolve(__dirname, '../..');
 const CORPUS = path.join(ROOT, 'compatibility');
 const RATCHET = path.join(CORPUS, 'css-prune-known-failures.json');
 
+// Exact, not a floor: the grid is deterministic, so any drift is a source edit.
+const EXPECTED_COMPONENTS = 1430;
+
 const args = process.argv.slice(2);
 const argValue = (name, fallback = null) => {
 	const i = args.indexOf(name);
@@ -55,6 +58,17 @@ const LIST = args.includes('--list');
 const BOTH = args.includes('--both');
 const CHECK = args.includes('--check');
 const UPDATE_BASELINE = args.includes('--update-baseline');
+
+// A narrowed run measures a subset, so it can neither clear the ratchet nor
+// rewrite it: the ids it never compiled are not evidence of anything.
+if (FILTER && (CHECK || UPDATE_BASELINE)) {
+	const flag = CHECK ? '--check' : '--update-baseline';
+	const harm = CHECK
+		? 'would report "no regressions" for components it never compiled'
+		: 'would delete every baseline id outside the filter';
+	console.error(`[css-prune-sweep] --filter cannot be combined with ${flag}: a filtered run ${harm}`);
+	process.exit(2);
+}
 
 // ---------------------------------------------------------------------------
 // grid ingredients
@@ -321,11 +335,26 @@ function* generate() {
 // compile + compare
 // ---------------------------------------------------------------------------
 
-const all0 = [...generate()].filter((c) => !FILTER || c.id.includes(FILTER));
+const generated = [...generate()];
+const all0 = generated.filter((c) => !FILTER || c.id.includes(FILTER));
 if (LIST) {
 	for (const c of all0) console.log(c.id);
-	console.log(`\n${all0.length} components`);
+	console.log(`\n${all0.length} of ${generated.length} components`);
 	process.exit(0);
+}
+
+// The grid is a pure product of the axes above, so its size is a property of
+// this file rather than of the corpus on disk — pin it exactly.
+if (generated.length !== EXPECTED_COMPONENTS) {
+	console.error(
+		`[css-prune-sweep] grid produced ${generated.length} components, expected ${EXPECTED_COMPONENTS}`
+	);
+	console.error(
+		generated.length < EXPECTED_COMPONENTS
+			? '  the generator lost cases; a sweep over a shrunken grid passes by comparing less'
+			: `  the axes grew; if that is intended, set EXPECTED_COMPONENTS to ${generated.length}`
+	);
+	process.exit(2);
 }
 
 const svelte = await import(
@@ -512,7 +541,9 @@ if (CHECK) {
 	// fixed" delta left unmerged on a later PR reads as normal noise, so a
 	// real regression could hide inside it.
 	if (regressions.length > 0 || fixed.length > 0) process.exit(1);
-	console.log(`\n[css-prune-sweep] no regressions (${divergedIds.length} known divergences)`);
+	console.log(
+		`\n[css-prune-sweep] no regressions — compared ${all.length} of ${EXPECTED_COMPONENTS} components (${divergedIds.length} known divergences)`
+	);
 	process.exit(0);
 }
 


### PR DESCRIPTION
Closes #2445.

## The bug, reproduced on `origin/main`

```
$ node scripts/compat-corpus/css-prune-sweep.mjs --check --filter ZZZNOMATCH
[css-prune-sweep] 0 components in 0.0s
  matched:  0
  diverged: 0

[css-prune-sweep] no regressions (0 known divergences)
EXIT=0
```

The gate compiled nothing and reported success. Nothing in the script ever
established that the population it compared was the population it exists to
gate — `all.length` was printed at one `console.log` and asserted nowhere.

## Fix

**An exact pin, not a floor.** The grid is a pure product of the axes in this
file — no corpus, no disk, no I/O — so its size is a property of the source and
drift is always a source edit. That also makes a threshold the wrong tool: the
realistic failure is losing one axis value, which drops **40 of 1430**
components. A floor of 1000 passes that; the pin catches it and prints the new
number so an intended change is a one-line update.

**`--filter` may not gate.** A narrowed run measures a subset, so it can neither
clear the ratchet nor rewrite it. Under `--update-baseline` it would have
deleted every id outside the filter — the same FALSE-SHRINK trap `verify.mjs`
already refuses for `--families`. This path was reachable before this PR.

The success banner now carries its denominator (`compared 1430 of 1430`), since
that is the line a human actually scans in CI output.

## Every arm observed firing

| Arm | Result |
|---|---|
| `--check --filter ZZZNOMATCH` (the bug) | `EXIT=2`, refuses — was `EXIT=0` "no regressions" |
| `--update-baseline --filter ZZZNOMATCH` | `EXIT=2`, refuses |
| axis shrink (`SELECTORS_C3.slice(1)`) | `EXIT=2` `grid produced 1390 components, expected 1430` |
| axis growth (`SELECTORS_B` doubled) | `EXIT=2` `the axes grew; if that is intended, set EXPECTED_COMPONENTS to 1502` |
| full `--check` (the CI form) | `EXIT=0` `compared 1430 of 1430 components (0 known divergences)`, 4.1s |
| `--list` | unchanged diagnostic, `1430 of 1430 components` |

Both assert branches were driven by mutating the generator itself, not by
editing the constant, so the pin is verified against the failure it names.
`--list` and `--id` stay unguarded on purpose: they inspect rather than gate,
and they are the tools you would reach for when the assert fires.

## Not in scope

Two lower-severity defects in the same file, left for separate PRs so this one
stays revertible: `--both` computes `clientServerDiffs` and never gates on it,
and `compileCss` discards `result.warnings`. Both are the same
discarded-measurement family; neither is on the CI path.

## CI

GitHub Actions is in a major outage, so this was verified locally only. The
compile arms ran in a warm worktree with submodules present; the script is
byte-identical between `origin/main` and that checkout (`git diff --stat` empty),
and it was restored to clean afterwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
