### PR TITLE
ci: key non-PR concurrency by commit so `main` runs cannot cancel each other

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -23,11 +23,19 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
-  # CodSpeed compares a PR against `main`'s run for the merge base. Cancelling
-  # `main`'s runs left it with no baseline at all, so it fell back to an older
-  # commit and reported every PR as a large regression.
-  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+  # Keyed by the head branch on a PR (a new push supersedes the old run) and by
+  # the commit otherwise, so a push to `main` shares a group with nothing and
+  # cannot be cancelled. The previous guard — `cancel-in-progress:
+  # ${{ github.ref != 'refs/heads/main' }}` — did not hold: every `main` run
+  # under it was still cancelled the instant the next merge started, so `main`
+  # never produced a verdict. The cost is one run per merge instead of one per
+  # burst; a branch with no verdict reads exactly like a green one, which is
+  # how a stale ratchet reached `main` unnoticed (#2435/#2593).
+  group: ${{ github.workflow }}-${{ github.head_ref || github.sha }}
+  # CodSpeed compares a PR against `main`'s run for the merge base, so a `main`
+  # branch with no run makes it fall back to an older commit and report every
+  # PR as a large regression.
+  cancel-in-progress: true
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,12 +12,16 @@ permissions:
   pull-requests: write
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
-  # Never on `main`: `github.ref` is the same for every merge, so cancelling
-  # meant each merge killed its predecessor's run and the branch carried no
-  # verdict at all. GitHub keeps at most one *pending* run per group, so the tip
-  # is still always scheduled — this costs a lag, not a runner per commit.
-  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+  # Keyed by the head branch on a PR (a new push supersedes the old run) and by
+  # the commit otherwise, so a push to `main` shares a group with nothing and
+  # cannot be cancelled. The previous guard — `cancel-in-progress:
+  # ${{ github.ref != 'refs/heads/main' }}` — did not hold: every `main` run
+  # under it was still cancelled the instant the next merge started, so `main`
+  # never produced a verdict. The cost is one run per merge instead of one per
+  # burst; a branch with no verdict reads exactly like a green one, which is
+  # how a stale ratchet reached `main` unnoticed (#2435/#2593).
+  group: ${{ github.workflow }}-${{ github.head_ref || github.sha }}
+  cancel-in-progress: true
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -8,8 +8,16 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  # Keyed by the head branch on a PR (a new push supersedes the old run) and by
+  # the commit otherwise, so a push to `main` shares a group with nothing and
+  # cannot be cancelled. The previous guard — `cancel-in-progress:
+  # ${{ github.ref != 'refs/heads/main' }}` — did not hold: every `main` run
+  # under it was still cancelled the instant the next merge started, so `main`
+  # never produced a verdict. The cost is one run per merge instead of one per
+  # burst; a branch with no verdict reads exactly like a green one, which is
+  # how a stale ratchet reached `main` unnoticed (#2435/#2593).
+  group: ${{ github.workflow }}-${{ github.head_ref || github.sha }}
+  cancel-in-progress: true
 
 permissions:
   contents: read

--- a/.github/workflows/corpus-compat.yml
+++ b/.github/workflows/corpus-compat.yml
@@ -139,10 +139,16 @@ on:
       - '.github/actions/**'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  # A cancelled run leaves that commit with no verdict, which reads the same as
-  # green — that is how a stale ratchet sat on `main` unnoticed (#2435/#2593).
-  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+  # Keyed by the head branch on a PR (a new push supersedes the old run) and by
+  # the commit otherwise, so a push to `main` shares a group with nothing and
+  # cannot be cancelled. The previous guard — `cancel-in-progress:
+  # ${{ github.ref != 'refs/heads/main' }}` — did not hold: every `main` run
+  # under it was still cancelled the instant the next merge started, so `main`
+  # never produced a verdict. The cost is one run per merge instead of one per
+  # burst; a branch with no verdict reads exactly like a green one, which is
+  # how a stale ratchet reached `main` unnoticed (#2435/#2593).
+  group: ${{ github.workflow }}-${{ github.head_ref || github.sha }}
+  cancel-in-progress: true
 
 permissions:
   contents: read

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -16,10 +16,17 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
-  # Same reason as ci.yml: `github.ref` is identical for every push to `main`,
-  # so the trend line only ever recorded whichever merge happened to be last.
-  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+  # Keyed by the head branch on a PR (a new push supersedes the old run) and by
+  # the commit otherwise, so a push to `main` shares a group with nothing and
+  # cannot be cancelled. The previous guard — `cancel-in-progress:
+  # ${{ github.ref != 'refs/heads/main' }}` — did not hold: every `main` run
+  # under it was still cancelled the instant the next merge started, so `main`
+  # never produced a verdict. The cost is one run per merge instead of one per
+  # burst; a branch with no verdict reads exactly like a green one, which is
+  # how a stale ratchet reached `main` unnoticed (#2435/#2593).
+  group: ${{ github.workflow }}-${{ github.head_ref || github.sha }}
+  # Without this the coverage trend line records only whichever merge was last.
+  cancel-in-progress: true
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
## What

Keys the concurrency group for `ci`, `corpus-compat`, `benchmark`, `coverage` and `codspeed` by the **commit SHA** when the run is not a pull request, and sets `cancel-in-progress: true` unconditionally. A push to `main` now shares a group with nothing, so there is nothing to cancel it.

## Why the existing guard is not enough

#2594 added `cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}` for exactly this reason. **It is not working.** Every `main` run since it merged has still been cancelled, each one at the moment the next merge's run started:

| workflow run | head | started | ended | result |
|---|---|---|---|---|
| Benchmark | `c84d227a` | 01:33:48 | 01:37:07 | cancelled |
| Benchmark | `675b34d5` | 01:37:06 | 01:40:06 | cancelled |
| Benchmark | `1d290bcd` | 01:40:05 | 01:44:53 | cancelled |
| Benchmark | `c78ce58e` | 01:44:52 | 01:46:18 | cancelled |
| Benchmark | `03d69cf5` | 01:46:17 | 01:53:32 | cancelled |

`c84d227a` **is** the merge commit of #2594, so the very first run carrying the guard was cancelled by the next one. The same pattern holds on `CI`, `Corpus Compat`, `Coverage` and `CodSpeed`; the only `main` run to survive the burst was a `Coverage` run that happened to finish inside the gap.

I did not establish *why* the expression is not honoured, and this PR does not answer that. It removes the dependency on it instead: with the group keyed by `github.sha` off pull requests, no two `main` runs can ever occupy the same group, whatever `cancel-in-progress` evaluates to.

## Why it matters now

A cancelled run leaves that commit with **no verdict**, which reads identically to a green one. That is the documented cause of a stale ratchet reaching `main` unnoticed (#2435 / #2593), and right now it also breaks the performance gate outright: CodSpeed compares a PR against `main`'s run for the merge base, and with no `main` run at all it falls back to an older commit and reports unrelated PRs as large regressions. #2574 failed its CodSpeed check this way while containing no code change.

## The cost, stated plainly

This is not free. Previously the intent was that GitHub keeps at most one *pending* run per group, so a burst of merges would cost roughly one run for the tip. Keying by SHA gives **one run per merge**. During a burst of six merges that is six full CI runs rather than one or two.

I think that trade is right — a gate that never renders a verdict is worth less than the runner minutes it saves, and the perf campaign currently cannot measure anything without a `main` baseline — but it is a real increase and should be a deliberate choice, not a side effect.

## How to verify it worked

Merge two PRs to `main` in quick succession and check that **both** runs reach a conclusion. That is the discriminating test; a single merge would pass under the old configuration too.
