### PR TITLE
ci(corpus-compat): gate on the submodules and actions the jobs consume (#2449)

### DIFF
--- a/.github/workflows/corpus-compat.yml
+++ b/.github/workflows/corpus-compat.yml
@@ -45,6 +45,8 @@ on:
       - 'submodules/svelte'
       - 'submodules/svelte.dev'
       - 'submodules/language-tools'
+      - 'submodules/eslint-plugin-svelte'
+      - 'submodules/svelte-eslint-parser'
       - 'submodules/bits-ui'
       - 'submodules/flowbite-svelte'
       - 'submodules/melt-ui'
@@ -83,6 +85,7 @@ on:
       - 'Cargo.toml'
       - 'Cargo.lock'
       - '.github/workflows/corpus-compat.yml'
+      - '.github/actions/**'
   pull_request:
     paths:
       - 'crates/**'
@@ -93,6 +96,8 @@ on:
       - 'submodules/svelte'
       - 'submodules/svelte.dev'
       - 'submodules/language-tools'
+      - 'submodules/eslint-plugin-svelte'
+      - 'submodules/svelte-eslint-parser'
       - 'submodules/bits-ui'
       - 'submodules/flowbite-svelte'
       - 'submodules/melt-ui'
@@ -131,6 +136,7 @@ on:
       - 'Cargo.toml'
       - 'Cargo.lock'
       - '.github/workflows/corpus-compat.yml'
+      - '.github/actions/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
Closes #2449.

## The gap

`corpus-compat.yml` is path-filtered on both `push` and `pull_request`. Three things every run depends on were absent from both blocks:

| path | consumed at | consequence |
|---|---|---|
| `submodules/eslint-plugin-svelte` | checked out `:356`, collected `:380` — it *is* the lint oracle | a gitlink bump ran no corpus gate; `lint-known-failures.json` was never re-validated against the new upstream rule set |
| `submodules/svelte-eslint-parser` | same | same |
| `.github/actions/**` | `uses: ./.github/actions/{setup-rust,setup-node-pnpm}` in all 6 jobs | a change to either composite action was covered by nothing else in the list |

The lint job's whole ground truth is a submodule that could not trigger it.

## Computed, not eyeballed

I extracted the two sets rather than reading down the list, because a hand-checked list is "paths I thought of":

```
before:  submodules referenced in workflow : 38
         submodules listed in paths blocks : 36
         REFERENCED BUT NOT IN paths       : ['eslint-plugin-svelte', 'svelte-eslint-parser']

after:   submodules referenced in workflow : 38
         submodules listed in paths blocks : 38
         REFERENCED BUT NOT IN paths       : NONE
         listed but never referenced       : NONE
```

## Verification (local — Actions is in a declared `major_outage`)

The `after` figures above are from parsing the file with `yaml.safe_load` and comparing the real `on.push.paths` / `on.pull_request.paths` lists, not from a regex over the text:

- YAML parses; all 6 jobs intact (`corpus`, `fmt-parity`, `lint-parity`, `check-parity`, `check-e2e-parity`, `shape-matrix`)
- both blocks are **identical** at 49 entries each — they are maintained by hand and had to be edited twice
- all three new entries present in both blocks
- 0 listed-but-unreferenced, so nothing stale was introduced

Diff is 6 added lines, 3 per block, no deletions.

## Deliberately not included

- **`package.json`** — the workflow invokes no `pnpm run` script (verified: zero matches for `pnpm run` / `pnpm exec` / `npm run` in the file), and dependency changes move `pnpm-lock.yaml`, which is already listed. Adding it would broaden the trigger without a demonstrated dependency.
- **`scripts/fixtures/**`** — only `fmt-corpus.oxfmtrc.json` is read, and it is already listed individually.

## Follow-up worth considering

The two blocks are duplicated by hand and must be kept in sync, which is the mechanism that produced this miss — and it will produce the next one. Deriving the submodule half from `corpus-sources.json` plus the jobs' checkout lists, or adding a CI assertion that every `submodules/X` referenced in the workflow appears in both blocks, would remove the class rather than this instance. I kept that out of this PR so the fix stays reviewable while CI cannot run; the check itself is ~20 lines and would sit alongside `scripts/ci/check-lint-types-lock.mjs`.

Context: found while building `compatibility/gate-coverage.md` (#2456), cross-cutting section C1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
