### PR TITLE
test(corpus): assert the client transform is idempotent

### DIFF
--- a/.github/workflows/corpus-compat.yml
+++ b/.github/workflows/corpus-compat.yml
@@ -258,6 +258,15 @@ jobs:
       - name: Collect corpus
         run: node scripts/compat-corpus/collect.mjs
 
+      # Asserts a PROPERTY of the transform rather than comparing its output, so
+      # it sees the #3026 class on inputs whose output is byte-perfect: on the
+      # tree that introduced it, 7,888 of 27,548 corpus units violated it while
+      # the output gate scored 0 divergences. Hard gate, no ratchet.
+      - name: Transform idempotency (client identifier transforms)
+        env:
+          RSVELTE_ASSERT_TRANSFORM_IDEMPOTENT: '1'
+        run: node scripts/compat-corpus/idempotency-verify.mjs
+
       - name: Compile corpus (official svelte + rsvelte, CSR + SSR + CSR dev)
         run: node scripts/compat-corpus/compile.mjs
 

--- a/.github/workflows/corpus-compat.yml
+++ b/.github/workflows/corpus-compat.yml
@@ -259,9 +259,9 @@ jobs:
         run: node scripts/compat-corpus/collect.mjs
 
       # Asserts a PROPERTY of the transform rather than comparing its output, so
-      # it sees the #3026 class on inputs whose output is byte-perfect: on the
-      # tree that introduced it, 7,888 of 27,548 corpus units violated it while
-      # the output gate scored 0 divergences. Hard gate, no ratchet.
+      # it sees the #3026 class on inputs whose output is byte-perfect: un-seal
+      # `b::getter_call` and 7,888 of 27,566 corpus units violate it while the
+      # output gate still scores 0 divergences. Hard gate, no ratchet.
       - name: Transform idempotency (client identifier transforms)
         env:
           RSVELTE_ASSERT_TRANSFORM_IDEMPOTENT: '1'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -410,6 +410,30 @@ Normalization is deliberately identical to `verify.mjs`, so a divergence this ga
 the corpus gate would also report. `--update-baseline` refuses to run under `--no-fmt` or a
 `--families` subset (both would FALSE-SHRINK the ratchet).
 
+### Transform idempotency (`scripts/compat-corpus/idempotency-verify.mjs`)
+
+**The one gate here that compares rsvelte to nothing.** With
+`RSVELTE_ASSERT_TRANSFORM_IDEMPOTENT` set, every top-level
+`apply_transforms_to_expression` re-applies itself to its own output and reports when the two
+differ; any report fails the run. It exists because #3026 is a *property* violation that output
+equality cannot sample: `try_transform_assignment` hands a converted subtree back to the outer
+walk, so a read whose output is itself re-readable is applied twice — and the input shape that
+exposes it occurs **0 times in 12,523 collected components**, with the bad output parsing
+cleanly. Measured over the same 27,548 units, the merge base carried **37,346** violations in
+**7,888** of them (28.6%) while scoring 0 output divergences; #3026's fix removed 9,274 of the
+builders' worth, and routing the remaining five read builders through `b::getter_call` took it
+to 0 with all 37,569 output hashes byte-identical.
+
+The generalisable part is not the invariant, it is what kind of gate it is. Every other gate
+here samples inputs and compares outputs, so its reach is the product of the population someone
+collected and the axes someone wrote — and #2535 already showed that a generated family is blind
+to the axis value its author did not think of. A gate that asserts a property of the *compiler*
+is bounded by neither. When a defect class is "the second application of a correct step",
+"a value read twice", "a cache that disagrees with a recompute", ask what invariant states it
+directly before adding another family: the corpus you already have becomes the detector, at
+whatever size it happens to be. What it costs you is that idempotent is not correct — read it as
+a necessary condition, never as parity.
+
 ### Corpus-seeded mutation fuzz (`scripts/compat-corpus/mutate-corpus.mjs`)
 
 The generalization of the matrix (`pnpm run corpus:mutate`, #2281 Gate 3): the 14,138 corpus

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -418,11 +418,12 @@ the corpus gate would also report. `--update-baseline` refuses to run under `--n
 differ; any report fails the run. It exists because #3026 is a *property* violation that output
 equality cannot sample: `try_transform_assignment` hands a converted subtree back to the outer
 walk, so a read whose output is itself re-readable is applied twice — and the input shape that
-exposes it occurs **0 times in 12,523 collected components**, with the bad output parsing
-cleanly. Measured over the same 27,548 units, the merge base carried **37,346** violations in
-**7,888** of them (28.6%) while scoring 0 output divergences; #3026's fix removed 9,274 of the
-builders' worth, and routing the remaining five read builders through `b::getter_call` took it
-to 0 with all 37,569 output hashes byte-identical.
+exposes it occurred **0 times in the 12,523 components the corpus held when it was reported**,
+with the bad output parsing cleanly. Remove the one line that seals `b::getter_call` and the
+same corpus reports **37,352** violations in **7,888** of 27,566 units (28.6%) — while still
+compiling to 0 output divergences. Sealing all seven read builders takes it to 0 with every one
+of the 37,596 output hashes byte-identical; #3026's own two accounted for three quarters of the
+total, and the five it never reached for the remaining 9,274.
 
 The generalisable part is not the invariant, it is what kind of gate it is. Every other gate
 here samples inputs and compares outputs, so its reach is the product of the population someone

--- a/compatibility/gate-coverage.md
+++ b/compatibility/gate-coverage.md
@@ -2290,6 +2290,80 @@ else in the repo runs it.
 
 ---
 
+## 28. Transform idempotency — `scripts/compat-corpus/idempotency-verify.mjs`
+
+**Unit.** One `(corpus component, client mode)` compile, 13,774 x 2 = 27,548 of them. Nothing is
+compared against official. The gate asserts a **property of rsvelte's own transform**: with
+`RSVELTE_ASSERT_TRANSFORM_IDEMPOTENT` set, every top-level `apply_transforms_to_expression`
+re-applies itself to its own output and prints a marker when the two prints differ. Any marker
+fails the run. Hard gate, no ratchet.
+
+**Why it exists.** `try_transform_assignment` converts both sides of a member mutation and hands
+the result back to the outer walk, so a read transform whose output the walk can transform again
+is applied twice — #3026, where `state.a = state.b` in an inline template arrow emitted
+`state().a = state()().b`. Output equality could not find it: the shape occurs **0 times in
+12,523 corpus components**, and the bad output parses, so the corpus gate and the parse oracle
+were both green. The generated `write-host` family (§5q) does find it, but a generated family is
+bounded by the axis values its author wrote; this gate is bounded by nothing the author chose,
+because it asks the corpus a question about the compiler rather than about the input.
+
+**[D]** The measurement that justifies it, three trees, same 27,548 units:
+
+| tree | non-idempotent transforms | units carrying one |
+|---|---|---|
+| merge base (`955b2ac0`) | 37,346 | 7,888 (28.6%) |
+| after #3026's fix (2 of 7 read builders) | 9,274 | 2,530 |
+| after routing all 7 through `b::getter_call` | 0 | 0 |
+
+Every one of those trees scores **0 output divergences** on the collected corpus. The corpus
+carried the ingredients of #3026 in more than a quarter of its units the whole time; only the
+re-walk path made one of them observable. Routing the remaining five builders through
+`b::getter_call` left all 37,569 `(file, target)` output hashes byte-identical, so the change is
+the property, not the output.
+
+**Positive control.** Built against the merge base, the check fires on #3026's own repro
+(`state().b` -> `state()().b`) and is silent with the variable unset; the script exits 2 rather
+than passing when the variable is unset, because a run that cannot emit a marker is not a gate.
+
+### 28a — the server transform is not in the population [S]
+
+`generate: 'server'` registers no identifier transforms, so the entry point never runs there. A
+server-side double-application would be invisible to this gate. Both client modes are swept
+because dev reaches codegen paths prod does not.
+
+### 28b — only the top-level entry is checked, not `…_with_shadowed` [S]
+
+The check sits in `apply_transforms_to_expression`. `apply_transforms_to_expression_with_shadowed`
+is public and called directly (`each_block.rs`, `types.rs`), and those calls are unchecked — a
+non-idempotent transform reachable only through a shadowed-scope walk would not be seen. Nesting
+is suppressed by a thread-local so the check does not go quadratic, which means the outermost
+call is the only one that reports.
+
+### 28c — the comparison is a print from the fallback text printer [S]
+
+`generate_expr` renders `Raw` and the nodes it does not support opaquely or truncated, so a
+divergence inside one of those is erased before the comparison. Truncated prints are *skipped*
+rather than reported (an unbalanced bracket count is the tell): measured on the first sweep, 12
+of 1,153 unique divergent pairs were printer truncations and the other 1,141 were the real
+class. The direction of this limit is one-sided — the printer can hide a divergence, never
+invent one.
+
+### 28d — idempotent is not correct [S]
+
+A transform that produces the wrong expression *consistently* satisfies this gate. It answers
+"can a second pass change this", nothing else; what the first pass should have produced is the
+output gates' question. Read it as a necessary condition that no amount of corpus growth would
+otherwise supply, not as a correctness proof.
+
+### 28e — it runs in one job, on a corpus that must already be collected [S]
+
+Wired into `corpus-compat.yml`'s `Compiler parity` job, after `collect.mjs` and before
+`compile.mjs`. It refuses below 1,000 manifest components and refuses if the worker reports
+fewer units than that, so a wiped `sources/` tree fails instead of passing vacuously — the
+`vacuous green` class at the top of this file.
+
+---
+
 ## Cross-cutting
 
 ### C0. A ratchet key is a lossy encoding, and it loses in two directions

--- a/compatibility/gate-coverage.md
+++ b/compatibility/gate-coverage.md
@@ -2292,7 +2292,7 @@ else in the repo runs it.
 
 ## 28. Transform idempotency — `scripts/compat-corpus/idempotency-verify.mjs`
 
-**Unit.** One `(corpus component, client mode)` compile, 13,774 x 2 = 27,548 of them. Nothing is
+**Unit.** One `(corpus component, client mode)` compile, 13,783 x 2 = 27,566 of them. Nothing is
 compared against official. The gate asserts a **property of rsvelte's own transform**: with
 `RSVELTE_ASSERT_TRANSFORM_IDEMPOTENT` set, every top-level `apply_transforms_to_expression`
 re-applies itself to its own output and prints a marker when the two prints differ. Any marker
@@ -2301,29 +2301,38 @@ fails the run. Hard gate, no ratchet.
 **Why it exists.** `try_transform_assignment` converts both sides of a member mutation and hands
 the result back to the outer walk, so a read transform whose output the walk can transform again
 is applied twice — #3026, where `state.a = state.b` in an inline template arrow emitted
-`state().a = state()().b`. Output equality could not find it: the shape occurs **0 times in
-12,523 corpus components**, and the bad output parses, so the corpus gate and the parse oracle
-were both green. The generated `write-host` family (§5q) does find it, but a generated family is
+`state().a = state()().b`. Output equality could not find it: the shape occurs **0 times in the
+12,523 corpus components measured when #3026 was reported**, and the bad output parses, so the
+corpus gate and the parse oracle were both green. The generated `write-host` family (§5q) does find it, but a generated family is
 bounded by the axis values its author wrote; this gate is bounded by nothing the author chose,
 because it asks the corpus a question about the compiler rather than about the input.
 
-**[D]** The measurement that justifies it, three trees, same 27,548 units:
+**[D] and positive control, one measurement.** This tree, and the same tree with the one line in
+`b::getter_call` that marks the produced callee opaque removed — which un-seals all seven read
+builders and is the state every one of them was in before #3026:
 
 | tree | non-idempotent transforms | units carrying one |
 |---|---|---|
-| merge base (`955b2ac0`) | 37,346 | 7,888 (28.6%) |
-| after #3026's fix (2 of 7 read builders) | 9,274 | 2,530 |
-| after routing all 7 through `b::getter_call` | 0 | 0 |
+| this tree, `b::getter_call` un-sealed | 37,352 | 7,888 of 27,566 (28.6%) |
+| this tree | 0 | 0 |
 
-Every one of those trees scores **0 output divergences** on the collected corpus. The corpus
-carried the ingredients of #3026 in more than a quarter of its units the whole time; only the
-re-walk path made one of them observable. Routing the remaining five builders through
-`b::getter_call` left all 37,569 `(file, target)` output hashes byte-identical, so the change is
-the property, not the output.
+Both compile the corpus to **0 output divergences**, and sealing the five builders #3026 did not
+reach left all 37,596 `(file, target)` output hashes byte-identical — so this is a property
+change, not an output change. The corpus carried the ingredients of #3026 in more than a quarter
+of its units the whole time; only the re-walk path made one of them observable.
 
-**Positive control.** Built against the merge base, the check fires on #3026's own repro
-(`state().b` -> `state()().b`) and is silent with the variable unset; the script exits 2 rather
-than passing when the variable is unset, because a run that cannot emit a marker is not a gate.
+Two earlier measurements, on the pre-#3053 tree and its 27,548-unit corpus, split that total by
+builder: the merge base scored 37,346, and the tree with #3026's own two builders sealed still
+scored **9,274 across 2,530 units** — the five the report never reached. Built against that
+merge base, the check also fires on #3026's own repro (`state().b` -> `state()().b`).
+
+**[D] The gate's own vacuous green, found by running it against a binding that lacks it.**
+Pointed at a `main` binding — a tree with five of the seven read builders still unsealed — the
+first version reported `0 violations`, because a compiler with no check compiled in prints
+nothing and silence was read as success. The compiler now announces
+`RSVELTE_IDEMPOTENCY_ARMED` from **inside** the comparison and the script exits 2 without it,
+so "the binding predates the check", "the variable was never read" and "the entry point was
+never reached" all fail instead of passing. What remains is 28f.
 
 ### 28a — the server transform is not in the population [S]
 
@@ -2361,6 +2370,15 @@ Wired into `corpus-compat.yml`'s `Compiler parity` job, after `collect.mjs` and 
 `compile.mjs`. It refuses below 1,000 manifest components and refuses if the worker reports
 fewer units than that, so a wiped `sources/` tree fails instead of passing vacuously — the
 `vacuous green` class at the top of this file.
+
+### 28f — the armed marker proves the check ran, not that it still compares [S]
+
+A comparison that regressed to always-equal would emit the armed line and no violations, and
+this script cannot tell that from a clean tree. The reporting rule — including the
+truncated-print skip — is therefore factored into `idempotency_report` and pinned by a unit
+test (`idempotency_report_tests`), which is where that failure mode is caught. The remaining
+uncovered case is a break in the *re-application* itself (a second pass that silently becomes a
+no-op for the wrong reason); nothing here would see it.
 
 ---
 

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/each_block.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/each_block.rs
@@ -1218,7 +1218,7 @@ fn build_declarations(
                             path.name.clone(),
                             IdentifierTransform {
                                 read_source: None,
-                                read: Some(|arena, node| b::call(arena, node, vec![])),
+                                read: Some(b::getter_call),
                                 assign: None,
                                 mutate: None,
                                 update: None,

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/program.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/program.rs
@@ -305,7 +305,7 @@ fn store_sub_read(
     arena: &crate::compiler::phases::phase3_transform::js_ast::arena::JsArena,
     node: JsExpr,
 ) -> JsExpr {
-    b::call(arena, node, vec![])
+    b::getter_call(arena, node)
 }
 
 /// Transform a store subscription assignment.
@@ -515,7 +515,7 @@ fn prop_read(
     arena: &crate::compiler::phases::phase3_transform::js_ast::arena::JsArena,
     node: JsExpr,
 ) -> JsExpr {
-    b::call(arena, node, vec![])
+    b::getter_call(arena, node)
 }
 
 /// Transform a prop assignment.
@@ -643,7 +643,7 @@ fn reactive_import_read(
     arena: &crate::compiler::phases::phase3_transform::js_ast::arena::JsArena,
     node: JsExpr,
 ) -> JsExpr {
-    b::call(arena, node, vec![])
+    b::getter_call(arena, node)
 }
 
 /// Transform a reactive import mutation.

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/declarations.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/declarations.rs
@@ -226,20 +226,7 @@ pub fn add_state_transformers(context: &mut ComponentContext) {
 /// This transforms `x` into `x()` by calling it as a function.
 /// In the generated code, `$.prop()` returns a getter function.
 fn prop_source_read(arena: &JsArena, node: JsExpr) -> JsExpr {
-    getter_call(arena, node)
-}
-
-/// Build the getter call a read transform produces (`x` -> `x()`).
-///
-/// A source-level `x()` and a transform-produced `x()` are the same shape, so the
-/// callee is marked opaque: without it a second `apply_transforms_to_expression`
-/// pass over an already-transformed subtree reads the prop twice (`x()()`).
-fn getter_call(arena: &JsArena, node: JsExpr) -> JsExpr {
-    let callee = match node {
-        JsExpr::Identifier(ref name) => JsExpr::OpaqueIdentifier(name.clone()),
-        _ => node,
-    };
-    b::call(arena, callee, vec![])
+    b::getter_call(arena, node)
 }
 
 /// Transform a prop source assignment.
@@ -309,7 +296,7 @@ fn prop_update(arena: &JsArena, operator: JsUpdateOp, argument: JsExpr, prefix: 
 ///
 /// A call expression: `$store()`
 fn store_sub_read(arena: &JsArena, node: JsExpr) -> JsExpr {
-    getter_call(arena, node)
+    b::getter_call(arena, node)
 }
 
 /// Transform a store subscription assignment.

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/utils.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/utils.rs
@@ -415,6 +415,17 @@ thread_local! {
     static IN_IDEMPOTENCY_CHECK: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
 }
 
+/// Marker the harness requires before it may report a clean run.
+///
+/// A binary with no check compiled in emits nothing, which is indistinguishable from a
+/// tree that satisfies the property — a `main` binding measured 0 violations for exactly
+/// that reason. Printed once per process from inside the comparison, so it also proves
+/// the comparison was reached, not just that the variable was read.
+fn announce_idempotency_check_armed() {
+    static ANNOUNCED: std::sync::Once = std::sync::Once::new();
+    ANNOUNCED.call_once(|| eprintln!("RSVELTE_IDEMPOTENCY_ARMED"));
+}
+
 /// Does every bracket in `s` close?
 fn is_balanced(s: &str) -> bool {
     let mut depth = 0i32;
@@ -449,17 +460,44 @@ fn assert_transform_is_idempotent(transformed: &JsExpr, context: &ComponentConte
     IN_IDEMPOTENCY_CHECK.with(|c| c.set(false));
 
     use crate::compiler::phases::phase3_transform::js_ast::codegen::generate_expr;
+    announce_idempotency_check_armed();
     let once = generate_expr(transformed, &context.arena);
     let twice = generate_expr(&again, &context.arena);
-    // The fallback text printer truncates the nodes it cannot render, and a truncated
-    // print differs from its twin for a reason that is not the transform.
-    if !is_balanced(&once) || !is_balanced(&twice) {
-        return;
-    }
-    if once != twice {
+    if let Some(line) = idempotency_report(&once, &twice) {
         // A panic would abort the process (`panic = "abort"` in release), which turns a
         // sweep into a bisect; the harness greps for this marker instead.
-        eprintln!("RSVELTE_NON_IDEMPOTENT_TRANSFORM\t{once}\t{twice}");
+        eprintln!("{line}");
+    }
+}
+
+/// The marker line for a pair of prints, or `None` when they agree.
+///
+/// Split out so the reporting rule — including the truncated-print skip — is reachable
+/// from a test; a comparison that silently stopped reporting would otherwise read as a
+/// clean sweep.
+fn idempotency_report(once: &str, twice: &str) -> Option<String> {
+    // The fallback text printer truncates the nodes it cannot render, and a truncated
+    // print differs from its twin for a reason that is not the transform.
+    if once == twice || !is_balanced(once) || !is_balanced(twice) {
+        return None;
+    }
+    Some(format!("RSVELTE_NON_IDEMPOTENT_TRANSFORM\t{once}\t{twice}"))
+}
+
+#[cfg(test)]
+mod idempotency_report_tests {
+    use super::idempotency_report;
+
+    #[test]
+    fn reports_a_doubled_getter_and_skips_a_truncated_print() {
+        assert_eq!(
+            idempotency_report("p().a", "p()().a").as_deref(),
+            Some("RSVELTE_NON_IDEMPOTENT_TRANSFORM\tp().a\tp()().a")
+        );
+        assert_eq!(idempotency_report("p().a", "p().a"), None);
+        // Either side truncated by the printer: not a transform difference.
+        assert_eq!(idempotency_report("() => {", ""), None);
+        assert_eq!(idempotency_report("{ a: p() }", "{"), None);
     }
 }
 

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/utils.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/utils.rs
@@ -397,7 +397,70 @@ pub fn apply_transforms_to_expression(expr: &JsExpr, context: &ComponentContext)
     {
         return expr.clone();
     }
-    apply_transforms_to_expression_with_shadowed(expr, context, &LocalScope::new())
+    let transformed =
+        apply_transforms_to_expression_with_shadowed(expr, context, &LocalScope::new());
+    if idempotency_check_enabled() {
+        assert_transform_is_idempotent(&transformed, context);
+    }
+    transformed
+}
+
+/// Is `RSVELTE_ASSERT_TRANSFORM_IDEMPOTENT` set?
+fn idempotency_check_enabled() -> bool {
+    static ON: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ON.get_or_init(|| std::env::var_os("RSVELTE_ASSERT_TRANSFORM_IDEMPOTENT").is_some())
+}
+
+thread_local! {
+    static IN_IDEMPOTENCY_CHECK: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+}
+
+/// Does every bracket in `s` close?
+fn is_balanced(s: &str) -> bool {
+    let mut depth = 0i32;
+    for b in s.bytes() {
+        match b {
+            b'(' | b'[' | b'{' => depth += 1,
+            b')' | b']' | b'}' => depth -= 1,
+            _ => {}
+        }
+        if depth < 0 {
+            return false;
+        }
+    }
+    depth == 0
+}
+
+/// Report when transforming an already-transformed expression changes it.
+///
+/// A transform whose output the next pass can transform again is #3026's defect class:
+/// `try_transform_assignment` hands a converted subtree back to the outer walk, so any
+/// read whose output is re-readable is applied twice. Shape cannot carry provenance, so
+/// the property has to be asserted rather than inspected. Off unless the env var is set —
+/// it doubles the walk and prints through the fallback text printer, which renders
+/// `Raw` nodes opaquely and so can only miss a divergence, never invent one.
+fn assert_transform_is_idempotent(transformed: &JsExpr, context: &ComponentContext) {
+    if IN_IDEMPOTENCY_CHECK.with(|c| c.get()) {
+        return;
+    }
+    IN_IDEMPOTENCY_CHECK.with(|c| c.set(true));
+    let again =
+        apply_transforms_to_expression_with_shadowed(transformed, context, &LocalScope::new());
+    IN_IDEMPOTENCY_CHECK.with(|c| c.set(false));
+
+    use crate::compiler::phases::phase3_transform::js_ast::codegen::generate_expr;
+    let once = generate_expr(transformed, &context.arena);
+    let twice = generate_expr(&again, &context.arena);
+    // The fallback text printer truncates the nodes it cannot render, and a truncated
+    // print differs from its twin for a reason that is not the transform.
+    if !is_balanced(&once) || !is_balanced(&twice) {
+        return;
+    }
+    if once != twice {
+        // A panic would abort the process (`panic = "abort"` in release), which turns a
+        // sweep into a bisect; the harness greps for this marker instead.
+        eprintln!("RSVELTE_NON_IDEMPOTENT_TRANSFORM\t{once}\t{twice}");
+    }
 }
 
 /// Apply transforms while treating specified variables as shadowed (preventing transformation).

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/snippet_block.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/snippet_block.rs
@@ -858,7 +858,7 @@ fn is_simple_expression_json(value: &serde_json::Value) -> bool {
 fn create_call_transform()
 -> crate::compiler::phases::phase3_transform::client::types::IdentifierTransform {
     crate::compiler::phases::phase3_transform::client::types::IdentifierTransform {
-        read: Some(|arena, expr| b::call(arena, expr, vec![])),
+        read: Some(b::getter_call),
         read_source: None,
         assign: None,
         mutate: None,

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/js_ast/builders.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/js_ast/builders.rs
@@ -997,6 +997,20 @@ pub fn call(arena: &JsArena, callee: JsExpr, arguments: Vec<JsExpr>) -> JsExpr {
     })
 }
 
+/// Create the getter call a read transform produces (`x` -> `x()`).
+///
+/// A source-level `x()` and a transform-produced `x()` are the same shape, so the
+/// callee is marked opaque: without it a second `apply_transforms_to_expression`
+/// pass over an already-transformed subtree reads the binding twice (`x()()`).
+#[inline]
+pub fn getter_call(arena: &JsArena, node: JsExpr) -> JsExpr {
+    let callee = match node {
+        JsExpr::Identifier(ref name) => JsExpr::OpaqueIdentifier(name.clone()),
+        _ => node,
+    };
+    call(arena, callee, vec![])
+}
+
 /// Create a call expression with trailing undefined/false arguments stripped.
 ///
 /// This matches the behavior of the official Svelte compiler's `b.call()` function

--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
 		"corpus:verify": "node scripts/compat-corpus/verify.mjs",
 		"corpus:matrix": "node scripts/compat-corpus/matrix/run.mjs",
 		"corpus:matrix:update": "node scripts/compat-corpus/matrix/run.mjs --update-baseline",
+		"corpus:idempotency": "RSVELTE_ASSERT_TRANSFORM_IDEMPOTENT=1 node scripts/compat-corpus/idempotency-verify.mjs",
 		"corpus:mutate": "node scripts/compat-corpus/mutate-corpus.mjs",
 		"corpus:mutate:full": "node scripts/compat-corpus/mutate-corpus.mjs --full",
 		"corpus:mutate:update": "node scripts/compat-corpus/mutate-corpus.mjs --full --update-baseline",

--- a/scripts/compat-corpus/idempotency-verify.mjs
+++ b/scripts/compat-corpus/idempotency-verify.mjs
@@ -1,0 +1,157 @@
+#!/usr/bin/env node
+/**
+ * Assert that rsvelte's client identifier transform is idempotent on every
+ * corpus entry.
+ *
+ * `try_transform_assignment` converts both sides of a member mutation and hands
+ * the result back to the outer `apply_transforms_to_expression` walk, so any
+ * read whose output the walk can transform *again* is applied twice. That is
+ * #3026: `state.a = state.b` in an inline template arrow emitted
+ * `state().a = state()().b`. Output equality cannot find the class on its own —
+ * the shape occurs 0 times in 12,523 corpus components, and the bad output
+ * parses — so the property is asserted directly instead of being sampled.
+ *
+ * The check lives in the compiler behind `RSVELTE_ASSERT_TRANSFORM_IDEMPOTENT`:
+ * every top-level transform re-applies itself to its own output and prints a
+ * `RSVELTE_NON_IDEMPOTENT_TRANSFORM` line when the two differ. This script runs
+ * the corpus through it and fails on any line. It is a hard gate with no
+ * ratchet — measured at 0 on the tree that introduced it, and a violation is a
+ * latent double-application rather than a divergence to be burned down.
+ *
+ * What it does not see: the server transform (no identifier transforms), the
+ * callers of `apply_transforms_to_expression_with_shadowed` that bypass the
+ * top-level entry, and any divergence the fallback text printer erases — a
+ * print with unbalanced brackets is one the printer truncated, so the pair is
+ * skipped rather than reported.
+ *
+ * Usage: node scripts/compat-corpus/idempotency-verify.mjs [--binding <path>]
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { createRequire } from 'node:module';
+import { spawnSync } from 'node:child_process';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, '../..');
+const CORPUS = path.join(ROOT, 'compatibility');
+
+const args = process.argv.slice(2);
+const argValue = (name, fallback) => {
+	const i = args.indexOf(name);
+	return i !== -1 && args[i + 1] ? args[i + 1] : fallback;
+};
+
+if (!process.env.RSVELTE_ASSERT_TRANSFORM_IDEMPOTENT) {
+	console.error('[idempotency] RSVELTE_ASSERT_TRANSFORM_IDEMPOTENT is unset — the compiler would not emit a single marker,');
+	console.error('  and a run that cannot fail is not a gate. Re-run with the variable set.');
+	process.exit(2);
+}
+
+const BINDING = path.resolve(ROOT, argValue('--binding', '.corpus-cache/rsvelte.node'));
+if (!fs.existsSync(BINDING)) {
+	console.error(`[idempotency] rsvelte NAPI binding missing at ${path.relative(ROOT, BINDING)}`);
+	console.error('  build: cargo build --release -p rsvelte_napi --lib');
+	process.exit(2);
+}
+
+const manifestPath = path.join(CORPUS, 'manifest.json');
+if (!fs.existsSync(manifestPath)) {
+	console.error('[idempotency] compatibility/manifest.json missing — run: node scripts/compat-corpus/collect.mjs');
+	process.exit(2);
+}
+const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8')).filter((e) => e.kind === 'component');
+
+// The same floor collect.mjs enforces: a near-empty manifest would let the gate
+// pass vacuously.
+const MIN_ENTRIES = 1000;
+if (manifest.length < MIN_ENTRIES) {
+	console.error(`[idempotency] only ${manifest.length} components in the manifest (expected >= ${MIN_ENTRIES})`);
+	process.exit(2);
+}
+
+// A native `eprintln!` writes straight to fd 2, so the markers cannot be
+// intercepted in-process — the compiles run in a child whose stderr is piped.
+// The child prints `UNIT <id> <target>` before each one so a marker can be
+// attributed to the entry that produced it.
+const MODES = [
+	{ key: 'client', dev: false },
+	{ key: 'client-dev', dev: true },
+];
+
+if (args.includes('--worker')) {
+	const require = createRequire(import.meta.url);
+	const rsvelte = require(BINDING);
+	for (const entry of manifest) {
+		let source;
+		try {
+			source = fs.readFileSync(path.join(CORPUS, 'sources', entry.id), 'utf8');
+		} catch {
+			continue;
+		}
+		for (const mode of MODES) {
+			process.stderr.write(`UNIT\t${entry.id}\t${mode.key}\n`);
+			try {
+				rsvelte.compile(source, { generate: 'client', dev: mode.dev, filename: entry.id });
+			} catch {
+				// A source the compiler rejects is the output gate's business, not this one.
+			}
+		}
+	}
+	process.exit(0);
+}
+
+const child = spawnSync(process.execPath, [fileURLToPath(import.meta.url), '--worker', '--binding', BINDING], {
+	cwd: ROOT,
+	encoding: 'utf8',
+	maxBuffer: 512 * 1024 * 1024,
+	env: process.env,
+});
+if (child.status !== 0) {
+	console.error(`[idempotency] worker exited ${child.status} (signal ${child.signal ?? 'none'}) — the compiler aborted mid-sweep.`);
+	console.error((child.stderr || '').split('\n').slice(-20).join('\n'));
+	process.exit(2);
+}
+
+const violations = [];
+let units = 0;
+let current = null;
+for (const line of (child.stderr || '').split('\n')) {
+	if (line.startsWith('UNIT\t')) {
+		const [, id, target] = line.split('\t');
+		current = { id, target };
+		units += 1;
+	} else if (line.startsWith('RSVELTE_NON_IDEMPOTENT_TRANSFORM\t')) {
+		const [, once, twice] = line.split('\t');
+		violations.push({ ...current, once, twice });
+	}
+}
+
+if (units < MIN_ENTRIES) {
+	console.error(`[idempotency] the worker reported ${units} units — it did not run the corpus.`);
+	process.exit(2);
+}
+
+console.log(`[idempotency] ${units} units (${manifest.length} components x ${MODES.length} modes)`);
+
+if (!violations.length) {
+	console.log('[idempotency] ✅ every transform is idempotent on its own output');
+	process.exit(0);
+}
+
+const byUnit = new Set(violations.map((v) => `${v.id} (${v.target})`));
+console.log(`\n[idempotency] ❌ ${violations.length} non-idempotent transforms across ${byUnit.size} units:`);
+const shown = new Set();
+for (const v of violations) {
+	const key = `${v.once} -> ${v.twice}`;
+	if (shown.has(key)) continue;
+	shown.add(key);
+	if (shown.size > 20) break;
+	console.log(`  - ${v.id} (${v.target})`);
+	console.log(`      once : ${v.once}`);
+	console.log(`      twice: ${v.twice}`);
+}
+console.log('\n  A read transform whose output the next pass can transform again is #3026\'s defect class.');
+console.log('  Mark the produced callee opaque (`b::getter_call`) so the second pass is a no-op.');
+process.exit(1);

--- a/scripts/compat-corpus/idempotency-verify.mjs
+++ b/scripts/compat-corpus/idempotency-verify.mjs
@@ -11,6 +11,10 @@
  * the shape occurs 0 times in 12,523 corpus components, and the bad output
  * parses — so the property is asserted directly instead of being sampled.
  *
+ * The compiler announces `RSVELTE_IDEMPOTENCY_ARMED` from inside the comparison and this
+ * script refuses a verdict without it — a binding that predates the check prints nothing,
+ * which would otherwise read as a clean sweep.
+ *
  * The check lives in the compiler behind `RSVELTE_ASSERT_TRANSFORM_IDEMPOTENT`:
  * every top-level transform re-applies itself to its own output and prints a
  * `RSVELTE_NON_IDEMPOTENT_TRANSFORM` line when the two differ. This script runs
@@ -116,9 +120,12 @@ if (child.status !== 0) {
 
 const violations = [];
 let units = 0;
+let armed = false;
 let current = null;
 for (const line of (child.stderr || '').split('\n')) {
-	if (line.startsWith('UNIT\t')) {
+	if (line === 'RSVELTE_IDEMPOTENCY_ARMED') {
+		armed = true;
+	} else if (line.startsWith('UNIT\t')) {
 		const [, id, target] = line.split('\t');
 		current = { id, target };
 		units += 1;
@@ -130,6 +137,17 @@ for (const line of (child.stderr || '').split('\n')) {
 
 if (units < MIN_ENTRIES) {
 	console.error(`[idempotency] the worker reported ${units} units — it did not run the corpus.`);
+	process.exit(2);
+}
+
+// A binding with no check compiled in prints nothing at all, which is indistinguishable
+// from a clean tree: a `main` binding measured 0 violations for exactly that reason
+// before this guard existed. The compiler announces itself from inside the comparison,
+// so an absent marker means the check never ran — not that it found nothing.
+if (!armed) {
+	console.error('[idempotency] the compiler never announced the check (no RSVELTE_IDEMPOTENCY_ARMED line).');
+	console.error('  The binding predates the check, or the transform entry point was never reached.');
+	console.error(`  binding: ${path.relative(ROOT, BINDING)} — rebuild it from this tree.`);
 	process.exit(2);
 }
 


### PR DESCRIPTION
Follow-up to #3053. **No output changes**: all 37,596 `(corpus file, target)` output hashes are
byte-identical to `main`.

## What this adds

A gate that compares rsvelte to **nothing**. With `RSVELTE_ASSERT_TRANSFORM_IDEMPOTENT` set,
every top-level `apply_transforms_to_expression` re-applies itself to its own output and reports
when the two differ; `scripts/compat-corpus/idempotency-verify.mjs` sweeps the corpus through it
and fails on any report. Hard gate, no ratchet, wired into the `Compiler parity` job.

## Why a property and not another family

#3026 was a *property* violation — `try_transform_assignment` hands a converted subtree back to
the outer walk, so a read whose output is itself re-readable is applied twice — and output
equality could not sample it: the input shape occurred **0 times in the 12,523 components the
corpus held when it was reported**, and `state().a = state()().b` parses. #3053 closed it with a
generated `write-host` family, which works, but a generated family is bounded by the axis values
its author wrote. #2535 is the standing counterexample to trusting that bound.

This gate is bounded by neither the population nor the axes, because it asks the corpus a
question about the compiler. On its first run it found that **five more read builders had the
same defect**, latent only because nothing re-walks their output today:

| | |
|---|---|
| `program.rs` | `store_sub_read`, `prop_read` (legacy `export let`), `reactive_import_read` |
| `each_block.rs` | the destructured each-path read |
| `snippet_block.rs` | the snippet parameter read |

All five now build their callee through the new `b::getter_call`, the same marker #3053 gave the
two it reached.

## Measured

Same tree, with and without the one line in `b::getter_call` that marks the produced callee
opaque — un-sealing it puts all seven builders back in their pre-#3026 state:

| tree | non-idempotent transforms | units carrying one |
|---|---|---|
| this branch, `b::getter_call` un-sealed | 37,352 | 7,888 of 27,566 (28.6%) |
| this branch | 0 | 0 |

**Both compile the corpus to 0 output divergences.** The corpus carried the ingredients of #3026
in more than a quarter of its units the whole time; only the re-walk path made one of them
observable. Split by builder on the pre-#3053 tree: the merge base scored 37,346, and with
#3026's own two sealed it still scored **9,274 across 2,530 units** — the five the report never
reached.

## The gate's own vacuous green, and the guard for it

Pointed at a `main` binding, the first version of this script reported **0 violations** — a tree
with five unsealed builders. A compiler with no check compiled in prints nothing, and silence
read as success. That is exactly the class the gate exists to catch, in the gate itself.

The compiler now announces `RSVELTE_IDEMPOTENCY_ARMED` **from inside the comparison**, and the
script exits 2 without it. "The binding predates the check", "the variable was never read" and
"the entry point was never reached" all fail instead of passing — verified by pointing it at a
`main` binding again and getting exit 2. The reporting rule (including the truncated-print skip)
is factored into `idempotency_report` and pinned by a unit test. What neither covers — a
comparison that regressed to always-equal — is written down as gate-coverage **28f** rather than
papered over.

## Verified locally

- `node scripts/compat-corpus/idempotency-verify.mjs` — 27,566 units, 0 violations; the
  un-sealed control reports 37,352; a `main` binding exits 2.
- 37,596 `(file, target)` output hashes identical to `main` across client / client-dev / server.
- `node scripts/compat-corpus/matrix/run.mjs` — no regressions, 396 known.
- `cargo clippy --all-targets --all-features -- -D warnings`, `cargo fmt --check`,
  `cargo test -p rsvelte_core --lib idempotency_report`.

## Blind spots recorded

`compatibility/gate-coverage.md` §28: the server transform is not in the population (28a); only
the top-level entry is checked, not `…_with_shadowed` (28b); the comparison goes through the
fallback text printer, which can hide a divergence but never invent one (28c); **idempotent is
not correct** — it is a necessary condition, not parity (28d); it runs in one job on an
already-collected corpus (28e); and 28f above.
