### PR TITLE
perf(esrap): inline short sequence layouts

### DIFF
--- a/.changeset/quick-esrap-bodies.md
+++ b/.changeset/quick-esrap-bodies.md
@@ -2,4 +2,4 @@
 "@rsvelte/compiler": patch
 ---
 
-Render comment-free statement and class bodies without speculative scopes or retroactive layout insertion. Release `rsvelte_esrap` 0.10.20 and update the compiler's exact dependency.
+Render comment-free statement bodies without speculative scopes or retroactive layout insertion. Release `rsvelte_esrap` 0.10.20 and update the compiler's exact dependency.

--- a/.changeset/short-esrap-sequences.md
+++ b/.changeset/short-esrap-sequences.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/compiler": patch
+---
+
+Keep layout metadata for sequences of up to three nodes inline. Release `rsvelte_esrap` 0.10.21 and update the compiler's exact dependency.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2605,7 +2605,7 @@ dependencies = [
 
 [[package]]
 name = "rsvelte_esrap"
-version = "0.10.20"
+version = "0.10.21"
 dependencies = [
  "compact_str 0.10.0",
  "memchr",

--- a/crates/rsvelte_core/Cargo.toml
+++ b/crates/rsvelte_core/Cargo.toml
@@ -94,7 +94,7 @@ oxc_ast = { version = "0.144", features = ["serialize"] }
 oxc_span = "0.144"
 oxc_diagnostics = "0.144"
 oxc_codegen = "0.144"
-rsvelte_esrap = { version = "=0.10.20", path = "../rsvelte_esrap" }
+rsvelte_esrap = { version = "=0.10.21", path = "../rsvelte_esrap" }
 oxc_syntax = "0.144"
 oxc_semantic = "0.144"
 

--- a/crates/rsvelte_esrap/Cargo.toml
+++ b/crates/rsvelte_esrap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rsvelte_esrap"
-version = "0.10.20"
+version = "0.10.21"
 edition = "2024"
 rust-version = "1.95"
 description = "A Rust port of esrap — prints an oxc AST to JavaScript with esrap's exact layout"

--- a/crates/rsvelte_esrap/src/printer.rs
+++ b/crates/rsvelte_esrap/src/printer.rs
@@ -859,6 +859,138 @@ impl<'opt, const HAS_COMMENTS: bool> Printer<'opt, HAS_COMMENTS> {
         trailing_newline: bool,
         parent: &mut Context,
     ) {
+        if n == 0 {
+            if let Some(until) = until {
+                self.flush_comments_until(parent, until, self.line_of(until), None, false);
+            }
+            return;
+        }
+
+        if n == 1 {
+            let node_meta = meta(0);
+            let mark = parent.event_mark();
+            let scope = parent.begin_scope();
+            render(self, 0, parent);
+            if node_meta.is_elision {
+                parent.write(separator);
+            }
+            if let Some(end) = node_meta.end {
+                self.flush_trailing_comments(parent, end, until);
+            }
+            let length = parent.measure();
+            let multiline = parent.end_scope(scope);
+
+            if multiline {
+                parent.insert_event(mark, EventKind::Newline);
+                parent.insert_event(mark, EventKind::Indent);
+                parent.multiline = true;
+            } else if pad && length > 0 {
+                parent.insert_event(mark, EventKind::Space);
+            }
+
+            if let Some(until) = until {
+                let from_line = node_meta
+                    .end
+                    .filter(|&end| self.has_loc(end))
+                    .map(|end| self.line_of(end));
+                self.flush_comments_until(parent, until, self.line_of(until), from_line, false);
+            }
+
+            if multiline {
+                parent.dedent();
+                if trailing_newline {
+                    parent.newline();
+                }
+            } else if pad && length > 0 {
+                parent.write(" ");
+            }
+            return;
+        }
+
+        if n <= 3 {
+            let mut multiline = false;
+            let mut length: i64 = -1;
+            let mut items = [None; 3];
+
+            for (i, item) in items.iter_mut().enumerate().take(n) {
+                let node_meta = meta(i);
+                let mark = parent.event_mark();
+                let scope = parent.begin_scope();
+                render(self, i, parent);
+
+                let node_multiline = parent.multiline;
+                if i < n - 1 || node_meta.is_elision {
+                    parent.write(separator);
+                }
+
+                let next = if i == n - 1 { until } else { meta(i + 1).start };
+                if let Some(end) = node_meta.end {
+                    self.flush_trailing_comments(parent, end, next);
+                }
+
+                length += usize_to_i64(parent.measure()) + 1;
+                multiline |= parent.end_scope(scope);
+                *item = Some(SeqLayout {
+                    mark,
+                    multiline: node_multiline,
+                    obj_or_array: node_meta.obj_or_array,
+                    is_elision: node_meta.is_elision,
+                });
+            }
+
+            multiline |= length > 60;
+
+            for i in (0..n).rev() {
+                let item = items[i].unwrap();
+                if i > 0 {
+                    let prev = items[i - 1].unwrap();
+                    let margin = prev.multiline
+                        && item.multiline
+                        && !(prev.obj_or_array && item.obj_or_array);
+                    if !item.is_elision {
+                        parent.insert_event(
+                            item.mark,
+                            if multiline {
+                                EventKind::Newline
+                            } else {
+                                EventKind::Space
+                            },
+                        );
+                    }
+                    if margin {
+                        parent.insert_event(item.mark, EventKind::Margin);
+                    }
+                }
+            }
+
+            let first = items[0].unwrap();
+            if multiline {
+                parent.insert_event(first.mark, EventKind::Newline);
+                parent.insert_event(first.mark, EventKind::Indent);
+                parent.multiline = true;
+            } else if pad && length > 0 {
+                parent.insert_event(first.mark, EventKind::Space);
+            }
+
+            if let Some(until) = until {
+                let from_line = meta(n - 1)
+                    .end
+                    .filter(|&end| self.has_loc(end))
+                    .map(|end| self.line_of(end));
+                self.flush_comments_until(parent, until, self.line_of(until), from_line, false);
+            }
+
+            if multiline {
+                parent.dedent();
+                if trailing_newline {
+                    parent.newline();
+                }
+            } else if pad && length > 0 {
+                parent.write(" ");
+            }
+            return;
+        }
+
         let mut multiline = false;
         let mut length: i64 = -1;
         let mut items: Vec<SeqLayout> = Vec::with_capacity(n);

--- a/crates/rsvelte_lint_types/Cargo.lock
+++ b/crates/rsvelte_lint_types/Cargo.lock
@@ -1111,7 +1111,7 @@ dependencies = [
 
 [[package]]
 name = "rsvelte_esrap"
-version = "0.10.20"
+version = "0.10.21"
 dependencies = [
  "compact_str",
  "memchr",


### PR DESCRIPTION
## Summary

- keep layout metadata inline for generic sequences containing zero to three nodes
- avoid allocating the layout `Vec` on the common short-sequence paths
- bump `rsvelte_esrap` to 0.10.21
- correct the already-merged 0.10.20 changeset wording: #2956 specialized statement blocks, not class bodies

## Measurement

After #2956, the block-only baseline was 1.360–1.364x esrap/OXC.

This branch, three 200-pair runs over the same 11-file / 50,406-byte generated-JS corpus:

- 1.312x
- 1.316x
- 1.318x

Command:

```console
target/release/ab_print --pairs 200 --iters 100 /tmp/rsvelte-main-ab-inputs/*.esrap.js
```

## Validation

- `cargo test -p rsvelte_esrap`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo fmt --check`
- `git diff --check`

The zero-, one-, two-, and three-node paths preserve the generic path's length correction, reverse event insertion, and trailing-comment boundary behavior.
