### PR TITLE
fix(svelte2tsx): rewrite a mustache tag by its brace positions

### DIFF
--- a/.changeset/mustache-source-range.md
+++ b/.changeset/mustache-source-range.md
@@ -1,0 +1,5 @@
+---
+'@rsvelte/compiler': patch
+---
+
+Rewrite a svelte2tsx mustache tag by its brace positions, like upstream, so a wrapping paren in `{(a ?? '')}` survives and `{@html …}` leaves the single space it is replaced with.

--- a/crates/rsvelte_projection/src/svelte2tsx/template/ctx.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/template/ctx.rs
@@ -185,19 +185,6 @@ impl ElementOpenerCommentIndex {
         &self.ranges[bound..]
     }
 
-    pub(super) fn contained_in(&self, start: u32, end: u32) -> &[(u32, u32)] {
-        let from = self
-            .ranges
-            .partition_point(|&(range_start, _)| range_start < start);
-        let mut to = self
-            .ranges
-            .partition_point(|&(range_start, _)| range_start < end);
-        if to > from && self.ranges[to - 1].1 > end {
-            to -= 1;
-        }
-        &self.ranges[from..to]
-    }
-
     #[cfg(test)]
     pub(super) fn record_range_visits(&self, count: usize) {
         self.range_visits.set(self.range_visits.get() + count);

--- a/crates/rsvelte_projection/src/svelte2tsx/template/nodes/comment.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/template/nodes/comment.rs
@@ -2,7 +2,6 @@
 
 use crate::ast::template::Comment;
 use crate::svelte2tsx::magic_string::MagicString;
-use crate::svelte2tsx::template::ctx::ElementOpenerCommentIndex;
 
 /// Handle an HTML comment node.
 ///
@@ -12,36 +11,4 @@ pub(crate) fn handle_comment(comment: &Comment, str: &mut MagicString<'_>) {
         return;
     }
     str.overwrite(comment.start, comment.end, "");
-}
-
-/// Comments (from the per-compile set) whose source range lies fully within
-/// `[start, end)`, sorted by start. Used to preserve `{/* c */ expr}` comments.
-pub(crate) fn comments_in_opener_range(
-    comments: &ElementOpenerCommentIndex,
-    start: u32,
-    end: u32,
-) -> &[(u32, u32)] {
-    if start >= end {
-        return &[];
-    }
-    let contained = comments.contained_in(start, end);
-    #[cfg(test)]
-    comments.record_range_visits(contained.len());
-    contained
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn opener_range_query_is_sorted_and_excludes_boundary_crossing_comments() {
-        let comments = ElementOpenerCommentIndex::new([(45, 49), (30, 42), (20, 25), (5, 9)]);
-        comments.reset_range_visits();
-
-        let actual = comments_in_opener_range(&comments, 10, 40);
-
-        assert_eq!(actual, [(20, 25)]);
-        assert_eq!(comments.range_visits(), 1);
-    }
 }

--- a/crates/rsvelte_projection/src/svelte2tsx/template/nodes/mustache_tag.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/template/nodes/mustache_tag.rs
@@ -3,81 +3,25 @@
 use crate::ast::template::ExpressionTag;
 use crate::svelte2tsx::magic_string::MagicString;
 
-use super::comment::comments_in_opener_range;
-use crate::svelte2tsx::template::ctx::ElementOpenerCommentIndex;
-use crate::svelte2tsx::template::utils::expr::get_expression_range;
-
 /// Handle an expression tag: `{expression}`.
 ///
-/// Overwrites `{` with empty and `}` with `;` so the expression is preserved
-/// as a statement: `{count}` → `count;`
-pub(crate) fn handle_expression_tag(
-    expr: &ExpressionTag,
-    source: &str,
-    str: &mut MagicString<'_>,
-    comments: &ElementOpenerCommentIndex,
-) {
+/// Upstream rewrites the two brace *positions* and nothing else, so whatever
+/// sits between them — wrapping parens, comments, a TS postfix — is kept
+/// verbatim: `{count}` → `count;`, `{(a ?? '')}` → `(a ?? '');`.
+pub(crate) fn handle_expression_tag(expr: &ExpressionTag, source: &str, str: &mut MagicString<'_>) {
     if expr.start >= expr.end {
         return;
     }
-
-    if let Some((expr_start, expr_end)) = get_expression_range(&expr.expression) {
-        // Leading: keep any `{/* c */ expr}` comments between the `{` and the
-        // expression (official preserves them, stripping only the `{` and a
-        // wrapping `(`). Strip from `{` up to the first such comment.
-        let lead_keep = comments_in_opener_range(comments, expr.start, expr_start)
-            .first()
-            .map(|&(cs, _)| cs)
-            .unwrap_or(expr_start);
-        if expr.start < lead_keep {
-            str.overwrite(expr.start, lead_keep, "");
-        }
-        // The parser narrows the expression span past a trailing TS postfix —
-        // `name as string`, `x satisfies T`, `x!`. Those must be PRESERVED
-        // (official keeps them), unlike wrapping parens (`(foo)`) which the
-        // narrowing strips symmetrically and which must stay stripped. So if the
-        // text between `expr_end` and the closing `}` is a TS postfix, keep it
-        // (overwrite only the `}`); otherwise overwrite from `expr_end` (which
-        // drops a trailing `)` to match the stripped leading `(`).
-        let close = {
-            let bytes = source.as_bytes();
-            let mut c = expr.end as usize;
-            while c > expr_end as usize && bytes[c - 1] != b'}' {
-                c -= 1;
-            }
-            c
-        };
-        let tail = source
-            .get(expr_end as usize..close.saturating_sub(1))
-            .unwrap_or("")
-            .trim_start();
-        let is_ts_postfix =
-            tail.starts_with("as ") || tail.starts_with("satisfies ") || tail.starts_with('!');
-        if is_ts_postfix && close > expr_end as usize {
-            str.overwrite((close - 1) as u32, expr.end, ";");
-        } else {
-            // Trailing: keep any `{expr /* c */}` comments between the expression
-            // and `}` (emit `;` right after the expression, strip a wrapping `)`
-            // and the `}`).
-            let trailing =
-                comments_in_opener_range(comments, expr_end, close.saturating_sub(1) as u32);
-            match (trailing.first(), trailing.last()) {
-                (Some(&(first_cs, _)), Some(&(_, last_ce))) => {
-                    if expr_end < first_cs {
-                        str.overwrite(expr_end, first_cs, "; ");
-                    }
-                    if last_ce < expr.end {
-                        str.overwrite(last_ce, expr.end, "");
-                    }
-                }
-                _ if expr_end < expr.end => {
-                    str.overwrite(expr_end, expr.end, ";");
-                }
-                _ => {}
-            }
-        }
-    } else {
-        // Fallback: overwrite the whole thing with a space
-        str.overwrite(expr.start, expr.end, " ");
+    let inner = source
+        .get(expr.start as usize + 1..expr.end as usize - 1)
+        .unwrap_or("");
+    if inner.trim_start().starts_with('{') {
+        // Possibly an object literal — parenthesized so it reads as an
+        // expression rather than a block.
+        str.overwrite(expr.start, expr.start + 1, ";(");
+        str.overwrite(expr.end - 1, expr.end, ");");
+        return;
     }
+    str.overwrite(expr.start, expr.start + 1, "");
+    str.overwrite(expr.end - 1, expr.end, ";");
 }

--- a/crates/rsvelte_projection/src/svelte2tsx/template/nodes/raw_mustache_tag.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/template/nodes/raw_mustache_tag.rs
@@ -14,9 +14,10 @@ pub(crate) fn handle_html_tag(html: &HtmlTag, _source: &str, str: &mut MagicStri
     }
 
     if let Some((expr_start, expr_end)) = get_expression_range(&html.expression) {
-        // Overwrite `{@html ` prefix
+        // `RawMustacheTag.ts` overwrites `{@html ` with a single space, not with
+        // nothing — the expression keeps its source column minus one.
         if html.start < expr_start {
-            str.overwrite(html.start, expr_start, "");
+            str.overwrite(html.start, expr_start, " ");
         }
         // Overwrite closing `}` with `;`
         if expr_end < html.end {

--- a/crates/rsvelte_projection/src/svelte2tsx/template/walk.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/template/walk.rs
@@ -56,9 +56,7 @@ pub(super) fn process_node_inplace(
     match node {
         TemplateNode::Text(text) => handle_text(text, source, str),
         TemplateNode::Comment(comment) => handle_comment(comment, str),
-        TemplateNode::ExpressionTag(expr) => {
-            handle_expression_tag(expr, source, str, &counter.element_opener_comments)
-        }
+        TemplateNode::ExpressionTag(expr) => handle_expression_tag(expr, source, str),
         TemplateNode::HtmlTag(html) => handle_html_tag(html, source, str),
         TemplateNode::ConstTag(tag) => handle_const_tag(tag, source, str),
         TemplateNode::DeclarationTag(tag) => handle_declaration_tag(tag, source, str),

--- a/crates/rsvelte_projection/tests/svelte2tsx_mustache_source_range.rs
+++ b/crates/rsvelte_projection/tests/svelte2tsx_mustache_source_range.rs
@@ -1,0 +1,87 @@
+//! `MustacheTag.ts` and `RawMustacheTag.ts` rewrite *positions*, not
+//! expressions: the brace becomes `` / `;` and everything between the braces is
+//! kept verbatim. rsvelte instead rebuilt the range around the parsed
+//! expression, which drops a wrapping paren the parser does not record and
+//! loses the space `{@html ` is replaced with.
+//!
+//! Both divergences are invisible to the corpus gate whenever oxfmt can parse
+//! the TSX, because formatting absorbs a paren and a leading space. They only
+//! surface once the file is unparseable and the comparison falls back to raw
+//! text — so the gate has been green over them, not clean.
+
+use rsvelte_projection::svelte2tsx::{
+    Svelte2TsxMode, Svelte2TsxNamespace, Svelte2TsxOptions, SvelteVersion, svelte2tsx,
+};
+
+fn opts() -> Svelte2TsxOptions {
+    Svelte2TsxOptions {
+        filename: "T.svelte".to_string(),
+        is_ts_file: false,
+        mode: Svelte2TsxMode::Ts,
+        accessors: false,
+        namespace: Svelte2TsxNamespace::Html,
+        version: SvelteVersion::V5,
+        runes: None,
+        emit_jsdoc: false,
+        rewrite_external_imports: None,
+    }
+}
+
+fn tsx(input: &str) -> String {
+    svelte2tsx(input, opts()).expect("svelte2tsx").code
+}
+
+/// `handleMustacheTag` overwrites `node.start..node.start+1` and
+/// `node.end-1..node.end` and nothing else, so a wrapping paren survives.
+#[test]
+fn a_wrapping_paren_survives_an_expression_tag() {
+    let out = tsx("<div>{(b ?? '')}</div>");
+    assert!(out.contains("(b ?? '');"), "paren dropped:\n{out}");
+}
+
+/// `handleRawHtml` overwrites `node.start..node.expression.start` with a single
+/// space, so the expression keeps its column minus one.
+#[test]
+fn a_raw_html_tag_leaves_one_space_where_the_opener_was() {
+    let out = tsx("<div>{@html a}</div>");
+    assert!(out.contains(" a;"), "no space where `{{@html ` was:\n{out}");
+}
+
+/// The two together — the shape `powertable` hits.
+#[test]
+fn a_raw_html_tag_around_a_parenthesized_expression() {
+    let out = tsx("<div>{@html (a ?? '')}</div>");
+    assert!(out.contains(" a ?? '';"), "got:\n{out}");
+}
+
+/// Control: an ordinary tag is unchanged, so the fix is about what sits between
+/// the braces and not about the braces themselves.
+#[test]
+fn a_plain_expression_tag_is_still_a_bare_statement() {
+    let out = tsx("<div>{count}</div>");
+    assert!(out.contains("count;"), "got:\n{out}");
+    assert!(!out.contains("(count)"), "unexpected paren:\n{out}");
+}
+
+/// A leading `{` still gets the object-literal parenthesization, which is the
+/// one case upstream rewrites the braces to something other than `` / `;`.
+#[test]
+fn an_object_literal_tag_is_still_parenthesized() {
+    let out = tsx("<div>{{ a: 1 }}</div>");
+    assert!(out.contains(";({ a: 1 });"), "got:\n{out}");
+}
+
+/// A TS postfix between the expression and the `}` is kept, because nothing
+/// between the braces is touched.
+#[test]
+fn a_ts_postfix_is_kept() {
+    let out = tsx("<div>{a as string}</div>");
+    assert!(out.contains("a as string;"), "got:\n{out}");
+}
+
+/// A comment between the braces is kept for the same reason.
+#[test]
+fn a_comment_between_the_braces_is_kept() {
+    let out = tsx("<div>{a /* c */}</div>");
+    assert!(out.contains("a /* c */;"), "got:\n{out}");
+}


### PR DESCRIPTION
Two svelte2tsx divergences from official, both on `main` today:

```svelte
<div>
	{@html (a ?? '')}
	{(b ?? '')}
</div>
```

| | official | rsvelte |
|---|---|---|
| `{@html (a ?? '')}` | `` ` a ?? '';` `` | `` `a ?? '';` `` |
| `{(b ?? '')}` | `(b ?? '');` | `b ?? '';` |

## Cause

Both upstream handlers rewrite **positions**, not expressions:

- `MustacheTag.ts` overwrites `node.start..start+1` and `node.end-1..node.end`, and touches nothing between them — so a wrapping paren survives.
- `RawMustacheTag.ts` overwrites `node.start..expression.start` with a **single space**, so the expression keeps its column minus one.

rsvelte rebuilt both ranges around the *parsed* expression instead. The parser's expression span excludes wrapping parens, so `(b ?? '')` lost them; and `{@html ` was replaced with nothing rather than a space.

Rewriting positions also makes `handle_expression_tag`'s comment, TS-postfix and trailing-paren special cases unnecessary — text between the braces is kept because nothing overwrites it — so those go, along with the now-unused `comments_in_opener_range` / `contained_in`. That is the bulk of the −122 lines. All three behaviours keep their own tests.

## Why the gate never saw this

oxfmt absorbs a paren and a leading space, so the corpus comparison is blind to both **whenever it can parse the TSX**. They surface only when a file is unparseable and the comparison falls back to raw text — which is how `powertable/app/src/lib/components/PowerTable.svelte` found them, in #2426, where fixing the `mode: 'ts'` type-assertion gating stops rsvelte from rewriting `<X>e` (matching upstream) and so removes oxfmt's cover.

So the gate has been *green over* these, not clean. Worth remembering when reading a 0-failure ratchet as evidence of parity.

## Verification

`crates/rsvelte_projection/tests/svelte2tsx_mustache_source_range.rs`: the paren case, the `{@html}` space, the two combined, plus controls that a plain `{count}` is still a bare statement with no paren added, that a leading `{` still gets the object-literal parenthesization (the one case upstream *does* rewrite the braces differently), and that a TS postfix and a comment between the braces are kept.

Measured against the official oracle (`submodules/language-tools` svelte2tsx, built as CI builds it) rather than asserted: the repro above is **byte-identical** to official with this change and differs without it. Sweeping 106 `svelte-ux` components through the gate's own `oxfmt` + `stripBlankLines` + `oracle-invalid` rules gives **0 verdict changes** — with a positive control confirming the sweep does report a difference when one exists.

`cargo test -p rsvelte_projection` green (svelte2tsx fixtures included), `cargo clippy --all-targets --all-features -- -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sb9ucum4Cxu99K1WCeyGC8
