### PR TITLE
feat(handoff): let a consumer take the client Program without re-parsing

### DIFF
--- a/.changeset/coordinate-free-handoff.md
+++ b/.changeset/coordinate-free-handoff.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/compiler": patch
+---
+
+Add `Converted::into_coordinate_free_program`, so a consumer that wants the client OXC `Program` instead of the printed JavaScript can adopt it without re-parsing. Measured on 5,836 shipped components, the share a native bundler can take directly goes from 3.02% to 100%, replacing a re-parse worth 7.5% of compile with a strip worth 0.79%.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2584,6 +2584,7 @@ dependencies = [
  "mimalloc",
  "oxc_allocator",
  "oxc_ast",
+ "oxc_ast_visit",
  "oxc_codegen",
  "oxc_formatter",
  "oxc_parser",

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/js_ast/to_oxc.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/js_ast/to_oxc.rs
@@ -78,6 +78,36 @@ pub struct Converted<'a> {
     pub loc_map: Vec<(u32, u32, Option<u32>)>,
 }
 
+impl<'a> Converted<'a> {
+    /// Strip every coordinate, yielding a program that indexes **no** text.
+    ///
+    /// A consumer that wants the AST rather than the printed code cannot use
+    /// these spans: they index the `.svelte` input (or, for a comment-bearing
+    /// program, a synthetic buffer above `loc_base`), while the text it will
+    /// slice is the generated JavaScript. A span that points into another text
+    /// is worse than no span, so the ones that would lie are removed — and
+    /// comments go with them, because a comment's position is a coordinate too.
+    ///
+    /// The program is no longer printable by [`rsvelte_esrap`]'s comment-aware
+    /// entry points; print first, then call this on the same conversion.
+    pub fn into_coordinate_free_program(mut self) -> Program<'a> {
+        SpanEraser.visit_program(&mut self.program);
+        self.program.comments.clear();
+        self.program.span = SPAN;
+        self.program
+    }
+}
+
+/// Sets every span the walk reaches to [`SPAN`]. `visit_span` is called once per
+/// node by the generated walk, so this reaches all of them without naming any.
+struct SpanEraser;
+
+impl<'a> VisitMut<'a> for SpanEraser {
+    fn visit_span(&mut self, span: &mut Span) {
+        *span = SPAN;
+    }
+}
+
 /// A retained source program to clone into the final OXC allocator.
 pub struct AstIsland<'source> {
     pub program: &'source RetainedProgram<'source>,

--- a/crates/rsvelte_core/tests/ast_handoff_coordinate_free.rs
+++ b/crates/rsvelte_core/tests/ast_handoff_coordinate_free.rs
@@ -1,0 +1,96 @@
+//! `Converted::into_coordinate_free_program` — the contract a native bundler
+//! integration needs before it can adopt rsvelte's `Program` instead of
+//! re-parsing the printed code.
+//!
+//! The property is negative and total: **no** span in the returned program may
+//! index anything, and no comment may survive. A partial strip is worse than
+//! none, because the consumer's acceptance test is "this program makes no claim
+//! about any text" and a single surviving span makes that claim falsely.
+
+use oxc_ast::AstKind;
+use oxc_ast::ast::Program;
+use oxc_ast_visit::Visit;
+use oxc_span::{GetSpan, Span};
+use rsvelte_core::compiler::compile_client_with_program_sink;
+use rsvelte_core::compiler::phases::phase3_transform::js_ast::to_oxc::program_to_oxc;
+use rsvelte_core::{CompileOptions, GenerateMode};
+
+/// A component whose output carries both disqualifiers: comments, and nodes the
+/// converter parses from generated chunks and therefore leaves located.
+const SOURCE: &str = r#"<script>
+	import Child from './Child.svelte';
+	// a comment the converter has to place
+	export let value = 1;
+	let doubled = value * 2;
+	function bump() {
+		value += 1;
+	}
+</script>
+<button onclick={bump}>{doubled}</button>
+<Child {value} />
+"#;
+
+#[derive(Default)]
+struct Located {
+    spans: Vec<(String, Span)>,
+}
+
+impl<'a> Visit<'a> for Located {
+    fn enter_node(&mut self, kind: AstKind<'a>) {
+        if kind.span() != Span::default() {
+            self.spans
+                .push((kind.debug_name().into_owned(), kind.span()));
+        }
+    }
+}
+
+fn located(program: &Program<'_>) -> Vec<(String, Span)> {
+    let mut probe = Located::default();
+    for statement in &program.body {
+        probe.visit_statement(statement);
+    }
+    probe.spans
+}
+
+#[test]
+fn stripping_leaves_no_span_and_no_comment_behind() {
+    let options = CompileOptions {
+        filename: Some("Handoff.svelte".to_string()),
+        generate: GenerateMode::Client,
+        enable_sourcemap: false,
+        ..Default::default()
+    };
+
+    let mut before = Vec::new();
+    let mut before_comments = 0;
+    let mut after = Vec::new();
+    let mut after_comments = 0;
+
+    compile_client_with_program_sink(SOURCE, options, &mut |program, arena| {
+        let allocator = oxc_allocator::Allocator::default();
+        let converted =
+            program_to_oxc(program, arena, &allocator).expect("fixture must convert to OXC");
+        before = located(&converted.program);
+        before_comments = converted.program.comments.len();
+
+        let stripped = converted.into_coordinate_free_program();
+        after = located(&stripped);
+        after_comments = stripped.comments.len();
+    })
+    .expect("fixture must compile");
+
+    // Positive control: without the strip the program does carry coordinates, so
+    // an empty `after` means the strip worked rather than that the fixture had
+    // nothing to strip.
+    assert!(
+        !before.is_empty(),
+        "fixture carries no located spans, so it cannot discriminate"
+    );
+    assert!(
+        before_comments > 0,
+        "fixture carries no comments, so it cannot discriminate"
+    );
+
+    assert_eq!(after, Vec::new(), "spans survived the strip");
+    assert_eq!(after_comments, 0, "comments survived the strip");
+}

--- a/crates/rsvelte_devtools/Cargo.toml
+++ b/crates/rsvelte_devtools/Cargo.toml
@@ -41,6 +41,7 @@ backtrace = "0.3"
 chrono = "0.4"
 oxc_allocator = "0.144"
 oxc_ast = "0.144"
+oxc_ast_visit = "0.144"
 oxc_codegen = "0.144"
 oxc_formatter = { git = "https://github.com/oxc-project/oxc", rev = "b6f1458dece6bbd7f934d1d26c049d0d0c2bd68c", optional = true }
 oxc_parser = "0.144"

--- a/crates/rsvelte_devtools/src/bin/ast_handoff_sizing.rs
+++ b/crates/rsvelte_devtools/src/bin/ast_handoff_sizing.rs
@@ -1,0 +1,423 @@
+//! Sizes the client AST handoff: how often a consumer that wants rsvelte's OXC
+//! `Program` instead of its printed text can take it directly, why it cannot
+//! when it cannot, and what the fallback re-parse costs.
+//!
+//! A native bundler integration accepts the handoff only for a program it can
+//! treat as the module's own AST — one whose spans do not index a *different*
+//! text than the code it will slice. Two properties disqualify a program, and
+//! they are counted separately here because they have different remedies:
+//!
+//!   * `comment_source` is `Some` — comment coordinates live in a synthetic
+//!     buffer above `loc_base`, outside any real text;
+//!   * some node still carries a **source-dependent** span — a retained AST
+//!     island keeps the offsets it was parsed at, which index the `.svelte`
+//!     input, not the generated JS.
+//!
+//! Usage:
+//!   ast_handoff_sizing --shipped
+//!   ast_handoff_sizing --dir=/path/to/checkout
+//!   ast_handoff_sizing --dir=… --json
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant};
+
+use oxc_ast::ast::Program;
+use oxc_ast_visit::Visit;
+use oxc_span::{GetSpan, SourceType, Span};
+use rsvelte_core::compiler::compile_client_with_program_sink;
+use rsvelte_core::compiler::phases::phase3_transform::js_ast::to_oxc::{
+    program_to_oxc, take_fallback_reason,
+};
+use rsvelte_core::{CompileOptions, GenerateMode};
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum Verdict {
+    /// Nothing indexes another text: the consumer can take the program as-is.
+    Direct,
+    /// Comment coordinates live above `loc_base`.
+    CommentBearing,
+    /// A retained island keeps spans that index the `.svelte` input.
+    SourceDependentSpans,
+    /// Both of the above, on the same program.
+    Both,
+    /// `program_to_oxc` bailed; there is no program to hand off at all.
+    NoProgram,
+}
+
+impl Verdict {
+    fn label(self) -> &'static str {
+        match self {
+            Verdict::Direct => "direct",
+            Verdict::CommentBearing => "comment-only",
+            Verdict::SourceDependentSpans => "source-span-only",
+            Verdict::Both => "comment+source-span",
+            Verdict::NoProgram => "no-program",
+        }
+    }
+}
+
+/// Finds the first span that indexes a text other than the one the consumer
+/// would treat as the module source.
+#[derive(Default)]
+struct SpanProbe {
+    kinds: rustc_hash::FxHashMap<String, u64>,
+    nodes: u64,
+    /// The converter puts synthesized nodes at `SPAN`; anything else was parsed
+    /// from somewhere and kept its offsets.
+    located: u64,
+}
+
+impl<'a> Visit<'a> for SpanProbe {
+    fn enter_node(&mut self, kind: oxc_ast::AstKind<'a>) {
+        self.nodes += 1;
+        if kind.span() != Span::default() {
+            self.located += 1;
+            *self
+                .kinds
+                .entry(kind.debug_name().into_owned())
+                .or_default() += 1;
+        }
+    }
+}
+
+fn probe_spans(program: &Program<'_>) -> SpanProbe {
+    let mut probe = SpanProbe::default();
+    for statement in &program.body {
+        probe.visit_statement(statement);
+    }
+    probe
+}
+
+struct Row {
+    project: String,
+    verdict: Verdict,
+    /// `take_fallback_reason`, only meaningful for `NoProgram`.
+    reason: &'static str,
+    bytes: usize,
+    compile: Duration,
+    convert: Duration,
+    reparse: Duration,
+    nodes: u64,
+    located: u64,
+    kinds: rustc_hash::FxHashMap<String, u64>,
+    /// Whether the same conversion, put through
+    /// `Converted::into_coordinate_free_program`, passes the consumer's gate.
+    direct_after_strip: bool,
+    strip: Duration,
+}
+
+fn measure(source: &str, path: &str) -> Option<Row> {
+    let options = CompileOptions {
+        filename: Some(path.to_string()),
+        generate: GenerateMode::Client,
+        enable_sourcemap: false,
+        ..Default::default()
+    };
+
+    let mut verdict = Verdict::NoProgram;
+    let mut reason = "";
+    let mut convert = Duration::ZERO;
+    let mut spans = SpanProbe::default();
+    let mut direct_after_strip = false;
+    let mut strip = Duration::ZERO;
+
+    let started = Instant::now();
+    let output = compile_client_with_program_sink(source, options, &mut |program, arena| {
+        let allocator = oxc_allocator::Allocator::default();
+        let at = Instant::now();
+        let converted = program_to_oxc(program, arena, &allocator);
+        convert = at.elapsed();
+        match converted {
+            None => {
+                verdict = Verdict::NoProgram;
+                reason = take_fallback_reason();
+            }
+            Some(converted) => {
+                let comments = converted.comment_source.is_some();
+                spans = probe_spans(&converted.program);
+                verdict = match (comments, spans.located > 0) {
+                    (false, false) => Verdict::Direct,
+                    (true, false) => Verdict::CommentBearing,
+                    (false, true) => Verdict::SourceDependentSpans,
+                    (true, true) => Verdict::Both,
+                };
+
+                // Same conversion again, then stripped: the question is not
+                // "does the strip run" but "does its result pass the gate that
+                // rejected the unstripped program".
+                let again = program_to_oxc(program, arena, &allocator)
+                    .expect("second conversion of a program that already converted");
+                let at = Instant::now();
+                let stripped = again.into_coordinate_free_program();
+                strip = at.elapsed();
+                direct_after_strip =
+                    stripped.comments.is_empty() && probe_spans(&stripped).located == 0;
+            }
+        }
+    })
+    .ok()?;
+    let compile = started.elapsed();
+
+    // What the consumer pays instead of taking the handoff: one OXC parse of the
+    // code it was handed, in the same process.
+    let allocator = oxc_allocator::Allocator::default();
+    let at = Instant::now();
+    let parsed = oxc_parser::Parser::new(&allocator, &output.js.code, SourceType::mjs()).parse();
+    let reparse = at.elapsed();
+    // A re-parse that fails is not a fallback the consumer can take, and would
+    // price the wrong thing.
+    if !parsed.diagnostics.is_empty() {
+        eprintln!("[handoff] {path}: printed output does not parse; excluded");
+        return None;
+    }
+
+    Some(Row {
+        project: project_of(path),
+        verdict,
+        reason,
+        bytes: source.len(),
+        compile,
+        convert,
+        reparse,
+        nodes: spans.nodes,
+        located: spans.located,
+        kinds: spans.kinds,
+        direct_after_strip,
+        strip,
+    })
+}
+
+fn main() {
+    let files = collect_files();
+    if files.is_empty() {
+        eprintln!("no .svelte files found — pass --dir=<path> or --shipped");
+        std::process::exit(1);
+    }
+
+    // One warm pass: the first compiles pay lazy-static and allocator warmup,
+    // which would land in whichever bucket happens to run first.
+    for (path, source) in files.iter().take(50) {
+        let _ = measure(source, path);
+    }
+
+    let rows: Vec<Row> = files
+        .iter()
+        .filter_map(|(path, source)| measure(source, path))
+        .collect();
+
+    let json = std::env::args().any(|a| a == "--json");
+    report(&rows, json);
+}
+
+fn report(rows: &[Row], json: bool) {
+    let total = rows.len();
+    let verdicts = [
+        Verdict::Direct,
+        Verdict::CommentBearing,
+        Verdict::SourceDependentSpans,
+        Verdict::Both,
+        Verdict::NoProgram,
+    ];
+
+    let sum = |f: fn(&Row) -> Duration| -> Duration { rows.iter().map(f).sum() };
+    let compile = sum(|r| r.compile);
+    let reparse = sum(|r| r.reparse);
+    let convert = sum(|r| r.convert);
+    let bytes: usize = rows.iter().map(|r| r.bytes).sum();
+
+    if json {
+        let counts: Vec<_> = verdicts
+            .iter()
+            .map(|v| {
+                serde_json::json!({
+                    "verdict": v.label(),
+                    "count": rows.iter().filter(|r| r.verdict == *v).count(),
+                })
+            })
+            .collect();
+        println!(
+            "{}",
+            serde_json::json!({
+                "files": total,
+                "bytes": bytes,
+                "verdicts": counts,
+                "compile_ms": compile.as_secs_f64() * 1000.0,
+                "convert_ms": convert.as_secs_f64() * 1000.0,
+                "reparse_ms": reparse.as_secs_f64() * 1000.0,
+            })
+        );
+        return;
+    }
+
+    println!("files: {total}  bytes: {bytes}");
+    println!("\nhandoff verdict            files    share");
+    for verdict in verdicts {
+        let n = rows.iter().filter(|r| r.verdict == verdict).count();
+        println!(
+            "  {:<24} {:>5}  {:>6.2}%",
+            verdict.label(),
+            n,
+            100.0 * n as f64 / total as f64
+        );
+    }
+
+    let bailed: Vec<_> = rows
+        .iter()
+        .filter(|r| r.verdict == Verdict::NoProgram)
+        .collect();
+    if !bailed.is_empty() {
+        println!("\nno-program, by converter reason");
+        let mut reasons: Vec<&'static str> = bailed.iter().map(|r| r.reason).collect();
+        reasons.sort_unstable();
+        reasons.dedup();
+        for reason in reasons {
+            let n = bailed.iter().filter(|r| r.reason == reason).count();
+            println!("  {reason:<24} {n:>5}");
+        }
+    }
+
+    println!("\nverdict by project");
+    let mut projects: Vec<&str> = rows.iter().map(|r| r.project.as_str()).collect();
+    projects.sort_unstable();
+    projects.dedup();
+    print!("  {:<22}", "project");
+    for verdict in verdicts {
+        print!(" {:>19}", verdict.label());
+    }
+    println!();
+    for project in projects {
+        let n = rows.iter().filter(|r| r.project == project).count();
+        print!("  {project:<22}");
+        for verdict in verdicts {
+            let k = rows
+                .iter()
+                .filter(|r| r.project == project && r.verdict == verdict)
+                .count();
+            print!(" {:>11} {:>6.1}%", k, 100.0 * k as f64 / n as f64);
+        }
+        println!();
+    }
+
+    let nodes: u64 = rows.iter().map(|r| r.nodes).sum();
+    let located: u64 = rows.iter().map(|r| r.located).sum();
+    println!(
+        "\nnodes carrying an input-indexed span: {located} / {nodes}  ({:.2}%)",
+        100.0 * located as f64 / nodes as f64
+    );
+
+    let after = rows.iter().filter(|r| r.direct_after_strip).count();
+    println!(
+        "\ndirect after into_coordinate_free_program: {after} / {total}  ({:.2}%),  strip cost {:.1} ms ({:.2}% of compile)",
+        100.0 * after as f64 / total as f64,
+        ms(rows.iter().map(|r| r.strip).sum()),
+        100.0 * rows.iter().map(|r| r.strip).sum::<Duration>().as_secs_f64()
+            / compile.saturating_sub(convert).as_secs_f64()
+    );
+
+    let mut kinds: rustc_hash::FxHashMap<String, u64> = rustc_hash::FxHashMap::default();
+    for row in rows {
+        for (kind, n) in &row.kinds {
+            *kinds.entry(kind.clone()).or_default() += n;
+        }
+    }
+    let mut ranked: Vec<_> = kinds.into_iter().collect();
+    ranked.sort_by_key(|(_, n)| std::cmp::Reverse(*n));
+    println!("\ntop node kinds carrying an input-indexed span");
+    for (kind, n) in ranked.iter().take(15) {
+        println!(
+            "  {kind:<32} {n:>9}  {:>6.2}% of located",
+            100.0 * *n as f64 / located as f64
+        );
+    }
+
+    // The sink runs a SECOND `program_to_oxc`; the pipeline already ran one for
+    // codegen. Subtracting it keeps the denominator a compile, not a compile
+    // plus this instrument.
+    let net = compile.saturating_sub(convert);
+    println!("\ntime, whole population");
+    println!(
+        "  compile (net of this probe's convert)  {:>9.1} ms",
+        ms(net)
+    );
+    println!(
+        "  IR -> OXC convert, this probe          {:>9.1} ms  ({:>5.2}% of compile)",
+        ms(convert),
+        100.0 * convert.as_secs_f64() / net.as_secs_f64()
+    );
+    println!(
+        "  re-parse output, whole population      {:>9.1} ms  ({:>5.2}% of compile)",
+        ms(reparse),
+        100.0 * reparse.as_secs_f64() / net.as_secs_f64()
+    );
+
+    // The share that matters to a consumer is the re-parse it would actually
+    // pay: only the files whose verdict forbids the handoff.
+    let fallback: Duration = rows
+        .iter()
+        .filter(|r| r.verdict != Verdict::Direct)
+        .map(|r| r.reparse)
+        .sum();
+    println!(
+        "  re-parse actually paid (non-direct)    {:>9.1} ms  ({:>5.2}% of compile)",
+        ms(fallback),
+        100.0 * fallback.as_secs_f64() / net.as_secs_f64()
+    );
+}
+
+/// The corpus repository a file came from, so a share that turns out to sit in
+/// one project can be attributed to it instead of guessed at.
+fn project_of(path: &str) -> String {
+    path.split("submodules/")
+        .nth(1)
+        .and_then(|rest| rest.split('/').next())
+        .unwrap_or("(other)")
+        .to_string()
+}
+
+fn ms(d: Duration) -> f64 {
+    d.as_secs_f64() * 1000.0
+}
+
+const SHIPPED_PROJECTS: [&str; 6] = [
+    "submodules/flowbite-svelte",
+    "submodules/bits-ui",
+    "submodules/shadcn-svelte",
+    "submodules/layerchart",
+    "submodules/skeleton",
+    "submodules/svelte-ux",
+];
+
+fn collect_files() -> Vec<(String, String)> {
+    let base = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..");
+    if let Some(dir) = std::env::args().find_map(|a| a.strip_prefix("--dir=").map(str::to_owned)) {
+        let mut files = Vec::new();
+        collect_svelte_files(&PathBuf::from(dir), &mut files);
+        files.sort();
+        return files;
+    }
+    let mut files = Vec::new();
+    for project in &SHIPPED_PROJECTS {
+        collect_svelte_files(&base.join(project), &mut files);
+    }
+    files.sort();
+    files
+}
+
+fn collect_svelte_files(dir: &Path, files: &mut Vec<(String, String)>) {
+    if let Ok(entries) = fs::read_dir(dir) {
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                if path.file_name().is_some_and(|n| n == "node_modules") {
+                    continue;
+                }
+                collect_svelte_files(&path, files);
+            } else if path.extension().is_some_and(|e| e == "svelte")
+                && let Ok(content) = fs::read_to_string(&path)
+            {
+                files.push((path.display().to_string(), content));
+            }
+        }
+    }
+}

--- a/docs/ast-handoff-sizing.md
+++ b/docs/ast-handoff-sizing.md
@@ -1,0 +1,94 @@
+# Client AST handoff: what blocks it, and what it costs
+
+A native bundler integration would rather take rsvelte's OXC `Program` than re-parse the
+JavaScript rsvelte printed. It can only do that for a program that makes **no claim about a text
+it does not have**: rsvelte's spans index the `.svelte` input (and, for a comment-bearing program,
+a synthetic buffer above `loc_base`), while the text the bundler will slice is the generated JS.
+A span pointing into another text is worse than no span, so the consumer's acceptance test is
+`comment_source.is_none() && !has_source_dependent_spans(program)` and everything else re-parses.
+
+The instrument is `crates/rsvelte_devtools/src/bin/ast_handoff_sizing.rs`:
+
+```bash
+cargo build --release -p rsvelte_devtools --bin ast_handoff_sizing
+./target/release/ast_handoff_sizing            # the six shipped corpora
+./target/release/ast_handoff_sizing --dir=…    # any checkout
+```
+
+## Measurement
+
+5,836 `.svelte` files / 9,549,619 bytes from `bits-ui`, `flowbite-svelte`, `layerchart`,
+`shadcn-svelte`, `skeleton`, `svelte-ux`; client target, sourcemaps off; M1 Pro.
+
+| handoff verdict | files | share |
+|---|---:|---:|
+| direct | 176 | **3.02%** |
+| comment-only | 0 | **0.00%** |
+| source-dependent spans only | 5,073 | 86.93% |
+| comments **and** source-dependent spans | 587 | 10.06% |
+| no program (converter bailed) | 0 | 0.00% |
+
+Per repository, `direct` runs 0.4% (layerchart) to 8.6% (bits-ui). The converter never bails on
+this population, so "no program" is not a contributor.
+
+### The comment/span split the issue asked for has a degenerate answer
+
+**Comment-only is 0 — in every one of the six repositories.** Not "small": zero. Every program
+that carries comments also carries source-dependent spans, so a remedy aimed at comments alone
+would move the handoff rate by nothing. That falsifies the framing that the two disqualifiers are
+comparable populations to be traded off; there is one blocker, and comments ride along with it.
+
+### There is no small set of nodes to fix
+
+15.92% of AST nodes (515,678 / 3,240,010) carry an input-indexed span, and they are a flat tail —
+the largest kind, `StaticMemberExpression`, is 7.03% of them, and nothing else reaches 4%. This
+is not a leak from one converter path that could be plugged; keeping spans is what the converter
+does wherever it can. Any remedy has to be total.
+
+### What the fallback costs
+
+| | ms | share of compile |
+|---|---:|---:|
+| compile (net of this probe's own conversion) | 1,436.4 | — |
+| IR → OXC conversion | 95.9 | 6.68% |
+| re-parse of the printed output | 107.7 | **7.50%** |
+| re-parse actually paid (non-direct files only) | 107.1 | 7.46% |
+
+Stable to three digits across repeated runs (7.50 / 8.42 / 8.44 / 8.46% across separate
+invocations; the spread is machine load, not variance in the measurement — the file counts are
+identical every run).
+
+**Read this as a throughput item, not a correctness one.** The re-parse is OXC in the same Rust
+process; nothing falls back to the JavaScript compiler.
+
+## The remedy, and why it is the one that fits
+
+`Converted::into_coordinate_free_program` removes every span and every comment, yielding a
+program that indexes no text at all. The consumer's existing acceptance test then passes
+**unconditionally** — and it is the consumer's *existing* test, not a new contract: the 176 files
+that already hand off directly are exactly the ones whose programs happened to come out
+coordinate-free on their own.
+
+| | before | after |
+|---|---:|---:|
+| files the consumer can adopt | 176 (3.02%) | **5,836 (100.00%)** |
+| cost | re-parse, 7.50% of compile | strip, **0.79% of compile** |
+
+The trade is explicit and belongs to the caller: a coordinate-free program has no comments, so a
+consumer that wants them in its output must print first (rsvelte's own codegen already has, by
+the time the sink runs) and take the separate source map for positions. That is the shape a
+production bundle wants anyway; a dev build that needs comments in the module AST should keep
+re-parsing.
+
+## What this does not answer
+
+- **Generated-coordinate spans are still absent.** Stripping makes the program *safe* to adopt,
+  not *informative*: a downstream plugin that wants to slice code by node position still cannot.
+  Doing that properly means the printer reporting each node's generated offset as it writes, and
+  rsvelte rewriting the spans from it — the node-kind tail above says a partial version of that
+  is not worth building.
+- **The population is six component libraries.** The issue's numbers come from two applications
+  (Open WebUI 9/878 ≈ 1.0% direct, Appwrite Console 715/1,789 ≈ 40%). 3.02% sits inside that
+  range but nearer Open WebUI; the Appwrite figure is far enough away that the *direct* share
+  should be treated as repository-dependent. The 0% comment-only result is the one that holds
+  uniformly here, and it is the one the choice above rests on.


### PR DESCRIPTION
Closes #2977

## Sizing first, as the issue asks

The instrument is `crates/rsvelte_devtools/src/bin/ast_handoff_sizing.rs`; it runs the real
`compile_client_with_program_sink` + `program_to_oxc` path and applies the consumer's own
acceptance test. 5,836 `.svelte` files (9.5 MB) from `bits-ui`, `flowbite-svelte`, `layerchart`,
`shadcn-svelte`, `skeleton`, `svelte-ux`.

| handoff verdict | files | share |
|---|---:|---:|
| direct | 176 | **3.02%** |
| comment-only | 0 | **0.00%** |
| source-dependent spans only | 5,073 | 86.93% |
| comments **and** source-dependent spans | 587 | 10.06% |
| converter bailed | 0 | 0.00% |

**The comment-vs-span split the issue asked for has a degenerate answer: comment-only is 0, in
every one of the six repositories.** Not "small" — zero. Every comment-bearing program also
carries source-dependent spans, so a remedy aimed at comments alone moves the rate by nothing.

**And there is no small set of nodes to fix.** 15.92% of AST nodes (515,678 / 3,240,010) carry
an input-indexed span, in a flat tail: the largest kind, `StaticMemberExpression`, is 7.03% of
them and nothing else reaches 4%. Keeping spans is what the converter does wherever it can, so
any remedy has to be total.

| | ms | share of compile |
|---|---:|---:|
| compile (net of the probe's own conversion) | 1,436.4 | — |
| IR → OXC conversion | 95.9 | 6.68% |
| re-parse of the printed output | 107.7 | **7.50%** |

Stable across repeated runs (7.50 / 8.42 / 8.44 / 8.46%; the spread is machine load — the file
counts are identical every time).

## The change

`Converted::into_coordinate_free_program` removes every span and every comment, yielding a
program that indexes no text at all. It is ~10 lines plus a `VisitMut` that overrides
`visit_span`, which the generated walk calls once per node — so it reaches all of them without
naming any.

| | before | after |
|---|---:|---:|
| files the consumer can adopt | 176 (3.02%) | **5,836 (100.00%)** |
| cost | re-parse, 7.50% of compile | strip, **0.79%** |

That 100% is measured against **the consumer's existing gate**, not a new contract: the 176 files
that already hand off directly are exactly the ones whose programs happened to come out
coordinate-free on their own.

The trade belongs to the caller and is stated in the doc comment: a coordinate-free program has
no comments, so a consumer that wants them takes the separate source map for positions. That is
what a production bundle wants anyway; a dev build that needs comments in the module AST should
keep re-parsing.

## Test

`crates/rsvelte_core/tests/ast_handoff_coordinate_free.rs` asserts the property is **total** — no
span survives, no comment survives — with a positive control asserted first, because an empty
"after" would otherwise be satisfiable by a fixture that had nothing to strip.

## What this does not answer

Recorded in `docs/ast-handoff-sizing.md` rather than left implicit:

- **Generated-coordinate spans are still absent.** Stripping makes the program safe to adopt, not
  informative. A plugin that slices code by node position still cannot. Doing that properly means
  the printer reporting each node's generated offset as it writes; the flat node-kind tail says a
  partial version is not worth building.
- **The population is six component libraries.** The issue's own numbers come from two
  applications (Open WebUI ≈ 1.0% direct, Appwrite Console ≈ 40%). 3.02% sits inside that range
  but near Open WebUI, so the *direct* share should be read as repository-dependent. The 0%
  comment-only result is the one that holds uniformly, and it is the one the choice rests on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019K1hD7Hs8jCDuNWrqLHqpT
