### PR TITLE
fix(compiler): keep a legacy `$:` statement whole across a `//` line

### DIFF
--- a/.changeset/reactive-continuation-boundary.md
+++ b/.changeset/reactive-continuation-boundary.md
@@ -1,0 +1,10 @@
+---
+"@rsvelte/compiler": patch
+---
+
+fix(compiler): keep a legacy `$:` statement whole across a `//` line
+
+The two accumulation loops in the server legacy `$:` reorder disagreed on
+whether a `// …` line ends a continuation. They now share one line
+classification, and a comment neither ends the statement nor completes it, so
+`$: total =` / `// c` / `a + b;` stays one statement as official emits it.

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/transform_legacy.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/transform_legacy.rs
@@ -823,6 +823,33 @@ fn scan_reactive_line(line: &str, mut depth: i32, in_template: bool) -> (i32, bo
     (depth, false)
 }
 
+/// How one line is treated while accumulating the continuation lines of a `$:`
+/// statement.
+enum ContinuationLine {
+    /// Ends the statement.
+    Boundary,
+    /// Part of the statement, but carries no continuation signal of its own, so
+    /// whether the statement is complete is decided by the next code line.
+    Comment,
+    Code,
+}
+
+/// Both accumulation loops below must share this classification, or the decision
+/// scan mis-routes a statement the collection scan then splits differently.
+fn classify_continuation_line(trimmed: &str, in_template: bool) -> ContinuationLine {
+    // Inside a template literal every line is literal text.
+    if in_template {
+        return ContinuationLine::Code;
+    }
+    if trimmed.is_empty() || trimmed.starts_with("$:") || trimmed.starts_with("function ") {
+        ContinuationLine::Boundary
+    } else if trimmed.starts_with("//") {
+        ContinuationLine::Comment
+    } else {
+        ContinuationLine::Code
+    }
+}
+
 // The only live caller is `{@const}` lowering, whose input is a declaration, so no `$:`
 // reaches this in a shipping compile.
 pub(crate) fn reorder_reactive_statements_after_functions(script: &str) -> String {
@@ -845,8 +872,6 @@ pub(crate) fn reorder_reactive_statements_after_functions(script: &str) -> Strin
         let mut needs = false;
         let mut in_reactive_multiline = false;
         let mut reactive_depth: i32 = 0;
-        // Threaded like the collection loop below; if the two disagree on where a
-        // block ends, this scan mis-routes.
         let mut in_template = false;
         let mut i = 0;
         while i < lines.len() {
@@ -906,13 +931,8 @@ pub(crate) fn reorder_reactive_statements_after_functions(script: &str) -> Strin
                         i += 1;
                         while i < lines.len() {
                             let nt = lines[i].trim();
-                            // Inside a template literal these are literal text, not
-                            // statement boundaries.
-                            if !acc_template
-                                && (nt.is_empty()
-                                    || nt.starts_with("$:")
-                                    || nt.starts_with("function "))
-                            {
+                            let kind = classify_continuation_line(nt, acc_template);
+                            if matches!(kind, ContinuationLine::Boundary) {
                                 break;
                             }
                             (acc_depth, acc_template) =
@@ -945,7 +965,12 @@ pub(crate) fn reorder_reactive_statements_after_functions(script: &str) -> Strin
                             } else {
                                 false
                             };
-                            if !is_cont && !following_starts && acc_depth <= 0 && !acc_template {
+                            if !matches!(kind, ContinuationLine::Comment)
+                                && !is_cont
+                                && !following_starts
+                                && acc_depth <= 0
+                                && !acc_template
+                            {
                                 break;
                             }
                         }
@@ -1053,14 +1078,8 @@ pub(crate) fn reorder_reactive_statements_after_functions(script: &str) -> Strin
                     while i < lines.len() {
                         let next = lines[i];
                         let next_trimmed = next.trim();
-                        // Inside a template literal these are literal text, not
-                        // statement boundaries.
-                        if !acc_template
-                            && (next_trimmed.is_empty()
-                                || next_trimmed.starts_with("$:")
-                                || next_trimmed.starts_with("function ")
-                                || next_trimmed.starts_with("//"))
-                        {
+                        let kind = classify_continuation_line(next_trimmed, acc_template);
+                        if matches!(kind, ContinuationLine::Boundary) {
                             break;
                         }
                         stmt_lines.push(next);
@@ -1095,7 +1114,8 @@ pub(crate) fn reorder_reactive_statements_after_functions(script: &str) -> Strin
                             false
                         };
                         i += 1;
-                        if !next_is_continuation
+                        if !matches!(kind, ContinuationLine::Comment)
+                            && !next_is_continuation
                             && !following_starts_cont
                             && accumulated_depth <= 0
                             && !acc_template
@@ -2281,6 +2301,47 @@ mod tests {
             extract_simple_assignments("const t = '\u{65e5}\u{672c}'; total = t.length;"),
             vec!["t".to_string(), "total".to_string()]
         );
+    }
+
+    #[test]
+    fn line_comment_does_not_end_a_reactive_continuation() {
+        // Official keeps `$: total = a + b` whole across an interleaved `// …` line.
+        for (script, stmt) in [
+            (
+                "let foo = 1;\n$: total =\n// pick the sum\na + b;\nlet after = 2;\n",
+                "$: total =\n// pick the sum\na + b;",
+            ),
+            (
+                "let foo = 1;\n$: total =\na +\n// second operand\nb;\nlet after = 2;\n",
+                "$: total =\na +\n// second operand\nb;",
+            ),
+        ] {
+            let out = reorder_reactive_statements_after_functions(script);
+            assert!(out.contains(stmt), "statement split at the comment: {out}");
+        }
+    }
+
+    #[test]
+    fn both_reactive_loops_share_one_line_classification() {
+        // A comment is neither a boundary nor a line that can complete the
+        // statement; the two accumulation loops used to disagree about the first
+        // half of that.
+        assert!(matches!(
+            classify_continuation_line("// pick the sum", false),
+            ContinuationLine::Comment
+        ));
+        for line in ["", "$: other = 1;", "function f() {}"] {
+            assert!(matches!(
+                classify_continuation_line(line, false),
+                ContinuationLine::Boundary
+            ));
+        }
+        for line in ["", "$: other = 1;", "function f() {}", "// c"] {
+            assert!(matches!(
+                classify_continuation_line(line, true),
+                ContinuationLine::Code
+            ));
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Which loop matched official

`reorder_reactive_statements_after_functions` accumulates the continuation lines of a `$:`
statement twice, and the two break-sets disagreed on `//`:

| loop | break-set (before) |
|---|---|
| `needs_reorder` decision scan | `is_empty()` \| `"$:"` \| `"function "` |
| collection scan | those **plus** `"//"` |

Official was run to settle it (`submodules/svelte` @ 5.56.8, `generate: 'server'`) on the two
shapes #2387 lists as unprobed — a `//` as the first line after the header, and a `//` in the
middle of a continuation:

```svelte
<script>
	export let a = 1;
	export let b = 2;
	let total;
	$: total =
		a +
		// second operand
		b;
	let after = 3;
</script>
```

```js
	// second operand
	let after = 3;

	$: total = a + b;
```

The comment is relocated and the statement stays whole: `//` is **not** a statement boundary.
The **decision scan is the one that matched official**; the `"//"` entry in the collection scan
is the defect. Same result for the first-line-after-the-header shape.

## The fix

Both loops now go through one `classify_continuation_line`, so a break-set can no longer move in
one loop without moving in the other:

```rust
enum ContinuationLine { Boundary, Comment, Code }
```

Removing `"//"` from the collection scan is necessary but **not sufficient** — see below.

## What changes for which input

`let foo = 1;` / `$: total =` / `// pick the sum` / `a + b;` / `let after = 2;`

| | statement collected |
|---|---|
| `origin/main` | `$: total =` — header only, comment and body demoted to ordinary code |
| `"//"` removed from the collection set only | `$: total =` + `// pick the sum` — still no body |
| this PR | `$: total =` + `// pick the sum` + `a + b;` |

The middle row is a second layer #2387 does not predict, and it is why the unification the issue
proposes is not on its own the fix. Once `//` stops being a boundary the comment line is
consumed — and then the loop's "does this line complete the statement?" test runs *on the
comment*: its last character is not a continuation operator and the next line does not start with
one, so the loop breaks there instead. A comment line carries no continuation signal of its own,
so `ContinuationLine::Comment` also suppresses that completeness test and lets the next code line
decide. Both loops apply it, so they stay in step.

## How the tests fail before the fix

`line_comment_does_not_end_a_reactive_continuation` calls the function directly (as the six
existing tests at `transform_legacy.rs:2082-2290` do) and asserts the whole statement survives.
Measured, not predicted — with `origin/main`'s collection-scan break restored:

```
---- line_comment_does_not_end_a_reactive_continuation stdout ----
statement split at the comment: let foo = 1;
// pick the sum
a + b;
let after = 2;

$: total =
```

and with only the break-sets unified (the middle row above):

```
statement split at the comment: let foo = 1;
a + b;
let after = 2;

$: total =
// pick the sum
```

`both_reactive_loops_share_one_line_classification` pins the shared classification, which kills
the *opposite* unification — adding `"//"` to the decision scan instead of removing it from the
collection scan. That mutant fails both tests. It is worth having its own test because for
well-formed input the decision scan's treatment of `//` never changes `needs_reorder` on its own:
the accumulation only reaches a comment while the statement is still incomplete, so a code line
always follows it and forces `needs = true` either way.

Mutant results, all measured:

| mutant | `line_comment_…` | `…share_one_line_classification` |
|---|---|---|
| `origin/main` (collection scan only breaks on `//`) | FAIL | pass |
| break-sets unified, completeness test unchanged | FAIL | pass |
| `//` added to the shared boundary set (opposite unification) | FAIL | FAIL |

## Ratchets

**No regeneration needed, and no compiled output moves.**
`reorder_reactive_statements_after_functions` is `pub(crate)` and its only live caller is
`{@const}` lowering (`server/ast/visitors/declaration_tag.rs:346` → `transform_script.rs:266`),
which passes a declaration; `has_reactive` is therefore false and the function returns before
either loop. No `$:` reaches it in a shipping compile, so
`known-failures.{client,server,client-dev}.json` and the warning ratchets are untouched. Nothing
was hand-edited.

## What was run

`cargo fmt --check`; `cargo clippy -p rsvelte_core --all-targets --all-features -- -D warnings`;
`cargo test --release -p rsvelte_core --lib` (1463 passed) plus the fixture-free `{@const}` /
legacy-`$:` suites — `ssr_const_scope_2059`, `ssr_const_instance_shadow_2144`,
`const_tag_pattern_pin`, `const_tag_multibyte`, `reactive_block_comment_delimiter_2351`,
`legacy_pre_effect_comment_2355`, `reactive_label_comment_ownership`,
`legacy_reactive_member_compound_2373`, `compile_both_parity`, `labeled_statement_preserved` (36
passed).

The fixture suites (`ssr`, `runtime`, `compiler_fixtures`) were **not** run locally: this
worktree has no generated `fixtures/`, and generating them was not possible here. They panic
rather than silently pass when fixtures are absent, so there is no false green — CI covers them.

## Out of scope, found on the way

Two adjacent defects in the same accumulation, left alone:

- A comment line also blocks the *lookahead*: in `$: total = a` / `// wait` / `+ b;`, the
  `next_starts_continuation` probe reads the comment, not the `+` line, so accumulation never
  starts. Both loops agree here, so it is not this issue.
- `sort_reactive_in_place` (`:1211`) has a third copy of the break-set. It agrees on `//`, but it
  never threads the template-literal state, so a `$:`, blank or `function ` line *inside* a
  template literal is still a boundary there.

Fixes #2387
