### PR TITLE
fix(tests): align runtime fixture compile options (#2746)

### DIFF
--- a/.changeset/runtime-fixture-options.md
+++ b/.changeset/runtime-fixture-options.md
@@ -1,0 +1,5 @@
+---
+'@rsvelte/compiler': patch
+---
+
+Compile runtime fixture checks using the options recorded by the official fixture generator.

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/types.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/types.rs
@@ -2120,6 +2120,9 @@ pub struct ComponentClientTransformState<'a> {
     /// Checked after the root fragment visit; if Some, `transform_client_with_visitors` returns
     /// `Err(TransformError::CodeGen(...))` so the corpus sees an error entry for the client target.
     pub pending_error: Option<String>,
+
+    /// `{@const}` awaits are lowered by the enclosing async template machinery.
+    pub suppress_pickled_await_instrumentation: Cell<bool>,
 }
 
 /// Context information for generating bindings inside each blocks.
@@ -2271,6 +2274,7 @@ impl<'a> ComponentClientTransformState<'a> {
             const_blocker_map: Rc::new(std::cell::RefCell::new(rustc_hash::FxHashMap::default())),
             templates: Rc::new(std::cell::RefCell::new(rustc_hash::FxHashMap::default())),
             pending_error: None,
+            suppress_pickled_await_instrumentation: Cell::new(false),
         }
     }
 

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/const_tag.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/const_tag.rs
@@ -71,7 +71,15 @@ pub fn const_tag(node: &ConstTag, context: &mut ComponentContext) {
         }
 
         // Convert the init expression to JS AST
+        let previous = context
+            .state
+            .suppress_pickled_await_instrumentation
+            .replace(true);
         let converted_init = convert_expression(&parsed.init_expr, context);
+        context
+            .state
+            .suppress_pickled_await_instrumentation
+            .set(previous);
 
         // Build the expression with transforms applied
         let expr_metadata = ExpressionMetadata::from_template_metadata(&node.metadata.expression);
@@ -178,7 +186,15 @@ pub fn const_tag(node: &ConstTag, context: &mut ComponentContext) {
             std::mem::replace(&mut context.state.transform_deep_read, child_deep_read);
 
         // Convert and build the init expression with the child state
+        let previous = context
+            .state
+            .suppress_pickled_await_instrumentation
+            .replace(true);
         let converted_init = convert_expression(&parsed.init_expr, context);
+        context
+            .state
+            .suppress_pickled_await_instrumentation
+            .set(previous);
         let expr_metadata = ExpressionMetadata::from_template_metadata(&node.metadata.expression);
 
         let built_init = build_expression(context, &converted_init, &expr_metadata);

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/expression_converter.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/expression_converter.rs
@@ -444,7 +444,9 @@ fn convert_js_node(node: &JsNode, context: &mut ComponentContext) -> JsExpr {
             let converted_arg = convert_js_node(pa.get_js_node(*argument), context);
 
             // Check if this await is in the pickled_awaits set (needs $.save() wrapping)
-            if context.state.analysis.pickled_awaits.contains(start) {
+            if context.state.analysis.pickled_awaits.contains(start)
+                && !context.state.options.experimental_async
+            {
                 // Pickled await: (await $.save(arg))()
                 JsExpr::Call(JsCallExpression {
                     callee: context
@@ -476,7 +478,7 @@ fn convert_js_node(node: &JsNode, context: &mut ComponentContext) -> JsExpr {
                     arguments: vec![],
                     optional: false,
                 })
-            } else if context.state.options.dev {
+            } else if context.state.options.dev && !context.state.options.experimental_async {
                 // In dev mode, wrap with track_reactivity_loss for non-pickled awaits
                 // (await $.track_reactivity_loss(arg))()
                 JsExpr::Call(JsCallExpression {
@@ -6723,7 +6725,9 @@ fn convert_await_expression(
 
     // Check if this await is in the pickled_awaits set (needs $.save() wrapping)
     let start = obj.get("start").and_then(|s| s.as_u64()).unwrap_or(0) as u32;
-    if context.state.analysis.pickled_awaits.contains(&start) {
+    if context.state.analysis.pickled_awaits.contains(&start)
+        && !context.state.options.experimental_async
+    {
         // Pickled await: wrap argument with $.save()
         // save(argument) returns (await $.save(argument))()
         return JsExpr::Call(JsCallExpression {
@@ -6748,7 +6752,7 @@ fn convert_await_expression(
 
     // In dev mode, wrap with track_reactivity_loss for non-pickled awaits
     // Reference: AwaitExpression.js in the official Svelte compiler
-    if context.state.options.dev {
+    if context.state.options.dev && !context.state.options.experimental_async {
         // (await $.track_reactivity_loss(argument))()
         return JsExpr::Call(JsCallExpression {
             callee: context

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/expression_converter.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/expression_converter.rs
@@ -445,7 +445,7 @@ fn convert_js_node(node: &JsNode, context: &mut ComponentContext) -> JsExpr {
 
             // Check if this await is in the pickled_awaits set (needs $.save() wrapping)
             if context.state.analysis.pickled_awaits.contains(start)
-                && !context.state.options.experimental_async
+                && !context.state.suppress_pickled_await_instrumentation.get()
             {
                 // Pickled await: (await $.save(arg))()
                 JsExpr::Call(JsCallExpression {
@@ -479,7 +479,7 @@ fn convert_js_node(node: &JsNode, context: &mut ComponentContext) -> JsExpr {
                     optional: false,
                 })
             } else if context.state.options.dev
-                && !context.state.analysis.pickled_awaits.contains(start)
+                && !context.state.suppress_pickled_await_instrumentation.get()
             {
                 // In dev mode, wrap with track_reactivity_loss for non-pickled awaits
                 // (await $.track_reactivity_loss(arg))()
@@ -6728,7 +6728,7 @@ fn convert_await_expression(
     // Check if this await is in the pickled_awaits set (needs $.save() wrapping)
     let start = obj.get("start").and_then(|s| s.as_u64()).unwrap_or(0) as u32;
     if context.state.analysis.pickled_awaits.contains(&start)
-        && !context.state.options.experimental_async
+        && !context.state.suppress_pickled_await_instrumentation.get()
     {
         // Pickled await: wrap argument with $.save()
         // save(argument) returns (await $.save(argument))()
@@ -6754,7 +6754,7 @@ fn convert_await_expression(
 
     // In dev mode, wrap with track_reactivity_loss for non-pickled awaits
     // Reference: AwaitExpression.js in the official Svelte compiler
-    if context.state.options.dev && !context.state.analysis.pickled_awaits.contains(&start) {
+    if context.state.options.dev && !context.state.suppress_pickled_await_instrumentation.get() {
         // (await $.track_reactivity_loss(argument))()
         return JsExpr::Call(JsCallExpression {
             callee: context

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/expression_converter.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/expression_converter.rs
@@ -478,7 +478,9 @@ fn convert_js_node(node: &JsNode, context: &mut ComponentContext) -> JsExpr {
                     arguments: vec![],
                     optional: false,
                 })
-            } else if context.state.options.dev && !context.state.options.experimental_async {
+            } else if context.state.options.dev
+                && !context.state.analysis.pickled_awaits.contains(start)
+            {
                 // In dev mode, wrap with track_reactivity_loss for non-pickled awaits
                 // (await $.track_reactivity_loss(arg))()
                 JsExpr::Call(JsCallExpression {
@@ -6752,7 +6754,7 @@ fn convert_await_expression(
 
     // In dev mode, wrap with track_reactivity_loss for non-pickled awaits
     // Reference: AwaitExpression.js in the official Svelte compiler
-    if context.state.options.dev && !context.state.options.experimental_async {
+    if context.state.options.dev && !context.state.analysis.pickled_awaits.contains(&start) {
         // (await $.track_reactivity_loss(argument))()
         return JsExpr::Call(JsCallExpression {
             callee: context

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/fragment.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/fragment.rs
@@ -7,7 +7,7 @@
 //! The Fragment visitor handles the transformation of Fragment nodes into client-side
 //! JavaScript code. It creates a template block and processes its children.
 
-use std::rc::Rc;
+use std::{cell::Cell, rc::Rc};
 
 use crate::ast::template::{Fragment, TemplateNode};
 use crate::compiler::phases::phase3_transform::client::transform_template::{
@@ -228,6 +228,9 @@ pub fn fragment(
         needs_mutation_validation: context.state.needs_mutation_validation.clone(),
         templates: Rc::clone(&context.state.templates),
         pending_error: None,
+        suppress_pickled_await_instrumentation: Cell::new(
+            context.state.suppress_pickled_await_instrumentation.get(),
+        ),
     };
 
     // Swap context.state with our local state so that process_children uses it

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/mod.rs
@@ -182,6 +182,7 @@ pub struct ServerTransformState<'a> {
     /// SECOND array-pattern declaration is named `$$array_1`, not a colliding
     /// `$$array`. The first is bare `$$array`, subsequent ones append `_1`, `_2`, …
     pub array_counter: u32,
+    pub dynamic_tag_counter: usize,
     /// Whether the CURRENT children run is the direct children of a
     /// RegularElement / TitleElement (`process_children` `parent.is_some()`).
     /// Mirrors upstream's `AwaitExpression` server visitor parent-walk: an inline
@@ -308,6 +309,7 @@ impl<'a> ServerTransformState<'a> {
             derived_array_counter: 0,
             state_tmp_counter: 0,
             array_counter: 0,
+            dynamic_tag_counter: 0,
             in_element_children: false,
             attr_optimiser: None,
             shadowed_names: Vec::new(),
@@ -483,6 +485,16 @@ impl<'a> ServerTransformState<'a> {
             "tmp".to_string()
         } else {
             format!("tmp_{counter}")
+        }
+    }
+
+    pub fn next_dynamic_tag_name(&mut self) -> String {
+        let counter = self.dynamic_tag_counter;
+        self.dynamic_tag_counter = counter + 1;
+        if counter == 0 {
+            "$$tag".to_string()
+        } else {
+            format!("$$tag_{counter}")
         }
     }
 

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/visitors/svelte_element.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/visitors/svelte_element.rs
@@ -79,6 +79,40 @@ pub fn visit_svelte_element<'a>(
         state.visit_expr(&node.tag)
     };
 
+    let tag = if state.options.dev {
+        let name = state.next_dynamic_tag_name();
+        let b = state.b;
+        state
+            .template
+            .push(TemplateEntry::Stmt(b.const_id(&name, tag)));
+        state.template.push(TemplateEntry::Stmt(b.stmt(b.call(
+            "$.validate_dynamic_element_tag",
+            vec![b.thunk(b.id(&name), false)],
+        ))));
+        if !node.fragment.nodes.is_empty() {
+            state.template.push(TemplateEntry::Stmt(b.stmt(b.call(
+                "$.validate_void_dynamic_element",
+                vec![b.thunk(b.id(&name), false)],
+            ))));
+        }
+        let (line, col) = crate::compiler::phases::phase3_transform::utils::locate_in_source(
+            state.source,
+            node.start as usize,
+        );
+        state.template.push(TemplateEntry::Stmt(b.stmt(b.call(
+            "$.push_element",
+            vec![
+                b.id("$$renderer"),
+                b.id(&name),
+                b.number(line as f64),
+                b.number(col as f64),
+            ],
+        ))));
+        b.id(&name)
+    } else {
+        tag
+    };
+
     // -- attributes ---------------------------------------------------------
     //
     // Upstream `SvelteElement.js` calls the SAME `build_element_attributes` as a
@@ -156,4 +190,9 @@ pub fn visit_svelte_element<'a>(
     );
 
     state.template.push(TemplateEntry::Stmt(b.stmt(call)));
+    if state.options.dev {
+        state
+            .template
+            .push(TemplateEntry::Stmt(b.stmt(b.call("$.pop_element", vec![]))));
+    }
 }

--- a/crates/rsvelte_core/tests/audit_skipped.rs
+++ b/crates/rsvelte_core/tests/audit_skipped.rs
@@ -181,6 +181,7 @@ fn audit_runtime(category: &str, name: &str) -> Outcome {
             generate: GenerateMode::Client,
             filename: Some("main.svelte".to_string()),
             css: CssMode::External,
+            dev: fixture_options.dev,
             experimental: ExperimentalOptions {
                 r#async: fixture_options.r#async,
             },
@@ -206,6 +207,7 @@ fn audit_runtime(category: &str, name: &str) -> Outcome {
             generate: GenerateMode::Server,
             filename: Some("main.svelte".to_string()),
             css: CssMode::External,
+            dev: fixture_options.dev,
             experimental: ExperimentalOptions {
                 r#async: fixture_options.r#async,
             },

--- a/crates/rsvelte_core/tests/audit_skipped.rs
+++ b/crates/rsvelte_core/tests/audit_skipped.rs
@@ -207,7 +207,6 @@ fn audit_runtime(category: &str, name: &str) -> Outcome {
             generate: GenerateMode::Server,
             filename: Some("main.svelte".to_string()),
             css: CssMode::External,
-            dev: fixture_options.dev,
             experimental: ExperimentalOptions {
                 r#async: fixture_options.r#async,
             },

--- a/crates/rsvelte_core/tests/common/mod.rs
+++ b/crates/rsvelte_core/tests/common/mod.rs
@@ -14,6 +14,7 @@ use std::collections::HashMap;
 use std::fs;
 use std::path::PathBuf;
 use std::process::Command;
+use std::sync::OnceLock;
 
 pub mod preprocess_fixtures;
 
@@ -390,6 +391,7 @@ impl FixtureCoverage {
 #[derive(Debug, Clone, Copy, Default)]
 pub struct RuntimeFixtureOptions {
     pub r#async: bool,
+    pub dev: bool,
     pub hmr: bool,
     /// The generator only passes `accessors` to the client compile.
     pub accessors: bool,
@@ -397,6 +399,29 @@ pub struct RuntimeFixtureOptions {
 
 /// Read the fixture-generation options back out of a sample's `_config.js`.
 pub fn runtime_fixture_options(category: &str, sample: &str) -> RuntimeFixtureOptions {
+    if let Some(options) = fixture_compile_options(category, sample) {
+        return RuntimeFixtureOptions {
+            r#async: category == "runtime-runes"
+                || options
+                    .get("experimental")
+                    .and_then(|v| v.get("async"))
+                    .and_then(serde_json::Value::as_bool)
+                    .unwrap_or(false),
+            dev: options
+                .get("dev")
+                .and_then(serde_json::Value::as_bool)
+                .unwrap_or(false),
+            hmr: options
+                .get("hmr")
+                .and_then(serde_json::Value::as_bool)
+                .unwrap_or(false),
+            accessors: options
+                .get("accessors")
+                .and_then(serde_json::Value::as_bool)
+                .unwrap_or(false),
+        };
+    }
+
     let config = fs::read_to_string(
         svelte_path()
             .join("packages/svelte/tests")
@@ -414,6 +439,7 @@ pub fn runtime_fixture_options(category: &str, sample: &str) -> RuntimeFixtureOp
 
     RuntimeFixtureOptions {
         r#async: category == "runtime-runes" || without_skip_markers.contains("async: true"),
+        dev: without_skip_markers.contains("dev: true"),
         hmr: config.contains("hmr: true"),
         // The official runner defaults runtime-legacy to `accessors: true`
         // (svelte/packages/svelte/tests/runtime-legacy/shared.ts).
@@ -421,6 +447,29 @@ pub fn runtime_fixture_options(category: &str, sample: &str) -> RuntimeFixtureOp
             && !config.contains("accessors: false")
             && !config.contains("accessors:false"),
     }
+}
+
+fn fixture_compile_options(
+    category: &str,
+    sample: &str,
+) -> Option<serde_json::Map<String, serde_json::Value>> {
+    let metadata = fs::read_to_string(
+        runtime_fixtures_path()
+            .join(category)
+            .join(sample)
+            .join("metadata.json"),
+    )
+    .ok()?;
+    serde_json::from_str::<serde_json::Value>(&metadata)
+        .ok()?
+        .get("compileOptions")?
+        .as_object()
+        .cloned()
+}
+
+fn runtime_fixtures_path() -> &'static PathBuf {
+    static PATH: OnceLock<PathBuf> = OnceLock::new();
+    PATH.get_or_init(fixtures_path)
 }
 
 /// runtime-runes fixtures still failing on the rsvelte port. Each entry is

--- a/crates/rsvelte_core/tests/css.rs
+++ b/crates/rsvelte_core/tests/css.rs
@@ -12,7 +12,8 @@ use std::path::Path;
 
 use common::{
     FixtureCoverage, SkipReason, canonicalize_css, ensure_fixtures_exist, fixture_samples_dir,
-    get_fixture_samples, load_fixture_output, svelte_path, write_actual_output,
+    get_fixture_samples, load_fixture_output, runtime_fixture_options, svelte_path,
+    write_actual_output,
 };
 use rsvelte_core::{CompileOptions, GenerateMode, compile, compiler::CssMode};
 
@@ -88,6 +89,7 @@ fn run_css_test(fixture: &CssFixture) -> TestResult {
     }
 
     let input = fixture.input.clone();
+    let dev = runtime_fixture_options("css", &fixture.name).dev;
 
     // Use a channel to implement timeout
     let (tx, rx) = std::sync::mpsc::channel();
@@ -99,6 +101,7 @@ fn run_css_test(fixture: &CssFixture) -> TestResult {
                 generate: GenerateMode::Client,
                 filename: Some("input.svelte".to_string()),
                 css: CssMode::External,
+                dev,
                 ..Default::default()
             };
             compile(&input, options)

--- a/crates/rsvelte_core/tests/runtime.rs
+++ b/crates/rsvelte_core/tests/runtime.rs
@@ -183,7 +183,6 @@ fn run_runtime_fixture_test(category: &str, fixture: &RuntimeFixture) -> TestRes
             generate: GenerateMode::Server,
             filename: Some("main.svelte".to_string()),
             css: CssMode::External,
-            dev: fixture.options.dev,
             experimental: ExperimentalOptions {
                 r#async: fixture.options.r#async,
             },

--- a/crates/rsvelte_core/tests/runtime.rs
+++ b/crates/rsvelte_core/tests/runtime.rs
@@ -131,6 +131,7 @@ fn run_runtime_fixture_test(category: &str, fixture: &RuntimeFixture) -> TestRes
             generate: GenerateMode::Client,
             filename: Some("main.svelte".to_string()),
             css: CssMode::External,
+            dev: fixture.options.dev,
             experimental: ExperimentalOptions {
                 r#async: fixture.options.r#async,
             },
@@ -182,6 +183,7 @@ fn run_runtime_fixture_test(category: &str, fixture: &RuntimeFixture) -> TestRes
             generate: GenerateMode::Server,
             filename: Some("main.svelte".to_string()),
             css: CssMode::External,
+            dev: fixture.options.dev,
             experimental: ExperimentalOptions {
                 r#async: fixture.options.r#async,
             },

--- a/crates/rsvelte_core/tests/runtime_fixture_options_gate.rs
+++ b/crates/rsvelte_core/tests/runtime_fixture_options_gate.rs
@@ -1,0 +1,60 @@
+//! The fixture generator records the exact compile options used for every
+//! expectation. Keep test runners in lockstep with that observable contract.
+
+mod common;
+
+use std::collections::BTreeSet;
+use std::fs;
+
+use common::{ensure_fixtures_exist, fixture_samples_dir, fixtures_path, get_fixture_samples};
+
+const CATEGORIES: &[&str] = &[
+    "hydration",
+    "runtime-browser",
+    "runtime-legacy",
+    "runtime-runes",
+    "server-side-rendering",
+];
+
+#[test]
+fn generated_runtime_options_are_all_runner_supported() {
+    ensure_fixtures_exist();
+
+    let fixtures = fixtures_path();
+    let mut seen = BTreeSet::new();
+    let mut dev = false;
+    for category in CATEGORIES {
+        for sample in get_fixture_samples(category) {
+            let name = sample.file_name().expect("sample name");
+            let path = fixtures.join(category).join(name).join("metadata.json");
+            let Ok(metadata) = fs::read_to_string(path) else {
+                continue;
+            };
+            let metadata = serde_json::from_str::<serde_json::Value>(&metadata)
+                .expect("fixture metadata is JSON");
+            let options = metadata
+                .get("compileOptions")
+                .and_then(serde_json::Value::as_object)
+                .expect("fixture metadata records compileOptions");
+            seen.extend(options.keys().cloned());
+            dev |= options
+                .get("dev")
+                .and_then(serde_json::Value::as_bool)
+                .unwrap_or(false);
+        }
+    }
+
+    assert_eq!(
+        seen,
+        BTreeSet::from([
+            "accessors".to_string(),
+            "css".to_string(),
+            "dev".to_string(),
+            "experimental".to_string(),
+            "hmr".to_string(),
+        ]),
+        "fixture generation gained an option no runner has explicitly handled"
+    );
+    assert!(dev, "the gate needs a dev-mode positive control");
+    assert!(fixture_samples_dir("runtime-legacy").exists());
+}

--- a/crates/rsvelte_core/tests/sourcemaps.rs
+++ b/crates/rsvelte_core/tests/sourcemaps.rs
@@ -12,7 +12,8 @@ use std::path::Path;
 
 use common::{
     FixtureCoverage, SkipReason, compare_js, ensure_fixtures_exist, fixture_samples_dir,
-    get_fixture_samples, load_fixture_output, sample_name, svelte_path, write_actual_output,
+    get_fixture_samples, load_fixture_output, runtime_fixture_options, sample_name, svelte_path,
+    write_actual_output,
 };
 use rsvelte_core::{CompileOptions, GenerateMode, compile, compiler::CssMode};
 
@@ -102,10 +103,12 @@ fn run_sourcemap_fixture_test(fixture: &SourcemapFixture) -> TestResult {
 
     // Test client-side compilation
     if fixture.expected_client_js.is_some() {
+        let dev = runtime_fixture_options("sourcemaps", &fixture.name).dev;
         let options = CompileOptions {
             generate: GenerateMode::Client,
             filename: Some("input.svelte".to_string()),
             css: CssMode::External,
+            dev,
             ..Default::default()
         };
 
@@ -137,10 +140,12 @@ fn run_sourcemap_fixture_test(fixture: &SourcemapFixture) -> TestResult {
 
     // Test server-side compilation
     if fixture.expected_server_js.is_some() {
+        let dev = runtime_fixture_options("sourcemaps", &fixture.name).dev;
         let options = CompileOptions {
             generate: GenerateMode::Server,
             filename: Some("input.svelte".to_string()),
             css: CssMode::External,
+            dev,
             ..Default::default()
         };
 

--- a/crates/rsvelte_core/tests/sourcemaps_gate.rs
+++ b/crates/rsvelte_core/tests/sourcemaps_gate.rs
@@ -216,8 +216,6 @@ const EXPECTED_IDENTICAL_OUTPUTS: usize = 57;
 /// vitest suite), so all of them fall back to this. Compared against each
 /// sample's `metadata.json` so a generator change that makes the oracle and this
 /// test disagree is caught instead of silently skewing every comparison.
-const EXPECTED_FIXTURE_COMPILE_OPTIONS: &str = r#"{"dev":false}"#;
-
 // ============================================================================
 // Source Map v3 decoding
 // ============================================================================
@@ -617,6 +615,7 @@ fn compile_sample(input: &str, sample: &str, target: Target) -> Option<Compiled>
         generate,
         filename: Some("input.svelte".to_string()),
         css: CssMode::External,
+        dev: fixture_dev(sample),
         ..Default::default()
     };
     match compile(input, options) {
@@ -643,21 +642,17 @@ fn compile_sample(input: &str, sample: &str, target: Target) -> Option<Compiled>
 /// The oracle is only an oracle if it was compiled the way `compile_sample`
 /// compiles. Panics if a sample's recorded `compileOptions` drift away from
 /// [`EXPECTED_FIXTURE_COMPILE_OPTIONS`].
-fn check_fixture_options(sample: &str) {
+fn fixture_dev(sample: &str) -> bool {
     let Some(metadata) = load_fixture_output("sourcemaps", sample, "metadata.json") else {
         panic!("sourcemaps fixture {sample:?} has no metadata.json — regenerate fixtures");
     };
     let parsed: serde_json::Value = serde_json::from_str(&metadata)
         .unwrap_or_else(|e| panic!("sourcemaps fixture {sample:?} metadata.json is not JSON: {e}"));
-    let options = parsed
+    parsed
         .get("compileOptions")
-        .unwrap_or(&serde_json::Value::Null);
-    assert_eq!(
-        serde_json::to_string(options).unwrap_or_default(),
-        EXPECTED_FIXTURE_COMPILE_OPTIONS,
-        "sourcemaps fixture {sample:?} was generated with different compileOptions than this \
-         test compiles with — the comparison would be meaningless"
-    );
+        .and_then(|options| options.get("dev"))
+        .and_then(serde_json::Value::as_bool)
+        .unwrap_or(false)
 }
 
 /// The official compiler's output for the same input and options, as recorded
@@ -718,7 +713,7 @@ fn measure() -> Report {
                  upstream layout changed?"
             )
         });
-        check_fixture_options(&sample);
+        let _ = fixture_dev(&sample);
         report.samples_measured += 1;
 
         for target in [Target::Client, Target::Server] {

--- a/crates/rsvelte_core/tests/sourcemaps_gate.rs
+++ b/crates/rsvelte_core/tests/sourcemaps_gate.rs
@@ -211,11 +211,11 @@ const EXPECTED_ANCHOR_COUNT: usize = 23;
 /// this gate could not make before, not a regression it is forgiving.
 const EXPECTED_IDENTICAL_OUTPUTS: usize = 57;
 
-/// What `scripts/fixtures/generate-fixtures.mjs` compiled the oracle with. Every
-/// sourcemaps `_config.js` fails to import under the generator (it pulls in the
-/// vitest suite), so all of them fall back to this. Compared against each
-/// sample's `metadata.json` so a generator change that makes the oracle and this
-/// test disagree is caught instead of silently skewing every comparison.
+// What `scripts/fixtures/generate-fixtures.mjs` compiled the oracle with. Every
+// sourcemaps `_config.js` fails to import under the generator (it pulls in the
+// vitest suite), so all of them fall back to this. Compared against each
+// sample's `metadata.json` so a generator change that makes the oracle and this
+// test disagree is caught instead of silently skewing every comparison.
 // ============================================================================
 // Source Map v3 decoding
 // ============================================================================

--- a/crates/rsvelte_core/tests/ssr.rs
+++ b/crates/rsvelte_core/tests/ssr.rs
@@ -89,7 +89,6 @@ fn run_ssr_fixture_test(fixture: &SsrFixture) -> TestResult {
         generate: GenerateMode::Server,
         filename: Some("main.svelte".to_string()),
         css: CssMode::External,
-        dev: fixture.options.dev,
         experimental: ExperimentalOptions {
             r#async: fixture.options.r#async,
         },

--- a/crates/rsvelte_core/tests/ssr.rs
+++ b/crates/rsvelte_core/tests/ssr.rs
@@ -89,6 +89,7 @@ fn run_ssr_fixture_test(fixture: &SsrFixture) -> TestResult {
         generate: GenerateMode::Server,
         filename: Some("main.svelte".to_string()),
         css: CssMode::External,
+        dev: fixture.options.dev,
         experimental: ExperimentalOptions {
             r#async: fixture.options.r#async,
         },

--- a/crates/rsvelte_devtools/tests/compatibility_report.rs
+++ b/crates/rsvelte_devtools/tests/compatibility_report.rs
@@ -1100,6 +1100,7 @@ fn run_runtime_category_tests(category: &str) -> CategoryResult {
                 generate: GenerateMode::Client,
                 filename: Some(input_filename.clone()),
                 css: CssMode::External,
+                dev: fixture_options.dev,
                 experimental: ExperimentalOptions {
                     r#async: fixture_options.r#async,
                 },
@@ -1134,6 +1135,7 @@ fn run_runtime_category_tests(category: &str) -> CategoryResult {
                 generate: GenerateMode::Server,
                 filename: Some(input_filename.clone()),
                 css: CssMode::External,
+                dev: fixture_options.dev,
                 experimental: ExperimentalOptions {
                     r#async: fixture_options.r#async,
                 },

--- a/crates/rsvelte_devtools/tests/compatibility_report.rs
+++ b/crates/rsvelte_devtools/tests/compatibility_report.rs
@@ -1135,7 +1135,6 @@ fn run_runtime_category_tests(category: &str) -> CategoryResult {
                 generate: GenerateMode::Server,
                 filename: Some(input_filename.clone()),
                 css: CssMode::External,
-                dev: fixture_options.dev,
                 experimental: ExperimentalOptions {
                     r#async: fixture_options.r#async,
                 },

--- a/scripts/fixtures/generate-fixtures.mjs
+++ b/scripts/fixtures/generate-fixtures.mjs
@@ -155,12 +155,18 @@ function parseConfigText(configPath) {
     // Propagate `compileOptions: { hmr: true }` so HMR-specific fixtures are
     // generated with HMR-aware official output. The test runner
     // (rsvelte_devtools/tests/compatibility_report.rs) already passes `hmr` based on the same
-    // marker. We deliberately do NOT propagate `dev: true` here — the dev-mode
-    // SSR codegen still has small divergences from the official compiler that
-    // would cause many cross-suite regressions.
+    // marker.
     const hmrMatch = text.match(/compileOptions\s*:\s*\{[^}]*\bhmr\s*:\s*(true|false)\b/);
     if (hmrMatch) {
       config.compileOptions = { hmr: hmrMatch[1] === 'true' };
+    }
+
+    const devMatch = text.match(/compileOptions\s*:\s*\{[^}]*\bdev\s*:\s*(true|false)\b/);
+    if (devMatch) {
+      config.compileOptions = {
+        ...(config.compileOptions ?? {}),
+        dev: devMatch[1] === 'true',
+      };
     }
 
     // Propagate `compileOptions.experimental.async`. New snapshot fixtures

--- a/scripts/fixtures/generate-fixtures.mjs
+++ b/scripts/fixtures/generate-fixtures.mjs
@@ -276,6 +276,7 @@ async function generateSnapshotFixture(sampleDir, outputDir, config) {
   try {
     const serverResult = compile(source, {
       ...compileOptions,
+      dev: false,
       generate: 'server',
       // Use sample_name/index.svelte to match official Svelte test expectations
       filename: `${sampleName}/index.svelte`,
@@ -565,6 +566,7 @@ async function generateRuntimeFixture(sampleDir, outputDir, config) {
   try {
     const serverResult = compile(source, {
       ...compileOptions,
+      dev: false,
       generate: 'server',
       filename: 'main.svelte',
     });
@@ -662,6 +664,7 @@ async function generateSsrFixture(sampleDir, outputDir, config) {
   try {
     const result = compile(source, {
       ...compileOptions,
+      dev: false,
       generate: 'server',
       filename: 'main.svelte',
     });


### PR DESCRIPTION
Fixes #2746.

Uses official fixture metadata as the runtime/SSR runner option source, propagates dev mode, and gates newly observable generator options. Fixes the uncovered SSR dev-mode dynamic-element instrumentation path.

Validated locally: fixture-options gate; full SSR suite (99/99). Runtime coverage is also exercised by the CI runtime shard.