### PR TITLE
fix(format): preserve adjacent directive comments

### DIFF
--- a/.changeset/quiet-adjacent-directive-comments.md
+++ b/.changeset/quiet-adjacent-directive-comments.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/fmt": patch
+---
+
+Preserve adjacent template directive comments when formatting a broken fragment.

--- a/crates/rsvelte_formatter/src/indent.rs
+++ b/crates/rsvelte_formatter/src/indent.rs
@@ -375,9 +375,14 @@ fn collect_indent_edits_inner(
             }
             let is_comment =
                 matches!(a, TemplateNode::Comment(_)) || matches!(b, TemplateNode::Comment(_));
+            let both_comments =
+                matches!(a, TemplateNode::Comment(_)) && matches!(b, TemplateNode::Comment(_));
             let a_is_block = matches!(a, TemplateNode::RegularElement(e) if is_prettier_block_element(e.name.as_str()));
             let b_is_block = matches!(b, TemplateNode::RegularElement(e) if is_prettier_block_element(e.name.as_str()));
             if !is_comment && !a_is_block && !b_is_block {
+                continue;
+            }
+            if both_comments {
                 continue;
             }
             // Adjacent comments that are already inline (no newline in the fragment's

--- a/crates/rsvelte_formatter/tests/indent.rs
+++ b/crates/rsvelte_formatter/tests/indent.rs
@@ -13,6 +13,18 @@ fn default_options_indent_with_two_spaces() {
 }
 
 #[test]
+fn adjacent_comments_stay_glued_in_a_broken_fragment() {
+    let src = "<svelte:head>\n<!-- eslint-disable-next-line --><!-- svelte-ignore hydration_html_changed -->\n{@html '<script></script>'}\n</svelte:head>";
+    let out = format(src, &FormatOptions::default()).expect("format ok");
+    assert!(
+        out.contains(
+            "<!-- eslint-disable-next-line --><!-- svelte-ignore hydration_html_changed -->"
+        ),
+        "adjacent directive comments must remain glued:\n{out}"
+    );
+}
+
+#[test]
 fn tab_indent_style_uses_tabs_for_outer_wrap() {
     let opts = FormatOptions {
         js: JsFormatOptions {


### PR DESCRIPTION
Fixes the formatter parity failure revealed by adding mode-watcher to the corpus. Adjacent HTML comments must remain contiguous even when the enclosing fragment is broken, because directive comments bind to the following node.