### PR TITLE
fix(corpus): write the jsKey delimiter as an escape, not a raw NUL byte

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -174,6 +174,23 @@ docker compose exec dev cargo test
 
 VS Code Dev Containers ("Reopen in Container") also works.
 
+### grep can return nothing and mean nothing
+
+Four ways `grep` has silently reported "no matches" for strings that were
+present. All of them produce a confident empty result, so a negative grep is
+never on its own evidence that something is absent — confirm with a positive
+control on a string you know is there.
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `grep X file` finds nothing that is there | `grep` is a shell function wrapping `ugrep --ignore-files`, which skips gitignored paths | `command grep` |
+| `Binary file … matches`, no lines printed | one NUL byte anywhere in the file (not non-ASCII — UTF-8 is fine) | `command grep -a`, or `git grep` |
+| `git show rev:file \| grep X` finds nothing | the wrapper's `-I` discards binary-looking **stdin** | `git grep X rev -- file` |
+| later matches missing | `\| head -N` truncates with no error | state the denominator, or drop the cap |
+
+Related: in `cmd \| head`, `$?` is `head`'s status, not `cmd`'s. Never read a
+verdict through a pipe.
+
 ### Working with Subagents
 
 Use the `Agent` tool for substantial work — feature implementation, multi-file refactors, broad code exploration, or anything likely to consume meaningful context.

--- a/scripts/compat-corpus/verify.mjs
+++ b/scripts/compat-corpus/verify.mjs
@@ -277,7 +277,7 @@ const failures = [];
 // diff.
 
 const AST_EQUIV_BIN = path.join(ROOT, 'target/release/ast_equiv_batch');
-const jsKey = (id, target) => `${id} ${target}`;
+const jsKey = (id, target) => `${id}\0${target}`;
 const jsByteEqual = new Map();
 const astCandidates = new Map();
 


### PR DESCRIPTION
Follow-up to the grep discussion on #2470.

## Root cause, not a workaround

`verify.mjs` contained **one literal NUL byte**, in a template literal:

```js
const jsKey = (id, target) => `${id}<NUL>${target}`;
```

A single NUL makes grep classify the whole file as binary, so it prints
`Binary file scripts/compat-corpus/verify.mjs matches` and **suppresses the
matching lines**. That is why several searches of the largest file in
`scripts/compat-corpus/` came back confidently empty today.

The diagnosis that it was non-ASCII (`✅`/`❌`) is wrong, and worth correcting
because it points at the wrong fix: the file is valid UTF-8 and has 8 distinct
non-ASCII bytes, which grep does not mind. `file(1)` said `(binary data)`; it now
says `Unicode text, UTF-8 text`.

## The fix changes no runtime value

`\0` is the same U+0000. Verified rather than assumed:

```
escape yields U+0000: true | equals raw byte form: true
distinct keys (delimiter still separates): true
```

The delimiter's purpose — a byte that cannot occur inside an id or a target — is
unchanged. Only the file's stored bytes change, from binary to text.

Before / after, same command, no `-a`:

```
$ command grep -n "^import" scripts/compat-corpus/verify.mjs
Binary file scripts/compat-corpus/verify.mjs matches          # before
77:import fs from 'node:fs';                                   # after
```

## Documentation

`AGENTS.md` gains a short table of the four ways grep has silently returned
nothing for a string that was present — a wrapper skipping gitignored paths, this
NUL classification, `-I` on piped stdin, and `| head` truncation — plus the note
that `$?` through a pipe is `head`'s status. This one was fixable at the source;
the other three are permanent properties of the tooling, so the guidance is to
treat a negative grep as evidence only after a positive control.

## CI

Actions is in a major outage; verified locally. `node --check` passes and the
`jsKey` call sites at `:291` and `:350` are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
