### PR TITLE
fix(check): reject symlinked overlay cache paths

### DIFF
--- a/.changeset/quiet-overlay-symlinks.md
+++ b/.changeset/quiet-overlay-symlinks.md
@@ -1,0 +1,5 @@
+---
+'@rsvelte/svelte-check': patch
+---
+
+Reject symlinked overlay output paths before writing generated files.

--- a/crates/rsvelte_check/src/svelte_check/overlay.rs
+++ b/crates/rsvelte_check/src/svelte_check/overlay.rs
@@ -465,7 +465,9 @@ pub fn materialize_overlay_with(
 ) -> Result<OverlayLayout, OverlayError> {
     let cache_dir = workspace.join(".svelte-check");
     let emit_dir = cache_dir.join("svelte");
+    reject_symlink_components(&cache_dir)?;
     fs::create_dir_all(&emit_dir)?;
+    reject_symlink_components(&emit_dir)?;
     let manifest_path = cache_dir.join("manifest.json");
     let namespace = compiler_opts.projection_namespace();
     let accessors = compiler_opts.projection_accessors();
@@ -597,7 +599,9 @@ pub fn materialize_overlay_with(
         // still goes through the `.d.svelte.ts` bridge.
         let emit_dts_twin = ext == ".tsx";
         if let Some(parent) = tsx_path.parent() {
+            reject_symlink_components(parent)?;
             fs::create_dir_all(parent)?;
+            reject_symlink_components(parent)?;
         }
         remove_stale_counterpart(&tsx_path, ext);
         if !emit_dts_twin {
@@ -1408,6 +1412,30 @@ fn append_extension(rel: &Path, extra: &str) -> PathBuf {
     let mut s = rel.as_os_str().to_owned();
     s.push(extra);
     PathBuf::from(s)
+}
+
+/// Refuse an overlay path once an existing component redirects filesystem
+/// operations through a symlink. The cache must never write outside itself.
+fn reject_symlink_components(path: &Path) -> io::Result<()> {
+    let mut current = PathBuf::new();
+    for component in path.components() {
+        current.push(component.as_os_str());
+        match fs::symlink_metadata(&current) {
+            Ok(metadata) if metadata.file_type().is_symlink() => {
+                return Err(io::Error::new(
+                    io::ErrorKind::PermissionDenied,
+                    format!(
+                        "overlay cache path contains a symlink: {}",
+                        current.display()
+                    ),
+                ));
+            }
+            Ok(_) => {}
+            Err(error) if error.kind() == io::ErrorKind::NotFound => {}
+            Err(error) => return Err(error),
+        }
+    }
+    Ok(())
 }
 
 /// Rebase `abs` under `base` for use as an emit path, guaranteeing the
@@ -3907,6 +3935,36 @@ mod tests {
         );
 
         let _ = fs::remove_dir_all(&tmp);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn rejects_symlinked_cache_paths_without_writing_outside_workspace() {
+        use std::os::unix::fs::symlink;
+
+        let tmp = std::env::temp_dir().join(format!("svc_overlay_symlink_{}", std::process::id()));
+        let outside =
+            std::env::temp_dir().join(format!("svc_overlay_outside_{}", std::process::id()));
+        let _ = fs::remove_dir_all(&tmp);
+        let _ = fs::remove_dir_all(&outside);
+        fs::create_dir_all(tmp.join("src")).unwrap();
+        fs::create_dir_all(&outside).unwrap();
+        fs::write(tmp.join("src/App.svelte"), "<div />").unwrap();
+
+        symlink(&outside, tmp.join(".svelte-check")).unwrap();
+        let err = materialize_overlay(&tmp, &[tmp.join("src/App.svelte")], None).unwrap_err();
+        assert!(err.to_string().contains("contains a symlink"));
+        assert!(!outside.join("svelte").exists());
+
+        fs::remove_file(tmp.join(".svelte-check")).unwrap();
+        fs::create_dir_all(tmp.join(".svelte-check/svelte")).unwrap();
+        symlink(&outside, tmp.join(".svelte-check/svelte/src")).unwrap();
+        let err = materialize_overlay(&tmp, &[tmp.join("src/App.svelte")], None).unwrap_err();
+        assert!(err.to_string().contains("contains a symlink"));
+        assert!(!outside.join("App.svelte.jsx").exists());
+
+        let _ = fs::remove_dir_all(&tmp);
+        let _ = fs::remove_dir_all(&outside);
     }
 
     #[test]


### PR DESCRIPTION
Resolves debt-list item 002.

Reject symlinks in `.svelte-check` and nested emit paths before writing generated overlay artifacts. A Unix regression test verifies both cache and nested-output links cannot create files outside the workspace.

Verified:
- `cargo test -p rsvelte_check rejects_symlinked_cache_paths_without_writing_outside_workspace --lib`
- `cargo clippy -p rsvelte_check --lib -- -D warnings`