### PR TITLE
fix(css): injected-stylesheet minification and the `</style>` block scan

### DIFF
--- a/.changeset/injected-css-minify.md
+++ b/.changeset/injected-css-minify.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/compiler": patch
+---
+
+Minify the injected stylesheet the way upstream does. `css: "injected"` (and every custom element, which injects unconditionally) emitted a `;` after every declaration on top of the one already in the source, doubled the opening brace of a rule with a nested rule — leaving the stylesheet with unbalanced braces — and kept the whitespace `remove_preceding_whitespace` removes. A declaration's span ends at the `;` or `}`, so the separator comes from the source; the whitespace runs before a rule, before a declaration and before a block's closing brace are now dropped from the emitted text rather than from a gap. `animation` / `animation-name` declarations, at-rules and their closing braces keep their whitespace, matching upstream's visitor split, and `@font-face` and `:global {…}` bodies are minified like any other block. `css.code` — the only thing the corpus gate compares — was already correct and is unchanged.

--- a/.changeset/style-close-tag-scan.md
+++ b/.changeset/style-close-tag-scan.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/compiler": patch
+---
+
+Stop ending a `<style>` block at a `</style>` that sits inside a CSS string, a `/* */` or `<!-- -->` comment, or an unquoted `url(…)`. Upstream never scans the block as raw text — `read_body` tests `parser.match('</style')` only at a rule boundary, so those occurrences are content — while rsvelte used a plain byte search and rejected `.a { content: "a</style>b" }` with `unexpected_eof`. The scan now mirrors the branch order of upstream's `read_value`; a non-CSS `lang` block in lenient (lint) mode keeps the plain search, since a SCSS `// don't` would otherwise open a string that never closes.

--- a/crates/rsvelte_core/src/compiler/phases/1_parse/read/style.rs
+++ b/crates/rsvelte_core/src/compiler/phases/1_parse/read/style.rs
@@ -183,6 +183,89 @@ fn record_selector_comment_error(
 // ============================================================================
 
 impl<'a> Parser<'a> {
+    /// Advance `self.index` to the `</style` that closes the current block,
+    /// mirroring the CSS tokenisation upstream's readers perform: a `</style`
+    /// inside a CSS string, a `/* */` or `<!-- -->` comment, or an unquoted
+    /// `url(...)` is content, not a closing tag.
+    ///
+    /// Returns the first `<` that could not start a closing tag (used for the
+    /// `css_expected_identifier` diagnostic) and whether the scan ran out of
+    /// input inside a `url(`.
+    ///
+    /// `tokenise` is off for a non-CSS `lang` block in lenient (lint) mode: a
+    /// SCSS `// don't` would otherwise open a string that never closes.
+    fn scan_to_style_close(&mut self, tokenise: bool) -> (Option<usize>, bool) {
+        let content_start = self.index;
+        let bytes = self.bytes;
+        let len = bytes.len();
+        let mut first_invalid_lt: Option<usize> = None;
+        let mut quote: Option<u8> = None;
+        let mut in_url = false;
+        let mut escaped = false;
+        let mut i = self.index;
+
+        if !tokenise {
+            while let Some(offset) = memchr::memchr(b'<', &bytes[i..]) {
+                i += offset;
+                self.index = i;
+                if self.is_valid_closing_tag("</style") {
+                    return (first_invalid_lt, false);
+                }
+                if first_invalid_lt.is_none() {
+                    first_invalid_lt = Some(i);
+                }
+                i += 1;
+            }
+            self.index = len;
+            return (first_invalid_lt, false);
+        }
+
+        while i < len {
+            let ch = bytes[i];
+            // Mirrors the branch order of upstream's `read_value`.
+            if escaped {
+                escaped = false;
+            } else if ch == b'\\' {
+                escaped = true;
+            } else if Some(ch) == quote {
+                quote = None;
+            } else if ch == b')' {
+                in_url = false;
+            } else if quote.is_none() && (ch == b'"' || ch == b'\'') {
+                quote = Some(ch);
+            } else if ch == b'(' && i >= content_start + 3 && &bytes[i - 3..i] == b"url" {
+                in_url = true;
+            } else if quote.is_none() && !in_url {
+                if ch == b'/' && bytes.get(i + 1) == Some(&b'*') {
+                    // An unterminated comment keeps the old behaviour: fall
+                    // through so the CSS parse reports it.
+                    if let Some(off) = memchr::memmem::find(&bytes[i + 2..], b"*/") {
+                        i += 2 + off + 2;
+                        continue;
+                    }
+                } else if ch == b'<' {
+                    if bytes[i..].starts_with(b"<!--")
+                        && let Some(off) = memchr::memmem::find(&bytes[i + 4..], b"-->")
+                    {
+                        i += 4 + off + 3;
+                        continue;
+                    }
+                    self.index = i;
+                    if self.is_valid_closing_tag("</style") {
+                        return (first_invalid_lt, false);
+                    }
+                    if first_invalid_lt.is_none() {
+                        first_invalid_lt = Some(i);
+                    }
+                }
+            }
+            i += 1;
+        }
+
+        self.index = len;
+        (first_invalid_lt, in_url)
+    }
+
     /// Parse a `<style>` tag and store it in stylesheet.
     pub fn parse_style_tag(
         &mut self,
@@ -242,26 +325,12 @@ impl<'a> Parser<'a> {
 
         let content_start = self.index;
 
-        // Use SIMD-accelerated search for </style and check for invalid '<' along the way
-        let mut first_invalid_lt: Option<usize> = None;
-        loop {
-            // Search for next '<' using memchr
-            if let Some(offset) = memchr::memchr(b'<', &self.bytes[self.index..]) {
-                let lt_pos = self.index + offset;
-                self.index = lt_pos;
-                if self.is_valid_closing_tag("</style") {
-                    break;
-                }
-                // Track first invalid '<' that is not part of </style
-                if first_invalid_lt.is_none() {
-                    first_invalid_lt = Some(lt_pos);
-                }
-                self.index = lt_pos + 1;
-            } else {
-                self.index = self.bytes.len();
-                break;
-            }
-        }
+        // Upstream never scans the block as raw text: `read_body` only tests
+        // `parser.match('</style')` at a rule boundary, so a `</style` inside a
+        // CSS string, comment or `url()` is swallowed by `read_value` /
+        // `read_comment` / `allow_comment_or_whitespace`. Mirror that
+        // tokenisation instead of a plain byte search.
+        let (first_invalid_lt, unterminated_url) = self.scan_to_style_close(!lenient_non_css);
 
         let content_end = self.index;
         let style_content = &self.source[content_start..content_end];
@@ -314,7 +383,7 @@ impl<'a> Parser<'a> {
                 }
                 i += 1;
             }
-            if in_string {
+            if in_string || unterminated_url {
                 // Upstream's CSS reader always reports EOF at `parser.template.length`,
                 // and its template is the source with trailing whitespace trimmed.
                 return Err(crate::error::ParseError::svelte(

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/css.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/css.rs
@@ -907,6 +907,32 @@ impl CssWriter {
     fn mark(&mut self, offset: usize) {
         self.marks.insert(offset as u32);
     }
+
+    /// Drop the whitespace already emitted, mirroring upstream's
+    /// `remove_preceding_whitespace(node.start)` — which walks back over the
+    /// source rather than over a gap, so it can also cut into the tail of the
+    /// node before it. `\s` in JS is White_Space plus U+FEFF.
+    fn trim_preceding_whitespace(&mut self) {
+        let trimmed = self
+            .text
+            .trim_end_matches(|c: char| c.is_whitespace() || c == '\u{feff}')
+            .len();
+        if trimmed == self.text.len() {
+            return;
+        }
+        self.text.truncate(trimmed);
+        let end = trimmed as u32;
+        while let Some(&(gen_start, _, len)) = self.copies.last() {
+            if gen_start >= end {
+                self.copies.pop();
+            } else {
+                if gen_start + len > end {
+                    self.copies.last_mut().unwrap().2 = end - gen_start;
+                }
+                break;
+            }
+        }
+    }
 }
 
 impl std::fmt::Write for CssWriter {
@@ -1287,6 +1313,40 @@ fn selector_contains_global_block(node: &Value) -> bool {
 /// At-rules count too: an `@media` nested inside a rule can contain rules whose
 /// selectors need transformation, and a nested `@keyframes` prelude needs hash
 /// prefixing, so the block cannot simply be copied verbatim from source.
+/// Upstream's Declaration visitor handles `animation` / `animation-name` (after
+/// `remove_css_prefix`) in its FIRST branch, so those declarations are never
+/// minified and keep the whitespace around them.
+fn is_animation_declaration(property: &str) -> bool {
+    let lower = property.to_ascii_lowercase();
+    let bare = lower
+        .strip_prefix("-webkit-")
+        .or_else(|| lower.strip_prefix("-moz-"))
+        .or_else(|| lower.strip_prefix("-o-"))
+        .or_else(|| lower.strip_prefix("-ms-"))
+        .unwrap_or(&lower);
+    bare == "animation" || bare == "animation-name"
+}
+
+/// Emit a declaration the way upstream's minifier does: the whitespace run that
+/// starts immediately after `property.length + 1` bytes is dropped, so
+/// `color : red` (space before the colon) is left alone and custom properties
+/// are skipped entirely.
+fn push_minified_declaration(output: &mut CssWriter, decl_text: &str, property: &str) {
+    if property.starts_with("--") {
+        output.push_str(decl_text);
+        return;
+    }
+    let start = property.len() + 1;
+    if start > decl_text.len() || !decl_text.is_char_boundary(start) {
+        output.push_str(decl_text);
+        return;
+    }
+    let rest = &decl_text[start..];
+    let value = rest.trim_start_matches(|c: char| c.is_whitespace() || c == '\u{feff}');
+    output.push_str(&decl_text[..start]);
+    output.push_str(value);
+}
+
 fn has_nested_rules(block: &Value) -> bool {
     if let Some(children) = block.get("children").and_then(|c| c.as_array()) {
         children.iter().any(|child| {
@@ -5416,17 +5476,18 @@ fn transform_rule_preserving<'a>(
     let node_start = node.get("start").and_then(|s| s.as_u64()).unwrap_or(0) as usize;
     let node_end = node.get("end").and_then(|e| e.as_u64()).unwrap_or(0) as usize;
 
-    // Copy leading content from source. In minify mode, mirror upstream's
-    // `remove_preceding_whitespace(node.start)`: only the whitespace run
-    // immediately before the node is dropped, so comments (and their own
+    // Copy leading content from source, then mirror upstream's
+    // `remove_preceding_whitespace(node.start)` so comments (and their own
     // leading whitespace) survive minification.
     if node_start > *last_end {
         let ws_start = (*last_end).saturating_sub(css_start);
         let ws_end = node_start.saturating_sub(css_start);
         if ws_end <= css_source.len() && ws_start < ws_end {
-            let gap = &css_source[ws_start..ws_end];
-            output.copy(*last_end, if ctx.minify { gap.trim_end() } else { gap });
+            output.copy(*last_end, &css_source[ws_start..ws_end]);
         }
+    }
+    if ctx.minify {
+        output.trim_preceding_whitespace();
     }
 
     output.mark(node_start);
@@ -5549,20 +5610,16 @@ fn transform_rule_preserving<'a>(
             let block_start = block.get("start").and_then(|s| s.as_u64()).unwrap_or(0) as usize;
             let block_end = block.get("end").and_then(|e| e.as_u64()).unwrap_or(0) as usize;
 
-            if ctx.minify {
-                // In minify mode, use " {" (single space before brace)
-                output.push_str(" {");
-            } else {
-                // Preserve original whitespace between selector and block brace
-                let ws_start = prelude_end.saturating_sub(css_start);
-                let ws_end = block_start.saturating_sub(css_start);
-                if ws_end <= css_source.len() && ws_start < ws_end {
-                    output.copy(prelude_end, &css_source[ws_start..ws_end]);
-                }
+            // Preserve original whitespace between selector and block brace;
+            // upstream never removes it, in minify mode either.
+            let ws_start = prelude_end.saturating_sub(css_start);
+            let ws_end = block_start.saturating_sub(css_start);
+            if ws_end <= css_source.len() && ws_start < ws_end {
+                output.copy(prelude_end, &css_source[ws_start..ws_end]);
             }
 
             // Check if block contains nested rules that need special handling
-            if has_nested_rules(block) {
+            if has_nested_rules(block) || ctx.minify {
                 // Check if this rule contains :global - if so, nested rules are in a global block context.
                 // This affects specificity bumping (uses direct class instead of :where()).
                 let rule_starts_with_global = is_global_selector_rule(node);
@@ -5603,43 +5660,6 @@ fn transform_rule_preserving<'a>(
 
                 // Pop the prelude after processing
                 ctx.parent_preludes.borrow_mut().pop();
-            } else if ctx.minify {
-                // Minified block: output declarations without extra whitespace
-                if let Some(children) = block.get("children").and_then(|c| c.as_array()) {
-                    for child in children {
-                        if child.get("type").and_then(|t| t.as_str()) == Some("Declaration") {
-                            let prop = child.get("property").and_then(|p| p.as_str()).unwrap_or("");
-                            let child_start =
-                                child.get("start").and_then(|s| s.as_u64()).unwrap_or(0) as usize;
-                            let child_end =
-                                child.get("end").and_then(|e| e.as_u64()).unwrap_or(0) as usize;
-
-                            // Get the declaration text from source
-                            let decl_start = child_start.saturating_sub(css_start);
-                            let decl_end = child_end.saturating_sub(css_start);
-                            if decl_end <= css_source.len() && decl_start < decl_end {
-                                let decl_text = &css_source[decl_start..decl_end];
-                                // Minify: remove whitespace after colon (unless custom property)
-                                if !prop.starts_with("--") {
-                                    if let Some(colon_pos) = decl_text.find(':') {
-                                        let before_colon = &decl_text[..=colon_pos];
-                                        let after_colon = decl_text[colon_pos + 1..].trim_start();
-                                        output.push_str(before_colon);
-                                        output.push_str(after_colon);
-                                    } else {
-                                        output.push_str(decl_text);
-                                    }
-                                } else {
-                                    output.push_str(decl_text);
-                                }
-                                // Declaration end position is before the semicolon in our AST,
-                                // so we need to add it back
-                                output.push(';');
-                            }
-                        }
-                    }
-                }
-                output.push('}');
             } else {
                 // Copy the entire block from source (including braces and content)
                 let blk_start = block_start.saturating_sub(css_start);
@@ -5683,15 +5703,13 @@ fn transform_block_with_nested_rules<'a>(
             let child_start = child.get("start").and_then(|s| s.as_u64()).unwrap_or(0) as usize;
             let child_end = child.get("end").and_then(|e| e.as_u64()).unwrap_or(0) as usize;
 
-            // Copy content before this child. In minify mode only the
-            // whitespace run immediately before the child is dropped
-            // (upstream `remove_preceding_whitespace`), keeping comments.
+            // Copy content before this child; the whitespace run immediately
+            // before it is dropped per child kind below, so comments survive.
             if child_start > last_end {
                 let ws_start = last_end.saturating_sub(css_start);
                 let ws_end = child_start.saturating_sub(css_start);
                 if ws_end <= css_source.len() && ws_start < ws_end {
-                    let gap = &css_source[ws_start..ws_end];
-                    output.push_str(if ctx.minify { gap.trim_end() } else { gap });
+                    output.push_str(&css_source[ws_start..ws_end]);
                 }
             }
 
@@ -5700,6 +5718,9 @@ fn transform_block_with_nested_rules<'a>(
                     if is_global_block(child) {
                         // This is a :global { ... } block
                         // Comment out the :global { and } but keep inner content
+                        if ctx.minify {
+                            output.trim_preceding_whitespace();
+                        }
                         transform_global_block(
                             child,
                             selector,
@@ -5745,35 +5766,16 @@ fn transform_block_with_nested_rules<'a>(
                     );
                 }
                 Some("Declaration") => {
-                    if ctx.minify {
-                        // Minified: output declaration without leading whitespace
-                        // and remove whitespace after colon
+                    let decl_start = child_start.saturating_sub(css_start);
+                    let decl_end = child_end.saturating_sub(css_start);
+                    if decl_end <= css_source.len() && decl_start < decl_end {
+                        let decl_text = &css_source[decl_start..decl_end];
                         let prop = child.get("property").and_then(|p| p.as_str()).unwrap_or("");
-                        let decl_start = child_start.saturating_sub(css_start);
-                        let decl_end = child_end.saturating_sub(css_start);
-                        if decl_end <= css_source.len() && decl_start < decl_end {
-                            let decl_text = &css_source[decl_start..decl_end];
-                            if !prop.starts_with("--") {
-                                if let Some(colon_pos) = decl_text.find(':') {
-                                    let before_colon = &decl_text[..=colon_pos];
-                                    let after_colon = decl_text[colon_pos + 1..].trim_start();
-                                    output.push_str(before_colon);
-                                    output.push_str(after_colon);
-                                } else {
-                                    output.push_str(decl_text);
-                                }
-                            } else {
-                                output.push_str(decl_text);
-                            }
-                            // Declaration end position is before the semicolon in our AST
-                            output.push(';');
-                        }
-                    } else {
-                        // Copy the declaration from source
-                        let decl_start = child_start.saturating_sub(css_start);
-                        let decl_end = child_end.saturating_sub(css_start);
-                        if decl_end <= css_source.len() && decl_start < decl_end {
-                            output.push_str(&css_source[decl_start..decl_end]);
+                        if ctx.minify && !is_animation_declaration(prop) {
+                            output.trim_preceding_whitespace();
+                            push_minified_declaration(output, decl_text, prop);
+                        } else {
+                            output.push_str(decl_text);
                         }
                     }
                 }
@@ -5784,15 +5786,18 @@ fn transform_block_with_nested_rules<'a>(
         }
     }
 
-    // Copy content before the closing brace. In minify mode mirror upstream's
-    // `remove_preceding_whitespace(node.block.end - 1)`.
+    // Copy content before the closing brace, then mirror upstream's
+    // `remove_preceding_whitespace(node.block.end - 1)` — which can cut into the
+    // last declaration's own span, since that span ends at the `;` or `}`.
     if block_end > last_end {
         let ws_start = last_end.saturating_sub(css_start);
         let ws_end = (block_end - 1).saturating_sub(css_start); // -1 to exclude the '}'
         if ws_end <= css_source.len() && ws_start < ws_end {
-            let gap = &css_source[ws_start..ws_end];
-            output.push_str(if ctx.minify { gap.trim_end() } else { gap });
+            output.push_str(&css_source[ws_start..ws_end]);
         }
+    }
+    if ctx.minify {
+        output.trim_preceding_whitespace();
     }
 
     output.push('}');
@@ -5885,16 +5890,18 @@ fn transform_nested_atrule<'a>(
             let child_start = child.get("start").and_then(|s| s.as_u64()).unwrap_or(0) as usize;
             let child_end = child.get("end").and_then(|e| e.as_u64()).unwrap_or(0) as usize;
 
-            // Copy content before this child (minify keeps comments, dropping
-            // only the whitespace run immediately before the child).
+            // Copy content before this child; the whitespace run immediately
+            // before it is dropped per child kind below, so comments survive.
             if child_start > last_end {
-                let gap = src(last_end, child_start);
-                output.push_str(if ctx.minify { gap.trim_end() } else { gap });
+                output.push_str(src(last_end, child_start));
             }
 
             match child_type {
                 Some("Rule") => {
                     if is_global_block(child) {
+                        if ctx.minify {
+                            output.trim_preceding_whitespace();
+                        }
                         transform_global_block(
                             child,
                             selector,
@@ -5939,25 +5946,13 @@ fn transform_nested_atrule<'a>(
                     );
                 }
                 Some("Declaration") => {
-                    if ctx.minify {
-                        let prop = child.get("property").and_then(|p| p.as_str()).unwrap_or("");
-                        let decl_text = src(child_start, child_end);
-                        if !prop.starts_with("--") {
-                            if let Some(colon_pos) = decl_text.find(':') {
-                                let before_colon = &decl_text[..=colon_pos];
-                                let after_colon = decl_text[colon_pos + 1..].trim_start();
-                                output.push_str(before_colon);
-                                output.push_str(after_colon);
-                            } else {
-                                output.push_str(decl_text);
-                            }
-                        } else {
-                            output.push_str(decl_text);
-                        }
-                        // Declaration end position is before the semicolon in our AST
-                        output.push(';');
+                    let prop = child.get("property").and_then(|p| p.as_str()).unwrap_or("");
+                    let decl_text = src(child_start, child_end);
+                    if ctx.minify && !is_animation_declaration(prop) {
+                        output.trim_preceding_whitespace();
+                        push_minified_declaration(output, decl_text, prop);
                     } else {
-                        output.push_str(src(child_start, child_end));
+                        output.push_str(decl_text);
                     }
                 }
                 _ => {}
@@ -5967,26 +5962,26 @@ fn transform_nested_atrule<'a>(
         }
     }
 
-    // Copy trailing content before the closing brace (minify drops only the
-    // final whitespace run).
+    // Copy trailing content before the closing brace verbatim: upstream's
+    // `remove_preceding_whitespace(node.block.end - 1)` lives in the Rule
+    // visitor, so an at-rule's own closing brace keeps its whitespace.
     if block_end > last_end + 1 {
-        let gap = src(last_end, block_end - 1);
-        output.push_str(if ctx.minify { gap.trim_end() } else { gap });
+        output.push_str(src(last_end, block_end - 1));
     }
 
     output.push('}');
 }
 
 /// Transform a :global { ... } block by commenting out the :global wrapper
-fn transform_global_block(
-    node: &Value,
+fn transform_global_block<'a>(
+    node: &'a Value,
     _selector: &str,
     _hash: &str,
     css_source: &str,
     css_start: usize,
     output: &mut CssWriter,
     _specificity_bumped: &mut bool,
-    _ctx: &CssContext,
+    _ctx: &CssContext<'a>,
 ) {
     // Get positions
     let prelude = node.get("prelude");
@@ -6017,13 +6012,65 @@ fn transform_global_block(
                 let child_start = child.get("start").and_then(|s| s.as_u64()).unwrap_or(0) as usize;
                 let child_end = child.get("end").and_then(|e| e.as_u64()).unwrap_or(0) as usize;
 
-                // Copy whitespace before child (skip when minifying)
-                if !_ctx.minify && child_start > last_end {
+                // Copy whitespace before child
+                if child_start > last_end {
                     let ws_start = last_end.saturating_sub(css_start);
                     let ws_end = child_start.saturating_sub(css_start);
                     if ws_end <= css_source.len() && ws_start < ws_end {
                         output.push_str(&css_source[ws_start..ws_end]);
                     }
+                }
+
+                // Upstream visits the block, so a minified `:global {}` body is
+                // minified like any other; only the scoping is skipped.
+                if _ctx.minify {
+                    let mut local_last_end = child_start;
+                    match child.get("type").and_then(|t| t.as_str()) {
+                        Some("Rule") => transform_rule_preserving(
+                            child,
+                            _selector,
+                            _hash,
+                            css_source,
+                            css_start,
+                            output,
+                            _specificity_bumped,
+                            &mut local_last_end,
+                            _ctx,
+                            false,
+                            true,
+                            true,
+                        ),
+                        Some("Atrule") => transform_nested_atrule(
+                            child,
+                            _selector,
+                            _hash,
+                            css_source,
+                            css_start,
+                            output,
+                            _specificity_bumped,
+                            _ctx,
+                            true,
+                            false,
+                            true,
+                        ),
+                        Some("Declaration") => {
+                            let prop = child.get("property").and_then(|p| p.as_str()).unwrap_or("");
+                            let from = child_start.saturating_sub(css_start);
+                            let to = child_end.saturating_sub(css_start);
+                            if to <= css_source.len() && from < to {
+                                let decl_text = &css_source[from..to];
+                                if is_animation_declaration(prop) {
+                                    output.push_str(decl_text);
+                                } else {
+                                    output.trim_preceding_whitespace();
+                                    push_minified_declaration(output, decl_text, prop);
+                                }
+                            }
+                        }
+                        _ => {}
+                    }
+                    last_end = child_end;
+                    continue;
                 }
 
                 // Copy the child from source (don't scope - it's inside :global).
@@ -6048,13 +6095,17 @@ fn transform_global_block(
                 last_end = child_end;
             }
 
-            // Copy whitespace before closing brace (skip when minifying)
-            if !_ctx.minify && block_end > last_end {
+            // Copy whitespace before closing brace, then mirror the Rule
+            // visitor's `remove_preceding_whitespace(node.block.end - 1)`.
+            if block_end > last_end {
                 let ws_start = last_end.saturating_sub(css_start);
                 let ws_end = (block_end - 1).saturating_sub(css_start);
                 if ws_end <= css_source.len() && ws_start < ws_end {
                     output.push_str(&css_source[ws_start..ws_end]);
                 }
+            }
+            if _ctx.minify {
+                output.trim_preceding_whitespace();
             }
         }
 
@@ -6121,8 +6172,10 @@ fn transform_atrule_preserving<'a>(
     let node_start = node.get("start").and_then(|s| s.as_u64()).unwrap_or(0) as usize;
     let node_end = node.get("end").and_then(|e| e.as_u64()).unwrap_or(0) as usize;
 
-    // Copy leading whitespace from source (skip when minifying)
-    if !ctx.minify && node_start > *last_end {
+    // Copy leading whitespace from source. Upstream's
+    // `remove_preceding_whitespace(node.start)` lives in the Rule visitor only,
+    // so an at-rule keeps the whitespace in front of it even when minifying.
+    if node_start > *last_end {
         let ws_start = (*last_end).saturating_sub(css_start);
         let ws_end = node_start.saturating_sub(css_start);
         if ws_end <= css_source.len() && ws_start < ws_end {
@@ -6183,6 +6236,25 @@ fn transform_atrule_preserving<'a>(
     );
 
     if is_passthrough {
+        // Upstream's Declaration visitor runs at every depth, so an `@font-face`
+        // body is minified like any other block.
+        if ctx.minify && block.is_some() {
+            transform_nested_atrule(
+                node,
+                selector,
+                hash,
+                css_source,
+                css_start,
+                output,
+                specificity_bumped,
+                ctx,
+                false,
+                false,
+                false,
+            );
+            *last_end = node_end;
+            return;
+        }
         // Copy the entire at-rule from source
         let src_start = node_start.saturating_sub(css_start);
         let src_end = node_end.saturating_sub(css_start);
@@ -6225,15 +6297,14 @@ fn transform_atrule_preserving<'a>(
                     false, // rules inside at-rules are not nested (they start fresh)
                 );
             }
-            // Copy trailing content in block (skip when minifying)
-            if !ctx.minify {
-                let block_end = block.get("end").and_then(|e| e.as_u64()).unwrap_or(0) as usize;
-                if inner_last_end < block_end {
-                    let trail_start = inner_last_end.saturating_sub(css_start);
-                    let trail_end = (block_end - 1).saturating_sub(css_start); // -1 to exclude closing brace
-                    if trail_end <= css_source.len() && trail_start < trail_end {
-                        output.push_str(&css_source[trail_start..trail_end]);
-                    }
+            // Copy trailing content in block. An at-rule's closing brace keeps
+            // its whitespace: only the Rule visitor trims upstream.
+            let block_end = block.get("end").and_then(|e| e.as_u64()).unwrap_or(0) as usize;
+            if inner_last_end < block_end {
+                let trail_start = inner_last_end.saturating_sub(css_start);
+                let trail_end = (block_end - 1).saturating_sub(css_start); // -1 to exclude closing brace
+                if trail_end <= css_source.len() && trail_start < trail_end {
+                    output.push_str(&css_source[trail_start..trail_end]);
                 }
             }
         }

--- a/crates/rsvelte_core/tests/css_injected_minify_3226.rs
+++ b/crates/rsvelte_core/tests/css_injected_minify_3226.rs
@@ -1,0 +1,138 @@
+//! The stylesheet injected into `js.code` (`css: "injected"`, and every custom
+//! element) is minified, and `css.code` — the only thing the corpus gate
+//! compares — is byte-identical on all of these, so nothing saw the minifier.
+//! It emitted a `;` per declaration on top of the source's own, doubled the
+//! opening brace of a nested block, and kept the whitespace upstream's
+//! `remove_preceding_whitespace` removes.
+
+use rsvelte_core::{CompileOptions, GenerateMode, compile, compiler::CssMode};
+
+fn injected(body: &str) -> String {
+    let source = format!("<b class=\"a\">x</b>\n<style>\n\t{body}\n</style>\n");
+    let result = compile(
+        &source,
+        CompileOptions {
+            filename: Some("T.svelte".to_string()),
+            generate: GenerateMode::Client,
+            dev: false,
+            css: CssMode::Injected,
+            ..Default::default()
+        },
+    )
+    .expect("compile");
+    let js = result.js.code;
+    let start = js.find("code: '").expect("no injected stylesheet") + "code: '".len();
+    let mut out = String::new();
+    let mut chars = js[start..].chars();
+    while let Some(ch) = chars.next() {
+        match ch {
+            '\'' => return out,
+            '\\' => match chars.next() {
+                Some('n') => out.push('\n'),
+                Some('t') => out.push('\t'),
+                Some(escaped) => out.push(escaped),
+                None => break,
+            },
+            _ => out.push(ch),
+        }
+    }
+    panic!("unterminated stylesheet literal");
+}
+
+#[test]
+fn a_declaration_without_a_trailing_semicolon_gets_none() {
+    assert_eq!(
+        injected(".a { color: red }"),
+        ".a.svelte-1lj1c24 {color:red}"
+    );
+}
+
+#[test]
+fn a_declaration_with_a_trailing_semicolon_keeps_exactly_one() {
+    assert_eq!(
+        injected(".a { color: red; }"),
+        ".a.svelte-1lj1c24 {color:red;}"
+    );
+}
+
+#[test]
+fn sibling_declarations_keep_the_source_separator() {
+    assert_eq!(
+        injected(".a { color: red; margin: 0 }"),
+        ".a.svelte-1lj1c24 {color:red;margin:0}"
+    );
+}
+
+#[test]
+fn a_value_with_spaces_is_not_given_a_trailing_semicolon() {
+    assert_eq!(
+        injected(".a { margin: 0 1px 2px 3px }"),
+        ".a.svelte-1lj1c24 {margin:0 1px 2px 3px}"
+    );
+}
+
+#[test]
+fn a_nested_rule_keeps_the_braces_balanced() {
+    assert_eq!(
+        injected(".a { color: red; &:hover { color: blue } }"),
+        ".a.svelte-1lj1c24 {color:red;&:hover {color:blue}}"
+    );
+}
+
+#[test]
+fn a_space_before_the_colon_is_left_alone() {
+    // Upstream cuts the whitespace run starting at `property.length + 1`, so a
+    // declaration whose colon is not adjacent to the property is untouched.
+    assert_eq!(
+        injected(".a { COLOR : red }"),
+        ".a.svelte-1lj1c24 {COLOR : red}"
+    );
+}
+
+#[test]
+fn a_custom_property_keeps_its_whitespace() {
+    assert_eq!(
+        injected(".a { --custom:   spaced  ; color: red }"),
+        ".a.svelte-1lj1c24 {--custom:   spaced  ;color:red}"
+    );
+}
+
+#[test]
+fn an_animation_declaration_is_not_minified() {
+    // Upstream's Declaration visitor handles `animation` in its first branch, so
+    // the minify branch never runs for it.
+    assert_eq!(
+        injected(".a { animation: spin 1s }\n\t@keyframes spin { from { opacity: 0 } }"),
+        ".a.svelte-1lj1c24 { animation: svelte-1lj1c24-spin 1s}\n\t@keyframes svelte-1lj1c24-spin { from { opacity: 0 } }"
+    );
+}
+
+#[test]
+fn an_at_rule_keeps_the_whitespace_around_it() {
+    // `remove_preceding_whitespace` is called from the Rule visitor only.
+    assert_eq!(
+        injected("@media (min-width: 1px) { .a { color: red } }"),
+        "\n\t@media (min-width: 1px) {.a.svelte-1lj1c24 {color:red} }"
+    );
+}
+
+#[test]
+fn a_font_face_body_is_minified_too() {
+    assert_eq!(
+        injected("@font-face { font-family: x; src: url(a.woff) }\n\t.a { color: red }"),
+        "\n\t@font-face {font-family:x;src:url(a.woff) }.a.svelte-1lj1c24 {color:red}"
+    );
+}
+
+#[test]
+fn a_global_block_body_is_minified_too() {
+    assert_eq!(injected(":global { .g { color: red } }"), ".g {color:red}");
+}
+
+#[test]
+fn a_comment_survives_minification() {
+    assert_eq!(
+        injected(".a { /* hi */ color: red }"),
+        ".a.svelte-1lj1c24 { /* hi */color:red}"
+    );
+}

--- a/crates/rsvelte_core/tests/style_close_tag_scan_3281.rs
+++ b/crates/rsvelte_core/tests/style_close_tag_scan_3281.rs
@@ -1,0 +1,167 @@
+//! Upstream never scans a `<style>` block as raw text: `read_body` tests
+//! `parser.match('</style')` only at a rule boundary, so a `</style` inside a
+//! CSS string, a comment or an unquoted `url()` is content. rsvelte used a plain
+//! byte search for `</style`, which ended the block early and left the rest of
+//! the file to be parsed as markup — an over-rejection of documents the official
+//! compiler compiles.
+
+use rsvelte_core::{CompileOptions, GenerateMode, compile, compiler::CssMode};
+
+/// The stylesheet with the component hash replaced by `HASH`.
+fn scoped_css(body: &str) -> String {
+    let source = format!("<p class=\"a\">x</p>\n<style>{body}</style>\n");
+    let result = compile(
+        &source,
+        CompileOptions {
+            filename: Some("T.svelte".to_string()),
+            generate: GenerateMode::Client,
+            dev: false,
+            css: CssMode::External,
+            ..Default::default()
+        },
+    )
+    .unwrap_or_else(|err| panic!("{body}: {err:?}"));
+    let css = result.css.map(|c| c.code).unwrap_or_default();
+    // An unused rule is commented out, so it carries no scope class.
+    let Some(start) = css.find("svelte-") else {
+        return css;
+    };
+    let len = css[start..]
+        .char_indices()
+        .find(|(i, c)| *i > 0 && !c.is_ascii_alphanumeric() && *c != '-')
+        .map_or(css.len() - start, |(i, _)| i);
+    css.replace(&css[start..start + len], "HASH")
+}
+
+#[test]
+fn a_closing_tag_inside_a_double_quoted_value_is_content() {
+    assert_eq!(
+        scoped_css(r#".a { content: "a</style>b" }"#),
+        r#".a.HASH { content: "a</style>b" }"#
+    );
+}
+
+#[test]
+fn a_closing_tag_inside_a_single_quoted_value_is_content() {
+    assert_eq!(
+        scoped_css(".a { content: 'a</style>b' }"),
+        ".a.HASH { content: 'a</style>b' }"
+    );
+}
+
+#[test]
+fn a_closing_tag_with_a_space_before_the_bracket_is_content() {
+    assert_eq!(
+        scoped_css(r#".a { content: "a</style >b" }"#),
+        r#".a.HASH { content: "a</style >b" }"#
+    );
+}
+
+#[test]
+fn a_closing_tag_inside_a_quoted_url_is_content() {
+    assert_eq!(
+        scoped_css(r#".a { background: url("</style>") }"#),
+        r#".a.HASH { background: url("</style>") }"#
+    );
+}
+
+#[test]
+fn a_closing_tag_inside_an_unquoted_url_is_content() {
+    assert_eq!(
+        scoped_css(".a { background: url(</style>) }"),
+        ".a.HASH { background: url(</style>) }"
+    );
+}
+
+#[test]
+fn a_closing_tag_inside_a_trailing_comment_is_content() {
+    assert_eq!(
+        scoped_css(".a { color: red } /* </style> */"),
+        ".a.HASH { color: red } /* </style> */"
+    );
+}
+
+#[test]
+fn a_closing_tag_inside_a_leading_comment_is_content() {
+    assert_eq!(
+        scoped_css("/* </style> */ .a { color: red }"),
+        "/* </style> */ .a.HASH { color: red }"
+    );
+}
+
+#[test]
+fn a_closing_tag_inside_an_html_comment_is_content() {
+    assert_eq!(
+        scoped_css("<!-- </style> --> .a { color: red }"),
+        "<!-- </style> --> .a.HASH { color: red }"
+    );
+}
+
+#[test]
+fn a_closing_tag_inside_an_attribute_selector_value_is_content() {
+    // The rule is unused, so it is commented out rather than pruned — which is
+    // still proof the block reader ran to the real `</style>`.
+    assert_eq!(
+        scoped_css(r#".a[data-x="</style>"] { color: red }"#),
+        r#"/* (unused) .a[data-x="</style>"] { color: red }*/"#
+    );
+}
+
+#[test]
+fn an_escaped_quote_does_not_reopen_the_string() {
+    assert_eq!(
+        scoped_css(r#".a { content: "a\"</style>b" }"#),
+        r#".a.HASH { content: "a\"</style>b" }"#
+    );
+}
+
+#[test]
+fn an_uppercase_closing_tag_is_content_too() {
+    // Control: the block reader is reached and agrees when there is no
+    // lowercase `</style` to trip on.
+    assert_eq!(
+        scoped_css(r#".a { content: "a</STYLE>b" }"#),
+        r#".a.HASH { content: "a</STYLE>b" }"#
+    );
+}
+
+#[test]
+fn a_real_closing_tag_still_ends_the_block() {
+    assert_eq!(
+        scoped_css(r#".a { content: "ab" }"#),
+        r#".a.HASH { content: "ab" }"#
+    );
+}
+
+#[test]
+fn a_stray_open_tag_in_the_block_is_still_rejected() {
+    let source = "<p class=\"a\">x</p>\n<style>.a { color: red } <b></style>\n";
+    let err = compile(
+        source,
+        CompileOptions {
+            filename: Some("T.svelte".to_string()),
+            generate: GenerateMode::Client,
+            ..Default::default()
+        },
+    )
+    .expect_err("expected a CSS parse error");
+    assert!(
+        format!("{err:?}").contains("css_expected_identifier"),
+        "{err:?}"
+    );
+}
+
+#[test]
+fn an_unterminated_string_still_reports_eof() {
+    let source = "<p class=\"a\">x</p>\n<style>.a { content: \"ab }</style>\n";
+    let err = compile(
+        source,
+        CompileOptions {
+            filename: Some("T.svelte".to_string()),
+            generate: GenerateMode::Client,
+            ..Default::default()
+        },
+    )
+    .expect_err("expected an EOF error");
+    assert!(format!("{err:?}").contains("unexpected_eof"), "{err:?}");
+}


### PR DESCRIPTION
Two CSS defects that no gate could see, one per commit.

Closes #3226
Closes #3281

## `fix(compiler)`: the injected stylesheet was minified wrong

`css: "injected"` — and every `customElement` component, which injects
unconditionally — is the only mode that runs the CSS minifier. `css.code`, the
only thing the corpus gate compares, is byte-identical on every shape below, so
the minifier had never been compared to anything.

Four causes, all in `3_transform/css.rs`:

- **A declaration's span ends at the `;` or `}`** (upstream sets `end` before
  `parser.eat(';')`), so the separator is already in the source. The emitter
  pushed one per declaration on top of it — `{color:red;;&:hover …}`.
- **The nested-block path pushed a second `{`** over the one
  `transform_rule_preserving` had already written as a hard-coded `" {"`,
  leaving the stylesheet with **unbalanced braces** — the browser drops
  everything after it.
- **`remove_preceding_whitespace` was applied to a gap**, but upstream applies it
  to the *source*, and it can cut into the tail of the node before it. Since a
  declaration's span reaches the `}`, `{color:red }` kept the space. It now
  truncates what has been written, which is what MagicString's `remove` does
  (`CssWriter::trim_preceding_whitespace`, which also repairs the sourcemap
  `copies`).
- **The colon-whitespace rule was "trim after the first `:`"**, where upstream
  cuts the run starting at `property.length + 1` — so `COLOR : red` (space
  before the colon) is left alone.

Three more divergences fell out of mirroring upstream's visitor split:
`animation` / `animation-name` declarations are handled in the Declaration
visitor's **first** branch and so are never minified; `remove_preceding_whitespace`
lives in the **Rule** visitor only, so an at-rule and its closing brace keep their
whitespace; and `@font-face` and `:global {…}` bodies are visited like any other
block, so their declarations are minified too.

Measured against the pinned official compiler over 30 stylesheet bodies × 2
script forms: **50 of 60 diverging before, 0 after** (the count was 54 before the
first two fixes). The non-minify path is untouched — every edit is behind
`ctx.minify` or is a no-op when it is false — so `css.code` and both dev targets
are unchanged.

## `fix(parser)`: a `</style>` inside CSS ended the block early

Upstream never scans a `<style>` block as raw text. `read_body`'s `finished`
predicate tests `parser.match('</style')` **only at a rule boundary**, so a
`</style` inside a CSS string, a `/* */` or `<!-- -->` comment, or an unquoted
`url(…)` is consumed by `read_value` / `read_comment` /
`allow_comment_or_whitespace`. rsvelte used a plain `memchr` search for `</style`,
ended the block there and parsed the rest of the file as markup, so
`.a { content: "a</style>b" }` was rejected with `unexpected_eof` — an
over-rejection of documents official compiles.

`scan_to_style_close` now mirrors the branch order of upstream's `read_value`
(escape, quote, `)`, quote-open, `url(`, comment, `<`). Verified against official
on 15 accepted shapes and 6 rejected ones.

One deliberate exception: a **non-CSS `lang` block in lenient (lint) mode** keeps
the plain byte search. That body is not CSS — a SCSS `// don't` would open a
string that never closes — and `lenient_non_css` is already the flag for "do not
apply CSS-shaped reasoning here" (it gates the unterminated-string and
no-`{` checks directly below). The formatter and the language server both set
`skip_non_css_lang_style: true`, so this preserves their behaviour exactly.

## Testing

- `crates/rsvelte_core/tests/css_injected_minify_3226.rs` — 12 cases, each
  asserting the exact injected literal the pinned official compiler emits.
- `crates/rsvelte_core/tests/style_close_tag_scan_3281.rs` — 14 cases: the six
  shapes from the issue, the two controls, an escaped quote, an attribute-selector
  value, plus two rejections that must stay rejections (`<b>` in the block still
  gives `css_expected_identifier`; an unterminated string still gives
  `unexpected_eof`).

Suites run green: `css`, `compiler_fixtures`, `compiler_errors`, `parser_fixtures`,
`validator`, `ssr`, `sourcemaps`, `sourcemaps_gate`, `runtime`, `print`,
`preprocess`, every `css_*` test, `-p rsvelte_formatter`, `-p rsvelte_projection`,
`-p rsvelte_lint --features native`. `cargo fmt` + `cargo clippy --all-targets
--all-features -D warnings` clean.

**No ratchet is touched** — no `compatibility/*known-failures*` file is modified,
and `--update-baseline` was not run.

## Two things deliberately not done

**No `pattern-corpus` repro for either fix.** For #3281 the oxfmt(`svelte: true`)
oracle — prettier-plugin-svelte, i.e. a vendored Svelte parser with the *same*
defect — rejects the shape outright (`element_invalid_closing_tag` on
`content: "a</style>b"`, `expected_token` on `/* </style> */`), so the file could
only ever be an oracle skip, never a formatter case. For #3226 a
`css="injected"` component diverges on `client-dev` for an **unrelated,
pre-existing** reason: the dev-only `sourceMappingURL` comment appended to the
injected stylesheet carries `"mappings":";;;;;;"` where official carries real
segments. That is present on `main` (reproduced with a binary built before these
commits) and is out of scope here — filed separately as
https://github.com/baseballyama/rsvelte/issues/3309. The Rust tests above pin
both behaviours instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ABb93VNuxXbM1MZZTRp19H
