### PR TITLE
fix(lint): classify svelte_scan word boundaries by character, not by byte

### DIFF
--- a/.changeset/svelte-scan-non-ascii-boundary.md
+++ b/.changeset/svelte-scan-non-ascii-boundary.md
@@ -1,0 +1,36 @@
+---
+"@rsvelte/lint": patch
+---
+
+Classify word boundaries in the `<script>` source-scan rules by character, not by byte
+
+`svelte_scan::is_ascii_ident_byte` answered "is this byte ASCII-alphanumeric, `_` or
+`$`", which makes **every non-ASCII character a word boundary** — so `foo` inside
+`naïvefoo` read as a standalone occurrence, and an identifier scan stopped at the
+first byte of an accented letter. Four rules shared it:
+`svelte/no-unused-props`, `svelte/require-event-prefix`,
+`svelte/require-event-dispatcher-types` and the `$$Slots` / `$$Events` declaration
+scan behind `svelte/experimental-require-slot-types` /
+`svelte/experimental-require-strict-events`.
+
+Observable effects, all fixed:
+
+- `interface $$Eventsé {}` satisfied the `$$Events` requirement, and a mention of
+  `éinterface $$Events` (inside a string) counted as a declaration.
+- `import { écreateEventDispatcher } from 'svelte'` was treated as importing
+  `createEventDispatcher`, so a call to the unrelated function was reported; the
+  reverse, `import { createEventDispatcher as créer }`, truncated the alias to `cr`
+  and the real untyped call went unreported.
+- A type member named `ïnput: () => void` was invisible to `require-event-prefix`,
+  and `interface Propsé` was accepted as the body of `Props`.
+- `no-unused-props` reported `'gr'` instead of `'grëeting'`, and a whole-object
+  declaration whose variable name contains a non-ASCII letter
+  (`const prôps: Props = $props()`) **panicked** on a mid-character string slice.
+
+Boundaries are now decided with `rsvelte_core::compiler::utils::is_js_ident_continue`
+— ECMA-262 `IdentifierPartChar` — so accented letters, CJK and the zero-width
+joiners are identifier glue while non-ASCII spaces (U+00A0, U+2000–U+200A, U+2028,
+U+2029, U+202F, U+205F, U+3000, U+FEFF) remain boundaries. ASCII input is
+unaffected: the two predicates agree on every ASCII byte. The CSS scanner
+(`scss_selector.rs`) keeps its own `>= 0x80` test — that is CSS Syntax Level 3 §4.2,
+a different specification.

--- a/compatibility/gate-coverage.md
+++ b/compatibility/gate-coverage.md
@@ -623,6 +623,24 @@ which `lint-collect.mjs:42-43` does list. **[S]** In CI the lint corpus contains
 file from the Svelte repo and no documentation snippet. `compatibility/pattern-corpus` — the 32
 hand-written regression repros — is also not in that list.
 
+### Blind spot 11g — every `svelte_scan` source-scan rule is outside the universe
+
+The four rules that resolve their facts by scanning `<script>` text through
+`crates/rsvelte_lint/src/svelte_scan.rs` are *all* in `EXCLUDE`, each for a different structural
+reason: `svelte/no-unused-props` (`lint-universe.mjs:26`, type-aware),
+`svelte/require-event-prefix` (`:33`, the oracle has no checker),
+`svelte/experimental-require-strict-events` (`:40`) and
+`svelte/require-event-dispatcher-types` (`:41`, both Svelte 3/4-only). **[D]** The word-boundary
+predicate they share can therefore be wrong in *both* directions with the ratchet at zero
+entries and CI green: `is_ascii_ident_byte` classified every non-ASCII character as a boundary,
+so `interface $$Eventsé {}` satisfied the `$$Events` requirement, an `as créer` alias truncated
+to `cr` and its call went unreported, and a whole-object `const prôps: Props = $props()`
+panicked on a mid-character slice (#2684). Because the rules are outside the universe rather
+than listed as failures, "re-baseline the ratchet" is not a remedy for this family; the
+compensating control is `crates/rsvelte_lint/tests/non_ascii_word_boundary.rs`, which drives all
+four rules through `lint_source` in both directions (a non-ASCII letter is glue; a non-ASCII
+space is a boundary).
+
 ---
 
 ## 12-13. svelte-check diagnostic parity (Layer 1 fixtures, Layer 2 e2e)

--- a/crates/rsvelte_lint/src/rules/no_unused_props.rs
+++ b/crates/rsvelte_lint/src/rules/no_unused_props.rs
@@ -23,7 +23,10 @@ use rsvelte_diagnostics::Diagnostic;
 use crate::config::LintConfig;
 use crate::line_index::LineIndex;
 use crate::rule::{Fixable, RuleCategory, RuleConditions, RuleMeta, Severity};
-use crate::svelte_scan::{blank_comments, is_ascii_ident_byte, script_blocks, script_is_ts};
+use crate::svelte_scan::{
+    blank_comments, ident_continues_at, ident_continues_before, ident_run_end, ident_run_start,
+    script_blocks, script_is_ts,
+};
 use crate::validator::{range_from_byte, to_dsev};
 
 pub static META: RuleMeta = RuleMeta {
@@ -527,12 +530,7 @@ fn parse_destructure_entries(pattern: &str) -> Vec<(String, String)> {
                 .strip_prefix(':')
                 .map(|r| {
                     let r = r.trim();
-                    let n = r
-                        .as_bytes()
-                        .iter()
-                        .position(|&c| !is_ascii_ident_byte(c))
-                        .unwrap_or(r.len());
-                    r[..n].to_string()
+                    r[..ident_run_end(r, 0)].to_string()
                 })
                 .filter(|s| !s.is_empty())
                 .unwrap_or_else(|| key.clone());
@@ -540,10 +538,7 @@ fn parse_destructure_entries(pattern: &str) -> Vec<(String, String)> {
             continue;
         }
         // Plain identifier key, optional `: local` / `= default`.
-        let name_end = bytes
-            .iter()
-            .position(|&c| !is_ascii_ident_byte(c))
-            .unwrap_or(bytes.len());
+        let name_end = ident_run_end(seg, 0);
         if name_end == 0 {
             continue;
         }
@@ -553,12 +548,7 @@ fn parse_destructure_entries(pattern: &str) -> Vec<(String, String)> {
             .strip_prefix(':')
             .map(|r| {
                 let r = r.trim();
-                let n = r
-                    .as_bytes()
-                    .iter()
-                    .position(|&c| !is_ascii_ident_byte(c))
-                    .unwrap_or(r.len());
-                r[..n].to_string()
+                r[..ident_run_end(r, 0)].to_string()
             })
             .filter(|s| !s.is_empty())
             .unwrap_or_else(|| key.clone());
@@ -597,7 +587,6 @@ fn member_chains(
     var: &str,
     exclude: Option<(usize, usize)>,
 ) -> (Vec<Vec<String>>, Vec<Vec<String>>) {
-    let bytes = source.as_bytes();
     let vb = var.as_bytes();
     let mut paths = Vec::new();
     let mut spreads = Vec::new();
@@ -613,9 +602,7 @@ fn member_chains(
         {
             continue;
         }
-        let before = start.checked_sub(1).map(|b| bytes[b]);
-        let after = bytes.get(end).copied();
-        if before.is_some_and(is_ascii_ident_byte) || after.is_some_and(is_ascii_ident_byte) {
+        if ident_continues_before(source, start) || ident_continues_at(source, end) {
             continue; // not a whole-word match
         }
         let p = skip_ws_back(source, start);
@@ -655,16 +642,13 @@ fn parse_member_chain(source: &str, mut pos: usize) -> Vec<String> {
             None
         };
         if let Some(q) = dot {
-            let mut q = skip_ws_forward(source, q);
-            let s = q;
-            while q < bytes.len() && is_ascii_ident_byte(bytes[q]) {
-                q += 1;
-            }
-            if q == s {
+            let s = skip_ws_forward(source, q);
+            let end = ident_run_end(source, s);
+            if end == s {
                 break;
             }
-            chain.push(source[s..q].to_string());
-            pos = q;
+            chain.push(source[s..end].to_string());
+            pos = end;
         } else if bytes[pos] == b'[' {
             let mut q = skip_ws_forward(source, pos + 1);
             if q < bytes.len() && (bytes[q] == b'\'' || bytes[q] == b'"') {
@@ -918,8 +902,8 @@ fn has_whole_object_spread(source: &str, var_name: &str) -> bool {
         if bytes[i..i + vb.len()] == *vb {
             // Check next char.
             let next = bytes.get(i + vb.len()).copied();
-            let next_is_member =
-                next.is_some_and(|c| c == b'.' || c == b'[' || is_ascii_ident_byte(c));
+            let next_is_member = next.is_some_and(|c| c == b'.' || c == b'[')
+                || ident_continues_at(source, i + vb.len());
             if !next_is_member {
                 return true;
             }
@@ -989,10 +973,7 @@ fn find_props_info(content: &str, blanked: &str, content_start: usize) -> Option
         // Whole-object form: `const props: Props = $props()`.
         let var_end_rel = before_colon.len();
         // Find start of var name (walk back over identifier chars).
-        let var_name_start = blanked[..var_end_rel]
-            .rfind(|c: char| !is_ascii_ident_byte(c as u8))
-            .map(|i| i + 1)
-            .unwrap_or(0);
+        let var_name_start = ident_run_start(blanked, var_end_rel);
         let var_name = content[var_name_start..var_end_rel].trim().to_string();
         if var_name.is_empty()
             || !var_name
@@ -1046,7 +1027,7 @@ fn is_type_imported(blanked: &str, name: &str) -> bool {
     let mut i = 0;
     while i + 6 <= bytes.len() {
         if &bytes[i..i + 6] == b"import" {
-            let before_ok = i == 0 || !is_ascii_ident_byte(bytes[i - 1]);
+            let before_ok = !ident_continues_before(blanked, i);
             if before_ok {
                 let end = blanked[i..]
                     .find(';')
@@ -1055,10 +1036,8 @@ fn is_type_imported(blanked: &str, name: &str) -> bool {
                     .unwrap_or(blanked.len());
                 let import_stmt = &blanked[i..end];
                 if let Some(name_pos) = import_stmt.find(name) {
-                    let before_ok2 =
-                        name_pos == 0 || !is_ascii_ident_byte(import_stmt.as_bytes()[name_pos - 1]);
-                    let after_ok = name_pos + nb.len() >= import_stmt.len()
-                        || !is_ascii_ident_byte(import_stmt.as_bytes()[name_pos + nb.len()]);
+                    let before_ok2 = !ident_continues_before(import_stmt, name_pos);
+                    let after_ok = !ident_continues_at(import_stmt, name_pos + nb.len());
                     if before_ok2 && after_ok {
                         return true;
                     }
@@ -1081,14 +1060,13 @@ fn find_named_type_body_no_extends(
     content_start: usize,
 ) -> Option<(String, usize)> {
     let nb = name.as_bytes();
-    let bytes = blanked.as_bytes();
 
     for kw in ["interface", "type"] {
         let mut search_from = 0usize;
         while let Some(rel) = blanked[search_from..].find(kw) {
             let kw_start = search_from + rel;
             let kw_end = kw_start + kw.len();
-            let before_ok = kw_start == 0 || !is_ascii_ident_byte(bytes[kw_start - 1]);
+            let before_ok = !ident_continues_before(blanked, kw_start);
             if !before_ok {
                 search_from = kw_end;
                 continue;
@@ -1101,8 +1079,7 @@ fn find_named_type_body_no_extends(
                 continue;
             }
             let after_name = rest_start + nb.len();
-            let after_char = bytes.get(after_name).copied();
-            if after_char.is_some_and(is_ascii_ident_byte) {
+            if ident_continues_at(blanked, after_name) {
                 search_from = kw_end;
                 continue;
             }
@@ -1229,10 +1206,7 @@ fn extract_member_name(seg: &str) -> Option<String> {
     }
 
     // Plain identifier (possibly followed by `?`, `:`, `(`)
-    let name_end = bytes
-        .iter()
-        .position(|&c| !is_ascii_ident_byte(c))
-        .unwrap_or(bytes.len());
+    let name_end = ident_run_end(seg, 0);
     if name_end == 0 {
         return None;
     }
@@ -1325,10 +1299,7 @@ fn extract_destructure_prop_name(seg: &str) -> Option<String> {
 
     // Plain identifier (take just the name, not `= default` or `: alias` or
     // nested `{ ... }`)
-    let name_end = bytes
-        .iter()
-        .position(|&c| !is_ascii_ident_byte(c))
-        .unwrap_or(bytes.len());
+    let name_end = ident_run_end(seg, 0);
     if name_end == 0 {
         return None;
     }
@@ -1372,15 +1343,15 @@ mod tests {
 
     #[test]
     fn member_chains_walks_back_over_multibyte_chars() {
-        // `々` is E3 80 85: its last byte cast to `char` is U+0085 NEL, which
+        // U+2005 is E2 80 85: its last byte cast to `char` is U+0085 NEL, which
         // `is_whitespace` accepts — a byte cursor steps into the character.
         assert_eq!(
-            member_chains("ab\u{3005}foo.bar", "foo", None).0,
+            member_chains("ab\u{2005}foo.bar", "foo", None).0,
             vec![vec!["bar".to_string()]]
         );
         // NBSP reaches the same place through its 0xA0 continuation byte.
         assert_eq!(
-            member_chains("ab\u{4EE0}foo.bar", "foo", None).0,
+            member_chains("ab\u{a0}foo.bar", "foo", None).0,
             vec![vec!["bar".to_string()]]
         );
         // A newline between does not save it: the cursor eats the newline, then
@@ -1396,13 +1367,40 @@ mod tests {
         // The `...` lookbehind slices three bytes back from a cursor that is
         // already on a boundary, which still lands inside a 4-byte character.
         assert_eq!(
-            member_chains("\u{1D54F}foo.bar", "foo", None).0,
+            member_chains("\u{1F600}foo.bar", "foo", None).0,
             vec![vec!["bar".to_string()]]
         );
         // Real Unicode whitespace before a spread is still recognised.
         assert_eq!(
             member_chains("...\u{3000}foo.bar", "foo", None).1,
             vec![vec!["bar".to_string()]]
+        );
+    }
+
+    /// The other direction of the same predicate: a non-ASCII letter beside the
+    /// name is identifier glue, so the hit is a different variable.
+    #[test]
+    fn member_chains_non_ascii_letter_is_glue() {
+        for src in [
+            "ab\u{3005}foo.bar",
+            "\u{1D54F}foo.bar",
+            "\u{e9}foo.bar",
+            "foo\u{e9}.bar",
+        ] {
+            assert!(
+                member_chains(src, "foo", None).0.is_empty(),
+                "{src:?} contains no standalone `foo`"
+            );
+        }
+    }
+
+    /// A member name runs to the end of the identifier, not to the first
+    /// non-ASCII byte.
+    #[test]
+    fn parse_member_chain_keeps_non_ascii_letters() {
+        assert_eq!(
+            parse_member_chain("foo.b\u{e4}r", 3),
+            vec!["b\u{e4}r".to_string()]
         );
     }
 

--- a/crates/rsvelte_lint/src/rules/require_event_dispatcher_types.rs
+++ b/crates/rsvelte_lint/src/rules/require_event_dispatcher_types.rs
@@ -18,7 +18,10 @@ use rsvelte_diagnostics::Diagnostic;
 use crate::config::LintConfig;
 use crate::line_index::LineIndex;
 use crate::rule::{Fixable, RuleCategory, RuleConditions, RuleMeta, Severity};
-use crate::svelte_scan::{blank_comments, is_ascii_ident_byte, script_blocks, script_is_ts};
+use crate::svelte_scan::{
+    blank_comments, ident_continues_at, ident_continues_before, ident_run_end, script_blocks,
+    script_is_ts,
+};
 use crate::validator::{range_from_byte, to_dsev};
 
 pub static META: RuleMeta = RuleMeta {
@@ -84,12 +87,11 @@ pub fn diagnostics(source: &str, file: &Path, config: &LintConfig) -> Vec<Diagno
 /// Collect the local binding names of `createEventDispatcher` imported from
 /// `'svelte'` in `content` (handles `as` aliases).
 fn collect_dispatcher_locals(content: &str, out: &mut Vec<String>) {
-    let bytes = content.as_bytes();
     let mut i = 0;
     while let Some(rel) = content[i..].find("import") {
         let imp = i + rel;
         // The keyword must be at a boundary.
-        if (imp == 0 || !is_ascii_ident_byte(bytes[imp - 1]))
+        if !ident_continues_before(content, imp)
             && let Some(stmt_end) = find_svelte_import_end(content, imp)
         {
             let segment = &content[imp..stmt_end];
@@ -113,16 +115,12 @@ fn dispatcher_local_in_import(import_segment: &str) -> Option<String> {
         return None;
     }
     let needle = "createEventDispatcher";
-    let bytes = import_segment.as_bytes();
     // Check every occurrence at an identifier boundary (a suffix like
     // `xcreateEventDispatcher` must not match).
     for (pos, _) in import_segment.match_indices(needle) {
-        let before_ok = pos == 0 || !is_ascii_ident_byte(bytes[pos - 1]);
+        let before_ok = !ident_continues_before(import_segment, pos);
         let after = &import_segment[pos + needle.len()..];
-        let after_ok = after
-            .as_bytes()
-            .first()
-            .is_none_or(|&c| !is_ascii_ident_byte(c));
+        let after_ok = !ident_continues_at(after, 0);
         if !(before_ok && after_ok) {
             continue;
         }
@@ -131,11 +129,8 @@ fn dispatcher_local_in_import(import_segment: &str) -> Option<String> {
         if let Some(rest) = trimmed.strip_prefix("as")
             && rest.as_bytes().first().is_some_and(u8::is_ascii_whitespace)
         {
-            let name: String = rest
-                .trim_start()
-                .chars()
-                .take_while(|&c| c == '_' || c == '$' || c.is_ascii_alphanumeric())
-                .collect();
+            let alias = rest.trim_start();
+            let name = alias[..ident_run_end(alias, 0)].to_string();
             if name.is_empty() {
                 continue; // malformed `as` with no alias — not a usable import
             }
@@ -157,11 +152,9 @@ fn call_sites_without_type_args(content: &str, locals: &[String]) -> Vec<usize> 
         let mut i = 0;
         while i + lb.len() <= bytes.len() {
             if &bytes[i..i + lb.len()] == lb {
-                let before_ok = i == 0 || !is_ascii_ident_byte(bytes[i - 1]);
+                let before_ok = !ident_continues_before(content, i);
                 let after_idx = i + lb.len();
-                let after_ok = bytes
-                    .get(after_idx)
-                    .is_none_or(|&c| !is_ascii_ident_byte(c));
+                let after_ok = !ident_continues_at(content, after_idx);
                 if before_ok && after_ok {
                     // Peek the next non-whitespace char.
                     let mut k = after_idx;

--- a/crates/rsvelte_lint/src/rules/require_event_prefix.rs
+++ b/crates/rsvelte_lint/src/rules/require_event_prefix.rs
@@ -19,7 +19,10 @@ use rsvelte_diagnostics::Diagnostic;
 use crate::config::LintConfig;
 use crate::line_index::LineIndex;
 use crate::rule::{Fixable, RuleCategory, RuleConditions, RuleMeta, Severity};
-use crate::svelte_scan::{blank_comments, is_ascii_ident_byte, script_blocks, script_is_ts};
+use crate::svelte_scan::{
+    blank_comments, ident_continues_at, ident_continues_before, ident_run_end, script_blocks,
+    script_is_ts,
+};
 use crate::validator::{range_from_byte, to_dsev};
 
 pub static META: RuleMeta = RuleMeta {
@@ -219,7 +222,6 @@ fn find_named_type_body(
     content_start: usize,
 ) -> Option<(String, usize)> {
     let nb = name.as_bytes();
-    let bytes = blanked.as_bytes();
 
     // Try `interface <name>` first.
     for kw in ["interface", "type"] {
@@ -227,7 +229,7 @@ fn find_named_type_body(
         while let Some(rel) = blanked[search_from..].find(kw) {
             let kw_start = search_from + rel;
             let kw_end = kw_start + kw.len();
-            let before_ok = kw_start == 0 || !is_ascii_ident_byte(bytes[kw_start - 1]);
+            let before_ok = !ident_continues_before(blanked, kw_start);
             if !before_ok {
                 search_from = kw_end;
                 continue;
@@ -241,8 +243,7 @@ fn find_named_type_body(
             }
             let after_name = rest_start + nb.len();
             // Name must end at a non-ident boundary.
-            let after_char = bytes.get(after_name).copied();
-            if after_char.is_some_and(is_ascii_ident_byte) {
+            if ident_continues_at(blanked, after_name) {
                 search_from = kw_end;
                 continue;
             }
@@ -373,13 +374,8 @@ fn top_level_position(bytes: &[u8], i: usize) -> bool {
 /// - Property with function type: `name: (…) => RetType` or `name?: (…) => RetType`
 /// - NOT function: `name: any`, `name: number`, `name: string`, etc.
 fn classify_member(segment: &str, name_abs_offset: usize) -> Option<TypeMember> {
-    let bytes = segment.as_bytes();
-
     // Extract the leading name (identifier chars, then optionally `?`).
-    let name_end = bytes
-        .iter()
-        .position(|&c| !is_ascii_ident_byte(c))
-        .unwrap_or(bytes.len());
+    let name_end = ident_run_end(segment, 0);
     if name_end == 0 {
         return None;
     }

--- a/crates/rsvelte_lint/src/svelte_scan.rs
+++ b/crates/rsvelte_lint/src/svelte_scan.rs
@@ -8,6 +8,8 @@
 //! [`ScriptRule`](crate::script::ScriptRule) trait can see together. A focused
 //! source scan over the `<script>` region keeps them simple and dependency-free.
 
+use rsvelte_core::compiler::utils::{char_at, char_before, is_js_ident_continue};
+
 /// Byte range `[start, end)` of each `<script …>…</script>` element's inner
 /// content, paired with the element's start-tag byte range `[tag_start, tag_gt)`
 /// (the `<` … `>` of the opening tag).
@@ -180,7 +182,7 @@ fn declares_type_in(content: &str, name: &str) -> bool {
         while let Some(rel) = content[from..].find(kw) {
             let kw_start = from + rel;
             let kw_end = kw_start + kw.len();
-            let before_ok = kw_start == 0 || !is_ascii_ident_byte(content.as_bytes()[kw_start - 1]);
+            let before_ok = !ident_continues_before(content, kw_start);
             // Require whitespace then the name then a non-identifier boundary.
             let rest = &content[kw_end..];
             let trimmed = rest.trim_start();
@@ -188,10 +190,7 @@ fn declares_type_in(content: &str, name: &str) -> bool {
             if before_ok
                 && consumed > 0
                 && let Some(after_name) = trimmed.strip_prefix(name)
-                && after_name
-                    .as_bytes()
-                    .first()
-                    .is_none_or(|&c| !is_ascii_ident_byte(c))
+                && !ident_continues_at(after_name, 0)
             {
                 return true;
             }
@@ -201,8 +200,39 @@ fn declares_type_in(content: &str, name: &str) -> bool {
     false
 }
 
-pub(crate) fn is_ascii_ident_byte(c: u8) -> bool {
-    c == b'_' || c == b'$' || c.is_ascii_alphanumeric()
+/// Whether the character starting at byte `at` can continue a JavaScript
+/// identifier — the word-boundary test these source scans need.
+///
+/// The predicate is the one ECMA-262 names (`IdentifierPartChar`), so an
+/// accented letter or a CJK character is glue and a non-ASCII space is a
+/// boundary. A byte test cannot answer either: every byte of a multi-byte
+/// character fails `is_ascii_alphanumeric`, so `foo` in `naïvefoo` would read as
+/// a standalone word.
+pub(crate) fn ident_continues_at(source: &str, at: usize) -> bool {
+    char_at(source, at).is_some_and(is_js_ident_continue)
+}
+
+/// Whether the character ending at byte `end` can continue a JavaScript
+/// identifier — see [`ident_continues_at`].
+pub(crate) fn ident_continues_before(source: &str, end: usize) -> bool {
+    char_before(source, end).is_some_and(is_js_ident_continue)
+}
+
+/// Byte offset just past the identifier run that starts at byte `from`.
+pub(crate) fn ident_run_end(source: &str, from: usize) -> usize {
+    source[from..]
+        .char_indices()
+        .find(|&(_, c)| !is_js_ident_continue(c))
+        .map_or(source.len(), |(i, _)| from + i)
+}
+
+/// Byte offset where the identifier run that ends at byte `end` starts.
+pub(crate) fn ident_run_start(source: &str, end: usize) -> usize {
+    source[..end]
+        .char_indices()
+        .rev()
+        .find(|&(_, c)| !is_js_ident_continue(c))
+        .map_or(0, |(i, c)| i + c.len_utf8())
 }
 
 /// Replace the contents of `//` line comments and `/* */` block comments in
@@ -308,6 +338,104 @@ mod tests {
         assert_eq!(out.matches('\n').count(), 1, "newline preserved");
         assert!(out.starts_with("a "), "code before comment kept: {out:?}");
         assert!(out.ends_with(" c"), "code after comment kept: {out:?}");
+    }
+
+    /// A boundary is a character that cannot continue an identifier — including
+    /// every non-ASCII space, which a byte test and this one agree on.
+    #[test]
+    fn non_identifier_neighbours_are_word_boundaries() {
+        for sep in [
+            ' ',
+            '\n',
+            '.',
+            '\u{85}',
+            '\u{a0}',
+            '\u{1680}',
+            '\u{2000}',
+            '\u{2009}',
+            '\u{2028}',
+            '\u{2029}',
+            '\u{202f}',
+            '\u{205f}',
+            '\u{3000}',
+            '\u{feff}',
+            '\u{2014}',
+            '\u{3001}',
+            '\u{1f600}',
+        ] {
+            let src = format!("{sep}foo{sep}");
+            let at = sep.len_utf8();
+            assert!(
+                !ident_continues_before(&src, at),
+                "U+{:04X} must be a word boundary",
+                sep as u32
+            );
+            assert!(
+                !ident_continues_at(&src, at + 3),
+                "U+{:04X} must be a word boundary",
+                sep as u32
+            );
+            assert_eq!(ident_run_end(&src, at), at + 3);
+            assert_eq!(ident_run_start(&src, at + 3), at);
+        }
+    }
+
+    /// The direction a byte test gets backwards: `ID_Continue` characters, `$`,
+    /// `_` and the zero-width joiners are identifier glue, so `foo` inside
+    /// `na\u{ef}vefoo` is not a standalone word.
+    #[test]
+    fn identifier_neighbours_are_glue() {
+        for glue in [
+            'a',
+            'Z',
+            '0',
+            '_',
+            '$',
+            '\u{e9}',
+            '\u{7dcf}',
+            '\u{5d0}',
+            '\u{3005}',
+            '\u{200c}',
+            '\u{200d}',
+            '\u{1d54f}',
+        ] {
+            let src = format!("{glue}foo{glue}");
+            let at = glue.len_utf8();
+            assert!(
+                ident_continues_before(&src, at),
+                "U+{:04X} must be identifier glue",
+                glue as u32
+            );
+            assert!(
+                ident_continues_at(&src, at + 3),
+                "U+{:04X} must be identifier glue",
+                glue as u32
+            );
+            assert_eq!(ident_run_end(&src, 0), src.len());
+            assert_eq!(ident_run_start(&src, src.len()), 0);
+        }
+    }
+
+    /// `interface $$Slots\u{e9}` declares a different type; a non-ASCII space
+    /// before the keyword is still a boundary.
+    #[test]
+    fn type_declaration_boundaries_are_character_classified() {
+        assert!(!script_declares_type(
+            "<script lang=\"ts\">\ninterface $$Slots\u{e9} {}\n</script>",
+            "$$Slots"
+        ));
+        assert!(!script_declares_type(
+            "<script lang=\"ts\">\n\u{e9}interface $$Slots {}\n</script>",
+            "$$Slots"
+        ));
+        assert!(script_declares_type(
+            "<script lang=\"ts\">\n\u{a0}interface $$Slots {}\n</script>",
+            "$$Slots"
+        ));
+        assert!(script_declares_type(
+            "<script lang=\"ts\">\ninterface $$Slots\u{a0}{}\n</script>",
+            "$$Slots"
+        ));
     }
 
     #[test]

--- a/crates/rsvelte_lint/tests/non_ascii_word_boundary.rs
+++ b/crates/rsvelte_lint/tests/non_ascii_word_boundary.rs
@@ -1,0 +1,189 @@
+//! Word boundaries in the `svelte_scan` source-scan rules must be classified by
+//! ECMA-262 `IdentifierPart`, not by "is this byte ASCII-alphanumeric".
+//!
+//! A byte test answers a different question in both directions: every byte of a
+//! multi-byte character fails it, so an accented letter reads as a *boundary*
+//! (`foo` inside `naïvefoo` becomes a standalone word, and an identifier scan
+//! stops mid-name), while a non-ASCII space must stay a boundary. This file
+//! pins both directions for each of the four callers — `no-unused-props`,
+//! `require-event-prefix`, `require-event-dispatcher-types`, and
+//! `svelte_scan::declares_type_in` (reached through
+//! `experimental-require-strict-events`). All four are `EXCLUDE`d from the lint
+//! output-parity universe, so its ratchet cannot see this class at all.
+
+use std::path::PathBuf;
+
+use rsvelte_core::CompileOptions;
+use rsvelte_lint::{LintConfig, Severity, lint_source};
+
+fn findings(src: &str, code: &str) -> Vec<String> {
+    let cfg = LintConfig::empty().with_override(code, Severity::Error);
+    lint_source(
+        src,
+        &PathBuf::from("Test.svelte"),
+        &CompileOptions::default(),
+        &cfg,
+    )
+    .into_iter()
+    .filter(|d| d.code.as_deref() == Some(code))
+    .map(|d| d.message)
+    .collect()
+}
+
+// ---------------------------------------------------------------------------
+// svelte/no-unused-props
+// ---------------------------------------------------------------------------
+
+const UNUSED_PROPS: &str = "svelte/no-unused-props";
+
+/// The whole-object variable name is read by walking back over identifier
+/// characters; a non-ASCII letter is part of the name, not the end of it.
+#[test]
+fn unused_props_whole_object_var_name_keeps_non_ascii_letters() {
+    let src = "<script lang=\"ts\">\n\
+        \tinterface Props { greeting: string }\n\
+        \tconst pr\u{f4}ps: Props = $props();\n\
+        </script>\n\
+        <p>{pr\u{f4}ps.greeting}</p>";
+    assert_eq!(findings(src, UNUSED_PROPS), Vec::<String>::new());
+}
+
+/// A member name is an identifier run, so it does not stop at a non-ASCII
+/// letter — the report must name the whole property.
+#[test]
+fn unused_props_member_name_keeps_non_ascii_letters() {
+    let src = "<script lang=\"ts\">\n\
+        \tinterface Props { gr\u{eb}eting: string }\n\
+        \tconst props: Props = $props();\n\
+        </script>\n\
+        <p>hi</p>";
+    assert_eq!(
+        findings(src, UNUSED_PROPS),
+        vec!["'gr\u{eb}eting' is an unused Props property.".to_string()]
+    );
+}
+
+/// The other direction: a non-ASCII space is a word boundary, so the use counts.
+#[test]
+fn unused_props_non_ascii_space_is_a_boundary() {
+    let src = "<script lang=\"ts\">\n\
+        \tinterface Props { greeting: string }\n\
+        \tconst props: Props = $props();\n\
+        </script>\n\
+        <p>{\u{a0}props.greeting}</p>";
+    assert_eq!(findings(src, UNUSED_PROPS), Vec::<String>::new());
+}
+
+// ---------------------------------------------------------------------------
+// svelte/require-event-prefix
+// ---------------------------------------------------------------------------
+
+const EVENT_PREFIX: &str = "svelte/require-event-prefix";
+
+/// A member whose name *starts* with a non-ASCII letter is still a member; a
+/// byte scan reads its name as empty and drops the violation.
+#[test]
+fn event_prefix_member_name_starting_with_a_non_ascii_letter_is_reported() {
+    let src = "<script lang=\"ts\">\n\
+        \tinterface Props { \u{ef}nput: () => void }\n\
+        \tconst props: Props = $props();\n\
+        </script>";
+    assert_eq!(
+        findings(src, EVENT_PREFIX),
+        vec!["Component event name must start with \"on\".".to_string()]
+    );
+}
+
+/// The named-type lookup must not accept `Props\u{e9}` for `Props`: the trailing
+/// letter is glue, so no type body resolves and nothing is reported.
+#[test]
+fn event_prefix_type_name_is_not_matched_by_a_non_ascii_suffixed_type() {
+    let src = "<script lang=\"ts\">\n\
+        \tinterface Props\u{e9} { click: () => void }\n\
+        \tconst props: Props = $props();\n\
+        </script>";
+    assert_eq!(findings(src, EVENT_PREFIX), Vec::<String>::new());
+}
+
+/// A non-ASCII space between the keyword and the type name stays a boundary.
+#[test]
+fn event_prefix_non_ascii_space_is_a_boundary() {
+    let src = "<script lang=\"ts\">\n\
+        \tinterface\u{a0}Props { click: () => void }\n\
+        \tconst props: Props = $props();\n\
+        </script>";
+    assert_eq!(
+        findings(src, EVENT_PREFIX),
+        vec!["Component event name must start with \"on\".".to_string()]
+    );
+}
+
+// ---------------------------------------------------------------------------
+// svelte/require-event-dispatcher-types
+// ---------------------------------------------------------------------------
+
+const DISPATCH: &str = "svelte/require-event-dispatcher-types";
+const DISPATCH_MSG: &str = "Type parameters missing for the `createEventDispatcher` function call.";
+
+/// `\u{e9}createEventDispatcher` is a different identifier; neither the import
+/// nor the call is `createEventDispatcher`.
+#[test]
+fn dispatcher_non_ascii_prefixed_name_is_a_different_identifier() {
+    let src = "<script lang=\"ts\">\n\
+        \timport { \u{e9}createEventDispatcher } from 'svelte';\n\
+        \tconst d = \u{e9}createEventDispatcher();\n\
+        </script>";
+    assert_eq!(findings(src, DISPATCH), Vec::<String>::new());
+}
+
+/// An `as` alias containing a non-ASCII letter is one name, so its call site is
+/// found; a byte scan truncates the alias and the call goes unreported.
+#[test]
+fn dispatcher_alias_keeps_non_ascii_letters() {
+    let src = "<script lang=\"ts\">\n\
+        \timport { createEventDispatcher as cr\u{e9}er } from 'svelte';\n\
+        \tconst d = cr\u{e9}er();\n\
+        </script>";
+    assert_eq!(findings(src, DISPATCH), vec![DISPATCH_MSG.to_string()]);
+}
+
+/// Non-ASCII spaces around the imported name and the call stay boundaries.
+#[test]
+fn dispatcher_non_ascii_space_is_a_boundary() {
+    let src = "<script lang=\"ts\">\n\
+        \timport {\u{a0}createEventDispatcher\u{a0}} from 'svelte';\n\
+        \tconst d =\u{a0}createEventDispatcher();\n\
+        </script>";
+    assert_eq!(findings(src, DISPATCH), vec![DISPATCH_MSG.to_string()]);
+}
+
+// ---------------------------------------------------------------------------
+// svelte_scan::declares_type_in (via experimental-require-strict-events)
+// ---------------------------------------------------------------------------
+
+const STRICT: &str = "svelte/experimental-require-strict-events";
+const STRICT_MSG: &str = "The component must have the strictEvents attribute on its <script> tag or it must define the $$Events interface.";
+
+/// `interface $$Events\u{e9}` declares a *different* type, so the component
+/// still has no `$$Events`.
+#[test]
+fn declares_type_rejects_a_non_ascii_suffixed_name() {
+    let src = "<script lang=\"ts\">\n\tinterface $$Events\u{e9} {}\n</script>";
+    assert_eq!(findings(src, STRICT), vec![STRICT_MSG.to_string()]);
+}
+
+/// `\u{e9}interface` is an identifier, not the `interface` keyword.
+#[test]
+fn declares_type_rejects_a_non_ascii_prefixed_keyword() {
+    let src =
+        "<script lang=\"ts\">\n\tconst s = \"\u{e9}interface $$Events {}\";\n\tvoid s;\n</script>";
+    assert_eq!(findings(src, STRICT), vec![STRICT_MSG.to_string()]);
+}
+
+/// The other direction: a non-ASCII space before the keyword is a boundary, so
+/// the declaration is still found.
+#[test]
+fn declares_type_non_ascii_space_is_a_boundary() {
+    let src = "<script lang=\"ts\">\n\u{a0}interface $$Events {}\n</script>";
+    assert_eq!(findings(src, STRICT), Vec::<String>::new());
+}


### PR DESCRIPTION
Closes #2684

## What was wrong

`svelte_scan::is_ascii_ident_byte` answered *"is this byte ASCII-alphanumeric, `_` or `$`"*.
Every byte of a multi-byte character fails that test, so **every non-ASCII character read as a
word boundary** — the mirror image of #2682, which treated every non-ASCII byte as identifier
glue. Four rules share the predicate: `svelte/no-unused-props`, `svelte/require-event-prefix`,
`svelte/require-event-dispatcher-types`, and the `$$Slots`/`$$Events` declaration scan behind
`svelte/experimental-require-slot-types` / `-strict-events`.

It broke in both of the two shapes a boundary test has:

| shape | example | old behaviour |
|---|---|---|
| neighbour test | `interface $$Eventsé {}` | satisfied the `$$Events` requirement |
| neighbour test | `import { écreateEventDispatcher } from 'svelte'` | read as importing `createEventDispatcher`; the unrelated call was reported |
| neighbour test | `interface Propsé { … }` used for `Props` | resolved as the body of `Props` |
| identifier run | `import { createEventDispatcher as créer }` | alias truncated to `cr`; the real untyped call went **unreported** |
| identifier run | `interface Props { ïnput: () => void }` | name parsed as empty → member dropped, violation missed |
| identifier run | `interface Props { grëeting: string }` | reported `'gr' is an unused Props property.` |
| identifier run | `const prôps: Props = $props()` | **panicked** — `byte index 49 is not a char boundary; it is inside 'ô'` |

## The fix

Boundaries and identifier runs are now decided with
`rsvelte_core::compiler::utils::is_js_ident_continue` — ECMA-262 `IdentifierPartChar`
(`UnicodeIDContinue | $ | <ZWNJ> | <ZWJ>`), the predicate #2682 uses and the one the compiler's
own classifiers share. `is_ascii_ident_byte` is replaced by four helpers on `&str`
(`ident_continues_at` / `ident_continues_before` / `ident_run_end` / `ident_run_start`), so no
third hand-rolled classifier is introduced and every remaining call site takes a character, not
a byte. ASCII input is unaffected: the two predicates agree on every ASCII byte.

`scss_selector.rs:675,680` keeps its `>= 0x80` test, deliberately — that is CSS Syntax Level 3
§4.2, a different specification, and #2684 scopes it out.

## The gate

`crates/rsvelte_lint/tests/non_ascii_word_boundary.rs` — 12 cases driving all four callers
through the public `lint_source`, three per rule, covering **both** directions the issue asks
for: a non-ASCII letter must be glue, and a non-ASCII space (U+00A0) must stay a boundary. Two
unit tests in `no_unused_props.rs` pin `member_chains` / `parse_member_chain`, and two in
`svelte_scan.rs` pin the predicates themselves over a 17-character boundary set and a
12-character glue set.

**Wired.** Integration binaries are partitioned from `cargo metadata` by
`scripts/ci/run-test-shard.sh`, which "automatically absorbs newly added `tests/*.rs` files";
the unit tests run in the dedicated `test-unit` job (`cargo nextest run --profile ci --lib`).

**Discriminating (positive control).** Reverting the four source files to `origin/main` while
keeping the tests: **8 of the 12** integration cases fail, spread across all four rules — one of
them by panicking inside `find_props_info`. The 4 that stay green are exactly the four
non-ASCII-space cases, i.e. the direction that must *not* move. Both `no_unused_props` unit
tests also fail on the reverted tree (`["b"]` vs `["bär"]`; `ab々foo.bar` counted as a use of
`foo`).

**No ASCII regression.** `crates/rsvelte_lint/tests/eslint_plugin_oracle.rs` passes against the
real `eslint-plugin-svelte` fixtures with the submodule checked out.

### What the gate does NOT see

- **It is not a parity gate.** It asserts rsvelte's own findings, not agreement with
  `eslint-plugin-svelte`. If upstream also classifies these positions differently, this file
  will not say so — the corpus gate that would is structurally unavailable here (below).
- **Only U+00A0 is exercised end-to-end.** The wider space/glue sets (U+2000–U+200A, U+2028/29,
  U+202F, U+205F, U+3000, U+FEFF, ZWNJ/ZWJ, CJK, U+1D54F) are covered at the predicate level in
  `svelte_scan.rs`, not through `lint_source`.
- **Three of the four callers have several boundary sites each; the tests reach one or two per
  rule.** They pin the classifier's behaviour through a representative path, not every call
  site — e.g. `no_unused_props::is_type_imported` and the `has_whole_object_spread` next-char
  test are reached by neither.
- **`member_chains` is only reachable from the type-aware path** (`diagnostics_typed_graph`),
  which needs a `TypeBackend`; it is therefore covered by unit tests, not by `lint_source`.
- **The lint output-parity ratchet cannot see any of this**, which is why a re-baseline would
  have been the wrong remedy (same shape as #2532): all four rules are in `EXCLUDE`
  (`scripts/compat-corpus/lint-universe.mjs:26,33,40,41`), each for a different structural
  reason. `compatibility/gate-coverage.md` gains blind spot **11g** recording that.

## Adjacent defect found, NOT fixed

`no_unused_props::whole_object_member_used` (`crates/rsvelte_lint/src/rules/no_unused_props.rs:891`)
decides whether `props.greeting` is read with a bare
`source.contains("props.greeting")` — **no word-boundary check at all**, in any encoding. A
template containing `{xprops.greeting}` (plain ASCII) marks `greeting` as used, and so does a
mention inside a string literal or a comment. It is not a non-ASCII bug — it fails identically on
ASCII input — so it is out of scope here and needs its own issue. The same function's
`props['greeting']` / `props["greeting"]` forms have the same hole.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016NFR39XQtQHKgv3kgRoCGP
