### PR TITLE
ci(release): comment the released version on the PRs and issues a release ships

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -978,6 +978,22 @@ jobs:
       - name: Check the CSS-prune sweep compares warnings
         run: node scripts/dev/test-css-prune-sweep-warning-verdict.mjs
 
+  release-comment:
+    name: Release comment mapping
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          submodules: false
+
+      # The release job that posts these comments runs once per release and
+      # only on main, so a mistake in the CHANGELOG -> pull request mapping
+      # would first surface as comments on the wrong issues. The parsers are
+      # pure and dependency-free, so pin them on every PR instead.
+      - name: Check the released-version comment mapping
+        run: node scripts/dev/test-release-comment.mjs
+
   vps-version-check:
     name: VPS native VERSION drift check
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -526,3 +526,37 @@ jobs:
           title: 'chore(release): version packages'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  # Tell every pull request that shipped in this release — and the issues it
+  # closed — which `package@version` carries it. Runs after `publish` so a
+  # comment is never posted for a release that did not reach the registry.
+  comment-released-versions:
+    name: Comment released versions
+    if: "${{ startsWith(github.event.head_commit.message, 'chore(release): version packages') }}"
+    needs: publish
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    # Job-level permissions REPLACE the workflow-level block, and the default
+    # there has no `issues: write` — without it the issue comments 404.
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # The script resolves each changeset's short hash back to its commit
+          # and diffs package versions against `HEAD^`; both need real history.
+          fetch-depth: 0
+          submodules: false
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: '24'
+
+      # No `pnpm install`: the script has no dependencies, so it runs against a
+      # bare checkout even if the release left node_modules in an odd state.
+      - name: Comment released versions on pull requests and issues
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: node scripts/release/comment-released-versions.mjs

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -385,6 +385,12 @@ Use the `Agent` tool for substantial work — feature implementation, multi-file
 - Run `cargo fmt && cargo clippy --all-targets --all-features -- -D warnings` before committing
 - Push immediately after committing
 - Releases are automated via Changesets Release PRs
+- After a successful publish, `scripts/release/comment-released-versions.mjs` comments the exact
+  `package@version` on every PR whose changeset shipped and on the issues that PR closed. The
+  mapping comes from the CHANGELOGs, not the commit range: `@changesets/cli/changelog` prefixes
+  each entry with the hash of the commit that added the changeset, so a PR with no changeset —
+  chore, test, docs — is deliberately not commented on. Preview with
+  `node scripts/release/comment-released-versions.mjs --base <prev-release>^ --dry-run`
 - A **brand-new** platform package cannot be published by CI: npm OIDC trusted publishing
   only works for a name that already exists. Bootstrap it once with
   `pnpm run bootstrap-platform-packages -- --run <ci-run-id> --yes`, attach the trusted

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
 		"test:corpus-generation": "node scripts/dev/test-corpus-generation-guard.mjs",
 		"test:mutant-classification": "node scripts/dev/test-mutant-classification.mjs",
 		"test:known-failures-md-check": "node scripts/dev/test-known-failures-md-check.mjs",
+		"test:release-comment": "node scripts/dev/test-release-comment.mjs",
 		"test:css-prune-verdict": "node scripts/dev/test-css-prune-sweep-warning-verdict.mjs",
 		"test:vps-shim": "node scripts/dev/test-vps-shim.mjs",
 		"test:vps-fixture": "node scripts/dev/test-vps-vite-fixture.mjs",

--- a/scripts/dev/test-release-comment.mjs
+++ b/scripts/dev/test-release-comment.mjs
@@ -1,0 +1,178 @@
+#!/usr/bin/env node
+/**
+ * Pins the mapping in `scripts/release/comment-released-versions.mjs` from a
+ * released CHANGELOG section back to the pull request that produced it.
+ *
+ * Every case below is chosen because a plausible implementation gets it wrong
+ * and still looks right on the happy path:
+ *
+ * - A `- Updated dependencies [hash]` entry carries the SAME hash as the
+ *   package that actually changed. Any hash scan that does not require the
+ *   `<hash>: ` shape reports the PR as released in packages it never touched.
+ * - `## 0.1.1` is a prefix of `## 0.1.10`, so a `startsWith` section finder
+ *   returns the wrong release's entries — for a release that also happens to
+ *   be the newest, that is invisible.
+ * - This repo's squash subjects carry TWO `(#N)` groups when the title cites
+ *   the issue: `… (#2547) (#2666)`. The first is an issue, the last is the PR;
+ *   a non-anchored match comments on the issue as if it were the PR.
+ * - `collectReleases` must skip a package whose version did not move. Running
+ *   it only on a tree where everything moved cannot show that it can skip, so
+ *   the fixture repo below bumps two of four packages and asserts the other
+ *   two are absent.
+ *
+ * Usage: node scripts/dev/test-release-comment.mjs
+ */
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { execFileSync } from 'node:child_process';
+
+import {
+	MARKER,
+	changesetHashesIn,
+	collectReleases,
+	commentBody,
+	packageUrl,
+	prNumberFromSubject,
+	sectionFor,
+} from '../release/comment-released-versions.mjs';
+
+let failed = 0;
+const check = (name, got, want) => {
+	const ok = JSON.stringify(got) === JSON.stringify(want);
+	if (ok) {
+		console.log(`ok   ${name}`);
+	} else {
+		console.error(`FAIL ${name}\n  got  ${JSON.stringify(got)}\n  want ${JSON.stringify(want)}`);
+		failed++;
+	}
+};
+
+// ---- sectionFor ---------------------------------------------------------------
+
+const CHANGELOG = [
+	'# @rsvelte/compiler',
+	'',
+	'## 0.1.10',
+	'',
+	'### Patch Changes',
+	'',
+	'- aaaaaaa: newest',
+	'',
+	'## 0.1.1',
+	'',
+	'### Patch Changes',
+	'',
+	'- bbbbbbb: older',
+	'',
+].join('\n');
+
+check('sectionFor picks the requested release', changesetHashesIn(sectionFor(CHANGELOG, '0.1.10')), ['aaaaaaa']);
+// The discriminating case: a prefix match would return the 0.1.10 section here.
+check('sectionFor is not a prefix match', changesetHashesIn(sectionFor(CHANGELOG, '0.1.1')), ['bbbbbbb']);
+check('sectionFor on an unreleased version', sectionFor(CHANGELOG, '9.9.9'), null);
+
+// ---- changesetHashesIn --------------------------------------------------------
+
+const SECTION = [
+	'',
+	'### Patch Changes',
+	'',
+	'- c2a8eeb: A real entry.',
+	'',
+	'  A continuation paragraph of the same entry, which itself contains a list:',
+	'',
+	'  - deadbee: not a changeset, just prose that looks like one',
+	'',
+	'- Updated dependencies [c2a8eeb, f2d913c]',
+	'  - @rsvelte/compiler@0.10.9',
+	'',
+].join('\n');
+
+check('changesetHashesIn takes only direct entries', changesetHashesIn(SECTION), ['c2a8eeb']);
+// A carry-only section: the hash appears ONLY under `Updated dependencies`, so
+// picking it up would credit this package with a change it did not receive.
+check(
+	'changesetHashesIn ignores a dependency carry',
+	changesetHashesIn('\n### Patch Changes\n\n- Updated dependencies [c2a8eeb]\n  - @rsvelte/compiler@0.10.9\n'),
+	[],
+);
+check('changesetHashesIn dedupes', changesetHashesIn('- abc1234: one\n- abc1234: one again'), ['abc1234']);
+
+// ---- prNumberFromSubject ------------------------------------------------------
+
+check('prNumberFromSubject takes the trailing group', prNumberFromSubject('fix(compiler): x (#2547) (#2666)'), 2666);
+check('prNumberFromSubject on a single group', prNumberFromSubject('chore: y (#2674)'), 2674);
+check('prNumberFromSubject on a direct push', prNumberFromSubject('chore: pushed straight to main'), null);
+// An issue cited mid-subject with no PR suffix must not be mistaken for the PR.
+check('prNumberFromSubject ignores a mid-subject reference', prNumberFromSubject('fix: repair (#2547) follow-up'), null);
+
+// ---- packageUrl / commentBody -------------------------------------------------
+
+check(
+	'packageUrl for a published package',
+	packageUrl('@rsvelte/compiler', '0.10.9', false),
+	'https://www.npmjs.com/package/@rsvelte/compiler/v/0.10.9',
+);
+check('packageUrl for a non-npm package', packageUrl('some-private-thing', '1.0.0', true), null);
+
+{
+	const body = commentBody([{ name: '@rsvelte/compiler', version: '0.10.9', private: false }], 2666);
+	check('commentBody carries the marker', body.includes(MARKER), true);
+	check('commentBody names the version', body.includes('@rsvelte/compiler@0.10.9'), true);
+	check('commentBody credits the PR on an issue', body.includes('Fixed by #2666'), true);
+	const own = commentBody([{ name: '@rsvelte/compiler', version: '0.10.9', private: false }], null);
+	check('commentBody on the PR itself omits the credit', own.includes('Fixed by'), false);
+}
+
+// ---- collectReleases against a fixture repository -----------------------------
+
+{
+	const root = fs.mkdtempSync(path.join(os.tmpdir(), 'rsvelte-release-comment-'));
+	const git = (...args) => execFileSync('git', args, { cwd: root, stdio: 'pipe' });
+
+	const writePackage = (dir, name, version, changelog) => {
+		const abs = path.join(root, 'apps/npm', dir);
+		fs.mkdirSync(abs, { recursive: true });
+		fs.writeFileSync(path.join(abs, 'package.json'), JSON.stringify({ name, version }, null, 2));
+		if (changelog !== null) fs.writeFileSync(path.join(abs, 'CHANGELOG.md'), changelog);
+	};
+
+	git('init', '-q', '-b', 'main');
+	git('config', 'user.email', 'test@example.com');
+	git('config', 'user.name', 'test');
+
+	writePackage('compiler', '@rsvelte/compiler', '0.1.0', '# c\n\n## 0.1.0\n');
+	writePackage('lint', '@rsvelte/lint', '0.1.0', '# l\n\n## 0.1.0\n');
+	writePackage('fmt', '@rsvelte/fmt', '0.1.0', '# f\n\n## 0.1.0\n');
+	writePackage('lint-darwin-arm64', '@rsvelte/lint-darwin-arm64', '0.1.0', '# p\n\n## 0.1.0\n');
+	git('add', '-A');
+	git('commit', '-qm', 'base');
+
+	// The release: compiler and the platform sidecar bump with entries, lint
+	// bumps with an empty section (a `fixed`-group carry), fmt does not move.
+	writePackage('compiler', '@rsvelte/compiler', '0.2.0', '# c\n\n## 0.2.0\n\n- c0ffee1: real change\n\n## 0.1.0\n');
+	writePackage('lint', '@rsvelte/lint', '0.2.0', '# l\n\n## 0.2.0\n\n## 0.1.0\n');
+	writePackage('lint-darwin-arm64', '@rsvelte/lint-darwin-arm64', '0.2.0', '# p\n\n## 0.2.0\n\n- c0ffee1: x\n');
+
+	const releases = collectReleases('HEAD', root).map((r) => [r.name, r.version, r.hashes]);
+	check('collectReleases finds the bumped packages', releases, [
+		['@rsvelte/compiler', '0.2.0', ['c0ffee1']],
+		['@rsvelte/lint', '0.2.0', []],
+	]);
+
+	// Control: with nothing bumped the same call must come back empty, so the
+	// assertion above is not just "it always returns these two".
+	git('add', '-A');
+	git('commit', '-qm', 'release');
+	check('collectReleases is empty when nothing moved', collectReleases('HEAD', root), []);
+
+	fs.rmSync(root, { recursive: true, force: true });
+}
+
+if (failed > 0) {
+	console.error(`\n${failed} check(s) failed.`);
+	process.exit(1);
+}
+console.log('\nAll checks passed.');

--- a/scripts/release/comment-released-versions.mjs
+++ b/scripts/release/comment-released-versions.mjs
@@ -1,0 +1,321 @@
+#!/usr/bin/env node
+/**
+ * After a release, comment on every PR whose changeset shipped in it, and on
+ * the issues that PR closed, naming the exact `package@version` it went out in.
+ *
+ * The mapping is taken from the CHANGELOGs rather than from the commit range:
+ * `@changesets/cli/changelog` prefixes each entry with the short hash of the
+ * commit that ADDED the changeset, so a CHANGELOG section answers "which PR is
+ * in which package at which version" directly. A commit range cannot — it lists
+ * every merge, including the ones that changed no published package.
+ *
+ * Usage:
+ *   node scripts/release/comment-released-versions.mjs [--base <ref>] [--dry-run]
+ *
+ * Environment: GITHUB_TOKEN (issues: write), GITHUB_REPOSITORY (owner/name).
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { execFileSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(HERE, '../..');
+
+/** Marker that makes a comment ours, so a re-run does not duplicate it. */
+export const MARKER = '<!-- rsvelte-released-in -->';
+
+/** Platform sidecar packages: they carry no changelog entry of their own. */
+const PLATFORM_PACKAGE = /-(darwin|linux|win32)-(arm64|x64)(-gnu|-msvc)?$/;
+
+// ---------------------------------------------------------------------------
+// Pure parsing (exported for scripts/dev/test-release-comment.mjs)
+// ---------------------------------------------------------------------------
+
+/** Body of the `## <version>` section of a changeset CHANGELOG, or null. */
+export function sectionFor(changelog, version) {
+	const lines = changelog.split('\n');
+	const start = lines.findIndex((line) => line.trim() === `## ${version}`);
+	if (start === -1) return null;
+	const rest = lines.slice(start + 1);
+	const end = rest.findIndex((line) => line.startsWith('## '));
+	return (end === -1 ? rest : rest.slice(0, end)).join('\n');
+}
+
+/**
+ * Short commit hashes of the changesets listed directly in a section.
+ *
+ * Anchored at column 0 so an indented continuation of a changeset body cannot
+ * match, and requires the `<hash>: ` shape so `- Updated dependencies [hash]`
+ * — a bump propagated from a dependency, not this package's own change — is
+ * left to the package that actually carries the entry.
+ */
+export function changesetHashesIn(section) {
+	const seen = new Set();
+	for (const line of section.split('\n')) {
+		const match = /^- ([0-9a-f]{7,40}): /.exec(line);
+		if (match) seen.add(match[1]);
+	}
+	return [...seen];
+}
+
+/** PR number from a squash-merge subject, e.g. `fix: x (#123) (#456)` -> 456. */
+export function prNumberFromSubject(subject) {
+	const match = /\(#(\d+)\)\s*$/.exec(subject.split('\n')[0]);
+	return match ? Number(match[1]) : null;
+}
+
+/** Where a released package can be read about. */
+export function packageUrl(name, version, isPrivate) {
+	if (isPrivate) {
+		return name === 'rsvelte-vscode'
+			? `https://marketplace.visualstudio.com/items?itemName=baseballyama.${name}`
+			: null;
+	}
+	return `https://www.npmjs.com/package/${name}/v/${version}`;
+}
+
+/** Renders the comment body. `prNumber` is null when commenting on the PR itself. */
+export function commentBody(releases, prNumber) {
+	const lines = releases.map((r) => {
+		const label = `\`${r.name}@${r.version}\``;
+		const url = packageUrl(r.name, r.version, r.private);
+		return `- ${url ? `[${label}](${url})` : label}`;
+	});
+	const lead =
+		prNumber === null
+			? 'The change in this pull request has been released in:'
+			: `Fixed by #${prNumber}, released in:`;
+	return [MARKER, '🚀 **Released**', '', lead, '', ...lines, ''].join('\n');
+}
+
+// ---------------------------------------------------------------------------
+// Repository state
+// ---------------------------------------------------------------------------
+
+const gitIn = (root, ...args) => execFileSync('git', args, { cwd: root, encoding: 'utf8' }).trim();
+
+function readJsonAt(root, ref, relPath) {
+	try {
+		return JSON.parse(gitIn(root, 'show', `${ref}:${relPath}`));
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * Packages whose version changed between `base` and the working tree, with the
+ * changeset hashes their new CHANGELOG section lists.
+ */
+export function collectReleases(base, root = ROOT) {
+	const npmDir = path.join(root, 'apps/npm');
+	const releases = [];
+	for (const entry of fs.readdirSync(npmDir, { withFileTypes: true })) {
+		if (!entry.isDirectory() || PLATFORM_PACKAGE.test(entry.name)) continue;
+
+		const rel = `apps/npm/${entry.name}/package.json`;
+		const pkgPath = path.join(root, rel);
+		if (!fs.existsSync(pkgPath)) continue;
+
+		const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
+		const previous = readJsonAt(root, base, rel);
+		if (previous && previous.version === pkg.version) continue;
+
+		const changelogPath = path.join(npmDir, entry.name, 'CHANGELOG.md');
+		if (!fs.existsSync(changelogPath)) continue;
+		const section = sectionFor(fs.readFileSync(changelogPath, 'utf8'), pkg.version);
+		if (section === null) continue;
+
+		releases.push({
+			name: pkg.name,
+			version: pkg.version,
+			private: Boolean(pkg.private),
+			hashes: changesetHashesIn(section),
+		});
+	}
+	return releases;
+}
+
+// ---------------------------------------------------------------------------
+// GitHub
+// ---------------------------------------------------------------------------
+
+class GitHub {
+	constructor(repo, token) {
+		this.repo = repo;
+		this.token = token;
+	}
+
+	async #request(url, init = {}) {
+		const response = await fetch(url, {
+			...init,
+			headers: {
+				accept: 'application/vnd.github+json',
+				authorization: `Bearer ${this.token}`,
+				'x-github-api-version': '2022-11-28',
+				...(init.body ? { 'content-type': 'application/json' } : {}),
+				...init.headers,
+			},
+		});
+		if (!response.ok) {
+			throw new Error(`${init.method ?? 'GET'} ${url} -> ${response.status} ${await response.text()}`);
+		}
+		return response.json();
+	}
+
+	/** The PR a commit was merged through, or null when it was pushed directly. */
+	async pullRequestForCommit(sha) {
+		const prs = await this.#request(`https://api.github.com/repos/${this.repo}/commits/${sha}/pulls?per_page=100`);
+		const merged = prs.filter((pr) => pr.merged_at);
+		return (merged[0] ?? prs[0])?.number ?? null;
+	}
+
+	/** Issues the PR closes via a `Fixes #N` style reference. */
+	async closingIssues(prNumber) {
+		const [owner, name] = this.repo.split('/');
+		const query = `query($owner:String!,$name:String!,$number:Int!){
+			repository(owner:$owner,name:$name){
+				pullRequest(number:$number){
+					closingIssuesReferences(first:50){nodes{number}}
+				}
+			}
+		}`;
+		const body = JSON.stringify({ query, variables: { owner, name, number: prNumber } });
+		const result = await this.#request('https://api.github.com/graphql', { method: 'POST', body });
+		if (result.errors) throw new Error(`graphql: ${JSON.stringify(result.errors)}`);
+		const pr = result.data?.repository?.pullRequest;
+		return (pr?.closingIssuesReferences?.nodes ?? []).map((node) => node.number);
+	}
+
+	async #comments(issueNumber) {
+		const out = [];
+		for (let page = 1; ; page++) {
+			const batch = await this.#request(
+				`https://api.github.com/repos/${this.repo}/issues/${issueNumber}/comments?per_page=100&page=${page}`,
+			);
+			out.push(...batch);
+			if (batch.length < 100) return out;
+		}
+	}
+
+	/** True when we already said exactly this, so a workflow re-run stays quiet. */
+	async alreadyCommented(issueNumber, versionLabels) {
+		const existing = await this.#comments(issueNumber);
+		return existing.some(
+			(comment) =>
+				comment.body?.includes(MARKER) && versionLabels.every((label) => comment.body.includes(label)),
+		);
+	}
+
+	async comment(issueNumber, body) {
+		await this.#request(`https://api.github.com/repos/${this.repo}/issues/${issueNumber}/comments`, {
+			method: 'POST',
+			body: JSON.stringify({ body }),
+		});
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main(argv) {
+	const dryRun = argv.includes('--dry-run') || process.env.DRY_RUN === '1';
+	const baseIndex = argv.indexOf('--base');
+	const base = baseIndex === -1 ? 'HEAD^' : argv[baseIndex + 1];
+	// An unresolvable base makes every package look newly bumped, which would
+	// comment the whole history onto every PR.
+	if (!base) throw new Error('--base needs a ref.');
+	gitIn(ROOT, 'rev-parse', '--verify', `${base}^{commit}`);
+
+	const releases = collectReleases(base);
+	if (releases.length === 0) {
+		console.log(`No package version changed since ${base}; nothing to comment.`);
+		return 0;
+	}
+	for (const release of releases) {
+		console.log(`${release.name}@${release.version}: ${release.hashes.length} changeset(s)`);
+	}
+
+	const repo = process.env.GITHUB_REPOSITORY ?? 'baseballyama/rsvelte';
+	const token = process.env.GITHUB_TOKEN;
+	if (!token && !dryRun) throw new Error('GITHUB_TOKEN is required (use --dry-run to preview).');
+	const api = token ? new GitHub(repo, token) : null;
+
+	// hash -> the packages it shipped in. A single changeset can appear in more
+	// than one CHANGELOG when it names more than one package.
+	const byHash = new Map();
+	for (const release of releases) {
+		for (const hash of release.hashes) {
+			if (!byHash.has(hash)) byHash.set(hash, []);
+			byHash.get(hash).push(release);
+		}
+	}
+
+	// PR -> packages, so a PR carrying two changesets gets one comment.
+	const byPr = new Map();
+	for (const [hash, packages] of byHash) {
+		let sha;
+		try {
+			sha = gitIn(ROOT, 'rev-parse', '--verify', `${hash}^{commit}`);
+		} catch {
+			console.warn(`warn: changeset hash ${hash} is not a commit in this checkout; skipping.`);
+			continue;
+		}
+		let pr = api ? await api.pullRequestForCommit(sha) : null;
+		if (pr === null) pr = prNumberFromSubject(gitIn(ROOT, 'log', '-1', '--format=%s', sha));
+		if (pr === null) {
+			console.warn(`warn: no pull request found for ${hash}; skipping.`);
+			continue;
+		}
+		if (!byPr.has(pr)) byPr.set(pr, new Map());
+		for (const pkg of packages) byPr.get(pr).set(`${pkg.name}@${pkg.version}`, pkg);
+	}
+
+	let failures = 0;
+	for (const [pr, packages] of byPr) {
+		const list = [...packages.values()].sort((a, b) => a.name.localeCompare(b.name));
+		const labels = list.map((pkg) => `${pkg.name}@${pkg.version}`);
+
+		const targets = [{ number: pr, body: commentBody(list, null) }];
+		if (api) {
+			for (const issue of await api.closingIssues(pr)) {
+				targets.push({ number: issue, body: commentBody(list, pr) });
+			}
+		}
+
+		for (const target of targets) {
+			try {
+				// Checked in a dry run too: a dedupe that silently never matches
+				// only shows up as a duplicate comment on a workflow re-run.
+				const already = api ? await api.alreadyCommented(target.number, labels) : false;
+				if (dryRun) {
+					const prefix = already ? `(already commented) ` : '';
+					console.log(`\n--- ${prefix}#${target.number} ---\n${target.body}`);
+					continue;
+				}
+				if (already) {
+					console.log(`#${target.number}: already commented; skipping.`);
+					continue;
+				}
+				await api.comment(target.number, target.body);
+				console.log(`#${target.number}: commented (${labels.join(', ')}).`);
+			} catch (error) {
+				console.error(`#${target.number}: ${error.message}`);
+				failures++;
+			}
+		}
+	}
+	return failures === 0 ? 0 : 1;
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+	main(process.argv.slice(2)).then(
+		(code) => process.exit(code),
+		(error) => {
+			console.error(error);
+			process.exit(1);
+		},
+	);
+}


### PR DESCRIPTION
## Why

A merged pull request gave no signal about when its fix became installable, and a closed issue gave none about which version to upgrade to. Both had to be answered by hand, against the CHANGELOG.

After a successful publish, this posts the exact `package@version` on every pull request whose changeset shipped, and on the issues that pull request closed.

## How the mapping is derived

From the CHANGELOGs, not from the commit range. `@changesets/cli/changelog` prefixes each entry with the short hash of the commit that added the changeset, so a `## <version>` section answers "which pull request, in which package, at which version" directly. A commit range only lists merges, and cannot say which published package — if any — a merge reached.

1. Diff `apps/npm/*/package.json` against `HEAD^` to find the packages this release bumped (platform sidecars excluded — they carry no entry of their own).
2. Take the `- <hash>: ` entries from that version's CHANGELOG section. `- Updated dependencies [hash]` is skipped: it repeats the hash of the package that actually changed, and crediting it here would name packages the pull request never touched.
3. Resolve each hash through `GET /commits/{sha}/pulls`, falling back to the trailing `(#N)` of the squash subject.
4. Comment on the pull request, and on each `closingIssuesReferences` issue.

A pull request with no changeset — chore, test, docs — is deliberately not commented on.

## Wiring

`release.yml` gets a `comment-released-versions` job with `needs: publish`, so a comment is never posted for a release that did not reach the registry. Job-level `permissions` replace the workflow-level block, which has no `issues: write` — without it the issue comments 404.

## What is gated, and why there

The release path runs once per release and only on `main`, so a mistake in the mapping would first surface as comments on the wrong issues. The parsers are pure and dependency-free, so `scripts/dev/test-release-comment.mjs` pins them on every pull request (new CI job `Release comment mapping`).

Each case is one a plausible implementation gets wrong while still looking correct on the happy path:

| shape | what a naive implementation does |
|---|---|
| `- Updated dependencies [c2a8eeb]` | credits a package that did not change |
| `## 0.1.1` is a prefix of `## 0.1.10` | a `startsWith` finder returns the other release's entries |
| `fix: x (#2547) (#2666)` | an unanchored match comments on the issue as if it were the pull request |

`collectReleases` is exercised against a fixture git repository that bumps two of four packages, so "it can skip an unbumped package" is asserted rather than assumed, with an unbumped control that must come back empty.

## Verification

Replacing each parser with its naive form makes exactly the corresponding check fail (4 of 17), so the suite is discriminating rather than merely green.

Dry run against the real 0.10.9 release resolves 6 pull requests and 6 issues:

```
@rsvelte/compiler@0.10.9: 5 changeset(s)
@rsvelte/svelte-check@0.5.13: 1 changeset(s)
#2666 -> #2547   #2670 -> #2669   #2672
#2660 -> #2653   #2663 -> #2652, #2661   #2668 -> #2650
```

Re-running the job is safe: each comment carries a marker and is skipped when one naming the same versions is already present. `--dry-run` performs that lookup too — a dedupe that never matches would otherwise stay invisible until the first re-run. Temporarily pointing the predicate at a marker that does occur in real comments returned `true` for the 6 pull requests and `false` for the 6 issues, so the check can move in both directions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PJL4sH9gBM8mkyAWs45hUB
