### PR TITLE
perf(esrap): render block bodies in place

### DIFF
--- a/.changeset/direct-esrap-blocks.md
+++ b/.changeset/direct-esrap-blocks.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/compiler": patch
+---
+
+Render esrap block bodies directly into their parent buffer and specialize comment-free call arguments. Release `rsvelte_esrap` 0.10.17 and update the compiler's exact dependency.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2605,7 +2605,7 @@ dependencies = [
 
 [[package]]
 name = "rsvelte_esrap"
-version = "0.10.16"
+version = "0.10.17"
 dependencies = [
  "compact_str 0.10.0",
  "memchr",

--- a/crates/rsvelte_core/Cargo.toml
+++ b/crates/rsvelte_core/Cargo.toml
@@ -94,7 +94,7 @@ oxc_ast = { version = "0.144", features = ["serialize"] }
 oxc_span = "0.144"
 oxc_diagnostics = "0.144"
 oxc_codegen = "0.144"
-rsvelte_esrap = { version = "=0.10.16", path = "../rsvelte_esrap" }
+rsvelte_esrap = { version = "=0.10.17", path = "../rsvelte_esrap" }
 oxc_syntax = "0.144"
 oxc_semantic = "0.144"
 

--- a/crates/rsvelte_esrap/Cargo.toml
+++ b/crates/rsvelte_esrap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rsvelte_esrap"
-version = "0.10.16"
+version = "0.10.17"
 edition = "2024"
 rust-version = "1.95"
 description = "A Rust port of esrap — prints an oxc AST to JavaScript with esrap's exact layout"

--- a/crates/rsvelte_esrap/src/context.rs
+++ b/crates/rsvelte_esrap/src/context.rs
@@ -25,6 +25,7 @@ pub struct Context {
 
 pub(crate) struct Scope {
     measure_base: usize,
+    event_len: usize,
     has_newline: bool,
     multiline: bool,
 }
@@ -122,6 +123,7 @@ impl Context {
     pub(crate) fn begin_scope(&mut self) -> Scope {
         let scope = Scope {
             measure_base: self.measure_base,
+            event_len: self.buffer.events.len(),
             has_newline: self.has_newline,
             multiline: self.multiline,
         };
@@ -137,6 +139,14 @@ impl Context {
         self.has_newline = scope.has_newline;
         self.multiline = scope.multiline || scope.has_newline || child_multiline;
         child_multiline
+    }
+
+    pub(crate) fn discard_scope(&mut self, scope: Scope) {
+        self.buffer.text.truncate(self.measure_base);
+        self.buffer.events.truncate(scope.event_len);
+        self.measure_base = scope.measure_base;
+        self.has_newline = scope.has_newline;
+        self.multiline = scope.multiline;
     }
 
     pub(crate) fn event_mark(&self) -> EventMark {
@@ -266,5 +276,17 @@ mod tests {
         assert!(ctx.end_scope(scope));
         ctx.insert_event(mark, EventKind::Margin);
         assert_eq!(print(&ctx.into_buffer(), "\t", 0), "a\n\nbc\nd");
+    }
+
+    #[test]
+    fn discarded_scope_removes_text_and_layout_events() {
+        let mut ctx = Context::new();
+        ctx.write("a");
+        let scope = ctx.begin_scope();
+        ctx.newline();
+        ctx.write("bc");
+        ctx.discard_scope(scope);
+        ctx.write("d");
+        assert_eq!(print(&ctx.into_buffer(), "\t", 0), "ad");
     }
 }

--- a/crates/rsvelte_esrap/src/printer.rs
+++ b/crates/rsvelte_esrap/src/printer.rs
@@ -3135,14 +3135,7 @@ impl<'opt> Printer<'opt> {
     /// argument can span lines while the call stays on one line
     /// (`$.run([ … ])`, `foo(a, b, () => { … })`). Length is not a factor.
     #[inline]
-    fn call_argument_direct(
-        &mut self,
-        arg: &Argument,
-        next: Option<u32>,
-        comma: bool,
-        ctx: &mut Context,
-    ) -> bool {
-        let scope = ctx.begin_scope();
+    fn print_argument(&mut self, arg: &Argument, ctx: &mut Context) {
         match arg {
             Argument::SpreadElement(spread) => {
                 ctx.write("...");
@@ -3153,6 +3146,18 @@ impl<'opt> Printer<'opt> {
                 None => self.unsupported("Argument", ctx),
             },
         }
+    }
+
+    #[inline]
+    fn call_argument_direct(
+        &mut self,
+        arg: &Argument,
+        next: Option<u32>,
+        comma: bool,
+        ctx: &mut Context,
+    ) -> bool {
+        let scope = ctx.begin_scope();
+        self.print_argument(arg, ctx);
         if comma {
             ctx.write(",");
         }
@@ -3160,7 +3165,97 @@ impl<'opt> Printer<'opt> {
         ctx.end_scope(scope) || (comma && emitted_line)
     }
 
+    #[inline]
+    fn call_argument_plain(&mut self, arg: &Argument, comma: bool, ctx: &mut Context) -> bool {
+        let scope = ctx.begin_scope();
+        self.print_argument(arg, ctx);
+        if comma {
+            ctx.write(",");
+        }
+        ctx.end_scope(scope)
+    }
+
+    fn call_arguments_plain(&mut self, args: &[Argument], ctx: &mut Context) {
+        match args {
+            [] => ctx.write("()"),
+            [arg] => {
+                ctx.write("(");
+                self.print_argument(arg, ctx);
+                ctx.write(")");
+            }
+            [first, last] => {
+                ctx.write("(");
+                let start = ctx.event_mark();
+                let multiline = self.call_argument_plain(first, true, ctx);
+                let separator = ctx.event_mark();
+                ctx.space();
+                self.print_argument(last, ctx);
+                if multiline {
+                    ctx.insert_event(separator, EventKind::Newline);
+                    ctx.insert_event(start, EventKind::Newline);
+                    ctx.insert_event(start, EventKind::Indent);
+                    ctx.dedent();
+                    ctx.newline();
+                }
+                ctx.write(")");
+            }
+            [first, second, last] => {
+                ctx.write("(");
+                let start = ctx.event_mark();
+                let first_multiline = self.call_argument_plain(first, true, ctx);
+                let first_separator = ctx.event_mark();
+                ctx.space();
+                let second_multiline = self.call_argument_plain(second, true, ctx);
+                let second_separator = ctx.event_mark();
+                ctx.space();
+                self.print_argument(last, ctx);
+                if first_multiline || second_multiline {
+                    ctx.insert_event(second_separator, EventKind::Newline);
+                    ctx.insert_event(first_separator, EventKind::Newline);
+                    ctx.insert_event(start, EventKind::Newline);
+                    ctx.insert_event(start, EventKind::Indent);
+                    ctx.dedent();
+                    ctx.newline();
+                }
+                ctx.write(")");
+            }
+            _ => {
+                ctx.write("(");
+                let start = ctx.event_mark();
+                let mut separators = Vec::with_capacity(args.len() - 1);
+                let mut multiline = false;
+                for (i, arg) in args.iter().enumerate() {
+                    let is_last = i == args.len() - 1;
+                    if i > 0 {
+                        separators.push(ctx.event_mark());
+                        ctx.space();
+                    }
+                    if is_last {
+                        self.print_argument(arg, ctx);
+                    } else {
+                        multiline |= self.call_argument_plain(arg, true, ctx);
+                    }
+                }
+                if multiline {
+                    for separator in separators.into_iter().rev() {
+                        ctx.insert_event(separator, EventKind::Newline);
+                    }
+                    ctx.insert_event(start, EventKind::Newline);
+                    ctx.insert_event(start, EventKind::Indent);
+                    ctx.dedent();
+                    ctx.newline();
+                }
+                ctx.write(")");
+            }
+        }
+    }
+
     fn call_arguments(&mut self, args: &[Argument], call_end: u32, ctx: &mut Context) {
+        if self.comments.is_empty() {
+            self.call_arguments_plain(args, ctx);
+            return;
+        }
+
         let n = args.len();
 
         if let [arg] = args {
@@ -3177,16 +3272,7 @@ impl<'opt> Printer<'opt> {
                 ctx.indent();
                 ctx.newline();
             }
-            match arg {
-                Argument::SpreadElement(spread) => {
-                    ctx.write("...");
-                    self.print_expression(&spread.argument, ctx);
-                }
-                _ => match arg.as_expression() {
-                    Some(expression) => self.print_expression(expression, ctx),
-                    None => self.unsupported("Argument", ctx),
-                },
-            }
+            self.print_argument(arg, ctx);
             self.flush_trailing_comments(ctx, arg.span().end, Some(call_end));
             if wrap {
                 ctx.dedent();

--- a/crates/rsvelte_esrap/src/printer.rs
+++ b/crates/rsvelte_esrap/src/printer.rs
@@ -1641,7 +1641,8 @@ impl<'opt> Printer<'opt> {
     fn class_body(&mut self, body: &ClassBody, ctx: &mut Context) {
         let span = body.span();
         ctx.write("{");
-        let mut child = ctx.child();
+        let mark = ctx.event_mark();
+        let scope = ctx.begin_scope();
         let elems = body
             .body
             .iter()
@@ -1649,11 +1650,13 @@ impl<'opt> Printer<'opt> {
             // not statements and have no printer mapping here, so drop them.
             .filter(|e| !matches!(e, ClassElement::TSIndexSignature(_)))
             .map(BodyElem::ClassMember);
-        self.body_elems(elems, Some(span.start), span.end, &mut child);
-        if !child.empty() {
-            ctx.indent();
-            ctx.newline();
-            ctx.append(child);
+        self.body_elems(elems, Some(span.start), span.end, ctx);
+        if ctx.empty() {
+            ctx.discard_scope(scope);
+        } else {
+            ctx.end_scope(scope);
+            ctx.insert_event(mark, EventKind::Newline);
+            ctx.insert_event(mark, EventKind::Indent);
             ctx.dedent();
             ctx.newline();
         }
@@ -2206,18 +2209,19 @@ impl<'opt> Printer<'opt> {
         }
     }
 
-    /// esrap's `BlockStatement|ClassBody`: build the body into a child context,
-    /// and only break it across lines when it has real content (so an empty body
-    /// stays `{}`). The `Newline`s are idempotent flags, so body's trailing
-    /// newline and the closing one collapse to a single line break before `}`.
+    /// esrap's `BlockStatement|ClassBody`: only break a body across lines when
+    /// it has real content, so an empty body stays `{}`.
     fn block(&mut self, body: &[Statement], body_start: u32, body_end: u32, ctx: &mut Context) {
         ctx.write("{");
-        let mut child = ctx.child();
-        self.body(body, body_start, body_end, &mut child);
-        if !child.empty() {
-            ctx.indent();
-            ctx.newline();
-            ctx.append(child);
+        let mark = ctx.event_mark();
+        let scope = ctx.begin_scope();
+        self.body(body, body_start, body_end, ctx);
+        if ctx.empty() {
+            ctx.discard_scope(scope);
+        } else {
+            ctx.end_scope(scope);
+            ctx.insert_event(mark, EventKind::Newline);
+            ctx.insert_event(mark, EventKind::Indent);
             ctx.dedent();
             ctx.newline();
         }

--- a/crates/rsvelte_lint_types/Cargo.lock
+++ b/crates/rsvelte_lint_types/Cargo.lock
@@ -1111,7 +1111,7 @@ dependencies = [
 
 [[package]]
 name = "rsvelte_esrap"
-version = "0.10.16"
+version = "0.10.17"
 dependencies = [
  "compact_str",
  "memchr",


### PR DESCRIPTION
## Summary

- render statement and class block bodies directly in the parent output buffer
- roll back layout-only events for empty bodies so `{}` remains byte-identical
- specialize comment-free call arguments while preserving the existing comment-aware path
- release `rsvelte_esrap` 0.10.17 and update exact consumers

## Performance

Pinned 11-file / 50,406-byte retained-AST harness, 200 paired A→B→B→A rounds × 100 iterations:

- before (#2950): median esrap/OXC 1.780x
- after: median esrap/OXC 1.638x

The block-only intermediate measured 1.673x; the comment-free call path reduced it further.

## Validation

- `cargo test -p rsvelte_esrap`
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- changeset package-name, esrap version-gate self-test, esrap version-bump, and lint-types lockfile guards
