### PR TITLE
fix(napi): reject unsupported modern AST option (#2697)

### DIFF
--- a/.changeset/reject-modern-ast.md
+++ b/.changeset/reject-modern-ast.md
@@ -1,0 +1,6 @@
+---
+"@rsvelte/compiler": patch
+---
+
+Reject `modernAst: true` at the N-API boundary until rsvelte can return the
+modern compiler AST, instead of silently accepting an option with no effect.

--- a/crates/rsvelte_napi/src/lib.rs
+++ b/crates/rsvelte_napi/src/lib.rs
@@ -1010,8 +1010,12 @@ impl NapiCompileOptions {
         if let Some(v) = &self.hmr {
             opts.hmr = coerce_bool("hmr", v)?;
         }
-        if let Some(v) = &self.modern_ast {
-            opts.modern_ast = coerce_bool("modernAst", v)?;
+        if let Some(v) = &self.modern_ast
+            && coerce_bool("modernAst", v)?
+        {
+            return Err(napi::Error::from_reason(
+                "modernAst is not supported by rsvelte yet",
+            ));
         }
         if let Some(v) = &self.experimental {
             opts.experimental = coerce_experimental(v)?;

--- a/scripts/dev/test-napi-compile-options.mjs
+++ b/scripts/dev/test-napi-compile-options.mjs
@@ -452,6 +452,17 @@ function runCase(surface, compile, c) {
 
 console.log('\n# compile options');
 for (const c of COMPILE_CASES) runCase('compile', (s, o) => napi.compile(s, o), c);
+assert(
+	'compile.modernAst: requesting the unsupported AST format is rejected',
+	(() => {
+		try {
+			napi.compile(CSS_SRC, { filename: 'A.svelte', modernAst: true });
+			return false;
+		} catch (e) {
+			return String(e.message).includes('modernAst is not supported');
+		}
+	})()
+);
 covered.add('compile.modernAst');
 
 for (const key of ['accessors', 'immutable']) {


### PR DESCRIPTION
## Summary

- reject `modernAst: true` at the N-API compile boundary
- cover the rejection with the native N-API options test
- add a patch changeset

## Root cause

The option was accepted and copied into core compile options, but rsvelte never produces a modern compiler AST, so callers received a successful compile with no effect.

## Validation

- `cargo fmt`
- `cargo clippy -p rsvelte_napi --lib -- -D warnings`
- `pnpm run build:vps-native`
- `pnpm run test:napi-options`