### PR TITLE
perf(esrap): flatten text and layout events

### DIFF
--- a/.changeset/flat-esrap-events.md
+++ b/.changeset/flat-esrap-events.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/compiler": patch
+---
+
+Replace esrap's nested command tree with flat text and offset-based layout events, and release `rsvelte_esrap` 0.10.11.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2605,7 +2605,7 @@ dependencies = [
 
 [[package]]
 name = "rsvelte_esrap"
-version = "0.10.10"
+version = "0.10.11"
 dependencies = [
  "compact_str 0.10.0",
  "memchr",

--- a/crates/rsvelte_core/Cargo.toml
+++ b/crates/rsvelte_core/Cargo.toml
@@ -94,7 +94,7 @@ oxc_ast = { version = "0.144", features = ["serialize"] }
 oxc_span = "0.144"
 oxc_diagnostics = "0.144"
 oxc_codegen = "0.144"
-rsvelte_esrap = { version = "=0.10.10", path = "../rsvelte_esrap" }
+rsvelte_esrap = { version = "=0.10.11", path = "../rsvelte_esrap" }
 oxc_syntax = "0.144"
 oxc_semantic = "0.144"
 

--- a/crates/rsvelte_esrap/Cargo.toml
+++ b/crates/rsvelte_esrap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rsvelte_esrap"
-version = "0.10.10"
+version = "0.10.11"
 edition = "2024"
 rust-version = "1.95"
 description = "A Rust port of esrap — prints an oxc AST to JavaScript with esrap's exact layout"

--- a/crates/rsvelte_esrap/src/command.rs
+++ b/crates/rsvelte_esrap/src/command.rs
@@ -1,55 +1,53 @@
-//! The esrap command buffer and its flattening driver.
-//!
-//! A faithful port of the command model in esrap's `src/index.js` /
-//! `src/context.js`. Visitors don't write strings directly; they push
-//! [`Command`]s onto a buffer, and the [`print()`] function flattens that buffer into the
-//! final source text. The indirection is what lets a visitor build a child
-//! layout, [`measure`](crate::context::Context::measure) it, and only then
-//! decide whether to emit it on one line or break it across several — esrap's
-//! whole layout strategy falls out of this.
-//!
-//! The sentinels (`Newline`/`Margin`/`Space`/`Indent`/`Dedent`) mirror the
-//! integer constants esrap pushes onto the same array as strings. `Indent` and
-//! `Dedent` don't emit anything immediately; they grow/shrink the whitespace
-//! prefix that a later `Newline` will emit, exactly as upstream mutates its
-//! `current_newline` string.
+//! Flat text and layout-event buffers used by the printer.
 
-use compact_str::CompactString;
-
-/// One entry in the command buffer. Strings are literal output; the sentinels
-/// defer whitespace decisions until the next string is emitted.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum Command {
-    /// An extra blank line before the next newline (only meaningful when a
-    /// `Newline` is also pending).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum EventKind {
     Margin,
-    /// Emit the current indentation-aware newline before the next string.
     Newline,
-    /// Grow the newline prefix by one indent level.
     Indent,
-    /// Shrink the newline prefix by one indent level.
     Dedent,
-    /// Emit a single space before the next string (unless a newline supersedes
-    /// it).
     Space,
-    /// Literal output. A `CompactString` so the fragments the printer emits —
-    /// punctuation, keywords, identifiers, nearly all under the 24-byte inline
-    /// limit — live in the command itself instead of a heap allocation.
-    Str(CompactString),
-    /// A nested buffer, spliced in place (esrap's nested command arrays).
-    Nested(Vec<Self>),
-    /// A source-map anchor (1-based line, 0-based column) for a following
-    /// string. `Driver::run` consumes it into a [`Mapping`] at the current
-    /// generated position (see [`flatten_with_map`]); like a string, it also
-    /// flushes pending whitespace first, matching upstream ordering.
+    Flush,
     Location { line: u32, column: u32 },
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct Event {
+    pub offset: u32,
+    pub kind: EventKind,
+}
+
+#[derive(Default)]
+pub(crate) struct Buffer {
+    pub text: String,
+    pub events: Vec<Event>,
+}
+
+impl Buffer {
+    pub fn event(&mut self, kind: EventKind) {
+        self.events.push(Event {
+            offset: u32::try_from(self.text.len()).expect("esrap output exceeds u32"),
+            kind,
+        });
+    }
+
+    pub fn append(&mut self, mut child: Self) {
+        let base = u32::try_from(self.text.len()).expect("esrap output exceeds u32");
+        self.text.push_str(&child.text);
+        self.events.extend(child.events.drain(..).map(|event| {
+            Event {
+                offset: base
+                    .checked_add(event.offset)
+                    .expect("esrap output exceeds u32"),
+                kind: event.kind,
+            }
+        }));
+        child.text.clear();
+        crate::pool::give(child);
+    }
+}
+
 /// One source-map entry: a generated position and the source position it came from, all 0-based.
-///
-/// Flat rather than grouped per generated line — grouping
-/// cost one `Vec` allocation for every line of output. esrap only ever maps a
-/// single source, so there is no source index.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Mapping {
     /// 0-based line in the generated output.
@@ -62,14 +60,7 @@ pub struct Mapping {
     pub source_column: u32,
 }
 
-/// Flatten `commands` into source text, using `indent` (e.g. `"\t"` or a run
-/// of spaces) for each indentation level. Faithful port of the `run`/`append`
-/// loop in esrap's `print`.
-pub fn print(commands: &[Command], indent: &str, capacity: usize) -> String {
-    flatten_without_map(commands, indent, capacity)
-}
-
-fn flatten_without_map(commands: &[Command], indent: &str, capacity: usize) -> String {
+pub(crate) fn print(buffer: &Buffer, indent: &str, capacity: usize) -> String {
     let mut driver = CodeDriver {
         code: String::with_capacity(capacity),
         current_newline: String::from("\n"),
@@ -78,10 +69,58 @@ fn flatten_without_map(commands: &[Command], indent: &str, capacity: usize) -> S
         needs_margin: false,
         needs_space: false,
     };
-    for command in commands {
-        driver.run(command);
-    }
+    drive(buffer, |text, event| {
+        if !text.is_empty() {
+            driver.append(text);
+        }
+        if let Some(event) = event {
+            driver.event(event);
+        }
+    });
     driver.code
+}
+
+pub(crate) fn flatten_with_map(
+    buffer: &Buffer,
+    indent: &str,
+    capacity: usize,
+) -> (String, Vec<Mapping>) {
+    let mut driver = Driver {
+        code: String::with_capacity(capacity),
+        current_newline: String::from("\n"),
+        indent,
+        needs_newline: false,
+        needs_margin: false,
+        needs_space: false,
+        current_line: 0,
+        current_column: 0,
+        mappings: Vec::new(),
+    };
+    drive(buffer, |text, event| {
+        if !text.is_empty() {
+            driver.append_text(text);
+        }
+        if let Some(event) = event {
+            driver.event(event);
+        }
+    });
+    (driver.code, driver.mappings)
+}
+
+fn drive(buffer: &Buffer, mut visit: impl FnMut(&str, Option<EventKind>)) {
+    let mut cursor = 0;
+    for item in &buffer.events {
+        let offset = item.offset as usize;
+        if offset > cursor {
+            visit(&buffer.text[cursor..offset], Some(item.kind));
+            cursor = offset;
+        } else {
+            visit("", Some(item.kind));
+        }
+    }
+    if cursor < buffer.text.len() {
+        visit(&buffer.text[cursor..], None);
+    }
 }
 
 struct CodeDriver<'a> {
@@ -94,27 +133,23 @@ struct CodeDriver<'a> {
 }
 
 impl CodeDriver<'_> {
-    fn run(&mut self, command: &Command) {
-        match command {
-            Command::Nested(inner) => {
-                for command in inner {
-                    self.run(command);
-                }
-            }
-            Command::Newline => self.needs_newline = true,
-            Command::Margin => self.needs_margin = true,
-            Command::Space => self.needs_space = true,
-            Command::Indent => self.current_newline.push_str(self.indent),
-            Command::Dedent => {
+    fn event(&mut self, event: EventKind) {
+        match event {
+            EventKind::Newline => self.needs_newline = true,
+            EventKind::Margin => self.needs_margin = true,
+            EventKind::Space => self.needs_space = true,
+            EventKind::Indent => self.current_newline.push_str(self.indent),
+            EventKind::Dedent => {
                 let len = self.current_newline.len().saturating_sub(self.indent.len());
                 self.current_newline.truncate(len);
             }
-            Command::Str(string) => {
-                self.flush_pending();
-                self.code.push_str(string);
-            }
-            Command::Location { .. } => self.flush_pending(),
+            EventKind::Flush | EventKind::Location { .. } => self.flush_pending(),
         }
+    }
+
+    fn append(&mut self, text: &str) {
+        self.flush_pending();
+        self.code.push_str(text);
     }
 
     fn flush_pending(&mut self) {
@@ -132,95 +167,50 @@ impl CodeDriver<'_> {
     }
 }
 
-/// Flatten `commands` into both the source text and its source-map [`Mapping`]s.
-/// A faithful port of esrap's `print` driver, which threads the generated
-/// position through `append` and records a mapping on every `Location` command.
-///
-/// Note on columns: esrap segments carry `ESTree` columns (UTF-16 code-unit
-/// indices). This port derives source columns from byte offsets, so the two
-/// agree for ASCII / BMP source (which covers the keyword sites). Generated
-/// columns are likewise tracked in `char`s of the emitted code.
-pub fn flatten_with_map(
-    commands: &[Command],
-    indent: &str,
-    capacity: usize,
-) -> (String, Vec<Mapping>) {
-    let mut driver = Driver {
-        code: String::with_capacity(capacity),
-        current_newline: String::from("\n"),
-        indent,
-        needs_newline: false,
-        needs_margin: false,
-        needs_space: false,
-        current_line: 0,
-        current_column: 0,
-        mappings: Vec::new(),
-    };
-    for command in commands {
-        driver.run(command);
-    }
-    (driver.code, driver.mappings)
-}
-
 struct Driver<'a> {
     code: String,
-    /// The whitespace emitted on a newline: `"\n"` plus one `indent` per active
-    /// level. `Indent`/`Dedent` mutate this in place.
     current_newline: String,
     indent: &'a str,
     needs_newline: bool,
     needs_margin: bool,
     needs_space: bool,
-    /// Current 0-based generated line, advanced on each `\n`.
     current_line: u32,
-    /// Current 0-based generated column (in `char`s), reset on each `\n`.
     current_column: u32,
     mappings: Vec<Mapping>,
 }
 
 impl Driver<'_> {
-    fn run(&mut self, command: &Command) {
-        match command {
-            Command::Nested(inner) => {
-                for c in inner {
-                    self.run(c);
-                }
-            }
-            Command::Newline => self.needs_newline = true,
-            Command::Margin => self.needs_margin = true,
-            Command::Space => self.needs_space = true,
-            Command::Indent => self.current_newline.push_str(self.indent),
-            Command::Dedent => {
+    fn event(&mut self, event: EventKind) {
+        match event {
+            EventKind::Newline => self.needs_newline = true,
+            EventKind::Margin => self.needs_margin = true,
+            EventKind::Space => self.needs_space = true,
+            EventKind::Indent => self.current_newline.push_str(self.indent),
+            EventKind::Dedent => {
                 let len = self.current_newline.len().saturating_sub(self.indent.len());
                 self.current_newline.truncate(len);
             }
-            Command::Str(s) => {
-                self.flush_pending();
-                self.append(s);
-            }
-            Command::Location { line, column } => {
-                // Anchors flush pending whitespace just like a string would (so
-                // adding source-map support doesn't shift output), then record a
-                // mapping at the current generated position. Mirrors esrap's
-                // `command.type === 'Location'` branch in `run`.
+            EventKind::Flush => self.flush_pending(),
+            EventKind::Location { line, column } => {
                 self.flush_pending();
                 self.mappings.push(Mapping {
                     gen_line: self.current_line,
                     gen_column: self.current_column,
-                    // `line` is 1-based, as ESTree `loc` reports it.
-                    source_line: *line - 1,
-                    source_column: *column,
+                    source_line: line - 1,
+                    source_column: column,
                 });
             }
         }
     }
 
-    /// Append literal text to the output, advancing the generated position per
-    /// char and rolling over to the next line on each `\n`. A faithful port of
-    /// esrap's `append`.
-    fn append(&mut self, str: &str) {
-        self.code.push_str(str);
-        for ch in str.chars() {
+    fn append_text(&mut self, text: &str) {
+        self.flush_pending();
+        self.append(text);
+    }
+
+    fn append(&mut self, text: &str) {
+        self.code.push_str(text);
+        for ch in text.chars() {
             if ch == '\n' {
                 self.current_line += 1;
                 self.current_column = 0;
@@ -230,17 +220,14 @@ impl Driver<'_> {
         }
     }
 
-    /// Emit any pending newline/space before the next string. A pending newline
-    /// supersedes a pending space; a pending margin adds one blank line ahead of
-    /// the newline.
     fn flush_pending(&mut self) {
         if self.needs_newline {
             if self.needs_margin {
                 self.append("\n");
             }
-            let nl = std::mem::take(&mut self.current_newline);
-            self.append(&nl);
-            self.current_newline = nl;
+            let newline = std::mem::take(&mut self.current_newline);
+            self.append(&newline);
+            self.current_newline = newline;
         } else if self.needs_space {
             self.append(" ");
         }
@@ -254,56 +241,60 @@ impl Driver<'_> {
 mod tests {
     use super::*;
 
-    fn cmds(v: &[Command]) -> String {
-        print(v, "\t", 0)
+    enum TestCommand<'a> {
+        Text(&'a str),
+        Event(EventKind),
+        Nested(Vec<Self>),
+    }
+
+    fn buffer(commands: Vec<TestCommand<'_>>) -> Buffer {
+        fn add(buffer: &mut Buffer, commands: Vec<TestCommand<'_>>) {
+            for command in commands {
+                match command {
+                    TestCommand::Text(text) => buffer.text.push_str(text),
+                    TestCommand::Event(event) => buffer.event(event),
+                    TestCommand::Nested(commands) => add(buffer, commands),
+                }
+            }
+        }
+        let mut buffer = Buffer::default();
+        add(&mut buffer, commands);
+        buffer
+    }
+
+    fn output(commands: Vec<TestCommand<'_>>) -> String {
+        print(&buffer(commands), "\t", 0)
     }
 
     #[test]
     fn plain_strings_concatenate() {
         assert_eq!(
-            cmds(&[Command::Str("a".into()), Command::Str("b".into())]),
+            output(vec![TestCommand::Text("a"), TestCommand::Text("b")]),
             "ab"
         );
     }
 
     #[test]
-    fn space_separates_only_before_next_string() {
-        // A trailing Space with no following string emits nothing.
+    fn space_separates_only_before_next_text() {
         assert_eq!(
-            cmds(&[
-                Command::Str("a".into()),
-                Command::Space,
-                Command::Str("b".into()),
-                Command::Space,
+            output(vec![
+                TestCommand::Text("a"),
+                TestCommand::Event(EventKind::Space),
+                TestCommand::Text("b"),
+                TestCommand::Event(EventKind::Space),
             ]),
             "a b"
         );
     }
 
     #[test]
-    fn newline_uses_indent_prefix() {
-        assert_eq!(
-            cmds(&[
-                Command::Str("{".into()),
-                Command::Indent,
-                Command::Newline,
-                Command::Str("x".into()),
-                Command::Dedent,
-                Command::Newline,
-                Command::Str("}".into()),
-            ]),
-            "{\n\tx\n}"
-        );
-    }
-
-    #[test]
     fn newline_supersedes_space() {
         assert_eq!(
-            cmds(&[
-                Command::Str("a".into()),
-                Command::Space,
-                Command::Newline,
-                Command::Str("b".into()),
+            output(vec![
+                TestCommand::Text("a"),
+                TestCommand::Event(EventKind::Space),
+                TestCommand::Event(EventKind::Newline),
+                TestCommand::Text("b")
             ]),
             "a\nb"
         );
@@ -312,11 +303,11 @@ mod tests {
     #[test]
     fn margin_adds_blank_line_before_newline() {
         assert_eq!(
-            cmds(&[
-                Command::Str("a".into()),
-                Command::Margin,
-                Command::Newline,
-                Command::Str("b".into()),
+            output(vec![
+                TestCommand::Text("a"),
+                TestCommand::Event(EventKind::Margin),
+                TestCommand::Event(EventKind::Newline),
+                TestCommand::Text("b")
             ]),
             "a\n\nb"
         );
@@ -325,81 +316,86 @@ mod tests {
     #[test]
     fn margin_without_newline_does_nothing() {
         assert_eq!(
-            cmds(&[
-                Command::Str("a".into()),
-                Command::Margin,
-                Command::Str("b".into())
+            output(vec![
+                TestCommand::Text("a"),
+                TestCommand::Event(EventKind::Margin),
+                TestCommand::Text("b")
             ]),
             "ab"
         );
     }
 
     #[test]
-    fn nested_commands_splice_in_place() {
+    fn nested_text_splices_in_place() {
         assert_eq!(
-            cmds(&[
-                Command::Str("(".into()),
-                Command::Nested(vec![
-                    Command::Str("x".into()),
-                    Command::Space,
-                    Command::Str("y".into())
+            output(vec![
+                TestCommand::Text("("),
+                TestCommand::Nested(vec![
+                    TestCommand::Text("x"),
+                    TestCommand::Event(EventKind::Space),
+                    TestCommand::Text("y"),
                 ]),
-                Command::Str(")".into()),
+                TestCommand::Text(")"),
             ]),
             "(x y)"
         );
     }
 
     #[test]
-    fn unbalanced_dedent_does_not_panic() {
-        // A Dedent with no matching Indent (unbalanced buffer) must floor the
-        // newline prefix at 0 rather than underflow-panic on the subtraction.
-        // The prefix (including the leading "\n") collapses to empty.
+    fn unbalanced_dedent_is_saturating() {
         assert_eq!(
-            cmds(&[Command::Dedent, Command::Newline, Command::Str("x".into()),]),
+            output(vec![
+                TestCommand::Event(EventKind::Dedent),
+                TestCommand::Event(EventKind::Newline),
+                TestCommand::Text("x")
+            ]),
             "x"
+        );
+    }
+
+    #[test]
+    fn newline_uses_indent_prefix() {
+        assert_eq!(
+            output(vec![
+                TestCommand::Text("{"),
+                TestCommand::Event(EventKind::Indent),
+                TestCommand::Event(EventKind::Newline),
+                TestCommand::Text("x"),
+                TestCommand::Event(EventKind::Dedent),
+                TestCommand::Event(EventKind::Newline),
+                TestCommand::Text("}"),
+            ]),
+            "{\n\tx\n}"
         );
     }
 
     #[test]
     fn multi_level_indent() {
         assert_eq!(
-            cmds(&[
-                Command::Indent,
-                Command::Indent,
-                Command::Newline,
-                Command::Str("x".into()),
+            output(vec![
+                TestCommand::Event(EventKind::Indent),
+                TestCommand::Event(EventKind::Indent),
+                TestCommand::Event(EventKind::Newline),
+                TestCommand::Text("x"),
             ]),
             "\n\t\tx"
         );
     }
 
     #[test]
-    fn no_map_output_matches_mapping_driver() {
-        let commands = vec![
-            Command::Location { line: 1, column: 0 },
-            Command::Str("const".into()),
-            Command::Space,
-            Command::Location { line: 1, column: 6 },
-            Command::Str("π".into()),
-            Command::Space,
-            Command::Str("=".into()),
-            Command::Nested(vec![
-                Command::Indent,
-                Command::Margin,
-                Command::Newline,
-                Command::Location { line: 2, column: 0 },
-                Command::Str("\"line 1\\nline 2\"".into()),
-                Command::Dedent,
-            ]),
-            Command::Newline,
-            Command::Str(";".into()),
-            Command::Space,
-        ];
-
+    fn mapping_and_plain_drivers_match() {
+        let buffer = buffer(vec![
+            TestCommand::Event(EventKind::Location { line: 1, column: 0 }),
+            TestCommand::Text("const"),
+            TestCommand::Event(EventKind::Space),
+            TestCommand::Event(EventKind::Location { line: 1, column: 6 }),
+            TestCommand::Text("π"),
+            TestCommand::Event(EventKind::Newline),
+            TestCommand::Text("x"),
+        ]);
         assert_eq!(
-            flatten_without_map(&commands, "  ", 0),
-            flatten_with_map(&commands, "  ", 0).0
+            print(&buffer, "  ", 0),
+            flatten_with_map(&buffer, "  ", 0).0
         );
     }
 }

--- a/crates/rsvelte_esrap/src/context.rs
+++ b/crates/rsvelte_esrap/src/context.rs
@@ -1,28 +1,20 @@
-//! The visitor-facing command builder.
+//! The visitor-facing output builder.
 //!
 //! A port of esrap's `Context` (`src/context.js`). A [`Context`] accumulates
-//! [`Command`]s and tracks whether it has gone multiline, which is the signal
+//! literal text and deferred layout events while tracking whether it has gone multiline, the signal
 //! visitors use to decide between a one-line and a broken-out layout. Unlike
 //! upstream, dispatch (`visit`) lives in the printer (a `match` over oxc node
-//! kinds), so `Context` is purely the buffer API: `write`, the whitespace
-//! sentinels, `append` (splice a child buffer), `measure`, and `empty`.
+//! kinds), so `Context` is purely the output API: `write`, whitespace events,
+//! `append` (splice a child buffer), `measure`, and `empty`.
 
-use compact_str::CompactString;
+use crate::command::{Buffer, EventKind};
 
-use crate::command::Command;
-
-/// Accumulates commands for one syntactic unit. Build a child with
+/// Accumulates output for one syntactic unit. Build a child with
 /// [`Context::child`], fill it, then [`Context::append`] it into the parent.
 #[derive(Default)]
 pub struct Context {
-    commands: Vec<Command>,
+    buffer: Buffer,
     has_newline: bool,
-    /// Running total of the literal string lengths written so far, so
-    /// [`Context::measure`] is O(1) instead of a re-walk of the command tree.
-    measure: usize,
-    /// `true` once a non-empty literal has been written (the inverse of
-    /// [`Context::empty`], tracked for the same reason as `measure`).
-    has_content: bool,
     /// `true` once this context (or an appended child) emitted a newline.
     /// Visitors read it to pick a layout.
     pub multiline: bool,
@@ -32,7 +24,7 @@ impl Context {
     /// A fresh, empty context.
     pub fn new() -> Self {
         Self {
-            commands: crate::pool::take(),
+            buffer: crate::pool::take(),
             ..Self::default()
         }
     }
@@ -45,49 +37,39 @@ impl Context {
 
     /// Grow the newline indentation by one level for subsequent newlines.
     pub fn indent(&mut self) {
-        self.commands.push(Command::Indent);
+        self.buffer.event(EventKind::Indent);
     }
 
     /// Shrink the newline indentation by one level.
     pub fn dedent(&mut self) {
-        self.commands.push(Command::Dedent);
+        self.buffer.event(EventKind::Dedent);
     }
 
     /// Request a blank line ahead of the next newline.
     pub fn margin(&mut self) {
-        self.commands.push(Command::Margin);
+        self.buffer.event(EventKind::Margin);
     }
 
     /// Emit an indentation-aware newline before the next write. Marks the
     /// context multiline.
     pub fn newline(&mut self) {
         self.has_newline = true;
-        self.commands.push(Command::Newline);
+        self.buffer.event(EventKind::Newline);
     }
 
     /// Emit a single space before the next write.
     pub fn space(&mut self) {
-        self.commands.push(Command::Space);
+        self.buffer.event(EventKind::Space);
     }
 
     /// Append literal `content`. If a newline is already pending in this
     /// context, writing after it makes the context multiline (mirrors esrap).
     pub fn write(&mut self, content: impl AsRef<str>) {
         let content = content.as_ref();
-        self.measure += content.len();
-        self.has_content |= !content.is_empty();
-        let can_inline = self.commands.last().is_some_and(|command| {
-            matches!(command, Command::Str(text) if !text.is_heap_allocated()
-                && text.len() + content.len() <= text.capacity())
-        });
-        if can_inline {
-            let Some(Command::Str(text)) = self.commands.last_mut() else {
-                unreachable!();
-            };
-            text.push_str(content);
+        if content.is_empty() {
+            self.buffer.event(EventKind::Flush);
         } else {
-            self.commands
-                .push(Command::Str(CompactString::new(content)));
+            self.buffer.text.push_str(content);
         }
         if self.has_newline {
             self.multiline = true;
@@ -96,15 +78,13 @@ impl Context {
 
     /// Record a source-map anchor (1-based line, 0-based column).
     pub fn location(&mut self, line: u32, column: u32) {
-        self.commands.push(Command::Location { line, column });
+        self.buffer.event(EventKind::Location { line, column });
     }
 
-    /// Splice `child`'s commands in place, propagating its multiline state.
+    /// Splice `child`'s output in place, propagating its multiline state.
     pub fn append(&mut self, child: Self) {
         let child_multiline = child.multiline;
-        self.measure += child.measure;
-        self.has_content |= child.has_content;
-        self.commands.push(Command::Nested(child.commands));
+        self.buffer.append(child.buffer);
         if self.has_newline || child_multiline {
             self.multiline = true;
         }
@@ -112,19 +92,19 @@ impl Context {
 
     /// `true` when nothing with visible content has been written.
     pub const fn empty(&self) -> bool {
-        !self.has_content
+        self.buffer.text.is_empty()
     }
 
     /// Total length of the literal strings in this context, ignoring whitespace
     /// sentinels — esrap's `measure`, used to decide if a layout fits on a line.
     pub const fn measure(&self) -> usize {
-        self.measure
+        self.buffer.text.len()
     }
 
-    /// Consume the context, yielding its raw command buffer (for the top-level
+    /// Consume the context, yielding its flat output buffer (for the top-level
     /// [`print`](crate::command::print) call).
-    pub fn into_commands(self) -> Vec<Command> {
-        self.commands
+    pub(crate) fn into_buffer(self) -> Buffer {
+        self.buffer
     }
 }
 
@@ -176,16 +156,24 @@ mod tests {
         child.write("y");
         parent.append(child);
         parent.write(")");
-        assert_eq!(print(&parent.into_commands(), "\t", 0), "(x y)");
+        assert_eq!(print(&parent.into_buffer(), "\t", 0), "(x y)");
     }
 
     #[test]
-    fn adjacent_inline_writes_share_one_command() {
+    fn adjacent_writes_share_the_text_buffer() {
         let mut ctx = Context::new();
         ctx.write("const");
         ctx.write(" ");
         ctx.write("x");
-        assert_eq!(ctx.commands.len(), 1);
-        assert_eq!(print(&ctx.into_commands(), "\t", 0), "const x");
+        assert_eq!(ctx.buffer.text, "const x");
+        assert_eq!(print(&ctx.into_buffer(), "\t", 0), "const x");
+    }
+
+    #[test]
+    fn empty_write_flushes_pending_whitespace() {
+        let mut ctx = Context::new();
+        ctx.space();
+        ctx.write("");
+        assert_eq!(print(&ctx.into_buffer(), "\t", 0), " ");
     }
 }

--- a/crates/rsvelte_esrap/src/internal_tests/golden.rs
+++ b/crates/rsvelte_esrap/src/internal_tests/golden.rs
@@ -95,7 +95,7 @@ fn reprint(source: &str) -> Option<Reprint> {
     let mut ctx = Context::new();
     printer.print_program(&ret.program, &mut ctx);
     Some(Reprint {
-        output: command::print(&ctx.into_commands(), &opts.indent, 0),
+        output: command::print(&ctx.into_buffer(), &opts.indent, 0),
         missing: printer.missing.map(|m| m.0.to_string()),
     })
 }

--- a/crates/rsvelte_esrap/src/internal_tests/pluggability.rs
+++ b/crates/rsvelte_esrap/src/internal_tests/pluggability.rs
@@ -22,6 +22,6 @@ fn custom_printer_via_context_buffer() {
     ctx.write(value);
     ctx.write(" - (:");
 
-    let code = command::print(&ctx.into_commands(), "\t", 0);
+    let code = command::print(&ctx.into_buffer(), "\t", 0);
     assert_eq!(code, ":) - testing 123 - (:");
 }

--- a/crates/rsvelte_esrap/src/lib.rs
+++ b/crates/rsvelte_esrap/src/lib.rs
@@ -12,10 +12,9 @@
 //!
 //! ## Model
 //!
-//! Printing is two internal layers, mirroring esrap:
-//! - a command buffer with a flattening driver (whitespace/indent
-//!   sentinels + literal strings), and
-//! - a context the visitors push commands onto, tracking the
+//! Printing is two internal layers, mirroring esrap's semantics:
+//! - a flat text buffer with offset-based whitespace, indentation, and mapping events, and
+//! - a context the visitors write into, tracking the
 //!   `multiline` signal used to choose layouts.
 //!
 //! The printer walks the oxc AST. Where esrap dispatches through a
@@ -115,9 +114,9 @@ pub fn print_with(program: &Program<'_>, source: &str, options: &PrintOptions) -
     let mut ctx = context::Context::new();
     printer.print_program(program, &mut ctx);
     let capacity = ctx.measure();
-    let commands = ctx.into_commands();
-    let code = command::print(&commands, &options.indent, capacity);
-    pool::recycle(commands);
+    let buffer = ctx.into_buffer();
+    let code = command::print(&buffer, &options.indent, capacity);
+    pool::give(buffer);
     code
 }
 
@@ -155,17 +154,17 @@ pub fn print_split(
     let mut ctx = context::Context::new();
     printer.print_program(program, &mut ctx);
     let capacity = ctx.measure();
-    let commands = ctx.into_commands();
+    let buffer = ctx.into_buffer();
     let output = if map_source.is_some() {
-        let (code, mappings) = command::flatten_with_map(&commands, &options.indent, capacity);
+        let (code, mappings) = command::flatten_with_map(&buffer, &options.indent, capacity);
         PrintWithMap { code, mappings }
     } else {
         PrintWithMap {
-            code: command::print(&commands, &options.indent, capacity),
+            code: command::print(&buffer, &options.indent, capacity),
             mappings: Vec::new(),
         }
     };
-    pool::recycle(commands);
+    pool::give(buffer);
     output
 }
 
@@ -193,9 +192,9 @@ pub fn print_with_map(program: &Program<'_>, source: &str, options: &PrintOption
     let mut ctx = context::Context::new();
     printer.print_program(program, &mut ctx);
     let capacity = ctx.measure();
-    let commands = ctx.into_commands();
-    let (code, mappings) = command::flatten_with_map(&commands, &options.indent, capacity);
-    pool::recycle(commands);
+    let buffer = ctx.into_buffer();
+    let (code, mappings) = command::flatten_with_map(&buffer, &options.indent, capacity);
+    pool::give(buffer);
     PrintWithMap { code, mappings }
 }
 

--- a/crates/rsvelte_esrap/src/pool.rs
+++ b/crates/rsvelte_esrap/src/pool.rs
@@ -1,53 +1,33 @@
-//! A thread-local free list of command buffers.
-//!
-//! One [`Context`](crate::context::Context) is built per syntactic unit the
-//! printer has to measure before laying out, so a single print allocates — and
-//! then frees — a `Vec<Command>` for nearly every node in the program. The
-//! buffers all die at the same moment (when the printed tree is dropped), so
-//! instead of returning them to the allocator [`recycle`] parks them here with
-//! their capacity intact and the next print takes them back.
+//! Thread-local reuse for context text and event buffers.
 
 use std::cell::RefCell;
 
-use crate::command::Command;
+use crate::command::Buffer;
 
-/// Buffers parked for reuse. Bounded because every buffer in a print stays live
-/// until the print ends: a large program would otherwise hand back one buffer
-/// per node and retain them all.
 const MAX_BUFFERS: usize = 8192;
-
-/// Buffers grown past this are dropped rather than parked, so one outlier
-/// program does not pin megabytes for the rest of the process.
-const MAX_CAPACITY: usize = 1024;
+const MAX_TEXT_CAPACITY: usize = 16 * 1024;
+const MAX_EVENT_CAPACITY: usize = 1024;
 
 thread_local! {
-    static BUFFERS: RefCell<Vec<Vec<Command>>> = const { RefCell::new(Vec::new()) };
+    static BUFFERS: RefCell<Vec<Buffer>> = const { RefCell::new(Vec::new()) };
 }
 
-/// An empty command buffer, reusing a parked allocation when one is available.
-pub fn take() -> Vec<Command> {
+pub fn take() -> Buffer {
     BUFFERS.with(|buffers| buffers.borrow_mut().pop().unwrap_or_default())
 }
 
-/// Drain a finished command tree, parking every buffer in it for reuse. Replaces
-/// the recursive drop of the tree, which did the same walk only to free.
-pub fn recycle(root: Vec<Command>) {
+pub fn give(mut buffer: Buffer) {
+    buffer.text.clear();
+    buffer.events.clear();
+    if buffer.text.capacity() > MAX_TEXT_CAPACITY || buffer.events.capacity() > MAX_EVENT_CAPACITY {
+        return;
+    }
     BUFFERS.with(|buffers| {
         let Ok(mut buffers) = buffers.try_borrow_mut() else {
             return;
         };
-        let mut pending = vec![root];
-        while let Some(mut buffer) = pending.pop() {
-            // Draining leaves `buffer`'s allocation available for the pool below.
-            #[allow(clippy::iter_with_drain)]
-            for command in buffer.drain(..) {
-                if let Command::Nested(inner) = command {
-                    pending.push(inner);
-                }
-            }
-            if buffers.len() < MAX_BUFFERS && buffer.capacity() <= MAX_CAPACITY {
-                buffers.push(buffer);
-            }
+        if buffers.len() < MAX_BUFFERS {
+            buffers.push(buffer);
         }
     });
 }

--- a/crates/rsvelte_esrap/src/printer.rs
+++ b/crates/rsvelte_esrap/src/printer.rs
@@ -467,7 +467,7 @@ impl<'opt> Printer<'opt> {
         self
     }
 
-    /// Enable source-map anchor commands for this print.
+    /// Enable source-map anchor events for this print.
     pub const fn with_source_map(mut self) -> Self {
         self.emit_locations = true;
         self
@@ -3890,7 +3890,7 @@ mod tests {
         let mut ctx = Context::new();
         printer.print_program(&ret.program, &mut ctx);
         (
-            crate::command::print(&ctx.into_commands(), &opts.indent, 0),
+            crate::command::print(&ctx.into_buffer(), &opts.indent, 0),
             printer.missing,
         )
     }
@@ -3917,7 +3917,7 @@ mod tests {
         let mut printer = Printer::with_comments(&opts, comments, line_starts(src));
         let mut ctx = Context::new();
         printer.print_program(&ret.program, &mut ctx);
-        let out = crate::command::print(&ctx.into_commands(), &opts.indent, 0);
+        let out = crate::command::print(&ctx.into_buffer(), &opts.indent, 0);
         assert!(
             printer.missing.is_none(),
             "unsupported node: {:?}",

--- a/crates/rsvelte_lint_types/Cargo.lock
+++ b/crates/rsvelte_lint_types/Cargo.lock
@@ -1111,7 +1111,7 @@ dependencies = [
 
 [[package]]
 name = "rsvelte_esrap"
-version = "0.10.10"
+version = "0.10.11"
 dependencies = [
  "compact_str",
  "memchr",


### PR DESCRIPTION
## What changed

- replace the nested `Vec<Command>` tree with one text buffer plus offset-based layout events
- splice child text and events into the parent immediately, then recycle both child allocations during the same print
- retain deferred whitespace, indentation, empty-write flushing, and source-map anchor semantics
- store event offsets as `u32`, reducing an event to 16 bytes on the supported targets
- release `rsvelte_esrap` 0.10.11 and update exact consumers

## Why

The command tree no longer participates in layout decisions: `measure`, `empty`, and `multiline` are scalar state. It nevertheless allocated one command vector per context, stored tiny output fragments in 32-byte commands, retained every child buffer until the end of the print, and required a final recursive flatten/recycle walk.

The flat representation writes literal bytes contiguously while retaining only events that must be deferred. Child splicing copies a short text tail, but prior instrumentation measured that cost as small compared with constructing and walking the command tree.

## Performance

On the paired `ab_print` harness over 11 generated CSR files (50,406 bytes, same retained AST, 50 pairs × 100 iterations), the just-merged #2944 baseline measured 4.201x esrap/oxc. This branch measured 3.183x, 3.199x, and 3.227x: about 23–24% lower again.

Relative to the pre-optimization current-main baseline of 5.467–5.594x, the two tranches together reduce the ratio by roughly 42%. This still does not claim parity with or superiority over `oxc_codegen`.

## Validation

- `cargo test -p rsvelte_esrap --all-targets` (45 unit tests plus integrations)
- `cargo clippy -p rsvelte_esrap --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `node scripts/release/test-esrap-version-bump-check.mjs`
- `node scripts/ci/check-lint-types-lock.mjs`
- paired release benchmark, 3 × 50 pairs × 100 iterations
