### PR TITLE
ci(release): never publish the extension from a failed registry query

### DIFF
--- a/scripts/release/publish-vscode.mjs
+++ b/scripts/release/publish-vscode.mjs
@@ -44,6 +44,11 @@ const extPkg = JSON.parse(readFileSync(extPkgPath, 'utf8'));
 const target = JSON.parse(readFileSync(lsPkgPath, 'utf8')).version;
 const id = `${extPkg.publisher}.${extPkg.name}`;
 
+// Exact versions: these CLIs are resolved fresh by `npx` on every run, so a
+// floating range makes the publish decision depend on the day it ran.
+const VSCE = '@vscode/vsce@3.9.2';
+const OVSX = 'ovsx@0.10.12';
+
 // The universal package carries no `--target`, so it needs a name of its own.
 const UNIVERSAL = 'universal';
 /** Every (version, targetPlatform) pair a complete publish produces. */
@@ -98,21 +103,28 @@ async function marketplaceState() {
   }
 }
 
-/** Latest version on Open VSX, or null (queried via the public API). */
-async function openvsxVersion() {
+/**
+ * Open VSX state, mirroring `marketplaceState`'s three answers: `null` when the
+ * query itself failed, `{ latest: null }` when the extension is definitively not
+ * published, `{ latest }` otherwise. A failed query must not read as "absent" —
+ * that direction publishes.
+ */
+async function openvsxState() {
   try {
     const r = await fetch(
       `https://open-vsx.org/api/${extPkg.publisher}/${extPkg.name}`,
     );
+    if (r.status === 404) return { latest: null };
     if (!r.ok) return null;
-    return (await r.json())?.version ?? null;
+    return { latest: (await r.json())?.version ?? null };
   } catch {
     return null;
   }
 }
 
 const mp = await marketplaceState();
-const ovsxPublished = await openvsxVersion();
+const ovsx = await openvsxState();
+const ovsxPublished = ovsx?.latest ?? null;
 
 // A live Marketplace version newer than ours means the release already moved
 // on; otherwise every platform `target` is missing is still to be published.
@@ -124,7 +136,10 @@ const missingMp =
 const needMp = force || missingMp.length > 0;
 // Only consider Open VSX when a token is available to publish there.
 const needOvsx =
-  hasOvsx && (force || ovsxPublished === null || cmp(target, ovsxPublished) > 0);
+  hasOvsx &&
+  (force ||
+    (ovsx !== null &&
+      (ovsxPublished === null || cmp(target, ovsxPublished) > 0)));
 const shouldPublish = needMp || needOvsx;
 
 console.log(`extension:            ${id}`);
@@ -138,7 +153,8 @@ console.log(
 );
 console.log(`  missing:            ${missingMp.join(', ') || '(none)'}`);
 console.log(
-  `open vsx version:     ${ovsxPublished ?? '(none)'}  → publish: ${needOvsx}` +
+  `open vsx version:     ${ovsx === null ? '(query failed)' : (ovsxPublished ?? '(none)')}` +
+    `  → publish: ${needOvsx}` +
     (hasOvsx ? '' : ' (OVSX_PAT unset)'),
 );
 
@@ -182,7 +198,7 @@ function pack(platform) {
     'npx',
     [
       '--yes',
-      '@vscode/vsce@^3',
+      VSCE,
       'package',
       '--no-dependencies',
       ...(platform === UNIVERSAL ? [] : ['--target', platform]),
@@ -205,20 +221,37 @@ const packaged = new Map(wanted.map((platform) => [platform, pack(platform)]));
 
 if (needMp) {
   for (const platform of mpPlatforms) {
-    execFileSync(
-      'npx',
-      [
-        '--yes',
-        '@vscode/vsce@^3',
-        'publish',
-        '--no-dependencies',
-        '--packagePath',
-        packaged.get(platform),
-        '-p',
-        process.env.VSCE_PAT,
-      ],
-      { cwd: extDir, stdio: 'inherit' },
-    );
+    try {
+      execFileSync(
+        'npx',
+        [
+          '--yes',
+          VSCE,
+          'publish',
+          '--no-dependencies',
+          '--packagePath',
+          packaged.get(platform),
+          '-p',
+          process.env.VSCE_PAT,
+        ],
+        { cwd: extDir, stdio: 'inherit' },
+      );
+    } catch (error) {
+      // The gallery query above found NO live version, yet the Marketplace
+      // rejects the name as taken: the two only agree if the extension is
+      // unlisted (removed / unpublished) while its name stays reserved. No
+      // amount of retrying moves that, so say what has to happen instead.
+      if (mp && mp.latest === null) {
+        console.error(
+          `\nThe Marketplace gallery reports NO live version of ${id}, but the\n` +
+            'publish was rejected. That pair means the extension is unlisted while its\n' +
+            'name is still reserved — a publisher-account state, not a build problem.\n' +
+            `Check https://marketplace.visualstudio.com/manage/publishers/${extPkg.publisher}\n` +
+            'and either restore the extension or rename it in apps/npm/vscode/package.json.',
+        );
+      }
+      throw error;
+    }
     console.log(`✓ published ${platform} to VS Code Marketplace`);
   }
 } else if (mp === null) {
@@ -232,7 +265,7 @@ if (needOvsx) {
   try {
     execFileSync(
       'npx',
-      ['--yes', 'ovsx@^0', 'create-namespace', extPkg.publisher, '-p', process.env.OVSX_PAT],
+      ['--yes', OVSX, 'create-namespace', extPkg.publisher, '-p', process.env.OVSX_PAT],
       { cwd: extDir, stdio: 'inherit' },
     );
   } catch {
@@ -241,7 +274,7 @@ if (needOvsx) {
   for (const platform of PLATFORMS) {
     execFileSync(
       'npx',
-      ['--yes', 'ovsx@^0', 'publish', packaged.get(platform), '-p', process.env.OVSX_PAT],
+      ['--yes', OVSX, 'publish', packaged.get(platform), '-p', process.env.OVSX_PAT],
       { cwd: extDir, stdio: 'inherit' },
     );
     console.log(`✓ published ${platform} to Open VSX`);


### PR DESCRIPTION
Refs #3174. **This PR does not turn the workflow green** — see the last section for what
actually has to happen, which is outside this repository.

## What #3174 got right, and what has already been fixed

#3174 was filed against the pre-#3161 script, which queried the Marketplace with
`vsce show … --json` and folded every failure into `null`. #3161 replaced that with a direct
gallery query that already distinguishes a failed query (`null`) from a definitive absence
(`{latest: null, live: new Set()}`), so that half is fixed. Three things were left.

## 1. The Open VSX query had the same shape

```js
if (!r.ok) return null;          // …and `ovsxPublished === null` means "not published"
} catch { return null; }         // …which means publish
```

`openvsxState` now answers three ways, matching `marketplaceState`: **404** is a definitive
absence, a transport error or non-ok response is `null`, and `needOvsx` treats `null` as *do not
publish*.

Measured against an unreachable host, with the same `OVSX_PAT` set on both:

```
old script:  open vsx version:     (none)          → publish: true
new script:  open vsx version:     (query failed)  → publish: false
```

The 404 branch is reachable: `open-vsx.org/api/<publisher>/<missing>` returns **404**, so a
genuine first publish still proceeds.

## 2. The CLIs were floating ranges

`npx --yes @vscode/vsce@^3` is resolved fresh on every run, so the publish decision depended on
the day it ran — the same "the oracle was an npm install, not a pin" shape already recorded for
the lint gates. Pinned to `@vscode/vsce@3.9.2` and `ovsx@0.10.12` behind two named constants.

## 3. The real failure said nothing useful

When the gallery reports no live version **and** the upload is refused as a duplicate name, those
two facts only agree in one situation, and no retry moves it. The publish now prints what has to
happen instead of just rethrowing.

## The blocker, which is not in this repo

`baseballyama.rsvelte-vscode` has been **removed from the Marketplace while its name stays
reserved**. Measured, with a positive control:

| probe | ours | control (`svelte.svelte-vscode`) |
|---|---|---|
| gallery `extensionquery` | no result | `validated, public`, 110.3.1 |
| `vsce show … --json` | prints `undefined`, exit 0 | full JSON |
| `vsce show …` | `ERROR Extension "…" not found.` | — |
| `vsce publish` | `The extension 'rsvelte-vscode' already exists in the Marketplace` | — |

It was live until recently: the 2026-08-19 14:25 run logged
`marketplace version: 0.5.2 → publish: false`, and the 18:18 run the same day logged `(none)`.
Every run since has failed. Open VSX still serves 0.5.2.

That is a publisher-account state. Someone with access has to look at
`marketplace.visualstudio.com/manage/publishers/baseballyama` and either restore the extension or
rename it in `apps/npm/vscode/package.json`. Deciding which is not mine to make, and making the
guard skip instead would only convert a loud failure into releases silently not shipping.


---

## Correction (2026-08-24): the last section's diagnosis was wrong

"Removed while its name stays reserved … that is a publisher-account state" was my inference from
the probe table, and it is **not** what happened. The extension is listed in
`microsoft/vsmarketplace` → `RemovedPackages.md`:

```
| baseballyama.rsvelte-vscode | 8/19/2026 | Malware |
```

Microsoft removed it as malware. The publisher account is intact — `baseballyama.contextualize`
still resolves `validated, public` in the same gallery query — so nothing in
`marketplace.visualstudio.com/manage/publishers/baseballyama` can restore it, and the four probe
rows above are consequences of a block-list entry rather than of an account setting.

**"or rename it in `apps/npm/vscode/package.json`" is retracted outright.** Republishing the same
payload under a different identifier after a malware removal is evasion, not a workaround, and it
would put the publisher account at risk. The only correct path is an appeal to
`vsmarketplace@microsoft.com`.

The likely trigger is the shape #3161 already removed: the flagged 0.5.2 was a single universal
47.88 MB VSIX carrying five unsigned native `rsvelte-language-server` binaries at once. Since
#3161 the pipeline emits one VSIX per platform (one binary each) plus a binary-free universal
fallback, so the flagged artifact is no longer producible — but that does not lift the block-list
entry by itself.

Everything above this line still stands: the three script defects are real and fixed. What
changed is only the identification of the blocker, and the fact that it is not actionable from
inside the Marketplace publisher UI.
