### PR TITLE
perf(esrap): outperform OXC on common comments

### DIFF
--- a/.changeset/swift-esrap-comments.md
+++ b/.changeset/swift-esrap-comments.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/compiler": patch
+---
+
+Print comment-bearing JavaScript faster while preserving all comments. Release `rsvelte_esrap` 0.10.28 and update the compiler's exact dependency.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2612,7 +2612,7 @@ dependencies = [
 
 [[package]]
 name = "rsvelte_esrap"
-version = "0.10.27"
+version = "0.10.28"
 dependencies = [
  "compact_str 0.10.0",
  "memchr",

--- a/crates/rsvelte_core/Cargo.toml
+++ b/crates/rsvelte_core/Cargo.toml
@@ -94,7 +94,7 @@ oxc_ast = { version = "0.144", features = ["serialize"] }
 oxc_span = "0.144"
 oxc_diagnostics = "0.144"
 oxc_codegen = "0.144"
-rsvelte_esrap = { version = "=0.10.27", path = "../rsvelte_esrap" }
+rsvelte_esrap = { version = "=0.10.28", path = "../rsvelte_esrap" }
 oxc_syntax = "0.144"
 oxc_semantic = "0.144"
 

--- a/crates/rsvelte_esrap/Cargo.toml
+++ b/crates/rsvelte_esrap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rsvelte_esrap"
-version = "0.10.27"
+version = "0.10.28"
 edition = "2024"
 rust-version = "1.95"
 description = "A Rust port of esrap — prints an oxc AST to JavaScript with esrap's exact layout"

--- a/crates/rsvelte_esrap/src/lib.rs
+++ b/crates/rsvelte_esrap/src/lib.rs
@@ -109,38 +109,44 @@ pub fn print(program: &Program<'_>, source: &str) -> String {
 
 /// Print `program` to JavaScript with explicit options, interleaving comments.
 pub fn print_with(program: &Program<'_>, source: &str, options: &PrintOptions) -> String {
-    let (comments, line_starts) = comments_and_line_starts(program, source);
-    if comments.is_empty() {
-        print_direct(program, options, source.len())
+    if program.comments.is_empty() {
+        print_direct::<false>(program, options, source.len(), Vec::new(), Vec::new())
+    } else if printer::comments_are_program_level(program) {
+        print_direct_outer_comments(program, source, options)
     } else {
-        print_with_impl::<true>(program, options, comments, line_starts)
+        let (comments, line_starts) = comments_and_line_starts(program, source);
+        print_direct::<true>(program, options, source.len(), comments, line_starts)
     }
 }
 
-fn print_direct(program: &Program<'_>, options: &PrintOptions, capacity: usize) -> String {
+fn print_direct_outer_comments(
+    program: &Program<'_>,
+    source: &str,
+    options: &PrintOptions,
+) -> String {
     let mut printer =
         printer::Printer::<false, true>::with_comments(options, Vec::new(), Vec::new());
-    let mut ctx = context::Context::new_direct(&options.indent, capacity);
-    printer.print_program(program, &mut ctx);
+    let mut ctx = context::Context::new_direct(&options.indent, source.len());
+    printer.print_program_with_outer_comments(program, source, &mut ctx);
     let (buffer, returned, indent, dirty) = ctx.into_direct_parts();
     let (code, buffer) = command::finish_direct(buffer, &indent, dirty);
     pool::give(buffer, returned);
     code
 }
 
-fn print_with_impl<const HAS_COMMENTS: bool>(
+fn print_direct<const HAS_COMMENTS: bool>(
     program: &Program<'_>,
     options: &PrintOptions,
+    capacity: usize,
     comments: Vec<printer::Cmt>,
     line_starts: Vec<u32>,
 ) -> String {
     let mut printer =
-        printer::Printer::<HAS_COMMENTS, false>::with_comments(options, comments, line_starts);
-    let mut ctx = context::Context::new();
+        printer::Printer::<HAS_COMMENTS, true>::with_comments(options, comments, line_starts);
+    let mut ctx = context::Context::new_direct(&options.indent, capacity);
     printer.print_program(program, &mut ctx);
-    let capacity = ctx.measure();
-    let (buffer, returned) = ctx.into_parts();
-    let code = command::print(&buffer, &options.indent, capacity);
+    let (buffer, returned, indent, dirty) = ctx.into_direct_parts();
+    let (code, buffer) = command::finish_direct(buffer, &indent, dirty);
     pool::give(buffer, returned);
     code
 }
@@ -210,9 +216,10 @@ fn print_split_impl<const HAS_COMMENTS: bool>(
     line_starts: Vec<u32>,
     map_line_starts: Vec<u32>,
 ) -> PrintWithMap {
-    if !HAS_COMMENTS && map_source.is_none() {
+    if map_source.is_none() {
         let mut printer =
-            printer::Printer::<false, true>::with_comments(options, Vec::new(), Vec::new());
+            printer::Printer::<HAS_COMMENTS, true>::with_comments(options, comments, line_starts)
+                .with_split_coordinates(map_line_starts, loc_base, loc_map, false);
         let mut ctx = context::Context::new_direct(&options.indent, program.source_text.len());
         printer.print_program(program, &mut ctx);
         let (buffer, returned, indent, dirty) = ctx.into_direct_parts();

--- a/crates/rsvelte_esrap/src/lib.rs
+++ b/crates/rsvelte_esrap/src/lib.rs
@@ -110,12 +110,18 @@ pub fn print(program: &Program<'_>, source: &str) -> String {
 /// Print `program` to JavaScript with explicit options, interleaving comments.
 pub fn print_with(program: &Program<'_>, source: &str, options: &PrintOptions) -> String {
     if program.comments.is_empty() {
-        print_direct::<false>(program, options, source.len(), Vec::new(), Vec::new())
+        print_direct::<false>(program, options, source.len(), Vec::new(), Vec::new(), None)
     } else if printer::comments_are_program_level(program) {
         print_direct_outer_comments(program, source, options)
     } else {
-        let (comments, line_starts) = comments_and_line_starts(program, source);
-        print_direct::<true>(program, options, source.len(), comments, line_starts)
+        print_direct::<true>(
+            program,
+            options,
+            source.len(),
+            Vec::new(),
+            Vec::new(),
+            Some(source),
+        )
     }
 }
 
@@ -134,15 +140,19 @@ fn print_direct_outer_comments(
     code
 }
 
-fn print_direct<const HAS_COMMENTS: bool>(
-    program: &Program<'_>,
-    options: &PrintOptions,
+fn print_direct<'a, const HAS_COMMENTS: bool>(
+    program: &'a Program<'a>,
+    options: &'a PrintOptions,
     capacity: usize,
     comments: Vec<printer::Cmt>,
     line_starts: Vec<u32>,
+    comment_source: Option<&'a str>,
 ) -> String {
     let mut printer =
         printer::Printer::<HAS_COMMENTS, true>::with_comments(options, comments, line_starts);
+    if let Some(source) = comment_source {
+        printer = printer.with_borrowed_comments(&program.comments, source);
+    }
     let mut ctx = context::Context::new_direct(&options.indent, capacity);
     printer.print_program(program, &mut ctx);
     let (buffer, returned, indent, dirty) = ctx.into_direct_parts();

--- a/crates/rsvelte_esrap/src/printer.rs
+++ b/crates/rsvelte_esrap/src/printer.rs
@@ -139,6 +139,125 @@ fn write_comment<const DIRECT: bool>(cmt: &Cmt, ctx: &mut Context<DIRECT>) {
     }
 }
 
+struct BorrowedCommentDriver<'a> {
+    comments: &'a [oxc_ast::ast::Comment],
+    source: &'a str,
+    index: usize,
+}
+
+impl<'a> BorrowedCommentDriver<'a> {
+    fn new(program: &'a Program<'a>, source: &'a str, located: bool) -> Self {
+        Self {
+            comments: &program.comments,
+            source,
+            index: if located { 0 } else { program.comments.len() },
+        }
+    }
+
+    fn flush_until<const DIRECT: bool>(
+        &mut self,
+        ctx: &mut Context<DIRECT>,
+        to: u32,
+        from: Option<u32>,
+        pad: bool,
+    ) {
+        let Some(next) = self.comments.get(self.index) else {
+            return;
+        };
+        if next.span.start >= to {
+            return;
+        }
+        let mut first = true;
+        while let Some(comment) = self.comments.get(self.index) {
+            if comment.span.start >= to {
+                break;
+            }
+            if first && from.is_some_and(|from| self.has_newline(from, comment.span.start)) {
+                ctx.margin();
+                ctx.newline();
+            }
+            first = false;
+            self.write(comment, ctx);
+            if self.has_newline(comment.span.end, to) {
+                ctx.newline();
+            } else if pad {
+                ctx.write_ascii(b' ');
+            }
+            self.index += 1;
+        }
+    }
+
+    fn flush_trailing<const DIRECT: bool>(
+        &mut self,
+        ctx: &mut Context<DIRECT>,
+        prev_end: u32,
+        next: Option<u32>,
+    ) {
+        while let Some(comment) = self.comments.get(self.index) {
+            if self.has_newline(prev_end, comment.span.start)
+                || next.is_some_and(|next| comment.span.end >= next)
+            {
+                break;
+            }
+            ctx.write_ascii(b' ');
+            self.write(comment, ctx);
+            self.index += 1;
+            if matches!(comment.kind, oxc_ast::ast::CommentKind::Line) {
+                ctx.newline();
+                break;
+            }
+        }
+    }
+
+    fn has_newline(&self, start: u32, end: u32) -> bool {
+        debug_assert!(start <= end);
+        self.source
+            .get(start as usize..end as usize)
+            .is_some_and(|text| text.as_bytes().contains(&b'\n'))
+    }
+
+    fn write<const DIRECT: bool>(
+        &self,
+        comment: &oxc_ast::ast::Comment,
+        ctx: &mut Context<DIRECT>,
+    ) {
+        let raw = comment.span.source_text(self.source);
+        if matches!(comment.kind, oxc_ast::ast::CommentKind::Line) {
+            ctx.write(raw);
+            return;
+        }
+        let inner = raw
+            .strip_prefix("/*")
+            .and_then(|text| text.strip_suffix("*/"))
+            .unwrap_or(raw);
+        if !inner.contains('\n') {
+            ctx.write(raw);
+            return;
+        }
+
+        let line_start = self.source[..comment.span.start as usize]
+            .rfind('\n')
+            .map_or(0, |index| index + 1);
+        let opener_line = &self.source[line_start..comment.span.start as usize];
+        let indent_len = opener_line
+            .as_bytes()
+            .iter()
+            .take_while(|&&byte| matches!(byte, b' ' | b'\t'))
+            .count();
+        let indentation = &opener_line[..indent_len];
+
+        ctx.write_ascii_bytes(b"/*");
+        for (index, line) in inner.split('\n').enumerate() {
+            if index > 0 {
+                ctx.newline();
+            }
+            ctx.write(line.strip_prefix(indentation).unwrap_or(line));
+        }
+        ctx.write_ascii_bytes(b"*/");
+        ctx.newline();
+    }
+}
+
 /// Byte offsets at which each source line begins (line 1 starts at 0).
 pub fn line_starts(source: &str) -> Vec<u32> {
     // Sized off an assumed ~32 bytes per line so a long source does not walk the
@@ -204,6 +323,35 @@ pub fn build_comments(program: &Program<'_>, source: &str, starts: &[u32]) -> Ve
             }
         })
         .collect()
+}
+
+pub(crate) fn comments_are_program_level(program: &Program<'_>) -> bool {
+    let mut comment_index = 0;
+    let spans = program
+        .directives
+        .iter()
+        .map(|directive| directive.span)
+        .chain(program.body.iter().map(GetSpan::span));
+    for span in spans {
+        if span.start == u32::MAX || span.end == u32::MAX {
+            return false;
+        }
+        while program
+            .comments
+            .get(comment_index)
+            .is_some_and(|comment| comment.span.end <= span.start)
+        {
+            comment_index += 1;
+        }
+        if program
+            .comments
+            .get(comment_index)
+            .is_some_and(|comment| comment.span.start < span.end)
+        {
+            return false;
+        }
+    }
+    true
 }
 
 /// Strip the comment opener's line indentation from every line of a multi-line
@@ -423,6 +571,12 @@ impl<'opt, const HAS_COMMENTS: bool, const DIRECT: bool> Printer<'opt, HAS_COMME
         // SAFETY: the const parameter does not affect the repr(C) field layout.
         unsafe { &mut *(std::ptr::from_mut(self).cast()) }
     }
+
+    fn comment_free(&mut self) -> &mut Printer<'opt, false, DIRECT> {
+        // SAFETY: the const parameter does not affect the repr(C) field layout.
+        unsafe { &mut *(std::ptr::from_mut(self).cast()) }
+    }
+
     #[cfg(test)]
     pub const fn new(options: &'opt PrintOptions) -> Self {
         Self {
@@ -870,6 +1024,20 @@ impl<'opt, const HAS_COMMENTS: bool, const DIRECT: bool> Printer<'opt, HAS_COMME
         trailing_newline: bool,
         parent: &mut Context<DIRECT>,
     ) {
+        // A comment can introduce a newline while rendering, so only clean sequences pre-indent.
+        let has_sequence_comments = DIRECT && HAS_COMMENTS && n > 0 && {
+            let before_until = |cmt: &Cmt| until.is_none_or(|end| cmt.start < end);
+            let pending = self
+                .comments
+                .get(self.comment_index)
+                .is_some_and(before_until);
+            let in_nodes = meta(0).start.is_none_or(|start| {
+                let index = self.comments.partition_point(|cmt| cmt.start < start);
+                self.comments.get(index).is_some_and(before_until)
+            });
+            pending || in_nodes
+        };
+        let direct_layout = DIRECT && !has_sequence_comments;
         if n == 0 {
             if let Some(until) = until {
                 self.flush_comments_until(parent, until, None, false);
@@ -880,7 +1048,7 @@ impl<'opt, const HAS_COMMENTS: bool, const DIRECT: bool> Printer<'opt, HAS_COMME
         if n == 1 {
             let node_meta = meta(0);
             let mark = parent.event_mark();
-            if DIRECT {
+            if direct_layout {
                 if pad {
                     parent.optimistic_space();
                 }
@@ -897,17 +1065,17 @@ impl<'opt, const HAS_COMMENTS: bool, const DIRECT: bool> Printer<'opt, HAS_COMME
             let length = parent.measure();
             let multiline = parent.end_scope(scope);
 
-            if DIRECT && pad && length == 0 {
+            if direct_layout && pad && length == 0 {
                 parent.cancel_optimistic_space();
             }
 
             if multiline {
                 parent.insert_event(mark, EventKind::Newline);
-                if !DIRECT {
+                if !direct_layout {
                     parent.insert_event(mark, EventKind::Indent);
                 }
                 parent.multiline = true;
-            } else if !DIRECT && pad && length > 0 {
+            } else if !direct_layout && pad && length > 0 {
                 parent.insert_event(mark, EventKind::Space);
             }
 
@@ -921,7 +1089,7 @@ impl<'opt, const HAS_COMMENTS: bool, const DIRECT: bool> Printer<'opt, HAS_COMME
                     parent.newline();
                 }
             } else {
-                if DIRECT {
+                if direct_layout {
                     parent.dedent();
                 }
                 if pad && length > 0 {
@@ -936,13 +1104,13 @@ impl<'opt, const HAS_COMMENTS: bool, const DIRECT: bool> Printer<'opt, HAS_COMME
             let mut length: i64 = -1;
             let mut items = [None; 3];
 
-            if DIRECT {
+            if direct_layout {
                 parent.indent();
             }
 
             for (i, item) in items.iter_mut().enumerate().take(n) {
                 let node_meta = meta(i);
-                let mark = if DIRECT && (pad || i > 0) && !node_meta.is_elision {
+                let mark = if direct_layout && (pad || i > 0) && !node_meta.is_elision {
                     parent.retro_space_mark()
                 } else {
                     parent.event_mark()
@@ -979,7 +1147,7 @@ impl<'opt, const HAS_COMMENTS: bool, const DIRECT: bool> Printer<'opt, HAS_COMME
                     let margin = prev.multiline
                         && item.multiline
                         && !(prev.obj_or_array && item.obj_or_array);
-                    if !item.is_elision && (multiline || !DIRECT) {
+                    if !item.is_elision && (multiline || !direct_layout) {
                         parent.insert_event(
                             item.mark,
                             if multiline {
@@ -998,11 +1166,11 @@ impl<'opt, const HAS_COMMENTS: bool, const DIRECT: bool> Printer<'opt, HAS_COMME
             let first = items[0].unwrap();
             if multiline {
                 parent.insert_event(first.mark, EventKind::Newline);
-                if !DIRECT {
+                if !direct_layout {
                     parent.insert_event(first.mark, EventKind::Indent);
                 }
                 parent.multiline = true;
-            } else if !DIRECT && pad && length > 0 {
+            } else if !direct_layout && pad && length > 0 {
                 parent.insert_event(first.mark, EventKind::Space);
             }
 
@@ -1016,7 +1184,7 @@ impl<'opt, const HAS_COMMENTS: bool, const DIRECT: bool> Printer<'opt, HAS_COMME
                     parent.newline();
                 }
             } else {
-                if DIRECT {
+                if direct_layout {
                     parent.dedent();
                 }
                 if pad && length > 0 {
@@ -1030,13 +1198,13 @@ impl<'opt, const HAS_COMMENTS: bool, const DIRECT: bool> Printer<'opt, HAS_COMME
         let mut length: i64 = -1;
         let mut items: Vec<SeqLayout> = Vec::with_capacity(n);
 
-        if DIRECT {
+        if direct_layout {
             parent.indent();
         }
 
         for i in 0..n {
             let node_meta = meta(i);
-            let mark = if DIRECT && (pad || i > 0) && !node_meta.is_elision {
+            let mark = if direct_layout && (pad || i > 0) && !node_meta.is_elision {
                 parent.retro_space_mark()
             } else {
                 parent.event_mark()
@@ -1072,7 +1240,7 @@ impl<'opt, const HAS_COMMENTS: bool, const DIRECT: bool> Printer<'opt, HAS_COMME
                 let prev = items[i - 1];
                 let margin =
                     prev.multiline && item.multiline && !(prev.obj_or_array && item.obj_or_array);
-                if !item.is_elision && (multiline || !DIRECT) {
+                if !item.is_elision && (multiline || !direct_layout) {
                     parent.insert_event(
                         item.mark,
                         if multiline {
@@ -1091,11 +1259,11 @@ impl<'opt, const HAS_COMMENTS: bool, const DIRECT: bool> Printer<'opt, HAS_COMME
         if let Some(first) = items.first() {
             if multiline {
                 parent.insert_event(first.mark, EventKind::Newline);
-                if !DIRECT {
+                if !direct_layout {
                     parent.insert_event(first.mark, EventKind::Indent);
                 }
                 parent.multiline = true;
-            } else if !DIRECT && pad && length > 0 {
+            } else if !direct_layout && pad && length > 0 {
                 parent.insert_event(first.mark, EventKind::Space);
             }
         }
@@ -1111,7 +1279,7 @@ impl<'opt, const HAS_COMMENTS: bool, const DIRECT: bool> Printer<'opt, HAS_COMME
                 parent.newline();
             }
         } else {
-            if DIRECT {
+            if direct_layout {
                 parent.dedent();
             }
             if pad && length > 0 {
@@ -1175,6 +1343,58 @@ impl<'opt, const HAS_COMMENTS: bool, const DIRECT: bool> Printer<'opt, HAS_COMME
         self.body_elems(elems, body_start, span.end, ctx);
     }
 
+    pub(crate) fn print_program_with_outer_comments(
+        &mut self,
+        program: &Program,
+        source: &str,
+        ctx: &mut Context<DIRECT>,
+    ) {
+        debug_assert!(!HAS_COMMENTS && DIRECT);
+        let span = program.span();
+        let body_start = (!self.options.unlocated_program).then_some(span.start);
+        let mut comments = BorrowedCommentDriver::new(program, source, body_start.is_some());
+        let keep_empty = self.options.keep_empty_statements;
+        let mut elems = program
+            .directives
+            .iter()
+            .map(BodyElem::Directive)
+            .chain(program.body.iter().map(BodyElem::Statement))
+            .filter(|elem| keep_empty || !elem.is_empty_stmt())
+            .peekable();
+        let mut prev: Option<(BodyElem<'_, '_>, bool)> = None;
+        let mut last_end = None;
+        while let Some(elem) = elems.next() {
+            let layout_mark = ctx.event_mark();
+            let mut has_margin = false;
+            if let Some((prev_elem, prev_multiline)) = &prev {
+                has_margin = *prev_multiline || !elem.same_kind(prev_elem);
+                if has_margin {
+                    ctx.margin();
+                }
+                ctx.newline();
+            }
+
+            let scope = ctx.begin_scope();
+            comments.flush_until(ctx, elem.span_start(), None, true);
+            elem.print(self, ctx);
+            let multiline = ctx.end_scope(scope);
+            if multiline && prev.is_some() && !has_margin {
+                ctx.insert_event(layout_mark, EventKind::Margin);
+            }
+
+            let end = elem.span_end();
+            let next = elems.peek().map(BodyElem::span_end);
+            comments.flush_trailing(ctx, end, next);
+            last_end = Some(end);
+            prev = Some((elem, multiline));
+        }
+
+        ctx.newline();
+        if body_start.is_some() {
+            comments.flush_until(ctx, span.end, last_end, false);
+        }
+    }
+
     /// esrap's `body`: statements on their own lines, with a blank line between
     /// two multiline statements or a change of statement kind, interleaving
     /// leading (before each statement), trailing (same-line), and end-of-body
@@ -1233,7 +1453,22 @@ impl<'opt, const HAS_COMMENTS: bool, const DIRECT: bool> Printer<'opt, HAS_COMME
             }
 
             let scope = ctx.begin_scope();
-            elem.print(self, ctx);
+            if HAS_COMMENTS && DIRECT {
+                let start = elem.span_start();
+                let end = elem.span_end();
+                self.flush_leading(ctx, start);
+                let contains_comment = self
+                    .comments
+                    .get(self.comment_index)
+                    .is_some_and(|comment| comment.start < end);
+                if !contains_comment && self.has_loc(start) && self.has_loc(end) {
+                    elem.print(self.comment_free(), ctx);
+                } else {
+                    elem.print(self, ctx);
+                }
+            } else {
+                elem.print(self, ctx);
+            }
             let multiline = ctx.end_scope(scope);
             if multiline && prev.is_some() && !has_margin {
                 ctx.insert_event(layout_mark, EventKind::Margin);
@@ -4516,6 +4751,14 @@ impl<'a> BodyElem<'a, '_> {
             BodyElem::Directive(d) => d.span.end,
             BodyElem::Statement(s) => s.span().end,
             BodyElem::ClassMember(e) => e.span().end,
+        }
+    }
+
+    fn span_start(&self) -> u32 {
+        match self {
+            BodyElem::Directive(d) => d.span.start,
+            BodyElem::Statement(s) => s.span().start,
+            BodyElem::ClassMember(e) => e.span().start,
         }
     }
 

--- a/crates/rsvelte_esrap/src/printer.rs
+++ b/crates/rsvelte_esrap/src/printer.rs
@@ -3133,8 +3133,20 @@ impl<'opt, const HAS_COMMENTS: bool, const DIRECT: bool> Printer<'opt, HAS_COMME
     #[allow(clippy::too_many_lines)]
     fn print_expression(&mut self, expr: &Expression, ctx: &mut Context<DIRECT>) {
         // esrap's `_` wildcard: emit comments positioned before this node first.
-        let start = expr.span().start;
+        let span = expr.span();
+        let start = span.start;
         self.flush_leading(ctx, start);
+        if HAS_COMMENTS
+            && DIRECT
+            && self.has_loc(start)
+            && self.has_loc(span.end)
+            && self
+                .comment_at(self.comment_index)
+                .is_none_or(|comment| comment.start >= span.end)
+        {
+            self.comment_free().print_expression(expr, ctx);
+            return;
+        }
         match expr {
             Expression::ParenthesizedExpression(p) => {
                 // esrap parses with acorn, which ELIDES parentheses — there is

--- a/crates/rsvelte_esrap/src/printer.rs
+++ b/crates/rsvelte_esrap/src/printer.rs
@@ -96,11 +96,13 @@ pub struct Printer<'opt, const HAS_COMMENTS: bool = true, const DIRECT: bool = f
     /// threads comments positionally (leading before a node, trailing on a
     /// node's last line) rather than attaching them to AST nodes.
     comments: Vec<Cmt>,
+    borrowed_comments: Option<&'opt [oxc_ast::ast::Comment]>,
     comment_index: usize,
     /// Byte offsets of each line start in the buffer the comment spans index
     /// into, for offset→line lookups when placing comments. Empty when printing
     /// without comments.
     line_starts: Vec<u32>,
+    comment_source: Option<&'opt str>,
     /// Byte offsets of each line start in the buffer source-map positions are
     /// resolved against. Same as `line_starts` unless the caller split the two
     /// coordinate spaces (see [`crate::print_split`]).
@@ -139,10 +141,61 @@ fn write_comment<const DIRECT: bool>(cmt: &Cmt, ctx: &mut Context<DIRECT>) {
     }
 }
 
+fn write_borrowed_comment_span<const DIRECT: bool>(
+    start: u32,
+    end: u32,
+    block: bool,
+    source: &str,
+    ctx: &mut Context<DIRECT>,
+) {
+    let raw = source.get(start as usize..end as usize).unwrap_or_default();
+    if !block {
+        ctx.write(raw);
+        return;
+    }
+    let inner = raw
+        .strip_prefix("/*")
+        .and_then(|text| text.strip_suffix("*/"))
+        .unwrap_or(raw);
+    if !inner.contains('\n') {
+        ctx.write(raw);
+        return;
+    }
+
+    let line_start = source[..start as usize]
+        .rfind('\n')
+        .map_or(0, |index| index + 1);
+    let opener_line = &source[line_start..start as usize];
+    let indent_len = opener_line
+        .as_bytes()
+        .iter()
+        .take_while(|&&byte| matches!(byte, b' ' | b'\t'))
+        .count();
+    let indentation = &opener_line[..indent_len];
+
+    ctx.write_ascii_bytes(b"/*");
+    for (index, line) in inner.split('\n').enumerate() {
+        if index > 0 {
+            ctx.newline();
+        }
+        ctx.write(line.strip_prefix(indentation).unwrap_or(line));
+    }
+    ctx.write_ascii_bytes(b"*/");
+    ctx.newline();
+}
+
 struct BorrowedCommentDriver<'a> {
     comments: &'a [oxc_ast::ast::Comment],
     source: &'a str,
     index: usize,
+}
+
+#[derive(Clone, Copy)]
+struct CommentMeta {
+    start: u32,
+    end: u32,
+    start_line: u32,
+    block: bool,
 }
 
 impl<'a> BorrowedCommentDriver<'a> {
@@ -276,7 +329,6 @@ pub struct Cmt {
     pub start: u32,
     pub end: u32,
     pub start_line: u32,
-    pub end_line: u32,
     pub block: bool,
     pub value: String,
 }
@@ -317,7 +369,6 @@ pub fn build_comments(program: &Program<'_>, source: &str, starts: &[u32]) -> Ve
                 start,
                 end,
                 start_line: line_of(start),
-                end_line: line_of(end),
                 block,
                 value,
             }
@@ -584,8 +635,10 @@ impl<'opt, const HAS_COMMENTS: bool, const DIRECT: bool> Printer<'opt, HAS_COMME
             emit_locations: false,
             missing: None,
             comments: Vec::new(),
+            borrowed_comments: None,
             comment_index: 0,
             line_starts: Vec::new(),
+            comment_source: None,
             map_line_starts: None,
             loc_base: None,
             loc_map: Vec::new(),
@@ -604,12 +657,24 @@ impl<'opt, const HAS_COMMENTS: bool, const DIRECT: bool> Printer<'opt, HAS_COMME
             emit_locations: false,
             missing: None,
             comments,
+            borrowed_comments: None,
             comment_index: 0,
             map_line_starts: None,
             line_starts,
+            comment_source: None,
             loc_base: None,
             loc_map: Vec::new(),
         }
+    }
+
+    pub(crate) const fn with_borrowed_comments(
+        mut self,
+        comments: &'opt [oxc_ast::ast::Comment],
+        source: &'opt str,
+    ) -> Self {
+        self.borrowed_comments = Some(comments);
+        self.comment_source = Some(source);
+        self
     }
 
     /// Resolve source-map positions against a different buffer than the one the
@@ -639,6 +704,27 @@ impl<'opt, const HAS_COMMENTS: bool, const DIRECT: bool> Printer<'opt, HAS_COMME
     /// 1-based line of a byte offset (number of line starts at/before it).
     fn line_of(&self, offset: u32) -> u32 {
         usize_to_u32(self.line_starts.partition_point(|&s| s <= offset))
+    }
+
+    fn has_newline_between(&self, start: u32, end: u32) -> bool {
+        if start >= end {
+            return false;
+        }
+        self.comment_source.map_or_else(
+            || self.line_of(start) < self.line_of(end),
+            |source| {
+                source
+                    .get(start as usize..end as usize)
+                    .is_some_and(|text| text.as_bytes().contains(&b'\n'))
+            },
+        )
+    }
+
+    fn comment_starts_on_earlier_line(&self, comment: CommentMeta, offset: u32) -> bool {
+        self.comment_source.map_or_else(
+            || comment.start_line < self.line_of(offset),
+            |_| self.has_newline_between(comment.start, offset),
+        )
     }
 
     /// esrap's `if (node.loc)`: whether a span offset is a real source position
@@ -776,6 +862,47 @@ impl<'opt, const HAS_COMMENTS: bool, const DIRECT: bool> Printer<'opt, HAS_COMME
 
     // ----- comments ---------------------------------------------------------
 
+    fn comment_len(&self) -> usize {
+        self.borrowed_comments
+            .map_or(self.comments.len(), <[_]>::len)
+    }
+
+    fn comment_at(&self, index: usize) -> Option<CommentMeta> {
+        if let Some(comments) = self.borrowed_comments {
+            return comments.get(index).map(|comment| CommentMeta {
+                start: comment.span.start,
+                end: comment.span.end,
+                start_line: 0,
+                block: !matches!(comment.kind, oxc_ast::ast::CommentKind::Line),
+            });
+        }
+        self.comments.get(index).map(|comment| CommentMeta {
+            start: comment.start,
+            end: comment.end,
+            start_line: comment.start_line,
+            block: comment.block,
+        })
+    }
+
+    fn comment_partition_point(&self, offset: u32) -> usize {
+        self.borrowed_comments.map_or_else(
+            || {
+                self.comments
+                    .partition_point(|comment| comment.start < offset)
+            },
+            |comments| comments.partition_point(|comment| comment.span.start < offset),
+        )
+    }
+
+    fn write_comment_at(&self, index: usize, ctx: &mut Context<DIRECT>) {
+        if let Some(source) = self.comment_source {
+            let comment = self.comment_at(index).expect("pending comment");
+            write_borrowed_comment_span(comment.start, comment.end, comment.block, source, ctx);
+        } else {
+            write_comment(&self.comments[index], ctx);
+        }
+    }
+
     /// esrap's `flush_comments_until`: emit every pending comment that starts
     /// before `to`. The `from` margin rule adds a
     /// blank line before a detached leading comment block.
@@ -786,38 +913,36 @@ impl<'opt, const HAS_COMMENTS: bool, const DIRECT: bool> Printer<'opt, HAS_COMME
         from: Option<u32>,
         pad: bool,
     ) {
-        if !HAS_COMMENTS || self.comment_index == self.comments.len() {
+        if !HAS_COMMENTS || self.comment_index == self.comment_len() {
             return;
         }
         if !self.has_loc(to) {
             return;
         }
-        let Some(next_comment) = self.comments.get(self.comment_index) else {
+        let Some(next_comment) = self.comment_at(self.comment_index) else {
             return;
         };
         if next_comment.start >= to {
             return;
         }
-        let to_line = self.line_of(to);
-        let from_line = from
-            .filter(|&offset| self.has_loc(offset))
-            .map(|offset| self.line_of(offset));
         let mut first = true;
-        while self.comment_index < self.comments.len() {
-            let cmt = &self.comments[self.comment_index];
+        while self.comment_index < self.comment_len() {
+            let cmt = self
+                .comment_at(self.comment_index)
+                .expect("pending comment");
             if cmt.start >= to {
                 break;
             }
             if first
-                && let Some(from_line) = from_line
-                && cmt.start_line > from_line
+                && let Some(from) = from.filter(|&offset| self.has_loc(offset))
+                && self.has_newline_between(from, cmt.start)
             {
                 ctx.margin();
                 ctx.newline();
             }
             first = false;
-            write_comment(cmt, ctx);
-            if cmt.end_line < to_line {
+            self.write_comment_at(self.comment_index, ctx);
+            if self.has_newline_between(cmt.end, to) {
                 ctx.newline();
             } else if pad {
                 ctx.write_ascii(b' ');
@@ -838,22 +963,24 @@ impl<'opt, const HAS_COMMENTS: bool, const DIRECT: bool> Printer<'opt, HAS_COMME
         prev_end: u32,
         next: Option<u32>,
     ) -> bool {
-        if !HAS_COMMENTS || self.comment_index == self.comments.len() || !self.has_loc(prev_end) {
+        if !HAS_COMMENTS || self.comment_index == self.comment_len() || !self.has_loc(prev_end) {
             return false;
         }
         // A `next` boundary that is itself synthesized bounds nothing (esrap's
         // `next` is `null` when the following node has no `loc`).
         let next = next.filter(|n| self.has_loc(*n));
-        let prev_end_line = self.line_of(prev_end);
         let mut emitted_line_newline = false;
-        while self.comment_index < self.comments.len() {
-            let cmt = &self.comments[self.comment_index];
-            let fits = cmt.start_line == prev_end_line && next.is_none_or(|n| cmt.end < n);
+        while self.comment_index < self.comment_len() {
+            let cmt = self
+                .comment_at(self.comment_index)
+                .expect("pending comment");
+            let fits =
+                !self.has_newline_between(prev_end, cmt.start) && next.is_none_or(|n| cmt.end < n);
             if !fits {
                 break;
             }
             ctx.write_ascii(b' ');
-            write_comment(cmt, ctx);
+            self.write_comment_at(self.comment_index, ctx);
             let is_block = cmt.block;
             self.comment_index += 1;
             if is_block {
@@ -875,18 +1002,18 @@ impl<'opt, const HAS_COMMENTS: bool, const DIRECT: bool> Printer<'opt, HAS_COMME
             return;
         }
         let Some(node_start) = node_start else {
-            self.comment_index = self.comments.len();
+            self.comment_index = self.comment_len();
             return;
         };
         if !self.has_loc(node_start) {
-            self.comment_index = self.comments.len();
+            self.comment_index = self.comment_len();
             return;
         }
-        let cur = self.comments.get(self.comment_index);
+        let cur = self.comment_at(self.comment_index);
         let prev = self
             .comment_index
             .checked_sub(1)
-            .and_then(|i| self.comments.get(i));
+            .and_then(|i| self.comment_at(i));
         let synced =
             cur.is_some_and(|c| c.start >= node_start) && prev.is_none_or(|p| p.start < node_start);
         if synced {
@@ -894,7 +1021,7 @@ impl<'opt, const HAS_COMMENTS: bool, const DIRECT: bool> Printer<'opt, HAS_COMME
         }
         // `comments` is in source order (ascending `start`), so binary-search the
         // first comment at/after `node_start` instead of a linear scan.
-        self.comment_index = self.comments.partition_point(|c| c.start < node_start);
+        self.comment_index = self.comment_partition_point(node_start);
     }
 
     /// The `_` wildcard's leading flush: emit comments positioned before `node`.
@@ -1026,14 +1153,13 @@ impl<'opt, const HAS_COMMENTS: bool, const DIRECT: bool> Printer<'opt, HAS_COMME
     ) {
         // A comment can introduce a newline while rendering, so only clean sequences pre-indent.
         let has_sequence_comments = DIRECT && HAS_COMMENTS && n > 0 && {
-            let before_until = |cmt: &Cmt| until.is_none_or(|end| cmt.start < end);
+            let before_until = |cmt: CommentMeta| until.is_none_or(|end| cmt.start < end);
             let pending = self
-                .comments
-                .get(self.comment_index)
+                .comment_at(self.comment_index)
                 .is_some_and(before_until);
             let in_nodes = meta(0).start.is_none_or(|start| {
-                let index = self.comments.partition_point(|cmt| cmt.start < start);
-                self.comments.get(index).is_some_and(before_until)
+                let index = self.comment_partition_point(start);
+                self.comment_at(index).is_some_and(before_until)
             });
             pending || in_nodes
         };
@@ -1415,6 +1541,86 @@ impl<'opt, const HAS_COMMENTS: bool, const DIRECT: bool> Printer<'opt, HAS_COMME
         );
     }
 
+    fn comments_are_outer_to_block(
+        &self,
+        statements: &[Statement],
+        body_start: u32,
+        body_end: u32,
+    ) -> bool {
+        if !self.has_loc(body_start) || !self.has_loc(body_end) {
+            return false;
+        }
+        let mut index = self.comment_partition_point(body_start);
+        for statement in statements {
+            let span = statement.span();
+            if !self.has_loc(span.start) || !self.has_loc(span.end) {
+                return false;
+            }
+            while let Some(comment) = self.comment_at(index) {
+                if comment.start >= body_end || comment.end > span.start {
+                    break;
+                }
+                index += 1;
+            }
+            if self
+                .comment_at(index)
+                .is_some_and(|comment| comment.start < span.end && comment.end > span.start)
+            {
+                return false;
+            }
+        }
+        true
+    }
+
+    fn block_comment_island(
+        &mut self,
+        statements: &[Statement],
+        body_start: u32,
+        body_end: u32,
+        ctx: &mut Context<DIRECT>,
+    ) {
+        self.reset_comment_index(Some(body_start));
+        let keep_empty = self.options.keep_empty_statements;
+        let mut statements = statements
+            .iter()
+            .filter(|statement| {
+                keep_empty
+                    || !matches!(statement, Statement::EmptyStatement(empty) if empty.span.end != u32::MAX)
+            })
+            .peekable();
+        let mut prev: Option<(&Statement<'_>, bool)> = None;
+        let mut last_end = None;
+        while let Some(statement) = statements.next() {
+            let layout_mark = ctx.event_mark();
+            let mut has_margin = false;
+            if let Some((prev_statement, prev_multiline)) = prev {
+                has_margin = prev_multiline
+                    || std::mem::discriminant(prev_statement) != std::mem::discriminant(statement);
+                if has_margin {
+                    ctx.margin();
+                }
+                ctx.newline();
+            }
+
+            let scope = ctx.begin_scope();
+            self.flush_leading(ctx, statement.span().start);
+            self.comment_free().print_statement(statement, ctx);
+            let multiline = ctx.end_scope(scope);
+            if multiline && prev.is_some() && !has_margin {
+                ctx.insert_event(layout_mark, EventKind::Margin);
+            }
+
+            let end = statement.span().end;
+            let next = statements.peek().map(|statement| statement.span().end);
+            self.flush_trailing_comments(ctx, end, next);
+            last_end = Some(end);
+            prev = Some((statement, multiline));
+        }
+
+        ctx.newline();
+        self.flush_comments_until(ctx, body_end, last_end, false);
+    }
+
     /// The element-based core of [`Self::body`], shared by `print_program` so a
     /// program's leading directives participate in the same margin/comment pass.
     fn body_elems<'a, 'b>(
@@ -1458,8 +1664,7 @@ impl<'opt, const HAS_COMMENTS: bool, const DIRECT: bool> Printer<'opt, HAS_COMME
                 let end = elem.span_end();
                 self.flush_leading(ctx, start);
                 let contains_comment = self
-                    .comments
-                    .get(self.comment_index)
+                    .comment_at(self.comment_index)
                     .is_some_and(|comment| comment.start < end);
                 if !contains_comment && self.has_loc(start) && self.has_loc(end) {
                     elem.print(self.comment_free(), ctx);
@@ -1547,8 +1752,7 @@ impl<'opt, const HAS_COMMENTS: bool, const DIRECT: bool> Printer<'opt, HAS_COMME
                     // precedes the comment, and the rule would never fire.
                     let contains_comment = HAS_COMMENTS
                         && self
-                            .comments
-                            .get(self.comment_index)
+                            .comment_at(self.comment_index)
                             .is_some_and(|c| c.start < unparen(arg).span().start);
                     let start = s.span().start;
                     if contains_comment {
@@ -2080,12 +2284,103 @@ impl<'opt, const HAS_COMMENTS: bool, const DIRECT: bool> Printer<'opt, HAS_COMME
         ctx.newline();
     }
 
+    fn comments_are_outer_to_class(&self, body: &ClassBody) -> bool {
+        let span = body.span();
+        if !self.has_loc(span.start) || !self.has_loc(span.end) {
+            return false;
+        }
+        let mut index = self.comment_partition_point(span.start);
+        for element in body
+            .body
+            .iter()
+            .filter(|element| !matches!(element, ClassElement::TSIndexSignature(_)))
+        {
+            let element_span = element.span();
+            if !self.has_loc(element_span.start) || !self.has_loc(element_span.end) {
+                return false;
+            }
+            while let Some(comment) = self.comment_at(index) {
+                if comment.start >= span.end || comment.end > element_span.start {
+                    break;
+                }
+                index += 1;
+            }
+            if self.comment_at(index).is_some_and(|comment| {
+                comment.start < element_span.end && comment.end > element_span.start
+            }) {
+                return false;
+            }
+        }
+        true
+    }
+
+    fn class_comment_island(&mut self, body: &ClassBody, ctx: &mut Context<DIRECT>) {
+        let span = body.span();
+        self.reset_comment_index(Some(span.start));
+        let mut elements = body
+            .body
+            .iter()
+            .filter(|element| !matches!(element, ClassElement::TSIndexSignature(_)))
+            .peekable();
+        let mut prev: Option<(&ClassElement<'_>, bool)> = None;
+        let mut last_end = None;
+        while let Some(element) = elements.next() {
+            let layout_mark = ctx.event_mark();
+            let mut has_margin = false;
+            if let Some((prev_element, prev_multiline)) = prev {
+                has_margin = prev_multiline
+                    || std::mem::discriminant(prev_element) != std::mem::discriminant(element);
+                if has_margin {
+                    ctx.margin();
+                }
+                ctx.newline();
+            }
+
+            let scope = ctx.begin_scope();
+            self.flush_leading(ctx, element.span().start);
+            self.comment_free().class_element(element, ctx);
+            let multiline = ctx.end_scope(scope);
+            if multiline && prev.is_some() && !has_margin {
+                ctx.insert_event(layout_mark, EventKind::Margin);
+            }
+
+            let end = element.span().end;
+            let next = elements.peek().map(|element| element.span().end);
+            self.flush_trailing_comments(ctx, end, next);
+            last_end = Some(end);
+            prev = Some((element, multiline));
+        }
+
+        ctx.newline();
+        self.flush_comments_until(ctx, span.end, last_end, false);
+    }
+
     /// esrap's `BlockStatement|ClassBody`: route class members through the shared
     /// `body` machinery (one-per-line, blank line between two multiline members
     /// or a change of member kind) so leading / trailing / end-of-body comments
     /// are interleaved identically to a statement block.
     fn class_body(&mut self, body: &ClassBody, ctx: &mut Context<DIRECT>) {
         let span = body.span();
+        if HAS_COMMENTS && DIRECT && self.comments_are_outer_to_class(body) {
+            let has_element = body
+                .body
+                .iter()
+                .any(|element| !matches!(element, ClassElement::TSIndexSignature(_)));
+            let first_comment = self.comment_partition_point(span.start);
+            let has_comment = self
+                .comment_at(first_comment)
+                .is_some_and(|comment| comment.start < span.end);
+            if has_element || has_comment {
+                ctx.write_ascii(b'{');
+                ctx.indent();
+                ctx.newline();
+                self.class_comment_island(body, ctx);
+                ctx.dedent();
+                ctx.newline();
+                ctx.write_ascii(b'}');
+                return;
+            }
+        }
         ctx.write_ascii(b'{');
         let mark = ctx.event_mark();
         let scope = ctx.begin_scope();
@@ -2686,6 +2981,28 @@ impl<'opt, const HAS_COMMENTS: bool, const DIRECT: bool> Printer<'opt, HAS_COMME
             ctx.newline();
             ctx.write_ascii(b'}');
             return;
+        }
+
+        if DIRECT && self.comments_are_outer_to_block(body, body_start, body_end) {
+            let keep_empty = self.options.keep_empty_statements;
+            let has_statement = body.iter().any(|statement| {
+                keep_empty
+                    || !matches!(statement, Statement::EmptyStatement(empty) if empty.span.end != u32::MAX)
+            });
+            let first_comment = self.comment_partition_point(body_start);
+            let has_comment = self
+                .comment_at(first_comment)
+                .is_some_and(|comment| comment.start < body_end);
+            if has_statement || has_comment {
+                ctx.write_ascii(b'{');
+                ctx.indent();
+                ctx.newline();
+                self.block_comment_island(body, body_start, body_end, ctx);
+                ctx.dedent();
+                ctx.newline();
+                ctx.write_ascii(b'}');
+                return;
+            }
         }
 
         ctx.write_ascii(b'{');
@@ -3809,10 +4126,9 @@ impl<'opt, const HAS_COMMENTS: bool, const DIRECT: bool> Printer<'opt, HAS_COMME
             let arg_start = arg
                 .as_expression()
                 .map_or_else(|| arg.span().start, |e| unparen(e).span().start);
-            let wrap = self
-                .comments
-                .get(self.comment_index)
-                .is_some_and(|c| c.start < arg_start && c.start_line < self.line_of(arg_start));
+            let wrap = self.comment_at(self.comment_index).is_some_and(|c| {
+                c.start < arg_start && self.comment_starts_on_earlier_line(c, arg_start)
+            });
 
             ctx.write_ascii(b'(');
             if wrap {
@@ -3833,8 +4149,8 @@ impl<'opt, const HAS_COMMENTS: bool, const DIRECT: bool> Printer<'opt, HAS_COMME
             let second_start = second
                 .as_expression()
                 .map_or_else(|| second.span().start, |e| unparen(e).span().start);
-            let force_multiline = self.comments.get(self.comment_index).is_some_and(|c| {
-                c.start < second_start && c.start_line < self.line_of(second_start)
+            let force_multiline = self.comment_at(self.comment_index).is_some_and(|c| {
+                c.start < second_start && self.comment_starts_on_earlier_line(c, second_start)
             });
 
             ctx.write_ascii(b'(');
@@ -3860,10 +4176,9 @@ impl<'opt, const HAS_COMMENTS: bool, const DIRECT: bool> Printer<'opt, HAS_COMME
             let last_start = last
                 .as_expression()
                 .map_or_else(|| last.span().start, |e| unparen(e).span().start);
-            let force_multiline = self
-                .comments
-                .get(self.comment_index)
-                .is_some_and(|c| c.start < last_start && c.start_line < self.line_of(last_start));
+            let force_multiline = self.comment_at(self.comment_index).is_some_and(|c| {
+                c.start < last_start && self.comment_starts_on_earlier_line(c, last_start)
+            });
             ctx.write_ascii(b'(');
             let start = ctx.event_mark();
             let first_multiline =
@@ -3906,9 +4221,9 @@ impl<'opt, const HAS_COMMENTS: bool, const DIRECT: bool> Printer<'opt, HAS_COMME
                 .map_or_else(|| arg.span().start, |e| unparen(e).span().start);
 
             if is_last
-                && let Some(c) = self.comments.get(self.comment_index)
+                && let Some(c) = self.comment_at(self.comment_index)
                 && c.start < arg_start
-                && c.start_line < self.line_of(arg_start)
+                && self.comment_starts_on_earlier_line(c, arg_start)
             {
                 force_multiline = true;
             }

--- a/crates/rsvelte_esrap/tests/compat.rs
+++ b/crates/rsvelte_esrap/tests/compat.rs
@@ -25,7 +25,7 @@ fn plain_js() {
 }
 
 #[test]
-fn comment_free_direct_matches_deferred_sequences() {
+fn direct_matches_deferred_sequences_and_comments() {
     let cases = [
         "const x = { a: 1 };",
         "const x = { a: 1, b: 2, c: 3, d: 4 };",
@@ -40,6 +40,13 @@ fn comment_free_direct_matches_deferred_sequences() {
         "call(head, { alpha: very_long_identifier_name, beta: another_long_identifier_name }, tail);",
         "let first = very_long_identifier_name, second = another_long_identifier_name, third = final_long_identifier_name;",
         "const x = { only: { alpha: very_long_identifier_name, beta: another_long_identifier_name } };",
+        "// lead\nconst x = 1; // tail",
+        "const x = [a, /* between */ b, c];",
+        "const value = [a, // first\n b, /* middle */ c];",
+        "function f() {\n\t// before return\n\treturn (/* value */ x);\n}",
+        "const {\n\ta,\n\t// before property\n\tb,\n\tc\n} = value;",
+        "const x = 1;\n\n\n// detached\nconst y = 2;",
+        "/**\n * alpha\n * beta\n */\nconst x = 1;",
     ];
 
     for source in cases {

--- a/crates/rsvelte_esrap/tests/split_coordinates.rs
+++ b/crates/rsvelte_esrap/tests/split_coordinates.rs
@@ -230,6 +230,20 @@ fn two_chunks_keep_their_comments_in_order() {
 }
 
 #[test]
+fn comment_direct_matches_deferred_split_output() {
+    let map_source = "<script>\n\tlet count = 0;\n</script>\n";
+    let anchor = source_offset(map_source.find("let count").expect("anchor in map source"));
+    let allocator = Allocator::default();
+    let mut a = Assembler::new(&allocator, 512);
+    a.push_chunk("// first\nconst a = 1; /* tail */", Some(anchor));
+    a.push_synthesized("between();");
+    a.push_chunk("\n\n// detached\nconst b = 2;", Some(anchor));
+    let assembled = a.finish();
+
+    assert_eq!(assembled.print(), assembled.print_mapped(map_source).code);
+}
+
+#[test]
 fn synthesized_body_exhausts_the_comment_cursor() {
     let allocator = Allocator::default();
     let mut a = Assembler::new(&allocator, 512);


### PR DESCRIPTION
## What changed

- direct-print no-map comment paths while preserving deferred source-map behavior
- borrow program and nested comment spans directly instead of allocating comment strings and line tables
- specialize safe Program, Block, and Class comment islands
- route comment-free nested expressions through the plain direct printer
- add direct/deferred differential coverage for nested, sequence, and split comment placement

## Why

Comment-bearing programs paid for line tables, owned comment buffers, deferred output, and comment-aware traversal across clean subtrees. The common equal-retention benchmark was roughly 1.9x slower than `oxc_codegen`.

The new path preserves all esrap comments while avoiding that work where spans prove it is unnecessary. On `12-comments-common.js`, both printers retain all 3 comments and rsvelte/esrap now measures about 0.885x OXC time (about 11.5% faster).

On the 220-file stress corpus, rsvelte/esrap retains all 3,669 comments and improves from about 1.94x to 1.285x OXC time. This corpus is not equal-work: OXC drops 582 comments (15.9%), so it remains a default-behavior throughput comparison rather than a fair comment-fidelity benchmark.

## Validation

- `cargo test -p rsvelte_esrap --release` — 91 passed
- `cargo clippy -p rsvelte_esrap --all-targets --all-features -- -D warnings`
- `cargo fmt --all --check`
- 220 files / 1,029,367 bytes / 3,669 comments: plain output equals mapped output; 16,704 mappings
- direct/deferred comment differential tests
