### PR TITLE
refactor(compiler): answer the control-header probe from the last line

### DIFF
--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/expression_utils.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/expression_utils.rs
@@ -301,6 +301,31 @@ pub(super) fn ends_with_braceless_control_header(prefix: &str) -> bool {
     false
 }
 
+/// [`ends_with_braceless_control_header`] answered from the statement's final
+/// line alone, or `None` when the verdict genuinely depends on earlier lines.
+///
+/// The full predicate only ever reads a suffix, so joining the accumulated
+/// lines is wasted unless the header's `(` opens on an earlier line.
+pub(super) fn braceless_control_header_from_last_line(last: &str) -> Option<bool> {
+    let t = last.trim_end();
+    if t.is_empty() {
+        return None;
+    }
+    if !t.ends_with(')') {
+        return Some(ends_with_keyword(t, "else") || ends_with_keyword(t, "do"));
+    }
+    let open = matching_open_paren(t)?;
+    let before = t[..open].trim_end();
+    if before.is_empty() {
+        return None;
+    }
+    Some(
+        ["if", "for", "while", "switch", "catch"]
+            .iter()
+            .any(|kw| ends_with_keyword(before, kw)),
+    )
+}
+
 pub(super) fn find_statement_end_client(s: &str) -> usize {
     let mut depth = 0;
     let mut in_string = false;

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
@@ -4506,6 +4506,22 @@ fn stage<'a>(
     }
 }
 
+/// Whether the statement accumulated so far ends in a brace-less control-flow
+/// header, materialising the joined text only when the last line cannot settle it.
+fn accumulated_ends_with_control_header(accumulated: &[&str], last: &str) -> bool {
+    if let Some(verdict) = expression_utils::braceless_control_header_from_last_line(last) {
+        super::profile::record_st_ctrl_header(0);
+        return verdict;
+    }
+    let mut acc = accumulated[..accumulated.len() - 1].join("\n");
+    if !acc.is_empty() {
+        acc.push('\n');
+    }
+    acc.push_str(last);
+    super::profile::record_st_ctrl_header(acc.len() as u64);
+    expression_utils::ends_with_braceless_control_header(&acc)
+}
+
 fn transform_instance_script_for_visitors(
     script: &str,
     analysis: &ComponentAnalysis,
@@ -4663,6 +4679,7 @@ fn transform_instance_script_for_visitors(
     // Pre-filter state_vars to only include variables that actually appear in the script.
     // This avoids O(M*N) scanning in downstream transforms for variables that can't match.
     // Uses O(text_len) identifier extraction instead of O(N*text_len) substring search.
+    super::profile::record_st_collect_scan(script_rest.len() as u64);
     utils::text_retain_matching_identifiers(&script_rest, &mut state_vars);
 
     // Ensure reactive import names are included in state_vars for $.get()/$.mutate() wrapping.
@@ -4715,6 +4732,7 @@ fn transform_instance_script_for_visitors(
     // top-level bindings take precedence for scope-level transforms. For example,
     // if there's a top-level `const multiplier = () => { let multiplier = $state(2); ... }`,
     // the inner `multiplier` should NOT cause the outer `multiplier` to be wrapped with $.get().
+    super::profile::record_st_collect_scan(script_rest.len() as u64);
     let local_reactive_vars = extract_local_reactive_vars(&script_rest);
     let top_level_binding_names: rustc_hash::FxHashSet<&str> = analysis
         .root
@@ -4750,6 +4768,8 @@ fn transform_instance_script_for_visitors(
     let (const_state_decls, reassigned_in_text) = if local_reactive_vars.is_empty() {
         Default::default()
     } else {
+        super::profile::record_st_collect_scan(script_rest.len() as u64);
+        super::profile::record_st_collect_scan(script_rest.len() as u64);
         (
             index_const_state_decls(&script_rest),
             index_reassigned_vars(&script_rest),
@@ -4822,6 +4842,7 @@ fn transform_instance_script_for_visitors(
 
     // Collect proxy vars - variables initialized with $state({ ... }) or $state([ ... ])
     // These are converted to $.proxy() and don't need $.get() wrapping for property access
+    super::profile::record_st_collect_scan(script_rest.len() as u64);
     let proxy_vars = extract_proxy_vars(&script_rest);
 
     // Collect rest_prop variable names (from `let props = $props()`)
@@ -4954,6 +4975,7 @@ fn transform_instance_script_for_visitors(
 
     // Check for legacy mode (export let or export { x })
     // Also detect `export { x }` patterns which create BindableProp bindings
+    super::profile::record_st_collect_scan(script_rest.len() as u64);
     let has_legacy_export_let = script_rest.lines().any(|line| {
         let trimmed = line.trim();
         trimmed.starts_with("export let ") || trimmed.starts_with("export let\t")
@@ -6049,6 +6071,8 @@ fn transform_instance_script_for_visitors(
     super::profile::record_st_collect_vars(super::profile::timer_elapsed(_stage));
     let _stage = super::profile::timer_start();
 
+    super::profile::record_st_loop_lines(script_lines.len() as u64);
+
     while line_idx < script_lines.len() {
         let line = script_lines[line_idx];
         let trimmed = line.trim();
@@ -6188,16 +6212,10 @@ fn transform_instance_script_for_visitors(
             // complete statement — its body statement must be accumulated with it.
             // Otherwise `$: if (cond)\n\tstmt` splits `stmt` off as a separate
             // top-level statement, dropping the guard and the reactive wrapper.
-            let ends_with_control_header = {
-                let mut acc = accumulated_lines[..accumulated_lines.len() - 1].join("\n");
-                if !acc.is_empty() {
-                    acc.push('\n');
-                }
-                acc.push_str(trimmed);
-                expression_utils::ends_with_braceless_control_header(&acc)
-            };
-
-            if !trailing_comma && !trailing_operator && !ends_with_control_header {
+            if !trailing_comma
+                && !trailing_operator
+                && !accumulated_ends_with_control_header(&accumulated_lines, trimmed)
+            {
                 // Before processing, check if the next non-empty line starts with a
                 // continuation token (`.` for method chains, `?`, `:`, `&&`, `||`,
                 // `??` for ternary/logical continuation). Example:
@@ -6243,6 +6261,7 @@ fn transform_instance_script_for_visitors(
                             && (!state_vars.is_empty() || !store_sub_vars.is_empty());
 
                         if !needs_rune && !needs_export && !needs_destructure {
+                            super::profile::record_st_fastpath_statement();
                             result.push_str(&statement);
                             result.push('\n');
                             accumulated_lines.clear();

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
@@ -3711,6 +3711,7 @@ pub(super) fn extract_local_reactive_vars(script: &str) -> Vec<(String, bool, bo
         return Vec::new();
     }
 
+    super::profile::record_st_collect_scan(script.len() as u64);
     let mut vars = Vec::new();
 
     // Pattern: (let|const|var) varname = $state(...) or (let|const|var) varname = $derived(...)
@@ -3823,6 +3824,7 @@ fn extract_proxy_vars(script: &str) -> Vec<String> {
     if memmem::find(script.as_bytes(), b"$state(").is_none() {
         return Vec::new();
     }
+    super::profile::record_st_collect_scan(script.len() as u64);
     let mut proxy_vars = Vec::new();
 
     for line in script.lines() {
@@ -4679,7 +4681,9 @@ fn transform_instance_script_for_visitors(
     // Pre-filter state_vars to only include variables that actually appear in the script.
     // This avoids O(M*N) scanning in downstream transforms for variables that can't match.
     // Uses O(text_len) identifier extraction instead of O(N*text_len) substring search.
-    super::profile::record_st_collect_scan(script_rest.len() as u64);
+    if !state_vars.is_empty() && !script_rest.is_empty() {
+        super::profile::record_st_collect_scan(script_rest.len() as u64);
+    }
     utils::text_retain_matching_identifiers(&script_rest, &mut state_vars);
 
     // Ensure reactive import names are included in state_vars for $.get()/$.mutate() wrapping.
@@ -4732,7 +4736,6 @@ fn transform_instance_script_for_visitors(
     // top-level bindings take precedence for scope-level transforms. For example,
     // if there's a top-level `const multiplier = () => { let multiplier = $state(2); ... }`,
     // the inner `multiplier` should NOT cause the outer `multiplier` to be wrapped with $.get().
-    super::profile::record_st_collect_scan(script_rest.len() as u64);
     let local_reactive_vars = extract_local_reactive_vars(&script_rest);
     let top_level_binding_names: rustc_hash::FxHashSet<&str> = analysis
         .root
@@ -4842,7 +4845,6 @@ fn transform_instance_script_for_visitors(
 
     // Collect proxy vars - variables initialized with $state({ ... }) or $state([ ... ])
     // These are converted to $.proxy() and don't need $.get() wrapping for property access
-    super::profile::record_st_collect_scan(script_rest.len() as u64);
     let proxy_vars = extract_proxy_vars(&script_rest);
 
     // Collect rest_prop variable names (from `let props = $props()`)
@@ -4975,15 +4977,19 @@ fn transform_instance_script_for_visitors(
 
     // Check for legacy mode (export let or export { x })
     // Also detect `export { x }` patterns which create BindableProp bindings
-    super::profile::record_st_collect_scan(script_rest.len() as u64);
-    let has_legacy_export_let = script_rest.lines().any(|line| {
-        let trimmed = line.trim();
-        trimmed.starts_with("export let ") || trimmed.starts_with("export let\t")
-    }) || analysis
-        .root
-        .bindings
-        .iter()
-        .any(|b| matches!(b.kind, BindingKind::BindableProp));
+    // The per-line walk can only succeed where the substring exists.
+    let has_legacy_export_let =
+        (memmem::find(script_rest.as_bytes(), b"export let").is_some() && {
+            super::profile::record_st_collect_scan(script_rest.len() as u64);
+            script_rest.lines().any(|line| {
+                let trimmed = line.trim();
+                trimmed.starts_with("export let ") || trimmed.starts_with("export let\t")
+            })
+        }) || analysis
+            .root
+            .bindings
+            .iter()
+            .any(|b| matches!(b.kind, BindingKind::BindableProp));
 
     // Collect exported names from analysis (needed for prop filtering below)
     let exported_names: Vec<String> = analysis.exports.iter().map(|e| e.name.clone()).collect();

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/profile.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/profile.rs
@@ -115,6 +115,19 @@ pub struct ScriptTextBreakdown {
     pub process_accumulated: Duration,
     /// Completed statements handed to the processor.
     pub statements: u64,
+    /// Source lines visited by the line loop.
+    pub loop_lines: u64,
+    /// Statements the runes fast path emitted without calling the processor.
+    pub fastpath_statements: u64,
+    /// Calls to the brace-less-control-header probe, and the bytes it had to
+    /// materialise to answer. Both are load-independent, so a change that
+    /// claims to remove this work has to move them.
+    pub ctrl_header_calls: u64,
+    pub ctrl_header_bytes: u64,
+    /// Script bytes handed to each whole-script scan in `collect_vars`,
+    /// summed over the scans that actually ran.
+    pub collect_scan_bytes: u64,
+    pub collect_scan_passes: u64,
     /// `transform_client_runes_with_skip_and_state`, the per-statement rune rewrite.
     pub runes: Duration,
     /// The legacy `$:` reactive-statement branch.
@@ -209,6 +222,12 @@ thread_local! {
     static ST_ENTRIES: Cell<u64> = const { Cell::new(0) };
     static ST_PROCESS_ACCUMULATED: Cell<Duration> = const { Cell::new(Duration::ZERO) };
     static ST_STATEMENTS: Cell<u64> = const { Cell::new(0) };
+    static ST_LOOP_LINES: Cell<u64> = const { Cell::new(0) };
+    static ST_FASTPATH_STATEMENTS: Cell<u64> = const { Cell::new(0) };
+    static ST_CTRL_HEADER_CALLS: Cell<u64> = const { Cell::new(0) };
+    static ST_CTRL_HEADER_BYTES: Cell<u64> = const { Cell::new(0) };
+    static ST_COLLECT_SCAN_BYTES: Cell<u64> = const { Cell::new(0) };
+    static ST_COLLECT_SCAN_PASSES: Cell<u64> = const { Cell::new(0) };
     static ST_RUNES: Cell<Duration> = const { Cell::new(Duration::ZERO) };
     static ST_REACTIVE_STMT: Cell<Duration> = const { Cell::new(Duration::ZERO) };
     static ST_REACTIVE_CALLS: Cell<u64> = const { Cell::new(0) };
@@ -489,6 +508,28 @@ pub fn record_st_line_loop(d: Duration) {
 }
 
 #[inline]
+pub fn record_st_loop_lines(n: u64) {
+    ST_LOOP_LINES.with(|c| c.set(c.get() + n));
+}
+
+#[inline]
+pub fn record_st_fastpath_statement() {
+    ST_FASTPATH_STATEMENTS.with(|c| c.set(c.get() + 1));
+}
+
+#[inline]
+pub fn record_st_ctrl_header(bytes: u64) {
+    ST_CTRL_HEADER_CALLS.with(|c| c.set(c.get() + 1));
+    ST_CTRL_HEADER_BYTES.with(|c| c.set(c.get() + bytes));
+}
+
+#[inline]
+pub fn record_st_collect_scan(bytes: u64) {
+    ST_COLLECT_SCAN_PASSES.with(|c| c.set(c.get() + 1));
+    ST_COLLECT_SCAN_BYTES.with(|c| c.set(c.get() + bytes));
+}
+
+#[inline]
 pub fn record_st_ast_transforms(d: Duration) {
     ST_AST_TRANSFORMS.with(|c| c.set(c.get() + d));
 }
@@ -508,6 +549,12 @@ pub fn take_script_text_breakdown() -> ScriptTextBreakdown {
         calls: ST_CALLS.with(|c| c.replace(0)),
         process_accumulated: ST_PROCESS_ACCUMULATED.with(|c| c.replace(Duration::ZERO)),
         statements: ST_STATEMENTS.with(|c| c.replace(0)),
+        loop_lines: ST_LOOP_LINES.with(|c| c.replace(0)),
+        fastpath_statements: ST_FASTPATH_STATEMENTS.with(|c| c.replace(0)),
+        ctrl_header_calls: ST_CTRL_HEADER_CALLS.with(|c| c.replace(0)),
+        ctrl_header_bytes: ST_CTRL_HEADER_BYTES.with(|c| c.replace(0)),
+        collect_scan_bytes: ST_COLLECT_SCAN_BYTES.with(|c| c.replace(0)),
+        collect_scan_passes: ST_COLLECT_SCAN_PASSES.with(|c| c.replace(0)),
         runes: ST_RUNES.with(|c| c.replace(Duration::ZERO)),
         reactive_stmt: ST_REACTIVE_STMT.with(|c| c.replace(Duration::ZERO)),
         reactive_calls: ST_REACTIVE_CALLS.with(|c| c.replace(0)),

--- a/crates/rsvelte_devtools/src/bin/compile_profile.rs
+++ b/crates/rsvelte_devtools/src/bin/compile_profile.rs
@@ -301,6 +301,15 @@ fn main() {
         );
     }
     println!("    (statements processed: {})", st.statements);
+    println!(
+        "    COUNTERS loop_lines {} | fastpath_stmts {} | ctrl_header {} calls / {} bytes | collect_scan {} passes / {} bytes",
+        st.loop_lines,
+        st.fastpath_statements,
+        st.ctrl_header_calls,
+        st.ctrl_header_bytes,
+        st.collect_scan_passes,
+        st.collect_scan_bytes
+    );
     let st_sum =
         st.prenormalize + st.collect_vars + st.line_loop + st.ast_transforms + st.post_passes;
     println!(


### PR DESCRIPTION
## What

Two things, both inside the instance-script line loop in `3_transform/client/mod.rs`.

**1. Load-independent counters for the text machinery.** `compile_profile` grows a `COUNTERS` row:
lines walked, control-header probe calls and bytes materialised, fast-pathed statements, whole-script
scan passes and bytes in `collect_vars`.

This is not decoration. Wall-clock attribution is currently unusable on a loaded box — two runs of the
same binary on the same input put `line_scan` at **2.08ms and 26.84ms** (13x). Every counter below was
bit-identical across the same pair of runs. A rewrite here can be byte-identical, green, and a complete
no-op; the counter is what rules that out.

**2. The brace-less-control-header probe now answers from the last line.**

`ends_with_braceless_control_header` only ever reads a *suffix* — `else` / `do`, or a `)` whose matching
`(` it scans back to. The caller was joining the entire accumulated statement to ask it, at **every line
where the depth counters read balanced**, and computing it eagerly even when a trailing comma or
operator already settled the boundary.

Now: evaluate lazily, and answer from the final line whenever that line settles it. The join survives
only for the case it exists for — a header whose `(` opens on an earlier line, or a last line that is
empty after comment stripping.

## Counter evidence

Bytes materialised for the probe, whole corpus, output unchanged:

| corpus | before | after |
|---|---:|---:|
| flowbite-svelte | 605,481 | **0** |
| bits-ui | 213,319 | 270 |
| svelte-ux | 246,676 | 1,233 |
| smelte | 175,988 | 730 |

Probe calls also fall slightly (laziness): smelte 2020 → 2018, svelte-ux 2872 → 2813, bits-ui 1524 → 1502.

## Why it is byte-identical

`braceless_control_header_from_last_line` returns `None` — deferring to the joined path — in exactly the
two cases where earlier lines can change the answer:

- the last line is empty after trimming, or
- it ends with `)` whose matching `(` is not on this line, or is at the very start of it (so the keyword
  before the paren could span the line break).

Otherwise the verdict provably depends only on the final line: a keyword match that would span the join
would have to include the `\n`, and `ends_with_keyword` cannot match across it.

## Sizing note

The brief that prompted this sized `line_loop` at 22.7% of `script_text_transform`. That timer brackets
`process_accumulated` too — `compile_profile` already prints the split, and the character scanner alone
is 0.4–5.3% of total across four corpora. The map and the corrected numbers are in the follow-up PR's
doc commit. This PR is a mechanical reduction, not the removal.

## Gates

Local `cargo test --release` in flight at time of opening; CI is authoritative for the corpus,
matrix and formatter-parity gates. No ratchet re-baselined.
