### PR TITLE
docs(compat): record option-as-axis, and the option class the matrix cannot see

### DIFF
--- a/compatibility/gate-coverage.md
+++ b/compatibility/gate-coverage.md
@@ -574,6 +574,35 @@ official**, while the live divergences are on `<svelte:body>` and `<svelte:self>
 names its element removes that class of misattribution; a hand-written repro cannot, because the
 reporter chooses the element. **[D]**
 
+### Blind spot 5j — option-as-axis is reusable, but an option that lands outside `js.code` is vacuous here
+
+`async-derived` made a compile **option** an axis for the first time (`run.mjs:156`), and the
+capability generalises to any option — the mechanics and the collision hazard are in
+[scripts/compat-corpus/README.md](../scripts/compat-corpus/README.md#generated-shape-matrix-matrix).
+What does **not** generalise is observability. `run.mjs` reads `result.js.code` and nothing else
+off the result object (`:167,173`), plus the warning `code` multiset and the error `code`. An
+option whose effect lands anywhere else produces identical output on both sides *by
+construction*, so declaring it as an axis buys a green column that means nothing — the vacuous
+green of § *A named blind-spot class*, one level up from an input that is merely absent.
+
+The sharp case is #2697, which raises `compile.modernAst` and `parse.skipCssAst` as declared at
+the NAPI boundary and accepted. The matrix reaches neither, **for two different reasons**, and
+the distinction is the point: `modernAst` *is* expressible as an axis and would be vacuous —
+official spends it entirely on `result.ast` (`compiler/index.js:58`,
+`result.ast = to_public_ast(source, parsed, options.modernAst)`), so both sides emit identical
+`js.code` whatever rsvelte does with it, and **an inert option and an option this gate cannot
+see are the same verdict**. `skipCssAst` is not expressible at all — it is an option of `parse`
+(`rsvelte_napi/src/lib.rs:219`), and this harness only ever calls `compile` / `compileModule`.
+Reading "the matrix cannot gate #2697" without that split invites someone to add the axis and
+read its green as evidence.
+
+The rest of that class — `runes`, `namespace`, `accessors`, `customElement`,
+`preserveWhitespace`, `preserveComments`, `hmr`, `discloseVersion`, further `experimental.*` —
+does surface in `js.code` and is reachable. Cost is not the constraint: an option axis compiles
+exactly like a shape axis. **[S]**
+
+---
+
 **Closing 5b/5c:** the matrix costs ~20 s of CPU on ~8,900 comparisons (wall clock on a box running other agents' builds is unusable — a paired A/B inverted once). Widening the markup axis (a
 second expression axis against `EXPRESSION_SLOTS`) is cheap relative to every other gate here.
 This is the highest value-per-cost item in this document. The `.warnings` half of that

--- a/scripts/compat-corpus/README.md
+++ b/scripts/compat-corpus/README.md
@@ -428,6 +428,41 @@ swallow: both compilers rejecting says nothing if rsvelte rejected for an
 unrelated reason. `run.mjs` now compares the two error codes and reports
 `error-code-mismatch` when they differ — for every family, not just this one.
 
+**An axis can be a compile OPTION, not just a source shape.** A case may carry
+`options`, merged over the per-target set (`run.mjs`: `Object.assign(options,
+testCase.options ?? {})`); the `async-derived` family is the first user and
+`experimental.async` the first option. This generalises — every other harness
+here compiles with a fixed `{ generate, dev, filename }`, so a defect that exists
+only under a flag is unreachable for them at any corpus size — but it costs
+nothing extra per case and has three mechanics and one hard limit:
+
+- **The option is not in the ratchet key.** The key is
+  `` `${id} [${verdict}] (${target})` `` (`run.mjs:274`) and `id` is *also* the
+  artifact path (`TREE/<id>`), so two cases differing only in options must encode
+  the option in the id or they collide in the baseline **and** overwrite each
+  other's output files.
+- **The merge is shallow.** A case's `experimental` replaces the target's whole
+  `experimental` object rather than merging into it. Latent today (no target sets
+  a nested option) and cheap to trip over later.
+- **A case can override the fixed options,** including `css: 'external'` set at
+  `:152` — that is deliberate, but note `result.css` is never compared, so
+  `css: 'injected'` is observable only through what it moves into `js.code`.
+- **Limit: an option whose effect lands outside `js.code`, the warning `code`
+  multiset, or the error `code` is a VACUOUS axis here** — it runs, costs time,
+  and is structurally incapable of reporting anything. `run.mjs` reads
+  `result.js.code` and nothing else off the result object; `map`, `ast` and
+  `metadata` are never touched. `compile.modernAst` is the example: official
+  spends it entirely on `result.ast` (`result.ast = to_public_ast(source, parsed,
+  options.modernAst)`, `compiler/index.js:58`), so both sides would emit
+  identical `js.code` whatever rsvelte did with it. And `parse.skipCssAst` is not
+  expressible as an axis **at all** — it is an option of `parse`, and this
+  harness only ever calls `compile` / `compileModule`. Those are the two options
+  #2697 raises, and the matrix reaches neither, for two different reasons.
+
+  Everything that surfaces in `js.code` *is* reachable: `runes`, `namespace`,
+  `accessors`, `customElement`, `preserveWhitespace`, `preserveComments`, `hmr`,
+  `discloseVersion`, further `experimental.*`.
+
 **Normalization is identical to `verify.mjs`** (flatten template holes → oxfmt →
 strip blank lines). That is a requirement, not a convenience: a divergence this
 gate reports must be one the corpus gate would also report, or the two gates


### PR DESCRIPTION
Follow-up to #2733 (issue #2540). Documentation only — no gate behaviour changes.

`async-derived` made a compile **option** an axis in the shape matrix for the first
time. That is a reusable capability, and #2687 / #2697 are about option handling, so
the next person should not have to rediscover either how to use it or where it stops
working. Two places, because they answer different questions.

## `scripts/compat-corpus/README.md` § Generated shape matrix — how to build one

Where an axis author looks. Records the mechanism (`run.mjs:156`,
`Object.assign(options, testCase.options ?? {})`) and three mechanics that are easy
to trip over, each verified against the code rather than assumed:

- **The option is not in the ratchet key.** The key is `` `${id} [${verdict}] (${target})` ``
  (`run.mjs:274`) and `id` is *also* the artifact path (`TREE/<id>`), so two cases
  differing only in options collide in the baseline **and** overwrite each other's
  output files unless the id encodes the option.
- **The merge is shallow.** A case's `experimental` replaces the target's whole
  `experimental` object. Latent today — no target sets a nested option — and cheap to
  trip over later. Verified by running the merge.
- **A case can override the fixed options,** including `css: 'external'`. Deliberate,
  but `result.css` is never compared, so `css: 'injected'` is observable only through
  what it moves into `js.code`.

## `compatibility/gate-coverage.md` — blind spot 5j, where it stops working

The capability generalises; **observability does not**, and that is the half worth
gating on. `run.mjs` reads `result.js.code` and nothing else off the result object
(`:167,173`), plus the warning `code` multiset and the error `code`. An option whose
effect lands anywhere else produces identical output on both sides *by construction* —
declaring it as an axis buys a green column that means nothing.

The sharp case is **#2697**, which raises `compile.modernAst` and `parse.skipCssAst`
as declared at the NAPI boundary and accepted. The matrix reaches neither — **for two
different reasons**, and the split is the point.

`modernAst` *is* expressible as an axis, and would be vacuous:

```js
// submodules/svelte/packages/svelte/src/compiler/index.js:58
result.ast = to_public_ast(source, parsed, options.modernAst);
```

Official spends it entirely on `result.ast`, which `run.mjs` never reads, so both
sides emit identical `js.code` whatever rsvelte does with it.

`skipCssAst` is not expressible **at all** — it is an option of `parse`
(`rsvelte_napi/src/lib.rs:219`), and this harness only ever calls `compile` /
`compileModule`. I had written a single shared reason for both and checked it before
pushing; it was wrong for `skipCssAst`, which is exactly the class of plausible-but-
unverified claim gate-coverage exists to keep out. Recording "the matrix cannot gate
#2697" without the split would invite someone to add the `modernAst` axis and read its
green as evidence.

The rest of that class *is* reachable, because it surfaces in `js.code`: `runes`,
`namespace`, `accessors`, `customElement`, `preserveWhitespace`, `preserveComments`,
`hmr`, `discloseVersion`, further `experimental.*`. Cost is not the constraint — an
option axis compiles exactly like a shape axis.

## Checks

`known-failures-md-check` (30 ratchets / 22 docs) and its self-test both pass. The two
files' pre-existing prettier warnings are unchanged — verified by re-running the check
on an unmodified tree, and no CI job formats them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016NFR39XQtQHKgv3kgRoCGP
