### PR TITLE
perf(esrap): write flat sequence spacing eagerly

### DIFF
--- a/.changeset/optimistic-esrap-sequences.md
+++ b/.changeset/optimistic-esrap-sequences.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/compiler": patch
+---
+
+Write flat esrap sequence spacing before rendering to avoid retroactive output copies. Release `rsvelte_esrap` 0.10.25 and update the compiler's exact dependency.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2605,7 +2605,7 @@ dependencies = [
 
 [[package]]
 name = "rsvelte_esrap"
-version = "0.10.24"
+version = "0.10.25"
 dependencies = [
  "compact_str 0.10.0",
  "memchr",

--- a/crates/rsvelte_core/Cargo.toml
+++ b/crates/rsvelte_core/Cargo.toml
@@ -94,7 +94,7 @@ oxc_ast = { version = "0.144", features = ["serialize"] }
 oxc_span = "0.144"
 oxc_diagnostics = "0.144"
 oxc_codegen = "0.144"
-rsvelte_esrap = { version = "=0.10.24", path = "../rsvelte_esrap" }
+rsvelte_esrap = { version = "=0.10.25", path = "../rsvelte_esrap" }
 oxc_syntax = "0.144"
 oxc_semantic = "0.144"
 

--- a/crates/rsvelte_esrap/Cargo.toml
+++ b/crates/rsvelte_esrap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rsvelte_esrap"
-version = "0.10.24"
+version = "0.10.25"
 edition = "2024"
 rust-version = "1.95"
 description = "A Rust port of esrap — prints an oxc AST to JavaScript with esrap's exact layout"

--- a/crates/rsvelte_esrap/src/printer.rs
+++ b/crates/rsvelte_esrap/src/printer.rs
@@ -921,6 +921,9 @@ impl<'opt, const HAS_COMMENTS: bool, const DIRECT: bool> Printer<'opt, HAS_COMME
             for (i, item) in items.iter_mut().enumerate().take(n) {
                 let node_meta = meta(i);
                 let mark = parent.event_mark();
+                if DIRECT && (pad || i > 0) && !node_meta.is_elision {
+                    parent.space();
+                }
                 let scope = parent.begin_scope();
                 render(self, i, parent);
 
@@ -953,7 +956,7 @@ impl<'opt, const HAS_COMMENTS: bool, const DIRECT: bool> Printer<'opt, HAS_COMME
                     let margin = prev.multiline
                         && item.multiline
                         && !(prev.obj_or_array && item.obj_or_array);
-                    if !item.is_elision {
+                    if !item.is_elision && (multiline || !DIRECT) {
                         parent.insert_event(
                             item.mark,
                             if multiline {
@@ -974,7 +977,7 @@ impl<'opt, const HAS_COMMENTS: bool, const DIRECT: bool> Printer<'opt, HAS_COMME
                 parent.insert_event(first.mark, EventKind::Newline);
                 parent.insert_event(first.mark, EventKind::Indent);
                 parent.multiline = true;
-            } else if pad && length > 0 {
+            } else if !DIRECT && pad && length > 0 {
                 parent.insert_event(first.mark, EventKind::Space);
             }
 
@@ -1004,6 +1007,9 @@ impl<'opt, const HAS_COMMENTS: bool, const DIRECT: bool> Printer<'opt, HAS_COMME
         for i in 0..n {
             let node_meta = meta(i);
             let mark = parent.event_mark();
+            if DIRECT && (pad || i > 0) && !node_meta.is_elision {
+                parent.space();
+            }
             let scope = parent.begin_scope();
             render(self, i, parent);
 
@@ -1035,7 +1041,7 @@ impl<'opt, const HAS_COMMENTS: bool, const DIRECT: bool> Printer<'opt, HAS_COMME
                 let prev = items[i - 1];
                 let margin =
                     prev.multiline && item.multiline && !(prev.obj_or_array && item.obj_or_array);
-                if !item.is_elision {
+                if !item.is_elision && (multiline || !DIRECT) {
                     parent.insert_event(
                         item.mark,
                         if multiline {
@@ -1056,7 +1062,7 @@ impl<'opt, const HAS_COMMENTS: bool, const DIRECT: bool> Printer<'opt, HAS_COMME
                 parent.insert_event(first.mark, EventKind::Newline);
                 parent.insert_event(first.mark, EventKind::Indent);
                 parent.multiline = true;
-            } else if pad && length > 0 {
+            } else if !DIRECT && pad && length > 0 {
                 parent.insert_event(first.mark, EventKind::Space);
             }
         }
@@ -4538,6 +4544,78 @@ mod tests {
             printer.missing
         );
         out
+    }
+
+    fn synthetic_sequence_deferred(n: usize, unsupported: bool) -> String {
+        let opts = PrintOptions::default();
+        let mut printer = Printer::<false>::new(&opts);
+        let mut ctx = Context::new();
+        ctx.write("[");
+        printer.sequence_indexed(
+            n,
+            |_| SeqMeta {
+                start: None,
+                end: None,
+                obj_or_array: false,
+                is_elision: false,
+            },
+            |printer, i, child| {
+                if unsupported && i + 1 == n {
+                    printer.unsupported("Synthetic", child);
+                }
+            },
+            None,
+            true,
+            ",",
+            true,
+            &mut ctx,
+        );
+        ctx.write("]");
+        let capacity = ctx.measure();
+        crate::command::print(&ctx.into_buffer(), &opts.indent, capacity)
+    }
+
+    fn synthetic_sequence_direct(n: usize, unsupported: bool) -> String {
+        let opts = PrintOptions::default();
+        let mut printer = Printer::<false, true>::new(&opts);
+        let mut ctx = Context::new_direct(&opts.indent, 32);
+        ctx.write("[");
+        printer.sequence_indexed(
+            n,
+            |_| SeqMeta {
+                start: None,
+                end: None,
+                obj_or_array: false,
+                is_elision: false,
+            },
+            |printer, i, child| {
+                if unsupported && i + 1 == n {
+                    printer.unsupported("Synthetic", child);
+                }
+            },
+            None,
+            true,
+            ",",
+            true,
+            &mut ctx,
+        );
+        ctx.write("]");
+        let (buffer, _, indent, dirty) = ctx.into_direct_parts();
+        crate::command::finish_direct(buffer, &indent, dirty).0
+    }
+
+    #[test]
+    fn optimistic_sequence_matches_empty_and_unsupported_renderers() {
+        for n in [1, 2] {
+            assert_eq!(
+                synthetic_sequence_direct(n, false),
+                synthetic_sequence_deferred(n, false)
+            );
+            assert_eq!(
+                synthetic_sequence_direct(n, true),
+                synthetic_sequence_deferred(n, true)
+            );
+        }
     }
 
     #[test]

--- a/crates/rsvelte_esrap/tests/compat.rs
+++ b/crates/rsvelte_esrap/tests/compat.rs
@@ -5,7 +5,7 @@ use oxc_allocator::Allocator;
 use oxc_ast::ast::Statement;
 use oxc_parser::Parser;
 use oxc_span::SourceType;
-use rsvelte_esrap::{UNLOCATED_SPAN, print};
+use rsvelte_esrap::{PrintOptions, UNLOCATED_SPAN, print, print_with_map};
 
 fn print_src(source: &str, ts: bool) -> String {
     let alloc = Allocator::default();
@@ -22,6 +22,36 @@ fn print_src(source: &str, ts: bool) -> String {
 #[test]
 fn plain_js() {
     assert_eq!(print_src("const x = 1;", false), "const x = 1;");
+}
+
+#[test]
+fn comment_free_direct_matches_deferred_sequences() {
+    let cases = [
+        "const x = { a: 1 };",
+        "const x = { a: 1, b: 2, c: 3, d: 4 };",
+        "const x = [a, b, c, d];",
+        "const x = [a, , b];",
+        "function f(a, b, c, d) { return a + b + c + d; }",
+        "const { a, b, c, d } = value;",
+        "const x = (a, b, c, d);",
+        "const x = [{ alpha: very_long_identifier_name, beta: another_long_identifier_name }, { gamma: third_long_identifier_name }];",
+    ];
+
+    for source in cases {
+        let alloc = Allocator::default();
+        let ret = Parser::new(&alloc, source, SourceType::default().with_module(true)).parse();
+        assert!(
+            ret.diagnostics.is_empty(),
+            "parse error for {source:?}: {:?}",
+            ret.diagnostics
+        );
+        let options = PrintOptions::default();
+        assert_eq!(
+            print(&ret.program, source),
+            print_with_map(&ret.program, source, &options).code,
+            "direct/deferred mismatch for {source:?}"
+        );
+    }
 }
 
 #[test]

--- a/crates/rsvelte_lint_types/Cargo.lock
+++ b/crates/rsvelte_lint_types/Cargo.lock
@@ -1111,7 +1111,7 @@ dependencies = [
 
 [[package]]
 name = "rsvelte_esrap"
-version = "0.10.24"
+version = "0.10.25"
 dependencies = [
  "compact_str",
  "memchr",


### PR DESCRIPTION
## Summary

- emit flat sequence spaces before rendering on the comment-free direct path
- upgrade those spaces to newlines only when the rendered sequence becomes multiline
- preserve the deferred comment/source-map path and the existing single-item path
- add direct/deferred differential coverage for parsed, empty, elided, and unsupported sequence elements
- release `rsvelte_esrap` 0.10.25 and update the compiler's exact dependency

## Performance

Paired retained-AST ABBA benchmark against `oxc_codegen`, 11 generated CSR files / 50,406 input bytes:

- current main: `1.203x`, `1.211x`
- this PR: `1.156x`, `1.158x`
- improvement: about 4.1%

A 500 x 100 main-thread profile measured `1.1716x` esrap/oxc versus `1.236x` on current main, a 5.21% normalized reduction. Retroactive patch copies fell from 43,582 to 36,237 bytes per corpus pass (-16.85%).

The optimized benchmark binary grows by 0.92%; its text section grows by 0.31%.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test -p rsvelte_esrap --release`
- `cargo test -p rsvelte_core --test compile_both_parity --release`
- `node scripts/ci/check-lint-types-lock.mjs`
- `git diff --check`
