### PR TITLE
feat(language-server): run trusted Svelte preprocessors

### DIFF
--- a/.changeset/preprocess-language-server.md
+++ b/.changeset/preprocess-language-server.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/language-server": patch
+---
+
+Apply trusted-workspace Svelte preprocessors through a supervised Node sidecar and compose their source maps with TypeScript shadow mappings.

--- a/apps/npm/language-server/README.md
+++ b/apps/npm/language-server/README.md
@@ -26,6 +26,12 @@ symbols, code actions, code lenses and pull diagnostics through tsgo. Svelte
 components use eagerly opened, diskless `.svelte.tsx` shadows; plain `.ts` and
 `.js` documents share the same project.
 
+In trusted workspaces, the server loads the nearest `svelte.config.*` through a
+supervised Node sidecar and applies its preprocessors before generating the
+TypeScript shadow. Preprocessor source maps keep diagnostics and TypeScript
+locations in original-source coordinates. Config files are never executed in
+an untrusted workspace.
+
 Install TypeScript 7 in the workspace, or set `TSGO_BIN` to its executable:
 
 ```sh
@@ -47,6 +53,7 @@ The server reads these from the client's `rsvelte.*` configuration:
 | --- | --- | --- |
 | `rsvelte.format.enable` | `true` | Enable formatting via `rsvelte-fmt`. |
 | `rsvelte.lint.enable` | `true` | Enable linting via the bundled engine. |
+| `rsvelte.preprocess.enable` | `true` | Apply preprocessors from `svelte.config.*` in trusted workspaces. |
 | `rsvelte.rsvelteFmtPath` | `""` | Explicit path to a `rsvelte-fmt` binary (overrides resolution). |
 
 ## Lint configuration

--- a/apps/npm/language-server/bin/rsvelte-language-server.mjs
+++ b/apps/npm/language-server/bin/rsvelte-language-server.mjs
@@ -61,7 +61,14 @@ if (override) {
 	}
 }
 
-const result = spawnSync(command, args, { stdio: 'inherit', windowsHide: true });
+const result = spawnSync(command, args, {
+	stdio: 'inherit',
+	windowsHide: true,
+	env: {
+		...process.env,
+		RSVELTE_PREPROCESS_NODE: process.env.RSVELTE_PREPROCESS_NODE ?? process.execPath,
+	},
+});
 
 if (result.error) {
 	console.error(

--- a/apps/npm/vscode/README.md
+++ b/apps/npm/vscode/README.md
@@ -25,6 +25,9 @@ and launches it over stdio.
 - **TypeScript language features** — hover, component-aware completion,
   definitions, references, rename, diagnostics, semantic tokens, code actions
   and reference/implementation code lenses through the native tsgo proxy.
+- **Project preprocessors** — trusted workspaces apply the nearest
+  `svelte.config.*` before type projection, with source-mapped diagnostics and
+  TypeScript locations. Workspace config is never executed in restricted mode.
 
 TypeScript features require TypeScript 7 in the workspace (or `TSGO_BIN`);
 native formatting, linting and template/CSS providers remain available without
@@ -88,6 +91,7 @@ doesn't conflict with the official Svelte extension):
 | --- | --- | --- |
 | `rsvelte.format.enable` | `true` | Enable formatting via `rsvelte-fmt`. |
 | `rsvelte.lint.enable` | `true` | Enable linting via the bundled engine. |
+| `rsvelte.preprocess.enable` | `true` | Apply preprocessors from `svelte.config.*` in trusted workspaces. |
 | `rsvelte.rsvelteFmtPath` | `""` | Explicit path to a `rsvelte-fmt` binary. |
 
 ## Lint configuration

--- a/apps/npm/vscode/package.json
+++ b/apps/npm/vscode/package.json
@@ -256,6 +256,11 @@
           "default": true,
           "description": "Enable linting via the bundled rsvelte_lint engine."
         },
+        "rsvelte.preprocess.enable": {
+          "type": "boolean",
+          "default": true,
+          "description": "In trusted workspaces, load svelte.config.* and run project preprocessors for editor features. Disable to prevent starting the Node sidecar."
+        },
         "rsvelte.rsvelteFmtPath": {
           "type": "string",
           "default": "",

--- a/apps/npm/vscode/src/extension.ts
+++ b/apps/npm/vscode/src/extension.ts
@@ -216,6 +216,7 @@ function createClient(
   const clientOptions: LanguageClientOptions = {
     documentSelector: DOCUMENT_SELECTOR,
     outputChannel: channel,
+    initializationOptions: { isTrusted: workspace.isTrusted },
     synchronize: {
       // Forward `rsvelte.*` configuration changes to the server.
       configurationSection: "rsvelte",
@@ -545,6 +546,7 @@ export function activate(context: ExtensionContext): void {
         void client.setTrace(traceFromConfig());
       }
     }),
+    workspace.onDidGrantWorkspaceTrust(() => restartLanguageServer()),
   );
 }
 

--- a/crates/rsvelte_language_server/src/client.rs
+++ b/crates/rsvelte_language_server/src/client.rs
@@ -30,12 +30,16 @@ pub struct ClientState {
     pub hierarchical_document_symbols: bool,
     /// Whether the client supports LSP 3.17 pull diagnostics.
     pub pull_diagnostics: bool,
+    /// Whether the client accepts `workspace/diagnostic/refresh` requests.
+    pub diagnostic_refresh: bool,
     /// Whether the client accepts dynamic watched-file registrations.
     pub dynamic_watched_files: bool,
     /// Semantic token types the client advertised, in client order.
     pub semantic_token_types: Vec<String>,
     /// Semantic token modifiers the client advertised, in client order.
     pub semantic_token_modifiers: Vec<String>,
+    /// Whether project JavaScript such as `svelte.config.js` may be executed.
+    pub is_trusted: bool,
 }
 
 impl ClientState {
@@ -59,6 +63,7 @@ impl ClientState {
             pull_diagnostics: params
                 .pointer("/capabilities/textDocument/diagnostic")
                 .is_some(),
+            diagnostic_refresh: flag(params, "/capabilities/workspace/diagnostics/refreshSupport"),
             dynamic_watched_files: flag(
                 params,
                 "/capabilities/workspace/didChangeWatchedFiles/dynamicRegistration",
@@ -71,6 +76,10 @@ impl ClientState {
                 params.pointer("/capabilities/textDocument/semanticTokens/tokenModifiers"),
             )
             .unwrap_or_default(),
+            is_trusted: params
+                .pointer("/initializationOptions/isTrusted")
+                .and_then(Value::as_bool)
+                .unwrap_or(true),
         }
     }
 
@@ -117,10 +126,12 @@ mod tests {
             "rootUri": "file:///home/u/app",
             "workspaceFolders": [{ "uri": "file:///home/u/app", "name": "app" }],
             "clientInfo": { "name": "Visual Studio Code", "version": "1.99.0" },
+            "initializationOptions": { "isTrusted": false },
             "capabilities": {
                 "workspace": {
                     "configuration": true,
                     "didChangeWatchedFiles": { "dynamicRegistration": true },
+                    "diagnostics": { "refreshSupport": true },
                 },
                 "general": { "positionEncodings": ["utf-16"] },
                 "textDocument": {
@@ -147,9 +158,11 @@ mod tests {
         assert!(state.line_folding_only);
         assert!(state.hierarchical_document_symbols);
         assert!(!state.pull_diagnostics);
+        assert!(state.diagnostic_refresh);
         assert!(state.dynamic_watched_files);
         assert_eq!(state.semantic_token_types, ["namespace", "class"]);
         assert_eq!(state.semantic_token_modifiers, ["declaration", "readonly"]);
+        assert!(!state.is_trusted);
     }
 
     #[test]
@@ -160,7 +173,9 @@ mod tests {
         assert!(!state.line_folding_only);
         assert!(!state.hierarchical_document_symbols);
         assert!(!state.pull_diagnostics);
+        assert!(!state.diagnostic_refresh);
         assert!(!state.dynamic_watched_files);
+        assert!(state.is_trusted);
     }
 
     #[test]

--- a/crates/rsvelte_language_server/src/diagnostics.rs
+++ b/crates/rsvelte_language_server/src/diagnostics.rs
@@ -6,6 +6,7 @@ use lsp_types::{
     CodeDescription, Diagnostic, DiagnosticSeverity, NumberOrString, Position, Range, Uri,
 };
 use rsvelte_diagnostics::{Diagnostic as LintDiagnostic, DiagnosticSeverity as LintSeverity};
+use sourcemap::SourceMap;
 
 use crate::settings::{CompilerWarnings, WarningLevel};
 
@@ -66,6 +67,156 @@ pub fn to_lsp(diagnostic: &LintDiagnostic, warnings: &CompilerWarnings) -> Optio
         message: diagnostic.message.clone(),
         ..Diagnostic::default()
     })
+}
+
+/// Compiler diagnostics that raw preprocessor syntax would make unreliable.
+#[must_use]
+pub fn keep_raw_compiler_diagnostic(diagnostic: &Diagnostic, source: &str) -> bool {
+    let languages = language_attributes(source);
+    let code = diagnostic.code.as_ref().and_then(|code| match code {
+        NumberOrString::String(code) => Some(code.as_str()),
+        NumberOrString::Number(_) => None,
+    });
+    if diagnostic.severity == Some(DiagnosticSeverity::ERROR)
+        && diagnostic.message.contains("expected")
+        && languages.any()
+    {
+        return false;
+    }
+    if (languages.template || languages.script_non_ts)
+        && code.is_none_or(|code| !code.starts_with("a11y"))
+    {
+        return false;
+    }
+    if languages.style && matches!(code, Some("css-unused-selector" | "css_unused_selector")) {
+        return false;
+    }
+    if matches!(code, Some("unused-export-let" | "export_let_unused")) {
+        let name = diagnostic
+            .message
+            .split_once('\'')
+            .and_then(|(_, tail)| tail.split_once('\''))
+            .map(|(name, _)| name)
+            .unwrap_or_default();
+        if !name.is_empty()
+            && ["enum", "namespace"].iter().any(|kind| {
+                source.contains(&format!("export {kind} {name}"))
+                    || source.contains(&format!("export\t{kind} {name}"))
+            })
+        {
+            return false;
+        }
+    }
+    true
+}
+
+/// Map a diagnostic emitted against preprocessed Svelte back to editor source.
+#[must_use]
+pub fn map_preprocessed_diagnostic(
+    mut diagnostic: Diagnostic,
+    source_map: &str,
+) -> Option<Diagnostic> {
+    let map = SourceMap::from_slice(source_map.as_bytes()).ok()?;
+    diagnostic.range.start = original_position(&map, diagnostic.range.start)?;
+    diagnostic.range.end = original_position(&map, diagnostic.range.end)?;
+    if diagnostic.range.end < diagnostic.range.start {
+        std::mem::swap(&mut diagnostic.range.start, &mut diagnostic.range.end);
+    }
+    Some(diagnostic)
+}
+
+/// Diagnostic shown without disabling raw-language editor features.
+#[must_use]
+pub fn preprocess_failure(message: impl Into<String>) -> Diagnostic {
+    Diagnostic {
+        range: Range::new(Position::new(0, 0), Position::new(0, 5)),
+        severity: Some(DiagnosticSeverity::WARNING),
+        source: Some(COMPILER_SOURCE.to_string()),
+        message: format!("Preprocessing failed\n\n{}", message.into()),
+        ..Diagnostic::default()
+    }
+}
+
+fn original_position(map: &SourceMap, position: Position) -> Option<Position> {
+    let token = map.lookup_token(position.line, position.character)?;
+    token
+        .get_source()
+        .map(|_| Position::new(token.get_src_line(), token.get_src_col()))
+}
+
+#[derive(Default)]
+struct LanguageAttributes {
+    script_non_ts: bool,
+    style: bool,
+    template: bool,
+}
+
+impl LanguageAttributes {
+    const fn any(&self) -> bool {
+        self.script_non_ts || self.style || self.template
+    }
+}
+
+fn language_attributes(source: &str) -> LanguageAttributes {
+    let script = tag_language(source, "script");
+    LanguageAttributes {
+        script_non_ts: script.as_deref().is_some_and(|lang| lang != "ts"),
+        style: tag_language(source, "style").is_some(),
+        template: tag_language(source, "template").is_some(),
+    }
+}
+
+fn tag_language(source: &str, tag: &str) -> Option<String> {
+    let needle = format!("<{tag}");
+    let start = source.find(&needle)? + needle.len();
+    let end = source[start..].find('>')? + start;
+    let attributes = &source[start..end];
+    attribute_value(attributes, "lang")
+        .or_else(|| attribute_value(attributes, "type"))
+        .map(|value| value.trim_start_matches("text/").to_ascii_lowercase())
+}
+
+fn attribute_value(attributes: &str, name: &str) -> Option<String> {
+    let bytes = attributes.as_bytes();
+    let mut offset = 0;
+    while offset < bytes.len() {
+        while offset < bytes.len() && bytes[offset].is_ascii_whitespace() {
+            offset += 1;
+        }
+        let start = offset;
+        while offset < bytes.len()
+            && (bytes[offset].is_ascii_alphanumeric() || matches!(bytes[offset], b'-' | b'_'))
+        {
+            offset += 1;
+        }
+        let key = attributes.get(start..offset)?;
+        while offset < bytes.len() && bytes[offset].is_ascii_whitespace() {
+            offset += 1;
+        }
+        if bytes.get(offset) != Some(&b'=') {
+            offset = offset.saturating_add(1);
+            continue;
+        }
+        offset += 1;
+        while offset < bytes.len() && bytes[offset].is_ascii_whitespace() {
+            offset += 1;
+        }
+        let quote = *bytes.get(offset)?;
+        if !matches!(quote, b'\'' | b'"') {
+            offset = offset.saturating_add(1);
+            continue;
+        }
+        offset += 1;
+        let value_start = offset;
+        while offset < bytes.len() && bytes[offset] != quote {
+            offset += 1;
+        }
+        if key.eq_ignore_ascii_case(name) {
+            return Some(attributes.get(value_start..offset)?.to_string());
+        }
+        offset = offset.saturating_add(1);
+    }
+    None
 }
 
 /// The documentation link for a compiler code, mirroring the official server:
@@ -221,6 +372,53 @@ mod tests {
         assert_eq!(
             d.code_description.unwrap().href.as_str(),
             "https://svelte.dev/docs/svelte/compiler-warnings#state_referenced_locally"
+        );
+    }
+
+    #[test]
+    fn raw_language_attributes_suppress_only_upstream_false_positives() {
+        let warning = |code: &str| Diagnostic {
+            code: Some(NumberOrString::String(code.to_string())),
+            severity: Some(DiagnosticSeverity::WARNING),
+            message: "warning".to_string(),
+            ..Diagnostic::default()
+        };
+        let source = r#"<script lang="coffee">x = 1</script>
+<style lang="scss">$x: red</style><template lang="pug">p hi</template>"#;
+        assert!(!keep_raw_compiler_diagnostic(
+            &warning("state_referenced_locally"),
+            source
+        ));
+        assert!(!keep_raw_compiler_diagnostic(
+            &warning("css_unused_selector"),
+            source
+        ));
+        assert!(keep_raw_compiler_diagnostic(
+            &warning("a11y_missing_attribute"),
+            source
+        ));
+        assert!(keep_raw_compiler_diagnostic(
+            &warning("state_referenced_locally"),
+            r#"<script lang="ts">let x: number</script>"#
+        ));
+    }
+
+    #[test]
+    fn preprocessing_map_returns_utf16_positions_to_raw_source() {
+        let mut builder = sourcemap::SourceMapBuilder::new(None);
+        builder.add(1, 2, 0, 3, Some("App.svelte"), None, false);
+        builder.add(1, 4, 0, 5, Some("App.svelte"), None, false);
+        let mut encoded = Vec::new();
+        builder.into_sourcemap().to_writer(&mut encoded).unwrap();
+        let map = String::from_utf8(encoded).unwrap();
+        let diagnostic = Diagnostic {
+            range: Range::new(Position::new(1, 2), Position::new(1, 4)),
+            message: "mapped".to_string(),
+            ..Diagnostic::default()
+        };
+        assert_eq!(
+            map_preprocessed_diagnostic(diagnostic, &map).unwrap().range,
+            Range::new(Position::new(0, 3), Position::new(0, 5))
         );
     }
 

--- a/crates/rsvelte_language_server/src/lib.rs
+++ b/crates/rsvelte_language_server/src/lib.rs
@@ -28,6 +28,7 @@ pub mod lint;
 pub mod log;
 pub mod modifiers;
 pub mod nodes;
+pub mod preprocess_sidecar;
 pub mod selection_ranges;
 pub mod server;
 pub mod settings;

--- a/crates/rsvelte_language_server/src/preprocess_sidecar.mjs
+++ b/crates/rsvelte_language_server/src/preprocess_sidecar.mjs
@@ -1,0 +1,160 @@
+import { createRequire } from 'node:module';
+import { createInterface } from 'node:readline';
+import { existsSync, realpathSync } from 'node:fs';
+import { dirname, isAbsolute, join, relative, resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const CONFIG_NAMES = [
+  'svelte.config.js',
+  'svelte.config.mjs',
+  'svelte.config.cjs',
+  'svelte.config.ts',
+  'svelte.config.mts',
+];
+
+const configs = new Map();
+const compilers = new Map();
+const protocolWrite = process.stdout.write.bind(process.stdout);
+
+// Config files routinely log while loading. Keep fd 1 recoverable for framing.
+process.stdout.write = function divertedStdout(chunk, encoding, callback) {
+  return process.stderr.write(chunk, encoding, callback);
+};
+
+function send(value) {
+  protocolWrite(`\u001eRSVELTE${JSON.stringify(value)}\n`);
+}
+
+function findConfig(filename, workspace) {
+  const root = realpathSync(resolve(workspace));
+  let current = realpathSync(dirname(resolve(filename)));
+  while (current === root || current.startsWith(`${root}/`) || current.startsWith(`${root}\\`)) {
+    for (const name of CONFIG_NAMES) {
+      const candidate = join(current, name);
+      if (!existsSync(candidate)) continue;
+      const canonical = realpathSync(candidate);
+      const fromRoot = relative(root, canonical);
+      const outside =
+        fromRoot === '..' ||
+        fromRoot.startsWith(`..${process.platform === 'win32' ? '\\' : '/'}`) ||
+        isAbsolute(fromRoot);
+      if (!outside) {
+        return canonical;
+      }
+    }
+    const parent = dirname(current);
+    if (parent === current) break;
+    current = parent;
+  }
+  return null;
+}
+
+async function loadConfig(path) {
+  if (!path) return null;
+  let cached = configs.get(path);
+  if (!cached) {
+    cached = import(pathToFileURL(path).href).then((module) => module.default ?? module);
+    configs.set(path, cached);
+  }
+  return cached;
+}
+
+async function loadCompiler(workspace) {
+  let cached = compilers.get(workspace);
+  if (!cached) {
+    cached = (async () => {
+      const require = createRequire(join(resolve(workspace), '__rsvelte_preprocess__.cjs'));
+      for (const specifier of ['svelte/compiler', '@rsvelte/vite-plugin-svelte-native']) {
+        try {
+          const module = await import(pathToFileURL(require.resolve(specifier)).href);
+          if (typeof module.preprocess === 'function') return module;
+        } catch {}
+      }
+      throw new Error(
+        `Cannot resolve svelte/compiler or @rsvelte/vite-plugin-svelte-native from ${workspace}`,
+      );
+    })();
+    compilers.set(workspace, cached);
+  }
+  return cached;
+}
+
+function normalizeMap(map) {
+  if (!map) return null;
+  if (typeof map === 'string') return map;
+  if (typeof map.toString === 'function') {
+    const stringified = map.toString();
+    if (stringified !== '[object Object]') return stringified;
+  }
+  return JSON.stringify(map);
+}
+
+async function preprocess(request) {
+  const configPath = findConfig(request.filename, request.workspace);
+  if (!configPath) {
+    return {
+      type: 'result',
+      id: request.id,
+      filename: request.filename,
+      version: request.version,
+      code: request.text,
+      map: null,
+      configPath: null,
+      hasPreprocessor: false,
+    };
+  }
+
+  const config = await loadConfig(configPath);
+  const groups = config?.preprocess;
+  if (!groups) {
+    return {
+      type: 'result',
+      id: request.id,
+      filename: request.filename,
+      version: request.version,
+      code: request.text,
+      map: null,
+      configPath,
+      hasPreprocessor: false,
+    };
+  }
+
+  const compiler = await loadCompiler(request.workspace);
+  const result = await compiler.preprocess(request.text, groups, {
+    filename: request.filename,
+  });
+  return {
+    type: 'result',
+    id: request.id,
+    filename: request.filename,
+    version: request.version,
+    code: result?.code ?? String(result ?? ''),
+    map: normalizeMap(result?.map),
+    dependencies: Array.isArray(result?.dependencies) ? result.dependencies : [],
+    configPath,
+    hasPreprocessor: true,
+  };
+}
+
+send({ type: 'ready', pid: process.pid });
+
+let queue = Promise.resolve();
+createInterface({ input: process.stdin, crlfDelay: Infinity }).on('line', (line) => {
+  queue = queue.then(async () => {
+    let request;
+    try {
+      request = JSON.parse(line);
+      if (request?.type !== 'preprocess') return;
+      send(await preprocess(request));
+    } catch (error) {
+      send({
+        type: 'error',
+        id: request?.id ?? null,
+        filename: request?.filename ?? null,
+        version: request?.version ?? null,
+        message: error instanceof Error ? error.message : String(error),
+        stack: error instanceof Error ? error.stack : undefined,
+      });
+    }
+  });
+});

--- a/crates/rsvelte_language_server/src/preprocess_sidecar.rs
+++ b/crates/rsvelte_language_server/src/preprocess_sidecar.rs
@@ -1,0 +1,1215 @@
+use std::collections::BTreeMap;
+use std::fmt;
+use std::fs;
+use std::io::{self, BufRead, BufReader, BufWriter, Write};
+use std::path::{Path, PathBuf};
+use std::process::{Child, ChildStdin, Command, ExitStatus, Stdio};
+use std::thread::{self, JoinHandle};
+use std::time::{Duration, Instant};
+
+use crossbeam_channel::{Receiver, Sender, after, select, tick, unbounded};
+use serde::{Deserialize, Serialize};
+
+const SCRIPT: &str = include_str!("preprocess_sidecar.mjs");
+const WIRE_PREFIX: &str = "\u{1e}RSVELTE";
+const POLL_INTERVAL: Duration = Duration::from_millis(50);
+const CONFIG_NAMES: &[&str] = &[
+    "svelte.config.js",
+    "svelte.config.mjs",
+    "svelte.config.cjs",
+    "svelte.config.ts",
+    "svelte.config.mts",
+];
+
+#[derive(Clone, Debug)]
+pub struct PreprocessSidecarConfig {
+    pub node: PathBuf,
+    pub restart_delay: Duration,
+    pub max_restart_delay: Duration,
+    pub request_timeout: Duration,
+    pub max_consecutive_crashes: u32,
+}
+
+impl Default for PreprocessSidecarConfig {
+    fn default() -> Self {
+        Self {
+            node: std::env::var_os("RSVELTE_PREPROCESS_NODE")
+                .map(PathBuf::from)
+                .unwrap_or_else(|| PathBuf::from("node")),
+            restart_delay: Duration::from_millis(250),
+            max_restart_delay: Duration::from_secs(30),
+            request_timeout: Duration::from_secs(30),
+            max_consecutive_crashes: 5,
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct PreprocessInput {
+    pub workspace: PathBuf,
+    pub filename: PathBuf,
+    pub version: i32,
+    pub text: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct PreprocessOutput {
+    pub generation: u64,
+    pub filename: PathBuf,
+    pub version: i32,
+    pub code: String,
+    pub map: Option<String>,
+    pub dependencies: Vec<PathBuf>,
+    pub config_path: Option<PathBuf>,
+    pub has_preprocessor: bool,
+}
+
+#[derive(Clone, Debug)]
+pub enum PreprocessEvent {
+    Ready {
+        generation: u64,
+    },
+    Result(PreprocessOutput),
+    Failed {
+        generation: u64,
+        filename: Option<PathBuf>,
+        version: Option<i32>,
+        message: String,
+    },
+    Crashed {
+        generation: u64,
+        status: Option<ExitStatus>,
+        error: String,
+    },
+    /// Automatic restarts are paused until [`PreprocessSidecar::restart`].
+    CircuitOpen {
+        generation: u64,
+        crashes: u32,
+        error: String,
+    },
+}
+
+pub struct PreprocessSidecar {
+    commands: Sender<SidecarCommand>,
+    supervisor: Option<JoinHandle<()>>,
+}
+
+impl PreprocessSidecar {
+    pub fn spawn(
+        config: PreprocessSidecarConfig,
+        events: Sender<PreprocessEvent>,
+    ) -> io::Result<Self> {
+        let (commands, receiver) = unbounded();
+        let supervisor = thread::Builder::new()
+            .name("rsvelte-preprocess-supervisor".to_string())
+            .spawn(move || supervise(config, receiver, events))?;
+        Ok(Self {
+            commands,
+            supervisor: Some(supervisor),
+        })
+    }
+
+    pub fn preprocess(&self, input: PreprocessInput) -> Result<(), PreprocessSidecarClosed> {
+        self.commands
+            .send(SidecarCommand::Upsert(input))
+            .map_err(|_| PreprocessSidecarClosed)
+    }
+
+    pub fn remove(&self, filename: PathBuf) -> Result<(), PreprocessSidecarClosed> {
+        self.commands
+            .send(SidecarCommand::Remove(filename))
+            .map_err(|_| PreprocessSidecarClosed)
+    }
+
+    pub fn restart(&self) -> Result<(), PreprocessSidecarClosed> {
+        self.commands
+            .send(SidecarCommand::Restart)
+            .map_err(|_| PreprocessSidecarClosed)
+    }
+}
+
+impl Drop for PreprocessSidecar {
+    fn drop(&mut self) {
+        let _ = self.commands.send(SidecarCommand::Shutdown);
+        if let Some(supervisor) = self.supervisor.take() {
+            let _ = supervisor.join();
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct PreprocessSidecarClosed;
+
+impl fmt::Display for PreprocessSidecarClosed {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("preprocess sidecar supervisor has stopped")
+    }
+}
+
+impl std::error::Error for PreprocessSidecarClosed {}
+
+enum SidecarCommand {
+    Upsert(PreprocessInput),
+    Remove(PathBuf),
+    Restart,
+    Shutdown,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct WireRequest<'a> {
+    r#type: &'static str,
+    id: u64,
+    workspace: &'a Path,
+    filename: &'a Path,
+    version: i32,
+    text: &'a str,
+}
+
+#[derive(Deserialize)]
+#[serde(tag = "type", rename_all = "camelCase")]
+enum WireEvent {
+    Ready {
+        #[allow(dead_code)]
+        pid: u32,
+    },
+    Result {
+        id: u64,
+        filename: PathBuf,
+        version: i32,
+        code: String,
+        map: Option<String>,
+        #[serde(default)]
+        dependencies: Vec<PathBuf>,
+        #[serde(rename = "configPath")]
+        config_path: Option<PathBuf>,
+        #[serde(rename = "hasPreprocessor")]
+        has_preprocessor: bool,
+    },
+    Error {
+        id: Option<u64>,
+        filename: Option<PathBuf>,
+        version: Option<i32>,
+        message: String,
+        #[allow(dead_code)]
+        stack: Option<String>,
+    },
+}
+
+enum ReaderEvent {
+    Wire(WireEvent),
+    Eof,
+    Error(String),
+}
+
+struct SidecarProcess {
+    child: Child,
+    stdin: BufWriter<ChildStdin>,
+    events: Receiver<ReaderEvent>,
+    reader: Option<JoinHandle<()>>,
+}
+
+impl SidecarProcess {
+    fn spawn(config: &PreprocessSidecarConfig) -> io::Result<Self> {
+        let mut child = Command::new(&config.node)
+            .arg("--input-type=module")
+            .arg("--eval")
+            .arg(SCRIPT)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::inherit())
+            .spawn()?;
+        let stdin = child
+            .stdin
+            .take()
+            .ok_or_else(|| io::Error::other("preprocess sidecar stdin was not piped"))?;
+        let stdout = child
+            .stdout
+            .take()
+            .ok_or_else(|| io::Error::other("preprocess sidecar stdout was not piped"))?;
+        let (sender, events) = unbounded();
+        let reader = thread::Builder::new()
+            .name("rsvelte-preprocess-reader".to_string())
+            .spawn(move || {
+                for line in BufReader::new(stdout).lines() {
+                    match line {
+                        Ok(line) => {
+                            let Some(prefix) = line.find(WIRE_PREFIX) else {
+                                crate::log::warn(format_args!("preprocess sidecar: {line}"));
+                                continue;
+                            };
+                            if prefix != 0 {
+                                crate::log::warn(format_args!(
+                                    "preprocess sidecar: {}",
+                                    &line[..prefix]
+                                ));
+                            }
+                            match serde_json::from_str(&line[prefix + WIRE_PREFIX.len()..]) {
+                                Ok(event) => {
+                                    if sender.send(ReaderEvent::Wire(event)).is_err() {
+                                        return;
+                                    }
+                                }
+                                Err(error) => crate::log::warn(format_args!(
+                                    "invalid preprocess sidecar response: {error}"
+                                )),
+                            }
+                        }
+                        Err(error) => {
+                            let _ = sender.send(ReaderEvent::Error(error.to_string()));
+                            return;
+                        }
+                    }
+                }
+                let _ = sender.send(ReaderEvent::Eof);
+            })?;
+        Ok(Self {
+            child,
+            stdin: BufWriter::new(stdin),
+            events,
+            reader: Some(reader),
+        })
+    }
+
+    fn send(&mut self, id: u64, input: &PreprocessInput) -> io::Result<()> {
+        serde_json::to_writer(
+            &mut self.stdin,
+            &WireRequest {
+                r#type: "preprocess",
+                id,
+                workspace: &input.workspace,
+                filename: &input.filename,
+                version: input.version,
+                text: &input.text,
+            },
+        )?;
+        self.stdin.write_all(b"\n")?;
+        self.stdin.flush()
+    }
+
+    fn finish(mut self, kill: bool) -> Option<ExitStatus> {
+        if kill {
+            let _ = self.child.kill();
+        }
+        let status = self.child.wait().ok();
+        if let Some(reader) = self.reader.take() {
+            let _ = reader.join();
+        }
+        status
+    }
+}
+
+enum ProcessOutcome {
+    Restart,
+    Shutdown,
+    Failed {
+        status: Option<ExitStatus>,
+        error: String,
+        stable: bool,
+    },
+}
+
+struct PendingRequest {
+    filename: PathBuf,
+    version: i32,
+    sent_at: Instant,
+}
+
+enum RestartWait {
+    Retry,
+    ResetAndRetry,
+    Shutdown,
+}
+
+fn supervise(
+    config: PreprocessSidecarConfig,
+    commands: Receiver<SidecarCommand>,
+    events: Sender<PreprocessEvent>,
+) {
+    let mut retained = BTreeMap::<PathBuf, PreprocessInput>::new();
+    let mut generation = 0_u64;
+    let mut consecutive_crashes = 0_u32;
+    loop {
+        while retained.is_empty() {
+            match commands.recv() {
+                Ok(SidecarCommand::Upsert(input)) => {
+                    retained.insert(input.filename.clone(), input);
+                }
+                Ok(SidecarCommand::Remove(_)) | Ok(SidecarCommand::Restart) => {}
+                Ok(SidecarCommand::Shutdown) | Err(_) => return,
+            }
+        }
+
+        generation += 1;
+        let process = match SidecarProcess::spawn(&config) {
+            Ok(process) => process,
+            Err(error) => {
+                consecutive_crashes = consecutive_crashes.saturating_add(1);
+                let error = format!("failed to start preprocess sidecar: {error}");
+                let _ = events.send(PreprocessEvent::Crashed {
+                    generation,
+                    status: None,
+                    error: error.clone(),
+                });
+                match wait_after_failure(
+                    &config,
+                    &commands,
+                    &events,
+                    &mut retained,
+                    generation,
+                    consecutive_crashes,
+                    error,
+                ) {
+                    RestartWait::Retry => continue,
+                    RestartWait::ResetAndRetry => {
+                        consecutive_crashes = 0;
+                        continue;
+                    }
+                    RestartWait::Shutdown => return,
+                }
+            }
+        };
+        match run_process(
+            process,
+            generation,
+            &config,
+            &commands,
+            &events,
+            &mut retained,
+        ) {
+            ProcessOutcome::Shutdown => return,
+            ProcessOutcome::Restart => consecutive_crashes = 0,
+            ProcessOutcome::Failed {
+                status,
+                error,
+                stable,
+            } => {
+                consecutive_crashes = if stable {
+                    1
+                } else {
+                    consecutive_crashes.saturating_add(1)
+                };
+                let _ = events.send(PreprocessEvent::Crashed {
+                    generation,
+                    status,
+                    error: error.clone(),
+                });
+                match wait_after_failure(
+                    &config,
+                    &commands,
+                    &events,
+                    &mut retained,
+                    generation,
+                    consecutive_crashes,
+                    error,
+                ) {
+                    RestartWait::Retry => {}
+                    RestartWait::ResetAndRetry => consecutive_crashes = 0,
+                    RestartWait::Shutdown => return,
+                }
+            }
+        }
+    }
+}
+
+fn run_process(
+    mut process: SidecarProcess,
+    generation: u64,
+    config: &PreprocessSidecarConfig,
+    commands: &Receiver<SidecarCommand>,
+    events: &Sender<PreprocessEvent>,
+    retained: &mut BTreeMap<PathBuf, PreprocessInput>,
+) -> ProcessOutcome {
+    let poll = tick(POLL_INTERVAL);
+    let started_at = Instant::now();
+    loop {
+        select! {
+            recv(commands) -> command => match command {
+                Ok(SidecarCommand::Upsert(input)) => {
+                    retained.insert(input.filename.clone(), input);
+                }
+                Ok(SidecarCommand::Remove(filename)) => {
+                    retained.remove(&filename);
+                }
+                Ok(SidecarCommand::Restart) => {
+                    process.finish(true);
+                    return ProcessOutcome::Restart;
+                }
+                Ok(SidecarCommand::Shutdown) | Err(_) => {
+                    process.finish(true);
+                    return ProcessOutcome::Shutdown;
+                }
+            },
+            recv(process.events) -> event => match event {
+                Ok(ReaderEvent::Wire(WireEvent::Ready { .. })) => break,
+                Ok(ReaderEvent::Wire(_)) => {}
+                Ok(ReaderEvent::Eof) | Err(_) => {
+                    let status = process.finish(true);
+                    return process_failed(status, "preprocess sidecar closed stdout during startup", false);
+                }
+                Ok(ReaderEvent::Error(error)) => {
+                    let status = process.finish(true);
+                    return ProcessOutcome::Failed {
+                        status,
+                        error,
+                        stable: false,
+                    };
+                }
+            },
+            recv(poll) -> _ => {
+                if started_at.elapsed() >= config.request_timeout {
+                    let status = process.finish(true);
+                    return process_failed(status, "preprocess sidecar timed out during startup", false);
+                }
+                match process.child.try_wait() {
+                    Ok(Some(status)) => {
+                        process.finish(false);
+                        return process_failed(Some(status), "preprocess sidecar exited during startup", false);
+                    }
+                    Ok(None) => {}
+                    Err(error) => {
+                        let status = process.finish(true);
+                        return ProcessOutcome::Failed {
+                            status,
+                            error: format!("could not inspect preprocess sidecar: {error}"),
+                            stable: false,
+                        };
+                    }
+                }
+            },
+        }
+    }
+
+    let _ = events.send(PreprocessEvent::Ready { generation });
+    let mut next_id = 0_u64;
+    let mut pending = BTreeMap::<u64, PendingRequest>::new();
+    let mut latest = BTreeMap::<PathBuf, u64>::new();
+    let replay = retained.values().cloned().collect::<Vec<_>>();
+    for input in replay {
+        if let Err(error) = send_input(
+            &mut process,
+            &mut next_id,
+            &input,
+            &mut pending,
+            &mut latest,
+        ) {
+            let status = process.finish(true);
+            return ProcessOutcome::Failed {
+                status,
+                error: format!("failed to replay preprocess input: {error}"),
+                stable: false,
+            };
+        }
+    }
+
+    let mut stable = pending.is_empty();
+    loop {
+        select! {
+            recv(commands) -> command => match command {
+                Ok(SidecarCommand::Upsert(input)) => {
+                    retained.insert(input.filename.clone(), input.clone());
+                    if let Err(error) = send_input(
+                        &mut process,
+                        &mut next_id,
+                        &input,
+                        &mut pending,
+                        &mut latest,
+                    ) {
+                        let status = process.finish(true);
+                        return ProcessOutcome::Failed {
+                            status,
+                            error: format!("failed to write preprocess input: {error}"),
+                            stable,
+                        };
+                    }
+                }
+                Ok(SidecarCommand::Remove(filename)) => {
+                    retained.remove(&filename);
+                    latest.remove(&filename);
+                }
+                Ok(SidecarCommand::Restart) => {
+                    process.finish(true);
+                    return ProcessOutcome::Restart;
+                }
+                Ok(SidecarCommand::Shutdown) | Err(_) => {
+                    process.finish(true);
+                    return ProcessOutcome::Shutdown;
+                }
+            },
+            recv(process.events) -> event => match event {
+                Ok(ReaderEvent::Wire(WireEvent::Result {
+                    id, filename, version, code, map, dependencies, config_path, has_preprocessor
+                })) => {
+                    let Some(request) = pending.remove(&id) else {
+                        continue;
+                    };
+                    if request.filename != filename || request.version != version {
+                        let status = process.finish(true);
+                        return ProcessOutcome::Failed {
+                            status,
+                            error: format!("preprocess sidecar response {id} did not match its request"),
+                            stable,
+                        };
+                    }
+                    if latest.get(&filename) != Some(&id) {
+                        stable |= pending.is_empty();
+                        continue;
+                    }
+                    stable |= pending.is_empty();
+                    let _ = events.send(PreprocessEvent::Result(PreprocessOutput {
+                        generation, filename, version, code, map, dependencies, config_path, has_preprocessor,
+                    }));
+                }
+                Ok(ReaderEvent::Wire(WireEvent::Error { id, filename, version, message, .. })) => {
+                    if let Some(id) = id {
+                        let Some(request) = pending.remove(&id) else {
+                            continue;
+                        };
+                        if filename.as_ref() != Some(&request.filename)
+                            || version != Some(request.version)
+                        {
+                            let status = process.finish(true);
+                            return ProcessOutcome::Failed {
+                                status,
+                                error: format!("preprocess sidecar error {id} did not match its request"),
+                                stable,
+                            };
+                        }
+                        if latest.get(&request.filename) != Some(&id) {
+                            stable |= pending.is_empty();
+                            continue;
+                        }
+                    }
+                    stable |= pending.is_empty();
+                    let _ = events.send(PreprocessEvent::Failed {
+                        generation, filename, version, message,
+                    });
+                }
+                Ok(ReaderEvent::Wire(WireEvent::Ready { .. })) => {}
+                Ok(ReaderEvent::Eof) | Err(_) => {
+                    let status = process.finish(true);
+                    return process_failed(status, "preprocess sidecar closed stdout", stable);
+                }
+                Ok(ReaderEvent::Error(error)) => {
+                    let status = process.finish(true);
+                    return ProcessOutcome::Failed { status, error, stable };
+                }
+            },
+            recv(poll) -> _ => {
+                if let Some(request) = pending.values().min_by_key(|request| request.sent_at)
+                    && request.sent_at.elapsed() >= config.request_timeout
+                {
+                    let filename = request.filename.clone();
+                    let version = request.version;
+                    let message = format!("preprocessing {} timed out", filename.display());
+                    let _ = events.send(PreprocessEvent::Failed {
+                        generation,
+                        filename: Some(filename),
+                        version: Some(version),
+                        message: message.clone(),
+                    });
+                    let status = process.finish(true);
+                    return process_failed(status, message, stable);
+                }
+                match process.child.try_wait() {
+                    Ok(Some(status)) => {
+                        process.finish(false);
+                        return process_failed(Some(status), "preprocess sidecar exited", stable);
+                    }
+                    Ok(None) => {}
+                    Err(error) => {
+                        let status = process.finish(true);
+                        return ProcessOutcome::Failed {
+                            status,
+                            error: format!("could not inspect preprocess sidecar: {error}"),
+                            stable,
+                        };
+                    }
+                }
+            },
+        }
+    }
+}
+
+fn send_input(
+    process: &mut SidecarProcess,
+    next_id: &mut u64,
+    input: &PreprocessInput,
+    pending: &mut BTreeMap<u64, PendingRequest>,
+    latest: &mut BTreeMap<PathBuf, u64>,
+) -> io::Result<()> {
+    *next_id = next_id.saturating_add(1);
+    process.send(*next_id, input)?;
+    pending.insert(
+        *next_id,
+        PendingRequest {
+            filename: input.filename.clone(),
+            version: input.version,
+            sent_at: Instant::now(),
+        },
+    );
+    latest.insert(input.filename.clone(), *next_id);
+    Ok(())
+}
+
+fn process_failed(
+    status: Option<ExitStatus>,
+    error: impl Into<String>,
+    stable: bool,
+) -> ProcessOutcome {
+    ProcessOutcome::Failed {
+        status,
+        error: error.into(),
+        stable,
+    }
+}
+
+fn wait_after_failure(
+    config: &PreprocessSidecarConfig,
+    commands: &Receiver<SidecarCommand>,
+    events: &Sender<PreprocessEvent>,
+    retained: &mut BTreeMap<PathBuf, PreprocessInput>,
+    generation: u64,
+    consecutive_crashes: u32,
+    error: String,
+) -> RestartWait {
+    let circuit_open = consecutive_crashes >= config.max_consecutive_crashes.max(1);
+    if circuit_open {
+        let _ = events.send(PreprocessEvent::CircuitOpen {
+            generation,
+            crashes: consecutive_crashes,
+            error,
+        });
+    }
+    let timer = (!circuit_open).then(|| after(restart_delay(config, consecutive_crashes)));
+    loop {
+        if let Some(timer) = &timer {
+            select! {
+                recv(commands) -> command => match match_restart_command(command, retained) {
+                    RestartWait::Retry => {}
+                    outcome => return outcome,
+                },
+                recv(timer) -> _ => return RestartWait::Retry,
+            }
+        } else {
+            match match_restart_command(commands.recv(), retained) {
+                RestartWait::Retry => {}
+                outcome => return outcome,
+            }
+        }
+    }
+}
+
+fn match_restart_command(
+    command: Result<SidecarCommand, crossbeam_channel::RecvError>,
+    retained: &mut BTreeMap<PathBuf, PreprocessInput>,
+) -> RestartWait {
+    match command {
+        Ok(SidecarCommand::Upsert(input)) => {
+            retained.insert(input.filename.clone(), input);
+            RestartWait::Retry
+        }
+        Ok(SidecarCommand::Remove(filename)) => {
+            retained.remove(&filename);
+            RestartWait::Retry
+        }
+        Ok(SidecarCommand::Restart) => RestartWait::ResetAndRetry,
+        Ok(SidecarCommand::Shutdown) | Err(_) => RestartWait::Shutdown,
+    }
+}
+
+fn restart_delay(config: &PreprocessSidecarConfig, consecutive_crashes: u32) -> Duration {
+    let exponent = consecutive_crashes.saturating_sub(1).min(31);
+    config
+        .restart_delay
+        .saturating_mul(1_u32 << exponent)
+        .min(config.max_restart_delay)
+}
+
+#[must_use]
+pub fn find_preprocess_config(filename: &Path, workspace: &Path) -> Option<PathBuf> {
+    let workspace = fs::canonicalize(workspace).ok()?;
+    let mut current = fs::canonicalize(filename.parent()?).ok()?;
+    loop {
+        if !current.starts_with(&workspace) {
+            return None;
+        }
+        for name in CONFIG_NAMES {
+            let candidate = current.join(name);
+            let Ok(candidate) = fs::canonicalize(candidate) else {
+                continue;
+            };
+            if candidate.starts_with(&workspace) && candidate.is_file() {
+                return Some(candidate);
+            }
+        }
+        if current == workspace {
+            return None;
+        }
+        current = current.parent()?.to_path_buf();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::process::Command;
+
+    fn temp_dir(name: &str) -> PathBuf {
+        let path = std::env::temp_dir().join(format!(
+            "rsvelte-preprocess-{name}-{}-{:?}",
+            std::process::id(),
+            std::thread::current().id()
+        ));
+        fs::remove_dir_all(&path).ok();
+        fs::create_dir_all(&path).unwrap();
+        path
+    }
+
+    fn node() -> Option<PathBuf> {
+        let node = std::env::var_os("RSVELTE_PREPROCESS_NODE")
+            .map(PathBuf::from)
+            .unwrap_or_else(|| PathBuf::from("node"));
+        Command::new(&node)
+            .arg("--version")
+            .output()
+            .ok()?
+            .status
+            .success()
+            .then_some(node)
+    }
+
+    fn test_config(node: PathBuf) -> PreprocessSidecarConfig {
+        PreprocessSidecarConfig {
+            node,
+            restart_delay: Duration::from_millis(10),
+            max_restart_delay: Duration::from_millis(40),
+            request_timeout: Duration::from_secs(2),
+            max_consecutive_crashes: 3,
+        }
+    }
+
+    fn write_fake_compiler(root: &Path) {
+        let package = root.join("node_modules/svelte");
+        fs::create_dir_all(&package).unwrap();
+        fs::write(
+            package.join("package.json"),
+            r#"{"name":"svelte","type":"module","exports":{"./compiler":"./compiler.js"}}"#,
+        )
+        .unwrap();
+        fs::write(
+            package.join("compiler.js"),
+            r#"
+export async function preprocess(source, configured, options) {
+  const groups = Array.isArray(configured) ? configured : [configured];
+  let code = source;
+  for (const group of groups) {
+    if (!group?.markup) continue;
+    const result = await group.markup({ content: code, filename: options?.filename });
+    if (result?.code != null) code = result.code;
+  }
+  return { code, map: null, dependencies: [] };
+}
+"#,
+        )
+        .unwrap();
+    }
+
+    fn input(root: &Path, version: i32, text: &str) -> PreprocessInput {
+        PreprocessInput {
+            workspace: root.to_path_buf(),
+            filename: root.join("App.svelte"),
+            version,
+            text: text.to_string(),
+        }
+    }
+
+    #[test]
+    fn nearest_config_is_confined_to_workspace() {
+        let root = temp_dir("config");
+        let nested = root.join("packages/app/src");
+        fs::create_dir_all(&nested).unwrap();
+        fs::write(root.join("svelte.config.js"), "export default {}").unwrap();
+        fs::write(
+            root.join("packages/app/svelte.config.mjs"),
+            "export default {}",
+        )
+        .unwrap();
+        let file = nested.join("App.svelte");
+        fs::write(&file, "<p />").unwrap();
+        assert_eq!(
+            find_preprocess_config(&file, &root),
+            Some(fs::canonicalize(root.join("packages/app/svelte.config.mjs")).unwrap())
+        );
+        fs::remove_dir_all(root).ok();
+    }
+
+    #[test]
+    fn supervisor_does_not_spawn_node_without_input() {
+        let (sender, events) = unbounded();
+        let sidecar = PreprocessSidecar::spawn(
+            PreprocessSidecarConfig {
+                node: PathBuf::from("definitely-not-a-node-executable"),
+                restart_delay: Duration::from_millis(1),
+                ..PreprocessSidecarConfig::default()
+            },
+            sender,
+        )
+        .unwrap();
+        drop(sidecar);
+        assert!(events.try_recv().is_err());
+    }
+
+    #[test]
+    fn restart_delay_is_exponential_and_capped() {
+        let config = PreprocessSidecarConfig {
+            restart_delay: Duration::from_millis(10),
+            max_restart_delay: Duration::from_millis(25),
+            ..PreprocessSidecarConfig::default()
+        };
+        assert_eq!(restart_delay(&config, 1), Duration::from_millis(10));
+        assert_eq!(restart_delay(&config, 2), Duration::from_millis(20));
+        assert_eq!(restart_delay(&config, 3), Duration::from_millis(25));
+        assert_eq!(restart_delay(&config, u32::MAX), Duration::from_millis(25));
+    }
+
+    #[test]
+    fn noisy_stdout_does_not_frame_a_stale_result() {
+        let Some(node) = node() else {
+            return;
+        };
+        let root = temp_dir("latest");
+        write_fake_compiler(&root);
+        fs::write(
+            root.join("svelte.config.mjs"),
+            r#"
+import { writeSync } from 'node:fs';
+writeSync(1, 'direct fd noise without a newline');
+process.stdout.write('config noise without a newline');
+export default {
+  preprocess: {
+    async markup({ content }) {
+      if (content === 'slow') await new Promise((resolve) => setTimeout(resolve, 300));
+      return { code: `processed:${content}` };
+    }
+  }
+};
+"#,
+        )
+        .unwrap();
+
+        let (sender, events) = unbounded();
+        let sidecar = PreprocessSidecar::spawn(test_config(node), sender).unwrap();
+        sidecar.preprocess(input(&root, 1, "slow")).unwrap();
+        loop {
+            if matches!(
+                events.recv_timeout(Duration::from_secs(3)).unwrap(),
+                PreprocessEvent::Ready { .. }
+            ) {
+                break;
+            }
+        }
+        sidecar.preprocess(input(&root, 2, "latest")).unwrap();
+
+        let output = loop {
+            match events.recv_timeout(Duration::from_secs(3)).unwrap() {
+                PreprocessEvent::Result(output) => break output,
+                PreprocessEvent::Crashed { error, .. }
+                | PreprocessEvent::CircuitOpen { error, .. } => panic!("{error}"),
+                PreprocessEvent::Ready { .. } | PreprocessEvent::Failed { .. } => {}
+            }
+        };
+        assert_eq!(output.version, 2);
+        assert_eq!(output.code, "processed:latest");
+        assert!(events.try_iter().all(|event| !matches!(
+            event,
+            PreprocessEvent::Result(PreprocessOutput { version: 1, .. })
+        )));
+        drop(sidecar);
+        fs::remove_dir_all(root).ok();
+    }
+
+    #[test]
+    fn crash_replays_the_latest_input() {
+        let Some(node) = node() else {
+            return;
+        };
+        let root = temp_dir("crash-replay");
+        write_fake_compiler(&root);
+        let marker = root.join("crashed-once");
+        let marker = serde_json::to_string(&marker.to_string_lossy()).unwrap();
+        fs::write(
+            root.join("svelte.config.mjs"),
+            format!(
+                r#"
+import {{ existsSync, writeFileSync }} from 'node:fs';
+const marker = {marker};
+export default {{
+  preprocess: {{
+    markup({{ content }}) {{
+      if (!existsSync(marker)) {{
+        writeFileSync(marker, '1');
+        process.exit(17);
+      }}
+      return {{ code: `replayed:${{content}}` }};
+    }}
+  }}
+}};
+"#
+            ),
+        )
+        .unwrap();
+
+        let (sender, events) = unbounded();
+        let mut config = test_config(node);
+        config.restart_delay = Duration::from_millis(250);
+        let sidecar = PreprocessSidecar::spawn(config, sender).unwrap();
+        sidecar.preprocess(input(&root, 7, "body")).unwrap();
+        let mut crashed_generation = None;
+        let output = loop {
+            match events.recv_timeout(Duration::from_secs(4)).unwrap() {
+                PreprocessEvent::Result(output) => break output,
+                PreprocessEvent::Crashed { generation, .. } => {
+                    crashed_generation = Some(generation);
+                    sidecar.preprocess(input(&root, 8, "new-body")).unwrap();
+                }
+                PreprocessEvent::CircuitOpen { error, .. } => panic!("{error}"),
+                PreprocessEvent::Ready { .. } | PreprocessEvent::Failed { .. } => {}
+            }
+        };
+        assert_eq!(crashed_generation, Some(1));
+        assert_eq!(output.generation, 2);
+        assert_eq!(output.version, 8);
+        assert_eq!(output.code, "replayed:new-body");
+        drop(sidecar);
+        fs::remove_dir_all(root).ok();
+    }
+
+    #[test]
+    fn restart_reimports_changed_config_for_the_latest_input() {
+        let Some(node) = node() else {
+            return;
+        };
+        let root = temp_dir("config-restart");
+        write_fake_compiler(&root);
+        let config_path = root.join("svelte.config.mjs");
+        let config = |prefix: &str| {
+            format!(
+                r#"
+export default {{
+  preprocess: {{
+    markup({{ content }}) {{ return {{ code: '{prefix}:' + content }}; }}
+  }}
+}};
+"#
+            )
+        };
+        fs::write(&config_path, config("first")).unwrap();
+
+        let (sender, events) = unbounded();
+        let sidecar = PreprocessSidecar::spawn(test_config(node), sender).unwrap();
+        sidecar.preprocess(input(&root, 1, "old-body")).unwrap();
+        let first = loop {
+            match events.recv_timeout(Duration::from_secs(3)).unwrap() {
+                PreprocessEvent::Result(output) => break output,
+                PreprocessEvent::Crashed { error, .. }
+                | PreprocessEvent::CircuitOpen { error, .. } => panic!("{error}"),
+                PreprocessEvent::Ready { .. } | PreprocessEvent::Failed { .. } => {}
+            }
+        };
+        assert_eq!(first.generation, 1);
+        assert_eq!(first.code, "first:old-body");
+
+        fs::write(&config_path, config("second")).unwrap();
+        sidecar.restart().unwrap();
+        sidecar.preprocess(input(&root, 2, "latest-body")).unwrap();
+        let second = loop {
+            match events.recv_timeout(Duration::from_secs(3)).unwrap() {
+                PreprocessEvent::Result(output) if output.generation > first.generation => {
+                    break output;
+                }
+                PreprocessEvent::Crashed { error, .. }
+                | PreprocessEvent::CircuitOpen { error, .. } => panic!("{error}"),
+                PreprocessEvent::Ready { .. }
+                | PreprocessEvent::Result(_)
+                | PreprocessEvent::Failed { .. } => {}
+            }
+        };
+        assert_eq!(second.generation, 2);
+        assert_eq!(second.version, 2);
+        assert_eq!(second.code, "second:latest-body");
+        drop(sidecar);
+        fs::remove_dir_all(root).ok();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn config_symlink_cannot_escape_the_workspace() {
+        use std::os::unix::fs::symlink;
+
+        let root = temp_dir("config-symlink-root");
+        let outside = temp_dir("config-symlink-outside");
+        let source = root.join("src/App.svelte");
+        fs::create_dir_all(source.parent().unwrap()).unwrap();
+        fs::write(&source, "<p />").unwrap();
+        let outside_config = outside.join("svelte.config.mjs");
+        fs::write(&outside_config, "export default {}").unwrap();
+        symlink(&outside_config, root.join("src/svelte.config.mjs")).unwrap();
+
+        assert_eq!(find_preprocess_config(&source, &root), None);
+        fs::remove_dir_all(root).ok();
+        fs::remove_dir_all(outside).ok();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn node_sidecar_skips_an_escaping_nearer_config() {
+        use std::os::unix::fs::symlink;
+
+        let Some(node) = node() else {
+            return;
+        };
+        let root = temp_dir("node-config-symlink-root");
+        let outside = temp_dir("node-config-symlink-outside");
+        write_fake_compiler(&root);
+        fs::write(
+            root.join("svelte.config.mjs"),
+            r#"export default { preprocess: { markup: ({ content }) => ({ code: `safe:${content}` }) } };"#,
+        )
+        .unwrap();
+        fs::write(
+            outside.join("svelte.config.mjs"),
+            r#"export default { preprocess: { markup: ({ content }) => ({ code: `escaped:${content}` }) } };"#,
+        )
+        .unwrap();
+        let source = root.join("src/App.svelte");
+        fs::create_dir_all(source.parent().unwrap()).unwrap();
+        fs::write(&source, "body").unwrap();
+        symlink(
+            outside.join("svelte.config.mjs"),
+            root.join("src/svelte.config.mjs"),
+        )
+        .unwrap();
+
+        let (sender, events) = unbounded();
+        let sidecar = PreprocessSidecar::spawn(test_config(node), sender).unwrap();
+        sidecar
+            .preprocess(PreprocessInput {
+                workspace: root.clone(),
+                filename: source,
+                version: 1,
+                text: "body".to_string(),
+            })
+            .unwrap();
+        let result = loop {
+            match events.recv_timeout(Duration::from_secs(5)).unwrap() {
+                PreprocessEvent::Result(result) => break result,
+                PreprocessEvent::Ready { .. }
+                | PreprocessEvent::Crashed { .. }
+                | PreprocessEvent::CircuitOpen { .. }
+                | PreprocessEvent::Failed { .. } => {}
+            }
+        };
+        assert_eq!(result.code, "safe:body");
+        drop(sidecar);
+        fs::remove_dir_all(root).ok();
+        fs::remove_dir_all(outside).ok();
+    }
+
+    #[test]
+    fn hung_preprocessor_opens_the_restart_circuit() {
+        let Some(node) = node() else {
+            return;
+        };
+        let root = temp_dir("timeout");
+        write_fake_compiler(&root);
+        fs::write(
+            root.join("svelte.config.mjs"),
+            r#"
+export default {
+  preprocess: {
+    async markup() { await new Promise(() => {}); }
+  }
+};
+"#,
+        )
+        .unwrap();
+
+        let mut config = test_config(node);
+        config.request_timeout = Duration::from_millis(120);
+        config.max_consecutive_crashes = 2;
+        let (sender, events) = unbounded();
+        let sidecar = PreprocessSidecar::spawn(config, sender).unwrap();
+        sidecar.preprocess(input(&root, 1, "hang")).unwrap();
+
+        let mut crashes = 0;
+        let opened_after = loop {
+            match events.recv_timeout(Duration::from_secs(4)).unwrap() {
+                PreprocessEvent::Crashed { .. } => crashes += 1,
+                PreprocessEvent::CircuitOpen { crashes, .. } => break crashes,
+                PreprocessEvent::Ready { .. }
+                | PreprocessEvent::Result(_)
+                | PreprocessEvent::Failed { .. } => {}
+            }
+        };
+        assert_eq!(crashes, 2);
+        assert_eq!(opened_after, 2);
+        drop(sidecar);
+        fs::remove_dir_all(root).ok();
+    }
+
+    #[test]
+    fn one_successful_replay_does_not_hide_a_repeatable_crash() {
+        let Some(node) = node() else {
+            return;
+        };
+        let root = temp_dir("partial-crash");
+        write_fake_compiler(&root);
+        fs::write(
+            root.join("svelte.config.mjs"),
+            r#"
+export default {
+  preprocess: {
+    markup({ content, filename }) {
+      if (filename.endsWith('ZBad.svelte')) process.exit(19);
+      return { code: `ok:${content}` };
+    }
+  }
+};
+"#,
+        )
+        .unwrap();
+
+        let mut config = test_config(node);
+        config.max_consecutive_crashes = 2;
+        let (sender, events) = unbounded();
+        let sidecar = PreprocessSidecar::spawn(config, sender).unwrap();
+        for name in ["Good.svelte", "ZBad.svelte"] {
+            sidecar
+                .preprocess(PreprocessInput {
+                    workspace: root.clone(),
+                    filename: root.join(name),
+                    version: 1,
+                    text: name.to_string(),
+                })
+                .unwrap();
+        }
+
+        let mut saw_success = false;
+        let crashes = loop {
+            match events.recv_timeout(Duration::from_secs(4)).unwrap() {
+                PreprocessEvent::Result(output) => {
+                    saw_success |= output.filename.ends_with("Good.svelte");
+                }
+                PreprocessEvent::CircuitOpen { crashes, .. } => break crashes,
+                PreprocessEvent::Ready { .. }
+                | PreprocessEvent::Failed { .. }
+                | PreprocessEvent::Crashed { .. } => {}
+            }
+        };
+        assert!(saw_success);
+        assert_eq!(crashes, 2);
+        drop(sidecar);
+        fs::remove_dir_all(root).ok();
+    }
+}

--- a/crates/rsvelte_language_server/src/server.rs
+++ b/crates/rsvelte_language_server/src/server.rs
@@ -1,10 +1,11 @@
 //! The LSP message loop.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::ffi::OsString;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::ExitCode;
+use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use anyhow::Result;
@@ -37,6 +38,10 @@ use crate::client::ClientState;
 use crate::completions::TRIGGER_CHARACTERS;
 use crate::document::{Document, DocumentStore};
 use crate::log;
+use crate::preprocess_sidecar::{
+    PreprocessEvent, PreprocessInput, PreprocessSidecar, PreprocessSidecarConfig,
+    find_preprocess_config,
+};
 use crate::settings::Settings;
 use crate::tsgo_client::{OpenBuffer, TsgoClient, TsgoConfig, TsgoEvent};
 use crate::tsgo_code_actions::{
@@ -62,8 +67,8 @@ use crate::tsgo_rename::{
     rewrite_prepare_response, rewrite_workspace_edit,
 };
 use crate::tsgo_response::{RequestDocumentContext, TsgoResponseMapper};
-use crate::uri::uri_to_path;
-use crate::worker::{FileReferenceSource, Job, Outcome, Worker};
+use crate::uri::{path_to_uri, uri_to_path};
+use crate::worker::{FileReferenceSource, Job, Outcome, PreprocessedAnalysis, Worker};
 
 pub const SERVER_NAME: &str = "rsvelte-language-server";
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -347,6 +352,7 @@ struct PendingCodeLensResolve {
 enum Outgoing {
     Configuration,
     WatchedFilesRegistration,
+    DiagnosticRefresh,
     Tsgo { child_id: RequestId },
 }
 
@@ -354,6 +360,18 @@ struct TsgoRuntime {
     client: TsgoClient,
     overlays: Vec<TsgoOverlay>,
     generation: Option<u64>,
+}
+
+struct PreprocessRuntime {
+    client: PreprocessSidecar,
+    generation: Option<u64>,
+}
+
+struct PreprocessDocumentState {
+    version: i32,
+    text: Arc<String>,
+    map: Option<Arc<String>>,
+    identity: bool,
 }
 
 impl TsgoRuntime {
@@ -441,6 +459,14 @@ impl TsgoRuntime {
             .max_by_key(|overlay| overlay.workspace().components().count())
     }
 
+    fn overlay_for_source(&self, source: &Path) -> Option<&TsgoOverlay> {
+        let source = fs::canonicalize(source).unwrap_or_else(|_| source.to_path_buf());
+        self.overlays
+            .iter()
+            .filter(|overlay| source.starts_with(overlay.workspace()))
+            .max_by_key(|overlay| overlay.workspace().components().count())
+    }
+
     fn completion_document_context(
         &self,
         params: &serde_json::Value,
@@ -490,6 +516,13 @@ struct Server {
     outgoing: HashMap<RequestId, Outgoing>,
     next_request_id: u32,
     tsgo: Option<TsgoRuntime>,
+    preprocess: Option<PreprocessRuntime>,
+    preprocess_events: Receiver<PreprocessEvent>,
+    preprocess_event_sender: Sender<PreprocessEvent>,
+    preprocess_failures: HashMap<PathBuf, (i32, String)>,
+    preprocess_documents: HashMap<PathBuf, PreprocessDocumentState>,
+    preprocess_dependencies: HashMap<PathBuf, HashSet<PathBuf>>,
+    watched_preprocess_directories: HashSet<PathBuf>,
     initialize_params: serde_json::Value,
     shutdown_requested: bool,
     exiting: bool,
@@ -504,6 +537,7 @@ impl Server {
         tsgo: Option<TsgoRuntime>,
         initialize_params: serde_json::Value,
     ) -> Self {
+        let (preprocess_event_sender, preprocess_events) = unbounded();
         Self {
             sender,
             client,
@@ -525,6 +559,13 @@ impl Server {
             outgoing: HashMap::new(),
             next_request_id: 0,
             tsgo,
+            preprocess: None,
+            preprocess_events,
+            preprocess_event_sender,
+            preprocess_failures: HashMap::new(),
+            preprocess_documents: HashMap::new(),
+            preprocess_dependencies: HashMap::new(),
+            watched_preprocess_directories: HashSet::new(),
             initialize_params,
             shutdown_requested: false,
             exiting: false,
@@ -534,12 +575,15 @@ impl Server {
     fn run(&mut self, connection: &Connection) -> Result<ExitCode> {
         if self.client.pull_configuration {
             self.request_configuration();
+        } else {
+            self.ensure_preprocess_runtime();
         }
         if self.client.dynamic_watched_files {
             self.register_watched_files();
         }
         // Cloned out of `self` so the handlers below can still borrow it.
         let outcomes = self.outcomes.clone();
+        let preprocess_events = self.preprocess_events.clone();
         let tsgo_events = self
             .tsgo
             .as_ref()
@@ -566,6 +610,10 @@ impl Server {
                 recv(tsgo_events) -> event => match event {
                     Ok(event) => self.on_tsgo_event(event),
                     Err(_) => self.tsgo = None,
+                },
+                recv(preprocess_events) -> event => match event {
+                    Ok(event) => self.on_preprocess_event(event),
+                    Err(_) => self.preprocess = None,
                 },
                 recv(timer) -> _ => self.run_scheduled_lints(),
             }
@@ -693,6 +741,7 @@ impl Server {
             id,
             path: uri_to_path(uri.as_str()),
             text: document.shared_text(),
+            preprocessed: self.preprocessed_analysis(&uri_to_path(uri.as_str()), document.version),
             warnings: self.settings.compiler_warnings.clone(),
         });
     }
@@ -1500,6 +1549,7 @@ impl Server {
                         self.client
                             .update_workspace_folders(params.event.added, &params.event.removed);
                         self.ensure_tsgo_runtime();
+                        self.restart_preprocessing();
                         if let Some(runtime) = &self.tsgo {
                             let workspace_folders = self.client.workspace_folders.clone();
                             let root_uri = workspace_folders
@@ -1537,9 +1587,17 @@ impl Server {
                             .changes
                             .iter()
                             .any(|change| is_project_config(&change.uri));
-                        if project_changed {
+                        let dependency_changed = params.changes.iter().any(|change| {
+                            let path = uri_to_path(change.uri.as_str());
+                            let path = fs::canonicalize(&path).unwrap_or(path);
+                            self.preprocess_dependencies
+                                .values()
+                                .any(|dependencies| dependencies.contains(&path))
+                        });
+                        if project_changed || dependency_changed {
                             self.invalidate_project_config();
                             self.rebuild_tsgo_overlays();
+                            self.restart_preprocessing();
                         } else {
                             self.refresh_tsgo_overlays();
                         }
@@ -1558,7 +1616,8 @@ impl Server {
                         self.documents
                             .open(doc.uri, doc.language_id, doc.version, doc.text);
                         self.sync_tsgo_document(&key);
-                        if !self.client.pull_diagnostics {
+                        let preprocessing = self.queue_preprocess_document(&key);
+                        if !self.client.pull_diagnostics && !preprocessing {
                             self.schedule_lint(key, Duration::ZERO);
                         }
                     }
@@ -1569,13 +1628,16 @@ impl Server {
                 match serde_json::from_value::<DidChangeTextDocumentParams>(notification.params) {
                     Ok(params) => {
                         let key = params.text_document.uri.as_str().to_string();
+                        let mut changed = false;
                         if let Some(document) = self.documents.get_mut(&params.text_document.uri) {
                             document.apply(params.text_document.version, &params.content_changes);
-                            if !self.client.pull_diagnostics {
-                                self.schedule_lint(key.clone(), LINT_DEBOUNCE);
-                            }
+                            changed = true;
                         }
                         self.sync_tsgo_document(&key);
+                        let preprocessing = self.queue_preprocess_document(&key);
+                        if changed && !self.client.pull_diagnostics && !preprocessing {
+                            self.schedule_lint(key, LINT_DEBOUNCE);
+                        }
                     }
                     Err(err) => log::warn(format_args!("{method}: {err}")),
                 }
@@ -1889,6 +1951,7 @@ impl Server {
         let version = document.version;
         let text = document.text().to_string();
         let path = uri_to_path(uri.as_str());
+        let path = fs::canonicalize(&path).unwrap_or(path);
         let Some(runtime) = &mut self.tsgo else {
             return;
         };
@@ -1937,36 +2000,50 @@ impl Server {
         };
         let language_id = document.language_id.clone();
         let path = uri_to_path(uri.as_str());
-        let Some(runtime) = &mut self.tsgo else {
-            return;
-        };
+        let path = fs::canonicalize(&path).unwrap_or(path);
         if is_svelte_document(&language_id, &path) {
-            let Some(overlay) = runtime.overlay_for_source_mut(&path) else {
-                return;
-            };
-            let shadow_uri = overlay
-                .shadow_for_source(&path)
-                .map(|shadow| shadow.shadow_uri.clone());
-            match overlay.close(&path) {
-                Ok(Some(shadow)) => {
-                    let _ = runtime.client.change_buffer(OpenBuffer::new(
-                        shadow.shadow_uri,
-                        shadow.language_id,
-                        shadow.version,
-                        shadow.text,
-                    ));
-                }
-                Ok(None) => {
-                    if let Some(shadow_uri) = shadow_uri {
-                        let _ = runtime.client.close_buffer(shadow_uri);
+            let mut closed_source = None;
+            if let Some(runtime) = &mut self.tsgo
+                && let Some(overlay) = runtime.overlay_for_source_mut(&path)
+            {
+                let shadow_uri = overlay
+                    .shadow_for_source(&path)
+                    .map(|shadow| shadow.shadow_uri.clone());
+                match overlay.close(&path) {
+                    Ok(Some(shadow)) => {
+                        closed_source = overlay
+                            .source_text(&path)
+                            .map(|text| (shadow.version, text.to_string()));
+                        let _ = runtime.client.change_buffer(OpenBuffer::new(
+                            shadow.shadow_uri,
+                            shadow.language_id,
+                            shadow.version,
+                            shadow.text,
+                        ));
                     }
+                    Ok(None) => {
+                        if let Some(shadow_uri) = shadow_uri {
+                            let _ = runtime.client.close_buffer(shadow_uri);
+                        }
+                    }
+                    Err(error) => log::warn(format_args!(
+                        "could not close tsgo shadow for {}: {error}",
+                        path.display()
+                    )),
                 }
-                Err(error) => log::warn(format_args!(
-                    "could not close tsgo shadow for {}: {error}",
-                    path.display()
-                )),
+            }
+            self.preprocess_failures.remove(&path);
+            self.preprocess_documents.remove(&path);
+            self.preprocess_dependencies.remove(&path);
+            if let Some((version, text)) = closed_source {
+                let _ = self.queue_preprocess_path(path, version, text);
+            } else if let Some(runtime) = &self.preprocess {
+                let _ = runtime.client.remove(path);
             }
         } else if is_typescript_or_javascript(&language_id, &path) {
+            let Some(runtime) = &mut self.tsgo else {
+                return;
+            };
             let Some(overlay) = runtime.overlay_for_source_mut(&path) else {
                 return;
             };
@@ -2135,6 +2212,444 @@ impl Server {
         }
     }
 
+    fn ensure_preprocess_runtime(&mut self) {
+        if !self.client.is_trusted || !self.settings.preprocess_enable {
+            self.preprocess = None;
+            self.preprocess_failures.clear();
+            self.preprocess_documents.clear();
+            self.preprocess_dependencies.clear();
+            return;
+        }
+        if self.preprocess.is_some() {
+            return;
+        }
+        let inputs = self.preprocess_inputs();
+        if inputs.is_empty() {
+            return;
+        }
+        let client = match PreprocessSidecar::spawn(
+            PreprocessSidecarConfig::default(),
+            self.preprocess_event_sender.clone(),
+        ) {
+            Ok(client) => client,
+            Err(error) => {
+                log::warn(format_args!(
+                    "could not start preprocess supervisor: {error}"
+                ));
+                return;
+            }
+        };
+        for input in inputs {
+            let _ = client.preprocess(input);
+        }
+        self.preprocess = Some(PreprocessRuntime {
+            client,
+            generation: None,
+        });
+    }
+
+    fn preprocess_inputs(&self) -> Vec<PreprocessInput> {
+        let mut inputs = HashMap::<PathBuf, PreprocessInput>::new();
+        if let Some(runtime) = &self.tsgo {
+            for overlay in &runtime.overlays {
+                for shadow in overlay.eager_shadows() {
+                    let filename = uri_to_path(shadow.source_uri.as_str());
+                    if find_preprocess_config(&filename, overlay.workspace()).is_none() {
+                        continue;
+                    }
+                    let Some(text) = overlay.source_text(&filename) else {
+                        continue;
+                    };
+                    inputs.insert(
+                        filename.clone(),
+                        PreprocessInput {
+                            workspace: overlay.workspace().to_path_buf(),
+                            filename,
+                            version: shadow.version,
+                            text: text.to_string(),
+                        },
+                    );
+                }
+            }
+        }
+        for document in self.documents.iter() {
+            let filename = uri_to_path(document.uri.as_str());
+            let Some(workspace) = self.preprocess_workspace_for_path(&filename) else {
+                continue;
+            };
+            if find_preprocess_config(&filename, &workspace).is_none() {
+                continue;
+            }
+            inputs.insert(
+                filename.clone(),
+                PreprocessInput {
+                    workspace,
+                    filename,
+                    version: document.version,
+                    text: document.text().to_string(),
+                },
+            );
+        }
+        inputs.into_values().collect()
+    }
+
+    fn queue_preprocess_document(&mut self, key: &str) -> bool {
+        self.ensure_preprocess_runtime();
+        let Some(document) = self.documents.get_by_key(key) else {
+            return false;
+        };
+        let filename = uri_to_path(document.uri.as_str());
+        let filename = fs::canonicalize(&filename).unwrap_or(filename);
+        self.preprocess_failures.remove(&filename);
+        self.preprocess_documents.remove(&filename);
+        self.queue_preprocess_path(filename, document.version, document.text().to_string())
+    }
+
+    fn queue_preprocess_path(&mut self, filename: PathBuf, version: i32, text: String) -> bool {
+        let Some(workspace) = self.preprocess_workspace_for_path(&filename) else {
+            return false;
+        };
+        if find_preprocess_config(&filename, &workspace).is_none() {
+            if let Some(runtime) = &self.preprocess {
+                let _ = runtime.client.remove(filename);
+            }
+            return false;
+        }
+        if let Some(runtime) = &self.preprocess {
+            return runtime
+                .client
+                .preprocess(PreprocessInput {
+                    workspace,
+                    filename,
+                    version,
+                    text,
+                })
+                .is_ok();
+        }
+        false
+    }
+
+    fn preprocess_workspace_for_path(&self, path: &Path) -> Option<PathBuf> {
+        if let Some(runtime) = &self.tsgo
+            && let Some(overlay) = runtime
+                .overlays
+                .iter()
+                .filter(|overlay| path.starts_with(overlay.workspace()))
+                .max_by_key(|overlay| overlay.workspace().components().count())
+        {
+            return Some(overlay.workspace().to_path_buf());
+        }
+        self.client
+            .workspace_folders
+            .iter()
+            .map(|folder| uri_to_path(folder.uri.as_str()))
+            .chain(
+                self.client
+                    .root_uri
+                    .iter()
+                    .map(|root| uri_to_path(root.as_str())),
+            )
+            .filter(|workspace| path.starts_with(workspace))
+            .max_by_key(|workspace| workspace.components().count())
+    }
+
+    fn register_preprocess_dependencies(
+        &mut self,
+        filename: &Path,
+        config_path: Option<&Path>,
+        dependencies: &[PathBuf],
+    ) {
+        let base = config_path
+            .and_then(Path::parent)
+            .or_else(|| filename.parent())
+            .unwrap_or(Path::new("."));
+        let dependencies = dependencies
+            .iter()
+            .map(|dependency| {
+                let dependency = if dependency.is_absolute() {
+                    dependency.clone()
+                } else {
+                    base.join(dependency)
+                };
+                fs::canonicalize(&dependency).unwrap_or(dependency)
+            })
+            .collect::<HashSet<_>>();
+        self.preprocess_dependencies
+            .insert(filename.to_path_buf(), dependencies.clone());
+        if !self.client.dynamic_watched_files {
+            return;
+        }
+        let candidate_directories = dependencies
+            .into_iter()
+            .filter_map(|dependency| {
+                self.preprocess_workspace_for_path(&dependency)?;
+                dependency.parent().map(Path::to_path_buf)
+            })
+            .collect::<Vec<_>>();
+        let watch_directories = candidate_directories
+            .into_iter()
+            .filter(|directory| {
+                self.watched_preprocess_directories
+                    .insert(directory.clone())
+            })
+            .collect::<Vec<_>>();
+        let watchers = watch_directories
+            .into_iter()
+            .filter_map(|directory| {
+                let base_uri = path_to_uri(&directory)?;
+                Some(serde_json::json!({
+                    "globPattern": {
+                        "baseUri": base_uri,
+                        "pattern": "*",
+                    }
+                }))
+            })
+            .collect::<Vec<_>>();
+        if watchers.is_empty() {
+            return;
+        }
+        self.next_request_id += 1;
+        let id = RequestId::from(format!(
+            "rsvelte-preprocess-dependencies-{}",
+            self.next_request_id
+        ));
+        self.outgoing
+            .insert(id.clone(), Outgoing::WatchedFilesRegistration);
+        self.send(Request::new(
+            id,
+            "client/registerCapability".to_string(),
+            serde_json::json!({
+                "registrations": [{
+                    "id": format!("rsvelte-preprocess-dependencies-{}", self.next_request_id),
+                    "method": "workspace/didChangeWatchedFiles",
+                    "registerOptions": { "watchers": watchers },
+                }],
+            }),
+        ));
+    }
+
+    fn restart_preprocessing(&mut self) {
+        self.preprocess_failures.clear();
+        self.preprocess_documents.clear();
+        self.preprocess_dependencies.clear();
+        self.preprocess = None;
+        self.ensure_preprocess_runtime();
+    }
+
+    fn on_preprocess_event(&mut self, event: PreprocessEvent) {
+        match event {
+            PreprocessEvent::Ready { generation } => {
+                if let Some(runtime) = &mut self.preprocess {
+                    runtime.generation = Some(generation);
+                }
+            }
+            PreprocessEvent::Result(output) => {
+                if self
+                    .preprocess
+                    .as_ref()
+                    .and_then(|runtime| runtime.generation)
+                    != Some(output.generation)
+                {
+                    return;
+                }
+                let filename = fs::canonicalize(&output.filename).unwrap_or(output.filename);
+                let original = self
+                    .documents
+                    .iter()
+                    .find(|document| {
+                        let path = uri_to_path(document.uri.as_str());
+                        fs::canonicalize(&path).unwrap_or(path) == filename
+                    })
+                    .filter(|document| document.version == output.version)
+                    .map(|document| document.text().to_string())
+                    .or_else(|| {
+                        self.tsgo.as_ref().and_then(|runtime| {
+                            let overlay = runtime.overlay_for_source(&filename)?;
+                            overlay
+                                .shadow_for_source(&filename)
+                                .filter(|shadow| shadow.version == output.version)
+                                .and_then(|_| overlay.source_text(&filename).map(str::to_string))
+                        })
+                    });
+                let Some(original) = original else {
+                    return;
+                };
+                self.preprocess_failures.remove(&filename);
+                if output.has_preprocessor {
+                    self.preprocess_documents.insert(
+                        filename.clone(),
+                        PreprocessDocumentState {
+                            version: output.version,
+                            text: Arc::new(output.code.clone()),
+                            map: output.map.clone().map(Arc::new),
+                            identity: original == output.code,
+                        },
+                    );
+                } else {
+                    self.preprocess_documents.remove(&filename);
+                }
+                self.register_preprocess_dependencies(
+                    &filename,
+                    output.config_path.as_deref(),
+                    &output.dependencies,
+                );
+                let mut projection_error = None;
+                if let Some(runtime) = &mut self.tsgo
+                    && let Some(overlay) = runtime.overlay_for_source_mut(&filename)
+                {
+                    match overlay.open_or_update_preprocessed(
+                        &filename,
+                        &original,
+                        &output.code,
+                        output.map.as_deref(),
+                        output.version,
+                    ) {
+                        Ok(shadow) => {
+                            let _ = runtime.client.change_buffer(OpenBuffer::new(
+                                shadow.shadow_uri,
+                                shadow.language_id,
+                                shadow.version,
+                                shadow.text,
+                            ));
+                        }
+                        Err(error) => projection_error = Some(error.to_string()),
+                    }
+                }
+                let open_key = self
+                    .documents
+                    .iter()
+                    .find(|document| {
+                        let path = uri_to_path(document.uri.as_str());
+                        fs::canonicalize(&path).unwrap_or(path) == filename
+                            && document.version == output.version
+                    })
+                    .map(|document| document.uri.as_str().to_string());
+                if let Some(error) = projection_error {
+                    let message = format!("could not project preprocessed document: {error}");
+                    log::warn(format_args!("{}: {message}", filename.display()));
+                    self.preprocess_documents.remove(&filename);
+                    self.preprocess_failures
+                        .insert(filename, (output.version, message));
+                    if let Some(key) = open_key {
+                        self.refresh_document_diagnostics(key);
+                    }
+                    return;
+                }
+                if let Some(key) = open_key {
+                    self.refresh_document_diagnostics(key);
+                }
+            }
+            PreprocessEvent::Failed {
+                generation,
+                filename,
+                version,
+                message,
+            } => {
+                if self
+                    .preprocess
+                    .as_ref()
+                    .and_then(|runtime| runtime.generation)
+                    != Some(generation)
+                {
+                    return;
+                }
+                log::warn(format_args!("preprocessing failed: {message}"));
+                if let (Some(filename), Some(version)) = (filename, version) {
+                    let filename = fs::canonicalize(&filename).unwrap_or(filename);
+                    self.preprocess_failures
+                        .insert(filename.clone(), (version, message));
+                    self.preprocess_documents.remove(&filename);
+                    self.preprocess_dependencies.remove(&filename);
+                    if let Some(runtime) = &mut self.tsgo
+                        && let Some(overlay) = runtime.overlay_for_source_mut(&filename)
+                        && let Some(original) = self
+                            .documents
+                            .iter()
+                            .find(|document| {
+                                let path = uri_to_path(document.uri.as_str());
+                                fs::canonicalize(&path).unwrap_or(path) == filename
+                                    && document.version == version
+                            })
+                            .map(|document| document.text().to_string())
+                            .or_else(|| overlay.source_text(&filename).map(str::to_string))
+                    {
+                        match overlay.open_or_update(&filename, &original, version) {
+                            Ok(shadow) => {
+                                let _ = runtime.client.change_buffer(OpenBuffer::new(
+                                    shadow.shadow_uri,
+                                    shadow.language_id,
+                                    shadow.version,
+                                    shadow.text,
+                                ));
+                            }
+                            Err(error) => log::warn(format_args!(
+                                "could not restore raw shadow for {}: {error}",
+                                filename.display()
+                            )),
+                        }
+                    }
+                    let open_key = self
+                        .documents
+                        .iter()
+                        .find(|document| {
+                            let path = uri_to_path(document.uri.as_str());
+                            fs::canonicalize(&path).unwrap_or(path) == filename
+                                && document.version == version
+                        })
+                        .map(|document| document.uri.as_str().to_string());
+                    if let Some(key) = open_key {
+                        self.refresh_document_diagnostics(key);
+                    }
+                }
+            }
+            PreprocessEvent::Crashed {
+                generation,
+                status,
+                error,
+            } => {
+                if let Some(runtime) = &mut self.preprocess
+                    && runtime.generation == Some(generation)
+                {
+                    runtime.generation = None;
+                }
+                log::warn(format_args!(
+                    "preprocess sidecar crashed ({status:?}): {error}"
+                ));
+            }
+            PreprocessEvent::CircuitOpen {
+                generation,
+                crashes,
+                error,
+            } => {
+                if let Some(runtime) = &mut self.preprocess
+                    && runtime.generation == Some(generation)
+                {
+                    runtime.generation = None;
+                }
+                log::warn(format_args!(
+                    "preprocess sidecar restart circuit opened after {crashes} crashes: {error}"
+                ));
+                for input in self.preprocess_inputs() {
+                    self.preprocess_documents.remove(&input.filename);
+                    self.preprocess_failures
+                        .insert(input.filename.clone(), (input.version, error.clone()));
+                    let open_key = self
+                        .documents
+                        .iter()
+                        .find(|document| {
+                            let path = uri_to_path(document.uri.as_str());
+                            fs::canonicalize(&path).unwrap_or(path) == input.filename
+                                && document.version == input.version
+                        })
+                        .map(|document| document.uri.as_str().to_string());
+                    if let Some(key) = open_key {
+                        self.refresh_document_diagnostics(key);
+                    }
+                }
+            }
+        }
+    }
+
     fn on_response(&mut self, mut response: Response) {
         let Some(outgoing) = self.outgoing.remove(&response.id) else {
             log::warn(format_args!("response to unknown request {}", response.id));
@@ -2142,6 +2657,7 @@ impl Server {
         };
         match outgoing {
             Outgoing::Configuration => {
+                let preprocessing_was_enabled = self.settings.preprocess_enable;
                 self.settings = match response.response_result {
                     Ok(value) => {
                         let items = value.as_array();
@@ -2184,11 +2700,21 @@ impl Server {
                 {
                     log::warn(format_args!("could not update tsgo settings: {error}"));
                 }
+                if preprocessing_was_enabled && !self.settings.preprocess_enable {
+                    self.preprocess = None;
+                    self.preprocess_failures.clear();
+                    self.preprocess_documents.clear();
+                    self.preprocess_dependencies.clear();
+                    self.rebuild_tsgo_overlays();
+                } else {
+                    self.ensure_preprocess_runtime();
+                }
                 if !self.client.pull_diagnostics {
                     self.relint_open_documents();
                 }
             }
             Outgoing::WatchedFilesRegistration => {}
+            Outgoing::DiagnosticRefresh => {}
             Outgoing::Tsgo { child_id } => {
                 response.id = child_id;
                 if let Some(runtime) = &self.tsgo {
@@ -2901,10 +3427,22 @@ impl Server {
                     );
                 }
             }
-            Outcome::PulledDiagnostics { id, diagnostics } => {
+            Outcome::PulledDiagnostics {
+                id,
+                mut diagnostics,
+            } => {
                 if let Some(Pending::DocumentDiagnostic { tsgo_fallback }) =
                     self.pending.remove(&id)
                 {
+                    if let Some(uri) = text_document_request_uri(&tsgo_fallback)
+                        && let Some((_, message)) = {
+                            let path = uri_to_path(uri.as_str());
+                            let path = fs::canonicalize(&path).unwrap_or(path);
+                            self.preprocess_failures.get(&path)
+                        }
+                    {
+                        diagnostics.push(crate::diagnostics::preprocess_failure(message));
+                    }
                     self.forward_tsgo_request_with_fallback(
                         tsgo_fallback,
                         serde_json::to_value(diagnostic_report(diagnostics)).ok(),
@@ -2920,9 +3458,17 @@ impl Server {
                 key,
                 uri,
                 version,
-                diagnostics,
+                mut diagnostics,
             } => {
                 if self.documents.get_by_key(&key).is_some() {
+                    if let Some((failed_version, message)) = {
+                        let path = uri_to_path(uri.as_str());
+                        let path = fs::canonicalize(&path).unwrap_or(path);
+                        self.preprocess_failures.get(&path)
+                    } && *failed_version == version
+                    {
+                        diagnostics.push(crate::diagnostics::preprocess_failure(message));
+                    }
                     self.pull_and_publish_tsgo_diagnostics(uri, version, diagnostics);
                 }
             }
@@ -2978,6 +3524,34 @@ impl Server {
 
     fn schedule_lint(&mut self, key: String, delay: Duration) {
         self.scheduled.insert(key, Instant::now() + delay);
+    }
+
+    fn refresh_document_diagnostics(&mut self, key: String) {
+        self.linted.remove(&key);
+        if !self.client.pull_diagnostics {
+            self.schedule_lint(key, Duration::ZERO);
+            return;
+        }
+        if !self.client.diagnostic_refresh
+            || self
+                .outgoing
+                .values()
+                .any(|outgoing| matches!(outgoing, Outgoing::DiagnosticRefresh))
+        {
+            return;
+        }
+        self.next_request_id += 1;
+        let id = RequestId::from(format!(
+            "rsvelte-diagnostic-refresh-{}",
+            self.next_request_id
+        ));
+        self.outgoing
+            .insert(id.clone(), Outgoing::DiagnosticRefresh);
+        self.send(Request::new(
+            id,
+            "workspace/diagnostic/refresh".to_string(),
+            serde_json::Value::Null,
+        ));
     }
 
     /// Re-lint everything after the settings changed — the results may differ
@@ -3040,8 +3614,22 @@ impl Server {
             version,
             path: uri_to_path(key),
             text: document.shared_text(),
+            preprocessed: self.preprocessed_analysis(&uri_to_path(key), version),
             warnings: self.settings.compiler_warnings.clone(),
         });
+    }
+
+    fn preprocessed_analysis(&self, path: &Path, version: i32) -> Option<PreprocessedAnalysis> {
+        let path = fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf());
+        let state = self.preprocess_documents.get(&path)?;
+        if state.version != version {
+            return None;
+        }
+        Some(PreprocessedAnalysis {
+            text: Arc::clone(&state.text),
+            map: state.map.as_ref().map(Arc::clone),
+            identity: state.identity,
+        })
     }
 
     fn publish(&self, uri: Uri, version: i32, diagnostics: Vec<lsp_types::Diagnostic>) {
@@ -3144,6 +3732,14 @@ fn custom_request_uri(params: &serde_json::Value) -> Option<Uri> {
         .or_else(|| params.get("uri").and_then(serde_json::Value::as_str))?
         .parse()
         .ok()
+}
+
+fn text_document_request_uri(request: &Request) -> Option<Uri> {
+    request
+        .params
+        .pointer("/textDocument/uri")
+        .cloned()
+        .and_then(|uri| serde_json::from_value(uri).ok())
 }
 
 /// Svelte components plus the `.svelte.js` / `.svelte.ts` module dialect.

--- a/crates/rsvelte_language_server/src/settings.rs
+++ b/crates/rsvelte_language_server/src/settings.rs
@@ -27,6 +27,7 @@ pub struct Settings {
     pub selection_range_enable: bool,
     pub document_symbol_enable: bool,
     pub runes_legacy_mode_code_lens_enable: bool,
+    pub preprocess_enable: bool,
     pub compiler_warnings: CompilerWarnings,
 }
 
@@ -41,6 +42,7 @@ impl Default for Settings {
             selection_range_enable: true,
             document_symbol_enable: true,
             runes_legacy_mode_code_lens_enable: true,
+            preprocess_enable: true,
             compiler_warnings: CompilerWarnings::default(),
         }
     }
@@ -65,6 +67,7 @@ impl Settings {
                 .unwrap_or(default.document_symbol_enable),
             runes_legacy_mode_code_lens_enable: enabled(value, "runesLegacyModeCodeLens")
                 .unwrap_or(default.runes_legacy_mode_code_lens_enable),
+            preprocess_enable: enabled(value, "preprocess").unwrap_or(default.preprocess_enable),
             compiler_warnings: compiler_warnings(value),
         }
     }
@@ -103,8 +106,9 @@ mod tests {
             "hover": { "enable": false },
             "foldingRange": { "enable": false },
             "selectionRange": { "enable": true },
-            "documentSymbol": { "enable": false }
-            ,"runesLegacyModeCodeLens": { "enable": true }
+            "documentSymbol": { "enable": false },
+            "runesLegacyModeCodeLens": { "enable": true },
+            "preprocess": { "enable": false }
         }));
         assert_eq!(
             s,
@@ -117,6 +121,7 @@ mod tests {
                 selection_range_enable: true,
                 document_symbol_enable: false,
                 runes_legacy_mode_code_lens_enable: true,
+                preprocess_enable: false,
                 compiler_warnings: CompilerWarnings::default(),
             }
         );

--- a/crates/rsvelte_language_server/src/tsgo_overlay.rs
+++ b/crates/rsvelte_language_server/src/tsgo_overlay.rs
@@ -18,7 +18,7 @@ use rsvelte_projection::{
     Svelte2TsxNamespace, Svelte2TsxOptions, SvelteVersion,
 };
 use serde_json::json;
-use sourcemap::SourceMap;
+use sourcemap::{SourceMap, SourceMapBuilder};
 
 use crate::text::LineIndex;
 
@@ -143,12 +143,42 @@ struct MappingToken {
     source: Option<(u32, u32)>,
 }
 
+#[derive(Debug, Clone, Copy)]
+struct ReverseMappingToken {
+    source_line: u32,
+    source_column: u32,
+    generated_line: u32,
+    generated_column: u32,
+}
+
+#[derive(Debug, Default)]
+struct PreprocessMappings {
+    generated: Vec<MappingToken>,
+    original: Vec<ReverseMappingToken>,
+}
+
+/// Whether a Svelte projection used a user-preprocessed document.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PreprocessStatus {
+    /// Original and preprocessed texts are identical.
+    Identity,
+    /// Changed preprocessed text has a usable source map back to the original.
+    Mapped,
+    /// Changed preprocessed text has no source map and cannot be mapped safely.
+    Unmapped,
+}
+
 struct ShadowState {
     document: ShadowDocument,
     source_path: PathBuf,
     shadow_path: PathBuf,
     source_text: String,
     source_index: LineIndex,
+    preprocessed_text: Option<String>,
+    preprocessed_index: Option<LineIndex>,
+    preprocess_map: Option<String>,
+    preprocess_mappings: PreprocessMappings,
+    preprocess_status: PreprocessStatus,
     generated_index: LineIndex,
     exact_map: ProjectionMap,
     source_map: Option<String>,
@@ -254,21 +284,57 @@ impl TsgoOverlay {
         text: &str,
         version: i32,
     ) -> Result<ShadowDocument, TsgoOverlayError> {
+        self.open_or_update_preprocessed(source_path, text, text, None, version)
+    }
+
+    /// Generate or replace one virtual shadow from a preprocessed Svelte document.
+    ///
+    /// `preprocess_map` is a standard v3 map from `preprocessed_text` back to
+    /// `original_text`. Changed text without a map remains usable by tsgo, but
+    /// editor positions cannot be mapped safely.
+    pub fn open_or_update_preprocessed(
+        &mut self,
+        source_path: &Path,
+        original_text: &str,
+        preprocessed_text: &str,
+        preprocess_map: Option<&str>,
+        version: i32,
+    ) -> Result<ShadowDocument, TsgoOverlayError> {
         let source_path = self.confined_source(source_path)?;
         let shadow_path = self.shadow_path_for(&source_path)?;
         self.ensure_shadow_parent(&shadow_path)?;
 
-        let options = self.projection_options(&source_path, &shadow_path, text);
-        let artifact =
-            self.engine
-                .project(text, options)
-                .map_err(|error| TsgoOverlayError::Projection {
-                    path: source_path.clone(),
-                    message: error.to_string(),
-                })?;
-        let mut exact_map = artifact.exact_mappings.unwrap_or_default();
-        let source_map = artifact.source_map;
-        let mut tokens = parse_mapping_tokens(&source_path, source_map.as_deref())?;
+        let preprocess_status = if original_text == preprocessed_text {
+            PreprocessStatus::Identity
+        } else if preprocess_map.is_some() {
+            PreprocessStatus::Mapped
+        } else {
+            PreprocessStatus::Unmapped
+        };
+        let preprocess_mappings = if preprocess_status == PreprocessStatus::Mapped {
+            parse_preprocess_mappings(
+                &source_path,
+                preprocess_map.expect("mapped preprocessing has a map"),
+            )?
+        } else {
+            PreprocessMappings::default()
+        };
+
+        let options = self.projection_options(&source_path, &shadow_path, preprocessed_text);
+        let artifact = self
+            .engine
+            .project(preprocessed_text, options)
+            .map_err(|error| TsgoOverlayError::Projection {
+                path: source_path.clone(),
+                message: error.to_string(),
+            })?;
+        let mut exact_map = if preprocess_status == PreprocessStatus::Identity {
+            artifact.exact_mappings.unwrap_or_default()
+        } else {
+            ProjectionMap::default()
+        };
+        let projection_source_map = artifact.source_map;
+        let mut tokens = parse_mapping_tokens(&source_path, projection_source_map.as_deref())?;
         let original_generated = artifact.code;
         let original_index = LineIndex::new(&original_generated);
         let (generated_text, import_insertions) = rewrite_plain_svelte_imports(&original_generated);
@@ -294,6 +360,18 @@ impl TsgoOverlay {
         for (_, generated_range) in &import_insertions {
             exact_map.insert_generated(generated_range.start as u32, generated_range.len() as u32);
         }
+        let generated_index = LineIndex::new(&generated_text);
+        let source_map = compose_source_map(
+            &source_path,
+            original_text,
+            projection_source_map.as_deref(),
+            &tokens,
+            &preprocess_mappings,
+            preprocess_status,
+            &generated_text,
+            &generated_index,
+            &import_insertions,
+        )?;
         let document = ShadowDocument {
             source_uri: path_to_uri(&source_path)?,
             shadow_uri: path_to_uri(&shadow_path)?,
@@ -310,9 +388,16 @@ impl TsgoOverlay {
         let state = ShadowState {
             source_path: source_path.clone(),
             shadow_path: shadow_path.clone(),
-            source_text: text.to_string(),
-            source_index: LineIndex::new(text),
-            generated_index: LineIndex::new(&document.text),
+            source_text: original_text.to_string(),
+            source_index: LineIndex::new(original_text),
+            preprocessed_text: (preprocess_status != PreprocessStatus::Identity)
+                .then(|| preprocessed_text.to_string()),
+            preprocessed_index: (preprocess_status != PreprocessStatus::Identity)
+                .then(|| LineIndex::new(preprocessed_text)),
+            preprocess_map: preprocess_map.map(str::to_string),
+            preprocess_mappings,
+            preprocess_status,
+            generated_index,
             exact_map,
             source_map,
             tokens,
@@ -359,6 +444,11 @@ impl TsgoOverlay {
             shadow_path: shadow_path.clone(),
             source_text: text.to_string(),
             source_index: LineIndex::new(text),
+            preprocessed_text: None,
+            preprocessed_index: None,
+            preprocess_map: None,
+            preprocess_mappings: PreprocessMappings::default(),
+            preprocess_status: PreprocessStatus::Identity,
             generated_index: LineIndex::new(text),
             exact_map: ProjectionMap::default(),
             tokens: Vec::new(),
@@ -519,6 +609,34 @@ impl TsgoOverlay {
             .map(|entry| entry.source_text.as_str())
     }
 
+    /// Preprocessed Svelte text used as input to svelte2tsx.
+    #[must_use]
+    pub fn preprocessed_text(&self, source_path: &Path) -> Option<&str> {
+        let path = self.lookup_source_path(source_path);
+        self.entries.get(&path).map(|entry| {
+            entry
+                .preprocessed_text
+                .as_deref()
+                .unwrap_or(&entry.source_text)
+        })
+    }
+
+    /// Standard v3 source map supplied by the preprocessor.
+    #[must_use]
+    pub fn preprocess_map(&self, source_path: &Path) -> Option<&str> {
+        let path = self.lookup_source_path(source_path);
+        self.entries
+            .get(&path)
+            .and_then(|entry| entry.preprocess_map.as_deref())
+    }
+
+    /// Mapping status of the preprocessed Svelte input.
+    #[must_use]
+    pub fn preprocess_status(&self, source_path: &Path) -> Option<PreprocessStatus> {
+        let path = self.lookup_source_path(source_path);
+        self.entries.get(&path).map(|entry| entry.preprocess_status)
+    }
+
     /// Standard source map retained for rewritten-template position fallback.
     #[must_use]
     pub fn source_map(&self, source_path: &Path) -> Option<&str> {
@@ -546,14 +664,29 @@ impl TsgoOverlay {
             return Some(utf8_position(&entry.document.text, generated_offset));
         }
 
-        if let Some(generated) = exact_source_offset(&entry.exact_map, source_offset) {
+        if entry.preprocess_status == PreprocessStatus::Identity
+            && let Some(generated) = exact_source_offset(&entry.exact_map, source_offset)
+        {
             return Some(utf8_position(&entry.document.text, generated as usize));
         }
 
-        let source_position = entry
+        let original_position = entry
             .source_index
             .position(&entry.source_text, source_offset);
-        let token = closest_source_token(&entry.tokens, source_position)?;
+        let preprocessed_position = map_original_to_preprocessed(entry, original_position)?;
+        let preprocessed_text = entry
+            .preprocessed_text
+            .as_deref()
+            .unwrap_or(&entry.source_text);
+        let preprocessed_index = entry
+            .preprocessed_index
+            .as_ref()
+            .unwrap_or(&entry.source_index);
+        let preprocessed_position = preprocessed_index.position(
+            preprocessed_text,
+            preprocessed_index.offset(preprocessed_text, preprocessed_position),
+        );
+        let token = closest_source_token(&entry.tokens, preprocessed_position)?;
         let generated_offset = entry.generated_index.offset(
             &entry.document.text,
             Position::new(token.generated_line, token.generated_column),
@@ -608,7 +741,9 @@ impl TsgoOverlay {
             return None;
         }
 
-        if let Some(source) = exact_generated_offset(&entry.exact_map, generated_offset) {
+        if entry.preprocess_status == PreprocessStatus::Identity
+            && let Some(source) = exact_generated_offset(&entry.exact_map, generated_offset)
+        {
             return Some(
                 entry
                     .source_index
@@ -624,12 +759,13 @@ impl TsgoOverlay {
                 <= (generated_utf16.line, generated_utf16.character)
         });
         let previous = index.checked_sub(1).and_then(|i| entry.tokens.get(i))?;
-        if generated_is_unmapped_gap(&entry.tokens, index, generated_utf16) {
+        if previous.generated_line != generated_utf16.line
+            || generated_is_unmapped_gap(&entry.tokens, index, generated_utf16)
+        {
             return None;
         }
-        previous
-            .source
-            .map(|(line, column)| Position::new(line, column))
+        let (line, column) = previous.source?;
+        map_preprocessed_to_original(entry, Position::new(line, column))
     }
 
     /// Map a tsgo UTF-8 range back to the editor's UTF-16 source range.
@@ -1189,6 +1325,135 @@ fn parse_mapping_tokens(
     Ok(tokens)
 }
 
+fn parse_preprocess_mappings(
+    source_path: &Path,
+    raw: &str,
+) -> Result<PreprocessMappings, TsgoOverlayError> {
+    let map = SourceMap::from_slice(raw.as_bytes()).map_err(|error| {
+        TsgoOverlayError::InvalidSourceMap {
+            path: source_path.to_path_buf(),
+            message: error.to_string(),
+        }
+    })?;
+    let single_source = map.get_source_count() == 1;
+    let mut mappings = PreprocessMappings::default();
+    for token in map.tokens() {
+        let belongs_to_document = token
+            .get_source()
+            .is_some_and(|source| single_source || source_matches(source_path, source));
+        let source = belongs_to_document.then(|| (token.get_src_line(), token.get_src_col()));
+        mappings.generated.push(MappingToken {
+            generated_line: token.get_dst_line(),
+            generated_column: token.get_dst_col(),
+            source,
+        });
+        if let Some((source_line, source_column)) = source {
+            mappings.original.push(ReverseMappingToken {
+                source_line,
+                source_column,
+                generated_line: token.get_dst_line(),
+                generated_column: token.get_dst_col(),
+            });
+        }
+    }
+    mappings
+        .generated
+        .sort_by_key(|token| (token.generated_line, token.generated_column));
+    mappings.original.sort_by_key(|token| {
+        (
+            token.source_line,
+            token.source_column,
+            token.generated_line,
+            token.generated_column,
+        )
+    });
+    Ok(mappings)
+}
+
+fn source_matches(source_path: &Path, source: &str) -> bool {
+    let expected = source_path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or_default();
+    source == source_path.to_string_lossy()
+        || source
+            .rsplit(['/', '\\'])
+            .next()
+            .is_some_and(|name| name == expected)
+}
+
+#[allow(clippy::too_many_arguments)]
+fn compose_source_map(
+    source_path: &Path,
+    original_text: &str,
+    projection_source_map: Option<&str>,
+    projection_tokens: &[MappingToken],
+    preprocess_mappings: &PreprocessMappings,
+    preprocess_status: PreprocessStatus,
+    generated_text: &str,
+    generated_index: &LineIndex,
+    import_insertions: &[(usize, std::ops::Range<usize>)],
+) -> Result<Option<String>, TsgoOverlayError> {
+    if projection_source_map.is_none() || preprocess_status == PreprocessStatus::Unmapped {
+        return Ok(None);
+    }
+
+    let mut composed = projection_tokens
+        .iter()
+        .map(|token| {
+            let source = token.source.and_then(|(line, column)| {
+                let position = Position::new(line, column);
+                match preprocess_status {
+                    PreprocessStatus::Identity => Some(position),
+                    PreprocessStatus::Mapped => {
+                        map_generated_tokens(&preprocess_mappings.generated, position)
+                    }
+                    PreprocessStatus::Unmapped => None,
+                }
+            });
+            (token.generated_line, token.generated_column, source)
+        })
+        .collect::<Vec<_>>();
+    composed.extend(import_insertions.iter().map(|(_, range)| {
+        let position = generated_index.position(generated_text, range.start);
+        (position.line, position.character, None)
+    }));
+    composed.sort_by_key(|(line, column, source)| (*line, *column, source.is_some()));
+
+    let source_name = source_path.to_string_lossy();
+    let mut builder = SourceMapBuilder::new(None);
+    let source_id = builder.add_source(&source_name);
+    builder.set_source_contents(source_id, Some(original_text));
+    for (generated_line, generated_column, source) in composed {
+        let (source_line, source_column, source_name) = source.map_or((0, 0, None), |position| {
+            (
+                position.line,
+                position.character,
+                Some(source_name.as_ref()),
+            )
+        });
+        builder.add(
+            generated_line,
+            generated_column,
+            source_line,
+            source_column,
+            source_name,
+            None,
+            false,
+        );
+    }
+    let map = builder.into_sourcemap();
+    let mut encoded = Vec::new();
+    map.to_writer(&mut encoded)
+        .map_err(|error| TsgoOverlayError::InvalidSourceMap {
+            path: source_path.to_path_buf(),
+            message: error.to_string(),
+        })?;
+    Ok(Some(
+        String::from_utf8(encoded).expect("source-map JSON is UTF-8"),
+    ))
+}
+
 fn rewrite_plain_svelte_imports(source: &str) -> (String, Vec<(usize, std::ops::Range<usize>)>) {
     let bytes = source.as_bytes();
     let mut insertions = Vec::new();
@@ -1252,10 +1517,62 @@ fn closest_source_token(tokens: &[MappingToken], source: Position) -> Option<Map
         .iter()
         .filter_map(|token| {
             let (line, column) = token.source?;
-            (line == source.line).then_some((column.abs_diff(source.character), *token))
+            (line == source.line && column <= source.character)
+                .then(|| (source.character - column, *token))
         })
         .min_by_key(|(distance, token)| (*distance, token.generated_line, token.generated_column))
         .map(|(_, token)| token)
+}
+
+fn map_original_to_preprocessed(entry: &ShadowState, position: Position) -> Option<Position> {
+    match entry.preprocess_status {
+        PreprocessStatus::Identity => Some(position),
+        PreprocessStatus::Mapped => {
+            map_original_tokens(&entry.preprocess_mappings.original, position)
+        }
+        PreprocessStatus::Unmapped => None,
+    }
+}
+
+fn map_preprocessed_to_original(entry: &ShadowState, position: Position) -> Option<Position> {
+    match entry.preprocess_status {
+        PreprocessStatus::Identity => Some(position),
+        PreprocessStatus::Mapped => {
+            map_generated_tokens(&entry.preprocess_mappings.generated, position)
+        }
+        PreprocessStatus::Unmapped => None,
+    }
+}
+
+fn map_generated_tokens(tokens: &[MappingToken], position: Position) -> Option<Position> {
+    let index = tokens.partition_point(|token| {
+        (token.generated_line, token.generated_column) <= (position.line, position.character)
+    });
+    let previous = index.checked_sub(1).and_then(|index| tokens.get(index))?;
+    if previous.generated_line != position.line
+        || generated_is_unmapped_gap(tokens, index, position)
+    {
+        return None;
+    }
+    previous
+        .source
+        .map(|(line, column)| Position::new(line, column))
+}
+
+fn map_original_tokens(tokens: &[ReverseMappingToken], position: Position) -> Option<Position> {
+    let key = (position.line, position.character);
+    let first_equal_or_greater =
+        tokens.partition_point(|token| (token.source_line, token.source_column) < key);
+    let token = tokens
+        .get(first_equal_or_greater)
+        .filter(|token| (token.source_line, token.source_column) == key)
+        .or_else(|| {
+            first_equal_or_greater
+                .checked_sub(1)
+                .and_then(|index| tokens.get(index))
+        })?;
+    (token.source_line == position.line)
+        .then_some(Position::new(token.generated_line, token.generated_column))
 }
 
 fn exact_source_offset(map: &ProjectionMap, offset: usize) -> Option<u32> {
@@ -1522,6 +1839,52 @@ mod tests {
         fs::write(path, text).unwrap();
     }
 
+    fn encoded_preprocess_map(
+        source_path: &Path,
+        original_text: &str,
+        mappings: &[(Position, Option<Position>)],
+    ) -> String {
+        let source_name = source_path.file_name().unwrap().to_string_lossy();
+        let mut builder = SourceMapBuilder::new(None);
+        let source_id = builder.add_source(&source_name);
+        builder.set_source_contents(source_id, Some(original_text));
+        let mut mappings = mappings.to_vec();
+        mappings.sort_by_key(|(generated, _)| (generated.line, generated.character));
+        for (generated, original) in mappings {
+            let (line, column, source) = original.map_or((0, 0, None), |original| {
+                (
+                    original.line,
+                    original.character,
+                    Some(source_name.as_ref()),
+                )
+            });
+            builder.add(
+                generated.line,
+                generated.character,
+                line,
+                column,
+                source,
+                None,
+                false,
+            );
+        }
+        let mut output = Vec::new();
+        builder.into_sourcemap().to_writer(&mut output).unwrap();
+        String::from_utf8(output).unwrap()
+    }
+
+    fn positions_of(text: &str, needle: &str) -> Vec<(Position, Position)> {
+        let index = LineIndex::new(text);
+        text.match_indices(needle)
+            .map(|(offset, value)| {
+                (
+                    index.position(text, offset),
+                    index.position(text, offset + value.len()),
+                )
+            })
+            .collect()
+    }
+
     #[test]
     fn an_existing_leaf_does_not_gain_an_empty_path_component() {
         let existing = PathBuf::from("/workspace/src/App.svelte");
@@ -1762,6 +2125,130 @@ mod tests {
             .map_generated_position(&shadow_path, generated)
             .expect("generated identifier maps back");
         assert_eq!(back, source_position);
+    }
+
+    #[test]
+    fn preprocessing_composes_original_preprocessed_and_tsx_positions() {
+        let workspace = TestWorkspace::new("preprocess-compose");
+        let app = workspace.0.join("src/App.svelte");
+        let original = concat!(
+            "<script lang=\"ts\">\r\n",
+            "const emoji = \"😀\"; let value = 1;\r\n",
+            "</script>\r\n",
+            "<p>{value}</p>\r\n"
+        );
+        let preprocessed = format!("<!-- generated -->\n{original}");
+        write(&app, original);
+        let original_values = positions_of(original, "value");
+        let preprocessed_values = positions_of(&preprocessed, "value");
+        let mappings = preprocessed_values
+            .iter()
+            .zip(&original_values)
+            .flat_map(
+                |(&(generated_start, generated_end), &(source_start, source_end))| {
+                    [
+                        (generated_start, Some(source_start)),
+                        (generated_end, Some(source_end)),
+                    ]
+                },
+            )
+            .collect::<Vec<_>>();
+        let preprocess_map = encoded_preprocess_map(&app, original, &mappings);
+        let mut overlay = TsgoOverlay::build(&workspace.0, None).unwrap();
+        let shadow = overlay
+            .open_or_update_preprocessed(&app, original, &preprocessed, Some(&preprocess_map), 4)
+            .unwrap();
+        let shadow_path = overlay.shadow_dir.join("src/App.svelte.tsx");
+
+        assert_eq!(
+            overlay.preprocess_status(&app),
+            Some(PreprocessStatus::Mapped)
+        );
+        assert_eq!(overlay.preprocessed_text(&app), Some(preprocessed.as_str()));
+        assert_eq!(overlay.preprocess_map(&app), Some(preprocess_map.as_str()));
+        assert!(overlay.projection_map(&app).unwrap().segments().is_empty());
+
+        let source_start = original_values[0].0;
+        let source_offset = original.find("value").unwrap();
+        let line_start = original[..source_offset].rfind('\n').map_or(0, |at| at + 1);
+        assert_eq!(
+            u32::try_from(source_offset - line_start).unwrap(),
+            source_start.character + 2,
+            "the source position must count the astral character as two UTF-16 units"
+        );
+        let generated_start = overlay
+            .map_source_position(&app, source_start)
+            .expect("original position maps through preprocessing and TSX");
+        assert_eq!(
+            overlay.map_generated_position(&shadow_path, generated_start),
+            Some(source_start)
+        );
+
+        let source_range = Range::new(original_values[0].0, original_values[1].1);
+        let generated_range = overlay
+            .map_source_range(&app, source_range)
+            .expect("multiline range maps through all layers");
+        assert_eq!(
+            overlay.map_generated_range(&shadow_path, generated_range),
+            Some(source_range)
+        );
+
+        let generated_offset = utf8_offset(&shadow.text, generated_start);
+        let generated_utf16 = LineIndex::new(&shadow.text).position(&shadow.text, generated_offset);
+        let composed = SourceMap::from_slice(overlay.source_map(&app).unwrap().as_bytes()).unwrap();
+        let token = composed
+            .lookup_token(generated_utf16.line, generated_utf16.character)
+            .unwrap();
+        assert_eq!(token.get_src(), (source_start.line, source_start.character));
+    }
+
+    #[test]
+    fn preprocessing_rejects_removed_and_generated_only_positions() {
+        let workspace = TestWorkspace::new("preprocess-unmapped");
+        let app = workspace.0.join("App.svelte");
+        let original = "<script>\nlet kept = 1;\nlet removed = 2;\n</script>\n";
+        let preprocessed = "<script>\nlet kept = 1;\nlet injected = 3;\n</script>\n";
+        write(&app, original);
+        let original_kept = positions_of(original, "kept")[0].0;
+        let preprocessed_kept = positions_of(preprocessed, "kept")[0].0;
+        let original_end = Position::new(3, 0);
+        let preprocessed_end = Position::new(3, 0);
+        let injected = positions_of(preprocessed, "injected")[0].0;
+        let preprocess_map = encoded_preprocess_map(
+            &app,
+            original,
+            &[
+                (preprocessed_kept, Some(original_kept)),
+                (injected, None),
+                (preprocessed_end, Some(original_end)),
+            ],
+        );
+        let mut overlay = TsgoOverlay::build(&workspace.0, None).unwrap();
+        let shadow = overlay
+            .open_or_update_preprocessed(&app, original, preprocessed, Some(&preprocess_map), 1)
+            .unwrap();
+        let shadow_path = overlay.shadow_dir.join("App.svelte.tsx");
+
+        let removed = positions_of(original, "removed")[0].0;
+        assert_eq!(overlay.map_source_position(&app, removed), None);
+        let generated_injected = shadow.text.find("injected").unwrap();
+        assert_eq!(
+            overlay.map_generated_position(
+                &shadow_path,
+                utf8_position(&shadow.text, generated_injected)
+            ),
+            None
+        );
+
+        overlay
+            .open_or_update_preprocessed(&app, original, preprocessed, None, 2)
+            .unwrap();
+        assert_eq!(
+            overlay.preprocess_status(&app),
+            Some(PreprocessStatus::Unmapped)
+        );
+        assert_eq!(overlay.source_map(&app), None);
+        assert_eq!(overlay.map_source_position(&app, original_kept), None);
     }
 
     #[test]

--- a/crates/rsvelte_language_server/src/worker.rs
+++ b/crates/rsvelte_language_server/src/worker.rs
@@ -44,6 +44,7 @@ pub enum Job {
         version: i32,
         path: PathBuf,
         text: Arc<String>,
+        preprocessed: Option<PreprocessedAnalysis>,
         warnings: CompilerWarnings,
     },
     Format {
@@ -109,6 +110,7 @@ pub enum Job {
         id: RequestId,
         path: PathBuf,
         text: Arc<String>,
+        preprocessed: Option<PreprocessedAnalysis>,
         warnings: CompilerWarnings,
     },
     FileReferences {
@@ -120,6 +122,13 @@ pub enum Job {
     /// Drop the resolved `rsvelte-lint.json` / `.oxfmtrc` caches so the next
     /// job re-reads them from disk.
     ClearCaches,
+}
+
+#[derive(Clone)]
+pub struct PreprocessedAnalysis {
+    pub text: Arc<String>,
+    pub map: Option<Arc<String>>,
+    pub identity: bool,
 }
 
 pub enum Outcome {
@@ -239,14 +248,18 @@ fn run(jobs: &Receiver<Job>, outcomes: &Sender<Outcome>) {
                 version,
                 path,
                 text,
+                preprocessed,
                 warnings,
             } => {
                 let config = lint_configs.get(path.parent().unwrap_or(Path::new(".")));
                 let diagnostics = guard("lint", &path, || {
-                    let mut diagnostics: Vec<_> = crate::lint::lint(&path, &text, &config)
-                        .iter()
-                        .filter_map(|d| crate::diagnostics::to_lsp(d, &warnings))
-                        .collect();
+                    let mut diagnostics = lint_with_preprocessor(
+                        &path,
+                        &text,
+                        preprocessed.as_ref(),
+                        &config,
+                        &warnings,
+                    );
                     diagnostics.extend(crate::css::diagnostics(&text));
                     diagnostics
                 })
@@ -382,14 +395,18 @@ fn run(jobs: &Receiver<Job>, outcomes: &Sender<Outcome>) {
                 id,
                 path,
                 text,
+                preprocessed,
                 warnings,
             } => {
                 let config = lint_configs.get(path.parent().unwrap_or(Path::new(".")));
                 let diagnostics = guard("pull diagnostics", &path, || {
-                    let mut diagnostics: Vec<_> = crate::lint::lint(&path, &text, &config)
-                        .iter()
-                        .filter_map(|d| crate::diagnostics::to_lsp(d, &warnings))
-                        .collect();
+                    let mut diagnostics = lint_with_preprocessor(
+                        &path,
+                        &text,
+                        preprocessed.as_ref(),
+                        &config,
+                        &warnings,
+                    );
                     diagnostics.extend(crate::css::diagnostics(&text));
                     diagnostics
                 })
@@ -410,6 +427,55 @@ fn run(jobs: &Receiver<Job>, outcomes: &Sender<Outcome>) {
             break;
         }
     }
+}
+
+fn lint_with_preprocessor(
+    path: &Path,
+    raw: &str,
+    preprocessed: Option<&PreprocessedAnalysis>,
+    config: &rsvelte_lint::LintConfig,
+    warnings: &CompilerWarnings,
+) -> Vec<Diagnostic> {
+    let mut diagnostics = crate::lint::lint(path, raw, config)
+        .iter()
+        .filter_map(|diagnostic| {
+            let compiler = diagnostic
+                .code
+                .as_deref()
+                .is_some_and(crate::diagnostics::is_compiler_code);
+            if compiler && preprocessed.is_some() {
+                return None;
+            }
+            let diagnostic = crate::diagnostics::to_lsp(diagnostic, warnings)?;
+            (!compiler || crate::diagnostics::keep_raw_compiler_diagnostic(&diagnostic, raw))
+                .then_some(diagnostic)
+        })
+        .collect::<Vec<_>>();
+    let Some(preprocessed) = preprocessed else {
+        return diagnostics;
+    };
+    let processed_diagnostics = crate::lint::lint(path, &preprocessed.text, config);
+    let mapped = processed_diagnostics
+        .into_iter()
+        .filter(|diagnostic| {
+            diagnostic
+                .code
+                .as_deref()
+                .is_some_and(crate::diagnostics::is_compiler_code)
+        })
+        .filter_map(|diagnostic| crate::diagnostics::to_lsp(&diagnostic, warnings))
+        .filter_map(|diagnostic| {
+            if preprocessed.identity {
+                Some(diagnostic)
+            } else {
+                crate::diagnostics::map_preprocessed_diagnostic(
+                    diagnostic,
+                    preprocessed.map.as_deref()?,
+                )
+            }
+        });
+    diagnostics.extend(mapped);
+    diagnostics
 }
 
 fn file_references(

--- a/crates/rsvelte_language_server/tests/protocol.rs
+++ b/crates/rsvelte_language_server/tests/protocol.rs
@@ -347,6 +347,71 @@ fn initialized_server() -> Server {
     server
 }
 
+fn workspace_server(root: &Path, is_trusted: bool) -> Server {
+    let mut server = Server::start();
+    let id = server.request(
+        "initialize",
+        json!({
+            "processId": Value::Null,
+            "rootUri": file_uri(root),
+            "initializationOptions": { "isTrusted": is_trusted },
+            "capabilities": { "workspace": { "configuration": true } },
+        }),
+    );
+    server.response(id);
+    server.notify("initialized", json!({}));
+    server.settle_configuration();
+    server
+}
+
+fn write_preprocess_fixture(root: &Path, marker: &Path) {
+    let package = root.join("node_modules/svelte");
+    std::fs::create_dir_all(&package).unwrap();
+    std::fs::write(
+        package.join("package.json"),
+        r#"{"name":"svelte","type":"module","exports":{"./compiler":"./compiler.js"}}"#,
+    )
+    .unwrap();
+    std::fs::write(
+        package.join("compiler.js"),
+        r#"
+export async function preprocess(source, configured, options) {
+  const group = Array.isArray(configured) ? configured[0] : configured;
+  const result = await group.markup({ content: source, filename: options?.filename });
+  return { code: result.code, map: result.map, dependencies: result.dependencies ?? [] };
+}
+"#,
+    )
+    .unwrap();
+    let marker = serde_json::to_string(&marker.to_string_lossy()).unwrap();
+    std::fs::write(
+        root.join("svelte.config.mjs"),
+        format!(
+            r#"
+import {{ writeFileSync }} from 'node:fs';
+writeFileSync({marker}, 'executed');
+export default {{
+  preprocess: {{
+    markup({{ content }}) {{
+      return {{
+        code: '<img>',
+        map: {{
+          version: 3,
+          sources: ['App.svelte'],
+          names: [],
+          mappings: 'AAAA',
+          sourcesContent: [content]
+        }}
+      }};
+    }}
+  }}
+}};
+"#
+        ),
+    )
+    .unwrap();
+}
+
 /// The same, with `textDocument` capabilities of the client's choosing, and the
 /// capabilities the server answered with.
 fn server_with(text_document: Value) -> (Server, Value) {
@@ -589,6 +654,94 @@ fn serves_pull_diagnostics_without_push_notifications() {
     let report = server.pull_diagnostics(&uri);
     assert_eq!(report["kind"], json!("full"));
     assert_eq!(report["items"], json!(expected));
+    assert_eq!(server.shutdown(), Some(0));
+}
+
+#[test]
+fn preprocessing_runs_only_in_trusted_workspaces_and_maps_diagnostics() {
+    if Command::new("node").arg("--version").output().is_err() {
+        return;
+    }
+    let root = temp_dir("preprocess-trusted");
+    let marker = root.join("config-executed");
+    write_preprocess_fixture(&root, &marker);
+    let path = root.join("App.svelte");
+    let uri = file_uri(&path);
+    let raw = r#"<template lang="pug">p image</template>"#;
+
+    let mut server = workspace_server(&root, true);
+    did_open(&mut server, &uri, raw);
+    let diagnostics = server.diagnostics_matching(&uri, |diagnostics| {
+        diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic["code"] == "a11y_missing_attribute")
+    });
+    let warning = diagnostics
+        .iter()
+        .find(|diagnostic| diagnostic["code"] == "a11y_missing_attribute")
+        .unwrap();
+    assert_eq!(
+        warning["range"]["start"],
+        json!({ "line": 0, "character": 0 })
+    );
+    assert!(marker.is_file());
+    assert_eq!(server.shutdown(), Some(0));
+
+    let root = temp_dir("preprocess-untrusted");
+    let marker = root.join("config-executed");
+    write_preprocess_fixture(&root, &marker);
+    let path = root.join("App.svelte");
+    let uri = file_uri(&path);
+    let mut server = workspace_server(&root, false);
+    did_open(&mut server, &uri, raw);
+    let _ = server.diagnostics(&uri);
+    assert!(!marker.exists(), "untrusted config was executed");
+    assert_eq!(server.shutdown(), Some(0));
+}
+
+#[test]
+fn preprocessing_failure_keeps_raw_language_features_available() {
+    if Command::new("node").arg("--version").output().is_err() {
+        return;
+    }
+    let root = temp_dir("preprocess-failure");
+    let marker = root.join("config-executed");
+    write_preprocess_fixture(&root, &marker);
+    std::fs::write(
+        root.join("svelte.config.mjs"),
+        r#"
+export default {
+  preprocess: {
+    markup() { throw new Error('fixture preprocessing failure'); }
+  }
+};
+"#,
+    )
+    .unwrap();
+    let path = root.join("App.svelte");
+    let uri = file_uri(&path);
+    let source = "<style>.x { color: #ffffff; }</style>\n<div>\n  <\n</div>\n";
+    let mut server = workspace_server(&root, true);
+    did_open(&mut server, &uri, source);
+    let diagnostics = server.diagnostics_matching(&uri, |diagnostics| {
+        diagnostics.iter().any(|diagnostic| {
+            diagnostic["message"]
+                .as_str()
+                .is_some_and(|message| message.contains("fixture preprocessing failure"))
+        })
+    });
+    assert!(diagnostics.iter().any(|diagnostic| {
+        diagnostic["message"]
+            .as_str()
+            .is_some_and(|message| message.starts_with("Preprocessing failed"))
+    }));
+    assert!(!server.completion(&uri, 2, 3).is_empty());
+    assert!(!server.folding_ranges(&uri).is_empty());
+    let id = server.request(
+        "textDocument/documentColor",
+        json!({ "textDocument": { "uri": uri } }),
+    );
+    assert_eq!(server.response(id).as_array().map(Vec::len), Some(1));
     assert_eq!(server.shutdown(), Some(0));
 }
 


### PR DESCRIPTION
## Summary

- add a lazy, supervised Node sidecar that loads the nearest `svelte.config.*` only in trusted workspaces, replays current buffers after crashes, and restarts for config or dependency changes
- compose original → preprocessed → svelte2tsx → tsgo shadow source maps in both directions, including UTF-16/UTF-8 boundaries and generated-region filtering
- run compiler diagnostics against preprocessed text while retaining raw HTML, CSS, folding, and completion behavior when preprocessing fails
- add the `rsvelte.preprocess.enable` opt-out, trust propagation, launcher wiring, documentation, a changeset, and protocol/unit coverage

## Why

The native language server previously projected raw `.svelte` source directly. Projects using markup, script, or style preprocessors therefore produced invalid TypeScript shadows, misplaced diagnostics, and false compiler errors. Executing project configuration also needs an explicit trust boundary and a failure mode that does not disable unrelated editor features.

## User impact

Trusted projects now receive type-aware and compiler-backed editor results from their preprocessed Svelte source. Untrusted workspaces and projects without a Svelte config do not start Node, and users can disable preprocessing explicitly. Crashes, hangs, invalid source maps, and configuration failures fall back to the raw document with a visible preprocessing diagnostic.

## Validation

- `cargo test -p rsvelte_language_server` (273 unit, 22 protocol)
- `cargo clippy -p rsvelte_language_server --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `pnpm --filter @rsvelte/language-server typecheck`
- `pnpm --filter @rsvelte/language-server test`
- `pnpm --filter rsvelte-vscode typecheck`
- `node --check crates/rsvelte_language_server/src/preprocess_sidecar.mjs`
- `node --check apps/npm/language-server/bin/rsvelte-language-server.mjs`

Closes #1765
