### PR TITLE
feat(language-server): support request cancellation

### DIFF
--- a/crates/rsvelte_language_server/src/server.rs
+++ b/crates/rsvelte_language_server/src/server.rs
@@ -8,17 +8,17 @@ use anyhow::Result;
 use crossbeam_channel::{Receiver, Sender, after, never, select, unbounded};
 use lsp_server::{Connection, ErrorCode, Message, Notification, Request, RequestId, Response};
 use lsp_types::{
-    CodeActionKind, CodeActionOptions, CodeActionOrCommand, CodeActionParams,
+    CancelParams, CodeActionKind, CodeActionOptions, CodeActionOrCommand, CodeActionParams,
     CodeActionProviderCapability, CompletionOptions, CompletionParams, ConfigurationItem,
     ConfigurationParams, DiagnosticOptions, DiagnosticServerCapabilities,
     DidChangeTextDocumentParams, DidCloseTextDocumentParams, DidOpenTextDocumentParams,
     DidSaveTextDocumentParams, DocumentDiagnosticParams, DocumentDiagnosticReport,
     DocumentFormattingParams, DocumentSymbolParams, DocumentSymbolResponse, FoldingRange,
     FoldingRangeParams, FoldingRangeProviderCapability, FullDocumentDiagnosticReport, HoverParams,
-    HoverProviderCapability, OneOf, PublishDiagnosticsParams, RelatedFullDocumentDiagnosticReport,
-    SelectionRangeParams, SelectionRangeProviderCapability, ServerCapabilities,
-    TextDocumentPositionParams, TextDocumentSyncCapability, TextDocumentSyncKind,
-    TextDocumentSyncOptions, TextDocumentSyncSaveOptions, TextEdit, Uri,
+    HoverProviderCapability, NumberOrString, OneOf, PublishDiagnosticsParams,
+    RelatedFullDocumentDiagnosticReport, SelectionRangeParams, SelectionRangeProviderCapability,
+    ServerCapabilities, TextDocumentPositionParams, TextDocumentSyncCapability,
+    TextDocumentSyncKind, TextDocumentSyncOptions, TextDocumentSyncSaveOptions, TextEdit, Uri,
 };
 
 use crate::client::ClientState;
@@ -516,6 +516,12 @@ impl Server {
     fn on_notification(&mut self, notification: Notification) {
         let method = notification.method.clone();
         match method.as_str() {
+            "$/cancelRequest" => {
+                match serde_json::from_value::<CancelParams>(notification.params) {
+                    Ok(params) => self.cancel_request(params.id),
+                    Err(err) => log::warn(format_args!("{method}: {err}")),
+                }
+            }
             "textDocument/didOpen" => {
                 match serde_json::from_value::<DidOpenTextDocumentParams>(notification.params) {
                     Ok(params) => {
@@ -587,6 +593,20 @@ impl Server {
             }
             "exit" => self.exiting = true,
             _ => {}
+        }
+    }
+
+    fn cancel_request(&mut self, id: NumberOrString) {
+        let id = match id {
+            NumberOrString::Number(id) => RequestId::from(id),
+            NumberOrString::String(id) => RequestId::from(id),
+        };
+        if self.pending.remove(&id).is_some() {
+            self.respond(Response::new_err(
+                id,
+                ErrorCode::RequestCanceled as i32,
+                "request cancelled by client".to_string(),
+            ));
         }
     }
 

--- a/crates/rsvelte_language_server/tests/protocol.rs
+++ b/crates/rsvelte_language_server/tests/protocol.rs
@@ -116,10 +116,14 @@ impl Server {
     /// Read until the response to `id` arrives, answering any
     /// `workspace/configuration` the server asks for on the way.
     fn response(&mut self, id: i64) -> Value {
+        self.response_message(id)["result"].clone()
+    }
+
+    fn response_message(&mut self, id: i64) -> Value {
         loop {
             let message = self.read();
             if message.get("id").and_then(Value::as_i64) == Some(id) {
-                return message["result"].clone();
+                return message;
             }
             self.answer_server_request(&message);
         }
@@ -863,6 +867,29 @@ fn a_notification_between_shutdown_and_exit_is_harmless() {
     server.response(id);
     server.notify("$/cancelRequest", json!({ "id": 1 }));
     assert_eq!(server.exit(), Some(0));
+}
+
+#[test]
+fn cancellation_returns_the_lsp_cancelled_error() {
+    let dir = temp_dir("cancel");
+    let uri = file_uri(&dir.join("App.svelte"));
+    let mut server = initialized_server();
+    did_open(
+        &mut server,
+        &uri,
+        &format!("{}{}", "<div>".repeat(500), "</div>".repeat(500)),
+    );
+    let id = server.request(
+        "textDocument/formatting",
+        json!({
+            "textDocument": { "uri": uri },
+            "options": { "tabSize": 2, "insertSpaces": true },
+        }),
+    );
+    server.notify("$/cancelRequest", json!({ "id": id }));
+    let response = server.response_message(id);
+    assert_eq!(response["error"]["code"], json!(-32800));
+    assert_eq!(server.shutdown(), Some(0));
 }
 
 /// Editing `rsvelte-lint.json` reaches the server as a configuration change,


### PR DESCRIPTION
Implements the LSP cancellation portion of #1761.

- handles `$/cancelRequest` for every async worker-backed request
- returns the protocol-defined `RequestCanceled` error
- discards late worker outcomes
- verifies behavior through the stdio integration test