### PR TITLE
fix(compat): the non-`this` read row was already parity when it was recorded

### DIFF
--- a/compatibility/deliberate-divergences.md
+++ b/compatibility/deliberate-divergences.md
@@ -51,8 +51,13 @@ export class R {
 | nested fn in constructor, `inst.#n++` | `$.get(inst.#n)++;` | **no** | `$.update(inst.#n);` | yes |
 | constructor root, `inst.#n++` | `inst.#n.v++;` | yes | `$.update(inst.#n);` | yes |
 | constructor root, `--inst.#n` | `--inst.#n.v;` | yes | `$.update_pre(inst.#n, -1);` | yes |
-| constructor root, read `inst.#n` | `inst.#n.v` | yes | `$.get(inst.#n)` | yes |
+| constructor root, read `inst.#n` | `inst.#n.v` | yes | `inst.#n.v` | yes |
+| method body, read `inst.#n` | `$.get(inst.#n)` | yes | `$.get(inst.#n)` | yes |
 | any position, `this.#n++` | `$.update(this.#n);` | yes | `$.update(this.#n);` | yes |
+
+**Only updates diverge.** Reads are parity in both positions — #2464 moved the
+constructor-root read onto upstream's `.v` form for every receiver before this entry was
+written, and the entry's first version had not seen it.
 
 The parse column is acorn's verdict on the official output and `oxc_parser`'s on rsvelte's;
 both reject the `$.get(...)++` rows with `Assigning to rvalue`, and V8 accepts the parse
@@ -74,8 +79,8 @@ Reported upstream as **sveltejs/svelte#18621** (open as of 2026-08-08).
 
 ### Why rsvelte's form is the correct one
 
-The unparseable rows need no argument beyond the parse column. The three constructor-root
-rows are the ones that need one, because upstream's output there is valid:
+The unparseable rows need no argument beyond the parse column. The two constructor-root
+update rows are the ones that need one, because upstream's output there is valid:
 
 - `.v++` writes the source's value **without notifying**, and upstream's receiver check is
   purely syntactic — it does not establish that the receiver is the object under
@@ -83,10 +88,11 @@ rows are the ones that need one, because upstream's output there is valid:
   `o.#n.v--`, and no subscriber of `o` ever hears about it. `$.update(o.#n)` notifies.
   Upstream's own lowering of `this.#n++` in the same constructor is `$.update(this.#n)`, so
   the helper form is upstream's semantics, not ours.
-- The read row is the same shape one level down: `.v` is the untracked read, `$.get` the
-  tracked one. Restricting the shortcut to a literal `this` over-tracks a constructor called
-  from inside a reaction and under-tracks nothing; upstream's version under-tracks any
-  receiver that is not the object under construction.
+The same argument would extend to the constructor-root **read** — `.v` is the untracked read
+and `$.get` the tracked one, so upstream's shortcut under-tracks any receiver that is not the
+object under construction. rsvelte nonetheless takes upstream's form there (#2464), because
+both forms parse and the correctness argument above rests on the parse column. Whether the
+read should follow the update is open: **#2629**.
 
 ### What would make this entry disappear
 

--- a/crates/rsvelte_core/tests/private_field_non_this_receiver_2483.rs
+++ b/crates/rsvelte_core/tests/private_field_non_this_receiver_2483.rs
@@ -145,23 +145,19 @@ fn a_this_receiver_is_unaffected() {
     );
 }
 
-/// Reads diverge in the other direction and are pinned here so the record and
-/// the compiler cannot drift apart: upstream applies its constructor-root `.v`
-/// shortcut to any receiver, rsvelte restricts it to `this` and reads a
-/// non-`this` receiver through `$.get`.
+/// Reads are plain parity and are pinned here so nobody widens the divergence
+/// to cover them: #2464 moved the constructor-root read onto upstream's `.v`
+/// form for every receiver, so only *updates* diverge. Both forms parse, so
+/// the correctness argument that justifies the update rows does not reach here.
 #[test]
-fn a_read_through_a_non_this_receiver_goes_through_get() {
+fn a_read_through_a_non_this_receiver_is_parity() {
     let out = compile(RECEIVERS, false);
     assert!(
-        out.contains("console.log($.get(inst.#n));"),
-        "a constructor-root read through an alias uses `$.get`:\n{out}"
+        out.contains("console.log(inst.#n.v);"),
+        "a constructor-root read takes upstream's `.v` shortcut:\n{out}"
     );
     assert!(
         out.contains("return $.get(inst.#n);"),
-        "a method-body read through an alias uses `$.get`:\n{out}"
-    );
-    assert!(
-        !out.contains("inst.#n.v"),
-        "the `.v` shortcut stays restricted to a `this` receiver:\n{out}"
+        "a method-body read goes through `$.get`, as upstream's does:\n{out}"
     );
 }


### PR DESCRIPTION
`main` is red: `a_read_through_a_non_this_receiver_goes_through_get` fails on
`c3968878`, taking down `Coverage`, `Test (macos-latest, 2)` and every PR that has
merged main since.

## What happened

Two merged PRs assert opposite behaviour for the same expression.

- **#2464** moved the constructor-root read of a private rune field onto upstream's `.v`
  shortcut for **every** receiver, and pins it: `nonthis_private_state_receiver_2467.rs`
  asserts `log(inst.#n.v);` and `const a = inst.#n.v;`.
- **#2574** recorded the opposite as a deliberate divergence and pinned that:
  `console.log($.get(inst.#n));` plus `!out.contains("inst.#n.v")`.

#2574's branch was cut before #2464 landed and never rebased. Its `Test (ubuntu-latest, N)`
shards completed **01:57–02:35Z** and it merged at **04:30Z** — after #2605, #2617 and
#2426. The shards did run the new binary (`PASS … a_read_through_a_non_this_receiver_goes_through_get`
appears in shard 1's log), against a tree that did not contain #2464.

## Attribution, by a three-value test rather than by reading the diff

| tree | result |
|---|---|
| `c3968878` (main) | 3 pass, **1 fail** |
| `c3968878` with **only** `675b34d5` (#2464) reverted | **4 pass** |
| failure mode | `inst.#n.v` where the test wants `$.get(inst.#n)` — **the predicted one** |

I also cleared the two nearer suspects before reaching for #2464: reverting only #2605
(`23e68acf`) leaves the failure intact. An earlier attempt that swapped `crates/` wholesale
to a pre-#2605 tree was a **broken control** — it removed #2574's own compiler change along
with everything else, so its "still fails" told me nothing. Recorded because the run looked
informative.

## What this changes

**Reads were already parity when the entry was written; only updates diverge.** The test
now pins that, the table gains the method-body read row, and the prose says why the
correctness argument for the update rows does not reach the read: upstream's
`$.get(o.#n)++` does not parse, and both read forms do.

Not decided here: **whether the read should follow the update anyway.** #2574's tracking
argument (`.v` is the untracked read; upstream's receiver check is syntactic and does not
establish that the receiver is the object under construction) was never answered by #2464,
which had no way to see it. That is a semantics question, filed as **#2629**, and picking
whichever test is cheaper to keep is not an answer to it.

## Verification

All three related binaries, 18 tests, on this branch:

```
private_field_non_this_receiver_2483   4 passed
nonthis_private_state_receiver_2467    8 passed
ctor_private_state_read_and_proxy_2395 6 passed
```

No compiler code changes — a test expectation and the record it pins.
