### PR TITLE
perf(esrap): specialize one-argument calls

### DIFF
--- a/.changeset/single-call-argument.md
+++ b/.changeset/single-call-argument.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/compiler": patch
+---
+
+Avoid allocating a temporary argument vector for one-argument calls, and release `rsvelte_esrap` 0.10.13.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2605,7 +2605,7 @@ dependencies = [
 
 [[package]]
 name = "rsvelte_esrap"
-version = "0.10.12"
+version = "0.10.13"
 dependencies = [
  "compact_str 0.10.0",
  "memchr",

--- a/crates/rsvelte_core/Cargo.toml
+++ b/crates/rsvelte_core/Cargo.toml
@@ -94,7 +94,7 @@ oxc_ast = { version = "0.144", features = ["serialize"] }
 oxc_span = "0.144"
 oxc_diagnostics = "0.144"
 oxc_codegen = "0.144"
-rsvelte_esrap = { version = "=0.10.12", path = "../rsvelte_esrap" }
+rsvelte_esrap = { version = "=0.10.13", path = "../rsvelte_esrap" }
 oxc_syntax = "0.144"
 oxc_semantic = "0.144"
 

--- a/crates/rsvelte_esrap/Cargo.toml
+++ b/crates/rsvelte_esrap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rsvelte_esrap"
-version = "0.10.12"
+version = "0.10.13"
 edition = "2024"
 rust-version = "1.95"
 description = "A Rust port of esrap — prints an oxc AST to JavaScript with esrap's exact layout"

--- a/crates/rsvelte_esrap/src/printer.rs
+++ b/crates/rsvelte_esrap/src/printer.rs
@@ -2967,6 +2967,42 @@ impl<'opt> Printer<'opt> {
     fn call_arguments(&mut self, args: &[Argument], call_end: u32, ctx: &mut Context) {
         let n = args.len();
 
+        if let [arg] = args {
+            let arg_start = arg
+                .as_expression()
+                .map_or_else(|| arg.span().start, |e| unparen(e).span().start);
+            let wrap = self
+                .comments
+                .get(self.comment_index)
+                .is_some_and(|c| c.start < arg_start && c.start_line < self.line_of(arg_start));
+
+            let mut child = ctx.child();
+            match arg {
+                Argument::SpreadElement(spread) => {
+                    child.write("...");
+                    self.print_expression(&spread.argument, &mut child);
+                }
+                _ => match arg.as_expression() {
+                    Some(expression) => self.print_expression(expression, &mut child),
+                    None => self.unsupported("Argument", &mut child),
+                },
+            }
+            self.flush_trailing_comments(&mut child, arg.span().end, Some(call_end));
+
+            ctx.write("(");
+            if wrap {
+                ctx.indent();
+                ctx.newline();
+                ctx.append(child);
+                ctx.dedent();
+                ctx.newline();
+            } else {
+                ctx.append(child);
+            }
+            ctx.write(")");
+            return;
+        }
+
         // Render each argument into its own context (non-final ones carry the
         // trailing comma), flushing each arg's trailing comments in source order
         // — esrap threads comments through the single `comment_index` cursor in

--- a/crates/rsvelte_lint_types/Cargo.lock
+++ b/crates/rsvelte_lint_types/Cargo.lock
@@ -1111,7 +1111,7 @@ dependencies = [
 
 [[package]]
 name = "rsvelte_esrap"
-version = "0.10.12"
+version = "0.10.13"
 dependencies = [
  "compact_str",
  "memchr",


### PR DESCRIPTION
## What changed

- add a direct one-argument call/new rendering path
- preserve the existing leading-comment wrap and trailing-comment placement rules
- avoid allocating and scanning `Vec<Context>` when there is only one argument
- release `rsvelte_esrap` 0.10.13 and update exact consumers

## Why

Post-#2946 sampling put `call_arguments` at about 6% self time. The generic path allocates a temporary context vector for every non-empty call even though the single-argument case does not need to compare sibling multiline state.

## Performance

On the paired `ab_print` harness over 11 generated CSR files (50,406 bytes, same retained AST, 50 pairs × 100 iterations), #2946 measured 3.010–3.056x esrap/oxc. This branch measured 2.829x, 2.831x, and 2.841x, roughly 6–7% lower again.

## Validation

- `cargo test -p rsvelte_esrap --all-targets` (45 unit tests plus integrations)
- `cargo clippy -p rsvelte_esrap --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `node scripts/release/test-esrap-version-bump-check.mjs`
- `node scripts/ci/check-lint-types-lock.mjs`
- paired release benchmark, 3 × 50 pairs × 100 iterations
