### PR TITLE
bench(corpus): add the two shipped-code shapes the fixtures were missing

### DIFF
--- a/benches/corpus/10-legacy-typescript-props.svelte
+++ b/benches/corpus/10-legacy-typescript-props.svelte
@@ -1,0 +1,127 @@
+<script lang="ts">
+	import { onMount, createEventDispatcher } from 'svelte';
+	import { writable, derived, type Readable } from 'svelte/store';
+
+	type Severity = 'info' | 'warning' | 'error';
+
+	interface Notice {
+		id: string;
+		severity: Severity;
+		message: string;
+		at: number;
+	}
+
+	export let title: string = 'Notifications';
+	export let notices: Notice[] = [];
+	export let maxVisible: number = 5;
+	export let dismissable: boolean = true;
+	export let emptyLabel: string = 'Nothing to show';
+	export let severityFilter: Severity | null = null;
+
+	const dispatch = createEventDispatcher<{ dismiss: { id: string }; seen: void }>();
+
+	const now = writable(Date.now());
+	const unreadCount = writable(0);
+	const label: Readable<string> = derived(unreadCount, (n) => (n === 0 ? 'read' : `${n} unread`));
+
+	let expanded = false;
+	let hovered: string | null = null;
+	let container: HTMLDivElement;
+
+	$: filtered = severityFilter ? notices.filter((n) => n.severity === severityFilter) : notices;
+	$: visible = expanded ? filtered : filtered.slice(0, maxVisible);
+	$: hiddenCount = filtered.length - visible.length;
+	$: errorCount = filtered.filter((n) => n.severity === 'error').length;
+	$: heading = errorCount > 0 ? `${title} (${errorCount})` : title;
+	$: ages = visible.map((n) => Math.max(0, Math.round(($now - n.at) / 1000)));
+
+	$: if (errorCount > 0 && !expanded) {
+		expanded = true;
+	}
+
+	function dismiss(id: string): void {
+		notices = notices.filter((n) => n.id !== id);
+		unreadCount.update((n) => Math.max(0, n - 1));
+		dispatch('dismiss', { id });
+	}
+
+	function severityClass(severity: Severity): string {
+		return `notice notice--${severity}`;
+	}
+
+	onMount(() => {
+		const timer = setInterval(() => now.set(Date.now()), 1000);
+		dispatch('seen');
+		return () => clearInterval(timer);
+	});
+</script>
+
+<div class="panel" bind:this={container} class:panel--expanded={expanded}>
+	<header>
+		<h2>{heading}</h2>
+		<span class="badge">{$label}</span>
+	</header>
+
+	{#if visible.length === 0}
+		<p class="empty">{emptyLabel}</p>
+	{:else}
+		<ul>
+			{#each visible as notice, i (notice.id)}
+				<li
+					class={severityClass(notice.severity)}
+					on:mouseenter={() => (hovered = notice.id)}
+					on:mouseleave={() => (hovered = null)}
+				>
+					<span class="message">{notice.message}</span>
+					<span class="age">{ages[i]}s</span>
+					{#if dismissable && hovered === notice.id}
+						<button type="button" on:click={() => dismiss(notice.id)}>Dismiss</button>
+					{/if}
+				</li>
+			{/each}
+		</ul>
+	{/if}
+
+	{#if hiddenCount > 0}
+		<button class="more" type="button" on:click={() => (expanded = !expanded)}>
+			{expanded ? 'Show less' : `Show ${hiddenCount} more`}
+		</button>
+	{/if}
+</div>
+
+<style>
+	.panel {
+		border: 1px solid #d8d8de;
+		border-radius: 6px;
+		padding: 12px;
+	}
+
+	.panel--expanded {
+		box-shadow: 0 2px 8px rgb(0 0 0 / 12%);
+	}
+
+	header {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+	}
+
+	.notice {
+		display: flex;
+		gap: 8px;
+		padding: 6px 0;
+	}
+
+	.notice--error {
+		color: #b3261e;
+	}
+
+	.notice--warning {
+		color: #8a6d00;
+	}
+
+	.empty {
+		color: #6c6c76;
+		font-style: italic;
+	}
+</style>

--- a/benches/corpus/11-store-heavy-legacy.svelte
+++ b/benches/corpus/11-store-heavy-legacy.svelte
@@ -1,0 +1,153 @@
+<script lang="ts">
+	import { getContext } from 'svelte';
+	import { writable, derived, get, type Writable, type Readable } from 'svelte/store';
+
+	interface Row {
+		id: number;
+		owner: string;
+		status: 'open' | 'closed' | 'blocked';
+		estimate: number;
+		spent: number;
+	}
+
+	export let boardId: string;
+	export let title = 'Board';
+	export let compact = false;
+
+	const rows: Writable<Row[]> = getContext('rows');
+	const query: Writable<string> = writable('');
+	const sortKey: Writable<keyof Row> = writable('id');
+	const ascending: Writable<boolean> = writable(true);
+	const selection: Writable<Set<number>> = writable(new Set());
+	const theme: Readable<string> = getContext('theme');
+
+	const totals = derived(rows, ($rows) => ({
+		estimate: $rows.reduce((n, r) => n + r.estimate, 0),
+		spent: $rows.reduce((n, r) => n + r.spent, 0)
+	}));
+
+	let editing: number | null = null;
+	let draft = '';
+
+	$: needle = $query.trim().toLowerCase();
+	$: matched = needle ? $rows.filter((r) => r.owner.toLowerCase().includes(needle)) : $rows;
+	$: sorted = [...matched].sort((a, b) => {
+		const key = $sortKey;
+		const dir = $ascending ? 1 : -1;
+		return a[key] > b[key] ? dir : a[key] < b[key] ? -dir : 0;
+	});
+	$: open = sorted.filter((r) => r.status === 'open').length;
+	$: blocked = sorted.filter((r) => r.status === 'blocked').length;
+	$: overrun = $totals.spent > $totals.estimate;
+	$: selectedCount = $selection.size;
+	$: allSelected = sorted.length > 0 && selectedCount === sorted.length;
+
+	$: if (overrun) {
+		console.warn('over estimate on', boardId, $totals.spent, $totals.estimate);
+	}
+
+	function toggle(id: number): void {
+		selection.update((set) => {
+			const next = new Set(set);
+			if (next.has(id)) next.delete(id);
+			else next.add(id);
+			return next;
+		});
+	}
+
+	function toggleAll(): void {
+		selection.set(allSelected ? new Set() : new Set(sorted.map((r) => r.id)));
+	}
+
+	function sortBy(key: keyof Row): void {
+		if (get(sortKey) === key) ascending.update((v) => !v);
+		else {
+			sortKey.set(key);
+			ascending.set(true);
+		}
+	}
+
+	function commit(row: Row): void {
+		$rows = $rows.map((r) => (r.id === row.id ? { ...r, owner: draft } : r));
+		editing = null;
+	}
+</script>
+
+<section class="board {$theme}" class:compact>
+	<header>
+		<h3>{title}</h3>
+		<input type="search" placeholder="Filter owner" bind:value={$query} />
+		<span>{open} open · {blocked} blocked · {selectedCount} selected</span>
+	</header>
+
+	<table>
+		<thead>
+			<tr>
+				<th><input type="checkbox" checked={allSelected} on:change={toggleAll} /></th>
+				<th on:click={() => sortBy('id')}>#</th>
+				<th on:click={() => sortBy('owner')}>Owner</th>
+				<th on:click={() => sortBy('status')}>Status</th>
+				<th on:click={() => sortBy('estimate')}>Estimate</th>
+			</tr>
+		</thead>
+		<tbody>
+			{#each sorted as row (row.id)}
+				<tr class:selected={$selection.has(row.id)} class:blocked={row.status === 'blocked'}>
+					<td><input type="checkbox" on:change={() => toggle(row.id)} /></td>
+					<td>{row.id}</td>
+					<td>
+						{#if editing === row.id}
+							<input bind:value={draft} on:blur={() => commit(row)} />
+						{:else}
+							<button
+								type="button"
+								on:click={() => {
+									editing = row.id;
+									draft = row.owner;
+								}}>{row.owner}</button
+							>
+						{/if}
+					</td>
+					<td>{row.status}</td>
+					<td>{row.estimate}h / {row.spent}h</td>
+				</tr>
+			{:else}
+				<tr><td colspan="5">No matching rows</td></tr>
+			{/each}
+		</tbody>
+		<tfoot>
+			<tr class:overrun>
+				<td colspan="4">Total</td>
+				<td>{$totals.estimate}h / {$totals.spent}h</td>
+			</tr>
+		</tfoot>
+	</table>
+</section>
+
+<style>
+	.board {
+		font-size: 14px;
+	}
+
+	.compact td,
+	.compact th {
+		padding: 2px 4px;
+	}
+
+	th {
+		cursor: pointer;
+		text-align: left;
+	}
+
+	.selected {
+		background: #eef4ff;
+	}
+
+	.blocked {
+		color: #b3261e;
+	}
+
+	.overrun td {
+		font-weight: 600;
+	}
+</style>

--- a/benches/corpus/README.md
+++ b/benches/corpus/README.md
@@ -22,9 +22,16 @@ These fixtures are committed directly to the repo, so the workload is stable
 across submodule bumps and identical on every branch. **Treat each file as an
 append-only, stable benchmark identity** — the benchmark IDs are derived from
 the filenames (without the `.svelte` extension), so renaming a file resets its
-CodSpeed history. Adding a new file is free; editing an existing one changes
-what that benchmark measures (which is fine, but expect a one-time step in the
-trend).
+CodSpeed history. Editing an existing one changes what that benchmark measures
+(which is fine, but expect a one-time step in the trend).
+
+Adding a new file is free for the **per-file** benchmark IDs, but not for the
+two that aggregate the whole corpus into a single ID:
+`parallel_parse::corpus` (`benches/parser.rs`) parses every fixture in one
+iteration, and `compile_both` sums over the workload. Their cost is
+proportional to the corpus, so adding a fixture raises them by construction and
+CodSpeed reports it as a regression. That alert has to be acknowledged once, in
+the PR that adds the file — it is a workload change, not a slowdown.
 
 ## What's here
 

--- a/benches/corpus/README.md
+++ b/benches/corpus/README.md
@@ -43,7 +43,30 @@ prefix so iteration order is deterministic.
 | `07-snippets.svelte`        | runes  | `{#snippet}` / `{@render}`, `{@const}`, snippet props |
 | `08-control-flow.svelte`    | runes  | `{#if}`/`{#each}`/`{#await}`/`{#key}` mix, `{@html}` |
 | `09-typescript-generics.svelte` | runes + TS | generic `$props`, typed snippets/callbacks, type assertions |
+| `10-legacy-typescript-props.svelte` | legacy + TS | `export let` with type annotations, `$:` chains, `$store` reads, typed `createEventDispatcher` |
+| `11-store-heavy-legacy.svelte` | legacy + TS | `$store` autosubscription throughout script *and* markup, `$store` assignment, `getContext` stores, `$:` over store reads |
 
 Synthetic *scale* inputs (large, deterministic, generated in-code) live in the
 bench files themselves, not here — they're pure functions, so they're stable
 without needing to commit a huge file.
+
+## Distribution, not just coverage
+
+Fixtures 01–09 were picked to *cover features* — one distinct compiler slice
+each. That makes them a poor proxy for the *mix* of shipped Svelte code, and
+the benchmarks aggregate over them, so the mix is what the numbers report.
+Measured over 3,509 `.svelte` files from four shipped projects (huly/plugins,
+open-webui, carbon-components-svelte, SMUI):
+
+| axis | shipped | fixtures 01–09 |
+|------|---------|----------------|
+| uses `$state` / `$derived` | 8.0% | 88.9% |
+| uses `$:` | 0–60% by project | 11% |
+| uses `export let` | 0–90% by project | 11% |
+| `lang="ts"` | 0–99% by project | 11% |
+| p90 source size | 4.9–15.7 KB | 2.6 KB |
+
+An optimization that only pays off on legacy, TypeScript, or store-heavy
+components — which is most of the shipped population — reads as 0% here.
+Fixtures 10–11 exist to close that gap; keep the distribution in mind when
+adding more.


### PR DESCRIPTION
## The problem

CodSpeed is this repo's only load-independent performance signal — instruction
counts under Valgrind, deterministic, head-vs-base per PR. Its workload is the
pinned corpus in `benches/corpus/`, 9 files chosen to *cover features*: one
distinct compiler slice each.

Feature coverage and population representativeness are different properties, and
the benchmarks aggregate over the corpus, so it is the population that the numbers
report. Measured over 3,509 `.svelte` files from four shipped projects
(huly/plugins 2,123, open-webui 650, carbon-components-svelte 287, SMUI 449):

| axis | shipped | fixtures 01-09 |
|------|---------|----------------|
| uses `$state` / `$derived` | **8.0%** | **88.9%** |
| uses `$:` | 0-60% by project | 11% |
| uses `export let` | 0-90% by project | 11% |
| `lang="ts"` | 0-99% by project | 11% |
| p90 source size | 4.9-15.7 KB | 2.6 KB |

Per-project runes share: huly 0.4%, open-webui 0.3%, carbon 0.0%, SMUI 59.9%.

The corpus is close to the inverse of shipped code on every axis that selects a
compiler hot path. A change that only pays off on legacy, TypeScript, or
store-heavy components reads as 0% — and that is most of what ships.

## What this adds

| file | shape |
|---|---|
| `10-legacy-typescript-props.svelte` | `export let` with type annotations, `$:` chains, `$store` reads, typed `createEventDispatcher` — the modal shipped component, and the one shape with no fixture at all (`05-legacy-reactive` is the closest and is untyped) |
| `11-store-heavy-legacy.svelte` | `$store` autosubscription across script *and* markup, `$store` assignment, `getContext` stores, `$:` over store reads |

Both compile clean — zero warnings — under the official compiler on all four
targets (client/server x prod/dev). Adding files does not disturb existing
CodSpeed history: benchmark identity is the filename, and these are new names.

I stopped at two deliberately. Each new file costs bench time on every PR, and
these two are the axes with zero current representation; further additions should
be argued the same way rather than accumulated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
