### PR TITLE
fix(compiler): resolve the component name's conflict suffix before the template walk (#2478)

### DIFF
--- a/.changeset/component-name-conflict-before-walk.md
+++ b/.changeset/component-name-conflict-before-walk.md
@@ -1,0 +1,5 @@
+---
+'@rsvelte/compiler': patch
+---
+
+fix(analyze): resolve the component name's conflict suffix before the template walk, so warnings name the component the way codegen does

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/mod.rs
@@ -529,6 +529,10 @@ pub(crate) fn analyze_prepared_component_with_retained(
         }
     }
 
+    // Must precede the walks: `svelte_self_deprecated` interpolates `analysis.name`
+    // while the template is being visited.
+    deconflict_component_name(ast, &mut analysis);
+
     // Analyze the template using visitors.
     // Take a pointer to the arena to avoid borrow conflict with &mut ast.
     let arena_ptr = &ast.arena as *const crate::ast::arena::ParseArena;
@@ -813,76 +817,80 @@ pub(crate) fn analyze_prepared_component_with_retained(
     // handles CSS hash injection in its transform visitor.
     synthesize_class_style_attributes(&mut ast.fragment, &analysis);
 
-    // Deconflict component name with existing declarations and references.
-    // This mirrors the official Svelte compiler's `module.scope.generate(component_name)`
-    // which ensures the exported function name doesn't shadow imported identifiers or
-    // other declarations/references. For example, if a component uses `<Countdown .../>`
-    // (self-reference) and the filename is also `Countdown.svelte`, the function name
-    // should be `Countdown_1`.
-    // Reference: svelte/packages/svelte/src/compiler/phases/2-analyze/index.js L468
-    {
-        // Collect all names that are used across all scopes (declarations + references)
-        // Use &str references to avoid String allocations.
-        // The root scope (analysis.root.scope) already has all declarations from all
-        // child scopes merged, so we only need to iterate it once for declarations.
-        // We still need to iterate all_scopes for references (those are not merged).
-        let mut used_names: rustc_hash::FxHashSet<&str> = rustc_hash::FxHashSet::default();
-        // Root scope has all declarations merged from all scopes
-        for key in analysis.root.scope.declarations.keys() {
-            used_names.insert(key.as_str());
-        }
-        // Collect references from all scopes (including root)
-        for scope in &analysis.root.all_scopes {
-            for r in &scope.references {
-                used_names.insert(r.name.as_str());
-            }
-        }
-        // Also collect component names from template AST since they're identifiers
-        // that need deconfliction but may not be in scope references
-        collect_template_component_names(&ast.fragment.nodes, &mut used_names);
+    Ok(analysis)
+}
 
-        // Walk script JSON to collect all identifier names that appear as references.
-        // This mirrors the official Svelte compiler's `scope.root.conflicts` set, which
-        // gets populated when a top-level identifier reference doesn't resolve to a
-        // declared binding (i.e., it's a global like `JSON`, `Math`, etc.).
-        // We only add identifiers that are NOT already declared, to approximate
-        // "unbound references at the top level".
-        let mut global_names: rustc_hash::FxHashSet<String> = rustc_hash::FxHashSet::default();
-        if let Some(script) = ast.instance.as_ref() {
-            collect_identifier_names_from_expression(&script.content, &mut global_names);
+/// Deconflict the component name with existing declarations and references.
+///
+/// Mirrors the official Svelte compiler's `module.scope.generate(component_name)`,
+/// which ensures the exported function name doesn't shadow imported identifiers or
+/// other declarations/references. For example, if a component uses `<Countdown .../>`
+/// (self-reference) and the filename is also `Countdown.svelte`, the function name
+/// should be `Countdown_1`.
+///
+/// Reference: svelte/packages/svelte/src/compiler/phases/2-analyze/index.js L476.
+/// Upstream resolves the name before any of the walks, so a diagnostic emitted
+/// during them (`svelte_self_deprecated`) interpolates the deconflicted name.
+fn deconflict_component_name(ast: &Root<'_>, analysis: &mut ComponentAnalysis) {
+    // Collect all names that are used across all scopes (declarations + references)
+    // Use &str references to avoid String allocations.
+    // The root scope (analysis.root.scope) already has all declarations from all
+    // child scopes merged, so we only need to iterate it once for declarations.
+    // We still need to iterate all_scopes for references (those are not merged).
+    let mut used_names: rustc_hash::FxHashSet<&str> = rustc_hash::FxHashSet::default();
+    // Root scope has all declarations merged from all scopes
+    for key in analysis.root.scope.declarations.keys() {
+        used_names.insert(key.as_str());
+    }
+    // Collect references from all scopes (including root)
+    for scope in &analysis.root.all_scopes {
+        for r in &scope.references {
+            used_names.insert(r.name.as_str());
         }
-        if let Some(script) = ast.module.as_ref() {
-            collect_identifier_names_from_expression(&script.content, &mut global_names);
-        }
-        // Template expressions also produce references (`scope.reference()` is
-        // called on every identifier inside `{...}` mustaches, attribute values,
-        // directives and block heads). An unbound one (e.g. `{progress.current}`
-        // with no `let progress`) is a global and must enter `root.conflicts`.
-        collect_template_reference_names(&ast.fragment.nodes, &mut global_names);
-        // Filter to only those NOT already declared (true globals/unbound).
-        global_names.retain(|n| !used_names.contains(n.as_str()));
+    }
+    // Also collect component names from template AST since they're identifiers
+    // that need deconfliction but may not be in scope references
+    collect_template_component_names(&ast.fragment.nodes, &mut used_names);
 
-        // Unbound (global) references at the top level are added to
-        // `scope.root.conflicts` by the official compiler's `scope.reference()`
-        // (scope.js: "no binding was found ... which means this is a global").
-        // Mirror that so generated template variables (e.g. a `<canvas>` local
-        // named `canvas`) avoid colliding with a referenced-but-undeclared global
-        // of the same name and get suffixed (`canvas_1`).
-        for name in &global_names {
-            analysis.root.conflicts.insert(name.clone());
-        }
+    // Walk script JSON to collect all identifier names that appear as references.
+    // This mirrors the official Svelte compiler's `scope.root.conflicts` set, which
+    // gets populated when a top-level identifier reference doesn't resolve to a
+    // declared binding (i.e., it's a global like `JSON`, `Math`, etc.).
+    // We only add identifiers that are NOT already declared, to approximate
+    // "unbound references at the top level".
+    let mut global_names: rustc_hash::FxHashSet<String> = rustc_hash::FxHashSet::default();
+    if let Some(script) = ast.instance.as_ref() {
+        collect_identifier_names_from_expression(&script.content, &mut global_names);
+    }
+    if let Some(script) = ast.module.as_ref() {
+        collect_identifier_names_from_expression(&script.content, &mut global_names);
+    }
+    // Template expressions also produce references (`scope.reference()` is
+    // called on every identifier inside `{...}` mustaches, attribute values,
+    // directives and block heads). An unbound one (e.g. `{progress.current}`
+    // with no `let progress`) is a global and must enter `root.conflicts`.
+    collect_template_reference_names(&ast.fragment.nodes, &mut global_names);
+    // Filter to only those NOT already declared (true globals/unbound).
+    global_names.retain(|n| !used_names.contains(n.as_str()));
 
-        let mut name = analysis.name.clone();
-        let base = name.clone();
-        let mut counter = 1u32;
-        while used_names.contains(name.as_str()) || global_names.contains(&name) {
-            name = format!("{}_{}", base, counter);
-            counter += 1;
-        }
-        analysis.name = name;
+    // Unbound (global) references at the top level are added to
+    // `scope.root.conflicts` by the official compiler's `scope.reference()`
+    // (scope.js: "no binding was found ... which means this is a global").
+    // Mirror that so generated template variables (e.g. a `<canvas>` local
+    // named `canvas`) avoid colliding with a referenced-but-undeclared global
+    // of the same name and get suffixed (`canvas_1`).
+    for name in &global_names {
+        analysis.root.conflicts.insert(name.clone());
     }
 
-    Ok(analysis)
+    let mut name = analysis.name.clone();
+    let base = name.clone();
+    let mut counter = 1u32;
+    while used_names.contains(name.as_str()) || global_names.contains(&name) {
+        name = format!("{}_{}", base, counter);
+        counter += 1;
+    }
+    analysis.name = name;
 }
 
 /// Synthesize empty class/style attributes for elements that need them.

--- a/crates/rsvelte_core/tests/component_name_conflict_before_walk_2478.rs
+++ b/crates/rsvelte_core/tests/component_name_conflict_before_walk_2478.rs
@@ -1,0 +1,97 @@
+//! Upstream resolves the component name against the module scope
+//! (`module.scope.generate`) *before* the template walk, so a diagnostic emitted
+//! during the walk interpolates the deconflicted name. rsvelte applied the
+//! conflict suffix after the walk, so `svelte_self_deprecated` printed the
+//! pre-conflict name while codegen used the suffixed one.
+//!
+//! `svelte_self_deprecated` is the only phase-2 diagnostic that reads
+//! `analysis.name`, so it is also the only observer of the ordering; the corpus
+//! warning gate compares `(code, line, column)` and never the message.
+
+use rsvelte_core::{CompileOptions, GenerateMode, compile};
+
+/// `input.svelte` yields the component name `Input`, which the instance script
+/// already declares — upstream therefore names the component `Input_1`.
+const CONFLICTING: &str = "<script>\n\
+\tlet { n = 5 } = $props();\n\
+\tconst Input = 1;\n\
+\tconsole.log(Input);\n\
+</script>\n\
+\n\
+{#if n === 0}\n\
+\t<p>lift-off!</p>\n\
+{:else}\n\
+\t<svelte:self n={n - 1} />\n\
+{/if}\n";
+
+/// Same component with nothing shadowing `Input`, as the negative control: the
+/// name must stay unsuffixed, so a fix that suffixes unconditionally fails here.
+const CLEAN: &str = "<script>\n\
+\tlet { n = 5 } = $props();\n\
+</script>\n\
+\n\
+{#if n === 0}\n\
+\t<p>lift-off!</p>\n\
+{:else}\n\
+\t<svelte:self n={n - 1} />\n\
+{/if}\n";
+
+fn compiled(src: &str) -> (String, String) {
+    let result = compile(
+        src,
+        CompileOptions {
+            filename: Some("input.svelte".to_string()),
+            generate: GenerateMode::Client,
+            dev: false,
+            ..Default::default()
+        },
+    )
+    .expect("compile");
+
+    let message = result
+        .warnings
+        .iter()
+        .find(|w| w.code == "svelte_self_deprecated")
+        .expect("svelte_self_deprecated was not emitted")
+        .message
+        .clone();
+
+    (message, result.js.code)
+}
+
+#[test]
+fn warning_names_the_deconflicted_component() {
+    let (message, _) = compiled(CONFLICTING);
+    assert!(
+        message.contains("import Input_1 "),
+        "expected the deconflicted name `Input_1`, got: {message}"
+    );
+}
+
+/// The warning and the emitted function must agree — that agreement is what the
+/// ordering buys, and asserting only the message would let them drift apart.
+#[test]
+fn warning_and_codegen_agree_on_the_name() {
+    let (message, js) = compiled(CONFLICTING);
+    assert!(
+        js.contains("function Input_1("),
+        "codegen must still deconflict to `Input_1`, got:\n{js}"
+    );
+    assert!(
+        message.contains("import Input_1 "),
+        "warning must name what codegen emitted, got: {message}"
+    );
+}
+
+#[test]
+fn unconflicted_component_keeps_its_plain_name() {
+    let (message, js) = compiled(CLEAN);
+    assert!(
+        message.contains("import Input "),
+        "expected the plain name `Input`, got: {message}"
+    );
+    assert!(
+        js.contains("function Input("),
+        "codegen must not suffix an unconflicted name, got:\n{js}"
+    );
+}


### PR DESCRIPTION
## What was broken

rsvelte applied the component name's conflict-avoidance suffix at the very end of `analyze_component`, **after** the template had been walked. Any diagnostic emitted during the walk that interpolates `analysis.name` therefore printed the pre-conflict name, while codegen — reading the same field later — emitted the suffixed one. The two disagreed.

Input (`filename: input.svelte`, so the component name is `Input`, which the instance script already declares):

```svelte
<script>
	let { n = 5 } = $props();
	const Input = 1;
	console.log(Input);
</script>

{#if n === 0}
	<p>lift-off!</p>
{:else}
	<svelte:self n={n - 1} />
{/if}
```

| | warning identifier | emitted function |
|---|---|---|
| official (svelte 5.56.8, the pinned submodule) | `Input_1` | `Input_1` |
| rsvelte before this PR | `Input` | `Input_1` |

The official numbers are measured, not assumed — the oracle above was run against `submodules/svelte` at the pinned SHA `44a7813`.

## Scope: enumerated, not assumed

The issue asked for the enumeration first, because it decides whether this is one emission site or a genuine reordering. Grepping every read of `analysis.name` in phase 2:

- rsvelte: `visitors/svelte_self.rs` (the emission site) and `mod.rs` (the deconfliction itself).
- upstream: `2-analyze/visitors/SvelteSelf.js`.

So `svelte_self_deprecated` is the **only** phase-2 diagnostic that reads the name — on both sides. It sits in the template walk, which is why the walk is the boundary that matters.

## What this matches upstream

`2-analyze/index.js:476` computes `const name = module.scope.generate(options.name ?? component_name)` before the `analysis` object is built and before `walk_module` / `walk_instance` / the template walk. This PR extracts rsvelte's deconfliction block into `deconflict_component_name` and calls it immediately before `visitors::analyze_template`.

Placed before the template walk rather than before the script walks, which is where upstream puts it: no phase-2 script-walk diagnostic reads `analysis.name` (the enumeration above), so the observable behaviour is identical, and the later position keeps every contribution the script walk makes to rsvelte's `used_names` set. rsvelte's set is a broader approximation of upstream's `module.scope.references ∪ declarations ∪ root.conflicts`, so moving it earlier than necessary would have shrunk it for no diagnostic gain.

## The two orderings were shown to agree, not assumed to

The issue flagged the real risk: `analysis.name` feeds codegen, so the reordering is only safe if `used_names` / `global_names` are already complete before the walk. Rather than argue it from the source, I measured it.

A temporary probe recomputed the name at the **old** post-walk position and asserted equality with the new pre-walk result, then ran the whole fixture corpus (snapshot, ssr, css, validator, compiler-errors, sourcemaps, runtime legacy/runes/browser, hydration). **Zero disagreements.**

The probe carries a positive control: gated behind `RSVELTE_PROBE_PERTURB`, perturbing the pre-walk name made it fire immediately (`left: "Await_block_scope_perturbed", right: "Await_block_scope"`), so the zero above is a real zero and not a probe that cannot move. The probe and its control were removed before committing; `grep` for `probe_base` / `PROBE` / `PERTURB` in the diff is clean.

Two structural facts that back this up:
- The CSS hash does **not** read `analysis.name` — `analyze_css` derives its own `component_name` from the filename, matching upstream, which passes `component_name` (not `name`) to `cssHash`. So the reordering cannot move a hash.
- No visitor reads `analysis.root.conflicts`, so populating it earlier is unobservable to the walk.

## How the test fails before the fix

`crates/rsvelte_core/tests/component_name_conflict_before_walk_2478.rs`, run on the parent commit:

```
---- warning_and_codegen_agree_on_the_name stdout ----
warning must name what codegen emitted, got: `<svelte:self>` is deprecated —
use self-imports (e.g. `import Input from './Input.svelte'`) instead

---- warning_names_the_deconflicted_component stdout ----
expected the deconflicted name `Input_1`, got: ... `import Input from './Input.svelte'` ...

test result: FAILED. 1 passed; 2 failed
```

That is the predicted failure and no other: `warning_and_codegen_agree_on_the_name` asserts `function Input_1(` in the JS **first**, and that half passed — so codegen was already correct and only the message lagged, which is exactly the claimed defect. The third test (`unconflicted_component_keeps_its_plain_name`) is the negative control; it passes on both sides, so a fix that suffixed unconditionally would not have been mistaken for a correct one.

## Ratchets: no regeneration needed

- **Warning ratchets** (`compatibility/warning-known-failures.*`) compare `(code, line, column)` only — `normalizeWarnings` in `scripts/compat-corpus/compile.mjs` drops the message text by design. This PR changes only message text, and moves no position and no code. Unaffected.
- **Output ratchets** (`compatibility/known-failures.{client,server,client-dev}.json`) would notice a changed component name in generated JS. The probe run above found no name changes anywhere in the fixture corpus, and the fixture corpus is the population these ratchets' inputs are drawn from. Unaffected.

No `*known-failures*` file is touched by this PR, by hand or otherwise. If a reviewer wants the corpus re-confirmed rather than inferred, the command is `pnpm run corpus:verify` (full) or the cheap `pnpm run corpus:matrix`; I did not run either locally because the machine is under disk pressure.

## Out of scope, reported not fixed

The same message still prints `./Input.svelte` where official prints `./input.svelte` — rsvelte derives the basename as `format!("{}.svelte", component_name)` instead of from the filename. That is #2411, fixed by the open PR #2477, which touches `svelte_self.rs` and the warning ratchets. This PR deliberately does not touch that file, and its assertions are written against the identifier only so the two do not collide. Note for whoever merges second: once both land, the basename becomes filename-derived, so it is unaffected by the suffix this PR now applies earlier.

`validator/samples/svelte-self-deprecated` remains listed in `compatibility/validator-known-failures.json` for the unrelated missing-span cause, so it still would not have observed either half.

Fixes #2478
