### PR TITLE
fix(transform): stop legacy $: order from depending on whitespace

### DIFF
--- a/.changeset/reactive-order-whitespace.md
+++ b/.changeset/reactive-order-whitespace.md
@@ -1,0 +1,17 @@
+---
+"@rsvelte/compiler": patch
+---
+
+Stop legacy `$:` statement order from depending on whitespace.
+
+`$: {mid=seed*2}` and `$: { mid = seed * 2 }` are the same program, but they
+compiled to different execution order. The scan that decides which variables a
+reactive statement assigns — which feeds the topological sort — matched the
+literal `" = "`, spaces included, so the unspaced form was credited with
+assigning nothing, never got an ordering edge, and ran before the statement
+whose value it produces. Anything reading `mid` then saw a stale value on first
+run. Every compound operator was affected too, not just `=`.
+
+The scan now finds the name and its operator separately, so any spacing (or
+none) is recognised. Comparisons are still excluded, and the longest operator
+wins, so `<=` stays a comparison while `<<=` assigns.

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/reactive_transforms.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/reactive_transforms.rs
@@ -146,38 +146,58 @@ pub(super) fn is_assigned_anywhere_in_body(body: &str, var_name: &str) -> bool {
         }
     }
 
-    // Check for assignment operators: `var = ...`, `var += ...`, `var -= ...`, etc.
-    let assign_patterns = [
-        " = ", " += ", " -= ", " *= ", " /= ", " %= ", " **= ", " &= ", " |= ", " ^= ", " <<= ",
-        " >>= ", " >>>= ", " ??= ", " &&= ", " ||= ",
-    ];
-    for assign_op in &assign_patterns {
-        let pattern = format!("{}{}", var_name, assign_op);
-        if let Some(pos) = body.find(&pattern) {
-            // Verify the variable name is at a word boundary (not part of a longer name)
-            let before = if pos > 0 {
-                body.as_bytes()[pos - 1]
-            } else {
-                b' '
-            };
-            let before_ok = !before.is_ascii_alphanumeric()
-                && before != b'_'
-                && before != b'$'
-                && before != b'.';
-            if before_ok {
-                // Also make sure it's not `==` or `=>`
-                let after_eq = pos + var_name.len() + assign_op.len();
-                if assign_op == &" = " && after_eq < body.len() {
-                    let next = body.as_bytes()[after_eq - 1]; // the char after '='
-                    if next == b'=' || next == b'>' {
-                        continue;
-                    }
-                }
-                return true;
-            }
+    // Check for assignment operators: `var = …`, `var += …`, etc. The spacing
+    // between the name and its operator is not fixed, so this walks every
+    // occurrence of the name rather than matching `"<var> = "` literally —
+    // `$: {a=b}` assigns `a` exactly as `$: { a = b }` does.
+    let bytes = body.as_bytes();
+    let mut from = 0;
+    while let Some(rel) = memmem::find(&bytes[from..], var_name.as_bytes()) {
+        let pos = from + rel;
+        from = pos + var_name.len().max(1);
+
+        let before = if pos > 0 { bytes[pos - 1] } else { b' ' };
+        if before.is_ascii_alphanumeric() || before == b'_' || before == b'$' || before == b'.' {
+            continue;
+        }
+        let mut i = pos + var_name.len();
+        // The name has to end here, not run on into a longer identifier.
+        if let Some(&c) = bytes.get(i)
+            && (c.is_ascii_alphanumeric() || c == b'_' || c == b'$')
+        {
+            continue;
+        }
+        while matches!(bytes.get(i), Some(b' ' | b'\t')) {
+            i += 1;
+        }
+        if is_assignment_operator_at(bytes, i) {
+            return true;
         }
     }
 
+    false
+}
+
+/// Whether an assignment operator starts at `i`. `<=` and `>=` are comparisons
+/// while `<<=` and `>>=` are not, so the longest candidate has to win; `=` also
+/// begins `==`, `===` and `=>`, none of which assign.
+fn is_assignment_operator_at(bytes: &[u8], i: usize) -> bool {
+    const OPS: [&[u8]; 16] = [
+        b">>>=", b"<<=", b">>=", b"**=", b"??=", b"&&=", b"||=", b"+=", b"-=", b"*=", b"/=", b"%=",
+        b"&=", b"|=", b"^=", b"=",
+    ];
+    let Some(rest) = bytes.get(i..) else {
+        return false;
+    };
+    for op in OPS {
+        if rest.starts_with(op) {
+            if op == b"=" {
+                let next = rest.get(1).copied().unwrap_or(b' ');
+                return next != b'=' && next != b'>';
+            }
+            return true;
+        }
+    }
     false
 }
 

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/tests.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/tests.rs
@@ -1935,3 +1935,68 @@ fn a_store_call_is_not_inserted_into_a_longer_non_ascii_identifier() {
         "$c()(1); x\u{E0}$c(2)"
     );
 }
+
+/// `$: {a=b}` and `$: { a = b }` are the same program, so they must order the
+/// same. The assignment scan feeding the topological sort matched the literal
+/// `" = "`, so the unspaced form was credited with assigning nothing, lost its
+/// ordering edge, and ran before the statement it depends on.
+#[test]
+fn reactive_statement_order_ignores_whitespace_around_the_assignment() {
+    fn effect_order(source: &str) -> Vec<String> {
+        let js = crate::compiler::compile(
+            source,
+            crate::compiler::CompileOptions {
+                generate: crate::compiler::GenerateMode::Client,
+                filename: Some("order/index.svelte".to_string()),
+                ..Default::default()
+            },
+        )
+        .unwrap()
+        .js
+        .code;
+        js.lines()
+            .filter(|l| l.contains("$.set(mid,") || l.contains("$.set(out,"))
+            .map(|l| l.trim().to_string())
+            .collect()
+    }
+
+    let unspaced = effect_order(
+        "<script>\nexport let seed = 1;\nlet mid = 0;\nlet out = 0;\n$: out = mid + 1;\n$: {mid=seed*2}\n</script>\n\n<p>{out}</p>\n",
+    );
+    let spaced = effect_order(
+        "<script>\nexport let seed = 1;\nlet mid = 0;\nlet out = 0;\n$: out = mid + 1;\n$: { mid = seed * 2 }\n</script>\n\n<p>{out}</p>\n",
+    );
+
+    // `out` reads `mid`, so the statement assigning `mid` has to come first.
+    assert!(
+        unspaced[0].contains("$.set(mid,"),
+        "unspaced ran out of order: {unspaced:?}"
+    );
+    // The spaced form is the control: it was already correct and must stay so.
+    assert!(
+        spaced[0].contains("$.set(mid,"),
+        "spaced ran out of order: {spaced:?}"
+    );
+    assert_eq!(unspaced, spaced);
+}
+
+/// A comparison is not an assignment, and the longest operator has to win:
+/// `<=` is a comparison while `<<=` assigns.
+#[test]
+fn the_assignment_scan_separates_operators_from_comparisons() {
+    use super::reactive_transforms::is_assigned_anywhere_in_body;
+
+    for body in [
+        "a=1", "a = 1", "a  =  1", "a+=1", "a **= 2", "a<<=1", "a >>>= 1", "a??=1", "a++", "--a",
+    ] {
+        assert!(is_assigned_anywhere_in_body(body, "a"), "missed: {body:?}");
+    }
+    for body in [
+        "a==1", "a === 1", "a=>1", "a<=1", "a >= 1", "a!=1", "a !== 1", "ab=1", "b.a=1", "abc",
+    ] {
+        assert!(
+            !is_assigned_anywhere_in_body(body, "a"),
+            "false positive: {body:?}"
+        );
+    }
+}


### PR DESCRIPTION
Fixes #2646.

## What was wrong

`$: {mid=seed*2}` and `$: { mid = seed * 2 }` are the same program — identical
ASTs, differing only in whitespace — but they compiled to **different execution
order**:

| | before | after |
|---|---|---|
| `$: {mid=seed*2}` | `out` first, reading a stale `mid` — **wrong** | `mid` first ✅ |
| `$: { mid = seed * 2 }` (control) | `mid` first | `mid` first — **unchanged** ✅ |

`is_assigned_anywhere_in_body` decides which variables a `$:` statement assigns,
and that feeds the topological sort. It matched literal operator strings with
the spaces baked in:

```rust
let assign_patterns = [" = ", " += ", " -= ", /* … */];
let pattern = format!("{}{}", var_name, assign_op);
if let Some(pos) = body.find(&pattern) {
```

So the unspaced form was credited with assigning nothing, never acquired an
ordering edge, and ran before the statement whose value it consumes. Every
compound operator was affected, not just `=`.

## The fix

The scan now finds the name at a word boundary, skips any spaces/tabs, and
tests the operator run at that point. Comparisons stay excluded, and the
**longest** candidate wins so `<=` remains a comparison while `<<=` assigns;
`=` is rejected when followed by `=` or `>`.

## Evidence

**Both probes**, treatment and control — the control matters because it shows
the change fixes the broken shape without moving the shape that was already
correct. The two now emit byte-identical output modulo the component name.

`reactive_statement_order_ignores_whitespace_around_the_assignment` pins both.
Run against the unfixed scan it **fails, for the predicted reason** — it trips
the *unspaced* assertion, not the control:

```
unspaced ran out of order: ["$.set(out, $.get(mid) + 1);", "$.set(mid, seed() * 2);"]
```

`the_assignment_scan_separates_operators_from_comparisons` tables the operator
rule: `a=1`, `a **= 2`, `a<<=1`, `a >>>= 1` assign; `a==1`, `a=>1`, `a<=1`,
`a !== 1`, `ab=1`, `b.a=1` do not.

**Full corpus** (14,138 entries, all three targets), run against this exact
dylib:

```
match          13190     — identical to main's own figure
js-mismatch        0     js-unparseable 0     css-mismatch 0     error-mismatch 0
no warning regressions (32 known, unchanged)
no error regressions  (236 known, unchanged)
all 39569 generated modules parse
```

Zero movement on every gate. **This is the acceptance criterion, not merely a
good result**: the output-parity baseline is *empty* — main is at 0 known
output failures — so main already matches official on all 14,138 entries, and
any correct change here must produce exactly zero diff. There is no direction
in which a corpus entry could improve.

**Official fixtures**, release, `Running` lines counted against binaries
requested rather than trusting the exit code:

```
4 Running lines / 4 binaries requested
compiler_fixtures  3 passed  0 failed
runtime            5 passed  0 failed   (runtime-legacy 1209, runtime-runes 1013,
                                          hydration 80, runtime-browser 32)
ssr                2 passed  0 failed   (126 fixtures)
validator          3 passed  0 failed
```

Clippy `--all-targets --all-features` clean. No ratchet is regenerated: nothing
moved, so there is nothing to re-baseline.

### What those green suites do *not* say

They cannot vote on `$:` ordering. The official fixtures contain no `$:`
statement whose ordering depends on a reference inside a function body — during
an earlier attempt at this fix they stayed green through **44 corpus
regressions**. A suite that cannot express the shape is not weak evidence about
it; it is no evidence. Read them as "nothing unrelated broke."

## Deliberate deferral

This leaves the text scanner on the client instance-script path, which is the
defect class [the pipeline notes](../blob/main/CLAUDE.md) exist to remove.
That is a considered trade, not an oversight.

The principled fix is to sort on the AST sets upstream itself uses
(`order_reactive_statements` reads `reactive_statement.{assignments,dependencies}`).
That was implemented and measured here, twice:

- Sourcing them from `cycle_collect_assignments_and_deps` — the walk the
  reactive-**cycle** check performs and discards — reordered **44** corpus
  entries away from parity. That walk stops at function bodies: correct for
  cycle detection, wrong for ordering, because upstream's dependency set comes
  from `scope.references` and counts references inside functions.
- Sourcing dependencies from `reactive_statement_dependencies` and assignments
  from a visitor-mirroring walk brought it to **38**. Still a regression, and
  against an empty baseline every one of those is pure loss.

So the rewrite is real work with a real remaining defect, and it belongs with
the AST migration that deletes the scanner outright rather than being rushed in
beside a one-line correctness fix. #2646 gets fixed today at zero blast radius;
the ordering rewrite is tracked for that migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
