### PR TITLE
chore(measure): split build_component into stages

### DIFF
--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/component.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/component.rs
@@ -802,6 +802,9 @@ fn process_let_directive(
     lets: &mut Vec<JsStatement>,
     let_names: &mut Vec<(String, Option<String>)>,
 ) {
+    let _tf = crate::compiler::phases::phase3_transform::profile::tf_guard(
+        crate::compiler::phases::phase3_transform::profile::TF_BC_LET,
+    );
     let prop_name = &let_dir.name;
 
     // Check if expression is an Identifier or null (simple case)
@@ -975,6 +978,9 @@ fn process_on_directive(
     context: &mut ComponentContext,
     events: &mut IndexMap<String, Vec<JsExpr>>,
 ) {
+    let _tf = crate::compiler::phases::phase3_transform::profile::tf_guard(
+        crate::compiler::phases::phase3_transform::profile::TF_BC_ON,
+    );
     // If no expression, mark that component needs props for event bubbling
     // This is handled via build_event_handler which sets needs_props_from_events
 
@@ -1014,6 +1020,9 @@ fn process_spread_attribute(
     props_and_spreads: &mut Vec<PropsEntry>,
     memoizer: &mut crate::compiler::phases::phase3_transform::client::types::Memoizer,
 ) {
+    let _tf = crate::compiler::phases::phase3_transform::profile::tf_guard(
+        crate::compiler::phases::phase3_transform::profile::TF_BC_SPREAD,
+    );
     let expression = convert_expression(&spread.expression, context);
 
     // Check if the expression has reactive state and function calls.
@@ -1083,6 +1092,9 @@ fn process_regular_attribute(
     custom_css_props: &mut Vec<JsObjectMember>,
     memoizer: &mut crate::compiler::phases::phase3_transform::client::types::Memoizer,
 ) {
+    let _tf = crate::compiler::phases::phase3_transform::profile::tf_guard(
+        crate::compiler::phases::phase3_transform::profile::TF_BC_ATTR,
+    );
     // Handle custom CSS properties (--var)
     if attr.name.starts_with("--") {
         // Build the attribute value with potential memoization
@@ -1353,6 +1365,9 @@ fn process_bind_directive<'a>(
     component_name: &str,
     ignored_codes: &[String],
 ) {
+    let _tf = crate::compiler::phases::phase3_transform::profile::tf_guard(
+        crate::compiler::phases::phase3_transform::profile::TF_BC_BIND,
+    );
     // Convert the expression without transforms first
     let raw_expression = convert_expression(&bind.expression, context);
 
@@ -2061,6 +2076,9 @@ fn process_attach_tag(
     context: &mut ComponentContext,
     props_and_spreads: &mut Vec<PropsEntry>,
 ) {
+    let _tf = crate::compiler::phases::phase3_transform::profile::tf_guard(
+        crate::compiler::phases::phase3_transform::profile::TF_BC_ATTACH,
+    );
     let expression = convert_expression(&attach.expression, context);
 
     // Check if expression has reactive state using the proper check.
@@ -2122,6 +2140,9 @@ fn process_snippet_block(
     props_and_spreads: &mut Vec<PropsEntry>,
     serialized_slots: &mut Vec<JsObjectMember>,
 ) {
+    let _tf = crate::compiler::phases::phase3_transform::profile::tf_guard(
+        crate::compiler::phases::phase3_transform::profile::TF_BC_SNIPPET,
+    );
     // Use the snippet_block visitor to generate the full snippet function
     // This properly handles the snippet body, parameters, and placement
     use crate::compiler::phases::phase3_transform::client::visitors::snippet_block::snippet_block;
@@ -2190,6 +2211,9 @@ fn build_slot_function(
     let_names: &[(String, Option<String>)],
     context: &mut ComponentContext,
 ) -> Option<JsExpr> {
+    let _tf = crate::compiler::phases::phase3_transform::profile::tf_guard(
+        crate::compiler::phases::phase3_transform::profile::TF_BC_SLOT_FN,
+    );
     if children.is_empty() {
         return None;
     }
@@ -2885,6 +2909,9 @@ fn build_component_expression(
     component_name: &str,
     context: &mut ComponentContext,
 ) -> JsExpr {
+    let _tf = crate::compiler::phases::phase3_transform::profile::tf_guard(
+        crate::compiler::phases::phase3_transform::profile::TF_BC_COMP_EXPR,
+    );
     match node {
         ComponentNode::Component(_) => {
             // For dynamic component identified by name
@@ -2956,6 +2983,9 @@ fn build_component_call(
     bind_this: Option<&Expression<'_>>,
     context: &mut ComponentContext,
 ) -> JsExpr {
+    let _tf = crate::compiler::phases::phase3_transform::profile::tf_guard(
+        crate::compiler::phases::phase3_transform::profile::TF_BC_COMP_CALL,
+    );
     let callee = if is_component_dynamic {
         b::id(intermediate_name)
     } else {
@@ -3028,6 +3058,9 @@ fn build_with_css_props(
     bind_this: Option<&Expression>,
     component_start: u32,
 ) {
+    let _tf = crate::compiler::phases::phase3_transform::profile::tf_guard(
+        crate::compiler::phases::phase3_transform::profile::TF_BC_CSS_PROPS,
+    );
     // Determine wrapper element based on namespace
     let is_svg = context.state.metadata.namespace == "svg";
     let wrapper_element = if is_svg { "g" } else { "svelte-css-wrapper" };
@@ -3103,6 +3136,9 @@ fn build_props_expression(
     arena: &crate::compiler::phases::phase3_transform::js_ast::arena::JsArena,
     props_and_spreads: Vec<PropsEntry>,
 ) -> JsExpr {
+    let _tf = crate::compiler::phases::phase3_transform::profile::tf_guard(
+        crate::compiler::phases::phase3_transform::profile::TF_BC_PROPS,
+    );
     if props_and_spreads.is_empty() {
         return b::object(vec![]);
     }
@@ -3168,6 +3204,9 @@ fn build_component_meta_stmt(
     dev: bool,
     source: &str,
 ) -> JsStatement {
+    let _tf = crate::compiler::phases::phase3_transform::profile::tf_guard(
+        crate::compiler::phases::phase3_transform::profile::TF_BC_META,
+    );
     if !dev {
         return b::stmt(arena, expression);
     }

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/profile.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/profile.rs
@@ -759,7 +759,7 @@ pub fn take_pa_breakdown() -> PaBreakdown {
     PaBreakdown::default()
 }
 
-pub const TF_KINDS: [&str; 27] = [
+pub const TF_KINDS: [&str; 40] = [
     "component",
     "svelte_component",
     "svelte_self",
@@ -787,20 +787,59 @@ pub const TF_KINDS: [&str; 27] = [
     "svelte_fragment",
     "slot_element",
     "other",
+    // Stages inside `build_component`. Self time, like the rows above, so they
+    // are subtracted from the `component` row rather than added beside it.
+    "bc:let_directive",
+    "bc:on_directive",
+    "bc:spread_attribute",
+    "bc:regular_attribute",
+    "bc:bind_directive",
+    "bc:attach_tag",
+    "bc:snippet_block",
+    "bc:slot_function",
+    "bc:props_expression",
+    "bc:component_expression",
+    "bc:component_call",
+    "bc:css_props",
+    "bc:meta_stmt",
 ];
+
+pub const TF_BC_LET: usize = 27;
+pub const TF_BC_ON: usize = 28;
+pub const TF_BC_SPREAD: usize = 29;
+pub const TF_BC_ATTR: usize = 30;
+pub const TF_BC_BIND: usize = 31;
+pub const TF_BC_ATTACH: usize = 32;
+pub const TF_BC_SNIPPET: usize = 33;
+pub const TF_BC_SLOT_FN: usize = 34;
+pub const TF_BC_PROPS: usize = 35;
+pub const TF_BC_COMP_EXPR: usize = 36;
+pub const TF_BC_COMP_CALL: usize = 37;
+pub const TF_BC_CSS_PROPS: usize = 38;
+pub const TF_BC_META: usize = 39;
 
 /// Self time and call count per template node kind, drained together with the
 /// `template_fragment` parent they are compared against.
-#[derive(Default, Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy)]
 pub struct TfBreakdown {
     pub time: [Duration; TF_KINDS.len()],
     pub calls: [u64; TF_KINDS.len()],
 }
 
+// `Default` is only derivable for arrays up to 32 entries.
+impl Default for TfBreakdown {
+    fn default() -> Self {
+        Self {
+            time: [Duration::ZERO; TF_KINDS.len()],
+            calls: [0; TF_KINDS.len()],
+        }
+    }
+}
+
 #[cfg(feature = "measure-tf-split")]
 thread_local! {
-    static TF_TIME: [Cell<u64>; TF_KINDS.len()] = Default::default();
-    static TF_CALLS: [Cell<u64>; TF_KINDS.len()] = Default::default();
+    static TF_TIME: [Cell<u64>; TF_KINDS.len()] = const { [const { Cell::new(0) }; TF_KINDS.len()] };
+    static TF_CALLS: [Cell<u64>; TF_KINDS.len()] = const { [const { Cell::new(0) }; TF_KINDS.len()] };
     /// Time the frames below the open one have already claimed. The visitor is
     /// recursive, so an inclusive timer would charge an element for everything
     /// inside it; each frame subtracts what its children took.


### PR DESCRIPTION
Stacked on #2674 — review that one first; this adds only the second level.

#2674 found that `component` is the largest row of the template-fragment bucket
on every shipping corpus (38–68%). It is one 675-line function, so the row named
a target without locating it. These guards split it, reusing #2674's accumulator
so the stages are **subtracted from** `component` rather than added beside it and
Σ-against-parent still holds.

Per-corpus, min over 5 runs, share of the `Template fragment` parent:

| corpus | `bc:slot_function` | `bc:regular_attribute` | `component` (rest) | `regular_element` |
|---|---|---|---|---|
| bits-ui | 12.3% (2,135) | 8.2% (3,946) | 9.6% (2,788) | 23.6% (1,412) |
| flowbite-svelte | 17.1% (4,656) | **20.6%** (10,264) | 10.2% (6,801) | 24.8% (2,802) |
| shadcn-svelte | **29.9%** (12,165) | 9.6% (16,915) | 20.3% (16,432) | 14.1% (2,487) |
| layercake | 4.1% (255) | **28.4%** (1,075) | 4.8% (479) | 37.2% (586) |

`component`'s share was **not** one hot spot. It is `build_slot_function` plus
`process_regular_attribute` plus a residual body, and which of the two leads
depends on the corpus — slots on shadcn/bits-ui, attributes on flowbite/
layercake. The other eleven stages are each under 6% everywhere;
`bc:props_expression` runs once per component (16,432 calls on shadcn) for 1.1%.

Per call the two differ in kind, which is the part worth carrying forward:
`bc:slot_function` costs 1.5–1.7 µs and is called once per slot;
`bc:regular_attribute` costs 0.4–2.2 µs — a 5× spread across corpora at the
same call site, which is a question this instrument raises and does not answer.

Same caveats as #2674: the machine was not quiet, absolute ms are not comparable
to the clean phase table, and the fixtures corpus inverts the ordering.
