### PR TITLE
perf(esrap): streamline plain output writes

### DIFF
--- a/.changeset/fast-esrap-output.md
+++ b/.changeset/fast-esrap-output.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/compiler": patch
+---
+
+Flatten plain output in one pass and write short syntax fragments without temporary formatting buffers. Release `rsvelte_esrap` 0.10.18 and update the compiler's exact dependency.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2605,7 +2605,7 @@ dependencies = [
 
 [[package]]
 name = "rsvelte_esrap"
-version = "0.10.17"
+version = "0.10.18"
 dependencies = [
  "compact_str 0.10.0",
  "memchr",

--- a/crates/rsvelte_core/Cargo.toml
+++ b/crates/rsvelte_core/Cargo.toml
@@ -94,7 +94,7 @@ oxc_ast = { version = "0.144", features = ["serialize"] }
 oxc_span = "0.144"
 oxc_diagnostics = "0.144"
 oxc_codegen = "0.144"
-rsvelte_esrap = { version = "=0.10.17", path = "../rsvelte_esrap" }
+rsvelte_esrap = { version = "=0.10.18", path = "../rsvelte_esrap" }
 oxc_syntax = "0.144"
 oxc_semantic = "0.144"
 

--- a/crates/rsvelte_esrap/Cargo.toml
+++ b/crates/rsvelte_esrap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rsvelte_esrap"
-version = "0.10.17"
+version = "0.10.18"
 edition = "2024"
 rust-version = "1.95"
 description = "A Rust port of esrap — prints an oxc AST to JavaScript with esrap's exact layout"

--- a/crates/rsvelte_esrap/src/command.rs
+++ b/crates/rsvelte_esrap/src/command.rs
@@ -60,23 +60,60 @@ pub struct Mapping {
 }
 
 pub(crate) fn print(buffer: &Buffer, indent: &str, capacity: usize) -> String {
-    let mut driver = CodeDriver {
-        code: String::with_capacity(capacity),
-        current_newline: String::from("\n"),
-        indent,
-        needs_newline: false,
-        needs_margin: false,
-        needs_space: false,
-    };
-    drive(buffer, |text, event| {
-        if !text.is_empty() {
-            driver.append(text);
+    let mut code = String::with_capacity(capacity);
+    let mut current_newline = String::from("\n");
+    let mut needs_newline = false;
+    let mut needs_margin = false;
+    let mut needs_space = false;
+    let mut cursor = 0;
+
+    macro_rules! flush_pending {
+        () => {{
+            if needs_newline {
+                if needs_margin {
+                    code.push('\n');
+                }
+                code.push_str(&current_newline);
+            } else if needs_space {
+                code.push(' ');
+            }
+            needs_newline = false;
+            needs_margin = false;
+            needs_space = false;
+        }};
+    }
+
+    for item in &buffer.events {
+        let offset = item.offset as usize;
+        if offset > cursor {
+            flush_pending!();
+            code.push_str(&buffer.text[cursor..offset]);
+            cursor = offset;
         }
-        if let Some(event) = event {
-            driver.event(event);
+        match item.kind {
+            EventKind::Newline => needs_newline = true,
+            EventKind::Margin => needs_margin = true,
+            EventKind::Space => needs_space = true,
+            EventKind::Indent => current_newline.push_str(indent),
+            EventKind::Dedent => {
+                let len = current_newline.len().saturating_sub(indent.len());
+                current_newline.truncate(len);
+            }
+            EventKind::Flush | EventKind::Location { .. } => flush_pending!(),
         }
-    });
-    driver.code
+    }
+    if cursor < buffer.text.len() {
+        if needs_newline {
+            if needs_margin {
+                code.push('\n');
+            }
+            code.push_str(&current_newline);
+        } else if needs_space {
+            code.push(' ');
+        }
+        code.push_str(&buffer.text[cursor..]);
+    }
+    code
 }
 
 pub(crate) fn flatten_with_map(
@@ -119,50 +156,6 @@ fn drive(buffer: &Buffer, mut visit: impl FnMut(&str, Option<EventKind>)) {
     }
     if cursor < buffer.text.len() {
         visit(&buffer.text[cursor..], None);
-    }
-}
-
-struct CodeDriver<'a> {
-    code: String,
-    current_newline: String,
-    indent: &'a str,
-    needs_newline: bool,
-    needs_margin: bool,
-    needs_space: bool,
-}
-
-impl CodeDriver<'_> {
-    fn event(&mut self, event: EventKind) {
-        match event {
-            EventKind::Newline => self.needs_newline = true,
-            EventKind::Margin => self.needs_margin = true,
-            EventKind::Space => self.needs_space = true,
-            EventKind::Indent => self.current_newline.push_str(self.indent),
-            EventKind::Dedent => {
-                let len = self.current_newline.len().saturating_sub(self.indent.len());
-                self.current_newline.truncate(len);
-            }
-            EventKind::Flush | EventKind::Location { .. } => self.flush_pending(),
-        }
-    }
-
-    fn append(&mut self, text: &str) {
-        self.flush_pending();
-        self.code.push_str(text);
-    }
-
-    fn flush_pending(&mut self) {
-        if self.needs_newline {
-            if self.needs_margin {
-                self.code.push('\n');
-            }
-            self.code.push_str(&self.current_newline);
-        } else if self.needs_space {
-            self.code.push(' ');
-        }
-        self.needs_newline = false;
-        self.needs_margin = false;
-        self.needs_space = false;
     }
 }
 

--- a/crates/rsvelte_esrap/src/printer.rs
+++ b/crates/rsvelte_esrap/src/printer.rs
@@ -1218,14 +1218,22 @@ impl<'opt> Printer<'opt> {
                 self.print_statement(&s.body, ctx);
             }
             Statement::EmptyStatement(_) => ctx.write(";"),
-            Statement::BreakStatement(s) => match &s.label {
-                Some(l) => ctx.write(format_compact!("break {};", l.name)),
-                None => ctx.write("break;"),
-            },
-            Statement::ContinueStatement(s) => match &s.label {
-                Some(l) => ctx.write(format_compact!("continue {};", l.name)),
-                None => ctx.write("continue;"),
-            },
+            Statement::BreakStatement(s) => {
+                ctx.write("break");
+                if let Some(label) = &s.label {
+                    ctx.write(" ");
+                    ctx.write(label.name.as_str());
+                }
+                ctx.write(";");
+            }
+            Statement::ContinueStatement(s) => {
+                ctx.write("continue");
+                if let Some(label) = &s.label {
+                    ctx.write(" ");
+                    ctx.write(label.name.as_str());
+                }
+                ctx.write(";");
+            }
             Statement::TSTypeAliasDeclaration(d) => self.type_alias_declaration(d, ctx),
             Statement::TSInterfaceDeclaration(d) => self.interface_declaration(d, ctx),
             Statement::TSEnumDeclaration(d) => self.enum_declaration(d, ctx),
@@ -1278,7 +1286,8 @@ impl<'opt> Printer<'opt> {
             }
         }
         if let Some(ns) = namespace_spec {
-            ctx.write(format_compact!("* as {}", ns.local.name));
+            ctx.write("* as ");
+            ctx.write(ns.local.name.as_str());
         }
         if !named.is_empty() {
             ctx.write("{");
@@ -1445,7 +1454,8 @@ impl<'opt> Printer<'opt> {
         ctx.write("`");
         for (i, expr) in node.expressions.iter().enumerate() {
             let raw = node.quasis.get(i).map_or("", |q| q.value.raw.as_str());
-            ctx.write(format_compact!("{raw}${{"));
+            ctx.write(raw);
+            ctx.write("${");
             self.print_expression(expr, ctx);
             ctx.write("}");
             // A newline *inside* the literal makes the enclosing context
@@ -1456,7 +1466,8 @@ impl<'opt> Printer<'opt> {
         }
         if let Some(last) = node.quasis.last() {
             let raw = last.value.raw.as_str();
-            ctx.write(format_compact!("{raw}`"));
+            ctx.write(raw);
+            ctx.write("`");
             if raw.contains('\n') {
                 ctx.multiline = true;
             }
@@ -1756,7 +1767,8 @@ impl<'opt> Printer<'opt> {
             self.decorator(decorator, ctx);
         }
         if let Some(acc) = &node.accessibility {
-            ctx.write(format_compact!("{} ", accessibility_str(*acc)));
+            ctx.write(accessibility_str(*acc));
+            ctx.write(" ");
         }
         if matches!(
             node.r#type,
@@ -1804,7 +1816,8 @@ impl<'opt> Printer<'opt> {
             self.decorator(decorator, ctx);
         }
         if let Some(acc) = &node.accessibility {
-            ctx.write(format_compact!("{} ", accessibility_str(*acc)));
+            ctx.write(accessibility_str(*acc));
+            ctx.write(" ");
         }
         if matches!(
             node.r#type,
@@ -2140,7 +2153,8 @@ impl<'opt> Printer<'opt> {
                 } else if i - this_len < item_len {
                     let param = &params.items[i - this_len];
                     if let Some(acc) = &param.accessibility {
-                        child.write(format_compact!("{} ", accessibility_str(*acc)));
+                        child.write(accessibility_str(*acc));
+                        child.write(" ");
                     }
                     if param.readonly {
                         child.write("readonly ");
@@ -2396,7 +2410,8 @@ impl<'opt> Printer<'opt> {
             Expression::PrivateFieldExpression(m) => {
                 self.child_with_parens(&m.object, 19, ctx);
                 ctx.write(if m.optional { "?." } else { "." });
-                ctx.write(format_compact!("#{}", m.field.name));
+                ctx.write("#");
+                ctx.write(m.field.name.as_str());
             }
             Expression::ImportMeta(_) => {
                 ctx.write("import");
@@ -2683,14 +2698,18 @@ impl<'opt> Printer<'opt> {
     fn binary_expression(&mut self, node: &BinaryExpression, ctx: &mut Context) {
         let op = node.operator.as_str();
         self.binary_child(&node.left, false, op, false, ctx);
-        ctx.write(format_compact!(" {op} "));
+        ctx.write(" ");
+        ctx.write(op);
+        ctx.write(" ");
         self.binary_child(&node.right, false, op, true, ctx);
     }
 
     fn logical_expression(&mut self, node: &LogicalExpression, ctx: &mut Context) {
         let op = node.operator.as_str();
         self.binary_child(&node.left, true, op, false, ctx);
-        ctx.write(format_compact!(" {op} "));
+        ctx.write(" ");
+        ctx.write(op);
+        ctx.write(" ");
         self.binary_child(&node.right, true, op, true, ctx);
     }
 
@@ -2721,7 +2740,8 @@ impl<'opt> Printer<'opt> {
             node.operator,
             UnaryOperator::Typeof | UnaryOperator::Void | UnaryOperator::Delete
         ) {
-            ctx.write(format_compact!("{op} "));
+            ctx.write(op);
+            ctx.write(" ");
         } else {
             ctx.write(op);
         }
@@ -2767,7 +2787,9 @@ impl<'opt> Printer<'opt> {
     fn assignment_expression(&mut self, node: &AssignmentExpression, ctx: &mut Context) {
         // esrap visits both sides without adding parens.
         self.assignment_target(&node.left, ctx);
-        ctx.write(format_compact!(" {} ", node.operator.as_str()));
+        ctx.write(" ");
+        ctx.write(node.operator.as_str());
+        ctx.write(" ");
         self.print_expression(&node.right, ctx);
     }
 
@@ -2781,7 +2803,8 @@ impl<'opt> Printer<'opt> {
             SimpleAssignmentTarget::PrivateFieldExpression(m) => {
                 self.child_with_parens(&m.object, 19, ctx);
                 ctx.write(if m.optional { "?." } else { "." });
-                ctx.write(format_compact!("#{}", m.field.name));
+                ctx.write("#");
+                ctx.write(m.field.name.as_str());
             }
             _ => self.unsupported("SimpleAssignmentTarget", ctx),
         }
@@ -2795,7 +2818,8 @@ impl<'opt> Printer<'opt> {
             AssignmentTarget::PrivateFieldExpression(m) => {
                 self.child_with_parens(&m.object, 19, ctx);
                 ctx.write(if m.optional { "?." } else { "." });
-                ctx.write(format_compact!("#{}", m.field.name));
+                ctx.write("#");
+                ctx.write(m.field.name.as_str());
             }
             AssignmentTarget::ArrayAssignmentTarget(a) => {
                 ctx.write("[");
@@ -3113,7 +3137,10 @@ impl<'opt> Printer<'opt> {
     fn property_key(&mut self, key: &PropertyKey, ctx: &mut Context) {
         match key {
             PropertyKey::StaticIdentifier(id) => ctx.write(id.name.as_str()),
-            PropertyKey::PrivateIdentifier(id) => ctx.write(format_compact!("#{}", id.name)),
+            PropertyKey::PrivateIdentifier(id) => {
+                ctx.write("#");
+                ctx.write(id.name.as_str());
+            }
             PropertyKey::StringLiteral(s) => ctx.write(Self::string_literal(s)),
             PropertyKey::NumericLiteral(n) => ctx.write(literal_raw(
                 n.raw.as_ref().map(oxc_ast::ast::Str::as_str),
@@ -3515,7 +3542,8 @@ impl<'opt> Printer<'opt> {
             }
             TSType::TSLiteralType(t) => self.ts_literal(&t.literal, ctx),
             TSType::TSTypeOperatorType(t) => {
-                ctx.write(format_compact!("{} ", ts_type_operator_str(t.operator)));
+                ctx.write(ts_type_operator_str(t.operator));
+                ctx.write(" ");
                 self.print_type(&t.type_annotation, ctx);
             }
             TSType::TSTypeQuery(t) => {
@@ -3582,7 +3610,8 @@ impl<'opt> Printer<'opt> {
                 ctx.write("`");
                 for (i, inner) in t.types.iter().enumerate() {
                     let raw = t.quasis.get(i).map_or("", |q| q.value.raw.as_str());
-                    ctx.write(format_compact!("{raw}${{"));
+                    ctx.write(raw);
+                    ctx.write("${");
                     self.print_type(inner, ctx);
                     ctx.write("}");
                     if raw.contains('\n') {
@@ -3590,7 +3619,8 @@ impl<'opt> Printer<'opt> {
                     }
                 }
                 if let Some(last) = t.quasis.last() {
-                    ctx.write(format_compact!("{}`", last.value.raw));
+                    ctx.write(last.value.raw.as_str());
+                    ctx.write("`");
                 }
             }
             other => self.unsupported(ts_type_kind(other), ctx),

--- a/crates/rsvelte_lint_types/Cargo.lock
+++ b/crates/rsvelte_lint_types/Cargo.lock
@@ -1111,7 +1111,7 @@ dependencies = [
 
 [[package]]
 name = "rsvelte_esrap"
-version = "0.10.17"
+version = "0.10.18"
 dependencies = [
  "compact_str",
  "memchr",


### PR DESCRIPTION
## Summary

- flatten plain esrap output with one specialized event/text loop
- avoid temporary `CompactString` formatting buffers for common short syntax fragments
- release `rsvelte_esrap` 0.10.18 and update the compiler's exact dependency

## Performance

On the existing 11-file, 50,406-byte paired retained-AST harness (200 pairs × 100 iterations), the median esrap/OXC ratio was 1.482x, 1.468x, and 1.473x across three runs. The merged baseline was 1.638x under the same setup.

## Validation

- `cargo test -p rsvelte_esrap`
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- release changeset/version/lock guards
