### PR TITLE
fix(css): preserve functional selector output (#2720, #2719)

### DIFF
--- a/.changeset/is-unused-branch-order.md
+++ b/.changeset/is-unused-branch-order.md
@@ -4,3 +4,7 @@
 
 Keep partially unused `:is()` / `:where()` selector-list branches in source
 order when emitting their `(unused)` comments.
+
+Preserve selector specificity by applying the complex selector's scope bump to
+functional pseudo-class arguments even when their scoped sibling appears later
+in source order.

--- a/.changeset/is-unused-branch-order.md
+++ b/.changeset/is-unused-branch-order.md
@@ -1,0 +1,6 @@
+---
+"@rsvelte/compiler": patch
+---
+
+Keep partially unused `:is()` / `:where()` selector-list branches in source
+order when emitting their `(unused)` comments.

--- a/compatibility/css-prune-known-failures.json
+++ b/compatibility/css-prune-known-failures.json
@@ -1,5 +1,4 @@
 [
-	"E/is(.a):is(.b)/compound_ab",
 	"E/is(.a)>.b/nested_ab",
 	"E/is(.a,.b)/only_b",
 	"E/is(.a,.miss)+.b/sibling_ab"

--- a/compatibility/pattern-corpus/issues/2719-is-argument-specificity.svelte
+++ b/compatibility/pattern-corpus/issues/2719-is-argument-specificity.svelte
@@ -1,0 +1,7 @@
+<div class="a"><div class="b"></div></div>
+
+<style>
+  :is(.a) > .b {
+    color: red;
+  }
+</style>

--- a/compatibility/pattern-corpus/issues/2720-is-leading-unused-branch.svelte
+++ b/compatibility/pattern-corpus/issues/2720-is-leading-unused-branch.svelte
@@ -1,0 +1,7 @@
+<div class="b"></div>
+
+<style>
+  :is(.a, .b) {
+    color: red;
+  }
+</style>

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/tests.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/tests.rs
@@ -22,6 +22,24 @@ fn invalidation_single_dependency_keeps_sequence_parentheses() {
 }
 
 #[test]
+fn is_unused_branch_keeps_its_source_position() {
+    let result = crate::compiler::compile(
+        "<div class=\"b\"></div><style>:is(.a, .b) { color: red; }</style>",
+        crate::compiler::CompileOptions {
+            filename: Some("is-unused.svelte".to_string()),
+            ..Default::default()
+        },
+    )
+    .unwrap();
+    let css = result.css.unwrap().code;
+
+    assert!(
+        css.starts_with(":is(/* (unused) .a,*/ .b"),
+        "the leading unused branch must stay before the surviving branch:\n{css}"
+    );
+}
+
+#[test]
 fn nonreactive_each_collection_does_not_invalidate_inner_signals() {
     let result = crate::compiler::compile(
         "{#each [1, 2] as item}<input bind:value={item}>{/each}",

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/tests.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/tests.rs
@@ -22,6 +22,24 @@ fn invalidation_single_dependency_keeps_sequence_parentheses() {
 }
 
 #[test]
+fn is_argument_inherits_later_complex_scope_bump() {
+    let result = crate::compiler::compile(
+        "<div class=\"a\"><div class=\"b\"></div></div><style>:is(.a) > .b { color: red; }</style>",
+        crate::compiler::CompileOptions {
+            filename: Some("is-specificity.svelte".to_string()),
+            ..Default::default()
+        },
+    )
+    .unwrap();
+    let css = result.css.unwrap().code;
+
+    assert!(
+        css.starts_with(":is(.a:where(.svelte-"),
+        "the :is() argument must inherit the later scope bump:\n{css}"
+    );
+}
+
+#[test]
 fn is_unused_branch_keeps_its_source_position() {
     let result = crate::compiler::compile(
         "<div class=\"b\"></div><style>:is(.a, .b) { color: red; }</style>",

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/css.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/css.rs
@@ -7440,8 +7440,7 @@ fn transform_is_not_args(
 
     // args should be a SelectorList
     if let Some(children) = args.get("children").and_then(|c| c.as_array()) {
-        let mut used_selectors = Vec::new();
-        let mut unused_selectors = Vec::new();
+        let mut selectors = Vec::new();
 
         for complex_selector in children.iter() {
             // For :not(), never mark inner selectors as unused
@@ -7458,41 +7457,40 @@ fn transform_is_not_args(
             };
 
             if is_unused {
-                // Collect the raw selector text for unused selectors
-                unused_selectors.push(get_selector_text(complex_selector));
+                selectors.push((true, get_selector_text(complex_selector)));
             } else {
-                // Transform and collect used selectors
-                used_selectors.push(transform_is_not_complex_selector(
-                    complex_selector,
-                    selector,
-                    css_source,
-                    pseudo_name,
-                    ctx,
-                    use_direct_class,
-                    outer_specificity_bumped,
+                selectors.push((
+                    false,
+                    transform_is_not_complex_selector(
+                        complex_selector,
+                        selector,
+                        css_source,
+                        pseudo_name,
+                        ctx,
+                        use_direct_class,
+                        outer_specificity_bumped,
+                    ),
                 ));
             }
         }
 
-        // Build the result: used selectors first, then unused comment
-        for (i, sel) in used_selectors.iter().enumerate() {
+        for (i, (is_unused, selector)) in selectors.iter().enumerate() {
             if i > 0 {
-                result.push_str(", ");
+                result.push(' ');
             }
-            result.push_str(sel);
-        }
-
-        // Add unused selectors as a comment if any
-        if !unused_selectors.is_empty() {
-            if !used_selectors.is_empty() {
-                result.push_str(" /* (unused) ");
-            } else {
-                // All selectors are unused - this case should be handled by the caller
-                // by marking the entire rule as unused
+            if *is_unused {
                 result.push_str("/* (unused) ");
+                result.push_str(selector);
+                if i + 1 < selectors.len() {
+                    result.push(',');
+                }
+                result.push_str("*/");
+            } else {
+                result.push_str(selector);
+                if i + 1 < selectors.len() && !selectors[i + 1].0 {
+                    result.push(',');
+                }
             }
-            result.push_str(&unused_selectors.join(", "));
-            result.push_str("*/");
         }
     } else {
         // Fallback to raw text

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/css.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/css.rs
@@ -6632,6 +6632,34 @@ fn transform_complex_selector(
                 }
             });
 
+        let complex_bumps_specificity = children.iter().any(|relative_selector| {
+            if is_global_like(relative_selector) {
+                return false;
+            }
+            let scoped = relative_selector
+                .get("metadata")
+                .and_then(|metadata| metadata.get("scoped"))
+                .and_then(|scoped| scoped.as_bool())
+                .unwrap_or(true);
+            scoped
+                && relative_selector
+                    .get("selectors")
+                    .and_then(|selectors| selectors.as_array())
+                    .is_some_and(|selectors| {
+                        selectors.iter().any(|selector| {
+                            let ty = selector.get("type").and_then(|ty| ty.as_str());
+                            !matches!(
+                                ty,
+                                Some(
+                                    "PseudoClassSelector"
+                                        | "PseudoElementSelector"
+                                        | "NestingSelector"
+                                )
+                            )
+                        })
+                    })
+        });
+
         // Track if the next relative selector should be treated as global
         // (after a bare :global modifier)
         let mut next_is_global = false;
@@ -7077,7 +7105,8 @@ fn transform_complex_selector(
                             });
                         let compound_bumps =
                             needs_scoping && !has_nesting_selector && !is_standalone_is_where;
-                        let outer_bumped_for_recursion = local_specificity_bumped || compound_bumps;
+                        let outer_bumped_for_recursion =
+                            local_specificity_bumped || compound_bumps || complex_bumps_specificity;
 
                         selector_parts.push_str(&format_simple_selector_with_scope(
                             sel,


### PR DESCRIPTION
Fixes #2720 and #2719.

- Preserve partially-unused `:is()` / `:where()` argument order when commenting branches.
- Make functional pseudo-class arguments inherit the complex selector scope bump even when the bumping sibling follows them in source order.
- Add minimal pattern-corpus cases and generated CSS regression tests for both.