### PR TITLE
refactor: retain OXC programs across allocator boundaries

### DIFF
--- a/.changeset/retained-oxc-programs.md
+++ b/.changeset/retained-oxc-programs.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/compiler": patch
+---
+
+Preserve source spans when transferring retained compiler programs into a new OXC allocator.

--- a/crates/rsvelte_core/src/ast/oxc_program.rs
+++ b/crates/rsvelte_core/src/ast/oxc_program.rs
@@ -1,4 +1,4 @@
-use oxc_allocator::Allocator;
+use oxc_allocator::{Allocator, CloneIn};
 use oxc_ast::ast::Program;
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_parser::Parser;
@@ -64,6 +64,11 @@ impl<'source> RetainedProgram<'source> {
     }
 
     #[must_use]
+    pub fn clone_program_into<'alloc>(&self, allocator: &'alloc Allocator) -> Program<'alloc> {
+        self.program().clone_in(allocator)
+    }
+
+    #[must_use]
     pub fn source(&self) -> &str {
         self.borrow_owner().source()
     }
@@ -102,6 +107,8 @@ pub(crate) struct RetainedScripts<'source> {
 #[cfg(test)]
 mod tests {
     use super::RetainedProgram;
+    use oxc_allocator::Allocator;
+    use oxc_span::GetSpan;
 
     #[test]
     fn retains_program_after_move() {
@@ -118,5 +125,15 @@ mod tests {
     fn is_send_when_owner_and_program_move_together() {
         fn assert_send<T: Send>() {}
         assert_send::<RetainedProgram<'static>>();
+    }
+
+    #[test]
+    fn clone_into_preserves_source_spans() {
+        let retained = RetainedProgram::parse("let answer = 42;", false);
+        let allocator = Allocator::default();
+        let cloned = retained.clone_program_into(&allocator);
+
+        assert_eq!(cloned.span, retained.program().span);
+        assert_eq!(cloned.body[0].span(), retained.program().body[0].span());
     }
 }


### PR DESCRIPTION
Foundation for #1781. Exposes a tested RetainedProgram clone into the final OXC allocator while preserving source spans. Subsequent commits will use this to insert instance-script AST nodes directly into the final client Program instead of stringifying and reparsing them.