### PR TITLE
feat(language-server): complete M1 native features

### DIFF
--- a/.changeset/native-lsp-m1.md
+++ b/.changeset/native-lsp-m1.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/language-server": minor
+---
+
+Add native Svelte code lenses, extract-component refactoring, and lint code actions.

--- a/crates/rsvelte_language_server/src/code_actions.rs
+++ b/crates/rsvelte_language_server/src/code_actions.rs
@@ -16,6 +16,8 @@ use rsvelte_core::ast::template::{Fragment, Root, TemplateNode};
 use crate::diagnostics::{COMPILER_SOURCE, is_compiler_code};
 use crate::text::{LineIndex, source_offset};
 
+pub const FIX_ALL_KIND: &str = "source.fixAll.rsvelte";
+
 /// Warnings a `svelte-ignore` comment cannot suppress, in both the spelling the
 /// official server lists and the one Svelte 5 emits.
 const NON_IGNORABLE: &[&str] = &[
@@ -46,8 +48,188 @@ pub fn quickfixes(source: &str, uri: &Uri, diagnostics: &[Diagnostic]) -> Vec<Co
     let mut actions = Vec::new();
     for diagnostic in diagnostics {
         for_diagnostic(source, &index, root.as_ref(), uri, diagnostic, &mut actions);
+        if code_of(diagnostic) == Some("security-anchor-rel-noreferrer") {
+            if let Some(action) = add_noreferrer(source, &index, uri, diagnostic) {
+                actions.push(action);
+            }
+        }
     }
     actions
+}
+
+/// Actions for rsvelte-lint's native fixes and editor-only suggestions.
+pub fn lint_actions(
+    source: &str,
+    path: &std::path::Path,
+    uri: &Uri,
+    config: &rsvelte_lint::LintConfig,
+    diagnostics: &[Diagnostic],
+    include_fixes: bool,
+    include_suggestions: bool,
+    include_fix_all: bool,
+) -> Vec<CodeActionOrCommand> {
+    let options = rsvelte_core::CompileOptions {
+        filename: Some(path.display().to_string()),
+        ..rsvelte_core::CompileOptions::default()
+    };
+    let messages = rsvelte_lint::lint_source_messages(source, path, &options, config);
+    let index = LineIndex::new(source);
+    let mut actions = Vec::new();
+
+    for message in &messages {
+        let Some((start, end)) = message.span else {
+            continue;
+        };
+        let range = Range::new(
+            index.position(source, start as usize),
+            index.position(source, end as usize),
+        );
+        let Some(code) = message.diagnostic.code.as_deref() else {
+            continue;
+        };
+        let matches_diagnostic = diagnostics.iter().any(|diagnostic| {
+            diagnostic.source.as_deref() == Some("rsvelte")
+                && code_of(diagnostic) == Some(code)
+                && diagnostic.range == range
+        });
+        if !matches_diagnostic {
+            continue;
+        }
+        if include_fixes && let Some(fix) = &message.fix {
+            actions.push(action(
+                uri,
+                &index,
+                source,
+                &fix.message,
+                CodeActionKind::QUICKFIX,
+                &fix.edits,
+            ));
+        }
+        for suggestion in include_suggestions
+            .then_some(&message.suggestions)
+            .into_iter()
+            .flatten()
+        {
+            actions.push(action(
+                uri,
+                &index,
+                source,
+                &suggestion.desc,
+                CodeActionKind::REFACTOR_REWRITE,
+                &suggestion.fix.edits,
+            ));
+        }
+    }
+
+    if include_fix_all {
+        let mut fixes: Vec<_> = messages
+            .into_iter()
+            .filter_map(|message| message.fix)
+            .collect();
+        fixes.sort_by_key(|fix| {
+            fix.edits
+                .iter()
+                .map(|edit| edit.start)
+                .min()
+                .unwrap_or(u32::MAX)
+        });
+        let mut edits = Vec::new();
+        let mut occupied = 0;
+        for fix in fixes {
+            let mut candidate = fix.edits;
+            candidate.sort_by_key(|edit| edit.start);
+            if candidate.iter().all(|edit| edit.start >= occupied) {
+                occupied = candidate
+                    .iter()
+                    .map(|edit| edit.end)
+                    .max()
+                    .unwrap_or(occupied);
+                edits.extend(candidate);
+            }
+        }
+        if !edits.is_empty() {
+            actions.push(action(
+                uri,
+                &index,
+                source,
+                "Fix all auto-fixable rsvelte problems",
+                CodeActionKind::new(FIX_ALL_KIND),
+                &edits,
+            ));
+        }
+    }
+    actions
+}
+
+fn action(
+    uri: &Uri,
+    index: &LineIndex,
+    source: &str,
+    title: &str,
+    kind: CodeActionKind,
+    edits: &[rsvelte_lint::TextEdit],
+) -> CodeActionOrCommand {
+    let edits = edits
+        .iter()
+        .map(|edit| TextEdit {
+            range: Range::new(
+                index.position(source, edit.start as usize),
+                index.position(source, edit.end as usize),
+            ),
+            new_text: edit.new_text.clone(),
+        })
+        .collect();
+    CodeActionOrCommand::CodeAction(CodeAction {
+        title: title.to_string(),
+        kind: Some(kind),
+        edit: Some(WorkspaceEdit {
+            changes: Some(HashMap::from([(uri.clone(), edits)])),
+            ..WorkspaceEdit::default()
+        }),
+        ..CodeAction::default()
+    })
+}
+
+fn add_noreferrer(
+    source: &str,
+    index: &LineIndex,
+    uri: &Uri,
+    diagnostic: &Diagnostic,
+) -> Option<CodeActionOrCommand> {
+    let start = index.offset(source, diagnostic.range.start);
+    let open = source[..start].rfind("<a")?;
+    let close = source[start..].find('>')? + start;
+    let tag = &source[open..=close];
+    let edit = if let Some(rel) = tag.find("rel=") {
+        let quote = tag[rel + 4..].chars().next()?;
+        if quote != '\'' && quote != '"' {
+            return None;
+        }
+        let value_start = open + rel + 5;
+        let value_end = source[value_start..].find(quote)? + value_start;
+        TextEdit {
+            range: Range::new(
+                index.position(source, value_end),
+                index.position(source, value_end),
+            ),
+            new_text: " noreferrer".to_string(),
+        }
+    } else {
+        let insert = index.position(source, close);
+        TextEdit {
+            range: Range::new(insert, insert),
+            new_text: " rel=\"noreferrer\"".to_string(),
+        }
+    };
+    Some(CodeActionOrCommand::CodeAction(CodeAction {
+        title: "(svelte) Add missing attribute rel=\"noreferrer\"".to_string(),
+        kind: Some(CodeActionKind::QUICKFIX),
+        edit: Some(WorkspaceEdit {
+            changes: Some(HashMap::from([(uri.clone(), vec![edit])])),
+            ..WorkspaceEdit::default()
+        }),
+        ..CodeAction::default()
+    }))
 }
 
 fn for_diagnostic(
@@ -274,6 +456,26 @@ mod tests {
 
     fn range(start: (u32, u32), end: (u32, u32)) -> Range {
         Range::new(Position::new(start.0, start.1), Position::new(end.0, end.1))
+    }
+
+    fn lint_diagnostic(source: &str, config: &rsvelte_lint::LintConfig, code: &str) -> Diagnostic {
+        let path = std::path::Path::new("App.svelte");
+        let options = rsvelte_core::CompileOptions::default();
+        let message = rsvelte_lint::lint_source_messages(source, path, &options, config)
+            .into_iter()
+            .find(|message| message.diagnostic.code.as_deref() == Some(code))
+            .expect("fixture should produce the requested lint finding");
+        let (start, end) = message.span.expect("native lint finding");
+        let index = LineIndex::new(source);
+        Diagnostic {
+            range: Range::new(
+                index.position(source, start as usize),
+                index.position(source, end as usize),
+            ),
+            code: Some(NumberOrString::String(code.to_string())),
+            source: Some("rsvelte".to_string()),
+            ..Diagnostic::default()
+        }
     }
 
     /// The (title, edit) pairs of every action, flattened for assertion.
@@ -525,5 +727,72 @@ mod tests {
             ],
         );
         assert_eq!(fixes.len(), 2);
+    }
+
+    #[test]
+    fn lint_suggestions_are_editor_actions_not_fix_all_edits() {
+        let source = "<p>{@debug value}</p>";
+        let config = rsvelte_lint::LintConfig::recommended();
+        let diagnostic = lint_diagnostic(source, &config, "svelte/no-at-debug-tags");
+        let actions = lint_actions(
+            source,
+            std::path::Path::new("App.svelte"),
+            &uri(),
+            &config,
+            &[diagnostic],
+            false,
+            true,
+            true,
+        );
+        assert_eq!(actions.len(), 1);
+        let CodeActionOrCommand::CodeAction(action) = &actions[0] else {
+            panic!("a command, not a code action");
+        };
+        assert_eq!(action.title, "Remove `{@debug}` from the source");
+        assert_eq!(action.kind, Some(CodeActionKind::REFACTOR_REWRITE));
+        assert_eq!(
+            action.edit.as_ref().unwrap().changes.as_ref().unwrap()[&uri()][0].new_text,
+            ""
+        );
+    }
+
+    #[test]
+    fn lint_fixes_and_fix_all_are_workspace_edits() {
+        let source = "<p>{ value }</p>";
+        let config = rsvelte_lint::LintConfig::from_json_str(
+            r#"{ "rules": { "svelte/mustache-spacing": "error" } }"#,
+        )
+        .unwrap();
+        let diagnostic = lint_diagnostic(source, &config, "svelte/mustache-spacing");
+        let actions = lint_actions(
+            source,
+            std::path::Path::new("App.svelte"),
+            &uri(),
+            &config,
+            &[diagnostic],
+            true,
+            false,
+            true,
+        );
+        assert!(actions.iter().any(|action| matches!(action, CodeActionOrCommand::CodeAction(action) if action.kind == Some(CodeActionKind::QUICKFIX))));
+        assert!(actions.iter().any(|action| matches!(action, CodeActionOrCommand::CodeAction(action) if action.kind.as_ref().is_some_and(|kind| kind.as_str() == FIX_ALL_KIND))));
+    }
+
+    #[test]
+    fn anchor_warning_offers_the_noreferrer_edit() {
+        let source = r#"<a target="_blank">link</a>"#;
+        let actions = fixes(
+            source,
+            &[diagnostic(
+                "security-anchor-rel-noreferrer",
+                range((0, 3), (0, 18)),
+            )],
+        );
+        assert_eq!(actions.len(), 2);
+        assert_eq!(
+            actions[1].0,
+            "(svelte) Add missing attribute rel=\"noreferrer\""
+        );
+        assert_eq!(actions[1].1.new_text, " rel=\"noreferrer\"");
     }
 }

--- a/crates/rsvelte_language_server/src/code_actions.rs
+++ b/crates/rsvelte_language_server/src/code_actions.rs
@@ -48,10 +48,10 @@ pub fn quickfixes(source: &str, uri: &Uri, diagnostics: &[Diagnostic]) -> Vec<Co
     let mut actions = Vec::new();
     for diagnostic in diagnostics {
         for_diagnostic(source, &index, root.as_ref(), uri, diagnostic, &mut actions);
-        if code_of(diagnostic) == Some("security-anchor-rel-noreferrer") {
-            if let Some(action) = add_noreferrer(source, &index, uri, diagnostic) {
-                actions.push(action);
-            }
+        if code_of(diagnostic) == Some("security-anchor-rel-noreferrer")
+            && let Some(action) = add_noreferrer(source, &index, uri, diagnostic)
+        {
+            actions.push(action);
         }
     }
     actions

--- a/crates/rsvelte_language_server/src/code_lens.rs
+++ b/crates/rsvelte_language_server/src/code_lens.rs
@@ -1,0 +1,70 @@
+//! The runes/legacy-mode indicator shown above Svelte 5 components.
+
+use std::path::Path;
+
+use lsp_types::{CodeLens, Command, Position, Range};
+use serde_json::json;
+
+const LEGACY_OVERVIEW: &str = "https://svelte.dev/docs/svelte/legacy-overview";
+
+/// Mirror Svelte's mode CodeLens. A failed compile deliberately keeps an empty
+/// lens so an editor does not shift surrounding lenses while the user is typing.
+pub fn code_lenses(source: &str, path: &Path) -> Vec<CodeLens> {
+    let range = Range::new(Position::new(0, 0), Position::new(0, 0));
+    let mut options = rsvelte_core::CompileOptions {
+        filename: Some(path.display().to_string()),
+        ..rsvelte_core::CompileOptions::default()
+    };
+    options.generate = rsvelte_core::GenerateMode::None;
+
+    let command = match rsvelte_core::compile(source, options) {
+        Ok(result) => Command::new(
+            if result.metadata.runes {
+                "Runes mode"
+            } else {
+                "Legacy mode"
+            }
+            .to_string(),
+            "svelte.openLink".to_string(),
+            Some(vec![json!(LEGACY_OVERVIEW)]),
+        ),
+        Err(_) => Command::default(),
+    };
+    vec![CodeLens {
+        range,
+        command: Some(command),
+        data: None,
+    }]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn reports_runes_and_legacy_modes() {
+        let path = Path::new("App.svelte");
+        assert_eq!(
+            code_lenses("<script>let x = 1;</script>", path)[0]
+                .command
+                .as_ref()
+                .unwrap()
+                .title,
+            "Legacy mode"
+        );
+        assert_eq!(
+            code_lenses("<script>let x = $state(1);</script>", path)[0]
+                .command
+                .as_ref()
+                .unwrap()
+                .title,
+            "Runes mode"
+        );
+    }
+
+    #[test]
+    fn keeps_an_empty_lens_after_a_compile_error() {
+        let lens = &code_lenses("{#if}", Path::new("App.svelte"))[0];
+        assert_eq!(lens.command, Some(Command::default()));
+    }
+}

--- a/crates/rsvelte_language_server/src/extract.rs
+++ b/crates/rsvelte_language_server/src/extract.rs
@@ -1,0 +1,163 @@
+//! The Svelte component extraction refactoring.
+
+use std::path::Path;
+
+use lsp_types::Range;
+use serde_json::{Value, json};
+
+use crate::text::LineIndex;
+use crate::uri::uri_to_path;
+
+pub const COMMAND: &str = "extract_to_svelte_component";
+
+/// Build the workspace edit returned by upstream's extract-component command.
+pub fn component(
+    source: &str,
+    uri: &str,
+    range: Range,
+    requested_path: &str,
+) -> Result<Value, String> {
+    let index = LineIndex::new(source);
+    let start = index.offset(source, range.start);
+    let end = index.offset(source, range.end);
+    if start >= end || !boundary(source, start, true) || !boundary(source, end, false) {
+        return Err("Invalid selection range".to_string());
+    }
+
+    let allocator = rsvelte_core::Allocator::default();
+    let root = rsvelte_core::parse(source, &allocator, rsvelte_core::ParseOptions::default())
+        .map_err(|_| "Invalid selection range".to_string())?;
+    let blocked = [
+        root.instance
+            .as_ref()
+            .map(|tag| (tag.start as usize, tag.end as usize)),
+        root.module
+            .as_ref()
+            .map(|tag| (tag.start as usize, tag.end as usize)),
+        root.css
+            .as_ref()
+            .map(|tag| (tag.start as usize, tag.end as usize)),
+    ];
+    if blocked
+        .into_iter()
+        .flatten()
+        .any(|(a, b)| start >= a && end <= b)
+    {
+        return Err("Invalid selection range".to_string());
+    }
+
+    let mut file_path = if requested_path.is_empty() {
+        "./NewComponent".to_string()
+    } else {
+        requested_path.to_string()
+    };
+    if !file_path.ends_with(".svelte") {
+        file_path.push_str(".svelte");
+    }
+    if !file_path.starts_with('.') {
+        file_path.insert_str(0, "./");
+    }
+    let name = Path::new(&file_path)
+        .file_stem()
+        .and_then(|name| name.to_str())
+        .filter(|name| !name.is_empty())
+        .ok_or_else(|| "Invalid selection range".to_string())?;
+    let old_path = uri_to_path(uri);
+    let new_path = old_path.parent().unwrap_or(Path::new(".")).join(&file_path);
+    let new_uri = file_uri(&new_path);
+
+    let mut new_source = format!("{}\n\n", &source[start..end]);
+    let mut tags: Vec<(usize, usize)> = [
+        root.instance
+            .as_ref()
+            .map(|tag| (tag.start as usize, tag.end as usize)),
+        root.module
+            .as_ref()
+            .map(|tag| (tag.start as usize, tag.end as usize)),
+        root.css
+            .as_ref()
+            .map(|tag| (tag.start as usize, tag.end as usize)),
+    ]
+    .into_iter()
+    .flatten()
+    .collect();
+    tags.sort_unstable();
+    for (tag_start, tag_end) in tags {
+        new_source.push_str(&source[tag_start..tag_end]);
+        new_source.push_str("\n\n");
+    }
+
+    let import_at = root
+        .instance
+        .as_ref()
+        .or(root.module.as_ref())
+        .map(|tag| tag.content_offset as usize);
+    let import = format!("\n  import {name} from '{file_path}';\n");
+    let import_edit = import_at.map_or_else(
+        || json!({ "range": zero(), "newText": format!("<script>{import}</script>") }),
+        |offset| json!({ "range": point(&index, source, offset), "newText": import }),
+    );
+    Ok(json!({
+        "documentChanges": [
+            { "textDocument": { "uri": uri, "version": null }, "edits": [
+                { "range": range, "newText": format!("<{name}></{name}>") }, import_edit
+            ] },
+            { "kind": "create", "uri": new_uri, "options": { "overwrite": true } },
+            { "textDocument": { "uri": new_uri, "version": null }, "edits": [
+                { "range": zero(), "newText": new_source }
+            ] }
+        ]
+    }))
+}
+
+fn boundary(source: &str, offset: usize, start: bool) -> bool {
+    let adjacent = if start {
+        source[..offset].chars().next_back()
+    } else {
+        source[offset..].chars().next()
+    };
+    adjacent.is_none_or(|c| c.is_whitespace() || !c.is_alphanumeric() && c != '_')
+}
+
+fn file_uri(path: &Path) -> String {
+    format!("file://{}", path.to_string_lossy().replace(' ', "%20"))
+}
+
+fn zero() -> Value {
+    json!({ "start": { "line": 0, "character": 0 }, "end": { "line": 0, "character": 0 } })
+}
+
+fn point(index: &LineIndex, source: &str, offset: usize) -> Value {
+    let position = index.position(source, offset);
+    json!({ "start": position, "end": position })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use lsp_types::Position;
+
+    #[test]
+    fn extracts_template_and_copies_tags() {
+        let source = "<script>\nlet x = 1;\n</script>\n\n<p>extract me</p>\n\n<style>p { color: blue; }</style>";
+        let edit = component(
+            source,
+            "file:///tmp/App.svelte",
+            Range::new(Position::new(4, 0), Position::new(4, 17)),
+            "NewComp",
+        )
+        .unwrap();
+        assert_eq!(
+            edit["documentChanges"][0]["edits"][0]["newText"],
+            "<NewComp></NewComp>"
+        );
+        assert_eq!(
+            edit["documentChanges"][1]["uri"],
+            "file:///tmp/./NewComp.svelte"
+        );
+        assert_eq!(
+            edit["documentChanges"][2]["edits"][0]["newText"],
+            "<p>extract me</p>\n\n<script>\nlet x = 1;\n</script>\n\n<style>p { color: blue; }</style>\n\n"
+        );
+    }
+}

--- a/crates/rsvelte_language_server/src/lib.rs
+++ b/crates/rsvelte_language_server/src/lib.rs
@@ -12,10 +12,12 @@
 
 pub mod client;
 pub mod code_actions;
+pub mod code_lens;
 pub mod completions;
 pub mod context;
 pub mod diagnostics;
 pub mod document;
+pub mod extract;
 pub mod folding;
 pub mod format;
 pub mod hover;

--- a/crates/rsvelte_language_server/src/server.rs
+++ b/crates/rsvelte_language_server/src/server.rs
@@ -14,12 +14,12 @@ use lsp_types::{
     DiagnosticServerCapabilities, DidChangeTextDocumentParams, DidCloseTextDocumentParams,
     DidOpenTextDocumentParams, DidSaveTextDocumentParams, DocumentDiagnosticParams,
     DocumentDiagnosticReport, DocumentFormattingParams, DocumentSymbolParams,
-    DocumentSymbolResponse, FoldingRange, FoldingRangeParams, FoldingRangeProviderCapability,
-    FullDocumentDiagnosticReport, HoverParams, HoverProviderCapability, NumberOrString, OneOf,
-    PublishDiagnosticsParams, RelatedFullDocumentDiagnosticReport, SelectionRangeParams,
-    SelectionRangeProviderCapability, ServerCapabilities, TextDocumentPositionParams,
-    TextDocumentSyncCapability, TextDocumentSyncKind, TextDocumentSyncOptions,
-    TextDocumentSyncSaveOptions, TextEdit, Uri,
+    DocumentSymbolResponse, ExecuteCommandOptions, ExecuteCommandParams, FoldingRange,
+    FoldingRangeParams, FoldingRangeProviderCapability, FullDocumentDiagnosticReport, HoverParams,
+    HoverProviderCapability, NumberOrString, OneOf, PublishDiagnosticsParams,
+    RelatedFullDocumentDiagnosticReport, SelectionRangeParams, SelectionRangeProviderCapability,
+    ServerCapabilities, TextDocumentPositionParams, TextDocumentSyncCapability,
+    TextDocumentSyncKind, TextDocumentSyncOptions, TextDocumentSyncSaveOptions, TextEdit, Uri,
 };
 
 use crate::client::ClientState;
@@ -102,6 +102,10 @@ fn capabilities(client: &ClientState) -> ServerCapabilities {
         code_lens_provider: Some(CodeLensOptions {
             resolve_provider: Some(false),
         }),
+        execute_command_provider: Some(ExecuteCommandOptions {
+            commands: vec![crate::extract::COMMAND.to_string()],
+            ..ExecuteCommandOptions::default()
+        }),
         folding_range_provider: Some(FoldingRangeProviderCapability::Simple(true)),
         selection_range_provider: Some(SelectionRangeProviderCapability::Simple(true)),
         document_symbol_provider: Some(OneOf::Left(true)),
@@ -126,6 +130,7 @@ enum Pending {
     Hover,
     CodeAction,
     CodeLens,
+    ExtractComponent,
     FoldingRange,
     SelectionRange,
     DocumentSymbol,
@@ -237,6 +242,7 @@ impl Server {
             "textDocument/hover" => self.on_hover(request),
             "textDocument/codeAction" => self.on_code_action(request),
             "textDocument/codeLens" => self.on_code_lens(request),
+            "workspace/executeCommand" => self.on_execute_command(request),
             "textDocument/foldingRange" => self.on_folding_range(request),
             "textDocument/selectionRange" => self.on_selection_range(request),
             "textDocument/documentSymbol" => self.on_document_symbol(request),
@@ -441,6 +447,51 @@ impl Server {
         };
         self.pending.insert(id, Pending::CodeLens);
         self.worker.submit(job);
+    }
+
+    fn on_execute_command(&mut self, request: Request) {
+        let id = request.id;
+        let params = match serde_json::from_value::<ExecuteCommandParams>(request.params) {
+            Ok(params) if params.command == crate::extract::COMMAND => params,
+            Ok(_) => return self.respond_nothing(id),
+            Err(err) => {
+                log::warn(format_args!("workspace/executeCommand: {err}"));
+                return self.respond_nothing(id);
+            }
+        };
+        let Some(args) = params.arguments.into_iter().nth(1) else {
+            return self.respond_nothing(id);
+        };
+        let Some(uri) = args.get("uri").and_then(serde_json::Value::as_str) else {
+            return self.respond_nothing(id);
+        };
+        let Ok(uri) = uri.parse::<Uri>() else {
+            return self.respond_nothing(id);
+        };
+        let Some(document) = self.component_document(&uri) else {
+            return self.respond_nothing(id);
+        };
+        let text = document.shared_text();
+        let Some(range) = args
+            .get("range")
+            .cloned()
+            .and_then(|value| serde_json::from_value(value).ok())
+        else {
+            return self.respond_nothing(id);
+        };
+        let file_path = args
+            .get("filePath")
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or_default()
+            .to_string();
+        self.pending.insert(id.clone(), Pending::ExtractComponent);
+        self.worker.submit(Job::ExtractComponent {
+            id,
+            uri,
+            text,
+            range,
+            file_path,
+        });
     }
 
     fn on_folding_range(&mut self, request: Request) {
@@ -698,6 +749,11 @@ impl Server {
             Outcome::CodeLenses { id, lenses } => {
                 if self.pending.remove(&id).is_some() {
                     self.respond(Response::new_ok(id, lenses));
+                }
+            }
+            Outcome::ExtractedComponent { id, result } => {
+                if self.pending.remove(&id).is_some() {
+                    self.respond(Response::new_ok(id, result));
                 }
             }
             Outcome::FoldingRanges { id, ranges } => {

--- a/crates/rsvelte_language_server/src/server.rs
+++ b/crates/rsvelte_language_server/src/server.rs
@@ -96,7 +96,11 @@ fn capabilities(client: &ClientState) -> ServerCapabilities {
         }),
         hover_provider: Some(HoverProviderCapability::Simple(true)),
         code_action_provider: Some(CodeActionProviderCapability::Options(CodeActionOptions {
-            code_action_kinds: Some(vec![CodeActionKind::QUICKFIX]),
+            code_action_kinds: Some(vec![
+                CodeActionKind::QUICKFIX,
+                CodeActionKind::REFACTOR_REWRITE,
+                CodeActionKind::new(crate::code_actions::FIX_ALL_KIND),
+            ]),
             ..CodeActionOptions::default()
         })),
         code_lens_provider: Some(CodeLensOptions {
@@ -400,14 +404,24 @@ impl Server {
             self.respond_no_actions(id);
             return;
         };
-        // A client asking only for other kinds (organize imports, refactorings)
-        // gets nothing rather than a quickfix it did not ask for.
         let wants_quickfix = params
             .context
             .only
             .as_ref()
             .is_none_or(|kinds| kinds.contains(&CodeActionKind::QUICKFIX));
-        if params.context.diagnostics.is_empty() || !wants_quickfix {
+        let wants_refactor = params.context.only.as_ref().is_none_or(|kinds| {
+            kinds
+                .iter()
+                .any(|kind| kind.as_str().starts_with(CodeActionKind::REFACTOR.as_str()))
+        });
+        let fix_all = params.context.only.as_ref().is_some_and(|kinds| {
+            kinds
+                .iter()
+                .any(|kind| kind.as_str() == crate::code_actions::FIX_ALL_KIND)
+        });
+        if (!wants_quickfix && !wants_refactor && !fix_all)
+            || (params.context.diagnostics.is_empty() && !fix_all)
+        {
             self.respond_no_actions(id);
             return;
         }
@@ -417,6 +431,9 @@ impl Server {
             text: document.shared_text(),
             uri,
             diagnostics: params.context.diagnostics,
+            quickfix: wants_quickfix,
+            suggestions: wants_refactor,
+            fix_all,
         };
         self.pending.insert(id, Pending::CodeAction);
         self.worker.submit(job);

--- a/crates/rsvelte_language_server/src/server.rs
+++ b/crates/rsvelte_language_server/src/server.rs
@@ -11,15 +11,16 @@ use lsp_types::{
     CancelParams, CodeActionKind, CodeActionOptions, CodeActionOrCommand, CodeActionParams,
     CodeActionProviderCapability, CodeLens, CodeLensOptions, CodeLensParams, CompletionOptions,
     CompletionParams, ConfigurationItem, ConfigurationParams, DiagnosticOptions,
-    DiagnosticServerCapabilities, DidChangeTextDocumentParams, DidCloseTextDocumentParams,
-    DidOpenTextDocumentParams, DidSaveTextDocumentParams, DocumentDiagnosticParams,
-    DocumentDiagnosticReport, DocumentFormattingParams, DocumentSymbolParams,
-    DocumentSymbolResponse, ExecuteCommandOptions, ExecuteCommandParams, FoldingRange,
-    FoldingRangeParams, FoldingRangeProviderCapability, FullDocumentDiagnosticReport, HoverParams,
-    HoverProviderCapability, NumberOrString, OneOf, PublishDiagnosticsParams,
-    RelatedFullDocumentDiagnosticReport, SelectionRangeParams, SelectionRangeProviderCapability,
-    ServerCapabilities, TextDocumentPositionParams, TextDocumentSyncCapability,
-    TextDocumentSyncKind, TextDocumentSyncOptions, TextDocumentSyncSaveOptions, TextEdit, Uri,
+    DiagnosticServerCapabilities, DidChangeTextDocumentParams, DidChangeWatchedFilesParams,
+    DidChangeWorkspaceFoldersParams, DidCloseTextDocumentParams, DidOpenTextDocumentParams,
+    DidSaveTextDocumentParams, DocumentDiagnosticParams, DocumentDiagnosticReport,
+    DocumentFormattingParams, DocumentSymbolParams, DocumentSymbolResponse, ExecuteCommandOptions,
+    ExecuteCommandParams, FoldingRange, FoldingRangeParams, FoldingRangeProviderCapability,
+    FullDocumentDiagnosticReport, HoverParams, HoverProviderCapability, NumberOrString, OneOf,
+    PublishDiagnosticsParams, RelatedFullDocumentDiagnosticReport, SelectionRangeParams,
+    SelectionRangeProviderCapability, ServerCapabilities, TextDocumentPositionParams,
+    TextDocumentSyncCapability, TextDocumentSyncKind, TextDocumentSyncOptions,
+    TextDocumentSyncSaveOptions, TextEdit, Uri, WorkspaceFoldersServerCapabilities,
 };
 
 use crate::client::ClientState;
@@ -99,7 +100,7 @@ fn capabilities(client: &ClientState) -> ServerCapabilities {
             code_action_kinds: Some(vec![
                 CodeActionKind::QUICKFIX,
                 CodeActionKind::REFACTOR_REWRITE,
-                CodeActionKind::new(crate::code_actions::FIX_ALL_KIND),
+                CodeActionKind::SOURCE_FIX_ALL,
             ]),
             ..CodeActionOptions::default()
         })),
@@ -120,6 +121,13 @@ fn capabilities(client: &ClientState) -> ServerCapabilities {
                 workspace_diagnostics: false,
                 ..DiagnosticOptions::default()
             })
+        }),
+        workspace: Some(lsp_types::WorkspaceServerCapabilities {
+            workspace_folders: Some(WorkspaceFoldersServerCapabilities {
+                supported: Some(true),
+                change_notifications: Some(OneOf::Left(true)),
+            }),
+            ..lsp_types::WorkspaceServerCapabilities::default()
         }),
         ..ServerCapabilities::default()
     }
@@ -145,6 +153,7 @@ enum Pending {
 /// echo back.
 enum Outgoing {
     Configuration,
+    WatchedFilesRegistration,
 }
 
 struct Server {
@@ -192,6 +201,9 @@ impl Server {
     fn run(&mut self, connection: &Connection) -> Result<ExitCode> {
         if self.client.pull_configuration {
             self.request_configuration();
+        }
+        if self.client.dynamic_watched_files {
+            self.register_watched_files();
         }
         // Cloned out of `self` so the handlers below can still borrow it.
         let outcomes = self.outcomes.clone();
@@ -404,36 +416,26 @@ impl Server {
             self.respond_no_actions(id);
             return;
         };
-        let wants_quickfix = params
-            .context
-            .only
-            .as_ref()
-            .is_none_or(|kinds| kinds.contains(&CodeActionKind::QUICKFIX));
-        let wants_refactor = params.context.only.as_ref().is_none_or(|kinds| {
-            kinds
-                .iter()
-                .any(|kind| kind.as_str().starts_with(CodeActionKind::REFACTOR.as_str()))
-        });
-        let fix_all = params.context.only.as_ref().is_some_and(|kinds| {
-            kinds
-                .iter()
-                .any(|kind| kind.as_str() == crate::code_actions::FIX_ALL_KIND)
-        });
-        if (!wants_quickfix && !wants_refactor && !fix_all)
-            || (params.context.diagnostics.is_empty() && !fix_all)
+        if params.context.diagnostics.is_empty()
+            && params
+                .context
+                .only
+                .as_ref()
+                .is_none_or(|kinds| !kinds.contains(&CodeActionKind::SOURCE_FIX_ALL))
         {
             self.respond_no_actions(id);
             return;
         }
+        let only = params.context.only.as_ref();
         let job = Job::CodeAction {
             id: id.clone(),
             path: uri_to_path(uri.as_str()),
             text: document.shared_text(),
             uri,
             diagnostics: params.context.diagnostics,
-            quickfix: wants_quickfix,
-            suggestions: wants_refactor,
-            fix_all,
+            quickfix: only.is_none_or(|kinds| kinds.contains(&CodeActionKind::QUICKFIX)),
+            suggestions: only.is_none_or(|kinds| kinds.contains(&CodeActionKind::REFACTOR_REWRITE)),
+            fix_all: only.is_none_or(|kinds| kinds.contains(&CodeActionKind::SOURCE_FIX_ALL)),
         };
         self.pending.insert(id, Pending::CodeAction);
         self.worker.submit(job);
@@ -441,48 +443,35 @@ impl Server {
 
     fn on_code_lens(&mut self, request: Request) {
         let id = request.id;
-        let params = match serde_json::from_value::<CodeLensParams>(request.params) {
-            Ok(params) => params,
-            Err(err) => {
-                log::warn(format_args!("textDocument/codeLens: {err}"));
-                self.respond_no_lenses(id);
-                return;
-            }
+        let Ok(params) = serde_json::from_value::<CodeLensParams>(request.params) else {
+            return self.respond_no_lenses(id);
         };
         if !self.settings.runes_legacy_mode_code_lens_enable {
-            self.respond_no_lenses(id);
-            return;
+            return self.respond_no_lenses(id);
         }
         let Some((path, text)) = self.component(&params.text_document.uri) else {
-            self.respond_no_lenses(id);
-            return;
+            return self.respond_no_lenses(id);
         };
-        let job = Job::CodeLens {
-            id: id.clone(),
-            path,
-            text,
-        };
-        self.pending.insert(id, Pending::CodeLens);
-        self.worker.submit(job);
+        self.pending.insert(id.clone(), Pending::CodeLens);
+        self.worker.submit(Job::CodeLens { id, path, text });
     }
 
     fn on_execute_command(&mut self, request: Request) {
         let id = request.id;
-        let params = match serde_json::from_value::<ExecuteCommandParams>(request.params) {
-            Ok(params) if params.command == crate::extract::COMMAND => params,
-            Ok(_) => return self.respond_nothing(id),
-            Err(err) => {
-                log::warn(format_args!("workspace/executeCommand: {err}"));
-                return self.respond_nothing(id);
-            }
+        let Ok(params) = serde_json::from_value::<ExecuteCommandParams>(request.params) else {
+            return self.respond_nothing(id);
         };
+        if params.command != crate::extract::COMMAND {
+            return self.respond_nothing(id);
+        }
         let Some(args) = params.arguments.into_iter().nth(1) else {
             return self.respond_nothing(id);
         };
-        let Some(uri) = args.get("uri").and_then(serde_json::Value::as_str) else {
-            return self.respond_nothing(id);
-        };
-        let Ok(uri) = uri.parse::<Uri>() else {
+        let Some(uri) = args
+            .get("uri")
+            .and_then(serde_json::Value::as_str)
+            .and_then(|uri| uri.parse::<Uri>().ok())
+        else {
             return self.respond_nothing(id);
         };
         let Some(document) = self.component_document(&uri) else {
@@ -623,6 +612,29 @@ impl Server {
                     Err(err) => log::warn(format_args!("{method}: {err}")),
                 }
             }
+            "workspace/didChangeWorkspaceFolders" => {
+                match serde_json::from_value::<DidChangeWorkspaceFoldersParams>(notification.params)
+                {
+                    Ok(params) => self
+                        .client
+                        .update_workspace_folders(params.event.added, &params.event.removed),
+                    Err(err) => log::warn(format_args!("{method}: {err}")),
+                }
+            }
+            "workspace/didChangeWatchedFiles" => {
+                match serde_json::from_value::<DidChangeWatchedFilesParams>(notification.params) {
+                    Ok(params)
+                        if params
+                            .changes
+                            .iter()
+                            .any(|change| is_project_config(&change.uri)) =>
+                    {
+                        self.invalidate_project_config();
+                    }
+                    Ok(_) => {}
+                    Err(err) => log::warn(format_args!("{method}: {err}")),
+                }
+            }
             "textDocument/didOpen" => {
                 match serde_json::from_value::<DidOpenTextDocumentParams>(notification.params) {
                     Ok(params) => {
@@ -682,14 +694,11 @@ impl Server {
                 // A `rsvelte-lint.json` / `.oxfmtrc` edit reaches the server as
                 // a configuration change too, so the resolved-config caches are
                 // dropped along with the client settings.
-                self.worker.submit(Job::ClearCaches);
+                self.invalidate_project_config();
                 if self.client.pull_configuration {
                     self.request_configuration();
                 } else {
                     self.settings = Settings::default();
-                    if !self.client.pull_diagnostics {
-                        self.relint_open_documents();
-                    }
                 }
             }
             "exit" => self.exiting = true,
@@ -708,6 +717,13 @@ impl Server {
                 ErrorCode::RequestCanceled as i32,
                 "request cancelled by client".to_string(),
             ));
+        }
+    }
+
+    fn invalidate_project_config(&mut self) {
+        self.worker.submit(Job::ClearCaches);
+        if !self.client.pull_diagnostics {
+            self.relint_open_documents();
         }
     }
 
@@ -736,6 +752,7 @@ impl Server {
                     self.relint_open_documents();
                 }
             }
+            Outgoing::WatchedFilesRegistration => {}
         }
     }
 
@@ -819,6 +836,28 @@ impl Server {
                     section: Some(CONFIG_SECTION.to_string()),
                 }],
             },
+        ));
+    }
+
+    fn register_watched_files(&mut self) {
+        self.next_request_id += 1;
+        let id = RequestId::from(format!("rsvelte-watch-files-{}", self.next_request_id));
+        self.outgoing
+            .insert(id.clone(), Outgoing::WatchedFilesRegistration);
+        self.send(Request::new(
+            id,
+            "client/registerCapability".to_string(),
+            serde_json::json!({
+                "registrations": [{
+                    "id": "rsvelte-project-configs",
+                    "method": "workspace/didChangeWatchedFiles",
+                    "registerOptions": {
+                        "watchers": project_config_names().iter().map(|name| serde_json::json!({
+                            "globPattern": format!("**/{name}"),
+                        })).collect::<Vec<_>>(),
+                    },
+                }],
+            }),
         ));
     }
 
@@ -948,4 +987,21 @@ fn is_lint_target(document: &Document) -> bool {
     }
     let uri = document.uri.as_str();
     uri.ends_with(".svelte.js") || uri.ends_with(".svelte.ts")
+}
+
+fn is_project_config(uri: &Uri) -> bool {
+    project_config_names()
+        .iter()
+        .any(|name| uri.as_str().rsplit('/').next() == Some(name))
+}
+
+const fn project_config_names() -> &'static [&'static str] {
+    &[
+        "rsvelte-lint.json",
+        ".rsvelte-lintrc.json",
+        ".oxfmtrc.json",
+        ".oxfmtrc.jsonc",
+        "oxfmt.config.ts",
+        "oxfmt.config.mts",
+    ]
 }

--- a/crates/rsvelte_language_server/src/server.rs
+++ b/crates/rsvelte_language_server/src/server.rs
@@ -100,7 +100,7 @@ fn capabilities(client: &ClientState) -> ServerCapabilities {
             code_action_kinds: Some(vec![
                 CodeActionKind::QUICKFIX,
                 CodeActionKind::REFACTOR_REWRITE,
-                CodeActionKind::SOURCE_FIX_ALL,
+                CodeActionKind::from(crate::code_actions::FIX_ALL_KIND),
             ]),
             ..CodeActionOptions::default()
         })),
@@ -417,11 +417,9 @@ impl Server {
             return;
         };
         if params.context.diagnostics.is_empty()
-            && params
-                .context
-                .only
-                .as_ref()
-                .is_none_or(|kinds| !kinds.contains(&CodeActionKind::SOURCE_FIX_ALL))
+            && params.context.only.as_ref().is_none_or(|kinds| {
+                !kinds.contains(&CodeActionKind::from(crate::code_actions::FIX_ALL_KIND))
+            })
         {
             self.respond_no_actions(id);
             return;
@@ -435,7 +433,9 @@ impl Server {
             diagnostics: params.context.diagnostics,
             quickfix: only.is_none_or(|kinds| kinds.contains(&CodeActionKind::QUICKFIX)),
             suggestions: only.is_none_or(|kinds| kinds.contains(&CodeActionKind::REFACTOR_REWRITE)),
-            fix_all: only.is_none_or(|kinds| kinds.contains(&CodeActionKind::SOURCE_FIX_ALL)),
+            fix_all: only.is_none_or(|kinds| {
+                kinds.contains(&CodeActionKind::from(crate::code_actions::FIX_ALL_KIND))
+            }),
         };
         self.pending.insert(id, Pending::CodeAction);
         self.worker.submit(job);

--- a/crates/rsvelte_language_server/src/server.rs
+++ b/crates/rsvelte_language_server/src/server.rs
@@ -9,18 +9,17 @@ use crossbeam_channel::{Receiver, Sender, after, never, select, unbounded};
 use lsp_server::{Connection, ErrorCode, Message, Notification, Request, RequestId, Response};
 use lsp_types::{
     CancelParams, CodeActionKind, CodeActionOptions, CodeActionOrCommand, CodeActionParams,
-    CodeActionProviderCapability, CompletionOptions, CompletionParams, ConfigurationItem,
-    ConfigurationParams, DiagnosticOptions, DiagnosticServerCapabilities,
-    DidChangeTextDocumentParams, DidChangeWatchedFilesParams, DidChangeWorkspaceFoldersParams,
-    DidCloseTextDocumentParams, DidOpenTextDocumentParams, DidSaveTextDocumentParams,
-    DocumentDiagnosticParams, DocumentDiagnosticReport, DocumentFormattingParams,
-    DocumentSymbolParams, DocumentSymbolResponse, FoldingRange, FoldingRangeParams,
-    FoldingRangeProviderCapability, FullDocumentDiagnosticReport, HoverParams,
-    HoverProviderCapability, NumberOrString, OneOf, PublishDiagnosticsParams,
-    RelatedFullDocumentDiagnosticReport, SelectionRangeParams, SelectionRangeProviderCapability,
-    ServerCapabilities, TextDocumentPositionParams, TextDocumentSyncCapability,
-    TextDocumentSyncKind, TextDocumentSyncOptions, TextDocumentSyncSaveOptions, TextEdit, Uri,
-    WorkspaceFoldersServerCapabilities,
+    CodeActionProviderCapability, CodeLens, CodeLensOptions, CodeLensParams, CompletionOptions,
+    CompletionParams, ConfigurationItem, ConfigurationParams, DiagnosticOptions,
+    DiagnosticServerCapabilities, DidChangeTextDocumentParams, DidCloseTextDocumentParams,
+    DidOpenTextDocumentParams, DidSaveTextDocumentParams, DocumentDiagnosticParams,
+    DocumentDiagnosticReport, DocumentFormattingParams, DocumentSymbolParams,
+    DocumentSymbolResponse, FoldingRange, FoldingRangeParams, FoldingRangeProviderCapability,
+    FullDocumentDiagnosticReport, HoverParams, HoverProviderCapability, NumberOrString, OneOf,
+    PublishDiagnosticsParams, RelatedFullDocumentDiagnosticReport, SelectionRangeParams,
+    SelectionRangeProviderCapability, ServerCapabilities, TextDocumentPositionParams,
+    TextDocumentSyncCapability, TextDocumentSyncKind, TextDocumentSyncOptions,
+    TextDocumentSyncSaveOptions, TextEdit, Uri,
 };
 
 use crate::client::ClientState;
@@ -100,6 +99,9 @@ fn capabilities(client: &ClientState) -> ServerCapabilities {
             code_action_kinds: Some(vec![CodeActionKind::QUICKFIX]),
             ..CodeActionOptions::default()
         })),
+        code_lens_provider: Some(CodeLensOptions {
+            resolve_provider: Some(false),
+        }),
         folding_range_provider: Some(FoldingRangeProviderCapability::Simple(true)),
         selection_range_provider: Some(SelectionRangeProviderCapability::Simple(true)),
         document_symbol_provider: Some(OneOf::Left(true)),
@@ -110,13 +112,6 @@ fn capabilities(client: &ClientState) -> ServerCapabilities {
                 workspace_diagnostics: false,
                 ..DiagnosticOptions::default()
             })
-        }),
-        workspace: Some(lsp_types::WorkspaceServerCapabilities {
-            workspace_folders: Some(WorkspaceFoldersServerCapabilities {
-                supported: Some(true),
-                change_notifications: Some(OneOf::Left(true)),
-            }),
-            ..lsp_types::WorkspaceServerCapabilities::default()
         }),
         ..ServerCapabilities::default()
     }
@@ -130,6 +125,7 @@ enum Pending {
     Completion,
     Hover,
     CodeAction,
+    CodeLens,
     FoldingRange,
     SelectionRange,
     DocumentSymbol,
@@ -140,7 +136,6 @@ enum Pending {
 /// echo back.
 enum Outgoing {
     Configuration,
-    WatchedFilesRegistration,
 }
 
 struct Server {
@@ -188,9 +183,6 @@ impl Server {
     fn run(&mut self, connection: &Connection) -> Result<ExitCode> {
         if self.client.pull_configuration {
             self.request_configuration();
-        }
-        if self.client.dynamic_watched_files {
-            self.register_watched_files();
         }
         // Cloned out of `self` so the handlers below can still borrow it.
         let outcomes = self.outcomes.clone();
@@ -244,6 +236,7 @@ impl Server {
             "textDocument/completion" => self.on_completion(request),
             "textDocument/hover" => self.on_hover(request),
             "textDocument/codeAction" => self.on_code_action(request),
+            "textDocument/codeLens" => self.on_code_lens(request),
             "textDocument/foldingRange" => self.on_folding_range(request),
             "textDocument/selectionRange" => self.on_selection_range(request),
             "textDocument/documentSymbol" => self.on_document_symbol(request),
@@ -423,6 +416,33 @@ impl Server {
         self.worker.submit(job);
     }
 
+    fn on_code_lens(&mut self, request: Request) {
+        let id = request.id;
+        let params = match serde_json::from_value::<CodeLensParams>(request.params) {
+            Ok(params) => params,
+            Err(err) => {
+                log::warn(format_args!("textDocument/codeLens: {err}"));
+                self.respond_no_lenses(id);
+                return;
+            }
+        };
+        if !self.settings.runes_legacy_mode_code_lens_enable {
+            self.respond_no_lenses(id);
+            return;
+        }
+        let Some((path, text)) = self.component(&params.text_document.uri) else {
+            self.respond_no_lenses(id);
+            return;
+        };
+        let job = Job::CodeLens {
+            id: id.clone(),
+            path,
+            text,
+        };
+        self.pending.insert(id, Pending::CodeLens);
+        self.worker.submit(job);
+    }
+
     fn on_folding_range(&mut self, request: Request) {
         let id = request.id;
         let params = match serde_json::from_value::<FoldingRangeParams>(request.params) {
@@ -535,29 +555,6 @@ impl Server {
                     Err(err) => log::warn(format_args!("{method}: {err}")),
                 }
             }
-            "workspace/didChangeWorkspaceFolders" => {
-                match serde_json::from_value::<DidChangeWorkspaceFoldersParams>(notification.params)
-                {
-                    Ok(params) => self
-                        .client
-                        .update_workspace_folders(params.event.added, &params.event.removed),
-                    Err(err) => log::warn(format_args!("{method}: {err}")),
-                }
-            }
-            "workspace/didChangeWatchedFiles" => {
-                match serde_json::from_value::<DidChangeWatchedFilesParams>(notification.params) {
-                    Ok(params)
-                        if params
-                            .changes
-                            .iter()
-                            .any(|change| is_project_config(&change.uri)) =>
-                    {
-                        self.invalidate_project_config();
-                    }
-                    Ok(_) => {}
-                    Err(err) => log::warn(format_args!("{method}: {err}")),
-                }
-            }
             "textDocument/didOpen" => {
                 match serde_json::from_value::<DidOpenTextDocumentParams>(notification.params) {
                     Ok(params) => {
@@ -617,11 +614,14 @@ impl Server {
                 // A `rsvelte-lint.json` / `.oxfmtrc` edit reaches the server as
                 // a configuration change too, so the resolved-config caches are
                 // dropped along with the client settings.
-                self.invalidate_project_config();
+                self.worker.submit(Job::ClearCaches);
                 if self.client.pull_configuration {
                     self.request_configuration();
                 } else {
                     self.settings = Settings::default();
+                    if !self.client.pull_diagnostics {
+                        self.relint_open_documents();
+                    }
                 }
             }
             "exit" => self.exiting = true,
@@ -640,13 +640,6 @@ impl Server {
                 ErrorCode::RequestCanceled as i32,
                 "request cancelled by client".to_string(),
             ));
-        }
-    }
-
-    fn invalidate_project_config(&mut self) {
-        self.worker.submit(Job::ClearCaches);
-        if !self.client.pull_diagnostics {
-            self.relint_open_documents();
         }
     }
 
@@ -675,7 +668,6 @@ impl Server {
                     self.relint_open_documents();
                 }
             }
-            Outgoing::WatchedFilesRegistration => {}
         }
     }
 
@@ -701,6 +693,11 @@ impl Server {
             Outcome::CodeActions { id, actions } => {
                 if self.pending.remove(&id).is_some() {
                     self.respond(Response::new_ok(id, actions));
+                }
+            }
+            Outcome::CodeLenses { id, lenses } => {
+                if self.pending.remove(&id).is_some() {
+                    self.respond(Response::new_ok(id, lenses));
                 }
             }
             Outcome::FoldingRanges { id, ranges } => {
@@ -749,28 +746,6 @@ impl Server {
                     section: Some(CONFIG_SECTION.to_string()),
                 }],
             },
-        ));
-    }
-
-    fn register_watched_files(&mut self) {
-        self.next_request_id += 1;
-        let id = RequestId::from(format!("rsvelte-watch-files-{}", self.next_request_id));
-        self.outgoing
-            .insert(id.clone(), Outgoing::WatchedFilesRegistration);
-        self.send(Request::new(
-            id,
-            "client/registerCapability".to_string(),
-            serde_json::json!({
-                "registrations": [{
-                    "id": "rsvelte-project-configs",
-                    "method": "workspace/didChangeWatchedFiles",
-                    "registerOptions": {
-                        "watchers": project_config_names().iter().map(|name| serde_json::json!({
-                            "globPattern": format!("**/{name}"),
-                        })).collect::<Vec<_>>(),
-                    },
-                }],
-            }),
         ));
     }
 
@@ -869,6 +844,10 @@ impl Server {
         self.respond(Response::new_ok(id, Vec::<CodeActionOrCommand>::new()));
     }
 
+    fn respond_no_lenses(&self, id: RequestId) {
+        self.respond(Response::new_ok(id, Vec::<CodeLens>::new()));
+    }
+
     fn respond_no_ranges(&self, id: RequestId) {
         self.respond(Response::new_ok(id, Vec::<FoldingRange>::new()));
     }
@@ -896,21 +875,4 @@ fn is_lint_target(document: &Document) -> bool {
     }
     let uri = document.uri.as_str();
     uri.ends_with(".svelte.js") || uri.ends_with(".svelte.ts")
-}
-
-fn is_project_config(uri: &Uri) -> bool {
-    project_config_names()
-        .iter()
-        .any(|name| uri.as_str().rsplit('/').next() == Some(name))
-}
-
-const fn project_config_names() -> &'static [&'static str] {
-    &[
-        "rsvelte-lint.json",
-        ".rsvelte-lintrc.json",
-        ".oxfmtrc.json",
-        ".oxfmtrc.jsonc",
-        "oxfmt.config.ts",
-        "oxfmt.config.mts",
-    ]
 }

--- a/crates/rsvelte_language_server/src/settings.rs
+++ b/crates/rsvelte_language_server/src/settings.rs
@@ -26,6 +26,7 @@ pub struct Settings {
     pub folding_range_enable: bool,
     pub selection_range_enable: bool,
     pub document_symbol_enable: bool,
+    pub runes_legacy_mode_code_lens_enable: bool,
     pub compiler_warnings: CompilerWarnings,
 }
 
@@ -39,6 +40,7 @@ impl Default for Settings {
             folding_range_enable: true,
             selection_range_enable: true,
             document_symbol_enable: true,
+            runes_legacy_mode_code_lens_enable: true,
             compiler_warnings: CompilerWarnings::default(),
         }
     }
@@ -61,6 +63,8 @@ impl Settings {
                 .unwrap_or(default.selection_range_enable),
             document_symbol_enable: enabled(value, "documentSymbol")
                 .unwrap_or(default.document_symbol_enable),
+            runes_legacy_mode_code_lens_enable: enabled(value, "runesLegacyModeCodeLens")
+                .unwrap_or(default.runes_legacy_mode_code_lens_enable),
             compiler_warnings: compiler_warnings(value),
         }
     }
@@ -100,6 +104,7 @@ mod tests {
             "foldingRange": { "enable": false },
             "selectionRange": { "enable": true },
             "documentSymbol": { "enable": false }
+            ,"runesLegacyModeCodeLens": { "enable": true }
         }));
         assert_eq!(
             s,
@@ -111,6 +116,7 @@ mod tests {
                 folding_range_enable: false,
                 selection_range_enable: true,
                 document_symbol_enable: false,
+                runes_legacy_mode_code_lens_enable: true,
                 compiler_warnings: CompilerWarnings::default(),
             }
         );

--- a/crates/rsvelte_language_server/src/worker.rs
+++ b/crates/rsvelte_language_server/src/worker.rs
@@ -66,6 +66,9 @@ pub enum Job {
         path: PathBuf,
         text: Arc<String>,
         diagnostics: Vec<Diagnostic>,
+        quickfix: bool,
+        suggestions: bool,
+        fix_all: bool,
     },
     CodeLens {
         id: RequestId,
@@ -269,9 +272,28 @@ fn run(jobs: &Receiver<Job>, outcomes: &Sender<Outcome>) {
                 path,
                 text,
                 diagnostics,
+                quickfix,
+                suggestions,
+                fix_all,
             } => {
+                let config = lint_configs.get(path.parent().unwrap_or(Path::new(".")));
                 let actions = guard("code action", &path, || {
-                    crate::code_actions::quickfixes(&text, &uri, &diagnostics)
+                    let mut actions = if quickfix {
+                        crate::code_actions::quickfixes(&text, &uri, &diagnostics)
+                    } else {
+                        Vec::new()
+                    };
+                    actions.extend(crate::code_actions::lint_actions(
+                        &text,
+                        &path,
+                        &uri,
+                        &config,
+                        &diagnostics,
+                        quickfix,
+                        suggestions,
+                        fix_all,
+                    ));
+                    actions
                 })
                 .unwrap_or_default();
                 Outcome::CodeActions { id, actions }

--- a/crates/rsvelte_language_server/src/worker.rs
+++ b/crates/rsvelte_language_server/src/worker.rs
@@ -18,8 +18,8 @@ use std::thread::JoinHandle;
 use crossbeam_channel::{Receiver, Sender, unbounded};
 use lsp_server::RequestId;
 use lsp_types::{
-    CodeActionOrCommand, CompletionList, Diagnostic, DocumentSymbolResponse, FoldingRange, Hover,
-    Range, SelectionRange, TextEdit, Uri,
+    CodeActionOrCommand, CodeLens, CompletionList, Diagnostic, DocumentSymbolResponse,
+    FoldingRange, Hover, Range, SelectionRange, TextEdit, Uri,
 };
 
 use crate::format::FormatSessions;
@@ -65,6 +65,11 @@ pub enum Job {
         path: PathBuf,
         text: Arc<String>,
         diagnostics: Vec<Diagnostic>,
+    },
+    CodeLens {
+        id: RequestId,
+        path: PathBuf,
+        text: Arc<String>,
     },
     FoldingRange {
         id: RequestId,
@@ -118,6 +123,10 @@ pub enum Outcome {
     CodeActions {
         id: RequestId,
         actions: Vec<CodeActionOrCommand>,
+    },
+    CodeLenses {
+        id: RequestId,
+        lenses: Vec<CodeLens>,
     },
     FoldingRanges {
         id: RequestId,
@@ -255,6 +264,13 @@ fn run(jobs: &Receiver<Job>, outcomes: &Sender<Outcome>) {
                 .unwrap_or_default();
                 Outcome::CodeActions { id, actions }
             }
+            Job::CodeLens { id, path, text } => Outcome::CodeLenses {
+                id,
+                lenses: guard("code lens", &path, || {
+                    crate::code_lens::code_lenses(&text, &path)
+                })
+                .unwrap_or_default(),
+            },
             Job::FoldingRange {
                 id,
                 path,

--- a/crates/rsvelte_language_server/src/worker.rs
+++ b/crates/rsvelte_language_server/src/worker.rs
@@ -317,7 +317,7 @@ fn run(jobs: &Receiver<Job>, outcomes: &Sender<Outcome>) {
                     crate::extract::component(&text, uri.as_str(), range, &file_path)
                 })
                 .unwrap_or_else(|| Err("Invalid selection range".to_string()))
-                .map_or_else(Value::String, |edit| edit),
+                .unwrap_or_else(Value::String),
             },
             Job::FoldingRange {
                 id,

--- a/crates/rsvelte_language_server/src/worker.rs
+++ b/crates/rsvelte_language_server/src/worker.rs
@@ -21,6 +21,7 @@ use lsp_types::{
     CodeActionOrCommand, CodeLens, CompletionList, Diagnostic, DocumentSymbolResponse,
     FoldingRange, Hover, Range, SelectionRange, TextEdit, Uri,
 };
+use serde_json::Value;
 
 use crate::format::FormatSessions;
 use crate::lint::LintConfigCache;
@@ -70,6 +71,13 @@ pub enum Job {
         id: RequestId,
         path: PathBuf,
         text: Arc<String>,
+    },
+    ExtractComponent {
+        id: RequestId,
+        uri: Uri,
+        text: Arc<String>,
+        range: Range,
+        file_path: String,
     },
     FoldingRange {
         id: RequestId,
@@ -127,6 +135,10 @@ pub enum Outcome {
     CodeLenses {
         id: RequestId,
         lenses: Vec<CodeLens>,
+    },
+    ExtractedComponent {
+        id: RequestId,
+        result: Value,
     },
     FoldingRanges {
         id: RequestId,
@@ -270,6 +282,20 @@ fn run(jobs: &Receiver<Job>, outcomes: &Sender<Outcome>) {
                     crate::code_lens::code_lenses(&text, &path)
                 })
                 .unwrap_or_default(),
+            },
+            Job::ExtractComponent {
+                id,
+                uri,
+                text,
+                range,
+                file_path,
+            } => Outcome::ExtractedComponent {
+                id,
+                result: guard("extract component", Path::new(uri.as_str()), || {
+                    crate::extract::component(&text, uri.as_str(), range, &file_path)
+                })
+                .unwrap_or_else(|| Err("Invalid selection range".to_string()))
+                .map_or_else(Value::String, |edit| edit),
             },
             Job::FoldingRange {
                 id,

--- a/crates/rsvelte_language_server/tests/protocol.rs
+++ b/crates/rsvelte_language_server/tests/protocol.rs
@@ -184,6 +184,14 @@ impl Server {
         self.response(id).as_array().cloned().unwrap_or_default()
     }
 
+    fn code_lenses(&mut self, uri: &str) -> Vec<Value> {
+        let id = self.request(
+            "textDocument/codeLens",
+            json!({ "textDocument": { "uri": uri } }),
+        );
+        self.response(id).as_array().cloned().unwrap_or_default()
+    }
+
     fn hover(&mut self, uri: &str, line: u32, character: u32) -> Value {
         let id = self.request(
             "textDocument/hover",
@@ -1042,6 +1050,61 @@ fn serves_folding_selection_and_symbols() {
         "a tree carries ranges, not locations"
     );
 
+    assert_eq!(server.shutdown(), Some(0));
+}
+
+#[test]
+fn serves_runes_legacy_mode_code_lenses() {
+    let dir = temp_dir("code-lens");
+    let uri = file_uri(&dir.join("App.svelte"));
+    let mut server = initialized_server();
+
+    did_open(&mut server, &uri, "<script>let count = $state(0);</script>");
+    assert_eq!(
+        server.code_lenses(&uri),
+        json!([{
+            "range": {
+                "start": { "line": 0, "character": 0 },
+                "end": { "line": 0, "character": 0 }
+            },
+            "command": {
+                "title": "Runes mode",
+                "command": "svelte.openLink",
+                "arguments": ["https://svelte.dev/docs/svelte/legacy-overview"]
+            }
+        }])
+        .as_array()
+        .unwrap()
+        .clone()
+    );
+
+    server.notify(
+        "textDocument/didChange",
+        json!({
+            "textDocument": { "uri": uri, "version": 2 },
+            "contentChanges": [{ "text": "<script>let count = 0;</script>" }],
+        }),
+    );
+    assert_eq!(
+        server.code_lenses(&uri)[0]["command"]["title"],
+        "Legacy mode"
+    );
+    assert_eq!(server.shutdown(), Some(0));
+}
+
+#[test]
+fn code_lens_respects_its_setting() {
+    let dir = temp_dir("code-lens-disabled");
+    let uri = file_uri(&dir.join("App.svelte"));
+    let mut server = initialized_server();
+    server.settings = json!({ "runesLegacyModeCodeLens": { "enable": false } });
+    server.notify(
+        "workspace/didChangeConfiguration",
+        json!({ "settings": Value::Null }),
+    );
+    server.settle_configuration();
+    did_open(&mut server, &uri, "<p>legacy</p>");
+    assert!(server.code_lenses(&uri).is_empty());
     assert_eq!(server.shutdown(), Some(0));
 }
 

--- a/crates/rsvelte_language_server/tests/protocol.rs
+++ b/crates/rsvelte_language_server/tests/protocol.rs
@@ -434,7 +434,7 @@ fn serves_diagnostics_and_formatting() {
     );
     assert_eq!(
         result["capabilities"]["codeActionProvider"]["codeActionKinds"],
-        json!(["quickfix"])
+        json!(["quickfix", "refactor.rewrite", "source.fixAll.rsvelte"])
     );
     assert_eq!(
         result["capabilities"]["workspace"]["workspaceFolders"],


### PR DESCRIPTION
Implements the remaining native M1 LSP features for #1762: runes/legacy code lenses, lint fixes and suggestions, fix-all support, anchor noreferrer quickfixes, and extract-component command support.

Validated with cargo test -p rsvelte_language_server and cargo clippy -p rsvelte_language_server --all-targets -- -D warnings.

Closes #1762.