### PR TITLE
perf(esrap): reduce plain printer overhead

### DIFF
--- a/.changeset/fast-esrap-commands.md
+++ b/.changeset/fast-esrap-commands.md
@@ -2,4 +2,4 @@
 "@rsvelte/compiler": patch
 ---
 
-Reduce `rsvelte_esrap` printer overhead by coalescing adjacent inline command text, skipping source-map anchors for plain output, and reserving the final output buffer. Release `rsvelte_esrap` 0.10.9 and update the compiler's exact dependency.
+Reduce `rsvelte_esrap` printer overhead by coalescing adjacent inline command text, skipping source-map anchors for plain output, avoiding line indexing for comment-free programs, and reserving the final output buffer. Release `rsvelte_esrap` 0.10.9 and update the compiler's exact dependency.

--- a/.changeset/fast-esrap-commands.md
+++ b/.changeset/fast-esrap-commands.md
@@ -2,4 +2,4 @@
 "@rsvelte/compiler": patch
 ---
 
-Reduce `rsvelte_esrap` printer overhead by coalescing adjacent inline command text, skipping source-map anchors for plain output, avoiding line indexing for comment-free programs, and reserving the final output buffer. Release `rsvelte_esrap` 0.10.9 and update the compiler's exact dependency.
+Reduce `rsvelte_esrap` printer overhead by coalescing adjacent inline command text, skipping source-map anchors for plain output, avoiding line indexing for comment-free programs, and reserving the final output buffer. Release `rsvelte_esrap` 0.10.10 and update the compiler's exact dependency.

--- a/.changeset/fast-esrap-commands.md
+++ b/.changeset/fast-esrap-commands.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/compiler": patch
+---
+
+Reduce `rsvelte_esrap` printer overhead by coalescing adjacent inline command text, skipping source-map anchors for plain output, and reserving the final output buffer. Release `rsvelte_esrap` 0.10.9 and update the compiler's exact dependency.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2605,7 +2605,7 @@ dependencies = [
 
 [[package]]
 name = "rsvelte_esrap"
-version = "0.10.9"
+version = "0.10.10"
 dependencies = [
  "compact_str 0.10.0",
  "memchr",

--- a/crates/rsvelte_core/Cargo.toml
+++ b/crates/rsvelte_core/Cargo.toml
@@ -94,7 +94,7 @@ oxc_ast = { version = "0.144", features = ["serialize"] }
 oxc_span = "0.144"
 oxc_diagnostics = "0.144"
 oxc_codegen = "0.144"
-rsvelte_esrap = { version = "=0.10.9", path = "../rsvelte_esrap" }
+rsvelte_esrap = { version = "=0.10.10", path = "../rsvelte_esrap" }
 oxc_syntax = "0.144"
 oxc_semantic = "0.144"
 

--- a/crates/rsvelte_esrap/Cargo.toml
+++ b/crates/rsvelte_esrap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rsvelte_esrap"
-version = "0.10.9"
+version = "0.10.10"
 edition = "2024"
 rust-version = "1.95"
 description = "A Rust port of esrap — prints an oxc AST to JavaScript with esrap's exact layout"

--- a/crates/rsvelte_esrap/src/command.rs
+++ b/crates/rsvelte_esrap/src/command.rs
@@ -65,13 +65,13 @@ pub struct Mapping {
 /// Flatten `commands` into source text, using `indent` (e.g. `"\t"` or a run
 /// of spaces) for each indentation level. Faithful port of the `run`/`append`
 /// loop in esrap's `print`.
-pub fn print(commands: &[Command], indent: &str) -> String {
-    flatten_without_map(commands, indent)
+pub fn print(commands: &[Command], indent: &str, capacity: usize) -> String {
+    flatten_without_map(commands, indent, capacity)
 }
 
-fn flatten_without_map(commands: &[Command], indent: &str) -> String {
+fn flatten_without_map(commands: &[Command], indent: &str, capacity: usize) -> String {
     let mut driver = CodeDriver {
-        code: String::new(),
+        code: String::with_capacity(capacity),
         current_newline: String::from("\n"),
         indent,
         needs_newline: false,
@@ -140,9 +140,13 @@ impl CodeDriver<'_> {
 /// indices). This port derives source columns from byte offsets, so the two
 /// agree for ASCII / BMP source (which covers the keyword sites). Generated
 /// columns are likewise tracked in `char`s of the emitted code.
-pub fn flatten_with_map(commands: &[Command], indent: &str) -> (String, Vec<Mapping>) {
+pub fn flatten_with_map(
+    commands: &[Command],
+    indent: &str,
+    capacity: usize,
+) -> (String, Vec<Mapping>) {
     let mut driver = Driver {
-        code: String::new(),
+        code: String::with_capacity(capacity),
         current_newline: String::from("\n"),
         indent,
         needs_newline: false,
@@ -251,7 +255,7 @@ mod tests {
     use super::*;
 
     fn cmds(v: &[Command]) -> String {
-        print(v, "\t")
+        print(v, "\t", 0)
     }
 
     #[test]
@@ -394,8 +398,8 @@ mod tests {
         ];
 
         assert_eq!(
-            flatten_without_map(&commands, "  "),
-            flatten_with_map(&commands, "  ").0
+            flatten_without_map(&commands, "  ", 0),
+            flatten_with_map(&commands, "  ", 0).0
         );
     }
 }

--- a/crates/rsvelte_esrap/src/context.rs
+++ b/crates/rsvelte_esrap/src/context.rs
@@ -72,11 +72,23 @@ impl Context {
 
     /// Append literal `content`. If a newline is already pending in this
     /// context, writing after it makes the context multiline (mirrors esrap).
-    pub fn write(&mut self, content: impl Into<CompactString>) {
-        let content = content.into();
+    pub fn write(&mut self, content: impl AsRef<str>) {
+        let content = content.as_ref();
         self.measure += content.len();
         self.has_content |= !content.is_empty();
-        self.commands.push(Command::Str(content));
+        let can_inline = self.commands.last().is_some_and(|command| {
+            matches!(command, Command::Str(text) if !text.is_heap_allocated()
+                && text.len() + content.len() <= text.capacity())
+        });
+        if can_inline {
+            let Some(Command::Str(text)) = self.commands.last_mut() else {
+                unreachable!();
+            };
+            text.push_str(content);
+        } else {
+            self.commands
+                .push(Command::Str(CompactString::new(content)));
+        }
         if self.has_newline {
             self.multiline = true;
         }
@@ -164,6 +176,16 @@ mod tests {
         child.write("y");
         parent.append(child);
         parent.write(")");
-        assert_eq!(print(&parent.into_commands(), "\t"), "(x y)");
+        assert_eq!(print(&parent.into_commands(), "\t", 0), "(x y)");
+    }
+
+    #[test]
+    fn adjacent_inline_writes_share_one_command() {
+        let mut ctx = Context::new();
+        ctx.write("const");
+        ctx.write(" ");
+        ctx.write("x");
+        assert_eq!(ctx.commands.len(), 1);
+        assert_eq!(print(&ctx.into_commands(), "\t", 0), "const x");
     }
 }

--- a/crates/rsvelte_esrap/src/internal_tests/golden.rs
+++ b/crates/rsvelte_esrap/src/internal_tests/golden.rs
@@ -95,7 +95,7 @@ fn reprint(source: &str) -> Option<Reprint> {
     let mut ctx = Context::new();
     printer.print_program(&ret.program, &mut ctx);
     Some(Reprint {
-        output: command::print(&ctx.into_commands(), &opts.indent),
+        output: command::print(&ctx.into_commands(), &opts.indent, 0),
         missing: printer.missing.map(|m| m.0.to_string()),
     })
 }

--- a/crates/rsvelte_esrap/src/internal_tests/pluggability.rs
+++ b/crates/rsvelte_esrap/src/internal_tests/pluggability.rs
@@ -22,6 +22,6 @@ fn custom_printer_via_context_buffer() {
     ctx.write(value);
     ctx.write(" - (:");
 
-    let code = command::print(&ctx.into_commands(), "\t");
+    let code = command::print(&ctx.into_commands(), "\t", 0);
     assert_eq!(code, ":) - testing 123 - (:");
 }

--- a/crates/rsvelte_esrap/src/lib.rs
+++ b/crates/rsvelte_esrap/src/lib.rs
@@ -115,8 +115,9 @@ pub fn print_with(program: &Program<'_>, source: &str, options: &PrintOptions) -
     let mut printer = printer::Printer::with_comments(options, comments, line_starts);
     let mut ctx = context::Context::new();
     printer.print_program(program, &mut ctx);
+    let capacity = ctx.measure();
     let commands = ctx.into_commands();
-    let code = command::print(&commands, &options.indent);
+    let code = command::print(&commands, &options.indent, capacity);
     pool::recycle(commands);
     code
 }
@@ -152,16 +153,17 @@ pub fn print_split(
     let comments = printer::build_comments(program, comment_source, &line_starts);
     let map_line_starts = map_source.map(printer::line_starts).unwrap_or_default();
     let mut printer = printer::Printer::with_comments(options, comments, line_starts)
-        .with_split_coordinates(map_line_starts, loc_base, loc_map);
+        .with_split_coordinates(map_line_starts, loc_base, loc_map, map_source.is_some());
     let mut ctx = context::Context::new();
     printer.print_program(program, &mut ctx);
+    let capacity = ctx.measure();
     let commands = ctx.into_commands();
     let output = if map_source.is_some() {
-        let (code, mappings) = command::flatten_with_map(&commands, &options.indent);
+        let (code, mappings) = command::flatten_with_map(&commands, &options.indent, capacity);
         PrintWithMap { code, mappings }
     } else {
         PrintWithMap {
-            code: command::print(&commands, &options.indent),
+            code: command::print(&commands, &options.indent, capacity),
             mappings: Vec::new(),
         }
     };
@@ -188,11 +190,13 @@ pub struct PrintWithMap {
 pub fn print_with_map(program: &Program<'_>, source: &str, options: &PrintOptions) -> PrintWithMap {
     let line_starts = printer::line_starts(source);
     let comments = printer::build_comments(program, source, &line_starts);
-    let mut printer = printer::Printer::with_comments(options, comments, line_starts);
+    let mut printer =
+        printer::Printer::with_comments(options, comments, line_starts).with_source_map();
     let mut ctx = context::Context::new();
     printer.print_program(program, &mut ctx);
+    let capacity = ctx.measure();
     let commands = ctx.into_commands();
-    let (code, mappings) = command::flatten_with_map(&commands, &options.indent);
+    let (code, mappings) = command::flatten_with_map(&commands, &options.indent, capacity);
     pool::recycle(commands);
     PrintWithMap { code, mappings }
 }

--- a/crates/rsvelte_esrap/src/lib.rs
+++ b/crates/rsvelte_esrap/src/lib.rs
@@ -110,8 +110,7 @@ pub fn print(program: &Program<'_>, source: &str) -> String {
 
 /// Print `program` to JavaScript with explicit options, interleaving comments.
 pub fn print_with(program: &Program<'_>, source: &str, options: &PrintOptions) -> String {
-    let line_starts = printer::line_starts(source);
-    let comments = printer::build_comments(program, source, &line_starts);
+    let (comments, line_starts) = comments_and_line_starts(program, source);
     let mut printer = printer::Printer::with_comments(options, comments, line_starts);
     let mut ctx = context::Context::new();
     printer.print_program(program, &mut ctx);
@@ -149,8 +148,7 @@ pub fn print_split(
     loc_map: &[(u32, u32, Option<u32>)],
     options: &PrintOptions,
 ) -> PrintWithMap {
-    let line_starts = printer::line_starts(comment_source);
-    let comments = printer::build_comments(program, comment_source, &line_starts);
+    let (comments, line_starts) = comments_and_line_starts(program, comment_source);
     let map_line_starts = map_source.map(printer::line_starts).unwrap_or_default();
     let mut printer = printer::Printer::with_comments(options, comments, line_starts)
         .with_split_coordinates(map_line_starts, loc_base, loc_map, map_source.is_some());
@@ -199,4 +197,13 @@ pub fn print_with_map(program: &Program<'_>, source: &str, options: &PrintOption
     let (code, mappings) = command::flatten_with_map(&commands, &options.indent, capacity);
     pool::recycle(commands);
     PrintWithMap { code, mappings }
+}
+
+fn comments_and_line_starts(program: &Program<'_>, source: &str) -> (Vec<printer::Cmt>, Vec<u32>) {
+    if program.comments.is_empty() {
+        return (Vec::new(), Vec::new());
+    }
+    let line_starts = printer::line_starts(source);
+    let comments = printer::build_comments(program, source, &line_starts);
+    (comments, line_starts)
 }

--- a/crates/rsvelte_esrap/src/printer.rs
+++ b/crates/rsvelte_esrap/src/printer.rs
@@ -663,7 +663,7 @@ impl<'opt> Printer<'opt> {
         prev_end: u32,
         next: Option<u32>,
     ) -> bool {
-        if !self.has_loc(prev_end) {
+        if self.comments.is_empty() || !self.has_loc(prev_end) {
             return false;
         }
         // A `next` boundary that is itself synthesized bounds nothing (esrap's
@@ -720,11 +720,11 @@ impl<'opt> Printer<'opt> {
     }
 
     /// The `_` wildcard's leading flush: emit comments positioned before `node`.
-    fn flush_leading(&mut self, ctx: &mut Context, node_start: u32, node_start_line: u32) {
+    fn flush_leading(&mut self, ctx: &mut Context, node_start: u32) {
         if self.comments.is_empty() {
             return;
         }
-        self.flush_comments_until(ctx, node_start, node_start_line, None, true);
+        self.flush_comments_until(ctx, node_start, self.line_of(node_start), None, true);
     }
 
     /// Port of esrap's `sequence` (`languages/ts/index.js`). Lays `nodes` out as
@@ -949,7 +949,7 @@ impl<'opt> Printer<'opt> {
     /// string-literal `ExpressionStatement` esrap sees.
     fn print_directive(&mut self, d: &Directive, ctx: &mut Context) {
         let start = d.span.start;
-        self.flush_leading(ctx, start, self.line_of(start));
+        self.flush_leading(ctx, start);
         ctx.write(Self::string_literal(&d.expression));
         ctx.write(";");
     }
@@ -958,7 +958,7 @@ impl<'opt> Printer<'opt> {
     fn print_statement(&mut self, stmt: &Statement, ctx: &mut Context) {
         // esrap's `_` wildcard: emit comments positioned before this node first.
         let start = stmt.span().start;
-        self.flush_leading(ctx, start, self.line_of(start));
+        self.flush_leading(ctx, start);
         match stmt {
             Statement::ExpressionStatement(s) => {
                 // esrap wraps a leading object/function-expression statement in
@@ -1528,7 +1528,7 @@ impl<'opt> Printer<'opt> {
         // esrap's `_` wildcard flushes any comment positioned before the member
         // (e.g. a leading JSDoc block) before visiting it.
         let start = element.span().start;
-        self.flush_leading(ctx, start, self.line_of(start));
+        self.flush_leading(ctx, start);
         match element {
             ClassElement::MethodDefinition(m) => self.method_definition(m, ctx),
             ClassElement::PropertyDefinition(p) => self.property_definition(p, ctx),
@@ -1874,7 +1874,7 @@ impl<'opt> Printer<'opt> {
                         // comment also forces the sequence multiline (via the
                         // `newline()` in `write_comment`), so it can't swallow the
                         // following token (`tabindex = // c 0` → unparseable).
-                        p.flush_leading(child, span.start, p.line_of(span.start));
+                        p.flush_leading(child, span.start);
                         p.binding_property(prop, child);
                     }),
                 }
@@ -1888,7 +1888,7 @@ impl<'opt> Printer<'opt> {
                 obj_or_array: false,
                 is_elision: false,
                 render: Box::new(move |p: &mut Printer, child: &mut Context| {
-                    p.flush_leading(child, span.start, p.line_of(span.start));
+                    p.flush_leading(child, span.start);
                     child.write("...");
                     p.binding_pattern(&rest.argument, child);
                 }),
@@ -2116,7 +2116,7 @@ impl<'opt> Printer<'opt> {
         for declarator in &decl.declarations {
             let mut child = Context::child();
             let start = declarator.span().start;
-            self.flush_leading(&mut child, start, self.line_of(start));
+            self.flush_leading(&mut child, start);
             self.binding_pattern(&declarator.id, &mut child);
             if declarator.definite {
                 child.write("!");
@@ -2179,7 +2179,7 @@ impl<'opt> Printer<'opt> {
     fn print_expression(&mut self, expr: &Expression, ctx: &mut Context) {
         // esrap's `_` wildcard: emit comments positioned before this node first.
         let start = expr.span().start;
-        self.flush_leading(ctx, start, self.line_of(start));
+        self.flush_leading(ctx, start);
         match expr {
             Expression::ParenthesizedExpression(p) => {
                 // esrap parses with acorn, which ELIDES parentheses — there is
@@ -2864,7 +2864,7 @@ impl<'opt> Printer<'opt> {
                         // esrap's `sequence` visits each property through the `_`
                         // wildcard, which flushes any comment positioned before
                         // it (`{ /** doc */ key: … }`). Mirror that per property.
-                        p.flush_leading(child, span.start, p.line_of(span.start));
+                        p.flush_leading(child, span.start);
                         match prop {
                             ObjectPropertyKind::ObjectProperty(prop) => {
                                 p.object_property(prop, child);

--- a/crates/rsvelte_esrap/src/printer.rs
+++ b/crates/rsvelte_esrap/src/printer.rs
@@ -83,6 +83,7 @@ impl KeywordCursor {
 
 pub struct Printer<'opt> {
     options: &'opt PrintOptions,
+    emit_locations: bool,
     /// Set by the first unsupported node encountered; printing continues so the
     /// harness gets a single representative miss per file.
     pub missing: Option<Unsupported>,
@@ -417,6 +418,7 @@ impl<'opt> Printer<'opt> {
     pub const fn new(options: &'opt PrintOptions) -> Self {
         Self {
             options,
+            emit_locations: false,
             missing: None,
             comments: Vec::new(),
             comment_index: 0,
@@ -436,6 +438,7 @@ impl<'opt> Printer<'opt> {
     ) -> Self {
         Self {
             options,
+            emit_locations: false,
             missing: None,
             comments,
             comment_index: 0,
@@ -455,10 +458,18 @@ impl<'opt> Printer<'opt> {
         map_line_starts: Vec<u32>,
         loc_base: u32,
         loc_map: &[(u32, u32, Option<u32>)],
+        emit_locations: bool,
     ) -> Self {
+        self.emit_locations = emit_locations;
         self.map_line_starts = Some(map_line_starts);
         self.loc_base = Some(loc_base);
         self.loc_map = loc_map.to_vec();
+        self
+    }
+
+    /// Enable source-map anchor commands for this print.
+    pub const fn with_source_map(mut self) -> Self {
+        self.emit_locations = true;
         self
     }
 
@@ -527,6 +538,11 @@ impl<'opt> Printer<'opt> {
     /// the offset can't be resolved (no source context), falls back to a plain
     /// `keyword + suffix` write.
     fn write_keyword(&self, ctx: &mut Context, start: u32, keyword: &str, suffix: &str) {
+        if !self.emit_locations {
+            ctx.write(keyword);
+            ctx.write(suffix);
+            return;
+        }
         if let Some((line, column)) = self.offset_to_line_col(start) {
             Self::write_source_keyword(ctx, line, column, keyword);
             if !suffix.is_empty() {
@@ -544,7 +560,7 @@ impl<'opt> Printer<'opt> {
     /// unmapped. Implemented as an explicit [`KeywordCursor`] because Rust closures
     /// can't borrow `self` mutably across calls the way the JS closure does.
     fn keyword_cursor(&self, start: u32, map_ok: bool) -> KeywordCursor {
-        let cursor = if map_ok {
+        let cursor = if map_ok && self.emit_locations {
             self.offset_to_line_col(start)
         } else {
             None
@@ -556,6 +572,9 @@ impl<'opt> Printer<'opt> {
     /// offsets are only trustworthy when the `function` token shares a line with
     /// `async`, anchored by the id or body starting on the same line as the node.
     fn function_async_offset_ok(&self, node: &Function) -> bool {
+        if !self.emit_locations {
+            return false;
+        }
         let Some((line, _)) = self.offset_to_line_col(node.span().start) else {
             return false;
         };
@@ -576,6 +595,9 @@ impl<'opt> Printer<'opt> {
     /// there are no decorators and the id (or body, if anonymous) starts on the
     /// node's start line.
     fn class_modifier_map_ok(&self, node: &Class) -> bool {
+        if !self.emit_locations {
+            return false;
+        }
         if !node.decorators.is_empty() {
             return false;
         }
@@ -3868,7 +3890,7 @@ mod tests {
         let mut ctx = Context::new();
         printer.print_program(&ret.program, &mut ctx);
         (
-            crate::command::print(&ctx.into_commands(), &opts.indent),
+            crate::command::print(&ctx.into_commands(), &opts.indent, 0),
             printer.missing,
         )
     }
@@ -3895,7 +3917,7 @@ mod tests {
         let mut printer = Printer::with_comments(&opts, comments, line_starts(src));
         let mut ctx = Context::new();
         printer.print_program(&ret.program, &mut ctx);
-        let out = crate::command::print(&ctx.into_commands(), &opts.indent);
+        let out = crate::command::print(&ctx.into_commands(), &opts.indent, 0);
         assert!(
             printer.missing.is_none(),
             "unsupported node: {:?}",

--- a/crates/rsvelte_lint_types/Cargo.lock
+++ b/crates/rsvelte_lint_types/Cargo.lock
@@ -1111,7 +1111,7 @@ dependencies = [
 
 [[package]]
 name = "rsvelte_esrap"
-version = "0.10.9"
+version = "0.10.10"
 dependencies = [
  "compact_str",
  "memchr",


### PR DESCRIPTION
## What changed

- omit source-map `Location` commands and coordinate lookup from plain printing
- skip source line indexing and comment line lookups when the AST has no comments
- coalesce adjacent inline command text without introducing heap allocation
- reserve the final output buffer from the measured command size
- release `rsvelte_esrap` 0.10.10 and update exact consumers

## Why

`oxc_codegen` cannot replace esrap while preserving the official Svelte compiler’s exact output. The existing plain path still paid for source-map data that it discarded, scanned every comment-free source for line starts, and emitted many tiny command strings.

On the existing paired `ab_print` harness over 11 generated CSR files (50,406 bytes, same retained AST for both printers), current `main` measured 5.467–5.594x esrap/oxc. This branch measured 4.201x after rebasing onto current `main` (previous repeated runs: 4.042–4.294x), approximately a 22–28% reduction in the ratio. Output remains governed by the existing byte-equality tests.

This is the first optimization tranche; it does not claim parity with or superiority over `oxc_codegen` yet.

## Validation

- `cargo test -p rsvelte_esrap --all-targets`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `node scripts/release/test-esrap-version-bump-check.mjs`
- `node scripts/ci/check-lint-types-lock.mjs`
- paired release benchmark, 3 × 30 pairs × 100 iterations

