### PR TITLE
fix(corpus): fail the fmt parity gate when the oracle tree is incomplete

### DIFF
--- a/scripts/compat-corpus/fmt-verify.mjs
+++ b/scripts/compat-corpus/fmt-verify.mjs
@@ -66,9 +66,9 @@ if (!fs.existsSync(META_PATH)) {
 const meta = JSON.parse(fs.readFileSync(META_PATH, "utf8"));
 const included = meta.included ?? [];
 
-// Guard against a silently-empty gate: if the oracle produced almost nothing
-// (e.g. corpus not collected, or oxfmt rejected everything) the byte compare
-// below would pass vacuously. The real corpus has thousands of components.
+// Guard against a truncated collection. This counts manifest entries, NOT
+// oracle files on disk — the vacuous-pass case (a manifest promising work that
+// the oracle tree no longer holds) is caught after the loop instead.
 if (included.length < 1000) {
   fail(
     `only ${included.length} components in the parity set — the corpus looks incomplete; re-run collect.mjs + fmt.mjs`,
@@ -84,6 +84,7 @@ const excludedSet = new Set(excludedEntries.map((e) => e.id));
 
 const includedSet = new Set(included);
 const failures = [];
+const missingOracle = [];
 let matched = 0;
 let excluded = 0;
 for (const id of included) {
@@ -94,7 +95,10 @@ for (const id of included) {
   }
   const oracle = readIf(path.join(ORACLE, id));
   const actual = readIf(path.join(ACTUAL, id));
-  if (oracle === null) continue; // not part of the parity set
+  if (oracle === null) {
+    missingOracle.push(id);
+    continue;
+  }
   if (actual === null) {
     failures.push({ id, kind: "missing", detail: { line: 0 } });
     continue;
@@ -104,6 +108,30 @@ for (const id of included) {
     continue;
   }
   failures.push({ id, kind: "diff", detail: firstDiffLine(oracle, actual) });
+}
+
+// fmt.mjs writes meta.included as exactly the ids whose oracle output it
+// copied, so a missing oracle file means the cached tree disagrees with its own
+// manifest and every such id was skipped without being compared.
+if (missingOracle.length) {
+  console.error(
+    `[fmt-verify] ${missingOracle.length} of ${included.length} components have no oracle output — ` +
+      `compared ${matched + failures.length} of ${included.length - excluded} comparable components`,
+  );
+  for (const id of missingOracle.slice(0, MAX_PRINT)) console.error(`  - ${id}`);
+  if (missingOracle.length > MAX_PRINT)
+    console.error(`  … and ${missingOracle.length - MAX_PRINT} more`);
+  fail("the oracle tree is incomplete; regenerate it with `node scripts/compat-corpus/fmt.mjs --force`");
+}
+
+// Every included id must leave the loop through exactly one counter; a silent
+// path added later would otherwise shrink the comparison set unnoticed.
+const accounted = matched + failures.length + excluded + missingOracle.length;
+if (accounted !== included.length) {
+  fail(
+    `accounting mismatch: ${accounted} ids accounted for (matched ${matched} + failed ${failures.length} + ` +
+      `excluded ${excluded} + no-oracle ${missingOracle.length}) but the parity set has ${included.length}`,
+  );
 }
 
 // Staleness checks for excluded entries.
@@ -213,5 +241,8 @@ if (failures.length) {
     `\n[fmt-verify] ✅ no regressions (${failures.length} known failures remain — burn down then --update-baseline)`,
   );
 } else {
-  console.log("\n[fmt-verify] ✅ all corpus components format identically to the oracle");
+  console.log(
+    `\n[fmt-verify] ✅ all ${matched} compared components format identically to the oracle ` +
+      `(${included.length} in the parity set, ${excluded} oracle-excluded)`,
+  );
 }


### PR DESCRIPTION
Closes #2447.

## The bug, reproduced on `origin/main`

With `fmt/meta.json` listing 1500 components and an empty `fmt/oracle/` tree:

```
[fmt-verify] results:
  included  1500
  matched   0
  failed    0

[fmt-verify] ✅ all corpus components format identically to the oracle
EXIT=0
```

A universal claim about 1500 components, backed by **zero** comparisons.

## Why the existing guard did not catch it

`fmt-verify.mjs` already had a guard whose comment claims this exact job:

> Guard against a silently-empty gate: if the oracle produced almost nothing …
> the byte compare below would pass vacuously.

It tests `included.length < 1000` — entries in **`fmt/meta.json`** — while the
loop reads files from **`fmt/oracle/`**. Two different populations. A manifest
that outlives its oracle tree satisfies the guard and then skips every
comparison at `if (oracle === null) continue;`.

That divergence is reachable rather than theoretical: `fmt/oracle/` is a
gitignored, SHA-keyed, CI-cached tree, and `fmt.mjs` carries `included` over
from an existing `meta.json` whenever the oracle is considered fresh, without
re-checking that the files are still there.

## Fix

`fmt.mjs` writes `meta.included` as exactly the ids whose oracle output it
copied (`fmt.mjs:259,263`), so a missing oracle file is an integrity violation,
not a per-id skip — the `// not part of the parity set` comment was describing a
condition that cannot legitimately arise. Collect those ids and fail, stating
how many of how many were compared.

Worth noting the asymmetry that let this survive: a missing **`actual`** was
already a loud failure two lines below. Only **`oracle`** was silent.

Also added a reconciliation of `matched + failed + excluded + no-oracle` against
the parity set. It is a tautology today, on purpose — it is there so a silent
path added later cannot shrink the comparison set without shrinking the report.

## Every arm observed firing

| Arm | Result |
|---|---|
| empty oracle tree (the bug) | `EXIT=1` `1500 of 1501 components have no oracle output — compared 0 of 1500 comparable components` |
| **one** missing oracle file | `EXIT=1` `1 of 1501 … — compared 1499 of 1500`, names `comp1499.svelte` |
| healthy corpus | `EXIT=0` `✅ all 1500 compared components format identically to the oracle (1501 in the parity set, 1 oracle-excluded)` |
| real formatting divergence | `EXIT=1` `1 NEW failures`, unchanged |
| missing `actual` | `EXIT=1` `[missing]`, pre-existing path unchanged |
| injected silent `continue` | `EXIT=1` `accounting mismatch: 1351 ids accounted for … but the parity set has 1501` |

The second arm is the one that argues against a threshold: a single missing
oracle in 1500 is caught exactly, and no floor would have noticed it. The last
arm confirms the reconciliation is not dead code.

Arms were driven by constructing the on-disk state (`meta.json` + trees), since
the script's only inputs are files; the real corpus is generated and
gitignored, and needs a runnable `oxfmt` plus the svelte.dev submodule.

## Risk

The strict reading is deliberate: any id in the manifest with no oracle file now
fails rather than being skipped. If some platform-specific case makes that
legitimate, it will surface as a precise count with ids listed — and the
`--update-baseline` path's "not-locally-checkable" carry-over handles ids that
are absent from `included` entirely, which is a different set and is untouched
here. Flagging it explicitly in case a reviewer knows of a case I do not.

## CI

GitHub Actions is in a major outage, so this was verified locally only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
