### PR TITLE
test(compat): declare the validator message ratchet in known-failures-md-check

### DIFF
--- a/compatibility/validator-message-known-failures.md
+++ b/compatibility/validator-message-known-failures.md
@@ -42,6 +42,8 @@ construction — it runs both compilers on the same source in the same process. 
 gate has to reproduce that property deliberately**, which is the whole reason this test reads
 the generated tree rather than the sample directory.
 
+## Current baseline: `validator-message-known-failures.json`, 2 entries
+
 ## Entries
 
 ### `svelte-self-deprecated` — `svelte_self_deprecated`

--- a/scripts/compat-corpus/known-failures-md-check.mjs
+++ b/scripts/compat-corpus/known-failures-md-check.mjs
@@ -72,6 +72,11 @@ const RATCHETS = [
 	},
 	{ doc: 'matrix-known-failures.md', key: 'matrix-known-failures.json', jsons: ['matrix-known-failures.json'] },
 	{ doc: 'validator-known-failures.md', key: 'validator-known-failures.json', jsons: ['validator-known-failures.json'] },
+	{
+		doc: 'validator-message-known-failures.md',
+		key: 'validator-message-known-failures.json',
+		jsons: ['validator-message-known-failures.json'],
+	},
 	{ doc: 'sourcemap-known-failures.md', key: 'sourcemap-known-failures.json', jsons: ['sourcemap-known-failures.json'] },
 	{ doc: 'sourcemap-oracle-excluded.md', key: 'sourcemap-oracle-excluded.json', jsons: ['sourcemap-oracle-excluded.json'] },
 	{ doc: 'css-prune-known-failures.md', key: 'css-prune-known-failures.json', jsons: ['css-prune-known-failures.json'] },


### PR DESCRIPTION
`main` is red, and with it every open PR: `known-failures-md-check` is the first step of the corpus jobs.

```
[known-failures-md-check] validator-message-known-failures.json is a ratchet on disk
  but is not declared in RATCHETS — add it with the doc that justifies it
```

#2418 added `compatibility/validator-message-known-failures.json`. #2488 changed the checker so coverage is **declared** rather than inferred: every ratchet JSON on disk must appear in the `RATCHETS` list. Neither PR touched the other's lines, so both merged green and the combination fails.

This is the declared-list design working exactly as intended — an undeclared ratchet is a ratchet nothing reconciles against its doc, and that is the failure it is meant to make loud. The two PRs simply raced, and nothing in either one could have seen it.

## What changed

- declare `validator-message-known-failures.json` against the `.md` that already justifies it;
- add the `Current baseline: … 2 entries` line that doc was missing, because the count check needs the count stated next to the ratchet name.

Nothing else — no ratchet entry moves here. #2496 carries the same declaration alongside its own re-baseline; this is split out so `main` goes green without waiting on that PR's full corpus run.

Verified: `node scripts/compat-corpus/known-failures-md-check.mjs` → `19 declared ratchets across 16 docs match their JSON`, and `node scripts/dev/test-known-failures-md-check.mjs` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sb9ucum4Cxu99K1WCeyGC8
