### PR TITLE
fix(napi): reject skipCssAst outside parseEnvelope (#2697)

### DIFF
--- a/crates/rsvelte_napi/src/lib.rs
+++ b/crates/rsvelte_napi/src/lib.rs
@@ -157,6 +157,16 @@ impl NapiParseOptions {
 pub fn napi_parse(source: String, options: Option<NapiParseOptions>) -> napi::Result<String> {
     use rsvelte_core::compiler::phases::phase1_parse::{ParseOptions, parse as rust_parse};
 
+    if options
+        .as_ref()
+        .and_then(|options| options.skip_css_ast.as_ref())
+        .is_some()
+    {
+        return Err(napi::Error::from_reason(
+            "skipCssAst is only supported by parseEnvelope",
+        ));
+    }
+
     let parse_options = ParseOptions {
         skip_expression_loc: NapiParseOptions::flag(
             options

--- a/scripts/dev/test-napi-compile-options.mjs
+++ b/scripts/dev/test-napi-compile-options.mjs
@@ -528,8 +528,18 @@ const PARSE_SRC = '<script>let x = 1 + 2;</script>\n<h1>{x}</h1>\n<style>h1 { co
 		`${locCount(full)} -> ${locCount(skipped)}`
 	);
 
-	// `skipCssAst` is only read by `parseEnvelope` — `napi_parse` never consults
-	// it, so this is the entry point that can observe it.
+	assert(
+		'parse.skipCssAst: parse rejects an envelope-only option',
+		(() => {
+			try {
+				napi.parse(PARSE_SRC, { skipCssAst: true });
+				return false;
+			} catch (e) {
+				return String(e.message).includes('only supported by parseEnvelope');
+			}
+		})()
+	);
+
 	covered.add('parse.skipCssAst');
 	const envFull = napi.parseEnvelope(PARSE_SRC, {});
 	const envSkipped = napi.parseEnvelope(PARSE_SRC, { skipCssAst: true });


### PR DESCRIPTION
## Summary

- reject `skipCssAst` on the JSON `parse()` endpoint instead of accepting and ignoring it
- retain the supported `parseEnvelope()` path and assert both behaviors in the option-boundary gate

## Validation

- `cargo fmt --check`
- `node --check scripts/dev/test-napi-compile-options.mjs`
- `git diff --check`
- native addon rebuild and `pnpm run test:napi-options` are in progress

Partially addresses #2697; `compile.modernAst` remains tracked there.