### PR TITLE
fix: lower generic template declaration runes

### DIFF
--- a/.changeset/fix-template-declaration-rune-generics.md
+++ b/.changeset/fix-template-declaration-rune-generics.md
@@ -1,0 +1,5 @@
+---
+'@rsvelte/compiler': patch
+---
+
+Compile TypeScript generic rune calls in template declarations without leaking `$state` into browser output.

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/declaration_tag.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/declaration_tag.rs
@@ -92,7 +92,13 @@ pub fn declaration_tag(node: &DeclarationTag, context: &mut ComponentContext) {
     // for the keyword, locate the top-level `=`, then strip the top-level `:`
     // annotation from the LHS pattern.
     // Mirrors upstream's reliance on OXC's TS-aware parse/emit.
-    let body_stripped = strip_ts_annotation_body(body);
+    let body_stripped = if context.state.analysis.is_typescript {
+        std::borrow::Cow::Owned(
+            crate::compiler::phases::phase2_analyze::types::strip_typescript(body),
+        )
+    } else {
+        strip_ts_annotation_body(body)
+    };
     let body = body_stripped.trim();
 
     // Ensure the statement ends with `;` so the rune-rewriting pipeline (which

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/visitors/declaration_tag.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/visitors/declaration_tag.rs
@@ -159,7 +159,11 @@ pub fn visit_declaration_tag<'a>(node: &DeclarationTag, state: &mut ServerTransf
     // `reparse_statement` parses plain mjs, so a `: type` annotation would make
     // it bail and silently drop the whole declaration. The official output is
     // the type-stripped JS (`const x = …`).
-    decl_src = strip_declarator_type_annotation(&decl_src);
+    decl_src = if state.analysis.is_typescript {
+        crate::compiler::phases::phase2_analyze::types::strip_typescript(&decl_src)
+    } else {
+        strip_declarator_type_annotation(&decl_src)
+    };
     if !decl_src.ends_with(';') {
         decl_src.push(';');
     }

--- a/crates/rsvelte_core/tests/template_declaration_runes_autodetection.rs
+++ b/crates/rsvelte_core/tests/template_declaration_runes_autodetection.rs
@@ -1,0 +1,39 @@
+use rsvelte_core::{CompileOptions, GenerateMode, compile, compiler::CssMode};
+
+#[test]
+fn declaration_tag_rune_auto_detects_runes_mode_before_scope_validation() {
+    let source = r#"<script lang="ts">
+</script>
+<footer>
+	{let x = $state<number>(0)}
+this is x: {x}
+	</footer>"#;
+
+    for (generate, dev) in [
+        (GenerateMode::Client, false),
+        (GenerateMode::Client, true),
+        (GenerateMode::Server, false),
+    ] {
+        let result = compile(
+            source,
+            CompileOptions {
+                filename: Some("Component.svelte".to_string()),
+                generate,
+                dev,
+                css: CssMode::External,
+                ..Default::default()
+            },
+        )
+        .expect("template declaration rune should compile");
+
+        assert!(
+            result.metadata.runes,
+            "declaration tag should enable runes mode"
+        );
+        assert!(
+            !result.js.code.contains("$state"),
+            "rune call must be lowered before it reaches the browser:\n{}",
+            result.js.code
+        );
+    }
+}


### PR DESCRIPTION
close: https://github.com/baseballyama/rsvelte/issues/2891

## What changed

Fixes typed template declaration runes such as `{let x = $state<number>(0)}`. The client and SSR declaration-tag paths now erase all TypeScript syntax before reusing their JavaScript lowering pipelines.

Adds a regression test for the reported component across client, client-dev, and SSR. It verifies both runes auto-detection and that raw `$state` never reaches generated JavaScript.

## Root cause

Runes auto-detection was already correct. The declaration-tag transforms used a narrow text stripper that removed only a declarator's `: Type` annotation. It left a rune call's `<number>` type argument intact, so the JavaScript reparser treated it as comparison operators and emitted `$state < number > 0`. The browser then raised `ReferenceError: $state is not defined`.

## Validation

- `cargo fmt`
- `cargo test -p rsvelte_core --test template_declaration_runes_autodetection`
- `cargo clippy -p rsvelte_core --test template_declaration_runes_autodetection -- -D warnings`
- WASM build is in progress locally; it is the same `rsvelte_core` compilation path used by the playground binding.
