### PR TITLE
chore(measure): separate visit_slot_children from its wrapper

### DIFF
--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/component.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/component.rs
@@ -2324,6 +2324,9 @@ fn visit_slot_children(
     children: &[&TemplateNode],
     context: &mut ComponentContext,
 ) -> Vec<JsStatement> {
+    let _tf = crate::compiler::phases::phase3_transform::profile::tf_guard(
+        crate::compiler::phases::phase3_transform::profile::TF_BC_SLOT_CHILDREN,
+    );
     use crate::compiler::phases::phase3_transform::client::transform_template::Namespace;
     use crate::compiler::phases::phase3_transform::utils::clean_nodes_refs;
 

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/profile.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/profile.rs
@@ -759,7 +759,7 @@ pub fn take_pa_breakdown() -> PaBreakdown {
     PaBreakdown::default()
 }
 
-pub const TF_KINDS: [&str; 40] = [
+pub const TF_KINDS: [&str; 41] = [
     "component",
     "svelte_component",
     "svelte_self",
@@ -802,6 +802,7 @@ pub const TF_KINDS: [&str; 40] = [
     "bc:component_call",
     "bc:css_props",
     "bc:meta_stmt",
+    "bc:slot_children",
 ];
 
 pub const TF_BC_LET: usize = 27;
@@ -817,6 +818,7 @@ pub const TF_BC_COMP_EXPR: usize = 36;
 pub const TF_BC_COMP_CALL: usize = 37;
 pub const TF_BC_CSS_PROPS: usize = 38;
 pub const TF_BC_META: usize = 39;
+pub const TF_BC_SLOT_CHILDREN: usize = 40;
 
 /// Self time and call count per template node kind, drained together with the
 /// `template_fragment` parent they are compared against.


### PR DESCRIPTION
The last commit of #2676 did not make it into `main`: #2676 was merged into
#2674's branch, then #2674 was squashed, and this commit was pushed after that
merge. `main` carries the 13 `bc:` stages and not this one.

It splits `visit_slot_children` out of `build_slot_function`, which #2676 left
as one row — a wrapper plus a single call, so the row could not say which of
the two carried it. The answer is the call:

| corpus | `bc:slot_children` | wrapper (rest of `build_slot_function`) |
|---|---|---|
| shadcn-svelte | 27.1% of parent, 1.66 µs/call | falls out of the top 7 |
| flowbite-svelte | 16.3%, 1.65 µs/call | " |
| bits-ui | 11.6%, 1.41 µs/call | " |

So the save/restore of let-directive transforms around the slot scope costs
nothing measurable. A hypothesis died cheaply on the way:
`context.state.transform_deep_read.clone()` runs unconditionally although only
the `let:` branch reads it — 12,165 apparently wasted clones on shadcn — but the
field is an `im::HashMap` and its clone is O(1). Not a defect.
