### PR TITLE
fix(codegen): bound function parameter comments

### DIFF
--- a/.changeset/fix-function-parameter-comment-boundary.md
+++ b/.changeset/fix-function-parameter-comment-boundary.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/compiler": patch
+---
+
+Keep comments from function bodies out of generated parameter lists.

--- a/.changeset/fix-function-parameter-comment-boundary.md
+++ b/.changeset/fix-function-parameter-comment-boundary.md
@@ -2,4 +2,5 @@
 "@rsvelte/compiler": patch
 ---
 
-Keep comments from function bodies out of generated parameter lists.
+Keep comments from function bodies out of generated parameter lists. `rsvelte_esrap`
+is released as 0.10.5 and `rsvelte_core` pins the new exact requirement.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2517,7 +2517,7 @@ dependencies = [
 
 [[package]]
 name = "rsvelte_esrap"
-version = "0.10.4"
+version = "0.10.5"
 dependencies = [
  "compact_str 0.10.0",
  "memchr",

--- a/crates/rsvelte_core/Cargo.toml
+++ b/crates/rsvelte_core/Cargo.toml
@@ -91,7 +91,7 @@ oxc_ast = { version = "0.143", features = ["serialize"] }
 oxc_span = "0.143"
 oxc_diagnostics = "0.143"
 oxc_codegen = "0.143"
-rsvelte_esrap = { version = "=0.10.4", path = "../rsvelte_esrap" }
+rsvelte_esrap = { version = "=0.10.5", path = "../rsvelte_esrap" }
 oxc_syntax = "0.143"
 oxc_semantic = "0.143"
 

--- a/crates/rsvelte_core/tests/client_function_body_comment_2527.rs
+++ b/crates/rsvelte_core/tests/client_function_body_comment_2527.rs
@@ -1,0 +1,50 @@
+use rsvelte_core::compiler::CompileOptions;
+use rsvelte_core::{GenerateMode, compile};
+
+const SOURCE: &str = r#"<script>
+	let n = $state(0);
+	function a(x) { return (g(/* c */ x)); }
+	function b(x) { return (x + /* c */ n) * 2; }
+	function c(x) { return ((/* c */ x)); }
+	function d(x) { return (x /* c */); }
+</script>
+<p>{n}</p>"#;
+
+#[test]
+fn function_body_comments_are_not_duplicated_into_parameters() {
+    for (generate, dev) in [
+        (GenerateMode::Client, false),
+        (GenerateMode::Client, true),
+        (GenerateMode::Server, false),
+    ] {
+        let code = compile(
+            SOURCE,
+            CompileOptions {
+                generate,
+                dev,
+                filename: Some("x.svelte".to_string()),
+                ..Default::default()
+            },
+        )
+        .expect("compile")
+        .js
+        .code;
+        for expected in [
+            "function a(x) {\n\t\treturn g(/* c */ x);",
+            "function b(x) {\n\t\treturn (x + /* c */ n) * 2;",
+            "function c(x) {\n\t\treturn (/* c */ x);",
+            "function d(x) {\n\t\treturn x; /* c */",
+        ] {
+            assert!(code.contains(expected), "missing body comment:\n{code}");
+        }
+        assert_eq!(
+            code.matches("/* c */").count(),
+            4,
+            "duplicated comment:\n{code}"
+        );
+        assert!(
+            !code.contains("x /* c */"),
+            "function parameter duplicated a body comment:\n{code}"
+        );
+    }
+}

--- a/crates/rsvelte_esrap/Cargo.toml
+++ b/crates/rsvelte_esrap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rsvelte_esrap"
-version = "0.10.4"
+version = "0.10.5"
 edition = "2024"
 rust-version = "1.95"
 description = "A Rust port of esrap — prints an oxc AST to JavaScript with esrap's exact layout"

--- a/crates/rsvelte_esrap/src/printer.rs
+++ b/crates/rsvelte_esrap/src/printer.rs
@@ -1350,7 +1350,12 @@ impl<'opt> Printer<'opt> {
             self.type_parameter_declaration(tp, ctx);
         }
         ctx.write("(");
-        self.formal_parameters_with_this(&node.params, node.this_param.as_deref(), ctx);
+        self.formal_parameters_with_this(
+            &node.params,
+            node.this_param.as_deref(),
+            Some(node.params.span().end),
+            ctx,
+        );
         ctx.write(")");
         if let Some(rt) = &node.return_type {
             self.type_annotation(rt, ctx);
@@ -1896,7 +1901,7 @@ impl<'opt> Printer<'opt> {
 
     /// Parameter list via esrap's `sequence` (no padding): `a, b, ...rest`.
     fn formal_parameters(&mut self, params: &FormalParameters, ctx: &mut Context) {
-        self.formal_parameters_with_this(params, None, ctx);
+        self.formal_parameters_with_this(params, None, Some(params.span().end), ctx);
     }
 
     /// As [`Self::formal_parameters`], but with a leading `this: T` parameter —
@@ -1905,6 +1910,7 @@ impl<'opt> Printer<'opt> {
         &mut self,
         params: &FormalParameters,
         this_param: Option<&TSThisParameter>,
+        until: Option<u32>,
         ctx: &mut Context,
     ) {
         let mut nodes: Vec<SeqNode> = Vec::new();
@@ -1974,11 +1980,7 @@ impl<'opt> Printer<'opt> {
                 }),
             });
         }
-        // esrap passes the closing `)` location as `until`, but the Rust caller
-        // already owns the parens around `formal_parameters`; there is no node
-        // span for the list itself, so no end-of-list comment flush is needed
-        // here (params rarely carry trailing comments in the corpus).
-        self.sequence(nodes, None, false, ",", true, ctx);
+        self.sequence(nodes, until, false, ",", true, ctx);
     }
 
     /// esrap's `ArrowFunctionExpression`: `[async ](params) => body`, wrapping an

--- a/crates/rsvelte_lint_types/Cargo.lock
+++ b/crates/rsvelte_lint_types/Cargo.lock
@@ -1106,7 +1106,7 @@ dependencies = [
 
 [[package]]
 name = "rsvelte_esrap"
-version = "0.10.4"
+version = "0.10.5"
 dependencies = [
  "compact_str",
  "memchr",


### PR DESCRIPTION
Closes #2527.

The shared esrap printer rendered formal parameters without the closing-parenthesis source boundary. A body comment on the same line as a parameter could therefore be emitted both after that parameter and in its actual body position. Thread `FormalParameters.span().end` through `sequence` as its `until` boundary.

The regression covers all four reported body-comment shapes in client, client-dev, and server output.

Verified with:
- `cargo test -p rsvelte_core --test client_function_body_comment_2527`
- `cargo test -p rsvelte_esrap`
- `cargo clippy -p rsvelte_core --test client_function_body_comment_2527 -- -D warnings`
- `cargo clippy -p rsvelte_esrap -- -D warnings`

A full matrix rebaseline is running against the current merge base; any resulting ratchet change will be added before CI is allowed to merge.