### PR TITLE
ci: extend the concurrency guard to job level, and run the ratchet-doc check where it can start

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1108,3 +1108,21 @@ jobs:
 
       - name: Run prerequisite coverage guard tests
         run: node scripts/ci/test-prereq-coverage-guard.mjs
+
+  ratchet-doc-guard:
+    name: Ratchet doc parity
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          submodules: false
+
+      # "Every ratchet on disk is declared" holds over the union of two branches,
+      # so no PR run can establish it: a `pull_request` merge ref is frozen when
+      # the event is created and may predate the rule it is checked against. The
+      # run that decides it is the push to `main`, and Corpus Compat cannot be
+      # that run — it is path-filtered and an hour long. This needs neither
+      # submodules nor a build, so it lives here instead.
+      - name: Verify known-failures.md matches the JSON ratchets
+        run: node scripts/compat-corpus/known-failures-md-check.mjs

--- a/compatibility/gate-coverage.md
+++ b/compatibility/gate-coverage.md
@@ -1154,6 +1154,12 @@ fixture gate runs on every PR. `corpus-compat.yml` **is** path-filtered (`push:`
 `known-failures-md-check.mjs` covers `known-failures.md` (`:37`), `warning-known-failures.md`
 (`:89`) and `matrix-known-failures.md` (`:153`). `ls compatibility/*.md` returns **16**.
 
+It runs from two places: `corpus-compat.yml:183` (path-filtered on both triggers, see C1) and
+`ci.yml`'s `ratchet-doc-guard` job (unfiltered). The second site exists because the assertion is
+over the **union** of two branches, which no `pull_request` run can observe — its merge ref is
+frozen when the event is created — so the only run that can decide it is the push to `main`, and
+the path filter meant most merges never started one.
+
 **[D] `compatibility/sourcemap-known-failures.md:158` says `| ratchet entries | 75 | **73** |`
 while `sourcemap-known-failures.json` has 74.** Already drifted, in an unchecked family.
 

--- a/scripts/ci/test-workflow-trigger-guard.mjs
+++ b/scripts/ci/test-workflow-trigger-guard.mjs
@@ -11,7 +11,12 @@ import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import { ALLOWLIST, analyzeWorkflow, checkWorkflows } from './workflow-trigger-guard.mjs';
+import {
+	ALLOWLIST,
+	JOB_CONCURRENCY_ALLOWLIST,
+	analyzeWorkflow,
+	checkWorkflows,
+} from './workflow-trigger-guard.mjs';
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const REAL_WORKFLOW_DIR = join(HERE, '..', '..', '.github', 'workflows');
@@ -67,7 +72,7 @@ console.log('workflow-trigger-guard self-test');
 
 check('flags an unallowlisted `pull_request: branches:` filter, naming the file', () => {
 	withDir({ 'offender.yml': FILTERED }, (dir) => {
-		const { violations } = checkWorkflows(dir, {});
+		const { violations } = checkWorkflows(dir, {}, {});
 		assert(violations.length === 1, `expected 1 violation, got ${violations.length}`);
 		assert(
 			violations[0].file === 'offender.yml',
@@ -78,7 +83,11 @@ check('flags an unallowlisted `pull_request: branches:` filter, naming the file'
 
 check('an allowlisted filter is accepted', () => {
 	withDir({ 'offender.yml': FILTERED }, (dir) => {
-		const { violations } = checkWorkflows(dir, { 'offender.yml': 'measures against a main baseline' });
+		const { violations } = checkWorkflows(
+			dir,
+			{ 'offender.yml': 'measures against a main baseline' },
+			{},
+		);
 		assert(violations.length === 0, `expected clean, got ${JSON.stringify(violations)}`);
 	});
 });
@@ -88,14 +97,14 @@ check('an allowlisted filter is accepted', () => {
 check('a `branches:` filter under `push:` alone is not a violation', () => {
 	const body = `name: push only\n\non:\n  push:\n    branches: [main]\n  pull_request:\n    paths:\n      - 'src/**'\n${JOBS}`;
 	withDir({ 'pushonly.yml': body }, (dir) => {
-		const { violations } = checkWorkflows(dir, {});
+		const { violations } = checkWorkflows(dir, {}, {});
 		assert(violations.length === 0, `expected clean, got ${JSON.stringify(violations)}`);
 	});
 });
 
 check('a bare `pull_request:` with no nested keys is not a violation', () => {
 	withDir({ 'bare.yml': UNFILTERED }, (dir) => {
-		const { violations } = checkWorkflows(dir, {});
+		const { violations } = checkWorkflows(dir, {}, {});
 		assert(violations.length === 0, `expected clean, got ${JSON.stringify(violations)}`);
 	});
 });
@@ -105,7 +114,7 @@ check('a bare `pull_request:` with no nested keys is not a violation', () => {
 check('block-sequence `branches:` listed after `types:`/`paths:` is caught', () => {
 	const body = `name: late\n\non:\n  push:\n    branches: [main]\n  pull_request:\n    types: [opened, synchronize]\n    paths:\n      - 'src/**'\n    branches:\n      - main\n      - 'release/**'\n${JOBS}`;
 	withDir({ 'late.yml': body }, (dir) => {
-		const { violations } = checkWorkflows(dir, {});
+		const { violations } = checkWorkflows(dir, {}, {});
 		assert(violations.length === 1, `expected 1 violation, got ${violations.length}`);
 	});
 });
@@ -113,7 +122,7 @@ check('block-sequence `branches:` listed after `types:`/`paths:` is caught', () 
 check('`branches-ignore:` is caught on the same axis', () => {
 	const body = `name: ignore\n\non:\n  pull_request:\n    branches-ignore: ['legacy/**']\n${JOBS}`;
 	withDir({ 'ignore.yml': body }, (dir) => {
-		const { violations } = checkWorkflows(dir, {});
+		const { violations } = checkWorkflows(dir, {}, {});
 		assert(violations.length === 1, `expected 1 violation, got ${violations.length}`);
 	});
 });
@@ -121,7 +130,7 @@ check('`branches-ignore:` is caught on the same axis', () => {
 check('`pull_request_target:` is caught too', () => {
 	const body = `name: target\n\non:\n  pull_request_target:\n    branches: [main]\n${JOBS}`;
 	withDir({ 'target.yml': body }, (dir) => {
-		const { violations } = checkWorkflows(dir, {});
+		const { violations } = checkWorkflows(dir, {}, {});
 		assert(violations.length === 1, `expected 1 violation, got ${violations.length}`);
 	});
 });
@@ -129,7 +138,7 @@ check('`pull_request_target:` is caught too', () => {
 check('a commented-out `branches:` does not count', () => {
 	const body = `name: commented\n\non:\n  pull_request:\n    # branches: [main]\n    types: [opened]\n${JOBS}`;
 	withDir({ 'commented.yml': body }, (dir) => {
-		const { violations } = checkWorkflows(dir, {});
+		const { violations } = checkWorkflows(dir, {}, {});
 		assert(violations.length === 0, `expected clean, got ${JSON.stringify(violations)}`);
 	});
 });
@@ -137,7 +146,7 @@ check('a commented-out `branches:` does not count', () => {
 check('a `branches:` key nested deeper than the trigger does not count', () => {
 	const body = `name: deep\n\non:\n  pull_request:\n    types: [opened]\n${JOBS}    env:\n      branches: nope\n`;
 	withDir({ 'deep.yml': body }, (dir) => {
-		const { violations } = checkWorkflows(dir, {});
+		const { violations } = checkWorkflows(dir, {}, {});
 		assert(violations.length === 0, `expected clean, got ${JSON.stringify(violations)}`);
 	});
 });
@@ -146,7 +155,7 @@ check('a `branches:` key nested deeper than the trigger does not count', () => {
 
 check('an allowlist entry for an unfiltered workflow is a stale-entry violation', () => {
 	withDir({ 'bare.yml': UNFILTERED }, (dir) => {
-		const { violations } = checkWorkflows(dir, { 'bare.yml': 'reason' });
+		const { violations } = checkWorkflows(dir, { 'bare.yml': 'reason' }, {});
 		assert(violations.length === 1, `expected 1 violation, got ${violations.length}`);
 		assert(/stale/i.test(violations[0].message), `expected a stale-entry message`);
 	});
@@ -154,7 +163,7 @@ check('an allowlist entry for an unfiltered workflow is a stale-entry violation'
 
 check('an allowlist entry for a missing workflow is a stale-entry violation', () => {
 	withDir({ 'bare.yml': UNFILTERED }, (dir) => {
-		const { violations } = checkWorkflows(dir, { 'gone.yml': 'reason' });
+		const { violations } = checkWorkflows(dir, { 'gone.yml': 'reason' }, {});
 		assert(violations.length === 1, `expected 1 violation, got ${violations.length}`);
 		assert(violations[0].file === 'gone.yml', `expected the missing file to be named`);
 	});
@@ -176,7 +185,7 @@ check('an empty workflow directory throws rather than reporting clean', () => {
 	let threw = false;
 	withDir({}, (dir) => {
 		try {
-			checkWorkflows(dir, {});
+			checkWorkflows(dir, {}, {});
 		} catch {
 			threw = true;
 		}
@@ -203,7 +212,7 @@ check('a ref-keyed cancelling group on a push workflow is rejected', () => {
 			'a.yml': `name: a${PUSH_ON}\nconcurrency:\n  group: a-\${{ github.ref }}\n  cancel-in-progress: true\n${JOBS}`,
 		},
 		(dir) => {
-			const { violations } = checkWorkflows(dir, {});
+			const { violations } = checkWorkflows(dir, {}, {});
 			assert(violations.length === 1, `expected 1 violation, got ${violations.length}`);
 			assert(/carries no verdict/.test(violations[0].message), 'expected the verdict wording');
 		},
@@ -216,7 +225,7 @@ check('the same group keyed by github.sha is accepted', () => {
 			'a.yml': `name: a${PUSH_ON}\nconcurrency:\n  group: a-\${{ github.head_ref || github.sha }}\n  cancel-in-progress: true\n${JOBS}`,
 		},
 		(dir) => {
-			const { violations } = checkWorkflows(dir, {});
+			const { violations } = checkWorkflows(dir, {}, {});
 			assert(violations.length === 0, `expected clean, got ${JSON.stringify(violations)}`);
 		},
 	);
@@ -228,7 +237,7 @@ check('cancel-in-progress: false makes the group key irrelevant', () => {
 			'a.yml': `name: a${PUSH_ON}\nconcurrency:\n  group: a-\${{ github.ref }}\n  cancel-in-progress: false\n${JOBS}`,
 		},
 		(dir) => {
-			const { violations } = checkWorkflows(dir, {});
+			const { violations } = checkWorkflows(dir, {}, {});
 			assert(violations.length === 0, `expected clean, got ${JSON.stringify(violations)}`);
 		},
 	);
@@ -240,19 +249,82 @@ check('a ref-keyed cancelling group without a push trigger is accepted', () => {
 			'a.yml': `name: a\non:\n  pull_request:\nconcurrency:\n  group: a-\${{ github.ref }}\n  cancel-in-progress: true\n${JOBS}`,
 		},
 		(dir) => {
-			const { violations } = checkWorkflows(dir, {});
+			const { violations } = checkWorkflows(dir, {}, {});
 			assert(violations.length === 0, `expected clean, got ${JSON.stringify(violations)}`);
 		},
 	);
 });
 
-check('a job-level concurrency block is not read as the workflow-level one', () => {
-	const source = `name: a${PUSH_ON}\njobs:\n  publish:\n    runs-on: ubuntu-latest\n    concurrency:\n      group: a-\${{ github.ref }}\n      cancel-in-progress: true\n    steps:\n      - run: echo hi\n`;
-	const { concurrency } = analyzeWorkflow(source);
-	assert(concurrency === null, `expected no top-level concurrency, got ${JSON.stringify(concurrency)}`);
-	withDir({ 'a.yml': source }, (dir) => {
-		const { violations } = checkWorkflows(dir, {});
+// --- The same mechanism one level down: a job-level cancelling group. ---
+
+/** A push workflow whose single job `publish` carries `group` and `cancels`. */
+function jobLevel(group, cancels = 'true') {
+	return (
+		`name: a${PUSH_ON}\njobs:\n  publish:\n    runs-on: ubuntu-latest\n` +
+		`    concurrency:\n      group: ${group}\n      cancel-in-progress: ${cancels}\n` +
+		`    steps:\n      - run: echo hi\n`
+	);
+}
+
+check('a job-level block is still not read as the workflow-level one', () => {
+	const { concurrency, jobs } = analyzeWorkflow(jobLevel('a-${{ github.ref }}'));
+	assert(
+		concurrency === null,
+		`expected no top-level concurrency, got ${JSON.stringify(concurrency)}`,
+	);
+	assert(jobs.length === 1 && jobs[0].id === 'publish', `expected the job, got ${JSON.stringify(jobs)}`);
+});
+
+check('a ref-keyed cancelling job group on a push workflow is rejected', () => {
+	withDir({ 'a.yml': jobLevel('a-${{ github.ref }}') }, (dir) => {
+		const { violations } = checkWorkflows(dir, {}, {});
+		assert(violations.length === 1, `expected 1 violation, got ${violations.length}`);
+		assert(/job `publish`/.test(violations[0].message), 'expected the job to be named');
+	});
+});
+
+check('an allowlisted converging job group is accepted', () => {
+	withDir({ 'a.yml': jobLevel('a-${{ github.ref }}') }, (dir) => {
+		const { violations } = checkWorkflows(dir, {}, { 'a.yml': { publish: 'converges on one PR' } });
 		assert(violations.length === 0, `expected clean, got ${JSON.stringify(violations)}`);
+	});
+});
+
+check('a job group keyed by github.sha needs no entry', () => {
+	withDir({ 'a.yml': jobLevel('a-${{ github.head_ref || github.sha }}') }, (dir) => {
+		const { violations } = checkWorkflows(dir, {}, {});
+		assert(violations.length === 0, `expected clean, got ${JSON.stringify(violations)}`);
+	});
+});
+
+check('a serialising job group (cancel-in-progress: false) needs no entry', () => {
+	withDir({ 'a.yml': jobLevel('a-${{ github.ref }}', 'false') }, (dir) => {
+		const { violations } = checkWorkflows(dir, {}, {});
+		assert(violations.length === 0, `expected clean, got ${JSON.stringify(violations)}`);
+	});
+});
+
+check('a job group on a workflow with no push trigger is accepted', () => {
+	const body = jobLevel('a-${{ github.ref }}').replace(PUSH_ON.trim(), 'on:\n  pull_request:');
+	withDir({ 'a.yml': body }, (dir) => {
+		const { violations } = checkWorkflows(dir, {}, {});
+		assert(violations.length === 0, `expected clean, got ${JSON.stringify(violations)}`);
+	});
+});
+
+check('a job entry for a group that no longer cancels is a stale-entry violation', () => {
+	withDir({ 'a.yml': jobLevel('a-${{ github.sha }}') }, (dir) => {
+		const { violations } = checkWorkflows(dir, {}, { 'a.yml': { publish: 'converges' } });
+		assert(violations.length === 1, `expected 1 violation, got ${violations.length}`);
+		assert(/stale/i.test(violations[0].message), 'expected a stale-entry message');
+	});
+});
+
+check('a job entry for a missing workflow is a stale-entry violation', () => {
+	withDir({ 'a.yml': jobLevel('a-${{ github.sha }}') }, (dir) => {
+		const { violations } = checkWorkflows(dir, {}, { 'gone.yml': { publish: 'converges' } });
+		assert(violations.length === 1, `expected 1 violation, got ${violations.length}`);
+		assert(violations[0].file === 'gone.yml', 'expected the missing file to be named');
 	});
 });
 
@@ -268,6 +340,34 @@ check('every shipped allowlist entry carries a non-empty reason', () => {
 	for (const [file, reason] of Object.entries(ALLOWLIST)) {
 		assert(typeof reason === 'string' && reason.trim().length > 20, `${file}: reason too thin`);
 	}
+	for (const [file, jobs] of Object.entries(JOB_CONCURRENCY_ALLOWLIST)) {
+		for (const [id, reason] of Object.entries(jobs)) {
+			assert(
+				typeof reason === 'string' && reason.trim().length > 20,
+				`${file}/${id}: reason too thin`,
+			);
+		}
+	}
+});
+
+// A guard that is clean because it looks at nothing is also clean. Emptying the
+// job allowlist must reproduce exactly the shipped entries against the real
+// tree — the check is wired iff those two sets agree.
+check('the shipped job allowlist is exactly what the real tree flags without it', () => {
+	const { violations } = checkWorkflows(REAL_WORKFLOW_DIR, ALLOWLIST, {});
+	const flagged = violations
+		.map((v) => /^job `([^`]+)`/.exec(v.message)?.[1])
+		.map((id, i) => (id ? `${violations[i].file}/${id}` : null))
+		.filter(Boolean)
+		.sort();
+	const declared = Object.entries(JOB_CONCURRENCY_ALLOWLIST)
+		.flatMap(([file, jobs]) => Object.keys(jobs).map((id) => `${file}/${id}`))
+		.sort();
+	assert(flagged.length > 0, 'expected the real tree to have job-level groups to flag');
+	assert(
+		JSON.stringify(flagged) === JSON.stringify(declared),
+		`flagged ${JSON.stringify(flagged)} but declared ${JSON.stringify(declared)}`,
+	);
 });
 
 console.log(

--- a/scripts/ci/workflow-trigger-guard.mjs
+++ b/scripts/ci/workflow-trigger-guard.mjs
@@ -15,8 +15,10 @@
 // This guard does NOT establish that an unfiltered workflow is *correct* off a
 // non-main base — that depends on the workflow's own logic (`changeset.yml` is
 // safe only because its gate diffs against `git merge-base HEAD origin/main`
-// rather than the PR base; see #1799). It answers one question: is every
-// base-branch filter on the `pull_request` trigger deliberate and explained?
+// rather than the PR base; see #1799). It answers two questions: is every
+// base-branch filter on the `pull_request` trigger deliberate and explained, and
+// can any cancelling `concurrency:` group — workflow-level or job-level — be
+// shared by two pushes to one branch?
 //
 // Exit codes: 0 = clean, 2 = violations found, 1 = internal/parse error.
 

--- a/scripts/ci/workflow-trigger-guard.mjs
+++ b/scripts/ci/workflow-trigger-guard.mjs
@@ -60,6 +60,31 @@ export const ALLOWLIST = {
 		'Reports coverage as a delta against main; the delta is meaningless when the base is not main.',
 };
 
+/**
+ * Jobs permitted a ref-keyed cancelling `concurrency:` of their own, keyed
+ * `file.yml` -> job id -> reason.
+ *
+ * The exemption is not "it is a job rather than a workflow" — the mechanism is
+ * identical one level down. It is that the job converges: it drives a single
+ * mutable target (a pull request, a deployment) where the newest commit's run
+ * subsumes every older one, so a superseded run destroys no verdict. A job that
+ * *reports* on the commit it was started for can never qualify.
+ *
+ * @type {Record<string, Record<string, string>>}
+ */
+export const JOB_CONCURRENCY_ALLOWLIST = {
+	'release.yml': {
+		'version-pr':
+			'Refreshes the single "Version Packages" PR from the tip of main; a newer push already contains the older push\'s changesets, so superseding is the intended behaviour.',
+		'close-version-cycle':
+			'Shares the version-PR group precisely so a publish commit supersedes an in-flight updater before it can reopen the PR from stale state.',
+	},
+	'deploy-docs.yml': {
+		build:
+			'Builds the single GitHub Pages site; only the newest main commit can be deployed, and a build break survives into the next push\'s run.',
+	},
+};
+
 /** Strip a trailing `# comment` that is not inside quotes. */
 function stripComment(line) {
 	let quote = null;
@@ -118,6 +143,17 @@ function directChildren(lines, startIndex, parentIndent) {
 	return children;
 }
 
+/** Read the `group:` / `cancel-in-progress:` under a `concurrency:` at `index`. */
+function readConcurrency(lines, index) {
+	const block = { group: '', cancels: false };
+	for (const child of directChildren(lines, index + 1, indentOf(lines[index]))) {
+		const value = inlineValueOf(child.line);
+		if (child.key === 'group') block.group = value;
+		if (child.key === 'cancel-in-progress') block.cancels = value === 'true';
+	}
+	return block;
+}
+
 /**
  * Parse one workflow's PR-trigger branch filters.
  *
@@ -158,26 +194,47 @@ export function analyzeWorkflow(source, { name = '<source>' } = {}) {
 
 	const pushes = directChildren(lines, onIndex + 1, 0).some((c) => c.key === 'push');
 
-	// Top-level only. A job-level `concurrency:` is scoped to that job and is how
-	// release.yml legitimately serialises its publish step.
-	let concurrency = null;
 	const concIndex = lines.findIndex((l) => indentOf(l) === 0 && keyOf(l) === 'concurrency');
-	if (concIndex !== -1) {
-		concurrency = { group: '', cancels: false };
-		for (const child of directChildren(lines, concIndex + 1, 0)) {
-			const value = inlineValueOf(child.line);
-			if (child.key === 'group') concurrency.group = value;
-			if (child.key === 'cancel-in-progress') concurrency.cancels = value === 'true';
+	const concurrency = concIndex === -1 ? null : readConcurrency(lines, concIndex);
+
+	// Job-level groups are the same mechanism one level down, so they are read
+	// separately rather than folded into the workflow-level one.
+	const jobs = [];
+	const jobsIndex = lines.findIndex((l) => indentOf(l) === 0 && keyOf(l) === 'jobs');
+	if (jobsIndex !== -1) {
+		for (const job of directChildren(lines, jobsIndex + 1, 0)) {
+			const child = directChildren(lines, job.index + 1, indentOf(job.line)).find(
+				(c) => c.key === 'concurrency',
+			);
+			if (child) jobs.push({ id: job.key, concurrency: readConcurrency(lines, child.index) });
 		}
 	}
 
-	return { triggers, pushes, concurrency };
+	return { triggers, pushes, concurrency, jobs };
 }
+
+/** True when two pushes to one branch would share this cancelling group. */
+function collidesAcrossPushes(concurrency) {
+	return (
+		concurrency?.cancels === true &&
+		!PER_PUSH_CONTEXTS.some((ctx) => concurrency.group.includes(ctx))
+	);
+}
+
+const VERDICT_EXPLANATION =
+	'Every push to a branch shares one `github.ref`, so each merge cancels its predecessor and the ' +
+	'branch carries no verdict — which reads exactly like a green one (#2435/#2593). Key the group ' +
+	'by `${{ github.head_ref || github.sha }}` so pushes cannot collide, or set ' +
+	'`cancel-in-progress: false`.';
 
 /**
  * @returns {{violations: Array<{file: string, message: string}>, checked: number}}
  */
-export function checkWorkflows(dir, allowlist = ALLOWLIST) {
+export function checkWorkflows(
+	dir,
+	allowlist = ALLOWLIST,
+	jobAllowlist = JOB_CONCURRENCY_ALLOWLIST,
+) {
 	const files = readdirSync(dir)
 		.filter((f) => f.endsWith('.yml') || f.endsWith('.yaml'))
 		.sort();
@@ -187,26 +244,36 @@ export function checkWorkflows(dir, allowlist = ALLOWLIST) {
 
 	const violations = [];
 	const filtered = new Set();
+	const collidingJobs = new Map();
 
 	for (const file of files) {
 		const source = readFileSync(join(dir, file), 'utf8');
-		const { triggers, pushes, concurrency } = analyzeWorkflow(source, { name: file });
+		const { triggers, pushes, concurrency, jobs } = analyzeWorkflow(source, { name: file });
 
-		if (
-			pushes &&
-			concurrency?.cancels &&
-			!PER_PUSH_CONTEXTS.some((ctx) => concurrency.group.includes(ctx))
-		) {
+		if (pushes && collidesAcrossPushes(concurrency)) {
 			violations.push({
 				file,
 				message:
 					`\`concurrency.group\` is \`${concurrency.group}\` with \`cancel-in-progress: true\`, ` +
-					`but this workflow runs on \`push\`. Every push to a branch shares one \`github.ref\`, ` +
-					`so each merge cancels its predecessor and the branch carries no verdict — which reads ` +
-					`exactly like a green one (#2435/#2593). Key the group by ` +
-					`\`\${{ github.head_ref || github.sha }}\` so pushes cannot collide, or set ` +
-					`\`cancel-in-progress: false\`.`,
+					`but this workflow runs on \`push\`. ${VERDICT_EXPLANATION}`,
 			});
+		}
+
+		if (pushes) {
+			const colliding = jobs.filter((j) => collidesAcrossPushes(j.concurrency));
+			if (colliding.length > 0) collidingJobs.set(file, new Set(colliding.map((j) => j.id)));
+			for (const job of colliding) {
+				if (Object.hasOwn(jobAllowlist[file] ?? {}, job.id)) continue;
+				violations.push({
+					file,
+					message:
+						`job \`${job.id}\` sets its own \`concurrency.group\` \`${job.concurrency.group}\` ` +
+						`with \`cancel-in-progress: true\`, and this workflow runs on \`push\`. ` +
+						`${VERDICT_EXPLANATION} If the job converges instead of reporting — it drives one ` +
+						`pull request or one deployment, so the newest run subsumes the older — add it to ` +
+						`JOB_CONCURRENCY_ALLOWLIST in scripts/ci/workflow-trigger-guard.mjs with that reason.`,
+				});
+			}
 		}
 
 		for (const { trigger, filters } of triggers) {
@@ -243,6 +310,25 @@ export function checkWorkflows(dir, allowlist = ALLOWLIST) {
 		}
 	}
 
+	for (const [file, entries] of Object.entries(jobAllowlist)) {
+		if (!files.includes(file)) {
+			violations.push({
+				file,
+				message: `has JOB_CONCURRENCY_ALLOWLIST entries but no such workflow exists; remove them.`,
+			});
+			continue;
+		}
+		for (const id of Object.keys(entries)) {
+			if (collidingJobs.get(file)?.has(id)) continue;
+			violations.push({
+				file,
+				message:
+					`job \`${id}\` is allowlisted for a cancelling ref-keyed \`concurrency:\` it no longer ` +
+					`has. Remove the stale JOB_CONCURRENCY_ALLOWLIST entry.`,
+			});
+		}
+	}
+
 	return { violations, checked: files.length };
 }
 
@@ -263,9 +349,14 @@ function main(argv) {
 	}
 
 	if (result.violations.length === 0) {
+		const jobEntries = Object.values(JOB_CONCURRENCY_ALLOWLIST).reduce(
+			(n, jobs) => n + Object.keys(jobs).length,
+			0,
+		);
 		console.log(
 			`workflow-trigger-guard: ${result.checked} workflows checked, ` +
-				`${Object.keys(ALLOWLIST).length} allowlisted base-branch filters, no violations.`,
+				`${Object.keys(ALLOWLIST).length} allowlisted base-branch filters, ` +
+				`${jobEntries} allowlisted converging job groups, no violations.`,
 		);
 		return EXIT_CLEAN;
 	}


### PR DESCRIPTION
Closes part of #2554.

The issue's Net 2 (the push-to-`main` run is cancelled by the next merge) was fixed
at **workflow** level by #2643. Measured again today, that fix holds — and it makes
the two remaining offenders readable, because they are now the only ones cancelling.

## Inventory: every `concurrency:` block, and what it does on `main` vs. a PR

`github.head_ref` is set only on `pull_request`; it is empty on `push`. So
`${{ github.head_ref || github.sha }}` is the branch name on a PR (a new push
supersedes the old run — desirable) and the commit SHA on a push (two merges can
never share a group). Both halves are confirmed against live runs, not just read:
`CI` on `main` is **0 cancelled / 21 success** in its last 24 runs, while `CI` on
`pull_request` is **5 cancelled / 60** — the PR-side supersede still works.

| workflow | triggers | group | cancels | on `main` | on a PR |
|---|---|---|---|---|---|
| benchmark, capi, ci, codspeed, corpus-compat, coverage, crates-io-packages, type-aware-lint | push+PR | `…${{ github.head_ref \|\| github.sha }}` | true | unique per merge — survives | supersedes older push |
| changeset | PR only | `…${{ github.head_ref \|\| github.ref }}` | true | n/a | supersedes older push |
| site-benchmark | dispatch only | `…${{ github.ref }}` | true | n/a (no push trigger) | n/a |
| auto-update-{oxfmt,svelte,submodules}, publish-crates, publish-vscode, release-capi | dispatch / schedule / tag | fixed or `github.ref` | **false** | serialises | n/a |
| **deploy-docs** job `build` | push `main` | `pages-build` | **true** | **cancelled by the next merge** | n/a |
| **release** jobs `version-pr`, `close-version-cycle` | push `main` | `release-version-pr-${{ github.ref }}` | **true** | **cancelled by the next merge** | n/a |
| release job `publish` | push `main` | `release-publish-${{ github.ref }}` | false | serialises | n/a |

Those last three are live, not historical. Last 24 runs on `main`, counted through
both `GET /actions/runs?branch=main` and `GET /actions/workflows/<f>/runs?branch=main`
(they agree):

| workflow | cancelled | success |
|---|---|---|
| Deploy Docs | **10** | 11 |
| Release | **5** | 18 |
| CI (fixed at workflow level) | 0 | 21 |
| Corpus Compat (fixed at workflow level) | 0 | 18 (+5 real failures) |

## What this PR changes

**1. The guard reads job-level `concurrency:` too.** `workflow-trigger-guard.mjs`
deliberately read only the top-level block, on the stated grounds that
`release.yml`'s job-level groups are correct. Two of the three are correct; the
grounds were not checked, and the mechanism is identical one level down. The guard
now applies the same rule to job blocks in `push`-triggered workflows, with a
second allowlist whose entries must say **why the job converges** — it drives one
pull request or one deployment, so the newest run subsumes the older one and no
verdict is destroyed. A job that *reports on the commit it was started for* can
never qualify, and that is the distinction the allowlist records.

The three jobs above are allowlisted with that reason rather than rewritten:
cancelling them is correct, and the point is that the next one cannot be added
silently.

**2. `known-failures-md-check.mjs` also runs in `ci.yml`.** This is #2554's other
half. The assertion holds over the *union* of two branches, so no `pull_request`
run can establish it — its merge ref is frozen when the event is created. The run
that decides it is the push to `main`, and `Corpus Compat` cannot be that run: it
is path-filtered on **both** triggers (`corpus-compat.yml:39-88` push, `:90-139`
PR), so any change outside those paths never starts it at all. That is a
*never-started* hole, not a cancellation, and #2643 did not touch it. The check
needs no submodules, no `node_modules` and no build (0.1 s locally), so it now also
runs as a small job in `ci.yml`, which is unfiltered on `push: main` and on every
PR and already keys its group by SHA.

## What was demonstrated, and how

- **The job-level check is wired, not merely written.** Emptying the job allowlist
  against the real `.github/workflows` reports exactly `deploy-docs.yml/build`,
  `release.yml/version-pr`, `release.yml/close-version-cycle` — and nothing else,
  notably not `release.yml/publish` (`cancel-in-progress: false`) or
  `deploy-docs.yml/deploy`. That set is reached by a static reading of the YAML and
  matches the set identified independently by the cancellation counts above. The
  self-test asserts this equality against the shipped tree, so the allowlist cannot
  drift from what the guard flags in either direction.
- **The parser is faithful.** Its job-level extraction was diffed against PyYAML
  over all 18 workflows: identical for every job, including the matrix-interpolated
  group in `auto-update-submodules.yml` and both non-cancelling groups.
- **Nine new controls** in `test-workflow-trigger-guard.mjs` cover the near misses:
  a SHA-keyed job group, `cancel-in-progress: false`, a job group on a
  non-`push` workflow, and both directions of allowlist staleness.
- **The ratchet-doc check fails for the right reason.** Dropping a stray
  `*-known-failures.json` into `compatibility/` reproduces #2554's exact message
  (`… is a ratchet on disk but is not declared in RATCHETS`) and exits 1.
- **The new job is wired, observed on this PR, not argued.** Commit `0e5ba360`
  pushed that stray file to this branch. The `Ratchet doc parity` check was
  created, ran, and **failed**, at step 3 — `Verify known-failures.md matches the
  JSON ratchets` — with steps 1, 2, 6 and 7 green
  ([job 93201759902](https://github.com/baseballyama/rsvelte/actions/runs/31295850624/job/93201759902)).
  `Workflow trigger guard` was SUCCESS on the same run. The probe was then reverted
  and the branch force-pushed back to a clean tree.
- **The concurrency rule was observed working on this branch too**, incidentally:
  pushing `0e5ba360` cancelled `3aa3a828`'s CI run — the PR-side supersede that the
  `github.head_ref` half of the expression is for — while every `main` run of the
  same workflow in the table above survived.

## Cost

**Zero extra runs.** The guard change adds nothing. The ratchet-doc check is one
more job inside the existing `ci.yml` run (23 jobs, up from 22): a bare checkout
plus one dependency-free node script, ~15 s of one `ubuntu-latest` runner.

I did **not** enable "require branches up to date before merge" (issue candidate 1).
Concretely, at the currently observed rate — 20 merges to `main` in the 8.85 h to
`04:56Z`, ~2.3/h with bursts of 3 in two minutes — and 8 open PRs, that setting
would force ~18 full check matrices per hour, and ~24 within two minutes during a
burst, against a pool that is *already* leaving `CI` queued for 20+ minutes. It
would buy a strictly weaker guarantee than the post-merge net, because a PR could
still be made stale by a merge between its re-run and its own merge.

## What this still cannot see

- **A run that is never started.** Path filters and `if:` guards are a different
  hole from cancellation, and closing the second does not close the first.
  `Corpus Compat` remains path-filtered on both triggers; this PR routes one check
  out from behind that filter and leaves the rest.
- **A census taken from a run listing** — and this one nearly went into this PR as
  a finding. I recorded `main`'s `6d86ce2a` as having *no* `CI` run: `gh run list
  --workflow=ci.yml --branch=main` skips straight from `500c8e02` to `720cfbf0`,
  and `GET /actions/runs?head_sha=6d86ce2a…` returns `total_count: 5` without it —
  both still, 45 minutes after the push. **The run exists.** `GET
  /actions/workflows/ci.yml/runs` lists id `31295136465` for that SHA with
  `head_branch: main`, `event: push`, `status: queued`, and its check suite carries
  all 26 CI jobs. The listing was wrong, not the trigger. Every conclusion count in
  this PR is therefore cross-checked against the workflow-scoped endpoint (both
  agree), and any future "does every `main` commit carry a verdict?" sweep must not
  be built on `gh run list --branch`.
- **Whether a surviving run is *timely*.** Not cancelling is not the same as
  starting. Both the new job and a separate workflow would compete for the same
  runner pool; the new job's advantage is that it does not inherit a 60-minute
  job's queue position or its path filter, not that a runner is waiting for it.
- **`site-benchmark.yml`** keys a cancelling group by `github.ref` but has only a
  `workflow_dispatch` trigger, so it is outside the rule's population; two manual
  dispatches on one ref would still cancel each other.
- **Net 1 proper.** The `pull_request` merge ref is still frozen at event-creation
  time. This PR does not fix that — it makes the post-merge net for *one* repo-wide
  invariant able to start and finish. Every other repo-wide invariant
  (`gate-coverage.md` rows, "every ratchet has a paired `.md`") has the same hazard
  and no such net.
