### PR TITLE
fix(transform): match a `$effect(`'s closing paren lexically

### DIFF
--- a/.changeset/effect-strip-lexical-paren.md
+++ b/.changeset/effect-strip-lexical-paren.md
@@ -1,0 +1,18 @@
+---
+"@rsvelte/compiler": patch
+---
+
+Match a `$effect(`'s closing paren lexically, so a `)` inside its body's comment does not truncate the deletion
+
+`strip_effects_from_source` deletes from `$effect(` to its matching `)`, and
+`find_matching_paren` counted every `)` byte. A `// ) c` inside the effect body closed the
+count early, so the deletion stopped mid-body and the tail of the comment — `c` — was
+emitted as a bare statement. The output no longer parses: `Unexpected token`,
+`Unterminated regular expression` and `'import' is a reserved word` are all the same defect
+landing at different arbitrary bytes.
+
+The fix is on the shared helper rather than the caller, because all 18 call sites (11 in
+the server transform, 7 in the client rune transforms) use the result to slice or delete a
+source range. Only the `$effect` / `$effect.pre` / `$effect.root` sites are shown to be
+reachable by a discriminating case; the other 15 are structurally exposed to the same input
+but unmeasured.

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/expression_utils.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/expression_utils.rs
@@ -1640,22 +1640,14 @@ pub(super) fn is_identifier_char(c: char) -> bool {
     c.is_alphanumeric() || c == '_' || c == '$'
 }
 
-/// Find the position of the matching closing parenthesis.
+/// Find the position of the matching closing parenthesis, given `s` positioned
+/// just after the opening `(`.
+///
+/// Delegates to the lexical matcher: every caller uses the result to slice or
+/// delete a source range, and a `)` inside a comment, string, template or regex
+/// would cut that range mid-expression (#2601).
 pub(crate) fn find_matching_paren(s: &str) -> Option<usize> {
-    let mut depth = 1;
-    for (i, c) in s.char_indices() {
-        match c {
-            '(' => depth += 1,
-            ')' => {
-                depth -= 1;
-                if depth == 0 {
-                    return Some(i);
-                }
-            }
-            _ => {}
-        }
-    }
-    None
+    crate::compiler::phases::phase1_parse::utils::find_matching_bracket(s, 0, '(')
 }
 
 /// Extract the name of the enclosing function from the text before a block opening.

--- a/crates/rsvelte_core/tests/server_effect_strip_comment_delimiter.rs
+++ b/crates/rsvelte_core/tests/server_effect_strip_comment_delimiter.rs
@@ -1,0 +1,122 @@
+//! A delimiter inside a comment ended the `$effect(…)` the server module path
+//! deletes, so the deletion cut the call in half.
+//!
+//! `strip_effects_from_source` locates the end of `$effect(` with
+//! `client::find_matching_paren`, which counts every `)` byte. A `)` inside a
+//! comment in the effect body closed the count early; the text removed then
+//! stopped mid-body and everything after the phantom `)` — including the tail of
+//! the comment itself — was emitted as code. `// ) c` left a bare `c` statement
+//! followed by the rest of the block, which no JS parser accepts. The #2253
+//! class, at a site the #2434 sweep did not reach because it counts through a
+//! different helper.
+//!
+//! Found by the corpus mutation sweep (#2601) on
+//! `bits-ui/…/scroll-area/scroll-area.svelte.ts`, whose mutant is exactly this
+//! shape.
+
+use rsvelte_core::{GenerateMode, ModuleCompileOptions, compile_module};
+
+fn compile_server(src: &str) -> String {
+    compile_module(
+        src,
+        ModuleCompileOptions {
+            generate: GenerateMode::Server,
+            filename: Some("m.svelte.js".to_string()),
+            ..Default::default()
+        },
+    )
+    .expect("module should compile")
+    .js
+    .code
+}
+
+#[track_caller]
+fn assert_parses(code: &str, what: &str) {
+    let allocator = oxc_allocator::Allocator::default();
+    let ret = oxc_parser::Parser::new(&allocator, code, oxc_span::SourceType::mjs()).parse();
+    assert!(
+        ret.diagnostics.is_empty(),
+        "{what}: emitted JS does not parse: {:?}\n--- output ---\n{code}",
+        ret.diagnostics
+    );
+}
+
+/// The reported shape: a line comment carrying `)` inside the effect body.
+#[test]
+fn a_close_paren_in_a_line_comment_does_not_end_the_effect() {
+    let out = compile_server(
+        "export function make() {\n  let n = $state(0);\n  $effect(() => {\n    // ) c\n    n += 1;\n  });\n  return () => n;\n}\n",
+    );
+    assert_parses(&out, "line comment with `)`");
+    assert!(!out.contains("n += 1"), "effect body survived:\n{out}");
+}
+
+/// The same through a block comment, and with the delimiter after real text so
+/// a fix that only skipped a comment *starting* with `)` would not cover it.
+#[test]
+fn a_close_paren_in_a_block_comment_does_not_end_the_effect() {
+    let out = compile_server(
+        "export function make() {\n  let n = $state(0);\n  $effect(() => {\n    /* keep ) going */\n    n += 1;\n  });\n  return () => n;\n}\n",
+    );
+    assert_parses(&out, "block comment with `)`");
+    assert!(!out.contains("n += 1"), "effect body survived:\n{out}");
+}
+
+/// A string literal is the other opaque region the byte counter walked into.
+#[test]
+fn a_close_paren_in_a_string_does_not_end_the_effect() {
+    let out = compile_server(
+        "export function make() {\n  let n = $state(0);\n  $effect(() => {\n    log(\")\");\n    n += 1;\n  });\n  return () => n;\n}\n",
+    );
+    assert_parses(&out, "string with `)`");
+    assert!(!out.contains("n += 1"), "effect body survived:\n{out}");
+}
+
+/// `$effect.pre` and `$effect.root` are deleted by the same helper with their
+/// own needles, so each needs its own case — fixing one call site would leave
+/// the other two counting bytes.
+#[test]
+fn effect_pre_and_root_are_covered_too() {
+    let pre = compile_server(
+        "export function make() {\n  let n = $state(0);\n  $effect.pre(() => {\n    // ) c\n    n += 1;\n  });\n  return () => n;\n}\n",
+    );
+    assert_parses(&pre, "$effect.pre");
+    assert!(!pre.contains("n += 1"), "$effect.pre body survived:\n{pre}");
+
+    let root = compile_server(
+        "export function make() {\n  let n = $state(0);\n  $effect.root(() => {\n    // ) c\n    n += 1;\n  });\n  return () => n;\n}\n",
+    );
+    assert_parses(&root, "$effect.root");
+    assert!(
+        !root.contains("n += 1"),
+        "$effect.root body survived:\n{root}"
+    );
+}
+
+/// The control: with no delimiter in the comment the effect was already deleted
+/// correctly, so this pins that the fix did not change the working case — and
+/// it is the case a fix that deleted too much would break.
+#[test]
+fn a_plain_comment_in_the_effect_body_still_deletes_exactly_the_effect() {
+    let out = compile_server(
+        "export function make() {\n  let n = $state(0);\n  $effect(() => {\n    // plain\n    n += 1;\n  });\n  return () => n;\n}\n",
+    );
+    assert_parses(&out, "plain comment");
+    assert!(!out.contains("n += 1"), "effect body survived:\n{out}");
+    assert!(
+        out.contains("return () => n;"),
+        "the statement after the effect was consumed:\n{out}"
+    );
+}
+
+/// The other direction: the statement *after* the effect must survive when the
+/// body carries a delimiter too. Without this, a matcher that ran past the real
+/// `)` would pass every assertion above by deleting more than the effect.
+#[test]
+fn the_statement_after_the_effect_survives_a_delimiter_comment() {
+    let out = compile_server(
+        "export function make() {\n  let n = $state(0);\n  $effect(() => {\n    // ) c\n    n += 1;\n  });\n  const after = 7;\n  return () => n + after;\n}\n",
+    );
+    assert_parses(&out, "statement after the effect");
+    assert!(out.contains("const after = 7;"), "over-deleted:\n{out}");
+}


### PR DESCRIPTION
Closes part of #2601 — the `unparseable` cluster in `main`'s mutation full sweep.

## Reproducer

`m.svelte.js`, `generate: 'server'`:

```js
export function make() {
  let n = $state(0);
  $effect(() => {
    // ) c
    n += 1;
  });
  return () => n;
}
```

rsvelte emits:

```js
export function make() {
  let n = 0;
  c
    n += 1;
  });
  return () => n;
}
```

Official emits:

```js
export function make() {
	let n = 0;

	// ) c
	return () => n;
}
```

Swap `$effect` for any other callee (`foo(() => { … })`) and the output is correct, so it is
the effect-removal path specifically.

## Mechanism

`strip_effects_from_source` deletes the range from `$effect(` to its matching `)`, and found
that `)` with `client::find_matching_paren`, which counted **every** `)` byte. The `)` inside
`// ) c` closed the count, so the deleted range stopped mid-body and everything after the
phantom `)` — starting with the *tail of the comment* — was emitted as code. That is why the
errors read `Unexpected token` / `Unterminated regular expression` / `'import' is a reserved
word`: the cut lands at an arbitrary byte, so what follows is whatever the source happened to
contain.

This is the #2253 class at a site the #2434 sweep did not reach — that one fixed
`find_matching_paren_server`, a different helper with the same defect. The doc comment above
`strip_effects_from_source` already *claims* lexical awareness ("Matching is JS-lexical-aware
via `code_match_positions`"): that is true of finding the `$effect(` occurrence, and false of
finding its closing paren.

## Fix

`find_matching_paren` now delegates to `phase1_parse::utils::find_matching_bracket`, the
existing lexical matcher (strings, templates, regex and comments all opaque) — the shared
function rather than the caller, as #2434 did, because there are **18 call sites**: 11 in
`server/mod.rs` and 7 in `client/rune_transforms.rs`, every one of them using the result to
slice or delete a source range.

**Scope claim, kept narrow.** The defect and the fix are demonstrated on the `$effect` /
`$effect.pre` / `$effect.root` sites. The other 15 call sites are *structurally* exposed to the
same input — they slice on the same helper — but no discriminating case is produced for each,
so read "18 sites fixed" as "one shared helper corrected", not as 18 measured bugs.

## Tests

6 in `crates/rsvelte_core/tests/server_effect_strip_comment_delimiter.rs`: line comment, block
comment with the delimiter after real text, string literal, `$effect.pre` + `$effect.root`, a
plain-comment control, and an over-deletion control (the statement after the effect must
survive). **5 of the 6 fail without the fix; the one that passes is the plain-comment
control** — which is what makes the set discriminating rather than merely green.

## What this does not settle

The 43 new mutation failures are **not one bug**. `flowbite-svelte/…/Navbar__m0__line-with-semi`
and `layerchart/…/stack__m0__line-with-semi` fail on **client** and **client-dev**, which never
run `strip_effects_from_source`; that second cause is `extract_imports` / `import_statement_end`
treating a `;` inside a comment as the import terminator, and it needs its own PR.

## Verification status

The local full `cargo test --release -p rsvelte_core` run is still compiling on a machine
saturated by another build, so at the time of opening **CI is the first complete run of the
suite against this change**. The 6 new tests and their negative controls were run locally.
