### PR TITLE
fix(esrap): unbreak main — restore the two comment-safe printer routings

### DIFF
--- a/.changeset/keep-interior-comments.md
+++ b/.changeset/keep-interior-comments.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/compiler": patch
+---
+
+Keep interior script comments in server output: a reassembled program's comment cursor was discarded before its located statements were printed.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2613,7 +2613,7 @@ dependencies = [
 
 [[package]]
 name = "rsvelte_esrap"
-version = "0.10.28"
+version = "0.10.29"
 dependencies = [
  "compact_str 0.10.0",
  "memchr",

--- a/crates/rsvelte_core/Cargo.toml
+++ b/crates/rsvelte_core/Cargo.toml
@@ -94,7 +94,7 @@ oxc_ast = { version = "0.144", features = ["serialize"] }
 oxc_span = "0.144"
 oxc_diagnostics = "0.144"
 oxc_codegen = "0.144"
-rsvelte_esrap = { version = "=0.10.28", path = "../rsvelte_esrap" }
+rsvelte_esrap = { version = "=0.10.29", path = "../rsvelte_esrap" }
 oxc_syntax = "0.144"
 oxc_semantic = "0.144"
 

--- a/crates/rsvelte_esrap/Cargo.toml
+++ b/crates/rsvelte_esrap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rsvelte_esrap"
-version = "0.10.28"
+version = "0.10.29"
 edition = "2024"
 rust-version = "1.95"
 description = "A Rust port of esrap — prints an oxc AST to JavaScript with esrap's exact layout"

--- a/crates/rsvelte_esrap/src/lib.rs
+++ b/crates/rsvelte_esrap/src/lib.rs
@@ -226,7 +226,7 @@ fn print_split_impl<const HAS_COMMENTS: bool>(
     line_starts: Vec<u32>,
     map_line_starts: Vec<u32>,
 ) -> PrintWithMap {
-    if map_source.is_none() {
+    if !HAS_COMMENTS && map_source.is_none() {
         let mut printer =
             printer::Printer::<HAS_COMMENTS, true>::with_comments(options, comments, line_starts)
                 .with_split_coordinates(map_line_starts, loc_base, loc_map, false);

--- a/crates/rsvelte_esrap/src/lib.rs
+++ b/crates/rsvelte_esrap/src/lib.rs
@@ -110,19 +110,28 @@ pub fn print(program: &Program<'_>, source: &str) -> String {
 /// Print `program` to JavaScript with explicit options, interleaving comments.
 pub fn print_with(program: &Program<'_>, source: &str, options: &PrintOptions) -> String {
     if program.comments.is_empty() {
-        print_direct::<false>(program, options, source.len(), Vec::new(), Vec::new(), None)
+        print_direct(program, options, source.len())
     } else if printer::comments_are_program_level(program) {
         print_direct_outer_comments(program, source, options)
     } else {
-        print_direct::<true>(
-            program,
-            options,
-            source.len(),
-            Vec::new(),
-            Vec::new(),
-            Some(source),
-        )
+        // Interior comments still go through the deferred printer: the direct
+        // one emits some that have no located node left to attach to, which the
+        // official compiler drops.
+        print_interleaved(program, source, options)
     }
+}
+
+fn print_interleaved(program: &Program<'_>, source: &str, options: &PrintOptions) -> String {
+    let mut printer =
+        printer::Printer::<true, false>::with_comments(options, Vec::new(), Vec::new())
+            .with_borrowed_comments(&program.comments, source);
+    let mut ctx = context::Context::new();
+    printer.print_program(program, &mut ctx);
+    let capacity = ctx.measure();
+    let (buffer, returned) = ctx.into_parts();
+    let code = command::print(&buffer, &options.indent, capacity);
+    pool::give(buffer, returned);
+    code
 }
 
 fn print_direct_outer_comments(
@@ -140,19 +149,9 @@ fn print_direct_outer_comments(
     code
 }
 
-fn print_direct<'a, const HAS_COMMENTS: bool>(
-    program: &'a Program<'a>,
-    options: &'a PrintOptions,
-    capacity: usize,
-    comments: Vec<printer::Cmt>,
-    line_starts: Vec<u32>,
-    comment_source: Option<&'a str>,
-) -> String {
+fn print_direct(program: &Program<'_>, options: &PrintOptions, capacity: usize) -> String {
     let mut printer =
-        printer::Printer::<HAS_COMMENTS, true>::with_comments(options, comments, line_starts);
-    if let Some(source) = comment_source {
-        printer = printer.with_borrowed_comments(&program.comments, source);
-    }
+        printer::Printer::<false, true>::with_comments(options, Vec::new(), Vec::new());
     let mut ctx = context::Context::new_direct(&options.indent, capacity);
     printer.print_program(program, &mut ctx);
     let (buffer, returned, indent, dirty) = ctx.into_direct_parts();

--- a/crates/rsvelte_esrap/tests/split_coordinates.rs
+++ b/crates/rsvelte_esrap/tests/split_coordinates.rs
@@ -329,3 +329,49 @@ fn unmapped_chunks_emit_no_source_positions() {
         mapped.mappings
     );
 }
+
+/// A reassembled program's own span starts at 0 — below `loc_base` — because
+/// the `Program` node is synthesized even when its statements are not. The
+/// program-level `reset_comment_index` therefore discards the pending cursor,
+/// and only a printer that re-syncs on the located descendants still emits
+/// their interior comments.
+///
+/// Every other case in this file builds a program whose span starts *at*
+/// `loc_base`, which is what let a regression through: the server SSR path
+/// prints exactly this shape and lost every interior script comment.
+#[test]
+fn an_unlocated_program_keeps_its_statements_interior_comments() {
+    let cases: &[(&str, &str, &str)] = &[
+        (
+            "function body",
+            "\n\n\texport function g() {\n\t\t/* mod */\n\t\treturn 1;\n\t}\n",
+            "/* mod */",
+        ),
+        (
+            "nested block",
+            "\n\n\tfunction g() {\n\t\tif (1) {\n\t\t\t// deep\n\t\t\treturn 2;\n\t\t}\n\t}\n",
+            "// deep",
+        ),
+        (
+            "trailing in body",
+            "\n\n\tfunction g() {\n\t\treturn 1; // tail\n\t}\n",
+            "// tail",
+        ),
+    ];
+
+    for &(name, source, needle) in cases {
+        let allocator = Allocator::default();
+        let program = Parser::new(&allocator, source, SourceType::mjs())
+            .parse()
+            .program;
+        assert_eq!(
+            program.span.start, 0,
+            "{name}: program starts below loc_base"
+        );
+        let printed = print_split(&program, source, 1, None, &[], &PrintOptions::default()).code;
+        assert!(
+            printed.contains(needle),
+            "{name}: lost {needle} from\n{printed}"
+        );
+    }
+}

--- a/crates/rsvelte_lint_types/Cargo.lock
+++ b/crates/rsvelte_lint_types/Cargo.lock
@@ -1111,7 +1111,7 @@ dependencies = [
 
 [[package]]
 name = "rsvelte_esrap"
-version = "0.10.27"
+version = "0.10.29"
 dependencies = [
  "compact_str",
  "memchr",


### PR DESCRIPTION
`main` is red at 316643e8 (`CI`, `Coverage`, `Corpus Compat`, `crates.io packages`,
`Release` all failed). **Four** `rsvelte_core` tests fail there and on every branch cut
from it, plus **984 new shape-matrix divergences**, which blocks every open PR.

`git bisect` names one culprit for all of it: #2979. It changed two routings, and both
are unsound.

## Defect 1 — `print_split_impl` lost its `!HAS_COMMENTS` guard

The fast-path condition went from `!HAS_COMMENTS && map_source.is_none()` to
`map_source.is_none()`, routing a comment-bearing **reassembled** program through the
direct printer.

A reassembled program's own `Program` span starts at 0 — below `loc_base` — because the
`Program` node is synthesized even though its statements are not. `body_elems` therefore
calls `reset_comment_index(Some(0))`, `has_loc(0)` is false, and esrap's `!node.loc` rule
discards the whole comment cursor. The deferred printer recovers, because every located
body re-syncs the cursor on the way down. The direct printer does not: its `body_elems`
shortcut reads the exhausted cursor as "this statement contains no comments" and prints
every located descendant with `comment_free()`, permanently dropping them.

Concretely, `<script module>` interior comments vanish from server output:

```
export function g() {      export function g() {
	/* mod */          →       return 1;
	return 1;              }
}
```

Measured with the NAPI binding built from this branch vs from `main`, everything else held
fixed:

| | `main` (316643e8) | this branch |
|---|---:|---:|
| shape matrix `js-mismatch` | 1,348 | 364 |
| shape matrix NEW divergences | **984** | **0** |

Every one of the 984 is in the `comment-slot` family.

## Defect 2 — `print_with`'s interior-comment branch is the mirror image

Where defect 1 drops comments, this one **invents** one: the direct printer emits a
comment that has no located node left to attach to after the client rewrites a statement
in place, and the official compiler emits none there. That is
`synthesized_invalidation_does_not_rewind_comments`, the fourth failing test — the guard
restoration alone does not fix it, which is how the second defect surfaced at all.

Both routings are reverted. `comments_are_program_level` /
`print_direct_outer_comments` — the case #2979 set out to speed up, and the common one —
keeps its direct path, so the PR's win on program-level comments is retained. The direct
path can be re-enabled for the other two shapes once it handles a comment cursor whose
program span sits below `loc_base`.

## Why no esrap test caught defect 1

Every case in `split_coordinates.rs` builds its program with `Span::new(self.loc_base, …)`
— the program span starts **at** `loc_base`, so `has_loc(program.span.start)` is true and
the discarding branch is never taken. #2979 even added
`comment_direct_matches_deferred_split_output` to that file, and it passes on the broken
tree for exactly this reason. `an_unlocated_program_keeps_its_statements_interior_comments`
is added here with `program.span.start == 0` asserted up front, and it fails on `main`.

Defect 2 gets **no** new esrap-level test, deliberately. I built one (parse a block, replace
a statement with a location-less node, print) and it did **not** reproduce — the deferred
printer emits both comments there too, so the shape that discriminates is something the
client's pipeline does downstream that I have not isolated. Shipping a test that passes for
a reason I cannot state would read as coverage this does not have. The existing
`synthesized_invalidation_comment_cursor_2262.rs` is the gate; it is CI-visible and it does
fail without this change.

## Also here

`crates/rsvelte_lint_types/Cargo.lock` was already stale on `main` — #2979 bumped
`rsvelte_esrap` without re-resolving it — so the `Lint-types lockfile` job failed there
too. Refreshed with `pnpm run fix:lint-types-lock`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019K1hD7Hs8jCDuNWrqLHqpT
