### PR TITLE
perf(compiler): route prop-read fragments through AST

### DIFF
--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/props_transforms.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/props_transforms.rs
@@ -169,6 +169,15 @@ pub(super) fn transform_prop_reads_in_expr(expr: &str, prop_vars: &[String]) -> 
         return expr.to_string();
     }
 
+    // Most callers hand us a complete JavaScript expression or statement. Let
+    // the AST rewriter handle those in one traversal; this scanner remains only
+    // for the incomplete fragments that cannot be parsed in program context.
+    if let Some(rewritten) =
+        super::prop_source_reads_ast::wrap_prop_source_reads_ast(expr, prop_vars, &[])
+    {
+        return rewritten;
+    }
+
     // Quick pre-check: if none of the prop vars appear as identifiers, skip expensive transforms
     let var_set: FxHashSet<&str> = prop_vars.iter().map(|v| v.as_str()).collect();
     if !super::utils::text_contains_any_identifier(expr, &var_set) {

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/tests.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/tests.rs
@@ -823,6 +823,23 @@ fn test_transform_prop_reads_in_expr() {
     );
 }
 
+#[cfg(feature = "measure-prop-reads")]
+#[test]
+fn prop_read_rewriter_uses_the_ast_path_for_complete_expressions() {
+    crate::measure_prop_reads::reset();
+    let props = vec!["a".to_string(), "b".to_string(), "c".to_string()];
+
+    assert_eq!(
+        transform_prop_reads_in_expr("a + b + c", &props),
+        "a() + b() + c()"
+    );
+
+    let (_, _, _, _, _, scanned_chars, vec_char_elems, _, _) =
+        crate::measure_prop_reads::snapshot();
+    assert_eq!(scanned_chars, 0);
+    assert_eq!(vec_char_elems, 0);
+}
+
 #[test]
 fn test_normalize_js_comma_separated_declarations() {
     let input = "let tmp = setup(), num = $.state($.proxy(tmp.num));";


### PR DESCRIPTION
## Summary

Route complete prop-read expressions and statements through the existing typed AST rewriter before using the legacy text scanner. This removes the per-prop full-expression Vec<char> allocation and scan from the normal path, retaining the scanner only for fragments OXC cannot parse in program context.

## Validation

- cargo fmt --check
- cargo test -p rsvelte_core --features measure-prop-reads prop_read_rewriter_uses_the_ast_path_for_complete_expressions --lib
- cargo test -p rsvelte_core compiler::phases::phase3_transform::client --lib (1,023 passed)

The fixture suite could not be run locally because its generated fixtures are absent and dependency download is blocked by DNS in this environment.