### PR TITLE
fix(ci): key fixture caches on their generator (#2747)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -272,10 +272,7 @@ jobs:
           # pointing at `.git/modules/svelte/`, not a directory the action
           # can hash.
           path: fixtures
-          # Bump the version to invalidate previously-cached fixtures: the
-          # generate-fixtures script now propagates the validator samples' own
-          # `runes` / `customElement` / `dev`, so an older cache is stale.
-          key: fixtures-v3-${{ runner.os }}-${{ steps.svelte-sha.outputs.sha }}-${{ hashFiles('.gitmodules') }}
+          key: fixtures-${{ runner.os }}-${{ steps.svelte-sha.outputs.sha }}-${{ hashFiles('.gitmodules', 'scripts/fixtures/generate-fixtures.mjs') }}
 
       - name: Cache Svelte compiler build
         # The Svelte compiler is built identically across CI / Compatibility
@@ -432,7 +429,7 @@ jobs:
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: fixtures
-          key: fixtures-v3-${{ runner.os }}-${{ steps.svelte-sha.outputs.sha }}-${{ hashFiles('.gitmodules') }}
+          key: fixtures-${{ runner.os }}-${{ steps.svelte-sha.outputs.sha }}-${{ hashFiles('.gitmodules', 'scripts/fixtures/generate-fixtures.mjs') }}
 
       - name: Cache Svelte compiler build
         id: svelte-build-cache
@@ -832,10 +829,7 @@ jobs:
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: fixtures
-          # Bump the version to invalidate previously-cached fixtures: the
-          # generate-fixtures script now propagates the validator samples' own
-          # `runes` / `customElement` / `dev`, so an older cache is stale.
-          key: fixtures-v3-${{ runner.os }}-${{ steps.svelte-sha.outputs.sha }}-${{ hashFiles('.gitmodules') }}
+          key: fixtures-${{ runner.os }}-${{ steps.svelte-sha.outputs.sha }}-${{ hashFiles('.gitmodules', 'scripts/fixtures/generate-fixtures.mjs') }}
 
       - name: Cache Svelte compiler build
         # See the matching step in the `test` job above.

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -73,7 +73,7 @@ jobs:
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: fixtures
-          key: fixtures-v3-${{ runner.os }}-${{ steps.svelte-sha.outputs.sha }}-${{ hashFiles('.gitmodules') }}
+          key: fixtures-${{ runner.os }}-${{ steps.svelte-sha.outputs.sha }}-${{ hashFiles('.gitmodules', 'scripts/fixtures/generate-fixtures.mjs') }}
 
       - name: Cache cargo registry + target
         uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2


### PR DESCRIPTION
Fixes #2747.

All four generated-fixture cache keys (three CI jobs and coverage) now hash `scripts/fixtures/generate-fixtures.mjs`, alongside OS, Svelte SHA, and `.gitmodules`. Generator changes now rebuild; unchanged inputs retain the same cache key.

The fixture cache was the cache whose producer was missing from its key. The formatter oracle hashes its configuration, lockfile, and pattern inputs; corpus artifacts are not restored through `actions/cache`; staged N-API bindings are built fresh by their consumers.

Validation: checked all four fixture-cache keys contain the generator hash and validated the workflows have no whitespace errors.