### PR TITLE
fix(compiler): reject every decorator position in a TypeScript script (#2597)

### DIFF
--- a/.changeset/typescript-decorator-positions.md
+++ b/.changeset/typescript-decorator-positions.md
@@ -1,0 +1,5 @@
+---
+'@rsvelte/compiler': patch
+---
+
+Reject every decorator in a TypeScript `<script>` with `typescript_invalid_feature`, not only the ones on a class declaration. A decorator on a method, a field, a getter, a class expression or a constructor parameter was copied verbatim into the generated module, which is then not JavaScript and which no gate could observe — the ratchets score match/mismatch, and the corpus has no witness. The error's code, message and span now match the official compiler in all of those positions.

--- a/crates/rsvelte_core/src/compiler/mod.rs
+++ b/crates/rsvelte_core/src/compiler/mod.rs
@@ -618,7 +618,7 @@ pub(crate) fn prepare_and_analyze<'source>(
     }
 
     // Remove TypeScript nodes from script content if TypeScript is detected.
-    remove_typescript_from_ast(ast)?;
+    remove_typescript_from_ast(ast, &retained_scripts)?;
 
     // Merge parsed <svelte:options> into compile options.
     // Reference: svelte/packages/svelte/src/compiler/index.js
@@ -1129,7 +1129,10 @@ fn check_module_store_subscriptions(
 /// and if so, applies `remove_typescript_nodes` to strip type annotations.
 /// This matches the official Svelte compiler behavior where TypeScript stripping
 /// happens during compilation, not during parsing.
-fn remove_typescript_from_ast(ast: &mut crate::ast::Root) -> Result<(), crate::error::ParseError> {
+fn remove_typescript_from_ast(
+    ast: &mut crate::ast::Root,
+    retained: &crate::ast::oxc_program::RetainedScripts<'_>,
+) -> Result<(), crate::error::ParseError> {
     use crate::ast::AttributeValue;
     use crate::ast::AttributeValuePart;
 
@@ -1148,9 +1151,19 @@ fn remove_typescript_from_ast(ast: &mut crate::ast::Root) -> Result<(), crate::e
 
     fn strip_ts_from_script(
         script: &mut crate::ast::Script,
+        retained: Option<&crate::ast::oxc_program::RetainedProgram<'_>>,
     ) -> Result<(), crate::error::ParseError> {
         use crate::ast::js::Expression;
-        match &mut script.content {
+        // A decorator on anything but a class declaration has no typed
+        // representation, so it has to be found on the OXC program instead.
+        // `retained` is only `None` for an empty script, which cannot hold one.
+        let decorator = retained.and_then(|program| {
+            phases::phase1_parse::remove_typescript_nodes::first_decorator_span(
+                program.program(),
+                script.content_offset as usize,
+            )
+        });
+        let stripped = match &mut script.content {
             // Typed path: mutate the arena-backed typed tree in place, keeping
             // the script `Expression::Typed` (no expensive `as_json()` round
             // trip). The serialize arena is installed by the caller's
@@ -1166,6 +1179,16 @@ fn remove_typescript_from_ast(ast: &mut crate::ast::Root) -> Result<(), crate::e
             Expression::Lazy { .. } => {
                 unreachable!("Expression::Lazy must be resolved before strip_ts")
             }
+        };
+        // Upstream walks one tree, so the earliest offending node wins.
+        match (decorator, &stripped) {
+            (Some(span), Ok(())) => {
+                Err(phases::phase1_parse::remove_typescript_nodes::decorator_error(span))
+            }
+            (Some(span), Err(other)) if span.0 < other.span().0 => {
+                Err(phases::phase1_parse::remove_typescript_nodes::decorator_error(span))
+            }
+            _ => stripped,
         }
     }
 
@@ -1180,10 +1203,10 @@ fn remove_typescript_from_ast(ast: &mut crate::ast::Root) -> Result<(), crate::e
 
     if any_is_typescript {
         if let Some(ref mut instance) = ast.instance {
-            strip_ts_from_script(instance)?;
+            strip_ts_from_script(instance, retained.instance.as_ref())?;
         }
         if let Some(ref mut module) = ast.module {
-            strip_ts_from_script(module)?;
+            strip_ts_from_script(module, retained.module.as_ref())?;
         }
         // Also strip TypeScript from the fragment (template expressions).
         // The official Svelte compiler calls remove_typescript_nodes on the entire fragment:

--- a/crates/rsvelte_core/src/compiler/phases/1_parse/remove_typescript_nodes.rs
+++ b/crates/rsvelte_core/src/compiler/phases/1_parse/remove_typescript_nodes.rs
@@ -75,6 +75,57 @@ fn recurse_range(range: IdRange, arena: &ParseArena) -> Result<(), ParseError> {
     Ok(())
 }
 
+const DECORATOR_FEATURE: &str = "decorators (related TSC proposal is not stage 4 yet)";
+
+/// Document-relative span of the earliest decorator in `program`, or `None`.
+///
+/// Only a class *declaration* carries decorators in the typed tree; a decorated
+/// member has no `JsNode` field to hold them, so the OXC program is the only
+/// place the rest of them can still be seen.
+pub(crate) fn first_decorator_span(
+    program: &oxc_ast::ast::Program<'_>,
+    offset: usize,
+) -> Option<(usize, usize)> {
+    use oxc_ast_visit::Visit;
+
+    // A decorator is always spelled with `@`, so this skips the walk entirely
+    // for the scripts that cannot contain one.
+    memchr::memchr(b'@', program.source_text.as_bytes())?;
+
+    struct Scan {
+        first: Option<(u32, u32)>,
+    }
+
+    impl<'a> Visit<'a> for Scan {
+        fn visit_decorator(&mut self, decorator: &oxc_ast::ast::Decorator<'a>) {
+            if self
+                .first
+                .is_none_or(|(start, _)| decorator.span.start < start)
+            {
+                self.first = Some((decorator.span.start, decorator.span.end));
+            }
+        }
+
+        // Upstream's `ExportDefaultDeclaration` visitor returns the node instead
+        // of `context.next()`, so nothing under a default export is ever visited.
+        fn visit_export_default_declaration(
+            &mut self,
+            _decl: &oxc_ast::ast::ExportDefaultDeclaration<'a>,
+        ) {
+        }
+    }
+
+    let mut scan = Scan { first: None };
+    scan.visit_program(program);
+    scan.first
+        .map(|(start, end)| (offset + start as usize, offset + end as usize))
+}
+
+/// The upstream `Decorator` visitor error, for a span already in document coordinates.
+pub(crate) fn decorator_error(span: (usize, usize)) -> ParseError {
+    ParseError::typescript_invalid_feature(DECORATOR_FEATURE, span)
+}
+
 /// Build a typed `EmptyStatement` carrying `node`'s span (the span is irrelevant
 /// to analyze, which treats every `EmptyStatement` as a no-op, but we keep it for
 /// faithfulness).
@@ -96,13 +147,10 @@ pub fn remove_typescript_nodes_typed(
     match node.node_type() {
         // Decorators are not supported.
         Some("Decorator") => {
-            return Err(ParseError::typescript_invalid_feature(
-                "decorators (related TSC proposal is not stage 4 yet)",
-                (
-                    node.start().unwrap_or(0) as usize,
-                    node.end().unwrap_or(0) as usize,
-                ),
-            ));
+            return Err(decorator_error((
+                node.start().unwrap_or(0) as usize,
+                node.end().unwrap_or(0) as usize,
+            )));
         }
 
         // Enums are not supported.

--- a/crates/rsvelte_core/tests/ts_decorators_2597.rs
+++ b/crates/rsvelte_core/tests/ts_decorators_2597.rs
@@ -1,0 +1,146 @@
+//! Upstream's `remove_typescript_nodes` rejects **every** decorator in a
+//! TypeScript `<script>` with `typescript_invalid_feature`. rsvelte only saw the
+//! ones on a class *declaration* — the typed AST has no field for a decorator on
+//! a member, a class expression or a parameter, so those were silently copied
+//! into the generated module, which then is not JavaScript.
+
+use rsvelte_core::{CompileOptions, GenerateMode, compile, compiler::CssMode};
+
+fn compile_result(src: &str, generate: GenerateMode) -> Result<String, String> {
+    compile(
+        src,
+        CompileOptions {
+            filename: Some("Test.svelte".to_string()),
+            generate,
+            dev: false,
+            css: CssMode::External,
+            ..Default::default()
+        },
+    )
+    .map(|result| result.js.code)
+    .map_err(|e| format!("{e:?}"))
+}
+
+fn instance(body: &str) -> String {
+    format!("<script lang=\"ts\">\n{body}\n</script>\n\n<p>{{s ? 'ok' : ''}}</p>\n")
+}
+
+/// Every shape upstream rejects, keyed by the source that carries it. The first
+/// `@` in each is the decorator upstream reports.
+const DECORATED: &[&str] = &[
+    "@dec class C {}\nconst s = C;",
+    "const C = @dec class {};\nconst s = C;",
+    "class C { @dec m() {} }\nconst s = C;",
+    "class C { @dec static m() {} }\nconst s = C;",
+    "class C { @dec x = 1; }\nconst s = C;",
+    "class C { @dec get x() { return 1; } }\nconst s = C;",
+    "class C { constructor(@dec a: number) {} }\nconst s = C;",
+    "class C { @a @b m() {} }\nconst s = C;",
+    "class C { @dec({ n: 1 }) m() {} }\nconst s = C;",
+    "class C { @ns.dec m() {} }\nconst s = C;",
+    "@outer class C { @inner m() {} }\nconst s = C;",
+    "function f() { class C { @dec m() {} } return C; }\nconst s = f;",
+];
+
+#[test]
+fn every_decorator_position_is_rejected() {
+    for generate in [GenerateMode::Client, GenerateMode::Server] {
+        for body in DECORATED {
+            let src = instance(body);
+            let err = match compile_result(&src, generate) {
+                Err(err) => err,
+                Ok(code) => panic!("{body:?} must not compile; emitted:\n{code}"),
+            };
+            assert!(
+                err.contains("typescript_invalid_feature"),
+                "expected typescript_invalid_feature for {body:?}, got: {err}"
+            );
+            assert!(
+                err.contains("decorators (related TSC proposal is not stage 4 yet)"),
+                "message must be upstream's for {body:?}, got: {err}"
+            );
+            let at = src.find('@').expect("source carries a decorator");
+            assert!(
+                err.contains(&format!("span: ({at},")),
+                "span must start at the first `@` ({at}) for {body:?}, got: {err}"
+            );
+        }
+    }
+}
+
+/// The module script is stripped by the same call, and its offsets differ.
+#[test]
+fn a_decorated_member_in_the_module_script_is_rejected() {
+    let src = "<script module lang=\"ts\">\nclass C { @dec m() {} }\nexport const s = C;\n</script>\n\n<p>{s ? 'ok' : ''}</p>\n";
+    let err = match compile_result(src, GenerateMode::Client) {
+        Err(err) => err,
+        Ok(code) => panic!("must not compile; emitted:\n{code}"),
+    };
+    assert!(err.contains("typescript_invalid_feature"), "got: {err}");
+    let at = src.find('@').unwrap();
+    assert!(err.contains(&format!("span: ({at},")), "got: {err}");
+}
+
+/// Upstream's `ExportDefaultDeclaration` visitor returns the node instead of
+/// `context.next()`, so a decorator under a default export is never seen and the
+/// later `module_illegal_default_export` is what a component reports.
+#[test]
+fn a_decorator_under_a_default_export_is_not_the_reported_error() {
+    for body in [
+        "export default @dec class {};\nconst s = 1;",
+        "export default class { @dec m() {} };\nconst s = 1;",
+    ] {
+        let err = compile_result(&instance(body), GenerateMode::Client)
+            .expect_err("a default export in a component never compiles");
+        assert!(
+            err.contains("module_illegal_default_export"),
+            "expected module_illegal_default_export for {body:?}, got: {err}"
+        );
+    }
+}
+
+/// Controls: an `@` that is not a decorator must not start rejecting, and a
+/// plain (non-TypeScript) script keeps acorn's `js_parse_error`.
+#[test]
+fn a_non_decorator_at_sign_still_compiles() {
+    for body in [
+        "const s = 'a@b.example';",
+        "const s = `a@${'b'}`;",
+        "const s = /@/.test('@') ? 1 : 0;",
+        "// @ts-expect-error\nconst s: number = 1;",
+        "/** @type {number} */\nconst s = 1;",
+    ] {
+        assert!(
+            compile_result(&instance(body), GenerateMode::Client).is_ok(),
+            "{body:?} should compile"
+        );
+    }
+}
+
+#[test]
+fn a_decorator_in_a_plain_script_is_still_a_parse_error() {
+    let src =
+        "<script>\nclass C { @dec m() {} }\nconst s = C;\n</script>\n\n<p>{s ? 'ok' : ''}</p>\n";
+    let err = compile_result(src, GenerateMode::Client)
+        .expect_err("decorators are not JavaScript syntax acorn accepts");
+    assert!(err.contains("js_parse_error"), "got: {err}");
+}
+
+/// Ordering: upstream walks one tree, so the earliest offending node is the one
+/// reported regardless of which feature it is.
+#[test]
+fn the_earliest_typescript_feature_wins() {
+    let dec_first = instance("class C { @dec m() {} }\nenum E { A }\nconst s = C;");
+    let err = compile_result(&dec_first, GenerateMode::Client).expect_err("must not compile");
+    assert!(
+        err.contains("decorators (related TSC proposal is not stage 4 yet)"),
+        "got: {err}"
+    );
+
+    let enum_first = instance("enum E { A }\nclass C { @dec m() {} }\nconst s = C;");
+    let err = compile_result(&enum_first, GenerateMode::Client).expect_err("must not compile");
+    assert!(
+        err.contains("TypeScript language features like enums"),
+        "got: {err}"
+    );
+}


### PR DESCRIPTION
Closes #2597.

## The issue's claim does not reproduce

#2597 says `strip_typescript` leaves `private` / `readonly` on a constructor parameter and emits non-JavaScript. It does not. rsvelte and the official compiler both **reject** the issue's own reproduction, with the same code and the same span:

```
$ compile_one ParamProp.svelte        # <script lang="ts"> class Store { constructor(private a: number) {} }
Parse(SvelteError { code: "typescript_invalid_feature",
  message: "TypeScript language features like accessibility modifiers on constructor parameters …",
  span: (51, 68) })

$ node -e "compile(src, {generate:'client'})"   # submodules/svelte
ERROR typescript_invalid_feature … start {"line":3,"column":16,"character":51} pos [ 51, 68 ]
```

Same for `readonly`, `public`, `protected` and the mixed form, on `client` and on `server`. The handler is `remove_typescript_nodes.rs`'s `TSParameterProperty` arm and it predates the issue by a long way (it has been there since #1326). **Official does not lower parameter properties either** — `remove_typescript_nodes.js` raises `typescript_invalid_feature('accessibility modifiers on constructor parameters')` — so the issue's "the lowering has to create the field assignments too" scope note describes work that must *not* be done: emitting `this.a = a` would diverge from upstream.

## What is actually broken, found by enumerating the rest of the class

The issue asked for the rest of the erasure class to be enumerated. Doing that against upstream's `remove_typescript_nodes.js`, over 60 shapes × {instance, module} × {client, server}, found one real defect of exactly the shape #2597 was chasing — **rsvelte emitting text no JS parser accepts, silently** — one construct over:

> **A decorator anywhere but on a class declaration is copied verbatim into the generated module.**

```svelte
<script lang="ts">
  class C { @dec m() {} }
</script>
```

```js
// rsvelte, before this PR — compiles "successfully"
class C {
	@dec
	m() {}
}
```
→ `acorn`: `Unexpected character '@' (9:2)`. Official raises `typescript_invalid_feature`.

Ten positions were affected — class expression, method, static method, field, getter, constructor parameter, stacked decorators, call-form, member-form, and a class nested in a function — on both targets and in both script slots. Only `@dec class C {}` was caught, because that is the one position with a `decorators` field on the typed AST.

The reason it survived is the pattern AGENTS.md already names for #2583: upstream's own `compiler-errors`/`validator` fixture for this code is `ts-unsupported-decorator`, and it contains **one** input — a decorated class *declaration*. One passing fixture per code reads as covered.

## The fix

`remove_typescript_nodes.rs` gains `first_decorator_span`, an OXC walk over the retained script program — the typed tree cannot answer this question, because a decorated member has no `JsNode` field to hold the decorator. `remove_typescript_from_ast` runs it alongside the typed strip and reports whichever offending node starts earlier, since upstream walks one tree and the first error wins.

Two details are upstream's, not inventions:

* the walk skips `ExportDefaultDeclaration` subtrees — upstream's visitor returns `node` instead of `context.next()`, so nothing under a default export is ever visited, and a component therefore reports the later `module_illegal_default_export` for `export default @dec class {}`. Without the skip rsvelte reported `typescript_invalid_feature` there.
* the check is at **compile** time, not parse time. `parse()` must keep accepting decorators (upstream only calls `remove_typescript_nodes` from `compile`), or svelte2tsx would stop being able to emit TSX for a decorator-using component.

A `memchr` for `@` gates the walk, so a TypeScript script without one pays nothing.

## Verification

**The test fails on the unfixed tree, for the predicted reason.** With `crates/rsvelte_core/tests/ts_decorators_2597.rs` present and the two source files reverted to `origin/main`:

```
$ git checkout origin/main -- crates/rsvelte_core/src/compiler/mod.rs \
      crates/rsvelte_core/src/compiler/phases/1_parse/remove_typescript_nodes.rs
$ RUST_MIN_STACK=33554432 cargo test --release -p rsvelte_core --test ts_decorators_2597

---- every_decorator_position_is_rejected stdout ----
panicked at crates/rsvelte_core/tests/ts_decorators_2597.rs:52:29:
"const C = @dec class {};\nconst s = C;" must not compile; emitted:
…
export default function Test($$anchor) {
	const C = @dec
	class {};
…

---- a_decorated_member_in_the_module_script_is_rejected stdout ----
panicked at crates/rsvelte_core/tests/ts_decorators_2597.rs:77:21:
must not compile; emitted:
…
class C {
	@dec
	m() {}
}
…

failures:
    a_decorated_member_in_the_module_script_is_rejected
    every_decorator_position_is_rejected
    the_earliest_typescript_feature_wins

test result: FAILED. 3 passed; 3 failed
```

It fails for the predicted reason — the compile *succeeds* and the panic message carries the `@dec` it emitted — not because an assertion happened to trip. The 3 that pass on the unfixed tree are the controls (`@` that is not a decorator, a decorator in a plain `<script>`, a decorator under `export default`); they must pass on both trees or they are measuring nothing.

**Output validity, not only text equality.** Every case was compiled by both compilers and rsvelte's emitted module fed to `acorn` (`sourceType: 'module'`). Before: 10 shapes produced modules acorn rejects. After: those shapes do not compile at all, and the error's code, message and span equal official's.

**Suites** — `cargo fmt --all` and `cargo clippy --all-targets --all-features -- -D warnings` are clean; `cargo test --release -p rsvelte_core` is running locally and its result is appended below when it lands. CI is the authority for the corpus / warning / error / matrix / mutation ratchets, none of which can move here (see below).

**No corpus movement is possible, and that is measured, not assumed.** All 13,121 `.svelte` files under `submodules/` were scanned for a decorator inside a `<script>` region: 6 hits, all `@media` / `@layer` inside a CSS template literal, 0 real decorators. The one real one is upstream's own validator fixture. So this defect could not have been found by growing the corpus, and the fix cannot move a ratchet.

## The rest of the enumeration

| construct | upstream | rsvelte | verdict |
|---|---|---|---|
| `constructor(private/public/protected/readonly x)` | error `typescript_invalid_feature` | same code, same span | **already correct** (the issue's claim) |
| decorator on class declaration | error | same code, same span | already correct |
| decorator on member / class expression / parameter | error | **emitted verbatim → non-JS** | **fixed here** |
| `declare` field, `declare` class/const/function | erased | identical output | correct |
| `abstract` method, `abstract` class | erased / kept | identical output | correct |
| `override`, definite-assignment `!`, optional `?` | erased | identical output | correct |
| `implements`, generics, `this` param | erased | identical output | correct |
| `import type` / `export type`, `interface`, `type` | erased | identical output | correct |
| `as` / `satisfies` / `!` / `<T>x` / `f<T>` | unwrapped | identical output | correct |
| enums, `const enum` | error | same code, same span | correct |
| namespace with non-type nodes | error | same code, same span | correct |
| type-only namespace, `declare global` | erased | identical output | correct |
| `accessor` field | error | same code, same span | correct |

One residual, **unchanged by this PR**: `namespace N { @dec class C {} }` gets the right code from both compilers but a different span (official `[33,37]`, the decorator; rsvelte `[19,50]`, the namespace). Upstream's `TSModuleDeclaration` visitor descends into the body *before* raising its own error, so a child's error beats its ancestor's there — the one place where "earliest start wins" is not walk order. It was already divergent before this change and encoding a per-visitor precedence table for one pathological input is not worth the machinery.

Three divergences are **out of scope** and want their own issues rather than a fix bolted onto this one:

1. **`declare module 'foo' { export const x: number; }`** — upstream errors (`namespaces with non-type nodes`); rsvelte compiles it away. rsvelte's `strip_typescript` deletes `declare module` / `declare namespace` / `declare global` blocks with a *text* scan before the AST check can see them. Under-rejection, and the output is valid JavaScript, so it is a diagnostic-parity bug, not an output bug. Fixing it means removing a text fallback, which is its own change with its own risk.
2. **`abstract class A { abstract x: number; }`** — upstream emits `class A { abstract x; }`, which is **not JavaScript**; rsvelte drops the field and emits valid JS. Matching upstream here would mean adopting an upstream bug. Left divergent deliberately.
3. **`class S { m(private a: number) {} }`** (a parameter property on a non-constructor method) — upstream strips the modifier and compiles, because its check is `context.path.at(-2)?.kind === 'constructor'`; rsvelte's parser rejects it as `js_parse_error`. The input is invalid TypeScript (TS2369) either way, so it is over-rejection of code no one can compile.
