### PR TITLE
fix(svelte2tsx): restore projection registry checks

### DIFF
--- a/.changeset/fix-projection-packed-spans.md
+++ b/.changeset/fix-projection-packed-spans.md
@@ -1,0 +1,5 @@
+---
+'@rsvelte/svelte2tsx': patch
+---
+
+Fix packed script-span and source-map VLQ encoding overflows in svelte2tsx output.

--- a/crates/rsvelte_capi/include/rsvelte.h
+++ b/crates/rsvelte_capi/include/rsvelte.h
@@ -234,11 +234,10 @@ struct RsvelteBuf rsvelte_compile_module_with_callbacks(const uint8_t *source,
                                                         const struct RsvelteCallbacks *callbacks);
 
 /**
- * Out-parameter variant of [`rsvelte_compile`] for hosts whose FFI can't
- * return structs by value (e.g. Ruby Fiddle, older PHP, some Java JNI setups).
- *
- * The result is written through `out`. The caller still owns the bytes and
- * must release them with [`rsvelte_free`].
+ * Out-parameter variant of [`rsvelte_compile`] for hosts whose FFI
+ * can't return structs by value (e.g. Ruby Fiddle, older PHP, some
+ * Java JNI setups). The result is written through `out`. The caller
+ * still owns the bytes and must release them with [`rsvelte_free`].
  *
  * # Safety
  * `out` must be a non-null pointer to a writable `RsvelteBuf`.

--- a/crates/rsvelte_projection/src/svelte2tsx/magic_string.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/magic_string.rs
@@ -528,7 +528,8 @@ fn vlq_encode(encoded: &mut String, value: i64) {
 
     let mut vlq = (value.unsigned_abs() << 1) | u64::from(value < 0);
     while vlq >= u64::from(VLQ_BASE) {
-        let digit = (u32::try_from(vlq).expect("VLQ digit fits in u32") & VLQ_BASE_MASK)
+        let digit = u32::try_from(vlq & u64::from(VLQ_BASE_MASK))
+            .expect("masked VLQ digit fits in u32")
             | VLQ_CONTINUATION_BIT;
         encoded.push(BASE64_CHARS[digit as usize] as char);
         vlq >>= VLQ_BASE_SHIFT;

--- a/crates/rsvelte_projection/src/svelte2tsx/script/component_events.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/script/component_events.rs
@@ -283,7 +283,7 @@ fn scan_dispatch_calls_with_observer<'source>(
     mut observe_identifier: impl FnMut(),
 ) -> DispatchScan<'source> {
     let mut dispatcher_indices: FxHashMap<&str, (usize, usize)> =
-        FxHashMap::with_capacity_and_hasher(decls.len(), FxBuildHasher::default());
+        FxHashMap::with_capacity_and_hasher(decls.len(), FxBuildHasher);
     let mut next_dispatcher = vec![usize::MAX; decls.len()];
     for (index, (name, _)) in decls.iter().enumerate() {
         dispatcher_indices

--- a/crates/rsvelte_projection/src/svelte2tsx/script/export_decl.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/script/export_decl.rs
@@ -482,9 +482,9 @@ mod tests {
         let result = run_svelte2tsx(source);
 
         assert_eq!(result.exported_names.get_prop_names(), vec!["a", "b", "c"]);
-        assert!(result.exported_names.get("a").unwrap().has_default);
-        assert!(!result.exported_names.get("b").unwrap().has_default);
-        assert!(result.exported_names.get("c").unwrap().has_default);
+        assert!(result.exported_names.get("a").unwrap().has_default());
+        assert!(!result.exported_names.get("b").unwrap().has_default());
+        assert!(result.exported_names.get("c").unwrap().has_default());
     }
 
     #[test]
@@ -493,7 +493,7 @@ mod tests {
         let result = run_svelte2tsx(source);
 
         assert!(result.exported_names.has("MAX"));
-        assert!(!result.exported_names.get("MAX").unwrap().is_prop);
+        assert!(!result.exported_names.get("MAX").unwrap().is_prop());
     }
 
     #[test]
@@ -502,7 +502,7 @@ mod tests {
         let result = run_svelte2tsx(source);
 
         assert!(result.exported_names.has("greet"));
-        assert!(!result.exported_names.get("greet").unwrap().is_prop);
+        assert!(!result.exported_names.get("greet").unwrap().is_prop());
     }
 
     #[test]

--- a/crates/rsvelte_projection/src/svelte2tsx/script/hoistable_types.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/script/hoistable_types.rs
@@ -406,7 +406,7 @@ pub(super) fn resolve_hoistable_type_decls(
         return;
     }
     let mut candidate_indices: FxHashMap<&str, u32> =
-        FxHashMap::with_capacity_and_hasher(candidates.len(), FxBuildHasher::default());
+        FxHashMap::with_capacity_and_hasher(candidates.len(), FxBuildHasher);
     for (index, candidate) in candidates.iter().enumerate() {
         candidate_indices
             .entry(candidate.name.as_str())

--- a/crates/rsvelte_projection/src/svelte2tsx/script/mod.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/script/mod.rs
@@ -1127,7 +1127,7 @@ mod tests {
         let result = run_svelte2tsx(source);
         assert!(!result.exported_names.has("VERSION"));
         assert!(result.exported_names.has("name"));
-        assert!(result.exported_names.get("name").unwrap().is_prop);
+        assert!(result.exported_names.get("name").unwrap().is_prop());
         assert_eq!(result.exported_names.get_prop_names(), vec!["name"]);
     }
 

--- a/crates/rsvelte_projection/src/svelte2tsx/script/props_rune.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/script/props_rune.rs
@@ -156,6 +156,7 @@ pub(super) fn apply_props_typedef(
     if info
         .flags
         .contains(PropsRuneFlags::TYPE_ANNOTATION | PropsRuneFlags::HOISTABLE_TYPE)
+        && !info.flags.contains(PropsRuneFlags::NAMED_TYPE_REFERENCE)
     {
         // TS case with inline object type: `: { a: number, b: string }`
         // Create $$ComponentProps alias and replace everything from `:` to end of type
@@ -230,7 +231,6 @@ pub(super) fn apply_props_typedef(
     } else if info
         .flags
         .contains(PropsRuneFlags::TYPE_ANNOTATION | PropsRuneFlags::NAMED_TYPE_REFERENCE)
-        && !info.flags.contains(PropsRuneFlags::HOISTABLE_TYPE)
     {
         // TS case with simple named type reference: `: Props` or `: Props<T>`
         // Keep the type annotation as-is, use it directly in props_type_text
@@ -642,31 +642,28 @@ pub(super) fn extract_props_from_binding_pattern_runes(
     exported_names: &mut ExportedNames,
     raw_content: &str,
 ) {
-    match pattern {
-        oxc::BindingPattern::ObjectPattern(obj_pat) => {
-            for prop in &obj_pat.properties {
-                let key_name = property_key_to_string(&prop.key);
-                let (local_name, has_default, is_bindable) =
-                    if let oxc::BindingPattern::AssignmentPattern(assign) = &prop.value {
-                        // { a = 1 } or { a = $bindable() }
-                        let name = binding_pattern_simple_name(&assign.left);
-                        let (bindable, _) = is_bindable_call(&assign.right, raw_content);
-                        (name, true, bindable)
-                    } else {
-                        let name = binding_pattern_simple_name(&prop.value);
-                        (name, false, false)
-                    };
+    if let oxc::BindingPattern::ObjectPattern(obj_pat) = pattern {
+        for prop in &obj_pat.properties {
+            let key_name = property_key_to_string(&prop.key);
+            let (local_name, has_default, is_bindable) =
+                if let oxc::BindingPattern::AssignmentPattern(assign) = &prop.value {
+                    // { a = 1 } or { a = $bindable() }
+                    let name = binding_pattern_simple_name(&assign.left);
+                    let (bindable, _) = is_bindable_call(&assign.right, raw_content);
+                    (name, true, bindable)
+                } else {
+                    let name = binding_pattern_simple_name(&prop.value);
+                    (name, false, false)
+                };
 
-                if let Some(ref key) = key_name {
-                    let local = local_name.unwrap_or(key).to_owned();
-                    exported_names.add(key.clone(), local, has_default, None, true);
-                    if is_bindable {
-                        exported_names.bindable_props.push(key.clone());
-                    }
+            if let Some(ref key) = key_name {
+                let local = local_name.unwrap_or(key).to_owned();
+                exported_names.add(key.clone(), local, has_default, None, true);
+                if is_bindable {
+                    exported_names.bindable_props.push(key.clone());
                 }
             }
         }
-        _ => {}
     }
 }
 
@@ -936,8 +933,8 @@ mod tests {
         assert!(result.exported_names.has("a"));
         assert!(result.exported_names.has("b"));
         assert_eq!(result.exported_names.get_prop_names(), vec!["a", "b"]);
-        assert!(!result.exported_names.get("a").unwrap().has_default);
-        assert!(!result.exported_names.get("b").unwrap().has_default);
+        assert!(!result.exported_names.get("a").unwrap().has_default());
+        assert!(!result.exported_names.get("b").unwrap().has_default());
     }
 
     #[test]
@@ -947,8 +944,8 @@ mod tests {
 
         assert!(result.exported_names.has("count"));
         assert!(result.exported_names.has("name"));
-        assert!(result.exported_names.get("count").unwrap().has_default);
-        assert!(result.exported_names.get("name").unwrap().has_default);
+        assert!(result.exported_names.get("count").unwrap().has_default());
+        assert!(result.exported_names.get("name").unwrap().has_default());
     }
 
     #[test]

--- a/crates/rsvelte_projection/src/svelte2tsx/script/runes.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/script/runes.rs
@@ -235,9 +235,9 @@ fn detect_rune_in_stmt(stmt: &oxc::Statement, declared_names: &HashSet<String>) 
                 }),
                 // ForStatementInit inherits Expression variants; use to_expression()
                 // for all non-VariableDeclaration arms.
-                _ => init.as_expression().map_or(false, |expression| {
-                    detect_rune_in_expr(expression, declared_names)
-                }),
+                _ => init
+                    .as_expression()
+                    .is_some_and(|expression| detect_rune_in_expr(expression, declared_names)),
             }) || for_stmt
                 .test
                 .as_ref()

--- a/crates/rsvelte_projection/src/svelte2tsx/script/stores.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/script/stores.rs
@@ -231,8 +231,11 @@ impl ScriptSpans {
     fn unpack(span: u64) -> Option<(usize, usize)> {
         (span != Self::NONE).then_some((
             (span >> 32) as usize,
-            usize::try_from(u32::try_from(span).expect("packed span low half fits in u32"))
-                .expect("u32 fits in usize"),
+            usize::try_from(
+                u32::try_from(span & u64::from(u32::MAX))
+                    .expect("packed span low half fits in u32"),
+            )
+            .expect("u32 fits in usize"),
         ))
     }
 
@@ -720,7 +723,7 @@ fn is_dollar_binding_shadowed(
     name: &str,
     pos: usize,
 ) -> bool {
-    shadow.get(name).map_or(false, |spans| {
+    shadow.get(name).is_some_and(|spans| {
         let p = source_offset(pos);
         spans.iter().any(|&(s, e)| p >= s && p < e)
     })

--- a/crates/rsvelte_projection/src/svelte2tsx/template/attributes/attribute.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/template/attributes/attribute.rs
@@ -44,7 +44,7 @@ pub fn format_attribute_node(node: &AttributeNode, source: &str, is_element: boo
         }
     }
 
-    let value = match &node.value {
+    match &node.value {
         AttributeValue::True(_) => {
             // Boolean attribute: `disabled` → `"disabled":true,`
             // For data-* on elements the boolean value is still `true` — official
@@ -127,8 +127,7 @@ pub fn format_attribute_node(node: &AttributeNode, source: &str, is_element: boo
             let inner = format!("\"{}\":`{}`", name, value_parts.join(""));
             wrap(&inner, is_data_attr, is_css_prop)
         }
-    };
-    value
+    }
 }
 
 /// Structured-bake variant of [`format_attribute_node`]. Wraps every

--- a/crates/rsvelte_projection/src/svelte2tsx/utils/source_features.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/utils/source_features.rs
@@ -266,7 +266,7 @@ mod tests {
             "<!-- on:click -->",
         ] {
             assert!(
-                scan_source_features(source).may_need_template_info,
+                scan_source_features(source).may_need_template_info(),
                 "{source}"
             );
         }
@@ -281,7 +281,7 @@ mod tests {
             "<script>const slot = true;</script>",
         ] {
             assert!(
-                !scan_source_features(source).may_need_template_info,
+                !scan_source_features(source).may_need_template_info(),
                 "{source}"
             );
         }


### PR DESCRIPTION
Fix current main CI and two exposed projection correctness bugs.

- update projection tests for the current accessor APIs
- mask packed span/VLQ values before narrowing to `u32`
- preserve named `$props()` type references without an unnecessary alias
- synchronize the generated C ABI header wrapping

Validated: projection lib tests (265), projection clippy, C ABI build, registry dependency-surface gate, fmt, diff check.