### PR TITLE
fix(compiler): look past comment text when joining continuation lines (server)

### DIFF
--- a/.changeset/comment-before-continuation-decl.md
+++ b/.changeset/comment-before-continuation-decl.md
@@ -1,0 +1,16 @@
+---
+"@rsvelte/compiler": patch
+---
+
+Stop a block comment from suppressing constant folding of the declaration below it (server).
+
+`join_continuation_lines` decides whether a physical line continues onto the
+next by reading the last non-whitespace byte it has emitted. Comment text went
+into that same buffer, and a block comment ends in `/` — a division operator —
+so a `/* … */` on its own line joined the next line onto itself. A joined
+`const` declaration no longer starts with `const`, so `extract_constant_vars`
+stopped seeing it and the template read was emitted as a runtime
+`$.escape(...)` where upstream folds the literal in.
+
+The continuation decision now looks past comment text to the last byte that was
+actually code.

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/helpers.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/helpers.rs
@@ -908,6 +908,11 @@ fn join_continuation_lines(script: &str) -> String {
     let mut depth_paren: i32 = 0;
     let mut depth_brace: i32 = 0;
     let mut depth_bracket: i32 = 0;
+    // Length of `out` up to the last byte that was *code*. A block comment ends
+    // in `/`, which the newline rule below would otherwise read as a division
+    // operator and use to join the following line onto this one; comment text is
+    // not code, so the continuation decision has to look past it.
+    let mut code_len = 0usize;
     let mut i = 0;
     while i < bytes.len() {
         let b = bytes[i];
@@ -957,6 +962,7 @@ fn join_continuation_lines(script: &str) -> String {
             } else {
                 out.push_str(&strip_line_continuations(&script[s..i]));
             }
+            code_len = out.len();
             continue;
         }
         if b == b'(' {
@@ -981,8 +987,7 @@ fn join_continuation_lines(script: &str) -> String {
             // a backtick, etc. The most common case we care about is `=`,
             // but covering operators avoids surprises with hand-formatted
             // declarations like `const x = a +\n  b`.
-            let prev = out
-                .as_bytes()
+            let prev = out.as_bytes()[..code_len]
                 .iter()
                 .rposition(|c| !c.is_ascii_whitespace())
                 .map(|p| out.as_bytes()[p]);
@@ -1020,6 +1025,7 @@ fn join_continuation_lines(script: &str) -> String {
             next += 1;
         }
         out.push_str(&script[i..next]);
+        code_len = out.len();
         i = next;
     }
     out

--- a/crates/rsvelte_core/tests/comment_before_continuation_decl.rs
+++ b/crates/rsvelte_core/tests/comment_before_continuation_decl.rs
@@ -1,0 +1,83 @@
+//! A block comment ends in `/`, and `/` is a division operator.
+//!
+//! `join_continuation_lines` decides whether a physical line continues onto the
+//! next by looking at the last non-whitespace byte it has emitted. Comment text
+//! was emitted into that same buffer, so a `/* … */` on its own line made the
+//! next line join onto it — and a joined `const` declaration no longer starts
+//! with `const`, so `extract_constant_vars` stopped seeing it and the value was
+//! read at runtime instead of folded.
+//!
+//! The pairing that isolates it: a `//` line comment does *not* trigger this,
+//! because its last byte is the comment's own text rather than `/`. Both are
+//! asserted, so a fix that stops looking at comments entirely still passes while
+//! one that special-cases the `)` in the mutant that found this does not — the
+//! delimiter was never the cause.
+
+use rsvelte_core::{CompileOptions, GenerateMode, compile};
+
+fn server(source: &str) -> String {
+    compile(
+        source,
+        CompileOptions {
+            filename: Some("A.svelte".to_string()),
+            generate: GenerateMode::Server,
+            ..Default::default()
+        },
+    )
+    .expect("compile failed")
+    .js
+    .code
+}
+
+/// `const cont = "a\<newline>b"` — a string whose value spans two physical
+/// lines through a line continuation. Folding it requires the declaration to be
+/// recognised, which requires the comment above it not to swallow it.
+fn source_with(comment: &str) -> String {
+    format!(
+        "<script>\n  let n = $state(0);\n{comment}\n  const cont =\n    \"a\\\n\t\tb\";\n</script>\n\n<p>{{cont}}{{n}}</p>\n"
+    )
+}
+
+#[test]
+fn a_block_comment_does_not_stop_the_next_declaration_folding() {
+    let out = server(&source_with("/* c */"));
+    assert!(
+        out.contains("<p>a\t\tb0</p>"),
+        "the constant was read at runtime instead of folded:\n{out}"
+    );
+}
+
+/// The mutant that found this carried a `)`, which looks like the cause and is
+/// not: the plain form above diverges identically.
+#[test]
+fn the_delimiter_in_the_comment_is_not_the_cause() {
+    let out = server(&source_with("/* ) c */"));
+    assert!(
+        out.contains("<p>a\t\tb0</p>"),
+        "the constant was read at runtime instead of folded:\n{out}"
+    );
+}
+
+/// Control: a `//` comment never ended in `/`, so it always folded. A change
+/// that moved this one would be reaching past the reported defect.
+#[test]
+fn a_line_comment_folds_as_it_always_did() {
+    let out = server(&source_with("// c"));
+    assert!(
+        out.contains("<p>a\t\tb0</p>"),
+        "the line-comment control moved:\n{out}"
+    );
+}
+
+/// Control: with no line continuation the declaration folds whatever precedes
+/// it. Both halves are required to reach the defect.
+#[test]
+fn a_plain_string_folds_with_a_block_comment_above_it() {
+    let out = server(
+        "<script>\n  let n = $state(0);\n/* ) c */\n  const cont =\n    \"ab\";\n</script>\n\n<p>{cont}{n}</p>\n",
+    );
+    assert!(
+        out.contains("<p>ab0</p>"),
+        "the no-continuation control moved:\n{out}"
+    );
+}


### PR DESCRIPTION
Fixes #2669. **`main` is currently red on `Corpus Compat`** (run 31283116948,
`9da01d5e`) — this closes it.

## What broke

`join_continuation_lines` decides whether a physical line continues onto the
next by reading the last non-whitespace byte it has already emitted:

```rust
let prev = out.as_bytes().iter().rposition(|c| !c.is_ascii_whitespace())…
```

Comment text is emitted into that same buffer, and **a block comment ends in
`/`** — which is on the continuation-operator list as division. So a `/* … */`
on its own line made the *next* line join onto it. A joined `const` declaration
no longer starts with `const`, `extract_constant_vars` stopped recognising it,
and the template read came out as a runtime `$.escape(cont)` where upstream
folds the literal in:

```
official: $$renderer.push(`<p>ab0</p>`);
rsvelte : $$renderer.push(`<p>${$.escape(cont)}0</p>`);
```

The comment does not touch the declaration — it sits between `let n` and
`const cont`.

The fix tracks the length of `out` up to the last byte that was *code*, and the
continuation decision reads from there.

## The delimiter was not the cause

The mutant that found this is the `block-with-paren` kind (`/* ) c */`), so `)`
looks like the obvious culprit — the same shape as #2253. It is not:

| comment | string | before |
|---|---|---|
| none | `"a\`⏎`b"` | match |
| `/* c */` (plain) | `"a\`⏎`b"` | **diverge** |
| `/* ) c */` | `"a\`⏎`b"` | **diverge** |
| `// c` | `"a\`⏎`b"` | match |
| `/* ) c */` | `"ab"` | match |
| none | `"ab"` | match |

Removing the delimiter leaves it; removing the line continuation removes it. A
`//` comment never triggers it because its last byte is its own text rather than
`/`. Both halves are required, and the test pins the pairing — a fix aimed at
the `)` would not pass it.

## Verification

- **Regression test** `crates/rsvelte_core/tests/comment_before_continuation_decl.rs`,
  4 tests including both controls. Demonstrated discriminating: against the
  unfixed tree exactly the two block-comment tests fail and both controls stay
  green.
- **Corpus** 14,138 entries × 3 targets: `js-mismatch 0`, `js-unparseable 0`,
  warning/error ratchets unmoved, 39,569 modules parse.
- **Full mutation sweep** (`--full`, what `main` runs, not the PR sample): back
  to the baselined **36**, with none of the 36 newly passing — so the ratchet
  shrinks on the new entry only and is not falsely shrunk elsewhere.

## Known adjacent defect, not fixed here

A comment placed *inside* the declaration — between `const cont =` and the value
— still diverges, and unlike this one it triggers on `//` too, so it is a
different mechanism (the join swallows the value into the line comment). It is
not what `main` is red on and it is not in the ratchet. Filed separately rather
than folded in, so this PR stays reviewable against one cause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
