### PR TITLE
fix(server): retain async derived ignore comments

### DIFF
--- a/.changeset/green-async-derived-comments.md
+++ b/.changeset/green-async-derived-comments.md
@@ -1,0 +1,5 @@
+---
+'@rsvelte/compiler': patch
+---
+
+Retain async-derived waterfall suppression comments in SSR output.

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/mod.rs
@@ -1495,7 +1495,16 @@ See https://svelte.dev/docs/svelte/v5-migration-guide#Components-are-no-longer-c
         crate::compiler::phases::phase3_transform::profile::timer_elapsed(_t),
     );
     comment_stats::dump();
-    Ok(rehome_derived_jsdoc(&code))
+    let code = rehome_derived_jsdoc(&code);
+    Ok(match state.analysis.instance_script_content.as_ref() {
+        Some(script) => {
+            crate::compiler::phases::phase3_transform::shared::async_body::restore_async_derived_ignore_comments(
+                &script.raw,
+                code,
+            )
+        }
+        None => code,
+    })
 }
 
 fn rehome_derived_jsdoc(code: &str) -> String {

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/shared/async_body.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/shared/async_body.rs
@@ -400,6 +400,75 @@ pub fn transform_async_body_dev(script: &str, runner: &str, dev: bool) -> Option
     transform_async_body_inner(script, runner, dev)
 }
 
+/// Reattach `svelte-ignore await_waterfall` comments that an AST lowering has
+/// detached before this text transform can hoist the declaration.
+pub fn restore_async_derived_ignore_comments(source: &str, mut transformed: String) -> String {
+    if transformed.contains("svelte-ignore await_waterfall") {
+        return transformed;
+    }
+
+    let mut search_from = 0;
+    while let Some(relative) = source[search_from..].find("svelte-ignore await_waterfall") {
+        let ignore = search_from + relative;
+        let comment_start = source[..ignore]
+            .rfind("/*")
+            .or_else(|| source[..ignore].rfind("//"));
+        let Some(comment_start) = comment_start else {
+            search_from = ignore + "svelte-ignore await_waterfall".len();
+            continue;
+        };
+        let comment_end = if source[comment_start..].starts_with("/*") {
+            source[comment_start..]
+                .find("*/")
+                .map(|end| comment_start + end + 2)
+        } else {
+            source[comment_start..]
+                .find('\n')
+                .map(|end| comment_start + end)
+                .or(Some(source.len()))
+        };
+        let Some(comment_end) = comment_end else {
+            break;
+        };
+        let rest = source[comment_end..].trim_start();
+        let Some((_, rest)) = ["const ", "let ", "var "]
+            .iter()
+            .find_map(|kind| rest.strip_prefix(kind).map(|rest| (*kind, rest)))
+        else {
+            search_from = comment_end;
+            continue;
+        };
+        let name_end = rest
+            .find(|c: char| !(c.is_ascii_alphanumeric() || c == '_' || c == '$'))
+            .unwrap_or(rest.len());
+        let name = &rest[..name_end];
+        if !rest[name_end..].trim_start().starts_with("= $derived(") {
+            search_from = comment_end;
+            continue;
+        }
+        let needle = format!("{name} = await $.async_derived");
+        if let Some(name_pos) = transformed.find(&needle)
+            && let Some(pos) = ["const ", "let ", "var "]
+                .iter()
+                .filter_map(|kind| transformed[..name_pos].rfind(kind))
+                .max()
+        {
+            transformed.insert_str(pos, &format!("{}\n", &source[comment_start..comment_end]));
+        } else {
+            let needle = format!("var {name};");
+            if let Some(pos) = transformed.find(&needle) {
+                transformed.insert_str(
+                    pos + "var ".len(),
+                    &format!("{} ", &source[comment_start..comment_end]),
+                );
+            }
+        }
+        search_from = comment_end;
+    }
+
+    transformed
+}
+
 fn transform_async_body_inner(script: &str, runner: &str, dev: bool) -> Option<AsyncBodyResult> {
     let trimmed = script.trim();
     if trimmed.is_empty() {

--- a/crates/rsvelte_core/tests/async_derived_comment_2755.rs
+++ b/crates/rsvelte_core/tests/async_derived_comment_2755.rs
@@ -4,26 +4,32 @@ use oxc_span::SourceType;
 use rsvelte_core::{CompileOptions, ExperimentalOptions, GenerateMode, compile};
 
 #[test]
-fn leading_block_comment_before_async_derived_produces_parseable_client_output() {
-    let output = compile(
-        "<script>\n/* comment */\nconst value = $derived(await Promise.resolve(1));\n</script>\n<p>{value}</p>",
-        CompileOptions {
-            generate: GenerateMode::Client,
+fn leading_block_svelte_ignore_before_async_derived_is_retained_and_parseable() {
+    for generate in [GenerateMode::Client, GenerateMode::Server] {
+        let output = compile(
+            "<script>\n/* svelte-ignore await_waterfall */ const value = $derived(await Promise.resolve(1));\n</script>\n<p>{value}</p>",
+            CompileOptions {
+                generate,
             experimental: ExperimentalOptions { r#async: true },
             ..Default::default()
-        },
-    )
-    .unwrap_or_else(|error| panic!("compile failed: {error:?}"))
-    .js
-    .code;
+            },
+        )
+        .unwrap_or_else(|error| panic!("compile failed for {generate:?}: {error:?}"))
+        .js
+        .code;
 
-    assert!(!output.contains("void (/*"), "{output}");
-    let allocator = Allocator::default();
-    let parsed = Parser::new(&allocator, &output, SourceType::mjs()).parse();
-    assert!(
-        !parsed.panicked && parsed.diagnostics.is_empty(),
-        "client output must parse:\n{output}"
-    );
+        assert!(
+            output.contains("svelte-ignore await_waterfall"),
+            "{generate:?} output lost the ignore comment:\n{output}"
+        );
+        assert!(!output.contains("void (/*"), "{output}");
+        let allocator = Allocator::default();
+        let parsed = Parser::new(&allocator, &output, SourceType::mjs()).parse();
+        assert!(
+            !parsed.panicked && parsed.diagnostics.is_empty(),
+            "{generate:?} output must parse:\n{output}"
+        );
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Retains `svelte-ignore await_waterfall` comments when SSR lowers async derived declarations.

Depends on #2817 and resolves an additional part of #2756.

## Verification

- `cargo test -p rsvelte_core --test async_derived_comment_2755`
- `cargo test -p rsvelte_core async_body --lib`
- `cargo clippy -p rsvelte_core --test async_derived_comment_2755 -- -D warnings`
