### PR TITLE
ci: key push-triggered concurrency groups by SHA so main keeps a verdict

### DIFF
--- a/.github/workflows/capi.yml
+++ b/.github/workflows/capi.yml
@@ -37,7 +37,10 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  # `github.sha`, not `github.ref`: every push to `main` shares one ref, so a
+  # ref-keyed group cancels each merge's run as the next merge starts and `main`
+  # carries no verdict — which reads exactly like a green one (#2435/#2593).
+  group: ${{ github.workflow }}-${{ github.head_ref || github.sha }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/crates-io-packages.yml
+++ b/.github/workflows/crates-io-packages.yml
@@ -46,7 +46,10 @@ permissions:
   contents: read
 
 concurrency:
-  group: crates-io-packages-${{ github.ref }}
+  # `github.sha`, not `github.ref`: every push to `main` shares one ref, so a
+  # ref-keyed group cancels each merge's run as the next merge starts and `main`
+  # carries no verdict — which reads exactly like a green one (#2435/#2593).
+  group: crates-io-packages-${{ github.head_ref || github.sha }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/type-aware-lint.yml
+++ b/.github/workflows/type-aware-lint.yml
@@ -40,7 +40,10 @@ permissions:
   contents: read
 
 concurrency:
-  group: type-aware-lint-${{ github.ref }}
+  # `github.sha`, not `github.ref`: every push to `main` shares one ref, so a
+  # ref-keyed group cancels each merge's run as the next merge starts and `main`
+  # carries no verdict — which reads exactly like a green one (#2435/#2593).
+  group: type-aware-lint-${{ github.head_ref || github.sha }}
   cancel-in-progress: true
 
 jobs:

--- a/scripts/ci/test-workflow-trigger-guard.mjs
+++ b/scripts/ci/test-workflow-trigger-guard.mjs
@@ -189,6 +189,73 @@ check('inline `on: [push, pull_request]` parses without crashing', () => {
 	assert(triggers.length === 0, `expected no nested triggers, got ${JSON.stringify(triggers)}`);
 });
 
+// --- Concurrency: a cancelling group that cannot distinguish two pushes. ---
+
+const PUSH_ON = `
+on:
+  push:
+    branches: [main]
+`;
+
+check('a ref-keyed cancelling group on a push workflow is rejected', () => {
+	withDir(
+		{
+			'a.yml': `name: a${PUSH_ON}\nconcurrency:\n  group: a-\${{ github.ref }}\n  cancel-in-progress: true\n${JOBS}`,
+		},
+		(dir) => {
+			const { violations } = checkWorkflows(dir, {});
+			assert(violations.length === 1, `expected 1 violation, got ${violations.length}`);
+			assert(/carries no verdict/.test(violations[0].message), 'expected the verdict wording');
+		},
+	);
+});
+
+check('the same group keyed by github.sha is accepted', () => {
+	withDir(
+		{
+			'a.yml': `name: a${PUSH_ON}\nconcurrency:\n  group: a-\${{ github.head_ref || github.sha }}\n  cancel-in-progress: true\n${JOBS}`,
+		},
+		(dir) => {
+			const { violations } = checkWorkflows(dir, {});
+			assert(violations.length === 0, `expected clean, got ${JSON.stringify(violations)}`);
+		},
+	);
+});
+
+check('cancel-in-progress: false makes the group key irrelevant', () => {
+	withDir(
+		{
+			'a.yml': `name: a${PUSH_ON}\nconcurrency:\n  group: a-\${{ github.ref }}\n  cancel-in-progress: false\n${JOBS}`,
+		},
+		(dir) => {
+			const { violations } = checkWorkflows(dir, {});
+			assert(violations.length === 0, `expected clean, got ${JSON.stringify(violations)}`);
+		},
+	);
+});
+
+check('a ref-keyed cancelling group without a push trigger is accepted', () => {
+	withDir(
+		{
+			'a.yml': `name: a\non:\n  pull_request:\nconcurrency:\n  group: a-\${{ github.ref }}\n  cancel-in-progress: true\n${JOBS}`,
+		},
+		(dir) => {
+			const { violations } = checkWorkflows(dir, {});
+			assert(violations.length === 0, `expected clean, got ${JSON.stringify(violations)}`);
+		},
+	);
+});
+
+check('a job-level concurrency block is not read as the workflow-level one', () => {
+	const source = `name: a${PUSH_ON}\njobs:\n  publish:\n    runs-on: ubuntu-latest\n    concurrency:\n      group: a-\${{ github.ref }}\n      cancel-in-progress: true\n    steps:\n      - run: echo hi\n`;
+	const { concurrency } = analyzeWorkflow(source);
+	assert(concurrency === null, `expected no top-level concurrency, got ${JSON.stringify(concurrency)}`);
+	withDir({ 'a.yml': source }, (dir) => {
+		const { violations } = checkWorkflows(dir, {});
+		assert(violations.length === 0, `expected clean, got ${JSON.stringify(violations)}`);
+	});
+});
+
 // --- The shipped tree. ---
 
 check('the real .github/workflows tree is clean under the shipped allowlist', () => {

--- a/scripts/ci/workflow-trigger-guard.mjs
+++ b/scripts/ci/workflow-trigger-guard.mjs
@@ -39,6 +39,11 @@ const PR_TRIGGERS = ['pull_request', 'pull_request_target'];
 // Keys that restrict a trigger to particular base branches.
 const BRANCH_FILTER_KEYS = ['branches', 'branches-ignore'];
 
+// A concurrency group must contain one of these to vary between two pushes to
+// the same branch. `github.ref` does not: it is `refs/heads/main` for every
+// merge, so a ref-keyed cancelling group makes each merge kill its predecessor.
+const PER_PUSH_CONTEXTS = ['github.sha', 'github.run_id'];
+
 /**
  * Workflows permitted to filter their PR trigger by base branch, each with the
  * reason. The reason is the point of the list: without it the intent survives
@@ -150,7 +155,23 @@ export function analyzeWorkflow(source, { name = '<source>' } = {}) {
 			.filter((k) => BRANCH_FILTER_KEYS.includes(k));
 		triggers.push({ trigger: trigger.key, filters });
 	}
-	return { triggers };
+
+	const pushes = directChildren(lines, onIndex + 1, 0).some((c) => c.key === 'push');
+
+	// Top-level only. A job-level `concurrency:` is scoped to that job and is how
+	// release.yml legitimately serialises its publish step.
+	let concurrency = null;
+	const concIndex = lines.findIndex((l) => indentOf(l) === 0 && keyOf(l) === 'concurrency');
+	if (concIndex !== -1) {
+		concurrency = { group: '', cancels: false };
+		for (const child of directChildren(lines, concIndex + 1, 0)) {
+			const value = inlineValueOf(child.line);
+			if (child.key === 'group') concurrency.group = value;
+			if (child.key === 'cancel-in-progress') concurrency.cancels = value === 'true';
+		}
+	}
+
+	return { triggers, pushes, concurrency };
 }
 
 /**
@@ -169,7 +190,25 @@ export function checkWorkflows(dir, allowlist = ALLOWLIST) {
 
 	for (const file of files) {
 		const source = readFileSync(join(dir, file), 'utf8');
-		const { triggers } = analyzeWorkflow(source, { name: file });
+		const { triggers, pushes, concurrency } = analyzeWorkflow(source, { name: file });
+
+		if (
+			pushes &&
+			concurrency?.cancels &&
+			!PER_PUSH_CONTEXTS.some((ctx) => concurrency.group.includes(ctx))
+		) {
+			violations.push({
+				file,
+				message:
+					`\`concurrency.group\` is \`${concurrency.group}\` with \`cancel-in-progress: true\`, ` +
+					`but this workflow runs on \`push\`. Every push to a branch shares one \`github.ref\`, ` +
+					`so each merge cancels its predecessor and the branch carries no verdict — which reads ` +
+					`exactly like a green one (#2435/#2593). Key the group by ` +
+					`\`\${{ github.head_ref || github.sha }}\` so pushes cannot collide, or set ` +
+					`\`cancel-in-progress: false\`.`,
+			});
+		}
+
 		for (const { trigger, filters } of triggers) {
 			if (filters.length === 0) continue;
 			filtered.add(file);


### PR DESCRIPTION
## The defect

`capi`, `crates-io-packages` and `type-aware-lint` run on `push:` to `main` under a
concurrency group keyed by `github.ref`, with `cancel-in-progress: true`.

Every push to `main` shares one `github.ref`. So at any real merge rate each merge
cancels its predecessor's run, and **`main` carries no verdict at all** — which in the
branch header is indistinguishable from a green one.

This is the failure mode that let #2435 ship 56 stale ratchet entries. It was fixed in
`ci`, `codspeed`, `coverage`, `benchmark` and `corpus-compat`, and **missed in these
three**.

## Measured, not inferred

Last 24 runs of each on `main`:

| workflow | cancelled | success |
|---|---|---|
| C ABI | **19** | 5 |
| crates.io packages | **19** | 5 |

The newest cancellations were minutes old when this was written, not historical.
For contrast, `corpus-compat`'s most recent cancellation is `2026-08-08T02:48` —
before its own fix landed — and it has cancelled nothing since.

## Deliberately untouched

- **`release.yml`** — its cancelling groups are **job-level**, and the publish job they
  guard is already `cancel-in-progress: false` because publishing is non-atomic across
  packages. Cancelling a superseded *version-PR* job is intended.
- **`changeset.yml`** — `pull_request` only. `github.ref` is `refs/pull/N/merge`, which
  is stable per PR and distinct between PRs, so supersession works and no push can collide.
- **`site-benchmark.yml`** — `workflow_dispatch` only, so it has no push to lose.

## The guard, because fixing three files does not stop a fourth

`workflow-trigger-guard` already existed to catch a neighbouring defect — a PR trigger
filtered by base branch, where *"its checks go missing rather than red"*. That is the same
argument one axis over, so the invariant belongs there:

> a `push`-triggered workflow whose concurrency group cancels must key that group by
> something that varies between two pushes to one branch (`github.sha` or `github.run_id`).

It reads **only the top-level `concurrency:` block**, so `release.yml`'s job-level one is
not mistaken for it.

### Control, exercised both ways

Run against `origin/main`'s workflow directory it reports **exactly these three files and
no others** — the same set the cancellation counts identify, reached by a completely
independent method (static config vs. observed run outcomes).

```
$ node scripts/ci/workflow-trigger-guard.mjs --dir <origin/main workflows>
workflow-trigger-guard: 3 violation(s)
  capi.yml / crates-io-packages.yml / type-aware-lint.yml
EXIT=2

$ node scripts/ci/workflow-trigger-guard.mjs          # this branch
workflow-trigger-guard: 18 workflows checked, 3 allowlisted base-branch filters, no violations.
EXIT=0
```

Five new self-test cases, each paired with its near-miss so a guard that returned
"clean" unconditionally would fail: ref-keyed + cancelling + push → **rejected**;
same group keyed by `github.sha` → accepted; `cancel-in-progress: false` → accepted;
no `push` trigger → accepted; job-level block → not read as workflow-level.

21/21 pass.
