### PR TITLE
fix client rune trailing comment ownership

### DIFF
--- a/.changeset/client-rune-trailing-comments.md
+++ b/.changeset/client-rune-trailing-comments.md
@@ -1,0 +1,5 @@
+---
+'@rsvelte/compiler': patch
+---
+
+Keep trailing comments attached to transformed client rune arguments.

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/js_ast/to_oxc.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/js_ast/to_oxc.rs
@@ -188,6 +188,33 @@ struct SingleTargetSequenceRebuilder<'a, 'x> {
     ab: &'x AstBuilder<'a>,
 }
 
+/// Calls rebuilt from user runes retain their argument locations but not a
+/// location for the call itself. Keeping the parsed call span would make a
+/// trailing source comment belong to the generated call rather than its last
+/// user argument.
+struct RebuiltRuneCallLocations;
+
+impl<'a> VisitMut<'a> for RebuiltRuneCallLocations {
+    fn visit_call_expression(&mut self, call: &mut CallExpression<'a>) {
+        oxc_ast_visit::walk_mut::walk_call_expression(self, call);
+
+        if ["user_effect", "user_pre_effect", "effect_root"]
+            .iter()
+            .any(|name| is_dollar_call(&call.callee, name))
+        {
+            call.span = SPAN;
+        } else if is_dollar_call(&call.callee, "inspect") {
+            call.span = SPAN;
+            if let Some(Argument::ArrowFunctionExpression(thunk)) = call.arguments.first_mut() {
+                thunk.span = SPAN;
+                if let Some(Expression::ArrayExpression(values)) = thunk.get_expression_mut() {
+                    values.span = SPAN;
+                }
+            }
+        }
+    }
+}
+
 impl<'a, 'x> VisitMut<'a> for SingleTargetSequenceRebuilder<'a, 'x> {
     fn visit_expression(&mut self, expr: &mut Expression<'a>) {
         oxc_ast_visit::walk_mut::walk_expression(self, expr);
@@ -1202,6 +1229,10 @@ impl<'a, 'arena> Cx<'a, 'arena> {
         let mut stmts = self.parse_chunk(code.trim())?;
         self.restore_legacy_pre_effect_deps(&mut stmts);
         self.restore_single_target_destructure_sequences(&mut stmts);
+        let mut locations = RebuiltRuneCallLocations;
+        for stmt in &mut stmts {
+            locations.visit_statement(stmt);
+        }
         Some(stmts)
     }
 

--- a/crates/rsvelte_core/tests/comment_delimiters_in_initializer.rs
+++ b/crates/rsvelte_core/tests/comment_delimiters_in_initializer.rs
@@ -39,6 +39,21 @@ fn compile_to(source: &str, generate: GenerateMode) -> String {
     .code
 }
 
+fn compile_client_dev(source: &str) -> String {
+    compile(
+        source,
+        CompileOptions {
+            filename: Some("A.svelte".to_string()),
+            generate: GenerateMode::Client,
+            dev: true,
+            ..Default::default()
+        },
+    )
+    .expect("compile failed")
+    .js
+    .code
+}
+
 /// The comment sits mid-expression, so the continuation line is severed too.
 const SEMI_MID: &str = "<script>\n  let x = a + // ; c\n    b\n  function go() { x = 2 }\n</script>\n\n<p on:click={go}>{x}</p>\n";
 
@@ -129,6 +144,30 @@ fn server_keeps_a_removed_statement_comment_with_its_successor() {
     assert!(
         out.contains("// removed\n\t\tlet b = 2;"),
         "the removed-statement comment did not remain with its successor:\n{out}"
+    );
+}
+
+#[test]
+fn client_attaches_a_trailing_effect_comment_to_its_callback() {
+    for rune in ["$effect", "$effect.pre", "$effect.root"] {
+        let source =
+            format!("<script>\n\t{rune}(() => {{\n\t\tfoo();\n\t}}); // trailing\n</script>");
+        let out = compile_to(&source, GenerateMode::Client);
+        assert!(
+            out.contains("foo();\n\t} // trailing\n\t);"),
+            "the effect comment did not attach to its callback for {rune}:\n{out}"
+        );
+    }
+}
+
+#[test]
+fn client_dev_attaches_a_trailing_inspect_comment_to_its_values() {
+    let out = compile_client_dev(
+        "<script>\n\tlet value = $state(0);\n\t$inspect(value); // trailing\n</script>",
+    );
+    assert!(
+        out.contains("$.inspect(() => [value // trailing\n\t],"),
+        "the inspect comment did not attach to its source value:\n{out}"
     );
 }
 


### PR DESCRIPTION
Closes #2718

Restores upstream comment ownership for rebuilt `$effect`, `$effect.pre`, `$effect.root`, and dev `$inspect` calls by preserving argument spans while clearing synthesized wrapper locations.

Validated with `cargo test -p rsvelte_core --test comment_delimiters_in_initializer`, `cargo clippy --all-targets --all-features -- -D warnings`, and the removed-statement-comment matrix.