### PR TITLE
feat(language-server): register config file watchers

### DIFF
--- a/crates/rsvelte_language_server/src/client.rs
+++ b/crates/rsvelte_language_server/src/client.rs
@@ -30,6 +30,8 @@ pub struct ClientState {
     pub hierarchical_document_symbols: bool,
     /// Whether the client supports LSP 3.17 pull diagnostics.
     pub pull_diagnostics: bool,
+    /// Whether the client accepts dynamic watched-file registrations.
+    pub dynamic_watched_files: bool,
 }
 
 impl ClientState {
@@ -53,6 +55,10 @@ impl ClientState {
             pull_diagnostics: params
                 .pointer("/capabilities/textDocument/diagnostic")
                 .is_some(),
+            dynamic_watched_files: flag(
+                params,
+                "/capabilities/workspace/didChangeWatchedFiles/dynamicRegistration",
+            ),
         }
     }
 
@@ -100,7 +106,10 @@ mod tests {
             "workspaceFolders": [{ "uri": "file:///home/u/app", "name": "app" }],
             "clientInfo": { "name": "Visual Studio Code", "version": "1.99.0" },
             "capabilities": {
-                "workspace": { "configuration": true },
+                "workspace": {
+                    "configuration": true,
+                    "didChangeWatchedFiles": { "dynamicRegistration": true },
+                },
                 "general": { "positionEncodings": ["utf-16"] },
                 "textDocument": {
                     "foldingRange": { "lineFoldingOnly": true },
@@ -122,6 +131,7 @@ mod tests {
         assert!(state.line_folding_only);
         assert!(state.hierarchical_document_symbols);
         assert!(!state.pull_diagnostics);
+        assert!(state.dynamic_watched_files);
     }
 
     #[test]
@@ -132,6 +142,7 @@ mod tests {
         assert!(!state.line_folding_only);
         assert!(!state.hierarchical_document_symbols);
         assert!(!state.pull_diagnostics);
+        assert!(!state.dynamic_watched_files);
     }
 
     #[test]

--- a/crates/rsvelte_language_server/src/server.rs
+++ b/crates/rsvelte_language_server/src/server.rs
@@ -140,6 +140,7 @@ enum Pending {
 /// echo back.
 enum Outgoing {
     Configuration,
+    WatchedFilesRegistration,
 }
 
 struct Server {
@@ -187,6 +188,9 @@ impl Server {
     fn run(&mut self, connection: &Connection) -> Result<ExitCode> {
         if self.client.pull_configuration {
             self.request_configuration();
+        }
+        if self.client.dynamic_watched_files {
+            self.register_watched_files();
         }
         // Cloned out of `self` so the handlers below can still borrow it.
         let outcomes = self.outcomes.clone();
@@ -671,6 +675,7 @@ impl Server {
                     self.relint_open_documents();
                 }
             }
+            Outgoing::WatchedFilesRegistration => {}
         }
     }
 
@@ -744,6 +749,28 @@ impl Server {
                     section: Some(CONFIG_SECTION.to_string()),
                 }],
             },
+        ));
+    }
+
+    fn register_watched_files(&mut self) {
+        self.next_request_id += 1;
+        let id = RequestId::from(format!("rsvelte-watch-files-{}", self.next_request_id));
+        self.outgoing
+            .insert(id.clone(), Outgoing::WatchedFilesRegistration);
+        self.send(Request::new(
+            id,
+            "client/registerCapability".to_string(),
+            serde_json::json!({
+                "registrations": [{
+                    "id": "rsvelte-project-configs",
+                    "method": "workspace/didChangeWatchedFiles",
+                    "registerOptions": {
+                        "watchers": project_config_names().iter().map(|name| serde_json::json!({
+                            "globPattern": format!("**/{name}"),
+                        })).collect::<Vec<_>>(),
+                    },
+                }],
+            }),
         ));
     }
 
@@ -872,13 +899,18 @@ fn is_lint_target(document: &Document) -> bool {
 }
 
 fn is_project_config(uri: &Uri) -> bool {
-    [
+    project_config_names()
+        .iter()
+        .any(|name| uri.as_str().rsplit('/').next() == Some(name))
+}
+
+const fn project_config_names() -> &'static [&'static str] {
+    &[
         "rsvelte-lint.json",
         ".rsvelte-lintrc.json",
-        ".oxfmtrc",
         ".oxfmtrc.json",
         ".oxfmtrc.jsonc",
+        "oxfmt.config.ts",
+        "oxfmt.config.mts",
     ]
-    .iter()
-    .any(|name| uri.as_str().ends_with(name))
 }


### PR DESCRIPTION
Advances #1761 watched-file support.

- registers configuration-file watchers for clients supporting dynamic registration
- scopes registration to lint and formatter config names
- retains notification handling for clients that provide watched-file events