### PR TITLE
fix(compiler): run the host-independent bind: rules for every host, and read a duplicate this= like upstream

### DIFF
--- a/.changeset/bind-host-axis-and-this-attribute.md
+++ b/.changeset/bind-host-axis-and-this-attribute.md
@@ -1,0 +1,12 @@
+---
+"@rsvelte/compiler": patch
+---
+
+Run the host-independent half of the `bind:` rules for every host, and read `this=` the way the official compiler does.
+
+- `await` anywhere a `bind:` expression can reach it — including both halves of a `{get, set}` pair — is now rejected with `experimental_async`, as the official compiler does; an `await` inside a function *below* the pair still compiles.
+- `<svelte:element>` reached none of the target-shape rules, so `bind:clientWidth={o?.k}` compiled into `($$value) => o?.k = $$value`, which no JS parser accepts, and a shorthand `bind:clientWidth` emitted a write to an undeclared name. A component and `<svelte:component>` never reached the `{get, set}` pair rules, so `bind:group={get, set}`, a parenthesised pair and a three-element pair were all accepted.
+- On the server, `<select bind:value={get, set}>` rendered the sequence expression — whose value is the *setter* — instead of calling the getter, so no `<option>` was ever selected.
+- `<C bind:this={x} bind:this={x} />` was rejected with `attribute_duplicate`; the official compiler exempts every attribute named `this` from that rule.
+- A second `this=` on `<svelte:element>` / `<svelte:component>` was dropped instead of being passed through as an attribute / prop.
+- `<svelte:self bind:group={x} />` did not declare its binding group array.

--- a/crates/rsvelte_core/src/compiler/phases/1_parse/state/element.rs
+++ b/crates/rsvelte_core/src/compiler/phases/1_parse/state/element.rs
@@ -685,17 +685,9 @@ impl<'a> Parser<'a> {
                 // Extract the "this" attribute to get the expression
                 let expression = self.extract_this_attribute(&attributes);
 
-                // Filter out the "this" attribute from the list
-                let filtered_attrs: Vec<_> = attributes
-                    .into_iter()
-                    .filter(|attr| {
-                        if let crate::ast::Attribute::Attribute(node) = attr {
-                            node.name.as_str() != "this"
-                        } else {
-                            true
-                        }
-                    })
-                    .collect();
+                // Upstream splices out only the *first* `this` (element.js L266-280);
+                // a second one stays in the list and is passed through as a prop.
+                let filtered_attrs = remove_first_this_attribute(attributes);
 
                 TemplateNode::SvelteComponent(Box::new(SvelteComponentElement {
                     start: start as u32,
@@ -739,43 +731,31 @@ impl<'a> Parser<'a> {
                 // Check if the "this" attribute is a string value (not an expression)
                 // and emit svelte_element_invalid_this warning if so.
                 // Corresponds to element.js L288-289: if (!is_expression_attribute(definition)) { w.svelte_element_invalid_this(definition); }
-                for attr in &attributes {
-                    if let crate::ast::Attribute::Attribute(node) = attr
-                        && node.name.as_str() == "this"
-                    {
-                        let is_expression_attribute = match &node.value {
-                            AttributeValue::Expression(_) => true,
-                            AttributeValue::Sequence(parts) => {
-                                parts.len() == 1
-                                    && matches!(&parts[0], AttributeValuePart::ExpressionTag(_))
-                            }
-                            _ => false,
-                        };
-                        if !is_expression_attribute {
-                            self.parse_warnings.push(crate::ast::template::ParseWarning {
-                                code: "svelte_element_invalid_this".to_string(),
-                                message: "`this` should be an `{expression}`. Using a string attribute value will cause an error in future versions of Svelte\nhttps://svelte.dev/e/svelte_element_invalid_this".to_string(),
-                                start: node.start,
-                                end: node.end,
-                            });
+                if let Some(node) = definition {
+                    let is_expression_attribute = match &node.value {
+                        AttributeValue::Expression(_) => true,
+                        AttributeValue::Sequence(parts) => {
+                            parts.len() == 1
+                                && matches!(&parts[0], AttributeValuePart::ExpressionTag(_))
                         }
+                        _ => false,
+                    };
+                    if !is_expression_attribute {
+                        self.parse_warnings.push(crate::ast::template::ParseWarning {
+                            code: "svelte_element_invalid_this".to_string(),
+                            message: "`this` should be an `{expression}`. Using a string attribute value will cause an error in future versions of Svelte\nhttps://svelte.dev/e/svelte_element_invalid_this".to_string(),
+                            start: node.start,
+                            end: node.end,
+                        });
                     }
                 }
 
                 // Extract the "this" attribute to get the tag expression
                 let tag = self.extract_this_attribute(&attributes);
 
-                // Filter out the "this" attribute from the list
-                let filtered_attrs: Vec<_> = attributes
-                    .into_iter()
-                    .filter(|attr| {
-                        if let crate::ast::Attribute::Attribute(node) = attr {
-                            node.name.as_str() != "this"
-                        } else {
-                            true
-                        }
-                    })
-                    .collect();
+                // Upstream splices out only the *first* `this` (element.js L282-296);
+                // a second one stays in the list and is rendered as an attribute.
+                let filtered_attrs = remove_first_this_attribute(attributes);
 
                 TemplateNode::SvelteElement(Box::new(SvelteDynamicElement {
                     start: start as u32,
@@ -2856,4 +2836,19 @@ fn shorthand_first_invalid_offset(name: &str) -> Option<usize> {
             .find(|(_, c)| !is_identifier_continue(*c))
             .map(|(i, _)| i),
     }
+}
+
+/// Upstream consumes a `<svelte:element>` / `<svelte:component>` tag definition
+/// with `attributes.splice(index, 1)` on the *first* `this` attribute, so a
+/// second one survives as an ordinary attribute/prop.
+fn remove_first_this_attribute<'a>(
+    attributes: Vec<crate::ast::Attribute<'a>>,
+) -> Vec<crate::ast::Attribute<'a>> {
+    let mut attributes = attributes;
+    if let Some(index) = attributes.iter().position(|attr| {
+        matches!(attr, crate::ast::Attribute::Attribute(node) if node.name.as_str() == "this")
+    }) {
+        attributes.remove(index);
+    }
+    attributes
 }

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/mod.rs
@@ -4522,6 +4522,13 @@ fn mark_group_bindings_in_node(
             );
         }
         TemplateNode::SvelteSelf(s) => {
+            for attr in &s.attributes {
+                if let Attribute::BindDirective(bind) = attr
+                    && bind.name == "group"
+                {
+                    register_standalone_bind_group(bind, analysis);
+                }
+            }
             mark_group_bindings_in_fragment(&mut s.fragment, ancestor_stack, assignments, analysis);
         }
         TemplateNode::IfBlock(if_block) => {

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/await_expression.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/await_expression.rs
@@ -49,6 +49,11 @@ pub fn visit_typed(node: &JsNode, context: &mut VisitorContext) -> Result<(), An
 
     let mut suspend = tla;
 
+    if context.bind_await_depth == Some(context.function_depth) {
+        context.bind_has_await = true;
+        suspend = true;
+    }
+
     if let Some(metadata) = context.current_expression() {
         metadata.set_has_await(true);
         suspend = true;

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/bind_directive.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/bind_directive.rs
@@ -56,79 +56,8 @@ fn visit_common(
     super::shared::attribute::record_assign_exempt_expression(context, &directive.expression, true);
 
     // Handle getter/setter syntax (SequenceExpression)
-    if directive.expression.node_type() == Some("SequenceExpression") {
-        if directive.name == "group" {
-            return Err(errors::bind_group_invalid_expression().at(directive.start, directive.end));
-        }
-
-        // Check for invalid parentheses in the binding expression, ignoring any
-        // '(' that sits inside a comment between the opening `{` and the
-        // expression. Comment regions are detected directly from the source
-        // (scanning `/* … */` and `// …`) rather than from the expression's
-        // `leadingComments` JSON — comment capture is off on the compile path,
-        // so the typed expression carries no comment metadata here; a source
-        // scan is the robust source of truth.
-        if let Some(start) = directive.expression.start() {
-            let start_usize = start as usize;
-            let source_bytes = context.analysis.source.as_bytes();
-            let mut i = start_usize;
-            while i > 0 && source_bytes.get(i.saturating_sub(1)) != Some(&b'{') {
-                i -= 1;
-            }
-
-            // Scan from just after `{` to the expression start, tracking comment
-            // state so parens inside comments are ignored.
-            let mut pos = i;
-            let mut found_invalid_paren = false;
-            while pos < start_usize {
-                match source_bytes.get(pos) {
-                    Some(&b'/') if source_bytes.get(pos + 1) == Some(&b'*') => {
-                        pos += 2;
-                        while pos < start_usize
-                            && !(source_bytes.get(pos) == Some(&b'*')
-                                && source_bytes.get(pos + 1) == Some(&b'/'))
-                        {
-                            pos += 1;
-                        }
-                        pos += 2;
-                    }
-                    Some(&b'/') if source_bytes.get(pos + 1) == Some(&b'/') => {
-                        pos += 2;
-                        while pos < start_usize && source_bytes.get(pos) != Some(&b'\n') {
-                            pos += 1;
-                        }
-                    }
-                    Some(&b'(') => {
-                        found_invalid_paren = true;
-                        break;
-                    }
-                    _ => pos += 1,
-                }
-            }
-
-            if found_invalid_paren {
-                return Err(AnalysisError::validation_at(
-                    "bind_invalid_parens",
-                    format!(
-                        "bind:{} cannot have parentheses around the expression",
-                        directive.name
-                    ),
-                    directive.start,
-                    directive.end,
-                ));
-            }
-        }
-
-        // Validate that sequence expression has exactly 2 expressions (getter and setter)
-        {
-            let node = directive.expression.as_node();
-            let expressions = node.expressions();
-            let arena = context.parse_arena;
-            let expr_slice = arena.get_js_children(expressions);
-            if !expr_slice.is_empty() && expr_slice.len() != 2 {
-                return Err(errors::bind_invalid_expression().at(directive.start, directive.end));
-            }
-        }
+    if is_get_set_pair(directive) {
+        validate_get_set_pair(directive, context)?;
 
         // Mark subtree as dynamic
         // In full implementation: mark_subtree_dynamic(context.path)
@@ -137,20 +66,7 @@ fn visit_common(
         // This is important for cases like:
         //   bind:checked={()=>check, (v)=>{ check = v }}
         // where the setter contains an assignment that marks `check` as reassigned
-        {
-            let node = directive.expression.as_node();
-            let expressions = node.expressions();
-            let arena = context.parse_arena;
-            for expr in arena.get_js_children(expressions) {
-                // Walk the expression to track mutations (e.g., assignments in setters).
-                // Use typed dispatch to skip the `to_value()` materialization.
-                super::script::walk_js_node_typed(expr, context)?;
-            }
-        }
-
-        // Check for await in the expression
-        // TODO: Check node.metadata.expression.has_await
-        // if has_await { return Err(errors::illegal_await_expression()); }
+        walk_get_set_pair(directive, context)?;
 
         return Ok(());
     }
@@ -256,12 +172,156 @@ fn visit_common(
     if directive.name == "this" {
         context.in_bind_this = true;
     }
-    super::script::walk_expression(&directive.expression, context)?;
+    let result = walk_bind_expression(directive, context);
     context.in_bind_this = prev_in_bind_this;
+    result
+}
 
-    // TODO: Check for await in expression
-    // if node.metadata.expression.has_await { return Err(errors::illegal_await_expression()); }
+/// Whether the directive uses the `bind:x={get, set}` pair form.
+pub(super) fn is_get_set_pair(directive: &BindDirective) -> bool {
+    directive.expression.node_type() == Some("SequenceExpression")
+}
 
+/// The `SequenceExpression` half of upstream's `BindDirective` visitor, which
+/// runs before it branches on the host. Every host must reach it: it is the only
+/// place `bind:group={get, set}` is rejected, and a component reached the
+/// getter/setter lowering without it.
+pub(super) fn validate_get_set_pair(
+    directive: &BindDirective,
+    context: &VisitorContext,
+) -> Result<(), AnalysisError> {
+    if directive.name == "group" {
+        return Err(errors::bind_group_invalid_expression().at(directive.start, directive.end));
+    }
+
+    // Check for invalid parentheses in the binding expression, ignoring any
+    // '(' that sits inside a comment between the opening `{` and the
+    // expression. Comment regions are detected directly from the source
+    // (scanning `/* … */` and `// …`) rather than from the expression's
+    // `leadingComments` JSON — comment capture is off on the compile path,
+    // so the typed expression carries no comment metadata here; a source
+    // scan is the robust source of truth.
+    if let Some(start) = directive.expression.start() {
+        let start_usize = start as usize;
+        let source_bytes = context.analysis.source.as_bytes();
+        let mut i = start_usize;
+        while i > 0 && source_bytes.get(i.saturating_sub(1)) != Some(&b'{') {
+            i -= 1;
+        }
+
+        // Scan from just after `{` to the expression start, tracking comment
+        // state so parens inside comments are ignored.
+        let mut pos = i;
+        let mut found_invalid_paren = false;
+        while pos < start_usize {
+            match source_bytes.get(pos) {
+                Some(&b'/') if source_bytes.get(pos + 1) == Some(&b'*') => {
+                    pos += 2;
+                    while pos < start_usize
+                        && !(source_bytes.get(pos) == Some(&b'*')
+                            && source_bytes.get(pos + 1) == Some(&b'/'))
+                    {
+                        pos += 1;
+                    }
+                    pos += 2;
+                }
+                Some(&b'/') if source_bytes.get(pos + 1) == Some(&b'/') => {
+                    pos += 2;
+                    while pos < start_usize && source_bytes.get(pos) != Some(&b'\n') {
+                        pos += 1;
+                    }
+                }
+                Some(&b'(') => {
+                    found_invalid_paren = true;
+                    break;
+                }
+                _ => pos += 1,
+            }
+        }
+
+        if found_invalid_paren {
+            return Err(AnalysisError::validation_at(
+                "bind_invalid_parens",
+                format!(
+                    "bind:{} cannot have parentheses around the expression",
+                    directive.name
+                ),
+                directive.start,
+                directive.end,
+            ));
+        }
+    }
+
+    // Validate that sequence expression has exactly 2 expressions (getter and setter)
+    let node = directive.expression.as_node();
+    let expr_slice = context.parse_arena.get_js_children(node.expressions());
+    if !expr_slice.is_empty() && expr_slice.len() != 2 {
+        return Err(errors::bind_invalid_expression().at(directive.start, directive.end));
+    }
+
+    Ok(())
+}
+
+/// Walk both halves of a `{get, set}` pair.
+///
+/// Upstream visits the get/set functions' **bodies** with `state.expression`
+/// installed, deliberately jumping across the function so an `await` in the body
+/// still suspends (`BindDirective.js` L157-170). `bind_await_depth` reproduces
+/// that without re-shaping the walk: a function-like half suspends one depth in.
+pub(super) fn walk_get_set_pair(
+    directive: &BindDirective,
+    context: &mut VisitorContext,
+) -> Result<(), AnalysisError> {
+    let node = directive.expression.as_node();
+    let expressions = node.expressions();
+    let arena = context.parse_arena;
+    let saw_await = std::mem::replace(&mut context.bind_has_await, false);
+    let saved_depth = context.bind_await_depth;
+
+    let mut result = Ok(());
+    for expr in arena.get_js_children(expressions) {
+        let depth = if matches!(
+            expr,
+            JsNode::ArrowFunctionExpression { .. } | JsNode::FunctionExpression { .. }
+        ) {
+            context.function_depth + 1
+        } else {
+            context.function_depth
+        };
+        context.bind_await_depth = Some(depth);
+        // Walk the expression to track mutations (e.g., assignments in setters).
+        // Use typed dispatch to skip the `to_value()` materialization.
+        result = super::script::walk_js_node_typed(expr, context);
+        if result.is_err() {
+            break;
+        }
+    }
+
+    context.bind_await_depth = saved_depth;
+    let has_await = std::mem::replace(&mut context.bind_has_await, saw_await);
+    result?;
+    if has_await {
+        return Err(errors::illegal_await_expression().at(directive.start, directive.end));
+    }
+    Ok(())
+}
+
+/// Walk a plain (non-pair) `bind:` expression the way upstream does — with
+/// `state.expression` installed, so an `await` that is not inside a nested
+/// function suspends.
+pub(super) fn walk_bind_expression(
+    directive: &BindDirective,
+    context: &mut VisitorContext,
+) -> Result<(), AnalysisError> {
+    let saw_await = std::mem::replace(&mut context.bind_has_await, false);
+    let saved_depth = context.bind_await_depth.replace(context.function_depth);
+    let result = super::script::walk_expression(&directive.expression, context);
+    context.bind_await_depth = saved_depth;
+    let has_await = std::mem::replace(&mut context.bind_has_await, saw_await);
+    result?;
+    if has_await {
+        return Err(errors::illegal_await_expression().at(directive.start, directive.end));
+    }
     Ok(())
 }
 
@@ -402,9 +462,9 @@ pub(super) fn validate_bind_value_identifier(
 }
 
 /// Resolve the binding for an Identifier bind expression and run
-/// `validate_bind_value_identifier`. Used by the component visitor
-/// (`shared/component.rs`), which does not go through `visit_common`.
-pub(super) fn validate_bind_value_for_component(
+/// `validate_bind_value_identifier`. Used by the hosts that do not go through
+/// `visit_common` — a component, `<svelte:self>` and `<svelte:element>`.
+pub(super) fn validate_bind_value_target(
     directive: &BindDirective,
     context: &VisitorContext,
 ) -> Result<(), AnalysisError> {

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/mod.rs
@@ -356,6 +356,15 @@ pub struct VisitorContext<'a> {
     /// Information about the current expression/directive/block value being analyzed.
     /// Set to Some(metadata) when visiting an expression, directive value, or block condition.
     pub expression: Option<*mut crate::ast::template::ExpressionMetadata>,
+    /// While walking a `bind:` expression, the `function_depth` at which an
+    /// `await` suspends. Upstream installs `state.expression` for the whole bind
+    /// expression — and, for a `{get, set}` pair, for the get/set function
+    /// *bodies*, jumping across the function that would otherwise reset it
+    /// (`BindDirective.js` L157-170) — so a deeper function does not suspend.
+    pub bind_await_depth: Option<usize>,
+    /// Set by the `AwaitExpression` visitor when `bind_await_depth` matched, so
+    /// the bind visitor can raise `illegal_await_expression`.
+    pub bind_has_await: bool,
     /// Parent element name (for validation).
     /// Tag name of parent element. None if parent is svelte:element, #snippet, component or root.
     pub parent_element: Option<String>,
@@ -559,6 +568,8 @@ impl<'a> VisitorContext<'a> {
             path: Vec::new(),
             js_path: Vec::new(),
             expression: None,
+            bind_await_depth: None,
+            bind_has_await: false,
             parent_element: None,
             function_depth: 0,
             derived_function_depth: 0,

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/shared/component.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/shared/component.rs
@@ -156,15 +156,18 @@ pub fn visit_component<'a, 'b: 'a>(
                 }
                 // Getter/setter bindings (`bind:value={get, set}`) skip the
                 // assignment + identifier validation, mirroring upstream's
-                // early SequenceExpression return in BindDirective.js.
-                if bind.expression.node_type() != Some("SequenceExpression") {
+                // early SequenceExpression return in BindDirective.js — but not
+                // the pair's own checks, which run for every host.
+                if super::super::bind_directive::is_get_set_pair(bind) {
+                    super::super::bind_directive::validate_get_set_pair(bind, context)?;
+                } else {
                     // Validate the binding expression (checks for const/import bindings)
                     let bind_node = bind.expression.as_node();
                     validate_assignment_node((bind.start, bind.end), &bind_node, context, true)?;
                     // `bind:x={y}` must target state or props (bind_invalid_value).
                     // Upstream's BindDirective visitor runs this for component
                     // bindings too (BindDirective.js L193-207).
-                    super::super::bind_directive::validate_bind_value_for_component(bind, context)?;
+                    super::super::bind_directive::validate_bind_value_target(bind, context)?;
                 }
             }
             Attribute::OnDirective(on) => {
@@ -216,8 +219,13 @@ pub fn visit_component<'a, 'b: 'a>(
                 if bind.name == "this" {
                     context.in_bind_this = true;
                 }
-                super::super::script::walk_expression(&bind.expression, context)?;
+                let result = if super::super::bind_directive::is_get_set_pair(bind) {
+                    super::super::bind_directive::walk_get_set_pair(bind, context)
+                } else {
+                    super::super::bind_directive::walk_bind_expression(bind, context)
+                };
                 context.in_bind_this = prev_in_bind_this;
+                result?;
             }
             Attribute::OnDirective(on) => {
                 // Visit the event handler expression if present

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/shared/component.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/shared/component.rs
@@ -427,36 +427,10 @@ pub fn validate_component(
         )));
     }
 
-    // Check for duplicate attributes
-    let mut seen_names: FxHashSet<String> = FxHashSet::default();
-
-    for attr in &component.attributes {
-        // Only check for duplicates on:
-        // - Attribute and BindDirective (treated the same)
-        // - ClassDirective
-        // - StyleDirective
-        // OnDirective can have multiple handlers for the same event
-        let attr_name = match attr {
-            Attribute::Attribute(a) => Some(format!("Attribute{}", a.name)),
-            Attribute::BindDirective(b) => Some(format!("Attribute{}", b.name)), // bind:x and x are duplicates
-            Attribute::ClassDirective(c) => Some(format!("class:{}", c.name)),
-            Attribute::StyleDirective(s) => Some(format!("style:{}", s.name)),
-            _ => None, // Other directives can have duplicates
-        };
-
-        if let Some(name) = attr_name {
-            if seen_names.contains(&name) {
-                let (start, end) = attr.span();
-                return Err(AnalysisError::validation_at(
-                    "attribute_duplicate",
-                    "Attributes need to be unique",
-                    start,
-                    end,
-                ));
-            }
-            seen_names.insert(name);
-        }
-    }
+    // `attribute_duplicate` is raised once, while reading the attributes
+    // (`1-parse/state/element.js`), and that port exempts every attribute named
+    // `this`. A second copy here did not, so `<C bind:this={x} bind:this={x} />`
+    // was rejected.
 
     // Track component bindings (excluding bind:this which doesn't need the settling loop)
     let has_bindings = component

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/svelte_component.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/svelte_component.rs
@@ -52,12 +52,20 @@ pub fn visit<'a, 'b: 'a>(
                 if bind.name != "this" {
                     context.analysis.uses_component_bindings = true;
                 }
-                let bind_node = bind.expression.as_node();
-                validate_assignment_node((bind.start, bind.end), &bind_node, context, true)?;
-                // Walk the bind expression to add template references.
-                // This is important for legacy mode state promotion - bindings need
-                // template references to be promoted from 'normal' to 'state' kind.
-                super::script::walk_expression(&bind.expression, context)?;
+                // Upstream runs one `BindDirective` visitor for every host, so a
+                // `{get, set}` pair takes its own early branch here too.
+                if super::bind_directive::is_get_set_pair(bind) {
+                    super::bind_directive::validate_get_set_pair(bind, context)?;
+                    super::bind_directive::walk_get_set_pair(bind, context)?;
+                } else {
+                    let bind_node = bind.expression.as_node();
+                    validate_assignment_node((bind.start, bind.end), &bind_node, context, true)?;
+                    super::bind_directive::validate_bind_value_target(bind, context)?;
+                    // Walk the bind expression to add template references.
+                    // This is important for legacy mode state promotion - bindings need
+                    // template references to be promoted from 'normal' to 'state' kind.
+                    super::bind_directive::walk_bind_expression(bind, context)?;
+                }
             }
             Attribute::OnDirective(on) => {
                 if on.modifiers.len() > 1 || on.modifiers.iter().any(|modifier| modifier != "once")

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/svelte_element.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/svelte_element.rs
@@ -215,6 +215,20 @@ pub fn visit<'a, 'b: 'a>(
                 "svelte:element",
                 &element.attributes,
             )?;
+            // Upstream's `BindDirective` visitor runs the host-independent half
+            // for a `SvelteElement` too — the target-shape / target-kind checks
+            // live below its `parent.type` block, not inside it.
+            if super::bind_directive::is_get_set_pair(bind) {
+                super::bind_directive::validate_get_set_pair(bind, context)?;
+            } else {
+                super::shared::utils::validate_assignment_node(
+                    (bind.start, bind.end),
+                    &bind.expression.as_node(),
+                    context,
+                    true,
+                )?;
+                super::bind_directive::validate_bind_value_target(bind, context)?;
+            }
         }
     }
 
@@ -258,7 +272,11 @@ pub fn visit<'a, 'b: 'a>(
                 super::style_directive::visit(sd, context)?;
             }
             Attribute::BindDirective(bd) => {
-                super::script::walk_expression(&bd.expression, context)?;
+                if super::bind_directive::is_get_set_pair(bd) {
+                    super::bind_directive::walk_get_set_pair(bd, context)?;
+                } else {
+                    super::bind_directive::walk_bind_expression(bd, context)?;
+                }
             }
             Attribute::SpreadAttribute(spread) => {
                 super::spread_attribute::visit(spread, context)?;

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/svelte_self.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/svelte_self.rs
@@ -45,14 +45,16 @@ pub fn visit<'a, 'b: 'a>(
     for attr in &self_.attributes {
         match attr {
             Attribute::BindDirective(bind) => {
-                if bind.expression.node_type() != Some("SequenceExpression") {
+                if super::bind_directive::is_get_set_pair(bind) {
+                    super::bind_directive::validate_get_set_pair(bind, context)?;
+                } else {
                     validate_assignment_node(
                         (bind.start, bind.end),
                         &bind.expression.as_node(),
                         context,
                         true,
                     )?;
-                    super::bind_directive::validate_bind_value_for_component(bind, context)?;
+                    super::bind_directive::validate_bind_value_target(bind, context)?;
                 }
             }
             Attribute::OnDirective(on) => {
@@ -95,7 +97,11 @@ pub fn visit<'a, 'b: 'a>(
                     context.analysis.uses_component_bindings = true;
                 }
                 // Walk the bind expression to add template references.
-                super::script::walk_expression(&bind.expression, context)?;
+                if super::bind_directive::is_get_set_pair(bind) {
+                    super::bind_directive::walk_get_set_pair(bind, context)?;
+                } else {
+                    super::bind_directive::walk_bind_expression(bind, context)?;
+                }
             }
             Attribute::OnDirective(on) => {
                 // Walk event handler expression if present. Event forwarding

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/visitors/element.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/visitors/element.rs
@@ -1799,10 +1799,16 @@ fn prepare_element_spread_object<'a>(
                 // emitted directly under its `get_attribute_name`, with NO
                 // `bind:value`-on-select skip and NO `bind:group` → `checked`
                 // transform (those are specific to `build_element_attributes`, the
-                // generic-element spread path). A `{get, set}` sequence would call
-                // `get()` — KNOWN GAP: the whole expression is used as-is.
+                // generic-element spread path). A `{get, set}` sequence collapses
+                // to `(getter)()` (upstream `b.call(expression.expressions[0])`).
                 let name = get_bind_attribute_name(node, bind.name.as_str());
-                let value = state.visit_expr(&bind.expression);
+                let value = if bind_expr_is_sequence(bind) {
+                    let seq = state.visit_expr(&bind.expression);
+                    let getter = sequence_first(seq, state);
+                    state.b.call(getter, vec![])
+                } else {
+                    state.visit_expr(&bind.expression)
+                };
                 props.push(state.b.init(&name, value));
             }
             Attribute::ClassDirective(dir) => class_directives.push(dir),

--- a/crates/rsvelte_core/tests/bind_await_3242.rs
+++ b/crates/rsvelte_core/tests/bind_await_3242.rs
@@ -1,0 +1,89 @@
+//! `await` in a `bind:` expression must be rejected the way upstream rejects it
+//! (issue #3242).
+//!
+//! Upstream's `BindDirective` visitor installs `state.expression` for the bind
+//! expression — and, for a `{get, set}` pair, for the get/set function *bodies*,
+//! deliberately jumping across the function that would otherwise reset it
+//! (`BindDirective.js` L157-170). rsvelte installed nothing, so every `await`
+//! reachable from a bind expression compiled.
+//!
+//! The host axis is part of the test: the check lives below upstream's
+//! `parent.type` block, so every host must reach it.
+
+use rsvelte_core::{CompileOptions, GenerateMode, compile, compiler::CssMode};
+
+const SCRIPT: &str = "<script>\n\timport C from './C.svelte';\n\tlet v = $state('a');\n\tlet o = $state({ k: 1 });\n\tlet tag = $state('div');\n\tlet n = $state(0);\n\tconst p = Promise.resolve(1);\n</script>\n";
+
+fn compile_err(markup: &str) -> Option<String> {
+    let src = format!("{SCRIPT}{markup}");
+    compile(
+        &src,
+        CompileOptions {
+            filename: Some("Test.svelte".to_string()),
+            generate: GenerateMode::Client,
+            dev: false,
+            css: CssMode::External,
+            ..Default::default()
+        },
+    )
+    .err()
+    .map(|e| format!("{e:?}"))
+}
+
+/// Upstream reports `experimental_async` (the await gate fires at the await node
+/// before `BindDirective` gets to its own `illegal_await_expression` check).
+#[test]
+fn await_in_a_get_set_pair_is_rejected_on_every_host() {
+    for markup in [
+        "<input bind:value={() => v, async (nv) => { await p; }} />",
+        "<input bind:value={async () => await p, (nv) => (v = nv)} />",
+        "<select bind:value={() => v, async (nv) => { await p; }}><option value=\"a\">a</option></select>",
+        "<textarea bind:value={() => v, async (nv) => { await p; }}></textarea>",
+        "<C bind:value={() => v, async (nv) => { await p; }} />",
+        "<svelte:component this={C} bind:value={() => v, async (nv) => { await p; }} />",
+        "{#if n}<svelte:self bind:value={() => v, async (nv) => { await p; }} />{/if}",
+        "<svelte:element this={tag} bind:this={() => v, async (nv) => { await p; }}>x</svelte:element>",
+    ] {
+        let err = compile_err(markup).unwrap_or_else(|| panic!("{markup} must not compile"));
+        assert!(
+            err.contains("experimental_async"),
+            "expected experimental_async for {markup}, got: {err}"
+        );
+    }
+}
+
+/// The plain (non-pair) form takes the same gate.
+#[test]
+fn await_in_a_plain_bind_expression_is_rejected() {
+    for markup in [
+        "<input bind:value={o[await p]} />",
+        "<C bind:value={o[await p]} />",
+        "<svelte:element this={tag} bind:this={o[await p]}>x</svelte:element>",
+    ] {
+        let err = compile_err(markup).unwrap_or_else(|| panic!("{markup} must not compile"));
+        assert!(
+            err.contains("experimental_async"),
+            "expected experimental_async for {markup}, got: {err}"
+        );
+    }
+}
+
+/// The control that separates "an await below the bind" from "an await below a
+/// function below the bind": upstream resets `state.expression` on function
+/// entry, so only the get/set function's own body suspends. Rejecting these
+/// would be an over-rejection.
+#[test]
+fn await_inside_a_nested_function_still_compiles() {
+    for markup in [
+        "<input bind:value={() => v, (nv) => { const f = async () => { await p; }; f(); }} />",
+        "<C bind:value={() => v, (nv) => { const f = async () => { await p; }; f(); }} />",
+        "<input bind:value={() => v, (nv) => (v = nv)} />",
+        "<button onclick={async () => { await p; }}>x</button>",
+    ] {
+        assert!(
+            compile_err(markup).is_none(),
+            "{markup} should compile, got: {:?}",
+            compile_err(markup)
+        );
+    }
+}

--- a/crates/rsvelte_core/tests/bind_host_axis_3264.rs
+++ b/crates/rsvelte_core/tests/bind_host_axis_3264.rs
@@ -1,0 +1,178 @@
+//! The host-independent half of upstream's `BindDirective` visitor must run for
+//! every host (issue #3264).
+//!
+//! Upstream runs the `binding_properties` block only for element-ish parents,
+//! but everything below it — the `{get, set}` pair checks, `object()` →
+//! `bind_invalid_expression`, and the `bind_invalid_value` identifier check —
+//! runs for *every* host. rsvelte had a copy per visitor, and three of them were
+//! missing: `<svelte:element>` reached none of it (so `bind:clientWidth={o?.k}`
+//! compiled into `($$value) => o?.k = $$value`, which no JS parser accepts), and
+//! a component / `<svelte:component>` never reached the pair checks.
+//!
+//! Over-acceptance and over-rejection are the two directions of one check, so
+//! the legal shapes are asserted on the same host axis.
+
+use rsvelte_core::{CompileOptions, GenerateMode, compile, compiler::CssMode};
+
+const SCRIPT: &str = "<script>\n\timport C from './C.svelte';\n\tlet v = $state('a');\n\tlet o = $state({ k: 1 });\n\tlet tag = $state('div');\n\tlet el = $state(null);\n\tlet n = $state(0);\n</script>\n";
+
+fn compile_err(markup: &str, generate: GenerateMode) -> Option<String> {
+    let src = format!("{SCRIPT}{markup}");
+    compile(
+        &src,
+        CompileOptions {
+            filename: Some("Test.svelte".to_string()),
+            generate,
+            dev: false,
+            css: CssMode::External,
+            ..Default::default()
+        },
+    )
+    .err()
+    .map(|e| format!("{e:?}"))
+}
+
+fn expect_code(markup: &str, code: &str) {
+    for generate in [GenerateMode::Client, GenerateMode::Server] {
+        let err = compile_err(markup, generate)
+            .unwrap_or_else(|| panic!("{markup} must not compile ({generate:?})"));
+        assert!(
+            err.contains(code),
+            "expected {code} for {markup} ({generate:?}), got: {err}"
+        );
+    }
+}
+
+/// `object()` returns null for an optional chain / a call / an assignment, so
+/// the target is not an assignable reference. `<svelte:element>` skipped it, and
+/// the emitted `o?.k = $$value` is not JavaScript.
+#[test]
+fn bind_invalid_expression_reaches_every_host() {
+    for markup in [
+        "<div bind:clientWidth={o?.k}>x</div>",
+        "<input bind:value={o?.k} />",
+        "<C bind:value={o?.k} />",
+        "<svelte:element this={tag} bind:clientWidth={o?.k}>x</svelte:element>",
+        "<svelte:element this={tag} bind:offsetWidth={o?.k}>x</svelte:element>",
+        "<svelte:element this={tag} bind:this={o?.k}>x</svelte:element>",
+        "<svelte:component this={C} bind:value={o?.k} />",
+        "<svelte:component this={C} bind:value={o.f()} />",
+        "<svelte:component this={C} bind:value={o.k = v} />",
+        "{#if n}<svelte:self bind:value={o?.k} />{/if}",
+    ] {
+        expect_code(markup, "bind_invalid_expression");
+    }
+}
+
+/// A shorthand `bind:clientWidth` with no such variable in scope is
+/// `bind_invalid_value`; `<svelte:element>` used to emit a write to an
+/// undeclared name.
+#[test]
+fn bind_invalid_value_reaches_every_host() {
+    for markup in [
+        "<div bind:clientWidth>x</div>",
+        "<svelte:element this={tag} bind:clientWidth>x</svelte:element>",
+        "<svelte:element this={tag} bind:offsetHeight>x</svelte:element>",
+        "<svelte:component this={C} bind:value />",
+        "<svelte:component this={C} bind:clientWidth />",
+    ] {
+        expect_code(markup, "bind_invalid_value");
+    }
+}
+
+/// `bind:group` takes no `{get, set}` pair. The check sat on the element path
+/// only, so a component lowered it into a getter/setter prop pair.
+#[test]
+fn bind_group_invalid_expression_reaches_every_host() {
+    for markup in [
+        "<input bind:group={() => v, (nv) => (v = nv)} />",
+        "<C bind:group={() => v, (nv) => (v = nv)} />",
+        "<svelte:component this={C} bind:group={() => v, (nv) => (v = nv)} />",
+    ] {
+        expect_code(markup, "bind_group_invalid_expression");
+    }
+}
+
+/// The other two pair checks — parenthesised pair, and a pair that is not two
+/// expressions — likewise run for every host.
+#[test]
+fn get_set_pair_shape_checks_reach_every_host() {
+    for markup in [
+        "<input bind:value={(() => v, (nv) => (v = nv))} />",
+        "<C bind:value={(() => v, (nv) => (v = nv))} />",
+        "<svelte:component this={C} bind:value={(() => v, (nv) => (v = nv))} />",
+    ] {
+        expect_code(markup, "bind_invalid_parens");
+    }
+    for markup in [
+        "<input bind:value={() => v, (nv) => (v = nv), 1} />",
+        "<C bind:value={() => v, (nv) => (v = nv), 1} />",
+        "<svelte:component this={C} bind:value={() => v, (nv) => (v = nv), 1} />",
+    ] {
+        expect_code(markup, "bind_invalid_expression");
+    }
+}
+
+/// The opposite direction: every legal shape on the same hosts must still
+/// compile, on both targets. A population of only-invalid inputs is blind to an
+/// over-rejection.
+#[test]
+fn legal_bindings_still_compile_on_every_host() {
+    for markup in [
+        "<div bind:clientWidth={n}>x</div>",
+        "<div bind:this={el}>x</div>",
+        "<input bind:value={v} />",
+        "<input bind:value={o.k} />",
+        "<input bind:group={v} />",
+        "<input bind:value={() => v, (nv) => (v = nv)} />",
+        "<C bind:value={v} />",
+        "<C bind:value={o.k} />",
+        "<C bind:this={el} />",
+        "<C bind:value={() => v, (nv) => (v = nv)} />",
+        "<svelte:element this={tag} bind:clientWidth={n}>x</svelte:element>",
+        "<svelte:element this={tag} bind:offsetWidth={o.k}>x</svelte:element>",
+        "<svelte:element this={tag} bind:this={el}>x</svelte:element>",
+        "<svelte:element this={tag} bind:this>x</svelte:element>",
+        "<svelte:component this={C} bind:value={v} />",
+        "<svelte:component this={C} bind:value={o.k} />",
+        "<svelte:component this={C} bind:this={el} />",
+        "<svelte:component this={C} bind:value={() => v, (nv) => (v = nv)} />",
+        "{#if n}<svelte:self bind:value={v} />{/if}",
+        "{#if n}<svelte:self bind:group={v} />{/if}",
+        "<svelte:window bind:innerWidth={n} />",
+        "<svelte:document bind:activeElement={el} />",
+        "<svelte:body bind:clientWidth={n} />",
+    ] {
+        for generate in [GenerateMode::Client, GenerateMode::Server] {
+            assert!(
+                compile_err(markup, generate).is_none(),
+                "{markup} should compile ({generate:?}), got: {:?}",
+                compile_err(markup, generate)
+            );
+        }
+    }
+}
+
+/// `<svelte:self bind:group>` needs its group array declared — the collector
+/// visited every other host's attributes and recursed past this one's.
+#[test]
+fn svelte_self_bind_group_declares_its_binding_group() {
+    let src = format!("{SCRIPT}{{#if n}}<svelte:self bind:group={{v}} />{{/if}}\n");
+    let out = compile(
+        &src,
+        CompileOptions {
+            filename: Some("Test.svelte".to_string()),
+            generate: GenerateMode::Client,
+            dev: false,
+            css: CssMode::External,
+            ..Default::default()
+        },
+    )
+    .expect("compile")
+    .js
+    .code;
+    assert!(
+        out.contains("const binding_group = [];"),
+        "expected the binding group declaration, got: {out}"
+    );
+}

--- a/crates/rsvelte_core/tests/ssr_select_bind_getset_3265.rs
+++ b/crates/rsvelte_core/tests/ssr_select_bind_getset_3265.rs
@@ -1,0 +1,63 @@
+//! `<select bind:value={get, set}>` must render the getter's *result* on the
+//! server, not the get/set sequence (issue #3265).
+//!
+//! `build_spread_object` — the `<select>` / `<option>` special path — emitted
+//! the whole `SequenceExpression` as the select's `value`. A sequence evaluates
+//! to its last operand, so `value` was the setter function and no `<option>` was
+//! ever selected. Upstream emits `b.call(expression.expressions[0])`.
+
+use rsvelte_core::{CompileOptions, GenerateMode, compile, compiler::CssMode};
+
+fn compile_server(markup: &str) -> String {
+    let src = format!("<script>\n\tlet v = $state('a');\n</script>\n{markup}\n");
+    compile(
+        &src,
+        CompileOptions {
+            filename: Some("Test.svelte".to_string()),
+            generate: GenerateMode::Server,
+            dev: false,
+            css: CssMode::External,
+            ..Default::default()
+        },
+    )
+    .expect("compile")
+    .js
+    .code
+}
+
+#[test]
+fn select_get_set_pair_calls_the_getter() {
+    let out = compile_server(
+        "<select bind:value={() => v, (nv) => (v = nv)}>\n\t<option value=\"a\">a</option>\n</select>",
+    );
+    assert!(
+        out.contains("value: (() => v)()"),
+        "expected the getter to be called, got: {out}"
+    );
+    assert!(
+        !out.contains("(nv) => v = nv)"),
+        "the setter must not reach the rendered value, got: {out}"
+    );
+}
+
+#[test]
+fn multiple_select_get_set_pair_calls_the_getter() {
+    let out = compile_server(
+        "<select multiple bind:value={() => v, (nv) => (v = nv)}>\n\t<option value=\"a\">a</option>\n</select>",
+    );
+    assert!(
+        out.contains("multiple: true, value: (() => v)()"),
+        "expected the getter to be called, got: {out}"
+    );
+}
+
+/// The control: the plain form is unchanged.
+#[test]
+fn select_plain_bind_value_is_unchanged() {
+    let out =
+        compile_server("<select bind:value={v}>\n\t<option value=\"a\">a</option>\n</select>");
+    assert!(
+        out.contains("value: v"),
+        "expected the bound value verbatim, got: {out}"
+    );
+}

--- a/crates/rsvelte_core/tests/this_attribute_3266_3267.rs
+++ b/crates/rsvelte_core/tests/this_attribute_3266_3267.rs
@@ -1,0 +1,138 @@
+//! Upstream reads the duplicate-attribute rule once, while parsing, and it
+//! exempts every attribute named `this` (`1-parse/state/element.js` L246-254);
+//! the tag definition it then consumes is `attributes.splice(index, 1)` — the
+//! *first* `this` only.
+//!
+//! rsvelte diverged from both halves: a second copy of the duplicate check in
+//! the phase-2 component visitor had no `this` exemption, so
+//! `<C bind:this={x} bind:this={x} />` was rejected (issue #3266); and the
+//! tag-definition extraction filtered out *every* `this` attribute, so a second
+//! one vanished from the output instead of being passed through (issue #3267).
+
+use rsvelte_core::{CompileOptions, GenerateMode, compile, compiler::CssMode};
+
+const SCRIPT: &str = "<script>\n\timport C from './C.svelte';\n\tlet el = $state(null);\n\tlet tag = $state('div');\n\tlet tag2 = $state('span');\n\tlet v = $state(1);\n\tlet n = $state(0);\n</script>\n";
+
+fn compile_with(markup: &str, generate: GenerateMode) -> Result<String, String> {
+    let src = format!("{SCRIPT}{markup}");
+    compile(
+        &src,
+        CompileOptions {
+            filename: Some("Test.svelte".to_string()),
+            generate,
+            dev: false,
+            css: CssMode::External,
+            ..Default::default()
+        },
+    )
+    .map(|r| r.js.code)
+    .map_err(|e| format!("{e:?}"))
+}
+
+/// A repeated `this` is accepted on every host — it is the attribute name that
+/// is exempt, not the element type and not the directive form.
+#[test]
+fn a_repeated_this_is_accepted_on_every_host() {
+    for markup in [
+        "<C bind:this={el} bind:this={el} />",
+        "<div bind:this={el} bind:this={el}></div>",
+        "<svelte:element this={tag} bind:this={el} bind:this={el}></svelte:element>",
+        "<svelte:component this={C} bind:this={el} bind:this={el} />",
+        "{#if n}<svelte:self bind:this={el} bind:this={el} />{/if}",
+        "<svelte:element this={tag} this={tag2}>x</svelte:element>",
+        "<svelte:component this={C} this={C} />",
+    ] {
+        for generate in [GenerateMode::Client, GenerateMode::Server] {
+            assert!(
+                compile_with(markup, generate).is_ok(),
+                "{markup} should compile ({generate:?}), got: {:?}",
+                compile_with(markup, generate).unwrap_err()
+            );
+        }
+    }
+}
+
+/// The opposite direction: no other name is exempt, so removing the phase-2
+/// copy must not lose the check. The parse-time port still raises it.
+#[test]
+fn other_duplicate_attributes_are_still_rejected() {
+    for markup in [
+        "<C bind:value={v} bind:value={v} />",
+        "<C title=\"a\" title=\"b\" />",
+        "<div a=\"1\" a=\"2\"></div>",
+        "<input bind:value={v} value=\"x\" />",
+        "<svelte:component this={C} bind:value={v} bind:value={v} />",
+        "{#if n}<svelte:self bind:value={v} bind:value={v} />{/if}",
+    ] {
+        let err = compile_with(markup, GenerateMode::Client)
+            .expect_err(&format!("{markup} must not compile"));
+        assert!(
+            err.contains("attribute_duplicate"),
+            "expected attribute_duplicate for {markup}, got: {err}"
+        );
+    }
+}
+
+/// The second `this` is consumed by nothing, so it is rendered as an ordinary
+/// attribute / passed as an ordinary prop.
+#[test]
+fn a_second_this_is_passed_through() {
+    let out = compile_with(
+        "<svelte:element this={tag} this={tag2}>x</svelte:element>",
+        GenerateMode::Client,
+    )
+    .expect("compile");
+    assert!(
+        out.contains("$.attribute_effect($$element, () => ({ this: tag2 }))"),
+        "expected the second `this` as an attribute, got: {out}"
+    );
+
+    let out = compile_with(
+        "<svelte:component this={C} this={C} />",
+        GenerateMode::Client,
+    )
+    .expect("compile");
+    assert!(
+        out.contains("get this()"),
+        "expected the second `this` as a prop, got: {out}"
+    );
+
+    let out = compile_with(
+        "<svelte:element this={tag} this={tag2}>x</svelte:element>",
+        GenerateMode::Server,
+    )
+    .expect("compile");
+    assert!(
+        out.contains("$.attr('this', tag2)"),
+        "expected the second `this` rendered, got: {out}"
+    );
+
+    let out = compile_with(
+        "<svelte:component this={C} this={C} />",
+        GenerateMode::Server,
+    )
+    .expect("compile");
+    assert!(
+        out.contains("C($$renderer, { this: C })"),
+        "expected the second `this` as a prop, got: {out}"
+    );
+}
+
+/// The control for the splice: the *first* `this` is still the tag / component,
+/// and a lone `this` is still consumed rather than rendered.
+#[test]
+fn a_single_this_is_still_consumed_as_the_tag() {
+    let out = compile_with(
+        "<svelte:element this={tag}>x</svelte:element>",
+        GenerateMode::Client,
+    )
+    .expect("compile");
+    assert!(
+        out.contains("$.element(node, () => tag,"),
+        "expected `tag` as the element, got: {out}"
+    );
+    assert!(
+        !out.contains("attribute_effect"),
+        "a lone `this` must not be rendered as an attribute, got: {out}"
+    );
+}


### PR DESCRIPTION
Five `bind:` / `this=` defects, all of the same shape: a rule that upstream
applies once, ported here as one copy per host visitor, with some copies short.

Closes #3242
Closes #3264
Closes #3265
Closes #3266
Closes #3267

## What was wrong

Upstream's `BindDirective` visitor gates **only** the `binding_properties` block
on the parent's type. Everything below it — the `{get, set}` pair checks,
`object()` → `bind_invalid_expression`, the `bind_invalid_value` identifier
check, and the `await` gate — runs for every host. rsvelte had a hand-written
copy per visitor and three of them were short:

| host | what it did not reach |
|---|---|
| `<svelte:element>` | every target-shape rule below the pair branch |
| component | the `{get, set}` pair rules |
| `<svelte:component>` | the pair rules *and* the target-shape rules |
| every host | the `await` gate — it had no port at all |

Consequences, all confirmed against the official compiler:

- `<svelte:element this={tag} bind:clientWidth={o?.k}>` compiled into
  `($$value) => o?.k = $$value` — **not JavaScript**. Same for `offsetWidth`,
  `clientHeight`, `offsetHeight`, `contentRect` and `this`.
- `<svelte:element this={tag} bind:clientWidth>` emitted a write to an
  undeclared name.
- `<C bind:group={() => v, (nv) => (v = nv)} />` was lowered into a
  getter/setter prop pair; so were a parenthesised pair and a three-element
  pair on a component / `<svelte:component>`.
- `await` anywhere a bind expression can reach it compiled.

Two more, adjacent:

- On the server, `<select bind:value={get, set}>` rendered the whole sequence
  expression as `value`. A sequence evaluates to its **last** operand, so the
  rendered value was the setter function and no `<option>` was ever selected.
  Upstream emits `b.call(expression.expressions[0])`.
- Upstream applies the duplicate-attribute rule **once**, while reading the
  attributes, and exempts every attribute named `this`; the tag definition it
  then consumes is `attributes.splice(index, 1)` — the *first* `this` only.
  rsvelte had a second copy of the duplicate check in the phase-2 component
  visitor with no exemption (so `<C bind:this={x} bind:this={x} />` was
  **rejected** where official compiles it), and its tag-definition extraction
  filtered out *every* `this` attribute rather than the first (so a second
  `this=` disappeared from the output instead of being passed through).

## How it is fixed

- `is_get_set_pair` / `validate_get_set_pair` / `walk_get_set_pair` /
  `walk_bind_expression` are one shared implementation in
  `2_analyze/visitors/bind_directive.rs`; `<svelte:element>`, a component,
  `<svelte:component>` and `<svelte:self>` now call it instead of carrying a
  partial copy. `validate_bind_value_for_component` is renamed
  `validate_bind_value_target` — it was never component-specific.
- The `await` gate is `VisitorContext::bind_await_depth`: the `function_depth`
  at which an `await` below a bind expression suspends. A function-like half of
  a `{get, set}` pair records `depth + 1`, which is exactly upstream's "visit
  `get.body` with `state.expression` installed" — it jumps across the function
  that would otherwise reset it, while a function *below* that still resets.
- The phase-2 duplicate-attribute check is deleted rather than patched: it was
  a second port of a rule the parser already applies to every element, and the
  parser's port already had the `this` exemption.
- The tag-definition extraction removes the first `this` by index.
- The `bind:group` collector now reads `<svelte:self>`'s own attributes; it
  visited every other host's and only recursed past this one, so
  `<svelte:self bind:group={x} />` never declared its group array.

## Evidence

A host × bind-expression-shape grid (12 hosts × 28 shapes × 2 targets = 672
cells) run against the official compiler:

| | before | after |
|---|---|---|
| match | 645 / 672 | **672 / 672** |

The 27 pre-fix divergences were, in order: 12 `<svelte:component>` cells that
reached none of the shape rules (a host the issues did not name — found by
crossing the axis), 12 `await` cells, 2 `<svelte:element>` cells, and the
`<svelte:self bind:group>` output.

Both directions are in the regression tests, on the same host axis: the illegal
shapes must be rejected **and** ~24 legal shapes per host must still compile on
both targets. `bind_host_axis_3264.rs`'s legal-shape list is what caught the
one over-rejection I introduced while writing it.

Every markup asserted by the new tests was first run through the official
compiler (152 cells, 152/152 agreement) before the assertion was written, so no
assertion encodes rsvelte's behaviour instead of upstream's.

## Ratchets

None touched. No `compatibility/*known-failures*` file is modified by this PR.

## Test plan

- `cargo test -p rsvelte_core` — green (whole suite)
- `cargo test -p rsvelte_projection` — green
- `cargo clippy -p rsvelte_core --all-targets --all-features -- -D warnings` — clean
- new: `bind_await_3242.rs`, `bind_host_axis_3264.rs`,
  `ssr_select_bind_getset_3265.rs`, `this_attribute_3266_3267.rs`
