### PR TITLE
feat(language-server): add pull diagnostics

### DIFF
--- a/crates/rsvelte_language_server/src/client.rs
+++ b/crates/rsvelte_language_server/src/client.rs
@@ -28,6 +28,8 @@ pub struct ClientState {
     /// Whether the client understands a tree of document symbols rather than a
     /// flat list.
     pub hierarchical_document_symbols: bool,
+    /// Whether the client supports LSP 3.17 pull diagnostics.
+    pub pull_diagnostics: bool,
 }
 
 impl ClientState {
@@ -48,6 +50,9 @@ impl ClientState {
                 params,
                 "/capabilities/textDocument/documentSymbol/hierarchicalDocumentSymbolSupport",
             ),
+            pull_diagnostics: params
+                .pointer("/capabilities/textDocument/diagnostic")
+                .is_some(),
         }
     }
 }
@@ -96,6 +101,7 @@ mod tests {
         assert!(state.pull_configuration);
         assert!(state.line_folding_only);
         assert!(state.hierarchical_document_symbols);
+        assert!(!state.pull_diagnostics);
     }
 
     #[test]
@@ -105,6 +111,7 @@ mod tests {
         }));
         assert!(!state.line_folding_only);
         assert!(!state.hierarchical_document_symbols);
+        assert!(!state.pull_diagnostics);
     }
 
     #[test]

--- a/crates/rsvelte_language_server/src/server.rs
+++ b/crates/rsvelte_language_server/src/server.rs
@@ -10,13 +10,15 @@ use lsp_server::{Connection, ErrorCode, Message, Notification, Request, RequestI
 use lsp_types::{
     CodeActionKind, CodeActionOptions, CodeActionOrCommand, CodeActionParams,
     CodeActionProviderCapability, CompletionOptions, CompletionParams, ConfigurationItem,
-    ConfigurationParams, DidChangeTextDocumentParams, DidCloseTextDocumentParams,
-    DidOpenTextDocumentParams, DidSaveTextDocumentParams, DocumentFormattingParams,
-    DocumentSymbolParams, DocumentSymbolResponse, FoldingRange, FoldingRangeParams,
-    FoldingRangeProviderCapability, HoverParams, HoverProviderCapability, OneOf,
-    PublishDiagnosticsParams, SelectionRangeParams, SelectionRangeProviderCapability,
-    ServerCapabilities, TextDocumentPositionParams, TextDocumentSyncCapability,
-    TextDocumentSyncKind, TextDocumentSyncOptions, TextDocumentSyncSaveOptions, TextEdit, Uri,
+    ConfigurationParams, DiagnosticOptions, DiagnosticServerCapabilities,
+    DidChangeTextDocumentParams, DidCloseTextDocumentParams, DidOpenTextDocumentParams,
+    DidSaveTextDocumentParams, DocumentDiagnosticParams, DocumentDiagnosticReport,
+    DocumentFormattingParams, DocumentSymbolParams, DocumentSymbolResponse, FoldingRange,
+    FoldingRangeParams, FoldingRangeProviderCapability, FullDocumentDiagnosticReport, HoverParams,
+    HoverProviderCapability, OneOf, PublishDiagnosticsParams, RelatedFullDocumentDiagnosticReport,
+    SelectionRangeParams, SelectionRangeProviderCapability, ServerCapabilities,
+    TextDocumentPositionParams, TextDocumentSyncCapability, TextDocumentSyncKind,
+    TextDocumentSyncOptions, TextDocumentSyncSaveOptions, TextEdit, Uri,
 };
 
 use crate::client::ClientState;
@@ -55,7 +57,7 @@ pub fn run_stdio() -> Result<ExitCode> {
     connection.initialize_finish(
         id,
         serde_json::json!({
-            "capabilities": capabilities(),
+            "capabilities": capabilities(&client),
             "serverInfo": { "name": SERVER_NAME, "version": VERSION },
         }),
     )?;
@@ -76,7 +78,7 @@ pub fn run_stdio() -> Result<ExitCode> {
     Ok(code)
 }
 
-fn capabilities() -> ServerCapabilities {
+fn capabilities(client: &ClientState) -> ServerCapabilities {
     ServerCapabilities {
         text_document_sync: Some(TextDocumentSyncCapability::Options(
             TextDocumentSyncOptions {
@@ -99,6 +101,14 @@ fn capabilities() -> ServerCapabilities {
         folding_range_provider: Some(FoldingRangeProviderCapability::Simple(true)),
         selection_range_provider: Some(SelectionRangeProviderCapability::Simple(true)),
         document_symbol_provider: Some(OneOf::Left(true)),
+        diagnostic_provider: client.pull_diagnostics.then(|| {
+            DiagnosticServerCapabilities::Options(DiagnosticOptions {
+                identifier: Some(SERVER_NAME.to_string()),
+                inter_file_dependencies: false,
+                workspace_diagnostics: false,
+                ..DiagnosticOptions::default()
+            })
+        }),
         ..ServerCapabilities::default()
     }
 }
@@ -114,6 +124,7 @@ enum Pending {
     FoldingRange,
     SelectionRange,
     DocumentSymbol,
+    DocumentDiagnostic,
 }
 
 /// A request this server sent to the client, keyed by the id the client will
@@ -223,6 +234,7 @@ impl Server {
             "textDocument/foldingRange" => self.on_folding_range(request),
             "textDocument/selectionRange" => self.on_selection_range(request),
             "textDocument/documentSymbol" => self.on_document_symbol(request),
+            "textDocument/diagnostic" => self.on_document_diagnostic(request),
             _ => self.respond(Response::new_err(
                 request.id,
                 ErrorCode::MethodNotFound as i32,
@@ -258,6 +270,34 @@ impl Server {
         };
         self.pending.insert(id, Pending::Formatting);
         self.worker.submit(job);
+    }
+
+    fn on_document_diagnostic(&mut self, request: Request) {
+        let id = request.id;
+        let params = match serde_json::from_value::<DocumentDiagnosticParams>(request.params) {
+            Ok(params) => params,
+            Err(err) => {
+                log::warn(format_args!("textDocument/diagnostic: {err}"));
+                self.respond_diagnostic_report(id, Vec::new());
+                return;
+            }
+        };
+        let uri = params.text_document.uri;
+        let Some(document) = self.documents.get(&uri) else {
+            self.respond_diagnostic_report(id, Vec::new());
+            return;
+        };
+        if !self.settings.lint_enable || !is_lint_target(document) {
+            self.respond_diagnostic_report(id, Vec::new());
+            return;
+        }
+        self.pending.insert(id.clone(), Pending::DocumentDiagnostic);
+        self.worker.submit(Job::PullDiagnostics {
+            id,
+            path: uri_to_path(uri.as_str()),
+            text: document.shared_text(),
+            warnings: self.settings.compiler_warnings.clone(),
+        });
     }
 
     fn on_completion(&mut self, request: Request) {
@@ -483,7 +523,9 @@ impl Server {
                         let key = doc.uri.as_str().to_string();
                         self.documents
                             .open(doc.uri, doc.language_id, doc.version, doc.text);
-                        self.schedule_lint(key, Duration::ZERO);
+                        if !self.client.pull_diagnostics {
+                            self.schedule_lint(key, Duration::ZERO);
+                        }
                     }
                     Err(err) => log::warn(format_args!("{method}: {err}")),
                 }
@@ -494,7 +536,9 @@ impl Server {
                         let key = params.text_document.uri.as_str().to_string();
                         if let Some(document) = self.documents.get_mut(&params.text_document.uri) {
                             document.apply(params.text_document.version, &params.content_changes);
-                            self.schedule_lint(key, LINT_DEBOUNCE);
+                            if !self.client.pull_diagnostics {
+                                self.schedule_lint(key, LINT_DEBOUNCE);
+                            }
                         }
                     }
                     Err(err) => log::warn(format_args!("{method}: {err}")),
@@ -502,10 +546,14 @@ impl Server {
             }
             "textDocument/didSave" => {
                 match serde_json::from_value::<DidSaveTextDocumentParams>(notification.params) {
-                    Ok(params) => self.schedule_lint(
-                        params.text_document.uri.as_str().to_string(),
-                        Duration::ZERO,
-                    ),
+                    Ok(params) => {
+                        if !self.client.pull_diagnostics {
+                            self.schedule_lint(
+                                params.text_document.uri.as_str().to_string(),
+                                Duration::ZERO,
+                            );
+                        }
+                    }
                     Err(err) => log::warn(format_args!("{method}: {err}")),
                 }
             }
@@ -516,7 +564,9 @@ impl Server {
                         self.scheduled.remove(uri.as_str());
                         self.linted.remove(uri.as_str());
                         let version = self.documents.close(&uri).map_or(0, |d| d.version);
-                        self.publish(uri, version, Vec::new());
+                        if !self.client.pull_diagnostics {
+                            self.publish(uri, version, Vec::new());
+                        }
                     }
                     Err(err) => log::warn(format_args!("{method}: {err}")),
                 }
@@ -530,7 +580,9 @@ impl Server {
                     self.request_configuration();
                 } else {
                     self.settings = Settings::default();
-                    self.relint_open_documents();
+                    if !self.client.pull_diagnostics {
+                        self.relint_open_documents();
+                    }
                 }
             }
             "exit" => self.exiting = true,
@@ -559,7 +611,9 @@ impl Server {
                         Settings::default()
                     }
                 };
-                self.relint_open_documents();
+                if !self.client.pull_diagnostics {
+                    self.relint_open_documents();
+                }
             }
         }
     }
@@ -601,6 +655,11 @@ impl Server {
             Outcome::DocumentSymbols { id, symbols } => {
                 if self.pending.remove(&id).is_some() {
                     self.respond(Response::new_ok(id, symbols));
+                }
+            }
+            Outcome::PulledDiagnostics { id, diagnostics } => {
+                if self.pending.remove(&id).is_some() {
+                    self.respond_diagnostic_report(id, diagnostics);
                 }
             }
             Outcome::Diagnostics {
@@ -701,6 +760,17 @@ impl Server {
                 version: Some(version),
             },
         ));
+    }
+
+    fn respond_diagnostic_report(&self, id: RequestId, diagnostics: Vec<lsp_types::Diagnostic>) {
+        let report = DocumentDiagnosticReport::Full(RelatedFullDocumentDiagnosticReport {
+            related_documents: None,
+            full_document_diagnostic_report: FullDocumentDiagnosticReport {
+                result_id: None,
+                items: diagnostics,
+            },
+        });
+        self.respond(Response::new_ok(id, report));
     }
 
     fn respond_no_edits(&self, id: RequestId) {

--- a/crates/rsvelte_language_server/src/worker.rs
+++ b/crates/rsvelte_language_server/src/worker.rs
@@ -85,6 +85,12 @@ pub enum Job {
         text: Arc<String>,
         hierarchical: bool,
     },
+    PullDiagnostics {
+        id: RequestId,
+        path: PathBuf,
+        text: Arc<String>,
+        warnings: CompilerWarnings,
+    },
     /// Drop the resolved `rsvelte-lint.json` / `.oxfmtrc` caches so the next
     /// job re-reads them from disk.
     ClearCaches,
@@ -124,6 +130,10 @@ pub enum Outcome {
     DocumentSymbols {
         id: RequestId,
         symbols: DocumentSymbolResponse,
+    },
+    PulledDiagnostics {
+        id: RequestId,
+        diagnostics: Vec<Diagnostic>,
     },
 }
 
@@ -282,6 +292,22 @@ fn run(jobs: &Receiver<Job>, outcomes: &Sender<Outcome>) {
                 })
                 .unwrap_or_else(|| DocumentSymbolResponse::Nested(Vec::new())),
             },
+            Job::PullDiagnostics {
+                id,
+                path,
+                text,
+                warnings,
+            } => {
+                let config = lint_configs.get(path.parent().unwrap_or(Path::new(".")));
+                let diagnostics = guard("pull diagnostics", &path, || {
+                    crate::lint::lint(&path, &text, &config)
+                        .iter()
+                        .filter_map(|d| crate::diagnostics::to_lsp(d, &warnings))
+                        .collect()
+                })
+                .unwrap_or_default();
+                Outcome::PulledDiagnostics { id, diagnostics }
+            }
         };
         if outcomes.send(outcome).is_err() {
             break;

--- a/crates/rsvelte_language_server/tests/protocol.rs
+++ b/crates/rsvelte_language_server/tests/protocol.rs
@@ -191,6 +191,14 @@ impl Server {
         self.response(id)
     }
 
+    fn pull_diagnostics(&mut self, uri: &str) -> Value {
+        let id = self.request(
+            "textDocument/diagnostic",
+            json!({ "textDocument": { "uri": uri } }),
+        );
+        self.response(id)
+    }
+
     /// Read until diagnostics for `uri` arrive.
     fn diagnostics(&mut self, uri: &str) -> Vec<Value> {
         loop {
@@ -487,6 +495,45 @@ fn serves_diagnostics_and_formatting() {
     );
     server.cleared_diagnostics(&uri);
 
+    assert_eq!(server.shutdown(), Some(0));
+}
+
+#[test]
+fn serves_pull_diagnostics_without_push_notifications() {
+    let path = temp_component();
+    let uri = file_uri(&path);
+    let mut server = Server::start();
+    let id = server.request(
+        "initialize",
+        json!({
+            "processId": Value::Null,
+            "rootUri": Value::Null,
+            "capabilities": { "textDocument": { "diagnostic": {} } },
+        }),
+    );
+    let capabilities = server.response(id)["capabilities"].clone();
+    assert_eq!(
+        capabilities["diagnosticProvider"]["interFileDependencies"],
+        json!(false)
+    );
+    assert_eq!(
+        capabilities["diagnosticProvider"]["workspaceDiagnostics"],
+        json!(false)
+    );
+    server.notify("initialized", json!({}));
+    did_open(&mut server, &uri, SOURCE);
+
+    let mut config_cache = rsvelte_language_server::lint::LintConfigCache::default();
+    let config = config_cache.get(path.parent().unwrap());
+    let warnings = rsvelte_language_server::settings::CompilerWarnings::default();
+    let expected: Vec<Value> = rsvelte_language_server::lint::lint(&path, SOURCE, &config)
+        .iter()
+        .filter_map(|d| rsvelte_language_server::diagnostics::to_lsp(d, &warnings))
+        .map(|d| serde_json::to_value(d).unwrap())
+        .collect();
+    let report = server.pull_diagnostics(&uri);
+    assert_eq!(report["kind"], json!("full"));
+    assert_eq!(report["items"], json!(expected));
     assert_eq!(server.shutdown(), Some(0));
 }
 


### PR DESCRIPTION
Implements the LSP 3.17 `textDocument/diagnostic` pull path for #1761.

- advertises pull diagnostics only to supporting clients
- executes linting on the existing analysis worker
- retains push diagnostics as the fallback for older clients
- verifies wire output through the real stdio server integration test