### PR TITLE
fix(preprocess): preserve mdsvex extension filtering

### DIFF
--- a/crates/rsvelte_preprocess/js/mdsvex-bridge.mjs
+++ b/crates/rsvelte_preprocess/js/mdsvex-bridge.mjs
@@ -1,5 +1,6 @@
 // JS-fallback bridge for mdsvex. Reads `{ content, filename, options }` on
-// stdin and writes `{ ok: { code, map } }` / `{ renderError }` / `{ bridgeError }`.
+// stdin and writes `{ ok: { code, map } }` / `{ skip: true }` /
+// `{ renderError }` / `{ bridgeError }`.
 let input = '';
 for await (const chunk of process.stdin) input += chunk;
 const { content, filename, options } = JSON.parse(input);
@@ -19,6 +20,10 @@ try {
 try {
   const pp = await mdsvex(options || {});
   const res = await pp.markup({ content, filename });
+  if (!res) {
+    process.stdout.write(JSON.stringify({ skip: true }));
+    process.exit(0);
+  }
   const map = res && res.map ? (typeof res.map === 'string' ? res.map : JSON.stringify(res.map)) : null;
   process.stdout.write(
     JSON.stringify({ ok: { code: res && res.code != null ? res.code : content, map } }),

--- a/crates/rsvelte_preprocess/src/bridge.rs
+++ b/crates/rsvelte_preprocess/src/bridge.rs
@@ -105,7 +105,8 @@ pub struct MarkupBridge {
 /// Build a markup `PreprocessorGroup` that delegates to a Node bridge script.
 ///
 /// The script receives `{ content, filename, options }` on stdin and must reply
-/// with `{ ok: { code, map } }`, `{ bridgeError }`, or `{ renderError }`.
+/// with `{ ok: { code, map } }`, `{ skip: true }`, `{ bridgeError }`, or
+/// `{ renderError }`.
 #[must_use]
 pub fn markup_group(
     name: &'static str,
@@ -131,6 +132,9 @@ pub fn markup_group(
                     let value =
                         run(script, &request, &config.bridge).map_err(PreprocessError::Other)?;
 
+                    if value.get("skip").and_then(|v| v.as_bool()) == Some(true) {
+                        return Ok(None);
+                    }
                     if let Some(err) = value.get("renderError").and_then(|v| v.as_str()) {
                         return Err(PreprocessError::Other(err.to_string()));
                     }

--- a/crates/rsvelte_preprocess/tests/bridge_ports.rs
+++ b/crates/rsvelte_preprocess/tests/bridge_ports.rs
@@ -75,6 +75,30 @@ fn mdsvex_renders_markdown() {
 }
 
 #[test]
+fn mdsvex_skips_non_matching_extensions() {
+    let mut group = rsvelte_preprocess::mdsvex(bridge_at(repo_root(), serde_json::json!({})));
+    let markup = group.markup.take().unwrap();
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .build()
+        .unwrap();
+    let result = rt.block_on(markup(
+        rsvelte_core::compiler::preprocess::types::MarkupPreprocessorOptions {
+            content: "# Hello".to_string(),
+            filename: Some("test.svelte".to_string()),
+        },
+    ));
+
+    match result {
+        Ok(None) => {}
+        Ok(Some(processed)) => panic!("expected mdsvex to skip, got {}", processed.code),
+        Err(err) if err.to_string().contains("Cannot find module") => {
+            eprintln!("skipping: bridge tool unavailable: {err}");
+        }
+        Err(err) => panic!("bridge error: {err}"),
+    }
+}
+
+#[test]
 fn markdown_renders_component_in_markdown() {
     let group = rsvelte_preprocess::markdown(bridge_at(repo_root(), serde_json::json!(null)));
     let Some(out) = guard(run("# Hello\n\nsome **bold** text", "test.md", group)) else {


### PR DESCRIPTION
## Summary

Preserve mdsvex's extension filter in the Rust-side Node bridge. Official mdsvex returns `undefined` for filenames outside its configured extensions; the bridge now carries that through as a skipped markup preprocessor rather than treating the input as a transformed result.

## Why

The rsvelte preprocess path must retain the behavior of existing Svelte ecosystem preprocessors. Treating a skipped mdsvex file as a result diverged from mdsvex's `PreprocessorGroup` contract.

## Validation

- `cargo fmt --check`
- `cargo clippy -p rsvelte_preprocess --all-targets --all-features -- -D warnings`
- `cargo test -p rsvelte_preprocess --test bridge_ports mdsvex -- --nocapture`

Fixes #1436.