### PR TITLE
fix(parse): decide every parser whitespace question with the JS whitespace set (#2561)

### DIFF
--- a/.changeset/js-whitespace-parser-predicate.md
+++ b/.changeset/js-whitespace-parser-predicate.md
@@ -1,0 +1,13 @@
+---
+'@rsvelte/compiler': patch
+---
+
+Decide every whitespace question in the parser with ECMAScript's whitespace set,
+the one upstream's `is_whitespace(cc)`, `\s` regexes and `String.prototype.trim*`
+all consult. The parser previously mixed three sets: Rust's Unicode
+`White_Space` (which adds `U+0085` and drops `U+FEFF`), `u8::is_ascii_whitespace`
+(which drops `U+000B`), and hand-written ASCII fast paths listing only space,
+tab, LF and CR. Block open/close/continuation markers, tag and attribute names,
+closing tags, snippet headers, the `{#each … as …}` alias separator, the
+`{#await … then/catch}` keywords and the CSS reader all now agree with upstream
+on `U+000B`, `U+000C`, `U+0085`, `U+FEFF`, `U+2028` and `U+2029`.

--- a/crates/rsvelte_core/src/compiler/phases/1_parse/parser.rs
+++ b/crates/rsvelte_core/src/compiler/phases/1_parse/parser.rs
@@ -40,6 +40,34 @@ static LANG_FINDER: std::sync::LazyLock<memchr::memmem::Finder<'static>> =
 static COMMENT_END_FINDER: std::sync::LazyLock<memchr::memmem::Finder<'static>> =
     std::sync::LazyLock::new(|| memchr::memmem::Finder::new(b"-->"));
 
+/// ECMAScript `WhiteSpace + LineTerminator` — the set every whitespace decision
+/// in upstream's parser consults, whether through `is_whitespace(cc)` in
+/// `1-parse/index.js`, a `\s` regex or `String.prototype.trim*`. Rust's
+/// `char::is_whitespace` is the Unicode `White_Space` property, which has the
+/// same 25 members but excludes `U+FEFF` and includes `U+0085`.
+pub(crate) fn is_js_whitespace(c: char) -> bool {
+    matches!(
+        c,
+        '\u{9}'..='\u{d}'
+            | '\u{20}'
+            | '\u{a0}'
+            | '\u{1680}'
+            | '\u{2000}'..='\u{200a}'
+            | '\u{2028}'
+            | '\u{2029}'
+            | '\u{202f}'
+            | '\u{205f}'
+            | '\u{3000}'
+            | '\u{feff}'
+    )
+}
+
+/// ASCII fast path for `is_js_whitespace`, derived from it rather than restated;
+/// every non-ASCII byte answers `false` so the caller decodes and asks again.
+pub(crate) fn is_js_whitespace_byte(b: u8) -> bool {
+    b.is_ascii() && is_js_whitespace(b as char)
+}
+
 /// Last auto-closed tag information.
 ///
 /// Corresponds to `LastAutoClosedTag` in `svelte/packages/svelte/src/compiler/phases/1-parse/index.js`.
@@ -581,13 +609,14 @@ impl<'a> Parser<'a> {
         let mut i = self.index + 1;
         while i < self.bytes.len() {
             let b = self.bytes[i];
-            if b == b' ' || b == b'\t' || b == b'\n' || b == b'\r' {
+            if b.is_ascii() {
+                if !is_js_whitespace_byte(b) {
+                    return Some(i);
+                }
                 i += 1;
-            } else if b < 0x80 {
-                return Some(i);
             } else {
                 let c = self.source[i..].chars().next().unwrap_or('\0');
-                if c.is_whitespace() {
+                if is_js_whitespace(c) {
                     i += c.len_utf8();
                 } else {
                     return Some(i);
@@ -727,19 +756,39 @@ impl<'a> Parser<'a> {
 
     /// Skip whitespace.
     #[inline]
+    /// Whether the character starting at byte `i` is JS whitespace. Byte-level
+    /// scans need this because a multi-byte character's lead byte answers
+    /// nothing on its own.
+    pub(crate) fn is_js_whitespace_at(&self, i: usize) -> bool {
+        match self.bytes.get(i) {
+            None => false,
+            Some(&b) if b.is_ascii() => is_js_whitespace_byte(b),
+            _ => self.source[i..]
+                .chars()
+                .next()
+                .is_some_and(is_js_whitespace),
+        }
+    }
+
+    /// Byte index of the first non-whitespace character at or after `i`.
+    pub(crate) fn skip_js_whitespace_from(&self, mut i: usize) -> usize {
+        while self.is_js_whitespace_at(i) {
+            i += self.source[i..].chars().next().map_or(1, char::len_utf8);
+        }
+        i
+    }
+
     pub fn skip_whitespace(&mut self) {
-        // Fast path for ASCII whitespace (space, tab, newline, carriage return)
         while self.index < self.bytes.len() {
             let b = self.bytes[self.index];
-            if b == b' ' || b == b'\t' || b == b'\n' || b == b'\r' {
+            if b.is_ascii() {
+                if !is_js_whitespace_byte(b) {
+                    break;
+                }
                 self.index += 1;
-            } else if b < 0x80 {
-                // ASCII non-whitespace: done
-                break;
             } else {
-                // Non-ASCII: check for Unicode whitespace via char
                 let c = self.source[self.index..].chars().next().unwrap_or('\0');
-                if c.is_whitespace() {
+                if is_js_whitespace(c) {
                     self.index += c.len_utf8();
                 } else {
                     break;
@@ -833,23 +882,18 @@ impl<'a> Parser<'a> {
     pub fn read_tag_name(&mut self) -> &str {
         let start = self.index;
 
-        // Fast path: tag name characters are ASCII (stop at whitespace, >, /, =)
+        // Mirrors upstream `read_until(/(\s|\/|>)/)`; `=` additionally ends a
+        // name so `<p=` does not swallow the rest of the tag.
         while self.index < self.bytes.len() {
             let b = self.bytes[self.index];
-            if b == b' '
-                || b == b'\t'
-                || b == b'\n'
-                || b == b'\r'
-                || b == b'>'
-                || b == b'/'
-                || b == b'='
-            {
-                break;
-            } else if b < 0x80 {
+            if b.is_ascii() {
+                if is_js_whitespace_byte(b) || b == b'>' || b == b'/' || b == b'=' {
+                    break;
+                }
                 self.index += 1;
             } else {
                 let c = self.source[self.index..].chars().next().unwrap_or('\0');
-                if c.is_whitespace() {
+                if is_js_whitespace(c) {
                     break;
                 }
                 self.index += c.len_utf8();
@@ -864,25 +908,17 @@ impl<'a> Parser<'a> {
     pub fn read_attribute_name(&mut self) -> &str {
         let start = self.index;
 
-        // Fast path: attribute name characters are ASCII (stop at whitespace, =, >, /, ", ')
+        // Mirrors upstream `read_until(/[\s=\/>"']/)`.
         while self.index < self.bytes.len() {
             let b = self.bytes[self.index];
-            if b == b' '
-                || b == b'\t'
-                || b == b'\n'
-                || b == b'\r'
-                || b == b'='
-                || b == b'>'
-                || b == b'/'
-                || b == b'"'
-                || b == b'\''
-            {
-                break;
-            } else if b < 0x80 {
+            if b.is_ascii() {
+                if is_js_whitespace_byte(b) || matches!(b, b'=' | b'>' | b'/' | b'"' | b'\'') {
+                    break;
+                }
                 self.index += 1;
             } else {
                 let c = self.source[self.index..].chars().next().unwrap_or('\0');
-                if c.is_whitespace() {
+                if is_js_whitespace(c) {
                     break;
                 }
                 self.index += c.len_utf8();
@@ -975,7 +1011,7 @@ impl<'a> Parser<'a> {
     ///
     /// Corresponds to `require_whitespace()` in JavaScript Parser.
     pub fn require_whitespace(&mut self) -> ParseResult<()> {
-        if self.is_eof() || !self.current_char().is_whitespace() {
+        if self.is_eof() || !is_js_whitespace(self.current_char()) {
             return Err(ParseError::svelte(
                 "expected_whitespace",
                 "Expected whitespace",

--- a/crates/rsvelte_core/src/compiler/phases/1_parse/read/expression.rs
+++ b/crates/rsvelte_core/src/compiler/phases/1_parse/read/expression.rs
@@ -29,6 +29,7 @@ use oxc_parser::Parser as OxcParser;
 use oxc_span::{GetSpan, SourceType};
 use serde_json::{Map, Value};
 
+use super::super::utils::TrimWs;
 use crate::ast::arena::{IdRange, ParseArena};
 use crate::ast::js::Expression;
 use crate::ast::typed_expr::{
@@ -449,7 +450,7 @@ fn try_parse_call_expression<'a>(
     //
     // `args_region` is the raw byte slice between `(` and `)`. `args_str` is
     // its trimmed form, used for the comma-split scan. We must add the byte
-    // count of the *leading* whitespace that `.trim()` stripped back into
+    // count of the *leading* whitespace that `.trim_ws()` stripped back into
     // every per-argument offset — otherwise multi-line argument lists like
     //
     //     {@render fn(
@@ -464,8 +465,8 @@ fn try_parse_call_expression<'a>(
     let args_start = paren_pos + 1;
     let args_end = bytes.len() - 1;
     let args_region = &content[args_start..args_end];
-    let args_str = args_region.trim();
-    let args_leading_ws = args_region.len() - args_region.trim_start().len();
+    let args_str = args_region.trim_ws();
+    let args_leading_ws = args_region.len() - args_region.trim_start_ws().len();
 
     let arguments = if args_str.is_empty() {
         Vec::new()
@@ -494,13 +495,13 @@ fn try_parse_call_expression<'a>(
                     depth -= 1;
                 }
                 b',' if depth == 0 => {
-                    let arg_str = args_str[start..i].trim();
+                    let arg_str = args_str[start..i].trim_ws();
                     let arg_bytes = arg_str.as_bytes();
                     let arg_offset = offset
                         + args_start
                         + args_leading_ws
                         + start
-                        + (args_str[start..i].len() - args_str[start..i].trim_start().len());
+                        + (args_str[start..i].len() - args_str[start..i].trim_start_ws().len());
                     let arg = try_parse_atom(arena, arg_str, arg_bytes, arg_offset, line_offsets)?;
                     args.push(expr_to_node(arg));
                     start = i + 1;
@@ -512,14 +513,14 @@ fn try_parse_call_expression<'a>(
             return None;
         }
         // Last argument
-        let arg_str = args_str[start..].trim();
+        let arg_str = args_str[start..].trim_ws();
         if !arg_str.is_empty() {
             let arg_bytes = arg_str.as_bytes();
             let arg_offset = offset
                 + args_start
                 + args_leading_ws
                 + start
-                + (args_str[start..].len() - args_str[start..].trim_start().len());
+                + (args_str[start..].len() - args_str[start..].trim_start_ws().len());
             let arg = try_parse_atom(arena, arg_str, arg_bytes, arg_offset, line_offsets)?;
             args.push(expr_to_node(arg));
         }
@@ -661,18 +662,18 @@ fn try_parse_ternary<'a>(
     let cons_raw = &content[q_pos + 1..colon_pos];
     let alt_raw = &content[colon_pos + 1..];
 
-    let test_str = test_raw.trim();
-    let cons_str = cons_raw.trim();
-    let alt_str = alt_raw.trim();
+    let test_str = test_raw.trim_ws();
+    let cons_str = cons_raw.trim_ws();
+    let alt_str = alt_raw.trim_ws();
 
     if test_str.is_empty() || cons_str.is_empty() || alt_str.is_empty() {
         return None;
     }
 
     // Calculate precise offsets accounting for leading whitespace
-    let test_offset = offset + (test_raw.len() - test_raw.trim_start().len());
-    let cons_offset = offset + q_pos + 1 + (cons_raw.len() - cons_raw.trim_start().len());
-    let alt_offset = offset + colon_pos + 1 + (alt_raw.len() - alt_raw.trim_start().len());
+    let test_offset = offset + (test_raw.len() - test_raw.trim_start_ws().len());
+    let cons_offset = offset + q_pos + 1 + (cons_raw.len() - cons_raw.trim_start_ws().len());
+    let alt_offset = offset + colon_pos + 1 + (alt_raw.len() - alt_raw.trim_start_ws().len());
 
     let test = try_parse_atom(
         arena,
@@ -772,7 +773,7 @@ fn try_parse_parenthesized<'a>(
 
     // Simple parenthesized: (expr) with nothing after
     if close + 1 == bytes.len() {
-        let inner = content[1..close].trim();
+        let inner = content[1..close].trim_ws();
         if inner.is_empty() {
             return None;
         }
@@ -795,7 +796,7 @@ fn try_parse_arrow_function<'a>(
     ws_after_paren: usize,
 ) -> Option<Expression<'a>> {
     let arrow_start = close_paren + 1 + ws_after_paren + 2; // past "=>"
-    let body_str = content[arrow_start..].trim();
+    let body_str = content[arrow_start..].trim_ws();
 
     if body_str.is_empty() {
         return None;
@@ -809,7 +810,7 @@ fn try_parse_arrow_function<'a>(
     let body_bytes = body_str.as_bytes();
     let body_offset = offset
         + arrow_start
-        + (content[arrow_start..].len() - content[arrow_start..].trim_start().len());
+        + (content[arrow_start..].len() - content[arrow_start..].trim_start_ws().len());
 
     // Parse body as expression
     let body = try_parse_atom(arena, body_str, body_bytes, body_offset, line_offsets)
@@ -830,11 +831,11 @@ fn try_parse_arrow_function<'a>(
     let region_base = offset + 1; // absolute position of `content[1]`
     let mut params_nodes = Vec::new();
 
-    if !region.trim().is_empty() {
+    if !region.trim_ws().is_empty() {
         let mut cursor = 0usize; // byte index within `region`
         for chunk in region.split(',') {
-            let lead_ws = chunk.len() - chunk.trim_start().len();
-            let p = chunk.trim();
+            let lead_ws = chunk.len() - chunk.trim_start_ws().len();
+            let p = chunk.trim_ws();
             if p.is_empty() {
                 return None;
             }
@@ -930,8 +931,8 @@ fn try_parse_compound_expression<'a>(
         return None;
     }
 
-    let left_content = content[..i].trim_end();
-    let right_content = content[right_start..].trim_end();
+    let left_content = content[..i].trim_end_ws();
+    let right_content = content[right_start..].trim_end_ws();
 
     let left_bytes = left_content.as_bytes();
     let right_bytes = right_content.as_bytes();
@@ -2245,7 +2246,7 @@ fn split_top_level_params(content: &str) -> Vec<String> {
         }
     }
 
-    if !current.trim().is_empty() {
+    if !current.trim_ws().is_empty() {
         parts.push(current);
     }
 
@@ -2361,7 +2362,7 @@ pub fn parse_typescript_params<'a>(
         let parts = split_top_level_params(content);
         let mut search_from = 0usize;
         for part in &parts {
-            let part = part.trim();
+            let part = part.trim_ws();
             if part.is_empty() {
                 continue;
             }
@@ -2407,10 +2408,10 @@ pub fn parse_typescript_params<'a>(
     }
 
     // Fallback: parse as comma-separated simple identifiers
-    if params.is_empty() && !content.trim().is_empty() {
+    if params.is_empty() && !content.trim_ws().is_empty() {
         let mut search_from = 0usize;
         for part in content.split(',') {
-            let part = part.trim();
+            let part = part.trim_ws();
             if !part.is_empty() {
                 let part_pos = content[search_from..]
                     .find(part)
@@ -2418,7 +2419,7 @@ pub fn parse_typescript_params<'a>(
                     .unwrap_or(search_from);
                 search_from = part_pos + part.len();
                 // Extract just the name (before colon for typed params)
-                let name = part.split(':').next().unwrap_or(part).trim();
+                let name = part.split(':').next().unwrap_or(part).trim_ws();
                 // Strip optional marker '?' from the end (e.g., "c?" -> "c")
                 let name = name.strip_suffix('?').unwrap_or(name);
                 let part_offset = offset + part_pos;
@@ -7172,7 +7173,7 @@ impl CommentAttacher<'_> {
 
     fn record_leading(&mut self, start: u32, index: usize) {
         let text = self.comments[index].text.clone();
-        if !text.trim_start().starts_with("svelte-ignore") {
+        if !text.trim_start_ws().starts_with("svelte-ignore") {
             return;
         }
         match self.map.last_mut() {
@@ -10883,7 +10884,7 @@ pub fn parse_binding_pattern<'a>(
 ) -> Result<Expression<'a>, crate::error::ParseError> {
     // Check for reserved words in simple identifier contexts
     // (e.g., {#each cases as case} where "case" is a reserved word)
-    let trimmed = content.trim();
+    let trimmed = content.trim_ws();
     if !trimmed.is_empty()
         && !trimmed.starts_with('{')
         && !trimmed.starts_with('[')
@@ -10902,7 +10903,7 @@ pub fn parse_binding_pattern<'a>(
     // `{#each xs as item}` / `{#await p then v}` bind a bare identifier in the
     // vast majority of cases; skip the `let … = null` wrap + full JS parse.
     if is_plain_ascii_identifier(trimmed) {
-        let start = offset + (content.len() - content.trim_start().len());
+        let start = offset + (content.len() - content.trim_start_ws().len());
         let end = start + trimmed.len();
         return Ok(Expression::from_node(
             create_identifier_for_binding_toplevel(trimmed, start, end, line_offsets),
@@ -10917,11 +10918,11 @@ pub fn parse_binding_pattern<'a>(
         let result = parser.parse();
 
         if !result.diagnostics.is_empty() {
-            let trimmed = content.trim();
+            let trimmed = content.trim_ws();
             if trimmed.starts_with('{') || trimmed.starts_with('[') {
                 let err = &result.diagnostics[0];
                 let msg = format!("{}", err);
-                let clean_msg = msg.split('\n').next().unwrap_or(&msg).trim().to_string();
+                let clean_msg = msg.split('\n').next().unwrap_or(&msg).trim_ws().to_string();
                 let err_pos = offset;
                 return Err(crate::error::ParseError::svelte(
                     "js_parse_error",
@@ -10949,10 +10950,10 @@ pub fn parse_binding_pattern<'a>(
         }
 
         // Fallback: return as simple identifier
-        let trimmed = content.trim();
+        let trimmed = content.trim_ws();
         let name = if let Some(colon_pos) = trimmed.find(':') {
             if !trimmed.starts_with('{') && !trimmed.starts_with('[') {
-                trimmed[..colon_pos].trim()
+                trimmed[..colon_pos].trim_ws()
             } else {
                 trimmed
             }

--- a/crates/rsvelte_core/src/compiler/phases/1_parse/read/options.rs
+++ b/crates/rsvelte_core/src/compiler/phases/1_parse/read/options.rs
@@ -17,6 +17,7 @@ use crate::error::{ParseError, ParseResult};
 use serde_json::Value as JsonValue;
 
 use super::super::parser::Parser;
+use super::super::utils::TrimWs;
 
 // Upstream emits one message per code regardless of which check failed.
 const INVALID_TAGNAME: &str = "Tag name must be lowercase and hyphenated";
@@ -68,7 +69,7 @@ impl<'a> Parser<'a> {
 
                 // Check if we found meaningful (non-whitespace) content
                 let content = &self.source[content_start..content_end];
-                if !content.trim().is_empty() {
+                if !content.trim_ws().is_empty() {
                     return Err(ParseError::svelte(
                         "svelte_meta_invalid_content",
                         "<svelte:options> cannot have children",

--- a/crates/rsvelte_core/src/compiler/phases/1_parse/read/style.rs
+++ b/crates/rsvelte_core/src/compiler/phases/1_parse/read/style.rs
@@ -21,7 +21,8 @@ use crate::ast::css::{StyleSheet, StyleSheetContent, StyleSheetType};
 use crate::ast::template::{AttributeValue, AttributeValuePart, TemplateNode};
 use crate::error::ParseResult;
 
-use super::super::parser::{MAX_NESTING_DEPTH, Parser};
+use super::super::parser::{MAX_NESTING_DEPTH, Parser, is_js_whitespace};
+use super::super::utils::TrimWs;
 
 /// Returns `true` when the `<style>` has a `lang` attribute whose value is not
 /// plain CSS (e.g. `sass`, `scss`, `stylus`, `less`, `postcss`). Such a block
@@ -35,7 +36,7 @@ fn has_non_css_lang<'a>(attributes: &[crate::ast::Attribute<'a>]) -> bool {
             && let AttributeValue::Sequence(parts) = &node.value
             && let Some(AttributeValuePart::Text(t)) = parts.first()
         {
-            let lang = t.data.as_ref().trim().to_ascii_lowercase();
+            let lang = t.data.as_ref().trim_ws().to_ascii_lowercase();
             return !lang.is_empty() && lang != "css";
         }
     }
@@ -285,7 +286,7 @@ impl<'a> Parser<'a> {
         // Skipped only for a non-CSS `lang` block in lenient (lint) mode (see
         // the string-quote check above).
         if !lenient_non_css {
-            let trimmed = style_content.trim();
+            let trimmed = style_content.trim_ws();
             if !trimmed.is_empty() {
                 // Fast path: no block comments present, so there is nothing to
                 // strip and `trimmed` itself already reflects the real content.
@@ -330,7 +331,7 @@ impl<'a> Parser<'a> {
                     if segment_start < bytes.len() {
                         stripped.push_str(&trimmed[segment_start..]);
                     }
-                    let stripped = stripped.trim();
+                    let stripped = stripped.trim_ws();
                     if !stripped.is_empty()
                         && !stripped.contains('{')
                         && !stripped.contains(';')
@@ -488,7 +489,7 @@ impl<'a> CssParser<'a> {
             }
             self.advance();
         }
-        let prelude = self.source[prelude_start..self.index].trim().to_string();
+        let prelude = self.source[prelude_start..self.index].trim_ws().to_string();
 
         // Check if there's a block
         let block = if self.current_char() == '{' {
@@ -628,7 +629,7 @@ impl<'a> CssParser<'a> {
         let selector_end = self.index;
         let selector_text = &self.source[selector_start..selector_end];
 
-        if selector_text.trim().is_empty() {
+        if selector_text.trim_ws().is_empty() {
             // An empty selector at a block start (e.g. `{}`) mirrors the official
             // `read_selector` → `read_identifier` path, which raises
             // `css_expected_identifier` at the block-start position.
@@ -647,7 +648,7 @@ impl<'a> CssParser<'a> {
         }
 
         // Calculate the actual start position (skipping leading whitespace)
-        let leading_ws = selector_text.len() - selector_text.trim_start().len();
+        let leading_ws = selector_text.len() - selector_text.trim_start_ws().len();
         let adjusted_start = self.offset + selector_start + leading_ws;
 
         let prelude = self.parse_selector_list(selector_text, adjusted_start);
@@ -775,7 +776,7 @@ impl<'a> CssParser<'a> {
             }
             if !bytes[i].is_ascii()
                 && let Some(ch) = text[i..].chars().next()
-                && ch.is_whitespace()
+                && is_js_whitespace(ch)
             {
                 i += ch.len_utf8();
                 continue;
@@ -982,7 +983,7 @@ impl<'a> CssParser<'a> {
 
             // Check for combinators (+, >, ~)
             if c == b'+' || c == b'>' || c == b'~' {
-                let selector_text = text[current_start..i].trim();
+                let selector_text = text[current_start..i].trim_ws();
                 if !selector_text.is_empty() {
                     let selector_offset = base_offset + current_start;
                     let rel_selector = self.create_relative_selector(
@@ -1038,7 +1039,7 @@ impl<'a> CssParser<'a> {
                         || bytes[j] == b'&'
                     {
                         // This is a descendant combinator (space)
-                        let selector_text = text[current_start..i].trim();
+                        let selector_text = text[current_start..i].trim_ws();
                         // Only treat as descendant if there's actual selector content before the whitespace
                         // (not just whitespace and comments)
                         if !selector_text.is_empty()
@@ -1072,9 +1073,9 @@ impl<'a> CssParser<'a> {
         // Add the last selector
         if current_start < text.len() {
             let selector_text = &text[current_start..];
-            if !selector_text.trim().is_empty() {
+            if !selector_text.trim_ws().is_empty() {
                 // Calculate offset skipping leading whitespace
-                let leading_ws = selector_text.len() - selector_text.trim_start().len();
+                let leading_ws = selector_text.len() - selector_text.trim_start_ws().len();
                 let selector_offset = base_offset + current_start + leading_ws;
                 let rel_selector =
                     self.create_relative_selector(selector_text, selector_offset, last_combinator);
@@ -1094,9 +1095,9 @@ impl<'a> CssParser<'a> {
         }
 
         // If no selectors were found, create one for the whole text
-        if result.is_empty() && !text.trim().is_empty() {
+        if result.is_empty() && !text.trim_ws().is_empty() {
             // Calculate offset skipping leading whitespace
-            let leading_ws = text.len() - text.trim_start().len();
+            let leading_ws = text.len() - text.trim_start_ws().len();
             let adjusted_offset = base_offset + leading_ws;
             let rel_selector = self.create_relative_selector(text, adjusted_offset, None);
             result.push(rel_selector);
@@ -1152,7 +1153,7 @@ impl<'a> CssParser<'a> {
 
         // Don't trim the text - we need to preserve Unicode escape sequence terminators
         // which may be whitespace characters
-        if text.trim().is_empty() {
+        if text.trim_ws().is_empty() {
             return selectors;
         }
 
@@ -1525,7 +1526,9 @@ impl<'a> CssParser<'a> {
             }
             self.advance();
         }
-        let property = self.source[property_start..self.index].trim().to_string();
+        let property = self.source[property_start..self.index]
+            .trim_ws()
+            .to_string();
 
         if property.is_empty() || self.is_eof() || self.current_char() != ':' {
             // No `property: value` shape. Upstream's `read_declaration` reads
@@ -1539,8 +1542,8 @@ impl<'a> CssParser<'a> {
             // `bar`, so it is NOT an error — keep skipping it silently.
             let upstream_property = property.split_whitespace().next().unwrap_or("");
             let upstream_value = property
-                .split_once(char::is_whitespace)
-                .map(|(_, rest)| rest.trim())
+                .split_once(is_js_whitespace)
+                .map(|(_, rest)| rest.trim_ws())
                 .unwrap_or("");
             if upstream_value.is_empty() && !upstream_property.starts_with("--") {
                 record_first_error(
@@ -1595,7 +1598,7 @@ impl<'a> CssParser<'a> {
             }
             self.advance();
         }
-        let value = self.source[value_start..self.index].trim().to_string();
+        let value = self.source[value_start..self.index].trim_ws().to_string();
 
         // End position is before the semicolon
         let end = self.offset + self.index;
@@ -1727,7 +1730,7 @@ impl<'a> CssParser<'a> {
     }
 
     fn skip_whitespace(&mut self) {
-        while !self.is_eof() && self.current_char().is_whitespace() {
+        while !self.is_eof() && is_js_whitespace(self.current_char()) {
             self.advance();
         }
     }
@@ -2133,8 +2136,8 @@ impl<'a> SelectorParser<'a> {
                 None
             } else if is_nth_pseudo {
                 // For nth-* pseudo-classes, parse the An+B syntax and optional 'of S' selector
-                let trimmed = content.trim();
-                let leading_ws = content.len() - content.trim_start().len();
+                let trimmed = content.trim_ws();
+                let leading_ws = content.len() - content.trim_start_ws().len();
                 let nth_start = args_start + leading_ws;
 
                 // Check for 'of ' keyword to split An+B from selector
@@ -2157,14 +2160,14 @@ impl<'a> SelectorParser<'a> {
                         || trimmed.starts_with('-');
 
                     if is_nth_pattern {
-                        let trailing_ws = content.len() - content.trim_end().len();
+                        let trailing_ws = content.len() - content.trim_end_ws().len();
                         let end_pos = self.offset + content_end - trailing_ws;
                         (trimmed, None, end_pos)
                     } else {
                         // Not an An+B pattern, treat as regular selector
                         // Fall through to the non-nth parsing below
-                        let mut trimmed_inner = content.trim();
-                        let mut leading_skip = content.len() - content.trim_start().len();
+                        let mut trimmed_inner = content.trim_ws();
+                        let mut leading_skip = content.len() - content.trim_start_ws().len();
 
                         loop {
                             if trimmed_inner.starts_with("/*") {
@@ -2173,9 +2176,9 @@ impl<'a> SelectorParser<'a> {
                                     leading_skip += end_pos + 2;
                                     trimmed_inner = &trimmed_inner[end_pos + 2..];
                                     let ws_skip =
-                                        trimmed_inner.len() - trimmed_inner.trim_start().len();
+                                        trimmed_inner.len() - trimmed_inner.trim_start_ws().len();
                                     leading_skip += ws_skip;
-                                    trimmed_inner = trimmed_inner.trim_start();
+                                    trimmed_inner = trimmed_inner.trim_start_ws();
                                 } else {
                                     break;
                                 }
@@ -2184,7 +2187,7 @@ impl<'a> SelectorParser<'a> {
                             }
                         }
 
-                        let trailing_ws = content.len() - content.trim_end().len();
+                        let trailing_ws = content.len() - content.trim_end_ws().len();
                         let trimmed_start = args_start + leading_skip;
                         let trimmed_end = self.offset + content_end - trailing_ws;
 
@@ -2237,7 +2240,7 @@ impl<'a> SelectorParser<'a> {
                 }
 
                 // Get the actual end position
-                let trailing_ws = content.len() - content.trim_end().len();
+                let trailing_ws = content.len() - content.trim_end_ws().len();
                 let actual_end = self.offset + content_end - trailing_ws;
 
                 // Wrap in RelativeSelector
@@ -2289,8 +2292,8 @@ impl<'a> SelectorParser<'a> {
                 Some(Value::Object(sel_list))
             } else {
                 // Calculate trimmed content positions (strip whitespace and leading comments)
-                let mut trimmed = content.trim();
-                let mut leading_skip = content.len() - content.trim_start().len();
+                let mut trimmed = content.trim_ws();
+                let mut leading_skip = content.len() - content.trim_start_ws().len();
 
                 // Also skip leading comments for the SelectorList start
                 // And update `trimmed` to not include the leading comment
@@ -2299,9 +2302,9 @@ impl<'a> SelectorParser<'a> {
                         if let Some(end_pos) = memmem::find(trimmed.as_bytes(), b"*/") {
                             leading_skip += end_pos + 2;
                             trimmed = &trimmed[end_pos + 2..];
-                            let ws_skip = trimmed.len() - trimmed.trim_start().len();
+                            let ws_skip = trimmed.len() - trimmed.trim_start_ws().len();
                             leading_skip += ws_skip;
-                            trimmed = trimmed.trim_start();
+                            trimmed = trimmed.trim_start_ws();
                         } else {
                             break;
                         }
@@ -2310,7 +2313,7 @@ impl<'a> SelectorParser<'a> {
                     }
                 }
 
-                let trailing_ws = content.len() - content.trim_end().len();
+                let trailing_ws = content.len() - content.trim_end_ws().len();
                 let trimmed_start = args_start + leading_skip;
                 let trimmed_end = self.offset + content_end - trailing_ws;
 
@@ -2346,9 +2349,9 @@ impl<'a> SelectorParser<'a> {
             .into_iter()
             .map(|(selector_text, selector_offset)| {
                 // Adjust offset for leading whitespace when trimming
-                let leading_ws = selector_text.len() - selector_text.trim_start().len();
+                let leading_ws = selector_text.len() - selector_text.trim_start_ws().len();
                 let adjusted_offset = selector_offset + leading_ws;
-                self.parse_complex_selector_from_text(selector_text.trim(), adjusted_offset)
+                self.parse_complex_selector_from_text(selector_text.trim_ws(), adjusted_offset)
             })
             .collect();
 
@@ -2422,7 +2425,7 @@ impl<'a> SelectorParser<'a> {
         loop {
             let before_len = current.len();
             // Strip leading whitespace
-            let trimmed = current.trim_start();
+            let trimmed = current.trim_start_ws();
             current_offset += before_len - trimmed.len();
             current = trimmed;
 
@@ -2442,7 +2445,7 @@ impl<'a> SelectorParser<'a> {
         // Strip trailing whitespace and comments
         let mut end_current = current;
         loop {
-            let trimmed = end_current.trim_end();
+            let trimmed = end_current.trim_end_ws();
             end_current = trimmed;
 
             // Strip trailing comment
@@ -2457,7 +2460,7 @@ impl<'a> SelectorParser<'a> {
             }
         }
 
-        let trimmed = end_current.trim();
+        let trimmed = end_current.trim_ws();
         let start = current_offset;
         let end = start + trimmed.len();
 
@@ -2527,7 +2530,7 @@ impl<'a> SelectorParser<'a> {
             // Check for combinators
             if c == b'+' || c == b'>' || c == b'~' {
                 // Found a combinator
-                let selector_text = text[current_start..i].trim();
+                let selector_text = text[current_start..i].trim_ws();
                 if !selector_text.is_empty() {
                     let selector_offset = base_offset + current_start;
                     let rel_selector = self.create_relative_selector(
@@ -2572,7 +2575,7 @@ impl<'a> SelectorParser<'a> {
                         || bytes[j] == b'&'
                     {
                         // This is a descendant combinator (space)
-                        let selector_text = text[current_start..i].trim();
+                        let selector_text = text[current_start..i].trim_ws();
                         if !selector_text.is_empty() {
                             let selector_offset = base_offset + current_start;
                             let rel_selector = self.create_relative_selector(
@@ -2602,9 +2605,9 @@ impl<'a> SelectorParser<'a> {
         // Add the last selector
         if current_start < text.len() {
             let selector_text = &text[current_start..];
-            if !selector_text.trim().is_empty() {
+            if !selector_text.trim_ws().is_empty() {
                 // Calculate offset skipping leading whitespace
-                let leading_ws = selector_text.len() - selector_text.trim_start().len();
+                let leading_ws = selector_text.len() - selector_text.trim_start_ws().len();
                 let selector_offset = base_offset + current_start + leading_ws;
                 let rel_selector =
                     self.create_relative_selector(selector_text, selector_offset, last_combinator);
@@ -2613,9 +2616,9 @@ impl<'a> SelectorParser<'a> {
         }
 
         // If no selectors were found, create one for the whole text
-        if result.is_empty() && !text.trim().is_empty() {
+        if result.is_empty() && !text.trim_ws().is_empty() {
             // Calculate offset skipping leading whitespace
-            let leading_ws = text.len() - text.trim_start().len();
+            let leading_ws = text.len() - text.trim_start_ws().len();
             let adjusted_offset = base_offset + leading_ws;
             let rel_selector = self.create_relative_selector(text, adjusted_offset, None);
             result.push(rel_selector);
@@ -2709,7 +2712,7 @@ impl<'a> SelectorParser<'a> {
         self.advance(); // consume '['
 
         // Skip whitespace
-        while !self.is_eof() && self.current_char().is_whitespace() {
+        while !self.is_eof() && is_js_whitespace(self.current_char()) {
             self.advance();
         }
 
@@ -2717,7 +2720,7 @@ impl<'a> SelectorParser<'a> {
         let name = self.read_identifier();
 
         // Skip whitespace
-        while !self.is_eof() && self.current_char().is_whitespace() {
+        while !self.is_eof() && is_js_whitespace(self.current_char()) {
             self.advance();
         }
 
@@ -2741,7 +2744,7 @@ impl<'a> SelectorParser<'a> {
 
         if matcher.is_some() {
             // Skip whitespace
-            while !self.is_eof() && self.current_char().is_whitespace() {
+            while !self.is_eof() && is_js_whitespace(self.current_char()) {
                 self.advance();
             }
 
@@ -2773,7 +2776,7 @@ impl<'a> SelectorParser<'a> {
                 let val_start = self.index;
                 while !self.is_eof() {
                     let ch = self.current_char();
-                    if ch == ']' || ch.is_whitespace() {
+                    if ch == ']' || is_js_whitespace(ch) {
                         break;
                     }
                     self.advance();
@@ -2784,7 +2787,7 @@ impl<'a> SelectorParser<'a> {
             }
 
             // Skip whitespace
-            while !self.is_eof() && self.current_char().is_whitespace() {
+            while !self.is_eof() && is_js_whitespace(self.current_char()) {
                 self.advance();
             }
 
@@ -2798,7 +2801,7 @@ impl<'a> SelectorParser<'a> {
                 flags = Some(self.source[flags_start..self.index].to_string());
 
                 // Skip whitespace
-                while !self.is_eof() && self.current_char().is_whitespace() {
+                while !self.is_eof() && is_js_whitespace(self.current_char()) {
                     self.advance();
                 }
             }
@@ -2889,7 +2892,7 @@ impl<'a> SelectorParser<'a> {
     }
 
     fn skip_whitespace(&mut self) {
-        while !self.is_eof() && self.current_char().is_whitespace() {
+        while !self.is_eof() && is_js_whitespace(self.current_char()) {
             self.advance();
         }
     }

--- a/crates/rsvelte_core/src/compiler/phases/1_parse/state/element.rs
+++ b/crates/rsvelte_core/src/compiler/phases/1_parse/state/element.rs
@@ -25,7 +25,7 @@ use crate::ast::template::{
 };
 use crate::error::ParseResult;
 
-use super::super::parser::{ElementType, Parser, StackEntry};
+use super::super::parser::{ElementType, Parser, StackEntry, is_js_whitespace};
 use super::super::utils::TrimWs;
 use super::super::utils::decode_html_entities;
 use super::super::utils::is_void_element;
@@ -845,9 +845,9 @@ impl<'a> Parser<'a> {
 
         let next_char = self.source[after_tag..].chars().next();
         match next_char {
-            Some('>') => true,                    // </textarea>
-            Some(c) if c.is_whitespace() => true, // </textarea ...> (valid, will find > eventually)
-            _ => false,                           // </textaread (not a valid closing tag)
+            Some('>') => true,                      // </textarea>
+            Some(c) if is_js_whitespace(c) => true, // </textarea ...> (valid, will find > eventually)
+            _ => false,                             // </textaread (not a valid closing tag)
         }
     }
 
@@ -1283,7 +1283,7 @@ impl<'a> Parser<'a> {
             if !self.options.loose
                 && let Some(bad) = shorthand_first_invalid_offset(&name)
             {
-                let leading_ws = expr_content.len() - expr_content.trim_start().len();
+                let leading_ws = expr_content.len() - expr_content.trim_start_ws().len();
                 return Err(crate::error::ParseError::expected_token(
                     "}",
                     expr_start + leading_ws + bad,
@@ -1854,7 +1854,7 @@ impl<'a> Parser<'a> {
                 while !self.is_eof() {
                     let c = self.current_char();
                     // End of unquoted value (but NOT / alone)
-                    if c.is_whitespace() || c == '>' {
+                    if is_js_whitespace(c) || c == '>' {
                         break;
                     }
                     // Expression start
@@ -2257,7 +2257,7 @@ impl<'a> Parser<'a> {
                 // Non-ASCII whitespace check
                 if cur_byte >= 0x80 {
                     let c = self.source[self.index..].chars().next().unwrap_or('\0');
-                    if c.is_whitespace() {
+                    if is_js_whitespace(c) {
                         break;
                     }
                 }
@@ -2406,7 +2406,7 @@ impl<'a> Parser<'a> {
                         } else {
                             // Non-ASCII: check for Unicode whitespace
                             let c = self.source[self.index..].chars().next().unwrap_or('\0');
-                            if c.is_whitespace() {
+                            if is_js_whitespace(c) {
                                 break;
                             }
                             self.index += c.len_utf8();
@@ -2520,7 +2520,7 @@ impl<'a> Parser<'a> {
                 // Check for {@html} or other @ tags in textarea - this is invalid
                 // Peek ahead: { followed by optional whitespace and @
                 let peek_content = self.source.get(self.index + 1..).unwrap_or("");
-                let trimmed_peek = peek_content.trim_start();
+                let trimmed_peek = peek_content.trim_start_ws();
                 if trimmed_peek.starts_with('@') {
                     // Extract the tag name after @
                     let after_at = trimmed_peek.get(1..).unwrap_or("");

--- a/crates/rsvelte_core/src/compiler/phases/1_parse/state/tag.rs
+++ b/crates/rsvelte_core/src/compiler/phases/1_parse/state/tag.rs
@@ -20,7 +20,7 @@ use crate::ast::typed_expr::JsNode;
 use crate::compiler::phases::phase1_parse::utils::find_matching_bracket;
 use crate::error::ParseResult;
 
-use super::super::parser::{Parser, StackEntry};
+use super::super::parser::{Parser, StackEntry, is_js_whitespace};
 use super::super::utils::TrimWs;
 
 impl<'a> Parser<'a> {
@@ -128,7 +128,7 @@ impl<'a> Parser<'a> {
         if is_maybe_type {
             let body_after = &self.source[decl_start + 4..body_end];
             let ident_next = body_after
-                .trim_start()
+                .trim_start_ws()
                 .as_bytes()
                 .first()
                 .copied()
@@ -141,7 +141,7 @@ impl<'a> Parser<'a> {
             // covers the whole declaration (trailing whitespace trimmed),
             // mirroring upstream's `{ start: declaration.start, end:
             // declaration.end }`.
-            let decl_text_end = decl_start + self.source[decl_start..body_end].trim_end().len();
+            let decl_text_end = decl_start + self.source[decl_start..body_end].trim_end_ws().len();
             return Err(crate::error::ParseError::svelte(
                 "declaration_tag_invalid_type",
                 "Declaration tags must be `let` or `const` declarations",
@@ -153,7 +153,7 @@ impl<'a> Parser<'a> {
         self.index = decl_start + kw_len;
         self.skip_whitespace();
         let body_start = self.index;
-        let body_text = self.source[body_start..body_end].trim_end();
+        let body_text = self.source[body_start..body_end].trim_end_ws();
         self.index = body_end;
         self.advance(); // consume `}`
 
@@ -188,7 +188,7 @@ impl<'a> Parser<'a> {
                     // `js_parse_error` — only a parseable statement that
                     // isn't a `let`/`const` declaration becomes
                     // `declaration_tag_invalid_type`.
-                    let stmt_text = self.source[decl_start..body_end].trim_end();
+                    let stmt_text = self.source[decl_start..body_end].trim_end_ws();
                     if let Some((msg, pos)) =
                         super::super::read::expression::check_js_statement_parse_error(
                             stmt_text, self.ts,
@@ -347,7 +347,7 @@ impl<'a> Parser<'a> {
         let init_offset = body_start
             + eq_idx
             + 1
-            + (body_text[eq_idx + 1..].len() - body_text[eq_idx + 1..].trim_start().len());
+            + (body_text[eq_idx + 1..].len() - body_text[eq_idx + 1..].trim_start_ws().len());
         // In loose mode an initializer that is not a complete expression
         // (e.g. `a /`) cannot be parsed. Upstream always parses the declaration
         // statement with acorn (non-loose); only the *fallback* is loose. So
@@ -415,7 +415,7 @@ impl<'a> Parser<'a> {
 
         let mut declarators: Vec<Value> = Vec::with_capacity(segments.len());
         for (seg_off, raw) in segments {
-            let lead = raw.len() - raw.trim_start().len();
+            let lead = raw.len() - raw.trim_start_ws().len();
             let seg = raw.trim_ws();
             if seg.is_empty() {
                 continue;
@@ -424,7 +424,7 @@ impl<'a> Parser<'a> {
 
             let (pattern_str, init_str, init_off) = match find_top_level_assignment(seg) {
                 Some(eq) => {
-                    let init_lead = seg[eq + 1..].len() - seg[eq + 1..].trim_start().len();
+                    let init_lead = seg[eq + 1..].len() - seg[eq + 1..].trim_start_ws().len();
                     (
                         seg[..eq].trim_ws().to_string(),
                         seg[eq + 1..].trim_ws().to_string(),
@@ -796,16 +796,10 @@ impl<'a> Parser<'a> {
     /// Tolerates arbitrary whitespace (incl. newlines) on both sides so a
     /// newline-split header parses like a single-spaced one.
     fn looks_like_as_separator(&self) -> bool {
-        let mut j = self.index;
-        while j < self.bytes.len() && self.bytes[j].is_ascii_whitespace() {
-            j += 1;
-        }
+        let j = self.skip_js_whitespace_from(self.index);
         self.bytes.get(j) == Some(&b'a')
             && self.bytes.get(j + 1) == Some(&b's')
-            && self
-                .bytes
-                .get(j + 2)
-                .is_some_and(|c| c.is_ascii_whitespace())
+            && self.is_js_whitespace_at(j + 2)
     }
 
     pub fn parse_each_block(&mut self, start: usize) -> ParseResult<Option<TemplateNode<'a>>> {
@@ -871,7 +865,10 @@ impl<'a> Parser<'a> {
                 // the same as `{#each cats as { id }}`. We trigger on the first
                 // whitespace byte of the run and skip the whole `WS* as` so it
                 // is not re-scanned; the rightmost top-level `as` wins.
-                _ if depth == 0 && b.is_ascii_whitespace() && self.looks_like_as_separator() => {
+                _ if depth == 0
+                    && self.is_js_whitespace_at(self.index)
+                    && self.looks_like_as_separator() =>
+                {
                     last_as = Some(self.index);
                     self.skip_whitespace();
                     self.index += 2; // consume `as`
@@ -958,7 +955,7 @@ impl<'a> Parser<'a> {
                             // can emit it; the parser no longer errors here.
                             let key_opt = if idx_has_key {
                                 let raw_slice = &self.source[expr_start..expr_end];
-                                let lead_ws = raw_slice.len() - raw_slice.trim_start().len();
+                                let lead_ws = raw_slice.len() - raw_slice.trim_start_ws().len();
                                 let base = expr_start + lead_ws;
                                 if let Some(rel_paren) = s[comma_pos + 1..].find('(') {
                                     let key_start = base + comma_pos + 1 + rel_paren + 1;
@@ -966,7 +963,7 @@ impl<'a> Parser<'a> {
                                         find_matching_bracket(self.source, key_start, '(')
                                             .unwrap_or(self.bytes.len());
                                     let key_raw = &self.source[key_start..key_end];
-                                    let key_lead = key_raw.len() - key_raw.trim_start().len();
+                                    let key_lead = key_raw.len() - key_raw.trim_start_ws().len();
                                     let key_content = key_raw.trim_ws().to_string();
                                     Some(self.parse_head_expression(
                                         &key_content,
@@ -1171,7 +1168,7 @@ impl<'a> Parser<'a> {
         let raw_content = &self.source[context_start..context_end];
         let trimmed_content = raw_content.trim_ws();
         // Calculate actual start position after trimming leading whitespace
-        let leading_ws = raw_content.len() - raw_content.trim_start().len();
+        let leading_ws = raw_content.len() - raw_content.trim_start_ws().len();
         let actual_context_start = context_start + leading_ws;
         let context = self.parse_binding_pattern(trimmed_content, actual_context_start)?;
 
@@ -1407,13 +1404,13 @@ impl<'a> Parser<'a> {
                     || self.source[..self.index]
                         .chars()
                         .next_back()
-                        .is_some_and(|c| c.is_whitespace() || c == ')' || c == ']');
+                        .is_some_and(|c| is_js_whitespace(c) || c == ')' || c == ']');
                 if preceded_by_ws && self.match_str("then") {
                     let after_idx = self.index + 4;
                     let is_word_boundary = self.source[after_idx.min(self.source.len())..]
                         .chars()
                         .next()
-                        .is_none_or(|c| c.is_whitespace() || c == '}');
+                        .is_none_or(|c| is_js_whitespace(c) || c == '}');
                     if is_word_boundary {
                         has_then = true;
                         break;
@@ -1424,7 +1421,7 @@ impl<'a> Parser<'a> {
                     let is_word_boundary = self.source[after_idx.min(self.source.len())..]
                         .chars()
                         .next()
-                        .is_none_or(|c| c.is_whitespace() || c == '}');
+                        .is_none_or(|c| is_js_whitespace(c) || c == '}');
                     if is_word_boundary {
                         has_catch = true;
                         break;
@@ -1436,10 +1433,10 @@ impl<'a> Parser<'a> {
         let expr_end = self.index;
         let expr_content = &self.source[expr_start..expr_end];
         // Calculate the actual start position after trimming leading whitespace
-        let trimmed_content = expr_content.trim_start();
+        let trimmed_content = expr_content.trim_start_ws();
         let leading_ws = expr_content.len() - trimmed_content.len();
         let adjusted_start = expr_start + leading_ws;
-        let adjusted_end = expr_end - (expr_content.len() - trimmed_content.trim_end().len());
+        let adjusted_end = expr_end - (expr_content.len() - trimmed_content.trim_end_ws().len());
         // For await blocks, we parse the expression with a known end position
         // to avoid find_matching_bracket finding the block's closing }
         let expression = if let Some(lazy) =
@@ -2073,7 +2070,8 @@ impl<'a> Parser<'a> {
                     let init_offset = expr_start
                         + eq_idx
                         + 1
-                        + (trimmed[eq_idx + 1..].len() - trimmed[eq_idx + 1..].trim_start().len());
+                        + (trimmed[eq_idx + 1..].len()
+                            - trimmed[eq_idx + 1..].trim_start_ws().len());
                     let init_expr = self.parse_js_expression(init_str, init_offset);
 
                     // Reject a sequence-expression initializer, mirroring
@@ -2107,7 +2105,7 @@ impl<'a> Parser<'a> {
                     // upstream's `declarator_end = parser.index` captured right
                     // after `read_expression` (Svelte 5.56.4), rather than the
                     // bare `init.end` (which stops inside the parens).
-                    let declarator_end = init_offset + init_str.trim_end().len();
+                    let declarator_end = init_offset + init_str.trim_end_ws().len();
                     // The VariableDeclaration starts at the `const` keyword
                     // (`start + 2`, i.e. past the leading `{@`), matching
                     // upstream's `start: start + 2 // start at const, not at @const`.
@@ -2225,7 +2223,7 @@ impl<'a> Parser<'a> {
         // parse_js_expression_strict() creates Lazy expressions.
 
         // Adjust offset for leading whitespace that gets trimmed
-        let leading_ws = content.len() - content.trim_start().len();
+        let leading_ws = content.len() - content.trim_start_ws().len();
         let trimmed = content.trim_ws();
         super::super::expression::parse_expression(
             &self.arena,
@@ -2257,7 +2255,7 @@ impl<'a> Parser<'a> {
         if self.should_defer_template_parse() {
             let trimmed = content.trim_ws();
             if !trimmed.is_empty() {
-                let leading_ws = content.len() - content.trim_start().len();
+                let leading_ws = content.len() - content.trim_start_ws().len();
                 return Ok(Expression::Lazy {
                     start: (offset + leading_ws) as u32,
                     end: (offset + leading_ws + trimmed.len()) as u32,
@@ -2268,7 +2266,7 @@ impl<'a> Parser<'a> {
         }
 
         // Adjust offset for leading whitespace that gets trimmed
-        let leading_ws = content.len() - content.trim_start().len();
+        let leading_ws = content.len() - content.trim_start_ws().len();
         let trimmed = content.trim_ws();
         let trimmed_offset = offset + leading_ws;
         super::super::expression::parse_expression(
@@ -2337,7 +2335,7 @@ impl<'a> Parser<'a> {
     /// identifier: `{@render …}` (its invalid-call check is an analysis-phase
     /// error) and the `{#await …}` head.
     pub fn parse_js_expression_lenient(&self, content: &str, offset: usize) -> Expression<'a> {
-        let leading_ws = content.len() - content.trim_start().len();
+        let leading_ws = content.len() - content.trim_start_ws().len();
         let trimmed = content.trim_ws();
         match self.defer_expression(trimmed, offset + leading_ws, LazyKind::Lenient) {
             Some(lazy) => lazy,
@@ -2355,7 +2353,7 @@ impl<'a> Parser<'a> {
         offset: usize,
     ) -> crate::error::ParseResult<Expression<'a>> {
         // Adjust offset for leading whitespace that gets trimmed
-        let leading_ws = content.len() - content.trim_start().len();
+        let leading_ws = content.len() - content.trim_start_ws().len();
         let trimmed = content.trim_ws();
         let trimmed_offset = offset + leading_ws;
         if let Some(lazy) = self.defer_expression(trimmed, trimmed_offset, LazyKind::Attribute) {
@@ -2403,7 +2401,7 @@ impl<'a> Parser<'a> {
         disallow_loose: bool,
         close_char: char,
     ) -> crate::error::ParseResult<Expression<'a>> {
-        let leading_ws = content.len() - content.trim_start().len();
+        let leading_ws = content.len() - content.trim_start_ws().len();
         let trimmed = content.trim_ws();
         let trimmed_offset = offset + leading_ws;
         let opening_token = if close_char == ')' { '(' } else { '{' };

--- a/crates/rsvelte_core/src/compiler/phases/1_parse/utils/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/1_parse/utils/mod.rs
@@ -25,32 +25,47 @@ pub use fuzzymatch::fuzzymatch;
 )]
 pub use html::{decode_character_references, is_void_element, validate_code};
 
-/// `str::trim` without the UTF-8 decode: template sources are ASCII at the
-/// trimmed edges in practice, and only a non-ASCII edge falls back to `trim`.
+/// Upstream's `String.prototype.trim` without the UTF-8 decode, so the trimmed
+/// set is JS whitespace rather than Unicode `White_Space` — the two differ on
+/// `U+0085` and `U+FEFF`. Only a non-ASCII edge pays for the decode.
 pub trait TrimWs {
     fn trim_ws(&self) -> &str;
+    fn trim_start_ws(&self) -> &str;
+    fn trim_end_ws(&self) -> &str;
 }
 
 impl TrimWs for str {
     #[inline]
     fn trim_ws(&self) -> &str {
-        const fn is_ascii_ws(b: u8) -> bool {
-            matches!(b, b' ' | b'\t' | b'\n' | b'\r' | 0x0b | 0x0c)
-        }
+        self.trim_start_ws().trim_end_ws()
+    }
+
+    #[inline]
+    fn trim_start_ws(&self) -> &str {
         let bytes = self.as_bytes();
         let mut start = 0;
-        let mut end = bytes.len();
-        while start < end && is_ascii_ws(bytes[start]) {
+        while start < bytes.len() && super::parser::is_js_whitespace_byte(bytes[start]) {
             start += 1;
         }
-        while end > start && is_ascii_ws(bytes[end - 1]) {
+        // Only ASCII bytes were skipped, so `start` is a char boundary.
+        let rest = &self[start..];
+        match rest.as_bytes().first() {
+            Some(&b) if b >= 0x80 => rest.trim_start_matches(super::parser::is_js_whitespace),
+            _ => rest,
+        }
+    }
+
+    #[inline]
+    fn trim_end_ws(&self) -> &str {
+        let bytes = self.as_bytes();
+        let mut end = bytes.len();
+        while end > 0 && super::parser::is_js_whitespace_byte(bytes[end - 1]) {
             end -= 1;
         }
-        // Only ASCII bytes were skipped, so both ends are char boundaries.
-        let trimmed = &self[start..end];
-        match (trimmed.as_bytes().first(), trimmed.as_bytes().last()) {
-            (Some(&first), Some(&last)) if first >= 0x80 || last >= 0x80 => trimmed.trim(),
-            _ => trimmed,
+        let head = &self[..end];
+        match head.as_bytes().last() {
+            Some(&b) if b >= 0x80 => head.trim_end_matches(super::parser::is_js_whitespace),
+            _ => head,
         }
     }
 }

--- a/crates/rsvelte_core/tests/js_whitespace_parser_2561.rs
+++ b/crates/rsvelte_core/tests/js_whitespace_parser_2561.rs
@@ -1,0 +1,237 @@
+//! Every whitespace decision in the parser reads the same set upstream reads:
+//! ECMAScript `WhiteSpace + LineTerminator`, spelled out in `is_whitespace(cc)`
+//! at `1-parse/index.js:15-30` and reached again through every `\s` regex and
+//! `String.prototype.trim*` in that parser. Rust's `char::is_whitespace` is the
+//! Unicode `White_Space` property, and `u8::is_ascii_whitespace` is a third set
+//! again — it omits `U+000B`.
+//!
+//! Expected verdicts below were measured against `svelte@5.56.8`, not recalled.
+
+use rsvelte_core::{Allocator, CompileOptions, GenerateMode, ParseOptions, compile, parse};
+
+/// JS whitespace that Rust's ASCII fast paths used to miss (`U+000B`, `U+000C`)
+/// or that Unicode `White_Space` omits (`U+FEFF`). Upstream accepts all three
+/// wherever it accepts a space.
+const JS_ONLY: [char; 3] = ['\u{b}', '\u{c}', '\u{feff}'];
+
+/// Unicode `White_Space` that is *not* JS whitespace. Upstream never skips it.
+const NEL: char = '\u{85}';
+
+fn parse_ok(src: &str) -> Result<(), String> {
+    let allocator = Allocator::default();
+    match parse(src, &allocator, ParseOptions::default()) {
+        Ok(_) => Ok(()),
+        Err(e) => Err(format!("{e:?}")),
+    }
+}
+
+fn server_js(src: &str) -> Result<String, String> {
+    compile(
+        src,
+        CompileOptions {
+            generate: GenerateMode::Server,
+            ..Default::default()
+        },
+    )
+    .map(|r| r.js.code)
+    .map_err(|e| format!("{e:?}"))
+}
+
+/// The predicate itself: exactly the 25 code points ECMA-262 lists, which is not
+/// what either Rust set contains. Counting members alone cannot tell them apart
+/// — `White_Space` also has 25.
+#[test]
+fn the_parser_whitespace_set_is_the_js_one() {
+    // Only whitespace is skipped between `{` and a close marker: anything else
+    // makes the braces an expression tag, which fails to parse. So "parses" is
+    // exactly "the parser called this character whitespace".
+    let is_skipped = |c: char| {
+        parse_ok(&format!(
+            "<script>let x = 1;</script>{{#if x}}<p>a</p>{{{c}/if}}"
+        ))
+        .is_ok()
+    };
+
+    let expected: Vec<char> = "\u{9}\u{a}\u{b}\u{c}\u{d}\u{20}\u{a0}\u{1680}\u{2000}\u{2001}\u{2002}\u{2003}\u{2004}\u{2005}\u{2006}\u{2007}\u{2008}\u{2009}\u{200a}\u{2028}\u{2029}\u{202f}\u{205f}\u{3000}\u{feff}".chars().collect();
+    assert_eq!(expected.len(), 25);
+
+    // Scanning the BMP is exhaustive for this question: the highest member of
+    // either candidate set is `U+FEFF`, asserted rather than assumed.
+    assert!(expected.iter().all(|c| (*c as u32) <= 0xFFFF));
+    assert!(
+        char::from_u32(0x10000)
+            .into_iter()
+            .chain((0x10000u32..=0x10FFFF).filter_map(char::from_u32))
+            .all(|c| !c.is_whitespace())
+    );
+
+    let unexpected: Vec<String> = (0u32..=0xFFFF)
+        .filter_map(char::from_u32)
+        .filter(|c| is_skipped(*c) != expected.contains(c))
+        .map(|c| format!("U+{:04X}", c as u32))
+        .collect();
+    assert!(
+        unexpected.is_empty(),
+        "characters classified against the wrong set: {unexpected:?}"
+    );
+    assert!(!is_skipped(NEL), "U+0085 is not JS whitespace");
+}
+
+/// `{ WS #if }`, `{ WS :else }`, `{ WS /if }` — upstream runs `allow_whitespace()`
+/// between `{` and the marker, so all three accept any JS whitespace.
+#[test]
+fn block_markers_accept_js_whitespace() {
+    for c in JS_ONLY {
+        for src in [
+            format!("<script>let x = 1;</script>{{{c}#if x}}<p>a</p>{{/if}}"),
+            format!("<script>let x = 1;</script>{{#if x}}<p>a</p>{{{c}:else}}<p>b</p>{{/if}}"),
+            format!("<script>let x = 1;</script>{{#if x}}<p>a</p>{{{c}/if}}"),
+        ] {
+            assert!(
+                parse_ok(&src).is_ok(),
+                "U+{:04X} rejected in a block marker: {:?}",
+                c as u32,
+                parse_ok(&src)
+            );
+        }
+    }
+}
+
+/// The other direction, which a fix that merely widened the set would miss:
+/// `U+0085` is not whitespace, so it must not be skipped before the marker.
+#[test]
+fn block_markers_reject_a_nel() {
+    let src = format!("<script>let x = 1;</script>{{#if x}}<p>a</p>{{{NEL}/if}}");
+    assert!(
+        parse_ok(&src).is_err(),
+        "U+0085 was skipped before a close marker; upstream raises js_parse_error"
+    );
+}
+
+/// A tag name ends at whitespace — upstream `read_until(/(\s|\/|>)/)`.
+#[test]
+fn a_tag_name_ends_at_js_whitespace() {
+    for c in JS_ONLY {
+        let src = format!("<p{c}a=\"1\">t</p>");
+        assert!(
+            parse_ok(&src).is_ok(),
+            "U+{:04X} did not end the tag name: {:?}",
+            c as u32,
+            parse_ok(&src)
+        );
+    }
+    let src = format!("<p{NEL}a=\"1\">t</p>");
+    assert!(
+        parse_ok(&src).is_err(),
+        "U+0085 ended the tag name; upstream raises tag_invalid_name"
+    );
+}
+
+/// The same scan runs on closing tags.
+#[test]
+fn a_closing_tag_name_ends_at_js_whitespace() {
+    for c in JS_ONLY {
+        let src = format!("<textarea>t</textarea{c}>");
+        assert!(
+            parse_ok(&src).is_ok(),
+            "U+{:04X} did not end the closing tag name: {:?}",
+            c as u32,
+            parse_ok(&src)
+        );
+    }
+}
+
+/// `{#snippet WS name()}` — the header separator.
+#[test]
+fn a_snippet_header_accepts_js_whitespace() {
+    for c in JS_ONLY {
+        let src = format!("{{#snippet{c}s()}}<p>a</p>{{/snippet}}");
+        assert!(
+            parse_ok(&src).is_ok(),
+            "U+{:04X} rejected in a snippet header: {:?}",
+            c as u32,
+            parse_ok(&src)
+        );
+    }
+}
+
+/// The `{#each … as …}` alias separator was found by a byte-level
+/// `is_ascii_whitespace` trigger, so a line separator never fired it.
+#[test]
+fn the_each_as_separator_accepts_a_line_separator() {
+    for c in ['\u{2028}', '\u{2029}'] {
+        let src = format!("<script>let a = [1];</script>{{#each a{c}as x}}<p>{{x}}</p>{{/each}}");
+        assert!(
+            parse_ok(&src).is_ok(),
+            "U+{:04X} did not separate the `as` alias: {:?}",
+            c as u32,
+            parse_ok(&src)
+        );
+    }
+}
+
+/// Not an error-code difference but an emitted-code one: upstream reports
+/// `then != null` for every JS whitespace before the keyword. rsvelte used to
+/// compile `{#await p<ZWNBSP>then v}` cleanly *without* the then branch.
+#[test]
+fn the_await_then_keyword_is_recognised_after_a_zwnbsp() {
+    let space = server_js("<script>let p = null;</script>{#await p then v}<p>{v}</p>{/await}")
+        .expect("ascii control must compile");
+    assert!(
+        space.contains("(v) =>"),
+        "ascii control lost its then branch: {space}"
+    );
+
+    let zwnbsp =
+        server_js("<script>let p = null;</script>{#await p\u{feff}then v}<p>{v}</p>{/await}")
+            .expect("zwnbsp variant must compile");
+    assert!(
+        zwnbsp.contains("(v) =>"),
+        "the then branch was dropped after U+FEFF: {zwnbsp}"
+    );
+}
+
+/// The CSS reader shares the parser's `allow_whitespace`, so its set must match
+/// too: upstream raises `css_expected_identifier` on a NEL before the block.
+#[test]
+fn the_css_reader_does_not_treat_a_nel_as_whitespace() {
+    let src = format!("<p class=\"a\">t</p><style>.a{NEL}{{ color: red; }}</style>");
+    assert!(
+        parse_ok(&src).is_err(),
+        "U+0085 was skipped in a selector; upstream raises css_expected_identifier"
+    );
+
+    let ok = "<p class=\"a\">t</p><style>.a\u{feff}{ color: red; }</style>";
+    assert!(
+        parse_ok(ok).is_ok(),
+        "U+FEFF rejected in a selector: {:?}",
+        parse_ok(ok)
+    );
+}
+
+/// Control: the 24 members both sets share must behave exactly like a space in
+/// every slot above, so a predicate that accepted or rejected everything fails.
+#[test]
+fn the_shared_members_behave_like_a_space() {
+    let shared: Vec<char> = (0u32..=0x10FFFF)
+        .filter_map(char::from_u32)
+        .filter(|c| c.is_whitespace() && *c != NEL)
+        .collect();
+    assert_eq!(shared.len(), 24);
+
+    for c in shared {
+        for template in [
+            "<script>let x = 1;</script>{#if x}<p>a</p>{{C}/if}",
+            "<p{C}a=\"1\">t</p>",
+            "{#snippet{C}s()}<p>a</p>{/snippet}",
+        ] {
+            let src = template.replace("{C}", &c.to_string());
+            assert!(
+                parse_ok(&src).is_ok(),
+                "U+{:04X} rejected where a space is accepted: {:?}",
+                c as u32,
+                parse_ok(&src)
+            );
+        }
+    }
+}


### PR DESCRIPTION
Fixes #2561.

## Three sets, not two

Upstream's parser asks one question everywhere: is this character in ECMAScript `WhiteSpace + LineTerminator`? It is spelled out by hand in `is_whitespace(cc)` at `submodules/svelte/packages/svelte/src/compiler/phases/1-parse/index.js:15-30` (`9..=13`, `32`, `160`, `5760`, `8192..=8202`, `8232`, `8233`, `8239`, `8287`, `12288`, `65279`), and reached again through every `\s` regex and every `String.prototype.trim*` in that parser — all the same 25 code points.

rsvelte's parser used **three** different sets:

| set | members | differs from JS by |
|---|---|---|
| `char::is_whitespace` (Unicode `White_Space`) | 25 | `+U+0085`, `−U+FEFF` |
| `u8::is_ascii_whitespace` | 5 | `−U+000B`, and the 19 non-ASCII members |
| hand-written fast paths (`b' '`,`\t`,`\n`,`\r`) | 4 | `−U+000B`, `−U+000C`, and the 19 non-ASCII members |

This PR replaces all three with one `is_js_whitespace` in `1_parse/parser.rs`, plus a byte-level `is_js_whitespace_byte` **derived from it** rather than restated, and `TrimWs::{trim_ws, trim_start_ws, trim_end_ws}` built on the same predicate.

## Differential measurement

40 template slots × 28 characters (the union of both candidate sets, plus a no-separator control and two non-whitespace controls) = **1102 comparisons** against `svelte@5.56.8`'s `parse(src, { modern: true })`.

```
pre-fix:  1102 comparisons,  69 divergent
post-fix: 1102 comparisons,  39 divergent
closed:    30      introduced: 0
```

The 30 closed, in full:

| slot | characters | before |
|---|---|---|
| `{<WS>#if x}` / `{<WS>:else}` / `{<WS>/if}` | `000B` `000C` `FEFF` | rsvelte `js_parse_error`, official OK |
| same three markers | `0085` | rsvelte OK, official `js_parse_error` |
| `{#snippet<WS>s()}` | `000B` `000C` `FEFF` / `0085` | both directions |
| `<p<WS>a="1">` | `000B` `000C` `FEFF` / `0085` | both directions |
| `</textarea<WS>>` | `000B` `000C` `FEFF` / `0085` | both directions |
| `{#each a<WS>as x}` | `2028` `2029` | rsvelte `expected_token`, official OK |
| `.a<NEL>{…}`, `.a<NEL>>.b{…}`, `.a<NEL>,.a{…}`, `.a {<NEL>.b{…}}` | `0085` | rsvelte OK, official `css_expected_identifier` |

No comparison that agreed before disagrees after (checked in both directions, not just by count).

## Denominator

Scope: `crates/rsvelte_core/src/compiler/phases/1_parse` — the parser path #2561 names. Counts from `command grep` (the plain `grep` here is a wrapper that skips gitignored paths); positive control: `is_js_whitespace` matches 17 lines in `parser.rs` and `pub fn parse` matches 5 in `1_parse/mod.rs`, both non-zero.

**N = 132 call sites found. M = 116 switched to the JS set. K = 16 deliberately left.**

| kind | before | after | note |
|---|---|---|---|
| `char::is_whitespace()` | 21 | **0** | all switched |
| `.trim()` | 45 | **0** | → `trim_ws()` |
| `.trim_start()` | 41 | **0** | → `trim_start_ws()` |
| `.trim_end()` | 14 | **2** | K, see below |
| `u8::is_ascii_whitespace` | 19 | **16** | 3 switched, 16 K |
| `trim_ascii*` | 0 | 0 | none exist |

**K = 16, with the reason for each:**

- **2** — `parser.rs` `content_end: source.trim_end()` (`Parser::new` and `Parser::reset`). Left on purpose: **#2560** fixes exactly these two with the same predicate. Fixing them here would duplicate that PR and conflict with it. After both land there is one predicate and no `trim_end()` in phase 1.
- **14** — byte scans in `read/style.rs` (CSS selector/declaration edges) and **2** in `utils/bracket.rs`. `is_ascii_whitespace` differs from the JS set by `U+000B` plus all 19 non-ASCII members, so these are *not* known-correct. They are **unmeasured**: none of the 1102 comparisons discriminates them — six CSS slots were added specifically to try (`css_decl_trailing`, `css_selector_list`, `css_media_query`, `css_important`, `css_nested`, `css_pseudo_args`), and all agree with official on every one of the 28 characters including `U+000B`. Converting the ASCII half is one mechanical edit, but I am not making an edit I cannot show the effect of; it needs a discriminating input first.

Phases 2 and 3 are **not surveyed** and are not claimed to be clean: `2_analyze` has 7 `is_whitespace()`, 4 `is_ascii_whitespace`, 29 `trim*`; `3_transform` has 75, 61, and 1034. Those consume already-parsed strings and assemble generated code rather than classifying source characters, but that is an argument, not a measurement, and no probe here reaches them.

## The 39 that remain — and why none of them is an alphabet bug

The negative controls settle this. `U+00A7` (§) and `U+0007` (BEL) are whitespace in *neither* set, so any slot that diverges for them is not diverging because of the whitespace set:

| remaining divergence | reproduces with `U+00A7`/`U+0007`? | cause |
|---|---|---|
| `await_keyword`, `const_keyword`, `await_then`, `attr_value_unquoted`, `directive_sep`, `css_attr_selector`, `css_nth`, `css_pseudo_args` | **yes** | rsvelte accepts input upstream rejects, independent of the character |
| `if_paren` / `each_bracket` / `html_paren` with **no separator at all** | n/a — diverges at `NONE` | `Parser::require_whitespace` exists but has **0 callers**; upstream calls `require_whitespace()` at 15 sites (`state/tag.js` ×14, `state/element.js:536`) |
| every remaining `U+0085` row | no | **oxc's JS lexer treats `U+0085` as whitespace** |

The last one is measured directly, not inferred. `oxc_parser::Parser::parse` on `let x\u{85}= 1;` returns `diagnostics=0, irregular_whitespaces=1`; acorn rejects the same input. Per ECMA-262 `U+0085` is not `WhiteSpace`, so acorn is right. Nothing in rsvelte's whitespace predicates can fix that, which is why `{#if<NEL>x}` — the example in #2561 — still parses. **That is two further layers under the issue's headline case, and this PR closes only the alphabet one.** Both deserve their own issues:

1. oxc accepts `U+0085` as JS whitespace (`irregular_whitespaces=1, diagnostics=0`).
2. `require_whitespace` is dead code in rsvelte; upstream calls it at 15 sites, and its absence diverges even with no whitespace character present.

## Tests

`crates/rsvelte_core/tests/js_whitespace_parser_2561.rs`, 10 tests, all through `parse` / `compile`:

- `the_parser_whitespace_set_is_the_js_one` — enumerates the BMP through a slot only whitespace can satisfy (`{<C>/if}`) and asserts the accepted set is exactly the 25 ECMA-262 code points. The BMP bound is asserted complete in-test, not assumed.
- `block_markers_accept_js_whitespace` / `block_markers_reject_a_nel` — both directions, so widening the set alone fails.
- `a_tag_name_ends_at_js_whitespace`, `a_closing_tag_name_ends_at_js_whitespace`, `a_snippet_header_accepts_js_whitespace`, `the_each_as_separator_accepts_a_line_separator`, `the_css_reader_does_not_treat_a_nel_as_whitespace`.
- `the_await_then_keyword_is_recognised_after_a_zwnbsp` — the only one that is not an error-code difference: `{#await p<ZWNBSP>then v}` compiled **cleanly with the then branch missing**, emitting `$.await($$renderer, , …)` with an empty argument slot.
- `the_shared_members_behave_like_a_space` — the 24 members both sets share, in three slots. Passes before and after; it is the control a predicate accepting or rejecting everything would break.

Pre-fix, on this PR's base (`8c53ac49`), **10 of 10 fail**:

```
---- the_parser_whitespace_set_is_the_js_one ----
characters classified against the wrong set: ["U+000B", "U+000C", "U+0085", "U+FEFF"]

---- block_markers_accept_js_whitespace ----
U+000B rejected in a block marker: Err("SvelteError { code: \"js_parse_error\",
  message: \"Expected `in` but found `Identifier`\", span: (33, 33) }")

---- block_markers_reject_a_nel ----
U+0085 was skipped before a close marker; upstream raises js_parse_error

---- a_closing_tag_name_ends_at_js_whitespace ----
U+000B did not end the closing tag name: Err("SvelteError { code: \"element_invalid_closing_tag\",
  message: \"`</textarea>` attempted to close an element that was not open\", span: (11, 11) }")

---- a_snippet_header_accepts_js_whitespace ----
U+000B rejected in a snippet header: Err("SvelteError { code: \"expected_token\",
  message: \"Expected token }\", span: (9, 9) }")

---- the_each_as_separator_accepts_a_line_separator ----
U+2028 did not separate the `as` alias: Err("SvelteError { code: \"expected_token\",
  message: \"Expected token }\", span: (40, 41) }")

---- the_css_reader_does_not_treat_a_nel_as_whitespace ----
U+0085 was skipped in a selector; upstream raises css_expected_identifier

---- the_await_then_keyword_is_recognised_after_a_zwnbsp ----
the then branch was dropped after U+FEFF:
	$.await(
		$$renderer,
		,
		() => { $$renderer.push(`<p>${$.escape(v)}</p>`); },
		() => {}
	);

---- the_shared_members_behave_like_a_space ----
U+000B rejected where a space is accepted: Err("SvelteError { code: \"js_parse_error\",
  message: \"Unterminated regular expression\", span: (47, 47) }")

test result: FAILED. 0 passed; 10 failed
```

Each failed for the predicted reason. After the fix all 10 pass, along with the 1508 `rsvelte_core` unit tests and `await_ideographic_space_2409`, `bindable_whitespace`, `comment_whitespace_run_1975`, `await_block_multibyte`, `const_tag_multibyte`.

## A test pinning the wrong behaviour

None found for this PR. The only candidate, `trailing_whitespace_trim_2410.rs` (which #2501 wrote to pin today's incorrect `U+0085` handling on purpose), tests `content_end`, which this PR leaves to #2560 — it still passes here, and #2560 already updates it.

## Ratchets

None move; no `*known-failures*.json` touched. `node scripts/compat-corpus/known-failures-md-check.mjs` → `19 declared ratchets across 16 docs match their JSON`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K7bw79DQ7roFtohdnGd1v6
