### PR TITLE
docs: record the RUST_MIN_STACK a debug test run needs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -177,6 +177,11 @@ pnpm run compatibility-report                        # Generate compatibility re
 pnpm run test-and-update                             # Refresh report + docs
 ```
 
+A **debug** run needs `RUST_MIN_STACK=33554432` — the value CI already sets
+(`ci.yml`). Without it `ast_gate_preconditions` and `runtime::test_runtime_legacy`
+abort with a stack overflow, which reads as a defect in whatever you just changed.
+`--release` does not need it.
+
 Pre-commit hooks run `cargo fmt` and `cargo clippy` automatically (`.githooks/pre-commit`).
 
 ### Docker (optional)


### PR DESCRIPTION
A one-line gap between what CI does and what the contributor docs say.

`ci.yml` sets `RUST_MIN_STACK: '33554432'` on every test job (`:303`, `:423`, `:458`, `:499`, `:512`, `:613`). AGENTS.md's Build & Test block does not mention it, so a local `cargo test` — the first command in that block — aborts with a stack overflow on `ast_gate_preconditions` and `runtime::test_runtime_legacy`.

Reproduced on unmodified `origin/main` (stash the change, run again) while working #2484, which is the part that matters: the failure looks like it belongs to whatever is in the tree. An agent that hits it mid-task has to spend the reproduction to learn it is pre-existing, and the tempting shortcut is to conclude the change broke the runtime suite.

`--release` is unaffected, which is why the existing "recommended for full runs" note has kept this quiet.

No behaviour change; docs only. `CLAUDE.md` is a symlink to this file.
