### PR TITLE
feat(language-server): track workspace folder changes

### DIFF
--- a/crates/rsvelte_language_server/src/client.rs
+++ b/crates/rsvelte_language_server/src/client.rs
@@ -55,6 +55,26 @@ impl ClientState {
                 .is_some(),
         }
     }
+
+    /// Apply the LSP workspace-folder delta, preserving the client order for
+    /// all folders that remain.
+    pub fn update_workspace_folders(
+        &mut self,
+        added: Vec<WorkspaceFolder>,
+        removed: &[WorkspaceFolder],
+    ) {
+        self.workspace_folders
+            .retain(|folder| !removed.iter().any(|removed| removed.uri == folder.uri));
+        for folder in added {
+            if !self
+                .workspace_folders
+                .iter()
+                .any(|current| current.uri == folder.uri)
+            {
+                self.workspace_folders.push(folder);
+            }
+        }
+    }
 }
 
 fn flag(params: &Value, pointer: &str) -> bool {
@@ -133,5 +153,33 @@ mod tests {
         assert!(state.workspace_folders.is_empty());
         assert!(!state.pull_configuration);
         assert_eq!(ClientState::from_initialize(&Value::Null).root_uri, None);
+    }
+
+    #[test]
+    fn updates_workspace_folders_from_lsp_deltas() {
+        let mut state = ClientState::from_initialize(&json!({
+            "workspaceFolders": [
+                { "uri": "file:///workspace/a", "name": "a" },
+                { "uri": "file:///workspace/b", "name": "b" },
+            ],
+        }));
+        let added: Vec<WorkspaceFolder> = serde_json::from_value(json!([
+            { "uri": "file:///workspace/c", "name": "c" },
+            { "uri": "file:///workspace/a", "name": "duplicate" },
+        ]))
+        .unwrap();
+        let removed: Vec<WorkspaceFolder> = serde_json::from_value(json!([
+            { "uri": "file:///workspace/b", "name": "b" },
+        ]))
+        .unwrap();
+        state.update_workspace_folders(added, &removed);
+        assert_eq!(
+            state
+                .workspace_folders
+                .iter()
+                .map(|folder| folder.uri.as_str())
+                .collect::<Vec<_>>(),
+            ["file:///workspace/a", "file:///workspace/c"]
+        );
     }
 }

--- a/crates/rsvelte_language_server/src/server.rs
+++ b/crates/rsvelte_language_server/src/server.rs
@@ -11,14 +11,15 @@ use lsp_types::{
     CancelParams, CodeActionKind, CodeActionOptions, CodeActionOrCommand, CodeActionParams,
     CodeActionProviderCapability, CompletionOptions, CompletionParams, ConfigurationItem,
     ConfigurationParams, DiagnosticOptions, DiagnosticServerCapabilities,
-    DidChangeTextDocumentParams, DidCloseTextDocumentParams, DidOpenTextDocumentParams,
-    DidSaveTextDocumentParams, DocumentDiagnosticParams, DocumentDiagnosticReport,
-    DocumentFormattingParams, DocumentSymbolParams, DocumentSymbolResponse, FoldingRange,
-    FoldingRangeParams, FoldingRangeProviderCapability, FullDocumentDiagnosticReport, HoverParams,
-    HoverProviderCapability, NumberOrString, OneOf, PublishDiagnosticsParams,
-    RelatedFullDocumentDiagnosticReport, SelectionRangeParams, SelectionRangeProviderCapability,
-    ServerCapabilities, TextDocumentPositionParams, TextDocumentSyncCapability,
-    TextDocumentSyncKind, TextDocumentSyncOptions, TextDocumentSyncSaveOptions, TextEdit, Uri,
+    DidChangeTextDocumentParams, DidChangeWorkspaceFoldersParams, DidCloseTextDocumentParams,
+    DidOpenTextDocumentParams, DidSaveTextDocumentParams, DocumentDiagnosticParams,
+    DocumentDiagnosticReport, DocumentFormattingParams, DocumentSymbolParams,
+    DocumentSymbolResponse, FoldingRange, FoldingRangeParams, FoldingRangeProviderCapability,
+    FullDocumentDiagnosticReport, HoverParams, HoverProviderCapability, NumberOrString, OneOf,
+    PublishDiagnosticsParams, RelatedFullDocumentDiagnosticReport, SelectionRangeParams,
+    SelectionRangeProviderCapability, ServerCapabilities, TextDocumentPositionParams,
+    TextDocumentSyncCapability, TextDocumentSyncKind, TextDocumentSyncOptions,
+    TextDocumentSyncSaveOptions, TextEdit, Uri, WorkspaceFoldersServerCapabilities,
 };
 
 use crate::client::ClientState;
@@ -108,6 +109,13 @@ fn capabilities(client: &ClientState) -> ServerCapabilities {
                 workspace_diagnostics: false,
                 ..DiagnosticOptions::default()
             })
+        }),
+        workspace: Some(lsp_types::WorkspaceServerCapabilities {
+            workspace_folders: Some(WorkspaceFoldersServerCapabilities {
+                supported: Some(true),
+                change_notifications: Some(OneOf::Left(true)),
+            }),
+            ..lsp_types::WorkspaceServerCapabilities::default()
         }),
         ..ServerCapabilities::default()
     }
@@ -519,6 +527,15 @@ impl Server {
             "$/cancelRequest" => {
                 match serde_json::from_value::<CancelParams>(notification.params) {
                     Ok(params) => self.cancel_request(params.id),
+                    Err(err) => log::warn(format_args!("{method}: {err}")),
+                }
+            }
+            "workspace/didChangeWorkspaceFolders" => {
+                match serde_json::from_value::<DidChangeWorkspaceFoldersParams>(notification.params)
+                {
+                    Ok(params) => self
+                        .client
+                        .update_workspace_folders(params.event.added, &params.event.removed),
                     Err(err) => log::warn(format_args!("{method}: {err}")),
                 }
             }

--- a/crates/rsvelte_language_server/tests/protocol.rs
+++ b/crates/rsvelte_language_server/tests/protocol.rs
@@ -428,6 +428,10 @@ fn serves_diagnostics_and_formatting() {
         result["capabilities"]["codeActionProvider"]["codeActionKinds"],
         json!(["quickfix"])
     );
+    assert_eq!(
+        result["capabilities"]["workspace"]["workspaceFolders"],
+        json!({ "supported": true, "changeNotifications": true })
+    );
 
     server.notify("initialized", json!({}));
     server.notify(


### PR DESCRIPTION
Implements the workspace-folder portion of #1761.

- advertises workspace folder support
- applies `workspace/didChangeWorkspaceFolders` additions/removals
- preserves deduplicated client workspace order
- covers the state delta and wire capability in tests