### PR TITLE
feat(preprocess): add native MDsveX Markdown core

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2766,6 +2766,7 @@ dependencies = [
  "regex",
  "rsvelte_core",
  "serde_json",
+ "serde_yaml",
  "tokio",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -229,6 +229,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
 
 [[package]]
+name = "caseless"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b6fd507454086c8edfd769ca6ada439193cdb209c7681712ef6275cccbfe5d8"
+dependencies = [
+ "unicode-normalization",
+]
+
+[[package]]
 name = "cast"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -472,6 +481,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "comrak"
+version = "0.54.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d5910408554659ed848ff469e67ec83b30f179e72cec286cfdae64d1616f466"
+dependencies = [
+ "caseless",
+ "entities",
+ "finl_unicode",
+ "jetscii",
+ "phf 0.13.1",
+ "phf_codegen",
+ "rustc-hash",
+ "smallvec",
+ "typed-arena",
+]
+
+[[package]]
 name = "console"
 version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -635,6 +661,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
+name = "entities"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5320ae4c3782150d900b79807611a59a99fc9a1d61d686faafc24b93fc8d7ca"
+
+[[package]]
 name = "equator"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -702,6 +734,12 @@ dependencies = [
  "libc",
  "winapi",
 ]
+
+[[package]]
+name = "finl_unicode"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9844ddc3a6e533d62bba727eb6c28b5d360921d5175e9ff0f1e621a5c590a4d5"
 
 [[package]]
 name = "float-cmp"
@@ -1227,6 +1265,12 @@ checksum = "6c5f4cff6dd96f6045e5e53d52ef114724989508a83e0dd72eea795844390297"
 dependencies = [
  "phf 0.14.0",
 ]
+
+[[package]]
+name = "jetscii"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47f142fe24a9c9944451e8349de0a56af5f3e7226dc46f3ed4d4ecc0b85af75e"
 
 [[package]]
 name = "js-sys"
@@ -2059,6 +2103,16 @@ dependencies = [
 
 [[package]]
 name = "phf"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
+dependencies = [
+ "phf_shared 0.13.1",
+ "serde",
+]
+
+[[package]]
+name = "phf"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "010378780309880b08997fae13be7834dba947d36393bd372f2b1556deb2a2f6"
@@ -2069,6 +2123,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "phf_codegen"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49aa7f9d80421bca176ca8dbfebe668cc7a2684708594ec9f3c0db0805d5d6e1"
+dependencies = [
+ "phf_generator 0.13.1",
+ "phf_shared 0.13.1",
+]
+
+[[package]]
 name = "phf_generator"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2076,6 +2140,16 @@ checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
  "phf_shared 0.11.3",
  "rand",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
+dependencies = [
+ "fastrand",
+ "phf_shared 0.13.1",
 ]
 
 [[package]]
@@ -2119,6 +2193,15 @@ name = "phf_shared"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
 dependencies = [
  "siphasher",
 ]
@@ -2678,6 +2761,7 @@ dependencies = [
 name = "rsvelte_preprocess"
 version = "0.1.0"
 dependencies = [
+ "comrak",
  "grass",
  "regex",
  "rsvelte_core",
@@ -3174,6 +3258,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "tokio"
 version = "1.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3265,6 +3364,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "typed-arena"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6af6ae20167a9ece4bcb41af5b80f8a1f1df981f6391189ce00fd257af04126a"
+
+[[package]]
 name = "typenum"
 version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3293,6 +3398,15 @@ name = "unicode-linebreak"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
 
 [[package]]
 name = "unicode-segmentation"

--- a/crates/rsvelte_preprocess/Cargo.toml
+++ b/crates/rsvelte_preprocess/Cargo.toml
@@ -32,7 +32,7 @@ less = ["dep:serde_json"]
 svelte-preprocess = ["sass", "dep:regex"]
 # JS-fallback markdown/CSS-modules ports (bridge to the installed upstream tool).
 mdsvex = ["bridge", "mdsvex-native"]
-mdsvex-native = ["dep:comrak"]
+mdsvex-native = ["dep:comrak", "dep:serde_yaml"]
 modular-css = ["bridge", "dep:regex"]
 markdown = ["bridge"]
 sveltex = ["bridge"]
@@ -43,6 +43,7 @@ grass = { version = "0.13", optional = true }
 serde_json = { version = "1", optional = true }
 regex = { version = "1.11", optional = true }
 comrak = { version = "0.54", default-features = false, optional = true }
+serde_yaml = { version = "0.9", optional = true }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["macros", "rt"] }

--- a/crates/rsvelte_preprocess/Cargo.toml
+++ b/crates/rsvelte_preprocess/Cargo.toml
@@ -31,7 +31,8 @@ less = ["dep:serde_json"]
 # scss, typescript). Reuses the `sass` backend for scss.
 svelte-preprocess = ["sass", "dep:regex"]
 # JS-fallback markdown/CSS-modules ports (bridge to the installed upstream tool).
-mdsvex = ["bridge"]
+mdsvex = ["bridge", "mdsvex-native"]
+mdsvex-native = ["dep:comrak"]
 modular-css = ["bridge", "dep:regex"]
 markdown = ["bridge"]
 sveltex = ["bridge"]
@@ -41,6 +42,7 @@ rsvelte_core = { path = "../rsvelte_core", default-features = false }
 grass = { version = "0.13", optional = true }
 serde_json = { version = "1", optional = true }
 regex = { version = "1.11", optional = true }
+comrak = { version = "0.54", default-features = false, optional = true }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["macros", "rt"] }

--- a/crates/rsvelte_preprocess/src/mdsvex.rs
+++ b/crates/rsvelte_preprocess/src/mdsvex.rs
@@ -2,12 +2,10 @@
 //! Svelte preprocessing.
 //!
 //! mdsvex's output is defined by its `unified`/remark/rehype pipeline (custom
-//! remark/rehype plugins, layouts, frontmatter, code highlighting). There is no
-//! pure-Rust engine that reproduces that output byte-for-byte, so this port
-//! follows the plan's JS-fallback boundary (§2.2 / §3): the rsvelte
-//! `PreprocessorGroup` delegates to the user's installed `mdsvex` over a Node
-//! bridge (`js/mdsvex-bridge.mjs`), making it a faithful drop-in on the
-//! rsvelte preprocess pipeline. A pure-Rust core is future work.
+//! remark/rehype plugins, layouts, frontmatter, code highlighting). The native
+//! module ports deterministic standard stages; the public `PreprocessorGroup`
+//! continues to delegate configurations requiring remaining stages or arbitrary
+//! JavaScript callbacks to the installed `mdsvex` package.
 
 use rsvelte_core::compiler::preprocess::types::PreprocessorGroup;
 

--- a/crates/rsvelte_preprocess/src/mdsvex.rs
+++ b/crates/rsvelte_preprocess/src/mdsvex.rs
@@ -13,6 +13,8 @@ use rsvelte_core::compiler::preprocess::types::PreprocessorGroup;
 
 use crate::bridge::{MarkupBridge, markup_group};
 
+pub mod native;
+
 const SCRIPT: &str = include_str!("../js/mdsvex-bridge.mjs");
 
 /// Build the `mdsvex` `PreprocessorGroup`.

--- a/crates/rsvelte_preprocess/src/mdsvex/native.rs
+++ b/crates/rsvelte_preprocess/src/mdsvex/native.rs
@@ -1,0 +1,46 @@
+//! Native building blocks for the mdsvex transform.
+//!
+//! The full mdsvex pipeline also accepts arbitrary JavaScript unified plugins,
+//! which remain on the official-package fallback path. This module contains
+//! only deterministic standard-transform pieces that can be differentially
+//! verified against mdsvex fixtures.
+
+use comrak::{Options, markdown_to_html};
+
+/// Render the CommonMark/GFM portion of mdsvex's standard pipeline.
+///
+/// Callers must run the mdsvex-specific Svelte, frontmatter, highlighting and
+/// layout stages around this renderer before exposing it as an mdsvex result.
+#[must_use]
+pub fn render_markdown(source: &str) -> String {
+    let mut options = Options::default();
+    options.parse.smart = true;
+    options.render.r#unsafe = true;
+    options.extension.strikethrough = true;
+    options.extension.table = true;
+    options.extension.autolink = true;
+    options.extension.tasklist = true;
+    format!("\n{}", escape_code(markdown_to_html(source, &options)))
+}
+
+fn escape_code(mut html: String) -> String {
+    let mut cursor = 0;
+    while let Some(relative_open) = html[cursor..].find("<code") {
+        let open = cursor + relative_open;
+        let Some(relative_body) = html[open..].find('>') else {
+            break;
+        };
+        let body = open + relative_body + 1;
+        let Some(relative_close) = html[body..].find("</code>") else {
+            break;
+        };
+        let close = body + relative_close;
+        let escaped = html[body..close]
+            .replace("&amp;", "&")
+            .replace('{', "&#123;")
+            .replace('}', "&#125;");
+        html.replace_range(body..close, &escaped);
+        cursor = body + escaped.len() + "</code>".len();
+    }
+    html
+}

--- a/crates/rsvelte_preprocess/src/mdsvex/native.rs
+++ b/crates/rsvelte_preprocess/src/mdsvex/native.rs
@@ -63,6 +63,7 @@ pub fn render_standard(source: &str) -> StandardResult {
 /// layout stages around this renderer before exposing it as an mdsvex result.
 #[must_use]
 pub fn render_markdown(source: &str) -> String {
+    let (preamble, source) = split_leading_script(source);
     let mut options = Options::default();
     options.parse.smart = true;
     options.render.r#unsafe = true;
@@ -70,7 +71,11 @@ pub fn render_markdown(source: &str) -> String {
     options.extension.table = true;
     options.extension.autolink = true;
     options.extension.tasklist = true;
-    format!("\n{}", escape_code(markdown_to_html(source, &options)))
+    let html = format!(
+        "\n{}",
+        restore_svelte_urls(escape_code(markdown_to_html(source, &options)))
+    );
+    preamble.map_or(html.clone(), |script| format!("{script}\n\n{html}"))
 }
 
 fn escape_code(mut html: String) -> String {
@@ -95,6 +100,25 @@ fn escape_code(mut html: String) -> String {
     html
 }
 
+fn restore_svelte_urls(mut html: String) -> String {
+    let mut cursor = 0;
+    while let Some(relative_open) = html[cursor..].find('<') {
+        let open = cursor + relative_open;
+        let Some(relative_end) = html[open..].find('>') else {
+            break;
+        };
+        let end = open + relative_end + 1;
+        if html[open..end].starts_with("<a ") || html[open..end].starts_with("<img ") {
+            let restored = html[open..end].replace("%7B", "{").replace("%7D", "}");
+            html.replace_range(open..end, &restored);
+            cursor = open + restored.len();
+        } else {
+            cursor = end;
+        }
+    }
+    html
+}
+
 fn split_frontmatter(source: &str) -> (Option<&str>, &str) {
     let Some(rest) = source.strip_prefix("---\n") else {
         return (None, source);
@@ -105,4 +129,15 @@ fn split_frontmatter(source: &str) -> (Option<&str>, &str) {
     let yaml = &rest[..end];
     let markdown = &rest[end + "\n---\n".len()..];
     (Some(yaml), markdown)
+}
+
+fn split_leading_script(source: &str) -> (Option<&str>, &str) {
+    if !source.starts_with("<script") {
+        return (None, source);
+    }
+    let Some(end) = source.find("</script>") else {
+        return (None, source);
+    };
+    let end = end + "</script>".len();
+    (Some(&source[..end]), source[end..].trim_start_matches('\n'))
 }

--- a/crates/rsvelte_preprocess/src/mdsvex/native.rs
+++ b/crates/rsvelte_preprocess/src/mdsvex/native.rs
@@ -6,6 +6,56 @@
 //! verified against mdsvex fixtures.
 
 use comrak::{Options, markdown_to_html};
+use serde_json::Value;
+
+/// The deterministic result of the standard MDsveX Markdown and frontmatter
+/// stages.
+#[derive(Debug, PartialEq)]
+pub struct StandardResult {
+    /// Svelte source emitted by the standard transform.
+    pub code: String,
+    /// The parsed YAML frontmatter, when present.
+    pub data: Option<Value>,
+}
+
+/// Render the standard Markdown and YAML-frontmatter portion of MDsveX.
+///
+/// This deliberately excludes option callbacks, layouts and Prism highlighting:
+/// callers with those options must use the official-package fallback until their
+/// native equivalents are complete.
+#[must_use]
+pub fn render_standard(source: &str) -> StandardResult {
+    let (frontmatter, markdown) = split_frontmatter(source);
+    let data: Option<Value> = frontmatter.and_then(|yaml| serde_yaml::from_str(yaml).ok());
+    let mut code = render_markdown(markdown);
+
+    if let Some(metadata) = &data
+        && let Some(object) = metadata.as_object()
+    {
+        let serialized = serde_json::to_string(metadata)
+            .expect("serde_json::Value always serializes")
+            .replace("<script", "<\"+\"script")
+            .replace("</script", "<\"+\"/script")
+            .replace("<style", "<\"+\"style")
+            .replace("</style", "<\"+\"/style");
+        let bindings = object
+            .keys()
+            .map(|key| {
+                if key.contains('-') {
+                    format!("'{key}': {}", key.replace('-', "_"))
+                } else {
+                    key.to_owned()
+                }
+            })
+            .collect::<Vec<_>>()
+            .join(", ");
+        code = format!(
+            "<script context=\"module\">\n\texport const metadata = {serialized};\n\tconst {{ {bindings} }} = metadata;\n</script>\n{code}"
+        );
+    }
+
+    StandardResult { code, data }
+}
 
 /// Render the CommonMark/GFM portion of mdsvex's standard pipeline.
 ///
@@ -43,4 +93,16 @@ fn escape_code(mut html: String) -> String {
         cursor = body + escaped.len() + "</code>".len();
     }
     html
+}
+
+fn split_frontmatter(source: &str) -> (Option<&str>, &str) {
+    let Some(rest) = source.strip_prefix("---\n") else {
+        return (None, source);
+    };
+    let Some(end) = rest.find("\n---\n") else {
+        return (None, source);
+    };
+    let yaml = &rest[..end];
+    let markdown = &rest[end + "\n---\n".len()..];
+    (Some(yaml), markdown)
 }

--- a/crates/rsvelte_preprocess/tests/mdsvex_native.rs
+++ b/crates/rsvelte_preprocess/tests/mdsvex_native.rs
@@ -1,0 +1,60 @@
+#![cfg(feature = "mdsvex")]
+
+use std::{
+    io::Write,
+    process::{Command, Stdio},
+};
+
+use rsvelte_preprocess::mdsvex::native::render_markdown;
+
+fn official(source: &str) -> String {
+    const SCRIPT: &str = r#"
+        import { mdsvex } from 'mdsvex';
+        let input = '';
+        for await (const chunk of process.stdin) input += chunk;
+        const pp = mdsvex({ extensions: ['.md'], highlight: false });
+        const result = await pp.markup({ content: JSON.parse(input), filename: 'fixture.md' });
+        process.stdout.write(result.code);
+    "#;
+    let mut child = Command::new("node")
+        .args(["--input-type=module", "-e", SCRIPT])
+        .current_dir(env!("CARGO_MANIFEST_DIR"))
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .spawn()
+        .unwrap();
+    child
+        .stdin
+        .take()
+        .unwrap()
+        .write_all(serde_json::to_string(source).unwrap().as_bytes())
+        .unwrap();
+    let output = child.wait_with_output().unwrap();
+    assert!(output.status.success());
+    String::from_utf8(output.stdout).unwrap()
+}
+
+fn assert_parity(name: &str, source: &str) {
+    assert_eq!(render_markdown(source), official(source), "{name}");
+}
+
+#[test]
+fn standard_markdown_matches_mdsvex_fixtures() {
+    for (name, source) in [
+        ("simple-paragraph", "Hello, world!"),
+        (
+            "strong",
+            "**important**\n\n__important__\n\nreally **freaking**strong",
+        ),
+        ("atx-heading", "# This is an H1\n\n## This is an H2"),
+        ("unordered-list", "* Red\n* Green\n* Blue"),
+        ("ordered-list", "1. One\n2. Two\n3. Three"),
+        ("blockquote", "> A quotation\n>\n> With two paragraphs"),
+        (
+            "inline-code",
+            "Please don't use any `<blink>` tags.\n\n`&#8212;` is the decimal-encoded equivalent of `&mdash;`.\n\nthis `inline **code** has ___magic___` chars",
+        ),
+    ] {
+        assert_parity(name, source);
+    }
+}

--- a/crates/rsvelte_preprocess/tests/mdsvex_native.rs
+++ b/crates/rsvelte_preprocess/tests/mdsvex_native.rs
@@ -5,7 +5,7 @@ use std::{
     process::{Command, Stdio},
 };
 
-use rsvelte_preprocess::mdsvex::native::render_markdown;
+use rsvelte_preprocess::mdsvex::native::{render_markdown, render_standard};
 
 fn official(source: &str) -> String {
     const SCRIPT: &str = r#"
@@ -38,6 +38,37 @@ fn assert_parity(name: &str, source: &str) {
     assert_eq!(render_markdown(source), official(source), "{name}");
 }
 
+fn official_with_data(source: &str) -> (String, serde_json::Value) {
+    const SCRIPT: &str = r#"
+        import { mdsvex } from 'mdsvex';
+        let input = '';
+        for await (const chunk of process.stdin) input += chunk;
+        const pp = mdsvex({ extensions: ['.md'], highlight: false });
+        const result = await pp.markup({ content: JSON.parse(input), filename: 'fixture.md' });
+        process.stdout.write(JSON.stringify({ code: result.code, data: result.data }));
+    "#;
+    let mut child = Command::new("node")
+        .args(["--input-type=module", "-e", SCRIPT])
+        .current_dir(env!("CARGO_MANIFEST_DIR"))
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .spawn()
+        .unwrap();
+    child
+        .stdin
+        .take()
+        .unwrap()
+        .write_all(serde_json::to_string(source).unwrap().as_bytes())
+        .unwrap();
+    let output = child.wait_with_output().unwrap();
+    assert!(output.status.success());
+    let result: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    (
+        result["code"].as_str().unwrap().to_owned(),
+        result["data"]["fm"].clone(),
+    )
+}
+
 #[test]
 fn standard_markdown_matches_mdsvex_fixtures() {
     for (name, source) in [
@@ -56,5 +87,19 @@ fn standard_markdown_matches_mdsvex_fixtures() {
         ),
     ] {
         assert_parity(name, source);
+    }
+}
+
+#[test]
+fn yaml_frontmatter_matches_mdsvex_output_and_data() {
+    for (name, source) in [
+        ("basic", "---\ntitle: Hello\nprice: '$10'\n---\n\n# Heading"),
+        ("hyphenated-key", "---\nfoo-bar: 1\n---\n\nHi"),
+        ("script-tag", "---\ntitle: '<script>'\n---\n\nHi"),
+    ] {
+        let native = render_standard(source);
+        let (code, data) = official_with_data(source);
+        assert_eq!(native.code, code, "{name}: code");
+        assert_eq!(native.data, Some(data), "{name}: data");
     }
 }

--- a/crates/rsvelte_preprocess/tests/mdsvex_native.rs
+++ b/crates/rsvelte_preprocess/tests/mdsvex_native.rs
@@ -85,6 +85,14 @@ fn standard_markdown_matches_mdsvex_fixtures() {
             "inline-code",
             "Please don't use any `<blink>` tags.\n\n`&#8212;` is the decimal-encoded equivalent of `&mdash;`.\n\nthis `inline **code** has ___magic___` chars",
         ),
+        ("template-expression", "Hello {name}"),
+        ("component", "<Component answer={42} />"),
+        ("component-in-heading", "## Hello {name}"),
+        (
+            "svelte-script",
+            "<script>let answer = 42;</script>\n\n# {answer}",
+        ),
+        ("link-expression", "[link](/things/{id})"),
     ] {
         assert_parity(name, source);
     }


### PR DESCRIPTION
## Summary

Adds the first native Rust building block for #1436: MDsveX's deterministic Markdown rendering core, backed by CommonMark/GFM parsing and MDsveX-compatible smart punctuation, raw HTML, and inline-code escaping.

The test invokes the installed official `mdsvex` package directly and compares byte-for-byte output for representative official fixtures. This revealed and implements MDsveX-specific handling of code entities and brace escaping.

## Scope

This is an intentionally bounded first native slice. The existing official-mdsvex bridge remains the production path while subsequent slices add the Svelte-aware parser, frontmatter, Prism-equivalent highlighting, layouts, and native-path routing. Arbitrary JavaScript remark/rehype plugins will retain the official fallback.

## Validation

- `cargo fmt --check`
- `cargo clippy -p rsvelte_preprocess --all-targets --all-features -- -D warnings`
- `cargo test -p rsvelte_preprocess --test mdsvex_native -- --nocapture`
- `cargo test -p rsvelte_preprocess --test bridge_ports -- --nocapture`

Refs #1436.