### PR TITLE
fix: rewrite shadowed state updates from AST

### DIFF
--- a/.changeset/gray-shadowed-state-updates.md
+++ b/.changeset/gray-shadowed-state-updates.md
@@ -1,0 +1,5 @@
+---
+'@rsvelte/compiler': patch
+---
+
+Rewrite updates of shadowed local `$state` bindings through the AST pipeline.

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
@@ -7603,24 +7603,16 @@ fn apply_local_state_transforms(func_body: &str, var_name: &str, is_state: bool)
     result = state_reads_ast::transform_state_reads_ast(&result, &[var_name.to_string()], &[])
         .unwrap_or(result);
 
-    // Apply $.update() for `var++`, `var--`, `++var`, `--var` patterns
-    // These must be applied BEFORE $.set() transforms since `x++` should become `$.update(x)`
-    // not `$.set(x, $.get(x)++, true)`
-    let update_patterns = [
-        (format!("{}++", var_name), format!("$.update({})", var_name)),
-        (
-            format!("{}--", var_name),
-            format!("$.update({}, -1)", var_name),
-        ),
-        (format!("++{}", var_name), format!("$.update({})", var_name)),
-        (
-            format!("--{}", var_name),
-            format!("$.update({}, -1)", var_name),
-        ),
-    ];
-
-    for (from, to) in &update_patterns {
-        result = replace_standalone_pattern(&result, from, to);
+    // Updates must precede sets, so `x++` becomes `$.update(x)` rather than
+    // a set around an update target. The AST pass keeps tokens in literals and
+    // comments out of this rewrite.
+    if let Some(transformed) = reactive_update_ast::transform_reactive_update_ast(
+        &result,
+        &[],
+        &[var_name.to_string()],
+        &[],
+    ) {
+        result = transformed;
     }
 
     // Apply $.set() for direct assignments (only for $state, not $derived)
@@ -7628,37 +7620,6 @@ fn apply_local_state_transforms(func_body: &str, var_name: &str, is_state: bool)
         result = apply_local_set_transforms(&result, var_name);
     }
 
-    result
-}
-
-/// Replace a pattern only when it appears as a standalone expression.
-fn replace_standalone_pattern(text: &str, from: &str, to: &str) -> String {
-    let mut result = String::new();
-    let mut search_from = 0;
-
-    while let Some(pos) = text[search_from..].find(from) {
-        let abs_pos = search_from + pos;
-        let before_ok = abs_pos == 0 || {
-            let b = text.as_bytes()[abs_pos - 1];
-            !b.is_ascii_alphanumeric() && b != b'_' && b != b'$' && b != b'.'
-        };
-        let after_pos = abs_pos + from.len();
-        let after_ok = after_pos >= text.len() || {
-            let b = text.as_bytes()[after_pos];
-            !b.is_ascii_alphanumeric() && b != b'_'
-        };
-
-        if before_ok && after_ok {
-            result.push_str(&text[search_from..abs_pos]);
-            result.push_str(to);
-            search_from = after_pos;
-        } else {
-            let next = crate::compiler::utils::next_char_boundary(text, abs_pos);
-            result.push_str(&text[search_from..next]);
-            search_from = next;
-        }
-    }
-    result.push_str(&text[search_from..]);
     result
 }
 

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/reactive_update_ast.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/reactive_update_ast.rs
@@ -84,7 +84,10 @@ fn transform_reactive_update_spliced(
         &MODULE_REACTIVE_UPDATE_ALLOC,
         source,
         SourceType::mjs(),
-        ParseOptions::default(),
+        ParseOptions {
+            allow_return_outside_function: true,
+            ..ParseOptions::default()
+        },
         false,
         |program| {
             let mut collector = ReactiveUpdateCollector {
@@ -355,7 +358,10 @@ pub(crate) fn transform_reactive_update_in_place(
         &MODULE_REACTIVE_UPDATE_IN_PLACE_ALLOC,
         source,
         SourceType::mjs(),
-        ParseOptions::default(),
+        ParseOptions {
+            allow_return_outside_function: true,
+            ..ParseOptions::default()
+        },
         |allocator, program| {
             let mut rewriter = ReactiveUpdateRewriter {
                 b: crate::compiler::phases::phase3_transform::builders::B::new(allocator),

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/tests.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/tests.rs
@@ -2134,46 +2134,22 @@ export function useInterval(callback, delay) {
     );
 }
 
-/// Discriminating. `replace_standalone_pattern` is called with needles like
-/// `format!("{var}++")`, whose first character is the identifier — so a rejected
-/// match advanced the cursor one *byte* into a multi-byte name and the next
-/// slice split it. A member increment must be rejected, which is exactly the
-/// branch that advances.
 #[test]
-fn a_rejected_match_advances_by_a_whole_character() {
-    assert_eq!(
-        replace_standalone_pattern("x.\u{540d}\u{524d}++;", "\u{540d}\u{524d}++", "REPLACED"),
-        "x.\u{540d}\u{524d}++;"
+fn shadowed_state_updates_do_not_rewrite_literal_tokens() {
+    let output = apply_local_state_transforms(
+        r#"{
+const sample = "multiplier++";
+return {
+	prefix: () => ++multiplier,
+	post: () => multiplier++
+};
+}"#,
+        "multiplier",
+        true,
     );
-}
-
-/// The same rejection through the other guard (`after_ok`), so the fix cannot
-/// be passed by handling only the `before_ok` path.
-#[test]
-fn a_rejected_match_advances_by_a_whole_character_on_the_trailing_guard() {
-    assert_eq!(
-        replace_standalone_pattern("\u{540d}\u{524d}++x;", "\u{540d}\u{524d}++", "REPLACED"),
-        "\u{540d}\u{524d}++x;"
-    );
-}
-
-/// Control on the other side: an accepted match must still be replaced, so a
-/// "fix" that rejected everything would fail here.
-#[test]
-fn an_accepted_non_ascii_match_is_still_replaced() {
-    assert_eq!(
-        replace_standalone_pattern("\u{540d}\u{524d}++;", "\u{540d}\u{524d}++", "REPLACED"),
-        "REPLACED;"
-    );
-}
-
-/// Control: byte and character steps coincide, so this passed before the fix.
-#[test]
-fn an_ascii_rejected_match_is_unchanged() {
-    assert_eq!(
-        replace_standalone_pattern("x.count++;", "count++", "REPLACED"),
-        "x.count++;"
-    );
+    assert!(output.contains(r#"const sample = "multiplier++";"#));
+    assert!(output.contains("$.update_pre(multiplier)"));
+    assert!(output.contains("$.update(multiplier)"));
 }
 
 /// A `}` or `)` inside a comment is comment text. Read as a bracket it drops the


### PR DESCRIPTION
## Summary

- route updates of shadowed local `$state` bindings through the existing AST update rewriter
- preserve `++`/`--` tokens in literals, comments, and other non-expression syntax
- emit the correct prefix-update helper for `++state` / `--state`

## Root cause

The shadowed-local recovery path still replaced update tokens by scanning strings after the main instance-script transform. It rewrote matching text inside literals and treated prefix updates as postfix updates.

## Validation

- `RUST_MIN_STACK=33554432 cargo test -p rsvelte_core shadowed_state_updates_do_not_rewrite_literal_tokens --lib -- --nocapture`
- `RUST_MIN_STACK=33554432 cargo test -p rsvelte_core shadowed_local_state_updates_use_ast_rewrite --lib -- --nocapture`
- `cargo fmt --check`
- `cargo clippy -p rsvelte_core --lib -- -D warnings`
- full four-target corpus compile and `verify.mjs --update-baseline` (14,197 entries; no ratchet changes)
- `pnpm run corpus:matrix:update` (no ratchet changes)
