### PR TITLE
test(svelte2tsx): gate source-map coverage

### DIFF
--- a/compatibility/gate-coverage.md
+++ b/compatibility/gate-coverage.md
@@ -90,7 +90,7 @@ samples) — see `AGENTS.md` § "Generated shape matrix" and issue #2281.
 | 4 | Compiler **error** parity | `error.json` `code`, `message`, `start`, `end`, `frame` | `filename`; the NAPI entries the corpus does not call; a missing artifact scored `match` until the per-tree precondition | [D] |
 | 5 | Generated shape matrix | per-case × target JS text + warning `code` multiset, or error `code` where official rejects | neither output is parsed — identical **non-JavaScript** scores `match`; CSS; warning **position**; error **message** and **position**; multi-directive and ancestry rules; whether a folded constant is the *right* value | [D] |
 | 6 | svelte2tsx TSX text parity | per-component TSX text, oxfmt-normalized | `exportedNames` / `events`; TSX line+column layout | [S] |
-| 7 | svelte2tsx source map | structural invariants on rsvelte's own map | map **coverage** — a 1-of-1000-line map is valid | [D] |
+| 7 | svelte2tsx source map | structural invariants and corpus-wide mapped-line coverage on rsvelte's own map | relation between generated text and mapped original text; source index | [D] |
 | 8 | css-prune sweep | `css.code` + `code@line:col` warnings of 1969 generated components | `js.code`; **every element in the grid is a plain `<div>`/`<p>` in one component** | [D] |
 | 9 | Formatter parity (JS corpus) | whole-file bytes vs oxfmt oracle | ids whose oracle file is absent are skipped, uncounted | [D] |
 | 10 | Formatter parity (Rust svelte.dev) | whole-file bytes vs generated fixture | exercises `--no-native-css`, not the shipped default | [S] |
@@ -784,14 +784,14 @@ calibrate. Official's map serves as a *veto*: if it violates an invariant, the e
 generated lines; generated columns sorted within a line; no 3+ "stalled copy run"; generated
 column in bounds; original line in bounds; original column in bounds.
 
-### Blind spot 7a — there is no coverage invariant
+### Blind spot 7a — closed: corpus-wide mapped-line coverage floor (#2453)
 
-`extra-mapping-lines` (`sourcemap.mjs:113-115`) fires only when the map has *more* lines than
-the text — one-directional. **[D]** Verified by running `mappingViolations` directly:
-`mappings: "AAAA"` against **1000** generated lines returns `[]` (`map-valid`), as does
-`mappings: ""`. A regression where rsvelte stops emitting segments after the `render()` opening
-would misplace every `svelte-check` diagnostic in the template body and the gate reports
-`map-valid` for all ~13.4k entries.
+`mappedLineCoverage` counts non-empty generated lines carrying a source-bearing segment, and
+`svelte2tsx-verify.mjs` rejects a corpus-wide ratio below 75%. **[D]** The pinned official
+oracle calibrates the same population at 78.66%; a `"AAAA"` map against 1000 non-empty lines
+therefore fails. Per-entry coverage cannot be used: valid official maps can have zero mapped
+lines, so only the corpus aggregate distinguishes a truncation from a legitimate generated
+wrapper.
 
 ### Blind spot 7b — no correctness invariant relates generated text to mapped original text
 

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
 		"test:corpus-verify-flags": "node scripts/dev/test-corpus-verify-baseline-flags.mjs",
 		"test:corpus-parse-gate": "node scripts/dev/test-corpus-parse-gate.mjs",
 		"test:lint-verify-floor": "node scripts/dev/test-lint-verify-population-floor.mjs",
+		"test:svelte2tsx-map-coverage": "node scripts/dev/test-svelte2tsx-map-coverage.mjs",
 		"test:corpus-generation": "node scripts/dev/test-corpus-generation-guard.mjs",
 		"test:mutant-classification": "node scripts/dev/test-mutant-classification.mjs",
 		"test:mutation-baseline-provenance": "node scripts/dev/test-mutation-baseline-provenance.mjs",

--- a/scripts/compat-corpus/sourcemap.mjs
+++ b/scripts/compat-corpus/sourcemap.mjs
@@ -26,6 +26,11 @@ const BASE64 = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/
 // A third means the generated column stopped advancing across copied text.
 const STALL_RUN_LIMIT = 3;
 
+// Official svelte2tsx maps 78.66% of non-empty generated lines on the pinned
+// corpus. Leave room for independently-segmented output while rejecting a map
+// that stops after a small prefix.
+export const MIN_MAPPED_LINE_COVERAGE = 0.75;
+
 /**
  * Split one comma-free segment into its VLQ fields. Accumulation is arithmetic
  * rather than bitwise: JS bit operators truncate to int32, which would silently
@@ -91,6 +96,25 @@ export function utf16LineLengths(text) {
 		for (const char of line) units += char.codePointAt(0) > 0xffff ? 2 : 1;
 		return units;
 	});
+}
+
+/**
+ * Count non-empty generated lines that have a source-bearing segment. Empty
+ * generated lines do not need a mapping, and a one-field segment has no source
+ * position for a consumer to follow.
+ */
+export function mappedLineCoverage(mappings, generatedLengths) {
+	const lines = decodeMappings(mappings);
+	if (lines === null) return null;
+
+	let generatedLines = 0;
+	let mappedLines = 0;
+	for (let generatedLine = 0; generatedLine < generatedLengths.length; generatedLine++) {
+		if (generatedLengths[generatedLine] === 0) continue;
+		generatedLines++;
+		if (lines[generatedLine]?.length) mappedLines++;
+	}
+	return { generatedLines, mappedLines };
 }
 
 /**

--- a/scripts/compat-corpus/svelte2tsx-verify.mjs
+++ b/scripts/compat-corpus/svelte2tsx-verify.mjs
@@ -51,7 +51,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { stripBlankLines, readIf, firstDiffLine, oxfmtTree, oxfmtParses as oxfmtParsesFile } from './normalize.mjs';
-import { mappingViolations } from './sourcemap.mjs';
+import { MIN_MAPPED_LINE_COVERAGE, mappedLineCoverage, mappingViolations } from './sourcemap.mjs';
 import { MIN_FULL_CORPUS_ENTRIES, S2T_TREES, cleanupArtifacts } from './artifacts.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -95,6 +95,8 @@ if (manifest.length < MIN_MANIFEST_ENTRIES) {
 // inconsistent with the map on any later re-run.
 const mapCounts = { 'map-valid': 0, 'map-invalid': 0, 'map-missing': 0, 'map-oracle-invalid': 0, 'map-absent': 0 };
 const mapFailures = [];
+const expectedCoverage = { generatedLines: 0, mappedLines: 0 };
+const actualCoverage = { generatedLines: 0, mappedLines: 0 };
 const readMap = (dir) => {
 	const json = readIf(path.join(dir, 'map.json'));
 	return json == null ? null : JSON.parse(json);
@@ -110,8 +112,22 @@ for (const { id } of manifest) {
 		// Official emitting a map while rsvelte emits none is the regression that
 		// would follow from dropping the map from the NAPI surface again.
 		verdict = expected == null ? 'map-absent' : 'map-missing';
-	} else if (expected != null && mappingViolations(expected.mappings, expected.generatedLines, source).length) {
-		verdict = 'map-oracle-invalid';
+	} else if (expected != null) {
+		const expectedDetails = mappingViolations(expected.mappings, expected.generatedLines, source);
+		if (expectedDetails.length) {
+			verdict = 'map-oracle-invalid';
+		} else {
+			const coverage = mappedLineCoverage(expected.mappings, expected.generatedLines);
+			expectedCoverage.generatedLines += coverage.generatedLines;
+			expectedCoverage.mappedLines += coverage.mappedLines;
+			details = mappingViolations(actual.mappings, actual.generatedLines, source);
+			verdict = details.length ? 'map-invalid' : 'map-valid';
+			if (!details.length) {
+				const coverage = mappedLineCoverage(actual.mappings, actual.generatedLines);
+				actualCoverage.generatedLines += coverage.generatedLines;
+				actualCoverage.mappedLines += coverage.mappedLines;
+			}
+		}
 	} else {
 		details = mappingViolations(actual.mappings, actual.generatedLines, source);
 		verdict = details.length ? 'map-invalid' : 'map-valid';
@@ -119,6 +135,27 @@ for (const { id } of manifest) {
 
 	mapCounts[verdict]++;
 	if (verdict === 'map-invalid' || verdict === 'map-missing') mapFailures.push({ id, verdict, details });
+}
+
+const coverageRatio = (coverage) => coverage.mappedLines / coverage.generatedLines;
+const expectedCoverageRatio = coverageRatio(expectedCoverage);
+const actualCoverageRatio = coverageRatio(actualCoverage);
+if (expectedCoverageRatio < MIN_MAPPED_LINE_COVERAGE) {
+	console.error(
+		`[s2t-verify] official source-map coverage ${(expectedCoverageRatio * 100).toFixed(2)}% ` +
+		`is below the ${(MIN_MAPPED_LINE_COVERAGE * 100).toFixed(0)}% calibrated floor; review the invariant`,
+	);
+	process.exit(2);
+}
+if (actualCoverageRatio < MIN_MAPPED_LINE_COVERAGE) {
+	mapFailures.push({
+		id: '__mapped-line-coverage__',
+		verdict: 'map-insufficient-coverage',
+		details: [{
+			kind: 'mapped-line-coverage',
+			detail: `${actualCoverage.mappedLines}/${actualCoverage.generatedLines} (${(actualCoverageRatio * 100).toFixed(2)}%)`,
+		}],
+	});
 }
 
 if (!NO_FMT) {
@@ -224,11 +261,20 @@ const report = {
 	failures,
 	mapCounts,
 	mapFailures,
+	mapCoverage: {
+		minimum: MIN_MAPPED_LINE_COVERAGE,
+		expected: { ...expectedCoverage, ratio: expectedCoverageRatio },
+		actual: { ...actualCoverage, ratio: actualCoverageRatio },
+	},
 };
 fs.writeFileSync(path.join(CORPUS, 'report-s2t.json'), JSON.stringify(report, null, '\t') + '\n');
 
 console.log('\n[s2t-verify] results:');
 for (const [k, v] of Object.entries({ ...counts, ...mapCounts })) console.log(`  ${k.padEnd(18)} ${v}`);
+console.log(
+	`  mapped lines       official ${expectedCoverage.mappedLines}/${expectedCoverage.generatedLines} (${(expectedCoverageRatio * 100).toFixed(2)}%), ` +
+		`rsvelte ${actualCoverage.mappedLines}/${actualCoverage.generatedLines} (${(actualCoverageRatio * 100).toFixed(2)}%)`,
+);
 console.log(`  report: ${path.relative(ROOT, path.join(CORPUS, 'report-s2t.json'))}`);
 
 if (UPDATE_BASELINE) {

--- a/scripts/dev/test-svelte2tsx-map-coverage.mjs
+++ b/scripts/dev/test-svelte2tsx-map-coverage.mjs
@@ -1,0 +1,31 @@
+#!/usr/bin/env node
+import { MIN_MAPPED_LINE_COVERAGE, mappedLineCoverage } from "../compat-corpus/sourcemap.mjs";
+
+let failed = 0;
+function check(name, actual, expected) {
+  const ok = JSON.stringify(actual) === JSON.stringify(expected);
+  console.log(`  ${ok ? "✓" : "✗"} ${name}`);
+  if (!ok) failed++;
+}
+
+check(
+  "counts source-bearing segments on non-empty lines",
+  mappedLineCoverage("AAAA;AACA;;AACA", [1, 1, 0, 1]),
+  {
+    generatedLines: 3,
+    mappedLines: 3,
+  },
+);
+check("does not count generated-only segments", mappedLineCoverage("A;AACA", [1, 1]), {
+  generatedLines: 2,
+  mappedLines: 1,
+});
+check("rejects undecodable mappings", mappedLineCoverage("!", [1]), null);
+const truncated = mappedLineCoverage("AAAA", Array(1000).fill(1));
+check(
+  "rejects a one-line map for 1000 generated lines",
+  truncated.mappedLines / truncated.generatedLines < MIN_MAPPED_LINE_COVERAGE,
+  true,
+);
+
+if (failed) process.exit(1);


### PR DESCRIPTION
## Summary

Adds a corpus-wide mapped-line coverage invariant to the svelte2tsx source-map gate.

The existing structural checks accepted an empty map or a map containing only one source-bearing segment for a long generated file. A per-map threshold is not safe because valid official wrapper maps can contain zero mappings, so the new 75% floor is measured across the corpus population.

The pinned official converter measures 78.66% on that population; rsvelte measured 79.90% for entries both converters map. A failing aggregate records `__mapped-line-coverage__` in the existing shrink-only map ratchet.

## Validation

- `pnpm run test:svelte2tsx-map-coverage`
- `node --check scripts/compat-corpus/svelte2tsx-verify.mjs`
- `git diff --check`

A full corpus conversion was not re-run in this worktree because its generated artifacts are intentionally absent; calibration used the current root corpus and official svelte2tsx.