### PR TITLE
ci: gate output-preserving corpus changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1135,6 +1135,9 @@ jobs:
       - name: Run workflow trigger guard tests
         run: node scripts/ci/test-workflow-trigger-guard.mjs
 
+      - name: Run differential corpus workflow tests
+        run: node scripts/ci/test-differential-corpus-workflow.mjs
+
   prereq-coverage-guard:
     name: Prerequisite coverage guard
     runs-on: ubuntu-latest

--- a/.github/workflows/differential-corpus.yml
+++ b/.github/workflows/differential-corpus.yml
@@ -1,0 +1,98 @@
+name: Differential corpus output preservation
+
+# This is intentionally opt-in. A compiler change that claims to preserve
+# output can request the `output-preserving` label and is then measured against
+# the exact merge ref it would land on, rather than a base that may move while
+# the PR waits in the queue.
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.sha }}
+  cancel-in-progress: true
+
+env:
+  CARGO_PROFILE_RELEASE_LTO: "off"
+  CARGO_PROFILE_RELEASE_CODEGEN_UNITS: "16"
+
+jobs:
+  differential-corpus:
+    name: Output-preserving corpus diff
+    if: contains(github.event.pull_request.labels.*.name, 'output-preserving')
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      # `refs/pull/.../merge` is the current merge ref. Checking out the head
+      # would make this a stale-base check again whenever main advances.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: refs/pull/${{ github.event.pull_request.number }}/merge
+          fetch-depth: 1
+          submodules: false
+
+      - uses: ./.github/actions/setup-rust
+
+      - uses: ./.github/actions/setup-node-pnpm
+
+      - name: Checkout corpus source submodules (shallow)
+        run: pnpm run corpus:sync
+
+      - name: Collect the corpus once for both compiler builds
+        run: node scripts/compat-corpus/collect.mjs
+
+      - name: Build current-merge compiler hash binary
+        run: |
+          cargo build --release -p rsvelte_devtools --bin corpus_hash --target-dir .differential/target/arm
+          mkdir -p .differential/bin
+          cp .differential/target/arm/release/corpus_hash .differential/bin/arm-corpus-hash
+
+      - name: Build base rsvelte_core with the current merge-ref harness
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          set -euo pipefail
+          git fetch --no-tags --depth=1 origin "$BASE_SHA"
+          mkdir -p .differential/base-tree
+          git archive "$BASE_SHA" crates/rsvelte_core | tar -x -C .differential/base-tree
+
+          restore_core() {
+            git restore --source=HEAD --staged --worktree crates/rsvelte_core
+          }
+          trap restore_core EXIT
+          rm -rf crates/rsvelte_core
+          mv .differential/base-tree/crates/rsvelte_core crates/rsvelte_core
+          cargo build --release -p rsvelte_devtools --bin corpus_hash --target-dir .differential/target/base
+          cp .differential/target/base/release/corpus_hash .differential/bin/base-corpus-hash
+          restore_core
+          trap - EXIT
+          git diff --exit-code -- crates/rsvelte_core Cargo.lock
+
+      - name: Prove a changed core produced two distinct binaries
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          set -euo pipefail
+          if ! git diff --quiet "$BASE_SHA" HEAD -- crates/rsvelte_core; then
+            base_hash=$(sha256sum .differential/bin/base-corpus-hash | awk '{print $1}')
+            arm_hash=$(sha256sum .differential/bin/arm-corpus-hash | awk '{print $1}')
+            test "$base_hash" != "$arm_hash"
+          fi
+
+      - name: Diff every compiler output target
+        run: |
+          set -euo pipefail
+          for target in client server client-dev server-dev; do
+            case "$target" in
+              client) args=() ;;
+              server) args=(--server) ;;
+              client-dev) args=(--dev) ;;
+              server-dev) args=(--server --dev) ;;
+            esac
+            .differential/bin/base-corpus-hash compatibility/sources --label base "${args[@]}" > ".differential/base-$target.txt"
+            .differential/bin/arm-corpus-hash compatibility/sources --label arm "${args[@]}" > ".differential/arm-$target.txt"
+            node scripts/dev/diff-corpus-hash.mjs ".differential/base-$target.txt" ".differential/arm-$target.txt"
+          done

--- a/compatibility/gate-coverage.md
+++ b/compatibility/gate-coverage.md
@@ -108,11 +108,30 @@ samples) — see `AGENTS.md` § "Generated shape matrix" and issue #2281.
 | 22 | NAPI option boundary | per declared option key: baseline vs. one-key variant, through the raw addon | it never compares against **official** — a key wired to the wrong semantics stays green | [S] |
 | 23 | Escaped-quote lookback shape | one line of Rust source, over every `.rs` under `crates/` + `apps/` | it matches a **spelling**; a scanner with *no* escape check at all produces no line to match | [D] |
 | 24 | `await_waterfall` runtime parity | the `await_waterfall` warnings a **mounted** rsvelte-compiled component logs vs. official's, 3 cases | one warning code, one component shape; nothing else about the running component is observed | [D] |
+| 25 | Differential output-preservation corpus hash | per `.svelte` source × client/server/client-dev/server-dev hash from base-core vs merge-ref-core | changes outside `crates/rsvelte_core`; every PR without the maintainer-applied `output-preserving` label | [S] |
 
 Cross-cutting blind spots (**ratchet keys losing in both directions**, path filters, ratchet-doc
 drift, vacuity floors, the **performance**
 gates' population, and **an uninitialised corpus source shrinking every corpus gate silently**)
 are in [§ Cross-cutting](#cross-cutting) at the end.
+
+## 25. Differential output-preservation corpus hash
+
+**Unit.** For every collected `.svelte` source and each of the four compiler targets, the
+`corpus_hash` rows from a binary built with the merge-ref harness plus base
+`crates/rsvelte_core` are compared to a binary built from the same merge ref. The job is
+`.github/workflows/differential-corpus.yml`; `scripts/dev/diff-corpus-hash.mjs` rejects equal
+labels, target mismatches and file-count mismatches instead of treating them as a zero diff.
+
+**Blind spot 25a — the opt-in population.** Only PRs carrying `output-preserving` run this job:
+the job condition reads the PR label in `differential-corpus.yml`, and the workflow only
+observes source in `crates/rsvelte_core` when it makes its base arm (`git archive "$BASE_SHA"
+crates/rsvelte_core`). An output-preserving change in another crate, or a core change whose
+author does not request the label, receives no differential measurement. This is intentional:
+the ordinary four-target official parity gate covers every compiler change, while forcing a
+second full sweep on every docs-only PR would worsen the branch-update queue it is meant to make
+evidence robust against. **Evidence [S]:** the label condition and base archive command in
+`differential-corpus.yml` are the respective filters.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
 		"test:bot-branch-guard": "node scripts/ci/test-bot-branch-guard.mjs",
 		"check:workflow-triggers": "node scripts/ci/workflow-trigger-guard.mjs",
 		"test:workflow-trigger-guard": "node scripts/ci/test-workflow-trigger-guard.mjs",
+		"test:differential-corpus-workflow": "node scripts/ci/test-differential-corpus-workflow.mjs",
 		"check:prereq-coverage": "node scripts/ci/prereq-coverage-guard.mjs",
 		"test:prereq-coverage-guard": "node scripts/ci/test-prereq-coverage-guard.mjs",
 		"test:esrap-version-gate": "node scripts/release/test-esrap-version-bump-check.mjs",

--- a/scripts/ci/test-differential-corpus-workflow.mjs
+++ b/scripts/ci/test-differential-corpus-workflow.mjs
@@ -1,0 +1,36 @@
+#!/usr/bin/env node
+// Keep the output-preserving job from silently degrading into a head-only or
+// same-binary comparison. The controls are deliberately structural: this is a
+// workflow contract, not a compiler test.
+
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const workflow = readFileSync(join(here, '..', '..', '.github', 'workflows', 'differential-corpus.yml'), 'utf8');
+
+let failures = 0;
+function check(name, condition) {
+	if (condition) console.log(`  ok   ${name}`);
+	else {
+		failures++;
+		console.error(`  FAIL ${name}`);
+	}
+}
+
+console.log('differential corpus workflow self-test');
+check('uses the explicit opt-in label', /contains\(github\.event\.pull_request\.labels\.\*\.name, 'output-preserving'\)/.test(workflow));
+check('reruns when the label changes or the PR synchronizes', /types: \[opened, synchronize, reopened, labeled, unlabeled\]/.test(workflow));
+check('checks out the current merge ref', /ref: refs\/pull\/\$\{\{ github\.event\.pull_request\.number \}\}\/merge/.test(workflow));
+check('archives only the base core source', /git archive "\$BASE_SHA" crates\/rsvelte_core/.test(workflow));
+check('uses isolated base and arm target directories', /--target-dir \.differential\/target\/arm/.test(workflow) && /--target-dir \.differential\/target\/base/.test(workflow));
+check('requires distinct binary hashes when core changed', /git diff --quiet "\$BASE_SHA" HEAD -- crates\/rsvelte_core/.test(workflow) && /sha256sum \.differential\/bin\/base-corpus-hash/.test(workflow) && /test "\$base_hash" != "\$arm_hash"/.test(workflow));
+check('diffs all four targets', /for target in client server client-dev server-dev/.test(workflow));
+check('maps server to the server flag', /server\) args=\(--server\)/.test(workflow));
+check('maps client-dev to the dev flag', /client-dev\) args=\(--dev\)/.test(workflow));
+check('maps server-dev to both flags', /server-dev\) args=\(--server --dev\)/.test(workflow));
+check('uses the labelled differential harness', /node scripts\/dev\/diff-corpus-hash\.mjs/.test(workflow) && /--label base/.test(workflow) && /--label arm/.test(workflow));
+
+console.log(failures === 0 ? '\nall checks passed' : `\n${failures} failure(s)`);
+process.exit(failures === 0 ? 0 : 1);

--- a/scripts/compat-corpus/README.md
+++ b/scripts/compat-corpus/README.md
@@ -644,6 +644,16 @@ node scripts/compat-corpus/svelte2tsx-cluster.mjs            # size the burn-dow
   pin automatically refreshes the corpus *and* its expectations; the fmt oracle
   is cached by a combined hash of all source SHAs + the `pattern` source's file
   contents + oxfmt + config.
+- `.github/workflows/differential-corpus.yml` — an opt-in guard for a PR marked
+  `output-preserving`. It checks out the PR's **current merge ref**, builds the
+  current `corpus_hash` harness once with the merge ref's core and once with
+  only `crates/rsvelte_core` substituted from the base, requires distinct binary
+  hashes when that core changed, then compares all four targets. It is not a
+  general parity gate: it deliberately cannot see output changes outside
+  `rsvelte_core`, and a maintainer must add the label. The label avoids making
+  every docs-only PR pay for a second whole-corpus sweep; it does not make a
+  repeatedly updated branch cheaper, because each update correctly reruns the
+  merge-ref measurement.
 - Source bumps arrive via `auto-update-submodules.yml` (weekly PR per submodule —
   svelte.dev and each real-world project) and `auto-update-svelte.yml` (the
   compiler). Both trigger corpus-compat through its submodule path filters, which


### PR DESCRIPTION
## Summary

- add label-gated differential corpus hashing on the current PR merge ref
- build the same merge-ref harness with base and arm `rsvelte_core`, asserting distinct binaries when core changes
- compare client, server, client-dev, and server-dev output hashes; document the intentional opt-in blind spot and branch-update cost

## Validation

- `node scripts/ci/test-differential-corpus-workflow.mjs`
- `node scripts/ci/workflow-trigger-guard.mjs`
- `node scripts/ci/test-workflow-trigger-guard.mjs`
- `cargo check -p rsvelte_devtools --bin corpus_hash --target-dir .differential/check-target`
- YAML parse and `git diff --check`

Closes #2647.