### PR TITLE
perf(esrap): write plain output directly

### DIFF
--- a/.changeset/direct-esrap-output.md
+++ b/.changeset/direct-esrap-output.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/compiler": patch
+---
+
+Write comment-free esrap output directly and patch only retroactively changed layout spans. Release `rsvelte_esrap` 0.10.24 and update the compiler's exact dependency.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2605,7 +2605,7 @@ dependencies = [
 
 [[package]]
 name = "rsvelte_esrap"
-version = "0.10.23"
+version = "0.10.24"
 dependencies = [
  "compact_str 0.10.0",
  "memchr",

--- a/crates/rsvelte_core/Cargo.toml
+++ b/crates/rsvelte_core/Cargo.toml
@@ -94,7 +94,7 @@ oxc_ast = { version = "0.144", features = ["serialize"] }
 oxc_span = "0.144"
 oxc_diagnostics = "0.144"
 oxc_codegen = "0.144"
-rsvelte_esrap = { version = "=0.10.23", path = "../rsvelte_esrap" }
+rsvelte_esrap = { version = "=0.10.24", path = "../rsvelte_esrap" }
 oxc_syntax = "0.144"
 oxc_semantic = "0.144"
 

--- a/crates/rsvelte_esrap/Cargo.toml
+++ b/crates/rsvelte_esrap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rsvelte_esrap"
-version = "0.10.23"
+version = "0.10.24"
 edition = "2024"
 rust-version = "1.95"
 description = "A Rust port of esrap — prints an oxc AST to JavaScript with esrap's exact layout"

--- a/crates/rsvelte_esrap/src/command.rs
+++ b/crates/rsvelte_esrap/src/command.rs
@@ -17,10 +17,21 @@ pub(crate) struct Event {
     pub kind: EventKind,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct LayoutSpan {
+    pub start: u32,
+    pub raw_len: u32,
+    pub depth: u32,
+    pub newline: bool,
+    pub margin: bool,
+    pub dirty: bool,
+}
+
 #[derive(Default)]
 pub(crate) struct Buffer {
     pub text: String,
     pub events: Vec<Event>,
+    pub layouts: Vec<LayoutSpan>,
 }
 
 impl Buffer {
@@ -43,6 +54,88 @@ impl Buffer {
             }
         }));
         child.text.clear();
+    }
+}
+
+pub(crate) fn finish_direct(mut buffer: Buffer, indent: &str, dirty: bool) -> (String, Buffer) {
+    if dirty {
+        patch_layouts(&mut buffer.text, &buffer.layouts, indent);
+    }
+    buffer.layouts.clear();
+    let text = std::mem::take(&mut buffer.text);
+    (text, buffer)
+}
+
+fn patch_layouts(text: &mut String, layouts: &[LayoutSpan], indent: &str) {
+    let old_len = text.len();
+    let new_len = layouts
+        .iter()
+        .filter(|span| span.dirty)
+        .fold(old_len, |len, span| {
+            let growth = rendered_layout_len(*span, indent.len())
+                .checked_sub(span.raw_len as usize)
+                .expect("retroactive layout edits only grow");
+            len.checked_add(growth).expect("esrap output exceeds usize")
+        });
+    debug_assert!(new_len >= old_len);
+    text.reserve(new_len - old_len);
+
+    // SAFETY: ordered non-overlapping spans only grow during the reverse rewrite.
+    unsafe {
+        let bytes = text.as_mut_vec();
+        bytes.resize(new_len, 0);
+        let ptr = bytes.as_mut_ptr();
+        let mut src = old_len;
+        let mut dst = new_len;
+
+        for span in layouts.iter().rev().filter(|span| span.dirty) {
+            let start = span.start as usize;
+            let end = start + span.raw_len as usize;
+            debug_assert!(end <= src);
+
+            let trailing = src - end;
+            dst -= trailing;
+            std::ptr::copy(ptr.add(end), ptr.add(dst), trailing);
+
+            let rendered_len = rendered_layout_len(*span, indent.len());
+            dst -= rendered_len;
+            write_layout(ptr.add(dst), *span, indent);
+            src = start;
+        }
+
+        debug_assert_eq!(dst, src);
+    }
+}
+
+fn rendered_layout_len(span: LayoutSpan, indent_len: usize) -> usize {
+    if span.newline {
+        1 + usize::from(span.margin) + span.depth as usize * indent_len
+    } else {
+        1
+    }
+}
+
+unsafe fn write_layout(mut dst: *mut u8, span: LayoutSpan, indent: &str) {
+    if !span.newline {
+        // SAFETY: caller reserved one byte for the space.
+        unsafe { dst.write(b' ') };
+        return;
+    }
+    if span.margin {
+        // SAFETY: caller reserved the rendered layout length.
+        unsafe { dst.write(b'\n') };
+        // SAFETY: the margin byte is within that reserved range.
+        dst = unsafe { dst.add(1) };
+    }
+    // SAFETY: caller reserved the rendered layout length.
+    unsafe { dst.write(b'\n') };
+    // SAFETY: the newline byte is within that reserved range.
+    dst = unsafe { dst.add(1) };
+    for _ in 0..span.depth {
+        // SAFETY: caller reserved the rendered layout length and indent is valid bytes.
+        unsafe { std::ptr::copy_nonoverlapping(indent.as_ptr(), dst, indent.len()) };
+        // SAFETY: each indent copy advances within that reserved range.
+        dst = unsafe { dst.add(indent.len()) };
     }
 }
 

--- a/crates/rsvelte_esrap/src/context.rs
+++ b/crates/rsvelte_esrap/src/context.rs
@@ -9,15 +9,25 @@
 
 use std::{cell::RefCell, rc::Rc};
 
-use crate::command::{Buffer, EventKind};
+use crate::command::{Buffer, EventKind, LayoutSpan};
+
+const PENDING_NEWLINE: u8 = 1 << 0;
+const PENDING_MARGIN: u8 = 1 << 1;
+const PENDING_SPACE: u8 = 1 << 2;
 
 /// Accumulates output for one syntactic unit. Build a child with
 /// [`Context::child`], fill it, then [`Context::append`] it into the parent.
-pub struct Context {
+#[repr(C)]
+pub struct Context<const DIRECT: bool = false> {
     buffer: Buffer,
     returned: Rc<RefCell<Vec<Buffer>>>,
+    indent: String,
+    indent_depth: u32,
+    literal_len: usize,
     measure_base: usize,
     has_newline: bool,
+    pending: u8,
+    direct_dirty: bool,
     /// `true` once this context (or an appended child) emitted a newline.
     /// Visitors read it to pick a layout.
     pub multiline: bool,
@@ -26,6 +36,12 @@ pub struct Context {
 pub(crate) struct Scope {
     measure_base: usize,
     event_len: usize,
+    text_len: usize,
+    layout_len: usize,
+    literal_len: usize,
+    indent_depth: u32,
+    pending: u8,
+    direct_dirty: bool,
     has_newline: bool,
     multiline: bool,
 }
@@ -36,7 +52,7 @@ pub(crate) struct EventMark {
     offset: u32,
 }
 
-impl Context {
+impl Context<false> {
     /// A fresh, empty context.
     pub fn new() -> Self {
         let returned = Rc::new(RefCell::new(crate::pool::take()));
@@ -44,57 +60,117 @@ impl Context {
         Self {
             buffer,
             returned,
+            indent: String::new(),
+            indent_depth: 0,
+            literal_len: 0,
             measure_base: 0,
             has_newline: false,
+            pending: 0,
+            direct_dirty: false,
             multiline: false,
         }
     }
+}
 
-    /// A fresh child context. Named `child` rather than mirroring esrap's `new`
-    /// because in this port it carries no shared visitor table.
-    pub fn child(&self) -> Self {
-        let buffer = self.returned.borrow_mut().pop().unwrap_or_default();
+impl Context<true> {
+    pub(crate) fn new_direct(indent: &str, capacity: usize) -> Self {
+        let returned = Rc::new(RefCell::new(crate::pool::take()));
+        let mut buffer = returned.borrow_mut().pop().unwrap_or_default();
+        buffer
+            .text
+            .reserve(capacity.saturating_sub(buffer.text.capacity()));
         Self {
             buffer,
-            returned: Rc::clone(&self.returned),
+            returned,
+            indent: indent.to_owned(),
+            indent_depth: 0,
+            literal_len: 0,
             measure_base: 0,
             has_newline: false,
+            pending: 0,
+            direct_dirty: false,
+            multiline: false,
+        }
+    }
+}
+
+impl<const DIRECT: bool> Context<DIRECT> {
+    /// A fresh child context. Named `child` rather than mirroring esrap's `new`
+    /// because in this port it carries no shared visitor table.
+    pub fn child(&self) -> Context<false> {
+        let buffer = self.returned.borrow_mut().pop().unwrap_or_default();
+        Context {
+            buffer,
+            returned: Rc::clone(&self.returned),
+            indent: String::new(),
+            indent_depth: 0,
+            literal_len: 0,
+            measure_base: 0,
+            has_newline: false,
+            pending: 0,
+            direct_dirty: false,
             multiline: false,
         }
     }
 
     /// Grow the newline indentation by one level for subsequent newlines.
     pub fn indent(&mut self) {
-        self.buffer.event(EventKind::Indent);
+        if DIRECT {
+            self.indent_depth += 1;
+        } else {
+            self.buffer.event(EventKind::Indent);
+        }
     }
 
     /// Shrink the newline indentation by one level.
     pub fn dedent(&mut self) {
-        self.buffer.event(EventKind::Dedent);
+        if DIRECT {
+            self.indent_depth = self.indent_depth.saturating_sub(1);
+        } else {
+            self.buffer.event(EventKind::Dedent);
+        }
     }
 
     /// Request a blank line ahead of the next newline.
     pub fn margin(&mut self) {
-        self.buffer.event(EventKind::Margin);
+        if DIRECT {
+            self.pending |= PENDING_MARGIN;
+        } else {
+            self.buffer.event(EventKind::Margin);
+        }
     }
 
     /// Emit an indentation-aware newline before the next write. Marks the
     /// context multiline.
     pub fn newline(&mut self) {
         self.has_newline = true;
-        self.buffer.event(EventKind::Newline);
+        if DIRECT {
+            self.pending |= PENDING_NEWLINE;
+        } else {
+            self.buffer.event(EventKind::Newline);
+        }
     }
 
     /// Emit a single space before the next write.
     pub fn space(&mut self) {
-        self.buffer.event(EventKind::Space);
+        if DIRECT {
+            self.pending |= PENDING_SPACE;
+        } else {
+            self.buffer.event(EventKind::Space);
+        }
     }
 
     /// Append literal `content`. If a newline is already pending in this
     /// context, writing after it makes the context multiline (mirrors esrap).
     pub fn write(&mut self, content: impl AsRef<str>) {
         let content = content.as_ref();
-        if content.is_empty() {
+        if DIRECT {
+            self.flush_direct();
+            if !content.is_empty() {
+                self.buffer.text.push_str(content);
+                self.literal_len += content.len();
+            }
+        } else if content.is_empty() {
             self.buffer.event(EventKind::Flush);
         } else {
             self.buffer.text.push_str(content);
@@ -106,14 +182,24 @@ impl Context {
 
     /// Record a source-map anchor (1-based line, 0-based column).
     pub fn location(&mut self, line: u32, column: u32) {
-        self.buffer.event(EventKind::Location { line, column });
+        if DIRECT {
+            self.flush_direct();
+        } else {
+            self.buffer.event(EventKind::Location { line, column });
+        }
     }
 
     /// Splice `child`'s output in place, propagating its multiline state.
-    pub fn append(&mut self, child: Self) {
+    pub fn append(&mut self, child: Context<false>) {
         let child_multiline = child.multiline;
         let mut child_buffer = child.buffer;
-        self.buffer.append(&mut child_buffer);
+        if DIRECT {
+            self.append_deferred(&child_buffer);
+            child_buffer.text.clear();
+            child_buffer.events.clear();
+        } else {
+            self.buffer.append(&mut child_buffer);
+        }
         self.returned.borrow_mut().push(child_buffer);
         if self.has_newline || child_multiline {
             self.multiline = true;
@@ -124,10 +210,20 @@ impl Context {
         let scope = Scope {
             measure_base: self.measure_base,
             event_len: self.buffer.events.len(),
+            text_len: self.buffer.text.len(),
+            layout_len: self.buffer.layouts.len(),
+            literal_len: self.literal_len,
+            indent_depth: self.indent_depth,
+            pending: self.pending,
+            direct_dirty: self.direct_dirty,
             has_newline: self.has_newline,
             multiline: self.multiline,
         };
-        self.measure_base = self.buffer.text.len();
+        self.measure_base = if DIRECT {
+            self.literal_len
+        } else {
+            self.buffer.text.len()
+        };
         self.has_newline = false;
         self.multiline = false;
         scope
@@ -142,8 +238,17 @@ impl Context {
     }
 
     pub(crate) fn discard_scope(&mut self, scope: Scope) {
-        self.buffer.text.truncate(self.measure_base);
+        self.buffer.text.truncate(if DIRECT {
+            scope.text_len
+        } else {
+            self.measure_base
+        });
         self.buffer.events.truncate(scope.event_len);
+        self.buffer.layouts.truncate(scope.layout_len);
+        self.literal_len = scope.literal_len;
+        self.indent_depth = scope.indent_depth;
+        self.pending = scope.pending;
+        self.direct_dirty = scope.direct_dirty;
         self.measure_base = scope.measure_base;
         self.has_newline = scope.has_newline;
         self.multiline = scope.multiline;
@@ -157,6 +262,10 @@ impl Context {
     }
 
     pub(crate) fn insert_event(&mut self, mark: EventMark, kind: EventKind) {
+        if DIRECT {
+            self.insert_direct(mark.offset, kind);
+            return;
+        }
         self.buffer.events.insert(
             mark.index,
             crate::command::Event {
@@ -168,13 +277,21 @@ impl Context {
 
     /// `true` when nothing with visible content has been written.
     pub const fn empty(&self) -> bool {
-        self.buffer.text.len() == self.measure_base
+        if DIRECT {
+            self.literal_len == self.measure_base
+        } else {
+            self.buffer.text.len() == self.measure_base
+        }
     }
 
     /// Total length of the literal strings in this context, ignoring whitespace
     /// sentinels — esrap's `measure`, used to decide if a layout fits on a line.
     pub const fn measure(&self) -> usize {
-        self.buffer.text.len() - self.measure_base
+        if DIRECT {
+            self.literal_len - self.measure_base
+        } else {
+            self.buffer.text.len() - self.measure_base
+        }
     }
 
     /// Consume the context, yielding its flat output buffer (for the top-level
@@ -187,6 +304,166 @@ impl Context {
         (self.buffer, returned)
     }
 
+    pub(crate) fn into_direct_parts(self) -> (Buffer, Vec<Buffer>, String, bool) {
+        debug_assert!(DIRECT);
+        let indent = self.indent;
+        let dirty = self.direct_dirty;
+        let returned = match Rc::try_unwrap(self.returned) {
+            Ok(returned) => returned.into_inner(),
+            Err(_) => unreachable!("all child contexts must be consumed before printing"),
+        };
+        (self.buffer, returned, indent, dirty)
+    }
+
+    fn append_deferred(&mut self, child: &Buffer) {
+        let child_literal_len = child.text.len();
+        let mut cursor = 0;
+        for event in &child.events {
+            let offset = event.offset as usize;
+            if offset > cursor {
+                self.write_direct_text(&child.text[cursor..offset]);
+                cursor = offset;
+            }
+            self.direct_event(event.kind);
+        }
+        if cursor < child.text.len() {
+            self.write_direct_text(&child.text[cursor..]);
+        }
+        self.literal_len += child_literal_len;
+    }
+
+    fn direct_event(&mut self, kind: EventKind) {
+        match kind {
+            EventKind::Margin => self.pending |= PENDING_MARGIN,
+            EventKind::Newline => self.pending |= PENDING_NEWLINE,
+            EventKind::Indent => self.indent_depth += 1,
+            EventKind::Dedent => self.indent_depth = self.indent_depth.saturating_sub(1),
+            EventKind::Space => self.pending |= PENDING_SPACE,
+            EventKind::Flush | EventKind::Location { .. } => self.flush_direct(),
+        }
+    }
+
+    fn write_direct_text(&mut self, text: &str) {
+        self.flush_direct();
+        self.buffer.text.push_str(text);
+    }
+
+    #[inline(always)]
+    fn flush_direct(&mut self) {
+        if self.pending == 0 {
+            return;
+        }
+        self.flush_direct_slow();
+    }
+
+    #[cold]
+    #[inline(never)]
+    fn flush_direct_slow(&mut self) {
+        let start = u32::try_from(self.buffer.text.len()).expect("esrap output exceeds u32");
+        if self.pending & PENDING_NEWLINE != 0 {
+            if self.pending & PENDING_MARGIN != 0 {
+                self.buffer.text.push('\n');
+            }
+            self.buffer.text.push('\n');
+            for _ in 0..self.indent_depth {
+                self.buffer.text.push_str(&self.indent);
+            }
+            let raw_len = u32::try_from(self.buffer.text.len() - start as usize)
+                .expect("esrap output exceeds u32");
+            self.buffer.layouts.push(LayoutSpan {
+                start,
+                raw_len,
+                depth: self.indent_depth,
+                newline: true,
+                margin: self.pending & PENDING_MARGIN != 0,
+                dirty: false,
+            });
+        } else if self.pending & PENDING_SPACE != 0 {
+            self.buffer.text.push(' ');
+            self.buffer.layouts.push(LayoutSpan {
+                start,
+                raw_len: 1,
+                depth: 0,
+                newline: false,
+                margin: false,
+                dirty: false,
+            });
+        }
+        self.pending = 0;
+    }
+
+    fn insert_direct(&mut self, offset: u32, kind: EventKind) {
+        match kind {
+            EventKind::Space => {
+                if self.layout_at(offset).is_none() {
+                    self.insert_layout(offset, false);
+                }
+            }
+            EventKind::Newline => {
+                if let Some(index) = self.layout_at(offset) {
+                    if !self.buffer.layouts[index].newline {
+                        self.buffer.layouts[index].newline = true;
+                        self.buffer.layouts[index].depth = self.indent_depth;
+                        self.buffer.layouts[index].dirty = true;
+                        self.direct_dirty = true;
+                    }
+                } else {
+                    self.insert_layout(offset, true);
+                }
+            }
+            EventKind::Margin => {
+                if let Some(index) = self.layout_at(offset)
+                    && self.buffer.layouts[index].newline
+                    && !self.buffer.layouts[index].margin
+                {
+                    self.buffer.layouts[index].margin = true;
+                    self.buffer.layouts[index].dirty = true;
+                    self.direct_dirty = true;
+                }
+            }
+            EventKind::Indent => {
+                for layout in self
+                    .buffer
+                    .layouts
+                    .iter_mut()
+                    .filter(|layout| layout.start >= offset && layout.newline)
+                {
+                    layout.depth += 1;
+                    layout.dirty = true;
+                }
+                self.indent_depth += 1;
+                self.direct_dirty = true;
+            }
+            _ => unreachable!("plain retroactive insertion only uses layout events"),
+        }
+    }
+
+    fn layout_at(&self, offset: u32) -> Option<usize> {
+        self.buffer
+            .layouts
+            .binary_search_by_key(&offset, |layout| layout.start)
+            .ok()
+    }
+
+    fn insert_layout(&mut self, offset: u32, newline: bool) {
+        let index = self
+            .buffer
+            .layouts
+            .partition_point(|layout| layout.start < offset);
+        self.buffer.layouts.insert(
+            index,
+            LayoutSpan {
+                start: offset,
+                raw_len: 0,
+                depth: self.indent_depth,
+                newline,
+                margin: false,
+                dirty: true,
+            },
+        );
+        self.direct_dirty = true;
+    }
+
     #[cfg(test)]
     pub(crate) fn into_buffer(self) -> Buffer {
         self.into_parts().0
@@ -196,7 +473,12 @@ impl Context {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::command::print;
+    use crate::command::{finish_direct, print};
+
+    fn direct_output(ctx: Context<true>) -> String {
+        let (buffer, _, indent, dirty) = ctx.into_direct_parts();
+        finish_direct(buffer, &indent, dirty).0
+    }
 
     #[test]
     fn measure_counts_only_strings() {
@@ -288,5 +570,27 @@ mod tests {
         ctx.discard_scope(scope);
         ctx.write("d");
         assert_eq!(print(&ctx.into_buffer(), "\t", 0), "ad");
+    }
+
+    #[test]
+    fn direct_parent_space_is_superseded_by_child_newline() {
+        let mut parent = Context::new_direct("\t", 0);
+        parent.space();
+        let mut child = parent.child();
+        child.newline();
+        child.write("x");
+        parent.append(child);
+        assert_eq!(direct_output(parent), "\nx");
+    }
+
+    #[test]
+    fn direct_parent_margin_combines_with_child_newline() {
+        let mut parent = Context::new_direct("\t", 0);
+        parent.margin();
+        let mut child = parent.child();
+        child.newline();
+        child.write("x");
+        parent.append(child);
+        assert_eq!(direct_output(parent), "\n\nx");
     }
 }

--- a/crates/rsvelte_esrap/src/lib.rs
+++ b/crates/rsvelte_esrap/src/lib.rs
@@ -111,10 +111,21 @@ pub fn print(program: &Program<'_>, source: &str) -> String {
 pub fn print_with(program: &Program<'_>, source: &str, options: &PrintOptions) -> String {
     let (comments, line_starts) = comments_and_line_starts(program, source);
     if comments.is_empty() {
-        print_with_impl::<false>(program, options, comments, line_starts)
+        print_direct(program, options, source.len())
     } else {
         print_with_impl::<true>(program, options, comments, line_starts)
     }
+}
+
+fn print_direct(program: &Program<'_>, options: &PrintOptions, capacity: usize) -> String {
+    let mut printer =
+        printer::Printer::<false, true>::with_comments(options, Vec::new(), Vec::new());
+    let mut ctx = context::Context::new_direct(&options.indent, capacity);
+    printer.print_program(program, &mut ctx);
+    let (buffer, returned, indent, dirty) = ctx.into_direct_parts();
+    let (code, buffer) = command::finish_direct(buffer, &indent, dirty);
+    pool::give(buffer, returned);
+    code
 }
 
 fn print_with_impl<const HAS_COMMENTS: bool>(
@@ -124,7 +135,7 @@ fn print_with_impl<const HAS_COMMENTS: bool>(
     line_starts: Vec<u32>,
 ) -> String {
     let mut printer =
-        printer::Printer::<HAS_COMMENTS>::with_comments(options, comments, line_starts);
+        printer::Printer::<HAS_COMMENTS, false>::with_comments(options, comments, line_starts);
     let mut ctx = context::Context::new();
     printer.print_program(program, &mut ctx);
     let capacity = ctx.measure();
@@ -199,8 +210,21 @@ fn print_split_impl<const HAS_COMMENTS: bool>(
     line_starts: Vec<u32>,
     map_line_starts: Vec<u32>,
 ) -> PrintWithMap {
+    if !HAS_COMMENTS && map_source.is_none() {
+        let mut printer =
+            printer::Printer::<false, true>::with_comments(options, Vec::new(), Vec::new());
+        let mut ctx = context::Context::new_direct(&options.indent, program.source_text.len());
+        printer.print_program(program, &mut ctx);
+        let (buffer, returned, indent, dirty) = ctx.into_direct_parts();
+        let (code, buffer) = command::finish_direct(buffer, &indent, dirty);
+        pool::give(buffer, returned);
+        return PrintWithMap {
+            code,
+            mappings: Vec::new(),
+        };
+    }
     let mut printer =
-        printer::Printer::<HAS_COMMENTS>::with_comments(options, comments, line_starts)
+        printer::Printer::<HAS_COMMENTS, false>::with_comments(options, comments, line_starts)
             .with_split_coordinates(map_line_starts, loc_base, loc_map, map_source.is_some());
     let mut ctx = context::Context::new();
     printer.print_program(program, &mut ctx);
@@ -252,7 +276,7 @@ fn print_with_map_impl<const HAS_COMMENTS: bool>(
     line_starts: Vec<u32>,
 ) -> PrintWithMap {
     let mut printer =
-        printer::Printer::<HAS_COMMENTS>::with_comments(options, comments, line_starts)
+        printer::Printer::<HAS_COMMENTS, false>::with_comments(options, comments, line_starts)
             .with_source_map();
     let mut ctx = context::Context::new();
     printer.print_program(program, &mut ctx);

--- a/crates/rsvelte_esrap/src/pool.rs
+++ b/crates/rsvelte_esrap/src/pool.rs
@@ -7,6 +7,7 @@ use crate::command::Buffer;
 const MAX_BUFFERS: usize = 8192;
 const MAX_TEXT_CAPACITY: usize = 16 * 1024;
 const MAX_EVENT_CAPACITY: usize = 1024;
+const MAX_LAYOUT_CAPACITY: usize = 1024;
 
 thread_local! {
     static BUFFERS: RefCell<Vec<Buffer>> = const { RefCell::new(Vec::new()) };
@@ -19,7 +20,11 @@ pub fn take() -> Vec<Buffer> {
 pub fn give(mut root: Buffer, mut returned: Vec<Buffer>) {
     root.text.clear();
     root.events.clear();
-    if root.text.capacity() <= MAX_TEXT_CAPACITY && root.events.capacity() <= MAX_EVENT_CAPACITY {
+    root.layouts.clear();
+    if root.text.capacity() <= MAX_TEXT_CAPACITY
+        && root.events.capacity() <= MAX_EVENT_CAPACITY
+        && root.layouts.capacity() <= MAX_LAYOUT_CAPACITY
+    {
         returned.push(root);
     }
     BUFFERS.with(|buffers| {
@@ -32,6 +37,7 @@ pub fn give(mut root: Buffer, mut returned: Vec<Buffer>) {
             };
             if buffer.text.capacity() <= MAX_TEXT_CAPACITY
                 && buffer.events.capacity() <= MAX_EVENT_CAPACITY
+                && buffer.layouts.capacity() <= MAX_LAYOUT_CAPACITY
             {
                 buffers.push(buffer);
             }

--- a/crates/rsvelte_esrap/src/printer.rs
+++ b/crates/rsvelte_esrap/src/printer.rs
@@ -72,7 +72,7 @@ struct KeywordCursor {
 impl KeywordCursor {
     /// Write one fragment (e.g. `"declare "`, `"class "`). Mapped if a cursor is
     /// active, otherwise a plain write.
-    fn write(&mut self, ctx: &mut Context, fragment: &str) {
+    fn write<const DIRECT: bool>(&mut self, ctx: &mut Context<DIRECT>, fragment: &str) {
         if let Some((line, col)) = self.cursor {
             ctx.location(line, col);
             ctx.write(fragment);
@@ -85,7 +85,8 @@ impl KeywordCursor {
     }
 }
 
-pub struct Printer<'opt, const HAS_COMMENTS: bool = true> {
+#[repr(C)]
+pub struct Printer<'opt, const HAS_COMMENTS: bool = true, const DIRECT: bool = false> {
     options: &'opt PrintOptions,
     emit_locations: bool,
     /// Set by the first unsupported node encountered; printing continues so the
@@ -117,7 +118,7 @@ pub struct Printer<'opt, const HAS_COMMENTS: bool = true> {
 /// body across `newline`s so its interior re-indents to the current level. A
 /// free function so the comment-flush loops can hold a `&Cmt` borrowed straight
 /// out of `self.comments` without cloning it.
-fn write_comment(cmt: &Cmt, ctx: &mut Context) {
+fn write_comment<const DIRECT: bool>(cmt: &Cmt, ctx: &mut Context<DIRECT>) {
     let value = &cmt.value;
     if !cmt.block {
         ctx.write(format_compact!("//{value}"));
@@ -417,7 +418,11 @@ fn arrow_concise_body_needs_wrap(body: &Expression) -> bool {
     }
 }
 
-impl<'opt, const HAS_COMMENTS: bool> Printer<'opt, HAS_COMMENTS> {
+impl<'opt, const HAS_COMMENTS: bool, const DIRECT: bool> Printer<'opt, HAS_COMMENTS, DIRECT> {
+    fn deferred(&mut self) -> &mut Printer<'opt, HAS_COMMENTS, false> {
+        // SAFETY: the const parameter does not affect the repr(C) field layout.
+        unsafe { &mut *(std::ptr::from_mut(self).cast()) }
+    }
     #[cfg(test)]
     pub const fn new(options: &'opt PrintOptions) -> Self {
         Self {
@@ -531,7 +536,7 @@ impl<'opt, const HAS_COMMENTS: bool> Printer<'opt, HAS_COMMENTS> {
 
     /// esrap's `write_source_keyword`: bracket the literal `keyword` with
     /// source-map anchors for its exact span, so breakpoints land on the keyword.
-    fn write_source_keyword(ctx: &mut Context, line: u32, column: u32, keyword: &str) {
+    fn write_source_keyword(ctx: &mut Context<DIRECT>, line: u32, column: u32, keyword: &str) {
         ctx.location(line, column);
         ctx.write(keyword);
         ctx.location(line, column + usize_to_u32(keyword.len()));
@@ -541,7 +546,7 @@ impl<'opt, const HAS_COMMENTS: bool> Printer<'opt, HAS_COMMENTS> {
     /// `start` (resolved to a source `loc`), then append an unmapped `suffix`. If
     /// the offset can't be resolved (no source context), falls back to a plain
     /// `keyword + suffix` write.
-    fn write_keyword(&self, ctx: &mut Context, start: u32, keyword: &str, suffix: &str) {
+    fn write_keyword(&self, ctx: &mut Context<DIRECT>, start: u32, keyword: &str, suffix: &str) {
         if !self.emit_locations {
             ctx.write(keyword);
             ctx.write(suffix);
@@ -622,7 +627,7 @@ impl<'opt, const HAS_COMMENTS: bool> Printer<'opt, HAS_COMMENTS> {
     /// blank line before a detached leading comment block.
     fn flush_comments_until(
         &mut self,
-        ctx: &mut Context,
+        ctx: &mut Context<DIRECT>,
         to: u32,
         to_line: u32,
         from_line: Option<u32>,
@@ -666,7 +671,7 @@ impl<'opt, const HAS_COMMENTS: bool> Printer<'opt, HAS_COMMENTS> {
     /// on to force the wrapped one-arg-per-line form.
     fn flush_trailing_comments(
         &mut self,
-        ctx: &mut Context,
+        ctx: &mut Context<DIRECT>,
         prev_end: u32,
         next: Option<u32>,
     ) -> bool {
@@ -730,7 +735,7 @@ impl<'opt, const HAS_COMMENTS: bool> Printer<'opt, HAS_COMMENTS> {
     }
 
     /// The `_` wildcard's leading flush: emit comments positioned before `node`.
-    fn flush_leading(&mut self, ctx: &mut Context, node_start: u32) {
+    fn flush_leading(&mut self, ctx: &mut Context<DIRECT>, node_start: u32) {
         if !HAS_COMMENTS {
             return;
         }
@@ -755,7 +760,7 @@ impl<'opt, const HAS_COMMENTS: bool> Printer<'opt, HAS_COMMENTS> {
         pad: bool,
         separator: &'static str,
         trailing_newline: bool,
-        parent: &mut Context,
+        parent: &mut Context<DIRECT>,
     ) {
         let n = nodes.len();
         let mut multiline = false;
@@ -773,7 +778,7 @@ impl<'opt, const HAS_COMMENTS: bool> Printer<'opt, HAS_COMMENTS> {
         let mut items: Vec<SeqItem> = Vec::with_capacity(n);
         for (i, node) in nodes.iter_mut().enumerate() {
             let mut child = parent.child();
-            (node.render)(self, &mut child);
+            (node.render)(self.deferred(), &mut child);
 
             let node_multiline = child.multiline;
 
@@ -787,7 +792,8 @@ impl<'opt, const HAS_COMMENTS: bool> Printer<'opt, HAS_COMMENTS> {
             // start, or `until` for the final node.
             let next = if i == n - 1 { until } else { starts[i + 1] };
             if let Some(end) = node.end {
-                self.flush_trailing_comments(&mut child, end, next);
+                self.deferred()
+                    .flush_trailing_comments(&mut child, end, next);
             }
 
             length += usize_to_i64(child.measure()) + 1;
@@ -852,12 +858,12 @@ impl<'opt, const HAS_COMMENTS: bool> Printer<'opt, HAS_COMMENTS> {
         &mut self,
         n: usize,
         mut meta: impl FnMut(usize) -> SeqMeta,
-        mut render: impl FnMut(&mut Self, usize, &mut Context),
+        mut render: impl FnMut(&mut Self, usize, &mut Context<DIRECT>),
         until: Option<u32>,
         pad: bool,
         separator: &'static str,
         trailing_newline: bool,
-        parent: &mut Context,
+        parent: &mut Context<DIRECT>,
     ) {
         if n == 0 {
             if let Some(until) = until {
@@ -1078,12 +1084,12 @@ impl<'opt, const HAS_COMMENTS: bool> Printer<'opt, HAS_COMMENTS> {
         &mut self,
         nodes: &[T],
         mut meta: impl FnMut(&T) -> SeqMeta,
-        mut render: impl FnMut(&mut Self, &T, &mut Context),
+        mut render: impl FnMut(&mut Self, &T, &mut Context<DIRECT>),
         until: Option<u32>,
         pad: bool,
         separator: &'static str,
         trailing_newline: bool,
-        parent: &mut Context,
+        parent: &mut Context<DIRECT>,
     ) {
         self.sequence_indexed(
             nodes.len(),
@@ -1097,7 +1103,7 @@ impl<'opt, const HAS_COMMENTS: bool> Printer<'opt, HAS_COMMENTS> {
         );
     }
 
-    fn unsupported(&mut self, kind: &'static str, ctx: &mut Context) {
+    fn unsupported(&mut self, kind: &'static str, ctx: &mut Context<DIRECT>) {
         if self.missing.is_none() {
             self.missing = Some(Unsupported(kind));
         }
@@ -1108,7 +1114,7 @@ impl<'opt, const HAS_COMMENTS: bool> Printer<'opt, HAS_COMMENTS> {
 
     // ----- statements -------------------------------------------------------
 
-    pub fn print_program(&mut self, program: &Program, ctx: &mut Context) {
+    pub fn print_program(&mut self, program: &Program, ctx: &mut Context<DIRECT>) {
         let span = program.span();
         // Upstream's program is builder-made and carries no `loc`, so its
         // statement list discards the pending comments and only a nested body
@@ -1139,7 +1145,7 @@ impl<'opt, const HAS_COMMENTS: bool> Printer<'opt, HAS_COMMENTS> {
         statements: &[Statement],
         body_start: u32,
         body_end: u32,
-        ctx: &mut Context,
+        ctx: &mut Context<DIRECT>,
     ) {
         self.body_elems(
             statements.iter().map(BodyElem::Statement),
@@ -1156,7 +1162,7 @@ impl<'opt, const HAS_COMMENTS: bool> Printer<'opt, HAS_COMMENTS> {
         elems: impl IntoIterator<Item = BodyElem<'a, 'b>>,
         body_start: Option<u32>,
         body_end: u32,
-        ctx: &mut Context,
+        ctx: &mut Context<DIRECT>,
     ) where
         'a: 'b,
     {
@@ -1221,7 +1227,7 @@ impl<'opt, const HAS_COMMENTS: bool> Printer<'opt, HAS_COMMENTS> {
 
     /// A program/function-body directive (`"use strict";`), printed like the
     /// string-literal `ExpressionStatement` esrap sees.
-    fn print_directive(&mut self, d: &Directive, ctx: &mut Context) {
+    fn print_directive(&mut self, d: &Directive, ctx: &mut Context<DIRECT>) {
         let start = d.span.start;
         self.flush_leading(ctx, start);
         ctx.write(Self::string_literal(&d.expression));
@@ -1229,7 +1235,7 @@ impl<'opt, const HAS_COMMENTS: bool> Printer<'opt, HAS_COMMENTS> {
     }
 
     #[allow(clippy::too_many_lines)]
-    fn print_statement(&mut self, stmt: &Statement, ctx: &mut Context) {
+    fn print_statement(&mut self, stmt: &Statement, ctx: &mut Context<DIRECT>) {
         // esrap's `_` wildcard: emit comments positioned before this node first.
         let start = stmt.span().start;
         self.flush_leading(ctx, start);
@@ -1396,7 +1402,7 @@ impl<'opt, const HAS_COMMENTS: bool> Printer<'opt, HAS_COMMENTS> {
         }
     }
 
-    fn import_declaration(&mut self, node: &ImportDeclaration, ctx: &mut Context) {
+    fn import_declaration(&mut self, node: &ImportDeclaration, ctx: &mut Context<DIRECT>) {
         if node.specifiers.as_ref().is_none_or(|v| v.is_empty()) {
             ctx.write("import ");
             ctx.write(Self::string_literal(&node.source));
@@ -1444,7 +1450,9 @@ impl<'opt, const HAS_COMMENTS: bool> Printer<'opt, HAS_COMMENTS> {
                         is_elision: false,
                     }
                 },
-                |_p, s, child| Printer::<HAS_COMMENTS>::import_specifier(s, child),
+                |_p, s, child| {
+                    Printer::<HAS_COMMENTS, DIRECT>::import_specifier(s, child);
+                },
                 None,
                 true,
                 ",",
@@ -1460,7 +1468,7 @@ impl<'opt, const HAS_COMMENTS: bool> Printer<'opt, HAS_COMMENTS> {
     }
 
     /// esrap's import-attributes tail: ` with { key: value, … }`.
-    fn import_attributes(clause: Option<&WithClause>, ctx: &mut Context) {
+    fn import_attributes(clause: Option<&WithClause>, ctx: &mut Context<DIRECT>) {
         let Some(clause) = clause else { return };
         if clause.with_entries.is_empty() {
             return;
@@ -1480,7 +1488,7 @@ impl<'opt, const HAS_COMMENTS: bool> Printer<'opt, HAS_COMMENTS> {
         ctx.write(" }");
     }
 
-    fn import_specifier(node: &ImportSpecifier, ctx: &mut Context) {
+    fn import_specifier(node: &ImportSpecifier, ctx: &mut Context<DIRECT>) {
         if matches!(node.import_kind, ImportOrExportKind::Type) {
             ctx.write("type ");
         }
@@ -1500,7 +1508,7 @@ impl<'opt, const HAS_COMMENTS: bool> Printer<'opt, HAS_COMMENTS> {
         ctx.write(node.local.name.as_str());
     }
 
-    fn export_declaration(&mut self, node: &ExportDeclaration, ctx: &mut Context) {
+    fn export_declaration(&mut self, node: &ExportDeclaration, ctx: &mut Context<DIRECT>) {
         // A class declaration's decorators are printed *before* `export`.
         if let Declaration::ClassDeclaration(c) = &node.declaration
             && !c.decorators.is_empty()
@@ -1521,7 +1529,7 @@ impl<'opt, const HAS_COMMENTS: bool> Printer<'opt, HAS_COMMENTS> {
         span_start: u32,
         specifiers: &[ExportSpecifier],
         export_kind: ImportOrExportKind,
-        ctx: &mut Context,
+        ctx: &mut Context<DIRECT>,
     ) {
         let mut kw = self.keyword_cursor(span_start, true);
         kw.write(ctx, "export ");
@@ -1540,7 +1548,9 @@ impl<'opt, const HAS_COMMENTS: bool> Printer<'opt, HAS_COMMENTS> {
                     is_elision: false,
                 }
             },
-            |_p, s, child| Printer::<HAS_COMMENTS>::export_specifier(s, child),
+            |_p, s, child| {
+                Printer::<HAS_COMMENTS, DIRECT>::export_specifier(s, child);
+            },
             None,
             true,
             ",",
@@ -1550,19 +1560,27 @@ impl<'opt, const HAS_COMMENTS: bool> Printer<'opt, HAS_COMMENTS> {
         ctx.write("}");
     }
 
-    fn export_named_declaration(&mut self, node: &ExportNamedDeclaration, ctx: &mut Context) {
+    fn export_named_declaration(
+        &mut self,
+        node: &ExportNamedDeclaration,
+        ctx: &mut Context<DIRECT>,
+    ) {
         self.export_specifier_list(node.span().start, &node.specifiers, node.export_kind, ctx);
         ctx.write(";");
     }
 
-    fn export_from_declaration(&mut self, node: &ExportFromDeclaration, ctx: &mut Context) {
+    fn export_from_declaration(&mut self, node: &ExportFromDeclaration, ctx: &mut Context<DIRECT>) {
         self.export_specifier_list(node.span().start, &node.specifiers, node.export_kind, ctx);
         ctx.write(" from ");
         ctx.write(Self::string_literal(&node.source));
         ctx.write(";");
     }
 
-    fn export_default_declaration(&mut self, node: &ExportDefaultDeclaration, ctx: &mut Context) {
+    fn export_default_declaration(
+        &mut self,
+        node: &ExportDefaultDeclaration,
+        ctx: &mut Context<DIRECT>,
+    ) {
         // esrap: `export ` then `default ` via a keyword cursor, mapped only when
         // the export is single-line (`single_line_node`).
         let map_ok = self
@@ -1592,7 +1610,7 @@ impl<'opt, const HAS_COMMENTS: bool> Printer<'opt, HAS_COMMENTS> {
         }
     }
 
-    fn template_literal(&mut self, node: &TemplateLiteral, ctx: &mut Context) {
+    fn template_literal(&mut self, node: &TemplateLiteral, ctx: &mut Context<DIRECT>) {
         ctx.write("`");
         for (i, expr) in node.expressions.iter().enumerate() {
             let raw = node.quasis.get(i).map_or("", |q| q.value.raw.as_str());
@@ -1616,7 +1634,7 @@ impl<'opt, const HAS_COMMENTS: bool> Printer<'opt, HAS_COMMENTS> {
         }
     }
 
-    fn export_specifier(node: &ExportSpecifier, ctx: &mut Context) {
+    fn export_specifier(node: &ExportSpecifier, ctx: &mut Context<DIRECT>) {
         if matches!(node.export_kind, ImportOrExportKind::Type) {
             ctx.write("type ");
         }
@@ -1631,7 +1649,7 @@ impl<'opt, const HAS_COMMENTS: bool> Printer<'opt, HAS_COMMENTS> {
 
     /// Print a `Declaration` node (the RHS of `export <decl>` and standalone
     /// declarations). Only the variable form is wired so far.
-    fn declaration(&mut self, decl: &Declaration, ctx: &mut Context) {
+    fn declaration(&mut self, decl: &Declaration, ctx: &mut Context<DIRECT>) {
         match decl {
             Declaration::VariableDeclaration(d) => {
                 self.variable_declaration(d, ctx);
@@ -1651,7 +1669,7 @@ impl<'opt, const HAS_COMMENTS: bool> Printer<'opt, HAS_COMMENTS> {
 
     /// esrap's `FunctionDeclaration|FunctionExpression`:
     /// `[async ]function[* ] id(params) { body }`.
-    fn function(&mut self, node: &Function, ctx: &mut Context) {
+    fn function(&mut self, node: &Function, ctx: &mut Context<DIRECT>) {
         if node.declare {
             ctx.write("declare ");
         }
@@ -1715,7 +1733,7 @@ impl<'opt, const HAS_COMMENTS: bool> Printer<'opt, HAS_COMMENTS> {
     }
 
     /// esrap's `ClassDeclaration|ClassExpression`: `class [id ][extends sup ]{…}`.
-    fn class_node(&mut self, node: &Class, ctx: &mut Context) {
+    fn class_node(&mut self, node: &Class, ctx: &mut Context<DIRECT>) {
         for decorator in &node.decorators {
             self.decorator(decorator, ctx);
         }
@@ -1724,7 +1742,7 @@ impl<'opt, const HAS_COMMENTS: bool> Printer<'opt, HAS_COMMENTS> {
 
     /// The class body sans leading decorators (already emitted by the caller —
     /// e.g. `export @dec class`, which prints decorators before `export`).
-    fn class_node_no_decorators(&mut self, node: &Class, ctx: &mut Context) {
+    fn class_node_no_decorators(&mut self, node: &Class, ctx: &mut Context<DIRECT>) {
         // esrap's class modifier keyword cursor: `declare `/`abstract `/`class `
         // mapped to their source span when `class_modifier_keywords_map_ok`
         // (no decorators, id/body on the node's start line).
@@ -1768,7 +1786,8 @@ impl<'opt, const HAS_COMMENTS: bool> Printer<'opt, HAS_COMMENTS> {
                         obj_or_array: false,
                         is_elision: false,
                         render: Box::new(
-                            move |p: &mut Printer<'_, HAS_COMMENTS>, child: &mut Context| {
+                            move |p: &mut Printer<'_, HAS_COMMENTS, false>,
+                                  child: &mut Context<false>| {
                                 Printer::<HAS_COMMENTS>::print_type_name(&imp.expression, child);
                                 if let Some(ta) = &imp.type_arguments {
                                     p.type_parameter_instantiation(ta, child);
@@ -1783,7 +1802,7 @@ impl<'opt, const HAS_COMMENTS: bool> Printer<'opt, HAS_COMMENTS> {
         self.class_body(&node.body, ctx);
     }
 
-    fn decorator(&mut self, node: &Decorator, ctx: &mut Context) {
+    fn decorator(&mut self, node: &Decorator, ctx: &mut Context<DIRECT>) {
         ctx.write("@");
         self.print_expression(&node.expression, ctx);
         ctx.newline();
@@ -1793,7 +1812,7 @@ impl<'opt, const HAS_COMMENTS: bool> Printer<'opt, HAS_COMMENTS> {
     /// `body` machinery (one-per-line, blank line between two multiline members
     /// or a change of member kind) so leading / trailing / end-of-body comments
     /// are interleaved identically to a statement block.
-    fn class_body(&mut self, body: &ClassBody, ctx: &mut Context) {
+    fn class_body(&mut self, body: &ClassBody, ctx: &mut Context<DIRECT>) {
         let span = body.span();
         ctx.write("{");
         let mark = ctx.event_mark();
@@ -1818,7 +1837,7 @@ impl<'opt, const HAS_COMMENTS: bool> Printer<'opt, HAS_COMMENTS> {
         ctx.write("}");
     }
 
-    fn class_element(&mut self, element: &ClassElement, ctx: &mut Context) {
+    fn class_element(&mut self, element: &ClassElement, ctx: &mut Context<DIRECT>) {
         // esrap's `_` wildcard flushes any comment positioned before the member
         // (e.g. a leading JSDoc block) before visiting it.
         let start = element.span().start;
@@ -1836,7 +1855,7 @@ impl<'opt, const HAS_COMMENTS: bool> Printer<'opt, HAS_COMMENTS> {
         }
     }
 
-    fn method_definition(&mut self, node: &MethodDefinition, ctx: &mut Context) {
+    fn method_definition(&mut self, node: &MethodDefinition, ctx: &mut Context<DIRECT>) {
         for decorator in &node.decorators {
             self.decorator(decorator, ctx);
         }
@@ -1906,7 +1925,7 @@ impl<'opt, const HAS_COMMENTS: bool> Printer<'opt, HAS_COMMENTS> {
         }
     }
 
-    fn property_definition(&mut self, node: &PropertyDefinition, ctx: &mut Context) {
+    fn property_definition(&mut self, node: &PropertyDefinition, ctx: &mut Context<DIRECT>) {
         for decorator in &node.decorators {
             self.decorator(decorator, ctx);
         }
@@ -1955,7 +1974,7 @@ impl<'opt, const HAS_COMMENTS: bool> Printer<'opt, HAS_COMMENTS> {
         ctx.write(";");
     }
 
-    fn accessor_property(&mut self, node: &AccessorProperty, ctx: &mut Context) {
+    fn accessor_property(&mut self, node: &AccessorProperty, ctx: &mut Context<DIRECT>) {
         for decorator in &node.decorators {
             self.decorator(decorator, ctx);
         }
@@ -1993,7 +2012,7 @@ impl<'opt, const HAS_COMMENTS: bool> Printer<'opt, HAS_COMMENTS> {
         ctx.write(";");
     }
 
-    fn if_statement(&mut self, node: &IfStatement, ctx: &mut Context) {
+    fn if_statement(&mut self, node: &IfStatement, ctx: &mut Context<DIRECT>) {
         self.write_keyword(ctx, node.span().start, "if", " (");
         self.print_expression(&node.test, ctx);
         ctx.write(") ");
@@ -2019,7 +2038,7 @@ impl<'opt, const HAS_COMMENTS: bool> Printer<'opt, HAS_COMMENTS> {
         }
     }
 
-    fn do_while_statement(&mut self, node: &DoWhileStatement, ctx: &mut Context) {
+    fn do_while_statement(&mut self, node: &DoWhileStatement, ctx: &mut Context<DIRECT>) {
         self.write_keyword(ctx, node.span().start, "do", " ");
         self.print_statement(&node.body, ctx);
         // esrap maps the trailing `while` to a computed offset (one past the body
@@ -2038,7 +2057,7 @@ impl<'opt, const HAS_COMMENTS: bool> Printer<'opt, HAS_COMMENTS> {
         ctx.write(");");
     }
 
-    fn for_statement(&mut self, node: &ForStatement, ctx: &mut Context) {
+    fn for_statement(&mut self, node: &ForStatement, ctx: &mut Context<DIRECT>) {
         ctx.write("for (");
         if let Some(init) = &node.init {
             match init {
@@ -2063,7 +2082,7 @@ impl<'opt, const HAS_COMMENTS: bool> Printer<'opt, HAS_COMMENTS> {
     }
 
     /// The binding of a `for…in` / `for…of` head: a declaration or a target.
-    fn for_statement_left(&mut self, left: &ForStatementLeft, ctx: &mut Context) {
+    fn for_statement_left(&mut self, left: &ForStatementLeft, ctx: &mut Context<DIRECT>) {
         match left {
             ForStatementLeft::VariableDeclaration(d) => self.variable_declaration(d, ctx),
             _ => match left.as_assignment_target() {
@@ -2074,7 +2093,7 @@ impl<'opt, const HAS_COMMENTS: bool> Printer<'opt, HAS_COMMENTS> {
     }
 
     /// esrap's `TryStatement`: `try {…}` + optional `catch (p) {…}` + `finally {…}`.
-    fn try_statement(&mut self, node: &TryStatement, ctx: &mut Context) {
+    fn try_statement(&mut self, node: &TryStatement, ctx: &mut Context<DIRECT>) {
         self.write_keyword(ctx, node.span().start, "try", " ");
         let span = node.block.span();
         self.block(&node.block.body, span.start, span.end, ctx);
@@ -2118,7 +2137,7 @@ impl<'opt, const HAS_COMMENTS: bool> Printer<'opt, HAS_COMMENTS> {
 
     /// esrap's `SwitchStatement`: `switch (disc) {`, each case indented with a
     /// blank-line margin between cases, statements one-per-line.
-    fn switch_statement(&mut self, node: &SwitchStatement, ctx: &mut Context) {
+    fn switch_statement(&mut self, node: &SwitchStatement, ctx: &mut Context<DIRECT>) {
         self.write_keyword(ctx, node.span().start, "switch", " (");
         self.print_expression(&node.discriminant, ctx);
         ctx.write(") {");
@@ -2150,7 +2169,7 @@ impl<'opt, const HAS_COMMENTS: bool> Printer<'opt, HAS_COMMENTS> {
         ctx.write("}");
     }
 
-    fn object_pattern(&mut self, node: &ObjectPattern, ctx: &mut Context) {
+    fn object_pattern(&mut self, node: &ObjectPattern, ctx: &mut Context<DIRECT>) {
         ctx.write("{");
         let property_len = node.properties.len();
         let n = property_len + usize::from(node.rest.is_some());
@@ -2192,7 +2211,7 @@ impl<'opt, const HAS_COMMENTS: bool> Printer<'opt, HAS_COMMENTS> {
         ctx.write("}");
     }
 
-    fn binding_property(&mut self, node: &BindingProperty, ctx: &mut Context) {
+    fn binding_property(&mut self, node: &BindingProperty, ctx: &mut Context<DIRECT>) {
         if node.shorthand {
             self.binding_pattern(&node.value, ctx);
             return;
@@ -2208,7 +2227,7 @@ impl<'opt, const HAS_COMMENTS: bool> Printer<'opt, HAS_COMMENTS> {
         self.binding_pattern(&node.value, ctx);
     }
 
-    fn array_pattern(&mut self, node: &ArrayPattern, ctx: &mut Context) {
+    fn array_pattern(&mut self, node: &ArrayPattern, ctx: &mut Context<DIRECT>) {
         ctx.write("[");
         let element_len = node.elements.len();
         let n = element_len + usize::from(node.rest.is_some());
@@ -2254,7 +2273,7 @@ impl<'opt, const HAS_COMMENTS: bool> Printer<'opt, HAS_COMMENTS> {
     }
 
     /// Parameter list via esrap's `sequence` (no padding): `a, b, ...rest`.
-    fn formal_parameters(&mut self, params: &FormalParameters, ctx: &mut Context) {
+    fn formal_parameters(&mut self, params: &FormalParameters, ctx: &mut Context<DIRECT>) {
         self.formal_parameters_with_this(params, None, Some(params.span().end), ctx);
     }
 
@@ -2265,7 +2284,7 @@ impl<'opt, const HAS_COMMENTS: bool> Printer<'opt, HAS_COMMENTS> {
         params: &FormalParameters,
         this_param: Option<&TSThisParameter>,
         until: Option<u32>,
-        ctx: &mut Context,
+        ctx: &mut Context<DIRECT>,
     ) {
         let this_len = usize::from(this_param.is_some());
         let item_len = params.items.len();
@@ -2336,7 +2355,7 @@ impl<'opt, const HAS_COMMENTS: bool> Printer<'opt, HAS_COMMENTS> {
 
     /// esrap's `ArrowFunctionExpression`: `[async ](params) => body`, wrapping an
     /// object concise body in parens so it isn't read as a block.
-    fn arrow_function(&mut self, node: &ArrowFunctionExpression, ctx: &mut Context) {
+    fn arrow_function(&mut self, node: &ArrowFunctionExpression, ctx: &mut Context<DIRECT>) {
         if node.r#async {
             ctx.write("async ");
         }
@@ -2369,7 +2388,13 @@ impl<'opt, const HAS_COMMENTS: bool> Printer<'opt, HAS_COMMENTS> {
 
     /// esrap's `BlockStatement|ClassBody`: only break a body across lines when
     /// it has real content, so an empty body stays `{}`.
-    fn block(&mut self, body: &[Statement], body_start: u32, body_end: u32, ctx: &mut Context) {
+    fn block(
+        &mut self,
+        body: &[Statement],
+        body_start: u32,
+        body_end: u32,
+        ctx: &mut Context<DIRECT>,
+    ) {
         if !HAS_COMMENTS {
             let keep_empty = self.options.keep_empty_statements;
             let has_content = body.iter().any(|statement| {
@@ -2411,7 +2436,7 @@ impl<'opt, const HAS_COMMENTS: bool> Printer<'opt, HAS_COMMENTS> {
     /// declarators one-per-line — joined by `,\n` and indented — when any
     /// declarator is itself multiline (e.g. carries a leading comment) or there
     /// is more than one and they don't fit (`measure + 2*(n-1) > 50`).
-    fn variable_declaration(&mut self, decl: &VariableDeclaration, ctx: &mut Context) {
+    fn variable_declaration(&mut self, decl: &VariableDeclaration, ctx: &mut Context<DIRECT>) {
         // esrap's `handle_var_declaration`: a keyword cursor anchored at the
         // declaration start writes `declare ` (if present) then the kind keyword,
         // each mapped to its source span so breakpoints land on `let`/`const`/etc.
@@ -2495,7 +2520,7 @@ impl<'opt, const HAS_COMMENTS: bool> Printer<'opt, HAS_COMMENTS> {
         }
     }
 
-    fn binding_pattern(&mut self, pattern: &BindingPattern, ctx: &mut Context) {
+    fn binding_pattern(&mut self, pattern: &BindingPattern, ctx: &mut Context<DIRECT>) {
         match pattern {
             BindingPattern::BindingIdentifier(id) => ctx.write(id.name.as_str()),
             BindingPattern::AssignmentPattern(a) => {
@@ -2511,7 +2536,7 @@ impl<'opt, const HAS_COMMENTS: bool> Printer<'opt, HAS_COMMENTS> {
     // ----- expressions ------------------------------------------------------
 
     #[allow(clippy::too_many_lines)]
-    fn print_expression(&mut self, expr: &Expression, ctx: &mut Context) {
+    fn print_expression(&mut self, expr: &Expression, ctx: &mut Context<DIRECT>) {
         // esrap's `_` wildcard: emit comments positioned before this node first.
         let start = expr.span().start;
         self.flush_leading(ctx, start);
@@ -2692,7 +2717,7 @@ impl<'opt, const HAS_COMMENTS: bool> Printer<'opt, HAS_COMMENTS> {
 
     // ----- JSX (port of esrap's `languages/tsx`) ---------------------------
 
-    fn jsx_element(&mut self, node: &JSXElement, ctx: &mut Context) {
+    fn jsx_element(&mut self, node: &JSXElement, ctx: &mut Context<DIRECT>) {
         // oxc derives self-closing from the absence of a closing element.
         self.jsx_opening_element(&node.opening_element, node.closing_element.is_none(), ctx);
         if !node.children.is_empty() {
@@ -2711,7 +2736,7 @@ impl<'opt, const HAS_COMMENTS: bool> Printer<'opt, HAS_COMMENTS> {
         }
     }
 
-    fn jsx_fragment(&mut self, node: &JSXFragment, ctx: &mut Context) {
+    fn jsx_fragment(&mut self, node: &JSXFragment, ctx: &mut Context<DIRECT>) {
         ctx.write("<>");
         if !node.children.is_empty() {
             ctx.indent();
@@ -2729,7 +2754,7 @@ impl<'opt, const HAS_COMMENTS: bool> Printer<'opt, HAS_COMMENTS> {
         &mut self,
         node: &JSXOpeningElement,
         self_closing: bool,
-        ctx: &mut Context,
+        ctx: &mut Context<DIRECT>,
     ) {
         ctx.write("<");
         Self::jsx_element_name(&node.name, ctx);
@@ -2759,7 +2784,7 @@ impl<'opt, const HAS_COMMENTS: bool> Printer<'opt, HAS_COMMENTS> {
         ctx.write(">");
     }
 
-    fn jsx_child(&mut self, child: &JSXChild, ctx: &mut Context) {
+    fn jsx_child(&mut self, child: &JSXChild, ctx: &mut Context<DIRECT>) {
         match child {
             JSXChild::Text(t) => ctx.write(t.value.as_str()),
             JSXChild::Element(e) => self.jsx_element(e, ctx),
@@ -2773,7 +2798,11 @@ impl<'opt, const HAS_COMMENTS: bool> Printer<'opt, HAS_COMMENTS> {
         }
     }
 
-    fn jsx_expression_container(&mut self, node: &JSXExpressionContainer, ctx: &mut Context) {
+    fn jsx_expression_container(
+        &mut self,
+        node: &JSXExpressionContainer,
+        ctx: &mut Context<DIRECT>,
+    ) {
         ctx.write("{");
         // A `JSXEmptyExpression` (e.g. `{}` or `{/* comment */}`) prints nothing.
         if let Some(expr) = node.expression.as_expression() {
@@ -2782,7 +2811,7 @@ impl<'opt, const HAS_COMMENTS: bool> Printer<'opt, HAS_COMMENTS> {
         ctx.write("}");
     }
 
-    fn jsx_attribute_value(&mut self, value: &JSXAttributeValue, ctx: &mut Context) {
+    fn jsx_attribute_value(&mut self, value: &JSXAttributeValue, ctx: &mut Context<DIRECT>) {
         match value {
             JSXAttributeValue::StringLiteral(s) => ctx.write(Self::string_literal(s)),
             JSXAttributeValue::ExpressionContainer(c) => self.jsx_expression_container(c, ctx),
@@ -2791,7 +2820,7 @@ impl<'opt, const HAS_COMMENTS: bool> Printer<'opt, HAS_COMMENTS> {
         }
     }
 
-    fn jsx_attribute_name(name: &JSXAttributeName, ctx: &mut Context) {
+    fn jsx_attribute_name(name: &JSXAttributeName, ctx: &mut Context<DIRECT>) {
         match name {
             JSXAttributeName::Identifier(id) => ctx.write(id.name.as_str()),
             JSXAttributeName::NamespacedName(n) => {
@@ -2802,7 +2831,7 @@ impl<'opt, const HAS_COMMENTS: bool> Printer<'opt, HAS_COMMENTS> {
         }
     }
 
-    fn jsx_element_name(name: &JSXElementName, ctx: &mut Context) {
+    fn jsx_element_name(name: &JSXElementName, ctx: &mut Context<DIRECT>) {
         match name {
             JSXElementName::Identifier(id) => ctx.write(id.name.as_str()),
             JSXElementName::IdentifierReference(id) => ctx.write(id.name.as_str()),
@@ -2816,7 +2845,7 @@ impl<'opt, const HAS_COMMENTS: bool> Printer<'opt, HAS_COMMENTS> {
         }
     }
 
-    fn jsx_member_expression(node: &JSXMemberExpression, ctx: &mut Context) {
+    fn jsx_member_expression(node: &JSXMemberExpression, ctx: &mut Context<DIRECT>) {
         match &node.object {
             JSXMemberExpressionObject::IdentifierReference(id) => ctx.write(id.name.as_str()),
             JSXMemberExpressionObject::MemberExpression(m) => Self::jsx_member_expression(m, ctx),
@@ -2834,7 +2863,7 @@ impl<'opt, const HAS_COMMENTS: bool> Printer<'opt, HAS_COMMENTS> {
     /// `ChainExpression` at the top, so its inner member objects are plain
     /// members/identifiers and never trip this — only an explicitly nested chain
     /// (the snippet-argument base) does.
-    fn member_object_with_parens(&mut self, object: &Expression, ctx: &mut Context) {
+    fn member_object_with_parens(&mut self, object: &Expression, ctx: &mut Context<DIRECT>) {
         // oxc keeps a `ParenthesizedExpression` around the nested chain, which
         // `print_expression` would then drop — look through it as the callee
         // rule does, so the required parens are not lost.
@@ -2848,7 +2877,7 @@ impl<'opt, const HAS_COMMENTS: bool> Printer<'opt, HAS_COMMENTS> {
     }
 
     /// Print `child` parenthesised iff its precedence is below `min`.
-    fn child_with_parens(&mut self, child: &Expression, min: u8, ctx: &mut Context) {
+    fn child_with_parens(&mut self, child: &Expression, min: u8, ctx: &mut Context<DIRECT>) {
         if expr_precedence(child) < min {
             ctx.write("(");
             self.print_expression(child, ctx);
@@ -2858,7 +2887,7 @@ impl<'opt, const HAS_COMMENTS: bool> Printer<'opt, HAS_COMMENTS> {
         }
     }
 
-    fn binary_expression(&mut self, node: &BinaryExpression, ctx: &mut Context) {
+    fn binary_expression(&mut self, node: &BinaryExpression, ctx: &mut Context<DIRECT>) {
         let op = node.operator.as_str();
         self.binary_child(&node.left, false, op, false, ctx);
         ctx.write(" ");
@@ -2867,7 +2896,7 @@ impl<'opt, const HAS_COMMENTS: bool> Printer<'opt, HAS_COMMENTS> {
         self.binary_child(&node.right, false, op, true, ctx);
     }
 
-    fn logical_expression(&mut self, node: &LogicalExpression, ctx: &mut Context) {
+    fn logical_expression(&mut self, node: &LogicalExpression, ctx: &mut Context<DIRECT>) {
         let op = node.operator.as_str();
         self.binary_child(&node.left, true, op, false, ctx);
         ctx.write(" ");
@@ -2885,7 +2914,7 @@ impl<'opt, const HAS_COMMENTS: bool> Printer<'opt, HAS_COMMENTS> {
         parent_is_logical: bool,
         parent_op: &str,
         is_right: bool,
-        ctx: &mut Context,
+        ctx: &mut Context<DIRECT>,
     ) {
         if binary_needs_parens(child, parent_is_logical, parent_op, is_right) {
             ctx.write("(");
@@ -2896,7 +2925,7 @@ impl<'opt, const HAS_COMMENTS: bool> Printer<'opt, HAS_COMMENTS> {
         }
     }
 
-    fn unary_expression(&mut self, node: &UnaryExpression, ctx: &mut Context) {
+    fn unary_expression(&mut self, node: &UnaryExpression, ctx: &mut Context<DIRECT>) {
         let op = node.operator.as_str();
         // `typeof`/`void`/`delete` are word operators and need a trailing space.
         if matches!(
@@ -2911,7 +2940,7 @@ impl<'opt, const HAS_COMMENTS: bool> Printer<'opt, HAS_COMMENTS> {
         self.child_with_parens(&node.argument, 15, ctx);
     }
 
-    fn call_expression(&mut self, node: &CallExpression, ctx: &mut Context) {
+    fn call_expression(&mut self, node: &CallExpression, ctx: &mut Context<DIRECT>) {
         // esrap's `CallExpression|NewExpression` wrap rule: parenthesize the
         // callee when it is a ChainExpression — otherwise a NON-optional call on
         // an optional-chain callee (`(a?.b)(c)`) would be mis-printed as the
@@ -2931,13 +2960,13 @@ impl<'opt, const HAS_COMMENTS: bool> Printer<'opt, HAS_COMMENTS> {
         self.call_arguments(&node.arguments, node.span().end, ctx);
     }
 
-    fn static_member(&mut self, node: &StaticMemberExpression, ctx: &mut Context) {
+    fn static_member(&mut self, node: &StaticMemberExpression, ctx: &mut Context<DIRECT>) {
         self.member_object_with_parens(&node.object, ctx);
         ctx.write(if node.optional { "?." } else { "." });
         ctx.write(node.property.name.as_str());
     }
 
-    fn computed_member(&mut self, node: &ComputedMemberExpression, ctx: &mut Context) {
+    fn computed_member(&mut self, node: &ComputedMemberExpression, ctx: &mut Context<DIRECT>) {
         self.member_object_with_parens(&node.object, ctx);
         if node.optional {
             ctx.write("?.");
@@ -2947,7 +2976,7 @@ impl<'opt, const HAS_COMMENTS: bool> Printer<'opt, HAS_COMMENTS> {
         ctx.write("]");
     }
 
-    fn assignment_expression(&mut self, node: &AssignmentExpression, ctx: &mut Context) {
+    fn assignment_expression(&mut self, node: &AssignmentExpression, ctx: &mut Context<DIRECT>) {
         // esrap visits both sides without adding parens.
         self.assignment_target(&node.left, ctx);
         ctx.write(" ");
@@ -2958,7 +2987,11 @@ impl<'opt, const HAS_COMMENTS: bool> Printer<'opt, HAS_COMMENTS> {
 
     /// A `SimpleAssignmentTarget` (the operand of `++`/`--`, a subset of
     /// `AssignmentTarget`).
-    fn simple_assignment_target(&mut self, target: &SimpleAssignmentTarget, ctx: &mut Context) {
+    fn simple_assignment_target(
+        &mut self,
+        target: &SimpleAssignmentTarget,
+        ctx: &mut Context<DIRECT>,
+    ) {
         match target {
             SimpleAssignmentTarget::AssignmentTargetIdentifier(id) => ctx.write(id.name.as_str()),
             SimpleAssignmentTarget::StaticMemberExpression(m) => self.static_member(m, ctx),
@@ -2973,7 +3006,7 @@ impl<'opt, const HAS_COMMENTS: bool> Printer<'opt, HAS_COMMENTS> {
         }
     }
 
-    fn assignment_target(&mut self, target: &AssignmentTarget, ctx: &mut Context) {
+    fn assignment_target(&mut self, target: &AssignmentTarget, ctx: &mut Context<DIRECT>) {
         match target {
             AssignmentTarget::AssignmentTargetIdentifier(id) => ctx.write(id.name.as_str()),
             AssignmentTarget::StaticMemberExpression(m) => self.static_member(m, ctx),
@@ -3071,7 +3104,7 @@ impl<'opt, const HAS_COMMENTS: bool> Printer<'opt, HAS_COMMENTS> {
     fn assignment_target_maybe_default(
         &mut self,
         target: &AssignmentTargetMaybeDefault,
-        ctx: &mut Context,
+        ctx: &mut Context<DIRECT>,
     ) {
         match target {
             AssignmentTargetMaybeDefault::AssignmentTargetWithDefault(d) => {
@@ -3086,7 +3119,11 @@ impl<'opt, const HAS_COMMENTS: bool> Printer<'opt, HAS_COMMENTS> {
         }
     }
 
-    fn assignment_target_property(&mut self, prop: &AssignmentTargetProperty, ctx: &mut Context) {
+    fn assignment_target_property(
+        &mut self,
+        prop: &AssignmentTargetProperty,
+        ctx: &mut Context<DIRECT>,
+    ) {
         match prop {
             AssignmentTargetProperty::AssignmentTargetPropertyIdentifier(p) => {
                 ctx.write(p.binding.name.as_str());
@@ -3113,13 +3150,15 @@ impl<'opt, const HAS_COMMENTS: bool> Printer<'opt, HAS_COMMENTS> {
     /// precedence); the branches are emitted as-is. When either branch is
     /// multiline or the two together exceed 50 columns, break onto indented
     /// `? …` / `: …` lines.
-    fn conditional_expression(&mut self, node: &ConditionalExpression, ctx: &mut Context) {
+    fn conditional_expression(&mut self, node: &ConditionalExpression, ctx: &mut Context<DIRECT>) {
         self.child_with_parens(&node.test, 5, ctx);
 
         let mut consequent = ctx.child();
-        self.print_expression(&node.consequent, &mut consequent);
+        self.deferred()
+            .print_expression(&node.consequent, &mut consequent);
         let mut alternate = ctx.child();
-        self.print_expression(&node.alternate, &mut alternate);
+        self.deferred()
+            .print_expression(&node.alternate, &mut alternate);
 
         let multiline = consequent.multiline
             || alternate.multiline
@@ -3142,7 +3181,7 @@ impl<'opt, const HAS_COMMENTS: bool> Printer<'opt, HAS_COMMENTS> {
         }
     }
 
-    fn array_expression(&mut self, node: &ArrayExpression, ctx: &mut Context) {
+    fn array_expression(&mut self, node: &ArrayExpression, ctx: &mut Context<DIRECT>) {
         ctx.write("[");
         self.sequence_slice(
             &node.elements,
@@ -3178,7 +3217,7 @@ impl<'opt, const HAS_COMMENTS: bool> Printer<'opt, HAS_COMMENTS> {
 
     /// esrap always parenthesizes a sequence expression (`(a, b)`), laying the
     /// comma list out with the shared `sequence` machinery.
-    fn sequence_expression(&mut self, node: &SequenceExpression, ctx: &mut Context) {
+    fn sequence_expression(&mut self, node: &SequenceExpression, ctx: &mut Context<DIRECT>) {
         ctx.write("(");
         self.sequence_slice(
             &node.expressions,
@@ -3201,7 +3240,7 @@ impl<'opt, const HAS_COMMENTS: bool> Printer<'opt, HAS_COMMENTS> {
         ctx.write(")");
     }
 
-    fn object_expression(&mut self, node: &ObjectExpression, ctx: &mut Context) {
+    fn object_expression(&mut self, node: &ObjectExpression, ctx: &mut Context<DIRECT>) {
         ctx.write("{");
         self.sequence_slice(
             &node.properties,
@@ -3239,7 +3278,7 @@ impl<'opt, const HAS_COMMENTS: bool> Printer<'opt, HAS_COMMENTS> {
         ctx.write("}");
     }
 
-    fn object_property(&mut self, prop: &ObjectProperty, ctx: &mut Context) {
+    fn object_property(&mut self, prop: &ObjectProperty, ctx: &mut Context<DIRECT>) {
         // Shorthand `{ x }` when key and value are the same identifier.
         if !prop.computed
             && prop.kind == PropertyKind::Init
@@ -3297,7 +3336,7 @@ impl<'opt, const HAS_COMMENTS: bool> Printer<'opt, HAS_COMMENTS> {
         self.print_expression(&prop.value, ctx);
     }
 
-    fn property_key(&mut self, key: &PropertyKey, ctx: &mut Context) {
+    fn property_key(&mut self, key: &PropertyKey, ctx: &mut Context<DIRECT>) {
         match key {
             PropertyKey::StaticIdentifier(id) => ctx.write(id.name.as_str()),
             PropertyKey::PrivateIdentifier(id) => {
@@ -3325,7 +3364,7 @@ impl<'opt, const HAS_COMMENTS: bool> Printer<'opt, HAS_COMMENTS> {
     /// argument can span lines while the call stays on one line
     /// (`$.run([ … ])`, `foo(a, b, () => { … })`). Length is not a factor.
     #[inline]
-    fn print_argument(&mut self, arg: &Argument, ctx: &mut Context) {
+    fn print_argument(&mut self, arg: &Argument, ctx: &mut Context<DIRECT>) {
         match arg {
             Argument::SpreadElement(spread) => {
                 ctx.write("...");
@@ -3344,7 +3383,7 @@ impl<'opt, const HAS_COMMENTS: bool> Printer<'opt, HAS_COMMENTS> {
         arg: &Argument,
         next: Option<u32>,
         comma: bool,
-        ctx: &mut Context,
+        ctx: &mut Context<DIRECT>,
     ) -> bool {
         let scope = ctx.begin_scope();
         self.print_argument(arg, ctx);
@@ -3356,7 +3395,12 @@ impl<'opt, const HAS_COMMENTS: bool> Printer<'opt, HAS_COMMENTS> {
     }
 
     #[inline]
-    fn call_argument_plain(&mut self, arg: &Argument, comma: bool, ctx: &mut Context) -> bool {
+    fn call_argument_plain(
+        &mut self,
+        arg: &Argument,
+        comma: bool,
+        ctx: &mut Context<DIRECT>,
+    ) -> bool {
         let scope = ctx.begin_scope();
         self.print_argument(arg, ctx);
         if comma {
@@ -3365,7 +3409,7 @@ impl<'opt, const HAS_COMMENTS: bool> Printer<'opt, HAS_COMMENTS> {
         ctx.end_scope(scope)
     }
 
-    fn call_arguments_plain(&mut self, args: &[Argument], ctx: &mut Context) {
+    fn call_arguments_plain(&mut self, args: &[Argument], ctx: &mut Context<DIRECT>) {
         match args {
             [] => ctx.write("()"),
             [arg] => {
@@ -3440,7 +3484,7 @@ impl<'opt, const HAS_COMMENTS: bool> Printer<'opt, HAS_COMMENTS> {
         }
     }
 
-    fn call_arguments(&mut self, args: &[Argument], call_end: u32, ctx: &mut Context) {
+    fn call_arguments(&mut self, args: &[Argument], call_end: u32, ctx: &mut Context<DIRECT>) {
         if !HAS_COMMENTS {
             self.call_arguments_plain(args, ctx);
             return;
@@ -3583,7 +3627,7 @@ impl<'opt, const HAS_COMMENTS: bool> Printer<'opt, HAS_COMMENTS> {
     // ----- TypeScript types -------------------------------------------------
 
     /// esrap's `TSTypeAnnotation`: `: ` + the type.
-    fn type_annotation(&mut self, node: &TSTypeAnnotation, ctx: &mut Context) {
+    fn type_annotation(&mut self, node: &TSTypeAnnotation, ctx: &mut Context<DIRECT>) {
         ctx.write(": ");
         self.print_type(&node.type_annotation, ctx);
     }
@@ -3592,7 +3636,7 @@ impl<'opt, const HAS_COMMENTS: bool> Printer<'opt, HAS_COMMENTS> {
     fn type_parameter_instantiation(
         &mut self,
         node: &TSTypeParameterInstantiation,
-        ctx: &mut Context,
+        ctx: &mut Context<DIRECT>,
     ) {
         ctx.write("<");
         for (i, p) in node.params.iter().enumerate() {
@@ -3605,7 +3649,11 @@ impl<'opt, const HAS_COMMENTS: bool> Printer<'opt, HAS_COMMENTS> {
     }
 
     /// esrap's `TSTypeParameterDeclaration`: `<T, U extends V = W>`.
-    fn type_parameter_declaration(&mut self, node: &TSTypeParameterDeclaration, ctx: &mut Context) {
+    fn type_parameter_declaration(
+        &mut self,
+        node: &TSTypeParameterDeclaration,
+        ctx: &mut Context<DIRECT>,
+    ) {
         ctx.write("<");
         for (i, p) in node.params.iter().enumerate() {
             if i > 0 {
@@ -3616,7 +3664,7 @@ impl<'opt, const HAS_COMMENTS: bool> Printer<'opt, HAS_COMMENTS> {
         ctx.write(">");
     }
 
-    fn type_parameter(&mut self, node: &TSTypeParameter, ctx: &mut Context) {
+    fn type_parameter(&mut self, node: &TSTypeParameter, ctx: &mut Context<DIRECT>) {
         ctx.write(node.name.name.as_str());
         if let Some(constraint) = &node.constraint {
             ctx.write(" extends ");
@@ -3629,7 +3677,7 @@ impl<'opt, const HAS_COMMENTS: bool> Printer<'opt, HAS_COMMENTS> {
     }
 
     /// esrap's `TSTypeName` (`IdentifierReference` / `TSQualifiedName`).
-    fn print_type_name(name: &TSTypeName, ctx: &mut Context) {
+    fn print_type_name(name: &TSTypeName, ctx: &mut Context<DIRECT>) {
         match name {
             TSTypeName::IdentifierReference(id) => ctx.write(id.name.as_str()),
             TSTypeName::QualifiedName(q) => {
@@ -3643,7 +3691,7 @@ impl<'opt, const HAS_COMMENTS: bool> Printer<'opt, HAS_COMMENTS> {
 
     /// The core type dispatcher (esrap's TS type visitors).
     #[allow(clippy::too_many_lines)]
-    fn print_type(&mut self, ty: &TSType, ctx: &mut Context) {
+    fn print_type(&mut self, ty: &TSType, ctx: &mut Context<DIRECT>) {
         match ty {
             TSType::TSAnyKeyword(_) => ctx.write("any"),
             TSType::TSBigIntKeyword(_) => ctx.write("bigint"),
@@ -3792,7 +3840,7 @@ impl<'opt, const HAS_COMMENTS: bool> Printer<'opt, HAS_COMMENTS> {
 
     /// esrap's `TSImportType`: `import('src')[.qualifier]`. (Type-argument
     /// support is unused by the samples.)
-    fn import_type(node: &TSImportType, ctx: &mut Context) {
+    fn import_type(node: &TSImportType, ctx: &mut Context<DIRECT>) {
         ctx.write("import(");
         ctx.write(Self::string_literal(&node.source));
         ctx.write(")");
@@ -3802,7 +3850,7 @@ impl<'opt, const HAS_COMMENTS: bool> Printer<'opt, HAS_COMMENTS> {
         }
     }
 
-    fn import_type_qualifier(q: &TSImportTypeQualifier, ctx: &mut Context) {
+    fn import_type_qualifier(q: &TSImportTypeQualifier, ctx: &mut Context<DIRECT>) {
         match q {
             TSImportTypeQualifier::Identifier(id) => ctx.write(id.name.as_str()),
             TSImportTypeQualifier::QualifiedName(qn) => {
@@ -3814,7 +3862,7 @@ impl<'opt, const HAS_COMMENTS: bool> Printer<'opt, HAS_COMMENTS> {
     }
 
     /// esrap's `TSNamedTupleMember`: `label[?]: type`.
-    fn named_tuple_member(&mut self, node: &TSNamedTupleMember, ctx: &mut Context) {
+    fn named_tuple_member(&mut self, node: &TSNamedTupleMember, ctx: &mut Context<DIRECT>) {
         ctx.write(node.label.name.as_str());
         if node.optional {
             ctx.write("?");
@@ -3823,7 +3871,7 @@ impl<'opt, const HAS_COMMENTS: bool> Printer<'opt, HAS_COMMENTS> {
         self.tuple_element(&node.element_type, ctx);
     }
 
-    fn tuple_element(&mut self, el: &TSTupleElement, ctx: &mut Context) {
+    fn tuple_element(&mut self, el: &TSTupleElement, ctx: &mut Context<DIRECT>) {
         match el {
             TSTupleElement::TSOptionalType(t) => {
                 self.print_type(&t.type_annotation, ctx);
@@ -3842,7 +3890,7 @@ impl<'opt, const HAS_COMMENTS: bool> Printer<'opt, HAS_COMMENTS> {
     }
 
     /// esrap's `TSMappedType`: `{[K in C]: T}` (no inner spaces).
-    fn mapped_type(&mut self, node: &TSMappedType, ctx: &mut Context) {
+    fn mapped_type(&mut self, node: &TSMappedType, ctx: &mut Context<DIRECT>) {
         ctx.write("{");
         if let Some(readonly) = node.readonly {
             ctx.write(mapped_modifier_prefix(readonly, "readonly"));
@@ -3867,14 +3915,14 @@ impl<'opt, const HAS_COMMENTS: bool> Printer<'opt, HAS_COMMENTS> {
     }
 
     /// esrap's `TSTypeLiteral`: `{ ` + `;`-separated members + ` }`.
-    fn type_literal(&mut self, node: &TSTypeLiteral, ctx: &mut Context) {
+    fn type_literal(&mut self, node: &TSTypeLiteral, ctx: &mut Context<DIRECT>) {
         ctx.write("{ ");
         let nodes = Self::signature_seq_nodes(&node.members);
         self.sequence(nodes, Some(node.span.end), false, ";", true, ctx);
         ctx.write(" }");
     }
 
-    fn ts_literal(&mut self, lit: &TSLiteral, ctx: &mut Context) {
+    fn ts_literal(&mut self, lit: &TSLiteral, ctx: &mut Context<DIRECT>) {
         match lit {
             TSLiteral::BooleanLiteral(b) => ctx.write(if b.value { "true" } else { "false" }),
             TSLiteral::NumericLiteral(n) => ctx.write(literal_raw(
@@ -3903,7 +3951,8 @@ impl<'opt, const HAS_COMMENTS: bool> Printer<'opt, HAS_COMMENTS> {
                     obj_or_array: false,
                     is_elision: false,
                     render: Box::new(
-                        move |p: &mut Printer<'_, HAS_COMMENTS>, child: &mut Context| {
+                        move |p: &mut Printer<'_, HAS_COMMENTS, false>,
+                              child: &mut Context<false>| {
                             p.print_type(ty, child);
                         },
                     ),
@@ -3924,7 +3973,8 @@ impl<'opt, const HAS_COMMENTS: bool> Printer<'opt, HAS_COMMENTS> {
                     obj_or_array: false,
                     is_elision: false,
                     render: Box::new(
-                        move |p: &mut Printer<'_, HAS_COMMENTS>, child: &mut Context| {
+                        move |p: &mut Printer<'_, HAS_COMMENTS, false>,
+                              child: &mut Context<false>| {
                             p.tuple_element(el, child);
                         },
                     ),
@@ -3944,7 +3994,8 @@ impl<'opt, const HAS_COMMENTS: bool> Printer<'opt, HAS_COMMENTS> {
                     obj_or_array: false,
                     is_elision: false,
                     render: Box::new(
-                        move |p: &mut Printer<'_, HAS_COMMENTS>, child: &mut Context| {
+                        move |p: &mut Printer<'_, HAS_COMMENTS, false>,
+                              child: &mut Context<false>| {
                             p.signature(m, child);
                         },
                     ),
@@ -3954,7 +4005,7 @@ impl<'opt, const HAS_COMMENTS: bool> Printer<'opt, HAS_COMMENTS> {
     }
 
     /// esrap's `TSSignature` visitors (members of an interface / type literal).
-    fn signature(&mut self, sig: &TSSignature, ctx: &mut Context) {
+    fn signature(&mut self, sig: &TSSignature, ctx: &mut Context<DIRECT>) {
         match sig {
             TSSignature::TSPropertySignature(s) => {
                 if s.readonly {
@@ -4033,7 +4084,7 @@ impl<'opt, const HAS_COMMENTS: bool> Printer<'opt, HAS_COMMENTS> {
 
     // ----- TypeScript declarations ------------------------------------------
 
-    fn type_alias_declaration(&mut self, node: &TSTypeAliasDeclaration, ctx: &mut Context) {
+    fn type_alias_declaration(&mut self, node: &TSTypeAliasDeclaration, ctx: &mut Context<DIRECT>) {
         if node.declare {
             ctx.write("declare ");
         }
@@ -4047,7 +4098,7 @@ impl<'opt, const HAS_COMMENTS: bool> Printer<'opt, HAS_COMMENTS> {
         ctx.write(";");
     }
 
-    fn interface_declaration(&mut self, node: &TSInterfaceDeclaration, ctx: &mut Context) {
+    fn interface_declaration(&mut self, node: &TSInterfaceDeclaration, ctx: &mut Context<DIRECT>) {
         if node.declare {
             ctx.write("declare ");
         }
@@ -4069,8 +4120,12 @@ impl<'opt, const HAS_COMMENTS: bool> Printer<'opt, HAS_COMMENTS> {
                         obj_or_array: false,
                         is_elision: false,
                         render: Box::new(
-                            move |p: &mut Printer<'_, HAS_COMMENTS>, child: &mut Context| {
-                                Self::print_type_name(&h.type_name, child);
+                            move |p: &mut Printer<'_, HAS_COMMENTS, false>,
+                                  child: &mut Context<false>| {
+                                Printer::<HAS_COMMENTS, false>::print_type_name(
+                                    &h.type_name,
+                                    child,
+                                );
                                 if let Some(ta) = &h.type_arguments {
                                     p.type_parameter_instantiation(ta, child);
                                 }
@@ -4088,7 +4143,7 @@ impl<'opt, const HAS_COMMENTS: bool> Printer<'opt, HAS_COMMENTS> {
         ctx.write("}");
     }
 
-    fn enum_declaration(&mut self, node: &TSEnumDeclaration, ctx: &mut Context) {
+    fn enum_declaration(&mut self, node: &TSEnumDeclaration, ctx: &mut Context<DIRECT>) {
         if node.declare {
             ctx.write("declare ");
         }
@@ -4112,7 +4167,8 @@ impl<'opt, const HAS_COMMENTS: bool> Printer<'opt, HAS_COMMENTS> {
                     obj_or_array: false,
                     is_elision: false,
                     render: Box::new(
-                        move |p: &mut Printer<'_, HAS_COMMENTS>, child: &mut Context| {
+                        move |p: &mut Printer<'_, HAS_COMMENTS, false>,
+                              child: &mut Context<false>| {
                             p.enum_member(m, child);
                         },
                     ),
@@ -4125,7 +4181,7 @@ impl<'opt, const HAS_COMMENTS: bool> Printer<'opt, HAS_COMMENTS> {
         ctx.write("}");
     }
 
-    fn enum_member(&mut self, node: &TSEnumMember, ctx: &mut Context) {
+    fn enum_member(&mut self, node: &TSEnumMember, ctx: &mut Context<DIRECT>) {
         match &node.id {
             TSEnumMemberName::Identifier(id) => ctx.write(id.name.as_str()),
             TSEnumMemberName::String(s) => ctx.write(Self::string_literal(s)),
@@ -4149,7 +4205,7 @@ impl<'opt, const HAS_COMMENTS: bool> Printer<'opt, HAS_COMMENTS> {
     fn external_module_declaration(
         &mut self,
         node: &TSExternalModuleDeclaration,
-        ctx: &mut Context,
+        ctx: &mut Context<DIRECT>,
     ) {
         if node.declare {
             ctx.write("declare ");
@@ -4165,7 +4221,7 @@ impl<'opt, const HAS_COMMENTS: bool> Printer<'opt, HAS_COMMENTS> {
         &mut self,
         node: &TSNamespaceDeclaration,
         include_keyword: bool,
-        ctx: &mut Context,
+        ctx: &mut Context<DIRECT>,
     ) {
         if include_keyword {
             if node.declare {
@@ -4186,7 +4242,7 @@ impl<'opt, const HAS_COMMENTS: bool> Printer<'opt, HAS_COMMENTS> {
         }
     }
 
-    fn global_declaration(&mut self, node: &TSGlobalDeclaration, ctx: &mut Context) {
+    fn global_declaration(&mut self, node: &TSGlobalDeclaration, ctx: &mut Context<DIRECT>) {
         if node.declare {
             ctx.write("declare ");
         }
@@ -4195,7 +4251,7 @@ impl<'opt, const HAS_COMMENTS: bool> Printer<'opt, HAS_COMMENTS> {
     }
 
     /// esrap's `TSModuleBlock`: ` {` + indented body + `}`.
-    fn module_block(&mut self, node: &TSModuleBlock, ctx: &mut Context) {
+    fn module_block(&mut self, node: &TSModuleBlock, ctx: &mut Context<DIRECT>) {
         ctx.write(" {");
         ctx.indent();
         ctx.newline();
@@ -4210,7 +4266,7 @@ impl<'opt, const HAS_COMMENTS: bool> Printer<'opt, HAS_COMMENTS> {
         ctx.write("}");
     }
 
-    fn import_equals_declaration(node: &TSImportEqualsDeclaration, ctx: &mut Context) {
+    fn import_equals_declaration(node: &TSImportEqualsDeclaration, ctx: &mut Context<DIRECT>) {
         ctx.write("import ");
         ctx.write(node.id.name.as_str());
         ctx.write(" = ");
@@ -4271,7 +4327,7 @@ fn quote(value: &str) -> CompactString {
 /// whether it's a property with an object/array value (which suppresses the
 /// blank-line margin between adjacent multiline elements).
 struct SeqItem {
-    ctx: Context,
+    ctx: Context<false>,
     multiline: bool,
     obj_or_array: bool,
     /// This item is an array elision (a hole, `[a, , b]`). esrap still writes
@@ -4300,7 +4356,7 @@ struct SeqMeta {
 /// node's source span (so trailing comments can be flushed in source order) and
 /// a closure that renders it into a child context.
 type SeqRenderer<'p, const HAS_COMMENTS: bool> =
-    dyn FnMut(&mut Printer<'_, HAS_COMMENTS>, &mut Context) + 'p;
+    dyn FnMut(&mut Printer<'_, HAS_COMMENTS, false>, &mut Context<false>) + 'p;
 
 struct SeqNode<'p, const HAS_COMMENTS: bool> {
     /// Node `loc.end` byte offset, or `None` for a synthetic node without a
@@ -4401,10 +4457,10 @@ impl<'a> BodyElem<'a, '_> {
         }
     }
 
-    fn print<const HAS_COMMENTS: bool>(
+    fn print<const HAS_COMMENTS: bool, const DIRECT: bool>(
         &self,
-        printer: &mut Printer<'_, HAS_COMMENTS>,
-        ctx: &mut Context,
+        printer: &mut Printer<'_, HAS_COMMENTS, DIRECT>,
+        ctx: &mut Context<DIRECT>,
     ) {
         match self {
             BodyElem::Directive(d) => printer.print_directive(d, ctx),

--- a/crates/rsvelte_lint_types/Cargo.lock
+++ b/crates/rsvelte_lint_types/Cargo.lock
@@ -1111,7 +1111,7 @@ dependencies = [
 
 [[package]]
 name = "rsvelte_esrap"
-version = "0.10.23"
+version = "0.10.24"
 dependencies = [
  "compact_str",
  "memchr",


### PR DESCRIPTION
## Summary

- write comment-free, source-map-free esrap output into the returned string as visitors run
- retain deferred child buffers so whitespace from parent and child contexts still coalesces identically
- record eager layout spans and rewrite only spans changed by retroactive sequence layout decisions
- release `rsvelte_esrap` 0.10.24 and update the compiler's exact dependency

## Performance

Paired retained-AST ABBA benchmark against `oxc_codegen`, 11 generated CSR files / 50,406 input bytes, 500 pairs x 100 iterations:

- current main: `1.293x` esrap/oxc
- this PR: `1.203x`, `1.208x`
- improvement: 6.6–7.0%

On a separate 31-file generated CSR set, this PR measured `1.186x` / `1.187x` versus the current path's `1.406x` / `1.373x`.

The optimized benchmark binary grows by 8.69% and its text section by 10.0%, due to specializing the visitor for direct and deferred contexts. This is the main tradeoff.

## Correctness and safety

Comment and source-map paths continue using the existing deferred event renderer. Direct output keeps child contexts deferred and replays them into the root, preserving pending-whitespace composition. Retroactive edits are sorted, non-overlapping, and growth-only; checked arithmetic enforces the growth invariant before the reverse in-place rewrite.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test -p rsvelte_esrap --release`
- `cargo test -p rsvelte_core --test compile_both_parity --release`
- `node scripts/ci/check-lint-types-lock.mjs`
- `git diff --check`
