### PR TITLE
feat(language-server): add tsgo-backed Svelte language features

### DIFF
--- a/.changeset/tsgo-language-surface.md
+++ b/.changeset/tsgo-language-surface.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/language-server": minor
+---
+
+Add the full TypeScript language surface through a supervised tsgo LSP child and diskless Svelte shadow workspace.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -532,7 +532,7 @@ dispatch) in process, so an embedder never re-implements it.
 | 1 | svelte2tsx | ✅ 253/253, wired into the compatibility report |
 | 2 | svelte-check | ✅ v1.0 — walker + overlay + tsgo + incremental cache + watch + parallel compile + hires source maps + SvelteKit kit-file augmentation; reads diagnostic-relevant `compilerOptions` from `svelte.config.*` and `vite.config.*` |
 | 3 | vite-plugin-svelte | 🟢 v1.0 — Rust NAPI bindings (`hmr_diff` / `resolve_id` / `preprocess`) + `@rsvelte/vite-plugin-svelte` shim at `apps/npm/vite-plugin-svelte`; supports Vite 6/7/8 |
-| 4 | svelte-language-server | 🚧 In progress — target is a full replacement for `svelte-language-server` + `svelte-vscode`, not a companion. M0 landed: `crates/rsvelte_language_server` (binary `rsvelte-language-server`) does document sync, formatting and push diagnostics in process |
+| 4 | svelte-language-server | 🟢 M3 — the native server owns document sync, formatting, linting, HTML/CSS/Svelte structure and the full TypeScript surface through a supervised tsgo LSP child over a diskless shadow workspace |
 
 Wave 4 architecture (decided; tsgo ships an LSP server as of TypeScript 7, so the earlier
 "waits on tsgo `tsserver` mode" blocker no longer applies):

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2682,8 +2682,10 @@ dependencies = [
  "rsvelte_diagnostics",
  "rsvelte_fmt",
  "rsvelte_lint",
+ "rsvelte_projection",
  "serde",
  "serde_json",
+ "sourcemap",
 ]
 
 [[package]]

--- a/apps/npm/language-server/README.md
+++ b/apps/npm/language-server/README.md
@@ -1,10 +1,9 @@
 # @rsvelte/language-server
 
 A Language Server for [rsvelte](https://github.com/baseballyama/rsvelte) — the
-Rust port of the Svelte compiler. It exposes rsvelte's **formatter** and
-**linter** over the Language Server Protocol, so any LSP client (VS Code,
-Neovim, …) can format and lint Svelte (and JS/TS/CSS/JSON) without a separate
-toolchain.
+Rust port of the Svelte compiler. The native server combines rsvelte's
+formatter, linter and Svelte/HTML/CSS providers with a TypeScript 7 LSP child,
+so editors get the complete Svelte and TypeScript language surface.
 
 ## Features (v1)
 
@@ -21,12 +20,20 @@ toolchain.
   open, on change (300 ms debounced), and on save. The rule set comes from the
   project's own [`rsvelte-lint.json`](#lint-configuration).
 
-Template and CSS completion/hover and structure features are supplied by the
-native server. Go-to-definition, rename, find-references, and TypeScript
-diagnostics wait on [tsgo](https://github.com/microsoft/typescript-go)'s
-`tsserver` mode landing upstream; until then, use
-[`@rsvelte/svelte-check`](https://www.npmjs.com/package/@rsvelte/svelte-check)
-as a batch type-checker.
+The native server proxies hover, definitions, references, completion and
+resolve, rename, signature help, inlay hints, semantic tokens, hierarchy,
+symbols, code actions, code lenses and pull diagnostics through tsgo. Svelte
+components use eagerly opened, diskless `.svelte.tsx` shadows; plain `.ts` and
+`.js` documents share the same project.
+
+Install TypeScript 7 in the workspace, or set `TSGO_BIN` to its executable:
+
+```sh
+npm install -D typescript@~6 @typescript/native@npm:typescript@7
+```
+
+If tsgo is unavailable, native formatting, linting and Svelte/HTML/CSS features
+continue to work.
 
 For VS Code, Emmet remains the built-in extension's responsibility. Enable its
 HTML abbreviations in Svelte documents with

--- a/apps/npm/language-server/package.json
+++ b/apps/npm/language-server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@rsvelte/language-server",
   "version": "0.4.1",
-  "description": "Language Server for rsvelte — formatting (native rsvelte-fmt) and linting (bundled rsvelte_lint wasm)",
+  "description": "Native Svelte language server with formatting, linting and TypeScript 7 language features",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/apps/npm/vscode/README.md
+++ b/apps/npm/vscode/README.md
@@ -22,14 +22,13 @@ and launches it over stdio.
 - **Native template and CSS assistance** — HTML/Svelte tag and attribute
   completions, directive and binding documentation, tag-linked editing, CSS
   property/value and selector completions, CSS hovers, selections, and colours.
+- **TypeScript language features** — hover, component-aware completion,
+  definitions, references, rename, diagnostics, semantic tokens, code actions
+  and reference/implementation code lenses through the native tsgo proxy.
 
-That's the full feature set — hover, completion, go-to-definition, rename,
-find-references, and TypeScript diagnostics are **not** provided (this is a
-formatter + linter, not a full language server). Those wait on
-[tsgo](https://github.com/microsoft/typescript-go)'s `tsserver` mode landing
-upstream; until then, use
-[`@rsvelte/svelte-check`](https://www.npmjs.com/package/@rsvelte/svelte-check)
-for batch type-checking.
+TypeScript features require TypeScript 7 in the workspace (or `TSGO_BIN`);
+native formatting, linting and template/CSS providers remain available without
+it.
 
 ## Emmet
 
@@ -48,6 +47,12 @@ Formatting requires the native `rsvelte-fmt` binary. Install it in your project:
 
 ```sh
 npm install -D @rsvelte/fmt
+```
+
+Install the TypeScript 7 native backend for type-aware features:
+
+```sh
+npm install -D typescript@~6 @typescript/native@npm:typescript@7
 ```
 
 The extension resolves `node_modules/.bin/rsvelte-fmt` from the workspace. If

--- a/apps/npm/vscode/package.json
+++ b/apps/npm/vscode/package.json
@@ -3,7 +3,7 @@
   "version": "0.4.1",
   "private": true,
   "displayName": "rsvelte",
-  "description": "Rust-powered Svelte formatting and linting for VS Code (rsvelte-fmt + rsvelte_lint)",
+  "description": "Rust-powered Svelte language support with formatting, linting and TypeScript 7 features",
   "license": "MIT",
   "publisher": "baseballyama",
   "icon": "icon.png",
@@ -58,8 +58,52 @@
       {
         "command": "rsvelte.restartLanguageServer",
         "title": "rsvelte: Restart Language Server"
+      },
+      {
+        "command": "rsvelte.typescript.findAllFileReferences",
+        "title": "rsvelte: Find File References"
+      },
+      {
+        "command": "rsvelte.typescript.findComponentReferences",
+        "title": "rsvelte: Find Component References"
       }
     ],
+    "menus": {
+      "commandPalette": [
+        {
+          "command": "rsvelte.typescript.findAllFileReferences",
+          "when": "editorLangId == svelte && resourceScheme == file"
+        },
+        {
+          "command": "rsvelte.typescript.findComponentReferences",
+          "when": "editorLangId == svelte && resourceScheme == file"
+        }
+      ],
+      "editor/context": [
+        {
+          "command": "rsvelte.typescript.findAllFileReferences",
+          "when": "editorLangId == svelte && resourceScheme == file",
+          "group": "4_search"
+        },
+        {
+          "command": "rsvelte.typescript.findComponentReferences",
+          "when": "editorLangId == svelte && resourceScheme == file",
+          "group": "4_search"
+        }
+      ],
+      "explorer/context": [
+        {
+          "command": "rsvelte.typescript.findAllFileReferences",
+          "when": "resourceLangId == svelte && resourceScheme == file",
+          "group": "4_search"
+        },
+        {
+          "command": "rsvelte.typescript.findComponentReferences",
+          "when": "resourceLangId == svelte && resourceScheme == file",
+          "group": "4_search"
+        }
+      ]
+    },
     "languages": [
       {
         "id": "svelte",

--- a/apps/npm/vscode/src/extension.ts
+++ b/apps/npm/vscode/src/extension.ts
@@ -7,6 +7,11 @@
 import * as path from "node:path";
 import {
   IndentAction,
+  Location,
+  Position,
+  ProgressLocation,
+  Range,
+  Uri,
   commands,
   extensions,
   languages,
@@ -71,6 +76,18 @@ const VOID_ELEMENTS = [
 const OFFICIAL_EXTENSION_ID = "svelte.svelte-vscode";
 const CONFLICT_DISMISSED_KEY = "rsvelte.officialExtensionConflictDismissed";
 const RESTART_COMMAND_ID = "rsvelte.restartLanguageServer";
+const FIND_FILE_REFERENCES_COMMAND_ID =
+  "rsvelte.typescript.findAllFileReferences";
+const FIND_COMPONENT_REFERENCES_COMMAND_ID =
+  "rsvelte.typescript.findComponentReferences";
+
+interface ProtocolLocation {
+  uri: string;
+  range: {
+    start: { line: number; character: number };
+    end: { line: number; character: number };
+  };
+}
 
 /**
  * Basenames of files whose content changes the server's effective
@@ -202,6 +219,64 @@ function createClient(
     synchronize: {
       // Forward `rsvelte.*` configuration changes to the server.
       configurationSection: "rsvelte",
+    },
+    middleware: {
+      resolveCodeLens: async (lens, token, next) => {
+        const resolved = await next(lens, token);
+        const command = resolved?.command;
+        const args = command?.arguments;
+        if (
+          !command ||
+          command.command !== "" ||
+          !Array.isArray(args) ||
+          typeof args[0] !== "string"
+        ) {
+          return resolved;
+        }
+        const position = args[1] as { line?: unknown; character?: unknown };
+        const locations = Array.isArray(args[2]) ? args[2] : [];
+        if (
+          typeof position?.line !== "number" ||
+          typeof position.character !== "number"
+        ) {
+          return resolved;
+        }
+        command.command = "editor.action.showReferences";
+        command.arguments = [
+          Uri.parse(args[0]),
+          new Position(position.line, position.character),
+          locations.flatMap((location) => {
+            const value = location as {
+              uri?: unknown;
+              range?: {
+                start?: { line?: unknown; character?: unknown };
+                end?: { line?: unknown; character?: unknown };
+              };
+            };
+            const start = value.range?.start;
+            const end = value.range?.end;
+            if (
+              typeof value.uri !== "string" ||
+              typeof start?.line !== "number" ||
+              typeof start.character !== "number" ||
+              typeof end?.line !== "number" ||
+              typeof end.character !== "number"
+            ) {
+              return [];
+            }
+            return [
+              new Location(
+                Uri.parse(value.uri),
+                new Range(
+                  new Position(start.line, start.character),
+                  new Position(end.line, end.character),
+                ),
+              ),
+            ];
+          }),
+        ];
+        return resolved;
+      },
     },
   };
   return new LanguageClient(
@@ -337,6 +412,89 @@ function isRestartTrigger(document: TextDocument): boolean {
   return RESTART_ON_SAVE_PATTERNS.some((pattern) => pattern.test(base));
 }
 
+async function applyFileRenameEdits(
+  files: readonly { oldUri: Uri; newUri: Uri }[],
+): Promise<void> {
+  const running = client;
+  if (!running || running.state !== State.Running) return;
+  for (const file of files) {
+    const result = await running.sendRequest<unknown>(
+      "$/getEditsForFileRename",
+      {
+        oldUri: file.oldUri.toString(),
+        newUri: file.newUri.toString(),
+      },
+    );
+    if (!result) continue;
+    const edit = await running.protocol2CodeConverter.asWorkspaceEdit(
+      result as Parameters<
+        typeof running.protocol2CodeConverter.asWorkspaceEdit
+      >[0],
+    );
+    if (edit) await workspace.applyEdit(edit);
+  }
+}
+
+async function showCustomReferences(
+  method: "$/getFileReferences" | "$/getComponentReferences",
+  title: string,
+  resource?: Uri,
+): Promise<void> {
+  const running = client;
+  if (!running || running.state !== State.Running) return;
+  const target = resource ?? window.activeTextEditor?.document.uri;
+  if (!target || target.scheme !== "file") return;
+
+  const document = await workspace.openTextDocument(target);
+  await window.withProgress(
+    { location: ProgressLocation.Window, title },
+    async (_progress, token) => {
+      const result = await running.sendRequest<ProtocolLocation[] | null>(
+        method,
+        document.uri.toString(),
+        token,
+      );
+      if (!result) return;
+      const locations = result.map(
+        ({ uri, range }) =>
+          new Location(
+            Uri.parse(uri),
+            new Range(
+              range.start.line,
+              range.start.character,
+              range.end.line,
+              range.end.character,
+            ),
+          ),
+      );
+      const showReferences = () =>
+        commands.executeCommand(
+          "editor.action.showReferences",
+          target,
+          new Position(0, 0),
+          locations,
+        );
+      if (method === "$/getComponentReferences") {
+        await showReferences();
+        return;
+      }
+
+      const references = workspace.getConfiguration("references");
+      const preferredLocation = references.inspect<string>("preferredLocation");
+      await references.update("preferredLocation", "view");
+      try {
+        await showReferences();
+      } finally {
+        await references.update(
+          "preferredLocation",
+          preferredLocation?.workspaceFolderValue ??
+            preferredLocation?.workspaceValue,
+        );
+      }
+    },
+  );
+}
+
 export function activate(context: ExtensionContext): void {
   registerSvelteLanguageConfiguration(context);
   void warnAboutOfficialExtension(context);
@@ -356,10 +514,31 @@ export function activate(context: ExtensionContext): void {
     commands.registerCommand(RESTART_COMMAND_ID, () =>
       restartLanguageServer(),
     ),
+    commands.registerCommand(
+      FIND_FILE_REFERENCES_COMMAND_ID,
+      (resource?: Uri) =>
+        showCustomReferences(
+          "$/getFileReferences",
+          "Finding file references",
+          resource,
+        ),
+    ),
+    commands.registerCommand(
+      FIND_COMPONENT_REFERENCES_COMMAND_ID,
+      (resource?: Uri) =>
+        showCustomReferences(
+          "$/getComponentReferences",
+          "Finding component references",
+          resource,
+        ),
+    ),
     workspace.onDidSaveTextDocument((document) => {
       if (isRestartTrigger(document)) {
         void restartLanguageServer();
       }
+    }),
+    workspace.onDidRenameFiles((event) => {
+      void applyFileRenameEdits(event.files);
     }),
     workspace.onDidChangeConfiguration((event) => {
       if (event.affectsConfiguration("rsvelte.trace.server") && client) {

--- a/apps/playground/src/lib/docs.ts
+++ b/apps/playground/src/lib/docs.ts
@@ -390,7 +390,7 @@ const languageServer: Guide = {
 	pkg: '@rsvelte/language-server',
 	dropInFor: 'svelte-language-server',
 	tagline:
-		'An LSP server that answers everything the Svelte AST alone can answer — diagnostics, formatting, completions, hover, quick fixes, folding and symbols — from the Rust core, in process.',
+		'A native LSP server for Svelte, HTML and CSS with the full TypeScript surface proxied through a supervised tsgo child.',
 	useFor: 'Power editor diagnostics, formatting and completions over LSP.',
 	install: 'pnpm add -D @rsvelte/language-server',
 	runnable: false,
@@ -400,9 +400,10 @@ const languageServer: Guide = {
 			list: [
 				'`textDocument/publishDiagnostics` — the `rsvelte_lint` engine, on open, on change (debounced) and on save.',
 				'`textDocument/formatting` — the `rsvelte-fmt` pipeline in process, no subprocess.',
-				'`textDocument/completion` and `hover` — template tags and event modifiers.',
-				'`textDocument/codeAction` — quick fixes for the diagnostics it reports.',
-				'`foldingRange`, `selectionRange` and `documentSymbol` — the structure the Svelte AST describes.'
+				'`completion`, `hover`, definitions, references, rename and signature help — mapped between `.svelte` and diskless `.svelte.tsx` shadows.',
+				'Pull diagnostics, semantic tokens, inlay hints, call hierarchy, workspace symbols and TypeScript code actions.',
+				'Component props, events and slot-let completions, SvelteKit `$types` imports, source actions and reference code lenses.',
+				'Plain `.ts` and `.js` proxying replaces the upstream TypeScript plugin.'
 			]
 		},
 		{
@@ -428,9 +429,9 @@ rsvelte-language-server`
 			}
 		},
 		{
-			title: 'What it does not answer yet',
+			title: 'TypeScript backend',
 			body: [
-				'TypeScript-backed features — go-to-definition, rename, find-references and type errors — are not served yet. The design is to proxy a child tsgo LSP over the same `.svelte` → virtual `.tsx` overlay `svelte-check` uses; until that lands, run `@rsvelte/svelte-check` as a batch type-checker.'
+				'TypeScript features require TypeScript 7 (`@typescript/native` or `@typescript/native-preview`) in the workspace, or an explicit `TSGO_BIN`. The native providers remain available when tsgo is absent.'
 			]
 		}
 	]

--- a/crates/rsvelte_language_server/Cargo.toml
+++ b/crates/rsvelte_language_server/Cargo.toml
@@ -17,12 +17,14 @@ rsvelte_check = { path = "../rsvelte_check" }
 rsvelte_diagnostics = { path = "../rsvelte_diagnostics" }
 rsvelte_fmt = { path = "../rsvelte_fmt" }
 rsvelte_lint = { path = "../rsvelte_lint", default-features = false, features = ["native"] }
+rsvelte_projection = { path = "../rsvelte_projection" }
 anyhow = "1.0"
 crossbeam-channel = "0.5"
 lsp-server = "0.10"
 lsp-types = "0.97"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+sourcemap = "9.0"
 
 [lints]
 workspace = true

--- a/crates/rsvelte_language_server/src/client.rs
+++ b/crates/rsvelte_language_server/src/client.rs
@@ -32,6 +32,10 @@ pub struct ClientState {
     pub pull_diagnostics: bool,
     /// Whether the client accepts dynamic watched-file registrations.
     pub dynamic_watched_files: bool,
+    /// Semantic token types the client advertised, in client order.
+    pub semantic_token_types: Vec<String>,
+    /// Semantic token modifiers the client advertised, in client order.
+    pub semantic_token_modifiers: Vec<String>,
 }
 
 impl ClientState {
@@ -59,6 +63,14 @@ impl ClientState {
                 params,
                 "/capabilities/workspace/didChangeWatchedFiles/dynamicRegistration",
             ),
+            semantic_token_types: field(
+                params.pointer("/capabilities/textDocument/semanticTokens/tokenTypes"),
+            )
+            .unwrap_or_default(),
+            semantic_token_modifiers: field(
+                params.pointer("/capabilities/textDocument/semanticTokens/tokenModifiers"),
+            )
+            .unwrap_or_default(),
         }
     }
 
@@ -114,6 +126,10 @@ mod tests {
                 "textDocument": {
                     "foldingRange": { "lineFoldingOnly": true },
                     "documentSymbol": { "hierarchicalDocumentSymbolSupport": true },
+                    "semanticTokens": {
+                        "tokenTypes": ["namespace", "class"],
+                        "tokenModifiers": ["declaration", "readonly"]
+                    },
                 },
             },
         }));
@@ -132,6 +148,8 @@ mod tests {
         assert!(state.hierarchical_document_symbols);
         assert!(!state.pull_diagnostics);
         assert!(state.dynamic_watched_files);
+        assert_eq!(state.semantic_token_types, ["namespace", "class"]);
+        assert_eq!(state.semantic_token_modifiers, ["declaration", "readonly"]);
     }
 
     #[test]

--- a/crates/rsvelte_language_server/src/lib.rs
+++ b/crates/rsvelte_language_server/src/lib.rs
@@ -1,10 +1,9 @@
 //! `rsvelte-language-server` — an LSP server exposing rsvelte's formatter and
 //! linter to any LSP client (VS Code, Neovim, …).
 //!
-//! It also ports the TypeScript-free half of the official language server's
-//! `SveltePlugin`: template tag and event modifier [`completions`] and
-//! [`hover`], and the structure the Svelte AST alone can answer for —
-//! [`folding`] ranges, [`selection_ranges`] and document [`symbols`].
+//! Native Svelte, HTML and CSS providers run alongside a supervised TypeScript
+//! 7 LSP child. A diskless `.svelte` to `.tsx` overlay maps TypeScript
+//! navigation, completion, rename, diagnostics and edits back to source files.
 //!
 //! The message loop owns only protocol state; every analysis runs on the
 //! [`worker`] thread, which is where the stack depth and panic isolation the
@@ -35,6 +34,14 @@ pub mod settings;
 pub mod symbols;
 pub mod tags;
 pub mod text;
+pub mod tsgo_client;
+pub mod tsgo_code_actions;
+pub mod tsgo_completion;
+pub mod tsgo_component_info;
+pub mod tsgo_custom;
+pub mod tsgo_overlay;
+pub mod tsgo_rename;
+pub mod tsgo_response;
 pub mod uri;
 pub mod worker;
 

--- a/crates/rsvelte_language_server/src/server.rs
+++ b/crates/rsvelte_language_server/src/server.rs
@@ -1,6 +1,9 @@
 //! The LSP message loop.
 
 use std::collections::HashMap;
+use std::ffi::OsString;
+use std::fs;
+use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 use std::time::{Duration, Instant};
 
@@ -8,22 +11,26 @@ use anyhow::Result;
 use crossbeam_channel::{Receiver, Sender, after, never, select, unbounded};
 use lsp_server::{Connection, ErrorCode, Message, Notification, Request, RequestId, Response};
 use lsp_types::{
-    CancelParams, CodeActionKind, CodeActionOptions, CodeActionOrCommand, CodeActionParams,
-    CodeActionProviderCapability, CodeLens, CodeLensOptions, CodeLensParams,
-    ColorPresentationParams, ColorProviderCapability, CompletionOptions, CompletionParams,
-    ConfigurationItem, ConfigurationParams, DiagnosticOptions, DiagnosticServerCapabilities,
-    DidChangeTextDocumentParams, DidChangeWatchedFilesParams, DidChangeWorkspaceFoldersParams,
-    DidCloseTextDocumentParams, DidOpenTextDocumentParams, DidSaveTextDocumentParams,
-    DocumentColorParams, DocumentDiagnosticParams, DocumentDiagnosticReport,
-    DocumentFormattingParams, DocumentHighlightParams, DocumentSymbolParams,
-    DocumentSymbolResponse, ExecuteCommandOptions, ExecuteCommandParams, FoldingRange,
-    FoldingRangeParams, FoldingRangeProviderCapability, FullDocumentDiagnosticReport, HoverParams,
-    HoverProviderCapability, LinkedEditingRangeParams, LinkedEditingRangeServerCapabilities,
-    NumberOrString, OneOf, PublishDiagnosticsParams, RelatedFullDocumentDiagnosticReport,
-    SelectionRangeParams, SelectionRangeProviderCapability, ServerCapabilities,
+    CallHierarchyServerCapability, CancelParams, CodeActionKind, CodeActionOptions,
+    CodeActionOrCommand, CodeActionParams, CodeActionProviderCapability, CodeLens, CodeLensOptions,
+    CodeLensParams, ColorPresentationParams, ColorProviderCapability, CompletionOptions,
+    CompletionParams, ConfigurationItem, ConfigurationParams, DiagnosticOptions,
+    DiagnosticServerCapabilities, DidChangeTextDocumentParams, DidChangeWatchedFilesParams,
+    DidChangeWorkspaceFoldersParams, DidCloseTextDocumentParams, DidOpenTextDocumentParams,
+    DidSaveTextDocumentParams, DocumentColorParams, DocumentDiagnosticParams,
+    DocumentDiagnosticReport, DocumentFormattingParams, DocumentHighlightParams,
+    DocumentSymbolParams, DocumentSymbolResponse, ExecuteCommandOptions, ExecuteCommandParams,
+    FoldingRange, FoldingRangeParams, FoldingRangeProviderCapability, FullDocumentDiagnosticReport,
+    HoverParams, HoverProviderCapability, ImplementationProviderCapability, InlayHintOptions,
+    InlayHintServerCapabilities, LinkedEditingRangeParams, LinkedEditingRangeServerCapabilities,
+    NumberOrString, OneOf, PositionEncodingKind, PublishDiagnosticsParams,
+    RelatedFullDocumentDiagnosticReport, RenameOptions, RenameParams, SelectionRangeParams,
+    SelectionRangeProviderCapability, SemanticTokenModifier, SemanticTokenType,
+    SemanticTokensFullOptions, SemanticTokensLegend, SemanticTokensOptions,
+    SemanticTokensServerCapabilities, ServerCapabilities, SignatureHelpOptions,
     TextDocumentPositionParams, TextDocumentSyncCapability, TextDocumentSyncKind,
-    TextDocumentSyncOptions, TextDocumentSyncSaveOptions, TextEdit, Uri,
-    WorkspaceFoldersServerCapabilities,
+    TextDocumentSyncOptions, TextDocumentSyncSaveOptions, TextEdit,
+    TypeDefinitionProviderCapability, Uri, WorkspaceFoldersServerCapabilities,
 };
 
 use crate::client::ClientState;
@@ -31,8 +38,32 @@ use crate::completions::TRIGGER_CHARACTERS;
 use crate::document::{Document, DocumentStore};
 use crate::log;
 use crate::settings::Settings;
+use crate::tsgo_client::{OpenBuffer, TsgoClient, TsgoConfig, TsgoEvent};
+use crate::tsgo_code_actions::{
+    TsgoCodeActionContext, document_has_parser_error, rewrite_code_action_response,
+};
+use crate::tsgo_completion::{
+    CompletionAction, CompletionRewriteContext, CompletionSite, completion_action,
+    rewrite_completion_item_for_context, rewrite_completion_response_for_context,
+    rewrite_visible_tsgo_response,
+};
+use crate::tsgo_component_info::{
+    ComponentCompletionSite, ComponentInfoAction, ComponentInfoQuery, ComponentInfoRequestId,
+    component_completion_site, generated_component_ranges,
+};
+use crate::tsgo_custom::{
+    CodeLensKind, ComponentReference, ShadowUriPair, WillRenameMapping, code_lens_kind,
+    component_probe_position, component_reference_code_lens, filter_component_references,
+    prepare_code_lenses, resolve_code_lens, rewrite_will_rename_params, rewrite_will_rename_result,
+};
+use crate::tsgo_overlay::TsgoOverlay;
+use crate::tsgo_rename::{
+    PrepareRenamePlan, RenameDocument, merge_workspace_edits, prepare_rename_plan,
+    rewrite_prepare_response, rewrite_workspace_edit,
+};
+use crate::tsgo_response::{RequestDocumentContext, TsgoResponseMapper};
 use crate::uri::uri_to_path;
-use crate::worker::{Job, Outcome, Worker};
+use crate::worker::{FileReferenceSource, Job, Outcome, Worker};
 
 pub const SERVER_NAME: &str = "rsvelte-language-server";
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -42,6 +73,49 @@ const LINT_DEBOUNCE: Duration = Duration::from_millis(300);
 
 /// The `rsvelte` configuration section this server pulls from the client.
 const CONFIG_SECTION: &str = "rsvelte";
+const JS_TS_CONFIG_SECTION: &str = "js/ts";
+const TYPESCRIPT_CONFIG_SECTION: &str = "typescript";
+const JAVASCRIPT_CONFIG_SECTION: &str = "javascript";
+const EDITOR_CONFIG_SECTION: &str = "editor";
+
+const TSGO_SEMANTIC_TOKEN_TYPES: &[&str] = &[
+    "namespace",
+    "class",
+    "enum",
+    "interface",
+    "struct",
+    "typeParameter",
+    "type",
+    "parameter",
+    "variable",
+    "property",
+    "enumMember",
+    "decorator",
+    "event",
+    "function",
+    "method",
+    "macro",
+    "label",
+    "comment",
+    "string",
+    "keyword",
+    "number",
+    "regexp",
+    "operator",
+];
+const TSGO_SEMANTIC_TOKEN_MODIFIERS: &[&str] = &[
+    "declaration",
+    "definition",
+    "readonly",
+    "static",
+    "deprecated",
+    "abstract",
+    "async",
+    "modification",
+    "documentation",
+    "defaultLibrary",
+    "local",
+];
 
 /// Serve the LSP over stdio until the client shuts the connection down.
 ///
@@ -58,6 +132,7 @@ pub fn run_stdio() -> Result<ExitCode> {
     let (connection, io_threads) = Connection::stdio();
     let (id, params) = connection.initialize_start()?;
     let client = ClientState::from_initialize(&params);
+    let tsgo = TsgoRuntime::start(&client, &params);
 
     connection.initialize_finish(
         id,
@@ -73,6 +148,8 @@ pub fn run_stdio() -> Result<ExitCode> {
         client,
         Worker::spawn(results),
         outcomes,
+        tsgo,
+        params,
     )
     .run(&connection)?;
 
@@ -85,6 +162,9 @@ pub fn run_stdio() -> Result<ExitCode> {
 
 fn capabilities(client: &ClientState) -> ServerCapabilities {
     ServerCapabilities {
+        // The editor-facing protocol stays on the LSP default. The tsgo child
+        // is negotiated separately to UTF-8 so all internal mapping is byte-based.
+        position_encoding: Some(PositionEncodingKind::UTF16),
         text_document_sync: Some(TextDocumentSyncCapability::Options(
             TextDocumentSyncOptions {
                 open_close: Some(true),
@@ -96,19 +176,33 @@ fn capabilities(client: &ClientState) -> ServerCapabilities {
         document_formatting_provider: Some(OneOf::Left(true)),
         completion_provider: Some(CompletionOptions {
             trigger_characters: Some(TRIGGER_CHARACTERS.map(str::to_string).to_vec()),
+            resolve_provider: Some(true),
             ..CompletionOptions::default()
         }),
         hover_provider: Some(HoverProviderCapability::Simple(true)),
+        signature_help_provider: Some(SignatureHelpOptions {
+            trigger_characters: Some(vec!["(".to_string(), ",".to_string(), "<".to_string()]),
+            retrigger_characters: Some(vec![")".to_string()]),
+            ..SignatureHelpOptions::default()
+        }),
+        definition_provider: Some(OneOf::Left(true)),
+        type_definition_provider: Some(TypeDefinitionProviderCapability::Simple(true)),
+        implementation_provider: Some(ImplementationProviderCapability::Simple(true)),
+        references_provider: Some(OneOf::Left(true)),
         code_action_provider: Some(CodeActionProviderCapability::Options(CodeActionOptions {
             code_action_kinds: Some(vec![
                 CodeActionKind::QUICKFIX,
                 CodeActionKind::REFACTOR_REWRITE,
+                CodeActionKind::SOURCE_ORGANIZE_IMPORTS,
+                CodeActionKind::from("source.sortImports"),
+                CodeActionKind::from("source.removeUnusedImports"),
+                CodeActionKind::SOURCE_FIX_ALL,
                 CodeActionKind::from(crate::code_actions::FIX_ALL_KIND),
             ]),
             ..CodeActionOptions::default()
         })),
         code_lens_provider: Some(CodeLensOptions {
-            resolve_provider: Some(false),
+            resolve_provider: Some(true),
         }),
         execute_command_provider: Some(ExecuteCommandOptions {
             commands: vec![crate::extract::COMMAND.to_string()],
@@ -119,6 +213,47 @@ fn capabilities(client: &ClientState) -> ServerCapabilities {
         document_symbol_provider: Some(OneOf::Left(true)),
         linked_editing_range_provider: Some(LinkedEditingRangeServerCapabilities::Simple(true)),
         document_highlight_provider: Some(OneOf::Left(true)),
+        workspace_symbol_provider: Some(OneOf::Left(true)),
+        rename_provider: Some(OneOf::Right(RenameOptions {
+            prepare_provider: Some(true),
+            work_done_progress_options: Default::default(),
+        })),
+        inlay_hint_provider: Some(OneOf::Right(InlayHintServerCapabilities::Options(
+            InlayHintOptions {
+                resolve_provider: Some(false),
+                ..InlayHintOptions::default()
+            },
+        ))),
+        semantic_tokens_provider: Some(SemanticTokensServerCapabilities::SemanticTokensOptions(
+            SemanticTokensOptions {
+                legend: SemanticTokensLegend {
+                    token_types: TSGO_SEMANTIC_TOKEN_TYPES
+                        .iter()
+                        .filter(|token| {
+                            client
+                                .semantic_token_types
+                                .iter()
+                                .any(|supported| supported == **token)
+                        })
+                        .map(|token| SemanticTokenType::new(token))
+                        .collect(),
+                    token_modifiers: TSGO_SEMANTIC_TOKEN_MODIFIERS
+                        .iter()
+                        .filter(|modifier| {
+                            client
+                                .semantic_token_modifiers
+                                .iter()
+                                .any(|supported| supported == **modifier)
+                        })
+                        .map(|modifier| SemanticTokenModifier::new(modifier))
+                        .collect(),
+                },
+                range: Some(true),
+                full: Some(SemanticTokensFullOptions::Bool(true)),
+                ..SemanticTokensOptions::default()
+            },
+        )),
+        call_hierarchy_provider: Some(CallHierarchyServerCapability::Simple(true)),
         color_provider: Some(ColorProviderCapability::Simple(true)),
         diagnostic_provider: client.pull_diagnostics.then(|| {
             DiagnosticServerCapabilities::Options(DiagnosticOptions {
@@ -144,15 +279,67 @@ fn capabilities(client: &ClientState) -> ServerCapabilities {
 /// produce one.
 enum Pending {
     Formatting,
-    Completion,
-    Hover,
-    CodeAction,
-    CodeLens,
+    Completion { tsgo_fallback: Request },
+    Hover { tsgo_fallback: Request },
+    CodeAction { tsgo_fallback: Request },
+    CodeLens { tsgo_fallback: Request },
     ExtractComponent,
-    FoldingRange,
+    FoldingRange { tsgo_fallback: Request },
     SelectionRange,
-    DocumentSymbol,
-    DocumentDiagnostic,
+    DocumentSymbol { tsgo_fallback: Request },
+    DocumentDiagnostic { tsgo_fallback: Request },
+    FileReferences,
+}
+
+struct PendingTsgoRequest {
+    method: String,
+    document: Option<RequestDocumentContext>,
+    fallback_result: Option<serde_json::Value>,
+    completion_site: Option<CompletionSite>,
+    rename: Option<PendingRename>,
+    code_action_diagnostic_codes: Vec<u32>,
+    push_diagnostics: Option<(Uri, i32)>,
+    component_site: Option<ComponentCompletionSite>,
+    component_references: Option<Uri>,
+    file_rename: Option<PendingFileRename>,
+    code_lens_resolve: Option<PendingCodeLensResolve>,
+}
+
+struct PendingComponentQuery {
+    query: ComponentInfoQuery,
+    site: ComponentCompletionSite,
+    result: serde_json::Value,
+}
+
+enum PendingRename {
+    Prepare(PrepareRenamePlan),
+    Primary {
+        plan: PrepareRenamePlan,
+        new_name: String,
+    },
+    Followup {
+        editor_id: RequestId,
+    },
+}
+
+struct RenameAggregate {
+    plan: PrepareRenamePlan,
+    new_name: String,
+    edits: Vec<serde_json::Value>,
+    remaining: usize,
+}
+
+struct PendingFileRename {
+    old_source: Uri,
+    old_shadow: Uri,
+    new_source: Uri,
+    new_shadow: Uri,
+}
+
+struct PendingCodeLensResolve {
+    lens: serde_json::Value,
+    kind: CodeLensKind,
+    source_uri: Uri,
 }
 
 /// A request this server sent to the client, keyed by the id the client will
@@ -160,12 +347,134 @@ enum Pending {
 enum Outgoing {
     Configuration,
     WatchedFilesRegistration,
+    Tsgo { child_id: RequestId },
+}
+
+struct TsgoRuntime {
+    client: TsgoClient,
+    overlays: Vec<TsgoOverlay>,
+    generation: Option<u64>,
+}
+
+impl TsgoRuntime {
+    fn start(editor: &ClientState, initialize_params: &serde_json::Value) -> Option<Self> {
+        let mut roots = editor
+            .workspace_folders
+            .iter()
+            .map(|folder| uri_to_path(folder.uri.as_str()))
+            .collect::<Vec<_>>();
+        if roots.is_empty()
+            && let Some(root) = &editor.root_uri
+        {
+            roots.push(uri_to_path(root.as_str()));
+        }
+        roots.retain(|root| root.is_dir());
+        roots.sort();
+        roots.dedup();
+        let primary = roots.first()?.clone();
+
+        let mut overlays = Vec::new();
+        for root in &roots {
+            match TsgoOverlay::build(root, None) {
+                Ok(overlay) => {
+                    for route in overlay.unresolved_shadow_routes() {
+                        log::warn(format_args!(
+                            "tsgo shadow is not resolvable: {} -> {}",
+                            route.source_path.display(),
+                            route.shadow_path.display()
+                        ));
+                    }
+                    overlays.push(overlay);
+                }
+                Err(error) => log::warn(format_args!(
+                    "could not prepare tsgo overlay for {}: {error}",
+                    root.display()
+                )),
+            }
+        }
+        if overlays.is_empty() {
+            return None;
+        }
+
+        let binary = match rsvelte_check::tsgo::find_compiler(&primary, true) {
+            Ok(binary) => binary,
+            Err(error) => {
+                log::warn(format_args!(
+                    "TypeScript language features unavailable: {error}"
+                ));
+                return None;
+            }
+        };
+        let mut config = TsgoConfig::new(PathBuf::from(binary.program));
+        config.args_prefix = binary.args_prefix.into_iter().map(OsString::from).collect();
+        config.current_dir = Some(primary);
+        config.root_uri = editor.root_uri.clone();
+        config.workspace_folders = editor.workspace_folders.clone();
+        config.editor_initialize_params = initialize_params.clone();
+        let client = match TsgoClient::spawn(config) {
+            Ok(client) => client,
+            Err(error) => {
+                log::warn(format_args!("could not start tsgo supervisor: {error}"));
+                return None;
+            }
+        };
+        for shadow in overlays.iter().flat_map(TsgoOverlay::eager_shadows) {
+            let _ = client.open_buffer(OpenBuffer::new(
+                shadow.shadow_uri.clone(),
+                shadow.language_id.clone(),
+                shadow.version,
+                shadow.text.clone(),
+            ));
+        }
+        Some(Self {
+            client,
+            overlays,
+            generation: None,
+        })
+    }
+
+    fn overlay_for_source_mut(&mut self, source: &Path) -> Option<&mut TsgoOverlay> {
+        let source = fs::canonicalize(source).unwrap_or_else(|_| source.to_path_buf());
+        self.overlays
+            .iter_mut()
+            .filter(|overlay| source.starts_with(overlay.workspace()))
+            .max_by_key(|overlay| overlay.workspace().components().count())
+    }
+
+    fn completion_document_context(
+        &self,
+        params: &serde_json::Value,
+    ) -> Option<RequestDocumentContext> {
+        let file_name = params
+            .get("data")?
+            .get("fileName")?
+            .as_str()
+            .map(Path::new)?;
+        let mapper = TsgoResponseMapper::for_overlays(&self.overlays);
+        for overlay in &self.overlays {
+            let Some(source) = overlay.source_for_shadow(file_name) else {
+                continue;
+            };
+            let Some(shadow) = overlay.shadow_for_source(source) else {
+                continue;
+            };
+            let uri = &shadow.source_uri;
+            if let Some(context) = mapper.document_context(uri) {
+                return Some(context);
+            }
+        }
+        None
+    }
 }
 
 struct Server {
     sender: Sender<Message>,
     client: ClientState,
     settings: Settings,
+    js_ts_settings: serde_json::Value,
+    typescript_settings: serde_json::Value,
+    javascript_settings: serde_json::Value,
+    editor_settings: serde_json::Value,
     documents: DocumentStore,
     worker: Worker,
     outcomes: Receiver<Outcome>,
@@ -174,8 +483,14 @@ struct Server {
     /// The content hash each document was last linted at.
     linted: HashMap<String, u64>,
     pending: HashMap<RequestId, Pending>,
+    pending_tsgo: HashMap<RequestId, PendingTsgoRequest>,
+    rename_aggregates: HashMap<RequestId, RenameAggregate>,
+    component_queries: HashMap<RequestId, PendingComponentQuery>,
+    component_query_requests: HashMap<RequestId, (RequestId, ComponentInfoRequestId)>,
     outgoing: HashMap<RequestId, Outgoing>,
     next_request_id: u32,
+    tsgo: Option<TsgoRuntime>,
+    initialize_params: serde_json::Value,
     shutdown_requested: bool,
     exiting: bool,
 }
@@ -186,19 +501,31 @@ impl Server {
         client: ClientState,
         worker: Worker,
         outcomes: Receiver<Outcome>,
+        tsgo: Option<TsgoRuntime>,
+        initialize_params: serde_json::Value,
     ) -> Self {
         Self {
             sender,
             client,
             settings: Settings::default(),
+            js_ts_settings: serde_json::Value::Null,
+            typescript_settings: serde_json::Value::Null,
+            javascript_settings: serde_json::Value::Null,
+            editor_settings: serde_json::Value::Null,
             documents: DocumentStore::default(),
             worker,
             outcomes,
             scheduled: HashMap::new(),
             linted: HashMap::new(),
             pending: HashMap::new(),
+            pending_tsgo: HashMap::new(),
+            rename_aggregates: HashMap::new(),
+            component_queries: HashMap::new(),
+            component_query_requests: HashMap::new(),
             outgoing: HashMap::new(),
             next_request_id: 0,
+            tsgo,
+            initialize_params,
             shutdown_requested: false,
             exiting: false,
         }
@@ -213,6 +540,11 @@ impl Server {
         }
         // Cloned out of `self` so the handlers below can still borrow it.
         let outcomes = self.outcomes.clone();
+        let tsgo_events = self
+            .tsgo
+            .as_ref()
+            .map(|runtime| runtime.client.events().clone())
+            .unwrap_or_else(never);
 
         while !self.exiting {
             // Rearmed each turn: the debounce deadline moves with every edit.
@@ -230,6 +562,10 @@ impl Server {
                 recv(outcomes) -> outcome => match outcome {
                     Ok(outcome) => self.on_outcome(outcome),
                     Err(_) => break,
+                },
+                recv(tsgo_events) -> event => match event {
+                    Ok(event) => self.on_tsgo_event(event),
+                    Err(_) => self.tsgo = None,
                 },
                 recv(timer) -> _ => self.run_scheduled_lints(),
             }
@@ -274,6 +610,26 @@ impl Server {
             "textDocument/documentColor" => self.on_document_color(request),
             "textDocument/colorPresentation" => self.on_color_presentation(request),
             "textDocument/diagnostic" => self.on_document_diagnostic(request),
+            "completionItem/resolve"
+            | "textDocument/definition"
+            | "textDocument/typeDefinition"
+            | "textDocument/implementation"
+            | "textDocument/references"
+            | "textDocument/signatureHelp"
+            | "textDocument/inlayHint"
+            | "textDocument/semanticTokens/full"
+            | "textDocument/semanticTokens/range"
+            | "textDocument/prepareCallHierarchy"
+            | "callHierarchy/incomingCalls"
+            | "callHierarchy/outgoingCalls"
+            | "workspace/symbol"
+            | "workspaceSymbol/resolve" => self.forward_tsgo_request(request),
+            "textDocument/prepareRename" => self.on_prepare_rename(request),
+            "textDocument/rename" => self.on_rename(request),
+            "$/getFileReferences" => self.on_get_file_references(request),
+            "$/getComponentReferences" => self.on_get_component_references(request),
+            "$/getEditsForFileRename" => self.on_get_edits_for_file_rename(request),
+            "codeLens/resolve" => self.on_resolve_code_lens(request),
             _ => self.respond(Response::new_err(
                 request.id,
                 ErrorCode::MethodNotFound as i32,
@@ -312,6 +668,7 @@ impl Server {
     }
 
     fn on_document_diagnostic(&mut self, request: Request) {
+        let tsgo_fallback = request.clone();
         let id = request.id;
         let params = match serde_json::from_value::<DocumentDiagnosticParams>(request.params) {
             Ok(params) => params,
@@ -323,14 +680,15 @@ impl Server {
         };
         let uri = params.text_document.uri;
         let Some(document) = self.documents.get(&uri) else {
-            self.respond_diagnostic_report(id, Vec::new());
+            self.forward_tsgo_request(tsgo_fallback);
             return;
         };
         if !self.settings.lint_enable || !is_lint_target(document) {
-            self.respond_diagnostic_report(id, Vec::new());
+            self.forward_tsgo_request(tsgo_fallback);
             return;
         }
-        self.pending.insert(id.clone(), Pending::DocumentDiagnostic);
+        self.pending
+            .insert(id.clone(), Pending::DocumentDiagnostic { tsgo_fallback });
         self.worker.submit(Job::PullDiagnostics {
             id,
             path: uri_to_path(uri.as_str()),
@@ -340,6 +698,7 @@ impl Server {
     }
 
     fn on_completion(&mut self, request: Request) {
+        let tsgo_fallback = request.clone();
         let id = request.id;
         let params = match serde_json::from_value::<CompletionParams>(request.params) {
             Ok(params) => params.text_document_position,
@@ -355,7 +714,8 @@ impl Server {
         }
         match self.locate(&params) {
             Some((path, text, offset)) => {
-                self.pending.insert(id.clone(), Pending::Completion);
+                self.pending
+                    .insert(id.clone(), Pending::Completion { tsgo_fallback });
                 self.worker.submit(Job::Complete {
                     id,
                     path,
@@ -363,11 +723,12 @@ impl Server {
                     offset,
                 });
             }
-            None => self.respond_nothing(id),
+            None => self.forward_tsgo_request(tsgo_fallback),
         }
     }
 
     fn on_hover(&mut self, request: Request) {
+        let tsgo_fallback = request.clone();
         let id = request.id;
         let params = match serde_json::from_value::<HoverParams>(request.params) {
             Ok(params) => params.text_document_position_params,
@@ -383,7 +744,8 @@ impl Server {
         }
         match self.locate(&params) {
             Some((path, text, offset)) => {
-                self.pending.insert(id.clone(), Pending::Hover);
+                self.pending
+                    .insert(id.clone(), Pending::Hover { tsgo_fallback });
                 self.worker.submit(Job::Hover {
                     id,
                     path,
@@ -391,7 +753,316 @@ impl Server {
                     offset,
                 });
             }
-            None => self.respond_nothing(id),
+            None => self.forward_tsgo_request(tsgo_fallback),
+        }
+    }
+
+    fn on_prepare_rename(&mut self, request: Request) {
+        let Ok(params) =
+            serde_json::from_value::<TextDocumentPositionParams>(request.params.clone())
+        else {
+            self.respond_nothing(request.id);
+            return;
+        };
+        let path = uri_to_path(params.text_document.uri.as_str());
+        if !is_svelte_document("", &path) {
+            self.forward_tsgo_request(request);
+            return;
+        }
+        let Some(plan) = self.svelte_rename_plan(&params) else {
+            self.respond_nothing(request.id);
+            return;
+        };
+        self.forward_rename_request(request.id, "textDocument/prepareRename", &plan, None);
+    }
+
+    fn on_rename(&mut self, request: Request) {
+        let Ok(params) = serde_json::from_value::<RenameParams>(request.params.clone()) else {
+            self.respond_nothing(request.id);
+            return;
+        };
+        let position = params.text_document_position.clone();
+        let path = uri_to_path(position.text_document.uri.as_str());
+        if !is_svelte_document("", &path) {
+            self.forward_tsgo_request(request);
+            return;
+        }
+        let Some(plan) = self.svelte_rename_plan(&position) else {
+            self.respond_nothing(request.id);
+            return;
+        };
+        self.forward_rename_request(
+            request.id,
+            "textDocument/rename",
+            &plan,
+            Some(params.new_name),
+        );
+    }
+
+    fn svelte_rename_plan(&self, params: &TextDocumentPositionParams) -> Option<PrepareRenamePlan> {
+        let runtime = self.tsgo.as_ref()?;
+        let source_path = uri_to_path(params.text_document.uri.as_str());
+        let canonical_source =
+            fs::canonicalize(&source_path).unwrap_or_else(|_| source_path.clone());
+        let source = self.documents.get(&params.text_document.uri)?.text();
+        let overlay = runtime
+            .overlays
+            .iter()
+            .filter(|overlay| canonical_source.starts_with(overlay.workspace()))
+            .max_by_key(|overlay| overlay.workspace().components().count())?;
+        let shadow = overlay.shadow_for_source(&source_path)?;
+        let document = RenameDocument {
+            source_uri: &shadow.source_uri,
+            shadow_uri: &shadow.shadow_uri,
+            source_text: source,
+            generated_text: &shadow.text,
+            projection_map: overlay.projection_map(&source_path)?,
+            source_map: overlay.source_map(&source_path),
+            parser_error: document_has_parser_error(source),
+        };
+        Some(prepare_rename_plan(document, params.position))
+    }
+
+    fn forward_rename_request(
+        &mut self,
+        id: RequestId,
+        method: &str,
+        plan: &PrepareRenamePlan,
+        new_name: Option<String>,
+    ) {
+        let Some((uri, position, _)) = plan.request() else {
+            self.respond_nothing(id);
+            return;
+        };
+        let Some(runtime) = &self.tsgo else {
+            self.respond_nothing(id);
+            return;
+        };
+        let mut params = serde_json::json!({
+            "textDocument": { "uri": uri },
+            "position": position,
+        });
+        if let Some(name) = &new_name {
+            params["newName"] = serde_json::Value::String(name.clone());
+        }
+        let rename = match new_name {
+            Some(new_name) => PendingRename::Primary {
+                plan: plan.clone(),
+                new_name,
+            },
+            None => PendingRename::Prepare(plan.clone()),
+        };
+        let pending = PendingTsgoRequest {
+            method: method.to_string(),
+            document: None,
+            fallback_result: None,
+            completion_site: None,
+            rename: Some(rename),
+            code_action_diagnostic_codes: Vec::new(),
+            push_diagnostics: None,
+            component_site: None,
+            component_references: None,
+            file_rename: None,
+            code_lens_resolve: None,
+        };
+        let child = Request::new(id.clone(), method.to_string(), params);
+        if let Err(error) = runtime.client.forward(child.into()) {
+            log::warn(format_args!("could not forward rename to tsgo: {error}"));
+            self.respond_nothing(id);
+            return;
+        }
+        self.pending_tsgo.insert(id, pending);
+    }
+
+    fn on_get_file_references(&mut self, request: Request) {
+        let Some(uri) = custom_request_uri(&request.params) else {
+            self.respond(Response::new_ok(
+                request.id,
+                Vec::<lsp_types::Location>::new(),
+            ));
+            return;
+        };
+        let roots = self
+            .tsgo
+            .as_ref()
+            .map(|runtime| {
+                runtime
+                    .overlays
+                    .iter()
+                    .map(|overlay| overlay.workspace().to_path_buf())
+                    .collect()
+            })
+            .unwrap_or_default();
+        let open_documents = self
+            .documents
+            .iter()
+            .map(|document| {
+                let path = uri_to_path(document.uri.as_str());
+                FileReferenceSource {
+                    path: fs::canonicalize(&path).unwrap_or(path),
+                    uri: document.uri.clone(),
+                    text: document.text().to_string(),
+                }
+            })
+            .collect();
+        let id = request.id;
+        self.pending.insert(id.clone(), Pending::FileReferences);
+        self.worker.submit(Job::FileReferences {
+            id,
+            target: uri_to_path(uri.as_str()),
+            roots,
+            open_documents,
+        });
+    }
+
+    fn on_get_component_references(&mut self, request: Request) {
+        let Some(source_uri) = custom_request_uri(&request.params) else {
+            self.respond(Response::new_ok(
+                request.id,
+                Vec::<lsp_types::Location>::new(),
+            ));
+            return;
+        };
+        let source_path = uri_to_path(source_uri.as_str());
+        let Some(runtime) = &self.tsgo else {
+            self.respond(Response::new_ok(
+                request.id,
+                Vec::<lsp_types::Location>::new(),
+            ));
+            return;
+        };
+        let Some(shadow) = runtime
+            .overlays
+            .iter()
+            .find_map(|overlay| overlay.shadow_for_source(&source_path))
+        else {
+            self.respond(Response::new_ok(
+                request.id,
+                Vec::<lsp_types::Location>::new(),
+            ));
+            return;
+        };
+        let Some(position) = component_probe_position(&shadow.text) else {
+            self.respond(Response::new_ok(
+                request.id,
+                Vec::<lsp_types::Location>::new(),
+            ));
+            return;
+        };
+        let mapper = TsgoResponseMapper::for_overlays(&runtime.overlays);
+        let document = mapper.document_context(&source_uri);
+        let child = Request::new(
+            request.id.clone(),
+            "textDocument/references".to_string(),
+            serde_json::json!({
+                "textDocument": { "uri": shadow.shadow_uri },
+                "position": position,
+                "context": { "includeDeclaration": false },
+            }),
+        );
+        let pending = PendingTsgoRequest {
+            method: "textDocument/references".to_string(),
+            document,
+            fallback_result: None,
+            completion_site: None,
+            rename: None,
+            code_action_diagnostic_codes: Vec::new(),
+            push_diagnostics: None,
+            component_site: None,
+            component_references: Some(source_uri),
+            file_rename: None,
+            code_lens_resolve: None,
+        };
+        if runtime.client.forward(child.into()).is_ok() {
+            self.pending_tsgo.insert(request.id, pending);
+        } else {
+            self.respond(Response::new_ok(
+                request.id,
+                Vec::<lsp_types::Location>::new(),
+            ));
+        }
+    }
+
+    fn on_get_edits_for_file_rename(&mut self, request: Request) {
+        let Some(old_uri) = request
+            .params
+            .get("oldUri")
+            .and_then(serde_json::Value::as_str)
+            .and_then(|uri| uri.parse::<Uri>().ok())
+        else {
+            self.respond_nothing(request.id);
+            return;
+        };
+        let Some(new_uri) = request
+            .params
+            .get("newUri")
+            .and_then(serde_json::Value::as_str)
+            .and_then(|uri| uri.parse::<Uri>().ok())
+        else {
+            self.respond_nothing(request.id);
+            return;
+        };
+        let Some(runtime) = &self.tsgo else {
+            self.respond_nothing(request.id);
+            return;
+        };
+        let old_path = uri_to_path(old_uri.as_str());
+        let new_path = uri_to_path(new_uri.as_str());
+        let Some((old_shadow, new_shadow)) = runtime.overlays.iter().find_map(|overlay| {
+            let old_shadow = overlay.shadow_for_source(&old_path)?.shadow_uri.clone();
+            let new_shadow = overlay.prospective_shadow_uri(&new_path).ok()?;
+            Some((old_shadow, new_shadow))
+        }) else {
+            self.forward_tsgo_request(Request::new(
+                request.id,
+                "workspace/willRenameFiles".to_string(),
+                serde_json::json!({
+                    "files": [{ "oldUri": old_uri, "newUri": new_uri }]
+                }),
+            ));
+            return;
+        };
+        let mapping = WillRenameMapping {
+            old: ShadowUriPair {
+                source_uri: &old_uri,
+                shadow_uri: &old_shadow,
+            },
+            new: ShadowUriPair {
+                source_uri: &new_uri,
+                shadow_uri: &new_shadow,
+            },
+        };
+        let mut params = serde_json::json!({
+            "files": [{ "oldUri": old_uri, "newUri": new_uri }]
+        });
+        rewrite_will_rename_params(&mut params, &[mapping]);
+        let child = Request::new(
+            request.id.clone(),
+            "workspace/willRenameFiles".to_string(),
+            params,
+        );
+        let pending = PendingTsgoRequest {
+            method: "workspace/willRenameFiles".to_string(),
+            document: None,
+            fallback_result: None,
+            completion_site: None,
+            rename: None,
+            code_action_diagnostic_codes: Vec::new(),
+            push_diagnostics: None,
+            component_site: None,
+            component_references: None,
+            file_rename: Some(PendingFileRename {
+                old_source: old_uri,
+                old_shadow,
+                new_source: new_uri,
+                new_shadow,
+            }),
+            code_lens_resolve: None,
+        };
+        if runtime.client.forward(child.into()).is_ok() {
+            self.pending_tsgo.insert(request.id, pending);
+        } else {
+            self.respond_nothing(request.id);
         }
     }
 
@@ -416,6 +1087,7 @@ impl Server {
     }
 
     fn on_document_highlight(&mut self, request: Request) {
+        let tsgo_fallback = request.clone();
         let id = request.id;
         let params = match serde_json::from_value::<DocumentHighlightParams>(request.params) {
             Ok(params) => params.text_document_position_params,
@@ -433,7 +1105,11 @@ impl Server {
             .map_or_else(Vec::new, |(_, text, offset)| {
                 crate::html_tags::highlights(text.as_str(), offset)
             });
-        self.respond(Response::new_ok(id, highlights));
+        if highlights.is_empty() {
+            self.forward_tsgo_request(tsgo_fallback);
+        } else {
+            self.respond(Response::new_ok(id, highlights));
+        }
     }
 
     fn on_tag_close(&mut self, request: Request) {
@@ -498,6 +1174,7 @@ impl Server {
     }
 
     fn on_code_action(&mut self, request: Request) {
+        let tsgo_fallback = request.clone();
         let id = request.id;
         let params = match serde_json::from_value::<CodeActionParams>(request.params) {
             Ok(params) => params,
@@ -508,18 +1185,10 @@ impl Server {
             }
         };
         let uri = params.text_document.uri;
-        let Some(document) = self.documents.get(&uri) else {
-            self.respond_no_actions(id);
+        let Some(document) = self.component_document(&uri) else {
+            self.forward_tsgo_request(tsgo_fallback);
             return;
         };
-        if params.context.diagnostics.is_empty()
-            && params.context.only.as_ref().is_none_or(|kinds| {
-                !kinds.contains(&CodeActionKind::from(crate::code_actions::FIX_ALL_KIND))
-            })
-        {
-            self.respond_no_actions(id);
-            return;
-        }
         let only = params.context.only.as_ref();
         let job = Job::CodeAction {
             id: id.clone(),
@@ -533,23 +1202,130 @@ impl Server {
                 kinds.contains(&CodeActionKind::from(crate::code_actions::FIX_ALL_KIND))
             }),
         };
-        self.pending.insert(id, Pending::CodeAction);
+        self.pending
+            .insert(id, Pending::CodeAction { tsgo_fallback });
         self.worker.submit(job);
     }
 
     fn on_code_lens(&mut self, request: Request) {
+        let tsgo_fallback = request.clone();
         let id = request.id;
         let Ok(params) = serde_json::from_value::<CodeLensParams>(request.params) else {
             return self.respond_no_lenses(id);
         };
         if !self.settings.runes_legacy_mode_code_lens_enable {
-            return self.respond_no_lenses(id);
+            return self.forward_tsgo_request(tsgo_fallback);
         }
         let Some((path, text)) = self.component(&params.text_document.uri) else {
-            return self.respond_no_lenses(id);
+            return self.forward_tsgo_request(tsgo_fallback);
         };
-        self.pending.insert(id.clone(), Pending::CodeLens);
+        self.pending
+            .insert(id.clone(), Pending::CodeLens { tsgo_fallback });
         self.worker.submit(Job::CodeLens { id, path, text });
+    }
+
+    fn on_resolve_code_lens(&mut self, request: Request) {
+        let id = request.id;
+        let lens = request.params;
+        let Some(kind) = code_lens_kind(&lens) else {
+            self.respond(Response::new_ok(id, lens));
+            return;
+        };
+        let Some(source_uri) = lens
+            .pointer("/data/uri")
+            .and_then(serde_json::Value::as_str)
+            .and_then(|uri| uri.parse::<Uri>().ok())
+        else {
+            self.respond(Response::new_ok(id, lens));
+            return;
+        };
+        let Some(runtime) = &self.tsgo else {
+            self.respond(Response::new_ok(id, lens));
+            return;
+        };
+        let source_path = uri_to_path(source_uri.as_str());
+        let component_lens = kind == CodeLensKind::Reference
+            && source_path
+                .extension()
+                .is_some_and(|extension| extension == "svelte")
+            && lens
+                .pointer("/range/start/line")
+                .and_then(serde_json::Value::as_u64)
+                == Some(0)
+            && lens
+                .pointer("/range/start/character")
+                .and_then(serde_json::Value::as_u64)
+                == Some(0)
+            && lens
+                .pointer("/range/end/line")
+                .and_then(serde_json::Value::as_u64)
+                == Some(0)
+            && lens
+                .pointer("/range/end/character")
+                .and_then(serde_json::Value::as_u64)
+                == Some(1);
+        let method = match kind {
+            CodeLensKind::Reference => "textDocument/references",
+            CodeLensKind::Implementation => "textDocument/implementation",
+        };
+        let mapper = TsgoResponseMapper::for_overlays(&runtime.overlays);
+        let document = mapper.document_context(&source_uri);
+        let mut params = serde_json::json!({
+            "textDocument": { "uri": source_uri },
+            "position": lens.pointer("/range/start").cloned().unwrap_or_default(),
+        });
+        if kind == CodeLensKind::Reference {
+            params["context"] = serde_json::json!({ "includeDeclaration": false });
+        }
+        if component_lens {
+            let Some(shadow) = runtime
+                .overlays
+                .iter()
+                .find_map(|overlay| overlay.shadow_for_source(&source_path))
+            else {
+                self.respond(Response::new_ok(id, lens));
+                return;
+            };
+            let Some(position) = component_probe_position(&shadow.text) else {
+                self.respond(Response::new_ok(id, lens));
+                return;
+            };
+            params["textDocument"]["uri"] =
+                serde_json::Value::String(shadow.shadow_uri.as_str().to_string());
+            params["position"] = serde_json::to_value(position).unwrap_or_default();
+        } else {
+            let mapper = TsgoResponseMapper::for_overlays_with_default_document(
+                &runtime.overlays,
+                document.clone(),
+            );
+            if !mapper.map_request(method, &mut params) {
+                self.respond(Response::new_ok(id, lens));
+                return;
+            }
+        }
+        let child = Request::new(id.clone(), method.to_string(), params);
+        let pending = PendingTsgoRequest {
+            method: method.to_string(),
+            document,
+            fallback_result: None,
+            completion_site: None,
+            rename: None,
+            code_action_diagnostic_codes: Vec::new(),
+            push_diagnostics: None,
+            component_site: None,
+            component_references: component_lens.then(|| source_uri.clone()),
+            file_rename: None,
+            code_lens_resolve: Some(PendingCodeLensResolve {
+                lens,
+                kind,
+                source_uri,
+            }),
+        };
+        if runtime.client.forward(child.into()).is_ok() {
+            self.pending_tsgo.insert(id, pending);
+        } else if let Some(resolve) = pending.code_lens_resolve {
+            self.respond(Response::new_ok(id, resolve.lens));
+        }
     }
 
     fn on_execute_command(&mut self, request: Request) {
@@ -597,6 +1373,7 @@ impl Server {
     }
 
     fn on_folding_range(&mut self, request: Request) {
+        let tsgo_fallback = request.clone();
         let id = request.id;
         let params = match serde_json::from_value::<FoldingRangeParams>(request.params) {
             Ok(params) => params,
@@ -612,7 +1389,8 @@ impl Server {
         }
         match self.component(&params.text_document.uri) {
             Some((path, text)) => {
-                self.pending.insert(id.clone(), Pending::FoldingRange);
+                self.pending
+                    .insert(id.clone(), Pending::FoldingRange { tsgo_fallback });
                 self.worker.submit(Job::FoldingRange {
                     id,
                     path,
@@ -620,7 +1398,7 @@ impl Server {
                     line_folding_only: self.client.line_folding_only,
                 });
             }
-            None => self.respond_no_ranges(id),
+            None => self.forward_tsgo_request(tsgo_fallback),
         }
     }
 
@@ -658,6 +1436,7 @@ impl Server {
     }
 
     fn on_document_symbol(&mut self, request: Request) {
+        let tsgo_fallback = request.clone();
         let id = request.id;
         let params = match serde_json::from_value::<DocumentSymbolParams>(request.params) {
             Ok(params) => params,
@@ -674,7 +1453,8 @@ impl Server {
         let uri = params.text_document.uri;
         match self.component(&uri) {
             Some((path, text)) => {
-                self.pending.insert(id.clone(), Pending::DocumentSymbol);
+                self.pending
+                    .insert(id.clone(), Pending::DocumentSymbol { tsgo_fallback });
                 self.worker.submit(Job::DocumentSymbol {
                     id,
                     uri,
@@ -683,7 +1463,7 @@ impl Server {
                     hierarchical: self.client.hierarchical_document_symbols,
                 });
             }
-            None => self.respond_no_symbols(id),
+            None => self.forward_tsgo_request(tsgo_fallback),
         }
     }
 
@@ -709,25 +1489,64 @@ impl Server {
                 }
             }
             "workspace/didChangeWorkspaceFolders" => {
+                let child_notification = notification.clone();
                 match serde_json::from_value::<DidChangeWorkspaceFoldersParams>(notification.params)
                 {
-                    Ok(params) => self
-                        .client
-                        .update_workspace_folders(params.event.added, &params.event.removed),
+                    Ok(params) => {
+                        self.update_tsgo_workspace_folders(
+                            &params.event.added,
+                            &params.event.removed,
+                        );
+                        self.client
+                            .update_workspace_folders(params.event.added, &params.event.removed);
+                        self.ensure_tsgo_runtime();
+                        if let Some(runtime) = &self.tsgo {
+                            let workspace_folders = self.client.workspace_folders.clone();
+                            let root_uri = workspace_folders
+                                .is_empty()
+                                .then(|| self.client.root_uri.clone())
+                                .flatten();
+                            let current_dir = self
+                                .client
+                                .workspace_folders
+                                .first()
+                                .map(|folder| uri_to_path(folder.uri.as_str()))
+                                .or_else(|| {
+                                    self.client
+                                        .root_uri
+                                        .as_ref()
+                                        .map(|root| uri_to_path(root.as_str()))
+                                })
+                                .filter(|path| path.is_dir());
+                            let _ = runtime.client.update_workspace(
+                                root_uri,
+                                workspace_folders,
+                                current_dir,
+                            );
+                            let _ = runtime.client.forward(child_notification.into());
+                        }
+                    }
                     Err(err) => log::warn(format_args!("{method}: {err}")),
                 }
             }
             "workspace/didChangeWatchedFiles" => {
+                let child_notification = notification.clone();
                 match serde_json::from_value::<DidChangeWatchedFilesParams>(notification.params) {
-                    Ok(params)
-                        if params
+                    Ok(params) => {
+                        let project_changed = params
                             .changes
                             .iter()
-                            .any(|change| is_project_config(&change.uri)) =>
-                    {
-                        self.invalidate_project_config();
+                            .any(|change| is_project_config(&change.uri));
+                        if project_changed {
+                            self.invalidate_project_config();
+                            self.rebuild_tsgo_overlays();
+                        } else {
+                            self.refresh_tsgo_overlays();
+                        }
+                        if let Some(runtime) = &self.tsgo {
+                            let _ = runtime.client.forward(child_notification.into());
+                        }
                     }
-                    Ok(_) => {}
                     Err(err) => log::warn(format_args!("{method}: {err}")),
                 }
             }
@@ -738,6 +1557,7 @@ impl Server {
                         let key = doc.uri.as_str().to_string();
                         self.documents
                             .open(doc.uri, doc.language_id, doc.version, doc.text);
+                        self.sync_tsgo_document(&key);
                         if !self.client.pull_diagnostics {
                             self.schedule_lint(key, Duration::ZERO);
                         }
@@ -752,9 +1572,10 @@ impl Server {
                         if let Some(document) = self.documents.get_mut(&params.text_document.uri) {
                             document.apply(params.text_document.version, &params.content_changes);
                             if !self.client.pull_diagnostics {
-                                self.schedule_lint(key, LINT_DEBOUNCE);
+                                self.schedule_lint(key.clone(), LINT_DEBOUNCE);
                             }
                         }
+                        self.sync_tsgo_document(&key);
                     }
                     Err(err) => log::warn(format_args!("{method}: {err}")),
                 }
@@ -776,6 +1597,7 @@ impl Server {
                 match serde_json::from_value::<DidCloseTextDocumentParams>(notification.params) {
                     Ok(params) => {
                         let uri = params.text_document.uri;
+                        self.close_tsgo_document(&uri);
                         self.scheduled.remove(uri.as_str());
                         self.linted.remove(uri.as_str());
                         let version = self.documents.close(&uri).map_or(0, |d| d.version);
@@ -807,13 +1629,248 @@ impl Server {
             NumberOrString::Number(id) => RequestId::from(id),
             NumberOrString::String(id) => RequestId::from(id),
         };
-        if self.pending.remove(&id).is_some() {
+        let native = self.pending.remove(&id).is_some();
+        let tsgo = self.pending_tsgo.remove(&id).is_some();
+        let rename = self.rename_aggregates.remove(&id).is_some();
+        let component = self.component_queries.remove(&id);
+        let child_component_ids = self
+            .component_query_requests
+            .iter()
+            .filter(|(_, (editor_id, _))| editor_id == &id)
+            .map(|(child_id, _)| child_id.clone())
+            .collect::<Vec<_>>();
+        for child_id in child_component_ids {
+            self.component_query_requests.remove(&child_id);
+            if let Some(runtime) = &self.tsgo {
+                let _ = runtime.client.forward(
+                    Notification::new(
+                        "$/cancelRequest".to_string(),
+                        serde_json::json!({ "id": child_id }),
+                    )
+                    .into(),
+                );
+            }
+        }
+        if let Some(component) = &component
+            && let Some(runtime) = &self.tsgo
+        {
+            let _ = runtime
+                .client
+                .close_buffer(component.query.query_uri().clone());
+        }
+        let child_rename_ids = self
+            .pending_tsgo
+            .iter()
+            .filter_map(|(child_id, pending)| match &pending.rename {
+                Some(PendingRename::Followup { editor_id }) if editor_id == &id => {
+                    Some(child_id.clone())
+                }
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+        for child_id in child_rename_ids {
+            self.pending_tsgo.remove(&child_id);
+            if let Some(runtime) = &self.tsgo {
+                let _ = runtime.client.forward(
+                    Notification::new(
+                        "$/cancelRequest".to_string(),
+                        serde_json::json!({ "id": child_id }),
+                    )
+                    .into(),
+                );
+            }
+        }
+        if tsgo && let Some(runtime) = &self.tsgo {
+            let _ = runtime.client.forward(
+                Notification::new(
+                    "$/cancelRequest".to_string(),
+                    serde_json::json!({ "id": id }),
+                )
+                .into(),
+            );
+        }
+        if native || tsgo || rename || component.is_some() {
             self.respond(Response::new_err(
                 id,
                 ErrorCode::RequestCanceled as i32,
                 "request cancelled by client".to_string(),
             ));
         }
+    }
+
+    fn forward_tsgo_request(&mut self, request: Request) {
+        self.forward_tsgo_request_with_fallback(request, None);
+    }
+
+    fn forward_tsgo_request_with_fallback(
+        &mut self,
+        mut request: Request,
+        fallback_result: Option<serde_json::Value>,
+    ) {
+        let completion_site = self.completion_site(&request);
+        let component_site = self.component_completion_site(&request);
+        let code_action_diagnostic_codes = code_action_diagnostic_codes(&request);
+        let Some(runtime) = &self.tsgo else {
+            self.respond(Response::new_ok(
+                request.id,
+                fallback_result.unwrap_or(serde_json::Value::Null),
+            ));
+            return;
+        };
+        let initial = TsgoResponseMapper::for_overlays_request(&runtime.overlays, &request.params);
+        let document = initial
+            .default_document()
+            .cloned()
+            .or_else(|| runtime.completion_document_context(&request.params));
+        let mapper = TsgoResponseMapper::for_overlays_with_default_document(
+            &runtime.overlays,
+            document.clone(),
+        );
+        if !mapper.map_request(&request.method, &mut request.params) {
+            self.respond(Response::new_ok(
+                request.id,
+                fallback_result.unwrap_or(serde_json::Value::Null),
+            ));
+            return;
+        }
+        let pending = PendingTsgoRequest {
+            method: request.method.clone(),
+            document,
+            fallback_result,
+            completion_site,
+            rename: None,
+            code_action_diagnostic_codes,
+            push_diagnostics: None,
+            component_site,
+            component_references: None,
+            file_rename: None,
+            code_lens_resolve: None,
+        };
+        let id = request.id.clone();
+        if let Err(error) = runtime.client.forward(request.into()) {
+            log::warn(format_args!("could not forward request to tsgo: {error}"));
+            self.respond(Response::new_ok(
+                id,
+                pending.fallback_result.unwrap_or(serde_json::Value::Null),
+            ));
+            return;
+        }
+        self.pending_tsgo.insert(id, pending);
+    }
+
+    fn pull_and_publish_tsgo_diagnostics(
+        &mut self,
+        uri: Uri,
+        version: i32,
+        native: Vec<lsp_types::Diagnostic>,
+    ) {
+        let native_fallback = native.clone();
+        let fallback = serde_json::to_value(diagnostic_report(native)).ok();
+        let Some(runtime) = &self.tsgo else {
+            self.publish(uri, version, native_fallback);
+            return;
+        };
+        let mut params = serde_json::json!({ "textDocument": { "uri": uri } });
+        let mapper = TsgoResponseMapper::for_overlays_request(&runtime.overlays, &params);
+        let document = mapper.default_document().cloned();
+        if !mapper.map_request("textDocument/diagnostic", &mut params) {
+            self.publish(uri, version, native_fallback);
+            return;
+        }
+        self.next_request_id += 1;
+        let id = RequestId::from(format!(
+            "rsvelte-tsgo-push-diagnostics-{}",
+            self.next_request_id
+        ));
+        let request = Request::new(id.clone(), "textDocument/diagnostic".to_string(), params);
+        let pending = PendingTsgoRequest {
+            method: "textDocument/diagnostic".to_string(),
+            document,
+            fallback_result: fallback,
+            completion_site: None,
+            rename: None,
+            code_action_diagnostic_codes: Vec::new(),
+            push_diagnostics: Some((uri.clone(), version)),
+            component_site: None,
+            component_references: None,
+            file_rename: None,
+            code_lens_resolve: None,
+        };
+        if runtime.client.forward(request.into()).is_ok() {
+            self.pending_tsgo.insert(id, pending);
+        } else {
+            self.publish(uri, version, native_fallback);
+        }
+    }
+
+    fn completion_site(&self, request: &Request) -> Option<CompletionSite> {
+        if request.method != "textDocument/completion" {
+            return None;
+        }
+        let uri = request
+            .params
+            .pointer("/textDocument/uri")?
+            .as_str()?
+            .parse::<Uri>()
+            .ok()?;
+        let position = serde_json::from_value(request.params.get("position")?.clone()).ok()?;
+        let document = self.documents.get(&uri)?;
+        if document.language_id != "svelte" {
+            return Some(CompletionSite::Script);
+        }
+        let text = document.text();
+        let offset = document.offset_at(position);
+        if crate::context::EmbeddedRegions::new(text).contains(offset) {
+            return Some(if inside_element_body(text, offset, "style") {
+                CompletionSite::Style
+            } else {
+                CompletionSite::Script
+            });
+        }
+        if let Some(prefix) = crate::context::attribute_prefix_context(text, offset) {
+            let component = prefix
+                .element_tag
+                .starts_with(|character: char| character.is_ascii_uppercase());
+            return Some(if component {
+                CompletionSite::ComponentStartTag {
+                    at_whitespace: prefix.prefix.is_empty(),
+                }
+            } else {
+                CompletionSite::ElementStartTag
+            });
+        }
+        let before = text.get(..offset)?;
+        let brace = before.rfind('{');
+        let close = before.rfind('}');
+        if brace > close {
+            let marker = before.get(brace? + 1..)?.trim_start();
+            return Some(if marker.starts_with(['#', ':', '/']) {
+                CompletionSite::BlockMarker
+            } else {
+                CompletionSite::TemplateExpression
+            });
+        }
+        Some(CompletionSite::RawTemplateText)
+    }
+
+    fn component_completion_site(&self, request: &Request) -> Option<ComponentCompletionSite> {
+        if request.method != "textDocument/completion" {
+            return None;
+        }
+        let params = serde_json::from_value::<CompletionParams>(request.params.clone()).ok()?;
+        let document = self
+            .documents
+            .get(&params.text_document_position.text_document.uri)?;
+        if document.language_id != "svelte" {
+            return None;
+        }
+        component_completion_site(
+            document.text(),
+            params.text_document_position.position,
+            params.context.as_ref(),
+            document_has_parser_error(document.text()),
+        )
+        .ok()
     }
 
     fn invalidate_project_config(&mut self) {
@@ -823,7 +1880,262 @@ impl Server {
         }
     }
 
-    fn on_response(&mut self, response: Response) {
+    fn sync_tsgo_document(&mut self, key: &str) {
+        let Some(document) = self.documents.get_by_key(key) else {
+            return;
+        };
+        let uri = document.uri.clone();
+        let language_id = document.language_id.clone();
+        let version = document.version;
+        let text = document.text().to_string();
+        let path = uri_to_path(uri.as_str());
+        let Some(runtime) = &mut self.tsgo else {
+            return;
+        };
+        if is_svelte_document(&language_id, &path) {
+            let Some(overlay) = runtime.overlay_for_source_mut(&path) else {
+                return;
+            };
+            match overlay.open_or_update(&path, &text, version) {
+                Ok(shadow) => {
+                    let _ = runtime.client.change_buffer(OpenBuffer::new(
+                        shadow.shadow_uri,
+                        shadow.language_id,
+                        shadow.version,
+                        shadow.text,
+                    ));
+                }
+                Err(error) => log::warn(format_args!(
+                    "could not update tsgo shadow for {}: {error}",
+                    path.display()
+                )),
+            }
+        } else if is_typescript_or_javascript(&language_id, &path) {
+            let Some(overlay) = runtime.overlay_for_source_mut(&path) else {
+                return;
+            };
+            match overlay.open_plain(&path, &text, version, &language_id) {
+                Ok(shadow) => {
+                    let _ = runtime.client.change_buffer(OpenBuffer::new(
+                        shadow.shadow_uri,
+                        shadow.language_id,
+                        shadow.version,
+                        shadow.text,
+                    ));
+                }
+                Err(error) => log::warn(format_args!(
+                    "could not route TypeScript buffer {}: {error}",
+                    path.display()
+                )),
+            }
+        }
+    }
+
+    fn close_tsgo_document(&mut self, uri: &Uri) {
+        let Some(document) = self.documents.get(uri) else {
+            return;
+        };
+        let language_id = document.language_id.clone();
+        let path = uri_to_path(uri.as_str());
+        let Some(runtime) = &mut self.tsgo else {
+            return;
+        };
+        if is_svelte_document(&language_id, &path) {
+            let Some(overlay) = runtime.overlay_for_source_mut(&path) else {
+                return;
+            };
+            let shadow_uri = overlay
+                .shadow_for_source(&path)
+                .map(|shadow| shadow.shadow_uri.clone());
+            match overlay.close(&path) {
+                Ok(Some(shadow)) => {
+                    let _ = runtime.client.change_buffer(OpenBuffer::new(
+                        shadow.shadow_uri,
+                        shadow.language_id,
+                        shadow.version,
+                        shadow.text,
+                    ));
+                }
+                Ok(None) => {
+                    if let Some(shadow_uri) = shadow_uri {
+                        let _ = runtime.client.close_buffer(shadow_uri);
+                    }
+                }
+                Err(error) => log::warn(format_args!(
+                    "could not close tsgo shadow for {}: {error}",
+                    path.display()
+                )),
+            }
+        } else if is_typescript_or_javascript(&language_id, &path) {
+            let Some(overlay) = runtime.overlay_for_source_mut(&path) else {
+                return;
+            };
+            match overlay.close_plain(&path) {
+                Ok(Some(shadow_uri)) => {
+                    let _ = runtime.client.close_buffer(shadow_uri);
+                }
+                Ok(None) => {}
+                Err(error) => log::warn(format_args!(
+                    "could not close TypeScript route {}: {error}",
+                    path.display()
+                )),
+            }
+        }
+    }
+
+    fn refresh_tsgo_overlays(&mut self) {
+        let Some(runtime) = &mut self.tsgo else {
+            return;
+        };
+        for overlay in &mut runtime.overlays {
+            match overlay.refresh() {
+                Ok(update) => {
+                    for shadow in update.opened_or_changed {
+                        let _ = runtime.client.change_buffer(OpenBuffer::new(
+                            shadow.shadow_uri,
+                            shadow.language_id,
+                            shadow.version,
+                            shadow.text,
+                        ));
+                    }
+                    for uri in update.closed {
+                        let _ = runtime.client.close_buffer(uri);
+                    }
+                }
+                Err(error) => log::warn(format_args!(
+                    "could not refresh tsgo overlay for {}: {error}",
+                    overlay.workspace().display()
+                )),
+            }
+        }
+    }
+
+    fn rebuild_tsgo_overlays(&mut self) {
+        let Some(runtime) = &mut self.tsgo else {
+            return;
+        };
+        let roots = runtime
+            .overlays
+            .iter()
+            .map(|overlay| overlay.workspace().to_path_buf())
+            .collect::<Vec<_>>();
+        let mut rebuilt = Vec::with_capacity(roots.len());
+        for root in roots {
+            match TsgoOverlay::build(&root, None) {
+                Ok(overlay) => rebuilt.push(overlay),
+                Err(error) => log::warn(format_args!(
+                    "could not rebuild tsgo overlay for {}: {error}",
+                    root.display()
+                )),
+            }
+        }
+        if rebuilt.is_empty() {
+            return;
+        }
+        for shadow in runtime.overlays.iter().flat_map(TsgoOverlay::open_shadows) {
+            let _ = runtime.client.close_buffer(shadow.shadow_uri.clone());
+        }
+        runtime.overlays = rebuilt;
+        for shadow in runtime.overlays.iter().flat_map(TsgoOverlay::eager_shadows) {
+            let _ = runtime.client.open_buffer(OpenBuffer::new(
+                shadow.shadow_uri.clone(),
+                shadow.language_id.clone(),
+                shadow.version,
+                shadow.text.clone(),
+            ));
+        }
+        let open = self
+            .documents
+            .iter()
+            .map(|document| document.uri.as_str().to_string())
+            .collect::<Vec<_>>();
+        for key in open {
+            self.sync_tsgo_document(&key);
+        }
+        self.abort_tsgo_requests("TypeScript project configuration changed");
+        if let Some(runtime) = &mut self.tsgo {
+            runtime.generation = None;
+            let _ = runtime.client.restart();
+        }
+    }
+
+    fn update_tsgo_workspace_folders(
+        &mut self,
+        added: &[lsp_types::WorkspaceFolder],
+        removed: &[lsp_types::WorkspaceFolder],
+    ) {
+        let Some(runtime) = &mut self.tsgo else {
+            return;
+        };
+        for folder in removed {
+            let path = uri_to_path(folder.uri.as_str());
+            let path = fs::canonicalize(&path).unwrap_or(path);
+            if let Some(index) = runtime
+                .overlays
+                .iter()
+                .position(|overlay| overlay.workspace() == path)
+            {
+                let overlay = runtime.overlays.remove(index);
+                for shadow in overlay.open_shadows() {
+                    let _ = runtime.client.close_buffer(shadow.shadow_uri.clone());
+                }
+            }
+        }
+        for folder in added {
+            let path = uri_to_path(folder.uri.as_str());
+            let path = fs::canonicalize(&path).unwrap_or(path);
+            if runtime
+                .overlays
+                .iter()
+                .any(|overlay| overlay.workspace() == path)
+            {
+                continue;
+            }
+            match TsgoOverlay::build(&path, None) {
+                Ok(overlay) => {
+                    for shadow in overlay.eager_shadows() {
+                        let _ = runtime.client.open_buffer(OpenBuffer::new(
+                            shadow.shadow_uri.clone(),
+                            shadow.language_id.clone(),
+                            shadow.version,
+                            shadow.text.clone(),
+                        ));
+                    }
+                    runtime.overlays.push(overlay);
+                }
+                Err(error) => log::warn(format_args!(
+                    "could not prepare tsgo overlay for {}: {error}",
+                    path.display()
+                )),
+            }
+        }
+    }
+
+    fn ensure_tsgo_runtime(&mut self) {
+        if self.tsgo.is_some() {
+            return;
+        }
+        let Some(runtime) = TsgoRuntime::start(&self.client, &self.initialize_params) else {
+            return;
+        };
+        let _ = runtime.client.update_configuration(
+            self.js_ts_settings.clone(),
+            self.editor_settings.clone(),
+            self.typescript_settings.clone(),
+            self.javascript_settings.clone(),
+        );
+        self.tsgo = Some(runtime);
+        let open = self
+            .documents
+            .iter()
+            .map(|document| document.uri.as_str().to_string())
+            .collect::<Vec<_>>();
+        for key in open {
+            self.sync_tsgo_document(&key);
+        }
+    }
+
+    fn on_response(&mut self, mut response: Response) {
         let Some(outgoing) = self.outgoing.remove(&response.id) else {
             log::warn(format_args!("response to unknown request {}", response.id));
             return;
@@ -831,11 +2143,29 @@ impl Server {
         match outgoing {
             Outgoing::Configuration => {
                 self.settings = match response.response_result {
-                    Ok(value) => value
-                        .as_array()
-                        .and_then(|items| items.first())
-                        .map(Settings::from_json)
-                        .unwrap_or_default(),
+                    Ok(value) => {
+                        let items = value.as_array();
+                        self.js_ts_settings = items
+                            .and_then(|items| items.get(1))
+                            .cloned()
+                            .unwrap_or(serde_json::Value::Null);
+                        self.typescript_settings = items
+                            .and_then(|items| items.get(2))
+                            .cloned()
+                            .unwrap_or(serde_json::Value::Null);
+                        self.javascript_settings = items
+                            .and_then(|items| items.get(3))
+                            .cloned()
+                            .unwrap_or(serde_json::Value::Null);
+                        self.editor_settings = items
+                            .and_then(|items| items.get(4))
+                            .cloned()
+                            .unwrap_or(serde_json::Value::Null);
+                        items
+                            .and_then(|items| items.first())
+                            .map(Settings::from_json)
+                            .unwrap_or_default()
+                    }
                     Err(err) => {
                         log::warn(format_args!(
                             "workspace/configuration failed: {}",
@@ -844,12 +2174,665 @@ impl Server {
                         Settings::default()
                     }
                 };
+                if let Some(runtime) = &self.tsgo
+                    && let Err(error) = runtime.client.update_configuration(
+                        self.js_ts_settings.clone(),
+                        self.editor_settings.clone(),
+                        self.typescript_settings.clone(),
+                        self.javascript_settings.clone(),
+                    )
+                {
+                    log::warn(format_args!("could not update tsgo settings: {error}"));
+                }
                 if !self.client.pull_diagnostics {
                     self.relint_open_documents();
                 }
             }
             Outgoing::WatchedFilesRegistration => {}
+            Outgoing::Tsgo { child_id } => {
+                response.id = child_id;
+                if let Some(runtime) = &self.tsgo {
+                    let _ = runtime.client.forward(response.into());
+                }
+            }
         }
+    }
+
+    fn on_tsgo_event(&mut self, event: TsgoEvent) {
+        match event {
+            TsgoEvent::Ready {
+                generation,
+                capabilities: _,
+            } => {
+                if let Some(runtime) = &mut self.tsgo {
+                    runtime.generation = Some(generation);
+                }
+            }
+            TsgoEvent::Message {
+                generation,
+                message,
+            } => {
+                if self
+                    .tsgo
+                    .as_ref()
+                    .is_some_and(|runtime| runtime.generation == Some(generation))
+                {
+                    self.on_tsgo_message(message);
+                }
+            }
+            TsgoEvent::Crashed {
+                generation,
+                status,
+                error,
+            } => {
+                if let Some(runtime) = &mut self.tsgo {
+                    runtime.generation = None;
+                }
+                log::warn(format_args!(
+                    "tsgo generation {generation} crashed ({status:?}): {error}"
+                ));
+                self.abort_tsgo_requests("TypeScript service restarted before answering");
+            }
+        }
+    }
+
+    fn abort_tsgo_requests(&mut self, message: &str) {
+        let stale_child_requests = self
+            .outgoing
+            .iter()
+            .filter_map(|(id, outgoing)| {
+                matches!(outgoing, Outgoing::Tsgo { .. }).then_some(id.clone())
+            })
+            .collect::<Vec<_>>();
+        for id in stale_child_requests {
+            self.outgoing.remove(&id);
+            self.send(Notification::new(
+                "$/cancelRequest".to_string(),
+                serde_json::json!({ "id": id }),
+            ));
+        }
+        for (id, pending) in std::mem::take(&mut self.pending_tsgo) {
+            if let Some((uri, version)) = pending.push_diagnostics {
+                let diagnostics = pending
+                    .fallback_result
+                    .and_then(|report| report.get("items").cloned())
+                    .and_then(|items| serde_json::from_value(items).ok())
+                    .unwrap_or_default();
+                self.publish(uri, version, diagnostics);
+                continue;
+            }
+            if matches!(pending.rename, Some(PendingRename::Followup { .. })) {
+                continue;
+            }
+            if let Some(fallback) = pending.fallback_result {
+                self.respond(Response::new_ok(id, fallback));
+            } else {
+                self.respond(Response::new_err(
+                    id,
+                    ErrorCode::InternalError as i32,
+                    message.to_string(),
+                ));
+            }
+        }
+        for (id, _) in std::mem::take(&mut self.rename_aggregates) {
+            self.respond(Response::new_err(
+                id,
+                ErrorCode::InternalError as i32,
+                message.to_string(),
+            ));
+        }
+        self.component_query_requests.clear();
+        for (id, pending) in std::mem::take(&mut self.component_queries) {
+            if let Some(runtime) = &self.tsgo {
+                let _ = runtime
+                    .client
+                    .close_buffer(pending.query.query_uri().clone());
+            }
+            self.respond(Response::new_err(
+                id,
+                ErrorCode::InternalError as i32,
+                message.to_string(),
+            ));
+        }
+    }
+
+    fn on_tsgo_message(&mut self, message: Message) {
+        match message {
+            Message::Response(mut response) => {
+                if self.on_component_query_response(response.clone()) {
+                    return;
+                }
+                let Some(pending) = self.pending_tsgo.remove(&response.id) else {
+                    log::warn(format_args!(
+                        "response to unknown tsgo request {}",
+                        response.id
+                    ));
+                    return;
+                };
+                if let Some(rename) = pending.rename {
+                    self.on_tsgo_rename_response(response, rename);
+                    return;
+                }
+                let PendingTsgoRequest {
+                    method,
+                    document,
+                    fallback_result,
+                    completion_site,
+                    rename: _,
+                    code_action_diagnostic_codes,
+                    push_diagnostics,
+                    component_site,
+                    component_references,
+                    file_rename,
+                    code_lens_resolve,
+                } = pending;
+                let source_path = document
+                    .as_ref()
+                    .map(|document| uri_to_path(document.source_uri().as_str()));
+                let source_uri = document
+                    .as_ref()
+                    .map(|document| document.source_uri().clone());
+                let completion_context =
+                    CompletionRewriteContext::new(source_path.as_deref(), true);
+                if let Ok(result) = &mut response.response_result {
+                    if let Some(runtime) = &self.tsgo {
+                        let mut mapper = TsgoResponseMapper::for_overlays_with_default_document(
+                            &runtime.overlays,
+                            document,
+                        );
+                        if let Some(rename) = &file_rename {
+                            let _ = mapper.add_uri_alias(
+                                rename.new_source.clone(),
+                                rename.new_shadow.clone(),
+                                &rename.old_source,
+                            );
+                        }
+                        mapper.map_response(&method, result);
+                    }
+                    match method.as_str() {
+                        "textDocument/completion" => {
+                            rewrite_completion_response_for_context(result, completion_context);
+                            if let Some(site) = completion_site {
+                                let (count, first_is_member) = completion_result_shape(result);
+                                if !matches!(
+                                    completion_action(site, count, first_is_member),
+                                    CompletionAction::Forward
+                                ) {
+                                    *result = serde_json::Value::Null;
+                                }
+                            }
+                        }
+                        "completionItem/resolve" => {
+                            rewrite_completion_item_for_context(result, completion_context);
+                        }
+                        "textDocument/codeAction" => {
+                            if let Some(uri) = source_uri.as_ref()
+                                && let Some(source) = self.documents.get(uri)
+                                && is_svelte_document(
+                                    &source.language_id,
+                                    &uri_to_path(uri.as_str()),
+                                )
+                            {
+                                let parser_error = document_has_parser_error(source.text());
+                                let context = TsgoCodeActionContext::new(uri, source.text())
+                                    .with_parser_error(parser_error)
+                                    .with_diagnostic_codes(&code_action_diagnostic_codes);
+                                rewrite_code_action_response(result, &context);
+                            }
+                        }
+                        "textDocument/codeLens" => {
+                            if let Some(uri) = source_uri.as_ref() {
+                                prepare_code_lenses(result, uri);
+                                if self.component_reference_code_lens_enabled(uri)
+                                    && let Some(lenses) = result.as_array_mut()
+                                {
+                                    lenses.push(component_reference_code_lens(uri));
+                                }
+                            }
+                        }
+                        _ => {}
+                    }
+                    rewrite_visible_tsgo_response(result);
+                    if component_references.is_some() {
+                        let locations =
+                            serde_json::from_value::<Vec<lsp_types::Location>>(result.clone())
+                                .unwrap_or_default();
+                        let texts = locations
+                            .iter()
+                            .map(|location| {
+                                self.documents
+                                    .get(&location.uri)
+                                    .map(|document| document.text().to_string())
+                                    .or_else(|| {
+                                        fs::read_to_string(uri_to_path(location.uri.as_str())).ok()
+                                    })
+                            })
+                            .collect::<Vec<_>>();
+                        let references =
+                            locations.into_iter().zip(&texts).map(|(location, text)| {
+                                ComponentReference {
+                                    location,
+                                    source_text: text.as_deref(),
+                                    is_definition: false,
+                                    is_generated: false,
+                                }
+                            });
+                        *result = serde_json::to_value(filter_component_references(references))
+                            .unwrap_or_else(|_| serde_json::Value::Array(Vec::new()));
+                    }
+                    if let Some(file_rename) = &file_rename {
+                        let mapping = WillRenameMapping {
+                            old: ShadowUriPair {
+                                source_uri: &file_rename.old_source,
+                                shadow_uri: &file_rename.old_shadow,
+                            },
+                            new: ShadowUriPair {
+                                source_uri: &file_rename.new_source,
+                                shadow_uri: &file_rename.new_shadow,
+                            },
+                        };
+                        let owned_pairs = self
+                            .tsgo
+                            .as_ref()
+                            .map(|runtime| {
+                                runtime
+                                    .overlays
+                                    .iter()
+                                    .flat_map(TsgoOverlay::eager_shadows)
+                                    .map(|shadow| {
+                                        (shadow.source_uri.clone(), shadow.shadow_uri.clone())
+                                    })
+                                    .collect::<Vec<_>>()
+                            })
+                            .unwrap_or_default();
+                        let pairs = owned_pairs
+                            .iter()
+                            .map(|(source, shadow)| ShadowUriPair {
+                                source_uri: source,
+                                shadow_uri: shadow,
+                            })
+                            .collect::<Vec<_>>();
+                        rewrite_will_rename_result(result, &[mapping], &pairs);
+                    }
+                    if let Some(mut resolve) = code_lens_resolve {
+                        let locations = locations_from_tsgo_result(result);
+                        resolve_code_lens(
+                            &mut resolve.lens,
+                            resolve.kind,
+                            &resolve.source_uri,
+                            locations,
+                        );
+                        *result = resolve.lens;
+                    }
+                    if let Some(fallback) = fallback_result {
+                        merge_tsgo_result(&method, result, fallback);
+                    }
+                } else if let Some(fallback) = fallback_result {
+                    response.response_result = Ok(fallback);
+                }
+                if let Some((uri, version)) = push_diagnostics {
+                    let diagnostics = response
+                        .response_result
+                        .as_ref()
+                        .ok()
+                        .and_then(|result| result.get("items"))
+                        .cloned()
+                        .and_then(|items| serde_json::from_value(items).ok())
+                        .unwrap_or_default();
+                    self.publish(uri, version, diagnostics);
+                    return;
+                }
+                if method == "textDocument/completion"
+                    && let (Some(site), Some(uri), Ok(result)) = (
+                        component_site,
+                        source_uri.as_ref(),
+                        response.response_result.as_ref(),
+                    )
+                    && self.start_component_query(response.id.clone(), uri, site, result.clone())
+                {
+                    return;
+                }
+                self.respond(response);
+            }
+            Message::Notification(mut notification) => {
+                if let Some(runtime) = &self.tsgo {
+                    let mapper = TsgoResponseMapper::for_overlays(&runtime.overlays);
+                    if !mapper.map_child_params(&notification.method, &mut notification.params) {
+                        return;
+                    }
+                }
+                self.send(notification);
+            }
+            Message::Request(mut request) => {
+                if let Some(runtime) = &self.tsgo {
+                    let mapper = TsgoResponseMapper::for_overlays_request(
+                        &runtime.overlays,
+                        &request.params,
+                    );
+                    if !mapper.map_child_params(&request.method, &mut request.params) {
+                        let _ = runtime.client.forward(
+                            Response::new_err(
+                                request.id,
+                                ErrorCode::InvalidParams as i32,
+                                "could not map generated request coordinates".to_string(),
+                            )
+                            .into(),
+                        );
+                        return;
+                    }
+                }
+                let child_id = request.id.clone();
+                self.next_request_id += 1;
+                let editor_id =
+                    RequestId::from(format!("rsvelte-tsgo-child-{}", self.next_request_id));
+                request.id = editor_id.clone();
+                self.outgoing.insert(editor_id, Outgoing::Tsgo { child_id });
+                self.send(request);
+            }
+        }
+    }
+
+    fn start_component_query(
+        &mut self,
+        editor_id: RequestId,
+        source_uri: &Uri,
+        site: ComponentCompletionSite,
+        result: serde_json::Value,
+    ) -> bool {
+        let Some(runtime) = self.tsgo.as_ref() else {
+            return false;
+        };
+        let source_path = uri_to_path(source_uri.as_str());
+        let Some((shadow_uri, generated_text, generated_range, version)) = runtime
+            .overlays
+            .iter()
+            .filter_map(|overlay| {
+                let shadow = overlay.shadow_for_source(&source_path)?;
+                let ranges = generated_component_ranges(
+                    overlay.projection_map(&source_path)?,
+                    &site,
+                    &shadow.text,
+                );
+                Some((
+                    shadow.shadow_uri.clone(),
+                    shadow.text.clone(),
+                    ranges.into_iter().next_back()?,
+                    shadow.version.saturating_add(10_000),
+                ))
+            })
+            .next()
+        else {
+            return false;
+        };
+        let Ok(query) = ComponentInfoQuery::new(
+            &shadow_uri,
+            generated_text,
+            generated_range,
+            site.component_expression(),
+            version,
+        ) else {
+            return false;
+        };
+        self.component_queries.insert(
+            editor_id.clone(),
+            PendingComponentQuery {
+                query,
+                site,
+                result,
+            },
+        );
+        self.drive_component_query(&editor_id);
+        true
+    }
+
+    fn component_reference_code_lens_enabled(&self, uri: &Uri) -> bool {
+        let Some(document) = self.documents.get(uri) else {
+            return false;
+        };
+        if !is_svelte_document(&document.language_id, &uri_to_path(uri.as_str()))
+            || document_has_parser_error(document.text())
+        {
+            return false;
+        }
+        let lower = document.text().to_ascii_lowercase();
+        let language = if lower.contains("lang=\"ts\"")
+            || lower.contains("lang='ts'")
+            || lower.contains("lang=ts")
+        {
+            &self.typescript_settings
+        } else {
+            &self.javascript_settings
+        };
+        let mut enabled = true;
+        for layer in [&self.editor_settings, language, &self.js_ts_settings] {
+            if let Some(value) = layer
+                .pointer("/referencesCodeLens/enabled")
+                .and_then(serde_json::Value::as_bool)
+            {
+                enabled = value;
+            }
+        }
+        enabled
+    }
+
+    fn on_component_query_response(&mut self, response: Response) -> bool {
+        let Some((editor_id, query_id)) = self.component_query_requests.remove(&response.id) else {
+            return false;
+        };
+        let Some(mut pending) = self.component_queries.remove(&editor_id) else {
+            return true;
+        };
+        match response.response_result {
+            Ok(result) => {
+                let _ = pending.query.accept_response(query_id, result);
+            }
+            Err(_) => {
+                let _ = pending.query.accept_error(query_id);
+            }
+        }
+        self.component_queries.insert(editor_id.clone(), pending);
+        self.drive_component_query(&editor_id);
+        true
+    }
+
+    fn drive_component_query(&mut self, editor_id: &RequestId) {
+        let Some(mut pending) = self.component_queries.remove(editor_id) else {
+            return;
+        };
+        loop {
+            let Some(action) = pending.query.next_action() else {
+                self.component_queries.insert(editor_id.clone(), pending);
+                return;
+            };
+            match action {
+                ComponentInfoAction::Open {
+                    uri,
+                    language_id,
+                    version,
+                    text,
+                } => {
+                    if let Some(runtime) = &self.tsgo {
+                        let _ = runtime.client.open_buffer(OpenBuffer::new(
+                            uri,
+                            language_id,
+                            version,
+                            text,
+                        ));
+                    }
+                }
+                ComponentInfoAction::Change { uri, version, text } => {
+                    if let Some(runtime) = &self.tsgo {
+                        let _ = runtime.client.change_buffer(OpenBuffer::new(
+                            uri,
+                            "typescriptreact",
+                            version,
+                            text,
+                        ));
+                    }
+                }
+                ComponentInfoAction::Request { id, method, params } => {
+                    self.next_request_id += 1;
+                    let child_id = RequestId::from(format!(
+                        "rsvelte-tsgo-component-info-{}",
+                        self.next_request_id
+                    ));
+                    let request = Request::new(child_id.clone(), method.to_string(), params);
+                    let sent = self
+                        .tsgo
+                        .as_ref()
+                        .is_some_and(|runtime| runtime.client.forward(request.into()).is_ok());
+                    if sent {
+                        self.component_query_requests
+                            .insert(child_id, (editor_id.clone(), id));
+                        self.component_queries.insert(editor_id.clone(), pending);
+                        return;
+                    }
+                    let _ = pending.query.accept_error(id);
+                }
+                ComponentInfoAction::Close { uri } => {
+                    if let Some(runtime) = &self.tsgo {
+                        let _ = runtime.client.close_buffer(uri);
+                    }
+                }
+                ComponentInfoAction::Complete(info) => {
+                    let manual = info.completion_items(&pending.site);
+                    append_component_completions(
+                        &mut pending.result,
+                        manual,
+                        pending.site.was_colon_triggered(),
+                    );
+                    self.respond(Response::new_ok(editor_id.clone(), pending.result));
+                    return;
+                }
+            }
+        }
+    }
+
+    fn on_tsgo_rename_response(&mut self, mut response: Response, pending: PendingRename) {
+        match pending {
+            PendingRename::Prepare(plan) => {
+                if let Ok(result) = response.response_result {
+                    let rewritten = self
+                        .tsgo
+                        .as_ref()
+                        .and_then(|runtime| {
+                            let documents = rename_documents(&runtime.overlays);
+                            rewrite_prepare_response(&plan, result, &documents)
+                        })
+                        .unwrap_or(serde_json::Value::Null);
+                    response.response_result = Ok(rewritten);
+                }
+                self.respond(response);
+            }
+            PendingRename::Primary { plan, new_name } => {
+                let Ok(result) = response.response_result else {
+                    self.respond(response);
+                    return;
+                };
+                let Some(runtime) = self.tsgo.as_ref() else {
+                    self.respond_nothing(response.id);
+                    return;
+                };
+                let documents = rename_documents(&runtime.overlays);
+                let rewritten = rewrite_workspace_edit(&plan, &result, &documents, &new_name, true);
+                if rewritten.followups.is_empty() {
+                    self.respond(Response::new_ok(response.id, rewritten.edit));
+                    return;
+                }
+                let editor_id = response.id;
+                let remaining = rewritten.followups.len();
+                let mut requests = Vec::with_capacity(remaining);
+                for followup in rewritten.followups {
+                    self.next_request_id += 1;
+                    let child_id = RequestId::from(format!(
+                        "rsvelte-tsgo-rename-followup-{}",
+                        self.next_request_id
+                    ));
+                    let request = Request::new(
+                        child_id.clone(),
+                        "textDocument/rename".to_string(),
+                        serde_json::json!({
+                            "textDocument": { "uri": followup.uri },
+                            "position": followup.position,
+                            "newName": followup.new_name,
+                        }),
+                    );
+                    let child_pending = PendingTsgoRequest {
+                        method: "textDocument/rename".to_string(),
+                        document: None,
+                        fallback_result: None,
+                        completion_site: None,
+                        rename: Some(PendingRename::Followup {
+                            editor_id: editor_id.clone(),
+                        }),
+                        code_action_diagnostic_codes: Vec::new(),
+                        push_diagnostics: None,
+                        component_site: None,
+                        component_references: None,
+                        file_rename: None,
+                        code_lens_resolve: None,
+                    };
+                    requests.push((child_id, request, child_pending));
+                }
+                self.rename_aggregates.insert(
+                    editor_id.clone(),
+                    RenameAggregate {
+                        plan,
+                        new_name,
+                        edits: vec![rewritten.edit],
+                        remaining,
+                    },
+                );
+                for (child_id, request, child_pending) in requests {
+                    if let Some(runtime) = &self.tsgo
+                        && runtime.client.forward(request.into()).is_ok()
+                    {
+                        self.pending_tsgo.insert(child_id, child_pending);
+                    } else {
+                        self.finish_rename_followup(&editor_id, None);
+                    }
+                }
+            }
+            PendingRename::Followup { editor_id } => {
+                let edit = response.response_result.ok().and_then(|result| {
+                    let aggregate = self.rename_aggregates.get(&editor_id)?;
+                    let runtime = self.tsgo.as_ref()?;
+                    let documents = rename_documents(&runtime.overlays);
+                    Some(
+                        rewrite_workspace_edit(
+                            &aggregate.plan,
+                            &result,
+                            &documents,
+                            &aggregate.new_name,
+                            false,
+                        )
+                        .edit,
+                    )
+                });
+                self.finish_rename_followup(&editor_id, edit);
+            }
+        }
+    }
+
+    fn finish_rename_followup(&mut self, editor_id: &RequestId, edit: Option<serde_json::Value>) {
+        let Some(aggregate) = self.rename_aggregates.get_mut(editor_id) else {
+            return;
+        };
+        if let Some(edit) = edit {
+            aggregate.edits.push(edit);
+        }
+        aggregate.remaining = aggregate.remaining.saturating_sub(1);
+        if aggregate.remaining != 0 {
+            return;
+        }
+        let aggregate = self
+            .rename_aggregates
+            .remove(editor_id)
+            .expect("aggregate existed above");
+        self.respond(Response::new_ok(
+            editor_id.clone(),
+            merge_workspace_edits(aggregate.edits),
+        ));
     }
 
     fn on_outcome(&mut self, outcome: Outcome) {
@@ -862,23 +2845,34 @@ impl Server {
                 }
             }
             Outcome::Completed { id, list } => {
-                if self.pending.remove(&id).is_some() {
-                    self.respond(Response::new_ok(id, list));
+                if let Some(Pending::Completion { tsgo_fallback }) = self.pending.remove(&id) {
+                    let fallback = list.and_then(|list| serde_json::to_value(list).ok());
+                    self.forward_tsgo_request_with_fallback(tsgo_fallback, fallback);
                 }
             }
             Outcome::Hovered { id, hover } => {
-                if self.pending.remove(&id).is_some() {
-                    self.respond(Response::new_ok(id, hover));
+                if let Some(Pending::Hover { tsgo_fallback }) = self.pending.remove(&id) {
+                    if hover.is_some() {
+                        self.respond(Response::new_ok(id, hover));
+                    } else {
+                        self.forward_tsgo_request(tsgo_fallback);
+                    }
                 }
             }
             Outcome::CodeActions { id, actions } => {
-                if self.pending.remove(&id).is_some() {
-                    self.respond(Response::new_ok(id, actions));
+                if let Some(Pending::CodeAction { tsgo_fallback }) = self.pending.remove(&id) {
+                    self.forward_tsgo_request_with_fallback(
+                        tsgo_fallback,
+                        serde_json::to_value(actions).ok(),
+                    );
                 }
             }
             Outcome::CodeLenses { id, lenses } => {
-                if self.pending.remove(&id).is_some() {
-                    self.respond(Response::new_ok(id, lenses));
+                if let Some(Pending::CodeLens { tsgo_fallback }) = self.pending.remove(&id) {
+                    self.forward_tsgo_request_with_fallback(
+                        tsgo_fallback,
+                        serde_json::to_value(lenses).ok(),
+                    );
                 }
             }
             Outcome::ExtractedComponent { id, result } => {
@@ -887,8 +2881,11 @@ impl Server {
                 }
             }
             Outcome::FoldingRanges { id, ranges } => {
-                if self.pending.remove(&id).is_some() {
-                    self.respond(Response::new_ok(id, ranges));
+                if let Some(Pending::FoldingRange { tsgo_fallback }) = self.pending.remove(&id) {
+                    self.forward_tsgo_request_with_fallback(
+                        tsgo_fallback,
+                        serde_json::to_value(ranges).ok(),
+                    );
                 }
             }
             Outcome::SelectionRanges { id, ranges } => {
@@ -897,13 +2894,26 @@ impl Server {
                 }
             }
             Outcome::DocumentSymbols { id, symbols } => {
-                if self.pending.remove(&id).is_some() {
-                    self.respond(Response::new_ok(id, symbols));
+                if let Some(Pending::DocumentSymbol { tsgo_fallback }) = self.pending.remove(&id) {
+                    self.forward_tsgo_request_with_fallback(
+                        tsgo_fallback,
+                        serde_json::to_value(symbols).ok(),
+                    );
                 }
             }
             Outcome::PulledDiagnostics { id, diagnostics } => {
-                if self.pending.remove(&id).is_some() {
-                    self.respond_diagnostic_report(id, diagnostics);
+                if let Some(Pending::DocumentDiagnostic { tsgo_fallback }) =
+                    self.pending.remove(&id)
+                {
+                    self.forward_tsgo_request_with_fallback(
+                        tsgo_fallback,
+                        serde_json::to_value(diagnostic_report(diagnostics)).ok(),
+                    );
+                }
+            }
+            Outcome::FileReferences { id, locations } => {
+                if matches!(self.pending.remove(&id), Some(Pending::FileReferences)) {
+                    self.respond(Response::new_ok(id, locations));
                 }
             }
             Outcome::Diagnostics {
@@ -913,7 +2923,7 @@ impl Server {
                 diagnostics,
             } => {
                 if self.documents.get_by_key(&key).is_some() {
-                    self.publish(uri, version, diagnostics);
+                    self.pull_and_publish_tsgo_diagnostics(uri, version, diagnostics);
                 }
             }
         }
@@ -927,10 +2937,19 @@ impl Server {
             id,
             "workspace/configuration".to_string(),
             ConfigurationParams {
-                items: vec![ConfigurationItem {
+                items: [
+                    CONFIG_SECTION,
+                    JS_TS_CONFIG_SECTION,
+                    TYPESCRIPT_CONFIG_SECTION,
+                    JAVASCRIPT_CONFIG_SECTION,
+                    EDITOR_CONFIG_SECTION,
+                ]
+                .into_iter()
+                .map(|section| ConfigurationItem {
                     scope_uri: None,
-                    section: Some(CONFIG_SECTION.to_string()),
-                }],
+                    section: Some(section.to_string()),
+                })
+                .collect(),
             },
         ));
     }
@@ -994,6 +3013,7 @@ impl Server {
             return;
         };
         let uri = document.uri.clone();
+        let language_id = document.language_id.clone();
         let version = document.version;
         let hash = document.content_hash();
         // A burst of edits that cancel out leaves the text — and therefore the
@@ -1004,7 +3024,14 @@ impl Server {
         self.linted.insert(key.to_string(), hash);
 
         if !self.settings.lint_enable || !is_lint_target(document) {
-            self.publish(uri, version, Vec::new());
+            let path = uri_to_path(key);
+            if is_svelte_document(&language_id, &path)
+                || is_typescript_or_javascript(&language_id, &path)
+            {
+                self.pull_and_publish_tsgo_diagnostics(uri, version, Vec::new());
+            } else {
+                self.publish(uri, version, Vec::new());
+            }
             return;
         }
         self.worker.submit(Job::Lint {
@@ -1029,14 +3056,7 @@ impl Server {
     }
 
     fn respond_diagnostic_report(&self, id: RequestId, diagnostics: Vec<lsp_types::Diagnostic>) {
-        let report = DocumentDiagnosticReport::Full(RelatedFullDocumentDiagnosticReport {
-            related_documents: None,
-            full_document_diagnostic_report: FullDocumentDiagnosticReport {
-                result_id: None,
-                items: diagnostics,
-            },
-        });
-        self.respond(Response::new_ok(id, report));
+        self.respond(Response::new_ok(id, diagnostic_report(diagnostics)));
     }
 
     fn respond_no_edits(&self, id: RequestId) {
@@ -1076,6 +3096,56 @@ impl Server {
     }
 }
 
+fn diagnostic_report(diagnostics: Vec<lsp_types::Diagnostic>) -> DocumentDiagnosticReport {
+    DocumentDiagnosticReport::Full(RelatedFullDocumentDiagnosticReport {
+        related_documents: None,
+        full_document_diagnostic_report: FullDocumentDiagnosticReport {
+            result_id: None,
+            items: diagnostics,
+        },
+    })
+}
+
+fn inside_element_body(text: &str, offset: usize, tag: &str) -> bool {
+    let before = text.get(..offset).unwrap_or(text);
+    let open = before.rfind(&format!("<{tag}"));
+    let close = before.rfind(&format!("</{tag}"));
+    open > close && open.is_some_and(|start| before[start..].contains('>'))
+}
+
+fn rename_documents(overlays: &[TsgoOverlay]) -> Vec<RenameDocument<'_>> {
+    let mut documents = Vec::new();
+    for overlay in overlays {
+        for shadow in overlay.eager_shadows() {
+            let source_path = uri_to_path(shadow.source_uri.as_str());
+            let Some(source_text) = overlay.source_text(&source_path) else {
+                continue;
+            };
+            let Some(projection_map) = overlay.projection_map(&source_path) else {
+                continue;
+            };
+            documents.push(RenameDocument {
+                source_uri: &shadow.source_uri,
+                shadow_uri: &shadow.shadow_uri,
+                source_text,
+                generated_text: &shadow.text,
+                projection_map,
+                source_map: overlay.source_map(&source_path),
+                parser_error: false,
+            });
+        }
+    }
+    documents
+}
+
+fn custom_request_uri(params: &serde_json::Value) -> Option<Uri> {
+    params
+        .as_str()
+        .or_else(|| params.get("uri").and_then(serde_json::Value::as_str))?
+        .parse()
+        .ok()
+}
+
 /// Svelte components plus the `.svelte.js` / `.svelte.ts` module dialect.
 fn is_lint_target(document: &Document) -> bool {
     if document.language_id == "svelte" {
@@ -1085,10 +3155,165 @@ fn is_lint_target(document: &Document) -> bool {
     uri.ends_with(".svelte.js") || uri.ends_with(".svelte.ts")
 }
 
+fn is_svelte_document(language_id: &str, path: &Path) -> bool {
+    language_id == "svelte"
+        || path
+            .extension()
+            .is_some_and(|extension| extension == "svelte")
+}
+
+fn is_typescript_or_javascript(language_id: &str, path: &Path) -> bool {
+    if matches!(
+        language_id,
+        "typescript" | "typescriptreact" | "javascript" | "javascriptreact"
+    ) {
+        return true;
+    }
+    path.extension().is_some_and(|extension| {
+        matches!(
+            extension.to_str(),
+            Some("ts" | "tsx" | "mts" | "cts" | "js" | "jsx" | "mjs" | "cjs")
+        )
+    })
+}
+
 fn is_project_config(uri: &Uri) -> bool {
     project_config_names()
         .iter()
         .any(|name| uri.as_str().rsplit('/').next() == Some(name))
+}
+
+fn merge_tsgo_result(method: &str, result: &mut serde_json::Value, fallback: serde_json::Value) {
+    if result.is_null() {
+        *result = fallback;
+        return;
+    }
+    match method {
+        "textDocument/completion" => {
+            let mut fallback = fallback;
+            let fallback_items = fallback
+                .get_mut("items")
+                .and_then(serde_json::Value::as_array_mut);
+            let result_items = result
+                .get_mut("items")
+                .and_then(serde_json::Value::as_array_mut);
+            if let (Some(fallback_items), Some(result_items)) = (fallback_items, result_items) {
+                fallback_items.append(result_items);
+                if let Some(object) = fallback.as_object_mut() {
+                    object.insert("isIncomplete".to_string(), serde_json::Value::Bool(false));
+                }
+                *result = fallback;
+            }
+        }
+        "textDocument/codeAction"
+        | "textDocument/codeLens"
+        | "textDocument/foldingRange"
+        | "textDocument/documentSymbol" => {
+            if let (Some(result_items), Some(mut fallback_items)) =
+                (result.as_array_mut(), fallback.as_array().cloned())
+            {
+                fallback_items.append(result_items);
+                *result = serde_json::Value::Array(fallback_items);
+            }
+        }
+        "textDocument/diagnostic" => {
+            let mut fallback = fallback;
+            let fallback_items = fallback
+                .get_mut("items")
+                .and_then(serde_json::Value::as_array_mut);
+            let result_items = result
+                .get_mut("items")
+                .and_then(serde_json::Value::as_array_mut);
+            if let (Some(fallback_items), Some(result_items)) = (fallback_items, result_items) {
+                fallback_items.append(result_items);
+                *result = fallback;
+            }
+        }
+        _ => {}
+    }
+}
+
+fn completion_result_shape(result: &serde_json::Value) -> (usize, bool) {
+    let items = result
+        .get("items")
+        .and_then(serde_json::Value::as_array)
+        .or_else(|| result.as_array());
+    let count = items.map_or(0, Vec::len);
+    let first_is_member = items
+        .and_then(|items| items.first())
+        .and_then(|item| item.get("kind"))
+        .and_then(serde_json::Value::as_u64)
+        .is_some_and(|kind| matches!(kind, 5 | 10));
+    (count, first_is_member)
+}
+
+fn locations_from_tsgo_result(result: &serde_json::Value) -> Vec<lsp_types::Location> {
+    let Some(items) = result.as_array() else {
+        return Vec::new();
+    };
+    items
+        .iter()
+        .filter_map(|item| {
+            serde_json::from_value::<lsp_types::Location>(item.clone())
+                .ok()
+                .or_else(|| {
+                    let uri = item
+                        .get("targetUri")
+                        .cloned()
+                        .and_then(|uri| serde_json::from_value(uri).ok())?;
+                    let range = item
+                        .get("targetSelectionRange")
+                        .or_else(|| item.get("targetRange"))
+                        .cloned()
+                        .and_then(|range| serde_json::from_value(range).ok())?;
+                    Some(lsp_types::Location { uri, range })
+                })
+        })
+        .collect()
+}
+
+fn append_component_completions(
+    result: &mut serde_json::Value,
+    manual: Vec<lsp_types::CompletionItem>,
+    replace: bool,
+) {
+    let manual = manual
+        .into_iter()
+        .filter_map(|item| serde_json::to_value(item).ok())
+        .collect::<Vec<_>>();
+    if replace {
+        *result = serde_json::json!({ "isIncomplete": false, "items": manual });
+        return;
+    }
+    if let Some(items) = result
+        .get_mut("items")
+        .and_then(serde_json::Value::as_array_mut)
+    {
+        items.splice(0..0, manual);
+    } else if let Some(items) = result.as_array_mut() {
+        items.splice(0..0, manual);
+    } else {
+        *result = serde_json::json!({ "isIncomplete": false, "items": manual });
+    }
+}
+
+fn code_action_diagnostic_codes(request: &Request) -> Vec<u32> {
+    if request.method != "textDocument/codeAction" {
+        return Vec::new();
+    }
+    request
+        .params
+        .pointer("/context/diagnostics")
+        .and_then(serde_json::Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter_map(|diagnostic| {
+            let code = diagnostic.get("code")?;
+            code.as_u64()
+                .and_then(|code| u32::try_from(code).ok())
+                .or_else(|| code.as_str()?.trim_start_matches("TS").parse::<u32>().ok())
+        })
+        .collect()
 }
 
 const fn project_config_names() -> &'static [&'static str] {
@@ -1099,5 +3324,17 @@ const fn project_config_names() -> &'static [&'static str] {
         ".oxfmtrc.jsonc",
         "oxfmt.config.ts",
         "oxfmt.config.mts",
+        "tsconfig.json",
+        "jsconfig.json",
+        "svelte.config.js",
+        "svelte.config.mjs",
+        "svelte.config.cjs",
+        "svelte.config.ts",
+        "svelte.config.mts",
+        "vite.config.js",
+        "vite.config.mjs",
+        "vite.config.cjs",
+        "vite.config.ts",
+        "vite.config.mts",
     ]
 }

--- a/crates/rsvelte_language_server/src/tsgo_client.rs
+++ b/crates/rsvelte_language_server/src/tsgo_client.rs
@@ -1,0 +1,1459 @@
+//! Supervised LSP transport for a `tsgo --lsp -stdio` child process.
+
+use std::collections::{BTreeMap, VecDeque};
+use std::ffi::OsString;
+use std::fmt;
+use std::io::{self, BufReader, BufWriter};
+use std::path::PathBuf;
+use std::process::{Child, ChildStdin, Command, ExitStatus, Stdio};
+use std::thread::{self, JoinHandle};
+use std::time::{Duration, Instant};
+
+use crossbeam_channel::{Receiver, Sender, after, select, tick, unbounded};
+use lsp_server::{ErrorCode, Message, Notification, Request, RequestId, Response};
+use lsp_types::{Uri, WorkspaceFolder};
+use serde_json::{Map, Value, json};
+
+use crate::uri::uri_to_path;
+
+const INITIALIZE_ID_PREFIX: &str = "rsvelte-tsgo-initialize";
+const SHUTDOWN_ID: &str = "rsvelte-tsgo-shutdown";
+const CHILD_POLL_INTERVAL: Duration = Duration::from_millis(50);
+const SHUTDOWN_TIMEOUT: Duration = Duration::from_millis(500);
+
+/// Settings returned when tsgo asks its LSP client for configuration.
+///
+/// tsgo consumes the VS Code-style nested shape, not the flat TypeScript
+/// preference names. Construction rejects values with no setting leaf so an
+/// accidental `{}` cannot reset all of tsgo's preferences.
+#[derive(Clone, Debug, PartialEq)]
+pub struct TsgoPreferences(Value);
+
+impl TsgoPreferences {
+    /// Validate a nested tsgo configuration value.
+    pub fn new(value: Value) -> Result<Self, InvalidPreferences> {
+        if !matches!(&value, Value::Object(_)) || !contains_setting(&value) {
+            return Err(InvalidPreferences);
+        }
+        Ok(Self(value))
+    }
+
+    #[must_use]
+    pub fn as_value(&self) -> &Value {
+        &self.0
+    }
+}
+
+impl Default for TsgoPreferences {
+    fn default() -> Self {
+        Self(json!({
+            "preferences": {
+                "importModuleSpecifierEnding": "index"
+            },
+            "suggest": {
+                "autoImports": true
+            },
+            "inlayHints": {
+                "parameterNames": {
+                    "enabled": "all",
+                    "suppressWhenArgumentMatchesName": false
+                },
+                "parameterTypes": { "enabled": true },
+                "variableTypes": {
+                    "enabled": true,
+                    "suppressWhenTypeMatchesName": true
+                },
+                "propertyDeclarationTypes": { "enabled": true },
+                "functionLikeReturnTypes": { "enabled": true },
+                "enumMemberValues": { "enabled": true }
+            },
+            "referencesCodeLens": {
+                "enabled": true,
+                "showOnAllFunctions": true
+            },
+            "implementationsCodeLens": {
+                "enabled": true,
+                "showOnInterfaceMethods": true
+            }
+        }))
+    }
+}
+
+impl TryFrom<Value> for TsgoPreferences {
+    type Error = InvalidPreferences;
+
+    fn try_from(value: Value) -> Result<Self, Self::Error> {
+        Self::new(value)
+    }
+}
+
+impl From<TsgoPreferences> for Value {
+    fn from(preferences: TsgoPreferences) -> Self {
+        preferences.0
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct InvalidPreferences;
+
+impl fmt::Display for InvalidPreferences {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("tsgo preferences must be a non-empty nested object")
+    }
+}
+
+impl std::error::Error for InvalidPreferences {}
+
+fn contains_setting(value: &Value) -> bool {
+    match value {
+        Value::Object(object) => object.values().any(contains_setting),
+        Value::Array(items) => items.iter().any(contains_setting),
+        Value::Null => false,
+        Value::Bool(_) | Value::Number(_) | Value::String(_) => true,
+    }
+}
+
+/// Everything needed to recreate the tsgo process after a crash.
+#[derive(Clone, Debug)]
+pub struct TsgoConfig {
+    pub executable: PathBuf,
+    /// Arguments inserted before the fixed `--lsp -stdio` pair.
+    pub args_prefix: Vec<OsString>,
+    pub current_dir: Option<PathBuf>,
+    pub root_uri: Option<Uri>,
+    pub workspace_folders: Vec<WorkspaceFolder>,
+    /// The editor's initialize params, retained except for child-owned fields.
+    pub editor_initialize_params: Value,
+    /// Raw configuration layers. Final settings are recursively merged as
+    /// default → editor → language → shared (`js/ts`).
+    pub shared_preferences: Value,
+    pub editor_preferences: Value,
+    pub typescript_preferences: Value,
+    pub javascript_preferences: Value,
+    pub restart_delay: Duration,
+}
+
+impl TsgoConfig {
+    #[must_use]
+    pub fn new(executable: impl Into<PathBuf>) -> Self {
+        Self {
+            executable: executable.into(),
+            args_prefix: Vec::new(),
+            current_dir: None,
+            root_uri: None,
+            workspace_folders: Vec::new(),
+            editor_initialize_params: json!({}),
+            shared_preferences: json!({}),
+            editor_preferences: json!({}),
+            typescript_preferences: json!({}),
+            javascript_preferences: json!({}),
+            restart_delay: Duration::from_millis(250),
+        }
+    }
+
+    fn initialize_params(&self) -> Value {
+        initialize_params(self)
+    }
+}
+
+/// A complete open document body retained for crash recovery.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct OpenBuffer {
+    pub uri: Uri,
+    pub language_id: String,
+    pub version: i32,
+    pub text: String,
+}
+
+impl OpenBuffer {
+    #[must_use]
+    pub fn new(
+        uri: Uri,
+        language_id: impl Into<String>,
+        version: i32,
+        text: impl Into<String>,
+    ) -> Self {
+        Self {
+            uri,
+            language_id: language_id.into(),
+            version,
+            text: text.into(),
+        }
+    }
+}
+
+/// Messages produced by the supervised child.
+#[derive(Clone, Debug)]
+pub enum TsgoEvent {
+    /// Initialization and open-buffer replay have both completed.
+    Ready {
+        generation: u64,
+        capabilities: Value,
+    },
+    /// A message not consumed by the lifecycle/configuration layer.
+    Message { generation: u64, message: Message },
+    /// An unexpected exit, transport failure, or initialization failure.
+    Crashed {
+        generation: u64,
+        status: Option<ExitStatus>,
+        error: String,
+    },
+}
+
+/// The handle used by the language-server loop.
+pub struct TsgoClient {
+    commands: Sender<ClientCommand>,
+    events: Receiver<TsgoEvent>,
+    supervisor: Option<JoinHandle<()>>,
+}
+
+impl TsgoClient {
+    /// Start a supervisor. Child startup and initialization complete
+    /// asynchronously and are reported through [`TsgoEvent::Ready`].
+    pub fn spawn(config: TsgoConfig) -> io::Result<Self> {
+        let (commands, command_receiver) = unbounded();
+        let (event_sender, events) = unbounded();
+        let supervisor = thread::Builder::new()
+            .name("rsvelte-tsgo-supervisor".to_string())
+            .spawn(move || supervise(config, command_receiver, event_sender))?;
+        Ok(Self {
+            commands,
+            events,
+            supervisor: Some(supervisor),
+        })
+    }
+
+    /// Receiver suitable for adding directly to the server's `select!` loop.
+    #[must_use]
+    pub const fn events(&self) -> &Receiver<TsgoEvent> {
+        &self.events
+    }
+
+    /// Forward an editor request, notification, or response unchanged.
+    pub fn forward(&self, message: Message) -> Result<(), TsgoClientClosed> {
+        self.send(ClientCommand::Forward(message))
+    }
+
+    /// Open a virtual or real document and retain its full body for replay.
+    pub fn open_buffer(&self, buffer: OpenBuffer) -> Result<(), TsgoClientClosed> {
+        self.send(ClientCommand::Open(buffer))
+    }
+
+    /// Replace an open document's full body. Unknown documents are opened.
+    pub fn change_buffer(&self, buffer: OpenBuffer) -> Result<(), TsgoClientClosed> {
+        self.send(ClientCommand::Change(buffer))
+    }
+
+    /// Close a retained document.
+    pub fn close_buffer(&self, uri: Uri) -> Result<(), TsgoClientClosed> {
+        self.send(ClientCommand::Close(uri))
+    }
+
+    /// Replace the four raw settings layers used to answer future
+    /// `workspace/configuration` requests.
+    pub fn update_configuration(
+        &self,
+        shared: Value,
+        editor: Value,
+        typescript: Value,
+        javascript: Value,
+    ) -> Result<(), TsgoClientClosed> {
+        self.send(ClientCommand::UpdateConfiguration {
+            shared,
+            editor,
+            typescript,
+            javascript,
+        })
+    }
+
+    /// Replace the workspace values used by the next child initialize.
+    ///
+    /// A current directory outside the updated root/folder set is replaced by
+    /// the first remaining folder, then the root. This keeps restart working
+    /// after the primary workspace folder is removed.
+    pub fn update_workspace(
+        &self,
+        root_uri: Option<Uri>,
+        workspace_folders: Vec<WorkspaceFolder>,
+        current_dir: Option<PathBuf>,
+    ) -> Result<(), TsgoClientClosed> {
+        self.send(ClientCommand::UpdateWorkspace {
+            root_uri,
+            workspace_folders,
+            current_dir,
+        })
+    }
+
+    /// Replace the current process and replay every retained buffer.
+    pub fn restart(&self) -> Result<(), TsgoClientClosed> {
+        self.send(ClientCommand::Restart)
+    }
+
+    /// Stop the child and join the supervisor thread.
+    pub fn shutdown(mut self) {
+        let _ = self.commands.send(ClientCommand::Shutdown);
+        self.join_supervisor();
+    }
+
+    fn send(&self, command: ClientCommand) -> Result<(), TsgoClientClosed> {
+        self.commands.send(command).map_err(|_| TsgoClientClosed)
+    }
+
+    fn join_supervisor(&mut self) {
+        if let Some(supervisor) = self.supervisor.take() {
+            let _ = supervisor.join();
+        }
+    }
+}
+
+impl Drop for TsgoClient {
+    fn drop(&mut self) {
+        let _ = self.commands.send(ClientCommand::Shutdown);
+        self.join_supervisor();
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct TsgoClientClosed;
+
+impl fmt::Display for TsgoClientClosed {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("tsgo client supervisor has stopped")
+    }
+}
+
+impl std::error::Error for TsgoClientClosed {}
+
+enum ClientCommand {
+    Forward(Message),
+    Open(OpenBuffer),
+    Change(OpenBuffer),
+    Close(Uri),
+    UpdateConfiguration {
+        shared: Value,
+        editor: Value,
+        typescript: Value,
+        javascript: Value,
+    },
+    UpdateWorkspace {
+        root_uri: Option<Uri>,
+        workspace_folders: Vec<WorkspaceFolder>,
+        current_dir: Option<PathBuf>,
+    },
+    Restart,
+    Shutdown,
+}
+
+enum ReaderEvent {
+    Message(Message),
+    Eof,
+    Error(String),
+}
+
+struct ChildProcess {
+    child: Child,
+    stdin: Option<BufWriter<ChildStdin>>,
+    messages: Receiver<ReaderEvent>,
+    reader: Option<JoinHandle<()>>,
+}
+
+impl ChildProcess {
+    fn spawn(config: &TsgoConfig) -> io::Result<Self> {
+        let mut command = Command::new(&config.executable);
+        command
+            .args(&config.args_prefix)
+            .arg("--lsp")
+            .arg("-stdio")
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::inherit());
+        if let Some(current_dir) = &config.current_dir {
+            command.current_dir(current_dir);
+        }
+        let mut child = command.spawn()?;
+        let stdin = child
+            .stdin
+            .take()
+            .ok_or_else(|| io::Error::other("tsgo stdin was not piped"))?;
+        let stdout = child
+            .stdout
+            .take()
+            .ok_or_else(|| io::Error::other("tsgo stdout was not piped"))?;
+        let (sender, messages) = unbounded();
+        let reader = thread::Builder::new()
+            .name("rsvelte-tsgo-reader".to_string())
+            .spawn(move || {
+                let mut stdout = BufReader::new(stdout);
+                loop {
+                    match Message::read(&mut stdout) {
+                        Ok(Some(message)) => {
+                            if sender.send(ReaderEvent::Message(message)).is_err() {
+                                return;
+                            }
+                        }
+                        Ok(None) => {
+                            let _ = sender.send(ReaderEvent::Eof);
+                            return;
+                        }
+                        Err(error) => {
+                            let _ = sender.send(ReaderEvent::Error(error.to_string()));
+                            return;
+                        }
+                    }
+                }
+            })?;
+        Ok(Self {
+            child,
+            stdin: Some(BufWriter::new(stdin)),
+            messages,
+            reader: Some(reader),
+        })
+    }
+
+    fn send(&mut self, message: &Message) -> io::Result<()> {
+        let stdin = self
+            .stdin
+            .as_mut()
+            .ok_or_else(|| io::Error::new(io::ErrorKind::BrokenPipe, "tsgo stdin is closed"))?;
+        message.write(stdin)
+    }
+
+    fn try_wait(&mut self) -> io::Result<Option<ExitStatus>> {
+        self.child.try_wait()
+    }
+
+    fn finish(mut self, kill: bool) -> Option<ExitStatus> {
+        self.stdin.take();
+        if kill {
+            let _ = self.child.kill();
+        }
+        let status = self.child.wait().ok();
+        if let Some(reader) = self.reader.take() {
+            let _ = reader.join();
+        }
+        status
+    }
+
+    fn finish_after_exit(mut self, timeout: Duration) -> Option<ExitStatus> {
+        self.stdin.take();
+        let deadline = Instant::now() + timeout;
+        loop {
+            match self.child.try_wait() {
+                Ok(Some(status)) => {
+                    if let Some(reader) = self.reader.take() {
+                        let _ = reader.join();
+                    }
+                    return Some(status);
+                }
+                Ok(None) if Instant::now() < deadline => {
+                    thread::sleep(Duration::from_millis(10));
+                }
+                Ok(None) | Err(_) => return self.finish(true),
+            }
+        }
+    }
+}
+
+struct Failure {
+    status: Option<ExitStatus>,
+    error: String,
+}
+
+enum ProcessOutcome {
+    Restart,
+    Shutdown,
+    Failed(Failure),
+}
+
+struct SupervisorState {
+    buffers: BTreeMap<String, OpenBuffer>,
+    queued: VecDeque<Message>,
+    configuration: TsgoConfiguration,
+}
+
+fn supervise(mut config: TsgoConfig, commands: Receiver<ClientCommand>, events: Sender<TsgoEvent>) {
+    let mut state = SupervisorState {
+        buffers: BTreeMap::new(),
+        queued: VecDeque::new(),
+        configuration: TsgoConfiguration::from_layers(
+            &config.shared_preferences,
+            &config.editor_preferences,
+            &config.typescript_preferences,
+            &config.javascript_preferences,
+        ),
+    };
+    let mut generation = 0_u64;
+
+    loop {
+        generation += 1;
+        let process = match ChildProcess::spawn(&config) {
+            Ok(process) => process,
+            Err(error) => {
+                let _ = events.send(TsgoEvent::Crashed {
+                    generation,
+                    status: None,
+                    error: format!("failed to start tsgo: {error}"),
+                });
+                match wait_to_restart(&mut config, &commands, &mut state) {
+                    ProcessOutcome::Shutdown => return,
+                    ProcessOutcome::Restart | ProcessOutcome::Failed(_) => continue,
+                }
+            }
+        };
+
+        match run_process(
+            process,
+            &mut config,
+            generation,
+            &commands,
+            &events,
+            &mut state,
+        ) {
+            ProcessOutcome::Shutdown => return,
+            ProcessOutcome::Restart => {}
+            ProcessOutcome::Failed(failure) => {
+                let _ = events.send(TsgoEvent::Crashed {
+                    generation,
+                    status: failure.status,
+                    error: failure.error,
+                });
+                if matches!(
+                    wait_to_restart(&mut config, &commands, &mut state),
+                    ProcessOutcome::Shutdown
+                ) {
+                    return;
+                }
+            }
+        }
+    }
+}
+
+fn run_process(
+    mut process: ChildProcess,
+    config: &mut TsgoConfig,
+    generation: u64,
+    commands: &Receiver<ClientCommand>,
+    events: &Sender<TsgoEvent>,
+    state: &mut SupervisorState,
+) -> ProcessOutcome {
+    let initialize_id = RequestId::from(format!("{INITIALIZE_ID_PREFIX}-{generation}"));
+    let initialize = Message::Request(Request::new(
+        initialize_id.clone(),
+        "initialize".to_string(),
+        config.initialize_params(),
+    ));
+    if let Err(error) = process.send(&initialize) {
+        return failed_process(process, format!("failed to initialize tsgo: {error}"));
+    }
+
+    let poll = tick(CHILD_POLL_INTERVAL);
+    let capabilities = loop {
+        select! {
+            recv(commands) -> command => match command {
+                Ok(ClientCommand::Shutdown) | Err(_) => {
+                    process.finish(true);
+                    return ProcessOutcome::Shutdown;
+                }
+                Ok(ClientCommand::Restart) => {
+                    process.finish(true);
+                    return ProcessOutcome::Restart;
+                }
+                Ok(command) => retain_or_queue(command, state, config),
+            },
+            recv(process.messages) -> message => match message {
+                Ok(ReaderEvent::Message(Message::Response(response))) if response.id == initialize_id => {
+                    match response.response_result {
+                        Ok(result) => match utf8_capabilities(&result) {
+                            Ok(capabilities) => break capabilities,
+                            Err(error) => return failed_process(process, error),
+                        },
+                        Err(error) => {
+                            return failed_process(
+                                process,
+                                format!("tsgo rejected initialize: {} ({})", error.message, error.code),
+                            );
+                        }
+                    }
+                }
+                Ok(ReaderEvent::Message(message)) => {
+                    if let Err(error) = handle_child_message(
+                        &mut process,
+                        &state.configuration,
+                        generation,
+                        events,
+                        message,
+                    ) {
+                        return failed_process(process, error);
+                    }
+                }
+                Ok(ReaderEvent::Eof) | Err(_) => {
+                    return failed_process(process, "tsgo closed stdout during initialize".to_string());
+                }
+                Ok(ReaderEvent::Error(error)) => {
+                    return failed_process(process, format!("invalid message from tsgo: {error}"));
+                }
+            },
+            recv(poll) -> _ => match process.try_wait() {
+                Ok(Some(status)) => {
+                    process.finish(false);
+                    return ProcessOutcome::Failed(Failure {
+                        status: Some(status),
+                        error: "tsgo exited during initialize".to_string(),
+                    });
+                }
+                Ok(None) => {}
+                Err(error) => return failed_process(process, format!("could not inspect tsgo: {error}")),
+            }
+        }
+    };
+
+    let initialized =
+        Message::Notification(Notification::new("initialized".to_string(), json!({})));
+    if let Err(error) = process.send(&initialized) {
+        return failed_process(
+            process,
+            format!("failed to finish tsgo initialization: {error}"),
+        );
+    }
+    for buffer in state.buffers.values() {
+        if let Err(error) = process.send(&did_open(buffer)) {
+            return failed_process(process, format!("failed to replay tsgo buffers: {error}"));
+        }
+    }
+    while let Some(message) = state.queued.pop_front() {
+        if let Err(error) = process.send(&message) {
+            return failed_process(
+                process,
+                format!("failed to flush queued tsgo message: {error}"),
+            );
+        }
+    }
+    let _ = events.send(TsgoEvent::Ready {
+        generation,
+        capabilities,
+    });
+
+    loop {
+        select! {
+            recv(commands) -> command => match command {
+                Ok(ClientCommand::Forward(message)) => {
+                    if let Err(error) = process.send(&message) {
+                        return failed_process(process, format!("failed to write to tsgo: {error}"));
+                    }
+                }
+                Ok(ClientCommand::Open(buffer)) | Ok(ClientCommand::Change(buffer)) => {
+                    let key = buffer.uri.as_str().to_string();
+                    let message = if state.buffers.contains_key(&key) {
+                        did_change(&buffer)
+                    } else {
+                        did_open(&buffer)
+                    };
+                    state.buffers.insert(key, buffer);
+                    if let Err(error) = process.send(&message) {
+                        return failed_process(process, format!("failed to update tsgo buffer: {error}"));
+                    }
+                }
+                Ok(ClientCommand::Close(uri)) => {
+                    if state.buffers.remove(uri.as_str()).is_some()
+                        && let Err(error) = process.send(&did_close(&uri))
+                    {
+                        return failed_process(process, format!("failed to close tsgo buffer: {error}"));
+                    }
+                }
+                Ok(ClientCommand::UpdateConfiguration { shared, editor, typescript, javascript }) => {
+                    state.configuration = TsgoConfiguration::from_layers(
+                        &shared,
+                        &editor,
+                        &typescript,
+                        &javascript,
+                    );
+                    if let Err(error) = process.send(&configuration_changed(&state.configuration)) {
+                        return failed_process(process, format!("failed to update tsgo configuration: {error}"));
+                    }
+                }
+                Ok(ClientCommand::UpdateWorkspace { root_uri, workspace_folders, current_dir }) => {
+                    update_workspace_config(config, root_uri, workspace_folders, current_dir);
+                }
+                Ok(ClientCommand::Restart) => {
+                    process.finish(true);
+                    return ProcessOutcome::Restart;
+                }
+                Ok(ClientCommand::Shutdown) | Err(_) => {
+                    graceful_shutdown(process, &state.configuration);
+                    return ProcessOutcome::Shutdown;
+                }
+            },
+            recv(process.messages) -> message => match message {
+                Ok(ReaderEvent::Message(message)) => {
+                    if let Err(error) = handle_child_message(
+                        &mut process,
+                        &state.configuration,
+                        generation,
+                        events,
+                        message,
+                    ) {
+                        return failed_process(process, error);
+                    }
+                }
+                Ok(ReaderEvent::Eof) | Err(_) => {
+                    return failed_process(process, "tsgo closed stdout".to_string());
+                }
+                Ok(ReaderEvent::Error(error)) => {
+                    return failed_process(process, format!("invalid message from tsgo: {error}"));
+                }
+            },
+            recv(poll) -> _ => match process.try_wait() {
+                Ok(Some(status)) => {
+                    process.finish(false);
+                    return ProcessOutcome::Failed(Failure {
+                        status: Some(status),
+                        error: "tsgo exited".to_string(),
+                    });
+                }
+                Ok(None) => {}
+                Err(error) => return failed_process(process, format!("could not inspect tsgo: {error}")),
+            }
+        }
+    }
+}
+
+fn retain_or_queue(command: ClientCommand, state: &mut SupervisorState, config: &mut TsgoConfig) {
+    match command {
+        ClientCommand::Forward(message) => state.queued.push_back(message),
+        ClientCommand::Open(buffer) | ClientCommand::Change(buffer) => {
+            state
+                .buffers
+                .insert(buffer.uri.as_str().to_string(), buffer);
+        }
+        ClientCommand::Close(uri) => {
+            state.buffers.remove(uri.as_str());
+        }
+        ClientCommand::UpdateConfiguration {
+            shared,
+            editor,
+            typescript,
+            javascript,
+        } => {
+            state.configuration =
+                TsgoConfiguration::from_layers(&shared, &editor, &typescript, &javascript);
+        }
+        ClientCommand::UpdateWorkspace {
+            root_uri,
+            workspace_folders,
+            current_dir,
+        } => update_workspace_config(config, root_uri, workspace_folders, current_dir),
+        ClientCommand::Restart | ClientCommand::Shutdown => {}
+    }
+}
+
+fn update_workspace_config(
+    config: &mut TsgoConfig,
+    root_uri: Option<Uri>,
+    workspace_folders: Vec<WorkspaceFolder>,
+    current_dir: Option<PathBuf>,
+) {
+    let mut roots = workspace_folders
+        .iter()
+        .map(|folder| uri_to_path(folder.uri.as_str()))
+        .collect::<Vec<_>>();
+    if let Some(root_uri) = &root_uri {
+        roots.push(uri_to_path(root_uri.as_str()));
+    }
+    let current_dir = current_dir
+        .filter(|current_dir| roots.iter().any(|root| root == current_dir))
+        .or_else(|| roots.into_iter().next());
+    config.root_uri = root_uri;
+    config.workspace_folders = workspace_folders;
+    config.current_dir = current_dir;
+}
+
+fn wait_to_restart(
+    config: &mut TsgoConfig,
+    commands: &Receiver<ClientCommand>,
+    state: &mut SupervisorState,
+) -> ProcessOutcome {
+    let restart = after(config.restart_delay);
+    loop {
+        select! {
+            recv(commands) -> command => match command {
+                Ok(ClientCommand::Shutdown) | Err(_) => return ProcessOutcome::Shutdown,
+                Ok(ClientCommand::Restart) => return ProcessOutcome::Restart,
+                Ok(command) => retain_or_queue(command, state, config),
+            },
+            recv(restart) -> _ => return ProcessOutcome::Restart,
+        }
+    }
+}
+
+fn failed_process(process: ChildProcess, error: String) -> ProcessOutcome {
+    let status = process.finish(true);
+    ProcessOutcome::Failed(Failure { status, error })
+}
+
+fn graceful_shutdown(mut process: ChildProcess, configuration: &TsgoConfiguration) {
+    let shutdown_id = RequestId::from(SHUTDOWN_ID.to_string());
+    let request = Message::Request(Request::new(
+        shutdown_id.clone(),
+        "shutdown".to_string(),
+        Value::Null,
+    ));
+    if process.send(&request).is_err() {
+        process.finish(true);
+        return;
+    }
+
+    let deadline = Instant::now() + SHUTDOWN_TIMEOUT;
+    while Instant::now() < deadline {
+        let timeout = after(deadline.saturating_duration_since(Instant::now()));
+        select! {
+            recv(process.messages) -> message => match message {
+                Ok(ReaderEvent::Message(Message::Response(response))) if response.id == shutdown_id => {
+                    let exit = Message::Notification(Notification::new("exit".to_string(), Value::Null));
+                    let _ = process.send(&exit);
+                    process.finish_after_exit(SHUTDOWN_TIMEOUT);
+                    return;
+                }
+                Ok(ReaderEvent::Message(message)) => {
+                    let _ = handle_child_message(
+                        &mut process,
+                        configuration,
+                        0,
+                        &unbounded().0,
+                        message,
+                    );
+                }
+                Ok(ReaderEvent::Eof | ReaderEvent::Error(_)) | Err(_) => {
+                    process.finish(false);
+                    return;
+                }
+            },
+            recv(timeout) -> _ => break,
+        }
+    }
+    process.finish(true);
+}
+
+fn handle_child_message(
+    process: &mut ChildProcess,
+    configuration: &TsgoConfiguration,
+    generation: u64,
+    events: &Sender<TsgoEvent>,
+    message: Message,
+) -> Result<(), String> {
+    if let Message::Request(request) = &message
+        && request.method == "workspace/configuration"
+    {
+        let response = workspace_configuration_response(request, configuration);
+        return process
+            .send(&Message::Response(response))
+            .map_err(|error| format!("failed to answer tsgo configuration request: {error}"));
+    }
+    events
+        .send(TsgoEvent::Message {
+            generation,
+            message,
+        })
+        .map_err(|_| "tsgo event receiver was dropped".to_string())
+}
+
+#[derive(Clone)]
+struct TsgoConfiguration {
+    typescript: TsgoPreferences,
+    javascript: TsgoPreferences,
+}
+
+fn workspace_configuration_response(
+    request: &Request,
+    configuration: &TsgoConfiguration,
+) -> Response {
+    let items = request.params.get("items").and_then(Value::as_array);
+    match items {
+        Some(items) if !items.is_empty() => Response::new_ok(
+            request.id.clone(),
+            items
+                .iter()
+                .map(|item| configuration.for_item(item).as_value().clone())
+                .collect::<Vec<_>>(),
+        ),
+        _ => Response::new_err(
+            request.id.clone(),
+            ErrorCode::InvalidParams as i32,
+            "workspace/configuration requires at least one item".to_string(),
+        ),
+    }
+}
+
+impl TsgoConfiguration {
+    fn from_layers(shared: &Value, editor: &Value, typescript: &Value, javascript: &Value) -> Self {
+        Self {
+            typescript: merged_preferences(editor, typescript, shared),
+            javascript: merged_preferences(editor, javascript, shared),
+        }
+    }
+
+    fn for_item(&self, item: &Value) -> &TsgoPreferences {
+        match item
+            .get("scopeUri")
+            .and_then(Value::as_str)
+            .and_then(language_from_uri)
+            .or_else(|| {
+                item.get("section")
+                    .and_then(Value::as_str)
+                    .and_then(language_from_section)
+            }) {
+            Some(ConfigurationLanguage::Javascript) => &self.javascript,
+            Some(ConfigurationLanguage::Typescript) | None => &self.typescript,
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+enum ConfigurationLanguage {
+    Typescript,
+    Javascript,
+}
+
+fn language_from_section(section: &str) -> Option<ConfigurationLanguage> {
+    let section = section.to_ascii_lowercase();
+    if section == "javascript" || section.starts_with("javascript.") {
+        Some(ConfigurationLanguage::Javascript)
+    } else if section == "typescript" || section.starts_with("typescript.") {
+        Some(ConfigurationLanguage::Typescript)
+    } else {
+        None
+    }
+}
+
+fn merged_preferences(editor: &Value, language: &Value, shared: &Value) -> TsgoPreferences {
+    let mut merged = TsgoPreferences::default().0;
+    merge_object_layer(&mut merged, editor);
+    merge_object_layer(&mut merged, language);
+    merge_object_layer(&mut merged, shared);
+    if merged.pointer("/preferences/importModuleSpecifierEnding") == Some(&json!("js")) {
+        merged["preferences"]["importModuleSpecifierEnding"] = json!("index");
+    }
+    TsgoPreferences(merged)
+}
+
+fn merge_object_layer(target: &mut Value, layer: &Value) {
+    let Value::Object(layer) = layer else {
+        return;
+    };
+    let Value::Object(target) = target else {
+        unreachable!("built-in tsgo preferences are an object");
+    };
+    for (key, value) in layer {
+        match (target.get_mut(key), value) {
+            (Some(Value::Object(existing)), Value::Object(update)) => {
+                merge_maps(existing, update);
+            }
+            _ => {
+                target.insert(key.clone(), value.clone());
+            }
+        }
+    }
+}
+
+fn merge_maps(target: &mut Map<String, Value>, layer: &Map<String, Value>) {
+    for (key, value) in layer {
+        match (target.get_mut(key), value) {
+            (Some(Value::Object(existing)), Value::Object(update)) => {
+                merge_maps(existing, update);
+            }
+            _ => {
+                target.insert(key.clone(), value.clone());
+            }
+        }
+    }
+}
+
+fn language_from_uri(uri: &str) -> Option<ConfigurationLanguage> {
+    let path = uri
+        .split(['?', '#'])
+        .next()
+        .unwrap_or(uri)
+        .to_ascii_lowercase();
+    if [".js", ".jsx", ".mjs", ".cjs"]
+        .iter()
+        .any(|extension| path.ends_with(extension))
+    {
+        Some(ConfigurationLanguage::Javascript)
+    } else if [".ts", ".tsx", ".mts", ".cts"]
+        .iter()
+        .any(|extension| path.ends_with(extension))
+    {
+        Some(ConfigurationLanguage::Typescript)
+    } else {
+        None
+    }
+}
+
+fn configuration_changed(configuration: &TsgoConfiguration) -> Message {
+    Message::Notification(Notification::new(
+        "workspace/didChangeConfiguration".to_string(),
+        json!({
+            "settings": {
+                "typescript": configuration.typescript.as_value(),
+                "javascript": configuration.javascript.as_value(),
+            }
+        }),
+    ))
+}
+
+fn initialize_params(config: &TsgoConfig) -> Value {
+    let mut params = match config.editor_initialize_params.clone() {
+        Value::Object(params) => params,
+        _ => Map::new(),
+    };
+    params.insert("processId".to_string(), json!(std::process::id()));
+    params.insert(
+        "rootUri".to_string(),
+        config
+            .root_uri
+            .as_ref()
+            .map_or(Value::Null, |uri| json!(uri)),
+    );
+    params.insert(
+        "workspaceFolders".to_string(),
+        json!(config.workspace_folders),
+    );
+
+    let capabilities = object_entry(&mut params, "capabilities");
+    object_entry(capabilities, "workspace").insert("configuration".to_string(), Value::Bool(true));
+    let general = object_entry(capabilities, "general");
+    let mut encodings = vec![Value::String("utf-8".to_string())];
+    if let Some(existing) = general.get("positionEncodings").and_then(Value::as_array) {
+        encodings.extend(
+            existing
+                .iter()
+                .filter(|encoding| encoding.as_str() != Some("utf-8"))
+                .cloned(),
+        );
+    }
+    general.insert("positionEncodings".to_string(), Value::Array(encodings));
+    Value::Object(params)
+}
+
+fn object_entry<'a>(object: &'a mut Map<String, Value>, key: &str) -> &'a mut Map<String, Value> {
+    let value = object
+        .entry(key.to_string())
+        .or_insert_with(|| Value::Object(Map::new()));
+    if !value.is_object() {
+        *value = Value::Object(Map::new());
+    }
+    value.as_object_mut().expect("object inserted above")
+}
+
+fn utf8_capabilities(initialize_result: &Value) -> Result<Value, String> {
+    let capabilities = initialize_result
+        .get("capabilities")
+        .cloned()
+        .ok_or_else(|| "tsgo initialize result omitted capabilities".to_string())?;
+    match capabilities.get("positionEncoding").and_then(Value::as_str) {
+        Some("utf-8") => Ok(capabilities),
+        Some(encoding) => Err(format!(
+            "tsgo negotiated {encoding}, but the projection mapper requires utf-8"
+        )),
+        None => Err("tsgo did not negotiate utf-8 position encoding".to_string()),
+    }
+}
+
+fn did_open(buffer: &OpenBuffer) -> Message {
+    Message::Notification(Notification::new(
+        "textDocument/didOpen".to_string(),
+        json!({
+            "textDocument": {
+                "uri": buffer.uri,
+                "languageId": buffer.language_id,
+                "version": buffer.version,
+                "text": buffer.text,
+            }
+        }),
+    ))
+}
+
+fn did_change(buffer: &OpenBuffer) -> Message {
+    Message::Notification(Notification::new(
+        "textDocument/didChange".to_string(),
+        json!({
+            "textDocument": {
+                "uri": buffer.uri,
+                "version": buffer.version,
+            },
+            "contentChanges": [{ "text": buffer.text }]
+        }),
+    ))
+}
+
+fn did_close(uri: &Uri) -> Message {
+    Message::Notification(Notification::new(
+        "textDocument/didClose".to_string(),
+        json!({ "textDocument": { "uri": uri } }),
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::str::FromStr;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    static NEXT_TEMP: AtomicU64 = AtomicU64::new(0);
+
+    #[test]
+    fn preferences_reject_empty_nested_settings() {
+        assert_eq!(
+            TsgoPreferences::new(json!({})).unwrap_err(),
+            InvalidPreferences
+        );
+        assert_eq!(
+            TsgoPreferences::new(json!({ "preferences": {} })).unwrap_err(),
+            InvalidPreferences
+        );
+        assert!(TsgoPreferences::new(json!({ "suggest": { "autoImports": true } })).is_ok());
+    }
+
+    #[test]
+    fn initialize_forces_utf8_first_and_preserves_editor_capabilities() {
+        let mut config = TsgoConfig::new("tsgo");
+        config.root_uri = Some(Uri::from_str("file:///workspace").unwrap());
+        config.workspace_folders = vec![WorkspaceFolder {
+            uri: Uri::from_str("file:///workspace").unwrap(),
+            name: "workspace".to_string(),
+        }];
+        config.editor_initialize_params = json!({
+            "clientInfo": { "name": "test-editor" },
+            "capabilities": {
+                "general": { "positionEncodings": ["utf-16", "utf-8"] },
+                "textDocument": { "hover": { "contentFormat": ["markdown"] } }
+            }
+        });
+
+        let params = config.initialize_params();
+        assert_eq!(
+            params.pointer("/capabilities/general/positionEncodings"),
+            Some(&json!(["utf-8", "utf-16"]))
+        );
+        assert_eq!(
+            params.pointer("/capabilities/workspace/configuration"),
+            Some(&Value::Bool(true))
+        );
+        assert_eq!(
+            params.pointer("/rootUri"),
+            Some(&json!("file:///workspace"))
+        );
+        assert_eq!(
+            params.pointer("/workspaceFolders/0/name"),
+            Some(&json!("workspace"))
+        );
+        assert_eq!(
+            params.pointer("/clientInfo/name"),
+            Some(&json!("test-editor"))
+        );
+        assert_eq!(
+            params.pointer("/capabilities/textDocument/hover/contentFormat/0"),
+            Some(&json!("markdown"))
+        );
+    }
+
+    #[test]
+    fn workspace_update_replaces_a_removed_primary_current_dir() {
+        let primary = Uri::from_str("file:///workspace/primary").unwrap();
+        let remaining = Uri::from_str("file:///workspace/remaining").unwrap();
+        let mut config = TsgoConfig::new("tsgo");
+        config.current_dir = Some(uri_to_path(primary.as_str()));
+        config.root_uri = Some(primary.clone());
+        config.workspace_folders = vec![WorkspaceFolder {
+            uri: primary,
+            name: "primary".to_string(),
+        }];
+
+        let old_current_dir = config.current_dir.clone();
+        update_workspace_config(
+            &mut config,
+            Some(remaining.clone()),
+            vec![WorkspaceFolder {
+                uri: remaining.clone(),
+                name: "remaining".to_string(),
+            }],
+            old_current_dir,
+        );
+
+        assert_eq!(config.root_uri, Some(remaining.clone()));
+        assert_eq!(config.workspace_folders[0].uri, remaining);
+        assert_eq!(
+            config.current_dir,
+            Some(PathBuf::from("/workspace/remaining"))
+        );
+    }
+
+    #[test]
+    fn configuration_repeats_the_nested_preferences_per_item() {
+        let typescript = TsgoPreferences::new(json!({
+            "preferences": { "importModuleSpecifierEnding": "index" },
+            "suggest": { "autoImports": true },
+            "kind": "typescript"
+        }))
+        .unwrap();
+        let javascript = TsgoPreferences::new(json!({ "kind": "javascript" })).unwrap();
+        let configuration = TsgoConfiguration {
+            typescript,
+            javascript,
+        };
+        let request = Request::new(
+            7.into(),
+            "workspace/configuration".to_string(),
+            json!({ "items": [{ "section": "typescript" }, { "section": "javascript" }] }),
+        );
+        let response = workspace_configuration_response(&request, &configuration);
+        let result = response.response_result.unwrap();
+        assert_eq!(result.as_array().unwrap().len(), 2);
+        assert_eq!(
+            result.pointer("/1/preferences/importModuleSpecifierEnding"),
+            None
+        );
+        assert_eq!(result.pointer("/1/kind"), Some(&json!("javascript")));
+    }
+
+    #[test]
+    fn configuration_uses_scope_uri_then_typescript_default_for_unknown_sections() {
+        let configuration = TsgoConfiguration {
+            typescript: TsgoPreferences::new(json!({ "kind": "typescript" })).unwrap(),
+            javascript: TsgoPreferences::new(json!({ "kind": "javascript" })).unwrap(),
+        };
+        let request = Request::new(
+            8.into(),
+            "workspace/configuration".to_string(),
+            json!({
+                "items": [
+                    { "section": "unknown", "scopeUri": "file:///src/main.jsx" },
+                    { "section": "unknown", "scopeUri": "file:///src/App.svelte.tsx" },
+                    { "section": "unknown" }
+                ]
+            }),
+        );
+        let result = workspace_configuration_response(&request, &configuration)
+            .response_result
+            .unwrap();
+        assert_eq!(result.pointer("/0/kind"), Some(&json!("javascript")));
+        assert_eq!(result.pointer("/1/kind"), Some(&json!("typescript")));
+        assert_eq!(result.pointer("/2/kind"), Some(&json!("typescript")));
+    }
+
+    #[test]
+    fn configuration_merges_layers_and_returns_one_value_for_all_scoped_sections() {
+        let configuration = TsgoConfiguration::from_layers(
+            &json!({
+                "preferences": { "importModuleSpecifierEnding": "js" },
+                "priority": "shared"
+            }),
+            &json!({
+                "priority": "editor",
+                "editorOnly": true,
+                "nested": { "editor": true }
+            }),
+            &json!({
+                "priority": "typescript",
+                "nested": { "typescript": true }
+            }),
+            &json!({ "priority": "javascript" }),
+        );
+        let items = ["js/ts", "typescript", "javascript", "editor"]
+            .into_iter()
+            .map(|section| {
+                json!({
+                    "section": section,
+                    "scopeUri": "file:///src/main.js"
+                })
+            })
+            .collect::<Vec<_>>();
+        let request = Request::new(
+            9.into(),
+            "workspace/configuration".to_string(),
+            json!({ "items": items }),
+        );
+        let result = workspace_configuration_response(&request, &configuration)
+            .response_result
+            .unwrap();
+        let items = result.as_array().unwrap();
+        assert!(items.windows(2).all(|pair| pair[0] == pair[1]));
+        assert_eq!(result.pointer("/0/priority"), Some(&json!("shared")));
+        assert_eq!(result.pointer("/0/editorOnly"), Some(&Value::Bool(true)));
+        assert_eq!(
+            result.pointer("/0/preferences/importModuleSpecifierEnding"),
+            Some(&json!("index"))
+        );
+    }
+
+    #[test]
+    fn configuration_refuses_an_empty_item_list() {
+        let request = Request::new(
+            7.into(),
+            "workspace/configuration".to_string(),
+            json!({ "items": [] }),
+        );
+        let defaults = TsgoConfiguration {
+            typescript: TsgoPreferences::default(),
+            javascript: TsgoPreferences::default(),
+        };
+        let response = workspace_configuration_response(&request, &defaults);
+        assert_eq!(
+            response.response_result.unwrap_err().code,
+            ErrorCode::InvalidParams as i32
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn crash_restarts_and_replays_open_buffers() {
+        let temp = unique_temp_dir();
+        fs::create_dir_all(&temp).unwrap();
+        let state = temp.join("generation");
+        let remaining = temp.join("remaining");
+        fs::create_dir_all(&remaining).unwrap();
+        let remaining_uri = crate::uri::path_to_uri(&remaining).unwrap();
+        let executable = temp.join("fake-tsgo");
+        let helper = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/support/fake_tsgo.rs");
+        let rustc = std::env::var_os("RUSTC").unwrap_or_else(|| OsString::from("rustc"));
+        assert!(
+            Command::new(rustc)
+                .arg("--edition=2024")
+                .arg(helper)
+                .arg("-o")
+                .arg(&executable)
+                .status()
+                .unwrap()
+                .success()
+        );
+
+        let mut config = TsgoConfig::new(&executable);
+        config.args_prefix.push(state.clone().into_os_string());
+        config
+            .args_prefix
+            .push(OsString::from(remaining_uri.as_str()));
+        config.current_dir = Some(temp.clone());
+        config.root_uri = Some(Uri::from_str("file:///workspace").unwrap());
+        config.editor_initialize_params = json!({
+            "capabilities": { "general": { "positionEncodings": ["utf-16"] } }
+        });
+        config.restart_delay = Duration::from_millis(10);
+        let client = TsgoClient::spawn(config).unwrap();
+
+        let first = recv_event(&client, Duration::from_secs(5));
+        assert!(
+            matches!(first, TsgoEvent::Ready { generation: 1, .. }),
+            "unexpected first event: {first:?}"
+        );
+        let uri = Uri::from_str("file:///workspace/App.svelte.tsx").unwrap();
+        client
+            .open_buffer(OpenBuffer::new(
+                uri,
+                "typescriptreact",
+                4,
+                "export default 42;",
+            ))
+            .unwrap();
+
+        let mut crashed = false;
+        let mut ready = false;
+        let mut replayed = false;
+        let deadline = Instant::now() + Duration::from_secs(10);
+        while Instant::now() < deadline && !(crashed && ready && replayed) {
+            match recv_event(&client, deadline.saturating_duration_since(Instant::now())) {
+                TsgoEvent::Crashed {
+                    generation: 1,
+                    status: Some(status),
+                    ..
+                } => {
+                    assert_eq!(status.code(), Some(7));
+                    crashed = true;
+                }
+                TsgoEvent::Ready { generation: 2, .. } => ready = true,
+                TsgoEvent::Message {
+                    generation: 2,
+                    message: Message::Notification(notification),
+                } if notification.method == "$/test/replayed" => {
+                    assert_eq!(notification.params["version"], 4);
+                    assert_eq!(notification.params["text"], "export default 42;");
+                    replayed = true;
+                }
+                _ => {}
+            }
+        }
+        assert!(crashed && ready && replayed);
+
+        client
+            .update_configuration(
+                json!({}),
+                json!({}),
+                json!({ "kind": "updated-typescript" }),
+                json!({ "kind": "updated-javascript" }),
+            )
+            .unwrap();
+        let deadline = Instant::now() + Duration::from_secs(5);
+        loop {
+            let TsgoEvent::Message {
+                generation: 2,
+                message: Message::Notification(notification),
+            } = recv_event(&client, deadline.saturating_duration_since(Instant::now()))
+            else {
+                continue;
+            };
+            if notification.method == "$/test/configUpdated" {
+                break;
+            }
+        }
+
+        client
+            .update_workspace(
+                Some(remaining_uri.clone()),
+                vec![WorkspaceFolder {
+                    uri: remaining_uri,
+                    name: "remaining".to_string(),
+                }],
+                Some(temp.clone()),
+            )
+            .unwrap();
+        client.restart().unwrap();
+
+        let mut ready = false;
+        let mut replayed = false;
+        let deadline = Instant::now() + Duration::from_secs(5);
+        while Instant::now() < deadline && !(ready && replayed) {
+            match recv_event(&client, deadline.saturating_duration_since(Instant::now())) {
+                TsgoEvent::Ready { generation: 3, .. } => ready = true,
+                TsgoEvent::Message {
+                    generation: 3,
+                    message: Message::Notification(notification),
+                } if notification.method == "$/test/replayed" => {
+                    assert_eq!(notification.params["generation"], 3);
+                    assert_eq!(notification.params["version"], 4);
+                    assert_eq!(notification.params["text"], "export default 42;");
+                    replayed = true;
+                }
+                _ => {}
+            }
+        }
+        assert!(ready && replayed);
+        client.shutdown();
+        let _ = fs::remove_dir_all(temp);
+    }
+
+    #[cfg(unix)]
+    fn recv_event(client: &TsgoClient, timeout: Duration) -> TsgoEvent {
+        client
+            .events()
+            .recv_timeout(timeout)
+            .expect("timed out waiting for tsgo event")
+    }
+
+    #[cfg(unix)]
+    fn unique_temp_dir() -> PathBuf {
+        std::env::temp_dir().join(format!(
+            "rsvelte-tsgo-client-{}-{}",
+            std::process::id(),
+            NEXT_TEMP.fetch_add(1, Ordering::Relaxed)
+        ))
+    }
+}

--- a/crates/rsvelte_language_server/src/tsgo_code_actions.rs
+++ b/crates/rsvelte_language_server/src/tsgo_code_actions.rs
@@ -1,0 +1,1006 @@
+//! Svelte-specific normalization for tsgo code actions.
+
+use lsp_types::{Position, Range, Uri};
+use rsvelte_core::{Allocator, ParseOptions, parse};
+use serde_json::{Map, Value, json};
+
+use crate::text::LineIndex;
+
+pub const SORT_IMPORTS_KIND: &str = "source.sortImports";
+pub const ADD_MISSING_IMPORTS_KIND: &str = "source.addMissingImports";
+pub const REMOVE_UNUSED_IMPORTS_KIND: &str = "source.removeUnusedImports";
+
+const QUICK_FIX_KIND: &str = "quickfix";
+const SOURCE_KIND: &str = "source";
+const ORGANIZE_IMPORTS_KIND: &str = "source.organizeImports";
+const FIX_ALL_KIND: &str = "source.fixAll";
+const COMPONENT_SUFFIX: &str = "__SvelteComponent_";
+const GENERATED_HELPERS: &[&str] = &[
+    "__sveltets_",
+    "__SvelteComponentTyped__",
+    "/*Ωignore_startΩ*/",
+    "/*Ωignore_endΩ*/",
+];
+
+/// Source state needed to normalize one code-action response.
+pub struct TsgoCodeActionContext<'a> {
+    pub source_uri: &'a Uri,
+    pub source: &'a str,
+    pub parser_error: bool,
+    pub default_script_language: Option<&'a str>,
+    pub diagnostic_codes: &'a [u32],
+}
+
+impl<'a> TsgoCodeActionContext<'a> {
+    #[must_use]
+    pub const fn new(source_uri: &'a Uri, source: &'a str) -> Self {
+        Self {
+            source_uri,
+            source,
+            parser_error: false,
+            default_script_language: None,
+            diagnostic_codes: &[],
+        }
+    }
+
+    #[must_use]
+    pub const fn with_parser_error(mut self, parser_error: bool) -> Self {
+        self.parser_error = parser_error;
+        self
+    }
+
+    #[must_use]
+    pub const fn with_default_script_language(mut self, language: Option<&'a str>) -> Self {
+        self.default_script_language = language;
+        self
+    }
+
+    #[must_use]
+    pub const fn with_diagnostic_codes(mut self, diagnostic_codes: &'a [u32]) -> Self {
+        self.diagnostic_codes = diagnostic_codes;
+        self
+    }
+}
+
+/// Whether a kind is implemented by the tsgo-backed Svelte action path.
+#[must_use]
+pub fn is_supported_code_action_kind(kind: &str) -> bool {
+    matches!(
+        kind,
+        QUICK_FIX_KIND
+            | SOURCE_KIND
+            | ORGANIZE_IMPORTS_KIND
+            | SORT_IMPORTS_KIND
+            | ADD_MISSING_IMPORTS_KIND
+            | REMOVE_UNUSED_IMPORTS_KIND
+            | FIX_ALL_KIND
+    )
+}
+
+#[must_use]
+pub fn is_source_code_action_kind(kind: &str) -> bool {
+    kind == SOURCE_KIND || kind.starts_with("source.")
+}
+
+#[must_use]
+pub fn is_organize_code_action_kind(kind: &str) -> bool {
+    matches!(
+        kind,
+        ORGANIZE_IMPORTS_KIND | SORT_IMPORTS_KIND | REMOVE_UNUSED_IMPORTS_KIND
+    )
+}
+
+#[must_use]
+pub fn document_has_script(source: &str) -> bool {
+    !script_regions(source).is_empty()
+}
+
+#[must_use]
+pub fn document_has_parser_error(source: &str) -> bool {
+    let allocator = Allocator::default();
+    parse(
+        source,
+        &allocator,
+        ParseOptions {
+            modern: true,
+            defer_script_parse: false,
+            skip_non_css_lang_style: true,
+            ..ParseOptions::default()
+        },
+    )
+    .is_err()
+}
+
+/// Decide before forwarding whether the requested `only` set can produce a
+/// safe action for this document.
+#[must_use]
+pub fn should_forward_code_action_request(
+    only: Option<&[String]>,
+    parser_error: bool,
+    has_script: bool,
+) -> bool {
+    let Some(only) = only else {
+        return true;
+    };
+    if only.is_empty() {
+        return true;
+    }
+    only.iter().any(|kind| {
+        is_supported_code_action_kind(kind)
+            && !(parser_error && is_source_code_action_kind(kind))
+            && (has_script || !is_organize_code_action_kind(kind))
+    })
+}
+
+/// Normalize a tsgo `textDocument/codeAction` result after shadow mapping.
+///
+/// Returns the number of actions left in the response.
+pub fn rewrite_code_action_response(
+    value: &mut Value,
+    context: &TsgoCodeActionContext<'_>,
+) -> usize {
+    let scripts = script_regions(context.source);
+    let Some(actions) = code_actions_mut(value) else {
+        return 0;
+    };
+
+    let mut normalized = Vec::with_capacity(actions.len() + 1);
+    for mut action in std::mem::take(actions) {
+        if normalize_action(&mut action, context, &scripts) {
+            normalized.push(action);
+        }
+    }
+    if needs_lang_ts_action(context)
+        && let Some(action) = create_add_lang_ts_action(context, &scripts)
+    {
+        normalized.insert(0, action);
+    }
+    *actions = normalized;
+    actions.len()
+}
+
+fn code_actions_mut(value: &mut Value) -> Option<&mut Vec<Value>> {
+    match value {
+        Value::Array(actions) => Some(actions),
+        Value::Object(object) => object.get_mut("items")?.as_array_mut(),
+        _ => None,
+    }
+}
+
+fn normalize_action(
+    action: &mut Value,
+    context: &TsgoCodeActionContext<'_>,
+    scripts: &[ScriptRegion],
+) -> bool {
+    let Some(object) = action.as_object_mut() else {
+        return false;
+    };
+    let kind = object
+        .get("kind")
+        .and_then(Value::as_str)
+        .map(str::to_string);
+    if kind
+        .as_deref()
+        .is_some_and(|kind| !is_supported_code_action_kind(kind))
+    {
+        return false;
+    }
+    if context.parser_error && kind.as_deref().is_some_and(is_source_code_action_kind) {
+        return false;
+    }
+    if scripts.is_empty() && kind.as_deref().is_some_and(is_organize_code_action_kind) {
+        return false;
+    }
+
+    let import_action = is_import_action(object);
+    rewrite_visible_fields(object);
+    let stats = normalize_workspace_edit(object, context, scripts, kind.as_deref());
+
+    if import_action && scripts.is_empty() {
+        wrap_import_edits_in_script(object, context);
+    }
+
+    let final_stats = workspace_edit_stats(object);
+    if stats.had_edits && final_stats.kept_edits == 0 {
+        return false;
+    }
+    if kind.as_deref().is_some_and(is_organize_code_action_kind)
+        && current_document_edit_count(object, context.source_uri) == 0
+    {
+        return false;
+    }
+    true
+}
+
+fn rewrite_visible_fields(object: &mut Map<String, Value>) {
+    for (key, value) in object {
+        if key == "data" || key == "command" || is_uri_key(key) {
+            continue;
+        }
+        rewrite_visible_value(value);
+    }
+}
+
+fn rewrite_visible_value(value: &mut Value) {
+    match value {
+        Value::String(text) => rewrite_visible_text(text),
+        Value::Array(items) => {
+            for item in items {
+                rewrite_visible_value(item);
+            }
+        }
+        Value::Object(object) => rewrite_visible_fields(object),
+        _ => {}
+    }
+}
+
+fn rewrite_visible_text(text: &mut String) {
+    let had_component_suffix = text.contains(COMPONENT_SUFFIX);
+    if had_component_suffix {
+        *text = text.replace(COMPONENT_SUFFIX, "");
+    }
+    if text.contains(".svelte.tsx") {
+        *text = text.replace(".svelte.tsx", ".svelte");
+    }
+    if had_component_suffix {
+        *text = text
+            .replace("import type ", "import ")
+            .replace(" type ", " ");
+    }
+}
+
+fn is_uri_key(key: &str) -> bool {
+    matches!(
+        key,
+        "uri" | "documentUri" | "targetUri" | "oldUri" | "newUri"
+    )
+}
+
+#[derive(Default)]
+struct EditStats {
+    had_edits: bool,
+    kept_edits: usize,
+}
+
+fn normalize_workspace_edit(
+    action: &mut Map<String, Value>,
+    context: &TsgoCodeActionContext<'_>,
+    scripts: &[ScriptRegion],
+    kind: Option<&str>,
+) -> EditStats {
+    let mut stats = EditStats::default();
+    let Some(edit) = action.get_mut("edit").and_then(Value::as_object_mut) else {
+        return stats;
+    };
+    let protect_script = kind.is_some_and(is_source_code_action_kind);
+
+    if let Some(changes) = edit.get_mut("changes").and_then(Value::as_object_mut) {
+        for (uri, edits) in changes {
+            let is_current = uri == context.source_uri.as_str();
+            normalize_edit_array(
+                edits,
+                is_current,
+                protect_script,
+                context.source,
+                scripts,
+                &mut stats,
+            );
+        }
+    }
+
+    if let Some(changes) = edit
+        .get_mut("documentChanges")
+        .and_then(Value::as_array_mut)
+    {
+        for change in changes {
+            let Some(change) = change.as_object_mut() else {
+                continue;
+            };
+            let uri = change
+                .get("textDocument")
+                .and_then(Value::as_object)
+                .and_then(|document| document.get("uri"))
+                .and_then(Value::as_str);
+            let is_current = uri == Some(context.source_uri.as_str());
+            if let Some(edits) = change.get_mut("edits") {
+                normalize_edit_array(
+                    edits,
+                    is_current,
+                    protect_script,
+                    context.source,
+                    scripts,
+                    &mut stats,
+                );
+            }
+        }
+    }
+    stats
+}
+
+fn normalize_edit_array(
+    value: &mut Value,
+    is_current: bool,
+    protect_script: bool,
+    source: &str,
+    scripts: &[ScriptRegion],
+    stats: &mut EditStats,
+) {
+    let Some(edits) = value.as_array_mut() else {
+        return;
+    };
+    stats.had_edits |= !edits.is_empty();
+    let index = LineIndex::new(source);
+    edits.retain_mut(|edit| {
+        let Some(edit) = edit.as_object_mut() else {
+            return false;
+        };
+        if !strip_generated_helper_text(edit) {
+            return false;
+        }
+        if is_current && protect_script && !edit_range_in_scripts(edit, source, &index, scripts) {
+            return false;
+        }
+        stats.kept_edits += 1;
+        true
+    });
+}
+
+fn strip_generated_helper_text(edit: &mut Map<String, Value>) -> bool {
+    let Some(text) = edit.get("newText").and_then(Value::as_str) else {
+        return true;
+    };
+    if !GENERATED_HELPERS.iter().any(|helper| text.contains(helper)) {
+        return true;
+    }
+    let stripped = text
+        .split_inclusive('\n')
+        .filter(|line| !GENERATED_HELPERS.iter().any(|helper| line.contains(helper)))
+        .collect::<String>();
+    if stripped.is_empty() {
+        return false;
+    }
+    edit.insert("newText".to_string(), Value::String(stripped));
+    true
+}
+
+fn edit_range_in_scripts(
+    edit: &Map<String, Value>,
+    source: &str,
+    index: &LineIndex,
+    scripts: &[ScriptRegion],
+) -> bool {
+    let Some(range) = edit.get("range").and_then(parse_range) else {
+        return false;
+    };
+    let start = index.offset(source, range.start);
+    let end = index.offset(source, range.end).max(start);
+    scripts
+        .iter()
+        .any(|script| script.content_start <= start && end <= script.content_end)
+}
+
+fn workspace_edit_stats(action: &Map<String, Value>) -> EditStats {
+    let mut stats = EditStats::default();
+    let Some(edit) = action.get("edit").and_then(Value::as_object) else {
+        return stats;
+    };
+    if let Some(changes) = edit.get("changes").and_then(Value::as_object) {
+        for edits in changes.values() {
+            let count = edits.as_array().map_or(0, Vec::len);
+            stats.kept_edits += count;
+            if count > 0 {
+                stats.had_edits = true;
+            }
+        }
+    }
+    if let Some(changes) = edit.get("documentChanges").and_then(Value::as_array) {
+        for change in changes {
+            let Some(change) = change.as_object() else {
+                continue;
+            };
+            let count = change
+                .get("edits")
+                .and_then(Value::as_array)
+                .map_or(0, Vec::len);
+            stats.kept_edits += count;
+            stats.had_edits |= count > 0;
+        }
+    }
+    stats
+}
+
+fn current_document_edit_count(action: &Map<String, Value>, source_uri: &Uri) -> usize {
+    let Some(edit) = action.get("edit").and_then(Value::as_object) else {
+        return 0;
+    };
+    let changes = edit
+        .get("changes")
+        .and_then(Value::as_object)
+        .and_then(|changes| changes.get(source_uri.as_str()))
+        .and_then(Value::as_array)
+        .map_or(0, Vec::len);
+    let document_changes = edit
+        .get("documentChanges")
+        .and_then(Value::as_array)
+        .map_or(0, |changes| {
+            changes
+                .iter()
+                .filter_map(Value::as_object)
+                .filter(|change| {
+                    change
+                        .get("textDocument")
+                        .and_then(Value::as_object)
+                        .and_then(|document| document.get("uri"))
+                        .and_then(Value::as_str)
+                        == Some(source_uri.as_str())
+                })
+                .filter_map(|change| change.get("edits").and_then(Value::as_array))
+                .map(Vec::len)
+                .sum()
+        });
+    changes + document_changes
+}
+
+fn is_import_action(action: &Map<String, Value>) -> bool {
+    if action
+        .get("data")
+        .and_then(Value::as_object)
+        .is_some_and(|data| {
+            data.get("fixName").and_then(Value::as_str) == Some("import")
+                || data.get("fixId").and_then(Value::as_str) == Some("fixMissingImport")
+        })
+    {
+        return true;
+    }
+    if action
+        .get("title")
+        .and_then(Value::as_str)
+        .is_some_and(|title| title.to_ascii_lowercase().contains("import"))
+    {
+        return true;
+    }
+    contains_import_edit(action.get("edit"))
+}
+
+fn contains_import_edit(value: Option<&Value>) -> bool {
+    let Some(value) = value else {
+        return false;
+    };
+    match value {
+        Value::String(text) => text.trim_start().starts_with("import "),
+        Value::Array(items) => items.iter().any(|item| contains_import_edit(Some(item))),
+        Value::Object(object) => object
+            .iter()
+            .any(|(key, value)| key != "data" && contains_import_edit(Some(value))),
+        _ => false,
+    }
+}
+
+fn wrap_import_edits_in_script(
+    action: &mut Map<String, Value>,
+    context: &TsgoCodeActionContext<'_>,
+) {
+    let mut imports = String::new();
+    let line_ending = newline(context.source);
+    for_each_current_edit_array(action, context.source_uri, &mut |edits| {
+        for edit in edits.iter() {
+            if let Some(text) = edit.get("newText").and_then(Value::as_str) {
+                imports.push_str(text.trim_start_matches(['\r', '\n']));
+                if !imports.ends_with(['\r', '\n']) {
+                    imports.push_str(line_ending);
+                }
+            }
+        }
+        edits.clear();
+    });
+    if imports.is_empty() {
+        return;
+    }
+    let language = match context.default_script_language {
+        Some(language @ ("js" | "ts")) => format!(" lang=\"{language}\""),
+        _ => String::new(),
+    };
+    let newline = newline(context.source);
+    let text = format!("<script{language}>{newline}{imports}</script>{newline}");
+    let insertion = json!({
+        "range": zero_range(),
+        "newText": text
+    });
+    insert_current_edit(action, context.source_uri, insertion);
+}
+
+fn for_each_current_edit_array(
+    action: &mut Map<String, Value>,
+    source_uri: &Uri,
+    callback: &mut impl FnMut(&mut Vec<Value>),
+) {
+    let Some(edit) = action.get_mut("edit").and_then(Value::as_object_mut) else {
+        return;
+    };
+    if let Some(edits) = edit
+        .get_mut("changes")
+        .and_then(Value::as_object_mut)
+        .and_then(|changes| changes.get_mut(source_uri.as_str()))
+        .and_then(Value::as_array_mut)
+    {
+        callback(edits);
+    }
+    if let Some(changes) = edit
+        .get_mut("documentChanges")
+        .and_then(Value::as_array_mut)
+    {
+        for change in changes {
+            let Some(change) = change.as_object_mut() else {
+                continue;
+            };
+            let is_current = change
+                .get("textDocument")
+                .and_then(Value::as_object)
+                .and_then(|document| document.get("uri"))
+                .and_then(Value::as_str)
+                == Some(source_uri.as_str());
+            if is_current && let Some(edits) = change.get_mut("edits").and_then(Value::as_array_mut)
+            {
+                callback(edits);
+            }
+        }
+    }
+}
+
+fn insert_current_edit(action: &mut Map<String, Value>, source_uri: &Uri, insertion: Value) {
+    let Some(edit) = action.get_mut("edit").and_then(Value::as_object_mut) else {
+        return;
+    };
+    if let Some(edits) = edit
+        .get_mut("changes")
+        .and_then(Value::as_object_mut)
+        .and_then(|changes| changes.get_mut(source_uri.as_str()))
+        .and_then(Value::as_array_mut)
+    {
+        edits.push(insertion);
+        return;
+    }
+    if let Some(changes) = edit
+        .get_mut("documentChanges")
+        .and_then(Value::as_array_mut)
+    {
+        for change in changes {
+            let Some(change) = change.as_object_mut() else {
+                continue;
+            };
+            let is_current = change
+                .get("textDocument")
+                .and_then(Value::as_object)
+                .and_then(|document| document.get("uri"))
+                .and_then(Value::as_str)
+                == Some(source_uri.as_str());
+            if is_current && let Some(edits) = change.get_mut("edits").and_then(Value::as_array_mut)
+            {
+                edits.push(insertion);
+                return;
+            }
+        }
+    }
+}
+
+fn needs_lang_ts_action(context: &TsgoCodeActionContext<'_>) -> bool {
+    context
+        .diagnostic_codes
+        .iter()
+        .any(|code| (8004..=8017).contains(code))
+}
+
+fn create_add_lang_ts_action(
+    context: &TsgoCodeActionContext<'_>,
+    scripts: &[ScriptRegion],
+) -> Option<Value> {
+    let newline = newline(context.source);
+    let edits = if scripts.is_empty() {
+        vec![json!({
+            "range": zero_range(),
+            "newText": format!("<script lang=\"ts\"></script>{newline}")
+        })]
+    } else {
+        let index = LineIndex::new(context.source);
+        scripts
+            .iter()
+            .filter(|script| !script.has_lang)
+            .map(|script| {
+                let position = index.position(context.source, script.tag_name_end);
+                json!({
+                    "range": {
+                        "start": position,
+                        "end": position
+                    },
+                    "newText": " lang=\"ts\""
+                })
+            })
+            .collect()
+    };
+    if edits.is_empty() {
+        return None;
+    }
+    let title = if scripts.is_empty() {
+        "Add <script lang=\"ts\"> tag"
+    } else {
+        "Add lang=\"ts\" to <script> tag"
+    };
+    Some(json!({
+        "title": title,
+        "kind": QUICK_FIX_KIND,
+        "edit": {
+            "documentChanges": [{
+                "textDocument": {
+                    "uri": context.source_uri.as_str(),
+                    "version": null
+                },
+                "edits": edits
+            }]
+        }
+    }))
+}
+
+#[derive(Clone, Copy, Debug)]
+struct ScriptRegion {
+    tag_name_end: usize,
+    content_start: usize,
+    content_end: usize,
+    has_lang: bool,
+}
+
+fn script_regions(source: &str) -> Vec<ScriptRegion> {
+    let allocator = Allocator::default();
+    let options = ParseOptions {
+        modern: true,
+        loose: true,
+        defer_script_parse: true,
+        lenient_script: true,
+        skip_non_css_lang_style: true,
+        ..ParseOptions::default()
+    };
+    if let Ok(root) = parse(source, &allocator, options) {
+        let mut regions = [root.module.as_deref(), root.instance.as_deref()]
+            .into_iter()
+            .flatten()
+            .map(|script| {
+                let tag_name_end = script.start as usize + "<script".len();
+                let content_start = script.content_offset as usize;
+                ScriptRegion {
+                    tag_name_end,
+                    content_start,
+                    content_end: content_start + script.raw_content.len(),
+                    has_lang: has_lang_attribute(&source[tag_name_end..content_start]),
+                }
+            })
+            .collect::<Vec<_>>();
+        regions.sort_by_key(|script| script.tag_name_end);
+        return regions;
+    }
+    scan_script_regions(source)
+}
+
+fn scan_script_regions(source: &str) -> Vec<ScriptRegion> {
+    let mut regions = Vec::new();
+    let mut search = 0;
+    while let Some(relative) = source[search..].find("<script") {
+        let tag_start = search + relative;
+        let tag_name_end = tag_start + "<script".len();
+        if source[tag_name_end..]
+            .chars()
+            .next()
+            .is_some_and(|character| !character.is_ascii_whitespace() && character != '>')
+        {
+            search = tag_name_end;
+            continue;
+        }
+        let Some(content_start) = find_tag_end(source, tag_name_end) else {
+            break;
+        };
+        let Some(relative_end) = source[content_start..].find("</script") else {
+            break;
+        };
+        let content_end = content_start + relative_end;
+        let opening_tag = &source[tag_name_end..content_start];
+        regions.push(ScriptRegion {
+            tag_name_end,
+            content_start,
+            content_end,
+            has_lang: has_lang_attribute(opening_tag),
+        });
+        search = content_end + "</script".len();
+    }
+    regions
+}
+
+fn find_tag_end(source: &str, mut offset: usize) -> Option<usize> {
+    let bytes = source.as_bytes();
+    let mut quote = None;
+    while offset < bytes.len() {
+        let byte = bytes[offset];
+        match quote {
+            Some(current) if byte == current => quote = None,
+            None if byte == b'\'' || byte == b'"' => quote = Some(byte),
+            None if byte == b'>' => return Some(offset + 1),
+            _ => {}
+        }
+        offset += 1;
+    }
+    None
+}
+
+fn has_lang_attribute(opening_tag: &str) -> bool {
+    opening_tag
+        .split_ascii_whitespace()
+        .any(|attribute| attribute == "lang" || attribute.starts_with("lang="))
+}
+
+fn parse_range(value: &Value) -> Option<Range> {
+    let object = value.as_object()?;
+    Some(Range::new(
+        parse_position(object.get("start")?)?,
+        parse_position(object.get("end")?)?,
+    ))
+}
+
+fn parse_position(value: &Value) -> Option<Position> {
+    let object = value.as_object()?;
+    Some(Position::new(
+        u32::try_from(object.get("line")?.as_u64()?).ok()?,
+        u32::try_from(object.get("character")?.as_u64()?).ok()?,
+    ))
+}
+
+fn zero_range() -> Value {
+    json!({
+        "start": { "line": 0, "character": 0 },
+        "end": { "line": 0, "character": 0 }
+    })
+}
+
+fn newline(source: &str) -> &'static str {
+    if source.contains("\r\n") {
+        "\r\n"
+    } else {
+        "\n"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+
+    use super::*;
+
+    fn uri() -> Uri {
+        Uri::from_str("file:///workspace/App.svelte").unwrap()
+    }
+
+    fn context<'a>(uri: &'a Uri, source: &'a str) -> TsgoCodeActionContext<'a> {
+        TsgoCodeActionContext::new(uri, source)
+    }
+
+    #[test]
+    fn supported_kind_helpers_match_the_forwarded_surface() {
+        for kind in [
+            "quickfix",
+            "source",
+            "source.organizeImports",
+            "source.sortImports",
+            "source.addMissingImports",
+            "source.removeUnusedImports",
+            "source.fixAll",
+        ] {
+            assert!(is_supported_code_action_kind(kind), "{kind}");
+        }
+        assert!(!is_supported_code_action_kind("refactor.extract"));
+        assert!(is_source_code_action_kind("source.fixAll.ts"));
+        assert!(is_organize_code_action_kind("source.sortImports"));
+
+        let source = vec!["source.organizeImports".to_string()];
+        assert!(!should_forward_code_action_request(
+            Some(&source),
+            true,
+            true
+        ));
+        assert!(!should_forward_code_action_request(
+            Some(&source),
+            false,
+            false
+        ));
+        let quickfix = vec!["quickfix".to_string()];
+        assert!(should_forward_code_action_request(
+            Some(&quickfix),
+            true,
+            false
+        ));
+    }
+
+    #[test]
+    fn component_import_is_unsuffixed_and_wrapped_in_a_typescript_script() {
+        let uri = uri();
+        let source = "<Button />\r\n";
+        let mut response = json!([{
+            "title": "Add import from ./Button.svelte.tsx",
+            "kind": "quickfix",
+            "edit": {
+                "changes": {
+                    uri.as_str(): [{
+                        "range": zero_range(),
+                        "newText": "import type Button__SvelteComponent_ from './Button.svelte.tsx';\r\n"
+                    }]
+                }
+            },
+            "data": {
+                "fixName": "import",
+                "name": "Button__SvelteComponent_",
+                "source": "./Button.svelte.tsx"
+            }
+        }]);
+        let context = context(&uri, source).with_default_script_language(Some("ts"));
+        assert_eq!(rewrite_code_action_response(&mut response, &context), 1);
+        let action = &response[0];
+        assert_eq!(action["title"], "Add import from ./Button.svelte");
+        assert_eq!(
+            action["edit"]["changes"][uri.as_str()][0]["newText"],
+            "<script lang=\"ts\">\r\nimport Button from './Button.svelte';\r\n</script>\r\n"
+        );
+        assert_eq!(
+            action["data"]["name"], "Button__SvelteComponent_",
+            "resolve data belongs to tsgo"
+        );
+        assert_eq!(action["data"]["source"], "./Button.svelte.tsx");
+    }
+
+    #[test]
+    fn parser_errors_suppress_source_actions_but_keep_quickfixes() {
+        let uri = uri();
+        let source = "<script>let broken = ;</script>";
+        let mut response = json!([
+            { "title": "Organize Imports", "kind": "source.organizeImports" },
+            { "title": "Fix typo", "kind": "quickfix" },
+            { "title": "Extract", "kind": "refactor.extract" }
+        ]);
+        let context = context(&uri, source).with_parser_error(true);
+        assert_eq!(rewrite_code_action_response(&mut response, &context), 1);
+        assert_eq!(response[0]["title"], "Fix typo");
+    }
+
+    #[test]
+    fn organize_imports_keeps_script_edits_and_drops_markup_and_helpers() {
+        let uri = uri();
+        let source = "<script>\n  import { b, a } from './x';\n</script>\n<p />\n";
+        let mut response = json!([{
+            "title": "Organize Imports",
+            "kind": "source.organizeImports",
+            "edit": {
+                "documentChanges": [{
+                    "textDocument": { "uri": uri.as_str(), "version": null },
+                    "edits": [
+                        {
+                            "range": {
+                                "start": { "line": 1, "character": 2 },
+                                "end": { "line": 1, "character": 36 }
+                            },
+                            "newText": "import { a, b } from './x';\n"
+                        },
+                        {
+                            "range": {
+                                "start": { "line": 0, "character": 0 },
+                                "end": { "line": 0, "character": 0 }
+                            },
+                            "newText": "import { SvelteComponentTyped as __SvelteComponentTyped__ } from 'svelte';\n"
+                        },
+                        {
+                            "range": {
+                                "start": { "line": 3, "character": 0 },
+                                "end": { "line": 3, "character": 0 }
+                            },
+                            "newText": "corrupt markup"
+                        }
+                    ]
+                }]
+            }
+        }]);
+        assert_eq!(
+            rewrite_code_action_response(&mut response, &context(&uri, source)),
+            1
+        );
+        let edits = response[0]["edit"]["documentChanges"][0]["edits"]
+            .as_array()
+            .unwrap();
+        assert_eq!(edits.len(), 1);
+        assert_eq!(edits[0]["newText"], "import { a, b } from './x';\n");
+    }
+
+    #[test]
+    fn organize_action_without_a_script_is_removed() {
+        let uri = uri();
+        let mut response = json!([{
+            "title": "Organize Imports",
+            "kind": "source.organizeImports",
+            "edit": { "changes": { uri.as_str(): [] } }
+        }]);
+        assert_eq!(
+            rewrite_code_action_response(&mut response, &context(&uri, "<p />")),
+            0
+        );
+        assert_eq!(response, json!([]));
+    }
+
+    #[test]
+    fn only_top_level_script_blocks_enable_source_actions() {
+        assert!(!document_has_script(
+            "<!-- <script></script> --><svelte:head><script></script></svelte:head><p />"
+        ));
+        assert!(document_has_script(
+            "<svelte:head><script></script></svelte:head><script>let x;</script>"
+        ));
+        assert!(document_has_parser_error("<script>let = ;</script>"));
+        assert!(!document_has_parser_error(
+            "<script lang=\"ts\">let x: string;</script>"
+        ));
+    }
+
+    #[test]
+    fn ts_only_diagnostic_adds_or_updates_script_language() {
+        let uri = uri();
+        let codes = [8004];
+        let mut no_script = json!([]);
+        let no_script_context = context(&uri, "<p />").with_diagnostic_codes(&codes);
+        assert_eq!(
+            rewrite_code_action_response(&mut no_script, &no_script_context),
+            1
+        );
+        assert_eq!(
+            no_script[0]["edit"]["documentChanges"][0]["edits"][0]["newText"],
+            "<script lang=\"ts\"></script>\n"
+        );
+
+        let source = "<script context=\"module\"></script>\n<script>let x;</script>";
+        let mut scripts = json!([]);
+        let context = context(&uri, source).with_diagnostic_codes(&codes);
+        assert_eq!(rewrite_code_action_response(&mut scripts, &context), 1);
+        let edits = scripts[0]["edit"]["documentChanges"][0]["edits"]
+            .as_array()
+            .unwrap();
+        assert_eq!(edits.len(), 2);
+        assert!(edits.iter().all(|edit| edit["newText"] == " lang=\"ts\""));
+    }
+
+    #[test]
+    fn helper_only_quickfix_is_dropped_but_external_file_edit_is_preserved() {
+        let uri = uri();
+        let source = "<script>let x;</script>";
+        let mut response = json!([
+            {
+                "title": "Generated helper",
+                "kind": "quickfix",
+                "edit": {
+                    "changes": {
+                        uri.as_str(): [{
+                            "range": zero_range(),
+                            "newText": "const x = __sveltets_2_any(0);"
+                        }]
+                    }
+                }
+            },
+            {
+                "title": "Update other file",
+                "kind": "quickfix",
+                "edit": {
+                    "changes": {
+                        "file:///workspace/other.ts": [{
+                            "range": zero_range(),
+                            "newText": "export const y = 1;"
+                        }]
+                    }
+                }
+            }
+        ]);
+        assert_eq!(
+            rewrite_code_action_response(&mut response, &context(&uri, source)),
+            1
+        );
+        assert_eq!(response[0]["title"], "Update other file");
+    }
+}

--- a/crates/rsvelte_language_server/src/tsgo_completion.rs
+++ b/crates/rsvelte_language_server/src/tsgo_completion.rs
@@ -1,0 +1,703 @@
+//! Svelte-specific normalization for tsgo completion items.
+
+use std::collections::HashMap;
+use std::path::Path;
+
+use serde_json::Value;
+
+const COMPONENT_SUFFIX: &str = "__SvelteComponent_";
+const RUNES: [&str; 4] = ["$props", "$state", "$derived", "$effect"];
+
+/// Source context needed to normalize an initial or resolved completion.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct CompletionRewriteContext {
+    kit_route: bool,
+    pub prefer_components: bool,
+}
+
+impl CompletionRewriteContext {
+    #[must_use]
+    pub fn new(file_path: Option<&Path>, prefer_components: bool) -> Self {
+        Self {
+            kit_route: file_path.is_some_and(is_kit_route_file),
+            prefer_components,
+        }
+    }
+
+    #[must_use]
+    pub const fn is_kit_route(self) -> bool {
+        self.kit_route
+    }
+}
+
+/// The original-source site at which tsgo completions were requested.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum CompletionSite {
+    Script,
+    TemplateExpression,
+    RawTemplateText,
+    Style,
+    BlockMarker,
+    ElementStartTag,
+    ComponentStartTag { at_whitespace: bool },
+}
+
+/// What the server should do with a tsgo completion response.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum CompletionAction {
+    Forward,
+    Suppress,
+    /// Discard global tsgo results and use Svelte props/directives instead.
+    NarrowToSvelte,
+}
+
+/// Apply the false-global-completion guards from upstream's completion
+/// provider without coupling them to a particular Svelte AST representation.
+#[must_use]
+pub const fn completion_action(
+    site: CompletionSite,
+    item_count: usize,
+    first_is_member_variable: bool,
+) -> CompletionAction {
+    match site {
+        CompletionSite::RawTemplateText | CompletionSite::Style | CompletionSite::BlockMarker => {
+            CompletionAction::Suppress
+        }
+        CompletionSite::ElementStartTag if item_count > 500 && !first_is_member_variable => {
+            CompletionAction::Suppress
+        }
+        CompletionSite::ComponentStartTag {
+            at_whitespace: true,
+        } if item_count > 500 => CompletionAction::NarrowToSvelte,
+        CompletionSite::Script
+        | CompletionSite::TemplateExpression
+        | CompletionSite::ElementStartTag
+        | CompletionSite::ComponentStartTag { .. } => CompletionAction::Forward,
+    }
+}
+
+/// Normalize one completion response while preserving tsgo's opaque `data`.
+///
+/// tsgo resolves a completion by the generated `data.name`, so changing data
+/// together with the visible label makes `completionItem/resolve` silently
+/// stop returning auto-import edits.
+pub fn rewrite_completion_response(value: &mut Value) {
+    rewrite_completion_response_for_context(
+        value,
+        CompletionRewriteContext {
+            kit_route: false,
+            prefer_components: true,
+        },
+    );
+}
+
+/// Normalize an initial response for its source context.
+pub fn rewrite_completion_response_for_context(
+    value: &mut Value,
+    context: CompletionRewriteContext,
+) {
+    let Some(items) = completion_items_mut(value) else {
+        return;
+    };
+    if context.kit_route {
+        duplicate_kit_types_items(items);
+    }
+    for item in items {
+        rewrite_completion_item_with_preference(item, context.prefer_components);
+    }
+}
+
+/// Normalize one initial or resolved completion item.
+pub fn rewrite_completion_item(item: &mut Value) {
+    rewrite_completion_item_for_context(
+        item,
+        CompletionRewriteContext {
+            kit_route: false,
+            prefer_components: true,
+        },
+    );
+}
+
+/// Normalize one resolved item and any auto-import edit it contains.
+pub fn rewrite_completion_item_for_context(item: &mut Value, context: CompletionRewriteContext) {
+    rewrite_completion_item_with_preference(item, context.prefer_components);
+    if context.kit_route {
+        rewrite_kit_types_import_edits(item);
+    }
+}
+
+/// Remove virtual component names and shadow extensions from editor-visible fields.
+pub fn rewrite_visible_tsgo_response(value: &mut Value) {
+    rewrite_visible_value(value);
+}
+
+fn rewrite_completion_item_with_preference(item: &mut Value, prefer_components: bool) {
+    let generated_component = item
+        .get("label")
+        .and_then(Value::as_str)
+        .is_some_and(|label| label.ends_with(COMPONENT_SUFFIX));
+    let rune = item
+        .get("label")
+        .and_then(Value::as_str)
+        .is_some_and(|label| RUNES.contains(&label));
+    rewrite_visible_value(item);
+    if prefer_components && (generated_component || rune) {
+        let Some(object) = item.as_object_mut() else {
+            return;
+        };
+        object.insert("sortText".to_string(), Value::String("-1".to_string()));
+        object.insert("preselect".to_string(), Value::Bool(true));
+    }
+    if generated_component {
+        let Some(object) = item.as_object_mut() else {
+            return;
+        };
+        object.insert(
+            "commitCharacters".to_string(),
+            Value::Array(vec![Value::String(">".to_string())]),
+        );
+    }
+}
+
+fn completion_items_mut(value: &mut Value) -> Option<&mut Vec<Value>> {
+    match value {
+        Value::Array(items) => Some(items),
+        Value::Object(object) => object.get_mut("items")?.as_array_mut(),
+        _ => None,
+    }
+}
+
+fn duplicate_kit_types_items(items: &mut Vec<Value>) {
+    let mut by_label = HashMap::new();
+    for (index, item) in items.iter().enumerate() {
+        let Some(label) = item.get("label").and_then(Value::as_str) else {
+            continue;
+        };
+        let Some(source) = item.get("data").and_then(find_kit_types_source) else {
+            continue;
+        };
+        if is_generated_kit_types_source(source) && !visible_uses_local_kit_types(item) {
+            by_label.insert(label.to_string(), index);
+        }
+    }
+
+    let mut indices = by_label.into_values().collect::<Vec<_>>();
+    indices.sort_unstable();
+    let additions = indices
+        .into_iter()
+        .map(|index| {
+            let source = items[index]
+                .get("data")
+                .and_then(find_kit_types_source)
+                .expect("index selected from a kit source");
+            let local = local_kit_types_specifier(source);
+            let mut duplicate = items[index].clone();
+            rewrite_kit_types_visible_fields(&mut duplicate, source, &local);
+            if let Some(object) = duplicate.as_object_mut()
+                && let Some(sort_text) = object.get("sortText").and_then(Value::as_str)
+                && let Ok(sort_number) = sort_text.parse::<i64>()
+            {
+                object.insert(
+                    "sortText".to_string(),
+                    Value::String((sort_number - 1).to_string()),
+                );
+            }
+            duplicate
+        })
+        .collect::<Vec<_>>();
+    items.extend(additions);
+}
+
+fn find_kit_types_source(value: &Value) -> Option<&str> {
+    match value {
+        Value::String(source) if is_generated_kit_types_source(source) => Some(source),
+        Value::Array(values) => values.iter().find_map(find_kit_types_source),
+        Value::Object(object) => object.values().find_map(find_kit_types_source),
+        _ => None,
+    }
+}
+
+fn is_generated_kit_types_source(source: &str) -> bool {
+    let normalized = source.replace('\\', "/");
+    normalized.contains(".svelte-kit/types/") && is_kit_types_path(&normalized)
+}
+
+fn is_kit_types_path(path: &str) -> bool {
+    path.ends_with("/$types") || path.ends_with("/$types.js") || path.ends_with("/$types.d.ts")
+}
+
+fn local_kit_types_specifier(source: &str) -> String {
+    if source.replace('\\', "/").ends_with("/$types.js") {
+        "./$types.js".to_string()
+    } else {
+        "./$types".to_string()
+    }
+}
+
+fn visible_uses_local_kit_types(item: &Value) -> bool {
+    match item {
+        Value::String(text) => text.contains("./$types"),
+        Value::Array(values) => values.iter().any(visible_uses_local_kit_types),
+        Value::Object(object) => object
+            .iter()
+            .filter(|(key, _)| key.as_str() != "data")
+            .any(|(_, value)| visible_uses_local_kit_types(value)),
+        _ => false,
+    }
+}
+
+fn rewrite_kit_types_visible_fields(value: &mut Value, source: &str, local: &str) {
+    let Value::Object(object) = value else {
+        return;
+    };
+    for (key, child) in object {
+        if key == "data" {
+            continue;
+        }
+        match child {
+            Value::String(text) => {
+                if text.contains(source) {
+                    *text = text.replace(source, local);
+                } else {
+                    rewrite_generated_kit_path(text, local);
+                }
+            }
+            Value::Object(_) => rewrite_kit_types_visible_fields(child, source, local),
+            Value::Array(values) => {
+                for value in values {
+                    match value {
+                        Value::String(text) => {
+                            if text.contains(source) {
+                                *text = text.replace(source, local);
+                            } else {
+                                rewrite_generated_kit_path(text, local);
+                            }
+                        }
+                        Value::Object(_) => {
+                            rewrite_kit_types_visible_fields(value, source, local);
+                        }
+                        _ => {}
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+fn rewrite_generated_kit_path(text: &mut String, local: &str) {
+    let Some(marker) = text.find(".svelte-kit/types/") else {
+        return;
+    };
+    let start = text[..marker]
+        .rfind(|character: char| character.is_whitespace() || ['\'', '"', '`'].contains(&character))
+        .map_or(0, |index| index + 1);
+    let Some(types) = text[marker..].find("/$types") else {
+        return;
+    };
+    let mut end = marker + types + "/$types".len();
+    for suffix in [".d.ts", ".js"] {
+        if text[end..].starts_with(suffix) {
+            end += suffix.len();
+            break;
+        }
+    }
+    text.replace_range(start..end, local);
+}
+
+/// Rewrite resolved tsgo edits to the SvelteKit-local `./$types` spelling.
+pub fn rewrite_kit_types_import_edits(item: &mut Value) {
+    let Value::Object(object) = item else {
+        return;
+    };
+    for key in ["textEdit", "additionalTextEdits"] {
+        if let Some(edits) = object.get_mut(key) {
+            rewrite_edit_new_text(edits);
+        }
+    }
+}
+
+fn rewrite_edit_new_text(value: &mut Value) {
+    match value {
+        Value::Array(values) => values.iter_mut().for_each(rewrite_edit_new_text),
+        Value::Object(object) => {
+            if let Some(text) = object
+                .get("newText")
+                .and_then(Value::as_str)
+                .map(str::to_string)
+            {
+                object.insert(
+                    "newText".to_string(),
+                    Value::String(rewrite_quoted_kit_paths(&text)),
+                );
+            }
+            object.values_mut().for_each(rewrite_edit_new_text);
+        }
+        _ => {}
+    }
+}
+
+fn rewrite_quoted_kit_paths(text: &str) -> String {
+    let mut output = text.to_string();
+    let mut cursor = 0;
+    while let Some(relative_start) = output[cursor..].find(['\'', '"', '`']) {
+        let quote_start = cursor + relative_start;
+        let quote = output.as_bytes()[quote_start] as char;
+        let path_start = quote_start + 1;
+        let Some(relative_end) = output[path_start..].find(quote) else {
+            break;
+        };
+        let path_end = path_start + relative_end;
+        let path = &output[path_start..path_end];
+        if is_generated_kit_types_source(path) {
+            let local = local_kit_types_specifier(path);
+            output.replace_range(path_start..path_end, &local);
+            cursor = path_start + local.len() + 1;
+        } else {
+            cursor = path_end + 1;
+        }
+    }
+    output
+}
+
+fn is_kit_route_file(path: &Path) -> bool {
+    path.file_name()
+        .and_then(|name| name.to_str())
+        .is_some_and(|name| name.starts_with('+'))
+}
+
+fn rewrite_visible_value(value: &mut Value) {
+    match value {
+        Value::Object(object) => {
+            for (key, child) in object {
+                if key != "data" {
+                    rewrite_visible_value(child);
+                }
+            }
+        }
+        Value::Array(items) => items.iter_mut().for_each(rewrite_visible_value),
+        Value::String(text) => rewrite_visible_text(text),
+        _ => {}
+    }
+}
+
+fn rewrite_visible_text(text: &mut String) {
+    if text.contains(COMPONENT_SUFFIX) {
+        let trailing_newline = text.ends_with('\n');
+        let filtered = text
+            .lines()
+            .filter(|line| {
+                !(line.contains("(alias) type ")
+                    && line.contains(COMPONENT_SUFFIX)
+                    && line.trim_end().ends_with("= any"))
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+        *text = filtered;
+        if trailing_newline {
+            text.push('\n');
+        }
+    }
+    while let Some(suffix) = text.find(COMPONENT_SUFFIX) {
+        text.replace_range(suffix..suffix + COMPONENT_SUFFIX.len(), "");
+    }
+    if text.contains(".svelte.tsx") {
+        *text = text.replace(".svelte.tsx", ".svelte");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+
+    use serde_json::json;
+
+    use super::*;
+
+    #[test]
+    fn rewrites_visible_component_fields_but_not_resolve_data() {
+        let mut response = json!({
+            "isIncomplete": false,
+            "items": [{
+                "label": "Button__SvelteComponent_",
+                "filterText": "Button__SvelteComponent_",
+                "insertText": "Button__SvelteComponent_",
+                "textEdit": {
+                    "range": {
+                        "start": { "line": 0, "character": 0 },
+                        "end": { "line": 0, "character": 1 }
+                    },
+                    "newText": "Button__SvelteComponent_"
+                },
+                "data": {
+                    "name": "Button__SvelteComponent_",
+                    "source": "./Button.svelte.tsx"
+                }
+            }]
+        });
+
+        rewrite_completion_response(&mut response);
+        let item = &response["items"][0];
+        assert_eq!(item["label"], "Button");
+        assert_eq!(item["filterText"], "Button");
+        assert_eq!(item["insertText"], "Button");
+        assert_eq!(item["textEdit"]["newText"], "Button");
+        assert_eq!(item["sortText"], "-1");
+        assert_eq!(item["preselect"], true);
+        assert_eq!(item["commitCharacters"], json!([">"]));
+        assert_eq!(item["data"]["name"], "Button__SvelteComponent_");
+        assert_eq!(item["data"]["source"], "./Button.svelte.tsx");
+    }
+
+    #[test]
+    fn visible_hover_hides_the_generated_component_alias() {
+        let mut hover = json!({
+            "contents": {
+                "value": "(alias) const Child__SvelteComponent_: Component\n(alias) type Child__SvelteComponent_ = any\n"
+            },
+            "data": { "name": "Child__SvelteComponent_" }
+        });
+        rewrite_visible_tsgo_response(&mut hover);
+        assert_eq!(
+            hover["contents"]["value"],
+            "(alias) const Child: Component\n"
+        );
+        assert_eq!(hover["data"]["name"], "Child__SvelteComponent_");
+    }
+
+    #[test]
+    fn resolved_import_edits_hide_the_shadow_suffix_and_path() {
+        let mut item = json!({
+            "label": "Button__SvelteComponent_",
+            "detail": "Auto import from ./Button.svelte.tsx",
+            "additionalTextEdits": [{
+                "range": {
+                    "start": { "line": 0, "character": 0 },
+                    "end": { "line": 0, "character": 0 }
+                },
+                "newText": "import Button__SvelteComponent_ from './Button.svelte.tsx';\n"
+            }],
+            "data": { "name": "Button__SvelteComponent_" }
+        });
+
+        rewrite_completion_item(&mut item);
+        assert_eq!(item["label"], "Button");
+        assert_eq!(item["detail"], "Auto import from ./Button.svelte");
+        assert_eq!(
+            item["additionalTextEdits"][0]["newText"],
+            "import Button from './Button.svelte';\n"
+        );
+        assert_eq!(item["data"]["name"], "Button__SvelteComponent_");
+    }
+
+    #[test]
+    fn ordinary_completion_keeps_tsgo_ranking() {
+        let mut item = json!({
+            "label": "ordinary",
+            "sortText": "11",
+            "data": { "name": "ordinary" }
+        });
+        rewrite_completion_item(&mut item);
+        assert_eq!(item["sortText"], "11");
+        assert!(item.get("preselect").is_none());
+    }
+
+    #[test]
+    fn component_and_runes_rank_first_only_where_upstream_prefers_them() {
+        let mut component = json!({
+            "label": "Button__SvelteComponent_",
+            "sortText": "11",
+            "data": { "name": "Button__SvelteComponent_" }
+        });
+        rewrite_completion_item_for_context(
+            &mut component,
+            CompletionRewriteContext::new(None, false),
+        );
+        assert_eq!(component["label"], "Button");
+        assert_eq!(component["sortText"], "11");
+        assert!(component.get("preselect").is_none());
+        assert_eq!(component["commitCharacters"], json!([">"]));
+
+        let mut rune = json!({ "label": "$state", "sortText": "11" });
+        rewrite_completion_item_for_context(&mut rune, CompletionRewriteContext::new(None, true));
+        assert_eq!(rune["sortText"], "-1");
+        assert_eq!(rune["preselect"], true);
+        assert!(rune.get("commitCharacters").is_none());
+    }
+
+    #[test]
+    fn plus_route_duplicates_kit_types_without_touching_opaque_data() {
+        let opaque = json!({
+            "entryId": {
+                "name": "PageData",
+                "source": "/work/.svelte-kit/types/src/routes/blog/$types.js",
+                "token": [1, { "future": true }]
+            }
+        });
+        let mut response = json!({
+            "isIncomplete": false,
+            "items": [{
+                "label": "PageData",
+                "sortText": "11",
+                "labelDetails": {
+                    "description": "/work/.svelte-kit/types/src/routes/blog/$types.js"
+                },
+                "data": opaque
+            }]
+        });
+        rewrite_completion_response_for_context(
+            &mut response,
+            CompletionRewriteContext::new(
+                Some(Path::new("/work/src/routes/blog/+page.svelte")),
+                false,
+            ),
+        );
+
+        let items = response["items"].as_array().unwrap();
+        assert_eq!(items.len(), 2);
+        assert_eq!(items[0]["sortText"], "11");
+        assert_eq!(items[1]["sortText"], "10");
+        assert_eq!(items[1]["labelDetails"]["description"], "./$types.js");
+        assert_eq!(items[1]["data"], items[0]["data"]);
+        assert_eq!(items[1]["data"], opaque);
+    }
+
+    #[test]
+    fn only_plus_routes_get_kit_types_duplicates() {
+        let mut ordinary = json!([{
+            "label": "PageData",
+            "data": { "source": "/work/.svelte-kit/types/src/routes/$types.d.ts" }
+        }]);
+        rewrite_completion_response_for_context(
+            &mut ordinary,
+            CompletionRewriteContext::new(Some(Path::new("/work/src/routes/Page.svelte")), true),
+        );
+        assert_eq!(ordinary.as_array().unwrap().len(), 1);
+
+        let mut route = ordinary.clone();
+        rewrite_completion_response_for_context(
+            &mut route,
+            CompletionRewriteContext::new(
+                Some(Path::new("/work/src/routes/+layout.svelte.tsx")),
+                true,
+            ),
+        );
+        assert_eq!(route.as_array().unwrap().len(), 2);
+        assert_eq!(route[1]["labelDetails"], Value::Null);
+        assert_eq!(route[1]["data"], route[0]["data"]);
+    }
+
+    #[test]
+    fn kit_types_keeps_one_duplicate_per_label_and_nonnumeric_sort_text() {
+        let mut response = json!({
+            "items": [
+                {
+                    "label": "PageData",
+                    "sortText": "auto",
+                    "detail": "first .svelte-kit/types/src/routes/$types.d.ts",
+                    "data": { "source": ".svelte-kit/types/src/routes/$types.d.ts", "id": 1 }
+                },
+                {
+                    "label": "PageData",
+                    "sortText": "auto",
+                    "detail": "second .svelte-kit/types/src/routes/$types.d.ts",
+                    "data": { "source": ".svelte-kit/types/src/routes/$types.d.ts", "id": 2 }
+                }
+            ]
+        });
+        rewrite_completion_response_for_context(
+            &mut response,
+            CompletionRewriteContext::new(Some(Path::new("+page.ts")), false),
+        );
+        let items = response["items"].as_array().unwrap();
+        assert_eq!(items.len(), 3);
+        assert_eq!(items[2]["sortText"], "auto");
+        assert_eq!(items[2]["detail"], "second ./$types");
+        assert_eq!(items[2]["data"]["id"], 2);
+    }
+
+    #[test]
+    fn resolved_kit_imports_use_local_types_and_preserve_js_suffix() {
+        let data = json!({
+            "source": "/work/.svelte-kit/types/src/routes/blog/$types.js",
+            "token": "opaque"
+        });
+        let mut item = json!({
+            "label": "PageData",
+            "textEdit": {
+                "newText": "import type { PageData } from '/work/.svelte-kit/types/src/routes/blog/$types.js';"
+            },
+            "additionalTextEdits": [{
+                "newText": "export type { LayoutData } from \"/work/.svelte-kit/types/src/routes/blog/$types.d.ts\";"
+            }],
+            "data": data
+        });
+        rewrite_completion_item_for_context(
+            &mut item,
+            CompletionRewriteContext::new(Some(Path::new("+page.svelte")), false),
+        );
+        assert_eq!(
+            item["textEdit"]["newText"],
+            "import type { PageData } from './$types.js';"
+        );
+        assert_eq!(
+            item["additionalTextEdits"][0]["newText"],
+            "export type { LayoutData } from \"./$types\";"
+        );
+        assert_eq!(item["data"], data);
+    }
+
+    #[test]
+    fn completion_suppression_matches_upstream_boundaries() {
+        for site in [
+            CompletionSite::RawTemplateText,
+            CompletionSite::Style,
+            CompletionSite::BlockMarker,
+        ] {
+            assert_eq!(
+                completion_action(site, 1, false),
+                CompletionAction::Suppress
+            );
+        }
+        assert_eq!(
+            completion_action(CompletionSite::Script, 1000, false),
+            CompletionAction::Forward
+        );
+        assert_eq!(
+            completion_action(CompletionSite::TemplateExpression, 1000, false),
+            CompletionAction::Forward
+        );
+        assert_eq!(
+            completion_action(CompletionSite::ElementStartTag, 500, false),
+            CompletionAction::Forward
+        );
+        assert_eq!(
+            completion_action(CompletionSite::ElementStartTag, 501, false),
+            CompletionAction::Suppress
+        );
+        assert_eq!(
+            completion_action(CompletionSite::ElementStartTag, 501, true),
+            CompletionAction::Forward
+        );
+        assert_eq!(
+            completion_action(
+                CompletionSite::ComponentStartTag {
+                    at_whitespace: true,
+                },
+                501,
+                true,
+            ),
+            CompletionAction::NarrowToSvelte
+        );
+        assert_eq!(
+            completion_action(
+                CompletionSite::ComponentStartTag {
+                    at_whitespace: false,
+                },
+                501,
+                false,
+            ),
+            CompletionAction::Forward
+        );
+    }
+}

--- a/crates/rsvelte_language_server/src/tsgo_component_info.rs
+++ b/crates/rsvelte_language_server/src/tsgo_component_info.rs
@@ -1,0 +1,1090 @@
+//! Component prop, event and slot-let completion through tsgo's public LSP.
+
+use std::ops::Range as ByteRange;
+use std::str::FromStr;
+
+use lsp_types::{
+    CompletionContext, CompletionItem, CompletionItemKind, CompletionTextEdit,
+    CompletionTriggerKind, Documentation, Position, Range, TextEdit, Uri,
+};
+use rsvelte_projection::{ByteRange as ProjectionRange, ProjectionMap};
+use serde_json::{Value, json};
+
+use crate::context::EmbeddedRegions;
+use crate::text::{LineIndex, source_offset};
+
+const QUERY_SUFFIX: &str = ".rsvelte-component-info.tsx";
+const PROBE_MEMBER: &str = "__rsvelte_component_info_probe";
+
+/// Why component-specific completions cannot be offered at a source position.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ComponentCompletionRejection {
+    ParserError,
+    UnsupportedTrigger,
+    EmbeddedLanguage,
+    NotComponentStartTag,
+    ComponentName,
+    AttributeValue,
+}
+
+/// Source information retained while component type information is queried.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ComponentCompletionSite {
+    component_expression: String,
+    component_range: ByteRange<usize>,
+    component_ordinal: usize,
+    word_range: Range,
+    colon_trigger: bool,
+}
+
+impl ComponentCompletionSite {
+    #[must_use]
+    pub fn component_expression(&self) -> &str {
+        &self.component_expression
+    }
+
+    #[must_use]
+    pub fn component_range(&self) -> ByteRange<usize> {
+        self.component_range.clone()
+    }
+
+    #[must_use]
+    pub const fn word_range(&self) -> Range {
+        self.word_range
+    }
+
+    #[must_use]
+    pub const fn was_colon_triggered(&self) -> bool {
+        self.colon_trigger
+    }
+}
+
+/// Locate a component completion site without requiring a successful Svelte AST.
+pub fn component_completion_site(
+    source: &str,
+    position: Position,
+    context: Option<&CompletionContext>,
+    parser_error: bool,
+) -> Result<ComponentCompletionSite, ComponentCompletionRejection> {
+    if parser_error {
+        return Err(ComponentCompletionRejection::ParserError);
+    }
+
+    let colon_trigger = match context {
+        None => false,
+        Some(context) if context.trigger_kind == CompletionTriggerKind::INVOKED => false,
+        Some(context)
+            if context.trigger_kind == CompletionTriggerKind::TRIGGER_CHARACTER
+                && context.trigger_character.as_deref() == Some(":") =>
+        {
+            true
+        }
+        Some(_) => return Err(ComponentCompletionRejection::UnsupportedTrigger),
+    };
+
+    let index = LineIndex::new(source);
+    let offset = index.offset(source, position);
+    if EmbeddedRegions::new(source).contains(offset) {
+        return Err(ComponentCompletionRejection::EmbeddedLanguage);
+    }
+
+    let (component_range, expression) = component_start_tag(source, offset)
+        .ok_or(ComponentCompletionRejection::NotComponentStartTag)?;
+    if offset <= component_range.end {
+        return Err(ComponentCompletionRejection::ComponentName);
+    }
+    if cursor_in_attribute_value(&source[component_range.end..offset]) {
+        return Err(ComponentCompletionRejection::AttributeValue);
+    }
+
+    let word = current_word(source, offset);
+    let component_ordinal = preceding_component_count(&source[..component_range.start], expression);
+    Ok(ComponentCompletionSite {
+        component_expression: expression.to_string(),
+        component_range,
+        component_ordinal,
+        word_range: Range::new(
+            index.position(source, word.start),
+            index.position(source, word.end),
+        ),
+        colon_trigger,
+    })
+}
+
+/// Find an exact generated occurrence of the component expression.
+///
+/// The returned candidates are ordered as the projection emits them. Callers
+/// can use an explicit generated range when a transform intentionally renames
+/// the tag expression.
+#[must_use]
+pub fn generated_component_ranges(
+    map: &ProjectionMap,
+    site: &ComponentCompletionSite,
+    generated_text: &str,
+) -> Vec<ByteRange<usize>> {
+    let Some(source_range) = ProjectionRange::new(
+        source_offset(site.component_range.start),
+        source_offset(site.component_range.end),
+    ) else {
+        return Vec::new();
+    };
+    let exact = map
+        .source_range_to_generated(source_range)
+        .into_iter()
+        .map(ProjectionRange::as_usize_range)
+        .filter(|range| {
+            generated_text.get(range.clone()) == Some(site.component_expression.as_str())
+        })
+        .collect::<Vec<_>>();
+    if !exact.is_empty() {
+        return exact;
+    }
+
+    let anchor = format!("__sveltets_2_ensureComponent({}", site.component_expression);
+    let candidates = generated_text
+        .match_indices(&anchor)
+        .map(|(start, _)| {
+            let start = start + "__sveltets_2_ensureComponent(".len();
+            start..start + site.component_expression.len()
+        })
+        .collect::<Vec<_>>();
+    candidates
+        .get(site.component_ordinal)
+        .cloned()
+        .into_iter()
+        .collect()
+}
+
+/// Component surface being enumerated by a virtual member completion.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum ComponentPart {
+    Props,
+    Events,
+    DefaultSlotLets,
+}
+
+impl ComponentPart {
+    const ALL: [Self; 3] = [Self::Props, Self::Events, Self::DefaultSlotLets];
+
+    const fn prefix(self) -> &'static str {
+        match self {
+            Self::Props => "",
+            Self::Events => "on:",
+            Self::DefaultSlotLets => "let:",
+        }
+    }
+}
+
+/// One property discovered from a component type.
+#[derive(Clone, Debug, PartialEq)]
+pub struct ComponentMember {
+    pub name: String,
+    pub type_detail: String,
+    pub documentation: Option<Documentation>,
+}
+
+/// The normalized component surface returned by a completed query.
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct ComponentInfo {
+    pub props: Vec<ComponentMember>,
+    pub events: Vec<ComponentMember>,
+    pub default_slot_lets: Vec<ComponentMember>,
+}
+
+impl ComponentInfo {
+    fn members_mut(&mut self, part: ComponentPart) -> &mut Vec<ComponentMember> {
+        match part {
+            ComponentPart::Props => &mut self.props,
+            ComponentPart::Events => &mut self.events,
+            ComponentPart::DefaultSlotLets => &mut self.default_slot_lets,
+        }
+    }
+
+    /// Convert type members into the manual items used in a component start tag.
+    #[must_use]
+    pub fn completion_items(&self, site: &ComponentCompletionSite) -> Vec<CompletionItem> {
+        let parts: &[(ComponentPart, &[ComponentMember])] = if site.colon_trigger {
+            &[
+                (ComponentPart::Events, &self.events),
+                (ComponentPart::DefaultSlotLets, &self.default_slot_lets),
+            ]
+        } else {
+            &[
+                (ComponentPart::Props, &self.props),
+                (ComponentPart::Events, &self.events),
+                (ComponentPart::DefaultSlotLets, &self.default_slot_lets),
+            ]
+        };
+
+        parts
+            .iter()
+            .flat_map(|(part, members)| {
+                members
+                    .iter()
+                    .map(move |member| completion_item(*part, member, site.word_range))
+            })
+            .collect()
+    }
+}
+
+/// A virtual document operation or public tsgo LSP request.
+#[derive(Clone, Debug, PartialEq)]
+pub enum ComponentInfoAction {
+    Open {
+        uri: Uri,
+        language_id: &'static str,
+        version: i32,
+        text: String,
+    },
+    Change {
+        uri: Uri,
+        version: i32,
+        text: String,
+    },
+    Request {
+        id: ComponentInfoRequestId,
+        method: &'static str,
+        params: Value,
+    },
+    Close {
+        uri: Uri,
+    },
+    Complete(ComponentInfo),
+}
+
+/// Stable correlation token for a request emitted by [`ComponentInfoQuery`].
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum ComponentInfoRequestId {
+    Completion(ComponentPart),
+    Resolve { part: ComponentPart, index: usize },
+}
+
+/// A protocol-state violation while driving a component query.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ComponentInfoQueryError {
+    RequestNotPending,
+    UnexpectedResponse,
+}
+
+/// A public-LSP-only query for legacy and Svelte 5 component type surfaces.
+///
+/// Drive it by repeatedly executing [`Self::next_action`]. Requests pause the
+/// machine until [`Self::accept_response`] or [`Self::accept_error`] is called.
+/// Open/change bodies are virtual and must only be sent to tsgo, never written.
+pub struct ComponentInfoQuery {
+    query_uri: Uri,
+    generated_text: String,
+    generated_component_range: ByteRange<usize>,
+    component_expression: String,
+    version: i32,
+    part_index: usize,
+    stage: QueryStage,
+    waiting: Option<ComponentInfoRequestId>,
+    items: Vec<Value>,
+    resolve_index: usize,
+    info: ComponentInfo,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum QueryStage {
+    Open,
+    Completion,
+    Resolve,
+    Close,
+    Complete,
+    Done,
+}
+
+impl ComponentInfoQuery {
+    /// Create a query next to a shadow URI so relative module resolution stays unchanged.
+    pub fn new(
+        shadow_uri: &Uri,
+        generated_text: impl Into<String>,
+        generated_component_range: ByteRange<usize>,
+        component_expression: impl Into<String>,
+        version: i32,
+    ) -> Result<Self, InvalidComponentQuery> {
+        let generated_text = generated_text.into();
+        let component_expression = component_expression.into();
+        if generated_component_range.start > generated_component_range.end
+            || component_expression.trim().is_empty()
+            || generated_text.get(generated_component_range.clone())
+                != Some(component_expression.as_str())
+        {
+            return Err(InvalidComponentQuery);
+        }
+        let query_uri = Uri::from_str(&format!("{}{QUERY_SUFFIX}", shadow_uri.as_str()))
+            .map_err(|_| InvalidComponentQuery)?;
+        Ok(Self {
+            query_uri,
+            generated_text,
+            generated_component_range,
+            component_expression,
+            version,
+            part_index: 0,
+            stage: QueryStage::Open,
+            waiting: None,
+            items: Vec::new(),
+            resolve_index: 0,
+            info: ComponentInfo::default(),
+        })
+    }
+
+    #[must_use]
+    pub const fn query_uri(&self) -> &Uri {
+        &self.query_uri
+    }
+
+    /// Return the next operation, or `None` while a request response is pending.
+    pub fn next_action(&mut self) -> Option<ComponentInfoAction> {
+        if self.waiting.is_some() {
+            return None;
+        }
+        match self.stage {
+            QueryStage::Open => {
+                self.stage = QueryStage::Completion;
+                let (text, _) = self.probe(ComponentPart::ALL[self.part_index]);
+                Some(ComponentInfoAction::Open {
+                    uri: self.query_uri.clone(),
+                    language_id: "typescriptreact",
+                    version: self.version,
+                    text,
+                })
+            }
+            QueryStage::Completion => {
+                let part = ComponentPart::ALL[self.part_index];
+                let (_, position) = self.probe(part);
+                let id = ComponentInfoRequestId::Completion(part);
+                self.waiting = Some(id);
+                Some(ComponentInfoAction::Request {
+                    id,
+                    method: "textDocument/completion",
+                    params: json!({
+                        "textDocument": { "uri": self.query_uri.as_str() },
+                        "position": position,
+                        "context": { "triggerKind": 1 }
+                    }),
+                })
+            }
+            QueryStage::Resolve if self.resolve_index < self.items.len() => {
+                let part = ComponentPart::ALL[self.part_index];
+                let id = ComponentInfoRequestId::Resolve {
+                    part,
+                    index: self.resolve_index,
+                };
+                self.waiting = Some(id);
+                Some(ComponentInfoAction::Request {
+                    id,
+                    method: "completionItem/resolve",
+                    params: self.items[self.resolve_index].clone(),
+                })
+            }
+            QueryStage::Resolve => self.advance_part(),
+            QueryStage::Close => {
+                self.stage = QueryStage::Complete;
+                Some(ComponentInfoAction::Close {
+                    uri: self.query_uri.clone(),
+                })
+            }
+            QueryStage::Complete => {
+                self.stage = QueryStage::Done;
+                Some(ComponentInfoAction::Complete(std::mem::take(
+                    &mut self.info,
+                )))
+            }
+            QueryStage::Done => None,
+        }
+    }
+
+    /// Feed a successful public LSP response back into the state machine.
+    pub fn accept_response(
+        &mut self,
+        id: ComponentInfoRequestId,
+        response: Value,
+    ) -> Result<(), ComponentInfoQueryError> {
+        if self.waiting != Some(id) {
+            return Err(if self.waiting.is_some() {
+                ComponentInfoQueryError::UnexpectedResponse
+            } else {
+                ComponentInfoQueryError::RequestNotPending
+            });
+        }
+        self.waiting = None;
+        match id {
+            ComponentInfoRequestId::Completion(part)
+                if part == ComponentPart::ALL[self.part_index] =>
+            {
+                self.items = completion_values(response);
+                self.resolve_index = 0;
+                self.stage = QueryStage::Resolve;
+            }
+            ComponentInfoRequestId::Resolve { part, index }
+                if part == ComponentPart::ALL[self.part_index] && index == self.resolve_index =>
+            {
+                let initial = self.items[index].clone();
+                let resolved = merge_completion_values(initial, response);
+                if let Some(member) = component_member(&resolved, part) {
+                    self.info.members_mut(part).push(member);
+                }
+                self.resolve_index += 1;
+            }
+            _ => return Err(ComponentInfoQueryError::UnexpectedResponse),
+        }
+        Ok(())
+    }
+
+    /// Continue after an LSP error. Resolve failures retain initial item detail;
+    /// a failed member-completion request produces an empty component part.
+    pub fn accept_error(
+        &mut self,
+        id: ComponentInfoRequestId,
+    ) -> Result<(), ComponentInfoQueryError> {
+        match id {
+            ComponentInfoRequestId::Completion(_) => self.accept_response(id, Value::Null),
+            ComponentInfoRequestId::Resolve { index, .. } => {
+                let fallback = self
+                    .items
+                    .get(index)
+                    .cloned()
+                    .ok_or(ComponentInfoQueryError::UnexpectedResponse)?;
+                self.accept_response(id, fallback)?;
+                Ok(())
+            }
+        }
+    }
+
+    fn advance_part(&mut self) -> Option<ComponentInfoAction> {
+        self.part_index += 1;
+        self.items.clear();
+        self.resolve_index = 0;
+        if self.part_index == ComponentPart::ALL.len() {
+            self.stage = QueryStage::Close;
+            return self.next_action();
+        }
+        self.version = self.version.saturating_add(1);
+        self.stage = QueryStage::Completion;
+        let (text, _) = self.probe(ComponentPart::ALL[self.part_index]);
+        Some(ComponentInfoAction::Change {
+            uri: self.query_uri.clone(),
+            version: self.version,
+            text,
+        })
+    }
+
+    fn probe(&self, part: ComponentPart) -> (String, Position) {
+        let replacement = probe_expression(part, &self.component_expression);
+        let cursor_in_replacement = replacement
+            .find(&format!(".{PROBE_MEMBER}"))
+            .expect("probe expression owns its cursor marker")
+            + 1;
+        let mut text = String::with_capacity(
+            self.generated_text.len() - self.generated_component_range.len() + replacement.len(),
+        );
+        text.push_str(&self.generated_text[..self.generated_component_range.start]);
+        text.push_str(&replacement);
+        text.push_str(&self.generated_text[self.generated_component_range.end..]);
+        let cursor = self.generated_component_range.start + cursor_in_replacement;
+        let position = utf8_position(&text, cursor);
+        (text, position)
+    }
+}
+
+/// Invalid generated range, expression or URI for a virtual component query.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct InvalidComponentQuery;
+
+fn component_start_tag(source: &str, offset: usize) -> Option<(ByteRange<usize>, &str)> {
+    let before = source.get(..offset)?;
+    for (open, _) in before.rmatch_indices('<') {
+        let tail = source.get(open + 1..)?;
+        if tail.starts_with(['/', '!', '?']) {
+            continue;
+        }
+        let end = tail
+            .find(|c: char| {
+                !(c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | '.' | ':' | '$'))
+            })
+            .map_or(source.len(), |end| open + 1 + end);
+        if end <= open + 1 || offset < end {
+            continue;
+        }
+        let expression = &source[open + 1..end];
+        let component = expression
+            .as_bytes()
+            .first()
+            .is_some_and(u8::is_ascii_uppercase)
+            || expression.contains('.');
+        if !component {
+            continue;
+        }
+        if source[end..offset].contains('>') {
+            continue;
+        }
+        return Some((open + 1..end, expression));
+    }
+    None
+}
+
+fn preceding_component_count(source: &str, expression: &str) -> usize {
+    let needle = format!("<{expression}");
+    let embedded = EmbeddedRegions::new(source);
+    source
+        .match_indices(&needle)
+        .filter(|(start, _)| {
+            !embedded.contains(*start)
+                && !inside_html_comment(source, *start)
+                && source[*start + needle.len()..]
+                    .chars()
+                    .next()
+                    .is_none_or(|character| {
+                        !(character.is_ascii_alphanumeric()
+                            || matches!(character, '-' | '_' | '.' | ':' | '$'))
+                    })
+        })
+        .count()
+}
+
+fn inside_html_comment(source: &str, offset: usize) -> bool {
+    let before = &source[..offset];
+    before.rfind("<!--") > before.rfind("-->")
+}
+
+fn cursor_in_attribute_value(after_name: &str) -> bool {
+    let mut quote = None;
+    let mut escaped = false;
+    let mut braces = 0usize;
+    let mut value = ValueState::None;
+    for character in after_name.chars() {
+        if let Some(active) = quote {
+            if escaped {
+                escaped = false;
+            } else if character == '\\' {
+                escaped = true;
+            } else if character == active {
+                quote = None;
+                value = ValueState::None;
+            }
+            continue;
+        }
+        if value == ValueState::Unquoted {
+            if character.is_whitespace() {
+                value = ValueState::None;
+            }
+            continue;
+        }
+        if value == ValueState::AfterEqual {
+            match character {
+                c if c.is_whitespace() => continue,
+                '"' | '\'' => {
+                    quote = Some(character);
+                    continue;
+                }
+                '{' => {
+                    braces = 1;
+                    value = ValueState::None;
+                    continue;
+                }
+                _ => {
+                    value = ValueState::Unquoted;
+                    continue;
+                }
+            }
+        }
+        match character {
+            '"' | '\'' if braces > 0 => quote = Some(character),
+            '{' => braces += 1,
+            '}' => braces = braces.saturating_sub(1),
+            '=' if braces == 0 => value = ValueState::AfterEqual,
+            _ => {}
+        }
+    }
+    quote.is_some() || braces > 0 || value != ValueState::None
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ValueState {
+    None,
+    AfterEqual,
+    Unquoted,
+}
+
+fn current_word(source: &str, offset: usize) -> ByteRange<usize> {
+    let mut start = offset;
+    while start > 0 {
+        let character = source[..start]
+            .chars()
+            .next_back()
+            .expect("nonempty prefix");
+        if character.is_whitespace() || character == '.' {
+            break;
+        }
+        start -= character.len_utf8();
+    }
+    let mut end = offset;
+    while end < source.len() {
+        let character = source[end..].chars().next().expect("nonempty suffix");
+        if !(character.is_ascii_alphanumeric()
+            || character == '_'
+            || character == '$'
+            || character == ':')
+        {
+            break;
+        }
+        end += character.len_utf8();
+    }
+    start..end
+}
+
+fn probe_expression(part: ComponentPart, component: &str) -> String {
+    let constructor = match part {
+        ComponentPart::Props => "I extends { $$prop_def: infer P } ? P : never",
+        ComponentPart::Events => "I extends { $$events_def: infer E } ? E : never",
+        ComponentPart::DefaultSlotLets => {
+            "I extends { $$slot_def: infer S } ? S extends { default?: infer D } ? NonNullable<D> : never : never"
+        }
+    };
+    let callable = match part {
+        ComponentPart::Props => "P",
+        ComponentPart::Events => "P extends { $$events?: infer E } ? NonNullable<E> : never",
+        ComponentPart::DefaultSlotLets => {
+            "P extends { $$slots?: infer S } ? NonNullable<S> extends { default?: infer D } ? NonNullable<D> : never : never"
+        }
+    };
+    format!(
+        "((null as unknown as (typeof {component} extends (internals: any, props: infer P, ...args: any[]) => any ? {callable} : typeof {component} extends abstract new (...args: any[]) => infer I ? {constructor} : never)).{PROBE_MEMBER}, ({component}))"
+    )
+}
+
+fn completion_values(response: Value) -> Vec<Value> {
+    match response {
+        Value::Array(items) => items,
+        Value::Object(mut object) => object
+            .remove("items")
+            .and_then(|items| items.as_array().cloned())
+            .unwrap_or_default(),
+        _ => Vec::new(),
+    }
+}
+
+fn merge_completion_values(initial: Value, resolved: Value) -> Value {
+    match (initial, resolved) {
+        (Value::Object(mut initial), Value::Object(resolved)) => {
+            initial.extend(resolved);
+            Value::Object(initial)
+        }
+        (_, resolved) => resolved,
+    }
+}
+
+fn component_member(value: &Value, part: ComponentPart) -> Option<ComponentMember> {
+    let item: CompletionItem = serde_json::from_value(value.clone()).ok()?;
+    let name = unquote_property_name(&item.label);
+    if name == PROBE_MEMBER || (part == ComponentPart::Props && name.starts_with("$$")) {
+        return None;
+    }
+    let type_detail = normalized_detail(&name, item.detail.as_deref(), item.label_details.as_ref());
+    Some(ComponentMember {
+        name,
+        type_detail,
+        documentation: item.documentation,
+    })
+}
+
+fn unquote_property_name(label: &str) -> String {
+    let label = label.strip_suffix('?').unwrap_or(label);
+    label
+        .strip_prefix(['\'', '"'])
+        .and_then(|label| label.strip_suffix(['\'', '"']))
+        .unwrap_or(label)
+        .to_string()
+}
+
+fn normalized_detail(
+    name: &str,
+    detail: Option<&str>,
+    label_details: Option<&lsp_types::CompletionItemLabelDetails>,
+) -> String {
+    if let Some(detail) = detail {
+        if let Some(at) = detail.rfind(name) {
+            let suffix = detail[at + name.len()..].trim();
+            if suffix.starts_with(':') || suffix.starts_with("?:") {
+                return format!("{name}{suffix}");
+            }
+        }
+        if !detail.is_empty() {
+            return detail.to_string();
+        }
+    }
+    if let Some(detail) = label_details.and_then(|details| details.detail.as_deref()) {
+        return format!("{name}{detail}");
+    }
+    name.to_string()
+}
+
+fn completion_item(
+    part: ComponentPart,
+    member: &ComponentMember,
+    word_range: Range,
+) -> CompletionItem {
+    let label = format!("{}{name}", part.prefix(), name = member.name);
+    let text_edit = (word_range.start != word_range.end)
+        .then(|| CompletionTextEdit::Edit(TextEdit::new(word_range, label.clone())));
+    CompletionItem {
+        label: label.clone(),
+        kind: (part == ComponentPart::Props).then_some(CompletionItemKind::FIELD),
+        sort_text: Some("-1".to_string()),
+        detail: Some(member.type_detail.clone()),
+        documentation: member.documentation.clone(),
+        commit_characters: Some(Vec::new()),
+        text_edit,
+        ..CompletionItem::default()
+    }
+}
+
+fn utf8_position(text: &str, offset: usize) -> Position {
+    let offset = offset.min(text.len());
+    let before = &text[..offset];
+    let line = before.bytes().filter(|byte| *byte == b'\n').count() as u32;
+    let line_start = before.rfind('\n').map_or(0, |index| index + 1);
+    Position::new(line, (offset - line_start) as u32)
+}
+
+#[cfg(test)]
+mod tests {
+    use lsp_types::{MarkupContent, MarkupKind};
+
+    use super::*;
+
+    fn invoked() -> CompletionContext {
+        CompletionContext {
+            trigger_kind: CompletionTriggerKind::INVOKED,
+            trigger_character: None,
+        }
+    }
+
+    fn colon() -> CompletionContext {
+        CompletionContext {
+            trigger_kind: CompletionTriggerKind::TRIGGER_CHARACTER,
+            trigger_character: Some(":".to_string()),
+        }
+    }
+
+    fn site(source: &str, needle: &str, context: &CompletionContext) -> ComponentCompletionSite {
+        let offset = source.find(needle).unwrap() + needle.len();
+        let position = LineIndex::new(source).position(source, offset);
+        component_completion_site(source, position, Some(context), false).unwrap()
+    }
+
+    #[test]
+    fn namespace_component_and_current_directive_word_are_located() {
+        let source = "<script>let no = 1</script>\n<Components.Button on:cli />";
+        let site = site(source, "on:cli", &invoked());
+        assert_eq!(site.component_expression(), "Components.Button");
+        assert_eq!(site.component_range(), 29..46);
+        assert_eq!(site.word_range().start, Position::new(1, 19));
+        assert_eq!(site.word_range().end, Position::new(1, 25));
+    }
+
+    #[test]
+    fn parser_script_native_value_and_non_colon_triggers_are_rejected() {
+        let source = "<script>Comp.</script><div x /><Comp value={foo} />";
+        let index = LineIndex::new(source);
+        let script = index.position(source, source.find("Comp.").unwrap() + 4);
+        assert_eq!(
+            component_completion_site(source, script, Some(&invoked()), false),
+            Err(ComponentCompletionRejection::EmbeddedLanguage)
+        );
+        let native = index.position(source, source.find("<div x").unwrap() + 6);
+        assert_eq!(
+            component_completion_site(source, native, Some(&invoked()), false),
+            Err(ComponentCompletionRejection::NotComponentStartTag)
+        );
+        let value = index.position(source, source.find("foo").unwrap() + 2);
+        assert_eq!(
+            component_completion_site(source, value, Some(&invoked()), false),
+            Err(ComponentCompletionRejection::AttributeValue)
+        );
+        assert_eq!(
+            component_completion_site(source, Position::new(0, 0), Some(&invoked()), true),
+            Err(ComponentCompletionRejection::ParserError)
+        );
+        let dot = CompletionContext {
+            trigger_kind: CompletionTriggerKind::TRIGGER_CHARACTER,
+            trigger_character: Some(".".to_string()),
+        };
+        assert_eq!(
+            component_completion_site(source, value, Some(&dot), false),
+            Err(ComponentCompletionRejection::UnsupportedTrigger)
+        );
+        let component_name = index.position(source, source.rfind("<Comp").unwrap() + 3);
+        assert!(matches!(
+            component_completion_site(source, component_name, Some(&invoked()), false),
+            Err(ComponentCompletionRejection::NotComponentStartTag)
+                | Err(ComponentCompletionRejection::ComponentName)
+        ));
+    }
+
+    #[test]
+    fn completed_attribute_values_allow_the_next_component_completion() {
+        for source in [
+            "<Comp value={foo}  />",
+            "<Comp value=foo  />",
+            "<Comp value=\"foo\"  />",
+        ] {
+            let offset = source.rfind("  ").unwrap() + 1;
+            let position = LineIndex::new(source).position(source, offset);
+            assert!(
+                component_completion_site(source, position, Some(&invoked()), false).is_ok(),
+                "{source}"
+            );
+        }
+    }
+
+    #[test]
+    fn projection_selects_only_exact_component_name_segments() {
+        let source = "<Component />";
+        let artifact = rsvelte_projection::ProjectionEngine
+            .project(source, Default::default())
+            .unwrap();
+        let position = Position::new(0, 12);
+        let site = component_completion_site(source, position, Some(&invoked()), false).unwrap();
+        let ranges = generated_component_ranges(
+            &artifact.exact_mappings.unwrap_or_default(),
+            &site,
+            &artifact.code,
+        );
+        assert!(!ranges.is_empty());
+        assert!(
+            ranges
+                .iter()
+                .all(|range| &artifact.code[range.clone()] == "Component")
+        );
+    }
+
+    #[test]
+    fn generated_fallback_uses_the_source_occurrence_of_a_repeated_component() {
+        let source =
+            "<script>const sample = '<Comp />';</script><!-- <Comp /> --><Comp a /><Comp b />";
+        let artifact = rsvelte_projection::ProjectionEngine
+            .project(source, Default::default())
+            .unwrap();
+        let offset = source.rfind(" b").unwrap() + 2;
+        let position = LineIndex::new(source).position(source, offset);
+        let site = component_completion_site(source, position, Some(&invoked()), false).unwrap();
+        let ranges = generated_component_ranges(&ProjectionMap::default(), &site, &artifact.code);
+        assert_eq!(ranges.len(), 1);
+        let second = artifact
+            .code
+            .match_indices("__sveltets_2_ensureComponent(Comp")
+            .nth(1)
+            .unwrap()
+            .0
+            + "__sveltets_2_ensureComponent(".len();
+        assert_eq!(ranges[0], second..second + 4);
+    }
+
+    #[test]
+    fn virtual_probes_cover_legacy_and_svelte_five_shapes() {
+        let legacy = probe_expression(ComponentPart::Events, "Components.Legacy");
+        assert!(legacy.contains("abstract new"));
+        assert!(legacy.contains("$$events_def"));
+        assert!(legacy.contains("props: infer P"));
+        assert!(legacy.contains("$$events?: infer E"));
+        let slots = probe_expression(ComponentPart::DefaultSlotLets, "Modern");
+        assert!(slots.contains("$$slot_def"));
+        assert!(slots.contains("$$slots?: infer S"));
+        assert!(slots.contains("default?: infer D"));
+    }
+
+    #[test]
+    fn query_is_open_completion_resolve_change_and_close_state_machine() {
+        let shadow_uri = Uri::from_str("file:///cache/svelte/App.svelte.tsx").unwrap();
+        let generated = "use(Components.Button);";
+        let range = generated.find("Components.Button").unwrap()
+            ..generated.find("Components.Button").unwrap() + "Components.Button".len();
+        let mut query =
+            ComponentInfoQuery::new(&shadow_uri, generated, range, "Components.Button", 7).unwrap();
+
+        let ComponentInfoAction::Open { text, version, .. } = query.next_action().unwrap() else {
+            panic!("expected open");
+        };
+        assert_eq!(version, 7);
+        assert!(text.contains("$$prop_def"));
+        let ComponentInfoAction::Request { id, method, .. } = query.next_action().unwrap() else {
+            panic!("expected completion");
+        };
+        assert_eq!(method, "textDocument/completion");
+        assert_eq!(id, ComponentInfoRequestId::Completion(ComponentPart::Props));
+        query
+            .accept_response(
+                id,
+                json!({ "items": [{
+                    "label": "title",
+                    "detail": "(property) title: string",
+                    "data": { "opaque": true }
+                }] }),
+            )
+            .unwrap();
+        let ComponentInfoAction::Request { id, method, params } = query.next_action().unwrap()
+        else {
+            panic!("expected resolve");
+        };
+        assert_eq!(method, "completionItem/resolve");
+        assert_eq!(params["data"]["opaque"], true);
+        query
+            .accept_response(
+                id,
+                json!({
+                    "label": "title",
+                    "detail": "(property) title: string",
+                    "documentation": { "kind": "markdown", "value": "Heading" }
+                }),
+            )
+            .unwrap();
+        let ComponentInfoAction::Change { text, version, .. } = query.next_action().unwrap() else {
+            panic!("expected event probe change");
+        };
+        assert_eq!(version, 8);
+        assert!(text.contains("$$events_def"));
+
+        for part in [ComponentPart::Events, ComponentPart::DefaultSlotLets] {
+            let ComponentInfoAction::Request { id, .. } = query.next_action().unwrap() else {
+                panic!("expected completion request");
+            };
+            assert_eq!(id, ComponentInfoRequestId::Completion(part));
+            query.accept_response(id, Value::Null).unwrap();
+            if part == ComponentPart::Events {
+                assert!(matches!(
+                    query.next_action(),
+                    Some(ComponentInfoAction::Change { .. })
+                ));
+            }
+        }
+        assert!(matches!(
+            query.next_action(),
+            Some(ComponentInfoAction::Close { .. })
+        ));
+        let Some(ComponentInfoAction::Complete(info)) = query.next_action() else {
+            panic!("expected completed info");
+        };
+        assert_eq!(info.props.len(), 1);
+        assert_eq!(info.props[0].type_detail, "title: string");
+        assert_eq!(
+            info.props[0].documentation,
+            Some(Documentation::MarkupContent(MarkupContent {
+                kind: MarkupKind::Markdown,
+                value: "Heading".to_string()
+            }))
+        );
+    }
+
+    #[test]
+    fn manual_items_include_type_docs_prefix_and_current_word_edit() {
+        let source = "<Comp on:ol />";
+        let site = site(source, "on:ol", &invoked());
+        let docs = Documentation::MarkupContent(MarkupContent {
+            kind: MarkupKind::Markdown,
+            value: "Dispatched when ready".to_string(),
+        });
+        let info = ComponentInfo {
+            props: vec![ComponentMember {
+                name: "title".to_string(),
+                type_detail: "title: string".to_string(),
+                documentation: None,
+            }],
+            events: vec![ComponentMember {
+                name: "old".to_string(),
+                type_detail: "old: CustomEvent<void>".to_string(),
+                documentation: Some(docs.clone()),
+            }],
+            default_slot_lets: vec![ComponentMember {
+                name: "item".to_string(),
+                type_detail: "item: Row".to_string(),
+                documentation: None,
+            }],
+        };
+        let items = info.completion_items(&site);
+        assert_eq!(
+            items
+                .iter()
+                .map(|item| item.label.as_str())
+                .collect::<Vec<_>>(),
+            ["title", "on:old", "let:item"]
+        );
+        assert_eq!(items[0].kind, Some(CompletionItemKind::FIELD));
+        assert_eq!(items[1].documentation, Some(docs));
+        let Some(CompletionTextEdit::Edit(edit)) = &items[1].text_edit else {
+            panic!("manual item must own its word replacement");
+        };
+        assert_eq!(edit.range, site.word_range());
+        assert_eq!(edit.new_text, "on:old");
+    }
+
+    #[test]
+    fn colon_trigger_returns_only_event_and_slot_directives() {
+        let source = "<Comp on: />";
+        let site = site(source, "on:", &colon());
+        let member = |name: &str| ComponentMember {
+            name: name.to_string(),
+            type_detail: format!("{name}: unknown"),
+            documentation: None,
+        };
+        let info = ComponentInfo {
+            props: vec![member("prop")],
+            events: vec![member("event")],
+            default_slot_lets: vec![member("slot")],
+        };
+        assert_eq!(
+            info.completion_items(&site)
+                .into_iter()
+                .map(|item| item.label)
+                .collect::<Vec<_>>(),
+            ["on:event", "let:slot"]
+        );
+    }
+
+    #[test]
+    fn whitespace_completion_keeps_the_official_absent_text_edit_shape() {
+        let source = "<Comp  />";
+        let site = site(source, "<Comp ", &invoked());
+        let info = ComponentInfo {
+            props: vec![ComponentMember {
+                name: "value".to_string(),
+                type_detail: "value: string".to_string(),
+                documentation: None,
+            }],
+            ..ComponentInfo::default()
+        };
+        let item = info.completion_items(&site).remove(0);
+        assert_eq!(site.word_range().start, site.word_range().end);
+        assert!(item.text_edit.is_none());
+    }
+
+    #[test]
+    fn generated_helpers_and_svelte_five_metadata_are_filtered() {
+        let values = [
+            (PROBE_MEMBER, ComponentPart::Events, false),
+            ("__public", ComponentPart::Events, true),
+            ("$$events", ComponentPart::Props, false),
+            ("optional?", ComponentPart::Props, true),
+            ("title", ComponentPart::Props, true),
+            ("click", ComponentPart::Events, true),
+        ];
+        for (label, part, expected) in values {
+            assert_eq!(
+                component_member(
+                    &json!({ "label": label, "detail": format!("{label}: any") }),
+                    part
+                )
+                .is_some(),
+                expected
+            );
+        }
+        assert_eq!(
+            component_member(&json!({ "label": "optional?" }), ComponentPart::Props)
+                .unwrap()
+                .name,
+            "optional"
+        );
+    }
+}

--- a/crates/rsvelte_language_server/src/tsgo_custom.rs
+++ b/crates/rsvelte_language_server/src/tsgo_custom.rs
@@ -1,0 +1,1153 @@
+//! Pure Svelte-specific helpers for tsgo custom requests and code lenses.
+
+use std::collections::BTreeMap;
+use std::path::{Component, Path, PathBuf};
+
+use lsp_types::{Location, Position, Range, Uri};
+use serde_json::{Map, Value, json};
+
+const COMPONENT_SUFFIX: &str = "__SvelteComponent_";
+const MODULE_EXTENSIONS: &[&str] = &[
+    "ts", "tsx", "js", "jsx", "mts", "cts", "mjs", "cjs", "svelte",
+];
+
+/// One mapped TypeScript reference considered for `$/getComponentReferences`.
+#[derive(Debug)]
+pub struct ComponentReference<'a> {
+    pub location: Location,
+    pub source_text: Option<&'a str>,
+    pub is_definition: bool,
+    pub is_generated: bool,
+}
+
+/// A source file visible to the file-reference index.
+#[derive(Debug, Clone, Copy)]
+pub struct WorkspaceSource<'a> {
+    pub path: &'a Path,
+    pub uri: &'a Uri,
+    pub text: &'a str,
+}
+
+/// The editor and tsgo identities of one Svelte document.
+#[derive(Debug, Clone, Copy)]
+pub struct ShadowUriPair<'a> {
+    pub source_uri: &'a Uri,
+    pub shadow_uri: &'a Uri,
+}
+
+/// The two URI pairs needed to forward a `workspace/willRenameFiles` request.
+#[derive(Debug, Clone, Copy)]
+pub struct WillRenameMapping<'a> {
+    pub old: ShadowUriPair<'a>,
+    pub new: ShadowUriPair<'a>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CodeLensKind {
+    Reference,
+    Implementation,
+}
+
+impl CodeLensKind {
+    fn name(self) -> &'static str {
+        match self {
+            Self::Reference => "reference",
+            Self::Implementation => "implementation",
+        }
+    }
+}
+
+/// Read the official provider's resolve discriminator from a lens.
+#[must_use]
+pub fn code_lens_kind(lens: &Value) -> Option<CodeLensKind> {
+    match lens
+        .pointer("/data/kind")
+        .and_then(Value::as_str)
+        .or_else(|| lens.pointer("/data/type").and_then(Value::as_str))
+    {
+        Some("references" | "reference") => Some(CodeLensKind::Reference),
+        Some("implementations" | "implementation") => Some(CodeLensKind::Implementation),
+        _ => None,
+    }
+}
+
+/// Reference lens for the component class synthesized by svelte2tsx.
+#[must_use]
+pub fn component_reference_code_lens(source_uri: &Uri) -> Value {
+    json!({
+        "range": {
+            "start": { "line": 0, "character": 0 },
+            "end": { "line": 0, "character": 1 }
+        },
+        "data": { "kind": "references", "uri": source_uri.as_str() }
+    })
+}
+
+/// Byte offset at which tsgo should probe the generated component export.
+#[must_use]
+pub fn component_probe_offset(generated_text: &str) -> Option<usize> {
+    generated_text.rfind(COMPONENT_SUFFIX)
+}
+
+/// UTF-8 LSP position at which tsgo should probe the generated component export.
+#[must_use]
+pub fn component_probe_position(generated_text: &str) -> Option<Position> {
+    component_probe_offset(generated_text).map(|offset| utf8_position(generated_text, offset))
+}
+
+/// Remove definitions, generated locations, closing tags, and zero ranges.
+#[must_use]
+pub fn filter_component_references<'a>(
+    references: impl IntoIterator<Item = ComponentReference<'a>>,
+) -> Vec<Location> {
+    references
+        .into_iter()
+        .filter(|reference| !reference.is_definition && !reference.is_generated)
+        .filter(|reference| non_zero_range(reference.location.range))
+        .filter(|reference| {
+            reference
+                .source_text
+                .is_none_or(|text| !is_component_closing_tag(text, reference.location.range.start))
+        })
+        .map(|reference| reference.location)
+        .collect()
+}
+
+/// Whether a mapped component name is immediately preceded by the `/` of an end tag.
+#[must_use]
+pub fn is_component_closing_tag(source_text: &str, start: Position) -> bool {
+    let offset = utf16_offset(source_text, start);
+    offset > 0 && source_text.as_bytes().get(offset - 1) == Some(&b'/')
+}
+
+/// Find ES module specifiers which resolve to `target_path`.
+#[must_use]
+pub fn find_file_references(target_path: &Path, sources: &[WorkspaceSource<'_>]) -> Vec<Location> {
+    let target_path = normalize_path(target_path);
+    let mut locations = Vec::new();
+
+    for source in sources {
+        for span in module_specifier_spans(source.path, source.text) {
+            let specifier = &source.text[span.clone()];
+            if !specifier.starts_with('.')
+                || !specifier_resolves_to(source.path, specifier, &target_path)
+            {
+                continue;
+            }
+            locations.push(Location::new(
+                source.uri.clone(),
+                Range::new(
+                    utf16_position(source.text, span.start),
+                    utf16_position(source.text, span.end),
+                ),
+            ));
+        }
+    }
+
+    locations.sort_by(|left, right| {
+        left.uri
+            .as_str()
+            .cmp(right.uri.as_str())
+            .then_with(|| left.range.start.line.cmp(&right.range.start.line))
+            .then_with(|| left.range.start.character.cmp(&right.range.start.character))
+            .then_with(|| left.range.end.line.cmp(&right.range.end.line))
+            .then_with(|| left.range.end.character.cmp(&right.range.end.character))
+    });
+
+    locations
+}
+
+/// Replace editor `.svelte` URIs with the old and prospective shadow URIs.
+pub fn rewrite_will_rename_params(params: &mut Value, mappings: &[WillRenameMapping<'_>]) {
+    if let Some(file) = params.as_object_mut() {
+        for mapping in mappings {
+            replace_uri_field(
+                file,
+                "oldUri",
+                mapping.old.source_uri,
+                mapping.old.shadow_uri,
+            );
+            replace_uri_field(
+                file,
+                "newUri",
+                mapping.new.source_uri,
+                mapping.new.shadow_uri,
+            );
+        }
+    }
+    let Some(files) = params.get_mut("files").and_then(Value::as_array_mut) else {
+        return;
+    };
+    for file in files.iter_mut().filter_map(Value::as_object_mut) {
+        for mapping in mappings {
+            replace_uri_field(
+                file,
+                "oldUri",
+                mapping.old.source_uri,
+                mapping.old.shadow_uri,
+            );
+            replace_uri_field(
+                file,
+                "newUri",
+                mapping.new.source_uri,
+                mapping.new.shadow_uri,
+            );
+        }
+    }
+}
+
+/// Normalize tsgo's file-rename edit before the generic range mapper runs.
+pub fn rewrite_will_rename_result(
+    result: &mut Value,
+    mappings: &[WillRenameMapping<'_>],
+    documents: &[ShadowUriPair<'_>],
+) {
+    let mut pairs = documents.to_vec();
+    pairs.extend(
+        mappings
+            .iter()
+            .flat_map(|mapping| [mapping.old, mapping.new]),
+    );
+    if let Some(changes) = result.get_mut("changes").and_then(Value::as_object_mut) {
+        rewrite_changes_map(changes, mappings, &pairs);
+    }
+
+    let Some(document_changes) = result
+        .get_mut("documentChanges")
+        .and_then(Value::as_array_mut)
+    else {
+        return;
+    };
+    let mut rewritten = Vec::<Value>::new();
+    for mut change in std::mem::take(document_changes) {
+        let Some(uri) = change.pointer("/textDocument/uri").and_then(Value::as_str) else {
+            rewritten.push(change);
+            continue;
+        };
+        if is_kit_types_path(uri) {
+            continue;
+        }
+        let mapped_uri = result_uri_for(uri, mappings, &pairs)
+            .unwrap_or(uri)
+            .to_string();
+        if let Some(value) = change.pointer_mut("/textDocument/uri") {
+            *value = Value::String(mapped_uri.clone());
+        }
+        if let Some(edits) = change.get_mut("edits").and_then(Value::as_array_mut) {
+            rewrite_text_edits(edits, &mapped_uri, &pairs);
+        }
+        if let Some(existing) = rewritten.iter_mut().find(|existing| {
+            existing
+                .pointer("/textDocument/uri")
+                .and_then(Value::as_str)
+                == Some(&mapped_uri)
+        }) {
+            if edit_count(&change) >= edit_count(existing) {
+                *existing = change;
+            }
+        } else {
+            rewritten.push(change);
+        }
+    }
+    *document_changes = rewritten;
+}
+
+/// Keep mapped, non-empty lenses and attach the editor-facing resolve identity.
+pub fn prepare_code_lenses(result: &mut Value, source_uri: &Uri) {
+    let Some(lenses) = result.as_array_mut() else {
+        return;
+    };
+    lenses.retain_mut(|lens| {
+        let Some(range) = lens.get("range").and_then(parse_range) else {
+            return false;
+        };
+        if !non_zero_range(range) {
+            return false;
+        }
+        let data = lens
+            .as_object_mut()
+            .expect("a lens with a range is an object")
+            .entry("data")
+            .or_insert_with(|| Value::Object(Map::new()));
+        if let Some(data) = data.as_object_mut() {
+            data.insert(
+                "uri".to_string(),
+                Value::String(source_uri.as_str().to_string()),
+            );
+        }
+        true
+    });
+}
+
+/// Build the editor-neutral command used by the official code-lens provider.
+pub fn resolve_code_lens(
+    lens: &mut Value,
+    kind: CodeLensKind,
+    source_uri: &Uri,
+    locations: Vec<Location>,
+) -> bool {
+    let Some(start) = lens
+        .get("range")
+        .and_then(parse_range)
+        .map(|range| range.start)
+    else {
+        return false;
+    };
+    let count = locations.len();
+    let plural = if count == 1 { "" } else { "s" };
+    lens.as_object_mut()
+        .expect("range belongs to an object")
+        .insert(
+            "command".to_string(),
+            json!({
+                "title": format!("{count} {}{plural}", kind.name()),
+                "command": "",
+                "arguments": [source_uri.as_str(), start, locations],
+            }),
+        );
+    true
+}
+
+fn replace_uri_field(object: &mut Map<String, Value>, key: &str, from: &Uri, to: &Uri) {
+    if object.get(key).and_then(Value::as_str) == Some(from.as_str()) {
+        object.insert(key.to_string(), Value::String(to.as_str().to_string()));
+    }
+}
+
+fn rewrite_changes_map(
+    changes: &mut Map<String, Value>,
+    mappings: &[WillRenameMapping<'_>],
+    pairs: &[ShadowUriPair<'_>],
+) {
+    let mut rewritten = BTreeMap::<String, Value>::new();
+    for (uri, mut edits) in std::mem::take(changes) {
+        if is_kit_types_path(&uri) {
+            continue;
+        }
+        let mapped_uri = result_uri_for(&uri, mappings, pairs)
+            .unwrap_or(&uri)
+            .to_string();
+        if let Some(edits) = edits.as_array_mut() {
+            rewrite_text_edits(edits, &mapped_uri, pairs);
+        }
+        if let Some(existing) = rewritten.get_mut(&mapped_uri)
+            && let (Some(existing), Some(edits)) = (existing.as_array_mut(), edits.as_array_mut())
+        {
+            if edits.len() >= existing.len() {
+                *existing = std::mem::take(edits);
+            }
+        } else {
+            rewritten.insert(mapped_uri, edits);
+        }
+    }
+    changes.extend(rewritten);
+}
+
+fn rewrite_text_edits(edits: &mut Vec<Value>, document_uri: &str, pairs: &[ShadowUriPair<'_>]) {
+    let route_file = uri_basename(document_uri).is_some_and(|name| name.starts_with('+'));
+    edits.retain_mut(|edit| {
+        let Some(new_text) = edit.get_mut("newText") else {
+            return true;
+        };
+        let Some(text) = new_text.as_str() else {
+            return true;
+        };
+        if route_file && is_kit_types_path(text) {
+            return false;
+        }
+        *new_text = Value::String(rewrite_shadow_specifiers(text, pairs));
+        true
+    });
+}
+
+fn rewrite_shadow_specifiers(text: &str, pairs: &[ShadowUriPair<'_>]) -> String {
+    let mut result = text.to_string();
+    for pair in pairs {
+        let Some(source_name) = uri_basename(pair.source_uri.as_str()) else {
+            continue;
+        };
+        if let Some(shadow_name) = uri_basename(pair.shadow_uri.as_str()) {
+            result = result.replace(shadow_name, source_name);
+        }
+        if source_name.ends_with(".svelte") {
+            for suffix in [".tsx", ".jsx", ".ts", ".js"] {
+                result = result.replace(&format!("{source_name}{suffix}"), source_name);
+            }
+        }
+    }
+    result
+}
+
+fn source_uri_for<'a>(uri: &str, pairs: &'a [ShadowUriPair<'_>]) -> Option<&'a str> {
+    pairs
+        .iter()
+        .find(|pair| pair.shadow_uri.as_str() == uri)
+        .map(|pair| pair.source_uri.as_str())
+}
+
+fn result_uri_for<'a>(
+    uri: &str,
+    mappings: &'a [WillRenameMapping<'_>],
+    pairs: &'a [ShadowUriPair<'_>],
+) -> Option<&'a str> {
+    mappings
+        .iter()
+        .find(|mapping| {
+            mapping.old.shadow_uri.as_str() == uri || mapping.old.source_uri.as_str() == uri
+        })
+        .map(|mapping| mapping.new.source_uri.as_str())
+        .or_else(|| source_uri_for(uri, pairs))
+}
+
+fn edit_count(change: &Value) -> usize {
+    change
+        .get("edits")
+        .and_then(Value::as_array)
+        .map_or(0, Vec::len)
+}
+
+fn is_kit_types_path(path: &str) -> bool {
+    path.ends_with("/$types.js") || path.ends_with("/$types") || path.ends_with("/$types.d.ts")
+}
+
+fn uri_basename(uri: &str) -> Option<&str> {
+    uri.rsplit('/').next().filter(|name| !name.is_empty())
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum TokenKind<'a> {
+    Ident(&'a str),
+    String,
+    Punct(u8),
+}
+
+#[derive(Debug, Clone, Copy)]
+struct Token<'a> {
+    kind: TokenKind<'a>,
+    start: usize,
+    end: usize,
+}
+
+fn module_specifier_spans(path: &Path, text: &str) -> Vec<std::ops::Range<usize>> {
+    let regions = if path
+        .extension()
+        .is_some_and(|extension| extension == "svelte")
+    {
+        svelte_script_regions(text)
+    } else {
+        std::iter::once(0..text.len()).collect()
+    };
+    let mut spans = Vec::new();
+    for region in regions {
+        let tokens = tokenize(&text[region.clone()], region.start);
+        let mut index = 0;
+        while index < tokens.len() {
+            match tokens[index].kind {
+                TokenKind::Ident("import") => {
+                    collect_import_specifier(&tokens, index, &mut spans);
+                }
+                TokenKind::Ident("export") => {
+                    collect_from_specifier(&tokens, index + 1, &mut spans);
+                }
+                TokenKind::Ident("require") => {
+                    collect_call_specifier(&tokens, index, &mut spans);
+                }
+                _ => {}
+            }
+            index += 1;
+        }
+    }
+    spans.sort_by_key(|span| (span.start, span.end));
+    spans.dedup();
+    spans
+}
+
+fn collect_import_specifier(
+    tokens: &[Token<'_>],
+    index: usize,
+    spans: &mut Vec<std::ops::Range<usize>>,
+) {
+    match tokens.get(index + 1).map(|token| token.kind) {
+        Some(TokenKind::String) => push_string_span(tokens[index + 1], spans),
+        Some(TokenKind::Punct(b'(')) => collect_call_specifier(tokens, index, spans),
+        _ => collect_from_specifier(tokens, index + 1, spans),
+    }
+}
+
+fn collect_call_specifier(
+    tokens: &[Token<'_>],
+    index: usize,
+    spans: &mut Vec<std::ops::Range<usize>>,
+) {
+    if matches!(
+        tokens.get(index + 1).map(|token| token.kind),
+        Some(TokenKind::Punct(b'('))
+    ) && let Some(token) = tokens.get(index + 2)
+        && token.kind == TokenKind::String
+    {
+        push_string_span(*token, spans);
+    }
+}
+
+fn collect_from_specifier(
+    tokens: &[Token<'_>],
+    mut index: usize,
+    spans: &mut Vec<std::ops::Range<usize>>,
+) {
+    let mut depth = 0usize;
+    while let Some(token) = tokens.get(index) {
+        match token.kind {
+            TokenKind::Punct(b'(' | b'[' | b'{') => depth += 1,
+            TokenKind::Punct(b')' | b']' | b'}') => depth = depth.saturating_sub(1),
+            TokenKind::Punct(b';') if depth == 0 => break,
+            TokenKind::Ident("import" | "export") if depth == 0 => break,
+            TokenKind::Ident("from") if depth == 0 => {
+                if let Some(next) = tokens.get(index + 1)
+                    && next.kind == TokenKind::String
+                {
+                    push_string_span(*next, spans);
+                }
+                break;
+            }
+            _ => {}
+        }
+        index += 1;
+    }
+}
+
+fn push_string_span(token: Token<'_>, spans: &mut Vec<std::ops::Range<usize>>) {
+    if token.end > token.start + 1 {
+        spans.push(token.start + 1..token.end - 1);
+    }
+}
+
+fn tokenize(text: &str, base: usize) -> Vec<Token<'_>> {
+    let bytes = text.as_bytes();
+    let mut tokens = Vec::new();
+    let mut index = 0;
+    while index < bytes.len() {
+        if bytes[index].is_ascii_whitespace() {
+            index += 1;
+            continue;
+        }
+        if bytes[index] == b'/' && bytes.get(index + 1) == Some(&b'/') {
+            index += 2;
+            while index < bytes.len() && !matches!(bytes[index], b'\n' | b'\r') {
+                index += 1;
+            }
+            continue;
+        }
+        if bytes[index] == b'/' && bytes.get(index + 1) == Some(&b'*') {
+            index += 2;
+            while index + 1 < bytes.len() && !(bytes[index] == b'*' && bytes[index + 1] == b'/') {
+                index += 1;
+            }
+            index = (index + 2).min(bytes.len());
+            continue;
+        }
+        if matches!(bytes[index], b'\'' | b'"' | b'`') {
+            let quote = bytes[index];
+            let start = index;
+            index += 1;
+            let mut interpolation = false;
+            while index < bytes.len() {
+                if bytes[index] == b'\\' {
+                    index = (index + 2).min(bytes.len());
+                } else if quote == b'`'
+                    && bytes[index] == b'$'
+                    && bytes.get(index + 1) == Some(&b'{')
+                {
+                    interpolation = true;
+                    index += 2;
+                } else if bytes[index] == quote {
+                    index += 1;
+                    break;
+                } else {
+                    index += 1;
+                }
+            }
+            if !interpolation {
+                tokens.push(Token {
+                    kind: TokenKind::String,
+                    start: base + start,
+                    end: base + index,
+                });
+            }
+            continue;
+        }
+        if is_identifier_start(bytes[index]) {
+            let start = index;
+            index += 1;
+            while index < bytes.len() && is_identifier_continue(bytes[index]) {
+                index += 1;
+            }
+            tokens.push(Token {
+                kind: TokenKind::Ident(&text[start..index]),
+                start: base + start,
+                end: base + index,
+            });
+            continue;
+        }
+        tokens.push(Token {
+            kind: TokenKind::Punct(bytes[index]),
+            start: base + index,
+            end: base + index + 1,
+        });
+        index += 1;
+    }
+    tokens
+}
+
+const fn is_identifier_start(byte: u8) -> bool {
+    byte.is_ascii_alphabetic() || matches!(byte, b'_' | b'$')
+}
+
+const fn is_identifier_continue(byte: u8) -> bool {
+    is_identifier_start(byte) || byte.is_ascii_digit()
+}
+
+fn svelte_script_regions(text: &str) -> Vec<std::ops::Range<usize>> {
+    let lower = text.to_ascii_lowercase();
+    let mut regions = Vec::new();
+    let mut cursor = 0;
+    while let Some(relative_start) = lower[cursor..].find("<script") {
+        let tag_start = cursor + relative_start;
+        let Some(relative_open_end) = lower[tag_start..].find('>') else {
+            break;
+        };
+        let content_start = tag_start + relative_open_end + 1;
+        let Some(relative_close) = lower[content_start..].find("</script") else {
+            break;
+        };
+        let content_end = content_start + relative_close;
+        regions.push(content_start..content_end);
+        cursor = content_end + "</script".len();
+    }
+    regions
+}
+
+fn specifier_resolves_to(source_path: &Path, specifier: &str, target: &Path) -> bool {
+    let specifier = specifier
+        .split(['?', '#'])
+        .next()
+        .unwrap_or(specifier)
+        .replace('\\', "/");
+    let parent = source_path.parent().unwrap_or_else(|| Path::new(""));
+    let base = normalize_path(&parent.join(specifier));
+    resolution_candidates(&base).any(|candidate| candidate == target)
+}
+
+fn resolution_candidates(base: &Path) -> impl Iterator<Item = PathBuf> {
+    let mut candidates = vec![base.to_path_buf()];
+    match base.extension().and_then(|extension| extension.to_str()) {
+        None => {
+            for extension in MODULE_EXTENSIONS {
+                candidates.push(base.with_extension(extension));
+                candidates.push(base.join("index").with_extension(extension));
+            }
+        }
+        Some("js") => {
+            candidates.push(base.with_extension("ts"));
+            candidates.push(base.with_extension("tsx"));
+            if base.to_string_lossy().ends_with(".svelte.js") {
+                candidates.push(PathBuf::from(
+                    base.to_string_lossy().trim_end_matches(".js"),
+                ));
+            }
+        }
+        Some("mjs") => candidates.push(base.with_extension("mts")),
+        Some("cjs") => candidates.push(base.with_extension("cts")),
+        _ => {}
+    }
+    candidates.into_iter()
+}
+
+fn normalize_path(path: &Path) -> PathBuf {
+    let mut normalized = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::CurDir => {}
+            Component::ParentDir => {
+                if !normalized.pop() {
+                    normalized.push(component.as_os_str());
+                }
+            }
+            _ => normalized.push(component.as_os_str()),
+        }
+    }
+    normalized
+}
+
+fn non_zero_range(range: Range) -> bool {
+    range.start != range.end
+}
+
+fn parse_range(value: &Value) -> Option<Range> {
+    serde_json::from_value(value.clone()).ok()
+}
+
+fn utf8_position(text: &str, offset: usize) -> Position {
+    let offset = floor_char_boundary(text, offset);
+    let before = &text[..offset];
+    let line = before.bytes().filter(|byte| *byte == b'\n').count();
+    let line_start = before.rfind('\n').map_or(0, |index| index + 1);
+    Position::new(line as u32, (offset - line_start) as u32)
+}
+
+fn utf16_position(text: &str, offset: usize) -> Position {
+    let offset = floor_char_boundary(text, offset);
+    let before = &text[..offset];
+    let line = before.bytes().filter(|byte| *byte == b'\n').count();
+    let line_start = before.rfind('\n').map_or(0, |index| index + 1);
+    Position::new(
+        line as u32,
+        text[line_start..offset].encode_utf16().count() as u32,
+    )
+}
+
+fn utf16_offset(text: &str, position: Position) -> usize {
+    let line_start = if position.line == 0 {
+        0
+    } else {
+        text.match_indices('\n')
+            .nth(position.line as usize - 1)
+            .map_or(text.len(), |(offset, _)| offset + 1)
+    };
+    let line_end = text[line_start..]
+        .find('\n')
+        .map_or(text.len(), |offset| line_start + offset);
+    let mut units = 0u32;
+    for (offset, character) in text[line_start..line_end].char_indices() {
+        let width = character.len_utf16() as u32;
+        if units + width > position.character {
+            return line_start + offset;
+        }
+        units += width;
+        if units == position.character {
+            return line_start + offset + character.len_utf8();
+        }
+    }
+    line_end
+}
+
+fn floor_char_boundary(text: &str, offset: usize) -> usize {
+    let mut offset = offset.min(text.len());
+    while !text.is_char_boundary(offset) {
+        offset -= 1;
+    }
+    offset
+}
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+
+    use super::*;
+
+    fn uri(value: &str) -> Uri {
+        Uri::from_str(value).unwrap()
+    }
+
+    fn location(uri: &Uri, line: u32, start: u32, end: u32) -> Location {
+        Location::new(
+            uri.clone(),
+            Range::new(Position::new(line, start), Position::new(line, end)),
+        )
+    }
+
+    #[test]
+    fn component_probe_uses_the_last_generated_export() {
+        let generated = "Old__SvelteComponent_\né Final__SvelteComponent_";
+        assert_eq!(
+            component_probe_offset(generated),
+            Some(generated.rfind(COMPONENT_SUFFIX).unwrap())
+        );
+        assert_eq!(
+            component_probe_position(generated),
+            Some(Position::new(1, 8))
+        );
+    }
+
+    #[test]
+    fn component_references_omit_definitions_generated_ranges_and_end_tags() {
+        let component_uri = uri("file:///workspace/Parent.svelte");
+        let source = "<script>import Child from './Child.svelte';</script>\n<Child />\n</Child>";
+        let references = vec![
+            ComponentReference {
+                location: location(&component_uri, 0, 15, 20),
+                source_text: Some(source),
+                is_definition: false,
+                is_generated: false,
+            },
+            ComponentReference {
+                location: location(&component_uri, 1, 1, 6),
+                source_text: Some(source),
+                is_definition: false,
+                is_generated: false,
+            },
+            ComponentReference {
+                location: location(&component_uri, 2, 2, 7),
+                source_text: Some(source),
+                is_definition: false,
+                is_generated: false,
+            },
+            ComponentReference {
+                location: location(&component_uri, 1, 1, 1),
+                source_text: Some(source),
+                is_definition: false,
+                is_generated: false,
+            },
+            ComponentReference {
+                location: location(&component_uri, 1, 1, 6),
+                source_text: Some(source),
+                is_definition: true,
+                is_generated: false,
+            },
+            ComponentReference {
+                location: location(&component_uri, 1, 1, 6),
+                source_text: Some(source),
+                is_definition: false,
+                is_generated: true,
+            },
+        ];
+
+        assert_eq!(
+            filter_component_references(references),
+            vec![
+                location(&component_uri, 0, 15, 20),
+                location(&component_uri, 1, 1, 6)
+            ]
+        );
+    }
+
+    #[test]
+    fn file_references_cover_svelte_scripts_and_es_module_forms() {
+        let target_path = Path::new("/workspace/target.ts");
+        let ts_path = Path::new("/workspace/consumer.ts");
+        let svelte_path = Path::new("/workspace/Consumer.svelte");
+        let ts_uri = uri("file:///workspace/consumer.ts");
+        let svelte_uri = uri("file:///workspace/Consumer.svelte");
+        let ts = concat!(
+            "import { named } from './target';\n",
+            "import './target.js';\n",
+            "export { named as again } from './target';\n",
+            "const lazy = import('./target.js');\n",
+            "const common = require('./target');\n",
+            "const ordinary = './target';\n",
+        );
+        let svelte = concat!(
+            "<script context=\"module\">export * from './target';</script>\n",
+            "<script>import './target.js';</script>\n",
+            "<p>{import('./target')}</p>\n",
+        );
+        let sources = [
+            WorkspaceSource {
+                path: ts_path,
+                uri: &ts_uri,
+                text: ts,
+            },
+            WorkspaceSource {
+                path: svelte_path,
+                uri: &svelte_uri,
+                text: svelte,
+            },
+        ];
+
+        let locations = find_file_references(target_path, &sources);
+        assert_eq!(locations.len(), 7);
+        assert_eq!(
+            locations.iter().filter(|item| item.uri == ts_uri).count(),
+            5
+        );
+        assert_eq!(
+            locations
+                .iter()
+                .filter(|item| item.uri == svelte_uri)
+                .count(),
+            2
+        );
+        assert!(locations.iter().all(|item| non_zero_range(item.range)));
+        assert!(locations.windows(2).all(|pair| {
+            (
+                pair[0].uri.as_str(),
+                pair[0].range.start.line,
+                pair[0].range.start.character,
+            ) <= (
+                pair[1].uri.as_str(),
+                pair[1].range.start.line,
+                pair[1].range.start.character,
+            )
+        }));
+        let first_start = ts.find("./target").unwrap();
+        let first_ts = locations.iter().find(|item| item.uri == ts_uri).unwrap();
+        assert_eq!(
+            first_ts.range,
+            Range::new(
+                utf16_position(ts, first_start),
+                utf16_position(ts, first_start + "./target".len())
+            )
+        );
+    }
+
+    #[test]
+    fn file_references_match_the_official_svelte_fixture_range() {
+        let target = Path::new("/workspace/find-file-references-child.svelte");
+        let source_path = Path::new("/workspace/find-file-references-parent.svelte");
+        let source_uri = uri("file:///workspace/find-file-references-parent.svelte");
+        let source = concat!(
+            "<script>\n",
+            "import FindFileReferencesChild from \"./find-file-references-child.svelte\";\n",
+            "</script>"
+        );
+        let sources = [WorkspaceSource {
+            path: source_path,
+            uri: &source_uri,
+            text: source,
+        }];
+
+        let locations = find_file_references(target, &sources);
+        assert_eq!(locations, vec![location(&source_uri, 1, 37, 72)]);
+    }
+
+    #[test]
+    fn will_rename_params_use_old_and_prospective_shadow_uris() {
+        let old_source = uri("file:///workspace/Imported.svelte");
+        let old_shadow = uri("file:///cache/Imported.svelte.tsx");
+        let new_source = uri("file:///workspace/Documentation.svelte");
+        let new_shadow = uri("file:///cache/Documentation.svelte.tsx");
+        let mappings = [WillRenameMapping {
+            old: ShadowUriPair {
+                source_uri: &old_source,
+                shadow_uri: &old_shadow,
+            },
+            new: ShadowUriPair {
+                source_uri: &new_source,
+                shadow_uri: &new_shadow,
+            },
+        }];
+        let mut params = json!({
+            "files": [{ "oldUri": old_source.as_str(), "newUri": new_source.as_str() }]
+        });
+        let mut custom_params =
+            json!({ "oldUri": old_source.as_str(), "newUri": new_source.as_str() });
+
+        rewrite_will_rename_params(&mut params, &mappings);
+        rewrite_will_rename_params(&mut custom_params, &mappings);
+
+        assert_eq!(params["files"][0]["oldUri"], old_shadow.as_str());
+        assert_eq!(params["files"][0]["newUri"], new_shadow.as_str());
+        assert_eq!(custom_params["oldUri"], old_shadow.as_str());
+        assert_eq!(custom_params["newUri"], new_shadow.as_str());
+    }
+
+    #[test]
+    fn will_rename_result_rewrites_shadow_documents_and_filters_kit_types() {
+        let consumer_source = uri("file:///workspace/Consumer.svelte");
+        let consumer_shadow = uri("file:///cache/Consumer.svelte.tsx");
+        let imported_source = uri("file:///workspace/Imported.svelte");
+        let imported_shadow = uri("file:///cache/Imported.svelte.tsx");
+        let renamed_source = uri("file:///workspace/Documentation.svelte");
+        let renamed_shadow = uri("file:///cache/Documentation.svelte.tsx");
+        let route_source = uri("file:///workspace/sub/+page.svelte");
+        let route_shadow = uri("file:///cache/+page.svelte.tsx");
+        let kit_types = uri("file:///workspace/.svelte-kit/types/$types.d.ts");
+        let mapping = WillRenameMapping {
+            old: ShadowUriPair {
+                source_uri: &imported_source,
+                shadow_uri: &imported_shadow,
+            },
+            new: ShadowUriPair {
+                source_uri: &renamed_source,
+                shadow_uri: &renamed_shadow,
+            },
+        };
+        let documents = [
+            ShadowUriPair {
+                source_uri: &consumer_source,
+                shadow_uri: &consumer_shadow,
+            },
+            ShadowUriPair {
+                source_uri: &route_source,
+                shadow_uri: &route_shadow,
+            },
+        ];
+        let mut result = json!({
+            "changes": {
+                (consumer_shadow.as_str()): [{
+                    "range": { "start": { "line": 1, "character": 17 }, "end": { "line": 1, "character": 44 } },
+                    "newText": "./Documentation.svelte.tsx"
+                }],
+                (kit_types.as_str()): [{ "range": { "start": { "line": 0, "character": 0 }, "end": { "line": 0, "character": 1 } }, "newText": "x" }]
+            },
+            "documentChanges": [{
+                "textDocument": { "uri": route_shadow.as_str(), "version": null },
+                "edits": [
+                    { "range": { "start": { "line": 1, "character": 0 }, "end": { "line": 1, "character": 1 } }, "newText": "./$types.js" },
+                    { "range": { "start": { "line": 2, "character": 0 }, "end": { "line": 2, "character": 1 } }, "newText": "./Documentation.svelte.js" }
+                ]
+            }, {
+                "textDocument": { "uri": imported_shadow.as_str(), "version": null },
+                "edits": [
+                    { "range": { "start": { "line": 0, "character": 0 }, "end": { "line": 0, "character": 1 } }, "newText": "old" }
+                ]
+            }, {
+                "textDocument": { "uri": renamed_shadow.as_str(), "version": null },
+                "edits": [
+                    { "range": { "start": { "line": 0, "character": 0 }, "end": { "line": 0, "character": 1 } }, "newText": "new" },
+                    { "range": { "start": { "line": 1, "character": 0 }, "end": { "line": 1, "character": 1 } }, "newText": "newer" }
+                ]
+            }]
+        });
+
+        rewrite_will_rename_result(&mut result, &[mapping], &documents);
+
+        assert!(result["changes"].get(kit_types.as_str()).is_none());
+        assert_eq!(
+            result["changes"][consumer_source.as_str()][0]["newText"],
+            "./Documentation.svelte"
+        );
+        assert_eq!(
+            result["documentChanges"][0]["textDocument"]["uri"],
+            route_source.as_str()
+        );
+        assert_eq!(
+            result["documentChanges"][0]["edits"]
+                .as_array()
+                .unwrap()
+                .len(),
+            1
+        );
+        assert_eq!(
+            result["documentChanges"][0]["edits"][0]["newText"],
+            "./Documentation.svelte"
+        );
+        assert_eq!(result["documentChanges"].as_array().unwrap().len(), 2);
+        assert_eq!(
+            result["documentChanges"][1]["textDocument"]["uri"],
+            renamed_source.as_str()
+        );
+        assert_eq!(
+            result["documentChanges"][1]["edits"]
+                .as_array()
+                .unwrap()
+                .len(),
+            2
+        );
+    }
+
+    #[test]
+    fn code_lenses_drop_zero_ranges_and_preserve_resolve_data() {
+        let source_uri = uri("file:///workspace/references.svelte");
+        let mut result = json!([
+            {
+                "range": { "start": { "line": 1, "character": 14 }, "end": { "line": 1, "character": 17 } },
+                "data": { "type": "reference", "opaque": [1, 2, 3] }
+            },
+            {
+                "range": { "start": { "line": 4, "character": 2 }, "end": { "line": 4, "character": 2 } },
+                "data": { "type": "reference" }
+            }
+        ]);
+
+        prepare_code_lenses(&mut result, &source_uri);
+
+        assert_eq!(result.as_array().unwrap().len(), 1);
+        assert_eq!(result[0]["data"]["uri"], source_uri.as_str());
+        assert_eq!(result[0]["data"]["opaque"], json!([1, 2, 3]));
+        assert_eq!(code_lens_kind(&result[0]), Some(CodeLensKind::Reference));
+
+        assert_eq!(
+            component_reference_code_lens(&source_uri),
+            json!({
+                "range": {
+                    "start": { "line": 0, "character": 0 },
+                    "end": { "line": 0, "character": 1 }
+                },
+                "data": { "kind": "references", "uri": source_uri.as_str() }
+            })
+        );
+    }
+
+    #[test]
+    fn code_lens_kind_accepts_tsgo_and_legacy_discriminators() {
+        assert_eq!(
+            code_lens_kind(&json!({ "data": { "kind": "references" } })),
+            Some(CodeLensKind::Reference)
+        );
+        assert_eq!(
+            code_lens_kind(&json!({ "data": { "kind": "implementations" } })),
+            Some(CodeLensKind::Implementation)
+        );
+        assert_eq!(
+            code_lens_kind(&json!({ "data": { "type": "reference" } })),
+            Some(CodeLensKind::Reference)
+        );
+        assert_eq!(
+            code_lens_kind(&json!({ "data": { "type": "implementation" } })),
+            Some(CodeLensKind::Implementation)
+        );
+        assert_eq!(
+            code_lens_kind(&json!({ "data": { "kind": "unknown" } })),
+            None
+        );
+    }
+
+    #[test]
+    fn prepare_code_lenses_preserves_tsgo_resolve_data() {
+        let source_uri = uri("file:///workspace/references.svelte");
+        let mut result = json!([{
+            "range": {
+                "start": { "line": 1, "character": 14 },
+                "end": { "line": 1, "character": 17 }
+            },
+            "data": {
+                "kind": "references",
+                "uri": "file:///overlay/references.svelte.ts",
+                "opaque": { "future": true }
+            }
+        }]);
+
+        prepare_code_lenses(&mut result, &source_uri);
+
+        assert_eq!(code_lens_kind(&result[0]), Some(CodeLensKind::Reference));
+        assert_eq!(result[0]["data"]["uri"], source_uri.as_str());
+        assert_eq!(result[0]["data"]["opaque"], json!({ "future": true }));
+        assert_eq!(result[0]["data"]["kind"], "references");
+    }
+
+    #[test]
+    fn code_lens_commands_match_official_reference_and_implementation_shape() {
+        let source_uri = uri("file:///workspace/references.svelte");
+        let mut reference_lens = json!({
+            "range": { "start": { "line": 1, "character": 14 }, "end": { "line": 1, "character": 17 } },
+            "data": { "type": "reference" }
+        });
+        let references = vec![location(&source_uri, 5, 13, 16)];
+
+        assert!(resolve_code_lens(
+            &mut reference_lens,
+            CodeLensKind::Reference,
+            &source_uri,
+            references.clone()
+        ));
+        assert_eq!(reference_lens["command"]["title"], "1 reference");
+        assert_eq!(reference_lens["command"]["command"], "");
+        assert_eq!(
+            reference_lens["command"]["arguments"],
+            json!([
+                source_uri.as_str(),
+                { "line": 1, "character": 14 },
+                references
+            ])
+        );
+
+        let mut implementation_lens = reference_lens;
+        assert!(resolve_code_lens(
+            &mut implementation_lens,
+            CodeLensKind::Implementation,
+            &source_uri,
+            Vec::new()
+        ));
+        assert_eq!(implementation_lens["command"]["title"], "0 implementations");
+    }
+}

--- a/crates/rsvelte_language_server/src/tsgo_overlay.rs
+++ b/crates/rsvelte_language_server/src/tsgo_overlay.rs
@@ -857,7 +857,7 @@ impl TsgoOverlay {
         let suffix = lexical
             .strip_prefix(existing)
             .expect("nearest existing path is an ancestor");
-        let real = real_existing.join(suffix);
+        let real = join_existing_suffix(real_existing, suffix);
         if !real.starts_with(&self.workspace) {
             return Err(TsgoOverlayError::InvalidSource {
                 path: lexical,
@@ -878,7 +878,7 @@ impl TsgoOverlay {
         let suffix = lexical
             .strip_prefix(existing)
             .expect("nearest existing path is an ancestor");
-        let real = real_existing.join(suffix);
+        let real = join_existing_suffix(real_existing, suffix);
         if !real.starts_with(&self.workspace) {
             return Err(TsgoOverlayError::InvalidSource {
                 path: lexical,
@@ -1431,6 +1431,14 @@ fn nearest_existing_path(path: &Path) -> io::Result<&Path> {
     ))
 }
 
+fn join_existing_suffix(existing: PathBuf, suffix: &Path) -> PathBuf {
+    if suffix.as_os_str().is_empty() {
+        existing
+    } else {
+        existing.join(suffix)
+    }
+}
+
 fn absolute_normalized(path: &Path) -> PathBuf {
     let path = if path.is_absolute() {
         path.to_path_buf()
@@ -1512,6 +1520,15 @@ mod tests {
     fn write(path: &Path, text: &str) {
         fs::create_dir_all(path.parent().unwrap()).unwrap();
         fs::write(path, text).unwrap();
+    }
+
+    #[test]
+    fn an_existing_leaf_does_not_gain_an_empty_path_component() {
+        let existing = PathBuf::from("/workspace/src/App.svelte");
+        assert_eq!(
+            join_existing_suffix(existing.clone(), Path::new("")),
+            existing
+        );
     }
 
     #[test]

--- a/crates/rsvelte_language_server/src/tsgo_overlay.rs
+++ b/crates/rsvelte_language_server/src/tsgo_overlay.rs
@@ -1,0 +1,1792 @@
+//! Diskless Svelte projections for the tsgo LSP child process.
+//!
+//! tsgo only considers an in-memory file during module resolution when its
+//! parent directory exists. This module therefore persists the minimum viable
+//! project — a tsconfig, the svelte2tsx shims, and empty parent directories —
+//! while every generated `.svelte.tsx` body stays in memory.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::fmt;
+use std::fs;
+use std::io;
+use std::path::{Component, Path, PathBuf};
+use std::str::FromStr;
+
+use lsp_types::{Position, Range, Uri};
+use rsvelte_projection::{
+    ProjectionEngine, ProjectionMap, RewriteExternalImportsOptions, Svelte2TsxMode,
+    Svelte2TsxNamespace, Svelte2TsxOptions, SvelteVersion,
+};
+use serde_json::json;
+use sourcemap::SourceMap;
+
+use crate::text::LineIndex;
+
+const CACHE_DIRECTORY: &str = ".rsvelte-language-server";
+const TSGO_DIRECTORY: &str = "tsgo";
+const SHADOW_DIRECTORY: &str = "svelte";
+const OVERLAY_TSCONFIG: &str = "tsconfig.json";
+const SHIM_SHIMS_NAME: &str = "svelte-shims-v4.d.ts";
+const SHIM_JSX_NAME: &str = "svelte-jsx-v4.d.ts";
+const SHIM_SHIMS: &str =
+    include_str!("../../rsvelte_check/src/svelte_check/shims/svelte-shims-v4.d.ts");
+const SHIM_JSX: &str =
+    include_str!("../../rsvelte_check/src/svelte_check/shims/svelte-jsx-v4.d.ts");
+const IGNORE_START: &str = "/*Ωignore_startΩ*/";
+const IGNORE_END: &str = "/*Ωignore_endΩ*/";
+
+/// One virtual document to open or update in the tsgo child.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ShadowDocument {
+    /// URI of the user's `.svelte` document.
+    pub source_uri: Uri,
+    /// URI of `<cache>/svelte/<relative>.svelte.tsx`.
+    pub shadow_uri: Uri,
+    /// LSP language id sent to tsgo.
+    pub language_id: String,
+    /// Generated svelte2tsx body. This text is never persisted by the overlay.
+    pub text: String,
+    /// Document version sent to tsgo.
+    pub version: i32,
+}
+
+/// Observable invariants that prevent an unresolved component from silently
+/// falling through to ambient `declare module '*.svelte'` and becoming `any`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ShadowResolutionInfo {
+    /// Source component routed by this entry.
+    pub source_path: PathBuf,
+    /// Virtual TSX path tsgo must have open.
+    pub shadow_path: PathBuf,
+    /// Whether the source is confined to the workspace.
+    pub source_in_workspace: bool,
+    /// Whether the shadow is confined to the cache's `svelte` root.
+    pub shadow_in_cache: bool,
+    /// Whether tsgo's required on-disk parent directory exists.
+    pub parent_directory_exists: bool,
+    /// Whether an in-memory shadow body is registered for this route.
+    pub shadow_registered: bool,
+    /// Whether the overlay tsconfig's include pattern admits the shadow.
+    pub included_by_overlay_config: bool,
+    /// Whether the shadow body was accidentally written to disk.
+    pub body_exists_on_disk: bool,
+}
+
+impl ShadowResolutionInfo {
+    /// Whether the route has every invariant needed to avoid ambient-any
+    /// fallback while retaining diskless overlay semantics.
+    #[must_use]
+    pub const fn is_resolvable(&self) -> bool {
+        self.source_in_workspace
+            && self.shadow_in_cache
+            && self.parent_directory_exists
+            && self.shadow_registered
+            && self.included_by_overlay_config
+            && !self.body_exists_on_disk
+    }
+}
+
+/// Changes found while reconciling the eager project set with disk.
+#[derive(Debug, Default, Clone)]
+pub struct OverlayUpdate {
+    /// New or changed shadow buffers to send with `didOpen` / `didChange`.
+    pub opened_or_changed: Vec<ShadowDocument>,
+    /// Shadow URIs removed because their sources no longer exist.
+    pub closed: Vec<Uri>,
+}
+
+/// Failure to prepare or update an overlay.
+#[derive(Debug)]
+pub enum TsgoOverlayError {
+    /// Filesystem operation failed.
+    Io(io::Error),
+    /// A source path does not name a confined `.svelte` file.
+    InvalidSource { path: PathBuf, reason: &'static str },
+    /// svelte2tsx rejected a source document.
+    Projection { path: PathBuf, message: String },
+    /// A filesystem path could not be represented as a file URI.
+    InvalidUri(PathBuf),
+    /// The generated source map was malformed.
+    InvalidSourceMap { path: PathBuf, message: String },
+}
+
+impl fmt::Display for TsgoOverlayError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Io(error) => write!(f, "overlay I/O error: {error}"),
+            Self::InvalidSource { path, reason } => {
+                write!(f, "invalid Svelte source {}: {reason}", path.display())
+            }
+            Self::Projection { path, message } => {
+                write!(f, "svelte2tsx failed on {}: {message}", path.display())
+            }
+            Self::InvalidUri(path) => write!(f, "cannot encode {} as a file URI", path.display()),
+            Self::InvalidSourceMap { path, message } => {
+                write!(f, "invalid source map for {}: {message}", path.display())
+            }
+        }
+    }
+}
+
+impl std::error::Error for TsgoOverlayError {}
+
+impl From<io::Error> for TsgoOverlayError {
+    fn from(value: io::Error) -> Self {
+        Self::Io(value)
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct MappingToken {
+    generated_line: u32,
+    generated_column: u32,
+    source: Option<(u32, u32)>,
+}
+
+struct ShadowState {
+    document: ShadowDocument,
+    source_path: PathBuf,
+    shadow_path: PathBuf,
+    source_text: String,
+    source_index: LineIndex,
+    generated_index: LineIndex,
+    exact_map: ProjectionMap,
+    source_map: Option<String>,
+    tokens: Vec<MappingToken>,
+    generated_ranges: Vec<std::ops::Range<usize>>,
+    identity: bool,
+    plain_insertions: Vec<(usize, std::ops::Range<usize>)>,
+}
+
+/// Workspace-scoped diskless overlay used by the tsgo LSP proxy.
+pub struct TsgoOverlay {
+    workspace: PathBuf,
+    cache_dir: PathBuf,
+    shadow_dir: PathBuf,
+    tsconfig_path: PathBuf,
+    source_tsconfig: Option<PathBuf>,
+    engine: ProjectionEngine,
+    accessors: bool,
+    namespace: Svelte2TsxNamespace,
+    entries: BTreeMap<PathBuf, ShadowState>,
+    by_shadow: BTreeMap<PathBuf, PathBuf>,
+}
+
+impl fmt::Debug for TsgoOverlay {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("TsgoOverlay")
+            .field("workspace", &self.workspace)
+            .field("cache_dir", &self.cache_dir)
+            .field("tsconfig_path", &self.tsconfig_path)
+            .field("entries", &self.entries.len())
+            .finish_non_exhaustive()
+    }
+}
+
+impl TsgoOverlay {
+    /// Build the workspace overlay and project every `.svelte` source eagerly.
+    ///
+    /// `tsconfig` defaults to `tsconfig.json`, then `jsconfig.json`, when one
+    /// exists at the workspace root.
+    pub fn build(workspace: &Path, tsconfig: Option<&Path>) -> Result<Self, TsgoOverlayError> {
+        let workspace = absolute_normalized(workspace);
+        let workspace = fs::canonicalize(&workspace)?;
+        if !workspace.is_dir() {
+            return Err(TsgoOverlayError::InvalidSource {
+                path: workspace,
+                reason: "workspace is not a directory",
+            });
+        }
+
+        let cache_dir = workspace.join(CACHE_DIRECTORY).join(TSGO_DIRECTORY);
+        let shadow_dir = cache_dir.join(SHADOW_DIRECTORY);
+        reject_symlink_components(&cache_dir, &workspace)?;
+        fs::create_dir_all(&shadow_dir)?;
+        reject_symlink_components(&shadow_dir, &cache_dir)?;
+
+        let source_tsconfig = resolve_tsconfig(&workspace, tsconfig);
+        let tsconfig_path = cache_dir.join(OVERLAY_TSCONFIG);
+        let compiler = rsvelte_check::config::load_compiler_options(&workspace);
+        let mut overlay = Self {
+            workspace,
+            cache_dir,
+            shadow_dir,
+            tsconfig_path,
+            source_tsconfig,
+            engine: ProjectionEngine::new(),
+            accessors: compiler.projection_accessors(),
+            namespace: compiler.projection_namespace(),
+            entries: BTreeMap::new(),
+            by_shadow: BTreeMap::new(),
+        };
+        overlay.materialize_support_files()?;
+
+        for path in rsvelte_check::find_svelte_files(&overlay.workspace, &[]) {
+            let text = fs::read_to_string(&path)?;
+            overlay.open_or_update(&path, &text, 0)?;
+        }
+        overlay.write_tsconfig()?;
+        Ok(overlay)
+    }
+
+    /// Absolute workspace root.
+    #[must_use]
+    pub fn workspace(&self) -> &Path {
+        &self.workspace
+    }
+
+    /// Directory containing the persisted config, shims, and skeleton.
+    #[must_use]
+    pub fn cache_dir(&self) -> &Path {
+        &self.cache_dir
+    }
+
+    /// Overlay tsconfig to pass to tsgo.
+    #[must_use]
+    pub fn tsconfig_path(&self) -> &Path {
+        &self.tsconfig_path
+    }
+
+    /// Generate or replace one virtual shadow buffer.
+    pub fn open_or_update(
+        &mut self,
+        source_path: &Path,
+        text: &str,
+        version: i32,
+    ) -> Result<ShadowDocument, TsgoOverlayError> {
+        let source_path = self.confined_source(source_path)?;
+        let shadow_path = self.shadow_path_for(&source_path)?;
+        self.ensure_shadow_parent(&shadow_path)?;
+
+        let options = self.projection_options(&source_path, &shadow_path, text);
+        let artifact =
+            self.engine
+                .project(text, options)
+                .map_err(|error| TsgoOverlayError::Projection {
+                    path: source_path.clone(),
+                    message: error.to_string(),
+                })?;
+        let mut exact_map = artifact.exact_mappings.unwrap_or_default();
+        let source_map = artifact.source_map;
+        let mut tokens = parse_mapping_tokens(&source_path, source_map.as_deref())?;
+        let original_generated = artifact.code;
+        let original_index = LineIndex::new(&original_generated);
+        let (generated_text, import_insertions) = rewrite_plain_svelte_imports(&original_generated);
+        let insertion_positions = import_insertions
+            .iter()
+            .map(|(original_offset, generated_range)| {
+                (
+                    original_index.position(&original_generated, *original_offset),
+                    generated_range.len() as u32,
+                )
+            })
+            .collect::<Vec<_>>();
+        for token in &mut tokens {
+            token.generated_column += insertion_positions
+                .iter()
+                .filter(|(position, _)| {
+                    token.generated_line == position.line
+                        && token.generated_column >= position.character
+                })
+                .map(|(_, length)| *length)
+                .sum::<u32>();
+        }
+        for (_, generated_range) in &import_insertions {
+            exact_map.insert_generated(generated_range.start as u32, generated_range.len() as u32);
+        }
+        let document = ShadowDocument {
+            source_uri: path_to_uri(&source_path)?,
+            shadow_uri: path_to_uri(&shadow_path)?,
+            language_id: "typescriptreact".to_string(),
+            text: generated_text,
+            version,
+        };
+        let mut generated_ranges = ignored_ranges(&document.text);
+        generated_ranges.extend(
+            import_insertions
+                .iter()
+                .map(|(_, generated)| generated.clone()),
+        );
+        let state = ShadowState {
+            source_path: source_path.clone(),
+            shadow_path: shadow_path.clone(),
+            source_text: text.to_string(),
+            source_index: LineIndex::new(text),
+            generated_index: LineIndex::new(&document.text),
+            exact_map,
+            source_map,
+            tokens,
+            generated_ranges,
+            identity: false,
+            plain_insertions: Vec::new(),
+            document: document.clone(),
+        };
+        if let Some(old) = self.entries.insert(source_path.clone(), state) {
+            self.by_shadow.remove(&old.shadow_path);
+        }
+        self.by_shadow.insert(shadow_path, source_path);
+        Ok(document)
+    }
+
+    /// Route an open TypeScript or JavaScript buffer through the overlay
+    /// project without persisting its body.
+    pub fn open_plain(
+        &mut self,
+        source_path: &Path,
+        text: &str,
+        version: i32,
+        language_id: &str,
+    ) -> Result<ShadowDocument, TsgoOverlayError> {
+        let source_path = self.confined_any_source(source_path)?;
+        let relative = source_path.strip_prefix(&self.workspace).map_err(|_| {
+            TsgoOverlayError::InvalidSource {
+                path: source_path.clone(),
+                reason: "source escapes the workspace",
+            }
+        })?;
+        let shadow_path = self.shadow_dir.join(relative);
+        self.ensure_shadow_parent(&shadow_path)?;
+        let (generated_text, plain_insertions) = rewrite_plain_svelte_imports(text);
+        let document = ShadowDocument {
+            source_uri: path_to_uri(&source_path)?,
+            shadow_uri: path_to_uri(&shadow_path)?,
+            language_id: language_id.to_string(),
+            text: generated_text,
+            version,
+        };
+        let state = ShadowState {
+            source_path: source_path.clone(),
+            shadow_path: shadow_path.clone(),
+            source_text: text.to_string(),
+            source_index: LineIndex::new(text),
+            generated_index: LineIndex::new(text),
+            exact_map: ProjectionMap::default(),
+            tokens: Vec::new(),
+            source_map: None,
+            generated_ranges: Vec::new(),
+            identity: true,
+            plain_insertions,
+            document: document.clone(),
+        };
+        if let Some(old) = self.entries.insert(source_path.clone(), state) {
+            self.by_shadow.remove(&old.shadow_path);
+        }
+        self.by_shadow.insert(shadow_path, source_path);
+        Ok(document)
+    }
+
+    /// Remove a routed plain buffer and its empty directory skeleton.
+    pub fn close_plain(&mut self, source_path: &Path) -> Result<Option<Uri>, TsgoOverlayError> {
+        let source_path = self.lookup_source_path(source_path);
+        let uri = self
+            .entries
+            .get(&source_path)
+            .filter(|entry| entry.identity)
+            .map(|entry| entry.document.shadow_uri.clone());
+        if uri.is_some() {
+            self.remove_source(&source_path)?;
+        }
+        Ok(uri)
+    }
+
+    /// Re-project a source using its current on-disk contents.
+    pub fn update_from_disk(
+        &mut self,
+        source_path: &Path,
+        version: i32,
+    ) -> Result<ShadowDocument, TsgoOverlayError> {
+        let source_path = self.confined_source(source_path)?;
+        let text = fs::read_to_string(&source_path)?;
+        self.open_or_update(&source_path, &text, version)
+    }
+
+    /// Close an editor buffer while keeping its project shadow eagerly open.
+    ///
+    /// If the source remains on disk, the returned document contains a fresh
+    /// disk projection and should be sent as `didChange`. If the source was
+    /// deleted, its route is removed and `None` is returned; the caller should
+    /// send `didClose` for the previously known shadow URI.
+    pub fn close(
+        &mut self,
+        source_path: &Path,
+    ) -> Result<Option<ShadowDocument>, TsgoOverlayError> {
+        let source_path = self.confined_source(source_path)?;
+        if source_path.is_file() {
+            let next_version = self
+                .entries
+                .get(&source_path)
+                .map_or(0, |entry| entry.document.version.saturating_add(1));
+            return self.update_from_disk(&source_path, next_version).map(Some);
+        }
+        self.remove_source(&source_path)?;
+        Ok(None)
+    }
+
+    /// Reconcile eager shadows with the current workspace tree.
+    pub fn refresh(&mut self) -> Result<OverlayUpdate, TsgoOverlayError> {
+        let discovered = rsvelte_check::find_svelte_files(&self.workspace, &[])
+            .into_iter()
+            .map(|path| fs::canonicalize(&path).unwrap_or(path))
+            .collect::<BTreeSet<_>>();
+        let known = self
+            .entries
+            .iter()
+            .filter(|(_, entry)| !entry.identity)
+            .map(|(path, _)| path.clone())
+            .collect::<BTreeSet<_>>();
+        let mut update = OverlayUpdate::default();
+
+        for removed in known.difference(&discovered) {
+            if let Some(entry) = self.entries.get(removed) {
+                update.closed.push(entry.document.shadow_uri.clone());
+            }
+            self.remove_source(removed)?;
+        }
+        for path in &discovered {
+            let text = fs::read_to_string(path)?;
+            let unchanged = self
+                .entries
+                .get(path)
+                .is_some_and(|entry| entry.source_text == text);
+            if unchanged {
+                continue;
+            }
+            let version = self
+                .entries
+                .get(path)
+                .map_or(0, |entry| entry.document.version.saturating_add(1));
+            update
+                .opened_or_changed
+                .push(self.open_or_update(path, &text, version)?);
+        }
+        Ok(update)
+    }
+
+    /// Resolve a source path to its virtual shadow document.
+    #[must_use]
+    pub fn shadow_for_source(&self, source_path: &Path) -> Option<&ShadowDocument> {
+        let path = self.lookup_source_path(source_path);
+        self.entries.get(&path).map(|entry| &entry.document)
+    }
+
+    /// URI a `.svelte` source would use after a prospective file rename.
+    pub fn prospective_shadow_uri(&self, source_path: &Path) -> Result<Uri, TsgoOverlayError> {
+        let source_path = self.confined_source(source_path)?;
+        path_to_uri(&self.shadow_path_for(&source_path)?)
+    }
+
+    /// Resolve a virtual shadow path to its original source path.
+    #[must_use]
+    pub fn source_for_shadow(&self, shadow_path: &Path) -> Option<&Path> {
+        let shadow_path = absolute_normalized(shadow_path);
+        self.by_shadow.get(&shadow_path).map(PathBuf::as_path)
+    }
+
+    /// Every shadow that must be replayed after starting or restarting tsgo.
+    #[must_use]
+    pub fn eager_shadows(&self) -> Vec<&ShadowDocument> {
+        self.entries
+            .values()
+            .filter(|entry| !entry.identity)
+            .map(|entry| &entry.document)
+            .collect()
+    }
+
+    /// Every open virtual document owned by this workspace.
+    #[must_use]
+    pub fn open_shadows(&self) -> Vec<&ShadowDocument> {
+        self.entries.values().map(|entry| &entry.document).collect()
+    }
+
+    /// Exact mapping segments retained for one source projection.
+    #[must_use]
+    pub fn projection_map(&self, source_path: &Path) -> Option<&ProjectionMap> {
+        let path = self.lookup_source_path(source_path);
+        self.entries.get(&path).map(|entry| &entry.exact_map)
+    }
+
+    /// Original source text retained alongside one projection.
+    #[must_use]
+    pub fn source_text(&self, source_path: &Path) -> Option<&str> {
+        let path = self.lookup_source_path(source_path);
+        self.entries
+            .get(&path)
+            .map(|entry| entry.source_text.as_str())
+    }
+
+    /// Standard source map retained for rewritten-template position fallback.
+    #[must_use]
+    pub fn source_map(&self, source_path: &Path) -> Option<&str> {
+        let path = self.lookup_source_path(source_path);
+        self.entries
+            .get(&path)
+            .and_then(|entry| entry.source_map.as_deref())
+    }
+
+    /// Map an editor UTF-16 position to the tsgo UTF-8 shadow position.
+    #[must_use]
+    pub fn map_source_position(&self, source_path: &Path, position: Position) -> Option<Position> {
+        let path = self.lookup_source_path(source_path);
+        let entry = self.entries.get(&path)?;
+        let source_offset = entry.source_index.offset(&entry.source_text, position);
+
+        if entry.identity {
+            let generated_offset = source_offset
+                + entry
+                    .plain_insertions
+                    .iter()
+                    .filter(|(source, _)| *source <= source_offset)
+                    .map(|(_, generated)| generated.len())
+                    .sum::<usize>();
+            return Some(utf8_position(&entry.document.text, generated_offset));
+        }
+
+        if let Some(generated) = exact_source_offset(&entry.exact_map, source_offset) {
+            return Some(utf8_position(&entry.document.text, generated as usize));
+        }
+
+        let source_position = entry
+            .source_index
+            .position(&entry.source_text, source_offset);
+        let token = closest_source_token(&entry.tokens, source_position)?;
+        let generated_offset = entry.generated_index.offset(
+            &entry.document.text,
+            Position::new(token.generated_line, token.generated_column),
+        );
+        Some(utf8_position(&entry.document.text, generated_offset))
+    }
+
+    /// Map an editor UTF-16 range to the tsgo UTF-8 shadow range.
+    #[must_use]
+    pub fn map_source_range(&self, source_path: &Path, range: Range) -> Option<Range> {
+        let start = self.map_source_position(source_path, range.start)?;
+        let end = self.map_source_position(source_path, range.end)?;
+        Some(ordered_range(start, end))
+    }
+
+    /// Map a tsgo UTF-8 position back to the editor's UTF-16 source position.
+    #[must_use]
+    pub fn map_generated_position(
+        &self,
+        shadow_path: &Path,
+        position: Position,
+    ) -> Option<Position> {
+        let source_path = self.source_for_shadow(shadow_path)?;
+        let entry = self.entries.get(source_path)?;
+        let generated_offset = utf8_offset(&entry.document.text, position);
+        if entry.identity {
+            if entry
+                .plain_insertions
+                .iter()
+                .any(|(_, generated)| generated.contains(&generated_offset))
+            {
+                return None;
+            }
+            let source_offset = generated_offset
+                - entry
+                    .plain_insertions
+                    .iter()
+                    .filter(|(_, generated)| generated.end <= generated_offset)
+                    .map(|(_, generated)| generated.len())
+                    .sum::<usize>();
+            return Some(
+                entry
+                    .source_index
+                    .position(&entry.source_text, source_offset),
+            );
+        }
+        if entry
+            .generated_ranges
+            .iter()
+            .any(|range| range.contains(&generated_offset))
+        {
+            return None;
+        }
+
+        if let Some(source) = exact_generated_offset(&entry.exact_map, generated_offset) {
+            return Some(
+                entry
+                    .source_index
+                    .position(&entry.source_text, source as usize),
+            );
+        }
+
+        let generated_utf16 = entry
+            .generated_index
+            .position(&entry.document.text, generated_offset);
+        let index = entry.tokens.partition_point(|token| {
+            (token.generated_line, token.generated_column)
+                <= (generated_utf16.line, generated_utf16.character)
+        });
+        let previous = index.checked_sub(1).and_then(|i| entry.tokens.get(i))?;
+        if generated_is_unmapped_gap(&entry.tokens, index, generated_utf16) {
+            return None;
+        }
+        previous
+            .source
+            .map(|(line, column)| Position::new(line, column))
+    }
+
+    /// Map a tsgo UTF-8 range back to the editor's UTF-16 source range.
+    #[must_use]
+    pub fn map_generated_range(&self, shadow_path: &Path, range: Range) -> Option<Range> {
+        if self.is_generated_range(shadow_path, range) {
+            return None;
+        }
+        let start = self.map_generated_position(shadow_path, range.start)?;
+        let end = self.map_generated_position(shadow_path, range.end)?;
+        Some(ordered_range(start, end))
+    }
+
+    /// Whether a tsgo position falls inside an `Ωignore` generated-code region.
+    #[must_use]
+    pub fn is_generated_position(&self, shadow_path: &Path, position: Position) -> bool {
+        let Some(source_path) = self.source_for_shadow(shadow_path) else {
+            return false;
+        };
+        let Some(entry) = self.entries.get(source_path) else {
+            return false;
+        };
+        let offset = utf8_offset(&entry.document.text, position);
+        entry
+            .generated_ranges
+            .iter()
+            .any(|range| range.contains(&offset))
+    }
+
+    /// Whether any byte of a tsgo range intersects generated-code markers.
+    #[must_use]
+    pub fn is_generated_range(&self, shadow_path: &Path, range: Range) -> bool {
+        let Some(source_path) = self.source_for_shadow(shadow_path) else {
+            return false;
+        };
+        let Some(entry) = self.entries.get(source_path) else {
+            return false;
+        };
+        let start = utf8_offset(&entry.document.text, range.start);
+        let end = utf8_offset(&entry.document.text, range.end).max(start);
+        entry
+            .generated_ranges
+            .iter()
+            .any(|generated| generated.start < end && start < generated.end)
+    }
+
+    /// Resolution integrity for every eager shadow.
+    #[must_use]
+    pub fn resolution_info(&self) -> Vec<ShadowResolutionInfo> {
+        self.entries
+            .values()
+            .filter(|entry| !entry.identity)
+            .map(|entry| ShadowResolutionInfo {
+                source_path: entry.source_path.clone(),
+                shadow_path: entry.shadow_path.clone(),
+                source_in_workspace: entry.source_path.starts_with(&self.workspace),
+                shadow_in_cache: entry.shadow_path.starts_with(&self.shadow_dir),
+                parent_directory_exists: entry.shadow_path.parent().is_some_and(Path::is_dir),
+                shadow_registered: self
+                    .by_shadow
+                    .get(&entry.shadow_path)
+                    .is_some_and(|source| source == &entry.source_path),
+                included_by_overlay_config: entry
+                    .shadow_path
+                    .strip_prefix(&self.shadow_dir)
+                    .is_ok_and(|relative| {
+                        relative
+                            .as_os_str()
+                            .to_string_lossy()
+                            .ends_with(".svelte.tsx")
+                    }),
+                body_exists_on_disk: entry.shadow_path.exists(),
+            })
+            .collect()
+    }
+
+    /// Routes that would be vulnerable to silent ambient-any degradation.
+    #[must_use]
+    pub fn unresolved_shadow_routes(&self) -> Vec<ShadowResolutionInfo> {
+        self.resolution_info()
+            .into_iter()
+            .filter(|info| !info.is_resolvable())
+            .collect()
+    }
+
+    fn projection_options(
+        &self,
+        source_path: &Path,
+        shadow_path: &Path,
+        source: &str,
+    ) -> Svelte2TsxOptions {
+        Svelte2TsxOptions {
+            filename: source_path.display().to_string(),
+            is_ts_file: looks_like_typescript(source),
+            mode: Svelte2TsxMode::Ts,
+            accessors: self.accessors,
+            namespace: self.namespace,
+            version: SvelteVersion::V5,
+            runes: None,
+            emit_jsdoc: true,
+            rewrite_external_imports: Some(RewriteExternalImportsOptions {
+                source_path: source_path.display().to_string(),
+                generated_path: shadow_path.display().to_string(),
+                workspace_path: self.workspace.display().to_string(),
+            }),
+        }
+    }
+
+    fn materialize_support_files(&self) -> Result<(), TsgoOverlayError> {
+        reject_symlink_components(&self.cache_dir, &self.cache_dir)?;
+        let shims = self.cache_dir.join(SHIM_SHIMS_NAME);
+        let jsx = self.cache_dir.join(SHIM_JSX_NAME);
+        reject_symlink_components(&shims, &self.cache_dir)?;
+        reject_symlink_components(&jsx, &self.cache_dir)?;
+        write_if_changed(&shims, SHIM_SHIMS)?;
+        write_if_changed(&jsx, SHIM_JSX)?;
+        self.write_tsconfig()
+    }
+
+    fn write_tsconfig(&self) -> Result<(), TsgoOverlayError> {
+        let specs = self
+            .source_tsconfig
+            .as_deref()
+            .map(read_tsconfig_specs)
+            .unwrap_or_default();
+        let mut include = vec!["svelte/**/*".to_string()];
+        if let Some(user_include) = specs.include {
+            include.extend(user_include);
+        } else if specs.files.is_none() {
+            let root = self
+                .source_tsconfig
+                .as_deref()
+                .and_then(Path::parent)
+                .unwrap_or(&self.workspace);
+            include.push(format!("{}/**/*", path_for_tsconfig(root)));
+        }
+        let mut files = vec![SHIM_SHIMS_NAME.to_string(), SHIM_JSX_NAME.to_string()];
+        files.extend(specs.files.unwrap_or_default());
+        let mut config = json!({
+            "compilerOptions": {
+                "allowArbitraryExtensions": true,
+                "allowImportingTsExtensions": true,
+                "jsx": "preserve",
+                "noEmit": true,
+                "rootDirs": [
+                    path_for_tsconfig(&self.workspace),
+                    path_for_tsconfig(&self.shadow_dir)
+                ]
+            },
+            "files": files,
+            "include": include
+        });
+        if let Some(source) = &self.source_tsconfig {
+            config["extends"] = json!(path_for_tsconfig(source));
+        }
+        if let Some(exclude) = specs.exclude {
+            config["exclude"] = json!(exclude);
+        }
+        let mut text = serde_json::to_string_pretty(&config).expect("JSON values are serializable");
+        text.push('\n');
+        reject_symlink_components(&self.tsconfig_path, &self.cache_dir)?;
+        write_if_changed(&self.tsconfig_path, &text)
+    }
+
+    fn shadow_path_for(&self, source_path: &Path) -> Result<PathBuf, TsgoOverlayError> {
+        let relative = source_path.strip_prefix(&self.workspace).map_err(|_| {
+            TsgoOverlayError::InvalidSource {
+                path: source_path.to_path_buf(),
+                reason: "source escapes the workspace",
+            }
+        })?;
+        if relative.components().any(|component| {
+            matches!(
+                component,
+                Component::ParentDir | Component::RootDir | Component::Prefix(_)
+            )
+        }) {
+            return Err(TsgoOverlayError::InvalidSource {
+                path: source_path.to_path_buf(),
+                reason: "source contains an escaping path component",
+            });
+        }
+        let mut shadow = self.shadow_dir.join(relative).into_os_string();
+        shadow.push(".tsx");
+        Ok(PathBuf::from(shadow))
+    }
+
+    fn ensure_shadow_parent(&self, shadow_path: &Path) -> Result<(), TsgoOverlayError> {
+        let parent = shadow_path
+            .parent()
+            .ok_or_else(|| TsgoOverlayError::InvalidSource {
+                path: shadow_path.to_path_buf(),
+                reason: "shadow has no parent directory",
+            })?;
+        reject_symlink_components(parent, &self.cache_dir)?;
+        fs::create_dir_all(parent)?;
+        reject_symlink_components(parent, &self.cache_dir)?;
+        reject_symlink_components(shadow_path, &self.cache_dir)?;
+        if shadow_path.exists() {
+            return Err(TsgoOverlayError::InvalidSource {
+                path: shadow_path.to_path_buf(),
+                reason: "diskless shadow path already exists on disk",
+            });
+        }
+        Ok(())
+    }
+
+    fn confined_source(&self, source_path: &Path) -> Result<PathBuf, TsgoOverlayError> {
+        let lexical = if source_path.is_absolute() {
+            absolute_normalized(source_path)
+        } else {
+            absolute_normalized(&self.workspace.join(source_path))
+        };
+        if lexical
+            .extension()
+            .is_none_or(|extension| extension != "svelte")
+        {
+            return Err(TsgoOverlayError::InvalidSource {
+                path: lexical,
+                reason: "source does not end in .svelte",
+            });
+        }
+        let existing = nearest_existing_path(&lexical)?;
+        let real_existing = fs::canonicalize(existing)?;
+        let suffix = lexical
+            .strip_prefix(existing)
+            .expect("nearest existing path is an ancestor");
+        let real = real_existing.join(suffix);
+        if !real.starts_with(&self.workspace) {
+            return Err(TsgoOverlayError::InvalidSource {
+                path: lexical,
+                reason: "source is redirected outside the workspace by a symlink",
+            });
+        }
+        Ok(fs::canonicalize(&real).unwrap_or(real))
+    }
+
+    fn confined_any_source(&self, source_path: &Path) -> Result<PathBuf, TsgoOverlayError> {
+        let lexical = if source_path.is_absolute() {
+            absolute_normalized(source_path)
+        } else {
+            absolute_normalized(&self.workspace.join(source_path))
+        };
+        let existing = nearest_existing_path(&lexical)?;
+        let real_existing = fs::canonicalize(existing)?;
+        let suffix = lexical
+            .strip_prefix(existing)
+            .expect("nearest existing path is an ancestor");
+        let real = real_existing.join(suffix);
+        if !real.starts_with(&self.workspace) {
+            return Err(TsgoOverlayError::InvalidSource {
+                path: lexical,
+                reason: "source is redirected outside the workspace by a symlink",
+            });
+        }
+        Ok(fs::canonicalize(&real).unwrap_or(real))
+    }
+
+    fn lookup_source_path(&self, source_path: &Path) -> PathBuf {
+        let path = if source_path.is_absolute() {
+            absolute_normalized(source_path)
+        } else {
+            absolute_normalized(&self.workspace.join(source_path))
+        };
+        fs::canonicalize(&path).unwrap_or(path)
+    }
+
+    fn remove_source(&mut self, source_path: &Path) -> Result<(), TsgoOverlayError> {
+        let Some(entry) = self.entries.remove(source_path) else {
+            return Ok(());
+        };
+        self.by_shadow.remove(&entry.shadow_path);
+        self.prune_empty_skeleton(entry.shadow_path.parent())
+    }
+
+    fn prune_empty_skeleton(&self, mut current: Option<&Path>) -> Result<(), TsgoOverlayError> {
+        while let Some(directory) = current {
+            if directory == self.shadow_dir {
+                break;
+            }
+            reject_symlink_components(directory, &self.cache_dir)?;
+            match fs::remove_dir(directory) {
+                Ok(()) => current = directory.parent(),
+                Err(error) if error.kind() == io::ErrorKind::DirectoryNotEmpty => break,
+                Err(error) if error.kind() == io::ErrorKind::NotFound => {
+                    current = directory.parent();
+                }
+                Err(error) => return Err(error.into()),
+            }
+        }
+        Ok(())
+    }
+}
+
+fn resolve_tsconfig(workspace: &Path, explicit: Option<&Path>) -> Option<PathBuf> {
+    if let Some(explicit) = explicit {
+        let path = if explicit.is_absolute() {
+            explicit.to_path_buf()
+        } else {
+            workspace.join(explicit)
+        };
+        return Some(absolute_normalized(&path));
+    }
+    ["tsconfig.json", "jsconfig.json"]
+        .into_iter()
+        .map(|name| workspace.join(name))
+        .find(|path| path.is_file())
+}
+
+#[derive(Debug, Default)]
+struct InheritedConfigSpecs {
+    include: Option<Vec<String>>,
+    exclude: Option<Vec<String>>,
+    files: Option<Vec<String>>,
+}
+
+fn read_tsconfig_specs(tsconfig: &Path) -> InheritedConfigSpecs {
+    let config_dir = tsconfig.parent().unwrap_or_else(|| Path::new("."));
+    let rebase = |key: &str| {
+        resolve_config_specs(tsconfig, key).map(|(specs, base)| {
+            specs
+                .into_iter()
+                .filter(|spec| key != "files" || !spec.ends_with(".svelte"))
+                .map(|spec| rebase_config_spec(&spec, &base, config_dir))
+                .collect()
+        })
+    };
+    InheritedConfigSpecs {
+        include: rebase("include"),
+        exclude: rebase("exclude"),
+        files: rebase("files"),
+    }
+}
+
+const MAX_EXTENDS_CONFIGS: usize = 32;
+
+fn resolve_config_specs(tsconfig: &Path, key: &str) -> Option<(Vec<String>, PathBuf)> {
+    let mut pending = vec![absolute_normalized(tsconfig)];
+    let mut seen = BTreeSet::new();
+    let mut visited = 0usize;
+    while let Some(path) = pending.pop() {
+        if visited == MAX_EXTENDS_CONFIGS || !seen.insert(path.clone()) {
+            continue;
+        }
+        visited += 1;
+        let Ok(raw) = fs::read_to_string(&path) else {
+            continue;
+        };
+        let Some(parsed) = parse_jsonc(&raw) else {
+            continue;
+        };
+        let base = path
+            .parent()
+            .unwrap_or_else(|| Path::new("."))
+            .to_path_buf();
+        if let Some(specs) = parsed.get(key).and_then(serde_json::Value::as_array) {
+            return Some((
+                specs
+                    .iter()
+                    .filter_map(serde_json::Value::as_str)
+                    .map(str::to_string)
+                    .collect(),
+                base,
+            ));
+        }
+        let parents = match parsed.get("extends") {
+            Some(serde_json::Value::String(parent)) => vec![parent.as_str()],
+            Some(serde_json::Value::Array(parents)) => parents
+                .iter()
+                .filter_map(serde_json::Value::as_str)
+                .collect(),
+            _ => Vec::new(),
+        };
+        pending.extend(
+            parents
+                .into_iter()
+                .filter_map(|parent| resolve_extends_target(&base, parent)),
+        );
+    }
+    None
+}
+
+fn resolve_extends_target(base: &Path, specifier: &str) -> Option<PathBuf> {
+    if specifier.starts_with('.') || Path::new(specifier).is_absolute() {
+        return Some(resolve_extends_path(base, specifier));
+    }
+    let mut cursor = Some(absolute_normalized(base));
+    while let Some(directory) = cursor {
+        let candidate = directory.join("node_modules").join(specifier);
+        for path in config_path_candidates(candidate) {
+            if path.is_file() {
+                return Some(path);
+            }
+        }
+        cursor = directory.parent().map(Path::to_path_buf);
+    }
+    None
+}
+
+fn resolve_extends_path(base: &Path, specifier: &str) -> PathBuf {
+    config_path_candidates(base.join(specifier))
+        .into_iter()
+        .find(|path| path.exists())
+        .unwrap_or_else(|| base.join(specifier))
+}
+
+fn config_path_candidates(path: PathBuf) -> Vec<PathBuf> {
+    if path.is_dir() {
+        return vec![path.join("tsconfig.json")];
+    }
+    if path.extension().is_none() {
+        let mut json = path.clone();
+        json.set_extension("json");
+        vec![path.join("tsconfig.json"), json, path]
+    } else {
+        vec![path]
+    }
+}
+
+fn rebase_config_spec(spec: &str, base: &Path, config_dir: &Path) -> String {
+    let project_dir = path_for_tsconfig(config_dir);
+    let substituted = spec.replace("${configDir}", &project_dir);
+    if Path::new(&substituted).is_absolute() {
+        substituted.replace('\\', "/")
+    } else {
+        path_for_tsconfig(&absolute_normalized(&base.join(substituted)))
+    }
+}
+
+fn parse_jsonc(source: &str) -> Option<serde_json::Value> {
+    serde_json::from_str(&strip_jsonc(&strip_trailing_jsonc_commas(source))).ok()
+}
+
+fn strip_trailing_jsonc_commas(source: &str) -> String {
+    let without_comments = strip_jsonc(source);
+    let bytes = without_comments.as_bytes();
+    let mut output = Vec::with_capacity(bytes.len());
+    let mut index = 0usize;
+    let mut in_string = false;
+    let mut escaped = false;
+    while index < bytes.len() {
+        let byte = bytes[index];
+        if in_string {
+            output.push(byte);
+            if escaped {
+                escaped = false;
+            } else if byte == b'\\' {
+                escaped = true;
+            } else if byte == b'"' {
+                in_string = false;
+            }
+            index += 1;
+            continue;
+        }
+        if byte == b'"' {
+            in_string = true;
+            output.push(byte);
+            index += 1;
+            continue;
+        }
+        if byte == b',' {
+            let mut next = index + 1;
+            while bytes.get(next).is_some_and(u8::is_ascii_whitespace) {
+                next += 1;
+            }
+            if bytes
+                .get(next)
+                .is_some_and(|next| matches!(next, b'}' | b']'))
+            {
+                index += 1;
+                continue;
+            }
+        }
+        output.push(byte);
+        index += 1;
+    }
+    String::from_utf8(output).ok().unwrap_or_default()
+}
+
+fn strip_jsonc(source: &str) -> String {
+    let bytes = source.as_bytes();
+    let mut output = Vec::with_capacity(bytes.len());
+    let mut index = 0usize;
+    let mut in_string = false;
+    let mut escaped = false;
+    while index < bytes.len() {
+        let byte = bytes[index];
+        if in_string {
+            output.push(byte);
+            if escaped {
+                escaped = false;
+            } else if byte == b'\\' {
+                escaped = true;
+            } else if byte == b'"' {
+                in_string = false;
+            }
+            index += 1;
+            continue;
+        }
+        if byte == b'"' {
+            in_string = true;
+            output.push(byte);
+            index += 1;
+            continue;
+        }
+        if byte == b'/' && index + 1 < bytes.len() {
+            match bytes[index + 1] {
+                b'/' => {
+                    while index < bytes.len() && bytes[index] != b'\n' {
+                        index += 1;
+                    }
+                    continue;
+                }
+                b'*' => {
+                    index += 2;
+                    while index + 1 < bytes.len()
+                        && !(bytes[index] == b'*' && bytes[index + 1] == b'/')
+                    {
+                        index += 1;
+                    }
+                    index = (index + 2).min(bytes.len());
+                    continue;
+                }
+                _ => {}
+            }
+        }
+        output.push(byte);
+        index += 1;
+    }
+    String::from_utf8(output).ok().unwrap_or_default()
+}
+
+fn parse_mapping_tokens(
+    source_path: &Path,
+    raw: Option<&str>,
+) -> Result<Vec<MappingToken>, TsgoOverlayError> {
+    let Some(raw) = raw else {
+        return Ok(Vec::new());
+    };
+    let map = SourceMap::from_slice(raw.as_bytes()).map_err(|error| {
+        TsgoOverlayError::InvalidSourceMap {
+            path: source_path.to_path_buf(),
+            message: error.to_string(),
+        }
+    })?;
+    let mut tokens = map
+        .tokens()
+        .map(|token| MappingToken {
+            generated_line: token.get_dst_line(),
+            generated_column: token.get_dst_col(),
+            source: token
+                .get_source()
+                .map(|_| (token.get_src_line(), token.get_src_col())),
+        })
+        .collect::<Vec<_>>();
+    tokens.sort_by_key(|token| (token.generated_line, token.generated_column));
+    Ok(tokens)
+}
+
+fn rewrite_plain_svelte_imports(source: &str) -> (String, Vec<(usize, std::ops::Range<usize>)>) {
+    let bytes = source.as_bytes();
+    let mut insertions = Vec::new();
+    let mut index = 0;
+    while index < bytes.len() {
+        let quote = bytes[index];
+        if !matches!(quote, b'\'' | b'"' | b'`') {
+            index += 1;
+            continue;
+        }
+        let start = index;
+        index += 1;
+        let content_start = index;
+        while index < bytes.len() {
+            if bytes[index] == b'\\' {
+                index = (index + 2).min(bytes.len());
+                continue;
+            }
+            if bytes[index] == quote {
+                break;
+            }
+            index += 1;
+        }
+        if index >= bytes.len() {
+            break;
+        }
+        let content = &source[content_start..index];
+        let svelte_end = content
+            .rfind(".svelte")
+            .map(|offset| content_start + offset + 7);
+        let suffix_ok = svelte_end
+            .is_some_and(|end| end == index || matches!(bytes.get(end), Some(b'?' | b'#')));
+        let prefix = source[..start].trim_end();
+        let module_context = prefix.ends_with("from")
+            || prefix.ends_with("import")
+            || prefix.ends_with("import(")
+            || prefix.ends_with("require(");
+        if suffix_ok && module_context {
+            insertions.push(svelte_end.expect("checked above"));
+        }
+        index += 1;
+    }
+
+    let mut generated = source.to_string();
+    for &offset in insertions.iter().rev() {
+        generated.insert_str(offset, ".tsx");
+    }
+    let ranges = insertions
+        .into_iter()
+        .enumerate()
+        .map(|(index, source)| {
+            let start = source + index * 4;
+            (source, start..start + 4)
+        })
+        .collect();
+    (generated, ranges)
+}
+
+fn closest_source_token(tokens: &[MappingToken], source: Position) -> Option<MappingToken> {
+    tokens
+        .iter()
+        .filter_map(|token| {
+            let (line, column) = token.source?;
+            (line == source.line).then_some((column.abs_diff(source.character), *token))
+        })
+        .min_by_key(|(distance, token)| (*distance, token.generated_line, token.generated_column))
+        .map(|(_, token)| token)
+}
+
+fn exact_source_offset(map: &ProjectionMap, offset: usize) -> Option<u32> {
+    let offset = u32::try_from(offset).ok()?;
+    if let Some(generated) = map.source_to_generated(offset).first() {
+        return Some(*generated);
+    }
+    map.segments()
+        .iter()
+        .find(|segment| segment.source.end() == offset)
+        .map(|segment| segment.generated.end())
+}
+
+fn exact_generated_offset(map: &ProjectionMap, offset: usize) -> Option<u32> {
+    let offset = u32::try_from(offset).ok()?;
+    if let Some(source) = map.generated_to_source(offset) {
+        return Some(source);
+    }
+    map.segments()
+        .iter()
+        .find(|segment| segment.generated.end() == offset)
+        .map(|segment| segment.source.end())
+}
+
+fn generated_is_unmapped_gap(
+    tokens: &[MappingToken],
+    next_index: usize,
+    position: Position,
+) -> bool {
+    let Some(previous) = next_index.checked_sub(1).and_then(|i| tokens.get(i)) else {
+        return true;
+    };
+    if (previous.generated_line, previous.generated_column) == (position.line, position.character) {
+        return previous.source.is_none();
+    }
+    let Some(next) = tokens.get(next_index) else {
+        return false;
+    };
+    next.generated_line == position.line
+        && previous.source.is_some()
+        && previous.source == next.source
+}
+
+fn ignored_ranges(text: &str) -> Vec<std::ops::Range<usize>> {
+    let mut ranges = Vec::new();
+    let mut cursor = 0;
+    while let Some(relative_start) = text[cursor..].find(IGNORE_START) {
+        let start = cursor + relative_start;
+        let content_start = start + IGNORE_START.len();
+        let Some(relative_end) = text[content_start..].find(IGNORE_END) else {
+            ranges.push(start..text.len());
+            break;
+        };
+        let end = content_start + relative_end + IGNORE_END.len();
+        ranges.push(start..end);
+        cursor = end;
+    }
+    ranges
+}
+
+fn ordered_range(start: Position, end: Position) -> Range {
+    if (start.line, start.character) <= (end.line, end.character) {
+        Range::new(start, end)
+    } else {
+        Range::new(end, start)
+    }
+}
+
+fn looks_like_typescript(source: &str) -> bool {
+    let lower = source.to_ascii_lowercase();
+    lower.contains("lang=\"ts\"") || lower.contains("lang='ts'") || lower.contains("lang=ts")
+}
+
+fn utf8_position(text: &str, offset: usize) -> Position {
+    let offset = floor_char_boundary(text, offset.min(text.len()));
+    let line = text.as_bytes()[..offset]
+        .iter()
+        .filter(|byte| **byte == b'\n')
+        .count();
+    let line_start = text.as_bytes()[..offset]
+        .iter()
+        .rposition(|byte| *byte == b'\n')
+        .map_or(0, |position| position + 1);
+    Position::new(
+        u32::try_from(line).unwrap_or(u32::MAX),
+        u32::try_from(offset - line_start).unwrap_or(u32::MAX),
+    )
+}
+
+fn utf8_offset(text: &str, position: Position) -> usize {
+    let mut line = 0u32;
+    let mut line_start = 0usize;
+    for (index, byte) in text.bytes().enumerate() {
+        if line == position.line {
+            break;
+        }
+        if byte == b'\n' {
+            line += 1;
+            line_start = index + 1;
+        }
+    }
+    if line != position.line {
+        return text.len();
+    }
+    let line_end = text[line_start..]
+        .find('\n')
+        .map_or(text.len(), |relative| line_start + relative);
+    floor_char_boundary(
+        text,
+        line_start
+            .saturating_add(position.character as usize)
+            .min(line_end),
+    )
+}
+
+fn floor_char_boundary(text: &str, mut offset: usize) -> usize {
+    while offset > 0 && !text.is_char_boundary(offset) {
+        offset -= 1;
+    }
+    offset
+}
+
+fn write_if_changed(path: &Path, contents: &str) -> Result<(), TsgoOverlayError> {
+    if fs::read_to_string(path).is_ok_and(|existing| existing == contents) {
+        return Ok(());
+    }
+    fs::write(path, contents)?;
+    Ok(())
+}
+
+fn reject_symlink_components(path: &Path, cache_dir: &Path) -> io::Result<()> {
+    let relative = path.strip_prefix(cache_dir).map_err(|_| {
+        io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            format!("overlay path escapes cache: {}", path.display()),
+        )
+    })?;
+    let mut current = cache_dir.to_path_buf();
+    reject_symlink(&current)?;
+    for component in relative.components() {
+        current.push(component.as_os_str());
+        reject_symlink(&current)?;
+    }
+    Ok(())
+}
+
+fn reject_symlink(path: &Path) -> io::Result<()> {
+    match fs::symlink_metadata(path) {
+        Ok(metadata) if metadata.file_type().is_symlink() => Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            format!("overlay cache path contains a symlink: {}", path.display()),
+        )),
+        Ok(_) => Ok(()),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(error),
+    }
+}
+
+fn nearest_existing_path(path: &Path) -> io::Result<&Path> {
+    let mut current = Some(path);
+    while let Some(candidate) = current {
+        match fs::symlink_metadata(candidate) {
+            Ok(_) => return Ok(candidate),
+            Err(error) if error.kind() == io::ErrorKind::NotFound => {
+                current = candidate.parent();
+            }
+            Err(error) => return Err(error),
+        }
+    }
+    Err(io::Error::new(
+        io::ErrorKind::NotFound,
+        format!("no existing ancestor for {}", path.display()),
+    ))
+}
+
+fn absolute_normalized(path: &Path) -> PathBuf {
+    let path = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        std::env::current_dir()
+            .unwrap_or_else(|_| PathBuf::from("."))
+            .join(path)
+    };
+    let mut normalized = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::CurDir => {}
+            Component::ParentDir => {
+                if matches!(
+                    normalized.components().next_back(),
+                    Some(Component::Normal(_))
+                ) {
+                    normalized.pop();
+                }
+            }
+            other => normalized.push(other.as_os_str()),
+        }
+    }
+    normalized
+}
+
+fn path_for_tsconfig(path: &Path) -> String {
+    path.to_string_lossy().replace('\\', "/")
+}
+
+fn path_to_uri(path: &Path) -> Result<Uri, TsgoOverlayError> {
+    let path = path_for_tsconfig(path);
+    let mut encoded = String::with_capacity(path.len() + 8);
+    for byte in path.bytes() {
+        if byte.is_ascii_alphanumeric() || matches!(byte, b'/' | b':' | b'-' | b'_' | b'.' | b'~') {
+            encoded.push(char::from(byte));
+        } else {
+            use std::fmt::Write as _;
+            write!(&mut encoded, "%{byte:02X}").expect("writing to String cannot fail");
+        }
+    }
+    let prefix = if encoded.starts_with('/') {
+        "file://"
+    } else {
+        "file:///"
+    };
+    Uri::from_str(&format!("{prefix}{encoded}"))
+        .map_err(|_| TsgoOverlayError::InvalidUri(path.to_owned().into()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    struct TestWorkspace(PathBuf);
+
+    impl TestWorkspace {
+        fn new(name: &str) -> Self {
+            let nonce = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_nanos();
+            let root = std::env::temp_dir().join(format!(
+                "rsvelte-tsgo-overlay-{name}-{}-{nonce}",
+                std::process::id()
+            ));
+            fs::create_dir_all(&root).unwrap();
+            Self(root)
+        }
+    }
+
+    impl Drop for TestWorkspace {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.0);
+        }
+    }
+
+    fn write(path: &Path, text: &str) {
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(path, text).unwrap();
+    }
+
+    #[test]
+    fn build_is_diskless_and_discovers_project_components() {
+        let workspace = TestWorkspace::new("build");
+        let app = workspace.0.join("src/App.svelte");
+        let nested = workspace.0.join("src/lib/Nested.svelte");
+        write(&app, "<h1>Hello</h1>");
+        write(&nested, "<p>Nested</p>");
+        write(
+            &workspace.0.join("node_modules/pkg/Skipped.svelte"),
+            "<p>skip</p>",
+        );
+
+        let overlay = TsgoOverlay::build(&workspace.0, None).unwrap();
+        assert_eq!(overlay.eager_shadows().len(), 2);
+        let shadow = overlay.shadow_for_source(&app).unwrap();
+        let shadow_path = overlay.shadow_dir.join("src/App.svelte.tsx");
+        assert_eq!(shadow.shadow_uri, path_to_uri(&shadow_path).unwrap());
+        assert!(shadow_path.parent().unwrap().is_dir());
+        assert!(!shadow_path.exists());
+        assert!(overlay.tsconfig_path().is_file());
+        assert!(overlay.cache_dir().join(SHIM_SHIMS_NAME).is_file());
+        assert!(overlay.cache_dir().join(SHIM_JSX_NAME).is_file());
+        assert!(overlay.unresolved_shadow_routes().is_empty());
+    }
+
+    #[test]
+    fn overlay_config_merges_inherited_plain_project_specs() {
+        let workspace = TestWorkspace::new("config-specs");
+        write(
+            &workspace.0.join("configs/base.json"),
+            r#"{
+                // inherited independently from the root config
+                "include": ["../src/**/*.ts",],
+                "files": ["../ambient.d.ts", "../Ignored.svelte"],
+                "exclude": ["../src/generated/**"]
+            }"#,
+        );
+        write(
+            &workspace.0.join("tsconfig.json"),
+            r#"{ "extends": "./configs/base.json", "compilerOptions": { "strict": true } }"#,
+        );
+        write(&workspace.0.join("src/main.ts"), "export const main = 1;");
+        write(
+            &workspace.0.join("ambient.d.ts"),
+            "declare const ambient: 1;",
+        );
+        write(&workspace.0.join("App.svelte"), "<p>{ambient}</p>");
+
+        let overlay = TsgoOverlay::build(&workspace.0, None).unwrap();
+        let config: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(overlay.tsconfig_path()).unwrap()).unwrap();
+        let include = config["include"].as_array().unwrap();
+        assert!(include.contains(&json!("svelte/**/*")));
+        assert!(include.contains(&json!(path_for_tsconfig(
+            &overlay.workspace().join("src/**/*.ts")
+        ))));
+        let files = config["files"].as_array().unwrap();
+        assert!(files.contains(&json!(SHIM_SHIMS_NAME)));
+        assert!(files.contains(&json!(SHIM_JSX_NAME)));
+        assert!(files.contains(&json!(path_for_tsconfig(
+            &overlay.workspace().join("ambient.d.ts")
+        ))));
+        assert!(!files.iter().any(|file| {
+            file.as_str()
+                .is_some_and(|file| file.ends_with("Ignored.svelte"))
+        }));
+        assert_eq!(
+            config["exclude"],
+            json!([path_for_tsconfig(
+                &overlay.workspace().join("src/generated/**")
+            )])
+        );
+    }
+
+    #[test]
+    fn config_without_file_specs_keeps_default_plain_project_membership() {
+        let workspace = TestWorkspace::new("config-default-include");
+        write(
+            &workspace.0.join("tsconfig.json"),
+            r#"{ "compilerOptions": { "strict": true } }"#,
+        );
+        write(&workspace.0.join("src/main.ts"), "export const main = 1;");
+        write(&workspace.0.join("App.svelte"), "<p />");
+
+        let overlay = TsgoOverlay::build(&workspace.0, None).unwrap();
+        let config: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(overlay.tsconfig_path()).unwrap()).unwrap();
+        assert!(
+            config["include"]
+                .as_array()
+                .unwrap()
+                .contains(&json!(format!(
+                    "{}/**/*",
+                    path_for_tsconfig(overlay.workspace())
+                )))
+        );
+    }
+
+    #[test]
+    fn open_update_close_keeps_or_removes_the_eager_shadow() {
+        let workspace = TestWorkspace::new("lifecycle");
+        let app = workspace.0.join("src/App.svelte");
+        write(&app, "<p>disk</p>");
+        let mut overlay = TsgoOverlay::build(&workspace.0, None).unwrap();
+
+        let changed = overlay.open_or_update(&app, "<p>buffer</p>", 7).unwrap();
+        assert_eq!(changed.version, 7);
+        assert_eq!(
+            overlay
+                .entries
+                .get(&fs::canonicalize(&app).unwrap())
+                .unwrap()
+                .source_text,
+            "<p>buffer</p>"
+        );
+        let reverted = overlay.close(&app).unwrap().unwrap();
+        assert_eq!(reverted.version, 8);
+        assert_eq!(
+            overlay
+                .entries
+                .get(&fs::canonicalize(&app).unwrap())
+                .unwrap()
+                .source_text,
+            "<p>disk</p>"
+        );
+
+        fs::remove_file(&app).unwrap();
+        assert!(overlay.close(&app).unwrap().is_none());
+        assert!(overlay.shadow_for_source(&app).is_none());
+        assert!(!overlay.shadow_dir.join("src").exists());
+    }
+
+    #[test]
+    fn plain_buffers_join_the_overlay_project_without_disk_bodies() {
+        let workspace = TestWorkspace::new("plain");
+        let source = workspace.0.join("src/main.ts");
+        write(&source, "const face = '😀';\nface;\n");
+        let mut overlay = TsgoOverlay::build(&workspace.0, None).unwrap();
+
+        let shadow = overlay
+            .open_plain(&source, "const face = '😀';\nface;\n", 3, "typescript")
+            .unwrap();
+        let shadow_path = overlay.shadow_dir.join("src/main.ts");
+        assert_eq!(shadow.shadow_uri, path_to_uri(&shadow_path).unwrap());
+        assert!(!shadow_path.exists());
+        assert_eq!(overlay.eager_shadows().len(), 0);
+        assert_eq!(
+            overlay.map_source_position(&source, Position::new(0, 17)),
+            Some(Position::new(0, 19))
+        );
+        assert_eq!(
+            overlay.map_generated_position(&shadow_path, Position::new(0, 19)),
+            Some(Position::new(0, 17))
+        );
+        assert_eq!(
+            overlay.close_plain(&source).unwrap(),
+            Some(shadow.shadow_uri)
+        );
+        assert!(overlay.shadow_for_source(&source).is_none());
+    }
+
+    #[test]
+    fn plain_module_specifiers_target_open_svelte_shadows() {
+        let source = "import App from './App.svelte';\nApp;\n";
+        let (generated, insertions) = rewrite_plain_svelte_imports(source);
+        assert_eq!(generated, "import App from './App.svelte.tsx';\nApp;\n");
+        assert_eq!(insertions.len(), 1);
+        assert_eq!(&generated[insertions[0].1.clone()], ".tsx");
+    }
+
+    #[test]
+    fn component_query_anchor_survives_overlay_import_rewriting() {
+        use lsp_types::{CompletionContext, CompletionTriggerKind};
+
+        let workspace = TestWorkspace::new("component-query");
+        let app = workspace.0.join("App.svelte");
+        let source =
+            "<script lang=\"ts\">\n  import Child from './Child.svelte';\n</script>\n<Child  />\n";
+        write(&app, source);
+        write(&workspace.0.join("Child.svelte"), "<p>child</p>");
+        let overlay = TsgoOverlay::build(&workspace.0, None).unwrap();
+        let cursor = LineIndex::new(source).position(source, source.rfind("  ").unwrap() + 1);
+        let site = crate::tsgo_component_info::component_completion_site(
+            source,
+            cursor,
+            Some(&CompletionContext {
+                trigger_kind: CompletionTriggerKind::INVOKED,
+                trigger_character: None,
+            }),
+            false,
+        )
+        .unwrap();
+        let shadow = overlay.shadow_for_source(&app).unwrap();
+        assert!(shadow.text.contains("from './Child.svelte.tsx'"));
+        let ranges = crate::tsgo_component_info::generated_component_ranges(
+            overlay.projection_map(&app).unwrap(),
+            &site,
+            &shadow.text,
+        );
+        assert_eq!(ranges.len(), 1, "{}", shadow.text);
+        assert_eq!(&shadow.text[ranges[0].clone()], "Child");
+        let source_position =
+            LineIndex::new(source).position(source, source.find("Child").unwrap());
+        let generated_position = overlay.map_source_position(&app, source_position).unwrap();
+        assert_eq!(
+            overlay.map_generated_position(
+                &overlay.shadow_dir.join("App.svelte.tsx"),
+                generated_position
+            ),
+            Some(source_position)
+        );
+    }
+
+    #[test]
+    fn positions_cross_utf16_and_utf8_only_at_the_editor_boundary() {
+        let workspace = TestWorkspace::new("positions");
+        let app = workspace.0.join("src/App.svelte");
+        let source = "<script lang=\"ts\">\nconst 名前 = \"💡\";\nconsole.log(名前);\n</script>\n";
+        write(&app, source);
+        let overlay = TsgoOverlay::build(&workspace.0, None).unwrap();
+        let shadow_path = overlay.shadow_dir.join("src/App.svelte.tsx");
+        let source_offset = source.rfind("名前").unwrap();
+        let source_position = LineIndex::new(source).position(source, source_offset);
+        let generated = overlay
+            .map_source_position(&app, source_position)
+            .expect("script identifier maps forward");
+        let back = overlay
+            .map_generated_position(&shadow_path, generated)
+            .expect("generated identifier maps back");
+        assert_eq!(back, source_position);
+    }
+
+    #[test]
+    fn source_map_supplies_a_fallback_for_rewritten_markup() {
+        let workspace = TestWorkspace::new("fallback");
+        let app = workspace.0.join("App.svelte");
+        let source = "<input bind:value={value}>";
+        write(&app, source);
+        let overlay = TsgoOverlay::build(&workspace.0, None).unwrap();
+        let opener = Position::new(0, 0);
+        assert!(
+            overlay.map_source_position(&app, opener).is_some(),
+            "rewritten template offsets must not inherit ProjectionMap's holes"
+        );
+    }
+
+    #[test]
+    fn generated_ignore_regions_are_not_mapped_back() {
+        let text = "a/*Ωignore_startΩ*/hidden/*Ωignore_endΩ*/b";
+        let ranges = ignored_ranges(text);
+        assert_eq!(ranges.len(), 1);
+        assert!(ranges[0].contains(&text.find("hidden").unwrap()));
+        assert!(!ranges[0].contains(&0));
+
+        let workspace = TestWorkspace::new("ignore-map");
+        let app = workspace.0.join("App.svelte");
+        write(&app, "<script>export let value;</script><p>{value}</p>");
+        let overlay = TsgoOverlay::build(&workspace.0, None).unwrap();
+        let shadow_path = overlay.shadow_dir.join("App.svelte.tsx");
+        let shadow = overlay.shadow_for_source(&app).unwrap();
+        let ignored = shadow.text.find(IGNORE_START).unwrap() + IGNORE_START.len();
+        let position = utf8_position(&shadow.text, ignored);
+        assert!(overlay.is_generated_position(&shadow_path, position));
+        assert_eq!(overlay.map_generated_position(&shadow_path, position), None);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn cache_symlink_is_rejected_before_any_write_through_it() {
+        use std::os::unix::fs::symlink;
+
+        let workspace = TestWorkspace::new("symlink");
+        let outside = TestWorkspace::new("outside");
+        let cache_parent = workspace.0.join(CACHE_DIRECTORY);
+        fs::create_dir_all(&cache_parent).unwrap();
+        symlink(&outside.0, cache_parent.join(TSGO_DIRECTORY)).unwrap();
+        let error = TsgoOverlay::build(&workspace.0, None).unwrap_err();
+        assert!(error.to_string().contains("symlink"));
+        assert!(fs::read_dir(&outside.0).unwrap().next().is_none());
+    }
+}

--- a/crates/rsvelte_language_server/src/tsgo_overlay.rs
+++ b/crates/rsvelte_language_server/src/tsgo_overlay.rs
@@ -1616,6 +1616,7 @@ mod tests {
 
         let changed = overlay.open_or_update(&app, "<p>buffer</p>", 7).unwrap();
         assert_eq!(changed.version, 7);
+        assert_eq!(fs::read_to_string(&app).unwrap(), "<p>disk</p>");
         assert_eq!(
             overlay
                 .entries
@@ -1624,6 +1625,7 @@ mod tests {
                 .source_text,
             "<p>buffer</p>"
         );
+        write(&app, "<p>disk</p>");
         let reverted = overlay.close(&app).unwrap().unwrap();
         assert_eq!(reverted.version, 8);
         assert_eq!(

--- a/crates/rsvelte_language_server/src/tsgo_overlay.rs
+++ b/crates/rsvelte_language_server/src/tsgo_overlay.rs
@@ -411,15 +411,20 @@ impl TsgoOverlay {
         source_path: &Path,
     ) -> Result<Option<ShadowDocument>, TsgoOverlayError> {
         let source_path = self.confined_source(source_path)?;
-        if source_path.is_file() {
-            let next_version = self
-                .entries
-                .get(&source_path)
-                .map_or(0, |entry| entry.document.version.saturating_add(1));
-            return self.update_from_disk(&source_path, next_version).map(Some);
+        let next_version = self
+            .entries
+            .get(&source_path)
+            .map_or(0, |entry| entry.document.version.saturating_add(1));
+        match fs::read_to_string(&source_path) {
+            Ok(text) => self
+                .open_or_update(&source_path, &text, next_version)
+                .map(Some),
+            Err(error) if error.kind() == io::ErrorKind::NotFound => {
+                self.remove_source(&source_path)?;
+                Ok(None)
+            }
+            Err(error) => Err(error.into()),
         }
-        self.remove_source(&source_path)?;
-        Ok(None)
     }
 
     /// Reconcile eager shadows with the current workspace tree.
@@ -1625,7 +1630,6 @@ mod tests {
                 .source_text,
             "<p>buffer</p>"
         );
-        write(&app, "<p>disk</p>");
         let reverted = overlay.close(&app).unwrap().unwrap();
         assert_eq!(reverted.version, 8);
         assert_eq!(

--- a/crates/rsvelte_language_server/src/tsgo_rename.rs
+++ b/crates/rsvelte_language_server/src/tsgo_rename.rs
@@ -1,0 +1,1068 @@
+//! Svelte-specific correction around tsgo's prepare-rename and rename LSP responses.
+//!
+//! tsgo sees the generated `.svelte.tsx` document. The editor sees the
+//! original component, and some generated rename locations are not edits at
+//! all: they are bridges to another TypeScript symbol which must be queried in
+//! a follow-up rename request. This module keeps that distinction explicit and
+//! has no transport or server-loop state.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use lsp_types::{Position, Range, Uri};
+use rsvelte_projection::{ByteRange, ProjectionMap};
+use serde_json::{Map, Value, json};
+use sourcemap::SourceMap;
+
+use crate::context::attribute_context;
+use crate::text::LineIndex;
+
+const IGNORE_START: &str = "/*Ωignore_startΩ*/";
+const IGNORE_END: &str = "/*Ωignore_endΩ*/";
+const STORE_GET: &str = "__sveltets_2_store_get(";
+const PROPS_RETURN: &str = "\nreturn { props: {";
+
+/// One source/generated pair needed by the pure rename correction layer.
+#[derive(Debug, Clone, Copy)]
+pub struct RenameDocument<'a> {
+    /// URI exposed to the editor.
+    pub source_uri: &'a Uri,
+    /// URI opened in tsgo.
+    pub shadow_uri: &'a Uri,
+    /// Original Svelte source.
+    pub source_text: &'a str,
+    /// Generated svelte2tsx text.
+    pub generated_text: &'a str,
+    /// Exact projection mappings for identifiers copied verbatim.
+    pub projection_map: &'a ProjectionMap,
+    /// Standard source map used when a template identifier lives in a
+    /// rewritten rather than byte-exact generated chunk.
+    pub source_map: Option<&'a str>,
+    /// True when projection is in an error state and rename must not run.
+    pub parser_error: bool,
+}
+
+/// Why a Svelte rename must not be forwarded to tsgo.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RenameRejection {
+    /// svelte2tsx has no reliable generated document in parser-error state.
+    ParserError,
+    /// The cursor is on a native HTML tag, attribute, or event-handler name.
+    NativeHtml,
+    /// The source position has no exact generated identifier to query.
+    UnmappedPosition,
+}
+
+/// Source symbol identified before asking tsgo.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RenameTarget {
+    /// Original identifier without the `$` store prefix.
+    pub name: String,
+    /// Editor range tsgo's prepare response is constrained to.
+    pub source_range: Range,
+    /// Whether the request began on an auto-subscription `$store` value.
+    pub is_store_value: bool,
+}
+
+/// Request routing decided from the original Svelte document.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PrepareRenamePlan {
+    /// Do not forward the request.
+    Reject(RenameRejection),
+    /// Ask tsgo at the virtual position.
+    Request {
+        /// Virtual shadow URI.
+        uri: Uri,
+        /// UTF-8 position negotiated with tsgo.
+        position: Position,
+        /// Source symbol facts retained for response correction.
+        target: RenameTarget,
+    },
+}
+
+impl PrepareRenamePlan {
+    /// Request details, if the rename is safe to forward.
+    #[must_use]
+    pub const fn request(&self) -> Option<(&Uri, Position, &RenameTarget)> {
+        match self {
+            Self::Request {
+                uri,
+                position,
+                target,
+            } => Some((uri, *position, target)),
+            Self::Reject(_) => None,
+        }
+    }
+}
+
+/// Why another `textDocument/rename` query is necessary.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum RenameFollowupReason {
+    /// Base store rename must also query the generated `$store` symbol.
+    StoreValue,
+    /// `$store` rename must also query the base store symbol.
+    StoreBase,
+    /// A legacy `export let` local rename must query the public props-object key.
+    LegacyPropKey,
+    /// A consumer prop rename must query the target component's generated local declaration.
+    LegacyPropDeclaration,
+}
+
+/// A follow-up tsgo rename request discovered in generated edits.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RenameFollowup {
+    /// Virtual document containing the bridge symbol.
+    pub uri: Uri,
+    /// UTF-8 tsgo position of that symbol.
+    pub position: Position,
+    /// Name to pass to the follow-up `textDocument/rename` request.
+    pub new_name: String,
+    /// Semantic reason for the extra query.
+    pub reason: RenameFollowupReason,
+}
+
+/// Corrected editor edit plus any additional tsgo work required for parity.
+#[derive(Debug, Clone, PartialEq)]
+pub struct RenameRewrite {
+    /// WorkspaceEdit in editor/source coordinates.
+    pub edit: Value,
+    /// Follow-up rename requests. Their responses should be fed through
+    /// [`rewrite_workspace_edit`] with `collect_followups = false` and merged.
+    pub followups: Vec<RenameFollowup>,
+}
+
+/// Reject unsafe source positions or route a prepare/rename request to tsgo.
+#[must_use]
+pub fn prepare_rename_plan(
+    document: RenameDocument<'_>,
+    source_position: Position,
+) -> PrepareRenamePlan {
+    if document.parser_error {
+        return PrepareRenamePlan::Reject(RenameRejection::ParserError);
+    }
+    let source_index = LineIndex::new(document.source_text);
+    let cursor = source_index.offset(document.source_text, source_position);
+    if is_native_html_name(document.source_text, cursor) {
+        return PrepareRenamePlan::Reject(RenameRejection::NativeHtml);
+    }
+    let Some((identifier, mut start, end)) = identifier_at(document.source_text, cursor) else {
+        return PrepareRenamePlan::Reject(RenameRejection::UnmappedPosition);
+    };
+    let is_store_value = identifier.starts_with('$') && identifier.len() > 1;
+    let name = if is_store_value {
+        start += 1;
+        &identifier[1..]
+    } else {
+        identifier
+    };
+    let Some(generated_offset) =
+        exact_source_offset(document.projection_map, start).or_else(|| {
+            source_map_source_to_generated(
+                document.source_map?,
+                document.source_text,
+                document.generated_text,
+                start,
+            )
+        })
+    else {
+        return PrepareRenamePlan::Reject(RenameRejection::UnmappedPosition);
+    };
+    let generated_position = utf8_position(document.generated_text, generated_offset as usize);
+    PrepareRenamePlan::Request {
+        uri: document.shadow_uri.clone(),
+        position: generated_position,
+        target: RenameTarget {
+            name: name.to_string(),
+            source_range: Range::new(
+                source_index.position(document.source_text, start),
+                source_index.position(document.source_text, end),
+            ),
+            is_store_value,
+        },
+    }
+}
+
+/// Map a tsgo prepare-rename result back to the editor.
+///
+/// Both standard response forms are accepted: a bare `Range` and
+/// `{ range, placeholder }`. A `$store` target always exposes only `store`.
+#[must_use]
+pub fn rewrite_prepare_response(
+    plan: &PrepareRenamePlan,
+    response: Value,
+    documents: &[RenameDocument<'_>],
+) -> Option<Value> {
+    let (_, _, target) = plan.request()?;
+    if response.is_null() {
+        return None;
+    }
+    if target.is_store_value {
+        return match response {
+            Value::Object(mut object) if object.contains_key("range") => {
+                object.insert("range".to_string(), range_value(target.source_range));
+                object.insert(
+                    "placeholder".to_string(),
+                    Value::String(target.name.clone()),
+                );
+                Some(Value::Object(object))
+            }
+            _ => Some(range_value(target.source_range)),
+        };
+    }
+
+    let (range, wrapped) = if let Some(range) = response.get("range") {
+        (parse_range(range)?, true)
+    } else {
+        (parse_range(&response)?, false)
+    };
+    let (uri, _, _) = plan.request()?;
+    let document = document_by_shadow(documents, uri.as_str())?;
+    let mapped = map_generated_range(document, range)?;
+    if wrapped {
+        let mut object = response.as_object()?.clone();
+        object.insert("range".to_string(), range_value(mapped));
+        Some(Value::Object(object))
+    } else {
+        Some(range_value(mapped))
+    }
+}
+
+/// Rewrite one tsgo WorkspaceEdit into original Svelte coordinates.
+///
+/// Generated edits are inspected for store/prop bridges before they are
+/// filtered. `collect_followups` should be true for the primary response and
+/// false while processing follow-up responses to prevent cycles.
+#[must_use]
+pub fn rewrite_workspace_edit(
+    plan: &PrepareRenamePlan,
+    response: &Value,
+    documents: &[RenameDocument<'_>],
+    new_name: &str,
+    collect_followups: bool,
+) -> RenameRewrite {
+    let target = plan.request().map(|(_, _, target)| target);
+    let mut edits = Vec::new();
+    let mut followups = Vec::new();
+    visit_workspace_edits(response, |uri, edit| {
+        let Some(range) = edit.get("range").and_then(parse_range) else {
+            return;
+        };
+        let new_text = edit
+            .get("newText")
+            .and_then(Value::as_str)
+            .unwrap_or(new_name);
+        let Some(document) = document_by_shadow(documents, uri) else {
+            edits.push(EditorEdit {
+                uri: uri.to_string(),
+                range,
+                new_text: new_text.to_string(),
+            });
+            return;
+        };
+        let start = utf8_offset(document.generated_text, range.start);
+        let end = utf8_offset(document.generated_text, range.end).max(start);
+
+        if collect_followups {
+            collect_generated_followups(document, start, end, new_name, target, &mut followups);
+        }
+        if is_generated_span(document.generated_text, start, end)
+            || is_wrong_generated_rename(document.generated_text, start)
+        {
+            return;
+        }
+        let Some(source_range) = map_generated_offsets(document, start, end) else {
+            return;
+        };
+        let (source_range, replacement) =
+            correct_shorthand(document.source_text, source_range, new_text, new_name);
+        edits.push(EditorEdit {
+            uri: document.source_uri.as_str().to_string(),
+            range: source_range,
+            new_text: replacement,
+        });
+    });
+
+    dedupe_followups(&mut followups);
+    RenameRewrite {
+        edit: workspace_edit(edits),
+        followups,
+    }
+}
+
+/// Merge already-corrected WorkspaceEdits, dropping duplicate text edits.
+#[must_use]
+pub fn merge_workspace_edits(edits: impl IntoIterator<Item = Value>) -> Value {
+    let mut merged = Vec::new();
+    for edit in edits {
+        visit_workspace_edits(&edit, |uri, value| {
+            let Some(range) = value.get("range").and_then(parse_range) else {
+                return;
+            };
+            let Some(new_text) = value.get("newText").and_then(Value::as_str) else {
+                return;
+            };
+            merged.push(EditorEdit {
+                uri: uri.to_string(),
+                range,
+                new_text: new_text.to_string(),
+            });
+        });
+    }
+    workspace_edit(merged)
+}
+
+#[derive(Debug, Clone)]
+struct EditorEdit {
+    uri: String,
+    range: Range,
+    new_text: String,
+}
+
+fn collect_generated_followups(
+    document: RenameDocument<'_>,
+    start: usize,
+    end: usize,
+    new_name: &str,
+    target: Option<&RenameTarget>,
+    followups: &mut Vec<RenameFollowup>,
+) {
+    let generated = document.generated_text;
+    let starts_in_generated = is_generated_span(generated, start, end);
+    if !starts_in_generated && has_exact_generated_range(document.projection_map, start, end) {
+        return;
+    }
+
+    if generated[..start].ends_with(STORE_GET) {
+        if let Some(dollar) = generated[..start]
+            .rfind("let $")
+            .map(|offset| offset + "let ".len())
+        {
+            followups.push(RenameFollowup {
+                uri: document.shadow_uri.clone(),
+                position: utf8_position(generated, dollar),
+                new_name: format!("${new_name}"),
+                reason: RenameFollowupReason::StoreValue,
+            });
+        }
+        return;
+    }
+
+    if generated[start..].starts_with('$') {
+        let tail = &generated[start..];
+        if let Some(argument) = tail
+            .find(STORE_GET)
+            .map(|relative| start + relative + STORE_GET.len())
+        {
+            followups.push(RenameFollowup {
+                uri: document.shadow_uri.clone(),
+                position: utf8_position(generated, argument),
+                new_name: new_name.to_string(),
+                reason: RenameFollowupReason::StoreBase,
+            });
+            return;
+        }
+    }
+
+    if is_after_props_return(generated, start) {
+        let old_name = generated.get(start..end).unwrap_or_default();
+        if let Some(key) = prop_key_before(generated, start) {
+            let origin_is_legacy_prop = target.is_some_and(|target| {
+                source_line_contains_export_let(
+                    document.source_text,
+                    target.source_range,
+                    &target.name,
+                )
+            });
+            followups.push(RenameFollowup {
+                uri: document.shadow_uri.clone(),
+                position: utf8_position(generated, key),
+                new_name: new_name.to_string(),
+                reason: if origin_is_legacy_prop {
+                    RenameFollowupReason::LegacyPropKey
+                } else {
+                    RenameFollowupReason::LegacyPropDeclaration
+                },
+            });
+        } else if let Some(declaration) = find_generated_let(generated, old_name) {
+            followups.push(RenameFollowup {
+                uri: document.shadow_uri.clone(),
+                position: utf8_position(generated, declaration),
+                new_name: new_name.to_string(),
+                reason: RenameFollowupReason::LegacyPropDeclaration,
+            });
+        }
+    }
+}
+
+fn source_line_contains_export_let(source: &str, range: Range, name: &str) -> bool {
+    let index = LineIndex::new(source);
+    let start = index.offset(source, Position::new(range.start.line, 0));
+    let end = source[start..]
+        .find(['\n', '\r'])
+        .map_or(source.len(), |relative| start + relative);
+    let line = &source[start..end];
+    let Some(export) = line.find("export") else {
+        return false;
+    };
+    let tail = &line[export + "export".len()..];
+    let tail = tail.trim_start();
+    let Some(tail) = tail.strip_prefix("let") else {
+        return false;
+    };
+    let tail = tail.trim_start();
+    tail.strip_prefix(name).is_some_and(|after| {
+        after.is_empty()
+            || after.starts_with(|character: char| {
+                character.is_whitespace() || matches!(character, ';' | ':' | '/')
+            })
+    })
+}
+
+fn prop_key_before(generated: &str, value_start: usize) -> Option<usize> {
+    let colon = generated[..value_start].rfind(':')?;
+    let mut key_end = colon;
+    while generated
+        .as_bytes()
+        .get(key_end.wrapping_sub(1))
+        .is_some_and(u8::is_ascii_whitespace)
+    {
+        key_end -= 1;
+    }
+    let mut key_start = key_end;
+    while generated
+        .as_bytes()
+        .get(key_start.wrapping_sub(1))
+        .is_some_and(|byte| is_identifier_byte(*byte))
+    {
+        key_start -= 1;
+    }
+    (key_start < key_end).then_some(key_start)
+}
+
+fn find_generated_let(generated: &str, name: &str) -> Option<usize> {
+    if name.is_empty() {
+        return None;
+    }
+    let needle = format!("let {name}");
+    generated
+        .match_indices(&needle)
+        .find_map(|(start, matched)| {
+            let end = start + matched.len();
+            generated
+                .as_bytes()
+                .get(end)
+                .is_none_or(|byte| !is_identifier_byte(*byte))
+                .then_some(start + "let ".len())
+        })
+}
+
+fn is_after_props_return(generated: &str, offset: usize) -> bool {
+    generated[..offset.min(generated.len())].contains(PROPS_RETURN)
+}
+
+fn is_wrong_generated_rename(generated: &str, start: usize) -> bool {
+    [
+        "__sveltets_2_instanceOf(",
+        "__sveltets_1_ensureType(",
+        "= __sveltets_2_store_get(",
+    ]
+    .iter()
+    .any(|prefix| generated[..start].ends_with(prefix))
+}
+
+fn map_generated_range(document: RenameDocument<'_>, range: Range) -> Option<Range> {
+    let start = utf8_offset(document.generated_text, range.start);
+    let end = utf8_offset(document.generated_text, range.end).max(start);
+    map_generated_offsets(document, start, end)
+}
+
+fn map_generated_offsets(document: RenameDocument<'_>, start: usize, end: usize) -> Option<Range> {
+    let generated = ByteRange::new(u32::try_from(start).ok()?, u32::try_from(end).ok()?)?;
+    if let Some(source) = document
+        .projection_map
+        .generated_range_to_source(generated)
+        .or_else(|| exact_boundary_range(document.projection_map, generated))
+    {
+        let index = LineIndex::new(document.source_text);
+        return Some(Range::new(
+            index.position(document.source_text, source.start() as usize),
+            index.position(document.source_text, source.end() as usize),
+        ));
+    }
+
+    let map = SourceMap::from_slice(document.source_map?.as_bytes()).ok()?;
+    let generated_index = LineIndex::new(document.generated_text);
+    let generated_start = generated_index.position(document.generated_text, start);
+    let token = map.lookup_token(generated_start.line, generated_start.character)?;
+    token.get_source()?;
+    let width = document
+        .generated_text
+        .get(start..end)?
+        .encode_utf16()
+        .count();
+    let source_start = Position::new(token.get_src_line(), token.get_src_col());
+    let source_end = Position::new(
+        source_start.line,
+        source_start
+            .character
+            .saturating_add(u32::try_from(width).ok()?),
+    );
+    Some(Range::new(source_start, source_end))
+}
+
+fn has_exact_generated_range(map: &ProjectionMap, start: usize, end: usize) -> bool {
+    let Some(range) = u32::try_from(start)
+        .ok()
+        .zip(u32::try_from(end).ok())
+        .and_then(|(start, end)| ByteRange::new(start, end))
+    else {
+        return false;
+    };
+    map.generated_range_to_source(range).is_some() || exact_boundary_range(map, range).is_some()
+}
+
+fn exact_boundary_range(map: &ProjectionMap, generated: ByteRange) -> Option<ByteRange> {
+    let segment = map.segments().iter().find(|segment| {
+        generated.start() >= segment.generated.start() && generated.end() <= segment.generated.end()
+    })?;
+    let start = segment.source.start() + generated.start() - segment.generated.start();
+    ByteRange::new(start, start + generated.len())
+}
+
+fn exact_source_offset(map: &ProjectionMap, source: usize) -> Option<u32> {
+    let source = u32::try_from(source).ok()?;
+    map.source_to_generated(source)
+        .first()
+        .copied()
+        .or_else(|| {
+            map.segments()
+                .iter()
+                .find(|segment| segment.source.end() == source)
+                .map(|segment| segment.generated.end())
+        })
+}
+
+fn source_map_source_to_generated(
+    raw_map: &str,
+    source_text: &str,
+    generated_text: &str,
+    source_offset: usize,
+) -> Option<u32> {
+    let source_position = LineIndex::new(source_text).position(source_text, source_offset);
+    let map = SourceMap::from_slice(raw_map.as_bytes()).ok()?;
+    let token = map
+        .tokens()
+        .filter(|token| {
+            token.get_source().is_some() && token.get_src_line() == source_position.line
+        })
+        .min_by_key(|token| {
+            (
+                token.get_src_col().abs_diff(source_position.character),
+                token.get_dst_line(),
+                token.get_dst_col(),
+            )
+        })?;
+    let generated_index = LineIndex::new(generated_text);
+    let offset = generated_index.offset(
+        generated_text,
+        Position::new(token.get_dst_line(), token.get_dst_col()),
+    );
+    u32::try_from(offset).ok()
+}
+
+fn correct_shorthand(
+    source: &str,
+    range: Range,
+    raw_replacement: &str,
+    _requested_name: &str,
+) -> (Range, String) {
+    let index = LineIndex::new(source);
+    let start = index.offset(source, range.start);
+    let end = index.offset(source, range.end).max(start);
+    let Some((public, value)) = split_rename_pair(raw_replacement) else {
+        return (range, raw_replacement.to_string());
+    };
+
+    let directive = source[..start]
+        .strip_suffix("bind:")
+        .or_else(|| source[..start].strip_suffix("let:"));
+    if directive.is_some() {
+        return (range, format!("{public}={{{value}}}"));
+    }
+
+    if source.as_bytes().get(start.wrapping_sub(1)) == Some(&b'{')
+        && source.as_bytes().get(end) == Some(&b'}')
+    {
+        let expanded = Range::new(
+            index.position(source, start - 1),
+            index.position(source, end + 1),
+        );
+        return (expanded, format!("{public}={{{value}}}"));
+    }
+
+    // A key/value pair outside Svelte shorthand syntax is already a complete
+    // TypeScript replacement and must retain tsgo's prefix/suffix semantics.
+    (range, raw_replacement.to_string())
+}
+
+fn split_rename_pair(replacement: &str) -> Option<(&str, &str)> {
+    let (public, value) = replacement.split_once(':')?;
+    let public = public.trim();
+    let value = value.trim();
+    (!public.is_empty() && !value.is_empty()).then_some((public, value))
+}
+
+fn is_native_html_name(source: &str, offset: usize) -> bool {
+    if let Some(attribute) = attribute_context(source, offset)
+        && !attribute.in_value
+        && !is_component_tag(attribute.element_tag)
+    {
+        return true;
+    }
+    let before = &source[..offset.min(source.len())];
+    let Some(open) = before.rfind('<') else {
+        return false;
+    };
+    if source[open..offset].contains('>') {
+        return false;
+    }
+    let mut start = open + 1;
+    if source.as_bytes().get(start) == Some(&b'/') {
+        start += 1;
+    }
+    let mut end = start;
+    while source
+        .as_bytes()
+        .get(end)
+        .is_some_and(|byte| is_tag_name_byte(*byte))
+    {
+        end += 1;
+    }
+    (start..=end).contains(&offset)
+        && source
+            .get(start..end)
+            .is_some_and(|tag| !is_component_tag(tag))
+}
+
+fn is_component_tag(tag: &str) -> bool {
+    tag.starts_with(|character: char| character.is_ascii_uppercase())
+        || tag.starts_with("svelte:component")
+}
+
+fn identifier_at(source: &str, cursor: usize) -> Option<(&str, usize, usize)> {
+    let bytes = source.as_bytes();
+    let mut at = cursor.min(bytes.len());
+    if at == bytes.len() || !bytes.get(at).is_some_and(|byte| is_identifier_byte(*byte)) {
+        at = at.checked_sub(1)?;
+    }
+    if !bytes.get(at).is_some_and(|byte| is_identifier_byte(*byte)) {
+        return None;
+    }
+    let mut start = at;
+    while bytes
+        .get(start.wrapping_sub(1))
+        .is_some_and(|byte| is_identifier_byte(*byte))
+    {
+        start -= 1;
+    }
+    let mut end = at + 1;
+    while bytes.get(end).is_some_and(|byte| is_identifier_byte(*byte)) {
+        end += 1;
+    }
+    Some((&source[start..end], start, end))
+}
+
+const fn is_identifier_byte(byte: u8) -> bool {
+    byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b'$') || byte >= 0x80
+}
+
+const fn is_tag_name_byte(byte: u8) -> bool {
+    byte.is_ascii_alphanumeric() || matches!(byte, b':' | b'-' | b'_' | b'.')
+}
+
+fn is_generated_span(text: &str, start: usize, end: usize) -> bool {
+    let start = start.min(text.len());
+    let end = end.min(text.len());
+    let last_start = text[..start].rfind(IGNORE_START);
+    let last_end = text[..start].rfind(IGNORE_END);
+    let next_end = text[end..].find(IGNORE_END).map(|at| end + at);
+    matches!((last_start, next_end), (Some(open), Some(close)) if last_end.is_none_or(|end| open > end) && open < close)
+}
+
+fn document_by_shadow<'a>(
+    documents: &'a [RenameDocument<'a>],
+    uri: &str,
+) -> Option<RenameDocument<'a>> {
+    documents
+        .iter()
+        .find(|document| document.shadow_uri.as_str() == uri)
+        .copied()
+}
+
+fn visit_workspace_edits(edit: &Value, mut visit: impl FnMut(&str, &Value)) {
+    if let Some(changes) = edit.get("changes").and_then(Value::as_object) {
+        for (uri, edits) in changes {
+            if let Some(edits) = edits.as_array() {
+                for edit in edits {
+                    visit(uri, edit);
+                }
+            }
+        }
+    }
+    if let Some(changes) = edit.get("documentChanges").and_then(Value::as_array) {
+        for change in changes {
+            let Some(uri) = change.pointer("/textDocument/uri").and_then(Value::as_str) else {
+                continue;
+            };
+            if let Some(edits) = change.get("edits").and_then(Value::as_array) {
+                for edit in edits {
+                    visit(uri, edit);
+                }
+            }
+        }
+    }
+}
+
+fn workspace_edit(edits: Vec<EditorEdit>) -> Value {
+    let mut seen = BTreeSet::new();
+    let mut changes: BTreeMap<String, Vec<Value>> = BTreeMap::new();
+    for edit in edits {
+        let key = (
+            edit.uri.clone(),
+            edit.range.start.line,
+            edit.range.start.character,
+            edit.range.end.line,
+            edit.range.end.character,
+            edit.new_text.clone(),
+        );
+        if !seen.insert(key) {
+            continue;
+        }
+        changes.entry(edit.uri).or_default().push(json!({
+            "range": range_value(edit.range),
+            "newText": edit.new_text
+        }));
+    }
+    let changes = changes
+        .into_iter()
+        .map(|(uri, edits)| (uri, Value::Array(edits)))
+        .collect::<Map<_, _>>();
+    json!({ "changes": Value::Object(changes) })
+}
+
+fn dedupe_followups(followups: &mut Vec<RenameFollowup>) {
+    let mut seen = BTreeSet::new();
+    followups.retain(|followup| {
+        seen.insert((
+            followup.uri.as_str().to_string(),
+            followup.position.line,
+            followup.position.character,
+            followup.new_name.clone(),
+            followup.reason,
+        ))
+    });
+}
+
+fn parse_range(value: &Value) -> Option<Range> {
+    Some(Range::new(
+        Position::new(
+            u32::try_from(value.pointer("/start/line")?.as_u64()?).ok()?,
+            u32::try_from(value.pointer("/start/character")?.as_u64()?).ok()?,
+        ),
+        Position::new(
+            u32::try_from(value.pointer("/end/line")?.as_u64()?).ok()?,
+            u32::try_from(value.pointer("/end/character")?.as_u64()?).ok()?,
+        ),
+    ))
+}
+
+fn range_value(range: Range) -> Value {
+    json!({
+        "start": { "line": range.start.line, "character": range.start.character },
+        "end": { "line": range.end.line, "character": range.end.character }
+    })
+}
+
+fn utf8_position(text: &str, offset: usize) -> Position {
+    let offset = floor_char_boundary(text, offset.min(text.len()));
+    let before = &text[..offset];
+    let line = before.bytes().filter(|byte| *byte == b'\n').count();
+    let line_start = before.rfind('\n').map_or(0, |at| at + 1);
+    Position::new(
+        u32::try_from(line).unwrap_or(u32::MAX),
+        u32::try_from(offset - line_start).unwrap_or(u32::MAX),
+    )
+}
+
+fn utf8_offset(text: &str, position: Position) -> usize {
+    let mut line = 0u32;
+    let mut start = 0usize;
+    for (offset, byte) in text.bytes().enumerate() {
+        if line == position.line {
+            break;
+        }
+        if byte == b'\n' {
+            line += 1;
+            start = offset + 1;
+        }
+    }
+    if line != position.line {
+        return text.len();
+    }
+    let end = text[start..]
+        .find('\n')
+        .map_or(text.len(), |relative| start + relative);
+    floor_char_boundary(
+        text,
+        start.saturating_add(position.character as usize).min(end),
+    )
+}
+
+fn floor_char_boundary(text: &str, mut offset: usize) -> usize {
+    while offset > 0 && !text.is_char_boundary(offset) {
+        offset -= 1;
+    }
+    offset
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rsvelte_projection::{ProjectionArtifact, ProjectionEngine, Svelte2TsxOptions};
+    use std::str::FromStr;
+
+    fn uri(value: &str) -> Uri {
+        Uri::from_str(value).unwrap()
+    }
+
+    fn project(source: &str) -> ProjectionArtifact {
+        ProjectionEngine::new()
+            .project(
+                source,
+                Svelte2TsxOptions {
+                    filename: "Input.svelte".to_string(),
+                    is_ts_file: source.contains("lang=\"ts\""),
+                    emit_jsdoc: true,
+                    ..Svelte2TsxOptions::default()
+                },
+            )
+            .unwrap()
+    }
+
+    fn view<'a>(
+        source_uri: &'a Uri,
+        shadow_uri: &'a Uri,
+        source: &'a str,
+        artifact: &'a ProjectionArtifact,
+    ) -> RenameDocument<'a> {
+        RenameDocument {
+            source_uri,
+            shadow_uri,
+            source_text: source,
+            generated_text: &artifact.code,
+            projection_map: artifact.exact_mappings.as_ref().unwrap(),
+            source_map: artifact.source_map.as_deref(),
+            parser_error: false,
+        }
+    }
+
+    fn edit(uri: &Uri, text: &str, start: Position, end: Position) -> Value {
+        json!({
+            "changes": {
+                uri.as_str(): [{
+                    "range": range_value(Range::new(start, end)),
+                    "newText": text
+                }]
+            }
+        })
+    }
+
+    #[test]
+    fn parser_errors_and_native_html_names_are_rejected() {
+        let source_uri = uri("file:///Input.svelte");
+        let shadow_uri = uri("file:///cache/Input.svelte.tsx");
+        let source = "<div class={value}></div><Component prop={value} />";
+        let artifact = project(source);
+        let mut document = view(&source_uri, &shadow_uri, source, &artifact);
+        document.parser_error = true;
+        assert_eq!(
+            prepare_rename_plan(document, Position::new(0, 1)),
+            PrepareRenamePlan::Reject(RenameRejection::ParserError)
+        );
+
+        document.parser_error = false;
+        assert_eq!(
+            prepare_rename_plan(document, Position::new(0, 1)),
+            PrepareRenamePlan::Reject(RenameRejection::NativeHtml)
+        );
+        assert_eq!(
+            prepare_rename_plan(document, Position::new(0, 6)),
+            PrepareRenamePlan::Reject(RenameRejection::NativeHtml)
+        );
+        let component = prepare_rename_plan(document, Position::new(0, 26));
+        assert!(
+            matches!(component, PrepareRenamePlan::Request { .. }),
+            "{component:?}"
+        );
+    }
+
+    #[test]
+    fn store_prepare_range_excludes_the_dollar() {
+        let source_uri = uri("file:///Input.svelte");
+        let shadow_uri = uri("file:///cache/Input.svelte.tsx");
+        let source = "<script>let store; $store;</script>";
+        let artifact = project(source);
+        let document = view(&source_uri, &shadow_uri, source, &artifact);
+        let offset = source.find("$store").unwrap() + 2;
+        let position = LineIndex::new(source).position(source, offset);
+        let plan = prepare_rename_plan(document, position);
+        let (_, _, target) = plan.request().unwrap();
+        assert!(target.is_store_value);
+        assert_eq!(target.name, "store");
+        assert_eq!(
+            &source[LineIndex::new(source).offset(source, target.source_range.start)
+                ..LineIndex::new(source).offset(source, target.source_range.end)],
+            "store"
+        );
+        assert_eq!(
+            rewrite_prepare_response(&plan, json!(null), &[document]),
+            None
+        );
+        assert_eq!(
+            rewrite_prepare_response(
+                &plan,
+                json!({"start":{"line":0,"character":0},"end":{"line":0,"character":1}}),
+                &[document]
+            ),
+            Some(range_value(target.source_range))
+        );
+    }
+
+    #[test]
+    fn generated_store_edit_becomes_a_followup_before_filtering() {
+        let source_uri = uri("file:///Input.svelte");
+        let shadow_uri = uri("file:///cache/Input.svelte.tsx");
+        let source = "<script>let store; $store;</script>";
+        let artifact = project(source);
+        let document = view(&source_uri, &shadow_uri, source, &artifact);
+        let base = artifact.code.find(&format!("{STORE_GET}store")).unwrap() + STORE_GET.len();
+        let response = edit(
+            &shadow_uri,
+            "renamed",
+            utf8_position(&artifact.code, base),
+            utf8_position(&artifact.code, base + "store".len()),
+        );
+        let source_position =
+            LineIndex::new(source).position(source, source.find("store").unwrap());
+        let plan = prepare_rename_plan(document, source_position);
+        let rewritten = rewrite_workspace_edit(&plan, &response, &[document], "renamed", true);
+        assert_eq!(rewritten.edit, json!({"changes": {}}));
+        assert_eq!(rewritten.followups.len(), 1);
+        assert_eq!(
+            rewritten.followups[0].reason,
+            RenameFollowupReason::StoreValue
+        );
+        assert_eq!(rewritten.followups[0].new_name, "$renamed");
+
+        let dollar = artifact.code[..base].rfind("let $").unwrap() + "let ".len();
+        let dollar_response = edit(
+            &shadow_uri,
+            "$renamed",
+            utf8_position(&artifact.code, dollar),
+            utf8_position(&artifact.code, dollar + "$store".len()),
+        );
+        let dollar_source = source.find("$store").unwrap() + 1;
+        let dollar_position = LineIndex::new(source).position(source, dollar_source);
+        let dollar_plan = prepare_rename_plan(document, dollar_position);
+        let dollar_rewritten =
+            rewrite_workspace_edit(&dollar_plan, &dollar_response, &[document], "renamed", true);
+        assert_eq!(dollar_rewritten.followups.len(), 1);
+        assert_eq!(
+            dollar_rewritten.followups[0].reason,
+            RenameFollowupReason::StoreBase
+        );
+        assert_eq!(dollar_rewritten.followups[0].new_name, "renamed");
+    }
+
+    #[test]
+    fn generated_prop_object_edit_becomes_an_explicit_followup() {
+        let source_uri = uri("file:///Input.svelte");
+        let shadow_uri = uri("file:///cache/Input.svelte.tsx");
+        let source = "<script>export let prop;</script>{prop}";
+        let artifact = project(source);
+        let document = view(&source_uri, &shadow_uri, source, &artifact);
+        let props = artifact.code.find(PROPS_RETURN).unwrap();
+        let value = artifact.code[props..].find("prop: prop").unwrap() + props + "prop: ".len();
+        let response = edit(
+            &shadow_uri,
+            "next",
+            utf8_position(&artifact.code, value),
+            utf8_position(&artifact.code, value + "prop".len()),
+        );
+        let position = LineIndex::new(source).position(source, source.find("prop").unwrap());
+        let plan = prepare_rename_plan(document, position);
+        let rewritten = rewrite_workspace_edit(&plan, &response, &[document], "next", true);
+        assert_eq!(rewritten.followups.len(), 1);
+        assert_eq!(
+            rewritten.followups[0].reason,
+            RenameFollowupReason::LegacyPropKey
+        );
+    }
+
+    #[test]
+    fn bind_prop_and_slot_shorthands_preserve_key_value_meaning() {
+        let source = "<Child bind:foo {foo} let:slot>{slot}</Child>";
+        let index = LineIndex::new(source);
+        let range = |needle: &str, from: usize| {
+            let start = source[from..].find(needle).unwrap() + from;
+            Range::new(
+                index.position(source, start),
+                index.position(source, start + needle.len()),
+            )
+        };
+
+        let bind = range("foo", 0);
+        assert_eq!(
+            correct_shorthand(source, bind, "foo: renamed", "renamed"),
+            (bind, "foo={renamed}".to_string())
+        );
+        let attr = range("foo", source.find("{foo}").unwrap());
+        let (expanded, replacement) = correct_shorthand(source, attr, "renamed: foo", "renamed");
+        assert_eq!(
+            &source[index.offset(source, expanded.start)..index.offset(source, expanded.end)],
+            "{foo}"
+        );
+        assert_eq!(replacement, "renamed={foo}");
+        let slot = range("slot", source.find("let:").unwrap());
+        assert_eq!(
+            correct_shorthand(source, slot, "slot: renamed", "renamed"),
+            (slot, "slot={renamed}".to_string())
+        );
+    }
+
+    #[test]
+    fn generated_marker_edits_are_removed_and_source_edits_merge_once() {
+        let source_uri = uri("file:///Input.svelte");
+        let shadow_uri = uri("file:///cache/Input.svelte.tsx");
+        let source = "<script>export let value;</script>{value}";
+        let artifact = project(source);
+        let document = view(&source_uri, &shadow_uri, source, &artifact);
+        let generated = artifact.code.find(IGNORE_START).unwrap() + IGNORE_START.len();
+        let response = edit(
+            &shadow_uri,
+            "next",
+            utf8_position(&artifact.code, generated),
+            utf8_position(&artifact.code, generated + 1),
+        );
+        let position = LineIndex::new(source).position(source, source.find("value").unwrap());
+        let plan = prepare_rename_plan(document, position);
+        let rewritten = rewrite_workspace_edit(&plan, &response, &[document], "next", false);
+        assert_eq!(rewritten.edit, json!({"changes": {}}));
+
+        let range = Range::new(Position::new(0, 0), Position::new(0, 1));
+        let plain = edit(&source_uri, "next", range.start, range.end);
+        assert_eq!(
+            merge_workspace_edits([plain.clone(), plain]),
+            json!({"changes": {source_uri.as_str(): [{"range": range_value(range), "newText": "next"}]}})
+        );
+    }
+}

--- a/crates/rsvelte_language_server/src/tsgo_response.rs
+++ b/crates/rsvelte_language_server/src/tsgo_response.rs
@@ -1,0 +1,1276 @@
+//! Position and URI translation at the tsgo protocol boundary.
+
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::str::FromStr;
+use std::sync::Arc;
+
+use lsp_types::{Position, Range, Uri};
+use serde_json::{Map, Value};
+
+use crate::text::LineIndex;
+use crate::tsgo_overlay::TsgoOverlay;
+use crate::uri::uri_to_path;
+
+/// The Svelte document associated with a request.
+///
+/// Responses such as hover and document highlights contain ranges but no URI,
+/// so the server retains this value alongside the forwarded request id.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RequestDocumentContext {
+    source_uri: Uri,
+    shadow_uri: Uri,
+    source_path: PathBuf,
+    shadow_path: PathBuf,
+    plain_text: Option<Arc<str>>,
+}
+
+#[derive(Clone, Debug)]
+struct UriAlias {
+    source_uri: Uri,
+    shadow_uri: Uri,
+    projection: RequestDocumentContext,
+}
+
+impl RequestDocumentContext {
+    #[must_use]
+    pub fn source_uri(&self) -> &Uri {
+        &self.source_uri
+    }
+
+    #[must_use]
+    pub fn shadow_uri(&self) -> &Uri {
+        &self.shadow_uri
+    }
+}
+
+/// Translates JSON protocol values between the editor and the tsgo child.
+pub struct TsgoResponseMapper<'a> {
+    overlays: &'a [TsgoOverlay],
+    default_document: Option<RequestDocumentContext>,
+    aliases: Vec<UriAlias>,
+}
+
+impl<'a> TsgoResponseMapper<'a> {
+    #[must_use]
+    pub const fn new(overlay: &'a TsgoOverlay) -> Self {
+        Self {
+            overlays: std::slice::from_ref(overlay),
+            default_document: None,
+            aliases: Vec::new(),
+        }
+    }
+
+    /// Construct a mapper for responses which may cross workspace roots.
+    #[must_use]
+    pub const fn for_overlays(overlays: &'a [TsgoOverlay]) -> Self {
+        Self {
+            overlays,
+            default_document: None,
+            aliases: Vec::new(),
+        }
+    }
+
+    /// Construct a mapper whose URI-less ranges belong to `document`.
+    #[must_use]
+    pub fn with_default_document(
+        overlay: &'a TsgoOverlay,
+        document: Option<RequestDocumentContext>,
+    ) -> Self {
+        Self {
+            overlays: std::slice::from_ref(overlay),
+            default_document: document,
+            aliases: Vec::new(),
+        }
+    }
+
+    /// Construct a cross-workspace mapper with a URI-less response context.
+    #[must_use]
+    pub const fn for_overlays_with_default_document(
+        overlays: &'a [TsgoOverlay],
+        document: Option<RequestDocumentContext>,
+    ) -> Self {
+        Self {
+            overlays,
+            default_document: document,
+            aliases: Vec::new(),
+        }
+    }
+
+    /// Capture the default document before the request URI is rewritten.
+    #[must_use]
+    pub fn for_request(overlay: &'a TsgoOverlay, params: &Value) -> Self {
+        let overlays = std::slice::from_ref(overlay);
+        let default_document =
+            find_request_uri(params).and_then(|uri| document_context_for_uri_in(overlays, uri));
+        Self {
+            overlays,
+            default_document,
+            aliases: Vec::new(),
+        }
+    }
+
+    /// Capture request context while allowing cross-workspace result URIs.
+    #[must_use]
+    pub fn for_overlays_request(overlays: &'a [TsgoOverlay], params: &Value) -> Self {
+        let default_document =
+            find_request_uri(params).and_then(|uri| document_context_for_uri_in(overlays, uri));
+        Self {
+            overlays,
+            default_document,
+            aliases: Vec::new(),
+        }
+    }
+
+    /// Resolve a source or shadow URI into a retainable request context.
+    #[must_use]
+    pub fn document_context(&self, uri: &Uri) -> Option<RequestDocumentContext> {
+        self.context_for_uri(uri.as_str())
+    }
+
+    #[must_use]
+    pub fn default_document(&self) -> Option<&RequestDocumentContext> {
+        self.default_document.as_ref()
+    }
+
+    /// Treat a prospective shadow URI as another name for an existing
+    /// projection while exposing its corresponding prospective source URI.
+    ///
+    /// This is used by `workspace/willRenameFiles`: tsgo computes ranges in
+    /// the old document but keys edits by the not-yet-open new shadow URI.
+    /// Registration fails when either prospective URI already has a real
+    /// overlay route, or when `projection_uri` has no readable mapping.
+    pub fn add_uri_alias(
+        &mut self,
+        source_uri: Uri,
+        shadow_uri: Uri,
+        projection_uri: &Uri,
+    ) -> bool {
+        if source_uri == shadow_uri
+            || document_context_for_uri_in(self.overlays, source_uri.as_str()).is_some()
+            || document_context_for_uri_in(self.overlays, shadow_uri.as_str()).is_some()
+            || self.aliases.iter().any(|alias| {
+                alias.source_uri == source_uri
+                    || alias.shadow_uri == source_uri
+                    || alias.source_uri == shadow_uri
+                    || alias.shadow_uri == shadow_uri
+            })
+        {
+            return false;
+        }
+        let Some(projection) = self.context_for_uri(projection_uri.as_str()) else {
+            return false;
+        };
+        self.aliases.push(UriAlias {
+            source_uri,
+            shadow_uri,
+            projection,
+        });
+        true
+    }
+
+    /// Map editor-facing request params from source UTF-16 to shadow UTF-8.
+    ///
+    /// `false` means a required source span has no shadow mapping and the
+    /// request should not be forwarded.
+    pub fn map_request(&self, method: &str, params: &mut Value) -> bool {
+        self.map_transactional(method, params, Direction::SourceToShadow)
+    }
+
+    /// Map a tsgo result from shadow UTF-8 back to source UTF-16.
+    ///
+    /// A root result whose required span is generated becomes `null`. Invalid
+    /// elements inside arrays are removed without discarding mapped siblings.
+    pub fn map_response(&self, method: &str, result: &mut Value) -> bool {
+        if is_semantic_tokens_method(method) {
+            let mapped = self.map_semantic_tokens(result);
+            if !mapped {
+                *result = Value::Null;
+            }
+            return mapped;
+        }
+
+        let mut mapped = result.clone();
+        if self.map_value(
+            &mut mapped,
+            Direction::ShadowToSource,
+            self.default_document.as_ref(),
+        ) {
+            *result = mapped;
+            true
+        } else {
+            *result = Value::Null;
+            false
+        }
+    }
+
+    /// Map child requests and notifications such as `workspace/applyEdit` and
+    /// pull/publish diagnostics to editor coordinates.
+    pub fn map_child_params(&self, method: &str, params: &mut Value) -> bool {
+        if is_semantic_tokens_method(method) {
+            return self.map_response(method, params);
+        }
+        self.map_transactional(method, params, Direction::ShadowToSource)
+    }
+
+    fn map_transactional(&self, _method: &str, value: &mut Value, direction: Direction) -> bool {
+        let mut mapped = value.clone();
+        if !self.map_value(&mut mapped, direction, self.default_document.as_ref()) {
+            return false;
+        }
+        *value = mapped;
+        true
+    }
+
+    fn map_value(
+        &self,
+        value: &mut Value,
+        direction: Direction,
+        inherited: Option<&RequestDocumentContext>,
+    ) -> bool {
+        if is_range(value) {
+            return self.map_range_value(value, direction, inherited);
+        }
+        if is_position(value) {
+            return self.map_position_value(value, direction, inherited);
+        }
+
+        match value {
+            Value::Array(items) => {
+                let mut mapped = Vec::with_capacity(items.len());
+                for mut item in std::mem::take(items) {
+                    if self.map_value(&mut item, direction, inherited) {
+                        mapped.push(item);
+                    }
+                }
+                *items = mapped;
+                true
+            }
+            Value::Object(object) => self.map_object(object, direction, inherited),
+            _ => true,
+        }
+    }
+
+    fn map_object(
+        &self,
+        object: &mut Map<String, Value>,
+        direction: Direction,
+        inherited: Option<&RequestDocumentContext>,
+    ) -> bool {
+        let own_context = self.object_document_context(object);
+        let local_context = own_context.as_ref().or(inherited);
+        let target_context = object
+            .get("targetUri")
+            .and_then(Value::as_str)
+            .and_then(|uri| self.context_for_uri(uri));
+        let call_from_context = object
+            .get("from")
+            .and_then(Value::as_object)
+            .and_then(|from| self.object_document_context(from));
+
+        if !self.map_folding_range(object, direction, local_context) {
+            return false;
+        }
+
+        for key in URI_FIELDS {
+            if let Some(uri) = object.get_mut(*key) {
+                self.map_uri_value(uri, direction);
+            }
+        }
+
+        for key in URI_KEYED_MAPS {
+            if let Some(value) = object.get_mut(*key)
+                && !self.map_uri_keyed_map(value, direction, local_context)
+            {
+                return false;
+            }
+        }
+
+        let keys = object.keys().cloned().collect::<Vec<_>>();
+        for key in keys {
+            if URI_FIELDS.contains(&key.as_str())
+                || URI_KEYED_MAPS.contains(&key.as_str())
+                || key == "data"
+                || FOLDING_FIELDS.contains(&key.as_str())
+            {
+                continue;
+            }
+
+            let context = match key.as_str() {
+                "originSelectionRange" => inherited,
+                "targetRange" | "targetSelectionRange" => target_context.as_ref().or(local_context),
+                "fromRanges" => call_from_context.as_ref().or(local_context),
+                _ => local_context,
+            };
+            let Some(child) = object.get_mut(&key) else {
+                continue;
+            };
+
+            let keep = if is_range_field(&key) && is_range(child) {
+                self.map_range_value(child, direction, context)
+            } else if key == "position" && is_position(child) {
+                self.map_position_value(child, direction, context)
+            } else {
+                self.map_value(child, direction, context)
+            };
+            if !keep {
+                return false;
+            }
+        }
+        true
+    }
+
+    fn map_uri_keyed_map(
+        &self,
+        value: &mut Value,
+        direction: Direction,
+        inherited: Option<&RequestDocumentContext>,
+    ) -> bool {
+        let Some(entries) = value.as_object_mut() else {
+            return true;
+        };
+        let mut mapped = BTreeMap::<String, Value>::new();
+        for (uri, mut child) in std::mem::take(entries) {
+            let context = self.context_for_uri(&uri);
+            if !self.map_value(&mut child, direction, context.as_ref().or(inherited)) {
+                continue;
+            }
+            let mapped_uri = self.mapped_uri_string(&uri, direction);
+            if let Some(existing) = mapped.get_mut(&mapped_uri)
+                && let (Some(existing), Some(child)) =
+                    (existing.as_array_mut(), child.as_array_mut())
+            {
+                existing.append(child);
+            } else {
+                mapped.insert(mapped_uri, child);
+            }
+        }
+        entries.extend(mapped);
+        true
+    }
+
+    fn map_folding_range(
+        &self,
+        object: &mut Map<String, Value>,
+        direction: Direction,
+        context: Option<&RequestDocumentContext>,
+    ) -> bool {
+        let Some(start_line) = object.get("startLine").and_then(json_u32) else {
+            return true;
+        };
+        let Some(end_line) = object.get("endLine").and_then(json_u32) else {
+            return true;
+        };
+        let start_character = object.get("startCharacter").and_then(json_u32).unwrap_or(0);
+        let end_character = object.get("endCharacter").and_then(json_u32).unwrap_or(0);
+        let Some(start) = self.map_position(
+            Position::new(start_line, start_character),
+            direction,
+            context,
+        ) else {
+            return false;
+        };
+        let Some(end) =
+            self.map_position(Position::new(end_line, end_character), direction, context)
+        else {
+            return false;
+        };
+        object.insert("startLine".to_string(), Value::from(start.line));
+        object.insert("endLine".to_string(), Value::from(end.line));
+        if object.contains_key("startCharacter") {
+            object.insert("startCharacter".to_string(), Value::from(start.character));
+        }
+        if object.contains_key("endCharacter") {
+            object.insert("endCharacter".to_string(), Value::from(end.character));
+        }
+        true
+    }
+
+    fn map_uri_value(&self, value: &mut Value, direction: Direction) {
+        let Some(uri) = value.as_str() else {
+            return;
+        };
+        *value = Value::String(self.mapped_uri_string(uri, direction));
+    }
+
+    fn mapped_uri_string(&self, uri: &str, direction: Direction) -> String {
+        if let Some(alias) = self.alias_for_uri(uri) {
+            return match direction {
+                Direction::SourceToShadow => alias.shadow_uri.as_str().to_string(),
+                Direction::ShadowToSource => alias.source_uri.as_str().to_string(),
+            };
+        }
+        let Some(context) = document_context_for_uri_in(self.overlays, uri) else {
+            return uri.to_string();
+        };
+        match direction {
+            Direction::SourceToShadow => context.shadow_uri.as_str().to_string(),
+            Direction::ShadowToSource => context.source_uri.as_str().to_string(),
+        }
+    }
+
+    fn map_position_value(
+        &self,
+        value: &mut Value,
+        direction: Direction,
+        context: Option<&RequestDocumentContext>,
+    ) -> bool {
+        let Some(position) = parse_position(value) else {
+            return true;
+        };
+        let Some(position) = self.map_position(position, direction, context) else {
+            return false;
+        };
+        write_position(value, position);
+        true
+    }
+
+    fn map_range_value(
+        &self,
+        value: &mut Value,
+        direction: Direction,
+        context: Option<&RequestDocumentContext>,
+    ) -> bool {
+        let Some(range) = parse_range(value) else {
+            return true;
+        };
+        let Some(range) = self.map_range(range, direction, context) else {
+            return false;
+        };
+        write_range(value, range);
+        true
+    }
+
+    fn map_position(
+        &self,
+        position: Position,
+        direction: Direction,
+        context: Option<&RequestDocumentContext>,
+    ) -> Option<Position> {
+        let Some(context) = context else {
+            return Some(position);
+        };
+        if let Some(text) = &context.plain_text {
+            return Some(match direction {
+                Direction::SourceToShadow => plain_source_to_tsgo(text, position),
+                Direction::ShadowToSource => plain_tsgo_to_source(text, position),
+            });
+        }
+        let overlay = self.overlay_for_context(context)?;
+        match direction {
+            Direction::SourceToShadow => {
+                let mapped = overlay.map_source_position(&context.source_path, position)?;
+                (!overlay.is_generated_position(&context.shadow_path, mapped)).then_some(mapped)
+            }
+            Direction::ShadowToSource => {
+                overlay.map_generated_position(&context.shadow_path, position)
+            }
+        }
+    }
+
+    fn map_range(
+        &self,
+        range: Range,
+        direction: Direction,
+        context: Option<&RequestDocumentContext>,
+    ) -> Option<Range> {
+        let Some(context) = context else {
+            return Some(range);
+        };
+        if let Some(text) = &context.plain_text {
+            return Some(match direction {
+                Direction::SourceToShadow => Range::new(
+                    plain_source_to_tsgo(text, range.start),
+                    plain_source_to_tsgo(text, range.end),
+                ),
+                Direction::ShadowToSource => Range::new(
+                    plain_tsgo_to_source(text, range.start),
+                    plain_tsgo_to_source(text, range.end),
+                ),
+            });
+        }
+        let overlay = self.overlay_for_context(context)?;
+        match direction {
+            Direction::SourceToShadow => {
+                let mapped = overlay.map_source_range(&context.source_path, range)?;
+                (!overlay.is_generated_range(&context.shadow_path, mapped)).then_some(mapped)
+            }
+            Direction::ShadowToSource => overlay.map_generated_range(&context.shadow_path, range),
+        }
+    }
+
+    fn map_semantic_tokens(&self, result: &mut Value) -> bool {
+        let Some(context) = self.default_document.as_ref() else {
+            return true;
+        };
+        let Some(data) = result.get_mut("data") else {
+            return true;
+        };
+        let Some(data) = data.as_array_mut() else {
+            return false;
+        };
+        if data.len() % 5 != 0 {
+            return false;
+        }
+        let input = std::mem::take(data);
+
+        let mut line = 0u32;
+        let mut character = 0u32;
+        let mut tokens = Vec::with_capacity(input.len() / 5);
+        for encoded in input.chunks_exact(5) {
+            let Some(delta_line) = json_u32(&encoded[0]) else {
+                return false;
+            };
+            let Some(delta_start) = json_u32(&encoded[1]) else {
+                return false;
+            };
+            let Some(length) = json_u32(&encoded[2]) else {
+                return false;
+            };
+            let Some(token_type) = json_u32(&encoded[3]) else {
+                return false;
+            };
+            let Some(modifiers) = json_u32(&encoded[4]) else {
+                return false;
+            };
+            let Some(next_line) = line.checked_add(delta_line) else {
+                return false;
+            };
+            character = if delta_line == 0 {
+                let Some(next) = character.checked_add(delta_start) else {
+                    return false;
+                };
+                next
+            } else {
+                delta_start
+            };
+            line = next_line;
+
+            let Some(end_character) = character.checked_add(length) else {
+                return false;
+            };
+            let generated = Range::new(
+                Position::new(line, character),
+                Position::new(line, end_character),
+            );
+            let Some(source) = self.map_range(generated, Direction::ShadowToSource, Some(context))
+            else {
+                continue;
+            };
+            if source.start.line != source.end.line
+                || source.start.character >= source.end.character
+            {
+                continue;
+            }
+            tokens.push((
+                source.start.line,
+                source.start.character,
+                source.end.character - source.start.character,
+                token_type,
+                modifiers,
+            ));
+        }
+
+        tokens.sort_unstable();
+        tokens.dedup();
+        let mut encoded = Vec::with_capacity(tokens.len() * 5);
+        let mut previous_line = 0u32;
+        let mut previous_character = 0u32;
+        for (line, character, length, token_type, modifiers) in tokens {
+            let delta_line = line - previous_line;
+            let delta_start = if delta_line == 0 {
+                character - previous_character
+            } else {
+                character
+            };
+            encoded.extend([
+                Value::from(delta_line),
+                Value::from(delta_start),
+                Value::from(length),
+                Value::from(token_type),
+                Value::from(modifiers),
+            ]);
+            previous_line = line;
+            previous_character = character;
+        }
+        *data = encoded;
+        true
+    }
+
+    fn overlay_for_context(&self, context: &RequestDocumentContext) -> Option<&'a TsgoOverlay> {
+        self.overlays.iter().find(|overlay| {
+            overlay
+                .shadow_for_source(&context.source_path)
+                .is_some_and(|shadow| shadow.shadow_uri == context.shadow_uri)
+        })
+    }
+
+    fn alias_for_uri(&self, uri: &str) -> Option<&UriAlias> {
+        self.aliases
+            .iter()
+            .find(|alias| alias.source_uri.as_str() == uri || alias.shadow_uri.as_str() == uri)
+    }
+
+    fn context_for_uri(&self, uri: &str) -> Option<RequestDocumentContext> {
+        self.alias_for_uri(uri)
+            .map(|alias| alias.projection.clone())
+            .or_else(|| document_context_for_uri_in(self.overlays, uri))
+    }
+
+    fn object_document_context(
+        &self,
+        object: &Map<String, Value>,
+    ) -> Option<RequestDocumentContext> {
+        object
+            .get("uri")
+            .or_else(|| object.get("documentUri"))
+            .and_then(Value::as_str)
+            .or_else(|| {
+                object
+                    .get("textDocument")
+                    .and_then(Value::as_object)
+                    .and_then(|document| document.get("uri"))
+                    .and_then(Value::as_str)
+            })
+            .and_then(|uri| self.context_for_uri(uri))
+    }
+}
+
+#[derive(Clone, Copy)]
+enum Direction {
+    SourceToShadow,
+    ShadowToSource,
+}
+
+const URI_FIELDS: &[&str] = &["uri", "documentUri", "targetUri", "oldUri", "newUri"];
+const URI_KEYED_MAPS: &[&str] = &["changes", "relatedDocuments"];
+const FOLDING_FIELDS: &[&str] = &["startLine", "startCharacter", "endLine", "endCharacter"];
+
+fn is_range_field(key: &str) -> bool {
+    matches!(
+        key,
+        "range"
+            | "selectionRange"
+            | "targetRange"
+            | "targetSelectionRange"
+            | "originSelectionRange"
+            | "insert"
+            | "replace"
+    )
+}
+
+fn is_semantic_tokens_method(method: &str) -> bool {
+    method == "textDocument/semanticTokens/full" || method == "textDocument/semanticTokens/range"
+}
+
+fn find_request_uri(value: &Value) -> Option<&str> {
+    let object = value.as_object()?;
+    object
+        .get("textDocument")
+        .and_then(Value::as_object)
+        .and_then(|document| document.get("uri"))
+        .and_then(Value::as_str)
+        .or_else(|| object.get("uri").and_then(Value::as_str))
+        .or_else(|| object.get("documentUri").and_then(Value::as_str))
+        .or_else(|| {
+            object
+                .get("item")
+                .and_then(Value::as_object)
+                .and_then(|item| item.get("uri"))
+                .and_then(Value::as_str)
+        })
+}
+
+fn document_context_for_uri_in(
+    overlays: &[TsgoOverlay],
+    uri: &str,
+) -> Option<RequestDocumentContext> {
+    Uri::from_str(uri).ok()?;
+    let path = uri_to_path(uri);
+    if let Some((_, shadow)) = overlays
+        .iter()
+        .filter_map(|overlay| {
+            overlay
+                .shadow_for_source(&path)
+                .map(|shadow| (overlay, shadow))
+        })
+        .max_by_key(|(overlay, _)| overlay.workspace().components().count())
+    {
+        return Some(RequestDocumentContext {
+            source_uri: shadow.source_uri.clone(),
+            shadow_uri: shadow.shadow_uri.clone(),
+            source_path: uri_to_path(shadow.source_uri.as_str()),
+            shadow_path: uri_to_path(shadow.shadow_uri.as_str()),
+            plain_text: None,
+        });
+    }
+    for overlay in overlays {
+        if let Some(source_path) = overlay.source_for_shadow(&path) {
+            let shadow = overlay.shadow_for_source(source_path)?;
+            return Some(RequestDocumentContext {
+                source_uri: shadow.source_uri.clone(),
+                shadow_uri: shadow.shadow_uri.clone(),
+                source_path: source_path.to_path_buf(),
+                shadow_path: path,
+                plain_text: None,
+            });
+        }
+    }
+    plain_disk_context(uri, &path)
+}
+
+fn plain_disk_context(uri: &str, path: &Path) -> Option<RequestDocumentContext> {
+    if !uri.starts_with("file://") || !is_script_path(path) {
+        return None;
+    }
+    let text: Arc<str> = fs::read_to_string(path).ok()?.into();
+    let uri = Uri::from_str(uri).ok()?;
+    Some(RequestDocumentContext {
+        source_uri: uri.clone(),
+        shadow_uri: uri,
+        source_path: path.to_path_buf(),
+        shadow_path: path.to_path_buf(),
+        plain_text: Some(text),
+    })
+}
+
+fn is_script_path(path: &Path) -> bool {
+    path.extension()
+        .and_then(|extension| extension.to_str())
+        .is_some_and(|extension| {
+            matches!(
+                extension.to_ascii_lowercase().as_str(),
+                "ts" | "tsx" | "mts" | "cts" | "js" | "jsx" | "mjs" | "cjs"
+            )
+        })
+}
+
+fn plain_source_to_tsgo(text: &str, position: Position) -> Position {
+    let offset = LineIndex::new(text).offset(text, position);
+    utf8_position(text, offset)
+}
+
+fn plain_tsgo_to_source(text: &str, position: Position) -> Position {
+    let offset = utf8_offset(text, position);
+    LineIndex::new(text).position(text, offset)
+}
+
+fn utf8_position(text: &str, offset: usize) -> Position {
+    let offset = floor_char_boundary(text, offset.min(text.len()));
+    let line = text.as_bytes()[..offset]
+        .iter()
+        .filter(|byte| **byte == b'\n')
+        .count();
+    let line_start = text.as_bytes()[..offset]
+        .iter()
+        .rposition(|byte| *byte == b'\n')
+        .map_or(0, |position| position + 1);
+    Position::new(
+        u32::try_from(line).unwrap_or(u32::MAX),
+        u32::try_from(offset - line_start).unwrap_or(u32::MAX),
+    )
+}
+
+fn utf8_offset(text: &str, position: Position) -> usize {
+    let mut line = 0u32;
+    let mut line_start = 0usize;
+    for (index, byte) in text.bytes().enumerate() {
+        if line == position.line {
+            break;
+        }
+        if byte == b'\n' {
+            line += 1;
+            line_start = index + 1;
+        }
+    }
+    if line != position.line {
+        return text.len();
+    }
+    let line_end = text[line_start..]
+        .find('\n')
+        .map_or(text.len(), |relative| line_start + relative);
+    floor_char_boundary(
+        text,
+        line_start
+            .saturating_add(position.character as usize)
+            .min(line_end),
+    )
+}
+
+fn floor_char_boundary(text: &str, mut offset: usize) -> usize {
+    while offset > 0 && !text.is_char_boundary(offset) {
+        offset -= 1;
+    }
+    offset
+}
+
+fn is_position(value: &Value) -> bool {
+    let Some(object) = value.as_object() else {
+        return false;
+    };
+    object.len() == 2
+        && object
+            .get("line")
+            .is_some_and(|value| json_u32(value).is_some())
+        && object
+            .get("character")
+            .is_some_and(|value| json_u32(value).is_some())
+}
+
+fn parse_position(value: &Value) -> Option<Position> {
+    let object = value.as_object()?;
+    Some(Position::new(
+        json_u32(object.get("line")?)?,
+        json_u32(object.get("character")?)?,
+    ))
+}
+
+fn write_position(value: &mut Value, position: Position) {
+    let Some(object) = value.as_object_mut() else {
+        return;
+    };
+    object.insert("line".to_string(), Value::from(position.line));
+    object.insert("character".to_string(), Value::from(position.character));
+}
+
+fn is_range(value: &Value) -> bool {
+    let Some(object) = value.as_object() else {
+        return false;
+    };
+    object.len() == 2
+        && object.get("start").is_some_and(is_position)
+        && object.get("end").is_some_and(is_position)
+}
+
+fn parse_range(value: &Value) -> Option<Range> {
+    let object = value.as_object()?;
+    Some(Range::new(
+        parse_position(object.get("start")?)?,
+        parse_position(object.get("end")?)?,
+    ))
+}
+
+fn write_range(value: &mut Value, range: Range) {
+    let Some(object) = value.as_object_mut() else {
+        return;
+    };
+    if let Some(start) = object.get_mut("start") {
+        write_position(start, range.start);
+    }
+    if let Some(end) = object.get_mut("end") {
+        write_position(end, range.end);
+    }
+}
+
+fn json_u32(value: &Value) -> Option<u32> {
+    value.as_u64().and_then(|value| u32::try_from(value).ok())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    use serde_json::json;
+
+    use super::*;
+    use crate::uri::path_to_uri;
+
+    struct Workspace(PathBuf);
+
+    impl Workspace {
+        fn new() -> Self {
+            let nonce = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_nanos();
+            let root = std::env::temp_dir().join(format!(
+                "rsvelte-tsgo-response-{}-{nonce}",
+                std::process::id()
+            ));
+            fs::create_dir_all(&root).unwrap();
+            Self(root)
+        }
+    }
+
+    impl Drop for Workspace {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.0);
+        }
+    }
+
+    fn overlay(source: &str) -> (Workspace, PathBuf, TsgoOverlay) {
+        let workspace = Workspace::new();
+        let path = workspace.0.join("src/App.svelte");
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(&path, source).unwrap();
+        let overlay = TsgoOverlay::build(&workspace.0, None).unwrap();
+        (workspace, path, overlay)
+    }
+
+    fn source_range(source: &str, needle: &str) -> Range {
+        let start = source.find(needle).unwrap();
+        let index = crate::text::LineIndex::new(source);
+        Range::new(
+            index.position(source, start),
+            index.position(source, start + needle.len()),
+        )
+    }
+
+    fn json_range(range: Range) -> Value {
+        json!({
+            "start": { "line": range.start.line, "character": range.start.character },
+            "end": { "line": range.end.line, "character": range.end.character }
+        })
+    }
+
+    #[test]
+    fn request_context_round_trips_uri_position_and_range() {
+        let source = "<script lang=\"ts\">\nconst 名前 = \"💡\";\nconsole.log(名前);\n</script>\n";
+        let (_workspace, path, overlay) = overlay(source);
+        let source_uri = overlay.shadow_for_source(&path).unwrap().source_uri.clone();
+        let range = source_range(source, "名前");
+        let mut params = json!({
+            "textDocument": { "uri": source_uri.as_str() },
+            "position": { "line": range.start.line, "character": range.start.character },
+            "range": json_range(range)
+        });
+        let mapper = TsgoResponseMapper::for_request(&overlay, &params);
+        let context = mapper.default_document().cloned().unwrap();
+        assert!(mapper.map_request("textDocument/hover", &mut params));
+        assert_eq!(params["textDocument"]["uri"], context.shadow_uri.as_str());
+
+        let generated_range = parse_range(&params["range"]).unwrap();
+        let mut response = json!({
+            "contents": { "kind": "markdown", "value": "type" },
+            "range": json_range(generated_range)
+        });
+        let mapper = TsgoResponseMapper::with_default_document(&overlay, Some(context));
+        assert!(mapper.map_response("textDocument/hover", &mut response));
+        assert_eq!(parse_range(&response["range"]), Some(range));
+    }
+
+    #[test]
+    fn locations_workspace_edits_and_nested_symbols_map_recursively() {
+        let source = "<script>\nlet value = 1;\nconsole.log(value);\n</script>";
+        let (_workspace, path, overlay) = overlay(source);
+        let shadow = overlay.shadow_for_source(&path).unwrap();
+        let source_range = source_range(source, "value");
+        let generated = overlay.map_source_range(&path, source_range).unwrap();
+        let shadow_uri = shadow.shadow_uri.clone();
+        let source_uri = shadow.source_uri.clone();
+        let mut response = json!({
+            "locations": [{ "uri": shadow_uri.as_str(), "range": json_range(generated) }],
+            "edit": {
+                "changes": {
+                    shadow_uri.as_str(): [{ "range": json_range(generated), "newText": "next" }]
+                },
+                "documentChanges": [{
+                    "textDocument": { "uri": shadow_uri.as_str(), "version": 1 },
+                    "edits": [{ "range": json_range(generated), "newText": "next" }]
+                }]
+            },
+            "symbols": [{
+                "name": "value",
+                "kind": 13,
+                "range": json_range(generated),
+                "selectionRange": json_range(generated),
+                "children": []
+            }]
+        });
+        let context = TsgoResponseMapper::new(&overlay)
+            .document_context(&source_uri)
+            .unwrap();
+        let mapper = TsgoResponseMapper::with_default_document(&overlay, Some(context));
+        assert!(mapper.map_response("test", &mut response));
+        assert_eq!(response["locations"][0]["uri"], source_uri.as_str());
+        assert_eq!(
+            parse_range(&response["locations"][0]["range"]),
+            Some(source_range)
+        );
+        assert!(
+            response["edit"]["changes"]
+                .get(source_uri.as_str())
+                .is_some()
+        );
+        assert_eq!(
+            response["edit"]["documentChanges"][0]["textDocument"]["uri"],
+            source_uri.as_str()
+        );
+        assert_eq!(
+            parse_range(&response["symbols"][0]["selectionRange"]),
+            Some(source_range)
+        );
+    }
+
+    #[test]
+    fn one_response_maps_shadow_locations_from_multiple_workspaces() {
+        let source = "<script>let value = 1;</script>";
+        let (_first_workspace, first_path, first_overlay) = overlay(source);
+        let (_second_workspace, second_path, second_overlay) = overlay(source);
+        let range = source_range(source, "value");
+        let first_generated = first_overlay.map_source_range(&first_path, range).unwrap();
+        let second_generated = second_overlay
+            .map_source_range(&second_path, range)
+            .unwrap();
+        let first_shadow = first_overlay.shadow_for_source(&first_path).unwrap();
+        let second_shadow = second_overlay.shadow_for_source(&second_path).unwrap();
+        let first_shadow_uri = first_shadow.shadow_uri.clone();
+        let first_source_uri = first_shadow.source_uri.clone();
+        let second_shadow_uri = second_shadow.shadow_uri.clone();
+        let second_source_uri = second_shadow.source_uri.clone();
+        let overlays = [first_overlay, second_overlay];
+        let mut response = json!([
+            { "uri": first_shadow_uri.as_str(), "range": json_range(first_generated) },
+            { "uri": second_shadow_uri.as_str(), "range": json_range(second_generated) }
+        ]);
+
+        let mapper = TsgoResponseMapper::for_overlays(&overlays);
+        assert!(mapper.map_response("workspace/symbol", &mut response));
+        assert_eq!(response[0]["uri"], first_source_uri.as_str());
+        assert_eq!(response[1]["uri"], second_source_uri.as_str());
+        assert_eq!(parse_range(&response[0]["range"]), Some(range));
+        assert_eq!(parse_range(&response[1]["range"]), Some(range));
+    }
+
+    #[test]
+    fn unopened_plain_and_node_module_files_cross_utf8_utf16_on_disk() {
+        let source = "<script>let value = 1;</script>";
+        let (workspace, _path, overlay) = overlay(source);
+        let dependency = workspace.0.join("node_modules/pkg/index.d.ts");
+        fs::create_dir_all(dependency.parent().unwrap()).unwrap();
+        let text = "export const icon = '😀'; export const 名前 = icon;\n";
+        fs::write(&dependency, text).unwrap();
+        let uri = path_to_uri(&dependency).unwrap();
+        let source_start = text.find("名前").unwrap();
+        let source_range = Range::new(
+            LineIndex::new(text).position(text, source_start),
+            LineIndex::new(text).position(text, source_start + "名前".len()),
+        );
+        let tsgo_range = Range::new(
+            plain_source_to_tsgo(text, source_range.start),
+            plain_source_to_tsgo(text, source_range.end),
+        );
+        assert_ne!(source_range.start.character, tsgo_range.start.character);
+
+        let mut response = json!({
+            "uri": uri.as_str(),
+            "range": json_range(tsgo_range)
+        });
+        let mapper = TsgoResponseMapper::new(&overlay);
+        assert!(mapper.map_response("textDocument/definition", &mut response));
+        assert_eq!(parse_range(&response["range"]), Some(source_range));
+
+        let mut params = json!({
+            "textDocument": { "uri": uri.as_str() },
+            "position": {
+                "line": source_range.start.line,
+                "character": source_range.start.character
+            },
+            "range": json_range(source_range)
+        });
+        let mapper = TsgoResponseMapper::for_request(&overlay, &params);
+        assert!(mapper.default_document().is_some());
+        assert!(mapper.map_request("textDocument/hover", &mut params));
+        assert_eq!(params["textDocument"]["uri"], uri.as_str());
+        assert_eq!(parse_range(&params["range"]), Some(tsgo_range));
+    }
+
+    #[test]
+    fn prospective_shadow_alias_uses_old_projection_and_new_visible_uri() {
+        let source = "<script>const 💡 = 1; let value = 💡;</script>";
+        let (workspace, old_path, overlay) = overlay(source);
+        let old = overlay.shadow_for_source(&old_path).unwrap();
+        let old_source_uri = old.source_uri.clone();
+        let old_shadow_uri = old.shadow_uri.clone();
+        let source_range = source_range(source, "value");
+        let generated = overlay.map_source_range(&old_path, source_range).unwrap();
+        let new_source_uri = path_to_uri(&workspace.0.join("src/Renamed.svelte")).unwrap();
+        let new_shadow_uri =
+            path_to_uri(&overlay.cache_dir().join("svelte/src/Renamed.svelte.tsx")).unwrap();
+
+        let mut mapper = TsgoResponseMapper::new(&overlay);
+        assert!(mapper.add_uri_alias(
+            new_source_uri.clone(),
+            new_shadow_uri.clone(),
+            &old_source_uri,
+        ));
+        assert!(!mapper.add_uri_alias(
+            old_source_uri.clone(),
+            new_shadow_uri.clone(),
+            &old_source_uri,
+        ));
+
+        let mut response = json!({
+            "changes": {
+                new_shadow_uri.as_str(): [{
+                    "range": json_range(generated),
+                    "newText": "renamed"
+                }],
+                old_shadow_uri.as_str(): [{
+                    "range": json_range(generated),
+                    "newText": "old"
+                }]
+            }
+        });
+        assert!(mapper.map_response("workspace/willRenameFiles", &mut response));
+        assert_eq!(
+            parse_range(&response["changes"][new_source_uri.as_str()][0]["range"]),
+            Some(source_range)
+        );
+        assert_eq!(
+            parse_range(&response["changes"][old_source_uri.as_str()][0]["range"]),
+            Some(source_range)
+        );
+
+        let mut request = json!({
+            "textDocument": { "uri": new_source_uri.as_str() },
+            "range": json_range(source_range)
+        });
+        assert!(mapper.map_request("textDocument/hover", &mut request));
+        assert_eq!(request["textDocument"]["uri"], new_shadow_uri.as_str());
+        assert_eq!(parse_range(&request["range"]), Some(generated));
+    }
+
+    #[test]
+    fn nested_workspace_uses_the_most_specific_shadow() {
+        let workspace = Workspace::new();
+        let nested = workspace.0.join("packages/app");
+        let path = nested.join("src/App.svelte");
+        let source = "<script>let value = 1;</script>";
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(&path, source).unwrap();
+        let parent_overlay = TsgoOverlay::build(&workspace.0, None).unwrap();
+        let nested_overlay = TsgoOverlay::build(&nested, None).unwrap();
+        let nested_shadow = nested_overlay.shadow_for_source(&path).unwrap();
+        let nested_shadow_uri = nested_shadow.shadow_uri.clone();
+        let source_uri = nested_shadow.source_uri.clone();
+        let overlays = [parent_overlay, nested_overlay];
+        let range = source_range(source, "value");
+        let mut params = json!({
+            "textDocument": { "uri": source_uri.as_str() },
+            "position": {
+                "line": range.start.line,
+                "character": range.start.character
+            }
+        });
+
+        let mapper = TsgoResponseMapper::for_overlays_request(&overlays, &params);
+        assert_eq!(
+            mapper.default_document().unwrap().shadow_uri(),
+            &nested_shadow_uri
+        );
+        assert!(mapper.map_request("textDocument/hover", &mut params));
+        assert_eq!(params["textDocument"]["uri"], nested_shadow_uri.as_str());
+    }
+
+    #[test]
+    fn generated_array_elements_are_dropped() {
+        let source = "<script>let value;</script><p>{value}</p>";
+        let (_workspace, path, overlay) = overlay(source);
+        let shadow = overlay.shadow_for_source(&path).unwrap();
+        let shadow_path = uri_to_path(shadow.shadow_uri.as_str());
+        let ignored_offset =
+            shadow.text.find("/*Ωignore_startΩ*/").unwrap() + "/*Ωignore_startΩ*/".len();
+        let ignored =
+            crate::text::LineIndex::new(&shadow.text).position(&shadow.text, ignored_offset);
+        let source_range = source_range(source, "value");
+        let generated = overlay.map_source_range(&path, source_range).unwrap();
+        assert!(overlay.is_generated_position(&shadow_path, ignored));
+
+        let mut result = json!([
+            { "uri": shadow.shadow_uri.as_str(), "range": json_range(Range::new(ignored, ignored)) },
+            { "uri": shadow.shadow_uri.as_str(), "range": json_range(generated) }
+        ]);
+        let mapper = TsgoResponseMapper::new(&overlay);
+        assert!(mapper.map_response("textDocument/definition", &mut result));
+        assert_eq!(result.as_array().unwrap().len(), 1);
+        assert_eq!(parse_range(&result[0]["range"]), Some(source_range));
+    }
+
+    #[test]
+    fn semantic_tokens_decode_map_filter_sort_and_reencode_utf16() {
+        let source = "<script lang=\"ts\">\nconst 💡name = 1;\nconsole.log(💡name);\n</script>";
+        let (_workspace, path, overlay) = overlay(source);
+        let shadow = overlay.shadow_for_source(&path).unwrap();
+        let first_source = source_range(source, "name");
+        let second_start = source.rfind("name").unwrap();
+        let index = crate::text::LineIndex::new(source);
+        let second_source = Range::new(
+            index.position(source, second_start),
+            index.position(source, second_start + 4),
+        );
+        let first = overlay.map_source_range(&path, first_source).unwrap();
+        let second = overlay.map_source_range(&path, second_source).unwrap();
+        assert_eq!(first.start.line, first.end.line);
+        assert_eq!(second.start.line, second.end.line);
+
+        let mut generated = [first, second];
+        generated.sort_by_key(|range| (range.start.line, range.start.character));
+        let mut data = Vec::new();
+        let mut line = 0;
+        let mut character = 0;
+        for range in generated {
+            let delta_line = range.start.line - line;
+            let delta_start = if delta_line == 0 {
+                range.start.character - character
+            } else {
+                range.start.character
+            };
+            data.extend([
+                delta_line,
+                delta_start,
+                range.end.character - range.start.character,
+                7,
+                0,
+            ]);
+            line = range.start.line;
+            character = range.start.character;
+        }
+        let mut result = json!({ "data": data });
+        let context = TsgoResponseMapper::new(&overlay)
+            .document_context(&shadow.source_uri)
+            .unwrap();
+        let mapper = TsgoResponseMapper::with_default_document(&overlay, Some(context));
+        assert!(mapper.map_response("textDocument/semanticTokens/full", &mut result));
+
+        let encoded = result["data"].as_array().unwrap();
+        assert_eq!(encoded.len(), 10);
+        assert_eq!(encoded[0], first_source.start.line);
+        assert_eq!(encoded[1], first_source.start.character);
+        assert_eq!(encoded[2], 4);
+        assert_eq!(
+            encoded[5],
+            second_source.start.line - first_source.start.line
+        );
+        assert_eq!(encoded[6], second_source.start.character);
+        assert_eq!(encoded[7], 4);
+        assert_eq!(first_source.end.character - first_source.start.character, 4);
+    }
+
+    #[test]
+    fn plain_typescript_values_and_completion_data_are_opaque() {
+        let workspace = Workspace::new();
+        fs::write(workspace.0.join("empty.txt"), "").unwrap();
+        let overlay = TsgoOverlay::build(&workspace.0, None).unwrap();
+        let mut value = json!({
+            "uri": "file:///plain.ts",
+            "range": {
+                "start": { "line": 1, "character": 2 },
+                "end": { "line": 1, "character": 4 }
+            },
+            "data": {
+                "uri": "file:///generated.svelte.tsx",
+                "range": {
+                    "start": { "line": 99, "character": 0 },
+                    "end": { "line": 99, "character": 1 }
+                }
+            }
+        });
+        let original = value.clone();
+        let mapper = TsgoResponseMapper::new(&overlay);
+        assert!(mapper.map_response("completionItem/resolve", &mut value));
+        assert_eq!(value, original);
+    }
+}

--- a/crates/rsvelte_language_server/src/uri.rs
+++ b/crates/rsvelte_language_server/src/uri.rs
@@ -1,6 +1,9 @@
 //! Document URI → filesystem path.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
+use std::str::FromStr;
+
+use lsp_types::Uri;
 
 /// Return the filesystem path denoted by a document URI.
 ///
@@ -24,6 +27,27 @@ pub fn uri_to_path(uri: &str) -> PathBuf {
         return PathBuf::from(&decoded[1..]);
     }
     PathBuf::from(decoded)
+}
+
+/// Return a percent-encoded file URI for a filesystem path.
+#[must_use]
+pub fn path_to_uri(path: &Path) -> Option<Uri> {
+    let path = path.to_string_lossy().replace('\\', "/");
+    let mut encoded = String::with_capacity(path.len() + 8);
+    for byte in path.bytes() {
+        if byte.is_ascii_alphanumeric() || matches!(byte, b'/' | b':' | b'-' | b'_' | b'.' | b'~') {
+            encoded.push(char::from(byte));
+        } else {
+            use std::fmt::Write as _;
+            write!(&mut encoded, "%{byte:02X}").ok()?;
+        }
+    }
+    let prefix = if encoded.starts_with('/') {
+        "file://"
+    } else {
+        "file:///"
+    };
+    Uri::from_str(&format!("{prefix}{encoded}")).ok()
 }
 
 fn has_drive_letter(path: &str) -> bool {

--- a/crates/rsvelte_language_server/src/worker.rs
+++ b/crates/rsvelte_language_server/src/worker.rs
@@ -10,6 +10,8 @@
 //! The resolved-config caches live here too, so the loop never touches the
 //! filesystem.
 
+use std::collections::HashMap;
+use std::fs;
 use std::panic::{AssertUnwindSafe, catch_unwind};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -19,7 +21,7 @@ use crossbeam_channel::{Receiver, Sender, unbounded};
 use lsp_server::RequestId;
 use lsp_types::{
     CodeActionOrCommand, CodeLens, CompletionList, Diagnostic, DocumentSymbolResponse,
-    FoldingRange, Hover, Range, SelectionRange, TextEdit, Uri,
+    FoldingRange, Hover, Location, Range, SelectionRange, TextEdit, Uri,
 };
 use serde_json::Value;
 
@@ -27,6 +29,8 @@ use crate::format::FormatSessions;
 use crate::lint::LintConfigCache;
 use crate::log;
 use crate::settings::CompilerWarnings;
+use crate::tsgo_custom::{WorkspaceSource, find_file_references};
+use crate::uri::path_to_uri;
 
 /// `rsvelte_core`'s own deeply-nested-AST tests reserve the same 256 MiB. It is
 /// address space, not resident memory — pages are committed only as the
@@ -107,6 +111,12 @@ pub enum Job {
         text: Arc<String>,
         warnings: CompilerWarnings,
     },
+    FileReferences {
+        id: RequestId,
+        target: PathBuf,
+        roots: Vec<PathBuf>,
+        open_documents: Vec<FileReferenceSource>,
+    },
     /// Drop the resolved `rsvelte-lint.json` / `.oxfmtrc` caches so the next
     /// job re-reads them from disk.
     ClearCaches,
@@ -159,6 +169,16 @@ pub enum Outcome {
         id: RequestId,
         diagnostics: Vec<Diagnostic>,
     },
+    FileReferences {
+        id: RequestId,
+        locations: Vec<Location>,
+    },
+}
+
+pub struct FileReferenceSource {
+    pub path: PathBuf,
+    pub uri: Uri,
+    pub text: String,
 }
 
 pub struct Worker {
@@ -376,10 +396,93 @@ fn run(jobs: &Receiver<Job>, outcomes: &Sender<Outcome>) {
                 .unwrap_or_default();
                 Outcome::PulledDiagnostics { id, diagnostics }
             }
+            Job::FileReferences {
+                id,
+                target,
+                roots,
+                open_documents,
+            } => Outcome::FileReferences {
+                id,
+                locations: file_references(&target, &roots, open_documents),
+            },
         };
         if outcomes.send(outcome).is_err() {
             break;
         }
+    }
+}
+
+fn file_references(
+    target: &Path,
+    roots: &[PathBuf],
+    open_documents: Vec<FileReferenceSource>,
+) -> Vec<Location> {
+    let mut sources = HashMap::<PathBuf, FileReferenceSource>::new();
+    for root in roots {
+        collect_source_directory(root, &mut sources);
+    }
+    for source in open_documents {
+        sources.insert(source.path.clone(), source);
+    }
+    let sources = sources.into_values().collect::<Vec<_>>();
+    let views = sources
+        .iter()
+        .map(|source| WorkspaceSource {
+            path: &source.path,
+            uri: &source.uri,
+            text: &source.text,
+        })
+        .collect::<Vec<_>>();
+    find_file_references(target, &views)
+}
+
+fn collect_source_directory(directory: &Path, sources: &mut HashMap<PathBuf, FileReferenceSource>) {
+    let Ok(entries) = fs::read_dir(directory) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let Ok(file_type) = entry.file_type() else {
+            continue;
+        };
+        if file_type.is_dir() {
+            if matches!(
+                entry.file_name().to_str(),
+                Some("node_modules" | ".git" | ".rsvelte-language-server" | "target")
+            ) {
+                continue;
+            }
+            collect_source_directory(&path, sources);
+            continue;
+        }
+        if !file_type.is_file()
+            || !path
+                .extension()
+                .and_then(|extension| extension.to_str())
+                .is_some_and(|extension| {
+                    matches!(
+                        extension,
+                        "ts" | "tsx" | "mts" | "cts" | "js" | "jsx" | "mjs" | "cjs" | "svelte"
+                    )
+                })
+        {
+            continue;
+        }
+        let Ok(text) = fs::read_to_string(&path) else {
+            continue;
+        };
+        let canonical = fs::canonicalize(&path).unwrap_or(path);
+        let Some(uri) = path_to_uri(&canonical) else {
+            continue;
+        };
+        sources.insert(
+            canonical.clone(),
+            FileReferenceSource {
+                path: canonical,
+                uri,
+                text,
+            },
+        );
     }
 }
 

--- a/crates/rsvelte_language_server/tests/protocol.rs
+++ b/crates/rsvelte_language_server/tests/protocol.rs
@@ -416,7 +416,15 @@ fn serves_diagnostics_and_formatting() {
         json!({
             "processId": Value::Null,
             "rootUri": Value::Null,
-            "capabilities": { "workspace": { "configuration": true } },
+            "capabilities": {
+                "workspace": { "configuration": true },
+                "textDocument": {
+                    "semanticTokens": {
+                        "tokenTypes": ["class", "namespace", "operator", "event"],
+                        "tokenModifiers": ["local", "declaration", "readonly"]
+                    }
+                }
+            },
         }),
     );
     let result = server.response(id);
@@ -434,7 +442,38 @@ fn serves_diagnostics_and_formatting() {
     );
     assert_eq!(
         result["capabilities"]["codeActionProvider"]["codeActionKinds"],
-        json!(["quickfix", "refactor.rewrite", "source.fixAll.rsvelte"])
+        json!([
+            "quickfix",
+            "refactor.rewrite",
+            "source.organizeImports",
+            "source.sortImports",
+            "source.removeUnusedImports",
+            "source.fixAll",
+            "source.fixAll.rsvelte"
+        ])
+    );
+    assert_eq!(result["capabilities"]["positionEncoding"], json!("utf-16"));
+    assert_eq!(result["capabilities"]["definitionProvider"], json!(true));
+    assert_eq!(
+        result["capabilities"]["typeDefinitionProvider"],
+        json!(true)
+    );
+    assert_eq!(
+        result["capabilities"]["implementationProvider"],
+        json!(true)
+    );
+    assert_eq!(result["capabilities"]["referencesProvider"], json!(true));
+    assert_eq!(
+        result["capabilities"]["renameProvider"]["prepareProvider"],
+        json!(true)
+    );
+    assert_eq!(
+        result["capabilities"]["semanticTokensProvider"]["legend"]["tokenTypes"],
+        json!(["namespace", "class", "event", "operator"])
+    );
+    assert_eq!(
+        result["capabilities"]["semanticTokensProvider"]["legend"]["tokenModifiers"],
+        json!(["declaration", "readonly", "local"])
     );
     assert_eq!(
         result["capabilities"]["workspace"]["workspaceFolders"],
@@ -1229,6 +1268,34 @@ fn the_structure_providers_survive_documents_that_do_not_parse() {
         server.selection_ranges(&missing, json!([{ "line": 0, "character": 0 }])),
         Value::Null
     );
+
+    assert_eq!(server.shutdown(), Some(0));
+}
+
+#[test]
+fn file_references_run_on_the_worker_and_are_sorted() {
+    let dir = temp_dir("file-references");
+    let target = file_uri(&dir.join("Target.svelte"));
+    let first = file_uri(&dir.join("A.svelte"));
+    let second = file_uri(&dir.join("B.svelte"));
+    let mut server = initialized_server();
+    did_open(&mut server, &target, "<p>target</p>");
+    did_open(
+        &mut server,
+        &second,
+        "<script>import Target from './Target.svelte';</script>",
+    );
+    did_open(
+        &mut server,
+        &first,
+        "<script>import './Target.svelte';</script>",
+    );
+
+    let id = server.request("$/getFileReferences", json!(target));
+    let locations = server.response(id);
+    assert_eq!(locations.as_array().map(Vec::len), Some(2));
+    assert_eq!(locations[0]["uri"], json!(first));
+    assert_eq!(locations[1]["uri"], json!(second));
 
     assert_eq!(server.shutdown(), Some(0));
 }

--- a/crates/rsvelte_language_server/tests/support/fake_tsgo.rs
+++ b/crates/rsvelte_language_server/tests/support/fake_tsgo.rs
@@ -1,0 +1,155 @@
+use std::fs;
+use std::io::{self, BufRead, Write};
+use std::path::PathBuf;
+
+fn main() {
+    let state = PathBuf::from(std::env::args_os().nth(1).expect("state path"));
+    let updated_uri = std::env::args().nth(2).expect("updated workspace URI");
+    let generation = fs::read_to_string(&state)
+        .ok()
+        .and_then(|generation| generation.parse::<u32>().ok())
+        .map_or(1, |generation| generation + 1);
+    let expected_cwd = if generation >= 3 {
+        state.parent().unwrap().join("remaining")
+    } else {
+        state.parent().unwrap().to_path_buf()
+    };
+    assert_eq!(
+        std::env::current_dir().unwrap().canonicalize().unwrap(),
+        expected_cwd.canonicalize().unwrap()
+    );
+    let stdin = io::stdin();
+    let mut input = stdin.lock();
+    let stdout = io::stdout();
+    let mut output = stdout.lock();
+
+    let initialize = read_message(&mut input).unwrap();
+    assert!(initialize.contains(r#""method":"initialize""#));
+    assert!(initialize.contains(r#""positionEncodings":["utf-8","utf-16"]"#));
+    assert!(initialize.contains(r#""configuration":true"#));
+    if generation >= 3 {
+        assert!(
+            initialize.contains(&format!(r#""rootUri":"{updated_uri}""#)),
+            "{initialize}"
+        );
+        assert!(
+            initialize.contains(&format!(r#""uri":"{updated_uri}""#)),
+            "{initialize}"
+        );
+        assert!(initialize.contains(r#""name":"remaining""#), "{initialize}");
+    } else {
+        assert!(initialize.contains(r#""rootUri":"file:///workspace""#));
+    }
+    let initialize_id = json_id(&initialize);
+    write_message(
+        &mut output,
+        &format!(
+            r#"{{"jsonrpc":"2.0","id":{initialize_id},"result":{{"capabilities":{{"positionEncoding":"utf-8","hoverProvider":true}}}}}}"#,
+        ),
+    )
+    .unwrap();
+
+    let mut initialized = false;
+    let mut configuration_ok = false;
+    let mut opened = false;
+    let mut replay_sent = false;
+    loop {
+        let message = read_message(&mut input).unwrap();
+        if message.contains(r#""method":"initialized""#) {
+            initialized = true;
+            write_message(
+                &mut output,
+                r#"{"jsonrpc":"2.0","id":77,"method":"workspace/configuration","params":{"items":[{"section":"typescript"},{"section":"javascript"}]}}"#,
+            )
+            .unwrap();
+        } else if message.contains(r#""id":77"#) && message.contains(r#""result""#) {
+            assert!(message.contains(r#""importModuleSpecifierEnding":"index""#));
+            assert!(message.contains(r#""suggest""#), "{message}");
+            configuration_ok = true;
+        } else if message.contains(r#""method":"textDocument/didOpen""#) {
+            assert!(message.contains(r#""version":4"#));
+            assert!(message.contains(r#""text":"export default 42;""#));
+            opened = true;
+        } else if message.contains(r#""method":"workspace/didChangeConfiguration""#) {
+            assert!(message.contains(r#""kind":"updated-typescript""#));
+            assert!(message.contains(r#""kind":"updated-javascript""#));
+            write_message(
+                &mut output,
+                r#"{"jsonrpc":"2.0","id":78,"method":"workspace/configuration","params":{"items":[{"section":"javascript"},{"section":"unknown","scopeUri":"file:///src/App.tsx"}]}}"#,
+            )
+            .unwrap();
+        } else if message.contains(r#""id":78"#) && message.contains(r#""result""#) {
+            let javascript = message.find("updated-javascript").unwrap();
+            let typescript = message.find("updated-typescript").unwrap();
+            assert!(javascript < typescript);
+            write_message(
+                &mut output,
+                r#"{"jsonrpc":"2.0","method":"$/test/configUpdated","params":{}}"#,
+            )
+            .unwrap();
+        } else if message.contains(r#""method":"shutdown""#) {
+            let id = json_id(&message);
+            write_message(
+                &mut output,
+                &format!(r#"{{"jsonrpc":"2.0","id":{id},"result":null}}"#),
+            )
+            .unwrap();
+        } else if message.contains(r#""method":"exit""#) {
+            return;
+        } else {
+            panic!("unexpected message: {message}");
+        }
+
+        if initialized && configuration_ok && opened && !replay_sent {
+            if generation == 1 {
+                fs::write(&state, b"1").unwrap();
+                std::process::exit(7);
+            }
+            fs::write(&state, generation.to_string()).unwrap();
+            replay_sent = true;
+            write_message(
+                &mut output,
+                &format!(
+                    r#"{{"jsonrpc":"2.0","method":"$/test/replayed","params":{{"generation":{generation},"version":4,"text":"export default 42;"}}}}"#
+                ),
+            )
+            .unwrap();
+        }
+    }
+}
+
+fn read_message(reader: &mut impl BufRead) -> io::Result<String> {
+    let mut content_length = None;
+    let mut line = String::new();
+    loop {
+        line.clear();
+        reader.read_line(&mut line)?;
+        if line == "\r\n" {
+            break;
+        }
+        if let Some(value) = line.strip_prefix("Content-Length: ") {
+            content_length = Some(value.trim().parse::<usize>().unwrap());
+        }
+    }
+    let mut body = vec![0; content_length.expect("Content-Length")];
+    reader.read_exact(&mut body)?;
+    Ok(String::from_utf8(body).unwrap())
+}
+
+fn write_message(writer: &mut impl Write, body: &str) -> io::Result<()> {
+    write!(writer, "Content-Length: {}\r\n\r\n{body}", body.len())?;
+    writer.flush()
+}
+
+fn json_id(message: &str) -> &str {
+    let rest = message.split_once(r#""id":"#).expect("id").1;
+    if let Some(rest) = rest.strip_prefix('"') {
+        let end = rest.find('"').expect("string id");
+        &message[message.len() - rest.len() - 1..message.len() - rest.len() + end + 1]
+    } else {
+        let end = rest
+            .find(|character: char| !character.is_ascii_digit() && character != '-')
+            .unwrap_or(rest.len());
+        &rest[..end]
+    }
+}

--- a/crates/rsvelte_projection/src/toolchain.rs
+++ b/crates/rsvelte_projection/src/toolchain.rs
@@ -103,6 +103,40 @@ impl ProjectionMap {
         &self.segments
     }
 
+    /// Adjust generated offsets after inserting an unmapped byte range.
+    pub fn insert_generated(&mut self, offset: u32, length: u32) {
+        if length == 0 {
+            return;
+        }
+        let mut adjusted = Vec::with_capacity(self.segments.len() + 1);
+        for segment in &self.segments {
+            let start = segment.generated.start();
+            let end = segment.generated.end();
+            if offset <= start {
+                adjusted.push(ExactMapping {
+                    source: segment.source,
+                    generated: ByteRange::trusted(start + length, end + length),
+                });
+            } else if offset >= end {
+                adjusted.push(*segment);
+            } else {
+                let left = offset - start;
+                adjusted.push(ExactMapping {
+                    source: ByteRange::trusted(
+                        segment.source.start(),
+                        segment.source.start() + left,
+                    ),
+                    generated: ByteRange::trusted(start, offset),
+                });
+                adjusted.push(ExactMapping {
+                    source: ByteRange::trusted(segment.source.start() + left, segment.source.end()),
+                    generated: ByteRange::trusted(offset + length, end + length),
+                });
+            }
+        }
+        self.segments = adjusted;
+    }
+
     /// Return every generated offset exactly corresponding to `offset`.
     #[must_use]
     pub fn source_to_generated(&self, offset: u32) -> Vec<u32> {
@@ -285,5 +319,24 @@ impl ProjectionEngine {
             exact_mappings,
             facts,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn generated_insertions_shift_and_split_exact_segments() {
+        let mut map = ProjectionMap::from_segments(vec![ExactMapping {
+            source: ByteRange::trusted(10, 20),
+            generated: ByteRange::trusted(30, 40),
+        }]);
+        map.insert_generated(35, 4);
+
+        assert_eq!(map.source_to_generated(12), vec![32]);
+        assert_eq!(map.source_to_generated(17), vec![41]);
+        assert_eq!(map.generated_to_source(36), None);
+        assert_eq!(map.generated_to_source(41), Some(17));
     }
 }


### PR DESCRIPTION
Closes #1764

## What changed

- supervise a TypeScript 7 `tsgo --lsp -stdio` child with UTF-8 negotiation, crash restart, buffer replay, workspace/configuration bridging, and workspace-folder updates
- add a diskless Svelte-to-TSX overlay with eager project shadows, bidirectional position mapping, generated-code filtering, and plain TypeScript/JavaScript proxying
- proxy the TypeScript language surface, including navigation, completion/resolve, rename, diagnostics, semantic tokens, code actions, code lenses, hierarchy, symbols, and custom reference/file-rename requests
- preserve Svelte-specific behavior for component props/events/slots, stores, legacy props, SvelteKit `$types`, component imports, script creation, and generated spans
- wire VS Code middleware/commands and update package metadata, playground docs, and the language-server roadmap

## Why

The native Rust language server previously implemented only the TypeScript-free half of the Svelte language surface. This completes the tsgo-backed proxy and Svelte mapping layer required by #1764 while keeping the editor-facing protocol compatible with the official language tools.

## Validation

- `cargo test -p rsvelte_language_server` — 258 unit tests and 20 protocol tests passed
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test -p rsvelte_projection`
- `pnpm --dir apps/npm/vscode typecheck && pnpm --dir apps/npm/vscode build`
- `pnpm --dir apps/npm/language-server build && pnpm --dir apps/npm/language-server test` — 16 passed, 1 skipped
- real TypeScript 7 LSP probe covering component completion, hover, and mapped rename
