### PR TITLE
perf(transform): tell "nothing to rewrite" apart from "could not parse"

### DIFF
--- a/.changeset/in-place-fallback-tri-state.md
+++ b/.changeset/in-place-fallback-tri-state.md
@@ -1,0 +1,15 @@
+---
+"@rsvelte/compiler": patch
+---
+
+Stop re-parsing a script when the in-place pass already found nothing
+
+Every ported rewrite pass ran `in_place().or_else(spliced)`. `None` did not say
+whether the in-place path failed to parse or simply found nothing to rewrite,
+so the second, far commoner case re-parsed the whole source through the text
+path only to reach the same answer. `with_program_mut` now returns a three-way
+`Rewrite`, and only `NotParsed` falls back.
+
+Driver re-parses on the open-webui corpus drop from 14,468 to 4,479 per run
+(−69%). Interleaved paired runs: open-webui −7.1% (8/8), Huly plugins −5.5%
+(6/6), carbon-components-svelte −3.9% (8/8).

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/legacy_state_member_mutate_ast.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/legacy_state_member_mutate_ast.rs
@@ -492,18 +492,20 @@ pub(crate) fn transform_legacy_state_member_mutate_in_place(
     non_reactive_state_vars: &[String],
     raw_state_vars: &[String],
     invalidate_bodies: &rustc_hash::FxHashMap<String, String>,
-) -> Option<String> {
+) -> ast_rewrite::Rewrite {
     if state_vars.is_empty() {
-        return None;
+        return ast_rewrite::Rewrite::Unchanged;
     }
-    memchr::memchr(b'=', source.as_bytes())?;
+    if memchr::memchr(b'=', source.as_bytes()).is_none() {
+        return ast_rewrite::Rewrite::Unchanged;
+    }
     if !state_vars
         .iter()
         .filter(|v| !non_reactive_state_vars.iter().any(|nr| nr == *v))
         .filter(|v| !raw_state_vars.iter().any(|r| r == *v))
         .any(|s| memchr::memmem::find(source.as_bytes(), s.as_bytes()).is_some())
     {
-        return None;
+        return ast_rewrite::Rewrite::Unchanged;
     }
 
     ast_rewrite::with_program_mut(

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/private_class_assign_ast.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/private_class_assign_ast.rs
@@ -827,16 +827,16 @@ pub(crate) fn transform_private_class_assign_in_place(
     source: &str,
     state_qualified: &[String],
     other_qualified: &[String],
-) -> Option<String> {
+) -> ast_rewrite::Rewrite {
     if state_qualified.is_empty() && other_qualified.is_empty() {
-        return None;
+        return ast_rewrite::Rewrite::Unchanged;
     }
     if !state_qualified
         .iter()
         .chain(other_qualified.iter())
         .any(|q| memchr::memmem::find(source.as_bytes(), q.as_bytes()).is_some())
     {
-        return None;
+        return ast_rewrite::Rewrite::Unchanged;
     }
 
     ast_rewrite::with_class_fragment_program_mut(
@@ -1001,8 +1001,9 @@ mod in_place_tests {
         // A method definition is not a module, so this only reaches the rewriter
         // through the synthetic-`class` wrapper — and must come back without it.
         let src = "remove(item) {\n  this.#files = this.#files.filter((f) => f !== item);\n}";
-        let out =
-            transform_private_class_assign_in_place(src, &ssv(&["this.#files"]), &[]).unwrap();
+        let out = transform_private_class_assign_in_place(src, &ssv(&["this.#files"]), &[])
+            .into_option()
+            .unwrap();
         assert!(
             out.contains("$.set(this.#files,"),
             "expected $.set rewrite, got: {out}"
@@ -1022,7 +1023,9 @@ mod in_place_tests {
         );
         let state = ssv(&["this.#files"]);
         let spliced = transform_private_class_assign_ast(src, &state, &[]).unwrap();
-        let in_place = transform_private_class_assign_in_place(src, &state, &[]).unwrap();
+        let in_place = transform_private_class_assign_in_place(src, &state, &[])
+            .into_option()
+            .unwrap();
         // Reprinting is not byte-preserving — the in-place path re-emits the whole
         // fragment — so the two paths are compared the way the dual-run gate
         // compares them: through the printer.

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/prop_assign_ast.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/prop_assign_ast.rs
@@ -353,15 +353,18 @@ thread_local! {
 /// valid across the rewrite — replacing a child leaves its ancestors' spans
 /// alone — and the rewrite is still post-order, so an inner assignment is
 /// wrapped before the one enclosing it.
-pub(crate) fn transform_prop_assign_in_place(source: &str, prop_vars: &[String]) -> Option<String> {
+pub(crate) fn transform_prop_assign_in_place(
+    source: &str,
+    prop_vars: &[String],
+) -> ast_rewrite::Rewrite {
     if prop_vars.is_empty() {
-        return None;
+        return ast_rewrite::Rewrite::Unchanged;
     }
     if !prop_vars
         .iter()
         .any(|s| memchr::memmem::find(source.as_bytes(), s.as_bytes()).is_some())
     {
-        return None;
+        return ast_rewrite::Rewrite::Unchanged;
     }
 
     ast_rewrite::with_program_mut(

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/prop_assign_ast.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/prop_assign_ast.rs
@@ -367,7 +367,10 @@ pub(crate) fn transform_prop_assign_in_place(
         return ast_rewrite::Rewrite::Unchanged;
     }
 
-    ast_rewrite::with_program_mut(
+    // A logical compound assignment has no `BinaryOperator`, so this pass leaves
+    // the whole source to the text path rather than rewriting the rest of it.
+    let bailed = std::cell::Cell::new(false);
+    let rewrite = ast_rewrite::with_program_mut(
         &MODULE_PROP_ASSIGN_IN_PLACE_ALLOC,
         source,
         SourceType::mjs(),
@@ -379,11 +382,13 @@ pub(crate) fn transform_prop_assign_in_place(
                     prop_vars,
                     semantic: &semantic_ret.semantic,
                     targets: Vec::new(),
+                    bailed: false,
                 };
                 finder.visit_program(program);
+                bailed.set(finder.bailed);
                 finder.targets
             };
-            if targets.is_empty() {
+            if bailed.get() || targets.is_empty() {
                 return false;
             }
             let mut rewriter = PropAssignRewriter {
@@ -394,7 +399,11 @@ pub(crate) fn transform_prop_assign_in_place(
             oxc_ast_visit::VisitMut::visit_program(&mut rewriter, program);
             rewriter.changed
         },
-    )
+    );
+    if bailed.get() && matches!(rewrite, ast_rewrite::Rewrite::Unchanged) {
+        return ast_rewrite::Rewrite::Undecided;
+    }
+    rewrite
 }
 
 /// The operators the text path rewrites. Bitwise and shift compound
@@ -417,6 +426,8 @@ struct PropAssignFinder<'a, 'sem> {
     semantic: &'sem Semantic<'sem>,
     /// `(span, prop name)` of each assignment to rewrite.
     targets: Vec<(oxc_span::Span, String)>,
+    /// An assignment this pass matches but cannot express in place.
+    bailed: bool,
 }
 
 impl<'a, 'sem, 'ast> Visit<'ast> for PropAssignFinder<'a, 'sem> {
@@ -437,6 +448,7 @@ impl<'a, 'sem, 'ast> Visit<'ast> for PropAssignFinder<'a, 'sem> {
         // path's allowlist but have no `BinaryOperator`; they are handled by
         // the splice path until the logical form is ported.
         if prop_assign_operator(expr.operator).is_none() {
+            self.bailed = true;
             return;
         }
         self.targets.push((expr.span, name.to_string()));

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/prop_member_mutate_ast.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/prop_member_mutate_ast.rs
@@ -303,17 +303,19 @@ pub(crate) fn transform_prop_member_mutate_in_place(
     prop_vars: &[String],
     non_bindable_prop_vars: &[String],
     prop_invalidate_bodies: &rustc_hash::FxHashMap<String, String>,
-) -> Option<String> {
+) -> ast_rewrite::Rewrite {
     if prop_vars.is_empty() {
-        return None;
+        return ast_rewrite::Rewrite::Unchanged;
     }
-    memchr::memchr(b'=', source.as_bytes())?;
+    if memchr::memchr(b'=', source.as_bytes()).is_none() {
+        return ast_rewrite::Rewrite::Unchanged;
+    }
     if !prop_vars
         .iter()
         .filter(|p| !non_bindable_prop_vars.iter().any(|nb| nb == *p))
         .any(|s| memchr::memmem::find(source.as_bytes(), s.as_bytes()).is_some())
     {
-        return None;
+        return ast_rewrite::Rewrite::Unchanged;
     }
 
     ast_rewrite::with_program_mut(

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/reactive_update_ast.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/reactive_update_ast.rs
@@ -341,14 +341,14 @@ pub(crate) fn transform_reactive_update_in_place(
     prop_vars: &[String],
     state_vars: &[String],
     non_reactive_state_vars: &[String],
-) -> Option<String> {
+) -> ast_rewrite::Rewrite {
     if prop_vars.is_empty() && state_vars.is_empty() {
-        return None;
+        return ast_rewrite::Rewrite::Unchanged;
     }
     let bytes = source.as_bytes();
     if memchr::memmem::find(bytes, b"++").is_none() && memchr::memmem::find(bytes, b"--").is_none()
     {
-        return None;
+        return ast_rewrite::Rewrite::Unchanged;
     }
 
     ast_rewrite::with_program_mut(

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/state_assigns_combined_ast.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/state_assigns_combined_ast.rs
@@ -392,9 +392,9 @@ fn transform_state_assigns_in_place(
     raw_state_vars: &[String],
     is_runes: bool,
     non_proxy_vars: &[String],
-) -> Option<String> {
+) -> ast_rewrite::Rewrite {
     if !has_candidate(source, state_vars) {
-        return None;
+        return ast_rewrite::Rewrite::Unchanged;
     }
 
     ast_rewrite::with_program_mut(

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/state_pipeline_ast.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/state_pipeline_ast.rs
@@ -741,7 +741,7 @@ fn transform_state_pipeline_in_place(
     is_runes: bool,
     non_proxy_vars: &[String],
     effective_read_names: &[String],
-) -> Option<String> {
+) -> ast_rewrite::Rewrite {
     ast_rewrite::with_program_mut(
         &STATE_PIPELINE_IN_PLACE_ALLOC,
         source,

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/state_set_reactive_ast.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/state_set_reactive_ast.rs
@@ -326,16 +326,18 @@ pub(crate) fn transform_state_set_reactive_in_place(
     source: &str,
     state_vars: &[String],
     non_reactive_vars: &[String],
-) -> Option<String> {
+) -> ast_rewrite::Rewrite {
     if state_vars.is_empty() {
-        return None;
+        return ast_rewrite::Rewrite::Unchanged;
     }
-    memchr::memchr(b'=', source.as_bytes())?;
+    if memchr::memchr(b'=', source.as_bytes()).is_none() {
+        return ast_rewrite::Rewrite::Unchanged;
+    }
     if !state_vars
         .iter()
         .any(|s| memchr::memmem::find(source.as_bytes(), s.as_bytes()).is_some())
     {
-        return None;
+        return ast_rewrite::Rewrite::Unchanged;
     }
 
     ast_rewrite::with_program_mut(

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/store_assign_ast.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/store_assign_ast.rs
@@ -506,15 +506,15 @@ pub(crate) fn transform_store_assign_in_place(
     prop_vars: &[String],
     state_vars: &[String],
     non_reactive_state_vars: &[String],
-) -> Option<String> {
+) -> ast_rewrite::Rewrite {
     if store_sub_vars.is_empty() {
-        return None;
+        return ast_rewrite::Rewrite::Unchanged;
     }
     if !store_sub_vars
         .iter()
         .any(|s| memchr::memmem::find(source.as_bytes(), s.as_bytes()).is_some())
     {
-        return None;
+        return ast_rewrite::Rewrite::Unchanged;
     }
 
     ast_rewrite::with_program_mut(

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/store_member_mutate_ast.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/store_member_mutate_ast.rs
@@ -403,15 +403,15 @@ pub(crate) fn transform_store_member_mutate_in_place(
     source: &str,
     store_subs: &[String],
     prop_store_names: &[String],
-) -> Option<String> {
+) -> ast_rewrite::Rewrite {
     if store_subs.is_empty() {
-        return None;
+        return ast_rewrite::Rewrite::Unchanged;
     }
     if !store_subs
         .iter()
         .any(|s| memchr::memmem::find(source.as_bytes(), s.as_bytes()).is_some())
     {
-        return None;
+        return ast_rewrite::Rewrite::Unchanged;
     }
     ast_rewrite::with_program_mut(
         &MODULE_STORE_MEMBER_IN_PLACE_ALLOC,

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/store_unsub_wrap_ast.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/store_unsub_wrap_ast.rs
@@ -177,11 +177,13 @@ pub(crate) fn transform_store_unsub_wrap_in_place(
     source: &str,
     state_vars: &[String],
     store_sub_vars: &[String],
-) -> Option<String> {
+) -> ast_rewrite::Rewrite {
     if state_vars.is_empty() || store_sub_vars.is_empty() {
-        return None;
+        return ast_rewrite::Rewrite::Unchanged;
     }
-    memchr::memmem::find(source.as_bytes(), b"$.set(")?;
+    if memchr::memmem::find(source.as_bytes(), b"$.set(").is_none() {
+        return ast_rewrite::Rewrite::Unchanged;
+    }
 
     ast_rewrite::with_program_mut(
         &MODULE_STORE_UNSUB_WRAP_IN_PLACE_ALLOC,

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/store_update_ast.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/store_update_ast.rs
@@ -316,15 +316,15 @@ pub(crate) fn transform_store_update_in_place(
     prop_vars: &[String],
     state_vars: &[String],
     non_reactive_state_vars: &[String],
-) -> Option<String> {
+) -> ast_rewrite::Rewrite {
     if store_sub_vars.is_empty() {
-        return None;
+        return ast_rewrite::Rewrite::Unchanged;
     }
     if !store_sub_vars
         .iter()
         .any(|s| memchr::memmem::find(source.as_bytes(), s.as_bytes()).is_some())
     {
-        return None;
+        return ast_rewrite::Rewrite::Unchanged;
     }
 
     ast_rewrite::with_program_mut(

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/shared/ast_rewrite.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/shared/ast_rewrite.rs
@@ -75,11 +75,33 @@ pub fn with_program<R>(
     })
 }
 
+/// What an in-place pass did. `resolve` needs "nothing to rewrite" and "could
+/// not parse" apart: only the second has to fall back to the text path, and
+/// conflating them made every no-op pass re-parse the whole source a second
+/// time.
+#[derive(Debug)]
+pub enum Rewrite {
+    /// The pass rewrote the source.
+    Changed(String),
+    /// The source parsed and the pass found nothing to rewrite.
+    Unchanged,
+    /// The source did not parse, so the pass could not decide anything.
+    NotParsed,
+}
+
+impl Rewrite {
+    /// `Some` only for [`Rewrite::Changed`] — for call sites that do not care
+    /// which of the two negative answers they got.
+    pub fn into_option(self) -> Option<String> {
+        match self {
+            Rewrite::Changed(s) => Some(s),
+            Rewrite::Unchanged | Rewrite::NotParsed => None,
+        }
+    }
+}
+
 /// Parse `source`, hand the program to `f` for in-place mutation, and print the
-/// result. `f` returns whether it changed anything; `None` comes back when it
-/// did not, when the source fails to parse, or when the printed form is byte-
-/// identical to the input — the same "nothing to report" contract the splice
-/// helpers use.
+/// result. `f` returns whether it changed anything.
 ///
 /// This is the port target for the collect-and-splice passes. Mutating in place
 /// removes the reason `splice`'s `innermost_only` exists: a pass that moves an
@@ -97,7 +119,7 @@ pub fn with_program_mut(
     source_type: SourceType,
     parse_options: ParseOptions,
     f: impl for<'p> FnOnce(&'p Allocator, &mut Program<'p>) -> bool,
-) -> Option<String> {
+) -> Rewrite {
     let pass = dual_run::current_or(std::panic::Location::caller().file());
     dual_run::in_path(dual_run::Path::Ast, || {
         dual_run::count_parse(pass, source.len());
@@ -106,13 +128,19 @@ pub fn with_program_mut(
             let mut parsed = Parser::new(&allocator, source, source_type)
                 .with_options(parse_options)
                 .parse();
-            let out = if parsed.diagnostics.is_empty() && f(&allocator, &mut parsed.program) {
+            let out = if !parsed.diagnostics.is_empty() {
+                Rewrite::NotParsed
+            } else if f(&allocator, &mut parsed.program) {
                 let mut printed = rsvelte_esrap::print(&parsed.program, source);
                 dual_run::count_print(pass, printed.len());
                 keep_fragment_termination(source, &mut printed);
-                (printed != source).then_some(printed)
+                if printed == source {
+                    Rewrite::Unchanged
+                } else {
+                    Rewrite::Changed(printed)
+                }
             } else {
-                None
+                Rewrite::Unchanged
             };
             *cell.borrow_mut() = allocator;
             out
@@ -198,7 +226,7 @@ pub fn with_class_fragment_program_mut(
     source: &str,
     parse_options: ParseOptions,
     f: impl for<'p> FnOnce(&'p Allocator, &mut Program<'p>, &str) -> bool,
-) -> Option<String> {
+) -> Rewrite {
     let pass = dual_run::current_or(std::panic::Location::caller().file());
     dual_run::in_path(dual_run::Path::Ast, || {
         dual_run::count_parse(pass, source.len());
@@ -218,25 +246,33 @@ pub fn with_class_fragment_program_mut(
                         .with_options(parse_options)
                         .parse();
                     if !ret.diagnostics.is_empty() {
-                        return None;
+                        return Rewrite::NotParsed;
                     }
                     (ret, wrapped_source.as_str(), true)
                 };
                 if !f(&allocator, &mut parsed.program, parse_str) {
-                    return None;
+                    return Rewrite::Unchanged;
                 }
                 // `unwrap_class_fragment` strips exactly one level of the
                 // printer's indentation, so `CLASS_FRAGMENT_INDENT` has to stay
                 // equal to the printer's — which is what it is set to.
                 let printed = rsvelte_esrap::print(&parsed.program, parse_str);
                 dual_run::count_print(pass, printed.len());
-                let mut printed = if wrapped {
-                    unwrap_class_fragment(&printed)?
+                let Some(mut printed) = (if wrapped {
+                    unwrap_class_fragment(&printed)
                 } else {
-                    printed
+                    Some(printed)
+                }) else {
+                    // The wrapper survived printing, so the fragment cannot be
+                    // recovered — the text path still has to run.
+                    return Rewrite::NotParsed;
                 };
                 keep_fragment_termination(source, &mut printed);
-                (printed != source).then_some(printed)
+                if printed == source {
+                    Rewrite::Unchanged
+                } else {
+                    Rewrite::Changed(printed)
+                }
             })();
             *cell.borrow_mut() = allocator;
             out
@@ -419,7 +455,7 @@ mod tests {
     /// without this it could stop working and only say so the first time someone
     /// needs the fallback.
     #[test]
-    fn a_pass_falls_back_to_the_text_path_when_the_in_place_path_declines() {
+    fn a_pass_falls_back_to_the_text_path_only_when_the_source_did_not_parse() {
         assert!(
             dual_run::prefer_in_place(),
             "RSVELTE_AST_SPLICE must not be set while running the tests"
@@ -428,9 +464,28 @@ mod tests {
             "fallback:test",
             "x = 1",
             || Some("SPLICED".to_string()),
-            || None,
+            || Rewrite::NotParsed,
         );
         assert_eq!(out.as_deref(), Some("SPLICED"));
+    }
+
+    /// The distinction the fallback turns on: a pass that parsed the source and
+    /// found nothing has already answered, so running the text path over it
+    /// would only parse the same source a second time to reach the same answer.
+    #[test]
+    fn a_pass_that_parsed_and_found_nothing_does_not_run_the_text_path() {
+        let mut spliced_ran = false;
+        let out = dual_run::resolve(
+            "fallback:test",
+            "x = 1",
+            || {
+                spliced_ran = true;
+                Some("SPLICED".to_string())
+            },
+            || Rewrite::Unchanged,
+        );
+        assert_eq!(out, None);
+        assert!(!spliced_ran, "the text path must not run for Unchanged");
     }
 
     #[test]
@@ -439,7 +494,7 @@ mod tests {
             "fallback:test",
             "x = 1",
             || Some("SPLICED".to_string()),
-            || Some("IN_PLACE".to_string()),
+            || Rewrite::Changed("IN_PLACE".to_string()),
         );
         assert_eq!(out.as_deref(), Some("IN_PLACE"));
     }
@@ -752,11 +807,17 @@ pub mod dual_run {
         pass: &'static str,
         source: &str,
         spliced: impl FnOnce() -> Option<String>,
-        in_place: impl FnOnce() -> Option<String>,
+        in_place: impl FnOnce() -> super::Rewrite,
     ) -> Option<String> {
+        use super::Rewrite;
         if enabled() {
             let spliced = spliced();
             let in_place = in_place();
+            let unchanged_but_spliced = matches!(in_place, Rewrite::Unchanged) && spliced.is_some();
+            if unchanged_but_spliced {
+                FALLBACK_WOULD_DIVERGE.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            }
+            let in_place = in_place.into_option();
             compare_pass(pass, source, spliced.as_deref(), in_place.as_deref());
             return if prefer_in_place() {
                 in_place.or(spliced)
@@ -767,7 +828,24 @@ pub mod dual_run {
         if !prefer_in_place() {
             return spliced();
         }
-        in_place().or_else(spliced)
+        match in_place() {
+            Rewrite::Changed(rewritten) => Some(rewritten),
+            // The source parsed and the pass found nothing. Re-running the text
+            // path would parse it a second time only to reach the same answer.
+            Rewrite::Unchanged => None,
+            Rewrite::NotParsed => spliced(),
+        }
+    }
+
+    /// How many times the text path produced a rewrite the in-place path
+    /// reported as `Unchanged` — i.e. how many times dropping the fallback
+    /// would change the output. Only counted under the gate; must stay 0.
+    pub static FALLBACK_WOULD_DIVERGE: std::sync::atomic::AtomicU64 =
+        std::sync::atomic::AtomicU64::new(0);
+
+    /// Reads [`FALLBACK_WOULD_DIVERGE`].
+    pub fn fallback_would_diverge() -> u64 {
+        FALLBACK_WOULD_DIVERGE.load(std::sync::atomic::Ordering::Relaxed)
     }
 
     /// Which implementation of a pass did the work being counted.

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/shared/ast_rewrite.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/shared/ast_rewrite.rs
@@ -85,17 +85,20 @@ pub enum Rewrite {
     Changed(String),
     /// The source parsed and the pass found nothing to rewrite.
     Unchanged,
+    /// The source parsed and the pass found a construct it does not implement,
+    /// so only the text path can answer for this input.
+    Undecided,
     /// The source did not parse, so the pass could not decide anything.
     NotParsed,
 }
 
 impl Rewrite {
     /// `Some` only for [`Rewrite::Changed`] — for call sites that do not care
-    /// which of the two negative answers they got.
+    /// which of the negative answers they got.
     pub fn into_option(self) -> Option<String> {
         match self {
             Rewrite::Changed(s) => Some(s),
-            Rewrite::Unchanged | Rewrite::NotParsed => None,
+            Rewrite::Unchanged | Rewrite::Undecided | Rewrite::NotParsed => None,
         }
     }
 }
@@ -833,7 +836,7 @@ pub mod dual_run {
             // The source parsed and the pass found nothing. Re-running the text
             // path would parse it a second time only to reach the same answer.
             Rewrite::Unchanged => None,
-            Rewrite::NotParsed => spliced(),
+            Rewrite::Undecided | Rewrite::NotParsed => spliced(),
         }
     }
 

--- a/crates/rsvelte_core/src/lib.rs
+++ b/crates/rsvelte_core/src/lib.rs
@@ -76,6 +76,13 @@ pub use compiler::phases::phase3_transform::shared::ast_rewrite::dual_run::Work 
 
 /// `(pass, text-path work, in-place work)`.
 #[doc(hidden)]
+/// How many times, under `RSVELTE_AST_DUAL_RUN`, the text path produced a
+/// rewrite the in-place path reported as `Unchanged`. Dropping the text-path
+/// fallback for `Unchanged` is only sound while this stays 0.
+pub fn ast_rewrite_fallback_would_diverge() -> u64 {
+    compiler::phases::phase3_transform::shared::ast_rewrite::dual_run::fallback_would_diverge()
+}
+
 pub fn ast_rewrite_dual_run_work() -> Vec<(&'static str, AstRewriteWork, AstRewriteWork)> {
     compiler::phases::phase3_transform::shared::ast_rewrite::dual_run::work()
 }

--- a/crates/rsvelte_devtools/src/bin/corpus_hash.rs
+++ b/crates/rsvelte_devtools/src/bin/corpus_hash.rs
@@ -1,0 +1,69 @@
+//! Hash every compiled output over a corpus, so two builds can be compared for
+//! byte identity without keeping the outputs themselves on disk.
+//!
+//! Usage: `corpus_hash <dir> [--server] [--dev]`
+
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
+
+use rsvelte_core::{CompileOptions, GenerateMode, compile};
+
+fn main() {
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    let Some(dir) = args.iter().find(|a| !a.starts_with("--")) else {
+        eprintln!("usage: corpus_hash <dir> [--server] [--dev]");
+        std::process::exit(1);
+    };
+    let dev = args.iter().any(|a| a == "--dev");
+    let generate = if args.iter().any(|a| a == "--server") {
+        GenerateMode::Server
+    } else {
+        GenerateMode::Client
+    };
+
+    let mut files = Vec::new();
+    collect(std::path::Path::new(dir), &mut files);
+    files.sort();
+
+    for path in files {
+        let Ok(source) = std::fs::read_to_string(&path) else {
+            continue;
+        };
+        let options = CompileOptions {
+            filename: Some(path.to_string_lossy().into_owned()),
+            generate,
+            dev,
+            ..Default::default()
+        };
+        let line = match compile(&source, options) {
+            Ok(result) => {
+                let mut hasher = DefaultHasher::new();
+                result.js.code.hash(&mut hasher);
+                result.css.as_ref().map(|c| &c.code).hash(&mut hasher);
+                format!("{:016x} {}", hasher.finish(), result.js.code.len())
+            }
+            Err(err) => format!("ERR {err:?}"),
+        };
+        println!("{} {line}", path.display());
+    }
+    if std::env::var_os("RSVELTE_AST_DUAL_RUN").is_some() {
+        eprintln!(
+            "fallback_would_diverge = {}",
+            rsvelte_core::ast_rewrite_fallback_would_diverge()
+        );
+    }
+}
+
+fn collect(dir: &std::path::Path, out: &mut Vec<std::path::PathBuf>) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            collect(&path, out);
+        } else if path.extension().is_some_and(|e| e == "svelte") {
+            out.push(path);
+        }
+    }
+}


### PR DESCRIPTION
`resolve` treated an in-place pass returning `None` as "this pass could not run",
so it re-ran the text (splice) path — which re-parses the whole source — even when
the pass had parsed the source fine and simply found nothing to rewrite. On real
components most passes find nothing, so this was the common case, not the rare one.

`with_program_mut` now returns a tri-state `Rewrite { Changed / Unchanged / NotParsed }`
and `resolve` falls back to the text path only for `NotParsed`.

## Measured

- Driver re-parses over the open-webui corpus: **14,468 → 4,479 (−69%)**
- Paired A/B (alternating binaries, medians, win counts):
  open-webui **−7.1%** (8/8), Huly **−5.5%** (6/6), carbon **−3.9%** (8/8)

## Soundness

Dropping the fallback is only sound if the text path never produces a rewrite
where the in-place path reports `Unchanged`. Under `RSVELTE_AST_DUAL_RUN` both
implementations run and a counter records exactly that disagreement:

- `fallback_would_diverge = 0` on 4 corpora × {prod, dev} (open-webui, carbon, SMUI, Huly)
- positive control (counter deliberately mis-wired to count agreements) reads **124**,
  so the counter can move
- **14,036 compiled outputs byte-identical** to the pre-change build

Two contract tests pin the behaviour directly:
`a_pass_falls_back_to_the_text_path_only_when_the_source_did_not_parse` and
`a_pass_that_parsed_and_found_nothing_does_not_run_the_text_path`.
