### PR TITLE
test(corpus): abort a differential sweep when the oracle cannot run

### DIFF
--- a/scripts/compat-corpus/README.md
+++ b/scripts/compat-corpus/README.md
@@ -129,6 +129,10 @@ itself never spends cycles on cosmetic output massaging (rsvelte targets
 # one-time / after pin changes
 pnpm run corpus:sync        # init/update every corpus source submodule
 
+# the oracle needs its OWN dependencies — the repo-root install does not cover
+# the submodule, and without them every worker dies before it compares anything
+(cd submodules/svelte && pnpm install --frozen-lockfile)
+
 # build + stage the rsvelte NAPI binding
 cargo build --release -p rsvelte_napi --lib
 mkdir -p .corpus-cache && cp target/release/librsvelte_napi.{dylib,so} .corpus-cache/rsvelte.node.staging && mv .corpus-cache/rsvelte.node.staging .corpus-cache/rsvelte.node   # .so on Linux

--- a/scripts/compat-corpus/compile.mjs
+++ b/scripts/compat-corpus/compile.mjs
@@ -27,6 +27,7 @@ import { createRequire } from 'node:module';
 import { fileURLToPath } from 'node:url';
 import { selectTargets } from './targets.mjs';
 import { BYTES_PER_TARGET, DISK_HEADROOM, requireDiskSpace, readGeneration, requireGenerationUnchanged } from './artifacts.mjs';
+import { assertOracleCompiles } from './oracle.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '../..');
@@ -209,6 +210,15 @@ if (!fs.existsSync(BINDING)) {
 if (!FILTER) {
 	fs.rmSync(EXPECTED, { recursive: true, force: true });
 	fs.rmSync(ACTUAL, { recursive: true, force: true });
+}
+
+// The workers are isolated so an rsvelte panic cannot end the run, which means
+// an oracle that cannot even load is recorded as a per-entry rust_panic instead.
+try {
+	assertOracleCompiles(ROOT, 'compile');
+} catch (e) {
+	console.error(`\n${e.message}`);
+	process.exit(2);
 }
 
 // After the wipe above, so the figure reflects the space this run really needs.

--- a/scripts/compat-corpus/mutate-corpus.mjs
+++ b/scripts/compat-corpus/mutate-corpus.mjs
@@ -70,6 +70,7 @@ import { flattenTemplateHoles, stripBlankLines, firstDiffLine } from './normaliz
 import { selectTargets, TARGETS as ALL_TARGETS } from './targets.mjs';
 import { insertionSlots } from './matrix/mutate.mjs';
 import { COMMENT_KINDS } from './matrix/axes.mjs';
+import { assertOracleCompiles } from './oracle.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '../..');
@@ -285,6 +286,16 @@ if (!fs.existsSync(BINDING)) {
 	console.error(`[mutate] rsvelte NAPI binding missing at ${path.relative(ROOT, BINDING)}`);
 	console.error('  build: cargo build --release -p rsvelte_napi --lib');
 	console.error('  stage: mkdir -p .corpus-cache && cp target/release/librsvelte_napi.{dylib,so} .corpus-cache/rsvelte.node');
+	process.exit(2);
+}
+
+// A dead oracle is indistinguishable from a dead compiler here: the workers run
+// in child processes so a panic cannot end the sweep, so an oracle that cannot
+// even load is recorded as `compiler-crash` on every seed.
+try {
+	assertOracleCompiles(ROOT, 'mutate');
+} catch (e) {
+	console.error(`\n${e.message}`);
 	process.exit(2);
 }
 

--- a/scripts/compat-corpus/oracle-load-probe.mjs
+++ b/scripts/compat-corpus/oracle-load-probe.mjs
@@ -1,0 +1,22 @@
+// Loads the official compiler and compiles one known-good component and one
+// known-good module. Runs as its own process for the same reason the binding
+// probe does: a broken oracle can die in ways an import guard cannot catch.
+import path from 'node:path';
+
+const entry = path.resolve(process.argv[2]);
+const svelte = await import(entry);
+
+const component = svelte.compile('<p>{1}</p>', { generate: 'client', dev: false, filename: 'C.svelte' });
+if (!component?.js?.code) {
+	console.error('official compiler loaded but produced no component output');
+	process.exit(1);
+}
+const module = svelte.compileModule('export const a = 1;', {
+	generate: 'server',
+	dev: false,
+	filename: 'm.svelte.js',
+});
+if (!module?.js?.code) {
+	console.error('official compiler loaded but produced no module output');
+	process.exit(1);
+}

--- a/scripts/compat-corpus/oracle.mjs
+++ b/scripts/compat-corpus/oracle.mjs
@@ -1,0 +1,60 @@
+/**
+ * Precondition check for the differential oracle.
+ *
+ * Every sweep here compares rsvelte against the official compiler imported from
+ * `submodules/svelte`. That import needs the submodule's own `node_modules`,
+ * which the repo's root `pnpm install` does not provide — and when it is absent
+ * the workers die on `Cannot find package 'zimmerframe'` before they reach a
+ * single comparison.
+ *
+ * The failure is invisible because it arrives wearing a verdict's clothes. The
+ * mutation sweep runs each seed in a child process precisely so a compiler panic
+ * cannot take the run down; the parent sees the dead child, records
+ * `compiler-crash`, and resumes. A dead ORACLE is indistinguishable from a dead
+ * compiler under test, so a full sweep in that state reports every seed as an
+ * rsvelte crash — 14,138 confident findings, none of them real.
+ *
+ * So probe the oracle once, on an input it must handle, before the sweep starts.
+ * Same shape as `verify.mjs` asserting that most manifest entries have compiled
+ * output before it compares them: a gate that cannot see its own preconditions
+ * reports the absence of measurement as a measurement.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { execFileSync } from 'node:child_process';
+
+export const OFFICIAL_COMPILER_REL = 'submodules/svelte/packages/svelte/src/compiler/index.js';
+
+/**
+ * Throws when the official compiler cannot compile a known-good component and
+ * module. `label` names the calling gate in the message.
+ */
+export function assertOracleCompiles(root, label) {
+	const entry = path.join(root, OFFICIAL_COMPILER_REL);
+	if (!fs.existsSync(entry)) {
+		throw new Error(
+			`[${label}] official compiler missing at ${OFFICIAL_COMPILER_REL}\n` +
+				'  run: git submodule update --init submodules/svelte'
+		);
+	}
+	const probe = path.join(root, 'scripts/compat-corpus/oracle-load-probe.mjs');
+	try {
+		execFileSync(process.execPath, [probe, entry], { stdio: ['ignore', 'ignore', 'pipe'] });
+	} catch (e) {
+		const stderr = (e?.stderr?.toString() ?? '').trim();
+		const lines = stderr.split('\n').filter((l) => l.trim());
+		// Node leads with the internal source frame that threw (`throw new
+		// ERR_MODULE_NOT_FOUND(...)`), which names nothing the reader can act on.
+		// The diagnosis is the thrown message itself.
+		const diagnosis = lines.find((l) => /\w*Error[:\s[]/.test(l) && !/^\s*(throw|\^)/.test(l));
+		const first = diagnosis ?? lines[0] ?? String(e?.message ?? e);
+		const signal = e?.signal ? ` (${e.signal})` : '';
+		throw new Error(
+			`[${label}] the official compiler does not run${signal} — every comparison would be scored against a dead oracle.\n` +
+				`  ${first}\n` +
+				'  most often its dependencies are missing; the repo-root install does not cover the submodule:\n' +
+				'    (cd submodules/svelte && pnpm install --frozen-lockfile)'
+		);
+	}
+}


### PR DESCRIPTION
## The failure

`submodules/svelte` needs its own `node_modules`; the repo-root `pnpm install`
does not provide them. Without them the official compiler cannot be imported.

That alone would be harmless if it were loud. It is not, because both sweeps
isolate compilation in child processes **precisely so an rsvelte panic cannot
end the run** — so the parent sees a dead child and does what it was built to
do: record a per-seed verdict and resume.

- `mutate-corpus.mjs` → `compiler-crash`, one per seed
- `compile.mjs` → `rust_panic`, one per entry

A full mutation sweep in that state produces **14,138 confident `compiler-crash`
findings and a completely coherent wrong story**. I hit this: my first sweep ran
25 minutes reporting crashes on every seed, and the cause was
`Cannot find package 'zimmerframe'` in a worker whose stderr nobody reads.

**The harness cannot distinguish a dead oracle from a dead compiler.** So the fix
is not a runbook line — it is a precondition. Probe the oracle once, on an input
it must handle, before the sweep starts. Same shape as `verify.mjs` asserting
that ≥99% of manifest entries have compiled output before it compares them, and
for the same reason: a gate that cannot see its own preconditions reports the
absence of measurement as a measurement.

## What this adds

- `oracle-load-probe.mjs` — imports the official compiler and compiles one
  known-good component and one known-good module. Runs as its own process for
  the reason `binding-load-probe.mjs` does: a broken oracle can die in ways an
  import guard cannot catch.
- `oracle.mjs` — `assertOracleCompiles(root, label)`. Its message names the
  thrown diagnosis rather than the internal frame that threw it (Node leads with
  `throw new ERR_MODULE_NOT_FOUND(...)`, which names nothing you can act on), and
  gives the command that fixes it.
- Called from the parent of both child-process sweeps, before any work.
- One runbook line in `scripts/compat-corpus/README.md`.

Left alone deliberately: `matrix/run.mjs` and `one.mjs` import the compiler
in-process, so an oracle failure there is an unhandled throw — loud, attributed,
and not mistakable for a verdict. This PR covers the gates where worker
isolation converts an oracle failure into a finding.

## Control, exercised both ways on both call sites

With `submodules/svelte/node_modules` moved aside:

```
$ node scripts/compat-corpus/mutate-corpus.mjs --seeds 5 ; echo $?
[mutate] the official compiler does not run — every comparison would be scored against a dead oracle.
  Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'zimmerframe' imported from …/submodules/svelte/packages/svelte/src/compiler/index.js
  most often its dependencies are missing; the repo-root install does not cover the submodule:
    (cd submodules/svelte && pnpm install --frozen-lockfile)
2

$ node scripts/compat-corpus/compile.mjs --filter pattern/issues ; echo $?
[compile] the official compiler does not run — …
2
```

Restored, both run to completion (exit 0). Exit codes read directly, not through
a pipe — `cmd | head` reports `head`'s status, which is how a probe like this
gets certified as working while doing nothing.
