### PR TITLE
perf(esrap): specialize comment-free blocks

### DIFF
--- a/.changeset/quick-esrap-bodies.md
+++ b/.changeset/quick-esrap-bodies.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/compiler": patch
+---
+
+Render comment-free statement and class bodies without speculative scopes or retroactive layout insertion. Release `rsvelte_esrap` 0.10.20 and update the compiler's exact dependency.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2605,7 +2605,7 @@ dependencies = [
 
 [[package]]
 name = "rsvelte_esrap"
-version = "0.10.19"
+version = "0.10.20"
 dependencies = [
  "compact_str 0.10.0",
  "memchr",

--- a/crates/rsvelte_core/Cargo.toml
+++ b/crates/rsvelte_core/Cargo.toml
@@ -94,7 +94,7 @@ oxc_ast = { version = "0.144", features = ["serialize"] }
 oxc_span = "0.144"
 oxc_diagnostics = "0.144"
 oxc_codegen = "0.144"
-rsvelte_esrap = { version = "=0.10.19", path = "../rsvelte_esrap" }
+rsvelte_esrap = { version = "=0.10.20", path = "../rsvelte_esrap" }
 oxc_syntax = "0.144"
 oxc_semantic = "0.144"
 

--- a/crates/rsvelte_esrap/Cargo.toml
+++ b/crates/rsvelte_esrap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rsvelte_esrap"
-version = "0.10.19"
+version = "0.10.20"
 edition = "2024"
 rust-version = "1.95"
 description = "A Rust port of esrap — prints an oxc AST to JavaScript with esrap's exact layout"

--- a/crates/rsvelte_esrap/src/printer.rs
+++ b/crates/rsvelte_esrap/src/printer.rs
@@ -2238,6 +2238,27 @@ impl<'opt, const HAS_COMMENTS: bool> Printer<'opt, HAS_COMMENTS> {
     /// esrap's `BlockStatement|ClassBody`: only break a body across lines when
     /// it has real content, so an empty body stays `{}`.
     fn block(&mut self, body: &[Statement], body_start: u32, body_end: u32, ctx: &mut Context) {
+        if !HAS_COMMENTS {
+            let keep_empty = self.options.keep_empty_statements;
+            let has_content = body.iter().any(|statement| {
+                keep_empty
+                    || !matches!(statement, Statement::EmptyStatement(empty) if empty.span.end != u32::MAX)
+            });
+            if !has_content {
+                ctx.write("{}");
+                return;
+            }
+
+            ctx.write("{");
+            ctx.indent();
+            ctx.newline();
+            self.body(body, body_start, body_end, ctx);
+            ctx.dedent();
+            ctx.newline();
+            ctx.write("}");
+            return;
+        }
+
         ctx.write("{");
         let mark = ctx.event_mark();
         let scope = ctx.begin_scope();

--- a/crates/rsvelte_lint_types/Cargo.lock
+++ b/crates/rsvelte_lint_types/Cargo.lock
@@ -1111,7 +1111,7 @@ dependencies = [
 
 [[package]]
 name = "rsvelte_esrap"
-version = "0.10.19"
+version = "0.10.20"
 dependencies = [
  "compact_str",
  "memchr",


### PR DESCRIPTION
## Summary

- specialize comment-free statement blocks so their known brace/newline layout is emitted directly
- retain the scoped insertion path for comment-bearing programs and source-map output
- bump `rsvelte_esrap` to 0.10.20

## Measurement

Current `origin/main` after #2953: 1.421–1.422x esrap/OXC.

This branch, three 200-pair runs over the pinned 11-file / 50,406-byte generated-JS corpus:

- 1.360x
- 1.360x
- 1.364x

That is about a 4.2% reduction in the remaining printer time. A broader class-body specialization was measured and removed because its extra scan did not improve the result.

Command:

```console
target/release/ab_print --pairs 200 --iters 100 /tmp/rsvelte-main-ab-inputs/*.esrap.js
```

## Validation

- `cargo test -p rsvelte_esrap`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo fmt --check`
- `git diff --check`
