### PR TITLE
fix(fmt): three formatter-parity fixes (await clauses, each header spacing, glued tag runs)

### DIFF
--- a/.changeset/fmt-await-clauses-each-index-glued-tags.md
+++ b/.changeset/fmt-await-clauses-each-index-glued-tags.md
@@ -1,0 +1,5 @@
+---
+'@rsvelte/fmt': patch
+---
+
+Three formatter-parity fixes. An `{#await}` block now keeps exactly the clauses prettier-plugin-svelte keeps — the decision is taken once from whether the pending / then / catch fragments hold anything that is not blank text, so an empty `{:then}` is dropped (and the surviving clause collapses into the header) in every combination, not just the three that were special-cased. An `{#each}` header's ` as ` keyword and `, index` separator are re-printed canonically instead of preserving the source's whitespace. And a run of expression tags glued together now shares one width budget, so the first breakable tag in an overlong run breaks the way the oracle breaks it.

--- a/compatibility/pattern-corpus/adversarial/control-flow/await-boundary-effects.svelte
+++ b/compatibility/pattern-corpus/adversarial/control-flow/await-boundary-effects.svelte
@@ -30,4 +30,5 @@
 
 {#await p}{:then v}{v}{/await}
 {#await p then}<i>bare-then</i>{/await}
+{#await p}{:then}{/await}
 <button onclick={() => (p = Promise.reject(new Error('x')))}>{n}</button>

--- a/compatibility/pattern-corpus/adversarial/control-flow/each-key-and-index.svelte
+++ b/compatibility/pattern-corpus/adversarial/control-flow/each-key-and-index.svelte
@@ -13,7 +13,7 @@
 	<p>{i}:{id}</p>
 {/each}
 
-{#each rows as [a = 1, ...rest], i}
+{#each rows as [a = 1, ...rest] , i}
 	<p>{a}{rest.length}{i}</p>
 {/each}
 

--- a/compatibility/pattern-corpus/adversarial/runes/class-rune-field-zoo.svelte
+++ b/compatibility/pattern-corpus/adversarial/runes/class-rune-field-zoo.svelte
@@ -41,8 +41,5 @@
 </script>
 
 <button onclick={() => { z.bump(); w.bump(); }}>
-	{z.plain}{z.raw.a}{z.derived}
-	{z.byDerived}{z.priv}
-	{z['quoted key']}
-	{Zoo.staticPlain}{w.inCtor}
+	{z.plain}{z.raw.a}{z.derived}{z.byDerived}{z.priv}{z['quoted key']}{Zoo.staticPlain}{w.inCtor}
 </button>

--- a/crates/rsvelte_formatter/src/expression/await_block.rs
+++ b/crates/rsvelte_formatter/src/expression/await_block.rs
@@ -1,0 +1,266 @@
+//! Layout decision for `{#await}` blocks, mirroring prettier-plugin-svelte's
+//! `case 'AwaitBlock'` printer.
+//!
+//! The oracle decides the whole shape from three booleans — whether the
+//! pending / then / catch fragments hold anything that is not blank text — and
+//! prints only the clauses those booleans keep. rsvelte is an edit-based
+//! formatter, so the same decision is expressed here as "which header form to
+//! re-print" plus "which source regions to erase", and the per-clause edit path
+//! is skipped for whatever this plan drops.
+
+use rsvelte_core::ast::template::{AwaitBlock, Fragment, TemplateNode};
+
+use crate::collapse::template_node_span;
+
+/// Which header the oracle prints for this block.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub(crate) enum AwaitHeaderForm {
+    /// `{#await expr}`
+    Bare,
+    /// `{#await expr then value}`
+    Then,
+    /// `{#await expr catch error}`
+    Catch,
+}
+
+pub(crate) struct AwaitPlan {
+    /// The header the output must carry.
+    pub form: AwaitHeaderForm,
+    /// When `Some(end)`, replace `blk.start..end` with a freshly rendered
+    /// header. `None` means the source header already has the right shape and
+    /// the per-edit path formats it in place (which keeps its width-aware
+    /// expression breaking).
+    pub rewrite_end: Option<u32>,
+    /// Source regions erased wholesale — a dropped separator plus its body.
+    pub deletions: Vec<(u32, u32)>,
+    pub keep_pending: bool,
+    pub keep_then: bool,
+    pub keep_catch: bool,
+}
+
+impl AwaitPlan {
+    /// The plan that changes nothing — used whenever the source anchors cannot
+    /// be resolved, so an unparseable shape keeps today's per-edit behaviour.
+    fn identity() -> Self {
+        Self {
+            form: AwaitHeaderForm::Bare,
+            rewrite_end: None,
+            deletions: Vec::new(),
+            keep_pending: true,
+            keep_then: true,
+            keep_catch: true,
+        }
+    }
+}
+
+/// prettier's `hasPendingBlock` / `hasThenBlock` / `hasCatchBlock`: at least one
+/// child that is not a whitespace-only text node.
+fn fragment_has_content(frag: Option<&Fragment>) -> bool {
+    frag.is_some_and(|f| {
+        f.nodes
+            .iter()
+            .any(|n| !matches!(n, TemplateNode::Text(t) if crate::is_blank_text(t.data.as_ref())))
+    })
+}
+
+/// Offset just past the first `}` at or after `from`.
+fn close_brace_after(source: &str, from: u32) -> Option<u32> {
+    source
+        .get(from as usize..)
+        .and_then(|s| s.find('}'))
+        .map(|rel| crate::source_offset(from as usize + rel + 1))
+}
+
+/// Offset of the `{` opening the separator `{:<keyword> …}` that starts at the
+/// first non-whitespace byte at or after `from`.
+fn separator_open_at(source: &str, from: u32, keyword: &str) -> Option<u32> {
+    let rest = source.get(from as usize..)?;
+    let after_ws = rest.trim_start_matches([' ', '\t', '\n', '\r']);
+    let open = from as usize + (rest.len() - after_ws.len());
+    let inner = after_ws.strip_prefix('{')?;
+    let inner = inner.trim_start_matches([' ', '\t', '\n', '\r']);
+    let inner = inner.strip_prefix(':')?;
+    let inner = inner.trim_start_matches([' ', '\t', '\n', '\r']);
+    inner.strip_prefix(keyword)?;
+    Some(crate::source_offset(open))
+}
+
+fn last_node_end(frag: Option<&Fragment>) -> Option<u32> {
+    frag?.nodes.last().map(|n| template_node_span(n).1)
+}
+
+/// The source anchors of an await block's headers, all resolved from the AST
+/// spans rather than by counting braces across the body.
+struct AwaitAnchors {
+    /// Just past the `}` of `{#await …}`.
+    header_end: u32,
+    /// `(open, close)` of `{:then …}`, when the source spells one.
+    then_sep: Option<(u32, u32)>,
+    /// `(open, close)` of `{:catch …}`, when the source spells one.
+    catch_sep: Option<(u32, u32)>,
+    /// The `{` of `{/await}`.
+    close_open: u32,
+}
+
+fn locate(source: &str, blk: &AwaitBlock) -> Option<AwaitAnchors> {
+    // The header carries the binding only in the shorthand form; otherwise the
+    // promise expression is the last thing before its `}`.
+    let header_anchor = if blk.pending.is_none() {
+        blk.value
+            .as_ref()
+            .and_then(|v| v.end())
+            .or_else(|| blk.error.as_ref().and_then(|e| e.end()))
+            .or_else(|| blk.expression.end())
+    } else {
+        blk.expression.end()
+    }?;
+    let header_end = close_brace_after(source, header_anchor)?;
+
+    let close_open = {
+        let head = source.get(..blk.end as usize)?;
+        let idx = crate::source_offset(head.rfind('{')?);
+        if idx < header_end {
+            return None;
+        }
+        let after = source.get(idx as usize + 1..blk.end as usize)?;
+        if !after.trim_start().starts_with('/') {
+            return None;
+        }
+        idx
+    };
+
+    // A `{:then …}` separator exists exactly when the header was not the
+    // shorthand `{#await … then …}` and a then fragment was parsed.
+    let then_sep = if blk.pending.is_some() && blk.then.is_some() {
+        let anchor = last_node_end(blk.pending.as_ref()).unwrap_or(header_end);
+        let open = separator_open_at(source, anchor, "then")?;
+        let close = match blk.value.as_ref().and_then(|v| v.end()) {
+            Some(end) if end > open => close_brace_after(source, end)?,
+            _ => close_brace_after(source, open + 1)?,
+        };
+        Some((open, close))
+    } else {
+        None
+    };
+
+    let catch_sep = if blk.catch.is_some() && (blk.pending.is_some() || blk.then.is_some()) {
+        let anchor = if blk.then.is_some() {
+            last_node_end(blk.then.as_ref())
+                .unwrap_or_else(|| then_sep.map_or(header_end, |(_, close)| close))
+        } else {
+            last_node_end(blk.pending.as_ref()).unwrap_or(header_end)
+        };
+        let open = separator_open_at(source, anchor, "catch")?;
+        let close = match blk.error.as_ref().and_then(|e| e.end()) {
+            Some(end) if end > open => close_brace_after(source, end)?,
+            _ => close_brace_after(source, open + 1)?,
+        };
+        Some((open, close))
+    } else {
+        None
+    };
+
+    Some(AwaitAnchors {
+        header_end,
+        then_sep,
+        catch_sep,
+        close_open,
+    })
+}
+
+/// Decide the block's layout the way prettier-plugin-svelte's `AwaitBlock`
+/// printer does.
+pub(crate) fn plan(source: &str, blk: &AwaitBlock) -> AwaitPlan {
+    let Some(anchors) = locate(source, blk) else {
+        return AwaitPlan::identity();
+    };
+
+    let has_pending = fragment_has_content(blk.pending.as_ref());
+    let has_then = fragment_has_content(blk.then.as_ref());
+    let has_catch = fragment_has_content(blk.catch.as_ref());
+
+    let source_form = if blk.pending.is_some() {
+        AwaitHeaderForm::Bare
+    } else if blk.value.is_some() {
+        AwaitHeaderForm::Then
+    } else if blk.error.is_some() {
+        AwaitHeaderForm::Catch
+    } else {
+        AwaitHeaderForm::Bare
+    };
+
+    let then_body_start = anchors.then_sep.map_or(anchors.header_end, |(_, c)| c);
+    let catch_body_start = anchors.catch_sep.map_or(anchors.header_end, |(_, c)| c);
+    let then_region_start = anchors.then_sep.map_or(then_body_start, |(o, _)| o);
+    let catch_region_start = anchors.catch_sep.map_or(catch_body_start, |(o, _)| o);
+
+    let (form, first_kept, keep_pending, keep_then, keep_catch) = if !has_pending && has_then {
+        (
+            AwaitHeaderForm::Then,
+            then_body_start,
+            false,
+            true,
+            has_catch,
+        )
+    } else if !has_pending && has_catch {
+        (AwaitHeaderForm::Catch, catch_body_start, false, false, true)
+    } else if has_pending {
+        (
+            AwaitHeaderForm::Bare,
+            anchors.header_end,
+            true,
+            has_then,
+            has_catch,
+        )
+    } else {
+        // Nothing survives: `{#await expr}{/await}`.
+        (
+            AwaitHeaderForm::Bare,
+            anchors.close_open,
+            false,
+            false,
+            false,
+        )
+    };
+
+    let mut deletions = Vec::new();
+    let mut rewrite_end = None;
+    if form == source_form {
+        // The header already has the right shape, so only the dropped clauses
+        // need erasing. Everything ahead of the first kept region goes.
+        if first_kept > anchors.header_end {
+            deletions.push((anchors.header_end, first_kept));
+        }
+    } else {
+        rewrite_end = Some(first_kept);
+    }
+
+    // A dropped clause that sits after a kept one needs its own erasure; the
+    // `first_kept` span above only covers the clauses ahead of the first
+    // survivor.
+    if keep_pending && !keep_then && blk.then.is_some() {
+        let end = if keep_catch {
+            catch_region_start
+        } else {
+            anchors.close_open
+        };
+        if end > then_region_start {
+            deletions.push((then_region_start, end));
+        }
+    } else if (keep_pending || keep_then)
+        && !keep_catch
+        && blk.catch.is_some()
+        && anchors.close_open > catch_region_start
+    {
+        deletions.push((catch_region_start, anchors.close_open));
+    }
+
+    AwaitPlan {
+        form,
+        rewrite_end,
+        deletions,
+        keep_pending,
+        keep_then,
+        keep_catch,
+    }
+}

--- a/crates/rsvelte_formatter/src/expression/collect.rs
+++ b/crates/rsvelte_formatter/src/expression/collect.rs
@@ -1,5 +1,6 @@
 use rsvelte_core::ast::template::{Fragment, TemplateNode};
 
+use super::await_block;
 use super::call_args;
 use super::declaration::format_pattern_source;
 use super::splice::{
@@ -27,6 +28,44 @@ fn each_key_source<'a>(
         .get(open as usize + 1..close_excl as usize - 1)
         .map(str::trim)
         .filter(|inner| !inner.is_empty())
+}
+
+/// Collapse the whitespace around an each-block's `as` keyword to one space on
+/// each side, which is what the oracle's fixed `' as'` + `' <pattern>'` prints.
+fn normalize_each_as_keyword(
+    source: &str,
+    expr_end: u32,
+    ctx_start: u32,
+    edits: &mut Vec<(u32, u32, String)>,
+) {
+    let Some(region) = source.get(expr_end as usize..ctx_start as usize) else {
+        return;
+    };
+    // Anything other than plain whitespace around `as` (a comment, say) is left
+    // alone rather than rewritten into something that may not parse.
+    if region.trim() != "as" || region == " as " {
+        return;
+    }
+    edits.push((expr_end, ctx_start, " as ".to_string()));
+}
+
+/// The `[ws] , [ws] <index>` run that follows an each-block's pattern, as
+/// `(start, end)`. The index name has no span in the AST, so it is located by
+/// matching the parsed name against the source.
+fn each_index_span(source: &str, ctx_end: u32, index: &str) -> Option<(u32, u32)> {
+    const WS: [char; 4] = [' ', '\t', '\n', '\r'];
+    let rest = source.get(ctx_end as usize..)?;
+    let after = rest
+        .trim_start_matches(WS)
+        .strip_prefix(',')?
+        .trim_start_matches(WS)
+        .strip_prefix(index)?;
+    // Guard against `i` matching the head of a longer name.
+    if after.starts_with(|c: char| c.is_alphanumeric() || c == '_' || c == '$') {
+        return None;
+    }
+    let end = ctx_end as usize + (rest.len() - after.len());
+    Some((ctx_end, crate::source_offset(end)))
 }
 
 /// The each-iterable source, used to measure how much it widens the header line.
@@ -254,9 +293,26 @@ fn collect_node_edits(
                 key_expansion,
                 edits,
             )?;
-            if let Some(ctx) = &blk.context {
+            // prettier-plugin-svelte re-prints the header's fixed parts, so the
+            // ` as ` keyword and the `, index` separator always come out
+            // canonically spaced no matter how the source wrote them.
+            let index_end = if let Some(ctx) = &blk.context {
+                if let (Some(expr_end), Some(ctx_start)) = (blk.expression.end(), ctx.start()) {
+                    normalize_each_as_keyword(source, expr_end, ctx_start, edits);
+                }
                 push_pattern_at_span(source, ctx, options, edits)?;
-            }
+                match (ctx.end(), blk.index.as_deref()) {
+                    (Some(ctx_end), Some(index)) => each_index_span(source, ctx_end, index)
+                        .map(|(start, end)| {
+                            edits.push((start, end, format!(", {index}")));
+                            end
+                        })
+                        .or(Some(ctx_end)),
+                    (ctx_end, _) => ctx_end,
+                }
+            } else {
+                None
+            };
             if let Some(key) = &blk.key {
                 // The each-key syntax is `(KEY)`. The Svelte AST stores only the
                 // inner KEY expression span; the delimiter parens — and any
@@ -363,12 +419,10 @@ fn collect_node_edits(
                         push_brace_wrapped_expression(source, key, options, edits)?;
                     }
                 }
-            } else if let Some(ctx) = &blk.context {
-                // No key — trim trailing whitespace between context and the
-                // header `}` (e.g. `{#each arr as x }` → `{#each arr as x}`).
-                if let Some(ctx_end) = ctx.end() {
-                    trim_trailing_ws_before_close_brace(source, ctx_end, edits);
-                }
+            } else if let Some(header_end) = index_end {
+                // No key — trim trailing whitespace between the last header part
+                // and the `}` (e.g. `{#each arr as x }` → `{#each arr as x}`).
+                trim_trailing_ws_before_close_brace(source, header_end, edits);
             }
             collect_template_edits(source, &blk.body, child_depth, options, edits)?;
             if let Some(fb) = &blk.fallback {
@@ -378,70 +432,22 @@ fn collect_node_edits(
         TemplateNode::AwaitBlock(blk) => {
             // Normalize extra whitespace between `{` and `#` in the opener.
             normalize_block_opener_ws(source, blk.start, edits);
-            // When the pending block is empty (whitespace-only) and there is a
-            // `{:then value}` or `{:catch error}` separator, prettier-plugin-svelte
-            // collapses the two headers into one:
-            //   `{#await expr}\n{:then value}` → `{#await expr then value}`
-            //   `{#await expr}\n{:catch error}` → `{#await expr catch error}`
-            // Emit a single rewrite spanning the entire collapsed region instead
-            // of the individual expression/pattern edits — those would conflict
-            // with the large rewrite if emitted separately.
-            let collapsed = if await_pending_is_empty(blk.pending.as_ref()) {
-                try_collapse_await_header(source, blk, options)?
-            } else {
-                None
-            };
-            // When the await block is already in shorthand form (`pending` is
-            // `None`) but the `then` body is empty, strip the `then value`
-            // clause entirely: `{#await expr then value}{/await}` →
-            // `{#await expr}{/await}`. This matches prettier-plugin-svelte's
-            // behaviour.
-            let stripped = if blk.pending.is_none()
-                && blk.value.is_some()
-                && blk.catch.is_none()
-                && blk.then.as_ref().is_some_and(is_empty_fragment_for_await)
+            // prettier-plugin-svelte prints only the clauses whose fragment holds
+            // something that is not blank text, and collapses the header when the
+            // pending clause is one of the dropped ones. `await_block::plan`
+            // reproduces that decision; everything below just applies it.
+            let plan = await_block::plan(source, blk);
+            for (del_start, del_end) in &plan.deletions {
+                edits.push((*del_start, *del_end, String::new()));
+            }
+            let mut rewritten = false;
+            if let Some(rewrite_end) = plan.rewrite_end
+                && let Some(header) = render_await_header(source, blk, plan.form, options)?
             {
-                try_strip_await_then_clause(source, blk, options)?
-            } else {
-                None
-            };
-            // When the block has a non-empty pending body but an empty `then` body
-            // (and no `catch`), strip the empty `{:then value}` separator entirely:
-            //   `{#await expr}\n  <input />\n{:then f}\n{/await}` →
-            //   `{#await expr}\n  <input />\n{/await}`
-            // This matches prettier-plugin-svelte's behaviour.
-            let separator_stripped = if collapsed.is_none()
-                && stripped.is_none()
-                && blk.pending.is_some()
-                && blk.value.is_some()
-                && blk.catch.is_none()
-                && blk.then.as_ref().is_some_and(is_empty_fragment_for_await)
-            {
-                try_strip_await_then_separator(source, blk)
-            } else {
-                None
-            };
-            // Remember whether the separator-stripped path fired before
-            // the ownership moves into `.or()`.
-            let separator_stripped_fired = separator_stripped.is_some();
-            if let Some((rewrite_start, rewrite_end, replacement)) =
-                collapsed.or(stripped).or(separator_stripped)
-            {
-                edits.push((rewrite_start, rewrite_end, replacement));
-                // When the separator-stripped path fires (pending has content,
-                // `{:then …}` and its empty body are erased), we still need to
-                // recurse into the pending fragment to format its children
-                // (e.g. `<input>` → `<input />`). For the `collapsed` and
-                // `stripped` paths the pending is either empty/whitespace-only
-                // or absent, so no recursion is needed there.
-                if separator_stripped_fired && let Some(frag) = &blk.pending {
-                    collect_template_edits(source, frag, child_depth, options, edits)?;
-                }
-                // Only recurse into the non-pending body fragments.
-                for frag in [&blk.then, &blk.catch].into_iter().flatten() {
-                    collect_template_edits(source, frag, child_depth, options, edits)?;
-                }
-            } else {
+                edits.push((blk.start, rewrite_end, header));
+                rewritten = true;
+            }
+            if !rewritten {
                 // Normalize leading whitespace: `{#await  expr}` → `{#await expr}`.
                 if let Some(start) = blk.expression.start() {
                     normalize_leading_ws_before_expr(source, start, edits);
@@ -476,7 +482,9 @@ fn collect_node_edits(
                     // 3-part form: header is `{#await expr}`, trim its trailing ws.
                     trim_trailing_ws_before_close_brace(source, expr_end, edits);
                     // The `:then binding` is handled below via `blk.value`.
-                    if let Some(v) = &blk.value {
+                    if plan.keep_then
+                        && let Some(v) = &blk.value
+                    {
                         // Normalize `{   :then i}` → `{:then i}`.
                         if let Some(v_start) = v.start() {
                             normalize_separator_opener_before(source, v_start, edits);
@@ -488,7 +496,9 @@ fn collect_node_edits(
                         }
                     }
                 }
-                if let Some(e) = &blk.error {
+                if plan.keep_catch
+                    && let Some(e) = &blk.error
+                {
                     // Normalize `{   :catch e}` → `{:catch e}`.
                     if let Some(e_start) = e.start() {
                         normalize_separator_opener_before(source, e_start, edits);
@@ -499,34 +509,23 @@ fn collect_node_edits(
                         trim_trailing_ws_before_close_brace(source, e_end, edits);
                     }
                 }
-                let pending_should_be_stripped = blk.then.is_none()
-                    && blk.catch.is_none()
-                    && await_pending_is_empty(blk.pending.as_ref());
-                if let Some(frag) = &blk.pending {
-                    // When the pending body is whitespace-only and there is no
-                    // `then` / `catch` separator to collapse into, strip the
-                    // whitespace so `{#await promise} {/await}` →
-                    // `{#await promise}{/await}`. We only do this when there is
-                    // nothing else in the block (no then, no catch), matching
-                    // prettier-plugin-svelte's behaviour.
-                    if pending_should_be_stripped {
-                        for node in &frag.nodes {
-                            if let TemplateNode::Text(t) = node
-                                && crate::is_blank_text(t.data.as_ref())
-                            {
-                                edits.push((t.start, t.end, String::new()));
-                            }
-                        }
-                    } else {
-                        collect_template_edits(source, frag, child_depth, options, edits)?;
-                    }
-                }
-                if let Some(frag) = &blk.then {
-                    collect_template_edits(source, frag, child_depth, options, edits)?;
-                }
-                if let Some(frag) = &blk.catch {
-                    collect_template_edits(source, frag, child_depth, options, edits)?;
-                }
+            }
+            // Only recurse into the fragments the plan keeps — a dropped clause's
+            // body is erased wholesale, so an edit inside it would collide.
+            if plan.keep_pending
+                && let Some(frag) = &blk.pending
+            {
+                collect_template_edits(source, frag, child_depth, options, edits)?;
+            }
+            if plan.keep_then
+                && let Some(frag) = &blk.then
+            {
+                collect_template_edits(source, frag, child_depth, options, edits)?;
+            }
+            if plan.keep_catch
+                && let Some(frag) = &blk.catch
+            {
+                collect_template_edits(source, frag, child_depth, options, edits)?;
             }
         }
         TemplateNode::KeyBlock(blk) => {
@@ -626,46 +625,16 @@ fn expand_inline_empty_block_body(
     }
 }
 
-/// Returns `true` when the pending fragment of an `{#await}` block is **present**
-/// but contains only whitespace — i.e., the block was written in the expanded form
-/// `{#await expr}\n{:then value}` with nothing between the headers.
+/// Render the collapsed `{#await …}` header the oracle prints for `form`.
 ///
-/// Returns `false` when `pending` is `None` (the source already uses the
-/// shorthand `{#await expr then value}` form and should not be re-collapsed).
-pub fn await_pending_is_empty(pending: Option<&rsvelte_core::ast::template::Fragment>) -> bool {
-    pending.is_some_and(|fragment| {
-        fragment.nodes.iter().all(|n| {
-            matches!(n, rsvelte_core::ast::template::TemplateNode::Text(t) if crate::is_blank_text(t.data.as_ref()))
-        })
-    })
-}
-
-/// Attempt to collapse an `{#await expr}` block with an empty pending body and a
-/// `{:then value}` or `{:catch error}` separator into a single header:
-///   `{#await expr}\n\n{:then value}` → `{#await expr then value}`
-///
-/// Returns `(edit_start, edit_end, replacement)` covering the entire region from
-/// `{#await` through the closing `}` of the separator header. When the block
-/// can't be collapsed (no value/error binding found, span out of range, etc.)
-/// returns `None` — the caller falls back to the individual-edit path.
-fn try_collapse_await_header(
+/// Returns `None` when the promise expression cannot be read back from the
+/// source, in which case the caller leaves the header untouched.
+fn render_await_header(
     source: &str,
     blk: &rsvelte_core::ast::template::AwaitBlock,
+    form: await_block::AwaitHeaderForm,
     options: &FormatOptions,
-) -> Result<Option<(u32, u32, String)>, FormatError> {
-    // Determine which separator we're collapsing and its keyword + binding.
-    let (keyword, binding) = if blk.then.is_some() && blk.value.is_some() {
-        ("then", blk.value.as_ref())
-    } else if blk.catch.is_some() && blk.error.is_some() {
-        ("catch", blk.error.as_ref())
-    } else {
-        // No collapsible binding — fall back.
-        return Ok(None);
-    };
-
-    let binding = binding.expect("checked above");
-
-    // Formatted expression (the promise / async value).
+) -> Result<Option<String>, FormatError> {
     let (Some(expr_start), Some(expr_end)) = (blk.expression.start(), blk.expression.end()) else {
         return Ok(None);
     };
@@ -677,164 +646,34 @@ fn try_collapse_await_header(
         return Ok(None);
     }
     let fmt_expr = format_inline_expression(expr_src, options)?;
-
-    // Formatted binding pattern (`value` / `error`).
-    let (Some(bind_start), Some(bind_end)) = (binding.start(), binding.end()) else {
-        return Ok(None);
-    };
-    let bind_src = source
-        .get(bind_start as usize..bind_end as usize)
-        .unwrap_or("")
-        .trim();
-    // If no binding source, skip collapse.
-    if bind_src.is_empty() {
-        return Ok(None);
-    }
-    let fmt_bind =
-        format_pattern_source(bind_src, options).unwrap_or_else(|_| bind_src.to_string());
-
-    // Find the `}` that closes the `{:then value}` / `{:catch error}` separator
-    // header — it comes immediately after the binding expression end.
-    let separator_close = source
-        .get(bind_end as usize..)
-        .and_then(|s| s.find('}'))
-        .map(|rel| bind_end as usize + rel + 1);
-    let Some(separator_close) = separator_close else {
-        return Ok(None);
-    };
-
-    let replacement = format!("{{#await {fmt_expr} {keyword} {fmt_bind}}}");
-    Ok(Some((
-        blk.start,
-        crate::source_offset(separator_close),
-        replacement,
-    )))
-}
-
-/// Returns `true` when a fragment contains only whitespace-only text nodes or
-/// is entirely empty — used to detect an empty `then` body in a shorthand
-/// `{#await expr then value}{/await}` block.
-fn is_empty_fragment_for_await(frag: &rsvelte_core::ast::template::Fragment) -> bool {
-    frag.nodes.iter().all(|n| {
-        matches!(n, rsvelte_core::ast::template::TemplateNode::Text(t) if crate::is_blank_text(t.data.as_ref()))
-    })
-}
-
-/// Strip the `then value` clause from a shorthand await block that has an
-/// empty then body: `{#await expr then value}{/await}` → the rewrite span
-/// covers from `blk.start` to the `}` that closes the header (`{#await expr
-/// then value}`), replacing it with `{#await expr}`.
-///
-/// Returns `None` when the span cannot be determined from the source.
-fn try_strip_await_then_clause(
-    source: &str,
-    blk: &rsvelte_core::ast::template::AwaitBlock,
-    options: &FormatOptions,
-) -> Result<Option<(u32, u32, String)>, FormatError> {
-    let (Some(expr_start), Some(expr_end)) = (blk.expression.start(), blk.expression.end()) else {
-        return Ok(None);
-    };
-    let expr_src = source
-        .get(expr_start as usize..expr_end as usize)
-        .unwrap_or("")
-        .trim();
-    if expr_src.is_empty() {
-        return Ok(None);
-    }
-    let fmt_expr = format_inline_expression(expr_src, options)?;
-
-    // Find the `}` that closes the header after the `then value` portion.
-    // `blk.value` is the binding pattern (e.g. `counter`).
-    let Some(v) = &blk.value else {
-        return Ok(None);
-    };
-    let Some(v_end) = v.end() else {
-        return Ok(None);
-    };
-    let header_close = source
-        .get(v_end as usize..)
-        .and_then(|s| s.find('}'))
-        .map(|rel| v_end as usize + rel + 1);
-    let Some(header_close) = header_close else {
-        return Ok(None);
-    };
-
-    let replacement = format!("{{#await {fmt_expr}}}");
-    Ok(Some((
-        blk.start,
-        crate::source_offset(header_close),
-        replacement,
-    )))
-}
-
-/// Strip an empty `{:then value}` (or `{:catch error}`) separator from a
-/// 3-part await block whose `then` (or `catch`) body is empty:
-///   `{#await expr}\n  <child />\n{:then f}\n{/await}` →
-/// emits an edit removing the `{:then f}\n` region so the output becomes
-///   `{#await expr}\n  <child />\n{/await}`
-///
-/// The edit span runs from the opening `{` of `{:then …}` up to (but not
-/// including) the opening `{` of `{/await}`.
-///
-/// Returns `None` when the span cannot be determined from the source.
-fn try_strip_await_then_separator(
-    source: &str,
-    blk: &rsvelte_core::ast::template::AwaitBlock,
-) -> Option<(u32, u32, String)> {
-    // We need the binding position to locate `{:then …}` by scanning backward.
-    let binding = if blk.value.is_some() {
-        blk.value.as_ref()
-    } else if blk.error.is_some() {
-        blk.error.as_ref()
-    } else {
-        return None;
-    };
-    let binding = binding.expect("checked above");
-
-    let bind_start = binding.start()?;
-
-    let bytes = source.as_bytes();
-
-    // Scan backward from the binding start to find the `{` that opens the separator.
-    let mut i = bind_start as usize;
-    while i > 0 {
-        i -= 1;
-        match bytes[i] {
-            b' ' | b'\t' | b'\n' | b'\r' | b'n' | b'h' | b'c' | b'a' | b't' | b'e' | b':' => {}
-            // Skip past the keyword (`then` or `catch`) and the leading `:`
-            // that the separator opener contains.  We stop at `{`.
-            b'{' => break,
-            _ => return None,
+    let clause = match form {
+        await_block::AwaitHeaderForm::Bare => String::new(),
+        await_block::AwaitHeaderForm::Then => {
+            render_await_clause(source, "then", blk.value.as_ref(), options)
         }
-    }
-    if bytes.get(i) != Some(&b'{') {
-        return None;
-    }
-    let separator_open = crate::source_offset(i);
+        await_block::AwaitHeaderForm::Catch => {
+            render_await_clause(source, "catch", blk.error.as_ref(), options)
+        }
+    };
+    Ok(Some(format!("{{#await {fmt_expr}{clause}}}")))
+}
 
-    // Find the start of `{/await}` by scanning backward from `blk.end`.
-    // `blk.end` points just past `}` of `{/await}`, so the `{` is at
-    // `blk.end - 8` for the 8-byte literal `{/await}`.  We verify by
-    // searching backward for `{` while skipping only non-brace chars.
-    let close_tag = b"{/await}";
-    let end = blk.end as usize;
-    if end < close_tag.len() {
-        return None;
+/// ` then value` / ` catch error`, or the bare keyword when the clause has no
+/// binding (`{:then}` collapses to `{#await p then}`, as the oracle prints it).
+fn render_await_clause(
+    source: &str,
+    keyword: &str,
+    binding: Option<&rsvelte_core::ast::js::Expression>,
+    options: &FormatOptions,
+) -> String {
+    let rendered = binding
+        .and_then(|b| Some((b.start()?, b.end()?)))
+        .and_then(|(s, e)| source.get(s as usize..e as usize))
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(|s| format_pattern_source(s, options).unwrap_or_else(|_| s.to_string()));
+    match rendered {
+        Some(b) => format!(" {keyword} {b}"),
+        None => format!(" {keyword}"),
     }
-    // Verify the close tag is present.
-    let close_tag_start = end - close_tag.len();
-    if source.as_bytes().get(close_tag_start..end) != Some(close_tag.as_ref()) {
-        // Try with a space: `{/ await}` — not standard but defensive.
-        return None;
-    }
-    let close_tag_pos = crate::source_offset(close_tag_start);
-
-    // The edit removes everything from `{` of `{:then …}` up to the `{` of
-    // `{/await}` (non-inclusive), which erases the separator header and its
-    // empty body (typically just a newline).
-    if separator_open >= close_tag_pos {
-        return None;
-    }
-
-    Some((separator_open, close_tag_pos, String::new()))
 }

--- a/crates/rsvelte_formatter/src/expression/mod.rs
+++ b/crates/rsvelte_formatter/src/expression/mod.rs
@@ -1,5 +1,6 @@
 use oxc_parser::ParseOptions as OxcParseOptions;
 
+mod await_block;
 mod call_args;
 mod collect;
 mod declaration;
@@ -12,7 +13,8 @@ mod width;
 #[cfg(test)]
 mod tests;
 
-pub use collect::{await_pending_is_empty, collect_template_edits};
+pub(crate) use await_block::plan as plan_await_block;
+pub use collect::collect_template_edits;
 pub use declaration::format_pattern_source;
 pub use directive::{
     format_directive_value, format_directive_value_extra, format_function_binding,

--- a/crates/rsvelte_formatter/src/expression/splice.rs
+++ b/crates/rsvelte_formatter/src/expression/splice.rs
@@ -16,7 +16,8 @@ use super::text::{
     is_method_chain_break, starts_with_array_or_object_literal,
 };
 use super::width::{
-    format_content_expression, format_content_expression_with_prefix, format_inline_expression,
+    format_content_expression, format_content_expression_with_bounds,
+    format_content_expression_with_prefix, format_inline_expression,
 };
 use super::{format_expression_source, format_pattern_source, formatter_parse_options};
 use crate::error::FormatError;
@@ -167,9 +168,95 @@ pub(super) fn push_expression_tag(
         } else {
             1
         };
-    let formatted = format_content_expression_with_prefix(inner, options, depth, prefix_lead)?;
+    let suffix_trail = glued_tag_run_width(source, tag.end, options);
+    let formatted =
+        format_content_expression_with_bounds(inner, options, depth, prefix_lead, suffix_trail)?;
     edits.push((tag.start, tag.end, format!("{{{formatted}}}")));
     Ok(())
+}
+
+/// The columns a tag's own fit test must charge for the run of tags glued
+/// directly to the `}` at `from`.
+///
+/// The oracle prints a fragment's children as a plain concatenation, so a group
+/// is measured against the rest of the line — adjacent mustaches offer no break
+/// opportunity of their own, and the first breakable one has to absorb the whole
+/// run. The scan therefore stops at the first following tag that *can* break,
+/// charging only the text before that break point, exactly as prettier's `fits`
+/// stops at the first line it meets in an enclosing break context.
+fn glued_tag_run_width(source: &str, from: u32, options: &FormatOptions) -> usize {
+    let tw = tab_width(options);
+    let rest = source.get(from as usize..).unwrap_or("");
+    let mut total = 0usize;
+    let mut consumed = 0usize;
+    while rest.as_bytes().get(consumed) == Some(&b'{') {
+        // A block tag opens its own fragment, which is a break opportunity.
+        if matches!(
+            rest.as_bytes().get(consumed + 1),
+            Some(b'#' | b':' | b'/' | b'@')
+        ) {
+            break;
+        }
+        let Some(end) = glued_tag_end(rest, consumed) else {
+            break;
+        };
+        let Some(span) = rest.get(consumed..end) else {
+            break;
+        };
+        let inner = span
+            .strip_prefix('{')
+            .and_then(|s| s.strip_suffix('}'))
+            .map_or("", str::trim);
+        if inner.is_empty() {
+            break;
+        }
+        match crate::expression::reformat_content_at_width(inner, options, 1, 0) {
+            Ok(broken) if broken.contains('\n') => {
+                total += 1 + broken.lines().next().unwrap_or("").visual_width(tw);
+                break;
+            }
+            _ => total += span.visual_width(tw),
+        }
+        consumed = end;
+    }
+    total
+}
+
+/// The offset just past the `}` closing the tag that opens at `open`, or `None`
+/// when it does not close on the same line (a line break is a break opportunity,
+/// so the run ends there either way).
+fn glued_tag_end(source: &str, open: usize) -> Option<usize> {
+    let bytes = source.as_bytes();
+    let mut depth = 0usize;
+    let mut quote: Option<u8> = None;
+    let mut i = open;
+    while i < bytes.len() {
+        let byte = bytes[i];
+        if let Some(q) = quote {
+            if byte == b'\\' {
+                i += 2;
+                continue;
+            }
+            if byte == q {
+                quote = None;
+            }
+        } else {
+            match byte {
+                b'\'' | b'"' | b'`' => quote = Some(byte),
+                b'{' => depth += 1,
+                b'}' => {
+                    depth -= 1;
+                    if depth == 0 {
+                        return Some(i + 1);
+                    }
+                }
+                b'\n' => return None,
+                _ => {}
+            }
+        }
+        i += 1;
+    }
+    None
 }
 
 /// Replace `{@<keyword> EXPR}` (full tag span) with the formatted expression

--- a/crates/rsvelte_formatter/src/expression/width.rs
+++ b/crates/rsvelte_formatter/src/expression/width.rs
@@ -152,6 +152,20 @@ pub(super) fn format_content_expression_with_prefix(
     depth: usize,
     prefix_lead: usize,
 ) -> Result<String, FormatError> {
+    format_content_expression_with_bounds(expr_source, options, depth, prefix_lead, 0)
+}
+
+/// As `format_content_expression_with_prefix`, but also charging `suffix_trail`
+/// columns for content glued to the tag's closing `}`. The oracle measures a
+/// group against the rest of the line, and a run of adjacent mustaches offers no
+/// break opportunity, so the whole run shares one width budget.
+pub(super) fn format_content_expression_with_bounds(
+    expr_source: &str,
+    options: &FormatOptions,
+    depth: usize,
+    prefix_lead: usize,
+    suffix_trail: usize,
+) -> Result<String, FormatError> {
     let indent_width = options.js.indent_width.value() as usize;
     let lead = depth * indent_width;
     let full_width = options.js.line_width.value() as usize;
@@ -171,8 +185,15 @@ pub(super) fn format_content_expression_with_prefix(
         .next()
         .unwrap_or(formatted.as_str())
         .visual_width(tab_width(options));
-    let formatted = if lead + overhead + first_line_width > full_width {
-        let narrowed2 = full_width.saturating_sub(lead + overhead);
+    let formatted = if lead + overhead + suffix_trail + first_line_width > full_width {
+        // The trailing run decides only THAT the tag breaks — in the oracle it
+        // makes the group miss its fit, but the group's contents are then laid
+        // out against their real column, not against a budget the run ate. So
+        // narrow to the tag's own remaining width, and never past the one column
+        // that forces the outermost break.
+        let narrowed2 = full_width
+            .saturating_sub(lead + overhead)
+            .min(first_line_width.saturating_sub(1));
         let lw2 = oxc_formatter_core::LineWidth::try_from(crate::formatter_width(narrowed2.max(1)))
             .unwrap_or(options.js.line_width);
         format_expr_core(expr_source, options, lw2, false)?

--- a/crates/rsvelte_formatter/src/indent.rs
+++ b/crates/rsvelte_formatter/src/indent.rs
@@ -670,39 +670,23 @@ fn recurse_into_children(
             }
         }
         TemplateNode::AwaitBlock(blk) => {
-            // When the pending block is whitespace-only AND there is a then/catch
-            // binding, the expression pass collapses the two headers into one
-            // (`{#await expr then value}`). Skip the pending fragment here so we
-            // don't emit a spurious blank-line edit inside the collapsed region.
-            // `await_pending_is_empty` returns false when pending is None (shorthand form)
-            // and true only when pending is Some but whitespace-only (expanded form to collapse).
-            // Mirror `try_collapse_await_header`'s collapse condition exactly so the
-            // two passes always agree on whether the pending block was collapsed.
-            let pending_collapsed = crate::expression::await_pending_is_empty(blk.pending.as_ref())
-                && ((blk.then.is_some() && blk.value.is_some())
-                    || (blk.catch.is_some() && blk.error.is_some()));
-            // When the pending block has real content but the `then` body is empty
-            // (and there's no catch), the expression pass strips the `{:then …}`
-            // separator entirely. Skip the then-body indent pass so we don't emit
-            // a spurious blank-line edit (`\n\n`) inside the erased region.
-            // Mirror `try_strip_await_then_separator`'s condition exactly.
-            let separator_stripped = !pending_collapsed
-                && blk.pending.is_some()
-                && blk.value.is_some()
-                && blk.catch.is_none()
-                && blk.then.as_ref().is_some_and(|f| {
-                    f.nodes.iter().all(|n| {
-                        matches!(n, rsvelte_core::ast::template::TemplateNode::Text(t)
-                            if crate::is_blank_text(t.data.as_ref()))
-                    })
-                });
-            if !pending_collapsed && let Some(frag) = &blk.pending {
+            // The expression pass erases whatever clauses the oracle drops, so
+            // indenting inside one of those regions would emit a blank-line edit
+            // into text that no longer exists. Both passes read the same plan.
+            let plan = crate::expression::plan_await_block(source, blk);
+            if plan.keep_pending
+                && let Some(frag) = &blk.pending
+            {
                 collect_indent_edits_inner(source, frag, next_depth, true, true, options, edits)?;
             }
-            if !separator_stripped && let Some(frag) = &blk.then {
+            if plan.keep_then
+                && let Some(frag) = &blk.then
+            {
                 collect_indent_edits_inner(source, frag, next_depth, true, true, options, edits)?;
             }
-            if let Some(frag) = &blk.catch {
+            if plan.keep_catch
+                && let Some(frag) = &blk.catch
+            {
                 collect_indent_edits_inner(source, frag, next_depth, true, true, options, edits)?;
             }
         }

--- a/crates/rsvelte_formatter/tests/adjacent_expression_tags.rs
+++ b/crates/rsvelte_formatter/tests/adjacent_expression_tags.rs
@@ -1,0 +1,90 @@
+//! A run of expression tags glued together shares one width budget.
+//!
+//! The oracle prints a fragment's children as a plain concatenation, so a tag's
+//! group is measured against the rest of the line — and adjacent mustaches offer
+//! no break opportunity of their own, so the first breakable one absorbs the
+//! whole run. Every expectation below was measured against the
+//! oxfmt(`svelte: true`) oracle.
+
+use rsvelte_formatter::{FormatOptions, JsFormatOptions, LineWidth, format};
+
+fn fmt(src: &str) -> String {
+    let opts = FormatOptions {
+        js: JsFormatOptions {
+            line_width: LineWidth::try_from(80u16).expect("valid line width"),
+            ..JsFormatOptions::default()
+        },
+        ..FormatOptions::default()
+    };
+    let out = format(src, &opts).expect("format ok");
+    out.strip_suffix('\n').map(str::to_string).unwrap_or(out)
+}
+
+#[test]
+fn a_long_run_breaks_the_first_breakable_tag() {
+    let src = "<button>\n\t{z.plain}{z.raw.a}{z.derived}{z.byDerived}{z.priv}{z['quoted key']}{Zoo.staticPlain}{w.inCtor}\n</button>";
+    assert_eq!(
+        fmt(src),
+        "<button>\n  {z.plain}{z.raw.a}{z.derived}{z.byDerived}{z.priv}{z[\n    \"quoted key\"\n  ]}{Zoo.staticPlain}{w.inCtor}\n</button>"
+    );
+}
+
+#[test]
+fn whitespace_in_the_run_ends_the_shared_budget() {
+    // A space is a break opportunity, so the trailing tags stop counting: the
+    // line wraps there instead of breaking inside the computed member.
+    let src = "<button>\n\t{z.plain}{z.raw.a}{z.derived}{z.byDerived}{z.priv}{z['quoted key']} {Zoo.staticPlain}{w.inCtor}\n</button>";
+    assert_eq!(
+        fmt(src),
+        "<button>\n  {z.plain}{z.raw.a}{z.derived}{z.byDerived}{z.priv}{z[\"quoted key\"]}\n  {Zoo.staticPlain}{w.inCtor}\n</button>"
+    );
+}
+
+#[test]
+fn a_run_that_fits_is_left_alone() {
+    let src = "<div>\n  {a[\"k1\"]}{b[\"k2\"]}{c[\"k3\"]}{d[\"k4\"]}{e[\"k5\"]}{f[\"k6\"]}{g[\"k7\"]}{h[\"k8\"]}\n</div>";
+    assert_eq!(fmt(src), src);
+}
+
+#[test]
+fn an_unbreakable_run_never_breaks() {
+    // Every tag is a bare identifier, so there is nothing to break no matter how
+    // far the line overflows.
+    let src = "<div>\n  {aaa}{bbb}{ccc}{ddd}{eee}{fff}{ggg}{hhh}{iii}{jjj}{kkk}{lll}{mmm}{nnn}{ooo}{ppp}{qqq}\n</div>";
+    assert_eq!(fmt(src), src);
+}
+
+#[test]
+fn the_run_stops_at_the_first_breakable_follower() {
+    // `{z.raw.a}` can break, but the fit test that decides it walks only as far
+    // as `{z[`, where the computed member offers a break — so it stays flat.
+    let src = "{z.plain}{z.raw.a}{z.derived}{z.byDerived}{z.priv}{z['quoted key']}{Zoo.staticPlain}{w.inCtor}";
+    assert_eq!(
+        fmt(src),
+        "{z.plain}{z.raw.a}{z.derived}{z.byDerived}{z.priv}{z[\n  \"quoted key\"\n]}{Zoo.staticPlain}{w.inCtor}"
+    );
+}
+
+#[test]
+fn an_unbreakable_follower_is_charged_in_full() {
+    let tail = "Z".repeat(70);
+    assert_eq!(
+        fmt(&format!("{{z.raw.a}}{{{tail}}}")),
+        format!("{{z.raw\n  .a}}{{{tail}}}")
+    );
+    // One column shorter and the run still fits, so nothing breaks.
+    let tail = "Z".repeat(60);
+    let src = format!("{{z.raw.a}}{{{tail}}}");
+    assert_eq!(fmt(&src), src);
+}
+
+#[test]
+fn a_broken_tag_breaks_only_at_its_outermost_group() {
+    // The run decides only THAT the tag breaks; how deep it breaks is settled by
+    // the tag's own content, so a huge trailing run must not over-break it.
+    let tail = "Z".repeat(140);
+    assert_eq!(
+        fmt(&format!("{{z.raw.a}}{{{tail}}}")),
+        format!("{{z.raw\n  .a}}{{{tail}}}")
+    );
+}

--- a/crates/rsvelte_formatter/tests/await_clauses.rs
+++ b/crates/rsvelte_formatter/tests/await_clauses.rs
@@ -1,0 +1,85 @@
+//! Which `{#await}` clauses survive formatting.
+//!
+//! prettier-plugin-svelte decides the whole shape from three booleans — whether
+//! the pending / then / catch fragments hold anything that is not blank text —
+//! and prints only the clauses those booleans keep. Every case below was
+//! measured against the oxfmt(`svelte: true`) oracle.
+
+use rsvelte_formatter::{FormatOptions, format};
+
+fn fmt(src: &str) -> String {
+    let out = format(src, &FormatOptions::default()).expect("format ok");
+    out.strip_suffix('\n').map(str::to_string).unwrap_or(out)
+}
+
+#[test]
+fn empty_bare_then_clause_is_dropped() {
+    assert_eq!(fmt("{#await p}{:then}{/await}"), "{#await p}{/await}");
+}
+
+#[test]
+fn empty_then_clause_with_binding_is_dropped() {
+    assert_eq!(fmt("{#await p}{:then v}{/await}"), "{#await p}{/await}");
+}
+
+#[test]
+fn empty_then_clause_after_a_pending_body_is_dropped() {
+    assert_eq!(
+        fmt("{#await p}\n\t<p>pending</p>\n{:then}\n{/await}"),
+        "{#await p}\n  <p>pending</p>\n{/await}"
+    );
+}
+
+#[test]
+fn empty_then_clause_is_dropped_even_when_a_catch_survives() {
+    assert_eq!(
+        fmt("{#await p}\n\t<p>pending</p>\n{:then v}\n{:catch e}\n\t<p>err</p>\n{/await}"),
+        "{#await p}\n  <p>pending</p>\n{:catch e}\n  <p>err</p>\n{/await}"
+    );
+}
+
+#[test]
+fn empty_pending_and_then_collapse_into_the_catch_header() {
+    assert_eq!(
+        fmt("{#await p}\n{:then v}\n{:catch e}\n\t<p>err</p>\n{/await}"),
+        "{#await p catch e}\n  <p>err</p>\n{/await}"
+    );
+}
+
+#[test]
+fn empty_pending_collapses_a_bare_then_into_the_header() {
+    assert_eq!(
+        fmt("{#await p}\n{:then}\n\t<p>ok</p>\n{/await}"),
+        "{#await p then}\n  <p>ok</p>\n{/await}"
+    );
+}
+
+#[test]
+fn empty_catch_body_drops_the_catch_clause() {
+    assert_eq!(
+        fmt("{#await p}\n\t<p>pending</p>\n{:then v}\n\t<p>ok</p>\n{:catch e}\n{/await}"),
+        "{#await p}\n  <p>pending</p>\n{:then v}\n  <p>ok</p>\n{/await}"
+    );
+}
+
+#[test]
+fn shorthand_headers_with_empty_bodies_lose_their_clause() {
+    assert_eq!(fmt("{#await p then v}{/await}"), "{#await p}{/await}");
+    assert_eq!(fmt("{#await p catch e}{/await}"), "{#await p}{/await}");
+    assert_eq!(fmt("{#await p}{:catch e}{/await}"), "{#await p}{/await}");
+}
+
+#[test]
+fn every_clause_survives_when_every_body_has_content() {
+    let src =
+        "{#await p}\n  <p>pending</p>\n{:then v}\n  <p>ok</p>\n{:catch e}\n  <p>err</p>\n{/await}";
+    assert_eq!(fmt(src), src);
+}
+
+#[test]
+fn a_comment_counts_as_content() {
+    let src = "{#await p}\n  <!-- c -->\n{:then v}\n{/await}";
+    assert_eq!(fmt(src), "{#await p}\n  <!-- c -->\n{/await}");
+    let src = "{#await p}\n{:then v}\n  <!-- c -->\n{/await}";
+    assert_eq!(fmt(src), "{#await p then v}\n  <!-- c -->\n{/await}");
+}

--- a/crates/rsvelte_formatter/tests/markup_patterns.rs
+++ b/crates/rsvelte_formatter/tests/markup_patterns.rs
@@ -211,3 +211,54 @@ fn each_long_header_does_not_break() {
         "each header must not break:\n{out}"
     );
 }
+
+#[test]
+fn each_index_separator_is_normalized() {
+    // The oracle re-prints the header's fixed parts (`' as'`, `', '`), so any
+    // spelling of the whitespace around them comes out canonical.
+    for src in [
+        "{#each rows as item , i}<p>{item}{i}</p>{/each}",
+        "{#each rows as item ,i}<p>{item}{i}</p>{/each}",
+        "{#each rows as item,    i}<p>{item}{i}</p>{/each}",
+        "{#each rows as item\t,\ti}<p>{item}{i}</p>{/each}",
+        "{#each rows as item , i }<p>{item}{i}</p>{/each}",
+    ] {
+        let out = fmt(src);
+        assert!(
+            out.contains("{#each rows as item, i}"),
+            "index separator not normalized for {src:?}:\n{out}"
+        );
+    }
+}
+
+#[test]
+fn each_index_separator_after_a_destructuring_pattern() {
+    let out = fmt("{#each rows as [a = 1, ...rest] , i}<p>{a}{rest.length}{i}</p>{/each}");
+    assert!(
+        out.contains("{#each rows as [a = 1, ...rest], i}"),
+        "index separator not normalized after an array pattern:\n{out}"
+    );
+    let out = fmt("{#each rows as {a, b} , i}<p>{a}{b}{i}</p>{/each}");
+    assert!(
+        out.contains("{#each rows as { a, b }, i}"),
+        "index separator not normalized after an object pattern:\n{out}"
+    );
+}
+
+#[test]
+fn each_index_separator_with_a_key_clause() {
+    let out = fmt("{#each rows as item , i (item.id)}<p>{item}{i}</p>{/each}");
+    assert!(
+        out.contains("{#each rows as item, i (item.id)}"),
+        "index separator not normalized before a key clause:\n{out}"
+    );
+}
+
+#[test]
+fn each_as_keyword_whitespace_is_normalized() {
+    let out = fmt("{#each rows  as  item , i}<p>{item}{i}</p>{/each}");
+    assert!(
+        out.contains("{#each rows as item, i}"),
+        "`as` spacing not normalized:\n{out}"
+    );
+}


### PR DESCRIPTION
Three formatter-parity divergences, all measured against the oxfmt(`svelte: true`) oracle before and after.

Closes #3084
Closes #3085
Closes #3086

## `{#await}` clause selection (#3084)

The oracle takes one decision from three booleans — does the pending / then / catch fragment hold anything that is not blank text — and prints only the clauses those keep. rsvelte had three special cases layered on one another, each with its own guard, so a shape none of them named survived unformatted.

Measuring a 16-row truth table of await shapes against the oracle: **6/16 matched before, 35/35 after** (the set was then widened to 35 rows). Nine of the ten failures were not the reported one; two were rsvelte emitting the *wrong header outright* rather than an extra clause:

| input | oracle | rsvelte before |
|---|---|---|
| `{#await p}{:then}{/await}` | `{#await p}{/await}` | unchanged ← the reported bug |
| `{#await p}{:then v}{/await}` | `{#await p}{/await}` | `{#await p then v}{/await}` |
| `{#await p}…pending…{:then v}{:catch e}…{/await}` | drops `{:then v}` | keeps it |
| `{#await p}{:then v}{:catch e}…{/await}` | `{#await p catch e}` | `{#await p then v}` |
| `{#await p catch e}{/await}` | `{#await p}{/await}` | unchanged |

`expression::await_block::plan` now makes the decision once; the arm applies it, and `indent.rs` — which had hand-duplicated two of the old guards so it would not indent inside an erased region — reads the same plan instead of a second copy of the conditions.

## `{#each}` header spacing (#3085)

The header is a source slice with sub-span edits spliced into it, and nothing owned the bytes between the iterable and the pattern or between the pattern and the index. The oracle re-prints both as fixed text (`' as'`, `', '`), so both are now normalized — `{#each rows as [a = 1, ...rest] , i}` → `{#each rows as [a = 1, ...rest], i}`, and `{#each rows  as  item}` → `{#each rows as item}`. The index name has no span in the AST, so it is located by matching the parsed name against the source. **4/20 → 25/25** on an each-header probe matrix (one row dropped: it was invalid Svelte).

## Adjacent expression tags (#3086)

rsvelte already charged the glued run *before* a tag (`prefix_lead`) but nothing after it, so a long run never broke — no tag exceeded the width on its own.

The interesting half is where the scan **stops**. The oracle's fit test walks the rest of the line and returns as soon as it meets a break opportunity, so the run stops at the first following tag that *can* break and charges only the text ahead of that break point. That is why `{z.raw.a}` stays flat when a computed member follows it (the walk stops at `{z[`) and breaks when only unbreakable tags follow — both behaviours confirmed against the oracle.

The second half: the trailing run decides only *that* a tag breaks. In the oracle it makes the group miss its fit, and the group's contents are then laid out against their real column, not against a budget the run ate. Narrowing by the run instead produced `{z\n  .raw\n  .a}` where the oracle prints `{z.raw\n  .a}`. The re-format width is therefore the tag's own remaining width, never narrower than the one column that forces the outermost break. **With no trailing run the arithmetic reduces to the previous behaviour exactly**, which is what confines this change to runs that were wrong before.

## Verification

- `crates/rsvelte_formatter` — all suites green, including three new files: `await_clauses.rs` (10 tests, the full truth table), `adjacent_expression_tags.rs` (7), and 4 new `markup_patterns.rs` tests for the each header.
- **`svelte_dev_corpus_parity` (the hard gate, no baseline tolerance) passes**: 556 `.svelte` files + 546 markdown blocks + 644 whole markdown files, byte-exact.
- `rsvelte_fmt` suites green (131 tests).
- All 697 `compatibility/pattern-corpus` components re-checked against the oracle by hand: the only divergences are ids already listed in `fmt-known-failures.json` / rejected by the oracle itself. No new ones.
- The three shapes the issues say the corpus "avoids for now" are restored in `pattern-corpus`, and each of those files formats byte-identically to the oracle and idempotently.

No `compatibility/*known-failures*` file is touched, so the PR #3176 re-baseline ordering does not apply here.
