### PR TITLE
fix(server): add development snippet guards

### DIFF
--- a/.changeset/soft-server-dev-snippets.md
+++ b/.changeset/soft-server-dev-snippets.md
@@ -1,0 +1,5 @@
+---
+'@rsvelte/compiler': patch
+---
+
+Match development-mode SSR snippet validation and stringification guards.

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/visitors/component.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/visitors/component.rs
@@ -512,7 +512,14 @@ fn build_component_children<'a, 'b>(
                 serialized_slots.push(state.b.init("default", slot_fn));
             } else if default_lets.is_empty() {
                 // No `let:` directives → the usual `children` prop path.
-                push_prop(groups, state.b.init("children", slot_fn));
+                let children = if state.options.dev {
+                    state
+                        .b
+                        .call("$.prevent_snippet_stringification", vec![slot_fn])
+                } else {
+                    slot_fn
+                };
+                push_prop(groups, state.b.init("children", children));
                 serialized_slots.push(state.b.init("default", state.b.bool(true)));
             } else {
                 // Scoped default slot (`let:`): expose `$$slots.default` as the

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/visitors/snippet_block.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/visitors/snippet_block.rs
@@ -79,8 +79,14 @@ pub fn visit_snippet_block<'a>(node: &SnippetBlock<'a>, state: &mut ServerTransf
     // as the function body.
     // SnippetBlock body IS an `is_text_first` parent (upstream `clean_nodes`).
     let saved_scope = state.enter_template_scope(node.start);
-    let body_block = super::shared::build_fragment_body(&node.body.nodes, true, true, state);
+    let mut body_block = super::shared::build_fragment_body(&node.body.nodes, true, true, state);
     state.restore_scope(saved_scope);
+    if state.options.dev {
+        body_block.insert(
+            0,
+            b.stmt(b.call("$.validate_snippet_args", vec![b.id("$$renderer")])),
+        );
+    }
     let fn_body = b.body(body_block);
 
     state.shadowed_names.pop();
@@ -113,8 +119,18 @@ pub fn visit_snippet_block<'a>(node: &SnippetBlock<'a>, state: &mut ServerTransf
     // than hoisted to module scope — mirroring the same gate the SvelteBoundary
     // visitor applies to the `failed` snippet.
     if node.metadata.can_hoist && state.fragment_depth <= 1 {
+        if state.options.dev {
+            state
+                .hoisted
+                .push(b.stmt(b.call("$.prevent_snippet_stringification", vec![b.id(&name)])));
+        }
         state.hoisted.push(fn_decl);
     } else {
+        if state.options.dev {
+            state.template.push(super::shared::TemplateEntry::Stmt(
+                b.stmt(b.call("$.prevent_snippet_stringification", vec![b.id(&name)])),
+            ));
+        }
         state
             .template
             .push(super::shared::TemplateEntry::HoistableDecl(fn_decl));

--- a/crates/rsvelte_core/tests/server_dev_snippet_guards_2610.rs
+++ b/crates/rsvelte_core/tests/server_dev_snippet_guards_2610.rs
@@ -1,0 +1,37 @@
+use rsvelte_core::{CompileOptions, GenerateMode, compile};
+
+fn compile_server_dev(source: &str) -> String {
+    compile(
+        source,
+        CompileOptions {
+            generate: GenerateMode::Server,
+            dev: true,
+            ..Default::default()
+        },
+    )
+    .unwrap_or_else(|error| panic!("compile failed: {error:?}"))
+    .js
+    .code
+}
+
+#[test]
+fn snippet_block_gets_server_dev_guards() {
+    let output = compile_server_dev("{#snippet foo()}foo{/snippet}{@render foo()}");
+    assert!(
+        output.contains("$.prevent_snippet_stringification(foo);"),
+        "{output}"
+    );
+    assert!(
+        output.contains("$.validate_snippet_args($$renderer);"),
+        "{output}"
+    );
+}
+
+#[test]
+fn default_component_children_get_server_dev_stringification_guard() {
+    let output = compile_server_dev("<Child>default</Child>");
+    assert!(
+        output.contains("children: $.prevent_snippet_stringification("),
+        "{output}"
+    );
+}


### PR DESCRIPTION
Addresses the known server-dev output differences behind #2610.

Mirrors upstream server visitors: snippet declarations validate their renderer arguments and are registered against stringification in development; default component children are wrapped against stringification too.

The server-dev corpus target itself remains a separate gate-enrollment change because it requires a fresh full-corpus baseline and new ratchets; this compiler correction has no matrix/baseline impact while that target is absent.

Verified with:
- `cargo test -p rsvelte_core --test server_dev_snippet_guards_2610`
- `cargo test -p rsvelte_core server_ast --lib`
- `cargo clippy -p rsvelte_core --test server_dev_snippet_guards_2610 -- -D warnings`