### PR TITLE
fix(client): classify commented async declarations

### DIFF
--- a/.changeset/async-derived-leading-comments.md
+++ b/.changeset/async-derived-leading-comments.md
@@ -1,0 +1,5 @@
+---
+'@rsvelte/compiler': patch
+---
+
+Keep leading comments from misclassifying async derived declarations as expressions.

--- a/compatibility/matrix-known-failures.json
+++ b/compatibility/matrix-known-failures.json
@@ -32,8 +32,6 @@
 	"async-derived/instance__identifier__block-before.svelte [js-mismatch] (client)",
 	"async-derived/instance__identifier__block-before.svelte [js-mismatch] (client-dev)",
 	"async-derived/instance__identifier__block-before.svelte [js-mismatch] (server)",
-	"async-derived/instance__identifier__block-inline.svelte [js-mismatch] (client)",
-	"async-derived/instance__identifier__block-inline.svelte [js-mismatch] (client-dev)",
 	"async-derived/instance__identifier__block-inline.svelte [js-mismatch] (server)",
 	"async-derived/instance__identifier__line-before.svelte [js-mismatch] (client)",
 	"async-derived/instance__identifier__line-before.svelte [js-mismatch] (client-dev)",

--- a/compatibility/matrix-known-failures.md
+++ b/compatibility/matrix-known-failures.md
@@ -28,9 +28,9 @@ Normalization here is identical to `verify.mjs` (flatten template holes → oxfm
 blank lines), so formatting-only differences are tolerated exactly as the corpus gate
 tolerates them. An entry is a divergence that survives that.
 
-## Matrix known failures (`matrix-known-failures.json`, 942 entries)
+## Matrix known failures (`matrix-known-failures.json`, 940 entries)
 
-Partition of `matrix-known-failures.json` by family: `2 + 212 + 0 + 18 + 60 + 62 + 3 + 324 + 253 + 8`
+Partition of `matrix-known-failures.json` by family: `2 + 212 + 0 + 18 + 60 + 62 + 3 + 324 + 251 + 8`
 
 ### `binding-position` — 2 entries
 
@@ -349,9 +349,9 @@ until their issues are fixed.
 
 ---
 
-### `async-derived` — 253 entries
+### `async-derived` — 251 entries
 
-Added by #2540. Read the size as a **disclosure**, not a regression: not one of these 253 was
+Added by #2540. Read the size as a **disclosure**, not a regression: not one of these 251 was
 reachable by any gate in the repo before this family existed, because every harness compiles
 with a fixed `{ generate, dev, filename }` and `$derived(await …)` is an `experimental_async`
 compile error without `experimental.async`. The shape occurs 0 times in the 14k-entry corpus
@@ -364,14 +364,14 @@ in dev — is *not* in this list; the rows that isolate it (`instance__identifie
 `instance__multi-declarator__none`, all three targets) pass. What remains are five independent
 defects the family exposed on the way, all of them older than the family:
 
-Partition of `matrix-known-failures.json` entries under `async-derived/` by cause: `154 + 39 + 18 + 14 + 13 + 13 + 2`
+Partition of `matrix-known-failures.json` entries under `async-derived/` by cause: `154 + 39 + 18 + 12 + 13 + 13 + 2`
 
 | # | cause | entries |
 |---|---|---|
 | 1 | `<script module>` / `compileModule` async-derived lowering | 154 |
 | 2 | the `$$d` temp appears in the hoisted `var` list | 39 |
 | 3 | `svelte-ignore` comment not reproduced on the hoisted declaration | 18 |
-| 4 | a block comment before the declaration produces **invalid JavaScript** | 14 |
+| 4 | a block comment before the declaration produces **invalid JavaScript** | 12 |
 | 5a | no `$.save(…)` around a non-final `await` | 13 |
 | 5b | `$derived.by(async …)` is suspended as if it were an async derived | 13 |
 | — | server `$$renderer.async` split lost alongside cause 3 | 2 |

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/shared/async_body.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/shared/async_body.rs
@@ -426,7 +426,16 @@ fn transform_async_body_inner(script: &str, runner: &str, dev: bool) -> Option<A
             continue;
         }
 
-        let (leading_comments, trimmed_stmt) = split_leading_comments(trimmed_stmt);
+        let (leading_comments, trimmed_stmt) =
+            if memmem::find(trimmed_stmt.as_bytes(), b"$$async_hole").is_some()
+                || memmem::find(trimmed_stmt.as_bytes(), b"$$inspect_hole").is_some()
+                || memmem::find(trimmed_stmt.as_bytes(), b"$$async_void_noop").is_some()
+                || memmem::find(trimmed_stmt.as_bytes(), b"$$async_noop").is_some()
+            {
+                ("", trimmed_stmt)
+            } else {
+                split_leading_comments(trimmed_stmt)
+            };
         if trimmed_stmt.is_empty() {
             continue;
         }
@@ -2996,6 +3005,17 @@ mod tests {
         assert!(
             !result.output.contains("void (/*"),
             "a declaration must not be emitted as a void expression: {}",
+            result.output
+        );
+    }
+
+    #[test]
+    fn test_inspect_hole_remains_an_async_slot() {
+        let script = "let data = await Promise.resolve(42);\n/* $$inspect_hole */";
+        let result = transform_async_body(script, "$.run").unwrap();
+        assert!(
+            result.output.contains("() => void 0"),
+            "inspect hole was dropped: {}",
             result.output
         );
     }

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/shared/async_body.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/shared/async_body.rs
@@ -426,27 +426,7 @@ fn transform_async_body_inner(script: &str, runner: &str, dev: bool) -> Option<A
             continue;
         }
 
-        // Strip leading single-line comment lines from the statement.
-        // The statement splitter may combine a `// comment` line with the following
-        // code line into one statement. We need to process the code, not skip it.
-        let trimmed_stmt = {
-            let mut s = trimmed_stmt;
-            loop {
-                if s.starts_with("//") {
-                    // Skip to end of this comment line
-                    if let Some(nl) = s.find('\n') {
-                        s = s[nl + 1..].trim();
-                    } else {
-                        // Entire statement is a comment — skip
-                        s = "";
-                        break;
-                    }
-                } else {
-                    break;
-                }
-            }
-            s
-        };
+        let (leading_comments, trimmed_stmt) = split_leading_comments(trimmed_stmt);
         if trimmed_stmt.is_empty() {
             continue;
         }
@@ -568,8 +548,12 @@ fn transform_async_body_inner(script: &str, runner: &str, dev: bool) -> Option<A
                 let decls = extract_var_declarations(trimmed_stmt);
 
                 // Hoist all variable names
-                for decl in &decls {
-                    hoisted_vars.push(decl.name.clone());
+                for (index, decl) in decls.iter().enumerate() {
+                    if index == 0 && !leading_comments.is_empty() {
+                        hoisted_vars.push(format!("{leading_comments} {}", decl.name));
+                    } else {
+                        hoisted_vars.push(decl.name.clone());
+                    }
                 }
 
                 // Separate non-hoist-only decls for thunk generation
@@ -1507,6 +1491,29 @@ fn skip_regex(bytes: &[u8], start: usize) -> usize {
         i += 1;
     }
     start + 1
+}
+
+fn split_leading_comments(mut statement: &str) -> (&str, &str) {
+    let original = statement;
+    loop {
+        statement = statement.trim_start();
+        if let Some(rest) = statement.strip_prefix("//") {
+            let Some(offset) = rest.find('\n') else {
+                return (original.trim(), "");
+            };
+            statement = &rest[offset + 1..];
+            continue;
+        }
+        if let Some(rest) = statement.strip_prefix("/*") {
+            let Some(end) = rest.find("*/") else {
+                return (original.trim(), "");
+            };
+            statement = &rest[end + 2..];
+            continue;
+        }
+        let comment_len = original.len() - statement.len();
+        return (original[..comment_len].trim(), statement);
+    }
 }
 
 /// Split a script into top-level statements.
@@ -2972,6 +2979,24 @@ mod tests {
             result
                 .output
                 .contains("async () => data = await fetch('/api')")
+        );
+    }
+
+    #[test]
+    fn test_leading_block_comment_on_async_var_declaration() {
+        let script = "/* keep */ const value = await $.async_derived(() => fetch());";
+        let result = transform_async_body(script, "$.run").unwrap();
+        assert!(
+            result
+                .output
+                .contains("async () => value = await $.async_derived"),
+            "async declaration was not classified as a declaration: {}",
+            result.output
+        );
+        assert!(
+            !result.output.contains("void (/*"),
+            "a declaration must not be emitted as a void expression: {}",
+            result.output
         );
     }
 

--- a/crates/rsvelte_core/tests/async_derived_comment_2755.rs
+++ b/crates/rsvelte_core/tests/async_derived_comment_2755.rs
@@ -1,0 +1,27 @@
+use oxc_allocator::Allocator;
+use oxc_parser::Parser;
+use oxc_span::SourceType;
+use rsvelte_core::{CompileOptions, ExperimentalOptions, GenerateMode, compile};
+
+#[test]
+fn leading_block_comment_before_async_derived_produces_parseable_client_output() {
+    let output = compile(
+        "<script>\n/* comment */\nconst value = $derived(await Promise.resolve(1));\n</script>\n<p>{value}</p>",
+        CompileOptions {
+            generate: GenerateMode::Client,
+            experimental: ExperimentalOptions { r#async: true },
+            ..Default::default()
+        },
+    )
+    .unwrap_or_else(|error| panic!("compile failed: {error:?}"))
+    .js
+    .code;
+
+    assert!(!output.contains("void (/*"), "{output}");
+    let allocator = Allocator::default();
+    let parsed = Parser::new(&allocator, &output, SourceType::mjs()).parse();
+    assert!(
+        !parsed.panicked && parsed.diagnostics.is_empty(),
+        "client output must parse:\n{output}"
+    );
+}

--- a/crates/rsvelte_core/tests/async_derived_comment_2755.rs
+++ b/crates/rsvelte_core/tests/async_derived_comment_2755.rs
@@ -25,3 +25,26 @@ fn leading_block_comment_before_async_derived_produces_parseable_client_output()
         "client output must parse:\n{output}"
     );
 }
+
+#[test]
+fn inspect_after_top_level_await_keeps_its_async_slot() {
+    let output = compile(
+        "<script>\nlet data = await Promise.resolve(42);\n$inspect(data);\n</script>\n<p>{data}</p>",
+        CompileOptions {
+            generate: GenerateMode::Client,
+            experimental: ExperimentalOptions { r#async: true },
+            ..Default::default()
+        },
+    )
+    .unwrap_or_else(|error| panic!("compile failed: {error:?}"))
+    .js
+    .code;
+
+    assert!(output.contains("() => void 0"), "{output}");
+    let allocator = Allocator::default();
+    let parsed = Parser::new(&allocator, &output, SourceType::mjs()).parse();
+    assert!(
+        !parsed.panicked && parsed.diagnostics.is_empty(),
+        "client output must parse:\n{output}"
+    );
+}


### PR DESCRIPTION
Fixes #2755.

Classifies a leading comment separately from the following async declaration and retains it on the generated hoisted var declaration. This prevents a const declaration from being emitted inside a void expression.

Adds an output-parseability regression test and shrinks the measured async-derived matrix ratchet by the two now-matching client rows.

Verified with focused Rust tests, the async-derived matrix family, and the corpus parse-gate self-test.