### PR TITLE
fix(corpus): distinguish re-keyed mutation baselines (#2625)

### DIFF
--- a/.changeset/mutation-baseline-provenance.md
+++ b/.changeset/mutation-baseline-provenance.md
@@ -1,0 +1,6 @@
+---
+"@rsvelte/compiler": patch
+---
+
+Record a hash for each mutation-corpus baseline seed so a source-content re-key
+cannot be misreported as a fixed compatibility failure.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1050,6 +1050,9 @@ jobs:
       - name: Check the output-parseability gate
         run: node scripts/dev/test-corpus-parse-gate.mjs
 
+      - name: Check mutation baseline provenance
+        run: node scripts/dev/test-mutation-baseline-provenance.mjs
+
       # The lint gate's rewrite floor and its compared population. Both linters
       # are stubbed, so this runs without the lint submodules, the dist-lint
       # build or the eslint oracle that the Lint parity job needs.

--- a/compatibility/gate-coverage.md
+++ b/compatibility/gate-coverage.md
@@ -1625,6 +1625,11 @@ already carry `__m<n>__` so they do not churn.
 
 ### Blind spot 20c — `already PASS` cannot distinguish *fixed* from *no longer produced*
 
+**CLOSED.** The mutation baseline provenance file records a SHA-256 hash for every
+baselined seed. A full run reports re-keyed seeds and seeds without comparable
+provenance separately from unchanged seeds whose entries actually pass. The
+mutation-baseline-provenance control exercises all three outcomes.
+
 **[S]** The staleness check is `baseline.filter((id) => !ids.has(id))` (`:661`) — a baseline key
 absent from this run's failures. `ids` is `` `${f.id} [${f.verdict}] (${f.target})` `` (`:588`).
 An entry leaves that set for at least four reasons and the output calls all of them "already

--- a/compatibility/mutation-known-failures.md
+++ b/compatibility/mutation-known-failures.md
@@ -67,6 +67,10 @@ the gate prints must be the reason for the verdict, and before this a reviewer c
 
 Full sweep: 14,138 seeds → 12,166 mutants → 36,498 comparisons, under oxfmt 0.62.0.
 
+The `mutation-known-failures.provenance.json` file records 21 entries, one SHA-256 seed-content
+hash for each source represented by the failure ratchet. A full sweep reports a changed
+hash as re-keyed instead of claiming that the old mutation now passes.
+
 | verdict | entries |
 |---|---|
 | `code-mismatch` | 36 |

--- a/compatibility/mutation-known-failures.provenance.json
+++ b/compatibility/mutation-known-failures.provenance.json
@@ -1,0 +1,23 @@
+{
+  "flowbite-svelte/src/routes/blocks/utils/ExampleWrapper.svelte": "13b0a86569d5ccd18bc5bdfe91792e9736109b9a42c072dfcf03b3576ec8d642",
+  "layercake/src/_components/Beeswarm.html.svelte": "4d4fcec5376d4dfe9d35f86661a40ac890ffb9d761b456a6b4f958964dbb90d3",
+  "layerchart/packages/layerchart/src/lib/components/layers/Canvas.svelte": "05878c9106f45f7aca016262158c940581cb4abcecc9c5f4a57e03d0911af1c5",
+  "powertable/app/src/lib/components/PowerTable.svelte": "b88b8c8e302ac9d4273aef4a4c22e5084e118cdbbbc571639907a4eace33eb8e",
+  "runed/packages/runed/src/lib/utilities/watch/watch.svelte.ts": "b72041513f375a070b836ceebd3dac297411ef5f08c9f94f34a25bdb37e56bf0",
+  "runed/sites/docs/src/lib/components/demos/pressed-keys.svelte": "57fa62788c4090d8b0977d5406a7ee129840512b98e5634b267a07825f35ae23",
+  "svelte-sonner/src/lib/Loader.svelte": "b5987618399bc482d6fb472248c64790dab6c0bcaffee872398f50dd1d5d61f8",
+  "svelte.dev/apps/svelte.dev/content/docs/svelte/02-runes/07-$inspect.md/1.svelte": "040d9b2125de49ad71ad6a09920e816a3cf00e5de8e2680a8ab2196065af6de5",
+  "svelte.dev/packages/repl/src/lib/Bundler.svelte.ts": "d035d25868ed622f227641ee40bf77d108ff37f905acea6613ca90779f6ea257",
+  "svelte/documentation/docs/02-runes/07-$inspect.md/1.svelte": "040d9b2125de49ad71ad6a09920e816a3cf00e5de8e2680a8ab2196065af6de5",
+  "svelte/documentation/docs/02-runes/07-$inspect.md/2.svelte": "6474daddf2f38349d9d3c1a67dc20e3d62bf4acc59dcaf54f466786cab3a395a",
+  "svelte/packages/svelte/tests/runtime-runes/samples/inspect-derived-4/main.svelte": "3a60fcece65d41220fa5947bb2c4da2b680b83f6effdad36939a8a79f5018893",
+  "svelte/packages/svelte/tests/runtime-runes/samples/inspect-derived-if-destroy/List.svelte": "6f8b9922252e5086e18ad22dee594fd3a8c3ee9a2d2bd748538d14ef2cb6d451",
+  "svelte/packages/svelte/tests/runtime-runes/samples/inspect-multiple/main.svelte": "d7099100fb1e08f5a37a8a7839f10a039528c8902c82aea7f4ee4a3c08117bdd",
+  "svelte/packages/svelte/tests/runtime-runes/samples/inspect-with-untracked/main.svelte": "c4b58ef8bfead0591e47d48e23c17bf8c3a9cd84e43fcfd3696fa463ca2fb09e",
+  "svelte/packages/svelte/tests/runtime-runes/samples/mutation-both/main.svelte": "f4ad5debb58e3427359ffecb73322737439f438ab982b637e63ba357b8903eff",
+  "svelte/packages/svelte/tests/runtime-runes/samples/state-snapshot-uncloneable-ignored/main.svelte": "b90740fc8eca0ef466302f26c973963c70f1b6870b1b930a6c56a4f725a47d36",
+  "svelte/packages/svelte/tests/validator/samples/anonymous-declarations/class.svelte.js": "a495cd1b22c5689ed40ab73c25faaa0dfde4b84a875061b179875a5a58e10541",
+  "svelte/packages/svelte/tests/validator/samples/ignore-warning-dash-backwards-compat/input.svelte": "e4c5078c6fac7e404a6b6b5d1e1a9bf77d2941dc5f4502685afa49c82b791765",
+  "svelte/packages/svelte/tests/validator/samples/runes-conflicting-store-in-module/input.svelte.js": "729e19c86c907954d917a3a01826dbf7ea019ef3d4043ddcf7deee3b24fa8487",
+  "svelte/packages/svelte/tests/validator/samples/unreferenced-variables/input.svelte": "3771bd95c200e34b46cd1a535949f5cecd9dcb07171bb612bd48f8d1febf67b8"
+}

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
 		"test:lint-verify-floor": "node scripts/dev/test-lint-verify-population-floor.mjs",
 		"test:corpus-generation": "node scripts/dev/test-corpus-generation-guard.mjs",
 		"test:mutant-classification": "node scripts/dev/test-mutant-classification.mjs",
+		"test:mutation-baseline-provenance": "node scripts/dev/test-mutation-baseline-provenance.mjs",
 		"test:known-failures-md-check": "node scripts/dev/test-known-failures-md-check.mjs",
 		"test:release-comment": "node scripts/dev/test-release-comment.mjs",
 		"test:css-prune-verdict": "node scripts/dev/test-css-prune-sweep-warning-verdict.mjs",

--- a/scripts/compat-corpus/known-failures-md-check.mjs
+++ b/scripts/compat-corpus/known-failures-md-check.mjs
@@ -142,6 +142,11 @@ const RATCHETS = [
 		jsons: ['validator-message-not-comparable.json'],
 	},
 	{ doc: 'mutation-known-failures.md', key: 'mutation-known-failures.json', jsons: ['mutation-known-failures.json'] },
+	{
+		doc: 'mutation-known-failures.md',
+		key: 'mutation-known-failures.provenance.json',
+		jsons: ['mutation-known-failures.provenance.json'],
+	},
 	{ doc: 'sourcemap-known-failures.md', key: 'sourcemap-known-failures.json', jsons: ['sourcemap-known-failures.json'] },
 	{ doc: 'sourcemap-oracle-excluded.md', key: 'sourcemap-oracle-excluded.json', jsons: ['sourcemap-oracle-excluded.json'] },
 	{ doc: 'css-prune-known-failures.md', key: 'css-prune-known-failures.json', jsons: ['css-prune-known-failures.json'] },
@@ -218,6 +223,7 @@ const fail = (msg) => {
 const escape = (s) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 
 const num = (s) => Number(s.replace(/,/g, ''));
+const jsonEntryCount = (value) => (Array.isArray(value) ? value.length : Object.keys(value).length);
 
 /**
  * Every count a doc states for `key`, or a reason none could be read. All of
@@ -294,7 +300,7 @@ for (const { doc, key, jsons } of RATCHETS) {
 	}
 	const lengths = jsons.map((j) => {
 		const p = path.join(CORPUS, j);
-		return fs.existsSync(p) ? JSON.parse(fs.readFileSync(p, 'utf8')).length : null;
+		return fs.existsSync(p) ? jsonEntryCount(JSON.parse(fs.readFileSync(p, 'utf8'))) : null;
 	});
 	if (lengths.some((n) => n === null)) continue; // already reported above
 	const unique = [...new Set(lengths)];

--- a/scripts/compat-corpus/mutate-corpus.mjs
+++ b/scripts/compat-corpus/mutate-corpus.mjs
@@ -71,6 +71,13 @@ import { selectTargets, TARGETS as ALL_TARGETS } from './targets.mjs';
 import { insertionSlots } from './matrix/mutate.mjs';
 import { COMMENT_KINDS } from './matrix/axes.mjs';
 import { assertOracleCompiles } from './oracle.mjs';
+import {
+	classifyBaseline,
+	readBaselineProvenance,
+	seedHash,
+	seedIdOfBaselineEntry,
+	seedIdOfMutant,
+} from './mutation-baseline.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '../..');
@@ -79,6 +86,7 @@ const SOURCES = path.join(CORPUS, 'sources');
 const TREE = path.join(CORPUS, 'mutant-artifacts');
 const SHARDS = path.join(CORPUS, '.mutant-shards');
 const BASELINE = path.join(CORPUS, 'mutation-known-failures.json');
+const BASELINE_PROVENANCE = path.join(CORPUS, 'mutation-known-failures.provenance.json');
 const BINDING = path.resolve(ROOT, '.corpus-cache/rsvelte.node');
 
 const args = process.argv.slice(2);
@@ -513,7 +521,6 @@ function astVerdicts(pairs) {
 }
 
 const allPairs = fs.existsSync(TREE) ? walkPairs(TREE) : [];
-const seedIdOfMutant = (id) => id.replace(/__m\d+__[a-z0-9-]+(?=\.svelte(\.[jt]s)?$)/, '');
 const mutantIdOfPair = (p) => path.relative(TREE, path.dirname(path.dirname(p)));
 // Scope the count to seeds a surviving shard accounted for, rather than deleting
 // the orphans: the invariant becomes true by construction and the artifacts stay
@@ -659,15 +666,24 @@ if (UPDATE_BASELINE) {
 		process.exit(2);
 	}
 	fs.writeFileSync(BASELINE, JSON.stringify([...ids].sort(), null, '\t') + '\n');
+	const provenance = Object.fromEntries(
+		[...ids]
+			.sort()
+			.map((id) => [seedIdOfBaselineEntry(id), seedHash(SOURCES, id)]),
+	);
+	fs.writeFileSync(BASELINE_PROVENANCE, JSON.stringify(provenance, null, '\t') + '\n');
 	console.log(`\n[mutate] baseline: ${ids.size} known -> ${path.relative(ROOT, BASELINE)}`);
 	finish(0);
 }
 
 const baseline = new Set(fs.existsSync(BASELINE) ? JSON.parse(fs.readFileSync(BASELINE, 'utf8')) : []);
+const baselineProvenance = readBaselineProvenance(BASELINE_PROVENANCE);
 const regressions = [...ids].filter((id) => !baseline.has(id));
 // Staleness is only decidable when the run saw everything. A sample that did
 // not measure an entry says nothing about whether it still fails.
-const stale = FULL ? [...baseline].filter((id) => !ids.has(id)) : [];
+const { rekeyed, unmeasured, stale } = FULL
+	? classifyBaseline({ baseline, ids, provenance: baselineProvenance, sources: SOURCES })
+	: { rekeyed: [], unmeasured: [], stale: [] };
 const failById = new Map(failures.map((f) => [`${f.id} [${f.verdict}] (${f.target})`, f]));
 
 if (regressions.length) {
@@ -692,7 +708,21 @@ if (stale.length) {
 	console.log('  fix: node scripts/compat-corpus/mutate-corpus.mjs --full --update-baseline');
 }
 
-if (regressions.length || stale.length) finish(1);
+if (rekeyed.length) {
+	console.log(`\n[mutate] ❌ ${rekeyed.length} baseline entries were re-keyed by seed-content changes:`);
+	for (const id of rekeyed.slice(0, MAX_PRINT)) console.log(`  - ${id}`);
+	if (rekeyed.length > MAX_PRINT) console.log(`  … and ${rekeyed.length - MAX_PRINT} more`);
+	console.log('  the current mutant is not the baselined mutant; inspect the corpus update, then re-baseline deliberately.');
+}
+
+if (unmeasured.length) {
+	console.log(`\n[mutate] ❌ ${unmeasured.length} baseline entries have no comparable seed provenance:`);
+	for (const id of unmeasured.slice(0, MAX_PRINT)) console.log(`  - ${id}`);
+	if (unmeasured.length > MAX_PRINT) console.log(`  … and ${unmeasured.length - MAX_PRINT} more`);
+	console.log('  restore the missing source or re-baseline deliberately before treating any stale entry as fixed.');
+}
+
+if (regressions.length || stale.length || rekeyed.length || unmeasured.length) finish(1);
 
 if (ids.size) {
 	console.log(`\n[mutate] ✅ no code regressions (${ids.size} known remain — see compatibility/mutation-known-failures.md)`);

--- a/scripts/compat-corpus/mutation-baseline.mjs
+++ b/scripts/compat-corpus/mutation-baseline.mjs
@@ -1,0 +1,47 @@
+import crypto from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+
+export function seedIdOfMutant(id) {
+  return id.replace(/__m\d+__[a-z0-9-]+(?=\.svelte(\.[jt]s)?$)/, "");
+}
+
+export function seedIdOfBaselineEntry(entry) {
+  return seedIdOfMutant(entry.replace(/ \[[^\]]+\] \([^)]+\)$/, ""));
+}
+
+export function seedHash(sources, entry) {
+  const source = path.join(sources, seedIdOfBaselineEntry(entry));
+  if (!fs.existsSync(source)) return null;
+  return crypto
+    .createHash("sha256")
+    .update(fs.readFileSync(source))
+    .digest("hex");
+}
+
+export function readBaselineProvenance(file) {
+  if (!fs.existsSync(file)) return {};
+  const parsed = JSON.parse(fs.readFileSync(file, "utf8"));
+  if (parsed === null || Array.isArray(parsed) || typeof parsed !== "object") {
+    throw new Error(`${file} must map seed ids to content hashes`);
+  }
+  return parsed;
+}
+
+export function classifyBaseline({ baseline, ids, provenance, sources }) {
+  const rekeyed = [];
+  const unmeasured = [];
+  const stale = [];
+  for (const entry of baseline) {
+    const hash = seedHash(sources, entry);
+    const recorded = provenance[seedIdOfBaselineEntry(entry)];
+    if (hash === null || recorded === undefined) {
+      unmeasured.push(entry);
+    } else if (recorded !== hash) {
+      rekeyed.push(entry);
+    } else if (!ids.has(entry)) {
+      stale.push(entry);
+    }
+  }
+  return { rekeyed, unmeasured, stale };
+}

--- a/scripts/dev/test-mutation-baseline-provenance.mjs
+++ b/scripts/dev/test-mutation-baseline-provenance.mjs
@@ -1,0 +1,49 @@
+#!/usr/bin/env node
+
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+  classifyBaseline,
+  seedHash,
+} from "../compat-corpus/mutation-baseline.mjs";
+
+const sources = fs.mkdtempSync(path.join(os.tmpdir(), "mutation-baseline-"));
+const entry = "seed__m0__line-with-semi.svelte [code-mismatch] (client)";
+const source = path.join(sources, "seed.svelte");
+
+try {
+  fs.writeFileSync(source, "<script>let x = 1;</script>");
+  const provenance = { "seed.svelte": seedHash(sources, entry) };
+  let result = classifyBaseline({
+    baseline: new Set([entry]),
+    ids: new Set(),
+    provenance,
+    sources,
+  });
+  assert.deepEqual(result, { rekeyed: [], unmeasured: [], stale: [entry] });
+
+  fs.writeFileSync(source, "<script>let x = 2;</script>");
+  result = classifyBaseline({
+    baseline: new Set([entry]),
+    ids: new Set([entry]),
+    provenance,
+    sources,
+  });
+  assert.deepEqual(result, { rekeyed: [entry], unmeasured: [], stale: [] });
+
+  fs.unlinkSync(source);
+  result = classifyBaseline({
+    baseline: new Set([entry]),
+    ids: new Set(),
+    provenance,
+    sources,
+  });
+  assert.deepEqual(result, { rekeyed: [], unmeasured: [entry], stale: [] });
+  console.log(
+    "[test-mutation-baseline-provenance] ✅ stale, re-keyed, and missing seeds remain distinct",
+  );
+} finally {
+  fs.rmSync(sources, { recursive: true, force: true });
+}


### PR DESCRIPTION
Fixes #2625

Stores a SHA-256 provenance hash for every seed represented by the mutation-failure baseline. Full sweeps now distinguish a genuinely stale entry from a re-keyed mutation or an unavailable/unattributed seed, preventing corpus movement from being reported as a fix.

Validation:
- `node scripts/dev/test-mutation-baseline-provenance.mjs`
- `node scripts/dev/test-known-failures-md-check.mjs`
- `node --check scripts/compat-corpus/mutate-corpus.mjs`