### PR TITLE
fix(compiler): reflow the dev `$.tag(...)` wrap when its value carries a comment

### DIFF
--- a/.changeset/tidy-pugs-jump.md
+++ b/.changeset/tidy-pugs-jump.md
@@ -1,0 +1,5 @@
+---
+'@rsvelte/compiler': patch
+---
+
+Reflow the dev `$.tag(...)` wrap of a class state field whose value carries a leading comment

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/tag_class_field_ast.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/tag_class_field_ast.rs
@@ -311,9 +311,91 @@ fn handle_property_definition<'a>(
         None => format!("{}.#{}", class_name, field_name),
     };
 
+    replacements.push(tag_edit(
+        source,
+        prop.span().start,
+        prop.key.span().end,
+        init_span,
+        tag_fn,
+        &label,
+    ));
+}
+
+/// The `$.tag(...)` wrap for one value, reflowed when a comment sits between the
+/// `=` and the value: esrap cannot keep such a call on one line, because a `//`
+/// comment would swallow the rest of it.
+fn tag_edit(
+    source: &str,
+    stmt_start: u32,
+    lhs_end: u32,
+    init_span: Span,
+    tag_fn: &str,
+    label: &str,
+) -> Edit {
     let init_text = &source[init_span.start as usize..init_span.end as usize];
-    let rewrite = format!("{}({}, '{}')", tag_fn, init_text, label);
-    replacements.push((init_span.start, init_span.end, rewrite));
+    let flat = (
+        init_span.start,
+        init_span.end,
+        format!("{}({}, '{}')", tag_fn, init_text, label),
+    );
+    let Some(eq) = assignment_eq_offset(source, lhs_end, init_span.start) else {
+        return flat;
+    };
+    let comment = source[eq as usize + 1..init_span.start as usize].trim();
+    if comment.is_empty() {
+        return flat;
+    }
+
+    let indent = line_indent(source, stmt_start);
+    let arg_indent = format!("{}\t", indent);
+    let comment = comment
+        .lines()
+        .map(str::trim)
+        .collect::<Vec<_>>()
+        .join(&format!("\n{}", arg_indent));
+    // The value moves one level deeper, so its own continuation lines follow.
+    let init_text = init_text.replace('\n', "\n\t");
+    (
+        eq + 1,
+        init_span.end,
+        format!(
+            " {tag_fn}(\n{arg_indent}{comment}\n{arg_indent}{init_text},\n{arg_indent}'{label}'\n{indent})"
+        ),
+    )
+}
+
+/// Offset of the `=` separating a field / assignment target from its value,
+/// skipping comments so an `=` inside one is not mistaken for it.
+fn assignment_eq_offset(source: &str, from: u32, to: u32) -> Option<u32> {
+    let bytes = source.as_bytes();
+    let end = to as usize;
+    let mut i = from as usize;
+    while i < end {
+        match bytes[i] {
+            b'/' if bytes.get(i + 1) == Some(&b'/') => {
+                while i < end && bytes[i] != b'\n' {
+                    i += 1;
+                }
+            }
+            b'/' if bytes.get(i + 1) == Some(&b'*') => {
+                i += 2;
+                while i < end && !(bytes[i] == b'*' && bytes.get(i + 1) == Some(&b'/')) {
+                    i += 1;
+                }
+                i += 2;
+            }
+            b'=' => return Some(i as u32),
+            _ => i += 1,
+        }
+    }
+    None
+}
+
+fn line_indent(source: &str, pos: u32) -> &str {
+    let line_start = source[..pos as usize].rfind('\n').map_or(0, |i| i + 1);
+    let line = &source[line_start..];
+    let width = line.len() - line.trim_start_matches([' ', '\t']).len();
+    &line[..width]
 }
 
 fn walk_method_stmt_for_this_assigns<'a>(
@@ -522,9 +604,14 @@ fn handle_this_assignment<'a>(
         None => format!("{}.{}", class_name, field_name),
     };
 
-    let init_text = &source[init_span.start as usize..init_span.end as usize];
-    let rewrite = format!("{}({}, '{}')", tag_fn, init_text, label);
-    replacements.push((init_span.start, init_span.end, rewrite));
+    replacements.push(tag_edit(
+        source,
+        a.span().start,
+        a.left.span().end,
+        init_span,
+        tag_fn,
+        &label,
+    ));
 }
 
 fn is_this(expr: &Expression) -> bool {
@@ -567,6 +654,34 @@ mod tests {
             out,
             "class Counter { #count = $.tag($.state(0), 'Counter.#count'); }"
         );
+    }
+
+    #[test]
+    fn reflows_a_field_whose_value_carries_a_comment() {
+        let src = "class C {\n\t#n = // c\n\t$.state(0);\n}";
+        let out = wrap_state_derived_with_tag_class_fields_ast(src).unwrap();
+        assert_eq!(
+            out,
+            "class C {\n\t#n = $.tag(\n\t\t// c\n\t\t$.state(0),\n\t\t'C.#n'\n\t);\n}"
+        );
+    }
+
+    #[test]
+    fn reflows_a_this_assignment_whose_value_carries_a_comment() {
+        let src =
+            "class C {\n\t#n;\n\tconstructor() {\n\t\tthis.#n = // c\n\t\t$.state(0);\n\t}\n}";
+        let out = wrap_state_derived_with_tag_class_fields_ast(src).unwrap();
+        assert!(
+            out.contains("this.#n = $.tag(\n\t\t\t// c\n\t\t\t$.state(0),\n\t\t\t'C.#n'\n\t\t);"),
+            "got: {out}"
+        );
+    }
+
+    #[test]
+    fn keeps_a_field_on_one_line_without_a_comment() {
+        let src = "class C {\n\t#n = $.state(0);\n}";
+        let out = wrap_state_derived_with_tag_class_fields_ast(src).unwrap();
+        assert_eq!(out, "class C {\n\t#n = $.tag($.state(0), 'C.#n');\n}");
     }
 
     #[test]

--- a/crates/rsvelte_core/tests/tag_reflow_comment_2495.rs
+++ b/crates/rsvelte_core/tests/tag_reflow_comment_2495.rs
@@ -1,0 +1,128 @@
+//! Regression tests for #2495 — the dev `$.tag(...)` wrap of a class state
+//! field whose *value* carries a leading comment.
+//!
+//! esrap cannot keep such a call on one line: a `//` comment would swallow the
+//! rest of it, so upstream breaks `$.tag(value, name)` across lines with the
+//! comment as the first line inside the call. rsvelte applied the wrap after the
+//! comment had already been placed, so the comment stayed before the `$.tag(`.
+//!
+//! Every expectation below is the byte-exact output of the official compiler
+//! (`compileModule(src, { generate: 'client', dev: true })`, Svelte v5.56.8).
+
+use rsvelte_core::compiler::ModuleCompileOptions;
+use rsvelte_core::{GenerateMode, compile_module};
+
+fn compile_dev(src: &str) -> String {
+    compile_module(
+        src,
+        ModuleCompileOptions {
+            filename: Some("m.svelte.js".to_string()),
+            generate: GenerateMode::Client,
+            dev: true,
+            ..Default::default()
+        },
+    )
+    .expect("compile")
+    .js
+    .code
+}
+
+/// Repro A — public field, comment on the line above it. The public field is
+/// lowered to a private backing key, which is why the comment ends up between
+/// the `=` and the value in the first place.
+#[test]
+fn public_field_with_a_comment_above_it_reflows() {
+    let out = compile_dev("export class C {\n\t// c\n\tn = $state(0);\n}\n");
+    assert!(
+        out.contains("\t#n = $.tag(\n\t\t// c\n\t\t$.state(0),\n\t\t'C.n'\n\t);"),
+        "in:\n{out}"
+    );
+}
+
+/// Repro B — private field, comment after the `=`. This shape never reaches the
+/// class-field emitter (the rune-field scanner tests a single line, so
+/// `#n = // c` matches no `= $state(` pattern), so it is a separate test rather
+/// than a second assertion on repro A.
+#[test]
+fn private_field_with_a_comment_after_the_equals_reflows() {
+    let out = compile_dev("export class C {\n\t#n = // c\n\t\t$state(0);\n}\n");
+    assert!(
+        out.contains("\t#n = $.tag(\n\t\t// c\n\t\t$.state(0),\n\t\t'C.#n'\n\t);"),
+        "in:\n{out}"
+    );
+}
+
+/// The control the two repros need: with no comment the call stays on one line.
+/// Without it a fix that reflowed unconditionally would pass both repros.
+#[test]
+fn a_field_without_a_comment_stays_on_one_line() {
+    let out = compile_dev("export class C {\n\tn = $state(0);\n}\n");
+    assert!(
+        out.contains("\t#n = $.tag($.state(0), 'C.n');"),
+        "in:\n{out}"
+    );
+    assert!(!out.contains("$.tag(\n"), "in:\n{out}");
+}
+
+/// A comment above a *private* field is not in the value's leading position —
+/// upstream keeps it on its own line and the call on one line. The negative
+/// control for "any comment near the field reflows".
+#[test]
+fn a_comment_above_a_private_field_does_not_reflow() {
+    let out = compile_dev("export class C {\n\t// c\n\t#p = $state(0);\n}\n");
+    assert!(
+        out.contains("\t// c\n\t#p = $.tag($.state(0), 'C.#p');"),
+        "in:\n{out}"
+    );
+}
+
+/// The same reflow applies to a constructor assignment, which reaches a
+/// different handler than the class-field one.
+#[test]
+fn a_this_assignment_with_a_comment_after_the_equals_reflows() {
+    let out = compile_dev(
+        "export class C {\n\t#n;\n\tconstructor() {\n\t\tthis.#n = // c\n\t\t\t$state(0);\n\t}\n}\n",
+    );
+    assert!(
+        out.contains("\t\tthis.#n = $.tag(\n\t\t\t// c\n\t\t\t$.state(0),\n\t\t\t'C.#n'\n\t\t);"),
+        "in:\n{out}"
+    );
+}
+
+/// `$state.raw` reaches the same emitter through a different branch, and a
+/// proxied `$state` object nests `$.proxy(...)` inside the tagged value — both
+/// must reflow identically.
+#[test]
+fn raw_and_proxied_values_reflow_too() {
+    let raw = compile_dev("export class C {\n\t// c\n\tn = $state.raw(0);\n}\n");
+    assert!(
+        raw.contains("\t#n = $.tag(\n\t\t// c\n\t\t$.state(0),\n\t\t'C.n'\n\t);"),
+        "in:\n{raw}"
+    );
+
+    let proxied = compile_dev("export class C {\n\t// c\n\to = $state({ a: 1 });\n}\n");
+    assert!(
+        proxied
+            .contains("\t#o = $.tag(\n\t\t// c\n\t\t$.state($.proxy({ a: 1 })),\n\t\t'C.o'\n\t);"),
+        "in:\n{proxied}"
+    );
+}
+
+/// Non-dev output has no `$.tag` at all, so the comment stays where it was and
+/// nothing reflows — the axis the issue reports as already matching.
+#[test]
+fn non_dev_output_is_unchanged() {
+    let out = compile_module(
+        "export class C {\n\t// c\n\tn = $state(0);\n}\n",
+        ModuleCompileOptions {
+            filename: Some("m.svelte.js".to_string()),
+            generate: GenerateMode::Client,
+            ..Default::default()
+        },
+    )
+    .expect("compile")
+    .js
+    .code;
+    assert!(!out.contains("$.tag"), "in:\n{out}");
+    assert!(out.contains("// c"), "in:\n{out}");
+}


### PR DESCRIPTION
## Still broken on today's `main`

Measured first, on `c193616e` (after #2522 / #2536 landed today), with a freshly built
`librsvelte_napi.dylib` copied into `.corpus-cache/rsvelte.node`:

```
$ node scripts/compat-corpus/one.mjs reproA.svelte.js --target client-dev --raw
 export class C {
-	#n = $.tag(
-		// c
-		$.state(0),
-		'C.n'
-	);
+	#n = // c
+	$.tag($.state(0), 'C.n');
```

Repro B produced the same diff with the `'C.#n'` label. So the fix was still needed.

## Cause

`tag_class_field_ast::handle_property_definition` / `handle_this_assignment` replaced exactly
the value's span with `$.tag(<value>, '<label>')`. When a comment sits between the `=` and the
value, that leaves the comment ahead of the `$.tag(` — which is why the whole call ends up on
the line *after* the comment.

Upstream's shape is what esrap produces for a call whose argument carries a leading comment:
it cannot stay on one line, because the `//` would swallow the rest of the call.

## Fix

One edit builder (`tag_edit`) shared by both handlers. It looks at the gap between the `=`
(located with a comment-skipping scan, so an `=` inside a comment is not mistaken for it) and
the value; when that gap holds a comment, the edit starts at the `=` instead of at the value
and emits the multi-line form, indented from the field's / assignment's own line.

Both handlers go through it, so the class-field shape (repro A) and the `this.#field =` shape
are covered by one change rather than one each — the one-sided-fix failure mode the issue
calls out.

Note the issue predicted repro B would need a second fix in `class_transforms.rs`. It does
not: repro B does bypass `emit_class_field`, but the later text passes leave it in the *same*
intermediate shape (`#n = // c` ⏎ `$.state(0);`) that repro A reaches, so both are fixed at the
single `$.tag`-wrap site. `class_transforms.rs` is untouched.

## Verification

Repro A, repro B and the no-comment control all `MATCH` against the official compiler on
`client-dev`. A wider sweep (`$state.raw`, a proxied object value, a `this.#n =` constructor
assignment, a comment above a *private* field) also matches.

Negative control — the new test file on the pre-fix `tag_class_field_ast.rs`:

```
test result: FAILED. 3 passed; 4 failed
failures:
    a_this_assignment_with_a_comment_after_the_equals_reflows
    private_field_with_a_comment_after_the_equals_reflows
    public_field_with_a_comment_above_it_reflows
    raw_and_proxied_values_reflow_too
```

The three controls pass before *and* after, which is what makes the four repro tests
discriminating rather than a shared property of every input.

Every expected string in `crates/rsvelte_core/tests/tag_reflow_comment_2495.rs` was taken by
running `compileModule(src, { generate: 'client', dev: true })` from `submodules/svelte`, not
transcribed from the issue.

Suites, `--release`: `runtime` (5/5, 150 s), `ssr` (2/2), `print` (2/2), `sourcemaps` (2/2),
`rsvelte_core --lib` (1488/1488). `cargo fmt` + `cargo clippy --all-targets --all-features -D
warnings` clean.

## Ratchets

`pnpm run corpus:matrix`: **162 known divergences before, 162 after** — `match 1833 /
js-mismatch 162`, identical to `compatibility/matrix-known-failures.json` (162 entries). No
regressions and no shrink, so no re-baseline. Repro A's exact shape turns out not to be
generated by the `comment-slot` axis after all (the axis inserts at line boundaries, and a
comment above a *public* rune field is what lands in the infix slot).

The three collected-corpus ratchets are all **empty**. That is itself the argument that this
change cannot move them: if any corpus file had a comment in the value's leading position, it
would already be diverging today (flat vs. reflowed) and would be listed. CI's corpus gate
confirms.

## Out of scope (reported, not fixed)

Two neighbouring shapes still diverge, both before and after this PR:

- A **block** comment above a public rune field (`/* c */` ⏎ `n = $state(0)`). rsvelte emits it
  as a prefix line, not in the infix slot, so it never reaches the `$.tag` wrap. That is a
  comment-*placement* bug in `emit_class_field`, upstream of this one.
- `$derived` with a comment above it. Official emits `$.derived((// c` ⏎ `) => 1)` — esrap
  attaches the comment inside the arrow's parameter list. This PR moves rsvelte to
  `// c` ⏎ `$.derived(() => 1)` inside the reflowed call, which is closer but still not equal.

## Merge-order note

`crates/rsvelte_core/.../client/class_transforms.rs` is busy (#2531, #2541, #2491), but this PR
does not touch it. The only source file changed is `client/tag_class_field_ast.rs`, which none
of those three PRs touch — no conflicting hunk with any of them.

Fixes #2495
