### PR TITLE
fix(transform): find an import's terminator lexically

### DIFF
--- a/.changeset/import-comment-delimiter.md
+++ b/.changeset/import-comment-delimiter.md
@@ -1,0 +1,18 @@
+---
+"@rsvelte/compiler": patch
+---
+
+Find an `import` statement's terminator lexically, so a `;` inside a comment does not truncate the specifier list
+
+`extract_imports` accumulated a multi-line `import` until a line "closed" it, and both the
+close test (`trimmed.contains(';')`) and `import_statement_end` read raw bytes. A `// ; c`
+line inside the specifier list closed the import after the previous specifier, terminated it
+with the comment's own `;`, and routed the rest of the statement — starting mid-comment —
+into the component body, so the output stopped being JavaScript.
+
+The two tests are now one lexical scan, which is what kept them from disagreeing: comments,
+template literals and regex literals are opaque, and the open-block-comment state already
+carried by `ScanState` is consulted, so a `;` on the continuation line of a `/* … */` is text
+too. All four `contains(';')` sites are replaced — `extract_imports` and
+`extract_imports_with_projection` are two copies of the same loop, and fixing one would have
+left the other live depending on whether source projection is on.

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
@@ -87,6 +87,7 @@ use std::cell::{Cell, RefCell};
 use std::rc::Rc;
 use std::sync::LazyLock;
 
+use crate::compiler::phases::phase3_transform::shared::js_scan::skip_opaque;
 use memchr::memmem;
 // rustc_hash is used by submodules via their own imports
 
@@ -2930,16 +2931,14 @@ pub(crate) fn extract_imports(script: &str) -> (Vec<String>, String) {
 
     for line in script.lines() {
         let line_starts_in_code = scan.in_code();
+        let line_starts_in_block_comment = scan.in_block_comment;
         scan.advance(line);
         let scan = line_starts_in_code; // shadow for the decision below
         if let Some(ref mut import_lines) = current_import {
             let trimmed = line.trim();
-            let closes = trimmed.contains(';')
-                || trimmed.ends_with('\'')
-                || trimmed.ends_with('"')
-                || trimmed.ends_with('`');
-            if closes {
-                if let Some(end) = import_statement_end(trimmed)
+            let scanned = scan_import_line(trimmed, line_starts_in_block_comment);
+            if scanned.closes(trimmed.len()) {
+                if let Some(end) = scanned.end()
                     && end < trimmed.len()
                     && !trimmed[end..].trim().is_empty()
                 {
@@ -2964,12 +2963,11 @@ pub(crate) fn extract_imports(script: &str) -> (Vec<String>, String) {
             let trimmed = line.trim();
             if scan && (trimmed.starts_with("import ") || trimmed.starts_with("import{")) {
                 // Check if this import is complete on one line
-                if trimmed.contains(';')
+                let scanned = scan_import_line(trimmed, false);
+                if scanned.semicolon.is_some()
                     || is_complete_side_effect_import(trimmed)
                     || (memmem::find(trimmed.as_bytes(), b" from ").is_some()
-                        && (trimmed.ends_with('\'')
-                            || trimmed.ends_with('"')
-                            || trimmed.ends_with('`')))
+                        && scanned.last_string_end == Some(trimmed.len()))
                 {
                     // The line begins with a *complete* import statement but may
                     // carry additional imports and/or statements on the same
@@ -3021,16 +3019,14 @@ fn extract_imports_with_projection(script: &str) -> (Vec<String>, String, Vec<Co
             physical_line
         };
         let line_starts_in_code = scan.in_code();
+        let line_starts_in_block_comment = scan.in_block_comment;
         scan.advance(line);
         let scan = line_starts_in_code;
         if let Some(ref mut import_lines) = current_import {
             let trimmed = line.trim();
-            let closes = trimmed.contains(';')
-                || trimmed.ends_with('\'')
-                || trimmed.ends_with('"')
-                || trimmed.ends_with('`');
-            if closes {
-                if let Some(end) = import_statement_end(trimmed)
+            let scanned = scan_import_line(trimmed, line_starts_in_block_comment);
+            if scanned.closes(trimmed.len()) {
+                if let Some(end) = scanned.end()
                     && end < trimmed.len()
                     && !trimmed[end..].trim().is_empty()
                 {
@@ -3062,12 +3058,11 @@ fn extract_imports_with_projection(script: &str) -> (Vec<String>, String, Vec<Co
         } else {
             let trimmed = line.trim();
             if scan && (trimmed.starts_with("import ") || trimmed.starts_with("import{")) {
-                if trimmed.contains(';')
+                let scanned = scan_import_line(trimmed, false);
+                if scanned.semicolon.is_some()
                     || is_complete_side_effect_import(trimmed)
                     || (memmem::find(trimmed.as_bytes(), b" from ").is_some()
-                        && (trimmed.ends_with('\'')
-                            || trimmed.ends_with('"')
-                            || trimmed.ends_with('`')))
+                        && scanned.last_string_end == Some(trimmed.len()))
                 {
                     let trimmed_start = line.len() - line.trim_start().len();
                     let (remainder, remainder_offset) =
@@ -3199,39 +3194,72 @@ fn compose_script_projection(
 /// then a single string literal (single or double quoted), then optional
 /// whitespace until end-of-line. Anything else (bindings, `from`, trailing
 /// content, dynamic `import(...)` calls) returns `false`.
-/// Find the byte index at which the leading import statement in `s` ends.
+#[derive(Default)]
+struct ImportLineScan {
+    /// Just past the first `;` that is code.
+    semicolon: Option<usize>,
+    /// Just past the last string or template literal that is code.
+    last_string_end: Option<usize>,
+}
+
+impl ImportLineScan {
+    /// Where the statement ends: the `;` if there is one, else — ASI — the last
+    /// completed string literal, which is the module specifier.
+    fn end(&self) -> Option<usize> {
+        self.semicolon.or(self.last_string_end)
+    }
+
+    fn closes(&self, line_len: usize) -> bool {
+        self.semicolon.is_some() || self.last_string_end == Some(line_len)
+    }
+}
+
+/// Scan one line of an `import` statement for its terminator.
 ///
-/// String literals (single/double quotes and template backticks) are skipped
-/// honouring backslash escapes, so a `;` inside a module specifier is ignored.
-/// If a top-level `;` is found it terminates the statement (index just past it).
-/// Otherwise — ASI — the statement ends just past the last completed top-level
-/// string literal (the module specifier). Returns `None` if neither is present.
-fn import_statement_end(s: &str) -> Option<usize> {
+/// A `;` or a closing quote inside a comment is text, and reading it as the
+/// terminator cut the statement mid-specifier-list (#2601).
+/// `in_block_comment` carries that state across the preceding lines.
+fn scan_import_line(s: &str, in_block_comment: bool) -> ImportLineScan {
     let bytes = s.as_bytes();
+    let mut out = ImportLineScan::default();
     let mut i = 0usize;
-    let mut last_string_end: Option<usize> = None;
-    while i < bytes.len() {
-        match bytes[i] {
-            b';' => return Some(i + 1),
-            q @ (b'\'' | b'"' | b'`') => {
-                i += 1;
-                while i < bytes.len() {
-                    if bytes[i] == b'\\' && i + 1 < bytes.len() {
-                        i += 2;
-                        continue;
-                    }
-                    if bytes[i] == q {
-                        i += 1;
-                        break;
-                    }
-                    i += 1;
-                }
-                last_string_end = Some(i);
-            }
-            _ => i += 1,
+    if in_block_comment {
+        match memmem::find(bytes, b"*/") {
+            Some(at) => i = at + 2,
+            None => return out,
         }
     }
-    last_string_end
+    let mut prev: Option<u8> = None;
+    while i < bytes.len() {
+        let quoted = matches!(bytes[i], b'\'' | b'"' | b'`');
+        if let Some((next, is_comment)) = skip_opaque(bytes, i, prev) {
+            if quoted {
+                out.last_string_end = Some(next);
+            }
+            if !is_comment {
+                prev = Some(b'x');
+            }
+            i = next;
+            continue;
+        }
+        if bytes[i] == b';' {
+            out.semicolon = Some(i + 1);
+            return out;
+        }
+        if !bytes[i].is_ascii_whitespace() {
+            prev = Some(bytes[i]);
+        }
+        i += 1;
+    }
+    out
+}
+
+/// Find the byte index at which the leading import statement in `s` ends.
+///
+/// Callers pass a slice that starts at a statement boundary, so no comment can
+/// already be open.
+fn import_statement_end(s: &str) -> Option<usize> {
+    scan_import_line(s, false).end()
 }
 
 /// Peel every complete leading `import` statement off `s`, pushing each onto

--- a/crates/rsvelte_core/tests/import_comment_delimiter_2601.rs
+++ b/crates/rsvelte_core/tests/import_comment_delimiter_2601.rs
@@ -1,0 +1,135 @@
+//! A `;` inside a comment terminated the import statement the client script
+//! pipeline hoists, so the specifier list was cut in half.
+//!
+//! `extract_imports` accumulates a multi-line `import` until a line "closes" it,
+//! and both the close test and `import_statement_end` read raw bytes. A
+//! `// ; c` line inside the specifier list closed the import after the previous
+//! specifier, terminated it with the comment's own `;`, and routed the rest of
+//! the statement — starting mid-comment — into the component body. The output
+//! stops being JavaScript.
+//!
+//! Found by the corpus mutation sweep (#2601) on
+//! `flowbite-svelte/…/Navbar__m0__line-with-semi.svelte`, whose mutant puts the
+//! comment inside a 20-specifier import.
+
+use rsvelte_core::{CompileOptions, GenerateMode, compile};
+
+fn compile_with(src: &str, generate: GenerateMode, dev: bool) -> String {
+    compile(
+        src,
+        CompileOptions {
+            filename: Some("T.svelte".into()),
+            generate,
+            dev,
+            ..Default::default()
+        },
+    )
+    .map(|r| r.js.code)
+    .unwrap_or_else(|e| format!("COMPILE_ERROR: {e:?}"))
+}
+
+#[track_caller]
+fn assert_parses(code: &str, what: &str) {
+    assert!(!code.contains("COMPILE_ERROR"), "{what}: {code}");
+    let allocator = oxc_allocator::Allocator::default();
+    let ret = oxc_parser::Parser::new(&allocator, code, oxc_span::SourceType::mjs()).parse();
+    assert!(
+        ret.diagnostics.is_empty(),
+        "{what}: emitted JS does not parse: {:?}\n--- output ---\n{code}",
+        ret.diagnostics
+    );
+}
+
+/// Every target compiles the instance script through `extract_imports`, so the
+/// defect is target-independent — asserting one would leave two live.
+#[track_caller]
+fn assert_all_targets_parse(src: &str, what: &str) {
+    for (generate, dev, label) in [
+        (GenerateMode::Client, false, "client"),
+        (GenerateMode::Server, false, "server"),
+        (GenerateMode::Client, true, "client-dev"),
+    ] {
+        assert_parses(
+            &compile_with(src, generate, dev),
+            &format!("{what} ({label})"),
+        );
+    }
+}
+
+const IMPORTED: &str = "<p>{n}{A}{B}</p>";
+
+/// The reported shape: a line comment carrying `;` inside the specifier list.
+#[test]
+fn a_semicolon_in_a_line_comment_does_not_end_the_import() {
+    let src = format!(
+        "<script>\n  import {{\n    A,\n    // ; c\n    B\n  }} from \"somewhere\";\n  let n = 1;\n</script>\n\n{IMPORTED}"
+    );
+    let out = compile_with(&src, GenerateMode::Client, false);
+    assert_parses(&out, "line comment with a semicolon");
+    assert!(
+        out.contains("import { A, B } from \"somewhere\"")
+            || out.contains("B\n} from \"somewhere\""),
+        "the specifier list lost `B`: {out}"
+    );
+    assert_all_targets_parse(&src, "line comment with a semicolon");
+}
+
+/// A block comment on its own line inside the list. `ScanState` already carried
+/// the open-comment state across lines for the *starts an import* decision; the
+/// terminator search did not consult it.
+#[test]
+fn a_semicolon_in_a_block_comment_does_not_end_the_import() {
+    let src = format!(
+        "<script>\n  import {{\n    A,\n    /* ; */\n    B\n  }} from \"somewhere\";\n  let n = 1;\n</script>\n\n{IMPORTED}"
+    );
+    assert_all_targets_parse(&src, "block comment with a semicolon");
+}
+
+/// A block comment that opens on one line and closes on the next, carrying the
+/// `;` on the continuation line — the only case a per-line scan cannot get right
+/// without the carried state.
+#[test]
+fn a_semicolon_in_a_multi_line_block_comment_does_not_end_the_import() {
+    let src = format!(
+        "<script>\n  import {{\n    A,\n    /* open\n       ; still comment */\n    B\n  }} from \"somewhere\";\n  let n = 1;\n</script>\n\n{IMPORTED}"
+    );
+    assert_all_targets_parse(&src, "multi-line block comment with a semicolon");
+}
+
+/// Control that already passed: a `;` inside the module specifier string. Kept
+/// because it is the property the old byte scan *did* have, and a rewrite that
+/// lost it would otherwise go unnoticed.
+#[test]
+fn a_semicolon_inside_the_specifier_string_still_does_not_end_the_import() {
+    let src = "<script>\n  import A from \"a;b\";\n  let n = 1;\n</script>\n\n<p>{n}{A}</p>";
+    let out = compile_with(src, GenerateMode::Client, false);
+    assert_parses(&out, "semicolon inside the specifier");
+    assert!(
+        out.contains("\"a;b\""),
+        "the specifier was truncated: {out}"
+    );
+}
+
+/// Control: a comment with no delimiter in it. This one passes without the fix,
+/// which is what makes the set above discriminating rather than merely green.
+#[test]
+fn a_plain_comment_in_the_specifier_list_is_unaffected() {
+    let src = format!(
+        "<script>\n  import {{\n    A,\n    // c\n    B\n  }} from \"somewhere\";\n  let n = 1;\n</script>\n\n{IMPORTED}"
+    );
+    assert_all_targets_parse(&src, "plain comment");
+}
+
+/// Negative control: an import that really does end with `;` followed by code on
+/// the same physical line must still be split there. Making the scanner ignore
+/// comments must not make it ignore the terminator it is looking for.
+#[test]
+fn a_real_semicolon_still_splits_the_line() {
+    let src = "<script>\n  import {\n    A\n  } from \"somewhere\"; let n = 1;\n</script>\n\n<p>{n}{A}</p>";
+    let out = compile_with(src, GenerateMode::Client, false);
+    assert_parses(&out, "real semicolon splits");
+    assert!(
+        out.contains("let n = 1") || out.contains("n = 1"),
+        "the statement after the import was swallowed into the import: {out}"
+    );
+}


### PR DESCRIPTION
Closes the second root cause in #2601 — the `client` / `client-dev` half of the 43 new mutation failures. (#2605 fixed the first, the `$effect` deletion.)

## Reproducer

`Min4.svelte`, `generate: 'client'`:

```svelte
<script>
  import {
    A,
    // ; c
    B
  } from "somewhere";
  let n = 1;
</script>

<p>{n}{A}{B}</p>
```

rsvelte emits:

```js
import { A,;

var root = $.from_html(`<p> </p>`);

export default function Min4($$anchor) {
	c
	  B
	} from "somewhere";
	let n = 1;
```

The import list is cut after `A,`, terminated with a `;` that came out of the comment, and the remainder of the statement is emitted inside the component function.

That is `flowbite-svelte/src/routes/admin-dashboard/(sidebar)/Navbar__m0__line-with-semi.svelte` reduced: its mutant puts `// ; c` inside a 20-specifier `import { … } from "flowbite-svelte-icons"`, and the CI artifact shows the same truncation (`… HeartSolid,;`).

## Mechanism

`extract_imports` accumulates a multi-line import until a line "closes" it:

```rust
let closes = trimmed.contains(';')
    || trimmed.ends_with('\'')
    || trimmed.ends_with('"')
    || trimmed.ends_with('`');
```

`trimmed.contains(';')` is a raw byte test, so `// ; c` closes the import. `import_statement_end` then returns the offset just past that same `;` — it skips string literals but not comments — the accumulator keeps only the text before it, and everything after is routed to `rest`, i.e. into the component body.

The function *does* carry a lexical scanner (`ScanState`), but it was consulted only for whether a line **starts** an import. Once inside one, the terminator search was raw bytes.

## Fix

The close test and the terminator search become **one** scan, `scan_import_line`, built on the existing `js_scan::skip_opaque`. That is the substance of the fix, not just a refactor: two independent tests for "does this line end the statement" is the shape the bug lived in — `closes` said yes at a byte `import_statement_end` then agreed with, and neither could be corrected without the other.

It also consults the open-block-comment state `ScanState` already carried, so a `;` on the **continuation line** of a `/* … */` is text too — the one case a per-line scan cannot get right on its own.

**All four `contains(';')` sites are replaced.** `extract_imports` and `extract_imports_with_projection` are two copies of the same loop, each carrying the test twice; fixing one copy would leave the other live depending on whether source projection is on — the failure mode that made `track_reactivity_loss` a three-way bug. `import_statement_end` keeps its name for `peel_leading_imports_ref`, which is only ever called on a slice starting at a statement boundary.

The server module path calls `extract_imports_str` → `extract_imports`, so this is one fix for all three targets, not three.

## Tests

`crates/rsvelte_core/tests/import_comment_delimiter_2601.rs`, 6 tests, each asserting the emitted JS **parses** (oxc) on client, server and client-dev:

| test | without the fix |
|---|---|
| `;` in a line comment inside the specifier list | ❌ fails |
| `;` in a single-line block comment | ❌ fails |
| `;` on the continuation line of a multi-line block comment | ❌ fails |
| control: `;` inside the module specifier string | ✅ passes |
| control: a comment with no delimiter | ✅ passes |
| negative control: a real `;` still splits the line | ✅ passes |

**3 of 6 fail without the change**, and the 3 that pass are exactly the controls — which is what makes the set discriminating rather than merely green. In particular the last one guards the direction this fix could have overshot in: teaching the scanner to ignore comments must not teach it to ignore the terminator it is looking for.

## Local verification

`--lib` (1528), `ssr`, `runtime` (incl. `runtime_legacy` / `runtime_runes` / `hydration`), `sourcemaps`, `sourcemaps_gate`, `print`, `preprocess` all pass, plus `cargo clippy --all-targets -- -D warnings`. The corpus and mutation gates are CI's.
