### PR TITLE
fix(server): keep a comment interior to a declaration's initializer

### DIFF
--- a/.changeset/server-initializer-interior-comments.md
+++ b/.changeset/server-initializer-interior-comments.md
@@ -1,0 +1,45 @@
+---
+"@rsvelte/compiler": patch
+---
+
+Keep a comment interior to a declaration's initializer in `generate: 'server'` output
+
+A comment inside a `let` / `const` / `var` initializer was dropped and the
+multi-line layout around it re-flowed onto one line:
+
+```svelte
+<script>
+	let data = {
+		/* c */
+		a: 1
+	};
+	function go() { data = { a: 2 }; }
+</script>
+
+<p on:click={go}>{data.a}</p>
+```
+
+```js
+// official          // rsvelte before
+let data = {         let data = { a: 1 };
+	/* c */
+	a: 1
+};
+```
+
+This is not a bracket-scanner defect: a plain `/* c */` with no delimiter in it
+diverged identically to `/* } c */`. The server rebuilds a declaration from
+re-parsed SUB-slices — the pattern from one slice, the initializer from another —
+so the emitted statement's nodes carry no coherent set of source positions and the
+comment carry-over can only collapse every span onto one address. That is enough
+for a leading comment (they all flush before the statement) but destroys every
+interior position, so an interior comment has nowhere to land.
+
+A declaration whose lowering is nothing but that re-parse plus init read-wrapping
+is now re-parsed WHOLE from its source span instead, the same way function
+declarations, `if` blocks and `$:` statements already were, so its spans stay
+coherent and the printer places the comment where the source put it. Declarations
+that really are rewritten — a prop lowered to `$$props['x']`, a destructured
+`$state` expanded into a temp group, a rune initializer, a multi-declarator
+declaration split into one statement per declarator — keep the per-declarator
+rebuild. Client and client-dev output is unchanged.

--- a/compatibility/pattern-corpus/issues/2626-comment-delimiter-in-initializer.svelte
+++ b/compatibility/pattern-corpus/issues/2626-comment-delimiter-in-initializer.svelte
@@ -1,0 +1,18 @@
+<script>
+	let mid_semi = a + // ; c
+		b;
+
+	let mid_paren = c + // ) c
+		d;
+
+	let mid_brace = e + // } c
+		f;
+
+	function go() {
+		mid_semi = 1;
+		mid_paren = 2;
+		mid_brace = 3;
+	}
+</script>
+
+<p on:click={go}>{mid_semi}{mid_paren}{mid_brace}</p>

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/script.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/script.rs
@@ -496,8 +496,12 @@ fn transform_script<'a>(
                     }
                 }
                 Statement::VariableDeclaration(vd) => {
-                    count_non_reparse(&ret.program.comments, vd.span);
-                    out.extend(lower_variable_declaration(vd, src, is_instance, state));
+                    let lowered =
+                        lower_variable_declaration(vd, src, is_instance, state, &mut verbatim);
+                    if verbatim.is_none() {
+                        count_non_reparse(&ret.program.comments, vd.span);
+                    }
+                    out.extend(lowered);
                 }
                 // INSTANCE-only `ExportNamedDeclaration` override (写经 the per-instance
                 // visitor added in `transform-server.js` line ~127): a declaration-less
@@ -521,8 +525,17 @@ fn transform_script<'a>(
                                 exp.span.start,
                                 vd.span.start,
                             );
-                            count_non_reparse(&ret.program.comments, vd.span);
-                            out.extend(lower_variable_declaration(vd, src, is_instance, state));
+                            let lowered = lower_variable_declaration(
+                                vd,
+                                src,
+                                is_instance,
+                                state,
+                                &mut verbatim,
+                            );
+                            if verbatim.is_none() {
+                                count_non_reparse(&ret.program.comments, vd.span);
+                            }
+                            out.extend(lowered);
                         }
                         decl => {
                             // `export function` / `export class` → keep the inner
@@ -1681,16 +1694,120 @@ impl<'a, 'b> VisitMut<'a> for ClassFieldRuneLower<'a, 'b> {
     }
 }
 
+/// Re-parse a whole `VariableDeclaration` from its source span and read-wrap
+/// each init, for the declarations whose lowering is otherwise nothing but a
+/// re-parse of the pattern and the init. Rebuilding those from SUB-slices leaves
+/// the statement's nodes with no coherent set of source positions, so the
+/// comment carry-over can only collapse them onto one address and every comment
+/// INTERIOR to the initializer is lost; a whole-statement re-parse keeps them.
+///
+/// `None` (fall back to the per-declarator rebuild) unless the declaration is a
+/// single declarator of a kind the rebuild would have reproduced verbatim —
+/// `using` / `await using` are rewritten to `let` there, and a multi-declarator
+/// `let a = …, b = …` is split into one statement per declarator.
+fn reparse_var_decl_whole<'a>(
+    vd: &oxc_ast::ast::VariableDeclaration,
+    src: &str,
+    state: &mut ServerTransformState<'a>,
+) -> Option<Statement<'a>> {
+    if vd.declarations.len() != 1
+        || !matches!(
+            vd.kind,
+            VariableDeclarationKind::Let
+                | VariableDeclarationKind::Const
+                | VariableDeclarationKind::Var
+        )
+    {
+        return None;
+    }
+    let slice = src.get(vd.span.start as usize..vd.span.end as usize)?;
+    let mut stmt = state.reparse_statement(slice)?;
+    let Statement::VariableDeclaration(out_vd) = &mut stmt else {
+        return None;
+    };
+    for d in out_vd.declarations.iter_mut() {
+        if let Some(init) = d.init.as_mut() {
+            super::read_wrap::wrap_reads(
+                init,
+                state.b,
+                state.analysis,
+                state.analysis.root.instance_scope_index,
+            );
+        }
+    }
+    Some(stmt)
+}
+
+/// The rune a declarator's init is, if any.
+///
+/// Store-rune conflict: `let x = $state()` where the `$state` store subscription
+/// is LEXICALLY VISIBLE at the instance scope is a store read, not the rune.
+/// Upstream's `get_rune` returns null (the auto-created `$state`
+/// store-subscription binding shadows the rune), so the declarator falls through
+/// to the ordinary read-wrap path, which emits
+/// `$.store_get(($$store_subs ??= {}), "$state", state)()`.
+///
+/// The lookup uses the `$`-PREFIXED callee name (`$state`), not the base
+/// `state`, and requires an actual STORE-SUBSCRIPTION binding
+/// (`BindingKind::StoreSub`, created only when the store is really read as
+/// `$state`). This precisely distinguishes the conflict from an ordinary rune:
+/// `let props = $props()` binds `props` but registers no `$props` store
+/// subscription, and `let state = $state(0)` (no `$state` read anywhere)
+/// registers none either — both correctly stay runes. The ancestor-or-self
+/// visibility check excludes a same-named binding in a DESCENDANT scope surfaced
+/// by the intentionally root-polluted scope table.
+///
+/// INSTANCE-only: store auto-subscriptions exist only in the instance script, so
+/// a module-script `const data = $state({…})` (with an unrelated module `const
+/// state`) stays the rune (`inspect-derived-2`).
+fn declarator_rune(
+    d: &oxc_ast::ast::VariableDeclarator,
+    is_instance: bool,
+    state: &ServerTransformState<'_>,
+) -> Option<DeclRune> {
+    let rune = d.init.as_ref().and_then(detect_decl_rune)?;
+    if is_instance
+        && let Some(callee) = d.init.as_ref().and_then(rune_callee_name)
+        && let Some(bidx) = state
+            .analysis
+            .root
+            .get_binding(callee, state.analysis.root.instance_scope_index)
+        && matches!(
+            state.analysis.root.bindings[bidx].kind,
+            BindingKind::StoreSub
+        )
+        && state.analysis.root.is_scope_ancestor_of(
+            state.analysis.root.bindings[bidx].scope_index,
+            state.analysis.root.instance_scope_index,
+        )
+    {
+        return None;
+    }
+    Some(rune)
+}
+
 /// Lower a single `VariableDeclaration` (runes branch). Returns the rebuilt
 /// statements (ONE per top-level declarator, mirroring the server text-oracle's
 /// `split_comma_separated_declarations`), or an empty vec if every declarator
-/// was dropped.
+/// was dropped. `verbatim` is set to the source range when the declaration was
+/// re-parsed WHOLE, which is what lets its interior comments be replayed.
 fn lower_variable_declaration<'a>(
     vd: &oxc_ast::ast::VariableDeclaration,
     src: &str,
     is_instance: bool,
     state: &mut ServerTransformState<'a>,
+    verbatim: &mut Option<Span>,
 ) -> Vec<Statement<'a>> {
+    if vd
+        .declarations
+        .first()
+        .is_some_and(|d| declarator_rune(d, is_instance, state).is_none())
+        && let Some(stmt) = reparse_var_decl_whole(vd, src, state)
+    {
+        *verbatim = Some(vd.span);
+        return vec![stmt];
+    }
+
     let b = state.b;
     let kind = match vd.kind {
         VariableDeclarationKind::Const => VariableDeclarationKind::Const,
@@ -1710,47 +1827,7 @@ fn lower_variable_declaration<'a>(
         // Per-source-declarator pair accumulator.
         let mut decls: Vec<(oxc_ast::ast::BindingPattern<'a>, Option<OxcExpression<'a>>)> =
             Vec::new();
-        let mut rune = d.init.as_ref().and_then(detect_decl_rune);
-        // Store-rune conflict: `let x = $state()` where the `$state` store
-        // subscription is LEXICALLY VISIBLE at the instance scope is a store
-        // read, not the rune. Upstream's `get_rune` returns null (the auto-created
-        // `$state` store-subscription binding shadows the rune), so the declarator
-        // falls through to the ordinary read-wrap path, which emits
-        // `$.store_get(($$store_subs ??= {}), "$state", state)()`. Nullify the
-        // rune here so the `None` branch below handles it.
-        //
-        // Look up the `$`-PREFIXED callee name (`$state`), not the base `state`,
-        // and require it to be an actual STORE-SUBSCRIPTION binding
-        // (`BindingKind::StoreSub`, created only when the store is really read as
-        // `$state`). This precisely distinguishes the conflict from an ordinary
-        // rune: `let props = $props()` binds `props` but registers no `$props`
-        // store subscription, and `let state = $state(0)` (no `$state` read
-        // anywhere) registers none either — both correctly stay runes. The
-        // ancestor-or-self visibility check excludes a same-named binding in a
-        // DESCENDANT scope surfaced by the intentionally root-polluted scope table.
-        //
-        // INSTANCE-only: store auto-subscriptions exist only in the instance
-        // script, so a module-script `const data = $state({…})` (with an unrelated
-        // module `const state`) stays the rune (`inspect-derived-2`).
-        if is_instance
-            && rune.is_some()
-            && let Some(callee) = d.init.as_ref().and_then(rune_callee_name)
-            && let Some(bidx) = state
-                .analysis
-                .root
-                .get_binding(callee, state.analysis.root.instance_scope_index)
-            && matches!(
-                state.analysis.root.bindings[bidx].kind,
-                BindingKind::StoreSub
-            )
-            && state.analysis.root.is_scope_ancestor_of(
-                state.analysis.root.bindings[bidx].scope_index,
-                state.analysis.root.instance_scope_index,
-            )
-        {
-            rune = None;
-        }
-        match rune {
+        match declarator_rune(d, is_instance, state) {
             None => {
                 // Non-rune declarator: re-parse the whole declarator span as a
                 // `let <decl>;` so the pattern + init survive verbatim, then
@@ -2788,14 +2865,18 @@ fn transform_script_legacy<'a>(
                                 exp.span.start,
                                 vd.span.start,
                             );
-                            count_non_reparse(&ret.program.comments, vd.span);
-                            out.extend(lower_legacy_var_decl(
+                            let lowered = lower_legacy_var_decl(
                                 vd,
                                 src,
                                 state,
                                 true,
                                 &mut array_counter,
-                            ));
+                                &mut verbatim,
+                            );
+                            if verbatim.is_none() {
+                                count_non_reparse(&ret.program.comments, vd.span);
+                            }
+                            out.extend(lowered);
                         }
                         other => {
                             // `export function` / `export class` → keep the inner
@@ -2825,14 +2906,18 @@ fn transform_script_legacy<'a>(
                     }
                 }
                 Statement::VariableDeclaration(vd) => {
-                    count_non_reparse(&ret.program.comments, vd.span);
-                    out.extend(lower_legacy_var_decl(
+                    let lowered = lower_legacy_var_decl(
                         vd,
                         src,
                         state,
                         false,
                         &mut array_counter,
-                    ));
+                        &mut verbatim,
+                    );
+                    if verbatim.is_none() {
+                        count_non_reparse(&ret.program.comments, vd.span);
+                    }
+                    out.extend(lowered);
                 }
                 Statement::LabeledStatement(ls) if is_instance && ls.label.name.as_str() == "$" => {
                     // Top-level legacy reactive `$:` statement. Upstream keeps the
@@ -3175,14 +3260,31 @@ fn collect_read_identifiers_in_statement(stmt: &Statement, out: &mut Vec<String>
 }
 
 /// Lower a legacy `VariableDeclaration`. `is_export` marks `export let …`
-/// declarators whose simple-identifier bindings are bindable props.
+/// declarators whose simple-identifier bindings are bindable props. `verbatim`
+/// is set to the source range when the declaration was re-parsed WHOLE, which is
+/// what lets its interior comments be replayed.
 fn lower_legacy_var_decl<'a>(
     vd: &oxc_ast::ast::VariableDeclaration,
     src: &str,
     state: &mut ServerTransformState<'a>,
     is_export: bool,
     array_counter: &mut u32,
+    verbatim: &mut Option<Span>,
 ) -> Vec<Statement<'a>> {
+    if vd.declarations.first().is_some_and(|d| {
+        let mut leaves: Vec<String> = Vec::new();
+        collect_binding_pattern_idents(&d.id, &mut leaves);
+        // A prop lowers to `$$props[…]` and a destructured state expands into a
+        // temp group; a plain or identifier-state declarator does neither.
+        !leaves.iter().any(|n| legacy_binding_is_prop(state, n))
+            && (matches!(d.id, oxc_ast::ast::BindingPattern::BindingIdentifier(_))
+                || !leaves.iter().any(|n| legacy_binding_is_state(state, n)))
+    }) && let Some(stmt) = reparse_var_decl_whole(vd, src, state)
+    {
+        *verbatim = Some(vd.span);
+        return vec![stmt];
+    }
+
     let b = state.b;
     let kind = match vd.kind {
         VariableDeclarationKind::Const => VariableDeclarationKind::Const,

--- a/crates/rsvelte_core/tests/comment_delimiters_in_initializer.rs
+++ b/crates/rsvelte_core/tests/comment_delimiters_in_initializer.rs
@@ -16,6 +16,12 @@
 //! inputs, not decoration. The real-world corpus contains none of them — 10,389
 //! files are byte-identical across this change — which is why they need a test
 //! of their own.
+//!
+//! The SERVER half of the file is here for the opposite reason: the corpus gate
+//! ignores comments entirely (`ast_equiv_batch` runs under
+//! `CommentPolicy::Ignore`), so a divergence living only in a comment is scored
+//! a pass on every entry and every target. A dropped comment is observable
+//! nowhere but in a text assertion like these.
 
 use rsvelte_core::{CompileOptions, GenerateMode, compile};
 
@@ -69,14 +75,91 @@ fn a_closing_paren_in_a_comment_does_not_end_the_initializer() {
     );
 }
 
-/// The server target never ran this scan; it drops the comment and keeps both
-/// operands. That is the control: a fix that reached the server would move it.
+/// The server target never ran this scan, so it must keep both operands
+/// whatever the client does. It keeps the comment too: the server rebuilds a
+/// declaration from its source, and a comment INTERIOR to the initializer only
+/// survives when that rebuild is a whole-statement re-parse.
 #[test]
-fn the_server_still_keeps_both_operands() {
+fn the_server_keeps_both_operands_and_the_comment() {
     let out = compile_to(SEMI_MID, GenerateMode::Server);
     assert!(
-        out.contains("let x = a + b;"),
+        out.contains("let x = a + // ; c\n\t\tb;"),
         "the server initializer changed:\n{out}"
+    );
+}
+
+/// A declaration is rebuilt from re-parsed SUB-slices (pattern, then init), so
+/// its nodes carry no coherent set of source positions and the comment
+/// carry-over can only collapse them onto one address — which drops every
+/// comment interior to the initializer and re-flows it onto one line. These
+/// three cover the bracket kinds that interior position comes in.
+const OBJECT_INIT: &str = "<script>\n\tlet data = {\n\t\t/* c */\n\t\ta: 1\n\t};\n\tfunction go() { data = { a: 2 }; }\n</script>\n\n<p on:click={go}>{data.a}</p>\n";
+
+const ARRAY_INIT: &str = "<script>\n\tlet items = [\n\t\t/* ) c */\n\t\t1\n\t];\n\tfunction go() { items = [2]; }\n</script>\n\n<p on:click={go}>{items[0]}</p>\n";
+
+const CALL_ARGS: &str = "<script>\n\tlet v = foo(\n\t\t/* ) c */\n\t\t1\n\t);\n\tfunction go() { v = 2; }\n</script>\n\n<p on:click={go}>{v}</p>\n";
+
+#[test]
+fn a_comment_inside_an_object_initializer_survives_the_server() {
+    let out = compile_to(OBJECT_INIT, GenerateMode::Server);
+    assert!(
+        out.contains("let data = {\n\t\t/* c */\n\t\ta: 1\n\t};"),
+        "the object initializer lost its comment or its layout:\n{out}"
+    );
+}
+
+#[test]
+fn a_comment_inside_an_array_initializer_survives_the_server() {
+    let out = compile_to(ARRAY_INIT, GenerateMode::Server);
+    assert!(
+        out.contains("let items = [\n\t\t/* ) c */\n\t\t1\n\t];"),
+        "the array initializer lost its comment or its layout:\n{out}"
+    );
+}
+
+#[test]
+fn a_comment_inside_a_call_argument_list_survives_the_server() {
+    let out = compile_to(CALL_ARGS, GenerateMode::Server);
+    assert!(
+        out.contains("let v = foo(\n\t\t/* ) c */\n\t\t1\n\t);"),
+        "the call argument list lost its comment or its layout:\n{out}"
+    );
+}
+
+/// Control: a comment interior to a statement BODY already survived, and a
+/// whole-statement re-parse of a DECLARATION must not disturb it.
+#[test]
+fn a_comment_inside_an_if_block_still_survives_the_server() {
+    let source = "<script>\n\tlet a = 1;\n\tlet b = 0;\n\tif (a) {\n\t\t/* inner */\n\t\tb = 1;\n\t}\n</script>\n{b}\n";
+    let out = compile_to(source, GenerateMode::Server);
+    assert!(
+        out.contains("if (a) {\n\t\t/* inner */\n\t\tb = 1;\n\t}"),
+        "the if-block comment moved:\n{out}"
+    );
+}
+
+/// Control: a declaration the server must NOT keep verbatim. `export let x` is
+/// prop-lowered to `$$props['x']`, so the whole-statement re-parse cannot apply
+/// — a guard that let it through would emit the source declaration unchanged.
+#[test]
+fn an_exported_prop_is_still_prop_lowered() {
+    let source = "<script>\n\texport let x = {\n\t\t/* c */\n\t\ta: 1\n\t};\n</script>\n{x.a}\n";
+    let out = compile_to(source, GenerateMode::Server);
+    assert!(
+        out.contains("$$props['x']"),
+        "the prop was emitted as a plain declaration:\n{out}"
+    );
+}
+
+/// Control: a multi-declarator declaration is still SPLIT into one statement
+/// per declarator, which a whole-statement re-parse would undo.
+#[test]
+fn a_multi_declarator_declaration_is_still_split() {
+    let source = "<script>\n\tlet a = 1, b = 2;\n\tfunction go() { a = 3; b = 4; }\n</script>\n\n<p on:click={go}>{a}{b}</p>\n";
+    let out = compile_to(source, GenerateMode::Server);
+    assert!(
+        out.contains("let a = 1;\n\tlet b = 2;"),
+        "the declarators were not split:\n{out}"
     );
 }
 

--- a/crates/rsvelte_core/tests/comment_delimiters_in_initializer.rs
+++ b/crates/rsvelte_core/tests/comment_delimiters_in_initializer.rs
@@ -83,7 +83,7 @@ fn a_closing_paren_in_a_comment_does_not_end_the_initializer() {
 fn the_server_keeps_both_operands_and_the_comment() {
     let out = compile_to(SEMI_MID, GenerateMode::Server);
     assert!(
-        out.contains("let x = a + // ; c\n\t\tb;"),
+        out.contains("let x = a + // ; c\n\tb;"),
         "the server initializer changed:\n{out}"
     );
 }


### PR DESCRIPTION
Closes #2644

## The defect

A comment interior to a **declaration's initializer** was dropped from
`generate: 'server'` output, and the multi-line layout around it collapsed onto one line.
`client` and `client-dev` were byte-identical to official for every case.

```svelte
<script>
	let data = {
		/* c */
		a: 1
	};
	function go() { data = { a: 2 }; }
</script>

<p on:click={go}>{data.a}</p>
```

```js
// official          // rsvelte before
let data = {         let data = { a: 1 };
	/* c */
	a: 1
};
```

This is **not** a bracket-scanner defect of the #2253 / #2639 family. A plain `/* c */` with
no delimiter in it diverged identically to `/* } c */` — nothing was mis-reading a `}` as
structure.

## The mechanism

#2536 (for #2504) gave the SSR comment carry-over a second placement mode: a statement
re-parsed WHOLE from its source range gets its spans **shifted** onto the registered region,
so its nodes sit at their real relative positions and the printer places interior comments
where the source put them. Statements rebuilt from sub-slices keep `Place::At`, which
collapses every span onto one address.

A `VariableDeclaration` was always in the second group. `lower_legacy_var_decl` /
`lower_variable_declaration` re-parse the binding pattern from one slice and the initializer
from another and reassemble them with `b.var_decl_from_pairs`, so the emitted statement has
no coherent set of source positions. Collapsing is fine for a *leading* comment — they all
flush before the statement — but it destroys every interior position, so the comment has
nowhere to land and dies with the region.

## What changed

A declaration whose lowering is *nothing but* that re-parse plus init read-wrapping is now
re-parsed WHOLE from `vd.span` (`reparse_var_decl_whole`) and reported through the existing
`verbatim` out-param, exactly the way function declarations, `if` blocks, expression
statements and `$:` statements already were. Everything else keeps the per-declarator
rebuild:

| declaration | path |
|---|---|
| plain declarator (`let x = <init>`) | **whole re-parse** |
| legacy identifier state (`let data = {…}`, mutated) | **whole re-parse** |
| prop (`export let x`) → `$$props['x']` | per-declarator rebuild |
| destructured legacy state / props → temp group | per-declarator rebuild |
| any rune initializer (`$state`, `$derived`, `$props`, …) | per-declarator rebuild |
| multi-declarator `let a = …, b = …` (split into one statement each) | per-declarator rebuild |
| `using` / `await using` (rewritten to `let`) | per-declarator rebuild |

The store-rune conflict test that decided the runes branch was lifted verbatim out of the
loop into `declarator_rune`, so the guard and the lowering ask the same question in one
place instead of two.

## Gate

`crates/rsvelte_core/tests/comment_delimiters_in_initializer.rs` — the file #2626 shipped —
gains **three positives and three controls**, plus one existing control whose subject this
change deliberately moves.

Positives (server): a comment inside an object-literal initializer, an array initializer and
a call's argument list, each asserting the comment **and** the multi-line layout.

Controls that must not move:

- `a_comment_inside_an_if_block_still_survives_the_server` — #2504's own example, the
  statement-body class this change must not disturb.
- `an_exported_prop_is_still_prop_lowered` — a guard that let a prop through would emit the
  source declaration instead of `$$props['x']`.
- `a_multi_declarator_declaration_is_still_split` — a whole-statement re-parse of
  `let a = 1, b = 2;` would undo the split into one statement per declarator.
- `a_real_semicolon_still_ends_the_initializer` (client, pre-existing) — unaffected.

`the_server_still_keeps_both_operands` is renamed to
`the_server_keeps_both_operands_and_the_comment` and now asserts the comment as well. It was
written as #2626's "the server never ran this scan" control; the operands half is unchanged,
the comment half is the subject of this fix.

**Discrimination proved by reverting.** With `server/ast/script.rs` checked out from
`origin/main` and the tests left as-is, the run is
`7 passed; 4 failed` — and the 4 are exactly the subject tests:

```
a_comment_inside_an_object_initializer_survives_the_server   let data = { a: 1 };
a_comment_inside_an_array_initializer_survives_the_server    let items = [1];
a_comment_inside_a_call_argument_list_survives_the_server    let v = foo(1);
the_server_keeps_both_operands_and_the_comment               let x = a + b;
```

All seven others — the three new controls, the three pre-existing #2626 client positives and
`a_real_semicolon_still_ends_the_initializer` — pass before and after.

`compatibility/pattern-corpus/issues/2626-comment-delimiter-in-initializer.svelte` lands too:
the corpus-level fixture #2644 was blocking. It is `MATCH` on all three targets (verified,
not assumed) and needs no `known-failures` entry.

## What the gate does NOT see

**The corpus gate cannot see this class at all, on any entry, on any target.**
`verify.mjs` defers byte-different pairs to `ast_equiv_batch` with empty argv, which selects
`CommentPolicy::Ignore` — gate-coverage blind spot 1a. A divergence living only in a comment
is byte-different, AST-equivalent, and scored a pass. So:

- the #2644 shapes would be `match` in `verify.mjs` before *and* after this change;
- a `pattern-corpus` fixture for #2644 would be **non-discriminating**, which is why this PR
  does not add one — the text assertions above are the only place a dropped comment is
  observable.
- the mutation-fuzz gate classifies this shape as `comment-mismatch`, which is **counted,
  not ratcheted** (only `code-mismatch` is), so it does not gate it either.

The `2626-*` fixture *is* corpus-discriminating, but for the other half: pre-#2626 the same
input produced `$.mutable_source(a + //); c`, which the parse gate rejects as unparseable.

The new tests also do not see: any target but `server`; a declaration with more than one
declarator; a prop or destructured-state declaration (both still drop the interior comment —
see below); and a comment's *position within a line*, since they assert whole substrings.

## Ratchets

Re-baselined nothing, because nothing moved:

- `compatibility/matrix-known-failures.json` — `pnpm run corpus:matrix`: 206 divergences,
  baseline 206, no regressions and no entry that now passes. The `comment-slot` family
  inserts into statement slots, not into a declaration initializer, which is why it never
  saw this.
- `compatibility/known-failures.server.json` is empty (saturated), so there was nothing to
  remove. Local `corpus:collect` + `corpus:compile` + `corpus:verify` over 14,167 entries × 3
  targets: *all corpus outputs identical after normalization*, 39,656/39,656 modules parse,
  no warning and no error regressions.
- `compatibility/mutation-known-failures.json` — `pnpm run corpus:mutate:full` (the two-sided
  mode; PRs only get a sample): 12,195 mutants, **36 `code-mismatch`, baseline 36**, no
  regressions and no entry that now passes. The 12,240 `comment-mismatch` results are counted,
  not gated — which is the bucket this defect falls in.
- The five `runtime-legacy` mutation seeds named in #2644 are **not** in
  `mutation-known-failures.json` — the issue reports them as *new* divergences, and they
  never entered it. Reconstructed mutants of
  `attachment-in-mutated-state/main.svelte` and `bindings-global-dependency/main.svelte`
  are `MATCH` on all three targets after this change.

## Adjacent defects found, NOT fixed

1. **server — a comment trailing a declaration on the same line moves to the next line.**

   ```svelte
   <script>
   	let a = foo(1) // ; c

   	let b = 2;
   </script>
   ```
   ```js
   // official                // rsvelte
   let a = foo(1); // ; c     let a = foo(1);
                              // ; c
   ```
   The comment is outside the statement's span, so it lands in the *next* region's gap and
   prints as a leading comment. Same family as the trailing-comment residual already
   recorded in `matrix-known-failures.md`, one statement earlier.

2. **client — a block comment after a trailing binary operator produces output no JS parser
   accepts.**

   ```svelte
   <script>
   	let x = g + /* ; ) } c */
   		h;
   	function go() { x = 4; }
   </script>
   ```
   ```js
   // official                                   // rsvelte
   let x = $.mutable_source(g /* ; ) } c */ + h); let x = $.mutable_source(g + /* ; ) } c */)
                                                  		h;
   ```
   `g + )` — the initializer ended at the block comment and the continuation line was
   severed. This is the #2605 / #2637 trailing-binary-operator class with a *block* comment
   in the way; #2626's `skip_opaque` adoption does not reach it. It is deliberately excluded
   from the `2626-*` fixture, which would otherwise be red.

3. I could not reproduce the separate `$.invalidate_inner_signals` client divergence #2644
   attributes to `bindings-global-dependency` with my reconstruction of its `m0` mutant —
   both slots I tried are `MATCH` on all three targets. Reported, not chased.
