### PR TITLE
test(transform): gate the dual-run byte divergence that nothing ran (#2564)

### DIFF
--- a/compatibility/dual-run-known-failures.json
+++ b/compatibility/dual-run-known-failures.json
@@ -1,0 +1,6 @@
+[
+	{
+		"id": "runtime-legacy/samples/store-auto-resubscribe-immediate/main.svelte",
+		"pass": "store_assign_ast:inplace"
+	}
+]

--- a/compatibility/dual-run-known-failures.md
+++ b/compatibility/dual-run-known-failures.md
@@ -1,0 +1,65 @@
+# Dual-run known failures
+
+`dual-run-known-failures.json` holds **1 entry**.
+
+## What this ratchet gates
+
+Every ported Phase-3 client pass has two implementations — the collect-and-splice
+text path it started as, and the in-place `&mut Program` path that replaced it.
+`ast_rewrite::dual_run::resolve` picks between them from `RSVELTE_AST_SPLICE`,
+which is a process-wide `LazyLock` over the environment. So when the two
+implementations disagree, **the compiler's byte output depends on an environment
+variable**, and no test that goes through the public entry point can see it: one
+process only ever exercises one of the two.
+
+`crates/rsvelte_devtools/tests/dual_run_gate.rs` runs both implementations over
+every official `.svelte` fixture, for `client` and `client-dev`, and lists the
+`(fixture, pass)` pairs whose two sides survive esrap normalisation still
+differing. The list may only shrink; an entry that starts passing fails the gate
+too, so the fix and the re-baseline land together.
+
+### What it cannot see
+
+The comparison is `esrap(parse(x))` on each side, so anything that round-trip
+cancels is invisible here — most of all **whitespace and line breaks**. It is
+also scoped to passes routed through `dual_run::resolve`; a pass with only one
+implementation has nothing to compare and is absent from the denominator rather
+than passing.
+
+## Entries
+
+### `runtime-legacy/samples/store-auto-resubscribe-immediate/main.svelte` — `store_assign_ast:inplace`
+
+The fixture nests a store write inside its own initializer and hangs a trailing
+prose comment off each closing bracket:
+
+```js
+$value = {
+	one: writable(
+		$value = {
+			two: ({ $value } = { $value: { fred: $value.qux } }) // { fred: 4 }
+		} // { two: { $value: { fred: 4 } } }
+	) // { one: { two: { $value: { fred: 4 } } } }
+};
+```
+
+The two implementations emit **the same program** and attach those two outer
+comments to different nodes: the text path keeps the source's `})` / `)` split,
+the in-place path reprints `}))` and pushes the outer comment onto its own line.
+
+Measured with the repository's own comparator (`rsvelte_ast_equiv::compare_with`)
+on the two outputs plus the official compiler's, under both of its policies:
+
+| policy | in-place vs spliced | in-place vs official | spliced vs official |
+|---|---|---|---|
+| `Ignore` | equivalent | equivalent | equivalent |
+| `Meaningful` | equivalent | equivalent | equivalent |
+
+So this is **not held open by a codegen disagreement**: neither side is wrong
+about the code, and neither matches official's *bytes* either, because official
+drops all three comments at this site while both rsvelte paths keep them.
+Closing it means reproducing official's comment-position rule, which is the
+comment-preservation work tracked separately (#2336, #2399) — not something
+`store_assign_ast` can decide locally. Making the two paths merely agree with
+each other would pick one arbitrary attachment that still does not match
+official, and would retire the entry while the defect stands.

--- a/crates/rsvelte_core/src/lib.rs
+++ b/crates/rsvelte_core/src/lib.rs
@@ -56,6 +56,13 @@ pub fn ast_rewrite_dual_run_tally() -> Vec<(&'static str, u32, u32, u32, u32)> {
     compiler::phases::phase3_transform::shared::ast_rewrite::dual_run::tally()
 }
 
+/// Clear the tally, so a driver can attribute what follows to one input
+/// instead of reading a total that says only that something diverged.
+#[doc(hidden)]
+pub fn ast_rewrite_dual_run_reset() {
+    compiler::phases::phase3_transform::shared::ast_rewrite::dual_run::reset();
+}
+
 /// How many times a Phase-3 rewrite pass re-parsed an intermediate script.
 #[doc(hidden)]
 pub fn ast_rewrite_dual_run_parses() -> u32 {

--- a/crates/rsvelte_devtools/src/bin/dual_run_tally.rs
+++ b/crates/rsvelte_devtools/src/bin/dual_run_tally.rs
@@ -10,6 +10,10 @@
 //! so the count is a triage obligation rather than a verdict. Every raw diff
 //! still has to be classified before this migration flips, which is what
 //! `RSVELTE_AST_DUAL_RUN_DUMP` is for.
+//!
+//! `--per-fixture` prints `MISMATCH\t<id>\t<pass>` instead of the report, which
+//! is what the ratcheted gate in `tests/dual_run_gate.rs` consumes: a total
+//! that moved says a pass diverged, not on which input.
 
 use std::path::{Path, PathBuf};
 
@@ -36,7 +40,8 @@ fn main() {
     }
 
     // A caller scoping the tally to one fixture subtree needs to say which.
-    let arg = std::env::args().nth(1);
+    let per_fixture = std::env::args().any(|a| a == "--per-fixture");
+    let arg = std::env::args().skip(1).find(|a| !a.starts_with("--"));
     let root = arg.as_deref().map_or_else(
         || Path::new("submodules/svelte/packages/svelte/tests"),
         Path::new,
@@ -55,10 +60,18 @@ fn main() {
         std::process::exit(1);
     }
 
+    // The aggregate tally names the pass that diverged but not the input, and a
+    // ratchet needs the input. Resetting per file is what turns one into the
+    // other; it costs a `Vec::clear` and changes no totals.
+    let mut per_fixture_mismatches: Vec<String> = Vec::new();
+
     for path in &files {
         let Ok(source) = std::fs::read_to_string(path) else {
             continue;
         };
+        if per_fixture {
+            rsvelte_core::ast_rewrite_dual_run_reset();
+        }
         for dev in [false, true] {
             let _ = compile(
                 &source,
@@ -70,6 +83,31 @@ fn main() {
                 },
             );
         }
+        if per_fixture {
+            let id = path
+                .strip_prefix(root)
+                .unwrap_or(path)
+                .display()
+                .to_string();
+            for (pass, _, _, mismatches, unverified) in rsvelte_core::ast_rewrite_dual_run_tally() {
+                if mismatches > 0 || unverified > 0 {
+                    per_fixture_mismatches.push(format!("{id}\t{pass}"));
+                }
+            }
+        }
+    }
+
+    if per_fixture {
+        per_fixture_mismatches.sort();
+        per_fixture_mismatches.dedup();
+        println!("{} fixtures", files.len());
+        for entry in &per_fixture_mismatches {
+            println!("MISMATCH\t{entry}");
+        }
+        if !per_fixture_mismatches.is_empty() {
+            std::process::exit(2);
+        }
+        return;
     }
 
     let tally = rsvelte_core::ast_rewrite_dual_run_tally();

--- a/crates/rsvelte_devtools/tests/dual_run_gate.rs
+++ b/crates/rsvelte_devtools/tests/dual_run_gate.rs
@@ -1,0 +1,136 @@
+//! Gate: the two implementations of every ported Phase-3 client pass must emit
+//! the same thing.
+//!
+//! `ast_rewrite::dual_run::resolve` chooses between a pass's text-splicing
+//! implementation and its in-place one from `RSVELTE_AST_SPLICE`, read once per
+//! process. A disagreement between them is therefore compiler output that
+//! depends on an environment variable — and it is invisible to every other
+//! gate: a test through the public entry point exercises exactly one of the two
+//! per process, and the corpus output-equality gate compares through
+//! `ast_equiv_batch`, which is blind to a divergence that lives only in
+//! comments (see the NOT COVERED note in `scripts/compat-corpus/verify.mjs`).
+//!
+//! `dual_run_tally --per-fixture` is run as a child process rather than
+//! in-process because the harness switch is a `LazyLock` over the environment:
+//! it has to be set before the first compile in the process that reads it.
+
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn repo_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .ancestors()
+        .nth(2)
+        .expect("crates/<pkg> is two levels below the repo root")
+        .to_path_buf()
+}
+
+fn ratchet_path(root: &Path) -> PathBuf {
+    root.join("compatibility/dual-run-known-failures.json")
+}
+
+fn read_ratchet(root: &Path) -> BTreeSet<String> {
+    let text = std::fs::read_to_string(ratchet_path(root)).expect("read the ratchet");
+    let entries: Vec<serde_json::Value> = serde_json::from_str(&text).expect("parse the ratchet");
+    entries
+        .iter()
+        .map(|e| {
+            format!(
+                "{}\t{}",
+                e["id"].as_str().expect("entry has an id"),
+                e["pass"].as_str().expect("entry has a pass"),
+            )
+        })
+        .collect()
+}
+
+fn write_ratchet(root: &Path, measured: &BTreeSet<String>) {
+    let entries: Vec<serde_json::Value> = measured
+        .iter()
+        .map(|line| {
+            let (id, pass) = line.split_once('\t').expect("measured line is id\\tpass");
+            serde_json::json!({ "id": id, "pass": pass })
+        })
+        .collect();
+    let mut json = serde_json::to_string_pretty(&entries).expect("serialize the ratchet");
+    // `serde_json` indents with spaces; the checked-in ratchets use tabs.
+    json = json
+        .lines()
+        .map(|line| {
+            let depth = line.len() - line.trim_start().len();
+            format!("{}{}", "\t".repeat(depth / 2), line.trim_start())
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+    json.push('\n');
+    std::fs::write(ratchet_path(root), json).expect("write the ratchet");
+}
+
+#[test]
+fn the_two_implementations_of_every_pass_agree() {
+    let root = repo_root();
+    let fixtures = root.join("submodules/svelte/packages/svelte/tests");
+    assert!(
+        fixtures.exists(),
+        "Svelte submodule missing at {} — run `git submodule update --init`",
+        fixtures.display()
+    );
+
+    let output = Command::new(env!("CARGO_BIN_EXE_dual_run_tally"))
+        .env("RSVELTE_AST_DUAL_RUN", "1")
+        .arg("--per-fixture")
+        .arg(&fixtures)
+        .output()
+        .expect("run dual_run_tally");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    // A run that measured nothing satisfies "no new mismatch" exactly as well as
+    // a clean one does, so the population is asserted before the verdict.
+    let counted: usize = stdout
+        .lines()
+        .find_map(|l| l.strip_suffix(" fixtures")?.parse().ok())
+        .unwrap_or_else(|| panic!("dual_run_tally printed no fixture count:\n{stdout}"));
+    assert!(
+        counted > 4000,
+        "expected the official fixture corpus, dual_run_tally saw only {counted} files"
+    );
+
+    let measured: BTreeSet<String> = stdout
+        .lines()
+        .filter_map(|l| l.strip_prefix("MISMATCH\t"))
+        .map(str::to_owned)
+        .collect();
+
+    if std::env::var_os("UPDATE_DUAL_RUN_RATCHET").is_some() {
+        write_ratchet(&root, &measured);
+        return;
+    }
+
+    let known = read_ratchet(&root);
+    let regressions: Vec<&String> = measured.difference(&known).collect();
+    let fixed: Vec<&String> = known.difference(&measured).collect();
+    assert!(
+        regressions.is_empty(),
+        "the two implementations of a Phase-3 pass now disagree on an input \
+         that is not in the ratchet — compiler output would depend on \
+         RSVELTE_AST_SPLICE:\n{}",
+        regressions
+            .iter()
+            .map(|s| format!("  {s}"))
+            .collect::<Vec<_>>()
+            .join("\n")
+    );
+    assert!(
+        fixed.is_empty(),
+        "these ratchet entries now agree — re-baseline in the same change that \
+         fixed them (UPDATE_DUAL_RUN_RATCHET=1 cargo test -p rsvelte_devtools \
+         --test dual_run_gate) and update \
+         compatibility/dual-run-known-failures.md:\n{}",
+        fixed
+            .iter()
+            .map(|s| format!("  {s}"))
+            .collect::<Vec<_>>()
+            .join("\n")
+    );
+}

--- a/scripts/compat-corpus/known-failures-md-check.mjs
+++ b/scripts/compat-corpus/known-failures-md-check.mjs
@@ -71,6 +71,7 @@ const RATCHETS = [
 		jsons: perTarget('warning-position-known-failures'),
 	},
 	{ doc: 'matrix-known-failures.md', key: 'matrix-known-failures.json', jsons: ['matrix-known-failures.json'] },
+	{ doc: 'dual-run-known-failures.md', key: 'dual-run-known-failures.json', jsons: ['dual-run-known-failures.json'] },
 	{ doc: 'validator-known-failures.md', key: 'validator-known-failures.json', jsons: ['validator-known-failures.json'] },
 	{
 		doc: 'validator-message-known-failures.md',


### PR DESCRIPTION
Closes #2564.

The issue asked two questions before any fix. Both are answered below, and
they moved the fix: **the codegen is not what is broken here — the gate is.**

## Q1. Which side is right? Neither, and not because of codegen

Compiled the fixture three ways and compared with the repository's own
comparator, `rsvelte_ast_equiv::compare_with` — the same crate
`scripts/compat-corpus/verify.mjs` uses:

| policy | in-place vs spliced | in-place vs official | spliced vs official |
|---|---|---|---|
| `Ignore` | equivalent | equivalent | equivalent |
| `Meaningful` (default) | equivalent | equivalent | equivalent |

**All three emit the same program.** The divergence is entirely where two
trailing prose comments attach:

```
official      rs in-place                  rs spliced
}))           })) // { two: … }            })  // { two: … }
});           <blank>                      )   // { one: … }
              // { one: … }                });
              });
```

Official drops all three comments at this site; both rsvelte paths keep them,
in different places. So "make the wrong one match upstream" means reproducing
official's comment-position rule — the comment-preservation work in #2336 /
#2399, which `store_assign_ast` cannot decide locally. And making the two
paths agree would pick one arbitrary attachment that still does not match
official, while retiring the entry.

The env-dependence claim survives, narrowed: output depends on
`RSVELTE_AST_SPLICE` in its **bytes**, not its AST.

## Q2. `dual_run_tally` fails — but nothing runs it

`crates/rsvelte_devtools/src/bin/dual_run_tally.rs:172` —
`if total_mismatches > 0 || total_unverified > 0 { std::process::exit(2); }`.
Verified unpiped: `exit=2` on the offending fixture.

But it is invoked by **nothing**: 0 hits for `dual` across
`.github/workflows/`, `package.json`, `scripts/` and `.githooks/`, and no
`#[test]` references `ast_rewrite_dual_run_tally`. Positive control on the
same greps: `cargo test` hits 5 workflows, `corpus:matrix` is present in
`package.json`. The in-place path shipped 2026-08-05 (#2251), so the mismatch
has been non-blocking since it appeared.

The gate that *does* run in CI cannot see it either. `verify.mjs` compares
through `ast_equiv_batch` with `CommentPolicy::Ignore` — its own source says
so in the `NOT COVERED — comment parity` note — and this divergence is
comment-only. `compatibility/known-failures.client.json` is `[]` and stays
`[]`, correctly, while the bytes differ.

So the gate half is the larger half, and this PR is that half.

## What this adds

- `dual_run_tally --per-fixture`: `MISMATCH\t<id>\t<pass>` lines. The
  aggregate tally names the pass that diverged, not the input a ratchet
  needs; a `reset()` per file turns one into the other and changes no totals.
- `crates/rsvelte_devtools/tests/dual_run_gate.rs`: runs both implementations
  over all 4459 official `.svelte` fixtures × `client` and `client-dev`, and
  ratchets the diverging `(fixture, pass)` pairs. `scripts/ci/run-test-shard.sh`
  partitions `tests/*.rs` from `cargo metadata`, so it is picked up with no
  workflow edit. 12 s in a debug shard; the harness itself runs in 2.8 s
  release / 20 s debug over the whole corpus.
- `compatibility/dual-run-known-failures.json` (1 entry) + paired `.md` with
  the measurement above as its justification, declared in
  `known-failures-md-check.mjs` (`20 declared ratchets across 17 docs match
  their JSON`).
- The gate runs a subprocess rather than compiling in-process because the
  harness switch is a `LazyLock` over the environment: it must be set before
  the first compile in the process that reads it.

## The gate can move — three controls

| state | result |
|---|---|
| as committed | **ok** |
| unmeasured entry added to the ratchet | **FAILED** — "these ratchet entries now agree" |
| the real entry removed from the ratchet | **FAILED** — names `store-auto-resubscribe-immediate` |
| proxy flag inverted in `private_class_assign_ast`'s **in-place copy only** | **FAILED** — names 9 previously-clean fixtures |

The last one is the discriminating control: it proves the gate catches a
divergence it has never seen, in a pass that is not the one it was seeded
from. `UPDATE_DUAL_RUN_RATCHET=1` regenerates the ratchet and reproduces the
committed file byte-for-byte from an emptied one.

## Not done here

The codegen. It is held open by comment-position parity (#2336 / #2399), and
the ratchet entry says so with the measurement rather than a plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K7bw79DQ7roFtohdnGd1v6
