### PR TITLE
fix(esrap): preserve body trailing comment cursor

### DIFF
--- a/.changeset/green-comment-cursor-body-boundary.md
+++ b/.changeset/green-comment-cursor-body-boundary.md
@@ -1,0 +1,6 @@
+---
+"@rsvelte/compiler": patch
+---
+
+Preserve same-line comments at the preceding statement boundary during client code generation.
+`rsvelte_esrap` is released as 0.10.7 and `rsvelte_core` pins the new exact requirement.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2532,7 +2532,7 @@ dependencies = [
 
 [[package]]
 name = "rsvelte_esrap"
-version = "0.10.6"
+version = "0.10.7"
 dependencies = [
  "compact_str 0.10.0",
  "memchr",

--- a/crates/rsvelte_core/Cargo.toml
+++ b/crates/rsvelte_core/Cargo.toml
@@ -94,7 +94,7 @@ oxc_ast = { version = "0.143", features = ["serialize"] }
 oxc_span = "0.143"
 oxc_diagnostics = "0.143"
 oxc_codegen = "0.143"
-rsvelte_esrap = { version = "=0.10.6", path = "../rsvelte_esrap" }
+rsvelte_esrap = { version = "=0.10.7", path = "../rsvelte_esrap" }
 oxc_syntax = "0.143"
 oxc_semantic = "0.143"
 

--- a/crates/rsvelte_core/tests/await_comment_run_relocation.rs
+++ b/crates/rsvelte_core/tests/await_comment_run_relocation.rs
@@ -56,6 +56,13 @@ fn a_comment_before_a_parenthesized_await_moves_inside_the_wrap() {
     );
 }
 
+#[test]
+fn comment_after_a_previous_statement_does_not_cross_into_a_later_await_wrap() {
+    let out = module("\tlet y = 1; return (/* c */ await load())();\n");
+    assert_contains(&out, "let y = 1; /* c */");
+    assert_contains(&out, "$.track_reactivity_loss(load())");
+}
+
 /// The adjacent shape — comment *between* `await` and its operand — already
 /// landed inside the call, and has to keep doing so.
 #[test]

--- a/crates/rsvelte_esrap/Cargo.toml
+++ b/crates/rsvelte_esrap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rsvelte_esrap"
-version = "0.10.6"
+version = "0.10.7"
 edition = "2024"
 rust-version = "1.95"
 description = "A Rust port of esrap — prints an oxc AST to JavaScript with esrap's exact layout"

--- a/crates/rsvelte_esrap/src/printer.rs
+++ b/crates/rsvelte_esrap/src/printer.rs
@@ -892,7 +892,7 @@ impl<'opt> Printer<'opt> {
             let multiline = child.multiline;
             ctx.append(child);
 
-            let next = non_empty.get(i + 1).map(|e| e.span_start());
+            let next = non_empty.get(i + 1).map(|e| e.span_end());
             self.flush_trailing_comments(ctx, elem.span_end(), next);
 
             prev = Some((elem, multiline));
@@ -3775,14 +3775,6 @@ impl<'a> BodyElem<'a, '_> {
         }
     }
 
-    fn span_start(&self) -> u32 {
-        match self {
-            BodyElem::Directive(d) => d.span.start,
-            BodyElem::Statement(s) => s.span().start,
-            BodyElem::ClassMember(e) => e.span().start,
-        }
-    }
-
     fn span_end(&self) -> u32 {
         match self {
             BodyElem::Directive(d) => d.span.end,
@@ -3917,6 +3909,16 @@ mod tests {
         assert_eq!(
             print_with_comments_ok("const a = 1;\n// c\nconst b = 2;"),
             "const a = 1;\n\n// c\nconst b = 2;"
+        );
+    }
+
+    #[test]
+    fn same_line_comment_before_later_statement_stays_trailing_on_previous() {
+        assert_eq!(
+            print_with_comments_ok(
+                "async function f() { let y = 1; return (await $.track_reactivity_loss(/* c */ load()))()(); }"
+            ),
+            "async function f() {\n\tlet y = 1; /* c */\n\n\treturn (await $.track_reactivity_loss(load()))()();\n}"
         );
     }
 

--- a/crates/rsvelte_lint_types/Cargo.lock
+++ b/crates/rsvelte_lint_types/Cargo.lock
@@ -1121,7 +1121,7 @@ dependencies = [
 
 [[package]]
 name = "rsvelte_esrap"
-version = "0.10.6"
+version = "0.10.7"
 dependencies = [
  "compact_str",
  "memchr",


### PR DESCRIPTION
Partial fix for #2336; it does not close the comment-cursor epic.

This fixes the current, independently reproduced same-line body-boundary case:

```js
export async function f() { let y = 1; return (/* c */ await load())(); }
```

Official emits `/* c */` trailing `let y = 1`; rsvelte had moved it into `$.track_reactivity_loss`. The Rust esrap port used the next statement's start as the prior statement's trailing-comment boundary. Upstream esrap uses the next statement's end.

Scope: this corrects that boundary rule and is covered in both the generic printer and compileModule client-dev paths. It does not implement #2336's remaining synthetic-node provenance work (unlocated-body cursor exhaustion, wrapper-span inheritance, and IR comment transport). The historical child issues #2262/#2307/#2368/#2375 are already closed; this PR does not claim to re-close or revalidate their broader mechanisms.

Tests:
- `cargo test -p rsvelte_esrap`
- `cargo test -p rsvelte_core --test await_comment_run_relocation --test module_dev_await_instrumentation`
- `cargo clippy -p rsvelte_esrap -p rsvelte_core --all-targets --all-features -- -D warnings`