### PR TITLE
fix(preprocess): report Sass/SCSS partials as dependencies

### DIFF
--- a/crates/rsvelte_preprocess/src/lib.rs
+++ b/crates/rsvelte_preprocess/src/lib.rs
@@ -24,6 +24,8 @@ pub mod bridge;
 
 #[cfg(feature = "sass")]
 pub mod sass;
+#[cfg(feature = "sass")]
+mod sass_fs;
 
 #[cfg(feature = "less")]
 pub mod less;

--- a/crates/rsvelte_preprocess/src/sass.rs
+++ b/crates/rsvelte_preprocess/src/sass.rs
@@ -13,6 +13,7 @@ use rsvelte_core::compiler::preprocess::types::{
 };
 
 use crate::filter::{FilterOptions, matches};
+use crate::sass_fs::RecordingFs;
 
 /// Options forwarded to the Sass compiler (subset of the dart-sass options
 /// object the JS package accepts).
@@ -71,7 +72,8 @@ pub fn preprocess_sass(
     // upstream spreads `...sassOptions` after the computed `indentedSyntax`.
     let indented = sass_options.indented_syntax.unwrap_or(indented_syntax);
 
-    let mut options = grass::Options::default();
+    let fs = RecordingFs::default();
+    let mut options = grass::Options::default().fs(&fs);
     if indented {
         options = options.input_syntax(grass::InputSyntax::Sass);
     }
@@ -94,6 +96,7 @@ pub fn preprocess_sass(
 
     Ok(Some(Processed {
         code: css,
+        dependencies: fs.dependencies(),
         ..Default::default()
     }))
 }

--- a/crates/rsvelte_preprocess/src/sass_fs.rs
+++ b/crates/rsvelte_preprocess/src/sass_fs.rs
@@ -1,0 +1,53 @@
+//! A `grass` filesystem that records the files it loads.
+//!
+//! `grass` resolves `@use` / `@import` internally and reports nothing about it,
+//! so the only way to learn which partials a block depends on — and therefore
+//! which files a watcher has to watch — is to observe the reads.
+
+use std::io;
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+
+#[derive(Debug, Default)]
+pub(crate) struct RecordingFs {
+    loaded: Mutex<Vec<PathBuf>>,
+}
+
+impl RecordingFs {
+    /// The files loaded so far, absolute where the path could be resolved,
+    /// sorted and deduplicated.
+    pub(crate) fn dependencies(&self) -> Vec<String> {
+        let Ok(loaded) = self.loaded.lock() else {
+            return Vec::new();
+        };
+        let mut paths: Vec<String> = loaded
+            .iter()
+            .map(|path| path.to_string_lossy().into_owned())
+            .collect();
+        paths.sort();
+        paths.dedup();
+        paths
+    }
+}
+
+impl grass::Fs for RecordingFs {
+    fn is_dir(&self, path: &Path) -> bool {
+        path.is_dir()
+    }
+
+    fn is_file(&self, path: &Path) -> bool {
+        path.is_file()
+    }
+
+    fn read(&self, path: &Path) -> io::Result<Vec<u8>> {
+        let contents = std::fs::read(path)?;
+        if let Ok(mut loaded) = self.loaded.lock() {
+            loaded.push(std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf()));
+        }
+        Ok(contents)
+    }
+
+    fn canonicalize(&self, path: &Path) -> io::Result<PathBuf> {
+        std::fs::canonicalize(path)
+    }
+}

--- a/crates/rsvelte_preprocess/src/svelte_preprocess/scss.rs
+++ b/crates/rsvelte_preprocess/src/svelte_preprocess/scss.rs
@@ -4,6 +4,8 @@
 
 use std::path::{Path, PathBuf};
 
+use crate::sass_fs::RecordingFs;
+
 /// Options for the scss transform (subset of the dart-sass legacy options).
 #[derive(Debug, Clone, Default)]
 pub struct ScssOptions {
@@ -42,7 +44,8 @@ pub fn transform(
         return Ok(ScssOutput::default());
     }
 
-    let mut grass_options = grass::Options::default();
+    let fs = RecordingFs::default();
+    let mut grass_options = grass::Options::default().fs(&fs);
     if indented {
         grass_options = grass_options.input_syntax(grass::InputSyntax::Sass);
     }
@@ -65,6 +68,6 @@ pub fn transform(
 
     Ok(ScssOutput {
         code: css,
-        dependencies: Vec::new(),
+        dependencies: fs.dependencies(),
     })
 }

--- a/crates/rsvelte_preprocess/tests/sass_dependencies.rs
+++ b/crates/rsvelte_preprocess/tests/sass_dependencies.rs
@@ -1,0 +1,141 @@
+//! `@use` / `@import`ed partials must be reported as dependencies, or a watcher
+//! never rebuilds a component when one of them changes.
+
+#![cfg(feature = "sass")]
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use rsvelte_core::compiler::preprocess::types::{AttributeValue, PreprocessAttributeMap as Map};
+use rsvelte_preprocess::filter::FilterOptions;
+use rsvelte_preprocess::sass::{SassOptions, preprocess_sass};
+use rsvelte_preprocess::svelte_preprocess::scss;
+
+fn attrs(pairs: &[(&str, &str)]) -> Map<String, AttributeValue> {
+    let mut m = Map::default();
+    for (k, v) in pairs {
+        m.insert(k.to_string(), AttributeValue::String(v.to_string()));
+    }
+    m
+}
+
+/// A directory holding `_vars.scss` and `_nested.scss`, where `_vars` forwards
+/// `_nested`, so a transitive load is covered too.
+struct Fixture {
+    dir: PathBuf,
+}
+
+impl Fixture {
+    fn new(name: &str) -> Self {
+        let dir = std::env::temp_dir().join(format!("rsvelte-sass-deps-{name}"));
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).unwrap();
+        fs::write(dir.join("_nested.scss"), "$accent: blue;\n").unwrap();
+        fs::write(dir.join("_vars.scss"), "@use 'nested';\n$color: red;\n").unwrap();
+        Fixture { dir }
+    }
+
+    fn entry(&self) -> String {
+        self.dir
+            .join("Component.svelte")
+            .to_string_lossy()
+            .into_owned()
+    }
+
+    fn canonical(&self, file: &str) -> String {
+        fs::canonicalize(self.dir.join(file))
+            .unwrap()
+            .to_string_lossy()
+            .into_owned()
+    }
+}
+
+impl Drop for Fixture {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.dir);
+    }
+}
+
+#[test]
+fn the_sass_backend_reports_used_partials() {
+    let fixture = Fixture::new("sass");
+    let processed = preprocess_sass(
+        &SassOptions::default(),
+        &FilterOptions::default(),
+        Some(&fixture.entry()),
+        "@use 'vars';\nb { color: vars.$color }",
+        &attrs(&[("lang", "scss")]),
+    )
+    .unwrap()
+    .expect("the block selects scss");
+
+    assert_eq!(processed.code, "b {\n  color: red;\n}");
+    assert_eq!(
+        processed.dependencies,
+        vec![
+            fixture.canonical("_nested.scss"),
+            fixture.canonical("_vars.scss")
+        ]
+    );
+}
+
+#[test]
+fn the_svelte_preprocess_backend_reports_used_partials() {
+    let fixture = Fixture::new("svelte-preprocess");
+    let output = scss::transform(
+        scss::ScssOptions::default(),
+        false,
+        Some(&fixture.entry()),
+        "@use 'vars';\nb { color: vars.$color }",
+    )
+    .unwrap();
+
+    assert_eq!(output.code, "b {\n  color: red;\n}");
+    assert_eq!(
+        output.dependencies,
+        vec![
+            fixture.canonical("_nested.scss"),
+            fixture.canonical("_vars.scss")
+        ]
+    );
+}
+
+#[test]
+fn a_block_with_no_imports_reports_no_dependencies() {
+    let processed = preprocess_sass(
+        &SassOptions::default(),
+        &FilterOptions::default(),
+        None,
+        "b { color: red }",
+        &attrs(&[("lang", "scss")]),
+    )
+    .unwrap()
+    .expect("the block selects scss");
+
+    assert!(processed.dependencies.is_empty());
+}
+
+#[test]
+fn an_extra_load_path_is_recorded_too() {
+    let fixture = Fixture::new("load-path");
+    let processed = preprocess_sass(
+        &SassOptions {
+            load_paths: vec![fixture.dir.clone()],
+            ..SassOptions::default()
+        },
+        &FilterOptions::default(),
+        Some(Path::new("elsewhere/Component.svelte").to_str().unwrap()),
+        "@use 'vars';\nb { color: vars.$color }",
+        &attrs(&[("lang", "scss")]),
+    )
+    .unwrap()
+    .expect("the block selects scss");
+
+    assert_eq!(
+        processed.dependencies,
+        vec![
+            fixture.canonical("_nested.scss"),
+            fixture.canonical("_vars.scss")
+        ]
+    );
+}


### PR DESCRIPTION
`rsvelte_preprocess`'s two `grass`-backed style backends returned
`dependencies: vec![]`, so `@use` / `@import`ed partials were never reported.
A watcher therefore never rebuilds a component when one of its partials
changes — silent, because the build itself is correct, it just doesn't happen.

`svelte_preprocess/scss.rs` is the worse shape of the two: `ScssOutput` already
*had* a `dependencies` field, hard-coded to `Vec::new()` and threaded on to
`Processed`, so a caller reading it got a well-formed "no dependencies" answer
rather than "not implemented".

`grass` resolves imports internally and reports nothing about them, so the only
way to learn what a block loaded is to observe the reads. `sass_fs::RecordingFs`
implements `grass::Fs` over `std::fs` and collects every path passed to `read`
(the probe calls — `is_file` / `is_dir` on candidate paths that mostly do not
exist — are deliberately not recorded). All four trait methods delegate,
including `canonicalize`, which `grass` uses for import de-duplication and which
the trait's default implementation would have turned into the identity.

Paths are canonicalized, sorted and deduplicated, matching what dart-sass's
`includedFiles` gives `svelte-preprocess`.

## Verification

`crates/rsvelte_preprocess/tests/sass_dependencies.rs` covers both backends with
a transitive load (`@use 'vars'` where `_vars.scss` itself `@use`s `_nested.scss`),
a block with no imports, and resolution through an explicit `load_paths` entry
rather than the entry file's directory. Every one of them asserted an empty
vector before this change.

Source maps remain a separate follow-up — `grass` emits none.

Closes #2975

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019K1hD7Hs8jCDuNWrqLHqpT
