### PR TITLE
fix(esrap): give a module's top-level comments the ownership upstream gives them

### DIFF
--- a/.changeset/module-comment-ownership.md
+++ b/.changeset/module-comment-ownership.md
@@ -1,0 +1,14 @@
+---
+'@rsvelte/compiler': patch
+---
+
+fix(esrap): drop the comments a client `.svelte.(js|ts)` module's top level cannot
+own, and wrap a call whose last argument is preceded by a line comment. Upstream
+hands esrap a builder-made program with no `loc`, so its statement list discards
+every pending comment and only a nested body that does carry one re-finds its
+own — a file header or a JSDoc block on a top-level `export const` is dropped,
+while a comment inside a function, arrow-block or class body survives. The call
+wrap is the same anchoring bug the `ReturnStatement` rule had: the test ran
+against oxc's preserved parens, so `g((// c\n a))` never went multiline.
+`rsvelte_esrap` is released as 0.10.4 and `rsvelte_core` pins the new exact
+requirement.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2508,7 +2508,7 @@ dependencies = [
 
 [[package]]
 name = "rsvelte_esrap"
-version = "0.10.3"
+version = "0.10.4"
 dependencies = [
  "compact_str 0.10.0",
  "memchr",

--- a/crates/rsvelte_core/Cargo.toml
+++ b/crates/rsvelte_core/Cargo.toml
@@ -73,7 +73,7 @@ oxc_ast = { version = "0.143", features = ["serialize"] }
 oxc_span = "0.143"
 oxc_diagnostics = "0.143"
 oxc_codegen = "0.143"
-rsvelte_esrap = { version = "=0.10.3", path = "../rsvelte_esrap" }
+rsvelte_esrap = { version = "=0.10.4", path = "../rsvelte_esrap" }
 oxc_syntax = "0.143"
 oxc_semantic = "0.143"
 

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
@@ -370,7 +370,9 @@ pub fn transform_client_module(
     let alloc = oxc_allocator::Allocator::default();
     if let Some(code) =
         super::js_ast::to_oxc::program_to_oxc(&program, &arena, &alloc).map(|converted| {
-            let print_opts = rsvelte_esrap::PrintOptions::default().with_empty_statements(true);
+            let print_opts = rsvelte_esrap::PrintOptions::default()
+                .with_empty_statements(true)
+                .with_unlocated_program(true);
             match &converted.comment_source {
                 Some(cs) => {
                     rsvelte_esrap::print_split(

--- a/crates/rsvelte_core/tests/module_comment_ownership.rs
+++ b/crates/rsvelte_core/tests/module_comment_ownership.rs
@@ -1,0 +1,82 @@
+//! Which comments survive a client `.svelte.(js|ts)` compile.
+//!
+//! Upstream hands esrap a builder-made program with no `loc`, so the program's
+//! statement list discards every pending comment and only a nested body that
+//! does carry a location re-finds its own. A file header is therefore dropped
+//! while a comment inside a function body survives. Expected strings are the
+//! official compiler's output.
+
+use rsvelte_core::compiler::ModuleCompileOptions;
+use rsvelte_core::{GenerateMode, compile_module};
+
+fn module(src: &str) -> String {
+    compile_module(
+        src,
+        ModuleCompileOptions {
+            filename: Some("m.svelte.js".to_string()),
+            generate: GenerateMode::Client,
+            dev: true,
+            ..Default::default()
+        },
+    )
+    .expect("compile")
+    .js
+    .code
+}
+
+/// The generated banner is not a source comment, so strip the header lines the
+/// assertions are not about.
+fn tail(src: &str) -> String {
+    let out = module(src);
+    out.lines().skip(1).collect::<Vec<_>>().join("\n")
+}
+
+#[test]
+fn a_top_level_comment_is_dropped() {
+    for comment in ["/* hdr */", "/** @type {number} */", "// hdr"] {
+        let out = tail(&format!("{comment}\nexport const a = 1;\n"));
+        assert!(!out.contains("hdr"), "{comment} survived:\n{out}");
+        assert!(!out.contains("@type"), "{comment} survived:\n{out}");
+        assert!(out.contains("export const a = 1;"), "{out}");
+    }
+}
+
+#[test]
+fn a_comment_between_top_level_statements_is_dropped() {
+    let out = tail("export const a = 1;\n/* mid */\nexport const b = 2;\n");
+    assert!(!out.contains("mid"), "{out}");
+}
+
+#[test]
+fn a_comment_inside_a_located_body_survives() {
+    let cases = [
+        "export function f() {\n\t/* inner */\n\treturn 1;\n}\n",
+        "export const f = () => {\n\t/* inner */\n};\n",
+        "export class C {\n\t/* inner */\n\tx = 1;\n}\n",
+    ];
+    for src in cases {
+        let out = tail(src);
+        assert!(out.contains("/* inner */"), "dropped in:\n{out}");
+    }
+}
+
+/// A comment leading the *expression* body of an arrow has no statement list to
+/// be re-found by, so it goes with the rest.
+#[test]
+fn an_arrow_expression_body_comment_is_dropped() {
+    let out = tail("export const f = () => (/* c */ x);\n");
+    assert_eq!(
+        out.trim_end().lines().last(),
+        Some("export const f = () => x;")
+    );
+}
+
+/// esrap forces the whole argument list multiline when a comment sits on a line
+/// above the final argument. The test is against the unwrapped argument: with
+/// oxc's preserved parens the argument would start at the `(`, sharing the
+/// comment's line, and the rule would never fire.
+#[test]
+fn a_line_comment_above_the_last_argument_wraps_the_call() {
+    let out = tail("export function f() {\n\tg((// c\n\t\ta));\n}\n");
+    assert!(out.contains("g(\n\t\t// c\n\t\ta\n\t);"), "{out}");
+}

--- a/crates/rsvelte_esrap/Cargo.toml
+++ b/crates/rsvelte_esrap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rsvelte_esrap"
-version = "0.10.3"
+version = "0.10.4"
 edition = "2024"
 rust-version = "1.95"
 description = "A Rust port of esrap — prints an oxc AST to JavaScript with esrap's exact layout"

--- a/crates/rsvelte_esrap/src/lib.rs
+++ b/crates/rsvelte_esrap/src/lib.rs
@@ -56,6 +56,13 @@ pub struct PrintOptions {
     /// real `EmptyStatement` nodes that the official *compiler* output keeps, so
     /// that path sets this to byte-match. Default `false` (filter, = esrap/server).
     keep_empty_statements: bool,
+    /// Treat the top-level `Program` as carrying no location, like the
+    /// builder-made program upstream hands esrap. Its statement list then
+    /// discards every pending comment (esrap's `!node.loc` branch), so only a
+    /// nested body that does carry one re-finds its own comments. Only a caller
+    /// whose nested bodies keep real locations may set this — otherwise the
+    /// comments have nothing to be recovered by. Default `false`.
+    unlocated_program: bool,
 }
 
 impl Default for PrintOptions {
@@ -63,6 +70,7 @@ impl Default for PrintOptions {
         Self {
             indent: String::from("\t"),
             keep_empty_statements: false,
+            unlocated_program: false,
         }
     }
 }
@@ -72,6 +80,13 @@ impl PrintOptions {
     #[must_use]
     pub fn with_empty_statements(mut self, keep: bool) -> Self {
         self.keep_empty_statements = keep;
+        self
+    }
+
+    /// Declare the top-level `Program` unlocated (see [`Self::unlocated_program`]).
+    #[must_use]
+    pub fn with_unlocated_program(mut self, unlocated: bool) -> Self {
+        self.unlocated_program = unlocated;
         self
     }
 }

--- a/crates/rsvelte_esrap/src/lib.rs
+++ b/crates/rsvelte_esrap/src/lib.rs
@@ -83,7 +83,11 @@ impl PrintOptions {
         self
     }
 
-    /// Declare the top-level `Program` unlocated (see [`Self::unlocated_program`]).
+    /// Treat the top-level `Program` as carrying no location, like the
+    /// builder-made program upstream hands esrap: its statement list then
+    /// discards every pending comment, and only a nested body that does carry a
+    /// location re-finds its own. Only a caller whose nested bodies keep real
+    /// locations may set this — otherwise nothing can recover the comments.
     #[must_use]
     pub fn with_unlocated_program(mut self, unlocated: bool) -> Self {
         self.unlocated_program = unlocated;

--- a/crates/rsvelte_esrap/src/printer.rs
+++ b/crates/rsvelte_esrap/src/printer.rs
@@ -643,7 +643,13 @@ impl<'opt> Printer<'opt> {
 
     /// esrap's `reset_comment_index`: re-sync the cursor to the first comment
     /// at/after `node_start` (so a nested body doesn't replay earlier comments).
-    fn reset_comment_index(&mut self, node_start: u32) {
+    /// `None` is esrap's `!node.loc`, which discards every pending comment
+    /// instead of carrying the cursor forward.
+    fn reset_comment_index(&mut self, node_start: Option<u32>) {
+        let Some(node_start) = node_start else {
+            self.comment_index = self.comments.len();
+            return;
+        };
         if !self.has_loc(node_start) {
             return;
         }
@@ -794,13 +800,20 @@ impl<'opt> Printer<'opt> {
 
     pub fn print_program(&mut self, program: &Program, ctx: &mut Context) {
         let span = program.span();
+        // Upstream's program is builder-made and carries no `loc`, so its
+        // statement list discards the pending comments and only a nested body
+        // that does carry one re-finds them — which is why a comment inside a
+        // function body survives while a file header does not. Opt-in because
+        // the recovery needs located nested bodies, and rsvelte only has those
+        // where the chunks were re-parsed rather than assembled from builders.
+        let body_start = (!self.options.unlocated_program).then_some(span.start);
         // Directives (`"use strict"`) are a separate oxc node, but esrap (from
         // an acorn AST) sees them as leading string-literal ExpressionStatements
         // in `body`; thread them through the same `body` sequence so margins and
         // leading comments are computed identically.
         let mut elems: Vec<BodyElem> = program.directives.iter().map(BodyElem::Directive).collect();
         elems.extend(program.body.iter().map(BodyElem::Statement));
-        self.body_elems(&elems, span.start, span.end, ctx);
+        self.body_elems(&elems, body_start, span.end, ctx);
     }
 
     /// esrap's `body`: statements on their own lines, with a blank line between
@@ -816,7 +829,7 @@ impl<'opt> Printer<'opt> {
         ctx: &mut Context,
     ) {
         let elems: Vec<BodyElem> = statements.iter().map(BodyElem::Statement).collect();
-        self.body_elems(&elems, body_start, body_end, ctx);
+        self.body_elems(&elems, Some(body_start), body_end, ctx);
     }
 
     /// The element-based core of [`Self::body`], shared by `print_program` so a
@@ -824,7 +837,7 @@ impl<'opt> Printer<'opt> {
     fn body_elems(
         &mut self,
         elems: &[BodyElem],
-        body_start: u32,
+        body_start: Option<u32>,
         body_end: u32,
         ctx: &mut Context,
     ) {
@@ -1442,7 +1455,7 @@ impl<'opt> Printer<'opt> {
             .filter(|e| !matches!(e, ClassElement::TSIndexSignature(_)))
             .map(BodyElem::ClassMember)
             .collect();
-        self.body_elems(&elems, span.start, span.end, &mut child);
+        self.body_elems(&elems, Some(span.start), span.end, &mut child);
         if !child.empty() {
             ctx.indent();
             ctx.newline();
@@ -2916,7 +2929,12 @@ impl<'opt> Printer<'opt> {
 
         for (i, arg) in args.iter().enumerate() {
             let is_last = i == n - 1;
-            let arg_start = arg.span().start;
+            // Unwrapped, for the same reason the `ReturnStatement` rule is: an
+            // explicit paren would put the argument's start on the `(`, which can
+            // share the comment's line and hide it from the test below.
+            let arg_start = arg
+                .as_expression()
+                .map_or_else(|| arg.span().start, |e| unparen(e).span().start);
 
             // No `has_loc` guard needed: every comment offset is >= `loc_base` by
             // construction, so `c.start < arg_start` is already false for a
@@ -3580,7 +3598,7 @@ impl<'opt> Printer<'opt> {
         ctx.newline();
         let mut elems: Vec<BodyElem> = node.directives.iter().map(BodyElem::Directive).collect();
         elems.extend(node.body.iter().map(BodyElem::Statement));
-        self.body_elems(&elems, node.span.start, node.span.end, ctx);
+        self.body_elems(&elems, Some(node.span.start), node.span.end, ctx);
         ctx.dedent();
         ctx.newline();
         ctx.write("}");

--- a/crates/rsvelte_lint_types/Cargo.lock
+++ b/crates/rsvelte_lint_types/Cargo.lock
@@ -1106,7 +1106,7 @@ dependencies = [
 
 [[package]]
 name = "rsvelte_esrap"
-version = "0.10.3"
+version = "0.10.4"
 dependencies = [
  "compact_str",
  "memchr",


### PR DESCRIPTION
Third and last in the paren/comment series (#2433, #2514). This one is about comment **ownership**, not parens — it closes the 4 divergences those left, plus 5 more they did not surface.

## The rule

Upstream hands esrap a builder-made program with **no `loc`**. esrap's `reset_comment_index` treats that as "discard every pending comment":

```js
function reset_comment_index(node) {
  if (!node.loc) { comment_index = comments.length; return; }
  …
  comment_index = comments.findIndex(c => c.loc && node.loc && !before(c.loc.start, node.loc.start));
}
```

`body()` calls it at every statement list, so a nested body that *does* carry a location re-finds its own comments. That asymmetry is the whole behaviour: a comment inside a function / arrow-block / class body survives, a file header does not.

rsvelte returned early instead of discarding, and kept them all. Verified against the oracle on raw output — this is upstream, not a probe artifact:

```
input:  /** @type {number} */
        export const a = 1;
official: export const a = 1;          ← the JSDoc is gone
main:     /** @type {number} */        ← rsvelte kept it
          export const a = 1;
```

Upstream does the same on all four paths (module client/server, component client/server).

## Why this is opt-in

The recovery needs **located nested bodies**, and rsvelte only has those where the chunks were re-parsed rather than assembled from builders. Keying the rule on `loc_base` — my first attempt — reaches the server path too, whose nested bodies carry synthesized spans: the comments are discarded at the program and nothing can recover them. `reactive_label_comment_ownership` (3) and `split_coordinates` (3) caught exactly that, plus `sourcemap_gate` regressing 57 → 56 byte-identical outputs.

So it is `PrintOptions::with_unlocated_program`, set only by the client `.svelte.(js|ts)` module path. `has_loc` is a span-based proxy for "is synthesized"; it agrees with upstream's `node.loc` at the program but not at every nested body, and that gap is in the AST assembly, not the printer.

## Also fixed

The call-argument wrap rule had the same anchoring bug `ReturnStatement` had in #2514 — it measured the last argument's line at oxc's preserved `(`, which shares the comment's line:

```diff
-	g(// c
-	a);
+	g(
+		// c
+		a
+	);
```

## Verification

49 paren/comment shapes through the official compiler vs rsvelte, from one shared case list:

| | diverging from official |
|---|---|
| `origin/main` | **9 / 49** |
| this PR | **0 / 49** |

Five of the nine were **not** in the earlier count: this PR is what made top-level comment ownership observable at all.

**Corpus** — NAPI binding built separately per printer (`corpus:compile` reads a prebuilt `.corpus-cache/rsvelte.node` and never rebuilds it):

| | of the 40 changed outputs |
|---|---|
| byte-identical to official, before | **0** |
| byte-identical to official, after | **36** |
| moved closer to official | **40** |
| moved further | **0** |

```diff
-	/** Value of the search query */      // main, bits-ui command.svelte.ts
 	search: '',
```

`corpus:verify` passes on both printers with identical numbers (`match 13183`, `js-mismatch 0`, same 580 known warning failures).

**Suite**: 412 suites green, 0 failures. `cargo fmt` + `clippy --all-targets --all-features -D warnings` clean. `rsvelte_esrap` released as 0.10.4 with `rsvelte_core`'s exact pin and both lockfiles advanced.

New: `crates/rsvelte_core/tests/module_comment_ownership.rs` pins which comments survive and which do not, and the call wrap.

## Known remaining divergence

The **server** path still keeps top-level comments upstream drops. Fixing it means giving its assembled nested bodies real locations, which is an AST-assembly change, not a printer one. Not attempted here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q94UFSt4NWQ7JpZMaeAoMT
