### PR TITLE
fix(lint): classify a no-unused-vars word boundary by character, not by byte

### DIFF
--- a/.changeset/unused-vars-non-ascii-boundary.md
+++ b/.changeset/unused-vars-non-ascii-boundary.md
@@ -1,0 +1,27 @@
+---
+"@rsvelte/lint": patch
+---
+
+Stop `svelte/no-unused-vars` reporting a binding whose only use is next to a non-ASCII space
+
+The rule's textual fallback — the one that keeps a name alive when Phase 2 records
+no reference for it (JSDoc `@type`, TypeScript type positions, generics) — decided
+word boundaries with a byte test that counted every byte `>= 0x80` as an identifier
+byte. A non-breaking space next to the name therefore read as identifier glue, the
+occurrence was discarded, and the binding was reported unused although it was used
+(here with a literal U+00A0 between `{` and `Foo`):
+
+```svelte
+<script>
+  import { Foo } from './x';
+  /** @type {<NBSP>Foo} */
+  let v = null;
+</script>
+```
+
+The boundary test now asks whether the neighbouring *character* is an ECMA-262
+`IdentifierPart` (`oxc_syntax::identifier::is_identifier_part`, the same rule the
+compiler's classifiers use), so non-ASCII spaces (U+00A0, U+2000–U+200A, U+2028,
+U+2029, U+202F, U+205F, U+3000, U+FEFF) are boundaries while accented letters, CJK
+and the zero-width joiners stay glue. ASCII input is unaffected: the two predicates
+agree on every ASCII byte.

--- a/crates/rsvelte_lint/src/rules/no_unused_vars.rs
+++ b/crates/rsvelte_lint/src/rules/no_unused_vars.rs
@@ -23,6 +23,7 @@
 use serde_json::Value;
 
 use rsvelte_core::compiler::phases::phase2_analyze::{Binding, BindingKind, DeclarationKind};
+use rsvelte_core::compiler::utils::{char_at, char_before, is_js_ident_continue};
 
 use crate::context::LintContext;
 use crate::rule::{Fixable, RuleCategory, RuleConditions, RuleMeta, Severity};
@@ -229,7 +230,6 @@ fn collect_pattern_names(pat: Option<&Value>, out: &mut Vec<String>) {
 /// TypeScript stripper removes (type annotations, generics) or that live in
 /// JSDoc, so a textual hit anywhere else vetoes the report.
 fn occurs_outside(source: &str, name: &str, decl_start: u32) -> bool {
-    let bytes = source.as_bytes();
     let mut from = 0usize;
     while let Some(rel) = source[from..].find(name) {
         let at = from + rel;
@@ -237,22 +237,15 @@ fn occurs_outside(source: &str, name: &str, decl_start: u32) -> bool {
         if at as u32 == decl_start {
             continue;
         }
-        let before_ok = at == 0 || !is_ident_or_non_ascii_byte(bytes[at - 1]);
-        let after = at + name.len();
-        let after_ok = after >= bytes.len() || !is_ident_or_non_ascii_byte(bytes[after]);
+        // A neighbour is glue only if it could continue the identifier; every
+        // other character (including non-ASCII space) is a word boundary.
+        let before_ok = char_before(source, at).is_none_or(|c| !is_js_ident_continue(c));
+        let after_ok = char_at(source, at + name.len()).is_none_or(|c| !is_js_ident_continue(c));
         if before_ok && after_ok {
             return true;
         }
     }
     false
-}
-
-/// Byte-level boundary guard: every non-ASCII byte counts as glue, so a hit
-/// abutting one is not a standalone occurrence. Wider than a JS identifier
-/// character, and the name says so — `svelte_scan::is_ascii_ident_byte` is the
-/// narrower guard used elsewhere in this crate.
-fn is_ident_or_non_ascii_byte(b: u8) -> bool {
-    b.is_ascii_alphanumeric() || b == b'_' || b == b'$' || b >= 0x80
 }
 
 #[cfg(test)]
@@ -405,5 +398,79 @@ mod tests {
     #[test]
     fn component_used_only_in_template_is_not_unused() {
         assert_clean("<script>\n  import Child from './Child.svelte';\n</script>\n<Child />");
+    }
+
+    /// A JSDoc `@type` is the shape this rule's textual fallback exists for, and
+    /// a non-ASCII space in it must not hide the use.
+    #[test]
+    fn nbsp_separated_jsdoc_use_is_not_unused() {
+        assert_clean(
+            "<script>\n  import { Foo } from './x';\n  /** @type {\u{a0}Foo} */\n  let v = null;\n</script>\n<p>{v}</p>",
+        );
+    }
+
+    /// A neighbour that can continue an identifier keeps the hit non-standalone,
+    /// so the binding stays reported — the direction a blanket
+    /// "non-ASCII is a boundary" rule would break.
+    #[test]
+    fn identifier_neighbour_still_hides_the_occurrence() {
+        assert_reports(
+            "<script>\n  const foo = 1;\n</script>\n<p>foo\u{7dcf}</p>",
+            "foo",
+        );
+        assert_reports(
+            "<script>\n  const foo = 1;\n</script>\n<p>foo\u{e9}</p>",
+            "foo",
+        );
+    }
+
+    /// Boundary characters: an occurrence flanked by them is standalone.
+    /// `U+0085` is here because it is not `ID_Continue`, independent of the
+    /// separate question of whether a JS parser accepts it as whitespace.
+    #[test]
+    fn non_identifier_neighbours_are_word_boundaries() {
+        for sep in [
+            ' ',
+            '\n',
+            '.',
+            '\u{85}',
+            '\u{a0}',
+            '\u{1680}',
+            '\u{2000}',
+            '\u{2009}',
+            '\u{2028}',
+            '\u{2029}',
+            '\u{202f}',
+            '\u{205f}',
+            '\u{3000}',
+            '\u{feff}',
+            '\u{2014}',
+            '\u{3001}',
+            '\u{1f600}',
+        ] {
+            let src = format!("x{sep}foo{sep}y");
+            assert!(
+                super::occurs_outside(&src, "foo", u32::MAX),
+                "U+{:04X} must be a word boundary",
+                sep as u32
+            );
+        }
+    }
+
+    /// The other direction of the same predicate: `ID_Start` / `ID_Continue`
+    /// characters, `$`, `_` and the zero-width joiners are identifier glue.
+    #[test]
+    fn identifier_neighbours_are_glue() {
+        for glue in [
+            'a', 'Z', '0', '_', '$', '\u{e9}', '\u{7dcf}', '\u{5d0}', '\u{3005}', '\u{200c}',
+            '\u{200d}',
+        ] {
+            let src = format!("x{glue}foo{glue}y");
+            assert!(
+                !super::occurs_outside(&src, "foo", u32::MAX),
+                "U+{:04X} must be identifier glue",
+                glue as u32
+            );
+        }
     }
 }


### PR DESCRIPTION
Fixes #2532.

## The defect

`svelte/no-unused-vars` keeps a binding alive when its name occurs anywhere else in
the source, because Phase 2 records no reference for reads the TypeScript stripper
removes or that live in JSDoc. That textual fallback decided word boundaries with a
byte test (`crates/rsvelte_lint/src/rules/no_unused_vars.rs`,
`is_ident_or_non_ascii_byte`):

```rust
b.is_ascii_alphanumeric() || b == b'_' || b == b'$' || b >= 0x80
```

`b >= 0x80` is right for an identifier continuation (`総額` really is one word) and
wrong for every non-ASCII character that is not one — first among them the space
separators. A neighbouring NBSP read as identifier glue, the occurrence was
discarded, and a **used** binding was reported unused.

## What I verified, and how

### The reported input is not the reachable one

The issue's repro is `bar(foo<NBSP>+ 1)` in the instance script. That shape is not
reachable: NBSP is `<USP>` (ECMA-262 §12.2 WhiteSpace), so the script parses, Phase 2
records a reference for `foo`, and the `binding.references` check returns before
`occurs_outside` is ever called. I probed six candidate shapes through the real rule
before writing a test; the reachable one is the shape the fallback exists for — a
JSDoc `@type`:

```
ts-annot-plain:   []
ts-annot-nbsp:    []
ts-annot-generic: []
jsdoc:            []
jsdoc-nbsp:       ["'Foo' is defined but never used."]   <-- false positive
markup-text:      ["'foo' is defined but never used."]
markup-text-cjk:  ["'foo' is defined but never used."]
```

So the *defect* is real and the *repro in the issue is not*; the committed test uses
the shape that reaches the code.

### The fix

The boundary test now classifies the neighbouring **character**, not the byte, via
`rsvelte_core::compiler::utils::is_js_ident_continue`
(`oxc_syntax::identifier::is_identifier_part`) — the pair #2531 added for exactly
this, so the linter stops carrying a third private copy of the rule.

Rule source, not intuition: ECMA-262 §12.7.1 defines
`IdentifierPartChar :: UnicodeIDContinue | $ | <ZWNJ> | <ZWJ>`, and §12.2 / §12.3 put
the space separators (`<USP>` = Unicode `Space_Separator`: U+00A0, U+1680,
U+2000–U+200A, U+202F, U+205F, U+3000), `<ZWNBSP>` (U+FEFF) and the line terminators
U+2028 / U+2029 outside it. Upstream behaviour agrees: ESLint core's `no-unused-vars`
resolves uses through the scope analyser over an acorn AST, where
`isIdentifierChar(code, true)` is the same set and inter-token whitespace is not a
boundary question at all.

ASCII is unaffected — `is_identifier_part` and the old byte test agree on every ASCII
byte, so the change is confined to `>= 0x80`.

### Both directions are tested, and each test can fail

**Direction 1 — non-ASCII whitespace that is not an identifier character.**
`non_identifier_neighbours_are_word_boundaries` plus the end-to-end
`nbsp_separated_jsdoc_use_is_not_unused`. Against the unfixed predicate
(`… || b >= 0x80` restored):

```
---- nbsp_separated_jsdoc_use_is_not_unused stdout ----
expected no findings, got ["'Foo' is defined but never used."]
--- source ---
<script>
  import { Foo } from './x';
  /** @type {<NBSP>Foo} */
  let v = null;
</script>
<p>{v}</p>

---- non_identifier_neighbours_are_word_boundaries stdout ----
U+0085 must be a word boundary

test result: FAILED. 21 passed; 2 failed; 0 ignored; 0 measured; 258 filtered out
```

Both fail, and for the predicted reason (the table fails at its first non-ASCII
entry).

**Direction 2 — non-ASCII characters that legitimately are identifier characters.**
`identifier_neighbours_are_glue` (`é`, `総`, `א`, `々`, ZWNJ, ZWJ, `$`, `_`, digits)
and the end-to-end `identifier_neighbour_still_hides_the_occurrence`. These pass both
before and after the fix by design; what makes them non-vacuous is the tempting wrong
fix — "reject all non-ASCII", i.e. dropping the `>= 0x80` term instead of replacing
it. Against that mutant:

```
test rules::no_unused_vars::tests::identifier_neighbours_are_glue ... FAILED
test rules::no_unused_vars::tests::identifier_neighbour_still_hides_the_occurrence ... FAILED
U+00E9 must be identifier glue
expected a finding for 'foo', got []
test result: FAILED. 21 passed; 2 failed; 0 ignored; 0 measured; 258 filtered out
```

So each of the four new tests is killed by a mutant, and the two mutants are the two
directions of the predicate.

### `U+0085`

#2582 records `oxc_parser` accepting U+0085 (NEL) as JS whitespace where ECMA-262 and
acorn reject it. That divergence does not propagate here and this PR does not copy it:
the predicate this code needs is `IdentifierPart`, and NEL is `Cc`, not `ID_Continue`,
under both oxc and ECMA-262. NEL is therefore a word boundary — the answer both specs
give — and it sits in the boundary table with that reason on one line.

## Other members of the same predicate class

- `is_ident_or_non_ascii_byte` had exactly two call sites, both inside
  `occurs_outside`; it is deleted.
- `crates/rsvelte_lint/src/rules/scss_selector.rs:675,680` have the same `>= 0x80`
  shape but are **CSS** ident predicates, and CSS Syntax Level 3 §4.2 does make
  non-ASCII code points ident code points — a different spec with a different answer,
  so left alone. (Current css-syntax-3 narrows "non-ASCII ident code point" to a list
  that excludes U+00A0; worth its own issue, not this PR.)
- `crates/rsvelte_lint/src/svelte_scan.rs:204` `is_ascii_ident_byte` is the *opposite*
  error of the same family — it treats `é` as a boundary — and is used by
  `no_unused_props`, `require_event_prefix`, `require_event_dispatcher_types` and
  `declares_type_in`. Out of scope for #2532; reported separately.

## Ratchets — the issue's note is wrong, and I checked rather than assumed

`lint-verify.mjs` compares only what `ruleUniverse()` returns, which is
`rsvelte ∩ eslint-plugin-svelte` (`scripts/compat-corpus/lint-universe.mjs:84`), and
the pinned plugin (3.22.0, submodule `32ba9159`) has no `no-unused-vars` rule:
`gh api …/src/rules?ref=32ba9159` lists `no-unused-class-name`, `no-unused-props`,
`no-unused-svelte-ignore` and nothing else (positive control — the same filter did
return those three). `compatibility/lint-known-failures.json` holds 0 entries for the
rule. `crates/rsvelte_lint/tests/eslint_plugin_oracle.rs:72` states the same from the
other side and names the inline unit tests as this rule's gate, which is where the new
tests live. No re-baseline is needed, and none is possible.

## Tests

`cargo test --release -p rsvelte_lint` — 281 lib tests plus every integration suite
pass (4 new tests).
