### PR TITLE
test(compiler): make the `$:` comment-delimiter crash gate discriminating (#2443)

### DIFF
--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/destructure_transforms.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/destructure_transforms.rs
@@ -1619,6 +1619,24 @@ mod non_ascii_tests {
             vec!["a".to_string(), "c".to_string()]
         );
     }
+
+    /// An unbalanced `{`- or `[`-prefixed fragment strips to itself, so recursing
+    /// into it never shrinks the input — that overflowed the stack and aborted the
+    /// host process instead of producing output or an error.
+    #[test]
+    fn extract_destructure_targets_terminates_on_an_unbalanced_fragment() {
+        use super::extract_destructure_targets;
+
+        assert!(extract_destructure_targets("{\n\t\t// } c\n\t\tbar").is_empty());
+        assert!(extract_destructure_targets("{ a").is_empty());
+        assert!(extract_destructure_targets("[ a").is_empty());
+        assert!(extract_destructure_targets("{ a: [b").is_empty());
+        // A balanced pattern still yields its targets.
+        assert_eq!(
+            extract_destructure_targets("{ a: [b] }"),
+            vec!["b".to_string()]
+        );
+    }
 }
 
 #[cfg(test)]

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/tests.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/tests.rs
@@ -1713,3 +1713,27 @@ export function useInterval(callback, delay) {
         "derived read should be called on the server:\n{server}"
     );
 }
+
+/// A `}` or `)` inside a comment is comment text. Read as a bracket it drops the
+/// scan's depth to 0 inside a `$:` block body, so the block's own `bar = []`
+/// reads as a top-level assignment and the `{`-prefixed left-hand side that
+/// produces is what reaches the destructure expansion.
+#[test]
+fn find_assignment_position_ignores_delimiters_inside_comments() {
+    use super::state_transforms::find_assignment_position;
+
+    assert_eq!(
+        find_assignment_position("{\n\t\t// } c\n\t\tbar = []\n\t}"),
+        None
+    );
+    assert_eq!(
+        find_assignment_position("{\n\t\t// ) c\n\t\tbar = []\n\t}"),
+        None
+    );
+    assert_eq!(
+        find_assignment_position("{\n\t\t/* } c */\n\t\tbar = []\n\t}"),
+        None
+    );
+    // A real top-level assignment is still found.
+    assert_eq!(find_assignment_position("bar = []"), Some(4));
+}

--- a/crates/rsvelte_core/tests/reactive_block_comment_delimiter_2351.rs
+++ b/crates/rsvelte_core/tests/reactive_block_comment_delimiter_2351.rs
@@ -1,20 +1,32 @@
-//! Issue #2351: a `}` / `)` inside a comment in a `$:` block body crashed the
-//! client compiler.
+//! Issue #2351 (re-reported as #2443): a `}` / `)` inside a comment in a `$:`
+//! block body crashed the client compiler.
+//!
+//! The three ordinary-comment cases below no longer reach the scan they were
+//! written for: `strip_reactive_statement_comments` now deletes a `$:` body's
+//! comments before phase 3 sees them, so they pass even with the fix reverted.
+//! That pass keeps `svelte-ignore` comments, which is why the variants carrying
+//! one are the cases that still exercise the scan end to end. The unit tests on
+//! `find_assignment_position` and `extract_destructure_targets` pin the two
+//! load-bearing behaviours directly, independent of what runs upstream of them.
 
 use rsvelte_core::{CompileOptions, GenerateMode, compile};
 
-fn client(src: &str) -> String {
+fn compile_client(src: &str, dev: bool) -> String {
     compile(
         src,
         CompileOptions {
             filename: Some("T.svelte".into()),
             generate: GenerateMode::Client,
-            dev: false,
+            dev,
             ..Default::default()
         },
     )
     .map(|r| r.js.code)
     .unwrap_or_else(|e| format!("COMPILE_ERROR: {e:?}"))
+}
+
+fn client(src: &str) -> String {
+    compile_client(src, false)
 }
 
 /// The official compiler emits this for every variant below; before the fix the
@@ -46,6 +58,25 @@ fn block_comment_with_paren_in_reactive_block() {
     assert_matches_official(&client(
         "<script>\n\tlet bar\n\t$: {\n\t\t/* ) c */\n\t\tbar = []\n\t}\n</script>",
     ));
+}
+
+/// A `svelte-ignore` comment survives the reactive-statement comment stripper,
+/// so these are the end-to-end inputs that still reach the scan. `dev` is
+/// covered too: the crash was reported on both client targets.
+#[test]
+fn svelte_ignore_comment_with_delimiter_in_reactive_block() {
+    for comment in [
+        "// svelte-ignore } c",
+        "// svelte-ignore ) c",
+        "/* svelte-ignore } c */",
+        "/* svelte-ignore ) c */",
+    ] {
+        let src =
+            format!("<script>\n\tlet bar\n\t$: {{\n\t\t{comment}\n\t\tbar = []\n\t}}\n</script>");
+        for dev in [false, true] {
+            assert_matches_official(&compile_client(&src, dev));
+        }
+    }
 }
 
 /// A `=` inside a string literal is not an assignment either — the same scan


### PR DESCRIPTION
Closes #2443.

## The report does not reproduce — it is #2351 with a stale binary

The exact repro in #2443 compiles correctly on `origin/main`, byte-for-byte
identical to the official compiler:

```
import 'svelte/internal/disclose-version';
import 'svelte/internal/flags/legacy';
import * as $ from 'svelte/internal/client';

export default function X($$anchor, $$props) {
	$.push($$props, false);

	let bar = $.mutable_source();

	$.legacy_pre_effect(() => {}, () => {
		$.set(bar, []);
	});

	$.legacy_pre_effect_reset();
	$.pop();
}
```

Four measurements, not one:

| where | what was run | result |
|---|---|---|
| `origin/main` (73aef74f) | release NAPI binding, the issue's exact JS snippet | compiles, matches official |
| `origin/main`, release + fat-LTO | the #2443 seed x 5 comment kinds x every line boundary x 3 targets = 195 compiles | 0 crashes |
| `3e22d146` — **the base the report was made from** | same 195 compiles | 0 crashes |
| `badd4303` (= `e799ef4a^`, one commit earlier) | the minimal repro | **stack overflow, process aborts** |

So the crash is real, and it was fixed by e799ef4a (PR #2354, issue #2351) —
which is already an ancestor of `3e22d146`. The binding used for the report
predates the fix. `git diff --stat` being empty compares *sources*; it says
nothing about what `.corpus-cache/rsvelte.node` was built from.

## The crash site

`extract_destructure_targets` recursed on a `{`-prefixed fragment that its own
"remove outer brackets" step declines to strip when the closing bracket is
missing, so the callee re-derived the identical string. The fragment came from
`find_assignment_position` reading the `}` inside `// } c` as a real bracket:
depth fell to 0 mid-block, the block's own `bar = []` looked like a top-level
assignment, and the left-hand side that produced was `{\n\t\t// } c\n\t\tbar`.
Both halves are what e799ef4a fixed.

## What this PR changes: the gate no longer sees the bug

`crates/rsvelte_core/tests/reactive_block_comment_delimiter_2351.rs` was written
for this crash. Mutating **both** hunks of e799ef4a into no-ops on today's
`main` leaves all four of its tests **green** — `strip_reactive_statement_comments`
(#2195, extended by #2365) now deletes a `$:` body's comments before phase 3
sees them, so the delimiter never reaches the scan. The tests pass for a reason
unrelated to what they guard.

Measured under that same mutation: of `cargo test -p rsvelte_core --lib` (1455
unit tests) plus 12 integration suites covering legacy `$:` and destructuring,
**zero** pre-existing tests fail. (`compiler_fixtures` fails, but it fails
identically on unmutated `main` — the generated fixtures are absent in this
checkout, so that failure is not attributable.)

Three additions restore discrimination, each verified against the mutation of
the hunk it guards:

| test | mutation that kills it | how it fails |
|---|---|---|
| `svelte_ignore_comment_with_delimiter_in_reactive_block` | both hunks | stack overflow / abort |
| `find_assignment_position_ignores_delimiters_inside_comments` | the `skip_opaque` hunk | returns `Some(17)` instead of `None` |
| `extract_destructure_targets_terminates_on_an_unbalanced_fragment` | the balanced-pair hunk | stack overflow / abort |

The end-to-end case uses a `svelte-ignore` comment because that is the one kind
the stripper keeps, so it is the only input shape that still reaches the scan
through the public API. The two unit tests pin the behaviours directly, so the
gate survives a future change to what runs upstream of them.

## Sibling sweep

Denominator: `git ls-files '*.rs'` — 13,348 `fn` definitions across 1,049 files.
509 are directly self-recursive; 101 of those take a `&str`. The crash class is
narrower than either: self-recursion on a **sub-slice of the same string that can
fail to shrink**. The destructure-pattern family is the only group that recurses
into a bracket-delimited sub-pattern:

| function | guard | verdict |
|---|---|---|
| `client/destructure_transforms.rs::extract_destructure_targets` | none, pre-fix | **the bug** |
| `client/destructure_transforms.rs::extract_destructure_paths` | recurses only inside a balanced arm, on strictly inner slices | safe |
| `client/state_transforms.rs::collect_legacy_destructure_var_names` | same | safe |
| `server/transform_script.rs::collect_destructure_leaf_names` | callee early-returns unless balanced | safe |
| `server/transform_script.rs::extract_destructured_names_simple` | callee early-returns unless balanced | safe |
| `server/transform_script.rs::flatten_destructured_let_ssr_inner` | same | safe |
| `server/transform_legacy.rs::extract_destructured_export_paths_ssr` | same | safe |

`extract_destructure_targets` was the outlier: its bracket-stripping step falls
through to `inner = trimmed` when unbalanced instead of returning, which is what
made the recursion non-shrinking. One fix, one site.

This does **not** close #2434. Cause 2 there is a server-side
`$derived(() => ({…}))` scanner, a different site reached by the same *trigger*
(a delimiter inside a comment) — that trigger class is the #2357 campaign's.

## Separate finding, not fixed here

On the `svelte-ignore` variant, rsvelte keeps the comment inside the emitted
`$.legacy_pre_effect` body and the official compiler drops it. The divergence is
delimiter-independent (`// svelte-ignore c` diverges the same way), so it is not
this crash. It is invisible to the corpus gate for the reason #2424 gives —
`ast_equiv_batch` runs with `CommentPolicy::Ignore`. Worth its own issue.

## Verification

Run locally (GitHub Actions is in a declared major outage; no CI signal exists
for this PR):

- `cargo test -p rsvelte_core --lib` — 1457 passed
- `cargo test -p rsvelte_core --test reactive_block_comment_delimiter_2351` — 5 passed
- 12 further integration suites covering legacy `$:` / destructuring — all pass
- `cargo +1.97.1 fmt --all -- --check` — clean
- `cargo clippy -p rsvelte_core --all-targets --all-features -- -D warnings` — clean

Test-only change, so no changeset (the `changeset` workflow requires one for
`fix` / `feat` titles only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
