### PR TITLE
perf(lint-types): open one tsgo worker per lint run, and measure where rsvelte-check time goes

### DIFF
--- a/.changeset/check-phase-timing.md
+++ b/.changeset/check-phase-timing.md
@@ -1,0 +1,5 @@
+---
+'@rsvelte/svelte-check': patch
+---
+
+Print a walk / compile / overlay / typecheck / post wall-clock split to stderr when `RSVELTE_CHECK_TIMING` is set. A single total cannot attribute a movement to any one of them, and the split shows that type checking is 66-89% of a run while overlay materialization is 8-29% — so `--incremental`, which reuses tsgo's program graph across runs, is worth 5.4-6.7x on a warm run and the overlay is not the lever it looks like.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -766,6 +766,46 @@ Wave 4 architecture (decided; tsgo ships an LSP server as of TypeScript 7, so th
 - Ships its own TextMate grammar / language definition and accepts upstream `svelte.*`
   settings, so users replace the official extension rather than running both.
 
+### Where `rsvelte-check` time goes (`RSVELTE_CHECK_TIMING=1`)
+
+`runner::run` prints a walk / compile / overlay / typecheck / post split to stderr under
+`RSVELTE_CHECK_TIMING`. Measured on synthetic 100- and 500-component projects (TS 7.1 `tsc`,
+`skipLibCheck`, idle machine, 3 runs each): **typecheck is 66-89% of the run**, overlay
+materialization 8-29%, walk + post under 2% together.
+
+**The overlay is not the lever, and a diskless overlay is not available anyway.** A batch
+`tsc -p` reads its program from disk, so the LSP's in-memory projection has no counterpart
+here — and even a free overlay caps the whole run at 1.1-1.4x. It does have a shape worth
+knowing: 500 components materialize **2,005 files** (`.svelte.tsx`, `.svelte.tsx.map`, and two
+byte-identical `.d.ts` bridges each), ~310 ms to rewrite.
+
+**`--incremental` is the largest measured lever and it is off by default.** On the
+500-component project a warm run drops from 1693-2147 ms to 254-319 ms — **5.4-6.7x** — because
+the overlay tsconfig already carries `incremental` + `tsBuildInfoFile`, so tsgo reuses its
+program graph instead of re-checking ~2k files. The default stays off on purpose: official
+svelte-check's flag is opt-in too, and its README states the mode "might result in slightly
+different type check outcomes". Flipping it trades goal #3 for speed on a mode upstream itself
+calls lossy.
+
+### Type-aware lint opens one worker, not one per component
+
+`CorsaTypeBackend::new` used to spawn a `tsgo` API worker, write a virtual `.tsx` plus a
+tsconfig, and build a program **per component**. Measured over the 76 upstream
+`no-unused-props` fixtures (one test binary, both arms, ABBA-ordered, 5 pairs): 6.62-11.02 s
+per-spawn against 1.23-2.94 s on one warm `CorsaTypeSession` — **≥4.3x**, a lower bound because
+the Rust side is a debug build in both arms. `lint_components_types` batches a project.
+
+**One program for all components is NOT the win; the warm process is.** 62 fixtures in a single
+program measured 26-39 ms/component against 23-58 ms/component for a project-per-component on
+the same worker — no separable difference. Those fixtures are independent files, so a shared
+program shares no module graph; whether a real project (whose components import each other)
+profits is **unmeasured**.
+
+The refactor also surfaced a harness defect worth remembering: `invalid/` and `valid/` hold
+same-named fixtures while the temp dir was keyed on the stem alone, so the second one was served
+from the first one's cached project. **Reversing the iteration order moved the failures to the
+other directory** — with a cold worker per fixture the collision was invisible.
+
 `rsvelte_lint` (native Svelte linter: validator/a11y wrap + a native port of
 `eslint-plugin-svelte`'s rules, `crates/rsvelte_lint`) ships as its own npm package,
 [`@rsvelte/lint`](apps/npm/lint), fixed-versioned with `@rsvelte/compiler` via Changesets.

--- a/crates/rsvelte_check/src/svelte_check/runner.rs
+++ b/crates/rsvelte_check/src/svelte_check/runner.rs
@@ -8,6 +8,7 @@
 
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
+use std::time::Instant;
 
 use rayon::prelude::*;
 
@@ -180,6 +181,48 @@ pub fn absolutize_workspace(path: &Path) -> PathBuf {
     super::overlay::absolutize(path)
 }
 
+/// Per-phase wall-clock split, printed to stderr under `RSVELTE_CHECK_TIMING`.
+///
+/// A single total cannot attribute a movement to walk / compile / overlay /
+/// tsgo, and those four have independent costs and independent fixes.
+struct Phases {
+    enabled: bool,
+    last: Instant,
+    rows: Vec<(&'static str, f64)>,
+}
+
+impl Phases {
+    fn new() -> Self {
+        Self {
+            enabled: std::env::var_os("RSVELTE_CHECK_TIMING").is_some_and(|v| v != "0"),
+            last: Instant::now(),
+            rows: Vec::new(),
+        }
+    }
+
+    fn mark(&mut self, name: &'static str) {
+        if !self.enabled {
+            return;
+        }
+        let now = Instant::now();
+        self.rows
+            .push((name, now.duration_since(self.last).as_secs_f64() * 1000.0));
+        self.last = now;
+    }
+
+    fn report(&self) {
+        if !self.enabled {
+            return;
+        }
+        let total: f64 = self.rows.iter().map(|(_, ms)| ms).sum();
+        for (name, ms) in &self.rows {
+            let share = if total > 0.0 { ms / total * 100.0 } else { 0.0 };
+            eprintln!("[timing] {name:<10} {ms:9.1} ms  {share:5.1}%");
+        }
+        eprintln!("[timing] {:<10} {total:9.1} ms  100.0%", "total");
+    }
+}
+
 /// Run rsvelte's compiler on every `.svelte` file under `options.workspace`
 /// and collect the resulting diagnostics. tsgo / svelte2tsx integration
 /// will plug in here in a follow-up.
@@ -195,6 +238,7 @@ pub fn absolutize_workspace(path: &Path) -> PathBuf {
 /// `absolutize_workspace`, or the two won't agree (#1919).
 #[must_use]
 pub fn run(options: &RunOptions) -> RunResult {
+    let mut phases = Phases::new();
     let workspace = absolutize_workspace(&options.workspace);
     let options = &RunOptions {
         workspace,
@@ -211,12 +255,14 @@ pub fn run(options: &RunOptions) -> RunResult {
     let files = relevant.svelte;
     let kit_files = relevant.kit;
     let files_checked = files.len();
+    phases.mark("walk");
     let diagnostics = compile_files_with_cache(
         &files,
         &options.workspace,
         options.incremental,
         &compiler_opts,
     );
+    phases.mark("compile");
     let mut result = RunResult {
         diagnostics,
         files_checked,
@@ -236,6 +282,7 @@ pub fn run(options: &RunOptions) -> RunResult {
             &compiler_opts,
         ) {
             Ok(layout) => {
+                phases.mark("overlay");
                 if options.type_check {
                     // The overlay restates the project's `paths` with absolute
                     // targets, which denies the compiler its own validation of
@@ -252,6 +299,7 @@ pub fn run(options: &RunOptions) -> RunResult {
                         options.prefer_tsgo,
                         &mut result.diagnostics,
                     );
+                    phases.mark("typecheck");
                 }
                 result.overlay = Some(layout);
             }
@@ -293,6 +341,8 @@ pub fn run(options: &RunOptions) -> RunResult {
     apply_warning_filter(&mut result.diagnostics, options);
 
     apply_filters(&mut result.diagnostics, options);
+    phases.mark("post");
+    phases.report();
 
     result
 }

--- a/crates/rsvelte_lint_types/src/lib.rs
+++ b/crates/rsvelte_lint_types/src/lib.rs
@@ -9,7 +9,8 @@
 //! 2. appends a universal probe anchor
 //!    (`ReturnType<typeof $$render>["props"]`) so the fully-resolved props type
 //!    can be queried without knowing the user's type name,
-//! 3. opens the generated TSX as the session's virtual document, and
+//! 3. opens the generated TSX as a virtual document in a [`CorsaTypeSession`]
+//!    (one worker process, reused across components), and
 //! 4. answers [`TypeBackend::probe_props`] / [`TypeBackend::probe_expr`] via
 //!    `get_type_at_position` probes (byte→UTF-16 converted).
 //!
@@ -18,8 +19,11 @@
 
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
+use std::rc::Rc;
 
-use corsa_client::api::{ApiMode, ApiSpawnConfig, ProjectSession, TypeHandle, TypeProbeOptions};
+use corsa_client::api::{
+    ApiClient, ApiMode, ApiSpawnConfig, ProjectSession, TypeHandle, TypeProbeOptions,
+};
 use corsa_runtime::block_on;
 use rsvelte_lint::type_backend::{PropMeta, TypeBackend, TypeFacts, TypeId, TypeMeta};
 use rsvelte_projection::svelte2tsx::{Svelte2TsxOptions, svelte2tsx};
@@ -58,6 +62,102 @@ pub fn lint_component_types(
         config,
         &mut backend,
     ));
+    Ok(out)
+}
+
+/// Lint several components with the **type-aware** rules on ONE warm worker.
+///
+/// The per-component entry point spawns a `tsgo` worker each time, which costs
+/// more than every probe it then answers; this opens the worker once.
+///
+/// # Errors
+///
+/// Returns an error when the worker cannot be started. A component whose own
+/// projection or project open fails is reported with no diagnostics rather
+/// than failing the batch.
+pub fn lint_components_types(
+    components: &[(PathBuf, String)],
+    config: &rsvelte_lint::config::LintConfig,
+    tsgo: &Path,
+    project_root: &Path,
+) -> Result<Vec<(PathBuf, Vec<Diagnostic>)>, String> {
+    use rsvelte_lint::rules::{no_navigation_without_resolve, no_unused_props};
+
+    if components.is_empty() {
+        return Ok(Vec::new());
+    }
+    let session = CorsaTypeSession::new(tsgo, project_root)?;
+
+    // Lower every component before the program is opened: the tsconfig has to
+    // name all of them at once, so a component added later would need a second
+    // program.
+    let projected: Vec<Option<Projected>> = components
+        .iter()
+        .map(|(path, source)| Projected::write(source, path).ok())
+        .collect();
+    let _files: Vec<VirtualFileGuard> = projected
+        .iter()
+        .flatten()
+        .map(|p| VirtualFileGuard(p.virtual_path.clone()))
+        .collect();
+
+    let virtual_paths: Vec<String> = projected
+        .iter()
+        .flatten()
+        .map(|p| json_string(&p.virtual_path.to_string_lossy()))
+        .collect();
+    if virtual_paths.is_empty() {
+        return Ok(components
+            .iter()
+            .map(|(path, _)| (path.clone(), Vec::new()))
+            .collect());
+    }
+    let tsconfig_path = project_root.join(format!(
+        ".rsvelte-lint.{}.tsconfig.json",
+        std::process::id()
+    ));
+    let tsconfig = TSCONFIG.replace(
+        "\"jsx\": \"preserve\"\n  }",
+        &format!(
+            "\"jsx\": \"preserve\"\n  }},\n  \"files\": [{}]",
+            virtual_paths.join(",")
+        ),
+    );
+    std::fs::write(&tsconfig_path, tsconfig)
+        .map_err(|e| format!("failed to write tsconfig {}: {e}", tsconfig_path.display()))?;
+    let tsconfig_guard = VirtualFileGuard(tsconfig_path.clone());
+
+    let first = projected
+        .iter()
+        .flatten()
+        .next()
+        .map(|p| p.virtual_path.to_string_lossy().into_owned());
+    let project = Rc::new(
+        block_on(ProjectSession::open(
+            session.client.clone(),
+            tsconfig_path.to_string_lossy().into_owned(),
+            first.map(Into::into),
+        ))
+        .map_err(|e| format!("failed to open corsa project: {e}"))?,
+    );
+    drop(tsconfig_guard);
+
+    let mut out = Vec::with_capacity(components.len());
+    for ((path, source), p) in components.iter().zip(projected) {
+        let Some(p) = p else {
+            out.push((path.clone(), Vec::new()));
+            continue;
+        };
+        let mut backend = CorsaTypeBackend::view(Rc::clone(&project), p);
+        let mut diags = no_unused_props::diagnostics_typed(source, path, config, &mut backend);
+        diags.extend(no_navigation_without_resolve::diagnostics_typed(
+            source,
+            path,
+            config,
+            &mut backend,
+        ));
+        out.push((path.clone(), diags));
+    }
     Ok(out)
 }
 
@@ -102,9 +202,130 @@ enum PropsTypeCache {
     Present(TypeId),
 }
 
+/// One component lowered to TSX and written beside its source, so relative
+/// imports (`./types`) resolve exactly as they do for the real file.
+struct Projected {
+    tsx: String,
+    forward_map: Vec<(u32, u32, u32)>,
+    props_anchor: Option<u32>,
+    virtual_path: PathBuf,
+}
+
+impl Projected {
+    fn write(source: &str, svelte_path: &Path) -> Result<Self, String> {
+        let filename = svelte_path.file_name().map_or_else(
+            || "Component.svelte".to_string(),
+            |n| n.to_string_lossy().into_owned(),
+        );
+        let result = svelte2tsx(
+            source,
+            Svelte2TsxOptions {
+                filename,
+                is_ts_file: true,
+                ..Default::default()
+            },
+        )
+        .map_err(|e| format!("svelte2tsx failed: {e:?}"))?;
+
+        let mut tsx = result.code;
+        // Inject the props anchor only when a render function exists to index.
+        let props_anchor = if tsx.contains("function $$render") {
+            tsx.push_str(PROPS_ANCHOR);
+            tsx.rfind(PROPS_ANCHOR_IDENT)
+                .and_then(|p| u32::try_from(p).ok())
+        } else {
+            None
+        };
+
+        let dir = svelte_path
+            .parent()
+            .map_or_else(|| PathBuf::from("."), Path::to_path_buf);
+        let stem = svelte_path.file_stem().map_or_else(
+            || "Component".to_string(),
+            |s| s.to_string_lossy().into_owned(),
+        );
+        let virtual_path = dir.join(format!("{stem}.{}.rsvelte-lint.tsx", std::process::id()));
+        std::fs::write(&virtual_path, &tsx).map_err(|e| {
+            format!(
+                "failed to write virtual TSX {}: {e}",
+                virtual_path.display()
+            )
+        })?;
+
+        Ok(Self {
+            tsx,
+            forward_map: result.forward_map,
+            props_anchor,
+            virtual_path,
+        })
+    }
+}
+
+/// A warm `tsgo` worker shared by every component of one lint run.
+///
+/// Spawning the worker and loading its libs costs far more than the probes it
+/// answers, so the process is opened once and each component only opens a
+/// project on top of it.
+pub struct CorsaTypeSession {
+    client: ApiClient,
+    closed: bool,
+}
+
+impl CorsaTypeSession {
+    /// Spawn the worker for `tsgo`, resolving relative paths against `cwd`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the worker cannot be spawned.
+    pub fn new(tsgo: &Path, cwd: &Path) -> Result<Self, String> {
+        let client = block_on(ApiClient::spawn(
+            ApiSpawnConfig::new(tsgo)
+                .with_mode(api_mode_for(tsgo))
+                .with_cwd(cwd),
+        ))
+        .map_err(|e| format!("failed to spawn corsa worker: {e}"))?;
+        Ok(Self {
+            client,
+            closed: false,
+        })
+    }
+
+    /// Open `source` (the `.svelte` file at `svelte_path`) on this worker.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when projection, virtual-file setup, or opening the
+    /// project fails.
+    pub fn backend(&self, source: &str, svelte_path: &Path) -> Result<CorsaTypeBackend, String> {
+        CorsaTypeBackend::open(self.client.clone(), None, source, svelte_path)
+    }
+
+    /// Shut the worker down. Idempotent.
+    pub fn close(&mut self) {
+        if self.closed {
+            return;
+        }
+        self.closed = true;
+        let _ = block_on(self.client.close());
+    }
+}
+
+impl Drop for CorsaTypeSession {
+    fn drop(&mut self) {
+        self.close();
+    }
+}
+
 /// A corsa/tsgo-backed [`TypeBackend`] for a single Svelte component.
 pub struct CorsaTypeBackend {
-    session: ProjectSession,
+    /// Kept alive only when this backend spawned its own worker
+    /// ([`CorsaTypeBackend::new`]); `None` when the worker is shared.
+    owned_worker: Option<CorsaTypeSession>,
+    /// Shared with every sibling component when one program covers them all.
+    session: Rc<ProjectSession>,
+    /// Whether dropping this backend should unlink the virtual TSX. False when
+    /// a batch owns the file for the lifetime of the shared program.
+    owns_virtual_file: bool,
     /// The generated TSX (with the props anchor appended) — kept for byte→UTF-16
     /// conversion at probe time.
     tsx: String,
@@ -130,53 +351,39 @@ pub struct CorsaTypeBackend {
 
 impl CorsaTypeBackend {
     /// Create a backend for `source` (the `.svelte` file at `svelte_path`),
-    /// driving the `tsgo` binary at `tsgo`. The virtual TSX document is written
-    /// beside `svelte_path` so relative imports (`./types`) resolve.
+    /// spawning a worker for the `tsgo` binary at `tsgo` and owning it. Prefer
+    /// [`CorsaTypeSession::backend`] when more than one component is checked.
     ///
     /// # Errors
     ///
     /// Returns an error when projection, virtual-file setup, or the checker
     /// session initialization fails.
     pub fn new(source: &str, svelte_path: &Path, tsgo: &Path) -> Result<Self, String> {
-        let filename = svelte_path.file_name().map_or_else(
-            || "Component.svelte".to_string(),
-            |n| n.to_string_lossy().into_owned(),
-        );
-        let result = svelte2tsx(
-            source,
-            Svelte2TsxOptions {
-                filename,
-                is_ts_file: true,
-                ..Default::default()
-            },
-        )
-        .map_err(|e| format!("svelte2tsx failed: {e:?}"))?;
+        let cwd = svelte_path
+            .parent()
+            .map_or_else(|| PathBuf::from("."), Path::to_path_buf);
+        let worker = CorsaTypeSession::new(tsgo, &cwd)?;
+        Self::open(worker.client.clone(), Some(worker), source, svelte_path)
+    }
 
-        let mut tsx = result.code;
-        // Inject the props anchor only when a render function exists to index.
-        let props_anchor = if tsx.contains("function $$render") {
-            tsx.push_str(PROPS_ANCHOR);
-            tsx.rfind(PROPS_ANCHOR_IDENT)
-                .and_then(|p| u32::try_from(p).ok())
-        } else {
-            None
-        };
-
+    /// Open a component on an already-spawned worker. The virtual TSX document
+    /// is written beside `svelte_path` so relative imports (`./types`) resolve.
+    fn open(
+        client: ApiClient,
+        owned_worker: Option<CorsaTypeSession>,
+        source: &str,
+        svelte_path: &Path,
+    ) -> Result<Self, String> {
+        let projected = Projected::write(source, svelte_path)?;
+        let Projected {
+            tsx,
+            forward_map,
+            props_anchor,
+            virtual_path,
+        } = projected;
         let project_root = svelte_path
             .parent()
             .map_or_else(|| PathBuf::from("."), Path::to_path_buf);
-        let stem = svelte_path.file_stem().map_or_else(
-            || "Component".to_string(),
-            |s| s.to_string_lossy().into_owned(),
-        );
-        let virtual_path =
-            project_root.join(format!("{stem}.{}.rsvelte-lint.tsx", std::process::id()));
-        std::fs::write(&virtual_path, &tsx).map_err(|e| {
-            format!(
-                "failed to write virtual TSX {}: {e}",
-                virtual_path.display()
-            )
-        })?;
         let cleanup = VirtualFileGuard(virtual_path.clone());
 
         // tsconfig listing the absolute virtual file (kept beside the source so
@@ -197,15 +404,12 @@ impl CorsaTypeBackend {
         let tsconfig_guard = VirtualFileGuard(tsconfig_path.clone());
 
         let virtual_wire = virtual_path.to_string_lossy().into_owned();
-        let mode = api_mode_for(tsgo);
-        let session = block_on(ProjectSession::spawn(
-            ApiSpawnConfig::new(tsgo)
-                .with_mode(mode)
-                .with_cwd(&project_root),
+        let session = block_on(ProjectSession::open(
+            client,
             tsconfig_path.to_string_lossy().into_owned(),
             Some(virtual_wire.clone().into()),
         ))
-        .map_err(|e| format!("failed to spawn corsa session: {e}"))?;
+        .map_err(|e| format!("failed to open corsa project: {e}"))?;
 
         // The tsconfig only needs to exist for the initial program load.
         drop(tsconfig_guard);
@@ -213,9 +417,11 @@ impl CorsaTypeBackend {
         std::mem::forget(cleanup); // ownership transferred to the struct's Drop
 
         Ok(Self {
-            session,
+            owned_worker,
+            session: Rc::new(session),
+            owns_virtual_file: true,
             tsx,
-            forward_map: result.forward_map,
+            forward_map,
             props_anchor,
             virtual_wire,
             virtual_path,
@@ -224,6 +430,26 @@ impl CorsaTypeBackend {
             type_index: HashMap::new(),
             props_type_cache: PropsTypeCache::Uncomputed,
         })
+    }
+
+    /// A component view onto a program that already contains its virtual TSX.
+    /// The batch owns the file, so dropping this view must not unlink it.
+    fn view(session: Rc<ProjectSession>, projected: Projected) -> Self {
+        let virtual_wire = projected.virtual_path.to_string_lossy().into_owned();
+        Self {
+            owned_worker: None,
+            session,
+            owns_virtual_file: false,
+            tsx: projected.tsx,
+            forward_map: projected.forward_map,
+            props_anchor: projected.props_anchor,
+            virtual_wire,
+            virtual_path: projected.virtual_path,
+            closed: false,
+            types: Vec::new(),
+            type_index: HashMap::new(),
+            props_type_cache: PropsTypeCache::Uncomputed,
+        }
     }
 
     /// Intern a type (handle + `ObjectFlags`) into a stable [`TypeId`], deduping
@@ -322,8 +548,12 @@ impl CorsaTypeBackend {
             return;
         }
         self.closed = true;
-        let _ = block_on(self.session.close());
-        let _ = std::fs::remove_file(&self.virtual_path);
+        if self.owns_virtual_file {
+            let _ = std::fs::remove_file(&self.virtual_path);
+        }
+        if let Some(worker) = self.owned_worker.as_mut() {
+            worker.close();
+        }
     }
 }
 

--- a/crates/rsvelte_lint_types/tests/no_unused_props_fixtures.rs
+++ b/crates/rsvelte_lint_types/tests/no_unused_props_fixtures.rs
@@ -11,7 +11,7 @@ use std::path::{Path, PathBuf};
 
 use rsvelte_lint::config::LintConfig;
 use rsvelte_lint::rules::no_unused_props;
-use rsvelte_lint_types::{CorsaTypeBackend, require_tsgo};
+use rsvelte_lint_types::{CorsaTypeSession, lint_components_types, require_tsgo};
 use serde::Deserialize;
 
 /// Lower bound on the fixture count, so a moved/renamed upstream directory
@@ -67,13 +67,20 @@ fn config_for(config_path: &Path) -> LintConfig {
 
 /// Run one fixture through the typed graph path; returns `(line, column1, message)`
 /// tuples (column is 1-based to match the fixtures).
-fn run_fixture(input: &Path, tsgo: &Path) -> Vec<(u32, u32, String)> {
+fn run_fixture(input: &Path, session: &CorsaTypeSession) -> Vec<(u32, u32, String)> {
     let source = std::fs::read_to_string(input).unwrap();
     let stem = input.file_stem().unwrap().to_string_lossy();
     let stem = stem.strip_suffix("-input").unwrap_or(&stem);
 
+    // `invalid/` and `valid/` hold same-named fixtures, so the enclosing
+    // directory has to be part of the temp path: a warm worker serves the
+    // second one from the first one's cached project.
+    let kind = input.parent().and_then(|p| p.file_name()).map_or_else(
+        || "fixture".to_string(),
+        |n| n.to_string_lossy().into_owned(),
+    );
     let dir = std::env::temp_dir().join(format!(
-        "rsvelte-nup-{}-{}",
+        "rsvelte-nup-{}-{kind}-{}",
         std::process::id(),
         stem.replace(['/', '.'], "_")
     ));
@@ -91,7 +98,7 @@ fn run_fixture(input: &Path, tsgo: &Path) -> Vec<(u32, u32, String)> {
     let config_path = input.with_file_name(format!("{stem}-config.json"));
     let cfg = config_for(&config_path);
 
-    let mut backend = CorsaTypeBackend::new(&source, &svelte_path, tsgo).expect("backend");
+    let mut backend = session.backend(&source, &svelte_path).expect("backend");
     let diags = no_unused_props::diagnostics_typed(&source, &svelte_path, &cfg, &mut backend);
     drop(backend);
     let _ = std::fs::remove_dir_all(&dir);
@@ -149,13 +156,14 @@ fn collect_inputs(dir: &Path) -> Vec<PathBuf> {
 fn no_unused_props_typed_oracle() {
     let tsgo = require_tsgo(Path::new(env!("CARGO_MANIFEST_DIR")));
     let root = fixture_root();
+    let session = CorsaTypeSession::new(&tsgo, &std::env::temp_dir()).expect("worker should start");
 
     let mut failures = Vec::new();
     let mut checked = 0;
     for kind in ["invalid", "valid"] {
         for input in collect_inputs(&root.join(kind)) {
             let name = format!("{kind}/{}", input.file_stem().unwrap().to_string_lossy());
-            let actual = run_fixture(&input, &tsgo);
+            let actual = run_fixture(&input, &session);
             let expected = expected_for(&input);
             checked += 1;
             if actual != expected {
@@ -179,4 +187,84 @@ fn no_unused_props_typed_oracle() {
         failures.join("\n")
     );
     eprintln!("no_unused_props_typed_oracle: {checked} fixtures OK");
+}
+
+/// The batch entry point puts every component in ONE program; a component that
+/// silently failed to enter it would answer `any` and report nothing, which is
+/// indistinguishable from "no findings" without comparing to the per-component
+/// path.
+#[test]
+fn batch_program_matches_per_component() {
+    let tsgo = require_tsgo(Path::new(env!("CARGO_MANIFEST_DIR")));
+    let root = fixture_root();
+    let batch_root = std::env::temp_dir().join(format!("rsvelte-nup-batch-{}", std::process::id()));
+    std::fs::create_dir_all(&batch_root).unwrap();
+
+    let mut components = Vec::new();
+    let mut expected = Vec::new();
+    for kind in ["invalid", "valid"] {
+        for input in collect_inputs(&root.join(kind)) {
+            let stem = input.file_stem().unwrap().to_string_lossy();
+            let stem = stem.strip_suffix("-input").unwrap_or(&stem).to_string();
+            // One config per batch, so only default-config fixtures qualify.
+            if input
+                .with_file_name(format!("{stem}-config.json"))
+                .is_file()
+            {
+                continue;
+            }
+            let dir = batch_root.join(format!("{kind}-{stem}"));
+            std::fs::create_dir_all(&dir).unwrap();
+            if let Some(parent) = input.parent() {
+                let shared = parent.join("shared-types.ts");
+                if shared.is_file() {
+                    let _ = std::fs::copy(&shared, dir.join("shared-types.ts"));
+                }
+            }
+            let source = std::fs::read_to_string(&input).unwrap();
+            let svelte_path = dir.join(format!("{stem}.svelte"));
+            std::fs::write(&svelte_path, &source).unwrap();
+            components.push((svelte_path, source));
+            expected.push((format!("{kind}/{stem}"), expected_for(&input)));
+        }
+    }
+    assert!(
+        components.len() >= 20,
+        "batch test ran only {} fixtures — upstream layout changed?",
+        components.len()
+    );
+    // Without a fixture that must report, an all-empty batch would pass.
+    assert!(
+        expected.iter().any(|(_, want)| !want.is_empty()),
+        "batch test selected no fixture with an expected finding"
+    );
+
+    let cfg = config_for(Path::new("this-file-does-not-exist.json"));
+    let results = lint_components_types(&components, &cfg, &tsgo, &batch_root)
+        .expect("batch session should start");
+    let _ = std::fs::remove_dir_all(&batch_root);
+
+    let mut failures = Vec::new();
+    for ((name, want), (_, diags)) in expected.iter().zip(&results) {
+        let mut got: Vec<(u32, u32, String)> = diags
+            .iter()
+            .filter_map(|d| {
+                let r = d.range?;
+                Some((r.start.line, r.start.column + 1, d.message.clone()))
+            })
+            .collect();
+        got.sort();
+        if &got != want {
+            failures.push(format!(
+                "  {name}\n    expected: {want:?}\n    actual:   {got:?}"
+            ));
+        }
+    }
+    assert!(
+        failures.is_empty(),
+        "{}/{} batched fixtures diverged from the per-component path:\n{}",
+        failures.len(),
+        results.len(),
+        failures.join("\n")
+    );
 }


### PR DESCRIPTION
## What

Two independent changes, both driven by measurement rather than by a suspicion.

### 1. Type-aware lint opens one tsgo worker per run, not one per component

`CorsaTypeBackend::new` spawned a corsa/tsgo API worker, wrote a virtual `.tsx` plus a
tsconfig, and built a program for **every component**. `CorsaTypeSession` now owns the
worker and each component only opens a project on it; `lint_components_types` batches a
whole project into a single program.

Measured over the 76 upstream `no-unused-props` fixtures — one test binary, both arms,
ABBA-ordered, 5 pairs, idle machine:

| arm | total |
|---|---|
| worker per component (before) | 6.62 – 11.02 s |
| one warm worker (after) | 1.23 – 2.94 s |

**5.4x** on the min estimator, **4.3x** on medians. It is a lower bound: the Rust side is a
debug build in both arms, and fixed cost compresses ratios.

**One program for all components is NOT the win; the warm process is.** 62 fixtures in a
single program measured 26-39 ms/component against 23-58 ms/component for a
project-per-component on the same worker — no separable difference. Those fixtures are
independent files, so a shared program shares no module graph; whether a real project
(whose components import each other) profits is **unmeasured**, and both entry points are
kept for that reason.

`batch_program_matches_per_component` exists because a component that never entered the
program answers `any` and reports nothing — indistinguishable from "no findings" unless it
is compared against the per-component path. It asserts a fixture with an expected finding
is in the batch, so an all-empty result cannot pass.

The refactor also surfaced a harness defect: `invalid/` and `valid/` hold same-named
fixtures while the temp dir was keyed on the stem alone, so a warm worker served the second
from the first one's cached project. **Reversing the iteration order moved the failures to
the other directory** — with a cold worker per fixture the collision was invisible.

### 2. `rsvelte-check` reports its per-phase wall-clock split

`RSVELTE_CHECK_TIMING=1` prints walk / compile / overlay / typecheck / post to stderr. A
single total cannot attribute a movement to any one of them, and they have independent
costs and independent fixes.

What it immediately showed, on synthetic 100- and 500-component projects (TS 7.1 `tsc`,
`skipLibCheck`, 3 runs each):

| phase | 100 comp | 500 comp |
|---|---|---|
| typecheck | 85-89% | 66-73% |
| overlay | 8-12% | 21-29% |
| compile (rsvelte) | 3-8% | 6-8% |
| walk + post | <1% | <2% |

Two consequences, both recorded in AGENTS.md:

- **The overlay is not the lever.** Even a free overlay caps a run at 1.1-1.4x. A diskless
  overlay is not available anyway — a batch `tsc -p` reads its program from disk, so the
  LSP's in-memory projection has no counterpart here.
- **`--incremental` is the largest measured lever and it stays off by default.** On the
  500-component project a warm run drops from 1693-2147 ms to 254-319 ms (**5.4-6.7x**),
  because the overlay tsconfig already carries `incremental` + `tsBuildInfoFile`. The
  default is deliberately unchanged: official svelte-check's flag is opt-in too, and its
  README states the mode "might result in slightly different type check outcomes".
  Flipping it would trade goal #3 for speed on a mode upstream itself calls lossy.

Incidental finding worth a follow-up: 500 components materialize **2,005 files** — a
`.svelte.tsx`, a `.svelte.tsx.map`, and two byte-identical `.d.ts` bridges each.

## Testing

- `cargo test -p rsvelte_check` — exit 0, 11 suites
- `pnpm run test:type-aware-lint` equivalent (`cargo test` in `crates/rsvelte_lint_types`
  with `CORSA_EXECUTABLE` set) — 10 tests, all green, suite wall time 8.5 s → 0.8 s
- `cargo fmt` + `cargo clippy --all-targets --all-features` clean in both workspaces

## Not in this PR

The content-mapper work discussed alongside this. Content mappers landed in
`typescript-go#4712` (merged 2026-08-19) and are live as of `typescript@7.1.0-dev.20260821.1`
(verified: `--runExternalCode` wired, `TS100024` / `TS100031` reachable), but they do not
touch the 66-89% that type checking owns — they change how files enter the program, not how
long checking them takes.
