### PR TITLE
fix(client): preserve single invalidation sequence parentheses (#2709)

### DIFF
--- a/.changeset/green-invalidation-sequences.md
+++ b/.changeset/green-invalidation-sequences.md
@@ -1,0 +1,5 @@
+---
+'@rsvelte/compiler': patch
+---
+
+Preserve parentheses around single invalidation sequences in generated client output.

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/tests.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/tests.rs
@@ -12,7 +12,12 @@ fn invalidation_single_dependency_keeps_sequence_parentheses() {
     )
     .unwrap();
 
-    assert!(result.js.code.contains("$.invalidate_inner_signals(() => ("));
+    assert!(
+        result
+            .js
+            .code
+            .contains("$.invalidate_inner_signals(() => (")
+    );
     assert!(!result.js.code.contains("__rsvelte_seq1"));
 }
 

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/tests.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/tests.rs
@@ -1,6 +1,22 @@
 use super::*;
 
 #[test]
+fn invalidation_single_dependency_keeps_sequence_parentheses() {
+    let result = crate::compiler::compile(
+        "<script>let list = [1];</script>{#each list as item}<input bind:value={item}>{/each}",
+        crate::compiler::CompileOptions {
+            filename: Some("each-sequence.svelte".to_string()),
+            runes: Some(false),
+            ..Default::default()
+        },
+    )
+    .unwrap();
+
+    assert!(result.js.code.contains("$.invalidate_inner_signals(() => ("));
+    assert!(!result.js.code.contains("__rsvelte_seq1"));
+}
+
+#[test]
 fn nonreactive_each_collection_does_not_invalidate_inner_signals() {
     let result = crate::compiler::compile(
         "{#each [1, 2] as item}<input bind:value={item}>{/each}",
@@ -12,11 +28,7 @@ fn nonreactive_each_collection_does_not_invalidate_inner_signals() {
     )
     .unwrap();
 
-    assert!(
-        !result.js.code.contains("$.invalidate_inner_signals"),
-        "a collection with no transitive dependencies must not be invalidated:\n{}",
-        result.js.code
-    );
+    assert!(!result.js.code.contains("$.invalidate_inner_signals"));
 }
 
 #[test]
@@ -31,11 +43,7 @@ fn reactive_each_collection_still_invalidates_inner_signals() {
     )
     .unwrap();
 
-    assert!(
-        result.js.code.contains("$.invalidate_inner_signals"),
-        "a collection with a transitive dependency must remain invalidated:\n{}",
-        result.js.code
-    );
+    assert!(result.js.code.contains("$.invalidate_inner_signals"));
 }
 
 #[test]

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/bind_directive.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/bind_directive.rs
@@ -22,6 +22,7 @@ use crate::compiler::phases::phase3_transform::client::visitors::expression_conv
 use crate::compiler::phases::phase3_transform::js_ast::JsArena;
 use crate::compiler::phases::phase3_transform::js_ast::builders as b;
 use crate::compiler::phases::phase3_transform::js_ast::nodes::*;
+use crate::compiler::phases::phase3_transform::js_ast::to_oxc::SINGLE_TARGET_DESTRUCTURE_SEQUENCE_MARKER;
 
 // Note: We implement bind_this directly here rather than using shared/utils
 // to avoid complex borrow checker issues with the context
@@ -2478,7 +2479,14 @@ fn build_invalidation_expr(
 
     // Build: $.invalidate_inner_signals(() => (expr1, expr2, ...))
     if !each_ctx.invalidation_exprs.is_empty() {
-        let inner = each_ctx.invalidation_exprs.join(", ");
+        let inner = if each_ctx.invalidation_exprs.len() == 1 {
+            format!(
+                "{}({})",
+                SINGLE_TARGET_DESTRUCTURE_SEQUENCE_MARKER, each_ctx.invalidation_exprs[0]
+            )
+        } else {
+            each_ctx.invalidation_exprs.join(", ")
+        };
         parts.push(format!("$.invalidate_inner_signals(() => ({}))", inner));
     }
 

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/js_ast/to_oxc.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/js_ast/to_oxc.rs
@@ -1177,7 +1177,8 @@ impl<'a, 'arena> Cx<'a, 'arena> {
     /// strips the synthetic parens. Returns `None` on a parse error.
     fn parse_raw_expression(&self, code: &str) -> Option<Expression<'a>> {
         let wrapped = format!("({})", code.trim());
-        let stmts = self.parse_chunk(&wrapped)?;
+        let mut stmts = self.parse_chunk(&wrapped)?;
+        self.restore_single_target_destructure_sequences(&mut stmts);
         // The synthetic parens are part of the chunk text, so the region already
         // covers them; no caller needs it for an expression.
         self.take_chunk_region(None);


### PR DESCRIPTION
Fixes #2709.

Single dependency invalidations are emitted through the AST sequence marker so `rsvelte_esrap` retains the parentheses required for byte-identical output. Adds a direct Rust generated-code regression test, since corpus comparison normalizes this formatting difference away.

Validated with `cargo fmt --check` and `cargo test -p rsvelte_core --lib`.