### PR TITLE
perf(devtools): measure the per-call fixed cost instead of inferring it

### DIFF
--- a/crates/rsvelte_devtools/src/bin/fixed_cost_split.rs
+++ b/crates/rsvelte_devtools/src/bin/fixed_cost_split.rs
@@ -1,0 +1,374 @@
+//! Separates rsvelte's per-call **fixed** cost from its per-byte cost, and
+//! attributes the fixed part to a phase.
+//!
+//! A ratio against the official compiler that is high on one app and low on
+//! another, where the low one has smaller components, is the signature of a cost
+//! that does not scale with file size. This measures that directly rather than
+//! inferring it: for every file it records `(bytes, nanoseconds)` per phase and
+//! fits `t = a + b·n`, where `a` **is** the per-call fixed cost. The size-bucket
+//! table beside it is the check — a real intercept shows up as a flat floor in
+//! the small buckets, and a fit whose intercept is an artefact of one outlier
+//! does not.
+//!
+//! Phases are timed by re-running the idempotent prefix of the pipeline, the
+//! same way `compile_profile` does. `plumbing` is the residual of the end-to-end
+//! `compile()` against them, so it holds warnings, CSS assembly, source maps and
+//! whatever the split does not name — it is a remainder, not a measurement, and
+//! is labelled that way in the output.
+//!
+//! Usage:
+//!   fixed_cost_split                      # the six shipped corpora, client prod
+//!   fixed_cost_split --dev
+//!   fixed_cost_split --server
+//!   fixed_cost_split --dir=/path/to/checkout
+
+// Defined per-bin rather than once in the lib so that linking the `rsvelte_core`
+// rlib never imposes an allocator on the consumer.
+#[cfg(all(
+    feature = "mimalloc-alloc",
+    not(target_arch = "wasm32"),
+    not(target_os = "windows")
+))]
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::time::Instant;
+
+use rsvelte_core::compiler::phases::phase1_parse::{
+    ParseOptions, compute_line_offsets, ensure_script_parsed, parse, resolve_lazy_expressions,
+};
+use rsvelte_core::compiler::phases::phase2_analyze::analyze_component;
+use rsvelte_core::compiler::phases::phase3_transform::transform_component;
+use rsvelte_core::{CompileOptions, GenerateMode, compile};
+
+/// One file's cost, split the way the throughput question needs it.
+#[derive(Clone, Copy, Default)]
+struct Sample {
+    bytes: f64,
+    /// Whether the component's scripts use runes. The two dialects are
+    /// different amounts of work per byte, and shipped applications hold far
+    /// more legacy than the component libraries the perf gates sample.
+    runes: bool,
+    /// Bytes inside `<script>` / `<script module>`. A per-KB rate against the
+    /// whole file confounds dialect with how much script the file has at all —
+    /// a markup-only wrapper is legacy by default and nearly free.
+    script_bytes: f64,
+    total: f64,
+    parse: f64,
+    analyze: f64,
+    transform: f64,
+}
+
+impl Sample {
+    fn plumbing(&self) -> f64 {
+        (self.total - self.parse - self.analyze - self.transform).max(0.0)
+    }
+}
+
+/// Ordinary least squares for `t = a + b·n`.
+struct Fit {
+    intercept: f64,
+    slope: f64,
+    /// Share of the phase's total time the intercept accounts for over this
+    /// population — the number that answers "does the fixed cost matter here".
+    fixed_share: f64,
+}
+
+fn fit(samples: &[Sample], value: impl Fn(&Sample) -> f64) -> Fit {
+    let n = samples.len() as f64;
+    let mean_x = samples.iter().map(|s| s.bytes).sum::<f64>() / n;
+    let mean_y = samples.iter().map(&value).sum::<f64>() / n;
+    let mut num = 0.0;
+    let mut den = 0.0;
+    for sample in samples {
+        let dx = sample.bytes - mean_x;
+        num += dx * (value(sample) - mean_y);
+        den += dx * dx;
+    }
+    let slope = if den == 0.0 { 0.0 } else { num / den };
+    let intercept = mean_y - slope * mean_x;
+    let total: f64 = samples.iter().map(&value).sum();
+    Fit {
+        intercept,
+        slope,
+        fixed_share: if total == 0.0 {
+            0.0
+        } else {
+            (intercept * n / total).clamp(0.0, 1.0)
+        },
+    }
+}
+
+fn measure(files: &[(String, String)], options: &CompileOptions) -> Vec<Sample> {
+    let parse_opts = ParseOptions {
+        modern: true,
+        skip_expression_loc: true,
+        defer_script_parse: true,
+        ..Default::default()
+    };
+
+    let mut samples = Vec::with_capacity(files.len());
+    for (_, content) in files {
+        let mut sample = Sample {
+            bytes: content.len() as f64,
+            runes: uses_runes(content),
+            ..Default::default()
+        };
+
+        let at = Instant::now();
+        let compiled = compile(content, options.clone());
+        sample.total = at.elapsed().as_secs_f64();
+        if compiled.is_err() {
+            continue;
+        }
+
+        let allocator = oxc_allocator::Allocator::default();
+        let at = Instant::now();
+        let ast = parse(content, &allocator, parse_opts).ok();
+        sample.parse = at.elapsed().as_secs_f64();
+        let Some(mut ast) = ast else { continue };
+        sample.script_bytes = [ast.instance.as_ref(), ast.module.as_ref()]
+            .into_iter()
+            .flatten()
+            .filter_map(|script| content.get(script.start as usize..script.end as usize))
+            .map(|text| text.len() as f64)
+            .sum();
+
+        let at = Instant::now();
+        // SAFETY: `ast` lives for the rest of this iteration, and the serialize
+        // arena pointer is cleared before the borrow ends.
+        unsafe { rsvelte_core::ast::arena::set_serialize_arena(&raw const ast.arena) };
+        let _ = resolve_lazy_expressions(&mut ast, content);
+        let line_offsets = compute_line_offsets(content, false);
+        if let Some(ref mut instance) = ast.instance {
+            let _ = ensure_script_parsed(&ast.arena, instance, content, &line_offsets);
+        }
+        if let Some(ref mut module) = ast.module {
+            let _ = ensure_script_parsed(&ast.arena, module, content, &line_offsets);
+        }
+        let analysis = analyze_component(&mut ast, content, options).ok();
+        sample.analyze = at.elapsed().as_secs_f64();
+
+        if let Some(analysis) = analysis.as_ref() {
+            let at = Instant::now();
+            let _ = transform_component(analysis, &ast, content, options);
+            sample.transform = at.elapsed().as_secs_f64();
+        }
+        rsvelte_core::ast::arena::clear_serialize_arena();
+
+        samples.push(sample);
+    }
+    samples
+}
+
+fn main() {
+    let files = collect_files();
+    if files.is_empty() {
+        eprintln!("no .svelte files found — pass --dir=<path>");
+        std::process::exit(1);
+    }
+
+    let options = CompileOptions {
+        generate: if std::env::args().any(|a| a == "--server") {
+            GenerateMode::Server
+        } else {
+            GenerateMode::Client
+        },
+        dev: std::env::args().any(|a| a == "--dev"),
+        ..Default::default()
+    };
+
+    // Warm: the first compiles pay lazy-static and allocator warmup, which is
+    // itself a fixed cost — but one paid once per process, not per call, and
+    // charging it to the intercept would be the exact error this bin exists to
+    // avoid.
+    for (_, content) in files.iter().take(100) {
+        let _ = compile(content, options.clone());
+    }
+
+    let samples = measure(&files, &options);
+    report(&samples, &options);
+}
+
+fn report(samples: &[Sample], options: &CompileOptions) {
+    let n = samples.len();
+    let bytes: f64 = samples.iter().map(|s| s.bytes).sum();
+    println!(
+        "target: {:?}{}   files: {n}   bytes: {bytes:.0}   mean file: {:.0} B",
+        options.generate,
+        if options.dev { " (dev)" } else { "" },
+        bytes / n as f64
+    );
+
+    let phases: [(&str, fn(&Sample) -> f64); 5] = [
+        ("compile (end to end)", |s| s.total),
+        ("  parse", |s| s.parse),
+        ("  analyze", |s| s.analyze),
+        ("  transform", |s| s.transform),
+        ("  plumbing (residual)", Sample::plumbing),
+    ];
+
+    println!("\nt = a + b·bytes, ordinary least squares");
+    println!(
+        "  {:<24} {:>12} {:>14} {:>16}",
+        "phase", "a (µs/call)", "b (ns/KB)", "fixed share"
+    );
+    for (label, value) in phases {
+        let f = fit(samples, value);
+        println!(
+            "  {:<24} {:>12.2} {:>14.1} {:>15.1}%",
+            label,
+            f.intercept * 1e6,
+            f.slope * 1e9 * 1024.0,
+            f.fixed_share * 100.0
+        );
+    }
+
+    // The fit's intercept is an extrapolation to zero bytes, which no file is.
+    // The buckets are what make it falsifiable: a real per-call cost shows as a
+    // floor the smallest bucket cannot go below.
+    println!("\nmean per-file time by size bucket");
+    println!(
+        "  {:<16} {:>7} {:>12} {:>12} {:>12} {:>12} {:>12}",
+        "bytes", "files", "compile µs", "parse", "analyze", "transform", "plumbing"
+    );
+    let edges = [0.0, 1024.0, 2048.0, 4096.0, 8192.0, 16384.0, f64::INFINITY];
+    for window in edges.windows(2) {
+        let (lo, hi) = (window[0], window[1]);
+        let bucket: Vec<&Sample> = samples
+            .iter()
+            .filter(|s| s.bytes >= lo && s.bytes < hi)
+            .collect();
+        if bucket.is_empty() {
+            continue;
+        }
+        let k = bucket.len() as f64;
+        let mean = |f: fn(&Sample) -> f64| bucket.iter().map(|s| f(s)).sum::<f64>() / k * 1e6;
+        println!(
+            "  {:<16} {:>7} {:>12.1} {:>12.1} {:>12.1} {:>12.1} {:>12.1}",
+            if hi.is_finite() {
+                format!("{lo:.0}–{hi:.0}")
+            } else {
+                format!("{lo:.0}+")
+            },
+            bucket.len(),
+            mean(|s| s.total),
+            mean(|s| s.parse),
+            mean(|s| s.analyze),
+            mean(|s| s.transform),
+            mean(Sample::plumbing),
+        );
+    }
+
+    // If there were a per-call fixed cost, it would be the same for both
+    // dialects and would show as the two curves converging at small sizes.
+    println!("\nµs per KB of SCRIPT by dialect, within script-size bucket");
+    println!(
+        "  {:<16} {:>9} {:>12} {:>9} {:>12} {:>10}",
+        "script bytes", "runes n", "runes µs/KB", "legacy n", "legacy µs/KB", "legacy/runes"
+    );
+    for window in edges.windows(2) {
+        let (lo, hi) = (window[0], window[1]);
+        let rate = |runes: bool| -> Option<(usize, f64)> {
+            let bucket: Vec<&Sample> = samples
+                .iter()
+                .filter(|s| s.script_bytes >= lo && s.script_bytes < hi && s.runes == runes)
+                .collect();
+            if bucket.is_empty() {
+                return None;
+            }
+            let time: f64 = bucket.iter().map(|s| s.total).sum();
+            let kb: f64 = bucket.iter().map(|s| s.script_bytes).sum::<f64>() / 1024.0;
+            Some((bucket.len(), time * 1e6 / kb))
+        };
+        let (Some((rn, rr)), Some((ln, lr))) = (rate(true), rate(false)) else {
+            continue;
+        };
+        println!(
+            "  {:<16} {:>9} {:>12.1} {:>9} {:>12.1} {:>10.2}x",
+            if hi.is_finite() {
+                format!("{lo:.0}–{hi:.0}")
+            } else {
+                format!("{lo:.0}+")
+            },
+            rn,
+            rr,
+            ln,
+            lr,
+            lr / rr
+        );
+    }
+
+    // Two files of the same size still differ, so the bucket means above are not
+    // a clean floor on their own. The minimum is: no file compiles faster than
+    // the per-call cost, whatever else it does.
+    let floor = samples
+        .iter()
+        .map(|s| s.total)
+        .fold(f64::INFINITY, f64::min);
+    println!(
+        "\nfastest single compile in the population: {:.1} µs",
+        floor * 1e6
+    );
+}
+
+/// A component counts as runes-mode if a rune appears anywhere in it. Coarse on
+/// purpose: the question is which dialect the file is written in, and a file
+/// that mixes them is a legacy file being migrated.
+fn uses_runes(content: &str) -> bool {
+    const RUNES: [&str; 7] = [
+        "$state",
+        "$derived",
+        "$props",
+        "$effect",
+        "$bindable",
+        "$inspect",
+        "$host",
+    ];
+    RUNES.iter().any(|rune| content.contains(rune))
+}
+
+const SHIPPED_PROJECTS: [&str; 6] = [
+    "submodules/flowbite-svelte",
+    "submodules/bits-ui",
+    "submodules/shadcn-svelte",
+    "submodules/layerchart",
+    "submodules/skeleton",
+    "submodules/svelte-ux",
+];
+
+fn collect_files() -> Vec<(String, String)> {
+    let base = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..");
+    if let Some(dir) = std::env::args().find_map(|a| a.strip_prefix("--dir=").map(str::to_owned)) {
+        let mut files = Vec::new();
+        collect_svelte_files(&PathBuf::from(dir), &mut files);
+        files.sort();
+        return files;
+    }
+    let mut files = Vec::new();
+    for project in &SHIPPED_PROJECTS {
+        collect_svelte_files(&base.join(project), &mut files);
+    }
+    files.sort();
+    files
+}
+
+fn collect_svelte_files(dir: &Path, files: &mut Vec<(String, String)>) {
+    if let Ok(entries) = fs::read_dir(dir) {
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                if path.file_name().is_some_and(|n| n == "node_modules") {
+                    continue;
+                }
+                collect_svelte_files(&path, files);
+            } else if path.extension().is_some_and(|e| e == "svelte")
+                && let Ok(content) = fs::read_to_string(&path)
+            {
+                files.push((path.display().to_string(), content));
+            }
+        }
+    }
+}

--- a/docs/per-call-fixed-cost.md
+++ b/docs/per-call-fixed-cost.md
@@ -1,0 +1,109 @@
+# Compiler throughput on small components: where the time actually goes
+
+A speedup ratio that is 9.43× on one application and 3.56× on another, where the low one has
+smaller components, reads like a cost that does not scale with file size. This measures that
+claim instead of inferring it.
+
+The instrument is `crates/rsvelte_devtools/src/bin/fixed_cost_split.rs`:
+
+```bash
+cargo build --release -p rsvelte_devtools --bin fixed_cost_split
+./target/release/fixed_cost_split                 # six shipped corpora, client prod
+./target/release/fixed_cost_split --dev
+./target/release/fixed_cost_split --server
+./target/release/fixed_cost_split --dir=…         # any checkout
+```
+
+5,836 `.svelte` files / 9.5 MB from `bits-ui`, `flowbite-svelte`, `layerchart`, `shadcn-svelte`,
+`skeleton`, `svelte-ux`; mean file 1,636 B; M1 Pro.
+
+## Result 1 — there is no per-call fixed cost worth naming
+
+Fitting `t = a + b·bytes` returns an intercept of **101 µs**, which would be 50% of the mean
+per-file compile. That number is wrong, and the table beside it is what shows it is wrong:
+
+| bytes | files | compile µs | parse | analyze | transform | plumbing |
+|---|---:|---:|---:|---:|---:|---:|
+| 0–1,024 | 3,178 | **75.3** | 2.8 | 24.0 | 42.2 | 8.5 |
+| 1,024–2,048 | 1,433 | 179.1 | 6.5 | 54.6 | 106.8 | 15.8 |
+| 2,048–4,096 | 807 | 349.1 | 11.5 | 106.2 | 217.0 | 22.0 |
+| 4,096–8,192 | 308 | 723.5 | 20.8 | 227.4 | 477.7 | 25.1 |
+| 8,192–16,384 | 86 | 1,377.4 | 36.9 | 415.0 | 954.6 | 35.2 |
+| 16,384+ | 24 | 2,863.3 | 64.3 | 723.2 | 2,083.6 | 90.2 |
+
+**The fitted intercept is larger than the mean of the smallest bucket (101 > 75.3), and 19× the
+fastest single compile in the population (5.4 µs).** A per-call floor cannot exceed the mean of
+the files nearest to zero. The intercept is an artefact of fitting a *linear* model to a
+*superlinear* curve: `transform` grows ~49× (42.2 → 2,083.6) across a bucket range whose mean
+size grows ~16×, an exponent near 1.4 — the same superlinearity already recorded for
+`script_text`.
+
+Two consequences. Any future report of a "fixed cost" from a linear fit on this corpus should be
+treated as this artefact until a bucket table says otherwise. And **hypothesis 1 of the issue
+(allocator/arena setup, option validation, per-pass construction, non-scaling assembly) is
+falsified**: whatever is left of it is under 5.4 µs, i.e. under 7% of a small-file compile.
+
+## Result 2 — the runes/legacy dialect is not the driver either, and the first denominator lied
+
+Against **whole-file** bytes, legacy components looked 0.51–0.73× the cost of runes ones — a
+large, clean-looking effect in the direction that would explain everything, since shipped
+applications are legacy-heavy and component libraries are not.
+
+It is a denominator artefact. A markup-only wrapper has no script, is legacy by default, and is
+nearly free per byte. Re-normalising to **script** bytes and bucketing by script size:
+
+| script bytes | runes n | runes µs/KB | legacy n | legacy µs/KB | legacy/runes |
+|---|---:|---:|---:|---:|---:|
+| 0–1,024 | 2,480 | 320.2 | 2,549 | 396.5 | **1.24×** |
+| 1,024–2,048 | 391 | 324.8 | 103 | 276.8 | 0.85× |
+| 2,048–4,096 | 184 | 278.6 | 29 | 264.2 | 0.95× |
+| 4,096–8,192 | 67 | 273.7 | 10 | 255.7 | 0.93× |
+
+The effect is small and changes sign across buckets. It is not what separates a 9.43× app from a
+3.56× one.
+
+## Result 3 — the decomposition the issue asked for
+
+Share of an end-to-end `compile()`, client production target:
+
+| phase | small files (0–1 KB) | large files (16 KB+) |
+|---|---:|---:|
+| parse | 3.7% | 2.2% |
+| analyze | 31.9% | 25.3% |
+| transform + codegen | 56.0% | 72.8% |
+| plumbing — warnings, CSS assembly, source map, per-file setup (residual) | 11.3% | 3.2% |
+
+Measured on the same population by `ast_handoff_sizing` (see
+[ast-handoff-sizing.md](ast-handoff-sizing.md)), inside those buckets:
+
+| | share of compile |
+|---|---:|
+| IR → OXC conversion | 6.7% |
+| re-parse of the printed output, as a bundler consumer pays it | 7.5% |
+
+By target, on the same files (OLS slope, which is the part of the fit that is not an artefact):
+
+| target | b (ns/KB) | mean compile µs/file |
+|---|---:|---:|
+| client, prod | 63,868 | 101 |
+| client, dev | 76,199 | 122 |
+| server, prod | 50,590 | 83 |
+| server, dev | 53,562 | 86 |
+
+`plumbing` is a **residual**, not a measurement: it is the end-to-end `compile()` minus the three
+phases timed by re-running the pipeline's idempotent prefix. It therefore also absorbs any
+double-counting the re-run introduces, and should not be quoted as "the cost of warnings + CSS +
+source maps" on its own.
+
+## What is left unexplained, stated as such
+
+The issue's observation stands and this corpus cannot resolve it: Appwrite Console has *smaller*
+components than Open WebUI (≈4.6 KB vs ≈5.6 KB) and rsvelte is *slower per file* on it
+(0.60 ms vs 0.49 ms). Neither result above explains that — a superlinear size curve predicts the
+**opposite** sign, and the dialect effect is too small and too unstable.
+
+So the remaining explanation is content-dependent and lives in those two repositories, not in a
+component-library corpus. `fixed_cost_split --dir=<checkout>` runs the whole decomposition on
+either of them; that is the measurement that should come next, and it is the reason the bin takes
+a path at all. Until it is run, "many small components" should not be repeated as the cause —
+this measurement rules out the two mechanisms that were proposed for it.


### PR DESCRIPTION
Closes #2978

`crates/rsvelte_devtools/src/bin/fixed_cost_split.rs` records `(bytes, ns)` per file for
parse / analyze / transform and the end-to-end `compile()`, fits `t = a + b·bytes`, and prints a
size-bucket table **beside** the fit. 5,836 `.svelte` files / 9.5 MB from six shipped libraries;
mean file 1,636 B; M1 Pro.

## Hypothesis 1 (per-call fixed cost) is falsified

The fit returns an intercept of **101 µs**, which would be ~50% of the mean per-file compile.
The bucket table is what shows that number is wrong:

| bytes | files | compile µs | parse | analyze | transform | plumbing |
|---|---:|---:|---:|---:|---:|---:|
| 0–1,024 | 3,178 | **75.3** | 2.8 | 24.0 | 42.2 | 8.5 |
| 1,024–2,048 | 1,433 | 179.1 | 6.5 | 54.6 | 106.8 | 15.8 |
| 2,048–4,096 | 807 | 349.1 | 11.5 | 106.2 | 217.0 | 22.0 |
| 4,096–8,192 | 308 | 723.5 | 20.8 | 227.4 | 477.7 | 25.1 |
| 8,192–16,384 | 86 | 1,377.4 | 36.9 | 415.0 | 954.6 | 35.2 |
| 16,384+ | 24 | 2,863.3 | 64.3 | 723.2 | 2,083.6 | 90.2 |

**101 µs is larger than the mean of the smallest bucket (75.3) and 19× the fastest single compile
in the population (5.4 µs).** A per-call floor cannot exceed the mean of the files nearest to
zero. The intercept is a linear model fitted to a superlinear curve: `transform` grows ~49×
across a bucket range whose mean size grows ~16× — an exponent near 1.4, the `script_text`
superlinearity already on record.

Whatever remains of allocator/arena setup, option validation and per-pass construction is under
**5.4 µs**, i.e. under 7% of a small-file compile.

## The dialect hypothesis is falsified too, and how it failed is the reusable part

Against **whole-file** bytes, legacy components looked 0.51–0.73× the cost of runes ones — large,
clean, and pointing exactly where a legacy-heavy application vs a runes-heavy library would
explain everything.

It is a denominator artefact. A markup-only wrapper has no script, is legacy by default, and is
nearly free per byte. Against **script** bytes, bucketed by script size:

| script bytes | runes n | runes µs/KB | legacy n | legacy µs/KB | legacy/runes |
|---|---:|---:|---:|---:|---:|
| 0–1,024 | 2,480 | 320.2 | 2,549 | 396.5 | **1.24×** |
| 1,024–2,048 | 391 | 324.8 | 103 | 276.8 | 0.85× |
| 2,048–4,096 | 184 | 278.6 | 29 | 264.2 | 0.95× |
| 4,096–8,192 | 67 | 273.7 | 10 | 255.7 | 0.93× |

Small, and it changes sign across buckets.

## The decomposition that was asked for

| phase | small files (0–1 KB) | large files (16 KB+) |
|---|---:|---:|
| parse | 3.7% | 2.2% |
| analyze | 31.9% | 25.3% |
| transform + codegen | 56.0% | 72.8% |
| plumbing — warnings, CSS, source map, per-file setup (**residual**) | 11.3% | 3.2% |

Plus, from `ast_handoff_sizing` on the same population (#2977): IR → OXC conversion **6.7%**,
re-parse of the printed output as a bundler consumer pays it **7.5%**.

Per target (OLS slope — the part of the fit that is not an artefact):

| target | b (ns/KB) | mean compile µs/file |
|---|---:|---:|
| client, prod | 63,868 | 101 |
| client, dev | 76,199 | 122 |
| server, prod | 50,590 | 83 |
| server, dev | 53,562 | 86 |

`plumbing` is a residual, not a measurement — end-to-end minus three re-run phases — so it also
absorbs any double counting the re-run introduces. The doc says so rather than letting the row be
quoted as "the cost of warnings + CSS + source maps".

## What this deliberately does not close over

Appwrite has **smaller** components than Open WebUI *and* rsvelte is **slower per file** on it. A
superlinear size curve predicts the opposite sign, and the dialect effect is too small to bridge
it. So the residue is content-dependent and lives in those two repositories, not in a
component-library corpus. `fixed_cost_split --dir=<checkout>` runs the whole decomposition on
either — that is the next measurement, and the reason the bin takes a path.

Until it is run, "many small components" should not be repeated as the cause: this rules out both
mechanisms that were proposed for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019K1hD7Hs8jCDuNWrqLHqpT
