### PR TITLE
perf(esrap): reserve deferred layout output

### DIFF
--- a/.changeset/reserve-esrap-layout.md
+++ b/.changeset/reserve-esrap-layout.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/compiler": patch
+---
+
+Reserve space for deferred esrap layout bytes before rendering. Release `rsvelte_esrap` 0.10.23 and update the compiler's exact dependency.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2605,7 +2605,7 @@ dependencies = [
 
 [[package]]
 name = "rsvelte_esrap"
-version = "0.10.22"
+version = "0.10.23"
 dependencies = [
  "compact_str 0.10.0",
  "memchr",

--- a/crates/rsvelte_core/Cargo.toml
+++ b/crates/rsvelte_core/Cargo.toml
@@ -94,7 +94,7 @@ oxc_ast = { version = "0.144", features = ["serialize"] }
 oxc_span = "0.144"
 oxc_diagnostics = "0.144"
 oxc_codegen = "0.144"
-rsvelte_esrap = { version = "=0.10.22", path = "../rsvelte_esrap" }
+rsvelte_esrap = { version = "=0.10.23", path = "../rsvelte_esrap" }
 oxc_syntax = "0.144"
 oxc_semantic = "0.144"
 

--- a/crates/rsvelte_esrap/Cargo.toml
+++ b/crates/rsvelte_esrap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rsvelte_esrap"
-version = "0.10.22"
+version = "0.10.23"
 edition = "2024"
 rust-version = "1.95"
 description = "A Rust port of esrap — prints an oxc AST to JavaScript with esrap's exact layout"

--- a/crates/rsvelte_esrap/src/command.rs
+++ b/crates/rsvelte_esrap/src/command.rs
@@ -60,7 +60,11 @@ pub struct Mapping {
 }
 
 pub(crate) fn print(buffer: &Buffer, indent: &str, capacity: usize) -> String {
-    let mut code = String::with_capacity(capacity);
+    let layout_capacity = buffer
+        .events
+        .len()
+        .saturating_mul(indent.len().saturating_add(2));
+    let mut code = String::with_capacity(capacity.saturating_add(layout_capacity));
     let mut current_newline = String::from("\n");
     let mut needs_newline = false;
     let mut needs_margin = false;
@@ -122,7 +126,14 @@ pub(crate) fn flatten_with_map(
     capacity: usize,
 ) -> (String, Vec<Mapping>) {
     let mut driver = Driver {
-        code: String::with_capacity(capacity),
+        code: String::with_capacity(
+            capacity.saturating_add(
+                buffer
+                    .events
+                    .len()
+                    .saturating_mul(indent.len().saturating_add(2)),
+            ),
+        ),
         current_newline: String::from("\n"),
         indent,
         needs_newline: false,

--- a/crates/rsvelte_lint_types/Cargo.lock
+++ b/crates/rsvelte_lint_types/Cargo.lock
@@ -1111,7 +1111,7 @@ dependencies = [
 
 [[package]]
 name = "rsvelte_esrap"
-version = "0.10.22"
+version = "0.10.23"
 dependencies = [
  "compact_str",
  "memchr",


### PR DESCRIPTION
## What changed

- reserve the deferred renderer's output string for both literal and estimated layout bytes
- release `rsvelte_esrap` 0.10.23 and update the compiler's exact dependency and lockfiles

## Why

The previous capacity used only literal bytes even though spaces, newlines, margins, and indentation are added while replaying layout events. That could force the final output string to grow and copy nearly all bytes again.

On the retained 11-file printer benchmark (50,406 input bytes, 500 ABBA pairs × 100 iterations), the median esrap/OXC ratio improved from approximately 1.302–1.308x to 1.293x in two consecutive runs.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p rsvelte_esrap --lib`
- `cargo test -p rsvelte_esrap --test esrap_samples`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `node scripts/ci/check-lint-types-lock.mjs --fix`
