### PR TITLE
test(devtools): make the differential corpus gate pin its own base

### DIFF
--- a/crates/rsvelte_devtools/src/bin/corpus_hash.rs
+++ b/crates/rsvelte_devtools/src/bin/corpus_hash.rs
@@ -1,7 +1,13 @@
 //! Hash every compiled output over a corpus, so two builds can be compared for
 //! byte identity without keeping the outputs themselves on disk.
 //!
-//! Usage: `corpus_hash <dir> [--server] [--dev]`
+//! Usage: `corpus_hash <dir> --label <build-id> [--server] [--dev]`
+//!
+//! `--label` is **required** and names the build this run measures — normally the
+//! commit it was built from. A differential result is meaningless without it: the
+//! base moves on the timescale of a single verification run, and diffing a new arm
+//! against a stale baseline reports the base's own drift as if it belonged to the
+//! change under test.
 
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
@@ -11,8 +17,18 @@ use rsvelte_core::{CompileOptions, GenerateMode, compile};
 fn main() {
     let args: Vec<String> = std::env::args().skip(1).collect();
     let Some(dir) = args.iter().find(|a| !a.starts_with("--")) else {
-        eprintln!("usage: corpus_hash <dir> [--server] [--dev]");
+        eprintln!("usage: corpus_hash <dir> --label <build-id> [--server] [--dev]");
         std::process::exit(1);
+    };
+    let Some(label) = args
+        .iter()
+        .position(|a| a == "--label")
+        .and_then(|i| args.get(i + 1))
+    else {
+        eprintln!(
+            "corpus_hash: --label <build-id> is required so the output records which build it measures"
+        );
+        std::process::exit(2);
     };
     let dev = args.iter().any(|a| a == "--dev");
     let generate = if args.iter().any(|a| a == "--server") {
@@ -24,6 +40,18 @@ fn main() {
     let mut files = Vec::new();
     collect(std::path::Path::new(dir), &mut files);
     files.sort();
+
+    // Comparison tooling skips `#` lines, so this records the build without
+    // showing up as a difference between two arms.
+    println!(
+        "# corpus_hash label={label} mode={} dev={dev} files={}",
+        if matches!(generate, GenerateMode::Server) {
+            "server"
+        } else {
+            "client"
+        },
+        files.len()
+    );
 
     for path in files {
         let Ok(source) = std::fs::read_to_string(&path) else {

--- a/scripts/dev/diff-corpus-hash.mjs
+++ b/scripts/dev/diff-corpus-hash.mjs
@@ -1,0 +1,69 @@
+#!/usr/bin/env node
+// Compare two `corpus_hash` runs for byte identity.
+//
+//   node scripts/dev/diff-corpus-hash.mjs <base.txt> <arm.txt>
+//
+// Two guards, both for failures that have actually happened here:
+//
+//  1. **The labels must differ.** `cargo build … | tail -3 && cp …` takes `tail`'s
+//     exit status, so a failed build reports success and copies a stale binary —
+//     and the comparison then diffs a build against itself and reports a perfect
+//     zero. A zero from one binary is indistinguishable from a zero from two.
+//  2. **Both files must carry a label.** Without it a run cannot say which build
+//     it measured, and diffing a new arm against a stale baseline attributes the
+//     base's own drift to the change under test.
+//
+// Exit 0 = identical, 1 = differences, 2 = the comparison itself is invalid.
+
+import { readFileSync } from 'node:fs';
+
+const [, , basePath, armPath] = process.argv;
+if (!basePath || !armPath) {
+  console.error('usage: diff-corpus-hash.mjs <base.txt> <arm.txt>');
+  process.exit(2);
+}
+
+function load(path) {
+  const lines = readFileSync(path, 'utf8').split('\n').filter(Boolean);
+  const header = lines.find((l) => l.startsWith('# corpus_hash '));
+  if (!header) {
+    console.error(`${path}: no '# corpus_hash' header — rerun with --label`);
+    process.exit(2);
+  }
+  const label = /label=(\S+)/.exec(header)?.[1];
+  const mode = /mode=(\S+)/.exec(header)?.[1];
+  const dev = /dev=(\S+)/.exec(header)?.[1];
+  return { label, mode, dev, rows: lines.filter((l) => !l.startsWith('#')) };
+}
+
+const base = load(basePath);
+const arm = load(armPath);
+
+if (base.label === arm.label) {
+  console.error(
+    `both files are labelled '${base.label}' — this compares a build against ` +
+      `itself and will report 0 differences whatever the change does`,
+  );
+  process.exit(2);
+}
+if (base.mode !== arm.mode || base.dev !== arm.dev) {
+  console.error(
+    `target mismatch: ${base.mode}/dev=${base.dev} vs ${arm.mode}/dev=${arm.dev}`,
+  );
+  process.exit(2);
+}
+if (base.rows.length !== arm.rows.length) {
+  console.error(`file-count mismatch: ${base.rows.length} vs ${arm.rows.length}`);
+  process.exit(2);
+}
+
+let differing = 0;
+for (let i = 0; i < base.rows.length; i++) {
+  if (base.rows[i] !== arm.rows[i]) differing++;
+}
+
+console.log(
+  `${base.label} → ${arm.label}  ${base.mode}${base.dev === 'true' ? '-dev' : ''}  ` +
+    `${base.rows.length} files  ${differing === 0 ? 'IDENTICAL' : `${differing} DIFFER`}`,
+);
+process.exit(differing === 0 ? 0 : 1);


### PR DESCRIPTION
Makes the differential corpus-output gate record which build it measured, and refuse the two comparisons that silently report a perfect zero.

## Why

While a byte-identity gate for #2622 was in flight, main moved. Re-running the base arm at the new tip and diffing the two baselines against each other:

```
old base 23e68acf vs new base c3968878, huly client:  8 files differ
```

**Main changed its own output on 8 files** (#2426 moved diagnostic source ranges). Diffing the new arm against the stale baseline would have reported those 8 as differences *in the change under test*, and the obvious next step — hunting your own diff for a behaviour change that isn't there — plausibly ends in a wrong "fix" rather than merely a wasted hour.

The base moves on the timescale of a single verification run. A rule that depends on remembering to write the SHA down fails exactly when the session is busy, which is when the base is most likely to have moved. So the tool records it.

## What changed

**`corpus_hash` now requires `--label <build-id>`** (exit 2 without it) and emits it as a `#` header line, which comparison tooling skips so it never counts as a difference:

```
# corpus_hash label=c3968878 mode=client dev=false files=449
```

**`scripts/dev/diff-corpus-hash.mjs`** performs the comparison and refuses three invalid ones outright (exit 2, distinct from exit 1 "differences found"):

- **equal labels** — this is what a stale binary produces. `cargo build … | tail -3 && cp …` takes `tail`'s exit status, so a *failed* build reports success and copies the previous binary; the comparison then diffs a build against itself and reports 0 differences whatever the change does. I hit this exact sequence. A zero from one binary and a zero from two are indistinguishable in the output.
- **missing header** — an unpinned run cannot say what it measured.
- **mismatched target or file count** — comparing client against dev, or two different corpora.

## Controls

Every guard was exercised, in both directions:

| case | expected | got |
|---|---|---|
| run without `--label` | exit 2 | ✅ exit 2 |
| run with `--label` | exit 0 + header | ✅ |
| two labels, identical content | exit 0 IDENTICAL | ✅ |
| **same label both sides** | exit 2 refused | ✅ |
| **header stripped** | exit 2 refused | ✅ |
| client vs dev | exit 2 refused | ✅ |
| **one row corrupted** | exit 1, `1 DIFFER` | ✅ |

The last row matters most: the first four prove the guards *fire*, but a comparator that refuses everything would also pass them. Corrupting a single row proves it still reports a real difference — otherwise the IDENTICAL results this gate produces would be worthless.

Devtools only; no compiler code and no gate in CI depends on it yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
