### PR TITLE
perf(transform): scan the comment/string state once per source

### DIFF
--- a/.changeset/prop-mutation-code-spans.md
+++ b/.changeset/prop-mutation-code-spans.md
@@ -1,0 +1,14 @@
+---
+"@rsvelte/compiler": patch
+---
+
+Scan the comment/string state once per source for prop-mutation validation
+
+`PropMutationSites::collect` re-ran the comment/string scanner from the last
+accepted site for every candidate occurrence of every prop, and recomputed the
+`$:` statement ranges once per prop. Both scans are prop-independent, so they
+now run once per source and each candidate is a binary search.
+
+Interleaved paired runs, dev-mode client: carbon-components-svelte −37.7%
+(8/8), SMUI −16.0% (8/8), open-webui −15.9% (8/8), Huly plugins −10.6% (6/6).
+Production-mode client is unchanged (−0.1%).

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/props_transforms.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/props_transforms.rs
@@ -2990,6 +2990,7 @@ pub(super) fn wrap_prop_mutation_validation(
     let _trimmed = stmt.trim();
 
     let mut result = stmt.to_string();
+    let scan = PropMutationScan::new(source);
 
     for (var_name, prop_alias) in prop_vars {
         let alias_literal = match prop_alias {
@@ -3000,7 +3001,7 @@ pub(super) fn wrap_prop_mutation_validation(
         // This handles the case where transform_prop_assignments skips member mutation wrapping in runes mode.
         let runes_prefix = format!("{}().", var_name);
         let mut runes_search_from = 0;
-        let mut sites = PropMutationSites::collect(source, var_name);
+        let mut sites = PropMutationSites::collect(source, var_name, &scan);
 
         while runes_search_from < result.len() {
             let Some(prefix_rel) = result[runes_search_from..].find(&runes_prefix) else {
@@ -3493,13 +3494,29 @@ pub(super) struct PropMutationSites {
     sites: Vec<PropMutationSite>,
 }
 
+/// The two source-wide scans every prop's site collection needs. Neither
+/// depends on the prop, so recomputing them per prop made the pass quadratic
+/// in the script length.
+pub(super) struct PropMutationScan {
+    reactive: Vec<(usize, usize)>,
+    code: CodeSpans,
+}
+
+impl PropMutationScan {
+    pub(super) fn new(source: &str) -> Self {
+        Self {
+            reactive: reactive_statement_ranges(source),
+            code: CodeSpans::scan(source),
+        }
+    }
+}
+
 impl PropMutationSites {
-    pub(super) fn collect(source: &str, var_name: &str) -> Self {
+    pub(super) fn collect(source: &str, var_name: &str, scan: &PropMutationScan) -> Self {
         let mut sites = Vec::new();
-        let reactive = reactive_statement_ranges(source);
-        let mut cursor = memchr::memmem::find(source.as_bytes(), b"<script").unwrap_or(0);
+        let reactive = &scan.reactive;
         let bytes = source.as_bytes();
-        let mut search = cursor;
+        let mut search = memchr::memmem::find(bytes, b"<script").unwrap_or(0);
         while search < source.len() {
             let Some(rel) = memchr::memmem::find(&bytes[search..], var_name.as_bytes()) else {
                 break;
@@ -3507,7 +3524,7 @@ impl PropMutationSites {
             let start = search + rel;
             let end = start + var_name.len();
             search = end;
-            if !is_in_code(source, cursor, start) {
+            if !scan.code.contains(start) {
                 continue;
             }
             if start > 0 {
@@ -3539,7 +3556,6 @@ impl PropMutationSites {
                         .any(|(from, to)| (*from..*to).contains(&start)),
                     used: false,
                 });
-                cursor = end;
             }
         }
         // A `$:` body is emitted at the end of the instance script as a
@@ -3747,69 +3763,228 @@ fn static_member_names(path_parts: &[String]) -> Option<Vec<String>> {
 /// Whether `target` sits in code rather than inside a comment or a string /
 /// template literal. `from` must itself be a code offset — the scan starts
 /// there in the code state, so callers pass the previous confirmed match.
-fn is_in_code(source: &str, from: usize, target: usize) -> bool {
-    #[derive(PartialEq)]
-    enum S {
-        Code,
-        Line,
-        Block,
-        Single,
-        Double,
-        Template,
-    }
-    let bytes = source.as_bytes();
-    let mut state = S::Code;
-    let mut i = from;
-    while i < target {
-        let c = bytes[i];
-        let next = bytes.get(i + 1).copied();
-        match state {
-            S::Code => match (c, next) {
-                (b'/', Some(b'/')) => {
-                    state = S::Line;
-                    i += 2;
-                    continue;
+/// Byte ranges of `source` the comment / string scanner reports as code.
+///
+/// The scanner is deterministic left-to-right, so running it once and looking
+/// a position up beats re-running it from the previous hit for every candidate
+/// occurrence of every prop — which was quadratic in the script length.
+pub(super) struct CodeSpans {
+    /// Sorted, non-overlapping `[start, end)` ranges. Everything before the
+    /// `<script` tag is code, matching the empty scan the old caller did there.
+    spans: Vec<(usize, usize)>,
+}
+
+impl CodeSpans {
+    fn scan(source: &str) -> Self {
+        #[derive(PartialEq)]
+        enum S {
+            Code,
+            Line,
+            Block,
+            Single,
+            Double,
+            Template,
+        }
+        let bytes = source.as_bytes();
+        let mut spans = Vec::new();
+        let mut state = S::Code;
+        let mut code_from = 0usize;
+        let mut i = memchr::memmem::find(bytes, b"<script").unwrap_or(0);
+        while i < bytes.len() {
+            let was_code = state == S::Code;
+            let c = bytes[i];
+            let next = bytes.get(i + 1).copied();
+            match state {
+                S::Code => match (c, next) {
+                    (b'/', Some(b'/')) => {
+                        spans.push((code_from, i + 1));
+                        state = S::Line;
+                        i += 2;
+                        continue;
+                    }
+                    (b'/', Some(b'*')) => {
+                        spans.push((code_from, i + 1));
+                        state = S::Block;
+                        i += 2;
+                        continue;
+                    }
+                    (b'\'', _) => state = S::Single,
+                    (b'"', _) => state = S::Double,
+                    (b'`', _) => state = S::Template,
+                    _ => {}
+                },
+                S::Line => {
+                    if c == b'\n' {
+                        state = S::Code;
+                    }
                 }
-                (b'/', Some(b'*')) => {
-                    state = S::Block;
-                    i += 2;
-                    continue;
+                S::Block => {
+                    if c == b'*' && next == Some(b'/') {
+                        state = S::Code;
+                        // `is_in_code` reported the byte after the `*` as code
+                        // because its two-byte skip overshot the query.
+                        code_from = i + 1;
+                        i += 2;
+                        continue;
+                    }
                 }
-                (b'\'', _) => state = S::Single,
-                (b'"', _) => state = S::Double,
-                (b'`', _) => state = S::Template,
+                S::Single | S::Double | S::Template => {
+                    if c == b'\\' {
+                        i += 2;
+                        continue;
+                    }
+                    let closer = match state {
+                        S::Single => b'\'',
+                        S::Double => b'"',
+                        _ => b'`',
+                    };
+                    if c == closer {
+                        state = S::Code;
+                    }
+                }
+            }
+            i += 1;
+            // The old scanner reported the state *at* the queried byte, so a
+            // quote opens its string at the byte after it and closes at the
+            // byte after the closer.
+            match (was_code, state == S::Code) {
+                (true, false) => spans.push((code_from, i)),
+                (false, true) => code_from = i,
                 _ => {}
-            },
-            S::Line => {
-                if c == b'\n' {
-                    state = S::Code;
-                }
-            }
-            S::Block => {
-                if c == b'*' && next == Some(b'/') {
-                    state = S::Code;
-                    i += 2;
-                    continue;
-                }
-            }
-            S::Single | S::Double | S::Template => {
-                if c == b'\\' {
-                    i += 2;
-                    continue;
-                }
-                let closer = match state {
-                    S::Single => b'\'',
-                    S::Double => b'"',
-                    _ => b'`',
-                };
-                if c == closer {
-                    state = S::Code;
-                }
             }
         }
-        i += 1;
+        if state == S::Code {
+            spans.push((code_from, bytes.len()));
+        }
+        spans.retain(|(from, to)| from < to);
+        Self { spans }
     }
-    state == S::Code
+
+    fn contains(&self, pos: usize) -> bool {
+        self.spans
+            .binary_search_by(|&(from, to)| {
+                if pos < from {
+                    std::cmp::Ordering::Greater
+                } else if pos >= to {
+                    std::cmp::Ordering::Less
+                } else {
+                    std::cmp::Ordering::Equal
+                }
+            })
+            .is_ok()
+    }
+}
+
+#[cfg(test)]
+mod code_spans_tests {
+    use super::CodeSpans;
+
+    /// The scanner `CodeSpans` replaced, kept verbatim as the oracle.
+    fn is_in_code_reference(source: &str, from: usize, target: usize) -> bool {
+        #[derive(PartialEq)]
+        enum S {
+            Code,
+            Line,
+            Block,
+            Single,
+            Double,
+            Template,
+        }
+        let bytes = source.as_bytes();
+        let mut state = S::Code;
+        let mut i = from;
+        while i < target {
+            let c = bytes[i];
+            let next = bytes.get(i + 1).copied();
+            match state {
+                S::Code => match (c, next) {
+                    (b'/', Some(b'/')) => {
+                        state = S::Line;
+                        i += 2;
+                        continue;
+                    }
+                    (b'/', Some(b'*')) => {
+                        state = S::Block;
+                        i += 2;
+                        continue;
+                    }
+                    (b'\'', _) => state = S::Single,
+                    (b'"', _) => state = S::Double,
+                    (b'`', _) => state = S::Template,
+                    _ => {}
+                },
+                S::Line => {
+                    if c == b'\n' {
+                        state = S::Code;
+                    }
+                }
+                S::Block => {
+                    if c == b'*' && next == Some(b'/') {
+                        state = S::Code;
+                        i += 2;
+                        continue;
+                    }
+                }
+                S::Single | S::Double | S::Template => {
+                    if c == b'\\' {
+                        i += 2;
+                        continue;
+                    }
+                    let closer = match state {
+                        S::Single => b'\'',
+                        S::Double => b'"',
+                        _ => b'`',
+                    };
+                    if c == closer {
+                        state = S::Code;
+                    }
+                }
+            }
+            i += 1;
+        }
+        state == S::Code
+    }
+
+    fn assert_agrees(source: &str) {
+        let script = memchr::memmem::find(source.as_bytes(), b"<script").unwrap_or(0);
+        let spans = CodeSpans::scan(source);
+        for pos in 0..source.len() {
+            let expected = if pos < script {
+                true
+            } else {
+                is_in_code_reference(source, script, pos)
+            };
+            assert_eq!(
+                spans.contains(pos),
+                expected,
+                "byte {pos} ({:?}) in {source:?}",
+                &source[pos..(pos + 1).min(source.len())]
+            );
+        }
+    }
+
+    #[test]
+    fn code_spans_agree_with_the_scanner_they_replaced() {
+        for source in [
+            "<script>let a = 1; // a.b = 2\na.c = 3;</script>",
+            "<script>/* a.b = 1 */ a.c = 2;</script>",
+            "<script>let s = 'a.b = 1'; a.c = 2;</script>",
+            "<script>let s = \"a.b = 1\"; a.c = 2;</script>",
+            "<script>let s = `a.b = ${x.y} 1`; a.c = 2;</script>",
+            "<script>let s = 'it\\'s'; a.c = 2;</script>",
+            // Unterminated: the tail is never code.
+            "<script>let s = 'oops; a.c = 2;</script>",
+            "<script>/* never closed a.c = 2;</script>",
+            // A `//` inside a string must not open a comment.
+            "<script>let s = '// a.b'; a.c = 2;</script>",
+            // Adjacent comment terminators.
+            "<script>/**/a.c = 2;/*x*/</script>",
+            // No script tag at all: everything is code.
+            "<p>a.b = 1</p>",
+        ] {
+            assert_agrees(source);
+        }
+    }
 }
 
 /// Advance past `.name` / `[expr]` accessors, returning the offset just after


### PR DESCRIPTION
## What

`PropMutationSites::collect` did two source-wide scans **per prop**:

- `is_in_code(source, cursor, start)` for every candidate occurrence of the
  prop name, where `cursor` only advanced when a site was *accepted* — so each
  rejected candidate re-ran the comment/string state machine from the last
  accepted site.
- `reactive_statement_ranges(source)`, recomputed once per prop.

Both are prop-independent. `PropMutationScan` now runs them once per source,
and `CodeSpans` turns each candidate's check into a binary search.

## Why

Sub-timers on the open-webui corpus (650 files, dev mode):

```
wrap_prop_mutation: total n=555 191.68ms
                  | collect n=2164 177.39ms
                  | reactive_ranges n=2164 36.94ms
```

`collect` was 92.5% of the pass, called 2164 times across 555 files (≈3.9
props/file). After #2511 landed, `wrap_prop_mutation_validation` was the single
largest self-time entry in the dev profile at 13.74%.

## Correctness

The scanner is deterministic left-to-right and an accepted site is always in
`Code` state, so restarting it there was equivalent to reading the state off a
single pass — that is what makes the precomputation sound.

`code_spans_agree_with_the_scanner_they_replaced` keeps the old scanner
verbatim as an oracle and asserts agreement at **every byte** of eleven
sources: unterminated string, unterminated block comment, `//` inside a string,
adjacent `/**/`, backslash escapes, template literals, and a source with no
`<script>` at all.

That test is what pinned the two off-by-one artifacts of the old two-byte skip:
the byte *at* a `//` or `/*` is code, and the byte after a `*` in `*/` is code.
Negative control: changing `code_from = i + 1` to `i + 2` in the block-comment
close makes the test FAIL, so it discriminates.

`cargo test --release -p rsvelte_core`: 2464 passed, 0 failed.

## Measurements

Interleaved paired A/B, median of N pairs, on top of #2511:

| corpus | files | baseline | fix | delta | wins |
|---|---|---|---|---|---|
| carbon-components-svelte (dev) | 287 | 366.4ms | 228.5ms | **−37.7%** | 8/8 |
| SMUI (dev) | 449 | 195.4ms | 164.1ms | **−16.0%** | 8/8 |
| open-webui (dev) | 650 | 1017.0ms | 855.5ms | **−15.9%** | 8/8 |
| Huly plugins (dev) | 2,123 | 1650.0ms | 1475.6ms | **−10.6%** | 6/6 |
| open-webui (prod) | 650 | 710.0ms | 709.2ms | −0.1% | 4/6 |

Production mode is unchanged — `prop_mutation_vars` is empty there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
