### PR TITLE
fix(server): preserve dev snippet guard order

### DIFF
--- a/.changeset/fix-server-dev-snippet-guard-order.md
+++ b/.changeset/fix-server-dev-snippet-guard-order.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/compiler": patch
+---
+
+Preserve declaration order for dev SSR snippet stringification guards.

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/visitors/snippet_block.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/visitors/snippet_block.rs
@@ -124,9 +124,14 @@ pub fn visit_snippet_block<'a>(node: &SnippetBlock<'a>, state: &mut ServerTransf
     } else {
         if state.options.dev {
             state
-                .snippet_inits
-                .push(b.stmt(b.call("$.prevent_snippet_stringification", vec![b.id(&name)])));
-            state.snippet_inits.push(fn_decl);
+                .template
+                .push(super::shared::TemplateEntry::HoistableDecl(b.stmt(b.call(
+                    "$.prevent_snippet_stringification",
+                    vec![b.id(&name)],
+                ))));
+            state
+                .template
+                .push(super::shared::TemplateEntry::HoistableDecl(fn_decl));
         } else {
             state
                 .template

--- a/crates/rsvelte_core/tests/server_dev_snippet_guards_2610.rs
+++ b/crates/rsvelte_core/tests/server_dev_snippet_guards_2610.rs
@@ -35,3 +35,16 @@ fn default_component_children_get_server_dev_stringification_guard() {
         "{output}"
     );
 }
+
+#[test]
+fn non_hoistable_snippet_guard_keeps_declaration_tag_order() {
+    let output = compile_server_dev("{#if true}{@const xx = test}{#snippet test()}{/snippet}{/if}");
+    let constant = output.find("const xx = test;").expect("const declaration");
+    let guard = output
+        .find("$.prevent_snippet_stringification(test);")
+        .expect("snippet guard");
+    assert!(
+        constant < guard,
+        "the guard must retain its source order after earlier declaration tags:\n{output}"
+    );
+}


### PR DESCRIPTION
## Summary
- emit non-hoistable server-dev snippet stringification guards in template declaration order
- retain the preceding `{@const}` before its snippet guard
- add a focused server-dev regression

## Verification
- `cargo fmt --check`
- `RUST_MIN_STACK=33554432 cargo test -p rsvelte_core --test server_dev_snippet_guards_2610`
- `cargo clippy -p rsvelte_core --all-targets --all-features -- -D warnings`
- `pnpm run corpus:compile:ssr-dev && pnpm run corpus:verify:ssr-dev` (14,198 entries; green, artifacts cleaned)
- `pnpm run corpus:matrix` (22,931 comparisons; no regressions; 872 known divergences)