### PR TITLE
fix(transform): stop a comment apostrophe from suppressing store and prop read rewrites

### DIFF
--- a/.changeset/comment-quote-read-scans.md
+++ b/.changeset/comment-quote-read-scans.md
@@ -1,0 +1,5 @@
+---
+'@rsvelte/compiler': patch
+---
+
+Stop an apostrophe in a comment from suppressing the store and prop read rewrites. `// it's fine` opened a string literal that nothing closed, so every `$store` / prop read after it was emitted uncalled — code that parses and is silently wrong at runtime.

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/props_transforms.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/props_transforms.rs
@@ -276,6 +276,31 @@ pub(super) fn transform_prop_reads_in_expr(expr: &str, prop_vars: &[String]) -> 
                 }
             }
 
+            // A quote inside a comment is text: an apostrophe in `// it's not
+            // defined` would otherwise open a string that nothing closes, and
+            // every identifier after it would be left untransformed.
+            if c == '/' && i + 1 < chars.len() && (chars[i + 1] == '/' || chars[i + 1] == '*') {
+                let line = chars[i + 1] == '/';
+                new_result.push(c);
+                new_result.push(chars[i + 1]);
+                i += 2;
+                while i < chars.len() {
+                    if line {
+                        if chars[i] == '\n' {
+                            break;
+                        }
+                    } else if chars[i] == '*' && i + 1 < chars.len() && chars[i + 1] == '/' {
+                        new_result.push(chars[i]);
+                        new_result.push(chars[i + 1]);
+                        i += 2;
+                        break;
+                    }
+                    new_result.push(chars[i]);
+                    i += 1;
+                }
+                continue;
+            }
+
             // Check for string literal start
             if c == '\'' || c == '"' || c == '`' {
                 in_string = Some(c);

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/state_transforms.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/state_transforms.rs
@@ -1102,7 +1102,39 @@ pub(super) fn is_inside_string_literal(code: &str, pos: usize) -> bool {
             if c == string_char {
                 in_string = false;
             }
-        } else if !template_interp_depth.is_empty() {
+            continue;
+        }
+
+        // A quote inside a comment is text: `// it doesn't matter` would
+        // otherwise open a string that nothing closes, so every position after
+        // it reads as "inside a string" and its rewrite is skipped.
+        if c == '/' {
+            match chars.peek() {
+                Some('/') => {
+                    chars.next();
+                    for ch in chars.by_ref() {
+                        if ch == '\n' {
+                            break;
+                        }
+                    }
+                    continue;
+                }
+                Some('*') => {
+                    chars.next();
+                    let mut prev = '\0';
+                    for ch in chars.by_ref() {
+                        if prev == '*' && ch == '/' {
+                            break;
+                        }
+                        prev = ch;
+                    }
+                    continue;
+                }
+                _ => {}
+            }
+        }
+
+        if !template_interp_depth.is_empty() {
             // Inside a template literal interpolation - track braces
             if c == '{' {
                 if let Some(depth) = template_interp_depth.last_mut() {

--- a/crates/rsvelte_core/tests/comment_quote_read_scans.rs
+++ b/crates/rsvelte_core/tests/comment_quote_read_scans.rs
@@ -1,0 +1,129 @@
+//! An apostrophe in a comment must not swallow the reads that follow it.
+//!
+//! Both scans below track quote state to avoid rewriting identifiers inside
+//! string literals, and neither knew what a comment was. `it's` opens a string
+//! nothing closes, so every position after it answers "inside a string" and its
+//! read is emitted uncalled — code that parses and is silently wrong at runtime,
+//! which is why no gate that only checks parseability sees it.
+
+use rsvelte_core::{CompileOptions, GenerateMode, compile, compiler::CssMode};
+
+fn client(source: &str) -> String {
+    compile(
+        source,
+        CompileOptions {
+            filename: Some("Apostrophe.svelte".to_string()),
+            generate: GenerateMode::Client,
+            css: CssMode::External,
+            ..Default::default()
+        },
+    )
+    .expect("compile")
+    .js
+    .code
+}
+
+/// Store read, reached through an ordinary multi-line statement — the comment
+/// survives into `transform_store_reads_client` because nothing strips comments
+/// outside a `$:` statement.
+#[test]
+fn a_comment_apostrophe_does_not_swallow_a_store_read() {
+    let out = client(
+        "<script>\n\
+         \timport { writable } from 'svelte/store';\n\
+         \tconst s = writable(1);\n\
+         \n\
+         \tconst obj = {\n\
+         \t\t// it's fine\n\
+         \t\tv: $s\n\
+         \t};\n\
+         </script>\n\
+         \n\
+         <div>{obj.v}</div>\n",
+    );
+
+    assert!(
+        out.contains("v: $s()"),
+        "store read left uncalled after a comment apostrophe: {out}"
+    );
+}
+
+/// Prop read inside a `$:` body. A `svelte-ignore` comment is deliberately left
+/// where it is — later text passes find it by scanning back from the node it
+/// annotates — so it is the one comment kind that always reaches these scans
+/// from a reactive statement.
+#[test]
+fn a_svelte_ignore_apostrophe_does_not_swallow_a_prop_read() {
+    let out = client(
+        "<script>\n\
+         \texport let rows = [];\n\
+         \texport let filterSelections = {};\n\
+         \n\
+         \t$: filteredRows = rows.filter((r) => {\n\
+         \t\treturn Object.keys(filterSelections).every((f) => {\n\
+         \t\t\t// svelte-ignore a11y_no_static_element_interactions it's not defined\n\
+         \t\t\tif (filterSelections[f] === '') {\n\
+         \t\t\t\treturn true;\n\
+         \t\t\t}\n\
+         \t\t\treturn false;\n\
+         \t\t});\n\
+         \t});\n\
+         </script>\n\
+         \n\
+         <div>{filteredRows.length}</div>\n",
+    );
+
+    assert!(
+        out.contains("filterSelections()[f]"),
+        "prop read left uncalled after a comment apostrophe: {out}"
+    );
+}
+
+/// Control: a real string literal still suppresses the rewrite, so the fix is
+/// "comments are not strings" and not "quote tracking was dropped".
+#[test]
+fn an_identifier_inside_a_real_string_is_still_left_alone() {
+    let out = client(
+        "<script>\n\
+         \timport { writable } from 'svelte/store';\n\
+         \tconst s = writable(1);\n\
+         \n\
+         \tconst obj = {\n\
+         \t\tlabel: 'read $s here',\n\
+         \t\tv: $s\n\
+         \t};\n\
+         </script>\n\
+         \n\
+         <div>{obj.v}</div>\n",
+    );
+
+    assert!(
+        out.contains("'read $s here'"),
+        "string literal rewritten: {out}"
+    );
+    assert!(out.contains("v: $s()"), "store read left uncalled: {out}");
+}
+
+/// A block comment reaches the same scans through the other `skip_opaque`
+/// branch, and an apostrophe in one is at least as common as in a line comment.
+#[test]
+fn a_block_comment_apostrophe_does_not_swallow_a_store_read() {
+    let out = client(
+        "<script>\n\
+         \timport { writable } from 'svelte/store';\n\
+         \tconst s = writable(1);\n\
+         \n\
+         \tconst obj = {\n\
+         \t\t/* it's fine */\n\
+         \t\tv: $s\n\
+         \t};\n\
+         </script>\n\
+         \n\
+         <div>{obj.v}</div>\n",
+    );
+
+    assert!(
+        out.contains("v: $s()"),
+        "store read left uncalled after a block-comment apostrophe: {out}"
+    );
+}


### PR DESCRIPTION
An apostrophe in a comment makes rsvelte emit a store or prop read **uncalled**. The output parses, so nothing that checks parseability sees it; it is simply wrong at runtime.

```svelte
<script>
	import { writable } from 'svelte/store';
	const s = writable(1);

	const obj = {
		// it's fine
		v: $s
	};
</script>
```

| | |
|---|---|
| official | `v: $s()` |
| rsvelte | `v: $s` |

Delete the apostrophe and rsvelte is correct.

## Cause

Two scans rewrite reads — `$store` → `$store()` and `prop` → `prop()` — and both track quote state so they do not rewrite identifiers inside string literals. Neither knew what a comment was:

- `is_inside_string_literal` (`client/state_transforms.rs:1078`), which guards `transform_store_reads_client`, has **no `/` handling at all**.
- the walk in `transform_prop_reads_in_expr` (`client/props_transforms.rs:162`) has its own copy of the same state machine, with the same gap.

The `'` in `doesn't` opens a string that nothing closes, so every position after it answers "inside a string" and its rewrite is skipped — for the rest of the statement in the prop scan, and for the rest of the string handed to the store scan.

Both now skip `//` and `/* */`. The template-literal semantics are unchanged on purpose: `${…}` contents stay *code*, so `` `${$store}` `` still becomes `` `${$store()}` ``. That is why this does not just call `shared/js_scan.rs::skip_opaque`, which treats a whole template including its interpolations as opaque — `server/helpers.rs:1396` already keeps a separate branch for the same reason.

## Reachability

Both shapes reproduce on **current `main`**, measured by building the NAPI binding from `main` and from this branch and running both compilers on the same input:

- **store read** — any ordinary multi-line statement. Nothing strips comments outside a `$:` statement, so the comment reaches the scan directly.
- **prop read** — a `svelte-ignore` comment inside a `$:` body. Reactive statements have their comments stripped before the visitors run, *except* `svelte-ignore`, which is deliberately left in place because later text passes locate it by scanning back from the node it annotates. So it is the one comment kind that always reaches these scans from a reactive statement.

Found while investigating #2572, which stops stripping `$:` comments and so turns the first class into a corpus failure on `layercake`, `svelte-table` and `svelte-ux`. It is split out here because both defects predate that PR and are reachable without it — `git log` will otherwise attribute a bug to the change that merely uncovered it.

## Verification

`crates/rsvelte_core/tests/comment_quote_read_scans.rs` — the line-comment store case, the `svelte-ignore` prop case, a block-comment case (the other branch), and a **control** asserting an identifier inside a real string literal is still left alone, so the fix reads as "comments are not strings" rather than "quote tracking was dropped".

Locally green: `--lib` 1508, `runtime` (release) 5/5, `ssr`, `print`, `css`, `validator`, `client_transforms_pin`, `compiler_fixtures`, `cargo clippy --all-targets --all-features -- -D warnings`.

Against the corpus seeds this was reduced from, using the gate's own `flattenTemplateHoles → oxfmt → stripBlankLines` chain: `layercake/src/lib/LayerCake.svelte` goes from mismatching to **MATCH**, and `svelte-table` loses both `filterSelections()` divergences.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sb9ucum4Cxu99K1WCeyGC8
