### PR TITLE
fix(compiler): preserve module derived await patterns

### DIFF
--- a/.changeset/module-derived-await-pattern.md
+++ b/.changeset/module-derived-await-pattern.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/compiler": patch
+---
+
+Preserve directly awaited destructured derived declarations in module scripts.

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/module_derived_ast.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/module_derived_ast.rs
@@ -112,6 +112,9 @@ impl<'a> ModuleDerivedCollector<'a> {
         if !contains_direct_await_in_expression(arg) {
             return None;
         }
+        if arg.starts_with("await") {
+            return Some((call.span.start, call.span.end, arg.to_string()));
+        }
         let pattern_span = declarator.id.span();
         let pattern = self
             .source
@@ -197,7 +200,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn lowers_async_object_pattern() {
+    fn keeps_directly_awaited_object_pattern_in_module_scope() {
         let out = transform_module_derived_destructuring_ast(
             "const { a, b } = $derived(await p);",
             false,
@@ -208,25 +211,21 @@ mod tests {
             None,
         )
         .unwrap();
-        assert_eq!(
-            out,
-            "const $$d = await $.async_derived(() => p),\n\ta = $.derived(() => $.get($$d).a),\n\tb = $.derived(() => $.get($$d).b);"
-        );
+        assert_eq!(out, "const { a, b } = await p;");
     }
 
     #[test]
-    fn lowers_async_array_pattern_with_local_temp_names() {
+    fn keeps_directly_awaited_array_pattern_in_module_scope() {
         let out = transform_module_derived_destructuring_ast(
             "const [a, b] = $derived(await p);",
             false,
             &[],
             &[],
             &[],
-            true,
+            false,
             None,
         )
         .unwrap();
-        assert!(out.contains("$$array = $.tag("));
-        assert!(!out.contains("$$array_1"));
+        assert_eq!(out, "const [a, b] = await p;");
     }
 }

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/script.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/script.rs
@@ -1953,6 +1953,22 @@ fn lower_variable_declaration<'a>(
                     let mut array_counter = state.array_counter;
                     create_state_declarators(pat, new_init, state, &mut array_counter, &mut decls);
                     state.array_counter = array_counter;
+                } else if matches!(rune, DeclRune::Derived)
+                    && !is_instance
+                    && !matches!(pat, oxc_ast::ast::BindingPattern::BindingIdentifier(_))
+                    && let Some(oxc_ast::ast::Expression::CallExpression(call)) = d.init.as_ref()
+                    && let Some(oxc_ast::ast::Expression::AwaitExpression(_)) =
+                        call.arguments.first().and_then(|arg| arg.as_expression())
+                {
+                    let argument = call.arguments[0].as_expression().unwrap();
+                    let argument_source =
+                        &src[argument.span().start as usize..argument.span().end as usize];
+                    if let Some((_, init)) = state.reparse_declarator(
+                        &format!("__rsvelte_direct_await = {argument_source}"),
+                        kind,
+                    ) {
+                        decls.push((pat, init));
+                    }
                 } else if matches!(rune, DeclRune::Derived | DeclRune::DerivedBy)
                     && !matches!(pat, oxc_ast::ast::BindingPattern::BindingIdentifier(_))
                 {

--- a/crates/rsvelte_core/tests/module_direct_async_derived_2754.rs
+++ b/crates/rsvelte_core/tests/module_direct_async_derived_2754.rs
@@ -1,0 +1,30 @@
+use rsvelte_core::{CompileOptions, ExperimentalOptions, GenerateMode, compile};
+
+fn compile_module_script(generate: GenerateMode) -> String {
+    compile(
+		"<script module>\n\tconst p = Promise.resolve(1);\n\tconst [a, b] = $derived(await p);\n</script>\n\n<p>ok</p>",
+		CompileOptions {
+			generate,
+			experimental: ExperimentalOptions { r#async: true },
+			..Default::default()
+		},
+	)
+	.unwrap()
+	.js
+	.code
+}
+
+#[test]
+fn directly_awaited_module_derived_pattern_is_not_an_async_cell() {
+    for generate in [GenerateMode::Client, GenerateMode::Server] {
+        let code = compile_module_script(generate);
+        assert!(
+            code.contains("const [a, b] = await p;"),
+            "module declaration must retain its direct await ({generate:?}):\n{code}"
+        );
+        assert!(
+            !code.contains("$.async_derived"),
+            "module declaration must not create an async cell ({generate:?}):\n{code}"
+        );
+    }
+}


### PR DESCRIPTION
Fixes the directly-awaited destructured `$derived` lowering in module scripts.

Upstream preserves `const [a, b] = await p`; rsvelte created an async-derived cell in both the client module transform and the SSR module AST transform.

Validation:
- `cargo test -p rsvelte_core --test module_direct_async_derived_2754`
- module-derived AST unit tests
- server AST unit suite
- clippy with warnings denied

This is one validated #2754 subcluster; the remaining module/dev shapes stay tracked by #2754.