### PR TITLE
fix(preprocess): compose, adopt and re-unit source maps

### DIFF
--- a/.changeset/composed-preprocess-maps.md
+++ b/.changeset/composed-preprocess-maps.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/compiler": patch
+---
+
+Compose the source maps of every preprocessor in the chain, consume an attached `//# sourceMappingURL` comment, and count map columns in UTF-16 code units. Also fixes the VLQ sign encoding, which made every negative delta in a preprocess map one too small.

--- a/crates/rsvelte_core/src/compiler/preprocess/combine_sourcemaps.rs
+++ b/crates/rsvelte_core/src/compiler/preprocess/combine_sourcemaps.rs
@@ -1,0 +1,407 @@
+//! Composition of a chain of preprocessor source maps into a single map.
+//!
+//! Port of `combine_sourcemaps` in `utils/mapped_code.js`, which delegates to
+//! `@jridgewell/remapping`. The maps arrive newest-first, and each one maps its
+//! own output back to the *previous* stage's output; composing them walks every
+//! segment of the newest map down the chain until it reaches an original file.
+
+use super::types::SimpleDecodedMap;
+
+/// A node of the source-map tree: either an original file (a leaf) or a
+/// transformation whose sources are themselves nodes.
+enum Node {
+    Original(String),
+    Mapped {
+        map: SimpleDecodedMap,
+        sources: Vec<Node>,
+    },
+}
+
+/// A position traced down to a leaf. An empty `source` is the sourceless
+/// mapping, which records only the generated column.
+struct Traced {
+    source: String,
+    line: i64,
+    column: i64,
+    name: String,
+}
+
+impl Traced {
+    fn sourceless() -> Self {
+        Traced {
+            source: String::new(),
+            line: -1,
+            column: -1,
+            name: String::new(),
+        }
+    }
+}
+
+const NO_NAME: i64 = -1;
+
+/// Combine multiple source maps into one.
+///
+/// `sourcemap_list` is ordered newest-first: index 0 is the map produced by the
+/// last preprocessor to run, and the final entry maps back to the original file.
+///
+/// Corresponds to `combine_sourcemaps` in mapped_code.js.
+pub(super) fn combine_sourcemaps(
+    filename: &str,
+    sourcemap_list: &[SimpleDecodedMap],
+) -> Option<SimpleDecodedMap> {
+    let (last, leading) = sourcemap_list.split_last()?;
+
+    // The array interface requires every map but the oldest to have exactly one
+    // source; otherwise the chain has to be walked through the loader interface,
+    // which matches a source against the input filename instead.
+    let tree = if leading.iter().all(|m| m.sources.len() == 1) {
+        let mut tree = Node::Mapped {
+            map: last.clone(),
+            sources: last.sources.iter().cloned().map(Node::Original).collect(),
+        };
+        for map in leading.iter().rev() {
+            tree = Node::Mapped {
+                map: map.clone(),
+                sources: vec![tree],
+            };
+        }
+        tree
+    } else {
+        let mut next = 1;
+        build_with_loader(&sourcemap_list[0], sourcemap_list, &mut next, filename)
+    };
+
+    let mut combined = trace_mappings(&tree);
+    if combined.sources.is_empty() {
+        combined.sources = vec![filename.to_string()];
+    }
+    Some(combined)
+}
+
+/// Build the tree by treating a source equal to the input filename as the output
+/// of the next map in the chain.
+fn build_with_loader(
+    map: &SimpleDecodedMap,
+    sourcemap_list: &[SimpleDecodedMap],
+    next: &mut usize,
+    filename: &str,
+) -> Node {
+    let sources = map
+        .sources
+        .iter()
+        .map(|source| {
+            if source == filename && *next < sourcemap_list.len() {
+                let child = &sourcemap_list[*next];
+                *next += 1;
+                build_with_loader(child, sourcemap_list, next, filename)
+            } else {
+                Node::Original(source.clone())
+            }
+        })
+        .collect();
+
+    Node::Mapped {
+        map: map.clone(),
+        sources,
+    }
+}
+
+/// Walk every segment of the root map down to a leaf and rebuild a map from the
+/// traced positions.
+///
+/// Corresponds to `traceMappings` in remapping.
+fn trace_mappings(tree: &Node) -> SimpleDecodedMap {
+    let Node::Mapped { map, sources } = tree else {
+        return SimpleDecodedMap::default();
+    };
+
+    let mut out = GenMapping {
+        file: map.file.clone().filter(|f| !f.is_empty()),
+        ..GenMapping::default()
+    };
+
+    for (generated_line, segments) in map.mappings.iter().enumerate() {
+        for segment in segments {
+            let Some(&generated_column) = segment.first() else {
+                continue;
+            };
+            let traced = if segment.len() == 1 {
+                Traced::sourceless()
+            } else if segment.len() >= 4 {
+                let name = if segment.len() >= 5 {
+                    name_at(&map.names, segment[4])
+                } else {
+                    String::new()
+                };
+                let Some(source) = node_at(sources, segment[1]) else {
+                    continue;
+                };
+                match original_position_for(source, segment[2], segment[3], name) {
+                    Some(traced) => traced,
+                    None => continue,
+                }
+            } else {
+                continue;
+            };
+            out.maybe_add_segment(generated_line, generated_column, &traced);
+        }
+    }
+
+    out.into_map()
+}
+
+/// Resolve a position in `node`'s output to a position in an original file.
+///
+/// Corresponds to `originalPositionFor` in remapping.
+fn original_position_for(node: &Node, line: i64, column: i64, name: String) -> Option<Traced> {
+    let (map, sources) = match node {
+        Node::Original(source) => {
+            return Some(Traced {
+                source: source.clone(),
+                line,
+                column,
+                name,
+            });
+        }
+        Node::Mapped { map, sources } => (map, sources),
+    };
+
+    let segment = trace_segment(map, line, column)?;
+    if segment.len() == 1 {
+        return Some(Traced::sourceless());
+    }
+    if segment.len() < 4 {
+        return None;
+    }
+    let name = if segment.len() >= 5 {
+        name_at(&map.names, segment[4])
+    } else {
+        name
+    };
+    original_position_for(node_at(sources, segment[1])?, segment[2], segment[3], name)
+}
+
+fn node_at(sources: &[Node], index: i64) -> Option<&Node> {
+    usize::try_from(index).ok().and_then(|i| sources.get(i))
+}
+
+fn name_at(names: &[String], index: i64) -> String {
+    usize::try_from(index)
+        .ok()
+        .and_then(|i| names.get(i))
+        .cloned()
+        .unwrap_or_default()
+}
+
+/// Find the segment covering `column` on `line`: the last segment whose
+/// generated column is at most `column`, resolved to the first of a run of
+/// equal columns.
+///
+/// Corresponds to `traceSegment` (greatest-lower-bound bias) in trace-mapping.
+fn trace_segment(map: &SimpleDecodedMap, line: i64, column: i64) -> Option<&Vec<i64>> {
+    let segments = usize::try_from(line)
+        .ok()
+        .and_then(|l| map.mappings.get(l))?;
+
+    let mut index = segments
+        .iter()
+        .rposition(|segment| segment.first().is_some_and(|&col| col <= column))?;
+    let found = segments[index].first() == Some(&column);
+    if found {
+        while index > 0 && segments[index - 1].first() == Some(&column) {
+            index -= 1;
+        }
+    }
+    segments.get(index)
+}
+
+/// The map being built, with its source and name tables interned on first use.
+///
+/// Corresponds to `GenMapping` in out-mapping.
+#[derive(Default)]
+struct GenMapping {
+    file: Option<String>,
+    sources: Vec<String>,
+    names: Vec<String>,
+    mappings: Vec<Vec<Vec<i64>>>,
+}
+
+impl GenMapping {
+    fn maybe_add_segment(&mut self, generated_line: usize, generated_column: i64, traced: &Traced) {
+        while self.mappings.len() <= generated_line {
+            self.mappings.push(Vec::new());
+        }
+
+        if traced.source.is_empty() {
+            let line = &mut self.mappings[generated_line];
+            let index = column_index(line, generated_column);
+            if index == 0 || line[index - 1].len() == 1 {
+                return;
+            }
+            line.insert(index, vec![generated_column]);
+            return;
+        }
+
+        let source_index = intern(&mut self.sources, &traced.source);
+        let name_index = if traced.name.is_empty() {
+            NO_NAME
+        } else {
+            intern(&mut self.names, &traced.name)
+        };
+
+        let line = &mut self.mappings[generated_line];
+        let index = column_index(line, generated_column);
+        if index > 0 {
+            let previous = &line[index - 1];
+            let previous_name = if previous.len() >= 5 {
+                previous[4]
+            } else {
+                NO_NAME
+            };
+            if previous.len() >= 4
+                && previous[1] == source_index
+                && previous[2] == traced.line
+                && previous[3] == traced.column
+                && previous_name == name_index
+            {
+                return;
+            }
+        }
+
+        let mut segment = vec![generated_column, source_index, traced.line, traced.column];
+        if name_index != NO_NAME {
+            segment.push(name_index);
+        }
+        line.insert(index, segment);
+    }
+
+    fn into_map(self) -> SimpleDecodedMap {
+        SimpleDecodedMap {
+            version: Some(3),
+            file: self.file,
+            sources: self.sources,
+            sources_content: None,
+            names: self.names,
+            mappings: self.mappings,
+            source_root: None,
+        }
+    }
+}
+
+/// Where a segment for `generated_column` belongs in an ordered line.
+fn column_index(line: &[Vec<i64>], generated_column: i64) -> usize {
+    let mut index = line.len();
+    for i in (0..line.len()).rev() {
+        if line[i].first().is_some_and(|&col| generated_column >= col) {
+            break;
+        }
+        index = i;
+    }
+    index
+}
+
+fn intern(table: &mut Vec<String>, value: &str) -> i64 {
+    match table.iter().position(|v| v == value) {
+        Some(index) => index as i64,
+        None => {
+            table.push(value.to_string());
+            (table.len() - 1) as i64
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn map(sources: &[&str], mappings: Vec<Vec<Vec<i64>>>) -> SimpleDecodedMap {
+        SimpleDecodedMap {
+            sources: sources.iter().map(|s| s.to_string()).collect(),
+            mappings,
+            ..SimpleDecodedMap::default()
+        }
+    }
+
+    #[test]
+    fn a_single_map_is_reproduced() {
+        let only = map(&["a.svelte"], vec![vec![vec![0, 0, 3, 7]]]);
+        let combined = combine_sourcemaps("a.svelte", &[only]).unwrap();
+        assert_eq!(combined.sources, vec!["a.svelte".to_string()]);
+        assert_eq!(combined.mappings, vec![vec![vec![0, 0, 3, 7]]]);
+    }
+
+    #[test]
+    fn two_maps_resolve_to_the_original_source() {
+        // Stage 2 maps its line 0 back to line 1 of stage 1's output, which
+        // stage 1 in turn maps back to line 5 of the original file. Composing
+        // must land on line 5, not line 1.
+        let newest = map(&["a.svelte"], vec![vec![vec![0, 0, 1, 0]]]);
+        let oldest = map(
+            &["a.svelte"],
+            vec![vec![vec![0, 0, 0, 0]], vec![vec![0, 0, 5, 2]]],
+        );
+        let combined = combine_sourcemaps("a.svelte", &[newest, oldest]).unwrap();
+        assert_eq!(combined.mappings, vec![vec![vec![0, 0, 5, 2]]]);
+    }
+
+    #[test]
+    fn a_column_between_segments_uses_the_greatest_lower_bound() {
+        let newest = map(&["a.svelte"], vec![vec![vec![0, 0, 0, 7]]]);
+        let oldest = map(
+            &["a.svelte"],
+            vec![vec![vec![0, 0, 0, 0], vec![4, 0, 9, 9], vec![10, 0, 0, 10]]],
+        );
+        let combined = combine_sourcemaps("a.svelte", &[newest, oldest]).unwrap();
+        assert_eq!(combined.mappings, vec![vec![vec![0, 0, 9, 9]]]);
+    }
+
+    #[test]
+    fn an_untraceable_segment_is_dropped() {
+        // Nothing on line 3 of the older map, so the newer map's only segment
+        // has no original position and must not appear in the result.
+        let newest = map(&["a.svelte"], vec![vec![vec![0, 0, 3, 0]]]);
+        let oldest = map(&["a.svelte"], vec![vec![vec![0, 0, 0, 0]]]);
+        let combined = combine_sourcemaps("a.svelte", &[newest, oldest]).unwrap();
+        assert!(combined.mappings.is_empty());
+    }
+
+    #[test]
+    fn redundant_segments_are_collapsed() {
+        let newest = map(
+            &["a.svelte"],
+            vec![vec![vec![0, 0, 0, 0], vec![3, 0, 0, 0], vec![6, 0, 0, 1]]],
+        );
+        let oldest = map(
+            &["a.svelte"],
+            vec![vec![vec![0, 0, 4, 4], vec![1, 0, 4, 5]]],
+        );
+        let combined = combine_sourcemaps("a.svelte", &[newest, oldest]).unwrap();
+        assert_eq!(
+            combined.mappings,
+            vec![vec![vec![0, 0, 4, 4], vec![6, 0, 4, 5]]]
+        );
+    }
+
+    #[test]
+    fn a_multi_source_leading_map_uses_the_loader_interface() {
+        // The newest map has two sources, so the chain is matched by filename.
+        let newest = map(
+            &["a.svelte", "helper.js"],
+            vec![vec![vec![0, 0, 1, 0], vec![5, 1, 2, 2]]],
+        );
+        let oldest = map(&["a.svelte"], vec![vec![], vec![vec![0, 0, 8, 3]]]);
+        let combined = combine_sourcemaps("a.svelte", &[newest, oldest]).unwrap();
+        assert_eq!(combined.sources, vec!["a.svelte", "helper.js"]);
+        assert_eq!(
+            combined.mappings,
+            vec![vec![vec![0, 0, 8, 3], vec![5, 1, 2, 2]]]
+        );
+    }
+
+    #[test]
+    fn an_empty_result_falls_back_to_the_filename() {
+        let only = map(&[], vec![vec![]]);
+        let combined = combine_sourcemaps("a.svelte", &[only]).unwrap();
+        assert_eq!(combined.sources, vec!["a.svelte".to_string()]);
+    }
+}

--- a/crates/rsvelte_core/src/compiler/preprocess/encode_sourcemap.rs
+++ b/crates/rsvelte_core/src/compiler/preprocess/encode_sourcemap.rs
@@ -1,0 +1,191 @@
+//! Source Map v3 encoding — the inverse of [`decode_sourcemap`].
+//!
+//! [`decode_sourcemap`]: super::decode_sourcemap
+
+use serde_json::Value;
+
+use super::types::SimpleDecodedMap;
+
+/// Serialize a [`SimpleDecodedMap`] to a standard [Source Map v3] JSON object —
+/// camelCase keys (`sourcesContent`, `sourceRoot`) and a VLQ-encoded `mappings`
+/// string — so downstream tools (Vite, Rolldown, magic-string consumers) can
+/// ingest it directly.
+///
+/// [Source Map v3]: https://sourcemaps.info/spec.html
+pub fn decoded_to_v3_json(map: &SimpleDecodedMap) -> Value {
+    let mut obj = serde_json::Map::new();
+    obj.insert(
+        "version".to_string(),
+        Value::Number(serde_json::Number::from(map.version.unwrap_or(3))),
+    );
+    if let Some(ref file) = map.file {
+        obj.insert("file".to_string(), Value::String(file.clone()));
+    }
+    if let Some(ref source_root) = map.source_root {
+        obj.insert("sourceRoot".to_string(), Value::String(source_root.clone()));
+    }
+    obj.insert(
+        "sources".to_string(),
+        Value::Array(map.sources.iter().cloned().map(Value::String).collect()),
+    );
+    if let Some(ref contents) = map.sources_content {
+        obj.insert(
+            "sourcesContent".to_string(),
+            Value::Array(
+                contents
+                    .iter()
+                    .map(|c| c.clone().map_or(Value::Null, Value::String))
+                    .collect(),
+            ),
+        );
+    }
+    obj.insert(
+        "names".to_string(),
+        Value::Array(map.names.iter().cloned().map(Value::String).collect()),
+    );
+    obj.insert(
+        "mappings".to_string(),
+        Value::String(encode_mappings(&map.mappings)),
+    );
+    Value::Object(obj)
+}
+
+/// Serialize a [`SimpleDecodedMap`] to a Source Map v3 JSON string.
+pub fn decoded_to_v3_string(map: &SimpleDecodedMap) -> String {
+    decoded_to_v3_json(map).to_string()
+}
+
+/// VLQ-encode a decoded `mappings` array (`Vec<Vec<Vec<i64>>>`) into the Source
+/// Map v3 string form: lines separated by `;`, segments within a line separated
+/// by `,`, fields within a segment as relative-encoded VLQs.
+pub fn encode_mappings(mappings: &[Vec<Vec<i64>>]) -> String {
+    let mut out = String::new();
+    // Source index / original line / original column / name index run relative
+    // to the *previous segment*, regardless of line. Generated column resets at
+    // each `;` (per spec).
+    let mut prev_source: i64 = 0;
+    let mut prev_orig_line: i64 = 0;
+    let mut prev_orig_col: i64 = 0;
+    let mut prev_name: i64 = 0;
+    for (i, line) in mappings.iter().enumerate() {
+        if i > 0 {
+            out.push(';');
+        }
+        let mut prev_gen_col: i64 = 0;
+        for (j, segment) in line.iter().enumerate() {
+            if j > 0 {
+                out.push(',');
+            }
+            if segment.is_empty() {
+                continue;
+            }
+            let gen_col = segment[0];
+            encode_vlq(&mut out, gen_col - prev_gen_col);
+            prev_gen_col = gen_col;
+            if segment.len() >= 4 {
+                let src = segment[1];
+                let orig_line = segment[2];
+                let orig_col = segment[3];
+                encode_vlq(&mut out, src - prev_source);
+                encode_vlq(&mut out, orig_line - prev_orig_line);
+                encode_vlq(&mut out, orig_col - prev_orig_col);
+                prev_source = src;
+                prev_orig_line = orig_line;
+                prev_orig_col = orig_col;
+                if segment.len() >= 5 {
+                    let name = segment[4];
+                    encode_vlq(&mut out, name - prev_name);
+                    prev_name = name;
+                }
+            }
+        }
+    }
+    out
+}
+
+const BASE64: &[u8; 64] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
+/// Append the base64-VLQ encoding of one signed value to `out`.
+pub fn encode_vlq(out: &mut String, value: i64) {
+    // Source map VLQ is sign-magnitude — bit 0 is the sign — not the
+    // two's-complement zigzag, which is off by one for every negative value.
+    let mut vlq = (value.unsigned_abs() << 1) | u64::from(value < 0);
+    loop {
+        let mut digit = (vlq & 0x1f) as u8;
+        vlq >>= 5;
+        if vlq > 0 {
+            digit |= 0x20;
+        }
+        out.push(BASE64[digit as usize] as char);
+        if vlq == 0 {
+            break;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::decode_sourcemap::decode_map;
+    use super::super::types::{Processed, SourceMapInput};
+    use super::*;
+
+    fn round_trip(map: &SimpleDecodedMap) -> SimpleDecodedMap {
+        let processed = Processed {
+            code: String::new(),
+            map: Some(SourceMapInput::Json(decoded_to_v3_string(map))),
+            dependencies: vec![],
+            attributes: None,
+        };
+        decode_map(&processed).expect("encoded map must decode")
+    }
+
+    #[test]
+    fn encode_then_decode_is_the_identity() {
+        let map = SimpleDecodedMap {
+            version: Some(3),
+            file: Some("out.js".to_string()),
+            sources: vec!["a.svelte".to_string(), "b.svelte".to_string()],
+            sources_content: Some(vec![Some("a".to_string()), None]),
+            names: vec!["foo".to_string(), "bar".to_string()],
+            mappings: vec![
+                vec![vec![0, 0, 0, 0], vec![4, 0, 0, 4, 0]],
+                vec![],
+                vec![vec![2, 1, 7, 13, 1], vec![9, 0, 3, 1]],
+            ],
+            source_root: Some("/src".to_string()),
+        };
+        assert_eq!(round_trip(&map), map);
+    }
+
+    #[test]
+    fn negative_deltas_round_trip() {
+        // The second line steps *backwards* in both source index and original
+        // position, which is what exercises the sign bit of the VLQ.
+        let map = SimpleDecodedMap {
+            sources: vec!["a".to_string(), "b".to_string()],
+            mappings: vec![
+                vec![vec![10, 1, 40, 90]],
+                vec![vec![0, 0, 2, 3], vec![1, 0, 1, 0]],
+            ],
+            ..SimpleDecodedMap::default()
+        };
+        assert_eq!(round_trip(&map), map);
+    }
+
+    #[test]
+    fn one_length_segments_round_trip() {
+        // A sourceless segment carries only the generated column.
+        let map = SimpleDecodedMap {
+            sources: vec!["a".to_string()],
+            mappings: vec![vec![vec![0], vec![5, 0, 0, 5]]],
+            ..SimpleDecodedMap::default()
+        };
+        assert_eq!(round_trip(&map), map);
+    }
+
+    #[test]
+    fn known_mappings_string() {
+        assert_eq!(encode_mappings(&[vec![vec![0, 0, 0, 0]]]), "AAAA");
+        assert_eq!(encode_mappings(&[vec![], vec![vec![0, 0, 0, 0]]]), ";AAAA");
+    }
+}

--- a/crates/rsvelte_core/src/compiler/preprocess/mod.rs
+++ b/crates/rsvelte_core/src/compiler/preprocess/mod.rs
@@ -6,13 +6,18 @@
 //!
 //! Corresponds to the implementation in `svelte/packages/svelte/src/compiler/preprocess/`.
 
+mod combine_sourcemaps;
 pub mod decode_sourcemap;
+pub mod encode_sourcemap;
+mod parse_attached_sourcemap;
 pub mod replace_in_code;
 pub mod types;
 
-use crate::compiler::utils::{get_basename, get_locator};
+use crate::compiler::utils::{get_basename, get_locator, utf16_len};
+use combine_sourcemaps::combine_sourcemaps;
 use decode_sourcemap::decode_map;
 use lazy_static::lazy_static;
+use parse_attached_sourcemap::parse_attached_sourcemap;
 use regex::Regex;
 use replace_in_code::{replace_in_code, slice_source};
 use rustc_hash::FxHashMap;
@@ -148,7 +153,7 @@ fn processed_content_to_code(
 ///
 /// Corresponds to `processed_tag_to_code` in index.js.
 fn processed_tag_to_code(
-    processed: &Processed,
+    processed: &mut Processed,
     tag_name: &str,
     original_attributes: &str,
     generated_attributes: &str,
@@ -166,33 +171,18 @@ fn processed_tag_to_code(
 
     let tag_open_code = if original_tag_open != tag_open {
         // Generate a source map for the open tag
-        let mut mappings = vec![vec![
-            vec![0, 0, 0, 0],
-            vec![
-                format!("<{}", tag_name).len() as i64,
-                0,
-                0,
-                format!("<{}", tag_name).len() as i64,
-            ],
-        ]];
+        let name_column = utf16_len(&format!("<{}", tag_name)) as i64;
+        let mut mappings = vec![vec![vec![0, 0, 0, 0], vec![name_column, 0, 0, name_column]]];
 
         let line = tag_open.split('\n').count() - 1;
-        let column = if line == 0 {
-            tag_open.len()
-        } else {
-            tag_open.len() - tag_open.rfind('\n').unwrap() - 1
-        };
+        let column = last_line_utf16_len(&tag_open);
 
         while mappings.len() <= line {
-            mappings.push(vec![vec![0, 0, 0, format!("<{}", tag_name).len() as i64]]);
+            mappings.push(vec![vec![0, 0, 0, name_column]]);
         }
 
         let original_line = original_tag_open.split('\n').count() - 1;
-        let original_column = if original_line == 0 {
-            original_tag_open.len()
-        } else {
-            original_tag_open.len() - original_tag_open.rfind('\n').unwrap() - 1
-        };
+        let original_column = last_line_utf16_len(&original_tag_open);
 
         mappings[line].push(vec![
             column as i64,
@@ -221,7 +211,7 @@ fn processed_tag_to_code(
     let tag_close_code =
         build_mapped_code(tag_close, original_tag_open.len() + source.source.len());
 
-    // TODO: parse_attached_sourcemap equivalent if needed
+    parse_attached_sourcemap(processed, tag_name);
     let content_code = processed_content_to_code(
         processed,
         get_location(original_tag_open.len()),
@@ -229,6 +219,12 @@ fn processed_tag_to_code(
     );
 
     tag_open_code.concat(content_code).concat(tag_close_code)
+}
+
+/// UTF-16 length of the last line of `s` — the column a source-map segment at
+/// the end of `s` sits at.
+fn last_line_utf16_len(s: &str) -> usize {
+    utf16_len(&s[s.rfind('\n').map(|i| i + 1).unwrap_or(0)..])
 }
 
 /// Parse tag attributes from a string.
@@ -349,7 +345,7 @@ async fn process_tag(
 
             let processed_opt = preprocessor(options).await?;
 
-            if let Some(processed) = processed_opt {
+            if let Some(mut processed) = processed_opt {
                 if !processed.dependencies.is_empty()
                     && let Ok(mut deps) = dependencies.lock()
                 {
@@ -383,7 +379,7 @@ async fn process_tag(
                 };
 
                 Ok(processed_tag_to_code(
-                    &processed,
+                    &mut processed,
                     &tag_name,
                     attributes,
                     &final_attributes,
@@ -462,24 +458,24 @@ async fn process_markup(
 /// Corresponds to the default export `preprocess` function in index.js.
 pub async fn preprocess(
     source: String,
-    preprocessors: Vec<PreprocessorGroup>,
+    preprocessors: &[PreprocessorGroup],
     filename: Option<String>,
 ) -> Result<Processed, PreprocessError> {
     let mut result = PreprocessResult::new(source, filename);
 
     for preprocessor in preprocessors {
-        if let Some(markup) = preprocessor.markup {
-            let update = process_markup(&markup, &result.as_source()).await?;
+        if let Some(markup) = &preprocessor.markup {
+            let update = process_markup(markup, &result.as_source()).await?;
             result.update_source(update);
         }
 
-        if let Some(script) = preprocessor.script {
-            let update = process_tag("script", &script, &result.as_source()).await?;
+        if let Some(script) = &preprocessor.script {
+            let update = process_tag("script", script, &result.as_source()).await?;
             result.update_source(update);
         }
 
-        if let Some(style) = preprocessor.style {
-            let update = process_tag("style", &style, &result.as_source()).await?;
+        if let Some(style) = &preprocessor.style {
+            let update = process_tag("style", style, &result.as_source()).await?;
             result.update_source(update);
         }
     }
@@ -511,30 +507,6 @@ fn sourcemap_add_offset(map: &mut SimpleDecodedMap, offset: Location, source_ind
             }
         }
     }
-}
-
-/// Combine multiple source maps into one.
-///
-/// Corresponds to `combine_sourcemaps` in mapped_code.js.
-fn combine_sourcemaps(
-    filename: &str,
-    sourcemap_list: &[SimpleDecodedMap],
-) -> Option<SimpleDecodedMap> {
-    if sourcemap_list.is_empty() {
-        return None;
-    }
-
-    // For simplicity, we'll use a basic implementation that takes the first map
-    // A full implementation would use proper source map remapping
-    // TODO: Implement full remapping logic similar to @jridgewell/remapping
-    let mut combined = sourcemap_list[0].clone();
-
-    // Ensure sources contains the filename
-    if combined.sources.is_empty() {
-        combined.sources = vec![filename.to_string()];
-    }
-
-    Some(combined)
 }
 
 #[cfg(test)]

--- a/crates/rsvelte_core/src/compiler/preprocess/parse_attached_sourcemap.rs
+++ b/crates/rsvelte_core/src/compiler/preprocess/parse_attached_sourcemap.rs
@@ -1,0 +1,242 @@
+//! Consume a `sourceMappingURL` comment that a preprocessor attached to its
+//! output instead of returning `processed.map`.
+//!
+//! Corresponds to `parse_attached_sourcemap` in `utils/mapped_code.js`.
+
+use std::sync::LazyLock;
+
+use regex::Regex;
+
+use super::types::{Processed, SourceMapInput};
+
+const URL_PATTERN: &str = r"[#@]\s*sourceMappingURL\s*=\s*(\S*)";
+
+static SCRIPT_COMMENT: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(&format!(r"(?://{URL_PATTERN})|(?:/\*{URL_PATTERN}\s*\*/)$")).unwrap()
+});
+
+static STYLE_COMMENT: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(&format!(r"/\*{URL_PATTERN}\s*\*/$")).unwrap());
+
+static DATA_URI: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"data:(?:application|text)/json;(?:charset[:=]\S+?;)?base64,(\S*)").unwrap()
+});
+
+/// Strip an attached `sourceMappingURL` comment from `processed.code`, adopting
+/// its map when the URL is a `data:` URI.
+pub(super) fn parse_attached_sourcemap(processed: &mut Processed, tag_name: &str) {
+    let regex: &Regex = if tag_name == "script" {
+        &SCRIPT_COMMENT
+    } else {
+        &STYLE_COMMENT
+    };
+
+    let Some(captures) = regex.captures(&processed.code) else {
+        return;
+    };
+
+    let matched = captures.get(0).expect("match 0 always exists");
+    let (start, end) = (matched.start(), matched.end());
+    let map_url = captures
+        .get(1)
+        .or_else(|| captures.get(2))
+        .map(|m| m.as_str().to_string())
+        .unwrap_or_default();
+
+    let map_data = DATA_URI
+        .captures(&map_url)
+        .and_then(|c| c.get(1).map(|m| m.as_str().to_string()));
+
+    match map_data {
+        Some(data) => {
+            if processed.map.is_some() {
+                log_warning(
+                    &processed.code,
+                    "Not implemented. Found sourcemap in both processed.code and processed.map. \
+                     Please update your preprocessor to return only one sourcemap.",
+                );
+            } else if let Some(decoded) = decode_base64_utf8(&data) {
+                processed.map = Some(SourceMapInput::Json(decoded));
+            }
+        }
+        None => {
+            if processed.map.is_none() {
+                log_warning(
+                    &processed.code,
+                    &format!(
+                        "Found sourcemap path {map_url:?} in processed.code, but no sourcemap data. \
+                         Please update your preprocessor to return sourcemap data directly."
+                    ),
+                );
+            }
+        }
+    }
+
+    processed.code.replace_range(start..end, "");
+}
+
+fn log_warning(code: &str, message: &str) {
+    // code_start: help to find the preprocessor responsible
+    let code_start = if code.len() < 100 {
+        code.to_string()
+    } else {
+        let cut = (0..=100).rev().find(|&i| code.is_char_boundary(i)).unwrap();
+        format!("{} [...]", &code[..cut])
+    };
+    eprintln!(
+        "warning: {message}. processed.code = {}",
+        serde_json::to_string(&code_start).unwrap_or_else(|_| format!("{code_start:?}"))
+    );
+}
+
+/// Decode a standard base64 payload into a UTF-8 string.
+fn decode_base64_utf8(input: &str) -> Option<String> {
+    const B64: [i8; 128] = {
+        let mut table = [-1i8; 128];
+        let alphabet = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+        let mut i = 0;
+        while i < alphabet.len() {
+            table[alphabet[i] as usize] = i as i8;
+            i += 1;
+        }
+        table
+    };
+
+    let mut bytes = Vec::with_capacity(input.len() / 4 * 3);
+    let mut accumulator: u32 = 0;
+    let mut bits = 0u32;
+    for byte in input.bytes() {
+        if byte == b'=' {
+            break;
+        }
+        if byte >= 128 {
+            return None;
+        }
+        let digit = B64[byte as usize];
+        if digit < 0 {
+            return None;
+        }
+        accumulator = (accumulator << 6) | digit as u32;
+        bits += 6;
+        if bits >= 8 {
+            bits -= 8;
+            bytes.push((accumulator >> bits) as u8);
+        }
+    }
+    String::from_utf8(bytes).ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const MAP_JSON: &str = r#"{"version":3,"sources":["a.svelte"],"names":[],"mappings":"AAAA"}"#;
+
+    fn data_uri() -> String {
+        // Base64 of MAP_JSON, produced by the encoder under test's inverse.
+        let mut encoded = String::new();
+        let bytes = MAP_JSON.as_bytes();
+        const ALPHABET: &[u8; 64] =
+            b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+        for chunk in bytes.chunks(3) {
+            let b = [
+                chunk[0],
+                *chunk.get(1).unwrap_or(&0),
+                *chunk.get(2).unwrap_or(&0),
+            ];
+            let n = (u32::from(b[0]) << 16) | (u32::from(b[1]) << 8) | u32::from(b[2]);
+            encoded.push(ALPHABET[(n >> 18) as usize & 63] as char);
+            encoded.push(ALPHABET[(n >> 12) as usize & 63] as char);
+            encoded.push(if chunk.len() > 1 {
+                ALPHABET[(n >> 6) as usize & 63] as char
+            } else {
+                '='
+            });
+            encoded.push(if chunk.len() > 2 {
+                ALPHABET[n as usize & 63] as char
+            } else {
+                '='
+            });
+        }
+        format!("data:application/json;charset=utf-8;base64,{encoded}")
+    }
+
+    fn processed(code: String) -> Processed {
+        Processed {
+            code,
+            map: None,
+            dependencies: vec![],
+            attributes: None,
+        }
+    }
+
+    #[test]
+    fn script_line_comment_is_consumed() {
+        let mut p = processed(format!("const a = 1;\n//# sourceMappingURL={}", data_uri()));
+        parse_attached_sourcemap(&mut p, "script");
+        assert_eq!(p.code, "const a = 1;\n");
+        match p.map {
+            Some(SourceMapInput::Json(json)) => assert_eq!(json, MAP_JSON),
+            other => panic!("expected the attached map to be adopted, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn script_block_comment_is_consumed() {
+        let mut p = processed(format!(
+            "const a = 1;\n/*# sourceMappingURL={} */",
+            data_uri()
+        ));
+        parse_attached_sourcemap(&mut p, "script");
+        assert_eq!(p.code, "const a = 1;\n");
+        assert!(p.map.is_some());
+    }
+
+    #[test]
+    fn style_block_comment_is_consumed() {
+        let mut p = processed(format!(
+            "a {{ color: red }}\n/*# sourceMappingURL={} */",
+            data_uri()
+        ));
+        parse_attached_sourcemap(&mut p, "style");
+        assert_eq!(p.code, "a { color: red }\n");
+        assert!(p.map.is_some());
+    }
+
+    #[test]
+    fn a_line_comment_is_not_consumed_for_style() {
+        let code = format!("a {{ color: red }}\n//# sourceMappingURL={}", data_uri());
+        let mut p = processed(code.clone());
+        parse_attached_sourcemap(&mut p, "style");
+        assert_eq!(p.code, code);
+        assert!(p.map.is_none());
+    }
+
+    #[test]
+    fn a_url_form_map_is_stripped_without_a_map() {
+        let mut p = processed("const a = 1;\n//# sourceMappingURL=out.js.map".to_string());
+        parse_attached_sourcemap(&mut p, "script");
+        assert_eq!(p.code, "const a = 1;\n");
+        assert!(p.map.is_none());
+    }
+
+    #[test]
+    fn a_returned_map_wins_over_an_attached_one() {
+        let mut p = processed(format!("const a = 1;\n//# sourceMappingURL={}", data_uri()));
+        p.map = Some(SourceMapInput::Json("{\"kept\":true}".to_string()));
+        parse_attached_sourcemap(&mut p, "script");
+        assert_eq!(p.code, "const a = 1;\n");
+        match p.map {
+            Some(SourceMapInput::Json(json)) => assert_eq!(json, "{\"kept\":true}"),
+            other => panic!("expected the returned map to be kept, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn code_without_a_comment_is_untouched() {
+        let mut p = processed("const a = 1;".to_string());
+        parse_attached_sourcemap(&mut p, "script");
+        assert_eq!(p.code, "const a = 1;");
+        assert!(p.map.is_none());
+    }
+}

--- a/crates/rsvelte_core/src/compiler/preprocess/replace_in_code.rs
+++ b/crates/rsvelte_core/src/compiler/preprocess/replace_in_code.rs
@@ -8,9 +8,13 @@ use std::sync::LazyLock;
 use regex::Regex;
 
 use super::types::{MappedCode, PreprocessError, Replacement, SimpleDecodedMap, Source};
+use crate::compiler::utils::utf16_len;
 
-// Cached regex for tokenizing lines (for source map generation)
-static REGEX_LINE_TOKEN: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"([^\w\s]|\s+)").unwrap());
+// Cached regex for tokenizing lines (for source map generation). The word class
+// is spelled out because JavaScript's `\w` is ASCII-only, so a non-ASCII letter
+// is its own token upstream but would join a word run under Unicode `\w`.
+static REGEX_LINE_TOKEN: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"([^0-9A-Za-z_\s]|\s+)").unwrap());
 
 /// Create a slice of a Source at a given offset.
 ///
@@ -161,14 +165,14 @@ impl MappedCode {
 
         for (line_idx, line) in line_list.iter().enumerate() {
             let mut line_mappings = vec![];
-            let mut column = 0u32;
+            let mut column = 0usize;
 
             // Split line into tokens
             let mut last_end = 0;
             for token_match in REGEX_LINE_TOKEN.find_iter(line) {
                 // Add token before this match
                 if token_match.start() > last_end {
-                    let token_len = (token_match.start() - last_end) as u32;
+                    let token_len = utf16_len(&line[last_end..token_match.start()]);
                     if token_len > 0 {
                         line_mappings.push(vec![
                             column as i64,
@@ -181,7 +185,7 @@ impl MappedCode {
                 }
 
                 // Add the matched token
-                let token_len = token_match.as_str().len() as u32;
+                let token_len = utf16_len(token_match.as_str());
                 if token_len > 0 {
                     line_mappings.push(vec![
                         column as i64,
@@ -196,7 +200,7 @@ impl MappedCode {
 
             // Add remaining part of line
             if last_end < line.len() {
-                let token_len = (line.len() - last_end) as u32;
+                let token_len = utf16_len(&line[last_end..]);
                 if token_len > 0 {
                     line_mappings.push(vec![
                         column as i64,
@@ -342,9 +346,9 @@ impl MappedCode {
     }
 }
 
-/// Get the length of the last line in a string.
+/// UTF-16 length of the last line in a string — the column its end sits at.
 fn last_line_length(s: &str) -> usize {
-    s.len() - s.rfind('\n').map(|i| i + 1).unwrap_or(0)
+    utf16_len(&s[s.rfind('\n').map(|i| i + 1).unwrap_or(0)..])
 }
 
 /// Merge two tables (sources or names arrays) and return the merged table,

--- a/crates/rsvelte_core/src/compiler/utils.rs
+++ b/crates/rsvelte_core/src/compiler/utils.rs
@@ -245,9 +245,23 @@ pub fn get_basename(filename: &str) -> String {
         .to_string()
 }
 
-/// Get a location function for finding line/column from character offset.
+/// Number of UTF-16 code units in `s`.
+///
+/// Source-map columns are JavaScript string indices, which count UTF-16 code
+/// units rather than bytes.
+pub fn utf16_len(s: &str) -> usize {
+    if s.is_ascii() {
+        s.len()
+    } else {
+        s.chars().map(char::len_utf16).sum()
+    }
+}
+
+/// Get a location function mapping a byte offset to a line and a UTF-16 column.
 ///
 /// This creates a closure that can efficiently look up locations in the source.
+///
+/// Corresponds to `getLocator` from locate-character.
 pub fn get_locator(
     source: &str,
 ) -> std::sync::Arc<dyn Fn(usize) -> crate::compiler::preprocess::types::Location + Send + Sync> {
@@ -259,9 +273,12 @@ pub fn get_locator(
         }
     }
 
-    let source_len = source.len();
+    let source = source.to_string();
     std::sync::Arc::new(move |index| {
-        let index = index.min(source_len);
+        let mut index = index.min(source.len());
+        while !source.is_char_boundary(index) {
+            index -= 1;
+        }
 
         // Binary search for the line
         let line = match line_starts.binary_search(&index) {
@@ -269,7 +286,8 @@ pub fn get_locator(
             Err(insert_pos) => insert_pos.saturating_sub(1),
         };
 
-        let column = index - line_starts.get(line).copied().unwrap_or(0);
+        let line_start = line_starts.get(line).copied().unwrap_or(0);
+        let column = utf16_len(&source[line_start..index]);
 
         crate::compiler::preprocess::types::Location { line, column }
     })

--- a/crates/rsvelte_core/tests/preprocess.rs
+++ b/crates/rsvelte_core/tests/preprocess.rs
@@ -85,7 +85,7 @@ pub fn run_preprocess_fixture(fixture: &PreprocessFixture) -> PreprocessResult {
 
     let result = runtime.block_on(preprocess(
         fixture.input.clone(),
-        preprocessors,
+        &preprocessors,
         fixture.filename.clone(),
     ));
 

--- a/crates/rsvelte_core/tests/preprocess_attributes.rs
+++ b/crates/rsvelte_core/tests/preprocess_attributes.rs
@@ -22,7 +22,7 @@ fn run(source: &str, group: PreprocessorGroup) -> String {
         .unwrap();
     rt.block_on(preprocess(
         source.to_string(),
-        vec![group],
+        &[group],
         Some("T.svelte".to_string()),
     ))
     .unwrap()

--- a/crates/rsvelte_core/tests/preprocess_sourcemap.rs
+++ b/crates/rsvelte_core/tests/preprocess_sourcemap.rs
@@ -1,0 +1,148 @@
+//! Source-map behaviour of `preprocess()`, checked against the maps the
+//! official compiler produces for the same inputs.
+//!
+//! Regenerate the expectations with
+//! `node scripts/dev/preprocess-sourcemap-oracle.mjs`.
+
+use rsvelte_core::compiler::preprocess::encode_sourcemap::encode_mappings;
+use rsvelte_core::compiler::preprocess::preprocess;
+use rsvelte_core::compiler::preprocess::types::{
+    MarkupPreprocessorFn, PreprocessorFn, PreprocessorGroup, Processed, SimpleDecodedMap,
+    SourceMapInput,
+};
+
+fn run(source: &str, preprocessors: &[PreprocessorGroup]) -> Processed {
+    tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap()
+        .block_on(preprocess(
+            source.to_string(),
+            preprocessors,
+            Some("input.svelte".to_string()),
+        ))
+        .expect("preprocess should succeed")
+}
+
+fn mappings_of(processed: &Processed) -> String {
+    match processed.map.as_ref().expect("a map should be produced") {
+        SourceMapInput::Decoded(map) => encode_mappings(&map.mappings),
+        SourceMapInput::Json(json) => panic!("expected a decoded map, got {json}"),
+    }
+}
+
+fn decoded(mappings: Vec<Vec<Vec<i64>>>) -> SourceMapInput {
+    SourceMapInput::Decoded(SimpleDecodedMap {
+        sources: vec!["input.svelte".to_string()],
+        mappings,
+        ..SimpleDecodedMap::default()
+    })
+}
+
+fn markup_group(name: &str, code: &'static str, mappings: Vec<Vec<Vec<i64>>>) -> PreprocessorGroup {
+    let markup: MarkupPreprocessorFn = Box::new(move |_| {
+        let mappings = mappings.clone();
+        Box::pin(async move {
+            Ok(Some(Processed {
+                code: code.to_string(),
+                map: Some(decoded(mappings)),
+                dependencies: vec![],
+                attributes: None,
+            }))
+        })
+    });
+    PreprocessorGroup {
+        name: Some(name.to_string()),
+        markup: Some(markup),
+        ..PreprocessorGroup::default()
+    }
+}
+
+fn script_group(name: &str, processed: fn() -> Processed) -> PreprocessorGroup {
+    let script: PreprocessorFn = Box::new(move |_| Box::pin(async move { Ok(Some(processed())) }));
+    PreprocessorGroup {
+        name: Some(name.to_string()),
+        script: Some(script),
+        ..PreprocessorGroup::default()
+    }
+}
+
+/// Two map-producing preprocessors: the composed map must resolve to the
+/// original source, not to the first stage's output. Before the chain was
+/// composed this produced `AAAA` — a mapping to line 0 of an intermediate text
+/// nobody has.
+#[test]
+fn two_preprocessor_maps_compose_back_to_the_original_source() {
+    let result = run(
+        "A\nB\nC\n",
+        &[
+            markup_group(
+                "first",
+                "X\nB\nC\n",
+                vec![vec![vec![0, 0, 2, 0]], vec![], vec![], vec![]],
+            ),
+            markup_group(
+                "second",
+                "Y\nB\nC\n",
+                vec![vec![vec![0, 0, 0, 0]], vec![], vec![], vec![]],
+            ),
+        ],
+    );
+
+    assert_eq!(result.code, "Y\nB\nC\n");
+    assert_eq!(mappings_of(&result), "AAEA");
+}
+
+/// A multi-byte character before the tag: mapped columns are UTF-16 code units,
+/// so the three-byte `ボ` advances the column by one, not by three.
+#[test]
+fn columns_are_counted_in_utf16_code_units() {
+    fn processed() -> Processed {
+        Processed {
+            code: "let b=1;".to_string(),
+            map: Some(decoded(vec![vec![vec![0, 0, 0, 0]]])),
+            dependencies: vec![],
+            attributes: None,
+        }
+    }
+
+    let result = run(
+        "<p>ボタン</p><script>let a=1;</script>",
+        &[script_group("script", processed)],
+    );
+
+    assert_eq!(result.code, "<p>ボタン</p><script>let b=1;</script>");
+    assert_eq!(
+        mappings_of(&result),
+        "AAAA,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,MAAM,CAAC,QAAQ,CAAC,CAAC,MAAM"
+    );
+}
+
+/// A preprocessor that attaches its map as a `sourceMappingURL` comment instead
+/// of returning it: the comment is consumed, not left in the component code.
+#[test]
+fn an_attached_sourcemap_is_consumed_and_stripped() {
+    fn processed() -> Processed {
+        // Base64 of {"version":3,"sources":["input.svelte"],"names":[],"mappings":"AAAA"}
+        let data = "eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImlucHV0LnN2ZWx0ZSJdLCJuYW1lcyI6W10sIm1hcHBpbmdzIjoiQUFBQSJ9";
+        Processed {
+            code: format!(
+                "let b=1;\n//# sourceMappingURL=data:application/json;charset=utf-8;base64,{data}"
+            ),
+            map: None,
+            dependencies: vec![],
+            attributes: None,
+        }
+    }
+
+    let result = run(
+        "<script>let a=1;</script>",
+        &[script_group("attach", processed)],
+    );
+
+    assert_eq!(result.code, "<script>let b=1;\n</script>");
+    assert_eq!(
+        mappings_of(&result),
+        "AAAA,CAAC,MAAM,CAAC;AAAQ,CAAC,CAAC,MAAM"
+    );
+}

--- a/crates/rsvelte_devtools/tests/compatibility_report.rs
+++ b/crates/rsvelte_devtools/tests/compatibility_report.rs
@@ -1354,7 +1354,7 @@ fn run_preprocess_tests() -> CategoryResult {
         };
         let filename = common::preprocess_fixtures::filename_for(&name);
 
-        let (status, error) = match runtime.block_on(preprocess(input, preprocessors, filename)) {
+        let (status, error) = match runtime.block_on(preprocess(input, &preprocessors, filename)) {
             Ok(processed) => {
                 if processed.code == expected {
                     (TestStatus::Passed, None)

--- a/crates/rsvelte_napi/src/lib.rs
+++ b/crates/rsvelte_napi/src/lib.rs
@@ -1436,7 +1436,7 @@ pub fn napi_preprocess(
 
     env.execute_tokio_future(
         async move {
-            rsvelte_core::compiler::preprocess::preprocess(source, rust_groups, filename)
+            rsvelte_core::compiler::preprocess::preprocess(source, &rust_groups, filename)
                 .await
                 .map_err(|e| napi::Error::from_reason(format!("{e}")))
         },
@@ -1448,6 +1448,7 @@ mod preprocess_bridge {
     use napi::Status;
     use napi::bindgen_prelude::{FromNapiValue, Object, Promise};
     use napi::threadsafe_function::ThreadsafeFunction;
+    use rsvelte_core::compiler::preprocess::encode_sourcemap::decoded_to_v3_json;
     use rsvelte_core::compiler::preprocess::types::{
         AttributeValue as RsAttrValue, MarkupPreprocessorFn, MarkupPreprocessorOptions,
         PreprocessError, PreprocessorFn, PreprocessorGroup, PreprocessorOptions,
@@ -1744,116 +1745,6 @@ mod preprocess_bridge {
             "map": map,
             "dependencies": deps,
         })
-    }
-
-    /// Serialize a `SimpleDecodedMap` to a standard [Source Map v3] JSON
-    /// object — camelCase keys (`sourcesContent`, `sourceRoot`) and a
-    /// VLQ-encoded `mappings` string — so downstream tools (Vite,
-    /// Rolldown, magic-string consumers) can ingest it directly.
-    ///
-    /// [Source Map v3]: https://sourcemaps.info/spec.html
-    fn decoded_to_v3_json(map: &SimpleDecodedMap) -> Value {
-        let mut obj = serde_json::Map::new();
-        obj.insert(
-            "version".to_string(),
-            Value::Number(serde_json::Number::from(map.version.unwrap_or(3))),
-        );
-        if let Some(ref file) = map.file {
-            obj.insert("file".to_string(), Value::String(file.clone()));
-        }
-        if let Some(ref source_root) = map.source_root {
-            obj.insert("sourceRoot".to_string(), Value::String(source_root.clone()));
-        }
-        obj.insert(
-            "sources".to_string(),
-            Value::Array(map.sources.iter().cloned().map(Value::String).collect()),
-        );
-        if let Some(ref contents) = map.sources_content {
-            obj.insert(
-                "sourcesContent".to_string(),
-                Value::Array(
-                    contents
-                        .iter()
-                        .map(|c| c.clone().map_or(Value::Null, Value::String))
-                        .collect(),
-                ),
-            );
-        }
-        obj.insert(
-            "names".to_string(),
-            Value::Array(map.names.iter().cloned().map(Value::String).collect()),
-        );
-        obj.insert(
-            "mappings".to_string(),
-            Value::String(encode_mappings(&map.mappings)),
-        );
-        Value::Object(obj)
-    }
-
-    /// VLQ-encode a decoded `mappings` array (`Vec<Vec<Vec<i64>>>`) into
-    /// the Source Map v3 string form: lines separated by `;`, segments
-    /// within a line separated by `,`, fields within a segment as
-    /// relative-encoded VLQs.
-    fn encode_mappings(mappings: &[Vec<Vec<i64>>]) -> String {
-        let mut out = String::new();
-        // Source index / original line / original column / name index
-        // run relative to the *previous segment*, regardless of line.
-        // Generated column resets at each `;` (per spec).
-        let mut prev_source: i64 = 0;
-        let mut prev_orig_line: i64 = 0;
-        let mut prev_orig_col: i64 = 0;
-        let mut prev_name: i64 = 0;
-        for (i, line) in mappings.iter().enumerate() {
-            if i > 0 {
-                out.push(';');
-            }
-            let mut prev_gen_col: i64 = 0;
-            for (j, segment) in line.iter().enumerate() {
-                if j > 0 {
-                    out.push(',');
-                }
-                if segment.is_empty() {
-                    continue;
-                }
-                let gen_col = segment[0];
-                vlq_encode(&mut out, gen_col - prev_gen_col);
-                prev_gen_col = gen_col;
-                if segment.len() >= 4 {
-                    let src = segment[1];
-                    let orig_line = segment[2];
-                    let orig_col = segment[3];
-                    vlq_encode(&mut out, src - prev_source);
-                    vlq_encode(&mut out, orig_line - prev_orig_line);
-                    vlq_encode(&mut out, orig_col - prev_orig_col);
-                    prev_source = src;
-                    prev_orig_line = orig_line;
-                    prev_orig_col = orig_col;
-                    if segment.len() >= 5 {
-                        let name = segment[4];
-                        vlq_encode(&mut out, name - prev_name);
-                        prev_name = name;
-                    }
-                }
-            }
-        }
-        out
-    }
-
-    const BASE64: &[u8; 64] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
-
-    fn vlq_encode(out: &mut String, value: i64) {
-        let mut vlq = (value.cast_unsigned() << 1) ^ (value >> 63).cast_unsigned();
-        loop {
-            let mut digit = (vlq & 0x1f) as u8;
-            vlq >>= 5;
-            if vlq > 0 {
-                digit |= 0x20;
-            }
-            out.push(BASE64[digit as usize] as char);
-            if vlq == 0 {
-                break;
-            }
-        }
     }
 }
 

--- a/crates/rsvelte_preprocess/tests/bridge_ports.rs
+++ b/crates/rsvelte_preprocess/tests/bridge_ports.rs
@@ -41,14 +41,10 @@ fn run(template: &str, filename: &str, group: PreprocessorGroup) -> Result<Strin
         .build()
         .unwrap();
     rt.block_on(async {
-        preprocess(
-            template.to_string(),
-            vec![group],
-            Some(filename.to_string()),
-        )
-        .await
-        .map(|p| p.code)
-        .map_err(|e| e.to_string())
+        preprocess(template.to_string(), &[group], Some(filename.to_string()))
+            .await
+            .map(|p| p.code)
+            .map_err(|e| e.to_string())
     })
 }
 

--- a/crates/rsvelte_preprocess/tests/svelte_preprocess.rs
+++ b/crates/rsvelte_preprocess/tests/svelte_preprocess.rs
@@ -22,7 +22,7 @@ fn run(template: &str, opts: AutoOptions) -> String {
     rt.block_on(async {
         preprocess(
             template.to_string(),
-            vec![svelte_preprocess(opts)],
+            &[svelte_preprocess(opts)],
             Some("/App.svelte".to_string()),
         )
         .await

--- a/crates/rsvelte_preprocess/tests/switch_case.rs
+++ b/crates/rsvelte_preprocess/tests/switch_case.rs
@@ -35,7 +35,7 @@ fn run(code: &str) -> Result<String, String> {
     rt.block_on(async {
         preprocess(
             minify(code),
-            vec![switch_case()],
+            &[switch_case()],
             Some("test.svelte".to_string()),
         )
         .await

--- a/scripts/dev/preprocess-sourcemap-oracle.mjs
+++ b/scripts/dev/preprocess-sourcemap-oracle.mjs
@@ -1,0 +1,91 @@
+// Prints the source maps official `preprocess()` produces for the scenarios the
+// preprocess source-map tests assert on, so the expectations are the oracle's
+// numbers rather than ours. Run: node scripts/dev/preprocess-sourcemap-oracle.mjs
+import { preprocess } from '../../submodules/svelte/packages/svelte/src/compiler/index.js';
+
+const show = async (label, source, preprocessors, filename) => {
+	const result = await preprocess(source, preprocessors, { filename });
+	console.log(`=== ${label}`);
+	console.log('code:', JSON.stringify(result.code));
+	console.log('map:', JSON.stringify(result.map));
+	console.log('');
+};
+
+// 1. Two markup preprocessors, each returning a map. The composed map must
+//    resolve back to the ORIGINAL source, not to stage 1's output.
+await show(
+	'two-markup-maps',
+	'A\nB\nC\n',
+	[
+		{
+			name: 'first',
+			markup: () => ({
+				code: 'X\nB\nC\n',
+				map: {
+					version: 3,
+					sources: ['input.svelte'],
+					names: [],
+					mappings: [[[0, 0, 2, 0]], [], [], []]
+				}
+			})
+		},
+		{
+			name: 'second',
+			markup: () => ({
+				code: 'Y\nB\nC\n',
+				map: {
+					version: 3,
+					sources: ['input.svelte'],
+					names: [],
+					mappings: [[[0, 0, 0, 0]], [], [], []]
+				}
+			})
+		}
+	],
+	'input.svelte'
+);
+
+// 2. A multi-byte character before the `<script>` tag: the mapped column is
+//    counted in UTF-16 code units, not UTF-8 bytes.
+await show(
+	'utf16-columns',
+	'<p>ボタン</p><script>let a=1;</script>',
+	[
+		{
+			name: 'script',
+			script: () => ({
+				code: 'let b=1;',
+				map: {
+					version: 3,
+					sources: ['input.svelte'],
+					names: [],
+					mappings: [[[0, 0, 0, 0]]]
+				}
+			})
+		}
+	],
+	'input.svelte'
+);
+
+// 3. A preprocessor that attaches its map to the code instead of returning it.
+const attached = Buffer.from(
+	JSON.stringify({
+		version: 3,
+		sources: ['input.svelte'],
+		names: [],
+		mappings: 'AAAA'
+	})
+).toString('base64');
+await show(
+	'attached-sourcemap',
+	'<script>let a=1;</script>',
+	[
+		{
+			name: 'attach',
+			script: () => ({
+				code: `let b=1;\n//# sourceMappingURL=data:application/json;charset=utf-8;base64,${attached}`
+			})
+		}
+	],
+	'input.svelte'
+);


### PR DESCRIPTION
Resolves the five preprocess source-map issues filed after #2970. All of them
live in `crates/rsvelte_core/src/compiler/preprocess/`; they are one PR because
they touch the same map arithmetic and the last three are only observable
together.

### #2970 — the chain is composed, not truncated

`combine_sourcemaps` returned `sourcemap_list[0]` (the *last* map) with a `TODO`.
With two map-producing preprocessors the returned map therefore pointed into an
intermediate text nobody has. `combine_sourcemaps.rs` is a port of
`@jridgewell/remapping`'s `traceMappings` / `originalPositionFor` /
`maybeAddSegment`, including both branches upstream selects between (array
interface, and the loader interface for a multi-source leading map).

### #2971 — an attached `sourceMappingURL` is consumed

There was no `parse_attached_sourcemap`. A preprocessor that attaches its map as
a `//# sourceMappingURL=data:…` comment had the map ignored **and** the comment
compiled into the component. Ported with both upstream warning cases.

### #2972 — columns are UTF-16 code units

`get_locator`, `MappedCode::from_source`, `concat` and the tag-open mapping all
counted UTF-8 bytes. One `utf16_len` helper now covers every column that crosses
the source-map boundary. The line-token regex also had to spell out `\w` as
`[0-9A-Za-z_]`: JavaScript's `\w` is ASCII-only, so upstream emits one segment
per non-ASCII letter where Unicode `\w` merged them into a word run.

### #2973 — the encoder is in `rsvelte_core` and it was wrong

`decoded_to_v3_json` / `encode_mappings` / `vlq_encode` moved out of
`rsvelte_napi` into `preprocess::encode_sourcemap`, public, with a round-trip
test. **That round-trip immediately failed**: the encoder used the
two's-complement zigzag (`(v << 1) ^ (v >> 63)`) where source map VLQ is
sign-magnitude, so every negative delta decoded one too small. Negative deltas
occur on essentially every real map (a new line starting left of the previous
segment), so every `preprocess()` map that crossed the N-API boundary was off.
This is the concrete payoff of the issue's "the one encoder we have is only
exercised through the N-API path".

### #2974 — `preprocess(source, &[PreprocessorGroup], filename)`

Taking the groups by value forced a caller to rebuild every closure per file.
The body only calls the hooks, so a slice suffices.

## Verification

`crates/rsvelte_core/tests/preprocess_sourcemap.rs` runs the three scenarios
end-to-end and asserts the **official compiler's own output** for the same
inputs — `scripts/dev/preprocess-sourcemap-oracle.mjs` regenerates the
expectations. All three encoded `mappings` strings are byte-identical to
official's; before this PR the composition case produced `AAAA` instead of
`AAEA`, and the UTF-16 case produced `GAAG` where official emits three `CAAC`.

The 19 upstream preprocess fixtures, `preprocess_attributes`,
`preprocess_vlq_sourcemap` and the whole `rsvelte_preprocess` suite still pass.

Closes #2970
Closes #2971
Closes #2972
Closes #2973
Closes #2974

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019K1hD7Hs8jCDuNWrqLHqpT
