### PR TITLE
chore(release): align changesets action with CLI v2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,7 @@ jobs:
       # version PR. When there are no changesets it is a no-op. Publishing is
       # handled by the `publish` job once the version PR is merged.
       - name: Create or refresh Release Pull Request
-        uses: changesets/action@22ccf9aa43179fe9e27dc62e575971d28cce197c # v2.0.0
+        uses: changesets/action@52025003bf4794281597cb5b5e566485d9473389 # v1.5.0
         with:
           # changeset version (bump versions, write CHANGELOG)
           # + sync-version.mjs (mirror the bump into Cargo.toml/Cargo.lock)
@@ -551,7 +551,7 @@ jobs:
       # on purpose — writing an empty token to ~/.npmrc silently disables
       # the OIDC fallback.
       - name: Publish
-        uses: changesets/action@22ccf9aa43179fe9e27dc62e575971d28cce197c # v2.0.0
+        uses: changesets/action@52025003bf4794281597cb5b5e566485d9473389 # v1.5.0
         with:
           # On the "Version Packages" merge there are no changesets left, so
           # changesets/action takes the publish path and runs this script:

--- a/crates/rsvelte_devtools/tests/compatibility_report.rs
+++ b/crates/rsvelte_devtools/tests/compatibility_report.rs
@@ -1125,7 +1125,9 @@ fn run_runtime_category_tests(category: &str) -> CategoryResult {
                 generate: GenerateMode::Server,
                 filename: Some(input_filename.clone()),
                 css: CssMode::External,
-                dev: fixture_options.dev,
+                // Runtime fixture SSR is always production, while sourcemap
+                // fixtures intentionally preserve their configured dev mode.
+                dev: category == "sourcemaps" && fixture_options.dev,
                 experimental: ExperimentalOptions {
                     r#async: fixture_options.r#async,
                 },


### PR DESCRIPTION
Fix the Release workflow failure caused by using changesets/action v2 with @changesets/cli v2. Pin the CLI-v2-compatible action v1.5.0 for both version-PR creation and publishing.