### PR TITLE
perf(transform): locate a source position without walking the whole prefix

### DIFF
--- a/.changeset/locate-in-source-memchr.md
+++ b/.changeset/locate-in-source-memchr.md
@@ -1,0 +1,14 @@
+---
+"@rsvelte/compiler": patch
+---
+
+Locate dev-mode source positions without walking the whole prefix
+
+`locate_in_source` counted lines and UTF-16 columns by iterating every
+character from byte 0. Dev-mode codegen calls it once per instrumented site, so
+the walk was quadratic in the source length. It now counts newlines with
+`memchr` and only walks the final line for the column.
+
+Interleaved paired runs, dev-mode client: open-webui −12.9% (8/8),
+SMUI −4.1% (8/8), carbon-components-svelte −4.0% (7/8), Huly plugins −4.0%
+(6/6). Production-mode client is unchanged (−0.9%, 2/6).

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/utils.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/utils.rs
@@ -1286,16 +1286,13 @@ pub fn locate_in_source(source: &str, byte_offset: usize) -> (usize, usize) {
     while end > 0 && !source.is_char_boundary(end) {
         end -= 1;
     }
-    let mut line = 1usize;
-    let mut column = 0usize;
-    for c in source[..end].chars() {
-        if c == '\n' {
-            line += 1;
-            column = 0;
-        } else {
-            column += c.len_utf16();
-        }
-    }
+    // Dev-mode codegen calls this once per instrumented site, so walking the
+    // whole prefix character by character made instrumentation quadratic in
+    // the source length. Only the final line needs a UTF-16 walk.
+    let head = &source.as_bytes()[..end];
+    let line = 1 + memchr::memchr_iter(b'\n', head).count();
+    let line_start = memchr::memrchr(b'\n', head).map_or(0, |i| i + 1);
+    let column = source[line_start..end].chars().map(char::len_utf16).sum();
     (line, column)
 }
 

--- a/crates/rsvelte_devtools/src/bin/compile_profile.rs
+++ b/crates/rsvelte_devtools/src/bin/compile_profile.rs
@@ -64,6 +64,7 @@ fn main() {
 
     let compile_opts = CompileOptions {
         generate: GenerateMode::Client,
+        dev: std::env::args().any(|a| a == "--dev"),
         ..Default::default()
     };
 


### PR DESCRIPTION
## What

`locate_in_source` counted lines and UTF-16 columns by iterating **every
character from byte 0** of the `.svelte` source. It now counts newlines with
`memchr` and walks only the final line for the column.

## Why

Dev-mode codegen calls `locate_in_source` once per instrumented site, from
roughly twenty call sites (client visitors, `wrap_prop_mutation_validation`,
assignment instrumentation, …) — so the prefix walk was quadratic in the
source length.

That cost was invisible until now because `compile_profile` was
client-**production** only. Measuring the dev target through the NAPI addon
first showed how lopsided it is:

| target | rsvelte | svelte-rs | ratio |
|---|---|---|---|
| client prod | 700ms | 172ms | 4.07x |
| server prod | 443ms | 145ms | 3.05x |
| server dev | 546ms | 153ms | 3.56x |
| **client dev** | **1171ms** | **178ms** | **6.59x** |

Dev mode costs rsvelte +67% over production and svelte-rs +3%. Profiling the
dev target (this PR adds `--dev` to `compile_profile` so that is possible)
put 11.72% of total self-time in `locate_in_source` alone.

## Measurements

Interleaved paired A/B, alternating baseline/fix binaries, median of N pairs:

| corpus | files | baseline | fix | delta | wins |
|---|---|---|---|---|---|
| open-webui (dev) | 650 | 1179.2ms | 1026.9ms | **−12.9%** | 8/8 |
| SMUI (dev) | 449 | 201.1ms | 192.8ms | **−4.1%** | 8/8 |
| carbon-components-svelte (dev) | 287 | 383.9ms | 368.4ms | **−4.0%** | 7/8 |
| Huly plugins (dev) | 2,123 | 1726.4ms | 1656.7ms | **−4.0%** | 6/6 |
| open-webui (prod) | 650 | 714.8ms | 708.2ms | −0.9% | 2/6 |

Production mode is unchanged, as expected — the call sites are `dev`-gated.

## Correctness

`cargo test --release -p rsvelte_core`: 2463 passed, 0 failed. The two existing
unit tests pin exactly what the rewrite has to preserve — UTF-16 column
counting (`🎉` is two columns, `あ` is one) and per-line column reset with
out-of-range clamping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
