### PR TITLE
fix(vscode): ship one VSIX per platform instead of one carrying all five

### DIFF
--- a/.changeset/vscode-platform-specific-vsix.md
+++ b/.changeset/vscode-platform-specific-vsix.md
@@ -1,0 +1,18 @@
+---
+"@rsvelte/language-server": patch
+---
+
+Ship the VS Code extension as one VSIX per platform.
+
+The extension bundled all five native language servers — ~110 MB uncompressed,
+including a 24 MB unsigned Windows PE — into a single universal VSIX, and every
+release since 0.5.0 failed the Marketplace's virus check on upload. Open VSX,
+which does not scan, carried 0.5.0/0.5.1/0.5.2 while the Marketplace stayed on
+0.4.1 and has since dropped the extension entirely.
+
+Each platform now gets its own VSIX carrying only its own server, alongside a
+binary-free universal package that the registries serve to every other platform,
+where the extension falls back to the bundled JS server as before. The publish
+guard also became per `(version, targetPlatform)`: one platform failing
+validation no longer reads as "published" for the rest, so the next run retries
+exactly what is missing.

--- a/.github/workflows/publish-vscode.yml
+++ b/.github/workflows/publish-vscode.yml
@@ -17,6 +17,7 @@ on:
       - 'Cargo.lock'
       - 'scripts/release/publish-vscode.mjs'
       - 'scripts/release/stage-vscode-language-server-binaries.mjs'
+      - 'scripts/release/vscode-targets.mjs'
       - '.github/workflows/publish-vscode.yml'
   workflow_dispatch:
     inputs:

--- a/apps/npm/vscode/build.mjs
+++ b/apps/npm/vscode/build.mjs
@@ -4,6 +4,10 @@
 // server is shipped as a separate ESM `server.mjs` (+ vendored wasm) that the
 // client spawns over stdio, so we just copy the language-server's built `dist`
 // next to the extension bundle.
+//
+// `RSVELTE_VSIX_TRIPLE` selects which staged native server this build embeds —
+// one per platform-specific VSIX. Unset builds the universal fallback, which
+// carries no native binary at all and starts `dist/server.mjs` instead.
 
 import { build } from "esbuild";
 import { cpSync, existsSync, mkdirSync, rmSync } from "node:fs";
@@ -42,8 +46,17 @@ cpSync(join(serverDist, "vendor"), join(distDir, "vendor"), {
   recursive: true,
 });
 
-if (existsSync(nativeDir)) {
-  cpSync(nativeDir, join(distDir, "bin"), { recursive: true });
+const triple = process.env.RSVELTE_VSIX_TRIPLE?.trim();
+if (triple) {
+  const source = join(nativeDir, triple);
+  if (!existsSync(source)) {
+    throw new Error(
+      `RSVELTE_VSIX_TRIPLE=${triple} but ${source} is missing — run \`pnpm run stage-vscode-language-server\` first.`,
+    );
+  }
+  cpSync(source, join(distDir, "bin", triple), { recursive: true });
 }
 
-console.log("[build] extension bundled to dist/extension.js (+ native/JS servers)");
+console.log(
+  `[build] extension bundled to dist/extension.js (native server: ${triple ?? "none — universal"})`,
+);

--- a/apps/npm/vscode/test/manifest.test.mjs
+++ b/apps/npm/vscode/test/manifest.test.mjs
@@ -138,10 +138,11 @@ test("every command referenced by a menu is contributed", () => {
   }
 });
 
-test("build stages platform servers into the runtime path", () => {
+test("build stages one platform server into the runtime path", () => {
   const build = readFileSync(join(root, "build.mjs"), "utf8");
   const extension = readFileSync(join(root, "src", "extension.ts"), "utf8");
-  assert.match(build, /cpSync\(nativeDir, join\(distDir, "bin"\)/);
+  assert.match(build, /cpSync\(source, join\(distDir, "bin", triple\)/);
+  assert.match(build, /RSVELTE_VSIX_TRIPLE/);
   assert.match(extension, /path\.join\("dist", "bin", triple, binary\)/);
   assert.match(extension, /RSVELTE_PREPROCESS_NODE/);
   assert.match(extension, /ELECTRON_RUN_AS_NODE/);

--- a/apps/npm/vscode/test/vsix-targets.test.mjs
+++ b/apps/npm/vscode/test/vsix-targets.test.mjs
@@ -1,0 +1,38 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+import { VSCODE_TARGETS } from "../../../../scripts/release/vscode-targets.mjs";
+
+const root = dirname(dirname(fileURLToPath(import.meta.url)));
+const extensionSource = readFileSync(join(root, "src", "extension.ts"), "utf8");
+
+// The packaging table names the directory `platformTriple()` looks in, so the
+// two drift silently: a VSIX would ship a binary the extension never resolves.
+test("every packaged triple is one the extension resolves at runtime", () => {
+  for (const { triple } of VSCODE_TARGETS) {
+    assert.equal(
+      extensionSource.includes(`"${triple}"`),
+      true,
+      `${triple} is packaged but never returned by platformTriple()`,
+    );
+  }
+});
+
+test("names each platform's binary the way the extension spawns it", () => {
+  for (const { target, binary } of VSCODE_TARGETS) {
+    assert.equal(
+      binary,
+      target.startsWith("win32-")
+        ? "rsvelte-language-server.exe"
+        : "rsvelte-language-server",
+      target,
+    );
+  }
+});
+
+test("packages one VSIX per target, with unique targets and triples", () => {
+  assert.equal(new Set(VSCODE_TARGETS.map(({ target }) => target)).size, VSCODE_TARGETS.length);
+  assert.equal(new Set(VSCODE_TARGETS.map(({ triple }) => triple)).size, VSCODE_TARGETS.length);
+});

--- a/scripts/release/publish-vscode.mjs
+++ b/scripts/release/publish-vscode.mjs
@@ -3,10 +3,17 @@
 // The extension version follows `@rsvelte/language-server` (kept in lockstep by
 // the changesets `fixed` group).
 //
+// The extension ships as one VSIX per platform (each carrying only its own
+// native language server) plus a binary-free universal VSIX that both registries
+// serve to every other platform, where the extension falls back to the bundled
+// JS server. A single universal VSIX carrying all five unsigned native servers
+// fails the Marketplace's virus check.
+//
 // Each registry is checked INDEPENDENTLY and published to only when it is behind
 // the target version, so the script is idempotent and safe to run on every push
-// to main. This also means Open VSX can be back-filled later (after OVSX_PAT is
-// added) even though the Marketplace is already up to date.
+// to main. The Marketplace check is per (version, targetPlatform): one platform
+// failing validation must not read as "published" for the rest, and must stay
+// retryable on the next run.
 //
 // Usage:
 //   node scripts/release/publish-vscode.mjs --check   # decide only (writes GITHUB_OUTPUT)
@@ -21,6 +28,7 @@ import { execFileSync } from 'node:child_process';
 import { appendFileSync, readFileSync, writeFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { VSCODE_TARGETS } from './vscode-targets.mjs';
 
 const here = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(here, '../..');
@@ -36,6 +44,11 @@ const extPkg = JSON.parse(readFileSync(extPkgPath, 'utf8'));
 const target = JSON.parse(readFileSync(lsPkgPath, 'utf8')).version;
 const id = `${extPkg.publisher}.${extPkg.name}`;
 
+// The universal package carries no `--target`, so it needs a name of its own.
+const UNIVERSAL = 'universal';
+/** Every (version, targetPlatform) pair a complete publish produces. */
+const PLATFORMS = [UNIVERSAL, ...VSCODE_TARGETS.map(({ target: t }) => t)];
+
 /** Numeric semver compare for simple `x.y.z` versions (no pre-release). */
 function cmp(a, b) {
   const pa = a.split('.').map(Number);
@@ -47,15 +60,39 @@ function cmp(a, b) {
   return 0;
 }
 
-/** Latest version on the VS Code Marketplace, or null. */
-function marketplaceVersion() {
+/**
+ * Marketplace state: the newest LIVE version, and which platforms of `target`
+ * are live. `vsce show` reports only the newest version, so it cannot answer
+ * the per-platform question; the gallery API can, and `ExcludeNonValidated`
+ * makes "live" mean "passed validation" rather than "was uploaded".
+ */
+async function marketplaceState() {
   try {
-    const out = execFileSync(
-      'npx',
-      ['--yes', '@vscode/vsce@^3', 'show', id, '--json'],
-      { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] },
+    const r = await fetch(
+      'https://marketplace.visualstudio.com/_apis/public/gallery/extensionquery',
+      {
+        method: 'POST',
+        headers: {
+          Accept: 'application/json;api-version=7.2-preview.1',
+          'Content-Type': 'application/json',
+        },
+        // IncludeVersions (1) | ExcludeNonValidated (32)
+        body: JSON.stringify({
+          filters: [{ criteria: [{ filterType: 7, value: id }] }],
+          flags: 33,
+        }),
+      },
     );
-    return JSON.parse(out)?.versions?.[0]?.version ?? null;
+    if (!r.ok) return null;
+    const extension = (await r.json())?.results?.[0]?.extensions?.[0];
+    if (!extension) return { latest: null, live: new Set() };
+    const versions = extension.versions ?? [];
+    const live = new Set(
+      versions
+        .filter((v) => v.version === target)
+        .map((v) => v.targetPlatform ?? UNIVERSAL),
+    );
+    return { latest: versions[0]?.version ?? null, live };
   } catch {
     return null;
   }
@@ -74,10 +111,17 @@ async function openvsxVersion() {
   }
 }
 
-const mpPublished = marketplaceVersion();
+const mp = await marketplaceState();
 const ovsxPublished = await openvsxVersion();
 
-const needMp = force || mpPublished === null || cmp(target, mpPublished) > 0;
+// A live Marketplace version newer than ours means the release already moved
+// on; otherwise every platform `target` is missing is still to be published.
+// A failed query (`null`) publishes nothing rather than guessing.
+const missingMp =
+  mp === null || (mp.latest && cmp(target, mp.latest) < 0)
+    ? []
+    : PLATFORMS.filter((p) => !mp.live.has(p));
+const needMp = force || missingMp.length > 0;
 // Only consider Open VSX when a token is available to publish there.
 const needOvsx =
   hasOvsx && (force || ovsxPublished === null || cmp(target, ovsxPublished) > 0);
@@ -85,7 +129,14 @@ const shouldPublish = needMp || needOvsx;
 
 console.log(`extension:            ${id}`);
 console.log(`target version:       ${target} (follows @rsvelte/language-server)`);
-console.log(`marketplace version:  ${mpPublished ?? '(none)'}  → publish: ${needMp}`);
+console.log(
+  `marketplace version:  ${mp === null ? '(query failed)' : (mp.latest ?? '(none)')}` +
+    `  → publish: ${needMp}`,
+);
+console.log(
+  `  live platforms:     ${[...(mp?.live ?? [])].sort().join(', ') || '(none)'}`,
+);
+console.log(`  missing:            ${missingMp.join(', ') || '(none)'}`);
 console.log(
   `open vsx version:     ${ovsxPublished ?? '(none)'}  → publish: ${needOvsx}` +
     (hasOvsx ? '' : ' (OVSX_PAT unset)'),
@@ -117,33 +168,61 @@ if (extPkg.version !== target) {
   console.log(`set extension version → ${target}`);
 }
 
-const vsix = resolve(extDir, `${extPkg.name}-${target}.vsix`);
-
-// Package once (shared by both registries). `vsce package` runs
-// `vscode:prepublish` (build.mjs), which needs the language-server bundle to
-// already exist (built by the workflow).
-execFileSync(
-  'npx',
-  ['--yes', '@vscode/vsce@^3', 'package', '--no-dependencies', '-o', vsix],
-  { cwd: extDir, stdio: 'inherit' },
-);
-
-if (needMp) {
+/**
+ * Package one platform. `vsce package` runs `vscode:prepublish` (build.mjs),
+ * which needs the language-server bundle to already exist (built by the
+ * workflow) and reads `RSVELTE_VSIX_TRIPLE` to pick the native server to embed.
+ */
+function pack(platform) {
+  const suffix = platform === UNIVERSAL ? '' : `-${platform}`;
+  const vsix = resolve(extDir, `${extPkg.name}-${target}${suffix}.vsix`);
+  const triple =
+    VSCODE_TARGETS.find(({ target: t }) => t === platform)?.triple ?? '';
   execFileSync(
     'npx',
     [
       '--yes',
       '@vscode/vsce@^3',
-      'publish',
+      'package',
       '--no-dependencies',
-      '--packagePath',
+      ...(platform === UNIVERSAL ? [] : ['--target', platform]),
+      '-o',
       vsix,
-      '-p',
-      process.env.VSCE_PAT,
     ],
-    { cwd: extDir, stdio: 'inherit' },
+    {
+      cwd: extDir,
+      stdio: 'inherit',
+      env: { ...process.env, RSVELTE_VSIX_TRIPLE: triple },
+    },
   );
-  console.log('✓ published to VS Code Marketplace');
+  return vsix;
+}
+
+// Open VSX takes the whole set; the Marketplace only what is missing there.
+const mpPlatforms = force ? PLATFORMS : missingMp;
+const wanted = needOvsx ? PLATFORMS : mpPlatforms;
+const packaged = new Map(wanted.map((platform) => [platform, pack(platform)]));
+
+if (needMp) {
+  for (const platform of mpPlatforms) {
+    execFileSync(
+      'npx',
+      [
+        '--yes',
+        '@vscode/vsce@^3',
+        'publish',
+        '--no-dependencies',
+        '--packagePath',
+        packaged.get(platform),
+        '-p',
+        process.env.VSCE_PAT,
+      ],
+      { cwd: extDir, stdio: 'inherit' },
+    );
+    console.log(`✓ published ${platform} to VS Code Marketplace`);
+  }
+} else if (mp === null) {
+  console.log('Marketplace state unknown (query failed) — skipping.');
 } else {
   console.log('Marketplace already up to date — skipping.');
 }
@@ -159,12 +238,14 @@ if (needOvsx) {
   } catch {
     /* namespace already exists, or not permitted — publish will report fatal errors */
   }
-  execFileSync(
-    'npx',
-    ['--yes', 'ovsx@^0', 'publish', vsix, '-p', process.env.OVSX_PAT],
-    { cwd: extDir, stdio: 'inherit' },
-  );
-  console.log('✓ published to Open VSX');
+  for (const platform of PLATFORMS) {
+    execFileSync(
+      'npx',
+      ['--yes', 'ovsx@^0', 'publish', packaged.get(platform), '-p', process.env.OVSX_PAT],
+      { cwd: extDir, stdio: 'inherit' },
+    );
+    console.log(`✓ published ${platform} to Open VSX`);
+  }
 } else if (!hasOvsx) {
   console.log('OVSX_PAT not set — skipping Open VSX.');
 } else {

--- a/scripts/release/stage-vscode-language-server-binaries.mjs
+++ b/scripts/release/stage-vscode-language-server-binaries.mjs
@@ -9,6 +9,7 @@ import {
 } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import { VSCODE_TARGETS } from "./vscode-targets.mjs";
 
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
 const artifactRoot = resolve(
@@ -19,17 +20,10 @@ const destinationRoot = resolve(
 	repoRoot,
 	process.env.VSCODE_NATIVE_ROOT || "apps/npm/vscode/native",
 );
-const targets = [
-	{ triple: "darwin-arm64", binary: "rsvelte-language-server" },
-	{ triple: "darwin-x64", binary: "rsvelte-language-server" },
-	{ triple: "linux-arm64-gnu", binary: "rsvelte-language-server" },
-	{ triple: "linux-x64-gnu", binary: "rsvelte-language-server" },
-	{ triple: "win32-x64-msvc", binary: "rsvelte-language-server.exe" },
-];
 
 rmSync(destinationRoot, { recursive: true, force: true });
 
-for (const { triple, binary } of targets) {
+for (const { triple, binary } of VSCODE_TARGETS) {
 	const source = resolve(
 		artifactRoot,
 		`rsvelte-language-server-${triple}`,

--- a/scripts/release/vscode-targets.mjs
+++ b/scripts/release/vscode-targets.mjs
@@ -1,0 +1,34 @@
+// The Marketplace scans every file in a VSIX, and a universal package carrying
+// all five unsigned native servers (~110 MB) fails that scan, so each target
+// ships its own VSIX alongside a binary-free universal fallback.
+//
+// `target` is the `vsce --target` identifier; `triple` is the directory name
+// `extension.ts`'s `platformTriple()` resolves at runtime. They differ for
+// linux/windows, so this table is the single place the two vocabularies meet.
+export const VSCODE_TARGETS = [
+	{
+		target: "darwin-arm64",
+		triple: "darwin-arm64",
+		binary: "rsvelte-language-server",
+	},
+	{
+		target: "darwin-x64",
+		triple: "darwin-x64",
+		binary: "rsvelte-language-server",
+	},
+	{
+		target: "linux-arm64",
+		triple: "linux-arm64-gnu",
+		binary: "rsvelte-language-server",
+	},
+	{
+		target: "linux-x64",
+		triple: "linux-x64-gnu",
+		binary: "rsvelte-language-server",
+	},
+	{
+		target: "win32-x64",
+		triple: "win32-x64-msvc",
+		binary: "rsvelte-language-server.exe",
+	},
+];


### PR DESCRIPTION
## 原因

`rsvelte-vscode` は 0.5.0 以降 **5 プラットフォーム分のネイティブ language server を 1 つの universal VSIX に同梱**していた。展開後 ~110 MB、うち 24 MB は **Authenticode 署名のない Windows PE32+**（PE ヘッダの Certificate データディレクトリが空）。これが Marketplace のウイルスチェックに落ちていた。

配信物を突き合わせた結果:

| | Marketplace | Open VSX | VSIX | `dist/bin` の実行ファイル |
|---|---|---|---|---|
| 0.4.1 | ✅ `validated` | ✅ | 3.8 MB | **0 個** |
| 0.5.0 | ❌ | ✅ | 47.6 MB | **5 個** |
| 0.5.1 | ❌ | ✅ | — | 5 個 |
| 0.5.2 | ❌ | ✅ | 48.2 MB | 5 個 |

0.4.1 と 0.5.0 の差分は `dist/bin/**` だけ。スキャンを行わない Open VSX には 3 つとも通っている。

> [!IMPORTANT]
> 調査中に、`baseballyama.rsvelte-vscode` が **Marketplace から削除された**ことを確認した（拡張ページ 404、gallery API で 0 件、`vsce show` が not found、検証済みだった 0.4.1 の VSIX アセットまで 404）。パブリッシャ自体は健在（`baseballyama.contextualize` は 0.6.2 で生存）。この PR は再公開が通る形を用意するもので、リスティング自体の復旧は別途 Microsoft 側の対応が要る可能性がある。

## 変更

- **`scripts/release/vscode-targets.mjs`（新規）** — `vsce --target` 識別子とランタイム triple の対応表。両者は linux / win32 で名前が異なる（`linux-x64` ↔ `linux-x64-gnu`）ため、突き合わせ点を 1 箇所に集約。
- **`build.mjs`** — `native/` 全体のコピーをやめ、`RSVELTE_VSIX_TRIPLE` が指す 1 つだけを埋め込む。未設定なら universal（バイナリ無し）。指定された triple が未ステージなら exit 1 で落ちる。
- **`publish-vscode.mjs`** — universal + 5 targets の計 6 VSIX を作り、Marketplace に無いものだけを publish。universal を先頭に置くので、あるプラットフォームが落ちてもフォールバックは先に着地する。
- **publish ガードを `(version, targetPlatform)` 単位に** — `vsce show` は最新バージョン 1 件しか返さず、プラットフォーム別の問いに答えられない。**旧ガードが `vsce show` で validated 済みバージョンだけを見ていたため、Marketplace は永久に 0.4.1 と判定され、0.5.0 以降 main への push のたびに 5 プラットフォームの Rust ビルド（1 run 40 分〜4 時間）と再アップロードが走り、その都度 validation 失敗メールが出ていた。**
- **`test/vsix-targets.test.mjs`（新規）** — 対応表が `platformTriple()` の返しうる triple から乖離するのを防ぐ。乖離すると「拡張が決して参照しないバイナリを同梱した VSIX」が黙って出る。

universal パッケージは 0.4.1 が validation を通った形そのものであり、`resolveNativeServer()` が `undefined` を返したときの `dist/server.mjs` フォールバックは既存の経路。

## 検証

**陽性対照** — 実際に `vsce package` を実行して中身を確認:

| VSIX | `TargetPlatform` | `dist/bin` |
|---|---|---|
| universal | なし | **0 個** |
| win32-x64 | `win32-x64` | `win32-x64-msvc/rsvelte-language-server.exe` のみ |
| darwin-arm64 | `darwin-arm64` | `darwin-arm64/rsvelte-language-server` のみ |

**陰性対照** — 未ステージの triple を指定すると `build.mjs` が exit 1（サイレントに universal を作らない）。

**ゲートの判別力** — 新テストは表の triple を `win32-x64-gnu` に書き換えた変異体で落ちる（9/0 → 8/1）。

**API の対照** — `flags: 33`（`IncludeVersions | ExcludeNonValidated`）が `targetPlatform` を返すことを、universal + 8 target を公開済みの `rust-lang.rust-analyzer` で確認済み。つまり「全部 live で missing が空」という分岐は到達可能。CI の `pnpm --filter rsvelte-vscode run build` は env 未設定なので universal を作る（従来も CI に `native/` は無く、出力は不変）。拡張のテストは 9/9。

## 未検証

**ウイルスチェックを通るかどうかは、実際に publish するまで確認できない。** これは最有力の原因（未署名 PE を含む 110 MB の universal パッケージ）を消す変更であって、スキャナが `.exe` 単体を誤検知しないことの証明ではない。ただし切り分けにはなる — win32-x64 だけ落ちて他 5 つが通れば、原因が `.exe` 自身であることが確定し、次の手（Authenticode 署名 / 誤検知申し立て）に進める。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uer7mE7tvSN4BDmW827nzH
