### PR TITLE
docs(compat): inventory the mutation-fuzz gate as coverage row 20

### DIFF
--- a/compatibility/gate-coverage.md
+++ b/compatibility/gate-coverage.md
@@ -60,6 +60,7 @@ samples) — see `AGENTS.md` § "Generated shape matrix" and issue #2281.
 | 17 | svelte2tsx fixture suite | per-fixture TSX text | text after the `export default class` cut is dropped from both sides | [S] |
 | 18 | Compatibility report (`AGENTS.md` numbers) | pass/fail per fixture | warnings compared by **count only** | [S] |
 | 19 | Output parseability (`verify.mjs`) | rsvelte's `js.code` alone, parsed with acorn | says nothing about whether the output is *right*; no CSS, no maps | [S] |
+| 20 | Corpus-seeded mutation fuzz | per-mutant × target JS text, normalized as gate 1 | the operator only **inserts comments** — a delimiter in a *string* is unreachable at any corpus size | [D] |
 
 Cross-cutting blind spots (path filters, ratchet-doc drift, vacuity floors, and the
 **performance** gates' population) are in [§ Cross-cutting](#cross-cutting) at the end.
@@ -869,6 +870,104 @@ scoped to one target parses one target's modules, exactly like every other compa
 `--targets client --update-parse-baseline` run rewrites only the client ratchet (the loop is
 over `TARGETS`), but nothing warns that the other two were not measured. Inherited from the
 existing diagnostic families, not introduced here.
+
+---
+
+## 20. Corpus-seeded mutation fuzz — `scripts/compat-corpus/mutate-corpus.mjs`
+
+**Unit.** Per mutant × target, official vs rsvelte `js.code`, normalized exactly as gate 1
+normalizes. A mutant is a seed with **one comment inserted at a line boundary** inside a
+`<script>` region (`:227`).
+
+**This section was added after the fact.** `AGENTS.md` requires a gate's row *before* its ratchet
+is first baselined; #2281 shipped this gate and `mutation-known-failures.json` without one, and
+the omission stood until a defect went looking for it. Named here rather than silently filled,
+because the next gate author will otherwise repeat it.
+
+**Three populations appear below and they are routinely confused.** 14,138 = manifest entries,
+the seed set. 12,166 = mutants actually generated (a seed with no insertion slot is skipped).
+39,563 = *(entry, target)* pairs for which rsvelte emitted a module and gate 19 acorn-parsed it
+(`verify.mjs:358-360`). Note that gate 19's unparseable counter is per **entry**, not per pair
+(`verify.mjs:365`), so its headline number and that denominator are not in the same unit.
+
+### Blind spot 20a — the operator inserts comments, so a bracket in a *string* is never moved
+
+*Not closable by scale — the contrast with 20b is the point.*
+
+**[D]** `:227` splices `COMMENT_KINDS[kindName]` into the source and changes nothing else. All
+eight kinds (`matrix/axes.mjs:178-187`) are comments. The gate reaches a defect whose trigger is
+a delimiter inside a **comment** and never one whose trigger is the same delimiter inside a
+**string, template or regex literal**.
+
+Discriminating case. `transform_class_fields_server` counted `(){}[]` byte by byte, so on the
+server target a two-field class whose second `$derived.by` spans lines with `q: ")"` in it
+dropped that field and every member after it, leaving `);` at statement position. Official is
+correct and rsvelte's own *client* target is correct. Its comment-carrying twin (`// ) c` in the
+same slot) **was** reported by this gate; the string form is unreachable by construction and was
+found by hand while fixing the twin. Fixed by #2639.
+
+What is measured about the corpus, and what is not: gate 19 reported **0 unparseable of 39,563**
+on the `80abbe52` main run, with `parse-known-failures.{client,server,client-dev}.json` all `[]`.
+So **nothing in the corpus triggers this defect at any target** — which is *not* the claim "the
+shape is absent from the sources", a thing nobody has measured. The first also carries gate 19's
+own hole: `parse-oracle-excluded.json` lists 2 pairs checked on **neither** side (19f).
+
+The lesson this document exists for: **growing the corpus cannot close this, and neither can more
+mutants.** Only an operator that edits existing tokens reaches the class. Related: #2637 makes
+the same point on another axis — the fuzzer inserts comments, not operators, so a `$:` line
+ending in `*` or `%` is outside it too.
+
+### Blind spot 20b — one mutant per seed, at a hash-chosen slot
+
+*Closable by scale — the opposite of 20a, which is why the two must not read as one item.*
+
+**[S]** `PER_FILE` defaults to 1 (`:96`) and the slot is `slots[h % slots.length]` with
+`h = fnv1a(id#n)` (`:216-217`). A seed with 40 insertion slots is sampled at one of them, fixed
+for that id — it contributes 1/40 of its own surface. Two independent defects in one file are
+never both observed, and which one is observed is decided by a hash. The full sweep's 12,166
+mutants are 12,166 seeds sampled once, not a sweep over slots.
+
+**`--per-file n` closes this and nothing else has to change**; cost is linear and the ratchet keys
+already carry `__m<n>__` so they do not churn.
+
+### Blind spot 20c — `already PASS` cannot distinguish *fixed* from *no longer produced*
+
+**[S]** The staleness check is `baseline.filter((id) => !ids.has(id))` (`:661`) — a baseline key
+absent from this run's failures. `ids` is `` `${f.id} [${f.verdict}] (${f.target})` `` (`:588`).
+An entry leaves that set for at least four reasons and the output calls all of them "already
+PASS":
+
+1. the defect was fixed;
+2. the seed file no longer exists, so no mutant is generated (`:144` filters the manifest to
+   sources present on disk) — a corpus-source removal or a submodule bump does this;
+3. the seed's **content** moved. `n` and `kindName` derive from the seed id alone, but the
+   **slot** is `slots[h % slots.length]` over the current line list, so an edit anywhere in the
+   file relocates the comment while the key stays identical. The same id then denotes a
+   different mutation, which may pass for reasons unrelated to any fix. The comment at
+   `:220-223` states this trade deliberately — keying on the line would churn every entry in a
+   seed on any edit — so the exposure is the accepted cost, not an oversight;
+4. the **verdict class** changed. The verdict is in the key, so `code-mismatch` →
+   `comment-mismatch` retires the entry as "already PASS" while the entry still diverges.
+
+Consequence for re-baselining: an `already PASS` count is only evidence of fixes if the corpus
+tree did not move. The check is `git log --oneline <since> -- submodules scripts/compat-corpus/corpus-sources.json`
+returning nothing, with a non-empty commit count over the same range as the positive control.
+Reason 4 is not covered by that check at all — **unmeasured** whether any current entry retires
+by class change rather than by fix.
+
+### Blind spot 20d — insertion is line-boundary only, and `<script>` only
+
+**[S]** `insertionSlots` (`matrix/mutate.mjs:41-61`) yields line boundaries inside `<script>`
+ranges. A comment inside an expression (`f(/* c */ x)`), in a template-markup slot, or between
+two tokens on one line is never generated. Same shape as blind spot 5c, from the same helper.
+
+### Blind spot 20e — only the `code` class is ratcheted per id
+
+**[S]** `:598` restricts the per-id regression check to `code-mismatch` and `unparseable`;
+`comment-mismatch` is an aggregate count (`:695-696`). On the full sweep that is 13,242
+divergences with no per-entry gate. Deliberate and documented (`AGENTS.md`; gate 5 ratchets
+comment fidelity per id on generated seeds that do not move when a submodule bumps) — but a
+comment regression on a *collected* seed is invisible here.
 
 ---
 

--- a/compatibility/gate-coverage.md
+++ b/compatibility/gate-coverage.md
@@ -62,8 +62,9 @@ samples) — see `AGENTS.md` § "Generated shape matrix" and issue #2281.
 | 19 | Output parseability (`verify.mjs`) | rsvelte's `js.code` alone, parsed with acorn | says nothing about whether the output is *right*; no CSS, no maps | [S] |
 | 20 | Corpus-seeded mutation fuzz | per-mutant × target JS text, normalized as gate 1 | the operator only **inserts comments** — a delimiter in a *string* is unreachable at any corpus size | [D] |
 
-Cross-cutting blind spots (path filters, ratchet-doc drift, vacuity floors, and the
-**performance** gates' population) are in [§ Cross-cutting](#cross-cutting) at the end.
+Cross-cutting blind spots (path filters, ratchet-doc drift, vacuity floors, the **performance**
+gates' population, and **an uninitialised corpus source shrinking every corpus gate silently**)
+are in [§ Cross-cutting](#cross-cutting) at the end.
 
 ---
 
@@ -950,10 +951,26 @@ PASS":
    `comment-mismatch` retires the entry as "already PASS" while the entry still diverges.
 
 Consequence for re-baselining: an `already PASS` count is only evidence of fixes if the corpus
-tree did not move. The check is `git log --oneline <since> -- submodules scripts/compat-corpus/corpus-sources.json`
+tree did not move. Two checks, and they cover different reasons.
+
+*Reason 2* — `git log --oneline <since> -- submodules scripts/compat-corpus/corpus-sources.json`
 returning nothing, with a non-empty commit count over the same range as the positive control.
-Reason 4 is not covered by that check at all — **unmeasured** whether any current entry retires
-by class change rather than by fix.
+This covers seeds vanishing because the tree moved; it does **not** cover a source absent from
+the working copy (**C7**).
+
+*Reason 4* — **measured `[D]` 0**, in the `code-mismatch ⇄ unparseable` direction. Method:
+extract `id (target)` from the NEW-divergences and already-PASS lists with the verdict stripped
+and intersect; an entry that merely changed class appears in both. Empty at `d1eedb3f` over
+14,138 seeds. The instrument is shown to move by the same counter reporting 16 unparseable at
+`d88546a7` and 10 at `39ba6489` on the same day, so this is not the vacuous kind of zero.
+
+That covers only the two verdicts the baseline can represent. **Transitions into
+`comment-mismatch` remain unmeasured**, because those ids are never recorded — `:555-557`
+increments the counter and `continue`s before any `failures.push`, so no comment-mismatch key
+exists to intersect against. Closing that half needs the id recorded alongside the count. The
+first attempt at this cell proposed intersecting against that non-existent set, which would have
+returned empty regardless of the truth — a vacuous zero is worse than a blank, because the blank
+advertises itself.
 
 ### Blind spot 20d — insertion is line-boundary only, and `<script>` only
 
@@ -1017,6 +1034,28 @@ while `sourcemap-known-failures.json` has 74.** Already drifted, in an unchecked
 | svelte2tsx fixtures | `total_tested >= 254`, absolute | `svelte2tsx_fixtures.rs:30,155` |
 | **css-prune sweep** | **none** | `css-prune-sweep.mjs:482` is a `console.log` |
 | check / check-e2e | scenarios > 0; **no diagnostic floor**, ratchets are `[]` | `check-verify.mjs:179`; gap at `:240` |
+
+### C7. An uninitialised corpus source shrinks the population silently, and no floor catches it
+
+**[D]** `collect.mjs:168-178` walks `corpus-sources.json` and, for a source whose directory is
+missing or empty, warns and `continue`s. Only `src.required` sources abort (`:171-174`) — and
+**2 of 36 sources are required**, so 34 can each disappear from the measured population while
+`collect.mjs` exits 0 and writes a manifest that looks complete.
+
+Observed, not hypothetical: a sweep run with `runed` and `svelte-toolbelt` uninitialised
+measured **14,035** entries instead of 14,138, and **10 baseline entries came from those two
+sources**. `--update-baseline` deletes every baseline id it did not measure, so those ten would
+have been dropped as fixed.
+
+The floor does not help. `MIN_FULL_CORPUS_ENTRIES = 12000` (`artifacts.mjs:87`) guards against
+*catastrophic* under-measurement; 14,035 clears it comfortably. A partial corpus is invisible to
+a lower bound **by construction** — the only thing that surfaced it was comparing the local
+manifest count against CI's.
+
+This sits upstream of blind spot 20c's reason 2 and applies to every corpus-derived gate (1, 2-3,
+4, 19, 20), not only the mutation fuzz. Closing it means asserting the *set* of collected
+sources against `corpus-sources.json`, not the entry count — an entry count cannot distinguish a
+missing source from a source that shrank.
 
 ### C4. Gate scripts that no workflow invokes
 


### PR DESCRIPTION
Docs only. Adds section 20 and its summary row for the corpus-seeded mutation fuzz gate
(`scripts/compat-corpus/mutate-corpus.mjs`), which had **no row at all** — #2281 shipped the gate
and `mutation-known-failures.json` together, and `AGENTS.md` asks for the row *before* the first
baseline. The section says so in its own body rather than filling the gap silently.

## The load-bearing entry is 20a, and it is graded `[D]`

The operator inserts a comment and only a comment (`:227`; all eight kinds in
`matrix/axes.mjs:178-187`). So a defect whose trigger is a delimiter inside a **string, template
or regex literal** is unreachable by this gate — **at any corpus size, and by any number of
mutants**. Only an operator that edits existing tokens reaches the class.

The discriminating case is the one #2639 fixed. `transform_class_fields_server` counted
`(){}[]` byte by byte, so a two-field class whose second `$derived.by` spans lines dropped that
field and left `);` at statement position:

- with `// ) c` in the object literal — **reported by this gate**;
- with `q: ")"` and no comment anywhere — **not reported, and not reportable**. Official is
  correct; rsvelte's own *client* target is correct. Found by hand while fixing the twin.

That is why 20a is `[D]` and not `[S]`: there is an observed case, not only an argument.

## 20b is the deliberate contrast

One mutant per seed at a hash-chosen slot (`:96`, `:216-217`), so a seed with 40 slots
contributes 1/40 of its own surface. Unlike 20a this **does** close with scale — `--per-file n`,
linear cost, and the ratchet keys already carry `__m<n>__` so they do not churn.

Both rows are tagged with whether scale closes them. A marker on only the closable one reads as
an oversight; on both it reads as a judgement, and it tells a future maintainer where spending
buys coverage.

## 20c — `already PASS` conflates "fixed" with "no longer produced"

Staleness is `baseline.filter((id) => !ids.has(id))` (`:661`) over a key of
`` `${f.id} [${f.verdict}] (${f.target})` `` (`:588`). Four ways an entry leaves that set, all
printed as "already PASS":

1. genuinely fixed;
2. the seed file is gone, so no mutant is generated (`:144` filters to sources on disk);
3. the seed's **content** moved — `n` and `kindName` derive from the id, but the slot is
   `slots[h % slots.length]` over the current line list, so an edit relocates the comment while
   the key stays identical. `:220-223` states this trade deliberately, so the exposure is the
   accepted cost of not churning every entry on any edit, not an oversight;
4. the **verdict class** changed, since the verdict is in the key — `code-mismatch` →
   `comment-mismatch` retires an entry that still diverges.

Reason 2 is what the pre-rebaseline check on `submodules` / `corpus-sources.json` covers.
**Reason 4 is left explicitly unmeasured** rather than guessed — a blank is honest, an
unsupported blind-spot claim reads to the next person as surveyed ground.

## Verification

Every citation was resolved against the file content at this commit, not recalled — #2640 had
already shifted `mutate-corpus.mjs` line numbers out from under an earlier draft of this text.
15 of 15 assert to the construct they claim.

The one number quoted from another gate (**0 unparseable of 39,563**, gate 19) is stated with its
population and its hole: `parsedModules` counts *(entry, target)* pairs (`verify.mjs:358-360`)
while the unparseable counter is per **entry** (`verify.mjs:365`), so the two are not in the same
unit; and `parse-oracle-excluded.json` lists 2 pairs checked on neither side. The section also
separates "nothing in the corpus triggers this defect" (measured, ratchets read in-tree) from
"the shape is absent from the sources" (**not** measured, and not claimed).
