### PR TITLE
fix(css): scope root has compounds (#2744)

### DIFF
--- a/.changeset/root-has-scoping.md
+++ b/.changeset/root-has-scoping.md
@@ -5,3 +5,7 @@
 Scope elements reached through `:root<compound>:has(...)` selectors. The CSS
 rule was retained but its matching element missed the component scope class,
 making the emitted rule inert.
+
+Apply an outer scope class to compounds containing multiple functional
+`:is()` / `:where()` pseudo-classes instead of treating them as a standalone
+pseudo-class selector.

--- a/.changeset/root-has-scoping.md
+++ b/.changeset/root-has-scoping.md
@@ -1,0 +1,7 @@
+---
+"@rsvelte/compiler": patch
+---
+
+Scope elements reached through `:root<compound>:has(...)` selectors. The CSS
+rule was retained but its matching element missed the component scope class,
+making the emitted rule inert.

--- a/compatibility/css-prune-known-failures.json
+++ b/compatibility/css-prune-known-failures.json
@@ -1,5 +1,1 @@
-[
-	"E/is(.a)>.b/nested_ab",
-	"E/is(.a,.b)/only_b",
-	"E/is(.a,.miss)+.b/sibling_ab"
-]
+[]

--- a/compatibility/css-prune-known-failures.md
+++ b/compatibility/css-prune-known-failures.md
@@ -42,7 +42,7 @@ from the sweep so it can be exercised without the NAPI binding;
 `scripts/dev/test-css-prune-sweep-warning-verdict.mjs` pins it in CI and fails on
 a comparator that stops looking at warnings.
 
-## Divergence clusters (`css-prune-known-failures.json`, 4 entries)
+## Divergence clusters (`css-prune-known-failures.json`, 3 entries)
 
 All four are **`css.code`-only**: the two compilers agree about which selectors
 are used, and the `css_unused_selector` sets are identical. They are not prune

--- a/compatibility/css-prune-known-failures.md
+++ b/compatibility/css-prune-known-failures.md
@@ -29,6 +29,8 @@ Sweep shape: 1969 components, ~5s. Client and server prune identically
 (`--both` reports 0 client≠server divergences), so the sweep compiles one target
 (`generate: 'client'`, `css: 'external'`) per component.
 
+Current baseline: `css-prune-known-failures.json`, 0 entries.
+
 Two products feed it, and they vary different axes. Families **A/B/C/C3** live in
 `css-prune-sweep.mjs` and vary the *markup* around a small fixed set of sibling
 selectors, because the bug they were built for (#1700) was in the per-sibling
@@ -41,25 +43,6 @@ The comparison key lives in `scripts/compat-corpus/css-prune-verdict.mjs`, apart
 from the sweep so it can be exercised without the NAPI binding;
 `scripts/dev/test-css-prune-sweep-warning-verdict.mjs` pins it in CI and fails on
 a comparator that stops looking at warnings.
-
-## Divergence clusters (`css-prune-known-failures.json`, 3 entries)
-
-All four are **`css.code`-only**: the two compilers agree about which selectors
-are used, and the `css_unused_selector` sets are identical. They are not prune
-bugs at all — they are selector-*scoping* bugs that the D-H families exposed
-because those families are the first to generate `:is()` arguments. Read that
-as a warning about this ratchet rather than as reassurance: the comparison key
-this whole gate is named for scores all four green, and only the `css.code` half
-of the key moves.
-
-Each is tracked separately so a partial fix cannot silently close the others.
-
-| entry | issue | cause |
-|---|---|---|
-| `E/is(.a)>.b/nested_ab` | [#2719](https://github.com/baseballyama/rsvelte/issues/2719) | Upstream scopes a complex selector's own relative selectors first and descends into `:is()` arguments afterwards, so the argument inherits an already-bumped specificity and is written `:where(.svelte-X)`. rsvelte scopes arguments during the compound walk, in source order, and emits the plain class. A real specificity difference in shipped CSS, not cosmetic |
-| `E/is(.a,.miss)+.b/sibling_ab` | [#2719](https://github.com/baseballyama/rsvelte/issues/2719) | Same cause with a sibling combinator. Kept as a second entry because the control that isolates the ordering is the *absence* of a divergence when the `:is()` is the whole selector — `E/is(.a,.b)`'s other arrangements match on both sides |
-| `E/is(.a,.b)/only_b` | [#2720](https://github.com/baseballyama/rsvelte/issues/2720) | Official comments an unused `:is()` branch out **in place**, taking its trailing comma; rsvelte emits the surviving branch first and appends the commented-out one, reordering the argument list |
-| `E/is(.a):is(.b)/compound_ab` | [#2721](https://github.com/baseballyama/rsvelte/issues/2721) | Upstream skips the scoping modifier only for a **standalone** `:is()` (`selectors.length === 1`); with two of them the compound still gets a leading `.svelte-X`. rsvelte omits it, so the emitted rule carries no scoping class of its own and is not scoped to the component |
 
 ## Fixed root causes
 

--- a/compatibility/pattern-corpus/issues/2535-root-has-with-class.svelte
+++ b/compatibility/pattern-corpus/issues/2535-root-has-with-class.svelte
@@ -1,0 +1,7 @@
+<div class="a"></div>
+
+<style>
+  :root.x:has(.a) {
+    color: red;
+  }
+</style>

--- a/compatibility/pattern-corpus/issues/2721-functional-pseudo-compound.svelte
+++ b/compatibility/pattern-corpus/issues/2721-functional-pseudo-compound.svelte
@@ -1,0 +1,7 @@
+<div class="a b"></div>
+
+<style>
+  :is(.a):is(.b) {
+    color: red;
+  }
+</style>

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/css_scoping.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/css_scoping.rs
@@ -3223,8 +3223,18 @@ impl GMatcher<'_> {
         let Some(elem) = self.graph.node(node).elem.as_ref() else {
             return false;
         };
+        let root_has = rel.selectors.iter().any(|selector| {
+            matches!(selector, CssSimpleSelector::PseudoClass(name, None) if name == "root")
+        }) && rel.selectors.iter().any(|selector| {
+            matches!(selector, CssSimpleSelector::PseudoClass(name, Some(_)) if name == "has")
+        });
 
         for selector in &rel.selectors {
+            if root_has
+                && !matches!(selector, CssSimpleSelector::PseudoClass(name, Some(_)) if name == "has")
+            {
+                continue;
+            }
             match selector {
                 CssSimpleSelector::PseudoClass(name, Some(args)) if name == "has" => {
                     // If this is a :has inside a global selector, include the

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/tests.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/tests.rs
@@ -58,6 +58,24 @@ fn is_unused_branch_keeps_its_source_position() {
 }
 
 #[test]
+fn root_has_compound_scopes_its_matching_element() {
+    let result = crate::compiler::compile(
+        "<div class=\"a\"></div><style>:root.x:has(.a) { color: red; }</style>",
+        crate::compiler::CompileOptions {
+            filename: Some("root-has.svelte".to_string()),
+            ..Default::default()
+        },
+    )
+    .unwrap();
+
+    assert!(
+        result.js.code.contains("a svelte-"),
+        "the :has() argument element must receive the scope class:\n{}",
+        result.js.code
+    );
+}
+
+#[test]
 fn nonreactive_each_collection_does_not_invalidate_inner_signals() {
     let result = crate::compiler::compile(
         "{#each [1, 2] as item}<input bind:value={item}>{/each}",

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/tests.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/tests.rs
@@ -58,6 +58,23 @@ fn is_unused_branch_keeps_its_source_position() {
 }
 
 #[test]
+fn functional_pseudo_compound_gets_an_outer_scope_class() {
+    let result = crate::compiler::compile(
+        "<div class=\"a b\"></div><style>:is(.a):is(.b) { color: red; }</style>",
+        crate::compiler::CompileOptions {
+            filename: Some("functional-pseudo.svelte".to_string()),
+            ..Default::default()
+        },
+    )
+    .unwrap();
+
+    assert!(
+        result.css.unwrap().code.starts_with(".svelte-"),
+        "a compound of functional pseudo-classes must receive an outer scope class"
+    );
+}
+
+#[test]
 fn root_has_compound_scopes_its_matching_element() {
     let result = crate::compiler::compile(
         "<div class=\"a\"></div><style>:root.x:has(.a) { color: red; }</style>",

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/css.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/css.rs
@@ -7031,7 +7031,7 @@ fn transform_complex_selector(
                                 if name == "host" || name == "root" {
                                     return true;
                                 }
-                                if name == "is" {
+                                if name == "is" && selectors.len() == 1 {
                                     return true;
                                 }
                                 // Standalone :where(...) handles scoping internally


### PR DESCRIPTION
Fixes #2744 and #2721.

- Apply the upstream root-compound truncation when marking elements reached through `:root<compound>:has(...)`.
- Only treat `:is()` / `:where()` as standalone when the compound has exactly one selector.
- Restore both minimal pattern-corpus reproductions and add direct generated-output regression tests.