### PR TITLE
perf(esrap): specialize comment-free printing

### DIFF
--- a/.changeset/quiet-esrap-comments.md
+++ b/.changeset/quiet-esrap-comments.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/compiler": patch
+---
+
+Specialize esrap's comment-free printer so comment placement checks are eliminated from its hot AST traversal. Release `rsvelte_esrap` 0.10.19 and update the compiler's exact dependency.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2605,7 +2605,7 @@ dependencies = [
 
 [[package]]
 name = "rsvelte_esrap"
-version = "0.10.18"
+version = "0.10.19"
 dependencies = [
  "compact_str 0.10.0",
  "memchr",

--- a/crates/rsvelte_core/Cargo.toml
+++ b/crates/rsvelte_core/Cargo.toml
@@ -94,7 +94,7 @@ oxc_ast = { version = "0.144", features = ["serialize"] }
 oxc_span = "0.144"
 oxc_diagnostics = "0.144"
 oxc_codegen = "0.144"
-rsvelte_esrap = { version = "=0.10.18", path = "../rsvelte_esrap" }
+rsvelte_esrap = { version = "=0.10.19", path = "../rsvelte_esrap" }
 oxc_syntax = "0.144"
 oxc_semantic = "0.144"
 

--- a/crates/rsvelte_esrap/Cargo.toml
+++ b/crates/rsvelte_esrap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rsvelte_esrap"
-version = "0.10.18"
+version = "0.10.19"
 edition = "2024"
 rust-version = "1.95"
 description = "A Rust port of esrap — prints an oxc AST to JavaScript with esrap's exact layout"

--- a/crates/rsvelte_esrap/src/internal_tests/golden.rs
+++ b/crates/rsvelte_esrap/src/internal_tests/golden.rs
@@ -91,7 +91,7 @@ fn reprint(source: &str) -> Option<Reprint> {
     let opts = PrintOptions::default();
     let line_starts = crate::printer::line_starts(source);
     let comments = crate::printer::build_comments(&ret.program, source, &line_starts);
-    let mut printer = Printer::with_comments(&opts, comments, line_starts);
+    let mut printer = Printer::<true>::with_comments(&opts, comments, line_starts);
     let mut ctx = Context::new();
     printer.print_program(&ret.program, &mut ctx);
     Some(Reprint {

--- a/crates/rsvelte_esrap/src/lib.rs
+++ b/crates/rsvelte_esrap/src/lib.rs
@@ -110,7 +110,21 @@ pub fn print(program: &Program<'_>, source: &str) -> String {
 /// Print `program` to JavaScript with explicit options, interleaving comments.
 pub fn print_with(program: &Program<'_>, source: &str, options: &PrintOptions) -> String {
     let (comments, line_starts) = comments_and_line_starts(program, source);
-    let mut printer = printer::Printer::with_comments(options, comments, line_starts);
+    if comments.is_empty() {
+        print_with_impl::<false>(program, options, comments, line_starts)
+    } else {
+        print_with_impl::<true>(program, options, comments, line_starts)
+    }
+}
+
+fn print_with_impl<const HAS_COMMENTS: bool>(
+    program: &Program<'_>,
+    options: &PrintOptions,
+    comments: Vec<printer::Cmt>,
+    line_starts: Vec<u32>,
+) -> String {
+    let mut printer =
+        printer::Printer::<HAS_COMMENTS>::with_comments(options, comments, line_starts);
     let mut ctx = context::Context::new();
     printer.print_program(program, &mut ctx);
     let capacity = ctx.measure();
@@ -149,8 +163,45 @@ pub fn print_split(
 ) -> PrintWithMap {
     let (comments, line_starts) = comments_and_line_starts(program, comment_source);
     let map_line_starts = map_source.map(printer::line_starts).unwrap_or_default();
-    let mut printer = printer::Printer::with_comments(options, comments, line_starts)
-        .with_split_coordinates(map_line_starts, loc_base, loc_map, map_source.is_some());
+    if comments.is_empty() {
+        print_split_impl::<false>(
+            program,
+            loc_base,
+            map_source,
+            loc_map,
+            options,
+            comments,
+            line_starts,
+            map_line_starts,
+        )
+    } else {
+        print_split_impl::<true>(
+            program,
+            loc_base,
+            map_source,
+            loc_map,
+            options,
+            comments,
+            line_starts,
+            map_line_starts,
+        )
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn print_split_impl<const HAS_COMMENTS: bool>(
+    program: &Program<'_>,
+    loc_base: u32,
+    map_source: Option<&str>,
+    loc_map: &[(u32, u32, Option<u32>)],
+    options: &PrintOptions,
+    comments: Vec<printer::Cmt>,
+    line_starts: Vec<u32>,
+    map_line_starts: Vec<u32>,
+) -> PrintWithMap {
+    let mut printer =
+        printer::Printer::<HAS_COMMENTS>::with_comments(options, comments, line_starts)
+            .with_split_coordinates(map_line_starts, loc_base, loc_map, map_source.is_some());
     let mut ctx = context::Context::new();
     printer.print_program(program, &mut ctx);
     let capacity = ctx.measure();
@@ -187,8 +238,22 @@ pub struct PrintWithMap {
 pub fn print_with_map(program: &Program<'_>, source: &str, options: &PrintOptions) -> PrintWithMap {
     let line_starts = printer::line_starts(source);
     let comments = printer::build_comments(program, source, &line_starts);
+    if comments.is_empty() {
+        print_with_map_impl::<false>(program, options, comments, line_starts)
+    } else {
+        print_with_map_impl::<true>(program, options, comments, line_starts)
+    }
+}
+
+fn print_with_map_impl<const HAS_COMMENTS: bool>(
+    program: &Program<'_>,
+    options: &PrintOptions,
+    comments: Vec<printer::Cmt>,
+    line_starts: Vec<u32>,
+) -> PrintWithMap {
     let mut printer =
-        printer::Printer::with_comments(options, comments, line_starts).with_source_map();
+        printer::Printer::<HAS_COMMENTS>::with_comments(options, comments, line_starts)
+            .with_source_map();
     let mut ctx = context::Context::new();
     printer.print_program(program, &mut ctx);
     let capacity = ctx.measure();

--- a/crates/rsvelte_esrap/src/printer.rs
+++ b/crates/rsvelte_esrap/src/printer.rs
@@ -76,7 +76,9 @@ impl KeywordCursor {
         if let Some((line, col)) = self.cursor {
             ctx.location(line, col);
             ctx.write(fragment);
-            self.cursor = Some((line, col + usize_to_u32(fragment.len())));
+            let next_col = col + usize_to_u32(fragment.len());
+            ctx.location(line, next_col);
+            self.cursor = Some((line, next_col));
         } else {
             ctx.write(fragment);
         }

--- a/crates/rsvelte_esrap/src/printer.rs
+++ b/crates/rsvelte_esrap/src/printer.rs
@@ -74,7 +74,8 @@ impl KeywordCursor {
     /// active, otherwise a plain write.
     fn write(&mut self, ctx: &mut Context, fragment: &str) {
         if let Some((line, col)) = self.cursor {
-            Printer::write_source_keyword(ctx, line, col, fragment);
+            ctx.location(line, col);
+            ctx.write(fragment);
             self.cursor = Some((line, col + usize_to_u32(fragment.len())));
         } else {
             ctx.write(fragment);
@@ -82,7 +83,7 @@ impl KeywordCursor {
     }
 }
 
-pub struct Printer<'opt> {
+pub struct Printer<'opt, const HAS_COMMENTS: bool = true> {
     options: &'opt PrintOptions,
     emit_locations: bool,
     /// Set by the first unsupported node encountered; printing continues so the
@@ -414,7 +415,7 @@ fn arrow_concise_body_needs_wrap(body: &Expression) -> bool {
     }
 }
 
-impl<'opt> Printer<'opt> {
+impl<'opt, const HAS_COMMENTS: bool> Printer<'opt, HAS_COMMENTS> {
     #[cfg(test)]
     pub const fn new(options: &'opt PrintOptions) -> Self {
         Self {
@@ -625,6 +626,9 @@ impl<'opt> Printer<'opt> {
         from_line: Option<u32>,
         pad: bool,
     ) {
+        if !HAS_COMMENTS {
+            return;
+        }
         if !self.has_loc(to) {
             return;
         }
@@ -664,7 +668,7 @@ impl<'opt> Printer<'opt> {
         prev_end: u32,
         next: Option<u32>,
     ) -> bool {
-        if self.comments.is_empty() || !self.has_loc(prev_end) {
+        if !HAS_COMMENTS || !self.has_loc(prev_end) {
             return false;
         }
         // A `next` boundary that is itself synthesized bounds nothing (esrap's
@@ -697,6 +701,9 @@ impl<'opt> Printer<'opt> {
     /// `None` and synthesized offsets are esrap's `!node.loc`, which discards
     /// every pending comment instead of carrying the cursor forward.
     fn reset_comment_index(&mut self, node_start: Option<u32>) {
+        if !HAS_COMMENTS {
+            return;
+        }
         let Some(node_start) = node_start else {
             self.comment_index = self.comments.len();
             return;
@@ -722,7 +729,7 @@ impl<'opt> Printer<'opt> {
 
     /// The `_` wildcard's leading flush: emit comments positioned before `node`.
     fn flush_leading(&mut self, ctx: &mut Context, node_start: u32) {
-        if self.comments.is_empty() {
+        if !HAS_COMMENTS {
             return;
         }
         self.flush_comments_until(ctx, node_start, self.line_of(node_start), None, true);
@@ -741,7 +748,7 @@ impl<'opt> Printer<'opt> {
     /// limit for the closing `flush_comments_until`.
     fn sequence(
         &mut self,
-        mut nodes: Vec<SeqNode<'_>>,
+        mut nodes: Vec<SeqNode<'_, HAS_COMMENTS>>,
         until: Option<u32>,
         pad: bool,
         separator: &'static str,
@@ -1067,7 +1074,7 @@ impl<'opt> Printer<'opt> {
         // block (`() => { /* x */ }`); the lone pending newline keeps the block
         // `empty()`, so a comment-free `{}` is unaffected.
         ctx.newline();
-        if !self.comments.is_empty()
+        if HAS_COMMENTS
             && body_start.is_some_and(|start| self.has_loc(start))
             && self.has_loc(body_end)
         {
@@ -1126,10 +1133,11 @@ impl<'opt> Printer<'opt> {
                     // acorn AST has no paren node: with oxc's preserved parens
                     // `return (/*c*/ x)` would otherwise anchor at the `(`, which
                     // precedes the comment, and the rule would never fire.
-                    let contains_comment = self
-                        .comments
-                        .get(self.comment_index)
-                        .is_some_and(|c| c.start < unparen(arg).span().start);
+                    let contains_comment = HAS_COMMENTS
+                        && self
+                            .comments
+                            .get(self.comment_index)
+                            .is_some_and(|c| c.start < unparen(arg).span().start);
                     let start = s.span().start;
                     if contains_comment {
                         self.write_keyword(ctx, start, "return", " (");
@@ -1302,7 +1310,7 @@ impl<'opt> Printer<'opt> {
                         is_elision: false,
                     }
                 },
-                |_p, s, child| Printer::import_specifier(s, child),
+                |_p, s, child| Printer::<HAS_COMMENTS>::import_specifier(s, child),
                 None,
                 true,
                 ",",
@@ -1398,7 +1406,7 @@ impl<'opt> Printer<'opt> {
                     is_elision: false,
                 }
             },
-            |_p, s, child| Printer::export_specifier(s, child),
+            |_p, s, child| Printer::<HAS_COMMENTS>::export_specifier(s, child),
             None,
             true,
             ",",
@@ -1615,7 +1623,7 @@ impl<'opt> Printer<'opt> {
         }
         if !node.implements.is_empty() {
             ctx.write("implements");
-            let nodes: Vec<SeqNode> = node
+            let nodes: Vec<SeqNode<HAS_COMMENTS>> = node
                 .implements
                 .iter()
                 .map(|imp| {
@@ -1625,12 +1633,14 @@ impl<'opt> Printer<'opt> {
                         end: Some(span.end),
                         obj_or_array: false,
                         is_elision: false,
-                        render: Box::new(move |p: &mut Printer, child: &mut Context| {
-                            Printer::print_type_name(&imp.expression, child);
-                            if let Some(ta) = &imp.type_arguments {
-                                p.type_parameter_instantiation(ta, child);
-                            }
-                        }),
+                        render: Box::new(
+                            move |p: &mut Printer<'_, HAS_COMMENTS>, child: &mut Context| {
+                                Printer::<HAS_COMMENTS>::print_type_name(&imp.expression, child);
+                                if let Some(ta) = &imp.type_arguments {
+                                    p.type_parameter_instantiation(ta, child);
+                                }
+                            },
+                        ),
                     }
                 })
                 .collect();
@@ -3278,7 +3288,7 @@ impl<'opt> Printer<'opt> {
     }
 
     fn call_arguments(&mut self, args: &[Argument], call_end: u32, ctx: &mut Context) {
-        if self.comments.is_empty() {
+        if !HAS_COMMENTS {
             self.call_arguments_plain(args, ctx);
             return;
         }
@@ -3729,7 +3739,7 @@ impl<'opt> Printer<'opt> {
     }
 
     /// Build [`SeqNode`]s for a list of types (union/intersection).
-    fn type_seq_nodes<'p>(types: &'p [TSType<'p>]) -> Vec<SeqNode<'p>> {
+    fn type_seq_nodes<'p>(types: &'p [TSType<'p>]) -> Vec<SeqNode<'p, HAS_COMMENTS>> {
         types
             .iter()
             .map(|ty| {
@@ -3739,15 +3749,19 @@ impl<'opt> Printer<'opt> {
                     end: Some(span.end),
                     obj_or_array: false,
                     is_elision: false,
-                    render: Box::new(move |p: &mut Printer, child: &mut Context| {
-                        p.print_type(ty, child);
-                    }),
+                    render: Box::new(
+                        move |p: &mut Printer<'_, HAS_COMMENTS>, child: &mut Context| {
+                            p.print_type(ty, child);
+                        },
+                    ),
                 }
             })
             .collect()
     }
 
-    fn tuple_element_seq_nodes<'p>(els: &'p [TSTupleElement<'p>]) -> Vec<SeqNode<'p>> {
+    fn tuple_element_seq_nodes<'p>(
+        els: &'p [TSTupleElement<'p>],
+    ) -> Vec<SeqNode<'p, HAS_COMMENTS>> {
         els.iter()
             .map(|el| {
                 let span = el.span();
@@ -3756,15 +3770,17 @@ impl<'opt> Printer<'opt> {
                     end: Some(span.end),
                     obj_or_array: false,
                     is_elision: false,
-                    render: Box::new(move |p: &mut Printer, child: &mut Context| {
-                        p.tuple_element(el, child);
-                    }),
+                    render: Box::new(
+                        move |p: &mut Printer<'_, HAS_COMMENTS>, child: &mut Context| {
+                            p.tuple_element(el, child);
+                        },
+                    ),
                 }
             })
             .collect()
     }
 
-    fn signature_seq_nodes<'p>(members: &'p [TSSignature<'p>]) -> Vec<SeqNode<'p>> {
+    fn signature_seq_nodes<'p>(members: &'p [TSSignature<'p>]) -> Vec<SeqNode<'p, HAS_COMMENTS>> {
         members
             .iter()
             .map(|m| {
@@ -3774,9 +3790,11 @@ impl<'opt> Printer<'opt> {
                     end: Some(span.end),
                     obj_or_array: false,
                     is_elision: false,
-                    render: Box::new(move |p: &mut Printer, child: &mut Context| {
-                        p.signature(m, child);
-                    }),
+                    render: Box::new(
+                        move |p: &mut Printer<'_, HAS_COMMENTS>, child: &mut Context| {
+                            p.signature(m, child);
+                        },
+                    ),
                 }
             })
             .collect()
@@ -3887,7 +3905,7 @@ impl<'opt> Printer<'opt> {
         }
         if !node.extends.is_empty() {
             ctx.write(" extends ");
-            let nodes: Vec<SeqNode> = node
+            let nodes: Vec<SeqNode<HAS_COMMENTS>> = node
                 .extends
                 .iter()
                 .map(|h| {
@@ -3897,12 +3915,14 @@ impl<'opt> Printer<'opt> {
                         end: Some(span.end),
                         obj_or_array: false,
                         is_elision: false,
-                        render: Box::new(move |p: &mut Printer, child: &mut Context| {
-                            Self::print_type_name(&h.type_name, child);
-                            if let Some(ta) = &h.type_arguments {
-                                p.type_parameter_instantiation(ta, child);
-                            }
-                        }),
+                        render: Box::new(
+                            move |p: &mut Printer<'_, HAS_COMMENTS>, child: &mut Context| {
+                                Self::print_type_name(&h.type_name, child);
+                                if let Some(ta) = &h.type_arguments {
+                                    p.type_parameter_instantiation(ta, child);
+                                }
+                            },
+                        ),
                     }
                 })
                 .collect();
@@ -3927,7 +3947,7 @@ impl<'opt> Printer<'opt> {
         ctx.write(" {");
         ctx.indent();
         ctx.newline();
-        let nodes: Vec<SeqNode> = node
+        let nodes: Vec<SeqNode<HAS_COMMENTS>> = node
             .body
             .members
             .iter()
@@ -3938,9 +3958,11 @@ impl<'opt> Printer<'opt> {
                     end: Some(span.end),
                     obj_or_array: false,
                     is_elision: false,
-                    render: Box::new(move |p: &mut Printer, child: &mut Context| {
-                        p.enum_member(m, child);
-                    }),
+                    render: Box::new(
+                        move |p: &mut Printer<'_, HAS_COMMENTS>, child: &mut Context| {
+                            p.enum_member(m, child);
+                        },
+                    ),
                 }
             })
             .collect();
@@ -4124,9 +4146,10 @@ struct SeqMeta {
 /// One node of a comma sequence, as fed to [`Printer::sequence`]. Carries the
 /// node's source span (so trailing comments can be flushed in source order) and
 /// a closure that renders it into a child context.
-type SeqRenderer<'p> = dyn FnMut(&mut Printer<'_>, &mut Context) + 'p;
+type SeqRenderer<'p, const HAS_COMMENTS: bool> =
+    dyn FnMut(&mut Printer<'_, HAS_COMMENTS>, &mut Context) + 'p;
 
-struct SeqNode<'p> {
+struct SeqNode<'p, const HAS_COMMENTS: bool> {
     /// Node `loc.end` byte offset, or `None` for a synthetic node without a
     /// span (no trailing-comment flush is attempted for it).
     end: Option<u32>,
@@ -4135,7 +4158,7 @@ struct SeqNode<'p> {
     start: Option<u32>,
     obj_or_array: bool,
     is_elision: bool,
-    render: Box<SeqRenderer<'p>>,
+    render: Box<SeqRenderer<'p, HAS_COMMENTS>>,
 }
 
 const fn accessibility_str(acc: TSAccessibility) -> &'static str {
@@ -4225,7 +4248,11 @@ impl<'a> BodyElem<'a, '_> {
         }
     }
 
-    fn print(&self, printer: &mut Printer, ctx: &mut Context) {
+    fn print<const HAS_COMMENTS: bool>(
+        &self,
+        printer: &mut Printer<'_, HAS_COMMENTS>,
+        ctx: &mut Context,
+    ) {
         match self {
             BodyElem::Directive(d) => printer.print_directive(d, ctx),
             BodyElem::Statement(s) => printer.print_statement(s, ctx),
@@ -4264,7 +4291,7 @@ mod tests {
             ret.diagnostics
         );
         let opts = PrintOptions::default();
-        let mut printer = Printer::new(&opts);
+        let mut printer = Printer::<false>::new(&opts);
         let mut ctx = Context::new();
         printer.print_program(&ret.program, &mut ctx);
         (
@@ -4292,7 +4319,7 @@ mod tests {
         );
         let opts = PrintOptions::default();
         let comments = build_comments(&ret.program, src, &line_starts(src));
-        let mut printer = Printer::with_comments(&opts, comments, line_starts(src));
+        let mut printer = Printer::<true>::with_comments(&opts, comments, line_starts(src));
         let mut ctx = Context::new();
         printer.print_program(&ret.program, &mut ctx);
         let out = crate::command::print(&ctx.into_buffer(), &opts.indent, 0);

--- a/crates/rsvelte_esrap/tests/sourcemap_keywords.rs
+++ b/crates/rsvelte_esrap/tests/sourcemap_keywords.rs
@@ -134,6 +134,14 @@ fn declare_let_maps_declare_and_let() {
     let seg_let = mapping_at_substring(&m.code, "let", &m.mappings);
     assert_eq!(seg_let[2], 0);
     assert_eq!(seg_let[3], src_col(&m.source, "let"));
+
+    let end = u32::try_from("declare let ".len()).unwrap();
+    assert!(m.mappings.iter().any(|mapping| {
+        mapping.gen_line == 0
+            && mapping.gen_column == end
+            && mapping.source_line == 0
+            && mapping.source_column == end
+    }));
 }
 
 #[test]

--- a/crates/rsvelte_lint_types/Cargo.lock
+++ b/crates/rsvelte_lint_types/Cargo.lock
@@ -1111,7 +1111,7 @@ dependencies = [
 
 [[package]]
 name = "rsvelte_esrap"
-version = "0.10.18"
+version = "0.10.19"
 dependencies = [
  "compact_str",
  "memchr",


### PR DESCRIPTION
## Summary

- monomorphize the esrap visitor for comment-free and comment-bearing programs
- eliminate comment cursor and placement checks from the common comment-free AST traversal
- preserve the existing comment and source-map paths as separate specializations
- release `rsvelte_esrap` 0.10.19 and update the compiler's exact dependency

## Performance

On the existing 11-file, 50,406-byte paired retained-AST harness (200 pairs × 100 iterations), the median esrap/OXC ratio was 1.422x, 1.421x, and 1.421x across three runs. The merged 0.10.18 baseline was 1.468–1.482x under the same setup.

## Validation

- `cargo test -p rsvelte_esrap`
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- release changeset/version/lock guards
