### PR TITLE
perf(compiler): build a warning frame from the shared line index

### DIFF
--- a/.changeset/warning-frame-line-index.md
+++ b/.changeset/warning-frame-line-index.md
@@ -1,0 +1,5 @@
+---
+'@rsvelte/compiler': patch
+---
+
+Build a warning's code frame from the shared line index instead of splitting the whole source once per warning, so a file with many spanned warnings no longer costs O(source × warnings).

--- a/crates/rsvelte_core/src/compiler/legacy.rs
+++ b/crates/rsvelte_core/src/compiler/legacy.rs
@@ -156,6 +156,24 @@ impl Utf8ToUtf16 {
         // Return column as offset from line start in UTF-16
         abs_utf16_pos.saturating_sub(line_start_utf16)
     }
+
+    /// Number of lines, counted the way JavaScript's `split('\n')` does — a
+    /// trailing newline yields a final empty line.
+    pub fn line_count(&self) -> usize {
+        self.line_starts_byte.len()
+    }
+
+    /// The 0-indexed `line` of `source`, without its terminator. `source` must
+    /// be the string this table was built from.
+    pub fn line_text<'s>(&self, source: &'s str, line: usize) -> &'s str {
+        let start = self.line_starts_byte[line];
+        let end = match self.line_starts_byte.get(line + 1) {
+            // The next line starts one byte past this line's `\n`.
+            Some(&next) => next - 1,
+            None => source.len(),
+        };
+        &source[start..end]
+    }
 }
 
 /// Recursively convert positions in JSON from UTF-8 to UTF-16.

--- a/crates/rsvelte_core/src/compiler/mod.rs
+++ b/crates/rsvelte_core/src/compiler/mod.rs
@@ -452,28 +452,32 @@ fn warning_position(table: &legacy::Utf8ToUtf16, offset: u32) -> Position {
 /// Generate a source code frame snippet for a warning/error.
 /// Shows 2 lines of context before and after, with a caret pointing to the column.
 /// Matches the official Svelte compiler's `locate_with_frame` output.
-fn generate_frame(source: &str, start_pos: &Position, end_pos: Option<&Position>) -> String {
+fn generate_frame(
+    source: &str,
+    table: &legacy::Utf8ToUtf16,
+    start_pos: &Position,
+    end_pos: Option<&Position>,
+) -> String {
     // Match the official compiler's get_code_frame behavior:
     // - Uses start.line - 1 (0-indexed) for the target line
     // - Uses end.column for the caret position
     // - Converts tabs to 2 spaces
-    // Use split('\n') to match JS behavior (includes trailing empty string after final newline)
-    let lines: Vec<&str> = source.split('\n').collect();
+    // A frame quotes five lines, so it reads them out of the line index the
+    // position conversion already built rather than splitting the whole source
+    // once per warning.
     let line_idx = start_pos.line.saturating_sub(1);
     let frame_start = line_idx.saturating_sub(2);
     // Match JS: Math.min(line + 3, lines.length) — exclusive upper bound
-    let frame_end = (line_idx + 3).min(lines.len());
+    let frame_end = (line_idx + 3).min(table.line_count());
 
     // Determine the column for the caret (official compiler uses end.column)
     let caret_column = end_pos.map_or(start_pos.column, |ep| ep.column);
 
     let digits = format!("{}", frame_end + 1).len();
 
-    lines[frame_start..frame_end]
-        .iter()
-        .enumerate()
-        .map(|(i, &line)| {
-            let actual_line = frame_start + i;
+    (frame_start..frame_end)
+        .map(|actual_line| {
+            let line = table.line_text(source, actual_line);
             let line_num = actual_line + 1;
             let line_content = tabs_to_spaces(line);
             if actual_line == line_idx {
@@ -793,7 +797,7 @@ pub(crate) fn finalize_compile_result(
                     let end_pos = w.end.map(|offset| warning_position(&pos_table, offset));
                     let frame = start_pos
                         .as_ref()
-                        .map(|sp| generate_frame(source, sp, end_pos.as_ref()));
+                        .map(|sp| generate_frame(source, &pos_table, sp, end_pos.as_ref()));
                     let url_suffix = format!("\nhttps://svelte.dev/e/{}", w.code);
                     let message_with_url = if w.message.contains(&url_suffix) {
                         w.message
@@ -1053,7 +1057,7 @@ pub fn compile_module(
                     let end_pos = w.end.map(|offset| warning_position(&pos_table, offset));
                     let frame = start_pos
                         .as_ref()
-                        .map(|sp| generate_frame(source, sp, end_pos.as_ref()));
+                        .map(|sp| generate_frame(source, &pos_table, sp, end_pos.as_ref()));
                     let url_suffix = format!("\nhttps://svelte.dev/e/{}", w.code);
                     let message_with_url = if w.message.contains(&url_suffix) {
                         w.message.clone()

--- a/crates/rsvelte_core/tests/warning_frame_line_index.rs
+++ b/crates/rsvelte_core/tests/warning_frame_line_index.rs
@@ -1,0 +1,120 @@
+//! A warning frame quotes five lines, and it used to find them by splitting the
+//! whole source into a `Vec<&str>` — once per warning, so a file with many
+//! spanned warnings paid O(source × warnings). It now reads those five lines
+//! out of the line index the position conversion already builds.
+//!
+//! Slicing by byte offset and `split('\n')` agree on ordinary input, so the
+//! cases below are the ones where they can drift: a `\r` that belongs to the
+//! line rather than to the terminator, multi-byte characters that move byte
+//! offsets away from column offsets, the first and last line, an empty line,
+//! and the phantom final line a trailing newline produces.
+
+use rsvelte_core::{CompileOptions, GenerateMode, Warning, compile};
+
+fn warnings(src: &str) -> Vec<Warning> {
+    compile(
+        src,
+        CompileOptions {
+            filename: Some("Main.svelte".to_string()),
+            generate: GenerateMode::Client,
+            ..Default::default()
+        },
+    )
+    .expect("compile")
+    .warnings
+}
+
+/// The frame of the first warning, which every case here arranges to exist.
+fn frame(src: &str) -> String {
+    let ws = warnings(src);
+    let w = ws
+        .first()
+        .unwrap_or_else(|| panic!("no warning for {src:?}"));
+    w.frame
+        .clone()
+        .unwrap_or_else(|| panic!("`{}` has no frame", w.code))
+}
+
+/// Warns `a11y_missing_attribute` on the element, so each case below only has
+/// to place it where the line lookup is interesting.
+const WARN: &str = "<img src=\"a\">";
+
+#[test]
+fn a_warning_on_the_only_line_quotes_that_line() {
+    assert_eq!(frame(WARN), "1: <img src=\"a\">\n                ^");
+}
+
+#[test]
+fn a_warning_on_the_last_line_without_a_trailing_newline_quotes_it() {
+    let src = format!("<p>a</p>\n<p>b</p>\n{WARN}");
+    assert_eq!(
+        frame(&src),
+        "1: <p>a</p>\n2: <p>b</p>\n3: <img src=\"a\">\n                ^"
+    );
+}
+
+/// A trailing newline makes `split('\n')` yield a final empty line, and the
+/// frame's upper bound is clamped to that count, so the index has to report the
+/// same number of lines.
+#[test]
+fn a_trailing_newline_adds_an_empty_last_line() {
+    let src = format!("{WARN}\n<p>a</p>\n");
+    assert_eq!(
+        frame(&src),
+        "1: <img src=\"a\">\n                ^\n2: <p>a</p>\n3: "
+    );
+}
+
+/// CRLF: `split('\n')` leaves the `\r` on the end of each line, so the slice
+/// has to stop at the `\n` and not at the `\r`.
+#[test]
+fn crlf_leaves_the_carriage_return_on_the_line() {
+    let src = format!("<p>a</p>\r\n{WARN}\r\n<p>b</p>");
+    assert_eq!(
+        frame(&src),
+        "1: <p>a</p>\r\n2: <img src=\"a\">\r\n                ^\n3: <p>b</p>"
+    );
+}
+
+/// Multi-byte characters ahead of the warning move the byte offsets away from
+/// the character offsets. The quoted line is still the whole line, and slicing
+/// it must land on a character boundary rather than panic.
+#[test]
+fn multibyte_lines_before_the_warning_do_not_shift_the_slice() {
+    let src = format!("<p>日本語のテキスト</p>\n<p>🎉🎉🎉</p>\n{WARN}");
+    assert_eq!(
+        frame(&src),
+        "1: <p>日本語のテキスト</p>\n2: <p>🎉🎉🎉</p>\n3: <img src=\"a\">\n                ^"
+    );
+}
+
+/// Leading tabs are rendered as two spaces each and the caret shifts to match,
+/// so the slice must keep the tabs rather than the line's trimmed text.
+#[test]
+fn leading_tabs_are_still_expanded_in_the_quoted_line() {
+    let src = format!("<p>a</p>\n\t\t{WARN}");
+    assert_eq!(
+        frame(&src),
+        "1: <p>a</p>\n2:     <img src=\"a\">\n                    ^"
+    );
+}
+
+/// Two lines of context on each side, so the window is neither clamped end.
+#[test]
+fn a_warning_in_the_middle_quotes_two_lines_on_each_side() {
+    let src = format!("<p>a</p>\n<p>b</p>\n<p>c</p>\n{WARN}\n<p>d</p>\n<p>e</p>\n<p>f</p>");
+    assert_eq!(
+        frame(&src),
+        "2: <p>b</p>\n3: <p>c</p>\n4: <img src=\"a\">\n                ^\n5: <p>d</p>\n6: <p>e</p>"
+    );
+}
+
+/// Empty lines are zero-length slices between adjacent line starts.
+#[test]
+fn empty_context_lines_are_quoted_as_empty() {
+    let src = format!("\n\n{WARN}\n\n");
+    assert_eq!(
+        frame(&src),
+        "1: \n2: \n3: <img src=\"a\">\n                ^\n4: \n5: "
+    );
+}


### PR DESCRIPTION
A warning's code frame quotes five source lines. `generate_frame` reached them with

```rust
let lines: Vec<&str> = source.split('\n').collect();
```

— a full scan and allocation of the whole source, **once per warning that has a position**. A file that warns a lot pays O(source × warnings) to print O(warnings × 5) lines.

The line starts it needs are already computed: the caller builds one `legacy::Utf8ToUtf16` per compile to turn warning byte offsets into line/column, and that table holds `line_starts_byte`. The frame now takes the table and slices its five lines straight out of `source`.

## Measured

3200 `<img src="a">` lines (44.8 KB, 3200 warnings), release, whole `compile` call, warm — steady-state of three runs each:

| | 400 | 800 | 1600 | 3200 |
|---|---|---|---|---|
| before | 18.1 ms | 25.1 ms | 46.8 ms | 126 ms |
| after | 3.4 ms | 2.8 ms | 5.4 ms | 13 ms |

Before grows ~2.7× per doubling; after grows ~2×. The absolute numbers are noisy (shared machine), the shape is not.

This is why I opened it separately rather than folding it into #2402: that PR gives spans to five warnings that previously had none, which moves them from "no frame" to "one full source scan each", and CodSpeed scored it a **-12% regression on all three `synthetic-state-heavy` benchmarks**. The quadratic is not #2402's — it is reachable on `main` today through any warning that already carries a position, which is most of them.

## Byte-identical output

Not argued, measured. Both implementations were run against the same eight shapes — the ones where slicing by offset can drift from `split('\n')`:

CRLF (the `\r` belongs to the line, not the terminator), multi-byte characters before the warning, the only line, the last line with no trailing newline, the phantom empty line a trailing newline produces, empty context lines, a window clamped at neither end, leading tabs.

`diff` is clean on all eight. As a control that the harness observes this function at all, the old `split` was poisoned to return `"POISON"` per line and the dump changed on 25 lines.

Those eight shapes are pinned in `crates/rsvelte_core/tests/warning_frame_line_index.rs`, with the expected strings taken from the **pre-change** implementation rather than written by hand.

Also green: `--lib` 1508, `compiler_fixtures`, `validator`, `css`, `cargo clippy --all-targets --all-features -- -D warnings`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sb9ucum4Cxu99K1WCeyGC8
