### PR TITLE
fix(analyze): point a11y_figcaption_index at the misplaced figcaption

### DIFF
--- a/.changeset/a11y-figcaption-index-span.md
+++ b/.changeset/a11y-figcaption-index-span.md
@@ -1,0 +1,5 @@
+---
+'@rsvelte/compiler': patch
+---
+
+Point `a11y_figcaption_index` at the misplaced `<figcaption>` instead of the enclosing `<figure>`

--- a/compatibility/warning-known-failures.md
+++ b/compatibility/warning-known-failures.md
@@ -35,7 +35,7 @@ compilers already run on every entry.
 ## Why the three per-target files are currently identical
 
 `warning-known-failures.client.json`, `.server.json` and `.client-dev.json` hold
-the same 51 entries; the three position files hold the same 529. That is not a
+the same 51 entries; the three position files hold the same 528. That is not a
 bug in the partitioning — almost every warning is produced in Phase 1/2 (parse
 and analyze), before the target is consulted, so a divergence shows up on all
 three targets at once. Only target-specific codes (`node_invalid_placement_ssr`

--- a/compatibility/warning-known-failures.md
+++ b/compatibility/warning-known-failures.md
@@ -80,7 +80,7 @@ from where the entries happened to cluster in the corpus rather than from
 upstream's control flow — worth remembering when reading the clusters above,
 which were written the same way.
 
-## Warning positions (`warning-position-known-failures.<target>.json`, 529 entries each)
+## Warning positions (`warning-position-known-failures.<target>.json`, 528 entries each)
 
 The codes agree but a `(line, column)` does not. There are **two** systemic
 causes, not one, and they need different edits. Measured over the 625 entries
@@ -153,13 +153,24 @@ missing-position code. It never was: rsvelte always emitted a span for it. That
 mis-attribution is exactly what a single-cause reading of this bucket produces —
 the split above was measured per tuple, not inferred from the code names.
 
-What is left is 650 tuples: the 649 missing-span ones, unchanged, plus a single
-`a11y_figcaption_index` that disagrees on **both** line and column. That one is a
-third cause, and it is structurally out of reach rather than merely unobserved:
-upstream raises it at `:532`, outside both attribute loops, on `children[index]`
-— so none of the four stamp sites can see it, and `stamp_attribute` skips
-anything that already carries a span. That argument holds regardless of what any
-run showed, which is why it is the one to record.
+What is left is the 649 missing-span tuples, unchanged.
+
+A single `a11y_figcaption_index` disagreeing on **both** line and column used to
+sit beside them, recorded here as a third cause that was "structurally out of
+reach rather than merely unobserved": upstream raises it at `:532`, outside both
+attribute loops, on `children[index]`, so none of the four stamp sites can see it
+and `stamp_attribute` skips anything that already carries a span. It was noted
+that the argument held "regardless of what any run showed".
+
+**The argument was sound and the conclusion was wrong** (#2490). Every step about
+the stamp sites was true; what did not follow is that the span was therefore
+unreachable. The fix does not stamp at all — it constructs the warning with
+`children[idx]`'s span at the emission site, which is what upstream does
+(`w.a11y_figcaption_index(children[index])`), and the caller's element fallback
+then leaves it alone. The reasoning enumerated the repair mechanisms that exist
+today and mistook that for the set of mechanisms available. An "out of reach"
+claim needs the second half stated: out of reach *of what*, and why no new
+emission site may be added.
 
 `perf_avoid_nested_class` was the first of these to be burned down (#2349),
 and it cost two entries rather than the one the `runed` / `svelte-toolbelt`

--- a/compatibility/warning-position-known-failures.client-dev.json
+++ b/compatibility/warning-position-known-failures.client-dev.json
@@ -471,7 +471,6 @@
 	"svelte/packages/svelte/tests/server-side-rendering/samples/component-yield/Widget.svelte",
 	"svelte/packages/svelte/tests/server-side-rendering/samples/head-no-duplicates-with-binding/Foo.svelte",
 	"svelte/packages/svelte/tests/server-side-rendering/samples/textarea-value/main.svelte",
-	"svelte/packages/svelte/tests/validator/samples/a11y-figcaption-wrong-place/input.svelte",
 	"svelte/packages/svelte/tests/validator/samples/attribute-quoted/input.svelte",
 	"svelte/packages/svelte/tests/validator/samples/bidirectional-control-characters/input.svelte",
 	"svelte/packages/svelte/tests/validator/samples/component-legacy-instantiation/input.svelte",

--- a/compatibility/warning-position-known-failures.client.json
+++ b/compatibility/warning-position-known-failures.client.json
@@ -471,7 +471,6 @@
 	"svelte/packages/svelte/tests/server-side-rendering/samples/component-yield/Widget.svelte",
 	"svelte/packages/svelte/tests/server-side-rendering/samples/head-no-duplicates-with-binding/Foo.svelte",
 	"svelte/packages/svelte/tests/server-side-rendering/samples/textarea-value/main.svelte",
-	"svelte/packages/svelte/tests/validator/samples/a11y-figcaption-wrong-place/input.svelte",
 	"svelte/packages/svelte/tests/validator/samples/attribute-quoted/input.svelte",
 	"svelte/packages/svelte/tests/validator/samples/bidirectional-control-characters/input.svelte",
 	"svelte/packages/svelte/tests/validator/samples/component-legacy-instantiation/input.svelte",

--- a/compatibility/warning-position-known-failures.server.json
+++ b/compatibility/warning-position-known-failures.server.json
@@ -471,7 +471,6 @@
 	"svelte/packages/svelte/tests/server-side-rendering/samples/component-yield/Widget.svelte",
 	"svelte/packages/svelte/tests/server-side-rendering/samples/head-no-duplicates-with-binding/Foo.svelte",
 	"svelte/packages/svelte/tests/server-side-rendering/samples/textarea-value/main.svelte",
-	"svelte/packages/svelte/tests/validator/samples/a11y-figcaption-wrong-place/input.svelte",
 	"svelte/packages/svelte/tests/validator/samples/attribute-quoted/input.svelte",
 	"svelte/packages/svelte/tests/validator/samples/bidirectional-control-characters/input.svelte",
 	"svelte/packages/svelte/tests/validator/samples/component-legacy-instantiation/input.svelte",

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/shared/a11y/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/shared/a11y/mod.rs
@@ -617,7 +617,14 @@ pub fn check_element(node: &RegularElement, ancestor_names: &[String]) -> Vec<w:
                 && idx != 0
                 && idx != children.len() - 1
             {
-                warnings.push(w::a11y_figcaption_index());
+                let mut warning = w::a11y_figcaption_index();
+                // Upstream warns on the offending child, not the visited
+                // `<figure>`; without this the caller stamps the element span.
+                if let TemplateNode::RegularElement(el) = children[idx] {
+                    warning.start = Some(el.start);
+                    warning.end = Some(el.end);
+                }
+                warnings.push(warning);
             }
         }
         _ => {}

--- a/crates/rsvelte_core/tests/a11y_figcaption_index_span.rs
+++ b/crates/rsvelte_core/tests/a11y_figcaption_index_span.rs
@@ -1,0 +1,87 @@
+//! Upstream raises `a11y_figcaption_index` while visiting the `<figure>` but
+//! passes the offending `<figcaption>` child as the warn target
+//! (`2-analyze/visitors/shared/a11y/index.js`). rsvelte constructed the warning
+//! without a span, so the caller's element-span fallback stamped the `<figure>`
+//! — a plausible but wrong location.
+
+use rsvelte_core::{CompileOptions, GenerateMode, Warning, compile};
+
+/// The upstream fixture `validator/samples/a11y-figcaption-wrong-place`.
+const SRC: &str = "<figure>\n\t<img src='foo.jpg' alt='a foo'>\n\n\t<figcaption>\n\t\ta foo in its natural habitat\n\t</figcaption>\n\n\t<p>this should not be here</p>\n</figure>\n";
+
+fn warnings(src: &str) -> Vec<Warning> {
+    compile(
+        src,
+        CompileOptions {
+            filename: Some("Main.svelte".to_string()),
+            generate: GenerateMode::Client,
+            dev: false,
+            ..Default::default()
+        },
+    )
+    .expect("compile")
+    .warnings
+}
+
+/// `(start line, start column, end line, end column)` of the first `code`
+/// warning, plus the source text the start points at.
+fn span<'a>(src: &'a str, ws: &[Warning], code: &str) -> ((usize, usize, usize, usize), &'a str) {
+    let w = ws.iter().find(|w| w.code == code).unwrap_or_else(|| {
+        panic!(
+            "no `{code}` warning in {:?}",
+            ws.iter().map(|w| &w.code).collect::<Vec<_>>()
+        )
+    });
+    let start = w
+        .start
+        .as_ref()
+        .unwrap_or_else(|| panic!("`{code}` has no start"));
+    let end = w
+        .end
+        .as_ref()
+        .unwrap_or_else(|| panic!("`{code}` has no end"));
+    let line = src.lines().nth(start.line - 1).unwrap_or("");
+    (
+        (start.line, start.column, end.line, end.column),
+        &line[start.column.min(line.len())..],
+    )
+}
+
+#[test]
+fn figcaption_index_points_at_the_figcaption_not_the_figure() {
+    let ws = warnings(SRC);
+    let (pos, text) = span(SRC, &ws, "a11y_figcaption_index");
+    assert!(
+        text.starts_with("<figcaption"),
+        "expected the `<figcaption>`, got {pos:?} -> {text:?}"
+    );
+    // Upstream's `warnings.json` for the fixture: 4:1..6:14.
+    assert_eq!(pos, (4, 1, 6, 14), "span pointed at {text:?}");
+}
+
+/// Pin: the sibling rule is raised *on* the `<figcaption>`, so the element-span
+/// fallback is already correct there and must stay untouched.
+#[test]
+fn figcaption_parent_still_points_at_the_figcaption() {
+    let src = "<div>\n\t<figcaption>x</figcaption>\n</div>\n";
+    let ws = warnings(src);
+    let (pos, text) = span(src, &ws, "a11y_figcaption_parent");
+    assert!(
+        text.starts_with("<figcaption"),
+        "expected the `<figcaption>`, got {pos:?} -> {text:?}"
+    );
+}
+
+/// Negative control: a `<figcaption>` in a legal position raises nothing, so a
+/// span fix cannot be mistaken for a changed firing condition.
+#[test]
+fn correctly_placed_figcaption_raises_no_index_warning() {
+    let src =
+        "<figure>\n\t<figcaption>x</figcaption>\n\t<img src='foo.jpg' alt='a foo'>\n</figure>\n";
+    let ws = warnings(src);
+    assert!(
+        !ws.iter().any(|w| w.code == "a11y_figcaption_index"),
+        "unexpected warning in {:?}",
+        ws.iter().map(|w| &w.code).collect::<Vec<_>>()
+    );
+}


### PR DESCRIPTION
## What was broken

`a11y_figcaption_index` was raised while visiting the `<figure>` and constructed with **no span**,
so `visitors/regular_element.rs:414-423` stamped the *visited element*'s range onto it. The result
is the one case in the corpus where rsvelte reports a **plausible, specific, wrong** location
rather than no location at all — a reader trusts `1:0` and lands on the wrong element.

Measured on `packages/svelte/tests/validator/samples/a11y-figcaption-wrong-place/input.svelte`:

| | start | end |
|---|---|---|
| upstream `warnings.json` | `4:1` (`<figcaption>`) | `6:14` |
| rsvelte before | `1:0` (`<figure>`) | `9:9` |
| rsvelte after | `4:1` | `6:14` |

## What it was aligned to

`submodules/svelte/packages/svelte/src/compiler/phases/2-analyze/visitors/shared/a11y/index.js:532`:

```js
w.a11y_figcaption_index(children[index]);
```

Upstream passes the offending child it just located, not the visited node. The fix threads that
child's `start`/`end` onto the warning in
`crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/shared/a11y/mod.rs`, which the caller's
`if warning.start.is_none()` fallback then leaves alone. This is the same shape as the existing
`stamp_attribute` carve-out in that file.

## Test

New `crates/rsvelte_core/tests/a11y_figcaption_index_span.rs` (3 tests). Run against the parent
commit, `figcaption_index_points_at_the_figcaption_not_the_figure` fails for exactly the predicted
reason:

```
thread 'figcaption_index_points_at_the_figcaption_not_the_figure' panicked at
crates/rsvelte_core/tests/a11y_figcaption_index_span.rs:54:5:
expected the `<figcaption>`, got (1, 0, 9, 9) -> "<figure>"
```

The other two are pins that pass **both** before and after, so they cannot be mistaken for the
discriminator: `figcaption_parent_still_points_at_the_figcaption` (the sibling rule is raised *on*
the `<figcaption>`, so the element fallback is already correct there and must stay) and
`correctly_placed_figcaption_raises_no_index_warning` (a legal `<figcaption>` still raises nothing,
so a span fix cannot be misread as a changed firing condition).

## Ratchets — one needs re-baselining, and I did not do it

**`compatibility/warning-position-known-failures.{client,server,client-dev}.json` (two-sided — this
will fail CI until re-baselined).** All three list
`svelte/packages/svelte/tests/validator/samples/a11y-figcaption-wrong-place/input.svelte`. That file
now matches upstream on **every** warning position for all three targets — verified by compiling it
directly with `rsvelte_core`:

```
generate=Client  dev=false  a11y_figcaption_index @ (4,1)..(6,14)   a11y_figcaption_parent @ (15,2)..(17,15)
generate=Client  dev=true   (identical)
generate=Server  dev=false  (identical)
generate=Server  dev=true   (identical)
```

versus upstream's `warnings.json` for the fixture: `4:1..6:14` and `15:2..17:15`. So the entry flips
to PASS and the two-sided gate will report "entries now pass".

I did **not** hand-edit the ratchets. Re-baselining needs a full corpus run (all 36 corpus sources,
the ≥12000-entry floor on `--update-warning-baseline`), which the disk budget on this machine does
not allow. The command to run, per `scripts/compat-corpus/README.md` — warning comparison needs no
normalization, so `--no-fmt` is safe here and only the warning ratchets are rewritten:

```
pnpm run corpus:compile
node scripts/compat-corpus/verify.mjs --no-fmt --update-warning-baseline
```

`compatibility/warning-known-failures.md` also needs its prose updated: the section "What is left is
650 tuples" calls out this exact `a11y_figcaption_index` tuple as "structurally out of reach", which
this PR makes untrue — the stamp sites could not see it, but the emission site itself can.

**`compatibility/validator-known-failures.json` (one-sided — CI stays green).** It lists
`a11y-figcaption-wrong-place`, which now passes fully. Only *regressions* are asserted in
`crates/rsvelte_core/tests/validator.rs:454`; the "now pass" list is printed, not enforced, and the
file is not referenced by any workflow. Left untouched deliberately, and note it was already stale
independently of this PR: the run prints **27** now-passing entries, 26 of which predate this branch.

## Verification

- `cargo fmt --all`, `cargo clippy --all-targets --all-features -- -D warnings` clean
- `--release`: `a11y_figcaption_index_span` (3), `a11y_attribute_warning_span` (7),
  `a11y_validator_fixes` (3), `validator` (2), `validator_message_wording` (9) — all green
- `compiler_fixtures` not run: it needs `pnpm run generate-fixtures`, and this change touches only a
  warning span, no emitted code

Fixes #2490
