### PR TITLE
fix(check): forward and validate the whole compilerOptions object

### DIFF
--- a/.changeset/fluffy-gorillas-shave.md
+++ b/.changeset/fluffy-gorillas-shave.md
@@ -1,0 +1,5 @@
+---
+'@rsvelte/svelte-check': patch
+---
+
+Read the whole `compilerOptions` object out of `svelte.config.*` / the inline `svelte()` / `sveltekit()` plugin options instead of a handful of keys, and validate it the way `svelte.compile` does. `accessors` / `customElement` now reach the TSX projection (they decide which `let` bindings are component exports, i.e. the component's public type), and an option key the compiler does not recognise, an illegal value, or an option removed in Svelte 5 is reported as `options_unrecognised` / `options_invalid_value` / `options_removed` on every checked component instead of being silently dropped.

--- a/compatibility/check-fixtures/svelte-config-accessors-off/project/package.json
+++ b/compatibility/check-fixtures/svelte-config-accessors-off/project/package.json
@@ -1,0 +1,5 @@
+{
+	"name": "check-fixture-svelte-config-accessors-off",
+	"private": true,
+	"type": "module"
+}

--- a/compatibility/check-fixtures/svelte-config-accessors-off/project/src/Child.svelte
+++ b/compatibility/check-fixtures/svelte-config-accessors-off/project/src/Child.svelte
@@ -1,0 +1,11 @@
+<script lang="ts">
+	export let value: string = 'x';
+</script>
+
+<span>{value}</span>
+
+<style>
+	.never-used {
+		color: red;
+	}
+</style>

--- a/compatibility/check-fixtures/svelte-config-accessors-off/project/src/Parent.svelte
+++ b/compatibility/check-fixtures/svelte-config-accessors-off/project/src/Parent.svelte
@@ -1,0 +1,12 @@
+<script lang="ts">
+	import Child from './Child.svelte';
+
+	let child!: Child;
+
+	function probe(): number {
+		return child.value;
+	}
+</script>
+
+<Child bind:this={child} value="a" />
+<span>{probe()}</span>

--- a/compatibility/check-fixtures/svelte-config-accessors-off/project/svelte.config.js
+++ b/compatibility/check-fixtures/svelte-config-accessors-off/project/svelte.config.js
@@ -1,0 +1,1 @@
+export default { compilerOptions: { customElement: false } };

--- a/compatibility/check-fixtures/svelte-config-accessors-off/project/tsconfig.json
+++ b/compatibility/check-fixtures/svelte-config-accessors-off/project/tsconfig.json
@@ -1,0 +1,14 @@
+{
+	"compilerOptions": {
+		"target": "esnext",
+		"module": "esnext",
+		"moduleResolution": "bundler",
+		"strict": true,
+		"skipLibCheck": true,
+		"noEmit": true
+	},
+	"include": [
+		"src/**/*.ts",
+		"src/**/*.svelte"
+	]
+}

--- a/compatibility/check-fixtures/svelte-config-accessors-off/scenario.json
+++ b/compatibility/check-fixtures/svelte-config-accessors-off/scenario.json
@@ -1,0 +1,5 @@
+{
+	"description": "Control for `svelte-config-accessors`: same sources, `customElement: false`. Without accessors a `let` prop is not a component export, so reading it off the instance is a type error \u2014 which is what makes the pair discriminating rather than merely present.",
+	"workspace": ".",
+	"tsconfig": "tsconfig.json"
+}

--- a/compatibility/check-fixtures/svelte-config-accessors/project/package.json
+++ b/compatibility/check-fixtures/svelte-config-accessors/project/package.json
@@ -1,0 +1,5 @@
+{
+	"name": "check-fixture-svelte-config-accessors",
+	"private": true,
+	"type": "module"
+}

--- a/compatibility/check-fixtures/svelte-config-accessors/project/src/Child.svelte
+++ b/compatibility/check-fixtures/svelte-config-accessors/project/src/Child.svelte
@@ -1,0 +1,11 @@
+<script lang="ts">
+	export let value: string = 'x';
+</script>
+
+<span>{value}</span>
+
+<style>
+	.never-used {
+		color: red;
+	}
+</style>

--- a/compatibility/check-fixtures/svelte-config-accessors/project/src/Parent.svelte
+++ b/compatibility/check-fixtures/svelte-config-accessors/project/src/Parent.svelte
@@ -1,0 +1,12 @@
+<script lang="ts">
+	import Child from './Child.svelte';
+
+	let child!: Child;
+
+	function probe(): number {
+		return child.value;
+	}
+</script>
+
+<Child bind:this={child} value="a" />
+<span>{probe()}</span>

--- a/compatibility/check-fixtures/svelte-config-accessors/project/svelte.config.js
+++ b/compatibility/check-fixtures/svelte-config-accessors/project/svelte.config.js
@@ -1,0 +1,1 @@
+export default { compilerOptions: { customElement: true } };

--- a/compatibility/check-fixtures/svelte-config-accessors/project/tsconfig.json
+++ b/compatibility/check-fixtures/svelte-config-accessors/project/tsconfig.json
@@ -1,0 +1,14 @@
+{
+	"compilerOptions": {
+		"target": "esnext",
+		"module": "esnext",
+		"moduleResolution": "bundler",
+		"strict": true,
+		"skipLibCheck": true,
+		"noEmit": true
+	},
+	"include": [
+		"src/**/*.ts",
+		"src/**/*.svelte"
+	]
+}

--- a/compatibility/check-fixtures/svelte-config-accessors/scenario.json
+++ b/compatibility/check-fixtures/svelte-config-accessors/scenario.json
@@ -1,0 +1,5 @@
+{
+	"description": "`compilerOptions.customElement` reaches the TSX projection through the `accessors ?? customElement` expression upstream's `DocumentSnapshot.ts` builds, so a `let` prop becomes readable off the component instance. Paired with `svelte-config-accessors-off`, whose project is byte-identical apart from the `customElement` value.",
+	"workspace": ".",
+	"tsconfig": "tsconfig.json"
+}

--- a/compatibility/check-fixtures/svelte-config-recognised-option/project/package.json
+++ b/compatibility/check-fixtures/svelte-config-recognised-option/project/package.json
@@ -1,0 +1,5 @@
+{
+	"name": "check-fixture-svelte-config-recognised-option",
+	"private": true,
+	"type": "module"
+}

--- a/compatibility/check-fixtures/svelte-config-recognised-option/project/src/Widget.svelte
+++ b/compatibility/check-fixtures/svelte-config-recognised-option/project/src/Widget.svelte
@@ -1,0 +1,12 @@
+<script lang="ts">
+	let { label }: { label: string } = $props();
+	const count: number = 'not a number';
+</script>
+
+<div>{label}{count}</div>
+
+<style>
+	.never-used {
+		color: red;
+	}
+</style>

--- a/compatibility/check-fixtures/svelte-config-recognised-option/project/svelte.config.js
+++ b/compatibility/check-fixtures/svelte-config-recognised-option/project/svelte.config.js
@@ -1,0 +1,1 @@
+export default { compilerOptions: { runes: true } };

--- a/compatibility/check-fixtures/svelte-config-recognised-option/project/tsconfig.json
+++ b/compatibility/check-fixtures/svelte-config-recognised-option/project/tsconfig.json
@@ -1,0 +1,14 @@
+{
+	"compilerOptions": {
+		"target": "esnext",
+		"module": "esnext",
+		"moduleResolution": "bundler",
+		"strict": true,
+		"skipLibCheck": true,
+		"noEmit": true
+	},
+	"include": [
+		"src/**/*.ts",
+		"src/**/*.svelte"
+	]
+}

--- a/compatibility/check-fixtures/svelte-config-recognised-option/scenario.json
+++ b/compatibility/check-fixtures/svelte-config-recognised-option/scenario.json
@@ -1,0 +1,5 @@
+{
+	"description": "Control for `svelte-config-unrecognised-option`: same sources, the key spelled as the option that exists. The component's own `css_unused_selector` warning and its TypeScript error both have to survive here \u2014 the TypeScript one has to survive in BOTH scenarios, since an options error does not stop the projection.",
+	"workspace": ".",
+	"tsconfig": "tsconfig.json"
+}

--- a/compatibility/check-fixtures/svelte-config-unrecognised-option/project/package.json
+++ b/compatibility/check-fixtures/svelte-config-unrecognised-option/project/package.json
@@ -1,0 +1,5 @@
+{
+	"name": "check-fixture-svelte-config-unrecognised-option",
+	"private": true,
+	"type": "module"
+}

--- a/compatibility/check-fixtures/svelte-config-unrecognised-option/project/src/Widget.svelte
+++ b/compatibility/check-fixtures/svelte-config-unrecognised-option/project/src/Widget.svelte
@@ -1,0 +1,12 @@
+<script lang="ts">
+	let { label }: { label: string } = $props();
+	const count: number = 'not a number';
+</script>
+
+<div>{label}{count}</div>
+
+<style>
+	.never-used {
+		color: red;
+	}
+</style>

--- a/compatibility/check-fixtures/svelte-config-unrecognised-option/project/svelte.config.js
+++ b/compatibility/check-fixtures/svelte-config-unrecognised-option/project/svelte.config.js
@@ -1,0 +1,1 @@
+export default { compilerOptions: { rune: true } };

--- a/compatibility/check-fixtures/svelte-config-unrecognised-option/project/tsconfig.json
+++ b/compatibility/check-fixtures/svelte-config-unrecognised-option/project/tsconfig.json
@@ -1,0 +1,14 @@
+{
+	"compilerOptions": {
+		"target": "esnext",
+		"module": "esnext",
+		"moduleResolution": "bundler",
+		"strict": true,
+		"skipLibCheck": true,
+		"noEmit": true
+	},
+	"include": [
+		"src/**/*.ts",
+		"src/**/*.svelte"
+	]
+}

--- a/compatibility/check-fixtures/svelte-config-unrecognised-option/scenario.json
+++ b/compatibility/check-fixtures/svelte-config-unrecognised-option/scenario.json
@@ -1,0 +1,5 @@
+{
+	"description": "An option key the compiler does not know. Upstream forwards the whole `compilerOptions` object to `svelte.compile`, which throws `options_unrecognised` before parsing, so every checked component reports it and reports none of its own warnings. Paired with `svelte-config-recognised-option`, whose project is byte-identical apart from the key name.",
+	"workspace": ".",
+	"tsconfig": "tsconfig.json"
+}

--- a/compatibility/gate-coverage.md
+++ b/compatibility/gate-coverage.md
@@ -647,7 +647,7 @@ space is a boundary).
 ## 12-13. svelte-check diagnostic parity (Layer 1 fixtures, Layer 2 e2e)
 
 **Unit.** A multiset of `` `${severity} ${relpath}:${line} ${code}` `` (`check-diagnostics.mjs:18`,
-`:63`). Layer 1 = 30 committed scenarios under `compatibility/check-fixtures/`
+`:63`). Layer 1 = 36 committed scenarios under `compatibility/check-fixtures/`
 (`check-verify.mjs:149-156`); Layer 2 = 3 units in 2 real repos
 (`check-e2e-verify.mjs:62-98`), sharing the same parsing module (`:49`).
 
@@ -687,7 +687,7 @@ false positives and nothing else. **This is a question, not a finding.** Resolve
 ### Blind spot 12d — the CLI surface is one point
 
 `check-verify.mjs:197-202` forwards only `--workspace`, `--tsconfig`, and per-scenario `args`.
-Exactly one of 30 scenarios uses `args` (`ts7-native`: `["--tsgo"]`). **[D]** `--threshold`,
+Exactly one of 36 scenarios uses `args` (`ts7-native`: `["--tsgo"]`). **[D]** `--threshold`,
 `--fail-on-warnings`, `--ignore`, `--compiler-warnings`, `--config`, `--watch` and the `human` /
 `machine` / `github-actions` output formats are compared against the oracle nowhere.
 
@@ -704,6 +704,37 @@ carried a third copy of the same wrong predicate.
 The lesson generalises past this gate: a flag that selects an input source is not one more
 option to forward, it is a **second population**. Compare 5a, where the same shape (an entry
 point nothing reached) hid a whole compiler path.
+
+### Blind spot 12f — the `compilerOptions` surface is compared only at the keys a scenario sets
+
+Six scenarios now set a `compilerOptions` key (`svelte-config-namespace-{foreign,html}`,
+`svelte-config-accessors{,-off}`, `svelte-config-{un,}recognised-option`), each half of a pair
+whose two projects are byte-identical apart from that one value. That is what makes 12d's
+"essentially no explicit-config branch is exercised" one notch less true — but only for those
+keys. The compiler accepts 32 options
+(`crates/rsvelte_check/src/svelte_check/options_schema.rs`'s `COMPONENT_OPTIONS`, derived from
+`validate-options.js` by `schema_matches_upstream`), and the rest are compared against the
+oracle nowhere.
+
+Three things this gate structurally cannot see, all **[S]** unless noted:
+
+* **Deprecation and `warn_removed` warnings.** `accessors: true`, `immutable: true`,
+  `hydratable`, `enableSourcemap`, `loopGuardTimeout` and `generate: 'dom'` produce *warnings*
+  through the compiler's `warn_once`, whose `warned` set is module-global — so upstream emits
+  each at most **once per svelte-check process**, on whichever component happened to compile
+  first. rsvelte-check does not reproduce them at all. **[D]** Confirmed against the pinned
+  oracle: two successive `compile(..., { accessors: true })` calls yield
+  `options_deprecated_accessors` on the first and nothing on the second. This is also why the
+  accessors pair keys off `customElement` rather than `accessors` — `accessors: true` would put
+  a once-per-run warning inside the scenario and force a ratchet entry, which would then
+  suppress every other divergence in it.
+* **Anything the static config reader cannot evaluate.** The oracle imports the config, rsvelte
+  parses it; `namespace: ns` or a spread is a legal value to one and unreadable to the other. A
+  scenario written with a computed value would compare "no diagnostic" to "no diagnostic" for
+  the wrong reason.
+* **Which of `svelte.config.*`, the inline `svelte()` / `sveltekit()` plugin options, and
+  `--config` supplied the value.** Every scenario uses `svelte.config.js`; the precedence rules
+  in `config.rs` are covered by unit tests only, and `--config` by nothing (12d).
 
 ### Blind spot 12e — the tsc/tsgo equivalence claim is asserted, not measured
 

--- a/crates/rsvelte_check/src/svelte_check/config.rs
+++ b/crates/rsvelte_check/src/svelte_check/config.rs
@@ -35,15 +35,12 @@ use oxc_parser::Parser as OxcParser;
 use oxc_span::SourceType;
 
 use super::kit_file::{lookup_property, unwrap_define_config_object};
+use super::options_schema::{ConfigObject, ConfigValue, OptionDiagnostic};
 use crate::svelte2tsx::Svelte2TsxNamespace;
-
-/// Namespaces the Svelte 5 compiler accepts for `compilerOptions.namespace`
-/// (`validate-options.js`'s `list(['html', 'mathml', 'svg'])`).
-const COMPILER_NAMESPACES: [&str; 3] = ["html", "mathml", "svg"];
 
 /// Subset of Svelte `compilerOptions` that influence svelte-check
 /// diagnostics. Extend as more options gain diagnostic relevance.
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq)]
 pub struct CompilerOptionsSettings {
     /// `compilerOptions.experimental.async` — allows top-level / derived
     /// `await`. When false (the default), the compiler emits the
@@ -58,6 +55,16 @@ pub struct CompilerOptionsSettings {
     /// the Svelte 5 compiler rejects, and both consequences are
     /// user-visible.
     pub namespace: Option<String>,
+    /// `compilerOptions.accessors` — turns every `let` binding into a
+    /// component export, which moves the component's public type.
+    pub accessors: Option<bool>,
+    /// `compilerOptions.customElement` — the fallback `accessors` reads when
+    /// it is unset, because custom elements always get accessors.
+    pub custom_element: Option<bool>,
+    /// Every statically-readable `compilerOptions` entry, merged across the
+    /// sources below. Upstream forwards this object wholesale to
+    /// `svelte.compile`, so it is also what gets validated.
+    pub raw: ConfigObject,
 }
 
 impl CompilerOptionsSettings {
@@ -66,11 +73,10 @@ impl CompilerOptionsSettings {
     /// compiler options change between runs (the `.svelte` source
     /// mtime/size is unaffected by a config edit, so the per-file key
     /// alone can't notice it).
+    /// Fingerprinting the whole parsed object rather than the fields read off
+    /// it keeps a newly-consumed option from silently reusing a stale cache.
     pub fn signature(&self) -> String {
-        format!(
-            "async={};runes={:?};namespace={:?}",
-            self.experimental_async, self.runes, self.namespace
-        )
+        format!("{:?}", self.raw)
     }
 
     /// The namespace the TSX projection runs under. Mirrors
@@ -86,14 +92,18 @@ impl CompilerOptionsSettings {
         }
     }
 
-    /// The configured namespace when the Svelte 5 compiler would reject it.
-    /// `svelte.compile` validates its options, so upstream svelte-check
-    /// surfaces `options_invalid_value` for every checked component of such
-    /// a project; rsvelte builds `CompileOptions` from a typed enum and so
-    /// has to make that check itself.
-    pub fn invalid_namespace(&self) -> Option<&str> {
-        let ns = self.namespace.as_deref()?;
-        (!COMPILER_NAMESPACES.contains(&ns)).then_some(ns)
+    /// Whether the TSX projection runs with accessors. Mirrors
+    /// `DocumentSnapshot.ts`'s `accessors ?? customElement`: a custom element
+    /// exposes its props as properties whether or not `accessors` is set.
+    pub fn projection_accessors(&self) -> bool {
+        self.accessors.or(self.custom_element).unwrap_or(false)
+    }
+
+    /// The diagnostic `svelte.compile` would raise for these options before
+    /// compiling anything, which upstream therefore reports on every checked
+    /// component.
+    pub fn option_diagnostic(&self) -> Option<OptionDiagnostic> {
+        super::options_schema::validate_component_options(&self.raw)
     }
 }
 
@@ -419,25 +429,86 @@ fn vite_uses_inline_sveltekit_config(source: &str, source_type: SourceType) -> b
     false
 }
 
-/// Read `compilerOptions.{experimental.async, runes, namespace}` out of an
-/// object expression (either a svelte.config root object or a svelte-plugin
-/// options object). Only sets a field when a literal of the right kind is
-/// present.
+/// Read the whole `compilerOptions` object out of an object expression
+/// (either a svelte.config root object or a svelte-plugin options object)
+/// and merge it over what earlier sources declared, then re-derive the typed
+/// fields. Only statically-readable literals are captured; anything else is
+/// recorded as [`ConfigValue::Unknown`] so it is neither used nor judged.
 fn extract_compiler_options(obj: &oxc::ObjectExpression, settings: &mut CompilerOptionsSettings) {
     let Some(oxc::Expression::ObjectExpression(co)) = lookup_property(obj, "compilerOptions")
     else {
         return;
     };
-    if let Some(oxc::Expression::BooleanLiteral(b)) = lookup_property(co, "runes") {
-        settings.runes = Some(b.value);
+    settings.raw.merge(&read_object(co));
+
+    if let Some(ConfigValue::Bool(b)) = settings.raw.get("runes") {
+        settings.runes = Some(*b);
     }
-    if let Some(oxc::Expression::StringLiteral(s)) = lookup_property(co, "namespace") {
-        settings.namespace = Some(s.value.to_string());
+    if let Some(ConfigValue::Bool(b)) = settings.raw.get("accessors") {
+        settings.accessors = Some(*b);
     }
-    if let Some(oxc::Expression::ObjectExpression(exp)) = lookup_property(co, "experimental")
-        && let Some(oxc::Expression::BooleanLiteral(b)) = lookup_property(exp, "async")
+    if let Some(ConfigValue::Bool(b)) = settings.raw.get("customElement") {
+        settings.custom_element = Some(*b);
+    }
+    if let Some(ConfigValue::Str(s)) = settings.raw.get("namespace") {
+        settings.namespace = Some(s.clone());
+    }
+    if let Some(ConfigValue::Object(exp)) = settings.raw.get("experimental")
+        && let Some(ConfigValue::Bool(b)) = exp.get("async")
     {
-        settings.experimental_async = b.value;
+        settings.experimental_async = *b;
+    }
+}
+
+/// Statically evaluate an object literal one property at a time.
+fn read_object(obj: &oxc::ObjectExpression) -> ConfigObject {
+    let mut entries = Vec::new();
+    let mut complete = true;
+    for prop in &obj.properties {
+        let oxc::ObjectPropertyKind::ObjectProperty(p) = prop else {
+            // A spread hides keys we would otherwise call unrecognised.
+            complete = false;
+            continue;
+        };
+        let name = match &p.key {
+            oxc::PropertyKey::StaticIdentifier(id) => id.name.to_string(),
+            oxc::PropertyKey::StringLiteral(s) => s.value.to_string(),
+            _ => {
+                complete = false;
+                continue;
+            }
+        };
+        entries.push((name, read_value(&p.value)));
+    }
+    if complete {
+        ConfigObject::complete(entries)
+    } else {
+        ConfigObject::partial(entries)
+    }
+}
+
+fn read_value(expr: &oxc::Expression) -> ConfigValue {
+    match expr {
+        oxc::Expression::BooleanLiteral(b) => ConfigValue::Bool(b.value),
+        oxc::Expression::NumericLiteral(n) => ConfigValue::Number(n.value),
+        oxc::Expression::StringLiteral(s) => ConfigValue::Str(s.value.to_string()),
+        oxc::Expression::NullLiteral(_) => ConfigValue::Null,
+        oxc::Expression::ObjectExpression(o) => ConfigValue::Object(read_object(o)),
+        oxc::Expression::ArrayExpression(_) => ConfigValue::Array,
+        oxc::Expression::ArrowFunctionExpression(_) | oxc::Expression::FunctionExpression(_) => {
+            ConfigValue::Function
+        }
+        oxc::Expression::ParenthesizedExpression(p) => read_value(&p.expression),
+        oxc::Expression::TSAsExpression(a) => read_value(&a.expression),
+        oxc::Expression::TSSatisfiesExpression(s) => read_value(&s.expression),
+        oxc::Expression::TSNonNullExpression(n) => read_value(&n.expression),
+        oxc::Expression::UnaryExpression(u) => match (u.operator, &u.argument) {
+            (oxc::UnaryOperator::UnaryNegation, oxc::Expression::NumericLiteral(n)) => {
+                ConfigValue::Number(-n.value)
+            }
+            _ => ConfigValue::Unknown,
+        },
+        _ => ConfigValue::Unknown,
     }
 }
 
@@ -546,6 +617,19 @@ mod tests {
 
     fn write(dir: &Path, name: &str, body: &str) {
         std::fs::write(dir.join(name), body).unwrap();
+    }
+
+    /// Settings as the loader would build them: the typed fields are views of
+    /// `raw`, so a hand-built one that skips it is not a reachable state.
+    fn settings_with(key: &str, value: ConfigValue) -> CompilerOptionsSettings {
+        let mut settings = CompilerOptionsSettings {
+            raw: ConfigObject::complete(vec![(key.to_string(), value.clone())]),
+            ..Default::default()
+        };
+        if let (ConfigValue::Str(s), "namespace") = (&value, key) {
+            settings.namespace = Some(s.clone());
+        }
+        settings
     }
 
     #[test]
@@ -657,7 +741,10 @@ mod tests {
         let s = load_compiler_options(&dir);
         assert_eq!(s.namespace.as_deref(), Some("foreign"));
         assert_eq!(s.projection_namespace(), Svelte2TsxNamespace::Foreign);
-        assert_eq!(s.invalid_namespace(), Some("foreign"));
+        assert_eq!(
+            s.option_diagnostic().map(|d| d.code),
+            Some("options_invalid_value")
+        );
         let _ = std::fs::remove_dir_all(&dir);
     }
 
@@ -673,7 +760,7 @@ mod tests {
         let s = load_compiler_options(&dir);
         assert_eq!(s.namespace.as_deref(), Some("svg"));
         assert_eq!(s.projection_namespace(), Svelte2TsxNamespace::Svg);
-        assert_eq!(s.invalid_namespace(), None);
+        assert_eq!(s.option_diagnostic(), None);
         let _ = std::fs::remove_dir_all(&dir);
     }
 
@@ -704,20 +791,18 @@ mod tests {
     #[test]
     fn only_compiler_illegal_namespaces_are_reported() {
         for legal in ["html", "svg", "mathml"] {
-            let s = CompilerOptionsSettings {
-                namespace: Some(legal.to_string()),
-                ..Default::default()
-            };
-            assert_eq!(s.invalid_namespace(), None, "{legal} is a compiler value");
+            let s = settings_with("namespace", ConfigValue::Str(legal.to_string()));
+            assert_eq!(s.option_diagnostic(), None, "{legal} is a compiler value");
         }
         for illegal in ["foreign", "HTML", ""] {
-            let s = CompilerOptionsSettings {
-                namespace: Some(illegal.to_string()),
-                ..Default::default()
-            };
-            assert_eq!(s.invalid_namespace(), Some(illegal));
+            let s = settings_with("namespace", ConfigValue::Str(illegal.to_string()));
+            assert_eq!(
+                s.option_diagnostic().map(|d| d.code),
+                Some("options_invalid_value"),
+                "{illegal}"
+            );
         }
-        assert_eq!(CompilerOptionsSettings::default().invalid_namespace(), None);
+        assert_eq!(CompilerOptionsSettings::default().option_diagnostic(), None);
     }
 
     /// A non-literal value is unreadable, and reporting it as invalid would
@@ -732,7 +817,7 @@ mod tests {
         );
         let s = load_compiler_options(&dir);
         assert_eq!(s.namespace, None);
-        assert_eq!(s.invalid_namespace(), None);
+        assert_eq!(s.option_diagnostic(), None);
         let _ = std::fs::remove_dir_all(&dir);
     }
 
@@ -1082,17 +1167,13 @@ mod tests {
     #[test]
     fn signature_changes_with_options() {
         let a = CompilerOptionsSettings::default();
-        let b = CompilerOptionsSettings {
-            experimental_async: true,
-            ..Default::default()
-        };
+        let b = settings_with("dev", ConfigValue::Bool(true));
         assert_ne!(a.signature(), b.signature());
-        // The overlay shadows depend on the namespace, so the signature that
-        // invalidates them has to move with it.
-        let c = CompilerOptionsSettings {
-            namespace: Some("foreign".to_string()),
-            ..Default::default()
-        };
-        assert_ne!(a.signature(), c.signature());
+        // The overlay shadows depend on the namespace and on `accessors`, so
+        // the signature that invalidates them has to move with either.
+        for key in ["namespace", "accessors", "someFutureOption"] {
+            let c = settings_with(key, ConfigValue::Str("foreign".to_string()));
+            assert_ne!(a.signature(), c.signature(), "{key}");
+        }
     }
 }

--- a/crates/rsvelte_check/src/svelte_check/mod.rs
+++ b/crates/rsvelte_check/src/svelte_check/mod.rs
@@ -12,6 +12,7 @@ pub mod config;
 pub mod kit_file;
 pub mod manifest;
 pub mod mapper;
+pub mod options_schema;
 pub mod overlay;
 pub mod runner;
 pub mod tsgo;

--- a/crates/rsvelte_check/src/svelte_check/options_schema.rs
+++ b/crates/rsvelte_check/src/svelte_check/options_schema.rs
@@ -1,0 +1,816 @@
+//! Port of the compiler's own `compilerOptions` validator.
+//!
+//! Upstream svelte-check hands the parsed `compilerOptions` object straight to
+//! `svelte.compile` (`SvelteDocument.ts`'s `getCompiledWith`), so the compiler's
+//! `validate-options.js` runs over it and every unrecognised key / illegal value
+//! surfaces as an `options_unrecognised` / `options_invalid_value` /
+//! `options_removed` diagnostic on each checked component. rsvelte-check builds
+//! a typed `CompileOptions` instead, so nothing validates what it reads — and a
+//! per-key check for whichever option a bug report happened to name does not
+//! scale. This is the whole table, mirroring
+//! `submodules/svelte/packages/svelte/src/compiler/validate-options.js`, checked
+//! against that file by `schema_matches_upstream`.
+//!
+//! Two deliberate under-approximations, both chosen so this can never invent a
+//! diagnostic upstream would not raise:
+//!   * a value that is not a literal (an identifier, a call, a spread-in key)
+//!     is unreadable here but perfectly readable to the real config loader, so
+//!     it is skipped rather than judged;
+//!   * `deprecate` / `warn_removed` options produce *warnings*, and upstream's
+//!     `warn_once` fires them once per process — which component they land on
+//!     is an artefact of compile order, so they are not reproduced at all.
+
+/// A `compilerOptions` value as far as static parsing can tell.
+#[derive(Debug, Clone, PartialEq)]
+pub enum ConfigValue {
+    Bool(bool),
+    Number(f64),
+    Str(String),
+    Null,
+    Object(ConfigObject),
+    Array,
+    Function,
+    /// Not statically readable — an identifier, call, member expression,
+    /// template literal, `undefined`, …
+    Unknown,
+}
+
+/// The statically-visible part of an object literal.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ConfigObject {
+    entries: Vec<(String, ConfigValue)>,
+    /// False when a spread element or a computed key hid part of the key set,
+    /// which is what makes "this key is unrecognised" unanswerable.
+    complete: bool,
+}
+
+/// Nothing read yet — and nothing hidden either, so the first source merged in
+/// decides completeness.
+impl Default for ConfigObject {
+    fn default() -> Self {
+        Self {
+            entries: Vec::new(),
+            complete: true,
+        }
+    }
+}
+
+impl ConfigObject {
+    /// An object whose key set is fully known (no spread, no computed key).
+    pub fn complete(entries: Vec<(String, ConfigValue)>) -> Self {
+        Self {
+            entries,
+            complete: true,
+        }
+    }
+
+    pub fn partial(entries: Vec<(String, ConfigValue)>) -> Self {
+        Self {
+            entries,
+            complete: false,
+        }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    pub fn get(&self, name: &str) -> Option<&ConfigValue> {
+        // Last wins, as in JS: a duplicate key overwrites the earlier one.
+        self.entries
+            .iter()
+            .rev()
+            .find(|(k, _)| k == name)
+            .map(|(_, v)| v)
+    }
+
+    /// Merge `other` over `self`, mirroring vite-plugin-svelte's
+    /// `svelte.config` → inline plugin options precedence. Object-valued keys
+    /// merge recursively so a source that declares `experimental.async` alone
+    /// does not erase a sibling.
+    pub fn merge(&mut self, other: &ConfigObject) {
+        self.complete &= other.complete;
+        for (key, value) in &other.entries {
+            match (self.get_mut(key), value) {
+                (Some(ConfigValue::Object(existing)), ConfigValue::Object(incoming)) => {
+                    existing.merge(incoming);
+                }
+                (Some(slot), _) => *slot = value.clone(),
+                (None, _) => self.entries.push((key.clone(), value.clone())),
+            }
+        }
+    }
+
+    fn get_mut(&mut self, name: &str) -> Option<&mut ConfigValue> {
+        self.entries
+            .iter_mut()
+            .rev()
+            .find(|(k, _)| k == name)
+            .map(|(_, v)| v)
+    }
+}
+
+/// A diagnostic `svelte.compile` would throw before compiling anything.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OptionDiagnostic {
+    pub code: &'static str,
+    pub message: String,
+}
+
+impl OptionDiagnostic {
+    fn error(code: &'static str, body: String) -> Self {
+        Self {
+            message: format!("{body}\nhttps://svelte.dev/e/{code}"),
+            code,
+        }
+    }
+}
+
+type Check = fn(&ConfigValue, &str) -> Option<String>;
+
+/// A member of `list([...])`. Upstream compares with `Array.includes`, so a
+/// number and its string spelling are different values.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum Lit {
+    Str(&'static str),
+    Num(f64),
+}
+
+impl Lit {
+    fn matches(self, value: &ConfigValue) -> bool {
+        match (self, value) {
+            (Lit::Str(s), ConfigValue::Str(v)) => s == v,
+            (Lit::Num(n), ConfigValue::Number(v)) => n == *v,
+            _ => false,
+        }
+    }
+
+    fn spelling(self) -> String {
+        match self {
+            Lit::Str(s) => s.to_string(),
+            Lit::Num(n) => format!("{n}"),
+        }
+    }
+}
+
+/// The validator families of `validate-options.js`, one variant per helper.
+pub enum Kind {
+    Boolean,
+    Str,
+    List(&'static [Lit]),
+    Function,
+    Object(&'static [Opt]),
+    Removed(&'static str),
+    /// Warns rather than errors, and only once per process — not reproduced.
+    WarnRemoved,
+    /// `validator` / `parametric` — a hand-written normalizer whose body no
+    /// derivation can read. `None` is upstream's identity normalizer, which
+    /// accepts every value.
+    Custom(Option<Check>),
+}
+
+pub struct Opt {
+    pub name: &'static str,
+    pub kind: Kind,
+    /// `deprecate(...)` — a once-per-process warning wrapped around a
+    /// validator that still runs.
+    pub deprecated: bool,
+}
+
+const fn opt(name: &'static str, kind: Kind) -> Opt {
+    Opt {
+        name,
+        kind,
+        deprecated: false,
+    }
+}
+
+const fn deprecated(name: &'static str, kind: Kind) -> Opt {
+    Opt {
+        name,
+        kind,
+        deprecated: true,
+    }
+}
+
+const EXPERIMENTAL: &[Opt] = &[opt("async", Kind::Boolean)];
+
+const COMPATIBILITY: &[Opt] = &[opt(
+    "componentApi",
+    Kind::List(&[Lit::Num(4.0), Lit::Num(5.0)]),
+)];
+
+/// `object({ ...common_options, ...component_options })` — declaration order
+/// matters, because upstream validates children in key order and the first
+/// throw wins.
+pub const COMPONENT_OPTIONS: &[Opt] = &[
+    // common_options
+    opt("filename", Kind::Str),
+    opt("rootDir", Kind::Str),
+    opt("dev", Kind::Boolean),
+    opt("generate", Kind::Custom(Some(check_generate))),
+    opt("warningFilter", Kind::Function),
+    opt("experimental", Kind::Object(EXPERIMENTAL)),
+    // component_options
+    deprecated("accessors", Kind::Boolean),
+    opt("css", Kind::Custom(Some(check_css))),
+    opt("cssHash", Kind::Function),
+    opt("cssOutputFilename", Kind::Str),
+    opt("customElement", Kind::Custom(Some(check_custom_element))),
+    opt("discloseVersion", Kind::Boolean),
+    deprecated("immutable", Kind::Boolean),
+    opt(
+        "legacy",
+        Kind::Removed(
+            "The legacy option has been removed. If you are using this because of \
+             legacy.componentApi, use compatibility.componentApi instead",
+        ),
+    ),
+    opt("compatibility", Kind::Object(COMPATIBILITY)),
+    opt("loopGuardTimeout", Kind::WarnRemoved),
+    opt("name", Kind::Str),
+    opt(
+        "namespace",
+        Kind::List(&[Lit::Str("html"), Lit::Str("mathml"), Lit::Str("svg")]),
+    ),
+    opt("modernAst", Kind::Boolean),
+    opt("outputFilename", Kind::Str),
+    opt("preserveComments", Kind::Boolean),
+    opt(
+        "fragments",
+        Kind::List(&[Lit::Str("html"), Lit::Str("tree")]),
+    ),
+    opt("preserveWhitespace", Kind::Boolean),
+    opt("runes", Kind::Custom(None)),
+    opt("hmr", Kind::Boolean),
+    opt("sourcemap", Kind::Custom(None)),
+    opt("enableSourcemap", Kind::WarnRemoved),
+    opt("hydratable", Kind::WarnRemoved),
+    opt(
+        "format",
+        Kind::Removed(
+            "The format option has been removed in Svelte 4, the compiler only outputs ESM now. \
+             Remove \"format\" from your compiler options. If you did not set this yourself, bump \
+             the version of your bundler plugin \
+             (vite-plugin-svelte/rollup-plugin-svelte/svelte-loader)",
+        ),
+    ),
+    opt(
+        "tag",
+        Kind::Removed(
+            "The tag option has been removed in Svelte 5. Use `<svelte:options \
+             customElement=\"tag-name\" />` inside the component instead. If that does not solve \
+             your use case, please open an issue on GitHub with details.",
+        ),
+    ),
+    opt(
+        "sveltePath",
+        Kind::Removed(
+            "The sveltePath option has been removed in Svelte 5. If this option was crucial for \
+             you, please open an issue on GitHub with your use case.",
+        ),
+    ),
+    opt(
+        "errorMode",
+        Kind::Removed(
+            "The errorMode option has been removed. If you are using this through \
+             svelte-preprocess with TypeScript, use the \
+             https://www.typescriptlang.org/tsconfig#verbatimModuleSyntax setting instead",
+        ),
+    ),
+    opt(
+        "varsReport",
+        Kind::Removed(
+            "The vars option has been removed. If you are using this through svelte-preprocess \
+             with TypeScript, use the \
+             https://www.typescriptlang.org/tsconfig#verbatimModuleSyntax setting instead",
+        ),
+    ),
+];
+
+fn check_generate(value: &ConfigValue, keypath: &str) -> Option<String> {
+    match value {
+        // 'dom' / 'ssr' are renamed, not rejected (a once-per-process warning).
+        ConfigValue::Str(s) if matches!(s.as_str(), "client" | "server" | "dom" | "ssr") => None,
+        ConfigValue::Bool(false) => None,
+        _ => Some(format!("{keypath} must be \"client\", \"server\" or false")),
+    }
+}
+
+fn check_css(value: &ConfigValue, _keypath: &str) -> Option<String> {
+    match value {
+        // A function is normalized on call, against a value we cannot see.
+        ConfigValue::Function => None,
+        ConfigValue::Bool(_) => Some(
+            "The boolean options have been removed from the css option. Use \"external\" instead \
+             of false and \"injected\" instead of true"
+                .to_string(),
+        ),
+        ConfigValue::Str(s) if s == "none" => Some(
+            "css: \"none\" is no longer a valid option. If this was crucial for you, please open \
+             an issue on GitHub with your use case."
+                .to_string(),
+        ),
+        ConfigValue::Str(s) if s == "external" || s == "injected" => None,
+        _ => Some(
+            "css should be either \"external\" (default, recommended) or \"injected\"".to_string(),
+        ),
+    }
+}
+
+fn check_custom_element(value: &ConfigValue, keypath: &str) -> Option<String> {
+    match value {
+        ConfigValue::Function | ConfigValue::Bool(_) => None,
+        _ => Some(format!("{keypath} should be true or false")),
+    }
+}
+
+/// The first diagnostic `svelte.compile` would raise for these options, or
+/// `None` when nothing statically readable is wrong with them.
+pub fn validate_component_options(options: &ConfigObject) -> Option<OptionDiagnostic> {
+    validate_object(options, "", COMPONENT_OPTIONS)
+}
+
+fn validate_object(
+    obj: &ConfigObject,
+    keypath: &str,
+    children: &'static [Opt],
+) -> Option<OptionDiagnostic> {
+    // Upstream reports every unrecognised key before validating any known one,
+    // and the first report throws.
+    if obj.complete {
+        for (key, _) in &obj.entries {
+            if !children.iter().any(|c| c.name == key) {
+                return Some(OptionDiagnostic::error(
+                    "options_unrecognised",
+                    format!("Unrecognised compiler option {}", join(keypath, key)),
+                ));
+            }
+        }
+    }
+    for child in children {
+        let Some(value) = obj.get(child.name) else {
+            continue;
+        };
+        // Absent and unreadable are the same thing here: judging either would
+        // be a diagnostic upstream never raises.
+        if matches!(value, ConfigValue::Unknown) {
+            continue;
+        }
+        if let Some(found) = validate_value(value, &join(keypath, child.name), &child.kind) {
+            return Some(found);
+        }
+    }
+    None
+}
+
+fn validate_value(
+    value: &ConfigValue,
+    keypath: &str,
+    kind: &'static Kind,
+) -> Option<OptionDiagnostic> {
+    let invalid = |detail: String| {
+        Some(OptionDiagnostic::error(
+            "options_invalid_value",
+            format!("Invalid compiler option: {detail}"),
+        ))
+    };
+    match kind {
+        Kind::Boolean => match value {
+            ConfigValue::Bool(_) => None,
+            _ => invalid(format!("{keypath} should be true or false, if specified")),
+        },
+        Kind::Str => match value {
+            ConfigValue::Str(_) => None,
+            _ => invalid(format!("{keypath} should be a string, if specified")),
+        },
+        Kind::Function => match value {
+            ConfigValue::Function => None,
+            _ => invalid(format!("{keypath} should be a function, if specified")),
+        },
+        Kind::List(options) => {
+            if options.iter().any(|lit| lit.matches(value)) {
+                return None;
+            }
+            invalid(format!("{keypath} should be {}", list_spelling(options)))
+        }
+        Kind::Object(children) => match value {
+            ConfigValue::Object(nested) => validate_object(nested, keypath, children),
+            // Falsy non-objects survive upstream's type check and fail later on
+            // a child instead; under-approximating keeps this side silent.
+            ConfigValue::Null | ConfigValue::Bool(false) => None,
+            _ => invalid(format!("{keypath} should be an object")),
+        },
+        Kind::Removed(detail) => Some(OptionDiagnostic::error(
+            "options_removed",
+            format!("Invalid compiler option: {detail}"),
+        )),
+        Kind::WarnRemoved => None,
+        Kind::Custom(check) => check.and_then(|f| f(value, keypath)).and_then(invalid),
+    }
+}
+
+fn list_spelling(options: &[Lit]) -> String {
+    if options.len() > 2 {
+        let (last, head) = options.split_last().expect("non-empty list");
+        let head = head
+            .iter()
+            .map(|o| format!("\"{}\"", o.spelling()))
+            .collect::<Vec<_>>()
+            .join(", ");
+        format!("one of {head} or \"{}\"", last.spelling())
+    } else {
+        format!(
+            "either \"{}\" or \"{}\"",
+            options[0].spelling(),
+            options[1].spelling()
+        )
+    }
+}
+
+fn join(keypath: &str, key: &str) -> String {
+    if keypath.is_empty() {
+        key.to_string()
+    } else {
+        format!("{keypath}.{key}")
+    }
+}
+
+#[cfg(test)]
+mod derived {
+    //! The table above is checked against the file it mirrors instead of being
+    //! maintained by hand: a new upstream option, a renamed one, a changed
+    //! `list([...])` set or an option moving to `removed` fails here rather
+    //! than becoming another silently-dropped key. What it cannot derive is the
+    //! *body* of a `validator` / `parametric` normalizer — those are compared
+    //! only as "hand-written", and their semantics are pinned by the unit tests
+    //! and the check fixtures instead.
+
+    use std::path::PathBuf;
+
+    use oxc_allocator::Allocator;
+    use oxc_ast::ast as oxc;
+    use oxc_parser::Parser as OxcParser;
+    use oxc_span::SourceType;
+
+    use super::*;
+
+    fn upstream_source() -> Option<String> {
+        let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("../../submodules/svelte/packages/svelte/src/compiler/validate-options.js");
+        std::fs::read_to_string(path).ok()
+    }
+
+    fn repr(opt: &Opt) -> String {
+        let base = match &opt.kind {
+            Kind::Boolean => "boolean".to_string(),
+            Kind::Str => "string".to_string(),
+            Kind::Function => "fun".to_string(),
+            Kind::List(options) => format!(
+                "list({})",
+                options
+                    .iter()
+                    .map(|o| o.spelling())
+                    .collect::<Vec<_>>()
+                    .join(",")
+            ),
+            Kind::Object(children) => format!("object({})", reprs(children).join("; ")),
+            Kind::Removed(_) => "removed".to_string(),
+            Kind::WarnRemoved => "warn_removed".to_string(),
+            Kind::Custom(_) => "custom".to_string(),
+        };
+        if opt.deprecated {
+            format!("deprecate({base})")
+        } else {
+            base
+        }
+    }
+
+    fn reprs(options: &[Opt]) -> Vec<String> {
+        options
+            .iter()
+            .map(|o| format!("{} = {}", o.name, repr(o)))
+            .collect()
+    }
+
+    fn unwrap_parens<'a>(expr: &'a oxc::Expression<'a>) -> &'a oxc::Expression<'a> {
+        match expr {
+            oxc::Expression::ParenthesizedExpression(p) => unwrap_parens(&p.expression),
+            oxc::Expression::TSAsExpression(a) => unwrap_parens(&a.expression),
+            _ => expr,
+        }
+    }
+
+    fn upstream_repr(expr: &oxc::Expression) -> String {
+        let oxc::Expression::CallExpression(call) = unwrap_parens(expr) else {
+            return "?".to_string();
+        };
+        let oxc::Expression::Identifier(callee) = &call.callee else {
+            return "?".to_string();
+        };
+        match callee.name.as_str() {
+            "boolean" => "boolean".to_string(),
+            "string" => "string".to_string(),
+            "fun" => "fun".to_string(),
+            "removed" => "removed".to_string(),
+            "warn_removed" => "warn_removed".to_string(),
+            "validator" | "parametric" => "custom".to_string(),
+            "list" => {
+                let Some(oxc::Argument::ArrayExpression(arr)) = call.arguments.first() else {
+                    return "list(?)".to_string();
+                };
+                let members: Vec<String> = arr
+                    .elements
+                    .iter()
+                    .map(|el| match el {
+                        oxc::ArrayExpressionElement::StringLiteral(s) => s.value.to_string(),
+                        oxc::ArrayExpressionElement::NumericLiteral(n) => format!("{}", n.value),
+                        _ => "?".to_string(),
+                    })
+                    .collect();
+                format!("list({})", members.join(","))
+            }
+            "object" => {
+                let Some(oxc::Argument::ObjectExpression(obj)) = call.arguments.first() else {
+                    return "object(?)".to_string();
+                };
+                format!("object({})", upstream_reprs(obj).join("; "))
+            }
+            "deprecate" => {
+                let Some(oxc::Argument::CallExpression(_)) = call.arguments.get(1) else {
+                    return "deprecate(?)".to_string();
+                };
+                let inner = call.arguments[1].to_expression();
+                format!("deprecate({})", upstream_repr(inner))
+            }
+            other => other.to_string(),
+        }
+    }
+
+    fn upstream_reprs(obj: &oxc::ObjectExpression) -> Vec<String> {
+        obj.properties
+            .iter()
+            .filter_map(|prop| {
+                let oxc::ObjectPropertyKind::ObjectProperty(p) = prop else {
+                    return None;
+                };
+                let oxc::PropertyKey::StaticIdentifier(key) = &p.key else {
+                    return None;
+                };
+                Some(format!("{} = {}", key.name, upstream_repr(&p.value)))
+            })
+            .collect()
+    }
+
+    fn declared_object<'a>(
+        program: &'a oxc::Program<'a>,
+        name: &str,
+    ) -> Option<&'a oxc::ObjectExpression<'a>> {
+        for stmt in &program.body {
+            let oxc::Statement::VariableDeclaration(decl) = stmt else {
+                continue;
+            };
+            for d in &decl.declarations {
+                let oxc::BindingPattern::BindingIdentifier(id) = &d.id else {
+                    continue;
+                };
+                if id.name.as_str() != name {
+                    continue;
+                }
+                if let Some(oxc::Expression::ObjectExpression(obj)) = &d.init {
+                    return Some(obj);
+                }
+            }
+        }
+        None
+    }
+
+    #[test]
+    fn schema_matches_upstream() {
+        let Some(source) = upstream_source() else {
+            // Only a job that promised this submodule may fail on its absence.
+            assert!(
+                std::env::var_os("RSVELTE_REQUIRE_PREREQS").is_none(),
+                "submodules/svelte is not checked out in a job that declares \
+                 RSVELTE_REQUIRE_PREREQS — the option table would go unchecked against the \
+                 compiler it mirrors."
+            );
+            eprintln!("[options_schema] submodules/svelte absent — skipping");
+            return;
+        };
+        let allocator = Allocator::default();
+        let parsed = OxcParser::new(&allocator, &source, SourceType::mjs()).parse();
+        assert!(
+            parsed.diagnostics.is_empty(),
+            "validate-options.js did not parse: {:?}",
+            parsed.diagnostics
+        );
+        let common = declared_object(&parsed.program, "common_options")
+            .expect("validate-options.js declares common_options");
+        let component = declared_object(&parsed.program, "component_options")
+            .expect("validate-options.js declares component_options");
+
+        // `validate_component_options` is `object({ ...common, ...component })`,
+        // and the order it spreads them in is the order children are validated.
+        let mut expected = upstream_reprs(common);
+        expected.extend(upstream_reprs(component));
+        assert_eq!(reprs(COMPONENT_OPTIONS), expected);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn object(entries: &[(&str, ConfigValue)]) -> ConfigObject {
+        ConfigObject::complete(
+            entries
+                .iter()
+                .map(|(k, v)| ((*k).to_string(), v.clone()))
+                .collect(),
+        )
+    }
+
+    fn code_of(entries: &[(&str, ConfigValue)]) -> Option<&'static str> {
+        validate_component_options(&object(entries)).map(|d| d.code)
+    }
+
+    #[test]
+    fn accepts_the_options_the_compiler_accepts() {
+        assert_eq!(
+            code_of(&[
+                ("runes", ConfigValue::Bool(true)),
+                ("css", ConfigValue::Str("injected".into())),
+                ("namespace", ConfigValue::Str("svg".into())),
+                ("customElement", ConfigValue::Bool(true)),
+                ("accessors", ConfigValue::Bool(true)),
+                ("generate", ConfigValue::Bool(false)),
+                ("warningFilter", ConfigValue::Function),
+                (
+                    "experimental",
+                    ConfigValue::Object(object(&[("async", ConfigValue::Bool(true))])),
+                ),
+                (
+                    "compatibility",
+                    ConfigValue::Object(object(&[("componentApi", ConfigValue::Number(4.0))])),
+                ),
+            ]),
+            None
+        );
+    }
+
+    #[test]
+    fn rejects_unrecognised_keys_including_nested_ones() {
+        assert_eq!(
+            code_of(&[("nonsense", ConfigValue::Number(1.0))]),
+            Some("options_unrecognised")
+        );
+        assert_eq!(
+            code_of(&[(
+                "compatibility",
+                ConfigValue::Object(object(&[("nope", ConfigValue::Number(1.0))])),
+            )]),
+            Some("options_unrecognised")
+        );
+    }
+
+    /// A spread hides part of the key set, so no key can be called unknown —
+    /// but the values that ARE visible are still checked.
+    #[test]
+    fn a_spread_suppresses_only_the_unrecognised_check() {
+        let partial = ConfigObject::partial(vec![
+            ("nonsense".to_string(), ConfigValue::Number(1.0)),
+            ("dev".to_string(), ConfigValue::Str("yes".into())),
+        ]);
+        assert_eq!(
+            validate_component_options(&partial).map(|d| d.code),
+            Some("options_invalid_value")
+        );
+    }
+
+    #[test]
+    fn rejects_illegal_values() {
+        for entry in [
+            ("dev", ConfigValue::Str("yes".into())),
+            ("css", ConfigValue::Str("nonsense".into())),
+            ("css", ConfigValue::Bool(true)),
+            ("namespace", ConfigValue::Str("foreign".into())),
+            ("fragments", ConfigValue::Str("nope".into())),
+            ("customElement", ConfigValue::Str("x".into())),
+            ("name", ConfigValue::Number(5.0)),
+            ("cssHash", ConfigValue::Str("x".into())),
+            ("generate", ConfigValue::Str("nope".into())),
+        ] {
+            assert_eq!(
+                code_of(&[(entry.0, entry.1.clone())]),
+                Some("options_invalid_value"),
+                "{entry:?}"
+            );
+        }
+        assert_eq!(
+            code_of(&[(
+                "experimental",
+                ConfigValue::Object(object(&[("async", ConfigValue::Str("yes".into()))])),
+            )]),
+            Some("options_invalid_value")
+        );
+    }
+
+    /// `parametric` with the identity normalizer never rejects anything —
+    /// `runes: 'yes'` compiles clean upstream.
+    #[test]
+    fn parametric_options_accept_every_value() {
+        assert_eq!(code_of(&[("runes", ConfigValue::Str("yes".into()))]), None);
+        assert_eq!(code_of(&[("sourcemap", ConfigValue::Number(5.0))]), None);
+    }
+
+    #[test]
+    fn removed_options_are_errors_and_warn_removed_ones_are_silent() {
+        assert_eq!(
+            code_of(&[("legacy", ConfigValue::Object(ConfigObject::default()))]),
+            Some("options_removed")
+        );
+        assert_eq!(
+            code_of(&[("tag", ConfigValue::Str("x-a".into()))]),
+            Some("options_removed")
+        );
+        // Warnings, and once per process — deliberately not reproduced.
+        assert_eq!(code_of(&[("hydratable", ConfigValue::Bool(true))]), None);
+        assert_eq!(
+            code_of(&[("enableSourcemap", ConfigValue::Bool(true))]),
+            None
+        );
+        assert_eq!(
+            code_of(&[("generate", ConfigValue::Str("dom".into()))]),
+            None
+        );
+    }
+
+    /// Anything not statically readable must not be judged: the real loader
+    /// evaluates it and could produce a perfectly legal value.
+    #[test]
+    fn unreadable_values_are_never_diagnosed() {
+        for name in ["dev", "namespace", "css", "legacy", "cssHash"] {
+            assert_eq!(code_of(&[(name, ConfigValue::Unknown)]), None, "{name}");
+        }
+    }
+
+    /// Unrecognised beats invalid, as in upstream's two loops.
+    #[test]
+    fn unrecognised_is_reported_before_an_illegal_value() {
+        assert_eq!(
+            code_of(&[
+                ("dev", ConfigValue::Str("yes".into())),
+                ("nonsense", ConfigValue::Bool(true)),
+            ]),
+            Some("options_unrecognised")
+        );
+    }
+
+    #[test]
+    fn messages_match_the_compilers_wording() {
+        let d = validate_component_options(&object(&[(
+            "namespace",
+            ConfigValue::Str("foreign".into()),
+        )]))
+        .unwrap();
+        assert_eq!(
+            d.message,
+            "Invalid compiler option: namespace should be one of \"html\", \"mathml\" or \"svg\"\n\
+             https://svelte.dev/e/options_invalid_value"
+        );
+        let d = validate_component_options(&object(&[(
+            "compatibility",
+            ConfigValue::Object(object(&[("componentApi", ConfigValue::Number(3.0))])),
+        )]))
+        .unwrap();
+        assert_eq!(
+            d.message,
+            "Invalid compiler option: compatibility.componentApi should be either \"4\" or \"5\"\n\
+             https://svelte.dev/e/options_invalid_value"
+        );
+    }
+
+    #[test]
+    fn later_sources_override_earlier_ones_key_by_key() {
+        let mut base = ConfigObject::complete(vec![
+            ("runes".to_string(), ConfigValue::Bool(true)),
+            (
+                "experimental".to_string(),
+                ConfigValue::Object(ConfigObject::complete(vec![(
+                    "async".to_string(),
+                    ConfigValue::Bool(true),
+                )])),
+            ),
+        ]);
+        base.merge(&ConfigObject::complete(vec![(
+            "experimental".to_string(),
+            ConfigValue::Object(ConfigObject::default()),
+        )]));
+        assert_eq!(base.get("runes"), Some(&ConfigValue::Bool(true)));
+        let ConfigValue::Object(exp) = base.get("experimental").unwrap() else {
+            panic!("experimental is an object");
+        };
+        assert_eq!(exp.get("async"), Some(&ConfigValue::Bool(true)));
+    }
+}

--- a/crates/rsvelte_check/src/svelte_check/overlay.rs
+++ b/crates/rsvelte_check/src/svelte_check/overlay.rs
@@ -468,6 +468,7 @@ pub fn materialize_overlay_with(
     fs::create_dir_all(&emit_dir)?;
     let manifest_path = cache_dir.join("manifest.json");
     let namespace = compiler_opts.projection_namespace();
+    let accessors = compiler_opts.projection_accessors();
     let config_signature = compiler_opts.signature();
     // Chosen up front: every shadow's `<reference types="svelte" />` has to be
     // blanked as it is emitted once the blanked copy stands in for the package.
@@ -534,6 +535,7 @@ pub fn materialize_overlay_with(
             &ext_root_dir_pairs,
             global_types.svelte_types.is_some(),
             namespace,
+            accessors,
         )?;
         module_bridges.extend(emit_svelte_module_bridges(
             &pkg.real_dir,
@@ -591,7 +593,7 @@ pub fn materialize_overlay_with(
                 filename: abs_source.display().to_string(),
                 is_ts_file,
                 mode: Svelte2TsxMode::Ts,
-                accessors: false,
+                accessors,
                 namespace,
                 version: SvelteVersion::V5,
                 runes: None,
@@ -907,6 +909,7 @@ fn emit_external_shadows(
     ext_pairs: &[(PathBuf, PathBuf)],
     blank_svelte_reference: bool,
     namespace: Svelte2TsxNamespace,
+    accessors: bool,
 ) -> Result<(), OverlayError> {
     // Mirror the package's own `node_modules` into the shadow dir so the
     // shadow's bare-package imports (`import type { X } from 'sortablejs'`,
@@ -941,7 +944,7 @@ fn emit_external_shadows(
             filename: abs_source.display().to_string(),
             is_ts_file,
             mode: Svelte2TsxMode::Ts,
-            accessors: false,
+            accessors,
             namespace,
             version: SvelteVersion::V5,
             runes: None,

--- a/crates/rsvelte_check/src/svelte_check/runner.rs
+++ b/crates/rsvelte_check/src/svelte_check/runner.rs
@@ -628,6 +628,19 @@ fn diagnostics_for_file(file: &Path, compiler_opts: &CompilerOptionsSettings) ->
             }];
         }
     };
+    // `svelte.compile` validates its options before it parses anything, so
+    // upstream reports this instead of — not alongside — the component's own
+    // diagnostics, once per checked component.
+    if let Some(invalid) = compiler_opts.option_diagnostic() {
+        return vec![Diagnostic {
+            file: file.to_path_buf(),
+            severity: DiagnosticSeverity::Error,
+            code: Some(invalid.code.into()),
+            message: invalid.message,
+            range: None,
+            source: "svelte",
+        }];
+    }
     let opts = CompileOptions {
         generate: GenerateMode::Client,
         filename: Some(file.display().to_string()),
@@ -637,25 +650,7 @@ fn diagnostics_for_file(file: &Path, compiler_opts: &CompilerOptionsSettings) ->
         runes: compiler_opts.runes,
         ..Default::default()
     };
-    let mut diagnostics: Vec<Diagnostic> = Vec::new();
-    // `svelte.compile` validates its options before it compiles anything, so
-    // upstream reports this once per checked component, not once per project.
-    if compiler_opts.invalid_namespace().is_some() {
-        diagnostics.push(Diagnostic {
-            file: file.to_path_buf(),
-            severity: DiagnosticSeverity::Error,
-            code: Some("options_invalid_value".into()),
-            message: "Invalid compiler option: namespace should be one of \"html\", \"mathml\" \
-                      or \"svg\"\nhttps://svelte.dev/e/options_invalid_value"
-                .into(),
-            range: Some(Range {
-                start: Position { line: 0, column: 0 },
-                end: Position { line: 0, column: 0 },
-            }),
-            source: "svelte",
-        });
-    }
-    diagnostics.extend(match compile(&source, opts) {
+    match compile(&source, opts) {
         Ok(res) => res
             .warnings
             .into_iter()
@@ -667,7 +662,7 @@ fn diagnostics_for_file(file: &Path, compiler_opts: &CompilerOptionsSettings) ->
                 range: range_from_warning(w.start.as_ref(), w.end.as_ref()),
                 source: "svelte",
             })
-            .collect::<Vec<_>>(),
+            .collect(),
         Err(e) => vec![Diagnostic {
             file: file.to_path_buf(),
             severity: DiagnosticSeverity::Error,
@@ -676,8 +671,7 @@ fn diagnostics_for_file(file: &Path, compiler_opts: &CompilerOptionsSettings) ->
             range: None,
             source: "svelte",
         }],
-    });
-    diagnostics
+    }
 }
 
 fn range_from_warning(


### PR DESCRIPTION
Closes #2687.

## What was wrong

`overlay.rs` hardcoded `accessors: false` at both svelte2tsx call sites, and nothing read
`compilerOptions.accessors` or `compilerOptions.customElement`. Upstream builds one expression
from both (`DocumentSnapshot.ts:250-258`):

```ts
accessors: document.config?.compilerOptions?.accessors ??
           (typeof …customElement === 'function' ? …customElement({filename}) : …customElement)
```

`accessors` decides which `let` bindings become component *exports*
(`exported_names.rs:661` — `if accessors && info.is_let { return true }`), i.e. the generated
component's public type, so a project that sets either key was type-checked against a projection
that does not describe it.

## The general form, which is the part that mattered

The issue's real complaint is that `#2529` special-cased validation for one key. This PR does
not add a third special case; it replaces the per-key reads with the two halves upstream gets
for free from `svelte.compile(text, {...compilerOptions})`:

1. **`config.rs` now reads the whole `compilerOptions` object** into a static value tree
   (`ConfigValue` / `ConfigObject`), merges it across `svelte.config.*` → inline
   `svelte()` / `sveltekit()` plugin options with the existing precedence, and derives the typed
   fields (`runes`, `experimental.async`, `namespace`, `accessors`, `customElement`) *from that
   tree* rather than from a second pass over the AST.
2. **`options_schema.rs` is a port of `validate-options.js`.** All 32 component options with
   their validator families, so an unrecognised key, an illegal value or an option removed in
   Svelte 5 produces `options_unrecognised` / `options_invalid_value` / `options_removed` on
   every checked component — and, as upstream does, *instead of* that component's own
   diagnostics, because the throw happens before parsing.

`invalid_namespace()` from #2686 is deleted: the general pass subsumes it, and the
`svelte-config-namespace-foreign` scenario still passes on the same diagnostic (it also goes red
under the positive control below, which is the check that the replacement is real).

### The key list is derived, not hand-maintained

`schema_matches_upstream` parses
`submodules/svelte/packages/svelte/src/compiler/validate-options.js` with oxc, extracts the
ordered `{ ...common_options, ...component_options }` key list and each key's validator family
(`boolean` / `string` / `list([…])` / `fun` / `object({…})` / `removed` / `warn_removed` /
`deprecate(…)`), and asserts it equals the Rust table. A new upstream option, a rename, a changed
`list` set or an option moving to `removed` fails on the Svelte bump. It runs under `--lib`, in
the `test-unit` job, which checks the submodule out and sets `RSVELTE_REQUIRE_PREREQS=1`, so a
missing submodule fails there rather than skipping.

What it cannot derive is the *body* of a `validator` / `parametric` normalizer — `generate`,
`css`, `customElement`, `runes`, `sourcemap`. Those are compared only as "hand-written", and
their semantics are pinned by unit tests measured against the pinned oracle instead.

### Two deliberate under-approximations

* **A value that is not a literal is skipped, not judged.** The real loader evaluates the
  config; this one parses it. `namespace: ns` or a spread must not become a diagnostic upstream
  would never raise, so `ConfigValue::Unknown` is treated exactly like an absent key, and a
  spread suppresses the unrecognised-key check for that object while still validating the values
  that *are* visible.
* **`deprecate` / `warn_removed` options are not reproduced.** They are warnings, and upstream's
  `warn_once` set is module-global, so each fires **once per svelte-check process**, on whichever
  component compiled first. Measured against the pinned oracle: two successive
  `compile(…, { accessors: true })` calls give `options_deprecated_accessors` on the first and
  nothing on the second. Reproducing that would mean matching svelte-check's file order.

### One correction to the issue text

`runes: 'yes'` produces **nothing** upstream, not `options_invalid_value` — `runes` is
`parametric()` with the identity normalizer, which never rejects a value. Measured, not reasoned:
`css: 'nonsense'` does throw, `runes: 'yes'` does not. Pinned as
`parametric_options_accept_every_value`.

## The gate

Two Layer-1 scenario pairs (`compatibility/check-fixtures/`), in the shape #2529/#2686 used:
two projects byte-identical apart from one option value, with a control diagnostic that must
**not** move between them. Ratchet `compatibility/check-known-failures.json` stays `[]`.

| scenario | `compilerOptions` | oracle = rsvelte |
|---|---|---|
| `svelte-config-accessors` | `customElement: true` | `WARNING Child.svelte:8 css_unused_selector`, `ERROR Parent.svelte:7 2322` |
| `svelte-config-accessors-off` | `customElement: false` | `WARNING Child.svelte:8 css_unused_selector` |
| `svelte-config-unrecognised-option` | `rune: true` | `ERROR Widget.svelte:1 options_unrecognised`, `ERROR Widget.svelte:3 2322` |
| `svelte-config-recognised-option` | `runes: true` | `WARNING Widget.svelte:9 css_unused_selector`, `ERROR Widget.svelte:3 2322` |

The accessors pair keys off `customElement` rather than `accessors` on purpose: `accessors: true`
would put the once-per-process deprecation warning inside the scenario and force a ratchet entry,
which would then suppress every other divergence in it. `accessors` itself lands in the same
field and is covered by unit tests.

The `2322` in the accessors pair is `return child.value` from a `(): number` function —
`SvelteComponent` carries `[prop: string]: any`, so *member access* through `bind:this` never
errors either way and would have been a non-discriminating probe. What accessors moves is the
member's **type**: `string` when `exports` carries it, `any` when it does not.

The unrecognised pair's control is the reverse direction: `css_unused_selector` is present only
in the tree whose options are legal (upstream throws before compiling), while the TypeScript
`2322` is present in **both** — an options error does not stop the projection.

### Positive control

Reverted both halves locally in one build (`accessors` back to `false`,
`option_diagnostic()` short-circuited to `None`) and re-ran the gate:

```
svelte-config-accessors            | -ERROR src/Parent.svelte:7 2322
svelte-config-namespace-foreign    | -ERROR src/Attrs.svelte:1 options_invalid_value
svelte-config-unrecognised-option  | +WARNING src/Widget.svelte:9 css_unused_selector
svelte-config-unrecognised-option  | -ERROR src/Widget.svelte:1 options_unrecognised
❌ 4 NEW divergence(s)
```

Both controls (`-off`, `-recognised-option`, `-namespace-html`) stayed green throughout, which is
what makes the pairs discriminating rather than merely present. Restored: `0 divergences` over
all 36 scenarios.

Separately, deleting one row from the Rust option table makes `schema_matches_upstream` fail with
the missing key named.

## What the gate does NOT see

Recorded as blind spot **12f** in `compatibility/gate-coverage.md`:

* **Only the keys a scenario sets.** Six scenarios now set a `compilerOptions` key; the other 26
  options the compiler accepts are compared against the oracle nowhere.
* **Deprecation / `warn_removed` warnings** — see above; structurally out of reach for a
  per-file gate because the diagnostic's file is decided by compile order.
* **Anything the static reader cannot evaluate.** The oracle imports the config, rsvelte parses
  it. A scenario written with a computed value would compare "no diagnostic" to "no diagnostic"
  for the wrong reason.
* **Which source supplied the value.** Every scenario uses `svelte.config.js`; the
  `svelte.config` / inline-plugin / `--config` precedence is covered by unit tests only, and
  `--config` by nothing (blind spot 12d).

The e2e (Layer 2) projects were checked for false-positive risk before pushing: neither
`cmsaasstarter` nor either `skeleton` unit declares `compilerOptions` at all, in
`svelte.config.js` or in a Vite config, so the validator sees an empty object there.

## Adjacent defects found, NOT fixed

1. **A compile error reports the code `compile-error`, not the compiler's own code.**
   `runner.rs`'s `Err(e) => … code: Some("compile-error")` — upstream's `getDiagnostics.ts`
   reports `error.code` (`js_parse_error`, …). The check gate compares the code, so any scenario
   where a component fails to compile would diverge on it; none currently does.
2. **`lookup_property` returns the first match, JS keeps the last.** `{ runes: true, runes: false }`
   in a config reads as `true` in `kit_file.rs`'s helper. The new `ConfigObject::get` follows JS
   (last wins), so the two now disagree about a duplicate key.
3. **`compileModule` / `.svelte.js` options are not validated.** Upstream uses
   `validate_module_options`, where component keys are accepted and ignored; rsvelte-check only
   compiles `.svelte` files, so the surface is currently unreachable rather than wrong.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016NFR39XQtQHKgv3kgRoCGP
