### PR TITLE
fix(vite): preserve maps after generated code edits

### DIFF
--- a/.changeset/map-aware-vite-edits.md
+++ b/.changeset/map-aware-vite-edits.md
@@ -1,0 +1,5 @@
+---
+'@rsvelte/vite-plugin-svelte': patch
+---
+
+Preserve source maps when the Vite integration rewrites generated HMR code or appends CSS imports.

--- a/apps/npm/vite-plugin-svelte/__tests__/map-edits.spec.js
+++ b/apps/npm/vite-plugin-svelte/__tests__/map-edits.spec.js
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+import MagicString from 'magic-string';
+import { TraceMap, originalPositionFor } from '@jridgewell/trace-mapping';
+import { addPartialAcceptExports, applyMapEdits } from '../src/utils/map-edits.js';
+
+const filename = '/project/Component.svelte';
+
+function positionOf(code, needle) {
+	const offset = code.indexOf(needle);
+	return {
+		line: code.slice(0, offset).split('\n').length,
+		column: offset - code.lastIndexOf('\n', offset - 1) - 1
+	};
+}
+
+function generatedMap(code) {
+	return new MagicString(code).generateMap({ hires: true, source: filename });
+}
+
+describe('generated JavaScript map edits', () => {
+	it('composes HMR and CSS-import edits without moving following mappings', () => {
+		const code = [
+			'const before = 1;',
+			'import.meta.hot.accept(() => {});',
+			'const after = before;'
+		].join('\n');
+		const compiled = { js: { code, map: generatedMap(code) } };
+
+		applyMapEdits(compiled, filename, (editor, generated) => {
+			addPartialAcceptExports(editor, generated);
+		});
+		applyMapEdits(compiled, filename, (editor) => {
+			editor.append('\nimport "Component.svelte?style";\n');
+		});
+
+		expect(compiled.js.code).toContain('import.meta.hot.acceptExports(["default"],() => {});');
+		const position = positionOf(compiled.js.code, 'const after');
+		expect(originalPositionFor(new TraceMap(compiled.js.map), position)).toMatchObject({
+			source: filename,
+			line: 3,
+			column: 0
+		});
+	});
+
+	it('only rewrites import.meta.hot.accept calls', () => {
+		const code = 'const text = "import.meta.hot.accept(";\nimport.meta.hot.accept(() => {});';
+		const compiled = { js: { code, map: generatedMap(code) } };
+		applyMapEdits(compiled, filename, (editor, generated) => {
+			addPartialAcceptExports(editor, generated);
+		});
+		expect(compiled.js.code).toBe(
+			'const text = "import.meta.hot.accept(";\nimport.meta.hot.acceptExports(["default"],() => {});'
+		);
+	});
+});

--- a/apps/npm/vite-plugin-svelte/package.json
+++ b/apps/npm/vite-plugin-svelte/package.json
@@ -39,8 +39,11 @@
   },
   "homepage": "https://github.com/baseballyama/rsvelte/tree/main/apps/npm/vite-plugin-svelte#readme",
   "dependencies": {
+    "@jridgewell/remapping": "^2.3.5",
+    "@jridgewell/trace-mapping": "^0.3.31",
     "@rsvelte/vite-plugin-svelte-native": "workspace:^",
     "@sveltejs/vite-plugin-svelte-inspector": "^5.0.0",
+    "acorn": "^8.16.0",
     "deepmerge": "^4.3.1",
     "magic-string": "^1.0.0",
     "obug": "^2.1.0",

--- a/apps/npm/vite-plugin-svelte/src/utils/compile.js
+++ b/apps/npm/vite-plugin-svelte/src/utils/compile.js
@@ -1,6 +1,7 @@
 import * as svelte from '@rsvelte/vite-plugin-svelte-native';
 import { safeBase64Hash } from './hash.js';
 import { log } from './log.js';
+import { addPartialAcceptExports, applyMapEdits } from './map-edits.js';
 
 import { mapToRelative } from './sourcemaps.js';
 import { enhanceCompileError } from './error.js';
@@ -109,12 +110,11 @@ export function createCompileSvelte() {
 			// TODO remove later
 			if (
 				options.server?.config.experimental.hmrPartialAccept &&
-				compiled.js.code.includes('import.meta.hot.accept(')
+				compiled.js.code.includes('import.meta.hot')
 			) {
-				compiled.js.code = compiled.js.code.replaceAll(
-					'import.meta.hot.accept(',
-					'import.meta.hot.acceptExports(["default"],'
-				);
+				applyMapEdits(compiled, filename, (editor, generated) => {
+					addPartialAcceptExports(editor, generated);
+				});
 			}
 		} catch (e) {
 			enhanceCompileError(e, code, options.preprocess);
@@ -137,8 +137,9 @@ export function createCompileSvelte() {
 			const hasCss = compiled.css?.code?.trim()?.length ?? 0 > 0;
 			// compiler might not emit css with mode none or it may be empty
 			if (emitCss && hasCss) {
-				// TODO properly update sourcemap?
-				compiled.js.code += `\nimport ${JSON.stringify(cssId)};\n`;
+				applyMapEdits(compiled, filename, (editor) => {
+					editor.append(`\nimport ${JSON.stringify(cssId)};\n`);
+				});
 			}
 		}
 

--- a/apps/npm/vite-plugin-svelte/src/utils/map-edits.js
+++ b/apps/npm/vite-plugin-svelte/src/utils/map-edits.js
@@ -1,0 +1,76 @@
+import remapping from '@jridgewell/remapping';
+import { parse } from 'acorn';
+import MagicString from 'magic-string';
+
+/** @param {any} callee */
+function isHotAcceptCallee(callee) {
+	return (
+		callee.type === 'MemberExpression' &&
+		!callee.computed &&
+		callee.property.type === 'Identifier' &&
+		callee.property.name === 'accept' &&
+		callee.object.type === 'MemberExpression' &&
+		!callee.object.computed &&
+		callee.object.property.type === 'Identifier' &&
+		callee.object.property.name === 'hot' &&
+		callee.object.object.type === 'MetaProperty' &&
+		callee.object.object.meta.name === 'import' &&
+		callee.object.object.property.name === 'meta'
+	);
+}
+
+/**
+ * @param {any} node
+ * @param {any[]} calls
+ */
+function collectHotAcceptCalls(node, calls) {
+	if (!node || typeof node !== 'object') return;
+	if (node.type === 'CallExpression' && isHotAcceptCallee(node.callee)) {
+		calls.push(node);
+	}
+	for (const value of Object.values(node)) {
+		if (Array.isArray(value)) {
+			for (const child of value) collectHotAcceptCalls(child, calls);
+		} else if (value && typeof value === 'object' && typeof value.type === 'string') {
+			collectHotAcceptCalls(value, calls);
+		}
+	}
+}
+
+/**
+ * @param {{ js: { code: string, map: any } }} compiled
+ * @param {string} filename
+ * @param {(editor: MagicString, code: string) => void} edit
+ */
+export function applyMapEdits(compiled, filename, edit) {
+	const editor = new MagicString(compiled.js.code);
+	edit(editor, compiled.js.code);
+	const previousMap = compiled.js.map;
+	compiled.js.code = editor.toString();
+	if (!previousMap) return;
+	const editMap = editor.generateMap({ hires: true, source: filename });
+	let loadedPreviousMap = false;
+	compiled.js.map = remapping(/** @type {any} */ (editMap), (source) => {
+		if (source !== filename || loadedPreviousMap) return null;
+		loadedPreviousMap = true;
+		return /** @type {any} */ (previousMap);
+	});
+}
+
+/**
+ * @param {MagicString} editor
+ * @param {string} code
+ */
+export function addPartialAcceptExports(editor, code) {
+	const calls = [];
+	collectHotAcceptCalls(parse(code, { ecmaVersion: 'latest', sourceType: 'module' }), calls);
+	for (const call of calls) {
+		const firstArgument = call.arguments[0];
+		if (!firstArgument || firstArgument.type === 'SpreadElement') continue;
+		editor.overwrite(
+			call.callee.start,
+			firstArgument.start,
+			`${code.slice(call.callee.start, call.callee.end)}Exports([\"default\"],`
+		);
+	}
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -212,12 +212,21 @@ importers:
 
   apps/npm/vite-plugin-svelte:
     dependencies:
+      '@jridgewell/remapping':
+        specifier: ^2.3.5
+        version: 2.3.5
+      '@jridgewell/trace-mapping':
+        specifier: ^0.3.31
+        version: 0.3.31
       '@rsvelte/vite-plugin-svelte-native':
         specifier: workspace:^
         version: link:../vite-plugin-svelte-native
       '@sveltejs/vite-plugin-svelte-inspector':
         specifier: ^5.0.0
         version: 5.0.2(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.56.8)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(less@4.8.1)(sass@1.102.0)(yaml@2.9.0)))(svelte@5.56.8)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(less@4.8.1)(sass@1.102.0)(yaml@2.9.0))
+      acorn:
+        specifier: ^8.16.0
+        version: 8.18.0
       deepmerge:
         specifier: ^4.3.1
         version: 4.3.1
@@ -1262,11 +1271,6 @@ packages:
     engines: {node: '>=16.20.0'}
     cpu: [x64]
     os: [win32]
-
-  acorn@8.17.0:
-    resolution: {integrity: sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==}
-    engines: {node: '>=0.4.0'}
-    hasBin: true
 
   acorn@8.18.0:
     resolution: {integrity: sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==}
@@ -2407,9 +2411,9 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.1': {}
 
-  '@sveltejs/acorn-typescript@1.0.11(acorn@8.17.0)':
+  '@sveltejs/acorn-typescript@1.0.11(acorn@8.18.0)':
     dependencies:
-      acorn: 8.17.0
+      acorn: 8.18.0
 
   '@sveltejs/acorn-typescript@1.0.12(acorn@8.18.0)':
     dependencies:
@@ -2513,8 +2517,6 @@ snapshots:
 
   '@typescript/typescript-win32-x64@7.0.2':
     optional: true
-
-  acorn@8.17.0: {}
 
   acorn@8.18.0: {}
 
@@ -2983,10 +2985,10 @@ snapshots:
     dependencies:
       '@jridgewell/remapping': 2.3.5
       '@jridgewell/sourcemap-codec': 1.5.5
-      '@sveltejs/acorn-typescript': 1.0.11(acorn@8.17.0)
+      '@sveltejs/acorn-typescript': 1.0.11(acorn@8.18.0)
       '@types/estree': 1.0.9
       '@types/trusted-types': 2.0.7
-      acorn: 8.17.0
+      acorn: 8.18.0
       aria-query: 5.3.1
       axobject-query: 4.1.0
       clsx: 2.1.1


### PR DESCRIPTION
## Summary

- compose generated edit maps with compiler maps for HMR partial accepts and emitted CSS imports
- identify HMR calls structurally, rather than by matching generated text
- test decoded mappings after both edits

## Validation

- `pnpm dlx vitest@4.1.10 run apps/npm/vite-plugin-svelte/__tests__/map-edits.spec.js`
- `node --check apps/npm/vite-plugin-svelte/src/utils/{compile,map-edits}.js`
- `git diff --check`

`check:types` still reports pre-existing native-binding type incompatibilities; this change introduces none.