### PR TITLE
fix(compiler): reject await/yield in a function's formal parameters (#2547)

### DIFF
--- a/.changeset/await-yield-in-parameter-defaults.md
+++ b/.changeset/await-yield-in-parameter-defaults.md
@@ -1,0 +1,5 @@
+---
+'@rsvelte/compiler': patch
+---
+
+Reject `await` and `yield` inside a function's formal parameters, which the official compiler raises as `js_parse_error` ("Await expression cannot be a default value") and rsvelte compiled. `export const f = async (p = await load()) => p;` built successfully here while `svelte.compileModule` refuses it, so a file the official compiler will not accept shipped instead of failing loudly. Acorn enforces this and OXC does not, so the check is now applied at every place rsvelte hands source to OXC — the instance and module scripts, `compileModule`, snippet parameters, and template expressions, which parse through a different function and stayed accepting after the script paths were fixed.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -198,13 +198,14 @@ corpus could never have found them — the same lesson as the warning gate, one 
 
 A **generated**, not collected, differential corpus (`pnpm run corpus:matrix`, #2281 Gate 2),
 ratcheted through `compatibility/matrix-known-failures.json` with per-cluster justification in
-the paired `.md`. Four declarative axis families in `matrix/axes.mjs` — binding kind × syntactic
-position, comment kind × insertion slot, invalid `bind:` target × directive slot, and
-string-literal escape × template expression slot — expanded into ~4,000 comparisons that run in
-**~7 s** and need only `submodules/svelte` plus the NAPI binding, so it gates every PR.
+the paired `.md`. Five declarative axis families in `matrix/axes.mjs` — binding kind × syntactic
+position, comment kind × insertion slot, invalid `bind:` target × directive slot,
+string-literal escape × template expression slot, and `await`/`yield` in a formal parameter list
+× function form × entry point — expanded into ~5,250 comparisons that run in **~10 s** and need
+only `submodules/svelte` plus the NAPI binding, so it gates every PR.
 
-The `bind:` family is the odd one out and the reason is worth stating: its inputs are programs the
-official compiler **rejects**, which is a population no collected corpus can hold, because
+The `bind:` and `param-default` families are the odd ones out and the reason is worth stating:
+their inputs are programs the official compiler **rejects**, which is a population no collected corpus can hold, because
 published code compiles. "rsvelte accepts what official rejects" was otherwise gated only by the
 145 `compiler-errors` fixtures at **one input per code** — and a code with a passing fixture
 reads as covered. #2583 is what that misses: `bind_invalid_expression` had a passing fixture on
@@ -213,11 +214,18 @@ assignment. Adding the family alone would still have measured nothing, because `
 any both-reject case as `error-parity` without looking at the codes; **the comparison and the
 population had to land together**.
 
-The family carries **valid** targets against the same slots too, and that half is not
-decoration: the first version had only the invalid rows, and CI then caught an over-rejection
-(a TypeScript assertion, `bind:group={c as T}`) from a corpus file instead of from the gate.
-An over- and an under-rejection are opposite directions of one check, and a population of
-only-invalid inputs is blind to one of them.
+Both families carry **valid** inputs against the same slots too, and that half is not
+decoration: the `bind:` family's first version had only the invalid rows, and CI then caught an
+over-rejection (a TypeScript assertion, `bind:group={c as T}`) from a corpus file instead of from
+the gate. An over- and an under-rejection are opposite directions of one check, and a population
+of only-invalid inputs is blind to one of them. The `param-default` family's legal rows are the
+same shape one level harder: `async (p = { async m() { return await 1; } }) => p` **is** legal,
+so a check that scans the parameter subtree for the keyword rejects real code.
+
+`param-default` also crosses the **entry point**, which the other four do not: the instance
+script, `compileModule`, and a template expression are three different parse functions in
+rsvelte, and #2547's fix was incomplete in exactly that way — the script paths rejected it while
+`{(async (p = await x) => p)}` still compiled.
 
 The string-literal family is the first to inject into **markup** rather than into a JS statement
 inside `<script>`, which gate-coverage 5c names as this gate's largest blind spot. Its axis is

--- a/compatibility/gate-coverage.md
+++ b/compatibility/gate-coverage.md
@@ -218,22 +218,21 @@ differ: the prose and span of two unrelated errors say nothing. Those pairs are
 
 ## 5. Generated shape matrix — `scripts/compat-corpus/matrix/`
 
-**Unit.** 1329 generated cases × 3 targets = 3987 comparisons. Where both compilers accept, the
+**Unit.** 1749 generated cases × 3 targets = 5247 comparisons. Where both compilers accept, the
 unit is `js.code` only (`matrix/run.mjs:134,139,166-167`), oxfmt-normalized identically to
-`verify.mjs`; where both reject it is the error **code** (`:150`), which the `invalid-bind`
-family exists to exercise.
+`verify.mjs`; where both reject it is the error **code** (`:150`), which the `invalid-bind` and
+`param-default` families exist to exercise.
 
-### Blind spot 5a — generated inputs are always `.svelte` components
+### Blind spot 5a — CLOSED: the module entry point is generated now
 
-`matrix/generate.mjs:16` and `:29` hardcode the `.svelte` suffix into every case id, and
-`run.mjs:99` passes `filename: path.basename(testCase.id)`. **[S]** `mutate.mjs:22-23` contains
-a `moduleSource` branch for exactly this purpose; `generate.mjs:27` calls `commentMutants`
-without options, so the branch is dead. `.svelte.js` / `.svelte.ts` module shapes are never
-generated.
+Originally: every case id hardcoded `.svelte`, so `compileModule` was never reached. Two
+families now emit module cases — `comment-slot` through `COMMENT_MODULE_SEEDS`
+(`generate.mjs:47-55`, `kind: 'module'`) and `param-default` through a `.svelte.js` twin of
+every function form (`generate.mjs:112-116`) — and `run.mjs:124` dispatches on `kind`.
+The entry point matters on its own: it is a different parse call in rsvelte, not a flag.
 
-**Tracked:** #2425. This is now load-bearing: PR #2436 establishes that the matrix is the
-*only* place a comment divergence can be observed at all, which raises #2425 from a coverage
-gap to the sole remaining path for module comment defects (cf. #2399).
+**Tracked:** #2425, closed. It was load-bearing while open: PR #2436 established that the matrix
+is the *only* place a module comment divergence can be observed at all (cf. #2399).
 
 ### Blind spot 5b — CSS and warnings
 
@@ -257,6 +256,12 @@ It crosses those slots with **one** axis: how a string literal spells itself. St
 `use:` / `transition:` / `animate:` / `in:` / `out:`, which no slot here reaches. **[S]** Comment
 insertion is likewise restricted to `<script>` bodies (`mutate.mjs:22-34`, `:48`), a deliberate
 and documented exclusion (`mutate.mjs:9-13`) — so HTML comments `<!-- -->` are never mutated.
+
+`param-default` adds two markup slots of its own (`PARAM_TEMPLATE_FORMS`: an event-handler
+attribute and an `{expr}` interpolation) for a different reason — rsvelte parses a template
+expression with a *different function* than a script body, so the two are separate code paths
+and not merely separate positions. #2547's first fix was green on every script path while
+`{(async (p = await x) => p)}` still compiled.
 
 What the escape axis is for is worth stating, because the class is easy to dismiss as cosmetic:
 these divergences produce output that **parses and computes the right value** and differs only
@@ -282,8 +287,10 @@ either alone measures nothing.
 
 ### Blind spot 5e — accept-where-official-rejects has one input per code elsewhere
 
-Family `invalid-bind` (`axes.mjs` — 20 invalid and 11 valid target expressions × 8 `bind:` slots)
-is the only *generated* population of programs official rejects. Both halves are needed: the
+Families `invalid-bind` (`axes.mjs` — 20 invalid and 11 valid target expressions × 8 `bind:`
+slots) and `param-default` (2 illegal and 5 legal parameter initializers × 5 positions in the
+list × 9 function forms + 3 template forms × 2 entry points) are the *generated* population of
+programs official rejects. Both halves are needed: the
 invalid rows report "rsvelte accepts what official rejects", the valid rows report the reverse,
 and neither can see the other's direction. The valid half exists because the first version of
 this family had only the invalid one, and CI then caught an over-rejection
@@ -294,12 +301,21 @@ a passing fixture read as covered. It is not: #2583 is `bind_invalid_expression`
 component while its fixture passed on an element. Three of the four accept-where-official-rejects
 divergences known when this row was written sit on codes that have a passing fixture.
 
-What remains **unmeasured**: every other error code. This family crosses one validation
-(`object(node.expression)`) with its slots. The same drift is possible for any check written per
-call site rather than once — `{@render}`, `use:`, `{#each … as}` patterns, `<svelte:element>` —
-and no gate here generates invalid inputs for them.
+`param-default` is the same row for a *parser* rule rather than a validator, and it says
+something the `bind:` family cannot: acorn enforces `checkYieldAwaitInDefaultParams` and OXC
+implements no equivalent, so the divergence was not a missing port but a rule rsvelte never had.
+Its legal rows are harder than `invalid-bind`'s, because the illegal and legal inputs differ only
+in *whose* parameter list the keyword sits in —
+`async (p = { async m() { return await 1; } }) => p` is legal, and a check that scans the
+parameter subtree rejects it.
 
-**Closing 5b/5c:** the matrix runs in ~7 s on ~4000 comparisons. Widening the markup axis (a
+What remains **unmeasured**: every other error code, and every other acorn rule OXC does not
+implement. These two families cross one validation and one parser rule with their slots. The
+same drift is possible for any check written per call site rather than once — `{@render}`,
+`use:`, `{#each … as}` patterns, `<svelte:element>` — and no gate here generates invalid inputs
+for them.
+
+**Closing 5b/5c:** the matrix runs in ~10 s on ~5,250 comparisons. Widening the markup axis (a
 second expression axis against `EXPRESSION_SLOTS`) or reading `.warnings` is cheap relative to
 every other gate here. This is the highest value-per-cost item in this document.
 

--- a/crates/rsvelte_core/src/compiler/phases/1_parse/read/expression.rs
+++ b/crates/rsvelte_core/src/compiler/phases/1_parse/read/expression.rs
@@ -1638,6 +1638,11 @@ pub fn check_js_parse_error_with_pos(content: &str) -> Option<(String, usize)> {
             {
                 return Some(("Assigning to rvalue".to_string(), 0));
             }
+            if let Some((at, message)) = await_or_yield_in_params(&result.program, content) {
+                // Acorn reports the `await` / `yield` token's start; strip the `(`.
+                let pos = (at as usize).saturating_sub(1).min(content.len());
+                return Some((message.to_string(), pos));
+            }
             None
         })
     };
@@ -1679,7 +1684,7 @@ pub fn check_params_parse_error(params: &str, ts: bool) -> Option<(String, usize
             SourceType::mjs()
         };
         let result = OxcParser::new(allocator, &wrapped, source_type).parse();
-        result.diagnostics.first().map(|first_error| {
+        if let Some(first_error) = result.diagnostics.first() {
             let pos = first_error
                 .labels
                 .first()
@@ -1689,7 +1694,13 @@ pub fn check_params_parse_error(params: &str, ts: bool) -> Option<(String, usize
                         .min(params.len())
                 })
                 .unwrap_or(0);
-            (first_error.message.to_string(), pos)
+            return Some((first_error.message.to_string(), pos));
+        }
+        await_or_yield_in_params(&result.program, params).map(|(at, message)| {
+            (
+                message.to_string(),
+                (at as usize).saturating_sub(1).min(params.len()),
+            )
         })
     })
 }
@@ -1709,14 +1720,16 @@ pub fn check_js_statement_parse_error(content: &str, ts: bool) -> Option<(String
             SourceType::mjs()
         };
         let result = OxcParser::new(allocator, content, source_type).parse();
-        result.diagnostics.first().map(|first_error| {
+        if let Some(first_error) = result.diagnostics.first() {
             let pos = first_error
                 .labels
                 .first()
                 .map(|label| (label.offset() as usize).min(content.len()))
                 .unwrap_or(0);
-            (first_error.message.to_string(), pos)
-        })
+            return Some((first_error.message.to_string(), pos));
+        }
+        await_or_yield_in_params(&result.program, content)
+            .map(|(at, message)| (message.to_string(), (at as usize).min(content.len())))
     })
 }
 
@@ -1841,6 +1854,13 @@ fn parse_expression_with_typescript<'a>(
             // OXC may parse these without errors, but acorn/the Svelte compiler
             // treats them as parse errors ("Assigning to rvalue").
             if is_invalid_assignment_expression(&expr_stmt.expression) {
+                return None;
+            }
+
+            // Same shape: acorn rejects `await` / `yield` in a parameter list
+            // and OXC does not. Failing here routes the caller to
+            // `check_js_parse_error_with_pos`, which reports acorn's message.
+            if await_or_yield_in_params(&result.program, content).is_some() {
                 return None;
             }
 
@@ -6718,6 +6738,102 @@ fn is_acorn_unchecked_ts_grammar_rule(diagnostic: &OxcDiagnostic) -> bool {
             .is_some_and(|n| ACORN_UNCHECKED_TS_GRAMMAR_RULES.contains(&n))
 }
 
+/// `await` / `yield` inside a function's formal parameters — acorn's
+/// `checkYieldAwaitInDefaultParams`, which OXC does not implement, so every
+/// acorn boundary in this file has to ask for it.
+///
+/// A nested function *body* inside a parameter list is its own scope and is
+/// legal; a nested function's *parameters* are not, which is why the flag is
+/// carried into params and cleared only on a body.
+struct AwaitYieldInParams {
+    in_params: bool,
+    found: Option<(u32, &'static str)>,
+}
+
+impl AwaitYieldInParams {
+    fn record(&mut self, at: u32, message: &'static str) {
+        if self.found.is_none_or(|(prev, _)| at < prev) {
+            self.found = Some((at, message));
+        }
+    }
+
+    fn walk_params_then_body(
+        &mut self,
+        params: impl FnOnce(&mut Self),
+        body: impl FnOnce(&mut Self),
+    ) {
+        let outer = self.in_params;
+        self.in_params = true;
+        params(self);
+        self.in_params = false;
+        body(self);
+        self.in_params = outer;
+    }
+}
+
+impl<'a> oxc_ast_visit::Visit<'a> for AwaitYieldInParams {
+    fn visit_function(
+        &mut self,
+        func: &oxc_ast::ast::Function<'a>,
+        _flags: oxc_syntax::scope::ScopeFlags,
+    ) {
+        self.walk_params_then_body(
+            |v| oxc_ast_visit::walk::walk_formal_parameters(v, &func.params),
+            |v| {
+                if let Some(body) = &func.body {
+                    oxc_ast_visit::walk::walk_function_body(v, body);
+                }
+            },
+        );
+    }
+
+    fn visit_arrow_function_expression(
+        &mut self,
+        func: &oxc_ast::ast::ArrowFunctionExpression<'a>,
+    ) {
+        self.walk_params_then_body(
+            |v| oxc_ast_visit::walk::walk_formal_parameters(v, &func.params),
+            |v| oxc_ast_visit::walk::walk_arrow_function_body(v, &func.body),
+        );
+    }
+
+    fn visit_await_expression(&mut self, expr: &oxc_ast::ast::AwaitExpression<'a>) {
+        if self.in_params {
+            self.record(
+                expr.span.start,
+                "Await expression cannot be a default value",
+            );
+        }
+        oxc_ast_visit::walk::walk_await_expression(self, expr);
+    }
+
+    fn visit_yield_expression(&mut self, expr: &oxc_ast::ast::YieldExpression<'a>) {
+        if self.in_params {
+            self.record(
+                expr.span.start,
+                "Yield expression cannot be a default value",
+            );
+        }
+        oxc_ast_visit::walk::walk_yield_expression(self, expr);
+    }
+}
+
+/// The offset and acorn message for the first `await` / `yield` in a parameter
+/// list, or `None`. `source` gates the walk — neither keyword can occur without
+/// its own spelling.
+fn await_or_yield_in_params(program: &OxcProgram<'_>, source: &str) -> Option<(u32, &'static str)> {
+    if !source.contains("await") && !source.contains("yield") {
+        return None;
+    }
+    use oxc_ast_visit::Visit;
+    let mut scan = AwaitYieldInParams {
+        in_params: false,
+        found: None,
+    };
+    scan.visit_program(program);
+    scan.found
+}
+
 fn convert_parsed_program<'ast>(
     arena: &ParseArena,
     program: &OxcProgram<'_>,
@@ -6791,13 +6907,15 @@ fn convert_parsed_program<'ast>(
 
             let check_decorator = !is_typescript && content.contains('@');
             let check_with = content.contains("with");
-            if check_decorator || check_with {
+            {
                 let mut finder = StrictModeScan {
                     check_decorator,
                     decorator_at: None,
                     with_at: None,
                 };
-                finder.visit_program(program);
+                if check_decorator || check_with {
+                    finder.visit_program(program);
+                }
 
                 let earliest = [
                     finder
@@ -6810,6 +6928,8 @@ fn convert_parsed_program<'ast>(
                                 .to_string(),
                         )
                     }),
+                    await_or_yield_in_params(program, content)
+                        .map(|(at, message)| (at, message.to_string())),
                 ]
                 .into_iter()
                 .flatten()

--- a/crates/rsvelte_core/tests/await_yield_in_params_2547.rs
+++ b/crates/rsvelte_core/tests/await_yield_in_params_2547.rs
@@ -1,0 +1,181 @@
+//! `await` / `yield` in a function's formal parameters is a `js_parse_error`
+//! upstream (acorn's `checkYieldAwaitInDefaultParams`); OXC has no such rule,
+//! so rsvelte compiled every shape below and shipped a file the official
+//! compiler refuses (issue #2547).
+//!
+//! The legal cases are the other half: the same keyword, lexically inside the
+//! parameter list, belonging to a function of its own.
+
+use rsvelte_core::{
+    CompileOptions, GenerateMode, ModuleCompileOptions, compile, compile_module, compiler::CssMode,
+};
+
+fn component_error(src: &str) -> Option<String> {
+    compile(
+        src,
+        CompileOptions {
+            filename: Some("Test.svelte".to_string()),
+            generate: GenerateMode::Client,
+            dev: false,
+            css: CssMode::External,
+            ..Default::default()
+        },
+    )
+    .err()
+    .map(|e| format!("{e:?}"))
+}
+
+fn module_error(src: &str) -> Option<String> {
+    compile_module(
+        src,
+        ModuleCompileOptions {
+            filename: Some("m.svelte.js".to_string()),
+            generate: GenerateMode::Client,
+            dev: false,
+            ..Default::default()
+        },
+    )
+    .err()
+    .map(|e| format!("{e:?}"))
+}
+
+const PREAMBLE: &str = "\tfunction load() {}\n\tlet awaitable = 1;\n";
+
+fn in_instance_script(statement: &str) -> String {
+    format!("<script>\n{PREAMBLE}\t{statement}\n</script>\n\n<p>ok</p>\n")
+}
+
+fn assert_rejected(err: Option<String>, needle: &str, what: &str) {
+    let err = err.unwrap_or_else(|| panic!("{what} must not compile"));
+    assert!(
+        err.contains("js_parse_error"),
+        "expected js_parse_error for {what}, got: {err}"
+    );
+    assert!(
+        err.contains(needle),
+        "expected upstream's message for {what}, got: {err}"
+    );
+}
+
+const AWAIT_MESSAGE: &str = "Await expression cannot be a default value";
+const YIELD_MESSAGE: &str = "Yield expression cannot be a default value";
+
+/// Every function form has its own parameter-parsing path upstream, and a
+/// check written for one of them does not see the others.
+#[test]
+fn await_in_a_parameter_default_is_rejected_in_every_function_form() {
+    for statement in [
+        "const f = async (p = await load()) => p;",
+        "const f = (p = await load()) => p;",
+        "async function f(p = await load()) { return p; }",
+        "const f = async function (p = await load()) { return p; };",
+        "const o = { async m(p = await load()) { return p; } };",
+        "class C { async m(p = await load()) { return p; } }",
+        "const o = { async *m(p = await load()) { return p; } };",
+    ] {
+        assert_rejected(
+            component_error(&in_instance_script(statement)),
+            AWAIT_MESSAGE,
+            statement,
+        );
+    }
+}
+
+#[test]
+fn yield_in_a_parameter_default_is_rejected_in_every_generator_form() {
+    for statement in [
+        "function* g(p = yield 1) { return p; }",
+        "const o = { *g(p = yield 1) { return p; } };",
+        "const g = function* (p = yield 1) { return p; };",
+        "const o = { async *g(p = yield 1) { return p; } };",
+    ] {
+        assert_rejected(
+            component_error(&in_instance_script(statement)),
+            YIELD_MESSAGE,
+            statement,
+        );
+    }
+}
+
+/// The offending keyword does not have to sit in the first parameter, or
+/// directly under it.
+#[test]
+fn await_is_rejected_wherever_it_sits_in_the_parameter_list() {
+    for statement in [
+        "const f = async ({ p = await load() } = {}) => p;",
+        "const f = async ([p = await load()] = []) => p;",
+        "const f = async (a, p = await load()) => p;",
+        "const f = async (p = ((q = await load()) => q)) => p;",
+    ] {
+        assert_rejected(
+            component_error(&in_instance_script(statement)),
+            AWAIT_MESSAGE,
+            statement,
+        );
+    }
+}
+
+/// `.svelte.js` is a different compiler entry point, and the one the issue was
+/// filed against.
+#[test]
+fn the_module_entry_point_rejects_it_too() {
+    assert_rejected(
+        module_error("export const f = async (p = /* c */ await load()) => p;"),
+        AWAIT_MESSAGE,
+        "module await default",
+    );
+    assert_rejected(
+        module_error("export function* g(p = yield 1) { return p; }"),
+        YIELD_MESSAGE,
+        "module yield default",
+    );
+}
+
+/// Template expressions are parsed by a different function than script bodies,
+/// so the script fix alone leaves this path accepting.
+#[test]
+fn template_expressions_reject_it_too() {
+    for markup in [
+        "<button onclick={async (p = await load()) => p}>go</button>",
+        "<p>{[async (p = await load()) => p].length}</p>",
+    ] {
+        let src = format!("<script>\n{PREAMBLE}</script>\n\n{markup}\n");
+        assert_rejected(component_error(&src), AWAIT_MESSAGE, markup);
+    }
+}
+
+/// The keyword belongs to a nested function, not to the parameter list — a
+/// scan of the whole subtree cannot tell these from the cases above.
+#[test]
+fn a_keyword_inside_a_nested_function_still_compiles() {
+    for statement in [
+        "const f = async (p = load()) => p;",
+        "const f = async (p = (async () => await load())) => p;",
+        "const f = async (p = { async m() { return await load(); } }) => p;",
+        "const f = async (p = class { async m() { return await load(); } }) => p;",
+        "const f = async (p = function* () { yield 1; }) => p;",
+        "const f = async (p = awaitable) => p;",
+        "const f = async (p) => await p;",
+        "function* g(p = 1) { yield p; }",
+    ] {
+        assert!(
+            component_error(&in_instance_script(statement)).is_none(),
+            "must still compile: {statement}"
+        );
+    }
+}
+
+#[test]
+fn a_keyword_inside_a_nested_function_still_compiles_on_the_module_path() {
+    for statement in [
+        "export const f = async (p = load()) => p;",
+        "export const f = async (p = { async m() { return await load(); } }) => p;",
+        "export const f = async (p = function* () { yield 1; }) => p;",
+    ] {
+        let src = format!("function load() {{}}\n{statement}\n");
+        assert!(
+            module_error(&src).is_none(),
+            "must still compile: {statement}"
+        );
+    }
+}

--- a/scripts/compat-corpus/matrix/axes.mjs
+++ b/scripts/compat-corpus/matrix/axes.mjs
@@ -503,3 +503,98 @@ export function toggle() {
 `,
 	},
 };
+
+/**
+ * `await` / `yield` inside a function's formal parameters — the fourth axis
+ * family, and the second whose inputs the official compiler REJECTS.
+ *
+ * Acorn raises `js_parse_error` for every illegal cell here
+ * (`checkYieldAwaitInDefaultParams`); OXC implements no such rule, so rsvelte
+ * compiled all of them. That is the direction that matters for a drop-in
+ * replacement — a file official refuses builds here and ships.
+ *
+ * The product is what finds it. A check written for one function form does not
+ * see the others (an async method is not an arrow), a check written for the
+ * first parameter does not see the second, and a check that walks the whole
+ * subtree over-rejects the legal rows, where the offending keyword sits in a
+ * NESTED function's body rather than in the parameter list itself.
+ */
+export const PARAM_FUNCTION_FORMS = {
+	'async-arrow': 'const f = async (%s) => p;',
+	'sync-arrow': 'const f = (%s) => p;',
+	'async-fn-decl': 'async function f(%s) {\n\treturn p;\n}',
+	'async-fn-expr': 'const f = async function (%s) {\n\treturn p;\n};',
+	'async-method': 'const o = {\n\tasync m(%s) {\n\t\treturn p;\n\t}\n};',
+	'async-class-method': 'class C {\n\tasync m(%s) {\n\t\treturn p;\n\t}\n}',
+	'async-generator-method': 'const o = {\n\tasync *m(%s) {\n\t\treturn p;\n\t}\n};',
+	'generator-fn-decl': 'function* g(%s) {\n\treturn p;\n}',
+	'generator-method': 'const o = {\n\t*g(%s) {\n\t\treturn p;\n\t}\n};',
+};
+
+/**
+ * The same parameter lists reached through a template expression instead of a
+ * script. rsvelte parses those with a different function, so a fix applied to
+ * the script path alone leaves this one accepting.
+ */
+export const PARAM_TEMPLATE_FORMS = {
+	'attr-async-arrow': '<button onclick={async (%s) => p}>go</button>',
+	'attr-sync-arrow': '<button onclick={(%s) => p}>go</button>',
+	'expr-async-arrow': '<p>{typeof (async (%s) => p)}</p>',
+};
+
+/** Where inside the parameter list the initializer sits. */
+export const PARAM_DEFAULT_SLOTS = {
+	simple: 'p = %s',
+	'object-pattern': '{ p = %s } = {}',
+	'array-pattern': '[p = %s] = []',
+	'second-param': 'a, p = %s',
+	'nested-arrow-param': 'p = ((q = %s) => q)',
+};
+
+/** Initializers acorn rejects in a parameter list, whatever encloses it. */
+export const PARAM_ILLEGAL_INITIALIZERS = {
+	await: 'await load()',
+	yield: 'yield 1',
+};
+
+/**
+ * Initializers that must keep compiling. The nested rows are the discriminating
+ * ones: the keyword is present, and lexically inside the parameter list, but it
+ * belongs to a function of its own — which is exactly what a subtree scan
+ * cannot tell apart from the illegal rows.
+ */
+export const PARAM_LEGAL_INITIALIZERS = {
+	call: 'load()',
+	'nested-async-body': '(async () => await load())',
+	'nested-method-body': '{ async m() { return await load(); } }',
+	'nested-generator-body': 'function* () { yield 1; }',
+	'keyword-lookalike': 'awaitable + yielded',
+};
+
+/** The declarations every parameter case shares, so only the axes differ. */
+export const PARAM_PREAMBLE = `<script>
+	function load() {}
+	let awaitable = 1;
+	let yielded = 1;
+%s
+</script>
+
+<p>ok</p>
+`;
+
+/** Same declarations, with the parameter list in the markup instead. */
+export const PARAM_TEMPLATE_PREAMBLE = `<script>
+	function load() {}
+	let awaitable = 1;
+	let yielded = 1;
+</script>
+
+%s
+`;
+
+/** Same declarations on the `.svelte.js` module path. */
+export const PARAM_MODULE_PREAMBLE = `function load() {}
+let awaitable = 1;
+let yielded = 1;
+%s
+`;

--- a/scripts/compat-corpus/matrix/generate.mjs
+++ b/scripts/compat-corpus/matrix/generate.mjs
@@ -18,6 +18,14 @@ import {
 	BIND_SLOTS,
 	BIND_PREAMBLE,
 	BIND_PREAMBLE_TS,
+	PARAM_FUNCTION_FORMS,
+	PARAM_TEMPLATE_FORMS,
+	PARAM_DEFAULT_SLOTS,
+	PARAM_ILLEGAL_INITIALIZERS,
+	PARAM_LEGAL_INITIALIZERS,
+	PARAM_PREAMBLE,
+	PARAM_TEMPLATE_PREAMBLE,
+	PARAM_MODULE_PREAMBLE,
 } from './axes.mjs';
 import { commentMutants } from './mutate.mjs';
 
@@ -95,11 +103,57 @@ function invalidBindCases() {
 	return cases;
 }
 
+function paramDefaultCases() {
+	const cases = [];
+	// The legal rows discriminate on (initializer × form) — where the keyword
+	// sits relative to the nested function, and what encloses the parameter
+	// list. Repeating them over every destructuring shape would add columns
+	// that cannot move independently of `simple`; `nested-arrow-param` is kept
+	// because re-entering a parameter list is the state the scan can get wrong.
+	const LEGAL_SLOTS = ['simple', 'nested-arrow-param'];
+	const initializers = [
+		...Object.entries(PARAM_ILLEGAL_INITIALIZERS).map(([n, e]) => [n, e, null]),
+		...Object.entries(PARAM_LEGAL_INITIALIZERS).map(([n, e]) => [`legal-${n}`, e, LEGAL_SLOTS]),
+	];
+	for (const [initName, initializer, slots] of initializers) {
+		for (const [slotName, slot] of Object.entries(PARAM_DEFAULT_SLOTS)) {
+			if (slots && !slots.includes(slotName)) continue;
+			const params = slot.replaceAll('%s', initializer);
+			for (const [formName, form] of Object.entries(PARAM_FUNCTION_FORMS)) {
+				const statement = form.replaceAll('%s', params);
+				cases.push({
+					id: `param-default/${initName}__${slotName}__${formName}.svelte`,
+					source: PARAM_PREAMBLE.replaceAll(
+						'%s',
+						statement
+							.split('\n')
+							.map((line) => `\t${line}`)
+							.join('\n')
+					),
+				});
+				cases.push({
+					id: `param-default/${initName}__${slotName}__${formName}.svelte.js`,
+					source: PARAM_MODULE_PREAMBLE.replaceAll('%s', statement),
+					kind: 'module',
+				});
+			}
+			for (const [formName, form] of Object.entries(PARAM_TEMPLATE_FORMS)) {
+				cases.push({
+					id: `param-default/${initName}__${slotName}__${formName}.svelte`,
+					source: PARAM_TEMPLATE_PREAMBLE.replaceAll('%s', form.replaceAll('%s', params)),
+				});
+			}
+		}
+	}
+	return cases;
+}
+
 export const FAMILIES = {
 	'binding-position': bindingPositionCases,
 	'comment-slot': commentSlotCases,
 	'literal-escape': literalEscapeCases,
 	'invalid-bind': invalidBindCases,
+	'param-default': paramDefaultCases,
 };
 
 export function generate(families = Object.keys(FAMILIES)) {

--- a/scripts/compat-corpus/matrix/run.mjs
+++ b/scripts/compat-corpus/matrix/run.mjs
@@ -96,9 +96,9 @@ const rsvelte = require(BINDING);
 
 // ---- generate + compile ----------------------------------------------------
 
-// The axes generate 1329 cases on an unmodified tree; the floor only has to
+// The axes generate 1749 cases on an unmodified tree; the floor only has to
 // separate "generation broke" from "the gate got easier".
-const MIN_MATRIX_CASES = 700;
+const MIN_MATRIX_CASES = 1000;
 
 const cases = generate(FAMILY_KEYS);
 console.log(`[matrix] families: ${FAMILY_KEYS.join(', ')}`);
@@ -227,7 +227,7 @@ if (UPDATE_BASELINE) {
 	// ratchet. This one is absolute.
 	if (cases.length < MIN_MATRIX_CASES) {
 		console.error(`\n[matrix] refusing to baseline from ${cases.length} generated cases (expected >= ${MIN_MATRIX_CASES}).`);
-		console.error('  the axes generate ~1329; far below that means generation broke, not that the gate got easier.');
+		console.error('  the axes generate ~1749; far below that means generation broke, not that the gate got easier.');
 		process.exit(2);
 	}
 	fs.writeFileSync(BASELINE, JSON.stringify([...ids].sort(), null, '\t') + '\n');


### PR DESCRIPTION
Closes #2547.

The issue asks which of two things is true before anything else — "whether rsvelte's parse of the script rejects it and the error is dropped, or whether it never rejects". It **never rejects**. Acorn raises this from `checkYieldAwaitInDefaultParams`, and OXC implements no equivalent rule, so nothing was lost on the way out; there was nothing to lose.

That makes it the same class as the two checks already sitting in `convert_parsed_program` — `with (…)` in strict mode, and a bare `@` decorator — and it is implemented the same way: a scan for what acorn rejects and OXC accepts, composed into the same earliest-position-wins list so a single-pass parser's ordering is preserved.

## Scope: it is `yield` too, and it is every function form

The issue's shape is one cell. The sweep against official:

| | rsvelte before | official |
|---|---|---|
| `async (p = await load()) => p` | compiles | `js_parse_error` |
| `(p = await load()) => p` — **not async** | compiles | same error, not "outside an async function" |
| `async function f(p = await load())` | compiles | ✓ |
| `{ async m(p = await load()) {} }` | compiles | ✓ |
| `class C { async m(p = await load()) {} }` | compiles | ✓ |
| `{ async *m(p = await load()) {} }` | compiles | ✓ |
| `function* g(p = yield 1)` | compiles | `Yield expression cannot be a default value` |
| `{ *g(p = yield 1) {} }` | compiles | ✓ |
| `async ({ p = await load() } = {}) => p` | compiles | ✓ |
| `async (a, p = await load()) => p` | compiles | ✓ |
| `async (p = ((q = await load()) => q)) => p` | compiles | ✓ — the **inner** arrow's params |

22 divergences over the first sweep, now 2 — and both remaining are message text on a shape where the codes already agree (`function f(p = await x)`, where OXC says "`await` is only allowed within async functions…" and acorn says "Cannot use keyword 'await' outside an async function"). That is the general OXC-vs-acorn wording class, not this one.

Positions match upstream's byte-for-byte on every shape that has one: acorn reports `awaitPos`/`yieldPos`, the keyword token's start, and so does this.

## The rule, and why a subtree scan is wrong

`AwaitYieldInParams` carries a flag into a function's parameters and clears it on its body. Nesting decides the answer, not lexical containment:

```js
async (p = { async m() { return await 1; } }) => p   // legal — await is in m's body
async (p = ((q = await 1) => q)) => p                // error — await is in q's parameter list
```

Both have `await` textually inside the outer parameter list. A scan of the parameter subtree rejects the first, which is real shipped code.

## Four boundaries, because the script fix was green while the template one was not

My first version was complete over `convert_parsed_program`, and `{(async (p = await x) => p)}` still compiled — template expressions go through `parse_expression_with_typescript`, a different function. The scan is now at every place rsvelte hands source to OXC where upstream hands it to acorn: the program path, the expression path, snippet parameters, and the statement path.

The gate had to grow the same way, which is the general lesson: **the entry point is an axis, not a flag.**

## Gate: a fifth matrix family, `param-default`

420 cases. 2 illegal initializers (`await load()`, `yield 1`) × 5 positions in the list (simple, object pattern, array pattern, second parameter, a nested arrow's parameter) × 9 function forms × 2 entry points (instance script, `.svelte.js`), plus 3 template forms — an event-handler attribute, an `{expr}` interpolation, and a sync arrow — and 5 **legal** initializers over the two positions where they discriminate.

The legal half is not decoration, and it is harder here than for `invalid-bind`: the legal and illegal inputs differ only in *whose* parameter list the keyword sits in, so it is the half that catches a fix that over-rejects. `bind:group={c as T}` taught us that lesson from a corpus file rather than from the gate ([#2658](https://github.com/baseballyama/rsvelte/pull/2658)); this family had its legal rows from the start.

Matrix after the change, measured rather than added: **1749 cases / 5247 comparisons** — binding-position 329, comment-slot 528, literal-escape 224, invalid-bind 248, param-default 420.

```
match            3928
error-parity     1113
js-mismatch       206   (baseline, unchanged)
error-mismatch      0
error-code-mismatch 0
```

Before the fix those 630 illegal comparisons were `error-mismatch` ("rsvelte accepts, official rejects"); they are `error-parity` now, and no legal row moved.

`gate-coverage.md` 5a is marked **CLOSED** by this: it recorded that no case ever reached `compileModule`, which stopped being true when `comment-slot` gained module seeds and is now doubly false.

## Unrelated finding, filed separately

The family's first template form used `{[async (…) => p].length}` and produced 20 divergences that have nothing to do with this issue: rsvelte folds a **member read on a literal**, so `{[1, 2].length}` emits `<p></p>` where official emits `<p> </p>` and the dynamic text node loses its placeholder. Filed as [#2665](https://github.com/baseballyama/rsvelte/issues/2665) with the reduced form and the `.name` variant. I changed the template form to `{typeof (…)}` rather than enrol 20 ratchet entries under an unrelated PR — so that shape is currently ungated, which #2665 says.

## Verified

- `await_yield_in_params_2547`: 7 tests — every function form, every generator form, every position in the list, both entry points, template expressions, and 11 legal shapes that must still compile.
- Shape matrix: 5247 comparisons, 0 new, 206 known.
- `compiler_fixtures` (145 compiler-errors), `validator` (333) green.
