### PR TITLE
fix(analyze): a valueless attribute is not "true", and the bidi check must reach attributes and template expressions

### DIFF
--- a/.changeset/a11y-valueless-value-and-bidi-slots.md
+++ b/.changeset/a11y-valueless-value-and-bidi-slots.md
@@ -1,0 +1,9 @@
+---
+"@rsvelte/compiler": patch
+---
+
+Fix two warning-parity divergences that both come from a slot the check never reached.
+
+`get_static_value` in the a11y checker collapsed a valueless attribute into the string `"true"`, where upstream keeps `null | true | string` and folds `true` back to `null` in `get_static_text_value`. `<div role>` was therefore looked up as an unknown role, `<div tabindex>` reached neither tabindex rule, and every `=== 'true'` comparison (`aria-hidden`, `aria-disabled`, a `<track kind>`) answered the wrong way. The numeric checks also parsed with `i32::from_str`, so `tabindex=""`, `"1.5"` and `" 2 "` fell through where upstream's `Number()` does not.
+
+`bidirectional_control_characters` is raised upstream from a `Text`, a `Literal` and a `TemplateElement` visitor, all of which zimmerframe reaches anywhere in the AST. rsvelte ran the `Text` scan on fragment text only and never reached the other two from a template expression, so an attribute or directive value and any string or template literal inside `{...}` were silent on every host.

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/attribute.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/attribute.rs
@@ -179,13 +179,22 @@ pub fn visit_attribute_value_expressions(
         }
         AttributeValue::Sequence(parts) => {
             for part in parts {
-                if let AttributeValuePart::ExpressionTag(expr_tag) = part {
-                    let node = expr_tag.expression.as_node();
-                    super::shared::utils::walk_js_expression_node(
-                        &node,
-                        context,
-                        &mut expr_tag.metadata.expression,
-                    )?;
+                match part {
+                    AttributeValuePart::ExpressionTag(expr_tag) => {
+                        let node = expr_tag.expression.as_node();
+                        super::shared::utils::walk_js_expression_node(
+                            &node,
+                            context,
+                            &mut expr_tag.metadata.expression,
+                        )?;
+                    }
+                    // A value chunk is a `Text` node upstream, so its `Text`
+                    // visitor runs on it too.
+                    AttributeValuePart::Text(text) => {
+                        super::text::check_bidirectional_control_characters(
+                            &text.data, text.start, context,
+                        );
+                    }
                 }
             }
         }

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/shared/a11y/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/shared/a11y/mod.rs
@@ -175,7 +175,7 @@ pub fn check_element(node: &A11yElement, ancestors: &A11yAncestors) -> Vec<w::An
                 // type-specific `a11y_incorrect_aria_attribute_type` warning
                 // because the attribute presence alone is not a valid value.
                 // (issue #454, H-078)
-                let value = get_static_value(attribute);
+                let value = get_static_text_value(attribute);
                 let is_bare = matches!(
                     attribute,
                     AttributeNode::Attribute(a) if matches!(a.value, AttributeValue::True(_))
@@ -210,7 +210,8 @@ pub fn check_element(node: &A11yElement, ancestors: &A11yAncestors) -> Vec<w::An
                     warnings.push(w::a11y_misplaced_role(node.name).at(attr_start, attr_end));
                 }
 
-                if let Some(value) = get_static_value(attribute) {
+                // A valueless `role` is the boolean `true`, which upstream skips.
+                if let Some(StaticValue::Text(value)) = get_static_value(attribute) {
                     for current_role in value.split(|c: char| c.is_whitespace()) {
                         if current_role.is_empty() {
                             continue;
@@ -356,8 +357,7 @@ pub fn check_element(node: &A11yElement, ancestors: &A11yAncestors) -> Vec<w::An
             // tabindex-no-positive
             if name == "tabindex"
                 && let Some(value) = get_static_value(attribute)
-                && let Ok(num) = value.parse::<i32>()
-                && num > 0
+                && value.to_number() > 0.0
             {
                 warnings.push(w::a11y_positive_tabindex().at(attr_start, attr_end));
             }
@@ -369,7 +369,7 @@ pub fn check_element(node: &A11yElement, ancestors: &A11yAncestors) -> Vec<w::An
     let has_role_attr = attribute_map.contains_key("role");
     let role_static_value = attribute_map
         .get("role")
-        .and_then(|attr| get_static_value(attr));
+        .and_then(|attr| get_static_text_value(attr));
 
     // click-events-have-key-events
     if handlers.contains("click") {
@@ -438,11 +438,9 @@ pub fn check_element(node: &A11yElement, ancestors: &A11yAncestors) -> Vec<w::An
         && !role_static_value.is_some_and(is_interactive_roles)
         && let Some(tab_index) = attribute_map.get("tabindex")
     {
-        let tab_index_value = get_static_value(tab_index);
-        let should_warn = tab_index_value.is_none()  // Dynamic value (like {0})
-            || tab_index_value
-                .and_then(|v| v.parse::<i32>().ok())
-                .is_some_and(|num| num >= 0);
+        let tab_index_value = get_static_text_value(tab_index);
+        let should_warn = tab_index_value.is_none()  // Dynamic value (like {0}) or valueless
+            || tab_index_value.is_some_and(|v| js_str_to_number(v) >= 0.0);
         if should_warn {
             warnings.push(w::a11y_no_noninteractive_tabindex());
         }
@@ -514,11 +512,10 @@ pub fn check_element(node: &A11yElement, ancestors: &A11yAncestors) -> Vec<w::An
 
     match node.name {
         "a" | "button" => {
-            let is_hidden = (attribute_map
-                .get("aria-hidden")
-                .and_then(|a| get_static_value(a))
-                == Some("true"))
-                || attribute_map.contains_key("inert");
+            let is_hidden = static_text_is(attribute_map.get("aria-hidden"), "true")
+                || attribute_map
+                    .get("inert")
+                    .is_some_and(|a| get_static_value(a).is_some());
 
             if !has_spread && !is_hidden && !is_labelled && !has_content(node.fragment) {
                 warnings.push(w::a11y_consider_explicit_label());
@@ -530,7 +527,7 @@ pub fn check_element(node: &A11yElement, ancestors: &A11yAncestors) -> Vec<w::An
                     .or_else(|| attribute_map.get("xlink:href"));
                 if let Some(href_attr) = href {
                     if let AttributeNode::Attribute(a) = href_attr
-                        && let Some(href_value) = get_static_value(href_attr)
+                        && let Some(href_value) = get_static_text_value(href_attr)
                         && (href_value.is_empty()
                             || href_value == "#"
                             || REGEX_JS_PREFIX.is_match(href_value))
@@ -544,12 +541,9 @@ pub fn check_element(node: &A11yElement, ancestors: &A11yAncestors) -> Vec<w::An
                     let id_attribute = attribute_map.get("id").and_then(|a| get_static_value(a));
                     let name_attribute =
                         attribute_map.get("name").and_then(|a| get_static_value(a));
-                    let aria_disabled = attribute_map
-                        .get("aria-disabled")
-                        .and_then(|a| get_static_value(a));
-                    if id_attribute.is_none_or(|v| v.is_empty())
-                        && name_attribute.is_none_or(|v| v.is_empty())
-                        && aria_disabled != Some("true")
+                    if !id_attribute.is_some_and(StaticValue::is_truthy)
+                        && !name_attribute.is_some_and(StaticValue::is_truthy)
+                        && !static_text_is(attribute_map.get("aria-disabled"), "true")
                     {
                         warn_missing_attribute(&mut warnings, node.name, &["href"], None);
                     }
@@ -559,9 +553,8 @@ pub fn check_element(node: &A11yElement, ancestors: &A11yAncestors) -> Vec<w::An
         "input" => {
             let type_value = attribute_map
                 .get("type")
-                .and_then(|t| get_static_value(t))
-                .unwrap_or("text");
-            if type_value == "image" && !has_spread {
+                .and_then(|t| get_static_text_value(t));
+            if type_value == Some("image") && !has_spread {
                 let required_attributes = ["alt", "aria-label", "aria-labelledby"];
                 let has_attribute = required_attributes
                     .iter()
@@ -582,19 +575,27 @@ pub fn check_element(node: &A11yElement, ancestors: &A11yAncestors) -> Vec<w::An
             {
                 let autocomplete_value = get_static_value(autocomplete_attr);
                 if !is_valid_autocomplete(autocomplete_value) {
-                    let display_value = autocomplete_value.unwrap_or("true");
+                    let display_value = match autocomplete_value {
+                        Some(StaticValue::Text(v)) => v,
+                        _ => "true",
+                    };
                     let mark = warnings.len();
-                    warnings.push(w::a11y_autocomplete_valid(display_value, type_value));
+                    warnings.push(w::a11y_autocomplete_valid(
+                        display_value,
+                        type_value.unwrap_or("..."),
+                    ));
                     stamp_attribute(&mut warnings[mark..], a);
                 }
             }
         }
         "img" => {
             if let Some(alt_attribute) = attribute_map.get("alt")
-                && let Some(alt_value) = get_static_value(alt_attribute)
+                && let Some(alt_value) = get_static_text_value(alt_attribute)
             {
-                let aria_hidden = attribute_map.get("aria-hidden");
-                if aria_hidden.is_none()
+                let aria_hidden = attribute_map
+                    .get("aria-hidden")
+                    .and_then(|a| get_static_value(a));
+                if !aria_hidden.is_some_and(StaticValue::is_truthy)
                     && !has_spread
                     && REGEX_REDUNDANT_IMG_ALT.is_match(alt_value)
                 {
@@ -610,10 +611,7 @@ pub fn check_element(node: &A11yElement, ancestors: &A11yAncestors) -> Vec<w::An
             warnings.push(w::a11y_label_has_associated_control());
         }
         "video" => {
-            let aria_hidden_exist = attribute_map
-                .get("aria-hidden")
-                .and_then(|a| get_static_value(a))
-                == Some("true");
+            let aria_hidden_exist = static_text_is(attribute_map.get("aria-hidden"), "true");
 
             if attribute_map.contains_key("muted") || aria_hidden_exist || has_spread {
                 // Skip video caption check if muted, aria-hidden, or has spread
@@ -638,7 +636,7 @@ pub fn check_element(node: &A11yElement, ancestors: &A11yAncestors) -> Vec<w::An
                     .any(|track| {
                         track.attributes.iter().any(|a| {
                             matches!(a, AttributeNode::SpreadAttribute(_))
-                                || matches!(a, AttributeNode::Attribute(attr) if attr.name == "kind" && get_static_value(a) == Some("captions"))
+                                || matches!(a, AttributeNode::Attribute(attr) if attr.name == "kind" && get_static_value(a) == Some(StaticValue::Text("captions")))
                         })
                     });
 
@@ -724,16 +722,17 @@ fn is_hidden_from_screen_reader(
 ) -> bool {
     if tag_name == "input"
         && let Some(type_attr) = attribute_map.get("type")
-        && get_static_value(type_attr) == Some("hidden")
+        && get_static_value(type_attr) == Some(StaticValue::Text("hidden"))
     {
         return true;
     }
 
     if let Some(aria_hidden) = attribute_map.get("aria-hidden") {
-        if let Some(value) = get_static_value(aria_hidden) {
-            return value == "true";
-        }
-        return true; // Dynamic value
+        return match get_static_value(aria_hidden) {
+            None => true, // Dynamic value
+            Some(StaticValue::True) => true,
+            Some(StaticValue::Text(value)) => value == "true",
+        };
     }
 
     false
@@ -741,14 +740,12 @@ fn is_hidden_from_screen_reader(
 
 fn has_disabled_attribute(attribute_map: &FxHashMap<String, &AttributeNode>) -> bool {
     if let Some(disabled) = attribute_map.get("disabled")
-        && get_static_value(disabled).is_some()
+        && get_static_value(disabled).is_some_and(StaticValue::is_truthy)
     {
         return true;
     }
 
-    if let Some(aria_disabled) = attribute_map.get("aria-disabled")
-        && get_static_value(aria_disabled) == Some("true")
-    {
+    if static_text_is(attribute_map.get("aria-disabled"), "true") {
         return true;
     }
 
@@ -779,7 +776,7 @@ fn match_schema_attrs(
         for schema_attr in schema_attrs {
             if let Some(attribute) = attribute_map.get(schema_attr.name) {
                 if let Some(expected_value) = schema_attr.value {
-                    if let Some(actual_value) = get_static_value(attribute) {
+                    if let Some(actual_value) = get_static_text_value(attribute) {
                         if actual_value != expected_value {
                             return false;
                         }
@@ -873,7 +870,8 @@ fn get_implicit_role(
 fn input_implicit_role(attribute_map: &FxHashMap<String, &AttributeNode>) -> Option<&'static str> {
     let type_value = attribute_map
         .get("type")
-        .and_then(|t| get_static_value(t))?;
+        .and_then(|t| get_static_text_value(t))
+        .filter(|t| !t.is_empty())?;
     let has_list = attribute_map.contains_key("list");
     if has_list && COMBOBOX_IF_LIST.contains(&type_value) {
         return Some("combobox");
@@ -886,7 +884,8 @@ fn menuitem_implicit_role(
 ) -> Option<&'static str> {
     let type_value = attribute_map
         .get("type")
-        .and_then(|t| get_static_value(t))?;
+        .and_then(|t| get_static_text_value(t))
+        .filter(|t| !t.is_empty())?;
     MENUITEM_TYPE_TO_IMPLICIT_ROLE.get(type_value).copied()
 }
 
@@ -902,19 +901,92 @@ fn is_abstract_role(role: &str) -> bool {
     ABSTRACT_ROLES.contains(role)
 }
 
-fn get_static_value<'b>(attribute: &'b AttributeNode<'_>) -> Option<&'b str> {
+/// Upstream's `get_static_value` yields `null | true | string`; a valueless
+/// attribute (`<div role>`) is the boolean `true`, which is not the string
+/// `"true"` any check may compare against.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum StaticValue<'b> {
+    True,
+    Text(&'b str),
+}
+
+impl StaticValue<'_> {
+    /// JS truthiness, which upstream tests directly on the result.
+    fn is_truthy(self) -> bool {
+        !matches!(self, StaticValue::Text(""))
+    }
+
+    /// JS `Number(value)`: `true` is 1 and a string coerces numerically.
+    fn to_number(self) -> f64 {
+        match self {
+            StaticValue::True => 1.0,
+            StaticValue::Text(s) => js_str_to_number(s),
+        }
+    }
+}
+
+/// JS `Number(string)` coercion — an empty/whitespace string is 0, and the
+/// numeric grammar is wider than Rust's `parse`.
+fn js_str_to_number(s: &str) -> f64 {
+    let t = s.trim_matches(|c: char| c.is_whitespace() || c == '\u{feff}');
+    if t.is_empty() {
+        return 0.0;
+    }
+    if let Some(hex) = t.strip_prefix("0x").or_else(|| t.strip_prefix("0X")) {
+        return i64::from_str_radix(hex, 16)
+            .map(|v| v as f64)
+            .unwrap_or(f64::NAN);
+    }
+    if let Some(oct) = t.strip_prefix("0o").or_else(|| t.strip_prefix("0O")) {
+        return i64::from_str_radix(oct, 8)
+            .map(|v| v as f64)
+            .unwrap_or(f64::NAN);
+    }
+    if let Some(bin) = t.strip_prefix("0b").or_else(|| t.strip_prefix("0B")) {
+        return i64::from_str_radix(bin, 2)
+            .map(|v| v as f64)
+            .unwrap_or(f64::NAN);
+    }
+    match t {
+        "Infinity" | "+Infinity" => return f64::INFINITY,
+        "-Infinity" => return f64::NEG_INFINITY,
+        _ => {}
+    }
+    // Rust accepts `inf`/`nan`/`1_0`; JS does not.
+    if t.bytes()
+        .any(|b| matches!(b, b'i' | b'I' | b'n' | b'N' | b'_'))
+    {
+        return f64::NAN;
+    }
+    t.parse::<f64>().unwrap_or(f64::NAN)
+}
+
+fn get_static_value<'b>(attribute: &'b AttributeNode<'_>) -> Option<StaticValue<'b>> {
     if let AttributeNode::Attribute(attr) = attribute {
         if matches!(attr.value, AttributeValue::True(_)) {
-            return Some("true");
+            return Some(StaticValue::True);
         }
         if let AttributeValue::Sequence(parts) = &attr.value
             && parts.len() == 1
             && let crate::ast::template::AttributeValuePart::Text(text) = &parts[0]
         {
-            return Some(&text.data);
+            return Some(StaticValue::Text(&text.data));
         }
     }
     None
+}
+
+/// Upstream's `get_static_text_value`: the valueless spelling reads as absent.
+fn get_static_text_value<'b>(attribute: &'b AttributeNode<'_>) -> Option<&'b str> {
+    match get_static_value(attribute)? {
+        StaticValue::True => None,
+        StaticValue::Text(s) => Some(s),
+    }
+}
+
+/// `get_static_value(attr) === expected` for a string `expected`.
+fn static_text_is(attribute: Option<&&AttributeNode<'_>>, expected: &str) -> bool {
+    attribute.map(|a| get_static_value(a)) == Some(Some(StaticValue::Text(expected)))
 }
 
 fn has_content(fragment: &Fragment) -> bool {
@@ -1118,10 +1190,7 @@ fn is_semantic_role_element(
         // Check if all required attributes match
         let attrs_match = match attrs {
             Some(required_attrs) => required_attrs.iter().all(|(attr_name, attr_value)| {
-                attribute_map
-                    .get(*attr_name)
-                    .and_then(|a| get_static_value(a))
-                    == Some(attr_value)
+                static_text_is(attribute_map.get(*attr_name), attr_value)
             }),
             None => true,
         };
@@ -1281,15 +1350,12 @@ fn validate_aria_attribute_value(
 
 /// Validate an autocomplete attribute value.
 /// Corresponds to `is_valid_autocomplete` in the official compiler's a11y/index.js.
-fn is_valid_autocomplete(autocomplete: Option<&str>) -> bool {
+fn is_valid_autocomplete(autocomplete: Option<StaticValue<'_>>) -> bool {
     let autocomplete = match autocomplete {
-        None => return true, // dynamic value
-        Some(v) => v,
+        Some(StaticValue::True) => return false,
+        None | Some(StaticValue::Text("")) => return true, // dynamic or falsy value
+        Some(StaticValue::Text(v)) => v,
     };
-
-    if autocomplete == "true" {
-        return false;
-    }
 
     // Empty string is valid (dynamic or intentionally empty)
     if autocomplete.trim().is_empty() {

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/shared/utils.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/shared/utils.rs
@@ -1622,10 +1622,22 @@ pub fn walk_js_expression_node(
             metadata.set_has_state(true);
             walk_js_expression_node(arena.get_js_node(*argument), context, metadata)?;
         }
-        JsNode::TemplateLiteral { expressions, .. } => {
+        JsNode::TemplateLiteral {
+            quasis,
+            expressions,
+            ..
+        } => {
+            // `quasis` precedes `expressions` in the ESTree node, and upstream's
+            // walk order decides the order the warnings come out in.
+            for quasi in arena.get_js_children(*quasis) {
+                super::super::template_element::visit_typed(quasi, context)?;
+            }
             for expr in arena.get_js_children(*expressions) {
                 walk_js_expression_node(expr, context, metadata)?;
             }
+        }
+        JsNode::Literal { .. } => {
+            super::super::literal::visit_typed(expression, context)?;
         }
         JsNode::TaggedTemplateExpression { tag, quasi, .. } => {
             walk_js_expression_node(arena.get_js_node(*tag), context, metadata)?;

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/style_directive.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/style_directive.rs
@@ -53,10 +53,17 @@ pub fn visit(
         AttributeValue::Sequence(parts) => {
             // Mixed content: `style:color="prefix{expr}suffix"`
             for part in parts {
-                if let AttributeValuePart::ExpressionTag(expr_tag) = part {
-                    let node = expr_tag.expression.as_node();
-                    let mut metadata = crate::ast::template::ExpressionMetadata::default();
-                    walk_js_expression_node(&node, context, &mut metadata)?;
+                match part {
+                    AttributeValuePart::ExpressionTag(expr_tag) => {
+                        let node = expr_tag.expression.as_node();
+                        let mut metadata = crate::ast::template::ExpressionMetadata::default();
+                        walk_js_expression_node(&node, context, &mut metadata)?;
+                    }
+                    AttributeValuePart::Text(text) => {
+                        super::text::check_bidirectional_control_characters(
+                            &text.data, text.start, context,
+                        );
+                    }
                 }
             }
         }

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/text.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/text.rs
@@ -32,15 +32,28 @@ pub fn visit(text: &Text, context: &mut VisitorContext) -> Result<(), AnalysisEr
         return Err(errors::node_invalid_placement(&message).at(text.start, text.end));
     }
 
-    // Check for bidirectional control characters
-    // Upstream offsets the match into `node.data`, not `node.raw`, so an entity
-    // ahead of the match shifts the reported range — mirrored deliberately.
-    for m in REGEX_BIDIRECTIONAL_CONTROL_CHARACTERS.find_iter(&text.data) {
-        let start = text.start + m.start() as u32;
+    check_bidirectional_control_characters(&text.data, text.start, context);
+
+    Ok(())
+}
+
+/// Scan one `Text` node's data for bidirectional control characters.
+///
+/// Upstream's `Text` visitor is reached for every `Text` in the AST, which
+/// includes the ones inside an attribute or directive value, so this is shared
+/// with the attribute walk rather than living in the fragment path.
+///
+/// Upstream offsets the match into `node.data`, not `node.raw`, so an entity
+/// ahead of the match shifts the reported range — mirrored deliberately.
+pub fn check_bidirectional_control_characters(
+    data: &str,
+    node_start: u32,
+    context: &mut VisitorContext,
+) {
+    for m in REGEX_BIDIRECTIONAL_CONTROL_CHARACTERS.find_iter(data) {
+        let start = node_start + m.start() as u32;
         context.emit_warning(
             warnings::bidirectional_control_characters().at(start, start + m.len() as u32),
         );
     }
-
-    Ok(())
 }

--- a/crates/rsvelte_core/tests/a11y_valueless_attribute_3258.rs
+++ b/crates/rsvelte_core/tests/a11y_valueless_attribute_3258.rs
@@ -1,0 +1,153 @@
+//! Upstream's `get_static_value` yields `null | true | string` and its
+//! `get_static_text_value` maps the `true` case back to `null`; rsvelte had a
+//! single helper that stringified a valueless attribute into `"true"`, so
+//! `<div role>` looked like `role="true"` (an unknown role) and `<div tabindex>`
+//! could not be coerced to a number at all.
+//!
+//! Every expectation here was read off the official compiler
+//! (`submodules/svelte`) one input per process.
+
+use rsvelte_core::{CompileOptions, GenerateMode, Warning, compile};
+
+fn warnings(src: &str) -> Vec<Warning> {
+    compile(
+        src,
+        CompileOptions {
+            filename: Some("Main.svelte".to_string()),
+            generate: GenerateMode::Client,
+            dev: false,
+            ..Default::default()
+        },
+    )
+    .expect("compile")
+    .warnings
+}
+
+/// `(code, line, column)` for every warning, in order.
+fn shape(src: &str) -> Vec<(String, usize, usize)> {
+    warnings(src)
+        .iter()
+        .map(|w| {
+            let pos = w.start.as_ref().expect("warning has a start position");
+            (w.code.clone(), pos.line, pos.column)
+        })
+        .collect()
+}
+
+fn codes(src: &str) -> Vec<String> {
+    warnings(src).iter().map(|w| w.code.clone()).collect()
+}
+
+#[test]
+fn valueless_role_is_not_an_unknown_role() {
+    // `role` reads as the boolean `true`, and upstream's `typeof value !== 'string'`
+    // bails before the role lookup.
+    assert!(codes("<div role>x</div>").is_empty());
+    // Controls: the two spellings that already agreed must keep agreeing.
+    assert!(codes("<div role=\"\">x</div>").is_empty());
+    assert!(codes("<div role=\"button\">x</div>").is_empty());
+    // ... while a genuinely unknown role still warns.
+    assert_eq!(
+        codes("<div role=\"toooltip\">x</div>"),
+        vec!["a11y_unknown_role"]
+    );
+}
+
+#[test]
+fn valueless_role_is_not_a_non_presentation_role() {
+    // `role_static_value` is the *text* value, so a valueless `role` is `null`
+    // and `(!role || is_non_presentation_role)` is false — no click warning.
+    assert!(codes("<div role onclick={() => {}}>x</div>").is_empty());
+    // Control: an explicit `role="true"` is a string, so the click rules do fire.
+    assert_eq!(
+        codes("<div role=\"true\" onclick={() => {}}>x</div>"),
+        vec![
+            "a11y_unknown_role",
+            "a11y_click_events_have_key_events",
+            "a11y_no_static_element_interactions",
+        ]
+    );
+}
+
+#[test]
+fn valueless_tabindex_is_number_one() {
+    // `Number(true)` is 1, so the positive-tabindex rule fires; the text value is
+    // `null`, so the noninteractive rule fires too.
+    assert_eq!(
+        shape("<div tabindex>x</div>"),
+        vec![
+            ("a11y_positive_tabindex".to_string(), 1, 5),
+            ("a11y_no_noninteractive_tabindex".to_string(), 1, 0),
+        ]
+    );
+}
+
+#[test]
+fn empty_tabindex_is_number_zero() {
+    // `Number('')` is 0: not positive, but `>= 0`, so only the noninteractive rule
+    // fires. The two spellings are deliberately not interchangeable.
+    assert_eq!(
+        shape("<div tabindex=\"\">x</div>"),
+        vec![("a11y_no_noninteractive_tabindex".to_string(), 1, 0)]
+    );
+}
+
+#[test]
+fn tabindex_is_coerced_with_js_number_rules() {
+    // `parse::<i32>()` rejected everything that is not a bare integer; `Number()`
+    // does not.
+    for src in [
+        "<div tabindex=\"1.5\">x</div>",
+        "<div tabindex=\" 2 \">x</div>",
+        "<div tabindex=\"0x2\">x</div>",
+    ] {
+        assert_eq!(
+            codes(src),
+            vec!["a11y_positive_tabindex", "a11y_no_noninteractive_tabindex"],
+            "{src}"
+        );
+    }
+    // Controls: the numeric spellings that already agreed.
+    assert_eq!(
+        codes("<div tabindex=\"0\">x</div>"),
+        vec!["a11y_no_noninteractive_tabindex"]
+    );
+    assert!(codes("<div tabindex=\"-1\">x</div>").is_empty());
+}
+
+#[test]
+fn a_valueless_attribute_is_not_the_string_true() {
+    // `get_static_value(aria-hidden) === 'true'` is false for the boolean `true`,
+    // so `<a aria-hidden>` is not "hidden" and still wants a label.
+    assert_eq!(
+        codes("<a href=\"/x\" aria-hidden></a>"),
+        vec![
+            "a11y_incorrect_aria_attribute_type_boolean",
+            "a11y_consider_explicit_label",
+        ]
+    );
+    // `inert` is read through `get_static_value(...) !== null`, so a dynamic value
+    // does not suppress the label warning either.
+    assert_eq!(
+        codes("<a href=\"/x\" inert={x}></a>"),
+        vec!["a11y_consider_explicit_label"]
+    );
+    // An empty `id` is falsy upstream, so `<a>` is still missing its `href` …
+    assert_eq!(codes("<a id=\"\">x</a>"), vec!["a11y_missing_attribute"]);
+    // … while a valueless `id` is `true`, which is truthy.
+    assert!(codes("<a id>x</a>").is_empty());
+}
+
+#[test]
+fn input_type_text_value_is_not_defaulted() {
+    // Upstream reports `'...'` when the `type` is not statically known; rsvelte
+    // substituted `text`.
+    let ws = warnings("<input type={t} autocomplete=\"bogus\">");
+    assert_eq!(ws.len(), 1);
+    assert_eq!(ws[0].code, "a11y_autocomplete_valid");
+    assert!(
+        ws[0].message.contains("<input type=\"...\">"),
+        "expected the unknown-type placeholder, got {:?}",
+        ws[0].message
+    );
+}

--- a/crates/rsvelte_core/tests/bidirectional_control_characters_slots_3227.rs
+++ b/crates/rsvelte_core/tests/bidirectional_control_characters_slots_3227.rs
@@ -1,0 +1,148 @@
+//! Upstream raises `bidirectional_control_characters` from three visitors —
+//! `Text`, `Literal` and `TemplateElement` — and zimmerframe reaches all three
+//! everywhere in the AST. rsvelte ran `Text` on fragment text only and never ran
+//! `Literal` / `TemplateElement` over a *template* expression, so every
+//! attribute value and every string inside `{...}` was silent.
+//!
+//! Every expectation here was read off the official compiler
+//! (`submodules/svelte`), one input per process — the upstream regex carries the
+//! `g` flag and `.test()` advances its `lastIndex`, so a multi-case run in one
+//! process reports a different answer than a real compile does.
+
+use rsvelte_core::{CompileOptions, GenerateMode, Warning, compile};
+
+/// U+202E RIGHT-TO-LEFT OVERRIDE.
+const RLO: &str = "\u{202e}";
+
+fn warnings(src: &str) -> Vec<Warning> {
+    compile(
+        src,
+        CompileOptions {
+            filename: Some("Main.svelte".to_string()),
+            generate: GenerateMode::Client,
+            dev: false,
+            ..Default::default()
+        },
+    )
+    .expect("compile")
+    .warnings
+}
+
+/// `line:column` of every bidi warning, in emission order.
+fn bidi(src: &str) -> Vec<String> {
+    warnings(src)
+        .iter()
+        .filter(|w| w.code == "bidirectional_control_characters")
+        .map(|w| {
+            let pos = w.start.as_ref().expect("warning has a start position");
+            format!("{}:{}", pos.line, pos.column)
+        })
+        .collect()
+}
+
+#[test]
+fn an_attribute_value_is_walked() {
+    assert_eq!(bidi(&format!("<b title=\"a{RLO}b\">x</b>")), ["1:11"]);
+    assert_eq!(bidi(&format!("<b title='a{RLO}b'>x</b>")), ["1:11"]);
+    assert_eq!(bidi(&format!("<b title=a{RLO}b>x</b>")), ["1:10"]);
+    // The offset is into the *decoded* data, so an entity ahead of the match
+    // shifts the reported column.
+    assert_eq!(bidi(&format!("<b title=\"&amp;a{RLO}b\">x</b>")), ["1:12"]);
+}
+
+#[test]
+fn every_attribute_host_is_walked() {
+    // A component, a `<svelte:element>` and a `<slot>` reach the same `Text`
+    // visitor upstream, so the host must not decide whether the rule runs.
+    assert_eq!(
+        bidi(&format!(
+            "<script>import C from './C.svelte';</script><C title=\"a{RLO}b\" />"
+        )),
+        ["1:55"]
+    );
+    assert_eq!(
+        bidi(&format!(
+            "<svelte:element this=\"div\" title=\"a{RLO}b\">x</svelte:element>"
+        )),
+        ["1:35"]
+    );
+    assert_eq!(bidi(&format!("<slot name=\"a{RLO}b\" />")), ["1:13"]);
+    // A `style:` directive's value is a `Text` node too.
+    assert_eq!(bidi(&format!("<b style:color=\"a{RLO}b\">x</b>")), ["1:17"]);
+}
+
+#[test]
+fn a_template_expression_literal_is_walked() {
+    assert_eq!(bidi(&format!("<b>{{\"a{RLO}b\"}}</b>")), ["1:4"]);
+    assert_eq!(bidi(&format!("<b title={{\"a{RLO}b\"}}>x</b>")), ["1:10"]);
+    assert_eq!(bidi(&format!("<b class:x={{\"a{RLO}b\"}}>y</b>")), ["1:12"]);
+    assert_eq!(
+        bidi(&format!("{{#each [\"a{RLO}b\"] as v}}{{v}}{{/each}}")),
+        ["1:8"]
+    );
+    assert_eq!(bidi(&format!("{{@html \"a{RLO}b\"}}")), ["1:7"]);
+    assert_eq!(bidi(&format!("{{#if \"a{RLO}b\"}}x{{/if}}")), ["1:5"]);
+}
+
+#[test]
+fn a_template_literal_quasi_is_walked() {
+    assert_eq!(bidi(&format!("<b>{{`a{RLO}b`}}</b>")), ["1:5"]);
+    assert_eq!(bidi(&format!("<b title={{`a{RLO}b`}}>x</b>")), ["1:11"]);
+}
+
+#[test]
+fn the_slots_upstream_does_not_walk_stay_silent() {
+    // Comments are not `Text` / `Literal` nodes in any of the three positions.
+    assert!(bidi(&format!("<script>// a{RLO}b\nlet s = 1;</script>")).is_empty());
+    assert!(bidi(&format!("<!-- a{RLO}b -->")).is_empty());
+    assert!(
+        bidi(&format!(
+            "<style>/* a{RLO}b */ b{{color:red}}</style><b>x</b>"
+        ))
+        .is_empty()
+    );
+}
+
+#[test]
+fn a_script_literal_still_warns() {
+    // The over-fire reported in #3227 is not one: official warns here too. This
+    // is the control that keeps the fix from being "delete the script arm".
+    assert_eq!(
+        bidi(&format!(
+            "<script>let s = \"a{RLO}b\";</script>\n<b>{{s}}</b>"
+        )),
+        ["1:16"]
+    );
+    assert_eq!(
+        bidi(&format!("<script module>let s = \"a{RLO}b\";</script>")),
+        ["1:23"]
+    );
+}
+
+#[test]
+fn svelte_ignore_still_suppresses_the_new_slots() {
+    assert!(
+        bidi(&format!(
+            "<!-- svelte-ignore bidirectional_control_characters -->\n<b title=\"a{RLO}b\">x</b>"
+        ))
+        .is_empty()
+    );
+    assert!(
+        bidi(&format!(
+            "<!-- svelte-ignore bidirectional_control_characters -->\n<b>{{\"a{RLO}b\"}}</b>"
+        ))
+        .is_empty()
+    );
+}
+
+#[test]
+fn an_attribute_and_an_expression_both_report() {
+    assert_eq!(
+        bidi(&format!("<b title=\"a{RLO}b\">{{\"c{RLO}d\"}}</b>")),
+        ["1:11", "1:16"]
+    );
+    assert_eq!(
+        bidi(&format!("<b>{{\"c{RLO}d\"}}</b><i title=\"a{RLO}b\">y</i>")),
+        ["1:4", "1:25"]
+    );
+}


### PR DESCRIPTION
Closes #3258
Closes #3227

Two warning-parity defects, both of which are "the check never reached that slot".

## 1. A valueless attribute is not the string `"true"` (#3258)

Upstream has two helpers: `get_static_value` yields `null | true | string`, and
`get_static_text_value` folds the `true` case back to `null`. rsvelte had **one**
helper returning `Option<&str>` that stringified a valueless attribute into
`Some("true")` — the "two ports of one upstream function" shape, collapsed into one
port that answers neither question.

Consequences the issue named:

- `<div role>` was looked up as the role `true` → a spurious `a11y_unknown_role`.
  Upstream breaks on `typeof value !== 'string'`.
- `<div tabindex>` reached **neither** tabindex rule: `"true".parse::<i32>()` fails,
  where upstream computes `Number(true) === 1` (positive) and
  `get_static_text_value(...) === null` (noninteractive).
- `<div tabindex="">` reached neither: `"".parse::<i32>()` fails, where
  `Number('') === 0` is `>= 0`.

Consequences the issue did not name, found by mapping every call site back to
upstream — the same conflation runs through every `=== 'true'` comparison and every
JS-truthiness test in the file:

| site | before | upstream |
|---|---|---|
| `<a aria-hidden>` label check | counted as hidden | `true !== 'true'` → not hidden |
| `<a inert={x}>` label check | `attribute_map.has('inert')` | `get_static_value(inert) !== null` |
| `<a id="">` | empty id counted as present | `''` is falsy |
| `<button disabled="">` | counted as disabled | `''` is falsy |
| `<img alt="photo" aria-hidden={x}>` | presence suppressed the warning | a dynamic value is falsy |
| `<input type={t} autocomplete="…">` | message said `type="text"` | upstream prints `type="..."` |

Numbers are now coerced with JS `Number()` rather than `parse::<i32>()`, so
`tabindex="1.5"`, `" 2 "` and `"0x2"` are classified as upstream classifies them.

All 27 probe inputs (code **and** line:column) now agree with the official compiler.

## 2. `bidirectional_control_characters` walked only fragment text (#3227)

Upstream raises this from three visitors — `Text`, `Literal`, `TemplateElement` —
and zimmerframe reaches all three anywhere in the AST, so an attribute value's
`Text` node and a template expression's string/template literal are covered by the
same visitors as body text. rsvelte ran the `Text` scan from the fragment walk only
and `walk_js_expression_node` had no `Literal` arm and never walked a
`TemplateLiteral`'s `quasis`.

Fixed by sharing the `Text` scan with `visit_attribute_value_expressions` (which is
the one path every attribute host funnels through) and `style_directive::visit`, and
by dispatching `Literal` / `TemplateElement` from `walk_js_expression_node`.

32 host inputs were probed on both sides; 31 now agree exactly, on position as well
as presence. The 32nd is the residual noted below.

### The `<script>` row of #3227 is a measurement artifact, not a defect

The issue reports `<script>` string literal as "official silent, rsvelte warns".
**Official warns there too**, at the identical position — verified one input per
process:

```
script-string        official 1:16   rsvelte 1:16
script-module-string official 1:23   rsvelte 1:23
script-template      official 1:17   rsvelte 1:17
```

The reason a grid disagrees: `regex_bidirectional_control_characters` carries the
`g` flag, and `Literal.js` / `TemplateElement.js` call `.test()` on the shared
module-level regex without resetting `lastIndex` (only `Text.js` resets it). A
successful `.test()` advances `lastIndex`, so the *next* literal is tested from the
wrong offset and reports nothing. Running many cases in one process therefore
alternates true/false. So this PR deliberately does **not** delete the script arm —
`a_script_literal_still_warns` is the control that pins that.

## Residual (pre-existing, filed separately)

Two divergences remain in this area. Both are reproducible on `main` through the
`<script>` path this PR does not touch, so neither is introduced here:

- **#3344** — the upstream `lastIndex` bug above: two or more consecutive
  `Literal`/`TemplateElement` hits with no intervening `Text` node yield 1 warning
  upstream and N in rsvelte.
- **#3345** — a computed property key's `Literal` start is the `[` in the script
  path (`{["a‮b"]: 1}` reports column 17, upstream 18). This is the same
  serialization defect AGENTS.md already records for `eslint_plugin_oracle.rs`.

## Tests

- `crates/rsvelte_core/tests/a11y_valueless_attribute_3258.rs` (7 tests)
- `crates/rsvelte_core/tests/bidirectional_control_characters_slots_3227.rs` (8 tests)

Every expectation was read off `submodules/svelte`, one input per process.

Negative controls, run four ways — each fix reverted independently, and each time
the failing tests are exactly the predicted ones:

| reverted | fails |
|---|---|
| `StaticValue::True` → `Text("true")` | the 4 role/`true`-comparison tests; the two `Number()` tests still pass |
| `js_str_to_number` → `parse::<f64>` | the 2 numeric tests; the `true` tests still pass |
| the shared `Text` scan | the 3 attribute tests |
| the `Literal`/`TemplateElement` arms | the 3 expression tests |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ABb93VNuxXbM1MZZTRp19H
