### PR TITLE
fix(napi): accept callable preprocessor maps

### DIFF
--- a/.changeset/green-callable-preprocessor-map.md
+++ b/.changeset/green-callable-preprocessor-map.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/vite-plugin-svelte-native": patch
+---
+
+Accept callable source maps returned by Svelte preprocessors such as SCSS.

--- a/crates/rsvelte_core/src/toolchain.rs
+++ b/crates/rsvelte_core/src/toolchain.rs
@@ -437,11 +437,33 @@ impl<'source> PreparedComponent<'source> {
             root.entry("comments")
                 .or_insert_with(|| Value::Array(Vec::new()));
         }
+        add_stylesheet_comments(&mut value);
         if !self.source.is_ascii() {
             let positions = crate::compiler::legacy::Utf8ToUtf16::new(self.source);
             crate::compiler::legacy::convert_positions_to_utf16(&mut value, &positions);
         }
         serde_json::to_string(&value).expect("the public AST JSON is serializable")
+    }
+}
+
+fn add_stylesheet_comments(value: &mut Value) {
+    match value {
+        Value::Object(object) => {
+            if object.get("type").and_then(Value::as_str) == Some("StyleSheet") {
+                object
+                    .entry("comments")
+                    .or_insert_with(|| Value::Array(Vec::new()));
+            }
+            for child in object.values_mut() {
+                add_stylesheet_comments(child);
+            }
+        }
+        Value::Array(items) => {
+            for item in items {
+                add_stylesheet_comments(item);
+            }
+        }
+        _ => {}
     }
 }
 

--- a/crates/rsvelte_napi/src/lib.rs
+++ b/crates/rsvelte_napi/src/lib.rs
@@ -1507,8 +1507,15 @@ mod preprocess_bridge {
     // `CalleeHandled = false` const generic suppresses the legacy
     // err-as-first-arg shape that would otherwise break every preprocessor
     // that destructures `{ content, filename }`.
-    pub type Tsfn =
-        ThreadsafeFunction<Value, MaybePromise<Option<Value>>, Value, Status, false, false, 0>;
+    pub type Tsfn = ThreadsafeFunction<
+        Value,
+        MaybePromise<Option<JsProcessed>>,
+        Value,
+        Status,
+        false,
+        false,
+        0,
+    >;
     pub type ArcTsfn = std::sync::Arc<Tsfn>;
 
     pub struct Extracted {
@@ -1553,8 +1560,7 @@ mod preprocess_bridge {
                         "content": opts.content,
                         "filename": opts.filename,
                     });
-                    let ret_val = await_tsfn(&tsfn, arg).await?;
-                    Ok(json_to_processed(&ret_val))
+                    await_tsfn(&tsfn, arg).await
                 })
             },
         )
@@ -1570,13 +1576,12 @@ mod preprocess_bridge {
                     "markup": opts.markup,
                     "filename": opts.filename,
                 });
-                let ret_val = await_tsfn(&tsfn, arg).await?;
-                Ok(json_to_processed(&ret_val))
+                await_tsfn(&tsfn, arg).await
             })
         })
     }
 
-    async fn await_tsfn(tsfn: &Tsfn, arg: Value) -> Result<Value, PreprocessError> {
+    async fn await_tsfn(tsfn: &Tsfn, arg: Value) -> Result<Option<Processed>, PreprocessError> {
         // The upstream Svelte preprocessor contract allows the callback to
         // return `Processed | Promise<Processed> | undefined | null`,
         // sync or async. `MaybePromise<Option<Value>>` probes `napi_is_promise`
@@ -1587,13 +1592,96 @@ mod preprocess_bridge {
         // `Option` collapses `undefined`/`null` to `None` on both paths.
         match tsfn.call_async(arg).await {
             Ok(MaybePromise::Promise(promise)) => match promise.await {
-                Ok(Some(v)) => Ok(v),
-                Ok(None) => Ok(Value::Null),
+                Ok(Some(v)) => Ok(Some(v.into_processed())),
+                Ok(None) => Ok(None),
                 Err(e) => Err(PreprocessError::Other(format!("{e}"))),
             },
-            Ok(MaybePromise::Value(Some(v))) => Ok(v),
-            Ok(MaybePromise::Value(None)) => Ok(Value::Null),
+            Ok(MaybePromise::Value(Some(v))) => Ok(Some(v.into_processed())),
+            Ok(MaybePromise::Value(None)) => Ok(None),
             Err(e) => Err(PreprocessError::Other(format!("{e}"))),
+        }
+    }
+
+    /// The JS contract permits source-map objects such as Sass's `SourceMapGenerator`,
+    /// whose `toString` is a function. Decode only the fields we consume instead of
+    /// asking napi-rs to JSON-serialize the entire user-controlled return object.
+    pub struct JsProcessed {
+        code: String,
+        map: Option<SourceMapInput>,
+        dependencies: Vec<String>,
+        attributes: Option<FxHashMap<String, RsAttrValue>>,
+    }
+
+    impl JsProcessed {
+        fn into_processed(self) -> Processed {
+            Processed {
+                code: self.code,
+                map: self.map,
+                dependencies: self.dependencies,
+                attributes: self.attributes,
+            }
+        }
+    }
+
+    impl FromNapiValue for JsProcessed {
+        unsafe fn from_napi_value(
+            env: napi::sys::napi_env,
+            napi_val: napi::sys::napi_value,
+        ) -> napi::Result<Self> {
+            let obj = Object::from_raw(env, napi_val);
+            let code = obj.get::<String>("code")?.ok_or_else(|| {
+                napi::Error::from_reason("preprocessor result is missing string `code`")
+            })?;
+            let map = obj
+                .get::<JsSourceMap>("map")?
+                .and_then(JsSourceMap::into_input);
+            let dependencies = obj.get::<Vec<String>>("dependencies")?.unwrap_or_default();
+            let attributes = obj
+                .get::<Value>("attributes")?
+                .as_ref()
+                .and_then(json_to_attributes);
+            Ok(Self {
+                code,
+                map,
+                dependencies,
+                attributes,
+            })
+        }
+    }
+
+    enum JsSourceMap {
+        Json(Value),
+        Stringified(String),
+    }
+
+    impl JsSourceMap {
+        fn into_input(self) -> Option<SourceMapInput> {
+            match self {
+                Self::Json(value) => json_to_sourcemap_input(&value),
+                Self::Stringified(json) => json_to_sourcemap_input(&Value::String(json)),
+            }
+        }
+    }
+
+    impl FromNapiValue for JsSourceMap {
+        unsafe fn from_napi_value(
+            env: napi::sys::napi_env,
+            napi_val: napi::sys::napi_value,
+        ) -> napi::Result<Self> {
+            // SAFETY: Node passed this valid value to `FromNapiValue`.
+            if let Ok(value) = unsafe { Value::from_napi_value(env, napi_val) } {
+                return Ok(Self::Json(value));
+            }
+
+            let obj = Object::from_raw(env, napi_val);
+            let stringify = obj
+                .get::<napi::bindgen_prelude::Function<(), String>>("toString")?
+                .ok_or_else(|| {
+                    napi::Error::from_reason(
+                        "preprocessor source map is neither JSON-serializable nor stringifiable",
+                    )
+                })?;
+            Ok(Self::Stringified(stringify.apply(obj, ())?))
         }
     }
 
@@ -1609,33 +1697,6 @@ mod preprocess_bridge {
             );
         }
         Value::Object(map)
-    }
-
-    fn json_to_processed(val: &Value) -> Option<Processed> {
-        let obj = val.as_object()?;
-
-        let code = obj.get("code").and_then(|v| v.as_str()).map(String::from)?;
-
-        let map = obj.get("map").and_then(json_to_sourcemap_input);
-
-        let dependencies = obj
-            .get("dependencies")
-            .and_then(|v| v.as_array())
-            .map(|arr| {
-                arr.iter()
-                    .filter_map(|v| v.as_str().map(String::from))
-                    .collect::<Vec<_>>()
-            })
-            .unwrap_or_default();
-
-        let attributes = obj.get("attributes").and_then(json_to_attributes);
-
-        Some(Processed {
-            code,
-            map,
-            dependencies,
-            attributes,
-        })
     }
 
     fn json_to_sourcemap_input(val: &Value) -> Option<SourceMapInput> {

--- a/scripts/dev/test-vps-shim.mjs
+++ b/scripts/dev/test-vps-shim.mjs
@@ -177,6 +177,28 @@ assert(
 	out?.code,
 );
 
+// Sass and other preprocessors return source-map instances with methods. The
+// N-API boundary must consume the documented fields without JSON-serializing
+// arbitrary callback objects (which rejects functions).
+const sourcemapped = await r.preprocess('<h1>map</h1>', [
+	{
+		markup: ({ content }) => ({
+			code: content,
+			ignoredCallbackState: () => {},
+			map: {
+				toString() {
+					return JSON.stringify({ version: 3, sources: ['Input.svelte'], names: [], mappings: '' });
+				},
+			},
+		}),
+	},
+]);
+assert(
+	'preprocess() accepts callable source-map instances and ignores unrelated callback functions',
+	typeof sourcemapped?.code === 'string' && sourcemapped?.map?.version === 3,
+	JSON.stringify(sourcemapped),
+);
+
 // 6. VERSION constant — feature detection in the shim
 assert(
 	'VERSION exposes upstream Svelte semver',


### PR DESCRIPTION
## Summary

- decode preprocessor callback results field-by-field at the N-API boundary
- normalize callable source-map instances through `toString()`
- add an end-to-end regression covering callable maps and unrelated function fields

## Root cause

The bridge attempted to convert the entire JavaScript callback result into `serde_json::Value`. SCSS preprocessors may return a source-map object with a `toString` function, which JSON conversion rejects even though the Svelte preprocessor contract accepts it.

Fixes #2915.

## Validation

- `cargo fmt --check`
- `cargo clippy -p rsvelte_napi --all-targets --all-features -- -D warnings`
- `pnpm run build:vps-native`
- `pnpm run test:vps-shim` (62 passed)