### PR TITLE
fix(compiler): four client-output divergences (numeric prop key, aliased prop getter, const fold, snippet hoist)

### DIFF
--- a/.changeset/client-output-numeric-key-alias-fold-hoist.md
+++ b/.changeset/client-output-numeric-key-alias-fold-hoist.md
@@ -1,0 +1,10 @@
+---
+"@rsvelte/compiler": patch
+---
+
+Four client-output divergences from the official compiler:
+
+- A numeric key in a `$props()` destructuring reaches `$.prop` as a number, not a string, and carries its value rather than its spelling (`0x10` → `16`). The same key is excluded from `$.rest_props` as a number, and a fractional key (`0.5`) is no longer truncated to `0` on the read-only path.
+- A component prop whose value aliases a local function is passed through a getter (and through a thunk when spread), matching `scope.evaluate`, which never treats a function as a known value.
+- A `const` initialised with a logical expression (`1 || 2`) or a regex literal folds into the template on all three targets; a folded regex is an object, so `{typeof c}` renders `object`.
+- An optional `{@render sn?.()}` inside a snippet no longer blocks the module-scope hoist, so the closure is allocated once per module instead of once per component instance.

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/snippet_block.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/snippet_block.rs
@@ -500,6 +500,12 @@ fn expression_only_uses_params_node(
             expression_only_uses_params_node(arena.get_js_node(*argument), param_names, context)
         }
 
+        // `a?.b` / `f?.()` — the optional marker wraps the same call/member the
+        // non-optional spelling produces, and upstream sees only the references.
+        JsNode::ChainExpression { expression, .. } => {
+            expression_only_uses_params_node(arena.get_js_node(*expression), param_names, context)
+        }
+
         JsNode::UnaryExpression { argument, .. } | JsNode::UpdateExpression { argument, .. } => {
             expression_only_uses_params_node(arena.get_js_node(*argument), param_names, context)
         }
@@ -1554,6 +1560,15 @@ fn expression_only_uses_params(
             Some("SpreadElement") => {
                 if let Some(arg) = obj.get("argument") {
                     return expression_only_uses_params(arg, param_names, context);
+                }
+                true
+            }
+
+            // `a?.b` / `f?.()` — the optional marker wraps the same call/member
+            // the non-optional spelling produces.
+            Some("ChainExpression") => {
+                if let Some(inner) = obj.get("expression") {
+                    return expression_only_uses_params(inner, param_names, context);
                 }
                 true
             }

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/variable_declarator.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/variable_declarator.rs
@@ -796,7 +796,11 @@ fn process_props_object_pattern_typed(
             JsNode::Identifier { name, .. } => Some(name.to_string()),
             JsNode::Literal { value, .. } => match value {
                 crate::ast::typed_expr::LiteralValue::String(s) => Some(s.to_string()),
-                crate::ast::typed_expr::LiteralValue::Number(n) => Some((*n as i64).to_string()),
+                crate::ast::typed_expr::LiteralValue::Number(n) => Some(
+                    crate::compiler::phases::phase3_transform::server::evaluate::js_number_to_string(
+                        *n,
+                    ),
+                ),
                 _ => None,
             },
             _ => None,

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/variable_declarator.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/variable_declarator.rs
@@ -228,6 +228,11 @@ fn extract_paths_typed_recursive(
 fn extract_literal_string_typed(node: &JsNode) -> Option<String> {
     match node {
         JsNode::Literal { raw, value, .. } => {
+            // A regex has no representation in the `initial` source-text model,
+            // and a `Some` here closes the AST-JSON path that can evaluate it.
+            if matches!(value, crate::ast::typed_expr::LiteralValue::Regex(_)) {
+                return None;
+            }
             if !raw.is_empty() {
                 return Some(raw.to_string());
             }
@@ -1045,7 +1050,13 @@ fn visit_non_runes_mode_typed(
 fn init_needs_expr_json(init: &JsNode) -> bool {
     match init {
         JsNode::TemplateLiteral { expressions, .. } => !expressions.is_empty(),
+        // A regex is the one literal `Binding::initial` cannot carry, so its
+        // node is what the evaluators have to read.
+        JsNode::Literal { value, .. } => {
+            matches!(value, crate::ast::typed_expr::LiteralValue::Regex(_))
+        }
         JsNode::BinaryExpression { .. }
+        | JsNode::LogicalExpression { .. }
         | JsNode::UnaryExpression { .. }
         | JsNode::ConditionalExpression { .. }
         | JsNode::CallExpression { .. } => true,

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/props_transforms.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/props_transforms.rs
@@ -1954,6 +1954,42 @@ pub(super) fn calculate_prop_flags(
     flags
 }
 
+/// The `$.prop($$props, <key>, …)` key exactly as upstream prints it. Upstream
+/// passes `b.literal(key.value)`, so a numeric destructuring key stays a
+/// **number** (and carries its value, not its spelling: `0x10` → `16`).
+pub(super) fn prop_key_js_literal(raw_key: &str, prop_name: &str) -> String {
+    if let Some(n) = numeric_key_value(raw_key) {
+        return crate::compiler::phases::phase3_transform::server::evaluate::js_number_to_string(n);
+    }
+    format!("'{}'", prop_name)
+}
+
+/// `Some(value)` when the raw key text is a numeric literal, parsed rather than
+/// pattern-matched so `1e3` / `0x10` / `1_000` carry their value.
+fn numeric_key_value(raw_key: &str) -> Option<f64> {
+    use oxc_allocator::Allocator;
+    use oxc_ast::ast::{Expression, Statement};
+    use oxc_parser::Parser;
+    use oxc_span::SourceType;
+
+    let trimmed = raw_key.trim();
+    if !trimmed.starts_with(|c: char| c.is_ascii_digit() || c == '.') {
+        return None;
+    }
+    let alloc = Allocator::default();
+    let parsed = Parser::new(&alloc, trimmed, SourceType::mjs()).parse();
+    if parsed.panicked || !parsed.diagnostics.is_empty() {
+        return None;
+    }
+    let [Statement::ExpressionStatement(stmt)] = parsed.program.body.as_slice() else {
+        return None;
+    };
+    match &stmt.expression {
+        Expression::NumericLiteral(lit) => Some(lit.value),
+        _ => None,
+    }
+}
+
 /// Check if a string is a valid JavaScript identifier.
 pub(super) fn is_identifier_str(s: &str) -> bool {
     let trimmed = s.trim();
@@ -2796,13 +2832,15 @@ pub(super) fn transform_props_destructuring(
     // Track "seen" prop names for $.rest_props() exclusion list.
     // Reference: VariableDeclaration.js lines 45-46
     // Starts with internal prop names that should always be excluded.
+    // Holds each entry's JS literal spelling, because a numeric key is excluded
+    // as a number upstream (`b.literal(key.value)`), not as a string.
     let mut seen: Vec<String> = vec![
-        "$$slots".to_string(),
-        "$$events".to_string(),
-        "$$legacy".to_string(),
+        "'$$slots'".to_string(),
+        "'$$events'".to_string(),
+        "'$$legacy'".to_string(),
     ];
     if analysis.custom_element.is_some() {
-        seen.push("$$host".to_string());
+        seen.push("'$$host'".to_string());
     }
 
     // Comments that bracket a declarator ride the esrap comment cursor
@@ -2873,7 +2911,7 @@ pub(super) fn transform_props_destructuring(
         if let Some(rest_name) = prop_part.strip_prefix("...") {
             let rest_name = rest_name.trim();
             // Generate: rest_name = $.rest_props($$props, ['$$slots', '$$events', '$$legacy', ...seen_props])
-            let seen_literals: Vec<String> = seen.iter().map(|s| format!("'{}'", s)).collect();
+            let seen_literals: Vec<String> = seen.clone();
             let dev_name = if dev {
                 format!(", '{}'", rest_name)
             } else {
@@ -2897,19 +2935,20 @@ pub(super) fn transform_props_destructuring(
             // In destructuring, `disabled: disabledProp = false` means:
             //   prop_name = "disabled" (the actual prop)
             //   local_name = "disabledProp" (the local variable)
-            let (prop_name, local_name) = if let Some(colon_pos) = name_part.find(':') {
-                let pn = name_part[..colon_pos].trim();
+            let (prop_key, local_name) = if let Some(colon_pos) = name_part.find(':') {
+                let raw_key = name_part[..colon_pos].trim();
                 // Strip surrounding quotes from prop name (e.g., 'weird-name': localVar)
-                let pn = pn
+                let pn = raw_key
                     .strip_prefix('\'')
                     .and_then(|s| s.strip_suffix('\''))
-                    .or_else(|| pn.strip_prefix('"').and_then(|s| s.strip_suffix('"')))
-                    .unwrap_or(pn);
+                    .or_else(|| raw_key.strip_prefix('"').and_then(|s| s.strip_suffix('"')))
+                    .unwrap_or(raw_key);
                 let ln = name_part[colon_pos + 1..].trim();
-                (pn, ln)
+                (prop_key_js_literal(raw_key, pn), ln)
             } else {
-                (name_part, name_part)
+                (format!("'{}'", name_part), name_part)
             };
+            let prop_key = prop_key.as_str();
 
             // Strip $bindable() wrapper: $bindable(value) -> value
             // Reference: VariableDeclaration.js - unwrap_bindable()
@@ -2958,12 +2997,12 @@ pub(super) fn transform_props_destructuring(
                         // In legacy mode, all props are sources
                         true
                     };
-                    seen.push(prop_name.to_string());
+                    seen.push(prop_key.to_string());
                     if is_source {
                         let flags = calculate_prop_flags(local_name, analysis, false);
                         declarators.push(format!(
-                            "{} = $.prop($$props, '{}', {})",
-                            local_name, prop_name, flags
+                            "{} = $.prop($$props, {}, {})",
+                            local_name, prop_key, flags
                         ));
                     }
                     return false;
@@ -2974,7 +3013,7 @@ pub(super) fn transform_props_destructuring(
             };
 
             // Add this prop name to the "seen" list for rest_props exclusion
-            seen.push(prop_name.to_string());
+            seen.push(prop_key.to_string());
 
             // Transform default value: apply read-only prop substitutions
             let default_value = {
@@ -3032,8 +3071,8 @@ pub(super) fn transform_props_destructuring(
 
             if is_simple {
                 declarators.push(format!(
-                    "{} = $.prop($$props, '{}', {}, {})",
-                    local_name, prop_name, flags, proxy_wrapped
+                    "{} = $.prop($$props, {}, {}, {})",
+                    local_name, prop_key, flags, proxy_wrapped
                 ));
             } else {
                 // Wrap non-simple values in a thunk: () => value
@@ -3041,29 +3080,30 @@ pub(super) fn transform_props_destructuring(
                 // OXC from parsing `() => {...}` as arrow with block body
                 let lazy_arg = make_lazy_prop_arg(&proxy_wrapped);
                 declarators.push(format!(
-                    "{} = $.prop($$props, '{}', {}, {})",
-                    local_name, prop_name, flags, lazy_arg
+                    "{} = $.prop($$props, {}, {}, {})",
+                    local_name, prop_key, flags, lazy_arg
                 ));
             }
             true
         } else {
             // No default value - handle rename pattern: `originalProp: localVar`
-            let (prop_name, local_name) = if let Some(colon_pos) = prop_part.find(':') {
-                let pn = prop_part[..colon_pos].trim();
+            let (prop_key, local_name) = if let Some(colon_pos) = prop_part.find(':') {
+                let raw_key = prop_part[..colon_pos].trim();
                 // Strip surrounding quotes from prop name
-                let pn = pn
+                let pn = raw_key
                     .strip_prefix('\'')
                     .and_then(|s| s.strip_suffix('\''))
-                    .or_else(|| pn.strip_prefix('"').and_then(|s| s.strip_suffix('"')))
-                    .unwrap_or(pn);
+                    .or_else(|| raw_key.strip_prefix('"').and_then(|s| s.strip_suffix('"')))
+                    .unwrap_or(raw_key);
                 let ln = prop_part[colon_pos + 1..].trim();
-                (pn, ln)
+                (prop_key_js_literal(raw_key, pn), ln)
             } else {
-                (prop_part, prop_part)
+                (format!("'{}'", prop_part), prop_part)
             };
+            let prop_key = prop_key.as_str();
 
             // Add to seen list for rest_props exclusion
-            seen.push(prop_name.to_string());
+            seen.push(prop_key.to_string());
 
             // Only generate $.prop() if this is a source prop or exported
             let is_exported = exported_names.contains(&local_name.to_string());
@@ -3072,8 +3112,8 @@ pub(super) fn transform_props_destructuring(
                 let flags = calculate_prop_flags(local_name, analysis, false);
 
                 declarators.push(format!(
-                    "{} = $.prop($$props, '{}', {})",
-                    local_name, prop_name, flags
+                    "{} = $.prop($$props, {}, {})",
+                    local_name, prop_key, flags
                 ));
             }
             // Read-only props without defaults are accessed directly via $$props.propName

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/utils.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/utils.rs
@@ -6810,11 +6810,11 @@ fn is_expression_known_json(json_value: &serde_json::Value, context: &ComponentC
                         return false;
                     }
 
-                    // For Normal bindings: known if never updated with known initial
-                    // Functions are always "known" (they're defined)
-                    if binding.is_function() {
-                        return true;
-                    }
+                    // A function value is never `is_known` to upstream's
+                    // `scope.evaluate` — it recurses into the initializer and a
+                    // function expression falls through to `UNKNOWN`. Reading a
+                    // function is kept out of `has_state` by the separate
+                    // `!binding.is_function()` term, not by this one.
                     // A non-literal initializer lives in `init_expr_json`, and
                     // upstream's `scope.evaluate` recurses into the init node
                     // whatever its shape (`const b = `${a}y`` is known when `a` is).

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/evaluate.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/evaluate.rs
@@ -1232,11 +1232,12 @@ impl<'a> EvalCtx<'a> {
                         Err(_) => Evaluation::unknown(),
                     };
                 }
-                // Regex literal: return its string representation (e.g. /[}]/gi)
+                // A regex literal stringifies to its source but is an object, so
+                // it cannot be folded as a `Str` (`typeof` would print `string`).
                 if let Some(regex) = node.get("regex") {
                     let pattern = regex.get("pattern").and_then(|p| p.as_str()).unwrap_or("");
                     let flags = regex.get("flags").and_then(|f| f.as_str()).unwrap_or("");
-                    return Evaluation::single(EvalValue::Str(format!("/{}/{}", pattern, flags)));
+                    return Evaluation::single(EvalValue::Regex(format!("/{}/{}", pattern, flags)));
                 }
                 match node.get("value") {
                     Some(Value::String(s)) => Evaluation::single(EvalValue::Str(s.clone())),

--- a/crates/rsvelte_core/tests/component_prop_alias_getter_3230.rs
+++ b/crates/rsvelte_core/tests/component_prop_alias_getter_3230.rs
@@ -1,0 +1,83 @@
+//! A function value is never `is_known` to upstream's `scope.evaluate`, so a
+//! `const` that ALIASES a local function is not a known value and a component
+//! prop reading it is passed through a getter (issue #3230). rsvelte's
+//! `is_expression_known_json` answered `true` for any `is_function()` binding,
+//! which made the alias known and the prop pass by value. Every expectation
+//! here is the official compiler's output for the same source.
+
+use rsvelte_core::{CompileOptions, GenerateMode, compile, compiler::CssMode};
+
+fn client(src: &str) -> String {
+    compile(
+        src,
+        CompileOptions {
+            filename: Some("A.svelte".to_string()),
+            generate: GenerateMode::Client,
+            dev: false,
+            css: CssMode::External,
+            ..Default::default()
+        },
+    )
+    .expect("must compile")
+    .js
+    .code
+}
+
+fn component(declaration: &str, host: &str) -> String {
+    client(&format!(
+        "<script>\n\timport C from './C.svelte';\n\t{declaration}\n</script>\n\n{host}\n"
+    ))
+}
+
+#[test]
+fn an_alias_of_a_local_function_is_passed_through_a_getter() {
+    for declaration in [
+        "const h = () => {};\n\tconst cb = h;",
+        "let h = () => {};\n\tconst cb = h;",
+        "const h = () => {};\n\tlet cb = h;",
+        "function h() {}\n\tconst cb = h;",
+        "const g = () => {};\n\tconst h = g;\n\tconst cb = h;",
+    ] {
+        let out = component(declaration, "<C {cb} />");
+        assert!(
+            out.contains("get cb()"),
+            "an aliased function is not a known value:\n{declaration}\n{out}"
+        );
+    }
+}
+
+#[test]
+fn an_aliased_function_spreads_through_a_thunk() {
+    let out = component("const h = () => {};\n\tconst cb = h;", "<C {...{ cb }} />");
+    assert!(
+        out.contains("$.spread_props(() => ({ cb }))"),
+        "the spread reads the props lazily, got:\n{out}"
+    );
+}
+
+#[test]
+fn a_direct_function_or_literal_is_still_inlined() {
+    for declaration in [
+        "const cb = () => {};",
+        "const h = 1;\n\tconst cb = h;",
+        "const h = 'x';\n\tconst cb = h;",
+    ] {
+        let out = component(declaration, "<C {cb} />");
+        assert!(
+            out.contains("{ cb }") && !out.contains("get cb()"),
+            "an inlinable value must not grow a getter:\n{declaration}\n{out}"
+        );
+    }
+}
+
+#[test]
+fn an_element_event_handler_is_unaffected() {
+    let out = component(
+        "const h = () => {};\n\tconst cb = h;",
+        "<button onclick={cb}>x</button>",
+    );
+    assert!(
+        out.contains("$.delegated('click', button, cb)") || out.contains("'click', button, cb"),
+        "an element handler still receives the binding directly, got:\n{out}"
+    );
+}

--- a/crates/rsvelte_core/tests/const_fold_logical_regex_3249.rs
+++ b/crates/rsvelte_core/tests/const_fold_logical_regex_3249.rs
@@ -1,0 +1,84 @@
+//! `scope.evaluate` recurses into a binding's initializer whatever its shape,
+//! so a `const` initialised with a logical expression or a regex literal is a
+//! known value and folds into the template (issue #3249). Phase 2 kept neither
+//! node: `LogicalExpression` was missing from `init_needs_expr_json`, and a
+//! regex set `binding.initial = Some("/ab/g")`, which closed the AST path that
+//! could evaluate it. Every expectation here is the official compiler's output
+//! for the same source.
+
+use rsvelte_core::{CompileOptions, GenerateMode, compile, compiler::CssMode};
+
+fn compiled(src: &str, generate: GenerateMode) -> String {
+    compile(
+        src,
+        CompileOptions {
+            filename: Some("A.svelte".to_string()),
+            generate,
+            dev: false,
+            css: CssMode::External,
+            ..Default::default()
+        },
+    )
+    .expect("must compile")
+    .js
+    .code
+}
+
+fn source(init: &str, read: &str) -> String {
+    format!("<script>\n\tconst c = {init};\n</script>\n{read}\n")
+}
+
+#[test]
+fn a_logical_initializer_folds_on_every_target() {
+    for (init, folded) in [
+        ("1 || 2", "1"),
+        ("1 && 2", "2"),
+        ("null ?? 3", "3"),
+        ("0 || 3", "3"),
+        ("true && false", "false"),
+    ] {
+        let client = compiled(&source(init, "{c}"), GenerateMode::Client);
+        assert!(
+            client.contains(&format!("text.nodeValue = '{folded}';")),
+            "`{init}` must fold to `{folded}` on the client, got:\n{client}"
+        );
+        assert!(
+            !client.contains("template_effect"),
+            "`{init}` is a known value, so the read is not reactive:\n{client}"
+        );
+        let server = compiled(&source(init, "{c}"), GenerateMode::Server);
+        assert!(
+            server.contains(&format!("<!---->{folded}`")),
+            "`{init}` must fold to `{folded}` on the server, got:\n{server}"
+        );
+    }
+}
+
+#[test]
+fn a_regex_initializer_folds_to_its_source() {
+    let client = compiled(&source("/ab/g", "{c}"), GenerateMode::Client);
+    assert!(
+        client.contains("text.nodeValue = '/ab/g';"),
+        "a regex stringifies to its source, got:\n{client}"
+    );
+    let server = compiled(&source("/ab/g", "{c}"), GenerateMode::Server);
+    assert!(
+        server.contains("<!---->/ab/g`"),
+        "a regex stringifies to its source, got:\n{server}"
+    );
+}
+
+#[test]
+fn a_folded_regex_is_an_object_not_a_string() {
+    for generate in [GenerateMode::Client, GenerateMode::Server] {
+        let out = compiled(&source("/ab/g", "{typeof c}"), generate);
+        assert!(
+            out.contains("object"),
+            "`typeof /ab/g` is `object`, got:\n{out}"
+        );
+        assert!(
+            !out.contains("'string'") && !out.contains("<!---->string`"),
+            "a regex must not be folded as a string value, got:\n{out}"
+        );
+    }
+}

--- a/crates/rsvelte_core/tests/props_numeric_key_3229.rs
+++ b/crates/rsvelte_core/tests/props_numeric_key_3229.rs
@@ -1,0 +1,89 @@
+//! A numeric key in a `$props()` destructuring is a NUMBER to upstream
+//! (`b.literal(key.value)`), not the text between the braces (issue #3229).
+//! rsvelte quoted every key, so `let { 0: a } = $props()` emitted
+//! `$.prop($$props, '0', …)`, and the key's *value* was truncated with an
+//! `as i64` cast, so `0.5` reached `$$props['0']`. Every expectation here is
+//! the official compiler's output for the same source.
+
+use rsvelte_core::{CompileOptions, GenerateMode, compile, compiler::CssMode};
+
+fn client(src: &str, dev: bool) -> String {
+    compile(
+        src,
+        CompileOptions {
+            filename: Some("A.svelte".to_string()),
+            generate: GenerateMode::Client,
+            dev,
+            css: CssMode::External,
+            ..Default::default()
+        },
+    )
+    .expect("must compile")
+    .js
+    .code
+}
+
+fn mutated(pattern: &str) -> String {
+    format!(
+        "<script>\n\tlet {pattern} = $props();\n</script>\n\n<button onclick={{() => (a = 2)}}>x</button>\n"
+    )
+}
+
+#[test]
+fn a_numeric_key_reaches_prop_as_a_number() {
+    for dev in [false, true] {
+        let out = client(&mutated("{ 0: a }"), dev);
+        assert!(
+            out.contains("$.prop($$props, 0, 7)"),
+            "dev={dev}: numeric key must stay a number, got:\n{out}"
+        );
+    }
+}
+
+#[test]
+fn a_numeric_key_carries_its_value_not_its_spelling() {
+    for (pattern, expected) in [
+        ("{ 0x10: a }", "$.prop($$props, 16, 7)"),
+        ("{ 1e3: a }", "$.prop($$props, 1000, 7)"),
+        ("{ 0.5: a }", "$.prop($$props, 0.5, 7)"),
+    ] {
+        let out = client(&mutated(pattern), false);
+        assert!(
+            out.contains(expected),
+            "`{pattern}` must emit `{expected}`, got:\n{out}"
+        );
+    }
+}
+
+#[test]
+fn a_quoted_numeric_key_stays_a_string() {
+    let out = client(&mutated("{ '0': a }"), false);
+    assert!(
+        out.contains("$.prop($$props, '0', 7)"),
+        "a string key keeps its quotes, got:\n{out}"
+    );
+}
+
+#[test]
+fn a_numeric_key_is_excluded_from_rest_props_as_a_number() {
+    let out = client(
+        "<script>\n\tlet { 1: a, x: b, ...rest } = $props();\n</script>\n\n<button onclick={() => (a = 2)}>{b}{rest.z}</button>\n",
+        false,
+    );
+    assert!(
+        out.contains("new Set(['$$slots', '$$events', '$$legacy', 1, 'x'])"),
+        "rest exclusions carry the key's literal spelling, got:\n{out}"
+    );
+}
+
+#[test]
+fn a_fractional_read_only_key_is_not_truncated() {
+    let out = client(
+        "<script>\n\tlet { 0.5: a } = $props();\n</script>\n\n{a}\n",
+        false,
+    );
+    assert!(
+        out.contains("$$props['0.5']"),
+        "a read-only numeric prop keeps its whole key, got:\n{out}"
+    );
+}

--- a/crates/rsvelte_core/tests/snippet_hoist_optional_render_3269.rs
+++ b/crates/rsvelte_core/tests/snippet_hoist_optional_render_3269.rs
@@ -1,0 +1,78 @@
+//! An optional `{@render sn?.()}` inside a hoistable snippet must not block the
+//! module-scope hoist (issue #3269). rsvelte's hoist walker had no arm for
+//! `ChainExpression`, so the optional call fell through to the conservative
+//! `_ => false` and the snippet stayed inside the component function — one
+//! closure per instance instead of one per module. Every expectation here is
+//! the official compiler's output for the same source.
+
+use rsvelte_core::{CompileOptions, GenerateMode, compile, compiler::CssMode};
+
+fn compiled(src: &str, generate: GenerateMode, dev: bool) -> String {
+    compile(
+        src,
+        CompileOptions {
+            filename: Some("A.svelte".to_string()),
+            generate,
+            dev,
+            css: CssMode::External,
+            ..Default::default()
+        },
+    )
+    .expect("must compile")
+    .js
+    .code
+}
+
+fn source(template: &str) -> String {
+    format!("<script>\n\tlet flag = $state(true);\n</script>\n{template}\n")
+}
+
+/// A hoisted snippet is declared before `export default`.
+fn is_hoisted(out: &str, needle: &str) -> bool {
+    match (out.find(needle), out.find("export default")) {
+        (Some(at), Some(default_at)) => at < default_at,
+        _ => false,
+    }
+}
+
+const OPTIONAL_INNER: &str = "{#snippet outer()}{#snippet sn()}<i>x</i>{/snippet}{@render sn?.()}{/snippet}{@render outer()}";
+
+#[test]
+fn an_optional_inner_render_still_hoists() {
+    let server = compiled(&source(OPTIONAL_INNER), GenerateMode::Server, false);
+    assert!(
+        is_hoisted(&server, "function outer($$renderer)"),
+        "the snippet has no component-state dependency, so it hoists:\n{server}"
+    );
+    // Dev wraps the same declaration in `$.wrap_snippet`.
+    for (dev, needle) in [
+        (false, "const outer = ($$anchor)"),
+        (true, "const outer = $.wrap_snippet("),
+    ] {
+        let client = compiled(&source(OPTIONAL_INNER), GenerateMode::Client, dev);
+        assert!(
+            is_hoisted(&client, needle),
+            "dev={dev}: the snippet hoists on the client too:\n{client}"
+        );
+    }
+}
+
+#[test]
+fn an_optional_render_with_an_argument_still_hoists() {
+    let template = "{#snippet outer()}{#snippet sn(v)}<i>{v}</i>{/snippet}{@render sn?.(1)}{/snippet}{@render outer()}";
+    let server = compiled(&source(template), GenerateMode::Server, false);
+    assert!(
+        is_hoisted(&server, "function outer($$renderer)"),
+        "an argument does not change the hoist decision:\n{server}"
+    );
+}
+
+#[test]
+fn a_state_dependency_still_blocks_the_hoist() {
+    let template = "{#snippet outer()}{#snippet sn()}<i>{flag}</i>{/snippet}{@render sn?.()}{/snippet}{@render outer()}";
+    let server = compiled(&source(template), GenerateMode::Server, false);
+    assert!(
+        !is_hoisted(&server, "function outer($$renderer)"),
+        "reading component state must keep the snippet nested:\n{server}"
+    );
+}


### PR DESCRIPTION
Four client-output divergences, each reduced to the enumeration or the rule that produced it and each verified against the official compiler over a grid rather than a single repro.

Every grid figure below is a paired measurement: two pinned `compile_one` builds — one from the merge base, one from this branch — each copied out of the shared target directory before use and md5-checked before and after the run, so "before" and "after" are the same inputs through two known binaries.

Closes #3229
Closes #3230
Closes #3249
Closes #3269

## #3229 — a numeric `$props()` key reaches `$.prop` as a string

Upstream passes `b.literal(key.value)`, so a numeric destructuring key stays a **number** and carries its **value**, not its spelling. rsvelte quoted every key unconditionally, and phase 2 stored the key with an `as i64` cast.

- `phase 3` — `transform_props_destructuring` now computes the key's JS literal spelling once (`prop_key_js_literal`, which parses the raw key text and only treats an actual `NumericLiteral` as a number). The `seen` list feeding `$.rest_props` holds literal spellings for the same reason, since upstream excludes a numeric key as a number.
- `phase 2` — `prop_alias` for a numeric key is formatted with the shared `js_number_to_string` instead of `(*n as i64).to_string()`.

The cast was a second, unreported bug the grid found: `let { 0.5: a } = $props(); {a}` read `$$props['0']`.

| key | before | after / official |
|---|---|---|
| `0` | `$.prop($$props, '0', 7)` | `$.prop($$props, 0, 7)` |
| `0x10` | `$.prop($$props, '0x10', 7)` | `$.prop($$props, 16, 7)` |
| `1e3` | `$.prop($$props, '1e3', 7)` | `$.prop($$props, 1000, 7)` |
| `'0'` | `$.prop($$props, '0', 7)` | unchanged (a string key) |
| `0.5`, read-only | `$$props['0']` | `$$props['0.5']` |

Grid: 9 patterns × 2 uses × 3 targets, 54 cells — 24 diverging → 0.

## #3230 — a component prop aliasing a local binding is passed by value

`is_expression_known_json`'s Identifier arm answered `true` for any `is_function()` binding. Upstream's `scope.evaluate` recurses into the initializer and a function expression falls through to `UNKNOWN` — a function is never a *known value*. Reading a function is kept out of `has_state` by the separate `!binding.is_function()` term in `Identifier.js`, which rsvelte already ports one level up in `identifier_has_reactive_state`; the arm removed here was a second, contradictory rule for the same question.

So `const h = () => {}; const cb = h;` now yields `{ get cb() { return cb; } }` and `$.spread_props(() => ({ cb }))`. A direct function expression, a literal, and a `$state` alias whose value is known are unchanged.

Grid: 11 declaration kinds × 6 hosts × 3 targets, 198 cells — 50 diverging → 0.

## #3249 — a logical or regex `const` initializer never folds

Two independent causes, both in what phase 2 keeps:

1. `init_needs_expr_json` enumerated 7 of the 8 expression kinds the consumers can evaluate; `LogicalExpression` was the eighth. Adding it fixed all four logical rows on all three targets — the consumer arms already existed.
2. A regex literal set `binding.initial = Some("/ab/g")` (the `raw` arm fires before the `Regex(_) => None` arm), which is a value the source-text model cannot represent **and** which closes the `initial.is_none() && init_expr_json` path in both evaluators. `initial` is now `None` for a regex and the node is kept as JSON instead.

One more divergence surfaced once the fold was reachable: the server evaluated a regex to `EvalValue::Str`, so `{typeof c}` rendered `string`. It is `EvalValue::Regex` now, as in the client — the two ports of one function agreeing is the point.

Grid: 27 initializer kinds × 7 read shapes × 3 targets, 567 cells — 160 diverging → 0.

## #3269 — an optional `{@render x?.()}` blocks the snippet hoist

The hoist walker (`can_hoist_snippet` → `expression_only_uses_params*`) had no arm for `ChainExpression`, so `sn?.()` hit the conservative `_ => false`. Both the typed and the JSON walker now recurse through it. The optional marker wraps the same call the non-optional spelling produces, and upstream sees only the scope's references.

Not just a byte difference: the nested form allocates the closure once per component instance.

Grid: 11 shapes × 3 targets, 33 cells — 15 diverging → 0, with the two "neither hoists" controls (a `$state` read, an `{#if}` wrapper) still not hoisting. The count is larger than the issue's, because an optional MEMBER read in a snippet body (`{obj?.a}`) is blocked by the same missing arm — the issue's axis only varied the render tag.

## Tests

One file per issue under `crates/rsvelte_core/tests/`, every expectation taken from the official compiler's output for the same source, each with the negative control the issue names (a string key, a direct function expression, a state dependency).

Reverting the five source hunks and re-running the four files fails 11 of 15 tests, each at the assertion the corresponding fix targets, while the four control tests keep passing — so no test is asserting something the tree already did.
