### PR TITLE
fix(compiler): strip a leading UTF-8 BOM before compiling

### DIFF
--- a/.changeset/quiet-jars-smile.md
+++ b/.changeset/quiet-jars-smile.md
@@ -1,0 +1,5 @@
+---
+'@rsvelte/compiler': patch
+---
+
+Strip a leading UTF-8 BOM before compiling, as `svelte/compiler` does. A BOM at the start of a `.svelte` or `.svelte.js` file was treated as template content, which added a text node to the client template (changing the extra-node flag and the fragment shape) and a stray zero-width no-break space to the server output.

--- a/crates/rsvelte_core/src/compiler/mod.rs
+++ b/crates/rsvelte_core/src/compiler/mod.rs
@@ -533,6 +533,13 @@ fn tabs_to_spaces_column(line: &str, column: usize) -> usize {
     taken + leading_tabs.min(taken)
 }
 
+/// Drop a leading byte order mark, which would otherwise be template content.
+/// Upstream `compiler/index.js` does this at every public entry point, so every
+/// position downstream is relative to the trimmed source.
+pub(crate) fn remove_bom(source: &str) -> &str {
+    source.strip_prefix('\u{feff}').unwrap_or(source)
+}
+
 /// Parse phase shared by [`compile`] and [`compile_both`]: the fixed component
 /// parse options plus [`phase1_parse::parse`](phases::phase1_parse::parse).
 ///
@@ -931,6 +938,7 @@ pub fn compile_module(
     source: &str,
     options: ModuleCompileOptions,
 ) -> Result<CompileResult, CompileError> {
+    let source = remove_bom(source);
     // Parse JS source into an AST using the same infrastructure as component scripts.
     // Upstream `compileModule` → `analyze_module` always parses with
     // `typescript: false` (2-analyze/index.js `parse(source, comments, false,

--- a/crates/rsvelte_core/src/toolchain.rs
+++ b/crates/rsvelte_core/src/toolchain.rs
@@ -340,6 +340,7 @@ impl std::fmt::Debug for PreparedComponent<'_> {
 
 impl<'source> PreparedComponent<'source> {
     pub(crate) fn new(source: &'source str, options: CompileOptions) -> Result<Self, CompileError> {
+        let source = crate::compiler::remove_bom(source);
         let mut ast = Box::new(crate::compiler::parse_component(
             source,
             options.modern_ast,

--- a/crates/rsvelte_core/tests/leading_bom_3277.rs
+++ b/crates/rsvelte_core/tests/leading_bom_3277.rs
@@ -1,0 +1,98 @@
+//! A leading UTF-8 BOM is not document content. Upstream's `compiler/index.js`
+//! calls `remove_bom` at every public entry (`compile`, `compileModule`,
+//! `parse`, `parseCss`) before anything sees the source; rsvelte kept it, so it
+//! became a template text node — which also shifts the template's node count,
+//! so the client's extra-node flag and the server's leading anchor move with it.
+//!
+//! Every expectation here was read off the official compiler
+//! (`submodules/svelte`) one input per process.
+
+use rsvelte_core::{
+    CompileOptions, GenerateMode, ModuleCompileOptions, compile, compile_both, compile_module,
+};
+
+const BOM: &str = "\u{feff}";
+
+fn js(src: &str, generate: GenerateMode) -> String {
+    compile(
+        src,
+        CompileOptions {
+            filename: Some("Main.svelte".to_string()),
+            generate,
+            ..Default::default()
+        },
+    )
+    .expect("compile")
+    .js
+    .code
+}
+
+#[test]
+fn leading_bom_is_not_template_content() {
+    let source = "<p>x</p>";
+    for generate in [GenerateMode::Client, GenerateMode::Server] {
+        assert_eq!(
+            js(&format!("{BOM}{source}"), generate),
+            js(source, generate),
+            "a leading BOM must compile like the same source without one"
+        );
+    }
+    // Positive control: the un-stripped form really did carry the BOM into the
+    // template, so this test can fail.
+    assert!(!js(source, GenerateMode::Client).contains(BOM));
+}
+
+#[test]
+fn leading_bom_with_a_script_is_stripped_too() {
+    let source = "<script>\n\tlet x = 1;\n</script>\n\n<p>{x}</p>\n";
+    for generate in [GenerateMode::Client, GenerateMode::Server] {
+        assert_eq!(
+            js(&format!("{BOM}{source}"), generate),
+            js(source, generate)
+        );
+    }
+}
+
+#[test]
+fn a_bom_that_is_not_leading_is_left_alone() {
+    // Control: upstream only strips index 0, so U+FEFF elsewhere stays content.
+    let with_inner_bom = format!("<p>a{BOM}b</p>");
+    assert!(js(&with_inner_bom, GenerateMode::Client).contains(BOM));
+    assert_eq!(
+        js(&format!("{BOM}{with_inner_bom}"), GenerateMode::Client),
+        js(&with_inner_bom, GenerateMode::Client)
+    );
+}
+
+#[test]
+fn compile_both_strips_the_leading_bom() {
+    let source = "<p>x</p>";
+    let (with_client, with_server) = compile_both(
+        &format!("{BOM}{source}"),
+        CompileOptions {
+            filename: Some("Main.svelte".to_string()),
+            ..Default::default()
+        },
+    )
+    .expect("compile_both");
+    assert_eq!(with_client.js.code, js(source, GenerateMode::Client));
+    assert_eq!(with_server.js.code, js(source, GenerateMode::Server));
+}
+
+#[test]
+fn compile_module_strips_the_leading_bom() {
+    let source = "export let count = $state(0);\n";
+    let module = |src: &str| {
+        compile_module(
+            src,
+            ModuleCompileOptions {
+                filename: Some("state.svelte.js".to_string()),
+                ..Default::default()
+            },
+        )
+        .expect("compile_module")
+        .js
+        .code
+    };
+    assert_eq!(module(&format!("{BOM}{source}")), module(source));
+}


### PR DESCRIPTION
## What

A leading UTF-8 BOM was compiled as document content.

Upstream `submodules/svelte/packages/svelte/src/compiler/index.js` calls
`remove_bom(source)` at **every** public entry — `compile`, `compileModule`,
`parse`, `parseCss` — so `U+FEFF` at index 0 never reaches the parser and every
position downstream is relative to the trimmed source. rsvelte kept it.

## Measured, before

```
$ printf '\xef\xbb\xbf<p>x</p>\n' > t.svelte     # BOM, then markup
```

```diff
-var root = $.from_html(`<p>x</p>`);
+var root = $.from_html(`﻿<p>x</p>`, 1);

 export default function T($$anchor) {
-	var p = root();
+	$.next();
+	var fragment = root();
+	$.next();
-	$.append($$anchor, p);
+	$.append($$anchor, fragment);
 }
```

So it is not only a byte divergence: the template gains a node, so the
extra-node flag and the `$.next()` / `var fragment = root()` shape change with
it, and a hydrating client walks a different node count than the server
produced. The server pushed the BOM into its markup for the same reason.

## Fix

`compiler::remove_bom` (one `strip_prefix('\u{feff}')`), applied at the two
funnels the public API goes through:

* `toolchain::PreparedComponent::new` — covers `compile`, `compile_both`,
  `compile_client_with_program_sink`, `compile_with_external_sourcemap_content`,
  `compile_batch` and `Toolchain::prepare`, and stores the trimmed slice, so
  transform, warnings and `sourcesContent` all see one source;
* `compiler::compile_module`.

It is a strict no-op for a source that does not start with a BOM.

## Verification

Every expectation was read off the official compiler
(`submodules/svelte/packages/svelte/src/compiler/index.js`), one input per
process, against `compile_one`:

| source | before | after |
|---|---|---|
| BOM + `<p>x</p>`, client | DIVERGE | MATCH |
| BOM + `<p>x</p>`, server | DIVERGE | MATCH |
| BOM + `<script>` + markup, client / server | DIVERGE | MATCH |
| `<p>a␎FEFF␏b</p>` (BOM **not** leading), client | MATCH | MATCH |
| BOM + `<p>a␎FEFF␏b</p>` | — | MATCH (only index 0 is stripped) |

`compileModule('﻿' + src)` is byte-identical to `compileModule(src)`
upstream; `crates/rsvelte_core/tests/leading_bom_3277.rs` pins that too.

Regression test: `crates/rsvelte_core/tests/leading_bom_3277.rs` (5 tests,
covering client, server, `compile_both`, `compile_module`, and the
non-leading-BOM control).

Not in scope: the standalone `parse()` / `parseEnvelope` NAPI surface, which
upstream also strips. Stripping inside `phase1_parse::parse` would shift every
returned offset by three bytes relative to a caller that still holds the
untrimmed string (svelte2tsx, the formatter, the language server all call it
directly), so it needs its own boundary rather than a change to the shared
parser.

Closes #3277
