### PR TITLE
docs(corpus): stage the binding by replace, not by overwrite in place

### DIFF
--- a/.github/workflows/corpus-compat.yml
+++ b/.github/workflows/corpus-compat.yml
@@ -230,7 +230,9 @@ jobs:
           cargo build --release --bin ast_equiv_batch
           mkdir -p .corpus-cache
           cp target/release/librsvelte_napi.so .corpus-cache/rsvelte.node.staging
-          # replace, never overwrite in place: an in-place write can leave a library the kernel kills on load
+          # Replace, never overwrite: if anything still has the old library mapped
+          # (a crashed loader keeps it mapped via ReportCrash), an in-place write
+          # leaves a binary the kernel SIGKILLs. Rename gives a new inode instead.
           mv .corpus-cache/rsvelte.node.staging .corpus-cache/rsvelte.node
 
       - name: Collect corpus
@@ -571,7 +573,9 @@ jobs:
           cargo build --release -p rsvelte_napi --lib
           mkdir -p .corpus-cache
           cp target/release/librsvelte_napi.so .corpus-cache/rsvelte.node.staging
-          # replace, never overwrite in place: an in-place write can leave a library the kernel kills on load
+          # Replace, never overwrite: if anything still has the old library mapped
+          # (a crashed loader keeps it mapped via ReportCrash), an in-place write
+          # leaves a binary the kernel SIGKILLs. Rename gives a new inode instead.
           mv .corpus-cache/rsvelte.node.staging .corpus-cache/rsvelte.node
 
       - name: Shape matrix parity (ratchet against matrix-known-failures.json)

--- a/.github/workflows/corpus-compat.yml
+++ b/.github/workflows/corpus-compat.yml
@@ -229,7 +229,9 @@ jobs:
           cargo build --release -p rsvelte_napi --lib
           cargo build --release --bin ast_equiv_batch
           mkdir -p .corpus-cache
-          cp target/release/librsvelte_napi.so .corpus-cache/rsvelte.node
+          cp target/release/librsvelte_napi.so .corpus-cache/rsvelte.node.staging
+          # replace, never overwrite in place: an in-place write can leave a library the kernel kills on load
+          mv .corpus-cache/rsvelte.node.staging .corpus-cache/rsvelte.node
 
       - name: Collect corpus
         run: node scripts/compat-corpus/collect.mjs
@@ -568,7 +570,9 @@ jobs:
         run: |
           cargo build --release -p rsvelte_napi --lib
           mkdir -p .corpus-cache
-          cp target/release/librsvelte_napi.so .corpus-cache/rsvelte.node
+          cp target/release/librsvelte_napi.so .corpus-cache/rsvelte.node.staging
+          # replace, never overwrite in place: an in-place write can leave a library the kernel kills on load
+          mv .corpus-cache/rsvelte.node.staging .corpus-cache/rsvelte.node
 
       - name: Shape matrix parity (ratchet against matrix-known-failures.json)
         run: node scripts/compat-corpus/matrix/run.mjs

--- a/compatibility/css-prune-known-failures.md
+++ b/compatibility/css-prune-known-failures.md
@@ -112,4 +112,4 @@ node scripts/compat-corpus/css-prune-sweep.mjs --update-baseline
 
 Requires a staged NAPI binding at `.corpus-cache/rsvelte.node`
 (`cargo build --release -p rsvelte_napi --lib`, then
-`cp target/release/librsvelte_napi.dylib .corpus-cache/rsvelte.node`).
+`mkdir -p .corpus-cache && cp target/release/librsvelte_napi.{dylib,so} .corpus-cache/rsvelte.node.staging && mv .corpus-cache/rsvelte.node.staging .corpus-cache/rsvelte.node`).

--- a/compatibility/matrix-known-failures.md
+++ b/compatibility/matrix-known-failures.md
@@ -90,7 +90,7 @@ Re-baseline in the same PR as the fix:
 
 ```
 cargo build --release -p rsvelte_napi --lib
-mkdir -p .corpus-cache && cp target/release/librsvelte_napi.{dylib,so} .corpus-cache/rsvelte.node
+mkdir -p .corpus-cache && cp target/release/librsvelte_napi.{dylib,so} .corpus-cache/rsvelte.node.staging && mv .corpus-cache/rsvelte.node.staging .corpus-cache/rsvelte.node
 node scripts/compat-corpus/matrix/run.mjs --update-baseline
 ```
 

--- a/docs/ast-refactor-handoff.md
+++ b/docs/ast-refactor-handoff.md
@@ -612,13 +612,12 @@ node scripts/compat-corpus/collect.mjs                             # コーパ�
 
 ### NAPI ビルド + ステージ
 ```bash
-export CARGO_TARGET_DIR=/tmp/rsvelte-ssr-target CARGO_BUILD_JOBS=6 RAYON_NUM_THREADS=2
-nice -n 10 cargo build --release --features napi --lib            # ← 並行させない！ -p は使わない(フル再ビルドになる)
-cp /tmp/rsvelte-ssr-target/release/librsvelte_core.dylib .corpus-cache/rsvelte.node   # Linux は .so
+cargo build --release -p rsvelte_napi --lib
+mkdir -p .corpus-cache && cp target/release/librsvelte_napi.{dylib,so} .corpus-cache/rsvelte.node.staging && mv .corpus-cache/rsvelte.node.staging .corpus-cache/rsvelte.node
 ```
-- ★教訓2: `cargo build --lib` は capi のリンク(遅い)まで待つが、**dylib は rsvelte_core 完了時点で更新される**。
-  `stat -f "%Sm" /tmp/rsvelte-ssr-target/release/librsvelte_core.dylib` の mtime が更新されたら、
-  capi リンク完了を待たずに即ステージ→検証してよい。
+- 旧記述（`--features napi` + `librsvelte_core.dylib` を自前で `cp`）は、cdylib が
+  `rsvelte_napi` に分離される前のもの。`rsvelte_core` は現在 rlib のみで dylib を出さず、
+  `napi` feature も存在しないため、当時の手順はいずれの行も再現しない。
 - ★教訓3: ポーリング（`grep Finished` 等）を毎ターン叩くと nice されたビルドの CPU を奪い遅くなる。
   バックグラウンドビルドの**完了通知を待つ**のが速い。
 

--- a/scripts/compat-corpus/README.md
+++ b/scripts/compat-corpus/README.md
@@ -131,7 +131,7 @@ pnpm run corpus:sync        # init/update every corpus source submodule
 
 # build + stage the rsvelte NAPI binding
 cargo build --release -p rsvelte_napi --lib
-cp target/release/librsvelte_napi.dylib .corpus-cache/rsvelte.node   # .so on Linux
+mkdir -p .corpus-cache && cp target/release/librsvelte_napi.{dylib,so} .corpus-cache/rsvelte.node.staging && mv .corpus-cache/rsvelte.node.staging .corpus-cache/rsvelte.node   # .so on Linux
 
 pnpm run corpus             # sync + collect + compile + verify
 ```

--- a/scripts/compat-corpus/README.md
+++ b/scripts/compat-corpus/README.md
@@ -132,6 +132,9 @@ pnpm run corpus:sync        # init/update every corpus source submodule
 # build + stage the rsvelte NAPI binding
 cargo build --release -p rsvelte_napi --lib
 mkdir -p .corpus-cache && cp target/release/librsvelte_napi.{dylib,so} .corpus-cache/rsvelte.node.staging && mv .corpus-cache/rsvelte.node.staging .corpus-cache/rsvelte.node   # .so on Linux
+# Replace, never overwrite: a crashed loader keeps the old library mapped (macOS
+# ReportCrash holds it for seconds), and an in-place write then yields a binary the
+# kernel SIGKILLs. Rename lands a new inode, so the holder keeps the old file.
 
 pnpm run corpus             # sync + collect + compile + verify
 ```

--- a/scripts/compat-corpus/compile.mjs
+++ b/scripts/compat-corpus/compile.mjs
@@ -180,7 +180,7 @@ if (args.includes('--worker')) {
 if (!fs.existsSync(BINDING)) {
 	console.error(`[compile] rsvelte NAPI binding missing at ${BINDING}`);
 	console.error('  build: cargo build --release -p rsvelte_napi --lib');
-	console.error('  stage: cp target/release/librsvelte_core.{dylib,so} .corpus-cache/rsvelte.node');
+	console.error('  stage: mkdir -p .corpus-cache && cp target/release/librsvelte_napi.{dylib,so} .corpus-cache/rsvelte.node.staging && mv .corpus-cache/rsvelte.node.staging .corpus-cache/rsvelte.node');
 	process.exit(1);
 }
 

--- a/scripts/compat-corpus/css-prune-sweep.mjs
+++ b/scripts/compat-corpus/css-prune-sweep.mjs
@@ -30,7 +30,7 @@
  *
  * Requires a staged NAPI binding at .corpus-cache/rsvelte.node
  * (cargo build --release -p rsvelte_napi --lib,
- *  then cp target/release/librsvelte_napi.dylib .corpus-cache/rsvelte.node).
+ *  then mkdir -p .corpus-cache && cp target/release/librsvelte_napi.{dylib,so} .corpus-cache/rsvelte.node.staging && mv .corpus-cache/rsvelte.node.staging .corpus-cache/rsvelte.node).
  */
 
 import fs from 'node:fs';
@@ -337,7 +337,7 @@ try {
 } catch (e) {
 	console.error('[css-prune-sweep] rsvelte NAPI binding missing at .corpus-cache/rsvelte.node');
 	console.error('  build: cargo build --release -p rsvelte_napi --lib');
-	console.error('  stage: cp target/release/librsvelte_napi.dylib .corpus-cache/rsvelte.node');
+	console.error('  stage: mkdir -p .corpus-cache && cp target/release/librsvelte_napi.{dylib,so} .corpus-cache/rsvelte.node.staging && mv .corpus-cache/rsvelte.node.staging .corpus-cache/rsvelte.node');
 	process.exit(1);
 }
 

--- a/scripts/compat-corpus/matrix/run.mjs
+++ b/scripts/compat-corpus/matrix/run.mjs
@@ -64,7 +64,7 @@ const BINDING = path.resolve(ROOT, '.corpus-cache/rsvelte.node');
 if (!fs.existsSync(BINDING)) {
 	console.error(`[matrix] rsvelte NAPI binding missing at ${path.relative(ROOT, BINDING)}`);
 	console.error('  build: cargo build --release -p rsvelte_napi --lib');
-	console.error('  stage: mkdir -p .corpus-cache && cp target/release/librsvelte_napi.{dylib,so} .corpus-cache/rsvelte.node');
+	console.error('  stage: mkdir -p .corpus-cache && cp target/release/librsvelte_napi.{dylib,so} .corpus-cache/rsvelte.node.staging && mv .corpus-cache/rsvelte.node.staging .corpus-cache/rsvelte.node');
 	process.exit(2);
 }
 const OFFICIAL = path.join(ROOT, 'submodules/svelte/packages/svelte/src/compiler/index.js');

--- a/scripts/compat-corpus/one.mjs
+++ b/scripts/compat-corpus/one.mjs
@@ -11,7 +11,7 @@
  *
  * --raw skips oxfmt normalization. Requires a staged NAPI binding at
  * .corpus-cache/rsvelte.node (cargo build --release -p rsvelte_napi --lib,
- * then cp target/release/librsvelte_napi.dylib .corpus-cache/rsvelte.node).
+ * then mkdir -p .corpus-cache && cp target/release/librsvelte_napi.{dylib,so} .corpus-cache/rsvelte.node.staging && mv .corpus-cache/rsvelte.node.staging .corpus-cache/rsvelte.node).
  */
 
 import fs from 'node:fs';

--- a/scripts/compat-corpus/svelte2tsx-compile.mjs
+++ b/scripts/compat-corpus/svelte2tsx-compile.mjs
@@ -152,7 +152,7 @@ if (args.includes('--worker')) {
 if (!fs.existsSync(BINDING)) {
 	console.error(`[s2t-compile] rsvelte NAPI binding missing at ${BINDING}`);
 	console.error('  build: cargo build --release -p rsvelte_napi --lib');
-	console.error('  stage: cp target/release/librsvelte_core.{dylib,so} .corpus-cache/rsvelte.node');
+	console.error('  stage: mkdir -p .corpus-cache && cp target/release/librsvelte_napi.{dylib,so} .corpus-cache/rsvelte.node.staging && mv .corpus-cache/rsvelte.node.staging .corpus-cache/rsvelte.node');
 	process.exit(1);
 }
 if (!fs.existsSync(OFFICIAL)) {


### PR DESCRIPTION
Independent of #2480 — based on `main`, merges on its own.

## What was wrong

**All twelve sites**, including both CI jobs, taught
`cp target/release/… .corpus-cache/rsvelte.node` — an in-place overwrite of the
destination.

**Four named `librsvelte_core`, which cannot exist.** That crate is
`crate-type = ["rlib"]` and emits no dylib; the cdylib lives in `rsvelte_napi` by
design. Two of the four are the error messages printed *when the binding is
missing*, so the advice offered at the moment of failure pointed at a file that
is never produced.

**One was not a path problem.** `docs/ast-refactor-handoff.md` built with
`cargo build --release --features napi --lib` under a custom `CARGO_TARGET_DIR`
and told readers not to use `-p`. `rsvelte_core` has no `napi` feature today, so
**no line of that recipe reproduces** — it predates the cdylib split. That is why
these were read individually: a `sed` would have "fixed" it into something
equally non-functional.

## Mechanism, confirmed

The precondition is a **live mapping of the destination at the moment of the
write** — not the destination's provenance, which was my earlier hypothesis and
is refuted: 15 trials by another agent show `cp`-created and rename-created
destinations behave identically, with mapping as the only discriminator.

My own trials looked like a counter-example because they *did* wait for the
loader to exit. The reconciliation is that **the loader crashed**:

| arm | first load | then | result |
|---|---|---|---|
| A | **segfaults** | immediate in-place `cp` | **3/3 SIGKILL** |
| B | succeeds | immediate in-place `cp` | 0/3 |
| C | segfaults | wait 8s, then in-place `cp` | 0/2 |
| D | segfaults | **rename** | 0/3 |

A crashed process is reaped by the shell but `ReportCrash` attaches to write its
report, holding the image mapped for seconds afterwards (confirmed: `ReportCrash`
resident, matching `node-*.ips` reports at those timestamps). So a harness that
waits correctly can still be inside the killing window — **the holder isn't
yours.** That matters here specifically because this repo's tooling loads
bindings that sometimes segfault; that is what #2443 was.

**Rename survives the killing condition** (arm D) rather than merely avoiding an
untested one: the holder keeps the old inode, and the new file is a different
one. That is why the recipe is copy-to-sibling + rename and must not be
"simplified" back to `cp` later.

## Why a mechanism, not a tool name

An earlier revision of this PR pointed every site at `binding.mjs --stage`
(#2480). That was wrong while #2480 is unmerged: those docs would have failed
with `No such file or directory` for anyone on `main`, sending readers straight
back to the `cp` the doc used to teach. **A tool name has a merge state; a
mechanism doesn't.** Once #2480 lands, these can collapse to the one-liner.

## Verification

- No `binding.mjs` reference remains — nothing here depends on an unmerged branch.
- No `librsvelte_core` remains except the note explaining why it is wrong.
- `corpus-compat.yml` parses; all five touched `.mjs` files pass `node --check`.
- Two `.claude/sessions/*.md` also name `librsvelte_core`; left alone as archived
  transcripts rather than instructions.

## CI

Actions is in a major outage; verified locally. The workflow edit is the one part
CI itself must exercise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
