### PR TITLE
Simplify compatibility and performance result pages

### DIFF
--- a/apps/playground/src/routes/benchmark/+page.svelte
+++ b/apps/playground/src/routes/benchmark/+page.svelte
@@ -100,23 +100,6 @@
 				</div>
 			</section>
 
-			{#if report.benchmarkCoverage?.length}
-				<section class="coverage" aria-labelledby="coverage-title">
-					<div class="coverage-head">
-						<h2 id="coverage-title">Benchmark coverage</h2>
-						<strong>{report.benchmarkCoverage.filter((item) => item.status === 'measured').length}<span> / {report.benchmarkCoverage.length}</span></strong>
-					</div>
-					<div class="coverage-grid">
-						{#each report.benchmarkCoverage as item}
-							<div class:measured={item.status === 'measured'} class:unsupported={item.status === 'unsupported'}>
-								<i></i><span>{item.label}<small>{item.detail}</small></span><b>{item.status === 'measured' ? 'Measured' : item.status === 'unsupported' ? 'Unsupported' : 'Not measured'}</b>
-							</div>
-						{/each}
-					</div>
-					<p class="note">Surfaces follow <a href="https://github.com/pikax/svelte-benchmarks">pikax/svelte-benchmarks</a>. Results from a different machine or workload are not mixed into this report.</p>
-				</section>
-			{/if}
-
 			<section class="alternatives" aria-labelledby="alternatives-title">
 				<div class="comparison-head">
 					<h2 id="alternatives-title">Implementation comparison</h2>
@@ -216,22 +199,6 @@
 	.alternatives { padding-top: 2rem; border-top: 1px solid var(--rule); }
 	.comparison-head { display: flex; align-items: baseline; justify-content: space-between; gap: 1rem; margin-bottom: 1.25rem; }
 	.comparison-head p { margin: 0; color: var(--ink-faint); font-size: .8rem; }
-	.coverage { padding-top: 2rem; border-top: 1px solid var(--rule); }
-	.coverage-head { display: flex; align-items: baseline; justify-content: space-between; margin-bottom: 1rem; }
-	.coverage-head strong { color: var(--ok); font-size: 2rem; letter-spacing: -.05em; }
-	.coverage-head strong span { color: var(--ink-faint); font-size: 1rem; }
-	.coverage-grid { display: grid; grid-template-columns: repeat(2, 1fr); overflow: hidden; border: 1px solid var(--rule); border-radius: 10px; }
-	.coverage-grid > div { display: grid; grid-template-columns: auto minmax(0, 1fr) auto; gap: .7rem; align-items: center; padding: .9rem 1rem; border-bottom: 1px solid var(--rule); }
-	.coverage-grid > div:nth-child(odd) { border-right: 1px solid var(--rule); }
-	.coverage-grid > div:nth-last-child(-n + 2) { border-bottom: 0; }
-	.coverage-grid i { width: .55rem; height: .55rem; border-radius: 50%; background: var(--ink-faint); }
-	.coverage-grid .measured i { background: var(--ok); box-shadow: 0 0 0 4px color-mix(in srgb, var(--ok) 14%, transparent); }
-	.coverage-grid .unsupported i { background: var(--warn); }
-	.coverage-grid span { font-size: .88rem; font-weight: 650; }
-	.coverage-grid small { display: block; margin-top: .15rem; color: var(--ink-faint); font-size: .7rem; font-weight: 400; }
-	.coverage-grid b { color: var(--ink-faint); font-size: .68rem; font-weight: 500; text-transform: uppercase; }
-	.coverage-grid .measured b { color: var(--ok); }
-	.coverage a { color: var(--accent); }
 	.alternative-grid { display: grid; grid-template-columns: repeat(2, 1fr); gap: 1rem; }
 	.alternative-grid > article { padding: 1.25rem; border: 1px solid var(--rule); border-radius: 10px; background: var(--paper); }
 	.alternative-grid h3 { display: flex; justify-content: space-between; gap: 1rem; margin: 0 0 .8rem; font-size: 1rem; }
@@ -269,6 +236,6 @@
 	details li { margin: .45rem 0; line-height: 1.5; }
 	details a, .links a { color: var(--accent); }
 	.links { margin-top: 1.5rem; font-size: .82rem; }
-	@media (max-width: 820px) { .alternative-grid, .coverage-grid { grid-template-columns: 1fr; } .coverage-grid > div, .coverage-grid > div:nth-child(odd) { border-right: 0; border-bottom: 1px solid var(--rule); } .coverage-grid > div:last-child { border-bottom: 0; } .section-head, .comparison-head { align-items: flex-start; flex-direction: column; } .comparison-table { overflow-x: auto; } .table-head, .comparison-row { min-width: 680px; } }
+	@media (max-width: 820px) { .alternative-grid { grid-template-columns: 1fr; } .section-head, .comparison-head { align-items: flex-start; flex-direction: column; } .comparison-table { overflow-x: auto; } .table-head, .comparison-row { min-width: 680px; } }
 	@media (max-width: 640px) { main { padding: 3rem 1rem 5rem; } .result-grid { grid-template-columns: 1fr; } .result-card { padding: 1.2rem; } .section-head p { line-height: 1.7; } }
 </style>

--- a/apps/playground/src/routes/progress/+page.svelte
+++ b/apps/playground/src/routes/progress/+page.svelte
@@ -30,20 +30,11 @@
 				<p class="lede"><strong>{report.summary.exact.toLocaleString('en-US')} / {report.summary.total.toLocaleString('en-US')}</strong> real-world files match Svelte in CSR, SSR, CSR dev, and SSR dev. Parser, formatter, svelte2tsx, and lint are tracked separately below.</p>
 			</header>
 
-			<section class="summary" aria-label="Compatibility summary">
-				<div><strong>{report.summary.percentage.toFixed(3)}%</strong><span>exact across all 4 compiler modes</span></div>
-				<div><strong>{report.corpus.configuredFiles.toLocaleString('en-US')}</strong><span>real-world files</span></div>
-				<div><strong class:good={report.summary.unparseable === 0}>{report.summary.unparseable}</strong><span>invalid JS outputs</span></div>
-			</section>
-
 			<section class="surfaces" aria-label="Compatibility by surface">
 				{#each report.surfaces as surface}
 					{@const value = percentage(surface.matched, surface.total)}
 					<article>
-						<div class="surface-head">
-							<h2>{surface.label}</h2>
-							<span class:pass={surface.status === 'pass'} class:difference={surface.status === 'differences'}>{surface.status === 'pass' ? 'Exact' : surface.status === 'differences' ? 'Differences' : 'Unmeasured'}</span>
-						</div>
+						<h2>{surface.label}</h2>
 						{#if value !== null}
 							<strong class="score">{value.toFixed(value === 100 ? 0 : 2)}%</strong>
 							<p>{surface.matched?.toLocaleString('en-US')} / {surface.total?.toLocaleString('en-US')} {surface.unit}</p>
@@ -89,20 +80,9 @@
 	h1 { margin: 0 0 1rem; font-size: clamp(2.7rem, 7vw, 4rem); line-height: 1; letter-spacing: -.05em; }
 	.lede { color: var(--ink-soft); font-size: 1.1rem; line-height: 1.7; }
 	.lede strong { color: var(--ink); }
-	.summary { display: grid; grid-template-columns: repeat(3, 1fr); margin-top: 2.5rem; border: 1px solid var(--rule); border-radius: 10px; overflow: hidden; }
-	.summary div { padding: 1.2rem; border-right: 1px solid var(--rule); }
-	.summary div:last-child { border: 0; }
-	.summary strong, .summary span { display: block; }
-	.summary strong { font-size: 1.55rem; letter-spacing: -.03em; }
-	.summary span { margin-top: .2rem; color: var(--ink-soft); font-size: .78rem; }
-	.good { color: var(--ok); }
 	.surfaces { display: grid; grid-template-columns: 1fr 1fr; gap: .8rem; margin-top: 3rem; }
 	article { padding: 1.25rem; border: 1px solid var(--rule); border-radius: 10px; background: var(--paper); }
-	.surface-head { display: flex; justify-content: space-between; align-items: center; gap: 1rem; }
 	h2 { margin: 0; font-size: 1rem; }
-	.surface-head span { padding: .22rem .48rem; border-radius: 999px; background: var(--rule); color: var(--ink-soft); font-size: .66rem; font-weight: 700; text-transform: uppercase; }
-	.surface-head span.pass { color: var(--ok); background: color-mix(in srgb, var(--ok) 10%, transparent); }
-	.surface-head span.difference { color: var(--warn); background: color-mix(in srgb, var(--warn) 10%, transparent); }
 	.score { display: block; margin-top: 1.4rem; font-size: 2rem; letter-spacing: -.045em; }
 	article p { margin-top: .15rem; color: var(--ink-soft); font-size: .8rem; }
 	.track { height: 3px; margin: 1rem 0; overflow: hidden; border-radius: 99px; background: var(--rule); }
@@ -115,5 +95,5 @@
 	.competitors { margin-top: 3rem; }
 	.competitor-row { display: grid; grid-template-columns: minmax(170px, 1.4fr) repeat(4, 1fr); gap: .75rem; padding: .9rem 0; border-bottom: 1px solid var(--rule); align-items: center; }
 	.competitor-row span { color: var(--ink-soft); font-size: .78rem; }
-	@media (max-width: 640px) { main { padding: 3rem 1rem 5rem; } .summary { grid-template-columns: 1fr; } .summary div { border-right: 0; border-bottom: 1px solid var(--rule); } .surfaces { grid-template-columns: 1fr; } .competitor-row { grid-template-columns: 1fr 1fr; } .competitor-row strong { grid-column: 1 / -1; } }
+	@media (max-width: 640px) { main { padding: 3rem 1rem 5rem; } .surfaces { grid-template-columns: 1fr; } .competitor-row { grid-template-columns: 1fr 1fr; } .competitor-row strong { grid-column: 1 / -1; } }
 </style>


### PR DESCRIPTION
## What changed

- removed the compatibility summary strip
- removed status badges from compatibility cards
- removed the benchmark coverage section
- removed the corresponding unused responsive styles

## Why

The result pages should foreground measured compatibility and performance data without duplicative summaries or auxiliary coverage status.

## Validation

- `pnpm --dir apps/playground lint`
- `pnpm --dir apps/playground build`
- `git diff --check`