### PR TITLE
perf(ast): shrink JsNode from 144 to 80 bytes

### DIFF
--- a/.changeset/shrink-jsnode-to-80-bytes.md
+++ b/.changeset/shrink-jsnode-to-80-bytes.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/compiler": patch
+---
+
+Shrink `JsNode` from 144 to 80 bytes by boxing the payloads of its two outlier variants (`Literal`'s regex values and `Program`'s comment/ignore metadata). Compiler output is unchanged.

--- a/crates/rsvelte_bindings_support/src/napi_raw_parse.rs
+++ b/crates/rsvelte_bindings_support/src/napi_raw_parse.rs
@@ -1228,7 +1228,7 @@ fn write_js_node<W: Writer>(w: &mut W, node: &JsNode, arena: &ParseArena) -> std
             write_typed_loc(w, loc.as_deref());
             write_literal_value(w, value);
             write_str(w, raw.as_str());
-            write_regex(w, regex.as_ref());
+            write_regex(w, regex.as_deref());
         }
         JsNode::BinaryExpression {
             start,

--- a/crates/rsvelte_bindings_support/src/napi_raw_parse.rs
+++ b/crates/rsvelte_bindings_support/src/napi_raw_parse.rs
@@ -1627,17 +1627,14 @@ fn write_js_node<W: Writer>(w: &mut W, node: &JsNode, arena: &ParseArena) -> std
             loc,
             body,
             source_type,
-            leading_comments,
-            trailing_comments,
-            // Internal analyze-only metadata; not part of the serialized AST.
-            ignore_comment_map: _,
+            metadata,
         } => {
             write_preamble(w, JS_PROGRAM, *start, *end);
             write_typed_loc(w, loc.as_deref());
             write_id_range(w, *body, arena)?;
             write_str(w, source_type.as_str());
-            write_opt_inline_json(w, trailing_comments.as_ref())?;
-            write_opt_inline_json(w, leading_comments.as_ref())?;
+            write_opt_inline_json(w, metadata.trailing_comments.as_ref())?;
+            write_opt_inline_json(w, metadata.leading_comments.as_ref())?;
         }
         JsNode::ExpressionStatement {
             start,

--- a/crates/rsvelte_core/src/ast/typed_expr.rs
+++ b/crates/rsvelte_core/src/ast/typed_expr.rs
@@ -58,7 +58,9 @@ pub enum LiteralValue {
     Number(f64),
     Bool(bool),
     Null,
-    Regex(RegexValue),
+    /// Boxed: a regex payload is two `CompactString`s, and inlining it would
+    /// widen every `JsNode` by 24 bytes for a variant that is vanishingly rare.
+    Regex(Box<RegexValue>),
 }
 
 impl Serialize for LiteralValue {
@@ -115,7 +117,8 @@ pub enum JsNode {
         loc: Option<Box<Loc>>,
         value: LiteralValue,
         raw: CompactString,
-        regex: Option<RegexValue>,
+        /// Boxed for the same reason as [`LiteralValue::Regex`].
+        regex: Option<Box<RegexValue>>,
     },
     BinaryExpression {
         start: u32,
@@ -2422,13 +2425,12 @@ impl JsNode {
                         name: get_str(obj, "name"),
                     },
                     "Literal" => {
-                        let regex =
-                            obj.get("regex")
-                                .and_then(|r| r.as_object())
-                                .map(|r| RegexValue {
-                                    pattern: get_str(r, "pattern"),
-                                    flags: get_str(r, "flags"),
-                                });
+                        let regex = obj.get("regex").and_then(|r| r.as_object()).map(|r| {
+                            Box::new(RegexValue {
+                                pattern: get_str(r, "pattern"),
+                                flags: get_str(r, "flags"),
+                            })
+                        });
                         let lit_value = match obj.get("value") {
                             Some(Value::String(s)) => LiteralValue::String(s.as_str().into()),
                             Some(Value::Number(n)) => {

--- a/crates/rsvelte_core/src/ast/typed_expr.rs
+++ b/crates/rsvelte_core/src/ast/typed_expr.rs
@@ -46,6 +46,23 @@ pub struct RegexValue {
     pub flags: CompactString,
 }
 
+/// The bulk of [`JsNode::Program`], held behind one `Box` so a per-script node
+/// does not set the width of every `JsNode` in the arena.
+#[derive(Debug, Clone, PartialEq, Default)]
+pub struct ProgramMetadata {
+    /// Leading comments on the Program node (e.g. from HTML comments before script tag).
+    pub leading_comments: Option<Vec<Value>>,
+    /// Trailing comments on the Program node (all JS comments in the program).
+    pub trailing_comments: Option<Vec<Value>>,
+    /// Map from a JS AST node's absolute `start` offset to the raw `svelte-ignore`
+    /// comment value texts that were attached to it as leading comments (at any
+    /// depth in this program). This lets Phase-2 analyze surface `svelte-ignore`
+    /// suppression for typed nodes without materializing them as `JsNode::Raw`
+    /// just to carry a `leadingComments` array. Empty when the script has no
+    /// `svelte-ignore` comments (the common case). Internal-only: not serialized.
+    pub ignore_comment_map: Vec<(u32, Vec<CompactString>)>,
+}
+
 #[derive(Debug, Clone, PartialEq)]
 pub struct TemplateElementValue {
     pub raw: CompactString,
@@ -375,17 +392,7 @@ pub enum JsNode {
         loc: Option<Box<Loc>>,
         body: IdRange,
         source_type: CompactString,
-        /// Leading comments on the Program node (e.g. from HTML comments before script tag).
-        leading_comments: Option<Vec<Value>>,
-        /// Trailing comments on the Program node (all JS comments in the program).
-        trailing_comments: Option<Vec<Value>>,
-        /// Map from a JS AST node's absolute `start` offset to the raw `svelte-ignore`
-        /// comment value texts that were attached to it as leading comments (at any
-        /// depth in this program). This lets Phase-2 analyze surface `svelte-ignore`
-        /// suppression for typed nodes without materializing them as `JsNode::Raw`
-        /// just to carry a `leadingComments` array. Empty when the script has no
-        /// `svelte-ignore` comments (the common case). Internal-only: not serialized.
-        ignore_comment_map: Vec<(u32, Vec<CompactString>)>,
+        metadata: Box<ProgramMetadata>,
     },
     ExpressionStatement {
         start: u32,
@@ -1451,10 +1458,7 @@ impl Serialize for JsNode {
                 loc,
                 body,
                 source_type,
-                leading_comments,
-                trailing_comments,
-                // Internal analyze-only metadata; never part of the ESTree output.
-                ignore_comment_map: _,
+                metadata,
             } => {
                 let mut map = serializer.serialize_map(Some(4))?;
                 map.serialize_entry("type", "Program")?;
@@ -1463,10 +1467,10 @@ impl Serialize for JsNode {
                 ser_loc!(map, loc);
                 ser_children!(map, "body", body);
                 map.serialize_entry("sourceType", source_type.as_str())?;
-                if let Some(tc) = trailing_comments {
+                if let Some(tc) = &metadata.trailing_comments {
                     map.serialize_entry("trailingComments", tc)?;
                 }
-                if let Some(lc) = leading_comments {
+                if let Some(lc) = &metadata.leading_comments {
                     map.serialize_entry("leadingComments", lc)?;
                 }
                 map.end()
@@ -2690,16 +2694,18 @@ impl JsNode {
                         loc,
                         body: convert_array(obj, "body"),
                         source_type: get_str(obj, "sourceType"),
-                        leading_comments: obj
-                            .get("leadingComments")
-                            .and_then(|v| v.as_array().cloned()),
-                        trailing_comments: obj
-                            .get("trailingComments")
-                            .and_then(|v| v.as_array().cloned()),
-                        // Reconstructed-from-Value programs carry no analyze-only
-                        // svelte-ignore map; comment-bearing nodes in that path keep
-                        // their leadingComments and go through the Value walker.
-                        ignore_comment_map: Vec::new(),
+                        metadata: Box::new(ProgramMetadata {
+                            leading_comments: obj
+                                .get("leadingComments")
+                                .and_then(|v| v.as_array().cloned()),
+                            trailing_comments: obj
+                                .get("trailingComments")
+                                .and_then(|v| v.as_array().cloned()),
+                            // Reconstructed-from-Value programs carry no analyze-only
+                            // svelte-ignore map; comment-bearing nodes in that path keep
+                            // their leadingComments and go through the Value walker.
+                            ignore_comment_map: Vec::new(),
+                        }),
                     },
                     "ExpressionStatement" => JsNode::ExpressionStatement {
                         start,

--- a/crates/rsvelte_core/src/compiler/phases/1_parse/read/expression.rs
+++ b/crates/rsvelte_core/src/compiler/phases/1_parse/read/expression.rs
@@ -4880,15 +4880,15 @@ fn create_regex_literal<'a>(
         start: start as u32,
         end: end as u32,
         loc: create_typed_loc(start, end, line_offsets),
-        value: LiteralValue::Regex(RegexValue {
+        value: LiteralValue::Regex(Box::new(RegexValue {
             pattern: CompactString::from(pattern_str),
             flags: CompactString::from(flags_str),
-        }),
+        })),
         raw: CompactString::from(raw),
-        regex: Some(RegexValue {
+        regex: Some(Box::new(RegexValue {
             pattern: CompactString::from(regex.regex.pattern.text.as_ref()),
             flags: CompactString::from(regex.regex.flags.to_string()),
-        }),
+        })),
     })
 }
 

--- a/crates/rsvelte_core/src/compiler/phases/1_parse/read/expression.rs
+++ b/crates/rsvelte_core/src/compiler/phases/1_parse/read/expression.rs
@@ -6986,9 +6986,11 @@ fn convert_parsed_program<'ast>(
                 loc,
                 body: arena.alloc_js_children(body),
                 source_type: CompactString::from("module"),
-                leading_comments: leading_comments_val,
-                trailing_comments: trailing_comments_val,
-                ignore_comment_map,
+                metadata: Box::new(crate::ast::typed_expr::ProgramMetadata {
+                    leading_comments: leading_comments_val,
+                    trailing_comments: trailing_comments_val,
+                    ignore_comment_map,
+                }),
             }),
             parse_error,
         )

--- a/crates/rsvelte_core/src/compiler/phases/1_parse/read/script.rs
+++ b/crates/rsvelte_core/src/compiler/phases/1_parse/read/script.rs
@@ -287,9 +287,7 @@ impl<'a> Parser<'a> {
                 loc: None,
                 body: crate::ast::arena::IdRange::empty(),
                 source_type: CompactString::from("module"),
-                leading_comments: None,
-                trailing_comments: None,
-                ignore_comment_map: Vec::new(),
+                metadata: Box::default(),
             });
             Script {
                 node_type: ScriptType::Script,
@@ -335,9 +333,7 @@ impl<'a> Parser<'a> {
                     loc: None,
                     body: crate::ast::arena::IdRange::empty(),
                     source_type: CompactString::from("module"),
-                    leading_comments: None,
-                    trailing_comments: None,
-                    ignore_comment_map: Vec::new(),
+                    metadata: Box::default(),
                 });
                 Script {
                     node_type: ScriptType::Script,

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/mod.rs
@@ -5209,9 +5209,7 @@ fn collect_identifier_names_in_node(
             loc: _,
             body,
             source_type: _,
-            leading_comments: _,
-            trailing_comments: _,
-            ignore_comment_map: _,
+            metadata: _,
         }
         | JsNode::BlockStatement {
             start: _,

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/script.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/script.rs
@@ -27,19 +27,15 @@ pub fn visit_script_expr(
 ) -> Result<(), AnalysisError> {
     match script_expr {
         Expression::Typed(te) => {
-            if let JsNode::Program {
-                body,
-                ignore_comment_map,
-                ..
-            } = &te.node
-            {
+            if let JsNode::Program { body, metadata, .. } = &te.node {
                 // Install this program's svelte-ignore map for the duration of the body
                 // walk, so the typed walker can surface statement-level svelte-ignore
                 // suppression without the nodes being materialized as `JsNode::Raw`.
                 // Save/restore the previous map (module vs instance scripts each set
                 // their own; template walks expect an empty map).
                 let saved_ignores = std::mem::take(&mut context.script_ignore_comments);
-                context.script_ignore_comments = ignore_comment_map.iter().cloned().collect();
+                context.script_ignore_comments =
+                    metadata.ignore_comment_map.iter().cloned().collect();
 
                 // Push the Program as a TYPED js_path entry, like every other node
                 // the walker pushes below. `as_json()` here used to materialize the


### PR DESCRIPTION
## Why

Every JS expression node in Phase 1 is individually heap-boxed
(`Expression::Typed(Box<TypedExpr>)`), so `size_of::<JsNode>()` is paid on every
`malloc` and on every `Vec<JsNode>` memcpy. It was 144 bytes — and
`-Zprint-type-sizes` showed that 144 came from exactly **two** of the 87
variants:

| variant | size | why |
| --- | --- | --- |
| `Literal` | 143 | two inline `RegexValue`s (`value` 48 + `regex` 48) |
| `Program` | 127 | four 24-byte fields, on a node there is one of per script |
| `ExportNamedDeclaration` | 79 | — |
| `Identifier` and ~75 others | ≤ 55 | — |

So the modal node — `Identifier`, 55 bytes of real payload — was stored at 144
because a regex literal *might* appear.

## What

Two representation-only commits:

1. `LiteralValue::Regex(Box<RegexValue>)` and `Literal.regex: Option<Box<RegexValue>>`.
2. `Program`'s `leading_comments` / `trailing_comments` / `ignore_comment_map`
   move into a `ProgramMetadata` behind one `Box`.

Nothing else changes: the serializer already reached both regex payloads through
`if let Some(..)` / a match arm, and the `Program` arm through named bindings, so
boxing leaves every emitted key, order and null-vs-absent decision identical.

## Sizes

`cargo +nightly rustc -p rsvelte_core --lib -- -Zprint-type-sizes`

| | before | after |
| --- | --- | --- |
| `JsNode` | 144 | **80** |
| `TypedExpr` | 152 | **88** |

Top variants after:

```
type: `ast::typed_expr::JsNode`: 80 bytes, alignment: 8 bytes
    discriminant: 1 bytes
    variant `Literal`: 79 bytes
    variant `ExportNamedDeclaration`: 79 bytes
    variant `TemplateElement`: 71 bytes
    variant `Program`: 63 bytes
    variant `ImportDeclaration`: 63 bytes
    variant `Comment`: 63 bytes
    variant `Identifier`: 55 bytes
```

`Literal` and `ExportNamedDeclaration` now tie at 79, so the next byte would cost
a third indirection on two unrelated variants at once. This is where it stops
paying.

## Allocated bytes

`crates/rsvelte_devtools/src/bin/alloc_count.rs`, release, over the 1,296
`.svelte` files of `submodules/flowbite-svelte`:

| target | bytes before | bytes after | Δ |
| --- | --- | --- | --- |
| client | 482,494,867 | 458,289,569 | **−24,205,298 (−5.02%)** |
| server | 324,343,421 | 300,334,317 | **−24,009,104 (−7.40%)** |

Allocation *count* moves the other way by exactly the amount predicted — +2,649
(client) / +2,544 (server) over 1,296 files, i.e. the ~2 `ProgramMetadata` boxes
per file. That is the intended trade: two 72-byte boxes per file to take 64 bytes
off every node in the arena.

No wall-clock timing was taken; this PR reports static sizes and deterministic
counters only.

## Verification

- `cargo test -p rsvelte_core --no-fail-fast`: **2,623 passed, 1 failed, 8
  ignored** across 246 test binaries. The single failure is
  `validator::validator_warning_messages_match_official`, a two-sided-ratchet
  complaint ("2 entr(ies) … now match") that reproduces **byte-identically on
  unmodified `origin/main`** — verified by re-running the same test with
  `git checkout origin/main -- crates/`. Pre-existing, unrelated.
  (`tests/ast_gate_preconditions` overflows the rayon worker stack in debug on
  this machine, also on unmodified `origin/main`; run under
  `RUST_MIN_STACK=33554432`.)
- `cargo test -p rsvelte_bindings_support -p rsvelte_esrap -p rsvelte_lint`: 0 failures.
- `cargo clippy --all-targets --all-features -- -D warnings`: clean. No
  `clippy::large_enum_variant` allow existed on `JsNode`, so there was none to remove.
- `cargo fmt --all`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
