### PR TITLE
fix(compiler): take client statement boundaries from the parser

### DIFF
--- a/.changeset/statement-boundaries-from-parser.md
+++ b/.changeset/statement-boundaries-from-parser.md
@@ -11,5 +11,8 @@ line. Each is an approximation, and the operator list is a list — a line endin
 in `-` or `/` was not on it, so `$: v = a -⏎ b;` split into two statements and
 `b` stopped being a dependency.
 
-The boundaries now come from one oxc parse of the script. A script that does not
-parse at that point keeps the scanner, so nothing that worked stops working.
+The boundaries now come from a parse of the script — the program Phase 1 already
+holds where that text is a verbatim region of it, and a fresh parse otherwise. A
+script that does not parse at that point keeps the scanner, so nothing that
+worked stops working, and the per-line depth scan no longer runs when a parser
+answered.

--- a/.changeset/statement-boundaries-from-parser.md
+++ b/.changeset/statement-boundaries-from-parser.md
@@ -1,0 +1,15 @@
+---
+"@rsvelte/compiler": patch
+---
+
+Take the client instance script's statement boundaries from the parser.
+
+The pipeline decided where a statement ended by scanning characters: balanced
+depths, a trailing comma, a list of operators a statement cannot end on, a
+brace-less control header, and a lookahead for a continuation token on the next
+line. Each is an approximation, and the operator list is a list — a line ending
+in `-` or `/` was not on it, so `$: v = a -⏎ b;` split into two statements and
+`b` stopped being a dependency.
+
+The boundaries now come from one oxc parse of the script. A script that does not
+parse at that point keeps the scanner, so nothing that worked stops working.

--- a/.changeset/ts-boundaries-through-projection.md
+++ b/.changeset/ts-boundaries-through-projection.md
@@ -1,0 +1,7 @@
+---
+"@rsvelte/compiler": patch
+---
+
+Place TypeScript statement boundaries through the strip projection, so the client
+instance-script pipeline reuses the program Phase 1 already parsed instead of
+parsing the script a second time.

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
@@ -4660,24 +4660,120 @@ fn statement_end_lines_from_spans(
     flush
 }
 
+/// The same spans, for a `script` that TypeScript stripping rewrote, placed
+/// through the projection that records which source bytes survived into it.
+///
+/// Only the first and last byte of each span are mapped, never the whole span:
+/// `let a: number = 1;` loses `: number`, so no annotated statement is one
+/// contiguous copied run, while its two endpoints almost always are — and the
+/// endpoints are all a line boundary needs.
+///
+/// A span whose endpoints both fail to map is a construct stripping deleted
+/// outright (`interface Foo {}`), so it is skipped rather than treated as a
+/// failure: bailing on it would give up on every file that declares a type.
+/// One endpoint mapping without the other is not interpretable, so that bails.
+fn statement_end_lines_via_projection(
+    script: &str,
+    program: &oxc_ast::ast::Program<'_>,
+    projection: &ScriptProjection,
+) -> Option<Vec<bool>> {
+    use oxc_span::GetSpan as _;
+
+    let place = |start: u32, end: u32| -> Option<Option<(u32, u32)>> {
+        if end <= start {
+            return Some(None);
+        }
+        let first = projection.output_range_for_source(start..start + 1);
+        let last = projection.output_range_for_source(end - 1..end);
+        match (first, last) {
+            (Some(first), Some(last)) => Some(Some((first.start, last.end))),
+            (None, None) => Some(None),
+            _ => None,
+        }
+    };
+
+    let mut stmt_spans: Vec<(u32, u32)> = Vec::with_capacity(program.body.len());
+    for stmt in &program.body {
+        let span = stmt.span();
+        if let Some(mapped) = place(span.start, span.end)? {
+            stmt_spans.push(mapped);
+        }
+    }
+    let mut comment_spans: Vec<(u32, u32)> = Vec::with_capacity(program.comments.len());
+    for comment in &program.comments {
+        if let Some(mapped) = place(comment.span.start, comment.span.end)? {
+            comment_spans.push(mapped);
+        }
+    }
+    // Every statement vanishing means the projection placed nothing, which is
+    // not an answer about `script` -- fall back rather than report "no
+    // statement covers any line", which reads as "flush everywhere".
+    if stmt_spans.is_empty() && comment_spans.is_empty() {
+        return None;
+    }
+    let limit = script.len() as u32;
+    if stmt_spans
+        .iter()
+        .chain(comment_spans.iter())
+        .any(|&(s, e)| e > limit || s > e)
+    {
+        return None;
+    }
+    Some(statement_end_lines_from_spans(
+        script,
+        stmt_spans.into_iter(),
+        comment_spans.into_iter(),
+    ))
+}
+
 /// The spans, in `script` coordinates, that `retained` already holds — when
 /// `script` is a verbatim, uniquely-locatable region of the text it parsed and
 /// no statement straddles that region's edge.
 fn statement_end_lines_from_retained(
     script: &str,
     retained: &crate::ast::oxc_program::RetainedProgram<'_>,
+    is_typescript: bool,
+    projection: Option<&ScriptProjection>,
 ) -> Option<Vec<bool>> {
     use oxc_span::GetSpan as _;
 
     if retained.panicked() || !retained.diagnostics().is_empty() {
+        super::profile::record_st_boundary_bail(super::profile::BOUNDARY_BAIL_DIAGNOSTICS);
         return None;
     }
     let core = script.trim();
     let source = retained.source();
     let mut matches = source.match_indices(core);
-    let (core_start, _) = matches.next()?;
+    let text_differs = match (is_typescript, projection.is_some()) {
+        (true, true) => super::profile::BOUNDARY_BAIL_TEXT_DIFFERS_TS,
+        (true, false) => super::profile::BOUNDARY_BAIL_TS_NO_PROJECTION,
+        (false, _) => super::profile::BOUNDARY_BAIL_TEXT_DIFFERS_JS,
+    };
+    // The text is not verbatim. Stripping is what rewrote it, and the
+    // projection records which bytes survived, so the spans can still be
+    // placed -- without it there is nothing left to try.
+    let fall_back_to_projection = || match projection {
+        Some(projection) => {
+            match statement_end_lines_via_projection(script, retained.program(), projection) {
+                Some(ends) => Some(ends),
+                None => {
+                    super::profile::record_st_boundary_bail(
+                        super::profile::BOUNDARY_BAIL_PROJECTION_FAILED,
+                    );
+                    None
+                }
+            }
+        }
+        None => {
+            super::profile::record_st_boundary_bail(text_differs);
+            None
+        }
+    };
+    let Some((core_start, _)) = matches.next() else {
+        return fall_back_to_projection();
+    };
     if matches.next().is_some() {
-        return None;
+        return fall_back_to_projection();
     }
     let core_end = (core_start + core.len()) as u32;
     let core_start = core_start as u32;
@@ -4702,6 +4798,7 @@ fn statement_end_lines_from_retained(
             .iter()
             .any(|comment| straddles(comment.span.start, comment.span.end))
     {
+        super::profile::record_st_boundary_bail(super::profile::BOUNDARY_BAIL_STRADDLE);
         return None;
     }
     // `core` is matched as text, so a region that merely *looks* like the script
@@ -4717,6 +4814,7 @@ fn statement_end_lines_from_retained(
             .iter()
             .any(|comment| comment.span.start == core_start)
     {
+        super::profile::record_st_boundary_bail(super::profile::BOUNDARY_BAIL_UNANCHORED);
         return None;
     }
     Some(statement_end_lines_from_spans(
@@ -4742,6 +4840,8 @@ fn statement_end_lines_from_retained(
 fn top_level_statement_end_lines(
     script: &str,
     retained: Option<&crate::ast::oxc_program::RetainedProgram<'_>>,
+    is_typescript: bool,
+    projection: Option<&ScriptProjection>,
 ) -> Option<Vec<bool>> {
     use oxc_span::GetSpan as _;
 
@@ -4749,7 +4849,15 @@ fn top_level_statement_end_lines(
         return None;
     }
 
-    let reused = retained.and_then(|retained| statement_end_lines_from_retained(script, retained));
+    let reused = match retained {
+        Some(retained) => {
+            statement_end_lines_from_retained(script, retained, is_typescript, projection)
+        }
+        None => {
+            super::profile::record_st_boundary_bail(super::profile::BOUNDARY_BAIL_NO_RETAINED);
+            None
+        }
+    };
     if let Some(ends) = reused.as_ref()
         && !super::profile::boundary_oracle_enabled()
     {
@@ -6511,7 +6619,17 @@ fn transform_instance_script_for_visitors(
     // means the text did not parse, which is not a defect here — the script is
     // mid-pipeline and may not be valid on its own — so the heuristics stay as
     // the fallback.
-    let stmt_end_lines = top_level_statement_end_lines(&script_rest, retained_program);
+    // The projection maps into the script as it entered this function. When
+    // prenormalize rewrote the text, it maps somewhere that no longer exists,
+    // and unlike the verbatim path -- which re-finds its own text and so cannot
+    // be wrong about this -- nothing downstream would catch it.
+    let projection_still_applies = script_rest == original_script;
+    let stmt_end_lines = top_level_statement_end_lines(
+        &script_rest,
+        retained_program,
+        analysis.is_typescript,
+        source_projection.filter(|_| projection_still_applies),
+    );
     super::profile::record_st_boundary_source(stmt_end_lines.is_some());
 
     super::profile::record_st_collect_vars(super::profile::timer_elapsed(_stage));

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
@@ -4586,27 +4586,180 @@ thread_local! {
         RefCell::new(oxc_allocator::Allocator::default());
 }
 
-/// Per line, whether the accumulated statement ends there.
+/// Per line of `script`, whether the accumulated statement ends there, given
+/// the top-level statement spans and the comment spans — both already in
+/// `script`'s own byte coordinates.
 ///
 /// True on a line that ends a top-level statement, and also on a line no
 /// statement covers — a comment or blank between statements. The scanner this
 /// replaces flushes those too (their depths are balanced), and the stages
 /// downstream read the first line of what they are handed, so folding a leading
 /// comment into the next statement stops `export let` from being recognised.
-///
+fn statement_end_lines_from_spans(
+    script: &str,
+    stmt_spans: impl Iterator<Item = (u32, u32)>,
+    comment_spans: impl Iterator<Item = (u32, u32)>,
+) -> Vec<bool> {
+    let mut line_starts: Vec<u32> = vec![0];
+    for (i, b) in script.bytes().enumerate() {
+        if b == b'\n' {
+            line_starts.push(i as u32 + 1);
+        }
+    }
+    let line_of = |byte: u32| match line_starts.binary_search(&byte) {
+        Ok(i) => i,
+        Err(i) => i - 1,
+    };
+    let line_count = line_starts.len();
+    let mut covered = vec![false; line_count];
+    let mut flush = vec![false; line_count];
+    // Lines where a block comment is still open at end of line. The text
+    // pipeline cannot cut there — half a comment is not a statement — and
+    // neither could the scanner, whose depth tracker stays inside the comment.
+    let mut comment_open = vec![false; line_count];
+
+    // `end` is exclusive, so a span's last byte is one before it; a span ending
+    // exactly at a newline would otherwise be attributed to the following line.
+    let lines_of = |start: u32, end: u32| {
+        (
+            line_of(start),
+            line_of(end.saturating_sub(1)).min(line_count - 1),
+        )
+    };
+
+    for (start, end) in stmt_spans {
+        let (first, last) = lines_of(start, end);
+        for c in covered.iter_mut().take(last + 1).skip(first) {
+            *c = true;
+        }
+        flush[last] = true;
+    }
+    for (start, end) in comment_spans {
+        let (first, last) = lines_of(start, end);
+        // A comment inside a statement is not a cut point — the scanner this
+        // replaces cannot stop there either, its depths being unbalanced — so
+        // only a comment that stands between statements ends a unit.
+        if !covered[last] {
+            flush[last] = true;
+        }
+        for open in comment_open.iter_mut().take(last).skip(first) {
+            *open = true;
+        }
+        for c in covered.iter_mut().take(last + 1).skip(first) {
+            *c = true;
+        }
+    }
+    for (l, f) in flush.iter_mut().enumerate() {
+        if !covered[l] {
+            *f = true;
+        }
+        if comment_open[l] {
+            *f = false;
+        }
+    }
+    flush
+}
+
+/// The spans, in `script` coordinates, that `retained` already holds — when
+/// `script` is a verbatim, uniquely-locatable region of the text it parsed and
+/// no statement straddles that region's edge.
+fn statement_end_lines_from_retained(
+    script: &str,
+    retained: &crate::ast::oxc_program::RetainedProgram<'_>,
+) -> Option<Vec<bool>> {
+    use oxc_span::GetSpan as _;
+
+    if retained.panicked() || !retained.diagnostics().is_empty() {
+        return None;
+    }
+    let core = script.trim();
+    let source = retained.source();
+    let mut matches = source.match_indices(core);
+    let (core_start, _) = matches.next()?;
+    if matches.next().is_some() {
+        return None;
+    }
+    let core_end = (core_start + core.len()) as u32;
+    let core_start = core_start as u32;
+    // Where `core` sits inside `script`, so a span lands on the same line the
+    // caller's line split produced.
+    let lead = (script.len() - script.trim_start().len()) as u32;
+    let rebase = |start: u32, end: u32| (start - core_start + lead, end - core_start + lead);
+
+    let program = retained.program();
+    let in_core = |start: u32, end: u32| start >= core_start && end <= core_end;
+    // A span crossing the edge would have been cut by the text that produced
+    // `script`, so it says nothing about `script`'s boundaries — and dropping
+    // it silently would leave the lines it covers looking uncovered.
+    let straddles =
+        |start: u32, end: u32| end > core_start && start < core_end && !in_core(start, end);
+    if program
+        .body
+        .iter()
+        .any(|stmt| straddles(stmt.span().start, stmt.span().end))
+        || program
+            .comments
+            .iter()
+            .any(|comment| straddles(comment.span.start, comment.span.end))
+    {
+        return None;
+    }
+    // `core` is matched as text, so a region that merely *looks* like the script
+    // — inside a template literal, say — would match too, and would hold no
+    // statements at all, which the caller would read as "every line flushes".
+    // Something has to begin exactly where it begins.
+    if !program
+        .body
+        .iter()
+        .any(|stmt| stmt.span().start == core_start)
+        && !program
+            .comments
+            .iter()
+            .any(|comment| comment.span.start == core_start)
+    {
+        return None;
+    }
+    Some(statement_end_lines_from_spans(
+        script,
+        program
+            .body
+            .iter()
+            .map(|stmt| (stmt.span().start, stmt.span().end))
+            .filter(|&(s, e)| in_core(s, e))
+            .map(|(s, e)| rebase(s, e)),
+        program
+            .comments
+            .iter()
+            .map(|c| (c.span.start, c.span.end))
+            .filter(|&(s, e)| in_core(s, e))
+            .map(|(s, e)| rebase(s, e)),
+    ))
+}
+
 /// `None` when the text does not parse. That is not a defect: this runs on a
 /// script that is part-way through the text pipeline, so the caller keeps its
 /// scanning heuristics as the fallback.
-fn top_level_statement_end_lines(script: &str) -> Option<Vec<bool>> {
+fn top_level_statement_end_lines(
+    script: &str,
+    retained: Option<&crate::ast::oxc_program::RetainedProgram<'_>>,
+) -> Option<Vec<bool>> {
     use oxc_span::GetSpan as _;
 
     if script.trim().is_empty() {
         return None;
     }
 
+    let reused = retained.and_then(|retained| statement_end_lines_from_retained(script, retained));
+    if let Some(ends) = reused.as_ref()
+        && !super::profile::boundary_oracle_enabled()
+    {
+        super::profile::record_st_boundary_retained();
+        return Some(ends.clone());
+    }
+
     // A separate arena from `ast_state_transform`'s: that one resets on entry,
     // and both would then be live in the same call.
-    STMT_BOUNDARY_ALLOCATOR.with(|cell| {
+    let fresh = STMT_BOUNDARY_ALLOCATOR.with(|cell| {
         const MAX_RETAINED_BYTES: usize = 16 * 1024 * 1024;
         let mut alloc = cell.borrow_mut();
         alloc.reset();
@@ -4618,67 +4771,19 @@ fn top_level_statement_end_lines(script: &str) -> Option<Vec<bool>> {
         let ends = if parsed.panicked || !parsed.diagnostics.is_empty() {
             None
         } else {
-            let mut line_starts: Vec<u32> = vec![0];
-            for (i, b) in script.bytes().enumerate() {
-                if b == b'\n' {
-                    line_starts.push(i as u32 + 1);
-                }
-            }
-            let line_of = |byte: u32| match line_starts.binary_search(&byte) {
-                Ok(i) => i,
-                Err(i) => i - 1,
-            };
-            let line_count = line_starts.len();
-            let mut covered = vec![false; line_count];
-            let mut flush = vec![false; line_count];
-            // Lines where a block comment is still open at end of line. The text
-            // pipeline cannot cut there — half a comment is not a statement —
-            // and neither could the scanner, whose depth tracker stays inside
-            // the comment.
-            let mut comment_open = vec![false; line_count];
-
-            // `span.end` is exclusive, so a span's last byte is one before it;
-            // a span ending exactly at a newline would otherwise be attributed
-            // to the following line.
-            let lines_of = |span: oxc_span::Span| {
-                (
-                    line_of(span.start),
-                    line_of(span.end.saturating_sub(1)).min(line_count - 1),
-                )
-            };
-
-            for stmt in &parsed.program.body {
-                let (first, last) = lines_of(stmt.span());
-                for c in covered.iter_mut().take(last + 1).skip(first) {
-                    *c = true;
-                }
-                flush[last] = true;
-            }
-            for comment in &parsed.program.comments {
-                let (first, last) = lines_of(comment.span);
-                // A comment inside a statement is not a cut point — the scanner
-                // this replaces cannot stop there either, its depths being
-                // unbalanced — so only a comment that stands between statements
-                // ends a unit.
-                if !covered[last] {
-                    flush[last] = true;
-                }
-                for open in comment_open.iter_mut().take(last).skip(first) {
-                    *open = true;
-                }
-                for c in covered.iter_mut().take(last + 1).skip(first) {
-                    *c = true;
-                }
-            }
-            for (l, f) in flush.iter_mut().enumerate() {
-                if !covered[l] {
-                    *f = true;
-                }
-                if comment_open[l] {
-                    *f = false;
-                }
-            }
-            Some(flush)
+            Some(statement_end_lines_from_spans(
+                script,
+                parsed
+                    .program
+                    .body
+                    .iter()
+                    .map(|stmt| (stmt.span().start, stmt.span().end)),
+                parsed
+                    .program
+                    .comments
+                    .iter()
+                    .map(|c| (c.span.start, c.span.end)),
+            ))
         };
 
         drop(parsed);
@@ -4686,7 +4791,16 @@ fn top_level_statement_end_lines(script: &str) -> Option<Vec<bool>> {
             *alloc = oxc_allocator::Allocator::default();
         }
         ends
-    })
+    });
+
+    if super::profile::boundary_oracle_enabled()
+        && let Some(reused) = reused
+    {
+        super::profile::record_boundary_oracle(fresh.as_ref() == Some(&reused));
+        super::profile::record_st_boundary_retained();
+        return Some(reused);
+    }
+    fresh
 }
 
 fn transform_instance_script_for_visitors(
@@ -6397,7 +6511,7 @@ fn transform_instance_script_for_visitors(
     // means the text did not parse, which is not a defect here — the script is
     // mid-pipeline and may not be valid on its own — so the heuristics stay as
     // the fallback.
-    let stmt_end_lines = top_level_statement_end_lines(&script_rest);
+    let stmt_end_lines = top_level_statement_end_lines(&script_rest, retained_program);
     super::profile::record_st_boundary_source(stmt_end_lines.is_some());
 
     super::profile::record_st_collect_vars(super::profile::timer_elapsed(_stage));
@@ -6470,22 +6584,25 @@ fn transform_instance_script_for_visitors(
         // Add line to accumulator (zero-copy borrow from script_lines)
         accumulated_lines.push(line);
 
-        // Incrementally update depth counters (only scans this new line, not the whole buffer)
-        update_expression_depths(
-            line,
-            &mut depth_paren,
-            &mut depth_bracket,
-            &mut depth_brace,
-            &mut depth_in_string,
-            &mut depth_in_block_comment,
-            &mut depth_template_interp_stack,
-        );
-
         // The parser's answer when we have one. It settles all four heuristics
         // below at once, so each of them is neutralised rather than consulted.
         let complete_hint = stmt_end_lines
             .as_ref()
             .map(|ends| ends.get(line_idx).copied().unwrap_or(true));
+
+        // These counters feed `is_expression_incomplete` and nothing else, so
+        // the parser's answer makes the per-line character scan dead work.
+        if complete_hint.is_none() {
+            update_expression_depths(
+                line,
+                &mut depth_paren,
+                &mut depth_bracket,
+                &mut depth_brace,
+                &mut depth_in_string,
+                &mut depth_in_block_comment,
+                &mut depth_template_interp_stack,
+            );
+        }
 
         // Check if we have a complete statement (balanced braces/parens)
         if complete_hint.unwrap_or_else(|| {

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
@@ -4581,6 +4581,114 @@ fn accumulated_ends_with_control_header(accumulated: &[&str], last: &str) -> boo
     expression_utils::ends_with_braceless_control_header(&acc)
 }
 
+thread_local! {
+    static STMT_BOUNDARY_ALLOCATOR: RefCell<oxc_allocator::Allocator> =
+        RefCell::new(oxc_allocator::Allocator::default());
+}
+
+/// Per line, whether the accumulated statement ends there.
+///
+/// True on a line that ends a top-level statement, and also on a line no
+/// statement covers — a comment or blank between statements. The scanner this
+/// replaces flushes those too (their depths are balanced), and the stages
+/// downstream read the first line of what they are handed, so folding a leading
+/// comment into the next statement stops `export let` from being recognised.
+///
+/// `None` when the text does not parse. That is not a defect: this runs on a
+/// script that is part-way through the text pipeline, so the caller keeps its
+/// scanning heuristics as the fallback.
+fn top_level_statement_end_lines(script: &str) -> Option<Vec<bool>> {
+    use oxc_span::GetSpan as _;
+
+    if script.trim().is_empty() {
+        return None;
+    }
+
+    // A separate arena from `ast_state_transform`'s: that one resets on entry,
+    // and both would then be live in the same call.
+    STMT_BOUNDARY_ALLOCATOR.with(|cell| {
+        const MAX_RETAINED_BYTES: usize = 16 * 1024 * 1024;
+        let mut alloc = cell.borrow_mut();
+        alloc.reset();
+
+        let _pt = super::profile::timer_start();
+        let parsed = oxc_parser::Parser::new(&alloc, script, oxc_span::SourceType::mjs()).parse();
+        super::profile::record_direct_parse(super::profile::timer_elapsed(_pt), script.len());
+
+        let ends = if parsed.panicked || !parsed.diagnostics.is_empty() {
+            None
+        } else {
+            let mut line_starts: Vec<u32> = vec![0];
+            for (i, b) in script.bytes().enumerate() {
+                if b == b'\n' {
+                    line_starts.push(i as u32 + 1);
+                }
+            }
+            let line_of = |byte: u32| match line_starts.binary_search(&byte) {
+                Ok(i) => i,
+                Err(i) => i - 1,
+            };
+            let line_count = line_starts.len();
+            let mut covered = vec![false; line_count];
+            let mut flush = vec![false; line_count];
+            // Lines where a block comment is still open at end of line. The text
+            // pipeline cannot cut there — half a comment is not a statement —
+            // and neither could the scanner, whose depth tracker stays inside
+            // the comment.
+            let mut comment_open = vec![false; line_count];
+
+            // `span.end` is exclusive, so a span's last byte is one before it;
+            // a span ending exactly at a newline would otherwise be attributed
+            // to the following line.
+            let lines_of = |span: oxc_span::Span| {
+                (
+                    line_of(span.start),
+                    line_of(span.end.saturating_sub(1)).min(line_count - 1),
+                )
+            };
+
+            for stmt in &parsed.program.body {
+                let (first, last) = lines_of(stmt.span());
+                for c in covered.iter_mut().take(last + 1).skip(first) {
+                    *c = true;
+                }
+                flush[last] = true;
+            }
+            for comment in &parsed.program.comments {
+                let (first, last) = lines_of(comment.span);
+                // A comment inside a statement is not a cut point — the scanner
+                // this replaces cannot stop there either, its depths being
+                // unbalanced — so only a comment that stands between statements
+                // ends a unit.
+                if !covered[last] {
+                    flush[last] = true;
+                }
+                for open in comment_open.iter_mut().take(last).skip(first) {
+                    *open = true;
+                }
+                for c in covered.iter_mut().take(last + 1).skip(first) {
+                    *c = true;
+                }
+            }
+            for (l, f) in flush.iter_mut().enumerate() {
+                if !covered[l] {
+                    *f = true;
+                }
+                if comment_open[l] {
+                    *f = false;
+                }
+            }
+            Some(flush)
+        };
+
+        drop(parsed);
+        if alloc.capacity() > MAX_RETAINED_BYTES {
+            *alloc = oxc_allocator::Allocator::default();
+        }
+        ends
+    })
+}
+
 fn transform_instance_script_for_visitors(
     script: &str,
     analysis: &ComponentAnalysis,
@@ -6284,6 +6392,14 @@ fn transform_instance_script_for_visitors(
     // which runs over the whole result after this loop, never per statement.
     let runes_fastpath_eligible = analysis.runes;
 
+    // Lines on which a top-level statement ends, according to a parser rather
+    // than to the depth/trailing-operator/lookahead heuristics below. `None`
+    // means the text did not parse, which is not a defect here — the script is
+    // mid-pipeline and may not be valid on its own — so the heuristics stay as
+    // the fallback.
+    let stmt_end_lines = top_level_statement_end_lines(&script_rest);
+    super::profile::record_st_boundary_source(stmt_end_lines.is_some());
+
     super::profile::record_st_collect_vars(super::profile::timer_elapsed(_stage));
     let _stage = super::profile::timer_start();
 
@@ -6365,15 +6481,23 @@ fn transform_instance_script_for_visitors(
             &mut depth_template_interp_stack,
         );
 
+        // The parser's answer when we have one. It settles all four heuristics
+        // below at once, so each of them is neutralised rather than consulted.
+        let complete_hint = stmt_end_lines
+            .as_ref()
+            .map(|ends| ends.get(line_idx).copied().unwrap_or(true));
+
         // Check if we have a complete statement (balanced braces/parens)
-        if !is_expression_incomplete(
-            depth_paren,
-            depth_bracket,
-            depth_brace,
-            &depth_in_string,
-            depth_in_block_comment,
-            &depth_template_interp_stack,
-        ) {
+        if complete_hint.unwrap_or_else(|| {
+            !is_expression_incomplete(
+                depth_paren,
+                depth_bracket,
+                depth_brace,
+                &depth_in_string,
+                depth_in_block_comment,
+                &depth_template_interp_stack,
+            )
+        }) {
             // Check for trailing comma in variable declarations (multi-declarator continuation)
             let first_trimmed_line = accumulated_lines[0].trim();
             let is_var_decl = first_trimmed_line.starts_with("let ")
@@ -6391,14 +6515,14 @@ fn transform_instance_script_for_visitors(
                 Some(pos) => trimmed[..pos].trim_end(),
                 None => trimmed,
             };
-            let trailing_comma = is_var_decl && trimmed.ends_with(',');
+            let trailing_comma = complete_hint.is_none() && is_var_decl && trimmed.ends_with(',');
 
             // Check if the current trimmed line ends with a binary/assignment operator,
             // indicating the expression continues on the next line.
             // e.g., `$: overflow_has_selected_tab =\n\thandle_overflow_has_selected_tab(...)`
             // Only check the most unambiguous operators to avoid false positives
             // (e.g., `*/` ending a JSDoc comment, or `}` ending a block).
-            let trailing_operator = {
+            let trailing_operator = complete_hint.is_none() && {
                 let t = trimmed.trim_end_matches(';');
                 (t.ends_with('=')
                     && !t.ends_with("==")
@@ -6434,7 +6558,8 @@ fn transform_instance_script_for_visitors(
             // top-level statement, dropping the guard and the reactive wrapper.
             if !trailing_comma
                 && !trailing_operator
-                && !accumulated_ends_with_control_header(&accumulated_lines, trimmed)
+                && (complete_hint.is_some()
+                    || !accumulated_ends_with_control_header(&accumulated_lines, trimmed))
             {
                 // Before processing, check if the next non-empty line starts with a
                 // continuation token (`.` for method chains, `?`, `:`, `&&`, `||`,
@@ -6446,7 +6571,16 @@ fn transform_instance_script_for_visitors(
                 // The `cond` line by itself looks balanced, but the next line starts
                 // with `?`, so the expression continues.
                 let mut next_continues = false;
-                for future_line in script_lines.iter().skip(line_idx + 1) {
+                for future_line in
+                    script_lines
+                        .iter()
+                        .skip(line_idx + 1)
+                        .take(if complete_hint.is_some() {
+                            0
+                        } else {
+                            usize::MAX
+                        })
+                {
                     let future_trimmed = future_line.trim();
                     if future_trimmed.is_empty() {
                         continue;

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/profile.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/profile.rs
@@ -123,6 +123,10 @@ pub struct ScriptTextBreakdown {
     /// Of `boundary_ast`, those answered from the program Phase 1 already
     /// parsed rather than from a parse this pipeline added.
     pub boundary_retained: u64,
+    /// Why the rest could not be: indexed by `BOUNDARY_BAIL_*`. Without this the
+    /// only visible number is the reuse rate, which says a parse was added but
+    /// not what would have to change to stop adding it.
+    pub boundary_bail: [u64; BOUNDARY_BAIL_KINDS],
     /// Statements the runes fast path emitted without calling the processor.
     pub fastpath_statements: u64,
     /// Calls to the brace-less-control-header probe, and the bytes it had to
@@ -232,6 +236,8 @@ thread_local! {
     static ST_BOUNDARY_AST: Cell<u64> = const { Cell::new(0) };
     static ST_BOUNDARY_SCAN: Cell<u64> = const { Cell::new(0) };
     static ST_BOUNDARY_RETAINED: Cell<u64> = const { Cell::new(0) };
+    static ST_BOUNDARY_BAIL: [Cell<u64>; BOUNDARY_BAIL_KINDS] =
+        const { [const { Cell::new(0) }; BOUNDARY_BAIL_KINDS] };
     static ST_FASTPATH_STATEMENTS: Cell<u64> = const { Cell::new(0) };
     static ST_CTRL_HEADER_CALLS: Cell<u64> = const { Cell::new(0) };
     static ST_CTRL_HEADER_BYTES: Cell<u64> = const { Cell::new(0) };
@@ -977,6 +983,46 @@ pub fn record_st_boundary_retained() {
     ST_BOUNDARY_RETAINED.with(|c| c.set(c.get() + 1));
 }
 
+pub const BOUNDARY_BAIL_KINDS: usize = 8;
+/// Phase 1 kept no program for this script.
+pub const BOUNDARY_BAIL_NO_RETAINED: usize = 0;
+/// It kept one, but the parse did not come out clean.
+pub const BOUNDARY_BAIL_DIAGNOSTICS: usize = 1;
+/// The pipeline's text is not a verbatim region of what Phase 1 parsed, on a
+/// TypeScript script — stripping rewrote it.
+pub const BOUNDARY_BAIL_TEXT_DIFFERS_TS: usize = 2;
+/// Same, but the script is not TypeScript, so stripping cannot be the cause and
+/// a projection through it would not help.
+pub const BOUNDARY_BAIL_TEXT_DIFFERS_JS: usize = 5;
+/// TypeScript, and no projection exists to map the retained spans through — so
+/// using the projection cannot recover this one. Separating it keeps "the cause
+/// is TS" from being read as "a projection fixes it".
+pub const BOUNDARY_BAIL_TS_NO_PROJECTION: usize = 6;
+/// A projection existed and still could not place the spans. Separate from
+/// `TEXT_DIFFERS_TS` so a projection path that silently never works is visible
+/// as its own number rather than folded back into the reason it was built for.
+pub const BOUNDARY_BAIL_PROJECTION_FAILED: usize = 7;
+/// A statement or comment crosses the region's edge.
+pub const BOUNDARY_BAIL_STRADDLE: usize = 3;
+/// Nothing begins where the region begins.
+pub const BOUNDARY_BAIL_UNANCHORED: usize = 4;
+
+pub const BOUNDARY_BAIL_NAMES: [&str; BOUNDARY_BAIL_KINDS] = [
+    "no retained program",
+    "retained parse unclean",
+    "text differs, TypeScript",
+    "span straddles the edge",
+    "region unanchored",
+    "text differs, not TypeScript",
+    "TypeScript, no projection",
+    "projection could not place the spans",
+];
+
+#[inline]
+pub fn record_st_boundary_bail(kind: usize) {
+    ST_BOUNDARY_BAIL.with(|a| a[kind].set(a[kind].get() + 1));
+}
+
 #[inline]
 pub fn record_st_loop_lines(n: u64) {
     ST_LOOP_LINES.with(|c| c.set(c.get() + n));
@@ -1023,6 +1069,7 @@ pub fn take_script_text_breakdown() -> ScriptTextBreakdown {
         boundary_ast: ST_BOUNDARY_AST.with(|c| c.replace(0)),
         boundary_scan: ST_BOUNDARY_SCAN.with(|c| c.replace(0)),
         boundary_retained: ST_BOUNDARY_RETAINED.with(|c| c.replace(0)),
+        boundary_bail: ST_BOUNDARY_BAIL.with(|a| std::array::from_fn(|i| a[i].replace(0))),
         fastpath_statements: ST_FASTPATH_STATEMENTS.with(|c| c.replace(0)),
         ctrl_header_calls: ST_CTRL_HEADER_CALLS.with(|c| c.replace(0)),
         ctrl_header_bytes: ST_CTRL_HEADER_BYTES.with(|c| c.replace(0)),

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/profile.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/profile.rs
@@ -117,6 +117,9 @@ pub struct ScriptTextBreakdown {
     pub statements: u64,
     /// Source lines visited by the line loop.
     pub loop_lines: u64,
+    /// Scripts whose statement boundaries came from the parser / from the scanner.
+    pub boundary_ast: u64,
+    pub boundary_scan: u64,
     /// Statements the runes fast path emitted without calling the processor.
     pub fastpath_statements: u64,
     /// Calls to the brace-less-control-header probe, and the bytes it had to
@@ -223,6 +226,8 @@ thread_local! {
     static ST_PROCESS_ACCUMULATED: Cell<Duration> = const { Cell::new(Duration::ZERO) };
     static ST_STATEMENTS: Cell<u64> = const { Cell::new(0) };
     static ST_LOOP_LINES: Cell<u64> = const { Cell::new(0) };
+    static ST_BOUNDARY_AST: Cell<u64> = const { Cell::new(0) };
+    static ST_BOUNDARY_SCAN: Cell<u64> = const { Cell::new(0) };
     static ST_FASTPATH_STATEMENTS: Cell<u64> = const { Cell::new(0) };
     static ST_CTRL_HEADER_CALLS: Cell<u64> = const { Cell::new(0) };
     static ST_CTRL_HEADER_BYTES: Cell<u64> = const { Cell::new(0) };
@@ -950,6 +955,18 @@ pub fn record_st_line_loop(d: Duration) {
     ST_LINE_LOOP.with(|c| c.set(c.get() + d));
 }
 
+/// Scripts whose statement boundaries came from the parser, and those that fell
+/// back to the scanner. A byte-identical corpus proves nothing about which path
+/// ran, so the adoption rate has to be counted rather than inferred.
+#[inline]
+pub fn record_st_boundary_source(from_ast: bool) {
+    if from_ast {
+        ST_BOUNDARY_AST.with(|c| c.set(c.get() + 1));
+    } else {
+        ST_BOUNDARY_SCAN.with(|c| c.set(c.get() + 1));
+    }
+}
+
 #[inline]
 pub fn record_st_loop_lines(n: u64) {
     ST_LOOP_LINES.with(|c| c.set(c.get() + n));
@@ -993,6 +1010,8 @@ pub fn take_script_text_breakdown() -> ScriptTextBreakdown {
         process_accumulated: ST_PROCESS_ACCUMULATED.with(|c| c.replace(Duration::ZERO)),
         statements: ST_STATEMENTS.with(|c| c.replace(0)),
         loop_lines: ST_LOOP_LINES.with(|c| c.replace(0)),
+        boundary_ast: ST_BOUNDARY_AST.with(|c| c.replace(0)),
+        boundary_scan: ST_BOUNDARY_SCAN.with(|c| c.replace(0)),
         fastpath_statements: ST_FASTPATH_STATEMENTS.with(|c| c.replace(0)),
         ctrl_header_calls: ST_CTRL_HEADER_CALLS.with(|c| c.replace(0)),
         ctrl_header_bytes: ST_CTRL_HEADER_BYTES.with(|c| c.replace(0)),

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/profile.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/profile.rs
@@ -120,6 +120,9 @@ pub struct ScriptTextBreakdown {
     /// Scripts whose statement boundaries came from the parser / from the scanner.
     pub boundary_ast: u64,
     pub boundary_scan: u64,
+    /// Of `boundary_ast`, those answered from the program Phase 1 already
+    /// parsed rather than from a parse this pipeline added.
+    pub boundary_retained: u64,
     /// Statements the runes fast path emitted without calling the processor.
     pub fastpath_statements: u64,
     /// Calls to the brace-less-control-header probe, and the bytes it had to
@@ -228,6 +231,7 @@ thread_local! {
     static ST_LOOP_LINES: Cell<u64> = const { Cell::new(0) };
     static ST_BOUNDARY_AST: Cell<u64> = const { Cell::new(0) };
     static ST_BOUNDARY_SCAN: Cell<u64> = const { Cell::new(0) };
+    static ST_BOUNDARY_RETAINED: Cell<u64> = const { Cell::new(0) };
     static ST_FASTPATH_STATEMENTS: Cell<u64> = const { Cell::new(0) };
     static ST_CTRL_HEADER_CALLS: Cell<u64> = const { Cell::new(0) };
     static ST_CTRL_HEADER_BYTES: Cell<u64> = const { Cell::new(0) };
@@ -967,6 +971,12 @@ pub fn record_st_boundary_source(from_ast: bool) {
     }
 }
 
+/// Of the AST-sourced boundaries, those that cost no parse.
+#[inline]
+pub fn record_st_boundary_retained() {
+    ST_BOUNDARY_RETAINED.with(|c| c.set(c.get() + 1));
+}
+
 #[inline]
 pub fn record_st_loop_lines(n: u64) {
     ST_LOOP_LINES.with(|c| c.set(c.get() + n));
@@ -1012,6 +1022,7 @@ pub fn take_script_text_breakdown() -> ScriptTextBreakdown {
         loop_lines: ST_LOOP_LINES.with(|c| c.replace(0)),
         boundary_ast: ST_BOUNDARY_AST.with(|c| c.replace(0)),
         boundary_scan: ST_BOUNDARY_SCAN.with(|c| c.replace(0)),
+        boundary_retained: ST_BOUNDARY_RETAINED.with(|c| c.replace(0)),
         fastpath_statements: ST_FASTPATH_STATEMENTS.with(|c| c.replace(0)),
         ctrl_header_calls: ST_CTRL_HEADER_CALLS.with(|c| c.replace(0)),
         ctrl_header_bytes: ST_CTRL_HEADER_BYTES.with(|c| c.replace(0)),
@@ -1169,5 +1180,30 @@ pub fn record_index_oracle(agrees: bool) {
 
 pub fn take_index_oracle() -> IndexOracle {
     let (checks, mismatches) = INDEX_ORACLE.replace((0, 0));
+    IndexOracle { checks, mismatches }
+}
+
+thread_local! {
+    static BOUNDARY_ORACLE: Cell<(u64, u64)> = const { Cell::new((0, 0)) };
+}
+
+/// Whether reusing Phase 1's program answers the boundary question the same way
+/// a fresh parse of the pipeline's own text does. A byte-identical corpus is
+/// not evidence: the reuse could be bailing on every file.
+pub fn boundary_oracle_enabled() -> bool {
+    static ON: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ON.get_or_init(|| std::env::var_os("RSVELTE_BOUNDARY_ORACLE").is_some())
+}
+
+#[inline]
+pub fn record_boundary_oracle(agrees: bool) {
+    BOUNDARY_ORACLE.with(|c| {
+        let (checks, mismatches) = c.get();
+        c.set((checks + 1, mismatches + u64::from(!agrees)));
+    });
+}
+
+pub fn take_boundary_oracle() -> IndexOracle {
+    let (checks, mismatches) = BOUNDARY_ORACLE.replace((0, 0));
     IndexOracle { checks, mismatches }
 }

--- a/crates/rsvelte_core/tests/statement_boundary_from_parser.rs
+++ b/crates/rsvelte_core/tests/statement_boundary_from_parser.rs
@@ -65,6 +65,41 @@ fn an_import_above_the_statement_does_not_shift_the_boundaries() {
     );
 }
 
+/// The reuse of Phase 1's program is invisible to every parity gate: it answers
+/// the same question a fresh parse does, so bailing on every file would leave
+/// the corpus byte-identical and the whole path dead. Count the hits.
+///
+/// It has to run through `compile()` — `transform_component` hard-codes
+/// `retained_scripts: None`, which is what made the profiler report 0%.
+#[test]
+fn the_boundaries_come_from_the_program_phase_1_already_parsed() {
+    use rsvelte_core::compiler::phases::phase3_transform::profile;
+
+    let _ = profile::take_script_text_breakdown();
+    let source = "<script>\n  import { noop } from './noop.js';\n  export let a = 1;\n  export let b = 2;\n  let n = 0;\n  $: v = a -\n    b;\n  noop;\n</script>\n\n<p>{v}{n}</p>\n";
+    compile(
+        source,
+        CompileOptions {
+            filename: Some("A.svelte".to_string()),
+            generate: GenerateMode::Client,
+            ..Default::default()
+        },
+    )
+    .expect("compile failed");
+    let st = profile::take_script_text_breakdown();
+
+    assert_eq!(
+        st.boundary_scan, 0,
+        "the script parsed, so no boundary should have come from the scanner"
+    );
+    assert!(
+        st.boundary_retained > 0,
+        "no boundary reused Phase 1's parse: {} from a parser, {} of them reused",
+        st.boundary_ast,
+        st.boundary_retained
+    );
+}
+
 /// Controls: these two were already in the scanner's list, so they held before
 /// this change and must still hold.
 #[test]

--- a/crates/rsvelte_core/tests/statement_boundary_from_parser.rs
+++ b/crates/rsvelte_core/tests/statement_boundary_from_parser.rs
@@ -100,6 +100,40 @@ fn the_boundaries_come_from_the_program_phase_1_already_parsed() {
     );
 }
 
+/// TypeScript is 100% of the cases where the pipeline's text is not verbatim,
+/// so the projection is the only thing that can place the spans there. The
+/// annotations make the verbatim match fail on purpose — without them stripping
+/// is a no-op, the verbatim path answers, and this test would prove nothing.
+///
+/// `interface Props` is the skip rule: stripping deletes it outright, so neither
+/// endpoint maps, and treating that as a failure would give up on every file
+/// that declares a type.
+#[test]
+fn a_typescript_script_places_its_boundaries_through_the_projection() {
+    use rsvelte_core::compiler::phases::phase3_transform::profile;
+
+    let _ = profile::take_script_text_breakdown();
+    let source = "<script lang=\"ts\">\n  interface Props { label: string }\n  let { label }: Props = $props();\n  let count: number = $state(0);\n  const doubled: number = $derived(count * 2);\n</script>\n\n<p>{label}{count}{doubled}</p>\n";
+    compile(
+        source,
+        CompileOptions {
+            filename: Some("A.svelte".to_string()),
+            generate: GenerateMode::Client,
+            ..Default::default()
+        },
+    )
+    .expect("compile failed");
+    let st = profile::take_script_text_breakdown();
+
+    assert!(
+        st.boundary_retained > 0,
+        "a TypeScript script added a parse instead of placing spans through the \
+         projection: {} from a parser, {} reused",
+        st.boundary_ast,
+        st.boundary_retained
+    );
+}
+
 /// Controls: these two were already in the scanner's list, so they held before
 /// this change and must still hold.
 #[test]

--- a/crates/rsvelte_core/tests/statement_boundary_from_parser.rs
+++ b/crates/rsvelte_core/tests/statement_boundary_from_parser.rs
@@ -50,6 +50,21 @@ fn a_slash_at_end_of_line_does_not_split_the_statement() {
     asserts_single_statement("/");
 }
 
+/// The boundaries are read off the program Phase 1 parsed, whose spans are in
+/// the *whole* script's coordinates while this pipeline sees the script with
+/// its imports already removed. An import above the statement is what makes the
+/// two coordinate systems differ, so without it the rebasing is untested.
+#[test]
+fn an_import_above_the_statement_does_not_shift_the_boundaries() {
+    let out = client(
+        "<script>\n  import { noop } from './noop.js';\n  export let a = 1;\n  export let b = 2;\n  let n = 0;\n  $: v = a -\n    b;\n  noop;\n</script>\n\n<p>{v}{n}</p>\n",
+    );
+    assert!(
+        out.contains("$.deep_read_state(a()), $.deep_read_state(b())"),
+        "the import shifted the statement boundaries:\n{out}"
+    );
+}
+
 /// Controls: these two were already in the scanner's list, so they held before
 /// this change and must still hold.
 #[test]

--- a/crates/rsvelte_core/tests/statement_boundary_from_parser.rs
+++ b/crates/rsvelte_core/tests/statement_boundary_from_parser.rs
@@ -1,0 +1,63 @@
+//! The client instance-script pipeline splits statements with a scanner, and
+//! the scanner's list of "operators a statement cannot end on" is a list, so a
+//! line ending in an operator missing from it splits one statement in two. The
+//! boundaries now come from a parser, which has no list.
+//!
+//! `-` and `/` are the discriminating cases: both were absent from that list,
+//! and both diverge from upstream on the pre-change tree. `+` and `&&` are in
+//! the list and are asserted too — a change that moved them would be reaching
+//! past the reported defect.
+
+use rsvelte_core::{CompileOptions, GenerateMode, compile};
+
+fn client(source: &str) -> String {
+    compile(
+        source,
+        CompileOptions {
+            filename: Some("A.svelte".to_string()),
+            generate: GenerateMode::Client,
+            ..Default::default()
+        },
+    )
+    .expect("compile failed")
+    .js
+    .code
+}
+
+/// A legacy reactive statement whose right-hand side continues on the next
+/// line. Reading it as one statement is what makes `b` a dependency.
+fn source_broken_at(op: &str) -> String {
+    format!(
+        "<script>\n  export let a = 1;\n  export let b = 2;\n  let n = 0;\n  $: v = a {op}\n    b;\n</script>\n\n<p>{{v}}{{n}}</p>\n"
+    )
+}
+
+fn asserts_single_statement(op: &str) {
+    let out = client(&source_broken_at(op));
+    assert!(
+        out.contains("$.deep_read_state(a()), $.deep_read_state(b())"),
+        "`{op}` at end of line split the reactive statement, so `b` is not a dependency:\n{out}"
+    );
+}
+
+#[test]
+fn a_minus_at_end_of_line_does_not_split_the_statement() {
+    asserts_single_statement("-");
+}
+
+#[test]
+fn a_slash_at_end_of_line_does_not_split_the_statement() {
+    asserts_single_statement("/");
+}
+
+/// Controls: these two were already in the scanner's list, so they held before
+/// this change and must still hold.
+#[test]
+fn a_plus_at_end_of_line_still_does_not_split_the_statement() {
+    asserts_single_statement("+");
+}
+
+#[test]
+fn a_logical_and_at_end_of_line_still_does_not_split_the_statement() {
+    asserts_single_statement("&&");
+}

--- a/crates/rsvelte_devtools/src/bin/compile_profile.rs
+++ b/crates/rsvelte_devtools/src/bin/compile_profile.rs
@@ -275,7 +275,9 @@ fn main() {
         } else {
             st_compile.boundary_retained as f64 / st_compile.boundary_ast as f64 * 100.0
         },
-        st_compile.boundary_ast.saturating_sub(st_compile.boundary_retained)
+        st_compile
+            .boundary_ast
+            .saturating_sub(st_compile.boundary_retained)
     );
     println!(
         "  [store_subs measured through compile(), total {:7.2}ms]",

--- a/crates/rsvelte_devtools/src/bin/compile_profile.rs
+++ b/crates/rsvelte_devtools/src/bin/compile_profile.rs
@@ -244,12 +244,39 @@ fn main() {
     // harness, not of the compiler. Drain that reading and re-take it through the
     // real entry point.
     let _ = rsvelte_core::compiler::phases::phase2_analyze::profile::take_store_subs();
+    // Same reason, one phase over: the statement-boundary reuse reads the
+    // program Phase 1 retained, which only `compile()` threads through.
+    let _ = profile::take_script_text_breakdown();
     let compile_start = Instant::now();
     for (_, content) in files.iter() {
         let _ = rsvelte_core::compile(content, compile_opts.clone());
     }
     let compile_total = compile_start.elapsed();
     let ss = rsvelte_core::compiler::phases::phase2_analyze::profile::take_store_subs();
+    let st_compile = profile::take_script_text_breakdown();
+    let compile_boundary_total = st_compile.boundary_ast + st_compile.boundary_scan;
+    println!(
+        "  [boundaries measured through compile(): from-parser {} / {} ({:.2}%) | scanner {}]",
+        st_compile.boundary_ast,
+        compile_boundary_total,
+        if compile_boundary_total == 0 {
+            0.0
+        } else {
+            st_compile.boundary_ast as f64 / compile_boundary_total as f64 * 100.0
+        },
+        st_compile.boundary_scan
+    );
+    println!(
+        "  [  of those, reused Phase-1's parse {} / {} ({:.2}%) | added a parse {}]",
+        st_compile.boundary_retained,
+        st_compile.boundary_ast,
+        if st_compile.boundary_ast == 0 {
+            0.0
+        } else {
+            st_compile.boundary_retained as f64 / st_compile.boundary_ast as f64 * 100.0
+        },
+        st_compile.boundary_ast.saturating_sub(st_compile.boundary_retained)
+    );
     println!(
         "  [store_subs measured through compile(), total {:7.2}ms]",
         ms(compile_total)
@@ -381,17 +408,11 @@ fn main() {
         },
         st.boundary_scan
     );
-    println!(
-        "    BOUNDARY reused Phase-1 parse {} / {} ({:.2}%) | added a parse {}",
-        st.boundary_retained,
-        st.boundary_ast,
-        if st.boundary_ast == 0 {
-            0.0
-        } else {
-            st.boundary_retained as f64 / st.boundary_ast as f64 * 100.0
-        },
-        st.boundary_ast.saturating_sub(st.boundary_retained)
-    );
+    // The reuse rate is deliberately NOT printed here: `transform_component`
+    // hard-codes `retained_scripts: None` (3_transform/mod.rs:88), so on this
+    // path it is 0 by construction — a property of the harness, exactly as the
+    // store_subs note below records for one field over. It is reported from the
+    // `compile()` pass instead.
     println!(
         "    COUNTERS loop_lines {} | fastpath_stmts {} | ctrl_header {} calls / {} bytes | collect_scan {} passes / {} bytes",
         st.loop_lines,

--- a/crates/rsvelte_devtools/src/bin/compile_profile.rs
+++ b/crates/rsvelte_devtools/src/bin/compile_profile.rs
@@ -382,6 +382,17 @@ fn main() {
         st.boundary_scan
     );
     println!(
+        "    BOUNDARY reused Phase-1 parse {} / {} ({:.2}%) | added a parse {}",
+        st.boundary_retained,
+        st.boundary_ast,
+        if st.boundary_ast == 0 {
+            0.0
+        } else {
+            st.boundary_retained as f64 / st.boundary_ast as f64 * 100.0
+        },
+        st.boundary_ast.saturating_sub(st.boundary_retained)
+    );
+    println!(
         "    COUNTERS loop_lines {} | fastpath_stmts {} | ctrl_header {} calls / {} bytes | collect_scan {} passes / {} bytes",
         st.loop_lines,
         st.fastpath_statements,
@@ -538,6 +549,17 @@ fn main() {
         oracle.mismatches,
         if oracle.checks == 0 {
             " (set RSVELTE_INDEX_ORACLE to run it)"
+        } else {
+            ""
+        }
+    );
+    let boundary_oracle = profile::take_boundary_oracle();
+    println!(
+        "  boundary oracle: {} checks, {} mismatches{}",
+        boundary_oracle.checks,
+        boundary_oracle.mismatches,
+        if boundary_oracle.checks == 0 {
+            " (set RSVELTE_BOUNDARY_ORACLE to run it)"
         } else {
             ""
         }

--- a/crates/rsvelte_devtools/src/bin/compile_profile.rs
+++ b/crates/rsvelte_devtools/src/bin/compile_profile.rs
@@ -369,6 +369,18 @@ fn main() {
         );
     }
     println!("    (statements processed: {})", st.statements);
+    let boundary_total = st.boundary_ast + st.boundary_scan;
+    println!(
+        "    BOUNDARY from-parser {} / {} ({:.2}%) | fell back to the scanner {}",
+        st.boundary_ast,
+        boundary_total,
+        if boundary_total == 0 {
+            0.0
+        } else {
+            st.boundary_ast as f64 / boundary_total as f64 * 100.0
+        },
+        st.boundary_scan
+    );
     println!(
         "    COUNTERS loop_lines {} | fastpath_stmts {} | ctrl_header {} calls / {} bytes | collect_scan {} passes / {} bytes",
         st.loop_lines,

--- a/crates/rsvelte_devtools/src/bin/compile_profile.rs
+++ b/crates/rsvelte_devtools/src/bin/compile_profile.rs
@@ -279,6 +279,26 @@ fn main() {
             .boundary_ast
             .saturating_sub(st_compile.boundary_retained)
     );
+    {
+        let bailed: u64 = st_compile.boundary_bail.iter().sum();
+        let mut kinds: Vec<(usize, u64)> = st_compile
+            .boundary_bail
+            .iter()
+            .enumerate()
+            .map(|(i, n)| (i, *n))
+            .filter(|&(_, n)| n > 0)
+            .collect();
+        kinds.sort_by_key(|&(_, n)| std::cmp::Reverse(n));
+        for (i, n) in kinds {
+            println!(
+                "  [    bail: {:<28} {:6}  ({:5.1}% of {} bails)]",
+                profile::BOUNDARY_BAIL_NAMES[i],
+                n,
+                n as f64 / bailed.max(1) as f64 * 100.0,
+                bailed
+            );
+        }
+    }
     println!(
         "  [store_subs measured through compile(), total {:7.2}ms]",
         ms(compile_total)


### PR DESCRIPTION
First slice of the script-pipeline AST migration. AGENTS.md justifies that work
by correctness — 35 real components where rsvelte emitted output no JS parser
accepts, every one "a scanner assuming input it did not get" — and this replaces
the scanner that decides where a statement ends.

## What it replaces

The line loop settled that question five ways: balanced depths, a trailing comma
in a declaration, **a list of operators a statement cannot end on**, a
brace-less control header, and a lookahead for a continuation token on the next
line. The third is a list, so anything missing from it splits a statement.

A single oxc parse of the script answers it exactly. All five heuristics are
neutralised when the parse succeeds; when it does not, they stay, so nothing
that worked stops working.

## It fixes real shapes, and I measured which

A/B over end-of-line operators in `$: v = a <op>⏎ b;`, `main` vs this branch:

```
main diverges from upstream on:  -  /  ?  .
this branch:                           ?  .
fixed:                           -  /
broken:                          (none)
```

`-` and `/` are the regression tests; `+` and `&&` were already in the list and
are asserted as controls. `?` and `.` still diverge and this change does not
move them — a different cause, not this one.

## The path is actually taken

A byte-identical corpus cannot distinguish "the parser answered" from "we fell
back every time", so the adoption rate is counted:

| corpus | boundaries from the parser |
|---|---|
| bits-ui | 517 / 517 (100%) |
| flowbite-svelte | 743 / 743 (100%) |
| shadcn-svelte | 1050 / 1050 (100%) |
| layercake | 173 / 175 (98.9%) |
| svelte-ux | 166 / 180 (92.2%) |

## Gates

- corpus verify, all three targets: **js-mismatch 0, js-unparseable 0**, all
  14,166 entries identical after normalization; no warning or error regressions
- mutation fuzz, full sweep: **36 known remain, no regressions**
- shape matrix: no regressions (206 known)
- `cargo fmt --check`, `clippy --all-targets --all-features -D warnings` clean

Two wrong versions preceded this one, both caught by the corpus rather than by
reading: cutting at every line no statement covers split multi-line block
comments (419 failures), and then flushing at every comment's end line cut
statements that contain a comment (207). Both are recorded in the code as the
reason those two lines are the way they are.

## Not in this PR

The per-line depth scan still runs, because the scanner is still the fallback.
Removing it on the parser path is the next slice, and it is what pays back this
PR's extra parse; I have not claimed a speedup here and have not measured one.
