### PR TITLE
fix(compiler): scope the `bind:` dev `$.assign` exemption to the directive's own arrows

### DIFF
--- a/.changeset/bind-sequence-assign-exemption.md
+++ b/.changeset/bind-sequence-assign-exemption.md
@@ -1,0 +1,5 @@
+---
+'@rsvelte/compiler': patch
+---
+
+fix(compiler): scope the `bind:` dev `$.assign` exemption to the directive's own arrows

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/types.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/types.rs
@@ -1882,9 +1882,12 @@ pub struct ComponentClientTransformState<'a> {
     /// This is used to skip rest_prop → $$props transformation for direct property assignments.
     pub in_direct_assignment_lhs: bool,
 
-    /// Flag indicating if we're inside a bind directive expression.
-    /// Used to skip coercive assignment transforms ($.assign_nullish, etc.) for bind setters.
-    pub in_bind_directive: bool,
+    /// Start offsets of the arrows a `bind:` directive exempts from the dev
+    /// `$.assign` wrap. Upstream asks a path question — the arrow must *be* the
+    /// directive's expression or a direct element of its `SequenceExpression`
+    /// (`AssignmentExpression.js`) — so an arrow reached through a call, or one
+    /// nested inside a setter body, keeps the wrap.
+    pub bind_exempt_arrows: Vec<u32>,
 
     /// Set while converting a component attribute / `on:` directive value: upstream
     /// exempts every such arrow body from the `$.assign` wrap, not just event ones.
@@ -2206,7 +2209,7 @@ impl<'a> ComponentClientTransformState<'a> {
             module_level_snippets: Vec::new(),
             snippet_names: ImHashSet::new(),
             in_direct_assignment_lhs: false,
-            in_bind_directive: false,
+            bind_exempt_arrows: Vec::new(),
             in_component_attribute: false,
             parent_is_regular_element: false,
             state_declarator_name: None,

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/bind_directive.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/bind_directive.rs
@@ -18,7 +18,9 @@ use rustc_hash::FxHashSet;
 use crate::ast::js::Expression;
 use crate::ast::template::{Attribute, AttributeValue, AttributeValuePart, BindDirective};
 use crate::compiler::phases::phase3_transform::client::types::*;
-use crate::compiler::phases::phase3_transform::client::visitors::expression_converter::convert_expression;
+use crate::compiler::phases::phase3_transform::client::visitors::expression_converter::{
+    convert_bind_expression, convert_expression,
+};
 use crate::compiler::phases::phase3_transform::js_ast::JsArena;
 use crate::compiler::phases::phase3_transform::js_ast::builders as b;
 use crate::compiler::phases::phase3_transform::js_ast::nodes::*;
@@ -59,10 +61,7 @@ pub fn unified_build_bind_this(
         apply_transforms_to_expression, apply_transforms_to_expression_with_shadowed,
     };
 
-    let saved_in_bind = context.state.in_bind_directive;
-    context.state.in_bind_directive = true;
-    let raw_expr = convert_expression(expression, context);
-    context.state.in_bind_directive = saved_in_bind;
+    let raw_expr = convert_bind_expression(expression, context);
 
     let (getter_expr, setter_expr) = if let JsExpr::Sequence(ref seq) = raw_expr {
         if seq.expressions.len() == 2 {
@@ -389,7 +388,7 @@ fn bind_directive_inner(
 
     // Visit the expression to transform it using the full expression converter
     // (supports ArrowFunctionExpression, MemberExpression, etc.)
-    let expression = convert_expression(&node.expression, context);
+    let expression = convert_bind_expression(&node.expression, context);
 
     // In dev mode with runes, validate binding to non-reactive properties.
     // Reference: BindDirective.js lines 26-41

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/expression_converter.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/expression_converter.rs
@@ -151,6 +151,33 @@ pub fn convert_expression(expr: &Expression, context: &mut ComponentContext) -> 
     convert_js_node(&node, context)
 }
 
+/// Convert a `bind:` directive's expression, exempting the arrows upstream
+/// exempts from the dev `$.assign` wrap.
+///
+/// Upstream's test is positional (`AssignmentExpression.js`): the assignment's
+/// parent arrow must be the directive's own expression or a direct element of
+/// its `SequenceExpression`, so an arrow handed over by a call — or one nested
+/// inside a setter body — is not covered.
+pub fn convert_bind_expression(expr: &Expression, context: &mut ComponentContext) -> JsExpr {
+    let node = expr.as_node();
+    let exempt: Vec<u32> = match node.node_type() {
+        Some("ArrowFunctionExpression") => node.start().into_iter().collect(),
+        Some("SequenceExpression") => context
+            .state
+            .parse_arena
+            .get_js_children(node.expressions())
+            .iter()
+            .filter(|child| child.node_type() == Some("ArrowFunctionExpression"))
+            .filter_map(|child| child.start())
+            .collect(),
+        _ => Vec::new(),
+    };
+    let saved = std::mem::replace(&mut context.state.bind_exempt_arrows, exempt);
+    let converted = convert_js_node(&node, context);
+    context.state.bind_exempt_arrows = saved;
+    converted
+}
+
 /// Convert a JsNode directly to JsExpr via pattern matching, bypassing serde_json::Value
 /// for simple expression types. Complex types fall back to convert_json_value.
 fn convert_js_node(node: &JsNode, context: &mut ComponentContext) -> JsExpr {
@@ -841,7 +868,9 @@ fn convert_js_node(node: &JsNode, context: &mut ComponentContext) -> JsExpr {
                 .analysis
                 .event_attribute_arrow_starts
                 .contains(arrow_start);
+            let is_bind_exempt_arrow = context.state.bind_exempt_arrows.contains(arrow_start);
             context.state.event_handler_arrow_body_level = if (is_event_attribute_arrow
+                || is_bind_exempt_arrow
                 || context.state.in_component_attribute)
                 && body_is_assignment
             {
@@ -3117,18 +3146,19 @@ fn convert_arrow_function(
                 body_obj.get("type").and_then(|t| t.as_str()),
                 Some("AssignmentExpression")
             );
-            let is_event_attribute_arrow =
-                obj.get("start")
-                    .and_then(|v| v.as_u64())
-                    .is_some_and(|start| {
-                        context
-                            .state
-                            .analysis
-                            .event_attribute_arrow_starts
-                            .contains(&(start as u32))
-                    });
+            let arrow_start = obj.get("start").and_then(|v| v.as_u64()).map(|s| s as u32);
+            let is_event_attribute_arrow = arrow_start.is_some_and(|start| {
+                context
+                    .state
+                    .analysis
+                    .event_attribute_arrow_starts
+                    .contains(&start)
+            });
+            let is_bind_exempt_arrow =
+                arrow_start.is_some_and(|start| context.state.bind_exempt_arrows.contains(&start));
             let saved_level = context.state.event_handler_arrow_body_level;
             context.state.event_handler_arrow_body_level = if (is_event_attribute_arrow
+                || is_bind_exempt_arrow
                 || context.state.in_component_attribute)
                 && body_is_assignment
             {
@@ -5133,7 +5163,6 @@ fn try_dev_assign_wrap_typed(
     if !context.state.dev
         || is_statement
         || !is_non_coercive_operator(operator)
-        || context.state.in_bind_directive
         || context.state.event_handler_arrow_body_level > 0
     {
         return None;
@@ -5251,12 +5280,6 @@ fn try_coercive_assignment_transform(
 
     // Right side must not be a known primitive
     if is_known_primitive_json(obj.get("right")) {
-        return None;
-    }
-
-    // Skip inside bind directive / component binding contexts
-    // Reference: AssignmentExpression.js lines 211-225
-    if context.state.in_bind_directive {
         return None;
     }
 

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/fragment.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/fragment.rs
@@ -188,7 +188,7 @@ pub fn fragment(
         module_level_snippets: Vec::new(),
         snippet_names: context.state.snippet_names.clone(),
         in_direct_assignment_lhs: false,
-        in_bind_directive: false,
+        bind_exempt_arrows: Vec::new(),
         in_component_attribute: false,
         parent_is_regular_element: false,
         state_declarator_name: None,

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/component.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/component.rs
@@ -10,7 +10,9 @@ use crate::ast::template::{
     SvelteElement, TemplateNode,
 };
 use crate::compiler::phases::phase3_transform::client::types::*;
-use crate::compiler::phases::phase3_transform::client::visitors::expression_converter::convert_expression;
+use crate::compiler::phases::phase3_transform::client::visitors::expression_converter::{
+    convert_bind_expression, convert_expression,
+};
 use crate::compiler::phases::phase3_transform::client::visitors::shared::element::build_attribute_value;
 use crate::compiler::phases::phase3_transform::client::visitors::shared::events::build_event_handler;
 use crate::compiler::phases::phase3_transform::js_ast::builders as b;
@@ -1358,10 +1360,7 @@ fn process_bind_directive<'a>(
     ignored_codes: &[String],
 ) {
     // Convert the expression without transforms first
-    let saved_in_bind = context.state.in_bind_directive;
-    context.state.in_bind_directive = true;
-    let raw_expression = convert_expression(&bind.expression, context);
-    context.state.in_bind_directive = saved_in_bind;
+    let raw_expression = convert_bind_expression(&bind.expression, context);
 
     // Apply transforms to get the proper getter expression (e.g., $store.value -> $store().value)
     let transformed_expression =

--- a/crates/rsvelte_core/tests/dev_assign_bind_sequence.rs
+++ b/crates/rsvelte_core/tests/dev_assign_bind_sequence.rs
@@ -1,0 +1,149 @@
+//! Upstream's `bind:prop={getter, setter}` exemption from the dev `$.assign`
+//! wrap is a path shape, not a subtree: `AssignmentExpression.js` L209-215 asks
+//! whether the assignment's *parent* is an arrow that is a *direct element* of
+//! the `SequenceExpression` owned by the `BindDirective` / `Component` /
+//! `SvelteComponent`. Anything nested deeper — an arrow passed through a call,
+//! an arrow inside the setter's body — is still wrapped, and the exemption
+//! applies to element bindings exactly as it does to component ones.
+//!
+//! The corpus gates compile with `dev: false`, so nothing else covers this.
+
+use rsvelte_core::{CompileOptions, GenerateMode, compile};
+
+fn compile_client_dev(src: &str) -> String {
+    compile(
+        src,
+        CompileOptions {
+            filename: Some("Main.svelte".to_string()),
+            generate: GenerateMode::Client,
+            dev: true,
+            ..Default::default()
+        },
+    )
+    .expect("compile")
+    .js
+    .code
+}
+
+const SCRIPT: &str = "<script>\n\timport Comp from './Comp.svelte';\n\tlet scroll = $state({ x: 0, y: 0 });\n\tlet other = $state({ d: 0 });\n\tlet obj = $state({});\n\tfunction wrap(f) { return f; }\n</script>\n";
+
+fn assigns(body: &str) -> usize {
+    compile_client_dev(&format!("{SCRIPT}{body}\n"))
+        .matches("$.assign(")
+        .count()
+}
+
+#[test]
+fn a_bare_assignment_is_wrapped() {
+    // positive control: nothing about `bind:` is involved.
+    assert_eq!(
+        assigns("<form onsubmit={wrap(() => (scroll.x = obj))}></form>"),
+        1
+    );
+}
+
+#[test]
+fn an_element_bind_sequence_setter_arrow_is_exempt() {
+    assert_eq!(
+        assigns("<input bind:value={() => scroll.x, (v) => (scroll.y = obj)} />"),
+        0
+    );
+}
+
+#[test]
+fn a_component_bind_sequence_setter_arrow_is_exempt() {
+    assert_eq!(
+        assigns("<Comp bind:value={() => scroll.x, (v) => (scroll.y = obj)} />"),
+        0
+    );
+}
+
+#[test]
+fn an_arrow_reached_through_a_call_is_not_a_direct_sequence_element() {
+    assert_eq!(
+        assigns("<Comp bind:value={() => scroll.x, wrap((v) => (scroll.y = obj))} />"),
+        1
+    );
+    assert_eq!(
+        assigns("<input bind:value={() => scroll.x, wrap((v) => (scroll.y = obj))} />"),
+        1
+    );
+}
+
+#[test]
+fn an_arrow_nested_inside_the_setter_body_is_wrapped() {
+    assert_eq!(
+        assigns(
+            "<Comp bind:value={() => scroll.x, (v) => (scroll.y = wrap(() => (other.d = obj)))} />"
+        ),
+        1
+    );
+    assert_eq!(
+        assigns(
+            "<input bind:value={() => scroll.x, (v) => (scroll.y = wrap(() => (other.d = obj)))} />"
+        ),
+        1
+    );
+}
+
+#[test]
+fn a_block_bodied_setter_assigns_through_an_expression_statement() {
+    // `path.at(-1) === 'ExpressionStatement'` already silences the wrap.
+    assert_eq!(
+        assigns("<Comp bind:value={() => scroll.x, (v) => { scroll.y = obj; }} />"),
+        0
+    );
+    assert_eq!(
+        assigns("<input bind:value={() => scroll.x, (v) => { scroll.y = obj; }} />"),
+        0
+    );
+}
+
+#[test]
+fn svelte_component_and_svelte_window_bindings_follow_the_same_rule() {
+    assert_eq!(
+        assigns(
+            "<svelte:component this={Comp} bind:value={() => scroll.x, (v) => (scroll.y = obj)} />"
+        ),
+        0
+    );
+    assert_eq!(
+        assigns("<svelte:window bind:scrollY={() => scroll.x, (v) => (scroll.y = obj)} />"),
+        0
+    );
+}
+
+#[test]
+fn bind_this_sequences_are_exempt_too() {
+    assert_eq!(
+        assigns("<input bind:this={() => scroll.x, (v) => (scroll.y = obj)} />"),
+        0
+    );
+    assert_eq!(
+        assigns("<Comp bind:this={() => scroll.x, (v) => (scroll.y = obj)} />"),
+        0
+    );
+}
+
+#[test]
+fn a_coercive_operator_in_a_setter_arrow_is_exempt() {
+    assert_eq!(
+        assigns("<input bind:value={() => scroll.x, (v) => (scroll.y ??= obj)} />"),
+        0
+    );
+}
+
+#[test]
+fn a_plain_member_binding_synthesises_its_setter_and_never_wraps() {
+    assert_eq!(assigns("<Comp bind:value={scroll.x} />"), 0);
+    assert_eq!(assigns("<input bind:value={scroll.x} />"), 0);
+}
+
+#[test]
+fn a_setter_body_that_is_itself_a_sequence_is_wrapped() {
+    // The assignments' parent is the inner `SequenceExpression`, not the arrow.
+    assert_eq!(
+        assigns("<input bind:value={() => scroll.x, (v) => (scroll.y = obj, other.d = obj)} />"),
+        2
+    );
+}


### PR DESCRIPTION
Fixes #2484.

## The predicate upstream asks

`submodules/svelte/packages/svelte/src/compiler/phases/3-transform/client/visitors/AssignmentExpression.js:204-218`:

```js
// special case — ignore `bind:prop={getter, (v) => (...)}` / `bind:value={x.y}`
if (
	path.at(-1) === 'BindDirective' ||
	path.at(-1) === 'Component' ||
	path.at(-1) === 'SvelteComponent' ||
	(path.at(-1) === 'ArrowFunctionExpression' &&
		(path.at(-2) === 'BindDirective' ||
			(path.at(-2) === 'Component' && path.at(-3) === 'Fragment') ||
			(path.at(-2) === 'SequenceExpression' &&
				(path.at(-3) === 'Component' ||
					path.at(-3) === 'SvelteComponent' ||
					path.at(-3) === 'BindDirective'))))
) {
	should_transform = false;
}
```

The assignment's **parent** must be an arrow that is the directive's own expression or a
**direct element** of its `SequenceExpression`. rsvelte asked a different question: a sticky
`state.in_bind_directive` boolean, set for the whole conversion of a *component* bind
expression and never set at all for an *element* bind directive. Wrong question, not a
mis-tuned threshold — which is why it was wrong in both directions at once, and why this PR
replaces the predicate instead of adding a second condition to it.

`state.bind_exempt_arrows` now carries the start offsets of exactly those arrows for the
duration of the directive's conversion, and the arrow converter feeds them into the same
`event_handler_arrow_body_level` mechanism the event-attribute exemption already uses — which
fires only when the arrow's body *is* the assignment, and which every nested arrow clears.
Both arrow converters (the typed `JsNode` path and the `serde_json` fallback) were updated,
and the three sites that convert a `bind:` expression — element directives
(`bind_directive_inner`), component directives (`process_bind_directive`) and `bind:this`
(`unified_build_bind_this`) — now go through one entry point.

## Both directions, measured

`$.assign(` occurrences in `compile(src, { generate: 'client', dev: true })`, oracle = official
`svelte@5.56.8` (the `submodules/svelte` pin). "before" is `origin/main` at `ddc8be40`, i.e.
**with #2421 already merged** — the issue predates it, so every row was re-derived by running
both compilers rather than copied from the issue.

### Direction A — rsvelte wrapped where upstream exempts (element bind directives)

| shape | official | before | after |
|---|---|---|---|
| `<input bind:value={() => s.x, (v) => (s.y = o)} />` | 0 | **1** | 0 |
| `<input bind:value={() => s.x, (v) => (s.y ??= o)} />` | 0 | **1** | 0 |
| `<svelte:window bind:scrollY={() => s.x, (v) => (s.y = o)} />` | 0 | **1** | 0 |

rsvelte had no equivalent of `path.at(-3) === 'BindDirective'` for elements at all.

### Direction B — rsvelte exempted where upstream wraps (component bind directives)

| shape | official | before | after |
|---|---|---|---|
| `<Comp bind:value={() => s.x, wrap((v) => (s.y = o))} />` | 1 | **0** | 1 |
| `<Comp bind:value={() => s.x, (v) => (s.y = wrap(() => (d.e = o)))} />` | 1 | **0** | 1 |

The sticky flag exempted the directive's whole subtree, so an arrow handed over by a call and
an arrow nested inside the setter body were both silenced.

### Controls that must not move (all unchanged, before = after = official)

| shape | official |
|---|---|
| `<form onsubmit={wrap(() => (s.x = o))}>` (no `bind:` involved) | 1 |
| `<Comp bind:value={() => s.x, (v) => (s.y = o)} />` | 0 |
| `<input bind:value={() => s.x, wrap((v) => (s.y = o))} />` | 1 |
| `<Comp bind:value={() => s.x, (v) => { s.y = o; }} />` / same on `<input>` | 0 |
| `<svelte:component this={C} bind:value={() => s.x, (v) => (s.y = o)} />` | 0 |
| `<input bind:this={...}>` / `<Comp bind:this={...}>` sequence form | 0 |
| `<Comp bind:value={s.x} />` / `<input bind:value={s.x} />` | 0 |
| `<input bind:value={() => s.x, (v) => (s.y = o, d.e = o)} />` | **2** |

The last one is the control that pins the *mechanism* rather than the flag: the arrow's body is
a `SequenceExpression`, so the assignments' parent is not the arrow and upstream wraps **both**.
An implementation that exempted "the setter arrow's subtree" would report 0 here.

## Pre-fix failure output

`crates/rsvelte_core/tests/dev_assign_bind_sequence.rs` on `origin/main` (source unchanged,
test file added): **6 passed, 5 failed**, each for the predicted count and direction —

```
test an_element_bind_sequence_setter_arrow_is_exempt ... FAILED           left: 1  right: 0
test a_coercive_operator_in_a_setter_arrow_is_exempt ... FAILED           left: 1  right: 0
test svelte_component_and_svelte_window_bindings_follow_the_same_rule ... FAILED  left: 1  right: 0
test an_arrow_reached_through_a_call_is_not_a_direct_sequence_element ... FAILED  left: 0  right: 1
test an_arrow_nested_inside_the_setter_body_is_wrapped ... FAILED         left: 0  right: 1
```

All 11 pass after.

## Gates

- `cargo test -p rsvelte_core` on `runtime` (legacy + runes + hydration + browser), `ssr`, `css`,
  `validator`, `compiler_fixtures`, `compiler_errors`, `print` and all seven `dev_assign_*` /
  `dev_bind_setter_ownership` suites: clean.
- `cargo fmt --all`, `cargo clippy --all-targets --all-features -- -D warnings`: clean.
- `pnpm run corpus:matrix`: `match 1833 / js-mismatch 162 / error-mismatch 0` — identical to the
  162-entry baseline, so no re-baseline. Expected: `matrix/axes.mjs` generates no `bind:`
  directive shapes, so that gate cannot observe this class at all.
