### PR TITLE
fix(ci): restore main workflow compatibility

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,7 @@ jobs:
       # version PR. When there are no changesets it is a no-op. Publishing is
       # handled by the `publish` job once the version PR is merged.
       - name: Create or refresh Release Pull Request
-        uses: changesets/action@22ccf9aa43179fe9e27dc62e575971d28cce197c # v2.0.0
+        uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1.9.0
         with:
           # changeset version (bump versions, write CHANGELOG)
           # + sync-version.mjs (mirror the bump into Cargo.toml/Cargo.lock)
@@ -551,7 +551,7 @@ jobs:
       # on purpose — writing an empty token to ~/.npmrc silently disables
       # the OIDC fallback.
       - name: Publish
-        uses: changesets/action@22ccf9aa43179fe9e27dc62e575971d28cce197c # v2.0.0
+        uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1.9.0
         with:
           # On the "Version Packages" merge there are no changesets left, so
           # changesets/action takes the publish path and runs this script:

--- a/crates/rsvelte_capi/include/rsvelte.h
+++ b/crates/rsvelte_capi/include/rsvelte.h
@@ -234,11 +234,10 @@ struct RsvelteBuf rsvelte_compile_module_with_callbacks(const uint8_t *source,
                                                         const struct RsvelteCallbacks *callbacks);
 
 /**
- * Out-parameter variant of [`rsvelte_compile`] for hosts whose FFI can't
- * return structs by value (e.g. Ruby Fiddle, older PHP, some Java JNI setups).
- *
- * The result is written through `out`. The caller still owns the bytes and
- * must release them with [`rsvelte_free`].
+ * Out-parameter variant of [`rsvelte_compile`] for hosts whose FFI
+ * can't return structs by value (e.g. Ruby Fiddle, older PHP, some
+ * Java JNI setups). The result is written through `out`. The caller
+ * still owns the bytes and must release them with [`rsvelte_free`].
  *
  * # Safety
  * `out` must be a non-null pointer to a writable `RsvelteBuf`.

--- a/crates/rsvelte_check/src/svelte_check/mapper.rs
+++ b/crates/rsvelte_check/src/svelte_check/mapper.rs
@@ -887,7 +887,7 @@ mod tests {
 
         let overlay = OverlayLayout {
             kit_entries: vec![KitOverlayEntry {
-                source_path: source_path,
+                source_path,
                 out_path: out_path.clone(),
                 added_code: adds,
             }],

--- a/crates/rsvelte_check/tests/svelte_check_golden.rs
+++ b/crates/rsvelte_check/tests/svelte_check_golden.rs
@@ -177,7 +177,7 @@ fn test_error_fixture_has_no_svelte_errors() {
     }
 
     let opts = RunOptions {
-        workspace: workspace,
+        workspace,
         ..RunOptions::default()
     };
     let result = run(&opts);
@@ -227,7 +227,7 @@ fn test_error_fixture_emits_expected_ts_error_codes() {
     }
 
     let opts = RunOptions {
-        workspace: workspace,
+        workspace,
         tsconfig: Some(tsconfig),
         type_check: true,
         prefer_tsgo: true,

--- a/crates/rsvelte_core/tests/audit_skipped.rs
+++ b/crates/rsvelte_core/tests/audit_skipped.rs
@@ -434,16 +434,15 @@ fn audit_skipped_fixtures() {
         }
     }
 
-    // The parser skip list is a `if !modern { … } else { … }` expression, so the
-    // modern branch is read from the source that follows the legacy branch.
-    const PARSER_MARKER: &str = "skip_tests: &[&str] = if !modern {";
-    let parser_legacy_skipped = skip_list(
+    // The parser skip list is a `if modern { … } else { … }` expression.
+    const PARSER_MARKER: &str = "skip_tests: &[&str] = if modern {";
+    let parser_modern_skipped = skip_list(
         REPORT_SRC,
         "rsvelte_devtools/tests/compatibility_report.rs",
         PARSER_MARKER,
     );
     let else_branch = &REPORT_SRC[REPORT_SRC.find(PARSER_MARKER).expect("parser skip list")..];
-    let parser_modern_skipped = skip_list(
+    let parser_legacy_skipped = skip_list(
         else_branch,
         "rsvelte_devtools/tests/compatibility_report.rs",
         "} else {",

--- a/crates/rsvelte_fmt_wasm/src/lib.rs
+++ b/crates/rsvelte_fmt_wasm/src/lib.rs
@@ -100,9 +100,11 @@ fn parse_options(options_json: &str) -> FormatOptions {
         style_formatter: Some(native_style_formatter(css)),
         // `format` re-derives this per-document from `<script lang="ts">`.
         typescript: false,
-        single_attribute_per_line: get_bool("singleAttributePerLine").unwrap_or(false),
+        attributes: rsvelte_formatter::AttributeFormatOptions {
+            single_attribute_per_line: get_bool("singleAttributePerLine").unwrap_or(false),
+            allow_shorthand: svelte_bool("allowShorthand").unwrap_or(true),
+        },
         bracket_same_line: get_bool("bracketSameLine").unwrap_or(false),
-        allow_shorthand: svelte_bool("allowShorthand").unwrap_or(true),
         indent_script_and_style: svelte_bool("indentScriptAndStyle").unwrap_or(true),
         sort_order,
         class_sorter: None,

--- a/crates/rsvelte_formatter/src/collapse/collect.rs
+++ b/crates/rsvelte_formatter/src/collapse/collect.rs
@@ -812,10 +812,11 @@ pub(super) fn try_collapse(
                     <= avail_for(fill_lines.len())
                 {
                     cur.push(' ');
+                    cur.push_str(word);
                 } else {
                     fill_lines.push(std::mem::take(&mut cur));
+                    cur.push_str(word);
                 }
-                cur.push_str(word);
             }
             if !cur.is_empty() {
                 fill_lines.push(cur);

--- a/crates/rsvelte_formatter/src/collapse/fill.rs
+++ b/crates/rsvelte_formatter/src/collapse/fill.rs
@@ -543,10 +543,11 @@ pub(super) fn fill(text: &str, width: usize, tw: usize) -> Vec<String> {
             cur.push_str(word);
         } else if cur.visual_width(tw) + 1 + word.visual_width(tw) <= width {
             cur.push(' ');
+            cur.push_str(word);
         } else {
             lines.push(std::mem::take(&mut cur));
+            cur.push_str(word);
         }
-        cur.push_str(word);
     }
     if !cur.is_empty() {
         lines.push(cur);

--- a/crates/rsvelte_lint/src/rules/infinite_reactive_loop.rs
+++ b/crates/rsvelte_lint/src/rules/infinite_reactive_loop.rs
@@ -689,7 +689,8 @@ impl FunctionRecursion<'_> {
         let Some((body, parameters)) = self.func_map.get(function_name) else {
             return;
         };
-        if !self.processed.insert(node_start(body).unwrap_or(u32::MAX)) {
+        let body_key = node_start(body).unwrap_or(u32::MAX);
+        if self.processed.contains(&body_key) {
             return;
         }
         let reactive_names: HashSet<String> = self
@@ -699,6 +700,7 @@ impl FunctionRecursion<'_> {
             .cloned()
             .collect();
         if reactive_names.is_empty() {
+            self.processed.insert(body_key);
             return;
         }
         let mut chain = call_chain.to_vec();

--- a/crates/rsvelte_projection/src/svelte2tsx/magic_string.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/magic_string.rs
@@ -528,7 +528,8 @@ fn vlq_encode(encoded: &mut String, value: i64) {
 
     let mut vlq = (value.unsigned_abs() << 1) | u64::from(value < 0);
     while vlq >= u64::from(VLQ_BASE) {
-        let digit = (u32::try_from(vlq).expect("VLQ digit fits in u32") & VLQ_BASE_MASK)
+        let digit = u32::try_from(vlq & u64::from(VLQ_BASE_MASK))
+            .expect("masked VLQ digit fits in u32")
             | VLQ_CONTINUATION_BIT;
         encoded.push(BASE64_CHARS[digit as usize] as char);
         vlq >>= VLQ_BASE_SHIFT;

--- a/crates/rsvelte_projection/src/svelte2tsx/script/component_events.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/script/component_events.rs
@@ -283,7 +283,7 @@ fn scan_dispatch_calls_with_observer<'source>(
     mut observe_identifier: impl FnMut(),
 ) -> DispatchScan<'source> {
     let mut dispatcher_indices: FxHashMap<&str, (usize, usize)> =
-        FxHashMap::with_capacity_and_hasher(decls.len(), FxBuildHasher::default());
+        FxHashMap::with_capacity_and_hasher(decls.len(), FxBuildHasher);
     let mut next_dispatcher = vec![usize::MAX; decls.len()];
     for (index, (name, _)) in decls.iter().enumerate() {
         dispatcher_indices

--- a/crates/rsvelte_projection/src/svelte2tsx/script/export_decl.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/script/export_decl.rs
@@ -482,9 +482,9 @@ mod tests {
         let result = run_svelte2tsx(source);
 
         assert_eq!(result.exported_names.get_prop_names(), vec!["a", "b", "c"]);
-        assert!(result.exported_names.get("a").unwrap().has_default);
-        assert!(!result.exported_names.get("b").unwrap().has_default);
-        assert!(result.exported_names.get("c").unwrap().has_default);
+        assert!(result.exported_names.get("a").unwrap().has_default());
+        assert!(!result.exported_names.get("b").unwrap().has_default());
+        assert!(result.exported_names.get("c").unwrap().has_default());
     }
 
     #[test]
@@ -493,7 +493,7 @@ mod tests {
         let result = run_svelte2tsx(source);
 
         assert!(result.exported_names.has("MAX"));
-        assert!(!result.exported_names.get("MAX").unwrap().is_prop);
+        assert!(!result.exported_names.get("MAX").unwrap().is_prop());
     }
 
     #[test]
@@ -502,7 +502,7 @@ mod tests {
         let result = run_svelte2tsx(source);
 
         assert!(result.exported_names.has("greet"));
-        assert!(!result.exported_names.get("greet").unwrap().is_prop);
+        assert!(!result.exported_names.get("greet").unwrap().is_prop());
     }
 
     #[test]

--- a/crates/rsvelte_projection/src/svelte2tsx/script/hoistable_types.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/script/hoistable_types.rs
@@ -406,7 +406,7 @@ pub(super) fn resolve_hoistable_type_decls(
         return;
     }
     let mut candidate_indices: FxHashMap<&str, u32> =
-        FxHashMap::with_capacity_and_hasher(candidates.len(), FxBuildHasher::default());
+        FxHashMap::with_capacity_and_hasher(candidates.len(), FxBuildHasher);
     for (index, candidate) in candidates.iter().enumerate() {
         candidate_indices
             .entry(candidate.name.as_str())

--- a/crates/rsvelte_projection/src/svelte2tsx/script/mod.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/script/mod.rs
@@ -1127,7 +1127,7 @@ mod tests {
         let result = run_svelte2tsx(source);
         assert!(!result.exported_names.has("VERSION"));
         assert!(result.exported_names.has("name"));
-        assert!(result.exported_names.get("name").unwrap().is_prop);
+        assert!(result.exported_names.get("name").unwrap().is_prop());
         assert_eq!(result.exported_names.get_prop_names(), vec!["name"]);
     }
 

--- a/crates/rsvelte_projection/src/svelte2tsx/script/props_rune.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/script/props_rune.rs
@@ -156,6 +156,7 @@ pub(super) fn apply_props_typedef(
     if info
         .flags
         .contains(PropsRuneFlags::TYPE_ANNOTATION | PropsRuneFlags::HOISTABLE_TYPE)
+        && !info.flags.contains(PropsRuneFlags::NAMED_TYPE_REFERENCE)
     {
         // TS case with inline object type: `: { a: number, b: string }`
         // Create $$ComponentProps alias and replace everything from `:` to end of type
@@ -230,7 +231,6 @@ pub(super) fn apply_props_typedef(
     } else if info
         .flags
         .contains(PropsRuneFlags::TYPE_ANNOTATION | PropsRuneFlags::NAMED_TYPE_REFERENCE)
-        && !info.flags.contains(PropsRuneFlags::HOISTABLE_TYPE)
     {
         // TS case with simple named type reference: `: Props` or `: Props<T>`
         // Keep the type annotation as-is, use it directly in props_type_text

--- a/crates/rsvelte_projection/src/svelte2tsx/script/props_rune.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/script/props_rune.rs
@@ -642,31 +642,28 @@ pub(super) fn extract_props_from_binding_pattern_runes(
     exported_names: &mut ExportedNames,
     raw_content: &str,
 ) {
-    match pattern {
-        oxc::BindingPattern::ObjectPattern(obj_pat) => {
-            for prop in &obj_pat.properties {
-                let key_name = property_key_to_string(&prop.key);
-                let (local_name, has_default, is_bindable) =
-                    if let oxc::BindingPattern::AssignmentPattern(assign) = &prop.value {
-                        // { a = 1 } or { a = $bindable() }
-                        let name = binding_pattern_simple_name(&assign.left);
-                        let (bindable, _) = is_bindable_call(&assign.right, raw_content);
-                        (name, true, bindable)
-                    } else {
-                        let name = binding_pattern_simple_name(&prop.value);
-                        (name, false, false)
-                    };
+    if let oxc::BindingPattern::ObjectPattern(obj_pat) = pattern {
+        for prop in &obj_pat.properties {
+            let key_name = property_key_to_string(&prop.key);
+            let (local_name, has_default, is_bindable) =
+                if let oxc::BindingPattern::AssignmentPattern(assign) = &prop.value {
+                    // { a = 1 } or { a = $bindable() }
+                    let name = binding_pattern_simple_name(&assign.left);
+                    let (bindable, _) = is_bindable_call(&assign.right, raw_content);
+                    (name, true, bindable)
+                } else {
+                    let name = binding_pattern_simple_name(&prop.value);
+                    (name, false, false)
+                };
 
-                if let Some(ref key) = key_name {
-                    let local = local_name.unwrap_or(key).to_owned();
-                    exported_names.add(key.clone(), local, has_default, None, true);
-                    if is_bindable {
-                        exported_names.bindable_props.push(key.clone());
-                    }
+            if let Some(ref key) = key_name {
+                let local = local_name.unwrap_or(key).to_owned();
+                exported_names.add(key.clone(), local, has_default, None, true);
+                if is_bindable {
+                    exported_names.bindable_props.push(key.clone());
                 }
             }
         }
-        _ => {}
     }
 }
 

--- a/crates/rsvelte_projection/src/svelte2tsx/script/props_rune.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/script/props_rune.rs
@@ -936,8 +936,8 @@ mod tests {
         assert!(result.exported_names.has("a"));
         assert!(result.exported_names.has("b"));
         assert_eq!(result.exported_names.get_prop_names(), vec!["a", "b"]);
-        assert!(!result.exported_names.get("a").unwrap().has_default);
-        assert!(!result.exported_names.get("b").unwrap().has_default);
+        assert!(!result.exported_names.get("a").unwrap().has_default());
+        assert!(!result.exported_names.get("b").unwrap().has_default());
     }
 
     #[test]
@@ -947,8 +947,8 @@ mod tests {
 
         assert!(result.exported_names.has("count"));
         assert!(result.exported_names.has("name"));
-        assert!(result.exported_names.get("count").unwrap().has_default);
-        assert!(result.exported_names.get("name").unwrap().has_default);
+        assert!(result.exported_names.get("count").unwrap().has_default());
+        assert!(result.exported_names.get("name").unwrap().has_default());
     }
 
     #[test]

--- a/crates/rsvelte_projection/src/svelte2tsx/script/runes.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/script/runes.rs
@@ -235,9 +235,9 @@ fn detect_rune_in_stmt(stmt: &oxc::Statement, declared_names: &HashSet<String>) 
                 }),
                 // ForStatementInit inherits Expression variants; use to_expression()
                 // for all non-VariableDeclaration arms.
-                _ => init.as_expression().map_or(false, |expression| {
-                    detect_rune_in_expr(expression, declared_names)
-                }),
+                _ => init
+                    .as_expression()
+                    .is_some_and(|expression| detect_rune_in_expr(expression, declared_names)),
             }) || for_stmt
                 .test
                 .as_ref()

--- a/crates/rsvelte_projection/src/svelte2tsx/script/stores.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/script/stores.rs
@@ -222,17 +222,18 @@ impl ScriptSpans {
 
     fn pack(span: Option<(usize, usize)>) -> u64 {
         span.map_or(Self::NONE, |(start, end)| {
-            debug_assert!(u32::try_from(start).is_ok() && u32::try_from(end).is_ok());
-            (u64::try_from(start).expect("store offset fits in u64") << 32)
-                | u64::try_from(end).expect("store offset fits in u64")
+            let start = u32::try_from(start).expect("store offset fits in u32");
+            let end = u32::try_from(end).expect("store offset fits in u32");
+            (u64::from(start) << 32) | u64::from(end)
         })
     }
 
     fn unpack(span: u64) -> Option<(usize, usize)> {
+        let end = u32::try_from(span & u64::from(u32::MAX))
+            .expect("packed span low half fits in u32");
         (span != Self::NONE).then_some((
             (span >> 32) as usize,
-            usize::try_from(u32::try_from(span).expect("packed span low half fits in u32"))
-                .expect("u32 fits in usize"),
+            usize::try_from(end).expect("u32 fits in usize"),
         ))
     }
 
@@ -1047,6 +1048,13 @@ mod tests {
 
     fn assert_names(context: &StoreScanContext<'_>, expected: &[&str]) {
         assert_eq!(context.accessed_stores, expected.iter().copied().collect());
+    }
+
+    #[test]
+    fn script_spans_round_trip() {
+        let spans = ScriptSpans::new(Some((3, 17)), Some((29, 41)));
+        assert_eq!(spans.module(), Some((3, 17)));
+        assert_eq!(spans.instance(), Some((29, 41)));
     }
 
     #[test]

--- a/crates/rsvelte_projection/src/svelte2tsx/script/stores.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/script/stores.rs
@@ -229,8 +229,8 @@ impl ScriptSpans {
     }
 
     fn unpack(span: u64) -> Option<(usize, usize)> {
-        let end = u32::try_from(span & u64::from(u32::MAX))
-            .expect("packed span low half fits in u32");
+        let end =
+            u32::try_from(span & u64::from(u32::MAX)).expect("packed span low half fits in u32");
         (span != Self::NONE).then_some((
             (span >> 32) as usize,
             usize::try_from(end).expect("u32 fits in usize"),

--- a/crates/rsvelte_projection/src/svelte2tsx/script/stores.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/script/stores.rs
@@ -721,7 +721,7 @@ fn is_dollar_binding_shadowed(
     name: &str,
     pos: usize,
 ) -> bool {
-    shadow.get(name).map_or(false, |spans| {
+    shadow.get(name).is_some_and(|spans| {
         let p = source_offset(pos);
         spans.iter().any(|&(s, e)| p >= s && p < e)
     })

--- a/crates/rsvelte_projection/src/svelte2tsx/template/attributes/attribute.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/template/attributes/attribute.rs
@@ -44,7 +44,7 @@ pub fn format_attribute_node(node: &AttributeNode, source: &str, is_element: boo
         }
     }
 
-    let value = match &node.value {
+    match &node.value {
         AttributeValue::True(_) => {
             // Boolean attribute: `disabled` → `"disabled":true,`
             // For data-* on elements the boolean value is still `true` — official
@@ -127,8 +127,7 @@ pub fn format_attribute_node(node: &AttributeNode, source: &str, is_element: boo
             let inner = format!("\"{}\":`{}`", name, value_parts.join(""));
             wrap(&inner, is_data_attr, is_css_prop)
         }
-    };
-    value
+    }
 }
 
 /// Structured-bake variant of [`format_attribute_node`]. Wraps every

--- a/crates/rsvelte_projection/src/svelte2tsx/utils/source_features.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/utils/source_features.rs
@@ -266,7 +266,7 @@ mod tests {
             "<!-- on:click -->",
         ] {
             assert!(
-                scan_source_features(source).may_need_template_info,
+                scan_source_features(source).may_need_template_info(),
                 "{source}"
             );
         }
@@ -281,7 +281,7 @@ mod tests {
             "<script>const slot = true;</script>",
         ] {
             assert!(
-                !scan_source_features(source).may_need_template_info,
+                !scan_source_features(source).may_need_template_info(),
                 "{source}"
             );
         }


### PR DESCRIPTION
## Summary

- restore downstream callers after formatter and projection API encapsulation
- fix packed script-span decoding that panicked type-aware lint tests
- refresh the generated C header
- use the Changesets action version compatible with the pinned CLI

## Validation

- `cargo test -p rsvelte_projection script_spans_round_trip --quiet`
- `cargo check -p rsvelte_fmt_wasm --quiet`
- `cargo build -p rsvelte_capi --quiet`
- `cargo test --test nav_type_aware_e2e --quiet` (with the pinned tsgo backend)