### PR TITLE
chore: update changesets action inputs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,9 +52,9 @@ jobs:
         with:
           # changeset version (bump versions, write CHANGELOG)
           # + sync-version.mjs (mirror the bump into Cargo.toml/Cargo.lock)
-          version: pnpm run version-packages
-          commit: 'chore(release): version packages'
-          title: 'chore(release): version packages'
+          version-script: pnpm run version-packages
+          commit-message: 'chore(release): version packages'
+          pr-title: 'chore(release): version packages'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -561,9 +561,9 @@ jobs:
           # changeset publish (pnpm publish all workspace packages).
           # No `version` input here — version bumping happens in the separate
           # `version-pr` job, decoupled from the binary builds this job needs.
-          publish: pnpm run release
-          commit: 'chore(release): version packages'
-          title: 'chore(release): version packages'
+          publish-script: pnpm run release
+          commit-message: 'chore(release): version packages'
+          pr-title: 'chore(release): version packages'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Summary

Update the renamed inputs for `changesets/action` in both release paths.

## Root cause

The pinned action now rejects the legacy `version`, `publish`, `commit`, and `title` inputs, preventing the release workflow from opening its version PR.

## Validation

- `git diff --check`