### PR TITLE
fix(compiler): preserve async derived leading comments (#2755)

### DIFF
--- a/.changeset/async-derived-leading-comment.md
+++ b/.changeset/async-derived-leading-comment.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/compiler": patch
+---
+
+Preserve leading comments when lowering asynchronous derived declarations.

--- a/compatibility/matrix-known-failures.json
+++ b/compatibility/matrix-known-failures.json
@@ -32,8 +32,6 @@
 	"async-derived/instance__identifier__block-before.svelte [js-mismatch] (client)",
 	"async-derived/instance__identifier__block-before.svelte [js-mismatch] (client-dev)",
 	"async-derived/instance__identifier__block-before.svelte [js-mismatch] (server)",
-	"async-derived/instance__identifier__block-inline.svelte [js-mismatch] (client)",
-	"async-derived/instance__identifier__block-inline.svelte [js-mismatch] (client-dev)",
 	"async-derived/instance__identifier__block-inline.svelte [js-mismatch] (server)",
 	"async-derived/instance__identifier__line-before.svelte [js-mismatch] (client)",
 	"async-derived/instance__identifier__line-before.svelte [js-mismatch] (client-dev)",

--- a/compatibility/matrix-known-failures.md
+++ b/compatibility/matrix-known-failures.md
@@ -28,9 +28,9 @@ Normalization here is identical to `verify.mjs` (flatten template holes → oxfm
 blank lines), so formatting-only differences are tolerated exactly as the corpus gate
 tolerates them. An entry is a divergence that survives that.
 
-## Matrix known failures (`matrix-known-failures.json`, 1368 entries)
+## Matrix known failures (`matrix-known-failures.json`, 1366 entries)
 
-Partition of `matrix-known-failures.json` by family: `2 + 212 + 90 + 18 + 60 + 398 + 3 + 253 + 324 + 8`
+Partition of `matrix-known-failures.json` by family: `2 + 212 + 90 + 18 + 60 + 398 + 3 + 251 + 324 + 8`
 
 ### `binding-position` — 2 entries
 
@@ -368,9 +368,9 @@ until their issues are fixed.
 
 ---
 
-### `async-derived` — 253 entries
+### `async-derived` — 251 entries
 
-Added by #2540. Read the size as a **disclosure**, not a regression: not one of these 253 was
+Added by #2540. Read the size as a **disclosure**, not a regression: not one of these 251 was
 reachable by any gate in the repo before this family existed, because every harness compiles
 with a fixed `{ generate, dev, filename }` and `$derived(await …)` is an `experimental_async`
 compile error without `experimental.async`. The shape occurs 0 times in the 14k-entry corpus
@@ -383,14 +383,14 @@ in dev — is *not* in this list; the rows that isolate it (`instance__identifie
 `instance__multi-declarator__none`, all three targets) pass. What remains are five independent
 defects the family exposed on the way, all of them older than the family:
 
-Partition of `matrix-known-failures.json` entries under `async-derived/` by cause: `154 + 39 + 18 + 14 + 13 + 13 + 2`
+Partition of `matrix-known-failures.json` entries under `async-derived/` by cause: `154 + 39 + 18 + 12 + 13 + 13 + 2`
 
 | # | cause | entries |
 |---|---|---|
 | 1 | `<script module>` / `compileModule` async-derived lowering | 154 |
 | 2 | the `$$d` temp appears in the hoisted `var` list | 39 |
 | 3 | `svelte-ignore` comment not reproduced on the hoisted declaration | 18 |
-| 4 | a block comment before the declaration produces **invalid JavaScript** | 14 |
+| 4 | a block comment before the declaration produces **invalid JavaScript** | 12 |
 | 5a | no `$.save(…)` around a non-final `await` | 13 |
 | 5b | `$derived.by(async …)` is suspended as if it were an async derived | 13 |
 | — | server `$$renderer.async` split lost alongside cause 3 | 2 |

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/shared/async_body.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/shared/async_body.rs
@@ -426,27 +426,9 @@ fn transform_async_body_inner(script: &str, runner: &str, dev: bool) -> Option<A
             continue;
         }
 
-        // Strip leading single-line comment lines from the statement.
-        // The statement splitter may combine a `// comment` line with the following
-        // code line into one statement. We need to process the code, not skip it.
-        let trimmed_stmt = {
-            let mut s = trimmed_stmt;
-            loop {
-                if s.starts_with("//") {
-                    // Skip to end of this comment line
-                    if let Some(nl) = s.find('\n') {
-                        s = s[nl + 1..].trim();
-                    } else {
-                        // Entire statement is a comment — skip
-                        s = "";
-                        break;
-                    }
-                } else {
-                    break;
-                }
-            }
-            s
-        };
+        // The splitter can combine a leading comment with the following statement.
+        // Classify the code, but retain that comment on a generated hoisted `var`.
+        let (leading_comments, trimmed_stmt) = split_leading_comments(trimmed_stmt);
         if trimmed_stmt.is_empty() {
             continue;
         }
@@ -568,8 +550,12 @@ fn transform_async_body_inner(script: &str, runner: &str, dev: bool) -> Option<A
                 let decls = extract_var_declarations(trimmed_stmt);
 
                 // Hoist all variable names
-                for decl in &decls {
-                    hoisted_vars.push(decl.name.clone());
+                for (index, decl) in decls.iter().enumerate() {
+                    if index == 0 && !leading_comments.is_empty() {
+                        hoisted_vars.push(format!("{leading_comments}{}", decl.name));
+                    } else {
+                        hoisted_vars.push(decl.name.clone());
+                    }
                 }
 
                 // Separate non-hoist-only decls for thunk generation
@@ -1951,6 +1937,50 @@ fn is_function_var_declaration(s: &str) -> bool {
 }
 
 /// Check if a statement is a variable declaration.
+fn split_leading_comments(s: &str) -> (&str, &str) {
+    let s = s.trim();
+    let bytes = s.as_bytes();
+    let mut index = 0;
+    let mut saw_comment = false;
+
+    loop {
+        if index + 1 >= bytes.len() || bytes[index] != b'/' {
+            break;
+        }
+        if bytes[index + 1] == b'/' {
+            saw_comment = true;
+            index += 2;
+            while index < bytes.len() && bytes[index] != b'\n' {
+                index += 1;
+            }
+        } else if bytes[index + 1] == b'*' {
+            saw_comment = true;
+            index += 2;
+            while index + 1 < bytes.len() && !(bytes[index] == b'*' && bytes[index + 1] == b'/') {
+                index += 1;
+            }
+            if index + 1 >= bytes.len() {
+                return ("", s);
+            }
+            index += 2;
+        } else {
+            break;
+        }
+
+        while index < bytes.len() && bytes[index].is_ascii_whitespace() {
+            index += 1;
+        }
+    }
+
+    if saw_comment && index == bytes.len() {
+        ("", "")
+    } else if saw_comment {
+        (&s[..index], s[index..].trim())
+    } else {
+        ("", s)
+    }
+}
+
 fn is_variable_declaration(s: &str) -> bool {
     let s = s.trim();
     s.starts_with("let ") || s.starts_with("const ") || s.starts_with("var ")
@@ -2963,6 +2993,27 @@ mod tests {
                 .output
                 .contains("async () => data = await fetch('/api')")
         );
+    }
+
+    #[test]
+    fn test_leading_comments_on_async_var_declarations() {
+        for comment in [
+            "// svelte-ignore await_waterfall\n",
+            "/* svelte-ignore await_waterfall */\n",
+        ] {
+            let script = format!("{comment}const a = await $.async_derived(() => p);");
+            let result = transform_async_body(&script, "$.run").unwrap();
+            assert!(
+                result.output.contains("a = await $.async_derived(() => p)"),
+                "comment must not turn a declaration into a void expression: {}",
+                result.output
+            );
+            assert!(
+                !result.output.contains("void (/*"),
+                "the generated output must stay parseable: {}",
+                result.output
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
Fixes #2755.

Leading line and block comments are now separated before async-body statement classification and retained on the generated hoisted declaration. This prevents a block comment followed by an async `$derived` declaration from being misclassified as an expression and emitted as invalid `void (/* … */ const …)`.

The generated async-derived matrix runs all entry points and targets. This change clears the client and client-dev block-inline rows and re-baselines the shrink-only ratchet. The existing output-parseability gate was also run to verify that output-ratchet entries cannot hide syntactically invalid JavaScript.

Validated with:
- `cargo test -p rsvelte_core --lib async_body::tests::test_leading_comments_on_async_var_declarations -- --nocapture`
- `pnpm run corpus:matrix:update -- --keep-artifacts`
- `node scripts/dev/test-corpus-parse-gate.mjs`