### PR TITLE
fix(transform): count only code delimiters in the class-member scan

### DIFF
--- a/.changeset/class-field-comment-brackets.md
+++ b/.changeset/class-field-comment-brackets.md
@@ -1,0 +1,21 @@
+---
+"@rsvelte/compiler": patch
+---
+
+Stop a delimiter inside a comment from ending a class field early (server).
+
+The server class-member scan accumulates a multi-line field until its brackets
+balance, and counted every `(`/`)`/`{`/`}`/`[`/`]` byte — including the ones
+inside comments and strings. A `// )` line inside a `$derived.by(…)`,
+`$state(…)` or plain multi-line initializer therefore closed the field one line
+early, and the leftover `);` was emitted as a class member of its own:
+
+```js
+	get snippetProps() { … }
+	);
+}
+```
+
+which does not parse. The six depth counters in that scan now run over code
+bytes only, and over the whole accumulated text rather than one line at a time,
+so a block comment that spans lines is closed by the same scan that opened it.

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/transform_script.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/transform_script.rs
@@ -4874,6 +4874,26 @@ fn strip_ts_field_modifiers(lhs: &str) -> &str {
     s
 }
 
+/// Net bracket depth of `s`, counting only bytes that are code.
+///
+/// The class-member accumulators below stop when their depth reaches zero, so a
+/// `)` inside a comment ends a field early and drops everything after it.
+/// Callers pass the whole accumulated text, not one line, so a block comment
+/// that spans lines is closed by the same scan that opened it.
+fn code_bracket_depth(s: &str) -> i32 {
+    let mut depth = 0i32;
+    for (_, byte) in
+        crate::compiler::phases::phase3_transform::shared::js_scan::code_bytes(s.as_bytes())
+    {
+        match byte {
+            b'(' | b'{' | b'[' => depth += 1,
+            b')' | b'}' | b']' => depth -= 1,
+            _ => {}
+        }
+    }
+    depth
+}
+
 /// Transform class fields with $derived runes for server-side.
 pub(crate) fn transform_class_fields_server(script: &str) -> String {
     let script_bytes = script.as_bytes();
@@ -4953,7 +4973,6 @@ pub(crate) fn transform_class_fields_server(script: &str) -> String {
     // For multiline derived fields: accumulate text until parens balance
     let mut in_derived_field = false;
     let mut derived_accum = String::new();
-    let mut derived_paren_depth: i32 = 0;
     let mut derived_field_name = String::new();
     let mut derived_field_is_private = false;
     let mut derived_field_is_by = false;
@@ -4965,7 +4984,6 @@ pub(crate) fn transform_class_fields_server(script: &str) -> String {
     // client module transform, which then privatizes the public field.
     let mut in_state_field = false;
     let mut state_accum = String::new();
-    let mut state_paren_depth: i32 = 0;
     let mut state_field_name = String::new();
 
     // For multiline plain (non-rune) field initializers: accumulate lines until
@@ -4973,7 +4991,6 @@ pub(crate) fn transform_class_fields_server(script: &str) -> String {
     // where the `{` is inside the initializer and spans multiple lines.
     let mut in_plain_field = false;
     let mut plain_field_lines: Vec<String> = Vec::new();
-    let mut plain_field_depth: i32 = 0;
 
     // For block comments (`/** … */` / `/* … */`) inside class bodies: accumulate
     // lines until the closing `*/` and push them as a `ClassMember::Comment` so the
@@ -5025,14 +5042,7 @@ pub(crate) fn transform_class_fields_server(script: &str) -> String {
         if in_derived_field {
             derived_accum.push('\n');
             derived_accum.push_str(trimmed);
-            for c in trimmed.chars() {
-                match c {
-                    '(' | '{' | '[' => derived_paren_depth += 1,
-                    ')' | '}' | ']' => derived_paren_depth -= 1,
-                    _ => {}
-                }
-            }
-            if derived_paren_depth <= 0 {
+            if code_bracket_depth(&derived_accum) <= 0 {
                 in_derived_field = false;
                 // Now process the complete multiline derived field
                 let full_text = derived_accum.clone();
@@ -5082,14 +5092,7 @@ pub(crate) fn transform_class_fields_server(script: &str) -> String {
         if in_state_field {
             state_accum.push('\n');
             state_accum.push_str(trimmed);
-            for c in trimmed.chars() {
-                match c {
-                    '(' | '{' | '[' => state_paren_depth += 1,
-                    ')' | '}' | ']' => state_paren_depth -= 1,
-                    _ => {}
-                }
-            }
-            if state_paren_depth <= 0 {
+            if code_bracket_depth(&state_accum) <= 0 {
                 in_state_field = false;
                 let full_text = state_accum.clone();
                 let state_pattern = if full_text.contains("$state.raw(") {
@@ -5122,14 +5125,7 @@ pub(crate) fn transform_class_fields_server(script: &str) -> String {
         // single Field member so the emitter can write it verbatim.
         if in_plain_field {
             plain_field_lines.push(line.to_string());
-            for c in trimmed.chars() {
-                match c {
-                    '(' | '{' | '[' => plain_field_depth += 1,
-                    ')' | '}' | ']' => plain_field_depth -= 1,
-                    _ => {}
-                }
-            }
-            if plain_field_depth <= 0 {
+            if code_bracket_depth(&plain_field_lines.join("\n")) <= 0 {
                 in_plain_field = false;
                 // Emit the full multi-line field as a single Field entry whose
                 // text is the source lines joined. The emitter handles it
@@ -5137,7 +5133,6 @@ pub(crate) fn transform_class_fields_server(script: &str) -> String {
                 let field_text = plain_field_lines.join("\n");
                 members.push(ClassMember::Field(field_text));
                 plain_field_lines.clear();
-                plain_field_depth = 0;
             }
             continue;
         }
@@ -5408,14 +5403,6 @@ pub(crate) fn transform_class_fields_server(script: &str) -> String {
                     // Multiline derived field - accumulate until parens balance
                     in_derived_field = true;
                     derived_accum = trimmed.to_string();
-                    derived_paren_depth = 0;
-                    for c in trimmed.chars() {
-                        match c {
-                            '(' | '{' | '[' => derived_paren_depth += 1,
-                            ')' | '}' | ']' => derived_paren_depth -= 1,
-                            _ => {}
-                        }
-                    }
                     derived_field_name = name;
                     derived_field_is_private = is_private;
                     derived_field_is_by = is_derived_by;
@@ -5455,14 +5442,6 @@ pub(crate) fn transform_class_fields_server(script: &str) -> String {
                 // parens balance, then unwrap (see the `in_state_field` block).
                 in_state_field = true;
                 state_accum = trimmed.to_string();
-                state_paren_depth = 0;
-                for c in trimmed.chars() {
-                    match c {
-                        '(' | '{' | '[' => state_paren_depth += 1,
-                        ')' | '}' | ']' => state_paren_depth -= 1,
-                        _ => {}
-                    }
-                }
                 state_field_name = field_name.to_string();
                 continue;
             }
@@ -5473,19 +5452,11 @@ pub(crate) fn transform_class_fields_server(script: &str) -> String {
         // lines (e.g. `bundler = new Bundler({\n  ...\n})`). Accumulate until
         // the depth returns to 0 so the full initializer is emitted verbatim
         // instead of just the first line with a spurious `;` appended.
-        let mut field_bracket_depth: i32 = 0;
-        for c in trimmed.chars() {
-            match c {
-                '(' | '{' | '[' => field_bracket_depth += 1,
-                ')' | '}' | ']' => field_bracket_depth -= 1,
-                _ => {}
-            }
-        }
+        let field_bracket_depth = code_bracket_depth(trimmed);
         if field_bracket_depth > 0 {
             in_plain_field = true;
             plain_field_lines.clear();
             plain_field_lines.push(line.to_string());
-            plain_field_depth = field_bracket_depth;
         } else {
             members.push(ClassMember::Field(trimmed.to_string()));
         }

--- a/crates/rsvelte_core/tests/class_field_comment_brackets_2601.rs
+++ b/crates/rsvelte_core/tests/class_field_comment_brackets_2601.rs
@@ -1,0 +1,99 @@
+//! The server class-member scan accumulates a multi-line field until its
+//! brackets balance. A delimiter inside a comment must not move that count, or
+//! the field ends early and every member after it is emitted into the wrong
+//! place.
+
+use rsvelte_core::{GenerateMode, ModuleCompileOptions, compile_module};
+
+fn server_module(src: &str) -> String {
+    compile_module(
+        src,
+        ModuleCompileOptions {
+            filename: Some("T.svelte.js".into()),
+            generate: GenerateMode::Server,
+            dev: false,
+            ..Default::default()
+        },
+    )
+    .expect("compiles")
+    .js
+    .code
+}
+
+fn parses(code: &str) -> bool {
+    let allocator = oxc_allocator::Allocator::default();
+    oxc_parser::Parser::new(&allocator, code, oxc_span::SourceType::mjs())
+        .parse()
+        .diagnostics
+        .is_empty()
+}
+
+/// The shape the corpus found it in: a class with a constructor and an earlier
+/// `$derived.by` field, then the field whose initializer carries the comment.
+fn class_with(field: &str) -> String {
+    format!(
+        "export class C {{\n\
+         \topts;\n\
+         \tconstructor(opts) {{\n\
+         \t\tthis.opts = opts;\n\
+         \t}}\n\
+         \tfirst = $derived.by(() => ({{ a: this.opts.a }}));\n\
+         {field}\
+         }}\n"
+    )
+}
+
+#[test]
+fn a_close_paren_in_a_comment_does_not_end_a_derived_field() {
+    let out = server_module(&class_with(
+        "\tsecond = $derived.by(\n\t\t() => ({\n\t\t\t// ) c\n\t\t\tb: 2,\n\t\t\tlast: 3\n\t\t})\n\t);\n",
+    ));
+    assert!(parses(&out), "{out}");
+    assert!(out.contains("last: 3"), "{out}");
+}
+
+#[test]
+fn a_close_brace_in_a_comment_does_not_end_a_state_field() {
+    let out = server_module(&class_with(
+        "\tsecond = $state(\n\t\t{\n\t\t\t// } c\n\t\t\tb: 2,\n\t\t\tlast: 3\n\t\t}\n\t);\n",
+    ));
+    assert!(parses(&out), "{out}");
+    assert!(out.contains("last: 3"), "{out}");
+}
+
+#[test]
+fn a_close_paren_in_a_comment_does_not_end_a_plain_field() {
+    let out = server_module(&class_with(
+        "\tsecond = f(\n\t\t// ) c\n\t\t1,\n\t\t2\n\t);\n\tlast = 3;\n",
+    ));
+    assert!(parses(&out), "{out}");
+    assert!(out.contains("last = 3"), "{out}");
+}
+
+#[test]
+fn the_delimiter_may_sit_in_a_block_comment_spanning_lines() {
+    let out = server_module(&class_with(
+        "\tsecond = $derived.by(\n\t\t() => ({\n\t\t\t/* )\n\t\t\t   ) */\n\t\t\tb: 2,\n\t\t\tlast: 3\n\t\t})\n\t);\n",
+    ));
+    assert!(parses(&out), "{out}");
+    assert!(out.contains("last: 3"), "{out}");
+}
+
+#[test]
+fn a_close_paren_in_a_string_does_not_end_a_derived_field() {
+    let out = server_module(&class_with(
+        "\tsecond = $derived.by(\n\t\t() => ({\n\t\t\tb: ')',\n\t\t\tlast: 3\n\t\t})\n\t);\n",
+    ));
+    assert!(parses(&out), "{out}");
+    assert!(out.contains("last: 3"), "{out}");
+}
+
+#[test]
+fn a_comment_free_multi_line_derived_field_is_unchanged() {
+    let out = server_module(&class_with(
+        "\tsecond = $derived.by(\n\t\t() => ({\n\t\t\tb: 2,\n\t\t\tlast: 3\n\t\t})\n\t);\n",
+    ));
+    assert!(parses(&out), "{out}");
+    assert!(out.contains("#second = $.derived("), "{out}");
+    assert!(out.contains("get second()"), "{out}");
+}


### PR DESCRIPTION
Fourth distinct site of the #2601 class, after #2605 (`$effect` deletion), #2624 (import terminator) and #2636 (declarator continuation). No overlap with #2618, #2619 or #2626.

## The defect

`transform_class_fields_server` accumulates a multi-line class field until its brackets balance. Six separate counters did it the same naive way:

```rust
for c in trimmed.chars() {
    match c {
        '(' | '{' | '[' => derived_paren_depth += 1,
        ')' | '}' | ']' => derived_paren_depth -= 1,
        _ => {}
    }
}
if derived_paren_depth <= 0 { /* field is complete */ }
```

A `)` inside a comment therefore closes the field one line early. On bits-ui's `toggle.svelte.ts` with a `// )` comment in the `props = $derived.by(…)` initializer:

```js
	get snippetProps() {
		return this.#snippetProps();
	}

	set snippetProps($$value) {
		return this.#snippetProps($$value);
	}
	);
}
```

The whole `props` field is gone and the initializer's real `);` is emitted as a class member of its own. It does not parse.

This is `find_matching_bracket`'s #2253 lesson one level in: that fix made the *class body's* closing brace lexical, and left the *member* accumulators inside it byte-counting.

## The fix

One helper, `code_bracket_depth`, over `js_scan::code_bytes`, called with the **whole accumulated text** rather than one line — so a block comment that spans lines is closed by the same scan that opened it, which a per-line counter cannot do. Recomputing the depth each time makes `derived_paren_depth` / `state_paren_depth` / `plain_field_depth` redundant as running state, so they go: −53 lines, +24.

## Which inputs found it

The two `server` entries in main's 16-strong `unparseable` set:

- `bits-ui/packages/bits-ui/src/lib/bits/toggle/toggle__m0__line-with-paren.svelte.ts`
- `layerchart/packages/layerchart/src/lib/components/Circle/Circle.shared__m0__line-with-paren.svelte.ts`

The second is the entry I reduced while writing #2628. #2628 fixed a real defect found during that reduction and I said explicitly there that it was *not* a proven root cause for the entry — this is the root cause.

I reconstructed both mutants locally from the submodule sources using the gate's own `insertionSlots` + `fnv1a` slot selection, and confirmed the reconstruction is faithful: it reproduces all 16 NEW verdicts, comment kind for comment kind, that CI reported on `80abbe52`. With this PR both go to `OK` on all three targets.

## Verification

6 tests in `crates/rsvelte_core/tests/class_field_comment_brackets_2601.rs`.

Negative control — `git checkout HEAD -- transform_script.rs`, re-run, restore:

```
test result: FAILED. 1 passed; 5 failed
    a_close_brace_in_a_comment_does_not_end_a_state_field
    a_close_paren_in_a_comment_does_not_end_a_derived_field
    a_close_paren_in_a_comment_does_not_end_a_plain_field
    a_close_paren_in_a_string_does_not_end_a_derived_field
    the_delimiter_may_sit_in_a_block_comment_spanning_lines
```

The string case failing too is the finding, not the test being loose: a `)` inside a string literal broke this scan the same way a comment did.

The one that passes either way is the control — a comment-free multi-line `$derived.by` field must still lower to `#second = $.derived(…)` + `get second()`, so an "always keep accumulating" non-fix would fail it.

An earlier draft of these tests used a bare `class C { props = $derived.by(…) }` and **5 of the 6 passed without the fix** — the shape only reaches this accumulator with a constructor and a preceding field present. I rewrote them against the shape the corpus actually found, and re-ran the control; the numbers above are from the rewrite.

Locally: `--test ssr` green in release. Runtime is left to CI.
