### PR TITLE
fix(svelte-check): read --config by what upstream calls a Svelte config

### DIFF
--- a/.changeset/config-flag-custom-vite-name.md
+++ b/.changeset/config-flag-custom-vite-name.md
@@ -1,0 +1,5 @@
+---
+'@rsvelte/svelte-check': patch
+---
+
+Read `--config` correctly when it names a Vite config under a non-standard filename. `rsvelte-check --config vite.custom.config.js` classified the file by asking whether its name began with `vite.config`, which is false for exactly the names the flag exists to support, so the `svelte()` plugin's inline `compilerOptions` were never read and a project with `experimental.async` enabled reported `experimental_async` on every top-level `await`. Upstream's `load-config` decides the other way round — a Svelte config is one named `svelte.config.*`, everything else is tried as a Vite config first — which is now the single predicate all three `--config` consumers share. A relative `--config` path is also resolved against the workspace before the loader reads it, instead of only for the existence check.

--- a/compatibility/gate-coverage.md
+++ b/compatibility/gate-coverage.md
@@ -52,7 +52,7 @@ samples) — see `AGENTS.md` § "Generated shape matrix" and issue #2281.
 | 9 | Formatter parity (JS corpus) | whole-file bytes vs oxfmt oracle | ids whose oracle file is absent are skipped, uncounted | [D] |
 | 10 | Formatter parity (Rust svelte.dev) | whole-file bytes vs generated fixture | exercises `--no-native-css`, not the shipped default | [S] |
 | 11 | Lint output parity | set of `rule\tline:col\tmessage` | `.svelte.(js\|ts)` ungated on **both** sides; autofixes never compared | [D] |
-| 12 | svelte-check Layer 1 (fixtures) | multiset of `SEVERITY file:line code` | column, message, `source`, file-walk counts | [S] |
+| 12 | svelte-check Layer 1 (fixtures) | multiset of `SEVERITY file:line code` | column, message, `source`, file-walk counts, every flag but `--tsconfig` | [D] |
 | 13 | svelte-check Layer 2 (e2e) | same key, 3 units in 2 repos | same fields; whether the oracle finds anything at all | [U] |
 | 14 | Compiler source-map gate | 23 anchors + budgets + parity vs official | segments rsvelte **adds**; `sources`/`names`; `dev: true` | [S] |
 | 15 | `ast_gate_preconditions` | "rsvelte's own output parses" | compile **failures** are skipped — errors make it greener | [S] |
@@ -651,9 +651,23 @@ false positives and nothing else. **This is a question, not a finding.** Resolve
 ### Blind spot 12d — the CLI surface is one point
 
 `check-verify.mjs:197-202` forwards only `--workspace`, `--tsconfig`, and per-scenario `args`.
-Exactly one of 30 scenarios uses `args` (`ts7-native`: `["--tsgo"]`). **[S]** `--threshold`,
-`--fail-on-warnings`, `--ignore`, `--compiler-warnings`, `--watch` and the `human` /
+Exactly one of 30 scenarios uses `args` (`ts7-native`: `["--tsgo"]`). **[D]** `--threshold`,
+`--fail-on-warnings`, `--ignore`, `--compiler-warnings`, `--config`, `--watch` and the `human` /
 `machine` / `github-actions` output formats are compared against the oracle nowhere.
+
+`--config` is the discriminating case (#2650). It changes *where the compiler options come
+from*, so it can move any diagnostic in any scenario, and it shipped classifying its argument by
+asking whether the filename began with `vite.config` — false for precisely the non-standard names
+the flag exists to accept. `--config vite.custom.config.js` therefore read the file as a Svelte
+config, found no `compilerOptions`, and reported `experimental_async` on every top-level `await`
+in a project that had enabled it. Two things kept that invisible: no scenario passes `--config`,
+and the flag's own unit tests all went through *discovery* (`load_compiler_options(&dir)`), so the
+explicit branch had **zero** tests across its three consumers — one of which (`kit_file.rs`)
+carried a third copy of the same wrong predicate.
+
+The lesson generalises past this gate: a flag that selects an input source is not one more
+option to forward, it is a **second population**. Compare 5a, where the same shape (an entry
+point nothing reached) hid a whole compiler path.
 
 ### Blind spot 12e — the tsc/tsgo equivalence claim is asserted, not measured
 

--- a/crates/rsvelte_check/src/main.rs
+++ b/crates/rsvelte_check/src/main.rs
@@ -197,16 +197,21 @@ fn main() -> ExitCode {
 
     // `--config` names an explicit config file; the JS reference errors
     // when the path doesn't exist rather than silently discovering one.
-    if let Some(config) = cli.config.as_deref() {
-        let abs = if config.is_absolute() {
-            config.to_path_buf()
+    // A relative path is workspace-relative there, and the resolved path is
+    // what the loader gets — resolving only for the existence check would let
+    // a run pass this gate and then read nothing.
+    let mut config = cli.config.clone();
+    if let Some(path) = cli.config.as_deref() {
+        let abs = if path.is_absolute() {
+            path.to_path_buf()
         } else {
-            workspace.join(config)
+            workspace.join(path)
         };
         if !abs.exists() {
-            eprintln!("Could not find config file at {}", config.display());
+            eprintln!("Could not find config file at {}", path.display());
             return ExitCode::from(2);
         }
+        config = Some(abs);
     }
 
     // `--no-tsconfig` means "use no project tsconfig": ignore `--tsconfig`
@@ -231,7 +236,7 @@ fn main() -> ExitCode {
         compiler_warnings,
         diagnostic_sources,
         incremental: cli.incremental,
-        config: cli.config.clone(),
+        config,
     };
 
     if cli.watch {

--- a/crates/rsvelte_check/src/svelte_check/config.rs
+++ b/crates/rsvelte_check/src/svelte_check/config.rs
@@ -132,7 +132,7 @@ pub fn load_compiler_options(workspace: &Path) -> CompilerOptionsSettings {
 /// instead of discovering `svelte.config.*` / `vite.config.*` under the
 /// workspace. Mirrors the JS reference's `--config` flag, which points at
 /// a `svelte.config` / `vite.config` under a non-standard name or location.
-/// Which kind it is comes from [`explicit_config_is_vite`], not from the
+/// Which kind it is comes from `explicit_config_is_vite`, not from the
 /// filename alone.
 pub fn load_compiler_options_with_config(
     workspace: &Path,

--- a/crates/rsvelte_check/src/svelte_check/config.rs
+++ b/crates/rsvelte_check/src/svelte_check/config.rs
@@ -79,6 +79,33 @@ const VITE_CONFIG_CANDIDATES: &[&str] = &[
     "vite.config.cts",
 ];
 
+/// Should an explicit `--config` be read as a **Vite** config?
+///
+/// `--config` exists to name a config whose filename is non-standard, so the
+/// name can only be trusted in the one direction upstream trusts it.
+/// `load-config`'s `loadConfigFromFile` matches `^svelte\.config\.` and hands
+/// everything else to the Vite loader *first*, falling back to the Svelte
+/// loader when that finds nothing — so a file is a Vite config when it both
+/// is not named as a Svelte one and actually carries a Svelte plugin call.
+///
+/// Asking "is it named `vite.config.*`" instead is neither half: it answers
+/// "Svelte" for `vite.custom.config.js`, the one kind of name the flag is
+/// for. Every `--config` consumer asks this question, so they all ask it
+/// here — the wrong polarity shipped because three copies existed and only
+/// one of them was tested.
+pub(super) fn explicit_config_is_vite(name: &str, source: &str, source_type: SourceType) -> bool {
+    !name.starts_with("svelte.config.") && declares_svelte_plugin(source, source_type)
+}
+
+/// The oxc `SourceType` implied by a config filename's extension.
+pub(super) fn config_source_type(name: &str) -> SourceType {
+    if name.ends_with(".ts") || name.ends_with(".mts") || name.ends_with(".cts") {
+        SourceType::ts()
+    } else {
+        SourceType::default()
+    }
+}
+
 /// Load the diagnostic-relevant `compilerOptions` from
 /// `<workspace>/svelte.config.*` and `<workspace>/vite.config.*`.
 ///
@@ -104,10 +131,9 @@ pub fn load_compiler_options(workspace: &Path) -> CompilerOptionsSettings {
 /// diagnostic-relevant `compilerOptions` are read from that exact file
 /// instead of discovering `svelte.config.*` / `vite.config.*` under the
 /// workspace. Mirrors the JS reference's `--config` flag, which points at
-/// a non-standard `svelte.config` / `vite.config` location. The file is
-/// classified by name: a `vite.config.*` is parsed for the inline
-/// `svelte()` / `sveltekit()` plugin options, anything else as a Svelte
-/// config.
+/// a `svelte.config` / `vite.config` under a non-standard name or location.
+/// Which kind it is comes from [`explicit_config_is_vite`], not from the
+/// filename alone.
 pub fn load_compiler_options_with_config(
     workspace: &Path,
     config: Option<&Path>,
@@ -122,13 +148,8 @@ pub fn load_compiler_options_with_config(
             .file_name()
             .and_then(|n| n.to_str())
             .unwrap_or_default();
-        let is_ts = name.ends_with(".ts") || name.ends_with(".mts") || name.ends_with(".cts");
-        let source_type = if is_ts {
-            SourceType::ts()
-        } else {
-            SourceType::default()
-        };
-        let kind = if name.starts_with("vite.config") {
+        let source_type = config_source_type(name);
+        let kind = if explicit_config_is_vite(name, &source, source_type) {
             ConfigKind::Vite
         } else {
             ConfigKind::Svelte
@@ -327,6 +348,21 @@ fn find_svelte_plugin_call<'a>(expr: &'a oxc::Expression<'a>) -> Option<SveltePl
 /// even an argument we can't read statically still suppresses the file,
 /// exactly as it would at runtime. The plain `svelte()` plugin never
 /// suppresses `svelte.config.js`.
+/// Does this source export a Vite config carrying a `svelte()` / `sveltekit()`
+/// plugin call? The question a `--config` path has to answer before it can be
+/// read as a Vite config at all.
+fn declares_svelte_plugin(source: &str, source_type: SourceType) -> bool {
+    let allocator = Allocator::default();
+    let parser = OxcParser::new(&allocator, source, source_type);
+    let result = parser.parse();
+    result.program.body.iter().any(|stmt| {
+        config_object_from_stmt(stmt)
+            .and_then(|obj| lookup_property(obj, "plugins"))
+            .and_then(find_svelte_plugin_call)
+            .is_some()
+    })
+}
+
 fn vite_uses_inline_sveltekit_config(source: &str, source_type: SourceType) -> bool {
     let allocator = Allocator::default();
     let parser = OxcParser::new(&allocator, source, source_type);
@@ -375,21 +411,24 @@ fn extract_compiler_options(obj: &oxc::ObjectExpression, settings: &mut Compiler
 /// without one never spawns Node; the sidecar re-checks `typeof === 'function'`
 /// after actually loading the config.
 ///
-/// Only `svelte.config.*` is considered (matching where the official
+/// Only a Svelte config is considered (matching where the official
 /// svelte-check reads `compilerOptions.warningFilter`). A `warningFilter` passed
-/// inline to the `svelte()` / `sveltekit()` plugin in `vite.config.*` is
-/// intentionally NOT supported: unlike the scalar options, importing a
-/// `vite.config.*` standalone in the sidecar would drag in the whole Vite plugin
+/// inline to the `svelte()` / `sveltekit()` plugin in a Vite config is
+/// intentionally NOT supported: unlike the scalar options, importing a Vite
+/// config standalone in the sidecar would drag in the whole Vite plugin
 /// graph. Returns `None` when no such file/property is found.
 pub fn warning_filter_config_path(workspace: &Path, config: Option<&Path>) -> Option<PathBuf> {
-    // `--config` wins when it names a Svelte config; a vite.config is not a
-    // standalone-importable source of `warningFilter`.
+    // `--config` wins when it is a Svelte config; a Vite config is not a
+    // standalone-importable source of `warningFilter`, whatever it is named.
     if let Some(path) = config {
         let name = path
             .file_name()
             .and_then(|n| n.to_str())
             .unwrap_or_default();
-        if name.starts_with("vite.config") {
+        let Ok(source) = std::fs::read_to_string(path) else {
+            return None;
+        };
+        if explicit_config_is_vite(name, &source, config_source_type(name)) {
             return None;
         }
         return declares_function_warning_filter(path).then(|| path.to_path_buf());
@@ -790,6 +829,121 @@ mod tests {
         assert_eq!(
             warning_filter_config_path(&dir, Some(&dir.join("vite.config.ts"))),
             None
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// `--config` exists for names that are not standard, so a Vite config
+    /// under any name has to be read as one (issue #2650).
+    #[test]
+    fn explicit_config_reads_a_vite_config_under_a_custom_name() {
+        let dir = workspace("explicit_custom_vite");
+        for name in [
+            "vite.custom.config.js",
+            "vite.config.custom.ts",
+            "custom.vite.js",
+            "playground.config.mjs",
+        ] {
+            write(
+                &dir,
+                name,
+                r#"import { svelte } from '@sveltejs/vite-plugin-svelte';
+                export default {
+                    plugins: [svelte({ compilerOptions: { experimental: { async: true } } })]
+                };"#,
+            );
+            let s = load_compiler_options_with_config(&dir, Some(&dir.join(name)));
+            assert!(
+                s.experimental_async,
+                "{name} carries the svelte plugin and must be read as a vite config"
+            );
+        }
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// The name test only decides the *Svelte* direction, so a Svelte config
+    /// under a custom name still has to be read as one — there is no plugin
+    /// call in it to read instead.
+    #[test]
+    fn explicit_config_reads_a_svelte_config_under_a_custom_name() {
+        let dir = workspace("explicit_custom_svelte");
+        for name in ["svelte.config.custom.js", "custom.svelte.js"] {
+            write(
+                &dir,
+                name,
+                "export default { compilerOptions: { experimental: { async: true } } };",
+            );
+            let s = load_compiler_options_with_config(&dir, Some(&dir.join(name)));
+            assert!(
+                s.experimental_async,
+                "{name} must be read as a svelte config"
+            );
+        }
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// An explicit config replaces discovery: a `svelte.config.js` sitting
+    /// next to it must not leak in.
+    #[test]
+    fn explicit_config_suppresses_discovery() {
+        let dir = workspace("explicit_suppress");
+        write(
+            &dir,
+            "svelte.config.js",
+            "export default { compilerOptions: { experimental: { async: true } } };",
+        );
+        write(
+            &dir,
+            "vite.custom.config.js",
+            r#"import { svelte } from '@sveltejs/vite-plugin-svelte';
+            export default { plugins: [svelte()] };"#,
+        );
+        let s = load_compiler_options_with_config(&dir, Some(&dir.join("vite.custom.config.js")));
+        assert!(
+            !s.experimental_async,
+            "the discovered svelte.config must not be consulted"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// A Vite config is not a `warningFilter` source — the sidecar imports
+    /// the file standalone, which a Vite config is not — and that stays true
+    /// under a custom name.
+    #[test]
+    fn custom_named_vite_config_is_not_a_warning_filter_source() {
+        let dir = workspace("wf_custom_vite");
+        // The top-level `compilerOptions` is not a shape a real vite config
+        // has; it is here so the only thing that can decide the answer is the
+        // classification. Reading it would mean handing the sidecar a file it
+        // cannot import standalone.
+        write(
+            &dir,
+            "vite.custom.config.js",
+            r#"import { svelte } from '@sveltejs/vite-plugin-svelte';
+            export default {
+                plugins: [svelte()],
+                compilerOptions: { warningFilter: () => false }
+            };"#,
+        );
+        assert_eq!(
+            warning_filter_config_path(&dir, Some(&dir.join("vite.custom.config.js"))),
+            None
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// …and the mirror: a Svelte config under a custom name *is* one.
+    #[test]
+    fn custom_named_svelte_config_is_a_warning_filter_source() {
+        let dir = workspace("wf_custom_svelte");
+        write(
+            &dir,
+            "custom.svelte.js",
+            "export default { compilerOptions: { warningFilter: () => false } };",
+        );
+        assert_eq!(
+            warning_filter_config_path(&dir, Some(&dir.join("custom.svelte.js"))),
+            Some(dir.join("custom.svelte.js"))
         );
         let _ = std::fs::remove_dir_all(&dir);
     }

--- a/crates/rsvelte_check/src/svelte_check/kit_file.rs
+++ b/crates/rsvelte_check/src/svelte_check/kit_file.rs
@@ -66,8 +66,8 @@ pub fn load_kit_files_settings(workspace: &Path) -> KitFilesSettings {
 /// discovered `svelte.config.*`. Mirrors the JS reference's `--config`.
 /// `kit.files` only ever lives in a Svelte config, so a config that is not
 /// one yields defaults — under any filename, which is why the test is
-/// [`is_svelte_config_name`](super::config::is_svelte_config_name) rather
-/// than a local one.
+/// `config::explicit_config_is_vite` negated: it reads the file's contents,
+/// so it answers "is this a Svelte config" for a name it has never seen.
 pub fn load_kit_files_settings_with_config(
     workspace: &Path,
     config: Option<&Path>,

--- a/crates/rsvelte_check/src/svelte_check/kit_file.rs
+++ b/crates/rsvelte_check/src/svelte_check/kit_file.rs
@@ -64,8 +64,10 @@ pub fn load_kit_files_settings(workspace: &Path) -> KitFilesSettings {
 /// Like [`load_kit_files_settings`], but when `config` is `Some` the
 /// `kit.files` settings are read from that exact file instead of the
 /// discovered `svelte.config.*`. Mirrors the JS reference's `--config`.
-/// `kit.files` only ever lives in a Svelte config, so a `vite.config.*`
-/// override yields defaults.
+/// `kit.files` only ever lives in a Svelte config, so a config that is not
+/// one yields defaults — under any filename, which is why the test is
+/// [`is_svelte_config_name`](super::config::is_svelte_config_name) rather
+/// than a local one.
 pub fn load_kit_files_settings_with_config(
     workspace: &Path,
     config: Option<&Path>,
@@ -77,10 +79,14 @@ pub fn load_kit_files_settings_with_config(
             .file_name()
             .and_then(|n| n.to_str())
             .unwrap_or_default();
-        if name.starts_with("vite.config") {
+        let Ok(source) = std::fs::read_to_string(path) else {
             return settings;
-        }
-        if let Ok(source) = std::fs::read_to_string(path) {
+        };
+        if !super::config::explicit_config_is_vite(
+            name,
+            &source,
+            super::config::config_source_type(name),
+        ) {
             parse_kit_files_source(&source, &mut settings);
         }
         return settings;
@@ -2318,6 +2324,47 @@ mod tests {
         );
         let s = load_kit_files_settings(&tmp);
         assert_eq!(s.server_hooks_path, "srv/hooks");
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    /// `--config` may name either kind of config under any filename (issue
+    /// #2650), and only a Svelte config carries `kit.files`. What separates
+    /// them is the Svelte plugin call, not the name: a file named
+    /// `vite.custom.config.js` with no plugin is a Svelte config upstream
+    /// too, because the Vite loader finds nothing and the Svelte loader runs.
+    #[test]
+    fn explicit_config_reads_kit_files_only_from_a_svelte_config() {
+        let tmp = std::env::temp_dir().join(format!("rsvelte_kit_cfg_expl_{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&tmp);
+        std::fs::create_dir_all(&tmp).unwrap();
+
+        const KIT: &str = "kit: { files: { hooks: { server: 'srv/hooks' } } }";
+
+        for name in ["custom.svelte.js", "vite.custom.config.js"] {
+            std::fs::write(tmp.join(name), format!("export default {{ {KIT} }};")).unwrap();
+            let s = load_kit_files_settings_with_config(&tmp, Some(&tmp.join(name)));
+            assert_eq!(
+                s.server_hooks_path, "srv/hooks",
+                "{name} declares no plugin, so it is a svelte config whatever it is called"
+            );
+        }
+
+        // A real Vite config — the plugin call is what makes it one — is not
+        // a `kit.files` source even when the property is sitting right there.
+        std::fs::write(
+            tmp.join("vite.custom.config.js"),
+            format!(
+                r#"import {{ svelte }} from '@sveltejs/vite-plugin-svelte';
+                export default {{ plugins: [svelte()], {KIT} }};"#
+            ),
+        )
+        .unwrap();
+        let s = load_kit_files_settings_with_config(&tmp, Some(&tmp.join("vite.custom.config.js")));
+        assert_ne!(
+            s.server_hooks_path, "srv/hooks",
+            "a vite config is not a kit.files source"
+        );
+
         let _ = std::fs::remove_dir_all(&tmp);
     }
 }

--- a/crates/rsvelte_check/tests/svelte_check_cli_flags.rs
+++ b/crates/rsvelte_check/tests/svelte_check_cli_flags.rs
@@ -155,6 +155,49 @@ fn no_tsconfig_ignores_tsconfig_flag() {
     let _ = std::fs::remove_dir_all(&dir);
 }
 
+/// Issue #2650: `--config vite.custom.config.js`. End-to-end through the
+/// binary, because both defects it hit live outside the config loader —
+/// the name classification, and the path staying workspace-relative while
+/// the loader reads it from the process cwd. The workspace is a temp dir
+/// and the test's cwd is not, so a relative read finds nothing and the
+/// component keeps its `experimental_async` error.
+#[test]
+fn custom_named_vite_config_supplies_compiler_options() {
+    let dir = workspace("config_custom_vite");
+    write(
+        &dir,
+        "Async.svelte",
+        "<script>\n  let x = await Promise.resolve(1);\n</script>\n<p>{x}</p>\n",
+    );
+    write(
+        &dir,
+        "vite.custom.config.js",
+        r#"import { svelte } from '@sveltejs/vite-plugin-svelte';
+        export default {
+            plugins: [svelte({ compilerOptions: { experimental: { async: true } } })]
+        };"#,
+    );
+
+    // Without the flag the same workspace must still error, or the
+    // assertion below would pass on a build that reads no config at all.
+    let bare = run(&dir, &["--no-type-check"]);
+    assert!(
+        String::from_utf8_lossy(&bare.stdout).contains("experimental_async"),
+        "control: an unconfigured run must report the error"
+    );
+
+    let out = run(
+        &dir,
+        &["--no-type-check", "--config", "vite.custom.config.js"],
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        !stdout.contains("experimental_async"),
+        "--config must read the plugin's compilerOptions; got:\n{stdout}"
+    );
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
 #[test]
 fn config_missing_file_errors() {
     let dir = workspace("config_missing");


### PR DESCRIPTION
Fixes #2650.

## What happened

`rsvelte-check --config vite.custom.config.js` kept reporting `experimental_async` even though the named config enables it. Three separate defects were in the path, and each one alone is sufficient to reproduce the report:

1. **The classification asked the wrong question.** The predicate was "is this named `vite.config.*`?" — false for `vite.custom.config.js`, which is precisely the kind of name `--config` exists to support. Upstream's `@sveltejs/load-config` decides the opposite way: a file matching `^svelte\.config\.` is a Svelte config, *everything else* is handed to the Vite loader first and only falls back to the Svelte loader when that finds nothing. So the question is "is it **not** svelte-named **and** does it actually declare a Svelte plugin?" — now one `explicit_config_is_vite` shared by every consumer.
2. **Three copies of that predicate existed** (the options loader, the warning-filter resolver, `kit_file.rs`) and only one of them had a test. Collapsing them to one is the point, not a tidy-up.
3. **The path stayed workspace-relative.** `main.rs` resolved `--config` against the workspace only for the *existence* check, then passed the original relative path to the loader, which reads it from the process cwd. Under `--workspace <dir>` from anywhere else, the read simply fails and the run silently falls back to defaults.

## Foundation

`compatibility/gate-coverage.md` blind spot 12d moves **[S] → [D]**: no Layer-1 scenario passes `--config`, and the flag's own unit tests all went through *discovery* (`load_compiler_options(&dir)`), so the explicit branch had **zero** tests across its three consumers. The generalisation recorded there is the transferable part: *a flag that selects an input source is not one more option to forward, it is a second population* — the discovery tests cannot see it however many of them there are.

The new end-to-end test spawns the binary and carries its own control: a bare run on the same workspace must still report `experimental_async`, otherwise the real assertion would pass on a build that reads no config at all. Each of the three defects was reverted individually and confirmed to break it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EUkGEUYELkmNArviFBDPNR
