### PR TITLE
fix(report): align SSR fixture dev options

### DIFF
--- a/crates/rsvelte_devtools/tests/compatibility_report.rs
+++ b/crates/rsvelte_devtools/tests/compatibility_report.rs
@@ -1125,7 +1125,9 @@ fn run_runtime_category_tests(category: &str) -> CategoryResult {
                 generate: GenerateMode::Server,
                 filename: Some(input_filename.clone()),
                 css: CssMode::External,
-                dev: fixture_options.dev,
+                // Runtime fixture SSR is always production, while sourcemap
+                // fixtures intentionally preserve their configured dev mode.
+                dev: category == "sourcemaps" && fixture_options.dev,
                 experimental: ExperimentalOptions {
                     r#async: fixture_options.r#async,
                 },


### PR DESCRIPTION
## Summary

Align the compatibility-report SSR compile options with the fixture generator and runtime gates.

Runtime and SSR fixtures always generate production SSR output; sourcemaps are the exception and retain their configured dev mode. The report previously passed browser `dev` settings to SSR, causing 167 false failures.

## Validation

- `cargo test --release --test compatibility_report report_sourcemaps_honor_fixture_dev_options -- --exact --nocapture`
- `cargo fmt --check`
- Full compatibility report before the branch refresh: 3,566 passed, 0 failed (86 scoped skips).