### PR TITLE
perf(transform): skip the instance-script scans whose answer is already settled

### DIFF
--- a/.changeset/collect-vars-scan-gates.md
+++ b/.changeset/collect-vars-scan-gates.md
@@ -1,0 +1,20 @@
+---
+"@rsvelte/compiler": patch
+---
+
+Skip the instance-script variable scans whose result is already settled
+
+Three whole-script text scans in the client instance-script transform ran on
+every component regardless of what the script contained:
+
+- `index_const_state_decls` and `index_reassigned_vars` are read only while
+  iterating `local_reactive_vars`, so an empty list makes both unobservable.
+- `extract_proxy_vars` pushes nothing without a `$state(` on the line.
+- `collect_local_state_decls` inserts nothing without a literal `= $state(`.
+
+Each now returns its empty result from a single `memmem` probe instead of
+walking the script. Measured as bytes handed to these scans across four
+real-world corpora: huly/plugins skips 6,710,403 of 6,710,403 (2,123 files),
+carbon/src 1,605,612 of 1,605,612, open-webui/src 3,767,567 of 3,776,399, and
+SMUI — which uses `$state` throughout, so the gates cannot fire — skips only
+160,953 of 2,191,645.

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
@@ -3397,6 +3397,11 @@ fn cleanup_import_line(import: &str) -> String {
 /// holds iff `<kw> N = $state(` occurs for some keyword. The keyword is matched as
 /// a raw substring (no left word boundary), mirroring the original `contains`.
 fn collect_local_state_decls(script: &str) -> rustc_hash::FxHashSet<&str> {
+    // The only insert requires this exact suffix, so its absence settles the answer
+    // without the three keyword scans below.
+    if memmem::find(script.as_bytes(), b" = $state(").is_none() {
+        return rustc_hash::FxHashSet::default();
+    }
     let mut set: rustc_hash::FxHashSet<&str> = rustc_hash::FxHashSet::default();
     for kw in ["let ", "const ", "var "] {
         let mut from = 0;
@@ -3802,6 +3807,10 @@ fn is_inside_function_with_param(script: &str, pos: usize, param_name: &str) -> 
 /// These variables will be transformed to $.proxy() and should NOT have $.get() wrapping
 /// when accessing their properties.
 fn extract_proxy_vars(script: &str) -> Vec<String> {
+    // Nothing is pushed without a `$state(` on the line, so no token means no result.
+    if memmem::find(script.as_bytes(), b"$state(").is_none() {
+        return Vec::new();
+    }
     let mut proxy_vars = Vec::new();
 
     for line in script.lines() {
@@ -4684,8 +4693,16 @@ fn transform_instance_script_for_visitors(
     // One pass each, shared by both loops below. Asking per variable walked
     // the whole script once per variable, which is where this stage's cost
     // grew faster than the script did.
-    let const_state_decls = index_const_state_decls(&script_rest);
-    let reassigned_in_text = index_reassigned_vars(&script_rest);
+    // Every read of either index happens while iterating `local_reactive_vars`, so
+    // an empty list makes both whole-script passes unobservable.
+    let (const_state_decls, reassigned_in_text) = if local_reactive_vars.is_empty() {
+        Default::default()
+    } else {
+        (
+            index_const_state_decls(&script_rest),
+            index_reassigned_vars(&script_rest),
+        )
+    };
     if super::profile::index_oracle_enabled() {
         for (var, ..) in &local_reactive_vars {
             super::profile::record_index_oracle(


### PR DESCRIPTION
Three whole-script text scans in the client instance-script transform ran on every
component regardless of what the script contained. Each is settled by a single
`memmem` probe:

| scan | why the probe settles it |
|---|---|
| `index_const_state_decls` | every read happens while iterating `local_reactive_vars` |
| `index_reassigned_vars` | same |
| `extract_proxy_vars` | pushes nothing without a `$state(` on the line |
| `collect_local_state_decls` | inserts nothing without a literal `= $state(` |

`collect_vars` is the largest pure-text bucket inside `script_text_transform`
(30.7% of it on real projects), and `index_reassigned_vars` in particular walks
every identifier in the script and applies a predicate per identifier.

## Measurement

Bytes handed to these scans, counted in one instrumented run per corpus (both
branches of each gate counted, so no A/B and no wall clock is involved):

| corpus | files | scanned | skipped | skip share |
|---|---|---|---|---|
| huly/plugins | 2,123 | 0 (0 calls) | 6,710,403 (4,136 calls) | **100.0%** |
| carbon/src | 287 | 0 (0 calls) | 1,605,612 (521 calls) | **100.0%** |
| open-webui/src | 650 | 8,832 (6 calls) | 3,767,567 (1,273 calls) | 99.8% |
| SMUI | 449 | 2,030,692 (799 calls) | 160,953 (317 calls) | 7.3% |

SMUI is the negative control: it uses `$state` throughout, so the gates cannot
fire there, and they don't.

## What this does not claim

No wall-clock number. The dev machine has been at load average ~100 from parallel
worktrees, where paired A/B on this repo has returned -18.3% and +4.4% on
neighbouring corpora within a single run. The byte counts above are deterministic
and load-independent; they say the work is gone, not how much time it was taking.

Note for reviewers: CodSpeed will most likely read 0% on this PR, and that is
expected rather than reassuring — 8 of the 9 files in `benches/corpus/` use
`$state`, so the gates cannot fire on the benchmark workload. Across 3,509 files
from four shipped projects, only 8.0% do.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
