### PR TITLE
fix(css): warn on a nested rule whose enclosing selector matches no ancestor

### DIFF
--- a/.changeset/nested-css-ancestor-warning.md
+++ b/.changeset/nested-css-ancestor-warning.md
@@ -1,0 +1,5 @@
+---
+'@rsvelte/compiler': patch
+---
+
+Report `css_unused_selector` for a nested rule whose enclosing selector matches no ancestor

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/css.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/css.rs
@@ -1542,6 +1542,12 @@ fn is_complex_selector_unused_impl(complex: &Value, ctx: &CssContext) -> bool {
             return true;
         }
 
+        // ...and, more precisely, whether the enclosing selectors match an
+        // *ancestor* of a match rather than merely existing somewhere.
+        if is_nested_selector_unused_against_ancestors(rel_selectors, ctx) {
+            return true;
+        }
+
         // NestingSelector (&) compound check: When a relative selector contains & combined
         // with other simple selectors (e.g., &.b inside .a {}), the compound meaning is that
         // the element must satisfy BOTH the parent rule's constraints AND the current ones.
@@ -1753,6 +1759,42 @@ fn is_parent_chain_unused(ctx: &CssContext) -> bool {
     }
 
     false
+}
+
+/// Returns `true` when a nested rule without an explicit `&` cannot match,
+/// because no element satisfying it has an ancestor chain satisfying the
+/// enclosing rules.
+///
+/// Upstream `get_relative_selectors` prepends an implicit `&` + descendant
+/// combinator to such a selector, so `.grand { .foo > .a { … } }` resolves to
+/// `.grand .foo > .a` and `apply_selector` walks the real ancestor chain.
+/// [`is_parent_chain_unused`] only asks whether each enclosing selector matches
+/// *some* element, which keeps the rule alive when `.grand` exists elsewhere in
+/// the component.
+fn is_nested_selector_unused_against_ancestors(rel_selectors: &[Value], ctx: &CssContext) -> bool {
+    if ctx.has_dynamic_elements
+        || ctx.dom_structure.elements.is_empty()
+        || !structural_ancestry_is_lexical(ctx)
+    {
+        return false;
+    }
+    // Rejects an explicit `&` too, which upstream resolves compound-wise instead
+    // of prepending — those shapes are handled by the nesting-specific checks.
+    if !level_is_structurally_evaluable(rel_selectors) {
+        return false;
+    }
+
+    let parent_preludes = ctx.parent_preludes.borrow();
+    let Some(chains) = build_parent_chains(&parent_preludes, parent_preludes.len()) else {
+        return false;
+    };
+
+    chains.iter().all(|prefix| {
+        let mut chain = prefix.clone();
+        chain.push(with_descendant_head(&rel_selectors[0]));
+        chain.extend(rel_selectors[1..].iter().cloned());
+        is_structural_descendant_chain_unused(&chain, ctx)
+    })
 }
 
 /// Returns `true` when `rel_selectors` contains a NestingSelector (`&`) and the

--- a/crates/rsvelte_core/tests/css_nested_ancestor_2474.rs
+++ b/crates/rsvelte_core/tests/css_nested_ancestor_2474.rs
@@ -1,0 +1,118 @@
+//! A nested rule without an explicit `&` must match only where its enclosing
+//! selectors match an *ancestor*.
+//!
+//! Upstream `get_relative_selectors` prepends an implicit `&` + descendant
+//! combinator, so `.grand { .foo { … } }` resolves to `.grand .foo` and
+//! `apply_selector` walks the real ancestor chain. rsvelte only asked whether
+//! `.grand` matched *some* element in the component, so a `.grand` that exists
+//! as a sibling kept the whole nest alive and its `css_unused_selector`
+//! warnings were never emitted.
+//!
+//! Every expectation below is the official compiler's output for the same
+//! source (Svelte 5.56.8, `{ generate: 'client', css: 'external' }`).
+
+use rsvelte_core::{CompileOptions, GenerateMode, compile, compiler::CssMode};
+
+fn css_unused(src: &str) -> Vec<String> {
+    compile(
+        src,
+        CompileOptions {
+            filename: Some("T.svelte".to_string()),
+            generate: GenerateMode::Client,
+            dev: false,
+            css: CssMode::External,
+            ..Default::default()
+        },
+    )
+    .expect("compile")
+    .warnings
+    .iter()
+    .filter(|w| w.code == "css_unused_selector")
+    .map(|w| w.message.lines().next().unwrap_or("").to_string())
+    .collect()
+}
+
+fn warns(selectors: &[&str]) -> Vec<String> {
+    selectors
+        .iter()
+        .map(|s| format!("Unused CSS selector \"{s}\""))
+        .collect()
+}
+
+#[test]
+fn outer_rule_of_unused_nest_warns() {
+    // `.grand` exists, but as a sibling of `.foo` — the nest is unreachable.
+    let src = "<div class=\"grand\"></div><div class=\"foo\"><div class=\"a\"></div><div class=\"a\"></div></div>\n\
+               <style>\n\t.grand {\n\t\t.foo > .a { & + & { color: red; } }\n\t}\n</style>";
+    assert_eq!(css_unused(src), warns(&[".foo > .a", "& + &"]));
+}
+
+#[test]
+fn outer_rule_of_used_nest_does_not_warn() {
+    // Positive control: the same stylesheet with `.grand` as a real ancestor.
+    let src = "<div class=\"grand\"><div class=\"foo\"><div class=\"a\"></div><div class=\"a\"></div></div></div>\n\
+               <style>\n\t.grand {\n\t\t.foo > .a { & + & { color: red; } }\n\t}\n</style>";
+    assert_eq!(css_unused(src), Vec::<String>::new());
+}
+
+#[test]
+fn nested_selector_needs_an_ancestor_not_just_an_occurrence() {
+    let sibling = "<div class=\"grand\"></div><div class=\"foo\"></div>\n\
+                   <style>.grand { .foo { color: red; } }</style>";
+    assert_eq!(css_unused(sibling), warns(&[".foo"]));
+
+    let ancestor = "<div class=\"grand\"><div class=\"foo\"></div></div>\n\
+                    <style>.grand { .foo { color: red; } }</style>";
+    assert_eq!(css_unused(ancestor), Vec::<String>::new());
+}
+
+#[test]
+fn implicit_ancestor_link_is_a_descendant_not_a_child() {
+    // `.grand .foo` matches through an intermediate element...
+    let indirect = "<div class=\"grand\"><span><div class=\"foo\"></div></span></div>\n\
+                    <style>.grand { .foo { color: red; } }</style>";
+    assert_eq!(css_unused(indirect), Vec::<String>::new());
+
+    // ...but an explicit `>` head keeps its own combinator.
+    let child = "<div class=\"grand\"><span><div class=\"foo\"></div></span></div>\n\
+                 <style>.grand { > .foo { color: red; } }</style>";
+    assert_eq!(css_unused(child), warns(&["> .foo"]));
+}
+
+#[test]
+fn every_unreachable_level_warns() {
+    let src = "<div class=\"grand\"></div><div class=\"foo\"><div class=\"a\"></div></div>\n\
+               <style>.grand { .foo { .a { color: red; } } }</style>";
+    assert_eq!(css_unused(src), warns(&[".foo", ".a"]));
+}
+
+#[test]
+fn comma_branches_are_ored_across_levels() {
+    // `.a` is reachable through the `.foo` branch of the outer selector list.
+    let src = "<div class=\"grand\"></div><div class=\"foo\"><div class=\"a\"></div></div>\n\
+               <style>.grand, .foo { .a { color: red; } }</style>";
+    assert_eq!(css_unused(src), Vec::<String>::new());
+}
+
+#[test]
+fn an_at_rule_between_levels_keeps_the_ancestor_link() {
+    let src = "<div class=\"grand\"></div><div class=\"foo\"></div>\n\
+               <style>.grand { @media (min-width: 1px) { .foo { color: red; } } }</style>";
+    assert_eq!(css_unused(src), warns(&[".foo"]));
+}
+
+#[test]
+fn a_dynamic_class_on_a_non_ancestor_does_not_rescue_the_nest() {
+    // `class={cls}` could be `grand`, but that element is still not an ancestor.
+    let src = "<script>let cls = \"grand\";</script><div class={cls}></div><div class=\"foo\"></div>\n\
+               <style>.grand { .foo { color: red; } }</style>";
+    assert_eq!(css_unused(src), warns(&[".foo"]));
+}
+
+#[test]
+fn an_unevaluable_enclosing_selector_stays_conservative() {
+    // `:global(.grand)` can match outside the component: no ancestor claim.
+    let src = "<div class=\"foo\"></div>\n\
+               <style>:global(.grand) { .foo { color: red; } }</style>";
+    assert_eq!(css_unused(src), Vec::<String>::new());
+}


### PR DESCRIPTION
## How it was broken

For a nested CSS rule, rsvelte asked only whether each enclosing selector matched
**some** element in the component. It never checked that the match was an
**ancestor**, so a `.grand` that happens to exist as a *sibling* kept the whole
nest alive and every `css_unused_selector` warning inside it was suppressed.

Reproduced on `origin/main` (`3c8593c2`) with the issue's input:

```svelte
<div class="grand"></div><div class="foo"><div class="a"></div><div class="a"></div></div>
<style>
	.grand {
		.foo > .a { & + & { color: red; } }
	}
</style>
```

| | warnings |
|---|---|
| official (5.56.8) | `.foo > .a` @ 4:2, `& + &` @ 4:14 |
| rsvelte (before)  | `& + &` @ 4:14 |
| rsvelte (after)   | `.foo > .a` @ 4:2, `& + &` @ 4:14 |

One correction to the issue text: the missing warning at column 2 is the
**middle** rule `.foo > .a`, not `.grand`. `.grand` matches a real element, so
official marks it used and warns about neither it nor anything else at that
level — the divergence is exactly one warning, on the intermediate nesting level.
`css.code` was already byte-identical before this change and still is.

## What it was aligned to

`packages/svelte/src/compiler/phases/2-analyze/css/css-prune.js`:

- `get_relative_selectors` (L171) prepends an implicit `&` with a **descendant**
  combinator when the rule has a `parent_rule` and no explicit `&`, so
  `.grand { .foo > .a { … } }` is applied as `.grand .foo > .a`.
- `apply_selector`'s `NestingSelector` case (L649) then resolves that `&` by
  walking `parent.prelude.children` — every comma branch, OR-ed — against the
  real ancestor chain.

`is_nested_selector_unused_against_ancestors` reproduces that: it flattens the
enclosing preludes into every alternative ancestor chain with the existing
`build_parent_chains` / `with_descendant_head` helpers (already used for the bare
`&` sibling case), appends the rule's own relative selectors, and runs each
candidate through the existing `is_structural_descendant_chain_unused` walker.
The rule is unused only when **every** alternative chain is unreachable.

It stays conservative — returns "not unused" — whenever the input is outside what
that walker models: dynamic elements, non-lexical ancestry, an explicit `&`, or
any non-evaluable simple selector (`:global`, `:root`, `:host`, `:is()`/`:not()`
args). `level_is_structurally_evaluable` is what rejects the explicit-`&` shapes,
which upstream resolves compound-wise rather than by prepending.

## How the test fails before the fix

`crates/rsvelte_core/tests/css_nested_ancestor_2474.rs`, 9 tests. Every
expectation is the official compiler's output for the same source. Against
unpatched `main`, 6 fail and 3 pass:

```
outer_rule_of_unused_nest_warns                          FAILED
  left:  ["Unused CSS selector \"& + &\""]
  right: ["Unused CSS selector \".foo > .a\"", "Unused CSS selector \"& + &\""]
nested_selector_needs_an_ancestor_not_just_an_occurrence FAILED   left: []  right: [".foo"]
every_unreachable_level_warns                            FAILED   left: []  right: [".foo", ".a"]
implicit_ancestor_link_is_a_descendant_not_a_child       FAILED   left: []  right: ["> .foo"]
an_at_rule_between_levels_keeps_the_ancestor_link        FAILED   left: []  right: [".foo"]
a_dynamic_class_on_a_non_ancestor_does_not_rescue_the_nest FAILED left: []  right: [".foo"]
```

The failure is exactly the predicted one — an empty/short warning list because
the nest was considered used. The 3 that pass before **and** after are the
negative controls (`outer_rule_of_used_nest_does_not_warn`,
`comma_branches_are_ored_across_levels`,
`an_unevaluable_enclosing_selector_stays_conservative`); they guard the opposite
direction, so a fix that just warns more would break them.

## Effect on other fixtures

- **Full `cargo test --release -p rsvelte_core`**: 226 test binaries + lib, all
  green. CSS 181/181 and Validator 333/333 unchanged. `rsvelte_lint` green.
- **CSS-fixture warning parity** (probe, not committed): rsvelte's
  `css_unused_selector` set — code, line, column and text — matches
  `warnings.json` for all 181 official CSS samples both before and after. So no
  official sample contains this shape; that is why the suite never saw the bug,
  and it confirms the change moves none of them.
- **Differential sweep vs. official** (600 cases: 15 templates × 40 nested
  stylesheets, comparing warnings *and* `css.code`):
  **250 mismatches before → 76 after, 0 new**. The 174 newly-matching cases are a
  strict superset relationship — every remaining mismatch was already failing on
  `main`.

The 76 remaining are pre-existing, separate divergences that this change
deliberately does not touch (explicit `&` under a non-ancestor parent; `:is()` /
`:where()` / `:not()` argument selectors; `:root`; a trailing `:global()`; and
the `class={…}` / `{...spread}` / `class:` dynamic-attribute families). Reported
separately rather than folded in here.

## Ratchets

This adds `css_unused_selector` warnings, so the corpus **warning** gates may
move: `compatibility/warning-known-failures.{client,server,client-dev}.json` and
`compatibility/warning-position-known-failures.*`. Those ratchets are two-sided —
an entry that now passes fails CI just as a new failure does. I did not run the
full corpus (local disk was under pressure and the run writes ~0.57 GiB per
target) and did not hand-edit any ratchet JSON or its paired `.md`.

If CI reports movement there, re-baseline with:

```sh
node scripts/compat-corpus/compile.mjs
node scripts/compat-corpus/verify.mjs --update-warning-baseline
```

(and `--update-baseline` as well only if `known-failures.*` also moves, which is
not expected: `css.code` was byte-identical on the repro and the differential
sweep found no new `css.code` divergence).

Fixes #2474
