### PR TITLE
fix(compiler): drop comment text from the server constant-fold line join

### DIFF
--- a/.changeset/comment-in-continuation-fold.md
+++ b/.changeset/comment-in-continuation-fold.md
@@ -1,0 +1,14 @@
+---
+"@rsvelte/compiler": patch
+---
+
+Fold a line-continuation string constant when a comment sits between `=` and the value
+
+`join_continuation_lines` reconstructs logical lines for `extract_constant_vars`,
+and it copied comment text into that reconstruction. A comment then landed in
+front of the declarator's value, where `is_whole_string_literal` tests the first
+byte, so the constant was never recorded and the SSR output read it at runtime
+instead of folding it — output that runs correctly and differs from official's.
+
+Comments now become a single space. That is the whole of the difference the sole
+consumer can observe: it reads values, and a comment carries none.

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/helpers.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/helpers.rs
@@ -908,25 +908,24 @@ fn join_continuation_lines(script: &str) -> String {
     let mut depth_paren: i32 = 0;
     let mut depth_brace: i32 = 0;
     let mut depth_bracket: i32 = 0;
-    // Length of `out` up to the last byte that was *code*. A block comment ends
-    // in `/`, which the newline rule below would otherwise read as a division
-    // operator and use to join the following line onto this one; comment text is
-    // not code, so the continuation decision has to look past it.
-    let mut code_len = 0usize;
     let mut i = 0;
     while i < bytes.len() {
         let b = bytes[i];
-        // Line / block comments — copy as-is.
+        // A comment becomes one space. The sole consumer is the constant
+        // extractor below, which reads declarator values, and a comment carries
+        // none — while keeping the text puts it exactly where that extractor's
+        // `starts_with` tests look, and leaves the continuation rule reading the
+        // comment's last character (`= /* c */` ends in `/` and joins the next
+        // line; `= // c` ends in `c` and does not, and joining anyway would let
+        // the `//` swallow the value).
         if b == b'/' && i + 1 < bytes.len() && bytes[i + 1] == b'/' {
-            let s = i;
             while i < bytes.len() && bytes[i] != b'\n' {
                 i += 1;
             }
-            out.push_str(&script[s..i]);
+            out.push(' ');
             continue;
         }
         if b == b'/' && i + 1 < bytes.len() && bytes[i + 1] == b'*' {
-            let s = i;
             i += 2;
             while i + 1 < bytes.len() && !(bytes[i] == b'*' && bytes[i + 1] == b'/') {
                 i += 1;
@@ -934,7 +933,7 @@ fn join_continuation_lines(script: &str) -> String {
             if i + 1 < bytes.len() {
                 i += 2;
             }
-            out.push_str(&script[s..i]);
+            out.push(' ');
             continue;
         }
         // String / template literals — copy verbatim. Newlines inside
@@ -962,7 +961,6 @@ fn join_continuation_lines(script: &str) -> String {
             } else {
                 out.push_str(&strip_line_continuations(&script[s..i]));
             }
-            code_len = out.len();
             continue;
         }
         if b == b'(' {
@@ -987,7 +985,8 @@ fn join_continuation_lines(script: &str) -> String {
             // a backtick, etc. The most common case we care about is `=`,
             // but covering operators avoids surprises with hand-formatted
             // declarations like `const x = a +\n  b`.
-            let prev = out.as_bytes()[..code_len]
+            let prev = out
+                .as_bytes()
                 .iter()
                 .rposition(|c| !c.is_ascii_whitespace())
                 .map(|p| out.as_bytes()[p]);
@@ -1025,7 +1024,6 @@ fn join_continuation_lines(script: &str) -> String {
             next += 1;
         }
         out.push_str(&script[i..next]);
-        code_len = out.len();
         i = next;
     }
     out

--- a/crates/rsvelte_core/tests/comment_before_continuation_decl.rs
+++ b/crates/rsvelte_core/tests/comment_before_continuation_decl.rs
@@ -69,6 +69,38 @@ fn a_line_comment_folds_as_it_always_did() {
     );
 }
 
+/// The same declaration with the comment BETWEEN `=` and the value, which is
+/// the slot the reported mutant actually occupies. Looking past comment text
+/// when deciding to join is not enough here: the join happens either way, and
+/// the comment lands in front of the value, where `is_whole_string_literal`
+/// tests the first byte.
+fn value_prefixed_by(comment: &str) -> String {
+    format!(
+        "<script>\n  let n = $state(0);\n  const cont =\n{comment}\n    \"a\\\n\t\tb\";\n</script>\n\n<p>{{cont}}{{n}}</p>\n"
+    )
+}
+
+#[test]
+fn a_block_comment_between_the_equals_and_the_value_still_folds() {
+    let out = server(&value_prefixed_by("/* ) c */"));
+    assert!(
+        out.contains("<p>a\t\tb0</p>"),
+        "the constant was read at runtime instead of folded:\n{out}"
+    );
+}
+
+/// The line-comment form of the same slot, and the one that a
+/// join-on-continuation fix makes *worse* rather than better: once the lines are
+/// joined, everything after `//` — the value included — is inside the comment.
+#[test]
+fn a_line_comment_between_the_equals_and_the_value_still_folds() {
+    let out = server(&value_prefixed_by("// c"));
+    assert!(
+        out.contains("<p>a\t\tb0</p>"),
+        "the constant was read at runtime instead of folded:\n{out}"
+    );
+}
+
 /// Control: with no line continuation the declaration folds whatever precedes
 /// it. Both halves are required to reach the defect.
 #[test]


### PR DESCRIPTION
Closes the mutation-fuzz divergence that has `main` red since c2a8eeb6:

```
pattern/matrix/string-line-continuation/indented-continuation__m0__block-with-paren.svelte [code-mismatch] (server)
  official: …n=0;constcont="a\b";$$renderer.push(`<p>ab0</p>`);}
  rsvelte : …n=0;constcont="a\b";$$renderer.push(`<p>${$.escape(cont)}0</p>`);}
```

#2670 addressed the same report and `main` is **still red on the identical entry** — the fix and the reported mutant are in different slots. Both are in `join_continuation_lines`, which exists only to rebuild logical lines for `extract_constant_vars`.

| slot | shape | pre-#2670 | with #2670 | here |
|---|---|---|---|---|
| comment ABOVE the declaration | `/* c */`⏎`const cont =` | broken (block only) | fixed | fixed |
| comment BETWEEN `=` and the value | `const cont =`⏎`/* c */`⏎`"a\`… | broken | **broken** | fixed |

#2670 stops the block comment's trailing `/` from being read as a division operator. That is real, but in the second slot the join is *correct* — `=` already asked for it — and the damage is where the comment lands: in front of the value, where `is_whole_string_literal` tests the first byte. For the `// c` form joining is actively harmful, because the value ends up inside the line comment.

So the change here is one thing instead: **a comment becomes a single space.** That is the whole of what the sole consumer can observe — it reads declarator values, and a comment carries none. `code_len` becomes unnecessary and is removed rather than left describing a rule that no longer applies.

## What the delimiter had to do with it: nothing

The mutant carries `)`, which invites a `#2601`-class reading ("a byte scan reads a delimiter inside a comment as code"). Measured across the full comment-kind × insertion-slot product, that is **wrong**:

```
kind               s1 s2 s3 s4 s5          s4 = inserted INSIDE the string
line                .   .   X   X   .      s5 = before </script>
line-with-brace     .   .   X   X   .
line-with-paren     .   .   X   X   .
line-with-semi      .   .   X   X   .
block               .   X   X   X   .
block-with-brace    .   X   X   X   .
block-with-paren    .   X   X   X   .
svelte-ignore       .   .   X   X   .
```

Every kind fails in the same slots; `)` / `}` / `;` change nothing. The `s2`-only-for-block column is the #2670 mechanism, and it is what makes the delimiter reading superficially plausible.

`s4` is **not** a divergence: both compilers reject it with `js_parse_error` and only the message text differs, which is `error-parity` to the gate. My first probe compared messages and reported it as a failure — recording that here because the number in the table would otherwise look like an unfixed case.

The control that identifies the real trigger: the same declaration **without** the line continuation folds under every kind in every slot. It takes continuation × comment.

## Verification

Run on this change (before the rebase onto #2670; re-running now on the rebased tree, will report):

- **Full mutation sweep** — the gate that is failing: `code-mismatch` 37 → **36**, `✅ no code regressions`, 0 crashes, 0 unparseable.
- **Corpus verify**, all 3 targets: `js-mismatch` **0**, `css-mismatch` 0, `output-unparseable` 0, no warning or error regressions.
- **Shape matrix**: 1749 cases / 5247 comparisons, `✅ no regressions`.
- **Negative control on the new tests**: reverting only `helpers.rs` to `origin/main` makes exactly the two added tests fail (4 passed / 2 failed) and every #2670 test pass. They are discriminating, and they fail *for the predicted reason*.

## Note on the gate, not the PR

A seed added by a PR cannot be mutation-tested by that PR: PRs run `--seeds 1500`, only `main` runs `--full`. #2663 added this seed and could not have seen its mutant. Every future `pattern-corpus` addition carries the same exposure — worth a line in `gate-coverage.md` §20 if someone agrees it belongs there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
