### PR TITLE
fix(esrap): print a removed $inspect hole as one `;;` statement

### DIFF
--- a/.changeset/inspect-hole-trailing-comment.md
+++ b/.changeset/inspect-hole-trailing-comment.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/compiler": patch
+---
+
+Print the `;;` a removed non-dev `$inspect(...)` leaves as one statement. Upstream keeps the `ExpressionStatement` and replaces its expression with `b.empty`, so esrap emits `;;` on one line and a comment trailing the call stays on it; rsvelte modelled the pair as two empty statements on separate lines, which put a blank line in front of the comment and, on the client, dropped the second `;` entirely.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2614,7 +2614,7 @@ dependencies = [
 
 [[package]]
 name = "rsvelte_esrap"
-version = "0.10.29"
+version = "0.10.30"
 dependencies = [
  "compact_str 0.10.0",
  "memchr",

--- a/crates/rsvelte_core/Cargo.toml
+++ b/crates/rsvelte_core/Cargo.toml
@@ -94,7 +94,7 @@ oxc_ast = { version = "0.144", features = ["serialize"] }
 oxc_span = "0.144"
 oxc_diagnostics = "0.144"
 oxc_codegen = "0.144"
-rsvelte_esrap = { version = "=0.10.29", path = "../rsvelte_esrap" }
+rsvelte_esrap = { version = "=0.10.30", path = "../rsvelte_esrap" }
 oxc_syntax = "0.144"
 oxc_semantic = "0.144"
 

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/rune_transforms.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/rune_transforms.rs
@@ -256,7 +256,9 @@ pub(super) fn transform_client_runes_with_skip_and_state<'a>(
                 } else {
                     let trailing_comment = after.strip_prefix(';').unwrap_or(after).trim_start();
                     let marker = if before.is_empty() && trailing_comment.starts_with("/*") {
-                        "/* $$inspect_removed$$ */"
+                        // The trailing `;` of the removed call is one of the
+                        // `;;` upstream prints for the empty-as-expression.
+                        "/* $$inspect_removed$$ */;"
                     } else {
                         ""
                     };

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/tests.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/tests.rs
@@ -197,8 +197,8 @@ fn block_comment_after_final_inspect_precedes_generated_element_variable() {
     .unwrap();
 
     assert!(
-        result.js.code.contains("/* c */\n\tvar p = root();"),
-        "the orphaned comment must flush before the generated declaration:\n{}",
+        result.js.code.contains(";; /* c */\n\n\tvar p = root();"),
+        "the comment must trail the `;;` hole, ahead of the generated declaration:\n{}",
         result.js.code
     );
     assert!(

--- a/crates/rsvelte_core/tests/inspect_hole_trailing_comment.rs
+++ b/crates/rsvelte_core/tests/inspect_hole_trailing_comment.rs
@@ -1,0 +1,41 @@
+//! A non-dev `$inspect(...)` is removed but its `ExpressionStatement` survives
+//! upstream with `b.empty` as its expression, so esrap prints `;;` on one line
+//! and a comment trailing the call stays on that line. Modelling the pair as two
+//! separate empty statements put a blank line before the comment.
+
+use rsvelte_core::{CompileOptions, GenerateMode, compile, compiler::CssMode};
+
+const SOURCE: &str = "<script>\n\
+     \tlet a = 1;\n\
+     \t$inspect(a); /* c */\n\
+     \tconsole.log(2);\n\
+     </script>\n\
+     \n\
+     <p>{a}</p>\n";
+
+fn compile_to(generate: GenerateMode) -> String {
+    compile(
+        SOURCE,
+        CompileOptions {
+            filename: Some("T.svelte".to_string()),
+            generate,
+            dev: false,
+            css: CssMode::External,
+            ..Default::default()
+        },
+    )
+    .expect("compiles")
+    .js
+    .code
+}
+
+#[test]
+fn the_removed_inspect_keeps_its_trailing_comment_on_one_line() {
+    for generate in [GenerateMode::Client, GenerateMode::Server] {
+        let out = compile_to(generate);
+        assert!(
+            out.contains(";; /* c */\n"),
+            "{generate:?} split the `;;` hole from its trailing comment:\n{out}"
+        );
+    }
+}

--- a/crates/rsvelte_esrap/Cargo.toml
+++ b/crates/rsvelte_esrap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rsvelte_esrap"
-version = "0.10.29"
+version = "0.10.30"
 edition = "2024"
 rust-version = "1.95"
 description = "A Rust port of esrap — prints an oxc AST to JavaScript with esrap's exact layout"

--- a/crates/rsvelte_esrap/src/printer.rs
+++ b/crates/rsvelte_esrap/src/printer.rs
@@ -1573,11 +1573,14 @@ impl<'opt, const HAS_COMMENTS: bool, const DIRECT: bool> Printer<'opt, HAS_COMME
             let layout_mark = ctx.event_mark();
             let mut has_margin = false;
             if let Some((prev_elem, prev_multiline)) = &prev {
-                has_margin = *prev_multiline || !elem.same_kind(prev_elem);
+                let joined = prev_elem.is_kept_empty() && elem.is_kept_empty();
+                has_margin = !joined && (*prev_multiline || !elem.same_kind(prev_elem));
                 if has_margin {
                     ctx.margin();
                 }
-                ctx.newline();
+                if !joined {
+                    ctx.newline();
+                }
             }
 
             let scope = ctx.begin_scope();
@@ -1588,8 +1591,8 @@ impl<'opt, const HAS_COMMENTS: bool, const DIRECT: bool> Printer<'opt, HAS_COMME
                 ctx.insert_event(layout_mark, EventKind::Margin);
             }
 
-            let end = elem.span_end();
-            let next = elems.peek().map(BodyElem::span_end);
+            let end = elem.comment_end();
+            let next = elems.peek().map(BodyElem::comment_end);
             comments.flush_trailing(ctx, end, next);
             last_end = Some(end);
             prev = Some((elem, multiline));
@@ -1674,12 +1677,15 @@ impl<'opt, const HAS_COMMENTS: bool, const DIRECT: bool> Printer<'opt, HAS_COMME
             let layout_mark = ctx.event_mark();
             let mut has_margin = false;
             if let Some((prev_statement, prev_multiline)) = prev {
-                has_margin = prev_multiline
-                    || std::mem::discriminant(prev_statement) != std::mem::discriminant(statement);
+                let joined = is_kept_empty_stmt(prev_statement) && is_kept_empty_stmt(statement);
+                has_margin =
+                    !joined && (prev_multiline || !same_statement_kind(prev_statement, statement));
                 if has_margin {
                     ctx.margin();
                 }
-                ctx.newline();
+                if !joined {
+                    ctx.newline();
+                }
             }
 
             let scope = ctx.begin_scope();
@@ -1690,8 +1696,10 @@ impl<'opt, const HAS_COMMENTS: bool, const DIRECT: bool> Printer<'opt, HAS_COMME
                 ctx.insert_event(layout_mark, EventKind::Margin);
             }
 
-            let end = statement.span().end;
-            let next = statements.peek().map(|statement| statement.span().end);
+            let end = statement_comment_end(statement);
+            let next = statements
+                .peek()
+                .map(|statement| statement_comment_end(statement));
             self.flush_trailing_comments(ctx, end, next);
             last_end = Some(end);
             prev = Some((statement, multiline));
@@ -1731,11 +1739,16 @@ impl<'opt, const HAS_COMMENTS: bool, const DIRECT: bool> Printer<'opt, HAS_COMME
             let layout_mark = ctx.event_mark();
             let mut has_margin = false;
             if let Some((prev_elem, prev_multiline)) = &prev {
-                has_margin = *prev_multiline || !elem.same_kind(prev_elem);
+                // The two kept empties of one `;;` hole are a single upstream
+                // statement, so nothing separates them.
+                let joined = prev_elem.is_kept_empty() && elem.is_kept_empty();
+                has_margin = !joined && (*prev_multiline || !elem.same_kind(prev_elem));
                 if has_margin {
                     ctx.margin();
                 }
-                ctx.newline();
+                if !joined {
+                    ctx.newline();
+                }
             }
 
             let scope = ctx.begin_scope();
@@ -1759,8 +1772,8 @@ impl<'opt, const HAS_COMMENTS: bool, const DIRECT: bool> Printer<'opt, HAS_COMME
                 ctx.insert_event(layout_mark, EventKind::Margin);
             }
 
-            let end = elem.span_end();
-            let next = elems.peek().map(BodyElem::span_end);
+            let end = elem.comment_end();
+            let next = elems.peek().map(BodyElem::comment_end);
             self.flush_trailing_comments(ctx, end, next);
 
             last_end = Some(end);
@@ -5178,6 +5191,26 @@ impl<'a> BodyElem<'a, '_> {
         }
     }
 
+    /// A surviving `EmptyStatement` is half of the `;;` upstream prints for a
+    /// removed `$inspect(...)`: one `ExpressionStatement` whose expression is
+    /// `b.empty`. The pair must print on one line and group with an
+    /// `ExpressionStatement` for esrap's margin rule.
+    fn is_kept_empty(&self) -> bool {
+        matches!(self, BodyElem::Statement(Statement::EmptyStatement(_)))
+    }
+
+    /// A sentinel empty has no real end, but its start is the removed
+    /// statement's own start — the anchor a comment trailing it on that line
+    /// needs.
+    fn comment_end(&self) -> u32 {
+        match self {
+            BodyElem::Statement(Statement::EmptyStatement(s)) if s.span.end == u32::MAX => {
+                s.span.start
+            }
+            _ => self.span_end(),
+        }
+    }
+
     fn span_end(&self) -> u32 {
         match self {
             BodyElem::Directive(d) => d.span.end,
@@ -5200,9 +5233,7 @@ impl<'a> BodyElem<'a, '_> {
     fn same_kind(&self, other: &BodyElem<'a, '_>) -> bool {
         match (self, other) {
             (BodyElem::Directive(_), BodyElem::Directive(_)) => true,
-            (BodyElem::Statement(a), BodyElem::Statement(b)) => {
-                std::mem::discriminant(*a) == std::mem::discriminant(*b)
-            }
+            (BodyElem::Statement(a), BodyElem::Statement(b)) => same_statement_kind(a, b),
             (BodyElem::ClassMember(a), BodyElem::ClassMember(b)) => {
                 std::mem::discriminant(*a) == std::mem::discriminant(*b)
             }
@@ -5221,6 +5252,35 @@ impl<'a> BodyElem<'a, '_> {
             BodyElem::ClassMember(e) => printer.class_element(e, ctx),
         }
     }
+}
+
+/// A surviving `EmptyStatement` is half of one `;;` hole (see
+/// [`BodyElem::is_kept_empty`]).
+const fn is_kept_empty_stmt(stmt: &Statement) -> bool {
+    matches!(stmt, Statement::EmptyStatement(_))
+}
+
+/// A sentinel empty's end is `u32::MAX`; its start is the anchor a trailing
+/// comment needs (see [`BodyElem::comment_end`]).
+fn statement_comment_end(stmt: &Statement) -> u32 {
+    match stmt {
+        Statement::EmptyStatement(s) if s.span.end == u32::MAX => s.span.start,
+        _ => stmt.span().end,
+    }
+}
+
+/// esrap's `child.type === prev_type` margin rule. A kept `EmptyStatement` is
+/// half of the `;;` upstream emits as an `ExpressionStatement`, so it groups
+/// with one.
+fn same_statement_kind(a: &Statement, b: &Statement) -> bool {
+    const fn expression_like(s: &Statement) -> bool {
+        matches!(
+            s,
+            Statement::EmptyStatement(_) | Statement::ExpressionStatement(_)
+        )
+    }
+    (expression_like(a) && expression_like(b))
+        || std::mem::discriminant(a) == std::mem::discriminant(b)
 }
 
 const fn expression_kind(expr: &Expression) -> &'static str {

--- a/crates/rsvelte_lint_types/Cargo.lock
+++ b/crates/rsvelte_lint_types/Cargo.lock
@@ -1111,7 +1111,7 @@ dependencies = [
 
 [[package]]
 name = "rsvelte_esrap"
-version = "0.10.29"
+version = "0.10.30"
 dependencies = [
  "compact_str",
  "memchr",


### PR DESCRIPTION
`main` is red on `Shape matrix parity (generated inputs)` with 10 `removed-statement-comment/inspect__trailing-*__instance-top__*` divergences.

## It is not a regression from a recent merge

The same 10 reproduce on **f67ce0b6a itself** — the exact commit whose own `main` run was green five hours earlier (run 32132704854 → `comment-mismatch 304`; re-dispatched run 32172970753 on the same tree → `comment-mismatch 314`). Both jobs restored the same caches, installed `oxfmt 0.63.0`, compiled the same five crates and generated the same `cases: 6035`. Reverting either of the two compiler fixes merged after it (#3022's `:global`-block keyframes, #3024's constructor member-chain wrap) leaves all 10 in place, on CI and locally with a rebuilt binding. The defect predates all of them; the earlier green run is the outlier.

## The defect

A non-dev `$inspect(...)` is removed, but upstream keeps the `ExpressionStatement` and replaces its *expression* with `b.empty`, so esrap prints one statement whose text is `;;` — and a comment trailing the call stays on that line:

```js
let a = 1;

;; /* c */
console.log(2);
```

rsvelte modelled the same `;;` as **two** empty statements. `body` puts each on its own line, and since the following `console.log(2)` is a different statement kind it also earns a margin, so the comment is pushed onto its own line behind a blank one:

```js
let a = 1;

;
;

/* c */
console.log(2);
```

oxfmt drops the empty statements on both sides, but it cannot take the blank line back — which is why only output equality sees this and the parse oracle cannot.

On the client the second `;` was dropped outright: the trailing-comment branch of the text-level `$inspect` removal emitted only the marker, so the chunk parsed as a single empty statement.

## The fix

- consecutive kept empty statements print adjacent, as the one upstream statement they represent;
- a kept empty groups with `ExpressionStatement` for esrap's `child.type === prev_type` margin rule, so nothing following it gains a blank line;
- a sentinel empty (`span.end == u32::MAX`) has no real end, so its **start** anchors the trailing-comment flush — the removed call's own line;
- the client removal emits the second `;`.

## Verification

Full `pnpm run corpus:matrix`: `match 20952`, `comment-mismatch 304`, `js-mismatch 60` — identical to the last green run, with no stale ratchet entry. `crates/rsvelte_core/tests/inspect_hole_trailing_comment.rs` pins the shape on both targets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017zzjgXQhzjAGPuMqF6SmKY
