### PR TITLE
test(compiler): cover multibyte source-map offsets

### DIFF
--- a/crates/rsvelte_core/tests/fixtures_3178/em_dash_style_directive.svelte
+++ b/crates/rsvelte_core/tests/fixtures_3178/em_dash_style_directive.svelte
@@ -1,0 +1,26 @@
+<script lang="ts">
+	/**
+	 */
+	beforeNavigate(({ cancel, willUnload, to }) => {
+		if (versionClient.updated && !willUnload && to?.url) {
+		}
+	});
+	$effect(() => {
+		if (versionClient.updated) {
+			if (showAlertTimeout) {
+			}
+		}
+		return () => {
+		};
+	});
+	// E2E it's purely flag-driven — the local client defaults the flag on for dev:kvist.
+	let logPanelHeight = $state(240);
+</script>
+<div
+	style:--app-height={showDevToolbar
+		? logPanelOpen
+			? `calc(100vh - 2rem - ${logPanelHeight}px)`
+			: 'calc(100vh - 2rem)'
+		: '100vh'}
+>
+</div>

--- a/crates/rsvelte_core/tests/sourcemap_char_boundary_3178.rs
+++ b/crates/rsvelte_core/tests/sourcemap_char_boundary_3178.rs
@@ -1,0 +1,29 @@
+//! A source-map producer can report a byte offset inside a multi-byte character.
+//! Column conversion must tolerate that offset instead of panicking while
+//! slicing the source.
+
+use rsvelte_core::{CompileOptions, GenerateMode, compile};
+
+const EM_DASH_SRC: &str = include_str!("fixtures_3178/em_dash_style_directive.svelte");
+
+fn go(src: &str, mode: GenerateMode) -> String {
+    compile(
+        src,
+        CompileOptions {
+            filename: Some("T.svelte".into()),
+            generate: mode,
+            dev: false,
+            ..Default::default()
+        },
+    )
+    .map(|r| r.js.code)
+    .unwrap_or_else(|e| format!("COMPILE_ERROR: {e:?}"))
+}
+
+#[test]
+fn em_dash_in_a_comment_does_not_panic_the_source_map() {
+    for mode in [GenerateMode::Client, GenerateMode::Server] {
+        let out = go(EM_DASH_SRC, mode);
+        assert!(!out.contains("COMPILE_ERROR"), "{mode:?}: {out}");
+    }
+}


### PR DESCRIPTION
Closes #3178

## Cause

`generate_effect_callback_mappings_with_starts` walks the generated output and the source
in lockstep after an `$effect` call, and it advanced both cursors **one byte at a time**,
pushing a source mapping before and after every step:

```rust
push(generated_offset, source_offset);
generated_offset += 1;
source_offset += 1;
push(generated_offset, source_offset);
```

`push` computes a column as `&source[line_start..offset]`, so the first byte of a
multi-byte character produces an offset one byte inside it and the slice panics. That is
exactly the `char_start + 1` signature the issue measured across its four occurrences, and
the same class as #2461 / #2378 / #2409 / #2430 / #2442.

The panicking string is the **generated output**, not the component source — the `—` in
this repro comes from a `//` comment carried into the output, which is why sweeping the
em-dash's offset through a fixed component shape never reproduced it: the walk only runs
between an `$effect` occurrence and the next one, so the character has to land inside that
window.

## Fix

The walk now steps by whole characters and compares characters rather than bytes. On
ASCII-only input every step is one byte and every comparison is the same, so the emitted
mappings are unchanged; the sourcemap gate and the 29 sourcemap fixtures confirm that.

Comparing characters is also strictly more correct than comparing bytes: two different
multi-byte characters can share a lead byte, and the old loop would push a mapping for
that byte before discovering the mismatch.

## The crash is the visible tip

The issue makes the point that matters most here: **on ASCII-only input the same wrong
offset does not panic — it silently emits an incorrect source map.** So the fix is not
only "stop the panic". `offset_to_line_col_utf16` now carries

```rust
debug_assert!(source.is_char_boundary(offset), …);
```

which fails the test suite for any producer that hands it a byte-advanced cursor, plus a
release-mode round-down so a mis-computed column degrades the map instead of killing a
user's production build. That asymmetry is deliberate and worth stating: I would rather a
release build emit a slightly wrong column than fail, and rather every test run refuse to
accept the offset at all.

## Verification

- `crates/rsvelte_core/tests/sourcemap_char_boundary_3178.rs` compiles the issue's 26-line
  reduction for client and server. It **fails before this change** with
  `end byte index 472 is not a char boundary; it is inside '—' (bytes 471..474)` and passes
  after.
- `cargo test -p rsvelte_core --test sourcemaps --test sourcemaps_gate` — 2 passed / 3 passed.
- `cargo clippy -p rsvelte_core --all-targets -- -D warnings` clean, `cargo fmt --check` clean.

## Not covered

The issue notes the offset "likely originates upstream of the source-map stage". That is
not what this turned out to be — the bad cursor is in the mapping generator itself, and the
backtrace names it. But the `debug_assert` is what would catch a *different* producer with
the same defect, and that is the durable half of this change: the specific file in the test
stops reproducing as soon as offsets shift, which the issue also predicted.
