### PR TITLE
fix(server): keep trailing declaration comments

### DIFF
--- a/.changeset/server-trailing-declaration-comments.md
+++ b/.changeset/server-trailing-declaration-comments.md
@@ -1,0 +1,5 @@
+---
+'@rsvelte/compiler': patch
+---
+
+Keep same-line comments trailing server-rendered script declarations.

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/script.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/script.rs
@@ -348,6 +348,34 @@ fn reparse_origin(src: &str, start: u32, end: u32) -> u32 {
     start + (slice.len() - slice.trim_start().len()) as u32
 }
 
+/// Return the end of comments that trail `stmt_end` on its physical line.
+/// A comment before another statement belongs to that next statement instead.
+fn trailing_comment_end(src: &str, all: &[Comment], stmt_end: u32) -> u32 {
+    let mut end = stmt_end;
+    let mut found = false;
+    for comment in all {
+        if comment.span.start < end {
+            continue;
+        }
+        let gap = &src[end as usize..comment.span.start as usize];
+        if gap.contains(['\n', '\r']) || !gap.trim().is_empty() {
+            break;
+        }
+        end = comment.span.end;
+        found = true;
+    }
+    if !found {
+        return stmt_end;
+    }
+    let after = &src[end as usize..];
+    let line_end = after.find(['\n', '\r']).unwrap_or(after.len());
+    if after[..line_end].trim().is_empty() {
+        end
+    } else {
+        stmt_end
+    }
+}
+
 /// Resolve a top-level statement's registered region into the [`comments::Place`]
 /// its emitted statement is stamped with. `verbatim` is the source range the
 /// statement was re-parsed from, when it was re-parsed whole.
@@ -359,8 +387,9 @@ fn place_on_region(
     stmt: Span,
     verbatim: Option<Span>,
 ) -> Option<comments::Place> {
-    let region_end = if verbatim.is_some() {
-        stmt.end
+    let trailing_end = trailing_comment_end(src, all, stmt.end);
+    let region_end = if verbatim.is_some() || trailing_end > stmt.end {
+        trailing_end
     } else {
         stmt.start
     };
@@ -747,7 +776,12 @@ fn transform_script<'a>(
                 place.visit_statement(first);
             }
         }
-        region_start = stmt_span.end;
+        let trailing_end = trailing_comment_end(src, &ret.program.comments, stmt_span.end);
+        region_start = if verbatim.is_some() || trailing_end > stmt_span.end {
+            trailing_end
+        } else {
+            stmt_span.end
+        };
     }
 
     // Lower `$state` / `$derived` class-field initializers in every emitted
@@ -3073,7 +3107,12 @@ fn transform_script_legacy<'a>(
                 }
             }
         }
-        region_start = stmt_span.end;
+        let trailing_end = trailing_comment_end(src, &ret.program.comments, stmt_span.end);
+        region_start = if verbatim.is_some() || trailing_end > stmt_span.end {
+            trailing_end
+        } else {
+            stmt_span.end
+        };
     }
 
     // Topologically reorder the reactive `$:` statements so each runs after the

--- a/crates/rsvelte_core/tests/comment_delimiters_in_initializer.rs
+++ b/crates/rsvelte_core/tests/comment_delimiters_in_initializer.rs
@@ -88,6 +88,50 @@ fn the_server_keeps_both_operands_and_the_comment() {
     );
 }
 
+#[test]
+fn server_keeps_same_line_trailing_declaration_comments() {
+    let cases = [
+        (
+            "<script>\n\tlet a = foo(1) // call\n\tlet b = 2;\n</script>",
+            "let a = foo(1); // call\n\tlet b = 2;",
+        ),
+        (
+            "<script>\n\tlet a = 1 /* literal */\n\tlet b = 2;\n</script>",
+            "let a = 1; /* literal */\n\tlet b = 2;",
+        ),
+        (
+            "<script>\n\tlet a = $state(1) // rune\n\tlet b = 2;\n</script>",
+            "let a = 1; // rune\n\tlet b = 2;",
+        ),
+        (
+            "<script>\n\tlet a = 1 /* first */ // second\n\tlet b = 2;\n</script>",
+            "let a = 1; /* first */ // second\n\tlet b = 2;",
+        ),
+        (
+            "<script>\n\tlet a = foo(1) // last\n</script>",
+            "let a = foo(1); // last",
+        ),
+    ];
+
+    for (source, expected) in cases {
+        let out = compile_to(source, GenerateMode::Server);
+        assert!(
+            out.contains(expected),
+            "the trailing declaration comment moved:\n{out}"
+        );
+    }
+}
+
+#[test]
+fn server_keeps_a_removed_statement_comment_with_its_successor() {
+    let source = "<script>\n\t$effect(() => {}) // removed\n\tlet b = 2;\n</script>";
+    let out = compile_to(source, GenerateMode::Server);
+    assert!(
+        out.contains("// removed\n\t\tlet b = 2;"),
+        "the removed-statement comment did not remain with its successor:\n{out}"
+    );
+}
+
 /// A declaration is rebuilt from re-parsed SUB-slices (pattern, then init), so
 /// its nodes carry no coherent set of source positions and the comment
 /// carry-over can only collapse them onto one address — which drops every


### PR DESCRIPTION
Fixes #2706.

Same-line `//` and `/* */` comments after server-rendered declarations now remain trailing on the declaration, including lowered rune initializers and the final declaration in a script. Comments after a server-elided `$effect` remain associated with the next surviving statement.

Validation:
- `cargo test -p rsvelte_core --test comment_delimiters_in_initializer -- --nocapture`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `RUST_MIN_STACK=33554432 cargo test -p rsvelte_core --test ssr` (98/99; pre-existing `invalid-nested-svelte-element` server JS mismatch, which has no script/comment path)