### PR TITLE
fix(napi): attest staged build commit

### DIFF
--- a/.changeset/napi-build-attestation.md
+++ b/.changeset/napi-build-attestation.md
@@ -1,0 +1,5 @@
+---
+'@rsvelte/vite-plugin-svelte-native': patch
+---
+
+Expose native build provenance and attest staged bindings against the commit embedded in the addon.

--- a/apps/npm/vite-plugin-svelte-native/index.cjs
+++ b/apps/npm/vite-plugin-svelte-native/index.cjs
@@ -284,6 +284,7 @@ module.exports.preprocess = binding.preprocess;
 module.exports.svelte2tsx = binding.svelte2tsx;
 module.exports.hmrDiff = binding.hmrDiff;
 module.exports.resolveId = binding.resolveId;
+module.exports.buildInfo = binding.buildInfo;
 // Standalone parse surfaces. `parse` returns a JSON string (decode with
 // `JSON.parse`); `parseEnvelope` returns the raw-transfer Buffer that skips
 // `JSON.parse` entirely — decode it with `decodeParseEnvelope` (re-exported

--- a/apps/npm/vite-plugin-svelte-native/index.d.ts
+++ b/apps/npm/vite-plugin-svelte-native/index.d.ts
@@ -101,6 +101,14 @@ export interface ModuleCompileOptions {
 	warningFilter?: (warning: Warning) => boolean;
 }
 
+/** Source revision embedded in the native addon at compile time. */
+export interface BuildInfo {
+	commit: string;
+	dirty: boolean;
+}
+
+export function buildInfo(): BuildInfo;
+
 // ---------------------------------------------------------------------------
 // Diagnostics
 // ---------------------------------------------------------------------------

--- a/crates/rsvelte_napi/build.rs
+++ b/crates/rsvelte_napi/build.rs
@@ -1,3 +1,35 @@
+use std::env;
+use std::path::Path;
+use std::process::Command;
+
+fn git(root: &Path, args: &[&str]) -> Option<String> {
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(root)
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    Some(String::from_utf8(output.stdout).ok()?.trim().to_owned())
+}
+
 fn main() {
     napi_build::setup();
+
+    let root = Path::new(env!("CARGO_MANIFEST_DIR")).join("../..");
+    let commit = git(&root, &["rev-parse", "HEAD"]).unwrap_or_else(|| "unknown".to_owned());
+    let dirty = git(&root, &["status", "--porcelain", "--untracked-files=no"])
+        .is_some_and(|status| !status.is_empty());
+    println!("cargo:rustc-env=RSVELTE_NAPI_BUILD_COMMIT={commit}");
+    println!("cargo:rustc-env=RSVELTE_NAPI_BUILD_DIRTY={dirty}");
+
+    if let Some(head) = git(&root, &["rev-parse", "--git-path", "HEAD"]) {
+        println!("cargo:rerun-if-changed={head}");
+    }
+    if let Some(reference) = git(&root, &["symbolic-ref", "-q", "HEAD"])
+        && let Some(path) = git(&root, &["rev-parse", "--git-path", &reference])
+    {
+        println!("cargo:rerun-if-changed={path}");
+    }
 }

--- a/crates/rsvelte_napi/src/lib.rs
+++ b/crates/rsvelte_napi/src/lib.rs
@@ -70,6 +70,21 @@ use rsvelte_projection::svelte2tsx::{
     svelte2tsx as rust_svelte2tsx,
 };
 
+#[napi(object)]
+pub struct NapiBuildInfo {
+    pub commit: String,
+    pub dirty: bool,
+}
+
+/// Build provenance embedded by `build.rs`, used to attest staged addons.
+#[napi(js_name = "buildInfo", catch_unwind)]
+pub fn napi_build_info() -> NapiBuildInfo {
+    NapiBuildInfo {
+        commit: env!("RSVELTE_NAPI_BUILD_COMMIT").to_owned(),
+        dirty: env!("RSVELTE_NAPI_BUILD_DIRTY") == "true",
+    }
+}
+
 /// Compile a Svelte component.
 /// Serialise compiler warnings into the JSON shape the official
 /// `svelte/compiler` output uses (`code`, `message`, `filename`, `start`, `end`,

--- a/scripts/compat-corpus/README.md
+++ b/scripts/compat-corpus/README.md
@@ -135,10 +135,9 @@ pnpm run corpus:sync        # init/update every corpus source submodule
 
 # build + stage the rsvelte NAPI binding
 cargo build --release -p rsvelte_napi --lib
-mkdir -p .corpus-cache && cp target/release/librsvelte_napi.{dylib,so} .corpus-cache/rsvelte.node.staging && mv .corpus-cache/rsvelte.node.staging .corpus-cache/rsvelte.node   # .so on Linux
-# Replace, never overwrite: a crashed loader keeps the old library mapped (macOS
-# ReportCrash holds it for seconds), and an in-place write then yields a binary the
-# kernel SIGKILLs. Rename lands a new inode, so the holder keeps the old file.
+node scripts/compat-corpus/binding.mjs --stage
+# This reads the commit embedded in the addon and refuses a target artifact that
+# was built from a different checkout before writing its provenance sidecar.
 
 pnpm run corpus             # sync + collect + compile + verify
 ```

--- a/scripts/compat-corpus/binding-load-probe.mjs
+++ b/scripts/compat-corpus/binding-load-probe.mjs
@@ -7,8 +7,14 @@ import path from 'node:path';
 const require = createRequire(import.meta.url);
 // Resolve first: require() reads a bare relative path as a module specifier.
 const binding = require(path.resolve(process.argv[2]));
+const buildInfo = binding.buildInfo?.();
+if (typeof buildInfo?.commit !== 'string' || typeof buildInfo?.dirty !== 'boolean') {
+	console.error('binding loaded but exposes no valid buildInfo()');
+	process.exit(1);
+}
 const out = binding.compile('<p>{1}</p>', { generate: 'client', dev: false, filename: 'C.svelte' });
 if (!out?.js?.code) {
 	console.error('binding loaded but produced no js output');
 	process.exit(1);
 }
+process.stdout.write(JSON.stringify(buildInfo));

--- a/scripts/compat-corpus/binding.mjs
+++ b/scripts/compat-corpus/binding.mjs
@@ -1,26 +1,9 @@
 /**
  * Provenance for the staged NAPI binding.
  *
- * `.corpus-cache/rsvelte.node` is a copied build artifact. Nothing in the file
- * records which source it was built from, it is per-worktree, and it survives
- * every checkout, rebase and branch switch — so a measurement can be attributed
- * to a commit that never produced it.
- *
- * mtime cannot answer this. A binding built before a fix and copied after it has
- * a newer mtime than the fix it lacks, which is the shape that shipped a fixed
- * crash as a live bug: staged 02:44, missing a fix committed at 16:26 the
- * previous day. mtime older than the base is sound evidence of staleness; mtime
- * newer is evidence of nothing.
- *
- * So record the commit at stage time and check it at use time. Absent a stamp
- * the answer is "unknown", which is treated as unusable for writing a ratchet —
- * a ratchet entry is a durable claim that a divergence exists in a given tree.
- *
- * The stamp is `stagedAtCommit`, never `builtFromCommit`: it records what was
- * checked out when the library was copied, which is a lower bound on its age and
- * not evidence of what compiled it. #2482 upgrades this to a real attestation by
- * having the build embed its own commit; until then the field name is the honest
- * one, because the name is what a reader three weeks from now will trust.
+ * The binary's `buildInfo()` export embeds its source commit at compile time.
+ * Staging reads it before writing the sidecar stamp, so a stale target artifact
+ * cannot be certified as the currently checked-out tree.
  */
 
 import fs from 'node:fs';
@@ -53,33 +36,32 @@ export function stageBinding(root) {
 			`no built library under target/release — run \`cargo build --release -p rsvelte_napi --lib\` first\n  looked for: ${candidates.map((p) => path.relative(root, p)).join(', ')}`
 		);
 	}
-	// mtime cannot show a binary is current, but it can show one is stale: a
-	// library older than the newest crates/ commit cannot contain it.
-	const lastCratesCommit = git(root, ['log', '-1', '--format=%ct', '--', 'crates']);
-	if (lastCratesCommit && fs.statSync(built).mtimeMs / 1000 < Number(lastCratesCommit)) {
-		throw new Error(
-			`${path.relative(root, built)} predates the newest commit touching crates/ — rebuild before staging, or the stamp would certify a binary that cannot contain it`
-		);
-	}
 	fs.mkdirSync(path.join(root, '.corpus-cache'), { recursive: true });
 	const dest = path.join(root, BINDING_REL);
+	// A failed attestation must not leave the prior binding's sidecar beside a
+	// newly copied artifact.
+	fs.rmSync(path.join(root, STAMP_REL), { force: true });
 	// Overwriting a loaded dylib in place leaves macOS holding a stale signature
 	// for the path and it SIGKILLs anything that loads it, so land a new inode.
 	const tmp = `${dest}.staging`;
 	fs.copyFileSync(built, tmp);
 	fs.renameSync(tmp, dest);
-	assertBindingLoads(root, dest);
-	return writeBindingProvenance(root);
+	try {
+		return writeBindingProvenance(root, dest);
+	} catch (error) {
+		fs.rmSync(dest, { force: true });
+		throw error;
+	}
 }
 
 /**
  * Stamping a binding that cannot load is the failure this whole module exists to
  * prevent, one level down: the attestation would outlive the thing it describes.
  */
-function assertBindingLoads(root, dest) {
+function readBuildInfo(root, dest) {
 	const probe = path.join(root, 'scripts/compat-corpus/binding-load-probe.mjs');
 	try {
-		execFileSync(process.execPath, [probe, dest], { stdio: ['ignore', 'ignore', 'pipe'] });
+		return JSON.parse(execFileSync(process.execPath, [probe, dest], { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] }));
 	} catch (e) {
 		fs.rmSync(dest, { force: true });
 		const signal = e?.signal ? ` (${e.signal})` : '';
@@ -89,15 +71,19 @@ function assertBindingLoads(root, dest) {
 	}
 }
 
-export function writeBindingProvenance(root) {
-	const stagedAtCommit = git(root, ['rev-parse', 'HEAD']);
-	if (!stagedAtCommit) throw new Error('cannot resolve HEAD to stamp the binding');
-	// A dirty crates/ tree means the binding may contain uncommitted work, which
-	// no commit id describes.
-	const dirty = (git(root, ['status', '--porcelain', '--', 'crates']) ?? '') !== '';
-	// Named for what it attests. This records the commit checked out when the
-	// library was copied, which is not evidence of what compiled it — see #2482.
-	const stamp = { stagedAtCommit, dirty, stagedAt: new Date().toISOString() };
+export function writeBindingProvenance(root, bindingPath = path.join(root, BINDING_REL)) {
+	const head = git(root, ['rev-parse', 'HEAD']);
+	if (!head) throw new Error('cannot resolve HEAD to attest the binding');
+	const buildInfo = readBuildInfo(root, bindingPath);
+	if (!/^[0-9a-f]{40}$/i.test(buildInfo?.commit ?? '')) {
+		throw new Error('the staged binding reports no git commit; rebuild it from a git checkout');
+	}
+	if (buildInfo.commit !== head) {
+		throw new Error(
+			`the staged binding was built from ${buildInfo.commit.slice(0, 8)}, not HEAD ${head.slice(0, 8)}; rebuild before staging`
+		);
+	}
+	const stamp = { builtFromCommit: buildInfo.commit, dirty: buildInfo.dirty, stagedAt: new Date().toISOString() };
 	fs.writeFileSync(path.join(root, STAMP_REL), JSON.stringify(stamp, null, '\t') + '\n');
 	return stamp;
 }
@@ -119,25 +105,25 @@ export function bindingProvenance(root) {
 	} catch {
 		return { state: 'unknown', detail: `${STAMP_REL} is unreadable` };
 	}
-	const at = stamp.stagedAtCommit;
+	const at = stamp.builtFromCommit;
 	if (typeof at !== 'string' || at === '') {
-		return { state: 'unknown', detail: `${STAMP_REL} records no stagedAtCommit` };
+		return { state: 'unknown', detail: `${STAMP_REL} records no builtFromCommit` };
 	}
 	if (stamp.dirty) {
-		return { state: 'dirty', detail: `staged at ${at.slice(0, 8)} with uncommitted changes under crates/` };
+		return { state: 'dirty', detail: `built from ${at.slice(0, 8)} with uncommitted changes` };
 	}
 	const known = git(root, ['rev-parse', '--verify', `${at}^{commit}`]);
 	if (!known) {
-		return { state: 'foreign', detail: `staged at ${at.slice(0, 8)}, which is not a commit in this repository` };
+		return { state: 'foreign', detail: `built from ${at.slice(0, 8)}, which is not a commit in this repository` };
 	}
 	const behind = git(root, ['rev-list', '--count', `${at}..HEAD`, '--', 'crates']);
 	if (behind && behind !== '0') {
 		return {
 			state: 'stale',
-			detail: `staged at ${at.slice(0, 8)}, which is ${behind} commit(s) touching crates/ behind HEAD`,
+			detail: `built from ${at.slice(0, 8)}, which is ${behind} commit(s) touching crates/ behind HEAD`,
 		};
 	}
-	return { state: 'ok', detail: `staged at ${at.slice(0, 8)}` };
+	return { state: 'ok', detail: `built from ${at.slice(0, 8)}` };
 }
 
 /** A reason string when the binding cannot back a durable claim, else null. */
@@ -152,7 +138,7 @@ if (process.argv[1] && process.argv[1].endsWith('binding.mjs') && process.argv.i
 	try {
 		const stamp = stageBinding(root);
 		console.log(
-			`[binding] staged at ${stamp.stagedAtCommit.slice(0, 8)}${stamp.dirty ? ' (DIRTY crates/)' : ''}`
+			`[binding] built from ${stamp.builtFromCommit.slice(0, 8)}${stamp.dirty ? ' (DIRTY)' : ''}`
 		);
 	} catch (e) {
 		console.error(`[binding] ${e.message}`);

--- a/scripts/dev/test-napi-compile-options.mjs
+++ b/scripts/dev/test-napi-compile-options.mjs
@@ -90,6 +90,12 @@ try {
 	process.exit(2);
 }
 
+const buildInfo = napi.buildInfo();
+assert(
+	'buildInfo() exposes an embedded commit and dirty flag',
+	typeof buildInfo?.commit === 'string' && /^[0-9a-f]{40}$/i.test(buildInfo.commit) && typeof buildInfo.dirty === 'boolean',
+);
+
 // ---------------------------------------------------------------------------
 // 1. The declared option surface (the denominator)
 // ---------------------------------------------------------------------------
@@ -133,6 +139,7 @@ const RESULT_STRUCTS = [
 	'NapiPosition',
 	'NapiWarning',
 	'CompileBuffersResult',
+	'NapiBuildInfo',
 	// `{ source, options }` — its `options` field is a NapiCompileOptions, already surveyed.
 	'CompileBatchInput',
 ];


### PR DESCRIPTION
## Summary

Embeds build provenance in the `rsvelte_napi` addon and makes staging attest the binary rather than infer freshness from filesystem timestamps.

- `build.rs` records the Git commit and dirty state; `buildInfo()` returns both through N-API.
- The staging probe reads `buildInfo()` from the copied addon and refuses a commit that differs from `HEAD`. It removes an old provenance sidecar before copying and removes an unattestable destination, so a failed attempt cannot leave a stale stamp beside a new binary.
- The provenance sidecar now uses `builtFromCommit`; docs use the attesting staging command.

## Validation

- `cargo check -p rsvelte_napi`
- `cargo build --release -p rsvelte_napi --lib`
- `node scripts/compat-corpus/binding.mjs --stage` → embedded `9a5cdb37`, dirty state reported as expected for this worktree
- `cargo clippy -p rsvelte_napi -- -D warnings`
- JS syntax checks and `git diff --check`