### PR TITLE
fix(check): make a SvelteKit project checkable end to end

### DIFF
--- a/.changeset/svelte-check-config-binding.md
+++ b/.changeset/svelte-check-config-binding.md
@@ -1,0 +1,5 @@
+---
+'@rsvelte/svelte-check': patch
+---
+
+Resolve a config exported through a binding — `const config = {...}; export default config;`, `module.exports = config`, and a plugin call whose options are a binding — when reading `compilerOptions` and `kit.files` out of `svelte.config.*` / `vite.config.*`. Only the inline-object and `defineConfig({...})` forms were read before, so a project written the referenced way silently ran with default compiler options

--- a/.changeset/svelte-check-external-publish-surface.md
+++ b/.changeset/svelte-check-external-publish-surface.md
@@ -1,0 +1,5 @@
+---
+'@rsvelte/svelte-check': patch
+---
+
+Bound the shadow emission for an out-of-workspace package to the roots its `package.json` publishes (`files`, incl. negated entries, else `exports` / `svelte` / `main` / `module` / `types`). A monorepo sibling symlinked into `node_modules` is a whole repository directory, so walking all of it pulled in test fixtures the consumer can never import — including deliberately unparseable ones, which failed the entire run. A `svelte2tsx` failure inside such a package is no longer fatal either: that one file falls back to the ambient `*.svelte` declaration

--- a/.changeset/svelte-check-kit-integration.md
+++ b/.changeset/svelte-check-kit-integration.md
@@ -1,0 +1,5 @@
+---
+'@rsvelte/svelte-check': patch
+---
+
+Follow a bare-package `extends` (`"extends": "$app/tsconfig"`, which SvelteKit writes into every app's `tsconfig.json`) when reading the project config. The base's `rootDirs`, `paths` and `types` were previously invisible, so the overlay restated `typeRoots` without them and `types: ["$app/types"]` became `TS2688` — one config-level error, which makes TypeScript suppress every semantic diagnostic program-wide and turns the whole run into a silent "0 errors". A config-level diagnostic (no file, no position) is now reported against the workspace instead of being dropped

--- a/crates/rsvelte_check/src/svelte_check/config.rs
+++ b/crates/rsvelte_check/src/svelte_check/config.rs
@@ -34,7 +34,7 @@ use oxc_ast::ast as oxc;
 use oxc_parser::Parser as OxcParser;
 use oxc_span::SourceType;
 
-use super::kit_file::{lookup_property, unwrap_define_config_object};
+use super::kit_file::{lookup_property, resolve_config_object};
 use super::options_schema::{ConfigObject, ConfigValue, OptionDiagnostic};
 use crate::svelte2tsx::Svelte2TsxNamespace;
 
@@ -266,7 +266,7 @@ fn parse_config(
     let parser = OxcParser::new(&allocator, source, source_type);
     let result = parser.parse();
     for stmt in &result.program.body {
-        let Some(obj) = config_object_from_stmt(stmt) else {
+        let Some(obj) = config_object_from_stmt(&result.program, stmt) else {
             continue;
         };
         match kind {
@@ -278,8 +278,12 @@ fn parse_config(
                 // call inside the `plugins` array.
                 if let Some(plugins) = lookup_property(obj, "plugins")
                     && let Some(plugin) = find_svelte_plugin_call(plugins)
-                    && let Some(oxc::Argument::ObjectExpression(opts)) =
-                        plugin.call.arguments.first()
+                    && let Some(opts) = plugin
+                        .call
+                        .arguments
+                        .first()
+                        .and_then(|arg| arg.as_expression())
+                        .and_then(|expr| resolve_config_object(&result.program, expr))
                 {
                     extract_compiler_options(opts, settings);
                 }
@@ -291,19 +295,18 @@ fn parse_config(
 /// Resolve the top-level config object exported by a statement:
 ///   * `export default {...}` / `export default defineConfig({...})`
 ///   * `module.exports = {...}` / `module.exports = defineConfig({...})`
+///
+/// Either form may name a top-level binding instead of spelling the object
+/// inline (`const config = {...}; export default config;`).
 fn config_object_from_stmt<'a>(
+    program: &'a oxc::Program<'a>,
     stmt: &'a oxc::Statement<'a>,
 ) -> Option<&'a oxc::ObjectExpression<'a>> {
     match stmt {
-        oxc::Statement::ExportDefaultDeclaration(ex) => {
-            if let oxc::ExportDefaultDeclarationKind::ObjectExpression(obj) = &ex.declaration {
-                Some(obj)
-            } else {
-                ex.declaration
-                    .as_expression()
-                    .and_then(unwrap_define_config_object)
-            }
-        }
+        oxc::Statement::ExportDefaultDeclaration(ex) => ex
+            .declaration
+            .as_expression()
+            .and_then(|expr| resolve_config_object(program, expr)),
         oxc::Statement::ExpressionStatement(es) => {
             let oxc::Expression::AssignmentExpression(assign) = &es.expression else {
                 return None;
@@ -320,11 +323,7 @@ fn config_object_from_stmt<'a>(
             if !is_module_exports {
                 return None;
             }
-            if let oxc::Expression::ObjectExpression(obj) = &assign.right {
-                Some(obj)
-            } else {
-                unwrap_define_config_object(&assign.right)
-            }
+            resolve_config_object(program, &assign.right)
         }
         _ => None,
     }
@@ -403,7 +402,7 @@ fn declares_svelte_plugin(source: &str, source_type: SourceType) -> bool {
     let parser = OxcParser::new(&allocator, source, source_type);
     let result = parser.parse();
     result.program.body.iter().any(|stmt| {
-        config_object_from_stmt(stmt)
+        config_object_from_stmt(&result.program, stmt)
             .and_then(|obj| lookup_property(obj, "plugins"))
             .and_then(find_svelte_plugin_call)
             .is_some()
@@ -415,7 +414,7 @@ fn vite_uses_inline_sveltekit_config(source: &str, source_type: SourceType) -> b
     let parser = OxcParser::new(&allocator, source, source_type);
     let result = parser.parse();
     for stmt in &result.program.body {
-        let Some(obj) = config_object_from_stmt(stmt) else {
+        let Some(obj) = config_object_from_stmt(&result.program, stmt) else {
             continue;
         };
         if let Some(plugins) = lookup_property(obj, "plugins")
@@ -575,7 +574,7 @@ fn declares_function_warning_filter(path: &Path) -> bool {
     let parser = OxcParser::new(&allocator, &source, source_type);
     let result = parser.parse();
     result.program.body.iter().any(|stmt| {
-        config_object_from_stmt(stmt)
+        config_object_from_stmt(&result.program, stmt)
             .and_then(|obj| lookup_property(obj, "compilerOptions"))
             .and_then(|co| match co {
                 oxc::Expression::ObjectExpression(co) => lookup_property(co, "warningFilter"),
@@ -651,6 +650,72 @@ mod tests {
         );
         let s = load_compiler_options(&dir);
         assert!(s.experimental_async);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn reads_config_exported_through_a_binding() {
+        // `const config = {…}; export default config;` — the shape a large
+        // share of real `svelte.config.js` / `vite.config.js` files use (#2710).
+        let dir = workspace("binding_svelte");
+        write(
+            &dir,
+            "svelte.config.js",
+            "const config = { compilerOptions: { experimental: { async: true } } };\n\
+             export default config;",
+        );
+        assert!(load_compiler_options(&dir).experimental_async);
+        let _ = std::fs::remove_dir_all(&dir);
+
+        let dir = workspace("binding_vite");
+        write(
+            &dir,
+            "vite.config.js",
+            r#"import { sveltekit } from '@sveltejs/kit/vite';
+            import { defineConfig } from 'vite';
+            const config = defineConfig({
+                plugins: [sveltekit({ compilerOptions: { experimental: { async: true } } })]
+            });
+            export default config;"#,
+        );
+        assert!(load_compiler_options(&dir).experimental_async);
+        let _ = std::fs::remove_dir_all(&dir);
+
+        let dir = workspace("binding_cjs");
+        write(
+            &dir,
+            "svelte.config.js",
+            "const config = { compilerOptions: { runes: true } };\n\
+             module.exports = config;",
+        );
+        assert_eq!(load_compiler_options(&dir).runes, Some(true));
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn reads_plugin_options_exported_through_a_binding() {
+        // The plugin's own argument may be a binding too.
+        let dir = workspace("binding_plugin_arg");
+        write(
+            &dir,
+            "vite.config.ts",
+            r#"import { svelte } from '@sveltejs/vite-plugin-svelte';
+            const svelteOptions = { compilerOptions: { runes: true } };
+            export default { plugins: [svelte(svelteOptions)] };"#,
+        );
+        assert_eq!(load_compiler_options(&dir).runes, Some(true));
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn binding_cycle_does_not_hang() {
+        let dir = workspace("binding_cycle");
+        write(
+            &dir,
+            "svelte.config.js",
+            "const a = b;\nconst b = a;\nexport default a;",
+        );
+        assert_eq!(load_compiler_options(&dir).runes, None);
         let _ = std::fs::remove_dir_all(&dir);
     }
 

--- a/crates/rsvelte_check/src/svelte_check/kit_file.rs
+++ b/crates/rsvelte_check/src/svelte_check/kit_file.rs
@@ -111,19 +111,21 @@ fn parse_kit_files_source(source: &str, settings: &mut KitFilesSettings) {
     let parser = OxcParser::new(&allocator, source, SourceType::default());
     let result = parser.parse();
     for stmt in &result.program.body {
-        extract_kit_files_from_stmt(stmt, settings);
+        extract_kit_files_from_stmt(&result.program, stmt, settings);
     }
 }
 
-fn extract_kit_files_from_stmt(stmt: &oxc::Statement, settings: &mut KitFilesSettings) {
+fn extract_kit_files_from_stmt(
+    program: &oxc::Program<'_>,
+    stmt: &oxc::Statement,
+    settings: &mut KitFilesSettings,
+) {
     match stmt {
         oxc::Statement::ExportDefaultDeclaration(ex) => {
-            // `export default { kit: { files: {...} } }` or
-            // `export default defineConfig({ kit: { files: {...} } })`.
-            if let oxc::ExportDefaultDeclarationKind::ObjectExpression(obj) = &ex.declaration {
-                extract_kit_files_from_object(obj, settings);
-            } else if let Some(expr) = ex.declaration.as_expression()
-                && let Some(obj) = unwrap_define_config_object(expr)
+            // `export default { kit: { files: {...} } }`,
+            // `export default defineConfig({...})` or `export default config`.
+            if let Some(expr) = ex.declaration.as_expression()
+                && let Some(obj) = resolve_config_object(program, expr)
             {
                 extract_kit_files_from_object(obj, settings);
             }
@@ -145,9 +147,7 @@ fn extract_kit_files_from_stmt(stmt: &oxc::Statement, settings: &mut KitFilesSet
                 if !is_module_exports {
                     return;
                 }
-                if let oxc::Expression::ObjectExpression(obj) = &assign.right {
-                    extract_kit_files_from_object(obj, settings);
-                } else if let Some(obj) = unwrap_define_config_object(&assign.right) {
+                if let Some(obj) = resolve_config_object(program, &assign.right) {
                     extract_kit_files_from_object(obj, settings);
                 }
             }
@@ -156,24 +156,74 @@ fn extract_kit_files_from_stmt(stmt: &oxc::Statement, settings: &mut KitFilesSet
     }
 }
 
-/// Match `defineConfig({...})` and return the inner object expression.
-pub(crate) fn unwrap_define_config_object<'a>(
-    expr: &'a oxc::Expression,
+/// Resolve the object literal an exported config expression denotes,
+/// looking through `defineConfig(...)`, TypeScript assertion / parenthesis
+/// wrappers, and top-level `const`/`let`/`var` indirection — the
+/// `const config = {...}; export default config;` form real configs are
+/// commonly written in (issue #2710).
+pub(crate) fn resolve_config_object<'a>(
+    program: &'a oxc::Program<'a>,
+    expr: &'a oxc::Expression<'a>,
 ) -> Option<&'a oxc::ObjectExpression<'a>> {
-    let oxc::Expression::CallExpression(call) = expr else {
-        return None;
-    };
-    let oxc::Expression::Identifier(callee) = &call.callee else {
-        return None;
-    };
-    if callee.name.as_str() != "defineConfig" {
-        return None;
+    resolve_config_object_inner(program, expr, &mut Vec::new())
+}
+
+fn resolve_config_object_inner<'a>(
+    program: &'a oxc::Program<'a>,
+    expr: &'a oxc::Expression<'a>,
+    seen: &mut Vec<&'a str>,
+) -> Option<&'a oxc::ObjectExpression<'a>> {
+    match expr.get_inner_expression() {
+        oxc::Expression::ObjectExpression(obj) => Some(obj),
+        oxc::Expression::CallExpression(call) => {
+            let oxc::Expression::Identifier(callee) = &call.callee else {
+                return None;
+            };
+            if callee.name.as_str() != "defineConfig" {
+                return None;
+            }
+            let arg = call.arguments.first()?.as_expression()?;
+            resolve_config_object_inner(program, arg, seen)
+        }
+        oxc::Expression::Identifier(id) => {
+            let name = id.name.as_str();
+            // `const a = b; const b = a;` would otherwise recurse forever.
+            if seen.contains(&name) {
+                return None;
+            }
+            seen.push(name);
+            let init = top_level_binding_init(program, name)?;
+            resolve_config_object_inner(program, init, seen)
+        }
+        _ => None,
     }
-    let arg = call.arguments.first()?;
-    let oxc::Argument::ObjectExpression(obj) = arg else {
-        return None;
-    };
-    Some(obj)
+}
+
+/// The initializer of a top-level `const`/`let`/`var <name> = …` binding,
+/// including one that is itself exported (`export const config = {…}`).
+fn top_level_binding_init<'a>(
+    program: &'a oxc::Program<'a>,
+    name: &str,
+) -> Option<&'a oxc::Expression<'a>> {
+    for stmt in &program.body {
+        let decl = match stmt {
+            oxc::Statement::VariableDeclaration(decl) => decl,
+            oxc::Statement::ExportDeclaration(export) => match &export.declaration {
+                oxc::Declaration::VariableDeclaration(decl) => decl,
+                _ => continue,
+            },
+            _ => continue,
+        };
+        for declarator in &decl.declarations {
+            let oxc::BindingPattern::BindingIdentifier(id) = &declarator.id else {
+                continue;
+            };
+            if id.name.as_str() == name {
+                return declarator.init.as_ref();
+            }
+        }
+    }
+    None
 }
 
 fn extract_kit_files_from_object(obj: &oxc::ObjectExpression, settings: &mut KitFilesSettings) {
@@ -1165,6 +1215,18 @@ fn binding_pattern_name<'a>(pat: &'a oxc::BindingPattern) -> Option<&'a str> {
 mod tests {
     use super::*;
     use std::path::PathBuf;
+
+    #[test]
+    fn kit_files_read_through_an_exported_binding() {
+        // `const config = {…}; export default config;` (#2710).
+        let mut settings = KitFilesSettings::default();
+        parse_kit_files_source(
+            "const config = { kit: { files: { params: 'src/my-params' } } };\n\
+             export default config;",
+            &mut settings,
+        );
+        assert_eq!(settings.params_path, "src/my-params");
+    }
 
     #[test]
     fn detects_kit_route_basenames() {

--- a/crates/rsvelte_check/src/svelte_check/overlay.rs
+++ b/crates/rsvelte_check/src/svelte_check/overlay.rs
@@ -540,7 +540,7 @@ pub fn materialize_overlay_with(
         module_bridges.extend(emit_svelte_module_bridges(
             &pkg.real_dir,
             &pkg.mirror_dir,
-            &[],
+            pkg.svelte_modules.clone(),
             allow_js,
             &mut withheld_js_modules,
         )?);
@@ -548,7 +548,7 @@ pub fn materialize_overlay_with(
     module_bridges.extend(emit_svelte_module_bridges(
         workspace,
         &emit_dir,
-        ignore,
+        super::walker::find_svelte_suffixed_modules(workspace, ignore),
         allow_js,
         &mut withheld_js_modules,
     )?);
@@ -777,6 +777,8 @@ struct ExternalPackage {
     /// Cache mirror dir that holds the emitted shadows.
     mirror_dir: PathBuf,
     svelte_files: Vec<PathBuf>,
+    /// `<name>.svelte.<ext>` rune modules needing an ESM bridge.
+    svelte_modules: Vec<PathBuf>,
 }
 
 /// Discover workspace-sibling packages reachable through the project's
@@ -847,18 +849,201 @@ fn discover_external_svelte_packages(
         if !seen.insert(real.clone()) {
             continue;
         }
-        let svelte_files = super::walker::find_svelte_files(&real, &[]);
+        let svelte_files = find_publishable(&real, super::walker::find_svelte_files);
         if svelte_files.is_empty() {
             continue;
         }
+        let svelte_modules = find_publishable(&real, super::walker::find_svelte_suffixed_modules);
         let mirror_dir = cache_dir.join("ext").join(out.len().to_string());
         out.push(ExternalPackage {
             real_dir: real,
             mirror_dir,
             svelte_files,
+            svelte_modules,
         });
     }
     out
+}
+
+/// Run `walk` over only the roots an external package's manifest publishes,
+/// rather than over its whole checkout.
+///
+/// A monorepo sibling reached through a `node_modules` symlink is a whole
+/// repository directory, not the tarball npm would ship: `@sveltejs/kit`'s
+/// package dir carries `test/**` fixture apps, some of which hold
+/// deliberately unparseable components (issue #2714). Shadowing those is
+/// both wasted work and a source of diagnostics for files the user never
+/// asked about. `files` (an allow-list a publish honours literally) is the
+/// authoritative answer; `exports` / `svelte` / `main` / `module` / `types`
+/// stand in when it is absent. A manifest that declares none of them
+/// publishes its whole directory, so the walk falls back to that.
+fn find_publishable(pkg_dir: &Path, walk: fn(&Path, &[String]) -> Vec<PathBuf>) -> Vec<PathBuf> {
+    let Some(surface) = publish_surface(pkg_dir) else {
+        return walk(pkg_dir, &[]);
+    };
+    let mut out: Vec<PathBuf> = Vec::new();
+    for root in &surface.roots {
+        out.extend(walk(root, &[]));
+    }
+    out.sort();
+    out.dedup();
+    out.retain(|file| !surface.excludes(pkg_dir, file));
+    out
+}
+
+/// What a package's manifest says it ships.
+struct PublishSurface {
+    /// Directories a published file can live under.
+    roots: Vec<PathBuf>,
+    /// Negated `files` patterns, segmented, package-relative.
+    deny: Vec<Vec<String>>,
+}
+
+impl PublishSurface {
+    /// Does a negated `files` entry cover `file`? A pattern naming a
+    /// directory excludes everything below it, so every ancestor prefix is
+    /// tested, not just the whole path.
+    fn excludes(&self, pkg_dir: &Path, file: &Path) -> bool {
+        if self.deny.is_empty() {
+            return false;
+        }
+        let Ok(rel) = file.strip_prefix(pkg_dir) else {
+            return false;
+        };
+        let owned: Vec<String> = rel
+            .components()
+            .map(|c| c.as_os_str().to_string_lossy().into_owned())
+            .collect();
+        let segments: Vec<&str> = owned.iter().map(String::as_str).collect();
+        self.deny
+            .iter()
+            .any(|pattern| (1..=segments.len()).any(|len| glob_matches(pattern, &segments[..len])))
+    }
+}
+
+/// What `pkg_dir`'s `package.json` exposes, or `None` when the manifest names
+/// nothing (or can't be read) and the whole package directory is therefore the
+/// surface.
+fn publish_surface(pkg_dir: &Path) -> Option<PublishSurface> {
+    let manifest = fs::read_to_string(pkg_dir.join("package.json")).ok()?;
+    let manifest: serde_json::Value = serde_json::from_str(&manifest).ok()?;
+    let mut roots: Vec<PathBuf> = Vec::new();
+    let mut deny: Vec<Vec<String>> = Vec::new();
+    if let Some(files) = manifest.get("files").and_then(|v| v.as_array()) {
+        for entry in files.iter().filter_map(|v| v.as_str()) {
+            match entry.strip_prefix('!') {
+                Some(negated) => deny.push(
+                    negated
+                        .trim_start_matches("./")
+                        .split('/')
+                        .filter(|s| !s.is_empty())
+                        .map(str::to_owned)
+                        .collect(),
+                ),
+                None => push_root(pkg_dir, entry, false, &mut roots),
+            }
+        }
+    }
+    if roots.is_empty() {
+        for key in ["svelte", "main", "module", "types", "typings"] {
+            if let Some(spec) = manifest.get(key).and_then(|v| v.as_str()) {
+                push_root(pkg_dir, spec, true, &mut roots);
+            }
+        }
+        if let Some(exports) = manifest.get("exports") {
+            collect_export_targets(exports, pkg_dir, &mut roots);
+        }
+    }
+    // A surface that isn't on disk — an unbuilt `dist/` in a monorepo — says
+    // nothing about where the sources are, so treat it as undeclared rather
+    // than as an empty package.
+    roots.retain(|root| root.is_dir());
+    (!roots.is_empty()).then_some(PublishSurface { roots, deny })
+}
+
+/// Match one path against a segmented glob, `**` spanning any number of
+/// segments and `*` staying inside one. Enough for the `files` patterns npm
+/// itself honours (`src/**/*.spec.js`, `src/core/**/test`).
+fn glob_matches(pattern: &[String], path: &[&str]) -> bool {
+    match pattern.split_first() {
+        None => path.is_empty(),
+        Some((head, rest)) if head.as_str() == "**" => {
+            (0..=path.len()).any(|skip| glob_matches(rest, &path[skip..]))
+        }
+        Some((head, rest)) => match path.split_first() {
+            Some((first, tail)) => segment_matches(head, first) && glob_matches(rest, tail),
+            None => false,
+        },
+    }
+}
+
+/// `*` matches any run of characters within a single path segment.
+fn segment_matches(pattern: &str, segment: &str) -> bool {
+    let mut parts = pattern.split('*');
+    let Some(first) = parts.next() else {
+        return true;
+    };
+    if !segment.starts_with(first) {
+        return false;
+    }
+    if !pattern.contains('*') {
+        return segment.len() == first.len();
+    }
+    let mut rest = &segment[first.len()..];
+    let parts: Vec<&str> = parts.collect();
+    for (i, part) in parts.iter().enumerate() {
+        if i + 1 == parts.len() {
+            // The trailing literal must land at the very end.
+            return rest.len() >= part.len() && rest.ends_with(part);
+        }
+        match rest.find(part) {
+            Some(at) => rest = &rest[at + part.len()..],
+            None => return false,
+        }
+    }
+    true
+}
+
+/// Record the deepest directory of `pkg_dir` that `spec` cannot escape. A
+/// `files` entry may be a glob (`src/**/*.js`), so only the leading literal
+/// segments bound a walk. An entry-point path (`entry`) names one module,
+/// and it is the directory around it that holds the package's other
+/// components, so its final segment is dropped.
+fn push_root(pkg_dir: &Path, spec: &str, entry: bool, roots: &mut Vec<PathBuf>) {
+    let mut segments: Vec<&str> = Vec::new();
+    for segment in spec.trim_start_matches("./").split('/') {
+        if segment.is_empty() || segment.contains('*') || segment == ".." {
+            break;
+        }
+        segments.push(segment);
+    }
+    if entry && segments.last().is_some_and(|s| s.contains('.')) {
+        segments.pop();
+    }
+    let mut path = pkg_dir.to_path_buf();
+    path.extend(segments);
+    if path != pkg_dir && !roots.contains(&path) {
+        roots.push(path);
+    }
+}
+
+/// Every string leaf of an `exports` map — its subpath and condition levels
+/// nest arbitrarily deep, and each leaf is a path into the package.
+fn collect_export_targets(value: &serde_json::Value, pkg_dir: &Path, roots: &mut Vec<PathBuf>) {
+    match value {
+        serde_json::Value::String(s) => push_root(pkg_dir, s, true, roots),
+        serde_json::Value::Array(items) => {
+            for item in items {
+                collect_export_targets(item, pkg_dir, roots);
+            }
+        }
+        serde_json::Value::Object(map) => {
+            for item in map.values() {
+                collect_export_targets(item, pkg_dir, roots);
+            }
+        }
+        _ => {}
+    }
 }
 
 /// Symlink `<dst>` → `<src>` (a directory), cross-platform.
@@ -958,10 +1143,13 @@ fn emit_external_shadows(
                 workspace_path: pkg.real_dir.display().to_string(),
             }),
         };
-        let result = svelte2tsx(&source, opts).map_err(|e| OverlayError::Svelte2Tsx {
-            file: abs_source.clone(),
-            message: format!("{e}"),
-        })?;
+        // A component the user never asked about must not be able to fail the
+        // whole run: an external package is somebody else's source, and the
+        // consumer can only lose the shadow's extra precision, falling back to
+        // the ambient `*.svelte` wildcard for that one file (issue #2714).
+        let Ok(result) = svelte2tsx(&source, opts) else {
+            continue;
+        };
         let mut tsx_code = rewrite_companion_module_imports(&result.code, abs_source, &tsx_path);
         if blank_svelte_reference {
             blank_svelte_type_reference(&mut tsx_code);
@@ -1513,10 +1701,15 @@ const MAX_EXTENDS_CONFIGS: usize = 32;
 /// wholesale) and gives the array form (TS 5.0+) its documented semantics of
 /// later entries winning.
 ///
-/// Only relative-path `extends` targets are followed; a bare package name ends
-/// that branch (see [`resolve_root_dirs_abs`] for the rationale). Paths are
-/// absolutised up front so a relative `--tsconfig` argument cannot compound
-/// through the hops into an unresolvable target.
+/// A bare package-name `extends` is resolved through `node_modules` the way
+/// TypeScript resolves it. SvelteKit writes `"extends": "$app/tsconfig"` into
+/// every app's `tsconfig.json`, so leaving that branch unfollowed loses the
+/// whole base config — its `rootDirs`, `paths` and `types` — while tsgo, which
+/// resolves it, sees a program the overlay was not built for (issue #2714's
+/// sibling: `typeRoots` restated from the truncated chain made `$app/types`
+/// unresolvable, and one TS2688 suppresses every semantic diagnostic
+/// program-wide). Paths are absolutised up front so a relative `--tsconfig`
+/// argument cannot compound through the hops into an unresolvable target.
 fn extends_chain(tsconfig_path: &Path) -> Vec<(PathBuf, serde_json::Value)> {
     let mut out = Vec::new();
     let mut pending = vec![absolutize(tsconfig_path)];
@@ -1545,8 +1738,7 @@ fn extends_chain(tsconfig_path: &Path) -> Vec<(PathBuf, serde_json::Value)> {
             _ => Vec::new(),
         }
         .iter()
-        .filter(|ext| ext.starts_with('.'))
-        .map(|ext| resolve_extends_path(&dir, ext))
+        .filter_map(|ext| resolve_extends_target(&dir, ext))
         .collect();
         pending.extend(parents);
 
@@ -1585,6 +1777,34 @@ fn resolve_extends_path(dir: &Path, ext: &str) -> PathBuf {
         next.set_extension("json");
     }
     next
+}
+
+/// Resolve any `extends` target to the config file it names — relative and
+/// rooted specs lexically, a bare package specifier (`"$app/tsconfig"`,
+/// `"@tsconfig/svelte/tsconfig.json"`) through the `node_modules` chain above
+/// `dir`. `None` when a bare specifier names nothing that exists, which is the
+/// branch TypeScript would report as unresolvable and we simply stop following.
+fn resolve_extends_target(dir: &Path, ext: &str) -> Option<PathBuf> {
+    if ext.starts_with('.') || Path::new(ext).is_absolute() {
+        return Some(resolve_extends_path(dir, ext));
+    }
+    let mut cursor = Some(absolutize(dir));
+    while let Some(d) = cursor {
+        let base = d.join("node_modules").join(ext);
+        if base.is_file() {
+            return Some(base);
+        }
+        let with_json = append_extension(&base, ".json");
+        if with_json.is_file() {
+            return Some(with_json);
+        }
+        let in_dir = base.join("tsconfig.json");
+        if in_dir.is_file() {
+            return Some(in_dir);
+        }
+        cursor = d.parent().map(Path::to_path_buf);
+    }
+    None
 }
 
 /// True if a single path segment carries a glob metacharacter.
@@ -1782,11 +2002,6 @@ fn strip_jsonc_comments(src: &str) -> String {
 /// `rootDirs` (a child `compilerOptions.rootDirs` replaces the parent's
 /// wholesale, mirroring TypeScript), each resolved relative to the directory of
 /// the file that defined it. Empty when no config in the chain sets `rootDirs`.
-///
-/// Only relative-path `extends` are followed (the common case, incl.
-/// SvelteKit's `./.svelte-kit/tsconfig.json`); a bare package-name
-/// `extends` ends that branch — we'd need full node resolution to chase it,
-/// and the caller falls back to a sensible default.
 fn resolve_root_dirs_abs(tsconfig_path: &Path) -> Vec<PathBuf> {
     let config_dir = config_dir_of(tsconfig_path);
     extends_chain(tsconfig_path)
@@ -2520,11 +2735,10 @@ fn write_esm_bridge(path: &Path, content: &str, only_if_missing: bool) -> io::Re
 fn emit_svelte_module_bridges(
     root: &Path,
     mirror_dir: &Path,
-    ignore: &[String],
+    mut modules: Vec<PathBuf>,
     allow_js: bool,
     withheld: &mut Vec<PathBuf>,
 ) -> Result<Vec<(PathBuf, PathBuf)>, OverlayError> {
-    let mut modules = super::walker::find_svelte_suffixed_modules(root, ignore);
     // `x.svelte.ts` and `x.svelte.js` share one bridge path; TypeScript probes
     // `.ts` first, so let it win.
     modules.sort_by_key(|p| {
@@ -4178,7 +4392,8 @@ mod tests {
             .map(|(dir, _)| dir.to_string_lossy().into_owned())
             .collect();
         // Every entry resolves to the same dir here, so assert on the count:
-        // self + b + a + a's parent, with the bare package name skipped.
+        // self + b + a + a's parent; the bare package name resolves to nothing
+        // under this tmp dir, so that branch ends there.
         assert_eq!(
             visited.len(),
             4,
@@ -4197,6 +4412,92 @@ mod tests {
             specs,
             vec!["./from-b/**/*".to_string()],
             "the last array entry must be searched before the first"
+        );
+
+        let _ = fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn extends_chain_follows_a_bare_package_specifier() {
+        // SvelteKit writes `"extends": "$app/tsconfig"`, resolved through
+        // `node_modules` — leaving it unfollowed loses the base's `rootDirs`,
+        // `paths` and `types` (issue #2714).
+        let tmp = std::env::temp_dir().join(format!("svc_ext_bare_{}", std::process::id()));
+        let _ = fs::remove_dir_all(&tmp);
+        let app = tmp.join("node_modules").join("$app");
+        fs::create_dir_all(&app).unwrap();
+        fs::write(
+            app.join("tsconfig.json"),
+            r#"{ "compilerOptions": { "rootDirs": ["../..", "../../.svelte-kit/types"], "types": ["$app/types"] } }"#,
+        )
+        .unwrap();
+        fs::write(
+            tmp.join("tsconfig.json"),
+            r#"{ "extends": "$app/tsconfig", "include": ["src"] }"#,
+        )
+        .unwrap();
+
+        // `..` segments resolve against the *defining* config's dir, so
+        // normalise before comparing.
+        let root_dirs: Vec<PathBuf> = resolve_root_dirs_abs(&tmp.join("tsconfig.json"))
+            .iter()
+            .map(|p| absolutize(p))
+            .collect();
+        assert_eq!(
+            root_dirs,
+            vec![absolutize(&tmp), absolutize(&tmp.join(".svelte-kit/types"))],
+            "the base config's rootDirs must be inherited"
+        );
+        assert!(
+            has_explicit_types(&tmp.join("tsconfig.json")),
+            "an inherited `types` must be visible, or `typeRoots` gets restated without it"
+        );
+
+        let _ = fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn external_package_walk_is_bounded_by_its_publish_surface() {
+        // A monorepo sibling symlinked into `node_modules` is a whole
+        // repository dir, not the tarball it ships (issue #2714).
+        let tmp = std::env::temp_dir().join(format!("svc_publish_{}", std::process::id()));
+        let _ = fs::remove_dir_all(&tmp);
+        let touch = |rel: &str| {
+            let p = tmp.join(rel);
+            fs::create_dir_all(p.parent().unwrap()).unwrap();
+            fs::write(&p, "<div></div>").unwrap();
+        };
+        touch("src/lib/Button.svelte");
+        touch("src/core/test/Broken.svelte");
+        touch("test/apps/syntax-error/+page.svelte");
+
+        // No manifest fields → the whole directory is the surface.
+        fs::write(tmp.join("package.json"), r#"{ "name": "pkg" }"#).unwrap();
+        assert_eq!(
+            find_publishable(&tmp, super::super::walker::find_svelte_files).len(),
+            3
+        );
+
+        // `files` bounds it, and a negated entry narrows it further.
+        fs::write(
+            tmp.join("package.json"),
+            r#"{ "name": "pkg", "files": ["src", "!src/core/**/test"] }"#,
+        )
+        .unwrap();
+        assert_eq!(
+            find_publishable(&tmp, super::super::walker::find_svelte_files),
+            vec![tmp.join("src/lib/Button.svelte")]
+        );
+
+        // Without `files`, the entry points stand in for it.
+        fs::write(
+            tmp.join("package.json"),
+            r#"{ "name": "pkg", "exports": { ".": "./src/lib/index.js" } }"#,
+        )
+        .unwrap();
+        assert_eq!(
+            find_publishable(&tmp, super::super::walker::find_svelte_files),
+            vec![tmp.join("src/lib/Button.svelte")]
         );
 
         let _ = fs::remove_dir_all(&tmp);

--- a/crates/rsvelte_check/src/svelte_check/runner.rs
+++ b/crates/rsvelte_check/src/svelte_check/runner.rs
@@ -388,6 +388,26 @@ fn run_type_check_phase(
     };
     match run_tsgo(&binary, &layout.overlay_tsconfig, workspace) {
         Ok(raw) => {
+            // A config-level diagnostic has no file to map onto, and while one
+            // is outstanding TypeScript emits no semantic diagnostics at all —
+            // so reporting it against the workspace is the difference between
+            // "your project can't be checked" and a silent clean pass.
+            let (global, raw): (Vec<_>, Vec<_>) =
+                raw.into_iter().partition(|d| d.file.as_os_str().is_empty());
+            for d in global {
+                out.push(Diagnostic {
+                    file: workspace.to_path_buf(),
+                    severity: if d.severity == "error" {
+                        DiagnosticSeverity::Error
+                    } else {
+                        DiagnosticSeverity::Warning
+                    },
+                    code: Some(d.code),
+                    message: d.message,
+                    range: None,
+                    source: "ts",
+                });
+            }
             let mut mapped = map_tsgo_diagnostics(&raw, layout, workspace);
             overlay::replay_withheld_js_module_diagnostics(
                 &mut mapped.diagnostics,

--- a/crates/rsvelte_check/src/svelte_check/tsgo.rs
+++ b/crates/rsvelte_check/src/svelte_check/tsgo.rs
@@ -248,12 +248,23 @@ pub fn run_tsgo(
 /// Parse the textual diagnostic stream emitted by `tsc --pretty=false`
 /// (and tsgo, which is wire-compatible). Lines look like:
 ///   `path/to/file.ts(line,col): error TSxxxx: message`
+///
+/// A diagnostic about the configuration itself carries no file or position
+/// (`error TS2688: Cannot find type definition file for '$app/types'.`).
+/// Those are returned with an empty [`RawTsDiagnostic::file`] and must not be
+/// dropped: TypeScript suppresses every *semantic* diagnostic program-wide
+/// while one is outstanding, so discarding them turns a project that cannot
+/// be checked at all into a clean pass.
 fn parse_diagnostics(output: &str) -> Vec<RawTsDiagnostic> {
     static RE: std::sync::LazyLock<regex::Regex> = std::sync::LazyLock::new(|| {
         regex::Regex::new(
             r"^(?P<file>.+?)\((?P<line>\d+),(?P<col>\d+)\):\s+(?P<sev>error|warning|info)\s+(?P<code>TS\d+):\s+(?P<msg>.*)$",
         )
         .expect("static regex compiles")
+    });
+    static GLOBAL_RE: std::sync::LazyLock<regex::Regex> = std::sync::LazyLock::new(|| {
+        regex::Regex::new(r"^(?P<sev>error|warning|info)\s+(?P<code>TS\d+):\s+(?P<msg>.*)$")
+            .expect("static regex compiles")
     });
     let mut diags = Vec::new();
     for line in output.lines() {
@@ -264,6 +275,15 @@ fn parse_diagnostics(output: &str) -> Vec<RawTsDiagnostic> {
                 file: PathBuf::from(&caps["file"]),
                 line: line_no,
                 column: col,
+                severity: caps["sev"].to_string(),
+                code: caps["code"].to_string(),
+                message: caps["msg"].trim().to_string(),
+            });
+        } else if let Some(caps) = GLOBAL_RE.captures(line) {
+            diags.push(RawTsDiagnostic {
+                file: PathBuf::new(),
+                line: 0,
+                column: 0,
                 severity: caps["sev"].to_string(),
                 code: caps["code"].to_string(),
                 message: caps["msg"].trim().to_string(),
@@ -298,6 +318,21 @@ mod tests {
         let diags = parse_diagnostics(sample);
         assert_eq!(diags.len(), 1);
         assert_eq!(diags[0].code, "TS9999");
+    }
+
+    #[test]
+    fn parse_keeps_config_level_diagnostics() {
+        // No file, no position — and while one of these is outstanding
+        // TypeScript reports no semantic diagnostics at all, so dropping it
+        // reads as a clean pass.
+        let sample = "error TS2688: Cannot find type definition file for '$app/types'.\n\
+                      \x20 The file is in the program because:\n\
+                      Found 1 error.";
+        let diags = parse_diagnostics(sample);
+        assert_eq!(diags.len(), 1, "{diags:?}");
+        assert_eq!(diags[0].code, "TS2688");
+        assert_eq!(diags[0].file, PathBuf::new());
+        assert_eq!(diags[0].severity, "error");
     }
 
     /// A TS 7 install under the `@typescript/native` alias, plus a stale


### PR DESCRIPTION
Closes #2710
Closes #2714

Three defects a SvelteKit app hits at once, found while wiring `@rsvelte/svelte-check` into [sveltejs/kit#16692](https://github.com/sveltejs/kit/pull/16692). Reproduced against that PR's branch (`playgrounds/basic`, `packages/kit/test/apps/basics`).

## 1. A bare-package `extends` was not followed — the whole run went silent

SvelteKit writes `"extends": "$app/tsconfig"` into every app's `tsconfig.json`, and `extends_chain` only followed relative targets. The base config was therefore invisible, so the overlay restated `typeRoots` without the `types` it declares, `types: ["$app/types"]` became `TS2688`, **and one config-level error makes TypeScript suppress every semantic diagnostic program-wide**.

```
# playgrounds/basic, with `const n: number = "not a number";` in +page.svelte
before: svelte-check found 0 errors and 0 warnings in 2 files
after:  ERROR src/routes/+page.svelte:2:7 (ts): Type 'string' is not assignable to type 'number'.
```

The base's `rootDirs` (`.svelte-kit/types`, i.e. every `./$types` import) and `paths` were lost for the same reason.

Second half of the fix: `parse_diagnostics` matched only `file(line,col): error TSxxxx:`, so a diagnostic **about the configuration** — no file, no position — was dropped on the floor. That is what made this failure mode silent rather than merely wrong. Those are now reported against the workspace.

## 2. An external package was walked in full, not as what it publishes

A monorepo sibling symlinked into `node_modules` is a repository directory, not the tarball npm ships. Walking all of `packages/kit` reached its `test/**` fixture apps, one of which is a deliberately unparseable component (`test/build-errors/apps/syntax-error`), and that failed the entire run:

```
before: ERROR (svelte): overlay generation failed: svelte2tsx failed on
        .../packages/kit/test/build-errors/apps/syntax-error/src/routes/+page.svelte
```

The walk is now bounded by `files` (honouring negated entries such as kit's `!src/core/**/test`), falling back to `exports` / `svelte` / `main` / `module` / `types`, and finally to the whole directory for a manifest that declares none of them. For `@sveltejs/kit` that is 99 shadows → the 3 components it actually publishes. A `svelte2tsx` failure inside such a package is no longer fatal either: that one file falls back to the ambient `*.svelte` declaration, because a component the user never asked about must not be able to fail their run.

## 3. `const config = {...}; export default config;` was not read

Only the inline-object and `defineConfig({...})` forms were resolved, so a config written the referenced way silently ran with **default** compiler options. Verified as a discriminating A/B against the published `0.5.4` binary:

```
0.5.4 : ERROR src/App.svelte (svelte): experimental_async: Cannot use `await` ...
local : (no error)
```

Also covers `module.exports = config` and a plugin call whose options are a binding (`svelte(svelteOptions)`), for both `compilerOptions` and `kit.files`.

## Not in this PR

Verifying the above surfaced a fourth, broader defect: shadows for **JS-authored** components are emitted as `.tsx`, and TypeScript honours JSDoc type annotations only in JS files. On `packages/kit/test/apps/basics` that is 68 false positives and a missed `/** @type {number} */ const yy = 'a string';`, where official `svelte-check` reports 0 and catches the JSDoc violation. Filed separately — the fix moves the shadow extension, which crosses alias rewriting, bridges, the mapper and the manifest.

## Tests

`cargo test -p rsvelte_check` green. New coverage: bare-specifier `extends` resolution, the publish-surface bound (incl. a negated `files` entry and the no-manifest fallback), config-level diagnostics surviving the parser, and the binding-exported config in all three forms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CQFGbmKgydpTBfK2T1D7da
