### PR TITLE
fix(analyze): raise every `<svelte:options>` diagnostic from one attribute walk

### DIFF
--- a/.changeset/svelte-options-deprecations.md
+++ b/.changeset/svelte-options-deprecations.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/compiler": patch
+---
+
+Raise the three `<svelte:options>` diagnostics from one walk of the attribute list, as upstream does. `options_deprecated_accessors` now fires in runes mode (it never did), `options_deprecated_immutable` carries the attribute's span instead of no position at all, `customElement={null}` warns `options_missing_custom_element` again, and the three come out in the source order of the attributes rather than in the order the checks happened to be written.

--- a/compatibility/gate-coverage.md
+++ b/compatibility/gate-coverage.md
@@ -527,6 +527,30 @@ and published code writes it almost never. The coverage is
 `crates/rsvelte_core/tests/a11y_svelte_element_2523.rs`, which constructs one case per rule and
 pairs each `!is_dynamic_element` row with the static element that does raise it.
 
+### Blind spot 2e — the unit is one compile, so a per-process rule is unobservable
+
+Every entry is compiled once per target and its warnings compared in isolation. **[D]** A
+warning whose emission depends on *how many times the compiler has already run* therefore has
+no observable here at any corpus size — the divergence **is** the second call.
+
+Measured (#3239): upstream dedupes the compile-**option** deprecations through a module-level
+`warned` Set in `validate-options.js`, so three `compile()` calls with `{ accessors: true }` in
+one fresh process yield `[options_deprecated_accessors]`, `[]`, `[]`. rsvelte emits the warning
+all three times. Two independent reasons this gate is blind to it: the unit above, and the fact
+that **no corpus entry passes either option** — `targets.mjs` fixes the option set, so blind
+spot 1d (the compile-option surface is one point) covers the same hole from the other side.
+
+The divergence is **deliberate**, not a backlog item: reproducing a module-level `warned` Set
+needs process-global mutable state, and under the parallel NAPI driver *which* file receives the
+single warning would be nondeterministic — worse for a user than over-warning, since a warning
+that lands on an arbitrary file is one a build log cannot be diffed against. It is pinned by
+`compile_option_deprecations_repeat_on_every_call` in
+`crates/rsvelte_core/tests/svelte_options_deprecations.rs` so that a later move to
+once-per-process is a decision rather than a drift. Note the asymmetry the issue's title hides:
+only the **option** path dedupes upstream. The `<svelte:options accessors />` *tag* path is
+raised from `2-analyze/index.js` with no `warn_once` at all, so it warns on every compile in
+both compilers — and that half this gate does see.
+
 ---
 
 ## 4. Compiler error parity

--- a/compatibility/warning-known-failures.client-dev.json
+++ b/compatibility/warning-known-failures.client-dev.json
@@ -7,6 +7,5 @@
 	"svelte-maplibre/src/routes/examples/draggable_custom_marker/+page.svelte",
 	"svelte-maplibre/src/routes/examples/geojson_line_layer/+page.svelte",
 	"svelte-ux/packages/svelte-ux/src/lib/components/Button.svelte",
-	"svelte/packages/svelte/tests/runtime-browser/custom-elements-samples/$$slot-dynamic-content/main.svelte",
 	"svelte/packages/svelte/tests/runtime-legacy/samples/dynamic-element-action-update/main.svelte"
 ]

--- a/compatibility/warning-known-failures.client.json
+++ b/compatibility/warning-known-failures.client.json
@@ -7,6 +7,5 @@
 	"svelte-maplibre/src/routes/examples/draggable_custom_marker/+page.svelte",
 	"svelte-maplibre/src/routes/examples/geojson_line_layer/+page.svelte",
 	"svelte-ux/packages/svelte-ux/src/lib/components/Button.svelte",
-	"svelte/packages/svelte/tests/runtime-browser/custom-elements-samples/$$slot-dynamic-content/main.svelte",
 	"svelte/packages/svelte/tests/runtime-legacy/samples/dynamic-element-action-update/main.svelte"
 ]

--- a/compatibility/warning-known-failures.md
+++ b/compatibility/warning-known-failures.md
@@ -34,8 +34,8 @@ compilers already run on every entry.
 
 ## Why the four per-target files are currently identical
 
-`warning-known-failures.<target>.json` holds the same 10 entries on all four,
-and `warning-position-known-failures.<target>.json` the same 1 entry. That is not a
+`warning-known-failures.<target>.json` holds the same 9 entries on all four,
+and `warning-position-known-failures.<target>.json` 0 entries on all four. That is not a
 bug in the partitioning — almost every warning is produced in Phase 1/2 (parse
 and analyze), before the target is consulted, so a divergence shows up on all
 four targets at once. Only target-specific codes (`node_invalid_placement_ssr`
@@ -46,16 +46,15 @@ and stays sensitive to an entry that starts diverging on a second target while
 already listed for the first. Expect all eight files to move together in a
 burn-down PR.
 
-## Warning codes (`warning-known-failures.<target>.json`, 10 entries each)
+## Warning codes (`warning-known-failures.<target>.json`, 9 entries each)
 
 The multiset of warning **codes** differs: rsvelte warns where upstream does
 not, or stays silent where upstream warns. This is a semantic bug — a user sees
 noise they cannot suppress, or misses a diagnostic they should have seen.
 
-Not every entry is equally bad. Of the 10 entries that still diverge, **3 are
+Not every entry is equally bad. Of the 9 entries that still diverge, **2 are
 under-warnings** — rsvelte stays silent where upstream warns
-(`state_referenced_locally` ×1, `perf_avoid_nested_class` ×2, and
-`options_missing_custom_element` ×1). The other
+(`state_referenced_locally` ×1, `perf_avoid_nested_class` ×2). The other
 7 are noise the user cannot suppress — 14 tuples over three codes
 (`component_name_lowercase` 10, `state_referenced_locally` 2,
 `export_let_unused` 2). Both are defects, but a
@@ -63,7 +62,18 @@ missing diagnostic and an extra one fail differently, and the ratchet count alon
 does not distinguish them; no entry diverges in both directions at once — which
 is what lets the two counts be added:
 
-Partition of `warning-known-failures.<target>.json` by direction: `3 + 7`
+Partition of `warning-known-failures.<target>.json` by direction: `2 + 7`
+
+The `options_missing_custom_element` under-warning that used to sit in the first
+half is gone, and it was one condition rather than a missing pass:
+`<svelte:options customElement={null} />` is skipped by `read_options` *before*
+it sets `component_options.customElement`, but upstream's analyze loop keys on
+the attribute **name**, so it still warns. rsvelte keyed on the parsed option and
+so stayed silent — and the entry that reproduced it,
+`runtime-browser/custom-elements-samples/$$slot-dynamic-content/main.svelte`, is
+the corpus's only file with that spelling. It is inlined as a test in
+`crates/rsvelte_core/tests/svelte_options_deprecations.rs`, so the shape keeps a
+guard now that the ratchet no longer holds it.
 
 Four entries left in #3027, and they are one cause in both directions: phase 2's
 `UpdateExpression` visitor never walked its argument, so `x++` recorded no
@@ -120,18 +130,22 @@ from where the entries happened to cluster in the corpus rather than from
 upstream's control flow — worth remembering when reading the clusters above,
 which were written the same way.
 
-## Warning positions (`warning-position-known-failures.<target>.json`, 1 entry each)
+## Warning positions (`warning-position-known-failures.<target>.json`, 0 entries each)
 
-The codes agree but a `(line, column)` does not. One entry remains, the same
-residual shape as the three cleared before it — rsvelte reports **no position at
-all** (`?:?`) where upstream reports one:
+The codes agree but a `(line, column)` does not. **No entry remains.**
 
-| entry | code |
-|---|---|
-| `svelte/…/migrate/samples/accessors/output.svelte` | `options_deprecated_immutable` |
-
-It is raised from a site that never received the span-attachment pass: the
-`<svelte:options>` reader. An attach-the-span fix at one emission site.
+The last one — `svelte/…/migrate/samples/accessors/output.svelte`, code
+`options_deprecated_immutable`, rsvelte reporting **no position at all** (`?:?`)
+— was the `<svelte:options>` reader, the one emission site the span-attachment
+pass never reached. Reading the whole of upstream's loop rather than attaching a
+span at the one site turned out to matter: the warning was raised from a
+per-option `if`, and upstream raises all three `<svelte:options>` diagnostics
+from a single walk of `root.options.attributes`, which is also what fixes their
+**order** (source order of the attributes, not the order the checks are written
+in) and what makes `options_deprecated_accessors` fire at all. **An empty
+ratchet makes "no worse than last time" a zero-information bar here** — the
+guards are the pinned `(code, line, column)` triples in
+`crates/rsvelte_core/tests/svelte_options_deprecations.rs`.
 
 The three `attribute_avoid_is` entries were the same shape and are fixed:
 upstream passes the attribute node (`2-analyze/visitors/shared/element.js`), and
@@ -141,7 +155,7 @@ neighbouring warnings raised from that same loop were already spanned.
 
 ### How the backlog was cleared
 
-This ratchet held **528** entries per target and now holds 1. Two systemic causes
+This ratchet held **528** entries per target and now holds none. Two systemic causes
 were measured over the 625 entries listed before the a11y half was fixed, which
 carried 967 mismatching tuples between them:
 

--- a/compatibility/warning-known-failures.server-dev.json
+++ b/compatibility/warning-known-failures.server-dev.json
@@ -7,6 +7,5 @@
 	"svelte-maplibre/src/routes/examples/draggable_custom_marker/+page.svelte",
 	"svelte-maplibre/src/routes/examples/geojson_line_layer/+page.svelte",
 	"svelte-ux/packages/svelte-ux/src/lib/components/Button.svelte",
-	"svelte/packages/svelte/tests/runtime-browser/custom-elements-samples/$$slot-dynamic-content/main.svelte",
 	"svelte/packages/svelte/tests/runtime-legacy/samples/dynamic-element-action-update/main.svelte"
 ]

--- a/compatibility/warning-known-failures.server.json
+++ b/compatibility/warning-known-failures.server.json
@@ -7,6 +7,5 @@
 	"svelte-maplibre/src/routes/examples/draggable_custom_marker/+page.svelte",
 	"svelte-maplibre/src/routes/examples/geojson_line_layer/+page.svelte",
 	"svelte-ux/packages/svelte-ux/src/lib/components/Button.svelte",
-	"svelte/packages/svelte/tests/runtime-browser/custom-elements-samples/$$slot-dynamic-content/main.svelte",
 	"svelte/packages/svelte/tests/runtime-legacy/samples/dynamic-element-action-update/main.svelte"
 ]

--- a/compatibility/warning-position-known-failures.client-dev.json
+++ b/compatibility/warning-position-known-failures.client-dev.json
@@ -1,3 +1,1 @@
-[
-	"svelte/packages/svelte/tests/migrate/samples/accessors/output.svelte"
-]
+[]

--- a/compatibility/warning-position-known-failures.client.json
+++ b/compatibility/warning-position-known-failures.client.json
@@ -1,3 +1,1 @@
-[
-	"svelte/packages/svelte/tests/migrate/samples/accessors/output.svelte"
-]
+[]

--- a/compatibility/warning-position-known-failures.server-dev.json
+++ b/compatibility/warning-position-known-failures.server-dev.json
@@ -1,3 +1,1 @@
-[
-	"svelte/packages/svelte/tests/migrate/samples/accessors/output.svelte"
-]
+[]

--- a/compatibility/warning-position-known-failures.server.json
+++ b/compatibility/warning-position-known-failures.server.json
@@ -1,3 +1,1 @@
-[
-	"svelte/packages/svelte/tests/migrate/samples/accessors/output.svelte"
-]
+[]

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/mod.rs
@@ -233,23 +233,6 @@ pub(crate) fn analyze_prepared_component_with_retained(
         analysis.accessors = true;
     }
 
-    // Check for options_missing_custom_element warning
-    // If svelte:options has customElement but the compile options don't have customElement: true
-    if let Some(ref svelte_options) = ast.options
-        && svelte_options.custom_element.is_some()
-        && !options.custom_element
-    {
-        let mut warning = warnings::options_missing_custom_element();
-        if let Some(attr) = svelte_options
-            .attributes
-            .iter()
-            .find(|attr| attr.name.as_str() == "customElement")
-        {
-            warning = warning.at(attr.start, attr.end);
-        }
-        analysis.warnings.push(warning);
-    }
-
     // Extract script content for Phase 3 (avoids re-parsing)
     analysis.extract_scripts(ast, source, retained_scripts);
 
@@ -373,19 +356,29 @@ pub(crate) fn analyze_prepared_component_with_retained(
         }
     }
 
+    // `<svelte:options>` diagnostics run once over the attribute list, so they
+    // come out in source order and each carries its own attribute's span.
+    // Reference: svelte/packages/svelte/src/compiler/phases/2-analyze/index.js L685-698
+    if let Some(ref svelte_options) = ast.options {
+        for attribute in &svelte_options.attributes {
+            let warning = match attribute.name.as_str() {
+                "accessors" if analysis.runes => warnings::options_deprecated_accessors(),
+                "customElement" if !options.custom_element => {
+                    warnings::options_missing_custom_element()
+                }
+                "immutable" if analysis.runes => warnings::options_deprecated_immutable(),
+                _ => continue,
+            };
+            analysis
+                .warnings
+                .push(warning.at(attribute.start, attribute.end));
+        }
+    }
+
     // In runes mode, immutable is always true and accessors is always false
     // (unless it's a custom element). This overrides any options passed by the user.
     // Reference: svelte/packages/svelte/src/compiler/phases/2-analyze/index.js
     if analysis.runes {
-        // `<svelte:options immutable>` is deprecated in runes mode (it has no
-        // effect there). Mirror upstream's analyze-phase warning, which fires
-        // when the `immutable` option attribute is present and runes is on
-        // (2-analyze/index.js). M-061.
-        if ast.options.as_ref().is_some_and(|o| o.immutable.is_some()) {
-            analysis
-                .warnings
-                .push(warnings::options_deprecated_immutable());
-        }
         analysis.immutable = true;
         if analysis.custom_element.is_none() {
             analysis.accessors = false;

--- a/crates/rsvelte_core/tests/svelte_options_deprecations.rs
+++ b/crates/rsvelte_core/tests/svelte_options_deprecations.rs
@@ -1,0 +1,204 @@
+//! `<svelte:options>` deprecation diagnostics, pinned against the official
+//! compiler's `(code, line, column)` triples.
+//!
+//! Upstream raises all three of these from one loop over
+//! `root.options.attributes` (`2-analyze/index.js` L685-698), so they come out
+//! in **attribute source order** and each carries its own attribute's span.
+//! rsvelte instead had two separate sites: `customElement` unconditionally
+//! early, `immutable` later and span-less, and `accessors` not at all — which
+//! is issues #3291/#3224 (missing), #3225 (no span) and the ordering.
+//!
+//! The last test pins a deliberate divergence rather than parity (#3239).
+
+use rsvelte_core::{CompileOptions, GenerateMode, Warning, compile};
+
+fn opts(generate: GenerateMode) -> CompileOptions {
+    CompileOptions {
+        filename: Some("T.svelte".into()),
+        generate,
+        dev: false,
+        ..Default::default()
+    }
+}
+
+/// `(code, "line:column")` per warning, in emission order — the same shape the
+/// official probe prints, so a row can be read straight off it.
+fn warned(src: &str, generate: GenerateMode) -> Vec<(String, String)> {
+    compile(src, opts(generate))
+        .expect("compile")
+        .warnings
+        .into_iter()
+        .map(|w: Warning| {
+            let pos = match (&w.start, &w.end) {
+                (Some(s), Some(e)) => format!("{}:{}-{}:{}", s.line, s.column, e.line, e.column),
+                _ => "none".to_string(),
+            };
+            (w.code, pos)
+        })
+        .collect()
+}
+
+/// Both targets agree in upstream, and every row below was measured on both, so
+/// each assertion runs twice rather than trusting the client to stand for the
+/// server.
+fn assert_both(src: &str, expected: &[(&str, &str)]) {
+    let expected: Vec<(String, String)> = expected
+        .iter()
+        .map(|(c, p)| ((*c).to_string(), (*p).to_string()))
+        .collect();
+    for generate in [GenerateMode::Client, GenerateMode::Server] {
+        assert_eq!(warned(src, generate), expected, "generate={generate:?}");
+    }
+}
+
+/// #3291 / #3224: the bare spelling warned nothing at all.
+#[test]
+fn accessors_warns_in_runes_mode() {
+    assert_both(
+        "<svelte:options accessors />\n<script>\n\tlet n = $state(1);\n</script>\n\n<b>{n}</b>",
+        &[("options_deprecated_accessors", "1:16-1:25")],
+    );
+}
+
+/// The explicit spelling too — upstream keys on the attribute's presence, not
+/// on its value, so `={true}` warns and the span covers the whole attribute.
+#[test]
+fn accessors_true_warns_and_spans_the_whole_attribute() {
+    assert_both(
+        "<svelte:options accessors={true} />\n<script>\n\tlet n = $state(1);\n</script>\n<b>{n}</b>",
+        &[("options_deprecated_accessors", "1:16-1:32")],
+    );
+}
+
+/// The negative control that makes this a runes-mode arm rather than a missing
+/// table entry: neither compiler warns in legacy mode.
+#[test]
+fn accessors_silent_in_legacy_mode() {
+    assert_both("<svelte:options accessors />\n<div>hi</div>", &[]);
+    assert_both(
+        "<svelte:options runes={false} accessors />\n<script>let n = 1;</script>\n<b>{n}</b>",
+        &[],
+    );
+}
+
+/// #3225: the code and the mode gate were already right; only the span was
+/// missing. `1:16` is the attribute's own start, not the tag's.
+#[test]
+fn immutable_carries_the_attribute_span() {
+    assert_both(
+        "<svelte:options immutable />\n<script>\n\tlet n = $state(1);\n</script>\n\n<b>{n}</b>",
+        &[("options_deprecated_immutable", "1:16-1:25")],
+    );
+}
+
+#[test]
+fn immutable_silent_in_legacy_mode() {
+    assert_both("<svelte:options immutable />\n<div>hi</div>", &[]);
+}
+
+/// One loop over the attribute list means the emission order is the source
+/// order of the attributes, which no per-check site can reproduce: here
+/// `immutable` precedes `accessors` even though upstream's `switch` tests
+/// `accessors` first.
+#[test]
+fn warnings_follow_attribute_source_order() {
+    assert_both(
+        "<svelte:options immutable accessors />\n<script>\n\tlet n = $state(1);\n</script>\n\n<b>{n}</b>",
+        &[
+            ("options_deprecated_immutable", "1:16-1:25"),
+            ("options_deprecated_accessors", "1:26-1:35"),
+        ],
+    );
+}
+
+/// The same two codes across the two sites rsvelte used to emit from, in both
+/// orders — `customElement` was pushed ahead of everything regardless of where
+/// it sat in the tag.
+#[test]
+fn custom_element_and_accessors_interleave_by_position() {
+    assert_both(
+        "<svelte:options customElement=\"my-el\" accessors />\n<script>\n\tlet n = $state(1);\n</script>\n<p>{n}</p>",
+        &[
+            ("options_missing_custom_element", "1:16-1:37"),
+            ("options_deprecated_accessors", "1:38-1:47"),
+        ],
+    );
+    assert_both(
+        "<svelte:options accessors customElement=\"my-el\" />\n<script>\n\tlet n = $state(1);\n</script>\n<p>{n}</p>",
+        &[
+            ("options_deprecated_accessors", "1:16-1:25"),
+            ("options_missing_custom_element", "1:26-1:47"),
+        ],
+    );
+}
+
+/// `customElement={null}` is skipped by `read_options` before it sets
+/// `component_options.customElement`, but the analyze loop keys on the
+/// attribute *name*, so upstream still warns. rsvelte keyed on the parsed
+/// option and so stayed silent.
+#[test]
+fn custom_element_null_still_warns() {
+    assert_both(
+        "<svelte:options customElement={null} />\n<script>let x = 0;</script>\n{x}",
+        &[("options_missing_custom_element", "1:16-1:36")],
+    );
+}
+
+/// The corpus warning-**code** ratchet's only `options_missing_custom_element`
+/// entry, inlined:
+/// `svelte/…/runtime-browser/custom-elements-samples/$$slot-dynamic-content/main.svelte`.
+/// Keeping it here means the entry can be removed from the ratchet without the
+/// shape losing its only guard.
+#[test]
+fn corpus_entry_custom_element_null_sample() {
+    assert_both(
+        "<!-- before Svelte 4 it was necessary to explicitly set customElement to null or else you'd get a warning. Keep this around for backwards compat -->\n<svelte:options customElement={null} />\n\n<script>\n\timport \"./my-widget.svelte\";\n\texport let name;\n</script>\n\n<my-widget>\n\t<p>default {name}</p>\n</my-widget>\n",
+        &[("options_missing_custom_element", "2:16-2:36")],
+    );
+}
+
+/// The corpus warning-**position** ratchet's only entry, inlined:
+/// `svelte/…/migrate/samples/accessors/output.svelte`. It is the shape that
+/// made `<svelte:options>` the one emission site the span-attachment pass never
+/// reached — a runes component whose `<svelte:options immutable/>` trails the
+/// markup, so the span is nowhere near the tag's own start either.
+#[test]
+fn corpus_entry_trailing_immutable_sample() {
+    assert_both(
+        "<script lang=\"ts\">\n\t\n\t\n\tinterface Props {\n\t\ttest: string;\n\t\tcount?: number;\n\t\tstuff: any;\n\t\tcool?: import('svelte').Snippet;\n\t}\n\n\tlet {\n\t\tcount = 0,\n\t\tstuff,\n\t\tcool\n\t}: Props = $props();\n\n\texport {\n\t\tcount,\n\t\tstuff,\n\t}\n</script>\n\n<button>\n\t{@render cool?.()}\n</button>\n\n<svelte:options immutable/>",
+        &[("options_deprecated_immutable", "27:16-27:25")],
+    );
+}
+
+/// #3239, pinned as a **deliberate** divergence, not as parity.
+///
+/// Upstream dedupes compile-*option* deprecations through a module-level
+/// `warned` Set in `validate-options.js`, so a second `compile()` in the same
+/// process reports nothing. Reproducing that in rsvelte needs process-global
+/// mutable state, which would make *which* file receives the single warning
+/// nondeterministic under the parallel NAPI driver. We warn every time; this
+/// test exists so that a future change to once-per-process is a deliberate
+/// choice rather than a silent one.
+#[test]
+fn compile_option_deprecations_repeat_on_every_call() {
+    let src = "<script>let n = 1;</script>\n<b>{n}</b>";
+    for _ in 0..3 {
+        let warnings = compile(
+            src,
+            CompileOptions {
+                accessors: true,
+                ..opts(GenerateMode::Client)
+            },
+        )
+        .expect("compile")
+        .warnings;
+        assert_eq!(
+            warnings.iter().map(|w| w.code.as_str()).collect::<Vec<_>>(),
+            ["options_deprecated_accessors"],
+        );
+        assert!(
+            warnings[0].start.is_none(),
+            "an option diagnostic has no node to point at"
+        );
+    }
+}

--- a/crates/rsvelte_core/tests/svelte_options_public.rs
+++ b/crates/rsvelte_core/tests/svelte_options_public.rs
@@ -36,19 +36,15 @@ fn explicit_runes_false_is_not_undone_by_autodetection() {
     );
 }
 
-/// H-115: `customElement={null}` must NOT enable the custom-element pipeline,
-/// so no `options_missing_custom_element` warning is produced.
+/// H-115: `customElement={null}` must NOT enable the custom-element pipeline.
+/// The observable is the emitted JS: `read_options` skips the attribute before
+/// it sets `component_options.customElement`. The warning is *not* an
+/// observable of that — upstream's analyze loop keys on the attribute name, so
+/// it warns here too (pinned in `svelte_options_deprecations.rs`).
 #[test]
 fn custom_element_null_does_not_enable_pipeline() {
     let src = "<svelte:options customElement={null} />\n<script>let x = 0;</script>\n{x}";
     let result = compile(src, opts(None, true)).expect("should compile");
-    assert!(
-        !result
-            .warnings
-            .iter()
-            .any(|w| w.code == "options_missing_custom_element"),
-        "customElement={{null}} wrongly enabled the custom-element pipeline"
-    );
     assert!(
         !result.js.code.contains("customElement"),
         "{}",

--- a/scripts/dev/test-known-failures-md-check.mjs
+++ b/scripts/dev/test-known-failures-md-check.mjs
@@ -230,8 +230,8 @@ withCorpus(
 		edit(
 			d,
 			'warning-known-failures.md',
-			'`warning-position-known-failures.<target>.json` the same 1 entry',
-			'`warning-position-known-failures.<target>.json` the same 5 entries',
+			'`warning-position-known-failures.<target>.json` 0 entries on all four',
+			'`warning-position-known-failures.<target>.json` 5 entries on all four',
 		),
 	(r) => check('a stale restatement fails', [r.code, /states 5 entries/.test(r.out)], [1, true]),
 );


### PR DESCRIPTION
Four issues, one cause: rsvelte had **two** `<svelte:options>` diagnostic sites where upstream
has one loop.

Upstream raises all three of them from a single walk of `root.options.attributes`
(`phases/2-analyze/index.js` L685-698):

```js
if (root.options) {
	for (const attribute of root.options.attributes) {
		if (attribute.name === 'accessors' && analysis.runes) w.options_deprecated_accessors(attribute);
		if (attribute.name === 'customElement' && !custom_element_from_option) w.options_missing_custom_element(attribute);
		if (attribute.name === 'immutable' && analysis.runes) w.options_deprecated_immutable(attribute);
	}
}
```

rsvelte instead had `customElement` in one `if` early in `analyze_prepared_component_with_retained`,
`immutable` in another `if` ~140 lines later inside the runes block, and `accessors` nowhere. Four
consequences, three of them filed:

| | before | after |
|---|---|---|
| `<svelte:options accessors />` in runes mode | no warning | `options_deprecated_accessors` @ the attribute (#3224, #3291) |
| `<svelte:options immutable />` in runes mode | warned with `start`/`end` `undefined` | warned at `1:16-1:25` (#3225) |
| `<svelte:options customElement={null} />` | no warning | `options_missing_custom_element` (not filed; found here) |
| `<svelte:options immutable accessors />` | order fixed by which `if` ran first | attribute **source** order |

Both mode gates keep their negative control: neither compiler warns for `accessors` / `immutable`
in legacy mode, nor under an explicit `<svelte:options runes={false} accessors />`.

The `customElement={null}` row is the one that was not filed. `read_options` `break`s on that
spelling *before* it sets `component_options.customElement`, so rsvelte — which keyed on the parsed
option — stayed silent; upstream's loop keys on the attribute **name** and warns. The existing
`custom_element_null_does_not_enable_pipeline` test asserted the absence of that warning as if it
were the observable for "the pipeline is off". It is not: the observable is the emitted JS, which
the same test already checks. The warning assertion is dropped and the real behaviour pinned.

## Every `(code, line, column)` here was measured against official 5.56.9, not derived

`crates/rsvelte_core/tests/svelte_options_deprecations.rs` (11 tests) pins the exact triples, and
each row runs on **both** targets rather than letting client stand for server.

## Ratchets: two entries removed, by hand, without `--update-warning-baseline`

Per the coordinator's ordering constraint (PR #3176 is re-measuring the corpus ratchets on a newer
merge base), this PR takes **option 2**: no baseline flag was run. Exactly the two entries whose
PASS I reproduced locally were deleted:

- `warning-position-known-failures.*.json` — the file's **only** entry,
  `svelte/…/migrate/samples/accessors/output.svelte` (`options_deprecated_immutable` with no
  position). The ratchet is now empty on all four targets.
- `warning-known-failures.*.json` — `svelte/…/custom-elements-samples/$$slot-dynamic-content/main.svelte`,
  the `options_missing_custom_element` under-warning. 10 → 9 per target.

Both sources are inlined verbatim as tests (`corpus_entry_*`), so removing them from a shrink-only
ratchet does not leave the shape unguarded — an empty ratchet makes "no worse than last time" a
zero-information bar. `compatibility/warning-known-failures.md` is updated with the counts, the
partition (`2 + 7`), and why each entry went; `node scripts/compat-corpus/known-failures-md-check.mjs`
passes, and its self-test's stale literal was updated with it.

## #3239 — decided as **option 2** (keep warning; record the divergence)

The issue offers three and picks none. This PR picks *keep warning every time, and make the
divergence a gated, documented decision*, for reasons that are structural rather than
preference:

1. **Option 1 (process-global `warned` set) buys exact parity and sells determinism.** Upstream's
   set is module-level in `validate-options.js`; the Rust equivalent is process-global mutable
   state, which this repo has a standing rule against in the compiler, and under the parallel NAPI
   driver *which* file receives the single warning becomes a race. A warning that lands on an
   arbitrary one of 200 files is worse for a build log than 200 identical warnings, because it
   cannot be diffed run to run.
2. It is also a latent flake generator inside our own suites: Rust runs a test binary's tests as
   threads of **one** process, and `runtime.rs` compiles all 1207 runtime-legacy fixtures with
   `accessors: true`. Under a process-global set, 1206 of them would silently stop reporting it.
3. **Option 3 (once per `compile_both` / per NAPI call) is not a fix for the reported scenario.**
   The 200-component build calls `compile` 200 times; per-call dedup is what we already do.
4. Upstream itself does not rely on the behaviour — `runtime-browser/test.ts:100` filters
   `options_deprecated_accessors` out rather than expecting it once.

Worth separating, because the issue title does not: **only the compile-option path dedupes
upstream.** The `<svelte:options accessors />` *tag* path (#3224/#3291, fixed above) is raised from
`2-analyze/index.js` with no `warn_once` at all, so it warns on every compile in both compilers.
The two halves are independent.

The decision is recorded twice so it cannot rot silently: `compile_option_deprecations_repeat_on_every_call`
pins the current behaviour (three compiles → three warnings, each position-less), and
`compatibility/gate-coverage.md` gets **blind spot 2e** — the warning gate's unit is one compile,
so a rule that depends on how many times the compiler has already run has no observable there at
any corpus size. The divergence *is* the second call.

Closes #3224
Closes #3291
Closes #3225
Closes #3239
