### PR TITLE
fix(compiler): warn for nested classes in legacy reactive blocks (#2740)

### DIFF
--- a/.changeset/legacy-reactive-nested-class-warning.md
+++ b/.changeset/legacy-reactive-nested-class-warning.md
@@ -1,0 +1,5 @@
+---
+'@rsvelte/compiler': patch
+---
+
+Emit `perf_avoid_nested_class` for classes declared inside legacy reactive statements.

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/class_declaration.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/class_declaration.rs
@@ -33,7 +33,7 @@ pub fn visit_typed(node: &JsNode, context: &mut VisitorContext) -> Result<(), An
             } else {
                 1
             };
-        if context.function_depth > allowed_depth {
+        if context.function_depth > allowed_depth || context.in_reactive_declaration {
             let mut warning = warnings::perf_avoid_nested_class();
             warning.start = node.start();
             warning.end = node.end();
@@ -110,6 +110,12 @@ mod tests {
     fn component_instance_script_allows_the_component_scope() {
         let warnings = component_warnings("<script>\n\tclass A {}\n</script>\n");
         assert!(nested_class(&warnings).is_empty());
+    }
+
+    #[test]
+    fn legacy_reactive_declaration_counts_as_nested_scope() {
+        let warnings = component_warnings("<script>\n$: { class A {} }\n</script>\n");
+        assert_eq!(nested_class(&warnings).len(), 1);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- treat a legacy reactive declaration as nested scope for `perf_avoid_nested_class`
- retain the ordinary top-level instance-script exemption
- add a focused regression test; the generated directive matrix covers the wider shape

## Validation

- `cargo fmt --check`
- `cargo test -p rsvelte_core --lib class_declaration::tests -- --nocapture`
- `git diff --check`

Fixes #2740