### PR TITLE
perf(esrap): reuse buffers within each print

### DIFF
--- a/.changeset/local-esrap-pool.md
+++ b/.changeset/local-esrap-pool.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/compiler": patch
+---
+
+Reuse esrap context buffers through one print-local cache, and release `rsvelte_esrap` 0.10.12.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2605,7 +2605,7 @@ dependencies = [
 
 [[package]]
 name = "rsvelte_esrap"
-version = "0.10.11"
+version = "0.10.12"
 dependencies = [
  "compact_str 0.10.0",
  "memchr",

--- a/crates/rsvelte_core/Cargo.toml
+++ b/crates/rsvelte_core/Cargo.toml
@@ -94,7 +94,7 @@ oxc_ast = { version = "0.144", features = ["serialize"] }
 oxc_span = "0.144"
 oxc_diagnostics = "0.144"
 oxc_codegen = "0.144"
-rsvelte_esrap = { version = "=0.10.11", path = "../rsvelte_esrap" }
+rsvelte_esrap = { version = "=0.10.12", path = "../rsvelte_esrap" }
 oxc_syntax = "0.144"
 oxc_semantic = "0.144"
 

--- a/crates/rsvelte_esrap/Cargo.toml
+++ b/crates/rsvelte_esrap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rsvelte_esrap"
-version = "0.10.11"
+version = "0.10.12"
 edition = "2024"
 rust-version = "1.95"
 description = "A Rust port of esrap — prints an oxc AST to JavaScript with esrap's exact layout"

--- a/crates/rsvelte_esrap/src/command.rs
+++ b/crates/rsvelte_esrap/src/command.rs
@@ -31,7 +31,7 @@ impl Buffer {
         });
     }
 
-    pub fn append(&mut self, mut child: Self) {
+    pub fn append(&mut self, child: &mut Self) {
         let base = u32::try_from(self.text.len()).expect("esrap output exceeds u32");
         self.text.push_str(&child.text);
         self.events.extend(child.events.drain(..).map(|event| {
@@ -43,7 +43,6 @@ impl Buffer {
             }
         }));
         child.text.clear();
-        crate::pool::give(child);
     }
 }
 

--- a/crates/rsvelte_esrap/src/context.rs
+++ b/crates/rsvelte_esrap/src/context.rs
@@ -7,13 +7,15 @@
 //! kinds), so `Context` is purely the output API: `write`, whitespace events,
 //! `append` (splice a child buffer), `measure`, and `empty`.
 
+use std::{cell::RefCell, rc::Rc};
+
 use crate::command::{Buffer, EventKind};
 
 /// Accumulates output for one syntactic unit. Build a child with
 /// [`Context::child`], fill it, then [`Context::append`] it into the parent.
-#[derive(Default)]
 pub struct Context {
     buffer: Buffer,
+    returned: Rc<RefCell<Vec<Buffer>>>,
     has_newline: bool,
     /// `true` once this context (or an appended child) emitted a newline.
     /// Visitors read it to pick a layout.
@@ -23,16 +25,26 @@ pub struct Context {
 impl Context {
     /// A fresh, empty context.
     pub fn new() -> Self {
+        let returned = Rc::new(RefCell::new(crate::pool::take()));
+        let buffer = returned.borrow_mut().pop().unwrap_or_default();
         Self {
-            buffer: crate::pool::take(),
-            ..Self::default()
+            buffer,
+            returned,
+            has_newline: false,
+            multiline: false,
         }
     }
 
     /// A fresh child context. Named `child` rather than mirroring esrap's `new`
     /// because in this port it carries no shared visitor table.
-    pub fn child() -> Self {
-        Self::new()
+    pub fn child(&self) -> Self {
+        let buffer = self.returned.borrow_mut().pop().unwrap_or_default();
+        Self {
+            buffer,
+            returned: Rc::clone(&self.returned),
+            has_newline: false,
+            multiline: false,
+        }
     }
 
     /// Grow the newline indentation by one level for subsequent newlines.
@@ -84,7 +96,9 @@ impl Context {
     /// Splice `child`'s output in place, propagating its multiline state.
     pub fn append(&mut self, child: Self) {
         let child_multiline = child.multiline;
-        self.buffer.append(child.buffer);
+        let mut child_buffer = child.buffer;
+        self.buffer.append(&mut child_buffer);
+        self.returned.borrow_mut().push(child_buffer);
         if self.has_newline || child_multiline {
             self.multiline = true;
         }
@@ -103,8 +117,17 @@ impl Context {
 
     /// Consume the context, yielding its flat output buffer (for the top-level
     /// [`print`](crate::command::print) call).
+    pub(crate) fn into_parts(self) -> (Buffer, Vec<Buffer>) {
+        let returned = match Rc::try_unwrap(self.returned) {
+            Ok(returned) => returned.into_inner(),
+            Err(_) => unreachable!("all child contexts must be consumed before printing"),
+        };
+        (self.buffer, returned)
+    }
+
+    #[cfg(test)]
     pub(crate) fn into_buffer(self) -> Buffer {
-        self.buffer
+        self.into_parts().0
     }
 }
 
@@ -137,7 +160,7 @@ mod tests {
     #[test]
     fn append_propagates_multiline() {
         let mut parent = Context::new();
-        let mut child = Context::child();
+        let mut child = parent.child();
         child.newline();
         child.write("x");
         assert!(child.multiline);
@@ -150,7 +173,7 @@ mod tests {
     fn append_splices_child_output() {
         let mut parent = Context::new();
         parent.write("(");
-        let mut child = Context::child();
+        let mut child = parent.child();
         child.write("x");
         child.space();
         child.write("y");

--- a/crates/rsvelte_esrap/src/lib.rs
+++ b/crates/rsvelte_esrap/src/lib.rs
@@ -114,9 +114,9 @@ pub fn print_with(program: &Program<'_>, source: &str, options: &PrintOptions) -
     let mut ctx = context::Context::new();
     printer.print_program(program, &mut ctx);
     let capacity = ctx.measure();
-    let buffer = ctx.into_buffer();
+    let (buffer, returned) = ctx.into_parts();
     let code = command::print(&buffer, &options.indent, capacity);
-    pool::give(buffer);
+    pool::give(buffer, returned);
     code
 }
 
@@ -154,7 +154,7 @@ pub fn print_split(
     let mut ctx = context::Context::new();
     printer.print_program(program, &mut ctx);
     let capacity = ctx.measure();
-    let buffer = ctx.into_buffer();
+    let (buffer, returned) = ctx.into_parts();
     let output = if map_source.is_some() {
         let (code, mappings) = command::flatten_with_map(&buffer, &options.indent, capacity);
         PrintWithMap { code, mappings }
@@ -164,7 +164,7 @@ pub fn print_split(
             mappings: Vec::new(),
         }
     };
-    pool::give(buffer);
+    pool::give(buffer, returned);
     output
 }
 
@@ -192,9 +192,9 @@ pub fn print_with_map(program: &Program<'_>, source: &str, options: &PrintOption
     let mut ctx = context::Context::new();
     printer.print_program(program, &mut ctx);
     let capacity = ctx.measure();
-    let buffer = ctx.into_buffer();
+    let (buffer, returned) = ctx.into_parts();
     let (code, mappings) = command::flatten_with_map(&buffer, &options.indent, capacity);
-    pool::give(buffer);
+    pool::give(buffer, returned);
     PrintWithMap { code, mappings }
 }
 

--- a/crates/rsvelte_esrap/src/pool.rs
+++ b/crates/rsvelte_esrap/src/pool.rs
@@ -12,22 +12,29 @@ thread_local! {
     static BUFFERS: RefCell<Vec<Buffer>> = const { RefCell::new(Vec::new()) };
 }
 
-pub fn take() -> Buffer {
-    BUFFERS.with(|buffers| buffers.borrow_mut().pop().unwrap_or_default())
+pub fn take() -> Vec<Buffer> {
+    BUFFERS.with(|buffers| std::mem::take(&mut *buffers.borrow_mut()))
 }
 
-pub fn give(mut buffer: Buffer) {
-    buffer.text.clear();
-    buffer.events.clear();
-    if buffer.text.capacity() > MAX_TEXT_CAPACITY || buffer.events.capacity() > MAX_EVENT_CAPACITY {
-        return;
+pub fn give(mut root: Buffer, mut returned: Vec<Buffer>) {
+    root.text.clear();
+    root.events.clear();
+    if root.text.capacity() <= MAX_TEXT_CAPACITY && root.events.capacity() <= MAX_EVENT_CAPACITY {
+        returned.push(root);
     }
     BUFFERS.with(|buffers| {
         let Ok(mut buffers) = buffers.try_borrow_mut() else {
             return;
         };
-        if buffers.len() < MAX_BUFFERS {
-            buffers.push(buffer);
+        while buffers.len() < MAX_BUFFERS {
+            let Some(buffer) = returned.pop() else {
+                break;
+            };
+            if buffer.text.capacity() <= MAX_TEXT_CAPACITY
+                && buffer.events.capacity() <= MAX_EVENT_CAPACITY
+            {
+                buffers.push(buffer);
+            }
         }
     });
 }

--- a/crates/rsvelte_esrap/src/printer.rs
+++ b/crates/rsvelte_esrap/src/printer.rs
@@ -762,7 +762,7 @@ impl<'opt> Printer<'opt> {
         // a leading comment.
         let mut items: Vec<SeqItem> = Vec::with_capacity(n);
         for (i, node) in nodes.iter_mut().enumerate() {
-            let mut child = Context::child();
+            let mut child = parent.child();
             (node.render)(self, &mut child);
 
             let node_multiline = child.multiline;
@@ -907,7 +907,7 @@ impl<'opt> Printer<'opt> {
 
         let mut prev: Option<(&BodyElem, bool)> = None;
         for (i, elem) in non_empty.iter().enumerate() {
-            let mut child = Context::child();
+            let mut child = ctx.child();
             elem.print(self, &mut child);
 
             if let Some((prev_elem, prev_multiline)) = prev {
@@ -1504,7 +1504,7 @@ impl<'opt> Printer<'opt> {
     fn class_body(&mut self, body: &ClassBody, ctx: &mut Context) {
         let span = body.span();
         ctx.write("{");
-        let mut child = Context::child();
+        let mut child = ctx.child();
         let elems: Vec<BodyElem> = body
             .body
             .iter()
@@ -2074,7 +2074,7 @@ impl<'opt> Printer<'opt> {
     /// newline and the closing one collapse to a single line break before `}`.
     fn block(&mut self, body: &[Statement], body_start: u32, body_end: u32, ctx: &mut Context) {
         ctx.write("{");
-        let mut child = Context::child();
+        let mut child = ctx.child();
         self.body(body, body_start, body_end, &mut child);
         if !child.empty() {
             ctx.indent();
@@ -2114,7 +2114,7 @@ impl<'opt> Printer<'opt> {
         let mut total_measure = keyword.len();
         let mut any_multiline = false;
         for declarator in &decl.declarations {
-            let mut child = Context::child();
+            let mut child = ctx.child();
             let start = declarator.span().start;
             self.flush_leading(&mut child, start);
             self.binding_pattern(&declarator.id, &mut child);
@@ -2761,9 +2761,9 @@ impl<'opt> Printer<'opt> {
     fn conditional_expression(&mut self, node: &ConditionalExpression, ctx: &mut Context) {
         self.child_with_parens(&node.test, 5, ctx);
 
-        let mut consequent = Context::child();
+        let mut consequent = ctx.child();
         self.print_expression(&node.consequent, &mut consequent);
-        let mut alternate = Context::child();
+        let mut alternate = ctx.child();
         self.print_expression(&node.alternate, &mut alternate);
 
         let multiline = consequent.multiline
@@ -2999,7 +2999,7 @@ impl<'opt> Printer<'opt> {
                 force_multiline = true;
             }
 
-            let mut child = Context::child();
+            let mut child = ctx.child();
             match arg {
                 Argument::SpreadElement(s) => {
                     child.write("...");

--- a/crates/rsvelte_lint_types/Cargo.lock
+++ b/crates/rsvelte_lint_types/Cargo.lock
@@ -1111,7 +1111,7 @@ dependencies = [
 
 [[package]]
 name = "rsvelte_esrap"
-version = "0.10.11"
+version = "0.10.12"
 dependencies = [
  "compact_str",
  "memchr",


### PR DESCRIPTION
## What changed

- take the thread-local esrap buffer cache once at print start and return it once at the end
- share that print-local cache across child contexts
- recycle a child buffer immediately after it is flattened into its parent
- retain the existing capacity bounds when returning buffers to the thread-local cache
- release `rsvelte_esrap` 0.10.12 and update exact consumers

## Why

After #2945 flattened the command tree, sampling showed that buffer-pool TLS lookups plus `pool::give` still accounted for about 6% of plain printing. A typical print performed roughly one TLS take and one TLS give per child context, despite all children belonging to the same print.

This change performs two TLS accesses per print and uses a shared local cache for the roughly 189 child contexts observed in the benchmark corpus.

## Performance

On the paired `ab_print` harness over 11 generated CSR files (50,406 bytes, same retained AST, 50 pairs × 100 iterations), the #2945 representation measured 3.183–3.227x esrap/oxc. This branch measured 3.010x, 3.033x, and 3.056x, about 5% lower again.

## Validation

- `cargo test -p rsvelte_esrap --all-targets` (45 unit tests plus integrations)
- `cargo clippy -p rsvelte_esrap --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `node scripts/release/test-esrap-version-bump-check.mjs`
- `node scripts/ci/check-lint-types-lock.mjs`
- paired release benchmark, 3 × 50 pairs × 100 iterations
