### PR TITLE
fix(lint): honour a lookaround pattern in sort-attributes' `order`

### DIFF
--- a/.changeset/sort-attributes-lookahead.md
+++ b/.changeset/sort-attributes-lookahead.md
@@ -1,0 +1,7 @@
+---
+"@rsvelte/lint": patch
+---
+
+`svelte/sort-attributes` now honours an `order` pattern that uses lookaround.
+
+The `order` option takes JS regexes, and Rust's `regex` crate implements no lookaround, so a pattern like `"/^(?=x-)x-a$/u"` failed to compile and its group was silently dropped — the rule then reported nothing for the attributes that group was meant to order. `regex` is still tried first and every default pattern compiles there, so the backtracking fallback is unreachable from the default path.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -745,14 +745,22 @@ accepted entries and the collected one from 104 to 45 — **the collected corpus
 suppressing 62 of its own entries' worth of defects it could not phrase**.
 
 That corpus has since grown to **1,365 patterns** across the four axes below, and the tree now
-stands at **5** accepted adversarial entries and **3** collected ones (6,788 real-world sources,
-73,378 findings compared). Read the composition before reading the count: **four of the five are
-upstream-side or deliberate** — two `svelte-eslint-parser` artifacts (`</style⏎⏎>` produces no
+stands at **4** accepted adversarial entries and **3** collected ones (6,788 real-world sources,
+73,378 findings compared). Read the composition before reading the count: **every remaining entry
+is upstream-side or deliberate** — two `svelte-eslint-parser` artifacts (`</style⏎⏎>` produces no
 `SvelteStyleElement`; the block-blanking regex is case-insensitive, so `<Style />` is treated as a
 style tag), the `globals.browser ∖ globals.node` split, and rsvelte's choice to treat a CSS
 `svelte-ignore` on an un-preprocessed `lang="scss"` block as *used*, which is also all three
-collected entries. Exactly one is an rsvelte limitation: `sort-attributes/07-lookahead-order`
-needs a JS-compatible regex engine.
+collected entries.
+
+**The one entry that was an rsvelte limitation is gone, and how it was closed is the reusable
+part.** `sort-attributes`'s `order` option takes JS regexes; Rust's `regex` has no lookaround, so
+`"/^(?=x-)x-a$/u"` failed to compile and the group was **silently dropped**. The listed
+justification declined a lookaround-capable engine on performance grounds — correctly, if the
+choice were all-or-nothing. It is not: `regex` is tried first and every default pattern still
+compiles there, so `fancy-regex` is reached only by a pattern `regex` rejects and the backtracking
+engine never touches the hot path. When a dependency is refused on a cost that only applies to the
+*default* path, ask whether the fallback can be made unreachable from it.
 
 Three method notes, each of which cost real time here:
 - **Two of the remaining entries are not rsvelte being wrong**, and neither is discoverable

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,6 +171,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -700,6 +715,17 @@ checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "fancy-regex"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "476de73bddf2ef8490aa4ee8f1cf40b430bf1d56c48c22080e5186952cd580e6"
+dependencies = [
+ "bit-set",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -2710,6 +2736,7 @@ dependencies = [
  "clap",
  "codspeed-criterion-compat",
  "compact_str 0.10.0",
+ "fancy-regex",
  "javascript-globals",
  "oxc_allocator",
  "oxc_ast",

--- a/compatibility/lint-adversarial-fix-all-known-failures.json
+++ b/compatibility/lint-adversarial-fix-all-known-failures.json
@@ -16,6 +16,5 @@
 	"no-target-blank/opt-key-allow-referrer.svelte",
 	"no-target-blank/opt-key-dynamic-never.svelte",
 	"oracle-crash:no-navigation-without-base/06-template-literals.svelte",
-	"shorthand-directive/16-never-mode-modifiers.svelte",
-	"sort-attributes/07-lookahead-order.svelte"
+	"shorthand-directive/16-never-mode-modifiers.svelte"
 ]

--- a/compatibility/lint-adversarial-fix-all-known-failures.md
+++ b/compatibility/lint-adversarial-fix-all-known-failures.md
@@ -23,7 +23,7 @@ uncompared, and both turned out to hold defects:
 
 An entry needs a reason that is *not* "rsvelte is wrong here".
 
-`lint-adversarial-fix-all-known-failures.json` holds **19 entries** over 1364
+`lint-adversarial-fix-all-known-failures.json` holds 18 entries over 1364
 compared patterns; on the run that baselined it the oracle rewrote 793 files and
 rsvelte rewrote 792.
 
@@ -32,12 +32,11 @@ other on the same pattern: a bare `<id>` is a text divergence, and
 `oracle-crash:<id>` is a pattern ESLint threw on while fixing, where there is no
 text to compare.
 
-Partition of `lint-adversarial-fix-all-known-failures.json` by cause: `14 + 1 + 1 + 1 + 1 + 1`
+Partition of `lint-adversarial-fix-all-known-failures.json` by cause: `14 + 1 + 1 + 1 + 1`
 
 | cause | entries |
 |---|---|
 | rsvelte-only autofix (upstream rule is report-only) | 14 |
-| Rust `regex` has no lookaround | 1 |
 | upstream autofix defect we decline to reproduce | 1 |
 | `svelte_meta_invalid_placement` is a parse error upstream, an analyze error here | 1 |
 | a listed upstream-parser defect, surfaced by a fix oscillation | 1 |
@@ -101,16 +100,6 @@ to `target="_blank"`, and the *next* pass hands `no-target-blank` a static
 `_blank` it now flags. Both sides report it in that pass; only rsvelte has a
 fixer. Same cause, reached only through another rule's edit.
 
-### `sort-attributes/07-lookahead-order.svelte`
-
-The fix-side face of entry 4 in
-[`lint-adversarial-known-failures.md`](lint-adversarial-known-failures.md),
-identical to the per-rule gate's entry: the `order` option is
-`["/^(?=x-)x-a$/u", "x-b"]`, Rust's `regex` crate has no lookaround, the pattern
-fails to compile and the group is dropped, so rsvelte has no finding to fix while
-the oracle reorders. The option comes from an inline `/* eslint … */` comment, so
-the rule is enabled on both sides here regardless of the config.
-
 ### `shorthand-directive/16-never-mode-modifiers.svelte`
 
 Upstream's `prefer: "never"` fix inserts `={name}` after the directive *name*
@@ -135,7 +124,7 @@ verification.
 
 Two causes stacked, and the divergence needs both.
 
-The first is already a ratchet entry on the **report** gate, entry 5 in
+The first is already a ratchet entry on the **report** gate, entry 4 in
 [`lint-adversarial-known-failures.md`](lint-adversarial-known-failures.md), and
 **rsvelte is the correct side of it**: `svelte-eslint-parser` blanks
 `<(script|style|template)([\s>])` case-insensitively, so `<Style />` is rewritten

--- a/compatibility/lint-adversarial-fix-known-failures.json
+++ b/compatibility/lint-adversarial-fix-known-failures.json
@@ -13,6 +13,5 @@
 	"no-target-blank/12-multibyte-crlf.svelte|svelte/no-target-blank",
 	"no-target-blank/opt-key-allow-referrer.svelte|svelte/no-target-blank",
 	"no-target-blank/opt-key-dynamic-never.svelte|svelte/no-target-blank",
-	"shorthand-directive/16-never-mode-modifiers.svelte|svelte/shorthand-directive",
-	"sort-attributes/07-lookahead-order.svelte|svelte/sort-attributes"
+	"shorthand-directive/16-never-mode-modifiers.svelte|svelte/shorthand-directive"
 ]

--- a/compatibility/lint-adversarial-fix-known-failures.md
+++ b/compatibility/lint-adversarial-fix-known-failures.md
@@ -24,14 +24,13 @@ and one of the four causes below is exactly that.
 
 An entry needs a reason that is *not* "rsvelte is wrong here".
 
-`lint-adversarial-fix-known-failures.json` holds **16 entries**.
+`lint-adversarial-fix-known-failures.json` holds 15 entries.
 
-Partition of `lint-adversarial-fix-known-failures.json` by cause: `13 + 1 + 1 + 1`
+Partition of `lint-adversarial-fix-known-failures.json` by cause: `13 + 1 + 1`
 
 | cause | entries |
 |---|---|
 | rsvelte-only autofix (upstream rule is report-only) | 13 |
-| Rust `regex` has no lookaround | 1 |
 | upstream autofix defect we decline to reproduce | 1 |
 | `svelte_meta_invalid_placement` is a parse error upstream, an analyze error here | 1 |
 
@@ -106,26 +105,6 @@ starts firing on a fourteenth shape, or stops firing on one of these thirteen,
 or writes different text — all of which a `svelte/no-target-blank` skip entry
 would swallow. The two-sided ratchet is what makes "rsvelte-only autofix" a
 claim about 13 named files rather than about a rule.
-
-### `sort-attributes/07-lookahead-order.svelte` `svelte/sort-attributes`
-
-Not an independent divergence: it is the fix-side face of entry 4 in
-[`lint-adversarial-known-failures.md`](lint-adversarial-known-failures.md), and
-that entry carries the reason. The `order` option is
-`["/^(?=x-)x-a$/u", "x-b"]`; Rust's `regex` crate has no lookaround, the pattern
-fails to compile, and the group is dropped.
-
-The two faces are the same root cause seen through two comparison keys. On the
-report side the missing group means rsvelte emits no finding at 5:14. Here it
-means rsvelte has no finding to fix, so it leaves the source alone while the
-oracle reorders:
-
-```svelte
-<div x-b="1" x-a="2">y</div>   <!-- oracle: <div x-a="2" x-b="1">y</div> -->
-```
-
-Both faces disappear together if the engine limitation is ever revisited; the
-ratchets are two-sided, so neither will rot.
 
 ### `shorthand-directive/16-never-mode-modifiers.svelte` `svelte/shorthand-directive`
 

--- a/compatibility/lint-adversarial-known-failures.json
+++ b/compatibility/lint-adversarial-known-failures.json
@@ -2,6 +2,5 @@
 	"html-closing-bracket-new-line/05-script-style-tags.svelte|+svelte/block-lang\t7:1\tThe lang attribute of the <style> block should be omitted.",
 	"no-nested-style-tag/14-component-lookalike.svelte|-svelte/html-self-closing\t5:8\tDisallow self-closing on HTML elements.",
 	"no-top-level-browser-globals/03-guard-browser.svelte|+svelte/no-top-level-browser-globals\t7:14\tUnexpected top-level browser global variable \"navigator\".",
-	"no-unused-svelte-ignore/10-style-scss-css-ignore.svelte|-svelte/no-unused-svelte-ignore\t2:20\tsvelte-ignore comment is used, but not warned",
-	"sort-attributes/07-lookahead-order.svelte|-svelte/sort-attributes\t5:14\tAttribute 'x-a' should go before 'x-b'."
+	"no-unused-svelte-ignore/10-style-scss-css-ignore.svelte|-svelte/no-unused-svelte-ignore\t2:20\tsvelte-ignore comment is used, but not warned"
 ]

--- a/compatibility/lint-adversarial-known-failures.md
+++ b/compatibility/lint-adversarial-known-failures.md
@@ -9,15 +9,15 @@ to separate two plausible implementations of one rule, so a divergence is a
 deliberate probe coming back positive rather than an accident of what published
 code happens to contain.
 
-**The expectation is that `lint-adversarial-known-failures.json` stays at 5 entries.**
+**The expectation is that `lint-adversarial-known-failures.json` stays at 4 entries.**
 It is not a burndown backlog: a new entry needs a reason that is *not*
-"rsvelte is wrong here", and the five below are the only such reasons found
+"rsvelte is wrong here", and the four below are the only such reasons found
 across 1365 patterns and 74 rules. Everything else the corpus surfaced (330
 divergences on the first run, 35 more when it grew past 1000 patterns) was fixed.
 
 `+` = rsvelte reports, oracle silent. `-` = oracle reports, rsvelte silent.
 
-## The five accepted entries
+## The four accepted entries
 
 ### 1. `html-closing-bracket-new-line/05-script-style-tags.svelte` `+svelte/block-lang 7:1`
 
@@ -56,19 +56,7 @@ the preprocessor configured. This is the same reasoning the exact-fixture gate
 records for `no-unused-svelte-ignore/invalid/style-lang0*`, whose expectations
 upstream recorded *with* the preprocessor installed.
 
-### 4. `sort-attributes/07-lookahead-order.svelte` `-svelte/sort-attributes 5:14`
-
-A custom `order` option containing a JS regex with lookahead
-(`"/^(?=x-)x-a$/u"`). Rust's `regex` crate does not implement lookaround, so the
-pattern fails to compile and the order group is dropped. Accepted as a **known
-engine limitation** rather than fixed, because the alternative is a
-lookaround-capable engine (`fancy-regex`) in a linter whose rule set is
-performance-critical, for a JS-only construct in one rule's option. Plain and
-`(?i)`-style patterns in `order` are handled and covered by sibling patterns.
-Note the failure is silent today: if this is ever revisited, the first move is to
-make an uncompilable `order` pattern observable rather than to widen the engine.
-
-### 5. `no-nested-style-tag/14-component-lookalike.svelte` `-svelte/html-self-closing 5:8`
+### 4. `no-nested-style-tag/14-component-lookalike.svelte` `-svelte/html-self-closing 5:8`
 
 `<Style />` — a component whose name differs from `style` only in case. Upstream
 reports `html-self-closing` on it; rsvelte does not, and **rsvelte is right**.

--- a/crates/rsvelte_lint/Cargo.toml
+++ b/crates/rsvelte_lint/Cargo.toml
@@ -47,6 +47,9 @@ compact_str = { version = "0.10", features = ["serde"] }
 # Minimal regex feature set (see rsvelte_core's regex dep) — only `(?i)`/`\w \s`
 # are used here, so the large Unicode tables are dropped.
 regex = { version = "1.11", default-features = false, features = ["std", "perf", "unicode-perl", "unicode-case"] }
+# Fallback for `sort-attributes`'s `order` patterns only, which are JS regexes and
+# may use lookaround. Never on the default path: `regex` is tried first.
+fancy-regex = { version = "0.19", default-features = false, features = ["std", "perf", "unicode"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 

--- a/crates/rsvelte_lint/src/rules/sort_attributes.rs
+++ b/crates/rsvelte_lint/src/rules/sort_attributes.rs
@@ -62,11 +62,30 @@ static META: RuleMeta = RuleMeta {
 
 // ─── Pattern / option compilation ────────────────────────────────────────────
 
+/// A compiled `order` pattern. `regex` is tried first and handles every default
+/// pattern, so the backtracking engine never touches the hot path.
+#[derive(Clone)]
+enum CompiledRe {
+    Fast(Regex),
+    /// Lookaround and backreferences — legal in a JS regex, absent from `regex`.
+    Fancy(fancy_regex::Regex),
+}
+
+impl CompiledRe {
+    fn is_match(&self, s: &str) -> bool {
+        match self {
+            Self::Fast(re) => re.is_match(s),
+            // Exceeding the backtrack limit is a non-match, not a rule failure.
+            Self::Fancy(re) => re.is_match(s).unwrap_or(false),
+        }
+    }
+}
+
 /// A single compiled pattern (from a string entry in the order array).
 #[derive(Clone)]
 struct Pattern {
     negative: bool,
-    re: Regex,
+    re: CompiledRe,
 }
 
 impl Pattern {
@@ -99,15 +118,19 @@ fn compile_pattern(p: &str) -> Option<Pattern> {
         .map_or((false, p), |stripped| (true, stripped));
 
     let re = to_regex(rest).map_or_else(
-        || Regex::new(&format!("^{}$", regex::escape(rest))).ok(),
+        || {
+            Regex::new(&format!("^{}$", regex::escape(rest)))
+                .ok()
+                .map(CompiledRe::Fast)
+        },
         Some,
     )?;
     Some(Pattern { negative, re })
 }
 
-/// Convert a `/pattern/flags` string to a `Regex`, returning `None` for plain
+/// Convert a `/pattern/flags` string to a regex, returning `None` for plain
 /// strings (which should be compiled as exact matchers by the caller).
-fn to_regex(s: &str) -> Option<Regex> {
+fn to_regex(s: &str) -> Option<CompiledRe> {
     if !s.starts_with('/') {
         return None;
     }
@@ -116,14 +139,20 @@ fn to_regex(s: &str) -> Option<Regex> {
     let last_slash = s.rfind('/')?;
     let pattern = &s[..last_slash];
     let flags = &s[last_slash + 1..];
-    // Build a regex with the given flags.
+    let case_insensitive = flags.contains('i');
+
     let mut builder = regex::RegexBuilder::new(pattern);
-    for flag in flags.chars() {
-        if flag == 'i' {
-            builder.case_insensitive(true);
-        }
+    builder.case_insensitive(case_insensitive);
+    if let Ok(re) = builder.build() {
+        return Some(CompiledRe::Fast(re));
     }
-    builder.build().ok()
+
+    let fancy = if case_insensitive {
+        format!("(?i){pattern}")
+    } else {
+        pattern.to_string()
+    };
+    fancy_regex::Regex::new(&fancy).ok().map(CompiledRe::Fancy)
 }
 
 /// Compile a group's match spec (string or string[]) into a list of `Pattern`s.
@@ -723,5 +752,56 @@ impl Rule for SortAttributes {
 
     fn check_special_element(&self, ctx: &mut LintContext, el: &SpecialElement<'_>) {
         Self::check_tag(ctx, &el.attributes);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{CompiledRe, compile_pattern, to_regex};
+
+    #[test]
+    fn a_plain_string_is_an_exact_matcher() {
+        let p = compile_pattern("x-a").unwrap();
+        assert!(p.matches("x-a"));
+        assert!(!p.matches("x-ab"));
+        assert!(!p.negative);
+    }
+
+    #[test]
+    fn a_leading_bang_negates() {
+        assert!(compile_pattern("!x-a").unwrap().negative);
+    }
+
+    /// The backtracking engine must stay off the path every default pattern
+    /// takes, so ordinary patterns have to select `Fast`.
+    #[test]
+    fn ordinary_patterns_stay_on_the_regex_crate() {
+        for src in ["/^x-/", "/^x-a$/u", "/^X-A$/i"] {
+            assert!(
+                matches!(to_regex(src), Some(CompiledRe::Fast(_))),
+                "{src} should not need the fallback"
+            );
+        }
+    }
+
+    #[test]
+    fn the_i_flag_survives_the_fallback() {
+        let p = to_regex("/^(?=X-)X-A$/i").unwrap();
+        assert!(matches!(p, CompiledRe::Fancy(_)));
+        assert!(p.is_match("x-a"));
+    }
+
+    /// `regex` has no lookaround; a JS `order` pattern may use it.
+    #[test]
+    fn lookahead_falls_back_and_matches() {
+        let p = compile_pattern("/^(?=x-)x-a$/u").unwrap();
+        assert!(matches!(p.re, CompiledRe::Fancy(_)));
+        assert!(p.matches("x-a"));
+        assert!(!p.matches("x-b"));
+    }
+
+    #[test]
+    fn a_pattern_neither_engine_accepts_is_dropped() {
+        assert!(to_regex("/(?</").is_none());
     }
 }

--- a/crates/rsvelte_lint_types/Cargo.lock
+++ b/crates/rsvelte_lint_types/Cargo.lock
@@ -46,6 +46,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -247,6 +262,17 @@ name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "fancy-regex"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "476de73bddf2ef8490aa4ee8f1cf40b430bf1d56c48c22080e5186952cd580e6"
+dependencies = [
+ "bit-set",
+ "regex-automata",
+ "regex-syntax",
+]
 
 [[package]]
 name = "fastrand"
@@ -1054,9 +1080,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.14"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+checksum = "ad8553b9b26413251cbf30e620595c7a41b3887f03da04579c0e6b0d6a06b4b2"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1128,6 +1154,7 @@ dependencies = [
  "anyhow",
  "bytecount",
  "compact_str",
+ "fancy-regex",
  "javascript-globals",
  "oxc_allocator",
  "oxc_ast",


### PR DESCRIPTION
`svelte/sort-attributes`'s `order` option takes JS regexes. Rust's `regex` crate implements no lookaround, so `"/^(?=x-)x-a$/u"` failed to compile and its group was **silently dropped** — the rule then reported nothing for the attributes that group was meant to order.

## Why this was listed rather than fixed, and what changed

The accepted-entry justification declined a lookaround-capable engine because `sort-attributes` sits in a performance-critical rule set. That reasoning is correct **if the choice is all-or-nothing**, and it isn't. `regex` is tried first; every default pattern still compiles there, so `fancy-regex` is reachable only by a pattern `regex` rejects and the backtracking engine never appears on the default path. A unit test asserts `CompiledRe::Fast` for ordinary patterns, so that property cannot rot silently.

Generalisable form: **when a dependency is refused on a cost that applies only to the default path, ask whether the fallback can be made unreachable from it.**

## Ratchets

Three two-sided ratchets listed this entry and all three reported it stale — which the fix gate's own justification predicted ("Both faces disappear together if the engine limitation is ever revisited; the ratchets are two-sided, so neither will rot"). Each is re-baselined with **exactly one** entry removed, verified by diff.

| gate | before | after |
|---|---|---|
| `lint-adversarial` | 5 divergences, oracle 5522 / rsvelte 5521 | 4, **5522 / 5522** |
| `lint-adversarial-fix` | 16 | 15 |
| `lint-adversarial-fix-all` | 19 | 18 |

Every remaining adversarial entry is now upstream-side or a deliberate rsvelte choice; none is an rsvelte limitation.

## Verification

- 10 lint gates green, including `lint-verify` over 6,788 real-world sources: `0 new, 0 fixed`, finding counts unchanged (73,380 / 73,378) — the change is inert on published code, as expected for a default-`Off` rule whose default patterns need no lookaround.
- `lint-adversarial-end` compares 5520 findings (was 5519) and still diverges on 12: the newly-matching finding's end position agrees too.
- `cargo fmt --check` 0, `cargo clippy --all-targets --all-features -D warnings` 0, `cargo test -p rsvelte_lint -p rsvelte_diagnostics` 14 suites / 0 failures, 6 new unit tests.
- `RUSTFLAGS=-Dwarnings cargo check -p rsvelte_lint --no-default-features` 0 (the wasm build).
- `known-failures-md-check.mjs` 0.
- `crates/rsvelte_lint_types/Cargo.lock` re-resolved: adding a dependency to `rsvelte_lint` staleifies the out-of-workspace lock and `check-lint-types-lock` fails on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YbSmFHQupqN9tVKhDFKwkr
