### PR TITLE
ci(release): exclude the test-only esrap directory from the version gate (#2417)

### DIFF
--- a/.github/workflows/changeset.yml
+++ b/.github/workflows/changeset.yml
@@ -91,6 +91,11 @@ jobs:
         # change between them — each must be named explicitly or it ships stale.
         run: node scripts/release/check-core-consumer-changesets.mjs
 
+      - name: Self-test the rsvelte_esrap version gate
+        # The gate excludes a `#[cfg(test)]`-gated directory; this is what notices
+        # when that exclusion stops being sound.
+        run: node scripts/release/test-esrap-version-bump-check.mjs
+
       - name: Require an rsvelte_esrap crate version bump
         env:
           SKIP: ${{ contains(github.event.pull_request.labels.*.name, 'skip-changeset') }}

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
 		"test:bot-branch-guard": "node scripts/ci/test-bot-branch-guard.mjs",
 		"check:workflow-triggers": "node scripts/ci/workflow-trigger-guard.mjs",
 		"test:workflow-trigger-guard": "node scripts/ci/test-workflow-trigger-guard.mjs",
+		"test:esrap-version-gate": "node scripts/release/test-esrap-version-bump-check.mjs",
 		"check:lint-types-lock": "node scripts/ci/check-lint-types-lock.mjs",
 		"fix:lint-types-lock": "node scripts/ci/check-lint-types-lock.mjs --fix",
 		"corpus:sync": "git submodule update --init --depth 1 submodules/svelte submodules/svelte.dev submodules/language-tools submodules/bits-ui submodules/flowbite-svelte submodules/melt-ui submodules/shadcn-svelte submodules/sveltestrap submodules/attractions submodules/svelte-ux submodules/smelte submodules/svar-core submodules/svelte-table submodules/powertable submodules/svelte-pivottable submodules/svelte-toast submodules/svelte-sonner submodules/svelte-notifications submodules/svelte-fa submodules/svelte-heroicons submodules/svelte-calendar submodules/date-picker-svelte submodules/svelte-maplibre submodules/layercake submodules/layerchart submodules/svelte-splitpanes submodules/svelte-stepper submodules/svelte-formly submodules/svelte-form-builder submodules/svelte-checkbox submodules/svelte-toggle submodules/svelthree submodules/runed submodules/svelte-toolbelt submodules/cmsaasstarter submodules/skeleton",

--- a/scripts/release/check-esrap-version-bump.mjs
+++ b/scripts/release/check-esrap-version-bump.mjs
@@ -7,7 +7,13 @@ import path from 'node:path';
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
 const manifestPath = 'crates/rsvelte_esrap/Cargo.toml';
-const sourcePrefix = 'crates/rsvelte_esrap/src/';
+
+export const LIB_PATH = 'crates/rsvelte_esrap/src/lib.rs';
+export const SOURCE_PREFIX = 'crates/rsvelte_esrap/src/';
+// Under `src/` but `#[cfg(test)]`-gated in lib.rs, so it cannot reach a published artifact.
+export const TEST_ONLY_PREFIXES = ['crates/rsvelte_esrap/src/internal_tests/'];
+
+const TEST_ONLY_GATE = /#\[cfg\(test\)\]\s*(?:\/\/[^\n]*\n\s*)*mod\s+internal_tests\s*;/;
 
 function git(...args) {
   return execFileSync('git', args, {
@@ -16,13 +22,13 @@ function git(...args) {
   }).trim();
 }
 
-function packageVersion(contents, source) {
+export function packageVersion(contents, source) {
   const match = contents.match(/\[package\][\s\S]*?\nversion\s*=\s*"([^"]+)"/);
   if (!match) throw new Error(`Unable to read [package].version from ${source}`);
   return match[1];
 }
 
-function compareVersions(left, right) {
+export function compareVersions(left, right) {
   const a = left.split('.').map(Number);
   const b = right.split('.').map(Number);
   const width = Math.max(a.length, b.length);
@@ -33,45 +39,85 @@ function compareVersions(left, right) {
   return 0;
 }
 
-if (process.env.SKIP === 'true') {
-  console.log('skip-changeset label present — skipping rsvelte_esrap version check.');
-  process.exit(0);
+/** True when lib.rs still declares the excluded directory behind `#[cfg(test)]`. */
+export function declaresTestOnlyModule(libSource) {
+  return TEST_ONLY_GATE.test(libSource);
 }
 
-try {
-  git('fetch', '--quiet', 'origin', '+main:refs/remotes/origin/main');
-} catch {
-  // Offline/local verification may use the existing remote-tracking ref.
-}
-
-let base;
-try {
-  base = git('merge-base', 'HEAD', 'origin/main');
-} catch {
-  base = git('merge-base', 'HEAD', 'main');
-}
-
-const changed = git('diff', '--name-only', `${base}...HEAD`)
-  .split('\n')
-  .filter(Boolean);
-if (!changed.some((file) => file.startsWith(sourcePrefix))) {
-  console.log('rsvelte_esrap source is unchanged.');
-  process.exit(0);
-}
-
-const previous = packageVersion(git('show', `${base}:${manifestPath}`), `${base}:${manifestPath}`);
-const current = packageVersion(
-  readFileSync(path.join(repoRoot, manifestPath), 'utf8'),
-  manifestPath,
-);
-
-if (compareVersions(current, previous) <= 0) {
-  console.error(
-    `::error::rsvelte_esrap source changed but its crate version did not increase ` +
-      `(base ${previous}, current ${current}). Bump ${manifestPath}; the exact ` +
-      `rsvelte_core dependency and compiler release-set changeset must advance with it.`,
+export function classifyChangedFiles(changed) {
+  const changedSource = changed.filter((file) => file.startsWith(SOURCE_PREFIX));
+  const shippedSource = changedSource.filter(
+    (file) => !TEST_ONLY_PREFIXES.some((prefix) => file.startsWith(prefix)),
   );
-  process.exit(1);
+  return {
+    changedSource,
+    shippedSource,
+    // The exclusion only has to be justified on runs where it actually dropped a file.
+    exclusionLoadBearing: shippedSource.length !== changedSource.length,
+  };
 }
 
-console.log(`rsvelte_esrap source changed and version advanced: ${previous} -> ${current}. ✓`);
+export const STALE_EXCLUSION_MESSAGE =
+  `${TEST_ONLY_PREFIXES.join(', ')} is excluded from this check because ${LIB_PATH} declares ` +
+  '`#[cfg(test)] mod internal_tests;`. That declaration is gone, so the directory can now ' +
+  'ship — remove the exclusion from this script.';
+
+function main() {
+  if (process.env.SKIP === 'true') {
+    console.log('skip-changeset label present — skipping rsvelte_esrap version check.');
+    return 0;
+  }
+
+  try {
+    git('fetch', '--quiet', 'origin', '+main:refs/remotes/origin/main');
+  } catch {
+    // Offline/local verification may use the existing remote-tracking ref.
+  }
+
+  let base;
+  try {
+    base = git('merge-base', 'HEAD', 'origin/main');
+  } catch {
+    base = git('merge-base', 'HEAD', 'main');
+  }
+
+  const changed = git('diff', '--name-only', `${base}...HEAD`)
+    .split('\n')
+    .filter(Boolean);
+  const { shippedSource, exclusionLoadBearing } = classifyChangedFiles(changed);
+
+  if (exclusionLoadBearing) {
+    const lib = readFileSync(path.join(repoRoot, LIB_PATH), 'utf8');
+    if (!declaresTestOnlyModule(lib)) {
+      console.error(`::error::${STALE_EXCLUSION_MESSAGE}`);
+      return 1;
+    }
+  }
+
+  if (shippedSource.length === 0) {
+    console.log('rsvelte_esrap shipped source is unchanged.');
+    return 0;
+  }
+
+  const previous = packageVersion(git('show', `${base}:${manifestPath}`), `${base}:${manifestPath}`);
+  const current = packageVersion(
+    readFileSync(path.join(repoRoot, manifestPath), 'utf8'),
+    manifestPath,
+  );
+
+  if (compareVersions(current, previous) <= 0) {
+    console.error(
+      `::error::rsvelte_esrap source changed but its crate version did not increase ` +
+        `(base ${previous}, current ${current}). Bump ${manifestPath}; the exact ` +
+        `rsvelte_core dependency and compiler release-set changeset must advance with it.`,
+    );
+    return 1;
+  }
+
+  console.log(`rsvelte_esrap source changed and version advanced: ${previous} -> ${current}. ✓`);
+  return 0;
+}
+
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+  process.exit(main());
+}

--- a/scripts/release/test-esrap-version-bump-check.mjs
+++ b/scripts/release/test-esrap-version-bump-check.mjs
@@ -1,0 +1,145 @@
+#!/usr/bin/env node
+// Self-test for scripts/release/check-esrap-version-bump.mjs.
+//
+// The gate passing on the current tree proves nothing. Each case below pairs a
+// change the gate must still demand a version bump for with the near-miss it must
+// let through, so a gate that always answered "source changed" — the behaviour
+// before the test-only exclusion — fails here.
+
+import { existsSync, readFileSync, statSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import {
+  LIB_PATH,
+  SOURCE_PREFIX,
+  TEST_ONLY_PREFIXES,
+  classifyChangedFiles,
+  compareVersions,
+  declaresTestOnlyModule,
+} from './check-esrap-version-bump.mjs';
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
+
+let failures = 0;
+
+function check(name, fn) {
+  try {
+    fn();
+    console.log(`  ok   ${name}`);
+  } catch (err) {
+    failures++;
+    console.error(`  FAIL ${name}\n       ${err.message}`);
+  }
+}
+
+function assert(cond, message) {
+  if (!cond) throw new Error(message);
+}
+
+console.log('check-esrap-version-bump self-test');
+
+// --- The control: the case the gate used to get wrong. ---
+
+check('a diff confined to internal_tests/ demands no version bump', () => {
+  const { shippedSource, exclusionLoadBearing } = classifyChangedFiles([
+    'crates/rsvelte_esrap/src/internal_tests/golden.rs',
+    'crates/rsvelte_esrap/src/internal_tests/mod.rs',
+  ]);
+  assert(shippedSource.length === 0, `expected no shipped source, got ${shippedSource.join(', ')}`);
+  assert(exclusionLoadBearing, 'expected the exclusion to be reported as load-bearing');
+});
+
+// --- Discrimination: everything else under src/ still trips the gate. ---
+
+check('a printer.rs change still counts as shipped source', () => {
+  const { shippedSource } = classifyChangedFiles(['crates/rsvelte_esrap/src/printer.rs']);
+  assert(shippedSource.length === 1, `expected 1 shipped file, got ${shippedSource.length}`);
+});
+
+check('lib.rs is not excluded, so dropping the cfg(test) gate trips the check on lib.rs', () => {
+  const { shippedSource } = classifyChangedFiles([LIB_PATH]);
+  assert(shippedSource.includes(LIB_PATH), 'expected lib.rs to count as shipped source');
+});
+
+check('a mixed diff is decided by its shipped half', () => {
+  const { shippedSource, exclusionLoadBearing } = classifyChangedFiles([
+    'crates/rsvelte_esrap/src/internal_tests/golden.rs',
+    'crates/rsvelte_esrap/src/command.rs',
+  ]);
+  assert(shippedSource.length === 1, `expected 1 shipped file, got ${shippedSource.length}`);
+  assert(exclusionLoadBearing, 'expected the exclusion to be reported as load-bearing');
+});
+
+check('a sibling file whose name merely starts with the excluded one is not excluded', () => {
+  const { shippedSource } = classifyChangedFiles([
+    'crates/rsvelte_esrap/src/internal_tests.rs',
+    'crates/rsvelte_esrap/src/internal_tests_helper.rs',
+  ]);
+  assert(shippedSource.length === 2, `expected both to ship, got ${shippedSource.join(', ')}`);
+});
+
+check('files outside the crate source are ignored entirely', () => {
+  const { changedSource, exclusionLoadBearing } = classifyChangedFiles([
+    'crates/rsvelte_core/src/lib.rs',
+    'crates/rsvelte_esrap/tests/golden.rs',
+    'README.md',
+  ]);
+  assert(changedSource.length === 0, `expected no crate source, got ${changedSource.join(', ')}`);
+  assert(!exclusionLoadBearing, 'the exclusion must not be reported as used here');
+});
+
+// --- The exclusion is only sound while lib.rs keeps the directory test-only. ---
+
+check('declaresTestOnlyModule accepts the gated declaration', () => {
+  assert(
+    declaresTestOnlyModule('mod printer;\n\n#[cfg(test)]\nmod internal_tests;\n'),
+    'expected the gated declaration to be recognised',
+  );
+});
+
+check('declaresTestOnlyModule rejects an ungated declaration', () => {
+  assert(
+    !declaresTestOnlyModule('mod printer;\n\nmod internal_tests;\n'),
+    'an ungated `mod internal_tests;` must not satisfy the invariant',
+  );
+});
+
+check('declaresTestOnlyModule rejects a gate that applies to another item', () => {
+  assert(
+    !declaresTestOnlyModule('#[cfg(test)]\nmod helpers;\n\nmod internal_tests;\n'),
+    'a cfg(test) on a different module must not satisfy the invariant',
+  );
+});
+
+// --- The shipped tree. ---
+
+check('the excluded directory exists and is a directory', () => {
+  for (const prefix of TEST_ONLY_PREFIXES) {
+    const dir = join(repoRoot, prefix);
+    assert(existsSync(dir), `${prefix} does not exist — the exclusion names nothing`);
+    assert(statSync(dir).isDirectory(), `${prefix} is not a directory`);
+    assert(prefix.startsWith(SOURCE_PREFIX), `${prefix} is not under ${SOURCE_PREFIX}`);
+    assert(prefix.endsWith('/'), `${prefix} must end in a slash to match a directory only`);
+  }
+});
+
+check('the shipped lib.rs still declares internal_tests behind #[cfg(test)]', () => {
+  assert(
+    declaresTestOnlyModule(readFileSync(join(repoRoot, LIB_PATH), 'utf8')),
+    `${LIB_PATH} no longer gates internal_tests — the exclusion must be removed`,
+  );
+});
+
+check('compareVersions orders releases numerically, not lexically', () => {
+  assert(compareVersions('0.10.2', '0.9.9') > 0, '0.10.2 must outrank 0.9.9');
+  assert(compareVersions('0.10.1', '0.10.1') === 0, 'equal versions must compare equal');
+  assert(compareVersions('0.10.1', '0.10.2') < 0, '0.10.1 must rank below 0.10.2');
+});
+
+console.log(
+  failures === 0
+    ? '\ncheck-esrap-version-bump self-test: all checks passed'
+    : `\ncheck-esrap-version-bump self-test: ${failures} failure(s)`,
+);
+process.exit(failures === 0 ? 0 : 1);


### PR DESCRIPTION
## What was wrong

`scripts/release/check-esrap-version-bump.mjs` decided "shipped source changed" from the path
prefix `crates/rsvelte_esrap/src/` alone. `src/internal_tests/` sits under that prefix but is
declared `#[cfg(test)] mod internal_tests;` in `lib.rs`, so none of it can appear in a published
artifact. A test-only diff therefore forced a crate version bump, an exact-pin bump in
`rsvelte_core`, two lockfile re-resolutions and a changeset — the release noise hit in #2408.

## What this does

Excludes the one directory, exactly as the issue specifies — **not** a general `#[cfg(test)]`
detector. A heuristic wrong in the permissive direction would silently disable a release gate;
a directory exclusion is exactly as reliable as the path-based *inclusion* it mirrors.

The exclusion is only sound while `lib.rs` keeps the module test-only, so on runs where the
exclusion actually dropped a file, the gate now asserts that `lib.rs` still contains a
`#[cfg(test)]`-gated `mod internal_tests;` and fails naming the exclusion if it does not.
`lib.rs` itself is never excluded, so removing the gate trips the check on `lib.rs` regardless.

Scope note from the issue: no other crate has this shape — `rsvelte_ast_equiv` and
`rsvelte_formatter` use inline `#[cfg(test)] mod tests {}` blocks, not a directory, and no other
crate is covered by this gate. The exclusion list names a directory that exists, and the
self-test asserts it exists and is a directory.

## How it is verified

The script's classifier is now exported and `scripts/release/test-esrap-version-bump-check.mjs`
drives it, wired into the same Changeset Gate job that runs the gate, so it is executed rather than
merely present.

Controls, all run:

| control | result |
|---|---|
| `TEST_ONLY_PREFIXES = []` (the pre-fix behaviour) | self-test **fails**: `a diff confined to internal_tests/ demands no version bump`, `a mixed diff is decided by its shipped half` |
| `#[cfg(test)]` removed from `lib.rs` | self-test **fails**: `the shipped lib.rs still declares internal_tests behind #[cfg(test)]` |
| end-to-end, real gate on a commit touching only `internal_tests/mod.rs` | `main`'s script → **exit 1** (`version did not increase`); this branch → **exit 0** (`shipped source is unchanged`) |

Discrimination cases in the self-test: `printer.rs` and `lib.rs` still count as shipped source;
`src/internal_tests.rs` / `src/internal_tests_helper.rs` (names that merely *start* with the
excluded one) are not excluded, because the prefix ends in a slash.

No changeset: this is CI tooling, no shipped package behaviour changes.

Fixes #2417
