### PR TITLE
fix(client): rehome derived field line comments

### DIFF
--- a/.changeset/bright-derived-line-comment.md
+++ b/.changeset/bright-derived-line-comment.md
@@ -1,0 +1,5 @@
+---
+'@rsvelte/compiler': patch
+---
+
+Fix dev-mode placement of comments before derived class fields.

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
@@ -2458,8 +2458,9 @@ fn transform_client_with_visitors(
 }
 
 fn rehome_derived_jsdoc(code: &str) -> String {
+    let code = rehome_tag_derived_line_comments(code);
     let mut result = String::with_capacity(code.len());
-    let mut rest = code;
+    let mut rest = code.as_str();
     const PREFIX: &str = "$.derived(() => /**";
 
     while let Some(start) = rest.find(PREFIX) {
@@ -2484,6 +2485,47 @@ fn rehome_derived_jsdoc(code: &str) -> String {
         result.push_str(indent);
         result.push_str(") => ");
         rest = expression;
+    }
+    result.push_str(rest);
+    result
+}
+
+fn rehome_tag_derived_line_comments(code: &str) -> String {
+    let mut result = String::with_capacity(code.len());
+    let mut rest = code;
+    const PREFIX: &str = "$.tag(\n";
+    const DERIVED: &str = "$.derived(() => ";
+
+    while let Some(start) = rest.find(PREFIX) {
+        let comment_start = start + PREFIX.len();
+        let indent_end = rest[comment_start..]
+            .find(|c: char| !matches!(c, ' ' | '\t'))
+            .map_or(rest.len(), |index| comment_start + index);
+        let indent = &rest[comment_start..indent_end];
+        let Some(comment_end_relative) = rest[indent_end..].find('\n') else {
+            result.push_str(&rest[..start + PREFIX.len()]);
+            rest = &rest[start + PREFIX.len()..];
+            continue;
+        };
+        let comment_end = indent_end + comment_end_relative;
+        let after_comment = comment_end + 1;
+
+        if !rest[indent_end..].starts_with("//")
+            || !rest[after_comment..].starts_with(indent)
+            || !rest[after_comment + indent.len()..].starts_with(DERIVED)
+        {
+            result.push_str(&rest[..start + PREFIX.len()]);
+            rest = &rest[start + PREFIX.len()..];
+            continue;
+        }
+
+        result.push_str(&rest[..indent_end]);
+        result.push_str("$.derived((");
+        result.push_str(&rest[indent_end..comment_end]);
+        result.push('\n');
+        result.push_str(indent);
+        result.push_str(") => ");
+        rest = &rest[after_comment + indent.len() + DERIVED.len()..];
     }
     result.push_str(rest);
     result

--- a/crates/rsvelte_core/tests/derived_comment_2557.rs
+++ b/crates/rsvelte_core/tests/derived_comment_2557.rs
@@ -1,0 +1,22 @@
+#[test]
+fn dev_derived_field_rehomes_a_leading_line_comment_to_the_arrow_parameter_list() {
+    let source = "<script>\nexport class C {\n// c\nx = $derived(1);\n}\n</script>";
+    let result = rsvelte_core::compiler::compile(
+        source,
+        rsvelte_core::compiler::CompileOptions {
+            dev: true,
+            generate: rsvelte_core::compiler::GenerateMode::Client,
+            ..Default::default()
+        },
+    )
+    .expect("compiles");
+
+    assert!(
+        result
+            .js
+            .code
+            .contains("#x = $.tag(\n\t\t\t$.derived((// c\n\t\t\t) => 1),\n\t\t\t'C.x'\n\t\t);"),
+        "{0}",
+        result.js.code
+    );
+}


### PR DESCRIPTION
Fixes #2557.

A dev-mode public `$derived` class field with a leading line comment was emitted as the first `$.tag` argument. Mirror the location-less official builders by relocating that generated comment into the synthesized derived arrow parameter list.

Verification:
- `cargo fmt --check`
- `cargo test -p rsvelte_core --test derived_comment_2557`
- `cargo test -p rsvelte_core dev_public_derived_field_keeps_jsdoc_in_its_synthesized_arrow --lib`
- `cargo clippy -p rsvelte_core --test derived_comment_2557 -- -D warnings`
- `pnpm run corpus:matrix` (934 known divergences; no regressions)