### PR TITLE
chore(measure): instrument store_subs so the $store AST rewrite can be sized

### DIFF
--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/mod.rs
@@ -26,6 +26,7 @@ mod diagnostic;
 mod diagnostics_test;
 pub mod errors;
 mod pattern_ids;
+pub mod profile;
 pub mod scope;
 mod scope_builder;
 mod store_subscriptions;
@@ -260,13 +261,19 @@ pub(crate) fn analyze_prepared_component_with_retained(
     // This must happen after scopes are created but before template analysis
     // Corresponds to Svelte's store subscription logic in 2-analyze/index.js L348-444
     let is_module_file = analysis.is_module_file;
-    store_subscriptions::detect_store_subscriptions(
+    // Timed outside the `?` so a script that errors still charges its time and
+    // its call: an early return that skips the record loses both, which reads
+    // as the stage being cheaper than it is.
+    let _store_subs_start = profile::timer_start();
+    let store_subs_result = store_subscriptions::detect_store_subscriptions(
         ast,
         &mut analysis,
         options.runes,
         is_module_file,
         retained_scripts,
-    )?;
+    );
+    profile::record_store_subs(profile::timer_elapsed(_store_subs_start));
+    store_subs_result?;
 
     // Detect await expressions and rune references in template and scripts.
     // This is needed for:

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/profile.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/profile.rs
@@ -1,0 +1,152 @@
+//! Analyze-phase accumulators. Only the native profiling binaries read these
+//! back, so they cannot affect compiler output.
+//!
+//! Gated on `measure-pa-split` so the call sites compile away in shipping
+//! builds, and reusing that feature rather than adding one keeps a profiling
+//! run from having to name two flags to get a whole picture.
+
+#[cfg(feature = "measure-pa-split")]
+use std::cell::Cell;
+use std::time::Duration;
+
+// `Instant::now()` traps on `wasm32-unknown-unknown` (no system clock), and the
+// call site lives in a shared compile path that the WASM playground reaches.
+// Same shim as `3_transform/profile.rs`, for the same reason.
+#[cfg(not(target_arch = "wasm32"))]
+pub type TimerStart = std::time::Instant;
+
+#[cfg(target_arch = "wasm32")]
+pub type TimerStart = ();
+
+#[cfg(not(target_arch = "wasm32"))]
+#[inline]
+pub(crate) fn timer_start() -> TimerStart {
+    std::time::Instant::now()
+}
+
+#[cfg(target_arch = "wasm32")]
+#[inline]
+pub(crate) fn timer_start() -> TimerStart {}
+
+#[cfg(not(target_arch = "wasm32"))]
+#[inline]
+pub(crate) fn timer_elapsed(start: TimerStart) -> Duration {
+    start.elapsed()
+}
+
+#[cfg(target_arch = "wasm32")]
+#[inline]
+pub(crate) fn timer_elapsed(_start: TimerStart) -> Duration {
+    Duration::ZERO
+}
+
+/// `detect_store_subscriptions` cost, split by whether the TS blanking step
+/// reused the compiler's own parse or had to make its own.
+///
+/// `calls` counts every entry, so a zero elsewhere in this struct can be told
+/// apart from "the stage never ran" — which is the failure mode a share alone
+/// cannot report.
+#[derive(Default, Debug, Clone, Copy)]
+pub struct StoreSubsCounters {
+    pub total: Duration,
+    pub calls: u64,
+    /// Scripts that went down the TS path at all.
+    pub ts_scripts: u64,
+    /// Of those, the ones that had to re-parse because the retained program was
+    /// unusable. `(A)` exists to keep this at zero; a non-zero value here is the
+    /// measurement that says how far it falls short.
+    pub ts_reparses: u64,
+    /// Bytes handed to the lexical scan, which is the work `(B)` would remove.
+    pub scan_bytes: u64,
+    /// Why the retained program was rejected, one bucket per guard clause. They
+    /// are evaluated in order and only the first failing one is charged, so the
+    /// four sum to `ts_reparses` — a residual means a fifth cause exists.
+    pub rej_absent: u64,
+    pub rej_panicked: u64,
+    pub rej_diagnostics: u64,
+    pub rej_source_differs: u64,
+}
+
+#[cfg(feature = "measure-pa-split")]
+thread_local! {
+    static STORE_SUBS: Cell<StoreSubsCounters> = const { Cell::new(StoreSubsCounters {
+        total: Duration::ZERO,
+        calls: 0,
+        ts_scripts: 0,
+        ts_reparses: 0,
+        scan_bytes: 0,
+        rej_absent: 0,
+        rej_panicked: 0,
+        rej_diagnostics: 0,
+        rej_source_differs: 0,
+    }) };
+}
+
+/// Which guard clause rejected the retained program, in evaluation order.
+#[derive(Clone, Copy)]
+pub(crate) enum Reject {
+    Absent,
+    Panicked,
+    Diagnostics,
+    SourceDiffers,
+}
+
+#[cfg(feature = "measure-pa-split")]
+#[inline]
+pub(crate) fn record_reject(reason: Reject) {
+    STORE_SUBS.with(|c| {
+        let mut v = c.get();
+        match reason {
+            Reject::Absent => v.rej_absent += 1,
+            Reject::Panicked => v.rej_panicked += 1,
+            Reject::Diagnostics => v.rej_diagnostics += 1,
+            Reject::SourceDiffers => v.rej_source_differs += 1,
+        }
+        c.set(v);
+    });
+}
+
+#[cfg(not(feature = "measure-pa-split"))]
+#[inline(always)]
+pub(crate) fn record_reject(_reason: Reject) {}
+
+#[cfg(feature = "measure-pa-split")]
+#[inline]
+pub(crate) fn record_store_subs(elapsed: Duration) {
+    STORE_SUBS.with(|c| {
+        let mut v = c.get();
+        v.total += elapsed;
+        v.calls += 1;
+        c.set(v);
+    });
+}
+
+#[cfg(not(feature = "measure-pa-split"))]
+#[inline(always)]
+pub(crate) fn record_store_subs(_elapsed: Duration) {}
+
+#[cfg(feature = "measure-pa-split")]
+#[inline]
+pub(crate) fn record_ts_script(reparsed: bool, scan_bytes: usize) {
+    STORE_SUBS.with(|c| {
+        let mut v = c.get();
+        v.ts_scripts += 1;
+        v.ts_reparses += u64::from(reparsed);
+        v.scan_bytes += scan_bytes as u64;
+        c.set(v);
+    });
+}
+
+#[cfg(not(feature = "measure-pa-split"))]
+#[inline(always)]
+pub(crate) fn record_ts_script(_reparsed: bool, _scan_bytes: usize) {}
+
+#[cfg(feature = "measure-pa-split")]
+pub fn take_store_subs() -> StoreSubsCounters {
+    STORE_SUBS.with(|c| c.replace(StoreSubsCounters::default()))
+}
+
+#[cfg(not(feature = "measure-pa-split"))]
+pub fn take_store_subs() -> StoreSubsCounters {
+    StoreSubsCounters::default()
+}

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/store_subscriptions.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/store_subscriptions.rs
@@ -511,13 +511,33 @@ fn collect_dollar_refs_from_script_with_context(
         // component source, so the retained program's slice never shares an
         // address with this one even when it holds the very same script.
         let reusable = retained.filter(|program| {
-            !program.panicked() && program.diagnostics().is_empty() && program.source() == content
+            use super::profile::Reject;
+            if program.panicked() {
+                super::profile::record_reject(Reject::Panicked);
+                return false;
+            }
+            if !program.diagnostics().is_empty() {
+                super::profile::record_reject(Reject::Diagnostics);
+                return false;
+            }
+            if program.source() != content {
+                super::profile::record_reject(Reject::SourceDiffers);
+                return false;
+            }
+            true
         });
+        if retained.is_none() {
+            super::profile::record_reject(super::profile::Reject::Absent);
+        }
         let blanked = match reusable {
             Some(program) => {
+                super::profile::record_ts_script(false, content.len());
                 super::types::blank_typescript_from_program(content, program.program())
             }
-            None => super::types::blank_typescript(content),
+            None => {
+                super::profile::record_ts_script(true, content.len());
+                super::types::blank_typescript(content)
+            }
         };
         collect_dollar_identifiers_from_js_with_context(&blanked, start, refs, in_module);
         return;

--- a/crates/rsvelte_devtools/src/bin/compile_profile.rs
+++ b/crates/rsvelte_devtools/src/bin/compile_profile.rs
@@ -236,6 +236,59 @@ fn main() {
         ms(analyze_visitor_time),
         pct(analyze_visitor_time)
     );
+    // `analyze_component` hard-codes `retained_scripts: None` (2_analyze/mod.rs:124);
+    // only `compile()` supplies them. Measuring store_subs on the phase-split path
+    // above would therefore report a retained-reuse rate that is a property of this
+    // harness, not of the compiler. Drain that reading and re-take it through the
+    // real entry point.
+    let _ = rsvelte_core::compiler::phases::phase2_analyze::profile::take_store_subs();
+    let compile_start = Instant::now();
+    for (_, content) in files.iter() {
+        let _ = rsvelte_core::compile(content, compile_opts.clone());
+    }
+    let compile_total = compile_start.elapsed();
+    let ss = rsvelte_core::compiler::phases::phase2_analyze::profile::take_store_subs();
+    println!(
+        "  [store_subs measured through compile(), total {:7.2}ms]",
+        ms(compile_total)
+    );
+    if ss.calls > 0 {
+        println!(
+            "    store_subs         {:7.2}ms ({:5.1}%) | {:.1}% of Visitors | calls {}",
+            ms(ss.total),
+            pct(ss.total),
+            ss.total.as_secs_f64() / analyze_visitor_time.as_secs_f64() * 100.0,
+            ss.calls
+        );
+        println!(
+            "      TS scripts {} | reparses {} ({:.2}%) | lexical scan {} bytes",
+            ss.ts_scripts,
+            ss.ts_reparses,
+            if ss.ts_scripts == 0 {
+                0.0
+            } else {
+                ss.ts_reparses as f64 / ss.ts_scripts as f64 * 100.0
+            },
+            ss.scan_bytes
+        );
+        // The four are charged in guard order, so they must sum to `reparses`.
+        // A residual means a fifth cause the split does not name.
+        let rej_sum = ss.rej_absent + ss.rej_panicked + ss.rej_diagnostics + ss.rej_source_differs;
+        println!(
+            "      REJECT absent {} | panicked {} | diagnostics {} | source-differs {} | sum {} vs reparses {} ({})",
+            ss.rej_absent,
+            ss.rej_panicked,
+            ss.rej_diagnostics,
+            ss.rej_source_differs,
+            rej_sum,
+            ss.ts_reparses,
+            if rej_sum == ss.ts_reparses {
+                "EXACT"
+            } else {
+                "RESIDUAL — a cause is unnamed"
+            }
+        );
+    }
     println!(
         "Phase 3 (Transform):   {:7.2}ms ({:5.1}%)",
         ms(transform_time),


### PR DESCRIPTION
`detect_store_subscriptions` is the largest single stage inside Phase 2's
`Visitors (rest)` residual, and nothing on `main` could measure it. The split
that could lives on `measure/analyze-split` — 208 commits behind, 36 files,
5,581 insertions — which is far too much to rebase to obtain one number.

## What it measures, on shipped code (5,879 files / 9.65 MB)

```
store_subs           39.40ms ( 3.0% of compile) | 12.9% of Visitors | calls 5879
  TS scripts 5571 | reparses 0 (0.00%) | lexical scan 3433073 bytes
  REJECT absent 0 | panicked 0 | diagnostics 0 | source-differs 0 | sum 0 vs reparses 0 (EXACT)
```

So the retained-parse reuse that removed the third full TS parse is working on
**every** TS script in the shipped corpus. The reject buckets are charged in
guard order and must sum to the reparse count, so an unnamed fifth cause would
appear as a residual rather than silently.

**This sizes the AST-based rewrite of the `$store` scan at a ceiling of 3.0% of
compile** — and less than that, since the replacement AST walk is not free. The
6.7–7.4%-of-gap figure recorded before the reuse landed no longer applies.

## Why it reports through `compile()` and not through the phase split

`analyze_component` hard-codes `retained_scripts: None` (`2_analyze/mod.rs:124`);
only `compile()` (`compiler/mod.rs:637`) supplies them. Measuring the reuse rate
on the phase-split path therefore reports a property of the harness rather than
of the compiler — concretely:

| path | reparses |
|---|---|
| via `analyze_component` (phase split) | 5571 / 5671 = **98.24%** |
| via `compile()` | 0 / 5571 = **0.00%** |

I measured the first one before noticing, and it looks exactly like a broken
optimisation. It is the harness. The tool now drains that reading and re-takes
it through the real entry point, with the reason in a comment so the next reader
does not repeat it.

## Cost and safety

Feature-gated on `measure-pa-split`, reusing that flag rather than adding one so
a profiling run does not have to name two flags for a whole picture. The timer
uses the same wasm shim as `3_transform/profile.rs` — `Instant::now()` traps on
`wasm32-unknown-unknown`, and this call site is on a path the WASM playground
reaches.

Output unchanged: corpus 14,138 entries × 3 targets, `js-mismatch 0`,
`js-unparseable 0`, all warning/error ratchets unmoved, 39,569 modules parse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
