### PR TITLE
fix(compiler): wrap the whole prop setter call when the printer broke it across lines

### DIFF
--- a/.changeset/dev-multiline-prop-mutation-wrap.md
+++ b/.changeset/dev-multiline-prop-mutation-wrap.md
@@ -1,0 +1,7 @@
+---
+'@rsvelte/compiler': patch
+---
+
+Wrap the whole prop setter call in `$$ownership_validator.mutation` when the
+printer broke it across lines. A dev-mode legacy `export let` prop whose member
+is assigned a multi-line value produced output that was not JavaScript.

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/props_transforms.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/props_transforms.rs
@@ -3046,9 +3046,11 @@ pub(super) fn wrap_prop_mutation_validation(
                 continue;
             }
 
-            // Check it's not already inside a prop(prop()...) wrapper
+            // Check it's not already inside a prop(prop()...) wrapper. The
+            // printer breaks a long setter call across lines, so the `prop(`
+            // need not be adjacent.
             let before = &result[..abs_start];
-            if before.ends_with(&format!("{}(", var_name)) {
+            if before.trim_end().ends_with(&format!("{}(", var_name)) {
                 runes_search_from = abs_start + runes_prefix.len();
                 continue;
             }
@@ -3247,11 +3249,10 @@ pub(super) fn wrap_prop_mutation_validation(
                 continue;
             }
 
-            let inner_probe_start = if result.as_bytes().get(after_outer) == Some(&b'(') {
-                after_outer + 1
-            } else {
-                after_outer
-            };
+            let mut inner_probe_start = skip_leading_ws(&result, after_outer);
+            if result.as_bytes().get(inner_probe_start) == Some(&b'(') {
+                inner_probe_start = skip_leading_ws(&result, inner_probe_start + 1);
+            }
             if !result[inner_probe_start..].starts_with(&inner_call) {
                 search_from = after_outer;
                 continue;
@@ -3322,15 +3323,20 @@ pub(super) fn wrap_prop_mutation_validation(
             // The content inside prop(...) is rest[..close_byte_pos]
             let inner_content = &rest[..close_byte_pos];
 
-            // Check if it ends with `, true`
+            // Check if it ends with `, true` — the comma and the flag may be on
+            // separate lines when the printer broke the call up.
             let inner_trimmed = inner_content.trim_end();
-            if !inner_trimmed.ends_with(", true") {
+            let Some(head) = inner_trimmed
+                .strip_suffix("true")
+                .map(str::trim_end)
+                .and_then(|head| head.strip_suffix(','))
+            else {
                 search_from = abs_start + wrapper_start_len;
                 continue;
-            }
+            };
 
             // Extract the assignment expression (without `, true`)
-            let assignment_expr = inner_trimmed[..inner_trimmed.len() - ", true".len()].trim();
+            let assignment_expr = head.trim();
             // Some call sites wrap the assignment in an extra pair of parens
             // (e.g. `(config().padAngle = value)`) when the result is consumed
             // as an expression; strip one layer before pattern-matching.
@@ -3475,6 +3481,12 @@ pub(super) fn wrap_prop_mutation_validation(
     }
 
     result
+}
+
+/// The byte offset of the first non-whitespace byte at or after `from`.
+fn skip_leading_ws(text: &str, from: usize) -> usize {
+    let rest = &text[from..];
+    from + (rest.len() - rest.trim_start().len())
 }
 
 /// The span of `(<mutation>, $.invalidate_inner_signals(…))` around the
@@ -4614,6 +4626,54 @@ mod pattern_end_unit_tests {
             let end = find_destructuring_pattern_end(pattern).unwrap();
             assert_eq!(&pattern[..end], pattern, "pattern {pattern:?}");
         }
+    }
+}
+
+/// The legacy setter wrap `prop(prop().member = v, true)` is matched as text, but
+/// the printer breaks it across lines once the assigned value is long. The
+/// single-line-only matcher fell through to the runes-mode branch, which cut the
+/// expression at the first newline and spliced the validator call *inside*
+/// `prop(` — leaving an empty argument slot and an orphaned `true`.
+#[cfg(test)]
+mod multiline_setter_wrap_tests {
+    use super::wrap_prop_mutation_validation;
+
+    fn wrap(stmt: &str) -> String {
+        wrap_prop_mutation_validation(
+            stmt,
+            &[("filter".to_string(), None)],
+            "<script>\n  export let filter;\n  filter.onRemove = () => {};\n</script>",
+        )
+    }
+
+    #[test]
+    fn multiline_setter_call_is_wrapped_as_a_whole() {
+        let out = wrap(
+            "filter(\n\tfilter().onRemove = () => {\n\t\tremove(filter().index);\n\t},\n\ttrue\n);",
+        );
+        assert_eq!(
+            out,
+            "$$ownership_validator.mutation(null, ['filter', 'onRemove'], filter(\n\tfilter().onRemove = () => {\n\t\tremove(filter().index);\n\t},\n\ttrue\n), 3, 2);"
+        );
+    }
+
+    /// Control: the single-line shape is unchanged by the tolerance.
+    #[test]
+    fn single_line_setter_call_is_unchanged() {
+        assert_eq!(
+            wrap("filter(filter().onRemove = 1, true);"),
+            "$$ownership_validator.mutation(null, ['filter', 'onRemove'], filter(filter().onRemove = 1, true), 3, 2);"
+        );
+    }
+
+    /// Control: an unrelated call whose argument merely mentions the prop is not
+    /// mistaken for the setter wrap.
+    #[test]
+    fn unrelated_multiline_call_is_left_alone() {
+        assert_eq!(
+            wrap("remove(\n\tfilter().index\n);"),
+            "remove(\n\tfilter().index\n);"
+        );
     }
 }
 

--- a/crates/rsvelte_core/tests/prop_mutation_multiline_dev_wrap.rs
+++ b/crates/rsvelte_core/tests/prop_mutation_multiline_dev_wrap.rs
@@ -1,0 +1,93 @@
+//! Dev-mode `$$ownership_validator.mutation` wrap around a **multi-line**
+//! prop-member mutation.
+//!
+//! `wrap_prop_mutation_validation` matches the already-lowered
+//! `prop(prop().member = value, true)` call as text. When the assigned value is
+//! long enough for the printer to break the call across lines, that text becomes
+//!
+//! ```text
+//! filter(
+//!     filter().onRemove = () => { … },
+//!     true
+//! );
+//! ```
+//!
+//! and the single-line-only matcher fell through to the runes-mode branch, which
+//! wrapped the inner assignment and terminated its expression scan at the first
+//! newline — emitting `mutation(…, filter().onRemove = …,, line, col)` inside
+//! `filter(`, with `true` orphaned. That output is not JavaScript.
+
+use rsvelte_core::{CompileOptions, GenerateMode, compile, compiler::CssMode};
+
+const SRC: &str = r#"<script>
+  export let filter;
+  filter.onRemove = () => {
+    remove(filter.index);
+  };
+</script>
+
+<p>{filter.index}</p>
+"#;
+
+fn client(src: &str, dev: bool) -> String {
+    compile(
+        src,
+        CompileOptions {
+            filename: Some("T.svelte".to_string()),
+            generate: GenerateMode::Client,
+            dev,
+            css: CssMode::External,
+            ..Default::default()
+        },
+    )
+    .expect("compile")
+    .js
+    .code
+}
+
+#[test]
+fn dev_wraps_the_whole_prop_setter_call() {
+    let out = client(SRC, true);
+
+    // The nesting upstream produces: the `filter(…, true)` setter call is the
+    // third *argument* of the validator call, not its parent.
+    assert!(
+        out.contains(
+            "$$ownership_validator.mutation(\n\t\tnull,\n\t\t['filter', 'onRemove'],\n\t\tfilter(\n\t\t\tfilter().onRemove = () => {\n\t\t\t\tremove(filter().index);\n\t\t\t},\n\t\t\ttrue\n\t\t),\n\t\t3,\n\t\t2\n\t);"
+        ),
+        "got:\n{out}"
+    );
+
+    // The two fingerprints of the mis-splice: an empty argument slot, and a
+    // `true` left outside the call it belonged to.
+    assert!(!out.contains(",,"), "empty argument slot in:\n{out}");
+    assert!(!out.contains("2)\n\t\ttrue"), "orphaned `true` in:\n{out}");
+}
+
+/// Control that can move: production output for this component is already
+/// correct and must stay byte-identical — the wrap only exists under `dev`.
+#[test]
+fn prod_output_is_unchanged() {
+    let out = client(SRC, false);
+    assert!(!out.contains("$$ownership_validator"), "got:\n{out}");
+    assert!(
+        out.contains(
+            "\tfilter(\n\t\tfilter().onRemove = () => {\n\t\t\tremove(filter().index);\n\t\t},\n\t\ttrue\n\t);"
+        ),
+        "got:\n{out}"
+    );
+}
+
+/// The single-line shape (short assigned value, no printer line break) already
+/// worked and must keep working — it is the arm the fix must not disturb.
+#[test]
+fn dev_single_line_mutation_still_wraps() {
+    let out = client(
+        "<script>\n  export let filter;\n  filter.index = 1;\n</script>\n\n<p>{filter.index}</p>\n",
+        true,
+    );
+    assert!(
+        out.contains("$$ownership_validator.mutation(null, ['filter', 'index'], filter(filter().index = 1, true), 3, 2)"),
+        "got:\n{out}"
+    );
+}


### PR DESCRIPTION
## The bug

Under `dev`, a legacy `export let` prop whose **member** is assigned produced output
that no JavaScript parser accepts. Minimal repro — eight lines, dev-only, prod clean:

```svelte
<script>
  export let filter;
  filter.onRemove = () => {
    remove(filter.index);
  };
</script>

<p>{filter.index}</p>
```

Official (`dev: true`) wraps the whole prop-setter call as the third **argument** of
the validator call:

```js
$$ownership_validator.mutation(
	null,
	['filter', 'onRemove'],
	filter(
		filter().onRemove = () => {
			remove(filter().index);
		},
		true
	),
	3,
	2
);
```

rsvelte inverted the nesting and mangled the argument list:

```js
filter(
	$$ownership_validator.mutation(null, ['filter', 'onRemove'], filter().onRemove = () => {
		remove(filter().index);
	},, 3, 2)
	true
);
```

## Mechanism

`wrap_prop_mutation_validation` (client/props_transforms.rs) matches the
already-lowered setter form as **text**, and had two loops:

1. a runes-mode loop that matches a bare `prop().member = value`, and
2. a legacy loop that matches the wrap `prop(prop().member = value, true)`.

Both were written against the *single-line* rendering. When the assigned value is
long enough, the printer breaks the setter call across lines:

```js
filter(
	filter().onRemove = () => { … },
	true
);
```

and then

* loop 2's probe `result[after_outer..].starts_with("filter()")` fails — there is a
  newline and a tab between `filter(` and `filter()` — so the legacy shape is never
  recognised; and
* loop 1's "am I already inside `prop(`?" guard, `before.ends_with("filter(")`, fails
  for the same reason, so the runes branch takes the site it was supposed to skip.

Loop 1 then delimits the expression by scanning for `;`, `\n` or an unbalanced closer
at depth 0. Its depth counter starts *inside* the enclosing `filter(`, so the newline
after `},` reads as depth 0 and terminates the expression **on the comma**. The comma
lands in `full_expr`, the emitted `, line, col` adds a second one — `,,` — and `true`
is left orphaned outside the call it belonged to.

## Fix

Make both matchers tolerant of the line break the printer inserts:

* loop 1's already-wrapped guard trims trailing whitespace before testing for `prop(`;
* loop 2 skips whitespace after `prop(` (and after the optional extra paren) when
  probing for `prop()`;
* loop 2 accepts `,` and `true` separated by whitespace, not only the literal `, true`.

Nothing else changes — with loop 1 correctly skipping, loop 2 matches the whole
`prop(…, true)` call and wraps it as the validator's third argument, exactly as
upstream does.

## Verification

Regression test `crates/rsvelte_core/tests/prop_mutation_multiline_dev_wrap.rs`
(plus function-level unit tests in `props_transforms.rs`). Run against unpatched
code it fails **for the predicted reason** — the validator call nested inside
`filter(`, with `,,` and an orphaned `true` — not for some other reason.

**Control that can move:** production output for this shape is already correct, so a
fix that "corrected" prod too would have broken something. Asserted in the test
(`prod_output_is_unchanged`) and measured below.

### Measured byte-identity, `corpus_hash` before vs after

51,085 files × 3 targets. Corpora: `carbon/src`, `huly/plugins`, `open-webui/src`,
`smui`, `submodules/{attractions,bits-ui,flowbite-svelte,layercake,layerchart,melt-ui,powertable,shadcn-svelte,skeleton,smelte,svar-core,svelte-calendar,svelte-form-builder,svelte-maplibre,svelte-pivottable,svelte-ux,svelthree,sveltestrap}`,
`compatibility/pattern-corpus`, `submodules/svelte`, `submodules/svelte.dev`.

| corpus set | files | client (prod) | server | client-dev |
|---|---|---|---|---|
| real-world + pattern-corpus | 10,389 | **0 changed** | **0 changed** | 15 changed |
| `svelte` + `svelte.dev` | 40,696 | **0 changed** | **0 changed** | **0 changed** |

Prod and server are byte-identical everywhere. The repo's own corpus ratchets draw
from `svelte` / `svelte.dev` / bits-ui / flowbite-svelte / melt-ui / shadcn-svelte —
all 0 changed, so no baseline needs re-cutting.

### The 15 changed dev outputs

Every one is strictly closer to the official compiler; none regressed.

|  | before | after |
|---|---|---|
| output rejected by a JS parser | **9** | **0** |
| byte-equal to official (raw, no normalization) | 0 | **9** |
| total line-distance to official over the 15 | 1999 | **41** |

The 9 invalid ones are exactly the 9 reported for this cluster (ChannelFilter,
MultipleChoiceQuestionDataEditor, OrderingQuestionDataEditor,
SingleChoiceQuestionDataEditor, ApplicantFilter, TagsFilter, ArrayFilter, ValueFilter,
open-webui `chat/Messages.svelte`), so this one mechanism accounts for **9 of 9**.

The other 6 files were hit by the same mis-splice but happened to stay *parseable* —
and silently wrong. In `EmployeeFilter.svelte` the mangled form was

```js
filter(
	$$ownership_validator.mutation(null, ['filter', 'modes'], filter().modes = $.strict_equals(filter().modes, undefined), 42, 2)
		? [view.filter.FilterObjectIn, view.filter.FilterObjectNin]
		: filter().modes,
	true
);
```

— valid JS that assigns the **boolean** instead of the ternary result. A parser-based
gate cannot see this class at all; only output comparison can.

Residual divergence in 6 files is pre-existing and unrelated (comment re-indentation,
`$:` → `legacy_pre_effect` ordering, and mutation-site line/column attribution when
two mutations share a member chain). None of it moved in this PR — verified per file.
