### PR TITLE
fix(language-server): keep serving after an undecodable LSP message

### DIFF
--- a/.changeset/undecodable-lsp-message.md
+++ b/.changeset/undecodable-lsp-message.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/language-server": patch
+---
+
+Keep serving after an undecodable LSP message. `lsp_server`'s stdio transport ends its reader thread on the first frame whose body will not deserialize, which closed the connection and took the server down — one malformed message from any client, extension or proxy in the chain and every open document lost its language features. The body of such a frame has already been consumed in full, so the stream is still framed correctly; the message is now dropped with a warning and the server keeps reading. A malformed *header* stays fatal, because the reader no longer knows where the next frame begins.

--- a/crates/rsvelte_language_server/src/lib.rs
+++ b/crates/rsvelte_language_server/src/lib.rs
@@ -35,6 +35,7 @@ pub mod settings;
 pub mod symbols;
 pub mod tags;
 pub mod text;
+pub mod transport;
 pub mod tsgo_client;
 pub mod tsgo_code_actions;
 pub mod tsgo_completion;

--- a/crates/rsvelte_language_server/src/server.rs
+++ b/crates/rsvelte_language_server/src/server.rs
@@ -135,7 +135,7 @@ const TSGO_SEMANTIC_TOKEN_MODIFIERS: &[&str] = &[
 ///
 /// Returns an error when initializing or serving the JSON-RPC connection fails.
 pub fn run_stdio() -> Result<ExitCode> {
-    let (connection, io_threads) = Connection::stdio();
+    let (connection, io_threads) = crate::transport::stdio();
     let (id, params) = connection.initialize_start()?;
     let client = ClientState::from_initialize(&params);
     let tsgo = TsgoRuntime::start(&client, &params);

--- a/crates/rsvelte_language_server/src/transport.rs
+++ b/crates/rsvelte_language_server/src/transport.rs
@@ -1,0 +1,135 @@
+//! The stdio transport the server runs on.
+//!
+//! `lsp_server::Connection::stdio` ends its reader thread on the first frame
+//! whose body will not deserialize, which closes the connection and takes the
+//! whole server down — one malformed message from any client, extension or
+//! proxy in the chain and every open document loses its language features. A
+//! body that failed to parse has already been consumed in full, so the stream is
+//! still framed correctly at that point and the message can simply be dropped.
+//! A malformed *header* is different: the reader no longer knows where the next
+//! frame starts, and that stays fatal.
+
+use std::io::{self, BufRead};
+use std::thread::{self, JoinHandle};
+
+use crossbeam_channel::{Receiver, Sender, bounded};
+use lsp_server::{Connection, Message};
+
+use crate::log;
+
+/// The reader and writer threads of [`stdio`], joined after the server stops.
+pub struct IoThreads {
+    reader: JoinHandle<io::Result<()>>,
+    writer: JoinHandle<io::Result<()>>,
+}
+
+impl IoThreads {
+    /// # Errors
+    ///
+    /// Returns the first I/O error either thread ended with.
+    pub fn join(self) -> io::Result<()> {
+        match self.reader.join() {
+            Ok(result) => result?,
+            Err(payload) => std::panic::resume_unwind(payload),
+        }
+        match self.writer.join() {
+            Ok(result) => result,
+            Err(payload) => std::panic::resume_unwind(payload),
+        }
+    }
+}
+
+/// A `Connection` over stdin/stdout that survives an undecodable message.
+#[must_use]
+pub fn stdio() -> (Connection, IoThreads) {
+    let (writer_sender, writer_receiver) = bounded::<Message>(0);
+    let writer = thread::Builder::new()
+        .name("LspServerWriter".to_owned())
+        .spawn(move || write_loop(&writer_receiver))
+        .expect("spawn LSP writer thread");
+
+    let (reader_sender, reader_receiver) = bounded::<Message>(0);
+    let reader = thread::Builder::new()
+        .name("LspServerReader".to_owned())
+        .spawn(move || read_loop(&reader_sender))
+        .expect("spawn LSP reader thread");
+
+    (
+        Connection {
+            sender: writer_sender,
+            receiver: reader_receiver,
+        },
+        IoThreads { reader, writer },
+    )
+}
+
+fn write_loop(receiver: &Receiver<Message>) -> io::Result<()> {
+    let stdout = io::stdout();
+    let mut stdout = stdout.lock();
+    for message in receiver {
+        message.write(&mut stdout)?;
+    }
+    Ok(())
+}
+
+fn read_loop(sender: &Sender<Message>) -> io::Result<()> {
+    let stdin = io::stdin();
+    let mut stdin = stdin.lock();
+    loop {
+        let Some(body) = read_frame(&mut stdin)? else {
+            return Ok(());
+        };
+        let message: Message = match serde_json::from_slice(&body) {
+            Ok(message) => message,
+            Err(err) => {
+                log::warn(format_args!("dropping undecodable message: {err}"));
+                continue;
+            }
+        };
+        let is_exit = matches!(&message, Message::Notification(n) if n.method == "exit");
+        if sender.send(message).is_err() {
+            return Ok(());
+        }
+        if is_exit {
+            return Ok(());
+        }
+    }
+}
+
+/// The body of the next frame, or `None` at end of input.
+fn read_frame(reader: &mut impl BufRead) -> io::Result<Option<Vec<u8>>> {
+    let mut length = None;
+    loop {
+        let mut line = String::new();
+        if reader.read_line(&mut line)? == 0 {
+            return Ok(None);
+        }
+        let line = line.trim_end_matches(['\r', '\n']);
+        if line.is_empty() {
+            break;
+        }
+        let Some((name, value)) = line.split_once(':') else {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("malformed header: {line:?}"),
+            ));
+        };
+        if name.eq_ignore_ascii_case("Content-Length") {
+            length = Some(value.trim().parse::<usize>().map_err(|err| {
+                io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!("bad Content-Length: {err}"),
+                )
+            })?);
+        }
+    }
+    let Some(length) = length else {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "frame without a Content-Length header",
+        ));
+    };
+    let mut body = vec![0u8; length];
+    reader.read_exact(&mut body)?;
+    Ok(Some(body))
+}

--- a/crates/rsvelte_language_server/tests/robustness.rs
+++ b/crates/rsvelte_language_server/tests/robustness.rs
@@ -107,9 +107,16 @@ impl Server {
 
     fn write(&mut self, message: &Value) {
         let body = serde_json::to_vec(message).expect("serialize LSP message");
+        self.write_frame(&body);
+    }
+
+    /// The framing stays correct whatever the body is, so a caller can send a
+    /// payload the *decoder* rejects without leaving the reader unable to find
+    /// where the next frame starts.
+    fn write_frame(&mut self, body: &[u8]) {
         let stdin = self.stdin.as_mut().expect("language server stdin is open");
         write!(stdin, "Content-Length: {}\r\n\r\n", body.len()).expect("write LSP header");
-        stdin.write_all(&body).expect("write LSP body");
+        stdin.write_all(body).expect("write LSP body");
         stdin.flush().expect("flush LSP body");
     }
 
@@ -287,6 +294,39 @@ fn file_uris_encode_spaces_and_non_ascii_paths() {
     let uri = file_uri(&dir.0.join("Component name.svelte"));
     assert!(uri.contains("uri%20space-%E9%9B%AA"), "{uri}");
     assert!(uri.ends_with("Component%20name.svelte"), "{uri}");
+}
+
+/// Malformed at the *protocol* layer rather than the document layer: a frame
+/// whose body will not deserialize into a JSON-RPC message. `lsp_server`'s own
+/// stdio transport ends its reader thread on the first one, which closes the
+/// connection and takes every open document's language features with it — so
+/// this is the one robustness case the sibling test above cannot reach, because
+/// its inputs are all valid messages carrying invalid Svelte.
+#[test]
+fn undecodable_protocol_messages_do_not_end_the_session() {
+    let dir = TestDir::new("undecodable");
+    let uri = file_uri(&dir.0.join("App.svelte"));
+    let mut server = Server::start(None, &[]);
+    server.open(&uri, "<script>let value = 1;</script>\n<p>{value}</p>\n");
+
+    for body in [
+        "{ this is not json",
+        "[]",
+        "null",
+        "42",
+        r#"{"jsonrpc":"2.0"}"#,
+        r#"{"jsonrpc":"2.0","method":42}"#,
+    ] {
+        server.write_frame(body.as_bytes());
+        server.probe();
+    }
+
+    let response = document_request(&mut server, "textDocument/foldingRange", &uri);
+    assert!(
+        response.get("result").is_some(),
+        "no response after undecodable protocol messages: {response}"
+    );
+    server.shutdown();
 }
 
 #[test]


### PR DESCRIPTION
One undecodable LSP message kills `rsvelte-language-server`.

`lsp_server::Connection::stdio` ends its reader thread on the first frame whose body will not deserialize into a JSON-RPC message. That closes the connection, `main_loop` exits, and the process is gone — one malformed message from any client, extension or proxy in the chain and every open document loses its language features, silently.

The body of such a frame has already been consumed in full, so the stream is still framed correctly at that point: the message can simply be dropped. `src/transport.rs` is a drop-in replacement for `Connection::stdio()` that does exactly that, logs a warning, and keeps reading. A malformed **header** is a different case and stays fatal, because the reader no longer knows where the next frame starts.

## Negative control

`undecodable_protocol_messages_do_not_end_the_session` (in the `tests/robustness.rs` added by #2980) sends six correctly framed, undecodably-bodied messages — invalid JSON, valid JSON that is not an object, an object missing `method`/`id`, a wrong-typed `method` — and then requires the server to answer a real request.

With the fix reverted to `Connection::stdio()` it fails at the first probe:

```
thread 'undecodable_protocol_messages_do_not_end_the_session' panicked at
crates/rsvelte_language_server/tests/robustness.rs:161:31:
language server closed stdout
```

With the fix: 6/6 pass.

## Why the existing robustness test does not reach this

#2980's `malformed_documents_do_not_end_the_session` sends malformed *Svelte source* inside well-formed frames — every input there is a valid message. The defect is one layer below that, in the decoder, so it needs a frame the transport itself rejects. `Server::write` is refactored to go through a `write_frame(&[u8])` helper so a test can send a body that is not a serialized `Value`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017LzPenwNb9zAGazC8JK2fH
