### PR TITLE
test(corpus): always mutate the pattern seeds on a PR

### DIFF
--- a/compatibility/gate-coverage.md
+++ b/compatibility/gate-coverage.md
@@ -1076,6 +1076,25 @@ divergences with no per-entry gate. Deliberate and documented (`AGENTS.md`; gate
 comment fidelity per id on generated seeds that do not move when a submodule bumps) — but a
 comment regression on a *collected* seed is invisible here.
 
+### Blind spot 20f — a PR samples by hash, so the run that adds a seed is the least likely to mutate it [D]
+
+**PRs run `--seeds 1500`, main runs `--full`** (`corpus-compat.yml:267-272`), and the sample
+was the 1500 lowest `fnv1a(id)` of ~14,100 eligible entries (`:145-152`). Nothing in that rank
+knows an id is *new*, so a repro landing in the same PR had roughly a 1-in-9 chance of being
+mutated — and the ratchet the PR was green against was measured without it.
+
+**[D]** #2671. #2663 added `pattern/matrix/string-line-continuation/indented-continuation.svelte`
+and was green; the mutant of that very seed turned main red on merge. Simulated over the real
+shape (13,963 collected + 137 `pattern/` ids), the old rank picked **14 of 137** `pattern/`
+entries; the mechanism is not "PRs sample less", it is that inclusion is a lottery uncorrelated
+with novelty.
+
+Now closed for `pattern/`: every eligible `pattern/` id is seeded unconditionally and the
+hash-ranked sample fills the rest, so the sample goes 1500 → 1637 (+9%) and a PR that lands a
+repro mutation-tests it. **Still open for the rest of the corpus** — a submodule bump that
+introduces a new real-world file is the same lottery, and there is no cheap fix, because
+"newly added" is a diff against the merge base rather than a property of the manifest.
+
 ---
 
 ## Cross-cutting

--- a/scripts/compat-corpus/mutate-corpus.mjs
+++ b/scripts/compat-corpus/mutate-corpus.mjs
@@ -142,15 +142,24 @@ if (missingSources.length && !WORKER) {
 }
 
 const eligible = manifest.filter((e) => !known.has(e.id) && fs.existsSync(path.join(SOURCES, e.id)));
+// A hash-ranked sample includes a newly added repro only if its id happens to
+// rank in the chosen slice, so the PR that lands one is the run least likely to
+// mutate it — which is how #2671 reached main. `pattern/` is the in-repo source
+// and small enough to always carry.
+const alwaysSeeded = (e) => e.id.startsWith('pattern/');
 const seeds = FULL
 	? eligible
-	: eligible
-			// Deterministic sample: rank by the seed's own hash, so the chosen set is
-			// reproducible and does not depend on the manifest's length.
-			.map((e) => [fnv1a(e.id), e])
-			.sort((a, b) => a[0] - b[0])
-			.slice(0, SEEDS)
-			.map(([, e]) => e);
+	: [
+			...eligible.filter(alwaysSeeded),
+			...eligible
+				.filter((e) => !alwaysSeeded(e))
+				// Deterministic sample: rank by the seed's own hash, so the chosen set is
+				// reproducible and does not depend on the manifest's length.
+				.map((e) => [fnv1a(e.id), e])
+				.sort((a, b) => a[0] - b[0])
+				.slice(0, SEEDS)
+				.map(([, e]) => e),
+		];
 
 // ---- worker: compile a seed range ------------------------------------------
 


### PR DESCRIPTION
Follow-up to #2671, which reached main exactly the way this closes.

## The mechanism

PRs run the mutation sweep with `--seeds 1500`, main with `--full` (`corpus-compat.yml:267-272`). The sample is the 1500 lowest `fnv1a(id)` of the ~14,100 eligible entries (`mutate-corpus.mjs:145-152`).

The usual phrasing — "a PR cannot mutation-test a seed it adds" — is close but names the wrong cause, and the wrong cause suggests the wrong fix (raise `--seeds`). **Nothing in that rank knows an id is new.** Inclusion is a lottery uncorrelated with novelty, so the run that lands a repro is the one *least likely* to exercise it, and the ratchet the PR was green against was measured without it.

Simulated over the real shape (13,963 collected ids + 137 under `pattern/`), the old rank picked **14 of 137** `pattern/` entries — 10%. #2663 added `indented-continuation.svelte`, went green, and the mutant of that same seed turned main red on merge.

## The change

`pattern/` is the in-repo source, is small, and is precisely where repros land. Every eligible `pattern/` id is now seeded unconditionally; the hash-ranked sample fills the rest. The sample goes **1500 → 1637 (+9%)** and every `pattern/` entry is mutated on every PR.

## What is still open

A submodule bump that introduces a new real-world file is the same lottery, and I did not fix it: "newly added" is a diff against the merge base, not a property of the manifest, so it cannot be answered inside the sampler the way `pattern/` can. Recorded as blind spot **20f** in `compatibility/gate-coverage.md` — closed for `pattern/`, explicitly still open for the rest, with the 14/137 measurement as the discriminating evidence rather than a plausible-sounding claim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EUkGEUYELkmNArviFBDPNR
