### PR TITLE
fix(esrap): unwrap parenthesized expressions unconditionally

### DIFF
--- a/.changeset/paren-unwrap-always.md
+++ b/.changeset/paren-unwrap-always.md
@@ -1,0 +1,14 @@
+---
+'@rsvelte/compiler': patch
+---
+
+fix(esrap): unwrap a `ParenthesizedExpression` unconditionally and let precedence
+re-add what the grammar needs, matching acorn — which has no paren node at all.
+The previous exception (keep the literal parens when a comment leads the inner
+expression) doubled whatever a parent adds, so `(/* c */ a + b) * 2` printed as
+`((/* c */ a + b)) * 2`, `(/* c */ o).x` kept parens upstream drops, and
+`(/* @__PURE__ */ new Date()).getTime()` did not collapse. The parens a leading
+comment genuinely needs come from `ReturnStatement` — the one place esrap
+parenthesizes for a comment — whose comment test now anchors on the *unwrapped*
+argument so oxc's preserved parens cannot suppress it. `rsvelte_esrap` is
+released as 0.10.3 and `rsvelte_core` pins the new exact requirement.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2508,7 +2508,7 @@ dependencies = [
 
 [[package]]
 name = "rsvelte_esrap"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "compact_str 0.10.0",
  "memchr",

--- a/crates/rsvelte_core/Cargo.toml
+++ b/crates/rsvelte_core/Cargo.toml
@@ -73,7 +73,7 @@ oxc_ast = { version = "0.143", features = ["serialize"] }
 oxc_span = "0.143"
 oxc_diagnostics = "0.143"
 oxc_codegen = "0.143"
-rsvelte_esrap = { version = "=0.10.2", path = "../rsvelte_esrap" }
+rsvelte_esrap = { version = "=0.10.3", path = "../rsvelte_esrap" }
 oxc_syntax = "0.143"
 oxc_semantic = "0.143"
 

--- a/crates/rsvelte_esrap/Cargo.toml
+++ b/crates/rsvelte_esrap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rsvelte_esrap"
-version = "0.10.2"
+version = "0.10.3"
 edition = "2024"
 rust-version = "1.95"
 description = "A Rust port of esrap — prints an oxc AST to JavaScript with esrap's exact layout"

--- a/crates/rsvelte_esrap/src/printer.rs
+++ b/crates/rsvelte_esrap/src/printer.rs
@@ -561,15 +561,6 @@ impl<'opt> Printer<'opt> {
         anchor.map(|(l, _)| l) == Some(line)
     }
 
-    /// Whether any source comment starts within `[start, end)` — used to decide
-    /// if an unwrapped `ParenthesizedExpression` must keep its literal parens to
-    /// bracket a comment that leads its inner expression (`(/*c*/ x)`).
-    fn comment_in_span(&self, start: u32, end: u32) -> bool {
-        self.comments
-            .iter()
-            .any(|c| c.start >= start && c.start < end)
-    }
-
     // ----- comments ---------------------------------------------------------
 
     /// esrap's `flush_comments_until`: emit every pending comment that starts
@@ -930,10 +921,14 @@ impl<'opt> Printer<'opt> {
                     // esrap: when a comment sits between `return` and the
                     // argument, wrap the argument in parens (`return (/*c*/ x);`)
                     // so the comment can't be read as ending the statement.
+                    // Compared against the UNWRAPPED argument because esrap's
+                    // acorn AST has no paren node: with oxc's preserved parens
+                    // `return (/*c*/ x)` would otherwise anchor at the `(`, which
+                    // precedes the comment, and the rule would never fire.
                     let contains_comment = self
                         .comments
                         .get(self.comment_index)
-                        .is_some_and(|c| c.start < arg.span().start);
+                        .is_some_and(|c| c.start < unparen(arg).span().start);
                     let start = s.span().start;
                     if contains_comment {
                         self.write_keyword(ctx, start, "return", " (");
@@ -2131,34 +2126,13 @@ impl<'opt> Printer<'opt> {
                 // (`child_with_parens` / `binary_needs_parens` at each parent)
                 // re-add only the parens the grammar requires.
                 //
-                // Two exceptions keep the literal parens:
-                //
-                // 1. A comment between the `(` and the inner expression:
-                //    dropping the parens would leave it dangling (`return (/*c*/
-                //    x)`, `return (// hey\n x)`). The comment is flushed as a
-                //    leading comment of the inner expression, so the parens must
-                //    stay to bracket it as in the source. The window stops at the
-                //    inner expression's start — a comment anywhere deeper is
-                //    already bracketed by that expression's own syntax, and
-                //    keeping the parens for it doubles those a parent adds from
-                //    precedence (`(await f(/*c*/ x))()` → `((await f(/*c*/ x)))()`).
-                // 2. A sequence: `(a, b)` parses as `Paren(Sequence)`, and the
-                //    `SequenceExpression` visitor already emits its own
-                //    surrounding parens, so the paren layer is dropped to avoid
-                //    doubling. (An explicit redundant `((a, b))` is handled
-                //    recursively — the outer layer here, the inner by the
-                //    sequence visitor.)
-                if matches!(p.expression, Expression::SequenceExpression(_)) {
-                    self.print_expression(&p.expression, ctx);
-                // No `has_loc` guard needed: every comment offset is >= `loc_base`
-                // by construction, so a synthesized span never contains one.
-                } else if self.comment_in_span(p.span.start, p.expression.span().start) {
-                    ctx.write("(");
-                    self.print_expression(&p.expression, ctx);
-                    ctx.write(")");
-                } else {
-                    self.print_expression(&p.expression, ctx);
-                }
+                // There is no exception. A comment leading the inner expression
+                // does need bracketing (`return (/*c*/ x)`, `return (// hey\n x)`),
+                // but esrap emits those parens from `ReturnStatement` — the one
+                // place it parenthesizes for a comment — not from the operand, so
+                // reproducing them here instead would double whatever a parent
+                // adds from precedence.
+                self.print_expression(&p.expression, ctx);
             }
             Expression::ChainExpression(c) => match &c.expression {
                 ChainElement::CallExpression(call) => self.call_expression(call, ctx),

--- a/crates/rsvelte_esrap/tests/compat.rs
+++ b/crates/rsvelte_esrap/tests/compat.rs
@@ -67,24 +67,45 @@ fn ts_module_and_mapped_type() {
 }
 
 /// oxc preserves explicit parens as a `ParenthesizedExpression`; acorn (esrap's
-/// own parser) elides them, so the printer unwraps them and lets precedence
-/// re-add what the grammar needs. The one case that must keep its literal parens
-/// is a comment *leading* the inner expression, which would otherwise dangle.
-/// A comment deeper inside is already bracketed by that expression's own syntax:
-/// keeping the parens for it doubles the pair a parent adds from precedence.
+/// own parser) elides them, so the printer unwraps them unconditionally and lets
+/// precedence re-add what the grammar requires. A comment is not an exception:
+/// reproducing the literal parens for one doubles whatever a parent adds.
 /// Oracle: the Svelte compiler (esrap 2.x) on the equivalent module sources.
 #[test]
-fn redundant_parens_survive_only_for_a_leading_comment() {
-    // Leading comment — parens stay.
-    assert_eq!(print_src("f((/* c */ x));", false), "f((/* c */ x));");
-    // Comment deeper inside — parens go, and the argument keeps the comment.
+fn redundant_parens_are_always_unwrapped() {
+    assert_eq!(print_src("f((/* c */ x));", false), "f(/* c */ x);");
     assert_eq!(print_src("f((g(/* c */ x)));", false), "f(g(/* c */ x));");
-    // No comment at all — parens go.
     assert_eq!(print_src("f((x));", false), "f(x);");
-    // The doubling this guards against: the callee's parens come from
-    // precedence, so the paren node must not add a second pair.
+    // Precedence still supplies the parens the grammar needs, exactly once.
     assert_eq!(
         print_src("async function f() {\n\t(await g(/* c */ x))();\n}", false),
         "async function f() {\n\t(await g(/* c */ x))();\n}"
+    );
+    assert_eq!(
+        print_src("((/* c */ a + b)) * 2;", false),
+        "(/* c */ a + b) * 2;"
+    );
+}
+
+/// `ReturnStatement` is the ONE place esrap parenthesizes because of a comment:
+/// when the next pending comment starts before the argument. The test is against
+/// the *unwrapped* argument — esrap's acorn AST has no paren node, so oxc's
+/// preserved parens would otherwise anchor the comparison at the `(`, which
+/// precedes the comment, and the rule would never fire.
+#[test]
+fn return_argument_is_parenthesized_for_a_leading_comment() {
+    assert_eq!(
+        print_src("function f() {\n\treturn (/* c */ x);\n}", false),
+        "function f() {\n\treturn (/* c */ x);\n}"
+    );
+    // A sequence keeps both layers: the return rule's, and its own.
+    assert_eq!(
+        print_src("function f() {\n\treturn (/* c */ a, b);\n}", false),
+        "function f() {\n\treturn (/* c */ (a, b));\n}"
+    );
+    // The comment trails the argument — the rule does not fire.
+    assert_eq!(
+        print_src("function f() {\n\treturn (x /* c */);\n}", false),
+        "function f() {\n\treturn x; /* c */\n}"
     );
 }

--- a/crates/rsvelte_lint_types/Cargo.lock
+++ b/crates/rsvelte_lint_types/Cargo.lock
@@ -1106,7 +1106,7 @@ dependencies = [
 
 [[package]]
 name = "rsvelte_esrap"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "compact_str",
  "memchr",


### PR DESCRIPTION
Follow-up to #2433, which fixed one symptom of the paren rule. This fixes the rule.

## The rule

acorn — the parser esrap is written against — has **no `ParenthesizedExpression` node at all**, so every paren esrap prints is recomputed from precedence. oxc preserves them, and the printer carried an exception: keep the literal parens when a comment leads the inner expression. That exception reproduces a pair the parent is about to add anyway.

The parens a leading comment genuinely needs come from exactly one place — `ReturnStatement` (esrap 2.2.12, `languages/ts/index.js:1516`):

```js
const contains_comment = comments[comment_index] && … &&
  before(comments[comment_index].loc.start, node.argument.loc.start);
write_keyword(context, node, 'return', contains_comment ? ' (' : ' ');
```

rsvelte already ported that rule, but **it could never fire**: with oxc's preserved parens the argument of `return (/* c */ x)` starts at the `(`, which precedes the comment. So the operand-side exception was added to compensate, and it compensated in every position — not just `return`.

## Fix

1. Unwrap `ParenthesizedExpression` unconditionally.
2. Anchor the `ReturnStatement` comment test on the **unwrapped** argument, i.e. on the node acorn would have handed esrap.

`comment_in_span` had no other caller and is removed.

## Verification

41 paren/comment shapes through the official compiler (`compileModule`, dev, client) vs rsvelte, generated from one shared case list so the two sides cannot drift:

| | diverging from official |
|---|---|
| `origin/main` | **26 / 41** |
| this PR | **4 / 41** |

**No new divergence**: all 4 were diverging before, verified by re-running the same 41 shapes against `origin/main`'s printer as a control.

The exception was not only doubling `(await …)()`. It also kept parens upstream drops outright:

```
(/* c */ o).x        →  /* c */ o.x
g(...(/* c */ a))    →  g(.../* c */ a)
`${(/* c */ a)}`     →  `${/* c */ a}`
{ k: (/* c */ v) }   →  { k: /* c */ v }
x = (/* c */ a)      →  x = /* c */ a
return (/* c */ a, b) → return (/* c */ (a, b))
```

Line-comment shapes were included specifically to check the unwrap cannot create an ASI hazard; `ast_gate_preconditions` (every compiled output parses) and the corpus `js-unparseable 0` both hold.

## Corpus

Built the NAPI binding separately for each printer (`corpus:compile` reads a prebuilt `.corpus-cache/rsvelte.node` and never rebuilds it). **10 outputs change; 4 become byte-identical to official; none move away from it.** Examples:

```diff
-	const currentYear = (/* @__PURE__ */ new Date()).getFullYear();   // main
+	const currentYear = /* @__PURE__ */ new Date().getFullYear();     // this PR, == official

-	… && ((// mode !== 'manual' but support annotations
+	… && (// mode !== 'manual' but support annotations
```

The gate itself cannot see any of it: `corpus:verify` reports identical numbers on both printers (`match 13183`, `js-mismatch 0`, same 580 known warning failures) because the comparison-side oxfmt collapses redundant parens.

## What is left

The 4 remaining divergences are a different mechanism — comment placement, not parens — and are untouched here:

- `() => (/* c */ x)` — upstream prints `() => x`, dropping the comment. Svelte hands esrap a **synthetic Program**, so `reset_comment_index` sees no `loc` and discards every pending comment; a loc-bearing statement list later re-finds them, which is why the same comment survives inside a `return`. (Pure esrap on a real acorn AST prints a third answer, `(/* c */) => x`.)
- `g((// c\n a))` — upstream breaks call arguments across lines when an argument carries a leading line comment.

## Suite

412 suites green, 0 failures. `cargo fmt` + `clippy --all-targets --all-features -D warnings` clean. `rsvelte_esrap` released as 0.10.3 with `rsvelte_core`'s exact pin and both lockfiles advanced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q94UFSt4NWQ7JpZMaeAoMT
