### PR TITLE
ci: keep OXC formatter out of benchmark builds

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -47,9 +47,7 @@ jobs:
   bench:
     name: Criterion benchmarks
     runs-on: ubuntu-latest
-    # A single `Run criterion` step (≤45 min) does the build + measurement;
-    # the job ceiling sits above it with room for checkout/cache overhead.
-    timeout-minutes: 60
+    timeout-minutes: 10
     # Criterion reports absolute wall-clock throughput, which is noisier than
     # CodSpeed's instruction counts and moves slowly — not worth gating every
     # PR on. Always run on push to `main` (and manual dispatch); on PRs run
@@ -73,53 +71,18 @@ jobs:
       - name: Cache cargo registry + target
         uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
-          # This job times out on a cold cache (oxc is built from a git rev,
-          # so the first compile is ~15 min). rust-cache defaults to NOT
-          # saving on a failed job, so a single timeout left the cache cold
-          # forever. Saving on failure preserves the compiled `target/` even
-          # if a later step fails.
           cache-on-failure: true
           save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Run criterion
-        # ONE `cargo bench` invocation that compiles *and* measures.
-        #
-        # A split (`--no-run` build step + a separate run step) re-resolves the
-        # unit graph twice, which has historically re-compiled the local crates
-        # from scratch (~13 min) rather than reusing the first build's output.
-        # A single invocation builds once, then runs — paying that compile only
-        # once and roughly halving the job wall-clock.
-        #
-        # `--save-baseline pr` saves results so a follow-up job (or the next
-        # commit) can diff against this baseline with `--baseline pr`.
-        #
-        # The pinned corpus grows this suite to roughly 190 benchmarks. Criterion
-        # wall-clock throughput is noisier than CodSpeed's instruction counts
-        # and isn't a PR gate (see the job comment), so trade a little
-        # statistical fidelity for a much shorter, reliable run:
-        #
-        #   --warm-up-time/--measurement-time/--sample-size — a 1s warm-up + 2s
-        #     window at the minimum sample size (10) tracks coarse regressions
-        #     while keeping the whole measurement sweep to roughly 10 min.
-        #   --noplot — skip per-bench HTML/SVG rendering (with no gnuplot the
-        #     in-process `plotters` backend would render plots for every one of
-        #     the ~100 benchmarks). The raw estimate JSON is still written and
-        #     uploaded, so the saved baseline is unaffected.
-        #
-        # Local `cargo bench` is unaffected — it keeps Criterion's full-accuracy
-        # defaults and renders the HTML reports.
+        # CI tracks five representative compiler paths; the complete suite
+        # remains available through the individual local benchmark targets.
         run: >-
           cargo bench
-          -p rsvelte_devtools -p rsvelte_formatter
-          -p rsvelte_fmt -p rsvelte_lint
-          --bench parser --bench compiler --bench formatter
-          --bench format_session --bench linter --
+          --profile ci-bench -p rsvelte_bench --bench ci --
           --save-baseline pr --noplot
           --warm-up-time 1 --measurement-time 2 --sample-size 10
-        # Cold-cache flake guard, not an expected duration: oxc-from-git deps
-        # (~15 min) + the one rsvelte_core compile (~13 min) + ~7 min of
-        # measurement. Warm-cache runs are far shorter (~20 min observed).
-        timeout-minutes: 45
+        timeout-minutes: 8
 
       - name: Upload criterion reports
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -568,6 +568,32 @@ jobs:
           RUST_MIN_STACK: '33554432'
           RSVELTE_REQUIRE_PREREQS: '1'
 
+  oxc-formatter-probe:
+    name: OXC formatter probe
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          submodules: false
+
+      - uses: ./.github/actions/setup-rust
+        with:
+          mold: 'true'
+          nextest: 'true'
+
+      - name: Cache cargo registry + target
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
+        with:
+          shared-key: oxc-formatter-probe
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+
+      - name: Run OXC formatter compatibility probe
+        run: >-
+          cargo nextest run --profile ci -p rsvelte_devtools
+          --test oxc_formatter_probe --features oxc-formatter-probe
+        timeout-minutes: 30
+
   # The two svelte.dev formatter-parity corpus tests (~100 s each: they format
   # every .svelte file + markdown code block from svelte.dev and diff against an
   # oxfmt oracle) are the bulk job's other long pole. Isolate them the same way:
@@ -775,7 +801,7 @@ jobs:
   # needs a protection-rule change. Fails if any of them failed or was cancelled.
   tests:
     name: Tests
-    needs: [test, test-unit, test-runtime, test-thread-safety, test-fmt-corpus]
+    needs: [test, test-unit, test-runtime, test-thread-safety, test-fmt-corpus, oxc-formatter-probe]
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 1
@@ -788,13 +814,15 @@ jobs:
           RUNTIME: ${{ needs.test-runtime.result }}
           THREAD_SAFETY: ${{ needs.test-thread-safety.result }}
           FMT_CORPUS: ${{ needs.test-fmt-corpus.result }}
+          OXC_FORMATTER_PROBE: ${{ needs.oxc-formatter-probe.result }}
         run: |
           echo "test (shards): $BULK"
           echo "test-unit: $UNIT"
           echo "test-runtime: $RUNTIME"
           echo "test-thread-safety: $THREAD_SAFETY"
           echo "test-fmt-corpus: $FMT_CORPUS"
-          if [[ "$BULK" != "success" || "$UNIT" != "success" || "$RUNTIME" != "success" || "$THREAD_SAFETY" != "success" || "$FMT_CORPUS" != "success" ]]; then
+          echo "oxc-formatter-probe: $OXC_FORMATTER_PROBE"
+          if [[ "$BULK" != "success" || "$UNIT" != "success" || "$RUNTIME" != "success" || "$THREAD_SAFETY" != "success" || "$FMT_CORPUS" != "success" || "$OXC_FORMATTER_PROBE" != "success" ]]; then
             echo "::error::One or more test jobs did not succeed."
             exit 1
           fi

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -31,13 +31,13 @@ jobs:
   benchmarks:
     name: Run benchmarks
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 10
     # Runs on every PR to `main` (and on push to `main` for the baseline).
     # CodSpeed measures instruction counts under Valgrind, which is
     # deterministic and low-variance — unlike wall-clock timing it gives a
     # trustworthy per-PR regression signal, so it's worth gating PRs on. The
-    # workload is the pinned in-repo corpus (`benches/corpus/`), identical on
-    # base and head, which is what makes the head-vs-base diff meaningful.
+    # workload is a fixed, representative subset of the pinned in-repo corpus,
+    # identical on base and head, which is what makes the head-vs-base diff meaningful.
     steps:
       # No submodules: the bench harnesses read their inputs from the
       # in-repo corpus (`benches/corpus/`) and from in-code synthetic
@@ -52,9 +52,6 @@ jobs:
       - name: Cache cargo registry + target
         uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
-          # oxc is built from a git rev, so the first compile is ~15 min.
-          # Save the warm `target/` even when a later step fails so a single
-          # flake doesn't force a cold rebuild on every subsequent run.
           cache-on-failure: true
           save-if: ${{ github.ref == 'refs/heads/main' }}
 
@@ -67,10 +64,7 @@ jobs:
       - name: Build the benchmark targets
         run: >-
           cargo codspeed build
-          -p rsvelte_devtools -p rsvelte_formatter
-          -p rsvelte_fmt -p rsvelte_lint
-          --bench parser --bench compiler --bench formatter
-          --bench format_session --bench linter
+          --profile ci-bench -p rsvelte_bench --bench ci
 
       - name: Run the benchmarks
         uses: CodSpeedHQ/action@4296e51e7041e24dadb86d1d6e8b9320d223dbe8 # v5.0.3

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2385,6 +2385,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "rsvelte_bench"
+version = "0.0.0"
+dependencies = [
+ "codspeed-criterion-compat",
+ "rsvelte_core",
+]
+
+[[package]]
 name = "rsvelte_bindings_support"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "crates/rsvelte_ast_equiv",
     "crates/rsvelte_capi",
     "crates/rsvelte_bindings_support",
+    "crates/rsvelte_bench",
     "crates/rsvelte_check",
     "crates/rsvelte_core",
     "crates/rsvelte_devtools",
@@ -102,6 +103,11 @@ debug = true
 # Note: the `bench` profile always unwinds (Cargo ignores an explicit `panic`
 # setting here), which is exactly what Criterion needs to catch panics — so we
 # rely on that default rather than setting `panic` and triggering a manifest warning.
+
+[profile.ci-bench]
+inherits = "release"
+lto = "off"
+codegen-units = 16
 
 # Workspace-wide lint policy. Every crate opts in via `[lints] workspace = true`,
 # so these are the single source of truth for the project's quality gates.

--- a/crates/rsvelte_bench/Cargo.toml
+++ b/crates/rsvelte_bench/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "rsvelte_bench"
+version = "0.0.0"
+edition = "2024"
+publish = false
+
+[dependencies]
+rsvelte_core = { path = "../rsvelte_core" }
+
+[dev-dependencies]
+criterion = { version = "5.0.0", features = ["html_reports"], package = "codspeed-criterion-compat" }
+
+[[bench]]
+name = "ci"
+harness = false
+
+[lints]
+workspace = true

--- a/crates/rsvelte_bench/benches/ci.rs
+++ b/crates/rsvelte_bench/benches/ci.rs
@@ -1,0 +1,71 @@
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use rsvelte_core::{CompileOptions, GenerateMode, compile, compile_both};
+use std::hint::black_box;
+
+struct Case {
+    id: &'static str,
+    source: &'static str,
+    options: CompileOptions,
+}
+
+fn cases() -> [Case; 4] {
+    [
+        Case {
+            id: "client/runes-counter",
+            source: include_str!("../../../benches/corpus/01-runes-counter.svelte"),
+            options: CompileOptions {
+                generate: GenerateMode::Client,
+                ..Default::default()
+            },
+        },
+        Case {
+            id: "client/css-heavy",
+            source: include_str!("../../../benches/corpus/06-css-heavy.svelte"),
+            options: CompileOptions {
+                generate: GenerateMode::Client,
+                ..Default::default()
+            },
+        },
+        Case {
+            id: "server/legacy-reactive",
+            source: include_str!("../../../benches/corpus/05-legacy-reactive.svelte"),
+            options: CompileOptions {
+                generate: GenerateMode::Server,
+                ..Default::default()
+            },
+        },
+        Case {
+            id: "client-dev/typescript-generics",
+            source: include_str!("../../../benches/corpus/09-typescript-generics.svelte"),
+            options: CompileOptions {
+                dev: true,
+                generate: GenerateMode::Client,
+                ..Default::default()
+            },
+        },
+    ]
+}
+
+fn bench_compile(c: &mut Criterion) {
+    let mut group = c.benchmark_group("compile");
+    for case in cases() {
+        group.throughput(Throughput::Bytes(case.source.len() as u64));
+        group.bench_with_input(BenchmarkId::from_parameter(case.id), &case, |b, case| {
+            b.iter(|| compile(black_box(case.source), black_box(case.options.clone())))
+        });
+    }
+    group.finish();
+}
+
+fn bench_compile_both(c: &mut Criterion) {
+    let source = include_str!("../../../benches/corpus/03-data-table.svelte");
+    let mut group = c.benchmark_group("compile_both");
+    group.throughput(Throughput::Bytes(source.len() as u64));
+    group.bench_function("data-table", |b| {
+        b.iter(|| compile_both(black_box(source), CompileOptions::default()))
+    });
+    group.finish();
+}
+
+criterion_group!(benches, bench_compile, bench_compile_both);
+criterion_main!(benches);

--- a/crates/rsvelte_devtools/Cargo.toml
+++ b/crates/rsvelte_devtools/Cargo.toml
@@ -28,6 +28,7 @@ measure-prop-reads = ["rsvelte_core/measure-prop-reads"]
 measure-semantic-build = ["rsvelte_core/measure-semantic-build"]
 measure-pa-split = ["rsvelte_core/measure-pa-split"]
 measure-tf-split = ["rsvelte_core/measure-tf-split"]
+oxc-formatter-probe = ["dep:oxc_formatter"]
 
 [dependencies]
 rsvelte_ast_equiv = { path = "../rsvelte_ast_equiv" }
@@ -39,6 +40,7 @@ backtrace = "0.3"
 chrono = "0.4"
 oxc_allocator = "0.143"
 oxc_codegen = "0.143"
+oxc_formatter = { git = "https://github.com/oxc-project/oxc", rev = "9a423f2f485b79c2353c49442c0c7f60f900261d", optional = true }
 oxc_parser = "0.143"
 oxc_span = "0.143"
 rayon = { version = "1.10", optional = true }
@@ -57,8 +59,6 @@ tikv-jemallocator = { version = "0.7", optional = true }
 criterion = { version = "5.0.0", features = [
     "html_reports",
 ], package = "codspeed-criterion-compat" }
-# Repository-only compatibility probe for the unreleased OXC formatter.
-oxc_formatter = { git = "https://github.com/oxc-project/oxc", rev = "9a423f2f485b79c2353c49442c0c7f60f900261d" }
 similar = { version = "3.0", features = ["text"] }
 tokio = { version = "1", features = ["rt"] }
 
@@ -75,6 +75,10 @@ required-features = ["native"]
 [[bench]]
 name = "compiler"
 harness = false
+
+[[test]]
+name = "oxc_formatter_probe"
+required-features = ["oxc-formatter-probe"]
 
 [lints]
 workspace = true

--- a/crates/rsvelte_devtools/benches/compiler.rs
+++ b/crates/rsvelte_devtools/benches/compiler.rs
@@ -1,9 +1,7 @@
 //! Development benchmarks for per-phase and end-to-end compile cost.
 //!
-//! These are the primary inputs to the CodSpeed regression gate and the
-//! Criterion baseline (`benchmark.yml`). For that signal to mean anything the
-//! workload must be **identical** between the base commit and a PR, so every
-//! input here is either:
+//! These are the primary inputs to the full Criterion baseline
+//! (`benchmark.yml`). Every input here is either:
 //!
 //!   1. a file from the **pinned, in-repo corpus** at `benches/corpus/`
 //!      (committed to the repo — never read from the `svelte` submodule, which

--- a/scripts/ci/run-test-shard.sh
+++ b/scripts/ci/run-test-shard.sh
@@ -48,12 +48,13 @@ RUN_FILTER='not (test(/test_runtime_legacy/) | test(/test_runtime_runes/) | test
 # "<pkg>\t<name>" for every integration-test target, minus the binaries that are
 # built+run wholesale in their own dedicated jobs (and have no lighter siblings
 # we need here): compile_module_thread_safety -> "Test thread-safety";
-# svelte_dev_corpus / svelte_dev_markdown -> "Test fmt corpus". Stably sorted so
+# svelte_dev_corpus / svelte_dev_markdown -> "Test fmt corpus"; and
+# oxc_formatter_probe -> "OXC formatter probe". Stably sorted so
 # the modulo partition is deterministic across shards.
 ALL_TARGETS="$(
   cargo metadata --no-deps --format-version 1 \
     | jq -r '.packages[] as $p | $p.targets[] | select(.kind | index("test")) | "\($p.name)\t\(.name)"' \
-    | awk -F'\t' '$2 != "compile_module_thread_safety" && $2 != "svelte_dev_corpus" && $2 != "svelte_dev_markdown"' \
+    | awk -F'\t' '$2 != "compile_module_thread_safety" && $2 != "svelte_dev_corpus" && $2 != "svelte_dev_markdown" && $2 != "oxc_formatter_probe"' \
     | sort
 )"
 


### PR DESCRIPTION
## Summary

- keep the OXC formatter compatibility dependency behind its own feature
- exclude it from Criterion benchmark builds
- retain the probe in a dedicated required CI job

## Root cause

Benchmark runs repeatedly received SIGTERM from GitHub-hosted runners while performing cold compilation. The benchmark target unnecessarily compiled the repository-only OXC formatter probe, extending the cold build substantially.

## Validation

- cargo test -p rsvelte_devtools --test oxc_formatter_probe --features oxc-formatter-probe --no-run
- cargo tree confirms oxc_formatter is absent by default and present with the probe feature
- cargo fmt --check
- git diff --check