### PR TITLE
fix(server): retain source comment order

### DIFF
--- a/.changeset/bronze-reactive-comments.md
+++ b/.changeset/bronze-reactive-comments.md
@@ -1,0 +1,5 @@
+---
+'@rsvelte/compiler': patch
+---
+
+Preserve SSR source comment placement when legacy reactive statements are reordered.

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/comments.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/comments.rs
@@ -5,7 +5,7 @@
 //! producer that keeps a statement *registers* the comment region around it and
 //! places the emitted statement on the returned base ([`Place`]), parking it in
 //! a provisional address range. Once the program is assembled, only the ranges the
-//! walk actually reaches are laid out — in encounter order — into a synthetic
+//! walk actually reaches are laid out in source order into a synthetic
 //! buffer, every span is remapped onto it, and the surviving comments go to
 //! [`rsvelte_esrap::print_split`].
 //!
@@ -46,15 +46,17 @@ struct Chunk {
 pub struct ChunkRegistry {
     chunks: Vec<Chunk>,
     next_prov: u32,
+    has_comments: bool,
 }
 
 impl ChunkRegistry {
     /// Register the source region `text` holding `comments` (spans relative to
     /// `text`) and return the region's provisional base — add a `text`-relative
-    /// offset to it to get the address to place a node at. `None` when there is
-    /// nothing to carry.
+    /// offset to it to get the address to place a node at. Empty comment sets
+    /// still need a region: a later source comment must be able to flush before
+    /// this statement after transformed statements have been reordered.
     pub fn register(&mut self, text: &str, comments: &[Comment]) -> Option<u32> {
-        if comments.is_empty() || text.is_empty() {
+        if text.is_empty() {
             return None;
         }
         let len = u32::try_from(text.len()).ok()?;
@@ -66,13 +68,16 @@ impl ChunkRegistry {
             text: text.to_string(),
             comments: comments.to_vec(),
         });
-        super::comment_stats::bump::REGISTERED_CHUNKS(1);
-        super::comment_stats::bump::REGISTERED_COMMENTS(comments.len() as u64);
+        if !comments.is_empty() {
+            self.has_comments = true;
+            super::comment_stats::bump::REGISTERED_CHUNKS(1);
+            super::comment_stats::bump::REGISTERED_COMMENTS(comments.len() as u64);
+        }
         Some(prov_base)
     }
 
     pub fn is_empty(&self) -> bool {
-        self.chunks.is_empty()
+        !self.has_comments
     }
 }
 
@@ -109,7 +114,6 @@ impl VisitMut<'_> for Place {
 struct Encounter<'m> {
     bases: &'m [(u32, u32)],
     seen: Vec<bool>,
-    order: Vec<usize>,
     /// Per region: whether the walk first reached it as a whole statement.
     via_stmt: Vec<bool>,
 }
@@ -121,7 +125,6 @@ impl Encounter<'_> {
         {
             self.seen[i] = true;
             self.via_stmt[i] = is_stmt;
-            self.order.push(i);
         }
     }
 }
@@ -194,7 +197,6 @@ pub fn print_with_comments<'a>(
     let mut encounter = Encounter {
         bases: &bases,
         seen: vec![false; bases.len()],
-        order: Vec::new(),
         via_stmt: vec![false; bases.len()],
     };
     encounter.visit_program(program);
@@ -213,8 +215,10 @@ pub fn print_with_comments<'a>(
     let mut buf = String::from(PAD);
     let mut shift: Vec<Option<i64>> = vec![None; bases.len()];
     let mut comments: Vec<Comment> = Vec::new();
-    for &i in encounter.order.iter().filter(|&&i| encounter.via_stmt[i]) {
-        let chunk = &registry.chunks[i];
+    for (i, chunk) in registry.chunks.iter().enumerate() {
+        if !encounter.via_stmt[i] {
+            continue;
+        }
         let base = buf.len() as u32;
         shift[i] = Some(i64::from(base) - i64::from(chunk.prov_base));
         buf.push_str(&chunk.text);

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/comments.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/comments.rs
@@ -5,7 +5,7 @@
 //! producer that keeps a statement *registers* the comment region around it and
 //! places the emitted statement on the returned base ([`Place`]), parking it in
 //! a provisional address range. Once the program is assembled, only the ranges the
-//! walk actually reaches are laid out in source order into a synthetic
+//! walk actually reaches are laid out into a synthetic
 //! buffer, every span is remapped onto it, and the surviving comments go to
 //! [`rsvelte_esrap::print_split`].
 //!
@@ -39,6 +39,7 @@ struct Chunk {
     text: String,
     /// Comments with spans relative to `text`.
     comments: Vec<Comment>,
+    position_only: bool,
 }
 
 /// The per-compile registry of comment regions.
@@ -46,17 +47,15 @@ struct Chunk {
 pub struct ChunkRegistry {
     chunks: Vec<Chunk>,
     next_prov: u32,
-    has_comments: bool,
 }
 
 impl ChunkRegistry {
     /// Register the source region `text` holding `comments` (spans relative to
     /// `text`) and return the region's provisional base — add a `text`-relative
-    /// offset to it to get the address to place a node at. Empty comment sets
-    /// still need a region: a later source comment must be able to flush before
-    /// this statement after transformed statements have been reordered.
+    /// offset to it to get the address to place a node at. `None` when there is
+    /// nothing to carry.
     pub fn register(&mut self, text: &str, comments: &[Comment]) -> Option<u32> {
-        if text.is_empty() {
+        if comments.is_empty() || text.is_empty() {
             return None;
         }
         let len = u32::try_from(text.len()).ok()?;
@@ -67,17 +66,33 @@ impl ChunkRegistry {
             prov_base,
             text: text.to_string(),
             comments: comments.to_vec(),
+            position_only: false,
         });
-        if !comments.is_empty() {
-            self.has_comments = true;
-            super::comment_stats::bump::REGISTERED_CHUNKS(1);
-            super::comment_stats::bump::REGISTERED_COMMENTS(comments.len() as u64);
+        super::comment_stats::bump::REGISTERED_CHUNKS(1);
+        super::comment_stats::bump::REGISTERED_COMMENTS(comments.len() as u64);
+        Some(prov_base)
+    }
+
+    /// Register a source position that does not own a comment. This is only
+    /// needed when a preceding comment-owning statement is reordered past it.
+    pub fn register_position(&mut self, text: &str) -> Option<u32> {
+        if text.is_empty() {
+            return None;
         }
+        let len = u32::try_from(text.len()).ok()?;
+        let prov_base = PROV_BASE.checked_add(self.next_prov)?;
+        self.next_prov = self.next_prov.checked_add(len)?.checked_add(1)?;
+        self.chunks.push(Chunk {
+            prov_base,
+            text: text.to_string(),
+            comments: Vec::new(),
+            position_only: true,
+        });
         Some(prov_base)
     }
 
     pub fn is_empty(&self) -> bool {
-        !self.has_comments
+        self.chunks.is_empty()
     }
 }
 
@@ -114,6 +129,7 @@ impl VisitMut<'_> for Place {
 struct Encounter<'m> {
     bases: &'m [(u32, u32)],
     seen: Vec<bool>,
+    order: Vec<usize>,
     /// Per region: whether the walk first reached it as a whole statement.
     via_stmt: Vec<bool>,
 }
@@ -125,6 +141,7 @@ impl Encounter<'_> {
         {
             self.seen[i] = true;
             self.via_stmt[i] = is_stmt;
+            self.order.push(i);
         }
     }
 }
@@ -197,6 +214,7 @@ pub fn print_with_comments<'a>(
     let mut encounter = Encounter {
         bases: &bases,
         seen: vec![false; bases.len()],
+        order: Vec::new(),
         via_stmt: vec![false; bases.len()],
     };
     encounter.visit_program(program);
@@ -215,10 +233,20 @@ pub fn print_with_comments<'a>(
     let mut buf = String::from(PAD);
     let mut shift: Vec<Option<i64>> = vec![None; bases.len()];
     let mut comments: Vec<Comment> = Vec::new();
-    for (i, chunk) in registry.chunks.iter().enumerate() {
-        if !encounter.via_stmt[i] {
-            continue;
-        }
+    let order: Vec<usize> = if registry.chunks.iter().any(|chunk| chunk.position_only) {
+        (0..registry.chunks.len())
+            .filter(|&i| encounter.via_stmt[i])
+            .collect()
+    } else {
+        encounter
+            .order
+            .iter()
+            .copied()
+            .filter(|&i| encounter.via_stmt[i])
+            .collect()
+    };
+    for i in order {
+        let chunk = &registry.chunks[i];
         let base = buf.len() as u32;
         shift[i] = Some(i64::from(base) - i64::from(chunk.prov_base));
         buf.push_str(&chunk.text);

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/script.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/script.rs
@@ -400,6 +400,17 @@ fn place_on_region(
     })
 }
 
+fn place_on_position(
+    registry: &mut comments::ChunkRegistry,
+    _src: &str,
+    _prev_end: u32,
+    _stmt: Span,
+    _verbatim: Option<Span>,
+) -> Option<comments::Place> {
+    let base = registry.register_position(" ")?;
+    Some(comments::Place::At(base))
+}
+
 /// Split a script's comments into the three classes the carry-over sees:
 /// LEADING (inside a `[prev_end, stmt_start)` gap — the only class
 /// [`register_leading_comments`] can capture), INTERIOR (inside a top-level
@@ -2851,9 +2862,15 @@ fn transform_script_legacy<'a>(
     // See the runes loop: a dropped statement does not advance the region, so its
     // comments are re-homed onto the next survivor instead of dying with it.
     let mut region_start: u32 = 0;
+    let mut reactive_leading_comment_pending = false;
 
     for stmt in ret.program.body.iter() {
         let stmt_span = stmt.span();
+        let is_reactive = matches!(stmt, Statement::LabeledStatement(ls) if is_instance && ls.label.name.as_str() == "$");
+        let reactive_leading_comment = is_reactive
+            && ret.program.comments.iter().any(|comment| {
+                comment.span.start >= region_start && comment.span.end <= stmt_span.start
+            });
         let out_len = out.len();
         let reactive_len = reactive.len();
         let sink_len = import_sink.as_deref().map_or(0, Vec::len);
@@ -3077,14 +3094,18 @@ fn transform_script_legacy<'a>(
         }
         // Anchor the region on the first statement this source statement emitted
         // that can carry one.
-        if let Some(mut place) = place_on_region(
+        let mut place = place_on_region(
             &mut state.comments,
             src,
             &ret.program.comments,
             region_start,
             stmt_span,
             verbatim,
-        ) {
+        );
+        if place.is_none() && reactive_leading_comment_pending && !into_sink && anchor.is_some() {
+            place = place_on_position(&mut state.comments, src, region_start, stmt_span, verbatim);
+        }
+        if let Some(mut place) = place {
             if into_sink {
                 if let Some(sink) = import_sink.as_deref_mut()
                     && let Some(first) = sink.get_mut(sink_len)
@@ -3106,6 +3127,11 @@ fn transform_script_legacy<'a>(
                     other => place.visit_statement(other),
                 }
             }
+        }
+        if is_reactive && reactive_leading_comment {
+            reactive_leading_comment_pending = true;
+        } else if !is_reactive && anchor.is_some() {
+            reactive_leading_comment_pending = false;
         }
         let trailing_end = trailing_comment_end(src, &ret.program.comments, stmt_span.end);
         region_start = if verbatim.is_some() || trailing_end > stmt_span.end {

--- a/crates/rsvelte_core/tests/reactive_label_comment_ownership.rs
+++ b/crates/rsvelte_core/tests/reactive_label_comment_ownership.rs
@@ -48,3 +48,14 @@ fn svelte_ignore_comment_follows_the_reactive_label() {
         "{out}"
     );
 }
+
+#[test]
+fn leading_comment_stays_before_a_successor_after_reactive_reorder() {
+    let out = server(
+        "<script>\n\tlet total = 10;\n\tlet half;\n\t// c\n\t$: half = total / 2;\n\tlet z = 1;\n</script>\n\n<p>{half}</p>\n",
+    );
+    let comment = out.find("// c").expect("comment survives");
+    let successor = out.find("let z = 1;").expect("successor survives");
+    let reactive = out.find("half = total / 2").expect("reactive survives");
+    assert!(comment < successor && successor < reactive, "{out}");
+}


### PR DESCRIPTION
## Summary

Keep SSR comment regions for all surviving script statements and lay them out in source order.

## Root cause

Only statements that owned comments had source regions. When a legacy `$:` statement moved after a later statement, its leading comment could only be positioned at the moved statement, rather than flushing before the later statement at its original source location.

## Validation

- `cargo test -p rsvelte_core --test reactive_label_comment_ownership`
- `cargo clippy -p rsvelte_core --test reactive_label_comment_ownership -- -D warnings`
- `cargo fmt --check`

Fixes #2735.
