### PR TITLE
perf(transform): attribute SemanticBuilder builds per site, gate them on a token probe

### DIFF
--- a/.changeset/semantic-build-token-probe.md
+++ b/.changeset/semantic-build-token-probe.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/compiler": patch
+---
+
+Attribute `SemanticBuilder` builds per call site and skip the ones a whole-identifier probe rules out

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/ast_state_transform.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/ast_state_transform.rs
@@ -4655,6 +4655,10 @@ fn collect_state_var_replacements(
         .collect();
     let raw_set: FxHashSet<&str> = config.raw_state_vars.iter().map(String::as_str).collect();
     let semantic_ret = state_assignment_needs_semantic(program, &var_set).then(|| {
+        super::super::profile::record_semantic_build(
+            super::super::profile::SEM_AST_STATE_TRANSFORM,
+            program.source_text.len(),
+        );
         oxc_semantic::SemanticBuilder::new()
             .with_build_nodes(true)
             .build(program)

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/prop_assign_ast.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/prop_assign_ast.rs
@@ -48,12 +48,13 @@ use oxc_ast::ast::*;
 use oxc_ast_visit::Visit;
 use oxc_ast_visit::walk;
 use oxc_parser::ParseOptions;
+use oxc_semantic::{Semantic, SemanticBuilder};
 use oxc_span::GetSpan;
 use oxc_span::SourceType;
 use oxc_syntax::operator::AssignmentOperator;
 use oxc_syntax::operator::BinaryOperator;
 
-use oxc_semantic::{Semantic, SemanticBuilder};
+use crate::compiler::phases::phase3_transform::shared::js_scan::contains_identifier;
 
 use super::ast_rewrite::{self, Edit};
 use super::scope_analysis::is_locally_shadowed;
@@ -76,10 +77,7 @@ fn transform_prop_assign_spliced(source: &str, prop_vars: &[String]) -> Option<S
     if prop_vars.is_empty() {
         return None;
     }
-    if !prop_vars
-        .iter()
-        .any(|s| memchr::memmem::find(source.as_bytes(), s.as_bytes()).is_some())
-    {
+    if !prop_vars.iter().any(|v| contains_identifier(source, v)) {
         return None;
     }
 
@@ -91,6 +89,10 @@ fn transform_prop_assign_spliced(source: &str, prop_vars: &[String]) -> Option<S
             ParseOptions::default(),
             true,
             |program| {
+                super::super::profile::record_semantic_build(
+                    super::super::profile::SEM_PROP_ASSIGN,
+                    program.source_text.len(),
+                );
                 let semantic_ret = SemanticBuilder::new().with_build_nodes(true).build(program);
                 let semantic = &semantic_ret.semantic;
                 let mut collector = PropAssignCollector {
@@ -360,10 +362,7 @@ pub(crate) fn transform_prop_assign_in_place(
     if prop_vars.is_empty() {
         return ast_rewrite::Rewrite::Unchanged;
     }
-    if !prop_vars
-        .iter()
-        .any(|s| memchr::memmem::find(source.as_bytes(), s.as_bytes()).is_some())
-    {
+    if !prop_vars.iter().any(|v| contains_identifier(source, v)) {
         return ast_rewrite::Rewrite::Unchanged;
     }
 
@@ -377,6 +376,10 @@ pub(crate) fn transform_prop_assign_in_place(
         ParseOptions::default(),
         |allocator, program| {
             let targets = {
+                super::super::profile::record_semantic_build(
+                    super::super::profile::SEM_PROP_ASSIGN_IN_PLACE,
+                    program.source_text.len(),
+                );
                 let semantic_ret = SemanticBuilder::new().with_build_nodes(true).build(program);
                 let mut finder = PropAssignFinder {
                     prop_vars,

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/prop_source_reads_ast.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/prop_source_reads_ast.rs
@@ -65,6 +65,8 @@ use oxc_ast_visit::{Visit, walk};
 use oxc_parser::ParseOptions;
 use oxc_semantic::{Semantic, SemanticBuilder};
 use oxc_span::SourceType;
+
+use crate::compiler::phases::phase3_transform::shared::js_scan::contains_identifier;
 use rustc_hash::FxHashSet;
 
 use super::ast_rewrite;
@@ -93,12 +95,9 @@ pub fn wrap_prop_source_reads_ast(
     {
         return None;
     }
-    // Fast probe — bail unless at least one prop var actually
-    // appears in the source.
-    if !prop_vars
-        .iter()
-        .any(|v| memchr::memmem::find(source.as_bytes(), v.as_bytes()).is_some())
-    {
+    // Fast probe — bail unless at least one prop var appears as a
+    // whole identifier token.
+    if !prop_vars.iter().any(|v| contains_identifier(source, v)) {
         return None;
     }
 
@@ -136,6 +135,10 @@ pub fn wrap_prop_source_reads_ast(
             ..ParseOptions::default()
         },
         |program| {
+            super::super::profile::record_semantic_build(
+                super::super::profile::SEM_PROP_SOURCE_READS,
+                program.source_text.len(),
+            );
             let semantic_ret = SemanticBuilder::new().with_build_nodes(true).build(program);
             let semantic = &semantic_ret.semantic;
 

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/read_only_props_ast.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/read_only_props_ast.rs
@@ -109,6 +109,10 @@ pub fn transform_read_only_props_ast(
             ..ParseOptions::default()
         },
         |program| {
+            super::super::profile::record_semantic_build(
+                super::super::profile::SEM_READ_ONLY_PROPS,
+                program.source_text.len(),
+            );
             let semantic_ret = SemanticBuilder::new().with_build_nodes(true).build(program);
             let semantic = &semantic_ret.semantic;
 

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/scope_analysis.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/scope_analysis.rs
@@ -70,6 +70,10 @@ where
     // Move the program into the arena so both it and the Semantic
     // can be borrowed for the closure lifetime.
     let program: &Program = allocator.alloc(parser_ret.program);
+    super::super::profile::record_semantic_build(
+        super::super::profile::SEM_SCOPE_ANALYSIS,
+        program.source_text.len(),
+    );
     let semantic_ret = SemanticBuilder::new().with_build_nodes(true).build(program);
     Some(f(program, &semantic_ret.semantic))
 }

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/state_assigns_combined_ast.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/state_assigns_combined_ast.rs
@@ -52,6 +52,8 @@ use oxc_syntax::operator::{
     AssignmentOperator, BinaryOperator, LogicalOperator, UnaryOperator, UpdateOperator,
 };
 use oxc_syntax::symbol::SymbolId;
+
+use crate::compiler::phases::phase3_transform::shared::js_scan::contains_identifier;
 use rustc_hash::FxHashSet;
 
 use super::ast_rewrite::{self, Edit};
@@ -101,16 +103,13 @@ pub fn transform_state_assigns_ast(
 }
 
 /// The three probes are pure cost avoidance: no state variable named in
-/// `state_vars` can be assigned without its name and an assignment token both
-/// appearing literally in `source`.
+/// `state_vars` can be assigned without its name appearing in `source` as a
+/// whole identifier token and an assignment token appearing too.
 fn has_candidate(source: &str, state_vars: &[String]) -> bool {
     if state_vars.is_empty() {
         return false;
     }
-    if !state_vars
-        .iter()
-        .any(|v| memchr::memmem::find(source.as_bytes(), v.as_bytes()).is_some())
-    {
+    if !state_vars.iter().any(|v| contains_identifier(source, v)) {
         return false;
     }
     // Cheapest probe — at least one `=` or `++`/`--` token.
@@ -151,6 +150,10 @@ fn single_pass(
             ..ParseOptions::default()
         },
         |program| {
+            super::super::profile::record_semantic_build(
+                super::super::profile::SEM_STATE_ASSIGNS,
+                program.source_text.len(),
+            );
             let semantic_ret = SemanticBuilder::new().with_build_nodes(true).build(program);
             let semantic = &semantic_ret.semantic;
             let state_var_symbols = find_state_var_symbols(semantic, state_vars);
@@ -407,6 +410,10 @@ fn transform_state_assigns_in_place(
         },
         |allocator, program| {
             let targets = {
+                super::super::profile::record_semantic_build(
+                    super::super::profile::SEM_STATE_ASSIGNS_IN_PLACE,
+                    program.source_text.len(),
+                );
                 let semantic_ret = SemanticBuilder::new().with_build_nodes(true).build(program);
                 let semantic = &semantic_ret.semantic;
                 let state_var_symbols = find_state_var_symbols(semantic, state_vars);

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/state_call_ast.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/state_call_ast.rs
@@ -51,6 +51,10 @@ pub(super) fn collect_state_call_edits(
     ambiguous_vars: &[String],
     non_proxy_vars: &[String],
 ) -> Vec<Edit> {
+    super::super::profile::record_semantic_build(
+        super::super::profile::SEM_STATE_CALL,
+        program.source_text.len(),
+    );
     let semantic_ret = SemanticBuilder::new().build(program);
     let mut collector = StateCallCollector {
         source,

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/state_pipeline_ast.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/state_pipeline_ast.rs
@@ -46,6 +46,8 @@ use oxc_syntax::operator::{
     AssignmentOperator, BinaryOperator, LogicalOperator, UnaryOperator, UpdateOperator,
 };
 use oxc_syntax::symbol::SymbolId;
+
+use crate::compiler::phases::phase3_transform::shared::js_scan::contains_identifier;
 use rustc_hash::{FxHashMap, FxHashSet};
 
 use super::ast_rewrite::{self, Edit};
@@ -77,10 +79,7 @@ pub fn transform_state_pipeline_ast(
         .filter(|v| !non_reactive_vars.iter().any(|n| n == *v))
         .cloned()
         .collect();
-    if !state_vars
-        .iter()
-        .any(|v| memchr::memmem::find(source.as_bytes(), v.as_bytes()).is_some())
-    {
+    if !state_vars.iter().any(|v| contains_identifier(source, v)) {
         return None;
     }
     if memchr::memchr(b'=', source.as_bytes()).is_none()
@@ -88,7 +87,7 @@ pub fn transform_state_pipeline_ast(
         && memchr::memmem::find(source.as_bytes(), b"--").is_none()
         && !effective_read_names
             .iter()
-            .any(|v| memchr::memmem::find(source.as_bytes(), v.as_bytes()).is_some())
+            .any(|v| contains_identifier(source, v))
     {
         return None;
     }
@@ -135,6 +134,10 @@ fn single_pass(
             ..ParseOptions::default()
         },
         |program| {
+            super::super::profile::record_semantic_build(
+                super::super::profile::SEM_STATE_PIPELINE,
+                program.source_text.len(),
+            );
             let semantic_ret = SemanticBuilder::new().with_build_nodes(true).build(program);
             let semantic = &semantic_ret.semantic;
             let state_var_symbols = find_state_var_symbols(semantic, state_vars);
@@ -752,6 +755,10 @@ fn transform_state_pipeline_in_place(
         },
         |allocator, program| {
             let sites = {
+                super::super::profile::record_semantic_build(
+                    super::super::profile::SEM_STATE_PIPELINE_IN_PLACE,
+                    program.source_text.len(),
+                );
                 let semantic_ret = SemanticBuilder::new().with_build_nodes(true).build(program);
                 let semantic = &semantic_ret.semantic;
                 let state_var_symbols = find_state_var_symbols(semantic, state_vars);

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/state_reads_ast.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/state_reads_ast.rs
@@ -67,6 +67,8 @@ use oxc_parser::ParseOptions;
 use oxc_semantic::{Semantic, SemanticBuilder};
 use oxc_span::SourceType;
 use oxc_syntax::symbol::SymbolId;
+
+use crate::compiler::phases::phase3_transform::shared::js_scan::contains_identifier;
 use rustc_hash::FxHashSet;
 
 use super::ast_rewrite;
@@ -173,11 +175,8 @@ pub fn transform_state_reads_ast(
         return None;
     }
     // Fast probe — bail unless at least one effective state-var
-    // substring appears.
-    if !effective
-        .iter()
-        .any(|v| memchr::memmem::find(source.as_bytes(), v.as_bytes()).is_some())
-    {
+    // appears as a whole identifier token.
+    if !effective.iter().any(|v| contains_identifier(source, v)) {
         return None;
     }
     // Bare-object-literal handling: input starting with `{` AND
@@ -220,6 +219,10 @@ pub fn transform_state_reads_ast(
             ..ParseOptions::default()
         },
         |program| {
+            super::super::profile::record_semantic_build(
+                super::super::profile::SEM_STATE_READS,
+                program.source_text.len(),
+            );
             let semantic_ret = SemanticBuilder::new().with_build_nodes(true).build(program);
             let semantic = &semantic_ret.semantic;
             let effective_names: Vec<String> = effective.iter().map(|s| s.to_string()).collect();

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/profile.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/profile.rs
@@ -535,6 +535,62 @@ pub fn take_breakdown() -> Phase3Breakdown {
     }
 }
 
+/// Per-call-site `SemanticBuilder::build` accounting.
+///
+/// The scope-tree / symbol-table build is a fixed cost per call, so the useful
+/// unit is builds-per-file, not bytes walked: knowing the total is hot does not
+/// say which pass to fix.
+pub const SEMANTIC_SITES: [&str; 14] = [
+    "server/rune_call",
+    "server/derived_reads",
+    "client/state_pipeline",
+    "client/state_pipeline.in_place",
+    "client/state_call",
+    "client/state_reads",
+    "client/read_only_props",
+    "client/state_assigns",
+    "client/state_assigns.in_place",
+    "client/prop_assign",
+    "client/prop_assign.in_place",
+    "client/scope_analysis",
+    "client/ast_state_transform",
+    "client/prop_source_reads",
+];
+
+pub const SEM_SERVER_RUNE_CALL: usize = 0;
+pub const SEM_SERVER_DERIVED_READS: usize = 1;
+pub const SEM_STATE_PIPELINE: usize = 2;
+pub const SEM_STATE_PIPELINE_IN_PLACE: usize = 3;
+pub const SEM_STATE_CALL: usize = 4;
+pub const SEM_STATE_READS: usize = 5;
+pub const SEM_READ_ONLY_PROPS: usize = 6;
+pub const SEM_STATE_ASSIGNS: usize = 7;
+pub const SEM_STATE_ASSIGNS_IN_PLACE: usize = 8;
+pub const SEM_PROP_ASSIGN: usize = 9;
+pub const SEM_PROP_ASSIGN_IN_PLACE: usize = 10;
+pub const SEM_SCOPE_ANALYSIS: usize = 11;
+pub const SEM_AST_STATE_TRANSFORM: usize = 12;
+pub const SEM_PROP_SOURCE_READS: usize = 13;
+
+thread_local! {
+    static SEMANTIC_BUILDS: Cell<[(u64, u64); SEMANTIC_SITES.len()]> =
+        const { Cell::new([(0, 0); SEMANTIC_SITES.len()]) };
+}
+
+#[inline]
+pub fn record_semantic_build(site: usize, bytes: usize) {
+    SEMANTIC_BUILDS.with(|c| {
+        let mut counts = c.get();
+        counts[site].0 += 1;
+        counts[site].1 += bytes as u64;
+        c.set(counts);
+    });
+}
+
+pub fn take_semantic_builds() -> [(u64, u64); SEMANTIC_SITES.len()] {
+    SEMANTIC_BUILDS.replace([(0, 0); SEMANTIC_SITES.len()])
+}
+
 /// Agreement between the one-pass indices and the per-variable scans they
 /// replace.
 ///

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/derived_reads_ast.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/derived_reads_ast.rs
@@ -82,6 +82,10 @@ pub(crate) fn wrap_derived_reads_ast(
             ..ParseOptions::default()
         },
         |program| {
+            super::super::profile::record_semantic_build(
+                super::super::profile::SEM_SERVER_DERIVED_READS,
+                program.source_text.len(),
+            );
             let semantic_ret = SemanticBuilder::new().build(program);
             let semantic = &semantic_ret.semantic;
 

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/rune_call_ast.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/rune_call_ast.rs
@@ -96,6 +96,10 @@ pub(crate) fn transform_rune_calls_combined(script: &str, prefixes: &[&str]) -> 
             ..ParseOptions::default()
         },
         |program| {
+            super::super::profile::record_semantic_build(
+                super::super::profile::SEM_SERVER_RUNE_CALL,
+                program.source_text.len(),
+            );
             let semantic_ret = SemanticBuilder::new().build(program);
             let mut collector = RuneCallCollector {
                 semantic: &semantic_ret.semantic,

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/shared/js_scan.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/shared/js_scan.rs
@@ -128,3 +128,75 @@ pub(crate) fn skip_opaque(bytes: &[u8], i: usize, prev: Option<u8>) -> Option<(u
         _ => None,
     }
 }
+
+/// Does `name` occur in `source` as a whole identifier token?
+///
+/// The rewrite passes only ever replace an identifier spelled exactly `name`,
+/// so a substring hit inside a longer identifier (`count` in `counter`) can
+/// never become an edit — but it still costs a parse plus a `SemanticBuilder`
+/// build. Boundary characters are tested per `char`, so a multi-byte
+/// identifier neighbour is not mistaken for a separator.
+pub(crate) fn contains_identifier(source: &str, name: &str) -> bool {
+    if name.is_empty() {
+        return false;
+    }
+    let bytes = source.as_bytes();
+    for at in memchr::memmem::find_iter(bytes, name.as_bytes()) {
+        let end = at + name.len();
+        if !source.is_char_boundary(at) || !source.is_char_boundary(end) {
+            continue;
+        }
+        if source[..at].chars().next_back().is_some_and(is_ident_char) {
+            continue;
+        }
+        if source[end..].chars().next().is_some_and(is_ident_char) {
+            continue;
+        }
+        return true;
+    }
+    false
+}
+
+fn is_ident_char(c: char) -> bool {
+    c.is_alphanumeric() || c == '_' || c == '$'
+}
+
+#[cfg(test)]
+mod tests {
+    use super::contains_identifier;
+
+    #[test]
+    fn whole_token_matches() {
+        assert!(contains_identifier("let count = 1;", "count"));
+        assert!(contains_identifier("count", "count"));
+        assert!(contains_identifier("obj.count += 1", "count"));
+        assert!(contains_identifier("{ count }", "count"));
+        assert!(contains_identifier("`${count}`", "count"));
+    }
+
+    #[test]
+    fn substring_of_longer_identifier_does_not_match() {
+        assert!(!contains_identifier("let counter = 1;", "count"));
+        assert!(!contains_identifier("discount = 1;", "count"));
+        assert!(!contains_identifier("$count2", "count"));
+        assert!(!contains_identifier("a_count_b", "count"));
+    }
+
+    #[test]
+    fn dollar_prefixed_store_names_need_the_dollar() {
+        assert!(contains_identifier("$store;", "$store"));
+        assert!(!contains_identifier("$store;", "store"));
+    }
+
+    #[test]
+    fn non_ascii_neighbours_are_read_as_chars() {
+        assert!(!contains_identifier("日count", "count"));
+        assert!(!contains_identifier("count日", "count"));
+        assert!(contains_identifier("「count」", "count"));
+    }
+
+    #[test]
+    fn later_occurrence_still_matches() {
+        assert!(contains_identifier("counter; count;", "count"));
+    }
+}

--- a/crates/rsvelte_devtools/src/bin/semantic_sites.rs
+++ b/crates/rsvelte_devtools/src/bin/semantic_sites.rs
@@ -1,0 +1,148 @@
+//! Per-call-site `SemanticBuilder::build` census over a real `.svelte` corpus.
+//!
+//! Counts, not times, so the answer does not move with machine load. The unit
+//! that matters is builds/file: the scope-tree + symbol-table build is a fixed
+//! cost per call, and the per-statement transform chain pays it once per
+//! statement.
+//!
+//! ```text
+//! cargo run --release -p rsvelte_devtools --bin semantic_sites -- \
+//!   --corpus submodules/flowbite-svelte
+//! ```
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use rsvelte_core::compiler::phases::phase3_transform::profile;
+use rsvelte_core::{CompileOptions, GenerateMode};
+
+#[derive(Clone, Copy)]
+struct Mode {
+    label: &'static str,
+    generate: GenerateMode,
+    dev: bool,
+}
+
+const MODES: [Mode; 3] = [
+    Mode {
+        label: "client-prod",
+        generate: GenerateMode::Client,
+        dev: false,
+    },
+    Mode {
+        label: "client-dev",
+        generate: GenerateMode::Client,
+        dev: true,
+    },
+    Mode {
+        label: "server-prod",
+        generate: GenerateMode::Server,
+        dev: false,
+    },
+];
+
+impl Mode {
+    fn options(self) -> CompileOptions {
+        CompileOptions {
+            generate: self.generate,
+            dev: self.dev,
+            enable_sourcemap: true,
+            ..Default::default()
+        }
+    }
+}
+
+fn main() {
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    let base = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..");
+    let roots: Vec<PathBuf> = args
+        .iter()
+        .enumerate()
+        .filter(|(i, a)| a.as_str() == "--corpus" && *i + 1 < args.len())
+        .map(|(i, _)| base.join(&args[i + 1]))
+        .collect();
+    let only_mode = args
+        .iter()
+        .position(|a| a == "--mode")
+        .and_then(|i| args.get(i + 1))
+        .cloned();
+
+    let mut files: Vec<String> = Vec::new();
+    for root in &roots {
+        walk(root, &mut files);
+    }
+    if files.is_empty() {
+        eprintln!("no .svelte files under {roots:?}");
+        std::process::exit(2);
+    }
+
+    for mode in MODES
+        .iter()
+        .filter(|m| only_mode.as_deref().is_none_or(|w| w == m.label))
+    {
+        let opts = mode.options();
+        // A file that fails to compile still runs part of the chain; count the
+        // ones that produced output so builds/file has a stable denominator.
+        let mut compiled = 0u64;
+        let _ = profile::take_semantic_builds();
+        for src in &files {
+            if rsvelte_core::compile(src, opts.clone()).is_ok() {
+                compiled += 1;
+            }
+        }
+        let counts = profile::take_semantic_builds();
+        let n = compiled as f64;
+        let total: u64 = counts.iter().map(|(c, _)| c).sum();
+        println!(
+            "\n## {} — {} files scanned, {compiled} compiled",
+            mode.label,
+            files.len()
+        );
+        println!(
+            "{:<34} {:>12} {:>12} {:>12}",
+            "site", "builds", "per file", "bytes/build"
+        );
+        let mut rows: Vec<(usize, u64, u64)> = counts
+            .iter()
+            .enumerate()
+            .map(|(s, &(c, b))| (s, c, b))
+            .collect();
+        rows.sort_by_key(|r| std::cmp::Reverse(r.1));
+        for (site, c, b) in rows {
+            if c == 0 {
+                continue;
+            }
+            println!(
+                "{:<34} {:>12} {:>12.2} {:>12.0}",
+                profile::SEMANTIC_SITES[site],
+                c,
+                c as f64 / n,
+                b as f64 / c as f64
+            );
+        }
+        println!("{:<34} {:>12} {:>12.2}", "TOTAL", total, total as f64 / n);
+    }
+}
+
+fn walk(dir: &Path, out: &mut Vec<String>) {
+    let Ok(entries) = fs::read_dir(dir) else {
+        return;
+    };
+    let mut paths: Vec<PathBuf> = entries.flatten().map(|e| e.path()).collect();
+    paths.sort();
+    for path in paths {
+        if path.is_dir() {
+            if path
+                .file_name()
+                .is_some_and(|n| n == "node_modules" || n == ".git")
+            {
+                continue;
+            }
+            walk(&path, out);
+        } else if path.extension().is_some_and(|e| e == "svelte")
+            && let Ok(content) = fs::read_to_string(&path)
+        {
+            out.push(content);
+        }
+    }
+}


### PR DESCRIPTION
## Why

A samply profile put the oxc AST walk near the top of Phase 3 self time, and a
counter on every `SemanticBuilder::new()` site put shipped legacy components at
11-21 builds per file at ~168 source bytes each. That says the cost is the fixed
per-build cost — scope tree, symbol table, node list — paid once per *statement*
by the per-statement chain in `process_accumulated`, not traversal volume.

It does not say **which** pass. There are 14 build sites. This PR makes that
question answerable, then removes the builds a cheap probe can rule out.

## What

**1. Per-site attribution.** `profile::SEMANTIC_SITES` + `record_semantic_build`
label all 14 sites and record `(builds, source bytes)` each.
`cargo run --release -p rsvelte_devtools --bin semantic_sites -- --corpus <dir>`
prints the census. Counts, not times, so the answer does not move with machine
load.

**2. A whole-identifier probe.** The census puts nearly all of it in four client
passes, each already gated by `memmem::find(source, var_name)` — a *substring*
test. `count` inside `counter` passes that test and can never become an edit:
these passes only replace an identifier spelled exactly that name.
`js_scan::contains_identifier` requires a whole-token occurrence, testing
boundary characters per `char` so a multi-byte identifier neighbour is not read
as a separator.

## Attribution table (builds/file, client-prod)

Measured with the same binary, swapping only the body of `contains_identifier`
between the old substring test and the new token test — so nothing else differs
between the two rows.

| corpus | prop_source_reads | prop_assign.in_place | state_reads | state_assigns.in_place | state_pipeline.in_place | TOTAL |
|---|---|---|---|---|---|---|
| svelthree | 95.62 → 75.67 | 74.33 → 74.33 | 79.10 → 48.43 | 53.67 → 42.05 | 2.19 → 0.00 | **304.90 → 240.48** |
| smelte | 2.80 → 1.61 | 2.43 → 2.43 | 3.85 → 1.53 | 3.97 → 2.16 | 1.62 → 0.00 | **14.68 → 7.73** |
| powertable | 0.43 → 0.43 | 0.43 → 0.43 | 4.21 → 4.07 | 3.29 → 3.14 | – | **8.36 → 8.07** |
| sveltestrap | 2.20 → 2.05 | 2.83 → 2.83 | 1.48 → 1.48 | 1.67 → 1.67 | – | **8.19 → 8.03** |
| attractions | 2.65 → 2.45 | 2.63 → 2.63 | 1.29 → 1.28 | 1.15 → 1.15 | – | **7.72 → 7.51** |
| svelte-ux | 1.16 → 1.09 | 1.39 → 1.39 | 1.77 → 1.67 | 1.97 → 1.95 | 0.01 → 0.00 | **6.30 → 6.10** |
| svelte-calendar | 0.77 → 0.75 | 0.81 → 0.81 | 1.81 → 1.67 | 1.56 → 1.48 | 0.08 → 0.00 | **5.04 → 4.71** |
| svelte-form-builder | 0.61 → 0.53 | 0.69 → 0.69 | 1.74 → 1.62 | 1.49 → 1.43 | – | **4.53 → 4.27** |
| layercake | 0.84 → 0.67 | 0.64 → 0.64 | 0.12 → 0.11 | 0.12 → 0.12 | – | **1.74 → 1.57** |

Summed over these nine legacy corpora: 11 477 → 9 461 builds, **−17.6%**.

**Negative controls** — runes-era corpora where the mechanism is idle. All
unchanged, as they must be:

| corpus | before | after |
|---|---|---|
| svelte-maplibre | 0.14 | 0.14 |
| melt-ui | 0.12 | 0.12 |
| runed | 0.12 | 0.12 |
| flowbite-svelte | 0.09 | 0.09 |
| bits-ui | 0.02 | 0.02 |
| shadcn-svelte | 0.02 | 0.02 |
| svelte-pivottable | 0.27 | 0.27 |

**One site did not move.** `prop_assign.in_place` reads 74.33 → 74.33,
2.83 → 2.83, 2.63 → 2.63 — identical on every corpus. Its probe was
strengthened for uniformity with its siblings, but on measured input every
substring hit there is already a token hit, so that hunk buys nothing. Recording
it rather than folding it into the total.

## Byte-identity

`corpus_hash` over 17 real repositories plus `compatibility/pattern-corpus`,
each in client-prod / server / client-dev: **134 550 compiled outputs, zero
differing hashes**, re-run against the committed HEAD after the last edit.

The 54 columns were checked for silent duplication (identical row multisets) and
for emptiness before the comparison was read — all 54 distinct, none empty, and
the three modes of every corpus produce three distinct hash sets.

## Scope note

Consolidating the per-statement builds — one `Semantic` shared across passes
that see the same text — was scoped but **not** attempted. The builds do
concentrate in four sites under one owner, but the four runes-era corpora above
sit at 0.02–0.14 builds/file: the mechanism is nearly idle on the code shape that
ships today, so the lifetime surgery would be optimizing a path modern Svelte
barely reaches. Recorded as a measured no-go rather than a half-finished
refactor.

## Verification

- `cargo test -p rsvelte_core` (debug, `RUST_MIN_STACK=33554432`): 246 suites,
  **2629 passed, 0 failed, 8 ignored**. `runtime` alone took 102 s, so the
  fixture suites did real work.
- `cargo clippy --all-targets --all-features -- -D warnings`: clean.
- `cargo fmt --all`: clean.
- No wall-clock number is claimed; every figure above is a deterministic counter
  or a hash comparison.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
