### PR TITLE
fix(lint): recognize Unicode each key bindings

### DIFF
--- a/.changeset/fresh-unicode-each-key.md
+++ b/.changeset/fresh-unicode-each-key.md
@@ -1,0 +1,5 @@
+---
+'@rsvelte/lint': patch
+---
+
+Recognize Unicode identifiers in `valid-each-key` references.

--- a/crates/rsvelte_lint/src/rules/valid_each_key.rs
+++ b/crates/rsvelte_lint/src/rules/valid_each_key.rs
@@ -12,6 +12,7 @@
 //! a key "valid", matching upstream's conservative intent for these fixtures.
 
 use rsvelte_core::ast::template::EachBlock;
+use rsvelte_core::compiler::utils::{is_js_ident_continue, is_js_ident_start};
 
 use crate::context::LintContext;
 use crate::rule::{Fixable, Rule, RuleCategory, RuleConditions, RuleMeta, Severity};
@@ -32,26 +33,16 @@ static META: RuleMeta = RuleMeta {
 
 const MESSAGE: &str = "Expected key to use the variables which are defined by the `{#each}` block.";
 
-/// Is `c` a character that can appear inside a JS identifier?
-fn is_ascii_ident_char(c: char) -> bool {
-    c.is_ascii_alphanumeric() || c == '_' || c == '$'
-}
-
-/// Is `c` a character that can START a JS identifier?
-fn is_ascii_ident_start(c: char) -> bool {
-    c.is_ascii_alphabetic() || c == '_' || c == '$'
-}
-
 /// Collect every JS identifier token in `src` (regex-free char scan).
 fn collect_identifiers(src: &str) -> Vec<String> {
     let bytes: Vec<char> = src.chars().collect();
     let mut out = Vec::new();
     let mut i = 0;
     while i < bytes.len() {
-        if is_ascii_ident_start(bytes[i]) {
+        if is_js_ident_start(bytes[i]) {
             let start = i;
             i += 1;
-            while i < bytes.len() && is_ascii_ident_char(bytes[i]) {
+            while i < bytes.len() && is_js_ident_continue(bytes[i]) {
                 i += 1;
             }
             out.push(bytes[start..i].iter().collect());
@@ -84,11 +75,11 @@ fn occurs_as_reference(key: &str, name: &str) -> bool {
                 p -= 1;
             }
             let prev = key[p..at].chars().next().unwrap_or(' ');
-            !is_ascii_ident_char(prev) && prev != '.'
+            !is_js_ident_continue(prev) && prev != '.'
         };
         // Char immediately after must not be an identifier char.
         let after_ok = match key[end..].chars().next() {
-            Some(c) => !is_ascii_ident_char(c),
+            Some(c) => !is_js_ident_continue(c),
             None => true,
         };
         if before_ok && after_ok {

--- a/crates/rsvelte_lint/tests/valid_each_key_unicode_2460.rs
+++ b/crates/rsvelte_lint/tests/valid_each_key_unicode_2460.rs
@@ -1,0 +1,21 @@
+use std::path::PathBuf;
+
+use rsvelte_core::CompileOptions;
+use rsvelte_lint::{LintConfig, Severity, lint_source};
+
+#[test]
+fn unicode_each_context_is_a_valid_key_reference() {
+    let config = LintConfig::empty().with_override("svelte/valid-each-key", Severity::Error);
+    let diagnostics = lint_source(
+        "{#each [{ id: 1 }] as 名前 (名前.id)}{名前.id}{/each}",
+        &PathBuf::from("Test.svelte"),
+        &CompileOptions::default(),
+        &config,
+    );
+    assert!(
+        diagnostics
+            .iter()
+            .all(|diagnostic| diagnostic.code.as_deref() != Some("svelte/valid-each-key")),
+        "{diagnostics:#?}"
+    );
+}


### PR DESCRIPTION
Fixes the reachable linter half of #2460.

`valid-each-key` used ASCII-only `char` classifiers, so `{#each … as 名前 (名前.id)}` was incorrectly reported despite the key referencing the each binding. The rule now uses the compiler shared ECMAScript identifier predicates.

Verified with:
- `cargo test -p rsvelte_lint --test valid_each_key_unicode_2460`
- `cargo clippy -p rsvelte_lint --test valid_each_key_unicode_2460 -- -D warnings`