### PR TITLE
fix(compat): record the constructor-root read as parity, not a divergence

### DIFF
--- a/compatibility/deliberate-divergences.md
+++ b/compatibility/deliberate-divergences.md
@@ -51,7 +51,7 @@ export class R {
 | nested fn in constructor, `inst.#n++` | `$.get(inst.#n)++;` | **no** | `$.update(inst.#n);` | yes |
 | constructor root, `inst.#n++` | `inst.#n.v++;` | yes | `$.update(inst.#n);` | yes |
 | constructor root, `--inst.#n` | `--inst.#n.v;` | yes | `$.update_pre(inst.#n, -1);` | yes |
-| constructor root, read `inst.#n` | `inst.#n.v` | yes | `$.get(inst.#n)` | yes |
+| constructor root, read `inst.#n` | `inst.#n.v` | yes | `inst.#n.v` — **parity** | yes |
 | any position, `this.#n++` | `$.update(this.#n);` | yes | `$.update(this.#n);` | yes |
 
 The parse column is acorn's verdict on the official output and `oxc_parser`'s on rsvelte's;
@@ -74,8 +74,8 @@ Reported upstream as **sveltejs/svelte#18621** (open as of 2026-08-08).
 
 ### Why rsvelte's form is the correct one
 
-The unparseable rows need no argument beyond the parse column. The three constructor-root
-rows are the ones that need one, because upstream's output there is valid:
+The unparseable rows need no argument beyond the parse column. The two constructor-root
+**update** rows are the ones that need one, because upstream's output there is valid:
 
 - `.v++` writes the source's value **without notifying**, and upstream's receiver check is
   purely syntactic — it does not establish that the receiver is the object under
@@ -83,18 +83,23 @@ rows are the ones that need one, because upstream's output there is valid:
   `o.#n.v--`, and no subscriber of `o` ever hears about it. `$.update(o.#n)` notifies.
   Upstream's own lowering of `this.#n++` in the same constructor is `$.update(this.#n)`, so
   the helper form is upstream's semantics, not ours.
-- The read row is the same shape one level down: `.v` is the untracked read, `$.get` the
-  tracked one. Restricting the shortcut to a literal `this` over-tracks a constructor called
-  from inside a reaction and under-tracks nothing; upstream's version under-tracks any
-  receiver that is not the object under construction.
+
+**The read row is not part of this entry.** An earlier revision listed it as a divergence
+(`$.get(inst.#n)`) on the argument that `.v` is the untracked read and restricting the
+shortcut to a literal `this` only ever over-tracks. That is a judgement about which
+tracking behaviour is nicer, not a correctness argument — both sides parse and both run —
+and upstream is the specification where the two merely differ. #2464 made the constructor
+root read `.v` for any receiver, mirroring
+`MemberExpression.js:15-18`'s `in_constructor` gate, and the row is now parity.
+`private_field_non_this_receiver_2483.rs` pins it as such so the two claims cannot be
+reintroduced side by side: they were, briefly, by two changes that were each green alone.
 
 ### What would make this entry disappear
 
 Upstream extending the `ThisExpression` check in `UpdateExpression.js` to any receiver — the
-fix #18621 asks for — makes official emit `$.update(o.#n)` too, and closes every row above
-except the two constructor-root `.v` ones, which close if `MemberExpression.js` gains the
-receiver check instead. Delete the entry, its in-code comments and its test when
-`submodules/svelte` is bumped past that fix.
+fix #18621 asks for — makes official emit `$.update(o.#n)` too, and closes every diverging
+row above. Delete the entry, its in-code comments and its test when `submodules/svelte` is
+bumped past that fix. The read row closes with nothing: it already matches.
 
 ### Why no gate sees it
 

--- a/crates/rsvelte_core/tests/private_field_non_this_receiver_2483.rs
+++ b/crates/rsvelte_core/tests/private_field_non_this_receiver_2483.rs
@@ -145,23 +145,19 @@ fn a_this_receiver_is_unaffected() {
     );
 }
 
-/// Reads diverge in the other direction and are pinned here so the record and
-/// the compiler cannot drift apart: upstream applies its constructor-root `.v`
-/// shortcut to any receiver, rsvelte restricts it to `this` and reads a
-/// non-`this` receiver through `$.get`.
+/// Reads are **parity**, not a divergence, and are pinned here so the two are
+/// not confused: upstream's constructor-root `.v` shortcut applies to any
+/// receiver, and #2464 made rsvelte match it. The divergence is confined to the
+/// update rows above, which are the ones where upstream's bytes do not parse.
 #[test]
-fn a_read_through_a_non_this_receiver_goes_through_get() {
+fn a_constructor_root_read_matches_upstreams_dot_v() {
     let out = compile(RECEIVERS, false);
     assert!(
-        out.contains("console.log($.get(inst.#n));"),
-        "a constructor-root read through an alias uses `$.get`:\n{out}"
+        out.contains("console.log(inst.#n.v);"),
+        "a constructor-root read through an alias uses upstream's `.v`:\n{out}"
     );
     assert!(
         out.contains("return $.get(inst.#n);"),
-        "a method-body read through an alias uses `$.get`:\n{out}"
-    );
-    assert!(
-        !out.contains("inst.#n.v"),
-        "the `.v` shortcut stays restricted to a `this` receiver:\n{out}"
+        "a method-body read is outside the constructor, so it stays `$.get`:\n{out}"
     );
 }


### PR DESCRIPTION
**`main` is red.** `rsvelte_core::private_field_non_this_receiver_2483::a_read_through_a_non_this_receiver_goes_through_get` fails on `c3968878`, and it fails for a docs-only PR too (#2613), which is how it surfaced — every PR cut from current `main` inherits it.

## Attribution, by A/B rather than by reading the diff

The test arrived with #2574. Copying its file onto two commits and running it:

| commit | verdict |
|---|---|
| `c84d227a` (#2594, immediately before #2464) | 4 passed |
| `675b34d5` (#2464) | 3 passed, **1 failed** |

Exactly one of the four flips, and it is the read test. #2464 is
"mirror upstream's constructor read form …", which adopts
`MemberExpression.js:15-18`'s `in_constructor` gate for **any** receiver.

## Why both PRs were green

#2574 was cut before #2464 merged, so its branch measured the pre-#2464 compiler and pinned that behaviour as a deliberate divergence. #2464's own
`nonthis_private_state_receiver_2467.rs` asserts `log(inst.#n.v);` — the exact opposite — two files away. Neither CI run could see the other. Green + green = red, which is the merge-order hazard, not a defect in either change.

## Which side stands, and why it is not a coin flip

**#2464's.** `compatibility/deliberate-divergences.md` opens by saying the file exists for cases where reproducing upstream's bytes would mean shipping *invalid JavaScript*. That is true of the update rows — official emits `$.get(o.#n)++`, which no parser accepts — and it is **not** true of the read row: `inst.#n.v` and `$.get(inst.#n)` both parse and both run.

What was left, once the parse argument does not apply, was "`.v` is the untracked read, so restricting the shortcut to a literal `this` only ever over-tracks". That is a judgement about which tracking behaviour is nicer, and where the two merely differ, upstream is the specification. An entry in this file has to carry more than a preference, because the file's whole purpose is to be the short list of places where the usual rule is suspended.

## The change

- `private_field_non_this_receiver_2483.rs`: the read test now pins **parity** (`console.log(inst.#n.v);` at a constructor root, `return $.get(inst.#n);` in a method body — the `in_constructor` boundary), renamed so it does not read as a divergence.
- `deliberate-divergences.md`: the read row is marked parity, the "why rsvelte's form is correct" section is scoped to the two update rows, and the retraction is written down rather than the old text quietly overwritten — including that it was reintroduced by two changes that were each green alone.
- No compiler code changes. The behaviour `main` already has is the behaviour that is now recorded.

## Verification

`private_field_non_this_receiver_2483` (4), `nonthis_private_state_receiver_2467` (8) and `ctor_private_state_read_and_proxy_2395` (6) all pass together — which they could not before, since the first contradicted the second.
