### PR TITLE
test(compiler): gate the comment-in-a-declaration fold against the corpus

### DIFF
--- a/compatibility/pattern-corpus/issues/2671-comment-between-assign-and-value.svelte
+++ b/compatibility/pattern-corpus/issues/2671-comment-between-assign-and-value.svelte
@@ -1,0 +1,13 @@
+<script>
+  let n = $state(0);
+  const block =
+    /* c */
+    "a\
+		b";
+  const line =
+    // c
+    "c\
+		d";
+</script>
+
+<p>{block}{line}{n}</p>

--- a/crates/rsvelte_core/tests/comment_before_continuation_decl.rs
+++ b/crates/rsvelte_core/tests/comment_before_continuation_decl.rs
@@ -113,3 +113,17 @@ fn a_plain_string_folds_with_a_block_comment_above_it() {
         "the no-continuation control moved:\n{out}"
     );
 }
+
+/// Guards the hazard the fix introduces rather than the defect it removes:
+/// comment text is now dropped from the joined line, so a commented-out
+/// declaration must not become a folded constant.
+#[test]
+fn a_commented_out_declaration_is_not_folded() {
+    let out = server(
+        "<script>\n  let n = $state(0);\n  /* const cont = \"zz\"; */\n  const cont = \"ab\";\n</script>\n\n<p>{cont}{n}</p>\n",
+    );
+    assert!(
+        out.contains("<p>ab0</p>"),
+        "a commented-out declaration was folded:\n{out}"
+    );
+}


### PR DESCRIPTION
Reduced to what #2672 does not already cover. #2672 landed the identical fix I
had written here — comments become a single space in the joined line, `code_len`
removed — so the compiler change and the two divergence tests are dropped as
duplicates.

What is left is additive:

**A control for the hazard the fix introduces.** Dropping comment text makes a
commented-out declaration textually indistinguishable from a declaration.
Nothing asserts it must not fold, and nothing in the corpus reaches that shape:

```svelte
  /* const cont = "zz"; */
  const cont = "ab";
```

**A pattern-corpus entry.** The shape is currently reachable only through the
mutation fuzz, which runs a deterministic *sample* on PRs and the full sweep
only on `main` — so a regression here would land before anything sees it. As a
corpus entry it is compared on every run of every gate. It carries both comment
kinds, because the `//` form is what separates this defect from #2669.

Verified on this branch: `comment_before_continuation_decl` 7/7, full corpus
verify `js-mismatch 0` with the entry enrolled (manifest 14,166), full mutation
sweep 36 known remain with no regressions and none newly passing.
