### PR TITLE
fix(analyze): emit `svelte-ignore` comment-code warnings during the fragment walk

### DIFF
--- a/.changeset/svelte-ignore-warning-order.md
+++ b/.changeset/svelte-ignore-warning-order.md
@@ -1,0 +1,5 @@
+---
+'@rsvelte/compiler': patch
+---
+
+Emit `svelte-ignore` comment-code warnings (`legacy_code` / `unknown_code`) while walking the annotated node instead of batching them before the fragment walk, so they interleave with the surrounding warnings in the same order as the official compiler

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/shared/fragment.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/shared/fragment.rs
@@ -45,7 +45,9 @@ fn compute_all_preceding_ignores(
                 // Extract svelte-ignore codes and accumulate them
                 let extracted = extract_svelte_ignore_with_warnings(&comment.data, runes);
                 pending_ignores.extend(extracted.ignores);
-                pending_warnings.extend(extracted.warnings);
+                // The official scan walks the preceding comment run backwards from the
+                // annotated node, so the comment nearest it reports first.
+                pending_warnings.splice(..0, extracted.warnings);
                 // Comments themselves get None
                 result.push(None);
             }
@@ -107,31 +109,22 @@ pub fn analyze<'a, 'b: 'a>(
     // but only emit legacy_code/unknown_code warnings for non-Comment/non-Text nodes.
     let mut ignore_info = compute_all_preceding_ignores(&fragment.nodes, runes);
 
-    // Emit warnings from svelte-ignore comment validation (legacy_code, unknown_code).
-    // These are emitted only once per comment because only the first
-    // non-Comment/non-Text node collects from preceding comments.
-    for entry in ignore_info.iter().flatten() {
-        let (preceding, is_text) = entry;
-        // Only emit legacy_code/unknown_code warnings for non-Text nodes
-        if !is_text {
-            for warning in &preceding.warnings {
-                context
-                    .analysis
-                    .warnings
-                    .push(warnings::AnalysisWarning::new(
-                        warning.code.clone(),
-                        warning.message.clone(),
-                    ));
-            }
-        }
-    }
-
     for (idx, node) in fragment.nodes.iter_mut().enumerate() {
         // Take ownership of ignore codes to avoid cloning
-        let ignore_codes = ignore_info[idx]
-            .take()
-            .map(|(p, _)| p.ignores)
-            .unwrap_or_default();
+        let ignore_codes = match ignore_info[idx].take() {
+            Some((preceding, is_text)) => {
+                // The official `_` visitor extracts (and so reports) svelte-ignore codes
+                // as it reaches the annotated node, which interleaves these warnings with
+                // that node's own in source order. Text nodes only consume the codes.
+                if !is_text {
+                    for warning in preceding.warnings {
+                        context.analysis.warnings.push(warning);
+                    }
+                }
+                preceding.ignores
+            }
+            None => Vec::new(),
+        };
         let has_ignores = !ignore_codes.is_empty();
         if has_ignores {
             // Store ignored codes on element metadata for use during code generation

--- a/crates/rsvelte_core/tests/svelte_ignore_warning_order.rs
+++ b/crates/rsvelte_core/tests/svelte_ignore_warning_order.rs
@@ -1,0 +1,99 @@
+//! `svelte-ignore` comment-code warnings (`legacy_code` / `unknown_code`) must be
+//! emitted while walking the node the comments precede, so they interleave with
+//! that node's own warnings in source order — matching the `_` visitor in
+//! `2-analyze/index.js`.
+
+use rsvelte_core::{CompileOptions, GenerateMode, compile, compiler::CssMode};
+
+fn warnings(src: &str) -> Vec<(String, String)> {
+    compile(
+        src,
+        CompileOptions {
+            filename: Some("T.svelte".to_string()),
+            generate: GenerateMode::Client,
+            dev: false,
+            css: CssMode::External,
+            ..Default::default()
+        },
+    )
+    .expect("compile")
+    .warnings
+    .iter()
+    .map(|w| (w.code.clone(), w.message.clone()))
+    .collect()
+}
+
+fn codes(src: &str) -> Vec<String> {
+    warnings(src).into_iter().map(|(code, _)| code).collect()
+}
+
+/// `packages/svelte/tests/validator/samples/unknown-code/input.svelte`, verbatim.
+const UNKNOWN_CODE_FIXTURE: &str = r#"<svelte:options runes={true} />
+
+<!-- svelte-ignore a11y-missing-attribute -->
+<div>
+	<img src="this-is-fine.jpg">
+</div>
+
+<!-- svelte-ignore ally_missing_attribute -->
+<div>
+	<img src="this-is-fine.jpg">
+</div>
+
+<!-- svelte-ignore a11y-misplaced-scope -->
+<div scope></div>
+"#;
+
+#[test]
+fn comment_code_warnings_interleave_with_node_warnings() {
+    // Upstream sequence, measured against the official compiler at the pinned
+    // submodule: strictly source-ordered (lines 3, 5, 8, 10, 13, 14).
+    assert_eq!(
+        codes(UNKNOWN_CODE_FIXTURE),
+        vec![
+            "legacy_code",
+            "a11y_missing_attribute",
+            "unknown_code",
+            "a11y_missing_attribute",
+            "legacy_code",
+            "a11y_misplaced_scope",
+        ]
+    );
+}
+
+#[test]
+fn comment_code_warning_precedes_the_node_it_annotates() {
+    let src = r#"<svelte:options runes={true} />
+<!-- svelte-ignore a11y-missing-attribute -->
+<img src="a.jpg">
+<div role="invalid_role"></div>
+"#;
+    assert_eq!(
+        codes(src),
+        vec!["legacy_code", "a11y_missing_attribute", "a11y_unknown_role"]
+    );
+}
+
+#[test]
+fn consecutive_ignore_comments_emit_in_reverse_source_order() {
+    // Upstream scans the preceding comment run backwards from the annotated
+    // node, so the comment nearest the node reports first.
+    let src = r#"<svelte:options runes={true} />
+<!-- svelte-ignore foo-bar -->
+<!-- svelte-ignore baz-qux -->
+<div></div>
+"#;
+    let messages: Vec<String> = warnings(src)
+        .into_iter()
+        .map(|(_, message)| message)
+        .collect();
+    assert_eq!(messages.len(), 2, "got: {messages:?}");
+    assert!(
+        messages[0].contains("baz-qux"),
+        "expected `baz-qux` first, got: {messages:?}"
+    );
+    assert!(
+        messages[1].contains("foo-bar"),
+        "expected `foo-bar` second, got: {messages:?}"
+    );
+}


### PR DESCRIPTION
## What was broken

`svelte-ignore` comment-code warnings (`legacy_code` / `unknown_code`) were flushed in a single loop **before** the fragment's node walk began, in `2_analyze/visitors/shared/fragment.rs`. Every comment-code warning for a fragment therefore landed ahead of every warning produced by walking that fragment's nodes.

Measured on `packages/svelte/tests/validator/samples/unknown-code/input.svelte` (unmodified upstream fixture), against the official compiler at the pinned submodule `44a7813`:

| # | official | rsvelte (before) |
|---|---|---|
| 1 | `legacy_code` | `legacy_code` |
| 2 | `a11y_missing_attribute` | `unknown_code` |
| 3 | `unknown_code` | `legacy_code` |
| 4 | `a11y_missing_attribute` | `a11y_missing_attribute` |
| 5 | `legacy_code` | `a11y_missing_attribute` |
| 6 | `a11y_misplaced_scope` | `a11y_misplaced_scope` |

The multisets are equal; the sequences are not. Neither compiler sorts its warning list, so this is purely a difference in *when* the warning is pushed.

A second, same-observable divergence fell out of probing upstream: within one run of consecutive ignore comments, official emits the comment **nearest the annotated node first**. Measured:

```
<!-- svelte-ignore foo-bar -->
<!-- svelte-ignore baz-qux -->
<div></div>
```

official → `baz-qux` @ 3:19, then `foo-bar` @ 2:19. rsvelte (before) → `foo-bar`, then `baz-qux`.

## What upstream does, and what changed here

`packages/svelte/src/compiler/phases/2-analyze/index.js:100-117` — the catch-all `_` visitor. There is no pre-pass: as the walk reaches each non-`Comment`/non-`Text` fragment child it scans **backwards** over the preceding comment run and calls `extract_svelte_ignore`, which is what pushes `legacy_code` / `unknown_code`. Emitting at visit time is what puts the warning between the surrounding nodes' warnings for free; the backwards `for (let i = idx - 1; i >= 0; i--)` is what reverses a multi-comment run.

Both emission points are now aligned rather than papered over with a sort:

- the batch loop is deleted; the warnings are pushed inside the existing per-node loop, just before `push_ignore` (same relative position as upstream, which extracts before `push_ignore(ignores)`);
- the pre-pass accumulator prepends each comment's warnings instead of appending, reproducing the backwards scan.

The `!is_text` guard is unchanged: upstream's `_` visitor skips `Text`, and `Text.js` only re-extracts when it is actually reporting a `bidirectional_control_characters` match.

## Test

New `crates/rsvelte_core/tests/svelte_ignore_warning_order.rs`, 3 tests. Run against the parent commit they fail for exactly the predicted reason — the sequence, not the contents:

```
---- comment_code_warnings_interleave_with_node_warnings ----
assertion `left == right` failed
  left: ["legacy_code", "unknown_code", "legacy_code", "a11y_missing_attribute", "a11y_missing_attribute", "a11y_misplaced_scope"]
 right: ["legacy_code", "a11y_missing_attribute", "unknown_code", "a11y_missing_attribute", "legacy_code", "a11y_misplaced_scope"]

---- consecutive_ignore_comments_emit_in_reverse_source_order ----
expected `baz-qux` first, got: ["`foo-bar` is not a recognised code…", "`baz-qux` is not a recognised code…"]
```

The third test (`comment_code_warning_precedes_the_node_it_annotates`) passed before and after — it is a single-comment-run shape the old batch happened to order correctly, kept as a guard that the move did not push the warning *after* its node.

All three pass after the change.

## Ratchets: no regeneration needed

Checked rather than assumed, because this changes warning order globally:

- `compatibility/validator-known-failures.json` — `cargo test --release -p rsvelte_core --test validator` is green, both directions. `unknown-code` still fails (the `legacy_code`/`unknown_code` warnings still carry no span; upstream passes the comment offset `prev.start + 4`), so the entry stays and no `.md` edit is needed. That span defect is the *other* half of #2498's analysis and is deliberately not touched here.
- `compatibility/warning-known-failures.*` / `warning-position-known-failures.*` — **structurally cannot see this**. `verify.mjs` compares codes as a multiset (`codeBag` / `bagDiff`) and positions as `.sort()`ed lists. Warning order is invisible to that gate; only the validator suite's zipped `warnings_match` observes it.
- `compatibility/lint-known-failures.json` — `lint-verify.mjs` accumulates findings into a `Set` per file. Order-insensitive.
- output ratchets (`known-failures.{client,server,client-dev}.json`) and the generated matrix — warnings are not part of the compared output, and `ignored_codes` (the only thing that reaches codegen) is untouched: only the warning vector's order changed, not the ignore-code vector's.

## Also run

`cargo fmt --all`, `cargo clippy --all-targets --all-features -- -D warnings` (clean), `--test validator`, `--test compiler_errors`, and the `svelte_ignore_*` / `warning_filter` / `a11y_*` / `validator_message_wording` / `comment_whitespace_run_1975` suites — all green.

`--test compiler_fixtures` is red in this worktree for an environment reason only (generated fixtures absent — it prints the "run generate-fixtures" banner); it compares generated JS, which this change cannot affect.

## Out of scope, reported not fixed

Comment-code warnings are pushed straight onto `analysis.warnings` and so bypass the ignore stack, where upstream's `w()` consults it. Measured on the same pinned submodule:

```svelte
<svelte:options runes={true} />
<!-- svelte-ignore unknown_code -->
<div>
  <!-- svelte-ignore zzz-yyy -->
  <span></span>
</div>
```

official → 0 warnings (the outer ignore suppresses it). rsvelte → 1 × `unknown_code`. This is a *presence* defect, not an ordering one, and unlike everything above the corpus warning-code ratchet **would** see it (multiset comparison), so it needs a full corpus run and belongs in its own PR.

Fixes #2498
