### PR TITLE
fix(parser): raise expected_whitespace at the header sites that require a separator

### DIFF
--- a/.changeset/expected-whitespace-sites.md
+++ b/.changeset/expected-whitespace-sites.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/compiler": patch
+---
+
+Raise `expected_whitespace` at the block, clause and tag headers that require a separator (`{#if}`, `{#each}`, `{#await}`, `{#key}`, `{#snippet}`, `{:else if}`, `{:then}`, `{:catch}`, `{@html}`, `{@const}`, `{@render}`, `{@attach}`), and stop requiring one after `{@debug}`, which the official compiler allows

--- a/crates/rsvelte_core/src/compiler/phases/1_parse/parser.rs
+++ b/crates/rsvelte_core/src/compiler/phases/1_parse/parser.rs
@@ -1020,7 +1020,8 @@ impl<'a> Parser<'a> {
             return Err(ParseError::svelte(
                 "expected_whitespace",
                 "Expected whitespace",
-                (self.index, self.index + 1),
+                // Upstream passes a bare index, so `start` and `end` coincide.
+                (self.index, self.index),
             ));
         }
 

--- a/crates/rsvelte_core/src/compiler/phases/1_parse/state/element.rs
+++ b/crates/rsvelte_core/src/compiler/phases/1_parse/state/element.rs
@@ -2209,7 +2209,7 @@ impl<'a> Parser<'a> {
         &mut self,
         start: usize,
     ) -> ParseResult<Option<crate::ast::Attribute<'a>>> {
-        self.skip_whitespace();
+        self.require_whitespace()?;
 
         // Parse the expression until the closing }
         let expr_start = self.index;

--- a/crates/rsvelte_core/src/compiler/phases/1_parse/state/tag.rs
+++ b/crates/rsvelte_core/src/compiler/phases/1_parse/state/tag.rs
@@ -564,24 +564,31 @@ impl<'a> Parser<'a> {
     pub fn parse_block_open(&mut self, start: usize) -> ParseResult<Option<TemplateNode<'a>>> {
         self.advance(); // consume '#'
 
-        let keyword = self.read_identifier();
-
-        match keyword.as_str() {
-            "if" => self.parse_if_block(start),
-            "each" => self.parse_each_block(start),
-            "await" => self.parse_await_block(start),
-            "key" => self.parse_key_block(start),
-            "snippet" => self.parse_snippet_block(start),
-            _ => {
-                // Unknown block, skip to closing brace using memchr
-                if let Some(pos) = memchr::memchr(b'}', &self.bytes[self.index..]) {
-                    self.index += pos + 1;
-                } else {
-                    self.index = self.bytes.len();
-                }
-                Ok(None)
-            }
+        // Upstream dispatches with `parser.eat(...)`, a prefix match, so `{#ifx}`
+        // is an `{#if}` missing its separator rather than an unknown block.
+        if self.eat_optional("if") {
+            return self.parse_if_block(start);
         }
+        if self.eat_optional("each") {
+            return self.parse_each_block(start);
+        }
+        if self.eat_optional("await") {
+            return self.parse_await_block(start);
+        }
+        if self.eat_optional("key") {
+            return self.parse_key_block(start);
+        }
+        if self.eat_optional("snippet") {
+            return self.parse_snippet_block(start);
+        }
+
+        // Unknown block, skip to closing brace using memchr
+        if let Some(pos) = memchr::memchr(b'}', &self.bytes[self.index..]) {
+            self.index += pos + 1;
+        } else {
+            self.index = self.bytes.len();
+        }
+        Ok(None)
     }
 
     /// Consume the matching `{/keyword}` close tag for the current block.
@@ -626,7 +633,7 @@ impl<'a> Parser<'a> {
 
     /// Parse {#if} block.
     pub fn parse_if_block(&mut self, start: usize) -> ParseResult<Option<TemplateNode<'a>>> {
-        self.skip_whitespace();
+        self.require_whitespace()?;
 
         // Read the test expression using find_matching_bracket to handle
         // strings, comments, and regex inside the expression (e.g., /^\d{4}/)
@@ -710,7 +717,7 @@ impl<'a> Parser<'a> {
 
         if self.eat_optional("if") {
             // {:else if ...}
-            self.skip_whitespace();
+            self.require_whitespace()?;
             let alt_expr_start = self.index;
             let end = find_matching_bracket(self.source, alt_expr_start, '{')
                 .unwrap_or(self.source.len());
@@ -803,7 +810,7 @@ impl<'a> Parser<'a> {
     }
 
     pub fn parse_each_block(&mut self, start: usize) -> ParseResult<Option<TemplateNode<'a>>> {
-        self.skip_whitespace();
+        self.require_whitespace()?;
 
         // Parse the iterable expression (up to " as " or closing "}")
         let expr_start = self.index;
@@ -1275,7 +1282,7 @@ impl<'a> Parser<'a> {
 
     /// Parse {#await} block.
     pub fn parse_await_block(&mut self, start: usize) -> ParseResult<Option<TemplateNode<'a>>> {
-        self.skip_whitespace();
+        self.require_whitespace()?;
 
         // Read the expression (until 'then', 'catch', or '}')
         let expr_start = self.index;
@@ -1540,6 +1547,11 @@ impl<'a> Parser<'a> {
             self.skip_whitespace();
 
             if self.eat_optional("then") {
+                // Upstream eats `}` before requiring the separator, so `{:then}`
+                // stays legal while `{:thenv}` is not.
+                if !self.match_str("}") {
+                    self.require_whitespace()?;
+                }
                 self.skip_whitespace();
 
                 // Check if there's a value identifier/pattern
@@ -1559,6 +1571,9 @@ impl<'a> Parser<'a> {
 
                 then_fragment = Some(self.parse_fragment()?);
             } else if self.eat_optional("catch") {
+                if !self.match_str("}") {
+                    self.require_whitespace()?;
+                }
                 self.skip_whitespace();
 
                 // Check if there's an error identifier/pattern
@@ -1612,7 +1627,7 @@ impl<'a> Parser<'a> {
 
     /// Parse {#key} block.
     pub fn parse_key_block(&mut self, start: usize) -> ParseResult<Option<TemplateNode<'a>>> {
-        self.skip_whitespace();
+        self.require_whitespace()?;
 
         // Read the key expression using find_matching_bracket to handle
         // strings, comments, and regex inside the expression
@@ -1653,7 +1668,7 @@ impl<'a> Parser<'a> {
 
     /// Parse {#snippet name(params)} block.
     pub fn parse_snippet_block(&mut self, start: usize) -> ParseResult<Option<TemplateNode<'a>>> {
-        self.skip_whitespace();
+        self.require_whitespace()?;
 
         // Parse the snippet name (identifier)
         let name_start = self.index;
@@ -1870,19 +1885,12 @@ impl<'a> Parser<'a> {
                 _ => None,
             };
             if let Some((kw, len)) = matched_kw {
-                // Check if followed by identifier chars
-                let pos_after_kw = self.index + len;
-                if pos_after_kw < self.bytes.len() {
-                    let next_byte = self.bytes[pos_after_kw];
-                    if next_byte.is_ascii_alphanumeric() || next_byte == b'_' {
-                        return Err(crate::error::ParseError::svelte(
-                            "expected_whitespace",
-                            "Expected whitespace",
-                            (pos_after_kw, pos_after_kw),
-                        ));
-                    }
-                }
                 self.index += len;
+                // `{@debug}` is upstream's one argument-less special tag, so it
+                // is the only keyword that does not require a separator.
+                if kw != "debug" {
+                    self.require_whitespace()?;
+                }
                 CompactString::from(kw)
             } else {
                 self.read_identifier()

--- a/crates/rsvelte_core/tests/expected_whitespace_2581.rs
+++ b/crates/rsvelte_core/tests/expected_whitespace_2581.rs
@@ -1,0 +1,152 @@
+//! Upstream calls `Parser#require_whitespace` at 15 sites; rsvelte's port had
+//! zero callers, so every one of those `expected_whitespace` errors went
+//! unraised and the construct compiled. The `start` position is asserted too:
+//! upstream passes a bare index to `e.expected_whitespace`, so `start` and
+//! `end` coincide there, and rsvelte's own helper used `index + 1`.
+
+use rsvelte_core::{CompileOptions, GenerateMode, compile};
+
+fn diagnostic(src: &str) -> Option<(Option<String>, Option<(u32, u32)>)> {
+    compile(
+        src,
+        CompileOptions {
+            filename: Some("Test.svelte".to_string()),
+            generate: GenerateMode::Client,
+            ..Default::default()
+        },
+    )
+    .err()
+    .map(|e| {
+        let d = e.diagnostic();
+        (d.code, d.span)
+    })
+}
+
+/// `(source, upstream start)` for the sites this port wires up. Every position
+/// is the one the official compiler reports for the same input.
+const REJECTED: &[(&str, u32)] = &[
+    // `{@attach}` on an element
+    ("<div {@attach(fn)}></div>", 13),
+    ("<div {@attachfn}></div>", 13),
+    // `{#if}`
+    ("{#if(x)}a{/if}", 4),
+    ("{#ifx}a{/if}", 4),
+    ("{#if}a{/if}", 4),
+    // `{#each}`
+    ("{#each(xs) as x}a{/each}", 6),
+    ("{#eachxs as x}a{/each}", 6),
+    // `{#await}`
+    ("{#await(p)}a{/await}", 7),
+    ("{#awaitp}a{/await}", 7),
+    // `{#key}`
+    ("{#key(x)}a{/key}", 5),
+    ("{#keyx}a{/key}", 5),
+    // `{#snippet}`
+    ("{#snippet(x)}a{/snippet}", 9),
+    ("{#snippetfoo()}a{/snippet}", 9),
+    // `{:else if}`
+    ("{#if a}x{:else if(b)}y{/if}", 17),
+    ("{#if a}x{:else ifb}y{/if}", 17),
+    // `{:then}`
+    ("{#await p}a{:then(v)}b{/await}", 17),
+    ("{#await p}a{:thenv}b{/await}", 17),
+    // `{:catch}`
+    ("{#await p}a{:catch(e)}b{/await}", 18),
+    ("{#await p}a{:catche}b{/await}", 18),
+    // `{@html}`
+    ("{@html(foo)}", 6),
+    ("{@html'x'}", 6),
+    // `{@const}`
+    ("{#if 1}{@const(a) = b}{/if}", 14),
+    ("{#if 1}{@const{a} = b}{/if}", 14),
+    // `{@render}`
+    ("{@render(foo())}", 8),
+    ("{@renderfoo()}", 8),
+];
+
+#[test]
+fn missing_separator_is_rejected_with_upstreams_code_and_position() {
+    for (src, start) in REJECTED {
+        let Some((code, span)) = diagnostic(src) else {
+            panic!("{src:?} must not compile");
+        };
+        assert_eq!(
+            code.as_deref(),
+            Some("expected_whitespace"),
+            "wrong code for {src:?}"
+        );
+        assert_eq!(
+            span,
+            Some((*start, *start)),
+            "wrong position for {src:?} (upstream reports [{start}, {start}])"
+        );
+    }
+}
+
+/// The other direction. Each row is a shape the official compiler accepts at a
+/// site this change now guards, so an over-rejection fails here rather than in
+/// the corpus gate. `\u{a0}` and `\u{3000}` are whitespace to upstream's
+/// `is_whitespace` but not to a naive ASCII check.
+#[test]
+fn legal_separators_still_compile() {
+    for src in [
+        "<div {@attach fn}></div>",
+        "<div {@attach\nfn}></div>",
+        "<div {@attach\tfn}></div>",
+        "<Comp {@attach fn} />",
+        "{#if x}a{/if}",
+        "{#if\nx}a{/if}",
+        "{#if\u{a0}x}a{/if}",
+        "{#each xs as x}a{/each}",
+        "{#each\nxs as x}a{/each}",
+        "{#each xs as { x }}a{/each}",
+        "{#await p}a{/await}",
+        "{#await\np}a{/await}",
+        "{#await p then v}a{/await}",
+        "{#await p then}a{/await}",
+        "{#await p catch e}a{/await}",
+        "{#key x}a{/key}",
+        "{#key\u{3000}x}a{/key}",
+        "{#snippet foo()}a{/snippet}",
+        "{#snippet\nfoo()}a{/snippet}",
+        "{#if a}x{:else if b}y{/if}",
+        "{#if a}x{:else if\nb}y{/if}",
+        "{#if a}x{:else}y{/if}",
+        "{#await p}a{:then v}b{/await}",
+        "{#await p}a{:then}b{/await}",
+        "{#await p}a{:then\nv}b{/await}",
+        "{#await p}a{:catch e}b{/await}",
+        "{#await p}a{:catch}b{/await}",
+        "{@html foo}",
+        "{@html\nfoo}",
+        "{#if 1}{@const a = 1}{/if}",
+        "{#if 1}{@const { a } = obj}{/if}",
+        "{@render foo()}",
+        "{@render\nfoo()}",
+    ] {
+        assert!(diagnostic(src).is_none(), "{src:?} should compile");
+    }
+}
+
+/// `{@debug}` is the one special tag upstream never calls `require_whitespace`
+/// for, and the ad-hoc check this change replaced rejected `{@debugfoo}` —
+/// an over-rejection of a program the official compiler accepts.
+#[test]
+fn debug_tag_needs_no_separator() {
+    for src in ["{@debug}", "{@debug }", "{@debugfoo}", "{@debug(foo)}"] {
+        assert!(diagnostic(src).is_none(), "{src:?} should compile");
+    }
+}
+
+/// The separator is required at EOF too: upstream reads a character code past
+/// the end and gets `NaN`, which is not whitespace.
+#[test]
+fn truncated_headers_are_rejected() {
+    for (src, start) in [("{#if", 4u32), ("{#snippet", 9), ("{@html", 6)] {
+        let Some((code, span)) = diagnostic(src) else {
+            panic!("{src:?} must not compile");
+        };
+        assert_eq!(code.as_deref(), Some("expected_whitespace"), "for {src:?}");
+        assert_eq!(span, Some((start, start)), "for {src:?}");
+    }
+}


### PR DESCRIPTION
Fixes #2581.

Both counts in the issue were re-derived rather than taken on trust, with `command grep`
(the shell wrapper skips gitignored paths) and a positive control in the same invocation:

- `command grep -rn require_whitespace --include='*.rs' .` outside `submodules/` returns
  **2 lines, both the definition** — the function and its doc comment. Positive control in
  the same run: `skip_whitespace` returns **81** hits, so grep was working.
- `command grep -rn "require_whitespace" submodules/svelte/packages/svelte/src/compiler/phases/1-parse/`
  returns **15** call sites: 1 in `state/element.js`, 14 in `state/tag.js`.

Both are correct. What the issue asked to establish — "the count of genuinely missing errors
is not necessarily 15" — turns out to be **15 of 15 sites incompletely or entirely
unimplemented**, plus one over-rejection in the opposite direction.

## Site inventory

Official positions are `error.position` from compiling each input with
`submodules/svelte/.../compiler/index.js` (v5.56.8) directly. `ew@n` = `expected_whitespace`
at `[n, n]`. The "rsvelte before" column is measured on `origin/main`, not inferred.

| # | upstream site | construct | minimal rejected input | official | rsvelte before | verdict |
|---|---|---|---|---|---|---|
| 1 | `element.js:536` | `{@attach` (element attribute) | `<div {@attach(fn)}></div>` | ew@13 | **compiled** | wired |
| 2 | `tag.js:157` | `{#if` | `{#if(x)}a{/if}` | ew@4 | **compiled** | wired |
| 3 | `tag.js:183` | `{#each` | `{#each(xs) as x}a{/each}` | ew@6 | **compiled** | wired |
| 4 | `tag.js:267` | `{#each … as` | `{#each xs as(x)}a{/each}` | ew@12 | **compiled** | **not wired** |
| 5 | `tag.js:337` | `{#await` | `{#await(p)}a{/await}` | ew@7 | **compiled** | wired |
| 6 | `tag.js:361` | `{#await … then` (inline) | `{#await p then(v)}a{/await}` | ew@14 | **compiled** | **not wired** |
| 7 | `tag.js:372` | `{#await … catch` (inline) | `{#await p catch(e)}a{/await}` | ew@15 | **compiled** | **not wired** |
| 8 | `tag.js:423` | `{#key` | `{#key(x)}a{/key}` | ew@5 | **compiled** | wired |
| 9 | `tag.js:449` | `{#snippet` | `{#snippet(x)}a{/snippet}` | ew@9 | **compiled** | wired |
| 10 | `tag.js:545` | `{:else if` | `{#if a}x{:else if(b)}y{/if}` | ew@17 | **compiled** | wired |
| 11 | `tag.js:602` | `{:then` (continuation) | `{#await p}a{:then(v)}b{/await}` | ew@17 | **compiled** | wired |
| 12 | `tag.js:621` | `{:catch` (continuation) | `{#await p}a{:catch(e)}b{/await}` | ew@18 | **compiled** | wired |
| 13 | `tag.js:718` | `{@html` | `{@html(foo)}` | ew@6 | **compiled** | wired |
| 14 | `tag.js:776` | `{@const` | `{#if 1}{@const(a) = b}{/if}` | ew@14 | **compiled** | wired |
| 15 | `tag.js:821` | `{@render` | `{@render(foo())}` | ew@8 | **compiled** | wired |

Every one of the 15 accepted its minimal rejected input. The three sites that *did* raise
`expected_whitespace` before this change — `{@html}`, `{@const}`, `{@render}` — did so only
through an ad-hoc guard that fired when the next byte was `[A-Za-z0-9_]`, so
`{@htmlfoo}` was rejected while `{@html(foo)}` and `{@html'x'}` were not. That guard is why
the two upstream fixtures passed.

The identifier-follow variants, before this change, show how much the code was also wrong:

| input | official | rsvelte before |
|---|---|---|
| `{#ifx}a{/if}` | ew@4 | `block_unexpected_close` @[7,8] |
| `{#eachxs as x}a{/each}` | ew@6 | `block_unexpected_close` @[15,16] |
| `{#awaitp}a{/await}` | ew@7 | `block_unexpected_close` @[10,11] |
| `{#keyx}a{/key}` | ew@5 | `block_unexpected_close` @[8,9] |
| `{#snippetfoo()}a{/snippet}` | ew@9 | `block_unexpected_close` @[16,17] |
| `{#if}a{/if}` | ew@4 | `js_parse_error` @[4,4] |
| `{@attachfn}` on an element | ew@13 | compiled |
| `{:thenv}`, `{:catche}`, `{:else ifb}` | ew | compiled |

The `block_unexpected_close` rows are the second half of the fix: rsvelte dispatched
`{#…}` on `read_identifier()`, so `{#ifx}` was an *unknown block* that got skipped to the
next `}`. Upstream dispatches with `parser.eat('if')`, a prefix match, so `{#ifx}` is an
`{#if}` whose separator is missing. `parse_block_open` now mirrors that.

## An over-rejection, in the direction a corpus can see

`{@debug}` is the one special tag upstream never calls `require_whitespace` for — it may be
argument-less. The ad-hoc `[A-Za-z0-9_]` guard applied to `debug` too, so **rsvelte rejected
`{@debugfoo}`, which the official compiler compiles**. Fixed here, covered by
`debug_tag_needs_no_separator`.

## The `expected_whitespace` span was also wrong

Upstream's `e(node, …)` sets `start === end` when `node` is a number, and every
`expected_whitespace` site passes `this.index`. rsvelte's helper used `(index, index + 1)`.
Nothing observed it: the corpus error-position ratchet compares only `start`
(`verify.mjs` `errorPosKey`), and the `compiler-errors` suite parses `position` out of
`_config.js` and then never compares it — `fixture.expected_error` is read at three places
in `tests/compiler_errors.rs` and all three read `.code`. That is why 145/145 passed with
13 of 15 sites missing.

## Not wired, and why

Both remaining causes are the same one: rsvelte finds the end of a block header's
expression by scanning bytes, while upstream lets acorn consume the expression and then
calls `eat(…)` at whatever position acorn stopped. Relaxing the byte scanner to fire on
these inputs over-rejects, and there is a discriminating case for each:

- **Site 4 (`{#each … as`)** — `looks_like_as_separator` requires the `as` to be bounded by
  whitespace on *both* sides and picks the **right-most** such run (that rule exists so
  `{#each items as const as item}` splits correctly). Dropping the trailing-whitespace
  requirement is not enough: for `{#each xs as(Foo) as x}a{/each}` the official compiler
  reports ew@**12**, i.e. it errors on the *first* `as`, while the right-most rule would
  take `as x` as the separator and accept the program. Matching upstream needs the
  iterable's end from the JS parser.
- **Sites 6 and 7 (inline `{#await … then/catch}`)** — the await scanner treats `then` /
  `catch` as a clause keyword only when the following character is whitespace or `}`.
  Dropping that condition over-rejects two programs the official compiler accepts:
  `{#await thenable}a{/await}` and `{#await x + thenable}a{/await}` (acorn consumes the
  whole expression, so `eat('then')` never fires — verified against official, both compile).
  The byte scanner cannot distinguish those from `{#await p thenify(x)}a{/await}`, which
  official rejects at ew@14.

Both are the "expression boundary from a scanner" hazard AGENTS.md already records for the
client instance-script pipeline, one phase earlier.

## Every case fails on the unfixed tree, for the predicted reason

`crates/rsvelte_core/tests/expected_whitespace_2581.rs` run against `origin/main`'s
`crates/rsvelte_core/src` with this PR's test file in place:

```
running 4 tests
test truncated_headers_are_rejected ... FAILED
test missing_separator_is_rejected_with_upstreams_code_and_position ... FAILED
test debug_tag_needs_no_separator ... FAILED
test legal_separators_still_compile ... ok

---- truncated_headers_are_rejected stdout ----
assertion `left == right` failed: for "{#if"
  left: Some("js_parse_error")
 right: Some("expected_whitespace")

---- missing_separator_is_rejected_with_upstreams_code_and_position stdout ----
"<div {@attach(fn)}></div>" must not compile

---- debug_tag_needs_no_separator stdout ----
"{@debugfoo}" should compile

test result: FAILED. 1 passed; 3 failed
```

Three failures, three predicted reasons: a wrong code, an under-rejection, an
over-rejection.

`legal_separators_still_compile` is the control, and it passes on both trees by
construction — so it was given its own negative control. Narrowing `require_whitespace`'s
predicate from the ECMAScript set to a literal `' '` on the *fixed* tree makes it fail:

```
---- legal_separators_still_compile stdout ----
"<div {@attach\nfn}></div>" should compile
test result: FAILED. 0 passed; 1 failed
```

It can move, so its passing is information.

## Over-rejection check against the corpus population

The full corpus byte-equality gate was **not** run (see below). Instead the shapes this
change newly rejects were searched for directly across the corpus submodules —
**13,121 `.svelte` files plus every `.md`** (markdown code blocks are corpus entries too).
Every `{#if|#each|#await|#key|#snippet}`, `{@html|@const|@render|@attach}` and
`{:then|:catch}` followed immediately by a non-separator, and the empty-header `{#if}` form:

- **2 hits in `.svelte` files**, and both are the upstream fixtures that are *supposed* to
  be rejected (`const-tag-whitespace`, `raw-mustaches-whitespace`) — unchanged by this PR,
  same code and same position before and after.
- The remaining hits are prose in `CHANGELOG.md` / docs and one `//` comment inside a
  `<script>`; none is compiled markup.

## Why there is no `compatibility/pattern-corpus` repro

Two of this PR's three directions cannot live there. The pattern corpus is an
output-equality source — "the official compiler must accept it" — so no input from the
site inventory qualifies, since official rejects every one of them. The `{@debugfoo}`
over-rejection *does* qualify on that rule, and fails the next one: pattern-corpus files
are committed formatted, and the formatter erases the shape. Measured, not assumed:

```
prettier.format("{@debugfoo}\n", {parser: "svelte", plugins: ["prettier-plugin-svelte"]})
  => "{@debug foo}\n"
```

The formatted form reproduces nothing, which is the trap AGENTS.md already records for the
string-literal escape axis. The Rust test is the only home for all three.

## Tests

- `cargo test -p rsvelte_core --test parser_fixtures --test compiler_errors
  --test parser_hardening --test parser_scanner_lexical --test parser_identifier_span
  --test js_whitespace_parser_2561 --test block_head_parse_errors
  --test expected_whitespace_2581` — all green (`compiler_errors` still 145/145).
- Full `cargo test -p rsvelte_core` — running locally; CI is the verdict.
