### PR TITLE
fix(svelte2tsx): rune references enter runes mode, and the export walk mirrors upstream's

### DIFF
--- a/.changeset/s2t-runes-reference-and-namespace-export.md
+++ b/.changeset/s2t-runes-reference-and-namespace-export.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/svelte2tsx": patch
+---
+
+Two svelte2tsx projections. Runes mode is now entered on a *reference* to `$state` / `$derived` / `$effect`, matching upstream's membership test over the `$`-prefixed globals set, instead of only on a rune *call* — so `{$state}`, `void $derived` and `{#each $effect as …}` no longer type the component as a legacy class component. And the instance-script export walk mirrors upstream's: `export namespace` / `export enum` / `export import` keep the `export` keyword upstream never strips, an `export` nested in a `namespace` / `declare module` / `declare global` body is lifted into the component's prop and export surface, and an export with no initializer is a required prop regardless of `let` / `const` / `var`.

--- a/crates/rsvelte_projection/src/svelte2tsx/nodes/runes_detection.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/nodes/runes_detection.rs
@@ -550,51 +550,47 @@ fn expression_references_rune_global(
     }
 }
 
-/// Check whether a callee `JsNode` directly IS a rune-global call target.
+/// Check whether a `JsNode` in head position IS a rune-global reference.
 ///
-/// A callee is a rune-global target when it is:
-///   - An `Identifier` named `$state`/`$derived`/`$effect`  (direct call: `$state(x)`)
-///   - A `MemberExpression` whose object is such an identifier  (`$state.eager(x)`)
+/// A node is a rune-global reference when it is:
+///   - An `Identifier` named `$state`/`$derived`/`$effect`  (`{$state}`, `$state(x)`)
+///   - A `MemberExpression` whose object is such a reference  (`$state.eager`)
 ///
-/// This intentionally does NOT recurse further — if the callee is something more
-/// complex, it is not a rune call pattern.
-#[inline]
-fn js_callee_is_rune_global(
-    callee: &crate::ast::typed_expr::JsNode,
+/// This intentionally does NOT look at the member *property*: upstream skips a
+/// `$`-identifier that is the property half of a property access.
+fn js_head_is_rune_global(
+    node: &crate::ast::typed_expr::JsNode,
     arena: &crate::ast::arena::ParseArena,
 ) -> bool {
     use crate::ast::typed_expr::JsNode;
-    match callee {
+    match node {
         JsNode::Identifier { name, .. } => is_rune_global_name(name.as_str()),
         JsNode::MemberExpression { object, .. } => {
-            let obj = arena.get_js_node(*object);
-            matches!(obj, JsNode::Identifier { name, .. } if is_rune_global_name(name.as_str()))
+            js_head_is_rune_global(arena.get_js_node(*object), arena)
         }
         _ => false,
     }
 }
 
 /// Walk a `JsNode` (typed AST node stored in the parse arena) looking for a
-/// `$state`/`$derived`/`$effect` rune call anywhere in the expression tree.
+/// `$state`/`$derived`/`$effect` rune-global REFERENCE anywhere in the tree.
 ///
-/// A RUNE CALL means the global is used as a call callee or as the object of a
-/// member-expression that is itself used as a call callee.  A bare `$state`
-/// identifier that is just a store auto-subscription (`{$state}`) does NOT match.
+/// Upstream needs only a reference: `getGlobals()` collects every unshadowed
+/// `$`-prefixed identifier and `checkGlobalsForRunes` tests that set for
+/// membership of the three rune names. A call is not required, so `{$state}`,
+/// `{$state.x}` and `{#each $state as …}` all count.
 ///
 /// Handles patterns like:
-///   - `$state(x)`                     → `CallExpression` callee = Identifier "$state"
+///   - `{$state}`                      → bare `Identifier`
 ///   - `$state.eager(x)`               → `CallExpression` callee = `MemberExpression` { object = Identifier "$state" }
-///   - `$effect.pre(() => …)`          → same
-///   - `foo($state(x))`                → arguments contain a rune `CallExpression`
+///   - `foo($state)`                   → arguments contain the reference
 ///   - `a === '/' ? $state(x) : null`  → `ConditionalExpression` branches
 ///   - `() => $effect(() => {})`       → `ArrowFunctionExpression` body
-///   - `{@attach $effect(() => {})}`   → `ArrowFunctionExpression` body in `AttachTag`
-///   - `[..., $state(x)]`              → `ArrayExpression` element
-///   - `{ k: $derived(v) }`            → `ObjectExpression` property value
+///   - `[..., $state]`                 → `ArrayExpression` element
+///   - `{ k: $derived }`               → `ObjectExpression` property value
 ///
-/// Does NOT match:
-///   - `{$state}` (bare store auto-subscription; no call)
-///   - `$state + 1` (store ref in arithmetic; no call)
+/// Does NOT match `obj.$state` — upstream skips a `$`-identifier in the property
+/// half of a property access.
 ///
 /// Reference: official `implicitStoreValues` collects ALL undeclared globals,
 /// including those inside nested function bodies passed to directives.
@@ -603,18 +599,20 @@ fn js_node_references_rune_global(
     arena: &crate::ast::arena::ParseArena,
 ) -> bool {
     use crate::ast::typed_expr::JsNode;
+    if js_head_is_rune_global(node, arena) {
+        return true;
+    }
     match node {
-        // CallExpression: the callee must be a rune-global target (direct call
-        // `$state(...)` or member-call `$state.eager(...)`).  Also recurse into
-        // arguments so nested rune calls like `foo($state(x))` are caught.
+        // CallExpression: the callee may be the rune global (direct call
+        // `$state(...)` or member-call `$state.eager(...)`), handled by the head
+        // check above. Recurse into arguments to catch `foo($state)`.
         JsNode::CallExpression {
             callee, arguments, ..
         } => {
             let callee_node = arena.get_js_node(*callee);
-            if js_callee_is_rune_global(callee_node, arena) {
+            if js_node_references_rune_global(callee_node, arena) {
                 return true;
             }
-            // Recurse into arguments to catch `foo($state(x))`.
             let args = arena.get_js_children(*arguments);
             args.iter()
                 .any(|arg| js_node_references_rune_global(arg, arena))
@@ -735,20 +733,33 @@ fn js_node_references_rune_global(
             argument.is_some_and(|a| js_node_references_rune_global(arena.get_js_node(a), arena))
         }
 
-        // Bare Identifier (e.g. `{$state}` — store auto-subscription) → NOT a rune call.
-        // MemberExpression without being called (e.g. `$state.value` as a bare expr) → NOT a rune call.
-        // These are legitimate store/object references, not rune invocations.
+        // A computed member (`a[$state]`) still reaches the reference through
+        // its property expression; the static form is covered by the head check.
+        JsNode::MemberExpression {
+            object,
+            property,
+            computed,
+            ..
+        } => {
+            js_node_references_rune_global(arena.get_js_node(*object), arena)
+                || (*computed
+                    && js_node_references_rune_global(arena.get_js_node(*property), arena))
+        }
         _ => false,
     }
 }
 
-/// Scan a raw source slice (from a `Lazy` expression) for a rune-global CALL.
+/// Scan a raw source slice (from a `Lazy` expression) for a rune-global
+/// REFERENCE.
 ///
-/// Only triggers when `$state`/`$derived`/`$effect` is immediately followed by
-/// `(` (direct call) or `.` (member call like `$state.eager(…)`).  A bare
-/// `$state` with no following `(` or `.` is a store auto-subscription reference
-/// and must NOT trigger runes mode.
+/// Upstream needs only a reference, so a bare `$state` counts; the match must
+/// still be a whole identifier (not `$state_machine`, not `obj.$state`).
 fn lazy_slice_references_rune_global(slice: &str) -> bool {
+    const fn is_ident_byte(b: u8) -> bool {
+        b.is_ascii_alphanumeric() || b == b'_' || b == b'$' || b >= 0x80
+    }
+
+    let bytes = slice.as_bytes();
     for candidate in &["$state", "$derived", "$effect"] {
         // A rune whose base is shadowed by a declared instance var is a store
         // sub, not a rune (see SHADOWED_RUNE_BASES).
@@ -759,14 +770,14 @@ fn lazy_slice_references_rune_global(slice: &str) -> bool {
         while let Some(rel) = slice[search_from..].find(candidate) {
             let idx = search_from + rel;
             let after = idx + candidate.len();
-            if after < slice.len() {
-                let next = slice.as_bytes()[after];
-                // Require `(` (direct call) or `.` (member call).
-                // Also ensure the match is not inside a longer identifier
-                // (e.g. `$state_machine` — `$` is a valid JS identifier char).
-                if next == b'(' || next == b'.' {
-                    return true;
-                }
+            // `$` is a valid identifier byte, so the preceding byte alone
+            // separates a reference from the tail of a longer name; a `.`
+            // before it makes this the property half of a property access.
+            let boundary_before =
+                idx == 0 || !(is_ident_byte(bytes[idx - 1]) || bytes[idx - 1] == b'.');
+            let boundary_after = after >= bytes.len() || !is_ident_byte(bytes[after]);
+            if boundary_before && boundary_after {
+                return true;
             }
             search_from = idx + 1;
         }

--- a/crates/rsvelte_projection/src/svelte2tsx/nodes/runes_detection.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/nodes/runes_detection.rs
@@ -357,7 +357,7 @@ fn template_node_has_rune_global(
             expression_references_rune_global(&tag.expression, source, arena)
         }
         // AttachTag ({@attach expr}) — the expression may contain nested
-        // rune calls, e.g. `{@attach $effect(() => { ... })}`.
+        // rune references, e.g. `{@attach $effect(() => { ... })}`.
         // Reference: official svelte2tsx collects `@attach` expression globals
         // via `implicitStoreValues` just like any other template expression.
         TemplateNode::AttachTag(tag) => {
@@ -477,7 +477,7 @@ fn attr_has_rune_global(
             .as_ref()
             .is_some_and(|e| expression_references_rune_global(e, source, arena)),
 
-        // let:item — rarely carries a rune call, but check for completeness.
+        // let:item — rarely carries a rune reference, but check for completeness.
         Attribute::LetDirective(l) => l
             .expression
             .as_ref()
@@ -512,14 +512,6 @@ fn is_rune_global_name(name: &str) -> bool {
 /// For `Typed` expressions, walks the `JsNode` tree stored in the parse arena.
 /// For `Lazy` expressions (raw source spans), scans the source text.
 /// For `Value` (JSON) expressions, inspects the JSON AST.
-///
-/// The walk is deliberately shallow-but-sufficient: it recurses into the callee
-/// of a `CallExpression` and the object of a `MemberExpression` (the two patterns
-/// that can reference a rune global — `$state(x)` and `$state.eager(x)`) but
-/// does NOT recurse into every sub-expression.  Template expressions that use
-/// rune globals almost always have the global as the outermost callee or
-/// member-expression object, so this covers all real-world cases while keeping
-/// the implementation simple and fast.
 ///
 /// Reference: ExportedNames.ts `checkGlobalsForRunes` which sets
 ///   `hasRunesGlobals` when any of `$state`/`$derived`/`$effect` appear as an
@@ -728,7 +720,7 @@ fn js_node_references_rune_global(
             init.is_some_and(|i| js_node_references_rune_global(arena.get_js_node(i), arena))
         }
 
-        // ReturnStatement / IfStatement bodies can also host rune calls.
+        // ReturnStatement / IfStatement bodies can also host a rune reference.
         JsNode::ReturnStatement { argument, .. } => {
             argument.is_some_and(|a| js_node_references_rune_global(arena.get_js_node(a), arena))
         }

--- a/crates/rsvelte_projection/src/svelte2tsx/script/ast_utils.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/script/ast_utils.rs
@@ -14,9 +14,16 @@ impl ExportBindingOptions {
     const IS_PROP: u8 = 1 << 1;
     const IS_LET: u8 = 1 << 2;
     const IS_NAMED_EXPORT: u8 = 1 << 3;
+    const IS_REQUIRED: u8 = 1 << 4;
 
     pub(super) const fn new() -> Self {
         Self(0)
+    }
+    pub(super) const fn with_required_if(mut self, enabled: bool) -> Self {
+        if enabled {
+            self.0 |= Self::IS_REQUIRED;
+        }
+        self
     }
     pub(super) const fn with_default(mut self) -> Self {
         self.0 |= Self::HAS_DEFAULT;
@@ -55,7 +62,8 @@ pub(super) fn extract_names_from_binding_pattern_full(
                     .with_default_if(options.contains(ExportBindingOptions::HAS_DEFAULT))
                     .with_prop_if(options.contains(ExportBindingOptions::IS_PROP))
                     .with_let_if(options.contains(ExportBindingOptions::IS_LET))
-                    .with_named_export_if(options.contains(ExportBindingOptions::IS_NAMED_EXPORT)),
+                    .with_named_export_if(options.contains(ExportBindingOptions::IS_NAMED_EXPORT))
+                    .with_required_if(options.contains(ExportBindingOptions::IS_REQUIRED)),
             );
         }
         oxc::BindingPattern::ObjectPattern(obj_pat) => {

--- a/crates/rsvelte_projection/src/svelte2tsx/script/export_decl.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/script/export_decl.rs
@@ -57,18 +57,20 @@ pub(super) fn handle_export_named_decl(
         // For instance scripts: remove the 'export ' keyword (replace with space).
         // For module scripts: keep the 'export' keyword (it's a real module export).
         //
-        // Type-only declarations (`export type X` / `export interface X`) are the
-        // exception: official svelte2tsx keeps their `export` keyword (they're
-        // moved verbatim by `HoistableInterfaces` and re-surface as part of the
-        // component's type API), so stripping it here would both diverge from
-        // upstream and, once the declaration is hoisted above `$$render()`,
-        // leave a dangling space. Skip the strip for those.
-        let is_type_only_decl = matches!(
+        // Upstream only ever removes it from the three node kinds its walk has a
+        // handler for — `handleVariableStatement`, plus `handleExportFunctionOrClass`
+        // for a function and a class. Every other exported declaration
+        // (`export type` / `export interface` / `export namespace` / `export enum` /
+        // `export import x =`) keeps its `export` keyword, so mirror the allow-list
+        // rather than enumerating exceptions: a kind nobody thought of must default
+        // to "left alone", which is what upstream does.
+        let strips_export_keyword = matches!(
             decl,
-            oxc::Declaration::TSTypeAliasDeclaration(_)
-                | oxc::Declaration::TSInterfaceDeclaration(_)
+            oxc::Declaration::VariableDeclaration(_)
+                | oxc::Declaration::FunctionDeclaration(_)
+                | oxc::Declaration::ClassDeclaration(_)
         );
-        if is_instance && !is_type_only_decl && decl_start > node_start {
+        if is_instance && strips_export_keyword && decl_start > node_start {
             str.overwrite(node_start, decl_start, " ");
         }
 
@@ -109,7 +111,11 @@ pub(super) fn handle_export_named_decl(
                                 ExportBindingOptions::new()
                             }
                             .with_prop_if(is_prop)
-                            .with_let_if(is_let),
+                            .with_let_if(is_let)
+                            // Official `handleExportedVariableDeclarationList`:
+                            // `required = !node.initializer`, independent of
+                            // `let`/`const`/`var`.
+                            .with_required_if(!has_default),
                         );
                         // Update the type annotation on the exported name
                         if let Some(ref ta_text) = type_annotation_text
@@ -363,7 +369,11 @@ pub(super) fn handle_export_named_decl(
                     .with_default_if(has_init)
                     .with_prop_if(is_prop)
                     .with_let_if(is_let)
-                    .with_named_export_if(true),
+                    .with_named_export_if(true)
+                    // Official `addExport`: `required: required || existing?.required`,
+                    // and a named export passes `required = false`, so the
+                    // declaration's own `!initializer` is the whole answer.
+                    .with_required_if(!has_init),
             );
             // The JSDoc lives on the `let x` declaration (or, for a renamed
             // export, on the `export { … }` statement); carry it onto the

--- a/crates/rsvelte_projection/src/svelte2tsx/script/export_decl.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/script/export_decl.rs
@@ -369,11 +369,15 @@ pub(super) fn handle_export_named_decl(
                     .with_default_if(has_init)
                     .with_prop_if(is_prop)
                     .with_let_if(is_let)
-                    .with_named_export_if(true)
-                    // Official `addExport`: `required: required || existing?.required`,
-                    // and a named export passes `required = false`, so the
-                    // declaration's own `!initializer` is the whole answer.
-                    .with_required_if(!has_init),
+                    // Official `addExport` passes `required = false` for the
+                    // named export itself, then preserves `required` from a
+                    // matching possible export. Thus `let x: T; export
+                    // { x as y }` stays required, while the collision path
+                    // above for `export let x: T; export { x as y }` is
+                    // optional (exported declarations are not possible
+                    // exports).
+                    .with_required_if(possible.is_some_and(|p| !p.has_init()))
+                    .with_named_export_if(true),
             );
             // The JSDoc lives on the `let x` declaration (or, for a renamed
             // export, on the `export { … }` statement); carry it onto the

--- a/crates/rsvelte_projection/src/svelte2tsx/script/exported_names.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/script/exported_names.rs
@@ -234,6 +234,10 @@ impl ExportedNameInfo {
     fn mark_named_export(&mut self) {
         self.flags.0 |= ExportFlags::IS_NAMED_EXPORT;
         self.flags.0 &= !ExportFlags::IS_LET;
+        // `export { local as exported }` calls official `addExport` with
+        // `required = false`. The renamed entry replaces the earlier
+        // `export let local` entry, so its required bit must not survive.
+        self.flags.0 &= !ExportFlags::IS_REQUIRED;
     }
 }
 

--- a/crates/rsvelte_projection/src/svelte2tsx/script/exported_names.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/script/exported_names.rs
@@ -166,7 +166,16 @@ impl ExportFlags {
     const IS_PROP: u8 = 1 << 1;
     const IS_LET: u8 = 1 << 2;
     const IS_NAMED_EXPORT: u8 = 1 << 3;
+    /// Official `ExportedName.required`, set from `!node.initializer` for a
+    /// variable declaration and left `false` for every other export kind.
+    const IS_REQUIRED: u8 = 1 << 4;
 
+    pub const fn with_required_if(mut self, enabled: bool) -> Self {
+        if enabled {
+            self.0 |= Self::IS_REQUIRED;
+        }
+        self
+    }
     pub const fn with_default_if(mut self, enabled: bool) -> Self {
         if enabled {
             self.0 |= Self::HAS_DEFAULT;
@@ -215,6 +224,11 @@ impl ExportedNameInfo {
     #[must_use]
     pub const fn is_named_export(&self) -> bool {
         self.flags.contains(ExportFlags::IS_NAMED_EXPORT)
+    }
+
+    #[must_use]
+    pub const fn is_required(&self) -> bool {
+        self.flags.contains(ExportFlags::IS_REQUIRED)
     }
 
     fn mark_named_export(&mut self) {
@@ -610,14 +624,14 @@ impl ExportedNames {
         // omit the `as {…}` cast entirely when every export is untyped AND
         // required — a plain `export let x` with no default and no type
         // annotation (`required = !initializer`). A typed or defaulted /
-        // optional export (or any non-`let` export) forces the cast. Computed
-        // up-front because it also gates whether the *value* elements carry the
-        // leading JSDoc (official `createReturnElements`: doc when dontAddTypeDef).
+        // optional export forces the cast. Computed up-front because it also
+        // gates whether the *value* elements carry the leading JSDoc (official
+        // `createReturnElements`: doc when dontAddTypeDef).
         let dont_add_type_def = !is_ts
             || self
                 .names
                 .values()
-                .all(|info| info.type_annotation.is_none() && info.is_let() && !info.has_default());
+                .all(|info| info.type_annotation.is_none() && info.is_required());
         // When `dontAddTypeDef`, the props object omits the `as {…}` type assert,
         // so a captured leading JSDoc `/** … */` is emitted before the prop's
         // value element — mirrors official `createReturnElements`.
@@ -913,7 +927,8 @@ impl ExportedNames {
             output.push(' ');
         }
         output.push_str(name);
-        if info.has_default() || !info.is_let() {
+        // Official `createReturnElementsType`: `${name}${value.required ? '' : '?'}`.
+        if !info.is_required() {
             output.push('?');
         }
         output.push_str(": ");

--- a/crates/rsvelte_projection/src/svelte2tsx/script/mod.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/script/mod.rs
@@ -407,70 +407,19 @@ pub fn process_instance_script(
         let mut reactive_declared_names: HashSet<String> = HashSet::new();
 
         // Pass 2: handle exports
-        for stmt in &program.body {
-            if let oxc::Statement::ExportDeclaration(export) = stmt {
-                handle_export_named_decl(
-                    export.span,
-                    Some(&export.declaration),
-                    &[],
-                    offset,
-                    str,
-                    exported_names,
-                    true,
-                    &possible_exports,
-                    raw_content,
-                    is_ts,
-                    basename,
-                    emit_jsdoc,
-                );
-            } else if let oxc::Statement::ExportNamedDeclaration(export) = stmt {
-                handle_export_named_decl(
-                    export.span,
-                    None,
-                    &export.specifiers,
-                    offset,
-                    str,
-                    exported_names,
-                    true,
-                    &possible_exports,
-                    raw_content,
-                    is_ts,
-                    basename,
-                    emit_jsdoc,
-                );
-            } else if let oxc::Statement::ExportFromDeclaration(export) = stmt {
-                handle_export_named_decl(
-                    export.span,
-                    None,
-                    &export.specifiers,
-                    offset,
-                    str,
-                    exported_names,
-                    true,
-                    &possible_exports,
-                    raw_content,
-                    is_ts,
-                    basename,
-                    emit_jsdoc,
-                );
-            } else if let oxc::Statement::ExportDefaultDeclaration(export) = stmt {
-                // Instance scripts can't have `export default` (svelte rejects
-                // it). Official svelte2tsx blanks just the `export` keyword for a
-                // default-exported FUNCTION or CLASS declaration, leaving
-                // `default function …`/`default class …` (invalid TSX → oxfmt
-                // skips → raw output). A default-exported EXPRESSION
-                // (`export default 42`) is kept verbatim. Mirror that.
-                let is_decl = matches!(
-                    export.declaration,
-                    oxc::ExportDefaultDeclarationKind::FunctionDeclaration(_)
-                        | oxc::ExportDefaultDeclarationKind::ClassDeclaration(_)
-                );
-                if is_decl {
-                    let start = export.span.start + offset;
-                    str.overwrite(start, start + 6, "");
-                }
-            }
-        }
+        handle_instance_export_statements(
+            &program.body,
+            &mut InstanceExportContext {
+                offset,
+                str,
+                exported_names,
+                possible_exports: &possible_exports,
+                raw_content,
+                is_ts,
+                basename,
+                emit_jsdoc,
+            },
+        );
 
         // Blank out $$Generic type alias declarations
         for &(start, end) in &exported_names.dollar_generic_positions {
@@ -841,6 +790,143 @@ fn collect_module_names(
         }
     }
     Ok(())
+}
+
+/// Everything `handle_export_named_decl` needs, bundled so the recursive
+/// instance-script export walk stays readable.
+struct InstanceExportContext<'a, 'b> {
+    offset: u32,
+    str: &'a mut MagicString<'b>,
+    exported_names: &'a mut ExportedNames,
+    possible_exports: &'a HashMap<String, PossibleExport>,
+    raw_content: &'a str,
+    is_ts: bool,
+    basename: &'a str,
+    emit_jsdoc: bool,
+}
+
+/// Lift every `export` in the instance script into the component's prop/export
+/// surface and strip the keyword.
+///
+/// Upstream's walk is `ts.forEachChild` over the WHOLE instance AST, and
+/// `handleVariableStatement` / `handleExportFunctionOrClass` /
+/// `handleExportDeclaration` fire wherever they match — the `export` branch of
+/// `handleVariableStatement` never checks that the parent is the source file. A
+/// `namespace` / `module` / `global` body is the only other place an `export`
+/// can legally sit, so recursing into those reproduces upstream's reach.
+fn handle_instance_export_statements(body: &[oxc::Statement], ctx: &mut InstanceExportContext) {
+    for stmt in body {
+        match stmt {
+            oxc::Statement::ExportDeclaration(export) => {
+                handle_export_named_decl(
+                    export.span,
+                    Some(&export.declaration),
+                    &[],
+                    ctx.offset,
+                    ctx.str,
+                    ctx.exported_names,
+                    true,
+                    ctx.possible_exports,
+                    ctx.raw_content,
+                    ctx.is_ts,
+                    ctx.basename,
+                    ctx.emit_jsdoc,
+                );
+                // `export namespace N { export const a = 1 }` — the outer
+                // `export` is left alone, but the body still gets walked.
+                match &export.declaration {
+                    oxc::Declaration::TSNamespaceDeclaration(ns) => {
+                        handle_namespace_body_exports(&ns.body, ctx);
+                    }
+                    oxc::Declaration::TSExternalModuleDeclaration(module_decl) => {
+                        if let Some(block) = &module_decl.body {
+                            handle_instance_export_statements(&block.body, ctx);
+                        }
+                    }
+                    oxc::Declaration::TSGlobalDeclaration(global) => {
+                        handle_instance_export_statements(&global.body.body, ctx);
+                    }
+                    _ => {}
+                }
+            }
+            oxc::Statement::ExportNamedDeclaration(export) => {
+                handle_export_named_decl(
+                    export.span,
+                    None,
+                    &export.specifiers,
+                    ctx.offset,
+                    ctx.str,
+                    ctx.exported_names,
+                    true,
+                    ctx.possible_exports,
+                    ctx.raw_content,
+                    ctx.is_ts,
+                    ctx.basename,
+                    ctx.emit_jsdoc,
+                );
+            }
+            oxc::Statement::ExportFromDeclaration(export) => {
+                handle_export_named_decl(
+                    export.span,
+                    None,
+                    &export.specifiers,
+                    ctx.offset,
+                    ctx.str,
+                    ctx.exported_names,
+                    true,
+                    ctx.possible_exports,
+                    ctx.raw_content,
+                    ctx.is_ts,
+                    ctx.basename,
+                    ctx.emit_jsdoc,
+                );
+            }
+            oxc::Statement::ExportDefaultDeclaration(export) => {
+                // Instance scripts can't have `export default` (svelte rejects
+                // it). Official svelte2tsx blanks just the `export` keyword for a
+                // default-exported FUNCTION or CLASS declaration, leaving
+                // `default function …`/`default class …` (invalid TSX → oxfmt
+                // skips → raw output). A default-exported EXPRESSION
+                // (`export default 42`) is kept verbatim. Mirror that.
+                let is_decl = matches!(
+                    export.declaration,
+                    oxc::ExportDefaultDeclarationKind::FunctionDeclaration(_)
+                        | oxc::ExportDefaultDeclarationKind::ClassDeclaration(_)
+                );
+                if is_decl {
+                    let start = export.span.start + ctx.offset;
+                    ctx.str.overwrite(start, start + 6, "");
+                }
+            }
+            oxc::Statement::TSNamespaceDeclaration(ns) => {
+                handle_namespace_body_exports(&ns.body, ctx);
+            }
+            oxc::Statement::TSExternalModuleDeclaration(module_decl) => {
+                if let Some(block) = &module_decl.body {
+                    handle_instance_export_statements(&block.body, ctx);
+                }
+            }
+            oxc::Statement::TSGlobalDeclaration(global) => {
+                handle_instance_export_statements(&global.body.body, ctx);
+            }
+            _ => {}
+        }
+    }
+}
+
+fn handle_namespace_body_exports(
+    body: &oxc::TSNamespaceDeclarationBody<'_>,
+    ctx: &mut InstanceExportContext,
+) {
+    match body {
+        // `namespace A.B { … }` — the dotted form nests another namespace.
+        oxc::TSNamespaceDeclarationBody::TSNamespaceDeclaration(inner) => {
+            handle_namespace_body_exports(&inner.body, ctx);
+        }
+        oxc::TSNamespaceDeclarationBody::TSModuleBlock(block) => {
+            handle_instance_export_statements(&block.body, ctx);
+        }
+    }
 }
 
 fn collect_exported_module_declaration(

--- a/crates/rsvelte_projection/src/svelte2tsx/script/mod.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/script/mod.rs
@@ -56,10 +56,7 @@ use props_rune::{
     PropsRuneInfo, apply_props_typedef, collect_props_rune_info, detect_props_rune_oxc,
 };
 use reactive::handle_reactive_statement;
-use runes::{
-    detect_rune_in_class_body, detect_rune_in_expr, detect_rune_in_nested_body,
-    detect_rune_in_stmt, detect_runes_call, detect_runes_expr_stmt, scope_with_params,
-};
+use runes::detect_runes_in_program;
 use script_facts::ScriptFacts;
 use stores::{
     inject_store_subscriptions_vars_only_with_program, inject_store_subscriptions_with_program,
@@ -132,6 +129,10 @@ pub fn process_instance_script(
         // statement whose initializer we're checking. See
         // collect_top_level_declared_names.
         let declared_names: HashSet<String> = collect_top_level_declared_names(&program.body);
+        // Runes-globals detection is ONE walk over the whole instance script,
+        // mirroring upstream's single identifier pass — not a per-statement-kind
+        // dispatch, which structurally cannot see the kinds it has no arm for.
+        detect_runes_in_program(&program.body, exported_names, &declared_names);
         // Top-level `type` / `interface` declarations that may be hoistable
         // out of `function $$render()`. Resolved (with `instance_value_names`
         // and `module_*_names`) into `hoistable_type_ranges` after Pass 1.
@@ -152,7 +153,6 @@ pub fn process_instance_script(
                     // into the `exports:` return, not `props:`).
                     let is_let = matches!(var_decl.kind, oxc::VariableDeclarationKind::Let);
                     for declarator in &var_decl.declarations {
-                        detect_runes_call(declarator, exported_names, &declared_names);
                         detect_props_rune_oxc(declarator, exported_names, raw_content);
                         // Collect $props() info for typedef generation (one per
                         // `$props()` destructure).
@@ -241,40 +241,6 @@ pub fn process_instance_script(
                         }
                     }
                 }
-                oxc::Statement::FunctionDeclaration(func) => {
-                    // Detect rune calls nested inside the function body.
-                    // The official svelte2tsx `checkGlobalsForRunes` walks the
-                    // entire TypeScript AST (including function bodies) and flags
-                    // any undeclared `$state`/`$derived`/`$effect` reference.
-                    // Mirror that here by recursively scanning the body.
-                    // Reference: ExportedNames.ts `checkGlobalsForRunes`.
-                    if let Some(ref body) = func.body {
-                        // Add the function's params to the scope so a rune name
-                        // shadowed by a param (`function bar($derived){ … }`) is
-                        // treated as that param, not a rune.
-                        let scope = scope_with_params(&declared_names, &func.params);
-                        if detect_rune_in_nested_body(&body.statements, &scope) {
-                            exported_names.set_uses_runes(true);
-                        }
-                    }
-                }
-                // Detect rune calls nested inside class method bodies.
-                oxc::Statement::ClassDeclaration(class)
-                    if class.body.body.iter().any(|member| match member {
-                        oxc::ClassElement::MethodDefinition(method) => {
-                            method.value.body.as_ref().is_some_and(|body| {
-                                detect_rune_in_nested_body(&body.statements, &declared_names)
-                            })
-                        }
-                        oxc::ClassElement::PropertyDefinition(prop) => prop
-                            .value
-                            .as_ref()
-                            .is_some_and(|e| detect_rune_in_expr(e, &declared_names)),
-                        _ => false,
-                    }) =>
-                {
-                    exported_names.set_uses_runes(true);
-                }
                 oxc::Statement::ExportDeclaration(export) => {
                     // Also check exports for declared names
                     {
@@ -321,22 +287,6 @@ pub fn process_instance_script(
                                         );
                                     }
                                 }
-                            }
-                            oxc::Declaration::FunctionDeclaration(func) => {
-                                // Runes inside an exported function body still
-                                // put the component in runes mode.
-                                if let Some(ref body) = func.body {
-                                    let scope = scope_with_params(&declared_names, &func.params);
-                                    if detect_rune_in_nested_body(&body.statements, &scope) {
-                                        exported_names.set_uses_runes(true);
-                                    }
-                                }
-                            }
-                            // `export class C { x = $state(0) }` → runes mode.
-                            oxc::Declaration::ClassDeclaration(class)
-                                if detect_rune_in_class_body(class, &declared_names) =>
-                            {
-                                exported_names.set_uses_runes(true);
                             }
                             // `export type X = ...` / `export interface X { ... }`.
                             //
@@ -439,22 +389,7 @@ pub fn process_instance_script(
                         exported_names,
                     );
                 }
-                // Detect rune globals used as standalone expression statements,
-                // e.g. `$effect(() => { ... })` or `$effect.pre(() => { ... })`.
-                // These are missed by `detect_runes_call` which only visits
-                // VariableDeclarator inits.
-                // Reference: svelte2tsx ExportedNames.ts `hasRunesGlobals` check.
-                oxc::Statement::ExpressionStatement(es) => {
-                    detect_runes_expr_stmt(es, exported_names, &declared_names);
-                }
-                // Every other statement kind — a block, `if`, loop, `switch`,
-                // `try`, label — reaches the recursive walker, which official's
-                // whole-AST globals walk also sees below a statement.
-                other => {
-                    if detect_rune_in_stmt(other, &declared_names) {
-                        exported_names.set_uses_runes(true);
-                    }
-                }
+                _ => {}
             }
         }
 

--- a/crates/rsvelte_projection/src/svelte2tsx/script/runes.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/script/runes.rs
@@ -71,97 +71,56 @@ fn detect_rune_in_call_args(call: &oxc::CallExpression, declared_names: &HashSet
     })
 }
 
-pub(super) fn detect_runes_call(
-    declarator: &oxc::VariableDeclarator,
+/// Run the whole-program rune-globals scan over the instance script body.
+///
+/// Upstream does this in ONE pass: every `$`-prefixed identifier *reference*
+/// becomes a global, and `checkGlobalsForRunes` then tests that set for
+/// membership of `['$state', '$derived', '$effect']` — there is no notion of a
+/// call anywhere in it.
+///
+/// Reference: `ExportedNames.ts` `checkGlobalsForRunes` fed by
+/// `ImplicitStoreValues.getGlobals()`.
+pub(super) fn detect_runes_in_program(
+    body: &[oxc::Statement],
     exported_names: &mut ExportedNames,
     declared_names: &HashSet<String>,
 ) {
-    if let Some(ref init) = declarator.init {
-        // Apply the official `is_rune` exclusion: the canonical
-        // `let stateX = $state(...)` form does not, by itself, trigger runes
-        // mode — but nested runes in the arguments still do.
-        if let Some(call) = excluded_rune_init(init, &declarator.id) {
-            if detect_rune_in_call_args(call, declared_names) {
-                exported_names.set_uses_runes(true);
-            }
-            return;
-        }
-        // `detect_rune_in_expr` subsumes `detect_rune_global_call_expr`: it
-        // fast-paths to the top-level check first, then recurses into nested
-        // function/arrow bodies. This catches patterns like:
-        //   `const action = (node) => { $effect(() => { … }); }`
-        // which the original top-level-only check missed.
-        // Reference: ExportedNames.ts `checkGlobalsForRunes` which walks the
-        // entire TS AST (not just top-level statements).
-        if detect_rune_in_expr(init, declared_names) {
-            exported_names.set_uses_runes(true);
-        }
+    if detect_rune_in_nested_body(body, declared_names) {
+        exported_names.set_uses_runes(true);
     }
 }
 
-/// Detect `$state(...)`, `$derived(...)`, `$effect(...)` — including member-call
-/// variants such as `$state.raw(...)`, `$effect.pre(...)` — anywhere as an
-/// expression (not just as a `VariableDeclarator` init).
+/// True when `name` is one of the three rune globals and is not shadowed.
 ///
-/// Mirrors the official `isRunesMode` `hasRunesGlobals` check which looks for
-/// undeclared `$state`/`$derived`/`$effect` identifiers in the instance scope.
-/// We check both direct calls (`$state(v)`) and member calls (`$state.raw(v)`)
-/// since both reference the `$state` global.
+/// Upstream's `getGlobals()` deletes the names bound by top-level variable
+/// declarations, reactive declarations and imports (`state` shadows `$state`),
+/// while `resolveStore` drops a reference whose literal `$state` spelling is
+/// declared in an enclosing scope (a parameter named `$state`). Both are
+/// carried in `declared_names`.
+fn is_rune_global_ident(name: &str, declared_names: &HashSet<String>) -> bool {
+    matches!(name, "$state" | "$derived" | "$effect")
+        && !declared_names.contains(&name[1..])
+        && !declared_names.contains(name)
+}
+
+/// Detect a reference to the `$state` / `$derived` / `$effect` globals in the
+/// head position of an expression: the bare identifier itself, the object of a
+/// member expression (`$state.raw`), or either of those as a call callee.
 ///
 /// Reference: language-tools/packages/svelte2tsx/src/svelte2tsx/nodes/ExportedNames.ts
 ///   `hasRunesGlobals = isSvelte5Plus && globals.some(g => ['$state','$derived','$effect'].includes(g))`
-fn detect_rune_global_call_expr(expr: &oxc::Expression, declared_names: &HashSet<String>) -> bool {
+fn detect_rune_global_ref_expr(expr: &oxc::Expression, declared_names: &HashSet<String>) -> bool {
     match expr {
-        // Direct call: $state(...), $derived(...), $effect(...)
+        // Bare reference: `void $state`, `const a = $derived`, `{ k: $effect }`.
+        oxc::Expression::Identifier(id) => is_rune_global_ident(id.name.as_str(), declared_names),
+        // Member read: `$state.raw`, `$effect.pre` — called or not.
+        oxc::Expression::StaticMemberExpression(mem) => {
+            detect_rune_global_ref_expr(&mem.object, declared_names)
+        }
         oxc::Expression::CallExpression(call) => {
-            match &call.callee {
-                // $state(...), $derived(...), $effect(...)
-                oxc::Expression::Identifier(id)
-                    if matches!(id.name.as_str(), "$state" | "$derived" | "$effect") =>
-                {
-                    // Not a rune if either the store base (`$state` is a
-                    // store-sub of a declared `state`) OR the full `$state`
-                    // identifier itself is declared (e.g. shadowed by a param
-                    // named `$derived`).
-                    let base = &id.name[1..]; // "$state" -> "state"
-                    !declared_names.contains(base) && !declared_names.contains(id.name.as_str())
-                }
-                // Member call: $state.raw(...), $effect.pre(...), etc.
-                // The object identifier must be $state/$derived/$effect.
-                oxc::Expression::StaticMemberExpression(mem) => {
-                    if let oxc::Expression::Identifier(obj) = &mem.object
-                        && matches!(obj.name.as_str(), "$state" | "$derived" | "$effect")
-                    {
-                        let base = &obj.name[1..];
-                        !declared_names.contains(base)
-                            && !declared_names.contains(obj.name.as_str())
-                    } else {
-                        false
-                    }
-                }
-                _ => false,
-            }
+            detect_rune_global_ref_expr(&call.callee, declared_names)
         }
         _ => false,
-    }
-}
-
-/// Detect rune globals used as top-level `ExpressionStatements` in the instance
-/// script, e.g. `$effect(() => { ... })`.
-///
-/// These don't have a `VariableDeclarator` so `detect_runes_call` misses them.
-/// Reference: official svelte2tsx `hasRunesGlobals` which checks ALL undeclared
-/// `$state`/`$derived`/`$effect` references in the instance script scope.
-pub(super) fn detect_runes_expr_stmt(
-    expr_stmt: &oxc::ExpressionStatement,
-    exported_names: &mut ExportedNames,
-    declared_names: &HashSet<String>,
-) {
-    // Use the recursive walker so runes nested in arrow/function bodies are also
-    // detected (e.g. `setTimeout(() => { $effect(() => {}) })`).
-    // `detect_rune_in_expr` fast-paths to `detect_rune_global_call_expr` first.
-    if detect_rune_in_expr(&expr_stmt.expression, declared_names) {
-        exported_names.set_uses_runes(true);
     }
 }
 
@@ -189,6 +148,23 @@ pub(super) fn detect_rune_in_nested_body(
     false
 }
 
+/// Walk a `VariableDeclaration`, applying the official `is_rune` exclusion: the
+/// canonical `let stateX = $state(...)` form is not a runes-globals trigger, but
+/// nested runes in the arguments still are.
+fn detect_rune_in_variable_declaration(
+    var_decl: &oxc::VariableDeclaration,
+    declared_names: &HashSet<String>,
+) -> bool {
+    var_decl.declarations.iter().any(|d| {
+        d.init.as_ref().is_some_and(|e| {
+            excluded_rune_init(e, &d.id).map_or_else(
+                || detect_rune_in_expr(e, declared_names),
+                |call| detect_rune_in_call_args(call, declared_names),
+            )
+        })
+    })
+}
+
 /// Walk a single statement (and any nested sub-statements / expressions)
 /// looking for an undeclared `$state`/`$derived`/`$effect` reference.
 pub(super) fn detect_rune_in_stmt(stmt: &oxc::Statement, declared_names: &HashSet<String>) -> bool {
@@ -196,17 +172,9 @@ pub(super) fn detect_rune_in_stmt(stmt: &oxc::Statement, declared_names: &HashSe
         oxc::Statement::ExpressionStatement(es) => {
             detect_rune_in_expr(&es.expression, declared_names)
         }
-        oxc::Statement::VariableDeclaration(var_decl) => var_decl.declarations.iter().any(|d| {
-            d.init.as_ref().is_some_and(|e| {
-                // Same `is_rune` exclusion as the top-level pass: the canonical
-                // `let stateX = $state(...)` form is not a runes-globals trigger,
-                // but nested runes in the arguments still are.
-                excluded_rune_init(e, &d.id).map_or_else(
-                    || detect_rune_in_expr(e, declared_names),
-                    |call| detect_rune_in_call_args(call, declared_names),
-                )
-            })
-        }),
+        oxc::Statement::VariableDeclaration(var_decl) => {
+            detect_rune_in_variable_declaration(var_decl, declared_names)
+        }
         oxc::Statement::ReturnStatement(ret) => ret
             .argument
             .as_ref()
@@ -265,13 +233,34 @@ pub(super) fn detect_rune_in_stmt(stmt: &oxc::Statement, declared_names: &HashSe
         }
         oxc::Statement::TryStatement(t) => {
             detect_rune_in_nested_body(&t.block.body, declared_names)
-                || t.handler
-                    .as_ref()
-                    .is_some_and(|h| detect_rune_in_nested_body(&h.body.body, declared_names))
+                || t.handler.as_ref().is_some_and(|h| {
+                    // A catch parameter named `$state` shadows the global, the
+                    // same way a function parameter does.
+                    let scope = h.param.as_ref().map_or_else(
+                        || declared_names.clone(),
+                        |p| scope_with_binding(declared_names, &p.pattern),
+                    );
+                    detect_rune_in_nested_body(&h.body.body, &scope)
+                })
                 || t.finalizer
                     .as_ref()
                     .is_some_and(|f| detect_rune_in_nested_body(&f.body, declared_names))
         }
+        // `export let p = $state` / `export function f() { $effect(…) }` — the
+        // `export` modifier is transparent to upstream's identifier walk.
+        oxc::Statement::ExportDeclaration(export) => match &export.declaration {
+            oxc::Declaration::VariableDeclaration(vd) => {
+                detect_rune_in_variable_declaration(vd, declared_names)
+            }
+            oxc::Declaration::FunctionDeclaration(func) => func.body.as_ref().is_some_and(|body| {
+                let scope = scope_with_params(declared_names, &func.params);
+                detect_rune_in_nested_body(&body.statements, &scope)
+            }),
+            oxc::Declaration::ClassDeclaration(class) => {
+                detect_rune_in_class_body(class, declared_names)
+            }
+            _ => false,
+        },
         oxc::Statement::SwitchStatement(s) => s.cases.iter().any(|c| {
             c.test
                 .as_ref()
@@ -319,6 +308,14 @@ pub(super) fn detect_rune_in_class_body(
 /// `$effect` shadowed by a parameter (e.g. `function bar($derived) { $derived(x) }`)
 /// is treated as a store-sub / call of the param, not a rune. Mirrors official's
 /// scope-aware global resolution.
+fn scope_with_binding(base: &HashSet<String>, pattern: &oxc::BindingPattern) -> HashSet<String> {
+    let mut s = base.clone();
+    let mut tmp: Vec<String> = Vec::new();
+    collect_binding_names(pattern, &mut tmp);
+    s.extend(tmp);
+    s
+}
+
 pub(super) fn scope_with_params(
     base: &HashSet<String>,
     params: &oxc::FormalParameters,
@@ -341,8 +338,8 @@ pub(super) fn detect_rune_in_expr(
     expr: &oxc::Expression,
     declared_names: &HashSet<String>,
 ) -> bool {
-    // Fast-path: check if this expression itself is a rune call.
-    if detect_rune_global_call_expr(expr, declared_names) {
+    // Fast-path: check if this expression itself references a rune global.
+    if detect_rune_global_ref_expr(expr, declared_names) {
         return true;
     }
     match expr {
@@ -353,10 +350,15 @@ pub(super) fn detect_rune_in_expr(
         }
         oxc::Expression::ArrowFunctionExpression(arrow) => {
             let scope = scope_with_params(declared_names, &arrow.params);
-            arrow
-                .body
-                .as_function_body()
-                .is_some_and(|block| detect_rune_in_nested_body(&block.statements, &scope))
+            match &arrow.body {
+                oxc::ArrowFunctionBody::FunctionBody(block) => {
+                    detect_rune_in_nested_body(&block.statements, &scope)
+                }
+                // Concise body: `() => $state`.
+                body => body
+                    .as_expression()
+                    .is_some_and(|e| detect_rune_in_expr(e, &scope)),
+            }
         }
         oxc::Expression::FunctionExpression(func) => func.body.as_ref().is_some_and(|body| {
             let scope = scope_with_params(declared_names, &func.params);

--- a/crates/rsvelte_projection/src/svelte2tsx/script/runes.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/script/runes.rs
@@ -124,9 +124,9 @@ fn detect_rune_global_ref_expr(expr: &oxc::Expression, declared_names: &HashSet<
     }
 }
 
-/// Detect whether any rune global call (`$state`, `$derived`, `$effect` including
-/// member variants such as `$state.raw`, `$effect.pre`) appears anywhere inside
-/// a function, class, or arrow-function body — even when not at the top level.
+/// Detect whether a rune global (`$state`, `$derived`, `$effect`, including
+/// member reads such as `$state.raw`) is referenced anywhere in these
+/// statements or in any nested function, class or arrow body.
 ///
 /// The official svelte2tsx `checkGlobalsForRunes` works by collecting every
 /// undeclared identifier referenced anywhere in the script (via the TypeScript
@@ -302,12 +302,8 @@ pub(super) fn detect_rune_in_class_body(
     })
 }
 
-/// Recursively detect an undeclared `$state`/`$derived`/`$effect` reference
-/// (including member variants) anywhere inside the given expression tree.
-/// Clone `base` and add a function's parameter names, so a `$state`/`$derived`/
-/// `$effect` shadowed by a parameter (e.g. `function bar($derived) { $derived(x) }`)
-/// is treated as a store-sub / call of the param, not a rune. Mirrors official's
-/// scope-aware global resolution.
+/// Clone `base` and add the names a binding pattern introduces, so a rune name
+/// shadowed by a catch parameter is treated as that binding, not as a rune.
 fn scope_with_binding(base: &HashSet<String>, pattern: &oxc::BindingPattern) -> HashSet<String> {
     let mut s = base.clone();
     let mut tmp: Vec<String> = Vec::new();
@@ -316,6 +312,10 @@ fn scope_with_binding(base: &HashSet<String>, pattern: &oxc::BindingPattern) -> 
     s
 }
 
+/// Clone `base` and add a function's parameter names, so a `$state`/`$derived`/
+/// `$effect` shadowed by a parameter (e.g. `function bar($derived) { $derived }`)
+/// resolves to the param, not to the rune. Mirrors official's scope-aware
+/// global resolution.
 pub(super) fn scope_with_params(
     base: &HashSet<String>,
     params: &oxc::FormalParameters,
@@ -334,6 +334,8 @@ pub(super) fn scope_with_params(
     s
 }
 
+/// Recursively detect an unshadowed `$state`/`$derived`/`$effect` reference
+/// anywhere inside the given expression tree.
 pub(super) fn detect_rune_in_expr(
     expr: &oxc::Expression,
     declared_names: &HashSet<String>,
@@ -344,7 +346,7 @@ pub(super) fn detect_rune_in_expr(
     }
     match expr {
         oxc::Expression::CallExpression(call) => {
-            // The callee might not be a rune but the arguments could contain rune calls.
+            // The callee might not be a rune but the arguments could reference one.
             detect_rune_in_expr(&call.callee, declared_names)
                 || detect_rune_in_arguments(&call.arguments, declared_names)
         }

--- a/crates/rsvelte_projection/src/svelte2tsx/script/runes.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/script/runes.rs
@@ -6,7 +6,10 @@ use std::collections::HashSet;
 use oxc_ast::ast as oxc;
 
 use super::ExportedNames;
-use super::ast_utils::{collect_binding_names, extract_all_names_from_binding_pattern};
+use super::ast_utils::{
+    collect_binding_names, extract_all_names_from_binding_pattern,
+    extract_names_from_assignment_target,
+};
 
 /// The official svelte2tsx `is_rune` quirk: a `$state(...)`/`$derived(...)`/
 /// `$props(...)` call that is the *direct* initializer of a variable
@@ -85,7 +88,31 @@ pub(super) fn detect_runes_in_program(
     exported_names: &mut ExportedNames,
     declared_names: &HashSet<String>,
 ) {
-    if detect_rune_in_nested_body(body, declared_names) {
+    // Reactive assignments introduce implicit top-level bindings for rune/store
+    // disambiguation, but they must not be added to the declaration set used by
+    // the later reactive-statement rewrite: that pass needs to know that they
+    // are new so it can turn `$: state = ...` into `let state = ...`.
+    let mut rune_scope = declared_names.clone();
+    for stmt in body {
+        let oxc::Statement::LabeledStatement(labeled) = stmt else {
+            continue;
+        };
+        if labeled.label.name != "$" {
+            continue;
+        }
+        let oxc::Statement::ExpressionStatement(expr_stmt) = &labeled.body else {
+            continue;
+        };
+        let expr = match &expr_stmt.expression {
+            oxc::Expression::ParenthesizedExpression(paren) => &paren.expression,
+            other => other,
+        };
+        if let oxc::Expression::AssignmentExpression(assign) = expr {
+            rune_scope.extend(extract_names_from_assignment_target(&assign.left));
+        }
+    }
+
+    if detect_rune_in_nested_body(body, &rune_scope) {
         exported_names.set_uses_runes(true);
     }
 }

--- a/crates/rsvelte_projection/tests/svelte2tsx_namespace_export_3257.rs
+++ b/crates/rsvelte_projection/tests/svelte2tsx_namespace_export_3257.rs
@@ -1,0 +1,134 @@
+//! Regression (#3257): `export namespace` keeps its `export`, and an export
+//! nested in a namespace / module body is lifted the way upstream lifts it.
+//!
+//! Upstream's instance-script walk is `ts.forEachChild` over the WHOLE AST, and
+//! it removes the `export` keyword only from the three node kinds it has a
+//! handler for (`handleVariableStatement`, `handleExportFunctionOrClass` for a
+//! function and a class, `handleExportDeclaration` for `export { … }`). rsvelte
+//! stripped `export` from every declaration kind and visited top-level
+//! statements only, so `export namespace N` lost its `export` while the
+//! namespace-body export was left alone.
+//!
+//! Every expectation below is the byte the pinned official `svelte2tsx`
+//! produces for the same source.
+
+use rsvelte_projection::svelte2tsx::{Svelte2TsxOptions, svelte2tsx};
+
+fn to_tsx(src: &str) -> String {
+    let opts = Svelte2TsxOptions {
+        filename: "Probe.svelte".to_string(),
+        is_ts_file: true,
+        ..Default::default()
+    };
+    svelte2tsx(src, opts).expect("svelte2tsx").code
+}
+
+fn instance(body: &str) -> String {
+    to_tsx(&format!(
+        "<script lang=\"ts\">\n{body}\n</script>\n<div></div>\n"
+    ))
+}
+
+#[track_caller]
+fn assert_contains(out: &str, needle: &str) {
+    assert!(out.contains(needle), "expected {needle:?} in:\n{out}");
+}
+
+#[test]
+fn a_non_value_declaration_keeps_its_export_keyword() {
+    // Upstream has no handler for a module / enum declaration, so the keyword
+    // survives into `$$render()` untouched.
+    assert_contains(
+        &instance("export namespace N { const a = 1; }\nvoid N;"),
+        "export namespace N { const a = 1; }",
+    );
+    assert_contains(
+        &instance("export enum E { A }\nvoid E;"),
+        "export enum E { A }",
+    );
+    assert_contains(
+        &instance("export const enum CE { A }\nvoid CE;"),
+        "export const enum CE { A }",
+    );
+    // The type-only forms already behaved this way; pin them to the same rule.
+    assert_contains(
+        &instance("export type T = number;"),
+        "export type T = number;",
+    );
+    assert_contains(
+        &instance("export interface I { a: number }"),
+        "export interface I { a: number }",
+    );
+}
+
+#[test]
+fn a_value_declaration_still_loses_its_export_keyword() {
+    let out = instance("export let l = 1;");
+    assert!(
+        !out.contains("export let l"),
+        "`export let` must still be stripped:\n{out}"
+    );
+    let out = instance("export function f() {}\nvoid f;");
+    assert!(
+        !out.contains("export function f"),
+        "`export function` must still be stripped:\n{out}"
+    );
+    let out = instance("export class C {}\nvoid C;");
+    assert!(
+        !out.contains("export class C"),
+        "`export class` must still be stripped:\n{out}"
+    );
+}
+
+#[test]
+fn a_namespace_body_export_is_lifted_into_the_component_surface() {
+    let out = instance("namespace N { export const a = 1; }\nvoid N;");
+    assert_contains(&out, "namespace N {  const a = 1; }");
+    assert_contains(&out, "props: {a: a} as {a?: typeof a}");
+    assert_contains(&out, "exports: {} as any as { a: typeof a }");
+
+    let out = instance("namespace N { export function nf() {} }\nvoid N;");
+    assert_contains(&out, "namespace N {  function nf() {} }");
+    assert_contains(&out, "exports: {} as any as { nf: typeof nf }");
+
+    let out = instance("namespace N { export class NC {} }\nvoid N;");
+    assert_contains(&out, "namespace N {  class NC {} }");
+
+    // `export { … }` inside a namespace: the whole statement goes.
+    let out = instance("namespace N { const q = 1; export { q }; }\nvoid N;");
+    assert_contains(&out, "namespace N { const q = 1;  }");
+    assert_contains(&out, "props: {q: q} as {q?: typeof q}");
+}
+
+#[test]
+fn the_outer_export_and_the_inner_lift_are_independent() {
+    let out = instance("export namespace N { export const a = 1; }\nvoid N;");
+    assert_contains(&out, "export namespace N {  const a = 1; }");
+    assert_contains(&out, "props: {a: a} as {a?: typeof a}");
+}
+
+#[test]
+fn nested_namespaces_and_ambient_modules_are_walked_too() {
+    let out = instance("namespace N { export namespace M { export const z = 1; } }\nvoid N;");
+    assert_contains(&out, "namespace N { export namespace M {  const z = 1; } }");
+    assert_contains(&out, "props: {z: z} as {z?: typeof z}");
+
+    let out = instance("declare module 'foo' { export const a: number; }");
+    assert_contains(&out, "declare module 'foo' {  const a: number; }");
+    assert_contains(&out, "props: {a: a} as {a: number}");
+}
+
+#[test]
+fn an_export_without_an_initializer_is_a_required_prop() {
+    // Official `handleExportedVariableDeclarationList` sets
+    // `required = !node.initializer`, independent of `let`/`const`/`var`, so a
+    // non-`let` export with no initializer must NOT be optional.
+    assert_contains(
+        &instance("export declare const dc: number;"),
+        "props: {dc: dc} as {dc: number}",
+    );
+    assert_contains(
+        &instance("export let l = 1;"),
+        "props: {l: l} as {l?: typeof l}",
+    );
+}

--- a/crates/rsvelte_projection/tests/svelte2tsx_namespace_export_3257.rs
+++ b/crates/rsvelte_projection/tests/svelte2tsx_namespace_export_3257.rs
@@ -131,4 +131,20 @@ fn an_export_without_an_initializer_is_a_required_prop() {
         &instance("export let l = 1;"),
         "props: {l: l} as {l?: typeof l}",
     );
+
+    // A named alias is added with `required = false` by official, even when
+    // the aliased declaration itself had no initializer.
+    assert_contains(
+        &instance("export let formModal: number; export { formModal as controller };"),
+        "controller?: typeof formModal",
+    );
+
+    // A non-exported declaration is first recorded as a possible export.
+    // Official carries that declaration's required bit into its later alias.
+    assert_contains(
+        &instance(
+            "type RequestStatus = { state: string }; let incomingRequestState: RequestStatus['state'] | undefined; export { incomingRequestState as requestState };",
+        ),
+        "requestState: RequestStatus['state'] | undefined",
+    );
 }

--- a/crates/rsvelte_projection/tests/svelte2tsx_runes_reference_3260.rs
+++ b/crates/rsvelte_projection/tests/svelte2tsx_runes_reference_3260.rs
@@ -1,0 +1,115 @@
+//! Regression (#3260): runes mode is entered on a *reference* to
+//! `$state` / `$derived` / `$effect`, not on a rune *call*.
+//!
+//! Upstream `ExportedNames.checkGlobalsForRunes` tests
+//! `implicitStoreValues.getGlobals()` — every unshadowed `$`-prefixed
+//! identifier reference in the component — for membership of a three-element
+//! list. rsvelte's port was structured entirely around `CallExpression`, so
+//! `{$state}`, `void $state`, `{#each $derived as …}` and friends left the
+//! component typed as a legacy class component.
+//!
+//! Every expectation below is the byte the pinned official `svelte2tsx`
+//! produces for the same source.
+
+use rsvelte_projection::svelte2tsx::{Svelte2TsxOptions, svelte2tsx};
+
+fn to_tsx(src: &str) -> String {
+    let opts = Svelte2TsxOptions {
+        filename: "Probe.svelte".to_string(),
+        ..Default::default()
+    };
+    svelte2tsx(src, opts).expect("svelte2tsx").code
+}
+
+#[track_caller]
+fn assert_runes(src: &str) {
+    let out = to_tsx(src);
+    assert!(
+        out.contains("bindings: __sveltets_$$bindings('')"),
+        "expected runes mode for:\n{src}\ngot:\n{out}"
+    );
+    assert!(
+        out.contains("__sveltets_2_fn_component("),
+        "expected a function component for:\n{src}\ngot:\n{out}"
+    );
+}
+
+#[track_caller]
+fn assert_legacy(src: &str) {
+    let out = to_tsx(src);
+    assert!(
+        out.contains("bindings: \"\""),
+        "expected legacy mode for:\n{src}\ngot:\n{out}"
+    );
+    assert!(
+        out.contains("__sveltets_2_isomorphic_component("),
+        "expected a class component for:\n{src}\ngot:\n{out}"
+    );
+}
+
+#[test]
+fn template_reference_enters_runes_mode() {
+    // No `<script>` at all — the template alone decides.
+    assert_runes("{$state}");
+    assert_runes("{$state.x}");
+    assert_runes("<div id={$derived}></div>");
+    assert_runes("{#each $derived as i}{i}{/each}");
+    assert_runes("<div {...$effect}></div>");
+    // The one template position that already worked.
+    assert_runes("{$state(1)}");
+}
+
+#[test]
+fn instance_script_reference_enters_runes_mode() {
+    assert_runes("<script>void $state;</script>");
+    assert_runes("<script>a: $derived;</script>");
+    assert_runes("<script>function f() { return $effect; }</script>");
+    assert_runes("<script>class C { m() { return $state; } }</script>");
+    assert_runes("<script>const a = typeof $derived;</script>");
+    assert_runes("<script>const a = $state;</script>");
+    assert_runes("<script>let a = $effect;</script>");
+    assert_runes("<script>const f = () => $state;</script>");
+    assert_runes("<script>const o = { k: $derived };</script>");
+    assert_runes("<script>const o = [$effect];</script>");
+    assert_runes("<script>let a; a = $state;</script>");
+    assert_runes("<script>let a; $: a = $derived;</script>");
+    assert_runes("<script>export let p = $effect;</script>");
+    assert_runes("<script>const { a } = { a: $state };</script>");
+}
+
+#[test]
+fn a_shadowed_rune_name_stays_a_store_subscription() {
+    // `getGlobals()` deletes the names bound by top-level declarations and
+    // imports, so `$state` is a store auto-subscription here.
+    assert_legacy("<script>import { state } from './s.js';\nvoid $state;</script><div></div>");
+    assert_legacy("<script>let derived = 1;\nvoid $derived;</script><div></div>");
+    assert_legacy("<script>let state = 1;</script>{$state}");
+    // A parameter that literally spells `$state` shadows it too.
+    assert_legacy("<script>function f($state) { return $state; }</script><div></div>");
+    assert_legacy("<script>try {} catch ($state) { void $state; }</script><div></div>");
+}
+
+#[test]
+fn a_property_named_like_a_rune_is_not_a_reference() {
+    // Upstream skips a `$`-identifier sitting in the property half of a
+    // property access.
+    assert_legacy("<script>const o = {};\nvoid o.$state;</script><div></div>");
+}
+
+#[test]
+fn non_listed_dollar_tokens_do_not_enter_runes_mode() {
+    // The negative control from the issue: `$props` and `$bindable` ARE runes,
+    // and they still do not flip the mode, because upstream's list holds only
+    // `$state` / `$derived` / `$effect`.
+    for token in ["$props", "$bindable", "$inspect", "$host", "$foo"] {
+        assert_legacy(&format!("<script>void {token};</script><div></div>"));
+        assert_legacy(&format!("{{{token}}}"));
+    }
+}
+
+#[test]
+fn a_module_script_reference_does_not_enter_runes_mode() {
+    // `<script module>` is processed by `processModuleScriptTag`, which never
+    // feeds `implicitStoreValues`.
+    assert_legacy("<script module>void $state;</script><div></div>");
+}

--- a/crates/rsvelte_projection/tests/svelte2tsx_runes_reference_3260.rs
+++ b/crates/rsvelte_projection/tests/svelte2tsx_runes_reference_3260.rs
@@ -84,6 +84,18 @@ fn a_shadowed_rune_name_stays_a_store_subscription() {
     assert_legacy("<script>import { state } from './s.js';\nvoid $state;</script><div></div>");
     assert_legacy("<script>let derived = 1;\nvoid $derived;</script><div></div>");
     assert_legacy("<script>let state = 1;</script>{$state}");
+    assert_legacy("<script>$: state = 1;\nvoid $state;</script><div></div>");
+    assert_legacy(
+        "<script>let source = {};\n$: ({ state } = source);\nvoid $state;</script><div></div>",
+    );
+
+    let output = to_tsx(
+        "<script lang=\"ts\">export let api: number;\nlet source = {};\n$: ({ state } = source);\nvoid $state;</script><div></div>",
+    );
+    assert!(
+        output.contains("props: {api: api}"),
+        "a reactive `state` declaration must keep legacy exported props:\n{output}"
+    );
     // A parameter that literally spells `$state` shadows it too.
     assert_legacy("<script>function f($state) { return $state; }</script><div></div>");
     assert_legacy("<script>try {} catch ($state) { void $state; }</script><div></div>");


### PR DESCRIPTION
Two svelte2tsx divergences, both fixed by making rsvelte's walk the shape upstream's walk actually is.

Closes #3260
Closes #3257

## 1. Runes mode needs a rune *reference*, not a rune *call* (#3260)

Upstream `ExportedNames.checkGlobalsForRunes` tests `implicitStoreValues.getGlobals()` — every unshadowed `$`-prefixed identifier **reference** in the component — for membership of `['$state', '$derived', '$effect']`. There is no notion of a call anywhere in it. rsvelte's two ports of that heuristic (`nodes/runes_detection.rs` for the template, `script/runes.rs` for the instance script) were structured entirely around `CallExpression`, so `{$state}`, `void $derived` and `{#each $effect as …}` typed a Svelte 5 runes component as a legacy **class** component (`__sveltets_2_isomorphic_component` / `InstanceType<…>` / `bindings: ""` instead of `__sveltets_2_fn_component` / `ReturnType<…>` / `bindings: __sveltets_$$bindings('')`).

Per the issue's caution, this widens the existing heuristic from *called* to *referenced* for those three tokens only. The `NOTE` in `runes_detection.rs` still stands: the compiler's `ComponentAnalysis::runes` flag is deliberately **not** used, and `$props` / `$bindable` / `$inspect` / `$host` still do not flip the mode, because upstream's list does not contain them.

The instance-script half also replaces a per-statement-kind dispatch in `script/mod.rs` (five hand-written arms, each re-deriving the scope) with the single whole-body walk upstream does. That is what made `label`, `class_method`, `typeof_only` and a concise arrow body invisible in the first place — a dispatch cannot see a kind nobody wrote an arm for. Two scope gaps the walk exposed are fixed with it: a catch-clause parameter now shadows a rune name the way a function parameter already did, and an `export`ed declaration is walked like its non-exported form.

## 2. `export namespace` and the namespace-body export (#3257)

Upstream removes the `export` keyword only from the three node kinds its walk has a handler for — `handleVariableStatement`, and `handleExportFunctionOrClass` for a function and a class — plus `handleExportDeclaration` for an `export { … }` clause. Every other exported declaration keeps its keyword. rsvelte inverted that: it stripped `export` from everything **except** `type` / `interface`, so `export namespace`, `export enum`, `export const enum` and `export import x =` lost an `export` upstream keeps. Replaced the exception list with the allow-list, so a kind nobody thought of defaults to "left alone" — which is what upstream does.

And upstream's walk is `ts.forEachChild` over the whole instance AST, while rsvelte's export pass visited top-level statements only. A `namespace` / `declare module` / `declare global` body is the only other place an `export` can legally sit, so the pass now recurses into those. Both halves of the issue's table now match byte for byte:

```
export namespace N {  const a = 1; }
return { props: {a: a} as {a?: typeof a}, exports: {} as any as { a: typeof a }, … }
```

On the second half the issue leaves the decision open between "match upstream" and "list it and file upstream". This PR matches upstream: byte equality is the project's stated goal, output equality is what the gate measures, and the shape is one the official **compiler** rejects anyway (#3244), so no compiling component reaches it.

### The third divergence, which only became reachable once the lift worked

With the namespace-body export lifted, `declare module 'foo' { export const a: number; }` still diverged — on the prop's *optionality*, not on the lift. Upstream's `required` is `!node.initializer` for every variable kind; rsvelte approximated it as `is_let && !has_default`, which is only equivalent for `let`. So `export declare const dc: number` (and `export var v;`) came out as `{dc?: number}` where official emits `{dc: number}`. `required` is now its own flag on `ExportedNameInfo`, read by both `createReturnElementsType`'s `?` and `dontAddTypeDef`.

## Measurement

Differential against the pinned official `svelte2tsx` (`submodules/language-tools`, built against `submodules/svelte` 5.56.9), byte equality on the full output:

| grid | before | after |
|---|---|---|
| rune token × position × host (156 cells) | 66 divergent | 6 |
| exported/nested declaration × host (50 cells) | 12 divergent | **0** |
| every source asserted by `svelte2tsx_runes_reference_3260.rs` (37 cells) | — | **0** |

The 6 remaining rune-grid cells are one pre-existing, token-**independent** divergence — a component whose only script is `<script module>` and whose entire template is a single newline emits `async () => {};` where official emits `async () => {\n};`. It reproduces identically for `$foo`, is unrelated to runes detection, and is filed separately as #3307.

Regression control: all 4,468 `.svelte` files under `submodules/svelte/packages/svelte/tests` compiled with both compilers before and after. The set of divergent ids is **identical** (266 either way) — i.e. this collected population never reaches either shape, which is why neither defect was visible to a corpus gate. `cargo test -p rsvelte_projection` is green (57 suites), including the 253-fixture upstream parity suite.

## Ratchets

No `compatibility/*known-failures*` file is touched, so the ordering constraint around #3176's re-baseline does not apply here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ABb93VNuxXbM1MZZTRp19H
