### PR TITLE
fix(parser): share keyword regex disambiguation

### DIFF
--- a/.changeset/keyword-regex-scanners.md
+++ b/.changeset/keyword-regex-scanners.md
@@ -1,0 +1,5 @@
+---
+'@rsvelte/compiler': patch
+---
+
+Recognize regular expressions after keywords consistently in parser and class-body scanners.

--- a/crates/rsvelte_core/src/compiler/phases/1_parse/utils/bracket.rs
+++ b/crates/rsvelte_core/src/compiler/phases/1_parse/utils/bracket.rs
@@ -4,6 +4,7 @@
 //!
 //! This module corresponds to `svelte/packages/svelte/src/compiler/phases/1-parse/utils/bracket.js`
 
+use crate::compiler::phases::phase3_transform::shared::js_scan::slash_starts_regex_at;
 use memchr::memchr;
 
 static BLOCK_COMMENT_END_FINDER: std::sync::LazyLock<memchr::memmem::Finder<'static>> =
@@ -264,29 +265,7 @@ pub fn find_matching_bracket(template: &str, index: usize, open: char) -> Option
                     continue;
                 }
 
-                // Determine if `/` is a division operator or the start of a regex.
-                // After a value — identifier, number, closing paren/bracket, a
-                // postfix operator, or a string/template-literal close quote —
-                // `/` is division. (A `/` immediately after a string literal such
-                // as `'ab' / divisor` is always division: no regex can follow a
-                // value without an intervening operator.)
-                let is_division = match prev_non_ws {
-                    Some(c) => {
-                        c.is_ascii_alphanumeric()
-                            || c == b'_'
-                            || c == b'$'
-                            || c == b')'
-                            || c == b']'
-                            || c == b'+'
-                            || c == b'-'
-                            || c == b'\''
-                            || c == b'"'
-                            || c == b'`'
-                    }
-                    None => false,
-                };
-
-                if is_division {
+                if !slash_starts_regex_at(bytes, i, prev_non_ws) {
                     prev_non_ws = Some(b'/');
                     i += 1;
                     continue;

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/shared/class_body.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/shared/class_body.rs
@@ -9,6 +9,7 @@
 use memchr::memmem;
 
 use crate::compiler::phases::phase1_parse::utils::find_matching_bracket;
+use crate::compiler::phases::phase3_transform::shared::js_scan::slash_starts_regex_at;
 use crate::compiler::utils::is_js_ident_continue;
 
 /// Skip a `'`/`"` string literal starting at `i`, returning the index just past
@@ -47,18 +48,6 @@ fn skip_template(s: &str, i: usize) -> usize {
         }
     }
     bytes.len()
-}
-
-/// Is a `/` at `prev` (the last non-whitespace byte before it) the start of a
-/// regex literal rather than a division operator?
-fn slash_starts_regex(prev: Option<u8>) -> bool {
-    match prev {
-        None => true,
-        // Non-ASCII bytes are identifier continuations, never operators.
-        Some(b) => {
-            !(b.is_ascii_alphanumeric() || !b.is_ascii() || matches!(b, b'_' | b'$' | b')' | b']'))
-        }
-    }
 }
 
 /// Does `s` end with the standalone keyword `kw` (not the tail of a longer identifier)?
@@ -225,7 +214,7 @@ pub(crate) fn split_class_members_onto_lines(class_body: &str) -> std::borrow::C
                 i = memmem::find(&bytes[i + 2..], b"*/").map_or(bytes.len(), |p| i + p + 4);
                 continue;
             }
-            b'/' if slash_starts_regex(prev_non_ws) => {
+            b'/' if slash_starts_regex_at(bytes, i, prev_non_ws) => {
                 let mut j = i + 1;
                 while j < bytes.len() {
                     match bytes[j] {
@@ -356,6 +345,16 @@ mod tests {
         assert_eq!(
             split_class_members_onto_lines("\ts = 'a; b'; t = `c;${d};e`; u = /;/;\n"),
             "\ts = 'a; b';\n\tt = `c;${d};e`;\n\tu = /;/;\n"
+        );
+    }
+
+    #[test]
+    fn regex_after_keyword_does_not_hide_the_following_member() {
+        assert_eq!(
+            split_class_members_onto_lines(
+                "\tmethod() { return /[//]/.test(value); } next = $state(1);\n"
+            ),
+            "\tmethod() { return /[//]/.test(value); }\n\tnext = $state(1);\n"
         );
     }
 

--- a/crates/rsvelte_core/tests/keyword_regex_2724.rs
+++ b/crates/rsvelte_core/tests/keyword_regex_2724.rs
@@ -1,0 +1,25 @@
+use oxc_allocator::Allocator;
+use oxc_parser::Parser;
+use oxc_span::SourceType;
+use rsvelte_core::{CompileOptions, GenerateMode, compile};
+
+#[test]
+fn regex_after_return_is_not_a_template_close_tag() {
+    let output = compile(
+        "<script>let value = ''; </script><p>{typeof /[//]/.exec(value)}</p>",
+        CompileOptions {
+            generate: GenerateMode::Client,
+            ..Default::default()
+        },
+    )
+    .unwrap_or_else(|error| panic!("valid template expression was rejected: {error:?}"))
+    .js
+    .code;
+
+    let allocator = Allocator::default();
+    let parsed = Parser::new(&allocator, &output, SourceType::mjs()).parse();
+    assert!(
+        !parsed.panicked && parsed.diagnostics.is_empty(),
+        "client output must parse:\n{output}"
+    );
+}


### PR DESCRIPTION
Fixes #2724.\n\nRoutes the parser bracket matcher and class-body scanner through the shared token-aware regex predicate, eliminating duplicate previous-byte rules. Adds direct parser/codegen regression coverage.\n\nVerified: 
running 4 tests
test compiler::phases::phase3_transform::shared::class_body::tests::brace_opens_class_body_recognises_class_headers ... ok
test compiler::phases::phase3_transform::shared::class_body::tests::regex_after_keyword_does_not_hide_the_following_member ... ok
test compiler::phases::phase3_transform::shared::class_body::tests::same_line_members_are_split ... ok
test compiler::phases::phase3_transform::shared::class_body::tests::conventionally_formatted_class_body_is_not_resplit ... ok

test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 1565 filtered out; finished in 0.00s; 
running 1 test
test regex_after_return_is_not_a_template_close_tag ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s; matrix run including keyword-regex (no baseline update).