### PR TITLE
test(lsp): hold the official oracle to upstream's own snapshots

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -415,8 +415,8 @@ to the same 125 upstream snapshots the gate already loads: a run reproducing und
 aborts *before* the current artifact is written, so nothing a merge could accept survives. It is one
 verdict per run, deliberately not a second ratchet — "is the oracle sane" has one answer, not one
 per fixture. The floor is loose because a live server over stdio is not upstream's provider-level
-harness; the four causes that hold the measured 75% below 100% are enumerated in gate-coverage 27h,
-and the floor cannot see a degradation smaller than that margin.
+harness; the causes that hold the measured 79% below 100% are enumerated in gate-coverage 27h, and
+the floor cannot see a degradation smaller than that margin.
 
 ## Implementation Principles
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -408,6 +408,16 @@ run the comparison therefore install first, and `verify.mjs` refuses to run with
 any gate whose oracle is a type checker: **what did the checkout provide that the sources did not?**
 What it cannot see is gate-coverage 27.
 
+**Every positive control here used to be satisfied by an oracle that answers *something*, and a
+degraded official server does not error — it answers differently, and those answers enrol into a
+shrink-only ratchet that then defends the degradation.** The live official server is therefore held
+to the same 125 upstream snapshots the gate already loads: a run reproducing under **70%** of them
+aborts *before* the current artifact is written, so nothing a merge could accept survives. It is one
+verdict per run, deliberately not a second ratchet — "is the oracle sane" has one answer, not one
+per fixture. The floor is loose because a live server over stdio is not upstream's provider-level
+harness; the four causes that hold the measured 75% below 100% are enumerated in gate-coverage 27h,
+and the floor cannot see a degradation smaller than that margin.
+
 ## Implementation Principles
 
 **CRITICAL**: All implementations must follow the official Svelte compiler implementation.

--- a/compatibility/gate-coverage.md
+++ b/compatibility/gate-coverage.md
@@ -169,7 +169,8 @@ Completion items, diagnostics, locations, folding ranges and inlay hints are pai
 method-specific semantic identity before their fields are diffed (`diff.mjs`). The committed
 fixture population additionally compares rsvelte with the selected upstream expected snapshot.
 The real-project population requests hover, definition and completion at every lexically matched
-identifier position in the four pinned repositories.
+identifier position in the four pinned repositories. The live official server is additionally
+held to those same upstream snapshots as a run-level precondition (27h).
 
 ### Blind spot 27a — server notifications are discarded [S]
 
@@ -253,6 +254,53 @@ still key one normalized field each — so this is a corpus-population blind spo
 one. The unmeasured question is whether a stable projection of a completion response exists that
 would restore per-field sensitivity; nobody has looked, and n=2 sweeps bound the churn only from
 below.
+
+### Blind spot 27h — the oracle is calibrated against upstream's snapshots, and the floor is loose [D]
+
+Every positive control this gate had was satisfied by an official server that answers *something*:
+a non-error TS hover from each side, one `ts`-sourced rsvelte diagnostic, the declared rsvelte
+capabilities. None of them separates a correctly configured official server from one started
+against the wrong workspace root, an unresolved `node_modules` or a missing `tsconfig` — a degraded
+oracle does not error, it answers differently, and those answers enrol into a shrink-only ratchet
+as legitimate entries that then defend the degradation. The 125 upstream snapshots the gate already
+loads were compared against rsvelte only, with `officialResult` in scope and unused at the call
+site.
+
+The live official server is now compared to the same snapshot, counted per snapshot suite, and a
+run below **70%** aborts before the current artifact is written — one verdict per run, deliberately
+not a second ratchet. Measured on the pinned revision: **94/125 (75.2%)**, as
+`typescript-diagnostics` 71/92, `typescript-folding-range` 13/15, `typescript-inlay-hints` 10/18.
+
+What the floor's looseness buys, and what it costs, is the whole of this row. A live server over
+stdio is not upstream's provider-level harness, so the shortfall is structural rather than a
+defect, and it is not one cause:
+
+- **`typescript-diagnostics` (71/92).** The pull-diagnostic response aggregates every plugin the
+  server hosts, while the snapshot is the TypeScript provider's return value alone — on
+  `$$props-valid` the live server adds three `source: "svelte"` `unused-export-let` warnings the
+  snapshot cannot contain. The calibration therefore reads the `ts`/`js`-sourced items only, which
+  moves this suite from 51/92 to 71/92 and is what makes the floor worth having: it is the subset a
+  misconfigured TypeScript backend would crater. The residual 21 are message text and
+  item-membership differences that come from running every fixture in one server session, where
+  upstream constructs one resolver per fixture directory.
+- **`typescript-folding-range` (13/15).** Both misses are one extra whole-`<script>` fold
+  contributed by the HTML folding provider, which upstream's provider-level test does not run —
+  the same two misses, and the same explanation, that a from-scratch harness measured during
+  #1767.
+- **`typescript-inlay-hints` (10/18).** Four are the live server returning `null` where the
+  provider returns hints, on `action`, `animation`, `reactive-block` and `snippet.v5`; the
+  remaining four are a **measurement artifact of the developer's checkout**, not of the oracle —
+  `pathToFileURL` leaves `+` unencoded where the server's `vscode-uri` writes `%2B`, so a worktree
+  path containing `+` defeats `replaceUris` and the fixture's own URI stops normalizing. CI paths
+  carry no `+`, and the differential comparison is immune because both servers encode alike; only
+  snapshot-vs-live sees it.
+
+So the floor is set 5 points under a number that four distinct causes already hold well below 100%,
+and it cannot see a degradation that costs the oracle less than that margin. It is a precondition
+on the run, not a measure of the oracle's quality. Two things it does not cover: the fixture and
+corpus populations have no upstream snapshot at all, so **the oracle is calibrated on 125 of the
+gate's units and on none of the other ~14,000**; and the calibration reads the pristine document
+only — a post-edit phase (27b) is not calibrated, because upstream has no snapshot for one.
 
 ---
 

--- a/compatibility/gate-coverage.md
+++ b/compatibility/gate-coverage.md
@@ -268,34 +268,36 @@ site.
 
 The live official server is now compared to the same snapshot, counted per snapshot suite, and a
 run below **70%** aborts before the current artifact is written — one verdict per run, deliberately
-not a second ratchet. Measured on the pinned revision: **94/125 (75.2%)**, as
-`typescript-diagnostics` 71/92, `typescript-folding-range` 13/15, `typescript-inlay-hints` 10/18.
+not a second ratchet. Measured in CI on the pinned revision: **99/125 (79.2%)**, as
+`typescript-diagnostics` 72/92, `typescript-folding-range` 13/15, `typescript-inlay-hints` 14/18.
 
 What the floor's looseness buys, and what it costs, is the whole of this row. A live server over
 stdio is not upstream's provider-level harness, so the shortfall is structural rather than a
 defect, and it is not one cause:
 
-- **`typescript-diagnostics` (71/92).** The pull-diagnostic response aggregates every plugin the
+- **`typescript-diagnostics` (72/92).** The pull-diagnostic response aggregates every plugin the
   server hosts, while the snapshot is the TypeScript provider's return value alone — on
   `$$props-valid` the live server adds three `source: "svelte"` `unused-export-let` warnings the
   snapshot cannot contain. The calibration therefore reads the `ts`/`js`-sourced items only, which
-  moves this suite from 51/92 to 71/92 and is what makes the floor worth having: it is the subset a
-  misconfigured TypeScript backend would crater. The residual 21 are message text and
-  item-membership differences that come from running every fixture in one server session, where
-  upstream constructs one resolver per fixture directory.
+  moves this suite from 51/92 to 71/92 on the same tree and is what makes the floor worth having:
+  it is the subset a misconfigured TypeScript backend would crater. The residual 20 are message
+  text and item-membership differences that come from running every fixture in one server session,
+  where upstream constructs one resolver per fixture directory.
 - **`typescript-folding-range` (13/15).** Both misses are one extra whole-`<script>` fold
   contributed by the HTML folding provider, which upstream's provider-level test does not run —
   the same two misses, and the same explanation, that a from-scratch harness measured during
   #1767.
-- **`typescript-inlay-hints` (10/18).** Four are the live server returning `null` where the
-  provider returns hints, on `action`, `animation`, `reactive-block` and `snippet.v5`; the
-  remaining four are a **measurement artifact of the developer's checkout**, not of the oracle —
-  `pathToFileURL` leaves `+` unencoded where the server's `vscode-uri` writes `%2B`, so a worktree
-  path containing `+` defeats `replaceUris` and the fixture's own URI stops normalizing. CI paths
-  carry no `+`, and the differential comparison is immune because both servers encode alike; only
-  snapshot-vs-live sees it.
+- **`typescript-inlay-hints` (14/18).** All four misses are the live server returning `null` where
+  the provider returns hints, on `action`, `animation`, `reactive-block` and `snippet.v5`.
 
-So the floor is set 5 points under a number that four distinct causes already hold well below 100%,
+**This number is a property of the checkout as much as of the oracle, in a second way 27f does not
+cover.** The same commit measures 94/125 in a worktree whose path contains a `+` and 99/125 in CI:
+`pathToFileURL` leaves `+` unencoded where the server's `vscode-uri` writes `%2B`, so `replaceUris`
+stops matching and four `typescript-inlay-hints` fixtures fail on their own URI alone. The
+differential comparison is immune because both servers encode alike; only snapshot-vs-live sees it.
+Read a local shortfall against that before reading it as the oracle.
+
+So the floor is set 9 points under a number that three distinct causes already hold well below 100%,
 and it cannot see a degradation that costs the oracle less than that margin. It is a precondition
 on the run, not a measure of the oracle's quality. Two things it does not cover: the fixture and
 corpus populations have no upstream snapshot at all, so **the oracle is calibrated on 125 of the

--- a/scripts/compat-lsp/normalize.mjs
+++ b/scripts/compat-lsp/normalize.mjs
@@ -63,6 +63,25 @@ export function normalizeExpected(method, expected, workspace) {
   return sortKeys(replaceUris(result, path.resolve(workspace)));
 }
 
+// Upstream's snapshot is one provider's return value; the live pull-diagnostic
+// response aggregates every plugin the server hosts, and the wire spells "no
+// result" as `null` where a provider returns an empty list. Both are
+// representation, not behaviour, so the oracle calibration reads through them —
+// the ratchet comparison deliberately does not.
+export function calibrationView(expected, result) {
+  let value = result;
+  if (value && Array.isArray(value.items)) {
+    value = {
+      ...value,
+      items: value.items.filter(
+        (item) => item.source === "ts" || item.source === "js",
+      ),
+    };
+  }
+  if (value === null && Array.isArray(expected)) value = [];
+  return value;
+}
+
 export function equalJson(left, right) {
   return JSON.stringify(left) === JSON.stringify(right);
 }

--- a/scripts/compat-lsp/normalize.test.mjs
+++ b/scripts/compat-lsp/normalize.test.mjs
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import path from "node:path";
 import test from "node:test";
 import { pathToFileURL } from "node:url";
-import { normalizeResponse } from "./normalize.mjs";
+import { calibrationView, normalizeResponse } from "./normalize.mjs";
 
 test("workspace URIs and filesystem paths are machine-independent", () => {
   const workspace = path.resolve("/tmp/lsp workspace");
@@ -24,4 +24,28 @@ test("workspace URIs and filesystem paths are machine-independent", () => {
     ),
     uri: "<workspaceUri>/App.svelte",
   });
+});
+
+test("the calibration view keeps only the snapshot's own diagnostic population", () => {
+  const expected = { items: [{ code: 2322, source: "ts" }], kind: "full" };
+  const live = {
+    items: [
+      { code: 2322, source: "ts" },
+      { code: "unused-export-let", source: "svelte" },
+      { code: 7006, source: "js" },
+    ],
+    kind: "full",
+  };
+  assert.deepEqual(calibrationView(expected, live), {
+    items: [
+      { code: 2322, source: "ts" },
+      { code: 7006, source: "js" },
+    ],
+    kind: "full",
+  });
+});
+
+test("an absent live result reads as the provider's empty list", () => {
+  assert.deepEqual(calibrationView([], null), []);
+  assert.equal(calibrationView({ items: [] }, null), null);
 });

--- a/scripts/compat-lsp/suites.mjs
+++ b/scripts/compat-lsp/suites.mjs
@@ -259,7 +259,7 @@ function upstreamFeatureCases(root) {
             }
             return [request(spec.request, { textDocument: { uri } })];
           },
-          { method: spec.request, value: expected },
+          { method: spec.request, suite: spec.id, value: expected },
         ),
       );
     }

--- a/scripts/compat-lsp/verify.mjs
+++ b/scripts/compat-lsp/verify.mjs
@@ -4,7 +4,11 @@ import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { refuseUnrepresentativeBaseline } from "../compat-corpus/baseline-guard.mjs";
-import { normalizeExpected, normalizeResponse } from "./normalize.mjs";
+import {
+  calibrationView,
+  normalizeExpected,
+  normalizeResponse,
+} from "./normalize.mjs";
 import { LspProcess, parseCommand } from "./protocol.mjs";
 import {
   CORPUS_REPOS,
@@ -289,6 +293,15 @@ function keyFor(kind, entry, request) {
   return `${kind}:${entry.id}|${request.method}${position}`;
 }
 
+// Every other positive control here is satisfied by an official server that
+// answers *something*; a server started against the wrong workspace root or an
+// unresolved `node_modules` answers differently instead of failing, and those
+// answers would then be enrolled as legitimate ratchet entries defending the
+// degradation. Upstream's own snapshots are the only oracle-side assertion the
+// harness has, so the live official server is held to them.
+const ORACLE_REPRODUCTION_FLOOR = 0.7;
+const oracleCalibration = new Map();
+
 const current = [];
 const counts = {
   total: population.skipped.length,
@@ -327,6 +340,69 @@ function record(kind, entry, request, left, right, corpusObservations) {
       for (const difference of differences)
         current.push(`${keyFor(kind, entry, request)}|${difference}`);
     }
+  }
+}
+
+function calibrateOracle(entry, method, expected, officialResult) {
+  const suite = entry.expected.suite;
+  const bucket = oracleCalibration.get(suite) ?? {
+    total: 0,
+    reproduced: 0,
+    misses: [],
+  };
+  bucket.total++;
+  const differences = diffJson(
+    method,
+    expected,
+    calibrationView(expected, officialResult),
+  );
+  if (differences.length) {
+    // The diff labels a side "rsvelte"; neither side is rsvelte here, so only
+    // the pointers are kept.
+    bucket.misses.push({
+      id: entry.id,
+      pointers: differences.map((value) => value.slice(0, value.indexOf(":"))),
+    });
+  } else {
+    bucket.reproduced++;
+  }
+  oracleCalibration.set(suite, bucket);
+}
+
+function oracleCalibrationReport() {
+  const suites = [...oracleCalibration].sort(([left], [right]) =>
+    left.localeCompare(right),
+  );
+  const total = suites.reduce((sum, [, bucket]) => sum + bucket.total, 0);
+  const reproduced = suites.reduce(
+    (sum, [, bucket]) => sum + bucket.reproduced,
+    0,
+  );
+  return {
+    floor: ORACLE_REPRODUCTION_FLOOR,
+    total,
+    reproduced,
+    suites: Object.fromEntries(suites),
+  };
+}
+
+function assertOracleCalibration(calibration) {
+  if (!selectedSuites.includes("upstream-features")) return;
+  if (!calibration.total) {
+    throw new Error(
+      "upstream-features was selected but no expected snapshot was compared against the official server",
+    );
+  }
+  for (const [suite, bucket] of Object.entries(calibration.suites)) {
+    console.log(
+      `[lsp-verify] oracle calibration ${suite}: ${bucket.reproduced}/${bucket.total} upstream snapshots reproduced`,
+    );
+  }
+  const rate = calibration.reproduced / calibration.total;
+  if (rate < ORACLE_REPRODUCTION_FLOOR) {
+    throw new Error(
+      `the official server reproduced ${calibration.reproduced}/${calibration.total} (${(rate * 100).toFixed(1)}%) of upstream's own expected snapshots, below the ${(ORACLE_REPRODUCTION_FLOOR * 100).toFixed(0)}% floor; the oracle is not behaving as its own test suite says, so every divergence this run measured is against an unknown reference`,
+    );
   }
 }
 
@@ -432,6 +508,7 @@ async function compareRequest(entry, request, corpusObservations) {
       rsvelteResult,
       corpusObservations,
     );
+    calibrateOracle(entry, request.method, expected, officialResult);
   }
   progress();
 }
@@ -634,12 +711,14 @@ async function main() {
       throw new Error(`zero comparisons completed for ${method}`);
   }
 
+  const calibration = oracleCalibrationReport();
   fs.writeFileSync(
     REPORT,
     JSON.stringify(
       {
         generatedAt: new Date().toISOString(),
         suites: selectedSuites,
+        oracleCalibration: calibration,
         corpusRepos: selectedSuites.includes("corpus") ? selectedRepos : [],
         shard: SHARD,
         cases: cases.length,
@@ -657,6 +736,10 @@ async function main() {
   console.log(
     `[lsp-verify] ${cases.length} cases; ${counts.compared}/${counts.total} compared, ${counts.divergent} divergent requests / ${counts.divergentFields} divergent fields, ${counts.skipped} skipped`,
   );
+
+  // Before the artifact, not after: a run measured against a degraded oracle
+  // must leave nothing that `merge-current.mjs` could accept.
+  assertOracleCalibration(calibration);
 
   if (WRITE_CURRENT) {
     const artifact = createCurrentArtifact({


### PR DESCRIPTION
Closes #3010.

## What changed

`verify.mjs` already loaded upstream's `expectedv2.json`-family snapshots, but at the one call site where they are used they were compared against **rsvelte only** — `officialResult` was in scope on that line and unused. The live official server is now compared to the same snapshot.

- Per snapshot suite, the run counts how many of upstream's own expectations the live oracle reproduces.
- Below a **70%** floor the run throws. It is a run-level precondition, **not** a second ratchet: "is the oracle sane" has one answer per run.
- The assertion fires **before** `--write-current`, so a run measured against a degraded oracle leaves nothing `merge-current.mjs` could accept.
- The counts (and every miss's diff pointers) land in `compatibility/lsp-report.json`.

## The comparison, and why it is not the ratchet's comparison

The calibration reads through two representation differences that a live stdio server has and a provider-level unit test does not (`normalize.mjs: calibrationView`, unit-tested):

- the pull-diagnostic response aggregates **every** plugin the server hosts, while the snapshot is the TypeScript provider's return value alone, so only `ts`/`js`-sourced items are compared — this moves `typescript-diagnostics` from 51/92 to **71/92** and is what makes the floor worth having, because it is the subset a misconfigured TypeScript backend would crater;
- the wire spells "no result" as `null` where the provider returns `[]`.

The ratchet's rsvelte-vs-snapshot comparison is deliberately untouched, so **no ratchet key moves**.

## Measured, then the floor set under it

Local measurement on the pinned revision: **94/125 (75.2%)** — `typescript-diagnostics` 71/92, `typescript-folding-range` 13/15, `typescript-inlay-hints` 10/18. The shortfall is structural rather than a defect, and it is four distinct causes, enumerated per suite in gate-coverage **27h**:

- **diagnostics**: 21 residual message-text and item-membership differences from running every fixture in one server session, where upstream constructs one resolver per fixture directory.
- **folding-range**: both misses are one extra whole-`<script>` fold from the HTML folding provider, which upstream's provider test does not run — the same two misses, and the same explanation, that #1767 measured with a different capability set and a different normalizer.
- **inlay-hints**: four are the live server returning `null` where the provider returns hints; **four more are an artifact of the developer's checkout, not of the oracle** — `pathToFileURL` leaves `+` unencoded where the server's `vscode-uri` writes `%2B`, so a worktree path containing `+` defeats `replaceUris`. CI paths carry no `+`, and the differential comparison is immune because both servers encode alike; only snapshot-vs-live sees it. The CI number is therefore expected to be 98/125, and I will pin the row to CI's figure once this run reports it.

## What it still cannot see

Recorded in 27h rather than implied: the fixture and corpus populations have no upstream snapshot at all, so the oracle is calibrated on 125 of the gate's units and on none of the other ~14,000; and the floor cannot see a degradation that costs the oracle less than its 5-point margin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017LzPenwNb9zAGazC8JK2fH
