### PR TITLE
perf(compiler): place TypeScript statement boundaries through the strip projection

### DIFF
--- a/.changeset/ts-boundaries-through-projection.md
+++ b/.changeset/ts-boundaries-through-projection.md
@@ -1,0 +1,7 @@
+---
+"@rsvelte/compiler": patch
+---
+
+Place TypeScript statement boundaries through the strip projection, so the client
+instance-script pipeline reuses the program Phase 1 already parsed instead of
+parsing the script a second time.

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
@@ -4659,24 +4659,120 @@ fn statement_end_lines_from_spans(
     flush
 }
 
+/// The same spans, for a `script` that TypeScript stripping rewrote, placed
+/// through the projection that records which source bytes survived into it.
+///
+/// Only the first and last byte of each span are mapped, never the whole span:
+/// `let a: number = 1;` loses `: number`, so no annotated statement is one
+/// contiguous copied run, while its two endpoints almost always are — and the
+/// endpoints are all a line boundary needs.
+///
+/// A span whose endpoints both fail to map is a construct stripping deleted
+/// outright (`interface Foo {}`), so it is skipped rather than treated as a
+/// failure: bailing on it would give up on every file that declares a type.
+/// One endpoint mapping without the other is not interpretable, so that bails.
+fn statement_end_lines_via_projection(
+    script: &str,
+    program: &oxc_ast::ast::Program<'_>,
+    projection: &ScriptProjection,
+) -> Option<Vec<bool>> {
+    use oxc_span::GetSpan as _;
+
+    let place = |start: u32, end: u32| -> Option<Option<(u32, u32)>> {
+        if end <= start {
+            return Some(None);
+        }
+        let first = projection.output_range_for_source(start..start + 1);
+        let last = projection.output_range_for_source(end - 1..end);
+        match (first, last) {
+            (Some(first), Some(last)) => Some(Some((first.start, last.end))),
+            (None, None) => Some(None),
+            _ => None,
+        }
+    };
+
+    let mut stmt_spans: Vec<(u32, u32)> = Vec::with_capacity(program.body.len());
+    for stmt in &program.body {
+        let span = stmt.span();
+        if let Some(mapped) = place(span.start, span.end)? {
+            stmt_spans.push(mapped);
+        }
+    }
+    let mut comment_spans: Vec<(u32, u32)> = Vec::with_capacity(program.comments.len());
+    for comment in &program.comments {
+        if let Some(mapped) = place(comment.span.start, comment.span.end)? {
+            comment_spans.push(mapped);
+        }
+    }
+    // Every statement vanishing means the projection placed nothing, which is
+    // not an answer about `script` -- fall back rather than report "no
+    // statement covers any line", which reads as "flush everywhere".
+    if stmt_spans.is_empty() && comment_spans.is_empty() {
+        return None;
+    }
+    let limit = script.len() as u32;
+    if stmt_spans
+        .iter()
+        .chain(comment_spans.iter())
+        .any(|&(s, e)| e > limit || s > e)
+    {
+        return None;
+    }
+    Some(statement_end_lines_from_spans(
+        script,
+        stmt_spans.into_iter(),
+        comment_spans.into_iter(),
+    ))
+}
+
 /// The spans, in `script` coordinates, that `retained` already holds — when
 /// `script` is a verbatim, uniquely-locatable region of the text it parsed and
 /// no statement straddles that region's edge.
 fn statement_end_lines_from_retained(
     script: &str,
     retained: &crate::ast::oxc_program::RetainedProgram<'_>,
+    is_typescript: bool,
+    projection: Option<&ScriptProjection>,
 ) -> Option<Vec<bool>> {
     use oxc_span::GetSpan as _;
 
     if retained.panicked() || !retained.diagnostics().is_empty() {
+        super::profile::record_st_boundary_bail(super::profile::BOUNDARY_BAIL_DIAGNOSTICS);
         return None;
     }
     let core = script.trim();
     let source = retained.source();
     let mut matches = source.match_indices(core);
-    let (core_start, _) = matches.next()?;
+    let text_differs = match (is_typescript, projection.is_some()) {
+        (true, true) => super::profile::BOUNDARY_BAIL_TEXT_DIFFERS_TS,
+        (true, false) => super::profile::BOUNDARY_BAIL_TS_NO_PROJECTION,
+        (false, _) => super::profile::BOUNDARY_BAIL_TEXT_DIFFERS_JS,
+    };
+    // The text is not verbatim. Stripping is what rewrote it, and the
+    // projection records which bytes survived, so the spans can still be
+    // placed -- without it there is nothing left to try.
+    let fall_back_to_projection = || match projection {
+        Some(projection) => {
+            match statement_end_lines_via_projection(script, retained.program(), projection) {
+                Some(ends) => Some(ends),
+                None => {
+                    super::profile::record_st_boundary_bail(
+                        super::profile::BOUNDARY_BAIL_PROJECTION_FAILED,
+                    );
+                    None
+                }
+            }
+        }
+        None => {
+            super::profile::record_st_boundary_bail(text_differs);
+            None
+        }
+    };
+    let Some((core_start, _)) = matches.next() else {
+        return fall_back_to_projection();
+    };
     if matches.next().is_some() {
-        return None;
+        return fall_back_to_projection();
     }
     let core_end = (core_start + core.len()) as u32;
     let core_start = core_start as u32;
@@ -4701,6 +4797,7 @@ fn statement_end_lines_from_retained(
             .iter()
             .any(|comment| straddles(comment.span.start, comment.span.end))
     {
+        super::profile::record_st_boundary_bail(super::profile::BOUNDARY_BAIL_STRADDLE);
         return None;
     }
     // `core` is matched as text, so a region that merely *looks* like the script
@@ -4716,6 +4813,7 @@ fn statement_end_lines_from_retained(
             .iter()
             .any(|comment| comment.span.start == core_start)
     {
+        super::profile::record_st_boundary_bail(super::profile::BOUNDARY_BAIL_UNANCHORED);
         return None;
     }
     Some(statement_end_lines_from_spans(
@@ -4741,6 +4839,8 @@ fn statement_end_lines_from_retained(
 fn top_level_statement_end_lines(
     script: &str,
     retained: Option<&crate::ast::oxc_program::RetainedProgram<'_>>,
+    is_typescript: bool,
+    projection: Option<&ScriptProjection>,
 ) -> Option<Vec<bool>> {
     use oxc_span::GetSpan as _;
 
@@ -4748,7 +4848,15 @@ fn top_level_statement_end_lines(
         return None;
     }
 
-    let reused = retained.and_then(|retained| statement_end_lines_from_retained(script, retained));
+    let reused = match retained {
+        Some(retained) => {
+            statement_end_lines_from_retained(script, retained, is_typescript, projection)
+        }
+        None => {
+            super::profile::record_st_boundary_bail(super::profile::BOUNDARY_BAIL_NO_RETAINED);
+            None
+        }
+    };
     if let Some(ends) = reused.as_ref()
         && !super::profile::boundary_oracle_enabled()
     {
@@ -6510,7 +6618,17 @@ fn transform_instance_script_for_visitors(
     // means the text did not parse, which is not a defect here — the script is
     // mid-pipeline and may not be valid on its own — so the heuristics stay as
     // the fallback.
-    let stmt_end_lines = top_level_statement_end_lines(&script_rest, retained_program);
+    // The projection maps into the script as it entered this function. When
+    // prenormalize rewrote the text, it maps somewhere that no longer exists,
+    // and unlike the verbatim path -- which re-finds its own text and so cannot
+    // be wrong about this -- nothing downstream would catch it.
+    let projection_still_applies = script_rest == original_script;
+    let stmt_end_lines = top_level_statement_end_lines(
+        &script_rest,
+        retained_program,
+        analysis.is_typescript,
+        source_projection.filter(|_| projection_still_applies),
+    );
     super::profile::record_st_boundary_source(stmt_end_lines.is_some());
 
     super::profile::record_st_collect_vars(super::profile::timer_elapsed(_stage));

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/profile.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/profile.rs
@@ -123,6 +123,10 @@ pub struct ScriptTextBreakdown {
     /// Of `boundary_ast`, those answered from the program Phase 1 already
     /// parsed rather than from a parse this pipeline added.
     pub boundary_retained: u64,
+    /// Why the rest could not be: indexed by `BOUNDARY_BAIL_*`. Without this the
+    /// only visible number is the reuse rate, which says a parse was added but
+    /// not what would have to change to stop adding it.
+    pub boundary_bail: [u64; BOUNDARY_BAIL_KINDS],
     /// Statements the runes fast path emitted without calling the processor.
     pub fastpath_statements: u64,
     /// Calls to the brace-less-control-header probe, and the bytes it had to
@@ -232,6 +236,8 @@ thread_local! {
     static ST_BOUNDARY_AST: Cell<u64> = const { Cell::new(0) };
     static ST_BOUNDARY_SCAN: Cell<u64> = const { Cell::new(0) };
     static ST_BOUNDARY_RETAINED: Cell<u64> = const { Cell::new(0) };
+    static ST_BOUNDARY_BAIL: [Cell<u64>; BOUNDARY_BAIL_KINDS] =
+        const { [const { Cell::new(0) }; BOUNDARY_BAIL_KINDS] };
     static ST_FASTPATH_STATEMENTS: Cell<u64> = const { Cell::new(0) };
     static ST_CTRL_HEADER_CALLS: Cell<u64> = const { Cell::new(0) };
     static ST_CTRL_HEADER_BYTES: Cell<u64> = const { Cell::new(0) };
@@ -977,6 +983,46 @@ pub fn record_st_boundary_retained() {
     ST_BOUNDARY_RETAINED.with(|c| c.set(c.get() + 1));
 }
 
+pub const BOUNDARY_BAIL_KINDS: usize = 8;
+/// Phase 1 kept no program for this script.
+pub const BOUNDARY_BAIL_NO_RETAINED: usize = 0;
+/// It kept one, but the parse did not come out clean.
+pub const BOUNDARY_BAIL_DIAGNOSTICS: usize = 1;
+/// The pipeline's text is not a verbatim region of what Phase 1 parsed, on a
+/// TypeScript script — stripping rewrote it.
+pub const BOUNDARY_BAIL_TEXT_DIFFERS_TS: usize = 2;
+/// Same, but the script is not TypeScript, so stripping cannot be the cause and
+/// a projection through it would not help.
+pub const BOUNDARY_BAIL_TEXT_DIFFERS_JS: usize = 5;
+/// TypeScript, and no projection exists to map the retained spans through — so
+/// using the projection cannot recover this one. Separating it keeps "the cause
+/// is TS" from being read as "a projection fixes it".
+pub const BOUNDARY_BAIL_TS_NO_PROJECTION: usize = 6;
+/// A projection existed and still could not place the spans. Separate from
+/// `TEXT_DIFFERS_TS` so a projection path that silently never works is visible
+/// as its own number rather than folded back into the reason it was built for.
+pub const BOUNDARY_BAIL_PROJECTION_FAILED: usize = 7;
+/// A statement or comment crosses the region's edge.
+pub const BOUNDARY_BAIL_STRADDLE: usize = 3;
+/// Nothing begins where the region begins.
+pub const BOUNDARY_BAIL_UNANCHORED: usize = 4;
+
+pub const BOUNDARY_BAIL_NAMES: [&str; BOUNDARY_BAIL_KINDS] = [
+    "no retained program",
+    "retained parse unclean",
+    "text differs, TypeScript",
+    "span straddles the edge",
+    "region unanchored",
+    "text differs, not TypeScript",
+    "TypeScript, no projection",
+    "projection could not place the spans",
+];
+
+#[inline]
+pub fn record_st_boundary_bail(kind: usize) {
+    ST_BOUNDARY_BAIL.with(|a| a[kind].set(a[kind].get() + 1));
+}
+
 #[inline]
 pub fn record_st_loop_lines(n: u64) {
     ST_LOOP_LINES.with(|c| c.set(c.get() + n));
@@ -1023,6 +1069,7 @@ pub fn take_script_text_breakdown() -> ScriptTextBreakdown {
         boundary_ast: ST_BOUNDARY_AST.with(|c| c.replace(0)),
         boundary_scan: ST_BOUNDARY_SCAN.with(|c| c.replace(0)),
         boundary_retained: ST_BOUNDARY_RETAINED.with(|c| c.replace(0)),
+        boundary_bail: ST_BOUNDARY_BAIL.with(|a| std::array::from_fn(|i| a[i].replace(0))),
         fastpath_statements: ST_FASTPATH_STATEMENTS.with(|c| c.replace(0)),
         ctrl_header_calls: ST_CTRL_HEADER_CALLS.with(|c| c.replace(0)),
         ctrl_header_bytes: ST_CTRL_HEADER_BYTES.with(|c| c.replace(0)),

--- a/crates/rsvelte_core/tests/statement_boundary_from_parser.rs
+++ b/crates/rsvelte_core/tests/statement_boundary_from_parser.rs
@@ -100,6 +100,40 @@ fn the_boundaries_come_from_the_program_phase_1_already_parsed() {
     );
 }
 
+/// TypeScript is 100% of the cases where the pipeline's text is not verbatim,
+/// so the projection is the only thing that can place the spans there. The
+/// annotations make the verbatim match fail on purpose — without them stripping
+/// is a no-op, the verbatim path answers, and this test would prove nothing.
+///
+/// `interface Props` is the skip rule: stripping deletes it outright, so neither
+/// endpoint maps, and treating that as a failure would give up on every file
+/// that declares a type.
+#[test]
+fn a_typescript_script_places_its_boundaries_through_the_projection() {
+    use rsvelte_core::compiler::phases::phase3_transform::profile;
+
+    let _ = profile::take_script_text_breakdown();
+    let source = "<script lang=\"ts\">\n  interface Props { label: string }\n  let { label }: Props = $props();\n  let count: number = $state(0);\n  const doubled: number = $derived(count * 2);\n</script>\n\n<p>{label}{count}{doubled}</p>\n";
+    compile(
+        source,
+        CompileOptions {
+            filename: Some("A.svelte".to_string()),
+            generate: GenerateMode::Client,
+            ..Default::default()
+        },
+    )
+    .expect("compile failed");
+    let st = profile::take_script_text_breakdown();
+
+    assert!(
+        st.boundary_retained > 0,
+        "a TypeScript script added a parse instead of placing spans through the \
+         projection: {} from a parser, {} reused",
+        st.boundary_ast,
+        st.boundary_retained
+    );
+}
+
 /// Controls: these two were already in the scanner's list, so they held before
 /// this change and must still hold.
 #[test]

--- a/crates/rsvelte_devtools/src/bin/compile_profile.rs
+++ b/crates/rsvelte_devtools/src/bin/compile_profile.rs
@@ -279,6 +279,26 @@ fn main() {
             .boundary_ast
             .saturating_sub(st_compile.boundary_retained)
     );
+    {
+        let bailed: u64 = st_compile.boundary_bail.iter().sum();
+        let mut kinds: Vec<(usize, u64)> = st_compile
+            .boundary_bail
+            .iter()
+            .enumerate()
+            .map(|(i, n)| (i, *n))
+            .filter(|&(_, n)| n > 0)
+            .collect();
+        kinds.sort_by_key(|&(_, n)| std::cmp::Reverse(n));
+        for (i, n) in kinds {
+            println!(
+                "  [    bail: {:<28} {:6}  ({:5.1}% of {} bails)]",
+                profile::BOUNDARY_BAIL_NAMES[i],
+                n,
+                n as f64 / bailed.max(1) as f64 * 100.0,
+                bailed
+            );
+        }
+    }
     println!(
         "  [store_subs measured through compile(), total {:7.2}ms]",
         ms(compile_total)


### PR DESCRIPTION
Stacked on #2699 — review that one first.

#2699 takes the client statement boundaries from a parser, and reuses the program
Phase 1 already parsed where the pipeline's text is a verbatim region of it. That
covered **29.1%** of shipping scripts. This PR covers the rest that can be covered.

## What the remaining 70.9% turned out to be

Counted rather than guessed, over 5,879 shipping files (`compile_profile --shipped`):

| bail reason | count |
|---|---|
| text differs (TypeScript stripping rewrote it) | **2,996 (100%)** |
| no retained program | 0 |
| retained parse unclean | 0 |
| span straddles the edge | 0 |
| region unanchored | 0 |

One reason, and `no retained program` is **zero** — Phase 1's program is always in
hand. Splitting that reason again: **2,624 (87.6%) already carry a projection**
recording which source bytes survived stripping; 373 do not.

That split is what decided the shape of this PR. Using the projection needs **no
plumbing change** — `source_projection` is already threaded into this function.
Widening where projections are built would change `extract_imports_with_projection`
routing, and is left out.

## Three decisions, each forced by the data

**Only each span's first and last byte are mapped.** `let a: number = 1;` loses
`: number`, so no annotated statement is one contiguous copied run —
`output_range_for_source` on the whole span always fails. The two endpoints
almost always survive, and endpoints are all a line boundary needs.

**A span whose endpoints both fail to map is skipped, not failed.**
`interface Foo {}` is deleted outright. Bailing on it would give up on every file
that declares a type — the 87.6% would have been a paper number.

**The projection is dropped when prenormalize rewrote the text.** It maps into the
script as it entered the function. Prenormalize caused **0** bails, but not firing
and being safe are different claims: the verbatim path re-finds its own text and
so cannot be wrong about this, and the projected path has no such self-check.

## Result

| | before | after |
|---|---|---|
| reused Phase 1's parse | 1,231 / 4,227 (29.1%) | **3,854 / 4,227 (91.2%)** |
| added a parse | 2,996 | **373** |
| projection failed to place spans | — | **0** |

**2,623 shipping scripts stop paying a second parse.** Every remaining bail is the
one reason left (`no projection`), with no unexpected failure mode.

## Gates

- corpus verify ×3 targets: 13,218 match, **0** js-mismatch / js-unparseable / css / error; 39,653 modules parse
- mutation fuzz, full sweep: 36 known, **0 crashes**, no regressions
- shape matrix: 206 known, no regressions
- warnings + errors: no regressions
- clippy `-D warnings`, `cargo fmt --check`: clean
- 7/7 boundary tests

## The counter is the only thing that can see this

Reuse answers the same question a fresh parse does, so a path that bailed on every
file would leave all 14,166 corpus entries byte-identical and this PR inert.
`a_typescript_script_places_its_boundaries_through_the_projection` counts hits
through `compile()`; **disabling the projection leaves the other six tests in that
file green and fails only that one.**

## This will not move CodSpeed

`bench_transform` calls `transform_component`, which hard-codes
`retained_scripts: None`, so the reuse cannot fire there — the same reason the
`transform_client` benchmark on #2699 shows a regression that `full_compile` does
not. **Removing 2,623 real parses will move that benchmark by nothing.** Worth
fixing separately; it shifts the baseline of every transform benchmark.
