### PR TITLE
fix(compiler): walk the client store lookback by characters (#2442)

### DIFF
--- a/.changeset/tidy-pugs-invent.md
+++ b/.changeset/tidy-pugs-invent.md
@@ -1,0 +1,14 @@
+---
+'@rsvelte/compiler': patch
+---
+
+Walk the client store-subscription lookback by characters. Deciding whether a
+`$name(` call sits in a function parameter list means stepping back over the
+function name to the `function` keyword, and the three cursors that did it moved
+one **byte** at a time. Continuation bytes leak through both predicates — `0x85`
+and `0xA0` read as whitespace, and nine of the sixty-four read as alphanumeric
+(`ª ² ³ µ ¹ º ¼ ½ ¾`) — so the cursor could stop inside a character. Depending on
+which character preceded the parenthesis that was either a panic on a
+non-boundary slice or, just as often, a silent wrong answer: the lookback never
+reached `function`, so a store call inside a parameter list was rewritten to
+`$s()(…)` when it should have been left alone.

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/store_transforms.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/store_transforms.rs
@@ -196,6 +196,17 @@ pub(super) fn is_function_parameter_in_statement(statement: &str, store_sub: &st
     false
 }
 
+fn is_ident_char(c: char) -> bool {
+    c.is_alphanumeric() || c == '_' || c == '$'
+}
+
+/// The character ending at byte offset `end`, when it satisfies `pred`.
+///
+/// `end` must be a char boundary; every caller advances by `len_utf8`, so it stays one.
+fn last_char_before(s: &str, end: usize, pred: impl Fn(char) -> bool) -> Option<char> {
+    s[..end].chars().next_back().filter(|c| pred(*c))
+}
+
 /// Pre-transform store sub names that are used as function calls with arguments.
 ///
 /// Handles cases like:
@@ -276,20 +287,19 @@ pub(super) fn transform_store_sub_calls(line: &str, store_sub_vars: &[String]) -
                 if let Some(p) = open_paren_pos {
                     // Check what is immediately before the `(`, skipping whitespace
                     // and an optional identifier (the function name).
+                    // Character steps, not byte steps: `k` is a slice index below, and a
+                    // byte step lands mid-character (`0x85` reads as NEL, `0xAA` as `ª`).
                     let mut k = p;
-                    while k > 0 && (bytes[k - 1] as char).is_whitespace() {
-                        k -= 1;
+                    while let Some(c) = last_char_before(before_text, k, char::is_whitespace) {
+                        k -= c.len_utf8();
                     }
                     // Skip an optional identifier (function name) before `(`
-                    while k > 0 && {
-                        let ch = bytes[k - 1] as char;
-                        ch.is_alphanumeric() || ch == '_' || ch == '$'
-                    } {
-                        k -= 1;
+                    while let Some(c) = last_char_before(before_text, k, is_ident_char) {
+                        k -= c.len_utf8();
                     }
                     // Skip whitespace before identifier
-                    while k > 0 && (bytes[k - 1] as char).is_whitespace() {
-                        k -= 1;
+                    while let Some(c) = last_char_before(before_text, k, char::is_whitespace) {
+                        k -= c.len_utf8();
                     }
                     // Now check if preceded by `function` keyword
                     if k >= 8 {
@@ -297,10 +307,7 @@ pub(super) fn transform_store_sub_calls(line: &str, store_sub_vars: &[String]) -
                             crate::compiler::utils::char_boundary_lookback(before_text, k, 8);
                         prefix == "function"
                             && (k == 8
-                                || !{
-                                    let c = bytes[k - 9] as char;
-                                    c.is_alphanumeric() || c == '_' || c == '$'
-                                })
+                                || last_char_before(before_text, k - 8, is_ident_char).is_none())
                     } else {
                         false
                     }
@@ -566,6 +573,65 @@ mod tests {
         assert_eq!(
             transform_store_reads_client("$\u{540d}\u{524d}();", &vars),
             "$\u{540d}\u{524d}();"
+        );
+    }
+
+    /// `$s` sits in a function parameter list, so `transform_store_sub_calls`
+    /// must leave it alone. The lookback walks back over the function name to
+    /// reach the `function` keyword, and it used to walk one byte at a time.
+    #[track_caller]
+    fn assert_param_list_is_left_alone(func_name: &str) {
+        let vars = vec!["$s".to_string()];
+        let line = format!("function {func_name}($s(1))");
+        assert_eq!(transform_store_sub_calls(&line, &vars), line);
+    }
+
+    /// Discriminating, and the quiet one. `\u{540d}`'s bytes are E5 90 8D; none of
+    /// them satisfies the identifier predicate, so the byte cursor stopped
+    /// immediately, never reached `function`, and the call was rewritten to
+    /// `$s()(1)` inside a parameter list. No panic — just the wrong answer.
+    #[test]
+    fn a_cjk_function_name_is_still_walked_back_over() {
+        assert_param_list_is_left_alone("foo\u{540d}");
+    }
+
+    /// Discriminating, and loud: `\u{3005}` is E3 80 85, and `0x85` reads as NEL,
+    /// so the whitespace loop stepped into the middle of the character.
+    #[test]
+    fn an_iteration_mark_in_the_function_name_does_not_split_a_character() {
+        assert_param_list_is_left_alone("foo\u{3005}");
+    }
+
+    /// Discriminating, and loud through the other door: `\u{05f2}` is D7 B2. The
+    /// identifier loop accepts `0xB2` (`\u{b2}`, category No) and then rejects the
+    /// lead byte `0xD7` (`\u{d7}`), stopping between the two.
+    #[test]
+    fn a_hebrew_function_name_does_not_split_a_character() {
+        assert_param_list_is_left_alone("foo\u{05f2}");
+    }
+
+    /// Same door as the Hebrew case but from a script whose lead byte passes:
+    /// `\u{306a}` is E3 81 AA, so `0xAA` (`\u{aa}`) is accepted and `0x81` rejected.
+    /// Picking one script and concluding is how this class stays hidden.
+    #[test]
+    fn a_kana_function_name_does_not_split_a_character() {
+        assert_param_list_is_left_alone("foo\u{306a}");
+    }
+
+    /// Control: byte and character steps coincide, so this passed before the fix.
+    #[test]
+    fn an_ascii_function_name_is_left_alone() {
+        assert_param_list_is_left_alone("foo");
+    }
+
+    /// Control on the other side: outside a parameter list the call *is* rewritten,
+    /// so a fix that made `is_in_func_params` always true would fail here.
+    #[test]
+    fn a_store_sub_call_outside_a_parameter_list_is_still_rewritten() {
+        let vars = vec!["$s".to_string()];
+        assert_eq!(
+            transform_store_sub_calls("x = $s(1);", &vars),
+            "x = $s()(1);"
         );
     }
 }


### PR DESCRIPTION
Fixes #2442.

## What

`client/store_transforms.rs`, in `transform_store_sub_calls`. Deciding whether a `$name(` call sits in a function parameter list means stepping back over the function name to the `function` keyword. Three cursors did that, all moving one **byte** at a time:

```rust
while k > 0 && (bytes[k - 1] as char).is_whitespace() { k -= 1; }              // :280
while k > 0 && { let ch = bytes[k - 1] as char;
                 ch.is_alphanumeric() || ch == '_' || ch == '$' } { k -= 1; }  // :284
while k > 0 && (bytes[k - 1] as char).is_whitespace() { k -= 1; }              // :291
```

`k` then becomes a slice index, via `char_boundary_lookback(before_text, k, 8)` — a helper that clamps only its `lo`, and whose own doc says `end` must already be a boundary. It was defending a boundary its caller had just crossed.

**The fix is the cursor, not the decode.** Walking characters makes `k` boundary-preserving by construction *and* fixes the predicate in the same move, which is why converting the `as char` casts alone would not have closed this.

## Correction to the framing this was handed to me with

I was told this was the `store_transforms.rs:128,136` site set I had classified as safe-to-convert, with `な` as the discriminating probe and **`名` as a control that must keep passing**. Two parts of that do not survive contact with the code:

1. **#2442 is a different site set.** `:128,136` are the arrow-parameter word-boundary checks, whose offsets come from `str::find` + `len()` and are boundaries. `:280/284/291` are the `is_in_func_params` lookback, and those cursors are **not** boundary-preserving. The classifications are opposite, and the safe-to-convert one is still untouched.
2. **`名` is discriminating here, not a control.** At `:128,136` its bytes make it accidentally-correct; at `:284` its last byte `0x8D` fails the identifier predicate, so the byte cursor stops immediately, never reaches `function`, and the call is rewritten **inside a parameter list**. It fails — quietly. The mutation table below shows it.

That second point is the same shape as #2412's CJK trap, inverted: there, carrying a control across sites made a test non-discriminating; here it would have thrown away the only test that catches the silent branch.

## Mutation table

Each loop reverted to its byte form alone, then restored. `cargo test -p rsvelte_core --lib store_transforms`.

| mutation | test | outcome |
|---|---|---|
| `:280` whitespace loop → bytes | `an_iteration_mark_in_the_function_name_does_not_split_a_character` | **panic** — `end byte index 14 is not a char boundary; it is inside '々' (bytes 12..15) of \`function foo々(\`` |
| " | other 7 | pass — `々` is the only input whose bytes reach this loop |
| `:284` identifier loop → bytes | `a_kana_function_name_does_not_split_a_character` | **panic** — inside `'な'` (bytes 12..15) |
| " | `a_hebrew_function_name_does_not_split_a_character` | **panic** — inside `'ײ'` (bytes 12..14) |
| " | `a_cjk_function_name_is_still_walked_back_over` | **silent** — `left: "function foo名($s()(1))"` / `right: "function foo名($s(1))"` |
| " | `an_iteration_mark_…` | **silent** — same shape, `foo々` |

**The same defect is loud or quiet purely as a function of which character reaches it.** Under the `:284` mutation, four inputs fail: two panic and two emit wrong code. Nothing about the site predicts which — `な` panics and `名` does not, and they differ only in their trailing byte. That is the argument for not ranking this class by observed symptom.

Why each input is in the suite, by the byte that selects it:

- `々` U+3005 = `E3 80 85` — `0x85` is NEL, the whitespace door.
- `ײ` U+05F2 = `D7 B2` — `0xB2` (`²`, category `No`) is accepted, then lead byte `0xD7` (`×`) is rejected, stopping *between* them. Hebrew is the only block whose lead byte fails the predicate, which is what makes it stop mid-character rather than run past.
- `な` U+306A = `E3 81 AA` — `0xAA` (`ª`) accepted, `0x81` rejected. Same door as Hebrew, reached from a script whose lead byte passes.
- `名` U+540D = `E5 90 8D` — nothing is accepted, so the cursor never moves and the failure is silent instead.
- `foo` — ASCII control, killed by no mutation: byte and character steps coincide.
- `a_store_sub_call_outside_a_parameter_list_is_still_rewritten` — the other-side control, which fails if a "fix" made `is_in_func_params` always true.

## Not claimed

**Reachability is unestablished, exactly as the issue says.** I did not find a `.svelte` input that reaches `is_in_func_params` with non-ASCII text before the `(`, and I did not go looking — the issue asks the right first question and I have not answered it. These tests are at the transform function. **This PR does not claim a user-visible crash**; it claims the function is wrong on inputs of the shape it accepts, which the mutation table demonstrates.

Also left in place deliberately: the backward paren scan at `:265` still does `bytes[i] as char`. It only ever compares against `(` and `)`, and no continuation byte equals an ASCII byte, so the comparison is sound and `i` lands on an ASCII byte whenever it is used. That is a needle-property argument, not a cursor property — it is out of scope here and belongs with #2461's population.

## Checks

`cargo fmt --all` clean, `cargo clippy -p rsvelte_core --all-targets --all-features -- -D warnings` clean, no `#[allow]`. `cargo test -p rsvelte_core --lib` → 1461 passed. Based on `origin/main` (`73aef74f`).
