### PR TITLE
fix(ci): fail closed on compatibility report comparison

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ on:
   pull_request:
 
 permissions:
+  actions: read
   contents: read
   pull-requests: write
 
@@ -895,21 +896,36 @@ jobs:
         env:
           RUST_MIN_STACK: '33554432'
 
+      - name: Validate compatibility report
+        run: node scripts/diff/compare-compatibility-reports.mjs --validate
+
       - name: Upload compatibility report
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: compatibility-report-${{ github.sha }}
           path: fixtures/**/compatibility-report.json
-          if-no-files-found: warn
+          if-no-files-found: error
           retention-days: 90
 
       - name: Check README is in sync with Svelte submodule
         run: node scripts/dev/update-docs.mjs --check
 
-      - name: Compare with main (PR only)
+      - name: Download base compatibility report (PR only)
         if: github.event_name == 'pull_request'
-        run: node scripts/diff/compare-compatibility-reports.mjs --pr-summary > pr-summary.md || echo "comparison unavailable" > pr-summary.md
-        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          base_run_id="$(gh run list --workflow ci.yml --branch "$GITHUB_BASE_REF" --commit "$BASE_SHA" --status success --limit 1 --json databaseId --jq '.[0].databaseId')"
+          test -n "$base_run_id"
+          gh run download "$base_run_id" --name "compatibility-report-$BASE_SHA" --dir base-report
+
+      - name: Compare with base (PR only)
+        if: github.event_name == 'pull_request'
+        run: |
+          base_report="$(find base-report -type f -name compatibility-report.json -print -quit)"
+          test -n "$base_report"
+          node scripts/diff/compare-compatibility-reports.mjs --base-report "$base_report" --pr-summary > pr-summary.md
 
       - name: Comment on PR
         if: github.event_name == 'pull_request'
@@ -1138,6 +1154,11 @@ jobs:
       - name: Run differential corpus workflow tests
         run: node scripts/ci/test-differential-corpus-workflow.mjs
 
+      - name: Run compatibility report comparison tests
+        run: node scripts/ci/test-compatibility-report-comparison.mjs
+
+      - name: Run compatibility report workflow tests
+        run: node scripts/ci/test-compatibility-report-workflow.mjs
   prereq-coverage-guard:
     name: Prerequisite coverage guard
     runs-on: ubuntu-latest

--- a/scripts/ci/test-compatibility-report-comparison.mjs
+++ b/scripts/ci/test-compatibility-report-comparison.mjs
@@ -1,0 +1,94 @@
+#!/usr/bin/env node
+
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const COMPARE = join(HERE, "..", "diff", "compare-compatibility-reports.mjs");
+const dir = mkdtempSync(join(tmpdir(), "compatibility-report-comparison-"));
+let failures = 0;
+
+function report(passed, failed) {
+  return JSON.stringify({
+    svelte_commit: "0123456789abcdef",
+    categories: {
+      parser: { stats: { passed, failed, total: passed + failed } },
+    },
+  });
+}
+
+function check(name, fn) {
+  try {
+    fn();
+    console.log(`  ok   ${name}`);
+  } catch (error) {
+    failures++;
+    console.error(`  FAIL ${name}\n       ${error.message}`);
+  }
+}
+
+function run(...args) {
+  return execFileSync("node", [COMPARE, ...args], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+}
+
+try {
+  const current = join(dir, "current.json");
+  const base = join(dir, "base.json");
+  writeFileSync(current, report(9, 1));
+  writeFileSync(base, report(8, 2));
+
+  console.log("compatibility report comparison self-test");
+  check("uses the downloaded base report for deltas", () => {
+    const output = run(
+      "--current-report",
+      current,
+      "--base-report",
+      base,
+      "--pr-summary",
+    );
+    if (
+      !output.includes("| parser | 8/10 (80.0%) | 9/10 (90.0%) | +1 | -1 ✅ |")
+    ) {
+      throw new Error(`unexpected comparison output: ${output}`);
+    }
+  });
+  check("rejects a missing base report", () => {
+    try {
+      run(
+        "--current-report",
+        current,
+        "--base-report",
+        join(dir, "missing.json"),
+      );
+    } catch (error) {
+      if (error.status !== 0) return;
+    }
+    throw new Error("missing base report was accepted");
+  });
+  check("rejects a base report without categories", () => {
+    const invalid = join(dir, "invalid.json");
+    writeFileSync(invalid, "{}");
+    try {
+      run("--current-report", current, "--base-report", invalid);
+    } catch (error) {
+      if (error.status !== 0) return;
+    }
+    throw new Error("category-less base report was accepted");
+  });
+  check("validates the current report on main", () => {
+    const output = run("--current-report", current, "--validate");
+    if (!output.includes("validated 1 compatibility report categories")) {
+      throw new Error(`unexpected validation output: ${output}`);
+    }
+  });
+} finally {
+  rmSync(dir, { recursive: true, force: true });
+}
+
+process.exitCode = failures === 0 ? 0 : 1;

--- a/scripts/ci/test-compatibility-report-workflow.mjs
+++ b/scripts/ci/test-compatibility-report-workflow.mjs
@@ -1,0 +1,46 @@
+#!/usr/bin/env node
+
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const workflow = readFileSync(
+  join(HERE, "..", "..", ".github", "workflows", "ci.yml"),
+  "utf8",
+);
+let failures = 0;
+
+function check(name, condition) {
+  if (condition) console.log(`  ok   ${name}`);
+  else {
+    failures++;
+    console.error(`  FAIL ${name}`);
+  }
+}
+
+console.log("compatibility report workflow self-test");
+check(
+  "retrieves the PR base SHA artifact",
+  /github\.event\.pull_request\.base\.sha/.test(workflow) &&
+    /gh run download/.test(workflow),
+);
+check(
+  "passes the downloaded report to the comparator",
+  /--base-report "\$base_report"/.test(workflow),
+);
+check(
+  "fails closed when comparison cannot run",
+  !/comparison unavailable/.test(workflow) &&
+    !/Compare with main \(PR only\)[\s\S]{0,500}continue-on-error/.test(
+      workflow,
+    ),
+);
+check(
+  "validates and requires the newly generated report",
+  /name: Validate compatibility report/.test(workflow) &&
+    /--validate/.test(workflow) &&
+    /if-no-files-found: error/.test(workflow),
+);
+
+process.exitCode = failures === 0 ? 0 : 1;

--- a/scripts/diff/compare-compatibility-reports.mjs
+++ b/scripts/diff/compare-compatibility-reports.mjs
@@ -4,19 +4,19 @@
  * PR's base branch and emit a Markdown summary suitable for posting on a PR.
  *
  * Usage:
- *   node scripts/diff/compare-compatibility-reports.mjs --pr-summary > out.md
+ *   node scripts/diff/compare-compatibility-reports.mjs --base-report <path> --pr-summary > out.md
+ *   node scripts/diff/compare-compatibility-reports.mjs --validate
  *
  * The script:
  *   1. Locates the current report at fixtures/{commitHash}/compatibility-report.json
- *   2. Fetches the same file from origin/main via `git show`
+ *   2. Reads the base-branch report downloaded from a successful CI artifact
  *   3. Diffs per-category pass counts
  *   4. Prints a Markdown table; non-zero diffs are flagged
  *
- * If the base branch report can't be located, the script still prints the
- * current numbers so the PR comment is useful.
+ * A comparison without both reports is not meaningful, so malformed or absent
+ * reports fail rather than publishing a head-only table.
  */
 
-import { execSync } from 'child_process';
 import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
@@ -39,35 +39,23 @@ function findCurrentReport() {
     (a, b) => fs.statSync(b).mtimeMs - fs.statSync(a).mtimeMs,
   )[0];
 }
-
 function readJson(file) {
   return JSON.parse(fs.readFileSync(file, 'utf8'));
 }
 
-function tryReadBaseReport(currentReportRelative) {
-  const refs = ['origin/main', 'main'];
-  for (const ref of refs) {
-    try {
-      const out = execSync(`git show ${ref}:${currentReportRelative}`, {
-        cwd: ROOT,
-        stdio: ['ignore', 'pipe', 'ignore'],
-      }).toString();
-      return JSON.parse(out);
-    } catch {
-      // Not on this ref or file doesn't exist there. Try the next.
-    }
+function summarizeReport(report, label) {
+  if (!report || typeof report !== 'object' || !report.categories || typeof report.categories !== 'object') {
+    throw new Error(`${label} report has no categories`);
   }
-  return null;
-}
-
-function summarizeReport(report) {
-  if (!report || !report.categories) return null;
   const out = {};
   for (const [name, cat] of Object.entries(report.categories)) {
     // Two shapes are accepted:
     //   * tests/common/mod.rs: CategoryResult { stats: { total, passed, ... } }
     //   * scripts/fixtures/generate-fixtures.mjs manifest: flat { total, success, failed }
-    const stats = cat.stats ?? cat;
+    const stats = cat?.stats ?? cat;
+    if (!stats || typeof stats !== 'object') {
+      throw new Error(`${label} report category ${name} has no stats`);
+    }
     out[name] = {
       passed: stats.passed ?? stats.success ?? 0,
       total: stats.total ?? 0,
@@ -75,9 +63,9 @@ function summarizeReport(report) {
       skipped: stats.skipped ?? 0,
     };
   }
+  if (Object.keys(out).length === 0) throw new Error(`${label} report has no categories`);
   return out;
 }
-
 function getCommitHash(report) {
   return (
     report?.svelte_commit ??
@@ -98,21 +86,30 @@ function diffSign(n) {
 }
 
 function main() {
-  const args = new Set(process.argv.slice(2));
-  const isSummary = args.has('--pr-summary');
+  const args = process.argv.slice(2);
+  const isSummary = args.includes('--pr-summary');
+  const isValidate = args.includes('--validate');
+  const currentIndex = args.indexOf('--current-report');
+  const baseIndex = args.indexOf('--base-report');
+  const currentOverride = currentIndex === -1 ? null : args[currentIndex + 1];
+  const basePath = baseIndex === -1 ? null : args[baseIndex + 1];
+  if (currentIndex !== -1 && !currentOverride) throw new Error('--current-report requires a path');
+  if (!isValidate && !basePath) throw new Error('--base-report requires a path');
 
-  const currentPath = findCurrentReport();
+  const currentPath = currentOverride ?? findCurrentReport();
   if (!currentPath) {
-    process.stdout.write('_No compatibility report found in `fixtures/`._\n');
-    process.exit(0);
+    throw new Error('current compatibility report not found');
   }
-
-  const currentRel = path.relative(ROOT, currentPath);
   const current = readJson(currentPath);
-  const base = tryReadBaseReport(currentRel);
+  const currentSummary = summarizeReport(current, 'current');
+  if (isValidate) {
+    process.stdout.write(`validated ${Object.keys(currentSummary).length} compatibility report categories\n`);
+    return;
+  }
+  if (!fs.existsSync(basePath)) throw new Error(`base compatibility report not found: ${basePath}`);
 
-  const currentSummary = summarizeReport(current) ?? {};
-  const baseSummary = summarizeReport(base) ?? {};
+  const base = readJson(basePath);
+  const baseSummary = summarizeReport(base, 'base');
 
   const allCategories = Array.from(
     new Set([...Object.keys(currentSummary), ...Object.keys(baseSummary)]),
@@ -122,11 +119,7 @@ function main() {
   const currentHash = getCommitHash(current);
   const baseHash = getCommitHash(base);
   lines.push(`Current commit: \`${currentHash?.slice(0, 12) ?? 'unknown'}\``);
-  if (baseHash) {
-    lines.push(`Base commit:    \`${baseHash.slice(0, 12)}\``);
-  } else {
-    lines.push('_(Base branch report not available — showing current numbers only.)_');
-  }
+  lines.push(`Base commit:    \`${baseHash?.slice(0, 12) ?? 'unknown'}\``);
   lines.push('');
   lines.push('| Category | Base | Current | Δ passed | Δ failed |');
   lines.push('|----------|------|---------|----------|----------|');
@@ -168,4 +161,9 @@ function main() {
   }
 }
 
-main();
+try {
+  main();
+} catch (error) {
+  console.error(`compatibility-report comparison failed: ${error.message}`);
+  process.exitCode = 1;
+}


### PR DESCRIPTION
## Summary

- retrieve the report artifact from the exact PR-base SHA instead of reading ignored fixtures from git
- reject missing or malformed current/base reports and require the generated artifact
- add comparison and workflow contract tests

## Root cause

The report artifact is ignored, so `git show origin/main:fixtures/...` could never find the base report. The comment therefore compared the current report with zeroes.

## Validation

- `node scripts/ci/test-compatibility-report-comparison.mjs`
- `node scripts/ci/test-compatibility-report-workflow.mjs`
- `cargo fmt --all -- --check`
- downloaded a successful main CI artifact and compared it against itself