### PR TITLE
fix(check): read compilerOptions.namespace instead of hardcoding the TSX overlay to html

### DIFF
--- a/.changeset/wise-eels-attack.md
+++ b/.changeset/wise-eels-attack.md
@@ -1,0 +1,5 @@
+---
+'@rsvelte/svelte-check': patch
+---
+
+Read `compilerOptions.namespace` from `svelte.config.*` / the inline `svelte()` / `sveltekit()` plugin options and use it for the TSX projection, which was hardcoded to `html`. `namespace: 'foreign'` now keeps element attribute casing as upstream svelte-check does, and a namespace the Svelte 5 compiler rejects is reported as `options_invalid_value` per checked component instead of being ignored.

--- a/compatibility/check-fixtures/svelte-config-namespace-foreign/project/package.json
+++ b/compatibility/check-fixtures/svelte-config-namespace-foreign/project/package.json
@@ -1,0 +1,5 @@
+{
+	"name": "check-fixture-svelte-config-namespace-foreign",
+	"private": true,
+	"type": "module"
+}

--- a/compatibility/check-fixtures/svelte-config-namespace-foreign/project/src/Attrs.svelte
+++ b/compatibility/check-fixtures/svelte-config-namespace-foreign/project/src/Attrs.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+	const label: string = 'hi';
+</script>
+
+<div contentEditable="true">{label}</div>
+<div someAttr="x">{label}</div>
+<svg viewBox="0 0 1 1"></svg>

--- a/compatibility/check-fixtures/svelte-config-namespace-foreign/project/svelte.config.js
+++ b/compatibility/check-fixtures/svelte-config-namespace-foreign/project/svelte.config.js
@@ -1,0 +1,1 @@
+export default { compilerOptions: { namespace: 'foreign' } };

--- a/compatibility/check-fixtures/svelte-config-namespace-foreign/project/tsconfig.json
+++ b/compatibility/check-fixtures/svelte-config-namespace-foreign/project/tsconfig.json
@@ -1,0 +1,14 @@
+{
+	"compilerOptions": {
+		"target": "esnext",
+		"module": "esnext",
+		"moduleResolution": "bundler",
+		"strict": true,
+		"skipLibCheck": true,
+		"noEmit": true
+	},
+	"include": [
+		"src/**/*.ts",
+		"src/**/*.svelte"
+	]
+}

--- a/compatibility/check-fixtures/svelte-config-namespace-foreign/scenario.json
+++ b/compatibility/check-fixtures/svelte-config-namespace-foreign/scenario.json
@@ -1,0 +1,5 @@
+{
+	"description": "`compilerOptions.namespace` reaches the TSX projection. Paired with `svelte-config-namespace-html`, whose project is byte-identical apart from the namespace value: only `foreign` suppresses svelte2tsx's attribute-name case fold, so `contentEditable` survives as written and stops matching `HTMLProps<'div'>`. `foreign` is also not a value the Svelte 5 compiler accepts, so `svelte.compile` rejects the options object once per checked component — both halves have to be reproduced for this scenario to reach parity.",
+	"workspace": ".",
+	"tsconfig": "tsconfig.json"
+}

--- a/compatibility/check-fixtures/svelte-config-namespace-html/project/package.json
+++ b/compatibility/check-fixtures/svelte-config-namespace-html/project/package.json
@@ -1,0 +1,5 @@
+{
+	"name": "check-fixture-svelte-config-namespace-html",
+	"private": true,
+	"type": "module"
+}

--- a/compatibility/check-fixtures/svelte-config-namespace-html/project/src/Attrs.svelte
+++ b/compatibility/check-fixtures/svelte-config-namespace-html/project/src/Attrs.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+	const label: string = 'hi';
+</script>
+
+<div contentEditable="true">{label}</div>
+<div someAttr="x">{label}</div>
+<svg viewBox="0 0 1 1"></svg>

--- a/compatibility/check-fixtures/svelte-config-namespace-html/project/svelte.config.js
+++ b/compatibility/check-fixtures/svelte-config-namespace-html/project/svelte.config.js
@@ -1,0 +1,1 @@
+export default { compilerOptions: { namespace: 'html' } };

--- a/compatibility/check-fixtures/svelte-config-namespace-html/project/tsconfig.json
+++ b/compatibility/check-fixtures/svelte-config-namespace-html/project/tsconfig.json
@@ -1,0 +1,14 @@
+{
+	"compilerOptions": {
+		"target": "esnext",
+		"module": "esnext",
+		"moduleResolution": "bundler",
+		"strict": true,
+		"skipLibCheck": true,
+		"noEmit": true
+	},
+	"include": [
+		"src/**/*.ts",
+		"src/**/*.svelte"
+	]
+}

--- a/compatibility/check-fixtures/svelte-config-namespace-html/scenario.json
+++ b/compatibility/check-fixtures/svelte-config-namespace-html/scenario.json
@@ -1,0 +1,5 @@
+{
+	"description": "Control for `svelte-config-namespace-foreign`: same sources, `namespace: 'html'`. Every value the Svelte 5 compiler accepts leaves the projection unchanged (svelte2tsx branches on `foreign` alone), so this scenario must keep exactly the one diagnostic that does not depend on the namespace — without it, a projection that never folds attribute case at all would satisfy the `foreign` scenario too.",
+	"workspace": ".",
+	"tsconfig": "tsconfig.json"
+}

--- a/crates/rsvelte_check/src/svelte_check/config.rs
+++ b/crates/rsvelte_check/src/svelte_check/config.rs
@@ -35,6 +35,11 @@ use oxc_parser::Parser as OxcParser;
 use oxc_span::SourceType;
 
 use super::kit_file::{lookup_property, unwrap_define_config_object};
+use crate::svelte2tsx::Svelte2TsxNamespace;
+
+/// Namespaces the Svelte 5 compiler accepts for `compilerOptions.namespace`
+/// (`validate-options.js`'s `list(['html', 'mathml', 'svg'])`).
+const COMPILER_NAMESPACES: [&str; 3] = ["html", "mathml", "svg"];
 
 /// Subset of Svelte `compilerOptions` that influence svelte-check
 /// diagnostics. Extend as more options gain diagnostic relevance.
@@ -47,6 +52,12 @@ pub struct CompilerOptionsSettings {
     /// `compilerOptions.runes` — forces runes mode on/off. `None` =
     /// auto-detect (the compiler default).
     pub runes: Option<bool>,
+    /// `compilerOptions.namespace`, verbatim. Kept as the raw string
+    /// because the projection and the compiler disagree about the legal
+    /// set: svelte2tsx still honours the Svelte 4 value `foreign`, which
+    /// the Svelte 5 compiler rejects, and both consequences are
+    /// user-visible.
+    pub namespace: Option<String>,
 }
 
 impl CompilerOptionsSettings {
@@ -56,7 +67,33 @@ impl CompilerOptionsSettings {
     /// mtime/size is unaffected by a config edit, so the per-file key
     /// alone can't notice it).
     pub fn signature(&self) -> String {
-        format!("async={};runes={:?}", self.experimental_async, self.runes)
+        format!(
+            "async={};runes={:?};namespace={:?}",
+            self.experimental_async, self.runes, self.namespace
+        )
+    }
+
+    /// The namespace the TSX projection runs under. Mirrors
+    /// `DocumentSnapshot.ts`'s `namespace: document.config?.compilerOptions
+    /// ?.namespace`: the config string reaches svelte2tsx unvalidated, and
+    /// only `foreign` changes what it emits (attribute case is preserved).
+    pub fn projection_namespace(&self) -> Svelte2TsxNamespace {
+        match self.namespace.as_deref() {
+            Some("svg") => Svelte2TsxNamespace::Svg,
+            Some("mathml") => Svelte2TsxNamespace::Mathml,
+            Some("foreign") => Svelte2TsxNamespace::Foreign,
+            _ => Svelte2TsxNamespace::Html,
+        }
+    }
+
+    /// The configured namespace when the Svelte 5 compiler would reject it.
+    /// `svelte.compile` validates its options, so upstream svelte-check
+    /// surfaces `options_invalid_value` for every checked component of such
+    /// a project; rsvelte builds `CompileOptions` from a typed enum and so
+    /// has to make that check itself.
+    pub fn invalid_namespace(&self) -> Option<&str> {
+        let ns = self.namespace.as_deref()?;
+        (!COMPILER_NAMESPACES.contains(&ns)).then_some(ns)
     }
 }
 
@@ -382,9 +419,10 @@ fn vite_uses_inline_sveltekit_config(source: &str, source_type: SourceType) -> b
     false
 }
 
-/// Read `compilerOptions.{experimental.async, runes}` out of an object
-/// expression (either a svelte.config root object or a svelte-plugin
-/// options object). Only sets a field when a boolean literal is present.
+/// Read `compilerOptions.{experimental.async, runes, namespace}` out of an
+/// object expression (either a svelte.config root object or a svelte-plugin
+/// options object). Only sets a field when a literal of the right kind is
+/// present.
 fn extract_compiler_options(obj: &oxc::ObjectExpression, settings: &mut CompilerOptionsSettings) {
     let Some(oxc::Expression::ObjectExpression(co)) = lookup_property(obj, "compilerOptions")
     else {
@@ -392,6 +430,9 @@ fn extract_compiler_options(obj: &oxc::ObjectExpression, settings: &mut Compiler
     };
     if let Some(oxc::Expression::BooleanLiteral(b)) = lookup_property(co, "runes") {
         settings.runes = Some(b.value);
+    }
+    if let Some(oxc::Expression::StringLiteral(s)) = lookup_property(co, "namespace") {
+        settings.namespace = Some(s.value.to_string());
     }
     if let Some(oxc::Expression::ObjectExpression(exp)) = lookup_property(co, "experimental")
         && let Some(oxc::Expression::BooleanLiteral(b)) = lookup_property(exp, "async")
@@ -602,6 +643,96 @@ mod tests {
         );
         let s = load_compiler_options(&dir);
         assert_eq!(s.runes, Some(true));
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn reads_namespace_from_svelte_config() {
+        let dir = workspace("ns_svelte");
+        write(
+            &dir,
+            "svelte.config.js",
+            "export default { compilerOptions: { namespace: 'foreign' } };",
+        );
+        let s = load_compiler_options(&dir);
+        assert_eq!(s.namespace.as_deref(), Some("foreign"));
+        assert_eq!(s.projection_namespace(), Svelte2TsxNamespace::Foreign);
+        assert_eq!(s.invalid_namespace(), Some("foreign"));
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn reads_namespace_from_vite_plugin_call() {
+        let dir = workspace("ns_vite");
+        write(
+            &dir,
+            "vite.config.ts",
+            r#"import { svelte } from '@sveltejs/vite-plugin-svelte';
+            export default { plugins: [svelte({ compilerOptions: { namespace: 'svg' } })] };"#,
+        );
+        let s = load_compiler_options(&dir);
+        assert_eq!(s.namespace.as_deref(), Some("svg"));
+        assert_eq!(s.projection_namespace(), Svelte2TsxNamespace::Svg);
+        assert_eq!(s.invalid_namespace(), None);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// Only `foreign` changes what svelte2tsx emits, so the mapping has to be
+    /// pinned alongside the fact that every compiler-legal value is inert.
+    #[test]
+    fn namespace_maps_to_the_projection_namespace() {
+        let cases = [
+            (None, Svelte2TsxNamespace::Html),
+            (Some("html"), Svelte2TsxNamespace::Html),
+            (Some("svg"), Svelte2TsxNamespace::Svg),
+            (Some("mathml"), Svelte2TsxNamespace::Mathml),
+            (Some("foreign"), Svelte2TsxNamespace::Foreign),
+            (Some("nonsense"), Svelte2TsxNamespace::Html),
+        ];
+        for (raw, expected) in cases {
+            let s = CompilerOptionsSettings {
+                namespace: raw.map(str::to_string),
+                ..Default::default()
+            };
+            assert_eq!(s.projection_namespace(), expected, "namespace {raw:?}");
+        }
+    }
+
+    /// The compiler's legal set is narrower than the projection's: `foreign`
+    /// is a Svelte 4 value svelte2tsx still honours and `svelte.compile`
+    /// rejects.
+    #[test]
+    fn only_compiler_illegal_namespaces_are_reported() {
+        for legal in ["html", "svg", "mathml"] {
+            let s = CompilerOptionsSettings {
+                namespace: Some(legal.to_string()),
+                ..Default::default()
+            };
+            assert_eq!(s.invalid_namespace(), None, "{legal} is a compiler value");
+        }
+        for illegal in ["foreign", "HTML", ""] {
+            let s = CompilerOptionsSettings {
+                namespace: Some(illegal.to_string()),
+                ..Default::default()
+            };
+            assert_eq!(s.invalid_namespace(), Some(illegal));
+        }
+        assert_eq!(CompilerOptionsSettings::default().invalid_namespace(), None);
+    }
+
+    /// A non-literal value is unreadable, and reporting it as invalid would
+    /// be a false positive on a project that computes a legal one.
+    #[test]
+    fn dynamic_namespace_is_not_read() {
+        let dir = workspace("ns_dynamic");
+        write(
+            &dir,
+            "svelte.config.js",
+            "import { ns } from './ns.js';\nexport default { compilerOptions: { namespace: ns } };",
+        );
+        let s = load_compiler_options(&dir);
+        assert_eq!(s.namespace, None);
+        assert_eq!(s.invalid_namespace(), None);
         let _ = std::fs::remove_dir_all(&dir);
     }
 
@@ -950,14 +1081,18 @@ mod tests {
 
     #[test]
     fn signature_changes_with_options() {
-        let a = CompilerOptionsSettings {
-            experimental_async: false,
-            runes: None,
-        };
+        let a = CompilerOptionsSettings::default();
         let b = CompilerOptionsSettings {
             experimental_async: true,
-            runes: None,
+            ..Default::default()
         };
         assert_ne!(a.signature(), b.signature());
+        // The overlay shadows depend on the namespace, so the signature that
+        // invalidates them has to move with it.
+        let c = CompilerOptionsSettings {
+            namespace: Some("foreign".to_string()),
+            ..Default::default()
+        };
+        assert_ne!(a.signature(), c.signature());
     }
 }

--- a/crates/rsvelte_check/src/svelte_check/manifest.rs
+++ b/crates/rsvelte_check/src/svelte_check/manifest.rs
@@ -61,6 +61,11 @@ pub struct ManifestEntry {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Manifest {
     pub version: u32,
+    /// `CompilerOptionsSettings::signature()` of the run that wrote this
+    /// manifest — the shadows depend on those options, which no per-file
+    /// `(mtime, size)` key can observe.
+    #[serde(default)]
+    pub config_signature: String,
     /// Keyed by absolute source path while in memory; serialised with
     /// workspace-relative paths via [`save`] / [`load`] so the file is
     /// portable across machines.
@@ -71,6 +76,7 @@ impl Manifest {
     pub fn empty() -> Self {
         Self {
             version: MANIFEST_VERSION,
+            config_signature: String::new(),
             entries: HashMap::new(),
         }
     }
@@ -86,6 +92,8 @@ pub fn load(manifest_path: &Path, workspace: &Path) -> Manifest {
     #[derive(Deserialize)]
     struct OnDiskManifest {
         version: u32,
+        #[serde(default)]
+        config_signature: String,
         #[serde(default)]
         entries: HashMap<String, OnDiskEntry>,
     }
@@ -128,6 +136,7 @@ pub fn load(manifest_path: &Path, workspace: &Path) -> Manifest {
     }
     Manifest {
         version: parsed.version,
+        config_signature: parsed.config_signature,
         entries,
     }
 }
@@ -142,6 +151,7 @@ pub fn save(manifest_path: &Path, manifest: &Manifest, workspace: &Path) -> std:
     #[derive(Serialize)]
     struct OnDiskManifest {
         version: u32,
+        config_signature: String,
         entries: HashMap<String, OnDiskEntry>,
     }
     #[derive(Serialize)]
@@ -170,6 +180,7 @@ pub fn save(manifest_path: &Path, manifest: &Manifest, workspace: &Path) -> std:
     }
     let body = OnDiskManifest {
         version: manifest.version,
+        config_signature: manifest.config_signature.clone(),
         entries: out_entries,
     };
     let json = serde_json::to_string_pretty(&body).map_err(std::io::Error::other)?;

--- a/crates/rsvelte_check/src/svelte_check/overlay.rs
+++ b/crates/rsvelte_check/src/svelte_check/overlay.rs
@@ -25,6 +25,7 @@ use oxc_ast::ast as oxc;
 use oxc_parser::Parser as OxcParser;
 use oxc_span::SourceType;
 
+use super::config::CompilerOptionsSettings;
 use super::diagnostic::{Diagnostic, DiagnosticSeverity, Position, Range};
 use super::kit_file::{self, AddedCode, KitFilesSettings};
 use super::manifest::{self, Manifest, ManifestEntry, current_stats};
@@ -108,9 +109,10 @@ struct SveltePackage {
 /// pair (`svelte-shims.d.ts` / `svelte-jsx.d.ts`), which rsvelte does not
 /// vendor because it is a Svelte 5 compiler — Svelte 3 falls back to the v4
 /// pair; and `svelte-native-jsx.d.ts`, which only types the
-/// `svelteNative.JSX` namespace rsvelte never emits (the overlay always runs
-/// svelte2tsx with `Svelte2TsxNamespace::Html`), matching upstream
-/// svelte-check's own commented-out entry in `incremental.ts`.
+/// `svelteNative.JSX` typings namespace rsvelte never emits — upstream selects
+/// that one from the tsconfig's `svelteOptions.namespace`, a separate input
+/// from `compilerOptions.namespace`, matching svelte-check's own commented-out
+/// entry in `incremental.ts`.
 fn select_global_types(workspace: &Path, cache_dir: &Path) -> GlobalTypes {
     // The resolved path is written into the overlay tsconfig, which lives in
     // a different directory than the CLI's cwd a relative `--workspace`
@@ -391,7 +393,14 @@ pub fn materialize_overlay(
     files: &[PathBuf],
     tsconfig_path: Option<&Path>,
 ) -> Result<OverlayLayout, OverlayError> {
-    materialize_overlay_with(workspace, files, tsconfig_path, false, &[])
+    materialize_overlay_with(
+        workspace,
+        files,
+        tsconfig_path,
+        false,
+        &[],
+        &CompilerOptionsSettings::default(),
+    )
 }
 
 /// Same as [`materialize_overlay_with`] but also materialises SvelteKit
@@ -407,9 +416,16 @@ pub fn materialize_overlay_with_kit(
     incremental: bool,
     settings: &KitFilesSettings,
     ignore: &[String],
+    compiler_opts: &CompilerOptionsSettings,
 ) -> Result<OverlayLayout, OverlayError> {
-    let mut layout =
-        materialize_overlay_with(workspace, svelte_files, tsconfig_path, incremental, ignore)?;
+    let mut layout = materialize_overlay_with(
+        workspace,
+        svelte_files,
+        tsconfig_path,
+        incremental,
+        ignore,
+        compiler_opts,
+    )?;
     layout.kit_entries = materialize_kit_files(workspace, &layout.emit_dir, kit_files, settings)?;
     materialize_kit_types(workspace, &layout.emit_dir, kit_files)?;
     // A kit file already has a mirror copy at its own path, which resolves its
@@ -445,20 +461,31 @@ pub fn materialize_overlay_with(
     tsconfig_path: Option<&Path>,
     incremental: bool,
     ignore: &[String],
+    compiler_opts: &CompilerOptionsSettings,
 ) -> Result<OverlayLayout, OverlayError> {
     let cache_dir = workspace.join(".svelte-check");
     let emit_dir = cache_dir.join("svelte");
     fs::create_dir_all(&emit_dir)?;
     let manifest_path = cache_dir.join("manifest.json");
+    let namespace = compiler_opts.projection_namespace();
+    let config_signature = compiler_opts.signature();
     // Chosen up front: every shadow's `<reference types="svelte" />` has to be
     // blanked as it is emitted once the blanked copy stands in for the package.
     let global_types = select_global_types(workspace, &cache_dir);
 
+    // The shadows depend on `compilerOptions` too, and a config edit moves
+    // neither the source mtime nor its size.
     let mut manifest = if incremental {
-        manifest::load(&manifest_path, workspace)
+        let cached = manifest::load(&manifest_path, workspace);
+        if cached.config_signature == config_signature {
+            cached
+        } else {
+            Manifest::empty()
+        }
     } else {
         Manifest::empty()
     };
+    manifest.config_signature = config_signature;
 
     // Resolve every input to an absolute path up-front so we can use
     // it both as the manifest key and (later) for prune.
@@ -506,6 +533,7 @@ pub fn materialize_overlay_with(
             svelte_resolver.as_ref(),
             &ext_root_dir_pairs,
             global_types.svelte_types.is_some(),
+            namespace,
         )?;
         module_bridges.extend(emit_svelte_module_bridges(
             &pkg.real_dir,
@@ -564,7 +592,7 @@ pub fn materialize_overlay_with(
                 is_ts_file,
                 mode: Svelte2TsxMode::Ts,
                 accessors: false,
-                namespace: Svelte2TsxNamespace::Html,
+                namespace,
                 version: SvelteVersion::V5,
                 runes: None,
                 // emit_jsdoc=true is required so tsgo doesn't choke on
@@ -878,6 +906,7 @@ fn emit_external_shadows(
     resolver: Option<&oxc_resolver::Resolver>,
     ext_pairs: &[(PathBuf, PathBuf)],
     blank_svelte_reference: bool,
+    namespace: Svelte2TsxNamespace,
 ) -> Result<(), OverlayError> {
     // Mirror the package's own `node_modules` into the shadow dir so the
     // shadow's bare-package imports (`import type { X } from 'sortablejs'`,
@@ -913,7 +942,7 @@ fn emit_external_shadows(
             is_ts_file,
             mode: Svelte2TsxMode::Ts,
             accessors: false,
-            namespace: Svelte2TsxNamespace::Html,
+            namespace,
             version: SvelteVersion::V5,
             runes: None,
             emit_jsdoc: true,
@@ -3421,6 +3450,25 @@ mod tests {
     static CWD_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
     use std::fs;
     use std::io::Write;
+
+    /// Shadows the real entry point with the default compiler options; the
+    /// tests below are about layout and module resolution, not config.
+    fn materialize_overlay_with(
+        workspace: &Path,
+        files: &[PathBuf],
+        tsconfig_path: Option<&Path>,
+        incremental: bool,
+        ignore: &[String],
+    ) -> Result<OverlayLayout, OverlayError> {
+        super::materialize_overlay_with(
+            workspace,
+            files,
+            tsconfig_path,
+            incremental,
+            ignore,
+            &CompilerOptionsSettings::default(),
+        )
+    }
 
     #[test]
     fn strip_jsonc_comments_preserves_non_ascii() {

--- a/crates/rsvelte_check/src/svelte_check/runner.rs
+++ b/crates/rsvelte_check/src/svelte_check/runner.rs
@@ -221,6 +221,7 @@ pub fn run(options: &RunOptions) -> RunResult {
             options.incremental,
             &kit_settings,
             &options.ignore,
+            &compiler_opts,
         ) {
             Ok(layout) => {
                 if options.type_check {
@@ -636,7 +637,25 @@ fn diagnostics_for_file(file: &Path, compiler_opts: &CompilerOptionsSettings) ->
         runes: compiler_opts.runes,
         ..Default::default()
     };
-    match compile(&source, opts) {
+    let mut diagnostics: Vec<Diagnostic> = Vec::new();
+    // `svelte.compile` validates its options before it compiles anything, so
+    // upstream reports this once per checked component, not once per project.
+    if compiler_opts.invalid_namespace().is_some() {
+        diagnostics.push(Diagnostic {
+            file: file.to_path_buf(),
+            severity: DiagnosticSeverity::Error,
+            code: Some("options_invalid_value".into()),
+            message: "Invalid compiler option: namespace should be one of \"html\", \"mathml\" \
+                      or \"svg\"\nhttps://svelte.dev/e/options_invalid_value"
+                .into(),
+            range: Some(Range {
+                start: Position { line: 0, column: 0 },
+                end: Position { line: 0, column: 0 },
+            }),
+            source: "svelte",
+        });
+    }
+    diagnostics.extend(match compile(&source, opts) {
         Ok(res) => res
             .warnings
             .into_iter()
@@ -648,7 +667,7 @@ fn diagnostics_for_file(file: &Path, compiler_opts: &CompilerOptionsSettings) ->
                 range: range_from_warning(w.start.as_ref(), w.end.as_ref()),
                 source: "svelte",
             })
-            .collect(),
+            .collect::<Vec<_>>(),
         Err(e) => vec![Diagnostic {
             file: file.to_path_buf(),
             severity: DiagnosticSeverity::Error,
@@ -657,7 +676,8 @@ fn diagnostics_for_file(file: &Path, compiler_opts: &CompilerOptionsSettings) ->
             range: None,
             source: "svelte",
         }],
-    }
+    });
+    diagnostics
 }
 
 fn range_from_warning(


### PR DESCRIPTION
Closes #2529.

## What was wrong

`crates/rsvelte_check/src/svelte_check/overlay.rs` built the projection options with
`namespace: Svelte2TsxNamespace::Html` at both svelte2tsx call sites, and nothing in
`rsvelte-check` read `compilerOptions.namespace`. Both quantities in the issue check out
against the shipped source (the line numbers moved to 595 / 945 on current `main`).

## Where the option enters, and what upstream does with it

Upstream resolves **two different namespaces from two different files**, and does not
derive either from the other — this settles decision 2 in the issue:

| option | upstream source | upstream sink |
|---|---|---|
| markup `namespace` | `document.config.compilerOptions.namespace` (the svelte config) | `svelte2tsx({ namespace })`, `DocumentSnapshot.ts:250` |
| `typingsNamespace` | the **tsconfig**'s `svelteOptions.namespace` | `svelte2tsx({ typingsNamespace })`, `service.ts:432`, `typescript-plugin/src/index.ts:107` |

`typingsNamespace` is therefore out of scope for a `compilerOptions` reader: it is a
tsconfig key, it selects the `svelteNative.JSX` shim rsvelte does not vendor, and rsvelte's
projection has no such option at all. Filed as follow-up work below rather than guessed at
here.

This PR reads `compilerOptions.namespace` in `config.rs`'s `extract_compiler_options`
(`:434`), which is the one place `svelte.config.*`, the inline `svelte({…})` /
`sveltekit({…})` plugin options in `vite.config.*`, and `--config` all funnel through — so
all three routes get it with their existing precedence rules, including SvelteKit's
"inline `sveltekit()` config suppresses `svelte.config.js`" branch.

## The observable difference, measured — including where it is nil

Only `foreign` changes the projection. `preserves_attribute_case()`
(`crates/rsvelte_projection/src/svelte2tsx/interfaces.rs:37`) is the sole consumer of the
enum, and it matches `Foreign` alone — identical to upstream's
`const preserveAttributeCase = options.namespace === 'foreign'`
(`htmlxtojsx_v2/index.ts:109`).

**So `html` / `svg` / `mathml` produce byte-identical TSX, and therefore no diagnostic
difference whatsoever.** That is not an artefact of rsvelte: upstream's compiler reads
`options.namespace` in exactly one analysis site (`2-analyze/visitors/SvelteElement.js:42`),
which sets codegen metadata and no warning. A test asserting a `svg`-vs-`html` diagnostic
difference could not fail, so none was written; the `-html` scenario below asserts the
inverse — that the value is inert — instead.

`foreign` is the discriminating value, and it carries a second consequence: it is **not** a
namespace Svelte 5 accepts (`validate-options.js:112`, `list(['html','mathml','svg'])`), so
`svelte.compile` throws and upstream svelte-check reports `options_invalid_value` once per
checked component. Measured against the pinned oracle (svelte-check 4.7.5 / svelte 5.56.8)
on a project with `namespace: 'foreign'` and `<div contentEditable="true">`:

```
oracle   ERROR src/Attrs.svelte:1 options_invalid_value
oracle   ERROR src/Attrs.svelte:5 2353   ("contentEditable" — foreign only)
oracle   ERROR src/Attrs.svelte:6 2353   ("someAttr" — both namespaces)
rsvelte  ERROR src/Attrs.svelte:6 2353
```

Both halves had to be implemented for the fixture to reach parity, so the PR also emits
`options_invalid_value` for a namespace the compiler rejects. rsvelte builds `CompileOptions`
from a typed enum, so unlike upstream it never gets that check for free.

## The acceptance test, and its failure on the unfixed tree

Two Layer-1 svelte-check scenarios (`compatibility/check-fixtures/`), byte-identical apart
from the config value — the gate whose unit is a type-checked project, per gate-coverage
§12; per-file text gates cannot see a config key at all.

* `svelte-config-namespace-foreign` — `namespace: 'foreign'`
* `svelte-config-namespace-html` — `namespace: 'html'`, the control. Without it a projection
  that simply never folded attribute case would satisfy the `foreign` scenario too.

**Run against the unfixed tree** (`git checkout origin/main -- crates/rsvelte_check/src`,
rebuild, same fixtures):

```
[check-verify] svelte-config-namespace-foreign: oracle 3, rsvelte 1 diagnostic(s)
[check-verify] svelte-config-namespace-html: oracle 1, rsvelte 1 diagnostic(s)
[check-verify] divergences: 2 current, 0 known (2 new, 0 fixed)

[check-verify] ❌ 2 NEW divergence(s) from official svelte-check:
  svelte-config-namespace-foreign|-ERROR src/Attrs.svelte:1 options_invalid_value
  svelte-config-namespace-foreign|-ERROR src/Attrs.svelte:5 2353
```

It fails for exactly the two predicted reasons: the unread option (line 5) and the unvalidated
one (line 1). The control scenario does **not** move between trees, which is the property that
makes the pair discriminating rather than a pair of one-sided assertions. With the fix, the
full 32-scenario gate is `0 current, 0 known`, so `check-known-failures.json` stays `[]`.

## Neighbours: what the loader reads and what it drops

`namespace` was not the only one. All references are to
`crates/rsvelte_check/src/svelte_check/`.

**Read today** (all in `config.rs::extract_compiler_options` unless noted):

| key | line | reaches |
|---|---|---|
| `compilerOptions.runes` | `config.rs:431` | `compile()` only — `overlay.rs:597,947` still pass `runes: None` to svelte2tsx |
| `compilerOptions.namespace` | `config.rs:434` | svelte2tsx (this PR) + the validity check |
| `compilerOptions.experimental.async` | `config.rs:437` | `compile()` (`runner.rs:635`) |
| `compilerOptions.warningFilter` | `config.rs:510` | the Node sidecar (`runner.rs:288`) |

**Not read, and diagnostic-relevant:**

* `compilerOptions.accessors` — hardcoded `accessors: false` at `overlay.rs:594` and `:944`.
  Upstream passes `compilerOptions.accessors ?? customElement(…)` (`DocumentSnapshot.ts:251-258`),
  and the flag changes which `let` bindings become component exports
  (`rsvelte_projection/.../add_component_export.rs:68`, `exported_names.rs:662`) — i.e. it moves
  the component's prop type and so its diagnostics. This is the closest sibling of #2529 and
  is worth its own issue.
* `compilerOptions.customElement` — same call site upstream; feeds `accessors` when callable.
* **Every other key**, generically: upstream's warning path calls
  `svelte.compile(text, {...compilerOptions})` (`SvelteDocument.ts:90`), so *any* option that
  is invalid, or that moves a warning, becomes a diagnostic there. rsvelte constructs
  `CompileOptions` field by field, so nothing it does not name is either applied or validated.
  `namespace` is now the one exception; `runes: 'yes'` or `css: 'nonsense'` still pass silently.

## Also in here

`Manifest` gained a `config_signature` (`manifest.rs`), mirroring the warnings cache's
existing one. The `.tsx` shadows now depend on `compilerOptions`, and a config edit moves
neither the source mtime nor its size, so `--incremental` would otherwise reuse shadows
projected under the previous namespace.

## Verified / not verified

Verified: the before/after oracle comparison above; `cargo test -p rsvelte_check` (all suites
green); the full `check-verify.mjs` run (32 scenarios, 0 divergences); `cargo fmt` + `cargo
clippy --all-targets --all-features -D warnings`.

Not verified: Layer 2 (`check-e2e-verify.mjs`) was not run — its repos are not installed here,
and no `compilerOptions.namespace` appears in them. `--rsvelte-backend tsgo` was not run
either; the namespace affects only the emitted TSX text, which is upstream of the backend
choice.
