### PR TITLE
feat(language-server): handle watched config changes

### DIFF
--- a/crates/rsvelte_language_server/src/server.rs
+++ b/crates/rsvelte_language_server/src/server.rs
@@ -11,15 +11,16 @@ use lsp_types::{
     CancelParams, CodeActionKind, CodeActionOptions, CodeActionOrCommand, CodeActionParams,
     CodeActionProviderCapability, CompletionOptions, CompletionParams, ConfigurationItem,
     ConfigurationParams, DiagnosticOptions, DiagnosticServerCapabilities,
-    DidChangeTextDocumentParams, DidChangeWorkspaceFoldersParams, DidCloseTextDocumentParams,
-    DidOpenTextDocumentParams, DidSaveTextDocumentParams, DocumentDiagnosticParams,
-    DocumentDiagnosticReport, DocumentFormattingParams, DocumentSymbolParams,
-    DocumentSymbolResponse, FoldingRange, FoldingRangeParams, FoldingRangeProviderCapability,
-    FullDocumentDiagnosticReport, HoverParams, HoverProviderCapability, NumberOrString, OneOf,
-    PublishDiagnosticsParams, RelatedFullDocumentDiagnosticReport, SelectionRangeParams,
-    SelectionRangeProviderCapability, ServerCapabilities, TextDocumentPositionParams,
-    TextDocumentSyncCapability, TextDocumentSyncKind, TextDocumentSyncOptions,
-    TextDocumentSyncSaveOptions, TextEdit, Uri, WorkspaceFoldersServerCapabilities,
+    DidChangeTextDocumentParams, DidChangeWatchedFilesParams, DidChangeWorkspaceFoldersParams,
+    DidCloseTextDocumentParams, DidOpenTextDocumentParams, DidSaveTextDocumentParams,
+    DocumentDiagnosticParams, DocumentDiagnosticReport, DocumentFormattingParams,
+    DocumentSymbolParams, DocumentSymbolResponse, FoldingRange, FoldingRangeParams,
+    FoldingRangeProviderCapability, FullDocumentDiagnosticReport, HoverParams,
+    HoverProviderCapability, NumberOrString, OneOf, PublishDiagnosticsParams,
+    RelatedFullDocumentDiagnosticReport, SelectionRangeParams, SelectionRangeProviderCapability,
+    ServerCapabilities, TextDocumentPositionParams, TextDocumentSyncCapability,
+    TextDocumentSyncKind, TextDocumentSyncOptions, TextDocumentSyncSaveOptions, TextEdit, Uri,
+    WorkspaceFoldersServerCapabilities,
 };
 
 use crate::client::ClientState;
@@ -539,6 +540,20 @@ impl Server {
                     Err(err) => log::warn(format_args!("{method}: {err}")),
                 }
             }
+            "workspace/didChangeWatchedFiles" => {
+                match serde_json::from_value::<DidChangeWatchedFilesParams>(notification.params) {
+                    Ok(params)
+                        if params
+                            .changes
+                            .iter()
+                            .any(|change| is_project_config(&change.uri)) =>
+                    {
+                        self.invalidate_project_config();
+                    }
+                    Ok(_) => {}
+                    Err(err) => log::warn(format_args!("{method}: {err}")),
+                }
+            }
             "textDocument/didOpen" => {
                 match serde_json::from_value::<DidOpenTextDocumentParams>(notification.params) {
                     Ok(params) => {
@@ -598,14 +613,11 @@ impl Server {
                 // A `rsvelte-lint.json` / `.oxfmtrc` edit reaches the server as
                 // a configuration change too, so the resolved-config caches are
                 // dropped along with the client settings.
-                self.worker.submit(Job::ClearCaches);
+                self.invalidate_project_config();
                 if self.client.pull_configuration {
                     self.request_configuration();
                 } else {
                     self.settings = Settings::default();
-                    if !self.client.pull_diagnostics {
-                        self.relint_open_documents();
-                    }
                 }
             }
             "exit" => self.exiting = true,
@@ -624,6 +636,13 @@ impl Server {
                 ErrorCode::RequestCanceled as i32,
                 "request cancelled by client".to_string(),
             ));
+        }
+    }
+
+    fn invalidate_project_config(&mut self) {
+        self.worker.submit(Job::ClearCaches);
+        if !self.client.pull_diagnostics {
+            self.relint_open_documents();
         }
     }
 
@@ -850,4 +869,16 @@ fn is_lint_target(document: &Document) -> bool {
     }
     let uri = document.uri.as_str();
     uri.ends_with(".svelte.js") || uri.ends_with(".svelte.ts")
+}
+
+fn is_project_config(uri: &Uri) -> bool {
+    [
+        "rsvelte-lint.json",
+        ".rsvelte-lintrc.json",
+        ".oxfmtrc",
+        ".oxfmtrc.json",
+        ".oxfmtrc.jsonc",
+    ]
+    .iter()
+    .any(|name| uri.as_str().ends_with(name))
 }

--- a/crates/rsvelte_language_server/tests/protocol.rs
+++ b/crates/rsvelte_language_server/tests/protocol.rs
@@ -930,6 +930,34 @@ fn a_config_change_invalidates_the_resolved_lint_config() {
     assert_eq!(server.shutdown(), Some(0));
 }
 
+#[test]
+fn a_watched_config_change_invalidates_the_resolved_lint_config() {
+    let dir = temp_dir("watched-lint-config");
+    let uri = file_uri(&dir.join("App.svelte"));
+    let config_uri = file_uri(&dir.join("rsvelte-lint.json"));
+    let mut server = initialized_server();
+
+    fn reports_at_html(diagnostics: &[Value]) -> bool {
+        diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic["code"] == "svelte/no-at-html-tags")
+    }
+
+    did_open(&mut server, &uri, "<div>{@html value}</div>\n");
+    server.diagnostics_matching(&uri, reports_at_html);
+    std::fs::write(
+        dir.join("rsvelte-lint.json"),
+        r#"{ "rules": { "svelte/no-at-html-tags": "off" } }"#,
+    )
+    .unwrap();
+    server.notify(
+        "workspace/didChangeWatchedFiles",
+        json!({ "changes": [{ "uri": config_uri, "type": 2 }] }),
+    );
+    server.diagnostics_matching(&uri, |diagnostics| !reports_at_html(diagnostics));
+    assert_eq!(server.shutdown(), Some(0));
+}
+
 /// What a VS Code-like client — folding whole lines, reading a symbol tree —
 /// gets for a component with elements, blocks, regions, imports and both
 /// embedded languages.


### PR DESCRIPTION
Implements the client-notification half of watched configuration changes for #1761.

- handles `workspace/didChangeWatchedFiles`
- invalidates lint and formatter config caches only for relevant config files
- re-lints open documents for push-diagnostic clients
- verifies the flow through the stdio protocol test