### PR TITLE
fix(svelte-check): use last duplicate config key (#2712)

### DIFF
--- a/.changeset/svelte-check-duplicate-config-keys.md
+++ b/.changeset/svelte-check-duplicate-config-keys.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/svelte-check": patch
+---
+
+Use JavaScript's last duplicate config key when reading SvelteKit file settings.

--- a/crates/rsvelte_check/src/svelte_check/kit_file.rs
+++ b/crates/rsvelte_check/src/svelte_check/kit_file.rs
@@ -266,7 +266,7 @@ pub(crate) fn lookup_property<'a>(
     obj: &'a oxc::ObjectExpression,
     name: &str,
 ) -> Option<&'a oxc::Expression<'a>> {
-    for prop in &obj.properties {
+    for prop in obj.properties.iter().rev() {
         let oxc::ObjectPropertyKind::ObjectProperty(p) = prop else {
             continue;
         };
@@ -1226,6 +1226,16 @@ mod tests {
             &mut settings,
         );
         assert_eq!(settings.params_path, "src/my-params");
+    }
+
+    #[test]
+    fn kit_files_duplicate_keys_follow_javascript_last_wins() {
+        let mut settings = KitFilesSettings::default();
+        parse_kit_files_source(
+            "export default { kit: { files: { params: 'first', params: 'last' } } };",
+            &mut settings,
+        );
+        assert_eq!(settings.params_path, "last");
     }
 
     #[test]


### PR DESCRIPTION
Fixes #2712.

`kit_file::lookup_property` now iterates object properties in reverse, matching JavaScript and `ConfigObject::get`: the final duplicate key wins.

The sweep found one hand-rolled AST object reader in `rsvelte_check` (`lookup_property`); the schema reader already uses reverse iteration. Adds a duplicate nested `kit.files.params` test.

Validation:
- `cargo test -p rsvelte_check --lib kit_files_duplicate_keys_follow_javascript_last_wins -- --nocapture`
- `cargo test -p rsvelte_check --lib options_schema -- --nocapture`