### PR TITLE
fix: preserve client source-map spans for unchanged scripts

### DIFF
--- a/.changeset/tiny-retained-client-map.md
+++ b/.changeset/tiny-retained-client-map.md
@@ -1,0 +1,5 @@
+---
+'@rsvelte/compiler': patch
+---
+
+Preserve source locations for unchanged client instance scripts in generated source maps.

--- a/compatibility/sourcemap-known-failures.json
+++ b/compatibility/sourcemap-known-failures.json
@@ -47,7 +47,7 @@
   "map-parity\tsourcemap-basename-without-outputname\tclient\t4",
   "map-parity\tsourcemap-concat\tclient\t14",
   "map-parity\tsourcemap-concat\tserver\t4",
-  "map-parity\tsourcemap-empty-source\tclient\t21",
+  "map-parity\tsourcemap-empty-source\tclient\t18",
   "map-parity\tsourcemap-empty-source\tserver\t6",
   "map-parity\tsourcemap-names\tclient\t36",
   "map-parity\tsourcemap-names\tserver\t6",

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
@@ -570,6 +570,7 @@ fn transform_client_with_visitors(
     // statements at module-body assembly (below) rather than spliced into the
     // final printed output.
     let mut rest_excludes_hoists: Vec<(String, String)> = Vec::new();
+    let mut ast_islands = Vec::new();
 
     // Transform the instance script once with the real reactive_import_names.
     // This also determines how many $$array names it consumes (for template generation)
@@ -1322,11 +1323,33 @@ fn transform_client_with_visitors(
                     // the official Svelte compiler's esrap output (consistent spacing,
                     // semicolons, etc.)
                     let normalized = normalize_js_with_oxc(trimmed, script_indent);
-                    component_body.push(script_raw_statement(
-                        normalized,
-                        script_source_offset,
-                        has_effect_rune,
-                    ));
+                    let retained = retained_scripts
+                        .and_then(|scripts| scripts.instance.as_ref())
+                        .filter(|retained| {
+                            !analysis.is_typescript
+                                && retained.source() == content.raw
+                                && retained.program().comments.is_empty()
+                                && transformed_script.trim() == content.raw.trim()
+                        });
+                    if let Some(retained) = retained {
+                        let index = ast_islands.len();
+                        ast_islands.push(super::js_ast::to_oxc::AstIsland {
+                            program: retained,
+                            source_offset: content.start,
+                        });
+                        component_body.push(JsStatement::RetainedAst {
+                            index,
+                            fallback: normalized.into(),
+                            source_offset: script_source_offset,
+                            has_effect_rune,
+                        });
+                    } else {
+                        component_body.push(script_raw_statement(
+                            normalized,
+                            script_source_offset,
+                            has_effect_rune,
+                        ));
+                    }
                 }
             }
         }
@@ -2394,51 +2417,52 @@ fn transform_client_with_visitors(
         let converted = CLIENT_TO_OXC_ALLOCATOR.with(|cell| {
             let mut alloc = cell.borrow_mut();
             alloc.reset();
-            super::js_ast::to_oxc::program_to_oxc(&program, &context.arena, &alloc).map(
-                |converted| {
-                    // Keep `;` empty statements: the parsed-`Raw` `;;` are real
-                    // EmptyStatement nodes the official compiler output preserves.
-                    let print_opts =
-                        rsvelte_esrap::PrintOptions::default().with_empty_statements(true);
-                    let oxc_prog = &converted.program;
-                    match &converted.comment_source {
-                        // The program carries comments, so it prints in the
-                        // unified comment coordinate space `to_oxc` built.
-                        Some(comment_source) => {
-                            let map_source = options.enable_sourcemap.then_some(source);
-                            let _t = super::profile::timer_start();
-                            let pm = rsvelte_esrap::print_split(
-                                oxc_prog,
-                                comment_source,
-                                converted.loc_base,
-                                map_source,
-                                &converted.loc_map,
-                                &print_opts,
-                            );
-                            super::profile::record_esrap_client_split(
-                                super::profile::timer_elapsed(_t),
-                            );
-                            (pm.code, esrap_mappings_to_source_mappings(&pm.mappings))
-                        }
-                        None if options.enable_sourcemap => {
-                            let _t = super::profile::timer_start();
-                            let pm = rsvelte_esrap::print_with_map(oxc_prog, source, &print_opts);
-                            super::profile::record_esrap_client_map(super::profile::timer_elapsed(
-                                _t,
-                            ));
-                            (pm.code, esrap_mappings_to_source_mappings(&pm.mappings))
-                        }
-                        None => {
-                            let _t = super::profile::timer_start();
-                            let code = rsvelte_esrap::print_with(oxc_prog, "", &print_opts);
-                            super::profile::record_esrap_client_plain(
-                                super::profile::timer_elapsed(_t),
-                            );
-                            (code, Vec::new())
-                        }
-                    }
-                },
+            super::js_ast::to_oxc::program_to_oxc_with_islands(
+                &program,
+                &context.arena,
+                &alloc,
+                &ast_islands,
             )
+            .map(|converted| {
+                // Keep `;` empty statements: the parsed-`Raw` `;;` are real
+                // EmptyStatement nodes the official compiler output preserves.
+                let print_opts = rsvelte_esrap::PrintOptions::default().with_empty_statements(true);
+                let oxc_prog = &converted.program;
+                match &converted.comment_source {
+                    // The program carries comments, so it prints in the
+                    // unified comment coordinate space `to_oxc` built.
+                    Some(comment_source) => {
+                        let map_source = options.enable_sourcemap.then_some(source);
+                        let _t = super::profile::timer_start();
+                        let pm = rsvelte_esrap::print_split(
+                            oxc_prog,
+                            comment_source,
+                            converted.loc_base,
+                            map_source,
+                            &converted.loc_map,
+                            &print_opts,
+                        );
+                        super::profile::record_esrap_client_split(super::profile::timer_elapsed(
+                            _t,
+                        ));
+                        (pm.code, esrap_mappings_to_source_mappings(&pm.mappings))
+                    }
+                    None if options.enable_sourcemap => {
+                        let _t = super::profile::timer_start();
+                        let pm = rsvelte_esrap::print_with_map(oxc_prog, source, &print_opts);
+                        super::profile::record_esrap_client_map(super::profile::timer_elapsed(_t));
+                        (pm.code, esrap_mappings_to_source_mappings(&pm.mappings))
+                    }
+                    None => {
+                        let _t = super::profile::timer_start();
+                        let code = rsvelte_esrap::print_with(oxc_prog, "", &print_opts);
+                        super::profile::record_esrap_client_plain(super::profile::timer_elapsed(
+                            _t,
+                        ));
+                        (code, Vec::new())
+                    }
+                }
+            })
         });
         if let Some((code, mappings)) = converted {
             super::profile::record_codegen(super::profile::timer_elapsed(_codegen_start));

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/js_ast/codegen.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/js_ast/codegen.rs
@@ -412,6 +412,14 @@ impl<'a> JsCodegen<'a> {
                 self.emit_raw_mapped(code, *source_offset);
                 self.needs_semicolon = false;
             }
+            JsStatement::RetainedAst {
+                fallback,
+                source_offset,
+                ..
+            } => {
+                self.emit_raw_mapped(fallback, *source_offset);
+                self.needs_semicolon = false;
+            }
         }
     }
 
@@ -2285,6 +2293,7 @@ fn stmt_type_name(stmt: &JsStatement) -> &'static str {
         JsStatement::RawMapped { code, .. } => raw_stmt_type_name(code),
         JsStatement::RawEffect(code) => raw_stmt_type_name(code),
         JsStatement::RawMappedEffect { code, .. } => raw_stmt_type_name(code),
+        JsStatement::RetainedAst { fallback, .. } => raw_stmt_type_name(fallback),
     }
 }
 

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/js_ast/nodes.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/js_ast/nodes.rs
@@ -91,6 +91,13 @@ pub enum JsStatement {
         code: CompactString,
         source_offset: u32,
     },
+    /// A retained source AST inserted directly into the final OXC program.
+    RetainedAst {
+        index: usize,
+        fallback: CompactString,
+        source_offset: u32,
+        has_effect_rune: bool,
+    },
 }
 
 /// Import declaration.

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/js_ast/to_oxc.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/js_ast/to_oxc.rs
@@ -56,6 +56,7 @@
 
 use super::arena::{ExprId, JsArena};
 use super::nodes::*;
+use crate::ast::oxc_program::RetainedProgram;
 use oxc_allocator::{ArenaBox, ArenaVec, GetAllocator, ReplaceWith};
 use oxc_ast::ast::*;
 use oxc_ast::builder::AstBuilder;
@@ -75,6 +76,12 @@ pub struct Converted<'a> {
     pub comment_source: Option<String>,
     pub loc_base: u32,
     pub loc_map: Vec<(u32, u32, Option<u32>)>,
+}
+
+/// A retained source program to clone into the final OXC allocator.
+pub struct AstIsland<'source> {
+    pub program: &'source RetainedProgram<'source>,
+    pub source_offset: u32,
 }
 
 thread_local! {
@@ -108,13 +115,23 @@ pub fn program_to_oxc<'a>(
     arena: &JsArena,
     allocator: &'a oxc_allocator::Allocator,
 ) -> Option<Converted<'a>> {
+    program_to_oxc_with_islands(program, arena, allocator, &[])
+}
+
+/// Convert an IR program while inserting retained source ASTs directly.
+pub fn program_to_oxc_with_islands<'a, 'source>(
+    program: &JsProgram,
+    arena: &JsArena,
+    allocator: &'a oxc_allocator::Allocator,
+    islands: &[AstIsland<'source>],
+) -> Option<Converted<'a>> {
     note_fallback(UNSUPPORTED);
-    let (probe, synth) = convert_once(program, arena, allocator, None)?;
+    let (probe, synth) = convert_once(program, arena, allocator, islands, None)?;
     if !synth.saw_comments {
         return Some(probe);
     }
     let loc_base = synth.max_span.saturating_add(2);
-    let (converted, synth) = convert_once(program, arena, allocator, Some(loc_base))?;
+    let (converted, synth) = convert_once(program, arena, allocator, islands, Some(loc_base))?;
     // Every span the pass produced outside a chunk region must stay below
     // `loc_base`, or the printer would mistake it for a real location.
     if synth.max_span >= loc_base {
@@ -124,15 +141,17 @@ pub fn program_to_oxc<'a>(
     Some(converted)
 }
 
-fn convert_once<'a>(
+fn convert_once<'a, 'source>(
     program: &JsProgram,
     arena: &JsArena,
     allocator: &'a oxc_allocator::Allocator,
+    islands: &[AstIsland<'source>],
     loc_base: Option<u32>,
 ) -> Option<(Converted<'a>, Synth)> {
     let cx = Cx {
         ab: AstBuilder::new(allocator),
         arena,
+        islands,
         synth: RefCell::new(Synth::new(loc_base)),
     };
 
@@ -351,13 +370,14 @@ pub(crate) const SINGLE_TARGET_DESTRUCTURE_SEQUENCE_MARKER: &str = "__rsvelte_se
 
 /// Conversion context: holds the oxc [`AstBuilder`] and the IR arena used to
 /// resolve [`ExprId`] handles.
-struct Cx<'a, 'arena> {
+struct Cx<'a, 'arena, 'source> {
     ab: AstBuilder<'a>,
     arena: &'arena JsArena,
+    islands: &'arena [AstIsland<'source>],
     synth: RefCell<Synth>,
 }
 
-impl<'a, 'arena> Cx<'a, 'arena> {
+impl<'a, 'arena, 'source> Cx<'a, 'arena, 'source> {
     /// Allocate a string into the oxc arena and return it as an `&'a str`,
     /// which satisfies the `Into<Atom<'a>>` / `Into<Str<'a>>` bounds used by
     /// the builder helpers.
@@ -546,6 +566,7 @@ impl<'a, 'arena> Cx<'a, 'arena> {
                 code,
                 source_offset,
             } => self.raw_single_statement(code, Some(*source_offset), true),
+            JsStatement::RetainedAst { .. } => None,
         }
     }
 
@@ -1425,6 +1446,16 @@ impl<'a, 'arena> Cx<'a, 'arena> {
     /// block bodies) so a multi-statement `Raw` flattens inline.
     fn expand_stmt(&self, stmt: &JsStatement) -> Option<Vec<Statement<'a>>> {
         match stmt {
+            JsStatement::RetainedAst { index, .. } => {
+                let island = self.islands.get(*index)?;
+                if !island.program.program().comments.is_empty() {
+                    return None;
+                }
+                let program = island
+                    .program
+                    .clone_program_into_at(self.ab.allocator(), island.source_offset);
+                Some(program.body.into_iter().collect())
+            }
             JsStatement::Raw(code) => {
                 let stmts = self.parse_raw_statements(code, false)?;
                 self.take_chunk_region(None);
@@ -2259,5 +2290,40 @@ fn unary_op(op: JsUnaryOp) -> UnaryOperator {
         JsUnaryOp::TypeOf => UnaryOperator::Typeof,
         JsUnaryOp::Void => UnaryOperator::Void,
         JsUnaryOp::Delete => UnaryOperator::Delete,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{AstIsland, program_to_oxc_with_islands};
+    use crate::ast::oxc_program::RetainedProgram;
+    use crate::compiler::phases::phase3_transform::js_ast::{JsArena, JsProgram, JsStatement};
+    use oxc_allocator::Allocator;
+    use oxc_span::GetSpan;
+
+    #[test]
+    fn retained_island_keeps_absolute_source_spans() {
+        let retained = RetainedProgram::parse("let value = 1;", false);
+        let program = JsProgram::with_body(vec![JsStatement::RetainedAst {
+            index: 0,
+            fallback: "let value = 1;".into(),
+            source_offset: 12,
+            has_effect_rune: false,
+        }]);
+        let arena = JsArena::new();
+        let allocator = Allocator::default();
+        let converted = program_to_oxc_with_islands(
+            &program,
+            &arena,
+            &allocator,
+            &[AstIsland {
+                program: &retained,
+                source_offset: 12,
+            }],
+        )
+        .expect("retained AST is supported");
+
+        assert_eq!(converted.program.body[0].span().start, 12);
+        assert_eq!(converted.program.body[0].span().end, 26);
     }
 }


### PR DESCRIPTION
## Summary

- clone unchanged instance-script ASTs directly into the final client OXC program
- retain absolute source spans instead of re-parsing a `RawMapped` chunk
- shrink the source-map parity ratchet for `sourcemap-empty-source`

## Root cause

The client pipeline serialised a retained source AST to text, parsed that text again, then interpreted chunk-local spans as positions in the complete `.svelte` source. This change introduces an explicit retained-AST island with a byte-identical RawMapped fallback, so the safe unchanged-JS slice carries original spans end to end.

## Validation

- `cargo fmt --check`
- `cargo clippy -p rsvelte_core --all-targets -- -D warnings`
- `RUST_MIN_STACK=33554432 cargo test -p rsvelte_core retained_island_keeps_absolute_source_spans --lib`
- `RUST_MIN_STACK=33554432 cargo test -p rsvelte_core --test sourcemaps_gate -- --nocapture`