### PR TITLE
feat(lint): carry globals configuration

### DIFF
--- a/.changeset/cyan-lint-globals-contract.md
+++ b/.changeset/cyan-lint-globals-contract.md
@@ -1,0 +1,5 @@
+---
+'@rsvelte/lint': patch
+---
+
+Preserve Oxlint-compatible globals and environment configuration across lint hosts.

--- a/apps/npm/lint/README.md
+++ b/apps/npm/lint/README.md
@@ -96,6 +96,8 @@ explicitly:
     "svelte/button-has-type": ["warn", { "submit": true, "reset": false }],
     "svelte/no-restricted-html-elements": ["error", { "elements": ["marquee"] }]
   },
+  "env": { "browser": true },
+  "globals": { "BUILD_ID": "readonly" },
   "files": ["src/**/*.svelte"],
   "ignores": ["**/generated/**"]
 }
@@ -116,6 +118,14 @@ explicitly:
   over the path relative to the working directory. An empty `files` list
   matches every candidate passed on the command line; `ignores` always wins
   over `files`.
+- **`env`** / **`globals`** — an Oxlint-compatible globals contract retained
+  by every lint host (CLI, language server, wasm and NAPI). `env` is a map of
+  environment names to booleans; an explicit map replaces the default
+  `builtin` environment. Each `globals` value is `"readonly"`, `"writable"`,
+  `"off"`, or the ESLint-compatible boolean/legacy spellings (`false` /
+  `"readable"`, `true` / `"writeable"`). These settings are intentionally
+  parsed before the undefined-variable rule is enabled: no rule will guess an
+  environment from an unresolved identifier.
 
 Run `--list-rules` to see every native rule's id, category, default severity,
 and whether it's autofixable; rules with an options schema are marked
@@ -143,7 +153,8 @@ npx rsvelte-lint --print-eslint-config > eslint.rsvelte.json
 ```
 
 `--config-from-eslint <file>` statically parses an ESLint flat config and
-imports its `svelte/*` rule severities as overrides on top of your
+imports its `svelte/*` rule severities plus literal
+`languageOptions.globals` entries as overrides on top of your
 `rsvelte-lint.json` (or the recommended preset if you have none).
 `--print-eslint-config` prints a flat-config object disabling every
 `rsvelte-lint`-owned rule id in ESLint; spread it into your `eslint.config.js`.

--- a/crates/rsvelte_lint/src/config.rs
+++ b/crates/rsvelte_lint/src/config.rs
@@ -21,6 +21,84 @@ use serde_json::Value;
 
 use crate::rule::{RuleMeta, Severity};
 
+/// Whether an explicitly configured global may be assigned to.
+///
+/// This is intentionally the same value vocabulary as Oxlint and ESLint's
+/// legacy config: `false`/`"readable"` mean readonly, `true`/`"writeable"`
+/// mean writable, and `"off"` removes an environment global. Keeping the
+/// original distinction matters for a future `no-undef`/write diagnostic.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GlobalValue {
+    Readonly,
+    Writable,
+    Off,
+}
+
+impl GlobalValue {
+    fn parse(value: &Value) -> Option<Self> {
+        match value {
+            Value::Bool(true) => Some(Self::Writable),
+            Value::Bool(false) => Some(Self::Readonly),
+            Value::String(value) => match value.as_str() {
+                "readonly" | "readable" => Some(Self::Readonly),
+                "writable" | "writeable" => Some(Self::Writable),
+                "off" => Some(Self::Off),
+                _ => None,
+            },
+            _ => None,
+        }
+    }
+}
+
+/// Globals and environments selected for a lint run.
+///
+/// The engine records this complete configuration now, before `no-undef` is
+/// enabled. That rule must consult an authoritative environment database rather
+/// than treating every unresolved OXC reference as an error.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GlobalConfig {
+    values: HashMap<String, GlobalValue>,
+    environments: HashMap<String, bool>,
+}
+
+impl Default for GlobalConfig {
+    fn default() -> Self {
+        Self {
+            values: HashMap::new(),
+            // Oxlint treats the ECMAScript builtin environment as enabled by
+            // default. An explicit `env` object replaces that default.
+            environments: HashMap::from([(String::from("builtin"), true)]),
+        }
+    }
+}
+
+impl GlobalConfig {
+    /// The configured mode for `name`, including an explicit `"off"`.
+    pub fn value(&self, name: &str) -> Option<GlobalValue> {
+        self.values.get(name).copied()
+    }
+
+    /// Whether the named environment is enabled.
+    pub fn environment_enabled(&self, name: &str) -> bool {
+        self.environments.get(name).copied().unwrap_or(false)
+    }
+
+    /// Iterate over enabled environment names.
+    pub fn enabled_environments(&self) -> impl Iterator<Item = &str> {
+        self.environments
+            .iter()
+            .filter_map(|(name, enabled)| enabled.then_some(name.as_str()))
+    }
+
+    fn set_global(&mut self, name: String, value: GlobalValue) {
+        self.values.insert(name, value);
+    }
+
+    fn set_environment(&mut self, name: String, enabled: bool) {
+        self.environments.insert(name, enabled);
+    }
+}
+
 /// Built-in preset names accepted in `extends`.
 const PRESET_NONE: &[&str] = &["none", "off", "empty"];
 
@@ -40,6 +118,10 @@ pub struct LintConfig {
     /// Glob patterns excluding files from linting. Takes precedence over
     /// `files`.
     ignores: Vec<String>,
+    /// Explicit globals and enabled environments. Native rules do not consume
+    /// this yet; retaining it is the contract needed before `no-undef` can be
+    /// made correct across the CLI, language server, wasm and NAPI bindings.
+    globals: GlobalConfig,
 }
 
 impl LintConfig {
@@ -67,6 +149,23 @@ impl LintConfig {
     pub fn with_options(mut self, rule: impl Into<String>, options: Value) -> Self {
         self.options.insert(rule.into(), options);
         self
+    }
+
+    /// Add, override, or disable one global in the Oxlint/ESLint vocabulary.
+    pub fn with_global(mut self, name: impl Into<String>, value: GlobalValue) -> Self {
+        self.globals.set_global(name.into(), value);
+        self
+    }
+
+    /// Enable or disable an Oxlint-compatible named environment.
+    pub fn with_environment(mut self, name: impl Into<String>, enabled: bool) -> Self {
+        self.globals.set_environment(name.into(), enabled);
+        self
+    }
+
+    /// Globals/environment settings preserved for semantic rules.
+    pub fn globals(&self) -> &GlobalConfig {
+        &self.globals
     }
 
     /// Resolve the effective severity for a native rule (default comes from its
@@ -182,6 +281,8 @@ impl LintConfig {
 
         config.files = string_array(obj.get("files"));
         config.ignores = string_array(obj.get("ignores"));
+        config.globals = parse_globals(obj.get("globals"))?;
+        config.globals.environments = parse_environments(obj.get("env"))?;
 
         Ok(config)
     }
@@ -216,6 +317,40 @@ fn string_array(v: Option<&Value>) -> Vec<String> {
             .collect(),
         _ => Vec::new(),
     }
+}
+
+fn parse_globals(value: Option<&Value>) -> anyhow::Result<GlobalConfig> {
+    let Some(value) = value else {
+        return Ok(GlobalConfig::default());
+    };
+    let object = value
+        .as_object()
+        .ok_or_else(|| anyhow::anyhow!("globals must be a JSON object"))?;
+    let mut globals = GlobalConfig::default();
+    for (name, value) in object {
+        let value = GlobalValue::parse(value).ok_or_else(|| {
+            anyhow::anyhow!("globals.{name} must be 'readonly', 'writable', 'off', or a boolean")
+        })?;
+        globals.set_global(name.clone(), value);
+    }
+    Ok(globals)
+}
+
+fn parse_environments(value: Option<&Value>) -> anyhow::Result<HashMap<String, bool>> {
+    let Some(value) = value else {
+        return Ok(GlobalConfig::default().environments);
+    };
+    let object = value
+        .as_object()
+        .ok_or_else(|| anyhow::anyhow!("env must be a JSON object"))?;
+    let mut environments = HashMap::new();
+    for (name, value) in object {
+        let enabled = value
+            .as_bool()
+            .ok_or_else(|| anyhow::anyhow!("env.{name} must be a boolean"))?;
+        environments.insert(name.clone(), enabled);
+    }
+    Ok(environments)
 }
 
 /// A small gitignore-flavoured glob matcher over `/`-separated paths.
@@ -335,5 +470,35 @@ mod tests {
         assert!(cfg.should_lint("src/Foo.svelte"));
         assert!(!cfg.should_lint("other/Foo.svelte"));
         assert!(!cfg.should_lint("src/_Private.svelte"));
+    }
+
+    #[test]
+    fn globals_and_env_follow_oxlint_value_semantics() {
+        let cfg = LintConfig::from_json_str(
+            r#"{
+                "env": { "browser": true, "node": false },
+                "globals": {
+                    "BUILD_ID": "readonly",
+                    "mutableCache": true,
+                    "Promise": "off"
+                }
+            }"#,
+        )
+        .unwrap();
+        assert_eq!(cfg.globals().value("BUILD_ID"), Some(GlobalValue::Readonly));
+        assert_eq!(
+            cfg.globals().value("mutableCache"),
+            Some(GlobalValue::Writable)
+        );
+        assert_eq!(cfg.globals().value("Promise"), Some(GlobalValue::Off));
+        assert!(cfg.globals().environment_enabled("browser"));
+        assert!(!cfg.globals().environment_enabled("node"));
+        assert!(!cfg.globals().environment_enabled("builtin"));
+    }
+
+    #[test]
+    fn malformed_globals_and_env_are_config_errors() {
+        assert!(LintConfig::from_json_str(r#"{ "globals": { "x": "yes" } }"#).is_err());
+        assert!(LintConfig::from_json_str(r#"{ "env": { "browser": "yes" } }"#).is_err());
     }
 }

--- a/crates/rsvelte_lint/src/eslint_import.rs
+++ b/crates/rsvelte_lint/src/eslint_import.rs
@@ -1,7 +1,7 @@
-//! `--config-from-eslint` — statically read `svelte/*` rule severities out of
-//! an existing `eslint.config.js` / `.mjs` flat config, so an ESLint-migrating
-//! project keeps its severities with zero re-authoring (design doc §D course
-//! correction 3).
+//! `--config-from-eslint` — statically read `svelte/*` rule severities and
+//! configured globals out of an existing `eslint.config.js` / `.mjs` flat
+//! config, so an ESLint-migrating project keeps its Svelte rule severities and
+//! global contract with zero re-authoring.
 //!
 //! This is a *static* extraction: we parse the config with OXC and walk every
 //! `ObjectExpression` for a `rules` property, collecting string-keyed entries
@@ -20,7 +20,7 @@ use oxc_ast_visit::{Visit, walk};
 use oxc_parser::Parser;
 use oxc_span::SourceType;
 
-use crate::rule::Severity;
+use crate::{config::GlobalValue, rule::Severity};
 
 thread_local! {
     static ESLINT_ALLOC: RefCell<Allocator> = RefCell::new(Allocator::default());
@@ -29,30 +29,52 @@ thread_local! {
 /// Extract `(rule_id, severity)` pairs for the `svelte/*` namespace from a flat
 /// config source. Returns an empty vec on parse failure.
 pub fn import_svelte_rules(source: &str) -> Vec<(String, Severity)> {
+    import_svelte_config(source).rules
+}
+
+/// The statically knowable subset of an ESLint flat config that rsvelte-lint
+/// owns. Dynamic object spreads and imported config objects remain deliberately
+/// out of scope: evaluating user configuration would make a native CLI depend
+/// on a JavaScript runtime.
+#[derive(Debug, Default, PartialEq, Eq)]
+pub struct ImportedEslintConfig {
+    pub rules: Vec<(String, Severity)>,
+    pub globals: Vec<(String, GlobalValue)>,
+}
+
+/// Extract Svelte rule severities and `languageOptions.globals` entries from an
+/// ESLint flat config. Later object literals win, matching flat config layering
+/// for the static shapes this importer can observe.
+pub fn import_svelte_config(source: &str) -> ImportedEslintConfig {
     ESLINT_ALLOC.with(|cell| {
         let allocator = std::mem::take(&mut *cell.borrow_mut());
-        let rules = extract(&allocator, source);
+        let config = extract(&allocator, source);
         *cell.borrow_mut() = allocator;
-        rules
+        config
     })
 }
 
-fn extract(allocator: &Allocator, source: &str) -> Vec<(String, Severity)> {
+fn extract(allocator: &Allocator, source: &str) -> ImportedEslintConfig {
     // Flat configs are usually ESM (`export default [...]`); retry as a script
     // (CJS `module.exports = [...]`) if the module parse errors.
     for source_type in [SourceType::mjs(), SourceType::cjs()] {
         let ret = Parser::new(allocator, source, source_type).parse();
         if ret.diagnostics.is_empty() {
-            let mut collector = Collector { rules: Vec::new() };
+            let mut collector = Collector::default();
             collector.visit_program(&ret.program);
-            return collector.rules;
+            return ImportedEslintConfig {
+                rules: collector.rules,
+                globals: collector.globals,
+            };
         }
     }
-    Vec::new()
+    ImportedEslintConfig::default()
 }
 
+#[derive(Default)]
 struct Collector {
     rules: Vec<(String, Severity)>,
+    globals: Vec<(String, GlobalValue)>,
 }
 
 impl<'a> Visit<'a> for Collector {
@@ -61,11 +83,21 @@ impl<'a> Visit<'a> for Collector {
             let ObjectPropertyKind::ObjectProperty(prop) = prop else {
                 continue;
             };
-            if prop.computed || property_key_name(&prop.key) != Some("rules") {
+            if prop.computed {
                 continue;
             }
-            if let Expression::ObjectExpression(rules_obj) = &prop.value {
-                self.collect_rules(rules_obj);
+            match property_key_name(&prop.key) {
+                Some("rules") => {
+                    if let Expression::ObjectExpression(rules_obj) = &prop.value {
+                        self.collect_rules(rules_obj);
+                    }
+                }
+                Some("languageOptions") => {
+                    if let Expression::ObjectExpression(options) = &prop.value {
+                        self.collect_language_options(options);
+                    }
+                }
+                _ => {}
             }
         }
         walk::walk_object_expression(self, obj);
@@ -89,6 +121,51 @@ impl Collector {
             }
             if let Some(sev) = severity_of(&prop.value) {
                 self.rules.push((key.to_string(), sev));
+            }
+        }
+    }
+
+    fn collect_globals(&mut self, globals_obj: &ObjectExpression) {
+        for prop in &globals_obj.properties {
+            let ObjectPropertyKind::ObjectProperty(prop) = prop else {
+                continue;
+            };
+            if prop.computed {
+                continue;
+            }
+            let Some(name) = property_key_name(&prop.key) else {
+                continue;
+            };
+            let value = match &prop.value {
+                Expression::BooleanLiteral(value) => {
+                    if value.value {
+                        GlobalValue::Writable
+                    } else {
+                        GlobalValue::Readonly
+                    }
+                }
+                Expression::StringLiteral(value) => match value.value.as_str() {
+                    "readonly" | "readable" => GlobalValue::Readonly,
+                    "writable" | "writeable" => GlobalValue::Writable,
+                    "off" => GlobalValue::Off,
+                    _ => continue,
+                },
+                _ => continue,
+            };
+            self.globals.push((name.to_string(), value));
+        }
+    }
+
+    fn collect_language_options(&mut self, options: &ObjectExpression) {
+        for prop in &options.properties {
+            let ObjectPropertyKind::ObjectProperty(prop) = prop else {
+                continue;
+            };
+            if prop.computed || property_key_name(&prop.key) != Some("globals") {
+                continue;
+            }
+            if let Expression::ObjectExpression(globals_obj) = &prop.value {
+                self.collect_globals(globals_obj);
             }
         }
     }
@@ -156,5 +233,26 @@ mod tests {
     fn ignores_non_svelte_and_unparseable() {
         assert!(import_svelte_rules("this is not valid <<< js").is_empty());
         assert!(import_svelte_rules("export default [{ rules: { 'no-console': 2 } }];").is_empty());
+    }
+
+    #[test]
+    fn imports_flat_config_globals_in_oxlint_compatible_form() {
+        let imported = import_svelte_config(
+            r#"
+                export default [
+                    { languageOptions: { globals: { BUILD_ID: 'readonly', cache: true } } },
+                    { languageOptions: { globals: { BUILD_ID: 'off', legacy: false } } }
+                ];
+            "#,
+        );
+        assert_eq!(
+            imported.globals,
+            vec![
+                ("BUILD_ID".to_string(), GlobalValue::Readonly),
+                ("cache".to_string(), GlobalValue::Writable),
+                ("BUILD_ID".to_string(), GlobalValue::Off),
+                ("legacy".to_string(), GlobalValue::Readonly),
+            ]
+        );
     }
 }

--- a/crates/rsvelte_lint/src/main.rs
+++ b/crates/rsvelte_lint/src/main.rs
@@ -34,7 +34,7 @@ struct Cli {
     #[arg(long, value_name = "FILE")]
     config: Option<PathBuf>,
 
-    /// Import `svelte/*` rule severities from an existing ESLint flat config.
+    /// Import `svelte/*` rule severities and configured globals from an existing ESLint flat config.
     #[arg(long, value_name = "FILE")]
     config_from_eslint: Option<PathBuf>,
 
@@ -123,8 +123,12 @@ fn build_config(cli: &Cli, workspace: &Path) -> anyhow::Result<LintConfig> {
     if let Some(eslint_path) = &cli.config_from_eslint {
         let text = std::fs::read_to_string(eslint_path)
             .map_err(|e| anyhow::anyhow!("failed to read {}: {e}", eslint_path.display()))?;
-        for (rule, severity) in rsvelte_lint::eslint_import::import_svelte_rules(&text) {
+        let imported = rsvelte_lint::eslint_import::import_svelte_config(&text);
+        for (rule, severity) in imported.rules {
             cfg = cfg.with_override(rule, severity);
+        }
+        for (name, value) in imported.globals {
+            cfg = cfg.with_global(name, value);
         }
     }
 

--- a/crates/rsvelte_lint_bindings/src/napi.rs
+++ b/crates/rsvelte_lint_bindings/src/napi.rs
@@ -7,7 +7,7 @@
 //! loaded (native-first, wasm-fallback) by `@rsvelte/oxlint-plugin`.
 //!
 //! The `js_name` on each export pins the snake_case names (`lint`,
-//! `lint_rules`) so callers use one property name regardless of engine — napi
+//! `lint_with_config`, `lint_rules`) so callers use one property name regardless of engine — napi
 //! would otherwise camelCase `lint_rules` to `lintRules`.
 //!
 //! `catch_unwind` on each export is load-bearing, not decorative: napi-rs only
@@ -35,6 +35,14 @@ use napi_derive::napi;
 #[napi(js_name = "lint", catch_unwind)]
 pub fn lint(source: String, filename: String) -> String {
     rsvelte_lint::json_api::lint(&source, &filename)
+}
+
+/// Lint under a caller-supplied `rsvelte-lint.json` document. This mirrors the
+/// wasm binding so hosts can share globals/environment configuration regardless
+/// of which engine was selected.
+#[napi(js_name = "lint_with_config", catch_unwind)]
+pub fn lint_with_config(source: String, filename: String, config: String) -> String {
+    rsvelte_lint::json_api::lint_with_config(&source, &filename, &config)
 }
 
 /// The full catalog of diagnostic ids [`lint`] can emit (see


### PR DESCRIPTION
## Summary

- retain Oxlint-compatible `env` and `globals` settings in `LintConfig`
- import literal `languageOptions.globals` values from ESLint flat configs
- expose `lint_with_config` through NAPI, matching the wasm binding

## Why

A correct Svelte `no-undef` must distinguish unresolved names from ECMAScript, environment, and project globals. This establishes the shared configuration contract before enabling that rule, so existing projects do not receive guessed-environment false positives.

## Validation

- `cargo fmt --check`
- `cargo test -p rsvelte_lint --lib config::tests`
- `cargo test -p rsvelte_lint --lib eslint_import::tests`
- `cargo clippy -p rsvelte_lint --lib --features eslint-import -- -D warnings`
- `cargo check -p rsvelte_lint_bindings --features napi --no-default-features -q`