### PR TITLE
fix(lint): collect .svelte.js and .svelte.ts files (#2465)

### DIFF
--- a/.changeset/lint-collect-svelte-modules.md
+++ b/.changeset/lint-collect-svelte-modules.md
@@ -1,0 +1,5 @@
+---
+'@rsvelte/lint': patch
+---
+
+fix(lint): lint `.svelte.js` and `.svelte.ts` files, which the CLI silently skipped

--- a/crates/rsvelte_lint/src/main.rs
+++ b/crates/rsvelte_lint/src/main.rs
@@ -1,6 +1,7 @@
 //! `rsvelte-lint` — the CLI.
 //!
-//! Lints `.svelte` files (passed directly or discovered under directories),
+//! Lints `.svelte`, `.svelte.js` and `.svelte.ts` files (passed directly or
+//! discovered under directories),
 //! merging compiler warnings/a11y (validator wrap) with native rules, and
 //! prints diagnostics through the shared `svelte_check` writers (plus a local
 //! SARIF writer) so the output matches `rsvelte check`.
@@ -20,7 +21,8 @@ const VERSION: &str = env!("CARGO_PKG_VERSION");
 #[derive(Parser, Debug)]
 #[command(name = "rsvelte-lint", about = "Fast native Svelte linter", version = VERSION)]
 struct Cli {
-    /// Files or directories to lint. Directories are searched for `.svelte`.
+    /// Files or directories to lint. Directories are searched for `.svelte`,
+    /// `.svelte.js` and `.svelte.ts`.
     paths: Vec<PathBuf>,
 
     /// Output format: human | human-verbose | machine | machine-verbose | github-actions | sarif.
@@ -62,17 +64,24 @@ struct Cli {
     print_eslint_config: bool,
 }
 
+/// `Path::extension()` of `a.svelte.js` is `js`, so a module's Svelte-ness is
+/// only visible in the whole file name.
+fn is_lintable(path: &Path) -> bool {
+    path.file_name().and_then(|n| n.to_str()).is_some_and(|n| {
+        n.ends_with(".svelte") || n.ends_with(".svelte.js") || n.ends_with(".svelte.ts")
+    })
+}
+
 fn collect_files(paths: &[PathBuf]) -> Vec<PathBuf> {
     let mut files = Vec::new();
     for p in paths {
         if p.is_dir() {
             for entry in walkdir::WalkDir::new(p).into_iter().flatten() {
-                let path = entry.path();
-                if path.extension().is_some_and(|e| e == "svelte") {
-                    files.push(path.to_path_buf());
+                if entry.file_type().is_file() && is_lintable(entry.path()) {
+                    files.push(entry.path().to_path_buf());
                 }
             }
-        } else if p.extension().is_some_and(|e| e == "svelte") {
+        } else if is_lintable(p) {
             files.push(p.clone());
         }
     }
@@ -257,5 +266,36 @@ fn internal_error(file: &Path) -> Diagnostic {
         message: "internal error while linting this file (skipped)".into(),
         range: None,
         source: "svelte",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn lintable_covers_components_and_svelte_modules() {
+        for name in ["A.svelte", "a.svelte.js", "a.svelte.ts", "dir/a.svelte.js"] {
+            assert!(is_lintable(Path::new(name)), "{name} should be lintable");
+        }
+    }
+
+    #[test]
+    fn lintable_rejects_plain_scripts_and_others() {
+        // `a.js`/`a.ts` are the negative control: collecting every script in a
+        // directory is a separate product decision, not this predicate's job.
+        for name in [
+            "a.js",
+            "a.ts",
+            "a.svelte.jsx",
+            "svelte",
+            "README.md",
+            "a.sveltefoo",
+        ] {
+            assert!(
+                !is_lintable(Path::new(name)),
+                "{name} should not be lintable"
+            );
+        }
     }
 }


### PR DESCRIPTION
Closes #2465. Prerequisite for #2448.

## The bug

`rsvelte-lint` silently linted **no** `.svelte.js` or `.svelte.ts` file. Not a missing rule — the CLI never handed those paths to the engine, which has supported them all along.

`crates/rsvelte_lint/src/main.rs`, before:

```rust
if path.extension().is_some_and(|e| e == "svelte") {   // :71 directory walk
...
} else if p.extension().is_some_and(|e| e == "svelte") { // :75 explicit path arg
```

`Path::extension()` returns the segment after the **last** dot, so `a.svelte.js` → `Some("js")`. Both arms rejected it.

**The failure mode is the worst kind: silent, user-facing, and indistinguishable from "your code is clean."** No warning, no skipped-file notice, exit 0. A project whose state lives in rune modules — which is the recommended Svelte 5 shape — gets a green `rsvelte-lint src/` while every one of those files goes unread. A CI pipeline built on it reports passing.

## Reproduction

Three files, the same `svelte/no-store-async` violation in each — one component, two modules.

**Before:**

```
$ rsvelte-lint --config cfg.json repro/
ERROR repro/Comp.svelte:3:24 (svelte): Do not pass async functions to svelte stores.

rsvelte-lint found 1 error and 0 warnings in 1 file          <- 1 of 3
```

Naming the modules explicitly is worse — the user asked for exactly these files and was told they are clean:

```
$ rsvelte-lint --config cfg.json repro/mod.svelte.js repro/mod.svelte.ts

rsvelte-lint found 0 errors and 0 warnings in 0 files
EXIT=0
```

A modules-only directory behaves the same: `0 files`, exit 0.

**After:**

```
$ rsvelte-lint --config cfg.json repro/
ERROR repro/Comp.svelte:3:24    (svelte): Do not pass async functions to svelte stores.
ERROR repro/mod.svelte.js:3:29  (svelte): Do not pass async functions to svelte stores.
ERROR repro/mod.svelte.ts:3:38  (svelte): Do not pass async functions to svelte stores.

rsvelte-lint found 3 errors and 0 warnings in 3 files
```

Explicit paths → 2 errors in 2 files, exit 1. Modules-only directory → 1 error in 1 file, exit 1.

Note the `.svelte.ts` column: **38** against the `.js`'s **29**, the offset of the `: unknown` annotation. The TS module was genuinely parsed as TS, not merely name-matched.

## The fix

Match the whole file name, since a module's Svelte-ness is invisible to `extension()`:

```rust
fn is_lintable(path: &Path) -> bool {
    path.file_name().and_then(|n| n.to_str()).is_some_and(|n| {
        n.ends_with(".svelte") || n.ends_with(".svelte.js") || n.ends_with(".svelte.ts")
    })
}
```

This is collection only. The engine was always ready: `engine::run_script_rules_module` (`engine.rs:332`) is public and implemented, `engine.rs:124,132` dispatch `.svelte.js`/`.svelte.ts` to it, and rules were written against it (`no_store_async.rs:5`, `require_stores_init.rs:4`).

Two smaller changes ride along, both stated rather than slipped in:

- **`entry.file_type().is_file()`** on the walk. The old code would also have pushed a *directory* named `foo.svelte`; widening the name set makes that likelier, so it is now guarded. Drop it if you'd rather keep the diff to one predicate.
- **Doc strings** — the module header and the `--help` text for `paths` both said `.svelte` only. `--help` is user-facing.

Deliberately **not** included: plain `.js`/`.ts`. `engine.rs:333` names them, but linting every script in a directory is a product decision, not a bug fix, and `.svelte.js`/`.svelte.ts` is exactly the set `lint-collect.mjs` classifies as `kind: 'module'`. Worth deciding separately.

## Verification

Local only — GitHub Actions is in a declared `major_outage` (status API: 12 components, 2 non-operational — Actions and Pages).

- **Reproduced and fixed**, all three invocation shapes above, against a real built binary.
- **`cargo test -p rsvelte_lint`: 304 tests, 0 failures.**
- **Two new unit tests** on `is_lintable`, with negative controls (`a.js`, `a.ts`, `a.svelte.jsx`, `svelte`, `README.md`, `a.sveltefoo`).
- **The tests were confirmed to discriminate.** I reverted `is_lintable` to the old predicate and re-ran: the positive test failed on exactly `a.svelte.js should be lintable`, and the negative-control test still passed — so it fails for the predicted reason and the two tests are not coupled. Then restored.
- `cargo fmt -p rsvelte_lint --check`: clean.

- **`cargo clippy -p rsvelte_lint --bin rsvelte-lint -- -D warnings`: exit 0.**

A note on that last one, because it briefly read otherwise. My first clippy run was killed when free space hit 6.2 GiB against an agreed 6 GiB floor (the machine is at 99% with several agents building). The wrapping pipeline reported **exit 0 — which was `tail`'s status, not clippy's**; the real output showed `signal: 15, SIGTERM`. I re-ran it later under a disk watchdog and it passed properly, 7666 → 6940 MiB with the floor never crossed. Recording it because a masked exit code in a pipeline is indistinguishable from a passing check, and this PR is about exactly that class of silence.

## Why this blocks #2448

#2448 removes the `kind === 'component'` filter so the lint corpus compares modules. Doing that first would have filled `lint-known-failures.json` with `-` (false-negative) entries that all restate this one bug, burying the rule-level divergences the gate exists to find. With this merged, that ratchet measures what it was meant to.

Related: `prefer_svelte_reactivity.rs:19-21` declines to port a rule path upstream implements, citing in-code that those fixtures are *"not collected by the component oracle"*. The blind spot did not only hide divergence — it was written down as grounds for not implementing. Context in #2456.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
