### PR TITLE
fix(napi): return modern AST from compile

### DIFF
--- a/.changeset/modern-ast-compile.md
+++ b/.changeset/modern-ast-compile.md
@@ -1,0 +1,5 @@
+---
+'@rsvelte/vite-plugin-svelte-native': patch
+---
+
+Return the public modern compiler AST from `compile({ modernAst: true })`.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,6 +104,7 @@ jobs:
       - uses: ./.github/actions/setup-node-pnpm
         with:
           cache: 'true'
+          cache-dependency-path: submodules/svelte/pnpm-lock.yaml
           cache-dependency-path: apps/playground/pnpm-lock.yaml
 
       - name: Check playground lockfile is in sync
@@ -743,6 +744,9 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
+
+      - name: Install Svelte compiler dependencies
+        run: pnpm --dir submodules/svelte install --frozen-lockfile
 
       - name: Build lint wasm (nodejs target)
         run: pnpm run build:wasm:lint-node

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,7 +104,6 @@ jobs:
       - uses: ./.github/actions/setup-node-pnpm
         with:
           cache: 'true'
-          cache-dependency-path: submodules/svelte/pnpm-lock.yaml
           cache-dependency-path: apps/playground/pnpm-lock.yaml
 
       - name: Check playground lockfile is in sync
@@ -745,9 +744,6 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Install Svelte compiler dependencies
-        run: pnpm --dir submodules/svelte install --frozen-lockfile
-
       - name: Build lint wasm (nodejs target)
         run: pnpm run build:wasm:lint-node
 
@@ -1006,6 +1002,7 @@ jobs:
       - uses: ./.github/actions/setup-node-pnpm
         with:
           cache: 'true'
+          cache-dependency-path: submodules/svelte/pnpm-lock.yaml
 
       - name: Cache cargo registry + target
         uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
@@ -1015,6 +1012,9 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
+
+      - name: Install Svelte compiler dependencies
+        run: pnpm --dir submodules/svelte install --frozen-lockfile
 
       - name: Build NAPI addon (host)
         run: pnpm run build:vps-native

--- a/apps/npm/vite-plugin-svelte-native/index.cjs
+++ b/apps/npm/vite-plugin-svelte-native/index.cjs
@@ -138,6 +138,9 @@ function compile(source, options) {
 		);
 	}
 	const { options: resolved, warningFilter } = prepareCompileOptions(options);
+	if (resolved?.modernAst) {
+		return applyWarningFilter(binding.compile(source, resolved), warningFilter);
+	}
 	return applyWarningFilter(
 		decodeEnvelope(binding.compileEnvelopeExternalSources(source, resolved), source),
 		warningFilter,
@@ -201,6 +204,9 @@ async function compileAsync(source, options) {
 			makeCssHashCallback(options.cssHash),
 		);
 		return applyWarningFilter(result, warningFilter);
+	}
+	if (resolved?.modernAst) {
+		return applyWarningFilter(binding.compile(source, resolved), warningFilter);
 	}
 	return applyWarningFilter(
 		decodeEnvelope(

--- a/apps/npm/vite-plugin-svelte-native/index.cjs
+++ b/apps/npm/vite-plugin-svelte-native/index.cjs
@@ -127,8 +127,9 @@ function applyWarningFilter(result, warningFilter) {
 //
 // Callers that need the raw envelope (e.g. to ship it across a worker
 // boundary without re-encoding) can still grab `binding.compileEnvelope`
-// directly. The legacy JSON path is preserved as `compileLegacy` for
-// parity testing and as an escape hatch.
+// directly, except with modernAst: the v1 envelope has no AST field.
+// The legacy JSON path is preserved as `compileLegacy` for parity testing
+// and as an escape hatch.
 function compile(source, options) {
 	if (typeof options?.cssHash === 'function') {
 		// A dynamic cssHash needs the Rust→JS callback bridge, which would deadlock
@@ -178,6 +179,11 @@ function compileBatch(inputs) {
 		if (warningFilter) filters[i] = warningFilter;
 		return options === input.options ? input : { source: input.source, options };
 	});
+	if (prepared.some((input) => input.options?.modernAst)) {
+		return prepared.map((input, i) =>
+			applyWarningFilter(binding.compile(input.source, input.options), filters[i]),
+		);
+	}
 	const sourceContents = prepared.map((input) => input.source);
 	const results = decodeBatch(
 		binding.compileBatchExternalSources(prepared),
@@ -225,6 +231,11 @@ async function compileBatchAsync(inputs) {
 		if (warningFilter) filters[i] = warningFilter;
 		return options === input.options ? input : { source: input.source, options };
 	});
+	if (prepared.some((input) => input.options?.modernAst)) {
+		return prepared.map((input, i) =>
+			applyWarningFilter(binding.compile(input.source, input.options), filters[i]),
+		);
+	}
 	const sourceContents = prepared.map((input) => input.source);
 	const results = decodeBatch(
 		await binding.compileBatchExternalSourcesAsync(prepared),

--- a/crates/rsvelte_capi/src/lib.rs
+++ b/crates/rsvelte_capi/src/lib.rs
@@ -846,5 +846,8 @@ fn compile_result_to_json(result: &rsvelte_core::compiler::CompileResult) -> Val
         "css": css_obj,
         "warnings": warnings,
         "metadata": { "runes": result.metadata.runes },
+        "ast": result.ast.as_deref()
+            .and_then(|ast| serde_json::from_str::<Value>(ast).ok())
+            .unwrap_or(Value::Null),
     })
 }

--- a/crates/rsvelte_capi/tests/options_coverage.rs
+++ b/crates/rsvelte_capi/tests/options_coverage.rs
@@ -297,16 +297,17 @@ fn component_api_v4_changes_codegen() {
 }
 
 // ---------------------------------------------------------------------------
-// modernAst — at minimum should be accepted without error
+// modernAst
 // ---------------------------------------------------------------------------
 
 #[test]
-fn modern_ast_option_accepted() {
+fn modern_ast_option_returns_public_ast() {
     let env = compile(
         "<h1>x</h1>",
         r#"{"filename":"App.svelte","modernAst":true}"#,
     );
     assert_eq!(env["ok"], serde_json::Value::Bool(true));
+    assert_eq!(env["result"]["ast"]["type"], "Root");
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/rsvelte_core/src/compiler/mod.rs
+++ b/crates/rsvelte_core/src/compiler/mod.rs
@@ -539,16 +539,19 @@ fn tabs_to_spaces_column(line: &str, column: usize) -> usize {
 /// Returned to the caller so the `Root` is pinned on the caller's stack before
 /// the arena guard is installed — the guard holds a raw pointer to `ast.arena`,
 /// so the `Root` must not move after the guard is created.
-pub(crate) fn parse_component(source: &str) -> Result<crate::ast::Root<'_>, CompileError> {
+pub(crate) fn parse_component(
+    source: &str,
+    modern_ast: bool,
+) -> Result<crate::ast::Root<'_>, CompileError> {
     let parse_options = crate::ParseOptions {
         modern: true,
         loose: false,
-        skip_expression_loc: true,
+        skip_expression_loc: !modern_ast,
         defer_script_parse: true,
         force_typescript: false,
         lenient_script: false,
         skip_non_css_lang_style: false,
-        capture_comments: false,
+        capture_comments: modern_ast,
     };
     // M5-A: caller-owned arena, unused for now (Root borrows only `source`).
     let alloc = oxc_allocator::Allocator::default();
@@ -839,7 +842,7 @@ pub(crate) fn finalize_compile_result(
                 .collect()
         },
         metadata: CompileMetadata { runes: runes_mode },
-        ast: None, // TODO: Return AST if options.modern_ast is true
+        ast: None,
     }
 }
 

--- a/crates/rsvelte_core/src/toolchain.rs
+++ b/crates/rsvelte_core/src/toolchain.rs
@@ -7,6 +7,8 @@
 
 use std::{cell::OnceCell, ops::Range};
 
+use serde_json::Value;
+
 use crate::{
     CompileError, CompileOptions, CompileResult, GenerateMode,
     ast::{AttributeValue, AttributeValuePart, Root, ScriptContext, oxc_program::RetainedScripts},
@@ -326,7 +328,10 @@ impl std::fmt::Debug for PreparedComponent<'_> {
 
 impl<'source> PreparedComponent<'source> {
     pub(crate) fn new(source: &'source str, options: CompileOptions) -> Result<Self, CompileError> {
-        let mut ast = Box::new(crate::compiler::parse_component(source)?);
+        let mut ast = Box::new(crate::compiler::parse_component(
+            source,
+            options.modern_ast,
+        )?);
         let (options, analysis, runes_mode, retained_scripts) = {
             // SAFETY: the guard is dropped before `ast` moves into the result.
             let _arena_guard =
@@ -398,13 +403,48 @@ impl<'source> PreparedComponent<'source> {
             Some(&self.retained_scripts),
         )
         .map_err(CompileError::from)?;
-        Ok(crate::compiler::finalize_compile_result(
+        let mut result = crate::compiler::finalize_compile_result(
             transform_result,
             &self.analysis,
             self.source,
             options,
             self.runes_mode,
-        ))
+        );
+        if options.modern_ast {
+            result.ast = Some(self.public_ast_json());
+        }
+        Ok(result)
+    }
+
+    fn public_ast_json(&self) -> String {
+        let mut value = serde_json::to_value(&*self.ast).expect("the public AST is serializable");
+        remove_metadata(&mut value);
+        if let Some(root) = value.as_object_mut() {
+            root.entry("comments")
+                .or_insert_with(|| Value::Array(Vec::new()));
+        }
+        if !self.source.is_ascii() {
+            let positions = crate::compiler::legacy::Utf8ToUtf16::new(self.source);
+            crate::compiler::legacy::convert_positions_to_utf16(&mut value, &positions);
+        }
+        serde_json::to_string(&value).expect("the public AST JSON is serializable")
+    }
+}
+
+fn remove_metadata(value: &mut Value) {
+    match value {
+        Value::Object(object) => {
+            object.remove("metadata");
+            for value in object.values_mut() {
+                remove_metadata(value);
+            }
+        }
+        Value::Array(values) => {
+            for value in values {
+                remove_metadata(value);
+            }
+        }
+        _ => {}
     }
 }
 

--- a/crates/rsvelte_napi/src/lib.rs
+++ b/crates/rsvelte_napi/src/lib.rs
@@ -1760,6 +1760,7 @@ pub fn napi_compile_buffers(
     options: Option<NapiCompileOptions>,
 ) -> napi::Result<CompileBuffersResult> {
     let opts = options_to_compile(options)?;
+    reject_modern_ast_for_binary_result(&opts, "compileBuffers")?;
     match rust_compile(&source, opts) {
         Ok(result) => Ok(CompileBuffersResult {
             js: CompileBuffersJs {
@@ -1850,6 +1851,16 @@ fn ensure_envelope_size(size: usize) -> napi::Result<()> {
     })
 }
 
+#[inline]
+fn reject_modern_ast_for_binary_result(options: &CompileOptions, api: &str) -> napi::Result<()> {
+    if options.modern_ast {
+        return Err(napi::Error::from_reason(format!(
+            "rsvelte: modernAst is not supported by {api}; use compile() instead"
+        )));
+    }
+    Ok(())
+}
+
 /// `compile()` returning a single packed envelope buffer.
 /// See `rsvelte_bindings_support::napi_raw` for the byte-level format.
 #[napi(js_name = "compileEnvelope", catch_unwind)]
@@ -1881,6 +1892,7 @@ fn compile_envelope(
     options: CompileOptions,
     externalize_sourcemap_content: bool,
 ) -> napi::Result<Buffer> {
+    reject_modern_ast_for_binary_result(&options, "compileEnvelope")?;
     let result = if externalize_sourcemap_content {
         rust_compile_with_external_sourcemap_content(source, options)
     } else {
@@ -2001,6 +2013,7 @@ pub fn napi_compile_envelope_zero_copy(
     options: Option<NapiCompileOptions>,
 ) -> napi::Result<JsBuffer> {
     let opts = options_to_compile(options)?;
+    reject_modern_ast_for_binary_result(&opts, "compileEnvelopeZeroCopy")?;
     let result = match rust_compile(&source, opts) {
         Ok(r) => r,
         Err(e) => return Err(napi::Error::from_reason(format!("{e:?}"))),
@@ -2110,6 +2123,9 @@ fn compile_batch_envelope(
         .into_iter()
         .map(|item| Ok((item.source, options_to_compile(item.options)?)))
         .collect::<napi::Result<_>>()?;
+    for (_, options) in &parsed {
+        reject_modern_ast_for_binary_result(options, "compileBatch")?;
+    }
 
     // Compile in parallel. `compile_batch` takes `&[(&str, CompileOptions)]`,
     // so we materialise the borrowed view once.
@@ -2229,6 +2245,7 @@ pub fn napi_compile_envelope_async(
     options: Option<NapiCompileOptions>,
 ) -> napi::Result<AsyncTask<CompileEnvelopeTask>> {
     let options = options_to_compile(options)?;
+    reject_modern_ast_for_binary_result(&options, "compileEnvelopeAsync")?;
     Ok(AsyncTask::new(CompileEnvelopeTask {
         source,
         filename: options.filename.clone(),
@@ -2243,6 +2260,7 @@ pub fn napi_compile_envelope_external_sources_async(
     options: Option<NapiCompileOptions>,
 ) -> napi::Result<AsyncTask<CompileEnvelopeTask>> {
     let options = options_to_compile(options)?;
+    reject_modern_ast_for_binary_result(&options, "compileEnvelopeExternalSourcesAsync")?;
     Ok(AsyncTask::new(CompileEnvelopeTask {
         source,
         filename: options.filename.clone(),
@@ -2325,6 +2343,9 @@ fn compile_batch_async_task(
         .into_iter()
         .map(|item| Ok((item.source, options_to_compile(item.options)?)))
         .collect::<napi::Result<_>>()?;
+    for (_, options) in &parsed {
+        reject_modern_ast_for_binary_result(options, "compileBatchAsync")?;
+    }
     Ok(AsyncTask::new(CompileBatchTask {
         inputs: parsed,
         externalize_sourcemap_content,

--- a/crates/rsvelte_napi/src/lib.rs
+++ b/crates/rsvelte_napi/src/lib.rs
@@ -365,7 +365,9 @@ fn compile_result_to_json(result: rsvelte_core::compiler::CompileResult) -> Valu
         "css": css_obj,
         "warnings": warnings_to_json(&result.warnings),
         "metadata": { "runes": result.metadata.runes },
-        "ast": Value::Null,
+        "ast": result.ast.as_deref()
+            .and_then(|ast| serde_json::from_str::<Value>(ast).ok())
+            .unwrap_or(Value::Null),
     })
 }
 

--- a/scripts/dev/test-napi-compile-options.mjs
+++ b/scripts/dev/test-napi-compile-options.mjs
@@ -480,6 +480,16 @@ assert(
 	'compile.modernAst: default remains null',
 	napi.compile(MODERN_AST_SRC, { filename: 'A.svelte' }).ast === null
 );
+let modernAstEnvelopeError;
+try {
+	napi.compileEnvelope(MODERN_AST_SRC, { filename: 'A.svelte', modernAst: true });
+} catch (error) {
+	modernAstEnvelopeError = error;
+}
+assert(
+	'compileEnvelope.modernAst: rejects unsupported envelope format',
+	/modernAst is not supported by compileEnvelope/.test(modernAstEnvelopeError?.message)
+);
 
 for (const key of ['accessors', 'immutable']) {
 	const result = napi.compile(LEGACY_SRC, { filename: 'A.svelte', [key]: false });

--- a/scripts/dev/test-napi-compile-options.mjs
+++ b/scripts/dev/test-napi-compile-options.mjs
@@ -31,6 +31,7 @@ import { readFileSync } from 'node:fs';
 import { createRequire } from 'node:module';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { compile as officialCompile } from '../../submodules/svelte/packages/svelte/src/compiler/index.js';
 
 const here = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(here, '../..');
@@ -165,10 +166,6 @@ const DECLARED = new Map([
 // than a gap: it reads as surveyed.
 const UNCOVERED = new Map([
 	[
-		'compile.modernAst',
-		'inert in rsvelte_core: `compile` returns `ast: None` unconditionally (compiler/mod.rs), and the napi layer forwards `ast: Value::Null`, so no input can tell `modernAst: true` from the default',
-	],
-	[
 		'compileModule.rootDir',
 		'forwarded to CompileOptions but every consumer of `root_dir` (the `$.FILENAME` / HMR key in the client component transform, and the CSS scope hash) is component-only, so a module compile has nothing to observe',
 	],
@@ -223,6 +220,14 @@ const warningCodes = (r) => (r.warnings ?? []).map((w) => w.code);
  * once in this process — a second compile with the same key would see no warning.
  */
 const COMPILE_CASES = [
+	{
+		key: 'modernAst',
+		src: '<script>let x = "α";</script><style>:global(h1) { color: red }</style><h1>{x}</h1>',
+		base: { filename: 'A.svelte' },
+		variant: { filename: 'A.svelte', modernAst: true },
+		marker: (r) => r.ast?.type === 'Root',
+		differsIn: (r) => r.ast,
+	},
 	{
 		key: 'dev',
 		src: RUNES_SRC,
@@ -452,7 +457,29 @@ function runCase(surface, compile, c) {
 
 console.log('\n# compile options');
 for (const c of COMPILE_CASES) runCase('compile', (s, o) => napi.compile(s, o), c);
-covered.add('compile.modernAst');
+
+const MODERN_AST_SRC =
+	'<script>let x = "α";</script><style>:global(h1) { color: red }</style><h1>{x}</h1>';
+const modernAst = napi.compile(MODERN_AST_SRC, { filename: 'A.svelte', modernAst: true }).ast;
+const canonicalJson = (value) => {
+	if (Array.isArray(value)) return value.map(canonicalJson);
+	if (value && typeof value === 'object') {
+		return Object.fromEntries(Object.keys(value).sort().map((key) => [key, canonicalJson(value[key])]));
+	}
+	return value;
+};
+assert(
+	'compile.modernAst: matches the official public AST',
+	JSON.stringify(canonicalJson(modernAst)) ===
+		JSON.stringify(
+			canonicalJson(officialCompile(MODERN_AST_SRC, { filename: 'A.svelte', modernAst: true }).ast)
+		),
+	'modern AST differs from svelte/compiler'
+);
+assert(
+	'compile.modernAst: default remains null',
+	napi.compile(MODERN_AST_SRC, { filename: 'A.svelte' }).ast === null
+);
 
 for (const key of ['accessors', 'immutable']) {
 	const result = napi.compile(LEGACY_SRC, { filename: 'A.svelte', [key]: false });


### PR DESCRIPTION
Fixes #2697.

Returns the public modern AST when `compile(..., { modernAst: true })` is used. The compiler preserves public `loc` and comments for that mode, strips internal metadata, and converts source positions to UTF-16 before exposing the result.

The N-API and C API serializers now expose the AST, and the JS wrapper bypasses its binary envelope path when the result must carry an AST. The N-API option gate compares a Unicode/CSS/script AST with the official compiler.

Validated with:
- `pnpm run test:napi-options`
- `cargo test -p rsvelte_capi --test options_coverage`
- `cargo clippy --all-targets --all-features -- -D warnings`