### PR TITLE
perf(esrap): remove hot sequence allocations

### DIFF
--- a/.changeset/typed-esrap-sequences.md
+++ b/.changeset/typed-esrap-sequences.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/compiler": patch
+---
+
+Remove per-element closure allocations from hot esrap sequences and specialize common multi-argument calls. Release `rsvelte_esrap` 0.10.14 and update the compiler's exact dependency.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2605,7 +2605,7 @@ dependencies = [
 
 [[package]]
 name = "rsvelte_esrap"
-version = "0.10.13"
+version = "0.10.14"
 dependencies = [
  "compact_str 0.10.0",
  "memchr",

--- a/crates/rsvelte_core/Cargo.toml
+++ b/crates/rsvelte_core/Cargo.toml
@@ -94,7 +94,7 @@ oxc_ast = { version = "0.144", features = ["serialize"] }
 oxc_span = "0.144"
 oxc_diagnostics = "0.144"
 oxc_codegen = "0.144"
-rsvelte_esrap = { version = "=0.10.13", path = "../rsvelte_esrap" }
+rsvelte_esrap = { version = "=0.10.14", path = "../rsvelte_esrap" }
 oxc_syntax = "0.144"
 oxc_semantic = "0.144"
 

--- a/crates/rsvelte_esrap/Cargo.toml
+++ b/crates/rsvelte_esrap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rsvelte_esrap"
-version = "0.10.13"
+version = "0.10.14"
 edition = "2024"
 rust-version = "1.95"
 description = "A Rust port of esrap — prints an oxc AST to JavaScript with esrap's exact layout"

--- a/crates/rsvelte_esrap/src/printer.rs
+++ b/crates/rsvelte_esrap/src/printer.rs
@@ -971,9 +971,12 @@ impl<'opt> Printer<'opt> {
         // an acorn AST) sees them as leading string-literal ExpressionStatements
         // in `body`; thread them through the same `body` sequence so margins and
         // leading comments are computed identically.
-        let mut elems: Vec<BodyElem> = program.directives.iter().map(BodyElem::Directive).collect();
-        elems.extend(program.body.iter().map(BodyElem::Statement));
-        self.body_elems(&elems, body_start, span.end, ctx);
+        let elems = program
+            .directives
+            .iter()
+            .map(BodyElem::Directive)
+            .chain(program.body.iter().map(BodyElem::Statement));
+        self.body_elems(elems, body_start, span.end, ctx);
     }
 
     /// esrap's `body`: statements on their own lines, with a blank line between
@@ -988,19 +991,25 @@ impl<'opt> Printer<'opt> {
         body_end: u32,
         ctx: &mut Context,
     ) {
-        let elems: Vec<BodyElem> = statements.iter().map(BodyElem::Statement).collect();
-        self.body_elems(&elems, Some(body_start), body_end, ctx);
+        self.body_elems(
+            statements.iter().map(BodyElem::Statement),
+            Some(body_start),
+            body_end,
+            ctx,
+        );
     }
 
     /// The element-based core of [`Self::body`], shared by `print_program` so a
     /// program's leading directives participate in the same margin/comment pass.
-    fn body_elems(
+    fn body_elems<'a, 'b>(
         &mut self,
-        elems: &[BodyElem],
+        elems: impl IntoIterator<Item = BodyElem<'a, 'b>>,
         body_start: Option<u32>,
         body_end: u32,
         ctx: &mut Context,
-    ) {
+    ) where
+        'a: 'b,
+    {
         // esrap filters `EmptyStatement` (`;`) nodes from statement-list bodies
         // (matching the server AST + official esrap). The client `to_oxc` path,
         // which parses string-codegen `Raw` `;;` into real EmptyStatement nodes the
@@ -1011,17 +1020,17 @@ impl<'opt> Printer<'opt> {
 
         let keep_empty = self.options.keep_empty_statements;
         let mut elems = elems
-            .iter()
+            .into_iter()
             .filter(|elem| keep_empty || !elem.is_empty_stmt())
             .peekable();
-        let mut prev: Option<(&BodyElem, bool)> = None;
+        let mut prev: Option<(BodyElem<'a, 'b>, bool)> = None;
         let mut last_end = None;
         while let Some(elem) = elems.next() {
             let mut child = ctx.child();
             elem.print(self, &mut child);
 
-            if let Some((prev_elem, prev_multiline)) = prev {
-                if child.multiline || prev_multiline || !elem.same_kind(prev_elem) {
+            if let Some((prev_elem, prev_multiline)) = &prev {
+                if child.multiline || *prev_multiline || !elem.same_kind(prev_elem) {
                     ctx.margin();
                 }
                 ctx.newline();
@@ -1029,10 +1038,11 @@ impl<'opt> Printer<'opt> {
             let multiline = child.multiline;
             ctx.append(child);
 
-            let next = elems.peek().map(|e| e.span_end());
-            self.flush_trailing_comments(ctx, elem.span_end(), next);
+            let end = elem.span_end();
+            let next = elems.peek().map(BodyElem::span_end);
+            self.flush_trailing_comments(ctx, end, next);
 
-            last_end = Some(elem.span_end());
+            last_end = Some(end);
             prev = Some((elem, multiline));
         }
 
@@ -1614,15 +1624,14 @@ impl<'opt> Printer<'opt> {
         let span = body.span();
         ctx.write("{");
         let mut child = ctx.child();
-        let elems: Vec<BodyElem> = body
+        let elems = body
             .body
             .iter()
             // esrap's `body` only skips `EmptyStatement`; TS index signatures are
             // not statements and have no printer mapping here, so drop them.
             .filter(|e| !matches!(e, ClassElement::TSIndexSignature(_)))
-            .map(BodyElem::ClassMember)
-            .collect();
-        self.body_elems(&elems, Some(span.start), span.end, &mut child);
+            .map(BodyElem::ClassMember);
+        self.body_elems(elems, Some(span.start), span.end, &mut child);
         if !child.empty() {
             ctx.indent();
             ctx.newline();
@@ -3957,9 +3966,12 @@ impl<'opt> Printer<'opt> {
         ctx.write(" {");
         ctx.indent();
         ctx.newline();
-        let mut elems: Vec<BodyElem> = node.directives.iter().map(BodyElem::Directive).collect();
-        elems.extend(node.body.iter().map(BodyElem::Statement));
-        self.body_elems(&elems, Some(node.span.start), node.span.end, ctx);
+        let elems = node
+            .directives
+            .iter()
+            .map(BodyElem::Directive)
+            .chain(node.body.iter().map(BodyElem::Statement));
+        self.body_elems(elems, Some(node.span.start), node.span.end, ctx);
         ctx.dedent();
         ctx.newline();
         ctx.write("}");

--- a/crates/rsvelte_esrap/src/printer.rs
+++ b/crates/rsvelte_esrap/src/printer.rs
@@ -1005,17 +1005,18 @@ impl<'opt> Printer<'opt> {
         // (matching the server AST + official esrap). The client `to_oxc` path,
         // which parses string-codegen `Raw` `;;` into real EmptyStatement nodes the
         // official COMPILER output keeps, opts into preserving them.
-        let non_empty: Vec<&BodyElem> = if self.options.keep_empty_statements {
-            elems.iter().collect()
-        } else {
-            elems.iter().filter(|e| !e.is_empty_stmt()).collect()
-        };
         // Re-sync to the body's own start so a leading comment that precedes the
         // first statement (e.g. a file header) isn't skipped over.
         self.reset_comment_index(body_start);
 
+        let keep_empty = self.options.keep_empty_statements;
+        let mut elems = elems
+            .iter()
+            .filter(|elem| keep_empty || !elem.is_empty_stmt())
+            .peekable();
         let mut prev: Option<(&BodyElem, bool)> = None;
-        for (i, elem) in non_empty.iter().enumerate() {
+        let mut last_end = None;
+        while let Some(elem) = elems.next() {
             let mut child = ctx.child();
             elem.print(self, &mut child);
 
@@ -1028,9 +1029,10 @@ impl<'opt> Printer<'opt> {
             let multiline = child.multiline;
             ctx.append(child);
 
-            let next = non_empty.get(i + 1).map(|e| e.span_end());
+            let next = elems.peek().map(|e| e.span_end());
             self.flush_trailing_comments(ctx, elem.span_end(), next);
 
+            last_end = Some(elem.span_end());
             prev = Some((elem, multiline));
         }
 
@@ -1045,9 +1047,7 @@ impl<'opt> Printer<'opt> {
             && body_start.is_some_and(|start| self.has_loc(start))
             && self.has_loc(body_end)
         {
-            let from_line = non_empty
-                .last()
-                .map(|e| e.span_end())
+            let from_line = last_end
                 .filter(|&end| self.has_loc(end))
                 .map(|end| self.line_of(end));
             self.flush_comments_until(ctx, body_end, self.line_of(body_end), from_line, false);

--- a/crates/rsvelte_esrap/src/printer.rs
+++ b/crates/rsvelte_esrap/src/printer.rs
@@ -2218,6 +2218,24 @@ impl<'opt> Printer<'opt> {
         }
         kw.write(ctx, keyword);
 
+        if let [declarator] = decl.declarations.as_slice() {
+            let mut child = ctx.child();
+            self.flush_leading(&mut child, declarator.span().start);
+            self.binding_pattern(&declarator.id, &mut child);
+            if declarator.definite {
+                child.write("!");
+            }
+            if let Some(ann) = &declarator.type_annotation {
+                self.type_annotation(ann, &mut child);
+            }
+            if let Some(init) = &declarator.init {
+                child.write(" = ");
+                self.print_expression(init, &mut child);
+            }
+            ctx.append(child);
+            return;
+        }
+
         let n = decl.declarations.len();
         let mut rendered: Vec<Context> = Vec::with_capacity(n);
         // esrap measures the whole `child_context`, which includes the keyword,

--- a/crates/rsvelte_esrap/src/printer.rs
+++ b/crates/rsvelte_esrap/src/printer.rs
@@ -838,6 +838,115 @@ impl<'opt> Printer<'opt> {
         }
     }
 
+    fn sequence_indexed(
+        &mut self,
+        n: usize,
+        mut meta: impl FnMut(usize) -> SeqMeta,
+        mut render: impl FnMut(&mut Self, usize, &mut Context),
+        until: Option<u32>,
+        pad: bool,
+        separator: &'static str,
+        trailing_newline: bool,
+        parent: &mut Context,
+    ) {
+        let mut multiline = false;
+        let mut length: i64 = -1;
+        let mut items: Vec<SeqItem> = Vec::with_capacity(n);
+
+        for i in 0..n {
+            let node_meta = meta(i);
+            let mut child = parent.child();
+            render(self, i, &mut child);
+
+            let node_multiline = child.multiline;
+            if i < n - 1 || node_meta.is_elision {
+                child.write(separator);
+            }
+
+            let next = if i == n - 1 { until } else { meta(i + 1).start };
+            if let Some(end) = node_meta.end {
+                self.flush_trailing_comments(&mut child, end, next);
+            }
+
+            length += usize_to_i64(child.measure()) + 1;
+            multiline |= child.multiline;
+            items.push(SeqItem {
+                ctx: child,
+                multiline: node_multiline,
+                obj_or_array: node_meta.obj_or_array,
+                is_elision: node_meta.is_elision,
+            });
+        }
+
+        multiline |= length > 60;
+
+        if multiline {
+            parent.indent();
+            parent.newline();
+        } else if pad && length > 0 {
+            parent.write(" ");
+        }
+
+        let mut prev: Option<(bool, bool)> = None;
+        for item in items {
+            if let Some((prev_multiline, prev_obj)) = prev {
+                if prev_multiline && item.multiline && !(prev_obj && item.obj_or_array) {
+                    parent.margin();
+                }
+                if !item.is_elision {
+                    if multiline {
+                        parent.newline();
+                    } else {
+                        parent.write(" ");
+                    }
+                }
+            }
+            prev = Some((item.multiline, item.obj_or_array));
+            parent.append(item.ctx);
+        }
+
+        if let Some(until) = until {
+            let from_line = n
+                .checked_sub(1)
+                .and_then(|i| meta(i).end)
+                .filter(|&e| self.has_loc(e))
+                .map(|e| self.line_of(e));
+            self.flush_comments_until(parent, until, self.line_of(until), from_line, false);
+        }
+
+        if multiline {
+            parent.dedent();
+            if trailing_newline {
+                parent.newline();
+            }
+        } else if pad && length > 0 {
+            parent.write(" ");
+        }
+    }
+
+    fn sequence_slice<T>(
+        &mut self,
+        nodes: &[T],
+        mut meta: impl FnMut(&T) -> SeqMeta,
+        mut render: impl FnMut(&mut Self, &T, &mut Context),
+        until: Option<u32>,
+        pad: bool,
+        separator: &'static str,
+        trailing_newline: bool,
+        parent: &mut Context,
+    ) {
+        self.sequence_indexed(
+            nodes.len(),
+            |i| meta(&nodes[i]),
+            |printer, i, child| render(printer, &nodes[i], child),
+            until,
+            pad,
+            separator,
+            trailing_newline,
+            parent,
+        );
+    }
+
     fn unsupported(&mut self, kind: &'static str, ctx: &mut Context) {
         if self.missing.is_none() {
             self.missing = Some(Unsupported(kind));
@@ -1856,45 +1965,43 @@ impl<'opt> Printer<'opt> {
 
     fn object_pattern(&mut self, node: &ObjectPattern, ctx: &mut Context) {
         ctx.write("{");
-        let mut nodes: Vec<SeqNode> = node
-            .properties
-            .iter()
-            .map(|prop| {
-                let span = prop.span();
-                SeqNode {
+        let property_len = node.properties.len();
+        let n = property_len + usize::from(node.rest.is_some());
+        self.sequence_indexed(
+            n,
+            |i| {
+                let span = if i < property_len {
+                    node.properties[i].span()
+                } else {
+                    node.rest.as_ref().unwrap().span()
+                };
+                SeqMeta {
                     start: Some(span.start),
                     end: Some(span.end),
                     obj_or_array: false,
                     is_elision: false,
-                    render: Box::new(move |p: &mut Printer, child: &mut Context| {
-                        // esrap's `sequence` visits each property through the `_`
-                        // wildcard, which flushes any comment positioned before it
-                        // (`{ a, /* c */ b } = x` or a `// line` comment before a
-                        // destructured prop). Mirror that per property — a `// line`
-                        // comment also forces the sequence multiline (via the
-                        // `newline()` in `write_comment`), so it can't swallow the
-                        // following token (`tabindex = // c 0` → unparseable).
-                        p.flush_leading(child, span.start);
-                        p.binding_property(prop, child);
-                    }),
                 }
-            })
-            .collect();
-        if let Some(rest) = &node.rest {
-            let span = rest.span();
-            nodes.push(SeqNode {
-                start: Some(span.start),
-                end: Some(span.end),
-                obj_or_array: false,
-                is_elision: false,
-                render: Box::new(move |p: &mut Printer, child: &mut Context| {
+            },
+            |p, i, child| {
+                if i < property_len {
+                    let prop = &node.properties[i];
+                    let span = prop.span();
+                    p.flush_leading(child, span.start);
+                    p.binding_property(prop, child);
+                } else {
+                    let rest = node.rest.as_ref().unwrap();
+                    let span = rest.span();
                     p.flush_leading(child, span.start);
                     child.write("...");
                     p.binding_pattern(&rest.argument, child);
-                }),
-            });
-        }
-        self.sequence(nodes, Some(node.span().end), true, ",", true, ctx);
+                }
+            },
+            Some(node.span().end),
+            true,
+            ",",
+            true,
+            ctx,
+        );
         ctx.write("}");
     }
 
@@ -1916,38 +2023,46 @@ impl<'opt> Printer<'opt> {
 
     fn array_pattern(&mut self, node: &ArrayPattern, ctx: &mut Context) {
         ctx.write("[");
-        let mut nodes: Vec<SeqNode> = node
-            .elements
-            .iter()
-            .map(|el| {
-                let span = el.as_ref().map(oxc_span::GetSpan::span);
-                SeqNode {
-                    start: span.map(|s| s.start),
-                    end: span.map(|s| s.end),
-                    obj_or_array: false,
-                    is_elision: el.is_none(),
-                    render: Box::new(move |p: &mut Printer, child: &mut Context| {
-                        if let Some(pattern) = el {
-                            p.binding_pattern(pattern, child);
-                        }
-                    }),
+        let element_len = node.elements.len();
+        let n = element_len + usize::from(node.rest.is_some());
+        self.sequence_indexed(
+            n,
+            |i| {
+                if i < element_len {
+                    let span = node.elements[i].as_ref().map(oxc_span::GetSpan::span);
+                    SeqMeta {
+                        start: span.map(|s| s.start),
+                        end: span.map(|s| s.end),
+                        obj_or_array: false,
+                        is_elision: span.is_none(),
+                    }
+                } else {
+                    let span = node.rest.as_ref().unwrap().span();
+                    SeqMeta {
+                        start: Some(span.start),
+                        end: Some(span.end),
+                        obj_or_array: false,
+                        is_elision: false,
+                    }
                 }
-            })
-            .collect();
-        if let Some(rest) = &node.rest {
-            let span = rest.span();
-            nodes.push(SeqNode {
-                start: Some(span.start),
-                end: Some(span.end),
-                obj_or_array: false,
-                is_elision: false,
-                render: Box::new(move |p: &mut Printer, child: &mut Context| {
+            },
+            |p, i, child| {
+                if i < element_len {
+                    if let Some(pattern) = &node.elements[i] {
+                        p.binding_pattern(pattern, child);
+                    }
+                } else {
+                    let rest = node.rest.as_ref().unwrap();
                     child.write("...");
                     p.binding_pattern(&rest.argument, child);
-                }),
-            });
-        }
-        self.sequence(nodes, Some(node.span().end), false, ",", true, ctx);
+                }
+            },
+            Some(node.span().end),
+            false,
+            ",",
+            true,
+            ctx,
+        );
         ctx.write("]");
     }
 
@@ -1965,31 +2080,35 @@ impl<'opt> Printer<'opt> {
         until: Option<u32>,
         ctx: &mut Context,
     ) {
-        let mut nodes: Vec<SeqNode> = Vec::new();
-        if let Some(tp) = this_param {
-            let span = tp.span;
-            nodes.push(SeqNode {
-                start: Some(span.start),
-                end: Some(span.end),
-                obj_or_array: false,
-                is_elision: false,
-                render: Box::new(move |p: &mut Printer, child: &mut Context| {
+        let this_len = usize::from(this_param.is_some());
+        let item_len = params.items.len();
+        let n = this_len + item_len + usize::from(params.rest.is_some());
+        self.sequence_indexed(
+            n,
+            |i| {
+                let span = if i < this_len {
+                    this_param.unwrap().span
+                } else if i - this_len < item_len {
+                    params.items[i - this_len].span()
+                } else {
+                    params.rest.as_ref().unwrap().span()
+                };
+                SeqMeta {
+                    start: Some(span.start),
+                    end: Some(span.end),
+                    obj_or_array: false,
+                    is_elision: false,
+                }
+            },
+            |p, i, child| {
+                if i < this_len {
+                    let tp = this_param.unwrap();
                     child.write("this");
                     if let Some(ann) = &tp.type_annotation {
                         p.type_annotation(ann, child);
                     }
-                }),
-            });
-        }
-        nodes.extend(params.items.iter().map(|param| {
-            let span = param.span();
-            SeqNode {
-                start: Some(span.start),
-                end: Some(span.end),
-                obj_or_array: false,
-                is_elision: false,
-                render: Box::new(move |p: &mut Printer, child: &mut Context| {
-                    // TS parameter properties (`constructor(private readonly x: T)`).
+                } else if i - this_len < item_len {
+                    let param = &params.items[i - this_len];
                     if let Some(acc) = &param.accessibility {
                         child.write(format_compact!("{} ", accessibility_str(*acc)));
                     }
@@ -2006,33 +2125,25 @@ impl<'opt> Printer<'opt> {
                     if let Some(ann) = &param.type_annotation {
                         p.type_annotation(ann, child);
                     }
-                    // Default value: oxc stores parameter defaults on
-                    // `FormalParameter::initializer`, not as an
-                    // `AssignmentPattern`.
                     if let Some(init) = &param.initializer {
                         child.write(" = ");
                         p.print_expression(init, child);
                     }
-                }),
-            }
-        }));
-        if let Some(rest) = &params.rest {
-            let span = rest.span();
-            nodes.push(SeqNode {
-                start: Some(span.start),
-                end: Some(span.end),
-                obj_or_array: false,
-                is_elision: false,
-                render: Box::new(move |p: &mut Printer, child: &mut Context| {
+                } else {
+                    let rest = params.rest.as_ref().unwrap();
                     child.write("...");
                     p.binding_pattern(&rest.rest.argument, child);
                     if let Some(ann) = &rest.type_annotation {
                         p.type_annotation(ann, child);
                     }
-                }),
-            });
-        }
-        self.sequence(nodes, until, false, ",", true, ctx);
+                }
+            },
+            until,
+            false,
+            ",",
+            true,
+            ctx,
+        );
     }
 
     /// esrap's `ArrowFunctionExpression`: `[async ](params) => body`, wrapping an
@@ -2641,72 +2752,82 @@ impl<'opt> Printer<'opt> {
             }
             AssignmentTarget::ArrayAssignmentTarget(a) => {
                 ctx.write("[");
-                let mut nodes: Vec<SeqNode> = a
-                    .elements
-                    .iter()
-                    .map(|el| {
-                        let span = el.as_ref().map(oxc_span::GetSpan::span);
-                        SeqNode {
-                            start: span.map(|s| s.start),
-                            end: span.map(|s| s.end),
-                            obj_or_array: false,
-                            is_elision: el.is_none(),
-                            render: Box::new(move |p: &mut Printer, child: &mut Context| {
-                                if let Some(t) = el {
-                                    p.assignment_target_maybe_default(t, child);
-                                }
-                            }),
+                let element_len = a.elements.len();
+                let n = element_len + usize::from(a.rest.is_some());
+                self.sequence_indexed(
+                    n,
+                    |i| {
+                        if i < element_len {
+                            let span = a.elements[i].as_ref().map(oxc_span::GetSpan::span);
+                            SeqMeta {
+                                start: span.map(|s| s.start),
+                                end: span.map(|s| s.end),
+                                obj_or_array: false,
+                                is_elision: span.is_none(),
+                            }
+                        } else {
+                            let span = a.rest.as_ref().unwrap().span();
+                            SeqMeta {
+                                start: Some(span.start),
+                                end: Some(span.end),
+                                obj_or_array: false,
+                                is_elision: false,
+                            }
                         }
-                    })
-                    .collect();
-                if let Some(rest) = &a.rest {
-                    let span = rest.span();
-                    nodes.push(SeqNode {
-                        start: Some(span.start),
-                        end: Some(span.end),
-                        obj_or_array: false,
-                        is_elision: false,
-                        render: Box::new(move |p: &mut Printer, child: &mut Context| {
+                    },
+                    |p, i, child| {
+                        if i < element_len {
+                            if let Some(target) = &a.elements[i] {
+                                p.assignment_target_maybe_default(target, child);
+                            }
+                        } else {
+                            let rest = a.rest.as_ref().unwrap();
                             child.write("...");
                             p.assignment_target(&rest.target, child);
-                        }),
-                    });
-                }
-                self.sequence(nodes, Some(a.span().end), false, ",", true, ctx);
+                        }
+                    },
+                    Some(a.span().end),
+                    false,
+                    ",",
+                    true,
+                    ctx,
+                );
                 ctx.write("]");
             }
             AssignmentTarget::ObjectAssignmentTarget(o) => {
                 ctx.write("{");
-                let mut nodes: Vec<SeqNode> = o
-                    .properties
-                    .iter()
-                    .map(|prop| {
-                        let span = prop.span();
-                        SeqNode {
+                let property_len = o.properties.len();
+                let n = property_len + usize::from(o.rest.is_some());
+                self.sequence_indexed(
+                    n,
+                    |i| {
+                        let span = if i < property_len {
+                            o.properties[i].span()
+                        } else {
+                            o.rest.as_ref().unwrap().span()
+                        };
+                        SeqMeta {
                             start: Some(span.start),
                             end: Some(span.end),
                             obj_or_array: false,
                             is_elision: false,
-                            render: Box::new(move |p: &mut Printer, child: &mut Context| {
-                                p.assignment_target_property(prop, child);
-                            }),
                         }
-                    })
-                    .collect();
-                if let Some(rest) = &o.rest {
-                    let span = rest.span();
-                    nodes.push(SeqNode {
-                        start: Some(span.start),
-                        end: Some(span.end),
-                        obj_or_array: false,
-                        is_elision: false,
-                        render: Box::new(move |p: &mut Printer, child: &mut Context| {
+                    },
+                    |p, i, child| {
+                        if i < property_len {
+                            p.assignment_target_property(&o.properties[i], child);
+                        } else {
+                            let rest = o.rest.as_ref().unwrap();
                             child.write("...");
                             p.assignment_target(&rest.target, child);
-                        }),
-                    });
-                }
-                self.sequence(nodes, Some(o.span().end), true, ",", true, ctx);
+                        }
+                    },
+                    Some(o.span().end),
+                    true,
+                    ",",
+                    true,
+                    ctx,
+                );
                 ctx.write("}");
             }
             _ => self.unsupported("AssignmentTarget", ctx),
@@ -2789,33 +2910,35 @@ impl<'opt> Printer<'opt> {
 
     fn array_expression(&mut self, node: &ArrayExpression, ctx: &mut Context) {
         ctx.write("[");
-        let nodes: Vec<SeqNode> = node
-            .elements
-            .iter()
-            .map(|el| {
-                let is_elision = matches!(el, ArrayExpressionElement::Elision(_));
+        self.sequence_slice(
+            &node.elements,
+            |el| {
                 let span = el.span();
-                SeqNode {
+                SeqMeta {
                     start: Some(span.start),
                     end: Some(span.end),
                     obj_or_array: false,
-                    is_elision,
-                    render: Box::new(move |p: &mut Printer, child: &mut Context| match el {
-                        ArrayExpressionElement::SpreadElement(s) => {
-                            child.write("...");
-                            p.print_expression(&s.argument, child);
-                        }
-                        ArrayExpressionElement::Elision(_) => {}
-                        _ => {
-                            if let Some(e) = el.as_expression() {
-                                p.print_expression(e, child);
-                            }
-                        }
-                    }),
+                    is_elision: matches!(el, ArrayExpressionElement::Elision(_)),
                 }
-            })
-            .collect();
-        self.sequence(nodes, Some(node.span().end), false, ",", true, ctx);
+            },
+            |p, el, child| match el {
+                ArrayExpressionElement::SpreadElement(s) => {
+                    child.write("...");
+                    p.print_expression(&s.argument, child);
+                }
+                ArrayExpressionElement::Elision(_) => {}
+                _ => {
+                    if let Some(e) = el.as_expression() {
+                        p.print_expression(e, child);
+                    }
+                }
+            },
+            Some(node.span().end),
+            false,
+            ",",
+            true,
+            ctx,
+        );
         ctx.write("]");
     }
 
@@ -2823,62 +2946,62 @@ impl<'opt> Printer<'opt> {
     /// comma list out with the shared `sequence` machinery.
     fn sequence_expression(&mut self, node: &SequenceExpression, ctx: &mut Context) {
         ctx.write("(");
-        let nodes: Vec<SeqNode> = node
-            .expressions
-            .iter()
-            .map(|e| {
+        self.sequence_slice(
+            &node.expressions,
+            |e| {
                 let span = e.span();
-                SeqNode {
+                SeqMeta {
                     start: Some(span.start),
                     end: Some(span.end),
                     obj_or_array: false,
                     is_elision: false,
-                    render: Box::new(move |p: &mut Printer, child: &mut Context| {
-                        p.print_expression(e, child);
-                    }),
                 }
-            })
-            .collect();
-        self.sequence(nodes, Some(node.span().end), false, ",", true, ctx);
+            },
+            |p, e, child| p.print_expression(e, child),
+            Some(node.span().end),
+            false,
+            ",",
+            true,
+            ctx,
+        );
         ctx.write(")");
     }
 
     fn object_expression(&mut self, node: &ObjectExpression, ctx: &mut Context) {
         ctx.write("{");
-        let nodes: Vec<SeqNode> = node
-            .properties
-            .iter()
-            .map(|prop| {
+        self.sequence_slice(
+            &node.properties,
+            |prop| {
                 let span = prop.span();
                 let obj_or_array = matches!(prop, ObjectPropertyKind::ObjectProperty(p)
                 if matches!(
                     &p.value,
                     Expression::ObjectExpression(_) | Expression::ArrayExpression(_)
                 ));
-                SeqNode {
+                SeqMeta {
                     start: Some(span.start),
                     end: Some(span.end),
                     obj_or_array,
                     is_elision: false,
-                    render: Box::new(move |p: &mut Printer, child: &mut Context| {
-                        // esrap's `sequence` visits each property through the `_`
-                        // wildcard, which flushes any comment positioned before
-                        // it (`{ /** doc */ key: … }`). Mirror that per property.
-                        p.flush_leading(child, span.start);
-                        match prop {
-                            ObjectPropertyKind::ObjectProperty(prop) => {
-                                p.object_property(prop, child);
-                            }
-                            ObjectPropertyKind::SpreadProperty(s) => {
-                                child.write("...");
-                                p.print_expression(&s.argument, child);
-                            }
-                        }
-                    }),
                 }
-            })
-            .collect();
-        self.sequence(nodes, Some(node.span().end), true, ",", true, ctx);
+            },
+            |p, prop, child| {
+                let span = prop.span();
+                p.flush_leading(child, span.start);
+                match prop {
+                    ObjectPropertyKind::ObjectProperty(prop) => p.object_property(prop, child),
+                    ObjectPropertyKind::SpreadProperty(s) => {
+                        child.write("...");
+                        p.print_expression(&s.argument, child);
+                    }
+                }
+            },
+            Some(node.span().end),
+            true,
+            ",",
+            true,
+            ctx,
+        );
         ctx.write("}");
     }
 
@@ -2998,6 +3121,121 @@ impl<'opt> Printer<'opt> {
                 ctx.newline();
             } else {
                 ctx.append(child);
+            }
+            ctx.write(")");
+            return;
+        }
+
+        if let [first, second] = args {
+            let second_start = second
+                .as_expression()
+                .map_or_else(|| second.span().start, |e| unparen(e).span().start);
+            let force_multiline = self.comments.get(self.comment_index).is_some_and(|c| {
+                c.start < second_start && c.start_line < self.line_of(second_start)
+            });
+
+            let mut first_child = ctx.child();
+            match first {
+                Argument::SpreadElement(spread) => {
+                    first_child.write("...");
+                    self.print_expression(&spread.argument, &mut first_child);
+                }
+                _ => match first.as_expression() {
+                    Some(expression) => self.print_expression(expression, &mut first_child),
+                    None => self.unsupported("Argument", &mut first_child),
+                },
+            }
+            first_child.write(",");
+            if self.flush_trailing_comments(
+                &mut first_child,
+                first.span().end,
+                Some(second.span().start),
+            ) {
+                first_child.multiline = true;
+            }
+
+            let mut second_child = ctx.child();
+            match second {
+                Argument::SpreadElement(spread) => {
+                    second_child.write("...");
+                    self.print_expression(&spread.argument, &mut second_child);
+                }
+                _ => match second.as_expression() {
+                    Some(expression) => self.print_expression(expression, &mut second_child),
+                    None => self.unsupported("Argument", &mut second_child),
+                },
+            }
+            self.flush_trailing_comments(&mut second_child, second.span().end, Some(call_end));
+
+            ctx.write("(");
+            if force_multiline || first_child.multiline {
+                ctx.indent();
+                ctx.newline();
+                ctx.append(first_child);
+                ctx.newline();
+                ctx.append(second_child);
+                ctx.dedent();
+                ctx.newline();
+            } else {
+                ctx.append(first_child);
+                ctx.write(" ");
+                ctx.append(second_child);
+            }
+            ctx.write(")");
+            return;
+        }
+
+        if let [_, _, last] = args {
+            let last_start = last
+                .as_expression()
+                .map_or_else(|| last.span().start, |e| unparen(e).span().start);
+            let force_multiline = self
+                .comments
+                .get(self.comment_index)
+                .is_some_and(|c| c.start < last_start && c.start_line < self.line_of(last_start));
+            let mut rendered = [ctx.child(), ctx.child(), ctx.child()];
+
+            for (i, (arg, child)) in args.iter().zip(&mut rendered).enumerate() {
+                match arg {
+                    Argument::SpreadElement(spread) => {
+                        child.write("...");
+                        self.print_expression(&spread.argument, child);
+                    }
+                    _ => match arg.as_expression() {
+                        Some(expression) => self.print_expression(expression, child),
+                        None => self.unsupported("Argument", child),
+                    },
+                }
+                if i < 2 {
+                    child.write(",");
+                }
+                let next = if i == 2 {
+                    Some(call_end)
+                } else {
+                    Some(args[i + 1].span().start)
+                };
+                if self.flush_trailing_comments(child, arg.span().end, next) && i < 2 {
+                    child.multiline = true;
+                }
+            }
+
+            let wrap = force_multiline || rendered[0].multiline || rendered[1].multiline;
+            ctx.write("(");
+            if wrap {
+                ctx.indent();
+                for child in rendered {
+                    ctx.newline();
+                    ctx.append(child);
+                }
+                ctx.dedent();
+                ctx.newline();
+            } else {
+                for (i, child) in rendered.into_iter().enumerate() {
+                    if i > 0 {
+                        ctx.write(" ");
+                    }
+                    ctx.append(child);
+                }
             }
             ctx.write(")");
             return;
@@ -3776,6 +4014,14 @@ struct SeqItem {
     /// This item is an array elision (a hole, `[a, , b]`). esrap still writes
     /// the hole's separator but omits the inter-element space/newline *before*
     /// it, so consecutive holes read `,,` rather than `, ,`.
+    is_elision: bool,
+}
+
+#[derive(Clone, Copy)]
+struct SeqMeta {
+    start: Option<u32>,
+    end: Option<u32>,
+    obj_or_array: bool,
     is_elision: bool,
 }
 

--- a/crates/rsvelte_lint_types/Cargo.lock
+++ b/crates/rsvelte_lint_types/Cargo.lock
@@ -1111,7 +1111,7 @@ dependencies = [
 
 [[package]]
 name = "rsvelte_esrap"
-version = "0.10.13"
+version = "0.10.14"
 dependencies = [
  "compact_str",
  "memchr",


### PR DESCRIPTION
## Summary

- render array, object, sequence, parameter, and destructuring lists through typed/indexed sequence paths
- eliminate one boxed renderer per element and temporary metadata vectors on these hot paths
- use fixed stack contexts for common two- and three-argument calls
- bypass the temporary declarator vector for single-declarator statements
- stream body filtering and directive/statement/class-member sources without per-body vectors
- release rsvelte_esrap 0.10.14 and update the exact compiler dependency

## Performance

Paired warmed benchmark on the retained AST corpus: 11 files, 50,406 bytes, 200 pairs x 100 iterations.

- this branch: median esrap/OXC 2.232x
- PR #2947 baseline: 2.829-2.841x across three 50-pair runs

The output artifact and printer options are unchanged.

## Validation

- cargo test -p rsvelte_esrap --all-targets
- cargo clippy -p rsvelte_esrap --all-targets --all-features -- -D warnings
- cargo fmt --all -- --check
- esrap version bump guard
- changeset package-name guard
- core consumer changeset guard