### PR TITLE
ci(release): skip the vscode publish when the name is reserved but unlisted

### DIFF
--- a/.github/workflows/publish-vscode.yml
+++ b/.github/workflows/publish-vscode.yml
@@ -16,6 +16,8 @@ on:
       - 'Cargo.toml'
       - 'Cargo.lock'
       - 'scripts/release/publish-vscode.mjs'
+      - 'scripts/release/vscode-publish-decision.mjs'
+      - 'scripts/release/test-publish-vscode-decision.mjs'
       - 'scripts/release/stage-vscode-language-server-binaries.mjs'
       - 'scripts/release/vscode-targets.mjs'
       - '.github/workflows/publish-vscode.yml'
@@ -47,6 +49,9 @@ jobs:
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '24'
+
+      - name: Self-test the publish decision
+        run: node scripts/release/test-publish-vscode-decision.mjs
 
       - name: Decide whether to publish
         id: decide

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
 		"check:prereq-coverage": "node scripts/ci/prereq-coverage-guard.mjs",
 		"test:prereq-coverage-guard": "node scripts/ci/test-prereq-coverage-guard.mjs",
 		"test:esrap-version-gate": "node scripts/release/test-esrap-version-bump-check.mjs",
+		"test:vscode-publish-decision": "node scripts/release/test-publish-vscode-decision.mjs",
 		"check:lint-types-lock": "node scripts/ci/check-lint-types-lock.mjs",
 		"fix:lint-types-lock": "node scripts/ci/check-lint-types-lock.mjs --fix",
 		"corpus:sync": "git submodule update --init --depth 1 submodules/svelte submodules/svelte.dev submodules/language-tools submodules/bits-ui submodules/flowbite-svelte submodules/melt-ui submodules/shadcn-svelte submodules/sveltestrap submodules/attractions submodules/svelte-ux submodules/smelte submodules/svar-core submodules/svelte-table submodules/powertable submodules/svelte-pivottable submodules/svelte-toast submodules/svelte-sonner submodules/svelte-notifications submodules/svelte-fa submodules/svelte-heroicons submodules/svelte-calendar submodules/date-picker-svelte submodules/svelte-maplibre submodules/layercake submodules/layerchart submodules/svelte-splitpanes submodules/svelte-stepper submodules/svelte-formly submodules/svelte-form-builder submodules/svelte-checkbox submodules/svelte-toggle submodules/svelthree submodules/runed submodules/mode-watcher submodules/svelte-toolbelt submodules/cmsaasstarter submodules/skeleton",

--- a/scripts/release/publish-vscode.mjs
+++ b/scripts/release/publish-vscode.mjs
@@ -28,6 +28,7 @@ import { execFileSync } from 'node:child_process';
 import { appendFileSync, readFileSync, writeFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { decide } from './vscode-publish-decision.mjs';
 import { VSCODE_TARGETS } from './vscode-targets.mjs';
 
 const here = dirname(fileURLToPath(import.meta.url));
@@ -53,17 +54,6 @@ const OVSX = 'ovsx@0.10.12';
 const UNIVERSAL = 'universal';
 /** Every (version, targetPlatform) pair a complete publish produces. */
 const PLATFORMS = [UNIVERSAL, ...VSCODE_TARGETS.map(({ target: t }) => t)];
-
-/** Numeric semver compare for simple `x.y.z` versions (no pre-release). */
-function cmp(a, b) {
-  const pa = a.split('.').map(Number);
-  const pb = b.split('.').map(Number);
-  for (let i = 0; i < 3; i++) {
-    const d = (pa[i] || 0) - (pb[i] || 0);
-    if (d !== 0) return d;
-  }
-  return 0;
-}
 
 /**
  * Marketplace state: the newest LIVE version, and which platforms of `target`
@@ -126,26 +116,26 @@ const mp = await marketplaceState();
 const ovsx = await openvsxState();
 const ovsxPublished = ovsx?.latest ?? null;
 
-// A live Marketplace version newer than ours means the release already moved
-// on; otherwise every platform `target` is missing is still to be published.
-// A failed query (`null`) publishes nothing rather than guessing.
-const missingMp =
-  mp === null || (mp.latest && cmp(target, mp.latest) < 0)
-    ? []
-    : PLATFORMS.filter((p) => !mp.live.has(p));
-const needMp = force || missingMp.length > 0;
-// Only consider Open VSX when a token is available to publish there.
-const needOvsx =
-  hasOvsx &&
-  (force ||
-    (ovsx !== null &&
-      (ovsxPublished === null || cmp(target, ovsxPublished) > 0)));
+const { missingMp, needMp, needOvsx, mpReason } = decide({
+  target,
+  mp,
+  ovsx,
+  hasOvsx,
+  force,
+  platforms: PLATFORMS,
+});
 const shouldPublish = needMp || needOvsx;
+
+const MP_STATE = {
+  'query-failed': '(query failed)',
+  'name-reserved': '(none, but the name is reserved)',
+  superseded: '(newer release is live)',
+};
 
 console.log(`extension:            ${id}`);
 console.log(`target version:       ${target} (follows @rsvelte/language-server)`);
 console.log(
-  `marketplace version:  ${mp === null ? '(query failed)' : (mp.latest ?? '(none)')}` +
+  `marketplace version:  ${MP_STATE[mpReason] ?? mp?.latest ?? '(none)'}` +
     `  → publish: ${needMp}`,
 );
 console.log(
@@ -254,8 +244,15 @@ if (needMp) {
     }
     console.log(`✓ published ${platform} to VS Code Marketplace`);
   }
-} else if (mp === null) {
+} else if (mpReason === 'query-failed') {
   console.log('Marketplace state unknown (query failed) — skipping.');
+} else if (mpReason === 'name-reserved') {
+  console.log(
+    `::warning::${id} is unlisted on the Marketplace while its name stays ` +
+      'reserved, so no publish can succeed. Restore it at ' +
+      `https://marketplace.visualstudio.com/manage/publishers/${extPkg.publisher} ` +
+      'or rename it in apps/npm/vscode/package.json.',
+  );
 } else {
   console.log('Marketplace already up to date — skipping.');
 }

--- a/scripts/release/test-publish-vscode-decision.mjs
+++ b/scripts/release/test-publish-vscode-decision.mjs
@@ -1,0 +1,133 @@
+#!/usr/bin/env node
+// Self-test for scripts/release/vscode-publish-decision.mjs.
+//
+// Every case below pairs a state the guard must publish from with the
+// near-miss it must skip, so a guard that always answered one way fails here.
+// The negative controls are the two that have actually shipped a red `main`:
+// a failed query read as "not published", and an unlisted-but-name-reserved
+// Marketplace read as "not published".
+
+import { cmp, decide } from './vscode-publish-decision.mjs';
+
+const PLATFORMS = ['universal', 'darwin-arm64', 'linux-x64'];
+
+let failures = 0;
+
+function check(name, fn) {
+  try {
+    fn();
+    console.log(`  ok   ${name}`);
+  } catch (err) {
+    failures++;
+    console.error(`  FAIL ${name}\n       ${err.message}`);
+  }
+}
+
+function assert(cond, message) {
+  if (!cond) throw new Error(message);
+}
+
+function run(overrides) {
+  return decide({
+    target: '0.5.2',
+    mp: null,
+    ovsx: null,
+    hasOvsx: false,
+    force: false,
+    platforms: PLATFORMS,
+    ...overrides,
+  });
+}
+
+const live = (...versions) => new Set(versions);
+
+console.log('vscode-publish-decision self-test');
+
+check('cmp orders x.y.z numerically, not lexically', () => {
+  assert(cmp('0.5.10', '0.5.9') > 0, '0.5.10 must be newer than 0.5.9');
+  assert(cmp('0.5.2', '0.5.2') === 0, 'equal versions compare equal');
+  assert(cmp('0.5.2', '0.6.0') < 0, '0.5.2 must be older than 0.6.0');
+});
+
+check('first publish: both registries empty → publish everything', () => {
+  const d = run({ mp: { latest: null, live: live() }, ovsx: { latest: null } });
+  assert(d.needMp === true, 'must publish to the Marketplace');
+  assert(d.missingMp.length === PLATFORMS.length, 'every platform is missing');
+  assert(d.mpReason === 'publish', `reason was ${d.mpReason}`);
+});
+
+check('a failed Marketplace query publishes nothing', () => {
+  const d = run({ mp: null, ovsx: { latest: null } });
+  assert(d.needMp === false, 'an unknown state must not publish');
+  assert(d.mpReason === 'query-failed', `reason was ${d.mpReason}`);
+});
+
+check('a failed Open VSX query publishes nothing there', () => {
+  const d = run({ mp: { latest: null, live: live() }, ovsx: null, hasOvsx: true });
+  assert(d.needOvsx === false, 'an unknown state must not publish');
+});
+
+check('every platform live → nothing to publish', () => {
+  const d = run({
+    mp: { latest: '0.5.2', live: live(...PLATFORMS) },
+    ovsx: { latest: '0.5.2' },
+  });
+  assert(d.needMp === false, 'nothing is missing');
+  assert(d.mpReason === 'up-to-date', `reason was ${d.mpReason}`);
+});
+
+check('one platform missing → only that platform is published', () => {
+  const d = run({
+    mp: { latest: '0.5.2', live: live('universal', 'darwin-arm64') },
+    ovsx: { latest: '0.5.2' },
+  });
+  assert(d.needMp === true, 'the missing platform must be published');
+  assert(
+    d.missingMp.length === 1 && d.missingMp[0] === 'linux-x64',
+    `missing was ${JSON.stringify(d.missingMp)}`,
+  );
+});
+
+check('a newer live release supersedes ours → skip', () => {
+  const d = run({ mp: { latest: '0.6.0', live: live() }, ovsx: { latest: '0.6.0' } });
+  assert(d.needMp === false, 'the release already moved on');
+  assert(d.mpReason === 'superseded', `reason was ${d.mpReason}`);
+});
+
+check('gallery empty while Open VSX already has the target → name reserved, skip', () => {
+  const d = run({ mp: { latest: null, live: live() }, ovsx: { latest: '0.5.2' } });
+  assert(d.needMp === false, 'publishing here is rejected as "already exists"');
+  assert(d.missingMp.length === 0, 'nothing may be packaged for the Marketplace');
+  assert(d.mpReason === 'name-reserved', `reason was ${d.mpReason}`);
+});
+
+check('name-reserved does NOT swallow the next version', () => {
+  // Open VSX behind the target is the discriminating half: the same empty
+  // gallery must still produce a real publish attempt for a new version.
+  const d = run({
+    target: '0.5.3',
+    mp: { latest: null, live: live() },
+    ovsx: { latest: '0.5.2' },
+  });
+  assert(d.needMp === true, 'a new version must still be attempted');
+  assert(d.mpReason === 'publish', `reason was ${d.mpReason}`);
+});
+
+check('force publishes through every skip', () => {
+  for (const mp of [null, { latest: null, live: live() }, { latest: '0.6.0', live: live() }]) {
+    const d = run({ mp, ovsx: { latest: '0.5.2' }, hasOvsx: true, force: true });
+    assert(d.needMp === true, 'force must reach the Marketplace');
+    assert(d.needOvsx === true, 'force must reach Open VSX');
+  }
+});
+
+check('Open VSX is skipped without a token, whatever its state', () => {
+  const d = run({ mp: { latest: null, live: live() }, ovsx: { latest: null }, hasOvsx: false });
+  assert(d.needOvsx === false, 'no token, no publish');
+});
+
+if (failures > 0) {
+  console.error(`\n${failures} case(s) failed`);
+  process.exit(1);
+}
+console.log('\nall cases passed');

--- a/scripts/release/vscode-publish-decision.mjs
+++ b/scripts/release/vscode-publish-decision.mjs
@@ -1,0 +1,65 @@
+// The publish decision for `rsvelte-vscode`, as a pure function of the two
+// registry states, so it can be tested without a network or a token.
+//
+// Three answers have to stay distinguishable per registry, because two of them
+// used to collapse into one and that is what published over a live version:
+// `null`      — the query itself failed; nothing is known
+// `latest: null` — the registry definitively holds no version
+// `latest: x`    — the registry holds `x`
+
+/** Numeric semver compare for simple `x.y.z` versions (no pre-release). */
+export function cmp(a, b) {
+  const pa = a.split('.').map(Number);
+  const pb = b.split('.').map(Number);
+  for (let i = 0; i < 3; i++) {
+    const d = (pa[i] || 0) - (pb[i] || 0);
+    if (d !== 0) return d;
+  }
+  return 0;
+}
+
+/**
+ * @param {object} input
+ * @param {string} input.target            version being published
+ * @param {null | { latest: string | null, live: Set<string> }} input.mp
+ * @param {null | { latest: string | null }} input.ovsx
+ * @param {boolean} input.hasOvsx          an OVSX_PAT is available
+ * @param {boolean} input.force            VSCODE_PUBLISH_FORCE
+ * @param {string[]} input.platforms       every (version, targetPlatform) pair
+ * @returns {{ missingMp: string[], needMp: boolean, needOvsx: boolean,
+ *             mpReason: 'query-failed' | 'name-reserved' | 'superseded' | 'publish' | 'up-to-date' }}
+ */
+export function decide({ target, mp, ovsx, hasOvsx, force, platforms }) {
+  const mpAbsent = mp !== null && mp.latest === null && mp.live.size === 0;
+  const ovsxAtOrAhead =
+    ovsx !== null && ovsx.latest !== null && cmp(ovsx.latest, target) >= 0;
+  // The gallery holding no record of an extension whose target version is
+  // already on Open VSX is a contradiction only one state produces: the
+  // Marketplace copy is unlisted (removed, or failed validation) while its name
+  // stays reserved. `vsce publish` answers that with "already exists", which no
+  // retry moves — so publishing here fails every push until a human restores or
+  // renames the extension. A new version still gets a real attempt, because
+  // Open VSX is then behind and this guard does not fire.
+  const nameReserved = mpAbsent && ovsxAtOrAhead;
+  const superseded = mp !== null && Boolean(mp.latest) && cmp(target, mp.latest) < 0;
+
+  const missingMp =
+    mp === null || nameReserved || superseded
+      ? []
+      : platforms.filter((p) => !mp.live.has(p));
+  const needMp = force || missingMp.length > 0;
+
+  const needOvsx =
+    hasOvsx &&
+    (force ||
+      (ovsx !== null &&
+        (ovsx.latest === null || cmp(target, ovsx.latest) > 0)));
+
+  let mpReason = 'up-to-date';
+  if (needMp) mpReason = 'publish';
+  else if (mp === null) mpReason = 'query-failed';
+  else if (nameReserved) mpReason = 'name-reserved';
+  else if (superseded) mpReason = 'superseded';
+
+  return { missingMp, needMp, needOvsx, mpReason };
+}


### PR DESCRIPTION
Closes #3174

`Publish VS Code Extension` has failed on every push to `main`. The cause the issue
named — a failed `vsce show` read as "not published" — was fixed on 2026-08-21 by
switching to the gallery API, which does separate *failed query* from *absent*. The
workflow kept failing for the state that fix left unmodelled.

## What the registries actually say

Measured here against the live APIs (2026-08-22):

| query | result |
|---|---|
| `extensionquery` for `baseballyama.rsvelte-vscode`, flags 1 / 3 / 33 / 35 | **no extension** under every flag combination, including without `ExcludeNonValidated` |
| `extensionquery` search text `rsvelte` | 0 results |
| `extensionquery` for `svelte.svelte-vscode` (positive control) | 1 result |
| `open-vsx.org/api/baseballyama/rsvelte-vscode` | `0.5.2` — the target version |
| `vsce publish` | `The extension 'rsvelte-vscode' already exists in the Marketplace.` |

The control rules out a broken query. An empty gallery *and* a name the Marketplace
refuses to take is the signature of an extension that is unlisted (removed, or failed
validation) while its name stays reserved — a publisher-account state, not a build
problem, and no retry moves it.

## Change

The decision is extracted to `scripts/release/vscode-publish-decision.mjs` as a pure
function of the two registry states, and gains one rule: an empty gallery whose target
version is **already on Open VSX** is `name-reserved` — publish nothing, and print a
`::warning::` naming the page to restore it on.

The discriminating half is that this must not become a blanket swallow. When the version
moves on, Open VSX is behind, the guard does not fire, and the publish is attempted for
real — so a genuine publish failure is still red. `VSCODE_PUBLISH_FORCE=true` overrides
either way.

The log line now distinguishes `(none)`, `(query failed)`, `(none, but the name is
reserved)` and `(newer release is live)`, which the issue asked for as a negative control.

## Verification

`scripts/release/test-publish-vscode-decision.mjs` (11 cases, wired into the workflow and
`pnpm run test:vscode-publish-decision`) pairs each skip with the near-miss that must
still publish. It is not green by construction: reverting `nameReserved` to `false` fails
exactly one case and leaves the other ten passing.

The real `--check` path against the live registries now prints:

```
marketplace version:  (none, but the name is reserved)  → publish: false
open vsx version:     0.5.2  → publish: false (OVSX_PAT unset)
```

## Still needs a human

This stops `main` going red; it does not republish the extension. To get
`rsvelte-vscode` back on the Marketplace, restore or rename it at
https://marketplace.visualstudio.com/manage/publishers/baseballyama — after which the
gallery reports it and this guard stops firing on its own.
