### PR TITLE
fix(preprocess): catch a throwing preprocessor, and discard an attribute-only result

### DIFF
--- a/.changeset/preprocess-failure-and-attributes.md
+++ b/.changeset/preprocess-failure-and-attributes.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/compiler": patch
+---
+
+Stop a failing preprocessor from killing the Node process, and discard an attribute-only result the way upstream does. A JS callback that threw was routed through `napi_fatal_exception`, so `await preprocess(...)` never rejected and the caller's `try`/`catch` never ran — in a Vite dev server one SCSS syntax error took the server down instead of drawing an error overlay. The callback is now called through `call_async_catch`, and the rejection carries the user's own message rather than `GenericFailure, oneshot canceled`. Separately, a `script` / `style` result whose code is unchanged and which returns no map is discarded whole, `attributes` included: applying them re-emitted the tag with a replaced attribute list, so `<script module>` lost its `module` and compiled as an instance script.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1096,6 +1096,12 @@ jobs:
       - name: Run NAPI cssHash gate
         run: pnpm run test:napi-csshash
 
+      # Separate process for the same reason, and it must be its own step: the
+      # failure this gate exists for kills the process, so a shared one would
+      # take the option gate's result with it.
+      - name: Run NAPI preprocessor parity gate
+        run: pnpm run test:napi-preprocess-parity
+
   vps-sourcemaps:
     name: VPS postprocessing source-map parity
     runs-on: ubuntu-latest

--- a/crates/rsvelte_core/src/compiler/preprocess/mod.rs
+++ b/crates/rsvelte_core/src/compiler/preprocess/mod.rs
@@ -352,15 +352,12 @@ async fn process_tag(
                     deps.extend_from_slice(&processed.dependencies);
                 }
 
-                // Check if anything changed. An attribute-only change (same code,
-                // no map, but returned `attributes`) must still be treated as a
-                // real diff so the tag is re-emitted with the new attributes —
-                // otherwise the original tag with stale attributes is returned
-                // (H-139).
-                if processed.map.is_none()
-                    && processed.code == content
-                    && processed.attributes.is_none()
-                {
+                // Upstream discards the whole result here, `attributes`
+                // included, so an attribute-only change never takes effect.
+                // Re-emitting the tag for it replaces the attribute list
+                // wholesale and drops `module` / `lang`, which changes what the
+                // component compiles to.
+                if processed.map.is_none() && processed.code == content {
                     return Ok(MappedCode::from_source(&slice_source(
                         tag_with_content.to_string(),
                         tag_offset,

--- a/crates/rsvelte_core/src/compiler/preprocess/types.rs
+++ b/crates/rsvelte_core/src/compiler/preprocess/types.rs
@@ -228,6 +228,10 @@ pub enum PreprocessError {
     Json(#[from] serde_json::Error),
     #[error("Preprocessor error: {0}")]
     Other(String),
+    /// A JS preprocessor callback threw or rejected. Upstream propagates the
+    /// user's error unchanged, so this variant must not decorate it.
+    #[error("{0}")]
+    JsCallback(String),
 }
 
 impl MappedCode {

--- a/crates/rsvelte_core/tests/preprocess_attributes.rs
+++ b/crates/rsvelte_core/tests/preprocess_attributes.rs
@@ -1,11 +1,24 @@
-//! Issue #460: a preprocessor that returns changed `attributes` must have them
-//! applied even when the code is unchanged (H-139), and `Some({})` must clear
-//! the tag's attributes rather than fall back to the originals (H-140).
+//! What a `script` / `style` preprocessor's returned `attributes` do, per cell
+//! of (code changed?, map returned?, attributes shape).
+//!
+//! Upstream applies them only on the path *after* its no-change guard
+//! (`if (!processed.map && processed.code === content) return no_change()`), so
+//! an attribute-only result is discarded whole. rsvelte used to except
+//! `attributes.is_some()` from that guard (#460), which re-emitted the tag and
+//! replaced its attribute list wholesale — dropping `module` and `lang`, so a
+//! module script silently became an instance script and the component compiled
+//! to different code (#3293).
+//!
+//! The map cell is what separates the two rules: attributes returned *with* a
+//! map are applied even though the code is unchanged. A grid without it is
+//! satisfied by "attributes never apply", which is not the rule either.
+//!
+//! Every expectation here was read off the official compiler, not derived.
 
 use rsvelte_core::compiler::preprocess::preprocess;
 use rsvelte_core::compiler::preprocess::types::{
     AttributeValue, PreprocessAttributeMap as FxHashMap, PreprocessError, PreprocessorFn,
-    PreprocessorGroup, PreprocessorOptions, PreprocessorResult, Processed,
+    PreprocessorGroup, PreprocessorOptions, PreprocessorResult, Processed, SourceMapInput,
 };
 use std::future::Future;
 
@@ -31,45 +44,104 @@ fn run(source: &str, group: PreprocessorGroup) -> String {
 
 const SRC: &str = "<script lang=\"ts\">let x = 1;</script>";
 
-/// H-139: changed attributes are applied even though the code is unchanged.
-#[test]
-fn attribute_only_change_is_applied() {
-    let group = PreprocessorGroup {
-        script: Some(Box::new(|opts: PreprocessorOptions| {
-            ok(async move {
-                let mut attrs = FxHashMap::default();
-                attrs.insert("foo".to_string(), AttributeValue::String("bar".to_string()));
-                Ok(Some(Processed {
-                    code: opts.content,
-                    attributes: Some(attrs),
-                    ..Default::default()
-                }))
-            })
-        }) as PreprocessorFn),
-        ..Default::default()
-    };
-    let out = run(SRC, group);
-    assert!(
-        out.contains("foo=\"bar\""),
-        "attribute change discarded: {out}"
-    );
+fn attrs(pairs: &[(&str, &str)]) -> FxHashMap<String, AttributeValue> {
+    let mut map = FxHashMap::default();
+    for (key, value) in pairs {
+        map.insert(
+            (*key).to_string(),
+            AttributeValue::String((*value).to_string()),
+        );
+    }
+    map
 }
 
-/// H-140: `Some({})` clears the tag's attributes.
-#[test]
-fn empty_attributes_map_clears() {
-    let group = PreprocessorGroup {
-        script: Some(Box::new(|opts: PreprocessorOptions| {
+fn script_returning(
+    change_code: bool,
+    map: bool,
+    attributes: Option<FxHashMap<String, AttributeValue>>,
+) -> PreprocessorGroup {
+    PreprocessorGroup {
+        script: Some(Box::new(move |opts: PreprocessorOptions| {
+            let attributes = attributes.clone();
             ok(async move {
                 Ok(Some(Processed {
-                    code: opts.content,
-                    attributes: Some(FxHashMap::default()),
+                    code: if change_code {
+                        format!("{} ", opts.content)
+                    } else {
+                        opts.content
+                    },
+                    map: map.then(|| {
+                        SourceMapInput::Json(
+                            r#"{"version":3,"sources":["T.svelte"],"names":[],"mappings":""}"#
+                                .to_string(),
+                        )
+                    }),
+                    attributes,
                     ..Default::default()
                 }))
             })
         }) as PreprocessorFn),
         ..Default::default()
-    };
-    let out = run(SRC, group);
-    assert!(!out.contains("lang"), "attributes not cleared: {out}");
+    }
+}
+
+#[test]
+fn unchanged_code_and_no_map_discards_the_attributes() {
+    let out = run(
+        SRC,
+        script_returning(false, false, Some(attrs(&[("foo", "bar")]))),
+    );
+    assert_eq!(out, "<script lang=\"ts\">let x = 1;</script>", "{out}");
+}
+
+#[test]
+fn unchanged_code_and_no_map_discards_an_empty_attribute_map() {
+    let out = run(
+        SRC,
+        script_returning(false, false, Some(FxHashMap::default())),
+    );
+    assert_eq!(out, "<script lang=\"ts\">let x = 1;</script>", "{out}");
+}
+
+#[test]
+fn changed_code_applies_the_attributes() {
+    let out = run(
+        SRC,
+        script_returning(true, false, Some(attrs(&[("foo", "bar")]))),
+    );
+    assert_eq!(out, "<script foo=\"bar\">let x = 1; </script>", "{out}");
+}
+
+/// `Some({})` clears the tag's attributes rather than falling back to the
+/// originals — the reachable half of #460's H-140.
+#[test]
+fn changed_code_with_an_empty_attribute_map_clears_them() {
+    let out = run(
+        SRC,
+        script_returning(true, false, Some(FxHashMap::default())),
+    );
+    assert_eq!(out, "<script>let x = 1; </script>", "{out}");
+}
+
+/// The discriminating cell: a returned map defeats the no-change guard, so the
+/// attributes apply even though the code is untouched.
+#[test]
+fn a_returned_map_applies_the_attributes_without_a_code_change() {
+    let out = run(
+        SRC,
+        script_returning(false, true, Some(attrs(&[("foo", "bar")]))),
+    );
+    assert_eq!(out, "<script foo=\"bar\">let x = 1;</script>", "{out}");
+}
+
+/// `module` survives an attribute-only result — the shape that made a module
+/// script compile as an instance script.
+#[test]
+fn a_module_script_keeps_its_module_attribute() {
+    let source = "<script module>\nexport const q = 1;\n</script>\n<p>x</p>\n";
+    let out = run(
+        source,
+        script_returning(false, false, Some(attrs(&[("data-x", "y")]))),
+    );
+    assert_eq!(out, source, "{out}");
 }

--- a/crates/rsvelte_napi/src/lib.rs
+++ b/crates/rsvelte_napi/src/lib.rs
@@ -1626,7 +1626,7 @@ mod preprocess_bridge {
                         "content": opts.content,
                         "filename": opts.filename,
                     });
-                    await_tsfn(&tsfn, arg).await
+                    await_tsfn(&tsfn, arg, Callsite::Markup).await
                 })
             },
         )
@@ -1642,12 +1642,35 @@ mod preprocess_bridge {
                     "markup": opts.markup,
                     "filename": opts.filename,
                 });
-                await_tsfn(&tsfn, arg).await
+                await_tsfn(&tsfn, arg, Callsite::Tag).await
             })
         })
     }
 
-    async fn await_tsfn(tsfn: &Tsfn, arg: Value) -> Result<Option<Processed>, PreprocessError> {
+    /// Upstream reads `processed.code` differently either side of the markup
+    /// boundary, and a result without one therefore diverges: markup treats it
+    /// as no change, a `<script>` / `<style>` result throws.
+    #[derive(Clone, Copy)]
+    enum Callsite {
+        Markup,
+        Tag,
+    }
+
+    /// A JS error carries its own message; `Display` on `napi::Error` prefixes
+    /// the status, which would replace the user's text with `GenericFailure, …`.
+    fn js_reason(error: &napi::Error) -> String {
+        if error.reason.is_empty() {
+            error.status.to_string()
+        } else {
+            error.reason.clone()
+        }
+    }
+
+    async fn await_tsfn(
+        tsfn: &Tsfn,
+        arg: Value,
+        callsite: Callsite,
+    ) -> Result<Option<Processed>, PreprocessError> {
         // The upstream Svelte preprocessor contract allows the callback to
         // return `Processed | Promise<Processed> | undefined | null`,
         // sync or async. `MaybePromise<Option<Value>>` probes `napi_is_promise`
@@ -1656,35 +1679,81 @@ mod preprocess_bridge {
         // `napi_fatal_error`, surfacing as `threadsafe_function.rs:749 Failed
         // to convert return value … Failed to call then method`). The outer
         // `Option` collapses `undefined`/`null` to `None` on both paths.
-        match tsfn.call_async(arg).await {
-            Ok(MaybePromise::Promise(promise)) => match promise.await {
-                Ok(Some(v)) => Ok(Some(v.into_processed())),
-                Ok(None) => Ok(None),
-                Err(e) => Err(PreprocessError::Other(format!("{e}"))),
+        //
+        // `call_async` routes a thrown JS error through `napi_fatal_exception`,
+        // which kills the host process: the caller's `try`/`catch` never runs and
+        // a dev server dies on any preprocessor failure. `call_async_catch`
+        // returns it as `Err` instead.
+        let resolved = match tsfn.call_async_catch(arg).await {
+            Ok(MaybePromise::Promise(promise)) => promise.await,
+            Ok(MaybePromise::Value(value)) => Ok(value),
+            Err(e) => return Err(PreprocessError::JsCallback(js_reason(&e))),
+        };
+        match resolved {
+            Ok(Some(v)) => match v.into_processed() {
+                Ok(processed) => Ok(processed),
+                // These read as V8 messages because they are: upstream reaches
+                // each one by operating on the value it was handed, and matching
+                // it is what makes rsvelte substitutable here.
+                // Upstream's markup path only reads `code` when it rebuilds the
+                // document, so a result without one changes nothing — and on the
+                // tag path the message names which of the two absent values it
+                // was, so they cannot share an arm.
+                Err(slot @ (CodeSlot::Missing | CodeSlot::Null)) => match callsite {
+                    Callsite::Markup => Ok(None),
+                    Callsite::Tag => Err(PreprocessError::JsCallback(format!(
+                        "Cannot read properties of {} (reading 'replace')",
+                        if matches!(slot, CodeSlot::Null) {
+                            "null"
+                        } else {
+                            "undefined"
+                        }
+                    ))),
+                },
+                Err(CodeSlot::NotAString) => Err(PreprocessError::JsCallback(
+                    match callsite {
+                        Callsite::Markup => "source.split is not a function",
+                        Callsite::Tag => "processed.code.replace is not a function",
+                    }
+                    .into(),
+                )),
+                Err(CodeSlot::Text(_)) => unreachable!("Text is the Ok arm"),
             },
-            Ok(MaybePromise::Value(Some(v))) => Ok(Some(v.into_processed())),
-            Ok(MaybePromise::Value(None)) => Ok(None),
-            Err(e) => Err(PreprocessError::Other(format!("{e}"))),
+            Ok(None) => Ok(None),
+            Err(e) => Err(PreprocessError::JsCallback(js_reason(&e))),
         }
     }
 
     /// The JS contract permits source-map objects such as Sass's `SourceMapGenerator`,
     /// whose `toString` is a function. Decode only the fields we consume instead of
     /// asking napi-rs to JSON-serialize the entire user-controlled return object.
+    /// What the preprocessor put in `code`. Upstream reaches its error through
+    /// whichever operation it tries on the value, so the three cases are three
+    /// different messages rather than one "invalid result".
+    pub enum CodeSlot {
+        Missing,
+        Null,
+        NotAString,
+        Text(String),
+    }
+
     pub struct JsProcessed {
-        code: String,
+        code: CodeSlot,
         map: Option<SourceMapInput>,
         dependencies: Vec<String>,
         attributes: Option<FxHashMap<String, RsAttrValue>>,
     }
 
     impl JsProcessed {
-        fn into_processed(self) -> Processed {
-            Processed {
-                code: self.code,
-                map: self.map,
-                dependencies: self.dependencies,
-                attributes: self.attributes,
+        fn into_processed(self) -> Result<Option<Processed>, CodeSlot> {
+            match self.code {
+                CodeSlot::Text(code) => Ok(Some(Processed {
+                    code,
+                    map: self.map,
+                    dependencies: self.dependencies,
+                    attributes: self.attributes,
+                })),
+                other => Err(other),
             }
         }
     }
@@ -1695,9 +1764,18 @@ mod preprocess_bridge {
             napi_val: napi::sys::napi_value,
         ) -> napi::Result<Self> {
             let obj = Object::from_raw(env, napi_val);
-            let code = obj.get::<String>("code")?.ok_or_else(|| {
-                napi::Error::from_reason("preprocessor result is missing string `code`")
-            })?;
+            let code = match obj
+                .get::<napi::bindgen_prelude::Unknown>("code")?
+                .map(|value| value.get_type())
+                .transpose()?
+            {
+                None | Some(napi::ValueType::Undefined) => CodeSlot::Missing,
+                Some(napi::ValueType::Null) => CodeSlot::Null,
+                Some(napi::ValueType::String) => obj
+                    .get::<String>("code")?
+                    .map_or(CodeSlot::Missing, CodeSlot::Text),
+                Some(_) => CodeSlot::NotAString,
+            };
             let map = obj
                 .get::<JsSourceMap>("map")?
                 .and_then(JsSourceMap::into_input);

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
 		"test:vps": "node scripts/dev/test-vps-shim.mjs && node scripts/dev/test-vps-vite-fixture.mjs",
 		"test:napi-options": "node scripts/dev/test-napi-compile-options.mjs",
 		"test:napi-csshash": "node scripts/dev/test-napi-css-hash.mjs",
+		"test:napi-preprocess-parity": "node scripts/dev/test-napi-preprocess-parity.mjs",
 		"test:wasm-compile": "node scripts/dev/test-wasm-compile-options.mjs",
 		"test:type-aware-lint": "node scripts/dev/test-type-aware-lint.mjs",
 		"build:oxlint-plugin": "pnpm --filter @rsvelte/oxlint-plugin run build",

--- a/scripts/dev/test-napi-preprocess-parity.mjs
+++ b/scripts/dev/test-napi-preprocess-parity.mjs
@@ -1,0 +1,144 @@
+#!/usr/bin/env node
+// Differential gate for the `preprocess()` N-API boundary: what happens when a
+// preprocessor FAILS (#3292), and what its returned `attributes` do (#3293).
+// Two properties, and only the first one is about parity:
+//
+//  1. SURVIVAL. A JS callback that throws must reject the returned promise, not
+//     terminate the host process. napi-rs routes a thrown callback through
+//     `napi_fatal_exception` unless the call site opts out, which took the whole
+//     Node process down — in a Vite dev server, one SCSS syntax error killed the
+//     server instead of drawing an error overlay. A test that only compared
+//     messages could not see this: the process dies before it compares anything,
+//     so this file asserts it reaches its own last line.
+//
+//  2. PARITY. Every cell is run against the official compiler in the same
+//     process and the two outcomes must agree, message included. The messages
+//     are V8's, because upstream reaches each one by operating on the value the
+//     preprocessor handed back; hard-coding expectations here would pin rsvelte
+//     to whatever this file's author believed rather than to the oracle.
+//
+// The error CONSTRUCTOR is deliberately not compared: upstream raises a
+// `TypeError` for the three value-shape cells and the N-API boundary can only
+// carry an `Error`. That is a real, unfixed divergence — see the PR for #3292.
+//
+// The attribute grid crosses (code changed?, map returned?, attributes shape).
+// The map row is what makes it discriminating: attributes returned *with* a map
+// apply even though the code is unchanged, so a grid without it is satisfied by
+// "attributes never apply", which is not the rule either.
+//
+// Prereq: `pnpm run build:vps-native`.
+
+import { createRequire } from 'node:module';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { preprocess as officialPreprocess } from '../../submodules/svelte/packages/svelte/src/compiler/index.js';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(here, '../..');
+const triple = `${process.platform === 'win32' ? 'win32' : process.platform}-${
+  process.arch === 'x64' ? 'x64' : process.arch
+}${process.platform === 'linux' ? '-gnu' : process.platform === 'win32' ? '-msvc' : ''}`;
+const addonPath = resolve(
+  repoRoot,
+  `apps/npm/vite-plugin-svelte-native-${triple}/rsvelte.node`,
+);
+const require_ = createRequire(import.meta.url);
+let addon;
+try {
+  addon = require_(addonPath);
+} catch (error) {
+  console.error(`Could not load ${addonPath}\nRun: pnpm run build:vps-native\n${error.message}`);
+  process.exit(1);
+}
+
+const SRC = '<script>let a = 1;</script>\n<p>hi</p>\n<style>p{color:red}</style>\n';
+
+// Every failure shape the issue enumerated, crossed with the three hooks. The
+// `markup` / tag split is load-bearing: upstream reads `code` differently either
+// side of it, so the same returned value is a no-change on one and a throw on
+// the other.
+const RESULTS = {
+  'empty object': () => ({}),
+  'code undefined': () => ({ code: undefined }),
+  'code null': () => ({ code: null }),
+  'code number': () => ({ code: 42 }),
+  'code object': () => ({ code: { toString: () => 'x' } }),
+  'sync throw': () => {
+    throw new Error('boom');
+  },
+  'async reject': () => Promise.reject(new Error('boom-async')),
+  'async throw': async () => {
+    throw new Error('boom-async-throw');
+  },
+  returns_null: () => null,
+  returns_undefined: () => undefined,
+};
+
+const cases = [];
+for (const hook of ['markup', 'script', 'style']) {
+  for (const [label, fn] of Object.entries(RESULTS)) {
+    cases.push([`${hook}: ${label}`, { [hook]: fn }]);
+  }
+}
+// A failure in the SECOND preprocessor of a chain runs through a different path
+// than the first: the first one's result is already installed when it throws.
+cases.push([
+  'chain: second markup throws',
+  [{ markup: (o) => ({ code: o.content }) }, { markup: () => { throw new Error('mid'); } }],
+]);
+cases.push([
+  'chain: second script throws',
+  [{ script: (o) => ({ code: o.content }) }, { script: () => { throw new Error('mid-script'); } }],
+]);
+
+// (label, source, preprocessor) — every cell's expectation comes from running the
+// official compiler below, never from a literal written here.
+const ATTR_SRC = '<script lang="ts">let x = 1;</script>';
+const MODULE_SRC = '<script module>\nexport const q = 1;\n</script>\n<p>x</p>\n';
+const MAP = { version: 3, sources: ['T.svelte'], names: [], mappings: '' };
+
+for (const [label, src, script] of [
+  ['attrs: same code', ATTR_SRC, ({ content }) => ({ code: content, attributes: { foo: 'bar' } })],
+  ['attrs: same code, empty', ATTR_SRC, ({ content }) => ({ code: content, attributes: {} })],
+  ['attrs: changed code', ATTR_SRC, ({ content }) => ({ code: `${content} `, attributes: { foo: 'bar' } })],
+  ['attrs: changed code, empty', ATTR_SRC, ({ content }) => ({ code: `${content} `, attributes: {} })],
+  ['attrs: same code + map', ATTR_SRC, ({ content }) => ({ code: content, map: MAP, attributes: { foo: 'bar' } })],
+  ['attrs: module kept', MODULE_SRC, ({ content }) => ({ code: content, attributes: { 'data-x': 'y' } })],
+]) {
+  cases.push([label, { script }, src]);
+}
+
+async function outcome(run) {
+  try {
+    const result = await run();
+    return { ok: true, code: result.code };
+  } catch (error) {
+    return { ok: false, message: error.message };
+  }
+}
+
+const describe = (o) => (o.ok ? `resolved: ${JSON.stringify(o.code)}` : `threw: ${o.message}`);
+
+let failures = 0;
+for (const [name, group, source = SRC] of cases) {
+  const expected = await outcome(() => officialPreprocess(source, group, { filename: 'P.svelte' }));
+  const actual = await outcome(() => addon.preprocess(source, group, { filename: 'P.svelte' }));
+  if (describe(expected) === describe(actual)) {
+    console.log(`  ok   ${name.padEnd(28)} ${describe(actual)}`);
+  } else {
+    failures++;
+    console.error(
+      `  FAIL ${name.padEnd(28)}\n       official: ${describe(expected)}\n       rsvelte : ${describe(actual)}`,
+    );
+  }
+}
+
+// Reaching this line at all is the survival half: an uncaught exception from the
+// N-API boundary exits before it.
+console.log(`\nreached the end of the script (${cases.length} cells)`);
+if (failures > 0) {
+  console.error(`${failures} cell(s) diverged`);
+  process.exit(1);
+}
+console.log('all cells match');


### PR DESCRIPTION
Closes #3292
Closes #3293

Two defects at the same boundary. The first is the severe one: **a preprocessor that throws takes the Node process down.**

## #3292 — the throw never becomes a rejection

`await_tsfn` called the user's callback through `napi::ThreadsafeFunction::call_async`, whose own doc says it routes a thrown JS callback through `napi_fatal_exception`. So the error surfaced as an `uncaughtException` outside any JS frame: `await preprocess(...)` never rejected, the caller's `try`/`catch` never ran, and the process exited 1. In a Vite dev server that means one SCSS syntax error kills the server instead of drawing an error overlay — and `@rsvelte/vite-plugin-svelte` calls this API directly.

`call_async_catch` returns the same throw as `Err(napi::Error)`. Two further changes were needed for the message to survive:

- `Display` on `napi::Error` prefixes the status, which is where `GenericFailure, …` came from. The bridge now reads `error.reason`, so the user's `boom` arrives as `boom`.
- `PreprocessError::Other` decorates its payload with `Preprocessor error: `. A new `JsCallback` variant carries a JS error unchanged, because upstream propagates it unchanged.

## #3293 — an attribute-only result is discarded upstream

Upstream's `process_single_tag` short-circuits on `if (!processed.map && processed.code === content) return no_change()`, and `attributes` are only ever applied *after* that guard. rsvelte excepted `attributes.is_some()` from it (#460's H-139), so an attribute-only result re-emitted the tag — and re-emitting replaces the attribute list wholesale, so `<script module>` became `<script data-x="y">`. That is not a spelling difference: the component compiles as an instance script instead of a module.

Removing the exception reverses two tests added for #460. `preprocess_attributes.rs` is rewritten as a grid over (code changed?, map returned?, attributes shape), every cell read off the official compiler. **The map cell is what makes the grid discriminating** — attributes returned *with* a map do apply despite unchanged code, so a grid without it is equally satisfied by "attributes never apply", which is not the rule either. H-140 (`Some({})` clears rather than falling back) survives on the reachable path and is still pinned.

## The gate

`scripts/dev/test-napi-preprocess-parity.mjs` (38 cells, wired into the existing NAPI CI job) runs every cell against the **official compiler in the same process** and compares the outcome, message included. Expectations are never written as literals here — the oracle produces them at run time.

It asserts two different things, and only one is parity:

- **Survival.** The script's last line is `reached the end of the script`. A message-only comparison could not see this defect: the process dies before it compares anything.
- **Parity.** Outcome plus message, per cell.

It is not green by construction. Reverting the single `call_async_catch` → `call_async` kills the run at cell 6 with `Error: boom` and no verdict at all — that is the negative control for the survival half. And while writing it, the oracle caught two cells I had hand-written wrongly: `{ code: null }` on a tag reports `Cannot read properties of **null**`, not `undefined`, which is why `CodeSlot` distinguishes them.

## Deliberately not fixed

The error **constructor**. Upstream raises a `TypeError` for the three value-shape cells; the N-API boundary can only carry an `Error`. The gate compares outcome and message and skips the constructor, with that stated in its header — a real residual divergence rather than a silent one.

The three value-shape messages themselves *are* matched, and they read as V8 messages because they are: upstream reaches each one by operating on the value the preprocessor handed back. Matching them is what makes rsvelte substitutable here; the alternative was an rsvelte-specific string that no caller could pattern-match the same way.

## Verification

- `pnpm run test:napi-preprocess-parity` — 38/38 cells match, process survives.
- `cargo test -p rsvelte_core --test preprocess --test preprocess_attributes --test preprocess_sourcemap --test preprocess_vlq_sourcemap` — 1 / 6 / 3 / 4 passed.
- `cargo clippy -p rsvelte_core -p rsvelte_napi --all-targets -- -D warnings` clean; `cargo fmt --check` clean.

#3294 (`cssHash`) is the third defect the issue set names in this area and is **not** in this PR — it is a different API surface (`compile` options) rather than the preprocessor bridge.
