### PR TITLE
fix(corpus): reject incomplete compile artifacts (#2707)

### DIFF
--- a/scripts/compat-corpus/artifacts.mjs
+++ b/scripts/compat-corpus/artifacts.mjs
@@ -156,6 +156,34 @@ export function requireGenerationUnchanged(corpusDir, before, label) {
 	}
 }
 
+/** Ensure workers never reinterpret a deleted input as a compiler failure. */
+export function assertCorpusSourcesPresent(corpusDir, manifest) {
+	const missing = manifest
+		.map(({ id }) => id)
+		.filter((id) => !fs.statSync(path.join(corpusDir, 'sources', id), { throwIfNoEntry: false })?.isFile());
+	if (missing.length) {
+		throw new Error(
+			`missing ${missing.length}/${manifest.length} source artifact(s), first: ${missing.slice(0, 3).join(', ')}`
+		);
+	}
+}
+
+/**
+ * Every entry has a warning map, even when both compilers were silent. This
+ * keeps a deleted artifact distinguishable from an empty warning set.
+ */
+export function missingCompiledArtifacts(tree, id, targetKeys) {
+	const dir = path.join(tree, id);
+	const missing = [];
+	if (!fs.existsSync(path.join(dir, 'warnings.json'))) missing.push('warnings.json');
+	const errorPath = path.join(dir, 'error.json');
+	const errors = fs.existsSync(errorPath) ? JSON.parse(fs.readFileSync(errorPath, 'utf8')) : {};
+	for (const key of targetKeys) {
+		if (!(key in errors) && !fs.existsSync(path.join(dir, `${key}.js`))) missing.push(`${key}.js or error.json`);
+	}
+	return missing;
+}
+
 export function keepArtifacts(argv, { failed }) {
 	if (argv.includes('--clean-artifacts')) return false;
 	if (argv.includes('--keep-artifacts')) return true;

--- a/scripts/compat-corpus/compile.mjs
+++ b/scripts/compat-corpus/compile.mjs
@@ -26,7 +26,14 @@ import { spawn } from 'node:child_process';
 import { createRequire } from 'node:module';
 import { fileURLToPath } from 'node:url';
 import { selectTargets } from './targets.mjs';
-import { BYTES_PER_TARGET, DISK_HEADROOM, requireDiskSpace, readGeneration, requireGenerationUnchanged } from './artifacts.mjs';
+import {
+	BYTES_PER_TARGET,
+	DISK_HEADROOM,
+	requireDiskSpace,
+	readGeneration,
+	requireGenerationUnchanged,
+	assertCorpusSourcesPresent,
+} from './artifacts.mjs';
 import { assertOracleCompiles } from './oracle.mjs';
 import { errorCode } from './error-code.mjs';
 
@@ -165,13 +172,9 @@ if (args.includes('--worker')) {
 			if (target.css && r.css != null) {
 				fs.writeFileSync(path.join(dir, `${target.key}.css`), r.css);
 			}
-			// Only entries that actually warn get a file; absence means "compiled
-			// with no warnings", which verify.mjs reads as the empty list.
 			if (r.warnings.length) warnings[target.key] = r.warnings;
 		}
-		if (Object.keys(warnings).length) {
-			fs.writeFileSync(path.join(dir, 'warnings.json'), JSON.stringify(warnings, null, '\t') + '\n');
-		}
+		fs.writeFileSync(path.join(dir, 'warnings.json'), JSON.stringify(warnings, null, '\t') + '\n');
 		if (Object.keys(errors).length) {
 			fs.writeFileSync(path.join(dir, 'error.json'), JSON.stringify(errors, null, '\t') + '\n');
 		}
@@ -196,6 +199,14 @@ if (!fs.existsSync(BINDING)) {
 	console.error('  build: cargo build --release -p rsvelte_napi --lib');
 	console.error('  stage: mkdir -p .corpus-cache && cp target/release/librsvelte_napi.{dylib,so} .corpus-cache/rsvelte.node.staging && mv .corpus-cache/rsvelte.node.staging .corpus-cache/rsvelte.node');
 	process.exit(1);
+}
+
+try {
+	assertCorpusSourcesPresent(CORPUS, manifest);
+} catch (e) {
+	console.error(`[compile] ${e.message}`);
+	console.error('  re-run: node scripts/compat-corpus/collect.mjs');
+	process.exit(2);
 }
 
 // A full run always starts from a clean tree so removed corpus ids and stale
@@ -237,6 +248,7 @@ function recordPanic(i) {
 	const err = { code: 'rust_panic', message: 'rsvelte compiler panicked (process aborted)' };
 	const errors = Object.fromEntries(TARGETS.map((t) => [t.key, err]));
 	fs.writeFileSync(path.join(dir, 'error.json'), JSON.stringify(errors, null, '\t') + '\n');
+	fs.writeFileSync(path.join(dir, 'warnings.json'), '{}\n');
 }
 
 function runRange(start, end) {

--- a/scripts/compat-corpus/verify.mjs
+++ b/scripts/compat-corpus/verify.mjs
@@ -149,6 +149,7 @@ import {
 	cleanupArtifacts,
 	readGeneration,
 	requireGenerationUnchanged,
+	missingCompiledArtifacts,
 } from './artifacts.mjs';
 import { refuseUnrepresentativeBaseline } from './baseline-guard.mjs';
 
@@ -305,22 +306,20 @@ if (manifest.length < MIN_MANIFEST_ENTRIES) {
 // tree reads that side as "no output, no error" and scores every entry `match` —
 // a green run that measured nothing, and one that `--update-*-baseline` would
 // then write out as an empty ratchet.
-function hasOutputs(tree, id) {
-	const errPath = path.join(tree, id, 'error.json');
-	const errors = fs.existsSync(errPath) ? JSON.parse(fs.readFileSync(errPath, 'utf8')) : {};
-	return TARGET_KEYS.every((key) => key in errors || fs.existsSync(path.join(tree, id, `${key}.js`)));
-}
-
 // Checked per tree, not against the union: a wiped `expected/` beside an intact
 // `actual/` passes a union check, and the error comparison then sees no official
 // error to compare against and scores parity everywhere. The 1% slack is for the
 // crashed-worker case, where `recordPanic` writes only the rsvelte side.
 for (const [label, tree] of [['expected', EXPECTED], ['actual', ACTUAL]]) {
-	const compiled = manifest.filter(({ id }) => hasOutputs(tree, id)).length;
+	const incomplete = manifest
+		.map(({ id }) => [id, missingCompiledArtifacts(tree, id, TARGET_KEYS)])
+		.filter(([, missing]) => missing.length);
+	const compiled = manifest.length - incomplete.length;
 	if (compiled < manifest.length * 0.99) {
 		console.error(
 			`[verify] only ${compiled}/${manifest.length} manifest entries have ${label}/ output for every target (${TARGET_KEYS.join(', ')})`
 		);
+		console.error(`  first incomplete entry: ${incomplete[0][0]} (${incomplete[0][1].join(', ')})`);
 		console.error('  run: node scripts/compat-corpus/compile.mjs   (outputs are deleted after a green verify)');
 		process.exit(2);
 	}

--- a/scripts/dev/test-corpus-artifact-completeness.mjs
+++ b/scripts/dev/test-corpus-artifact-completeness.mjs
@@ -1,0 +1,54 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { assertCorpusSourcesPresent, missingCompiledArtifacts } from '../compat-corpus/artifacts.mjs';
+
+let failed = false;
+function check(name, fn) {
+	try {
+		fn();
+		console.log(`[test-corpus-artifact-completeness] ok   ${name}`);
+	} catch (e) {
+		console.error(`[test-corpus-artifact-completeness] FAIL ${name}: ${e.message}`);
+		failed = true;
+	}
+}
+
+const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'corpus-artifacts-'));
+try {
+	const manifest = [{ id: 'fixture.svelte' }];
+	fs.mkdirSync(path.join(dir, 'sources'), { recursive: true });
+	fs.writeFileSync(path.join(dir, 'sources', 'fixture.svelte'), '<h1 />');
+	check('complete sources pass', () => assertCorpusSourcesPresent(dir, manifest));
+	fs.rmSync(path.join(dir, 'sources', 'fixture.svelte'));
+	check('missing sources fail before workers run', () => {
+		try {
+			assertCorpusSourcesPresent(dir, manifest);
+			throw new Error('expected source preflight to throw');
+		} catch (e) {
+			if (!e.message.includes('missing 1/1 source artifact')) throw e;
+		}
+	});
+
+	const output = path.join(dir, 'expected', 'fixture.svelte');
+	fs.mkdirSync(output, { recursive: true });
+	fs.writeFileSync(path.join(output, 'client.js'), 'export {};');
+	fs.writeFileSync(path.join(output, 'error.json'), JSON.stringify({ server: { code: 'x' } }));
+	fs.writeFileSync(path.join(output, 'warnings.json'), '{}');
+	check('complete output and empty warnings pass', () => {
+		if (missingCompiledArtifacts(path.join(dir, 'expected'), 'fixture.svelte', ['client', 'server']).length) {
+			throw new Error('complete artifacts reported missing');
+		}
+	});
+	fs.rmSync(path.join(output, 'warnings.json'));
+	check('missing warning artifact is not mistaken for silence', () => {
+		const missing = missingCompiledArtifacts(path.join(dir, 'expected'), 'fixture.svelte', ['client', 'server']);
+		if (!missing.includes('warnings.json')) throw new Error(`missing warning file was not reported: ${missing}`);
+	});
+} finally {
+	fs.rmSync(dir, { recursive: true, force: true });
+}
+
+if (failed) process.exit(1);

--- a/scripts/dev/test-corpus-parse-gate.mjs
+++ b/scripts/dev/test-corpus-parse-gate.mjs
@@ -111,6 +111,7 @@ function buildSandbox() {
 			const dir = path.join(CORPUS, tree, id);
 			fs.mkdirSync(dir, { recursive: true });
 			fs.writeFileSync(path.join(dir, 'client.js'), GOOD);
+			fs.writeFileSync(path.join(dir, 'warnings.json'), '{}\n');
 		}
 	}
 	fs.writeFileSync(path.join(CORPUS, 'manifest.json'), JSON.stringify(manifest));

--- a/scripts/dev/test-corpus-verify-baseline-flags.mjs
+++ b/scripts/dev/test-corpus-verify-baseline-flags.mjs
@@ -95,6 +95,7 @@ function buildSandbox() {
 		for (const tree of ['expected', 'actual']) {
 			const dir = path.join(CORPUS, tree, id);
 			fs.mkdirSync(dir, { recursive: true });
+			fs.writeFileSync(path.join(dir, 'warnings.json'), '{}\n');
 			// One entry both sides reject with the same code and different detail,
 			// so the error family has a non-empty population to rewrite from. With
 			// none, verify refuses the rewrite and this file would be testing the


### PR DESCRIPTION
## Summary

- validate every manifest source before workers can report a deleted input as a compiler panic
- write `warnings.json` for every compiled entry, including empty warning sets
- require that artifact in each expected/actual tree before any verify verdict
- add a discriminating artifact-completeness control

## Validation

- `node scripts/dev/test-corpus-artifact-completeness.mjs`
- `node --check scripts/compat-corpus/{artifacts,compile,verify}.mjs`
- `git diff --check`

Fixes #2707