### PR TITLE
chore(measure): split the client template-fragment visitor by node kind

### DIFF
--- a/crates/rsvelte_core/Cargo.toml
+++ b/crates/rsvelte_core/Cargo.toml
@@ -58,6 +58,11 @@ measure-pa-split = []
 # its share of `compile()` can be measured. Off by default; the build counts are
 # unconditional, only the `Instant` pair is gated.
 measure-semantic-build = []
+# Repository-local instrumentation: charge self time per template node kind
+# inside the client fragment visitor. The visitor recurses, so the guard also
+# maintains a child-time accumulator; one `Instant` pair per visited node makes
+# it far too heavy to leave on. Off by default and zero-cost when off.
+measure-tf-split = []
 # Select the JavaScript entropy backend when the compiler is embedded in wasm.
 # Binding exports live in `rsvelte_lint_bindings`, not in this library.
 wasm-target = ["dep:getrandom", "getrandom/wasm_js"]

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/types.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/types.rs
@@ -68,7 +68,10 @@ impl<'a> ComponentContext<'a> {
     }
 
     /// Index into `profile::TF_KINDS`. Kept next to `visit_node`'s match so the
-    /// two arms cannot drift apart silently.
+    /// two arms cannot drift apart silently. Gated with its only call site so
+    /// the default build does not run this match per visited node and then
+    /// discard the result.
+    #[cfg(feature = "measure-tf-split")]
     #[inline]
     fn tf_kind_index_of(node: &TemplateNode<'_>) -> usize {
         match node {
@@ -113,6 +116,7 @@ impl<'a> ComponentContext<'a> {
         node: &TemplateNode<'_>,
         _state_override: Option<&ComponentClientTransformState<'a>>,
     ) -> TransformResult {
+        #[cfg(feature = "measure-tf-split")]
         let _tf = crate::compiler::phases::phase3_transform::profile::tf_guard(
             Self::tf_kind_index_of(node),
         );

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/types.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/types.rs
@@ -67,6 +67,41 @@ impl<'a> ComponentContext<'a> {
         self.path.last().copied()
     }
 
+    /// Index into `profile::TF_KINDS`. Kept next to `visit_node`'s match so the
+    /// two arms cannot drift apart silently.
+    #[inline]
+    fn tf_kind_index_of(node: &TemplateNode<'_>) -> usize {
+        match node {
+            TemplateNode::Component(_) => 0,
+            TemplateNode::SvelteComponent(_) => 1,
+            TemplateNode::SvelteSelf(_) => 2,
+            TemplateNode::SvelteElement(_) => 3,
+            TemplateNode::ExpressionTag(_) => 4,
+            TemplateNode::RegularElement(_) => 5,
+            TemplateNode::Text(_) => 6,
+            TemplateNode::IfBlock(_) => 7,
+            TemplateNode::EachBlock(_) => 8,
+            TemplateNode::AwaitBlock(_) => 9,
+            TemplateNode::KeyBlock(_) => 10,
+            TemplateNode::SnippetBlock(_) => 11,
+            TemplateNode::RenderTag(_) => 12,
+            TemplateNode::HtmlTag(_) => 13,
+            TemplateNode::ConstTag(_) => 14,
+            TemplateNode::DeclarationTag(_) => 15,
+            TemplateNode::DebugTag(_) => 16,
+            TemplateNode::SvelteBoundary(_) => 17,
+            TemplateNode::SvelteHead(_) => 18,
+            TemplateNode::SvelteBody(_) => 19,
+            TemplateNode::SvelteWindow(_) => 20,
+            TemplateNode::SvelteDocument(_) => 21,
+            TemplateNode::TitleElement(_) => 22,
+            TemplateNode::Comment(_) => 23,
+            TemplateNode::SvelteFragment(_) => 24,
+            TemplateNode::SlotElement(_) => 25,
+            _ => 26,
+        }
+    }
+
     /// Visit a template node and transform it.
     ///
     /// This is the main entry point for visiting nodes during transformation.
@@ -78,6 +113,9 @@ impl<'a> ComponentContext<'a> {
         node: &TemplateNode<'_>,
         _state_override: Option<&ComponentClientTransformState<'a>>,
     ) -> TransformResult {
+        let _tf = crate::compiler::phases::phase3_transform::profile::tf_guard(
+            Self::tf_kind_index_of(node),
+        );
         match node {
             TemplateNode::Component(comp) => self.visit_component(comp),
             TemplateNode::SvelteComponent(comp) => self.visit_svelte_component(comp),

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/component.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/component.rs
@@ -802,6 +802,9 @@ fn process_let_directive(
     lets: &mut Vec<JsStatement>,
     let_names: &mut Vec<(String, Option<String>)>,
 ) {
+    let _tf = crate::compiler::phases::phase3_transform::profile::tf_guard(
+        crate::compiler::phases::phase3_transform::profile::TF_BC_LET,
+    );
     let prop_name = &let_dir.name;
 
     // Check if expression is an Identifier or null (simple case)
@@ -975,6 +978,9 @@ fn process_on_directive(
     context: &mut ComponentContext,
     events: &mut IndexMap<String, Vec<JsExpr>>,
 ) {
+    let _tf = crate::compiler::phases::phase3_transform::profile::tf_guard(
+        crate::compiler::phases::phase3_transform::profile::TF_BC_ON,
+    );
     // If no expression, mark that component needs props for event bubbling
     // This is handled via build_event_handler which sets needs_props_from_events
 
@@ -1014,6 +1020,9 @@ fn process_spread_attribute(
     props_and_spreads: &mut Vec<PropsEntry>,
     memoizer: &mut crate::compiler::phases::phase3_transform::client::types::Memoizer,
 ) {
+    let _tf = crate::compiler::phases::phase3_transform::profile::tf_guard(
+        crate::compiler::phases::phase3_transform::profile::TF_BC_SPREAD,
+    );
     let expression = convert_expression(&spread.expression, context);
 
     // Check if the expression has reactive state and function calls.
@@ -1083,6 +1092,9 @@ fn process_regular_attribute(
     custom_css_props: &mut Vec<JsObjectMember>,
     memoizer: &mut crate::compiler::phases::phase3_transform::client::types::Memoizer,
 ) {
+    let _tf = crate::compiler::phases::phase3_transform::profile::tf_guard(
+        crate::compiler::phases::phase3_transform::profile::TF_BC_ATTR,
+    );
     // Handle custom CSS properties (--var)
     if attr.name.starts_with("--") {
         // Build the attribute value with potential memoization
@@ -1353,6 +1365,9 @@ fn process_bind_directive<'a>(
     component_name: &str,
     ignored_codes: &[String],
 ) {
+    let _tf = crate::compiler::phases::phase3_transform::profile::tf_guard(
+        crate::compiler::phases::phase3_transform::profile::TF_BC_BIND,
+    );
     // Convert the expression without transforms first
     let raw_expression = convert_expression(&bind.expression, context);
 
@@ -2061,6 +2076,9 @@ fn process_attach_tag(
     context: &mut ComponentContext,
     props_and_spreads: &mut Vec<PropsEntry>,
 ) {
+    let _tf = crate::compiler::phases::phase3_transform::profile::tf_guard(
+        crate::compiler::phases::phase3_transform::profile::TF_BC_ATTACH,
+    );
     let expression = convert_expression(&attach.expression, context);
 
     // Check if expression has reactive state using the proper check.
@@ -2122,6 +2140,9 @@ fn process_snippet_block(
     props_and_spreads: &mut Vec<PropsEntry>,
     serialized_slots: &mut Vec<JsObjectMember>,
 ) {
+    let _tf = crate::compiler::phases::phase3_transform::profile::tf_guard(
+        crate::compiler::phases::phase3_transform::profile::TF_BC_SNIPPET,
+    );
     // Use the snippet_block visitor to generate the full snippet function
     // This properly handles the snippet body, parameters, and placement
     use crate::compiler::phases::phase3_transform::client::visitors::snippet_block::snippet_block;
@@ -2190,6 +2211,9 @@ fn build_slot_function(
     let_names: &[(String, Option<String>)],
     context: &mut ComponentContext,
 ) -> Option<JsExpr> {
+    let _tf = crate::compiler::phases::phase3_transform::profile::tf_guard(
+        crate::compiler::phases::phase3_transform::profile::TF_BC_SLOT_FN,
+    );
     if children.is_empty() {
         return None;
     }
@@ -2885,6 +2909,9 @@ fn build_component_expression(
     component_name: &str,
     context: &mut ComponentContext,
 ) -> JsExpr {
+    let _tf = crate::compiler::phases::phase3_transform::profile::tf_guard(
+        crate::compiler::phases::phase3_transform::profile::TF_BC_COMP_EXPR,
+    );
     match node {
         ComponentNode::Component(_) => {
             // For dynamic component identified by name
@@ -2956,6 +2983,9 @@ fn build_component_call(
     bind_this: Option<&Expression<'_>>,
     context: &mut ComponentContext,
 ) -> JsExpr {
+    let _tf = crate::compiler::phases::phase3_transform::profile::tf_guard(
+        crate::compiler::phases::phase3_transform::profile::TF_BC_COMP_CALL,
+    );
     let callee = if is_component_dynamic {
         b::id(intermediate_name)
     } else {
@@ -3028,6 +3058,9 @@ fn build_with_css_props(
     bind_this: Option<&Expression>,
     component_start: u32,
 ) {
+    let _tf = crate::compiler::phases::phase3_transform::profile::tf_guard(
+        crate::compiler::phases::phase3_transform::profile::TF_BC_CSS_PROPS,
+    );
     // Determine wrapper element based on namespace
     let is_svg = context.state.metadata.namespace == "svg";
     let wrapper_element = if is_svg { "g" } else { "svelte-css-wrapper" };
@@ -3103,6 +3136,9 @@ fn build_props_expression(
     arena: &crate::compiler::phases::phase3_transform::js_ast::arena::JsArena,
     props_and_spreads: Vec<PropsEntry>,
 ) -> JsExpr {
+    let _tf = crate::compiler::phases::phase3_transform::profile::tf_guard(
+        crate::compiler::phases::phase3_transform::profile::TF_BC_PROPS,
+    );
     if props_and_spreads.is_empty() {
         return b::object(vec![]);
     }
@@ -3168,6 +3204,9 @@ fn build_component_meta_stmt(
     dev: bool,
     source: &str,
 ) -> JsStatement {
+    let _tf = crate::compiler::phases::phase3_transform::profile::tf_guard(
+        crate::compiler::phases::phase3_transform::profile::TF_BC_META,
+    );
     if !dev {
         return b::stmt(arena, expression);
     }

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/profile.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/profile.rs
@@ -759,6 +759,115 @@ pub fn take_pa_breakdown() -> PaBreakdown {
     PaBreakdown::default()
 }
 
+pub const TF_KINDS: [&str; 27] = [
+    "component",
+    "svelte_component",
+    "svelte_self",
+    "svelte_element",
+    "expression_tag",
+    "regular_element",
+    "text",
+    "if_block",
+    "each_block",
+    "await_block",
+    "key_block",
+    "snippet_block",
+    "render_tag",
+    "html_tag",
+    "const_tag",
+    "declaration_tag",
+    "debug_tag",
+    "svelte_boundary",
+    "svelte_head",
+    "svelte_body",
+    "svelte_window",
+    "svelte_document",
+    "title_element",
+    "comment",
+    "svelte_fragment",
+    "slot_element",
+    "other",
+];
+
+/// Self time and call count per template node kind, drained together with the
+/// `template_fragment` parent they are compared against.
+#[derive(Default, Debug, Clone, Copy)]
+pub struct TfBreakdown {
+    pub time: [Duration; TF_KINDS.len()],
+    pub calls: [u64; TF_KINDS.len()],
+}
+
+#[cfg(feature = "measure-tf-split")]
+thread_local! {
+    static TF_TIME: [Cell<u64>; TF_KINDS.len()] = Default::default();
+    static TF_CALLS: [Cell<u64>; TF_KINDS.len()] = Default::default();
+    /// Time the frames below the open one have already claimed. The visitor is
+    /// recursive, so an inclusive timer would charge an element for everything
+    /// inside it; each frame subtracts what its children took.
+    static TF_CHILD: Cell<u64> = const { Cell::new(0) };
+}
+
+/// Charges self time to `idx` on drop.
+#[cfg(feature = "measure-tf-split")]
+pub struct TfGuard {
+    idx: usize,
+    start: TimerStart,
+    saved_child: u64,
+}
+
+#[cfg(feature = "measure-tf-split")]
+impl Drop for TfGuard {
+    fn drop(&mut self) {
+        let total = timer_elapsed(self.start).as_nanos() as u64;
+        let child = TF_CHILD.with(|c| c.get());
+        TF_TIME.with(|a| a[self.idx].set(a[self.idx].get() + total.saturating_sub(child)));
+        TF_CALLS.with(|a| a[self.idx].set(a[self.idx].get() + 1));
+        TF_CHILD.with(|c| c.set(self.saved_child + total));
+    }
+}
+
+#[cfg(feature = "measure-tf-split")]
+#[inline]
+pub fn tf_guard(idx: usize) -> TfGuard {
+    let saved_child = TF_CHILD.with(|c| c.replace(0));
+    TfGuard {
+        idx,
+        start: timer_start(),
+        saved_child,
+    }
+}
+
+#[cfg(not(feature = "measure-tf-split"))]
+pub struct TfGuard;
+
+#[cfg(not(feature = "measure-tf-split"))]
+#[inline(always)]
+pub fn tf_guard(_idx: usize) -> TfGuard {
+    TfGuard
+}
+
+#[cfg(feature = "measure-tf-split")]
+pub fn take_tf_breakdown() -> TfBreakdown {
+    let mut out = TfBreakdown::default();
+    TF_TIME.with(|a| {
+        for (i, c) in a.iter().enumerate() {
+            out.time[i] = Duration::from_nanos(c.replace(0));
+        }
+    });
+    TF_CALLS.with(|a| {
+        for (i, c) in a.iter().enumerate() {
+            out.calls[i] = c.replace(0);
+        }
+    });
+    TF_CHILD.with(|c| c.set(0));
+    out
+}
+
+#[cfg(not(feature = "measure-tf-split"))]
+pub fn take_tf_breakdown() -> TfBreakdown {
+    TfBreakdown::default()
+}
+
 /// Records the legacy `$:` branch on drop, which returns from several points.
 pub struct ReactiveStmtGuard(pub TimerStart);
 

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/profile.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/profile.rs
@@ -759,7 +759,7 @@ pub fn take_pa_breakdown() -> PaBreakdown {
     PaBreakdown::default()
 }
 
-pub const TF_KINDS: [&str; 27] = [
+pub const TF_KINDS: [&str; 40] = [
     "component",
     "svelte_component",
     "svelte_self",
@@ -787,20 +787,59 @@ pub const TF_KINDS: [&str; 27] = [
     "svelte_fragment",
     "slot_element",
     "other",
+    // Stages inside `build_component`. Self time, like the rows above, so they
+    // are subtracted from the `component` row rather than added beside it.
+    "bc:let_directive",
+    "bc:on_directive",
+    "bc:spread_attribute",
+    "bc:regular_attribute",
+    "bc:bind_directive",
+    "bc:attach_tag",
+    "bc:snippet_block",
+    "bc:slot_function",
+    "bc:props_expression",
+    "bc:component_expression",
+    "bc:component_call",
+    "bc:css_props",
+    "bc:meta_stmt",
 ];
+
+pub const TF_BC_LET: usize = 27;
+pub const TF_BC_ON: usize = 28;
+pub const TF_BC_SPREAD: usize = 29;
+pub const TF_BC_ATTR: usize = 30;
+pub const TF_BC_BIND: usize = 31;
+pub const TF_BC_ATTACH: usize = 32;
+pub const TF_BC_SNIPPET: usize = 33;
+pub const TF_BC_SLOT_FN: usize = 34;
+pub const TF_BC_PROPS: usize = 35;
+pub const TF_BC_COMP_EXPR: usize = 36;
+pub const TF_BC_COMP_CALL: usize = 37;
+pub const TF_BC_CSS_PROPS: usize = 38;
+pub const TF_BC_META: usize = 39;
 
 /// Self time and call count per template node kind, drained together with the
 /// `template_fragment` parent they are compared against.
-#[derive(Default, Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy)]
 pub struct TfBreakdown {
     pub time: [Duration; TF_KINDS.len()],
     pub calls: [u64; TF_KINDS.len()],
 }
 
+// `Default` is only derivable for arrays up to 32 entries.
+impl Default for TfBreakdown {
+    fn default() -> Self {
+        Self {
+            time: [Duration::ZERO; TF_KINDS.len()],
+            calls: [0; TF_KINDS.len()],
+        }
+    }
+}
+
 #[cfg(feature = "measure-tf-split")]
 thread_local! {
-    static TF_TIME: [Cell<u64>; TF_KINDS.len()] = Default::default();
-    static TF_CALLS: [Cell<u64>; TF_KINDS.len()] = Default::default();
+    static TF_TIME: [Cell<u64>; TF_KINDS.len()] = const { [const { Cell::new(0) }; TF_KINDS.len()] };
+    static TF_CALLS: [Cell<u64>; TF_KINDS.len()] = const { [const { Cell::new(0) }; TF_KINDS.len()] };
     /// Time the frames below the open one have already claimed. The visitor is
     /// recursive, so an inclusive timer would charge an element for everything
     /// inside it; each frame subtracts what its children took.

--- a/crates/rsvelte_devtools/Cargo.toml
+++ b/crates/rsvelte_devtools/Cargo.toml
@@ -27,6 +27,7 @@ measure-json = ["rsvelte_core/measure-json"]
 measure-prop-reads = ["rsvelte_core/measure-prop-reads"]
 measure-semantic-build = ["rsvelte_core/measure-semantic-build"]
 measure-pa-split = ["rsvelte_core/measure-pa-split"]
+measure-tf-split = ["rsvelte_core/measure-tf-split"]
 
 [dependencies]
 rsvelte_ast_equiv = { path = "../rsvelte_ast_equiv" }

--- a/crates/rsvelte_devtools/src/bin/compile_profile.rs
+++ b/crates/rsvelte_devtools/src/bin/compile_profile.rs
@@ -147,6 +147,7 @@ fn main() {
     let _ = profile::take_breakdown();
     let _ = profile::take_script_text_breakdown();
     let _ = profile::take_pa_breakdown();
+    let _ = profile::take_tf_breakdown();
     // A raw count rather than a share, so warmup cannot skew a percentage here
     // -- but it would leave the oracle's check count covering a population no
     // other number in the report covers, which is the same hazard one field over.
@@ -204,6 +205,7 @@ fn main() {
     let transform_breakdown = totals;
     let script_text_breakdown = profile::take_script_text_breakdown();
     let pa = profile::take_pa_breakdown();
+    let tf = profile::take_tf_breakdown();
     let sp = profile::take_state_pipeline_counters();
 
     let total = parse_time + analyze_time + transform_time;
@@ -533,6 +535,42 @@ fn main() {
         ms(template_fragment),
         pct(template_fragment)
     );
+    if tf.calls.iter().sum::<u64>() > 0 {
+        let mut rows: Vec<(usize, std::time::Duration, u64)> = profile::TF_KINDS
+            .iter()
+            .enumerate()
+            .map(|(i, _)| (i, tf.time[i], tf.calls[i]))
+            .filter(|(_, t, c)| *c > 0 || !t.is_zero())
+            .collect();
+        rows.sort_by_key(|r| std::cmp::Reverse(r.1));
+        let split: std::time::Duration = tf.time.iter().sum();
+        for (i, t, calls) in &rows {
+            println!(
+                "      {:<18}{:7.2}ms ({:5.1}%) calls={}",
+                profile::TF_KINDS[*i],
+                ms(*t),
+                pct(*t),
+                calls
+            );
+        }
+        let pairs: u64 = tf.calls.iter().sum();
+        let per_pair = calibrate_tf_overhead();
+        println!(
+            "      {:<18}{} pairs x {:.1}ns = {:.3}ms ({:.1}% of parent), charged to the visited node's PARENT row",
+            "TF-OVERHEAD",
+            pairs,
+            per_pair,
+            pairs as f64 * per_pair / 1e6,
+            (pairs as f64 * per_pair / 1e6) / ms(template_fragment) * 100.0
+        );
+        println!(
+            "      {:<18}{:7.2}ms ({:5.1}%)  <- Sigma self-time / parent {:.1}%",
+            "= split",
+            ms(split),
+            pct(split),
+            split.as_secs_f64() / template_fragment.as_secs_f64() * 100.0
+        );
+    }
     println!(
         "  Assembly (post-frag):{:7.2}ms ({:5.1}%)",
         ms(assembly_after),
@@ -777,6 +815,17 @@ fn report_scaling(rows: &[ScalingRow], label: &str, predictor: fn(&ScalingRow) -
 /// next to it.
 /// Cost of one instrumented stage boundary, measured in this process so a
 /// loaded machine moves the bound and the rows it applies to together.
+fn calibrate_tf_overhead() -> f64 {
+    let n = 200_000u64;
+    let t = Instant::now();
+    for _ in 0..n {
+        let _g = profile::tf_guard(0);
+    }
+    let per = t.elapsed().as_nanos() as f64 / n as f64;
+    let _ = profile::take_tf_breakdown();
+    per
+}
+
 fn calibrate_pa_overhead() -> f64 {
     let n = 200_000u64;
     let t = Instant::now();
@@ -787,6 +836,7 @@ fn calibrate_pa_overhead() -> f64 {
     let per = t.elapsed().as_nanos() as f64 / n as f64;
     // Discard the calibration's own counts.
     let _ = profile::take_pa_breakdown();
+    let _ = profile::take_tf_breakdown();
     per
 }
 


### PR DESCRIPTION
Instrumentation only, off by default (`measure-tf-split`), zero-cost when off.

`Template fragment` was the second-largest Phase 3 bucket (18.2% of compile) and
one timer around one call — `fragment(&ast.fragment, …)`. `visit_node` is the
single dispatch point for every template node kind, so the guard goes there. The
visitor recurses, so an inclusive timer would charge an element for everything
inside it; the guard keeps a child-time accumulator and charges **self time**.

## What it found

Per-corpus, min over 5 runs (the machine was not quiet — see the caveats):

| corpus | `component` | `regular_element` | Σ split / parent | residual |
|---|---|---|---|---|
| bits-ui | **45.2%** (2,788 calls) | 24.0% (1,412) | 93.5% | 6.5% |
| flowbite-svelte | **46.1%** (6,801) | 27.5% (2,802) | 93.9% | 6.1% |
| shadcn-svelte | **67.8%** (16,432) | 15.7% (2,487) | 95.9% | 4.1% |
| layercake | **38.3%** (479) | 37.8% (586) | 93.4% | 6.6% |

Two node kinds carry **62–84%** of the bucket. Everything else — `if_block`,
`each_block`, `render_tag`, `const_tag`, and the 19 other kinds — is under 8%
each. The residual (4–7%) is `fragment()`'s own work plus `Text` and
`ExpressionTag`, which the fragment loop handles inline and which therefore
never pass through `visit_node` (they read as 0 calls, by construction, not
because templates lack them).

Per call, `component` is the **cheaper** of the two (2.8–6.8 µs vs 4.2–5.5 µs).
Its share is call count, and call count is a property of real component
libraries.

## Why the ranking is not the instrument

`component` has the most calls, and the guard adds one `Instant` pair per
visited node, so "the biggest row is the row with the most timer pairs" is the
obvious confound. It is bounded and reported inline:

```
TF-OVERHEAD  20164 pairs x 58.9ns = 1.188ms (0.9% of parent)
```

0.9% cannot produce a 67.8% row. The pair cost also lands in the *parent* frame,
not the child's, because the child's timer starts after its guard's bookkeeping.
A paired feature-on/off A/B is below this machine's noise floor (on < off in 2
of 4 corpora), which agrees with the 0.9% bound rather than adding to it.

## Caveats

- **Do not size this from the fixtures corpus.** There the order inverts —
  `regular_element` 6.9% of compile against `component` 1.0% — one more instance
  of the fixture corpus skewing shares.
- Absolute ms here are not comparable to the clean phase table: the machine had
  other builds running throughout. Shares are min-estimator over 5 runs;
  `component > regular_element` holds in **5/5** runs on bits-ui, flowbite and
  shadcn, and **3/5** on layercake, where the two are within 2% of each other.
