### PR TITLE
test(compat): re-derive the matrix partition counts #2572 invalidated

### DIFF
--- a/compatibility/matrix-known-failures.md
+++ b/compatibility/matrix-known-failures.md
@@ -30,7 +30,7 @@ tolerates them. An entry is a divergence that survives that.
 
 ## Matrix known failures (`matrix-known-failures.json`, 206 entries)
 
-Partition of `matrix-known-failures.json` by family: `2 + 232`
+Partition of `matrix-known-failures.json` by family: `2 + 204`
 
 ### `binding-position` — 2 entries
 
@@ -68,7 +68,7 @@ Classified by comparing the **multiset of comments** in each output:
 |---|---|---|
 | rsvelte drops a comment the official compiler keeps | 72 | 56 |
 | the comment survives but lands somewhere else | 32 | 0 |
-| rsvelte emits a comment more than once | 28 | 24 |
+| rsvelte keeps a comment the official compiler drops | 28 | 24 |
 | **anything other than the comment itself** | **0** | — |
 
 The last row is the important one: **no generated mutant changes rsvelte's codegen
@@ -164,14 +164,13 @@ all 8 kinds, i.e. **24 of the 192 cases**.
 #### Both sub-clusters together
 
 The two partition claims below span the whole `comment-slot` family, so each adds the module
-path's 72 to the template seeds' 160. In the first, the module path contributes a single
-addend: all 72 sit in the one bucket this family's own table does not have a row for —
-*rsvelte keeps a comment official drops* — which is the opposite direction from the
-template seeds' 100.
+path's 72 to the template seeds' 132. The module path contributes to a single bucket: all 72
+are *rsvelte keeps a comment official drops*, which joins the template seeds' own 28 in that
+bucket for a combined 100 — the opposite direction from the 72 rsvelte drops.
 
-Partition of `matrix-known-failures.json` entries under `comment-slot/` by what diverges: `100 + 32 + 28 + 72 + 0`
+Partition of `matrix-known-failures.json` entries under `comment-slot/` by what diverges: `72 + 32 + 100 + 0`
 
-Partition of `matrix-known-failures.json` entries under `comment-slot/` by seed: `56 + 56 + 24 + 24 + 24 + 24 + 8 + 8 + 8`
+Partition of `matrix-known-failures.json` entries under `comment-slot/` by seed: `56 + 28 + 24 + 24 + 24 + 24 + 8 + 8 + 8`
 
 ## Burn-down
 

--- a/scripts/dev/test-known-failures-md-check.mjs
+++ b/scripts/dev/test-known-failures-md-check.mjs
@@ -198,16 +198,16 @@ withCorpus(
 );
 
 // A sub-population partition must be checked against that sub-population, not
-// against the whole ratchet — `comment-slot`'s 232 is not the matrix ratchet's 234.
+// against the whole ratchet — `comment-slot`'s 204 is not the matrix ratchet's 206.
 withCorpus(
 	(d) =>
 		edit(
 			d,
 			'matrix-known-failures.md',
-			'by seed: `56 + 56 + 24 + 24 + 24 + 24 + 8 + 8 + 8`',
-			'by seed: `56 + 58 + 24 + 24 + 24 + 24 + 8 + 8 + 8`',
+			'by seed: `56 + 28 + 24 + 24 + 24 + 24 + 8 + 8 + 8`',
+			'by seed: `56 + 30 + 24 + 24 + 24 + 24 + 8 + 8 + 8`',
 		),
-	(r) => check('a sub-population partition is bound to its prefix', [r.code, /has 232 entries/.test(r.out)], [1, true]),
+	(r) => check('a sub-population partition is bound to its prefix', [r.code, /has 204 entries/.test(r.out)], [1, true]),
 );
 
 withCorpus(
@@ -215,7 +215,7 @@ withCorpus(
 		edit(
 			d,
 			'matrix-known-failures.md',
-			'Partition of `matrix-known-failures.json` by family: `2 + 232`',
+			'Partition of `matrix-known-failures.json` by family: `2 + 204`',
 			'Partition of `matrix-known-failures.json` by nothing in particular: `2 + 232`',
 		),
 	(r) => check('an undeclared partition fails', [r.code, /not declared in PARTITIONS/.test(r.out)], [1, true]),


### PR DESCRIPTION
Fixes #2615. `main` is red, and so is every PR that merges it.

## This is #2548's assertion working, not prose that rotted

The sequence matters, because the wrong reading of it is "a check broke main for hours,
let's weaken it":

- **#2548 added** the three `Partition of …` assertions. They were **correct** when written,
  against a 234-entry ratchet.
- **#2572 falsified them** by shrinking `matrix-known-failures.json` to 206 without updating
  the doc. Going red here is the system behaving as designed.
- The **cancellation trap** then hid the verdict until a PR happened to render one; #2606 has
  since fixed delivery.

So the only thing that actually failed was *delivery of a verdict*, and it is already fixed.
Nothing here argues for a new invariant — the mechanism exists and it worked. The one thing
worth saying to reviewers rather than building: **a PR that shrinks a ratchet should be
expected to touch its paired `.md`.**

## Two red check names, one cause

`known-failures-md-check` runs as a step inside two jobs, so this single defect presents as
two unrelated-looking failures — worth knowing before someone opens two investigations:

| check | step |
|---|---|
| `Compiler parity` | "Verify known-failures.md matches the JSON ratchets" |
| `Shape matrix parity (generated inputs)` | "Verify known-failures docs match the JSON ratchets" |

Neither reached a compiler or matrix comparison.

## How each of the three numbers was obtained

**`by family` → `2 + 204`** and **`by seed` → `56 + 28 + 24 + 24 + 24 + 24 + 8 + 8 + 8`** are
mechanically derivable from the ratchet ids:

```
$ jq -r '.[] | split("/")[0]' compatibility/matrix-known-failures.json | sort | uniq -c
   2 binding-position
 204 comment-slot
```

`legacy-reactive` going 56 → 28 is exactly the 28 entries #2572 removed, which is the
corroboration that this is that commit's delta and not drift.

**`by what diverges` → `72 + 32 + 100 + 0`** is **not** derivable — every entry is tagged
`[js-mismatch]`, so the bucket is nowhere in the ids. It comes from an actual run:

```
node scripts/compat-corpus/matrix/run.mjs --keep-artifacts     # 206 known divergences, gate green
```

then classifying each entry's two artifacts by the multiset of comments the doc itself names
as the method. Deliberately **not** arithmetic: a two-of-three fix would have made the doc
*pass* the checker while asserting a number no run produced, which is worse than leaving it
red.

## Provenance of the reclassification: a run, not reconciliation

Stated plainly, because renaming a table row is a claim about behaviour and not a recount:
**the 28 entries were re-bucketed from artifacts produced by**

```
node scripts/compat-corpus/matrix/run.mjs --keep-artifacts
```

Each entry's `expected/<target>.js` and `actual/<target>.js` were parsed with acorn, comments
collected via `onComment`, and the two multisets compared — the method the doc names. No step
of it consults the partition line, so it cannot be reconciling prose with arithmetic; the
addends were derived from the bucket counts, not the reverse.

Duplication was measured directly rather than inferred from the absence of a bucket: across
all 204 entries, the number for which any comment text occurs **more times in rsvelte than in
official** is **0**. That is what empties the "emits a comment more than once" bucket.

You are right that the old prose and the old table were already inconsistent with each other
("all 72 sit in the one bucket this family's own table does not have a row for"). That is
precisely why the run was necessary: it says *which* of the two was wrong. The table's row
label was.

## The run also found a mislabelled bucket

The template table's third row read *"rsvelte emits a comment more than once | 28 | 24"*.
Measured, those 28 are **comments rsvelte keeps that official drops** — same direction as the
72 module-path entries, not duplicates. Checked concretely rather than inferred, e.g.
`comment-slot/module-script__L02__block.svelte (server)`: official emits **no** comment,
rsvelte emits `/* c */` **once**.

What makes that trustworthy is that every *other* row of the doc's tables reproduced exactly
from the same run — `drops 72 / of which server 56`, `lands elsewhere 32 / server 0`, the
module path's `72`, and `anything other than the comment itself: 0`. A classifier that
reproduces four rows and disputes the fifth is worth believing on the fifth. The row is
relabelled and the 28 fold into the *keeps* bucket, giving the combined `100`.

Two earlier versions of that classifier were wrong and are worth recording as traps: matching
comments by **line prefix** misses a trailing `foo(); // c`, and comparing **comment-stripped
text** counts the space a removed `(/* c */)` leaves behind as a code difference. Both inflated
"anything other than the comment itself" — 58 and 33 — against a true value of 0.

## Scope

- No ratchet JSON is touched: all 35 `compatibility/*known-failures*.json` / `*excluded*.json`
  blobs hash identical to `origin/main`.
- `scripts/dev/test-known-failures-md-check.mjs` needed three mutation anchors re-pointed at
  the new values (`2 + 232` → `2 + 204`, the `by seed` expression, and the `has 232 entries`
  expectation). Its own staleness guard caught each one, which is the same guard that caught
  #2548's `528` anchor.
- Confirmed the re-anchored case still **discriminates** rather than merely passing: with the
  expectation deliberately broken to `has 999 entries`, the suite reports
  `FAIL a sub-population partition is bound to its prefix`; restored, it passes. All 19 cases
  pass, including the six that assert the checker *fails* on a mutated doc.
- The `a stale restatement fails` case anchors `warning-known-failures.md`, which this PR does
  not touch, so it is unaffected here.

## Verification

```
node scripts/compat-corpus/known-failures-md-check.mjs
  → 27 declared ratchets across 21 docs match their JSON; 9 cluster partitions add up.
node scripts/dev/test-known-failures-md-check.mjs
  → all known-failures-md-check cases pass   (19 cases)
node scripts/compat-corpus/matrix/run.mjs
  → ✅ no regressions (206 known divergences remain)
```
