### PR TITLE
test(projection): give svelte2tsx_fixtures an absolute coverage floor (#2454)

### DIFF
--- a/crates/rsvelte_projection/tests/common/svelte2tsx.rs
+++ b/crates/rsvelte_projection/tests/common/svelte2tsx.rs
@@ -884,9 +884,19 @@ pub fn iter_svelte2tsx_outcomes() -> Option<Vec<FixtureOutcome>> {
 
     let mut outcomes: Vec<FixtureOutcome> = Vec::new();
 
+    // `None` means "submodule absent", which callers are entitled to skip on. A
+    // directory that exists but cannot be enumerated is a broken environment, and
+    // silently returning a short list would understate coverage instead.
     let mut entries: Vec<_> = fs::read_dir(&samples_dir)
-        .ok()?
-        .filter_map(|e| e.ok())
+        .unwrap_or_else(|e| panic!("{} exists but is not readable: {e}", samples_dir.display()))
+        .map(|e| {
+            e.unwrap_or_else(|err| {
+                panic!(
+                    "{}: directory entry unreadable: {err}",
+                    samples_dir.display()
+                )
+            })
+        })
         .collect();
     entries.sort_by_key(|e| e.file_name());
 

--- a/crates/rsvelte_projection/tests/svelte2tsx_fixtures.rs
+++ b/crates/rsvelte_projection/tests/svelte2tsx_fixtures.rs
@@ -22,6 +22,13 @@ use std::path::{Path, PathBuf};
 use common::TestStatus;
 use common::svelte2tsx::iter_svelte2tsx_outcomes;
 
+/// Grow-only coverage floor: the number of samples that must actually be
+/// compared, measured against the pinned `language-tools` submodule. Absolute on
+/// purpose — a floor expressed as a fraction of what the run happened to find
+/// shrinks together with its own numerator, so it cannot detect the erosion it
+/// exists to detect. Never lower it without saying why.
+const MIN_S2TSX_FIXTURES: u32 = 254;
+
 fn baseline_path() -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR"))
         .join("../..")
@@ -145,9 +152,13 @@ fn test_svelte2tsx_fixtures() {
 
     let total_tested = passed + failed;
     assert!(
-        total_tested > 0,
-        "[s2tsx-fixtures] no fixture ran ({} discovered, {skipped} skipped) — \
-         the language-tools fixture layout changed?",
+        total_tested >= MIN_S2TSX_FIXTURES,
+        "[s2tsx-fixtures] only {total_tested} fixtures were compared, below the floor \
+         of {MIN_S2TSX_FIXTURES} ({} discovered, {skipped} skipped) — the ratchet below \
+         cannot see a regression in a fixture that never ran, so this is coverage \
+         erosion, not a passing run. Either the language-tools fixture layout changed \
+         or samples are being skipped; if upstream legitimately removed fixtures, lower \
+         the floor deliberately and say why.",
         outcomes.len(),
     );
     println!(


### PR DESCRIPTION
Closes #2454.

`svelte2tsx_fixtures.rs` guarded its coverage with `assert!(total_tested > 0)`. A run that compared **1 of 254** samples printed "no regressions" and passed. The ratchet underneath cannot see a regression in a fixture that never ran, so erosion of the sample set was indistinguishable from a clean run.

## The floor is absolute, deliberately

```rust
const MIN_S2TSX_FIXTURES: u32 = 254;
```

Not a fraction of what the run happened to discover. A relative floor shrinks together with its own numerator, so it cannot detect the erosion it exists to detect — if the sample set halves, "90% of discovered samples ran" is still true and still green.

## Two paths turned "cannot establish the count" into a smaller count

Both in `iter_svelte2tsx_outcomes`, both now panic and name the directory:

- `fs::read_dir(&samples_dir).ok()?` returned `None` on an IO error. `None` is the caller's signal for **"submodule absent"**, which it legitimately skips on — so an unreadable-but-present directory was reported as an absent submodule and skipped. The `.exists()` check has already passed at that point, so a read failure there is a broken environment, not an absent checkout.
- `.filter_map(|e| e.ok())` dropped unreadable entries silently, shrinking the count with no signal at all.

`find_svelte_file` still has the same `.ok()?` / `filter_map` shape. I left it: its failure turns a sample into a `Skipped` outcome, which lowers `total_tested` and is therefore caught by the floor. **The floor is the backstop that makes the remaining tolerant reads safe** — which is the point of having an aggregate gate rather than auditing every `.ok()`.

## Verification: three values, because the new gate firing proves nothing on its own

The question is not "does the new assert fire" but "does it catch something the old one passed". So the old gate had to be run against the same broken input:

| tree | old gate (`> 0`) | new gate (`>= 254`) |
|---|---|---|
| intact — 254 compared | pass | pass |
| one sample directory removed — 253 compared | **pass** | **fail** |

Bottom-left is the cell that justifies the change. The old gate cannot move.

The eroded run's message:

```
[s2tsx-fixtures] only 253 fixtures were compared, below the floor of 254
(253 discovered, 0 skipped) — the ratchet below cannot see a regression in a
fixture that never ran, so this is coverage erosion, not a passing run.
```

The "old gate" arm was produced by setting the constant to `1`, which is exactly equivalent to `> 0` for a `u32` count, and re-running against the eroded tree — not by reasoning about what the old code would have done.

Sample directory restored afterwards; `git status` in the submodule is clean.

## The floor was predicted before it was measured

I derived 254 by enumerating sample directories and their expected-output files (`expected.error.json`, `expectedv2.ts`, `expected-svelte5.ts`) with no build, which predicted **254 tested, 0 skipped**. The run returned exactly 254 and 0. Had it returned 253 I would have had a wrong model to fix rather than a number to copy.

## One discrepancy I am flagging, not fixing

`CLAUDE.md`'s test-status table reports **svelte2tsx as 253/253**. This suite measures **249/254**, with 5 entries in `compatibility/svelte2tsx-fixtures-known-failures.json`. Those are different populations and I have not reconciled them — but "253/253" reads as "everything passes" while five known failures sit in a ratchet, which is the same shape as #2452. Worth someone's attention; I did not touch the table.

## Also spotted, not fixed here

This ratchet is **one-sided** in exactly the way `validator-known-failures.json` was in #2457: `fixed_known` is printed at `svelte2tsx_fixtures.rs:180` and never asserted. `fixed_known` is currently empty, so making it two-sided would be free right now. Left out to keep this PR to the coverage floor; filed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
