### PR TITLE
fix(transform): type offset lengths

### DIFF
--- a/.changeset/typed-offset-lengths.md
+++ b/.changeset/typed-offset-lengths.md
@@ -1,0 +1,5 @@
+---
+'@rsvelte/compiler': patch
+---
+
+Prevent character offsets from being combined with byte lengths during compiler transforms.

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/destructure_transforms.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/destructure_transforms.rs
@@ -360,12 +360,12 @@ pub(super) fn find_and_transform_one_destructure(
         // Compute rhs_end for each candidate to determine containment
         let rhs_ends: Vec<usize> = candidates
             .iter()
-            .map(|c| find_destructure_rhs_end(statement, c.eq_pos + 1).get())
+            .map(|c| find_destructure_rhs_end(statement, c.eq_pos.next()).get())
             .collect();
 
         let mut selected = 0; // default to first
         'outer: for (ci, c) in candidates.iter().enumerate() {
-            let rhs_start = (c.eq_pos + 1).get();
+            let rhs_start = c.eq_pos.next().get();
             let rhs_end = rhs_ends[ci];
             // Check if any other candidate's close_pos is inside this candidate's RHS range
             let mut contains_other = false;

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/shared/offsets.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/shared/offsets.rs
@@ -8,10 +8,8 @@
 //! would restore exactly the silence this removes. Every crossing goes through a
 //! named method and stays greppable.
 //!
-//! Two things this does **not** catch. `Add<usize>` accepts any `usize`, so
-//! `char_offset + name.len()` — a char offset advanced by a byte length — still
-//! compiles. And neither type carries provenance, so an offset measured against a
-//! trimmed copy still slices the original without complaint.
+//! Neither offset nor length carries provenance, so a value measured against a
+//! trimmed copy can still be used against the original string.
 
 use std::ops::{Add, Sub};
 
@@ -20,8 +18,46 @@ use std::ops::{Add, Sub};
 pub struct ByteOffset(usize);
 
 /// Offset in `char`s. Only these may index a `[char]`.
+///
+/// ```compile_fail
+/// use rsvelte_core::compiler::phases::phase3_transform::shared::offsets::CharOffset;
+///
+/// let _ = CharOffset::new(4) + "$名前".len();
+/// ```
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug, Hash)]
 pub struct CharOffset(usize);
+
+/// Length in bytes. Only this may advance a [`ByteOffset`].
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug, Hash)]
+pub struct ByteLen(usize);
+
+/// Length in `char`s. Only this may advance a [`CharOffset`].
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug, Hash)]
+pub struct CharLen(usize);
+
+impl ByteLen {
+    pub const ONE: Self = Self(1);
+
+    pub fn of(s: &str) -> Self {
+        Self(s.len())
+    }
+
+    pub fn get(self) -> usize {
+        self.0
+    }
+}
+
+impl CharLen {
+    pub const ONE: Self = Self(1);
+
+    pub fn of(s: &str) -> Self {
+        Self(s.chars().count())
+    }
+
+    pub fn get(self) -> usize {
+        self.0
+    }
+}
 
 impl ByteOffset {
     pub const ZERO: Self = Self(0);
@@ -36,7 +72,7 @@ impl ByteOffset {
 
     /// Byte offset one past the end of `s`.
     pub fn end_of(s: &str) -> Self {
-        Self(s.len())
+        Self(ByteLen::of(s).get())
     }
 
     pub fn before(self, s: &str) -> &str {
@@ -49,6 +85,10 @@ impl ByteOffset {
 
     pub fn to(self, end: Self, s: &str) -> &str {
         &s[self.0..end.0]
+    }
+
+    pub fn next(self) -> Self {
+        self + ByteLen::ONE
     }
 }
 
@@ -67,37 +107,36 @@ impl CharOffset {
         chars.get(self.0).copied()
     }
 
-    /// Length of `s` counted in the same unit, for comparing against an offset.
-    pub fn len_of(s: &str) -> Self {
-        Self(s.chars().count())
+    pub fn next(self) -> Self {
+        self + CharLen::ONE
     }
 }
 
-impl Add<usize> for ByteOffset {
+impl Add<ByteLen> for ByteOffset {
     type Output = Self;
-    fn add(self, n: usize) -> Self {
-        Self(self.0 + n)
+    fn add(self, n: ByteLen) -> Self {
+        Self(self.0 + n.0)
     }
 }
 
-impl Sub<usize> for ByteOffset {
+impl Sub<ByteLen> for ByteOffset {
     type Output = Self;
-    fn sub(self, n: usize) -> Self {
-        Self(self.0 - n)
+    fn sub(self, n: ByteLen) -> Self {
+        Self(self.0 - n.0)
     }
 }
 
-impl Add<usize> for CharOffset {
+impl Add<CharLen> for CharOffset {
     type Output = Self;
-    fn add(self, n: usize) -> Self {
-        Self(self.0 + n)
+    fn add(self, n: CharLen) -> Self {
+        Self(self.0 + n.0)
     }
 }
 
-impl Sub<usize> for CharOffset {
+impl Sub<CharLen> for CharOffset {
     type Output = Self;
-    fn sub(self, n: usize) -> Self {
-        Self(self.0 - n)
+    fn sub(self, n: CharLen) -> Self {
+        Self(self.0 - n.0)
     }
 }
 
@@ -158,5 +197,13 @@ mod tests {
         let s = "あ";
         let table = CharToByte::new(s);
         assert_eq!(table.byte(CharOffset::new(9)), ByteOffset::new(3));
+    }
+
+    #[test]
+    fn lengths_only_advance_offsets_in_the_same_unit() {
+        let chars = CharOffset::new(4) + CharLen::of("$名前");
+        let bytes = ByteOffset::new(4) + ByteLen::of("$名前");
+        assert_eq!(chars.get(), 7);
+        assert_eq!(bytes.get(), 11);
     }
 }


### PR DESCRIPTION
## Summary

Closes #2404 by making offset arithmetic unit-safe in the one current Phase 3 consumer.

- Adds `ByteLen` and `CharLen`; only matching lengths can add to/subtract from their offsets.
- Removes `Add<usize>`/`Sub<usize>` from both offset types and provides explicit `next()` for single-character/byte movement.
- Converts the two CharOffset stepping sites to `next()`.
- Adds a unit test for the multibyte `$名前` measurement and a compile-fail doctest proving `CharOffset + str::len()` is rejected.

The scan found only 45 offset references, all in the destructure scanner/shared offset module; the only old offset arithmetic was the two explicit `+ 1` steps.

## Validation

- `cargo test -p rsvelte_core offsets::tests --lib`
- `cargo test -p rsvelte_core --doc`
- `cargo check -p rsvelte_core`
- `cargo clippy -p rsvelte_core --lib -- -D warnings`
- `git diff --check`