### PR TITLE
perf(esrap): optimize printing and add benchmark coverage

### DIFF
--- a/.changeset/brisk-esrap-newlines.md
+++ b/.changeset/brisk-esrap-newlines.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/compiler": patch
+---
+
+Write common indented newlines with fixed-width stores and avoid unnecessary source-line lookups on exhausted comment paths. Release `rsvelte_esrap` 0.10.27 and update the compiler's exact dependency.

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -5,12 +5,15 @@ on:
     branches: [main]
     paths:
       - 'crates/rsvelte_core/**'
+      - 'crates/rsvelte_esrap/**'
+      - 'crates/rsvelte_bench/**'
       - 'crates/rsvelte_devtools/**'
       - 'crates/rsvelte_formatter/**'
       - 'crates/rsvelte_fmt/**'
       - 'crates/rsvelte_lint/**'
       - 'crates/rsvelte_projection/**'
       - 'benches/corpus/**'
+      - 'benches/printer-corpus/**'
       - 'benches/common/**'
       - 'Cargo.toml'
       - 'Cargo.lock'

--- a/.github/workflows/corpus-compat.yml
+++ b/.github/workflows/corpus-compat.yml
@@ -5,8 +5,8 @@ name: Corpus Compat
 # svelte.dev, and the real-world projects bits-ui / flowbite-svelte / melt-ui /
 # shadcn-svelte, each pinned by its submodule gitlink (see
 # scripts/compat-corpus/corpus-sources.json) — with BOTH the official Svelte
-# compiler and rsvelte, for the client (CSR), server (SSR) and client-dev
-# (CSR with `dev: true`) targets, normalizes both output trees with oxfmt, and
+# compiler and rsvelte, for the client (CSR), server (SSR), client-dev
+# (CSR with `dev: true`) and server-dev targets, normalizes both output trees with oxfmt, and
 # requires the results to be byte-identical.
 # The same corpus also drives a svelte2tsx TSX output-parity check (official
 # svelte2tsx from submodules/language-tools vs rsvelte's port) plus a structural
@@ -241,10 +241,11 @@ jobs:
           cache-on-failure: true
           save-if: ${{ github.ref == 'refs/heads/main' }}
 
-      - name: Build rsvelte NAPI binding + AST comparator
+      - name: Build rsvelte NAPI binding + corpus gates
         run: |
           cargo build --release -p rsvelte_napi --lib
           cargo build --release --bin ast_equiv_batch
+          cargo build --release -p rsvelte_devtools --bin esrap_corpus
           mkdir -p .corpus-cache
           cp target/release/librsvelte_napi.so .corpus-cache/rsvelte.node.staging
           # Replace, never overwrite: if anything still has the old library mapped
@@ -257,6 +258,9 @@ jobs:
 
       - name: Compile corpus (official svelte + rsvelte, CSR + SSR + CSR dev)
         run: node scripts/compat-corpus/compile.mjs
+
+      - name: Verify esrap round-trip, comments, and source maps
+        run: node scripts/compat-corpus/esrap-verify.mjs
 
       - name: Verify (oxfmt-normalized outputs must be identical)
         run: node scripts/compat-corpus/verify.mjs
@@ -310,6 +314,7 @@ jobs:
           name: corpus-report
           path: |
             compatibility/report.json
+            compatibility/esrap-report.json
             compatibility/report-s2t.json
             compatibility/manifest.json
             compatibility/cluster.txt

--- a/.github/workflows/site-benchmark.yml
+++ b/.github/workflows/site-benchmark.yml
@@ -59,7 +59,7 @@ jobs:
           cache-on-failure: true
 
       - name: Build Rust benchmark runner
-        run: cargo build --release -p rsvelte_devtools --bin benchmark_runner
+        run: cargo build --release -p rsvelte_devtools --bin benchmark_runner --bin printer_benchmark_runner
 
       - name: Collect real-world source corpus
         run: pnpm run corpus:collect
@@ -76,12 +76,14 @@ jobs:
         run: |
           echo '### Real-world compiler report' >> "$GITHUB_STEP_SUMMARY"
           echo '```json' >> "$GITHUB_STEP_SUMMARY"
-          jq '{generatedAt,corpus,runner,surfaces:[.surfaces[]|{id,classes:[.comparisonClasses[]|{id,files,variants:[.variants[]|{id,status,compiledFiles,speedup,cvPct}]}]}]}' apps/playground/static/performance-report.json >> "$GITHUB_STEP_SUMMARY"
+          jq '{generatedAt,corpus,runner,printerBenchmarks,surfaces:[.surfaces[]|{id,classes:[.comparisonClasses[]|{id,files,variants:[.variants[]|{id,status,compiledFiles,speedup,cvPct}]}]}]}' apps/playground/static/performance-report.json >> "$GITHUB_STEP_SUMMARY"
           echo '```' >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload performance JSON
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: performance-report
-          path: apps/playground/static/performance-report.json
+          path: |
+            apps/playground/static/performance-report.json
+            apps/playground/static/printer-performance-report.json
           retention-days: 30

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2477,7 +2477,13 @@ name = "rsvelte_bench"
 version = "0.0.0"
 dependencies = [
  "codspeed-criterion-compat",
+ "oxc_allocator",
+ "oxc_ast",
+ "oxc_codegen",
+ "oxc_parser",
+ "oxc_span",
  "rsvelte_core",
+ "rsvelte_esrap",
 ]
 
 [[package]]
@@ -2576,6 +2582,7 @@ dependencies = [
  "codspeed-criterion-compat",
  "mimalloc",
  "oxc_allocator",
+ "oxc_ast",
  "oxc_codegen",
  "oxc_formatter",
  "oxc_parser",
@@ -2605,7 +2612,7 @@ dependencies = [
 
 [[package]]
 name = "rsvelte_esrap"
-version = "0.10.26"
+version = "0.10.27"
 dependencies = [
  "compact_str 0.10.0",
  "memchr",

--- a/apps/playground/src/lib/types/reports.ts
+++ b/apps/playground/src/lib/types/reports.ts
@@ -87,10 +87,51 @@ export interface PerformanceReport {
   };
   surfaces: PerformanceSurface[];
   toolTasks: PerformanceToolTask[];
+  printerBenchmarks?: PrinterBenchmarks;
   benchmarkCoverage?: BenchmarkCoverage[];
   alternativeProducts?: AlternativeProduct[];
   unsupported: UnsupportedCompetitor[];
   methodology: string[];
+}
+
+export interface PrinterBenchmarks {
+  schemaVersion: number;
+  measurementKind: "native-wall";
+  generatedAt: string;
+  workloadHash: string;
+  versions: {
+    rsvelteEsrap: string;
+    oxcCodegen: string;
+    javascriptEsrap: string;
+  };
+  runner: {
+    label: string;
+    platform: string;
+    arch: string;
+    cpus: number;
+    cpuModel: string;
+    node: string;
+    loadAvg1min: number;
+  };
+  warmups: number;
+  runs: number;
+  batch: number;
+  cases: {
+    id: "parsed-no-map" | "decoded-map" | "comments-common";
+    label: string;
+    comparability: string;
+    files: number;
+    bytes: number;
+    variants: {
+      id: "rsvelte-esrap" | "oxc-codegen" | "javascript-esrap";
+      label: string;
+      medianMs: number;
+      cvPct: number;
+      timesMs: number[];
+      relativeToRsvelte: number;
+      workGate: "parseable-output";
+    }[];
+  }[];
 }
 
 export interface PerformanceSurface {

--- a/apps/playground/src/routes/benchmark/+page.svelte
+++ b/apps/playground/src/routes/benchmark/+page.svelte
@@ -16,6 +16,10 @@
 		if (typeof ms !== 'number' || !Number.isFinite(ms)) return '—';
 		return ms >= 1000 ? `${(ms / 1000).toFixed(2)}s` : `${ms.toFixed(ms < 10 ? 1 : 0)}ms`;
 	};
+	const printerDuration = (ms?: number) => {
+		if (typeof ms !== 'number' || !Number.isFinite(ms)) return '—';
+		return ms < 1 ? `${(ms * 1000).toFixed(1)}µs` : `${ms.toFixed(2)}ms`;
+	};
 	const formatDate = (iso: string) => {
 		const date = new Date(iso);
 		return Number.isNaN(date.getTime())
@@ -48,7 +52,7 @@
 	<title>Performance · rsvelte</title>
 	<meta
 		name="description"
-		content="Measured compiler, parser, formatter, linter, and svelte2tsx performance."
+		content="Measured compiler, JavaScript printer, parser, formatter, linter, and svelte2tsx performance."
 	/>
 </svelte:head>
 
@@ -99,6 +103,31 @@
 					{/each}
 				</div>
 			</section>
+
+			{#if report.printerBenchmarks}
+				<section class="printers" aria-labelledby="printers-title">
+					<div class="comparison-head">
+						<h2 id="printers-title">JavaScript printer</h2>
+						<p>Fixed generated-JavaScript workload · parsing excluded</p>
+					</div>
+					<div class="printer-grid">
+						{#each report.printerBenchmarks.cases as benchmark}
+							{@const baseline = benchmark.variants.find((variant) => variant.id === 'rsvelte-esrap')}
+							<article>
+								<h3>{benchmark.label}<span>{benchmark.files} {benchmark.files === 1 ? 'file' : 'files'}</span></h3>
+								{#each benchmark.variants as variant}
+									<div class:rsvelte-row={variant.id === 'rsvelte-esrap'} class="printer-row">
+										<b>{variant.label}</b>
+										<strong>{printerDuration(variant.medianMs)}</strong>
+										<em>{relativeToRsvelte(variant.medianMs, baseline?.medianMs)}</em>
+									</div>
+								{/each}
+							</article>
+						{/each}
+					</div>
+					<p class="note">Native wall time on {report.printerBenchmarks.runner.cpuModel}, recorded {formatDate(report.printerBenchmarks.generatedAt)}. The three printers receive the same source workload and retain their parser-specific ASTs; code, decoded-map, and common-comment paths are reported separately.</p>
+				</section>
+			{/if}
 
 			<section class="alternatives" aria-labelledby="alternatives-title">
 				<div class="comparison-head">
@@ -196,6 +225,15 @@
 	.bar-row .track { height: .55rem; margin-top: .4rem; overflow: hidden; border-radius: 99px; background: color-mix(in srgb, var(--rule) 60%, transparent); }
 	.bar-row .track i { display: block; width: 100%; height: 100%; min-width: 3px; border-radius: inherit; background: var(--ok); }
 	.bar-row.reference .track i { background: var(--ink-faint); }
+	.printer-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 1rem; }
+	.printer-grid article { padding: 1.25rem; border: 1px solid var(--rule); border-radius: 10px; background: var(--paper); }
+	.printer-grid h3 { display: flex; justify-content: space-between; gap: .75rem; margin: 0 0 .75rem; font-size: .95rem; }
+	.printer-grid h3 span { color: var(--ink-faint); font-size: .7rem; font-weight: 400; }
+	.printer-row { display: grid; grid-template-columns: 1fr auto auto; align-items: baseline; gap: .75rem; padding: .55rem 0; border-top: 1px solid var(--rule); }
+	.printer-row b { font-size: .82rem; }
+	.printer-row strong { font-size: .9rem; }
+	.printer-row em { min-width: 6rem; color: var(--ink-faint); font-size: .7rem; font-style: normal; text-align: right; }
+	.printer-row.rsvelte-row { color: var(--ok); }
 	.alternatives { padding-top: 2rem; border-top: 1px solid var(--rule); }
 	.comparison-head { display: flex; align-items: baseline; justify-content: space-between; gap: 1rem; margin-bottom: 1.25rem; }
 	.comparison-head p { margin: 0; color: var(--ink-faint); font-size: .8rem; }
@@ -236,6 +274,6 @@
 	details li { margin: .45rem 0; line-height: 1.5; }
 	details a, .links a { color: var(--accent); }
 	.links { margin-top: 1.5rem; font-size: .82rem; }
-	@media (max-width: 820px) { .alternative-grid { grid-template-columns: 1fr; } .section-head, .comparison-head { align-items: flex-start; flex-direction: column; } .comparison-table { overflow-x: auto; } .table-head, .comparison-row { min-width: 680px; } }
+	@media (max-width: 820px) { .alternative-grid, .printer-grid { grid-template-columns: 1fr; } .section-head, .comparison-head { align-items: flex-start; flex-direction: column; } .comparison-table { overflow-x: auto; } .table-head, .comparison-row { min-width: 680px; } }
 	@media (max-width: 640px) { main { padding: 3rem 1rem 5rem; } .result-grid { grid-template-columns: 1fr; } .result-card { padding: 1.2rem; } .section-head p { line-height: 1.7; } }
 </style>

--- a/apps/playground/src/routes/benchmark/+page.ts
+++ b/apps/playground/src/routes/benchmark/+page.ts
@@ -1,6 +1,6 @@
 import { base } from "$app/paths";
 import type { PageLoad } from "./$types";
-import type { PerformanceReport } from "$lib/types/reports";
+import type { PerformanceReport, PrinterBenchmarks } from "$lib/types/reports";
 
 export const load: PageLoad = async ({ fetch }) => {
   try {
@@ -14,6 +14,15 @@ export const load: PageLoad = async ({ fetch }) => {
       };
     }
     const results: PerformanceReport = await response.json();
+    if (!results.printerBenchmarks) {
+      const printerResponse = await fetch(
+        `${base}/printer-performance-report.json?refresh=${Date.now()}`,
+        { cache: "no-store" },
+      );
+      if (printerResponse.ok) {
+        results.printerBenchmarks = (await printerResponse.json()) as PrinterBenchmarks;
+      }
+    }
     return { results, error: null };
   } catch {
     return {

--- a/apps/playground/static/printer-performance-report.json
+++ b/apps/playground/static/printer-performance-report.json
@@ -1,0 +1,168 @@
+{
+  "schemaVersion": 1,
+  "measurementKind": "native-wall",
+  "generatedAt": "2026-08-15T09:55:53.924Z",
+  "workloadHash": "sha256:ff9da0754e9b93046a3958e914e569586cebbea81299a5c438aaed5d94130dc6",
+  "versions": {
+    "rsvelteEsrap": "0.10.27",
+    "oxcCodegen": "0.144.0",
+    "javascriptEsrap": "2.3.2"
+  },
+  "runner": {
+    "label": "local",
+    "platform": "darwin",
+    "arch": "arm64",
+    "cpus": 10,
+    "cpuModel": "Apple M1 Pro",
+    "node": "25.7.0",
+    "loadAvg1min": 7.91796875
+  },
+  "warmups": 3,
+  "runs": 11,
+  "batch": 200,
+  "cases": [
+    {
+      "id": "parsed-no-map",
+      "label": "Parsed JavaScript, code only",
+      "comparability": "same-source-retained-parser-specific-ast",
+      "files": 11,
+      "bytes": 50417,
+      "variants": [
+        {
+          "id": "rsvelte-esrap",
+          "label": "rsvelte/esrap",
+          "medianMs": 0.10036167000000001,
+          "cvPct": 4.127761829685891,
+          "timesMs": [
+            0.10033521000000001, 0.10429479000000001, 0.09640874999999999, 0.09406541500000001,
+            0.099374375, 0.108176875, 0.10123770500000001, 0.10075771000000001, 0.10036167000000001,
+            0.10276228999999999, 0.093356875
+          ],
+          "workGate": "parseable-output",
+          "relativeToRsvelte": 1
+        },
+        {
+          "id": "oxc-codegen",
+          "label": "oxc_codegen",
+          "medianMs": 0.10986083500000002,
+          "cvPct": 4.106873086617713,
+          "timesMs": [
+            0.106189795, 0.10470853999999999, 0.11145791499999999, 0.113626665, 0.11744104,
+            0.11383167, 0.11002187499999999, 0.10237666499999999, 0.106334795, 0.10452853999999999,
+            0.10986083500000002
+          ],
+          "workGate": "parseable-output",
+          "relativeToRsvelte": 1.0946493317618171
+        },
+        {
+          "id": "javascript-esrap",
+          "label": "esrap",
+          "medianMs": 2.3336047899999994,
+          "cvPct": 0.9034887381382445,
+          "timesMs": [
+            2.3378943750000007, 2.358095000000003, 2.3154983300000005, 2.3336047899999994,
+            2.346233124999999, 2.362911039999999, 2.310263749999999, 2.286853125000002,
+            2.3306795850000026, 2.3179408349999995, 2.338062290000007
+          ],
+          "workGate": "parseable-output",
+          "relativeToRsvelte": 23.251952563164792
+        }
+      ]
+    },
+    {
+      "id": "decoded-map",
+      "label": "Parsed JavaScript, decoded source map",
+      "comparability": "same-source-retained-parser-specific-ast",
+      "files": 11,
+      "bytes": 50417,
+      "variants": [
+        {
+          "id": "rsvelte-esrap",
+          "label": "rsvelte/esrap",
+          "medianMs": 0.23450270499999998,
+          "cvPct": 2.3172839093263717,
+          "timesMs": [
+            0.225839585, 0.22625708500000002, 0.24070749999999996, 0.23450270499999998, 0.235205415,
+            0.23915312500000002, 0.23452333499999997, 0.237026665, 0.223221665, 0.23251729,
+            0.230687295
+          ],
+          "workGate": "parseable-output",
+          "relativeToRsvelte": 1
+        },
+        {
+          "id": "oxc-codegen",
+          "label": "oxc_codegen",
+          "medianMs": 0.27619729,
+          "cvPct": 2.2526028886148763,
+          "timesMs": [
+            0.27619729, 0.28469917, 0.278318955, 0.282911665, 0.28766396, 0.271324375, 0.270198125,
+            0.27293604, 0.270197295, 0.268055835, 0.27634479500000003
+          ],
+          "workGate": "parseable-output",
+          "relativeToRsvelte": 1.1778000172748542
+        },
+        {
+          "id": "javascript-esrap",
+          "label": "esrap",
+          "medianMs": 3.0018120850000014,
+          "cvPct": 0.7943366951889387,
+          "timesMs": [
+            3.0289568750000035, 2.9890737499999975, 2.9709739549999994, 3.0466522900000017,
+            2.989178334999997, 3.0072385399999986, 3.0361372949999987, 2.990361250000005,
+            3.007874790000005, 3.0018120850000014, 2.97176895999999
+          ],
+          "workGate": "parseable-output",
+          "relativeToRsvelte": 12.800756754596932
+        }
+      ]
+    },
+    {
+      "id": "comments-common",
+      "label": "Statement-level comments, code only",
+      "comparability": "same-source-retained-parser-specific-ast",
+      "files": 1,
+      "bytes": 234,
+      "variants": [
+        {
+          "id": "rsvelte-esrap",
+          "label": "rsvelte/esrap",
+          "medianMs": 0.00068340835,
+          "cvPct": 4.764896294522646,
+          "timesMs": [
+            0.0006677125000000001, 0.0007648042000000001, 0.00068340835, 0.0006739833500000001,
+            0.00069660625, 0.0006790604, 0.00071548955, 0.0007260375000000001, 0.0007584271,
+            0.0006718895499999999, 0.0006768583499999999
+          ],
+          "workGate": "parseable-output",
+          "relativeToRsvelte": 1
+        },
+        {
+          "id": "oxc-codegen",
+          "label": "oxc_codegen",
+          "medianMs": 0.0003574375,
+          "cvPct": 4.550916853488458,
+          "timesMs": [
+            0.00035384794999999996, 0.00036106045, 0.0003574375, 0.00037167705,
+            0.00035043959999999996, 0.00034666039999999996, 0.0003908125, 0.00039458335,
+            0.00038112295, 0.00035265625000000005, 0.00034810835
+          ],
+          "workGate": "parseable-output",
+          "relativeToRsvelte": 0.5230218506987806
+        },
+        {
+          "id": "javascript-esrap",
+          "label": "esrap",
+          "medianMs": 0.009915220849999969,
+          "cvPct": 1.54761914025275,
+          "timesMs": [
+            0.009583716650000133, 0.009694306249999863, 0.009915220849999969, 0.009966439549999996,
+            0.00960004584999988, 0.009993908300000113, 0.009899029149999843, 0.00994601249999996,
+            0.009838756250000006, 0.00992476874999993, 0.010057118750000154
+          ],
+          "workGate": "parseable-output",
+          "relativeToRsvelte": 14.508486543952774
+        }
+      ]
+    }
+  ]
+}

--- a/benches/printer-corpus/01-runes-counter.esrap.js
+++ b/benches/printer-corpus/01-runes-counter.esrap.js
@@ -1,0 +1,70 @@
+import 'svelte/internal/disclose-version';
+import * as $ from 'svelte/internal/client';
+
+var root = $.from_html(`<div class="counter svelte-18h6zmf"><h1>Counter</h1> <p> </p> <p> </p> <label>Step <input type="number" min="1"/></label> <div class="buttons svelte-18h6zmf"><button class="svelte-18h6zmf">-</button> <button class="svelte-18h6zmf">+</button> <button class="svelte-18h6zmf">Reset</button></div></div>`);
+
+export default function Component($$anchor, $$props) {
+	$.push($$props, true);
+
+	let count = $.state(0);
+	let step = $.state(1);
+	let doubled = $.derived(() => $.get(count) * 2);
+	let parity = $.derived(() => $.get(count) % 2 === 0 ? 'even' : 'odd');
+
+	$.user_effect(() => {
+		document.title = `Count: ${$.get(count)}`;
+	});
+
+	function increment() {
+		$.set(count, $.get(count) + $.get(step));
+	}
+
+	function decrement() {
+		$.set(count, $.get(count) - $.get(step));
+	}
+
+	function reset() {
+		$.set(count, 0);
+		$.set(step, 1);
+	}
+
+	var div = root();
+	var p = $.sibling($.child(div), 2);
+	var text = $.child(p);
+
+	$.reset(p);
+
+	var p_1 = $.sibling(p, 2);
+	var text_1 = $.child(p_1);
+
+	$.reset(p_1);
+
+	var label = $.sibling(p_1, 2);
+	var input = $.sibling($.child(label));
+
+	$.remove_input_defaults(input);
+	$.reset(label);
+
+	var div_1 = $.sibling(label, 2);
+	var button = $.child(div_1);
+	var button_1 = $.sibling(button, 2);
+	var button_2 = $.sibling(button_1, 2);
+
+	$.reset(div_1);
+	$.reset(div);
+
+	$.template_effect(() => {
+		$.set_text(text, `Current: ${$.get(count) ?? ''} (${$.get(parity) ?? ''})`);
+		$.set_text(text_1, `Doubled: ${$.get(doubled) ?? ''}`);
+		button_2.disabled = $.get(count) === 0;
+	});
+
+	$.bind_value(input, () => $.get(step), ($$value) => $.set(step, $$value));
+	$.delegated('click', button, decrement);
+	$.delegated('click', button_1, increment);
+	$.delegated('click', button_2, reset);
+	$.append($$anchor, div);
+	$.pop();
+}
+
+$.delegate(['click']);

--- a/benches/printer-corpus/02-todo-app.esrap.js
+++ b/benches/printer-corpus/02-todo-app.esrap.js
@@ -1,0 +1,163 @@
+import 'svelte/internal/disclose-version';
+import * as $ from 'svelte/internal/client';
+
+var root = $.from_html(`<button> </button>`);
+var root_1 = $.from_html(`<p class="empty">Nothing here.</p>`);
+var root_2 = $.from_html(`<li><label class="svelte-sbbj5z"><input type="checkbox"/> </label> <button class="remove">×</button></li>`);
+var root_3 = $.from_html(`<ul class="svelte-sbbj5z"></ul>`);
+var root_4 = $.from_html(`<section class="todo svelte-sbbj5z"><header class="svelte-sbbj5z"><h1>Todos</h1> <span class="count"> </span></header> <form><input placeholder="What needs doing?"/> <button type="submit">Add</button></form> <nav class="filters svelte-sbbj5z"></nav> <!> <footer><button>Clear completed</button></footer></section>`);
+
+export default function Component($$anchor, $$props) {
+	$.push($$props, true);
+
+	let nextId = $.state(4);
+	let draft = $.state('');
+	let filter = $.state('all');
+
+	let todos = $.state($.proxy([
+		{ id: 1, text: 'Learn Svelte', done: true },
+		{ id: 2, text: 'Build something', done: false },
+		{ id: 3, text: 'Ship it', done: false }
+	]));
+
+	let remaining = $.derived(() => $.get(todos).filter((t) => !t.done).length);
+
+	let visible = $.derived(() => $.get(todos).filter((t) => {
+		if ($.get(filter) === 'active') return !t.done;
+		if ($.get(filter) === 'completed') return t.done;
+
+		return true;
+	}));
+
+	function add() {
+		const text = $.get(draft).trim();
+
+		if (!text) return;
+
+		$.set(todos, [...$.get(todos), { id: $.update(nextId), text, done: false }], true);
+		$.set(draft, '');
+	}
+
+	function toggle(id) {
+		$.set(todos, $.get(todos).map((t) => t.id === id ? { ...t, done: !t.done } : t), true);
+	}
+
+	function remove(id) {
+		$.set(todos, $.get(todos).filter((t) => t.id !== id), true);
+	}
+
+	function clearCompleted() {
+		$.set(todos, $.get(todos).filter((t) => !t.done), true);
+	}
+
+	var section = root_4();
+	var header = $.child(section);
+	var span = $.sibling($.child(header), 2);
+	var text_1 = $.child(span);
+
+	$.reset(span);
+	$.reset(header);
+
+	var form = $.sibling(header, 2);
+	var input = $.child(form);
+
+	$.remove_input_defaults(input);
+
+	var button = $.sibling(input, 2);
+
+	$.reset(form);
+
+	var nav = $.sibling(form, 2);
+
+	$.each(nav, 20, () => ['all', 'active', 'completed'], $.index, ($$anchor, name) => {
+		var button_1 = root();
+		let classes;
+		var text_2 = $.child(button_1, true);
+
+		$.reset(button_1);
+
+		$.template_effect(() => {
+			classes = $.set_class(button_1, 1, 'svelte-sbbj5z', null, classes, { active: $.get(filter) === name });
+			$.set_text(text_2, name);
+		});
+
+		$.delegated('click', button_1, () => $.set(filter, name, true));
+		$.append($$anchor, button_1);
+	});
+
+	$.reset(nav);
+
+	var node = $.sibling(nav, 2);
+
+	{
+		var consequent = ($$anchor) => {
+			var p = root_1();
+
+			$.append($$anchor, p);
+		};
+
+		var alternate = ($$anchor) => {
+			var ul = root_3();
+
+			$.each(ul, 21, () => $.get(visible), (todo) => todo.id, ($$anchor, todo) => {
+				var li = root_2();
+				let classes_1;
+				var label = $.child(li);
+				var input_1 = $.child(label);
+
+				$.remove_input_defaults(input_1);
+
+				var text_3 = $.sibling(input_1);
+
+				$.reset(label);
+
+				var button_2 = $.sibling(label, 2);
+
+				$.reset(li);
+
+				$.template_effect(() => {
+					classes_1 = $.set_class(li, 1, 'svelte-sbbj5z', null, classes_1, { done: $.get(todo).done });
+					$.set_checked(input_1, $.get(todo).done);
+					$.set_text(text_3, ` ${$.get(todo).text ?? ''}`);
+				});
+
+				$.delegated('change', input_1, () => toggle($.get(todo).id));
+				$.delegated('click', button_2, () => remove($.get(todo).id));
+				$.append($$anchor, li);
+			});
+
+			$.reset(ul);
+			$.append($$anchor, ul);
+		};
+
+		$.if(node, ($$render) => {
+			if ($.get(visible).length === 0) $$render(consequent); else $$render(alternate, -1);
+		});
+	}
+
+	var footer = $.sibling(node, 2);
+	var button_3 = $.child(footer);
+
+	$.reset(footer);
+	$.reset(section);
+
+	$.template_effect(
+		($0) => {
+			$.set_text(text_1, `${$.get(remaining) ?? ''} left`);
+			button.disabled = $0;
+		},
+		[() => !$.get(draft).trim()]
+	);
+
+	$.event('submit', form, (e) => {
+		e.preventDefault();
+		add();
+	});
+
+	$.bind_value(input, () => $.get(draft), ($$value) => $.set(draft, $$value));
+	$.delegated('click', button_3, clearCompleted);
+	$.append($$anchor, section);
+	$.pop();
+}
+
+$.delegate(['click', 'change']);

--- a/benches/printer-corpus/03-data-table.esrap.js
+++ b/benches/printer-corpus/03-data-table.esrap.js
@@ -1,0 +1,213 @@
+import 'svelte/internal/disclose-version';
+import * as $ from 'svelte/internal/client';
+
+var root = $.from_html(`<span class="arrow"> </span>`);
+var root_1 = $.from_html(`<th> <!></th>`);
+var root_2 = $.from_html(`<tr><td> </td><td> </td><td class="num svelte-rmw92e"> </td><td><span> </span></td></tr>`);
+var root_3 = $.from_html(`<p class="empty">No matching rows.</p>`);
+var root_4 = $.from_html(`<div class="table-wrap svelte-rmw92e"><div class="toolbar svelte-rmw92e"><input placeholder="Filter by name…"/> <span class="avg"> </span></div> <table class="svelte-rmw92e"><thead><tr><!><th class="svelte-rmw92e">Status</th></tr></thead><tbody></tbody></table> <!></div>`);
+
+export default function Component($$anchor, $$props) {
+	$.push($$props, true);
+
+	let sortKey = $.state('name');
+	let sortDir = $.state(1);
+	let query = $.state('');
+
+	let rows = $.proxy([
+		{
+			id: 1,
+			name: 'Alice',
+			role: 'Engineer',
+			score: 92,
+			active: true
+		},
+
+		{
+			id: 2,
+			name: 'Bob',
+			role: 'Designer',
+			score: 78,
+			active: false
+		},
+
+		{
+			id: 3,
+			name: 'Carol',
+			role: 'Manager',
+			score: 85,
+			active: true
+		},
+
+		{
+			id: 4,
+			name: 'Dave',
+			role: 'Engineer',
+			score: 64,
+			active: true
+		},
+
+		{
+			id: 5,
+			name: 'Erin',
+			role: 'Analyst',
+			score: 88,
+			active: false
+		},
+
+		{
+			id: 6,
+			name: 'Frank',
+			role: 'Designer',
+			score: 71,
+			active: true
+		}
+	]);
+
+	let filtered = $.derived(() => rows.filter((r) => r.name.toLowerCase().includes($.get(query).toLowerCase())));
+
+	let sorted = $.derived(() => [...$.get(filtered)].sort((a, b) => {
+		const av = a[$.get(sortKey)];
+		const bv = b[$.get(sortKey)];
+
+		if (av < bv) return -1 * $.get(sortDir);
+		if (av > bv) return 1 * $.get(sortDir);
+
+		return 0;
+	}));
+
+	let average = $.derived(() => $.get(sorted).length
+		? Math.round($.get(sorted).reduce((s, r) => s + r.score, 0) / $.get(sorted).length)
+		: 0);
+
+	function sortBy(key) {
+		if ($.get(sortKey) === key) {
+			$.set(sortDir, $.get(sortDir) * -1);
+		} else {
+			$.set(sortKey, key, true);
+			$.set(sortDir, 1);
+		}
+	}
+
+	var div = root_4();
+	var div_1 = $.child(div);
+	var input = $.child(div_1);
+
+	$.remove_input_defaults(input);
+
+	var span = $.sibling(input, 2);
+	var text = $.child(span);
+
+	$.reset(span);
+	$.reset(div_1);
+
+	var table = $.sibling(div_1, 2);
+	var thead = $.child(table);
+	var tr = $.child(thead);
+	var node = $.child(tr);
+
+	$.each(node, 16, () => [['name', 'Name'], ['role', 'Role'], ['score', 'Score']], $.index, ($$anchor, $$item) => {
+		var $$array = $.derived(() => $.to_array($$item, 2));
+		let key = () => $.get($$array)[0];
+		let label = () => $.get($$array)[1];
+		var th = root_1();
+		let classes;
+		var text_1 = $.child(th);
+		var node_1 = $.sibling(text_1);
+
+		{
+			var consequent = ($$anchor) => {
+				var span_1 = root();
+				var text_2 = $.child(span_1, true);
+
+				$.reset(span_1);
+				$.template_effect(() => $.set_text(text_2, $.get(sortDir) === 1 ? '▲' : '▼'));
+				$.append($$anchor, span_1);
+			};
+
+			$.if(node_1, ($$render) => {
+				if ($.get(sortKey) === key()) $$render(consequent);
+			});
+		}
+
+		$.reset(th);
+
+		$.template_effect(() => {
+			classes = $.set_class(th, 1, 'svelte-rmw92e', null, classes, { sorted: $.get(sortKey) === key() });
+			$.set_text(text_1, `${label() ?? ''} `);
+		});
+
+		$.delegated('click', th, () => sortBy(key()));
+		$.append($$anchor, th);
+	});
+
+	$.next();
+	$.reset(tr);
+	$.reset(thead);
+
+	var tbody = $.sibling(thead);
+
+	$.each(tbody, 21, () => $.get(sorted), (row) => row.id, ($$anchor, row) => {
+		var tr_1 = root_2();
+		let classes_1;
+		var td = $.child(tr_1);
+		var text_3 = $.child(td, true);
+
+		$.reset(td);
+
+		var td_1 = $.sibling(td);
+		var text_4 = $.child(td_1, true);
+
+		$.reset(td_1);
+
+		var td_2 = $.sibling(td_1);
+		var text_5 = $.child(td_2, true);
+
+		$.reset(td_2);
+
+		var td_3 = $.sibling(td_2);
+		var span_2 = $.child(td_3);
+		let classes_2;
+		var text_6 = $.child(span_2, true);
+
+		$.reset(span_2);
+		$.reset(td_3);
+		$.reset(tr_1);
+
+		$.template_effect(() => {
+			classes_1 = $.set_class(tr_1, 1, 'svelte-rmw92e', null, classes_1, { inactive: !$.get(row).active });
+			$.set_text(text_3, $.get(row).name);
+			$.set_text(text_4, $.get(row).role);
+			$.set_text(text_5, $.get(row).score);
+			classes_2 = $.set_class(span_2, 1, 'badge svelte-rmw92e', null, classes_2, { on: $.get(row).active });
+			$.set_text(text_6, $.get(row).active ? 'Active' : 'Inactive');
+		});
+
+		$.append($$anchor, tr_1);
+	});
+
+	$.reset(tbody);
+	$.reset(table);
+
+	var node_2 = $.sibling(table, 2);
+
+	{
+		var consequent_1 = ($$anchor) => {
+			var p = root_3();
+
+			$.append($$anchor, p);
+		};
+
+		$.if(node_2, ($$render) => {
+			if ($.get(sorted).length === 0) $$render(consequent_1);
+		});
+	}
+
+	$.reset(div);
+	$.template_effect(() => $.set_text(text, `Average score: ${$.get(average) ?? ''}`));
+	$.bind_value(input, () => $.get(query), ($$value) => $.set(query, $$value));
+	$.append($$anchor, div);
+	$.pop();
+}
+
+$.delegate(['click']);

--- a/benches/printer-corpus/04-form-bindings.esrap.js
+++ b/benches/printer-corpus/04-form-bindings.esrap.js
@@ -1,0 +1,176 @@
+import 'svelte/internal/disclose-version';
+import * as $ from 'svelte/internal/client';
+
+var root = $.from_html(`<label class="check"><input type="checkbox"/> </label>`);
+var root_1 = $.from_html(`<form class="svelte-oeyshj"><label>Name <input/></label> <label>Email <input type="email"/></label> <label> <input type="range" min="13" max="99"/></label> <label>Bio <textarea rows="3"></textarea></label> <label>Plan <select><option>Free</option><option>Pro</option><option>Team</option></select></label> <fieldset><legend>Interests</legend> <!></fieldset> <fieldset><legend>Preferred contact</legend> <label><input type="radio"/> Email</label> <label><input type="radio"/> Phone</label></fieldset> <label class="check"><input type="checkbox"/> I agree to the terms</label> <p class="summary svelte-oeyshj"> </p> <button type="submit">Submit</button></form>`);
+
+export default function Component($$anchor, $$props) {
+	$.push($$props, true);
+
+	const binding_group = [];
+	const binding_group_1 = [];
+	let name = $.state('');
+	let email = $.state('');
+	let age = $.state(18);
+	let bio = $.state('');
+	let plan = $.state('free');
+	let agree = $.state(false);
+	let interests = $.state($.proxy([]));
+	let contact = $.state('email');
+	const options = ['sports', 'music', 'reading', 'travel', 'cooking'];
+	let emailValid = $.derived(() => (/^[^@\s]+@[^@\s]+\.[^@\s]+$/).test($.get(email)));
+	let nameValid = $.derived(() => $.get(name).trim().length >= 2);
+	let canSubmit = $.derived(() => $.get(nameValid) && $.get(emailValid) && $.get(agree));
+	let summary = $.derived(() => `${$.get(name) || 'Anonymous'} <${$.get(email) || 'n/a'}> — ${$.get(plan)} plan, ${$.get(interests).length} interests`);
+
+	function submit() {
+		if (!$.get(canSubmit)) return;
+
+		console.log($.get(summary));
+	}
+
+	var form = root_1();
+	var label = $.child(form);
+	var input = $.sibling($.child(label));
+
+	$.remove_input_defaults(input);
+
+	let classes;
+
+	$.reset(label);
+
+	var label_1 = $.sibling(label, 2);
+	var input_1 = $.sibling($.child(label_1));
+
+	$.remove_input_defaults(input_1);
+
+	let classes_1;
+
+	$.reset(label_1);
+
+	var label_2 = $.sibling(label_1, 2);
+	var text = $.child(label_2);
+	var input_2 = $.sibling(text);
+
+	$.remove_input_defaults(input_2);
+	$.reset(label_2);
+
+	var label_3 = $.sibling(label_2, 2);
+	var textarea = $.sibling($.child(label_3));
+
+	$.remove_textarea_child(textarea);
+	$.reset(label_3);
+
+	var label_4 = $.sibling(label_3, 2);
+	var select = $.sibling($.child(label_4));
+	var option = $.child(select);
+
+	option.value = option.__value = 'free';
+
+	var option_1 = $.sibling(option);
+
+	option_1.value = option_1.__value = 'pro';
+
+	var option_2 = $.sibling(option_1);
+
+	option_2.value = option_2.__value = 'team';
+	$.reset(select);
+	$.reset(label_4);
+
+	var fieldset = $.sibling(label_4, 2);
+	var node = $.sibling($.child(fieldset), 2);
+
+	$.each(node, 17, () => options, $.index, ($$anchor, opt) => {
+		var label_5 = root();
+		var input_3 = $.child(label_5);
+
+		$.remove_input_defaults(input_3);
+
+		var input_3_value;
+		var text_1 = $.sibling(input_3);
+
+		$.reset(label_5);
+
+		$.template_effect(() => {
+			if (input_3_value !== (input_3_value = $.get(opt))) {
+				input_3.value = (input_3.__value = $.get(opt)) ?? '';
+			}
+
+			$.set_text(text_1, ` ${$.get(opt) ?? ''}`);
+		});
+
+		$.bind_group(
+			binding_group,
+			[],
+			input_3,
+			() => {
+				$.get(opt);
+
+				return $.get(interests);
+			},
+			($$value) => $.set(interests, $$value)
+		);
+
+		$.append($$anchor, label_5);
+	});
+
+	$.reset(fieldset);
+
+	var fieldset_1 = $.sibling(fieldset, 2);
+	var label_6 = $.sibling($.child(fieldset_1), 2);
+	var input_4 = $.child(label_6);
+
+	$.remove_input_defaults(input_4);
+	input_4.value = input_4.__value = 'email';
+	$.next();
+	$.reset(label_6);
+
+	var label_7 = $.sibling(label_6, 2);
+	var input_5 = $.child(label_7);
+
+	$.remove_input_defaults(input_5);
+	input_5.value = input_5.__value = 'phone';
+	$.next();
+	$.reset(label_7);
+	$.reset(fieldset_1);
+
+	var label_8 = $.sibling(fieldset_1, 2);
+	var input_6 = $.child(label_8);
+
+	$.remove_input_defaults(input_6);
+	$.next();
+	$.reset(label_8);
+
+	var p = $.sibling(label_8, 2);
+	var text_2 = $.child(p, true);
+
+	$.reset(p);
+
+	var button = $.sibling(p, 2);
+
+	$.reset(form);
+
+	$.template_effect(() => {
+		classes = $.set_class(input, 1, 'svelte-oeyshj', null, classes, { invalid: $.get(name) && !$.get(nameValid) });
+		classes_1 = $.set_class(input_1, 1, 'svelte-oeyshj', null, classes_1, { invalid: $.get(email) && !$.get(emailValid) });
+		$.set_text(text, `Age: ${$.get(age) ?? ''} `);
+		$.set_text(text_2, $.get(summary));
+		button.disabled = !$.get(canSubmit);
+	});
+
+	$.event('submit', form, (e) => {
+		e.preventDefault();
+		submit();
+	});
+
+	$.bind_value(input, () => $.get(name), ($$value) => $.set(name, $$value));
+	$.bind_value(input_1, () => $.get(email), ($$value) => $.set(email, $$value));
+	$.bind_value(input_2, () => $.get(age), ($$value) => $.set(age, $$value));
+	$.bind_value(textarea, () => $.get(bio), ($$value) => $.set(bio, $$value));
+	$.bind_select_value(select, () => $.get(plan), ($$value) => $.set(plan, $$value));
+	$.bind_group(binding_group_1, [], input_4, () => $.get(contact), ($$value) => $.set(contact, $$value));
+	$.bind_group(binding_group_1, [], input_5, () => $.get(contact), ($$value) => $.set(contact, $$value));
+	$.bind_checked(input_6, () => $.get(agree), ($$value) => $.set(agree, $$value));
+	$.append($$anchor, form);
+	$.pop();
+}

--- a/benches/printer-corpus/05-legacy-reactive.esrap.js
+++ b/benches/printer-corpus/05-legacy-reactive.esrap.js
@@ -1,0 +1,203 @@
+import 'svelte/internal/disclose-version';
+import 'svelte/internal/flags/legacy';
+import * as $ from 'svelte/internal/client';
+import { writable } from 'svelte/store';
+import { createEventDispatcher } from 'svelte';
+
+var root = $.from_html(`<li class="svelte-1ktd2x7"><span class="name"> </span> <span class="price"> </span> <span class="qty"><button>−</button> <button>+</button></span> <span class="line"> </span></li>`);
+var root_1 = $.from_html(`<dt>Discount</dt> <dd> </dd>`, 1);
+var root_2 = $.from_html(`<div class="cart svelte-1ktd2x7"><h2> </h2> <ul class="svelte-1ktd2x7"></ul> <label class="coupon">Coupon <input placeholder="Try SAVE10"/></label> <dl class="totals svelte-1ktd2x7"><dt>Subtotal</dt> <dd> </dd> <!> <dt>Tax</dt> <dd> </dd> <dt class="grand svelte-1ktd2x7">Total</dt> <dd class="grand svelte-1ktd2x7"> </dd></dl> <button class="checkout">Checkout</button></div>`);
+
+export default function Component($$anchor, $$props) {
+	$.push($$props, false);
+
+	const $coupon = () => $.store_get(coupon, '$coupon', $$stores);
+	const [$$stores, $$cleanup] = $.setup_stores();
+	const subtotal = $.mutable_source();
+	const discount = $.mutable_source();
+	const tax = $.mutable_source();
+	const total = $.mutable_source();
+	const itemCount = $.mutable_source();
+	let title = $.prop($$props, 'title', 8, 'Cart');
+	let taxRate = $.prop($$props, 'taxRate', 8, 0.1);
+	const dispatch = createEventDispatcher();
+	const coupon = writable('');
+
+	let items = $.mutable_source([
+		{ id: 1, name: 'Widget', price: 9.99, qty: 1 },
+		{ id: 2, name: 'Gadget', price: 19.5, qty: 2 },
+		{ id: 3, name: 'Gizmo', price: 4.25, qty: 5 }
+	]);
+
+	function changeQty(id, delta) {
+		$.set(items, $.get(items).map((item) => item.id === id
+			? { ...item, qty: Math.max(0, item.qty + delta) }
+			: item));
+	}
+
+	function checkout() {
+		dispatch('checkout', { items: $.get(items), total: $.get(total) });
+	}
+
+	$.legacy_pre_effect(() => $.get(items), () => {
+		$.set(subtotal, $.get(items).reduce((sum, item) => sum + item.price * item.qty, 0));
+	});
+
+	$.legacy_pre_effect(() => ($coupon(), $.get(subtotal)), () => {
+		$.set(discount, $coupon() === 'SAVE10' ? $.get(subtotal) * 0.1 : 0);
+	});
+
+	$.legacy_pre_effect(
+		() => (
+			$.get(subtotal),
+			$.get(discount),
+			$.deep_read_state(taxRate())
+		),
+		() => {
+			$.set(tax, ($.get(subtotal) - $.get(discount)) * taxRate());
+		}
+	);
+
+	$.legacy_pre_effect(() => ($.get(subtotal), $.get(discount), $.get(tax)), () => {
+		$.set(total, $.get(subtotal) - $.get(discount) + $.get(tax));
+	});
+
+	$.legacy_pre_effect(() => $.get(items), () => {
+		$.set(itemCount, $.get(items).reduce((n, item) => n + item.qty, 0));
+	});
+
+	$.legacy_pre_effect(() => $.get(total), () => {
+		if ($.get(total) > 100) {
+			console.log('Big order:', $.get(total));
+		}
+	});
+
+	$.legacy_pre_effect_reset();
+	$.init();
+
+	var div = root_2();
+	var h2 = $.child(div);
+	var text = $.child(h2);
+
+	$.reset(h2);
+
+	var ul = $.sibling(h2, 2);
+
+	$.each(ul, 5, () => $.get(items), (item) => item.id, ($$anchor, item) => {
+		var li = root();
+		var span = $.child(li);
+		var text_1 = $.child(span, true);
+
+		$.reset(span);
+
+		var span_1 = $.sibling(span, 2);
+		var text_2 = $.child(span_1);
+
+		$.reset(span_1);
+
+		var span_2 = $.sibling(span_1, 2);
+		var button = $.child(span_2);
+		var text_3 = $.sibling(button);
+		var button_1 = $.sibling(text_3);
+
+		$.reset(span_2);
+
+		var span_3 = $.sibling(span_2, 2);
+		var text_4 = $.child(span_3);
+
+		$.reset(span_3);
+		$.reset(li);
+
+		$.template_effect(
+			($0, $1) => {
+				$.set_text(text_1, ($.get(item), $.untrack(() => $.get(item).name)));
+				$.set_text(text_2, `$${$0 ?? ''}`);
+				$.set_text(text_3, ` ${($.get(item), $.untrack(() => $.get(item).qty)) ?? ''} `);
+				$.set_text(text_4, `$${$1 ?? ''}`);
+			},
+			[
+				() => ($.get(item), $.untrack(() => $.get(item).price.toFixed(2))),
+				() => (
+					$.get(item),
+					$.untrack(() => ($.get(item).price * $.get(item).qty).toFixed(2))
+				)
+			]
+		);
+
+		$.event('click', button, () => changeQty($.get(item).id, -1));
+		$.event('click', button_1, () => changeQty($.get(item).id, 1));
+		$.append($$anchor, li);
+	});
+
+	$.reset(ul);
+
+	var label = $.sibling(ul, 2);
+	var input = $.sibling($.child(label));
+
+	$.remove_input_defaults(input);
+	$.reset(label);
+
+	var dl = $.sibling(label, 2);
+	var dd = $.sibling($.child(dl), 2);
+	var text_5 = $.child(dd);
+
+	$.reset(dd);
+
+	var node = $.sibling(dd, 2);
+
+	{
+		var consequent = ($$anchor) => {
+			var fragment = root_1();
+			var dd_1 = $.sibling($.first_child(fragment), 2);
+			var text_6 = $.child(dd_1);
+
+			$.reset(dd_1);
+
+			$.template_effect(($0) => $.set_text(text_6, `−$${$0 ?? ''}`), [
+				() => ($.get(discount), $.untrack(() => $.get(discount).toFixed(2)))
+			]);
+
+			$.append($$anchor, fragment);
+		};
+
+		$.if(node, ($$render) => {
+			if ($.get(discount) > 0) $$render(consequent);
+		});
+	}
+
+	var dd_2 = $.sibling(node, 4);
+	var text_7 = $.child(dd_2);
+
+	$.reset(dd_2);
+
+	var dd_3 = $.sibling(dd_2, 4);
+	var text_8 = $.child(dd_3);
+
+	$.reset(dd_3);
+	$.reset(dl);
+
+	var button_2 = $.sibling(dl, 2);
+
+	$.reset(div);
+
+	$.template_effect(
+		($0, $1, $2) => {
+			$.set_text(text, `${title() ?? ''} (${$.get(itemCount) ?? ''})`);
+			$.set_text(text_5, `$${$0 ?? ''}`);
+			$.set_text(text_7, `$${$1 ?? ''}`);
+			$.set_text(text_8, `$${$2 ?? ''}`);
+			button_2.disabled = $.get(itemCount) === 0;
+		},
+		[
+			() => ($.get(subtotal), $.untrack(() => $.get(subtotal).toFixed(2))),
+			() => ($.get(tax), $.untrack(() => $.get(tax).toFixed(2))),
+			() => ($.get(total), $.untrack(() => $.get(total).toFixed(2)))
+		]
+	);
+
+	$.bind_value(input, $coupon, ($$value) => $.store_set(coupon, $$value));
+	$.event('click', button_2, checkout);
+	$.append($$anchor, div);
+	$.pop();
+	$$cleanup();
+}

--- a/benches/printer-corpus/06-css-heavy.esrap.js
+++ b/benches/printer-corpus/06-css-heavy.esrap.js
@@ -1,0 +1,69 @@
+import 'svelte/internal/disclose-version';
+import * as $ from 'svelte/internal/client';
+
+var root = $.from_html(`<article><h2 class="svelte-3aeeh3"> </h2> <p class="svelte-3aeeh3"> </p></article>`);
+var root_1 = $.from_html(`<div><header class="bar svelte-3aeeh3"><h1 class="svelte-3aeeh3">Showcase</h1> <button class="toggle svelte-3aeeh3"> </button></header> <div class="grid svelte-3aeeh3"></div></div>`);
+
+export default function Component($$anchor) {
+	let theme = $.state('light');
+	let active = $.state(0);
+	let pulse = true;
+
+	const cards = [
+		{ title: 'Performance', body: 'Compiled, not interpreted.' },
+		{ title: 'Reactivity', body: 'Fine-grained by default.' },
+		{ title: 'Ergonomics', body: 'Less boilerplate.' }
+	];
+
+	var div = root_1();
+
+	$.set_class(div, 1, 'surface svelte-3aeeh3', null, {}, { pulse });
+
+	var header = $.child(div);
+	var button = $.sibling($.child(header), 2);
+	let styles;
+	var text = $.child(button, true);
+
+	$.reset(button);
+	$.reset(header);
+
+	var div_1 = $.sibling(header, 2);
+
+	$.each(div_1, 21, () => cards, $.index, ($$anchor, card, i) => {
+		var article = root();
+		let classes;
+		var h2 = $.child(article);
+		var text_1 = $.child(h2, true);
+
+		$.reset(h2);
+
+		var p = $.sibling(h2, 2);
+		var text_2 = $.child(p, true);
+
+		$.reset(p);
+		$.reset(article);
+
+		$.template_effect(() => {
+			classes = $.set_class(article, 1, 'card svelte-3aeeh3', null, classes, { selected: $.get(active) === i });
+			$.set_text(text_1, $.get(card).title);
+			$.set_text(text_2, $.get(card).body);
+		});
+
+		$.delegated('click', article, () => $.set(active, i, true));
+		$.append($$anchor, article);
+	});
+
+	$.reset(div_1);
+	$.reset(div);
+
+	$.template_effect(() => {
+		$.set_attribute(div, 'data-theme', $.get(theme));
+		styles = $.set_style(button, '', styles, { '--accent': $.get(theme) === 'light' ? '#2563eb' : '#f59e0b' });
+		$.set_text(text, $.get(theme));
+	});
+
+	$.delegated('click', button, () => $.set(theme, $.get(theme) === 'light' ? 'dark' : 'light', true));
+	$.append($$anchor, div);
+}
+
+$.delegate(['click']);

--- a/benches/printer-corpus/07-snippets.esrap.js
+++ b/benches/printer-corpus/07-snippets.esrap.js
@@ -1,0 +1,127 @@
+import 'svelte/internal/disclose-version';
+import * as $ from 'svelte/internal/client';
+
+const chip = ($$anchor, label = $.noop) => {
+	var span = root();
+	var text = $.child(span, true);
+
+	$.reset(span);
+	$.template_effect(() => $.set_text(text, label()));
+	$.append($$anchor, span);
+};
+
+const empty = ($$anchor) => {
+	var p = root_3();
+
+	$.append($$anchor, p);
+};
+
+var root = $.from_html(`<span class="chip svelte-1nz2zt8"> </span>`);
+var root_1 = $.from_html(`<div class="tags svelte-1nz2zt8"></div>`);
+var root_2 = $.from_html(`<article><div class="avatar svelte-1nz2zt8"> </div> <div class="body"><h3> </h3> <!></div> <!></article>`);
+var root_3 = $.from_html(`<p class="empty">No people yet.</p>`);
+var root_4 = $.from_html(`<div class="toolbar"><label><input type="checkbox"/> Show tags</label></div> <section class="people svelte-1nz2zt8"></section> <!>`, 1);
+
+export default function Component($$anchor, $$props) {
+	$.push($$props, true);
+
+	const card = ($$anchor, person = $.noop, index = $.noop) => {
+		const initials = $.derived(() => person().name.slice(0, 1).toUpperCase());
+		var article = root_2();
+		let classes;
+		var div = $.child(article);
+		var text_1 = $.child(div, true);
+
+		$.reset(div);
+
+		var div_1 = $.sibling(div, 2);
+		var h3 = $.child(div_1);
+		var text_2 = $.child(h3);
+
+		$.reset(h3);
+
+		var node = $.sibling(h3, 2);
+
+		{
+			var consequent = ($$anchor) => {
+				var div_2 = root_1();
+
+				$.each(div_2, 21, () => person().tags, $.index, ($$anchor, tag) => {
+					chip($$anchor, () => $.get(tag));
+				});
+
+				$.reset(div_2);
+				$.append($$anchor, div_2);
+			};
+
+			$.if(node, ($$render) => {
+				if ($.get(showTags) && person().tags.length) $$render(consequent);
+			});
+		}
+
+		$.reset(div_1);
+
+		var node_1 = $.sibling(div_1, 2);
+
+		{
+			var consequent_1 = ($$anchor) => {
+				chip($$anchor, () => '★ featured');
+			};
+
+			$.if(node_1, ($$render) => {
+				if (person().featured) $$render(consequent_1);
+			});
+		}
+
+		$.reset(article);
+
+		$.template_effect(() => {
+			classes = $.set_class(article, 1, 'card svelte-1nz2zt8', null, classes, { featured: person().featured });
+			$.set_text(text_1, $.get(initials));
+			$.set_text(text_2, `#${index() + 1} — ${person().name ?? ''}`);
+		});
+
+		$.append($$anchor, article);
+	};
+
+	let people = $.proxy([
+		{ name: 'Ada', tags: ['math', 'engines'], featured: true },
+		{ name: 'Alan', tags: ['logic', 'machines'], featured: false },
+		{ name: 'Grace', tags: ['compilers'], featured: true }
+	]);
+
+	let showTags = $.state(true);
+	var fragment_2 = root_4();
+	var div_3 = $.first_child(fragment_2);
+	var label_1 = $.child(div_3);
+	var input = $.child(label_1);
+
+	$.remove_input_defaults(input);
+	$.next();
+	$.reset(label_1);
+	$.reset(div_3);
+
+	var section = $.sibling(div_3, 2);
+
+	$.each(section, 23, () => people, (person) => person.name, ($$anchor, person, i) => {
+		card($$anchor, () => $.get(person), () => $.get(i));
+	});
+
+	$.reset(section);
+
+	var node_2 = $.sibling(section, 2);
+
+	{
+		var consequent_2 = ($$anchor) => {
+			empty($$anchor);
+		};
+
+		$.if(node_2, ($$render) => {
+			if (people.length === 0) $$render(consequent_2);
+		});
+	}
+
+	$.bind_checked(input, () => $.get(showTags), ($$value) => $.set(showTags, $$value));
+	$.append($$anchor, fragment_2);
+	$.pop();
+}

--- a/benches/printer-corpus/08-control-flow.esrap.js
+++ b/benches/printer-corpus/08-control-flow.esrap.js
@@ -1,0 +1,204 @@
+import 'svelte/internal/disclose-version';
+import * as $ from 'svelte/internal/client';
+
+var root = $.from_html(`<p class="muted svelte-1yhzv6r">Choose a state…</p>`);
+var root_1 = $.from_html(`<p class="ok svelte-1yhzv6r">Ready to go.</p>`);
+var root_2 = $.from_html(`<p class="error svelte-1yhzv6r">Something is off.</p>`);
+var root_3 = $.from_html(`<button> </button>`);
+var root_4 = $.from_html(`<p>Loaded <b> </b> </p>`);
+var root_5 = $.from_html(`<p class="error svelte-1yhzv6r"> </p> <button>Retry</button>`, 1);
+var root_6 = $.from_html(`<p> </p>`);
+var root_7 = $.from_html(`<div class="panel"><!></div>`);
+var root_8 = $.from_html(`<li> </li>`);
+var root_9 = $.from_html(`<ol></ol>`);
+var root_10 = $.from_html(`<p class="muted svelte-1yhzv6r">Empty section.</p>`);
+var root_11 = $.from_html(`<section><h3> </h3> <!></section>`);
+var root_12 = $.from_html(`<div class="app svelte-1yhzv6r"><!> <div class="controls svelte-1yhzv6r"></div> <div class="raw"></div> <!> <!></div>`);
+
+export default function Component($$anchor, $$props) {
+	$.push($$props, true);
+
+	let status = $.state('loading');
+	let attempt = $.state(0);
+
+	const sections = [
+		{ id: 'a', title: 'Intro', items: ['one', 'two', 'three'] },
+		{ id: 'b', title: 'Details', items: ['alpha', 'beta'] },
+		{ id: 'c', title: 'Outro', items: [] }
+	];
+
+	function load() {
+		$.set(attempt, $.get(attempt) + 1);
+
+		return new Promise((resolve, reject) => {
+			if ($.get(attempt) % 3 === 0) {
+				reject(new Error('Network error'));
+			} else {
+				resolve({ name: 'Report', generated: $.get(attempt) });
+			}
+		});
+	}
+
+	let promise = $.state($.proxy(load()));
+
+	function retry() {
+		$.set(promise, load(), true);
+	}
+
+	const notice = '<strong>Heads up:</strong> rendered as raw HTML.';
+	var div = root_12();
+	var node = $.child(div);
+
+	{
+		var consequent = ($$anchor) => {
+			var p = root();
+
+			$.append($$anchor, p);
+		};
+
+		var consequent_1 = ($$anchor) => {
+			var p_1 = root_1();
+
+			$.append($$anchor, p_1);
+		};
+
+		var alternate = ($$anchor) => {
+			var p_2 = root_2();
+
+			$.append($$anchor, p_2);
+		};
+
+		$.if(node, ($$render) => {
+			if ($.get(status) === 'loading') $$render(consequent); else if ($.get(status) === 'ready') $$render(consequent_1, 1); else $$render(alternate, -1);
+		});
+	}
+
+	var div_1 = $.sibling(node, 2);
+
+	$.each(div_1, 20, () => ['loading', 'ready', 'error'], $.index, ($$anchor, s) => {
+		var button = root_3();
+		let classes;
+		var text = $.child(button, true);
+
+		$.reset(button);
+
+		$.template_effect(() => {
+			classes = $.set_class(button, 1, 'svelte-1yhzv6r', null, classes, { active: $.get(status) === s });
+			$.set_text(text, s);
+		});
+
+		$.delegated('click', button, () => $.set(status, s, true));
+		$.append($$anchor, button);
+	});
+
+	$.reset(div_1);
+
+	var div_2 = $.sibling(div_1, 2);
+
+	$.html(div_2, () => notice, true);
+	$.reset(div_2);
+
+	var node_1 = $.sibling(div_2, 2);
+
+	$.key(node_1, () => $.get(attempt), ($$anchor) => {
+		var div_3 = root_7();
+		var node_2 = $.child(div_3);
+
+		$.await(
+			node_2,
+			() => $.get(promise),
+			($$anchor) => {
+				var p_5 = root_6();
+				var text_4 = $.child(p_5);
+
+				$.reset(p_5);
+				$.template_effect(() => $.set_text(text_4, `Loading attempt ${$.get(attempt) ?? ''}…`));
+				$.append($$anchor, p_5);
+			},
+			($$anchor, data) => {
+				var p_3 = root_4();
+				var b = $.sibling($.child(p_3));
+				var text_1 = $.child(b, true);
+
+				$.reset(b);
+
+				var text_2 = $.sibling(b);
+
+				$.reset(p_3);
+
+				$.template_effect(() => {
+					$.set_text(text_1, $.get(data).name);
+					$.set_text(text_2, ` (gen ${$.get(data).generated ?? ''})`);
+				});
+
+				$.append($$anchor, p_3);
+			},
+			($$anchor, error) => {
+				var fragment = root_5();
+				var p_4 = $.first_child(fragment);
+				var text_3 = $.child(p_4);
+
+				$.reset(p_4);
+
+				var button_1 = $.sibling(p_4, 2);
+
+				$.template_effect(() => $.set_text(text_3, `Failed: ${$.get(error).message ?? ''}`));
+				$.delegated('click', button_1, retry);
+				$.append($$anchor, fragment);
+			}
+		);
+
+		$.reset(div_3);
+		$.append($$anchor, div_3);
+	});
+
+	var node_3 = $.sibling(node_1, 2);
+
+	$.each(node_3, 17, () => sections, (section) => section.id, ($$anchor, section) => {
+		var section_1 = root_11();
+		var h3 = $.child(section_1);
+		var text_5 = $.child(h3, true);
+
+		$.reset(h3);
+
+		var node_4 = $.sibling(h3, 2);
+
+		{
+			var consequent_2 = ($$anchor) => {
+				var ol = root_9();
+
+				$.each(ol, 21, () => $.get(section).items, $.index, ($$anchor, item, i) => {
+					var li = root_8();
+					var text_6 = $.child(li);
+
+					$.reset(li);
+					$.template_effect(() => $.set_text(text_6, `${i + 1}. ${$.get(item) ?? ''}`));
+					$.append($$anchor, li);
+				});
+
+				$.reset(ol);
+				$.append($$anchor, ol);
+			};
+
+			var alternate_1 = ($$anchor) => {
+				var p_6 = root_10();
+
+				$.append($$anchor, p_6);
+			};
+
+			$.if(node_4, ($$render) => {
+				if ($.get(section).items.length) $$render(consequent_2); else $$render(alternate_1, -1);
+			});
+		}
+
+		$.reset(section_1);
+		$.template_effect(() => $.set_text(text_5, $.get(section).title));
+		$.append($$anchor, section_1);
+	});
+
+	$.reset(div);
+	$.append($$anchor, div);
+	$.pop();
+}
+
+$.delegate(['click']);

--- a/benches/printer-corpus/09-typescript-generics.esrap.js
+++ b/benches/printer-corpus/09-typescript-generics.esrap.js
@@ -1,0 +1,87 @@
+import 'svelte/internal/disclose-version';
+import * as $ from 'svelte/internal/client';
+
+var root = $.from_html(`<button><span> </span> <small> </small></button>`);
+var root_1 = $.from_html(`<div class="results svelte-138j00e"></div>`);
+var root_2 = $.from_html(`<p>No typed rows match.</p>`);
+var root_3 = $.from_html(`<section class="svelte-138j00e"><label>Filter <input/></label> <!></section>`);
+
+export default function Component($$anchor, $$props) {
+	$.push($$props, true);
+
+	const result = ($$anchor, row = $.noop, index = $.noop) => {
+		var button = root();
+		let classes;
+		var span = $.child(button);
+		var text = $.child(span);
+
+		$.reset(span);
+
+		var small = $.sibling(span, 2);
+		var text_1 = $.child(small, true);
+
+		$.reset(small);
+		$.reset(button);
+
+		$.template_effect(() => {
+			$.set_attribute(button, 'aria-pressed', $.get(selected)?.id === row().id);
+			classes = $.set_class(button, 1, 'svelte-138j00e', null, classes, { selected: $.get(selected)?.id === row().id });
+			$.set_text(text, `${index() + 1}. ${row().label ?? ''}`);
+			$.set_text(text_1, row().id);
+		});
+
+		$.delegated('click', button, () => choose(row()));
+		$.append($$anchor, button);
+	};
+
+	let initial = $.prop($$props, 'initial', 3, null),
+		onselect = $.prop($$props, 'onselect', 3, () => {});
+
+	let query = $.state('');
+	let selected = $.state($.proxy(initial()));
+	let visible = $.derived(() => $$props.rows.filter((row) => row.active !== false && row.label.toLowerCase().includes($.get(query).toLowerCase())));
+
+	function choose(row) {
+		$.set(selected, row, true);
+		onselect()(row);
+	}
+
+	var section = root_3();
+	var label = $.child(section);
+	var input = $.sibling($.child(label));
+
+	$.remove_input_defaults(input);
+	$.reset(label);
+
+	var node = $.sibling(label, 2);
+
+	{
+		var consequent = ($$anchor) => {
+			var div = root_1();
+
+			$.each(div, 23, () => $.get(visible), (row) => row.id, ($$anchor, row, index) => {
+				result($$anchor, () => $.get(row), () => $.get(index));
+			});
+
+			$.reset(div);
+			$.append($$anchor, div);
+		};
+
+		var alternate = ($$anchor) => {
+			var p = root_2();
+
+			$.append($$anchor, p);
+		};
+
+		$.if(node, ($$render) => {
+			if ($.get(visible).length) $$render(consequent); else $$render(alternate, -1);
+		});
+	}
+
+	$.reset(section);
+	$.bind_value(input, () => $.get(query), ($$value) => $.set(query, $$value));
+	$.append($$anchor, section);
+	$.pop();
+}
+
+$.delegate(['click']);

--- a/benches/printer-corpus/10-legacy-typescript-props.esrap.js
+++ b/benches/printer-corpus/10-legacy-typescript-props.esrap.js
@@ -1,0 +1,234 @@
+import 'svelte/internal/disclose-version';
+import 'svelte/internal/flags/legacy';
+import * as $ from 'svelte/internal/client';
+import { onMount, createEventDispatcher } from 'svelte';
+import { writable, derived } from 'svelte/store';
+
+var root = $.from_html(`<p class="empty svelte-1jser4n"> </p>`);
+var root_1 = $.from_html(`<button type="button">Dismiss</button>`);
+var root_2 = $.from_html(`<li><span class="message"> </span> <span class="age"> </span> <!></li>`);
+var root_3 = $.from_html(`<ul></ul>`);
+var root_4 = $.from_html(`<button class="more" type="button"> </button>`);
+var root_5 = $.from_html(`<div><header class="svelte-1jser4n"><h2> </h2> <span class="badge"> </span></header> <!> <!></div>`);
+
+export default function Component($$anchor, $$props) {
+	$.push($$props, false);
+
+	const $now = () => $.store_get(now, '$now', $$stores);
+	const $label = () => $.store_get(label, '$label', $$stores);
+	const [$$stores, $$cleanup] = $.setup_stores();
+	const filtered = $.mutable_source();
+	const visible = $.mutable_source();
+	const hiddenCount = $.mutable_source();
+	const errorCount = $.mutable_source();
+	const heading = $.mutable_source();
+	const ages = $.mutable_source();
+	let title = $.prop($$props, 'title', 8, 'Notifications');
+	let notices = $.prop($$props, 'notices', 28, () => []);
+	let maxVisible = $.prop($$props, 'maxVisible', 8, 5);
+	let dismissable = $.prop($$props, 'dismissable', 8, true);
+	let emptyLabel = $.prop($$props, 'emptyLabel', 8, 'Nothing to show');
+	let severityFilter = $.prop($$props, 'severityFilter', 8, null);
+	const dispatch = createEventDispatcher();
+	const now = writable(Date.now());
+	const unreadCount = writable(0);
+	const label = derived(unreadCount, (n) => n === 0 ? 'read' : `${n} unread`);
+	let expanded = $.mutable_source(false);
+	let hovered = $.mutable_source(null);
+	let container = $.mutable_source();
+
+	function dismiss(id) {
+		notices(notices().filter((n) => n.id !== id));
+		unreadCount.update((n) => Math.max(0, n - 1));
+		dispatch('dismiss', { id });
+	}
+
+	function severityClass(severity) {
+		return `notice notice--${severity}`;
+	}
+
+	onMount(() => {
+		const timer = setInterval(() => now.set(Date.now()), 1000);
+
+		dispatch('seen');
+
+		return () => clearInterval(timer);
+	});
+
+	$.legacy_pre_effect(
+		() => (
+			$.deep_read_state(severityFilter()),
+			$.deep_read_state(notices())
+		),
+		() => {
+			$.set(filtered, severityFilter()
+				? notices().filter((n) => n.severity === severityFilter())
+				: notices());
+		}
+	);
+
+	$.legacy_pre_effect(() => $.get(filtered), () => {
+		$.set(errorCount, $.get(filtered).filter((n) => n.severity === 'error').length);
+	});
+
+	$.legacy_pre_effect(() => ($.get(errorCount), $.get(expanded)), () => {
+		if ($.get(errorCount) > 0 && !$.get(expanded)) {
+			$.set(expanded, true);
+		}
+	});
+
+	$.legacy_pre_effect(
+		() => (
+			$.get(expanded),
+			$.get(filtered),
+			$.deep_read_state(maxVisible())
+		),
+		() => {
+			$.set(visible, $.get(expanded)
+				? $.get(filtered)
+				: $.get(filtered).slice(0, maxVisible()));
+		}
+	);
+
+	$.legacy_pre_effect(() => ($.get(filtered), $.get(visible)), () => {
+		$.set(hiddenCount, $.get(filtered).length - $.get(visible).length);
+	});
+
+	$.legacy_pre_effect(() => ($.get(errorCount), $.deep_read_state(title())), () => {
+		$.set(heading, $.get(errorCount) > 0 ? `${title()} (${$.get(errorCount)})` : title());
+	});
+
+	$.legacy_pre_effect(() => ($.get(visible), $now()), () => {
+		$.set(ages, $.get(visible).map((n) => Math.max(0, Math.round(($now() - n.at) / 1000))));
+	});
+
+	$.legacy_pre_effect_reset();
+	$.init();
+
+	var div = root_5();
+	let classes;
+	var header = $.child(div);
+	var h2 = $.child(header);
+	var text = $.child(h2, true);
+
+	$.reset(h2);
+
+	var span = $.sibling(h2, 2);
+	var text_1 = $.child(span, true);
+
+	$.reset(span);
+	$.reset(header);
+
+	var node = $.sibling(header, 2);
+
+	{
+		var consequent = ($$anchor) => {
+			var p = root();
+			var text_2 = $.child(p, true);
+
+			$.reset(p);
+			$.template_effect(() => $.set_text(text_2, emptyLabel()));
+			$.append($$anchor, p);
+		};
+
+		var alternate = ($$anchor) => {
+			var ul = root_3();
+
+			$.each(ul, 7, () => $.get(visible), (notice) => notice.id, ($$anchor, notice, i) => {
+				var li = root_2();
+				var span_1 = $.child(li);
+				var text_3 = $.child(span_1, true);
+
+				$.reset(span_1);
+
+				var span_2 = $.sibling(span_1, 2);
+				var text_4 = $.child(span_2);
+
+				$.reset(span_2);
+
+				var node_1 = $.sibling(span_2, 2);
+
+				{
+					var consequent_1 = ($$anchor) => {
+						var button = root_1();
+
+						$.event('click', button, () => dismiss($.get(notice).id));
+						$.append($$anchor, button);
+					};
+
+					$.if(node_1, ($$render) => {
+						if ((
+							$.deep_read_state(dismissable()),
+							$.get(hovered),
+							$.get(notice),
+							$.untrack(() => dismissable() && $.get(hovered) === $.get(notice).id)
+						)) $$render(consequent_1);
+					});
+				}
+
+				$.reset(li);
+
+				$.template_effect(
+					($0) => {
+						$.set_class(li, 1, $0, 'svelte-1jser4n');
+						$.set_text(text_3, ($.get(notice), $.untrack(() => $.get(notice).message)));
+
+						$.set_text(text_4, `${(
+							$.get(ages),
+							$.deep_read_state($.get(i)),
+							$.untrack(() => $.get(ages)[$.get(i)])
+						) ?? ''}s`);
+					},
+					[
+						() => $.clsx((
+							$.get(notice),
+							$.untrack(() => severityClass($.get(notice).severity))
+						))
+					]
+				);
+
+				$.event('mouseenter', li, () => $.set(hovered, $.get(notice).id));
+				$.event('mouseleave', li, () => $.set(hovered, null));
+				$.append($$anchor, li);
+			});
+
+			$.reset(ul);
+			$.append($$anchor, ul);
+		};
+
+		$.if(node, ($$render) => {
+			if (($.get(visible), $.untrack(() => $.get(visible).length === 0))) $$render(consequent); else $$render(alternate, -1);
+		});
+	}
+
+	var node_2 = $.sibling(node, 2);
+
+	{
+		var consequent_2 = ($$anchor) => {
+			var button_1 = root_4();
+			var text_5 = $.child(button_1, true);
+
+			$.reset(button_1);
+			$.template_effect(() => $.set_text(text_5, $.get(expanded) ? 'Show less' : `Show ${$.get(hiddenCount)} more`));
+			$.event('click', button_1, () => $.set(expanded, !$.get(expanded)));
+			$.append($$anchor, button_1);
+		};
+
+		$.if(node_2, ($$render) => {
+			if ($.get(hiddenCount) > 0) $$render(consequent_2);
+		});
+	}
+
+	$.reset(div);
+	$.bind_this(div, ($$value) => $.set(container, $$value), () => $.get(container));
+
+	$.template_effect(() => {
+		classes = $.set_class(div, 1, 'panel svelte-1jser4n', null, classes, { 'panel--expanded': $.get(expanded) });
+		$.set_text(text, $.get(heading));
+		$.set_text(text_1, $label());
+	});
+
+	$.append($$anchor, div);
+	$.pop();
+	$$cleanup();
+}

--- a/benches/printer-corpus/11-store-heavy-legacy.esrap.js
+++ b/benches/printer-corpus/11-store-heavy-legacy.esrap.js
@@ -1,0 +1,286 @@
+import 'svelte/internal/disclose-version';
+import 'svelte/internal/flags/legacy';
+import * as $ from 'svelte/internal/client';
+import { getContext } from 'svelte';
+import { writable, derived, get } from 'svelte/store';
+
+var root = $.from_html(`<input/>`);
+var root_1 = $.from_html(`<button type="button"> </button>`);
+var root_2 = $.from_html(`<tr><td class="svelte-15juqoh"><input type="checkbox"/></td><td class="svelte-15juqoh"> </td><td class="svelte-15juqoh"><!></td><td class="svelte-15juqoh"> </td><td class="svelte-15juqoh"> </td></tr>`);
+var root_3 = $.from_html(`<tr><td colspan="5" class="svelte-15juqoh">No matching rows</td></tr>`);
+var root_4 = $.from_html(`<section><header><h3> </h3> <input type="search" placeholder="Filter owner"/> <span> </span></header> <table><thead><tr><th class="svelte-15juqoh"><input type="checkbox"/></th><th class="svelte-15juqoh">#</th><th class="svelte-15juqoh">Owner</th><th class="svelte-15juqoh">Status</th><th class="svelte-15juqoh">Estimate</th></tr></thead><tbody></tbody><tfoot><tr><td colspan="4" class="svelte-15juqoh">Total</td><td class="svelte-15juqoh"> </td></tr></tfoot></table></section>`);
+
+export default function Component($$anchor, $$props) {
+	$.push($$props, false);
+
+	const $query = () => $.store_get(query, '$query', $$stores);
+	const $rows = () => $.store_get(rows, '$rows', $$stores);
+	const $sortKey = () => $.store_get(sortKey, '$sortKey', $$stores);
+	const $ascending = () => $.store_get(ascending, '$ascending', $$stores);
+	const $totals = () => $.store_get(totals, '$totals', $$stores);
+	const $selection = () => $.store_get(selection, '$selection', $$stores);
+	const $theme = () => $.store_get(theme, '$theme', $$stores);
+	const [$$stores, $$cleanup] = $.setup_stores();
+	const needle = $.mutable_source();
+	const matched = $.mutable_source();
+	const sorted = $.mutable_source();
+	const open = $.mutable_source();
+	const blocked = $.mutable_source();
+	const overrun = $.mutable_source();
+	const selectedCount = $.mutable_source();
+	const allSelected = $.mutable_source();
+	let boardId = $.prop($$props, 'boardId', 8);
+	let title = $.prop($$props, 'title', 8, 'Board');
+	let compact = $.prop($$props, 'compact', 8, false);
+	const rows = getContext('rows');
+	const query = writable('');
+	const sortKey = writable('id');
+	const ascending = writable(true);
+	const selection = writable(new Set());
+	const theme = getContext('theme');
+
+	const totals = derived(rows, ($rows) => ({
+		estimate: $rows.reduce((n, r) => n + r.estimate, 0),
+		spent: $rows.reduce((n, r) => n + r.spent, 0)
+	}));
+
+	let editing = $.mutable_source(null);
+	let draft = $.mutable_source('');
+
+	function toggle(id) {
+		selection.update((set) => {
+			const next = new Set(set);
+
+			if (next.has(id)) next.delete(id); else next.add(id);
+
+			return next;
+		});
+	}
+
+	function toggleAll() {
+		selection.set($.get(allSelected) ? new Set() : new Set($.get(sorted).map((r) => r.id)));
+	}
+
+	function sortBy(key) {
+		if (get(sortKey) === key) ascending.update((v) => !v); else {
+			sortKey.set(key);
+			ascending.set(true);
+		}
+	}
+
+	function commit(row) {
+		$.store_set(rows, $rows().map((r) => r.id === row.id ? { ...r, owner: $.get(draft) } : r));
+		$.set(editing, null);
+	}
+
+	$.legacy_pre_effect(() => $query(), () => {
+		$.set(needle, $query().trim().toLowerCase());
+	});
+
+	$.legacy_pre_effect(() => ($.get(needle), $rows()), () => {
+		$.set(matched, $.get(needle)
+			? $rows().filter((r) => r.owner.toLowerCase().includes($.get(needle)))
+			: $rows());
+	});
+
+	$.legacy_pre_effect(() => ($.get(matched), $sortKey(), $ascending()), () => {
+		$.set(sorted, [...$.get(matched)].sort((a, b) => {
+			const key = $sortKey();
+			const dir = $ascending() ? 1 : -1;
+
+			return a[key] > b[key] ? dir : a[key] < b[key] ? -dir : 0;
+		}));
+	});
+
+	$.legacy_pre_effect(() => $.get(sorted), () => {
+		$.set(open, $.get(sorted).filter((r) => r.status === 'open').length);
+	});
+
+	$.legacy_pre_effect(() => $.get(sorted), () => {
+		$.set(blocked, $.get(sorted).filter((r) => r.status === 'blocked').length);
+	});
+
+	$.legacy_pre_effect(() => $totals(), () => {
+		$.set(overrun, $totals().spent > $totals().estimate);
+	});
+
+	$.legacy_pre_effect(() => $selection(), () => {
+		$.set(selectedCount, $selection().size);
+	});
+
+	$.legacy_pre_effect(() => ($.get(sorted), $.get(selectedCount)), () => {
+		$.set(allSelected, $.get(sorted).length > 0 && $.get(selectedCount) === $.get(sorted).length);
+	});
+
+	$.legacy_pre_effect(() => ($.get(overrun), $.deep_read_state(boardId()), $totals()), () => {
+		if ($.get(overrun)) {
+			console.warn('over estimate on', boardId(), $totals().spent, $totals().estimate);
+		}
+	});
+
+	$.legacy_pre_effect_reset();
+	$.init();
+
+	var section = root_4();
+	let classes;
+	var header = $.child(section);
+	var h3 = $.child(header);
+	var text = $.child(h3, true);
+
+	$.reset(h3);
+
+	var input = $.sibling(h3, 2);
+
+	$.remove_input_defaults(input);
+
+	var span = $.sibling(input, 2);
+	var text_1 = $.child(span);
+
+	$.reset(span);
+	$.reset(header);
+
+	var table = $.sibling(header, 2);
+	var thead = $.child(table);
+	var tr = $.child(thead);
+	var th = $.child(tr);
+	var input_1 = $.child(th);
+
+	$.remove_input_defaults(input_1);
+	$.reset(th);
+
+	var th_1 = $.sibling(th);
+	var th_2 = $.sibling(th_1);
+	var th_3 = $.sibling(th_2);
+	var th_4 = $.sibling(th_3);
+
+	$.reset(tr);
+	$.reset(thead);
+
+	var tbody = $.sibling(thead);
+
+	$.each(
+		tbody,
+		5,
+		() => $.get(sorted),
+		(row) => row.id,
+		($$anchor, row) => {
+			var tr_1 = root_2();
+			let classes_1;
+			var td = $.child(tr_1);
+			var input_2 = $.child(td);
+
+			$.reset(td);
+
+			var td_1 = $.sibling(td);
+			var text_2 = $.child(td_1, true);
+
+			$.reset(td_1);
+
+			var td_2 = $.sibling(td_1);
+			var node = $.child(td_2);
+
+			{
+				var consequent = ($$anchor) => {
+					var input_3 = root();
+
+					$.remove_input_defaults(input_3);
+					$.bind_value(input_3, () => $.get(draft), ($$value) => $.set(draft, $$value));
+					$.event('blur', input_3, () => commit($.get(row)));
+					$.append($$anchor, input_3);
+				};
+
+				var alternate = ($$anchor) => {
+					var button = root_1();
+					var text_3 = $.child(button, true);
+
+					$.reset(button);
+					$.template_effect(() => $.set_text(text_3, ($.get(row), $.untrack(() => $.get(row).owner))));
+
+					$.event('click', button, () => {
+						$.set(editing, $.get(row).id);
+						$.set(draft, $.get(row).owner);
+					});
+
+					$.append($$anchor, button);
+				};
+
+				$.if(node, ($$render) => {
+					if ((
+						$.get(editing),
+						$.get(row),
+						$.untrack(() => $.get(editing) === $.get(row).id)
+					)) $$render(consequent); else $$render(alternate, -1);
+				});
+			}
+
+			$.reset(td_2);
+
+			var td_3 = $.sibling(td_2);
+			var text_4 = $.child(td_3, true);
+
+			$.reset(td_3);
+
+			var td_4 = $.sibling(td_3);
+			var text_5 = $.child(td_4);
+
+			$.reset(td_4);
+			$.reset(tr_1);
+
+			$.template_effect(
+				($0) => {
+					classes_1 = $.set_class(tr_1, 1, 'svelte-15juqoh', null, classes_1, $0);
+					$.set_text(text_2, ($.get(row), $.untrack(() => $.get(row).id)));
+					$.set_text(text_4, ($.get(row), $.untrack(() => $.get(row).status)));
+					$.set_text(text_5, `${($.get(row), $.untrack(() => $.get(row).estimate)) ?? ''}h / ${($.get(row), $.untrack(() => $.get(row).spent)) ?? ''}h`);
+				},
+				[
+					() => ({
+						selected: $selection().has($.get(row).id),
+						blocked: $.get(row).status === 'blocked'
+					})
+				]
+			);
+
+			$.event('change', input_2, () => toggle($.get(row).id));
+			$.append($$anchor, tr_1);
+		},
+		($$anchor) => {
+			var tr_2 = root_3();
+
+			$.append($$anchor, tr_2);
+		}
+	);
+
+	$.reset(tbody);
+
+	var tfoot = $.sibling(tbody);
+	var tr_3 = $.child(tfoot);
+	let classes_2;
+	var td_5 = $.sibling($.child(tr_3));
+	var text_6 = $.child(td_5);
+
+	$.reset(td_5);
+	$.reset(tr_3);
+	$.reset(tfoot);
+	$.reset(table);
+	$.reset(section);
+
+	$.template_effect(() => {
+		classes = $.set_class(section, 1, `board ${$theme() ?? ''}`, 'svelte-15juqoh', classes, { compact: compact() });
+		$.set_text(text, title());
+		$.set_text(text_1, `${$.get(open) ?? ''} open · ${$.get(blocked) ?? ''} blocked · ${$.get(selectedCount) ?? ''} selected`);
+		$.set_checked(input_1, $.get(allSelected));
+		classes_2 = $.set_class(tr_3, 1, 'svelte-15juqoh', null, classes_2, { overrun: $.get(overrun) });
+		$.set_text(text_6, `${($totals(), $.untrack(() => $totals().estimate)) ?? ''}h / ${($totals(), $.untrack(() => $totals().spent)) ?? ''}h`);
+	});
+
+	$.bind_value(input, $query, ($$value) => $.store_set(query, $$value));
+	$.event('change', input_1, toggleAll);
+	$.event('click', th_1, () => sortBy('id'));
+	$.event('click', th_2, () => sortBy('owner'));
+	$.event('click', th_3, () => sortBy('status'));
+	$.event('click', th_4, () => sortBy('estimate'));
+	$.append($$anchor, section);
+	$.pop();
+	$$cleanup();
+}

--- a/benches/printer-corpus/12-comments-common.js
+++ b/benches/printer-corpus/12-comments-common.js
@@ -1,0 +1,11 @@
+/* Initialize shared state. */
+const state = { count: 0 };
+
+// Update the state before exporting it.
+function increment(step = 1) {
+	state.count += step;
+	return state.count;
+}
+
+/** Public counter API. */
+export { increment, state };

--- a/benches/printer-corpus/README.md
+++ b/benches/printer-corpus/README.md
@@ -1,0 +1,13 @@
+# Printer benchmark corpus
+
+The first eleven files are fixed CSR outputs generated from `benches/corpus/*.svelte` by
+rsvelte at commit `38b4f2a56`, with a terminal newline added. They are committed so
+compiler-transform changes cannot move the printer workload. `12-comments-common.js` adds
+the statement-level comments supported by all three compared printers.
+
+CI parses each input once and measures code-only, decoded-source-map, and common-comment
+printing for `rsvelte_esrap` and `oxc_codegen`. The site report runs the same cases with
+JavaScript `esrap` 2.3.2 on the same native runner. Parsing is outside every timed sample.
+
+`manifest.json` records each input digest and the aggregate workload digest. Update both only
+when intentionally changing the benchmark population.

--- a/benches/printer-corpus/manifest.json
+++ b/benches/printer-corpus/manifest.json
@@ -1,0 +1,56 @@
+{
+  "schemaVersion": 1,
+  "generatorCommit": "38b4f2a56",
+  "source": "benches/corpus/*.svelte CSR output",
+  "workloadSha256": "ff9da0754e9b93046a3958e914e569586cebbea81299a5c438aaed5d94130dc6",
+  "files": [
+    {
+      "path": "01-runes-counter.esrap.js",
+      "sha256": "26d407458363392d9f633df10c94f194d91f6955b06b3771926739b9a948c378"
+    },
+    {
+      "path": "02-todo-app.esrap.js",
+      "sha256": "2ed35f734e1903c1a393ef2de09ee9b23a5071e4ef3edb92fde571d652f40a43"
+    },
+    {
+      "path": "03-data-table.esrap.js",
+      "sha256": "c50b2df461e2da9b39da58a22ccca993f937356371d2c4e02cafe78492df2f83"
+    },
+    {
+      "path": "04-form-bindings.esrap.js",
+      "sha256": "c47fe89e462a887bafa2af6668158178c74c76387ea4daba85475cfdb2d3e157"
+    },
+    {
+      "path": "05-legacy-reactive.esrap.js",
+      "sha256": "122dd701c0c1a24f37cb6cbd575babd2f8380475b905cb16d292207aec3738b2"
+    },
+    {
+      "path": "06-css-heavy.esrap.js",
+      "sha256": "e0760d8d2b54bb3d8a8ed70782f3db3cc3728f50c4722713ea2bbe86c51e2aa1"
+    },
+    {
+      "path": "07-snippets.esrap.js",
+      "sha256": "f00cf06c3a2415ba0007c30116ab0abf5f8e545e2ac26f38b1adb06c9256ff05"
+    },
+    {
+      "path": "08-control-flow.esrap.js",
+      "sha256": "def7d347d396579d4b67c9117c4d5b4b7cd08e78d23fb6dcdfabc2fa0865c5b5"
+    },
+    {
+      "path": "09-typescript-generics.esrap.js",
+      "sha256": "58c9d86a5b009a4963347ccd6cbdc3e2f223632e04db0c0dd8f282cb846bbf71"
+    },
+    {
+      "path": "10-legacy-typescript-props.esrap.js",
+      "sha256": "4544980d58194d4d74a22de86dc5c58a3c58021f0cd3142137bfe0c9dfe0cb49"
+    },
+    {
+      "path": "11-store-heavy-legacy.esrap.js",
+      "sha256": "7e85cc3ee962fb3bd81db11c6dc463c62a8c56eecee9b02ccbeb428e8b7c4be6"
+    },
+    {
+      "path": "12-comments-common.js",
+      "sha256": "0f1d2759952408d0ae0ab37d5c92929df95dab845133415c137ceff59df6bbc5"
+    }
+  ]
+}

--- a/compatibility/gate-coverage.md
+++ b/compatibility/gate-coverage.md
@@ -109,7 +109,7 @@ samples) — see `AGENTS.md` § "Generated shape matrix" and issue #2281.
 | 23 | Escaped-quote lookback shape | one line of Rust source, over every `.rs` under `crates/` + `apps/` | it matches a **spelling**; a scanner with *no* escape check at all produces no line to match | [D] |
 | 24 | `await_waterfall` runtime parity | the `await_waterfall` warnings a **mounted** rsvelte-compiled component logs vs. official's, 3 cases | one warning code, one component shape; nothing else about the running component is observed | [D] |
 | 25 | Differential output-preservation corpus hash | per `.svelte` source × client/server/client-dev/server-dev hash from base-core vs merge-ref-core | changes outside `crates/rsvelte_core`; every PR without the maintainer-applied `output-preserving` label | [S] |
-| 26 | esrap generated-output corpus | parsed JS output × official/rsvelte tree × 4 targets; AST equivalence, raw comments, code/map equality, map bounds/order | production synthetic AST spans and whether a mapping points at the corresponding source token | [S] |
+| 26 | esrap generated-output corpus | parsed JS output × official/rsvelte tree × 4 targets; AST equivalence, comment kind/body sequence, code/map equality, map bounds/order | production synthetic AST spans and whether a mapping points at the corresponding source token | [S] |
 
 Cross-cutting blind spots (**ratchet keys losing in both directions**, path filters, ratchet-doc
 drift, vacuity floors, the **performance**
@@ -121,8 +121,9 @@ are in [§ Cross-cutting](#cross-cutting) at the end.
 **Unit.** Every available JavaScript output in both `expected/` and `actual/`, across
 client, server, client-dev and server-dev, is parsed with OXC and printed by
 `rsvelte_esrap` with and without mappings. The gate requires semantic AST equivalence,
-identical code from the mapped and unmapped APIs, ordered raw comment-text preservation,
-and ordered in-bounds mapping coordinates. It rejects fewer than 12,000 outputs in any
+identical code from the mapped and unmapped APIs, ordered comment kind/body preservation,
+and ordered in-bounds mapping coordinates. Block bodies use esrap's own indentation dedent,
+so layout-only re-indentation is not a content divergence. It rejects fewer than 12,000 outputs in any
 tree/target and records the measured population in `esrap-report.json`.
 
 **Blind spot 26a — reparsing erases production AST provenance.** The gate consumes compiler

--- a/compatibility/gate-coverage.md
+++ b/compatibility/gate-coverage.md
@@ -122,8 +122,9 @@ are in [§ Cross-cutting](#cross-cutting) at the end.
 client, server, client-dev and server-dev, is parsed with OXC and printed by
 `rsvelte_esrap` with and without mappings. The gate requires semantic AST equivalence,
 identical code from the mapped and unmapped APIs, ordered comment kind/body preservation,
-and ordered in-bounds mapping coordinates. Block bodies use esrap's own indentation dedent,
-so layout-only re-indentation is not a content divergence. It rejects fewer than 12,000 outputs in any
+and ordered in-bounds mapping coordinates. Block bodies discard the common indentation of
+their continuation lines, so layout-only re-indentation is not a content divergence while
+relative indentation remains observable. It rejects fewer than 12,000 outputs in any
 tree/target and records the measured population in `esrap-report.json`.
 
 **Blind spot 26a — reparsing erases production AST provenance.** The gate consumes compiler

--- a/compatibility/gate-coverage.md
+++ b/compatibility/gate-coverage.md
@@ -109,11 +109,34 @@ samples) — see `AGENTS.md` § "Generated shape matrix" and issue #2281.
 | 23 | Escaped-quote lookback shape | one line of Rust source, over every `.rs` under `crates/` + `apps/` | it matches a **spelling**; a scanner with *no* escape check at all produces no line to match | [D] |
 | 24 | `await_waterfall` runtime parity | the `await_waterfall` warnings a **mounted** rsvelte-compiled component logs vs. official's, 3 cases | one warning code, one component shape; nothing else about the running component is observed | [D] |
 | 25 | Differential output-preservation corpus hash | per `.svelte` source × client/server/client-dev/server-dev hash from base-core vs merge-ref-core | changes outside `crates/rsvelte_core`; every PR without the maintainer-applied `output-preserving` label | [S] |
+| 26 | esrap generated-output corpus | parsed JS output × official/rsvelte tree × 4 targets; AST equivalence, raw comments, code/map equality, map bounds/order | production synthetic AST spans and whether a mapping points at the corresponding source token | [S] |
 
 Cross-cutting blind spots (**ratchet keys losing in both directions**, path filters, ratchet-doc
 drift, vacuity floors, the **performance**
 gates' population, and **an uninitialised corpus source shrinking every corpus gate silently**)
 are in [§ Cross-cutting](#cross-cutting) at the end.
+
+## 26. esrap generated-output corpus — `scripts/compat-corpus/esrap-verify.mjs`
+
+**Unit.** Every available JavaScript output in both `expected/` and `actual/`, across
+client, server, client-dev and server-dev, is parsed with OXC and printed by
+`rsvelte_esrap` with and without mappings. The gate requires semantic AST equivalence,
+identical code from the mapped and unmapped APIs, ordered raw comment-text preservation,
+and ordered in-bounds mapping coordinates. It rejects fewer than 12,000 outputs in any
+tree/target and records the measured population in `esrap-report.json`.
+
+**Blind spot 26a — reparsing erases production AST provenance.** The gate consumes compiler
+text from `expected/` and `actual/` and constructs a fresh OXC `Program`; it never
+passes rsvelte's synthetic phase-3 AST, its `loc_map`, or original synthesized spans to the
+printer. A defect reachable only before compiler output is materialized is therefore outside
+this population. **Evidence [S]:** `esrap-verify.mjs` passes only file paths to
+`esrap_corpus`, whose `parse` function constructs every tested `Program` from file text.
+
+**Blind spot 26b — mapping validity is structural, not semantic.** `validate_mappings`
+checks generated ordering and source/generated bounds, but it does not resolve a mapping and
+compare the generated token with the source token. A mapping can point to the wrong in-bounds
+location and pass. **Evidence [S]:** those are the only predicates read from each `Mapping`
+in `esrap_corpus.rs`.
 
 ## 25. Differential output-preservation corpus hash
 
@@ -2025,6 +2048,7 @@ while `sourcemap-known-failures.json` has 74.** Already drifted, in an unchecked
 | Gate | Floor | Cite |
 |---|---|---|
 | corpus verify | manifest ≥ 1000; ≥99% compiled; ≥12000 to rebaseline | `verify.mjs:204,224`; `artifacts.mjs:79` |
+| esrap generated-output corpus | ≥12000 JavaScript outputs and ≥1 comment-bearing output in each tree × target | `esrap-verify.mjs` population loop and per-population `esrap_corpus` invocation |
 | svelte2tsx verify | manifest ≥ 1000 components; ≥12000 to rebaseline | `svelte2tsx-verify.mjs:85,237` |
 | fmt verify | `included` ≥ 1000 — **but not the comparisons performed** | `fmt-verify.mjs:69`; gap at `:97` |
 | lint verify | manifest ≥ 1000; ≥99% with a source on disk; ≥6000 **and** repo set == `CI_REPOS` to rebaseline; ≥1 module compared; 0 unmeasured | `lint-verify.mjs:39,44,47,218-236`; **no universe floor** — gap at `:239` |

--- a/crates/rsvelte_bench/Cargo.toml
+++ b/crates/rsvelte_bench/Cargo.toml
@@ -6,9 +6,15 @@ publish = false
 
 [dependencies]
 rsvelte_core = { path = "../rsvelte_core" }
+rsvelte_esrap = { path = "../rsvelte_esrap" }
 
 [dev-dependencies]
 criterion = { version = "5.0.0", features = ["html_reports"], package = "codspeed-criterion-compat" }
+oxc_allocator = "0.144"
+oxc_ast = "0.144"
+oxc_codegen = "0.144"
+oxc_parser = "0.144"
+oxc_span = "0.144"
 
 [[bench]]
 name = "ci"

--- a/crates/rsvelte_bench/benches/ci.rs
+++ b/crates/rsvelte_bench/benches/ci.rs
@@ -1,6 +1,25 @@
 use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use oxc_allocator::Allocator;
+use oxc_codegen::{Codegen, CodegenOptions};
+use oxc_parser::{ParseOptions, Parser};
+use oxc_span::SourceType;
 use rsvelte_core::{CompileOptions, GenerateMode, compile, compile_both};
 use std::hint::black_box;
+
+const PRINTER_SOURCES: [&str; 11] = [
+    include_str!("../../../benches/printer-corpus/01-runes-counter.esrap.js"),
+    include_str!("../../../benches/printer-corpus/02-todo-app.esrap.js"),
+    include_str!("../../../benches/printer-corpus/03-data-table.esrap.js"),
+    include_str!("../../../benches/printer-corpus/04-form-bindings.esrap.js"),
+    include_str!("../../../benches/printer-corpus/05-legacy-reactive.esrap.js"),
+    include_str!("../../../benches/printer-corpus/06-css-heavy.esrap.js"),
+    include_str!("../../../benches/printer-corpus/07-snippets.esrap.js"),
+    include_str!("../../../benches/printer-corpus/08-control-flow.esrap.js"),
+    include_str!("../../../benches/printer-corpus/09-typescript-generics.esrap.js"),
+    include_str!("../../../benches/printer-corpus/10-legacy-typescript-props.esrap.js"),
+    include_str!("../../../benches/printer-corpus/11-store-heavy-legacy.esrap.js"),
+];
+const COMMENT_SOURCE: &str = include_str!("../../../benches/printer-corpus/12-comments-common.js");
 
 struct Case {
     id: &'static str,
@@ -67,5 +86,117 @@ fn bench_compile_both(c: &mut Criterion) {
     group.finish();
 }
 
-criterion_group!(benches, bench_compile, bench_compile_both);
+fn bench_printers(c: &mut Criterion) {
+    let allocator = Allocator::default();
+    let programs: Vec<_> = PRINTER_SOURCES
+        .iter()
+        .map(|source| parse(&allocator, source))
+        .collect();
+    let comment_allocator = Allocator::default();
+    let comment_programs = [parse(&comment_allocator, COMMENT_SOURCE)];
+    let print_options = rsvelte_esrap::PrintOptions::default().with_empty_statements(true);
+
+    let mut group = c.benchmark_group("printer/parsed-no-map");
+    group.throughput(Throughput::Bytes(
+        PRINTER_SOURCES
+            .iter()
+            .map(|source| source.len() as u64)
+            .sum(),
+    ));
+    group.bench_function("rsvelte-esrap", |b| {
+        b.iter(|| {
+            for (program, source) in programs.iter().zip(PRINTER_SOURCES) {
+                black_box(rsvelte_esrap::print_with(program, source, &print_options));
+            }
+        })
+    });
+    group.bench_function("oxc-codegen", |b| {
+        b.iter(|| {
+            for program in &programs {
+                black_box(
+                    Codegen::new()
+                        .with_options(CodegenOptions {
+                            single_quote: true,
+                            ..CodegenOptions::default()
+                        })
+                        .build(program),
+                );
+            }
+        })
+    });
+    group.finish();
+
+    let mut group = c.benchmark_group("printer/decoded-map");
+    group.throughput(Throughput::Bytes(
+        PRINTER_SOURCES
+            .iter()
+            .map(|source| source.len() as u64)
+            .sum(),
+    ));
+    group.bench_function("rsvelte-esrap", |b| {
+        b.iter(|| {
+            for (program, source) in programs.iter().zip(PRINTER_SOURCES) {
+                black_box(rsvelte_esrap::print_with_map(
+                    program,
+                    source,
+                    &print_options,
+                ));
+            }
+        })
+    });
+    group.bench_function("oxc-codegen", |b| {
+        b.iter(|| {
+            for program in &programs {
+                black_box(
+                    Codegen::new()
+                        .with_options(CodegenOptions {
+                            single_quote: true,
+                            source_map_path: Some("input.js".into()),
+                            ..CodegenOptions::default()
+                        })
+                        .build(program),
+                );
+            }
+        })
+    });
+    group.finish();
+
+    let mut group = c.benchmark_group("printer/comments-common");
+    group.throughput(Throughput::Bytes(COMMENT_SOURCE.len() as u64));
+    group.bench_function("rsvelte-esrap", |b| {
+        b.iter(|| {
+            black_box(rsvelte_esrap::print_with(
+                &comment_programs[0],
+                COMMENT_SOURCE,
+                &print_options,
+            ))
+        })
+    });
+    group.bench_function("oxc-codegen", |b| {
+        b.iter(|| {
+            black_box(
+                Codegen::new()
+                    .with_options(CodegenOptions {
+                        single_quote: true,
+                        ..CodegenOptions::default()
+                    })
+                    .build(&comment_programs[0]),
+            )
+        })
+    });
+    group.finish();
+}
+
+fn parse<'a>(allocator: &'a Allocator, source: &'a str) -> oxc_ast::ast::Program<'a> {
+    let parsed = Parser::new(allocator, source, SourceType::mjs())
+        .with_options(ParseOptions {
+            preserve_parens: true,
+            ..ParseOptions::default()
+        })
+        .parse();
+    assert!(!parsed.panicked && parsed.diagnostics.is_empty());
+    parsed.program
+}
+
+criterion_group!(benches, bench_compile, bench_compile_both, bench_printers);
 criterion_main!(benches);

--- a/crates/rsvelte_core/Cargo.toml
+++ b/crates/rsvelte_core/Cargo.toml
@@ -94,7 +94,7 @@ oxc_ast = { version = "0.144", features = ["serialize"] }
 oxc_span = "0.144"
 oxc_diagnostics = "0.144"
 oxc_codegen = "0.144"
-rsvelte_esrap = { version = "=0.10.26", path = "../rsvelte_esrap" }
+rsvelte_esrap = { version = "=0.10.27", path = "../rsvelte_esrap" }
 oxc_syntax = "0.144"
 oxc_semantic = "0.144"
 

--- a/crates/rsvelte_devtools/Cargo.toml
+++ b/crates/rsvelte_devtools/Cargo.toml
@@ -40,6 +40,7 @@ rsvelte_projection = { path = "../rsvelte_projection" }
 backtrace = "0.3"
 chrono = "0.4"
 oxc_allocator = "0.144"
+oxc_ast = "0.144"
 oxc_codegen = "0.144"
 oxc_formatter = { git = "https://github.com/oxc-project/oxc", rev = "b6f1458dece6bbd7f934d1d26c049d0d0c2bd68c", optional = true }
 oxc_parser = "0.144"

--- a/crates/rsvelte_devtools/src/bin/esrap_corpus.rs
+++ b/crates/rsvelte_devtools/src/bin/esrap_corpus.rs
@@ -81,7 +81,7 @@ fn main() {
             report.comment_files += 1;
             report.comments += parsed.program.comments.len();
         }
-        let input_comments = comment_texts(&parsed.program, &source);
+        let input_comments = comment_bodies(&parsed.program, &source);
         let plain = rsvelte_esrap::print_with(&parsed.program, &source, &options);
         let mapped = rsvelte_esrap::print_with_map(&parsed.program, &source, &options);
         if plain != mapped.code {
@@ -113,10 +113,10 @@ fn main() {
             ));
             continue;
         }
-        let output_comments = comment_texts(&output.program, &plain);
+        let output_comments = comment_bodies(&output.program, &plain);
         if input_comments != output_comments {
             failures.push(format!(
-                "{}: comments changed: input={input_comments:?}, output={output_comments:?}",
+                "{}: comment kinds or bodies changed: input={input_comments:?}, output={output_comments:?}",
                 path.display()
             ));
             continue;
@@ -166,12 +166,50 @@ fn parse<'a>(allocator: &'a Allocator, source: &'a str) -> oxc_parser::ParserRet
         .parse()
 }
 
-fn comment_texts(program: &Program<'_>, source: &str) -> Vec<String> {
+fn comment_bodies(program: &Program<'_>, source: &str) -> Vec<(bool, String)> {
     program
         .comments
         .iter()
-        .map(|comment| comment.span().source_text(source).to_string())
+        .map(|comment| {
+            let span = comment.span();
+            let raw = span.source_text(source);
+            let block = !matches!(comment.kind, oxc_ast::ast::CommentKind::Line);
+            let value = if block {
+                let inner = raw
+                    .strip_prefix("/*")
+                    .and_then(|text| text.strip_suffix("*/"))
+                    .unwrap_or(raw);
+                dedent_comment(source, span.start, inner)
+            } else {
+                raw.strip_prefix("//").unwrap_or(raw).to_string()
+            };
+            (block, value)
+        })
         .collect()
+}
+
+fn dedent_comment(source: &str, start: u32, inner: &str) -> String {
+    if !inner.contains('\n') {
+        return inner.to_string();
+    }
+    let bytes = source.as_bytes();
+    let mut line_start = start as usize;
+    while line_start > 0 && bytes[line_start - 1] != b'\n' {
+        line_start -= 1;
+    }
+    let mut content_start = line_start;
+    while content_start < bytes.len() && matches!(bytes[content_start], b' ' | b'\t') {
+        content_start += 1;
+    }
+    let indentation = &source[line_start..content_start];
+    if indentation.is_empty() {
+        return inner.to_string();
+    }
+    let mut normalized = String::with_capacity(inner.len());
+    for line in inner.split_inclusive('\n') {
+        normalized.push_str(line.strip_prefix(indentation).unwrap_or(line));
+    }
+    normalized
 }
 
 fn validate_mappings(
@@ -209,4 +247,25 @@ fn parse_usize(value: Option<String>, fallback: usize) -> usize {
     value
         .and_then(|value| value.parse().ok())
         .unwrap_or(fallback)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{comment_bodies, parse};
+    use oxc_allocator::Allocator;
+
+    #[test]
+    fn comment_bodies_ignore_printer_reindentation() {
+        let input_source = "/** first\n * second */";
+        let output_source = "\t/** first\n\t * second */";
+        let input_allocator = Allocator::default();
+        let output_allocator = Allocator::default();
+        let input = parse(&input_allocator, input_source);
+        let output = parse(&output_allocator, output_source);
+
+        assert_eq!(
+            comment_bodies(&input.program, input_source),
+            comment_bodies(&output.program, output_source)
+        );
+    }
 }

--- a/crates/rsvelte_devtools/src/bin/esrap_corpus.rs
+++ b/crates/rsvelte_devtools/src/bin/esrap_corpus.rs
@@ -179,7 +179,7 @@ fn comment_bodies(program: &Program<'_>, source: &str) -> Vec<(bool, String)> {
                     .strip_prefix("/*")
                     .and_then(|text| text.strip_suffix("*/"))
                     .unwrap_or(raw);
-                dedent_comment(source, span.start, inner)
+                normalize_block_comment(inner)
             } else {
                 raw.strip_prefix("//").unwrap_or(raw).to_string()
             };
@@ -188,26 +188,41 @@ fn comment_bodies(program: &Program<'_>, source: &str) -> Vec<(bool, String)> {
         .collect()
 }
 
-fn dedent_comment(source: &str, start: u32, inner: &str) -> String {
+fn normalize_block_comment(inner: &str) -> String {
     if !inner.contains('\n') {
         return inner.to_string();
     }
-    let bytes = source.as_bytes();
-    let mut line_start = start as usize;
-    while line_start > 0 && bytes[line_start - 1] != b'\n' {
-        line_start -= 1;
+
+    let mut common_indent: Option<&str> = None;
+    for line in inner.split('\n').skip(1) {
+        let indent_len = line
+            .as_bytes()
+            .iter()
+            .take_while(|&&byte| matches!(byte, b' ' | b'\t'))
+            .count();
+        let indentation = &line[..indent_len];
+        common_indent = Some(match common_indent {
+            None => indentation,
+            Some(common) => {
+                let common_len = common
+                    .bytes()
+                    .zip(indentation.bytes())
+                    .take_while(|(left, right)| left == right)
+                    .count();
+                &common[..common_len]
+            }
+        });
     }
-    let mut content_start = line_start;
-    while content_start < bytes.len() && matches!(bytes[content_start], b' ' | b'\t') {
-        content_start += 1;
-    }
-    let indentation = &source[line_start..content_start];
-    if indentation.is_empty() {
-        return inner.to_string();
-    }
+
+    let common_indent = common_indent.unwrap_or_default();
     let mut normalized = String::with_capacity(inner.len());
-    for line in inner.split_inclusive('\n') {
-        normalized.push_str(line.strip_prefix(indentation).unwrap_or(line));
+    for (index, line) in inner.split('\n').enumerate() {
+        if index > 0 {
+            normalized.push('\n');
+            normalized.push_str(line.strip_prefix(common_indent).unwrap_or(line));
+        } else {
+            normalized.push_str(line);
+        }
     }
     normalized
 }
@@ -256,8 +271,8 @@ mod tests {
 
     #[test]
     fn comment_bodies_ignore_printer_reindentation() {
-        let input_source = "/** first\n * second */";
-        let output_source = "\t/** first\n\t * second */";
+        let input_source = "/** first\n\t * second\n\t */";
+        let output_source = "\t/** first\n\t\t * second\n\t\t */";
         let input_allocator = Allocator::default();
         let output_allocator = Allocator::default();
         let input = parse(&input_allocator, input_source);

--- a/crates/rsvelte_devtools/src/bin/esrap_corpus.rs
+++ b/crates/rsvelte_devtools/src/bin/esrap_corpus.rs
@@ -1,0 +1,212 @@
+//! Large-corpus round-trip and source-map gate for `rsvelte_esrap`.
+
+use std::fs;
+use std::path::PathBuf;
+
+use oxc_allocator::Allocator;
+use oxc_ast::ast::Program;
+use oxc_parser::{ParseOptions, Parser};
+use oxc_span::{GetSpan, SourceType};
+use rsvelte_ast_equiv::Comparison;
+use serde::Serialize;
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct Report {
+    files: usize,
+    bytes: usize,
+    comment_files: usize,
+    comments: usize,
+    mapped_files: usize,
+    mappings: usize,
+}
+
+fn main() {
+    let mut file_list = None;
+    let mut minimum_files = 1;
+    let mut minimum_comment_files = 0;
+
+    let mut args = std::env::args().skip(1);
+    while let Some(arg) = args.next() {
+        match arg.as_str() {
+            "--files" => file_list = args.next(),
+            "--minimum-files" => minimum_files = parse_usize(args.next(), minimum_files),
+            "--minimum-comment-files" => {
+                minimum_comment_files = parse_usize(args.next(), minimum_comment_files);
+            }
+            value => panic!("unknown argument: {value}"),
+        }
+    }
+
+    let file_list = file_list.expect("usage: esrap_corpus --files <path>");
+    let paths: Vec<PathBuf> = fs::read_to_string(&file_list)
+        .unwrap_or_else(|error| panic!("cannot read {file_list}: {error}"))
+        .lines()
+        .filter(|line| !line.is_empty())
+        .map(PathBuf::from)
+        .collect();
+    assert!(
+        paths.len() >= minimum_files,
+        "esrap corpus population is too small: {} files, expected at least {minimum_files}",
+        paths.len()
+    );
+
+    let options = rsvelte_esrap::PrintOptions::default().with_empty_statements(true);
+    let mut report = Report {
+        files: paths.len(),
+        bytes: 0,
+        comment_files: 0,
+        comments: 0,
+        mapped_files: 0,
+        mappings: 0,
+    };
+    let mut failures = Vec::new();
+
+    for path in &paths {
+        let source = fs::read_to_string(path)
+            .unwrap_or_else(|error| panic!("cannot read {}: {error}", path.display()));
+        report.bytes += source.len();
+        let allocator = Allocator::default();
+        let parsed = parse(&allocator, &source);
+        if parsed.panicked || !parsed.diagnostics.is_empty() {
+            failures.push(format!(
+                "{}: input is not valid JavaScript: {:?}",
+                path.display(),
+                parsed.diagnostics.first()
+            ));
+            continue;
+        }
+
+        if !parsed.program.comments.is_empty() {
+            report.comment_files += 1;
+            report.comments += parsed.program.comments.len();
+        }
+        let input_comments = comment_texts(&parsed.program, &source);
+        let plain = rsvelte_esrap::print_with(&parsed.program, &source, &options);
+        let mapped = rsvelte_esrap::print_with_map(&parsed.program, &source, &options);
+        if plain != mapped.code {
+            failures.push(format!(
+                "{}: print_with and print_with_map emitted different code",
+                path.display()
+            ));
+            continue;
+        }
+
+        match rsvelte_ast_equiv::compare(&source, &plain) {
+            Comparison::Equivalent => {}
+            difference => {
+                failures.push(format!(
+                    "{}: printed program changed semantics: {difference:?}",
+                    path.display()
+                ));
+                continue;
+            }
+        }
+
+        let output_allocator = Allocator::default();
+        let output = parse(&output_allocator, &plain);
+        if output.panicked || !output.diagnostics.is_empty() {
+            failures.push(format!(
+                "{}: printer emitted invalid JavaScript: {:?}",
+                path.display(),
+                output.diagnostics.first()
+            ));
+            continue;
+        }
+        let output_comments = comment_texts(&output.program, &plain);
+        if input_comments != output_comments {
+            failures.push(format!(
+                "{}: comments changed: input={input_comments:?}, output={output_comments:?}",
+                path.display()
+            ));
+            continue;
+        }
+
+        if !mapped.mappings.is_empty() {
+            report.mapped_files += 1;
+            report.mappings += mapped.mappings.len();
+        }
+        if let Err(error) = validate_mappings(&mapped.mappings, &plain, &source) {
+            failures.push(format!("{}: {error}", path.display()));
+        }
+    }
+
+    assert!(
+        report.comment_files >= minimum_comment_files,
+        "esrap corpus comment population is too small: {} files, expected at least {minimum_comment_files}",
+        report.comment_files
+    );
+    assert!(
+        report.mapped_files > 0,
+        "esrap corpus produced no source maps"
+    );
+    if !failures.is_empty() {
+        for failure in failures.iter().take(20) {
+            eprintln!("{failure}");
+        }
+        panic!(
+            "esrap corpus failed for {} of {} files",
+            failures.len(),
+            paths.len()
+        );
+    }
+
+    println!(
+        "{}",
+        serde_json::to_string(&report).expect("corpus report serializes")
+    );
+}
+
+fn parse<'a>(allocator: &'a Allocator, source: &'a str) -> oxc_parser::ParserReturn<'a> {
+    Parser::new(allocator, source, SourceType::mjs())
+        .with_options(ParseOptions {
+            preserve_parens: true,
+            ..ParseOptions::default()
+        })
+        .parse()
+}
+
+fn comment_texts(program: &Program<'_>, source: &str) -> Vec<String> {
+    program
+        .comments
+        .iter()
+        .map(|comment| comment.span().source_text(source).to_string())
+        .collect()
+}
+
+fn validate_mappings(
+    mappings: &[rsvelte_esrap::Mapping],
+    generated: &str,
+    source: &str,
+) -> Result<(), String> {
+    let generated_lines: Vec<&str> = generated.split('\n').collect();
+    let source_lines: Vec<&str> = source.split('\n').collect();
+    let mut previous = None;
+
+    for mapping in mappings {
+        let generated_line = mapping.gen_line as usize;
+        let source_line = mapping.source_line as usize;
+        if generated_line >= generated_lines.len()
+            || mapping.gen_column as usize > generated_lines[generated_line].len()
+        {
+            return Err(format!("generated mapping is out of bounds: {mapping:?}"));
+        }
+        if source_line >= source_lines.len()
+            || mapping.source_column as usize > source_lines[source_line].len()
+        {
+            return Err(format!("source mapping is out of bounds: {mapping:?}"));
+        }
+        let position = (mapping.gen_line, mapping.gen_column);
+        if previous.is_some_and(|previous| position < previous) {
+            return Err(format!("generated mappings are not ordered at {mapping:?}"));
+        }
+        previous = Some(position);
+    }
+    Ok(())
+}
+
+fn parse_usize(value: Option<String>, fallback: usize) -> usize {
+    value
+        .and_then(|value| value.parse().ok())
+        .unwrap_or(fallback)
+}

--- a/crates/rsvelte_devtools/src/bin/printer_benchmark_runner.rs
+++ b/crates/rsvelte_devtools/src/bin/printer_benchmark_runner.rs
@@ -1,0 +1,244 @@
+//! Retained-AST benchmark for `rsvelte_esrap` and `oxc_codegen`.
+
+#[cfg(all(
+    feature = "mimalloc-alloc",
+    not(target_arch = "wasm32"),
+    not(target_os = "windows")
+))]
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
+use std::fs;
+use std::hint::black_box;
+use std::path::PathBuf;
+use std::time::Instant;
+
+use oxc_allocator::Allocator;
+use oxc_codegen::{Codegen, CodegenOptions};
+use oxc_parser::{ParseOptions, Parser};
+use oxc_span::{GetSpan, SourceType};
+use serde::Serialize;
+
+#[derive(Clone, Copy, Serialize)]
+#[serde(rename_all = "kebab-case")]
+enum Mode {
+    Code,
+    SourceMap,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct Variant {
+    times_ms: Vec<f64>,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct Report {
+    mode: Mode,
+    files: usize,
+    bytes: usize,
+    comment_files: usize,
+    comments: usize,
+    warmups: usize,
+    runs: usize,
+    batch: usize,
+    work_gate: &'static str,
+    rsvelte_esrap: Variant,
+    oxc_codegen: Variant,
+}
+
+fn main() {
+    let mut file_list = None;
+    let mut warmups = 1;
+    let mut runs = 5;
+    let mut batch = 1;
+    let mut mode = Mode::Code;
+
+    let mut args = std::env::args().skip(1);
+    while let Some(arg) = args.next() {
+        match arg.as_str() {
+            "--files" => file_list = args.next(),
+            "--warmup" => warmups = parse_usize(args.next(), warmups),
+            "--iterations" => runs = parse_usize(args.next(), runs),
+            "--batch" => batch = parse_usize(args.next(), batch),
+            "--mode" => {
+                mode = match args.next().as_deref() {
+                    Some("code") => Mode::Code,
+                    Some("source-map") => Mode::SourceMap,
+                    value => panic!("unknown printer mode: {value:?}"),
+                };
+            }
+            value => panic!("unknown argument: {value}"),
+        }
+    }
+
+    let file_list = file_list.expect("usage: printer_benchmark_runner --files <path>");
+    assert!(runs > 0, "--iterations must be greater than zero");
+    assert!(batch > 0, "--batch must be greater than zero");
+    let paths: Vec<PathBuf> = fs::read_to_string(&file_list)
+        .unwrap_or_else(|error| panic!("cannot read {file_list}: {error}"))
+        .lines()
+        .filter(|line| !line.is_empty())
+        .map(PathBuf::from)
+        .collect();
+    assert!(!paths.is_empty(), "printer benchmark file list is empty");
+
+    let sources: Vec<String> = paths
+        .iter()
+        .map(|path| {
+            fs::read_to_string(path)
+                .unwrap_or_else(|error| panic!("cannot read {}: {error}", path.display()))
+        })
+        .collect();
+    let allocator = Allocator::default();
+    let programs: Vec<_> = sources
+        .iter()
+        .zip(&paths)
+        .map(|(source, path)| {
+            let parsed = Parser::new(&allocator, source, SourceType::mjs())
+                .with_options(ParseOptions {
+                    preserve_parens: true,
+                    ..ParseOptions::default()
+                })
+                .parse();
+            assert!(
+                !parsed.panicked && parsed.diagnostics.is_empty(),
+                "{} is not valid JavaScript: {:?}",
+                path.display(),
+                parsed.diagnostics.first()
+            );
+            parsed.program
+        })
+        .collect();
+
+    let print_options = rsvelte_esrap::PrintOptions::default().with_empty_statements(true);
+    let mut oxc_options = CodegenOptions {
+        single_quote: true,
+        ..CodegenOptions::default()
+    };
+    if matches!(mode, Mode::SourceMap) {
+        oxc_options.source_map_path = Some(PathBuf::from("input.js"));
+    }
+    for (program, source) in programs.iter().zip(&sources) {
+        let expected_comments: Vec<_> = program
+            .comments
+            .iter()
+            .map(|comment| comment.span().source_text(source).to_string())
+            .collect();
+        let esrap_code = match mode {
+            Mode::Code => rsvelte_esrap::print_with(program, source, &print_options),
+            Mode::SourceMap => rsvelte_esrap::print_with_map(program, source, &print_options).code,
+        };
+        let oxc_code = Codegen::new()
+            .with_options(oxc_options.clone())
+            .build(program)
+            .code;
+        assert_valid_output(&esrap_code, "rsvelte/esrap", &expected_comments);
+        assert_valid_output(&oxc_code, "oxc_codegen", &expected_comments);
+    }
+
+    let mut esrap = || match mode {
+        Mode::Code => {
+            for (program, source) in programs.iter().zip(&sources) {
+                black_box(rsvelte_esrap::print_with(program, source, &print_options));
+            }
+        }
+        Mode::SourceMap => {
+            for (program, source) in programs.iter().zip(&sources) {
+                black_box(rsvelte_esrap::print_with_map(
+                    program,
+                    source,
+                    &print_options,
+                ));
+            }
+        }
+    };
+    let mut oxc = || {
+        for program in &programs {
+            black_box(
+                Codegen::new()
+                    .with_options(oxc_options.clone())
+                    .build(program),
+            );
+        }
+    };
+
+    for _ in 0..warmups {
+        for _ in 0..batch {
+            esrap();
+            oxc();
+        }
+    }
+    let mut esrap_times = Vec::with_capacity(runs);
+    let mut oxc_times = Vec::with_capacity(runs);
+    for index in 0..runs {
+        if index % 2 == 0 {
+            esrap_times.push(timed(&mut esrap, batch));
+            oxc_times.push(timed(&mut oxc, batch));
+        } else {
+            oxc_times.push(timed(&mut oxc, batch));
+            esrap_times.push(timed(&mut esrap, batch));
+        }
+    }
+
+    let report = Report {
+        mode,
+        files: sources.len(),
+        bytes: sources.iter().map(String::len).sum(),
+        comment_files: programs
+            .iter()
+            .filter(|program| !program.comments.is_empty())
+            .count(),
+        comments: programs.iter().map(|program| program.comments.len()).sum(),
+        warmups,
+        runs,
+        batch,
+        work_gate: "parseable-output",
+        rsvelte_esrap: Variant {
+            times_ms: esrap_times,
+        },
+        oxc_codegen: Variant {
+            times_ms: oxc_times,
+        },
+    };
+    println!(
+        "{}",
+        serde_json::to_string(&report).expect("benchmark report serializes")
+    );
+}
+
+fn parse_usize(value: Option<String>, fallback: usize) -> usize {
+    value
+        .and_then(|value| value.parse().ok())
+        .unwrap_or(fallback)
+}
+
+fn assert_valid_output(source: &str, label: &str, expected_comments: &[String]) {
+    let allocator = Allocator::default();
+    let parsed = Parser::new(&allocator, source, SourceType::mjs()).parse();
+    assert!(
+        !parsed.panicked && parsed.diagnostics.is_empty(),
+        "{label} emitted invalid JavaScript: {:?}",
+        parsed.diagnostics.first()
+    );
+    let output_comments: Vec<_> = parsed
+        .program
+        .comments
+        .iter()
+        .map(|comment| comment.span().source_text(source))
+        .collect();
+    let expected_comments: Vec<_> = expected_comments.iter().map(String::as_str).collect();
+    assert_eq!(
+        output_comments, expected_comments,
+        "{label} changed comments"
+    );
+}
+
+fn timed(run: &mut dyn FnMut(), batch: usize) -> f64 {
+    let start = Instant::now();
+    for _ in 0..batch {
+        run();
+    }
+    start.elapsed().as_secs_f64() * 1_000.0 / batch as f64
+}

--- a/crates/rsvelte_esrap/Cargo.toml
+++ b/crates/rsvelte_esrap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rsvelte_esrap"
-version = "0.10.26"
+version = "0.10.27"
 edition = "2024"
 rust-version = "1.95"
 description = "A Rust port of esrap — prints an oxc AST to JavaScript with esrap's exact layout"

--- a/crates/rsvelte_esrap/src/context.rs
+++ b/crates/rsvelte_esrap/src/context.rs
@@ -15,6 +15,7 @@ const PENDING_NEWLINE: u8 = 1 << 0;
 const PENDING_MARGIN: u8 = 1 << 1;
 const PENDING_SPACE: u8 = 1 << 2;
 const PENDING_OPTIMISTIC_SPACE: u8 = 1 << 3;
+const FAST_INDENT_BYTES: usize = 32;
 
 #[inline(always)]
 fn push_str_small(text: &mut String, value: &str) {
@@ -465,6 +466,9 @@ impl<const DIRECT: bool> Context<DIRECT> {
         if self.pending == 0 {
             return;
         }
+        if self.try_flush_direct_newline() {
+            return;
+        }
         self.flush_direct_slow();
     }
 
@@ -473,7 +477,49 @@ impl<const DIRECT: bool> Context<DIRECT> {
         if self.pending & !PENDING_OPTIMISTIC_SPACE == 0 {
             return;
         }
+        if self.try_flush_direct_newline() {
+            return;
+        }
         self.flush_direct_slow();
+    }
+
+    #[inline(never)]
+    fn try_flush_direct_newline(&mut self) -> bool {
+        let depth = self.indent_depth as usize;
+        if self.pending & PENDING_NEWLINE == 0
+            || self.pending & PENDING_MARGIN != 0
+            || self.indent.as_bytes() != b"\t"
+            || depth > FAST_INDENT_BYTES
+            || self.buffer.text.capacity() - self.buffer.text.len() < FAST_INDENT_BYTES + 1
+            || self.buffer.layouts.len() == self.buffer.layouts.capacity()
+        {
+            return false;
+        }
+
+        let text_len = self.buffer.text.len();
+        let start = u32::try_from(text_len).expect("esrap output exceeds u32");
+        let raw_len = depth + 1;
+        // SAFETY: the fast-path capacity check leaves room for the fixed write.
+        unsafe {
+            let bytes = self.buffer.text.as_mut_vec();
+            let dst = bytes.as_mut_ptr().add(text_len);
+            dst.write(b'\n');
+            dst.add(1)
+                .cast::<[u8; FAST_INDENT_BYTES]>()
+                .write([b'\t'; FAST_INDENT_BYTES]);
+            bytes.set_len(text_len + raw_len);
+        }
+        self.layout_bytes += raw_len;
+        self.buffer.layouts.push(LayoutSpan {
+            start,
+            raw_len: raw_len as u32,
+            depth: self.indent_depth,
+            newline: true,
+            margin: false,
+            dirty: false,
+        });
+        self.pending = 0;
+        true
     }
 
     #[cold]
@@ -688,6 +734,66 @@ mod tests {
         ctx.write("");
         ctx.cancel_optimistic_space();
         assert_eq!(direct_output(ctx), "\n");
+    }
+
+    #[test]
+    fn direct_fast_newline_preserves_layout_span() {
+        let mut ctx = Context::new_direct("\t", 64);
+        ctx.buffer.layouts.reserve(1);
+        for _ in 0..FAST_INDENT_BYTES {
+            ctx.indent();
+        }
+        ctx.newline();
+        ctx.write_ascii(b'x');
+
+        assert_eq!(ctx.buffer.text, format!("\n{}x", "\t".repeat(32)));
+        assert_eq!(ctx.layout_bytes, 33);
+        assert_eq!(
+            ctx.buffer.layouts,
+            [LayoutSpan {
+                start: 0,
+                raw_len: 33,
+                depth: 32,
+                newline: true,
+                margin: false,
+                dirty: false,
+            }]
+        );
+    }
+
+    #[test]
+    fn direct_fast_newline_falls_back_for_other_layouts() {
+        let mut custom = Context::new_direct("  ", 64);
+        custom.buffer.layouts.reserve(1);
+        custom.indent();
+        custom.newline();
+        custom.write_ascii(b'x');
+        assert_eq!(direct_output(custom), "\n  x");
+
+        let mut margin = Context::new_direct("\t", 64);
+        margin.buffer.layouts.reserve(1);
+        margin.indent();
+        margin.margin();
+        margin.newline();
+        margin.write_ascii(b'x');
+        assert_eq!(direct_output(margin), "\n\n\tx");
+
+        let mut deep = Context::new_direct("\t", 128);
+        deep.buffer.layouts.reserve(1);
+        for _ in 0..=FAST_INDENT_BYTES {
+            deep.indent();
+        }
+        deep.newline();
+        deep.write_ascii(b'x');
+        assert_eq!(direct_output(deep), format!("\n{}x", "\t".repeat(33)));
+
+        let mut growth = Context::new_direct("\t", 0);
+        growth.buffer.text = String::new();
+        growth.buffer.layouts = Vec::new();
+        growth.indent();
+        growth.newline();
+        growth.write_ascii(b'x');
+        assert_eq!(direct_output(growth), "\n\tx");
     }
 
     #[test]

--- a/crates/rsvelte_esrap/src/printer.rs
+++ b/crates/rsvelte_esrap/src/printer.rs
@@ -623,22 +623,31 @@ impl<'opt, const HAS_COMMENTS: bool, const DIRECT: bool> Printer<'opt, HAS_COMME
     // ----- comments ---------------------------------------------------------
 
     /// esrap's `flush_comments_until`: emit every pending comment that starts
-    /// before `to` (byte offset / `to_line`). The `from_line` margin rule adds a
+    /// before `to`. The `from` margin rule adds a
     /// blank line before a detached leading comment block.
     fn flush_comments_until(
         &mut self,
         ctx: &mut Context<DIRECT>,
         to: u32,
-        to_line: u32,
-        from_line: Option<u32>,
+        from: Option<u32>,
         pad: bool,
     ) {
-        if !HAS_COMMENTS {
+        if !HAS_COMMENTS || self.comment_index == self.comments.len() {
             return;
         }
         if !self.has_loc(to) {
             return;
         }
+        let Some(next_comment) = self.comments.get(self.comment_index) else {
+            return;
+        };
+        if next_comment.start >= to {
+            return;
+        }
+        let to_line = self.line_of(to);
+        let from_line = from
+            .filter(|&offset| self.has_loc(offset))
+            .map(|offset| self.line_of(offset));
         let mut first = true;
         while self.comment_index < self.comments.len() {
             let cmt = &self.comments[self.comment_index];
@@ -675,7 +684,7 @@ impl<'opt, const HAS_COMMENTS: bool, const DIRECT: bool> Printer<'opt, HAS_COMME
         prev_end: u32,
         next: Option<u32>,
     ) -> bool {
-        if !HAS_COMMENTS || !self.has_loc(prev_end) {
+        if !HAS_COMMENTS || self.comment_index == self.comments.len() || !self.has_loc(prev_end) {
             return false;
         }
         // A `next` boundary that is itself synthesized bounds nothing (esrap's
@@ -739,7 +748,7 @@ impl<'opt, const HAS_COMMENTS: bool, const DIRECT: bool> Printer<'opt, HAS_COMME
         if !HAS_COMMENTS {
             return;
         }
-        self.flush_comments_until(ctx, node_start, self.line_of(node_start), None, true);
+        self.flush_comments_until(ctx, node_start, None, true);
     }
 
     /// Port of esrap's `sequence` (`languages/ts/index.js`). Lays `nodes` out as
@@ -836,12 +845,8 @@ impl<'opt, const HAS_COMMENTS: bool, const DIRECT: bool> Printer<'opt, HAS_COMME
 
         // esrap: flush_comments_until(context, lastNode.loc.end, until, false).
         if let Some(until) = until {
-            let from_line = nodes
-                .last()
-                .and_then(|node| node.end)
-                .filter(|&e| self.has_loc(e))
-                .map(|e| self.line_of(e));
-            self.flush_comments_until(parent, until, self.line_of(until), from_line, false);
+            let from = nodes.last().and_then(|node| node.end);
+            self.flush_comments_until(parent, until, from, false);
         }
 
         if multiline {
@@ -867,7 +872,7 @@ impl<'opt, const HAS_COMMENTS: bool, const DIRECT: bool> Printer<'opt, HAS_COMME
     ) {
         if n == 0 {
             if let Some(until) = until {
-                self.flush_comments_until(parent, until, self.line_of(until), None, false);
+                self.flush_comments_until(parent, until, None, false);
             }
             return;
         }
@@ -907,11 +912,7 @@ impl<'opt, const HAS_COMMENTS: bool, const DIRECT: bool> Printer<'opt, HAS_COMME
             }
 
             if let Some(until) = until {
-                let from_line = node_meta
-                    .end
-                    .filter(|&end| self.has_loc(end))
-                    .map(|end| self.line_of(end));
-                self.flush_comments_until(parent, until, self.line_of(until), from_line, false);
+                self.flush_comments_until(parent, until, node_meta.end, false);
             }
 
             if multiline {
@@ -1006,11 +1007,7 @@ impl<'opt, const HAS_COMMENTS: bool, const DIRECT: bool> Printer<'opt, HAS_COMME
             }
 
             if let Some(until) = until {
-                let from_line = meta(n - 1)
-                    .end
-                    .filter(|&end| self.has_loc(end))
-                    .map(|end| self.line_of(end));
-                self.flush_comments_until(parent, until, self.line_of(until), from_line, false);
+                self.flush_comments_until(parent, until, meta(n - 1).end, false);
             }
 
             if multiline {
@@ -1104,12 +1101,8 @@ impl<'opt, const HAS_COMMENTS: bool, const DIRECT: bool> Printer<'opt, HAS_COMME
         }
 
         if let Some(until) = until {
-            let from_line = n
-                .checked_sub(1)
-                .and_then(|i| meta(i).end)
-                .filter(|&e| self.has_loc(e))
-                .map(|e| self.line_of(e));
-            self.flush_comments_until(parent, until, self.line_of(until), from_line, false);
+            let from = n.checked_sub(1).and_then(|i| meta(i).end);
+            self.flush_comments_until(parent, until, from, false);
         }
 
         if multiline {
@@ -1265,10 +1258,7 @@ impl<'opt, const HAS_COMMENTS: bool, const DIRECT: bool> Printer<'opt, HAS_COMME
             && body_start.is_some_and(|start| self.has_loc(start))
             && self.has_loc(body_end)
         {
-            let from_line = last_end
-                .filter(|&end| self.has_loc(end))
-                .map(|end| self.line_of(end));
-            self.flush_comments_until(ctx, body_end, self.line_of(body_end), from_line, false);
+            self.flush_comments_until(ctx, body_end, last_end, false);
         }
     }
 

--- a/crates/rsvelte_lint_types/Cargo.lock
+++ b/crates/rsvelte_lint_types/Cargo.lock
@@ -1111,7 +1111,7 @@ dependencies = [
 
 [[package]]
 name = "rsvelte_esrap"
-version = "0.10.26"
+version = "0.10.27"
 dependencies = [
  "compact_str",
  "memchr",

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
 		"corpus:sync": "git submodule update --init --depth 1 submodules/svelte submodules/svelte.dev submodules/language-tools submodules/bits-ui submodules/flowbite-svelte submodules/melt-ui submodules/shadcn-svelte submodules/sveltestrap submodules/attractions submodules/svelte-ux submodules/smelte submodules/svar-core submodules/svelte-table submodules/powertable submodules/svelte-pivottable submodules/svelte-toast submodules/svelte-sonner submodules/svelte-notifications submodules/svelte-fa submodules/svelte-heroicons submodules/svelte-calendar submodules/date-picker-svelte submodules/svelte-maplibre submodules/layercake submodules/layerchart submodules/svelte-splitpanes submodules/svelte-stepper submodules/svelte-formly submodules/svelte-form-builder submodules/svelte-checkbox submodules/svelte-toggle submodules/svelthree submodules/runed submodules/mode-watcher submodules/svelte-toolbelt submodules/cmsaasstarter submodules/skeleton",
 		"corpus:collect": "node scripts/compat-corpus/collect.mjs",
 		"corpus:compile": "node scripts/compat-corpus/compile.mjs",
+		"corpus:esrap": "node scripts/compat-corpus/esrap-verify.mjs",
 		"corpus:verify": "node scripts/compat-corpus/verify.mjs",
 		"corpus:matrix": "node scripts/compat-corpus/matrix/run.mjs",
 		"corpus:matrix:update": "node scripts/compat-corpus/matrix/run.mjs --update-baseline",

--- a/scripts/bench/competitor-oracle/package-lock.json
+++ b/scripts/bench/competitor-oracle/package-lock.json
@@ -9,6 +9,8 @@
         "@mrwaip/svelte-rs": "0.0.0-canary.13.1",
         "@typescript/native-preview": "7.0.0-dev.20260707.2",
         "@verter/wasm": "0.0.1-beta.3",
+        "acorn": "8.18.0",
+        "esrap": "2.3.2",
         "svelte-check-rs": "0.11.0",
         "svelte-mrwaip-reference": "npm:svelte@5.56.9"
       }

--- a/scripts/bench/competitor-oracle/package.json
+++ b/scripts/bench/competitor-oracle/package.json
@@ -7,6 +7,8 @@
     "@mrwaip/svelte-rs": "0.0.0-canary.13.1",
     "@typescript/native-preview": "7.0.0-dev.20260707.2",
     "@verter/wasm": "0.0.1-beta.3",
+    "acorn": "8.18.0",
+    "esrap": "2.3.2",
     "svelte-check-rs": "0.11.0",
     "svelte-mrwaip-reference": "npm:svelte@5.56.9"
   }

--- a/scripts/bench/run-printer-benchmark.mjs
+++ b/scripts/bench/run-printer-benchmark.mjs
@@ -1,0 +1,243 @@
+import { createHash } from "node:crypto";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { arch, cpus, loadavg, platform, tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { performance } from "node:perf_hooks";
+import { fileURLToPath } from "node:url";
+import { spawnSync } from "node:child_process";
+import * as acorn from "./competitor-oracle/node_modules/acorn/dist/acorn.mjs";
+import { print } from "./competitor-oracle/node_modules/esrap/src/index.js";
+import ts from "./competitor-oracle/node_modules/esrap/src/languages/ts/index.js";
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
+const corpusDir = join(root, "benches/printer-corpus");
+const manifest = JSON.parse(readFileSync(join(corpusDir, "manifest.json"), "utf8"));
+const warmups = Number(process.env.PRINTER_BENCHMARK_WARMUPS ?? process.env.REPORT_WARMUPS ?? 1);
+const runs = Number(process.env.PRINTER_BENCHMARK_RUNS ?? process.env.REPORT_RUNS ?? 5);
+const batch = Number(process.env.PRINTER_BENCHMARK_BATCH ?? 100);
+const rustRunner =
+  process.env.PRINTER_BENCHMARK_RUNNER ?? join(root, "target/release/printer_benchmark_runner");
+const esrapCargo = readFileSync(join(root, "crates/rsvelte_esrap/Cargo.toml"), "utf8");
+const rsvelteEsrapVersion = esrapCargo.match(/^version\s*=\s*"([^"]+)"/m)?.[1] ?? "unknown";
+
+if (
+  !Number.isInteger(warmups) ||
+  warmups < 0 ||
+  !Number.isInteger(runs) ||
+  runs < 1 ||
+  !Number.isInteger(batch) ||
+  batch < 1
+) {
+  throw new Error("printer benchmark warmups, runs, and batch must be non-negative integers");
+}
+
+const entries = manifest.files.map((entry) => {
+  const path = join(corpusDir, entry.path);
+  const source = readFileSync(path, "utf8");
+  const digest = createHash("sha256").update(source).digest("hex");
+  if (digest !== entry.sha256) {
+    throw new Error(`printer corpus digest mismatch for ${entry.path}`);
+  }
+  return { ...entry, path, source };
+});
+const aggregate = createHash("sha256")
+  .update(
+    entries
+      .map(({ sha256, path }) => `${sha256}  benches/printer-corpus/${path.split("/").at(-1)}\n`)
+      .join(""),
+  )
+  .digest("hex");
+if (aggregate !== manifest.workloadSha256) {
+  throw new Error("printer corpus workload digest mismatch");
+}
+
+const plainEntries = entries.filter(({ path }) => !path.endsWith("12-comments-common.js"));
+const commentEntries = entries.filter(({ path }) => path.endsWith("12-comments-common.js"));
+const temp = mkdtempSync(join(tmpdir(), "rsvelte-printer-bench-"));
+
+try {
+  const plainList = writeList("plain", plainEntries);
+  const commentList = writeList("comments", commentEntries);
+  const codeRust = runRust(plainList, "code");
+  const mapRust = runRust(plainList, "source-map");
+  const commentRust = runRust(commentList, "code", batch * 100);
+
+  const cases = [
+    makeCase(
+      "parsed-no-map",
+      "Parsed JavaScript, code only",
+      plainEntries,
+      runJavascript(plainEntries, false, false, batch),
+      codeRust,
+    ),
+    makeCase(
+      "decoded-map",
+      "Parsed JavaScript, decoded source map",
+      plainEntries,
+      runJavascript(plainEntries, true, false, batch),
+      mapRust,
+    ),
+    makeCase(
+      "comments-common",
+      "Statement-level comments, code only",
+      commentEntries,
+      runJavascript(commentEntries, false, true, batch * 100),
+      commentRust,
+    ),
+  ];
+
+  process.stdout.write(
+    `${JSON.stringify({
+      schemaVersion: 1,
+      measurementKind: "native-wall",
+      generatedAt: new Date().toISOString(),
+      workloadHash: `sha256:${manifest.workloadSha256}`,
+      versions: {
+        rsvelteEsrap: rsvelteEsrapVersion,
+        oxcCodegen: "0.144.0",
+        javascriptEsrap: "2.3.2",
+      },
+      runner: {
+        label: process.env.BENCHMARK_RUNNER_LABEL ?? "local",
+        platform: platform(),
+        arch: arch(),
+        cpus: cpus().length,
+        cpuModel: cpus()[0]?.model?.trim() ?? "unknown",
+        node: process.versions.node,
+        loadAvg1min: loadavg()[0],
+      },
+      warmups,
+      runs,
+      batch,
+      cases,
+    })}\n`,
+  );
+} finally {
+  rmSync(temp, { recursive: true, force: true });
+}
+
+function writeList(name, selected) {
+  const path = join(temp, `${name}.txt`);
+  writeFileSync(path, `${selected.map((entry) => entry.path).join("\n")}\n`);
+  return path;
+}
+
+function runRust(files, mode, caseBatch = batch) {
+  const result = spawnSync(
+    rustRunner,
+    [
+      "--files",
+      files,
+      "--warmup",
+      String(warmups),
+      "--iterations",
+      String(runs),
+      "--batch",
+      String(caseBatch),
+      "--mode",
+      mode,
+    ],
+    { cwd: root, encoding: "utf8", maxBuffer: 1 << 24 },
+  );
+  if (result.stderr) process.stderr.write(result.stderr);
+  if (result.status !== 0) {
+    throw new Error(`Rust printer benchmark exited ${result.status}`);
+  }
+  return JSON.parse(result.stdout);
+}
+
+function runJavascript(selected, sourceMap, commentsEnabled, caseBatch) {
+  const parsed = selected.map(({ source }) => {
+    const comments = [];
+    const program = acorn.parse(source, {
+      ecmaVersion: "latest",
+      sourceType: "module",
+      locations: sourceMap || commentsEnabled,
+      onComment: comments,
+    });
+    return { comments, program, source };
+  });
+  const visitors = parsed.map(({ comments }) => ts({ comments }));
+  const run = () => {
+    let emitted = 0;
+    for (let index = 0; index < parsed.length; index += 1) {
+      const { program, source } = parsed[index];
+      const output = print(program, visitors[index], {
+        sourceMapContent: sourceMap ? source : undefined,
+        sourceMapEncodeMappings: sourceMap ? false : undefined,
+        sourceMapSource: sourceMap ? "input.js" : undefined,
+      });
+      emitted += output.code.length;
+      if (sourceMap) emitted += output.map.mappings.length;
+    }
+    return emitted;
+  };
+  for (let index = 0; index < warmups; index += 1) {
+    for (let sample = 0; sample < caseBatch; sample += 1) run();
+  }
+  const timesMs = [];
+  for (let index = 0; index < runs; index += 1) {
+    const start = performance.now();
+    let emitted = 0;
+    for (let sample = 0; sample < caseBatch; sample += 1) emitted += run();
+    timesMs.push((performance.now() - start) / caseBatch);
+    if (emitted === 0) throw new Error("JavaScript esrap emitted no output");
+  }
+  for (let index = 0; index < parsed.length; index += 1) {
+    const output = print(parsed[index].program, visitors[index], {
+      sourceMapContent: sourceMap ? parsed[index].source : undefined,
+      sourceMapEncodeMappings: sourceMap ? false : undefined,
+      sourceMapSource: sourceMap ? "input.js" : undefined,
+    });
+    const outputComments = [];
+    acorn.parse(output.code, {
+      ecmaVersion: "latest",
+      sourceType: "module",
+      onComment: outputComments,
+    });
+    const expectedComments = parsed[index].comments.map(({ type, value }) => ({ type, value }));
+    const actualComments = outputComments.map(({ type, value }) => ({ type, value }));
+    if (JSON.stringify(actualComments) !== JSON.stringify(expectedComments)) {
+      throw new Error("JavaScript esrap changed the benchmark comments");
+    }
+  }
+  return { timesMs };
+}
+
+function makeCase(id, label, selected, javascript, rust) {
+  const variants = [
+    variant("rsvelte-esrap", "rsvelte/esrap", rust.rsvelteEsrap.timesMs),
+    variant("oxc-codegen", "oxc_codegen", rust.oxcCodegen.timesMs),
+    variant("javascript-esrap", "esrap", javascript.timesMs),
+  ];
+  const baseline = variants[0].medianMs;
+  for (const item of variants) item.relativeToRsvelte = item.medianMs / baseline;
+  return {
+    id,
+    label,
+    comparability: "same-source-retained-parser-specific-ast",
+    files: selected.length,
+    bytes: selected.reduce((sum, entry) => sum + Buffer.byteLength(entry.source), 0),
+    variants,
+  };
+}
+
+function variant(id, label, timesMs) {
+  const medianMs = median(timesMs);
+  const mean = timesMs.reduce((sum, value) => sum + value, 0) / timesMs.length;
+  const variance = timesMs.reduce((sum, value) => sum + (value - mean) ** 2, 0) / timesMs.length;
+  return {
+    id,
+    label,
+    medianMs,
+    cvPct: mean === 0 ? 0 : (Math.sqrt(variance) / mean) * 100,
+    timesMs,
+    workGate: "parseable-output",
+  };
+}
+
+function median(values) {
+  const sorted = [...values].sort((a, b) => a - b);
+  const middle = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 0 ? (sorted[middle - 1] + sorted[middle]) / 2 : sorted[middle];
+}

--- a/scripts/compat-corpus/README.md
+++ b/scripts/compat-corpus/README.md
@@ -151,7 +151,12 @@ Pipeline stages (all idempotent, everything under `compatibility/` except
    `compatibility/{expected,actual}/<id>/{client.js,server.js,server-dev.js,client-dev.js,client.css,client-dev.css,error.json}`.
    Sharded across worker processes; a Rust panic is recorded as a `rust_panic`
    error for that entry instead of killing the run.
-3. `verify.mjs` — oxfmt-normalizes both trees, byte-compares, writes `report.json`,
+3. `esrap-verify.mjs` — re-parses every generated JavaScript output from both
+   compiler trees and all four targets, then requires `rsvelte_esrap` code-only and
+   mapped printing to agree, preserve AST semantics and ordered raw comments, and
+   produce ordered in-bounds source mappings. Each tree/target must contain at least
+   12,000 outputs, so a missing or partial tree cannot pass vacuously.
+4. `verify.mjs` — oxfmt-normalizes both trees, byte-compares, writes `report.json`,
    and ratchets each target independently against
    `compatibility/known-failures.client.json` (CSR),
    `compatibility/known-failures.server.json` (SSR) and

--- a/scripts/compat-corpus/esrap-verify.mjs
+++ b/scripts/compat-corpus/esrap-verify.mjs
@@ -1,0 +1,102 @@
+#!/usr/bin/env node
+
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { TARGETS } from "./targets.mjs";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const args = process.argv.slice(2);
+
+function argument(name, fallback) {
+  const index = args.indexOf(name);
+  return index === -1 ? fallback : args[index + 1];
+}
+
+const compatibility = path.resolve(
+  argument("--compatibility-dir", path.join(root, "compatibility")),
+);
+const manifestPath = path.join(compatibility, "manifest.json");
+const minimumPerTreeTarget = Number(argument("--minimum-per-tree-target", "12000"));
+if (!Number.isInteger(minimumPerTreeTarget) || minimumPerTreeTarget < 1) {
+  throw new Error("--minimum-per-tree-target must be a positive integer");
+}
+if (!fs.existsSync(manifestPath)) {
+  throw new Error("compatibility/manifest.json is missing; run pnpm corpus:collect first");
+}
+
+const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8"));
+const populations = [];
+for (const tree of ["expected", "actual"]) {
+  for (const target of TARGETS) {
+    const population = [];
+    for (const { id } of manifest) {
+      const candidate = path.join(compatibility, tree, id, `${target.key}.js`);
+      if (fs.existsSync(candidate)) population.push(candidate);
+    }
+    if (population.length < minimumPerTreeTarget) {
+      throw new Error(
+        `${tree}/${target.key} contains ${population.length} JavaScript outputs; expected at least ${minimumPerTreeTarget}`,
+      );
+    }
+    populations.push({ tree, target: target.key, paths: population });
+  }
+}
+
+const stage = fs.mkdtempSync(path.join(os.tmpdir(), "rsvelte-esrap-corpus-"));
+
+try {
+  const binary = path.resolve(argument("--binary", path.join(root, "target/release/esrap_corpus")));
+  if (!fs.existsSync(binary)) {
+    throw new Error(
+      "target/release/esrap_corpus is missing; build the rsvelte_devtools binary first",
+    );
+  }
+  const measured = populations.map((population, index) => {
+    const fileList = path.join(stage, `files-${index}.txt`);
+    fs.writeFileSync(fileList, `${population.paths.join("\n")}\n`);
+    const output = execFileSync(
+      binary,
+      [
+        "--files",
+        fileList,
+        "--minimum-files",
+        String(minimumPerTreeTarget),
+        "--minimum-comment-files",
+        "1",
+      ],
+      { cwd: root, encoding: "utf8", maxBuffer: 1 << 24 },
+    );
+    return {
+      tree: population.tree,
+      target: population.target,
+      ...JSON.parse(output),
+    };
+  });
+  const printer = measured.reduce(
+    (totals, population) => {
+      for (const key of ["files", "bytes", "commentFiles", "comments", "mappedFiles", "mappings"]) {
+        totals[key] += population[key];
+      }
+      return totals;
+    },
+    { files: 0, bytes: 0, commentFiles: 0, comments: 0, mappedFiles: 0, mappings: 0 },
+  );
+  const report = {
+    schemaVersion: 1,
+    kind: "rsvelte-esrap-corpus-report",
+    manifestEntries: manifest.length,
+    minimumPerTreeTarget,
+    populations: measured,
+    printer,
+  };
+  const reportPath = path.join(compatibility, "esrap-report.json");
+  fs.writeFileSync(reportPath, `${JSON.stringify(report, null, "\t")}\n`);
+  console.log(
+    `esrap corpus passed: ${printer.files} outputs, ${printer.commentFiles} comment-bearing, ${printer.mappings} mappings`,
+  );
+} finally {
+  fs.rmSync(stage, { recursive: true, force: true });
+}

--- a/scripts/reports/run-performance.mjs
+++ b/scripts/reports/run-performance.mjs
@@ -643,6 +643,29 @@ const toolTasks = [
   }),
 ];
 
+console.error("[report] benchmarking JavaScript printers");
+const printerBenchmark = spawnSync(
+  process.execPath,
+  [join(root, "scripts/bench/run-printer-benchmark.mjs")],
+  {
+    cwd: root,
+    encoding: "utf8",
+    maxBuffer: 1 << 24,
+    env: {
+      ...process.env,
+      PRINTER_BENCHMARK_WARMUPS: String(warmups),
+      PRINTER_BENCHMARK_RUNS: String(runs),
+    },
+  },
+);
+if (printerBenchmark.stderr) process.stderr.write(printerBenchmark.stderr);
+if (printerBenchmark.status !== 0) {
+  throw new Error(`Printer benchmark exited ${printerBenchmark.status}`);
+}
+const printerBenchmarks = JSON.parse(printerBenchmark.stdout);
+const printerOutputPath = join(root, "apps/playground/static/printer-performance-report.json");
+writeFileSync(printerOutputPath, `${JSON.stringify(printerBenchmarks, null, 2)}\n`);
+
 const git = (...args) => {
   try {
     return execFileSync("git", args, { cwd: root, encoding: "utf8" }).trim();
@@ -654,7 +677,7 @@ const fileSetHash = createHash("sha256")
   .update(selectedEntries.map(({ id }) => id).join("\n"))
   .digest("hex");
 const result = {
-  schemaVersion: 9,
+  schemaVersion: 10,
   kind: "rsvelte-performance-report",
   generatedAt: new Date().toISOString(),
   provenance: {
@@ -664,6 +687,7 @@ const result = {
     competitorPackages: [
       "@mrwaip/svelte-rs@0.0.0-canary.13.1",
       "@verter/wasm@0.0.1-beta.3",
+      "esrap@2.3.2",
       "oxfmt@0.62.0",
       `svelte-check@${svelteCheckVersion}`,
       `svelte-check-rs@${svelteCheckRsVersion}`,
@@ -697,8 +721,15 @@ const result = {
   },
   surfaces,
   toolTasks,
+  printerBenchmarks,
   benchmarkCoverage: [
     { id: "compiler", label: "Compiler", status: "measured", detail: "CSR, SSR, CSR dev, SSR dev" },
+    {
+      id: "printer",
+      label: "JavaScript printer",
+      status: "measured",
+      detail: "Code, decoded source maps, and common comments",
+    },
     { id: "parser", label: "Parser", status: "measured", detail: "Complete accepted corpus" },
     { id: "projection", label: "TS projection", status: "measured", detail: "svelte2tsx" },
     {
@@ -785,9 +816,11 @@ const result = {
     "A competitor stays unranked unless every complete-corpus input has the same acceptance outcome and every accepted input has equivalent normalized JavaScript and identical CSS output.",
     "Compiler elapsed time and correctness use the same complete corpus, with rejections included; partial implementations remain visible but are not equivalent-work speed rankings.",
     "Verter's published Node package requires an asset-path adapter; initialization is excluded from timed samples.",
+    "Printer rows use a fixed generated-JavaScript corpus and native wall time. Each backend retains its parsed AST; parsing and process startup are excluded.",
   ],
 };
 
 writeFileSync(outputPath, `${JSON.stringify(result, null, 2)}\n`);
 execFileSync(join(root, "node_modules/.bin/oxfmt"), [outputPath], { stdio: "ignore" });
+execFileSync(join(root, "node_modules/.bin/oxfmt"), [printerOutputPath], { stdio: "ignore" });
 console.error(`[report] wrote ${outputPath}`);


### PR DESCRIPTION
## Summary

- speed up the direct printer's common newline flush and avoid comment line lookups after the comment cursor is exhausted
- add pinned Rust/JavaScript printer benchmarks for rsvelte/esrap, oxc_codegen, and esrap, and surface the results on the benchmark site
- add a large-corpus esrap gate covering code round trips, ordered comments, and source-map structure across official and rsvelte output trees

## Why

The remaining no-map printer gap was concentrated in indentation writes, while comment-bearing programs repeatedly paid line lookup costs after all comments had been consumed. The project also lacked a pinned three-way printer benchmark and a corpus-scale printer correctness gate.

## Results

On the committed 50.7 kB printer workload:

- code: rsvelte/esrap 0.100 ms, oxc_codegen 0.110 ms, esrap 2.334 ms
- decoded source map: rsvelte/esrap 0.235 ms, oxc_codegen 0.276 ms, esrap 3.002 ms
- common comments: rsvelte/esrap 0.00068 ms, oxc_codegen 0.00036 ms, esrap 0.0099 ms

The outlined newline fast path improves the retained-AST Rust comparison by about 2.1% with a 1.2 kB binary increase. The exhausted-comment fast path improves the standard leading-comment workload by about 26.7% and the committed common-comment case by 6–7%.

## Validation

- `cargo test -p rsvelte_esrap --release`
- `cargo check --release -p rsvelte_devtools --bin printer_benchmark_runner --bin esrap_corpus`
- `cargo check --release -p rsvelte_bench --bench ci`
- `cargo clippy -p rsvelte_esrap -p rsvelte_devtools -p rsvelte_bench --all-targets --all-features -- -D warnings`
- `cargo fmt --all --check`
- `pnpm run build` in `apps/playground`
- fixed 12-file corpus: 50,651 bytes, 3 comments, 1,090 mappings
- synthetic 8-population corpus harness smoke test
