### PR TITLE
fix(compiler): follow esrap's comment cursor at the end of an instance script

### DIFF
--- a/.changeset/script-tail-comment-cursor.md
+++ b/.changeset/script-tail-comment-cursor.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/compiler": patch
+---
+
+A comment at the end of an instance script now follows esrap's comment cursor: on the server it lands in the first template expression that keeps a source location, at the end of the component body when there is none, and is dropped when a block gets printed first; on the client a comment below the last legacy `$:` is dropped, because the `$.legacy_pre_effect` block upstream builds for it carries no location. The same rule moves a comment trailing a `$:` on its own line, which upstream never flushes onto the loc-less label.

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/formatting.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/formatting.rs
@@ -324,7 +324,7 @@ fn reactive_statement_spans(source: &str) -> Vec<ReactiveSpan> {
         after_last_surviving_code = i;
     }
 
-    spans
+    let mut spans: Vec<ReactiveSpan> = spans
         .into_iter()
         .map(|(leading, label, end)| ReactiveSpan {
             leading,
@@ -332,7 +332,17 @@ fn reactive_statement_spans(source: &str) -> Vec<ReactiveSpan> {
             end,
             has_successor: after_last_surviving_code > end,
         })
-        .collect()
+        .collect();
+    // The `$.legacy_pre_effect(…, () => { … })` upstream builds for the last
+    // reactive statement carries a span-less block, and printing it parks esrap's
+    // comment cursor past the end of the list. With no statement left to flush
+    // them first, every comment after that statement dies with it.
+    if let Some(last) = spans.last_mut()
+        && !last.has_successor
+    {
+        last.end = source.len();
+    }
+    spans
 }
 
 /// Whether a statement can begin at `at`, `after_last_code` being the byte just

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/comments.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/comments.rs
@@ -48,6 +48,7 @@ struct Chunk {
     position_only: bool,
     expression_anchor: bool,
     component_tail: bool,
+    component_tail_nested: bool,
 }
 
 /// The per-compile registry of comment regions.
@@ -92,6 +93,7 @@ impl ChunkRegistry {
             position_only: false,
             expression_anchor,
             component_tail: false,
+            component_tail_nested: false,
         });
         super::comment_stats::bump::REGISTERED_CHUNKS(1);
         super::comment_stats::bump::REGISTERED_COMMENTS(comments.len() as u64);
@@ -114,6 +116,7 @@ impl ChunkRegistry {
             position_only: true,
             expression_anchor: false,
             component_tail: false,
+            component_tail_nested: false,
         });
         Some(prov_base)
     }
@@ -122,9 +125,19 @@ impl ChunkRegistry {
         self.chunks.is_empty()
     }
 
-    pub fn register_component_tail(&mut self, text: &str, comments: &[Comment]) -> Option<u32> {
+    /// `nested` when the component body is the `$$renderer.component(($$renderer)
+    /// => { … })` callback rather than the exported function itself, which is
+    /// where the replayed comments have to land.
+    pub fn register_component_tail(
+        &mut self,
+        text: &str,
+        comments: &[Comment],
+        nested: bool,
+    ) -> Option<u32> {
         let base = self.register_inner(text, comments, true)?;
-        self.chunks.last_mut()?.component_tail = true;
+        let chunk = self.chunks.last_mut()?;
+        chunk.component_tail = true;
+        chunk.component_tail_nested = nested;
         Some(base)
     }
 }
@@ -390,10 +403,17 @@ pub fn print_with_comments<'a>(
         .code
     };
     for chunk in registry.chunks.iter().filter(|chunk| chunk.component_tail) {
+        // The last line closing the component body — `\t});` for the
+        // `$$renderer.component` callback, `}` for the exported function itself.
+        let (close, indent) = if chunk.component_tail_nested {
+            ("\n\t}", "\n\t\t")
+        } else {
+            ("\n}", "\n\t")
+        };
         for comment in &chunk.comments {
             let raw = &chunk.text[comment.span.start as usize..comment.span.end as usize];
-            if let Some(at) = code.rfind("\n}") {
-                code.insert_str(at, &format!("\n\t{raw}"));
+            if let Some(at) = code.rfind(close) {
+                code.insert_str(at, &format!("{indent}{raw}"));
             }
         }
     }

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/mod.rs
@@ -225,9 +225,11 @@ pub struct ServerTransformState<'a> {
     /// Leading-comment regions registered by the script transform, replayed onto
     /// a synthetic buffer at print time. See [`comments`].
     pub comments: comments::ChunkRegistry,
-    /// Comments trailing direct block-bodied legacy `$:` statements. Their final
-    /// anchor is decided after the reordered script body is assembled.
-    pub pending_reactive_comments: Vec<PendingReactiveComment>,
+    /// Comments no emitted instance statement is left to flush — the run after
+    /// the last one, and the same-line trailer of a `$:` whose label upstream
+    /// rebuilds loc-less. Their final anchor is decided after the reordered
+    /// script body is assembled.
+    pub pending_tail_comments: Vec<PendingTailComment>,
     /// Set when [`Self::reparse_program`] rejected text this compiler generated.
     /// The instance body cannot be reconstructed after that, so assembly aborts
     /// instead of shipping a component whose `<script>` silently did nothing.
@@ -259,7 +261,7 @@ pub struct AsyncConstsGroup<'a> {
     pub let_decls: Vec<Statement<'a>>,
 }
 
-pub struct PendingReactiveComment {
+pub struct PendingTailComment {
     suffix: String,
     comments: Vec<Comment>,
     replay_at_tail: bool,
@@ -326,12 +328,12 @@ impl<'a> ServerTransformState<'a> {
             slot_let_shadows: Vec::new(),
             current_scope_index: analysis.root.instance_scope_index,
             comments: comments::ChunkRegistry::default(),
-            pending_reactive_comments: Vec::new(),
+            pending_tail_comments: Vec::new(),
             reparse_failure: std::cell::RefCell::new(None),
         }
     }
 
-    pub fn defer_reactive_block_comments(
+    pub fn defer_tail_comments(
         &mut self,
         source: &str,
         comments: &[Comment],
@@ -351,38 +353,51 @@ impl<'a> ServerTransformState<'a> {
                 comment
             })
             .collect();
-        self.pending_reactive_comments.push(PendingReactiveComment {
+        self.pending_tail_comments.push(PendingTailComment {
             suffix,
             comments,
             replay_at_tail: false,
         });
     }
 
-    pub fn mark_deferred_reactive_comment_landed(&mut self, index: usize) {
-        if let Some(comment) = self.pending_reactive_comments.get_mut(index) {
+    pub fn mark_deferred_tail_comment_landed(&mut self, index: usize) {
+        if let Some(comment) = self.pending_tail_comments.get_mut(index) {
             comment.replay_at_tail = true;
         }
     }
 
-    /// The first template expression receives a deferred comment only when no
-    /// script successor already claimed its initial landing.
-    pub fn claim_deferred_reactive_comment(&mut self, expression: &mut OxcExpression<'a>) {
-        let Some(index) = self
-            .pending_reactive_comments
+    /// The first template expression flushes every still-pending comment, the way
+    /// esrap's cursor writes the whole run before the next node it finds a
+    /// location on. A comment a script successor already took is not among them.
+    pub fn claim_deferred_tail_comment(&mut self, expression: &mut OxcExpression<'a>) {
+        if self
+            .pending_tail_comments
             .iter()
-            .position(|comment| !comment.replay_at_tail)
-        else {
+            .all(|comment| comment.replay_at_tail)
+        {
             return;
-        };
-        let comment = self.pending_reactive_comments.remove(index);
-        let mut text = String::from("x");
-        text.push_str(&comment.suffix);
-        text.push('\n');
-        let mut comments = comment.comments;
-        for comment in &mut comments {
-            comment.span.start += 1;
-            comment.span.end += 1;
         }
+        let mut text = String::from("x");
+        let mut comments: Vec<Comment> = Vec::new();
+        let mut kept = Vec::new();
+        for entry in std::mem::take(&mut self.pending_tail_comments) {
+            if entry.replay_at_tail {
+                kept.push(entry);
+                continue;
+            }
+            let base = text.len() as u32;
+            text.push_str(&entry.suffix);
+            comments.extend(entry.comments.into_iter().map(|mut comment| {
+                comment.span.start += base;
+                comment.span.end += base;
+                comment
+            }));
+        }
+        self.pending_tail_comments = kept;
+        // The anchor goes on the line after the run, so a line comment cannot
+        // swallow it and a block one still gets its own line — which is what
+        // upstream produces, the script always sitting above the template.
+        text.push('\n');
         if let Some(base) = self.comments.register_expression(&text, &comments) {
             let mut place = comments::Place::At(base + text.len() as u32);
             place.visit_expression(expression);
@@ -392,8 +407,8 @@ impl<'a> ServerTransformState<'a> {
     /// A script successor receives the first copy; the cursor then replays the
     /// same comment at the component tail. An unclaimed comment has that tail as
     /// its fallback when there is no template expression.
-    pub fn replay_deferred_reactive_comments_at_tail(&mut self) {
-        let pending = std::mem::take(&mut self.pending_reactive_comments);
+    pub fn replay_deferred_tail_comments(&mut self) {
+        let pending = std::mem::take(&mut self.pending_tail_comments);
         let Some(last) = self.body.last_mut() else {
             return;
         };
@@ -414,7 +429,13 @@ impl<'a> ServerTransformState<'a> {
                 comment.span.start = comment.span.start - first as u32 + 3;
                 comment.span.end = comment.span.end - first as u32 + 3;
             }
-            if let Some(base) = self.comments.register_component_tail(&text, &comments) {
+            // Mirrors the `should_inject_context` decision below, which is what
+            // puts the component body one level deeper.
+            let nested = self.options.dev || self.analysis.needs_context;
+            if let Some(base) = self
+                .comments
+                .register_component_tail(&text, &comments, nested)
+            {
                 let mut place = comments::Place::At(base);
                 place.visit_statement(last);
             }
@@ -1267,6 +1288,7 @@ pub fn server_component_ast<'a>(
         template_body
     };
 
+    let template_start = state.body.len();
     state.body.extend(template_body);
 
     // `template.body.push(b.if($$store_subs, $.unsubscribe_stores($$store_subs)))`.
@@ -1279,7 +1301,14 @@ pub fn server_component_ast<'a>(
         state.body.push(cleanup);
     }
 
-    state.replay_deferred_reactive_comments_at_tail();
+    // esrap re-syncs its comment cursor at every body it prints, and every body
+    // the template emits starts past the script — so a comment the template's
+    // first expression did not flush dies at that block instead of reaching the
+    // component body's own end.
+    if state.body[template_start..].iter().any(holds_a_body) {
+        state.pending_tail_comments.clear();
+    }
+    state.replay_deferred_tail_comments();
 
     // -- $.bind_props trailer (upstream lines 224-243) ----------------------
     // Collect `props` from bindable_prop bindings (`prop_alias ?? name`, excluding
@@ -1641,6 +1670,26 @@ See https://svelte.dev/docs/svelte/v5-migration-guide#Components-are-no-longer-c
         ),
         None => code,
     })
+}
+
+/// Whether `stmt` holds a `{ … }` esrap prints through `body()` — the call that
+/// moves the comment cursor.
+fn holds_a_body(stmt: &Statement<'_>) -> bool {
+    struct Search(bool);
+    impl<'a> oxc_ast_visit::Visit<'a> for Search {
+        fn visit_block_statement(&mut self, _: &oxc_ast::ast::BlockStatement<'a>) {
+            self.0 = true;
+        }
+        fn visit_function_body(&mut self, _: &oxc_ast::ast::FunctionBody<'a>) {
+            self.0 = true;
+        }
+        fn visit_class_body(&mut self, _: &oxc_ast::ast::ClassBody<'a>) {
+            self.0 = true;
+        }
+    }
+    let mut search = Search(false);
+    oxc_ast_visit::Visit::visit_statement(&mut search, stmt);
+    search.0
 }
 
 fn is_prevent_snippet_stringification(stmt: &Statement<'_>) -> bool {

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/script.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/script.rs
@@ -393,6 +393,18 @@ fn trailing_comment_end(src: &str, all: &[Comment], stmt_end: u32) -> u32 {
     }
 }
 
+/// End of the comment run that follows the last statement of an instance script.
+/// No emitted statement is left to flush it, so esrap's cursor keeps it pending
+/// until the first template expression — or, with none, the component body's own
+/// end. Returns `from` when there is nothing left.
+fn script_tail_comment_end(all: &[Comment], from: u32) -> u32 {
+    all.iter()
+        .filter(|comment| comment.span.start >= from)
+        .map(|comment| comment.span.end)
+        .max()
+        .unwrap_or(from)
+}
+
 /// The legacy reactive label itself may contain a block, or directly wrap an
 /// `if` whose branch does. Those retained blocks are the locations that rewind
 /// esrap's comment cursor after the label has been reordered.
@@ -413,6 +425,9 @@ fn reactive_body_has_direct_block(stmt: &Statement<'_>) -> bool {
 /// Resolve a top-level statement's registered region into the [`comments::Place`]
 /// its emitted statement is stamped with. `verbatim` is the source range the
 /// statement was re-parsed from, when it was re-parsed whole.
+/// `include_trailing` is false when the emitted statement carries no location of
+/// its own (a `$:` label), so a comment trailing it on the same line has nothing
+/// to attach to and is left for the script tail instead.
 fn place_on_region(
     registry: &mut comments::ChunkRegistry,
     src: &str,
@@ -420,8 +435,13 @@ fn place_on_region(
     prev_end: u32,
     stmt: Span,
     verbatim: Option<Span>,
+    include_trailing: bool,
 ) -> Option<comments::Place> {
-    let trailing_end = trailing_comment_end(src, all, stmt.end);
+    let trailing_end = if include_trailing {
+        trailing_comment_end(src, all, stmt.end)
+    } else {
+        stmt.end
+    };
     let region_end = if verbatim.is_some() || trailing_end > stmt.end {
         trailing_end
     } else {
@@ -849,6 +869,7 @@ fn transform_script<'a>(
             region_start,
             stmt_span,
             verbatim,
+            true,
         );
         if place.is_none() && verbatim.is_some() && !ret.program.comments.is_empty() {
             place = place_on_position(&mut state.comments, src, region_start, stmt_span, verbatim);
@@ -869,6 +890,13 @@ fn transform_script<'a>(
         } else {
             stmt_span.end
         };
+    }
+
+    if is_instance {
+        let tail_end = script_tail_comment_end(&ret.program.comments, region_start);
+        if tail_end > region_start {
+            state.defer_tail_comments(src, &ret.program.comments, region_start, tail_end);
+        }
     }
 
     // Lower `$state` / `$derived` class-field initializers in every emitted
@@ -3081,9 +3109,15 @@ fn transform_script_legacy<'a>(
     let mut reactive_leading_comment_pending = false;
     let mut deferred_reactive_comment: Option<usize> = None;
 
-    for stmt in ret.program.body.iter() {
+    let body_len = ret.program.body.len();
+    for (stmt_index, stmt) in ret.program.body.iter().enumerate() {
         let stmt_span = stmt.span();
+        let is_last_stmt = stmt_index + 1 == body_len;
         let is_reactive = matches!(stmt, Statement::LabeledStatement(ls) if is_instance && ls.label.name.as_str() == "$");
+        // Upstream rebuilds the `$` label as a loc-less `b.labeled(...)`, so
+        // `body()` never flushes a comment trailing it on the same line; being the
+        // last statement, nothing located is left in the script to take it either.
+        let defer_reactive_tail = is_reactive && is_last_stmt;
         let reactive_leading_comment = is_reactive
             && ret.program.comments.iter().any(|comment| {
                 comment.span.start >= region_start && comment.span.end <= stmt_span.start
@@ -3238,15 +3272,16 @@ fn transform_script_legacy<'a>(
                         });
                         let trailing_end =
                             trailing_comment_end(src, &ret.program.comments, stmt_span.end);
-                        defer_block_reactive_trailing = trailing_end > stmt_span.end
+                        defer_block_reactive_trailing = !defer_reactive_tail
+                            && trailing_end > stmt_span.end
                             && reactive_body_has_direct_block(&ls.body)
                             && !ret.program.comments.iter().any(|comment| {
                                 comment.span.start >= region_start
                                     && comment.span.end <= stmt_span.start
                             });
                         if defer_block_reactive_trailing {
-                            let index = state.pending_reactive_comments.len();
-                            state.defer_reactive_block_comments(
+                            let index = state.pending_tail_comments.len();
+                            state.defer_tail_comments(
                                 src,
                                 &ret.program.comments,
                                 stmt_span.end,
@@ -3352,6 +3387,7 @@ fn transform_script_legacy<'a>(
             region_start,
             stmt_span,
             verbatim,
+            !defer_reactive_tail,
         );
         if place.is_none() && verbatim.is_some() && !ret.program.comments.is_empty() {
             place = place_on_position(&mut state.comments, src, region_start, stmt_span, verbatim);
@@ -3382,7 +3418,7 @@ fn transform_script_legacy<'a>(
                 }
             }
             if let Some(index) = deferred_reactive_comment.take() {
-                state.mark_deferred_reactive_comment_landed(index);
+                state.mark_deferred_tail_comment_landed(index);
             }
         }
         if is_reactive && reactive_leading_comment {
@@ -3391,11 +3427,20 @@ fn transform_script_legacy<'a>(
             reactive_leading_comment_pending = false;
         }
         let trailing_end = trailing_comment_end(src, &ret.program.comments, stmt_span.end);
-        region_start = if verbatim.is_some() || trailing_end > stmt_span.end {
+        region_start = if defer_reactive_tail {
+            stmt_span.end
+        } else if verbatim.is_some() || trailing_end > stmt_span.end {
             trailing_end
         } else {
             stmt_span.end
         };
+    }
+
+    if is_instance {
+        let tail_end = script_tail_comment_end(&ret.program.comments, region_start);
+        if tail_end > region_start {
+            state.defer_tail_comments(src, &ret.program.comments, region_start, tail_end);
+        }
     }
 
     // Topologically reorder the reactive `$:` statements so each runs after the

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/visitors/shared.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/visitors/shared.rs
@@ -653,6 +653,36 @@ enum SeqNode<'n> {
 /// Whether `src` is a single bare JS identifier (`foo`, `$bar`, `_x9`) — used to
 /// gate the block-local `constant_vars` fold so only a simple `{name}` read folds
 /// to its registered literal (a member access / call / operator never does).
+/// Whether `build_getter` replaces a read of `name` WHOLESALE with a
+/// builder-made node. The `derived` arm calls `b.call(binding.node)` — the node
+/// of the DECLARATION, whose location sits above any comment trailing the script
+/// — and the store arm builds the whole `$.store_get(...)` call fresh, so
+/// neither gives esrap's cursor a stop here. Every other read keeps the source
+/// expression's own `loc`.
+fn read_loses_its_location(state: &ServerTransformState<'_>, source: &str) -> bool {
+    let name = source.trim();
+    if !is_plain_identifier(name) {
+        return false;
+    }
+    if name == "$$props" || name.starts_with("$$derived_array") {
+        return true;
+    }
+    if state.local_derived_names.contains(name) {
+        return true;
+    }
+    state
+        .analysis
+        .root
+        .get_binding(name, state.current_scope_index)
+        .is_some_and(|index| {
+            matches!(
+                state.analysis.root.bindings[index].kind,
+                crate::compiler::phases::phase2_analyze::scope::BindingKind::StoreSub
+                    | crate::compiler::phases::phase2_analyze::scope::BindingKind::Derived
+            )
+        })
+}
+
 fn is_plain_identifier(src: &str) -> bool {
     let mut chars = src.chars();
     match chars.next() {
@@ -750,7 +780,12 @@ fn flush_sequence<'a>(sequence: &[SeqNode<'_>], state: &mut ServerTransformState
                 }
 
                 let mut visited = state.visit_expr(expr);
-                state.claim_deferred_reactive_comment(&mut visited);
+                if !state
+                    .expr_source(expr)
+                    .is_some_and(|src| read_loses_its_location(state, src))
+                {
+                    state.claim_deferred_tail_comment(&mut visited);
+                }
                 let escaped = state.b.call("$.escape", vec![visited]);
                 exprs.push(escaped);
                 quasis.push(String::new());

--- a/crates/rsvelte_core/tests/script_tail_comment_cursor.rs
+++ b/crates/rsvelte_core/tests/script_tail_comment_cursor.rs
@@ -1,0 +1,159 @@
+//! Comments at the end of an instance script follow esrap's comment cursor.
+//!
+//! The cursor is one index over the whole comment list, so the fate of a comment
+//! no emitted statement flushes is decided by what the printer meets next:
+//!
+//! * server — the next node upstream keeps a `loc` on is the template
+//!   expression, so the comment lands inside it; with no such expression the
+//!   component body's own end flushes it (`#3080`, `#3098`);
+//! * client — a `$:` statement becomes `$.legacy_pre_effect(…, () => { … })`
+//!   whose block is builder-made, which parks the cursor past the end of the
+//!   list, so the comment is dropped instead (`#3251`).
+
+use oxc_allocator::Allocator;
+use oxc_parser::Parser;
+use oxc_span::SourceType;
+use rsvelte_core::{CompileOptions, GenerateMode, compile};
+
+fn build(source: &str, generate: GenerateMode) -> String {
+    let code = compile(
+        source,
+        CompileOptions {
+            filename: Some("A.svelte".to_string()),
+            generate,
+            ..Default::default()
+        },
+    )
+    .expect("component should compile")
+    .js
+    .code;
+    let allocator = Allocator::default();
+    let parsed = Parser::new(&allocator, &code, SourceType::mjs()).parse();
+    assert!(
+        !parsed.panicked && parsed.diagnostics.is_empty(),
+        "output must parse:\n{code}"
+    );
+    code
+}
+
+fn server(source: &str) -> String {
+    build(source, GenerateMode::Server)
+}
+
+fn client(source: &str) -> String {
+    build(source, GenerateMode::Client)
+}
+
+/// Everything from the namespace import on, which is what upstream's own output
+/// starts with once the hoisted preamble is skipped.
+fn body(code: &str) -> &str {
+    code.find("export default")
+        .map_or(code, |start| &code[start..])
+        .trim_end()
+}
+
+#[test]
+fn server_reactive_same_line_trailing_comment_lands_in_the_template_expression() {
+    let out = server(
+        "<script>\n\texport let a = 1;\n\t$: doubled = a * 2; // trailing\n</script>\n\n<p>{doubled}</p>",
+    );
+    assert_eq!(
+        body(&out),
+        "export default function A($$renderer, $$props) {\n\tlet doubled;\n\tlet a = $.fallback($$props['a'], 1);\n\n\t$: doubled = a * 2;\n\n\t$$renderer.push(`<p>${$.escape(\n\t\t// trailing\n\t\tdoubled\n\t)}</p>`);\n\n\t$.bind_props($$props, { a });\n}"
+    );
+}
+
+#[test]
+fn server_reactive_own_line_trailing_comment_lands_in_the_template_expression() {
+    let out = server(
+        "<script>\n\texport let a = 1;\n\tlet b;\n\t$: b = a * 2;\n\t// tail\n</script>\n<div>{b}</div>",
+    );
+    assert_eq!(
+        body(&out),
+        "export default function A($$renderer, $$props) {\n\tlet a = $.fallback($$props['a'], 1);\n\tlet b;\n\n\t$: b = a * 2;\n\n\t$$renderer.push(`<div>${$.escape(\n\t\t// tail\n\t\tb\n\t)}</div>`);\n\n\t$.bind_props($$props, { a });\n}"
+    );
+}
+
+#[test]
+fn server_runes_trailing_comment_falls_back_to_the_component_tail() {
+    let out = server(
+        "<script>\n\tlet n = $state(0);\n\t// trailing script comment\n</script>\n\n<p>{n}</p>",
+    );
+    assert_eq!(
+        body(&out),
+        "export default function A($$renderer) {\n\tlet n = 0;\n\n\t$$renderer.push(`<p>0</p>`);\n\t// trailing script comment\n}"
+    );
+}
+
+#[test]
+fn server_legacy_trailing_comment_falls_back_to_the_component_tail() {
+    let out =
+        server("<script>\n\texport let a = 1;\n\tlet b = a;\n\t// tail\n</script>\n<div>x</div>");
+    assert_eq!(
+        body(&out),
+        "export default function A($$renderer, $$props) {\n\tlet a = $.fallback($$props['a'], 1);\n\tlet b = a;\n\n\t$$renderer.push(`<div>x</div>`);\n\t$.bind_props($$props, { a });\n\t// tail\n}"
+    );
+}
+
+/// A comment trailing a statement upstream keeps a `loc` on is flushed there, so
+/// it must NOT be deferred — the negative control for the two tests above.
+#[test]
+fn server_same_line_comment_on_a_located_statement_stays_put() {
+    let out =
+        server("<script>\n\texport let a = 1;\n\tlet b = a; // same\n</script>\n<div>{b}</div>");
+    assert!(
+        out.contains("let b = a; // same"),
+        "the comment left its statement:\n{out}"
+    );
+}
+
+#[test]
+fn client_trailing_comment_after_the_last_reactive_statement_is_dropped() {
+    let out = client(
+        "<script>\n\texport let a = 1;\n\tlet b;\n\t$: b = a * 2;\n\t// tail\n</script>\n<div>{b}</div>",
+    );
+    assert!(
+        !out.contains("// tail"),
+        "the builder-made effect block should have killed the comment:\n{out}"
+    );
+}
+
+#[test]
+fn client_a_block_bodied_reactive_statement_drops_it_too() {
+    let out = client(
+        "<script>\n\texport let a = 1;\n\tlet b;\n\t$: { b = a * 2; }\n\t/* tail */\n</script>\n<div>{b}</div>",
+    );
+    assert!(!out.contains("tail"), "comment survived:\n{out}");
+}
+
+#[test]
+fn client_two_trailing_comments_after_a_reactive_statement_are_both_dropped() {
+    let out = client(
+        "<script>\n\texport let a = 1;\n\tlet b;\n\t$: b = a * 2;\n\t// one\n\t// two\n</script>\n<div>{b}</div>",
+    );
+    assert!(
+        !out.contains("// one") && !out.contains("// two"),
+        "comments survived:\n{out}"
+    );
+}
+
+/// With a statement left after it the comment re-homes onto that statement, which
+/// is printed before the effect kills the cursor.
+#[test]
+fn client_a_surviving_successor_keeps_the_comment() {
+    let out = client(
+        "<script>\n\texport let a = 1;\n\tlet b;\n\t$: b = a * 2;\n\t// tail\n\tlet z = 1;\n</script>\n<div>{b}{z}</div>",
+    );
+    assert!(
+        out.contains("// tail\n\tlet z = 1;"),
+        "the comment did not re-home onto its successor:\n{out}"
+    );
+}
+
+/// Without a `$:` nothing kills the cursor, so the comment is kept.
+#[test]
+fn client_a_trailing_comment_without_a_reactive_statement_is_kept() {
+    let out =
+        client("<script>\n\texport let a = 1;\n\tlet b = a;\n\t// tail\n</script>\n<div>{b}</div>");
+    assert!(out.contains("// tail"), "comment was dropped:\n{out}");
+}

--- a/crates/rsvelte_core/tests/server_removed_statement_comments_2567.rs
+++ b/crates/rsvelte_core/tests/server_removed_statement_comments_2567.rs
@@ -121,17 +121,17 @@ fn instance_inspect_rehomes_its_leading_comment_past_the_sentinels() {
     assert!(out.contains("// leading"), "leading comment lost:\n{out}");
 }
 
-/// The counterweight, and it must keep FAILING to re-home: with nothing after the
-/// effect there is no anchor region, and upstream flushes the comments at the end
-/// of the component body instead. That is a separate defect with its own issue;
-/// what this pins is that the re-home did not resurrect them somewhere arbitrary.
+/// The counterweight: with nothing after the effect there is no anchor region,
+/// so the comments stay pending and upstream flushes them at the end of the
+/// component body — which here is the `$$renderer.component` callback, not the
+/// exported function.
 #[test]
-fn effect_with_no_successor_still_drops_its_comments() {
+fn effect_with_no_successor_lands_at_the_component_body_end() {
     let out = ssr(
         "<script>\n\tlet a = $state(1);\n\n\t// leading\n\t$effect(() => {\n\t\t// interior\n\t\tconsole.log(a);\n\t});\n</script>\n\n<p>{a}</p>\n",
     );
-    assert!(
-        !out.contains("// leading") && !out.contains("// interior"),
-        "unexpected comment placement — upstream puts both after the template push:\n{out}"
+    assert_body(
+        &out,
+        "import * as $ from 'svelte/internal/server';\n\nexport default function A($$renderer, $$props) {\n\t$$renderer.component(($$renderer) => {\n\t\tlet a = 1;\n\n\t\t$$renderer.push(`<p>1</p>`);\n\t\t// leading\n\t\t// interior\n\t});\n}",
     );
 }

--- a/crates/rsvelte_core/tests/trailing_script_comment_2727.rs
+++ b/crates/rsvelte_core/tests/trailing_script_comment_2727.rs
@@ -1,3 +1,12 @@
+//! A comment trailing the last legacy `$:` statement must not be spliced into the
+//! generated setter.
+//!
+//! The regex body is what made this a scanner problem: `/[//]/` looks like the
+//! start of a line comment, so the statement's end was mis-located and the
+//! comment landed inside `$.legacy_pre_effect(…)`. Upstream drops the comment —
+//! its `$:` becomes a builder-made effect whose block parks esrap's comment
+//! cursor — so the output must simply not carry it, and must still parse.
+
 use oxc_allocator::Allocator;
 use oxc_parser::Parser;
 use oxc_span::SourceType;
@@ -19,8 +28,12 @@ fn trailing_line_comment_stays_outside_the_generated_setter() {
     .code;
 
     assert!(
-        output.contains("// } c\n\t$.legacy_pre_effect"),
-        "the trailing comment was spliced into the generated setter:\n{output}"
+        !output.contains("// } c"),
+        "upstream drops the comment with the statement it trailed:\n{output}"
+    );
+    assert!(
+        output.contains("$.set(k, typeof (/[//]/).exec(String(v())));"),
+        "the reactive statement was mis-scanned:\n{output}"
     );
 
     let allocator = Allocator::default();


### PR DESCRIPTION
A comment at the end of an instance script has no statement of its own left to
flush it, so its fate is decided entirely by what esrap's comment cursor meets
next. rsvelte modelled neither half of that: on the server the comment was
dropped (or replayed at the wrong place), and on the client it was kept where
upstream kills it.

Closes #3080
Closes #3251
Partially addresses #3098 (the instance-script half; see *Not fixed* below)

## The mechanism

esrap keeps ONE cursor over the whole comment list. `flush_comments_until` writes
every pending comment before the next node that carries a `loc`, and `body()`'s
`reset_comment_index` re-syncs the cursor at every block it prints — forward, so
a block that starts past a pending comment skips it.

That gives three outcomes for a comment left over at the end of the instance
script, and upstream produces all three:

| next thing printed | outcome |
|---|---|
| a template expression upstream keeps located | flushed there — inside `$.escape(…)`, `$.attr(…)`, the `if (…)` test |
| a block (`{#if}` arm, `$.head(…)` callback, …) | dropped |
| nothing but the component body's end | flushed there |

## Server

* A comment run after the last top-level statement is now registered as a
  deferred region instead of falling off the end of the statement loop
  (`transform_script` and `transform_script_legacy`, both instance-only).
* A comment trailing a `$:` statement on the same line joins it: upstream
  rebuilds the label as a loc-less `b.labeled(...)`, so `body()`'s
  `flush_trailing_comments` gets `prev === null` and never writes it. That is
  #3080 — the comment belongs to the next located node, not to the label.
  `place_on_region` takes an `include_trailing` flag for this; the narrower
  block-bodied special case it used to have is subsumed.
* The first template expression claims the whole pending run at once, the way
  one `flush_comments_until` writes it — unless the expression is one
  `build_getter` replaces wholesale (`derived`, `store_sub`, `$$props`), whose
  only located node is the DECLARATION and therefore sits above the comment.
* If the template emits a body before anything claimed, the run is dropped,
  because that is what `reset_comment_index` does to it.
* The component-tail replay had a latent bug that this made reachable: it
  inserted at `code.rfind("\n}")`, which is the exported function's brace, not
  the `$$renderer.component(($$renderer) => { … })` callback that is the
  component body whenever `dev || needs_context`.

## Client

A `$:` statement becomes `$.legacy_pre_effect(…, () => { … })` whose block is
builder-made, so printing it parks the cursor past the end of the list. With no
statement after the last `$:` to flush them first, every comment below it dies
— #3251. `rehome_reactive_statement_comments` now extends the last reactive
span to the end of the script when nothing survives after it.

The negative controls are what make it narrow: a surviving successor still
re-homes the comment onto itself (upstream prints that statement before the
effect), and a script with no `$:` at all keeps it.

## Measurement

A generated grid of 11 script shapes x 7 tail-comment shapes x 7 template shapes
x 2 targets (1078 comparisons against the pinned official compiler):

| | diverging |
|---|---|
| merge base | 712 |
| this branch | 497 |

215 fixed, **0 regressions** — checked as a set difference, not a count. Two
narrower grids that isolate the issues' own shapes go 56 -> 0 and 11 -> 1 (the
one left is `mid-$:-block-sameline`, which also diverges on the merge base).

## Not fixed

* **#3098's client half** — `{/* inline */ n}` compiling to
  `$.append($$anchor, p /* inline */)`. rsvelte cannot place that comment
  because it does not HAVE it: `js_ast/to_oxc.rs::into_coordinate_free_program`
  clears `program.comments` outright ("a comment's position is a coordinate
  too"), and `client/visitors/expression_converter.rs` only ever handles
  own-line statement raw text and `svelte-ignore` scanning, so a template
  expression's comment never enters the printed comment list at all. That is a
  missing channel, not a misplacement, so #3098 stays open.

  (Correcting something I claimed earlier in this PR's discussion: upstream's
  placement is NOT construct-dependent, and it is not that template expressions
  keep their `loc`. It is one rule — `transform-client.js:394` sets
  `component_block.loc = instance.loc` to keep a cursor over the whole file's
  comments alive, `shared/fragment.js:116` builds the generated element binding
  as `b.id(scope.generate(name), node.name_loc)` so `button` reports the TAG
  NAME's position, and esrap's `sequence()` writes the `,` separator BEFORE
  `flush_trailing_comments(child.loc?.end, next)`, which keys on the comment
  sharing a line with `child.loc.end`. So `$.child(button, /* inline */ true)`
  and `$.child(button /* a */ /* b */)` are the same rule, the latter simply
  having no separator to write. Credit to metA, who derived this independently
  and wrote it up in `upstream_issues/`; I verified each of the three sites
  before amending this.)
* The server still does not claim at an attribute value, an `{#if}` test, an
  `{#each}` collection or a `{@html}` argument, so a tail comment those would
  flush is dropped instead. That column diverges on the merge base too, in the
  same rows — this change does not widen it.

## Ratchets

None touched. `--update-baseline` was NOT run (per the standing instruction
about PR #3176's re-measurement): comment-only divergences are invisible to the
corpus output gate, which falls back to `ast_equiv_batch` with no `--comments`.
If the matrix gate's comment-aware verdict moves, CI will say so and I will
re-baseline off a fresh `origin/main`.
