### PR TITLE
fix(transform): carry a comment run in front of `await` into the dev-mode wrap

### DIFF
--- a/.changeset/await-comment-run-relocation.md
+++ b/.changeset/await-comment-run-relocation.md
@@ -1,0 +1,5 @@
+---
+'@rsvelte/compiler': patch
+---
+
+Move a comment run in front of an `await` into the dev-mode `$.track_reactivity_loss` wrap, as the official compiler does

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/ast_state_transform.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/ast_state_transform.rs
@@ -255,6 +255,8 @@ struct StateVarCollector<'a, 's> {
     in_shorthand_property: bool,
     /// Subtrees carrying a `svelte-ignore await_reactivity_loss`.
     await_ignore_ranges: super::await_reactivity_loss_ast::AwaitIgnoreRanges,
+    /// Comment runs the `await` wrap has to carry inside the call.
+    await_comment_runs: super::await_reactivity_loss_ast::AwaitCommentRuns,
     /// Starts of `await` expressions that are a whole statement relying on ASI.
     /// Statement start → end of the statement a `;` has to separate it from.
     await_separators: FxHashMap<u32, u32>,
@@ -385,6 +387,7 @@ impl<'a, 's> StateVarCollector<'a, 's> {
             scoped_vars: vec![FxHashSet::default()],
             in_shorthand_property: false,
             await_ignore_ranges: Default::default(),
+            await_comment_runs: Default::default(),
             await_separators: FxHashMap::default(),
             prop_source_vars: prop_source_set,
             non_bindable_prop_vars: non_bindable_set,
@@ -2029,18 +2032,29 @@ impl<'a, 's> StateVarCollector<'a, 's> {
         let arg_start = expr.span.start + "await".len() as u32;
         let arg_text = self.apply_and_drain_inner_replacements(arg_start, expr.span.end);
 
-        let wrap = format!("(await $.track_reactivity_loss({}))()", arg_text.trim());
+        let wrap = |argument: &str| format!("(await $.track_reactivity_loss({argument}))()");
         // The `;` rides inside this replacement rather than being appended to
         // the statement before it, which may have no replacement of its own.
         let (start, replacement) = match self.await_separators.get(&expr.span.start) {
             Some(&prev_end) => (
                 prev_end,
                 format!(
-                    ";{}{wrap}",
-                    &self.source[prev_end as usize..expr.span.start as usize]
+                    ";{}{}",
+                    &self.source[prev_end as usize..expr.span.start as usize],
+                    wrap(arg_text.trim())
                 ),
             ),
-            None => (expr.span.start, wrap),
+            // A statement whose own start is the `await` is exactly the shape
+            // that keeps its leading comments outside, so the two never mix.
+            None => match self
+                .await_comment_runs
+                .relocatable_run(self.source, expr.span.start)
+            {
+                Some((run_start, comments)) => {
+                    (run_start, wrap(&format!("{comments}{}", arg_text.trim())))
+                }
+                None => (expr.span.start, wrap(arg_text.trim())),
+            },
         };
         self.add_replacement(start, expr.span.end, replacement);
         true
@@ -2089,6 +2103,8 @@ impl<'a, 's> StateVarCollector<'a, 's> {
             self.source,
             self.is_runes,
         );
+        self.await_comment_runs =
+            super::await_reactivity_loss_ast::AwaitCommentRuns::collect(program);
     }
 
     /// Walk every argument of a `CallExpression` so inner state-var refs

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/await_reactivity_loss_ast.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/await_reactivity_loss_ast.rs
@@ -325,7 +325,7 @@ impl AwaitCommentRuns {
             text.push_str(&source[start as usize..end as usize]);
             let next = self.comments[first + index + 1..]
                 .first()
-                .map_or(await_start, |&(next_start, ..)| next_start);
+                .map_or(await_start, |&(next_start, ..)| next_start.min(await_start));
             // Whether the comment stood on a line of its own survives the move,
             // because the printer reproduces that break rather than the offset.
             // A line comment always breaks, or it would swallow the wrapper.

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/await_reactivity_loss_ast.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/await_reactivity_loss_ast.rs
@@ -246,6 +246,7 @@ pub(super) fn collect_await_reactivity_loss_edits(
 ) -> Vec<Edit> {
     let mut collector = AwaitCollector {
         source,
+        runs: AwaitCommentRuns::collect(program),
         ignored: collect_await_ignore_ranges(program, source, is_runes),
         separators: rustc_hash::FxHashMap::default(),
         experimental_async,
@@ -255,8 +256,117 @@ pub(super) fn collect_await_reactivity_loss_edits(
     collector.edits
 }
 
+/// Where the comments in front of an `await` keyword end up once the wrapper
+/// replaces it.
+///
+/// Upstream rebuilds the expression from position-less nodes and keeps only the
+/// argument's original span, so esrap — which flushes a pending comment at the
+/// first *located* node it reaches that starts after it — cannot flush the run
+/// before the wrapper and defers it to the argument. Two of esrap's other flush
+/// points still catch a run first: an enclosing node that starts on the `await`
+/// keyword itself, and the same-line trailing flush after a list element.
+#[derive(Default)]
+pub(super) struct AwaitCommentRuns {
+    /// `(start, end, is_line)` per comment, in source order.
+    comments: Vec<(u32, u32, bool)>,
+    /// Offsets where a node other than an `await` begins. A node starting on an
+    /// `await` keyword can only be one of that `await`'s ancestors, because
+    /// spans sharing a start nest and no child of an `await` reaches its `a`.
+    enclosing_starts: rustc_hash::FxHashSet<u32>,
+}
+
+impl AwaitCommentRuns {
+    pub(super) fn collect(program: &Program<'_>) -> Self {
+        if program.comments.is_empty() {
+            return Self::default();
+        }
+        let mut scan = StartScan {
+            starts: rustc_hash::FxHashSet::default(),
+        };
+        scan.visit_program(program);
+        Self {
+            comments: program
+                .comments
+                .iter()
+                .map(|comment| (comment.span.start, comment.span.end, comment.is_line()))
+                .collect(),
+            enclosing_starts: scan.starts,
+        }
+    }
+
+    /// The run to move, as `(start of the run, text to re-emit before the
+    /// argument)`, or `None` when it belongs outside the wrapper.
+    pub(super) fn relocatable_run(&self, source: &str, await_start: u32) -> Option<(u32, String)> {
+        if self.enclosing_starts.contains(&await_start) {
+            return None;
+        }
+
+        let mut run_start = await_start;
+        let mut first = self.comments.len();
+        for (index, &(start, end, _)) in self.comments.iter().enumerate().rev() {
+            if end > run_start {
+                continue;
+            }
+            if !source[end as usize..run_start as usize].trim().is_empty() {
+                break;
+            }
+            run_start = start;
+            first = index;
+        }
+        if first == self.comments.len() || flushed_as_a_trailing_comment(source, run_start) {
+            return None;
+        }
+
+        let mut text = String::new();
+        for (index, &(start, end, is_line)) in self.comments[first..].iter().enumerate() {
+            if start >= await_start {
+                break;
+            }
+            text.push_str(&source[start as usize..end as usize]);
+            let next = self.comments[first + index + 1..]
+                .first()
+                .map_or(await_start, |&(next_start, ..)| next_start);
+            // Whether the comment stood on a line of its own survives the move,
+            // because the printer reproduces that break rather than the offset.
+            // A line comment always breaks, or it would swallow the wrapper.
+            let broken = is_line || source[end as usize..next as usize].contains('\n');
+            text.push(if broken { '\n' } else { ' ' });
+        }
+        Some((run_start, text))
+    }
+}
+
+/// Whether the run at `run_start` sits on the same line as the end of the list
+/// element it follows, separated from it only by that list's `,` — the shape
+/// esrap prints as a trailing comment of the element instead.
+///
+/// A statement's `;` cannot reach here: it would make the `await` the first
+/// token of the next statement, which the enclosing-start check already
+/// rejects. Treating `;` as a separator would only misread a `for` head.
+fn flushed_as_a_trailing_comment(source: &str, run_start: u32) -> bool {
+    let before = source[..run_start as usize].trim_end();
+    if !before.ends_with(',') {
+        return false;
+    }
+    let previous = before[..before.len() - 1].trim_end();
+    !previous.is_empty() && !source[previous.len()..run_start as usize].contains('\n')
+}
+
+struct StartScan {
+    starts: rustc_hash::FxHashSet<u32>,
+}
+
+impl<'a> Visit<'a> for StartScan {
+    fn enter_node(&mut self, kind: AstKind<'a>) {
+        if !matches!(kind, AstKind::AwaitExpression(_)) {
+            self.starts.insert(kind.span().start);
+        }
+    }
+}
+
 struct AwaitCollector<'src> {
     source: &'src str,
+    runs: AwaitCommentRuns,
     ignored: AwaitIgnoreRanges,
     /// Statement start → end of the statement a `;` has to separate it from.
     separators: rustc_hash::FxHashMap<u32, u32>,
@@ -300,18 +410,26 @@ impl<'a, 'src> Visit<'a> for AwaitCollector<'src> {
         // `)` wherever the parse does not preserve parens.
         let arg_start = expr.span.start as usize + "await".len();
         let arg_text = self.source[arg_start..expr.span.end as usize].trim();
-        let wrap = track_reactivity_loss_wrap(arg_text);
         // The `;` rides inside this edit rather than as an insertion of its own,
         // which `splice`'s innermost-only filter would read as nested.
         let (start, replacement) = match self.separators.get(&expr.span.start) {
             Some(&prev_end) => (
                 prev_end,
                 format!(
-                    ";{}{wrap}",
-                    &self.source[prev_end as usize..expr.span.start as usize]
+                    ";{}{}",
+                    &self.source[prev_end as usize..expr.span.start as usize],
+                    track_reactivity_loss_wrap(arg_text)
                 ),
             ),
-            None => (expr.span.start, wrap),
+            // A statement whose own start is the `await` is exactly the shape
+            // that keeps its leading comments outside, so the two never mix.
+            None => match self.runs.relocatable_run(self.source, expr.span.start) {
+                Some((run_start, comments)) => (
+                    run_start,
+                    track_reactivity_loss_wrap(&format!("{comments}{arg_text}")),
+                ),
+                None => (expr.span.start, track_reactivity_loss_wrap(arg_text)),
+            },
         };
         self.edits.push((start, expr.span.end, replacement));
     }

--- a/crates/rsvelte_core/tests/await_comment_run_relocation.rs
+++ b/crates/rsvelte_core/tests/await_comment_run_relocation.rs
@@ -136,6 +136,16 @@ fn a_comment_on_its_own_line_keeps_the_break() {
     );
 }
 
+/// The break is read from the gap up to the `await`, not up to the next comment
+/// anywhere in the file: a later comment must not make this run look broken.
+#[test]
+fn a_later_comment_does_not_break_the_moved_run() {
+    assert_contains(
+        &module("\treturn (/* c */ await load())();\n\t// tail\n"),
+        "return (await $.track_reactivity_loss(/* c */ load()))()();",
+    );
+}
+
 const RUNES: &str = "<script>\n\tlet x = $state(1);\n\tasync function f() {\n\t\treturn (/* c */ await load())();\n\t}\n</script>\n<p>{x}{f}</p>";
 
 /// A runes instance script reaches a second copy of this rewrite, in

--- a/crates/rsvelte_core/tests/await_comment_run_relocation.rs
+++ b/crates/rsvelte_core/tests/await_comment_run_relocation.rs
@@ -1,0 +1,177 @@
+//! A comment run in front of an `await` keyword travels *into* the dev-mode
+//! `(await $.track_reactivity_loss(X))()` wrap, landing just before the wrapped
+//! argument — and the shapes that keep it outside keep it outside.
+//!
+//! Upstream rebuilds the expression from position-less builder nodes and keeps
+//! only the argument's original span, so esrap has nothing located to flush the
+//! run against until it reaches the argument. Two of its other flush points win
+//! first: an enclosing node that begins on the `await` keyword itself, and the
+//! same-line trailing flush after a preceding list element.
+//!
+//! Every expectation below is the official compiler's bytes.
+
+use rsvelte_core::compiler::ModuleCompileOptions;
+use rsvelte_core::{CompileOptions, GenerateMode, compile, compile_module};
+
+fn module(body: &str) -> String {
+    compile_module(
+        &format!("export async function f() {{\n{body}}}\n"),
+        ModuleCompileOptions {
+            filename: Some("m.svelte.js".to_string()),
+            generate: GenerateMode::Client,
+            dev: true,
+            ..Default::default()
+        },
+    )
+    .expect("compile")
+    .js
+    .code
+}
+
+fn component(body: &str) -> String {
+    compile(
+        body,
+        CompileOptions {
+            filename: Some("T.svelte".into()),
+            generate: GenerateMode::Client,
+            dev: true,
+            ..Default::default()
+        },
+    )
+    .expect("compile")
+    .js
+    .code
+}
+
+#[track_caller]
+fn assert_contains(out: &str, expected: &str) {
+    assert!(out.contains(expected), "expected `{expected}`. Got:\n{out}");
+}
+
+#[test]
+fn a_comment_before_a_parenthesized_await_moves_inside_the_wrap() {
+    assert_contains(
+        &module("\treturn (/* c */ await load())();\n"),
+        "return (await $.track_reactivity_loss(/* c */ load()))()();",
+    );
+}
+
+/// The adjacent shape — comment *between* `await` and its operand — already
+/// landed inside the call, and has to keep doing so.
+#[test]
+fn a_comment_between_await_and_its_operand_still_lands_inside() {
+    assert_contains(
+        &module("\treturn await /* c */ load();\n"),
+        "return (await $.track_reactivity_loss(/* c */ load()))();",
+    );
+}
+
+/// A statement that *begins* with the `await` is the shape upstream flushes the
+/// run against the statement instead, so the comment stays outside the wrap.
+#[test]
+fn a_statement_leading_comment_stays_outside_the_wrap() {
+    assert_contains(
+        &module("\t/* c */ await load();\n"),
+        "/* c */ (await $.track_reactivity_loss(load()))();",
+    );
+}
+
+/// Likewise for any other node that begins on the `await` keyword.
+#[test]
+fn a_comment_leading_an_enclosing_expression_stays_outside_the_wrap() {
+    assert_contains(
+        &module("\treturn /* c */ await load() + 1;\n"),
+        "return (/* c */ (await $.track_reactivity_loss(load()))() + 1);",
+    );
+}
+
+/// A run separated from the previous list element by only a comma, on that
+/// element's own line, is printed as *its* trailing comment.
+#[test]
+fn a_comment_trailing_the_previous_list_element_stays_outside_the_wrap() {
+    assert_contains(
+        &module("\tg(1, /* c */ await load());\n"),
+        "g(1, /* c */ (await $.track_reactivity_loss(load()))());",
+    );
+}
+
+/// The same source shape one line down: no longer trailing, so it moves.
+#[test]
+fn a_comma_separated_run_on_its_own_line_moves_inside_the_wrap() {
+    assert_contains(
+        &module("\tg(\n\t\t1,\n\t\t/* c */ await load()\n\t);\n"),
+        "g(1, (await $.track_reactivity_loss(/* c */ load()))());",
+    );
+}
+
+#[test]
+fn every_comment_in_the_run_moves_together() {
+    assert_contains(
+        &module("\treturn (/* a */ /* b */ await load())();\n"),
+        "return (await $.track_reactivity_loss(/* a */ /* b */ load()))()();",
+    );
+}
+
+/// Only the run adjacent to the `await` moves; a comment the `(` separates from
+/// it belongs to the enclosing call and stays put.
+#[test]
+fn a_run_broken_by_a_paren_moves_only_its_adjacent_half() {
+    assert_contains(
+        &module("\treturn /* a */ (/* b */ await load())();\n"),
+        "return (/* a */ (await $.track_reactivity_loss(/* b */ load()))()());",
+    );
+}
+
+/// A comment that stood on a line of its own keeps that break, which is also
+/// what stops a line comment from swallowing the wrapper's own `))()`.
+#[test]
+fn a_comment_on_its_own_line_keeps_the_break() {
+    assert_contains(
+        &module("\treturn (\n\t\t/* c */\n\t\tawait load())();\n"),
+        "return (await $.track_reactivity_loss(\n\t\t/* c */\n\t\tload()\n\t))()();",
+    );
+    assert_contains(
+        &module("\treturn (\n\t\t// c\n\t\tawait load())();\n"),
+        "return (await $.track_reactivity_loss(\n\t\t// c\n\t\tload()\n\t))()();",
+    );
+}
+
+const RUNES: &str = "<script>\n\tlet x = $state(1);\n\tasync function f() {\n\t\treturn (/* c */ await load())();\n\t}\n</script>\n<p>{x}{f}</p>";
+
+/// A runes instance script reaches a second copy of this rewrite, in
+/// `ast_state_transform`, which the module and legacy tails never touch.
+#[test]
+fn a_runes_instance_script_relocates_the_run_too() {
+    assert_contains(
+        &component(RUNES),
+        "return (await $.track_reactivity_loss(/* c */ load()))()();",
+    );
+}
+
+#[test]
+fn a_runes_instance_script_keeps_a_statement_leading_run_outside() {
+    let src = "<script>\n\tlet x = $state(1);\n\tasync function f() {\n\t\t/* c */ await load();\n\t}\n</script>\n<p>{x}{f}</p>";
+    assert_contains(
+        &component(src),
+        "/* c */ (await $.track_reactivity_loss(load()))();",
+    );
+}
+
+#[test]
+fn a_legacy_instance_script_relocates_the_run_too() {
+    let src = "<script>\n\texport let x = 1;\n\tasync function f() {\n\t\treturn (/* c */ await load())();\n\t}\n</script>\n<p>{x}{f}</p>";
+    assert_contains(
+        &component(src),
+        "return (await $.track_reactivity_loss(/* c */ load()))()();",
+    );
+}
+
+/// Covers the ignore gate rather than the move: this `await` never reaches the
+/// wrap, so the comment must be left exactly where the source put it.
+#[test]
+fn an_ignored_await_keeps_its_run_in_place() {
+    let out =
+        module("\t// svelte-ignore await_reactivity_loss\n\treturn (/* c */ await load())();\n");
+    assert!(!out.contains("track_reactivity_loss"), "got:\n{out}");
+    assert_contains(&out, "/* c */");
+}


### PR DESCRIPTION
A comment run standing in front of an `await` keyword stayed outside the dev-mode
`(await $.track_reactivity_loss(X))()` wrap. Official moves it inside the call, immediately
before the wrapped argument.

```js
// m.svelte.js, generate: 'client', dev: true
export async function f() {
	return (/* c */ await load())();
}
```

```js
official: return (await $.track_reactivity_loss(/* c */ load()))()();
before  : return (/* c */ (await $.track_reactivity_loss(load()))())();
```

## Where official does the relocation

`phases/3-transform/client/visitors/AwaitExpression.js:21` rebuilds the node as

```js
b.call(b.await(b.call('$.track_reactivity_loss', argument)))
```

Every node in that expression is a position-less builder node; only `argument` keeps its
original `loc`. esrap's `_` visitor (`esrap/src/languages/ts/index.js`) flushes pending
comments at each node that *has* a `loc` starting after them, so nothing between the old
`await` keyword and the argument can be flushed until the walk reaches `argument` — which is
already inside the call. The relocation is emergent, not written down anywhere.

rsvelte instead splices source text over `[await.start, await.end)`, so a comment sitting just
before the keyword was never part of the replaced range and stayed where it was.

## What changed

`relocatable_run` in `await_reactivity_loss_ast.rs` extends the replaced range backwards over
the comment run adjacent to the `await`, and re-emits that run just before the argument text —
unless one of esrap's other two flush points claims it first:

1. **An enclosing node begins on the `await` keyword.** `/* c */ await load();` (the
   `ExpressionStatement` starts at `await`), `return /* c */ await load() + 1;` (the
   `BinaryExpression` does). esrap flushes there, so the comment stays outside. Detected by
   collecting the start offsets of every non-`await` node: a node sharing an `await`'s start
   can only be one of its ancestors, since spans that share a start nest and no child of an
   `await` reaches its first byte.
2. **A same-line trailing flush after a preceding list element.** `g(1, /* c */ await load())`
   — `sequence()` calls `flush_trailing_comments` with the previous element's end, and the
   comment is on that line. Moving the same source one line down (`g(\n1,\n/* c */ await
   load())`) makes official relocate it, and this change follows.

Whether a comment stood on a line of its own is carried across the move, both to reproduce
official's layout and because a line comment that loses its break would swallow the wrapper's
own `))()`.

The two conditions never combine with the existing ASI-`;` path: that path only fires for an
`await` that is the first token of an `ExpressionStatement`, which condition 1 already rejects.

## Both copies of the rewrite

`track_reactivity_loss` is implemented twice. The module tail (`.svelte.js` / `<script
module>`) and the legacy instance tail share `await_reactivity_loss_ast.rs`; a **runes**
instance script is rewritten by `ast_state_transform::try_rewrite_await_reactivity_loss`
instead. The issue's "unmeasured" note was right: measuring all three showed the runes
instance diverging identically, so the new helper is shared and both call sites use it.

## Measurement

51 module-path shapes and 11 component shapes were compared byte-for-byte against
`svelte@5.56.8` (`generate: 'client'`, `dev: true`).

| | matching official |
|---|---|
| 51 module shapes (`.svelte.js`) on `origin/main` | 13 |
| … after this change | 49 |
| 11 component shapes, with only the module/legacy half fixed | 9 (both misses runes-instance) |
| … after the runes-instance half too | 11 |

The two module shapes still diverging are pre-existing and unrelated to this change (they
diverged before it too):

- `let y = 1; return (/* c */ await load())();` on one line — esrap's *statement-level*
  trailing flush hoists the comment out of the following statement entirely
  (`let y = 1; /* c */` then the return on the next line). A source-range splice cannot move a
  comment across a statement boundary.
- `async (p = /* c */ await load()) => p` — official rejects this with
  `Await expression cannot be a default value`; rsvelte compiles it. A parser-validation gap,
  filed separately from this fix's scope.

## How the tests fail without the fix

`crates/rsvelte_core/tests/await_comment_run_relocation.rs`, run against `origin/main`'s two
source files with the new tests in place:

```
test result: FAILED. 6 passed; 7 failed
failures:
    a_comma_separated_run_on_its_own_line_moves_inside_the_wrap
    a_comment_before_a_parenthesized_await_moves_inside_the_wrap
    a_comment_on_its_own_line_keeps_the_break
    a_legacy_instance_script_relocates_the_run_too
    a_run_broken_by_a_paren_moves_only_its_adjacent_half
    a_runes_instance_script_relocates_the_run_too
    every_comment_in_the_run_moves_together
```

Each failure is the predicted one — the comment printed before the wrapper rather than inside
it, e.g. `return (/* c */ (await $.track_reactivity_loss(load()))()());`. The 6 that pass are
the negative controls, and they are what a "relocate unconditionally" mutant would break:
`a_statement_leading_comment_stays_outside_the_wrap`,
`a_comment_leading_an_enclosing_expression_stays_outside_the_wrap`,
`a_comment_trailing_the_previous_list_element_stays_outside_the_wrap`,
`a_comment_between_await_and_its_operand_still_lands_inside` (the shape the issue notes was
already correct), `a_runes_instance_script_keeps_a_statement_leading_run_outside` and
`an_ignored_await_keeps_its_run_in_place`.

## Ratchets

No re-baselining is expected or performed.

- `compatibility/known-failures.client-dev.json` is `[]`, so there is nothing listed that could
  start passing. A *new* divergence would fail the gate; the 62-shape official comparison above
  is the evidence against one. `client` and `server` cannot be reached at all — the wrap is
  dev-and-client-only.
- `pnpm run corpus:matrix` (the generated shape matrix, 1995 comparisons) is green:
  `330 js-mismatch`, exactly the baseline, so neither side of that two-sided ratchet moves. Its
  `await` entries are all `{#await}` **template blocks** rather than `await` expressions with
  an adjacent comment, so the generated matrix does not reach this shape either way.
- The fmt, svelte2tsx and lint ratchets do not observe dev-mode client codegen.

Worth noting for the corpus gate's blind spot: `.svelte.js` / `.svelte.ts` entries lose their
comments to esbuild's TS strip (#2424), so the collected corpus would not have seen the
module-path half of this at all.

Fixes #2503
