### PR TITLE
fix(parse): reject a duplicate {:then} / {:catch} in an await block

### DIFF
--- a/.changeset/await-duplicate-clause.md
+++ b/.changeset/await-duplicate-clause.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/compiler": patch
+---
+
+Reject a duplicate `{:then}` / `{:catch}` inside `{#await}` with `block_duplicate_clause`, as the official compiler does. rsvelte's continuation loop overwrote the clause it had already parsed, so `{#await p}a{:then v}b{:catch e}c{:catch f}d{/await}` compiled and the first `{:catch}` branch vanished from the output with no diagnostic. A clause named in the header counts too — `{#await p then v}` fills the `then` slot, so a later `{:then}` is a duplicate. The error is anchored at the `:` of the continuation marker, matching upstream's `parser.index - 1`.

--- a/crates/rsvelte_core/src/compiler/phases/1_parse/state/tag.rs
+++ b/crates/rsvelte_core/src/compiler/phases/1_parse/state/tag.rs
@@ -1368,6 +1368,15 @@ impl<'a> Parser<'a> {
         )
     }
 
+    /// Upstream anchors this at the `:` of the continuation marker, not the `{`.
+    fn block_duplicate_clause(colon_pos: usize, name: &str) -> crate::error::ParseError {
+        crate::error::ParseError::svelte(
+            "block_duplicate_clause",
+            format!("{name} cannot appear more than once within a block"),
+            (colon_pos, colon_pos),
+        )
+    }
+
     /// Parse {#await} block.
     pub fn parse_await_block(&mut self, start: usize) -> ParseResult<Option<TemplateNode<'a>>> {
         self.require_whitespace()?;
@@ -1635,6 +1644,9 @@ impl<'a> Parser<'a> {
             self.skip_whitespace();
 
             if self.eat_optional("then") {
+                if then_fragment.is_some() {
+                    return Err(Self::block_duplicate_clause(colon_pos, "{:then}"));
+                }
                 // Upstream eats `}` before requiring the separator, so `{:then}`
                 // stays legal while `{:thenv}` is not.
                 if !self.match_str("}") {
@@ -1659,6 +1671,9 @@ impl<'a> Parser<'a> {
 
                 then_fragment = Some(self.parse_fragment()?);
             } else if self.eat_optional("catch") {
+                if catch_fragment.is_some() {
+                    return Err(Self::block_duplicate_clause(colon_pos, "{:catch}"));
+                }
                 if !self.match_str("}") {
                     self.require_whitespace()?;
                 }

--- a/crates/rsvelte_core/tests/await_duplicate_clause_3349.rs
+++ b/crates/rsvelte_core/tests/await_duplicate_clause_3349.rs
@@ -1,0 +1,115 @@
+//! Regression test for issue #3349: a duplicate `{:then}` / `{:catch}` inside
+//! `{#await}` must be rejected with `block_duplicate_clause`.
+//!
+//! Bug: rsvelte's await continuation loop overwrote `then_fragment` /
+//! `catch_fragment` on every clause, so a second `{:catch}` silently replaced
+//! the first and the earlier branch's content vanished from the output with no
+//! diagnostic. Upstream raises `block_duplicate_clause` from
+//! `phases/1-parse/state/tag.js` (`if (block.then) e.block_duplicate_clause(...)`,
+//! likewise for `catch`) anchored at the `:` of the continuation marker.
+//!
+//! Expected values were read off the official compiler
+//! (`submodules/svelte/packages/svelte/src/compiler/index.js`, Svelte 5.56.10)
+//! on the same sources; both `client` and `server` agree, so this is one parse
+//! rule rather than a target-specific gap.
+
+use rsvelte_core::error::ParseError;
+use rsvelte_core::{ParseOptions, parse};
+
+fn parse_error(source: &str) -> Option<(String, String, (usize, usize))> {
+    match parse(
+        source,
+        &oxc_allocator::Allocator::default(),
+        ParseOptions::default(),
+    ) {
+        Ok(_) => None,
+        Err(ParseError::SvelteError {
+            code,
+            message,
+            span,
+        }) => Some((code, message, span)),
+        Err(other) => panic!("expected a SvelteError, got {other:?} for:\n{source}"),
+    }
+}
+
+#[track_caller]
+fn assert_duplicate(source: &str, clause: &str, colon: usize) {
+    let Some((code, message, span)) = parse_error(source) else {
+        panic!("expected `block_duplicate_clause` for {source:?}, but it parsed");
+    };
+    assert_eq!(code, "block_duplicate_clause", "for {source:?}");
+    assert_eq!(
+        message,
+        format!("{clause} cannot appear more than once within a block"),
+        "for {source:?}"
+    );
+    // Upstream's `start` is `parser.index - 1` after `{` + whitespace + `:`,
+    // i.e. the `:` byte; the error is a point, so `end` equals it.
+    assert_eq!(span, (colon, colon), "for {source:?}");
+}
+
+#[track_caller]
+fn assert_parses(source: &str) {
+    if let Some((code, _, _)) = parse_error(source) {
+        panic!("expected {source:?} to parse, got `{code}`");
+    }
+}
+
+#[test]
+fn duplicate_catch_is_rejected() {
+    //                       0         1         2         3
+    //                       0123456789012345678901234567890123
+    assert_duplicate(
+        "{#await p}a{:then v}b{:catch e}c{:catch f}d{/await}",
+        "{:catch}",
+        33,
+    );
+    assert_duplicate("{#await p}a{:catch}b{:catch}c{/await}", "{:catch}", 21);
+    // The third clause is caught by the same test as the second.
+    assert_duplicate(
+        "{#await p}a{:catch e}b{:catch f}c{:catch g}d{/await}",
+        "{:catch}",
+        23,
+    );
+}
+
+#[test]
+fn duplicate_then_is_rejected() {
+    assert_duplicate("{#await p}a{:then v}b{:then w}c{/await}", "{:then}", 22);
+    assert_duplicate("{#await p}a{:then}b{:then}c{/await}", "{:then}", 20);
+    // A `{:catch}` between the two does not reset the `{:then}` slot.
+    assert_duplicate(
+        "{#await p}a{:then v}b{:catch e}c{:then w}d{/await}",
+        "{:then}",
+        33,
+    );
+}
+
+#[test]
+fn a_header_clause_occupies_the_slot() {
+    // `{#await p then v}` fills `block.then`, so a later `{:then}` is a
+    // duplicate even though only one continuation marker appears.
+    assert_duplicate("{#await p then v}a{:then w}b{/await}", "{:then}", 19);
+    assert_duplicate("{#await p catch e}a{:catch f}b{/await}", "{:catch}", 20);
+}
+
+#[test]
+fn whitespace_before_the_colon_does_not_move_the_anchor() {
+    assert_duplicate(
+        "{#await p}a{:catch e}c{  :catch f}d{/await}",
+        "{:catch}",
+        25,
+    );
+}
+
+#[test]
+fn distinct_clauses_still_parse() {
+    // The control that could have moved: one of each, in either order, and a
+    // header clause paired with the other one.
+    assert_parses("{#await p}a{:then v}b{:catch e}c{/await}");
+    assert_parses("{#await p}a{:catch e}b{:then v}c{/await}");
+    assert_parses("{#await p}a{:then v}b{/await}");
+    assert_parses("{#await p}a{:catch e}b{/await}");
+    assert_parses("{#await p then v}a{:catch e}b{/await}");
+    assert_parses("{#await p}a{/await}");
+}


### PR DESCRIPTION
Closes #3349

`{#await}` is the only block whose `next()` arm carries a duplicate-clause test upstream, and rsvelte's await continuation loop had neither half of it: it assigned `then_fragment` / `catch_fragment` unconditionally on every clause, so a second `{:catch}` replaced the first and the earlier branch's content vanished from the output with **no diagnostic**.

```svelte
{#await p}a{:then v}b{:catch e}c{:catch f}d{/await}
```

| | verdict |
|---|---|
| official | `block_duplicate_clause` — `{:catch} cannot appear more than once within a block`, `1:33`–`1:33` |
| rsvelte (before) | compiles |

## The fix

`if (block.then) e.block_duplicate_clause(start, '{:then}')` from `phases/1-parse/state/tag.js` L595-600 and L614-619, ported to the same two positions in `parse_await_block`'s continuation loop — before the separator/pattern is read, so the error wins against a malformed pattern in the same clause, as upstream's does.

The anchor is upstream's `start = parser.index - 1` taken after `{` + whitespace + `:`, i.e. **the `:` byte**, not the `{`. `match_block_continuation_marker` already returns exactly that index, so `{  :catch f}` anchors at the `:` and not at the brace. The error is a point (`start == end`), matching `e(node, …)` with a numeric node.

## What the slot test reads

`then_fragment` / `catch_fragment` rather than "have I seen a `{:then}` marker", because **a clause named in the header fills the same slot**: `{#await p then v}a{:then w}b{/await}` is a duplicate upstream (`block.then` is set by `open()`), and it is now one here. That row was measured, not assumed — it is one of the two cases the negative control below flags.

## Expected values

Every row was read off the official compiler (`submodules/svelte/packages/svelte/src/compiler/index.js`, Svelte 5.56.10) on the same source, for `client` **and** `server`. All 13 probe inputs agree across both targets, so this is one parse rule rather than a target-specific gap. Nothing is hand-written.

Measured rows, all now reproduced byte-for-byte:

| source | code | clause | column |
|---|---|---|---|
| `{#await p}a{:then v}b{:catch e}c{:catch f}d{/await}` | `block_duplicate_clause` | `{:catch}` | 33 |
| `{#await p}a{:then v}b{:then w}c{/await}` | " | `{:then}` | 22 |
| `{#await p}a{:then}b{:then}c{/await}` | " | `{:then}` | 20 |
| `{#await p}a{:catch}b{:catch}c{/await}` | " | `{:catch}` | 21 |
| `{#await p then v}a{:then w}b{/await}` | " | `{:then}` | 19 |
| `{#await p catch e}a{:catch f}b{/await}` | " | `{:catch}` | 20 |
| `{#await p}a{:catch e}b{:catch f}c{:catch g}d{/await}` | " | `{:catch}` | 23 |
| `{#await p}a{:then v}b{:catch e}c{:then w}d{/await}` | " | `{:then}` | 33 |
| `{#await p}a{:catch e}c{  :catch f}d{/await}` | " | `{:catch}` | 25 |
| `{#await p}a{:then v}b{:catch e}c{/await}` | — compiles | | |
| `{#await p}a{:catch e}b{:then v}c{/await}` | — compiles | | |
| `{#await p then v}a{:catch e}b{/await}` | — compiles | | |
| `{#await p}a{:then v}b{/await}` | — compiles | | |

The order-independence row (`{:catch}` before `{:then}`) and the header-plus-*other*-clause row are the controls that could have moved: a fix keyed on "a clause has already been seen" rather than on the specific slot would have rejected both.

## Tests

`crates/rsvelte_core/tests/await_duplicate_clause_3349.rs` — 5 tests asserting **code, message and span** (not just "it errors"), plus a 6-input control that must still parse.

Negative control: with the two checks removed, 4 of the 5 tests fail and every failure is `expected block_duplicate_clause …, but it parsed` — the predicted reason. The fifth (`distinct_clauses_still_parse`) passes either way, as it must.

Regression scope: `parser_fixtures` (modern + legacy), `compiler_errors`, `compiler_fixtures`, `validator`, `block_close_mismatch`, `block_head_parse_errors`, `print_await_pending_only` all pass.

## Not fixed here

The `{#if}` / `{#each}` arms of `next()` have no duplicate test upstream at all — a second `{:else}` is *accepted* there (#3284, PR #3348). This PR deliberately does not touch them; a fix to one does not reach the other, which is why #3349 reads as the mirror of #3284 rather than the same defect.
