### PR TITLE
perf(client): stop the per-statement transform chain from copying what it did not rewrite

### DIFF
--- a/.changeset/statement-chain-no-copy.md
+++ b/.changeset/statement-chain-no-copy.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/compiler": patch
+---
+
+Stop the per-statement client transform chain from copying a statement it did not rewrite. Nine of its stages now return their input borrowed when they find nothing to do, and the two loop-invariant legacy-state name vectors are built once instead of once per top-level statement. Output is unchanged.

--- a/crates/rsvelte_core/Cargo.toml
+++ b/crates/rsvelte_core/Cargo.toml
@@ -45,6 +45,10 @@ measure-json = []
 # Repository-local instrumentation: decompose the per-prop re-scan in
 # `transform_prop_reads_in_expr`. Off by default.
 measure-prop-reads = []
+# Repository-local instrumentation: count, per stage, whether the per-statement
+# transform chain allocated a new string or handed its input through. Off by
+# default and zero-cost when off.
+measure-stmt-chain = []
 # Select the JavaScript entropy backend when the compiler is embedded in wasm.
 # Binding exports live in `rsvelte_lint_bindings`, not in this library.
 wasm-target = ["dep:getrandom", "getrandom/wasm_js"]

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/destructure_transforms.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/destructure_transforms.rs
@@ -14,6 +14,7 @@ use oxc_allocator::Allocator;
 use oxc_ast::ast::{Expression, Statement};
 use oxc_parser::{ParseOptions, Parser};
 use oxc_span::SourceType;
+use std::borrow::Cow;
 
 pub(super) fn unthunk_string(expr: &str) -> String {
     let trimmed = expr.trim();
@@ -71,6 +72,7 @@ pub(super) fn transform_destructure_assignments(
     store_sub_vars: &[String],
 ) -> String {
     transform_destructure_assignments_with_props(statement, state_vars, &[], store_sub_vars, &[])
+        .into_owned()
 }
 
 /// Transform destructure assignments, with knowledge of prop variables.
@@ -87,16 +89,16 @@ pub(super) fn transform_destructure_assignments(
 /// `non_reactive_state_vars` is subtracted from `state_vars` for that same
 /// right-hand-side test: only a state variable whose read becomes `$.get(…)`
 /// makes the visited value a CallExpression.
-pub(super) fn transform_destructure_assignments_with_props(
-    statement: &str,
+pub(super) fn transform_destructure_assignments_with_props<'a>(
+    statement: &'a str,
     state_vars: &[String],
     non_reactive_state_vars: &[String],
     store_sub_vars: &[String],
     prop_vars: &[String],
-) -> String {
+) -> Cow<'a, str> {
     // Quick check: destructure assignments require `=` with `[` or `{` on the LHS
     if state_vars.is_empty() && store_sub_vars.is_empty() && prop_vars.is_empty() {
-        return statement.to_string();
+        return Cow::Borrowed(statement);
     }
 
     // Byte-level fast path: a destructure assignment requires either `]` or `}`
@@ -106,10 +108,10 @@ pub(super) fn transform_destructure_assignments_with_props(
     // is the common case for plain declarations like `let x = $state(0);` which
     // call this function once per statement when `state_vars` is non-empty.
     if memchr::memchr2(b']', b'}', statement.as_bytes()).is_none() {
-        return statement.to_string();
+        return Cow::Borrowed(statement);
     }
 
-    let mut result = statement.to_string();
+    let mut result = Cow::Borrowed(statement);
 
     // Build HashSets once for O(1) lookups across all iterations
     let store_set: rustc_hash::FxHashSet<&str> =
@@ -130,7 +132,7 @@ pub(super) fn transform_destructure_assignments_with_props(
         &prop_set,
         &reactive_state_set,
     ) {
-        result = transformed;
+        result = Cow::Owned(transformed);
     }
 
     result
@@ -1533,15 +1535,15 @@ pub(super) fn generate_destructure_iife(
 /// The subsequent `wrap_state_vars_in_expr` call will handle `$.get()` wrapping
 /// inside the mutation expression (the `in_mutate_first_arg` guard in that
 /// function ensures the first argument of `$.mutate()` is NOT double-wrapped).
-pub(super) fn transform_member_mutations(
-    line: &str,
+pub(super) fn transform_member_mutations<'a>(
+    line: &'a str,
     state_vars: &[String],
     non_reactive_state_vars: &[String],
     raw_state_vars: &[String],
     invalidate_bodies: &rustc_hash::FxHashMap<String, String>,
-) -> String {
+) -> Cow<'a, str> {
     if state_vars.is_empty() {
-        return line.to_string();
+        return Cow::Borrowed(line);
     }
 
     // AST-based pre-pass for `obj.prop = rhs` (legacy state member
@@ -1559,10 +1561,7 @@ pub(super) fn transform_member_mutations(
             raw_state_vars,
             invalidate_bodies,
         );
-    if let Some(rewritten) = ast_result {
-        return rewritten;
-    }
-    line.to_string()
+    ast_result.map_or(Cow::Borrowed(line), Cow::Owned)
 }
 
 #[cfg(test)]

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/expression_utils.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/expression_utils.rs
@@ -1,6 +1,7 @@
 //! Expression parsing, shadowing detection, and identifier analysis utilities.
 
 use memchr::memmem;
+use std::borrow::Cow;
 use std::fmt::Write as _;
 
 use super::scan_index::ScanIndex;
@@ -630,14 +631,14 @@ pub(super) fn is_expression_incomplete(
 /// (function params, for-loop vars, nested lets). Returns the input
 /// unchanged when nothing matches (no state-var reference in `expr`)
 /// or when parsing fails — those are no-op cases, not regressions.
-pub(super) fn wrap_state_vars_in_expr(
-    expr: &str,
+pub(super) fn wrap_state_vars_in_expr<'a>(
+    expr: &'a str,
     state_vars: &[String],
     non_reactive_vars: &[String],
     _proxy_vars: &[String],
-) -> String {
+) -> Cow<'a, str> {
     super::state_reads_ast::transform_state_reads_ast(expr, state_vars, non_reactive_vars)
-        .unwrap_or_else(|| expr.to_string())
+        .map_or(Cow::Borrowed(expr), Cow::Owned)
 }
 
 /// Check if a variable at the given position is shadowed by a function parameter.

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
@@ -5058,6 +5058,18 @@ fn transform_instance_script_for_visitors(
         Vec::new()
     };
 
+    // Name-only projections of `legacy_state_vars`, used once per top-level
+    // statement by the per-statement loop below and invariant across it.
+    let legacy_state_var_names: Vec<String> = legacy_state_vars
+        .iter()
+        .map(|(name, _, _)| name.clone())
+        .collect();
+    let legacy_var_state_var_names: Vec<String> = legacy_state_vars
+        .iter()
+        .filter(|(_, _, kind)| *kind == DeclarationKind::Var)
+        .map(|(name, _, _)| name.clone())
+        .collect();
+
     // Collect prop variable info for ownership mutation validation (dev mode only).
     // Maps prop variable name to its prop alias (the public prop name).
     let prop_mutation_vars: Vec<(String, Option<String>)> = if dev {
@@ -5386,11 +5398,6 @@ fn transform_instance_script_for_visitors(
             );
             super::profile::record_rs_deps(super::profile::timer_elapsed(_rs_deps_start));
 
-            let var_state_vars: Vec<String> = legacy_state_vars
-                .iter()
-                .filter(|(_, _, kind)| *kind == DeclarationKind::Var)
-                .map(|(n, _, _)| n.clone())
-                .collect();
             // AST-derived ordered dependency names for THIS top-level `$:` statement
             // (Phase 2, source-ordinal aligned). Both phases count top-level `$:`
             // in source order, so the ordinal stays in sync.
@@ -5409,7 +5416,7 @@ fn transform_instance_script_for_visitors(
                 prop_assignment_transform_vars,
                 store_sub_vars,
                 import_names,
-                &var_state_vars,
+                &legacy_var_state_var_names,
                 dep_names,
                 analysis,
                 &prop_invalidate_bodies,
@@ -5810,13 +5817,9 @@ fn transform_instance_script_for_visitors(
         // e.g., `let { foo, bar } = expr` -> `let tmp = expr, foo = $.mutable_source(tmp.foo), bar = tmp.bar`
         // Reference: create_state_declarators in VariableDeclaration.js
         let transformed = if !analysis.runes && !legacy_state_vars.is_empty() {
-            let state_var_names: Vec<String> = legacy_state_vars
-                .iter()
-                .map(|(name, _, _)| name.clone())
-                .collect();
             transform_legacy_destructure_declarations(
                 &transformed,
-                &state_var_names,
+                &legacy_state_var_names,
                 analysis.immutable,
                 dev,
             )

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
@@ -4446,6 +4446,17 @@ fn instance_has_top_level_multi_declarator(ast: &Root, script: &str) -> bool {
     })
 }
 
+/// A pass's answer read as "did it rewrite?". A borrowed result is the very
+/// text the pass was handed, so the chain keeps the string it already owns
+/// instead of taking a copy of it.
+#[inline]
+fn rewritten(out: Cow<'_, str>) -> Option<String> {
+    match out {
+        Cow::Borrowed(_) => None,
+        Cow::Owned(text) => Some(text),
+    }
+}
+
 /// Run one stage of the per-statement transform chain, so the split between a
 /// stage that rewrote and one that handed its input through stays measurable.
 #[inline]
@@ -5506,14 +5517,15 @@ fn transform_instance_script_for_visitors(
                 // Destructured export let: flatten using extract_paths pattern
                 if let Some(flattened) = transform_destructured_export_let(&statement, analysis) {
                     let flattened = if analysis.runes {
-                        flattened // AST transform handles state var wrapping
+                        Cow::Owned(flattened) // AST transform handles state var wrapping
                     } else {
-                        wrap_state_vars_in_expr(
+                        rewritten(wrap_state_vars_in_expr(
                             &flattened,
                             state_vars,
                             non_reactive_state_vars,
                             proxy_vars,
-                        )
+                        ))
+                        .map_or(Cow::Owned(flattened), Cow::Owned)
                     };
                     result.push_str(&flattened);
                     result.push('\n');
@@ -5624,7 +5636,7 @@ fn transform_instance_script_for_visitors(
         // Transform runes ($state, $derived, $effect, $props)
         let _runes_start = super::profile::timer_start();
         let mut transformed = stage("runes", Cow::Borrowed(statement.as_str()), |t| {
-            Cow::Owned(transform_client_runes_with_skip_and_state(
+            rewritten(transform_client_runes_with_skip_and_state(
                 &t,
                 non_reactive_state_vars,
                 state_vars,
@@ -5637,6 +5649,8 @@ fn transform_instance_script_for_visitors(
                 store_sub_vars,
                 read_only_props,
             ))
+            .map(Cow::Owned)
+            .unwrap_or(t)
         });
         super::profile::record_st_runes(super::profile::timer_elapsed(_runes_start));
 
@@ -5718,13 +5732,15 @@ fn transform_instance_script_for_visitors(
             {
                 t
             } else {
-                Cow::Owned(transform_destructure_assignments_with_props(
+                rewritten(transform_destructure_assignments_with_props(
                     &t,
                     state_vars,
                     non_reactive_state_vars,
                     store_sub_vars,
                     prop_assignment_transform_vars,
                 ))
+                .map(Cow::Owned)
+                .unwrap_or(t)
             }
         });
 
@@ -5746,11 +5762,13 @@ fn transform_instance_script_for_visitors(
                 .unwrap_or(t)
             });
             stage("store_unsub_for_state_sets", transformed, |t| {
-                Cow::Owned(wrap_store_unsub_for_state_sets(
+                rewritten(wrap_store_unsub_for_state_sets(
                     &t,
                     state_vars,
                     store_sub_vars,
                 ))
+                .map(Cow::Owned)
+                .unwrap_or(t)
             })
         };
 
@@ -5760,13 +5778,15 @@ fn transform_instance_script_for_visitors(
         // and BEFORE wrap_state_vars_in_expr (which will apply $.get() inside the $.mutate()).
         let transformed = stage("member_mutations", transformed, |t| {
             if !analysis.runes && !state_vars.is_empty() {
-                Cow::Owned(transform_member_mutations(
+                rewritten(transform_member_mutations(
                     &t,
                     state_vars,
                     non_reactive_state_vars,
                     raw_state_vars,
                     &prop_invalidate_bodies,
                 ))
+                .map(Cow::Owned)
+                .unwrap_or(t)
             } else {
                 t
             }
@@ -5778,10 +5798,12 @@ fn transform_instance_script_for_visitors(
         // In runes mode, deferred to AST-based transform after main loop.
         let transformed = stage("prop_update_expressions", transformed, |t| {
             if !prop_assignment_transform_vars.is_empty() && !analysis.runes {
-                Cow::Owned(transform_prop_update_expressions(
+                rewritten(transform_prop_update_expressions(
                     &t,
                     prop_assignment_transform_vars,
                 ))
+                .map(Cow::Owned)
+                .unwrap_or(t)
             } else {
                 t
             }
@@ -5813,12 +5835,14 @@ fn transform_instance_script_for_visitors(
         // In runes mode, deferred to AST-based transform after main loop.
         let transformed = stage("prop_assignments", transformed, |t| {
             if !analysis.runes {
-                Cow::Owned(transform_prop_assignments(
+                rewritten(transform_prop_assignments(
                     &t,
                     prop_assignment_transform_vars,
                     &non_bindable_prop_vars,
                     &prop_invalidate_bodies,
                 ))
+                .map(Cow::Owned)
+                .unwrap_or(t)
             } else {
                 t
             }
@@ -5872,12 +5896,14 @@ fn transform_instance_script_for_visitors(
         // Reference: create_state_declarators in VariableDeclaration.js
         let transformed = stage("legacy_destructure_declarations", transformed, |t| {
             if !analysis.runes && !legacy_state_vars.is_empty() {
-                Cow::Owned(transform_legacy_destructure_declarations(
+                rewritten(transform_legacy_destructure_declarations(
                     &t,
                     &legacy_state_var_names,
                     analysis.immutable,
                     dev,
                 ))
+                .map(Cow::Owned)
+                .unwrap_or(t)
             } else {
                 t
             }
@@ -5892,12 +5918,14 @@ fn transform_instance_script_for_visitors(
         // and then wrap_state_vars_in_expr correctly skips them since each starts with `let `.
         let transformed = stage("legacy_state_declarations", transformed, |t| {
             if !analysis.runes && !legacy_state_vars.is_empty() {
-                Cow::Owned(transform_legacy_state_declarations(
+                rewritten(transform_legacy_state_declarations(
                     &t,
                     legacy_state_vars,
                     analysis.immutable,
                     dev,
                 ))
+                .map(Cow::Owned)
+                .unwrap_or(t)
             } else {
                 t
             }
@@ -5909,12 +5937,14 @@ fn transform_instance_script_for_visitors(
             if analysis.runes {
                 t
             } else {
-                Cow::Owned(wrap_state_vars_in_expr(
+                rewritten(wrap_state_vars_in_expr(
                     &t,
                     state_vars,
                     non_reactive_state_vars,
                     proxy_vars,
                 ))
+                .map(Cow::Owned)
+                .unwrap_or(t)
             }
         });
 
@@ -6437,8 +6467,14 @@ fn transform_instance_script_for_visitors(
                 result = ast_result;
             }
             // Apply store_unsub wrapping after AST transform (searches for $.set patterns)
-            if !store_sub_vars.is_empty() {
-                result = wrap_store_unsub_for_state_sets(&result, &state_vars, &store_sub_vars);
+            if !store_sub_vars.is_empty()
+                && let Some(wrapped) = rewritten(wrap_store_unsub_for_state_sets(
+                    &result,
+                    &state_vars,
+                    &store_sub_vars,
+                ))
+            {
+                result = wrapped;
             }
             // The post-AST `wrap_state_derived_with_tag(&result)` pass that
             // used to tag AST-emitted `$.state(...)` / `$.derived(...)`

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
@@ -6,6 +6,7 @@
 //! `svelte/packages/svelte/src/compiler/phases/3-transform/client/`.
 
 pub(crate) use super::shared::ast_rewrite;
+use std::borrow::Cow;
 use std::fmt::Write as _;
 mod assign_dev_ast;
 mod ast;
@@ -4445,6 +4446,28 @@ fn instance_has_top_level_multi_declarator(ast: &Root, script: &str) -> bool {
     })
 }
 
+/// Run one stage of the per-statement transform chain, so the split between a
+/// stage that rewrote and one that handed its input through stays measurable.
+#[inline]
+fn stage<'a>(
+    name: &'static str,
+    input: Cow<'a, str>,
+    f: impl FnOnce(Cow<'a, str>) -> Cow<'a, str>,
+) -> Cow<'a, str> {
+    #[cfg(feature = "measure-stmt-chain")]
+    {
+        let before = input.as_ptr();
+        let out = f(input);
+        crate::measure_stmt_chain::record(name, before, &out);
+        out
+    }
+    #[cfg(not(feature = "measure-stmt-chain"))]
+    {
+        let _ = name;
+        f(input)
+    }
+}
+
 fn transform_instance_script_for_visitors(
     script: &str,
     analysis: &ComponentAnalysis,
@@ -5600,19 +5623,21 @@ fn transform_instance_script_for_visitors(
 
         // Transform runes ($state, $derived, $effect, $props)
         let _runes_start = super::profile::timer_start();
-        let mut transformed = transform_client_runes_with_skip_and_state(
-            &statement,
-            non_reactive_state_vars,
-            state_vars,
-            non_reactive_state_vars,
-            prop_source_vars,
-            exported_names,
-            proxy_vars,
-            dev,
-            analysis,
-            store_sub_vars,
-            read_only_props,
-        );
+        let mut transformed = stage("runes", Cow::Borrowed(statement.as_str()), |t| {
+            Cow::Owned(transform_client_runes_with_skip_and_state(
+                &t,
+                non_reactive_state_vars,
+                state_vars,
+                non_reactive_state_vars,
+                prop_source_vars,
+                exported_names,
+                proxy_vars,
+                dev,
+                analysis,
+                store_sub_vars,
+                read_only_props,
+            ))
+        });
         super::profile::record_st_runes(super::profile::timer_elapsed(_runes_start));
 
         // In dev mode, if the previous output line carries a
@@ -5644,7 +5669,7 @@ fn transform_instance_script_for_visitors(
             };
             if prev_has_ignore {
                 let mut new_transformed = String::new();
-                let mut remaining = transformed.as_str();
+                let mut remaining: &str = &transformed;
                 while let Some(pos) = memmem::find(remaining.as_bytes(), b"$state.snapshot(") {
                     new_transformed.push_str(&remaining[..pos]);
                     let call_start = pos + "$state.snapshot(".len();
@@ -5658,7 +5683,7 @@ fn transform_instance_script_for_visitors(
                     }
                 }
                 new_transformed.push_str(remaining);
-                transformed = new_transformed;
+                transformed = Cow::Owned(new_transformed);
             }
         }
 
@@ -5686,20 +5711,22 @@ fn transform_instance_script_for_visitors(
         // transforms can then process.
         // Corresponds to visit_assignment_expression in shared/assignments.js.
         // Skip if there is no reactive target (state / store / prop) to destructure against
-        let transformed = if state_vars.is_empty()
-            && store_sub_vars.is_empty()
-            && prop_assignment_transform_vars.is_empty()
-        {
-            transformed
-        } else {
-            transform_destructure_assignments_with_props(
-                &transformed,
-                state_vars,
-                non_reactive_state_vars,
-                store_sub_vars,
-                prop_assignment_transform_vars,
-            )
-        };
+        let transformed = stage("destructure_assignments", transformed, |t| {
+            if state_vars.is_empty()
+                && store_sub_vars.is_empty()
+                && prop_assignment_transform_vars.is_empty()
+            {
+                t
+            } else {
+                Cow::Owned(transform_destructure_assignments_with_props(
+                    &t,
+                    state_vars,
+                    non_reactive_state_vars,
+                    store_sub_vars,
+                    prop_assignment_transform_vars,
+                ))
+            }
+        });
 
         // Transform state variable assignments to $.set()
         // In runes mode, deferred to AST-based transform after main loop.
@@ -5707,74 +5734,95 @@ fn transform_instance_script_for_visitors(
             transformed
         } else {
             // Unified AST pass — see Site 1 comment for rationale.
-            let transformed = state_assigns_combined_ast::transform_state_assigns_ast(
-                &transformed,
-                state_vars,
-                raw_state_vars,
-                analysis.runes,
-                &non_proxy_vars,
-            )
-            .unwrap_or(transformed);
-            wrap_store_unsub_for_state_sets(&transformed, state_vars, store_sub_vars)
+            let transformed = stage("state_assigns", transformed, |t| {
+                state_assigns_combined_ast::transform_state_assigns_ast(
+                    &t,
+                    state_vars,
+                    raw_state_vars,
+                    analysis.runes,
+                    &non_proxy_vars,
+                )
+                .map(Cow::Owned)
+                .unwrap_or(t)
+            });
+            stage("store_unsub_for_state_sets", transformed, |t| {
+                Cow::Owned(wrap_store_unsub_for_state_sets(
+                    &t,
+                    state_vars,
+                    store_sub_vars,
+                ))
+            })
         };
 
         // Transform member mutations to $.mutate() calls (only in legacy/non-runes mode).
         // This handles patterns like `obj.self = obj` → `$.mutate(obj, obj.self = obj)`.
         // Must run AFTER transform_state_assignments (which handles direct assignments like `x = v`)
         // and BEFORE wrap_state_vars_in_expr (which will apply $.get() inside the $.mutate()).
-        let transformed = if !analysis.runes && !state_vars.is_empty() {
-            transform_member_mutations(
-                &transformed,
-                state_vars,
-                non_reactive_state_vars,
-                raw_state_vars,
-                &prop_invalidate_bodies,
-            )
-        } else {
-            transformed
-        };
+        let transformed = stage("member_mutations", transformed, |t| {
+            if !analysis.runes && !state_vars.is_empty() {
+                Cow::Owned(transform_member_mutations(
+                    &t,
+                    state_vars,
+                    non_reactive_state_vars,
+                    raw_state_vars,
+                    &prop_invalidate_bodies,
+                ))
+            } else {
+                t
+            }
+        });
 
         // Transform prop update expressions like `x++` to `$.update_prop(x)` FIRST,
         // before transform_prop_assignments runs (which would incorrectly turn `x++` into `x(x() + 1)`)
         // and before wrap_prop_source_reads (which would turn `count` → `count()`, causing `count()++`)
         // In runes mode, deferred to AST-based transform after main loop.
-        let transformed = if !prop_assignment_transform_vars.is_empty() && !analysis.runes {
-            transform_prop_update_expressions(&transformed, prop_assignment_transform_vars)
-        } else {
-            transformed
-        };
+        let transformed = stage("prop_update_expressions", transformed, |t| {
+            if !prop_assignment_transform_vars.is_empty() && !analysis.runes {
+                Cow::Owned(transform_prop_update_expressions(
+                    &t,
+                    prop_assignment_transform_vars,
+                ))
+            } else {
+                t
+            }
+        });
 
         // Transform prop source variable reads to prop() calls BEFORE prop assignments.
         // This handles props used as function calls: `callback(args)` → `callback()(args)`.
         // Must come BEFORE transform_prop_assignments so that `callback = value` (assignment)
         // doesn't get incorrectly double-wrapped as `callback()(value)`.
         // In runes mode, deferred to AST-based transform after main loop.
-        let transformed = if !prop_assignment_transform_vars.is_empty() && !analysis.runes {
-            prop_source_reads_ast::wrap_prop_source_reads_ast(
-                &transformed,
-                prop_assignment_transform_vars,
-                &non_bindable_prop_vars,
-            )
-            .unwrap_or(transformed)
-        } else {
-            transformed
-        };
+        let transformed = stage("prop_source_reads", transformed, |t| {
+            if !prop_assignment_transform_vars.is_empty() && !analysis.runes {
+                prop_source_reads_ast::wrap_prop_source_reads_ast(
+                    &t,
+                    prop_assignment_transform_vars,
+                    &non_bindable_prop_vars,
+                )
+                .map(Cow::Owned)
+                .unwrap_or(t)
+            } else {
+                t
+            }
+        });
 
         // Transform prop assignments to prop(prop() + value) syntax
         // This handles props declared with `export let` in legacy mode
         // Note: We use prop_assignment_transform_vars which excludes RestProp bindings
         // because rest_props use $.rest_props() which returns a plain object, not getter/setter
         // In runes mode, deferred to AST-based transform after main loop.
-        let transformed = if !analysis.runes {
-            transform_prop_assignments(
-                &transformed,
-                prop_assignment_transform_vars,
-                &non_bindable_prop_vars,
-                &prop_invalidate_bodies,
-            )
-        } else {
-            transformed
-        };
+        let transformed = stage("prop_assignments", transformed, |t| {
+            if !analysis.runes {
+                Cow::Owned(transform_prop_assignments(
+                    &t,
+                    prop_assignment_transform_vars,
+                    &non_bindable_prop_vars,
+                    &prop_invalidate_bodies,
+                ))
+            } else {
+                t
+            }
+        });
 
         // Store transforms: skip entirely when there are no store subscriptions
         // In runes mode, deferred to AST-based transform after main loop.
@@ -5799,15 +5847,21 @@ fn transform_instance_script_for_visitors(
                     store_sub_vars
                 };
 
-            let transformed = transform_store_sub_calls(&transformed, effective_store_sub_vars);
-            let transformed = transform_store_assignments_client(
-                &transformed,
-                effective_store_sub_vars,
-                prop_assignment_transform_vars,
-                state_vars,
-                non_reactive_state_vars,
-            );
-            transform_store_reads_client(&transformed, effective_store_sub_vars)
+            let transformed = stage("store_sub_calls", transformed, |t| {
+                Cow::Owned(transform_store_sub_calls(&t, effective_store_sub_vars))
+            });
+            let transformed = stage("store_assignments", transformed, |t| {
+                Cow::Owned(transform_store_assignments_client(
+                    &t,
+                    effective_store_sub_vars,
+                    prop_assignment_transform_vars,
+                    state_vars,
+                    non_reactive_state_vars,
+                ))
+            });
+            stage("store_reads", transformed, |t| {
+                Cow::Owned(transform_store_reads_client(&t, effective_store_sub_vars))
+            })
         } else {
             transformed
         };
@@ -5816,16 +5870,18 @@ fn transform_instance_script_for_visitors(
         // individual declarations BEFORE mutable_source wrapping.
         // e.g., `let { foo, bar } = expr` -> `let tmp = expr, foo = $.mutable_source(tmp.foo), bar = tmp.bar`
         // Reference: create_state_declarators in VariableDeclaration.js
-        let transformed = if !analysis.runes && !legacy_state_vars.is_empty() {
-            transform_legacy_destructure_declarations(
-                &transformed,
-                &legacy_state_var_names,
-                analysis.immutable,
-                dev,
-            )
-        } else {
-            transformed
-        };
+        let transformed = stage("legacy_destructure_declarations", transformed, |t| {
+            if !analysis.runes && !legacy_state_vars.is_empty() {
+                Cow::Owned(transform_legacy_destructure_declarations(
+                    &t,
+                    &legacy_state_var_names,
+                    analysis.immutable,
+                    dev,
+                ))
+            } else {
+                t
+            }
+        });
 
         // Transform legacy state declarations to $.mutable_source() BEFORE wrapping reads.
         // This must come before wrap_state_vars_in_expr because multi-variable declarations
@@ -5834,46 +5890,55 @@ fn transform_instance_script_for_visitors(
         // By transforming declarations first, `let a, b;` becomes:
         //   `let a = $.mutable_source();\nlet b = $.mutable_source();`
         // and then wrap_state_vars_in_expr correctly skips them since each starts with `let `.
-        let transformed = if !analysis.runes && !legacy_state_vars.is_empty() {
-            transform_legacy_state_declarations(
-                &transformed,
-                legacy_state_vars,
-                analysis.immutable,
-                dev,
-            )
-        } else {
-            transformed
-        };
+        let transformed = stage("legacy_state_declarations", transformed, |t| {
+            if !analysis.runes && !legacy_state_vars.is_empty() {
+                Cow::Owned(transform_legacy_state_declarations(
+                    &t,
+                    legacy_state_vars,
+                    analysis.immutable,
+                    dev,
+                ))
+            } else {
+                t
+            }
+        });
 
         // Wrap state variable reads in $.get() for ALL statements including declarations.
         // In runes mode, deferred to AST-based transform after main loop.
-        let transformed = if analysis.runes {
-            transformed
-        } else {
-            wrap_state_vars_in_expr(
-                &transformed,
-                state_vars,
-                non_reactive_state_vars,
-                proxy_vars,
-            )
-        };
+        let transformed = stage("state_reads", transformed, |t| {
+            if analysis.runes {
+                t
+            } else {
+                Cow::Owned(wrap_state_vars_in_expr(
+                    &t,
+                    state_vars,
+                    non_reactive_state_vars,
+                    proxy_vars,
+                ))
+            }
+        });
 
         // Transform rest_prop member access to $$props (only in non-runes mode here;
         // in runes mode, deferred to AST-based transform after main loop)
-        let transformed = if !analysis.runes && !rest_prop_vars.is_empty() {
-            transform_rest_prop_member_access(&transformed, rest_prop_vars)
-        } else {
-            transformed
-        };
+        let transformed = stage("rest_prop_member_access", transformed, |t| {
+            if !analysis.runes && !rest_prop_vars.is_empty() {
+                Cow::Owned(transform_rest_prop_member_access(&t, rest_prop_vars))
+            } else {
+                t
+            }
+        });
 
         // Transform read-only props to $$props.propName (only in non-runes mode here;
         // in runes mode, deferred to AST-based transform after main loop).
-        let transformed = if !analysis.runes && !read_only_props.is_empty() {
-            read_only_props_ast::transform_read_only_props_ast(&transformed, read_only_props)
-                .unwrap_or(transformed)
-        } else {
-            transformed
-        };
+        let transformed = stage("read_only_props", transformed, |t| {
+            if !analysis.runes && !read_only_props.is_empty() {
+                read_only_props_ast::transform_read_only_props_ast(&t, read_only_props)
+                    .map(Cow::Owned)
+                    .unwrap_or(t)
+            } else {
+                t
+            }
+        });
 
         // In dev mode, wrap console.METHOD() calls with $.log_if_contains_state
         // to detect when state proxies are logged directly.
@@ -5884,18 +5949,17 @@ fn transform_instance_script_for_visitors(
         // fragment fails to parse standalone (rare — the parser is lenient
         // for any complete expression / statement). The AST path fixes the
         // quote-counting string-skip heuristic that the text version uses.
-        let transformed = if dev {
-            let is_ts =
-                analysis.filename.ends_with(".ts") || analysis.filename.ends_with(".svelte.ts");
-            console_dev_ast::transform_console_calls_dev_fragment(
-                &transformed,
-                is_ts,
-                Some(analysis),
-            )
-            .unwrap_or(transformed)
-        } else {
-            transformed
-        };
+        let transformed = stage("console_dev", transformed, |t| {
+            if dev {
+                let is_ts =
+                    analysis.filename.ends_with(".ts") || analysis.filename.ends_with(".svelte.ts");
+                console_dev_ast::transform_console_calls_dev_fragment(&t, is_ts, Some(analysis))
+                    .map(Cow::Owned)
+                    .unwrap_or(t)
+            } else {
+                t
+            }
+        });
 
         result.push_str(&transformed);
         result.push('\n');

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/reactive_transforms.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/reactive_transforms.rs
@@ -1,6 +1,7 @@
 //! Reactive statement handling and state mutation transformations.
 
 use memchr::memmem;
+use std::borrow::Cow;
 
 use crate::compiler::phases::phase2_analyze::ComponentAnalysis;
 
@@ -429,7 +430,7 @@ pub(super) fn transform_reactive_statement(
     // This involves:
     // 1. Transform prop reads to prop() calls
     // 2. Transform prop assignments to prop(value) calls
-    let transformed_body;
+    let transformed_body: String;
 
     // First, check if this is an assignment statement: `c = expr`
     // We must guard against ternary expressions like `a ? b = x : b = y` where
@@ -481,7 +482,8 @@ pub(super) fn transform_reactive_statement(
             let temp = transform_state_member_mutations(&temp, state_vars, non_reactive_state_vars);
             let temp = transform_state_set_in_reactive(&temp, state_vars, non_reactive_state_vars);
             transformed_body =
-                wrap_state_vars_in_expr(&temp, state_vars, non_reactive_state_vars, proxy_vars);
+                wrap_state_vars_in_expr(&temp, state_vars, non_reactive_state_vars, proxy_vars)
+                    .into_owned();
         } else if (lhs.starts_with('[') || lhs.starts_with('{')) && {
             // Check if the LHS contains reactive targets that need destructure expansion
             let targets = extract_destructure_targets(lhs);
@@ -503,7 +505,7 @@ pub(super) fn transform_reactive_statement(
                 store_sub_vars,
                 prop_assignment_transform_vars,
             );
-            let body = body.as_str();
+            let body: &str = body;
             let temp = transform_prop_update_expressions(body, prop_assignment_transform_vars);
             let temp =
                 transform_state_update_expressions(&temp, state_vars, non_reactive_state_vars);
@@ -527,7 +529,8 @@ pub(super) fn transform_reactive_statement(
                 &temp,
                 state_vars,
                 store_sub_vars,
-            );
+            )
+            .into_owned();
         } else {
             // If the LHS is a prop variable, transform to prop(value) call
             if prop_assignment_transform_vars.contains(&lhs.to_string()) {
@@ -685,7 +688,7 @@ pub(super) fn transform_reactive_statement(
             store_sub_vars,
             prop_assignment_transform_vars,
         );
-        let body = body.as_str();
+        let body: &str = body;
         // Transform prop update expressions like `x++` to `$.update_prop(x)` FIRST,
         // before transform_prop_assignments runs (which would incorrectly turn `x++` into `x(x() + 1)`)
         let temp = transform_prop_update_expressions(body, prop_assignment_transform_vars);
@@ -732,7 +735,8 @@ pub(super) fn transform_reactive_statement(
             &temp,
             state_vars,
             store_sub_vars,
-        );
+        )
+        .into_owned();
     }
 
     // Apply store subscription transformations to body.
@@ -972,12 +976,15 @@ pub(super) fn unwrap_block_statement_owned(body: &str) -> (String, bool) {
 ///
 /// Converts `x++` to `$.update_prop(x)`, `++x` to `$.update_pre_prop(x)`,
 /// `x--` to `$.update_prop(x, -1)`, and `--x` to `$.update_pre_prop(x, -1)`.
-pub(super) fn transform_prop_update_expressions(expr: &str, prop_vars: &[String]) -> String {
+pub(super) fn transform_prop_update_expressions<'a>(
+    expr: &'a str,
+    prop_vars: &[String],
+) -> Cow<'a, str> {
     if prop_vars.is_empty() {
-        return expr.to_string();
+        return Cow::Borrowed(expr);
     }
     super::reactive_update_ast::transform_reactive_update_ast(expr, prop_vars, &[], &[])
-        .unwrap_or_else(|| expr.to_string())
+        .map_or(Cow::Borrowed(expr), Cow::Owned)
 }
 
 /// Transform update expressions (++ / --) for state variables.

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/rune_transforms.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/rune_transforms.rs
@@ -1,6 +1,7 @@
 //! Rune detection and transformation for $state, $derived, and $effect.
 
 use memchr::memmem;
+use std::borrow::Cow;
 
 use super::destructure_transforms::{build_fallback_string, literal_key_value};
 use super::{
@@ -12,8 +13,8 @@ use crate::compiler::phases::phase3_transform::shared::js_scan::skip_opaque;
 use crate::compiler::phases::phase3_transform::shared::template::escape_js_string;
 
 /// Transform runes for client-side usage with skip and state variable handling.
-pub(super) fn transform_client_runes_with_skip_and_state(
-    line: &str,
+pub(super) fn transform_client_runes_with_skip_and_state<'a>(
+    line: &'a str,
     _skip_state_vars: &[String],
     _state_vars: &[String],
     _non_reactive_vars: &[String],
@@ -24,13 +25,13 @@ pub(super) fn transform_client_runes_with_skip_and_state(
     _analysis: &ComponentAnalysis,
     store_sub_vars: &[String],
     _read_only_props: &[(String, String)],
-) -> String {
+) -> Cow<'a, str> {
     // Quick pre-check: if no rune-like pattern (`$` followed by letter) appears, skip
     if !line.contains('$') {
-        return line.to_string();
+        return Cow::Borrowed(line);
     }
 
-    let mut result = line.to_string();
+    let mut result = Cow::Borrowed(line);
 
     // Check which rune names are actually store subscriptions.
     // When $state or $effect is imported from a store (not a real rune),
@@ -203,7 +204,7 @@ pub(super) fn transform_client_runes_with_skip_and_state(
                 {
                     start -= 1;
                 }
-                result = format!("{}{}", &result[..start], &result[end..]);
+                result = Cow::Owned(format!("{}{}", &result[..start], &result[end..]));
             } else {
                 break;
             }
@@ -251,10 +252,11 @@ pub(super) fn transform_client_runes_with_skip_and_state(
                     let args = &result[inspect_start..inspect_start + content_end];
                     // Use $$INSPECT_EMPTY$$ marker that survives wrap_state_vars_in_expr
                     // and later transforms, then gets converted to ;; before OXC processing
-                    return format!("/* $$async_hole:{} */", args);
+                    return Cow::Owned(format!("/* $$async_hole:{} */", args));
                 } else {
                     // Remove just the $inspect(...) part but keep other code on the line
-                    result = format!("{}{}", &result[..pos], &result[pos + total_end..]);
+                    result =
+                        Cow::Owned(format!("{}{}", &result[..pos], &result[pos + total_end..]));
                 }
             }
         }
@@ -288,14 +290,14 @@ pub(super) fn transform_client_runes_with_skip_and_state(
         if let Some(rewritten) =
             super::tag_declarator_ast::wrap_state_derived_with_tag_declarators_ast(&result, false)
         {
-            result = rewritten;
+            result = Cow::Owned(rewritten);
         }
         if let Some(rewritten) =
             super::tag_class_field_ast::wrap_state_derived_with_tag_class_fields_ast(&result)
         {
-            result = rewritten;
+            result = Cow::Owned(rewritten);
         }
-        result = wrap_state_derived_with_tag(&result);
+        result = Cow::Owned(wrap_state_derived_with_tag(&result));
     }
 
     result

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/state_transforms.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/state_transforms.rs
@@ -2,6 +2,7 @@
 
 use memchr::memmem;
 use rustc_hash::FxHashSet;
+use std::borrow::Cow;
 
 use super::STATE_TMP_COUNTER;
 use super::destructure_transforms::{ArrayHelperRead, extract_destructure_paths};
@@ -1147,19 +1148,19 @@ pub(super) fn is_inside_string_literal(code: &str, pos: usize) -> bool {
 /// - `$.set(foo, writable(42))` → `$.store_unsub($.set(foo, writable(42)), '$foo', $$stores)`
 ///
 /// Reference: declarations.js `add_state_transformers` → `assign_value_with_store`
-pub(super) fn wrap_store_unsub_for_state_sets(
-    line: &str,
+pub(super) fn wrap_store_unsub_for_state_sets<'a>(
+    line: &'a str,
     state_vars: &[String],
     store_sub_vars: &[String],
-) -> String {
+) -> Cow<'a, str> {
     if state_vars.is_empty() || store_sub_vars.is_empty() {
-        return line.to_string();
+        return Cow::Borrowed(line);
     }
     if memmem::find(line.as_bytes(), b"$.set(").is_none() {
-        return line.to_string();
+        return Cow::Borrowed(line);
     }
     super::store_unsub_wrap_ast::transform_store_unsub_wrap_ast(line, state_vars, store_sub_vars)
-        .unwrap_or_else(|| line.to_string())
+        .map_or(Cow::Borrowed(line), Cow::Owned)
 }
 
 /// Transform prop assignments to getter/setter function call syntax.
@@ -1173,14 +1174,14 @@ pub(super) fn wrap_store_unsub_for_state_sets(
 ///
 /// Note: Update expressions (x++, --x, etc.) are handled by transform_prop_update_expressions
 /// which must be called BEFORE this function.
-pub(super) fn transform_prop_assignments(
-    line: &str,
+pub(super) fn transform_prop_assignments<'a>(
+    line: &'a str,
     prop_vars: &[String],
     non_bindable_prop_vars: &[String],
     prop_invalidate_bodies: &rustc_hash::FxHashMap<String, String>,
-) -> String {
+) -> Cow<'a, str> {
     if prop_vars.is_empty() {
-        return line.to_string();
+        return Cow::Borrowed(line);
     }
 
     // Skip lines that are prop declarations (contain $.prop() or $.rest_props())
@@ -1191,13 +1192,13 @@ pub(super) fn transform_prop_assignments(
     if memmem::find(line.as_bytes(), b"$.prop(").is_some()
         || memmem::find(line.as_bytes(), b"$.rest_props(").is_some()
     {
-        return line.to_string();
+        return Cow::Borrowed(line);
     }
 
     // Quick pre-check: if none of the prop vars appear as identifiers, skip expensive transforms
     let var_set: FxHashSet<&str> = prop_vars.iter().map(|v| v.as_str()).collect();
     if !super::utils::text_contains_any_identifier(line, &var_set) {
-        return line.to_string();
+        return Cow::Borrowed(line);
     }
 
     // Two AST passes — both cover every shape the text loops
@@ -1208,13 +1209,15 @@ pub(super) fn transform_prop_assignments(
     //    member mutations) → `name(name().foo = expr, true)`
     let after_assigns = super::prop_assign_ast::transform_prop_assign_ast(line, prop_vars);
     let stage1: &str = after_assigns.as_deref().unwrap_or(line);
-    super::prop_member_mutate_ast::transform_prop_member_mutate_ast(
+    let mutated = super::prop_member_mutate_ast::transform_prop_member_mutate_ast(
         stage1,
         prop_vars,
         non_bindable_prop_vars,
         prop_invalidate_bodies,
-    )
-    .unwrap_or_else(|| stage1.to_string())
+    );
+    mutated
+        .or(after_assigns)
+        .map_or(Cow::Borrowed(line), Cow::Owned)
 }
 
 /// Split a multi-declarator variable statement into individual declarations.
@@ -1310,12 +1313,12 @@ pub(super) fn split_multi_declarator(line: &str) -> Option<Vec<String>> {
 ///   `let tmp = expr, foo = $.mutable_source(tmp.foo), bar = tmp.bar;`
 ///
 /// Reference: `create_state_declarators` in VariableDeclaration.js
-pub(super) fn transform_legacy_destructure_declarations(
-    statement: &str,
+pub(super) fn transform_legacy_destructure_declarations<'a>(
+    statement: &'a str,
     legacy_state_var_names: &[String],
     immutable: bool,
     dev: bool,
-) -> String {
+) -> Cow<'a, str> {
     // Only look at the first line to determine if this is a destructuring declaration
     let first_line = statement.lines().next().unwrap_or("");
     let trimmed = first_line.trim();
@@ -1328,14 +1331,14 @@ pub(super) fn transform_legacy_destructure_declarations(
     } else if let Some(r) = trimmed.strip_prefix("var ") {
         ("var", r)
     } else {
-        return statement.to_string();
+        return Cow::Borrowed(statement);
     };
 
     let rest_start = rest_start.trim();
 
     // Check if this is a destructuring pattern (starts with { or [)
     if !rest_start.starts_with('{') && !rest_start.starts_with('[') {
-        return statement.to_string();
+        return Cow::Borrowed(statement);
     }
 
     // For the full pattern matching, we need the complete statement (multi-line)
@@ -1363,7 +1366,7 @@ pub(super) fn transform_legacy_destructure_declarations(
 
     let pattern_end = match pattern_end {
         Some(e) => e,
-        None => return statement.to_string(),
+        None => return Cow::Borrowed(statement),
     };
 
     let pattern_str = &rest[..=pattern_end];
@@ -1371,7 +1374,7 @@ pub(super) fn transform_legacy_destructure_declarations(
 
     // Must have `= expr` after the pattern
     if !after_pattern.starts_with('=') {
-        return statement.to_string();
+        return Cow::Borrowed(statement);
     }
 
     let expr = after_pattern[1..].trim().trim_end_matches(';').trim();
@@ -1385,7 +1388,7 @@ pub(super) fn transform_legacy_destructure_declarations(
         .any(|name| legacy_state_var_names.contains(name));
 
     if !has_state {
-        return statement.to_string();
+        return Cow::Borrowed(statement);
     }
 
     // Generate tmp variable name
@@ -1433,7 +1436,7 @@ pub(super) fn transform_legacy_destructure_declarations(
     }
 
     let trailing = if full_trimmed.ends_with(';') { ";" } else { "" };
-    format!("{} {}{}", keyword, parts.join(", "), trailing)
+    Cow::Owned(format!("{} {}{}", keyword, parts.join(", "), trailing))
 }
 
 /// Every name bound by a destructuring pattern, nested leaves included.
@@ -1517,14 +1520,14 @@ fn tag_legacy_source(call: String, name: &str, dev: bool) -> String {
 /// - `let state = 'foo'` → `let state = $.mutable_source('foo')`
 /// - `let count = 0` → `let count = $.mutable_source(0)`
 /// - `const arr = [1, 2]` → `const arr = $.mutable_source([1, 2])`
-pub(super) fn transform_legacy_state_declarations(
-    line: &str,
+pub(super) fn transform_legacy_state_declarations<'a>(
+    line: &'a str,
     legacy_state_vars: &[(String, Option<String>, DeclarationKind)],
     immutable: bool,
     dev: bool,
-) -> String {
+) -> Cow<'a, str> {
     if legacy_state_vars.is_empty() {
-        return line.to_string();
+        return Cow::Borrowed(line);
     }
 
     // Handle multi-declarator statements like `let a = 1, b = 2, c = 3;`
@@ -1534,14 +1537,16 @@ pub(super) fn transform_legacy_state_declarations(
     if !is_legacy_destructure_expansion(line)
         && let Some(split_lines) = split_multi_declarator(line)
     {
-        let transformed_lines: Vec<String> = split_lines
+        // The split itself re-renders the statement, so this branch answers with
+        // its own text even when no declarator was rewritten.
+        let transformed_lines: Vec<Cow<'_, str>> = split_lines
             .iter()
             .map(|l| transform_legacy_state_declarations(l, legacy_state_vars, immutable, dev))
             .collect();
-        return transformed_lines.join("\n");
+        return Cow::Owned(transformed_lines.join("\n"));
     }
 
-    let mut result = line.to_string();
+    let mut result = Cow::Borrowed(line);
 
     for (var, _initial, decl_kind) in legacy_state_vars {
         // Every pattern below is `"<keyword> <var>…"`, so one scan rules the whole
@@ -1623,12 +1628,12 @@ pub(super) fn transform_legacy_state_declarations(
                     );
 
                     // Replace the declaration
-                    result = format!(
+                    result = Cow::Owned(format!(
                         "{}{}{}",
                         &result[..pos],
                         replacement,
                         &result[pos + pattern_with_init.len() + ws + expr_end..]
-                    );
+                    ));
                     matched = true;
                     break;
                 }
@@ -1691,12 +1696,12 @@ pub(super) fn transform_legacy_state_declarations(
                             var,
                             tag_legacy_source(call, var, dev)
                         );
-                        result = format!(
+                        result = Cow::Owned(format!(
                             "{}{}{}",
                             &result[..pos],
                             replacement,
                             &result[after_eq + ws + expr_end..]
-                        );
+                        ));
                         matched = true;
                         break;
                     }
@@ -1736,12 +1741,12 @@ pub(super) fn transform_legacy_state_declarations(
                     );
 
                     // Replace the declaration
-                    result = format!(
+                    result = Cow::Owned(format!(
                         "{}{}{}",
                         &result[..pos],
                         replacement,
                         &result[pos + pattern_no_init.len()..]
-                    );
+                    ));
                     matched = true;
                     break;
                 }
@@ -1809,12 +1814,12 @@ pub(super) fn transform_legacy_state_declarations(
                             var,
                             tag_legacy_source(call, var, dev)
                         );
-                        result = format!(
+                        result = Cow::Owned(format!(
                             "{}{}{}",
                             &result[..pos],
                             replacement,
                             &result[after_eq + expr_end..]
-                        );
+                        ));
                         matched = true;
                         break;
                     }
@@ -1829,7 +1834,12 @@ pub(super) fn transform_legacy_state_declarations(
                         var,
                         tag_legacy_source(call, var, dev)
                     );
-                    result = format!("{}{}{}", &result[..pos], replacement, &result[after_pos..]);
+                    result = Cow::Owned(format!(
+                        "{}{}{}",
+                        &result[..pos],
+                        replacement,
+                        &result[after_pos..]
+                    ));
                     matched = true;
                     break;
                 }

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/declaration_tag.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/declaration_tag.rs
@@ -134,6 +134,7 @@ pub fn declaration_tag(node: &DeclarationTag, context: &mut ComponentContext) {
             &[],
             &[],
         )
+        .into_owned()
     };
 
     let trimmed = transformed.trim();

--- a/crates/rsvelte_core/src/lib.rs
+++ b/crates/rsvelte_core/src/lib.rs
@@ -38,6 +38,8 @@ pub mod measure_module_source;
 pub mod measure_prop_reads;
 #[cfg(feature = "measure-slot-key")]
 pub mod measure_slot_key;
+#[cfg(feature = "measure-stmt-chain")]
+pub mod measure_stmt_chain;
 pub mod toolchain;
 
 pub use compiler::legacy::convert_to_legacy;

--- a/crates/rsvelte_core/src/measure_stmt_chain.rs
+++ b/crates/rsvelte_core/src/measure_stmt_chain.rs
@@ -258,4 +258,111 @@ mod tests {
             "the per-statement chain is client-only, but SSR recorded stages"
         );
     }
+
+    const BINS: [(usize, &str); 5] = [
+        (1024, "0-1 KB"),
+        (3 * 1024, "1-3 KB"),
+        (8 * 1024, "3-8 KB"),
+        (20 * 1024, "8-20 KB"),
+        (usize::MAX, ">20 KB"),
+    ];
+
+    fn collect_svelte_files(dir: &std::path::Path, out: &mut Vec<std::path::PathBuf>) {
+        let Ok(entries) = std::fs::read_dir(dir) else {
+            return;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                collect_svelte_files(&path, out);
+            } else if path.extension().is_some_and(|e| e == "svelte") {
+                out.push(path);
+            }
+        }
+    }
+
+    /// Which stage of the chain grows faster than the corpus it is fed.
+    ///
+    /// A stage whose bytes-per-file rises faster than the bin's source
+    /// bytes-per-file is the superlinear one; that comparison is what the
+    /// column ratios below are for, and it is load-independent.
+    ///
+    /// Point `RSVELTE_STMT_CHAIN_CORPUS` at a tree of `.svelte` files and run
+    /// with `--ignored --nocapture`.
+    #[test]
+    #[ignore = "needs a corpus directory in RSVELTE_STMT_CHAIN_CORPUS"]
+    fn stmt_chain_size_bins() {
+        let root = std::env::var("RSVELTE_STMT_CHAIN_CORPUS")
+            .expect("set RSVELTE_STMT_CHAIN_CORPUS to a directory of .svelte files");
+        let mut files = Vec::new();
+        collect_svelte_files(std::path::Path::new(&root), &mut files);
+        files.sort();
+        assert!(!files.is_empty(), "corpus {root} holds no .svelte files");
+
+        for (limit, label) in BINS {
+            let lower = BINS
+                .iter()
+                .take_while(|(l, _)| *l < limit)
+                .last()
+                .map_or(0, |(l, _)| *l);
+            let mut compiled = 0u64;
+            let mut source_bytes = 0u64;
+            let mut totals: Vec<Stage> = Vec::new();
+            for path in &files {
+                let Ok(source) = std::fs::read_to_string(path) else {
+                    continue;
+                };
+                if source.len() < lower || source.len() >= limit {
+                    continue;
+                }
+                reset();
+                let name = path.file_name().unwrap_or_default().to_string_lossy();
+                if compile(
+                    &source,
+                    CompileOptions {
+                        filename: Some(name.into_owned()),
+                        ..CompileOptions::default()
+                    },
+                )
+                .is_err()
+                {
+                    continue;
+                }
+                compiled += 1;
+                source_bytes += source.len() as u64;
+                for stage in snapshot() {
+                    match totals.iter_mut().find(|t| t.name == stage.name) {
+                        Some(total) => {
+                            total.owned += stage.owned;
+                            total.owned_bytes += stage.owned_bytes;
+                            total.borrowed += stage.borrowed;
+                            total.borrowed_bytes += stage.borrowed_bytes;
+                        }
+                        None => totals.push(stage),
+                    }
+                }
+            }
+            if compiled == 0 {
+                continue;
+            }
+            let per_file = |n: u64| n as f64 / compiled as f64;
+            println!(
+                "--- {label}: {compiled} files, {:.0} source B/file ---",
+                per_file(source_bytes)
+            );
+            totals.sort_by(|a, b| {
+                (b.owned_bytes + b.borrowed_bytes).cmp(&(a.owned_bytes + a.borrowed_bytes))
+            });
+            for stage in &totals {
+                let handled = stage.owned_bytes + stage.borrowed_bytes;
+                println!(
+                    "{:<34} {:>8.0} B/file  ({:>5.2}x source)  {:>6.1} runs/file",
+                    stage.name,
+                    per_file(handled),
+                    per_file(handled) / per_file(source_bytes),
+                    per_file(stage.owned + stage.borrowed),
+                );
+            }
+        }
+    }
 }

--- a/crates/rsvelte_core/src/measure_stmt_chain.rs
+++ b/crates/rsvelte_core/src/measure_stmt_chain.rs
@@ -12,7 +12,6 @@
 //! allocation rather than the `Cow` discriminant, which a pass-through would
 //! otherwise report as owned forever after the first real rewrite.
 
-use std::borrow::Cow;
 use std::cell::RefCell;
 
 /// One chain stage's tally for the current thread.
@@ -29,7 +28,7 @@ thread_local! {
     static STAGES: RefCell<Vec<Stage>> = const { RefCell::new(Vec::new()) };
 }
 
-pub fn record(name: &'static str, input: *const u8, value: &Cow<'_, str>) {
+pub fn record(name: &'static str, input: *const u8, value: &str) {
     let owned = !std::ptr::eq(value.as_ptr(), input);
     let len = value.len() as u64;
     STAGES.with(|s| {
@@ -81,7 +80,7 @@ pub fn reset() {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::compiler::{CompileOptions, compile};
+    use crate::compiler::{CompileOptions, GenerateMode, compile};
 
     /// A legacy (non-runes) component: every guarded stage in the chain fires.
     const LEGACY: &str = r#"<script>
@@ -169,17 +168,22 @@ mod tests {
 <Child {rows} {summary} {selected} />
 "#;
 
-    fn measure(source: &str, filename: &str) -> Vec<Stage> {
+    fn measure_with(source: &str, filename: &str, generate: GenerateMode) -> Vec<Stage> {
         reset();
         compile(
             source,
             CompileOptions {
                 filename: Some(filename.to_string()),
+                generate,
                 ..CompileOptions::default()
             },
         )
         .expect("fixture must compile");
         snapshot()
+    }
+
+    fn measure(source: &str, filename: &str) -> Vec<Stage> {
+        measure_with(source, filename, GenerateMode::Client)
     }
 
     fn report(label: &str, stages: &[Stage]) {
@@ -205,6 +209,13 @@ mod tests {
         );
     }
 
+    fn stage_of<'a>(stages: &'a [Stage], name: &str) -> &'a Stage {
+        stages
+            .iter()
+            .find(|s| s.name == name)
+            .unwrap_or_else(|| panic!("stage {name} never ran, so it measures nothing"))
+    }
+
     #[test]
     fn stmt_chain_allocation_report() {
         let legacy = measure(LEGACY, "Legacy.svelte");
@@ -215,6 +226,36 @@ mod tests {
         assert!(
             !legacy.is_empty() && !runes.is_empty(),
             "the chain must have run at all — an empty report measures nothing"
+        );
+
+        // Each converted stage has to be observed handing its input through at
+        // least once. Byte-identical output is not evidence that it does: a
+        // conversion that never takes the borrowed path passes every
+        // correctness test while saving nothing.
+        for name in [
+            "runes",
+            "destructure_assignments",
+            "store_unsub_for_state_sets",
+            "member_mutations",
+            "prop_update_expressions",
+            "prop_assignments",
+            "legacy_destructure_declarations",
+            "legacy_state_declarations",
+            "state_reads",
+        ] {
+            assert!(
+                stage_of(&legacy, name).borrowed > 0,
+                "stage {name} never handed its input through"
+            );
+        }
+
+        // Negative control: SSR does not run this chain at all, so no stage may
+        // report anything for it — if one does, the counter is not measuring
+        // the chain it claims to.
+        let server = measure_with(LEGACY, "Legacy.svelte", GenerateMode::Server);
+        assert!(
+            server.is_empty(),
+            "the per-statement chain is client-only, but SSR recorded stages"
         );
     }
 }

--- a/crates/rsvelte_core/src/measure_stmt_chain.rs
+++ b/crates/rsvelte_core/src/measure_stmt_chain.rs
@@ -1,0 +1,220 @@
+//! Counts what the per-statement transform chain in
+//! `transform_instance_script_for_visitors` allocates, per stage.
+//!
+//! The chain runs ~20 rewrite stages over every top-level statement of an
+//! instance script, and a stage that fires its guard but rewrites nothing used
+//! to be indistinguishable from one that rewrote: both returned a fresh
+//! `String`. Correctness tests cannot separate those two, so the split is
+//! counted rather than assumed.
+//!
+//! A stage counts as `owned` when its output does not share a buffer with its
+//! input — moving a `String` through keeps its pointer, so this measures the
+//! allocation rather than the `Cow` discriminant, which a pass-through would
+//! otherwise report as owned forever after the first real rewrite.
+
+use std::borrow::Cow;
+use std::cell::RefCell;
+
+/// One chain stage's tally for the current thread.
+#[derive(Clone, Copy)]
+pub struct Stage {
+    pub name: &'static str,
+    pub owned: u64,
+    pub owned_bytes: u64,
+    pub borrowed: u64,
+    pub borrowed_bytes: u64,
+}
+
+thread_local! {
+    static STAGES: RefCell<Vec<Stage>> = const { RefCell::new(Vec::new()) };
+}
+
+pub fn record(name: &'static str, input: *const u8, value: &Cow<'_, str>) {
+    let owned = !std::ptr::eq(value.as_ptr(), input);
+    let len = value.len() as u64;
+    STAGES.with(|s| {
+        let mut s = s.borrow_mut();
+        let entry = match s.iter_mut().position(|e| e.name == name) {
+            Some(i) => &mut s[i],
+            None => {
+                s.push(Stage {
+                    name,
+                    owned: 0,
+                    owned_bytes: 0,
+                    borrowed: 0,
+                    borrowed_bytes: 0,
+                });
+                s.last_mut().expect("just pushed")
+            }
+        };
+        if owned {
+            entry.owned += 1;
+            entry.owned_bytes += len;
+        } else {
+            entry.borrowed += 1;
+            entry.borrowed_bytes += len;
+        }
+    });
+}
+
+/// Per-stage tallies since the last [`reset`], in first-run order.
+pub fn snapshot() -> Vec<Stage> {
+    STAGES.with(|s| s.borrow().clone())
+}
+
+/// `(owned, owned_bytes, borrowed, borrowed_bytes)` across every stage.
+pub fn totals() -> (u64, u64, u64, u64) {
+    snapshot().iter().fold((0, 0, 0, 0), |acc, s| {
+        (
+            acc.0 + s.owned,
+            acc.1 + s.owned_bytes,
+            acc.2 + s.borrowed,
+            acc.3 + s.borrowed_bytes,
+        )
+    })
+}
+
+pub fn reset() {
+    STAGES.with(|s| s.borrow_mut().clear());
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::compiler::{CompileOptions, compile};
+
+    /// A legacy (non-runes) component: every guarded stage in the chain fires.
+    const LEGACY: &str = r#"<script>
+	import { onMount } from 'svelte';
+	import Child from './Child.svelte';
+
+	export let label = 'hi';
+	export let rows = [];
+
+	let count = 0;
+	let items = [1, 2, 3];
+	let selected = null;
+
+	const greeting = 'hello world, this is a fairly long constant string';
+	const formatter = new Intl.NumberFormat('en-US', { style: 'decimal' });
+	const noop = () => {};
+
+	function bump() {
+		count += 1;
+	}
+
+	function reset_all() {
+		count = 0;
+		items = [];
+		selected = null;
+	}
+
+	function describe(row) {
+		return `${row.id}: ${row.name} (${formatter.format(row.value)})`;
+	}
+
+	async function load() {
+		const response = await fetch('/api/rows');
+		rows = await response.json();
+	}
+
+	onMount(() => {
+		load();
+		noop();
+	});
+
+	$: doubled = count * 2;
+	$: summary = rows.map(describe).join(', ');
+</script>
+
+<button onclick={bump}>{label} {count} {doubled} {items.length} {greeting}</button>
+<Child {rows} {summary} {selected} />
+"#;
+
+    /// A runes component: the legacy-only stages are skipped by their guards, so
+    /// only the always-on stages can be observed here.
+    const RUNES: &str = r#"<script>
+	import { untrack } from 'svelte';
+	import Child from './Child.svelte';
+
+	let { label, rows = [] } = $props();
+
+	let count = $state(0);
+	let selected = $state(null);
+	let doubled = $derived(count * 2);
+	let summary = $derived(rows.map((row) => row.name).join(', '));
+
+	const greeting = 'hello world, this is a fairly long constant string';
+	const formatter = new Intl.NumberFormat('en-US', { style: 'decimal' });
+
+	function bump() {
+		count += 1;
+	}
+
+	function reset_all() {
+		count = 0;
+		selected = null;
+	}
+
+	function describe(row) {
+		return `${row.id}: ${row.name} (${formatter.format(row.value)})`;
+	}
+
+	$effect(() => {
+		untrack(() => describe(rows[0] ?? { id: 0, name: '', value: 0 }));
+	});
+</script>
+
+<button onclick={bump}>{label} {count} {doubled} {greeting}</button>
+<Child {rows} {summary} {selected} />
+"#;
+
+    fn measure(source: &str, filename: &str) -> Vec<Stage> {
+        reset();
+        compile(
+            source,
+            CompileOptions {
+                filename: Some(filename.to_string()),
+                ..CompileOptions::default()
+            },
+        )
+        .expect("fixture must compile");
+        snapshot()
+    }
+
+    fn report(label: &str, stages: &[Stage]) {
+        println!("--- {label} ---");
+        for s in stages {
+            println!(
+                "{:<34} owned {:>4} / {:>7} B   borrowed {:>4} / {:>7} B",
+                s.name, s.owned, s.owned_bytes, s.borrowed, s.borrowed_bytes
+            );
+        }
+        let (owned, owned_bytes, borrowed, borrowed_bytes) =
+            stages.iter().fold((0u64, 0u64, 0u64, 0u64), |acc, s| {
+                (
+                    acc.0 + s.owned,
+                    acc.1 + s.owned_bytes,
+                    acc.2 + s.borrowed,
+                    acc.3 + s.borrowed_bytes,
+                )
+            });
+        println!(
+            "{:<34} owned {:>4} / {:>7} B   borrowed {:>4} / {:>7} B",
+            "TOTAL", owned, owned_bytes, borrowed, borrowed_bytes
+        );
+    }
+
+    #[test]
+    fn stmt_chain_allocation_report() {
+        let legacy = measure(LEGACY, "Legacy.svelte");
+        report("legacy", &legacy);
+        let runes = measure(RUNES, "Runes.svelte");
+        report("runes", &runes);
+
+        assert!(
+            !legacy.is_empty() && !runes.is_empty(),
+            "the chain must have run at all — an empty report measures nothing"
+        );
+    }
+}


### PR DESCRIPTION
## Why

`process_accumulated` — the per-top-level-statement closure in
`transform_instance_script_for_visitors` — runs ~20 rewrite stages over every
statement of an instance script, each shaped like

```rust
let transformed = if <cheap guard> { some_pass(&transformed, …) } else { transformed };
```

`some_pass` returns a fresh `String` whether or not it rewrote anything, so a
statement paid one full copy per stage whose guard fired, even for stages that
found nothing to do. `alloc_callers` attribution over a 2,123-file corpus put
this closure at 16.3% of allocations by count but **38% by bytes** — the largest
single byte sink in the compiler.

## What changed

Three commits.

1. **Hoist the loop-invariant name vectors.** `process_accumulated` rebuilt both
   name-only projections of `legacy_state_vars` on every statement although
   neither input changes inside the loop.

2. **Count what each stage allocates**, behind a new off-by-default
   `measure-stmt-chain` feature. A stage counts as allocating when its output
   does not share a buffer with its input — not by the `Cow` discriminant, which
   would report every stage after the first real rewrite as owned, since moving
   a `String` through keeps its pointer.

3. **Let a no-op stage return its input.** Nine passes now return
   `Cow<'_, str>`, borrowed when they found nothing; the chain reads that with a
   `rewritten()` adapter and keeps the string it already owns.

Output is unchanged — every one of the new `Cow::Borrowed` returns replaces a
`x.to_string()` of that exact input.

## Evidence

`cargo test -p rsvelte_core --lib --features measure-stmt-chain -- --nocapture`,
same two fixtures before and after:

| fixture | before | after |
|---|---|---|
| legacy component (11 statements) | 113 copies / 6353 B | **18 copies / 1107 B** |
| runes component (10 statements) | 20 copies / 1078 B | **0 copies / 0 B** |

Negative controls, i.e. populations where the mechanism cannot fire, all
unchanged to the byte:

| stage | before | after | why it cannot move |
|---|---|---|---|
| `state_assigns` | 2 / 137 B | 2 / 137 B | already `Option`-shaped |
| `prop_source_reads` | 1 / 104 B | 1 / 104 B | already `Option`-shaped |
| `rest_prop_member_access` | 11 / 653 B | 11 / 653 B | deliberately not converted |
| SSR compile of the same source | 0 stages | 0 stages | chain is client-only |

The test also asserts each converted stage is observed taking the borrowed path
at least once. Byte-identical output is not evidence that it does: a conversion
whose borrowed path never fires passes every correctness test while saving
nothing.

## Stages left alone

* `transform_store_sub_calls` / `transform_store_assignments_client` /
  `transform_store_reads_client` — their call-site guard already establishes
  that a store name occurs in the statement, so "guard fired, nothing changed"
  is not their common case, and each rebuilds the text per store variable
  internally. Converting the signature alone would save nothing.
* `transform_rest_prop_member_access` — its fallback is a regex text loop that
  `clone()`s the working string per variable; converting it is a rewrite, not a
  signature change. It is the negative control above.

## Also included

`stmt_chain_size_bins` (ignored by default) aggregates the same per-stage
counters over a corpus binned by source size, so the stage whose bytes-per-file
grows faster than the corpus's bytes-per-file can be named. That is the
localisation instrument for the separate `pa_rest` superlinearity finding; it
changes no behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
