### PR TITLE
fix(server): replay trailing legacy reactive comments

### DIFF
--- a/.changeset/olive-reactive-comment.md
+++ b/.changeset/olive-reactive-comment.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/compiler": patch
+---
+
+Preserve server output comments trailing direct legacy reactive blocks.

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/comments.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/comments.rs
@@ -40,6 +40,8 @@ struct Chunk {
     /// Comments with spans relative to `text`.
     comments: Vec<Comment>,
     position_only: bool,
+    expression_anchor: bool,
+    component_tail: bool,
 }
 
 /// The per-compile registry of comment regions.
@@ -55,6 +57,21 @@ impl ChunkRegistry {
     /// offset to it to get the address to place a node at. `None` when there is
     /// nothing to carry.
     pub fn register(&mut self, text: &str, comments: &[Comment]) -> Option<u32> {
+        self.register_inner(text, comments, false)
+    }
+
+    /// Register a region whose anchor is a template expression rather than a
+    /// statement.
+    pub fn register_expression(&mut self, text: &str, comments: &[Comment]) -> Option<u32> {
+        self.register_inner(text, comments, true)
+    }
+
+    fn register_inner(
+        &mut self,
+        text: &str,
+        comments: &[Comment],
+        expression_anchor: bool,
+    ) -> Option<u32> {
         if comments.is_empty() || text.is_empty() {
             return None;
         }
@@ -67,6 +84,8 @@ impl ChunkRegistry {
             text: text.to_string(),
             comments: comments.to_vec(),
             position_only: false,
+            expression_anchor,
+            component_tail: false,
         });
         super::comment_stats::bump::REGISTERED_CHUNKS(1);
         super::comment_stats::bump::REGISTERED_COMMENTS(comments.len() as u64);
@@ -87,12 +106,20 @@ impl ChunkRegistry {
             text: text.to_string(),
             comments: Vec::new(),
             position_only: true,
+            expression_anchor: false,
+            component_tail: false,
         });
         Some(prov_base)
     }
 
     pub fn is_empty(&self) -> bool {
         self.chunks.is_empty()
+    }
+
+    pub fn register_component_tail(&mut self, text: &str, comments: &[Comment]) -> Option<u32> {
+        let base = self.register_inner(text, comments, true)?;
+        self.chunks.last_mut()?.component_tail = true;
+        Some(base)
     }
 }
 
@@ -235,14 +262,20 @@ pub fn print_with_comments<'a>(
     let mut comments: Vec<Comment> = Vec::new();
     let order: Vec<usize> = if registry.chunks.iter().any(|chunk| chunk.position_only) {
         (0..registry.chunks.len())
-            .filter(|&i| encounter.via_stmt[i])
+            .filter(|&i| {
+                !registry.chunks[i].component_tail
+                    && (encounter.via_stmt[i] || registry.chunks[i].expression_anchor)
+            })
             .collect()
     } else {
         encounter
             .order
             .iter()
             .copied()
-            .filter(|&i| encounter.via_stmt[i])
+            .filter(|&i| {
+                !registry.chunks[i].component_tail
+                    && (encounter.via_stmt[i] || registry.chunks[i].expression_anchor)
+            })
             .collect()
     };
     for i in order {
@@ -267,20 +300,29 @@ pub fn print_with_comments<'a>(
     };
     remap.visit_program(program);
 
-    if comments.is_empty() {
-        return rsvelte_esrap::print(program, "");
+    let mut code = if comments.is_empty() {
+        rsvelte_esrap::print(program, "")
+    } else {
+        comments.sort_by_key(|c| c.span.start);
+        super::comment_stats::bump::EMITTED_COMMENTS(comments.len() as u64);
+        program.comments = ArenaVec::from_iter_in(comments, &allocator);
+        rsvelte_esrap::print_split(
+            program,
+            &buf,
+            PAD.len() as u32,
+            None,
+            &[],
+            &rsvelte_esrap::PrintOptions::default(),
+        )
+        .code
+    };
+    for chunk in registry.chunks.iter().filter(|chunk| chunk.component_tail) {
+        for comment in &chunk.comments {
+            let raw = &chunk.text[comment.span.start as usize..comment.span.end as usize];
+            if let Some(at) = code.rfind("\n}") {
+                code.insert_str(at, &format!("\n\t{raw}"));
+            }
+        }
     }
-    comments.sort_by_key(|c| c.span.start);
-    super::comment_stats::bump::EMITTED_COMMENTS(comments.len() as u64);
-    program.comments = ArenaVec::from_iter_in(comments, &allocator);
-
-    rsvelte_esrap::print_split(
-        program,
-        &buf,
-        PAD.len() as u32,
-        None,
-        &[],
-        &rsvelte_esrap::PrintOptions::default(),
-    )
-    .code
+    code
 }

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/mod.rs
@@ -28,7 +28,8 @@ use crate::compiler::phases::phase2_analyze::ComponentAnalysis;
 use crate::compiler::phases::phase3_transform::builders::B;
 use crate::compiler::phases::phase3_transform::jsnode_to_oxc::jsnode_to_oxc_expr;
 use oxc_allocator::Allocator;
-use oxc_ast::ast::{Expression as OxcExpression, Statement};
+use oxc_ast::ast::{Comment, Expression as OxcExpression, Statement};
+use oxc_ast_visit::VisitMut;
 use oxc_span::SPAN;
 use visitors::shared::TemplateEntry;
 
@@ -224,6 +225,9 @@ pub struct ServerTransformState<'a> {
     /// Leading-comment regions registered by the script transform, replayed onto
     /// a synthetic buffer at print time. See [`comments`].
     pub comments: comments::ChunkRegistry,
+    /// Comments trailing direct block-bodied legacy `$:` statements. Their final
+    /// anchor is decided after the reordered script body is assembled.
+    pub pending_reactive_comments: Vec<PendingReactiveComment>,
     /// Set when [`Self::reparse_program`] rejected text this compiler generated.
     /// The instance body cannot be reconstructed after that, so assembly aborts
     /// instead of shipping a component whose `<script>` silently did nothing.
@@ -253,6 +257,12 @@ pub struct AsyncConstsGroup<'a> {
     /// Bare `let <name>;` statements (one per declared binding) emitted before
     /// the `var promises = $$renderer.run([...])` declaration.
     pub let_decls: Vec<Statement<'a>>,
+}
+
+pub struct PendingReactiveComment {
+    suffix: String,
+    comments: Vec<Comment>,
+    replay_at_tail: bool,
 }
 
 /// The precomputed inputs to the SSR constant-folding evaluator
@@ -316,7 +326,95 @@ impl<'a> ServerTransformState<'a> {
             slot_let_shadows: Vec::new(),
             current_scope_index: analysis.root.instance_scope_index,
             comments: comments::ChunkRegistry::default(),
+            pending_reactive_comments: Vec::new(),
             reparse_failure: std::cell::RefCell::new(None),
+        }
+    }
+
+    pub fn defer_reactive_block_comments(
+        &mut self,
+        source: &str,
+        comments: &[Comment],
+        statement_end: u32,
+        trailing_end: u32,
+    ) {
+        let suffix = source[statement_end as usize..trailing_end as usize].to_string();
+        let comments = comments
+            .iter()
+            .filter(|comment| {
+                comment.span.start >= statement_end && comment.span.end <= trailing_end
+            })
+            .map(|comment| {
+                let mut comment = *comment;
+                comment.span.start -= statement_end;
+                comment.span.end -= statement_end;
+                comment
+            })
+            .collect();
+        self.pending_reactive_comments.push(PendingReactiveComment {
+            suffix,
+            comments,
+            replay_at_tail: false,
+        });
+    }
+
+    pub fn mark_deferred_reactive_comment_landed(&mut self, index: usize) {
+        if let Some(comment) = self.pending_reactive_comments.get_mut(index) {
+            comment.replay_at_tail = true;
+        }
+    }
+
+    /// The first template expression receives a deferred comment only when no
+    /// script successor already claimed its initial landing.
+    pub fn claim_deferred_reactive_comment(&mut self, expression: &mut OxcExpression<'a>) {
+        let Some(index) = self
+            .pending_reactive_comments
+            .iter()
+            .position(|comment| !comment.replay_at_tail)
+        else {
+            return;
+        };
+        let comment = self.pending_reactive_comments.remove(index);
+        let mut text = String::from("x");
+        text.push_str(&comment.suffix);
+        text.push('\n');
+        let mut comments = comment.comments;
+        for comment in &mut comments {
+            comment.span.start += 1;
+            comment.span.end += 1;
+        }
+        if let Some(base) = self.comments.register_expression(&text, &comments) {
+            let mut place = comments::Place::At(base + text.len() as u32);
+            place.visit_expression(expression);
+        }
+    }
+
+    /// A script successor receives the first copy; the cursor then replays the
+    /// same comment at the component tail. An unclaimed comment has that tail as
+    /// its fallback when there is no template expression.
+    pub fn replay_deferred_reactive_comments_at_tail(&mut self) {
+        let pending = std::mem::take(&mut self.pending_reactive_comments);
+        let Some(last) = self.body.last_mut() else {
+            return;
+        };
+        for comment in pending {
+            let first = comment
+                .comments
+                .iter()
+                .map(|comment| comment.span.start as usize)
+                .min()
+                .unwrap_or(0);
+            let mut text = String::from("x;\n");
+            text.push_str(&comment.suffix[first..]);
+            let mut comments = comment.comments;
+            for comment in &mut comments {
+                comment.span.start = comment.span.start - first as u32 + 3;
+                comment.span.end = comment.span.end - first as u32 + 3;
+            }
+            if let Some(base) = self.comments.register_component_tail(&text, &comments) {
+                let mut place = comments::Place::At(base);
+                place.visit_statement(last);
+            }
         }
     }
 
@@ -1169,6 +1267,8 @@ pub fn server_component_ast<'a>(
         );
         state.body.push(cleanup);
     }
+
+    state.replay_deferred_reactive_comments_at_tail();
 
     // -- $.bind_props trailer (upstream lines 224-243) ----------------------
     // Collect `props` from bindable_prop bindings (`prop_alias ?? name`, excluding

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/script.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/script.rs
@@ -376,6 +376,23 @@ fn trailing_comment_end(src: &str, all: &[Comment], stmt_end: u32) -> u32 {
     }
 }
 
+/// The legacy reactive label itself may contain a block, or directly wrap an
+/// `if` whose branch does. Those retained blocks are the locations that rewind
+/// esrap's comment cursor after the label has been reordered.
+fn reactive_body_has_direct_block(stmt: &Statement<'_>) -> bool {
+    match stmt {
+        Statement::BlockStatement(_) => true,
+        Statement::IfStatement(if_stmt) => {
+            matches!(&if_stmt.consequent, Statement::BlockStatement(_))
+                || if_stmt
+                    .alternate
+                    .as_ref()
+                    .is_some_and(|alternate| matches!(alternate, Statement::BlockStatement(_)))
+        }
+        _ => false,
+    }
+}
+
 /// Resolve a top-level statement's registered region into the [`comments::Place`]
 /// its emitted statement is stamped with. `verbatim` is the source range the
 /// statement was re-parsed from, when it was re-parsed whole.
@@ -2863,6 +2880,7 @@ fn transform_script_legacy<'a>(
     // comments are re-homed onto the next survivor instead of dying with it.
     let mut region_start: u32 = 0;
     let mut reactive_leading_comment_pending = false;
+    let mut deferred_reactive_comment: Option<usize> = None;
 
     for stmt in ret.program.body.iter() {
         let stmt_span = stmt.span();
@@ -2877,6 +2895,7 @@ fn transform_script_legacy<'a>(
         // Set by every branch that re-parses the statement WHOLE from a source
         // range, to that range.
         let mut verbatim: Option<Span> = None;
+        let mut defer_block_reactive_trailing = false;
 
         'emit: {
             match stmt {
@@ -3018,6 +3037,24 @@ fn transform_script_legacy<'a>(
                             assigns,
                             deps,
                         });
+                        let trailing_end =
+                            trailing_comment_end(src, &ret.program.comments, stmt_span.end);
+                        defer_block_reactive_trailing = trailing_end > stmt_span.end
+                            && reactive_body_has_direct_block(&ls.body)
+                            && !ret.program.comments.iter().any(|comment| {
+                                comment.span.start >= region_start
+                                    && comment.span.end <= stmt_span.start
+                            });
+                        if defer_block_reactive_trailing {
+                            let index = state.pending_reactive_comments.len();
+                            state.defer_reactive_block_comments(
+                                src,
+                                &ret.program.comments,
+                                stmt_span.end,
+                                trailing_end,
+                            );
+                            deferred_reactive_comment = Some(index);
+                        }
                     }
                 }
                 Statement::ExpressionStatement(es) => {
@@ -3087,6 +3124,9 @@ fn transform_script_legacy<'a>(
             }
         }
 
+        if defer_block_reactive_trailing {
+            continue;
+        }
         let into_sink = import_sink.as_deref().is_some_and(|s| s.len() > sink_len);
         let anchor = out.iter().skip(out_len).position(anchors_a_region);
         if !into_sink && anchor.is_none() && reactive.len() == reactive_len {
@@ -3126,6 +3166,9 @@ fn transform_script_legacy<'a>(
                     }
                     other => place.visit_statement(other),
                 }
+            }
+            if let Some(index) = deferred_reactive_comment.take() {
+                state.mark_deferred_reactive_comment_landed(index);
             }
         }
         if is_reactive && reactive_leading_comment {

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/visitors/shared.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/visitors/shared.rs
@@ -750,7 +750,8 @@ fn flush_sequence<'a>(sequence: &[SeqNode<'_>], state: &mut ServerTransformState
                     continue;
                 }
 
-                let visited = state.visit_expr(expr);
+                let mut visited = state.visit_expr(expr);
+                state.claim_deferred_reactive_comment(&mut visited);
                 let escaped = state.b.call("$.escape", vec![visited]);
                 exprs.push(escaped);
                 quasis.push(String::new());

--- a/crates/rsvelte_core/tests/server_reactive_block_comment_cursor_2717.rs
+++ b/crates/rsvelte_core/tests/server_reactive_block_comment_cursor_2717.rs
@@ -1,0 +1,73 @@
+//! Server-side legacy reactive block comments follow esrap's cursor semantics.
+//!
+//! Upstream's located nested block rewinds the comment cursor after its comment
+//! has already re-homed. A script successor therefore receives one copy and the
+//! reactive block receives the other; if the template expression is the next
+//! located node, only that expression receives the copy.
+
+use rsvelte_core::{CompileOptions, GenerateMode, compile};
+
+fn server(source: &str) -> String {
+    compile(
+        source,
+        CompileOptions {
+            filename: Some("A.svelte".to_string()),
+            generate: GenerateMode::Server,
+            dev: false,
+            ..Default::default()
+        },
+    )
+    .expect("component should compile")
+    .js
+    .code
+}
+
+fn body(code: &str) -> &str {
+    code.find("import * as $")
+        .map_or(code, |start| &code[start..])
+        .trim_end()
+}
+
+#[test]
+fn block_body_trailing_comment_rehomes_then_rewinds_with_a_script_successor() {
+    let out = server(
+        "<script>\n\tlet total = 10;\n\tlet half;\n\t$: { half = total / 2; } // C\n\tlet z = 1;\n\tconsole.log(z);\n</script>\n\n<p>x</p>",
+    );
+    assert_eq!(
+        body(&out),
+        "import * as $ from 'svelte/internal/server';\n\nexport default function A($$renderer) {\n\tlet total = 10;\n\tlet half;\n\n\t// C\n\tlet z = 1;\n\n\tconsole.log(z);\n\n\t$: {\n\t\thalf = total / 2;\n\t}\n\n\t$$renderer.push(`<p>x</p>`);\n\t// C\n}"
+    );
+}
+
+#[test]
+fn if_body_trailing_block_comment_rehomes_then_rewinds() {
+    let out = server(
+        "<script>\n\tlet total = 10;\n\tlet half;\n\t$: if (total) { half = total / 2; } /* C */\n\tlet z = 1;\n</script>\n\n<p>x</p>",
+    );
+    assert_eq!(
+        body(&out),
+        "import * as $ from 'svelte/internal/server';\n\nexport default function A($$renderer) {\n\tlet total = 10;\n\tlet half;\n\n\t/* C */\n\tlet z = 1;\n\n\t$: if (total) {\n\t\thalf = total / 2;\n\t}\n\n\t$$renderer.push(`<p>x</p>`);\n\t/* C */\n}"
+    );
+}
+
+#[test]
+fn block_body_trailing_comment_lands_in_the_template_expression() {
+    let out = server(
+        "<script>\n\tlet total = 10;\n\tlet half;\n\t$: { half = total / 2; } // C\n</script>\n\n<p>{half}</p>",
+    );
+    assert_eq!(
+        body(&out),
+        "import * as $ from 'svelte/internal/server';\n\nexport default function A($$renderer) {\n\tlet total = 10;\n\tlet half;\n\n\t$: {\n\t\thalf = total / 2;\n\t}\n\n\t$$renderer.push(`<p>${$.escape(\n\t\t// C\n\t\thalf\n\t)}</p>`);\n}"
+    );
+}
+
+#[test]
+fn block_body_trailing_comment_falls_back_to_the_component_tail() {
+    let out = server(
+        "<script>\n\tlet total = 10;\n\tlet half;\n\t$: { half = total / 2; } // C\n</script>\n\n<p>x</p>",
+    );
+    assert_eq!(
+        body(&out),
+        "import * as $ from 'svelte/internal/server';\n\nexport default function A($$renderer) {\n\tlet total = 10;\n\tlet half;\n\n\t$: {\n\t\thalf = total / 2;\n\t}\n\n\t$$renderer.push(`<p>x</p>`);\n\t// C\n}"
+    );
+}


### PR DESCRIPTION
Fixes #2717.

Direct block-bodied legacy reactive statements now defer only their same-line trailing comments. The first template expression claims an unlanded comment; when a following script statement claimed the first copy, or no template expression exists, it is replayed at the component tail to match upstream cursor behavior.

Verified with:
- `RUST_MIN_STACK=33554432 cargo test -p rsvelte_core --test server_reactive_block_comment_cursor_2717`
- `RUST_MIN_STACK=33554432 cargo test -p rsvelte_core server::ast:: --lib`
- `cargo clippy -p rsvelte_core --test server_reactive_block_comment_cursor_2717 -- -D warnings`