### PR TITLE
perf(esrap): render variable declarators in place

### DIFF
--- a/.changeset/direct-esrap-declarators.md
+++ b/.changeset/direct-esrap-declarators.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/compiler": patch
+---
+
+Render multi-declarator variable statements in one output buffer. Release `rsvelte_esrap` 0.10.22 and update the compiler's exact dependency.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2605,7 +2605,7 @@ dependencies = [
 
 [[package]]
 name = "rsvelte_esrap"
-version = "0.10.21"
+version = "0.10.22"
 dependencies = [
  "compact_str 0.10.0",
  "memchr",

--- a/crates/rsvelte_core/Cargo.toml
+++ b/crates/rsvelte_core/Cargo.toml
@@ -94,7 +94,7 @@ oxc_ast = { version = "0.144", features = ["serialize"] }
 oxc_span = "0.144"
 oxc_diagnostics = "0.144"
 oxc_codegen = "0.144"
-rsvelte_esrap = { version = "=0.10.21", path = "../rsvelte_esrap" }
+rsvelte_esrap = { version = "=0.10.22", path = "../rsvelte_esrap" }
 oxc_syntax = "0.144"
 oxc_semantic = "0.144"
 

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/tests.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/tests.rs
@@ -4101,16 +4101,17 @@ fn ast_matches_oracle_destructure_state_and_store_init() {
 fn array_counter_is_shared_across_declarations() {
     let src = "<script>\n\tlet [a, b] = $state([1, 2]);\n\tlet [c, d] = $state([3, 4]);\n</script>\n\n{a}{b}{c}{d}";
     let out = run(src);
+    let compact: String = out.chars().filter(|ch| !ch.is_ascii_whitespace()).collect();
     assert!(
-        out.contains("$$array = $.to_array(tmp, 2)"),
+        compact.contains("$$array=$.to_array(tmp,2)"),
         "first array declarator should be the bare `$$array` temp:\n{out}"
     );
     assert!(
-        out.contains("$$array_1 = $.to_array(tmp_1, 2)"),
+        compact.contains("$$array_1=$.to_array(tmp_1,2)"),
         "second array declarator should deconflict to `$$array_1`:\n{out}"
     );
     assert!(
-        !out.contains("$$array_2"),
+        !compact.contains("$$array_2"),
         "only two array patterns were declared, so no `$$array_2` should appear:\n{out}"
     );
 }

--- a/crates/rsvelte_esrap/Cargo.toml
+++ b/crates/rsvelte_esrap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rsvelte_esrap"
-version = "0.10.21"
+version = "0.10.22"
 edition = "2024"
 rust-version = "1.95"
 description = "A Rust port of esrap — prints an oxc AST to JavaScript with esrap's exact layout"

--- a/crates/rsvelte_esrap/src/printer.rs
+++ b/crates/rsvelte_esrap/src/printer.rs
@@ -2478,11 +2478,11 @@ impl<'opt, const HAS_COMMENTS: bool> Printer<'opt, HAS_COMMENTS> {
         let multiline = any_multiline || (n > 1 && length > 50);
 
         if multiline {
-            if n > 1 {
-                ctx.insert_event(first, EventKind::Indent);
-            }
             for separator in separators.into_iter().rev() {
                 ctx.insert_event(separator, EventKind::Newline);
+            }
+            if n > 1 {
+                ctx.insert_event(first, EventKind::Indent);
             }
             if n > 1 {
                 ctx.dedent();

--- a/crates/rsvelte_esrap/src/printer.rs
+++ b/crates/rsvelte_esrap/src/printer.rs
@@ -2445,29 +2445,33 @@ impl<'opt, const HAS_COMMENTS: bool> Printer<'opt, HAS_COMMENTS> {
         }
 
         let n = decl.declarations.len();
-        let mut rendered: Vec<Context> = Vec::with_capacity(n);
         // esrap measures the whole `child_context`, which includes the keyword,
         // so the fit test sees `let `/`const ` etc. as part of the length.
         let mut total_measure = keyword.len();
         let mut any_multiline = false;
-        for declarator in &decl.declarations {
-            let mut child = ctx.child();
+        let first = ctx.event_mark();
+        let mut separators = Vec::with_capacity(n.saturating_sub(1));
+        for (index, declarator) in decl.declarations.iter().enumerate() {
+            if index > 0 {
+                ctx.write(",");
+                separators.push(ctx.event_mark());
+            }
+            let scope = ctx.begin_scope();
             let start = declarator.span().start;
-            self.flush_leading(&mut child, start);
-            self.binding_pattern(&declarator.id, &mut child);
+            self.flush_leading(ctx, start);
+            self.binding_pattern(&declarator.id, ctx);
             if declarator.definite {
-                child.write("!");
+                ctx.write("!");
             }
             if let Some(ann) = &declarator.type_annotation {
-                self.type_annotation(ann, &mut child);
+                self.type_annotation(ann, ctx);
             }
             if let Some(init) = &declarator.init {
-                child.write(" = ");
-                self.print_expression(init, &mut child);
+                ctx.write(" = ");
+                self.print_expression(init, ctx);
             }
-            total_measure += child.measure();
-            any_multiline |= child.multiline;
-            rendered.push(child);
+            total_measure += ctx.measure();
+            any_multiline |= ctx.end_scope(scope);
         }
 
         let length = total_measure + 2 * n.saturating_sub(1);
@@ -2475,24 +2479,18 @@ impl<'opt, const HAS_COMMENTS: bool> Printer<'opt, HAS_COMMENTS> {
 
         if multiline {
             if n > 1 {
-                ctx.indent();
+                ctx.insert_event(first, EventKind::Indent);
             }
-            for (i, child) in rendered.into_iter().enumerate() {
-                if i > 0 {
-                    ctx.write(",");
-                    ctx.newline();
-                }
-                ctx.append(child);
+            for separator in separators.into_iter().rev() {
+                ctx.insert_event(separator, EventKind::Newline);
             }
             if n > 1 {
                 ctx.dedent();
             }
+            ctx.multiline = true;
         } else {
-            for (i, child) in rendered.into_iter().enumerate() {
-                if i > 0 {
-                    ctx.write(", ");
-                }
-                ctx.append(child);
+            for separator in separators.into_iter().rev() {
+                ctx.insert_event(separator, EventKind::Space);
             }
         }
     }

--- a/crates/rsvelte_lint_types/Cargo.lock
+++ b/crates/rsvelte_lint_types/Cargo.lock
@@ -1111,7 +1111,7 @@ dependencies = [
 
 [[package]]
 name = "rsvelte_esrap"
-version = "0.10.21"
+version = "0.10.22"
 dependencies = [
  "compact_str",
  "memchr",


### PR DESCRIPTION
## Summary

- render multiple variable declarators directly into the parent text buffer
- retain each declarator's scoped measure/multiline decision and insert only the chosen separator layout afterward
- remove one child `Context` and one child-to-parent text copy per declarator
- bump `rsvelte_esrap` to 0.10.22

## Measurement

Three 500-pair runs over the 11-file / 50,406-byte generated-JS corpus:

- 1.308x
- 1.304x
- 1.302x

The post-#2957 baseline was 1.311–1.316x. This is a small but repeatable reduction in the remaining copy cost.

Command:

```console
target/release/ab_print --pairs 500 --iters 100 /tmp/rsvelte-main-ab-inputs/*.esrap.js
```

## Validation

- `cargo test -p rsvelte_esrap`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo fmt --check`
- `git diff --check`
