### PR TITLE
feat(lint): add semantic no-undef rule

### DIFF
--- a/.changeset/semantic-svelte-no-undef.md
+++ b/.changeset/semantic-svelte-no-undef.md
@@ -1,0 +1,5 @@
+---
+'@rsvelte/lint': patch
+---
+
+Add opt-in `svelte/no-undef` diagnostics for unresolved component-script references.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1214,6 +1214,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "javascript-globals"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c5f4cff6dd96f6045e5e53d52ef114724989508a83e0dd72eea795844390297"
+dependencies = [
+ "phf 0.14.0",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2606,12 +2615,14 @@ dependencies = [
  "clap",
  "codspeed-criterion-compat",
  "compact_str 0.10.0",
+ "javascript-globals",
  "oxc_allocator",
  "oxc_ast",
  "oxc_ast_visit",
  "oxc_parser",
  "oxc_semantic",
  "oxc_span",
+ "oxc_syntax",
  "rayon",
  "regex",
  "rsvelte_core",

--- a/crates/rsvelte_lint/Cargo.toml
+++ b/crates/rsvelte_lint/Cargo.toml
@@ -64,6 +64,8 @@ oxc_ast = "0.143"
 oxc_ast_visit = { version = "0.143", optional = true }
 oxc_span = "0.143"
 oxc_semantic = "0.143"
+oxc_syntax = "0.143"
+javascript-globals = "1.5.1"
 
 [dev-dependencies]
 criterion = { version = "5.0.0", features = [

--- a/crates/rsvelte_lint/src/compiler_scope.rs
+++ b/crates/rsvelte_lint/src/compiler_scope.rs
@@ -26,6 +26,7 @@ use oxc_ast::AstKind;
 use oxc_parser::{ParseOptions, Parser};
 use oxc_semantic::{IsGlobalReference, SemanticBuilder};
 use oxc_span::{GetSpan, SourceType};
+use oxc_syntax::operator::UnaryOperator;
 
 /// The scope facts a lint rule needs about one `<script>` body. See the module
 /// docs for how each field is used.
@@ -42,6 +43,18 @@ pub struct ScriptScope {
     /// Names declared in the script's **root** (module / instance top-level)
     /// scope — the bindings visible to the component's template.
     pub root_binding_names: Vec<String>,
+    /// Unresolved runtime references in this script, relative to its body.
+    pub unresolved_references: Vec<UnresolvedReference>,
+}
+
+/// An unresolved value reference emitted by OXC semantic analysis.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UnresolvedReference {
+    pub name: String,
+    pub start: u32,
+    pub end: u32,
+    pub in_typeof: bool,
+    pub arguments_in_function: bool,
 }
 
 /// Resolve the scope facts for one `<script>` body via a single oxc semantic
@@ -57,6 +70,76 @@ pub struct ScriptScope {
 /// and a script ESLint accepts parses cleanly here anyway (both this and
 /// `svelte-eslint-parser` sit on a standard JS/TS grammar).
 pub fn resolve_script_scope(script_src: &str, is_ts: bool) -> ScriptScope {
+    with_semantic(script_src, is_ts, |semantic| {
+        let scoping = semantic.scoping();
+        let mut non_global_spans = Vec::new();
+        for node in semantic.nodes().iter() {
+            match node.kind() {
+                AstKind::IdentifierReference(ident) if !ident.is_global_reference(scoping) => {
+                    let span = ident.span();
+                    non_global_spans.push((span.start, span.end));
+                }
+                AstKind::BindingIdentifier(ident) => {
+                    let span = ident.span();
+                    non_global_spans.push((span.start, span.end));
+                }
+                _ => {}
+            }
+        }
+        let root_scope = scoping.root_scope_id();
+        let root_binding_names = scoping
+            .symbol_ids()
+            .filter(|&id| scoping.symbol_scope_id(id) == root_scope)
+            .map(|id| scoping.symbol_name(id).to_string())
+            .collect();
+        let mut unresolved_references = Vec::new();
+        for ids in scoping.root_unresolved_references_ids() {
+            for id in ids {
+                let reference = scoping.get_reference(id);
+                if reference.is_type() {
+                    continue;
+                }
+                let node = semantic.nodes().get_node(reference.node_id());
+                let AstKind::IdentifierReference(ident) = node.kind() else {
+                    continue;
+                };
+                let in_typeof = is_typeof(node, semantic);
+                let arguments_in_function = ident.name.as_str() == "arguments"
+                    && scoping
+                        .scope_ancestors(reference.scope_id())
+                        .map(|scope| scoping.scope_flags(scope))
+                        .any(|flags| flags.is_function() && !flags.is_arrow());
+                unresolved_references.push(UnresolvedReference {
+                    name: ident.name.to_string(),
+                    start: ident.span.start,
+                    end: ident.span.end,
+                    in_typeof,
+                    arguments_in_function,
+                });
+            }
+        }
+        ScriptScope {
+            non_global_spans,
+            root_binding_names,
+            unresolved_references,
+        }
+    })
+}
+
+fn is_typeof(node: &oxc_semantic::AstNode<'_>, semantic: &oxc_semantic::Semantic<'_>) -> bool {
+    let parent = semantic.nodes().parent_node(node.id());
+    match parent.kind() {
+        AstKind::UnaryExpression(expr) => expr.operator == UnaryOperator::Typeof,
+        AstKind::ParenthesizedExpression(_) => is_typeof(parent, semantic),
+        _ => false,
+    }
+}
+
+fn with_semantic<T>(
+    script_src: &str,
+    is_ts: bool,
+    f: impl FnOnce(&oxc_semantic::Semantic<'_>) -> T,
+) -> T {
     let allocator = Allocator::default();
     let source_type = if is_ts {
         SourceType::ts().with_module(true)
@@ -79,37 +162,7 @@ pub fn resolve_script_scope(script_src: &str, is_ts: bool) -> ScriptScope {
         .with_build_nodes(true)
         .build(program)
         .semantic;
-    let scoping = semantic.scoping();
-
-    let mut non_global_spans = Vec::new();
-    for node in semantic.nodes().iter() {
-        match node.kind() {
-            // A read that resolves to a local binding (not a global).
-            AstKind::IdentifierReference(ident) if !ident.is_global_reference(scoping) => {
-                let span = ident.span();
-                non_global_spans.push((span.start, span.end));
-            }
-            // Every declaration site — never a global reference.
-            AstKind::BindingIdentifier(ident) => {
-                let span = ident.span();
-                non_global_spans.push((span.start, span.end));
-            }
-            _ => {}
-        }
-    }
-
-    // Root-scope declarations are the names a component's template can read.
-    let root_scope = scoping.root_scope_id();
-    let root_binding_names = scoping
-        .symbol_ids()
-        .filter(|&id| scoping.symbol_scope_id(id) == root_scope)
-        .map(|id| scoping.symbol_name(id).to_string())
-        .collect();
-
-    ScriptScope {
-        non_global_spans,
-        root_binding_names,
-    }
+    f(&semantic)
 }
 
 #[cfg(test)]

--- a/crates/rsvelte_lint/src/context.rs
+++ b/crates/rsvelte_lint/src/context.rs
@@ -180,6 +180,11 @@ impl<'a> LintContext<'a> {
         self.source
     }
 
+    /// The resolved file configuration.
+    pub fn config(&self) -> &'a LintConfig {
+        self.config
+    }
+
     /// The source slice for a byte range, clamped to the source bounds.
     pub fn slice(&self, start: u32, end: u32) -> &'a str {
         let (s, e) = (start as usize, end as usize);

--- a/crates/rsvelte_lint/src/engine.rs
+++ b/crates/rsvelte_lint/src/engine.rs
@@ -191,12 +191,13 @@ fn run_over_programs(
 /// an extra oxc semantic pass, so the engine only pays for it when this rule is
 /// enabled.
 pub(crate) const SCOPE_RESOLVER_RULE: &str = "svelte/no-top-level-browser-globals";
+pub(crate) const NO_UNDEF_RULE: &str = "svelte/no-undef";
 
 /// Whether any enabled script rule needs the (oxc-semantic-backed) resolver.
 fn needs_scope_resolver(enabled: &[EnabledScriptRule<'_>]) -> bool {
     enabled
         .iter()
-        .any(|(_, meta, _)| meta.name == SCOPE_RESOLVER_RULE)
+        .any(|(_, meta, _)| matches!(meta.name, SCOPE_RESOLVER_RULE | NO_UNDEF_RULE))
 }
 
 /// Build the scope resolver from a component's `<script>` block(s). Each
@@ -243,7 +244,8 @@ pub(crate) fn maybe_scope_resolver(
     config: &LintConfig,
 ) -> Option<ScopeResolver> {
     // Mirrors the rule's own `config.severity_for(&META)` (its default is Warn).
-    (config.resolve_code(SCOPE_RESOLVER_RULE, Severity::Warn) != Severity::Off)
+    (config.resolve_code(SCOPE_RESOLVER_RULE, Severity::Warn) != Severity::Off
+        || config.resolve_code(NO_UNDEF_RULE, Severity::Off) != Severity::Off)
         .then(|| scope_resolver_for_root(root, source))
 }
 

--- a/crates/rsvelte_lint/src/registry.rs
+++ b/crates/rsvelte_lint/src/registry.rs
@@ -184,6 +184,7 @@ pub fn all_script_rules() -> Vec<Box<dyn crate::script::ScriptRule>> {
     use crate::rules::no_reactive_reassign::NoReactiveReassign;
     use crate::rules::no_store_async::NoStoreAsync;
     use crate::rules::no_top_level_browser_globals::NoTopLevelBrowserGlobals;
+    use crate::rules::no_undef::NoUndef;
     use crate::rules::no_unnecessary_state_wrap::NoUnnecessaryStateWrap;
     use crate::rules::prefer_const::PreferConst;
     use crate::rules::prefer_derived_over_derived_by::PreferDerivedOverDerivedBy;
@@ -220,5 +221,6 @@ pub fn all_script_rules() -> Vec<Box<dyn crate::script::ScriptRule>> {
         ),
         Box::new(crate::rules::infinite_reactive_loop::InfiniteReactiveLoop),
         Box::new(crate::rules::no_unused_vars::NoUnusedVars),
+        Box::new(NoUndef),
     ]
 }

--- a/crates/rsvelte_lint/src/rules/mod.rs
+++ b/crates/rsvelte_lint/src/rules/mod.rs
@@ -65,6 +65,7 @@ pub mod no_svelte_internal;
 pub mod no_target_blank;
 pub mod no_top_level_browser_globals;
 pub mod no_trailing_spaces;
+pub mod no_undef;
 pub mod no_unknown_style_directive_property;
 pub mod no_unnecessary_state_wrap;
 pub mod no_unused_class_name;

--- a/crates/rsvelte_lint/src/rules/no_undef.rs
+++ b/crates/rsvelte_lint/src/rules/no_undef.rs
@@ -1,0 +1,182 @@
+//! `svelte/no-undef` — report unresolved runtime references from OXC semantic analysis.
+
+use javascript_globals::{GLOBALS, GLOBALS_BUILTIN};
+
+use crate::config::{GlobalValue, LintConfig};
+use crate::context::LintContext;
+use crate::rule::{Fixable, RuleCategory, RuleConditions, RuleMeta, Severity};
+use crate::script::{ProgramView, ScriptKind, ScriptRule};
+
+pub static META: RuleMeta = RuleMeta {
+    name: "svelte/no-undef",
+    category: RuleCategory::Correctness,
+    fixable: Fixable::No,
+    // Core ESLint owns this rule upstream; require an explicit Svelte-aware opt-in.
+    default_severity: Severity::Off,
+    conditions: RuleConditions {
+        runes_only: false,
+        legacy_only: false,
+    },
+    type_aware: false,
+    docs: "Disallow unresolved runtime references in component scripts",
+    options_schema: Some(
+        r#"{ "type": "object", "properties": { "typeof": { "type": "boolean" } }, "additionalProperties": false }"#,
+    ),
+};
+
+#[derive(Default)]
+pub struct NoUndef;
+
+impl ScriptRule for NoUndef {
+    fn meta(&self) -> &'static RuleMeta {
+        &META
+    }
+
+    fn check_program(&self, ctx: &mut LintContext, program: &ProgramView<'_>, _kind: ScriptKind) {
+        let Some(scope) = ctx.scope_resolver() else {
+            return;
+        };
+        let start = program
+            .get("start")
+            .and_then(serde_json::Value::as_u64)
+            .unwrap_or(0) as u32;
+        let end = program
+            .get("end")
+            .and_then(serde_json::Value::as_u64)
+            .unwrap_or(ctx.source().len() as u64) as u32;
+        let report_typeof = ctx.option_bool("typeof", false);
+        for reference in scope.unresolved_references() {
+            if !(start <= reference.start && reference.end <= end)
+                || reference.arguments_in_function
+                || (!report_typeof && reference.in_typeof)
+                || is_svelte_implicit_global(&reference.name, scope)
+                || is_configured_global(&reference.name, ctx.config())
+            {
+                continue;
+            }
+            ctx.report_with_help(
+                reference.start,
+                reference.end,
+                format!("'{}' is not defined.", reference.name),
+                format!(
+                    "Either define '{}' or add it to the 'globals' configuration.",
+                    reference.name
+                ),
+            );
+        }
+    }
+}
+
+fn is_configured_global(name: &str, config: &LintConfig) -> bool {
+    match config.globals().value(name) {
+        Some(GlobalValue::Off) => false,
+        Some(_) => true,
+        None if GLOBALS_BUILTIN.contains_key(name) => true,
+        None => config.globals().enabled_environments().any(|environment| {
+            GLOBALS
+                .get(environment)
+                .is_some_and(|globals| globals.contains_key(name))
+        }),
+    }
+}
+
+fn is_svelte_implicit_global(name: &str, scope: &crate::scope::ScopeResolver) -> bool {
+    matches!(
+        name,
+        "$state"
+            | "$derived"
+            | "$effect"
+            | "$props"
+            | "$bindable"
+            | "$inspect"
+            | "$host"
+            | "$untrack"
+            | "$trace"
+            | "$effect.tracking"
+            | "$effect.root"
+            | "$state.raw"
+            | "$state.snapshot"
+            | "$derived.by"
+            | "$$props"
+            | "$$restProps"
+            | "$$slots"
+    ) || name
+        .strip_prefix('$')
+        .is_some_and(|store| scope.is_component_binding(store))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+
+    use crate::{LintConfig, Severity, lint_source_raw};
+
+    fn findings(source: &str, config: LintConfig) -> Vec<(String, u32)> {
+        lint_source_raw(source, Path::new("App.svelte"), &config)
+            .into_iter()
+            .filter(|diagnostic| diagnostic.rule == "svelte/no-undef")
+            .map(|diagnostic| (diagnostic.message, diagnostic.start))
+            .collect()
+    }
+
+    fn enabled() -> LintConfig {
+        LintConfig::empty().with_override("svelte/no-undef", Severity::Error)
+    }
+
+    #[test]
+    fn reports_unresolved_values_but_not_type_references_or_default_typeof() {
+        let source = "<script lang=\"ts\">\nlet x: MissingType;\ntype T = MissingType;\nconst y = missingValue;\ntype U = typeof declared;\n</script>";
+        let reports = findings(source, enabled());
+        assert_eq!(reports.len(), 2, "{reports:?}");
+        assert!(reports[0].0.contains("missingValue"));
+        assert!(reports[1].0.contains("declared"));
+    }
+
+    #[test]
+    fn typeof_option_and_arguments_match_eslint_semantics() {
+        let source = "<script>\nconst a = typeof maybe;\nconst arrow = () => arguments;\nfunction regular() { return arguments.length; }\n</script>";
+        let reports = findings(source, enabled());
+        assert_eq!(reports.len(), 1, "{reports:?}");
+        assert!(reports[0].0.contains("arguments"));
+        let reports = findings(
+            source,
+            enabled().with_options("svelte/no-undef", serde_json::json!({ "typeof": true })),
+        );
+        assert_eq!(reports.len(), 2, "{reports:?}");
+        assert!(reports.iter().any(|(message, _)| message.contains("maybe")));
+    }
+
+    #[test]
+    fn honors_svelte_runes_store_subscriptions_and_configured_globals() {
+        let source = "<script>\nlet count = $state(0);\nconst props = $props();\nconst value = $count + projectGlobal + document.title;\n</script>";
+        let config = enabled()
+            .with_global("projectGlobal", crate::config::GlobalValue::Readonly)
+            .with_environment("browser", true);
+        assert!(findings(source, config).is_empty());
+    }
+
+    #[test]
+    fn explicit_off_overrides_an_environment_global() {
+        let source = "<script>document.title;</script>";
+        let reports = findings(
+            source,
+            enabled()
+                .with_environment("browser", true)
+                .with_global("document", crate::config::GlobalValue::Off),
+        );
+        assert_eq!(reports.len(), 1, "{reports:?}");
+    }
+
+    #[test]
+    fn inline_disable_suppresses_the_rule() {
+        let source = "<script>\n// eslint-disable-next-line svelte/no-undef\nmissing;\n</script>";
+        assert!(findings(source, enabled()).is_empty());
+    }
+
+    #[test]
+    fn reports_each_script_reference_once() {
+        let source = "<script module>moduleMissing;</script><script>instanceMissing;</script>";
+        let reports = findings(source, enabled());
+        assert_eq!(reports.len(), 2, "{reports:?}");
+    }
+}

--- a/crates/rsvelte_lint/src/scope.rs
+++ b/crates/rsvelte_lint/src/scope.rs
@@ -76,6 +76,9 @@ pub struct ScopeResolver {
     /// Names declared at the top level of the file's script(s) — the bindings a
     /// template `{expr}` can read.
     binding_names: HashSet<String>,
+    /// Unresolved value references, with absolute file offsets. These are kept
+    /// alongside the local facts because both come from the same semantic pass.
+    unresolved_references: Vec<crate::compiler_scope::UnresolvedReference>,
 }
 
 impl ScopeResolver {
@@ -88,6 +91,17 @@ impl ScopeResolver {
             self.local_spans.insert((s + base, e + base));
         }
         self.binding_names.extend(scope.root_binding_names);
+        self.unresolved_references
+            .extend(
+                scope
+                    .unresolved_references
+                    .into_iter()
+                    .map(|mut reference| {
+                        reference.start += base;
+                        reference.end += base;
+                        reference
+                    }),
+            );
     }
 
     /// Whether the identifier reference at absolute `[start, end)` is *not* a
@@ -104,6 +118,11 @@ impl ScopeResolver {
     /// global of the same name.
     pub fn is_component_binding(&self, name: &str) -> bool {
         self.binding_names.contains(name)
+    }
+
+    /// Unresolved references from all component scripts.
+    pub fn unresolved_references(&self) -> &[crate::compiler_scope::UnresolvedReference] {
+        &self.unresolved_references
     }
 }
 

--- a/crates/rsvelte_lint/tests/eslint_plugin_oracle.rs
+++ b/crates/rsvelte_lint/tests/eslint_plugin_oracle.rs
@@ -73,6 +73,9 @@ const NO_FIXTURE_RULES: &[&str] = &[
     // has no such rule (upstream defers to ESLint core, which cannot see template
     // reads). Covered by the inline `crate::rules::no_unused_vars` unit tests.
     "svelte/no-unused-vars",
+    // `no-undef` is an rsvelte-only Svelte-aware port of ESLint core's rule;
+    // eslint-plugin-svelte deliberately has no fixture directory for it.
+    "svelte/no-undef",
 ];
 
 /// Meta-rules whose findings come from the whole-component compile / source-scan

--- a/crates/rsvelte_lint_types/Cargo.lock
+++ b/crates/rsvelte_lint_types/Cargo.lock
@@ -456,6 +456,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "javascript-globals"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c5f4cff6dd96f6045e5e53d52ef114724989508a83e0dd72eea795844390297"
+dependencies = [
+ "phf",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1122,11 +1131,13 @@ version = "0.10.11"
 dependencies = [
  "anyhow",
  "compact_str",
+ "javascript-globals",
  "oxc_allocator",
  "oxc_ast",
  "oxc_parser",
  "oxc_semantic",
  "oxc_span",
+ "oxc_syntax",
  "regex",
  "rsvelte_core",
  "rsvelte_diagnostics",


### PR DESCRIPTION
## Summary
- add opt-in `svelte/no-undef` backed by OXC semantic unresolved references
- honor configured globals and Oxlint environment globals, Svelte runes, and `$store` auto-subscriptions
- mirror ESLint handling for TypeScript type references, `typeof`, regular-function `arguments`, and inline disables

## Validation
- `cargo test -p rsvelte_lint --lib no_undef -- --nocapture` — 6/6 passed
- `cargo fmt --check`
- `cargo clippy -p rsvelte_lint --lib -- -D warnings`
- `cargo clippy --all-targets --locked -- -D warnings` in `crates/rsvelte_lint_types`
- `git diff --check`

The rule is default-off because core ESLint owns `no-undef`; it is enabled explicitly as `svelte/no-undef`. The isolated lint-types lockfile is updated for the new dependency.