### PR TITLE
fix(analyze): warn event_directive_deprecated on `<svelte:element on:…>`

### DIFF
--- a/.changeset/svelte-element-on-directive-deprecated.md
+++ b/.changeset/svelte-element-on-directive-deprecated.md
@@ -1,0 +1,5 @@
+---
+'@rsvelte/compiler': patch
+---
+
+fix(analyze): warn `event_directive_deprecated` for `on:` on `<svelte:element>` too

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/on_directive.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/on_directive.rs
@@ -6,6 +6,7 @@
 
 use super::super::AnalysisError;
 use super::super::types::EventDirectiveInfo;
+use super::super::warnings;
 use super::VisitorContext;
 use super::shared::fragment::mark_subtree_dynamic;
 use super::shared::utils::walk_js_expression_node;
@@ -15,12 +16,10 @@ use crate::ast::template::{OnDirective, TemplateNode};
 ///
 /// In Svelte 5 (runes mode), on: directives are deprecated in favor of event attributes.
 /// This visitor:
-/// 1. Tracks the first event directive (for detecting mixed syntax)
-/// 2. Marks the subtree as dynamic
-/// 3. Walks the expression to track dependencies
-///
-/// Note: The event_directive_deprecated warning is emitted by the parent element visitor
-/// (RegularElement, SvelteElement) because this visitor doesn't have access to the parent type.
+/// 1. Warns `event_directive_deprecated` in runes mode
+/// 2. Tracks the first event directive (for detecting mixed syntax)
+/// 3. Marks the subtree as dynamic
+/// 4. Walks the expression to track dependencies
 ///
 /// Corresponds to `OnDirective(node, context)` in OnDirective.js.
 pub fn visit(
@@ -37,6 +36,11 @@ pub fn visit(
         );
 
         if is_element {
+            // Component events might not be under the author's control, so they don't warn
+            if context.analysis.runes {
+                context.emit_warning(warnings::event_directive_deprecated(&directive.name));
+            }
+
             // Track in context for mixed_event_handler_syntaxes check
             if context.event_directive_node.is_none() {
                 context.event_directive_node = Some(directive.name.to_string());

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/regular_element.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/regular_element.rs
@@ -1120,19 +1120,6 @@ pub fn visit<'a, 'b: 'a>(
     for attr in &mut element.attributes {
         match attr {
             Attribute::OnDirective(on) => {
-                // In runes mode, warn about deprecated event directive usage
-                // on RegularElement (not components). This is done here because
-                // on_directive::visit doesn't have access to the parent type.
-                // Reference: svelte/packages/svelte/src/compiler/phases/2-analyze/visitors/OnDirective.js
-                if context.analysis.runes {
-                    context.emit_warning(warnings::event_directive_deprecated(&on.name));
-                }
-
-                // Track event directive for mixed_event_handler_syntaxes check
-                // This is a RegularElement, so we track it
-                if context.event_directive_node.is_none() {
-                    context.event_directive_node = Some(on.name.to_string());
-                }
                 on_directive::visit(on, context)?;
             }
             Attribute::ClassDirective(class_dir) => {

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/svelte_element.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/svelte_element.rs
@@ -310,9 +310,7 @@ pub fn visit<'a, 'b: 'a>(
                 super::spread_attribute::visit(spread, context)?;
             }
             Attribute::OnDirective(on) => {
-                if let Some(ref expr) = on.expression {
-                    super::script::walk_expression(expr, context)?;
-                }
+                super::on_directive::visit(on, context)?;
             }
             _ => {}
         }

--- a/crates/rsvelte_core/tests/svelte_element_on_directive_deprecated_2497.rs
+++ b/crates/rsvelte_core/tests/svelte_element_on_directive_deprecated_2497.rs
@@ -1,0 +1,76 @@
+//! Regression test: in runes mode, `event_directive_deprecated` must fire for an
+//! `on:` directive on **both** `<button on:click>` and `<svelte:element on:click>`.
+//!
+//! Upstream `2-analyze/visitors/OnDirective.js` warns when the parent is either
+//! `RegularElement` or `SvelteElement` (components are the only exclusion). rsvelte
+//! raised the warning from the parent element visitor, and only `regular_element.rs`
+//! did so — `<svelte:element this={tag} on:click={…}>` produced no warning at all.
+
+use rsvelte_core::{CompileOptions, GenerateMode, compile, compiler::CssMode};
+
+fn warning_codes(src: &str, runes: Option<bool>) -> Vec<String> {
+    compile(
+        src,
+        CompileOptions {
+            filename: Some("T.svelte".to_string()),
+            generate: GenerateMode::Client,
+            dev: false,
+            css: CssMode::External,
+            runes,
+            ..Default::default()
+        },
+    )
+    .expect("compile")
+    .warnings
+    .iter()
+    .map(|w| w.code.clone())
+    .collect()
+}
+
+fn count(codes: &[String]) -> usize {
+    codes
+        .iter()
+        .filter(|c| *c == "event_directive_deprecated")
+        .count()
+}
+
+const RUNES_SCRIPT: &str = "<script>let count = $state(0); let tag = $state('button');</script>";
+
+#[test]
+fn regular_element_warns() {
+    let src = format!("{RUNES_SCRIPT}<button on:click={{() => count++}}>{{count}}</button>");
+    let codes = warning_codes(&src, Some(true));
+    assert_eq!(count(&codes), 1, "got: {codes:?}");
+}
+
+#[test]
+fn svelte_element_warns() {
+    let src = format!(
+        "{RUNES_SCRIPT}<svelte:element this={{tag}} on:click={{() => count++}}>{{count}}</svelte:element>"
+    );
+    let codes = warning_codes(&src, Some(true));
+    assert_eq!(count(&codes), 1, "got: {codes:?}");
+}
+
+#[test]
+fn both_parents_warn_once_each() {
+    let src = format!(
+        "{RUNES_SCRIPT}<button on:click={{() => count++}}>a</button><svelte:element this={{tag}} on:click={{() => count++}}>b</svelte:element>"
+    );
+    let codes = warning_codes(&src, Some(true));
+    assert_eq!(count(&codes), 2, "got: {codes:?}");
+}
+
+#[test]
+fn component_does_not_warn() {
+    let src = "<script>import Button from './Button.svelte'; let count = $state(0);</script><Button on:click={() => count++}>a</Button>";
+    let codes = warning_codes(src, Some(true));
+    assert_eq!(count(&codes), 0, "got: {codes:?}");
+}
+
+#[test]
+fn legacy_mode_does_not_warn() {
+    let src = "<script>let tag = 'button';</script><svelte:element this={tag} on:click={() => {}}>b</svelte:element>";
+    let codes = warning_codes(src, Some(false));
+    assert_eq!(count(&codes), 0, "got: {codes:?}");
+}


### PR DESCRIPTION
## What was broken

In runes mode, `<svelte:element this={tag} on:click={…}>` emitted **no**
`event_directive_deprecated` warning. Confirmed against the official compiler on
`origin/main` (`3c8593c2`):

| source | official (svelte 5.56.8) | rsvelte before |
|---|---|---|
| `<button on:click={…}>` | `event_directive_deprecated` | `event_directive_deprecated` |
| `<svelte:element this={tag} on:click={…}>` | `event_directive_deprecated` | *(nothing)* |

The warning was not raised from an `OnDirective` visitor at all — it was raised by
the parent element visitor, and only `regular_element.rs` did it. `svelte_element.rs`
had an `Attribute::OnDirective(on)` arm that merely walked the handler expression.

## What upstream does

`submodules/svelte/packages/svelte/src/compiler/phases/2-analyze/visitors/OnDirective.js`
warns from the directive visitor, for **both** parent types — components are the only
exclusion:

```js
if (context.state.analysis.runes) {
	const parent_type = context.path.at(-1)?.type;
	if (parent_type === 'RegularElement' || parent_type === 'SvelteElement') {
		w.event_directive_deprecated(node, node.name);
	}
}
```

## Change

Mirror that structure instead of patching the second site, so the "which parents warn"
rule lives in one place:

- `on_directive.rs` emits the warning inside the block that already tests
  `parent is SvelteElement | RegularElement` (`context.path.last()` is correct here —
  `visit_node` pushes the element before dispatching).
- `regular_element.rs` drops its emission, plus the `event_directive_node` assignment
  that `on_directive::visit` already performs identically.
- `svelte_element.rs` calls `on_directive::visit` like every other element-ish visitor
  (`regular_element`, `svelte_window`, `svelte_body`, `svelte_document`) already does.
  This also makes the `SvelteElement` arm of `on_directive.rs`'s parent check — which
  was dead code — reachable, so `mixed_event_handler_syntaxes` is now detected on
  `<svelte:element>` as upstream does.

The warning is emitted without a span, exactly as `regular_element.rs` did before;
adding spans to `event_directive_deprecated` is separate work and is deliberately not
mixed in here.

### Codegen is unchanged

`svelte_element.rs` previously walked the handler through `script::walk_expression`;
`on_directive::visit` uses `walk_js_expression_node` and populates
`metadata.expression`. A before/after dump of `js.code` for 7 `<svelte:element on:…>`
shapes (runes / legacy / event-forwarding / modifiers / call handler / nested) across
`client`, `client-dev` and `server` is **byte-identical**; the only diff is the new
warning line.

## Tests

`crates/rsvelte_core/tests/svelte_element_on_directive_deprecated_2497.rs`, 5 tests
pinning both parents plus the two negative controls. Before the fix:

```
test legacy_mode_does_not_warn ... ok
test component_does_not_warn ... ok
test regular_element_warns ... ok
test svelte_element_warns ... FAILED
test both_parents_warn_once_each ... FAILED

---- svelte_element_warns ----
assertion `left == right` failed: got: []
  left: 0
 right: 1

---- both_parents_warn_once_each ----
assertion `left == right` failed: got: ["event_directive_deprecated"]
  left: 1
 right: 2
```

i.e. the `<svelte:element>` case produced an empty warning list, and the mixed case
produced exactly one warning instead of two — the predicted failure, with the
regular-element / component / legacy controls staying green (so the test discriminates
the missing emission, not "warnings are broken"). After the fix all 5 pass.
`both_parents_warn_once_each` also guards the mirror-image regression: a fix applied to
`svelte_element.rs` alone, or a double emission from moving the site, changes that count.

## Verification

`--release`: `runtime` (legacy 1207 / runes 1007 / hydration / browser), `ssr`,
`validator`, `compiler_fixtures`, `compiler_errors`, `css` — all green.
`cargo fmt`, `cargo clippy --all-targets --all-features -- -D warnings` clean.

`runtime-legacy/samples/dynamic-element-event-handler{1,2}` are existing fixtures that
compile `<svelte:element this={tag} on:click={handler}>`; they cover the codegen path
touched here and still pass.

Fixes #2497
