### PR TITLE
fix: preserve unicode pseudo-element arguments

### DIFF
--- a/.changeset/fix-unicode-pseudo-element-arguments.md
+++ b/.changeset/fix-unicode-pseudo-element-arguments.md
@@ -1,0 +1,5 @@
+---
+'@rsvelte/compiler': patch
+---
+
+Prevent Unicode pseudo-element arguments from panicking CSS compilation.

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/css.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/css.rs
@@ -7411,7 +7411,7 @@ fn format_simple_selector_with_scope(
                     if remaining.starts_with('(') {
                         // Find the matching closing parenthesis
                         let mut depth = 0;
-                        for (i, c) in remaining.chars().enumerate() {
+                        for (i, c) in remaining.char_indices() {
                             if c == '(' {
                                 depth += 1;
                             } else if c == ')' {

--- a/crates/rsvelte_core/tests/css_pseudo_element_unicode_2378.rs
+++ b/crates/rsvelte_core/tests/css_pseudo_element_unicode_2378.rs
@@ -1,0 +1,22 @@
+use rsvelte_core::{CompileOptions, GenerateMode, compile};
+
+#[test]
+fn preserves_unicode_pseudo_element_arguments() {
+    let source = "<style>::view-transition-group(あ) { color: red }</style>";
+
+    for generate in [GenerateMode::Client, GenerateMode::Server] {
+        let result = compile(
+            source,
+            CompileOptions {
+                generate,
+                ..Default::default()
+            },
+        )
+        .expect("unicode pseudo-element argument should compile");
+
+        assert_eq!(
+            result.css.expect("style output").code,
+            "::view-transition-group(あ) { color: red }"
+        );
+    }
+}


### PR DESCRIPTION
Fixes #2378.

`format_simple_selector_with_scope` used a character index from `chars().enumerate()` as a byte endpoint while preserving pseudo-element arguments. A non-ASCII argument to `::view-transition-group(...)` therefore panicked CSS compilation.

The scan now uses `char_indices()`. The regression compiles the reproducer in both client and server modes and checks the CSS against the official output.