### PR TITLE
fix(analyze): reject an invalid bind: target on components too (#2583)

### DIFF
--- a/.changeset/bind-invalid-expression-on-components.md
+++ b/.changeset/bind-invalid-expression-on-components.md
@@ -1,0 +1,5 @@
+---
+'@rsvelte/compiler': patch
+---
+
+Reject `bind:` to an expression that names no binding on a **component**, not only on an element. `<Comp bind:value={o.x = obj} />` compiled and was lowered into a getter/setter around the assignment where the official compiler raises `bind_invalid_expression`. The element path's message is now upstream's text too, so a user comparing diagnostics sees the same string.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -198,9 +198,20 @@ corpus could never have found them — the same lesson as the warning gate, one 
 
 A **generated**, not collected, differential corpus (`pnpm run corpus:matrix`, #2281 Gate 2),
 ratcheted through `compatibility/matrix-known-failures.json` with per-cluster justification in
-the paired `.md`. Two declarative axis families in `matrix/axes.mjs` — binding kind × syntactic
-position, and comment kind × insertion slot — expanded into ~2,000 comparisons that run in
-**~5 s** and need only `submodules/svelte` plus the NAPI binding, so it gates every PR.
+the paired `.md`. Three declarative axis families in `matrix/axes.mjs` — binding kind × syntactic
+position, comment kind × insertion slot, and invalid `bind:` target × directive slot — expanded
+into ~3,000 comparisons that run in **~7 s** and need only `submodules/svelte` plus the NAPI
+binding, so it gates every PR.
+
+The third family is the odd one out and the reason is worth stating: its inputs are programs the
+official compiler **rejects**, which is a population no collected corpus can hold, because
+published code compiles. "rsvelte accepts what official rejects" was otherwise gated only by the
+145 `compiler-errors` fixtures at **one input per code** — and a code with a passing fixture
+reads as covered. #2583 is what that misses: `bind_invalid_expression` had a passing fixture on
+an element while `<Comp bind:value={o.x = obj} />` compiled into a getter/setter around an
+assignment. Adding the family alone would still have measured nothing, because `run.mjs` scored
+any both-reject case as `error-parity` without looking at the codes; **the comparison and the
+population had to land together**.
 
 It exists because the collected corpus samples the **marginal** distribution of published code
 while every bug in the #2253/#2254/#2255/#2256 batch was an **interaction**: #2254's shape occurs

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -213,6 +213,12 @@ assignment. Adding the family alone would still have measured nothing, because `
 any both-reject case as `error-parity` without looking at the codes; **the comparison and the
 population had to land together**.
 
+The family carries **valid** targets against the same slots too, and that half is not
+decoration: the first version had only the invalid rows, and CI then caught an over-rejection
+(a TypeScript assertion, `bind:group={c as T}`) from a corpus file instead of from the gate.
+An over- and an under-rejection are opposite directions of one check, and a population of
+only-invalid inputs is blind to one of them.
+
 It exists because the collected corpus samples the **marginal** distribution of published code
 while every bug in the #2253/#2254/#2255/#2256 batch was an **interaction**: #2254's shape occurs
 **0 times in 14,026 real files**, #2253's likewise, and `client`/`server` were at 0 known failures

--- a/compatibility/gate-coverage.md
+++ b/compatibility/gate-coverage.md
@@ -218,10 +218,10 @@ differ: the prose and span of two unrelated errors say nothing. Those pairs are
 
 ## 5. Generated shape matrix — `scripts/compat-corpus/matrix/`
 
-**Unit.** 1017 generated cases × 3 targets = 3051 comparisons. For the 857 cases both
-compilers accept the unit is `js.code` only (`matrix/run.mjs:134,139,166-167`),
-oxfmt-normalized identically to `verify.mjs`; for the 160 `invalid-bind` cases, which the
-official compiler rejects by construction, it is the error **code** (`:150`).
+**Unit.** 1105 generated cases × 3 targets = 3315 comparisons. Where both compilers accept, the
+unit is `js.code` only (`matrix/run.mjs:134,139,166-167`), oxfmt-normalized identically to
+`verify.mjs`; where both reject it is the error **code** (`:150`), which the `invalid-bind`
+family exists to exercise.
 
 ### Blind spot 5a — generated inputs are always `.svelte` components
 
@@ -270,8 +270,13 @@ either alone measures nothing.
 
 ### Blind spot 5e — accept-where-official-rejects has one input per code elsewhere
 
-Family `invalid-bind` (`axes.mjs:297,326` — 20 invalid target expressions × 8 `bind:` slots) is
-the only *generated* population of programs official rejects. Everywhere else that question is
+Family `invalid-bind` (`axes.mjs` — 20 invalid and 11 valid target expressions × 8 `bind:` slots)
+is the only *generated* population of programs official rejects. Both halves are needed: the
+invalid rows report "rsvelte accepts what official rejects", the valid rows report the reverse,
+and neither can see the other's direction. The valid half exists because the first version of
+this family had only the invalid one, and CI then caught an over-rejection
+(`bind:group={c as T}`, a TypeScript assertion) from a **corpus file** rather than from the
+gate — on the one slot that file happens to use. Everywhere else that question is
 asked by the 145 `compiler-errors` fixtures, at **one input per code**, which makes a code with
 a passing fixture read as covered. It is not: #2583 is `bind_invalid_expression` accepted on a
 component while its fixture passed on an element. Three of the four accept-where-official-rejects

--- a/compatibility/gate-coverage.md
+++ b/compatibility/gate-coverage.md
@@ -45,7 +45,7 @@ samples) — see `AGENTS.md` § "Generated shape matrix" and issue #2281.
 | 2 | Compiler warning codes | multiset of `code` per entry × target | warning **message text** (#2403) | [S] |
 | 3 | Compiler warning positions | multiset of `code@line:col` | warning **end** span | [S] |
 | 4 | Compiler **error** parity | `error.json` `code`, `message`, `start` | error **`end`** and `frame` — never captured | [D] |
-| 5 | Generated shape matrix | per-case × target JS text | `.svelte.(js\|ts)` shapes; CSS; warnings; template positions | [S] |
+| 5 | Generated shape matrix | per-case × target JS text, or error `code` where official rejects | CSS; warnings; error **message** and **position**; template positions | [S] |
 | 6 | svelte2tsx TSX text parity | per-component TSX text, oxfmt-normalized | `exportedNames` / `events`; TSX line+column layout | [S] |
 | 7 | svelte2tsx source map | structural invariants on rsvelte's own map | map **coverage** — a 1-of-1000-line map is valid | [D] |
 | 8 | css-prune sweep | `css.code` + `code@line:col` warnings of 1430 generated components | `js.code`; **an empty population exits 0** | [D] |
@@ -218,8 +218,10 @@ differ: the prose and span of two unrelated errors say nothing. Those pairs are
 
 ## 5. Generated shape matrix — `scripts/compat-corpus/matrix/`
 
-**Unit.** 665 generated cases × 3 targets = 1995 comparisons of `js.code` only
-(`matrix/run.mjs:106,110,164-166`), oxfmt-normalized identically to `verify.mjs`.
+**Unit.** 1017 generated cases × 3 targets = 3051 comparisons. For the 857 cases both
+compilers accept the unit is `js.code` only (`matrix/run.mjs:134,139,166-167`),
+oxfmt-normalized identically to `verify.mjs`; for the 160 `invalid-bind` cases, which the
+official compiler rejects by construction, it is the error **code** (`:150`).
 
 ### Blind spot 5a — generated inputs are always `.svelte` components
 
@@ -251,13 +253,36 @@ attributes, `{@html}`, `{@const}`. **[S]** Comment insertion is likewise restric
 `<script>` bodies (`mutate.mjs:22-34`, `:48`), a deliberate and documented exclusion
 (`mutate.mjs:9-13`) — so HTML comments `<!-- -->` are never mutated.
 
-### Blind spot 5d — both-reject cases discard the error entirely
+### Blind spot 5d — both-reject cases discard the message and the position
 
-`run.mjs:117-120` counts `error-parity` and `continue`s without comparing the messages it
-captured. **[S]** rsvelte can reject a shape with an entirely wrong code at an entirely wrong
-offset and the case is scored as parity.
+`run.mjs:146-162` now compares the two error **codes** and reports `error-code-mismatch` when
+they differ, so "both threw" no longer stands in for "both diagnosed the same thing". What it
+still drops is everything else the error carries: the message prose and `start`. **[S]** rsvelte
+can reject a shape with the right code, the wrong wording and an offset pointing at the wrong
+token, and the case scores as parity. The collected-corpus gate does ratchet both
+(`error-message-known-failures.*`, `error-position-known-failures.*`); this one does not, so a
+shape only the matrix generates is unmeasured on both fields.
 
-**Closing 5b/5c:** the matrix runs in ~5 s on ~2000 comparisons. Adding a third axis family
+Note what closing the code half required: it is worth nothing without inputs that reach it, and
+before family `invalid-bind` (`generate.mjs:73`) the only both-reject cases here were valid
+programs that happened to break. **A comparison and a population have to be added together** —
+either alone measures nothing.
+
+### Blind spot 5e — accept-where-official-rejects has one input per code elsewhere
+
+Family `invalid-bind` (`axes.mjs:297,326` — 20 invalid target expressions × 8 `bind:` slots) is
+the only *generated* population of programs official rejects. Everywhere else that question is
+asked by the 145 `compiler-errors` fixtures, at **one input per code**, which makes a code with
+a passing fixture read as covered. It is not: #2583 is `bind_invalid_expression` accepted on a
+component while its fixture passed on an element. Three of the four accept-where-official-rejects
+divergences known when this row was written sit on codes that have a passing fixture.
+
+What remains **unmeasured**: every other error code. This family crosses one validation
+(`object(node.expression)`) with its slots. The same drift is possible for any check written per
+call site rather than once — `{@render}`, `use:`, `{#each … as}` patterns, `<svelte:element>` —
+and no gate here generates invalid inputs for them.
+
+**Closing 5b/5c:** the matrix runs in ~7 s on ~3000 comparisons. Adding another axis family
 (template-position × comment kind) or reading `.warnings` is cheap relative to every other gate
 here. This is the highest value-per-cost item in this document.
 

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/diagnostics_test.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/diagnostics_test.rs
@@ -20,7 +20,7 @@ use super::errors;
 use super::warnings;
 
 /// Constructors declared inside the `diagnostics!` block in `errors.rs`.
-const ERROR_MACRO_COUNT: usize = 126;
+const ERROR_MACRO_COUNT: usize = 127;
 /// Constructors declared inside the `diagnostics!` block in `warnings.rs`.
 const WARNING_MACRO_COUNT: usize = 77;
 /// Calls below covering `errors.rs`'s hand-written constructor (`bind_invalid_name`),
@@ -34,7 +34,7 @@ const WARNING_HANDWRITTEN_CALLS: usize = 7;
 /// FNV-1a 64 of `"<code>\t<message>\n"` for every entry `dump_all()` produces, in the
 /// fixed order below. Pinned from this PR; if it legitimately changes, update it to the
 /// value printed in the assertion failure after confirming the new wording is correct.
-const DIAGNOSTICS_DIGEST: u64 = 0x16dd_ae65_8049_6f45;
+const DIAGNOSTICS_DIGEST: u64 = 0x0856_867a_8ed7_4cbb;
 
 fn fnv1a64(bytes: &[u8]) -> u64 {
     let mut hash: u64 = 0xcbf2_9ce4_8422_2325;

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/errors.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/errors.rs
@@ -89,6 +89,9 @@ diagnostics! {
     /// `bind:%name%` can only be used with %elements%
     bind_invalid_target(name: &str, elements: &str) => "`bind:{}` can only be used with {}", name, elements;
 
+    /// Can only bind to an Identifier or MemberExpression or a `{get, set}` pair
+    bind_invalid_expression() => "Can only bind to an Identifier or MemberExpression or a `{get, set}` pair\nhttps://svelte.dev/e/bind_invalid_expression";
+
     /// `bind:group` can only bind to an Identifier or MemberExpression
     bind_group_invalid_expression() => "`bind:group` can only bind to an Identifier or MemberExpression";
 

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/bind_directive.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/bind_directive.rs
@@ -784,6 +784,15 @@ fn get_object_node<'a>(
         JsNode::MemberExpression { object, .. } => {
             get_object_node(arena.get_js_node(*object), arena)
         }
+        // Upstream analyses the AST with the TypeScript nodes already removed,
+        // so `x as T` reaches `object()` as the bare `x`.
+        JsNode::TSAsExpression { expression, .. }
+        | JsNode::TSSatisfiesExpression { expression, .. }
+        | JsNode::TSNonNullExpression { expression, .. }
+        | JsNode::TSTypeAssertion { expression, .. }
+        | JsNode::TSInstantiationExpression { expression, .. } => {
+            get_object_node(arena.get_js_node(*expression), arena)
+        }
         _ => None,
     }
 }
@@ -804,6 +813,11 @@ fn get_object_name_from_json(v: &serde_json::Value) -> Option<String> {
             let obj = v.get("object")?;
             get_object_name_from_json(obj)
         }
+        "TSAsExpression"
+        | "TSSatisfiesExpression"
+        | "TSNonNullExpression"
+        | "TSTypeAssertion"
+        | "TSInstantiationExpression" => get_object_name_from_json(v.get("expression")?),
         _ => None,
     }
 }

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/bind_directive.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/bind_directive.rs
@@ -122,12 +122,7 @@ fn visit_common(
             let arena = context.parse_arena;
             let expr_slice = arena.get_js_children(expressions);
             if !expr_slice.is_empty() && expr_slice.len() != 2 {
-                return Err(AnalysisError::validation_at(
-                    "bind_invalid_expression",
-                    "Binding with getter/setter requires exactly two functions",
-                    directive.start,
-                    directive.end,
-                ));
+                return Err(errors::bind_invalid_expression().at(directive.start, directive.end));
             }
         }
 
@@ -163,23 +158,8 @@ fn visit_common(
     }
 
     // Get the leftmost identifier (the binding target)
-    let expr_node = directive.expression.as_node();
-    let binding_name_owned: String;
-    let binding_name: &str = if let Some(left) = get_object_node(&expr_node, context.parse_arena) {
-        left.name().unwrap_or_default()
-    } else {
-        // Fall back to JSON for MemberExpression chains
-        binding_name_owned = get_object_name_via_json(&expr_node).unwrap_or_default();
-        if binding_name_owned.is_empty() {
-            return Err(AnalysisError::validation_at(
-                "bind_invalid_expression",
-                "Invalid binding expression",
-                directive.start,
-                directive.end,
-            ));
-        }
-        &binding_name_owned
-    };
+    let binding_name_owned = bind_target_name(directive, context)?;
+    let binding_name: &str = &binding_name_owned;
 
     // Look up the binding in the scope using proper scope chain traversal
     let binding_idx = context
@@ -424,6 +404,11 @@ pub(super) fn validate_bind_value_for_component(
     directive: &BindDirective,
     context: &VisitorContext,
 ) -> Result<(), AnalysisError> {
+    // Runs before the shape branch below, or a component binding to an
+    // expression that names nothing is lowered into a getter/setter instead of
+    // being rejected.
+    bind_target_name(directive, context)?;
+
     if !directive.expression.is_identifier_node() {
         return Ok(());
     }
@@ -758,6 +743,28 @@ fn is_text_attribute(attr: &crate::ast::template::AttributeNode) -> bool {
     } else {
         false
     }
+}
+
+/// The binding's target name — upstream's `object(node.expression)`, which is
+/// `null` for anything that is not an identifier or a member chain rooted in
+/// one, and raises `bind_invalid_expression` there.
+///
+/// Element and component bindings must share it: upstream runs the check once,
+/// before it branches on the shape, and a copy per branch drifts.
+pub(super) fn bind_target_name(
+    directive: &BindDirective,
+    context: &VisitorContext,
+) -> Result<String, AnalysisError> {
+    let expr_node = directive.expression.as_node();
+    let name = match get_object_node(&expr_node, context.parse_arena) {
+        Some(left) => left.name().unwrap_or_default().to_string(),
+        // Fall back to JSON for MemberExpression chains
+        None => get_object_name_via_json(&expr_node).unwrap_or_default(),
+    };
+    if name.is_empty() {
+        return Err(errors::bind_invalid_expression().at(directive.start, directive.end));
+    }
+    Ok(name)
 }
 
 /// Get the object (leftmost identifier) from a JsNode expression.

--- a/crates/rsvelte_core/tests/bind_invalid_expression_2583.rs
+++ b/crates/rsvelte_core/tests/bind_invalid_expression_2583.rs
@@ -101,3 +101,22 @@ fn valid_bind_targets_still_compile() {
         );
     }
 }
+
+/// Upstream analyses the AST with the TypeScript nodes removed, so a target
+/// wrapped in an assertion reaches its `object()` as the bare expression.
+#[test]
+fn typescript_assertion_bind_targets_still_compile() {
+    const TS: &str = "<script lang=\"ts\">\n\timport Comp from './Comp.svelte';\n\tlet o = $state({ x: 1 });\n\tlet obj = $state({});\n</script>\n";
+    for markup in [
+        "<Comp bind:value={o.x as number} />",
+        "<Comp bind:value={obj as object} />",
+        "<Comp bind:this={o.x as number} />",
+        "<input bind:value={o.x as number} />",
+        "<input bind:value={o.x!} />",
+        "<input bind:value={(o.x satisfies number)} />",
+        "<input bind:value={(o.x as number)!} />",
+    ] {
+        let src = format!("{TS}{markup}");
+        assert!(compile_err(&src).is_none(), "{markup} should compile");
+    }
+}

--- a/crates/rsvelte_core/tests/bind_invalid_expression_2583.rs
+++ b/crates/rsvelte_core/tests/bind_invalid_expression_2583.rs
@@ -1,0 +1,103 @@
+//! `bind:` to something that names no binding must be rejected with
+//! `bind_invalid_expression`, on a **component** as well as on an element
+//! (issue #2583). Upstream runs `object(node.expression)` once, before it
+//! branches on the element/component shape; rsvelte had the check on the
+//! element path only, so `<Comp bind:value={o.x = obj} />` compiled and was
+//! lowered into a getter/setter around an assignment expression.
+
+use rsvelte_core::{CompileOptions, GenerateMode, compile, compiler::CssMode};
+
+fn compile_err(src: &str) -> Option<String> {
+    compile(
+        src,
+        CompileOptions {
+            filename: Some("Test.svelte".to_string()),
+            generate: GenerateMode::Client,
+            dev: false,
+            css: CssMode::External,
+            ..Default::default()
+        },
+    )
+    .err()
+    .map(|e| format!("{e:?}"))
+}
+
+const SCRIPT: &str = "<script>\n\timport Comp from './Comp.svelte';\n\tlet o = $state({});\n\tlet obj = {};\n</script>\n";
+
+fn with_script(markup: &str) -> String {
+    format!("{SCRIPT}{markup}")
+}
+
+#[test]
+fn component_bind_value_to_an_assignment_is_rejected() {
+    let err = compile_err(&with_script("<Comp bind:value={o.x = obj} />"))
+        .expect("component bind:value to an assignment must not compile");
+    assert!(
+        err.contains("bind_invalid_expression"),
+        "expected bind_invalid_expression, got: {err}"
+    );
+}
+
+#[test]
+fn component_bind_this_to_an_assignment_is_rejected() {
+    let err = compile_err(&with_script("<Comp bind:this={o.x = obj} />"))
+        .expect("component bind:this to an assignment must not compile");
+    assert!(
+        err.contains("bind_invalid_expression"),
+        "expected bind_invalid_expression, got: {err}"
+    );
+}
+
+#[test]
+fn element_bind_value_to_an_assignment_is_rejected_with_upstreams_message() {
+    let err = compile_err(&with_script("<input bind:value={o.x = obj} />"))
+        .expect("element bind:value to an assignment must not compile");
+    assert!(
+        err.contains("bind_invalid_expression"),
+        "expected bind_invalid_expression, got: {err}"
+    );
+    assert!(
+        err.contains("Can only bind to an Identifier or MemberExpression or a `{get, set}` pair"),
+        "message must be upstream's, got: {err}"
+    );
+}
+
+#[test]
+fn bind_to_a_call_is_rejected_on_both_paths() {
+    for markup in [
+        "<input bind:value={o.f()} />",
+        "<Comp bind:value={o.f()} />",
+    ] {
+        let err = compile_err(&with_script(markup))
+            .unwrap_or_else(|| panic!("{markup} must not compile"));
+        assert!(
+            err.contains("bind_invalid_expression"),
+            "expected bind_invalid_expression for {markup}, got: {err}"
+        );
+    }
+}
+
+/// The control: the shapes upstream *accepts* must keep compiling, or the fix
+/// rejects too much. The component path never ran this check before, so every
+/// component row here is newly exposed to it — a computed member, a deep chain
+/// and `bind:this` included.
+#[test]
+fn valid_bind_targets_still_compile() {
+    for markup in [
+        "<Comp bind:value={obj} />",
+        "<Comp bind:value={o.x} />",
+        "<Comp bind:value={o.x.y.z} />",
+        "<Comp bind:value={o[obj]} />",
+        "<Comp bind:value={o['k']} />",
+        "<Comp bind:this={o.x} />",
+        "<Comp bind:value={() => o.x, (v) => (o.x = v)} />",
+        "<input bind:value={o.x} />",
+        "<input bind:value={o[obj]} />",
+        "<input bind:group={o.x} />",
+    ] {
+        assert!(
+            compile_err(&with_script(markup)).is_none(),
+            "{markup} should compile"
+        );
+    }
+}

--- a/scripts/compat-corpus/README.md
+++ b/scripts/compat-corpus/README.md
@@ -387,9 +387,12 @@ reported. A 329-case matrix found 21 divergences in seconds.
   position adds 7 cases × 3 targets.
 - `COMMENT_SEEDS` × line boundaries × `COMMENT_KINDS` → family `comment-slot`.
   Insertion is restricted to `<script>` regions, where a JS comment is inert.
-- `INVALID_BIND_TARGETS` × `BIND_SLOTS` → family `invalid-bind` (20 × 8). The
-  odd one out: these cases are programs the official compiler **rejects**, so
-  the question is not "same output" but "same error code".
+- `INVALID_BIND_TARGETS` × `BIND_SLOTS` and `VALID_BIND_TARGETS` × `BIND_SLOTS`
+  → family `invalid-bind` ((20 + 11) × 8). The odd one out: the invalid half is
+  programs the official compiler **rejects**, so the question is not "same
+  output" but "same error code". The valid half carries the counterpart signal
+  — a validation that rejects too much — which the invalid rows structurally
+  cannot report.
 
 `matrix/mutate.mjs` holds the mutation itself and is shared with the
 corpus-seeded fuzz (Gate 3).

--- a/scripts/compat-corpus/README.md
+++ b/scripts/compat-corpus/README.md
@@ -387,9 +387,27 @@ reported. A 329-case matrix found 21 divergences in seconds.
   position adds 7 cases × 3 targets.
 - `COMMENT_SEEDS` × line boundaries × `COMMENT_KINDS` → family `comment-slot`.
   Insertion is restricted to `<script>` regions, where a JS comment is inert.
+- `INVALID_BIND_TARGETS` × `BIND_SLOTS` → family `invalid-bind` (20 × 8). The
+  odd one out: these cases are programs the official compiler **rejects**, so
+  the question is not "same output" but "same error code".
 
 `matrix/mutate.mjs` holds the mutation itself and is shared with the
 corpus-seeded fuzz (Gate 3).
+
+**Why an invalid-input family.** Every other input here is a valid program,
+which is also all the collected corpus can hold — published code compiles. So
+"rsvelte accepts what official rejects" was gated only by the 145
+`compiler-errors` fixtures, at **one input per code**, and a code with a passing
+fixture reads as covered. #2583 is what that misses: `bind_invalid_expression`
+had a passing fixture while `<Comp bind:value={o.x = obj} />` compiled into a
+getter/setter around an assignment, because upstream runs `object(…)` once for
+both slots and rsvelte had the check on the element path only. The element ×
+component axis is what turns one input into a product.
+
+For this family the verdict that matters is the one `error-parity` used to
+swallow: both compilers rejecting says nothing if rsvelte rejected for an
+unrelated reason. `run.mjs` now compares the two error codes and reports
+`error-code-mismatch` when they differ — for every family, not just this one.
 
 **Normalization is identical to `verify.mjs`** (flatten template holes → oxfmt →
 strip blank lines). That is a requirement, not a convenience: a divergence this

--- a/scripts/compat-corpus/compile.mjs
+++ b/scripts/compat-corpus/compile.mjs
@@ -28,6 +28,7 @@ import { fileURLToPath } from 'node:url';
 import { selectTargets } from './targets.mjs';
 import { BYTES_PER_TARGET, DISK_HEADROOM, requireDiskSpace, readGeneration, requireGenerationUnchanged } from './artifacts.mjs';
 import { assertOracleCompiles } from './oracle.mjs';
+import { errorCode } from './error-code.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '../..');
@@ -97,17 +98,8 @@ if (args.includes('--worker')) {
 	// `https://svelte.dev/e/<code>` link, which restates the code.
 	const errorInfo = (e) => {
 		const message = String(e?.message ?? e);
-		// A pre-#2446 rsvelte binding carried a generic `code`
-		// ("GenericFailure") with the real svelte code embedded in a Rust
-		// `Debug` dump; keep extracting it so an older binding still scores
-		// code parity instead of silently reporting `null` everywhere.
-		let code = e?.code ?? null;
-		if (!code || code === 'GenericFailure') {
-			const m = message.match(/svelte\.dev\/e\/([a-z0-9_]+)/) ?? message.match(/code: "([a-z0-9_]+)"/);
-			if (m) code = m[1];
-		}
 		return {
-			code,
+			code: errorCode(e),
 			message: message.split('\n')[0],
 			line: e?.start?.line ?? null,
 			column: e?.start?.column ?? null,

--- a/scripts/compat-corpus/error-code.mjs
+++ b/scripts/compat-corpus/error-code.mjs
@@ -1,0 +1,16 @@
+/**
+ * The svelte error code carried by a thrown compiler error, from either
+ * compiler. Shared so the collected-corpus gate and the matrix gate agree about
+ * what "the same error" means.
+ */
+export function errorCode(e) {
+	const message = String(e?.message ?? e);
+	// A pre-#2446 rsvelte binding carried a generic `code` ("GenericFailure")
+	// with the real svelte code embedded in a Rust `Debug` dump; keep extracting
+	// it so an older binding still scores code parity instead of reporting
+	// `null` everywhere.
+	const code = e?.code ?? null;
+	if (code && code !== 'GenericFailure') return code;
+	const m = message.match(/svelte\.dev\/e\/([a-z0-9_]+)/) ?? message.match(/code: "([a-z0-9_]+)"/);
+	return m ? m[1] : code;
+}

--- a/scripts/compat-corpus/matrix/axes.mjs
+++ b/scripts/compat-corpus/matrix/axes.mjs
@@ -278,6 +278,74 @@ export const COMMENT_SEEDS = {
 };
 
 /**
+ * Axis D — expressions that are not a legal `bind:` target, crossed with axis E,
+ * the directive slot they sit in.
+ *
+ * Every other family here generates VALID programs and asks whether the two
+ * compilers agree on the output. This one generates programs the official
+ * compiler rejects and asks whether rsvelte rejects them with the same code —
+ * a question no collected corpus can pose, because published code compiles.
+ * The `compiler-errors` fixtures do pose it, but at one input per code, and
+ * that is not enough: `<Comp bind:value={o.x = obj} />` compiled into a
+ * getter/setter around an assignment while `bind_invalid_expression` had a
+ * passing fixture, because upstream runs `object(node.expression)` once for
+ * both slots and rsvelte had the check on the element path only.
+ *
+ * The element and component slots are the axis that finds that: a validation
+ * written per slot drifts, and only the product notices.
+ */
+export const INVALID_BIND_TARGETS = {
+	assignment: 'o.x = obj',
+	'compound-assignment': 'o.x += 1',
+	call: 'o.f()',
+	'call-plain': 'fn()',
+	binary: 'o.x + 1',
+	conditional: 'flag ? o.x : o.y',
+	literal: "'lit'",
+	number: '1',
+	array: '[o.x]',
+	unary: '!o.x',
+	template: '`t${o.x}`',
+	'new-expression': 'new Thing()',
+	'await-like': 'o.x ?? o.y',
+	'logical-or': 'o.x || o.y',
+	'paren-assignment': '(o.x = obj)',
+	'optional-member': 'o?.x',
+	'optional-call': 'o.f?.()',
+	update: 'o.x++',
+	'arrow-only': '() => o.x',
+	'object-literal': '{ a: o.x }',
+};
+
+/**
+ * Axis E — the `bind:` slot. `%s` is the target expression.
+ *
+ * `bind:this` is here because it takes a different code path from a value
+ * binding on both compilers, and on components a third one again.
+ */
+export const BIND_SLOTS = {
+	'element-value': '<input bind:value={%s} />',
+	'element-group': '<input type="checkbox" bind:group={%s} />',
+	'element-this': '<div bind:this={%s}></div>',
+	'element-clientwidth': '<div bind:clientWidth={%s}></div>',
+	'component-value': '<Comp bind:value={%s} />',
+	'component-this': '<Comp bind:this={%s} />',
+	'component-named': '<Comp bind:whatever={%s} />',
+	'window-scrolly': '<svelte:window bind:scrollY={%s} />',
+};
+
+/** The declarations every invalid-bind case shares, so only the axes differ. */
+export const BIND_PREAMBLE = `<script>
+	import Comp from './Comp.svelte';
+	let o = $state({ x: 1, y: 2 });
+	let obj = $state({});
+	let flag = $state(true);
+	function fn() {}
+	class Thing {}
+</script>
+`;
+
+/**
  * Seeds for the comment axis on the `.svelte.(js|ts)` MODULE path — the whole-file
  * insertion `mutate.mjs` documents but that nothing fed until now.
  *

--- a/scripts/compat-corpus/matrix/axes.mjs
+++ b/scripts/compat-corpus/matrix/axes.mjs
@@ -334,12 +334,52 @@ export const BIND_SLOTS = {
 	'window-scrolly': '<svelte:window bind:scrollY={%s} />',
 };
 
-/** The declarations every invalid-bind case shares, so only the axes differ. */
+/**
+ * Axis D2 — expressions that ARE a legal `bind:` target, crossed with the same
+ * slots. The counterpart signal: a validation that rejects too much shows up as
+ * "rsvelte rejects, official accepts", which the invalid rows can never report.
+ *
+ * The TypeScript rows are the discriminating ones. Upstream analyses the AST
+ * with the TS nodes already removed, so `o.x as number` reaches its `object()`
+ * as the bare member chain; a port that walks the parsed AST sees a
+ * `TSAsExpression` and calls the target invalid. `<Radio bind:group={c as T} />`
+ * is real shipped code (flowbite-svelte), which is how that over-rejection got
+ * caught — by a corpus file, not by this gate, and only for the component slot
+ * that file happens to use.
+ */
+export const VALID_BIND_TARGETS = {
+	identifier: { expr: 'obj' },
+	member: { expr: 'o.x' },
+	'deep-member': { expr: 'o.x.y' },
+	'computed-member': { expr: 'o[key]' },
+	'string-computed': { expr: "o['k']" },
+	'getter-setter-pair': { expr: '() => o.x, (v) => (o.x = v)' },
+	'ts-as': { expr: 'o.x as number', ts: true },
+	'ts-as-identifier': { expr: 'obj as object', ts: true },
+	'ts-non-null': { expr: 'o.x!', ts: true },
+	'ts-satisfies': { expr: '(o.x satisfies number)', ts: true },
+	'ts-as-then-non-null': { expr: '(o.x as number)!', ts: true },
+};
+
+/** The declarations every bind case shares, so only the axes differ. */
 export const BIND_PREAMBLE = `<script>
 	import Comp from './Comp.svelte';
 	let o = $state({ x: 1, y: 2 });
 	let obj = $state({});
 	let flag = $state(true);
+	let key = $state('x');
+	function fn() {}
+	class Thing {}
+</script>
+`;
+
+/** Same declarations under `lang="ts"`, for the rows that carry TS syntax. */
+export const BIND_PREAMBLE_TS = `<script lang="ts">
+	import Comp from './Comp.svelte';
+	let o = $state({ x: 1, y: 2 });
+	let obj = $state({});
+	let flag = $state(true);
+	let key = $state('x');
 	function fn() {}
 	class Thing {}
 </script>

--- a/scripts/compat-corpus/matrix/generate.mjs
+++ b/scripts/compat-corpus/matrix/generate.mjs
@@ -5,7 +5,16 @@
  * key), so adding a row to one axis never renumbers the others.
  */
 
-import { BINDINGS, POSITIONS, COMMENT_KINDS, COMMENT_SEEDS, COMMENT_MODULE_SEEDS } from './axes.mjs';
+import {
+	BINDINGS,
+	POSITIONS,
+	COMMENT_KINDS,
+	COMMENT_SEEDS,
+	COMMENT_MODULE_SEEDS,
+	INVALID_BIND_TARGETS,
+	BIND_SLOTS,
+	BIND_PREAMBLE,
+} from './axes.mjs';
 import { commentMutants } from './mutate.mjs';
 
 function bindingPositionCases() {
@@ -45,9 +54,23 @@ function commentSlotCases() {
 	return cases;
 }
 
+function invalidBindCases() {
+	const cases = [];
+	for (const [targetName, expression] of Object.entries(INVALID_BIND_TARGETS)) {
+		for (const [slotName, markup] of Object.entries(BIND_SLOTS)) {
+			cases.push({
+				id: `invalid-bind/${targetName}__${slotName}.svelte`,
+				source: BIND_PREAMBLE + markup.replaceAll('%s', expression) + '\n',
+			});
+		}
+	}
+	return cases;
+}
+
 export const FAMILIES = {
 	'binding-position': bindingPositionCases,
 	'comment-slot': commentSlotCases,
+	'invalid-bind': invalidBindCases,
 };
 
 export function generate(families = Object.keys(FAMILIES)) {

--- a/scripts/compat-corpus/matrix/generate.mjs
+++ b/scripts/compat-corpus/matrix/generate.mjs
@@ -12,8 +12,10 @@ import {
 	COMMENT_SEEDS,
 	COMMENT_MODULE_SEEDS,
 	INVALID_BIND_TARGETS,
+	VALID_BIND_TARGETS,
 	BIND_SLOTS,
 	BIND_PREAMBLE,
+	BIND_PREAMBLE_TS,
 } from './axes.mjs';
 import { commentMutants } from './mutate.mjs';
 
@@ -61,6 +63,17 @@ function invalidBindCases() {
 			cases.push({
 				id: `invalid-bind/${targetName}__${slotName}.svelte`,
 				source: BIND_PREAMBLE + markup.replaceAll('%s', expression) + '\n',
+			});
+		}
+	}
+	for (const [targetName, target] of Object.entries(VALID_BIND_TARGETS)) {
+		for (const [slotName, markup] of Object.entries(BIND_SLOTS)) {
+			cases.push({
+				id: `invalid-bind/valid-${targetName}__${slotName}.svelte`,
+				source:
+					(target.ts ? BIND_PREAMBLE_TS : BIND_PREAMBLE) +
+					markup.replaceAll('%s', target.expr) +
+					'\n',
 			});
 		}
 	}

--- a/scripts/compat-corpus/matrix/run.mjs
+++ b/scripts/compat-corpus/matrix/run.mjs
@@ -37,6 +37,7 @@ import { flattenTemplateHoles, stripBlankLines, firstDiffLine, oxfmtTree } from 
 import { selectTargets, TARGET_KEYS } from '../targets.mjs';
 import { refuseUnrepresentativeBaseline } from '../baseline-guard.mjs';
 import { unattributedBindingReason } from '../binding.mjs';
+import { errorCode } from '../error-code.mjs';
 import { generate, FAMILIES } from './generate.mjs';
 
 const require = createRequire(import.meta.url);
@@ -95,9 +96,9 @@ const rsvelte = require(BINDING);
 
 // ---- generate + compile ----------------------------------------------------
 
-// The axes generate 665 cases on an unmodified tree; the floor only has to
+// The axes generate 1017 cases on an unmodified tree; the floor only has to
 // separate "generation broke" from "the gate got easier".
-const MIN_MATRIX_CASES = 400;
+const MIN_MATRIX_CASES = 700;
 
 const cases = generate(FAMILY_KEYS);
 console.log(`[matrix] families: ${FAMILY_KEYS.join(', ')}`);
@@ -105,7 +106,7 @@ console.log(`[matrix] cases: ${cases.length}  targets: ${TARGETS.map((t) => t.ke
 
 fs.rmSync(TREE, { recursive: true, force: true });
 
-const counts = { match: 0, 'error-parity': 0, 'js-mismatch': 0, 'error-mismatch': 0 };
+const counts = { match: 0, 'error-parity': 0, 'js-mismatch': 0, 'error-mismatch': 0, 'error-code-mismatch': 0 };
 /** Pending byte comparisons, resolved after the trees are normalized. */
 const pending = [];
 const failures = [];
@@ -132,17 +133,30 @@ for (const testCase of cases) {
 		try {
 			expected = compileWith(svelte).js.code;
 		} catch (e) {
-			expectedError = firstLine(e.message);
+			expectedError = { message: firstLine(e.message), code: errorCode(e) };
 		}
 		try {
 			actual = compileWith(rsvelte).js.code;
 		} catch (e) {
-			actualError = firstLine(e.message);
+			actualError = { message: firstLine(e.message), code: errorCode(e) };
 		}
 
 		// Both compilers rejecting is the generated shape being invalid, not a
 		// finding — but ONE rejecting is the sharpest signal this gate produces.
 		if (expectedError && actualError) {
+			// …and rejecting for a DIFFERENT reason is the second sharpest:
+			// "both threw" cannot separate a ported diagnostic from a lucky
+			// parse error, which is what an invalid-input family needs it to do.
+			if (expectedError.code !== actualError.code) {
+				counts['error-code-mismatch'] += 1;
+				failures.push({
+					id: testCase.id,
+					target: target.key,
+					verdict: 'error-code-mismatch',
+					detail: `official ${expectedError.code ?? '(none)'}, rsvelte ${actualError.code ?? '(none)'}: ${actualError.message}`,
+				});
+				continue;
+			}
 			counts['error-parity'] += 1;
 			continue;
 		}
@@ -153,8 +167,8 @@ for (const testCase of cases) {
 				target: target.key,
 				verdict: 'error-mismatch',
 				detail: expectedError
-					? `rsvelte accepts, official rejects: ${expectedError}`
-					: `rsvelte rejects, official accepts: ${actualError}`,
+					? `rsvelte accepts, official rejects: ${expectedError.message}`
+					: `rsvelte rejects, official accepts: ${actualError.message}`,
 			});
 			continue;
 		}
@@ -213,7 +227,7 @@ if (UPDATE_BASELINE) {
 	// ratchet. This one is absolute.
 	if (cases.length < MIN_MATRIX_CASES) {
 		console.error(`\n[matrix] refusing to baseline from ${cases.length} generated cases (expected >= ${MIN_MATRIX_CASES}).`);
-		console.error('  the axes generate ~665; far below that means generation broke, not that the gate got easier.');
+		console.error('  the axes generate ~1017; far below that means generation broke, not that the gate got easier.');
 		process.exit(2);
 	}
 	fs.writeFileSync(BASELINE, JSON.stringify([...ids].sort(), null, '\t') + '\n');

--- a/scripts/compat-corpus/matrix/run.mjs
+++ b/scripts/compat-corpus/matrix/run.mjs
@@ -96,7 +96,7 @@ const rsvelte = require(BINDING);
 
 // ---- generate + compile ----------------------------------------------------
 
-// The axes generate 1017 cases on an unmodified tree; the floor only has to
+// The axes generate 1105 cases on an unmodified tree; the floor only has to
 // separate "generation broke" from "the gate got easier".
 const MIN_MATRIX_CASES = 700;
 
@@ -227,7 +227,7 @@ if (UPDATE_BASELINE) {
 	// ratchet. This one is absolute.
 	if (cases.length < MIN_MATRIX_CASES) {
 		console.error(`\n[matrix] refusing to baseline from ${cases.length} generated cases (expected >= ${MIN_MATRIX_CASES}).`);
-		console.error('  the axes generate ~1017; far below that means generation broke, not that the gate got easier.');
+		console.error('  the axes generate ~1105; far below that means generation broke, not that the gate got easier.');
 		process.exit(2);
 	}
 	fs.writeFileSync(BASELINE, JSON.stringify([...ids].sort(), null, '\t') + '\n');


### PR DESCRIPTION
Closes #2583.

## The defect

`<Comp bind:value={o.x = obj} />` compiled. Official rejects it with
`bind_invalid_expression`; rsvelte lowered it into a getter/setter pair wrapped
around the assignment expression.

Upstream runs `object(node.expression)` **once**, before it branches on whether
the binding is on an element or a component, and raises `bind_invalid_expression`
when the expression is not an identifier or a member chain rooted in one. rsvelte
had that check on the element path only: `validate_bind_value_for_component`
early-returned `Ok(())` for every non-identifier expression, so anything that was
not an identifier skipped validation entirely on its way to the getter/setter
lowering.

Two smaller things fell out of the same place:

- `bind:this` on a component took the same unvalidated path.
- The element path raised rsvelte's own wording ("Invalid binding expression")
  rather than upstream's `Can only bind to an Identifier or MemberExpression or
  a \`{get, set}\` pair`.

## The fix

`bind_target_name()` — the port of upstream's `object()` + its diagnostic — is
now a shared helper that **both** paths call. A check that lives at one of two
call sites is what let this drift; there is now one call site's worth of logic
and two callers. The diagnostic moved into `2_analyze/errors.rs` with upstream's
exact message and URL.

## Why this could be reported at all, and what stops the next one

Every gate in this repo compares programs both compilers accept. That is also
all the collected corpus can hold — published code compiles — so
"rsvelte accepts what official rejects" was gated only by the 145
`compiler-errors` fixtures, at **one input per code**. `bind_invalid_expression`
has a passing fixture. It is on an element. The component slot was never asked.

So this PR adds the population that asks it, plus the comparison that can see
the answer:

**1. New matrix family `invalid-bind`** (`matrix/axes.mjs`) — 20 invalid target
expressions × 8 `bind:` slots (element value/group/this/clientWidth, component
value/this/named, `<svelte:window>`) = 160 generated cases × 3 targets. These are
programs official rejects by construction; a collected corpus cannot contain
them.

**2. `error-code-mismatch` in `matrix/run.mjs`** — the family alone would have
measured nothing. `run.mjs` scored any both-reject case as `error-parity` and
`continue`d without looking at the errors, so rsvelte rejecting for an unrelated
reason (or with a wrong code) read as agreement. It now compares the two error
codes. This applies to every family, not just the new one.

The comparison and the population had to land together — either alone is inert.

**Positive control.** The same 480 comparisons, run against a binary built with
the two Rust files reverted to `origin/main` and nothing else changed:

| | `error-parity` | `error-mismatch` |
|---|---|---|
| `origin/main` binary | 300 | **180** |
| this branch | 480 | 0 |

The 180 that move are exactly 20 invalid targets × **3 component slots** × 3
targets. Every element slot and `<svelte:window>` was already rejected before
this PR — which is the shape of the defect, stated as a measurement rather than
as a reading of the code.

## Also updated

- `compatibility/gate-coverage.md` — blind spot 5d rewritten (codes are now
  compared; **message and position still are not**, and that is stated as the
  remaining gap), new blind spot 5e naming what `invalid-bind` does *not* reach:
  every error code other than this one. The same per-call-site drift is possible
  for `{@render}`, `use:`, `{#each … as}` patterns and `<svelte:element>`, and no
  gate generates invalid inputs for them.
- `MIN_MATRIX_CASES` raised 400 → 700 (1017 cases are generated now).
- `errorCode()` extracted to `scripts/compat-corpus/error-code.mjs` so the
  collected-corpus gate and the matrix gate agree on what "the same error" is.
