### PR TITLE
fix(compiler): compile the two benchmark corpora rsvelte rejects

### DIFF
--- a/.changeset/open-webui-false-positives.md
+++ b/.changeset/open-webui-false-positives.md
@@ -1,0 +1,27 @@
+---
+"@rsvelte/compiler": patch
+---
+
+Stop rejecting three constructs upstream compiles
+
+Compiling open-webui v0.11.0 (650 components) failed on four files that
+`svelte.compile` accepts:
+
+- **`catch (err) { err = … }`** reported `constant_assignment`. The catch
+  parameter was declared `const`; upstream's `scope.js` declares it `let`.
+- **`const { $from } = state.selection`** reported
+  `store_invalid_scoped_subscription` when some other scope happened to declare
+  a `from`. The `$`-name is a declaration, but the scan that decides which
+  `$name`s are store reads only recognised `let`/`const`/`var $x` written
+  directly, not a destructuring pattern. The same shorthand inside an object
+  *literal* is still a store read — the two are told apart by what precedes the
+  pattern's opening bracket.
+- **`(a?: string, b: string) => b`** and 14 other TypeScript grammar rules were
+  raised as `js_parse_error`. Upstream parses `lang="ts"` with
+  `acorn-typescript`, which does not run TypeScript's grammar checks; OXC does.
+  Each suppressed rule was confirmed against `svelte.compile`, and the TS rules
+  acorn-typescript *does* implement (1049, 1096, 1098, 1257, 1276, 2452, …) still
+  fail, as does TypeScript syntax in a plain `<script>`.
+
+The corpus now compiles 649 of 650 for client and server, the remaining file
+being one upstream rejects too.

--- a/.changeset/open-webui-false-positives.md
+++ b/.changeset/open-webui-false-positives.md
@@ -2,10 +2,10 @@
 "@rsvelte/compiler": patch
 ---
 
-Stop rejecting three constructs upstream compiles
+Stop rejecting five constructs upstream compiles
 
-Compiling open-webui v0.11.0 (650 components) failed on four files that
-`svelte.compile` accepts:
+Compiling open-webui v0.11.0 (650 components) and Huly Platform v0.7.426 (2,462)
+failed on nine files that `svelte.compile` accepts:
 
 - **`catch (err) { err = … }`** reported `constant_assignment`. The catch
   parameter was declared `const`; upstream's `scope.js` declares it `let`.
@@ -16,6 +16,14 @@ Compiling open-webui v0.11.0 (650 components) failed on four files that
   directly, not a destructuring pattern. The same shorthand inside an object
   *literal* is still a store read — the two are told apart by what precedes the
   pattern's opening bracket.
+- **`import { $comparedDocument as compareTo }`** reported
+  `global_reference_invalid`. The imported name is not a reference at all.
+- **`export let state` alongside `$state.room = v`** reported
+  `legacy_export_invalid`. `$state` there is a store read, not the rune, and
+  upstream removes such names before it decides runes mode — but the scan that
+  collects locally declared names missed `export let`, declarators with no
+  initialiser, and TypeScript annotations, so all three of `export let state`,
+  `let state;` and `let state: T` left `$state` looking like a rune.
 - **`(a?: string, b: string) => b`** and 14 other TypeScript grammar rules were
   raised as `js_parse_error`. Upstream parses `lang="ts"` with
   `acorn-typescript`, which does not run TypeScript's grammar checks; OXC does.
@@ -23,5 +31,4 @@ Compiling open-webui v0.11.0 (650 components) failed on four files that
   acorn-typescript *does* implement (1049, 1096, 1098, 1257, 1276, 2452, …) still
   fail, as does TypeScript syntax in a plain `<script>`.
 
-The corpus now compiles 649 of 650 for client and server, the remaining file
-being one upstream rejects too.
+Both corpora now compile for client and server everywhere upstream does.

--- a/crates/rsvelte_core/src/compiler/phases/1_parse/read/expression.rs
+++ b/crates/rsvelte_core/src/compiler/phases/1_parse/read/expression.rs
@@ -6678,6 +6678,38 @@ pub fn parse_program_retained_with_error<'ast, 'source>(
     (program, parse_error, retained)
 }
 
+/// TypeScript grammar rules OXC enforces that `acorn-typescript` — which upstream
+/// parses `lang="ts"` scripts with — does not, so upstream compiles these inputs
+/// and rsvelte must too. Each entry was confirmed against `svelte.compile`; the
+/// TS rules acorn-typescript *does* implement (1019, 1028, 1049, 1096, 1174,
+/// 1184, 1257, 1276, 2398, 2452, 2730, …) are deliberately absent.
+const ACORN_UNCHECKED_TS_GRAMMAR_RULES: [&str; 15] = [
+    "1015", // A parameter cannot have a question mark and an initializer
+    "1016", // A required parameter cannot follow an optional parameter
+    "1021", // An index signature must have a type annotation
+    "1038", // A 'declare' modifier cannot be used in an already ambient context
+    "1047", // A rest parameter cannot be optional
+    "1051", // A 'set' accessor cannot have an optional parameter
+    "1093", // Type annotation cannot appear on a constructor declaration
+    "1094", // An accessor cannot have type parameters
+    "1095", // A 'set' accessor cannot have a return type annotation
+    "1221", // Generators are not allowed in an ambient context
+    "1222", // An overload signature cannot be declared as a generator
+    "1263", // Declarations with initializers cannot also have definite assignment assertions
+    "1264", // Declarations with definite assignment assertions must also have type annotations
+    "2681", // A constructor cannot have a `this` parameter
+    "5085", // A tuple member cannot be both optional and rest
+];
+
+fn is_acorn_unchecked_ts_grammar_rule(diagnostic: &OxcDiagnostic) -> bool {
+    diagnostic.code.scope.as_deref() == Some("TS")
+        && diagnostic
+            .code
+            .number
+            .as_deref()
+            .is_some_and(|n| ACORN_UNCHECKED_TS_GRAMMAR_RULES.contains(&n))
+}
+
 fn convert_parsed_program<'ast>(
     arena: &ParseArena,
     program: &OxcProgram<'_>,
@@ -6697,19 +6729,22 @@ fn convert_parsed_program<'ast>(
         // Mirror upstream acorn's throw-on-error behaviour: capture the first
         // parse error (acorn reports `err.pos` where it stopped consuming
         // input; OXC's first label is the closest equivalent).
-        let mut parse_error = diagnostics.first().map(|first_error| {
-            let pos = first_error
-                .labels
-                .first()
-                .map(|label| (label.offset() as usize).min(content.len()))
-                .unwrap_or(0)
-                + offset;
-            crate::error::ParseError::svelte(
-                "js_parse_error",
-                first_error.message.to_string(),
-                (pos, pos),
-            )
-        });
+        let mut parse_error = diagnostics
+            .iter()
+            .find(|d| !is_acorn_unchecked_ts_grammar_rule(d))
+            .map(|first_error| {
+                let pos = first_error
+                    .labels
+                    .first()
+                    .map(|label| (label.offset() as usize).min(content.len()))
+                    .unwrap_or(0)
+                    + offset;
+                crate::error::ParseError::svelte(
+                    "js_parse_error",
+                    first_error.message.to_string(),
+                    (pos, pos),
+                )
+            });
 
         // OXC has no strict-mode syntax-restriction pass at all, unlike acorn,
         // which applies one uniformly because every script is parsed with

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/scope_builder.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/scope_builder.rs
@@ -979,13 +979,16 @@ impl<'a> ScopeBuilder<'a> {
                         let param = *param;
                         let body = *body;
                         let old_scope = self.push_scope();
-                        // Declare catch parameter if present
+                        // Declare catch parameter if present. Upstream declares it
+                        // `let` (scope.js CatchClause), so `catch (e) { e = ... }`
+                        // is legal and must not report `constant_assignment`.
                         if let Some(param_id) = param {
                             let param_node = self.arena.get_js_node(param_id);
-                            self.declare_bindings_from_pattern_node(
+                            self.declare_bindings_from_pattern_node_with_kind(
                                 param_node,
                                 BindingKind::Normal,
                                 false,
+                                DeclarationKind::Let,
                             );
                         }
                         let body_node = self.arena.get_js_node(body);

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/store_subscriptions.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/store_subscriptions.rs
@@ -706,6 +706,42 @@ fn is_dollar_ident_variable_declaration(chars: &[char], ident_start: usize) -> b
     false
 }
 
+/// Index of the `{` or `[` that opens the pattern enclosing `from`, or `None`
+/// when the scan leaves the pattern before finding one.
+fn enclosing_pattern_open(chars: &[char], from: usize) -> Option<usize> {
+    let (mut curly, mut square) = (0usize, 0usize);
+    let mut k = from as isize - 1;
+    while k >= 0 {
+        match chars[k as usize] {
+            '}' => curly += 1,
+            ']' => square += 1,
+            '{' if curly > 0 => curly -= 1,
+            '[' if square > 0 => square -= 1,
+            '{' | '[' => return Some(k as usize),
+            // A `(` means a parameter list or a parenthesised expression, neither
+            // of which this helper answers for; `;` ends the statement.
+            '(' | ')' | ';' => return None,
+            _ => {}
+        }
+        k -= 1;
+    }
+    None
+}
+
+/// `const { $from } = …` and `const [$a] = …` declare the name, while the same
+/// shorthand inside an object *literal* (`const x = { $store }`) reads it — the
+/// two are told apart by what precedes the pattern's opening bracket.
+fn is_dollar_ident_destructuring_declaration(chars: &[char], ident_start: usize) -> bool {
+    let mut from = ident_start;
+    while let Some(open) = enclosing_pattern_open(chars, from) {
+        if is_dollar_ident_variable_declaration(chars, open) {
+            return true;
+        }
+        from = open;
+    }
+    false
+}
+
 /// Check if a `$$xxx` identifier is used in a TypeScript type declaration context
 /// (e.g., `type $$Props = ...` or `interface $$Props { ... }`).
 /// These are TypeScript-only constructs that should not be treated as store references.
@@ -946,7 +982,8 @@ fn collect_dollar_identifiers_pass(
                 // (bare $ detection is handled separately via proper AST analysis)
                 if ident.len() > 1 {
                     let param_range = dollar_param_body_range(chars, ident_start, i);
-                    let is_var_decl = is_dollar_ident_variable_declaration(chars, ident_start);
+                    let is_var_decl = is_dollar_ident_variable_declaration(chars, ident_start)
+                        || is_dollar_ident_destructuring_declaration(chars, ident_start);
                     let is_declaration = param_range.is_some() || is_var_decl;
                     if collect_declared {
                         if let Some((bs, be)) = param_range {

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/store_subscriptions.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/store_subscriptions.rs
@@ -734,10 +734,40 @@ fn enclosing_pattern_open(chars: &[char], from: usize) -> Option<usize> {
 fn is_dollar_ident_destructuring_declaration(chars: &[char], ident_start: usize) -> bool {
     let mut from = ident_start;
     while let Some(open) = enclosing_pattern_open(chars, from) {
+        if sits_in_a_default_value(chars, from, open) {
+            return false;
+        }
         if is_dollar_ident_variable_declaration(chars, open) {
             return true;
         }
         from = open;
+    }
+    false
+}
+
+/// Whether a plain `=` separates `pos` from its element's start, i.e. `{ value =
+/// $page }` reads `$page` rather than binding it.
+fn sits_in_a_default_value(chars: &[char], pos: usize, open: usize) -> bool {
+    let mut k = pos as isize - 1;
+    while k > open as isize {
+        let c = chars[k as usize];
+        if c == ',' {
+            return false;
+        }
+        if c == '=' {
+            let next = chars.get(k as usize + 1).copied().unwrap_or(' ');
+            let prev = chars[k as usize - 1];
+            if next != '='
+                && next != '>'
+                && !matches!(
+                    prev,
+                    '=' | '!' | '<' | '>' | '+' | '-' | '*' | '/' | '%' | '&' | '|' | '^'
+                )
+            {
+                return true;
+            }
+        }
+        k -= 1;
     }
     false
 }

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/store_subscriptions.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/store_subscriptions.rs
@@ -742,6 +742,46 @@ fn is_dollar_ident_destructuring_declaration(chars: &[char], ident_start: usize)
     false
 }
 
+/// Whether `kw` ends at `end` (inclusive) and is not part of a longer word.
+fn keyword_ends_at(chars: &[char], end: isize, kw: &str) -> bool {
+    let n = kw.chars().count() as isize;
+    if end < n - 1 {
+        return false;
+    }
+    let start = (end - n + 1) as usize;
+    if !chars[start..=end as usize].iter().copied().eq(kw.chars()) {
+        return false;
+    }
+    start == 0 || !is_identifier_char(chars[start - 1])
+}
+
+/// `import { $foo as bar }` names a module export rather than reading a store,
+/// and a bare `import { $foo }` declares the name outright.
+fn is_dollar_ident_import_specifier(chars: &[char], ident_start: usize) -> bool {
+    let Some(open) = enclosing_pattern_open(chars, ident_start) else {
+        return false;
+    };
+    if chars[open] != '{' {
+        return false;
+    }
+    let mut k = open as isize - 1;
+    while k >= 0 && chars[k as usize].is_whitespace() {
+        k -= 1;
+    }
+    if keyword_ends_at(chars, k, "import") {
+        return true;
+    }
+    // `import type { … }`
+    if keyword_ends_at(chars, k, "type") {
+        k -= 4;
+        while k >= 0 && chars[k as usize].is_whitespace() {
+            k -= 1;
+        }
+        return keyword_ends_at(chars, k, "import");
+    }
+    false
+}
+
 /// Check if a `$$xxx` identifier is used in a TypeScript type declaration context
 /// (e.g., `type $$Props = ...` or `interface $$Props { ... }`).
 /// These are TypeScript-only constructs that should not be treated as store references.
@@ -984,7 +1024,9 @@ fn collect_dollar_identifiers_pass(
                     let param_range = dollar_param_body_range(chars, ident_start, i);
                     let is_var_decl = is_dollar_ident_variable_declaration(chars, ident_start)
                         || is_dollar_ident_destructuring_declaration(chars, ident_start);
-                    let is_declaration = param_range.is_some() || is_var_decl;
+                    let is_declaration = param_range.is_some()
+                        || is_var_decl
+                        || is_dollar_ident_import_specifier(chars, ident_start);
                     if collect_declared {
                         if let Some((bs, be)) = param_range {
                             // A param shadows only inside its own arrow body.

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/types.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/types.rs
@@ -513,7 +513,11 @@ pub fn extract_local_non_rune_declared_names(raw: &str) -> rustc_hash::FxHashSet
     let mut names = rustc_hash::FxHashSet::default();
     for line in raw.lines() {
         let trimmed = line.trim();
-        // Look for `const/let/var NAME = <rhs>`
+        // `export let x` is the legacy prop form and declares `x` just the same.
+        let trimmed = trimmed
+            .strip_prefix("export ")
+            .map_or(trimmed, str::trim_start);
+        // Look for `const/let/var NAME[: T][ = <rhs>]`
         let rest = trimmed
             .strip_prefix("const ")
             .or_else(|| trimmed.strip_prefix("let "))
@@ -522,24 +526,26 @@ pub fn extract_local_non_rune_declared_names(raw: &str) -> rustc_hash::FxHashSet
             Some(r) => r.trim(),
             None => continue,
         };
-        // Find the `= ` separator (simple assignment, not destructuring)
-        if let Some(eq_pos) = rest.find(" = ") {
-            let name_part = rest[..eq_pos].trim();
-            // Only simple identifiers (no destructuring patterns)
-            if name_part.is_empty()
-                || !name_part
-                    .chars()
-                    .all(|c| c.is_alphanumeric() || c == '_' || c == '$')
-            {
-                continue;
-            }
-            let rhs = rest[eq_pos + 3..].trim();
-            // If the RHS starts with a rune call, this variable IS rune-initialised
-            let is_rune_init = RUNE_PREFIXES.iter().any(|p| rhs.starts_with(p));
-            if !is_rune_init {
-                names.insert(name_part.to_string());
-            }
+        // A declarator with no initialiser cannot be rune-initialised.
+        let (declarator, rhs) = match rest.find(" = ") {
+            Some(eq_pos) => (&rest[..eq_pos], rest[eq_pos + 3..].trim()),
+            None => (rest.trim_end_matches(';'), ""),
+        };
+        // Drop a TypeScript annotation: `state: Writable<Record<string, any>>`.
+        let name_part = declarator.split(':').next().unwrap_or(declarator).trim();
+        // Only simple identifiers (no destructuring patterns)
+        if name_part.is_empty()
+            || !name_part
+                .chars()
+                .all(|c| c.is_alphanumeric() || c == '_' || c == '$')
+        {
+            continue;
         }
+        // If the RHS starts with a rune call, this variable IS rune-initialised
+        if RUNE_PREFIXES.iter().any(|p| rhs.starts_with(p)) {
+            continue;
+        }
+        names.insert(name_part.to_string());
     }
     names
 }

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/svelte_fragment.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/svelte_fragment.rs
@@ -36,8 +36,16 @@ pub fn visit<'a, 'b: 'a>(
         context.scope = frag_scope;
     }
 
+    // Children are the fragment's, not the component's, so a `slot="…"` on one
+    // is `slot_attribute_invalid_placement` upstream (`owner !== parent`) and a
+    // nested `<svelte:fragment>` is invalid too.
+    let was_direct_child = context.is_direct_child_of_component;
+    context.is_direct_child_of_component = false;
+
     // Analyze children
     fragment::analyze(&mut frag.fragment, context)?;
+
+    context.is_direct_child_of_component = was_direct_child;
 
     // Restore scope
     context.scope = old_scope;

--- a/crates/rsvelte_core/tests/open_webui_false_positives.rs
+++ b/crates/rsvelte_core/tests/open_webui_false_positives.rs
@@ -1,0 +1,105 @@
+//! Regression tests for three false-positive compile errors found by compiling
+//! open-webui v0.11.0, which upstream `svelte.compile` accepts. Each case was
+//! reduced from a real component and confirmed against the official compiler in
+//! both directions — the negative controls below still have to fail.
+
+use rsvelte_core::{CompileOptions, GenerateMode, compile, compiler::CssMode};
+
+fn try_compile(src: &str) -> Result<(), String> {
+    compile(
+        src,
+        CompileOptions {
+            filename: Some("Test.svelte".to_string()),
+            generate: GenerateMode::Client,
+            dev: false,
+            css: CssMode::External,
+            ..Default::default()
+        },
+    )
+    .map(|_| ())
+    .map_err(|e| format!("{e:?}"))
+}
+
+#[test]
+fn catch_clause_parameter_is_assignable() {
+    assert!(
+        try_compile(
+            "<script>\nconst go = () => { try { x(); } catch (err) { err = err.message; } };\n</script>"
+        )
+        .is_ok()
+    );
+    assert!(
+        try_compile(
+            "<script>\nconst go = () => { try { x(); } catch ({ a }) { a = 1; } };\n</script>"
+        )
+        .is_ok()
+    );
+}
+
+#[test]
+fn const_declared_in_a_function_is_still_constant() {
+    assert!(try_compile("<script>\nconst go = () => { const e = 1; e = 2; };\n</script>").is_err());
+}
+
+#[test]
+fn dollar_name_destructured_from_a_declaration_is_not_a_store_read() {
+    let src = "<script>\n\
+        const a = (r) => { r.forEach(({ from }) => from); };\n\
+        const b = (state) => { const { $from } = state.selection; return $from; };\n\
+        </script>";
+    assert!(try_compile(src).is_ok());
+    // Nested patterns reach the declaration keyword through more than one hop.
+    let nested = "<script>\n\
+        const a = (r) => { r.forEach(({ from }) => from); };\n\
+        const b = (s) => { const { a: { $from } } = s; return $from; };\n\
+        </script>";
+    assert!(try_compile(nested).is_ok());
+}
+
+#[test]
+fn dollar_name_in_an_object_literal_is_still_a_store_read() {
+    // Same shorthand, but the `{` opens a literal rather than a pattern, so the
+    // scoped-store error must survive.
+    let src = "<script>\n\
+        const a = (r) => { r.forEach(({ from }) => from); };\n\
+        const b = () => $from;\n\
+        </script>";
+    assert!(try_compile(src).is_err());
+}
+
+#[test]
+fn typescript_grammar_rules_acorn_does_not_check_are_not_parse_errors() {
+    let ts = |body: &str| format!("<script lang=\"ts\">\n{body}\n</script>");
+    for body in [
+        "const f = (a?: string, b: string) => b;", // TS1016
+        "const f = (a?: string = \"x\") => a;",    // TS1015
+        "const f = (...a?: string[]) => a;",       // TS1047
+        "class C { set x(a?: number) {} }",        // TS1051
+        "class C { set x(a: number): void {} }",   // TS1095
+        "class C { constructor(this: C) {} }",     // TS2681
+        "let x!: number = 1;",                     // TS1263
+        "type T = [...a?: string[]];",             // TS5085
+    ] {
+        assert!(try_compile(&ts(body)).is_ok(), "should compile: {body}");
+    }
+}
+
+#[test]
+fn typescript_grammar_rules_acorn_does_check_stay_parse_errors() {
+    let ts = |body: &str| format!("<script lang=\"ts\">\n{body}\n</script>");
+    for body in [
+        "class C { set x(a: number, b: number) {} }", // TS1049
+        "interface I { [a: string, b: string]: number }", // TS1096
+        "function f<>() {}",                          // TS1098
+        "type T = [a?: string, b: string];",          // TS1257
+        "class C { accessor x?: number; }",           // TS1276
+        "enum E { 1 = 1 }",                           // TS2452
+    ] {
+        assert!(
+            try_compile(&ts(body)).is_err(),
+            "should be rejected: {body}"
+        );
+    }
+    // TypeScript syntax in a plain script stays a `js_parse_error`.
+    assert!(try_compile("<script>\nconst x = <string>y;\n</script>").is_err());
+}

--- a/crates/rsvelte_core/tests/real_world_false_positives.rs
+++ b/crates/rsvelte_core/tests/real_world_false_positives.rs
@@ -1,7 +1,8 @@
-//! Regression tests for three false-positive compile errors found by compiling
-//! open-webui v0.11.0, which upstream `svelte.compile` accepts. Each case was
-//! reduced from a real component and confirmed against the official compiler in
-//! both directions — the negative controls below still have to fail.
+//! Regression tests for false-positive compile errors found by compiling
+//! open-webui v0.11.0 (650 components) and Huly Platform v0.7.426 (2,462), which
+//! upstream `svelte.compile` accepts. Each case was reduced from a real component
+//! and confirmed against the official compiler in both directions — the negative
+//! controls below still have to fail.
 
 use rsvelte_core::{CompileOptions, GenerateMode, compile, compiler::CssMode};
 
@@ -102,4 +103,71 @@ fn typescript_grammar_rules_acorn_does_check_stay_parse_errors() {
     }
     // TypeScript syntax in a plain script stays a `js_parse_error`.
     assert!(try_compile("<script>\nconst x = <string>y;\n</script>").is_err());
+}
+
+#[test]
+fn a_rune_named_store_prop_does_not_flip_runes_mode() {
+    // `export let state` + `$state.x` is a store read, so `export let` stays legal.
+    // Upstream deletes the synthetic store name from `module.scope.references`
+    // before runes detection reads it.
+    for name in ["state", "derived", "props", "effect"] {
+        let src = format!(
+            "<script>\nexport let {name};\nfunction go(v) {{ ${name}.room = v; }}\n</script>"
+        );
+        assert!(try_compile(&src).is_ok(), "should compile: {name}");
+    }
+    // A type annotation and a missing initialiser must not hide the declaration.
+    assert!(
+        try_compile(
+            "<script lang=\"ts\">\nexport let state: unknown;\nlet other;\nfunction go() { return $state; }\n</script>"
+        )
+        .is_ok()
+    );
+}
+
+#[test]
+fn a_real_rune_still_flips_runes_mode() {
+    assert!(try_compile("<script>\nlet a = $state(0);\nexport let b;\n</script>").is_err());
+}
+
+#[test]
+fn a_dollar_prefixed_import_specifier_is_not_a_store_read() {
+    assert!(
+        try_compile("<script>\nimport { $comparedDocument as compareTo } from './s';\nconst v = compareTo;\n</script>")
+            .is_ok()
+    );
+    // A `$`-prefixed *local* name is still reserved, aliased or not.
+    assert!(
+        try_compile("<script>\nimport { $foo } from './s';\nconst v = $foo;\n</script>").is_err()
+    );
+}
+
+#[test]
+fn a_free_dollar_reference_is_still_an_invalid_global() {
+    assert!(try_compile("<script>\nconst v = $comparedDocument;\n</script>").is_err());
+}
+
+#[test]
+fn a_slot_attribute_inside_a_fragment_is_invalid_placement() {
+    // Upstream errors because the element's parent is the fragment, not the
+    // component (`owner !== parent` in shared/attribute.js).
+    let src = "<script>import C from './C.svelte';</script>\n\
+        <C>\n<svelte:fragment slot=\"pool\">\n\
+        <div slot=\"afterContent\">x</div>\n</svelte:fragment>\n</C>";
+    assert!(try_compile(src).is_err());
+    // A nested fragment is invalid for the same reason.
+    let nested = "<script>import C from './C.svelte';</script>\n\
+        <C>\n<svelte:fragment slot=\"a\"><svelte:fragment slot=\"b\">x</svelte:fragment></svelte:fragment>\n</C>";
+    assert!(try_compile(nested).is_err());
+}
+
+#[test]
+fn a_slot_attribute_directly_under_a_component_is_still_valid() {
+    let src = "<script>import C from './C.svelte';</script>\n\
+        <C><div slot=\"x\">y</div></C>";
+    assert!(try_compile(src).is_ok());
+    // A component may carry `slot=` anywhere under its owner.
+    let inner = "<script>import C from './C.svelte'; import D from './D.svelte';</script>\n\
+        <C><svelte:fragment slot=\"a\"><D slot=\"b\" /></svelte:fragment></C>";
+    assert!(try_compile(inner).is_ok());
 }

--- a/crates/rsvelte_core/tests/real_world_false_positives.rs
+++ b/crates/rsvelte_core/tests/real_world_false_positives.rs
@@ -171,3 +171,11 @@ fn a_slot_attribute_directly_under_a_component_is_still_valid() {
         <C><svelte:fragment slot=\"a\"><D slot=\"b\" /></svelte:fragment></C>";
     assert!(try_compile(inner).is_ok());
 }
+
+#[test]
+fn a_dollar_name_in_a_destructuring_default_is_still_a_store_read() {
+    // `{ value = $page }` reads the store; only the binding target is a declaration.
+    let src = "<script>\nimport { writable } from 'svelte/store';\n\
+        const page = writable(1);\nconst { value = $page } = $props();\n</script>\n{value}";
+    assert!(try_compile(src).is_ok());
+}


### PR DESCRIPTION
rsvelte fails to compile two of the corpora in
[pikax/svelte-benchmarks](https://github.com/pikax/svelte-benchmarks) — open-webui
and Huly Platform — where the official compiler succeeds. Both are reported as
`error` in the published results, so neither is timed at all.

Compiling them locally against `svelte.compile` finds nine files rsvelte rejects
and upstream accepts, from five distinct bugs.

| corpus | before | after |
| --- | ---: | ---: |
| open-webui v0.11.0 (649 files) | 4 rejected | **0** |
| Huly Platform v0.7.426 (2,432 files) | 5 rejected | **0** |

Both corpora are exactly "the files upstream compiles" (650 − 1 and 2,462 − 30),
and rsvelte now rejects nothing outside that set, for `client` and `server` alike.

## The bugs

1. **`catch (err) { err = err.message }`** → `constant_assignment`. The catch
   parameter was declared `const`; upstream's `scope.js` declares it `let`.
2. **`const { $from } = state.selection`** → `store_invalid_scoped_subscription`
   whenever some unrelated scope declared a `from`. The `$`-name is a
   declaration, but the scan deciding which `$name`s are store reads only
   recognised `let`/`const`/`var $x` written directly, not a destructuring
   pattern. The same shorthand in an object *literal* is still a store read; the
   two are told apart by what precedes the pattern's opening bracket.
3. **`import { $comparedDocument as compareTo }`** → `global_reference_invalid`.
   The imported name is not a reference.
4. **`export let state` + `$state.room = v`** → `legacy_export_invalid`. That
   `$state` is a store read, not the rune, and upstream drops such names from
   `module.scope.references` before deciding runes mode — but the scan collecting
   locally declared names required a bare `let`/`const`/`var` *with* an
   initialiser, so `export let state`, `let state;` and `let state: T` all left
   `$state` looking like a rune.
5. **`(a?: string, b: string) => b`** and 14 other TypeScript grammar rules →
   `js_parse_error`. Upstream parses `lang="ts"` with `acorn-typescript`, which
   runs no TypeScript grammar checks; OXC does, and tags each with a `TS` code.

Plus one error rsvelte was *missing*: a `slot="…"` on a child of a
`<svelte:fragment>` is `slot_attribute_invalid_placement` upstream, because the
nearest component ancestor is not the element's parent. The fragment visitor kept
`is_direct_child_of_component` set while analysing its children, unlike the
if/key block visitors.

## How the suppressed TypeScript rules were chosen

Not by reasoning about which rules "look semantic" — a first pass at that would
have been wrong, since `acorn-typescript` *does* implement a good number of them.
Every candidate was run through `svelte.compile`, and only the rules it accepts
are suppressed. The rules it rejects (1049, 1096, 1098, 1257, 1276, 2452, …) still
fail, and so does TypeScript syntax in a plain `<script>` (`8xxx`).

Both directions are pinned by tests: 12 cases assert the accepted constructs
compile, and the negative controls — a real `const` reassignment, a genuinely
scoped store subscription, a free `$` reference, `let a = $state(0)` still
flipping runes mode, `{ $from }` in an object literal still reading a store — all
still fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
