### PR TITLE
fix(check): honour JSDoc types in JavaScript-authored components

### DIFF
--- a/.changeset/svelte-check-jsdoc-shadows.md
+++ b/.changeset/svelte-check-jsdoc-shadows.md
@@ -1,0 +1,6 @@
+---
+'@rsvelte/svelte-check': patch
+'@rsvelte/svelte2tsx': patch
+---
+
+Honour JSDoc types in JavaScript-authored components. A `.svelte` file without `lang="ts"` was shadowed as `.tsx`, where TypeScript ignores JSDoc entirely — so `/** @type {…} */` neither constrained a value nor reported a violation, while the props it left untyped produced implicit-`any` errors the author could not act on. Such a component now gets a `.jsx` shadow (official svelte-check reaches the same place through `ScriptKind.JS`), the overlay adds `allowJs` when one exists, and the Svelte 5 isomorphic component export emits the `export const` + `@typedef` form upstream uses for JSDoc output. `checkJs` is left to the project. A SvelteKit route prop that already carries a JSDoc `@type` also keeps it: `ts.getJSDocType` suppresses the `import('./$types.js')` injection just as a TS annotation does, so `/** @type {any} */ export let form` on a route with no server actions no longer reports a nonexistent `ActionData`

--- a/crates/rsvelte_check/src/svelte_check/overlay.rs
+++ b/crates/rsvelte_check/src/svelte_check/overlay.rs
@@ -585,10 +585,24 @@ pub fn materialize_overlay_with(
         let tsx_path = emit_dir.join(&tsx_rel);
         let dts_path = emit_dir.join(&dts_rel);
         let map_path = append_extension(&tsx_path, ".map");
+        // `X.svelte.d.ts` is TypeScript's declaration counterpart of
+        // `X.svelte.jsx`, so with a JS shadow the bridges' own
+        // `./X.svelte.jsx` resolves to the twin, which re-exports from
+        // `./X.svelte.jsx` — a cycle that types the component `any` and
+        // silently drops every diagnostic about using it. `.tsx` escapes
+        // it through `allowImportingTsExtensions`, which resolves an
+        // explicit TS extension literally. Dropping the twin costs nothing:
+        // `allowJs` is on whenever a `.jsx` shadow exists, so CJS-mode
+        // resolution of `./X.svelte` finds the shadow itself, and ESM mode
+        // still goes through the `.d.svelte.ts` bridge.
+        let emit_dts_twin = ext == ".tsx";
         if let Some(parent) = tsx_path.parent() {
             fs::create_dir_all(parent)?;
         }
         remove_stale_counterpart(&tsx_path, ext);
+        if !emit_dts_twin {
+            let _ = fs::remove_file(&dts_path);
+        }
 
         let stats_match = match (stats, cached_entry) {
             (Some((mtime, size)), Some(entry)) => {
@@ -604,7 +618,10 @@ pub fn materialize_overlay_with(
         // source map; we don't gate cache validity on it, so a workspace
         // that gained / lost source maps still hits the cache. On hit we
         // simply best-effort-read whatever sits at `map_path`.
-        let can_skip = incremental && stats_match && tsx_path.exists() && dts_path.exists();
+        let can_skip = incremental
+            && stats_match
+            && tsx_path.exists()
+            && (!emit_dts_twin || dts_path.exists());
 
         let source_map = if can_skip {
             fs::read_to_string(&map_path).ok()
@@ -662,7 +679,9 @@ pub fn materialize_overlay_with(
 
             // `<name>.svelte.d.ts` re-exports default + named so module
             // resolution by `import Foo from './Foo.svelte'` still works.
-            fs::write(&dts_path, shadow_reexport(&tsx_path))?;
+            if emit_dts_twin {
+                fs::write(&dts_path, shadow_reexport(&tsx_path))?;
+            }
             // Persist the source map so the next incremental run can
             // recover it without re-running svelte2tsx.
             if let Some(map) = &result.map {
@@ -1013,7 +1032,14 @@ fn emit_external_shadows(
         }
         fs::write(&tsx_path, &tsx_code)?;
         let dts_content = shadow_reexport(&tsx_path);
-        fs::write(&dts_path, &dts_content)?;
+        // See the twin's comment in `materialize_overlay_with`: next to a
+        // `.jsx` shadow this file IS its declaration counterpart, so writing
+        // it makes the shadow resolve to itself.
+        if ext == ".tsx" {
+            fs::write(&dts_path, &dts_content)?;
+        } else {
+            let _ = fs::remove_file(&dts_path);
+        }
         write_esm_bridge(&tsx_path, &dts_content, false)?;
     }
     Ok(any_js_shadow)
@@ -3647,7 +3673,8 @@ mod tests {
 
         for entry in &layout.entries {
             assert!(entry.tsx_path.exists(), "{:?}", entry.tsx_path);
-            assert!(entry.dts_path.exists(), "{:?}", entry.dts_path);
+            let bridge = esm_bridge_path(&entry.tsx_path).unwrap();
+            assert!(bridge.exists(), "{bridge:?}");
             // shadow mirrors source relative path under emit_dir/svelte;
             // a JS-authored component gets `.jsx` so JSDoc is honoured
             let rel = entry
@@ -3725,7 +3752,7 @@ mod tests {
         let layout1 = materialize_overlay_with(&tmp, &files, None, true, &[]).unwrap();
         let entry = &layout1.entries[0];
         assert!(entry.tsx_path.exists());
-        assert!(entry.dts_path.exists());
+        assert!(esm_bridge_path(&entry.tsx_path).unwrap().exists());
         let manifest_path = layout1.cache_dir.join("manifest.json");
         assert!(manifest_path.exists(), "manifest should be written");
 
@@ -3777,12 +3804,7 @@ mod tests {
             .find(|e| e.source_path == removed)
             .map(|e| e.tsx_path.clone())
             .unwrap();
-        let removed_dts = layout1
-            .entries
-            .iter()
-            .find(|e| e.source_path == removed)
-            .map(|e| e.dts_path.clone())
-            .unwrap();
+        let removed_dts = esm_bridge_path(&removed_tsx).unwrap();
         assert!(removed_tsx.exists());
         assert!(removed_dts.exists());
 
@@ -3792,7 +3814,10 @@ mod tests {
         let _ =
             materialize_overlay_with(&tmp, std::slice::from_ref(&kept), None, true, &[]).unwrap();
         assert!(!removed_tsx.exists(), "stale .tsx should have been pruned");
-        assert!(!removed_dts.exists(), "stale .d.ts should have been pruned");
+        assert!(
+            !removed_dts.exists(),
+            "stale ESM bridge should have been pruned"
+        );
 
         let _ = fs::remove_dir_all(&tmp);
     }
@@ -4345,11 +4370,51 @@ mod tests {
         let layout = materialize_overlay(&tmp, &[svelte_path], None).unwrap();
         let bridge = layout.emit_dir.join("src/Foo.d.svelte.ts");
         let content = fs::read_to_string(&bridge).unwrap_or_default();
-        assert_eq!(
-            content,
-            fs::read_to_string(&layout.entries[0].dts_path).unwrap(),
-            "the bridge forwards exactly what the `.svelte.d.ts` twin does"
+        let shadow = layout.entries[0].tsx_path.file_name().unwrap();
+        assert!(
+            content.contains(&format!("from \"./{}\"", shadow.to_string_lossy())),
+            "the bridge must forward the shadow itself:\n{content}"
         );
+
+        let _ = fs::remove_dir_all(&tmp);
+    }
+
+    /// A `.jsx` shadow must NOT get the `<name>.svelte.d.ts` twin: that file is
+    /// TypeScript's declaration counterpart for it, so the bridges' own
+    /// `./<name>.svelte.jsx` would resolve to the twin, which re-exports from
+    /// `./<name>.svelte.jsx` — a cycle that types the component `any` and
+    /// silently swallows every diagnostic about using it. A `.tsx` shadow is
+    /// resolved literally (`allowImportingTsExtensions`) and keeps its twin.
+    #[test]
+    fn a_js_shadow_has_no_declaration_counterpart_but_a_ts_one_does() {
+        let tmp = std::env::temp_dir().join(format!("svc_overlay_twin_{}", std::process::id()));
+        let _ = fs::remove_dir_all(&tmp);
+        fs::create_dir_all(tmp.join("src")).unwrap();
+        let js = tmp.join("src/Js.svelte");
+        let ts = tmp.join("src/Ts.svelte");
+        fs::write(&js, "<div>hi</div>").unwrap();
+        fs::write(&ts, "<script lang=\"ts\">let x: number = 0;</script>{x}").unwrap();
+
+        let layout = materialize_overlay(&tmp, &[js.clone(), ts.clone()], None).unwrap();
+        let twin = |src: &Path| {
+            let entry = layout
+                .entries
+                .iter()
+                .find(|e| e.source_path == *src)
+                .expect("entry");
+            (entry.tsx_path.clone(), entry.dts_path.exists())
+        };
+
+        let (js_shadow, js_twin) = twin(&js);
+        assert!(js_shadow.to_string_lossy().ends_with(".svelte.jsx"));
+        assert!(
+            !js_twin,
+            "a .jsx shadow must not shadow itself via its twin"
+        );
+
+        let (ts_shadow, ts_twin) = twin(&ts);
+        assert!(ts_shadow.to_string_lossy().ends_with(".svelte.tsx"));
+        assert!(ts_twin, "a .tsx shadow still needs its CJS-mode twin");
 
         let _ = fs::remove_dir_all(&tmp);
     }

--- a/crates/rsvelte_check/src/svelte_check/overlay.rs
+++ b/crates/rsvelte_check/src/svelte_check/overlay.rs
@@ -526,8 +526,9 @@ pub fn materialize_overlay_with(
     let allow_js = resolve_allow_js(tsconfig_path);
     let mut module_bridges: Vec<(PathBuf, PathBuf)> = Vec::new();
     let mut withheld_js_modules: Vec<PathBuf> = Vec::new();
+    let mut external_js_shadows = false;
     for pkg in &external {
-        emit_external_shadows(
+        external_js_shadows |= emit_external_shadows(
             pkg,
             workspace,
             &emit_dir,
@@ -555,9 +556,31 @@ pub fn materialize_overlay_with(
 
     let mut entries = Vec::with_capacity(files.len());
     let mut augments: Vec<CompanionAugment> = Vec::new();
+    let mut any_js_shadow = external_js_shadows;
     for abs_source in &abs_files {
         let rel = safe_relative(abs_source, workspace);
-        let tsx_rel = append_extension(&rel, ".tsx");
+        let stats = current_stats(abs_source);
+        let cached_entry = manifest.entries.get(abs_source);
+        // An unchanged file keeps the extension its own shadow already has, so
+        // the cache hit below still costs no read.
+        let ext = match (stats, cached_entry) {
+            (Some((mtime, size)), Some(entry))
+                if incremental
+                    && entry.mtime_ms == mtime
+                    && entry.size == size
+                    && entry.out_path.extension().is_some_and(|e| e == "jsx") =>
+            {
+                ".jsx"
+            }
+            (Some((mtime, size)), Some(entry))
+                if incremental && entry.mtime_ms == mtime && entry.size == size =>
+            {
+                ".tsx"
+            }
+            _ => shadow_extension(abs_source),
+        };
+        any_js_shadow |= ext == ".jsx";
+        let tsx_rel = append_extension(&rel, ext);
         let dts_rel = append_extension(&rel, ".d.ts");
         let tsx_path = emit_dir.join(&tsx_rel);
         let dts_path = emit_dir.join(&dts_rel);
@@ -565,9 +588,8 @@ pub fn materialize_overlay_with(
         if let Some(parent) = tsx_path.parent() {
             fs::create_dir_all(parent)?;
         }
+        remove_stale_counterpart(&tsx_path, ext);
 
-        let stats = current_stats(abs_source);
-        let cached_entry = manifest.entries.get(abs_source);
         let stats_match = match (stats, cached_entry) {
             (Some((mtime, size)), Some(entry)) => {
                 entry.mtime_ms == mtime
@@ -744,6 +766,7 @@ pub fn materialize_overlay_with(
         has_augments,
         &alias_path_overrides,
         &global_types,
+        any_js_shadow,
     );
     fs::write(&overlay_tsconfig, tsconfig_json)?;
 
@@ -910,7 +933,7 @@ fn emit_external_shadows(
     blank_svelte_reference: bool,
     namespace: Svelte2TsxNamespace,
     accessors: bool,
-) -> Result<(), OverlayError> {
+) -> Result<bool, OverlayError> {
     // Mirror the package's own `node_modules` into the shadow dir so the
     // shadow's bare-package imports (`import type { X } from 'sortablejs'`,
     // incl. its `@types/*` declarations) resolve from the SAME context as the
@@ -931,15 +954,19 @@ fn emit_external_shadows(
         fs::create_dir_all(&pkg.mirror_dir)?;
         let _ = symlink_dir(&real_nm, &mirror_nm);
     }
+    let mut any_js_shadow = false;
     for abs_source in &pkg.svelte_files {
         let rel = safe_relative(abs_source, &pkg.real_dir);
-        let tsx_path = pkg.mirror_dir.join(append_extension(&rel, ".tsx"));
+        let source = fs::read_to_string(abs_source)?;
+        let is_ts_file = looks_like_ts_svelte(&source);
+        let ext = shadow_extension_for(is_ts_file);
+        any_js_shadow |= ext == ".jsx";
+        let tsx_path = pkg.mirror_dir.join(append_extension(&rel, ext));
         let dts_path = pkg.mirror_dir.join(append_extension(&rel, ".d.ts"));
         if let Some(parent) = tsx_path.parent() {
             fs::create_dir_all(parent)?;
         }
-        let source = fs::read_to_string(abs_source)?;
-        let is_ts_file = looks_like_ts_svelte(&source);
+        remove_stale_counterpart(&tsx_path, ext);
         let opts = Svelte2TsxOptions {
             filename: abs_source.display().to_string(),
             is_ts_file,
@@ -989,7 +1016,7 @@ fn emit_external_shadows(
         fs::write(&dts_path, &dts_content)?;
         write_esm_bridge(&tsx_path, &dts_content, false)?;
     }
-    Ok(())
+    Ok(any_js_shadow)
 }
 
 fn materialize_kit_files(
@@ -1202,6 +1229,51 @@ fn looks_like_ts_svelte(source: &str) -> bool {
     lower.contains("lang=\"ts\"") || lower.contains("lang='ts'") || lower.contains("lang=ts")
 }
 
+/// The extension a component's shadow carries: `.tsx` for a `lang="ts"`
+/// component, `.jsx` for a JavaScript one.
+///
+/// TypeScript honours JSDoc type annotations **only in JS files**, so a
+/// JS-authored component emitted as `.tsx` has every `/** @type {...} */` in
+/// it silently discarded — which both invents implicit-`any` errors the user
+/// cannot act on and hides real violations of the types they did declare
+/// (issue #2730). Official svelte-check reaches the same place through
+/// `ScriptKind.JS` on its in-memory snapshot; an on-disk overlay has to say it
+/// with the file name. Whether such a shadow is then *checked* stays the
+/// project's own `checkJs` decision, matching upstream.
+///
+/// Falls back to `.tsx` for an unreadable source, which is what the caller
+/// would have produced anyway.
+fn shadow_extension(source_path: &Path) -> &'static str {
+    match fs::read_to_string(source_path) {
+        Ok(source) => shadow_extension_for(looks_like_ts_svelte(&source)),
+        Err(_) => ".tsx",
+    }
+}
+
+/// The same decision made from an already-classified source.
+fn shadow_extension_for(is_ts_file: bool) -> &'static str {
+    if is_ts_file { ".tsx" } else { ".jsx" }
+}
+
+/// Delete the shadow (and its source map) this component would have had under
+/// the *other* extension. Both live under the overlay's `include`, so a
+/// leftover from before the component changed language — or from before
+/// [`shadow_extension`] existed — would enter the program a second time and
+/// duplicate every declaration in it.
+fn remove_stale_counterpart(shadow: &Path, ext: &str) {
+    let Some(stem) = shadow
+        .to_str()
+        .and_then(|s| s.strip_suffix(ext))
+        .map(str::to_owned)
+    else {
+        return;
+    };
+    let other = if ext == ".tsx" { ".jsx" } else { ".tsx" };
+    let counterpart = PathBuf::from(format!("{stem}{other}"));
+    let _ = fs::remove_file(&counterpart);
+    let _ = fs::remove_file(append_extension(&counterpart, ".map"));
+}
+
 fn build_overlay_tsconfig(
     cache_dir: &Path,
     original: Option<&Path>,
@@ -1211,6 +1283,7 @@ fn build_overlay_tsconfig(
     has_companion_augmentation: bool,
     alias_path_overrides: &[(String, PathBuf)],
     global_types: &GlobalTypes,
+    any_js_shadow: bool,
 ) -> String {
     let mut obj: BTreeMap<&str, serde_json::Value> = BTreeMap::new();
     if let Some(orig) = original {
@@ -1220,6 +1293,17 @@ fn build_overlay_tsconfig(
     let mut compiler_opts = serde_json::Map::new();
     compiler_opts.insert("noEmit".into(), true.into());
     compiler_opts.insert("allowArbitraryExtensions".into(), true.into());
+    // A `.jsx` shadow (see `shadow_extension`) is only admitted to the program
+    // when JS files are. `allowJs` defaults to OFF, so without this every
+    // JS-authored component would silently leave the program — and take its
+    // importers' resolution with it. Upstream gets the same effect from
+    // `allowNonTsExtensions`, which no tsconfig can express. It stays off for a
+    // project with no JS component, so a TS-only overlay is unchanged.
+    // `checkJs` is deliberately NOT forced: whether a JS component is checked
+    // remains the project's own decision, exactly as upstream leaves it.
+    if any_js_shadow {
+        compiler_opts.insert("allowJs".into(), true.into());
+    }
     // `rewrite_aliased_svelte_imports` rewrites alias-resolved `.svelte`
     // imports to relative `.svelte.tsx` specifiers (no rootDirs bridge
     // applies across an alias), which tsgo/tsc otherwise reject unless the
@@ -2378,7 +2462,9 @@ fn compute_alias_path_overrides(
     for pkg in external {
         for abs_source in &pkg.svelte_files {
             let rel = safe_relative(abs_source, &pkg.real_dir);
-            let tsx_path = pkg.mirror_dir.join(append_extension(&rel, ".tsx"));
+            let tsx_path = pkg
+                .mirror_dir
+                .join(append_extension(&rel, shadow_extension(abs_source)));
             candidates.push((canonicalized(abs_source), tsx_path));
         }
     }
@@ -2596,8 +2682,11 @@ fn prune_orphaned_module_bridges(mirror_dir: &Path, written: &std::collections::
         if written.contains(&bridge) {
             continue;
         }
-        let shadow = bridge.with_file_name(format!("{base}.svelte.tsx"));
-        if shadow.is_file() {
+        if [".tsx", ".jsx"].iter().any(|ext| {
+            bridge
+                .with_file_name(format!("{base}.svelte{ext}"))
+                .is_file()
+        }) {
             continue;
         }
         let _ = fs::remove_file(&bridge);
@@ -3260,7 +3349,7 @@ fn rewrite_aliased_svelte_imports(
                 })
                 .max_by_key(|(rel, _)| resolved_canon.as_os_str().len() - rel.as_os_str().len())?
         };
-        let shadow = append_extension(&mirror_dir.join(rel), ".tsx");
+        let shadow = append_extension(&mirror_dir.join(rel), shadow_extension(&resolved_canon));
         let mut rewritten = lexical_relative_posix(generated_dir, &shadow);
         if !rewritten.starts_with('.') {
             rewritten = format!("./{rewritten}");
@@ -3559,12 +3648,13 @@ mod tests {
         for entry in &layout.entries {
             assert!(entry.tsx_path.exists(), "{:?}", entry.tsx_path);
             assert!(entry.dts_path.exists(), "{:?}", entry.dts_path);
-            // .tsx mirrors source relative path under emit_dir/svelte
+            // shadow mirrors source relative path under emit_dir/svelte;
+            // a JS-authored component gets `.jsx` so JSDoc is honoured
             let rel = entry
                 .tsx_path
                 .strip_prefix(&layout.emit_dir)
                 .expect("tsx under emit_dir");
-            assert!(rel.to_string_lossy().ends_with(".svelte.tsx"));
+            assert!(rel.to_string_lossy().ends_with(".svelte.jsx"));
         }
 
         // Overlay tsconfig parses as JSON and includes our svelte folder.
@@ -4311,7 +4401,7 @@ mod tests {
         );
         // Pair's bridge is the component's, pointing at the shadow.
         let pair = read("Pair.d.svelte.ts").unwrap();
-        assert!(pair.contains("./Pair.svelte.tsx"), "{pair}");
+        assert!(pair.contains("./Pair.svelte.jsx"), "{pair}");
 
         let _ = fs::remove_dir_all(&tmp);
     }
@@ -4756,7 +4846,7 @@ mod tests {
             .as_str()
             .unwrap_or_else(|| panic!("no exact override for $lib/Pair.svelte:\n{paths}"));
         assert!(
-            pair.ends_with("Pair.svelte.tsx"),
+            pair.ends_with("Pair.svelte.jsx"),
             "the companion outranked its own component: {pair}"
         );
 
@@ -5068,7 +5158,7 @@ mod tests {
 
         // The shadow's own type reference would pull the original back in
         // through a channel `paths` cannot reach.
-        let tsx = fs::read_to_string(tmp.join(".svelte-check/svelte/src/App.svelte.tsx")).unwrap();
+        let tsx = fs::read_to_string(tmp.join(".svelte-check/svelte/src/App.svelte.jsx")).unwrap();
         assert!(
             !tsx.contains("reference types=\"svelte\""),
             "the svelte type reference must be blanked:\n{tsx}"

--- a/crates/rsvelte_projection/src/svelte2tsx/add_component_export.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/add_component_export.rs
@@ -470,6 +470,9 @@ pub(crate) fn add_component_export(
                     closing.push_str(doc);
                     closing.push('\n');
                 }
+                if !use_ts_syntax {
+                    closing.push_str("export ");
+                }
                 closing.push_str("const ");
                 closing.push_str(&safe_name);
                 closing.push_str(" = ");
@@ -483,11 +486,20 @@ pub(crate) fn add_component_export(
                     render_call,
                 );
                 closing.push_str(");\n");
-                closing.push_str("/*\u{03A9}ignore_start\u{03A9}*/type ");
-                closing.push_str(&safe_name);
-                closing.push_str(" = InstanceType<typeof ");
-                closing.push_str(&safe_name);
-                closing.push_str(">;\n");
+                closing.push_str("/*\u{03A9}ignore_start\u{03A9}*/");
+                if use_ts_syntax {
+                    closing.push_str("type ");
+                    closing.push_str(&safe_name);
+                    closing.push_str(" = InstanceType<typeof ");
+                    closing.push_str(&safe_name);
+                    closing.push_str(">;\n");
+                } else {
+                    closing.push_str("/** @typedef {InstanceType<typeof ");
+                    closing.push_str(&safe_name);
+                    closing.push_str(">} ");
+                    closing.push_str(&safe_name);
+                    closing.push_str(" */\n");
+                }
                 closing.push_str("/*\u{03A9}ignore_end\u{03A9}*/export default ");
                 closing.push_str(&safe_name);
                 closing.push(';');

--- a/crates/rsvelte_projection/src/svelte2tsx/script/export_decl.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/script/export_decl.rs
@@ -183,7 +183,12 @@ pub(super) fn handle_export_named_decl(
                         // widener so the two combine into ONE ignore block in the
                         // right order (`: KitType; x = any(x);`), not separate
                         // out-of-order blocks. Mirrors `emitKitType`.
-                        let kit_type: Option<&str> = if is_instance && !has_type_annotation {
+                        // `ts.getJSDocType` counts here too, so an explicitly
+                        // typed prop keeps the author's type.
+                        let kit_type: Option<&str> = if is_instance
+                            && !has_type_annotation
+                            && !has_jsdoc_type
+                        {
                             binding_pattern_simple_name(&declarator.id).and_then(|name| {
                                 classify_kit_route_file(basename).and_then(|layout| {
                                     if !is_let {

--- a/crates/rsvelte_projection/src/svelte2tsx/template/attributes/binding.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/template/attributes/binding.rs
@@ -155,7 +155,7 @@ pub(crate) fn build_bind_directive_suffix(
     source: &str,
     element_var: Option<&str>,
     parent_tag: &str,
-    is_ts_file: bool,
+    use_ts_syntax: bool,
 ) -> String {
     let mut out = String::new();
     for attr in attributes {
@@ -167,7 +167,7 @@ pub(crate) fn build_bind_directive_suffix(
             source,
             element_var,
             parent_tag,
-            is_ts_file,
+            use_ts_syntax,
         ));
     }
     out
@@ -181,7 +181,7 @@ pub(crate) fn bind_directive_suffix_seg(
     source: &str,
     element_var: Option<&str>,
     parent_tag: &str,
-    is_ts_file: bool,
+    use_ts_syntax: bool,
 ) -> String {
     let mut out = String::new();
     {
@@ -229,12 +229,14 @@ pub(crate) fn bind_directive_suffix_seg(
             // `htmlxtojsx_v2/nodes/Binding.ts::handleBinding`.
             let _ = write!(out, "{} = __sveltets_2_any(null);", expr_text);
         } else if let Some(ty) = one_way_binding_not_on_element_type(&bind.name) {
-            // Official uses `null as Type` whenever `isTsFile || !emitJsDoc`;
-            // `emitJsDoc` defaults to false, so the TS-syntax form is used even
-            // in a plain `<script>` component (the JSDoc form would only appear
-            // under an explicit emitJsDoc run, which the corpus does not use).
-            let _ = is_ts_file;
-            let value = format!("null as {}", ty);
+            // `Binding.ts`'s `useTypescriptSyntax`. A TS assertion in a shadow
+            // emitted as JavaScript is a SYNTAX error (TS8016), which suppresses
+            // every semantic diagnostic in the program.
+            let value = if use_ts_syntax {
+                format!("null as {}", ty)
+            } else {
+                format!("/** @type {{{}}} */ (null)", ty)
+            };
             let _ = write!(
                 out,
                 "{}= /*\u{03A9}ignore_start\u{03A9}*/{}/*\u{03A9}ignore_end\u{03A9}*/;",

--- a/crates/rsvelte_projection/src/svelte2tsx/template/attributes/directive_suffix.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/template/attributes/directive_suffix.rs
@@ -30,7 +30,7 @@ pub(crate) fn build_element_directive_suffix_segments(
     source: &str,
     element_var: Option<&str>,
     parent_tag: &str,
-    is_ts_file: bool,
+    use_ts_syntax: bool,
     tag: &str,
 ) -> Vec<Seg> {
     let mut out: Vec<Seg> = Vec::new();
@@ -70,7 +70,7 @@ pub(crate) fn build_element_directive_suffix_segments(
             }
             Attribute::BindDirective(bind) => {
                 let s =
-                    bind_directive_suffix_seg(bind, source, element_var, parent_tag, is_ts_file);
+                    bind_directive_suffix_seg(bind, source, element_var, parent_tag, use_ts_syntax);
                 if !s.is_empty() {
                     segs_push_lit(&mut out, &s);
                 }

--- a/crates/rsvelte_projection/src/svelte2tsx/template/nodes/dynamic_element.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/template/nodes/dynamic_element.rs
@@ -189,7 +189,7 @@ pub(crate) fn handle_svelte_dynamic_element(
         source,
         element_var.as_deref(),
         &el.name,
-        options.is_ts_file,
+        options.is_ts_file || !options.emit_jsdoc,
     );
     let element_var_decl = element_var
         .as_ref()

--- a/crates/rsvelte_projection/src/svelte2tsx/template/nodes/element.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/template/nodes/element.rs
@@ -198,7 +198,7 @@ pub(crate) fn handle_regular_element(
         source,
         element_var.as_deref(),
         &el.name,
-        options.is_ts_file,
+        options.is_ts_file || !options.emit_jsdoc,
         &el.name,
     );
 

--- a/crates/rsvelte_projection/src/svelte2tsx/template/nodes/special_element.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/template/nodes/special_element.rs
@@ -335,7 +335,7 @@ pub(crate) fn handle_svelte_special_element(
             source,
             element_var.as_deref(),
             &el.name,
-            options.is_ts_file,
+            options.is_ts_file || !options.emit_jsdoc,
         );
         let element_var_decl = element_var
             .as_ref()

--- a/crates/rsvelte_projection/tests/svelte2tsx_kit_type_respects_jsdoc.rs
+++ b/crates/rsvelte_projection/tests/svelte2tsx_kit_type_respects_jsdoc.rs
@@ -1,0 +1,105 @@
+//! A SvelteKit route prop that already carries a JSDoc `@type` keeps it.
+//!
+//! `ExportedNames.handleTypeAssertion` computes `kitType` from
+//! `tsType || ts.getJSDocType(declaration)`, so `/** @type {any} */ export let
+//! form` suppresses the `import('./$types.js').ActionData` injection. Injecting
+//! anyway is not merely redundant: on a route whose `$types.d.ts` has no
+//! `ActionData` (no `+page.server.js` actions) it raises a TS2694 the author
+//! never wrote.
+
+use rsvelte_projection::svelte2tsx::{Svelte2TsxOptions, svelte2tsx};
+
+fn to_tsx(src: &str, filename: &str, is_ts_file: bool) -> String {
+    let opts = Svelte2TsxOptions {
+        filename: filename.to_string(),
+        is_ts_file,
+        emit_jsdoc: true,
+        ..Default::default()
+    };
+    svelte2tsx(src, opts).expect("svelte2tsx").code
+}
+
+#[test]
+fn jsdoc_typed_kit_prop_keeps_the_authors_type() {
+    let out = to_tsx(
+        concat!(
+            "<script>\n",
+            "  /** @type {any} */\n",
+            "  export let form;\n",
+            "  /** @type {any} */\n",
+            "  export let data;\n",
+            "</script>\n",
+        ),
+        "+page.svelte",
+        false,
+    );
+    assert!(
+        !out.contains("ActionData"),
+        "kit type injected over an explicit JSDoc type:\n{out}"
+    );
+    assert!(
+        !out.contains("PageData"),
+        "kit type injected over an explicit JSDoc type:\n{out}"
+    );
+}
+
+#[test]
+fn untyped_kit_prop_still_gets_the_injection() {
+    let out = to_tsx(
+        concat!("<script>\n", "  export let form;\n", "</script>\n"),
+        "+page.svelte",
+        false,
+    );
+    assert!(
+        out.contains("import('./$types.js').ActionData"),
+        "kit type missing on an untyped prop:\n{out}"
+    );
+}
+
+/// The overlay gives a JS-authored component a `.jsx` shadow, which only works
+/// if its projection is JavaScript. `<script generics="T">` is the shape that
+/// most nearly isn't — it declares type parameters — so pin that it comes out
+/// as `@template` / `@typedef` rather than TS syntax.
+#[test]
+fn a_js_generics_component_projects_to_javascript() {
+    let out = to_tsx(
+        concat!(
+            "<script generics=\"T\">\n",
+            "  /** @type {{ b: T }} */\n",
+            "  let { b } = $props();\n",
+            "</script>\n",
+            "{b}\n",
+        ),
+        "Input.svelte",
+        false,
+    );
+    assert!(
+        out.contains("/** @template T */"),
+        "generics not projected as JSDoc:\n{out}"
+    );
+    assert!(
+        !out.contains("interface "),
+        "TS-only syntax in a JS projection:\n{out}"
+    );
+    assert!(
+        !out.contains("declare "),
+        "TS-only syntax in a JS projection:\n{out}"
+    );
+}
+
+#[test]
+fn ts_typed_kit_prop_keeps_the_authors_type() {
+    let out = to_tsx(
+        concat!(
+            "<script lang=\"ts\">\n",
+            "  export let form: unknown;\n",
+            "</script>\n",
+        ),
+        "+page.svelte",
+        true,
+    );
+    assert!(
+        !out.contains("ActionData"),
+        "kit type injected over an explicit TS annotation:\n{out}"
+    );
+}


### PR DESCRIPTION
Closes #2730.

A `.svelte` file with no `lang="ts"` was shadowed as `.tsx`, and TypeScript ignores JSDoc entirely in a TS file. Every `/** @type {…} */` in such a component was therefore discarded — the annotation neither constrained the value nor reported a violation, while the props it was meant to type produced implicit-`any` errors the author could not act on.

Official svelte-check reaches the right place through `ScriptKind.JS` on its in-memory snapshot (`getScriptKindFromAttributes`); an on-disk overlay has to say it with the file name, so a JS-authored component now gets a `.jsx` shadow. `allowJs` is added to the overlay config when such a shadow exists (it defaults off, and the shadow would otherwise leave the program silently, taking its importers' resolution with it); `checkJs` is deliberately left to the project, exactly as upstream leaves it. The counterpart shadow under the other extension is removed on each run, so a component that changes language does not enter the program twice.

Two svelte2tsx ports were incomplete in the same direction and had to land with it:

- `addComponentExport`'s Svelte 5 isomorphic branch emitted `type X = InstanceType<typeof X>` unconditionally. Upstream picks `export const` plus a `@typedef` when emitting JSDoc, because declaration merging with a `@typedef` needs the const exported. The runes branch already did this; the isomorphic one did not.
- `ExportedNames.handleTypeAssertion` computes its SvelteKit `$types` injection from `tsType || ts.getJSDocType(declaration)`; rsvelte looked only at the TS annotation. `/** @type {any} */ export let form` therefore got `import('./$types.js').ActionData` injected over the author's own type — and on a route with no server actions that reports a member the route's `$types` never had.

### Verification

`packages/kit/test/apps/basics` from https://github.com/sveltejs/kit/pull/16692, against official `svelte-check@4`'s 0 errors:

| | errors |
|---|---|
| before | 68 |
| after | 6 |

A JSDoc violation that used to be accepted silently is now reported, which is the point of the change rather than a side effect.

Of the 6 that remain, 5 are `TS2683 'this' implicitly has type 'any'` and are **not** rsvelte's: TypeScript 7 (`@typescript/native` 7.0.2, which is what `basics` resolves as `typescript`) ignores a JSDoc `@this` when a `@type` is present on the same function, in `.js` and `.jsx` alike, while `tsc` 6.0.3 does not — confirmed on a standalone two-file probe with one tsconfig. The 6th is a `$types` injection whose diagnostic official drops because it lands in generated text; that needs the mapper to distinguish an insertion from an edited chunk and is filed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CQFGbmKgydpTBfK2T1D7da
