### PR TITLE
fix(compiler): warn for deprecated options when false (#2542)

### DIFF
--- a/.changeset/deprecated-option-presence.md
+++ b/.changeset/deprecated-option-presence.md
@@ -1,0 +1,5 @@
+---
+'@rsvelte/compiler': patch
+---
+
+Warn for deprecated `accessors` and `immutable` options whenever they are supplied, including `false`.

--- a/crates/rsvelte_core/src/compiler/mod.rs
+++ b/crates/rsvelte_core/src/compiler/mod.rs
@@ -115,6 +115,10 @@ pub struct LegacyOptions {
     /// `generate: 'dom' | 'ssr'` — the pre-Svelte-5 spellings of
     /// `'client'` / `'server'`, still honoured but renamed.
     pub generate_dom_ssr: bool,
+    /// `accessors` — deprecated in Svelte 5. Presence matters even for `false`.
+    pub accessors: bool,
+    /// `immutable` — deprecated in Svelte 5. Presence matters even for `false`.
+    pub immutable: bool,
     /// `loopGuardTimeout` — removed in Svelte 5.
     pub loop_guard_timeout: bool,
     /// `enableSourcemap` — removed in Svelte 5.
@@ -727,13 +731,18 @@ pub(crate) fn finalize_compile_result(
             phases::phase2_analyze::warnings::options_renamed_ssr_dom(),
         ));
     }
-    if options.accessors && runes_mode {
+    if options.legacy_options.accessors || options.accessors {
         option_warnings.push(phases::phase3_transform::TransformWarning {
             code: "options_deprecated_accessors".to_string(),
             message: "The `accessors` option has been deprecated. It will have no effect in runes mode\nhttps://svelte.dev/e/options_deprecated_accessors".to_string(),
             start: None,
             end: None,
         });
+    }
+    if options.legacy_options.immutable || options.immutable {
+        option_warnings.push(legacy_option_warning(
+            phases::phase2_analyze::warnings::options_deprecated_immutable(),
+        ));
     }
     if options.legacy_options.loop_guard_timeout {
         option_warnings.push(legacy_option_warning(

--- a/crates/rsvelte_core/tests/legacy_compile_options_warnings.rs
+++ b/crates/rsvelte_core/tests/legacy_compile_options_warnings.rs
@@ -57,6 +57,34 @@ fn hydratable_is_reported_as_removed() {
 }
 
 #[test]
+fn deprecated_options_are_reported_when_present_even_if_false() {
+    let mut options = base();
+    options.legacy_options.accessors = true;
+    options.legacy_options.immutable = true;
+    assert_eq!(
+        codes(options),
+        vec![
+            "options_deprecated_accessors",
+            "options_deprecated_immutable"
+        ]
+    );
+}
+
+#[test]
+fn direct_rust_true_deprecated_options_are_reported() {
+    let mut options = base();
+    options.accessors = true;
+    options.immutable = true;
+    assert_eq!(
+        codes(options),
+        vec![
+            "options_deprecated_accessors",
+            "options_deprecated_immutable"
+        ]
+    );
+}
+
+#[test]
 fn hydratable_message_matches_upstream() {
     let mut options = base();
     options.legacy_options.hydratable = true;

--- a/crates/rsvelte_napi/src/lib.rs
+++ b/crates/rsvelte_napi/src/lib.rs
@@ -954,12 +954,14 @@ impl NapiCompileOptions {
         }
         if let Some(v) = &self.accessors {
             opts.accessors = coerce_bool("accessors", v)?;
+            opts.legacy_options.accessors = true;
         }
         if let Some(v) = &self.namespace {
             opts.namespace = coerce_namespace(v)?;
         }
         if let Some(v) = &self.immutable {
             opts.immutable = coerce_bool("immutable", v)?;
+            opts.legacy_options.immutable = true;
         }
         if let Some(v) = &self.css {
             opts.css = coerce_css(v)?;

--- a/scripts/dev/test-napi-compile-options.mjs
+++ b/scripts/dev/test-napi-compile-options.mjs
@@ -454,6 +454,14 @@ console.log('\n# compile options');
 for (const c of COMPILE_CASES) runCase('compile', (s, o) => napi.compile(s, o), c);
 covered.add('compile.modernAst');
 
+for (const key of ['accessors', 'immutable']) {
+	const result = napi.compile(LEGACY_SRC, { filename: 'A.svelte', [key]: false });
+	assert(
+		`compile.${key}: false still reports the deprecated option`,
+		warningCodes(result).includes(`options_deprecated_${key}`)
+	);
+}
+
 // `generate: 'dom'` is the pre-Svelte-5 spelling of the same key; it must still
 // select the client target AND raise the rename warning.
 {


### PR DESCRIPTION
## Summary

- retain `accessors` and `immutable` option presence through the N-API boundary
- emit the upstream deprecation warnings for explicit `false`, legacy mode, and direct Rust `true` options
- add core and N-API-boundary controls

## Validation

- `cargo fmt --check`
- `cargo test -p rsvelte_core --test legacy_compile_options_warnings -- --nocapture`
- `node --check scripts/dev/test-napi-compile-options.mjs`
- `git diff --check`

Fixes #2542