### PR TITLE
test: honor fixture dev options in runtime oracles (#2746)

### DIFF
--- a/crates/rsvelte_core/tests/audit_skipped.rs
+++ b/crates/rsvelte_core/tests/audit_skipped.rs
@@ -178,6 +178,7 @@ fn audit_runtime(category: &str, name: &str) -> Outcome {
 
     if let Some(expected) = &expected_client {
         let options = CompileOptions {
+            dev: fixture_options.dev,
             generate: GenerateMode::Client,
             filename: Some("main.svelte".to_string()),
             css: CssMode::External,
@@ -203,6 +204,7 @@ fn audit_runtime(category: &str, name: &str) -> Outcome {
 
     if let Some(expected) = &expected_server {
         let options = CompileOptions {
+            dev: fixture_options.dev,
             generate: GenerateMode::Server,
             filename: Some("main.svelte".to_string()),
             css: CssMode::External,

--- a/crates/rsvelte_core/tests/common/mod.rs
+++ b/crates/rsvelte_core/tests/common/mod.rs
@@ -390,6 +390,7 @@ impl FixtureCoverage {
 #[derive(Debug, Clone, Copy, Default)]
 pub struct RuntimeFixtureOptions {
     pub r#async: bool,
+    pub dev: bool,
     pub hmr: bool,
     /// The generator only passes `accessors` to the client compile.
     pub accessors: bool,
@@ -414,6 +415,7 @@ pub fn runtime_fixture_options(category: &str, sample: &str) -> RuntimeFixtureOp
 
     RuntimeFixtureOptions {
         r#async: category == "runtime-runes" || without_skip_markers.contains("async: true"),
+        dev: config.contains("dev: true") || config.contains("dev:true"),
         hmr: config.contains("hmr: true"),
         // The official runner defaults runtime-legacy to `accessors: true`
         // (svelte/packages/svelte/tests/runtime-legacy/shared.ts).
@@ -457,7 +459,11 @@ pub const HYDRATION_SKIP_NAMES: &[&str] = &[
 ];
 
 /// server-side-rendering fixtures still failing on the rsvelte port.
-pub const SSR_SKIP_NAMES: &[&str] = &[];
+pub const SSR_SKIP_NAMES: &[&str] = &[
+    // Upstream marks this dev-mode fixture skipped because it cannot assert the
+    // diagnostic that SSR prints rather than throws.
+    "invalid-nested-svelte-element",
+];
 
 /// The documented skip list for a runtime-style fixture category.
 pub fn runtime_skip_names(category: &str) -> &'static [&'static str] {

--- a/crates/rsvelte_core/tests/runtime.rs
+++ b/crates/rsvelte_core/tests/runtime.rs
@@ -128,6 +128,7 @@ fn run_runtime_fixture_test(category: &str, fixture: &RuntimeFixture) -> TestRes
     // Test client-side compilation
     if let Some(expected_client) = &fixture.expected_client_js {
         let client_options = CompileOptions {
+            dev: fixture.options.dev,
             generate: GenerateMode::Client,
             filename: Some("main.svelte".to_string()),
             css: CssMode::External,
@@ -179,6 +180,7 @@ fn run_runtime_fixture_test(category: &str, fixture: &RuntimeFixture) -> TestRes
     // Test server-side compilation
     if let Some(expected_server) = &fixture.expected_server_js {
         let server_options = CompileOptions {
+            dev: fixture.options.dev,
             generate: GenerateMode::Server,
             filename: Some("main.svelte".to_string()),
             css: CssMode::External,

--- a/crates/rsvelte_core/tests/ssr.rs
+++ b/crates/rsvelte_core/tests/ssr.rs
@@ -86,6 +86,7 @@ fn run_ssr_fixture_test(fixture: &SsrFixture) -> TestResult {
     }
 
     let options = CompileOptions {
+        dev: fixture.options.dev,
         generate: GenerateMode::Server,
         filename: Some("main.svelte".to_string()),
         css: CssMode::External,

--- a/crates/rsvelte_devtools/tests/compatibility_report.rs
+++ b/crates/rsvelte_devtools/tests/compatibility_report.rs
@@ -1097,6 +1097,7 @@ fn run_runtime_category_tests(category: &str) -> CategoryResult {
         // Test client
         if let Some(expected) = &expected_client {
             let options = CompileOptions {
+                dev: fixture_options.dev,
                 generate: GenerateMode::Client,
                 filename: Some(input_filename.clone()),
                 css: CssMode::External,
@@ -1131,6 +1132,7 @@ fn run_runtime_category_tests(category: &str) -> CategoryResult {
         // Test server
         if let Some(expected) = &expected_server {
             let options = CompileOptions {
+                dev: fixture_options.dev,
                 generate: GenerateMode::Server,
                 filename: Some(input_filename.clone()),
                 css: CssMode::External,


### PR DESCRIPTION
Fixes #2746.

Runtime, hydration, SSR, skipped-fixture audit, and the compatibility report now compile with each fixture’s configured `compileOptions.dev`, matching the official fixture generator. This exposes option-sensitive divergences instead of comparing production output to a development expectation.

`invalid-nested-svelte-element` is intentionally skipped by upstream because its SSR diagnostic is printed rather than thrown; the shared SSR skip list now mirrors that scope.

Validated with:
- `pnpm run generate-fixtures`
- `cargo test -p rsvelte_core --test runtime -- --nocapture`
- `cargo test -p rsvelte_core --test ssr -- --nocapture`
- `cargo test -p rsvelte_devtools --test compatibility_report --no-run`