### PR TITLE
fix(corpus): remove duplicate server-dev target

### DIFF
--- a/.changeset/fix-corpus-server-dev-target.md
+++ b/.changeset/fix-corpus-server-dev-target.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/compiler": patch
+---
+
+Fix corpus mutation accounting for the server development target.

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
 		"test:corpus-generation": "node scripts/dev/test-corpus-generation-guard.mjs",
 		"test:mutant-classification": "node scripts/dev/test-mutant-classification.mjs",
 		"test:mutation-baseline-provenance": "node scripts/dev/test-mutation-baseline-provenance.mjs",
+		"test:corpus-targets": "node scripts/dev/test-corpus-targets.mjs",
 		"test:known-failures-md-check": "node scripts/dev/test-known-failures-md-check.mjs",
 		"test:release-comment": "node scripts/dev/test-release-comment.mjs",
 		"test:css-prune-verdict": "node scripts/dev/test-css-prune-sweep-warning-verdict.mjs",

--- a/scripts/compat-corpus/targets.mjs
+++ b/scripts/compat-corpus/targets.mjs
@@ -98,21 +98,6 @@ export const TARGETS = [
 		errorFrameBaseline: 'error-frame-known-failures.client-dev.json',
 		parseBaseline: 'parse-known-failures.client-dev.json',
 	},
-	{
-		key: 'server-dev',
-		generate: 'server',
-		dev: true,
-		css: false,
-		baseline: 'known-failures.server-dev.json',
-		warningBaseline: 'warning-known-failures.server-dev.json',
-		warningPositionBaseline: 'warning-position-known-failures.server-dev.json',
-		warningMessageBaseline: 'warning-message-known-failures.server-dev.json',
-		errorMessageBaseline: 'error-message-known-failures.server-dev.json',
-		errorPositionBaseline: 'error-position-known-failures.server-dev.json',
-		errorEndBaseline: 'error-end-known-failures.server-dev.json',
-		errorFrameBaseline: 'error-frame-known-failures.server-dev.json',
-		parseBaseline: 'parse-known-failures.server-dev.json',
-	},
 ];
 
 export const TARGET_KEYS = TARGETS.map((t) => t.key);

--- a/scripts/dev/test-corpus-targets.mjs
+++ b/scripts/dev/test-corpus-targets.mjs
@@ -1,0 +1,18 @@
+#!/usr/bin/env node
+
+import assert from 'node:assert/strict';
+import { TARGETS, TARGET_KEYS } from '../compat-corpus/targets.mjs';
+
+assert.equal(
+	new Set(TARGET_KEYS).size,
+	TARGET_KEYS.length,
+	`duplicate corpus targets: ${TARGET_KEYS.join(', ')}`,
+);
+assert.equal(
+	TARGETS.length,
+	TARGET_KEYS.length,
+	'mutation accounting must run each configured target exactly once',
+);
+assert.deepEqual(TARGET_KEYS, ['client', 'server', 'server-dev', 'client-dev']);
+
+console.log(`[test-corpus-targets] ✅ ${TARGET_KEYS.length} unique targets: ${TARGET_KEYS.join(', ')}`);


### PR DESCRIPTION
## Summary
- remove the duplicate `server-dev` corpus target descriptor
- add a target-list invariant so mutation accounting cannot enroll a target twice

## Verification
- `pnpm run test:corpus-targets`
- `node --check scripts/compat-corpus/targets.mjs`
- `node --check scripts/compat-corpus/mutate-corpus.mjs`