### PR TITLE
perf(compiler): reuse reactive dependencies from analysis

### DIFF
--- a/.changeset/reactive-deps-from-analysis.md
+++ b/.changeset/reactive-deps-from-analysis.md
@@ -1,0 +1,5 @@
+---
+'@rsvelte/compiler': patch
+---
+
+Reuse Phase 2's typed dependency list when ordering legacy reactive statements, avoiding the duplicate Phase 3 text scan of each `$:` body.

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
@@ -5568,17 +5568,6 @@ fn transform_instance_script_for_visitors(
         if !analysis.runes && first_line_trimmed.starts_with("$:") {
             let _reactive_start = super::profile::timer_start();
             let _reactive_guard = super::profile::ReactiveStmtGuard(_reactive_start);
-            // Extract assignment targets and dependencies from the raw statement
-            // for topological sorting (matching official compiler's order_reactive_statements)
-            let _rs_deps_start = super::profile::timer_start();
-            let (assigned_vars, dep_vars) = extract_reactive_statement_deps(
-                &statement,
-                state_vars,
-                prop_assignment_transform_vars,
-                store_sub_vars,
-            );
-            super::profile::record_rs_deps(super::profile::timer_elapsed(_rs_deps_start));
-
             // AST-derived ordered dependency names for THIS top-level `$:` statement
             // (Phase 2, source-ordinal aligned). Both phases count top-level `$:`
             // in source order, so the ordinal stays in sync.
@@ -5588,6 +5577,17 @@ fn transform_instance_script_for_visitors(
                 .map(|v| v.as_slice())
                 .unwrap_or(&[]);
             *reactive_ordinal += 1;
+            // Assignment targets still decide the topological graph, but its
+            // dependency side was already collected by Phase 2 from the typed AST.
+            let _rs_deps_start = super::profile::timer_start();
+            let assigned_vars = extract_reactive_statement_assignments(
+                &statement,
+                state_vars,
+                prop_assignment_transform_vars,
+                store_sub_vars,
+            );
+            let dep_vars = dep_names.to_vec();
+            super::profile::record_rs_deps(super::profile::timer_elapsed(_rs_deps_start));
             let _rs_body_start = super::profile::timer_start();
             let transformed = transform_reactive_statement(
                 &statement,

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/reactive_transforms.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/reactive_transforms.rs
@@ -6,38 +6,35 @@ use std::borrow::Cow;
 use crate::compiler::phases::phase2_analyze::ComponentAnalysis;
 
 use super::{
-    body_references_identifier, extract_destructure_targets, extract_member_expression_base,
-    find_assignment_position, get_or_compile_regex, is_simple_identifier, lhs_starts_with_keyword,
+    extract_destructure_targets, extract_member_expression_base, find_assignment_position,
+    get_or_compile_regex, is_simple_identifier, lhs_starts_with_keyword,
     transform_destructure_assignments_with_props, transform_prop_assignments,
     transform_prop_reads_in_expr, transform_store_assignments_client, transform_store_reads_client,
     transform_store_sub_calls, wrap_state_vars_in_expr,
 };
 
-/// Extract assigned variable names and dependency variable names from a raw `$:` reactive statement.
+/// Extract the reactive variables assigned by a raw `$:` statement.
 ///
-/// This is used for topological sorting of reactive statements.
-/// Returns (assigned_vars, dependency_vars).
-///
-/// For `$: c = a + b;`, returns (["c"], ["a", "b"])
-/// For `$: console.log(x);`, returns ([], ["console", "x"])
-pub(super) fn extract_reactive_statement_deps(
+/// Dependency names come from Phase 2's typed traversal. Keeping only the
+/// assignment scan here avoids walking every reactive body twice in Phase 3.
+pub(super) fn extract_reactive_statement_assignments(
     statement: &str,
     state_vars: &[String],
     prop_vars: &[String],
     store_sub_vars: &[String],
-) -> (Vec<String>, Vec<String>) {
+) -> Vec<String> {
     let trimmed = statement.trim();
 
     // Extract the body after `$:`
     let body = if let Some(stripped) = trimmed.strip_prefix("$:") {
         stripped.trim()
     } else {
-        return (vec![], vec![]);
+        return vec![];
     };
 
     let body = body.trim_end_matches(';').trim();
     if body.is_empty() {
-        return (vec![], vec![]);
+        return vec![];
     }
 
     // All known reactive variable names (state vars + prop vars + store subs)
@@ -50,12 +47,10 @@ pub(super) fn extract_reactive_statement_deps(
         .collect();
 
     let mut assigned_vars = Vec::new();
-    let mut dep_vars = Vec::new();
 
     // Check if this is an assignment statement
     if let Some(eq_pos) = find_assignment_position(body) {
         let lhs = body[..eq_pos].trim();
-        let rhs = body[eq_pos + 1..].trim();
 
         // Extract assigned variable from LHS
         // Simple identifier: `c = ...`
@@ -66,24 +61,6 @@ pub(super) fn extract_reactive_statement_deps(
             // Extract the base identifier
             if let Some(base) = extract_member_expression_base(lhs) {
                 assigned_vars.push(base.to_string());
-            }
-        }
-
-        // Extract dependencies from RHS
-        for var_name in &all_reactive_vars {
-            if body_references_identifier(rhs, var_name) {
-                // Only add as dependency if it's not also being assigned
-                if !assigned_vars.contains(&var_name.to_string()) {
-                    dep_vars.push(var_name.to_string());
-                }
-            }
-        }
-    } else {
-        // Not a simple assignment - expression statement like `console.log(x)` or `if (...) { x++ }`
-        // All referenced reactive vars are dependencies
-        for var_name in &all_reactive_vars {
-            if body_references_identifier(body, var_name) {
-                dep_vars.push(var_name.to_string());
             }
         }
     }
@@ -103,7 +80,7 @@ pub(super) fn extract_reactive_statement_deps(
         }
     }
 
-    (assigned_vars, dep_vars)
+    assigned_vars
 }
 
 /// Check if a variable is assigned anywhere in a code body (including nested blocks).
@@ -1104,4 +1081,35 @@ pub(super) fn transform_state_member_mutations(
         non_reactive_vars,
     )
     .unwrap_or_else(|| expr.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::extract_reactive_statement_assignments;
+
+    #[test]
+    fn reactive_assignment_scan_keeps_only_the_topology_targets() {
+        let state = vec!["count".to_string(), "total".to_string()];
+        let props = vec!["step".to_string()];
+        let stores = vec!["$store".to_string()];
+
+        assert_eq!(
+            extract_reactive_statement_assignments(
+                "$: total = count + step;",
+                &state,
+                &props,
+                &stores,
+            ),
+            vec!["total"]
+        );
+        assert_eq!(
+            extract_reactive_statement_assignments(
+                "$: if (step) { count++; $store = total; }",
+                &state,
+                &props,
+                &stores,
+            ),
+            vec!["count", "$store"]
+        );
+    }
 }

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/state_transforms.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/state_transforms.rs
@@ -14,9 +14,9 @@ use super::rune_transforms::{
     split_derived_object_properties,
 };
 use crate::compiler::phases::phase2_analyze::scope::DeclarationKind;
-use crate::compiler::phases::phase3_transform::shared::js_scan::{
-    code_bytes, code_bytes_from, skip_opaque,
-};
+#[cfg(test)]
+use crate::compiler::phases::phase3_transform::shared::js_scan::code_bytes_from;
+use crate::compiler::phases::phase3_transform::shared::js_scan::{code_bytes, skip_opaque};
 
 // ---------------------------------------------------------------------------
 // Identifier reference detection (lines 7653-8602 of mod.rs)
@@ -32,6 +32,7 @@ use crate::compiler::phases::phase3_transform::shared::js_scan::{
 /// because it appears on the RHS.
 /// For block bodies like `{ c = a + b; count = count + 1; }`, we check each statement
 /// within the block.
+#[cfg(test)]
 pub(super) fn body_references_identifier(body: &str, identifier: &str) -> bool {
     // Every strip below only blanks or deletes characters, so a name absent from
     // the raw body is absent from all of them. Callers ask this once per
@@ -81,12 +82,14 @@ pub(super) fn body_references_identifier(body: &str, identifier: &str) -> bool {
 /// - the same with `.` also excluded before the name for every other identifier,
 ///   so `obj.prop` does not match a standalone `prop` — except for a spread
 ///   prefix (`f(...prop)`), which reads it
+#[cfg(test)]
 pub(super) struct IdentifierMatcher<'a> {
     identifier: &'a str,
     /// `$$`-names accept a `.` immediately before them; the rest do not.
     allows_leading_dot: bool,
 }
 
+#[cfg(test)]
 impl<'a> IdentifierMatcher<'a> {
     pub(super) fn new(identifier: &'a str) -> Self {
         Self {
@@ -135,6 +138,7 @@ impl<'a> IdentifierMatcher<'a> {
     }
 }
 
+#[cfg(test)]
 fn continues_identifier(byte: u8) -> bool {
     byte.is_ascii_alphanumeric() || byte == b'_' || byte == b'$'
 }
@@ -143,6 +147,7 @@ fn continues_identifier(byte: u8) -> bool {
 /// was a comment. Restricted to `/`-led runs on purpose: this scanner's whole job
 /// is to descend into string and template literals, which `skip_opaque` — the
 /// same lexer this delegates to — treats as opaque.
+#[cfg(test)]
 fn skip_slash_run(bytes: &[u8], i: usize, prev: Option<u8>) -> Option<(usize, bool)> {
     if bytes[i] != b'/' {
         return None;
@@ -159,6 +164,7 @@ fn skip_slash_run(bytes: &[u8], i: usize, prev: Option<u8>) -> Option<(usize, bo
 ///
 /// This prevents false identifier matches inside literal text, e.g., `<circle>` in
 /// a template literal won't match the variable name `circle`.
+#[cfg(test)]
 pub(super) fn strip_string_literal_text(code: &str) -> std::borrow::Cow<'_, str> {
     // Fast path: if no string delimiters exist, return as-is
     // Uses memchr3 for SIMD-accelerated search of all three delimiters at once
@@ -321,6 +327,7 @@ pub(super) fn strip_string_literal_text(code: &str) -> std::borrow::Cow<'_, str>
 /// - `{ key: value }` -> `{     value }` (non-shorthand key blanked)
 /// - `{ key }` -> `{ key }` (shorthand preserved)
 /// - `{ [expr]: value }` -> `{ [expr]: value }` (computed preserved)
+#[cfg(test)]
 pub(super) fn strip_object_property_keys(code: &str) -> std::borrow::Cow<'_, str> {
     // A key can only be blanked at a `:`, and the two `Vec<char>` below cost four
     // bytes per source byte, so the absence of one is worth checking for.
@@ -404,6 +411,7 @@ pub(super) fn strip_object_property_keys(code: &str) -> std::borrow::Cow<'_, str
 /// Whether `c` can follow the last character of a parameter name. Spelled over
 /// characters rather than the single space the ASCII whitelist accepted, because
 /// `U+3000` and NBSP separate a parameter exactly as a space does.
+#[cfg(test)]
 fn ends_a_parameter_name(c: char) -> bool {
     c == ',' || c == ')' || c == ':' || c.is_whitespace()
 }
@@ -416,6 +424,7 @@ fn ends_a_parameter_name(c: char) -> bool {
 /// - `function (a) { ... }` -> `                   `
 /// - `(a) => { ... }` -> `              `
 /// - `(a) => expr` -> `            `
+#[cfg(test)]
 pub(super) fn strip_function_scopes_that_shadow<'a>(
     body: &'a str,
     identifier: &str,
@@ -633,6 +642,7 @@ pub(super) fn strip_function_scopes_that_shadow<'a>(
 
 /// Recursively check if an identifier is read (not just assigned to) in a body of code.
 /// Handles block statements, if/else blocks, and compound statements.
+#[cfg(test)]
 pub(super) fn body_references_identifier_recursive(
     body: &str,
     identifier: &str,
@@ -728,6 +738,7 @@ pub(super) fn body_references_identifier_recursive(
 }
 
 /// Check if an identifier is referenced as a read across multiple statements.
+#[cfg(test)]
 pub(super) fn body_references_identifier_in_statements(
     content: &str,
     identifier: &str,
@@ -765,6 +776,7 @@ pub(super) fn body_references_identifier_in_statements(
 }
 
 /// Check if an identifier appears as a read (not just assignment target) in a single statement.
+#[cfg(test)]
 pub(super) fn check_identifier_in_statement(
     stmt: &str,
     identifier: &str,
@@ -966,6 +978,7 @@ pub(super) fn find_assignment_position(expr: &str) -> Option<usize> {
 /// Find the position of a `:` at depth 0 in an expression.
 /// This is used to split ternary expressions like `true_rhs : false_branch`.
 /// The returned position is a **byte** offset: the caller slices `expr` with it.
+#[cfg(test)]
 pub(super) fn find_colon_at_depth0(expr: &str) -> Option<usize> {
     // Not `code_bytes`: `${`/`}` move the outer depth here and the bookkeeping is
     // preserved exactly rather than re-derived. UTF-8 continuation bytes are all


### PR DESCRIPTION
Reuse the Phase 2 typed dependency list for legacy reactive-statement topology. Phase 3 retains only the assignment-target scan and no longer re-scans each reactive body per binding to rediscover dependencies.

Validation: cargo fmt --check; cargo clippy -p rsvelte_core --lib -- -D warnings; 1,024 client-transform tests; 21 targeted legacy-reactive regression tests.