### PR TITLE
fix(parse): accept the full custom-element name production and every ID_Continue snippet name

### DIFF
--- a/.changeset/tidy-moons-argue.md
+++ b/.changeset/tidy-moons-argue.md
@@ -1,0 +1,5 @@
+---
+'@rsvelte/compiler': patch
+---
+
+Accept the full HTML `PotentialCustomElementName` production for element names and every ECMAScript `ID_Continue` character in a snippet name, and fix the three divergences those over-rejections were hiding: a declarator span whose end came from the generated identifier's byte length (a panic on a non-ASCII tag name), an ASCII-only guard around the `toLowerCase` of an HTML tag name, and an identifier sanitizer that counted characters where upstream's regex counts UTF-16 code units. Element-vs-component classification now uses upstream's `regex_valid_component_name`, so `<X-a>` and `<x-a.b>` are regular elements rather than component calls.

--- a/crates/rsvelte_core/src/compiler/phases/1_parse/parser.rs
+++ b/crates/rsvelte_core/src/compiler/phases/1_parse/parser.rs
@@ -885,23 +885,32 @@ impl<'a> Parser<'a> {
         }
     }
 
-    /// Read an identifier.
+    /// Read an identifier. Mirrors upstream's `read_identifier`, which uses
+    /// acorn's `isIdentifierStart` / `isIdentifierChar` and so accepts every
+    /// `ID_Continue` character — combining marks and ZWNJ/ZWJ included.
     #[inline]
     pub fn read_identifier(&mut self) -> CompactString {
         let start = self.index;
 
-        // Fast path: ASCII identifier characters (a-z, A-Z, 0-9, _, $)
+        let Some(first) = self.source[start..].chars().next() else {
+            return CompactString::default();
+        };
+        if !oxc_syntax::identifier::is_identifier_start(first) {
+            return CompactString::default();
+        }
+        self.index += first.len_utf8();
+
         while self.index < self.bytes.len() {
             let b = self.bytes[self.index];
-            if b.is_ascii_alphanumeric() || b == b'_' || b == b'$' {
-                self.index += 1;
-            } else if b < 0x80 {
-                // ASCII non-identifier char: done
-                break;
+            if b.is_ascii() {
+                if oxc_syntax::identifier::is_identifier_part_ascii(b as char) {
+                    self.index += 1;
+                } else {
+                    break;
+                }
             } else {
-                // Non-ASCII: check via char
                 let c = self.source[self.index..].chars().next().unwrap_or('\0');
-                if c.is_alphanumeric() {
+                if oxc_syntax::identifier::is_identifier_part_unicode(c) {
                     self.index += c.len_utf8();
                 } else {
                     break;

--- a/crates/rsvelte_core/src/compiler/phases/1_parse/state/element.rs
+++ b/crates/rsvelte_core/src/compiler/phases/1_parse/state/element.rs
@@ -890,13 +890,9 @@ impl<'a> Parser<'a> {
             "svelte:self" => ElementType::SvelteSelf,
             "svelte:options" => ElementType::SvelteOptions,
             _ => {
-                // Check if component (starts with uppercase or contains dot)
-                // Fast byte-level check: uppercase ASCII or first char is uppercase Unicode
-                let first = name.as_bytes().first().copied().unwrap_or(0);
-                if first.is_ascii_uppercase()
-                    || (first >= 0x80 && name.chars().next().is_some_and(|c| c.is_uppercase()))
-                    || memchr(b'.', name.as_bytes()).is_some()
-                {
+                // Upstream decides this with `regex_valid_component_name`, so a
+                // name it rejects (`X-a`, `x-a.b`) is a regular element.
+                if is_valid_component_name(name) || (self.options.loose && name.ends_with('.')) {
                     ElementType::Component
                 } else {
                     ElementType::Regular
@@ -2699,142 +2695,147 @@ impl<'a> Parser<'a> {
     }
 }
 
-/// Check if a name is a valid HTML element name.
-/// Based on: /^(?:![a-zA-Z]+|[a-zA-Z](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?|[a-zA-Z][a-zA-Z0-9]*:[a-zA-Z][a-zA-Z0-9-]*[a-zA-Z0-9])$/
+/// Mirrors upstream `is_valid_element_name`: a doctype, a namespaced name, or
+/// `REGEX_VALID_TAG_NAME` (`svelte/src/utils.js`).
 fn is_valid_element_name(name: &str) -> bool {
+    is_doctype_name(name) || is_namespaced_name(name) || is_valid_tag_name(name)
+}
+
+/// `/^![a-zA-Z]+$/`
+fn is_doctype_name(name: &str) -> bool {
+    let Some(rest) = name.strip_prefix('!') else {
+        return false;
+    };
+    !rest.is_empty() && rest.bytes().all(|b| b.is_ascii_alphabetic())
+}
+
+/// `/^[a-zA-Z][a-zA-Z0-9]*:[a-zA-Z][a-zA-Z0-9-]*[a-zA-Z0-9]$/`
+fn is_namespaced_name(name: &str) -> bool {
     let bytes = name.as_bytes();
-    if bytes.is_empty() {
+    let Some(colon) = memchr(b':', bytes) else {
+        return false;
+    };
+    let (before, after) = (&bytes[..colon], &bytes[colon + 1..]);
+
+    if before.is_empty() || !before[0].is_ascii_alphabetic() {
+        return false;
+    }
+    if !before[1..].iter().all(u8::is_ascii_alphanumeric) {
         return false;
     }
 
-    // Check for doctype-like: !DOCTYPE, etc.
-    if bytes[0] == b'!' {
-        return bytes.len() > 1 && bytes[1..].iter().all(|b| b.is_ascii_alphabetic());
-    }
-
-    // Must start with a letter
-    if !bytes[0].is_ascii_alphabetic() {
+    // The tail needs an alphabetic head *and* an alphanumeric last character.
+    if after.len() < 2 || !after[0].is_ascii_alphabetic() {
         return false;
     }
-
-    // Check for namespaced element (e.g., svg:rect)
-    if let Some(colon_pos) = memchr(b':', bytes) {
-        let before_bytes = &name.as_bytes()[..colon_pos];
-        let after_bytes = &name.as_bytes()[colon_pos + 1..];
-
-        // Before colon: [a-zA-Z][a-zA-Z0-9]*
-        if before_bytes.is_empty() || !before_bytes[0].is_ascii_alphabetic() {
-            return false;
-        }
-        if !before_bytes[1..].iter().all(|b| b.is_ascii_alphanumeric()) {
-            return false;
-        }
-
-        // After colon: [a-zA-Z][a-zA-Z0-9-]*[a-zA-Z0-9]
-        if after_bytes.is_empty() || !after_bytes[0].is_ascii_alphabetic() {
-            return false;
-        }
-        if after_bytes.len() == 1 {
-            return true;
-        }
-        // Must end with alphanumeric
-        if !after_bytes.last().unwrap().is_ascii_alphanumeric() {
-            return false;
-        }
-        // Middle can be alphanumeric or hyphen
-        return after_bytes[1..after_bytes.len() - 1]
-            .iter()
-            .all(|b| b.is_ascii_alphanumeric() || *b == b'-');
-    }
-
-    // Simple element name: [a-zA-Z](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?
-    if bytes.len() == 1 {
-        return true; // Single letter is valid
-    }
-
-    // Must end with alphanumeric
-    if !bytes.last().unwrap().is_ascii_alphanumeric() {
+    if !after[after.len() - 1].is_ascii_alphanumeric() {
         return false;
     }
-
-    // Middle can be alphanumeric or hyphen
-    bytes[1..bytes.len() - 1]
+    after[1..after.len() - 1]
         .iter()
         .all(|b| b.is_ascii_alphanumeric() || *b == b'-')
 }
 
-/// Check if a name is a valid Svelte component name.
-/// Based on: /^(?:\p{Lu}[$\u200c\u200d\p{ID_Continue}.]*|\p{ID_Start}[$\u200c\u200d\p{ID_Continue}]*(?:\.[$\u200c\u200d\p{ID_Continue}]+)+)$/u
-///
-/// Simplified implementation that handles the common cases:
-/// 1. Uppercase starting names: Component, MyComponent, Cæжαकン中
-/// 2. Dot notation: foo.Bar, a.b.C
-fn is_valid_component_name(name: &str) -> bool {
-    if name.is_empty() {
-        return false;
+/// Upstream `REGEX_VALID_TAG_NAME`: `/^[a-zA-Z][a-zA-Z0-9]*(-[PCENChar]*)?$/u`.
+fn is_valid_tag_name(name: &str) -> bool {
+    let mut chars = name.char_indices();
+    match chars.next() {
+        Some((_, c)) if c.is_ascii_alphabetic() => {}
+        _ => return false,
     }
+    // Nothing may follow the `[a-zA-Z0-9]*` run except the optional hyphen
+    // group, so the first character outside it must be that group's `-`.
+    let Some((i, c)) = chars.find(|(_, c)| !c.is_ascii_alphanumeric()) else {
+        return true;
+    };
+    c == '-'
+        && name[i + 1..]
+            .chars()
+            .all(is_potential_custom_element_name_char)
+}
 
+/// The `PCENChar` continuation set of the HTML custom-element-name production.
+fn is_potential_custom_element_name_char(c: char) -> bool {
+    matches!(c,
+        'a'..='z' | 'A'..='Z' | '0'..='9' | '.' | '-' | '_'
+            | '\u{b7}'
+            | '\u{c0}'..='\u{d6}'
+            | '\u{d8}'..='\u{f6}'
+            | '\u{f8}'..='\u{37d}'
+            | '\u{37f}'..='\u{1fff}'
+            | '\u{200c}'..='\u{200d}'
+            | '\u{203f}'..='\u{2040}'
+            | '\u{2070}'..='\u{218f}'
+            | '\u{2c00}'..='\u{2fef}'
+            | '\u{3001}'..='\u{d7ff}'
+            | '\u{f900}'..='\u{fdcf}'
+            | '\u{fdf0}'..='\u{fffd}'
+            | '\u{10000}'..='\u{effff}')
+}
+
+/// Upstream `regex_valid_component_name`:
+/// /^(?:\p{Lu}[$\u200c\u200d\p{ID_Continue}.]*|\p{ID_Start}[$\u200c\u200d\p{ID_Continue}]*(?:\.[$\u200c\u200d\p{ID_Continue}]+)+)$/u
+fn is_valid_component_name(name: &str) -> bool {
     let mut chars = name.chars();
-    let first = chars.next().unwrap();
+    let Some(first) = chars.next() else {
+        return false;
+    };
 
-    // Check for uppercase-starting component (e.g., Component, MyComponent)
-    // Also supports Unicode uppercase letters (e.g., Wunderschön, Cæжαकン中)
-    if first.is_uppercase() {
-        // Rest can be identifier characters, $, or .
+    if is_uppercase_letter(first) {
         return chars.all(is_component_name_char);
     }
 
-    // Check for dot-notation component (e.g., foo.Bar, a.b.C)
-    // Must start with a valid identifier start character
-    if !is_identifier_start(first) {
+    if !is_id_start(first) {
         return false;
     }
 
-    // Split by dots
-    let parts: Vec<&str> = name.split('.').collect();
-    if parts.len() < 2 {
-        return false; // Must have at least one dot for non-uppercase start
+    // The star class excludes `.`, so splitting on it reproduces the grouping.
+    let mut parts = name.split('.');
+    let head = parts.next().unwrap_or_default();
+    if !head[first.len_utf8()..].chars().all(is_identifier_continue) {
+        return false;
     }
 
-    // Each part must be a valid identifier
-    for (i, part) in parts.iter().enumerate() {
-        if part.is_empty() {
-            return false;
-        }
-        let mut part_chars = part.chars();
-        let part_first = part_chars.next().unwrap();
-
-        // First part must start with identifier start
-        if i == 0 {
-            if !is_identifier_start(part_first) {
-                return false;
-            }
-        } else {
-            // Subsequent parts can start with identifier continue, $
-            if !is_identifier_continue(part_first) && part_first != '$' {
-                return false;
-            }
-        }
-
-        // Rest of part must be identifier continue or $
-        if !part_chars.all(|c| is_identifier_continue(c) || c == '$') {
+    let mut has_member = false;
+    for part in parts {
+        has_member = true;
+        if part.is_empty() || !part.chars().all(is_identifier_continue) {
             return false;
         }
     }
+    has_member
+}
 
-    true
+/// `\p{Lu}`. Rust's `char::is_uppercase` is the Uppercase property, which is
+/// `Lu` plus `Other_Uppercase`; the regex class means the category alone.
+fn is_uppercase_letter(c: char) -> bool {
+    c.is_uppercase()
+        && !matches!(c,
+            '\u{2160}'..='\u{216f}'
+                | '\u{24b6}'..='\u{24cf}'
+                | '\u{1f130}'..='\u{1f149}'
+                | '\u{1f150}'..='\u{1f169}'
+                | '\u{1f170}'..='\u{1f189}')
+}
+
+/// `\p{ID_Start}` alone — unlike acorn's identifier-start test it admits
+/// neither `$` nor `_`.
+fn is_id_start(c: char) -> bool {
+    if c.is_ascii() {
+        c.is_ascii_alphabetic()
+    } else {
+        oxc_syntax::identifier::is_identifier_start_unicode(c)
+    }
 }
 
 /// Check if a character can start a JavaScript identifier.
-/// Simplified version of Unicode ID_Start.
 fn is_identifier_start(c: char) -> bool {
-    c.is_alphabetic() || c == '_' || c == '$'
+    oxc_syntax::identifier::is_identifier_start(c)
 }
 
 /// Check if a character can continue a JavaScript identifier.
-/// Simplified version of Unicode ID_Continue.
 fn is_identifier_continue(c: char) -> bool {
-    c.is_alphanumeric() || c == '_' || c == '$' || c == '\u{200c}' || c == '\u{200d}'
+    oxc_syntax::identifier::is_identifier_part(c)
 }
 
 /// Check if a character is valid in a component name (after the first char).

--- a/crates/rsvelte_core/src/compiler/phases/1_parse/state/tag.rs
+++ b/crates/rsvelte_core/src/compiler/phases/1_parse/state/tag.rs
@@ -1763,6 +1763,14 @@ impl<'a> Parser<'a> {
         let name = self.read_identifier();
         let name_end = self.index;
 
+        if name.is_empty() && !self.options.loose {
+            return Err(crate::error::ParseError::svelte(
+                "expected_identifier",
+                "Expected an identifier\nhttps://svelte.dev/e/expected_identifier",
+                (self.index, self.index),
+            ));
+        }
+
         // Create expression for the snippet name (with character field in loc)
         let expression = super::super::expression::create_identifier_with_character(
             &name,

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/types.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/types.rs
@@ -2960,18 +2960,20 @@ fn is_valid_identifier(name: &str) -> bool {
 fn sanitize_identifier(name: &str) -> String {
     let mut result = String::with_capacity(name.len());
 
+    // Upstream is `name.replace(/(^[^a-zA-Z_$]|[^a-zA-Z0-9_$])/g, '_')` over a
+    // UTF-16 string, so an astral character is replaced by *two* underscores.
     for (i, c) in name.chars().enumerate() {
-        if c.is_ascii_alphabetic() || c == '_' || c == '$' {
-            result.push(c);
-        } else if c.is_ascii_digit() {
-            if i == 0 {
-                // Can't start with a digit, prefix with underscore
-                result.push('_');
-            }
+        let keep = if i == 0 {
+            c.is_ascii_alphabetic() || c == '_' || c == '$'
+        } else {
+            c.is_ascii_alphanumeric() || c == '_' || c == '$'
+        };
+        if keep {
             result.push(c);
         } else {
-            // Replace invalid characters (like '-') with underscore
-            result.push('_');
+            for _ in 0..c.len_utf16() {
+                result.push('_');
+            }
         }
     }
 

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/fragment.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/fragment.rs
@@ -285,7 +285,7 @@ pub fn fragment(
                     &context.arena,
                     &id_name,
                     Some(b::call(&context.arena, template_id_expr, vec![])),
-                    Some(name_start),
+                    Some((name_start, name_end)),
                 ),
             );
 

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/regular_element.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/regular_element.rs
@@ -197,10 +197,9 @@ pub fn visit_regular_element(
 ) -> TransformResult {
     // Push element to template
     let is_html = context.state.metadata.namespace == "html" && node.name != "svg";
-    // Avoid allocation when name is already lowercase (common case for HTML)
     let name_str = node.name.as_str();
-    let elem_name = if is_html && name_str.bytes().any(|b| b.is_ascii_uppercase()) {
-        name_str.to_lowercase()
+    let elem_name = if is_html {
+        super::shared::utils::html_lowercase(name_str)
     } else {
         name_str.to_string()
     };

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/fragment.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/fragment.rs
@@ -314,7 +314,7 @@ pub fn process_children<F>(
     // Helper: flush a single node
     let flush_node = |is_text: bool,
                       name: &str,
-                      loc: Option<u32>,
+                      loc: Option<(u32, u32)>,
                       prev_fn: &mut SiblingPrev<F>,
                       skip_count: &mut usize,
                       ctx: &mut ComponentContext|
@@ -538,7 +538,11 @@ pub fn process_children<F>(
                 } else {
                     // Get node name for identifier
                     let (name, name_loc) = if let TemplateNode::RegularElement(elem) = node {
-                        (elem.name.as_str(), Some(elem.start.saturating_add(1)))
+                        let start = elem.start.saturating_add(1);
+                        (
+                            elem.name.as_str(),
+                            Some((start, start.saturating_add(elem.name.len() as u32))),
+                        )
                     } else {
                         ("node", None)
                     };
@@ -640,11 +644,9 @@ fn push_static_element_to_template_inner(
         TemplateNode::RegularElement(elem) => {
             // Determine if this is an HTML element (not SVG/MathML)
             let is_html = namespace == "html" && elem.name != "svg";
-            // Avoid allocation when name is already lowercase (common case for HTML)
             let name_str = elem.name.as_str();
-            let needs_lowercase = is_html && name_str.bytes().any(|b| b.is_ascii_uppercase());
-            let elem_name = if needs_lowercase {
-                name_str.to_lowercase()
+            let elem_name = if is_html {
+                super::utils::html_lowercase(name_str)
             } else {
                 name_str.to_string()
             };

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/utils.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/utils.rs
@@ -3340,6 +3340,21 @@ pub fn build_render_statement_with_memoizer(
 /// # Returns
 ///
 /// Returns a member expression or identifier.
+/// Upstream lowercases an HTML element/attribute name with JS `toLowerCase`,
+/// which is not limited to ASCII; only the no-op fast path is.
+pub fn html_lowercase(name: &str) -> String {
+    let needs_lowering = if name.is_ascii() {
+        name.bytes().any(|b| b.is_ascii_uppercase())
+    } else {
+        name.chars().any(|c| c.to_lowercase().next() != Some(c))
+    };
+    if needs_lowering {
+        name.to_lowercase()
+    } else {
+        name.to_string()
+    }
+}
+
 pub fn parse_directive_name(
     arena: &crate::compiler::phases::phase3_transform::js_ast::arena::JsArena,
     name: &str,

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/js_ast/builders.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/js_ast/builders.rs
@@ -1404,22 +1404,20 @@ pub fn var_decl_anchored(
     arena: &JsArena,
     name: impl Into<CompactString>,
     init: Option<JsExpr>,
-    comment_anchor: Option<u32>,
+    // The span is the *source* name's, which the generated identifier does not
+    // reproduce byte for byte once the source name is non-ASCII.
+    anchor: Option<(u32, u32)>,
 ) -> JsStatement {
     let name = name.into();
     JsStatement::VariableDeclaration(JsVariableDeclaration {
         kind: JsVariableKind::Var,
         declarations: vec![JsVariableDeclarator {
-            id: match comment_anchor {
-                Some(start) => JsPattern::SpannedIdentifier {
-                    end: start.saturating_add(name.len() as u32),
-                    name,
-                    start,
-                },
+            id: match anchor {
+                Some((start, end)) => JsPattern::SpannedIdentifier { name, start, end },
                 None => id_pattern(name),
             },
             init: init.map(|e| arena.alloc_expr(e)),
-            comment_anchor,
+            comment_anchor: anchor.map(|(start, _)| start),
         }],
     })
 }

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/js_ast/codegen.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/js_ast/codegen.rs
@@ -2668,6 +2668,20 @@ pub fn offset_to_line_col_utf16(
 ) -> (usize, usize) {
     let (line, _) = offset_to_line_col(line_starts, offset);
     let line_start = line_starts[line];
+    // A span whose end is not a character boundary is a producer bug; keep it
+    // loud in tests but never abort a user's build over a source-map column.
+    debug_assert!(
+        source.is_char_boundary(offset),
+        "source-map offset {offset} is not a char boundary"
+    );
+    let offset = if source.is_char_boundary(offset) {
+        offset
+    } else {
+        (line_start..offset)
+            .rev()
+            .find(|i| source.is_char_boundary(*i))
+            .unwrap_or(line_start)
+    };
     let column = &source[line_start..offset];
     let column = if column.is_ascii() {
         column.len()

--- a/crates/rsvelte_core/tests/tag_and_snippet_names_3279.rs
+++ b/crates/rsvelte_core/tests/tag_and_snippet_names_3279.rs
@@ -1,0 +1,145 @@
+//! Two name scanners were narrower than upstream's (#3279): the element-name
+//! check accepted only `[a-z0-9-]` after the leading hyphen where upstream
+//! implements the HTML `PotentialCustomElementName` production, and
+//! `read_identifier` accepted only `char::is_alphanumeric` where upstream uses
+//! acorn's `ID_Continue`.
+//!
+//! Removing those two over-rejections makes non-ASCII element names reachable
+//! for the first time, which exposed three further divergences behind them:
+//! a span whose end was computed from the *generated* identifier's byte length
+//! (a panic once the source name is non-ASCII), an ASCII-only guard around the
+//! `toLowerCase` of an HTML tag name, and an identifier sanitizer that counted
+//! characters where upstream's regex counts UTF-16 code units.
+//!
+//! Every expectation here is the official compiler's output for the same source.
+
+use rsvelte_core::{CompileOptions, GenerateMode, compile};
+
+fn go(src: &str, mode: GenerateMode) -> String {
+    compile(
+        src,
+        CompileOptions {
+            filename: Some("T.svelte".into()),
+            generate: mode,
+            dev: false,
+            ..Default::default()
+        },
+    )
+    .map(|r| r.js.code)
+    .unwrap_or_else(|e| format!("COMPILE_ERROR: {e:?}"))
+}
+
+fn client(src: &str) -> String {
+    go(src, GenerateMode::Client)
+}
+
+#[test]
+fn pcen_continuation_characters_are_accepted() {
+    // `_`, `.` and U+00B7 are plain `PCENChar`s; the hyphen group may be empty.
+    for src in [
+        "<x-a_b />",
+        "<x-a.b />",
+        "<x-\u{b7} />",
+        "<x- />",
+        "<foo- />",
+        "<x-- />",
+        "<my-café>y</my-café>",
+    ] {
+        for mode in [GenerateMode::Client, GenerateMode::Server] {
+            let out = go(src, mode);
+            assert!(!out.contains("COMPILE_ERROR"), "{src} ({mode:?}): {out}");
+        }
+    }
+}
+
+#[test]
+fn non_pcen_names_are_still_rejected() {
+    // A non-ASCII character before the first hyphen, and a leading hyphen, are
+    // outside the production in both compilers.
+    for src in ["<xü />", "<-x-foo />", "<1foo />"] {
+        assert!(
+            client(src).contains("COMPILE_ERROR"),
+            "{src} should be rejected"
+        );
+    }
+}
+
+#[test]
+fn namespaced_name_needs_two_characters_after_the_colon() {
+    // `[a-zA-Z][a-zA-Z0-9-]*[a-zA-Z0-9]` — an alphabetic head *and* an
+    // alphanumeric last character, so a one-character tail does not match.
+    assert!(client("<a:b />").contains("COMPILE_ERROR"));
+    assert!(!client("<svg:rect />").contains("COMPILE_ERROR"));
+}
+
+#[test]
+fn a_name_the_component_regex_rejects_is_a_regular_element() {
+    // `-` is neither `ID_Continue` nor `.`, so `X-a` is an element upstream
+    // even though it starts uppercase; emitting a component call would produce
+    // `X-a(...)`, which is not JavaScript.
+    let out = client("<X-a>y</X-a>");
+    assert!(out.contains("$.from_html(`<x-a>y</x-a>`"), "{out}");
+    assert!(out.contains("var X_a = root();"), "{out}");
+
+    // Same for a dotted name whose head is not a valid identifier chain.
+    let out = client("<x-a.b />");
+    assert!(out.contains("$.from_html(`<x-a.b></x-a.b>`"), "{out}");
+    assert!(out.contains("var x_a_b = root();"), "{out}");
+}
+
+#[test]
+fn multibyte_element_names_do_not_panic_and_keep_the_source_span() {
+    // The declarator's span end was `start + generated_name.len()`, which lands
+    // mid-character for every one of these. Two-, three- and four-byte
+    // characters and a combining mark are separate cases because the byte
+    // length is what decides whether the offset happens to be a boundary.
+    for (src, expected_id) in [
+        ("<x-\u{e9} />", "x__"),
+        ("<x-\u{3042} />", "x__"),
+        ("<x-\u{1d54f} />", "x___"),
+        ("<x-e\u{301} />", "x_e_"),
+        ("<my-caf\u{e9}>y</my-caf\u{e9}>", "my_caf_"),
+    ] {
+        let out = client(src);
+        assert!(!out.contains("COMPILE_ERROR"), "{src}: {out}");
+        assert!(
+            out.contains(&format!("var {expected_id} = root();")),
+            "{src}: expected `{expected_id}`\n{out}"
+        );
+    }
+}
+
+#[test]
+fn html_tag_names_lowercase_beyond_ascii() {
+    let out = client("<x-aⰀb />");
+    assert!(out.contains("$.from_html(`<x-aⰰb></x-aⰰb>`"), "{out}");
+}
+
+#[test]
+fn snippet_names_accept_every_id_continue_character() {
+    // A combining mark and ZWNJ / ZWJ are `ID_Continue` in ECMAScript.
+    for (src, name) in [
+        (
+            "{#snippet s\u{301}()}x{/snippet}{@render s\u{301}()}",
+            "s\u{301}",
+        ),
+        (
+            "{#snippet a\u{200c}b()}x{/snippet}{@render a\u{200c}b()}",
+            "a\u{200c}b",
+        ),
+        (
+            "{#snippet a\u{200d}b()}x{/snippet}{@render a\u{200d}b()}",
+            "a\u{200d}b",
+        ),
+    ] {
+        let out = client(src);
+        assert!(!out.contains("COMPILE_ERROR"), "{src}: {out}");
+        assert!(out.contains(&format!("const {name} = ($$anchor)")), "{out}");
+    }
+}
+
+#[test]
+fn a_snippet_name_that_is_not_an_identifier_start_is_expected_identifier() {
+    let out = client("{#snippet 1a()}x{/snippet}");
+    assert!(out.contains("expected_identifier"), "{out}");
+}


### PR DESCRIPTION
Closes #3279

## Two independent defects in one PR, and why

Commit 1 (`fix(transform): …`) and commit 2 (`fix(parse): …`) fix **two separate
defects**. They ship together because the second is what makes the first
*reachable*: before the parse relaxation, every element name that reaches the
declarator builder is ASCII, so commit 1 alone has no input that exercises it and
no repro that could land with it. This is the AGENTS.md #3175 shape — removing an
over-rejection makes whatever the rejection was hiding reachable — so the
negative controls are stated separately below.

## 1. The over-rejections (#3279)

| site | rsvelte before | upstream |
|---|---|---|
| element name | `[a-zA-Z][a-zA-Z0-9-]*[a-zA-Z0-9]` | `REGEX_VALID_TAG_NAME` = `/^[a-zA-Z][a-zA-Z0-9]*(-[PCENChar]*)?$/u` (`svelte/src/utils.js`) |
| namespaced name | tail of **1** char accepted | `[a-zA-Z][a-zA-Z0-9-]*[a-zA-Z0-9]` — tail needs ≥ 2 |
| component name | "starts uppercase **or** contains a dot" | `regex_valid_component_name` |
| `read_identifier` | `char::is_alphanumeric` + `_` `$`, no start check | acorn `isIdentifierStart` / `isIdentifierChar` |
| `{#snippet}` empty name | fell through | `e.expected_identifier(parser.index)` |

The component-name row is not cosmetic: `regex_valid_component_name` is *also*
what upstream uses to decide element-vs-component, and `-` is neither
`ID_Continue` nor `.`. Fixing only the tag-name check would have turned `<X-a>`
and `<x-a.b>` from `tag_invalid_name` into a **component call** — `X-a($$anchor,
…)`, which is not JavaScript. `\p{Lu}` is implemented as `is_uppercase()` minus
`Other_Uppercase` (5 ranges), because Rust's `is_uppercase` is the Uppercase
property and the regex means the category (`Ⅰ`, `Ⓐ` are Uppercase but not `Lu`,
and upstream rejects both).

## 2. What the over-rejection was hiding (commit 1)

Once non-ASCII element names compile, three more divergences appear. All three
were previously unreachable through this path, and all three are graded against
the official compiler.

**(a) `var_decl_anchored` computed the span end from the generated identifier.**
`end = start + name.len()` where `name` is the *deconflicted* identifier (`x_`,
`x_e_1`) and `start` is the source name's offset. For an ASCII name this is
merely a wrong span whenever the memoizer appends a suffix; for a non-ASCII name
it lands mid-character and `offset_to_line_col_utf16` aborts the compile:

```
panicked at js_ast/codegen.rs:2671: end byte index 4 is not a char boundary;
it is inside 'é' (bytes 3..5) of `<x-é />`
```

**Enumeration (as asked).** Every `start + …len()` span-end computation in
`crates/rsvelte_core/src/`:

| site | length taken from | verdict |
|---|---|---|
| `js_ast/builders.rs::var_decl_anchored` | **generated** identifier | **fixed** — now takes `(start, end)` from the caller |
| `client/visitors/fragment.rs:254`, `shared/fragment.rs:544` | `element.name` (source) | correct; both now pass the pair through |
| `client/visitors/regular_element.rs:450,1299`, `bind_directive.rs:544` | `node.name` / `element.name` (source) | correct |
| `client/visitors/shared/utils.rs:2508,2761` | binding `name` at its declaration (source) | correct |
| `2_analyze/{visitors/component.rs:72, visitors/text.rs:56, types.rs:771,1412, utils/mod.rs:210, mod.rs:1106,6114, scope_builder.rs:2926}` | source-derived slices | correct |
| `js_ast/to_oxc.rs:1616`, `server/ast/mod.rs:387`, `server/ast/comments.rs:299`, `client/mod.rs:1243` | comment text taken from source | correct |
| `3_transform/mod.rs:1715,1717` | a source-map **column**, not a byte offset | correct — the arm is guarded by `text.is_ascii() && source_end == src_pos + text.len()`, and the non-ASCII branch goes through `advance_token_utf16` |

So the population is one site out of 18, not three; the other two defects below
are a different class. `offset_to_line_col_utf16` additionally gained a
`debug_assert!` + release-safe clamp, so a future producer bug is loud in tests
and never aborts a user's build.

**(b) The `toLowerCase` of an HTML tag name was ASCII-guarded.** Upstream is
`node.name.toLowerCase()`; rsvelte skipped the call unless
`bytes().any(is_ascii_uppercase)`, so `<x-aⰀb>` templated `x-aⰀb` where official
templates `x-aⰰb`. Two client sites; the server already lowercased
unconditionally and was byte-identical throughout — which is the positive control
that named the guard rather than the lowering.

**(c) The identifier sanitizer counted characters.** Upstream is
`name.replace(/(^[^a-zA-Z_$]|[^a-zA-Z0-9_$])/g, '_')` over a **UTF-16** string,
so an astral character is replaced by *two* underscores: `<x-𝕏>` declares
`x___`, not `x__`. The leading-digit arm also disagreed (`0a` → `_0a` vs `_a`);
it is unreachable from a tag name but is now the same single rule.

## Measurement

Two generated grids, official vs rsvelte, client **and** server, compared on
generated JS or error `code`:

| grid | before | after |
|---|---|---|
| 47 tag names × {paired, self-closing} + 15 snippet names × 2 targets (214 cells) | **104** diverging | **2** |
| 58 component/namespaced/PCEN-boundary names × 2 targets (116 cells) | **25** diverging | **0** |

Negative controls, taken separately:

* Commit 2 alone (binary `1af23deb…`): the tag/snippet rows go green and **32
  cells turn into the `codegen.rs:2671` panic** — that is defect (a) becoming
  reachable, and it is the control for commit 1.
* Commit 1 on top (binary `c233961d…`): those 32 cells compile, and the
  remaining `x-aⰀb` / `x-𝕏` output mismatches — defects (b) and (c) — go green.
* `non_pcen_names_are_still_rejected` and
  `namespaced_name_needs_two_characters_after_the_colon` are the other
  direction: `<xü>`, `<-x-foo>`, `<1foo>`, `<a:b>` must stay rejected. `<a:b>`
  was an **under**-rejection before this PR.

Non-ASCII is exercised at four byte lengths, because the byte length is exactly
what decides whether an offset happens to land on a boundary: 2-byte (`é`),
3-byte (`あ`), 4-byte (`𝕏`), and a combining mark (`e` + U+0301).

## The 2 remaining grid cells are a different, pre-existing bug

`<x-a b>y</x-a b>`: official raises `expected_token` on the **closing** tag,
rsvelte accepts. It has nothing to do with name validation — `<div>y</div x>`
reproduces it identically on `main` — so it is filed separately and not fixed
here.

## Tests

`crates/rsvelte_core/tests/tag_and_snippet_names_3279.rs` (8 tests). Suites run
green: `parser_fixtures`, `compiler_errors`, `compiler_fixtures`, `validator`,
`css`, `ssr`, `print`, `sourcemaps`, `sourcemaps_gate`.
