### PR TITLE
fix(devtools): drain the script-text counters warmup filled

### DIFF
--- a/crates/rsvelte_devtools/src/bin/compile_profile.rs
+++ b/crates/rsvelte_devtools/src/bin/compile_profile.rs
@@ -138,8 +138,15 @@ fn main() {
     let analyze_visitor_time = start.elapsed();
     let analyze_time = resolve_lazy_time + ensure_script_time + analyze_visitor_time;
 
-    // Reset Phase 3 sub-phase counters in case warmup left non-zero state.
+    // Reset Phase 3 sub-phase counters in case warmup left non-zero state. The
+    // script-text counters are drained here too: they are read once after the
+    // loop, so anything warmup left in them is priced against the measured
+    // loop's denominator and inflates every script-text share by (100+N)/N.
     let _ = profile::take_breakdown();
+    let _ = profile::take_script_text_breakdown();
+    // Also a once-after-the-loop read, so warmup would price its checks against
+    // a population no other number in the report covers.
+    let _ = profile::take_index_oracle();
 
     let _ = profile::take_reparse_breakdown();
     // Per-file rows, so re-parse cost can be read against file size instead of


### PR DESCRIPTION
## The defect

`compile_profile` warms on the corpus's first 100 files (`:47`), then drains
only `take_breakdown()` (`:142`). `take_script_text_breakdown()` is first read
at `:194`, **after** the measured loop — so it still holds everything warmup put
there. Every share printed under `line_loop` was `(warmup + measured)` over a
denominator that covers the measured loop alone.

The other profiling binaries do not have this — `semantic_sites.rs`,
`esrap_share.rs` and `corpus_profile.rs` all drain before their measured loop.
It is specific to this counter in this binary.

## Why it matters more than a constant factor

The inflation is `(min(100,N)+N)/N`. It is **corpus-size dependent**, so it
cannot be divided out after the fact and it silently **re-ranks corpora** —
small ones inflate most. Paired old/new runs of the same binary on the same
corpora, same machine:

| corpus | files | predicted | `process_accum` old → fixed | measured ratio |
|---|---|---|---|---|
| smelte | 74 | 2.00 | 57.1% → **25.5%** | 2.24 |
| layercake | 177 | 1.565 | 8.8% → **5.6%** | **1.57** |

layercake lands on the prediction. smelte sits slightly above it because warmup
calls the full `rsvelte_core::compile` while the measured loop calls
`transform_component` alone, so warmup's per-file contribution is the larger of
the two.

## What this invalidates

Every script-text share ever read off this tool — `line_loop`, `process_accum`,
`runes_xform`, `reactive_stmt`, and the `pa_rest` residual derived from them.
Numbers taken on large corpora are barely affected (`--shipped`, N=5879, factor
1.017); numbers taken per-repo on small corpora are affected by up to 2.2×.

It is also the mechanism behind the reading that the instance-script line loop
is a **legacy-syntax** cost: the legacy repos that were sampled were also the
smallest ones (74/129/198 files), so they took the largest inflation. Corrected,
`--shipped` reports `line_loop` 3.4% / `process_accum` 1.5%.

`take_index_oracle` is drained for the same reason — read once after the loop,
so warmup made its check count cover a population no other number in the report
covers. The measured loop repopulates it, so the row still reports.

## Scope

Dev binary only; nothing under `crates/rsvelte_core/src` changes, so no gate,
ratchet or output is touched. `skip-changeset` because `rsvelte_devtools` is
unpublished (`0.0.0`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
