### PR TITLE
docs(site): reach the sub-navigation on mobile, and cover the shipped toolchain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
     # repo-root lockfile) used to surface only after merge. Gate it here so a
     # package.json bump without a lockfile update goes red on the PR instead.
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -69,7 +69,19 @@ jobs:
 
       - name: Check playground lockfile is in sync
         working-directory: apps/playground
-        run: pnpm install --frozen-lockfile --lockfile-only
+        run: pnpm install --frozen-lockfile
+
+      # `GUIDES` is a `Record<ToolId, Guide>`, so a package added to the tool
+      # switcher without a docs page is a type error rather than a 404 nobody
+      # notices. Nothing else type-checks the site on a PR — the full project
+      # check needs the wasm packages built — so these two files, which import
+      # only each other, are checked standalone.
+      - name: Check the docs metadata is exhaustive
+        working-directory: apps/playground
+        run: >
+          ./node_modules/.bin/tsc --ignoreConfig --noEmit --strict
+          --target es2022 --module esnext --moduleResolution bundler --lib es2023
+          src/lib/docs.ts src/lib/tools.ts
 
   lint-types-lock:
     name: Lint-types lockfile

--- a/apps/playground/src/lib/components/DocsShell.svelte
+++ b/apps/playground/src/lib/components/DocsShell.svelte
@@ -1,0 +1,54 @@
+<script lang="ts">
+	import type { Snippet } from 'svelte';
+	import DocsSidebar from '$lib/components/DocsSidebar.svelte';
+	import DocsToc from '$lib/components/DocsToc.svelte';
+
+	interface Props {
+		/** Sidebar entry to mark as current. */
+		current: string;
+		toc: { label: string; href: string }[];
+		children: Snippet;
+	}
+
+	let { current, toc, children }: Props = $props();
+</script>
+
+<div class="docs-shell">
+	<DocsSidebar {current} />
+	{@render children()}
+	<DocsToc items={toc} />
+</div>
+
+<style>
+	/* Placement is by area name, so the DOM order (nav, article, toc) can stay
+	   the reading order while the narrow layouts move the two navs around it. */
+	.docs-shell {
+		flex: 1;
+		width: 100%;
+		max-width: 1440px;
+		margin: 0 auto;
+		display: grid;
+		grid-template-columns: 230px minmax(0, 52rem) 200px;
+		grid-template-areas: 'nav main toc';
+		justify-content: center;
+	}
+
+	@media (max-width: 1120px) {
+		.docs-shell {
+			grid-template-columns: 230px minmax(0, 1fr);
+			grid-template-areas:
+				'nav toc'
+				'nav main';
+		}
+	}
+
+	@media (max-width: 860px) {
+		.docs-shell {
+			grid-template-columns: minmax(0, 1fr);
+			grid-template-areas:
+				'nav'
+				'toc'
+				'main';
+		}
+	}
+</style>

--- a/apps/playground/src/lib/components/DocsSidebar.svelte
+++ b/apps/playground/src/lib/components/DocsSidebar.svelte
@@ -1,16 +1,30 @@
 <script lang="ts">
 	import { base } from '$app/paths';
-	import { GUIDES } from '$lib/docs';
+	import { GUIDE_LIST } from '$lib/docs';
 
 	interface Props {
 		current?: string;
 	}
 
 	let { current = '' }: Props = $props();
+	let open = $state(false);
 </script>
 
 <aside class="sidebar">
-	<nav aria-label="Documentation navigation">
+	<button
+		type="button"
+		class="disclosure"
+		aria-expanded={open}
+		aria-controls="docs-nav"
+		onclick={() => (open = !open)}
+	>
+		<span>Documentation menu</span>
+		<svg viewBox="0 0 16 16" width="14" height="14" aria-hidden="true" class:flip={open}>
+			<path d="m4 6 4 4 4-4" fill="none" stroke="currentColor" stroke-width="1.5" />
+		</svg>
+	</button>
+
+	<nav id="docs-nav" class:open aria-label="Documentation navigation">
 		<div class="group">
 			<p>Getting started</p>
 			<a class:current={current === 'introduction'} href="{base}/">Introduction</a>
@@ -19,7 +33,7 @@
 
 		<div class="group">
 			<p>Toolchain</p>
-			{#each GUIDES as guide (guide.id)}
+			{#each GUIDE_LIST as guide (guide.id)}
 				<a class:current={current === guide.id} href="{base}/docs/{guide.id}">{guide.title}</a>
 			{/each}
 		</div>
@@ -35,6 +49,7 @@
 
 <style>
 	.sidebar {
+		grid-area: nav;
 		padding: 2rem 1.25rem 4rem 1rem;
 		border-right: 1px solid var(--rule);
 	}
@@ -79,9 +94,52 @@
 		font-weight: 600;
 	}
 
+	.disclosure {
+		display: none;
+		width: 100%;
+		align-items: center;
+		justify-content: space-between;
+		gap: 0.5rem;
+		padding: 0.6rem 0.75rem;
+		border: 1px solid var(--rule);
+		border-radius: 6px;
+		background: var(--paper);
+		font-family: inherit;
+		font-size: 0.86rem;
+		font-weight: 600;
+		color: var(--ink);
+		cursor: pointer;
+	}
+
+	.disclosure svg {
+		flex: none;
+		transition: transform 0.15s ease;
+	}
+
+	.disclosure svg.flip {
+		transform: rotate(180deg);
+	}
+
 	@media (max-width: 860px) {
 		.sidebar {
+			padding: 1rem clamp(1rem, 5vw, 2.5rem);
+			border-right: 0;
+			border-bottom: 1px solid var(--rule);
+		}
+
+		.disclosure {
+			display: flex;
+		}
+
+		nav {
 			display: none;
+			position: static;
+			gap: 1.25rem;
+			padding-top: 1rem;
+		}
+
+		nav.open {
+			display: flex;
 		}
 	}
 </style>

--- a/apps/playground/src/lib/components/DocsToc.svelte
+++ b/apps/playground/src/lib/components/DocsToc.svelte
@@ -9,19 +9,34 @@
 	}
 
 	let { items }: Props = $props();
+	let open = $state(false);
 </script>
 
 <aside class="toc">
-	<nav aria-label="On this page">
+	<button
+		type="button"
+		class="disclosure"
+		aria-expanded={open}
+		aria-controls="page-toc"
+		onclick={() => (open = !open)}
+	>
+		<span>On this page</span>
+		<svg viewBox="0 0 16 16" width="14" height="14" aria-hidden="true" class:flip={open}>
+			<path d="m4 6 4 4 4-4" fill="none" stroke="currentColor" stroke-width="1.5" />
+		</svg>
+	</button>
+
+	<nav id="page-toc" class:open aria-label="On this page">
 		<p>On this page</p>
 		{#each items as item (item.href)}
-			<a href={item.href}>{item.label}</a>
+			<a href={item.href} onclick={() => (open = false)}>{item.label}</a>
 		{/each}
 	</nav>
 </aside>
 
 <style>
 	.toc {
+		grid-area: toc;
 		padding: 2rem 1rem 3rem 1.5rem;
 		border-left: 1px solid var(--rule);
 	}
@@ -52,9 +67,61 @@
 		color: var(--accent);
 	}
 
+	.disclosure {
+		display: none;
+		width: 100%;
+		align-items: center;
+		justify-content: space-between;
+		gap: 0.5rem;
+		padding: 0.6rem 0.75rem;
+		border: 1px solid var(--rule);
+		border-radius: 6px;
+		background: var(--paper);
+		font-family: inherit;
+		font-size: 0.86rem;
+		font-weight: 600;
+		color: var(--ink);
+		cursor: pointer;
+	}
+
+	.disclosure svg {
+		flex: none;
+		transition: transform 0.15s ease;
+	}
+
+	.disclosure svg.flip {
+		transform: rotate(180deg);
+	}
+
+	/* Below the three-column breakpoint the table of contents moves under the
+	   article head, so the heading it duplicates is the disclosure label. */
 	@media (max-width: 1120px) {
 		.toc {
+			padding: 1.5rem clamp(1rem, 5vw, 2.5rem) 0;
+			border-left: 0;
+		}
+
+		.disclosure {
+			display: flex;
+		}
+
+		nav {
 			display: none;
+			position: static;
+			padding-top: 0.75rem;
+		}
+
+		nav.open {
+			display: flex;
+		}
+
+		nav p {
+			display: none;
+		}
+
+		nav a {
+			padding: 0.3rem 0;
+			font-size: 0.86rem;
 		}
 	}
 </style>

--- a/apps/playground/src/lib/components/Guide.svelte
+++ b/apps/playground/src/lib/components/Guide.svelte
@@ -1,8 +1,7 @@
 <script lang="ts">
 	import { base } from '$app/paths';
-	import { GUIDES, type Guide } from '$lib/docs';
-	import DocsSidebar from '$lib/components/DocsSidebar.svelte';
-	import DocsToc from '$lib/components/DocsToc.svelte';
+	import { GUIDE_LIST, type Guide } from '$lib/docs';
+	import DocsShell from '$lib/components/DocsShell.svelte';
 	import SiteNav from '$lib/components/SiteNav.svelte';
 	import SiteFooter from '$lib/components/SiteFooter.svelte';
 	import CodeBlock from '$lib/components/CodeBlock.svelte';
@@ -20,9 +19,11 @@
 			.replace(/[^a-z0-9]+/g, '-')
 			.replace(/(^-|-$)/g, '');
 
-	const guideIndex = $derived(GUIDES.findIndex((item) => item.id === guide.id));
-	const previousGuide = $derived(guideIndex > 0 ? GUIDES[guideIndex - 1] : null);
-	const nextGuide = $derived(guideIndex < GUIDES.length - 1 ? GUIDES[guideIndex + 1] : null);
+	const guideIndex = $derived(GUIDE_LIST.findIndex((item) => item.id === guide.id));
+	const previousGuide = $derived(guideIndex > 0 ? GUIDE_LIST[guideIndex - 1] : null);
+	const nextGuide = $derived(
+		guideIndex < GUIDE_LIST.length - 1 ? GUIDE_LIST[guideIndex + 1] : null,
+	);
 	const toc = $derived(
 		guide.sections.map((section) => ({
 			label: section.title,
@@ -34,9 +35,7 @@
 <div class="page">
 	<SiteNav active="docs" />
 
-	<div class="docs-shell">
-		<DocsSidebar current={guide.id} />
-
+	<DocsShell current={guide.id} {toc}>
 		<main class="wrap">
 			<nav class="crumbs" aria-label="Breadcrumb">
 				<a href="{base}/docs">Docs</a>
@@ -151,9 +150,7 @@
 				{/if}
 			</nav>
 		</main>
-
-		<DocsToc items={toc} />
-	</div>
+	</DocsShell>
 
 	<SiteFooter />
 </div>
@@ -165,17 +162,8 @@
 		flex-direction: column;
 	}
 
-	.docs-shell {
-		flex: 1;
-		width: 100%;
-		max-width: 1440px;
-		margin: 0 auto;
-		display: grid;
-		grid-template-columns: 230px minmax(0, 52rem) 200px;
-		justify-content: center;
-	}
-
 	.wrap {
+		grid-area: main;
 		width: 100%;
 		min-width: 0;
 		padding: 3.5rem clamp(2rem, 5vw, 4rem) 5rem;
@@ -400,17 +388,9 @@
 		color: var(--accent);
 	}
 
-	@media (max-width: 1120px) {
-		.docs-shell {
-			grid-template-columns: 230px minmax(0, 1fr);
-		}
-	}
-
-	@media (max-width: 800px) {
-		.docs-shell {
-			grid-template-columns: 1fr;
-		}
+	@media (max-width: 860px) {
 		.wrap {
+			padding-top: 2rem;
 			padding-inline: clamp(1rem, 5vw, 2.5rem);
 		}
 	}

--- a/apps/playground/src/lib/docs.ts
+++ b/apps/playground/src/lib/docs.ts
@@ -2,8 +2,11 @@
 // per shipped package, keyed by the same slug as `tools.ts` and the
 // `/docs/[slug]` route. Keep prose terse and code copy-pasteable; these are
 // drop-in replacements, so the APIs mirror the upstream tools they replace.
+//
+// `GUIDES` is a `Record<ToolId, Guide>`, so a tool added to `tools.ts` without
+// a page here fails to type-check instead of 404ing at `/docs/<slug>`.
 
-import { type ToolId } from './tools';
+import { TOOLS, type ToolId } from './tools';
 
 export interface GuideCode {
 	lang: string;
@@ -30,6 +33,8 @@ export interface Guide {
 	pkg: string;
 	dropInFor: string;
 	tagline: string;
+	/** One line for the "choosing a package" table on the overview page. */
+	useFor: string;
 	/** Install command. */
 	install: string;
 	/** Whether the playground can run this tool in-browser. */
@@ -44,6 +49,7 @@ const compiler: Guide = {
 	dropInFor: 'svelte/compiler',
 	tagline:
 		'The whole compile pipeline — parse, analyze, transform — for client, SSR and hydration, with output that matches the official compiler across the in-scope test suite.',
+	useFor: 'Compile Svelte components for client and server.',
 	install: 'pnpm add @rsvelte/compiler',
 	runnable: true,
 	sections: [
@@ -78,11 +84,17 @@ const ast = JSON.parse(parse_svelte(source).ast);
 			}
 		},
 		{
+			title: 'Node, not the browser',
+			body: [
+				'The same compiler core also ships as a native NAPI addon inside `@rsvelte/vite-plugin-svelte-native`, with the `svelte/compiler` surface (`compile`, `compileModule`, `parse`, `preprocess`, `walk`). The Vite plugin uses it; reach for it directly when you are writing your own build step.'
+			]
+		},
+		{
 			title: 'Why it is fast',
 			list: [
-				'Written in Rust — the same core also ships as a native NAPI addon (`@rsvelte/vite-plugin-svelte-native`) with the exact `svelte/compiler` surface.',
-				'Memory-efficient AST (u32 spans, compact strings) and direct phase-to-phase AST passing.',
-				'Parser alone runs ~113× the JavaScript parser; the full pipeline ~13×.'
+				'Written in Rust, with a memory-efficient AST (u32 spans, compact strings) and direct phase-to-phase AST passing — no re-parse between phases.',
+				'The parser and the whole pipeline are parallel over files, so a project build scales with cores.',
+				'Numbers move with every release, so they live on the benchmark page rather than in this prose — it is regenerated from a recorded run.'
 			]
 		}
 	]
@@ -95,6 +107,7 @@ const svelte2tsx: Guide = {
 	dropInFor: 'svelte2tsx',
 	tagline:
 		'Turns a .svelte component into the TSX shadow file the TypeScript checker reads, with column-accurate source maps.',
+	useFor: 'Generate TypeScript shadow files from Svelte components.',
 	install: 'pnpm add @rsvelte/svelte2tsx',
 	runnable: true,
 	sections: [
@@ -145,19 +158,26 @@ const fmt: Guide = {
 	pkg: '@rsvelte/fmt',
 	dropInFor: 'prettier-plugin-svelte',
 	tagline:
-		'A Rust-native formatter for .svelte files — in-process, with no Node startup and no Prettier doc-IR round-trip. JS / TS go through oxc_formatter; CSS routes to oxfmt.',
+		'A Rust-native formatter for .svelte files — in-process, with no Node startup and no Prettier doc-IR round-trip. Embedded JS / TS / CSS go through the same oxc engines oxfmt uses.',
+	useFor: 'Format .svelte files, and the JS / TS / CSS / JSON around them.',
 	install: 'pnpm add -D @rsvelte/fmt',
 	runnable: true,
 	sections: [
 		{
 			title: 'Format files',
+			body: [
+				'`.svelte` files are formatted in process. Any other path is handed to `oxfmt`, so a directory covers the whole set it formats — `.ts` / `.js` / `.css` / `.json`, and `.md` / `.yaml` / `.toml` / `.html` too. With no path at all, the current directory is formatted.'
+			],
 			code: {
 				lang: 'bash',
 				code: `# Check formatting (non-zero exit if any file would change)
 rsvelte-fmt --check "src/**/*.svelte"
 
 # Rewrite files in place
-rsvelte-fmt --write "src/**/*.svelte"`
+rsvelte-fmt --write src
+
+# Format a buffer from an editor
+rsvelte-fmt --stdin --stdin-filepath src/App.svelte < App.svelte`
 			}
 		},
 		{
@@ -166,17 +186,20 @@ rsvelte-fmt --write "src/**/*.svelte"`
 				head: ['Flag', 'Default', 'Meaning'],
 				rows: [
 					['--check', '—', 'Exit non-zero if any file is unformatted'],
-					['--write', '—', 'Rewrite files in place'],
+					['--write', '—', 'Rewrite files in place (implied for a directory)'],
+					['--stdin --stdin-filepath <path>', '—', 'Format stdin; the path picks the engine'],
+					['-c, --config <path>', 'discovered', 'Explicit `.oxfmtrc`; otherwise found upward'],
+					['--print-width <n>', '80', 'Target line width'],
+					['--tab-width <n>', '2', 'Spaces per indent level'],
 					['--use-tabs', 'false', 'Indent with tabs instead of spaces'],
-					['--tab-width', '2', 'Spaces per indent level'],
-					['--print-width', '80', 'Target line width']
+					['--no-native-js / --no-native-css', 'false', 'Delegate JS / CSS back to an `oxfmt` subprocess']
 				]
 			}
 		},
 		{
 			title: 'Configuration',
 			body: [
-				'JS / TS keys (quotes, semicolons, trailing commas, …) are read from an `.oxfmtrc` so inline `<script>` blocks format identically to standalone files.'
+				'JS / TS keys (quotes, semicolons, trailing commas, …) are read from an `.oxfmtrc` so inline `<script>` blocks format identically to standalone files. The nearest `.oxfmtrc.json` / `.oxfmtrc.jsonc` is discovered upward from the working directory, matching oxfmt.'
 			],
 			code: {
 				lang: 'json',
@@ -190,9 +213,96 @@ rsvelte-fmt --write "src/**/*.svelte"`
 			}
 		},
 		{
-			title: 'In the browser',
+			title: 'CSS is formatted in process too',
 			body: [
-				'The playground runs the formatter on WebAssembly. `<style>` bodies are left verbatim there — CSS formatting needs the native `oxfmt` subprocess, which the CLI uses but a browser cannot spawn.'
+				'Embedded `<style>` blocks and standalone `.css` / `.scss` / `.less` files go through the Rust `oxc_formatter_css` crate — the same engine `oxfmt` runs, byte-identical, without a subprocess. That is why the playground can format a full component in the browser, `<style>` included. `--no-native-css` reverts to the old `oxfmt`-subprocess path if a divergence is ever found.'
+			]
+		},
+		{
+			title: 'Embedding it',
+			body: [
+				'`rsvelte_fmt::FormatSession` is the CLI pipeline — config discovery, option layering, extension dispatch — exposed as a library, so an editor integration resolves a buffer exactly the way `rsvelte-fmt --stdin --stdin-filepath` would. The language server uses it.'
+			]
+		}
+	]
+};
+
+const lint: Guide = {
+	id: 'lint',
+	title: 'lint',
+	pkg: '@rsvelte/lint',
+	dropInFor: 'eslint-plugin-svelte',
+	tagline:
+		"A native Svelte linter built on the compiler itself — no second ESTree parse, no Node in the hot path. The compiler's own validator and a11y diagnostics and the ported eslint-plugin-svelte rules run in one shared AST walk.",
+	useFor: 'Lint .svelte components and .svelte.js/.ts modules.',
+	install: 'pnpm add -D @rsvelte/lint',
+	runnable: true,
+	sections: [
+		{
+			title: 'Lint a project',
+			code: {
+				lang: 'bash',
+				code: `npx rsvelte-lint src/                 # recurse a directory
+npx rsvelte-lint src/App.svelte       # a single file
+npx rsvelte-lint --fix src/           # apply autofixes in place
+npx rsvelte-lint --format sarif src/  # SARIF for CI code scanning
+npx rsvelte-lint --list-rules         # every rule + default severity`
+			}
+		},
+		{
+			title: 'Flags',
+			table: {
+				head: ['Flag', 'Meaning'],
+				rows: [
+					['--format <f>', 'human | human-verbose | machine | machine-verbose | github-actions | sarif'],
+					['--config <file>', '`rsvelte-lint.json`; discovered upward when omitted'],
+					['--config-from-eslint <file>', 'Import `svelte/*` severities from an ESLint flat config'],
+					['--off <rule> / --error <rule>', 'Override one rule (repeatable)'],
+					['--fix', 'Apply autofixes in place before reporting'],
+					['--max-warnings <n>', 'Exit non-zero above this many warnings'],
+					['--list-rules', 'Print the native rule set and exit'],
+					['--print-eslint-config', 'Print a flat-config snippet disabling the rules this owns']
+				]
+			}
+		},
+		{
+			title: 'Configuration',
+			body: [
+				'Severities and rule options come from a `rsvelte-lint.json` (or `.rsvelte-lintrc.json`), found by walking up from the file being linted. With no config every rule runs at its default severity — the `recommended` preset. Use `"extends": ["none"]` to start from nothing and opt in.'
+			],
+			code: {
+				lang: 'json',
+				caption: 'rsvelte-lint.json',
+				code: `{
+  "extends": ["recommended"],
+  "rules": {
+    "svelte/no-at-html-tags": "error",
+    "svelte/no-unused-class-name": "off",
+    "svelte/button-has-type": ["warn", { "submit": true, "reset": false }]
+  }
+}`
+			}
+		},
+		{
+			title: 'Running it inside oxlint',
+			body: [
+				'`@rsvelte/oxlint-plugin` exposes the same rules as oxlint rules, so JS / TS and Svelte diagnostics come out of a single pass and a single report. It loads the native addon where one exists and falls back to the WebAssembly engine everywhere else, with identical output.'
+			],
+			code: {
+				lang: 'json',
+				caption: '.oxlintrc.json',
+				code: `{
+  "jsPlugins": ["@rsvelte/oxlint-plugin"],
+  "extends": ["./node_modules/@rsvelte/oxlint-plugin/recommended.json"]
+}`
+			}
+		},
+		{
+			title: 'Notes',
+			list: [
+				"All 80 upstream `eslint-plugin-svelte` rules are ported and checked against the plugin's own fixtures.",
+				"The compiler's ~70 warning codes, ~145 error codes and 42 `a11y_*` rules surface as diagnostics from the same run.",
+				'This is the engine behind the language server’s editor diagnostics.'
 			]
 		}
 	]
@@ -204,7 +314,8 @@ const svelteCheck: Guide = {
 	pkg: '@rsvelte/svelte-check',
 	dropInFor: 'svelte-check',
 	tagline:
-		'The project type-checker CLI. A Rust walker + svelte2tsx overlay drives tsc — or Microsoft\'s native tsgo with --tsgo — for the TypeScript half; diagnostics map back to .svelte positions. Watch + incremental cache included.',
+		'The project type-checker CLI. A Rust walker + svelte2tsx overlay drives tsc — or the TypeScript 7 native compiler with --tsgo — for the TypeScript half; diagnostics map back to .svelte positions. Watch + incremental cache included.',
+	useFor: 'Type-check Svelte projects from the command line.',
 	install: 'pnpm add -D @rsvelte/svelte-check',
 	runnable: false,
 	sections: [
@@ -215,7 +326,7 @@ const svelteCheck: Guide = {
 				code: `# Type-check the current project
 rsvelte-check
 
-# Prefer the native tsgo backend (faster than tsc)
+# Use the TypeScript 7 native compiler
 rsvelte-check --tsgo
 
 # Point at a workspace folder and tsconfig
@@ -232,19 +343,33 @@ rsvelte-check --watch --incremental`
 				rows: [
 					['--workspace <dir>', 'Root folder to discover `.svelte` files under'],
 					['--tsconfig <path>', 'tsconfig the generated overlay should extend'],
-					['--tsgo', 'Prefer the native tsgo backend over tsc'],
+					['--no-tsconfig', 'Ignore any project tsconfig/jsconfig entirely'],
+					['--config <path>', 'A `svelte.config.*` / `vite.config.*` under a non-standard name'],
+					['--tsgo', 'Type-check with the TypeScript 7 native compiler'],
 					['--no-type-check', 'Svelte diagnostics only, skip TypeScript'],
+					['--diagnostic-sources <list>', 'Any subset of `svelte`, `ts`/`js`, `css`'],
+					['--compiler-warnings <list>', '`code:error|ignore` overrides, comma-separated'],
+					['--threshold <level>', '`warning` (default) or `error` — filters printing, not counts'],
+					['--ignore <list>', 'Path components to skip while walking'],
 					['--watch', 'Watch and re-check on change'],
 					['--incremental', 'Reuse the cached overlay between runs'],
 					['--fail-on-warnings', 'Exit non-zero when warnings exist'],
-					['--output <format>', 'Reporter: human | human-verbose | machine | machine-verbose']
+					['--emit-overlay', 'Keep the generated `.tsx` overlay on disk for inspection'],
+					['--output <format>', 'human | human-verbose | machine | machine-verbose | github-actions']
 				]
 			}
 		},
 		{
+			title: 'Reading project config',
+			body: [
+				'The diagnostic-relevant `compilerOptions` are read statically from `svelte.config.*` and from a `svelte()` / `sveltekit()` plugin call in `vite.config.*`, merged the way vite-plugin-svelte merges them. That is what keeps `experimental.async` projects from being told their top-level `await` is an error.',
+				'`--config` names one of those files under a non-standard name or location. A file named `svelte.config.*` is read as a Svelte config; anything else is read as a Vite config when it actually declares a Svelte plugin, matching upstream `load-config`.'
+			]
+		},
+		{
 			title: 'Why it cannot run in the playground',
 			body: [
-				'svelte-check type-checks an entire project through a native TypeScript backend (`tsc` or `tsgo`), which cannot run in a browser. The Rust walker discovers files, generates a TSX overlay per component, runs the type-checker, then maps diagnostics back to `.svelte` positions — none of which works in a browser sandbox. Run the CLI in your project instead.'
+				'svelte-check type-checks an entire project through a native TypeScript backend (`tsc` or the TypeScript 7 native compiler), which cannot run in a browser. The Rust walker discovers files, generates a TSX overlay per component, runs the type-checker, then maps diagnostics back to `.svelte` positions — none of which works in a browser sandbox. Run the CLI in your project instead.'
 			]
 		},
 		{
@@ -252,7 +377,60 @@ rsvelte-check --watch --incremental`
 			list: [
 				'Incremental cache (incl. a per-file warning cache) keeps re-checks fast.',
 				'Parallel compile + hi-res svelte2tsx source maps for column-accurate diagnostics.',
-				'SvelteKit generated kit-files are augmented so `$app/*` / route types resolve.'
+				'SvelteKit generated kit-files are augmented so `$app/*` / route types resolve.',
+				'`--tsgo` is a hard error when TypeScript 7 is not installed, never a silent downgrade to `tsc`.'
+			]
+		}
+	]
+};
+
+const languageServer: Guide = {
+	id: 'language-server',
+	title: 'language-server',
+	pkg: '@rsvelte/language-server',
+	dropInFor: 'svelte-language-server',
+	tagline:
+		'An LSP server that answers everything the Svelte AST alone can answer — diagnostics, formatting, completions, hover, quick fixes, folding and symbols — from the Rust core, in process.',
+	useFor: 'Power editor diagnostics, formatting and completions over LSP.',
+	install: 'pnpm add -D @rsvelte/language-server',
+	runnable: false,
+	sections: [
+		{
+			title: 'What it answers',
+			list: [
+				'`textDocument/publishDiagnostics` — the `rsvelte_lint` engine, on open, on change (debounced) and on save.',
+				'`textDocument/formatting` — the `rsvelte-fmt` pipeline in process, no subprocess.',
+				'`textDocument/completion` and `hover` — template tags and event modifiers.',
+				'`textDocument/codeAction` — quick fixes for the diagnostics it reports.',
+				'`foldingRange`, `selectionRange` and `documentSymbol` — the structure the Svelte AST describes.'
+			]
+		},
+		{
+			title: 'Wire it into an editor',
+			body: [
+				'The binary speaks LSP over stdio, so any client can launch it. In VS Code, install the `rsvelte` extension instead — it bundles the server, a TextMate grammar and the `svelte.*` settings.'
+			],
+			code: {
+				lang: 'bash',
+				code: `# Neovim, Helix, Emacs, … — launch over stdio
+rsvelte-language-server`
+			}
+		},
+		{
+			title: 'Settings',
+			table: {
+				head: ['Key', 'Default', 'Meaning'],
+				rows: [
+					['rsvelte.format.enable', 'true', 'Enable formatting'],
+					['rsvelte.lint.enable', 'true', 'Enable diagnostics'],
+					['rsvelte.rsvelteFmtPath', '""', 'Explicit `rsvelte-fmt` binary path']
+				]
+			}
+		},
+		{
+			title: 'What it does not answer yet',
+			body: [
+				'TypeScript-backed features — go-to-definition, rename, find-references and type errors — are not served yet. The design is to proxy a child tsgo LSP over the same `.svelte` → virtual `.tsx` overlay `svelte-check` uses; until that lands, run `@rsvelte/svelte-check` as a batch type-checker.'
 			]
 		}
 	]
@@ -265,12 +443,15 @@ const vitePlugin: Guide = {
 	dropInFor: '@sveltejs/vite-plugin-svelte',
 	tagline:
 		'A fork of the Vite plugin whose every transform / HMR / preprocess call routes through the rsvelte compiler over NAPI. Your vite.config.js does not change.',
+	useFor: 'Compile Svelte applications with Vite.',
 	install: 'pnpm add -D @rsvelte/vite-plugin-svelte',
 	runnable: false,
 	sections: [
 		{
 			title: 'Use it in vite.config',
-			body: ['Swap the import — the plugin API matches upstream, so the rest of your config is unchanged.'],
+			body: [
+				'Swap the import — the plugin API matches upstream, so the rest of your config is unchanged. Vite 6, 7 and 8 are supported.'
+			],
 			code: {
 				lang: 'js',
 				caption: 'vite.config.js',
@@ -298,6 +479,19 @@ export default defineConfig({
 	]
 };
 
-export const GUIDES: Guide[] = [compiler, svelte2tsx, fmt, svelteCheck, vitePlugin];
+/** Every tool in `tools.ts` must have a page; the `Record` is what enforces it. */
+export const GUIDES: Record<ToolId, Guide> = {
+	compiler,
+	svelte2tsx,
+	fmt,
+	lint,
+	'svelte-check': svelteCheck,
+	'language-server': languageServer,
+	'vite-plugin-svelte': vitePlugin
+};
 
-export const guideById = (id: string): Guide | undefined => GUIDES.find((g) => g.id === id);
+/** Guides in the order the toolchain is presented, i.e. `TOOLS` order. */
+export const GUIDE_LIST: Guide[] = TOOLS.map((tool) => GUIDES[tool.id]);
+
+export const guideById = (id: string): Guide | undefined =>
+	Object.hasOwn(GUIDES, id) ? GUIDES[id as ToolId] : undefined;

--- a/apps/playground/src/lib/tools.ts
+++ b/apps/playground/src/lib/tools.ts
@@ -2,10 +2,11 @@
 // guides (`/docs`) and the multi-tool playground (`/playground?tool=…`).
 //
 // `runnable` marks the tools that can execute entirely in the browser on
-// WebAssembly. The two that can't — svelte-check (drives the native `tsgo`
-// type-checker) and vite-plugin-svelte (needs a running Vite / Node dev
-// server) — still get a playground entry, but it explains the limitation
-// and links the guide instead of running.
+// WebAssembly. The ones that can't — svelte-check (drives a native TypeScript
+// compiler), the language server (speaks LSP to an editor) and
+// vite-plugin-svelte (needs a running Vite / Node dev server) — still get a
+// playground entry, but it explains the limitation and links the guide
+// instead of running.
 
 export type ToolId =
 	| 'compiler'
@@ -13,6 +14,7 @@ export type ToolId =
 	| 'fmt'
 	| 'lint'
 	| 'svelte-check'
+	| 'language-server'
 	| 'vite-plugin-svelte';
 
 export interface Tool {
@@ -55,19 +57,29 @@ export const TOOLS: Tool[] = [
 	{
 		id: 'lint',
 		label: 'lint',
-		pkg: 'rsvelte_lint',
+		pkg: '@rsvelte/lint',
 		tagline:
-			'Lint a .svelte component with the Rust-native linter (compiler warnings + a11y + native rules). Powers the language server; not yet a standalone npm CLI.',
+			'Lint a .svelte component with the Rust-native linter (compiler warnings + a11y + the ported eslint-plugin-svelte rules).',
 		runnable: true
 	},
 	{
 		id: 'svelte-check',
 		label: 'svelte-check',
 		pkg: '@rsvelte/svelte-check',
-		tagline: 'Project type-checker CLI — a Rust walker + overlay driving tsc or the native tsgo.',
+		tagline:
+			'Project type-checker CLI — a Rust walker + overlay driving tsc or the TypeScript 7 native compiler.',
 		runnable: false,
 		cantRunReason:
-			'svelte-check type-checks a whole project through a native TypeScript backend (tsc or tsgo), which cannot run in a browser. Use the CLI; the guide shows how.'
+			'svelte-check type-checks a whole project through a native TypeScript backend (tsc or the TypeScript 7 native compiler), which cannot run in a browser. Use the CLI; the guide shows how.'
+	},
+	{
+		id: 'language-server',
+		label: 'language-server',
+		pkg: '@rsvelte/language-server',
+		tagline: 'LSP server serving diagnostics, formatting, completions and hover from the Rust core.',
+		runnable: false,
+		cantRunReason:
+			'A language server answers LSP requests from an editor over stdio, so there is nothing to run in a browser tab. Point your editor at it; the guide shows how.'
 	},
 	{
 		id: 'vite-plugin-svelte',

--- a/apps/playground/src/routes/+page.svelte
+++ b/apps/playground/src/routes/+page.svelte
@@ -2,10 +2,9 @@
 	import { base } from '$app/paths';
 	import { onMount } from 'svelte';
 	import type { TestResults } from '$lib/types/test-results';
-	import { GUIDES } from '$lib/docs';
+	import { GUIDE_LIST } from '$lib/docs';
 	import CodeBlock from '$lib/components/CodeBlock.svelte';
-	import DocsSidebar from '$lib/components/DocsSidebar.svelte';
-	import DocsToc from '$lib/components/DocsToc.svelte';
+	import DocsShell from '$lib/components/DocsShell.svelte';
 	import SiteFooter from '$lib/components/SiteFooter.svelte';
 	import SiteNav from '$lib/components/SiteNav.svelte';
 
@@ -47,9 +46,7 @@ const result = compile(source, {
 <div class="page">
 	<SiteNav active="docs" />
 
-	<div class="docs-shell">
-		<DocsSidebar current="introduction" />
-
+	<DocsShell current="introduction" {toc}>
 		<main class="article">
 			<nav class="breadcrumbs" aria-label="Breadcrumb">
 				<span>Documentation</span>
@@ -115,7 +112,7 @@ const result = compile(source, {
 							</tr>
 						</thead>
 						<tbody>
-							{#each GUIDES as guide (guide.id)}
+							{#each GUIDE_LIST as guide (guide.id)}
 								<tr>
 									<td>
 										<a href="{base}/docs/{guide.id}">{guide.title}</a>
@@ -156,9 +153,7 @@ const result = compile(source, {
 				</a>
 			</nav>
 		</main>
-
-		<DocsToc items={toc} />
-	</div>
+	</DocsShell>
 
 	<SiteFooter />
 </div>
@@ -170,17 +165,8 @@ const result = compile(source, {
 		flex-direction: column;
 	}
 
-	.docs-shell {
-		flex: 1;
-		width: 100%;
-		max-width: 1440px;
-		margin: 0 auto;
-		display: grid;
-		grid-template-columns: 230px minmax(0, 52rem) 200px;
-		justify-content: center;
-	}
-
 	.article {
+		grid-area: main;
 		min-width: 0;
 		padding: 3rem clamp(2rem, 5vw, 4rem) 5rem;
 	}
@@ -369,18 +355,9 @@ const result = compile(source, {
 		color: var(--accent);
 	}
 
-	@media (max-width: 1120px) {
-		.docs-shell {
-			grid-template-columns: 230px minmax(0, 1fr);
-		}
-	}
-
 	@media (max-width: 860px) {
-		.docs-shell {
-			grid-template-columns: 1fr;
-		}
-
 		.article {
+			padding-top: 2rem;
 			padding-inline: clamp(1rem, 5vw, 2.5rem);
 		}
 	}

--- a/apps/playground/src/routes/docs/+page.svelte
+++ b/apps/playground/src/routes/docs/+page.svelte
@@ -1,9 +1,8 @@
 <script lang="ts">
 	import { base } from '$app/paths';
-	import { GUIDES } from '$lib/docs';
+	import { GUIDE_LIST } from '$lib/docs';
 	import CodeBlock from '$lib/components/CodeBlock.svelte';
-	import DocsSidebar from '$lib/components/DocsSidebar.svelte';
-	import DocsToc from '$lib/components/DocsToc.svelte';
+	import DocsShell from '$lib/components/DocsShell.svelte';
 	import SiteFooter from '$lib/components/SiteFooter.svelte';
 	import SiteNav from '$lib/components/SiteNav.svelte';
 
@@ -15,14 +14,6 @@
 
 	const migration = `- import { compile } from 'svelte/compiler';
 + import { compile } from '@rsvelte/compiler';`;
-
-	const packageUses: Record<string, string> = {
-		compiler: 'Compile Svelte components for client and server.',
-		svelte2tsx: 'Generate TypeScript shadow files from Svelte components.',
-		fmt: 'Format .svelte files.',
-		'svelte-check': 'Type-check Svelte projects from the command line.',
-		'vite-plugin-svelte': 'Compile Svelte applications with Vite.',
-	};
 </script>
 
 <svelte:head>
@@ -36,9 +27,7 @@
 <div class="page">
 	<SiteNav active="docs" />
 
-	<div class="docs-shell">
-		<DocsSidebar current="overview" />
-
+	<DocsShell current="overview" {toc}>
 		<main class="article">
 			<nav class="breadcrumbs" aria-label="Breadcrumb">
 				<a href="{base}/">Documentation</a>
@@ -70,10 +59,10 @@
 							</tr>
 						</thead>
 						<tbody>
-							{#each GUIDES as guide (guide.id)}
+							{#each GUIDE_LIST as guide (guide.id)}
 								<tr>
 									<td><a href="{base}/docs/{guide.id}">{guide.title}</a></td>
-									<td>{packageUses[guide.id]}</td>
+									<td>{guide.useFor}</td>
 									<td><code>{guide.pkg}</code></td>
 								</tr>
 							{/each}
@@ -124,9 +113,7 @@
 				</a>
 			</nav>
 		</main>
-
-		<DocsToc items={toc} />
-	</div>
+	</DocsShell>
 
 	<SiteFooter />
 </div>
@@ -138,17 +125,8 @@
 		flex-direction: column;
 	}
 
-	.docs-shell {
-		flex: 1;
-		width: 100%;
-		max-width: 1440px;
-		margin: 0 auto;
-		display: grid;
-		grid-template-columns: 230px minmax(0, 52rem) 200px;
-		justify-content: center;
-	}
-
 	.article {
+		grid-area: main;
 		min-width: 0;
 		padding: 3rem clamp(2rem, 5vw, 4rem) 5rem;
 	}
@@ -316,18 +294,9 @@
 		color: var(--accent);
 	}
 
-	@media (max-width: 1120px) {
-		.docs-shell {
-			grid-template-columns: 230px minmax(0, 1fr);
-		}
-	}
-
 	@media (max-width: 860px) {
-		.docs-shell {
-			grid-template-columns: 1fr;
-		}
-
 		.article {
+			padding-top: 2rem;
 			padding-inline: clamp(1rem, 5vw, 2.5rem);
 		}
 	}

--- a/apps/playground/src/routes/docs/[slug]/+page.ts
+++ b/apps/playground/src/routes/docs/[slug]/+page.ts
@@ -1,11 +1,11 @@
 import { error } from '@sveltejs/kit';
 import type { EntryGenerator, PageLoad } from './$types';
-import { GUIDES, guideById } from '$lib/docs';
+import { GUIDE_LIST, guideById } from '$lib/docs';
 
 // Enumerate every guide slug so adapter-static prerenders a real HTML file per
 // page (build/docs/<slug>/index.html). Without this the SPA fallback would
 // 404 on a direct deep link under GitHub Pages.
-export const entries: EntryGenerator = () => GUIDES.map((g) => ({ slug: g.id }));
+export const entries: EntryGenerator = () => GUIDE_LIST.map((g) => ({ slug: g.id }));
 
 export const load: PageLoad = ({ params }) => {
 	const guide = guideById(params.slug);

--- a/apps/playground/src/routes/playground/+page.svelte
+++ b/apps/playground/src/routes/playground/+page.svelte
@@ -293,6 +293,12 @@
 		if (id === 'svelte-check') {
 			return { lang: 'bash', code: 'pnpm add -D @rsvelte/svelte-check\nrsvelte-check --watch' };
 		}
+		if (id === 'language-server') {
+			return {
+				lang: 'bash',
+				code: 'pnpm add -D @rsvelte/language-server\nrsvelte-language-server'
+			};
+		}
 		return {
 			lang: 'js',
 			code: `import { svelte } from '@rsvelte/vite-plugin-svelte';\n\nexport default { plugins: [svelte()] };`


### PR DESCRIPTION
Reported: *"the docs at https://baseballyama.github.io/rsvelte/ don't show the sub-navigation menu on mobile. They only show up on the left for desktop views"*.

## The reported defect

`DocsSidebar.svelte` ended with `@media (max-width: 860px) { .sidebar { display: none } }`. Below that width there was no route to a guide except the top-level nav — the whole toolchain section was desktop-only. It is now a disclosure ("Documentation menu" + the group list), the same pattern `SiteNav` already uses for its own mobile menu, and unchanged as a sticky column above the breakpoint. `DocsToc` was hidden the same way below 1120px and gets the same treatment.

## Why the shell moved into a component

The grid lived in three copies — `Guide.svelte`, `/docs/+page.svelte`, `/+page.svelte` — and they had **already drifted**: the sidebar hid at 860px while `Guide.svelte` kept its 230px column until 800px, so between those two widths a guide page reserved a column for an element that was not rendered. `DocsShell.svelte` now owns the grid and places the three regions by `grid-template-areas`, which is what lets the DOM order stay nav → article → toc (reading and tab order) while the narrow layouts move the two navs around the article.

## Content that had gone stale

| | was | now |
|---|---|---|
| `lint` | in the tool switcher, **no page** — `/docs/lint` 404'd | full guide; `@rsvelte/lint`, not "not yet a standalone npm CLI" |
| `language-server` | absent | guide from the server's actual `ServerCapabilities` |
| `fmt` | "CSS routes to oxfmt", "`<style>` left verbatim in the browser" | CSS is `oxc_formatter_css` in process, which is why the playground formats a whole component |
| `svelte-check` | flag table predating `--config`, `--threshold`, `--diagnostic-sources`, `--compiler-warnings`, `--ignore`, `--emit-overlay` | current, plus how project config is resolved |
| `compiler` | "~113× the JavaScript parser; the full pipeline ~13×" | the recorded run says 44×/217× (parse) and 3.1×/21× (client) — the prose no longer carries numbers, it points at `/benchmark`, which is generated from that run |

## Keeping it from drifting again

`GUIDES` is a `Record<ToolId, Guide>`: a package added to the tool switcher **without** a docs page is a type error, not a 404 nobody notices. The overview's one-line descriptions now come from the guide itself, replacing a parallel `Record<string, string>` that silently rendered `undefined` for anything unlisted — which is exactly what `lint` would have hit.

That type only bites if something type-checks it, and nothing did: the full project check needs the wasm packages built, so no PR job could run it. `docs.ts` and `tools.ts` import only each other, so CI checks those two standalone (`tsc --ignoreConfig`) inside the existing playground job. Verified in both directions — removing `lint` from the record reproduces `TS2741: Property 'lint' is missing … but required in type 'Record<ToolId, Guide>'`, and the check is green with it back.

## What I could not verify

The full site builds and prerenders all seven guide pages (`build/docs/{compiler,svelte2tsx,fmt,lint,svelte-check,language-server,vite-plugin-svelte}.html`), and the metadata type-checks. I could **not** open the rendered pages in a browser at a phone width — the Chrome extension available here refuses `http://localhost` and `http://<lan-ip>` ("blocked by your site permissions"), so the responsive behaviour is argued from the CSS rather than seen. Worth a look on the deploy preview before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EUkGEUYELkmNArviFBDPNR
