### PR TITLE
perf(esrap): render statement bodies in place

### DIFF
--- a/.changeset/inplace-esrap-bodies.md
+++ b/.changeset/inplace-esrap-bodies.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/compiler": patch
+---
+
+Render esrap statement bodies and single declarators directly into their parent buffer. Release `rsvelte_esrap` 0.10.15 and update the compiler's exact dependency.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2605,7 +2605,7 @@ dependencies = [
 
 [[package]]
 name = "rsvelte_esrap"
-version = "0.10.14"
+version = "0.10.15"
 dependencies = [
  "compact_str 0.10.0",
  "memchr",

--- a/crates/rsvelte_core/Cargo.toml
+++ b/crates/rsvelte_core/Cargo.toml
@@ -94,7 +94,7 @@ oxc_ast = { version = "0.144", features = ["serialize"] }
 oxc_span = "0.144"
 oxc_diagnostics = "0.144"
 oxc_codegen = "0.144"
-rsvelte_esrap = { version = "=0.10.14", path = "../rsvelte_esrap" }
+rsvelte_esrap = { version = "=0.10.15", path = "../rsvelte_esrap" }
 oxc_syntax = "0.144"
 oxc_semantic = "0.144"
 

--- a/crates/rsvelte_esrap/Cargo.toml
+++ b/crates/rsvelte_esrap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rsvelte_esrap"
-version = "0.10.14"
+version = "0.10.15"
 edition = "2024"
 rust-version = "1.95"
 description = "A Rust port of esrap — prints an oxc AST to JavaScript with esrap's exact layout"

--- a/crates/rsvelte_esrap/src/context.rs
+++ b/crates/rsvelte_esrap/src/context.rs
@@ -16,10 +16,23 @@ use crate::command::{Buffer, EventKind};
 pub struct Context {
     buffer: Buffer,
     returned: Rc<RefCell<Vec<Buffer>>>,
+    measure_base: usize,
     has_newline: bool,
     /// `true` once this context (or an appended child) emitted a newline.
     /// Visitors read it to pick a layout.
     pub multiline: bool,
+}
+
+pub(crate) struct Scope {
+    measure_base: usize,
+    has_newline: bool,
+    multiline: bool,
+}
+
+#[derive(Clone, Copy)]
+pub(crate) struct EventMark {
+    index: usize,
+    offset: u32,
 }
 
 impl Context {
@@ -30,6 +43,7 @@ impl Context {
         Self {
             buffer,
             returned,
+            measure_base: 0,
             has_newline: false,
             multiline: false,
         }
@@ -42,6 +56,7 @@ impl Context {
         Self {
             buffer,
             returned: Rc::clone(&self.returned),
+            measure_base: 0,
             has_newline: false,
             multiline: false,
         }
@@ -104,15 +119,52 @@ impl Context {
         }
     }
 
+    pub(crate) fn begin_scope(&mut self) -> Scope {
+        let scope = Scope {
+            measure_base: self.measure_base,
+            has_newline: self.has_newline,
+            multiline: self.multiline,
+        };
+        self.measure_base = self.buffer.text.len();
+        self.has_newline = false;
+        self.multiline = false;
+        scope
+    }
+
+    pub(crate) fn end_scope(&mut self, scope: Scope) -> bool {
+        let child_multiline = self.multiline;
+        self.measure_base = scope.measure_base;
+        self.has_newline = scope.has_newline;
+        self.multiline = scope.multiline || scope.has_newline || child_multiline;
+        child_multiline
+    }
+
+    pub(crate) fn event_mark(&self) -> EventMark {
+        EventMark {
+            index: self.buffer.events.len(),
+            offset: u32::try_from(self.buffer.text.len()).expect("esrap output exceeds u32"),
+        }
+    }
+
+    pub(crate) fn insert_event(&mut self, mark: EventMark, kind: EventKind) {
+        self.buffer.events.insert(
+            mark.index,
+            crate::command::Event {
+                offset: mark.offset,
+                kind,
+            },
+        );
+    }
+
     /// `true` when nothing with visible content has been written.
     pub const fn empty(&self) -> bool {
-        self.buffer.text.is_empty()
+        self.buffer.text.len() == self.measure_base
     }
 
     /// Total length of the literal strings in this context, ignoring whitespace
     /// sentinels — esrap's `measure`, used to decide if a layout fits on a line.
     pub const fn measure(&self) -> usize {
-        self.buffer.text.len()
+        self.buffer.text.len() - self.measure_base
     }
 
     /// Consume the context, yielding its flat output buffer (for the top-level
@@ -198,5 +250,21 @@ mod tests {
         ctx.space();
         ctx.write("");
         assert_eq!(print(&ctx.into_buffer(), "\t", 0), " ");
+    }
+
+    #[test]
+    fn scope_tracks_local_layout_without_a_child_buffer() {
+        let mut ctx = Context::new();
+        ctx.write("a");
+        let mark = ctx.event_mark();
+        ctx.newline();
+        let scope = ctx.begin_scope();
+        ctx.write("bc");
+        assert_eq!(ctx.measure(), 2);
+        ctx.newline();
+        ctx.write("d");
+        assert!(ctx.end_scope(scope));
+        ctx.insert_event(mark, EventKind::Margin);
+        assert_eq!(print(&ctx.into_buffer(), "\t", 0), "a\n\nbc\nd");
     }
 }

--- a/crates/rsvelte_esrap/src/printer.rs
+++ b/crates/rsvelte_esrap/src/printer.rs
@@ -45,6 +45,7 @@ use oxc_syntax::operator::UnaryOperator;
 use compact_str::{CompactString, format_compact};
 
 use crate::PrintOptions;
+use crate::command::EventKind;
 use crate::context::Context;
 
 fn usize_to_u32(value: usize) -> u32 {
@@ -1026,17 +1027,22 @@ impl<'opt> Printer<'opt> {
         let mut prev: Option<(BodyElem<'a, 'b>, bool)> = None;
         let mut last_end = None;
         while let Some(elem) = elems.next() {
-            let mut child = ctx.child();
-            elem.print(self, &mut child);
-
+            let layout_mark = ctx.event_mark();
+            let mut has_margin = false;
             if let Some((prev_elem, prev_multiline)) = &prev {
-                if child.multiline || *prev_multiline || !elem.same_kind(prev_elem) {
+                has_margin = *prev_multiline || !elem.same_kind(prev_elem);
+                if has_margin {
                     ctx.margin();
                 }
                 ctx.newline();
             }
-            let multiline = child.multiline;
-            ctx.append(child);
+
+            let scope = ctx.begin_scope();
+            elem.print(self, ctx);
+            let multiline = ctx.end_scope(scope);
+            if multiline && prev.is_some() && !has_margin {
+                ctx.insert_event(layout_mark, EventKind::Margin);
+            }
 
             let end = elem.span_end();
             let next = elems.peek().map(BodyElem::span_end);

--- a/crates/rsvelte_esrap/src/printer.rs
+++ b/crates/rsvelte_esrap/src/printer.rs
@@ -2234,20 +2234,18 @@ impl<'opt> Printer<'opt> {
         kw.write(ctx, keyword);
 
         if let [declarator] = decl.declarations.as_slice() {
-            let mut child = ctx.child();
-            self.flush_leading(&mut child, declarator.span().start);
-            self.binding_pattern(&declarator.id, &mut child);
+            self.flush_leading(ctx, declarator.span().start);
+            self.binding_pattern(&declarator.id, ctx);
             if declarator.definite {
-                child.write("!");
+                ctx.write("!");
             }
             if let Some(ann) = &declarator.type_annotation {
-                self.type_annotation(ann, &mut child);
+                self.type_annotation(ann, ctx);
             }
             if let Some(init) = &declarator.init {
-                child.write(" = ");
-                self.print_expression(init, &mut child);
+                ctx.write(" = ");
+                self.print_expression(init, ctx);
             }
-            ctx.append(child);
             return;
         }
 

--- a/crates/rsvelte_lint_types/Cargo.lock
+++ b/crates/rsvelte_lint_types/Cargo.lock
@@ -1111,7 +1111,7 @@ dependencies = [
 
 [[package]]
 name = "rsvelte_esrap"
-version = "0.10.14"
+version = "0.10.15"
 dependencies = [
  "compact_str",
  "memchr",


### PR DESCRIPTION
## Summary

- add scoped local measure and multiline tracking within a shared output buffer
- render body statements directly into the parent buffer and insert only the required leading margin event
- avoid child-buffer allocation, text copying, event rebasing, and pool recycling for each statement
- render single variable declarators directly as well
- release rsvelte_esrap 0.10.15 and update the exact compiler dependency

## Performance

Paired warmed benchmark on the retained AST corpus: 11 files, 50,406 bytes, 200 pairs x 100 iterations.

- this branch: median esrap/OXC 1.944x
- merged PR #2948 baseline: 2.232x before in-place body rendering

The same-buffer optimization is deliberately limited to statement bodies; nested layout decisions still see local measure and multiline state.

## Validation

- cargo test -p rsvelte_esrap --all-targets
- cargo clippy -p rsvelte_esrap --all-targets --all-features -- -D warnings
- cargo fmt --all -- --check
- esrap version bump guard
- changeset package-name guard
- core consumer changeset guard