### PR TITLE
fix(parse): reject the two characters oxc calls whitespace and ECMAScript does not

### DIFF
--- a/.changeset/script-irregular-whitespace.md
+++ b/.changeset/script-irregular-whitespace.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/compiler": patch
+---
+
+Reject `U+200B` (ZWSP) and `U+0085` (NEL) in a `<script>` body, as upstream does. Neither is ECMAScript `WhiteSpace` or `LineTerminator` — `U+200B` has been `Cf` rather than `Zs` since Unicode 4.0.1 — so acorn, and therefore the official compiler, raises `js_parse_error` on a program that carries one between tokens. oxc's `is_irregular_whitespace` admits both, so rsvelte compiled them. The verdict now comes from the `irregular_whitespaces` spans oxc itself reports, filtered by the ECMAScript set, which leaves the same character accepted inside a string literal or a comment.

--- a/crates/rsvelte_core/src/ast/oxc_program.rs
+++ b/crates/rsvelte_core/src/ast/oxc_program.rs
@@ -3,7 +3,7 @@ use oxc_ast::ast::Program;
 use oxc_ast_visit::VisitMut;
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_parser::Parser;
-use oxc_span::SourceType;
+use oxc_span::{SourceType, Span};
 use self_cell::self_cell;
 
 struct ProgramOwner<'source> {
@@ -21,6 +21,7 @@ impl ProgramOwner<'_> {
 struct ParsedProgram<'alloc> {
     program: Program<'alloc>,
     diagnostics: Vec<OxcDiagnostic>,
+    irregular_whitespaces: Vec<Span>,
     panicked: bool,
 }
 
@@ -53,6 +54,7 @@ impl<'source> RetainedProgram<'source> {
                 ParsedProgram {
                     program: parsed.program,
                     diagnostics: parsed.diagnostics.into_vec(),
+                    irregular_whitespaces: parsed.irregular_whitespaces.into_vec(),
                     panicked: parsed.panicked,
                 }
             },
@@ -92,6 +94,14 @@ impl<'source> RetainedProgram<'source> {
 
     pub fn diagnostics(&self) -> &[OxcDiagnostic] {
         &self.borrow_dependent().diagnostics
+    }
+
+    /// Spans oxc classified as irregular whitespace. Two of the characters it
+    /// admits there are not ECMAScript whitespace at all, so acorn — and so
+    /// upstream — rejects the program the parser accepted.
+    #[must_use]
+    pub fn irregular_whitespaces(&self) -> &[Span] {
+        &self.borrow_dependent().irregular_whitespaces
     }
 
     #[must_use]

--- a/crates/rsvelte_core/src/compiler/phases/1_parse/read/expression.rs
+++ b/crates/rsvelte_core/src/compiler/phases/1_parse/read/expression.rs
@@ -6793,7 +6793,13 @@ pub fn parse_program_with_error<'a>(
             SourceType::mjs()
         };
         let result = OxcParser::new(allocator, params.content, source_type).parse();
-        convert_parsed_program(arena, &result.program, &result.diagnostics, params)
+        convert_parsed_program(
+            arena,
+            &result.program,
+            &result.diagnostics,
+            &result.irregular_whitespaces,
+            params,
+        )
     })
 }
 
@@ -6807,8 +6813,13 @@ pub fn parse_program_retained_with_error<'ast, 'source>(
 ) {
     let retained =
         crate::ast::oxc_program::RetainedProgram::parse(params.content, params.is_typescript);
-    let (program, parse_error) =
-        convert_parsed_program(arena, retained.program(), retained.diagnostics(), params);
+    let (program, parse_error) = convert_parsed_program(
+        arena,
+        retained.program(),
+        retained.diagnostics(),
+        retained.irregular_whitespaces(),
+        params,
+    );
     (program, parse_error, retained)
 }
 
@@ -7036,10 +7047,29 @@ fn realign_missing_semicolon(content: &str, at: usize, message: &str) -> (usize,
     (i, "Unexpected token".to_string())
 }
 
+/// The first offset oxc classified as irregular whitespace that ECMAScript does
+/// not admit as whitespace at all. oxc's `is_irregular_whitespace` spans
+/// `U+2000..=U+200B` and includes `U+0085`, while `WhiteSpace` is `Zs` plus the
+/// four fixed code points — so `U+200B` and `U+0085` parse here and are
+/// `Unexpected character` for acorn, and so for upstream. Keying on the spans
+/// the parser itself reports is what keeps a string literal or a comment
+/// containing one of them accepted, as upstream accepts it.
+fn first_non_ecmascript_whitespace(content: &str, irregular: &[oxc_span::Span]) -> Option<usize> {
+    irregular
+        .iter()
+        .filter_map(|span| {
+            let at = span.start as usize;
+            let ch = content.get(at..)?.chars().next()?;
+            (!super::super::parser::is_js_whitespace(ch)).then_some(at)
+        })
+        .min()
+}
+
 fn convert_parsed_program<'ast>(
     arena: &ParseArena,
     program: &OxcProgram<'_>,
     diagnostics: &[OxcDiagnostic],
+    irregular_whitespaces: &[oxc_span::Span],
     params: ProgramParseParams<'_, '_>,
 ) -> (Expression<'ast>, Option<crate::error::ParseError>) {
     let ProgramParseParams {
@@ -7055,7 +7085,7 @@ fn convert_parsed_program<'ast>(
         // Mirror upstream acorn's throw-on-error behaviour: capture the first
         // parse error (acorn reports `err.pos` where it stopped consuming
         // input; OXC's first label is the closest equivalent).
-        let mut parse_error = diagnostics
+        let reported_at = diagnostics
             .iter()
             .find(|d| !is_acorn_unchecked_ts_grammar_rule(d))
             .map(|first_error| {
@@ -7064,18 +7094,38 @@ fn convert_parsed_program<'ast>(
                     .first()
                     .map(|label| (label.offset() as usize).min(content.len()))
                     .unwrap_or(0);
-                let (at, message) = realign_missing_semicolon(content, at, &first_error.message);
-                let pos = at + offset;
-                crate::error::ParseError::svelte("js_parse_error", message, (pos, pos))
+                realign_missing_semicolon(content, at, &first_error.message)
             });
+        let mut reported_at = reported_at;
+        let mut parse_error = reported_at.as_ref().map(|(at, message)| {
+            let pos = at + offset;
+            crate::error::ParseError::svelte("js_parse_error", message.clone(), (pos, pos))
+        });
 
         if parse_error.is_none()
             && let Some((at, message)) = acorn_only_violation(program, content, is_typescript)
         {
             let pos = at as usize + offset;
+            reported_at = Some((at as usize, message.clone()));
             parse_error = Some(crate::error::ParseError::svelte(
                 "js_parse_error",
                 message,
+                (pos, pos),
+            ));
+        }
+
+        // acorn stops at the first thing it cannot read, so a character it does
+        // not accept as whitespace outranks any error further along the source.
+        if let Some(at) = first_non_ecmascript_whitespace(content, irregular_whitespaces)
+            && reported_at
+                .as_ref()
+                .is_none_or(|(reported, _)| at < *reported)
+        {
+            let ch = content[at..].chars().next().unwrap_or('\u{fffd}');
+            let pos = at + offset;
+            parse_error = Some(crate::error::ParseError::svelte(
+                "js_parse_error",
+                format!("Unexpected character '{ch}'"),
                 (pos, pos),
             ));
         }

--- a/crates/rsvelte_core/tests/js_script_irregular_whitespace_3312.rs
+++ b/crates/rsvelte_core/tests/js_script_irregular_whitespace_3312.rs
@@ -1,0 +1,132 @@
+//! oxc's `is_irregular_whitespace` admits `U+2000..=U+200B` and `U+0085`, while
+//! ECMAScript `WhiteSpace` is the `Zs` category plus four fixed code points —
+//! `U+200B` (ZWSP, `Cf` since Unicode 4.0.1) and `U+0085` (NEL, `Cc`) are in
+//! neither `WhiteSpace` nor `LineTerminator`. acorn agrees with the spec and
+//! rejects both, so upstream rejects a `<script>` that rsvelte compiled
+//! (issue #3312; #2582 recorded the `U+0085` half as unreachable from rsvelte's
+//! own code, which the `irregular_whitespaces` spans make reachable).
+//!
+//! Every verdict below was measured against the official compiler at
+//! `svelte@5.56.8`, not recalled: `Unexpected character '<ch>'` with `start` ==
+//! `end` at the offending character.
+
+use rsvelte_core::{CompileOptions, GenerateMode, compile, compiler::CssMode};
+
+fn diagnostic(
+    src: &str,
+    generate: GenerateMode,
+) -> Option<(Option<String>, String, Option<(u32, u32)>)> {
+    compile(
+        src,
+        CompileOptions {
+            filename: Some("Test.svelte".to_string()),
+            generate,
+            dev: false,
+            css: CssMode::External,
+            ..Default::default()
+        },
+    )
+    .err()
+    .map(|e| {
+        let d = e.diagnostic();
+        (d.code, d.message, d.span)
+    })
+}
+
+/// The slots the issue names. Each returns a source with `c` spliced in; the
+/// injected character is the only occurrence of `c`, so the test can locate it
+/// rather than hard-coding an offset that a wording change would silently move.
+const CODE_SLOTS: [fn(char) -> String; 5] = [
+    |c| format!("<script>\n\tlet{c} x = 1;\n</script>\n"),
+    |c| format!("<script>\n\tlet x{c} = 1;\n</script>\n"),
+    |c| format!("<script>\n\tlet a = 1; let b = a{c} + 1;\n</script>\n"),
+    |c| format!("<script>\n{c}let x = 1;\n</script>\n"),
+    |c| format!("<script>\n\tlet x = 1;\n\t${c}: console.log(x);\n</script>\n"),
+];
+
+/// The two slots where the character is data, not source layout. Upstream
+/// accepts all 17 characters here, so a fix that scans the source text instead
+/// of the parser's own spans fails these and not the ones above.
+const OPAQUE_SLOTS: [fn(char) -> String; 2] = [
+    |c| format!("<script>\n\tlet x = \"a{c}b\";\n</script>\n"),
+    |c| format!("<script>\n\t// a{c}b\n\tlet x = 1;\n</script>\n"),
+];
+
+/// oxc classifies these as irregular whitespace and ECMAScript does not accept
+/// them at all.
+const REJECTED: [char; 2] = ['\u{200b}', '\u{85}'];
+
+/// The rest of oxc's irregular set. Every one is real ECMAScript `WhiteSpace`,
+/// so the same filter that rejects the two above must leave all of these
+/// accepted — including `U+200A`, whose only difference from `U+200B` is the
+/// last digit of the code point.
+const ACCEPTED: [char; 15] = [
+    '\u{b}', '\u{c}', '\u{a0}', '\u{feff}', '\u{1680}', '\u{2000}', '\u{2001}', '\u{2005}',
+    '\u{2009}', '\u{200a}', '\u{202f}', '\u{205f}', '\u{3000}', '\u{2028}', '\u{2029}',
+];
+
+#[test]
+fn zwsp_and_nel_are_rejected_where_upstream_rejects_them() {
+    for ch in REJECTED {
+        for (i, slot) in CODE_SLOTS.iter().enumerate() {
+            let src = slot(ch);
+            let at = src
+                .find(ch)
+                .expect("the injected character is in the source") as u32;
+            for generate in [GenerateMode::Client, GenerateMode::Server] {
+                let Some((code, message, span)) = diagnostic(&src, generate) else {
+                    panic!(
+                        "U+{:04X} in slot {i} ({generate:?}) compiled; upstream rejects it",
+                        ch as u32
+                    );
+                };
+                assert_eq!(
+                    code.as_deref(),
+                    Some("js_parse_error"),
+                    "U+{:04X} in slot {i} ({generate:?})",
+                    ch as u32
+                );
+                assert_eq!(
+                    message,
+                    format!("Unexpected character '{ch}'\nhttps://svelte.dev/e/js_parse_error"),
+                    "U+{:04X} in slot {i} ({generate:?})",
+                    ch as u32
+                );
+                assert_eq!(
+                    span,
+                    Some((at, at)),
+                    "U+{:04X} in slot {i} ({generate:?}) — upstream reports the character itself",
+                    ch as u32
+                );
+            }
+        }
+    }
+}
+
+#[test]
+fn a_string_or_comment_carrying_one_still_compiles() {
+    for ch in REJECTED.iter().chain(ACCEPTED.iter()) {
+        for (i, slot) in OPAQUE_SLOTS.iter().enumerate() {
+            let src = slot(*ch);
+            assert!(
+                diagnostic(&src, GenerateMode::Client).is_none(),
+                "U+{:04X} in opaque slot {i} was rejected; upstream accepts it",
+                *ch as u32
+            );
+        }
+    }
+}
+
+#[test]
+fn real_js_whitespace_in_oxcs_irregular_set_still_compiles() {
+    for ch in ACCEPTED {
+        for (i, slot) in CODE_SLOTS.iter().enumerate() {
+            let src = slot(ch);
+            assert!(
+                diagnostic(&src, GenerateMode::Client).is_none(),
+                "U+{:04X} in slot {i} was rejected; it is ECMAScript whitespace",
+                ch as u32
+            );
+        }
+    }
+}


### PR DESCRIPTION
Closes #3312

`U+200B` (ZWSP) between two tokens in a `<script>` body compiled here and is a `js_parse_error` upstream. It is not ECMAScript whitespace: `WhiteSpace` is the `Zs` category plus four fixed code points, and `U+200B` has been `Cf` since Unicode 4.0.1. oxc's `is_irregular_whitespace` spans `U+2000..=U+200B` — one code point past `Zs` — and also lists `U+0085` (NEL, `Cc`), so both parse here and neither parses in acorn.

## The fix is keyed on the parser's own spans, not on a source scan

#2582 closed the `U+0085` half as unreachable from rsvelte's code, with this reasoning:

> rejecting NEL in rsvelte's own scanner would not help, because the acceptance happens inside `oxc_parser`. A local check would have to duplicate the parser's notion of where JS whitespace may appear, which is the kind of second definition that goes stale.

That is right about a source scan and wrong about the only option. `ParserReturn` already exposes `irregular_whitespaces: Box<[Span]>` — the parser reports **where** it accepted an irregularity. Filtering that list by `is_js_whitespace` (the ECMAScript set rsvelte already spells out for its own scanners) needs no second notion of where whitespace may appear: a `U+200B` inside a string literal or a comment never enters the list, so it stays accepted, as upstream accepts it. That is the `a_string_or_comment_carrying_one_still_compiles` test, and it is the cell a source scan fails.

`RetainedProgram` now carries the same spans so both parse entry points get the check.

acorn stops at the first thing it cannot read, so the character outranks a diagnostic further along the source and loses to one before it.

## Expectations are measured, not recalled

`scripts`-free grid against `svelte@5.56.8`: 17 characters × 5 code slots + 2 opaque slots. Exactly **10 cells reject** — `U+200B` and `U+0085` in each of the five code slots — with `Unexpected character '<ch>'` and `start == end` at the character. Every other cell accepts, including `U+200A`, whose only difference from `U+200B` is the last digit of the code point, and including `U+2028`/`U+2029` in the `$`/`:` gap and inside a comment (I had guarded those two as "different construct"; the oracle says they compile, so the guards are gone — a skipped cell that actually passes is a fake exclusion).

The 15 accepted characters are all of oxc's irregular set that ECMAScript does accept, and they are asserted in every code slot. Without that half the change is equally satisfied by "reject every irregular whitespace", which is not the rule.

## Negative control

Feeding the filter an empty span list fails `zwsp_and_nel_are_rejected_where_upstream_rejects_them` at the first cell with `U+200B in slot 0 (Client) compiled; upstream rejects it` — the predicted reason — while both control tests stay green, so the fix is what moved and not the harness.

## Side effect worth naming

This also closes the rsvelte side of **#2582** (`U+0085`), which was filed against oxc and closed as out of reach. The oxc range is still off by one; that is worth reporting there separately, but rsvelte no longer depends on it being fixed. I have not closed #2582 — it is an oxc issue and its subject is oxc's behaviour, which has not changed.

## Verification

- `cargo test -p rsvelte_core --test js_script_irregular_whitespace_3312` — 3/3.
- `cargo test -p rsvelte_core --test compiler_errors --test compiler_fixtures --test js_whitespace_parser_2561 --test js_whitespace_trim_2502` — 2 / 3 / 10 / 5 passed.
- `cargo test --release -p rsvelte_core --test parser_fixtures --test ssr --test validator` — see the run in this PR's checks.
