### PR TITLE
fix(transform): close a rune field's derived on a new line after a trailing comment

### DIFF
--- a/.changeset/rune-argument-trailing-comment.md
+++ b/.changeset/rune-argument-trailing-comment.md
@@ -1,0 +1,15 @@
+---
+"@rsvelte/compiler": patch
+---
+
+Close a rune field's `$.derived(…)` on a new line when its argument ends in a `//` comment
+
+The server class-field path splices the `$derived(…)` argument verbatim and then appends the
+closing paren. `value.trim()` removes the newline that ended a trailing `//` comment, so the
+paren landed inside the comment and the call was never closed — the emitted module stopped
+being JavaScript.
+
+An object-literal argument is worse, because it takes a wrapping-paren branch and loses two.
+
+The variant carrying a delimiter (`// ) c`) already worked: it bails to the AST path, which
+relocates the comment. It is the *plain* comment that was unguarded here.

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/transform_script.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/transform_script.rs
@@ -4153,6 +4153,27 @@ fn unthunk_no_arg_ident_call(expr: &str) -> Option<&str> {
     Some(id_trimmed)
 }
 
+/// The rune argument as it goes inside `$.derived(…)`, verbatim except for an
+/// object literal's wrapping parens — and a newline when the argument ends
+/// inside a `//` comment, which would otherwise swallow the closing paren the
+/// caller appends.
+fn rune_field_value(value: &str) -> String {
+    let value = value.trim();
+    let mut out = String::with_capacity(value.len() + 3);
+    let needs_paren = value.starts_with('{');
+    if needs_paren {
+        out.push('(');
+    }
+    out.push_str(value);
+    if crate::compiler::phases::phase3_transform::shared::js_scan::ends_inside_line_comment(&out) {
+        out.push('\n');
+    }
+    if needs_paren {
+        out.push(')');
+    }
+    out
+}
+
 /// Emit the server replacement for a single rune call, given the raw text
 /// `inner` between the call's parentheses (verbatim, including any comments /
 /// trailing comma / formatting) and which derived flavour it is. Shared by the
@@ -5053,12 +5074,7 @@ pub(crate) fn transform_class_fields_server(script: &str) -> String {
                             backing_private(&derived_field_name)
                         };
 
-                        let value_str = value.trim();
-                        let wrapped_value = if value_str.starts_with('{') {
-                            format!("({})", value_str)
-                        } else {
-                            value_str.to_string()
-                        };
+                        let wrapped_value = rune_field_value(&value);
 
                         let transformed_line = if derived_field_is_by {
                             format!("{} = $.derived({})", private_name, wrapped_value)
@@ -5383,12 +5399,7 @@ pub(crate) fn transform_class_fields_server(script: &str) -> String {
                         backing_private(&name)
                     };
 
-                    let value_str = value.trim();
-                    let wrapped_value = if value_str.starts_with('{') {
-                        format!("({})", value_str)
-                    } else {
-                        value_str.to_string()
-                    };
+                    let wrapped_value = rune_field_value(&value);
 
                     let transformed_line = if is_derived_by {
                         format!("{} = $.derived({})", private_name, wrapped_value)

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/shared/js_scan.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/shared/js_scan.rs
@@ -129,6 +129,34 @@ pub(crate) fn skip_opaque(bytes: &[u8], i: usize, prev: Option<u8>) -> Option<(u
     }
 }
 
+/// Does `s` end with a `//` comment that no newline has closed?
+///
+/// Every pass that splices raw source into a wrapper appends its closing
+/// delimiter after that text, and an open line comment swallows it.
+pub(crate) fn ends_inside_line_comment(s: &str) -> bool {
+    let bytes = s.as_bytes();
+    let mut i = 0usize;
+    let mut prev: Option<u8> = None;
+    while i < bytes.len() {
+        let line_comment = bytes[i] == b'/' && bytes.get(i + 1) == Some(&b'/');
+        if let Some((next, is_comment)) = skip_opaque(bytes, i, prev) {
+            if line_comment && next == bytes.len() {
+                return true;
+            }
+            if !is_comment {
+                prev = Some(b'x');
+            }
+            i = next;
+            continue;
+        }
+        if !bytes[i].is_ascii_whitespace() {
+            prev = Some(bytes[i]);
+        }
+        i += 1;
+    }
+    false
+}
+
 /// Does `name` occur in `source` as a whole identifier token?
 ///
 /// The rewrite passes only ever replace an identifier spelled exactly `name`,

--- a/crates/rsvelte_core/tests/rune_argument_trailing_comment_2601.rs
+++ b/crates/rsvelte_core/tests/rune_argument_trailing_comment_2601.rs
@@ -1,0 +1,90 @@
+//! A `//` comment on the last line of a rune call's argument swallowed the
+//! closing paren the emitter appends after it.
+//!
+//! `emit_rune_replacement` splices the argument verbatim and then pushes `)`.
+//! `inner.trim_end()` removes the newline that closed the comment, so the `)`
+//! landed inside it and the call was never closed.
+//!
+//! The variant that carries a delimiter is the one that already worked: with
+//! `// ) c` in the same slot the field bails to the AST path and comes out
+//! right. It is the *plain* comment that is unguarded here — the inverse of the
+//! usual "delimiter-carrying comments are the dangerous ones" rule, which is why
+//! a triage pass over the `-with-` mutation kinds would have walked past this.
+
+use rsvelte_core::{GenerateMode, ModuleCompileOptions, compile_module};
+
+fn server(src: &str) -> String {
+    compile_module(
+        src,
+        ModuleCompileOptions {
+            generate: GenerateMode::Server,
+            filename: Some("m.svelte.js".to_string()),
+            ..Default::default()
+        },
+    )
+    .map(|r| r.js.code)
+    .unwrap_or_else(|e| format!("COMPILE_ERROR: {e:?}"))
+}
+
+#[track_caller]
+fn assert_parses(code: &str, what: &str) {
+    assert!(!code.contains("COMPILE_ERROR"), "{what}: {code}");
+    let allocator = oxc_allocator::Allocator::default();
+    let ret = oxc_parser::Parser::new(&allocator, code, oxc_span::SourceType::mjs()).parse();
+    assert!(
+        ret.diagnostics.is_empty(),
+        "{what}: emitted JS does not parse: {:?}\n--- output ---\n{code}",
+        ret.diagnostics
+    );
+}
+
+/// The reduction of `layerchart/…/Circle.shared__m0__line-with-paren.svelte.ts`.
+const CLASS_FIELD: &str = "export class C {\n  #p = () => ({});\n  a = $derived(\n    this.#p().x != null ||\n      f(this.#p().y, this.#p().z)\n// c\n  );\n  b = 1;\n}\n";
+
+#[test]
+fn a_trailing_line_comment_does_not_swallow_the_derived_closing_paren() {
+    assert_parses(&server(CLASS_FIELD), "class field $derived");
+}
+
+/// The same slot with a `)` in the comment. This already passed — it is the
+/// control that makes the test above discriminating rather than merely green.
+#[test]
+fn the_delimiter_carrying_variant_still_works() {
+    assert_parses(
+        &server(&CLASS_FIELD.replace("// c", "// ) c")),
+        "class field $derived with a paren in the comment",
+    );
+}
+
+#[test]
+fn a_trailing_line_comment_survives_a_plain_derived_declaration() {
+    let src = "export function make() {\n  let n = $state(1);\n  let d = $derived(\n    n + 1\n// c\n  );\n  return () => d;\n}\n";
+    assert_parses(&server(src), "plain $derived declaration");
+}
+
+#[test]
+fn a_trailing_line_comment_survives_derived_by() {
+    let src = "export function make() {\n  let n = $state(1);\n  let d = $derived.by(\n    () => n + 1\n// c\n  );\n  return () => d;\n}\n";
+    assert_parses(&server(src), "$derived.by");
+}
+
+/// An object-literal argument takes the wrapping-paren branch, so the comment
+/// has to be closed before *that* paren too, not only the outer one.
+#[test]
+fn a_trailing_line_comment_survives_an_object_literal_argument() {
+    let src = "export class C {\n  a = $derived(\n    { x: 1 }\n// c\n  );\n  b = 1;\n}\n";
+    assert_parses(&server(src), "object-literal $derived argument");
+}
+
+/// Control: no comment at all. Guards the direction this fix could overshoot in
+/// — a stray newline before every closing paren would change output everywhere.
+#[test]
+fn a_derived_without_a_trailing_comment_is_byte_for_byte_unchanged() {
+    let src = "export function make() {\n  let n = $state(1);\n  let d = $derived(n + 1);\n  return () => d;\n}\n";
+    let out = server(src);
+    assert_parses(&out, "no comment");
+    assert!(
+        out.contains("$.derived(() => n + 1)"),
+        "a newline was inserted where no comment was open: {out}"
+    );
+}


### PR DESCRIPTION
Third root cause from #2601, found while reducing `layerchart/…/Circle/Circle.shared__m0__line-with-paren.svelte.ts`. Independent of #2605 (`$effect` deletion) and #2624 (import terminator).

## Reproducer

`m.svelte.js`, `generate: 'server'`:

```ts
export class C {
  #p = () => ({});
  a = $derived(
    this.#p().x != null ||
      f(this.#p().y, this.#p().z)
// c
  );
  b = 1;
}
```

rsvelte emits:

```js
		#a = $.derived(() => this.#p().x != null ||
f(this.#p().y, this.#p().z)
// c);

		get a() { … }
```

The `);` that closes the rune argument is emitted **inside the comment**, so the call is never closed and the module stops being JavaScript.

## The interesting part: the loud variant is the one that works

Same input, one substitution apart:

| comment at the slot before `);` | emitted JS parses |
|---|---|
| `// ) c` | ✅ |
| `// c` | ❌ |

The `)` makes the field bail to the AST path, which relocates the comment correctly. The plain comment is the unguarded one. That inverts, **at this site**, the heuristic this gate rests on — delimiter-carrying comments find code divergences 2.81× as often as plain ones. It is not a refutation of the corpus-wide ratio; the guard that catches the delimiter is precisely what leaves the plain case exposed. But a triage rule of "look at the `-with-` kinds first" walks straight past this.

## Mechanism

Two sites in `server/transform_script.rs` build a rune field the same way:

```rust
let value_str = value.trim();
let wrapped_value = if value_str.starts_with('{') { format!("({})", value_str) } else { value_str.to_string() };
format!("{} = $.derived(() => {})", private_name, wrapped_value)
```

`value.trim()` removes the newline that terminated the `//` comment, and every appended delimiter after that is inside it. The object-literal branch loses **two** parens, not one, because it appends its own before the caller's.

Both sites now go through one helper, `rune_field_value`, which closes an open line comment with a newline before either paren. The predicate is `js_scan::ends_inside_line_comment`, added next to `skip_opaque` because this is a property of *any* pass that splices raw source into a wrapper, not of this one.

## Tests

`crates/rsvelte_core/tests/rune_argument_trailing_comment_2601.rs`, 6 tests, each asserting the emitted JS parses:

| test | without the fix |
|---|---|
| class field `$derived`, trailing line comment | ❌ fails |
| object-literal argument, trailing line comment | ❌ fails |
| control: the same slot with `// ) c` | ✅ passes |
| control: plain `$derived` declaration | ✅ passes |
| control: `$derived.by` | ✅ passes |
| control: no comment — output byte-for-byte unchanged | ✅ passes |

**2 of 6 fail without the change.** The last control is the one that matters for the direction this fix could have overshot in: a newline before every closing paren would have changed output everywhere, so it pins that `$.derived(() => n + 1)` is emitted exactly as before.

## Scope, stated rather than glossed

- `$derived.by` now routes through the same helper. I have **no discriminating case** for it — its test passes without the fix. It is covered structurally, not measured.
- This reduction is **not** the same failure `Circle.shared`'s CI entry shows. That entry fails on the `line-with-paren` mutant and leaves a stray `);` behind, so the full-size file takes a different branch than this 9-line reduction. What is fixed here is a real, independently reproducible defect found while reducing it — not a proven root cause for that entry. The mutation ratchet will say whether it clears.
- `emit_rune_replacement` (the shared byte-scanner/AST-locator emitter) has the same shape and I could not produce a case that reaches it, so it is **left alone**. An unverified edit there would have been a change with no test that can fail.

## Local verification

`--lib` (1544), `ssr`, `runtime` (incl. `runtime_legacy` / `runtime_runes` / `hydration`) pass, plus `cargo clippy --all-targets -- -D warnings`.
