### PR TITLE
test(validator): burn down the two message-ratchet entries main already fixed

### DIFF
--- a/compatibility/validator-message-known-failures.json
+++ b/compatibility/validator-message-known-failures.json
@@ -1,4 +1,1 @@
-[
-	"a11y-anchor-in-svg-is-valid",
-	"svelte-self-deprecated"
-]
+[]

--- a/compatibility/validator-message-known-failures.md
+++ b/compatibility/validator-message-known-failures.md
@@ -10,8 +10,9 @@ official, and is deliberately independent of `validator-known-failures.json`.
 
 `validator-known-failures.json` is per-fixture and all-or-nothing. Once a fixture is listed —
 almost always because a span is missing — it stops being watched for its **message text** too.
-All three entries below were suppressed that way, and `attribute_quoted` shipped a message
-asserting the warning applies to plain elements, which it never does (#2391).
+All three entries this ratchet was created for were suppressed that way, and
+`attribute_quoted` shipped a message asserting the warning applies to plain elements, which it
+never does (#2391).
 
 The generalisation is the point: **an entry suppresses everything about itself, not the thing
 its justification names.** A justification should therefore say what the entry *stops
@@ -42,25 +43,19 @@ construction — it runs both compilers on the same source in the same process. 
 gate has to reproduce that property deliberately**, which is the whole reason this test reads
 the generated tree rather than the sample directory.
 
-## Current baseline: `validator-message-known-failures.json`, 2 entries
+## Current baseline: `validator-message-known-failures.json`, 0 entries
 
-## Entries
+Empty. Every fixture matches upstream's rendered warning text. Both entries this ratchet was
+created with are fixed:
 
-### `svelte-self-deprecated` — `svelte_self_deprecated`
+- `a11y-anchor-in-svg-is-valid` — `a11y_invalid_attribute` named `href` where the source
+  spells it `xlink:href`, sending the reader to fix an attribute that is not there (#2413,
+  fixed by #2451).
+- `svelte-self-deprecated` — the suggested self-import path was capitalised, so following the
+  suggestion breaks the build on a case-sensitive filesystem (#2411, fixed by #2477).
 
-- rsvelte: ``<svelte:self>` is deprecated — use self-imports (e.g. `import Input from './Input.svelte'`) instead`
-- official: ``<svelte:self>` is deprecated — use self-imports (e.g. `import Input from './input.svelte'`) instead`
-
-The identifier is right; the **path** is capitalised and does not exist. Following the
-suggestion breaks the build on a case-sensitive filesystem. Tracked in #2411.
-
-### `a11y-anchor-in-svg-is-valid` — `a11y_invalid_attribute`
-
-- rsvelte: `'' is not a valid href attribute`
-- official: `'' is not a valid xlink:href attribute`
-
-Inside SVG the attribute is spelled `xlink:href`; naming it `href` sends the reader to fix an
-attribute that is not there. Tracked in #2413.
+Keep it empty: a new entry means a message regression, and the honest fix is the format
+string, not the baseline.
 
 ## Removing an entry
 


### PR DESCRIPTION
`main` is red on `validator_warning_messages_match_official`, and it is the `Test` job, so it fails on every open PR:

```
1 entr(ies) in compatibility/validator-message-known-failures.json now match —
  remove them (and their justification in the paired .md): ["a11y-anchor-in-svg-is-valid"]
```

Both entries the ratchet was created with are now fixed on `main`, and neither fix re-baselined:

- **`a11y-anchor-in-svg-is-valid`** — #2451 passes `&a.name` instead of the literal `"href"`, so the message names `xlink:href` as upstream does (#2413).
- **`svelte-self-deprecated`** — #2477 stopped capitalising the suggested self-import path, so following the suggestion no longer breaks the build on a case-sensitive filesystem (#2411).

CI only names the first because its run predates #2477 landing; running the suite against current `main` locally names both. This empties the ratchet.

That is the ratchet working as designed — two-sided means the PR that fixes an entry removes it in the same PR — but #2451 and #2477 were each green when they merged, because the ratchet did not exist on their base yet (#2418 added it in between). Same shape as the #2418/#2488 race #2552 just fixed: two PRs that do not touch each other's lines, red only in combination.

## Verification

`cargo test -p rsvelte_core --test validator` → 3/3 (`test_validator`, `validator_warning_messages_match_official`, `list_validator_fixtures`), and `known-failures-md-check` → 19 declared ratchets across 16 docs.

Split out of #2496 / #2426, which both carry this removal alongside larger re-baselines, so `main` goes green without waiting on either PR's full corpus run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sb9ucum4Cxu99K1WCeyGC8
