### PR TITLE
docs(compat): the position backlog is missing spans, not wide ones

### DIFF
--- a/compatibility/validator-known-failures.md
+++ b/compatibility/validator-known-failures.md
@@ -20,9 +20,12 @@ The divergences fall into three clusters:
   fixing it means auditing each `AnalysisError::*` construction individually.
 
 - **Warning span-only mismatches (53).** The warning `code` and `message` match
-  upstream exactly; only the reported `start`/`end` differs — typically rsvelte
-  reports a whole-line/whole-node span where upstream reports a narrower
-  sub-span (an attribute value, a role token, an identifier). Affects
+  upstream exactly; only the reported `start`/`end` differs — **rsvelte reports
+  no span at all** (`None..None`) where upstream reports a real range, because
+  the warning is constructed without threading the triggering node through.
+  Measured on both populations: 26 of 26 span-only divergences here are missing
+  spans and 0 are present-but-different, and on the ~14k real-world corpus the
+  split is 2,082 missing against 3 present-but-different (99.86%). Affects
   `component-name-lowercase`, `custom-element-props-identifier*`,
   `rest-eachblock-binding*`, `invalid-self-closing-tag`,
   `a11y-aria-proptypes-*`, `a11y-scope`, `a11y-no-abstract-roles`,
@@ -40,8 +43,13 @@ The divergences fall into three clusters:
   `script-unknown-attribute`, `script-context-module-runes-deprecated`,
   `script-invalid-spread-attribute`, `tag-custom-element-options-missing`,
   `runes-legacy-syntax-warnings`, and `a11y-aria-unsupported-element`.
-  Each is a narrow-the-span fix once the underlying node's precise range is
-  identified (per-rule, not architectural).
+  Each is an *attach*-the-span fix, not a narrow-the-span one: pass the
+  triggering node to the warning constructor so the caller's element-span
+  fallback is not reached. Per-rule, not architectural — one systemic cause but
+  one emission site per code, so the work does not collapse into a single edit.
+  Where the check locates its subject by walking children (as `figure` does for
+  `a11y_figcaption_index`, #2490), the same fallback lands a **plausible wrong**
+  span rather than none, which is the worse symptom of the same defect.
 
 - **Warning/error content differs from upstream wording (13).** The diagnostic
   fires on the right node but the message text itself — or, for one rule, the

--- a/scripts/dev/cluster-warning-positions.mjs
+++ b/scripts/dev/cluster-warning-positions.mjs
@@ -1,0 +1,153 @@
+#!/usr/bin/env node
+/**
+ * Scope the `warning-position-mismatch` backlog: how many DISTINCT causes are
+ * behind it, and where is the mass?
+ *
+ * The answer decides whether the backlog is one fix or many, and those are
+ * different questions from "how many causes" — a single systemic cause can
+ * still need one edit per emission site. Both numbers come out of this run.
+ *
+ * The clustering is derived rather than imposed. Every divergence is reduced
+ * first by *which side has a span at all* — a fact — and only where both sides
+ * have one is a `(dline, dcol)` delta computed, which is a judgement about what
+ * counts as "close". Reporting the layers separately shows which one carries
+ * the mass instead of asserting it.
+ *
+ * Needs a compiled corpus:
+ *   node scripts/compat-corpus/collect.mjs
+ *   node scripts/compat-corpus/compile.mjs
+ *   node scripts/dev/cluster-warning-positions.mjs
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { TARGET_KEYS } from '../compat-corpus/targets.mjs';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const CORPUS = path.join(ROOT, 'compatibility');
+
+const manifestPath = path.join(CORPUS, 'manifest.json');
+if (!fs.existsSync(manifestPath)) {
+	console.error('[cluster] compatibility/manifest.json missing — run collect.mjs then compile.mjs first');
+	process.exit(2);
+}
+const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+
+const readIf = (p) => (fs.existsSync(p) ? fs.readFileSync(p, 'utf8') : null);
+const readW = (d) => JSON.parse(readIf(path.join(d, 'warnings.json')) ?? '{}');
+const codeBag = (l) => l.map((w) => w.code).sort();
+const key = (w) => `${w.code}@${w.line ?? '?'}:${w.column ?? '?'}`;
+const hasSpan = (w) => w.line !== null && w.line !== undefined;
+
+const entries = new Set();
+const byCode = new Map();
+const byShape = new Map();
+const byCodeShape = new Map();
+const deltas = new Map();
+const examples = new Map();
+let pairs = 0;
+// Entries that were actually compiled. Counting *comparisons* does not work: a
+// missing file reads as `{}`, both sides come back as empty warning lists, and
+// every entry scores as agreement — a clean sheet over an absent tree. Counting
+// `warnings.json` does not work either: compile.mjs writes it only for entries
+// that have warnings, which is 8% of the corpus. Same predicate as
+// verify.mjs's coverage assertion, for the same reason.
+let withArtifacts = 0;
+const hasOutputs = (tree, id) =>
+	fs.existsSync(path.join(tree, id, 'error.json')) ||
+	TARGET_KEYS.some((k) => fs.existsSync(path.join(tree, id, `${k}.js`)));
+
+const bump = (m, k) => m.set(k, (m.get(k) ?? 0) + 1);
+const groupByCode = (list) => {
+	const m = new Map();
+	for (const w of list) {
+		if (!m.has(w.code)) m.set(w.code, []);
+		m.get(w.code).push(w);
+	}
+	return m;
+};
+
+for (const { id } of manifest) {
+	const exp = readW(path.join(CORPUS, 'expected', id));
+	const act = readW(path.join(CORPUS, 'actual', id));
+	const expErr = JSON.parse(readIf(path.join(CORPUS, 'expected', id, 'error.json')) ?? '{}');
+	const actErr = JSON.parse(readIf(path.join(CORPUS, 'actual', id, 'error.json')) ?? '{}');
+
+	if (hasOutputs(path.join(CORPUS, 'expected'), id) || hasOutputs(path.join(CORPUS, 'actual'), id)) {
+		withArtifacts++;
+	}
+
+	for (const t of TARGET_KEYS) {
+		if (expErr[t] || actErr[t]) continue;
+		const el = exp[t] ?? [];
+		const al = act[t] ?? [];
+		// A differing set of codes is the code ratchet's business, not this one.
+		if (String(codeBag(el)) !== String(codeBag(al))) continue;
+		if (String(el.map(key).sort()) === String(al.map(key).sort())) continue;
+		entries.add(id);
+
+		const ea = groupByCode(el);
+		const aa = groupByCode(al);
+		for (const [code, ews] of ea) {
+			const aws = aa.get(code) ?? [];
+			for (let i = 0; i < Math.min(ews.length, aws.length); i++) {
+				const ew = ews[i];
+				const aw = aws[i];
+				if (ew.line === aw.line && ew.column === aw.column) continue;
+				pairs++;
+
+				let shape;
+				if (hasSpan(ew) && !hasSpan(aw)) shape = 'rsvelte has NO span (official does)';
+				else if (!hasSpan(ew) && hasSpan(aw)) shape = 'official has NO span (rsvelte does)';
+				else if (!hasSpan(ew) && !hasSpan(aw)) shape = 'neither has a span';
+				else {
+					const dl = aw.line - ew.line;
+					const dc = aw.column - ew.column;
+					shape = dl === 0 ? `same line, column off by ${dc > 0 ? '+' : ''}${dc}` : `line off by ${dl > 0 ? '+' : ''}${dl}`;
+					bump(deltas, `dline=${dl} dcol=${dc}`);
+				}
+
+				bump(byCode, code);
+				bump(byShape, shape);
+				const cell = `${shape}  ||  ${code}`;
+				bump(byCodeShape, cell);
+				if (!examples.has(cell)) examples.set(cell, `${id} [${t}]  official ${key(ew)}  rsvelte ${key(aw)}`);
+			}
+		}
+	}
+}
+
+// A run against an absent or truncated tree reports "0 divergences", which
+// reads as agreement. Coverage is asserted against the manifest rather than
+// against comparisons attempted, so a partially deleted tree fails too — the
+// hazard in #2455, where a sibling checkout's clean removes inputs mid-run.
+if (withArtifacts < manifest.length * 0.99) {
+	console.error(
+		`[cluster] only ${withArtifacts}/${manifest.length} manifest entries have compiled output — this run measured nothing`
+	);
+	console.error('  run: node scripts/compat-corpus/compile.mjs');
+	process.exit(2);
+}
+
+const top = (m, n) => [...m].sort((x, y) => y[1] - x[1]).slice(0, n);
+console.log(`position-divergent entries        ${entries.size}`);
+console.log(`diverging (entry,target,warning)  ${pairs}`);
+console.log(`manifest entries with output      ${withArtifacts}/${manifest.length}\n`);
+
+console.log('=== layer 1: by SHAPE — does each side have a span at all, else the delta ===');
+for (const [k, v] of top(byShape, 20)) {
+	console.log(`  ${String(v).padStart(6)}  ${((v / pairs) * 100).toFixed(2).padStart(6)}%  ${k}`);
+}
+
+console.log(`\n=== layer 2: by WARNING CODE (${byCode.size} distinct) ===`);
+for (const [k, v] of top(byCode, 40)) console.log(`  ${String(v).padStart(6)}  ${k}`);
+
+console.log(`\n=== layer 3: SHAPE x CODE — the candidate repair sites (${byCodeShape.size} cells) ===`);
+for (const [k, v] of top(byCodeShape, 40)) {
+	console.log(`  ${String(v).padStart(6)}  ${k}`);
+	console.log(`          e.g. ${examples.get(k)}`);
+}
+
+console.log(`\n=== layer 4: exact (dline,dcol) where both sides have spans (${deltas.size} distinct) ===`);
+for (const [k, v] of top(deltas, 20)) console.log(`  ${String(v).padStart(6)}  ${k}`);


### PR DESCRIPTION
A ratchet doc that describes its backlog wrongly sizes future work wrongly, which is worse
than no description. This corrects one and adds the script the correction was measured with.

## What was wrong

`compatibility/validator-known-failures.md` described the 53 span-only entries as:

> typically rsvelte reports a whole-line/whole-node span where upstream reports a narrower
> sub-span (an attribute value, a role token, an identifier)

That describes **almost none of them**, and it points at the wrong fix — someone reading it
would go looking for span-*narrowing* logic that is not the problem.

## Measured on both populations

Two populations, because a claim in the validator doc is about the validator fixtures and my
first measurement was on the corpus — the counts are not interchangeable.

**Validator fixtures** (`cargo test -p rsvelte_core --test validator -- --nocapture` with the
ratchet temporarily emptied, then classifying every divergence where `code` *and* `message`
match and only the span differs):

| shape | count |
|---|---:|
| rsvelte has **no** span (`None..None`) | **26** |
| rsvelte has a span that differs | **0** |

**Real-world corpus**, 14,131 entries × 3 targets, 2,085 diverging `(entry, target, warning)`
triples:

| shape | count | share |
|---|---:|---:|
| rsvelte has **no** span, official does | **2,082** | 99.86% |
| present but different (all one code, all `dline=-3 dcol=-1`) | **3** | 0.14% |

So the backlog is **absent** spans, not wide ones, in both populations. The fix is to pass the
triggering node to the warning constructor so the caller's element-span fallback is never
reached — an *attach*, not a *narrow*.

## Two things the corrected text now says that the old text did not

- **One systemic cause, but one emission site per code.** 32 distinct codes underlie the
  corpus backlog, so the work does not collapse into a single edit. "How many causes" and "how
  many places you must edit" are separate measurements, and the first being 1 is what makes the
  second feel already answered.
- **Where a check locates its subject by walking children, the fallback lands a *plausible
  wrong* span rather than none** — the worse symptom of the same defect, because a reader
  trusts a specific location. `a11y_figcaption_index` is the only corpus instance (#2490).

## The script

`scripts/dev/cluster-warning-positions.mjs` — reproduces the table above from a compiled
corpus. Layering is deliberate: it reduces first by *which side has a span at all* (a fact),
and only computes a `(dline, dcol)` delta where both sides have one (a judgement about what
counts as "close"). Layers are reported separately so the reader can see which carries the
mass rather than being told.

**It refuses to report on a tree it cannot measure**, which took three attempts to get right
and is the part worth reviewing:

1. First version counted *comparisons attempted*. A missing `warnings.json` reads as `{}`,
   both sides come back empty, every entry scores as agreement — it reported **"0 divergences,
   exit 0"** against a completely absent tree. Exactly the failure the guard existed to prevent.
2. Second version counted entries with a `warnings.json`. That fails a **good** tree:
   `compile.mjs` writes the file only for entries that have warnings, which is 1,191 of 14,131.
3. Current version uses verify.mjs's own coverage predicate (`error.json` or `<target>.js`
   present), asserted at ≥99% of the manifest.

Both directions are controlled, because testing only the refusal path is what let version 2
through:

| control | result |
|---|---|
| good tree | exit **0**, reports 529 / 2,085 / 99.86% |
| manifest present, trees absent | exit **2**, "only 0/2 … measured nothing" |
| 707 entries (5%) deleted from both trees — the #2455 shape | exit **2**, "only 13,424/14,131" |

No behaviour change to any gate; this is documentation plus a dev tool.
