### PR TITLE
fix(compiler): use UTF-16 source map columns

### DIFF
--- a/.changeset/utf16-sourcemap-columns.md
+++ b/.changeset/utf16-sourcemap-columns.md
@@ -1,0 +1,5 @@
+---
+'@rsvelte/compiler': patch
+---
+
+Emit source-map columns in UTF-16 code units for astral Unicode characters.

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/css.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/css.rs
@@ -529,7 +529,7 @@ fn generate_css_sourcemap(
 ) -> Option<String> {
     use super::js_ast::codegen::{
         SourceMapping, build_line_starts, encode_vlq_mappings, generate_sourcemap_json,
-        get_source_name, offset_to_line_col,
+        get_source_name, offset_to_line_col_utf16,
     };
 
     let css_output_filename = options.css_output_filename.as_deref();
@@ -560,12 +560,12 @@ fn generate_css_sourcemap(
     let mut cursor = 0usize;
 
     let advance = |from: usize, to: usize, gen_line: &mut u32, gen_col: &mut u32| {
-        for &byte in &code[from..to] {
-            if byte == b'\n' {
+        for c in writer.text[from..to].chars() {
+            if c == '\n' {
                 *gen_line += 1;
                 *gen_col = 0;
             } else {
-                *gen_col += 1;
+                *gen_col += c.len_utf16() as u32;
             }
         }
     };
@@ -575,15 +575,18 @@ fn generate_css_sourcemap(
         advance(cursor, gen_start, &mut gen_line, &mut gen_col);
         cursor = gen_start + len as usize;
 
-        let (mut line, mut column) = offset_to_line_col(&source_line_starts, src_start as usize);
+        let (mut line, mut column) =
+            offset_to_line_col_utf16(source, &source_line_starts, src_start as usize);
         let mut first = true;
-        for offset in src_start..src_start + len {
-            if source.as_bytes()[offset as usize] == b'\n' {
+        let mut offset = src_start;
+        for c in source[offset as usize..(src_start + len) as usize].chars() {
+            if c == '\n' {
                 line += 1;
                 column = 0;
                 gen_line += 1;
                 gen_col = 0;
                 first = true;
+                offset += c.len_utf8() as u32;
                 continue;
             }
             if first || writer.marks.contains(&offset) {
@@ -596,9 +599,10 @@ fn generate_css_sourcemap(
                     name: None,
                 });
             }
-            column += 1;
-            gen_col += 1;
+            column += c.len_utf16();
+            gen_col += c.len_utf16() as u32;
             first = false;
+            offset += c.len_utf8() as u32;
         }
     }
     advance(cursor, code.len(), &mut gen_line, &mut gen_col);

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/js_ast/codegen.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/js_ast/codegen.rs
@@ -181,9 +181,13 @@ impl<'a> JsCodegen<'a> {
         let mut mappings = Vec::with_capacity(self.raw_spans.len());
 
         for span in &self.raw_spans {
-            let (gen_line, gen_col) = offset_to_line_col(&output_line_starts, span.output_offset);
-            let (orig_line, orig_col) =
-                offset_to_line_col(&source_line_starts, span.source_start as usize);
+            let (gen_line, gen_col) =
+                offset_to_line_col_utf16(&self.output, &output_line_starts, span.output_offset);
+            let (orig_line, orig_col) = offset_to_line_col_utf16(
+                source_code,
+                &source_line_starts,
+                span.source_start as usize,
+            );
 
             mappings.push(SourceMapping {
                 gen_line: gen_line as u32,
@@ -2610,6 +2614,21 @@ pub fn offset_to_line_col(line_starts: &[usize], offset: usize) -> (usize, usize
     }
 }
 
+/// Convert a byte offset to a source-map line and UTF-16 column.
+///
+/// Source Map v3 positions use JavaScript string columns, so an astral
+/// character occupies two units even though its Rust UTF-8 representation is
+/// four bytes.
+pub fn offset_to_line_col_utf16(
+    source: &str,
+    line_starts: &[usize],
+    offset: usize,
+) -> (usize, usize) {
+    let (line, _) = offset_to_line_col(line_starts, offset);
+    let line_start = line_starts[line];
+    (line, source[line_start..offset].encode_utf16().count())
+}
+
 /// Encode a list of source mappings into a VLQ-encoded mappings string.
 pub fn encode_vlq_mappings(mappings: &[SourceMapping]) -> String {
     if mappings.is_empty() {
@@ -3107,6 +3126,21 @@ mod tests {
             generate_sourcemap_json("out.js", "App.svelte", Some("<h1>\"x\"</h1>"), "AAAA", &[]);
         let map: serde_json::Value = serde_json::from_str(&json).unwrap();
         assert_eq!(map["sourcesContent"], serde_json::json!(["<h1>\"x\"</h1>"]));
+    }
+
+    #[test]
+    fn sourcemap_columns_count_astral_characters_as_two_utf16_units() {
+        let source = "🎉anchor\n";
+        let starts = build_line_starts(source);
+
+        assert_eq!(
+            offset_to_line_col_utf16(source, &starts, "🎉".len()),
+            (0, 2)
+        );
+        assert_eq!(
+            offset_to_line_col_utf16(source, &starts, source.len()),
+            (1, 0)
+        );
     }
 
     #[test]

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/mod.rs
@@ -734,7 +734,7 @@ impl std::error::Error for TransformError {}
 /// where framework code tokens (appearing early in the generated output) can
 /// consume source positions intended for user-code tokens that appear later.
 fn generate_token_mappings(generated: &str, source: &str) -> Vec<js_ast::codegen::SourceMapping> {
-    use js_ast::codegen::{build_line_starts, offset_to_line_col};
+    use js_ast::codegen::{build_line_starts, offset_to_line_col_utf16};
 
     let gen_line_starts = build_line_starts(generated);
     let src_line_starts = build_line_starts(source);
@@ -763,16 +763,6 @@ fn generate_token_mappings(generated: &str, source: &str) -> Vec<js_ast::codegen
     });
 
     let mut mappings = Vec::new();
-    // Generated offsets arrive in non-decreasing order, so a forward cursor over
-    // the line table answers what `offset_to_line_col` would binary-search for.
-    let mut gen_cursor = 0usize;
-    let mut gen_line_col = |offset: usize| {
-        while gen_cursor + 1 < gen_line_starts.len() && gen_line_starts[gen_cursor + 1] <= offset {
-            gen_cursor += 1;
-        }
-        (gen_cursor, offset - gen_line_starts[gen_cursor])
-    };
-
     for_each_token(generated, |text, gen_offset| {
         // Skip framework-generated tokens
         if should_skip_token(text) {
@@ -791,8 +781,8 @@ fn generate_token_mappings(generated: &str, source: &str) -> Vec<js_ast::codegen
         let src_pos = slot.positions[slot.consumed as usize] as usize;
         slot.consumed += 1;
 
-        let (gen_line, gen_col) = gen_line_col(gen_offset);
-        let (orig_line, orig_col) = offset_to_line_col(&src_line_starts, src_pos);
+        let (gen_line, gen_col) = offset_to_line_col_utf16(generated, &gen_line_starts, gen_offset);
+        let (orig_line, orig_col) = offset_to_line_col_utf16(source, &src_line_starts, src_pos);
 
         // Start of token
         mappings.push(js_ast::codegen::SourceMapping {
@@ -806,13 +796,14 @@ fn generate_token_mappings(generated: &str, source: &str) -> Vec<js_ast::codegen
 
         // End of token
         let end_gen = gen_offset + text.len();
-        let (gen_line_end, gen_col_end) = gen_line_col(end_gen);
+        let (gen_line_end, gen_col_end) =
+            offset_to_line_col_utf16(generated, &gen_line_starts, end_gen);
         // A token without a newline cannot cross a line boundary, so its end
         // sits on the same source line as its start.
         let (orig_line_end, orig_col_end) = if text.as_bytes().contains(&b'\n') {
-            offset_to_line_col(&src_line_starts, src_pos + text.len())
+            offset_to_line_col_utf16(source, &src_line_starts, src_pos + text.len())
         } else {
-            (orig_line, orig_col + text.len())
+            (orig_line, orig_col + text.encode_utf16().count())
         };
         mappings.push(js_ast::codegen::SourceMapping {
             gen_line: gen_line_end as u32,
@@ -837,7 +828,7 @@ fn generate_token_mappings(generated: &str, source: &str) -> Vec<js_ast::codegen
 /// This function creates mappings from the generated runtime call positions
 /// back to the original rune positions in the source code.
 fn generate_rune_mappings(generated: &str, source: &str) -> Vec<js_ast::codegen::SourceMapping> {
-    use js_ast::codegen::{build_line_starts, offset_to_line_col};
+    use js_ast::codegen::{build_line_starts, offset_to_line_col_utf16};
 
     // Rune -> runtime transform pairs: (source_pattern, generated_pattern)
     let rune_transforms: &[(&str, &str)] = &[
@@ -900,8 +891,10 @@ fn generate_rune_mappings(generated: &str, source: &str) -> Vec<js_ast::codegen:
 
         // Match 1:1 in order
         for (gen_pos, src_pos) in gen_positions.iter().zip(src_positions.iter()) {
-            let (gen_line, gen_col) = offset_to_line_col(&gen_line_starts, *gen_pos);
-            let (orig_line, orig_col) = offset_to_line_col(&src_line_starts, *src_pos);
+            let (gen_line, gen_col) =
+                offset_to_line_col_utf16(generated, &gen_line_starts, *gen_pos);
+            let (orig_line, orig_col) =
+                offset_to_line_col_utf16(source, &src_line_starts, *src_pos);
 
             // Start mapping
             mappings.push(js_ast::codegen::SourceMapping {
@@ -916,8 +909,10 @@ fn generate_rune_mappings(generated: &str, source: &str) -> Vec<js_ast::codegen:
             // End mapping
             let gen_end = gen_pos + gen_pattern.len();
             let src_end = src_pos + src_pattern.len();
-            let (gen_line_end, gen_col_end) = offset_to_line_col(&gen_line_starts, gen_end);
-            let (orig_line_end, orig_col_end) = offset_to_line_col(&src_line_starts, src_end);
+            let (gen_line_end, gen_col_end) =
+                offset_to_line_col_utf16(generated, &gen_line_starts, gen_end);
+            let (orig_line_end, orig_col_end) =
+                offset_to_line_col_utf16(source, &src_line_starts, src_end);
             mappings.push(js_ast::codegen::SourceMapping {
                 gen_line: gen_line_end as u32,
                 gen_col: gen_col_end as u32,

--- a/crates/rsvelte_core/tests/sourcemaps_gate.rs
+++ b/crates/rsvelte_core/tests/sourcemaps_gate.rs
@@ -308,19 +308,20 @@ fn decode_map(json: &str) -> Option<DecodedMap> {
 }
 
 // ============================================================================
-// Character locating (mirrors `locate-character`)
+// UTF-16 locating (mirrors `locate-character`)
 // ============================================================================
 
-/// 0-based line / column of a character offset, plus the offset itself.
+/// 0-based line / column of a UTF-16 offset, plus the offset itself.
 #[derive(Clone, Copy, Debug)]
 struct Loc {
     line: usize,
     column: usize,
-    character: usize,
+    utf16_offset: usize,
 }
 
-/// Character offset of the `nth` (0-based) occurrence of `needle`, mirroring
-/// upstream's repeated `indexOf(str, prev + 1)`.
+/// UTF-16 offset of the `nth` (0-based) occurrence of `needle`, mirroring
+/// upstream's repeated `indexOf(str, prev + 1)`. JavaScript strings, source-map
+/// columns, and `locate-character` all use UTF-16 code units.
 fn find_nth(haystack: &str, needle: &str, nth: usize) -> Option<usize> {
     let mut byte_from = 0usize;
     let mut found = None;
@@ -330,32 +331,34 @@ fn find_nth(haystack: &str, needle: &str, nth: usize) -> Option<usize> {
         byte_from = at + needle.chars().next().map(char::len_utf8).unwrap_or(1);
     }
     let byte = found?;
-    Some(haystack[..byte].chars().count())
+    Some(haystack[..byte].encode_utf16().count())
 }
 
-fn locate(source: &str, character: usize) -> Loc {
+fn locate(source: &str, utf16_offset: usize) -> Loc {
     let mut line = 0usize;
     let mut column = 0usize;
-    for (i, c) in source.chars().enumerate() {
-        if i == character {
+    let mut offset = 0usize;
+    for c in source.chars() {
+        if offset == utf16_offset {
             break;
         }
         if c == '\n' {
             line += 1;
             column = 0;
         } else {
-            column += 1;
+            column += c.len_utf16();
         }
+        offset += c.len_utf16();
     }
     Loc {
         line,
         column,
-        character,
+        utf16_offset,
     }
 }
 
-fn char_at(source: &str, character: usize) -> Option<char> {
-    source.chars().nth(character)
+fn utf16_unit_at(source: &str, utf16_offset: usize) -> Option<u16> {
+    source.encode_utf16().nth(utf16_offset)
 }
 
 // ============================================================================
@@ -420,11 +423,16 @@ fn check_anchor(source: &str, output: &str, map: &DecodedMap, entry: &Anchor) ->
     // runs to the end of the generated line. Running past the end of the whole
     // output is *not* tolerated: upstream indexes past the end, gets `undefined`,
     // and its `/[\r\n]/` test fails — so `None` is a failure here too.
-    let generated_end = generated.column + generated_str.chars().count();
+    let generated_end = generated.column + generated_str.encode_utf16().count();
     let Some(end_segment) = segments.iter().find(|s| s[0] == generated_end as i64) else {
         let last_col = segments.last().map(|s| s[0]).unwrap_or(0);
-        let next = char_at(output, generated.character + generated_str.chars().count());
-        if last_col > generated_end as i64 || !matches!(next, Some('\n') | Some('\r')) {
+        let next = utf16_unit_at(
+            output,
+            generated.utf16_offset + generated_str.encode_utf16().count(),
+        );
+        if last_col > generated_end as i64
+            || (next != Some(b'\n' as u16) && next != Some(b'\r' as u16))
+        {
             return AnchorOutcome::Failed(format!(
                 "no end segment at {}:{} for '{}'",
                 generated.line, generated_end, entry.str
@@ -439,7 +447,7 @@ fn check_anchor(source: &str, output: &str, map: &DecodedMap, entry: &Anchor) ->
         ));
     }
 
-    let expected_end_column = original.column + entry.str.chars().count();
+    let expected_end_column = original.column + entry.str.encode_utf16().count();
     if end_segment[2] != original.line as i64 || end_segment[3] != expected_end_column as i64 {
         return AnchorOutcome::Failed(format!(
             "end of '{}' maps to {}:{}, expected {}:{}",
@@ -470,7 +478,7 @@ fn out_of_range(map: &DecodedMap, fallback_source: &str) -> (usize, usize) {
                 .and_then(|c| c.as_deref())
                 .unwrap_or(fallback_source);
             text.split('\n')
-                .map(|l| l.trim_end_matches('\r').chars().count())
+                .map(|l| l.trim_end_matches('\r').encode_utf16().count())
                 .collect()
         })
         .collect();
@@ -1058,4 +1066,34 @@ fn sourcemap_gate() {
         "{} stale entries in compatibility/sourcemap-known-failures.json (they already pass)",
         fixed.len()
     );
+}
+
+#[test]
+fn astral_anchor_columns_match_upstreams_utf16_locator() {
+    let source = "x🎉foo\n";
+    let output = "🎉foo\n";
+    let map = DecodedMap {
+        sources: vec!["input.svelte".to_string()],
+        sources_content: vec![Some(source.to_string())],
+        // `foo` begins after one astral character in the generated line and
+        // after `x` plus that character in the original line.
+        lines: vec![vec![vec![2, 0, 0, 3], vec![5, 0, 0, 6]]],
+    };
+
+    assert!(matches!(
+        check_anchor(source, output, &map, &a("foo")),
+        AnchorOutcome::Ok
+    ));
+}
+
+#[test]
+fn astral_original_columns_are_in_range_in_utf16_units() {
+    let source = "🎉\n";
+    let map = DecodedMap {
+        sources: vec!["input.svelte".to_string()],
+        sources_content: vec![Some(source.to_string())],
+        lines: vec![vec![vec![0, 0, 0, 2]]],
+    };
+
+    assert_eq!(out_of_range(&map, source), (0, 1));
 }


### PR DESCRIPTION
## Summary
- emit generated and original source-map columns in UTF-16 code units
- make the source-map gate mirror upstream `locate-character` / JavaScript string indexing
- cover astral-character anchor and range checks

## Root cause
The gate and source-map emitters treated Rust UTF-8 byte offsets or Unicode scalar counts as source-map columns. Source Map v3 and upstream Svelte use JavaScript UTF-16 columns.

## Validation
- `cargo fmt --check`
- `cargo test -p rsvelte_core sourcemap_columns_count_astral_characters_as_two_utf16_units --lib`
- `cargo test -p rsvelte_core --test sourcemaps_gate astral_`
- `cargo clippy -p rsvelte_core --lib --test sourcemaps_gate -- -D warnings`

The full fixture-backed sourcemap gate requires the generated fixtures, which are not present in this isolated worktree; CI provides them.