### PR TITLE
fix(parse): delete the dead non-ASCII arm from the trailing text trim (#2410)

### DIFF
--- a/.changeset/great-moons-repeat.md
+++ b/.changeset/great-moons-repeat.md
@@ -1,0 +1,11 @@
+---
+'@rsvelte/compiler': patch
+---
+
+Delete the non-ASCII arm from the parser's trailing whitespace-only text trim.
+The predicate ran under `all()`, so every byte of the text had to satisfy it,
+and the lead byte of any multi-byte character casts to a non-whitespace Latin-1
+character — the arm could never be the deciding term. Trailing non-ASCII
+whitespace is already dropped upstream by the `trim_end()` that sets
+`content_end`, which is what matches official Svelte's `template.trimEnd()`. No
+behaviour change; the arm only ever looked like Unicode support.

--- a/crates/rsvelte_core/src/compiler/phases/1_parse/state/fragment.rs
+++ b/crates/rsvelte_core/src/compiler/phases/1_parse/state/fragment.rs
@@ -165,14 +165,14 @@ impl<'a> Parser<'a> {
         // But only if they're at the very end of the file (after script/style too)
         while let Some(TemplateNode::Text(text)) = fragment.nodes.last() {
             let after_special = text.end >= max_special_end;
-            // Fast byte-level whitespace check
-            let is_whitespace = text.data.as_bytes().iter().all(|&b| {
-                b == b' '
-                    || b == b'\t'
-                    || b == b'\n'
-                    || b == b'\r'
-                    || (b >= 0x80 && (b as char).is_whitespace())
-            });
+            // ASCII-only by design: the parser already dropped every trailing
+            // whitespace run via `trim_end()` when it set `content_end`, so a
+            // Unicode-aware test here would be unreachable, not more correct.
+            let is_whitespace = text
+                .data
+                .as_bytes()
+                .iter()
+                .all(|&b| b == b' ' || b == b'\t' || b == b'\n' || b == b'\r');
             if is_whitespace && after_special {
                 fragment.nodes.pop();
             } else {

--- a/crates/rsvelte_core/tests/trailing_whitespace_trim_2410.rs
+++ b/crates/rsvelte_core/tests/trailing_whitespace_trim_2410.rs
@@ -1,0 +1,69 @@
+//! Trailing whitespace-only text nodes are dropped by `trim_end()` when the
+//! parser sets `content_end`, not by the fragment-level trim that follows it.
+//!
+//! That trim carried a `b >= 0x80 && (b as char).is_whitespace()` arm which
+//! could never decide anything: the predicate runs under `all()`, and the lead
+//! byte of every multi-byte character (`C2..=F4`) casts to a non-whitespace
+//! Latin-1 char, so `all()` fails before the arm matters. These tests pin the
+//! behaviour the arm appeared — but failed — to provide, so that deleting it is
+//! visibly a no-op and a future "Unicode support" repair has something to fail
+//! against.
+
+use rsvelte_core::{Allocator, ParseOptions, parse};
+
+fn trailing_node_count(trailer: &str) -> usize {
+    let src = format!("<script>\n</script>\n{trailer}");
+    let allocator = Allocator::default();
+    parse(&src, &allocator, ParseOptions::default())
+        .expect("component should parse")
+        .fragment
+        .nodes
+        .len()
+}
+
+/// Every non-ASCII character with the Unicode `White_Space` property — the
+/// arm's entire intended domain. All are already dropped upstream.
+///
+/// One of them, `U+0085`, is dropped where official Svelte keeps it: JS trims
+/// by `WhiteSpace + LineTerminator`, which excludes `U+0085` and includes
+/// `U+FEFF`, the exact opposite of Rust's `White_Space` on both. That is a
+/// `trim_end()` question, tracked separately; this test pins today's behaviour
+/// so the divergence cannot move without a failure.
+#[test]
+fn every_non_ascii_whitespace_trailer_is_already_dropped() {
+    let ws: Vec<char> = (0u32..=0x10FFFF)
+        .filter_map(char::from_u32)
+        .filter(|c| c.is_whitespace() && !c.is_ascii())
+        .collect();
+    assert_eq!(ws.len(), 19, "the White_Space domain changed");
+
+    for c in ws {
+        assert_eq!(
+            trailing_node_count(&c.to_string()),
+            0,
+            "U+{:04X} survived as a trailing text node",
+            c as u32
+        );
+    }
+}
+
+/// The ASCII half of the same trim, which is the part the byte scan really
+/// decides. Over-deleting from the predicate fails here.
+#[test]
+fn ascii_whitespace_trailers_are_dropped() {
+    for trailer in [" ", "\t", "\n", "\r", " \t\r\n  "] {
+        assert_eq!(
+            trailing_node_count(trailer),
+            0,
+            "ASCII whitespace trailer {trailer:?} survived"
+        );
+    }
+}
+
+/// The other side: a trailer that is not whitespace must be kept, so a
+/// predicate that accepted everything would fail.
+#[test]
+fn a_non_whitespace_trailer_is_kept() {
+    assert_eq!(trailing_node_count("x"), 1);
+    assert_eq!(trailing_node_count("\u{540d}"), 1);
+}


### PR DESCRIPTION
Fixes #2410.

## The decision: delete, not repair — and the oracle says so twice over

The issue asks for a comparison against official before touching anything. Run, against `submodules/svelte` v5.56.8 via `parse(src, { modern: true })`:

```
U+00A0  official: nodes=0        U+3000  official: nodes=0
U+2028  official: nodes=0        U+FEFF  official: nodes=0
```

Official trims trailing non-ASCII whitespace, because `Parser`'s constructor does `this.template = template.trimEnd()` (`1-parse/index.js:95`) before parsing — a whole-template trim, not a node-removal pass.

**rsvelte already matches, and not because of this branch.** `parser.rs` sets `content_end = source.trim_end().len()`, and Rust's `trim_end()` is `White_Space`-aware. Exhaustively, over the arm's entire intended domain — all **19** non-ASCII characters with `char::is_whitespace()` — every one is already dropped: `kept as a trailing text node: 0 of 19`.

So the arm is dead twice: it could never return `true` (the `all()` + lead-byte argument in the issue, which holds), and for its whole domain the text node never reaches the loop at all.

## Why "repair" would have been actively wrong

The issue worried that dead code looking like Unicode support invites a repair into a divergence. That is now concrete rather than a worry: the obvious repair — `text.data.chars().all(char::is_whitespace)` — would make rsvelte trim `U+0085` **harder**, and `U+0085` is a case where rsvelte **already over-trims relative to official**. See the separate issue below. Repairing the arm would have deepened a real divergence while looking like a Unicode fix.

## Instrumentation, with the positive controls that make the zeros mean something

I got two worthless zeros before a real one, so all three are recorded:

1. **Zero #1, broken.** Instrumented the arm, ran it, got 0 firings — then the positive control (`b >= 0x80` → `b >= 0x00`) *also* gave 0. `b == b' '` short-circuits before the arm, so the probe was never reached. That zero measured nothing.
2. **Zero #2, wrong denominator.** `cargo test --lib` gave 0 arm evaluations — because `--lib` unit tests never take the parse path. Also meaningless.
3. **Zero #3, real.** Logging every *evaluation* rather than firings: the arm is reached (`byte 0x78 -> false`, `byte 0xef -> false`) and returns `false` both times. Reached, never decides.

Separately, for the enclosing loop: it is reached but **never pops** — 0 pops across 15 template shapes and three parse-heavy suites. The positive control is real this time: dropping `is_whitespace` from the condition yields **4** pops over the same 15 shapes, so the instrumentation is wired and the loop body executes.

## What kills these tests — stated because the obvious answer is wrong

**No mutation of the loop kills them.** I removed `b == b'\n'` from the predicate and all three still passed. That is not a weak test suite; it is the finding: the loop is dead, so nothing done to it is observable.

The tests are killed by mutating the mechanism that actually provides the behaviour. `content_end = source.trim_end().len()` → `source.len()`:

```
every_non_ascii_whitespace_trailer_is_already_dropped ... FAILED
  U+0085 survived as a trailing text node
```

And informatively, `ascii_whitespace_trailers_are_dropped` **still passes** under that mutation — with `trim_end` disabled the trailing ASCII node does reach the loop, and the loop pops it. So the loop is a redundant ASCII-only backstop, correct but unreached.

That is why I deleted the **arm** and kept the **loop**: the arm is wrong in every world, the loop is merely unreached in this one, and removing a working backstop is a larger claim than #2410 asks for. The loop's deadness is recorded in the issue below rather than acted on here.

| mutation | result |
|---|---|
| restore the `b >= 0x80` arm | **nothing fails** — the point of the PR |
| drop `b == b'\n'` from the predicate | nothing fails — loop is unreached |
| predicate accepts everything | nothing fails — loop is unreached |
| `content_end` → `source.len()` | `every_non_ascii_whitespace_trailer_is_already_dropped` fails at U+0085 |

## Separate bug found, filed not folded

Comparing the two trim domains turned up a divergence the issue did not predict, and it is the "denominator agrees, partition doesn't" shape again — **both sets have exactly 19 non-ASCII members**, so any count-based check calls them identical:

| | Rust `White_Space` | JS `WhiteSpace + LineTerminator` |
|---|---|---|
| `U+0085` NEL | ✅ trimmed | ❌ kept |
| `U+FEFF` ZWNBSP | ❌ kept | ✅ trimmed |

Confirmed on both sides with explicit code points (the terminal renders both invisibly, so `Text("\n")` was hiding a literal `U+0085` until I printed code points):

```
U+0085  official nodes=1 lastdata=[U+000A U+0085]   rsvelte: 0 nodes  → rsvelte over-trims
U+FEFF  official nodes=0                             rsvelte: 1 node   → rsvelte under-trims
```

Filed separately — it lives in `trim_end`, not here, and fixing it is a behaviour change needing corpus movement.

## Checks

`cargo fmt --all` clean, `cargo clippy -p rsvelte_core --all-targets --all-features -- -D warnings` clean, no `#[allow]`. `cargo test -p rsvelte_core --lib` → 1455 passed; the new suite → 3 passed. Based on `origin/main` (`73aef74f`).
