### PR TITLE
fix: hmr output parity, cssHash at the NAPI boundary, and two fabricated js.map fields

### DIFF
--- a/.changeset/hmr-map-fields-and-css-hash.md
+++ b/.changeset/hmr-map-fields-and-css-hash.md
@@ -1,0 +1,10 @@
+---
+"@rsvelte/compiler": patch
+"@rsvelte/vite-plugin-svelte-native": patch
+---
+
+`hmr: true` now matches the official compiler in four places it diverged in: the `import.meta.hot.accept` hook calls `$.cleanup_styles(<hash>)` before the update when the component has CSS (so injected stylesheets no longer accumulate across hot updates), `customElements.define` is guarded by `customElements.get(tag) == null` (a second hot update of a custom-element component used to throw), and `is_standalone` is suppressed for a root component but *not* for a root `{@render}` — which restores the anchor comment on the client and the trailing `<!---->` hydration anchor on the server.
+
+`js.map` no longer carries a `file` key (upstream's esrap-produced map has none; rsvelte emitted a constant `"input.svelte.js"`), and `outputFilename` no longer prefixes `js.map.sources` with `./` — the relative path is joined verbatim, as `get_relative_path` does upstream. The CSS map keeps its `file` key, which upstream does set.
+
+`cssHash` works at the NAPI boundary. `compileWithCssHash` now invokes the callback the way the official compiler does — one `{ hash, css, name, filename }` argument, returning the scope class — so `({ hash, css }) => \`x-${hash(css)}\`` works verbatim, and a throwing callback rejects the returned promise instead of terminating the process. The synchronous entries (`compile`, `compileEnvelope`, …) now *reject* a function-valued `cssHash` naming `compileWithCssHash`, rather than dropping it and silently returning a different scope class.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1091,6 +1091,11 @@ jobs:
       - name: Run NAPI option-boundary gate
         run: pnpm run test:napi-options
 
+      # Again a separate process, for the same reason: this one is the only gate
+      # that drives the `cssHash` callback across the boundary.
+      - name: Run NAPI cssHash gate
+        run: pnpm run test:napi-csshash
+
   vps-sourcemaps:
     name: VPS postprocessing source-map parity
     runs-on: ubuntu-latest

--- a/apps/npm/vite-plugin-svelte-native/index.cjs
+++ b/apps/npm/vite-plugin-svelte-native/index.cjs
@@ -54,32 +54,6 @@ function prepareCompileOptions(options) {
 	return { options: resolved, warningFilter: hasWarningFilter ? warningFilter : undefined };
 }
 
-// Port of Svelte's `hash()` (submodules/svelte/packages/svelte/src/utils.js),
-// handed to a user `cssHash` callback so custom scope classes match upstream's digest.
-const regexReturnCharacters = /\r/g;
-function hash(str) {
-	str = str.replace(regexReturnCharacters, '');
-	let h = 5381;
-	let i = str.length;
-	while (i--) h = ((h << 5) - h) ^ str.charCodeAt(i);
-	return (h >>> 0).toString(36);
-}
-
-// Adapt a user `cssHash` to the bridge shape. It must never reject: a rejected
-// Promise crossing the NAPI boundary can crash V8 during threadsafe-function
-// teardown — so a throw becomes `{ error }` (Rust turns it into a compile failure)
-// and a non-string return becomes `{ value: null }` (Rust falls back to the default hash).
-function makeCssHashCallback(userCssHash) {
-	return async (name, filename, css) => {
-		try {
-			const result = await userCssHash({ hash, css, name, filename });
-			return { value: typeof result === 'string' ? result : null };
-		} catch (err) {
-			return { error: err instanceof Error ? err.message : String(err) };
-		}
-	};
-}
-
 function applyWarningFilter(result, warningFilter) {
 	if (!warningFilter || result == null) return result;
 	const warnings = result.warnings;
@@ -183,11 +157,9 @@ async function compileAsync(source, options) {
 	const { options: resolved, warningFilter } = prepareCompileOptions(options);
 	if (typeof options?.cssHash === 'function') {
 		// The bridge entry returns a plain (JSON) CompileResult, not an envelope.
-		const result = await binding.compileWithCssHash(
-			source,
-			resolved,
-			makeCssHashCallback(options.cssHash),
-		);
+		// The callback is handed straight through: Rust calls it with upstream's
+		// own `{ hash, css, name, filename }` object and reads the string back.
+		const result = await binding.compileWithCssHash(source, resolved, options.cssHash);
 		return applyWarningFilter(result, warningFilter);
 	}
 	if (resolved?.modernAst) {
@@ -254,6 +226,11 @@ module.exports.compileModuleBuffers = binding.compileModuleBuffers;
 module.exports.compileBatch = compileBatch;
 module.exports.compileBatchRaw = binding.compileBatch;
 module.exports.compileAsync = compileAsync;
+// The only entry that honours a function-valued `cssHash`. The callback takes
+// upstream's single `{ hash, css, name, filename }` argument and returns the
+// scope class; the synchronous entries reject a function `cssHash` rather than
+// dropping it. Returns a plain CompileResult (no envelope).
+module.exports.compileWithCssHash = binding.compileWithCssHash;
 module.exports.compileBatchAsync = compileBatchAsync;
 module.exports.compileEnvelopeAsync = binding.compileEnvelopeAsync;
 module.exports.compileBatchAsyncRaw = binding.compileBatchAsync;

--- a/apps/npm/vite-plugin-svelte-native/index.d.ts
+++ b/apps/npm/vite-plugin-svelte-native/index.d.ts
@@ -46,7 +46,8 @@ export interface CompileOptions {
 	 * Custom hash function for CSS scoping. Called once per component with the
 	 * component's CSS; the returned string becomes the scope class. Because it
 	 * depends on the CSS, it is bridged into the compiler through a threadsafe
-	 * callback and is only supported on the async path — use `compileAsync`.
+	 * callback and is only supported on the async path — use `compileAsync`
+	 * (or `compileWithCssHash`, which it routes to).
 	 * The synchronous `compile` throws if given a `cssHash` function; pass a
 	 * pre-computed constant via `cssHashOverride` instead.
 	 */
@@ -273,6 +274,19 @@ export function decodeBatch(
 export function compileAsync(
 	source: string,
 	options?: CompileOptions,
+): Promise<CompileResult>;
+
+/**
+ * The one entry that honours a function-valued `cssHash`. The callback receives
+ * upstream's single `{ hash, css, name, filename }` argument and returns the
+ * scope class; a throw aborts the compile. `compileAsync` routes here
+ * automatically when `options.cssHash` is a function, so most callers never need
+ * this directly.
+ */
+export function compileWithCssHash(
+	source: string,
+	options: CompileOptions | undefined | null,
+	cssHash: NonNullable<CompileOptions['cssHash']>,
 ): Promise<CompileResult>;
 
 /** Async variant of {@link compileBatch}. */

--- a/compatibility/gate-coverage.md
+++ b/compatibility/gate-coverage.md
@@ -111,6 +111,7 @@ samples) — see `AGENTS.md` § "Generated shape matrix" and issue #2281.
 | 25 | Differential output-preservation corpus hash | per `.svelte` source × client/server/client-dev/server-dev hash from base-core vs merge-ref-core | changes outside `crates/rsvelte_core`; every PR without the maintainer-applied `output-preserving` label | [S] |
 | 26 | esrap generated-output corpus | parsed JS output × official/rsvelte tree × 4 targets; AST equivalence, comment kind/body sequence, code/map equality, map bounds/order | production synthetic AST spans and whether a mapping points at the corresponding source token | [S] |
 | 27 | LSP differential parity | normalized JSON response field per request against the pinned official server and selected upstream snapshots | **every server notification**; incremental edit and resolve sequences; **inside a corpus `(file, method)`, everything but the divergent-request count** | [S] [D] |
+| 38 | NAPI `cssHash` | the scope class the callback produces, and the callback's own argument list, against **official** | one component shape and one option set; only `css.code` / the class in `js.code`; nothing about the wasm or facade ports of the same option | [S] |
 
 Cross-cutting blind spots (**ratchet keys losing in both directions**, path filters, ratchet-doc
 drift, vacuity floors, the **performance**
@@ -2177,7 +2178,7 @@ both directions, so a new field with no case fails and a case naming a deleted f
 symbols only resolve when Node dlopens the addon), there is no `crates/rsvelte_napi/tests/`, and
 before this gate nothing anywhere crossed the JS-object → `CompileOptions` mapping per key.
 Deleting a field, or dropping its arm from `into_compile_options`, failed nothing. Denominator:
-**38 of 40 declared keys** are crossed; the 2 exclusions are listed in the script's `UNCOVERED`
+**39 of 41 declared keys** are crossed; the 2 exclusions are listed in the script's `UNCOVERED`
 map with their reasons, and the reasons are themselves asserted to exist.
 
 ### 22a — it compares rsvelte against rsvelte, never against official [S]
@@ -2194,10 +2195,15 @@ gate in this repo compares rsvelte's option behaviour to the official compiler's
 `napiObjectStructs()` reads the `pub <field>:` lines of the four `#[napi(object)]` option
 structs. An option a real caller passes that the boundary never declares is therefore not a
 failure — it is not even a row. Discriminating case: `warningFilter` and `cssHash` are genuine
-`svelte/compiler` options; the addon declares neither, and the shim resolves them in JS
-(`apps/npm/vite-plugin-svelte-native/index.cjs:57-77`). The denominator prints 40 and never
-mentions them. This is the #2438 shape one level out: that bug was a *declared* field nothing
-read; this blind spot is an *undeclared* option nothing accepts.
+`svelte/compiler` options; the addon declared neither, and the shim resolved them in JS
+(`apps/npm/vite-plugin-svelte-native/index.cjs`). The denominator printed 40 and never mentioned
+them. This is the #2438 shape one level out: that bug was a *declared* field nothing read; this
+blind spot is an *undeclared* option nothing accepts. **#3294 is the shipped instance**: a
+function-valued `cssHash` was dropped at this boundary with no error, so the component got a
+different scope class than the caller asked for, in `css.code` and in every `class` attribute of
+`js.code`. `cssHash` is now declared (and rejected) here, which puts it in the denominator; the
+option's *behaviour* is gate 38. `warningFilter` is still undeclared and still invisible to the
+count.
 
 ### 22c — one entry point per surface, and per-entry-point consistency is not asserted [S]
 
@@ -3051,6 +3057,62 @@ truncated-print skip — is therefore factored into `idempotency_report` and pin
 test (`idempotency_report_tests`), which is where that failure mode is caught. The remaining
 uncovered case is a break in the *re-application* itself (a second pass that silently becomes a
 no-op for the wrong reason); nothing here would see it.
+
+---
+
+## 38. NAPI `cssHash` — `scripts/dev/test-napi-css-hash.mjs`
+
+**Unit.** One component with one scoped selector, compiled through the raw addon for `client` and
+`server` under five callback shapes, compared to the **official** compiler's `css.code` for the
+same callback; plus the callback's own argument list, the rejection the synchronous entries raise,
+and the two degenerate returns (a non-string, and a throw). Hard gate, no ratchet.
+
+**Why it exists.** `cssHash` is the one compile option whose value is a *callback*, and that makes
+it invisible to gate 22 twice over. It was not declared at the boundary, so the exhaustiveness half
+had no row for it (22b); and gate 22's discrimination test is "do the two results differ", which is
+exactly what a *dropped* option fails — but the drop was at the JS-object decode, before any
+comparison, and the option never appeared in the denominator to be tested. #3294 is what that cost:
+`compile()` returned a wrong scope class with no error, and `compileWithCssHash` invoked the
+callback with three positional arguments (`name`, `filename`, `css`) where upstream passes one
+object carrying `hash`, so the documented `({ hash, css }) => …` idiom threw, and every failure on
+that entry was an **uncaught exception** rather than a rejected promise.
+
+**[D] Positive control on the last of those.** napi's `ThreadsafeFunction::call_async` documents
+that a JS throw is routed through `napi_fatal_exception`, which terminates the process;
+`call_async_catch` is the one that returns `Err`. Built with `call_async`, this gate's throwing-
+callback case kills the runner (the `try`/`catch` around the `await` never runs, and the awaited
+promise settles as `oneshot canceled`); with `call_async_catch` it rejects with the callback's own
+message. No other gate distinguishes the two, because `test-vps-shim.mjs` reaches this entry only
+through an adapter that catches the throw in JavaScript first.
+
+### 38a — one component, one option set [S]
+
+Every case compiles the same `<p class="k">` + one rule, with `filename: 'Probe.svelte'` and
+`css: 'external'`. A `cssHash` interaction with `customElement`, `dev`, a preprocessor map, or a
+component with several scoped selectors is not in the population.
+
+### 38b — only `css.code` and the class inside `js.code` are compared [S]
+
+The scope class is extracted from official's `css.code` with a regex and looked for in rsvelte's
+`js.code`; the rest of `js.code`, the maps and the warnings are not compared to official on this
+gate. A `cssHash` that reached the stylesheet and not (say) the server's `$.attr_class` argument
+list would pass, since `includes()` only needs one occurrence.
+
+### 38c — the other two ports of the same option are not here [S]
+
+`cssHash` is implemented three times: the napi bridge, the wasm bridge
+(`crates/rsvelte_lint_bindings/src/compiler_wasm/mod.rs`, exercised only by
+`scripts/dev/test-wasm-compile-options.mjs`, which compares rsvelte to rsvelte), and the
+`rsvelte` facade's `options.rs`, which no gate drives at all. This is the "two ports of one
+function and no gate compares the ports" shape recorded for the constant fold: the wasm port
+already passed the official argument shape while the napi port did not, and nothing would have
+reported the disagreement.
+
+### 38d — it needs a freshly built addon and says nothing when it cannot load one [S]
+
+Like gate 22 it exits **2** when `apps/npm/vite-plugin-svelte-native-<triple>/rsvelte.node` is
+absent, which CI treats as a failure but a local run can silently skip. A **stale** addon is worse:
+it loads, and every assertion then measures a binary that predates the change under test.
 
 ---
 

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
@@ -2288,13 +2288,21 @@ pub(crate) fn transform_client(
         //   if (import.meta.hot) {
         //     Component = $.hmr(Component);
         //     import.meta.hot.accept((module) => {
+        //       $.cleanup_styles('<hash>');   // only when the component has CSS
         //       Component[$.HMR].update(module.default);
         //     });
         //   }
+        // The `cleanup_styles` call removes the previous version's injected
+        // stylesheet, so rules do not accumulate across hot updates.
+        let cleanup_styles = if analysis.css.hash.is_empty() {
+            String::new()
+        } else {
+            format!("\t\t$.cleanup_styles('{}');\n", analysis.css.hash)
+        };
         body.push(JsStatement::Raw(
             format!(
-                "if (import.meta.hot) {{\n\t{} = $.hmr({});\n\n\timport.meta.hot.accept((module) => {{\n\t\t{}[$.HMR].update(module.default);\n\t}});\n}}",
-                analysis.name, analysis.name, analysis.name
+                "if (import.meta.hot) {{\n\t{name} = $.hmr({name});\n\n\timport.meta.hot.accept((module) => {{\n{cleanup_styles}\t\t{name}[$.HMR].update(module.default);\n\t}});\n}}",
+                name = analysis.name,
             ).into(),
         ));
 
@@ -2486,14 +2494,35 @@ pub(crate) fn transform_client(
 
         // If tag name is provided, call customElements.define
         if let Some(ref tag) = ce.tag {
-            body.push(b::stmt(
+            let define = b::stmt(
                 &context.arena,
                 b::call(
                     &context.arena,
                     b::member_path(&context.arena, "customElements.define"),
                     vec![b::string(tag.clone()), create_ce],
                 ),
-            ));
+            );
+            if options.hmr {
+                // `customElements.define` throws on an already-defined name, so a
+                // second hot update of the same module would otherwise abort.
+                body.push(b::if_stmt(
+                    &context.arena,
+                    b::binary_str(
+                        &context.arena,
+                        "==",
+                        b::call(
+                            &context.arena,
+                            b::member_path(&context.arena, "customElements.get"),
+                            vec![b::string(tag.clone())],
+                        ),
+                        b::null(),
+                    ),
+                    define,
+                    None,
+                ));
+            } else {
+                body.push(define);
+            }
         } else {
             body.push(b::stmt(&context.arena, create_ce));
         }

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/types.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/types.rs
@@ -1568,8 +1568,6 @@ pub struct TransformOptions {
     pub experimental_async: bool,
 
     /// Whether HMR (Hot Module Replacement) is enabled.
-    /// When true, components need fragment wrappers even in standalone mode
-    /// because $.hmr() uses block/branch effects that need stable anchor nodes.
     pub hmr: bool,
 }
 

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/fragment.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/fragment.rs
@@ -107,6 +107,7 @@ pub fn fragment(
         context.state.analysis,
         context.state.preserve_whitespace,
         context.state.options.preserve_comments,
+        context.state.options.hmr,
     );
 
     // Early return if no nodes
@@ -384,11 +385,8 @@ pub fn fragment(
                     vec![b::id("$$anchor"), text_id],
                 ),
             ));
-        } else if cleaned.is_standalone && !context.state.options.hmr {
+        } else if cleaned.is_standalone {
             // No need to create a template, we can just use the existing block's anchor.
-            // When HMR is enabled, we always need a fragment wrapper because $.hmr()
-            // uses block/branch effects that need a stable anchor node.
-            // Reference: utils.js line 288 checks `!state.options.hmr`
             // Set is_standalone on state so component/render-tag visitors know
             // they need to emit $.next() after $.async() wrapping.
             context.state.is_standalone = true;

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/regular_element.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/regular_element.rs
@@ -903,6 +903,7 @@ pub fn visit_regular_element(
         context.state.analysis,
         preserve_whitespace || node.name == "script",
         context.state.options.preserve_comments,
+        context.state.options.hmr,
     );
 
     // Check if there are any SnippetBlocks in the fragment

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/component.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/component.rs
@@ -2539,6 +2539,7 @@ fn visit_slot_children(
         context.state.analysis,
         context.state.preserve_whitespace,
         context.state.options.preserve_comments,
+        context.state.options.hmr,
     );
 
     // If no trimmed nodes and no hoisted nodes, return empty

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/css.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/css.rs
@@ -625,7 +625,7 @@ fn generate_css_sourcemap(
     }
 
     Some(generate_sourcemap_json(
-        &file_name,
+        Some(&file_name),
         &source_name,
         include_sourcemap_content.then_some(source),
         &mappings_str,

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/js_ast/codegen.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/js_ast/codegen.rs
@@ -2770,45 +2770,39 @@ pub fn get_source_name(
     }
 }
 
-/// Get relative path from `from` to `to`, matching Svelte's `get_relative_path`.
+/// Get relative path from `from` to `to`, matching Svelte's `get_relative_path`
+/// (`utils/mapped_code.js`), which joins the parts verbatim — no `./` prefix.
 fn get_relative_path(from: &str, to: &str) -> String {
-    let from_parts: Vec<&str> = from.split('/').collect();
-    let to_parts: Vec<&str> = to.split('/').collect();
+    let from_parts: Vec<&str> = from.split(['/', '\\']).collect();
+    let to_parts: Vec<&str> = to.split(['/', '\\']).collect();
 
     // Remove filename part from `from`
     let from_dir = &from_parts[..from_parts.len().saturating_sub(1)];
 
     let mut common = 0;
-    for (a, b) in from_dir.iter().zip(to_parts.iter()) {
-        if a == b {
-            common += 1;
-        } else {
-            break;
-        }
+    // Upstream stops shifting once `to_parts` is exhausted (it would otherwise
+    // spin on `undefined === undefined`).
+    while common < from_dir.len() && common < to_parts.len() && from_dir[common] == to_parts[common]
+    {
+        common += 1;
     }
 
-    let ups = from_dir.len() - common;
-    let mut parts: Vec<&str> = vec![".."; ups];
-    for p in &to_parts[common..] {
-        parts.push(p);
-    }
-
-    let result = parts.join("/");
-    if result.starts_with("../") || result.starts_with("./") {
-        result
-    } else {
-        format!("./{}", result)
-    }
+    let mut parts: Vec<&str> = vec![".."; from_dir.len() - common];
+    parts.extend_from_slice(&to_parts[common..]);
+    parts.join("/")
 }
 
 /// Get basename of a path (last component).
 fn get_basename(path: &str) -> &str {
-    path.rsplit('/').next().unwrap_or(path)
+    path.rsplit(['/', '\\']).next().unwrap_or(path)
 }
 
 /// Generate a complete source map JSON string (v3 format).
+///
+/// `file` is `None` for the JS map: upstream builds it through esrap's `print()`,
+/// which never sets the key. Only the CSS map names its output file.
 pub fn generate_sourcemap_json(
-    file: &str,
+    file: Option<&str>,
     source_name: &str,
     source_content: Option<&str>,
     mappings: &str,
@@ -2816,9 +2810,11 @@ pub fn generate_sourcemap_json(
 ) -> String {
     let mut json = String::with_capacity(256 + source_content.map_or(0, str::len) + mappings.len());
     json.push_str("{\"version\":3");
-    json.push_str(",\"file\":\"");
-    json_escape_str(&mut json, file);
-    json.push('"');
+    if let Some(file) = file {
+        json.push_str(",\"file\":\"");
+        json_escape_str(&mut json, file);
+        json.push('"');
+    }
     json.push_str(",\"sources\":[\"");
     json_escape_str(&mut json, source_name);
     json.push_str("\"]");
@@ -3109,7 +3105,7 @@ pub fn remap_through_sourcemap(mappings: &mut [SourceMapping], preprocessor_map_
 
 /// Generate a source map JSON with multiple sources support.
 pub fn generate_sourcemap_json_multi(
-    file: &str,
+    file: Option<&str>,
     sources: &[&str],
     sources_content: &[&str],
     mappings: &str,
@@ -3117,9 +3113,11 @@ pub fn generate_sourcemap_json_multi(
 ) -> String {
     let mut json = String::with_capacity(256 + mappings.len());
     json.push_str("{\"version\":3");
-    json.push_str(",\"file\":\"");
-    json_escape_str(&mut json, file);
-    json.push('"');
+    if let Some(file) = file {
+        json.push_str(",\"file\":\"");
+        json_escape_str(&mut json, file);
+        json.push('"');
+    }
     json.push_str(",\"sources\":[");
     for (i, src) in sources.iter().enumerate() {
         if i > 0 {
@@ -3163,15 +3161,20 @@ mod tests {
 
     #[test]
     fn sourcemap_can_externalize_single_source_content() {
-        let json = generate_sourcemap_json("out.js", "App.svelte", None, "AAAA", &[]);
+        let json = generate_sourcemap_json(Some("out.js"), "App.svelte", None, "AAAA", &[]);
         let map: serde_json::Value = serde_json::from_str(&json).unwrap();
         assert_eq!(map["sourcesContent"], serde_json::json!([null]));
     }
 
     #[test]
     fn sourcemap_preserves_embedded_source_content() {
-        let json =
-            generate_sourcemap_json("out.js", "App.svelte", Some("<h1>\"x\"</h1>"), "AAAA", &[]);
+        let json = generate_sourcemap_json(
+            Some("out.js"),
+            "App.svelte",
+            Some("<h1>\"x\"</h1>"),
+            "AAAA",
+            &[],
+        );
         let map: serde_json::Value = serde_json::from_str(&json).unwrap();
         assert_eq!(map["sourcesContent"], serde_json::json!(["<h1>\"x\"</h1>"]));
     }

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/mod.rs
@@ -591,15 +591,9 @@ pub(crate) fn transform_component_with_scripts<'source>(
             let filename = options.filename.as_deref();
             let source_name = get_source_name(filename, output_filename, "input.svelte");
 
-            // Determine the output file basename for the "file" field
-            let file_name = output_filename
-                .map(|f| {
-                    f.split(['/', '\\'])
-                        .next_back()
-                        .unwrap_or("input.svelte.js")
-                        .to_string()
-                })
-                .unwrap_or_else(|| "input.svelte.js".to_string());
+            // Upstream's JS map comes out of esrap's `print()`, which sets no
+            // `file` key; only the CSS map names its output file.
+            let file_name: Option<&str> = None;
 
             let mut mappings_str = encode_vlq_mappings(&js_mappings);
 
@@ -695,7 +689,7 @@ pub(crate) fn transform_component_with_scripts<'source>(
                         // Only one source referenced - use single-source format
                         let content = multi_contents.first().map(|s| s.as_str()).unwrap_or(source);
                         Some(generate_sourcemap_json(
-                            &file_name,
+                            file_name,
                             &multi_sources[0],
                             include_sourcemap_content.then_some(content),
                             &mappings_str,
@@ -707,7 +701,7 @@ pub(crate) fn transform_component_with_scripts<'source>(
                         let contents_refs: Vec<&str> =
                             multi_contents.iter().map(|s| s.as_str()).collect();
                         Some(js_ast::codegen::generate_sourcemap_json_multi(
-                            &file_name,
+                            file_name,
                             &sources_refs,
                             &contents_refs,
                             &mappings_str,
@@ -727,7 +721,7 @@ pub(crate) fn transform_component_with_scripts<'source>(
                         .map(String::as_str)
                         .unwrap_or(&source_name);
                     Some(generate_sourcemap_json(
-                        &file_name,
+                        file_name,
                         preprocessed_source,
                         include_sourcemap_content.then_some(content),
                         &mappings_str,
@@ -736,7 +730,7 @@ pub(crate) fn transform_component_with_scripts<'source>(
                 }
             } else {
                 Some(generate_sourcemap_json(
-                    &file_name,
+                    file_name,
                     &source_name,
                     include_sourcemap_content.then_some(source),
                     &mappings_str,
@@ -750,14 +744,7 @@ pub(crate) fn transform_component_with_scripts<'source>(
             let filename = options.filename.as_deref();
             if output_filename.is_some() || filename.is_some() {
                 let source_name = get_source_name(filename, output_filename, "input.svelte");
-                let file_name = output_filename
-                    .map(|f| {
-                        f.split(['/', '\\'])
-                            .next_back()
-                            .unwrap_or("input.svelte.js")
-                            .to_string()
-                    })
-                    .unwrap_or_else(|| "input.svelte.js".to_string());
+                let file_name: Option<&str> = None;
 
                 // Generate line-level identity mappings (each generated line maps to line 0, col 0)
                 let line_count = js.chars().filter(|&c| c == '\n').count();
@@ -774,7 +761,7 @@ pub(crate) fn transform_component_with_scripts<'source>(
                 }
                 let mappings_str = encode_vlq_mappings(&trivial_mappings);
                 Some(generate_sourcemap_json(
-                    &file_name,
+                    file_name,
                     &source_name,
                     include_sourcemap_content.then_some(source),
                     &mappings_str,
@@ -892,7 +879,7 @@ pub(crate) fn remap_css_sourcemap(
 
     let names_refs: Vec<&str> = names.iter().map(|s| s.as_str()).collect();
     generate_sourcemap_json(
-        file_name,
+        Some(file_name),
         &source_name,
         Some(if original_content.is_empty() {
             ""

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/mod.rs
@@ -636,6 +636,7 @@ impl<'a> ServerTransformState<'a> {
     pub fn is_standalone_fragment<'t, N: AsRef<TemplateNode<'t>>>(
         nodes: &[N],
         preserve_whitespace: bool,
+        hmr: bool,
     ) -> bool {
         use crate::compiler::phases::phase3_transform::utils::is_svelte_whitespace_only;
         let meaningful: Vec<&TemplateNode> = nodes
@@ -668,7 +669,11 @@ impl<'a> ServerTransformState<'a> {
         match meaningful[0] {
             TemplateNode::RenderTag(tag) => !tag.metadata.dynamic,
             TemplateNode::Component(comp) => {
-                !comp.metadata.dynamic
+                // Upstream gates only this arm on `state.options.hmr`
+                // (`3-transform/utils.js`), so under HMR a component keeps its
+                // trailing `<!---->` anchor while a `{@render}` still loses it.
+                !hmr
+                    && !comp.metadata.dynamic
                     && !comp.attributes.iter().any(|attr| {
                         matches!(attr, crate::ast::template::Attribute::Attribute(a) if a.name.starts_with("--"))
                     })
@@ -1184,6 +1189,7 @@ pub fn server_component_ast<'a>(
     state.is_standalone = ServerTransformState::is_standalone_fragment(
         &ast.fragment.nodes,
         state.preserve_whitespace,
+        state.options.hmr,
     );
     // Root fragment: parent is the Fragment node itself, so it IS an
     // `is_text_first` parent (upstream `clean_nodes`/`Fragment`).

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/visitors/shared.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/visitors/shared.rs
@@ -1059,8 +1059,11 @@ pub fn build_fragment_body<'a, N: AsRef<TemplateNode<'a>>>(
     // child. Recompute it here (save/restore) so every fragment block matches
     // upstream.
     let saved_standalone = state.is_standalone;
-    state.is_standalone =
-        ServerTransformState::is_standalone_fragment(nodes, state.preserve_whitespace);
+    state.is_standalone = ServerTransformState::is_standalone_fragment(
+        nodes,
+        state.preserve_whitespace,
+        state.options.hmr,
+    );
     // Track fragment nesting depth: the root component fragment is depth 1; any
     // nested block / boundary / snippet body is depth ≥ 2. The boundary visitor
     // reads this to decide `failed`-snippet hoist-vs-inline placement.

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/utils.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/utils.rs
@@ -627,6 +627,7 @@ pub fn clean_nodes<'a>(
     analysis: &ComponentAnalysis,
     preserve_whitespace: bool,
     preserve_comments: bool,
+    hmr: bool,
 ) -> CleanedNodes<'a> {
     clean_node_list(
         parent,
@@ -638,6 +639,7 @@ pub fn clean_nodes<'a>(
         analysis,
         preserve_whitespace,
         preserve_comments,
+        hmr,
     )
 }
 
@@ -654,6 +656,7 @@ pub fn clean_nodes_refs<'a>(
     analysis: &ComponentAnalysis,
     preserve_whitespace: bool,
     preserve_comments: bool,
+    hmr: bool,
 ) -> CleanedNodes<'a> {
     clean_node_list(
         parent,
@@ -665,6 +668,7 @@ pub fn clean_nodes_refs<'a>(
         analysis,
         preserve_whitespace,
         preserve_comments,
+        hmr,
     )
 }
 
@@ -678,6 +682,7 @@ fn clean_node_list<'a, L: NodeList<'a>>(
     analysis: &ComponentAnalysis,
     preserve_whitespace: bool,
     preserve_comments: bool,
+    hmr: bool,
 ) -> CleanedNodes<'a> {
     // Sort const tags topologically in legacy (non-runes) mode
     // This matches the official compiler's behavior in clean_nodes (utils.js line 138-139)
@@ -783,9 +788,11 @@ fn clean_node_list<'a, L: NodeList<'a>>(
             TemplateNode::RenderTag(render_tag) => !render_tag.metadata.dynamic,
             TemplateNode::Component(comp) => {
                 // Not standalone if:
+                // - HMR is on (upstream gates only this arm on `state.options.hmr`,
+                //   so a root `{@render}` stays anchor-free while a component does not)
                 // - Component is dynamic (uses $derived or similar)
                 // - Component has CSS custom properties (--var attributes)
-                !comp.metadata.dynamic
+                !hmr && !comp.metadata.dynamic
                     && !comp.attributes.iter().any(
                         |attr| matches!(attr, Attribute::Attribute(a) if a.name.starts_with("--")),
                     )
@@ -1370,6 +1377,7 @@ mod tests {
             &analysis,
             false,
             false,
+            false,
         );
 
         assert!(cleaned.hoisted.is_empty());
@@ -1426,6 +1434,7 @@ mod tests {
             &analysis,
             false,
             false,
+            false,
         );
 
         // Whitespace-only text node should be removed
@@ -1464,6 +1473,7 @@ mod tests {
             "html",
             &scope,
             &analysis,
+            false,
             false,
             false,
         );
@@ -1508,6 +1518,7 @@ mod tests {
             "html",
             &scope,
             &analysis,
+            false,
             false,
             false,
         );

--- a/crates/rsvelte_core/tests/hmr_option_parity.rs
+++ b/crates/rsvelte_core/tests/hmr_option_parity.rs
@@ -1,0 +1,134 @@
+//! `hmr: true` output parity (issue #3240).
+//!
+//! `hmr` is the Vite plugin's compile path and no corpus target sets it, so four
+//! divergences lived there unobserved. Each expectation below is the official
+//! compiler's verbatim output at the pinned Svelte revision.
+
+use rsvelte_core::{CompileOptions, GenerateMode, compile, compiler::CssMode};
+
+fn code(src: &str, generate: GenerateMode, hmr: bool, css: CssMode) -> String {
+    let opts = CompileOptions {
+        filename: Some("A.svelte".to_string()),
+        generate,
+        css,
+        hmr,
+        ..Default::default()
+    };
+    compile(src, opts).expect("compiles").js.code
+}
+
+const RENDER_TAG: &str = "{#snippet s(x)}<b>{x}</b>{/snippet}{@render s(1)}";
+
+const COMPONENT: &str = "<script>\n\timport C from \"./C.svelte\";\n</script>\n<C a={1}>x</C>";
+
+const STYLED: &str = "<script>\n\tlet n = $state(1);\n</script>\n<div class=\"a\">{n}</div>\n<style>\n\t.a { color: red }\n</style>";
+
+const CUSTOM_ELEMENT: &str = "<svelte:options customElement=\"my-el\" />\n<script>\n\tlet { a = 1 } = $props();\n</script>\n<div>{a}</div>";
+
+/// A `<style>` block means the accept hook has to drop the previous version's
+/// injected stylesheet, or its rules accumulate across every hot update.
+#[test]
+fn accept_hook_cleans_up_injected_styles() {
+    let with_style = code(STYLED, GenerateMode::Client, true, CssMode::Injected);
+    assert!(
+        with_style.contains(
+            "\timport.meta.hot.accept((module) => {\n\t\t$.cleanup_styles('svelte-1lj1c2h');\n\t\tA[$.HMR].update(module.default);\n\t});"
+        ),
+        "expected `$.cleanup_styles` ahead of the update call:\n{with_style}"
+    );
+
+    // Control: no `<style>` means no hash, and then no `cleanup_styles` call.
+    let no_style = code(
+        "<script>\n\tlet n = $state(1);\n</script>\n<div>{n}</div>",
+        GenerateMode::Client,
+        true,
+        CssMode::Injected,
+    );
+    assert!(
+        no_style.contains(
+            "\timport.meta.hot.accept((module) => {\n\t\tA[$.HMR].update(module.default);\n\t});"
+        ) && !no_style.contains("cleanup_styles"),
+        "a style-less component must not clean up styles:\n{no_style}"
+    );
+}
+
+/// `customElements.define` throws on a name that is already defined, so the
+/// second hot update of a custom-element component would abort the module.
+#[test]
+fn custom_element_definition_is_guarded_under_hmr() {
+    let hot = code(
+        CUSTOM_ELEMENT,
+        GenerateMode::Client,
+        true,
+        CssMode::External,
+    );
+    assert!(
+        hot.contains(
+            "if (customElements.get('my-el') == null) customElements.define('my-el', $.create_custom_element(A, { a: {} }, [], [], { mode: 'open' }));"
+        ),
+        "expected the `customElements.get(...) == null` guard:\n{hot}"
+    );
+
+    let cold = code(
+        CUSTOM_ELEMENT,
+        GenerateMode::Client,
+        false,
+        CssMode::External,
+    );
+    assert!(
+        cold.contains("customElements.define('my-el',") && !cold.contains("customElements.get"),
+        "without hmr the define stays bare:\n{cold}"
+    );
+}
+
+/// Upstream gates `is_standalone` on `hmr` for the `Component` arm only, so a
+/// root `{@render}` keeps the parent anchor while a root component does not.
+/// One of the two alone cannot tell a blanket rule from the real one.
+#[test]
+fn hmr_suppresses_standalone_for_components_but_not_render_tags() {
+    let render_tag = code(RENDER_TAG, GenerateMode::Client, true, CssMode::External);
+    assert!(
+        render_tag.contains("function A($$anchor) {\n\ts($$anchor, () => 1);\n}"),
+        "a root `{{@render}}` needs no anchor comment under hmr:\n{render_tag}"
+    );
+
+    let component = code(COMPONENT, GenerateMode::Client, true, CssMode::External);
+    assert!(
+        component.contains("var fragment = $.comment();\n\tvar node = $.first_child(fragment);")
+            && component.contains("$.append($$anchor, fragment);"),
+        "a root component DOES get the anchor comment under hmr:\n{component}"
+    );
+
+    // Control: without hmr the component is standalone again.
+    let cold = code(COMPONENT, GenerateMode::Client, false, CssMode::External);
+    assert!(
+        !cold.contains("$.comment()"),
+        "without hmr the root component stays standalone:\n{cold}"
+    );
+}
+
+/// The server port of the same predicate: the trailing hydration anchor after a
+/// component must survive under `hmr`, or hydration of that subtree mismatches.
+#[test]
+fn server_keeps_the_trailing_anchor_after_a_component_under_hmr() {
+    let hot = code(COMPONENT, GenerateMode::Server, true, CssMode::External);
+    assert!(
+        hot.contains("\t\t$$slots: { default: true }\n\t});\n\n\t$$renderer.push(`<!---->`);"),
+        "expected the closing `<!---->` push:\n{hot}"
+    );
+
+    let cold = code(COMPONENT, GenerateMode::Server, false, CssMode::External);
+    assert!(
+        !cold.contains("$$renderer.push(`<!---->`);"),
+        "without hmr there is no trailing anchor:\n{cold}"
+    );
+
+    // A render tag is unaffected in either mode.
+    for hmr in [false, true] {
+        let render_tag = code(RENDER_TAG, GenerateMode::Server, hmr, CssMode::External);
+        assert!(
+            render_tag.contains("export default function A($$renderer) {\n\ts($$renderer, 1);\n}"),
+            "render tag must be unchanged (hmr={hmr}):\n{render_tag}"
+        );
+    }
+}

--- a/crates/rsvelte_core/tests/js_sourcemap_result_fields.rs
+++ b/crates/rsvelte_core/tests/js_sourcemap_result_fields.rs
@@ -1,0 +1,94 @@
+//! `js.map` header fields (issue #3295).
+//!
+//! Upstream builds the JS map with esrap's `print()`, which emits no `file` key
+//! at all, and derives `sources` from `get_source_name` — whose `outputFilename`
+//! branch (`utils/mapped_code.js:430`) joins the relative parts verbatim, with no
+//! `./` prefix. rsvelte baked in a constant `"input.svelte.js"` for `file` and
+//! prefixed every `outputFilename`-relative source with `./`.
+//!
+//! The CSS map is the control: upstream *does* set `file` there
+//! (`3-transform/css/index.js`), so a fix that strips the key everywhere would
+//! break it.
+
+use rsvelte_core::{CompileOptions, GenerateMode, compile, compiler::CssMode};
+use serde_json::Value;
+
+const SRC: &str = "<script>\n\tlet n = $state(1);\n</script>\n<p class=\"k\">{n}</p>\n<style>.k { color: red }</style>";
+
+fn maps(opts: CompileOptions) -> (Value, Option<Value>) {
+    let r = compile(SRC, opts).expect("compiles");
+    let js = serde_json::from_str(r.js.map.as_deref().expect("js map")).expect("js map is JSON");
+    let css = r
+        .css
+        .and_then(|c| c.map)
+        .map(|m| serde_json::from_str(&m).expect("css map is JSON"));
+    (js, css)
+}
+
+fn base(generate: GenerateMode) -> CompileOptions {
+    CompileOptions {
+        filename: Some("Probe.svelte".to_string()),
+        generate,
+        css: CssMode::External,
+        ..Default::default()
+    }
+}
+
+#[test]
+fn js_map_has_no_file_key() {
+    for generate in [GenerateMode::Client, GenerateMode::Server] {
+        let (js, _) = maps(base(generate));
+        assert!(
+            js.get("file").is_none(),
+            "official's js.map carries no `file`, got {js:#}"
+        );
+    }
+}
+
+#[test]
+fn css_map_keeps_its_file_key() {
+    let (_, css) = maps(base(GenerateMode::Client));
+    let css = css.expect("external css produces a map");
+    assert_eq!(
+        css.get("file").and_then(Value::as_str),
+        Some("Probe.svelte")
+    );
+}
+
+#[test]
+fn output_filename_does_not_prefix_sources() {
+    let mut opts = base(GenerateMode::Client);
+    opts.output_filename = Some("out.js".to_string());
+    let (js, _) = maps(opts);
+    assert_eq!(
+        js.get("sources"),
+        Some(&serde_json::json!(["Probe.svelte"])),
+        "a same-directory outputFilename leaves `sources` a bare basename"
+    );
+    assert!(js.get("file").is_none(), "still no `file`: {js:#}");
+}
+
+#[test]
+fn output_filename_relative_path_matches_upstream() {
+    let mut opts = base(GenerateMode::Client);
+    opts.filename = Some("src/lib/Probe.svelte".to_string());
+    opts.output_filename = Some("dist/out.js".to_string());
+    let (js, _) = maps(opts);
+    assert_eq!(
+        js.get("sources"),
+        Some(&serde_json::json!(["../src/lib/Probe.svelte"]))
+    );
+}
+
+#[test]
+fn css_output_filename_names_the_css_map_file() {
+    let mut opts = base(GenerateMode::Client);
+    opts.css_output_filename = Some("out.css".to_string());
+    let (_, css) = maps(opts);
+    let css = css.expect("external css produces a map");
+    assert_eq!(css.get("file").and_then(Value::as_str), Some("out.css"));
+    assert_eq!(
+        css.get("sources"),
+        Some(&serde_json::json!(["Probe.svelte"]))
+    );
+}

--- a/crates/rsvelte_napi/src/lib.rs
+++ b/crates/rsvelte_napi/src/lib.rs
@@ -449,10 +449,17 @@ pub async fn napi_compile_with_css_hash(
     source: String,
     options: Option<NapiCompileOptions>,
     #[napi(
-        ts_arg_type = "(name: string, filename: string, css: string) => Promise<{ value: string | null } | { error: string }>"
+        ts_arg_type = "(input: { hash: (str: string) => string, css: string, name: string, filename: string }) => string"
     )]
     css_hash: css_hash_bridge::JsCssHashCb,
 ) -> napi::Result<CssHashOutcome> {
+    // The callback arrives as its own argument, so a `cssHash` left on the
+    // options object is this same function — drop it instead of rejecting it the
+    // way the synchronous entries do.
+    let mut options = options;
+    if let Some(o) = options.as_mut() {
+        o.css_hash = None;
+    }
     let mut opts = options_to_compile(options)?;
     let filename = opts.filename.clone();
     let handle: css_hash_bridge::Handle =
@@ -530,23 +537,50 @@ impl napi::bindgen_prelude::ToNapiValue for CssHashOutcome {
 
 mod css_hash_bridge {
     use napi::Status;
-    use napi::bindgen_prelude::{FnArgs, Promise, block_on};
+    use napi::bindgen_prelude::{FromNapiValue, ToNapiValue, block_on};
     use napi::threadsafe_function::ThreadsafeFunction;
     use rsvelte_core::compiler::{CssHashFn, CssHashInput};
     use serde_json::Value;
     use std::sync::{Arc, Mutex, RwLock};
 
-    // (name, filename, css) in; `{ value: string | null }` (string, or null to
-    // fall back to the default hash) or `{ error: string }` (throw → compile
-    // failure) out. `CalleeHandled = false` so the callback receives the args
-    // directly.
-    pub type JsCssHashCb = ThreadsafeFunction<
-        FnArgs<(String, String, String)>,
-        Promise<Value>,
-        FnArgs<(String, String, String)>,
-        Status,
-        false,
-    >;
+    /// The single argument upstream hands a `cssHash` callback:
+    /// `{ hash, css, name, filename }`. `hash` is a real JS function wrapping the
+    /// compiler's own digest, so `({ hash, css }) => \`x-${hash(css)}\`` — the
+    /// documented idiom — works verbatim.
+    pub struct CssHashArg {
+        pub name: String,
+        pub filename: String,
+        pub css: String,
+        pub hash: Arc<dyn Fn(&str) -> String + Send + Sync>,
+    }
+
+    impl ToNapiValue for CssHashArg {
+        unsafe fn to_napi_value(
+            env: napi::sys::napi_env,
+            val: Self,
+        ) -> napi::Result<napi::sys::napi_value> {
+            let e = napi::Env::from_raw(env);
+            let mut obj = napi::bindgen_prelude::Object::new(&e)?;
+            obj.set("name", val.name)?;
+            obj.set("filename", val.filename)?;
+            obj.set("css", val.css)?;
+            let digest = val.hash;
+            let hash_fn: napi::bindgen_prelude::Function<'_, String, String> = e
+                .create_function_from_closure("hash", move |ctx| {
+                    let input: String = ctx.get::<String>(0).unwrap_or_default();
+                    Ok(digest(&input))
+                })?;
+            obj.set("hash", hash_fn)?;
+            // SAFETY: same env, and `obj` is a value created from it.
+            unsafe { napi::bindgen_prelude::Object::to_napi_value(env, obj) }
+        }
+    }
+
+    // One `{ hash, css, name, filename }` object in, the scope class out. A
+    // non-string return falls back to the default hash (as upstream's own
+    // `cssHash` default would); a throw aborts the compile.
+    // `CalleeHandled = false` so the callback receives the argument directly.
+    pub type JsCssHashCb = ThreadsafeFunction<CssHashArg, Value, CssHashArg, Status, false>;
 
     pub type Handle = Arc<RwLock<Option<JsCssHashCb>>>;
     pub type ErrorSlot = Arc<Mutex<Option<String>>>;
@@ -557,39 +591,52 @@ mod css_hash_bridge {
             let Some(cb) = guard.as_ref() else {
                 return default_hash(input, root_dir.as_deref());
             };
-            let args = FnArgs::from((
-                input.name.clone(),
-                input.filename.clone(),
-                input.css.clone(),
-            ));
-            let outcome = block_on(async {
-                match cb.call_async(args).await {
-                    Ok(promise) => promise.await.map_err(|e| e.to_string()),
-                    Err(e) => Err(e.to_string()),
-                }
-            });
+            let arg = CssHashArg {
+                name: input.name.clone(),
+                filename: input.filename.clone(),
+                css: input.css.clone(),
+                hash: Arc::clone(&input.hash),
+            };
+            // `call_async_catch`, never `call_async`: the latter routes a JS
+            // throw through `napi_fatal_exception`, which kills the process
+            // instead of failing the compile.
+            let outcome = block_on(async { cb.call_async_catch(arg).await });
             drop(guard);
             match outcome {
-                Ok(v) => {
-                    if let Some(err) = v.get("error").and_then(Value::as_str) {
-                        // Record the first thrown cssHash error; the returned hash
-                        // is discarded once the caller sees the recorded failure.
-                        error_slot
-                            .lock()
-                            .unwrap()
-                            .get_or_insert_with(|| err.to_string());
-                        return default_hash(input, root_dir.as_deref());
-                    }
-                    v.get("value").and_then(Value::as_str).map_or_else(
-                        || default_hash(input, root_dir.as_deref()),
-                        ToString::to_string,
-                    )
+                // A non-string return is not usable as a scope class.
+                Ok(v) => v.as_str().map_or_else(
+                    || default_hash(input, root_dir.as_deref()),
+                    ToString::to_string,
+                ),
+                Err(e) => {
+                    // Record the first thrown cssHash error; the returned hash is
+                    // discarded once the caller sees the recorded failure. Upstream
+                    // lets the exception abort compilation.
+                    error_slot
+                        .lock()
+                        .unwrap()
+                        .get_or_insert_with(|| callback_error_message(&e));
+                    default_hash(input, root_dir.as_deref())
                 }
-                // Internal TSFN failure (not a user throw) → default hash.
-                Err(_) => default_hash(input, root_dir.as_deref()),
             }
         })
     }
+
+    /// The JS `Error.message` when there is one, else the raw reason.
+    fn callback_error_message(e: &napi::Error) -> String {
+        let reason = e.reason.clone();
+        if reason.is_empty() {
+            e.to_string()
+        } else {
+            reason
+        }
+    }
+
+    // Silence the unused-import lint when the trait is only needed for the bound.
+    const _: fn() = || {
+        fn assert_from_napi<T: FromNapiValue>() {}
+        assert_from_napi::<Value>();
+    };
 
     // Reproduces the compiler's default (no-cssHash) scope hash: the rootDir-relative
     // filename when known, else the CSS content (see phases/2-analyze/types.rs).
@@ -645,7 +692,11 @@ pub enum LenientScalar {
     // self-referential object safe to decode. `undefined` children are dropped
     // (unset); everything the consumers read lives at depth 1.
     Object(Vec<(String, Self)>),
-    // Arrays, functions, symbols and other non-scalars — JS-truthy, but not a
+    // A JS function. Kept apart from `Other` because `cssHash` is *only* legal
+    // as a function, so "a function was passed" and "a wrong type was passed"
+    // are different diagnoses.
+    Function,
+    // Arrays, symbols and other non-scalars — JS-truthy, but not a
     // value any option can consume.
     Other,
 }
@@ -700,6 +751,7 @@ unsafe fn decode_scalar(
             napi::sys::ValueType::napi_string => {
                 LenientScalar::Str(String::from_napi_value(env, napi_val)?)
             }
+            napi::sys::ValueType::napi_function => LenientScalar::Function,
             _ => LenientScalar::Other,
         })
     }
@@ -773,7 +825,7 @@ impl napi::bindgen_prelude::ToNapiValue for LenientScalar {
                 Self::Bool(b) => bool::to_napi_value(env, b),
                 Self::Number(n) => f64::to_napi_value(env, n),
                 Self::Str(s) => String::to_napi_value(env, s),
-                Self::Object(_) | Self::Other => {
+                Self::Object(_) | Self::Function | Self::Other => {
                     napi::bindgen_prelude::Null::to_napi_value(env, napi::bindgen_prelude::Null)
                 }
             }
@@ -969,6 +1021,11 @@ pub struct NapiCompileOptions {
     pub modern_ast: Option<LenientScalar>,
     pub experimental: Option<LenientScalar>,
     pub compatibility: Option<LenientScalar>,
+    /// Upstream's `cssHash` callback. The synchronous entries cannot call back
+    /// into JavaScript, so this is declared only to be *rejected* there: dropping
+    /// it silently hands the caller a different scope class than it asked for.
+    /// `compileWithCssHash` is the entry that honours it.
+    pub css_hash: Option<LenientScalar>,
     /// Pre-computed deterministic hash for the test harness (the JS
     /// `cssHash` callback can't be called from Rust).
     pub css_hash_override: Option<String>,
@@ -1088,6 +1145,14 @@ impl NapiCompileOptions {
         }
         if let Some(v) = &self.compatibility {
             opts.compatibility.component_api = coerce_compatibility(v)?;
+        }
+        if let Some(v) = &self.css_hash {
+            return Err(match v {
+                LenientScalar::Function => napi::Error::from_reason(
+                    "A function-valued `cssHash` cannot be called from this entry point; use `compileWithCssHash` (or `compileAsync`, which routes to it).".to_string(),
+                ),
+                _ => invalid_option("cssHash should be a function, if specified"),
+            });
         }
         if let Some(hash_override) = self.css_hash_override {
             opts.css_hash = Some(std::sync::Arc::new(

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
 		"test:vps-unit": "pnpm --filter @rsvelte/vite-plugin-svelte run test",
 		"test:vps": "node scripts/dev/test-vps-shim.mjs && node scripts/dev/test-vps-vite-fixture.mjs",
 		"test:napi-options": "node scripts/dev/test-napi-compile-options.mjs",
+		"test:napi-csshash": "node scripts/dev/test-napi-css-hash.mjs",
 		"test:wasm-compile": "node scripts/dev/test-wasm-compile-options.mjs",
 		"test:type-aware-lint": "node scripts/dev/test-type-aware-lint.mjs",
 		"build:oxlint-plugin": "pnpm --filter @rsvelte/oxlint-plugin run build",

--- a/scripts/dev/test-napi-compile-options.mjs
+++ b/scripts/dev/test-napi-compile-options.mjs
@@ -173,6 +173,10 @@ const DECLARED = new Map([
 // than a gap: it reads as surveyed.
 const UNCOVERED = new Map([
 	[
+		'compile.cssHash',
+		'a callback, not a value: the synchronous entries reject it and only `compileWithCssHash` can call it, so it has no baseline/variant pair here — covered end-to-end by `pnpm run test:napi-csshash` (its own process, because two addons in one process SIGSEGV)',
+	],
+	[
 		'compileModule.rootDir',
 		'forwarded to CompileOptions but every consumer of `root_dir` (the `$.FILENAME` / HMR key in the client component transform, and the CSS scope hash) is component-only, so a module compile has nothing to observe',
 	],
@@ -350,9 +354,15 @@ const COMPILE_CASES = [
 	{
 		key: 'outputFilename',
 		src: CSS_SRC,
-		base: { filename: 'A.svelte' },
-		variant: { filename: 'A.svelte', outputFilename: 'out.js' },
-		marker: (r) => r.js.map.file === 'out.js',
+		// Upstream's map carries no `file` key at all (esrap's `print()` never
+		// sets one), so what `outputFilename` moves is `sources`: it becomes the
+		// path from the OUTPUT's directory to the source. A same-directory output
+		// leaves the bare basename, which is what the baseline already is — hence
+		// the nested pair.
+		base: { filename: 'src/A.svelte' },
+		variant: { filename: 'src/A.svelte', outputFilename: 'dist/out.js' },
+		marker: (r) => r.js.map.sources[0] === '../src/A.svelte',
+		differsIn: (r) => r.js.map.sources.join(','),
 	},
 	{
 		key: 'cssOutputFilename',

--- a/scripts/dev/test-napi-css-hash.mjs
+++ b/scripts/dev/test-napi-css-hash.mjs
@@ -1,0 +1,227 @@
+#!/usr/bin/env node
+// Differential gate for the `cssHash` compile option at the NAPI boundary
+// (issue #3294), with the official compiler as the oracle.
+//
+// `cssHash` is the one compile option whose value is a *callback*, which is why
+// no other gate reaches it: `test-napi-compile-options.mjs` compares two
+// results that differ in one key, and a key the boundary silently drops produces
+// two identical results, so that gate's own `differs` check is what a dropped
+// scalar trips. A dropped *callback* was invisible to it because the option was
+// never declared at the boundary at all.
+//
+// Three things are asserted here, and each has its own failure mode:
+//
+//  1. The synchronous entries REJECT a function-valued `cssHash`. They cannot
+//     call back into JavaScript, and dropping it hands the caller a different
+//     scope class than it asked for — in `css.code` and in every `class`
+//     attribute of `js.code` — with no error.
+//  2. `compileWithCssHash` invokes the callback the way upstream does: ONE
+//     argument, `{ hash, css, name, filename }`, with `hash` a real function.
+//     Comparing only the resulting scope class would pass against a callback
+//     invoked with the right VALUES in the wrong SHAPE, so the argument list is
+//     inspected directly as well.
+//  3. A throwing callback becomes a rejected promise. napi's `call_async` routes
+//     a JS throw through `napi_fatal_exception` (i.e. it kills the process), so
+//     this is a live hazard rather than a hypothetical one — the bridge has to
+//     use `call_async_catch`.
+//
+// The raw addon is loaded directly, like `test-napi-compile-options.mjs`, and in
+// its own process: two rsvelte addons in one process have been observed to
+// SIGSEGV.
+//
+// Prereq: `pnpm run build:vps-native`.
+
+import { createRequire } from 'node:module';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { compile as officialCompile } from '../../submodules/svelte/packages/svelte/src/compiler/index.js';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(here, '../..');
+
+let pass = 0;
+let fail = 0;
+function assert(label, cond, detail) {
+	if (cond) {
+		pass += 1;
+		console.log(`  ok   ${label}`);
+	} else {
+		fail += 1;
+		console.error(`  FAIL ${label}${detail ? ` — ${detail}` : ''}`);
+	}
+}
+
+function resolveTriple() {
+	const { platform, arch } = process;
+	if (platform === 'darwin') {
+		if (arch === 'arm64') return 'darwin-arm64';
+		if (arch === 'x64') return 'darwin-x64';
+	} else if (platform === 'linux') {
+		let isMusl = false;
+		try {
+			isMusl = !process.report.getReport().header.glibcVersionRuntime;
+		} catch {
+			isMusl = false;
+		}
+		const libc = isMusl ? 'musl' : 'gnu';
+		if (arch === 'x64') return `linux-x64-${libc}`;
+		if (arch === 'arm64') return `linux-arm64-${libc}`;
+	} else if (platform === 'win32') {
+		if (arch === 'x64') return 'win32-x64-msvc';
+	}
+	return null;
+}
+
+const triple = resolveTriple();
+if (!triple) {
+	console.error(`[napi-csshash] unsupported platform ${process.platform}/${process.arch}`);
+	process.exit(2);
+}
+const addonPath = resolve(repoRoot, `apps/npm/vite-plugin-svelte-native-${triple}/rsvelte.node`);
+const require_ = createRequire(import.meta.url);
+let napi;
+try {
+	napi = require_(addonPath);
+} catch (e) {
+	console.error(
+		`[napi-csshash] cannot load ${addonPath}\n  run \`pnpm run build:vps-native\` first\n  ${e.message}`,
+	);
+	process.exit(2);
+}
+
+const SRC = '<p class="k">hi</p>\n<style>.k { color: red }</style>';
+const OPTS = { filename: 'Probe.svelte', generate: 'client', css: 'external' };
+
+// ---------------------------------------------------------------------------
+// 1. The synchronous entries reject rather than drop
+// ---------------------------------------------------------------------------
+console.log('\n# synchronous entries');
+
+for (const [label, entry] of [
+	['compile', (options) => napi.compile(SRC, options)],
+	['compileEnvelope', (options) => napi.compileEnvelope(SRC, options)],
+]) {
+	let message = null;
+	try {
+		entry({ ...OPTS, cssHash: () => 'fixed-hash' });
+	} catch (e) {
+		message = String(e?.message ?? e);
+	}
+	assert(
+		`${label} rejects a function-valued cssHash`,
+		message != null && /compileWithCssHash/.test(message),
+		message ?? 'no error thrown',
+	);
+}
+
+let typeMessage = null;
+try {
+	napi.compile(SRC, { ...OPTS, cssHash: 'not-a-function' });
+} catch (e) {
+	typeMessage = String(e?.message ?? e);
+}
+assert(
+	'compile reports a non-function cssHash the way validate-options does',
+	typeMessage != null && /cssHash should be a function/.test(typeMessage),
+	typeMessage ?? 'no error thrown',
+);
+
+const defaultResult = napi.compile(SRC, OPTS);
+assert(
+	'compile without cssHash is unaffected',
+	typeof defaultResult.js.code === 'string' && defaultResult.css.code.includes('.k.svelte-'),
+	defaultResult.css.code,
+);
+
+// ---------------------------------------------------------------------------
+// 2. compileWithCssHash calls the callback the way upstream does
+// ---------------------------------------------------------------------------
+console.log('\n# callback shape');
+
+let seenArgs = null;
+const fixed = await napi.compileWithCssHash(SRC, OPTS, (...args) => {
+	seenArgs = args;
+	return 'fixed-hash';
+});
+assert('the callback receives exactly one argument', seenArgs?.length === 1, `argc=${seenArgs?.length}`);
+const arg = seenArgs?.[0];
+assert(
+	'the argument is { hash, css, name, filename }',
+	arg != null &&
+		typeof arg === 'object' &&
+		typeof arg.hash === 'function' &&
+		arg.css.includes('.k { color: red }') &&
+		arg.name === 'Probe' &&
+		arg.filename === 'Probe.svelte',
+	JSON.stringify(arg && { ...arg, hash: typeof arg.hash }),
+);
+assert(
+	'the returned string becomes the scope class in css.code and js.code',
+	fixed.css.code.includes('.k.fixed-hash') && fixed.js.code.includes('fixed-hash'),
+	fixed.css.code,
+);
+
+// ---------------------------------------------------------------------------
+// 3. Output parity with the official compiler, per callback shape
+// ---------------------------------------------------------------------------
+console.log('\n# parity with the official compiler');
+
+const CALLBACKS = [
+	// The documented idiom. `hash` must be the compiler's own digest, or the
+	// scope class differs while every other field agrees.
+	['({ hash, css }) => `zz-${hash(css)}`', ({ hash, css }) => `zz-${hash(css)}`],
+	['({ hash, filename }) => …', ({ hash, filename }) => `f-${hash(filename)}`],
+	['() => a constant', () => 'fixed-el'],
+	['({ name }) => …', ({ name }) => `n-${name}`],
+	['({ css }) => …', ({ css }) => `c-${css.length}`],
+];
+
+for (const generate of ['client', 'server']) {
+	for (const [label, cb] of CALLBACKS) {
+		const options = { ...OPTS, generate };
+		const want = officialCompile(SRC, { ...options, cssHash: cb });
+		const got = await napi.compileWithCssHash(SRC, options, cb);
+		assert(
+			`[${generate}] css.code matches official for ${label}`,
+			got.css?.code === want.css?.code,
+			`${got.css?.code} vs ${want.css?.code}`,
+		);
+		// The scope class also lands in the `class` attribute of the emitted
+		// template, which `css.code` alone does not cover.
+		const scopeClass = /\.k\.([\w-]+)/.exec(want.css?.code ?? '')?.[1];
+		assert(
+			`[${generate}] the scope class reaches js.code for ${label}`,
+			scopeClass != null && got.js.code.includes(scopeClass),
+			`${scopeClass} not in ${got.js.code.slice(0, 200)}`,
+		);
+	}
+}
+
+// ---------------------------------------------------------------------------
+// 4. Degenerate returns and throws
+// ---------------------------------------------------------------------------
+console.log('\n# degenerate callbacks');
+
+const nonString = await napi.compileWithCssHash(SRC, OPTS, () => 42);
+assert(
+	'a non-string return falls back to the default hash',
+	nonString.css.code === defaultResult.css.code,
+	nonString.css.code,
+);
+
+let thrown = null;
+try {
+	await napi.compileWithCssHash(SRC, OPTS, () => {
+		throw new Error('boom');
+	});
+} catch (e) {
+	thrown = String(e?.message ?? e);
+}
+assert(
+	'a throwing cssHash rejects the promise instead of killing the process',
+	thrown != null && /boom/.test(thrown),
+	thrown ?? 'no rejection',
+);
+
+console.log(`\n${pass} passed, ${fail} failed`);
+process.exit(fail === 0 ? 0 : 1);


### PR DESCRIPTION
Three compile-option boundary defects, each in a place no gate looks at.

Closes #3240
Closes #3294

## 1. `hmr: true` — four divergences, none of them dev-mode (#3240)

`hmr` is the Vite plugin's compile path and none of the three corpus targets
(`client`, `server`, `client-dev`) sets it, so the whole option went ungated.
Each fix is upstream's own condition:

| | upstream | rsvelte was |
|---|---|---|
| accept hook | `if (analysis.css.hash)` unshifts `$.cleanup_styles(hash)` (`transform-client.js`) | a hard-coded `Raw` block with no CSS branch — every hot update left the previous stylesheet in the document |
| custom element | `b.if(customElements.get(tag) == null, define)` when `options.hmr` | a bare `customElements.define`, which throws on the second hot update |
| `is_standalone` | gated on `hmr` for the **`Component` arm only** (`3-transform/utils.js`) | a blanket `!options.hmr` in the client fragment visitor (so a root `{@render}` also lost standalone), no `hmr` term in the component visitor, and none at all on the server |

The last row is one defect with two ports: the client emits a `$.comment()` /
`$.first_child` / `$.append` wrapper it should not for a `{@render}`, and the
server drops the trailing `$$renderer.push(`<!---->`)` it should keep after a
component — which is a hydration mismatch. `hmr` now threads into
`clean_nodes` / `clean_nodes_refs` / `clean_node_list` and into the server's
`is_standalone_fragment`, so the two ports share one rule.

`crates/rsvelte_core/tests/hmr_option_parity.rs` pins all four against the
official compiler's verbatim output. A repro must carry **both** a root
`{@render}` and a root `<Component>`: one alone cannot tell upstream's rule
from a blanket one. Negative control run per port — removing the `!hmr` term
from the client predicate fails only
`hmr_suppresses_standalone_for_components_but_not_render_tags`, removing it
from the server predicate fails only
`server_keeps_the_trailing_anchor_after_a_component_under_hmr`.

## 2. `cssHash` (#3294)

Neither entry point that should honour it worked.

**The synchronous entries dropped it silently.** The options decoder ignored
unknown JS fields, so `compile(src, { cssHash: () => 'x' })` returned a
component with a *different scope class* than the caller asked for — in
`css.code` and in every `class` attribute of `js.code` — with no error. They
now reject a function-valued `cssHash` naming `compileWithCssHash`, and report
a non-function with upstream's `validate-options` wording. `LenientScalar`
grows a `Function` variant so the two diagnoses stay apart.

**`compileWithCssHash` called the callback with the wrong shape.** Upstream
passes ONE object, `{ hash, css, name, filename }`; rsvelte passed three
positional arguments starting with the component name, so the documented
`({ hash, css }) => \`x-${hash(css)}\`` idiom threw `hash is not a function`.
The bridge now builds that object, with `hash` a real JS function wrapping the
compiler's own digest, and reads a plain string back. The JS-side adapter in
`index.cjs` is gone and the entry is exported from the package.

**And a throwing callback took the process with it.** napi's
`ThreadsafeFunction::call_async` documents that a JS throw is routed through
`napi_fatal_exception`, which terminates the host — so the `try`/`catch` around
the `await` never ran (the awaited promise settled as `oneshot canceled` while
Node reported an uncaught exception). `call_async_catch` hands the throw back
as `Err`, which becomes a compile failure the way upstream's exception does.
That is a **discriminating** control: built with `call_async`, the new gate's
throwing-callback case kills the runner.

New gate **38**, `scripts/dev/test-napi-css-hash.mjs` (`pnpm run
test:napi-csshash`, wired into the `vps-shim` CI job in its own process, since
two rsvelte addons in one process have been observed to SIGSEGV). It compares
the produced scope class to the **official** compiler across five callback
shapes × two targets, and inspects the callback's own argument list — comparing
only the resulting class would pass against a callback invoked with the right
values in the wrong shape. Its blind spots are written up in
`compatibility/gate-coverage.md` § 38, including 38c: `cssHash` has three ports
(napi, wasm, the `rsvelte` facade) and no gate compares them to each other,
which is exactly how the wasm port ended up with the official shape while the
napi port did not.

Gate 22's `outputFilename` case had to move (see below): its marker was
`js.map.file === 'out.js'`, a field that should not exist. It now discriminates
on `sources`, with a nested `filename`/`outputFilename` pair — a
same-directory output leaves the bare basename, which is what the baseline
already is.

## 3. Two of the three result-object fields of #3295

* `js.map.file` was a baked-in constant `"input.svelte.js"` on every compile,
  unrelated to the input. Upstream builds the JS map with esrap's `print()`,
  which sets no `file` key at all. `generate_sourcemap_json{,_multi}` now take
  `file: Option<&str>`; the **CSS** map keeps its `file`, which upstream does
  set, and that is the control in the new test.
* `outputFilename` prefixed `js.map.sources` with `./`. Upstream's
  `get_relative_path` (`utils/mapped_code.js`) joins the parts verbatim, so the
  result is a bare basename or a `../`-prefixed path, never `./`. A bundler
  resolving `sources` relative to the map's location got a different path.
  `get_basename` also now splits on `\` as upstream does.

`crates/rsvelte_core/tests/js_sourcemap_result_fields.rs` pins both against
values read off the official compiler; three of its five cases failed before
the fix and the two CSS-map cases passed throughout.

**#3295 is not closed by this PR.** Its first item — `result.ast` is `null`
unless `modernAst: true`, where official returns the Svelte-4 legacy AST —
needs a port of `submodules/svelte/packages/svelte/src/compiler/legacy.js`
(641 lines of `convert()`), which is its own piece of work and does not belong
in this change.

## Verification

* `cargo test -p rsvelte_core` — lib (1732), `hmr_option_parity`,
  `js_sourcemap_result_fields`, `compiler_fixtures`, `ssr`, `sourcemaps`,
  `sourcemaps_gate`, and `--release --test runtime` (1207 legacy + 1007 runes +
  hydration + browser) all green.
* `pnpm run test:napi-options` — 104 passed, 0 failed; the denominator moves
  39/41 (`cssHash` is now a declared key, justified as `UNCOVERED` there with a
  pointer to gate 38).
* `pnpm run test:napi-csshash` — 29 passed, 0 failed.
* `pnpm run test:vps-shim` — 62 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ABb93VNuxXbM1MZZTRp19H
