### PR TITLE
refactor(offsets): finish Phase 3 byte/char offset typing

### DIFF
--- a/.changeset/typed-phase3-offsets.md
+++ b/.changeset/typed-phase3-offsets.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/compiler": patch
+---
+
+Prevent non-ASCII text from corrupting legacy client transform boundaries by keeping character and byte offsets as distinct types.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2567,6 +2567,7 @@ dependencies = [
  "similar 3.1.2",
  "smallvec",
  "sourcemap",
+ "static_assertions",
  "string_wizard",
  "test-generator",
  "thiserror",

--- a/crates/rsvelte_core/Cargo.toml
+++ b/crates/rsvelte_core/Cargo.toml
@@ -135,6 +135,7 @@ oxc_ast_visit = "0.144"
 rsvelte_ast_equiv = { path = "../rsvelte_ast_equiv" }
 insta = { version = "1.42", features = ["json", "glob"] }
 pretty_assertions = "1.4"
+static_assertions = "1.1"
 chrono = "0.4"
 test-generator = "0.3"
 glob = "0.3"

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/destructure_transforms.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/destructure_transforms.rs
@@ -171,7 +171,7 @@ pub(super) fn find_and_transform_one_destructure(
 
     // Build char-index → byte-index mapping for safe string slicing with multi-byte chars
     let table = CharToByte::new(statement);
-    let b = |char_idx: usize| -> usize { table.byte(CharOffset::new(char_idx)).get() };
+    let b = |char_idx: CharOffset| -> ByteOffset { table.byte(char_idx) };
 
     // Scan for `] =` or `} =` patterns that indicate destructure assignments.
     // We need to be careful to avoid:
@@ -244,7 +244,8 @@ pub(super) fn find_and_transform_one_destructure(
                         .char_of(byte)
                         .unwrap_or_else(|| bracket_offset_miss(byte.get(), statement.len()))
                 }) {
-                    let pattern_str = &statement[b(pattern_start.get())..b(i + 1)];
+                    let pattern_end = CharOffset::new(i).next();
+                    let pattern_str = b(pattern_start).to(b(pattern_end), statement);
                     let rhs_start = j + 1;
 
                     // For array patterns, check if `[` is actually member access
@@ -262,7 +263,7 @@ pub(super) fn find_and_transform_one_destructure(
                     }
 
                     // Skip declaration destructures (let/const/var)
-                    let before_pattern = statement[..b(pattern_start.get())].trim_end();
+                    let before_pattern = b(pattern_start).before(statement).trim_end();
                     if before_pattern.ends_with("let")
                         || before_pattern.ends_with("const")
                         || before_pattern.ends_with("var")
@@ -290,7 +291,7 @@ pub(super) fn find_and_transform_one_destructure(
                     // brace/bracket depth. If we encounter an unmatched
                     // opening `{` or `[` before hitting a statement boundary,
                     // we're nested inside another pattern and should skip.
-                    if is_inside_enclosing_pattern(statement, b(pattern_start.get())) {
+                    if is_inside_enclosing_pattern(statement, b(pattern_start).get()) {
                         i = j + 1;
                         continue;
                     }
@@ -314,8 +315,9 @@ pub(super) fn find_and_transform_one_destructure(
                     }
 
                     // Find the end of the RHS expression
-                    let rhs_end = find_destructure_rhs_end(statement, CharOffset::new(rhs_start));
-                    let rhs_str = statement[b(rhs_start)..b(rhs_end.get())].trim();
+                    let rhs_start = CharOffset::new(rhs_start);
+                    let rhs_end = find_destructure_rhs_end(statement, rhs_start);
+                    let rhs_str = b(rhs_start).to(b(rhs_end), statement).trim();
 
                     if rhs_str.is_empty() {
                         i = j + 1;
@@ -372,14 +374,14 @@ pub(super) fn find_and_transform_one_destructure(
     // the other and should be deferred.
     let candidate_idx = {
         // Compute rhs_end for each candidate to determine containment
-        let rhs_ends: Vec<usize> = candidates
+        let rhs_ends: Vec<CharOffset> = candidates
             .iter()
-            .map(|c| find_destructure_rhs_end(statement, c.eq_pos.next()).get())
+            .map(|c| find_destructure_rhs_end(statement, c.eq_pos.next()))
             .collect();
 
         let mut selected = 0; // default to first
         'outer: for (ci, c) in candidates.iter().enumerate() {
-            let rhs_start = c.eq_pos.next().get();
+            let rhs_start = c.eq_pos.next();
             let rhs_end = rhs_ends[ci];
             // Check if any other candidate's close_pos is inside this candidate's RHS range
             let mut contains_other = false;
@@ -388,7 +390,7 @@ pub(super) fn find_and_transform_one_destructure(
                     continue;
                 }
                 // Check if other's close bracket is within this candidate's RHS
-                if other.close_pos.get() > rhs_start && other.close_pos.get() < rhs_end {
+                if other.close_pos > rhs_start && other.close_pos < rhs_end {
                     contains_other = true;
                     break;
                 }
@@ -401,26 +403,25 @@ pub(super) fn find_and_transform_one_destructure(
         selected
     };
     let candidate = &candidates[candidate_idx];
-    let i = candidate.close_pos.get();
-    let pattern_start = candidate.pattern_start.get();
-    let j = candidate.eq_pos.get();
-    let rhs_start = j + 1;
+    let pattern_end = candidate.close_pos.next();
+    let pattern_start = candidate.pattern_start;
+    let rhs_start = candidate.eq_pos.next();
 
-    let pattern_str = &statement[b(pattern_start)..b(i + 1)];
-    let rhs_end = find_destructure_rhs_end(statement, CharOffset::new(rhs_start)).get();
-    let rhs_str = statement[b(rhs_start)..b(rhs_end)].trim();
+    let pattern_str = b(pattern_start).to(b(pattern_end), statement);
+    let rhs_end = find_destructure_rhs_end(statement, rhs_start);
+    let rhs_str = b(rhs_start).to(b(rhs_end), statement).trim();
 
     // Check for surrounding parentheses
     let mut actual_start = b(pattern_start);
     let mut actual_end = b(rhs_end);
 
-    let before = statement[..b(pattern_start)].trim_end();
+    let before = b(pattern_start).before(statement).trim_end();
     if before.ends_with('(') {
-        let paren_pos = statement[..b(pattern_start)].rfind('(').unwrap();
-        let after_rhs = &statement[b(rhs_end)..];
+        let paren_pos = b(pattern_start).before(statement).rfind('(').unwrap();
+        let after_rhs = b(rhs_end).after(statement);
         if let Some(close_paren_offset) = after_rhs.find(')') {
-            actual_start = paren_pos;
-            actual_end = b(rhs_end) + close_paren_offset + 1;
+            actual_start = ByteOffset::new(paren_pos);
+            actual_end = ByteOffset::new(b(rhs_end).get() + close_paren_offset + 1);
         }
     }
 
@@ -429,8 +430,8 @@ pub(super) fn find_and_transform_one_destructure(
     // the `\n` tests below unreachable — so an assignment whose neighbour was
     // separated by nothing but a newline was read as a sub-expression and got a
     // `return` the official compiler does not emit.
-    let before_text = statement[..actual_start].trim_end_matches([' ', '\t']);
-    let after_text = statement[actual_end..].trim_start_matches([' ', '\t']);
+    let before_text = actual_start.before(statement).trim_end_matches([' ', '\t']);
+    let after_text = actual_end.after(statement).trim_start_matches([' ', '\t']);
     let is_standalone = (before_text.is_empty()
         || before_text.ends_with(';')
         || before_text.ends_with('{')
@@ -455,9 +456,9 @@ pub(super) fn find_and_transform_one_destructure(
 
     // Replace the destructure expression with the IIFE
     let mut new_statement = String::new();
-    new_statement.push_str(&statement[..actual_start]);
+    new_statement.push_str(actual_start.before(statement));
     new_statement.push_str(&iife);
-    new_statement.push_str(&statement[actual_end..]);
+    new_statement.push_str(actual_end.after(statement));
 
     Some(new_statement)
 }
@@ -1737,6 +1738,19 @@ mod non_ascii_tests {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn destructure_rewrite_keeps_char_and_byte_offsets_separate() {
+        let props = vec!["a".to_string()];
+        let out = transform_destructure_assignments_with_props(
+            "({ café: a } = value);",
+            &[],
+            &[],
+            &[],
+            &props,
+        );
+        assert!(out.contains("a = value.café"), "{out}");
+    }
 
     #[cfg(feature = "measure-destructure-scanner")]
     #[test]

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/expression_utils.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/expression_utils.rs
@@ -10,6 +10,7 @@ use std::borrow::Cow;
 use std::fmt::Write as _;
 
 use crate::compiler::phases::phase3_transform::shared::js_scan::skip_opaque;
+use crate::compiler::phases::phase3_transform::shared::offsets::{ByteOffset, CharOffset};
 use crate::compiler::utils::{is_escaped, is_escaped_char};
 
 use super::scan_index::ScanIndex;
@@ -759,16 +760,17 @@ pub(super) fn wrap_state_vars_in_expr<'a>(
 /// indicate this scope is a for-loop body with the variable declared in the init.
 /// Convert a byte position in a string to a character index.
 /// Returns the character index for the given byte offset.
-pub(super) fn byte_pos_to_char_index(s: &str, byte_pos: usize) -> usize {
-    s[..byte_pos].chars().count()
+pub(super) fn byte_pos_to_char_index(s: &str, byte_pos: ByteOffset) -> CharOffset {
+    CharOffset::new(byte_pos.before(s).chars().count())
 }
 
 /// Also check if we're directly inside the for-loop header (between the `for (` and `)`).
 pub(super) fn is_shadowed_by_for_loop_var(
     chars: &[char],
-    var_start: usize,
+    var_start: CharOffset,
     var_name: &str,
 ) -> bool {
+    let var_start = var_start.get();
     // First, check if we're inside a for-loop HEADER (init, test, or update section)
     // where the variable is declared as `let`/`const` in the init.
     // Scan backwards to find an unmatched `(` that might be a for-loop's opening paren.

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/props_transforms.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/props_transforms.rs
@@ -780,20 +780,10 @@ pub(super) fn apply_prop_reads_in_prop_default_values(line: &str, prop_vars: &[S
         let mut i = 0;
         let mut depth = 1i32;
         let mut arg_count = 0;
-        let mut fourth_arg_start: Option<usize> = None;
-        let mut fourth_arg_end: Option<usize> = None;
+        let mut fourth_arg_start: Option<CharOffset> = None;
+        let mut fourth_arg_end: Option<CharOffset> = None;
         let mut in_string: Option<char> = None;
-        let mut char_byte_positions: Vec<usize> = Vec::new();
-
-        // Build char->byte mapping
-        {
-            let mut byte_pos = 0;
-            for ch in after_prop.chars() {
-                char_byte_positions.push(byte_pos);
-                byte_pos += ch.len_utf8();
-            }
-            char_byte_positions.push(byte_pos);
-        }
+        let char_to_byte = CharToByte::new(after_prop);
 
         while i < chars.len() {
             let c = chars[i];
@@ -821,7 +811,7 @@ pub(super) fn apply_prop_reads_in_prop_default_values(line: &str, prop_vars: &[S
                     if depth == 0 {
                         // End of $.prop() call
                         if fourth_arg_start.is_some() {
-                            fourth_arg_end = Some(i);
+                            fourth_arg_end = Some(CharOffset::new(i));
                         }
                         break;
                     }
@@ -835,7 +825,7 @@ pub(super) fn apply_prop_reads_in_prop_default_values(line: &str, prop_vars: &[S
                         while j < chars.len() && chars[j].is_whitespace() {
                             j += 1;
                         }
-                        fourth_arg_start = Some(j);
+                        fourth_arg_start = Some(CharOffset::new(j));
                     }
                 }
                 _ => {}
@@ -845,11 +835,10 @@ pub(super) fn apply_prop_reads_in_prop_default_values(line: &str, prop_vars: &[S
 
         // Now reconstruct the $.prop() call with transformed 4th arg
         if let (Some(start_char), Some(end_char)) = (fourth_arg_start, fourth_arg_end) {
-            let start_byte = char_byte_positions[start_char];
-            let end_byte = char_byte_positions[end_char];
-            let before_default = &after_prop[..start_byte];
-            let default_val = &after_prop[start_byte..end_byte];
-            let _after_default = &after_prop[end_byte..];
+            let start_byte = char_to_byte.byte(start_char);
+            let end_byte = char_to_byte.byte(end_char);
+            let before_default = start_byte.before(after_prop);
+            let default_val = start_byte.to(end_byte, after_prop);
 
             // A default value that is EXACTLY a bare prop identifier is the lazy
             // getter reference upstream passes directly (`get_prop_source`
@@ -873,9 +862,9 @@ pub(super) fn apply_prop_reads_in_prop_default_values(line: &str, prop_vars: &[S
             result.push_str(before_default);
             result.push_str(&transformed_default);
             // Continue parsing from after the closing paren
-            let close_byte = char_byte_positions[end_char + 1];
-            result.push_str(&after_prop[end_byte..close_byte]);
-            search_from = abs_pos + 7 + close_byte;
+            let close_byte = char_to_byte.byte(end_char.next());
+            result.push_str(end_byte.to(close_byte, after_prop));
+            search_from = abs_pos + 7 + close_byte.get();
         } else {
             // No 4th arg found, copy $.prop(...) as-is
             result.push_str("$.prop(");
@@ -897,7 +886,7 @@ pub(super) fn apply_prop_reads_in_prop_default_values(line: &str, prop_vars: &[S
                         ')' | ']' | '}' => {
                             d -= 1;
                             if d == 0 {
-                                ec = Some(ci);
+                                ec = Some(CharOffset::new(ci));
                                 break;
                             }
                         }
@@ -906,9 +895,9 @@ pub(super) fn apply_prop_reads_in_prop_default_values(line: &str, prop_vars: &[S
                 }
                 ec
             } {
-                let end_byte = char_byte_positions[end_char + 1];
-                result.push_str(&after_prop[..end_byte]);
-                search_from = abs_pos + 7 + end_byte;
+                let end_byte = char_to_byte.byte(end_char.next());
+                result.push_str(end_byte.before(after_prop));
+                search_from = abs_pos + 7 + end_byte.get();
             } else {
                 result.push_str(after_prop);
                 search_from = line.len();
@@ -943,19 +932,10 @@ pub(super) fn apply_store_reads_in_prop_default_values(
         let mut i = 0usize;
         let mut depth: i32 = 1;
         let mut arg_count = 0usize;
-        let mut fourth_arg_start: Option<usize> = None;
-        let mut fourth_arg_end: Option<usize> = None;
+        let mut fourth_arg_start: Option<CharOffset> = None;
+        let mut fourth_arg_end: Option<CharOffset> = None;
         let mut in_string: Option<char> = None;
-
-        let mut char_byte_positions: Vec<usize> = Vec::new();
-        {
-            let mut byte_pos = 0;
-            for ch in after_prop.chars() {
-                char_byte_positions.push(byte_pos);
-                byte_pos += ch.len_utf8();
-            }
-            char_byte_positions.push(byte_pos);
-        }
+        let char_to_byte = CharToByte::new(after_prop);
 
         while i < chars.len() {
             let c = chars[i];
@@ -977,7 +957,7 @@ pub(super) fn apply_store_reads_in_prop_default_values(
                     depth -= 1;
                     if depth == 0 {
                         if fourth_arg_start.is_some() {
-                            fourth_arg_end = Some(i);
+                            fourth_arg_end = Some(CharOffset::new(i));
                         }
                         break;
                     }
@@ -989,7 +969,7 @@ pub(super) fn apply_store_reads_in_prop_default_values(
                         while j < chars.len() && chars[j].is_whitespace() {
                             j += 1;
                         }
-                        fourth_arg_start = Some(j);
+                        fourth_arg_start = Some(CharOffset::new(j));
                     }
                 }
                 _ => {}
@@ -998,10 +978,10 @@ pub(super) fn apply_store_reads_in_prop_default_values(
         }
 
         if let (Some(start_char), Some(end_char)) = (fourth_arg_start, fourth_arg_end) {
-            let start_byte = char_byte_positions[start_char];
-            let end_byte = char_byte_positions[end_char];
-            let before_default = &after_prop[..start_byte];
-            let default_val = &after_prop[start_byte..end_byte];
+            let start_byte = char_to_byte.byte(start_char);
+            let end_byte = char_to_byte.byte(end_char);
+            let before_default = start_byte.before(after_prop);
+            let default_val = start_byte.to(end_byte, after_prop);
 
             // Only transform if default is wrapped in an arrow function.
             let trimmed_default = default_val.trim_start();
@@ -1018,9 +998,9 @@ pub(super) fn apply_store_reads_in_prop_default_values(
             result.push_str("$.prop(");
             result.push_str(before_default);
             result.push_str(&transformed_default);
-            let close_byte = char_byte_positions[end_char + 1];
-            result.push_str(&after_prop[end_byte..close_byte]);
-            search_from = abs_pos + 7 + close_byte;
+            let close_byte = char_to_byte.byte(end_char.next());
+            result.push_str(end_byte.to(close_byte, after_prop));
+            search_from = abs_pos + 7 + close_byte.get();
         } else {
             result.push_str("$.prop(");
             let mut d: i32 = 1;
@@ -1039,7 +1019,7 @@ pub(super) fn apply_store_reads_in_prop_default_values(
                     ')' | ']' | '}' => {
                         d -= 1;
                         if d == 0 {
-                            ec = Some(ci);
+                            ec = Some(CharOffset::new(ci));
                             break;
                         }
                     }
@@ -1047,9 +1027,9 @@ pub(super) fn apply_store_reads_in_prop_default_values(
                 }
             }
             if let Some(end_char) = ec {
-                let end_byte = char_byte_positions[end_char + 1];
-                result.push_str(&after_prop[..end_byte]);
-                search_from = abs_pos + 7 + end_byte;
+                let end_byte = char_to_byte.byte(end_char.next());
+                result.push_str(end_byte.before(after_prop));
+                search_from = abs_pos + 7 + end_byte.get();
             } else {
                 result.push_str(after_prop);
                 search_from = line.len();
@@ -3357,9 +3337,9 @@ pub(super) fn wrap_prop_mutation_validation(
             let mut depth = 1i32; // we're inside prop(
             let mut close_pos = None;
             let rest_chars: Vec<char> = rest.chars().collect();
+            let char_to_byte = CharToByte::new(rest);
             let mut in_str: Option<char> = None;
             let mut ci = 0;
-            let mut byte_i = 0;
             while ci < rest_chars.len() {
                 let c = rest_chars[ci];
                 if let Some(quote) = in_str {
@@ -3380,24 +3360,24 @@ pub(super) fn wrap_prop_mutation_validation(
                         ')' | ']' | '}' => {
                             depth -= 1;
                             if depth == 0 {
-                                close_pos = Some(byte_i);
+                                close_pos = Some(CharOffset::new(ci));
                                 break;
                             }
                         }
                         _ => {}
                     }
                 }
-                byte_i += c.len_utf8();
                 ci += 1;
             }
 
-            let Some(close_byte_pos) = close_pos else {
+            let Some(close_char_pos) = close_pos else {
                 search_from = abs_start + wrapper_start_len;
                 continue;
             };
 
-            // The content inside prop(...) is rest[..close_byte_pos]
-            let inner_content = &rest[..close_byte_pos];
+            // The content inside prop(...).
+            let close_byte_pos = char_to_byte.byte(close_char_pos);
+            let inner_content = close_byte_pos.before(rest);
 
             // Check if it ends with `, true` — the comma and the flag may be on
             // separate lines when the printer broke the call up.
@@ -3518,7 +3498,7 @@ pub(super) fn wrap_prop_mutation_validation(
             }
 
             // The full original expression is the entire prop(prop().member = value, true) call
-            let end_pos = inner_start + close_byte_pos + 1; // +1 for closing paren
+            let end_pos = inner_start + close_byte_pos.next().get();
             // Upstream builds the `$.invalidate_inner_signals` sequence first and
             // passes the whole thing to `validate_mutation`, so the sequence has to
             // go inside the wrap rather than around it.
@@ -4605,6 +4585,24 @@ mod split_declarators_tests {
     }
 
     #[test]
+    fn legacy_default_scanners_keep_offset_units_separate() {
+        assert_eq!(
+            apply_prop_reads_in_prop_default_values(
+                "☃ $.prop($$props, '名', 24, () => logs.push(1));",
+                &["logs".to_string()],
+            ),
+            "☃ $.prop($$props, '名', 24, () => logs().push(1));",
+        );
+        assert_eq!(
+            super::apply_store_reads_in_prop_default_values(
+                "$.prop($$props, '名', 24, () => $items);",
+                &["$items".to_string()],
+            ),
+            "$.prop($$props, '名', 24, () => $items());",
+        );
+    }
+
+    #[test]
     fn splits_top_level_commas() {
         assert_eq!(split_declarators("a, b, c"), vec!["a", " b", " c"]);
     }
@@ -4835,6 +4833,9 @@ mod non_ascii_boundary_tests {
             "\u{540D}count(count().a = 1, true);"
         );
         assert!(wrap("count(count().a = 1, true);").starts_with("$$ownership_validator.mutation("));
+        assert!(
+            wrap("count(count().名 = 1, true);").starts_with("$$ownership_validator.mutation(")
+        );
     }
 
     /// `PropMutationSites::collect` carries the same boundary; a site collected

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/props_transforms.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/props_transforms.rs
@@ -3010,16 +3010,17 @@ pub(super) fn transform_rest_prop_member_access(line: &str, rest_prop_vars: &[St
                 new_result.push_str(mat.as_str());
             } else {
                 // Find the end of the property name
-                let mut prop_end = 0;
+                let mut prop_end = CharOffset::ZERO;
                 for (i, c) in after_match.chars().enumerate() {
                     if c.is_alphanumeric() || c == '_' || c == '$' {
-                        prop_end = i + 1;
+                        prop_end = CharOffset::new(i).next();
                     } else {
                         break;
                     }
                 }
 
-                let after_prop = &after_match[prop_end..].trim_start();
+                let char_to_byte = CharToByte::new(after_match);
+                let after_prop = char_to_byte.byte(prop_end).after(after_match).trim_start();
                 let is_direct_assignment =
                     after_prop.starts_with('=') && !after_prop.starts_with("==");
                 let has_deeper_access = after_prop.starts_with('.');
@@ -4498,6 +4499,20 @@ mod prop_mutation_location_tests {
         assert_eq!(
             wrap_prop_mutation_validation("item().name = 1", &prop_vars, source),
             "$$ownership_validator.mutation('item', ['item', 'name'], item().name = 1, 3, 23)"
+        );
+    }
+}
+
+#[cfg(test)]
+mod rest_prop_fallback_tests {
+    use super::transform_rest_prop_member_access;
+
+    #[test]
+    fn keeps_non_ascii_property_boundaries() {
+        let input = "@ rest.名前 = 1";
+        assert_eq!(
+            transform_rest_prop_member_access(input, &["rest".to_string()]),
+            input,
         );
     }
 }

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/state_transforms.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/state_transforms.rs
@@ -17,6 +17,7 @@ use crate::compiler::phases::phase2_analyze::scope::DeclarationKind;
 #[cfg(test)]
 use crate::compiler::phases::phase3_transform::shared::js_scan::code_bytes_from;
 use crate::compiler::phases::phase3_transform::shared::js_scan::{code_bytes, skip_opaque};
+use crate::compiler::phases::phase3_transform::shared::offsets::{ByteLen, ByteOffset};
 
 // ---------------------------------------------------------------------------
 // Identifier reference detection (lines 7653-8602 of mod.rs)
@@ -1660,7 +1661,8 @@ pub(super) fn transform_legacy_state_declarations<'a>(
                     // Check if this declaration is inside a for-loop header.
                     // Scan backwards from `pos` to see if we find `for (` with unmatched parens.
                     let chars: Vec<char> = result.chars().collect();
-                    let char_pos = byte_pos_to_char_index(&result, pos + keyword.len() + 1);
+                    let byte_pos = ByteOffset::new(pos) + ByteLen::of(keyword) + ByteLen::ONE;
+                    let char_pos = byte_pos_to_char_index(&result, byte_pos);
                     if is_shadowed_by_for_loop_var(&chars, char_pos, var) {
                         // This `let x = ...` is inside a for-loop header, skip it
                         search_offset = pos + pattern_with_init.len();
@@ -1793,7 +1795,8 @@ pub(super) fn transform_legacy_state_declarations<'a>(
 
                     // Check if this declaration is inside a for-loop header
                     let chars: Vec<char> = result.chars().collect();
-                    let char_pos = byte_pos_to_char_index(&result, pos + keyword.len() + 1);
+                    let byte_pos = ByteOffset::new(pos) + ByteLen::of(keyword) + ByteLen::ONE;
+                    let char_pos = byte_pos_to_char_index(&result, byte_pos);
                     if is_shadowed_by_for_loop_var(&chars, char_pos, var) {
                         search_offset = pos + pattern_no_init.len();
                         continue;
@@ -1845,7 +1848,8 @@ pub(super) fn transform_legacy_state_declarations<'a>(
 
                     // Check if this declaration is inside a for-loop header
                     let chars: Vec<char> = result.chars().collect();
-                    let char_pos = byte_pos_to_char_index(&result, pos + keyword.len() + 1);
+                    let byte_pos = ByteOffset::new(pos) + ByteLen::of(keyword) + ByteLen::ONE;
+                    let char_pos = byte_pos_to_char_index(&result, byte_pos);
                     if is_shadowed_by_for_loop_var(&chars, char_pos, var) {
                         search_offset = pos + pattern_no_semi.len();
                         continue;
@@ -2020,8 +2024,11 @@ mod scan_lexing_tests {
 
 #[cfg(test)]
 mod non_ascii_tests {
-    use super::{body_references_identifier, transform_legacy_state_declarations};
+    use super::{
+        body_references_identifier, byte_pos_to_char_index, transform_legacy_state_declarations,
+    };
     use crate::compiler::phases::phase2_analyze::scope::DeclarationKind;
+    use crate::compiler::phases::phase3_transform::shared::offsets::{ByteOffset, CharOffset};
 
     #[test]
     fn body_references_identifier_handles_non_ascii_statement() {
@@ -2032,12 +2039,27 @@ mod non_ascii_tests {
     }
 
     #[test]
+    fn byte_position_conversion_is_typed_after_non_ascii() {
+        assert_eq!(
+            byte_pos_to_char_index("名let", ByteOffset::new("名".len())),
+            CharOffset::new(1),
+        );
+    }
+
+    #[test]
     fn transform_legacy_state_declarations_handles_non_ascii_type() {
         // `let x: Café = 0` — the `=` sits past a multi-byte char in the type
         // annotation; slicing must use byte offsets (no panic).
         let vars = vec![("x".to_string(), None, DeclarationKind::Let)];
         let out = transform_legacy_state_declarations("let x: Café = 0", &vars, false, false);
         assert!(out.contains("$.mutable_source(0)"), "got: {out}");
+    }
+
+    #[test]
+    fn for_loop_shadow_scan_converts_a_byte_position_after_non_ascii() {
+        let vars = vec![("x".to_string(), None, DeclarationKind::Let)];
+        let out = transform_legacy_state_declarations("名(); let x = 0;", &vars, false, false);
+        assert_eq!(out, "名(); let x = $.mutable_source(0);");
     }
 }
 

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/store_transforms.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/store_transforms.rs
@@ -5,6 +5,7 @@ use rustc_hash::FxHashSet;
 
 use super::scan_index::ScanIndex;
 use super::{find_matching_paren, is_shorthand_object_property};
+use crate::compiler::phases::phase3_transform::shared::offsets::{CharLen, CharOffset, CharToByte};
 
 /// Transform store assignments in client-side code.
 ///
@@ -370,29 +371,31 @@ pub(super) fn transform_store_reads_client(line: &str, store_sub_vars: &[String]
         // But avoid replacing function calls that already have ()
         let mut new_result = String::with_capacity(result.len() * 2);
         // `i` walks `chars`, so the name's length has to be counted in the same unit.
-        let sub_chars = store_sub.chars().count();
+        let sub_chars = CharLen::of(store_sub);
         let chars: Vec<char> = result.chars().collect();
         let index = ScanIndex::new(&chars);
-        let mut char_byte_offsets: Vec<usize> = result.char_indices().map(|(i, _)| i).collect();
-        char_byte_offsets.push(result.len());
-        let mut i = 0;
+        let char_to_byte = CharToByte::new(&result);
+        let mut i = CharOffset::ZERO;
 
-        while i < chars.len() {
+        while i.get() < chars.len() {
             // Check if we're at the start of the identifier
-            let byte_i = char_byte_offsets[i];
-            let remaining = &result[byte_i..];
+            let byte_i = char_to_byte.byte(i);
+            let remaining = byte_i.after(&result);
             if remaining.starts_with(store_sub) {
                 // Check character before (must be non-identifier char or start of string)
                 // Also exclude `.` - a dot before means this is a property access like `obj.$value`.
                 // EXCEPTION: a `...` spread (`[...$store]`, `f(...$store)`) ends in a `.`
                 // but is NOT a property access — the spread argument IS a read and must be
                 // wrapped. Detect the spread by the three preceding dots.
-                let is_spread_prefix =
-                    i >= 3 && chars[i - 1] == '.' && chars[i - 2] == '.' && chars[i - 3] == '.';
-                let before_ok = if i == 0 || is_spread_prefix {
+                let char_i = i.get();
+                let is_spread_prefix = char_i >= 3
+                    && chars[char_i - 1] == '.'
+                    && chars[char_i - 2] == '.'
+                    && chars[char_i - 3] == '.';
+                let before_ok = if i == CharOffset::ZERO || is_spread_prefix {
                     true
                 } else {
-                    let prev_char = chars[i - 1];
+                    let prev_char = chars[char_i - 1];
                     !prev_char.is_alphanumeric()
                         && prev_char != '_'
                         && prev_char != '$'
@@ -401,16 +404,17 @@ pub(super) fn transform_store_reads_client(line: &str, store_sub_vars: &[String]
 
                 // Check character after (must be non-identifier char)
                 let after_idx = i + sub_chars;
-                let after_ok = if after_idx >= chars.len() {
+                let after_ok = if after_idx.get() >= chars.len() {
                     true
                 } else {
-                    let next_char = chars[after_idx];
+                    let next_char = chars[after_idx.get()];
                     !next_char.is_alphanumeric() && next_char != '_' && next_char != '$'
                 };
 
                 // Check if this reference is already followed by `()` (getter call)
                 // If so, skip adding () to avoid double-calling: $x() is already correct
-                let is_already_call = after_idx < chars.len() && chars[after_idx] == '(';
+                let is_already_call =
+                    after_idx.get() < chars.len() && chars[after_idx.get()] == '(';
 
                 // Check if this is inside $.untrack() or $.derived() - don't transform there
                 // $.untrack expects a getter function, so $store should remain $store
@@ -430,12 +434,12 @@ pub(super) fn transform_store_reads_client(line: &str, store_sub_vars: &[String]
                     let after_idx2 = i + sub_chars;
                     let mut k = after_idx2;
                     // Skip whitespace
-                    while k < chars.len() && chars[k].is_whitespace() {
-                        k += 1;
+                    while k.get() < chars.len() && chars[k.get()].is_whitespace() {
+                        k = k.next();
                     }
-                    let has_colon = k < chars.len()
-                        && chars[k] == ':'
-                        && (k + 1 >= chars.len() || chars[k + 1] != ':');
+                    let has_colon = k.get() < chars.len()
+                        && chars[k.get()] == ':'
+                        && (k.next().get() >= chars.len() || chars[k.next().get()] != ':');
 
                     // A real property key is ALWAYS immediately preceded (skipping
                     // whitespace/newlines) by `{` (first entry) or `,` (later entry).
@@ -444,7 +448,7 @@ pub(super) fn transform_store_reads_client(line: &str, store_sub_vars: &[String]
                     // whose block `{` would otherwise make the brace-depth check below
                     // a false positive for any ternary `$store :` in the body.
                     let prev_is_obj_sep = {
-                        let mut j = i;
+                        let mut j = i.get();
                         while j > 0 && chars[j - 1].is_whitespace() {
                             j -= 1;
                         }
@@ -473,32 +477,33 @@ pub(super) fn transform_store_reads_client(line: &str, store_sub_vars: &[String]
                 // state rather than only inspecting the preceding char. A `$x`
                 // inside a `${ }` interpolation is code and is still transformed.
                 let is_inside_string =
-                    super::state_transforms::is_inside_string_literal(&result, byte_i);
+                    super::state_transforms::is_inside_string_literal(&result, byte_i.get());
 
                 if before_ok && after_ok {
                     if is_inside_string {
                         // Inside a string literal - don't transform
                         new_result.push_str(store_sub);
-                        i += sub_chars;
+                        i = i + sub_chars;
                         continue;
                     } else if is_property_key {
                         // Don't transform property keys like `{ $userName4: value }`
                         new_result.push_str(store_sub);
-                        i += sub_chars;
+                        i = i + sub_chars;
                         continue;
                     } else if is_inside_getter_context {
                         // Inside $.untrack() or $.derived(), keep as $store (don't add parentheses)
                         new_result.push_str(store_sub);
-                        i += sub_chars;
+                        i = i + sub_chars;
                         continue;
                     } else if is_already_call {
                         // Already followed by `(` - don't add another `()`
                         // This handles cases like `$x()` or `$.update_store(x, $x())`
                         // where the `()` was already generated by store assignment transforms
                         new_result.push_str(store_sub);
-                        i += sub_chars;
+                        i = i + sub_chars;
                         continue;
-                    } else if is_shorthand_object_property(&index, &chars, i, sub_chars) {
+                    } else if is_shorthand_object_property(&index, &chars, i.get(), sub_chars.get())
+                    {
                         // Shorthand object property: `{ $width }` -> `{ $width: $width() }`.
                         // Emitting `{ $width() }` is invalid (method shorthand), so expand
                         // like the prop-read path, keeping the leading `$` in the key.
@@ -506,21 +511,21 @@ pub(super) fn transform_store_reads_client(line: &str, store_sub_vars: &[String]
                         new_result.push_str(": ");
                         new_result.push_str(store_sub);
                         new_result.push_str("()");
-                        i += sub_chars;
+                        i = i + sub_chars;
                         continue;
                     } else {
                         // Bare store reference - add () to call the getter
                         new_result.push_str(store_sub);
                         new_result.push_str("()");
-                        i += sub_chars;
+                        i = i + sub_chars;
                         continue;
                     }
                 }
             }
 
             // No match, just copy the character
-            new_result.push(chars[i]);
-            i += 1;
+            new_result.push(chars[i.get()]);
+            i = i.next();
         }
 
         result = new_result;

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/shared/offsets.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/shared/offsets.rs
@@ -177,6 +177,16 @@ impl CharToByte {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use static_assertions::{assert_impl_all, assert_not_impl_any};
+
+    assert_impl_all!(ByteOffset: Add<ByteLen, Output = ByteOffset>, Sub<ByteLen, Output = ByteOffset>);
+    assert_impl_all!(CharOffset: Add<CharLen, Output = CharOffset>, Sub<CharLen, Output = CharOffset>);
+    assert_not_impl_any!(
+        ByteOffset: Add<usize>, Sub<usize>, Add<CharLen>, Sub<CharLen>, Into<CharOffset>
+    );
+    assert_not_impl_any!(
+        CharOffset: Add<usize>, Sub<usize>, Add<ByteLen>, Sub<ByteLen>, Into<ByteOffset>
+    );
 
     #[test]
     fn conversion_lands_on_char_boundaries() {


### PR DESCRIPTION
Closes #2386

## What changed

- keep character and byte coordinates typed through every remaining Phase 3 crossing in the destructure, store, prop-default, prop-mutation, rest-prop, and legacy-state fallback scanners
- replace raw `Vec<usize>` conversion tables with `CharToByte`, and make byte-to-char conversion accept `ByteOffset` and return `CharOffset`
- add compile-time assertions that reject `usize`, cross-unit length arithmetic, and implicit `Into` conversions
- fix the non-ASCII rest-prop fallback panic surfaced by the final sweep, in its own commit with a failing-first regression test
- add a compiler patch changeset

## Why

The official Svelte compiler performs these transformations over AST nodes, so character indices never cross into UTF-8 string slicing. rsvelte still retains text fallbacks for malformed or unsupported intermediate programs. Before this PR, several of those fallbacks computed a position in `Vec<char>` space and carried it through an untyped `usize` boundary into a `&str` slice. The newtypes make that mismatch a compile error at the boundary.

The completed Phase 3 producer census covered 71 producer hits across 24 compiler files. `scan_index.rs` and the other excluded sites remain entirely in `&[char]` space; after the changes here, the Phase 3 char-to-byte crossing population is zero.

## Validation

- `cargo fmt --all -- --check`
- `RUST_MIN_STACK=33554432 cargo test -p rsvelte_core --lib` — 1621 passed, 1 ignored
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo clippy -p rsvelte_core --all-targets --all-features -- -D warnings`

No compatibility baseline was changed because the type-only slices preserve output; the one behavior fix has a focused malformed-fallback regression test.
