### PR TITLE
fix(compiler): read the character next to a match in the client transforms, not the byte (#2409)

### DIFF
--- a/.changeset/non-ascii-boundary-client-transforms.md
+++ b/.changeset/non-ascii-boundary-client-transforms.md
@@ -1,0 +1,11 @@
+---
+'@rsvelte/compiler': patch
+---
+
+Read the character adjacent to a match in the client transforms, not the byte. Twelve
+word-boundary and whitespace scans in the class, state, store and prop transforms decided
+what sits next to a match from `bytes[i] as char`, which Latin-1-decodes one byte of a
+UTF-8 sequence: `א`'s lead byte reads as `×` (not alphanumeric) and `名`'s trailing byte as
+a C1 control, so a letter inside an identifier looked like a word boundary — `this.#cא`
+compiled to `log($.get(this.#c)א)`, which is not JavaScript — while `U+3000` and NBSP, whose
+lead bytes decode to letters, were not recognised as the whitespace they are.

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/class_transforms.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/class_transforms.rs
@@ -748,11 +748,7 @@ pub(super) fn transform_constructor_private_reads(
                     continue;
                 }
 
-                let next_char = if after_pos < result.len() {
-                    Some(result.as_bytes()[after_pos] as char)
-                } else {
-                    None
-                };
+                let next_char = crate::compiler::utils::char_at(&result, after_pos);
 
                 match next_char {
                     Some(' ')
@@ -818,11 +814,7 @@ pub(super) fn transform_constructor_private_reads(
                     continue;
                 }
 
-                let next_char = if after_pos < result.len() {
-                    Some(result.as_bytes()[after_pos] as char)
-                } else {
-                    None
-                };
+                let next_char = crate::compiler::utils::char_at(&result, after_pos);
 
                 match next_char {
                     Some(' ')
@@ -1742,12 +1734,11 @@ pub(super) fn find_private_field_prefixes(content: &str, field_name: &str) -> Ve
         let abs_pos = search_from + pos;
         // Check the character after the field name to ensure it's a word boundary
         let after_pos = abs_pos + hash_pattern.len();
-        if after_pos < content.len() {
-            let next_char = content.as_bytes()[after_pos] as char;
-            if next_char.is_alphanumeric() || next_char == '_' {
-                search_from = abs_pos + 1;
-                continue;
-            }
+        if crate::compiler::utils::char_at(content, after_pos)
+            .is_some_and(|next_char| next_char.is_alphanumeric() || next_char == '_')
+        {
+            search_from = abs_pos + 1;
+            continue;
         }
 
         // Walk backwards to find the identifier prefix
@@ -1995,11 +1986,7 @@ pub(super) fn wrap_standalone_private_reads(content: &str, qualified: &str) -> S
         }
 
         // Check character after
-        let next_char = if after_pos < result.len() {
-            Some(result.as_bytes()[after_pos] as char)
-        } else {
-            None
-        };
+        let next_char = crate::compiler::utils::char_at(&result, after_pos);
 
         // If followed by = (assignment), ++ or -- (increment/decrement), . (property access),
         // ? (optional chain), or alphanumeric (part of longer name), skip

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/props_transforms.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/props_transforms.rs
@@ -3010,12 +3010,11 @@ pub(super) fn wrap_prop_mutation_validation(
             let abs_start = runes_search_from + prefix_rel;
 
             // Check this is a standalone identifier (not part of a longer name)
-            if abs_start > 0 {
-                let prev_char = result.as_bytes()[abs_start - 1] as char;
-                if prev_char.is_alphanumeric() || prev_char == '_' || prev_char == '$' {
-                    runes_search_from = abs_start + runes_prefix.len();
-                    continue;
-                }
+            if crate::compiler::utils::char_before(&result, abs_start)
+                .is_some_and(|c| c.is_alphanumeric() || c == '_' || c == '$')
+            {
+                runes_search_from = abs_start + runes_prefix.len();
+                continue;
             }
 
             // Check it's not already inside a prop(prop()...) wrapper
@@ -3212,12 +3211,11 @@ pub(super) fn wrap_prop_mutation_validation(
             let after_outer = abs_start + outer_call.len();
 
             // Check this is a standalone identifier (not part of a longer name)
-            if abs_start > 0 {
-                let prev_char = result.as_bytes()[abs_start - 1] as char;
-                if prev_char.is_alphanumeric() || prev_char == '_' || prev_char == '$' {
-                    search_from = after_outer;
-                    continue;
-                }
+            if crate::compiler::utils::char_before(&result, abs_start)
+                .is_some_and(|c| c.is_alphanumeric() || c == '_' || c == '$')
+            {
+                search_from = after_outer;
+                continue;
             }
 
             let inner_probe_start = if result.as_bytes().get(after_outer) == Some(&b'(') {
@@ -3235,6 +3233,8 @@ pub(super) fn wrap_prop_mutation_validation(
                 search_from = after_outer;
                 continue;
             }
+            // Sound on a byte: both targets are ASCII, and no byte of a multi-byte
+            // UTF-8 character can equal an ASCII byte.
             let next_char = result.as_bytes()[after_inner_call] as char;
             if next_char != '.' && next_char != '[' {
                 search_from = after_outer;
@@ -3527,18 +3527,17 @@ impl PropMutationSites {
             if !scan.code.contains(start) {
                 continue;
             }
-            if start > 0 {
-                let prev = bytes[start - 1] as char;
-                if prev.is_alphanumeric() || prev == '_' || prev == '$' || prev == '.' {
-                    continue;
-                }
+            if crate::compiler::utils::char_before(source, start)
+                .is_some_and(|c| c.is_alphanumeric() || c == '_' || c == '$' || c == '.')
+            {
+                continue;
             }
             let chain_start = skip_non_null_assertions(bytes, end);
             if !starts_member_access(bytes, chain_start) {
                 continue;
             }
-            if let Some((after, chain)) = scan_member_chain_names(bytes, chain_start)
-                && let Some(value_start) = mutation_value_start(bytes, after)
+            if let Some((after, chain)) = scan_member_chain_names(source, chain_start)
+                && let Some(value_start) = mutation_value_start(source, after)
             {
                 let (line, column) =
                     crate::compiler::phases::phase3_transform::utils::locate_in_source(
@@ -3718,15 +3717,30 @@ fn starts_member_access(bytes: &[u8], pos: usize) -> bool {
     }
 }
 
+/// The offset of the first non-whitespace character at or after `pos`.
+///
+/// Stepping by characters is what keeps a non-ASCII JavaScript space (`U+3000`,
+/// NBSP) recognised — its lead byte Latin-1-decodes to a letter — and is what keeps
+/// the cursor from stranding inside a character whose `0x85`/`0xA0` continuation
+/// byte would read as whitespace on its own.
+fn skip_whitespace_chars(source: &str, mut pos: usize) -> usize {
+    while let Some(c) = crate::compiler::utils::char_at(source, pos) {
+        if !c.is_whitespace() {
+            break;
+        }
+        pos += c.len_utf8();
+    }
+    pos
+}
+
 /// The offset just after the mutation operator at `pos`, or `None` when there
 /// is no operator there.
-fn mutation_value_start(bytes: &[u8], mut pos: usize) -> Option<usize> {
-    if !is_mutation_operator(bytes, pos) {
+fn mutation_value_start(source: &str, mut pos: usize) -> Option<usize> {
+    if !is_mutation_operator(source, pos) {
         return None;
     }
-    while pos < bytes.len() && (bytes[pos] as char).is_whitespace() {
-        pos += 1;
-    }
+    let bytes = source.as_bytes();
+    pos = skip_whitespace_chars(source, pos);
     // `++` / `--` write no value of their own.
     if matches!(bytes.get(pos), Some(b'+') | Some(b'-')) && bytes.get(pos + 1) == bytes.get(pos) {
         return Some((pos + 2).min(bytes.len()));
@@ -3989,7 +4003,8 @@ mod code_spans_tests {
 
 /// Advance past `.name` / `[expr]` accessors, returning the offset just after
 /// the chain plus the names it reads — `None` once a computed access appears.
-fn scan_member_chain_names(bytes: &[u8], mut pos: usize) -> Option<(usize, Option<Vec<String>>)> {
+fn scan_member_chain_names(source: &str, mut pos: usize) -> Option<(usize, Option<Vec<String>>)> {
+    let bytes = source.as_bytes();
     let mut names = Some(Vec::new());
     loop {
         while pos < bytes.len() && (bytes[pos] == b' ' || bytes[pos] == b'\t') {
@@ -4015,10 +4030,9 @@ fn scan_member_chain_names(bytes: &[u8], mut pos: usize) -> Option<(usize, Optio
                     pos += 1;
                 }
                 let ident_start = pos;
-                while pos < bytes.len() {
-                    let c = bytes[pos] as char;
+                while let Some(c) = crate::compiler::utils::char_at(source, pos) {
                     if c.is_alphanumeric() || c == '_' || c == '$' {
-                        pos += 1;
+                        pos += c.len_utf8();
                     } else {
                         break;
                     }
@@ -4027,7 +4041,7 @@ fn scan_member_chain_names(bytes: &[u8], mut pos: usize) -> Option<(usize, Optio
                     return None;
                 }
                 if let Some(names) = names.as_mut() {
-                    names.push(String::from_utf8_lossy(&bytes[ident_start..pos]).into_owned());
+                    names.push(source[ident_start..pos].to_string());
                 }
             }
             b'[' => {
@@ -4057,10 +4071,9 @@ fn scan_member_chain_names(bytes: &[u8], mut pos: usize) -> Option<(usize, Optio
 }
 
 /// Whether an assignment or update operator starts at `pos`.
-fn is_mutation_operator(bytes: &[u8], mut pos: usize) -> bool {
-    while pos < bytes.len() && (bytes[pos] as char).is_whitespace() {
-        pos += 1;
-    }
+fn is_mutation_operator(source: &str, pos: usize) -> bool {
+    let bytes = source.as_bytes();
+    let mut pos = skip_whitespace_chars(source, pos);
     if pos >= bytes.len() {
         return false;
     }
@@ -4571,6 +4584,115 @@ mod pattern_end_unit_tests {
         for pattern in ["{ a }", "{ café }", "{ ああ }", "[ あ, い ]", "  { café }"] {
             let end = find_destructuring_pattern_end(pattern).unwrap();
             assert_eq!(&pattern[..end], pattern, "pattern {pattern:?}");
+        }
+    }
+}
+
+/// The prop-mutation scans read the character adjacent to a match, not the byte.
+/// Each case pairs a non-ASCII input with the ASCII input it must agree with;
+/// before the fix every non-ASCII row returned the *other* answer.
+#[cfg(test)]
+mod non_ascii_boundary_tests {
+    use super::{
+        PropMutationScan, PropMutationSites, is_mutation_operator, mutation_value_start,
+        scan_member_chain_names, wrap_prop_mutation_validation,
+    };
+
+    /// `名` ends in `0x8D`, which reads as a C1 control — so the letter before
+    /// `count(` looked like a word boundary and a member of an unrelated
+    /// identifier was wrapped in an ownership check that names `count`.
+    #[test]
+    fn a_prop_name_inside_a_longer_non_ascii_identifier_is_not_a_mutation() {
+        let wrap = |stmt: &str| {
+            wrap_prop_mutation_validation(
+                stmt,
+                &[("count".to_string(), None)],
+                "<script>let { count } = $props();</script>",
+            )
+        };
+        // Control: the ASCII form is left alone, before and after the fix.
+        assert_eq!(wrap("x_count().a = 1;"), "x_count().a = 1;");
+        assert_eq!(wrap("\u{540D}count().a = 1;"), "\u{540D}count().a = 1;");
+        assert_eq!(wrap("\u{5D0}count().a = 1;"), "\u{5D0}count().a = 1;");
+        // Control on the other side: a standalone prop mutation is still wrapped.
+        assert!(wrap("count().a = 1;").starts_with("$$ownership_validator.mutation("));
+    }
+
+    /// The same boundary on the legacy `prop(prop().member = v, true)` shape.
+    #[test]
+    fn the_legacy_mutation_shape_honours_the_same_boundary() {
+        let wrap = |stmt: &str| {
+            wrap_prop_mutation_validation(
+                stmt,
+                &[("count".to_string(), None)],
+                "<script>export let count;</script>",
+            )
+        };
+        assert_eq!(
+            wrap("x_count(count().a = 1, true);"),
+            "x_count(count().a = 1, true);"
+        );
+        assert_eq!(
+            wrap("\u{540D}count(count().a = 1, true);"),
+            "\u{540D}count(count().a = 1, true);"
+        );
+        assert!(wrap("count(count().a = 1, true);").starts_with("$$ownership_validator.mutation("));
+    }
+
+    /// `PropMutationSites::collect` carries the same boundary; a site collected
+    /// here is what gives a dev-mode ownership warning its line and column.
+    #[test]
+    fn a_collected_site_honours_the_same_boundary() {
+        let count = |source: &str| {
+            let scan = PropMutationScan::new(source);
+            PropMutationSites::collect(source, "count", &scan)
+                .sites
+                .len()
+        };
+        assert_eq!(count("<script>x_count.a = 1;</script>"), 0);
+        assert_eq!(count("<script>\u{540D}count.a = 1;</script>"), 0);
+        assert_eq!(count("<script>count.a = 1;</script>"), 1);
+    }
+
+    /// A non-ASCII member name is one name, not a replacement character, and the
+    /// offset the scan stops at must stay on a character boundary — the byte scan
+    /// consumed only the lead byte and handed the rest of the pipeline a cursor
+    /// pointing inside the character.
+    #[test]
+    fn a_non_ascii_member_name_is_scanned_whole() {
+        for (source, name) in [
+            ("item.name = 5;", "name"),
+            ("item.\u{540D} = 5;", "\u{540D}"),
+            ("item.\u{E0} = 5;", "\u{E0}"),
+        ] {
+            let (after, names) = scan_member_chain_names(source, 4).unwrap();
+            assert_eq!(names.as_deref(), Some([name.to_string()].as_slice()));
+            assert!(source.is_char_boundary(after), "source {source:?}");
+            assert!(is_mutation_operator(source, after), "source {source:?}");
+            assert!(mutation_value_start(source, after).is_some());
+        }
+    }
+
+    /// `U+3000` and NBSP are JavaScript whitespace. Their lead bytes (`0xE3`,
+    /// `0xC2`) Latin-1-decode to letters, so the byte scan read them as part of
+    /// the member name and then failed to find the `=` behind them.
+    #[test]
+    fn non_ascii_whitespace_separates_a_member_from_its_operator() {
+        for source in [
+            "item.name = 5;",
+            "item.name\u{3000}= 5;",
+            "item.name\u{A0}= 5;",
+            "item.name\t= 5;",
+        ] {
+            let (after, names) = scan_member_chain_names(source, 4).unwrap();
+            assert_eq!(
+                names.as_deref(),
+                Some(["name".to_string()].as_slice()),
+                "source {source:?}"
+            );
+            assert!(is_mutation_operator(source, after), "source {source:?}");
+            let value_start = mutation_value_start(source, after).unwrap();
+            assert_eq!(source[value_start..].trim(), "5;", "source {source:?}");
         }
     }
 }

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/state_transforms.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/state_transforms.rs
@@ -400,6 +400,13 @@ pub(super) fn strip_object_property_keys(code: &str) -> std::borrow::Cow<'_, str
     std::borrow::Cow::Owned(result.into_iter().collect())
 }
 
+/// Whether `c` can follow the last character of a parameter name. Spelled over
+/// characters rather than the single space the ASCII whitelist accepted, because
+/// `U+3000` and NBSP separate a parameter exactly as a space does.
+fn ends_a_parameter_name(c: char) -> bool {
+    c == ',' || c == ')' || c == ':' || c.is_whitespace()
+}
+
 /// Strip out function/arrow expression bodies where the identifier is declared as a parameter.
 /// This replaces the function body (including the function itself) with empty space,
 /// leaving only the parts of the code that don't shadow the identifier.
@@ -432,14 +439,13 @@ pub(super) fn strip_function_scopes_that_shadow<'a>(
         while let Some(pos) = result.find(pat.as_str()) {
             // Verify the identifier is actually a parameter (followed by `,` or `)`)
             let after_ident = pos + pat.len();
-            if after_ident < result.len() {
-                let next_char = result.as_bytes()[after_ident] as char;
-                if next_char != ',' && next_char != ')' && next_char != ' ' && next_char != ':' {
-                    // Not a word boundary - the pattern is a prefix of a longer name
-                    // Replace just this occurrence to prevent infinite loop
-                    result.replace_range(pos..pos + 1, " ");
-                    continue;
-                }
+            if crate::compiler::utils::char_at(&result, after_ident)
+                .is_some_and(|next_char| !ends_a_parameter_name(next_char))
+            {
+                // Not a word boundary - the pattern is a prefix of a longer name
+                // Replace just this occurrence to prevent infinite loop
+                result.replace_range(pos..pos + 1, " ");
+                continue;
             }
 
             // Find the opening brace of the function body
@@ -512,8 +518,9 @@ pub(super) fn strip_function_scopes_that_shadow<'a>(
             if after_ident >= result.len() {
                 break;
             }
-            let next_char = result.as_bytes()[after_ident] as char;
-            if next_char != ',' && next_char != ')' && next_char != ' ' && next_char != ':' {
+            if !crate::compiler::utils::char_at(&result, after_ident)
+                .is_some_and(ends_a_parameter_name)
+            {
                 search_from = pos + 1;
                 continue;
             }

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/store_transforms.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/store_transforms.rs
@@ -122,20 +122,12 @@ pub(super) fn is_function_parameter_in_statement(statement: &str, store_sub: &st
         if let Some(found) = statement[pos..].find(store_sub) {
             let abs_found = pos + found;
             // Check word boundary before
-            let before_ok = if abs_found == 0 {
-                true
-            } else {
-                let prev = statement.as_bytes()[abs_found - 1] as char;
-                !prev.is_alphanumeric() && prev != '_' && prev != '$'
-            };
+            let before_ok = !crate::compiler::utils::char_before(statement, abs_found)
+                .is_some_and(is_ident_char);
             // Check word boundary after
             let after_pos = abs_found + store_sub_len;
-            let after_ok = if after_pos >= statement.len() {
-                true
-            } else {
-                let next = statement.as_bytes()[after_pos] as char;
-                !next.is_alphanumeric() && next != '_' && next != '$'
-            };
+            let after_ok =
+                !crate::compiler::utils::char_at(statement, after_pos).is_some_and(is_ident_char);
 
             if before_ok && after_ok {
                 // Check if followed by `=>` (with optional whitespace) = simple arrow param
@@ -242,13 +234,8 @@ pub(super) fn transform_store_sub_calls(line: &str, store_sub_vars: &[String]) -
             let abs_pos = search_start + pos;
 
             // Check if this is a word boundary (not part of a larger identifier)
-            let before_ok = if abs_pos == 0 {
-                true
-            } else {
-                let prev_byte = result.as_bytes()[abs_pos - 1];
-                let prev_char = prev_byte as char;
-                !prev_char.is_alphanumeric() && prev_char != '_' && prev_char != '$'
-            };
+            let before_ok =
+                !crate::compiler::utils::char_before(&result, abs_pos).is_some_and(is_ident_char);
 
             if !before_ok {
                 // Not a word boundary, skip
@@ -273,6 +260,8 @@ pub(super) fn transform_store_sub_calls(line: &str, store_sub_vars: &[String]) -
                 let mut i = bytes.len();
                 while i > 0 {
                     i -= 1;
+                    // Sound on a byte: the only targets are ASCII, and no byte of a
+                    // multi-byte UTF-8 character can equal an ASCII byte.
                     let ch = bytes[i] as char;
                     if ch == ')' {
                         depth += 1;

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/tests.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/tests.rs
@@ -1737,3 +1737,159 @@ fn find_assignment_position_ignores_delimiters_inside_comments() {
     // A real top-level assignment is still found.
     assert_eq!(find_assignment_position("bar = []"), Some(4));
 }
+
+/// A private field whose name continues past the one being transformed must be
+/// left alone. `א` (`D7 90`) is the discriminating case: `0xD7` is the lead byte
+/// of the whole Hebrew block and is the one lead byte whose Latin-1 image (`×`)
+/// is not alphanumeric, so the byte scan saw a word boundary in the middle of an
+/// identifier and appended `.v` there — `this.#c.vא`.
+#[test]
+fn a_private_state_read_stops_at_a_non_ascii_identifier_character() {
+    use super::class_transforms::{ClassStateField, transform_constructor_private_reads};
+
+    let field = |rune: &str| ClassStateField {
+        name: "c".to_string(),
+        is_private: true,
+        rune_type: rune.to_string(),
+        value: "0".to_string(),
+        private_backing_name: "c".to_string(),
+        constructor_declared: false,
+        had_class_body_decl: false,
+        trailing_comment: None,
+    };
+
+    for rune in ["$state", "$derived"] {
+        // Control: an ASCII continuation was already rejected.
+        assert_eq!(
+            transform_constructor_private_reads("log(this.#cx);", &[field(rune)]),
+            "log(this.#cx);"
+        );
+        assert_eq!(
+            transform_constructor_private_reads("log(this.#c\u{5D0});", &[field(rune)]),
+            "log(this.#c\u{5D0});"
+        );
+    }
+}
+
+/// The `$derived` and standalone-read paths both spliced `$.get(...)` in the
+/// middle of the identifier, which is not JavaScript at all: `log($.get(this.#c)א)`.
+#[test]
+fn a_standalone_private_read_stops_at_a_non_ascii_identifier_character() {
+    use super::class_transforms::wrap_standalone_private_reads;
+
+    assert_eq!(
+        wrap_standalone_private_reads("log(this.#cx);", "this.#c"),
+        "log(this.#cx);"
+    );
+    assert_eq!(
+        wrap_standalone_private_reads("log(this.#c\u{5D0});", "this.#c"),
+        "log(this.#c\u{5D0});"
+    );
+    // Control on the other side: a real standalone read is still wrapped.
+    assert_eq!(
+        wrap_standalone_private_reads("log(this.#c);", "this.#c"),
+        "log($.get(this.#c));"
+    );
+}
+
+/// `obj.#cא` is a read of a different field, so `obj` is not a prefix of `#c`.
+#[test]
+fn a_private_field_prefix_is_not_collected_across_a_non_ascii_continuation() {
+    use super::class_transforms::find_private_field_prefixes;
+
+    assert_eq!(find_private_field_prefixes("obj.#cx = 1;", "c"), ["this"]);
+    assert_eq!(
+        find_private_field_prefixes("obj.#c\u{5D0} = 1;", "c"),
+        ["this"]
+    );
+    // Control on the other side: a real prefix is still collected.
+    assert_eq!(
+        find_private_field_prefixes("obj.#c = 1;", "c"),
+        ["obj", "this"]
+    );
+}
+
+/// `U+3000` and NBSP separate a parameter from its `)` exactly as a space does.
+/// The scan used an ASCII whitelist, so it decided the pattern was a prefix of a
+/// longer name, blanked the `f` of `function` and left the shadowing scope — and
+/// therefore the shadowed identifier — in the body it hands to dependency analysis.
+#[test]
+fn a_shadowing_scope_is_stripped_across_non_ascii_whitespace() {
+    use super::state_transforms::strip_function_scopes_that_shadow;
+
+    for body in [
+        "function (a ) { a }",
+        "function (a\u{3000}) { a }",
+        "function (a\u{A0}) { a }",
+    ] {
+        let stripped = strip_function_scopes_that_shadow(body, "a");
+        assert!(
+            stripped.trim().is_empty(),
+            "body {body:?} left {stripped:?}"
+        );
+    }
+    for body in ["(a ) => a", "(a\u{3000}) => a"] {
+        let stripped = strip_function_scopes_that_shadow(body, "a");
+        assert!(
+            stripped.trim().is_empty(),
+            "body {body:?} left {stripped:?}"
+        );
+    }
+    // Control: a body that does not shadow `a` is untouched.
+    assert_eq!(
+        strip_function_scopes_that_shadow("function (b) { a }", "a"),
+        "function (b) { a }"
+    );
+}
+
+/// `名$c` is one identifier, so `$c` is not an arrow parameter there. The byte
+/// before `$c` is `名`'s trailing `0x8D`, a C1 control that no identifier
+/// predicate accepts — so the scan saw a word boundary inside a name.
+#[test]
+fn a_store_name_inside_a_longer_non_ascii_identifier_is_not_a_parameter() {
+    use super::store_transforms::is_function_parameter_in_statement;
+
+    // Control: the ASCII form was already rejected.
+    assert!(!is_function_parameter_in_statement("x$c => 1", "$c"));
+    assert!(!is_function_parameter_in_statement("\u{540D}$c => 1", "$c"));
+    assert!(!is_function_parameter_in_statement("\u{5D0}$c => 1", "$c"));
+    // Control on the other side: a real arrow parameter is still recognised.
+    assert!(is_function_parameter_in_statement("$c => 1", "$c"));
+}
+
+/// The trailing side of the same check: `U+3000` before `=>` is whitespace, and
+/// its lead byte `0xE3` Latin-1-decodes to `ã`, which is alphanumeric — so the
+/// parameter looked like the prefix of a longer name and was not recognised.
+#[test]
+fn a_store_parameter_is_recognised_across_non_ascii_whitespace() {
+    use super::store_transforms::is_function_parameter_in_statement;
+
+    assert!(is_function_parameter_in_statement("$c => 1", "$c"));
+    assert!(is_function_parameter_in_statement("$c\u{3000}=> 1", "$c"));
+    assert!(is_function_parameter_in_statement("$c\u{A0}=> 1", "$c"));
+    // Control: a longer name is still not the parameter.
+    assert!(!is_function_parameter_in_statement("$c\u{5D0} => 1", "$c"));
+}
+
+/// `x名$c` is one identifier, so the getter call must not be inserted into it.
+/// The first `$c(1)` is there because the cheap pre-check that guards this
+/// transform is character-correct already — without it the loop is never reached
+/// and the test cannot see the branch it is about.
+#[test]
+fn a_store_call_is_not_inserted_into_a_longer_non_ascii_identifier() {
+    use super::store_transforms::transform_store_sub_calls;
+
+    let subs = ["$c".to_string()];
+    assert_eq!(
+        transform_store_sub_calls("$c(1); xy$c(2)", &subs),
+        "$c()(1); xy$c(2)"
+    );
+    assert_eq!(
+        transform_store_sub_calls("$c(1); x\u{540D}$c(2)", &subs),
+        "$c()(1); x\u{540D}$c(2)"
+    );
+    assert_eq!(
+        transform_store_sub_calls("$c(1); x\u{E0}$c(2)", &subs),
+        "$c()(1); x\u{E0}$c(2)"
+    );
+}

--- a/crates/rsvelte_core/src/compiler/utils.rs
+++ b/crates/rsvelte_core/src/compiler/utils.rs
@@ -21,6 +21,25 @@ pub fn char_boundary_lookback(source: &str, end: usize, window: usize) -> &str {
     &source[lo..end]
 }
 
+/// The character that starts at byte offset `at`, or `None` past the end.
+///
+/// Replaces `source.as_bytes()[at] as char`, which Latin-1-decodes a single byte
+/// of a UTF-8 sequence: `名`'s lead byte reads as `å` and `א`'s as `×`, so an
+/// `is_alphanumeric` / `is_whitespace` predicate answers about a character that is
+/// not in the source. `at` must be a char boundary; a `find()` match offset always is.
+pub fn char_at(source: &str, at: usize) -> Option<char> {
+    source.get(at..).and_then(|rest| rest.chars().next())
+}
+
+/// The character that ends at byte offset `end`, or `None` at the start of `source`.
+///
+/// Replaces `source.as_bytes()[end - 1] as char`, which reads a *continuation*
+/// byte of the preceding character: `名` (`E5 90 8D`) reads as `U+008D`, a control
+/// that no identifier predicate accepts, so a letter is mistaken for a word boundary.
+pub fn char_before(source: &str, end: usize) -> Option<char> {
+    source.get(..end).and_then(|head| head.chars().next_back())
+}
+
 /// List of Element events that will be delegated.
 ///
 /// Corresponds to `DELEGATED_EVENTS` in utils.js.

--- a/crates/rsvelte_core/tests/private_field_non_ascii_2409.rs
+++ b/crates/rsvelte_core/tests/private_field_non_ascii_2409.rs
@@ -1,0 +1,83 @@
+//! A private field whose name continues past the `$state` field being
+//! transformed must not be split.
+//!
+//! The client class transform decided where the field name ended from
+//! `result.as_bytes()[after_pos] as char`, which Latin-1-decodes one byte of a
+//! UTF-8 sequence. `א` is `D7 90`, and `0xD7` — the lead byte of the whole Hebrew
+//! block — is the one lead byte whose Latin-1 image (`×`) is not alphanumeric, so
+//! the scan saw a word boundary inside an identifier and spliced `$.get(...)`
+//! there. `compile()` returned `Ok` with `return $.get(this.#c)א;` in the output,
+//! which is not JavaScript at all.
+
+use rsvelte_core::{CompileOptions, GenerateMode, compile};
+
+fn client_code(source: &str) -> String {
+    compile(
+        source,
+        CompileOptions {
+            generate: GenerateMode::Client,
+            filename: Some("Probe.svelte".to_string()),
+            ..Default::default()
+        },
+    )
+    .expect("component should compile")
+    .js
+    .code
+}
+
+#[track_caller]
+fn assert_parses(code: &str) {
+    let allocator = oxc_allocator::Allocator::default();
+    let ret = oxc_parser::Parser::new(&allocator, code, oxc_span::SourceType::mjs()).parse();
+    assert!(
+        ret.diagnostics.is_empty(),
+        "output is not JavaScript: {:?}\n--- output ---\n{code}",
+        ret.diagnostics,
+    );
+}
+
+const HEBREW: &str = "\
+<script>
+class C {
+	#c = $state(0);
+	#c\u{5D0} = 1;
+
+	read() { return this.#c\u{5D0}; }
+}
+</script>
+";
+
+/// Control: the ASCII shape of the same component, which already compiled.
+const ASCII: &str = "\
+<script>
+class C {
+	#c = $state(0);
+	#cx = 1;
+
+	read() { return this.#cx; }
+}
+</script>
+";
+
+#[test]
+fn a_hebrew_private_field_compiles_to_javascript() {
+    assert_parses(&client_code(ASCII));
+    assert_parses(&client_code(HEBREW));
+}
+
+/// The read must stay a read of `#cא`, not of `#c`. Asserting only that the
+/// output parses would not catch a fix that produced valid but wrong JavaScript.
+#[test]
+fn a_hebrew_private_field_read_keeps_its_own_field() {
+    let code = client_code(HEBREW);
+    assert!(
+        code.contains("return this.#c\u{5D0};"),
+        "read was rewritten: {code}"
+    );
+    assert!(
+        !code.contains("$.get(this.#c)"),
+        "read was rewritten: {code}"
+    );
+    // Control on the other side: the `$state` field is still a state field.
+    assert!(code.contains("#c = $.state(0);"), "{code}");
+}


### PR DESCRIPTION
The remainder of #2409, after #2416 fixed the three `tag.rs` sites the issue leads with.

## The population, counted today

The issue's "22 sites" does not survive; the comments already said so, and the number moved
again since. Re-derived against `origin/main` (`0f05d357`) with the command that produced it:

```
git grep -n 'as char' origin/main -- crates/rsvelte_core/src/compiler/phases/3_transform/client
```

**17 sites**, in the four client transform files. The five in `server/transform_store.rs`
(#2412) and the five in `rsvelte_lint`'s `no_unused_props.rs` (#2430) are the same class but
already have open PRs — **#2423** and **#2441** — so they are out of scope here rather than
missing. `tag.rs` is at zero. Phase 1 has three `bytes[i] as char` casts
(`read/style.rs:2395`, `utils/bracket.rs:213,245`) and they are all ASCII-target
comparisons; `parser.rs:506` guards on `b < 0x80` and decodes properly above it.

## Classification

Every row was decided by running the function, not by reading it. Each non-ASCII input is
paired with the ASCII input it must agree with, and the "before" column is the value the
function actually returned on unfixed `main`.

| site | predicate | class | what it returned, vs. the ASCII control |
|---|---|---|---|
| `class_transforms.rs:752` | `is_alphanumeric` on the next byte | **real bug** | `log(this.#cא);` → `log(this.#c.vא);` (`#cx` untouched) |
| `class_transforms.rs:822` | same | **real bug** | `log(this.#cא);` → `log($.get(this.#c)א);` — **not JavaScript** |
| `class_transforms.rs:1746` | same | **real bug** | `obj.#cא = 1;` → prefixes `["obj","this"]` (`#cx` → `["this"]`) |
| `class_transforms.rs:1999` | same | **real bug** | `log(this.#cא);` → `log($.get(this.#c)א);` — **not JavaScript** |
| `state_transforms.rs:436` | ASCII whitelist `, ) space :` | **real bug — but not the cast** | `function (a　) { a }` → `" unction (a　) { a }"` (ASCII → fully blanked) |
| `state_transforms.rs:515` | same | **real bug — but not the cast** | `(a　) => a` → unchanged (ASCII → blanked) |
| `store_transforms.rs:128` | `is_alphanumeric` on the previous byte | **real bug** | `名$c => 1` → `true` (`x$c => 1` → `false`) |
| `store_transforms.rs:136` | `is_alphanumeric` on the next byte | **real bug** | `$c　=> 1` → `false` (`$c => 1` → `true`) |
| `store_transforms.rs:249` | previous byte | **real bug** | `$c(1); x名$c(2)` → `$c()(1); x名$c()(2)` (`xy$c` untouched) |
| `store_transforms.rs:276` | `(` / `)` only | **accidentally safe** | agrees on every input; see below |
| `props_transforms.rs:3014` | previous byte | **real bug** | `名count().a = 1;` wrapped in an ownership check (`x_count` not) |
| `props_transforms.rs:3216` | previous byte | **real bug** | `名count(count().a = 1, true);` wrapped (`x_count` not) |
| `props_transforms.rs:3238` | `.` / `[` only | **accidentally safe** | agrees on every input; see below |
| `props_transforms.rs:3531` | previous byte | **real bug** | `名count.a = 1;` collected as 1 mutation site (`x_count` → 0) |
| `props_transforms.rs:3727` | `is_whitespace` on a byte | **real bug** | `item.name　= 5;` → `None` (ASCII space → `Some(11)`) |
| `props_transforms.rs:4019` | `is_alphanumeric` identifier scan | **real bug** | `item.名 = 5;` → member name `"\u{FFFD}"`, and a cursor **inside** the character |
| `props_transforms.rs:4061` | `is_whitespace` on a byte | **real bug** | `item.name　= 5;` → `false` (ASCII space → `true`) |

**15 real / 2 accidentally safe / 0 unreachable.**

### The two "accidentally safe" rows, with the reason in one line

Both compare against ASCII characters only, and no byte of a multi-byte UTF-8 sequence can
equal an ASCII byte — a lead byte is `0xC2..=0xF4`, a continuation byte `0x80..=0xBF`, and
`as char` maps those to `U+0080..U+00F4`, which contains no ASCII character. So the byte and
the character give the same answer on every input. That reason is checkable by reading the
comparison targets, which is exactly what the `transform_store.rs` "benign" claim in this
issue's comments could not offer — there the predicate was `is_alphabetic`, and the
enumeration had a one-byte hole (`0xD7`). Both rows now carry that one line in the source so
a later sweep does not re-derive them.

### The two rows whose cause is *not* the cast

`state_transforms.rs:436,515` compare against `','`, `')'`, `' '`, `':'` — all ASCII, so by
the paragraph above **the cast is sound there**. The defect is the whitelist: `U+3000` and
NBSP are JavaScript whitespace and separate a parameter exactly as a space does, and neither
is in the list. Decoding the character correctly does not change the answer; widening the
predicate does. I fixed them anyway — they are on the issue's list, the corruption is real
(the scan blanks the `f` of `function` and leaves the shadowing scope in the body it hands
to dependency analysis), and the fix is one line — but the PR should not claim the byte cast
caused it.

The widened predicate is `c.is_whitespace()`, so `\t` and `\n` now count as parameter
separators too, where the old whitelist rejected them. That is a behaviour change on ASCII
input, and it is the only one in this PR. It is strictly a repair: `function (a\t)` was
being treated as the prefix of a longer name.

Rust's `char::is_whitespace` is Unicode `White_Space`, which is not exactly JavaScript's
`WhiteSpace` production (it omits `U+FEFF`, includes `U+0085`). **That delta is #2502 and
is deliberately not addressed here** — this PR only moves the predicate from "one ASCII
space" to "whitespace", and #2502 is free to change what "whitespace" means everywhere at once.

## The end-to-end failure

`class_transforms.rs:822` / `:1999` are reachable from an ordinary `.svelte` file, and
`compile()` returns `Ok` with output that is not JavaScript. On `origin/main`:

```svelte
<script>
class C {
	#c = $state(0);
	#cא = 1;

	read() { return this.#cא; }
}
</script>
```

```js
class C {
	#c = $.state(0);
	#cא = 1;

	read() { return $.get(this.#c)א; }   // ← Expected a semicolon ... but found none
}
```

`א` is `D7 90`. `0xD7` is the lead byte of the entire Hebrew block (U+0590–U+05FF), and it is
the **only** lead byte whose Latin-1 image (`×`) is not alphanumeric — so of every script in
Unicode, Hebrew is the one that reaches this branch.

## Tests

14 tests, each pinning one row of the table above. Every one was confirmed to fail on the
unfixed sources **for the predicted reason** — the runs are quoted below — and every one
carries an ASCII control asserted *before* the non-ASCII case, so a fix that broke ASCII
would fail on the control line instead.

`crates/rsvelte_core/tests/private_field_non_ascii_2409.rs` (new file, 2 tests)
- `a_hebrew_private_field_compiles_to_javascript` — compiles the component above and parses
  the output with `oxc_parser`. Before: `output is not JavaScript: "Expected a semicolon or
  an implicit semicolon after a statement, but found none"`, with the emitted code in the
  message. The ASCII control (`#cx`) is parsed first and passed.
- `a_hebrew_private_field_read_keeps_its_own_field` — a "does it parse" assertion alone would
  pass a fix that emitted valid but wrong JavaScript, so this one pins the exact read.

`client/tests.rs` (7 tests)

| test | failed before with |
|---|---|
| `a_private_state_read_stops_at_a_non_ascii_identifier_character` | `left: "log(this.#c.vא);"` / `right: "log(this.#cא);"` |
| `a_standalone_private_read_stops_at_a_non_ascii_identifier_character` | `left: "log($.get(this.#c)א);"` |
| `a_private_field_prefix_is_not_collected_across_a_non_ascii_continuation` | `left: ["obj", "this"]` / `right: ["this"]` |
| `a_shadowing_scope_is_stripped_across_non_ascii_whitespace` | `body "function (a\u{3000}) { a }" left " unction (a\u{3000}) { a }"` |
| `a_store_name_inside_a_longer_non_ascii_identifier_is_not_a_parameter` | `assertion failed: !is_function_parameter_in_statement("名$c => 1", "$c")` |
| `a_store_parameter_is_recognised_across_non_ascii_whitespace` | `assertion failed: is_function_parameter_in_statement("$c\u{3000}=> 1", "$c")` |
| `a_store_call_is_not_inserted_into_a_longer_non_ascii_identifier` | `left: "$c()(1); x名$c()(2)"` / `right: "$c()(1); x名$c(2)"` |

`props_transforms.rs::non_ascii_boundary_tests` (5 tests)

| test | failed before with |
|---|---|
| `a_prop_name_inside_a_longer_non_ascii_identifier_is_not_a_mutation` | `left: "名$$ownership_validator.mutation(null, ['count', 'a'], count().a = 1);"` |
| `the_legacy_mutation_shape_honours_the_same_boundary` | same shape, legacy `prop(prop().m = v, true)` form |
| `a_collected_site_honours_the_same_boundary` | `left: 1` / `right: 0` |
| `a_non_ascii_member_name_is_scanned_whole` | `left: Some(["\u{FFFD}"])` / `right: Some(["名"])` |
| `non_ascii_whitespace_separates_a_member_from_its_operator` | `left: Some(["name\u{FFFD}"])` / `right: Some(["name"])` |

The store-call test needs a leading `$c(1);` because the cheap pre-check that guards
`transform_store_sub_calls` is character-correct already and would otherwise return before
the loop is entered — the test would then pass on the unfixed code without ever reaching the
branch it is about.

## Shape of the fix

Two decoders in `compiler/utils.rs` — `char_at` and `char_before` — replace
`bytes[i] as char` and `bytes[i - 1] as char`; both are O(1) on a `&str`. Three of the
`props_transforms` helpers change their parameter from `&[u8]` to `&str` so they can decode
at all; the ASCII-only helpers beside them (`skip_non_null_assertions`,
`starts_member_access`, `statement_end`) keep `&[u8]`. The whitespace skip is its own
function (`skip_whitespace_chars` in `props_transforms.rs`, `ends_a_parameter_name` in
`state_transforms.rs`) rather than being folded into anything shared.

`scan_member_chain_names` also stops handing its caller a cursor pointing *inside* a
character, so `String::from_utf8_lossy` there is gone and the member name is the real one.

## Merge-order notes

- **#2531 (issue #2492)** adds identifier classification to `compiler/utils.rs` using
  `oxc_syntax::identifier`. This PR adds two unrelated character decoders to the same file
  and does not touch identifier classification, so the collision is textual only — but if
  #2531 lands first, `char_at`/`char_before` and the new classifier should be looked at
  together, because `is_some_and(is_ident_char)` at four of the call sites here is exactly
  the predicate #2531 is unifying.
- **#2491 (issue #2461)** edits `class_transforms.rs:1748` and `state_transforms.rs:514-517`,
  which are inside the hunks this PR rewrites. Expect a textual conflict in both files
  whichever lands second; the changes are independent (that PR fixes the *cursor step*, this
  one the *decode*) and both must survive the resolution.
- **#2423** and **#2441** own the `server/transform_store.rs` and `no_unused_props.rs` sites
  of this issue and do not overlap with these files.

## Ratchets

No ratchet file is touched and none is expected to move: every changed predicate is
byte-identical on ASCII input except `ends_a_parameter_name`, whose ASCII widening needs
`function (<name>` followed immediately by a tab or newline — a shape prettier does not
produce, since it breaks after the `(`. If the corpus or matrix gate disagrees, that is a
real finding about the widening and not a baseline to refresh.

## Out of scope, reported not fixed

- `expression_utils.rs:350` skips whitespace with an explicit ASCII byte set
  (`b' ' | b'\t' | b'\r' | b'\n'`). Not a byte-decode bug — the same JS-whitespace-set
  question as #2502.
- I demonstrated each row at the function it lives in. Only the `class_transforms` pair has
  an end-to-end `.svelte` trigger here; `:752`/`:822`/`:1999` additionally sit behind an AST
  fast path, so reaching the text loop needs that path to bail. I did not construct
  end-to-end triggers for the `props_transforms` and `store_transforms` rows.

Fixes #2409
