### PR TITLE
fix: restore server-dev corpus coverage

### DIFF
--- a/.changeset/fix-corpus-server-dev-target.md
+++ b/.changeset/fix-corpus-server-dev-target.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/compiler": patch
+---
+
+Fix corpus mutation accounting for the server development target.

--- a/.changeset/fix-server-dev-snippet-guard-order.md
+++ b/.changeset/fix-server-dev-snippet-guard-order.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/compiler": patch
+---
+
+Preserve declaration order for dev SSR snippet stringification guards.

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/visitors/snippet_block.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/visitors/snippet_block.rs
@@ -124,9 +124,14 @@ pub fn visit_snippet_block<'a>(node: &SnippetBlock<'a>, state: &mut ServerTransf
     } else {
         if state.options.dev {
             state
-                .snippet_inits
-                .push(b.stmt(b.call("$.prevent_snippet_stringification", vec![b.id(&name)])));
-            state.snippet_inits.push(fn_decl);
+                .template
+                .push(super::shared::TemplateEntry::HoistableDecl(b.stmt(b.call(
+                    "$.prevent_snippet_stringification",
+                    vec![b.id(&name)],
+                ))));
+            state
+                .template
+                .push(super::shared::TemplateEntry::HoistableDecl(fn_decl));
         } else {
             state
                 .template

--- a/crates/rsvelte_core/tests/server_dev_snippet_guards_2610.rs
+++ b/crates/rsvelte_core/tests/server_dev_snippet_guards_2610.rs
@@ -35,3 +35,16 @@ fn default_component_children_get_server_dev_stringification_guard() {
         "{output}"
     );
 }
+
+#[test]
+fn non_hoistable_snippet_guard_keeps_declaration_tag_order() {
+    let output = compile_server_dev("{#if true}{@const xx = test}{#snippet test()}{/snippet}{/if}");
+    let constant = output.find("const xx = test;").expect("const declaration");
+    let guard = output
+        .find("$.prevent_snippet_stringification(test);")
+        .expect("snippet guard");
+    assert!(
+        constant < guard,
+        "the guard must retain its source order after earlier declaration tags:\n{output}"
+    );
+}

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
 		"test:corpus-generation": "node scripts/dev/test-corpus-generation-guard.mjs",
 		"test:mutant-classification": "node scripts/dev/test-mutant-classification.mjs",
 		"test:mutation-baseline-provenance": "node scripts/dev/test-mutation-baseline-provenance.mjs",
+		"test:corpus-targets": "node scripts/dev/test-corpus-targets.mjs",
 		"test:known-failures-md-check": "node scripts/dev/test-known-failures-md-check.mjs",
 		"test:release-comment": "node scripts/dev/test-release-comment.mjs",
 		"test:css-prune-verdict": "node scripts/dev/test-css-prune-sweep-warning-verdict.mjs",

--- a/scripts/compat-corpus/targets.mjs
+++ b/scripts/compat-corpus/targets.mjs
@@ -98,21 +98,6 @@ export const TARGETS = [
 		errorFrameBaseline: 'error-frame-known-failures.client-dev.json',
 		parseBaseline: 'parse-known-failures.client-dev.json',
 	},
-	{
-		key: 'server-dev',
-		generate: 'server',
-		dev: true,
-		css: false,
-		baseline: 'known-failures.server-dev.json',
-		warningBaseline: 'warning-known-failures.server-dev.json',
-		warningPositionBaseline: 'warning-position-known-failures.server-dev.json',
-		warningMessageBaseline: 'warning-message-known-failures.server-dev.json',
-		errorMessageBaseline: 'error-message-known-failures.server-dev.json',
-		errorPositionBaseline: 'error-position-known-failures.server-dev.json',
-		errorEndBaseline: 'error-end-known-failures.server-dev.json',
-		errorFrameBaseline: 'error-frame-known-failures.server-dev.json',
-		parseBaseline: 'parse-known-failures.server-dev.json',
-	},
 ];
 
 export const TARGET_KEYS = TARGETS.map((t) => t.key);

--- a/scripts/dev/test-corpus-targets.mjs
+++ b/scripts/dev/test-corpus-targets.mjs
@@ -1,0 +1,18 @@
+#!/usr/bin/env node
+
+import assert from 'node:assert/strict';
+import { TARGETS, TARGET_KEYS } from '../compat-corpus/targets.mjs';
+
+assert.equal(
+	new Set(TARGET_KEYS).size,
+	TARGET_KEYS.length,
+	`duplicate corpus targets: ${TARGET_KEYS.join(', ')}`,
+);
+assert.equal(
+	TARGETS.length,
+	TARGET_KEYS.length,
+	'mutation accounting must run each configured target exactly once',
+);
+assert.deepEqual(TARGET_KEYS, ['client', 'server', 'server-dev', 'client-dev']);
+
+console.log(`[test-corpus-targets] ✅ ${TARGET_KEYS.length} unique targets: ${TARGET_KEYS.join(', ')}`);


### PR DESCRIPTION
## Summary
- preserve non-hoistable server-dev snippet guard declaration order
- remove the duplicate `server-dev` target that ran mutation accounting twice
- add targeted regressions for both behaviors

## Verification
- `pnpm run test:corpus-targets`
- `RUST_MIN_STACK=33554432 cargo test -p rsvelte_core --test server_dev_snippet_guards_2610`
- `cargo fmt --check`
- `cargo clippy -p rsvelte_core --all-targets --all-features -- -D warnings`

A full corpus/matrix run requires a clean staged NAPI binding and initialized corpus submodules; this fresh checkout has 1.9 GiB free, below the corpus artifact preflight budget.