### PR TITLE
fix(release): build the Linux binaries against glibc 2.35, and check it

### DIFF
--- a/.changeset/linux-glibc-floor.md
+++ b/.changeset/linux-glibc-floor.md
@@ -1,0 +1,10 @@
+---
+'@rsvelte/svelte-check': patch
+'@rsvelte/vite-plugin-svelte-native': patch
+'@rsvelte/language-server': patch
+'@rsvelte/compiler': patch
+'@rsvelte/fmt': patch
+'@rsvelte/lint': patch
+---
+
+Build the Linux binaries against glibc 2.35 instead of whatever `ubuntu-latest` happens to provide. The release matrix ran on the hosted `ubuntu-latest` image, which moved to Ubuntu 24.04 (glibc 2.39), so every published `linux-x64-gnu` / `linux-arm64-gnu` artifact refused to start on Ubuntu 22.04 LTS and other distributions on an older glibc — `libc.so.6: version 'GLIBC_2.39' not found`. The Linux legs are now pinned to `ubuntu-22.04`, and each one asserts the requirement by reading the artifact it just built, so a future image bump fails the release instead of shipping.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,45 @@ jobs:
       - name: Check formatting
         run: cargo fmt --all -- --check
 
+  glibc-floor:
+    name: Glibc floor
+    # The release matrix builds the Linux artifacts on ubuntu-22.04 and asserts
+    # they need no glibc newer than 2.35, but release.yml only runs on the
+    # version-packages merge — so the assertion and the image that satisfies it
+    # were never exercised until a publish. This builds one shipped binary the
+    # same way and runs the same script, including a negative control: with the
+    # floor lowered the script must fail, or a green run would prove nothing.
+    runs-on: ubuntu-22.04
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          submodules: false
+
+      - name: Checkout svelte submodule (shallow)
+        run: git submodule update --init --depth 1 submodules/svelte
+
+      - uses: ./.github/actions/setup-rust
+
+      - name: Cache cargo registry + target
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
+        with:
+          key: glibc-floor
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+
+      - name: Build a shipped binary
+        run: cargo build -p rsvelte_fmt --bin rsvelte-fmt
+
+      - name: Check glibc floor
+        run: scripts/release/check-glibc-floor.sh target/debug/rsvelte-fmt
+
+      - name: Negative control — the check must be able to fail
+        run: |
+          if GLIBC_FLOOR=2.0 scripts/release/check-glibc-floor.sh target/debug/rsvelte-fmt; then
+            echo "::error::check-glibc-floor.sh passed a binary below the floor"
+            exit 1
+          fi
+
   playground-lockfile:
     name: Playground lockfile
     # Deploy Docs only runs on pushes to main, so a stale

--- a/.github/workflows/release-capi.yml
+++ b/.github/workflows/release-capi.yml
@@ -46,8 +46,8 @@ jobs:
         include:
           - { os: macos-latest,   target: aarch64-apple-darwin,       triple: darwin-arm64,    archive: tar.gz, lib: librsvelte_capi.dylib,  staticlib: librsvelte_capi.a }
           - { os: macos-latest,   target: x86_64-apple-darwin,        triple: darwin-x64,      archive: tar.gz, lib: librsvelte_capi.dylib,  staticlib: librsvelte_capi.a }
-          - { os: ubuntu-latest,  target: x86_64-unknown-linux-gnu,   triple: linux-x64-gnu,   archive: tar.gz, lib: librsvelte_capi.so,     staticlib: librsvelte_capi.a }
-          - { os: ubuntu-latest,  target: aarch64-unknown-linux-gnu,  triple: linux-arm64-gnu, archive: tar.gz, lib: librsvelte_capi.so,     staticlib: librsvelte_capi.a, apt: gcc-aarch64-linux-gnu, linker: aarch64-linux-gnu-gcc }
+          - { os: ubuntu-22.04,   target: x86_64-unknown-linux-gnu,   triple: linux-x64-gnu,   archive: tar.gz, lib: librsvelte_capi.so,     staticlib: librsvelte_capi.a }
+          - { os: ubuntu-22.04,   target: aarch64-unknown-linux-gnu,  triple: linux-arm64-gnu, archive: tar.gz, lib: librsvelte_capi.so,     staticlib: librsvelte_capi.a, apt: gcc-aarch64-linux-gnu, linker: aarch64-linux-gnu-gcc }
           - { os: windows-latest, target: x86_64-pc-windows-msvc,     triple: win32-x64-msvc,  archive: zip,    lib: rsvelte_capi.dll,       staticlib: rsvelte_capi.lib, implib: rsvelte_capi.dll.lib }
     runs-on: ${{ matrix.os }}
     timeout-minutes: 45
@@ -146,6 +146,16 @@ jobs:
           echo "${ver}" > "${stage}/VERSION"
           echo "$(git rev-parse HEAD)" > "${stage}/COMMIT"
           ls -lR "${stage}"
+
+      # The shipped shared object must not need a newer glibc than the floor
+      # we promise; the check reads the artifact, not the runner (#2675).
+      - name: Check glibc floor
+        if: startsWith(matrix.triple, 'linux-')
+        shell: bash
+        run: |
+          ver="${{ steps.ver.outputs.version }}"
+          scripts/release/check-glibc-floor.sh \
+            "stage/rsvelte_capi-${ver}-${{ matrix.triple }}/lib/${{ matrix.lib }}"
 
       - name: Pack archive
         id: pack

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,8 +88,8 @@ jobs:
         include:
           - { os: macos-latest, target: aarch64-apple-darwin, triple: darwin-arm64, ext: '' }
           - { os: macos-latest, target: x86_64-apple-darwin, triple: darwin-x64, ext: '' }
-          - { os: ubuntu-latest, target: x86_64-unknown-linux-gnu, triple: linux-x64-gnu, ext: '' }
-          - { os: ubuntu-latest, target: aarch64-unknown-linux-gnu, triple: linux-arm64-gnu, ext: '', apt: gcc-aarch64-linux-gnu, linker: aarch64-linux-gnu-gcc }
+          - { os: ubuntu-22.04, target: x86_64-unknown-linux-gnu, triple: linux-x64-gnu, ext: '' }
+          - { os: ubuntu-22.04, target: aarch64-unknown-linux-gnu, triple: linux-arm64-gnu, ext: '', apt: gcc-aarch64-linux-gnu, linker: aarch64-linux-gnu-gcc }
           - { os: windows-latest, target: x86_64-pc-windows-msvc, triple: win32-x64-msvc, ext: '.exe' }
     runs-on: ${{ matrix.os }}
     timeout-minutes: ${{ matrix.triple == 'linux-x64-gnu' && 60 || 30 }}
@@ -140,6 +140,14 @@ jobs:
           cp "target/${{ matrix.target }}/dist/svelte_check${{ matrix.ext }}" \
              "stage/svelte-check${{ matrix.ext }}"
 
+      # A published binary must not need a newer glibc than the floor the
+      # runner image happens to provide; the check reads the artifact, so an
+      # image bump cannot raise the requirement silently (#2675).
+      - name: Check glibc floor
+        if: startsWith(matrix.triple, 'linux-')
+        shell: bash
+        run: scripts/release/check-glibc-floor.sh stage/*
+
       - name: Upload artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -161,8 +169,8 @@ jobs:
         include:
           - { os: macos-latest, target: aarch64-apple-darwin, triple: darwin-arm64, dylib: librsvelte_napi.dylib }
           - { os: macos-latest, target: x86_64-apple-darwin, triple: darwin-x64, dylib: librsvelte_napi.dylib }
-          - { os: ubuntu-latest, target: x86_64-unknown-linux-gnu, triple: linux-x64-gnu, dylib: librsvelte_napi.so }
-          - { os: ubuntu-latest, target: aarch64-unknown-linux-gnu, triple: linux-arm64-gnu, dylib: librsvelte_napi.so, apt: gcc-aarch64-linux-gnu, linker: aarch64-linux-gnu-gcc }
+          - { os: ubuntu-22.04, target: x86_64-unknown-linux-gnu, triple: linux-x64-gnu, dylib: librsvelte_napi.so }
+          - { os: ubuntu-22.04, target: aarch64-unknown-linux-gnu, triple: linux-arm64-gnu, dylib: librsvelte_napi.so, apt: gcc-aarch64-linux-gnu, linker: aarch64-linux-gnu-gcc }
           - { os: windows-latest, target: x86_64-pc-windows-msvc, triple: win32-x64-msvc, dylib: rsvelte_napi.dll }
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
@@ -205,6 +213,14 @@ jobs:
           mkdir -p stage
           cp "target/${{ matrix.target }}/dist-napi/${{ matrix.dylib }}" stage/rsvelte.node
 
+      # A published binary must not need a newer glibc than the floor the
+      # runner image happens to provide; the check reads the artifact, so an
+      # image bump cannot raise the requirement silently (#2675).
+      - name: Check glibc floor
+        if: startsWith(matrix.triple, 'linux-')
+        shell: bash
+        run: scripts/release/check-glibc-floor.sh stage/*
+
       - name: Upload artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -225,8 +241,8 @@ jobs:
         include:
           - { os: macos-latest, target: aarch64-apple-darwin, triple: darwin-arm64, ext: '' }
           - { os: macos-latest, target: x86_64-apple-darwin, triple: darwin-x64, ext: '' }
-          - { os: ubuntu-latest, target: x86_64-unknown-linux-gnu, triple: linux-x64-gnu, ext: '' }
-          - { os: ubuntu-latest, target: aarch64-unknown-linux-gnu, triple: linux-arm64-gnu, ext: '', apt: gcc-aarch64-linux-gnu, linker: aarch64-linux-gnu-gcc }
+          - { os: ubuntu-22.04, target: x86_64-unknown-linux-gnu, triple: linux-x64-gnu, ext: '' }
+          - { os: ubuntu-22.04, target: aarch64-unknown-linux-gnu, triple: linux-arm64-gnu, ext: '', apt: gcc-aarch64-linux-gnu, linker: aarch64-linux-gnu-gcc }
           - { os: windows-latest, target: x86_64-pc-windows-msvc, triple: win32-x64-msvc, ext: '.exe' }
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
@@ -264,6 +280,14 @@ jobs:
           cp "target/${{ matrix.target }}/dist/rsvelte-fmt${{ matrix.ext }}" \
              "stage/rsvelte-fmt${{ matrix.ext }}"
 
+      # A published binary must not need a newer glibc than the floor the
+      # runner image happens to provide; the check reads the artifact, so an
+      # image bump cannot raise the requirement silently (#2675).
+      - name: Check glibc floor
+        if: startsWith(matrix.triple, 'linux-')
+        shell: bash
+        run: scripts/release/check-glibc-floor.sh stage/*
+
       - name: Upload artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -289,8 +313,8 @@ jobs:
         include:
           - { os: macos-latest, target: aarch64-apple-darwin, triple: darwin-arm64, ext: '', dylib: librsvelte_lint.dylib }
           - { os: macos-latest, target: x86_64-apple-darwin, triple: darwin-x64, ext: '', dylib: librsvelte_lint.dylib }
-          - { os: ubuntu-latest, target: x86_64-unknown-linux-gnu, triple: linux-x64-gnu, ext: '', dylib: librsvelte_lint.so }
-          - { os: ubuntu-latest, target: aarch64-unknown-linux-gnu, triple: linux-arm64-gnu, ext: '', apt: gcc-aarch64-linux-gnu, linker: aarch64-linux-gnu-gcc, dylib: librsvelte_lint.so }
+          - { os: ubuntu-22.04, target: x86_64-unknown-linux-gnu, triple: linux-x64-gnu, ext: '', dylib: librsvelte_lint.so }
+          - { os: ubuntu-22.04, target: aarch64-unknown-linux-gnu, triple: linux-arm64-gnu, ext: '', apt: gcc-aarch64-linux-gnu, linker: aarch64-linux-gnu-gcc, dylib: librsvelte_lint.so }
           - { os: windows-latest, target: x86_64-pc-windows-msvc, triple: win32-x64-msvc, ext: '.exe', dylib: rsvelte_lint.dll }
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
@@ -348,6 +372,14 @@ jobs:
           cp "target/${{ matrix.target }}/dist-lint/${{ matrix.dylib }}" \
              "stage/rsvelte_lint.node"
 
+      # A published binary must not need a newer glibc than the floor the
+      # runner image happens to provide; the check reads the artifact, so an
+      # image bump cannot raise the requirement silently (#2675).
+      - name: Check glibc floor
+        if: startsWith(matrix.triple, 'linux-')
+        shell: bash
+        run: scripts/release/check-glibc-floor.sh stage/*
+
       - name: Upload artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -370,8 +402,8 @@ jobs:
         include:
           - { os: macos-latest, target: aarch64-apple-darwin, triple: darwin-arm64, ext: '' }
           - { os: macos-latest, target: x86_64-apple-darwin, triple: darwin-x64, ext: '' }
-          - { os: ubuntu-latest, target: x86_64-unknown-linux-gnu, triple: linux-x64-gnu, ext: '' }
-          - { os: ubuntu-latest, target: aarch64-unknown-linux-gnu, triple: linux-arm64-gnu, ext: '', apt: gcc-aarch64-linux-gnu, linker: aarch64-linux-gnu-gcc }
+          - { os: ubuntu-22.04, target: x86_64-unknown-linux-gnu, triple: linux-x64-gnu, ext: '' }
+          - { os: ubuntu-22.04, target: aarch64-unknown-linux-gnu, triple: linux-arm64-gnu, ext: '', apt: gcc-aarch64-linux-gnu, linker: aarch64-linux-gnu-gcc }
           - { os: windows-latest, target: x86_64-pc-windows-msvc, triple: win32-x64-msvc, ext: '.exe' }
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
@@ -408,6 +440,14 @@ jobs:
           mkdir -p stage
           cp "target/${{ matrix.target }}/dist-lsp/rsvelte-language-server${{ matrix.ext }}" \
              "stage/rsvelte-language-server${{ matrix.ext }}"
+
+      # A published binary must not need a newer glibc than the floor the
+      # runner image happens to provide; the check reads the artifact, so an
+      # image bump cannot raise the requirement silently (#2675).
+      - name: Check glibc floor
+        if: startsWith(matrix.triple, 'linux-')
+        shell: bash
+        run: scripts/release/check-glibc-floor.sh stage/*
 
       - name: Upload artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/apps/npm/fmt/README.md
+++ b/apps/npm/fmt/README.md
@@ -25,7 +25,7 @@ The package resolves the right prebuilt native binary for your platform via
 | OS | Architecture |
 |---|---|
 | macOS | arm64, x64 |
-| Linux | x64 (glibc), arm64 (glibc) |
+| Linux | x64 (glibc ≥ 2.35), arm64 (glibc ≥ 2.35) |
 | Windows | x64 (MSVC) |
 
 If your platform isn't listed, please [open an issue](https://github.com/baseballyama/rsvelte/issues).

--- a/apps/npm/lint/README.md
+++ b/apps/npm/lint/README.md
@@ -31,7 +31,7 @@ alongside it; `rsvelte-lint` is self-contained. Supported targets:
 | OS | Architecture |
 |---|---|
 | macOS | arm64, x64 |
-| Linux | x64 (glibc), arm64 (glibc) |
+| Linux | x64 (glibc ≥ 2.35), arm64 (glibc ≥ 2.35) |
 | Windows | x64 (MSVC) |
 
 If your platform isn't listed, please [open an issue](https://github.com/baseballyama/rsvelte/issues).

--- a/apps/npm/svelte-check/README.md
+++ b/apps/npm/svelte-check/README.md
@@ -17,7 +17,7 @@ The package ships a small loader that resolves the right prebuilt native binary 
 | OS | Architecture |
 |---|---|
 | macOS | arm64, x64 |
-| Linux | x64 (glibc), arm64 (glibc) |
+| Linux | x64 (glibc ≥ 2.35), arm64 (glibc ≥ 2.35) |
 | Windows | x64 (MSVC) |
 
 If your platform isn't listed, please [open an issue](https://github.com/baseballyama/rsvelte/issues).

--- a/apps/npm/vite-plugin-svelte-native/README.md
+++ b/apps/npm/vite-plugin-svelte-native/README.md
@@ -17,7 +17,7 @@ The package ships a loader that resolves the right prebuilt `.node` binary for y
 | OS | Architecture |
 |---|---|
 | macOS | arm64, x64 |
-| Linux | x64 (glibc), arm64 (glibc) |
+| Linux | x64 (glibc ≥ 2.35), arm64 (glibc ≥ 2.35) |
 | Windows | x64 (MSVC) |
 
 If your platform isn't listed, please [open an issue](https://github.com/baseballyama/rsvelte/issues).

--- a/compatibility/gate-coverage.md
+++ b/compatibility/gate-coverage.md
@@ -61,6 +61,7 @@ samples) — see `AGENTS.md` § "Generated shape matrix" and issue #2281.
 | 18 | Compatibility report (`AGENTS.md` numbers) | pass/fail per fixture | warnings compared by **count only** | [S] |
 | 19 | Output parseability (`verify.mjs`) | rsvelte's `js.code` alone, parsed with acorn | says nothing about whether the output is *right*; no CSS, no maps | [S] |
 | 20 | Corpus-seeded mutation fuzz | per-mutant × target JS text, normalized as gate 1 | the operator only **inserts comments** — a delimiter in a *string* is unreachable at any corpus size | [D] |
+| 21 | Published-artifact glibc floor | max `GLIBC_*` version referenced by each Linux artifact | whether the binary actually **runs** anywhere; every non-glibc dependency | [D] |
 
 Cross-cutting blind spots (path filters, ratchet-doc drift, vacuity floors, the **performance**
 gates' population, and **an uninitialised corpus source shrinking every corpus gate silently**)
@@ -1077,6 +1078,33 @@ comment fidelity per id on generated seeds that do not move when a submodule bum
 comment regression on a *collected* seed is invisible here.
 
 ---
+
+## 21. Published-artifact glibc floor — `scripts/release/check-glibc-floor.sh`
+
+**Unit.** Per Linux artifact staged for publication, the highest `GLIBC_x.y` version its
+dynamic symbols and `.gnu.version_r` entries reference, compared against a declared floor
+(2.35, the glibc of the `ubuntu-22.04` image the release matrix now builds on).
+
+**Why it exists.** Every gate in this file compares *what the compiler produced*. None of them
+looks at the file that reaches npm. `ubuntu-latest` moved to Ubuntu 24.04, every published
+`linux-*-gnu` artifact started requiring glibc 2.39, and the whole test suite stayed green
+because nothing it runs is the shipped binary (#2675).
+
+### Blind spot 21a — it reads symbols, not behaviour [D]
+
+A binary whose highest reference is under the floor can still fail to start: a `dlopen`ed
+library, a `GLIBC_PRIVATE` symbol, or a non-glibc shared object (`libgcc_s`, `libstdc++`)
+whose own floor is higher are all invisible here. The discriminating case is the reverse
+direction and is what the CI negative control asserts: with `GLIBC_FLOOR=2.0` the same
+artifact must be rejected, which is the only evidence that a green run means anything.
+
+### Blind spot 21b — the floor is a number in a workflow, not a tested claim [S]
+
+Nothing checks that 2.35 is the glibc of the image named in `runs-on`. Pin and floor are two
+independent edits, and lowering `runs-on` to an older image while leaving the floor at 2.35
+would keep passing — the check only fails when the artifact needs *more* than the floor. What
+it does close is the direction that actually broke: an image bump can no longer raise the
+requirement silently.
 
 ## Cross-cutting
 

--- a/scripts/release/check-glibc-floor.sh
+++ b/scripts/release/check-glibc-floor.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Fail when a Linux artifact we are about to publish needs a newer glibc than
+# the floor we promise. The answer is read out of the binary, so a bump of the
+# runner image cannot raise the requirement without this going red.
+set -Eeuo pipefail
+
+export LC_ALL=C
+
+FLOOR="${GLIBC_FLOOR:-2.35}"
+
+die() {
+  echo "check-glibc-floor: $*" >&2
+  exit 1
+}
+
+if [ "$#" -eq 0 ]; then
+  die "usage: [GLIBC_FLOOR=x.y] $0 <artifact>..."
+fi
+
+case "$FLOOR" in
+  [0-9]*.[0-9]*) ;;
+  *) die "GLIBC_FLOOR must look like 2.35, got '$FLOOR'" ;;
+esac
+
+reader=
+for candidate in readelf eu-readelf; do
+  if command -v "$candidate" >/dev/null 2>&1; then
+    reader="$candidate"
+    break
+  fi
+done
+[ -n "$reader" ] || die "readelf is required (install binutils)"
+
+status=0
+
+for artifact in "$@"; do
+  [ -f "$artifact" ] || die "no such file: $artifact"
+
+  # `head -c 4` rather than `file`, which is not installed on every image.
+  magic=$(head -c 4 -- "$artifact" | od -An -tx1 | tr -d ' \n')
+  [ "$magic" = "7f454c46" ] || die "not an ELF object: $artifact"
+
+  # Both sections name the requirement: `--version-info` lists what the
+  # `.gnu.version_r` entries ask for, `--dyn-syms` the per-symbol `@GLIBC_*`
+  # suffixes. Reading both means a stripped-down layout still answers.
+  versions=$(
+    "$reader" --dyn-syms --version-info -W -- "$artifact" 2>/dev/null |
+      grep -o 'GLIBC_[0-9][0-9.]*' |
+      sed -e 's/^GLIBC_//' -e 's/\.$//' |
+      sort -uV || true
+  )
+
+  if [ -z "$versions" ]; then
+    echo "ok   $artifact — no versioned glibc symbols"
+    continue
+  fi
+
+  highest=$(printf '%s\n' "$versions" | tail -1)
+  if [ "$(printf '%s\n%s\n' "$FLOOR" "$highest" | sort -V | tail -1)" = "$FLOOR" ]; then
+    echo "ok   $artifact — needs glibc $highest (floor $FLOOR)"
+  else
+    echo "FAIL $artifact — needs glibc $highest, above the floor $FLOOR" >&2
+    echo "     versions referenced: $(printf '%s' "$versions" | tr '\n' ' ')" >&2
+    status=1
+  fi
+done
+
+exit "$status"


### PR DESCRIPTION
Fixes #2675.

## What broke

Every `linux-*-gnu` artifact was built on `runs-on: ubuntu-latest`. That label moved to Ubuntu 24.04, whose glibc is 2.39, so the published binaries stopped starting on anything older — Ubuntu 22.04 LTS (2.35, supported to April 2027), Debian 12 (2.36), and so on:

```
/lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.39' not found
```

Nothing about the code changed; the runner image did, and that is enough to publish an unusable binary.

**It is not only `@rsvelte/svelte-check`.** The same `ubuntu-latest` row is in all five package families and in the C API release, so `@rsvelte/fmt`, `@rsvelte/lint`, `@rsvelte/language-server` and `@rsvelte/vite-plugin-svelte-native` have the identical defect; the reporter happened to install svelte-check. All ten matrix rows plus the two C API rows are pinned to `ubuntu-22.04`.

## Why not musl

The issue suggests publishing `linux-x64-musl`. That means a brand-new package name, and npm OIDC trusted publishing cannot create one — `AGENTS.md` records that a new platform package has to be bootstrapped by hand before CI can ever publish it. Fixing the glibc the existing packages are built against needs no new names and fixes every family at once. A lower floor than 2.35 (RHEL 9 and Amazon Linux 2023 are on 2.34) wants `cargo-zigbuild` with an explicit `…-gnu.2.17` target; that is a bigger change to a workflow I cannot run before merging, so it is worth its own issue rather than riding along with a fix release.

## Why it can't recur quietly

Pinning alone leaves the same failure one image bump away. The deeper reason it shipped is that **no gate in this repo looks at the file that reaches npm** — all ~20 of them compare what the compiler produced, and the whole suite was green while the artifact was unusable. So each Linux leg now runs `scripts/release/check-glibc-floor.sh` on what it just staged: the highest `GLIBC_*` it references, out of the binary's own dynamic symbols and `.gnu.version_r`, must not exceed the declared floor. A future image bump fails the release instead of publishing.

A release-only check is one that never runs until it matters, so `ci.yml` gets a `Glibc floor` job: same image, one shipped binary built the same way, same script — **and a negative control**. With `GLIBC_FLOOR=2.0` the script must reject that binary; if it passes, the job fails. Without that, a green line proves only that the script printed something.

Verified rather than assumed, on both sides and including a real defect the exercise found: driving the script with fixed `readelf` output, a binary referencing 2.39 fails against floor 2.35, one topping out at 2.35 passes, a missing file and a non-ELF file are hard errors — and the "no versioned glibc symbols" case *exited 1* on the first version, because `set -e` kills the assignment when `grep` matches nothing. A statically-linked artifact would have failed the release for no reason. Fixed and re-checked.

`compatibility/gate-coverage.md` gets the gate as § 21, with what it cannot see: it reads symbols, not behaviour (a `dlopen`ed library or a `libstdc++` with a higher floor is invisible), and nothing asserts that 2.35 is really the glibc of the image named in `runs-on` — pin and floor are two independent edits, and the check only fires in the direction that actually broke.

## Release

The changeset patches all six user-facing packages, so the fix reaches every family in one release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EUkGEUYELkmNArviFBDPNR
