### PR TITLE
fix(fmt): normalise whitespace inside a `class` attribute on a regular element

### DIFF
--- a/.changeset/fmt-class-attribute-whitespace.md
+++ b/.changeset/fmt-class-attribute-whitespace.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/fmt": patch
+---
+
+The formatter now collapses whitespace runs inside a `class` attribute value on a regular element, matching prettier-plugin-svelte: a run after a non-whitespace character shrinks to one space (or is dropped when a newline follows), and a run at the end of the value is dropped when it ends the value and shrunk to one space otherwise. Leading whitespace, a multi-line value, other attributes, and `class` on a component / `<svelte:element>` / `<slot>` are left untouched.

--- a/crates/rsvelte_formatter/src/markup/attribute.rs
+++ b/crates/rsvelte_formatter/src/markup/attribute.rs
@@ -20,12 +20,18 @@ pub(super) fn render_attribute(
     options: &FormatOptions,
     attr_depth: usize,
     narrow_value: bool,
+    regular_element: bool,
 ) -> Result<String, FormatError> {
     let tw = tab_width(options);
     match attr {
-        Attribute::Attribute(node) => {
-            render_attribute_node(node, source, options, attr_depth, narrow_value)
-        }
+        Attribute::Attribute(node) => render_attribute_node(
+            node,
+            source,
+            options,
+            attr_depth,
+            narrow_value,
+            regular_element,
+        ),
         Attribute::SpreadAttribute(spread) => render_spread(spread, source, options, attr_depth),
         Attribute::AttachTag(attach) => {
             let mut inner = format_expression_at(source, &attach.expression, options, attr_depth)?

--- a/crates/rsvelte_formatter/src/markup/class_value.rs
+++ b/crates/rsvelte_formatter/src/markup/class_value.rs
@@ -1,0 +1,135 @@
+//! Whitespace normalization of a `class` attribute value on a regular element.
+//!
+//! Port of prettier-plugin-svelte's `Text` printer branch guarded by
+//! `parent.name === 'class' && path.getParentNode(1).type === 'RegularElement'`
+//! (`print/index.ts`). It is two passes over each text node's raw source:
+//!
+//! ```js
+//! rawText = rawText.replace(
+//!   /([^ \t\n])(([ \t]+$)|([ \t]+(\r?\n))|[ \t]+)/g,
+//!   (match, char, _, isEndOfString, isEndOfLine, endOfLine) =>
+//!     isEndOfString ? match : char + (isEndOfLine ? endOfLine : ' '),
+//! );
+//! rawText = rawText.replace(
+//!   /([^ \t\n])[ \t]+$/,
+//!   isLastValuePart ? '$1' : '$1 ',
+//! );
+//! ```
+//!
+//! Both patterns require a `[^ \t\n]` immediately before the run, so leading
+//! whitespace — at the start of the node or after a newline — is preserved.
+
+use std::borrow::Cow;
+
+use rsvelte_core::ast::template::AttributeValuePart;
+
+/// Apply the two passes to one text node. `is_last_part` is upstream's
+/// `parent.value.indexOf(node) === parent.value.length - 1`.
+fn normalize_class_text(raw: &str, is_last_part: bool) -> Cow<'_, str> {
+    let bytes = raw.as_bytes();
+    let mut out: Option<String> = None;
+    let mut copied = 0usize;
+    let mut index = 0usize;
+
+    while index < bytes.len() {
+        if bytes[index] != b' ' && bytes[index] != b'\t' {
+            index += 1;
+            continue;
+        }
+        let run_start = index;
+        while index < bytes.len() && (bytes[index] == b' ' || bytes[index] == b'\t') {
+            index += 1;
+        }
+        // The regex anchors on a preceding `[^ \t\n]`; a run at the start of the
+        // node or right after a newline has none, so it survives verbatim.
+        if run_start == 0 || bytes[run_start - 1] == b'\n' {
+            continue;
+        }
+        let replacement = if index == bytes.len() {
+            // End of string: pass 1 keeps the match, pass 2 decides.
+            if is_last_part { "" } else { " " }
+        } else if bytes[index] == b'\n'
+            || (bytes[index] == b'\r' && bytes.get(index + 1) == Some(&b'\n'))
+        {
+            // Trailing whitespace on a line with content — dropped, the
+            // line terminator is re-emitted by the untouched tail.
+            ""
+        } else {
+            " "
+        };
+        if raw[run_start..index] == *replacement {
+            continue;
+        }
+        let buffer = out.get_or_insert_with(String::new);
+        buffer.push_str(&raw[copied..run_start]);
+        buffer.push_str(replacement);
+        copied = index;
+    }
+
+    match out {
+        Some(mut buffer) => {
+            buffer.push_str(&raw[copied..]);
+            Cow::Owned(buffer)
+        }
+        None => Cow::Borrowed(raw),
+    }
+}
+
+/// Normalized copies of `parts` for a `class` attribute on a regular element,
+/// or `None` when no text node changes (the common case — the caller then
+/// renders the original slice and allocates nothing).
+pub(super) fn normalized_class_parts<'a>(
+    parts: &[AttributeValuePart<'a>],
+) -> Option<Vec<AttributeValuePart<'a>>> {
+    let last = parts.len().checked_sub(1)?;
+    let mut changed = false;
+    let mut out = Vec::with_capacity(parts.len());
+    for (index, part) in parts.iter().enumerate() {
+        match part {
+            AttributeValuePart::Text(text) => {
+                let raw = normalize_class_text(text.raw.as_ref(), index == last);
+                let data = normalize_class_text(text.data.as_ref(), index == last);
+                changed |= matches!(raw, Cow::Owned(_)) || matches!(data, Cow::Owned(_));
+                let mut text = text.clone();
+                text.raw = Cow::Owned(raw.into_owned());
+                text.data = Cow::Owned(data.into_owned());
+                out.push(AttributeValuePart::Text(text));
+            }
+            part => out.push(part.clone()),
+        }
+    }
+    changed.then_some(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::normalize_class_text;
+
+    #[test]
+    fn collapses_interior_runs() {
+        assert_eq!(normalize_class_text("a  b   c", true), "a b c");
+    }
+
+    #[test]
+    fn keeps_leading_run_and_drops_trailing_on_the_last_part() {
+        assert_eq!(
+            normalize_class_text("  lead and trail  ", true),
+            "  lead and trail"
+        );
+    }
+
+    #[test]
+    fn shrinks_trailing_run_when_a_part_follows() {
+        assert_eq!(normalize_class_text("a  ", false), "a ");
+    }
+
+    #[test]
+    fn drops_trailing_whitespace_before_a_newline() {
+        assert_eq!(normalize_class_text("a  \n  b", true), "a\n  b");
+    }
+
+    #[test]
+    fn keeps_a_run_that_is_only_whitespace() {
+        assert_eq!(normalize_class_text("   ", true), "   ");
+    }
+}

--- a/crates/rsvelte_formatter/src/markup/mod.rs
+++ b/crates/rsvelte_formatter/src/markup/mod.rs
@@ -26,6 +26,7 @@
 //! - Children fragments (recursed into separately by the caller)
 
 mod attribute;
+mod class_value;
 mod close_tag;
 mod directive;
 mod elements;

--- a/crates/rsvelte_formatter/src/markup/open_tag.rs
+++ b/crates/rsvelte_formatter/src/markup/open_tag.rs
@@ -125,6 +125,7 @@ struct OpenTagRenderer<'a> {
     this_attr: Option<String>,
     comments: Vec<OpenTagComment>,
     order: Vec<(u32, OpenTagItem)>,
+    regular_element: bool,
 }
 
 impl<'a> OpenTagRenderer<'a> {
@@ -136,6 +137,7 @@ impl<'a> OpenTagRenderer<'a> {
         this_attr: Option<String>,
         options: &'a FormatOptions,
         attr_depth: usize,
+        regular_element: bool,
     ) -> Self {
         let comments = collect_open_tag_comments(source, element_start, open_tag_end, attributes);
         let mut order = Vec::with_capacity(attributes.len() + comments.len() + 1);
@@ -157,6 +159,7 @@ impl<'a> OpenTagRenderer<'a> {
             this_attr,
             comments,
             order,
+            regular_element,
         }
     }
 
@@ -175,6 +178,7 @@ impl<'a> OpenTagRenderer<'a> {
                     self.options,
                     self.attr_depth,
                     wrapped,
+                    self.regular_element,
                 ),
                 OpenTagItem::Comment(index) => Ok(self.comments[*index].text.clone()),
             })
@@ -298,6 +302,7 @@ fn open_tag_renderer<'a>(
     this_attr: Option<String>,
     options: &'a FormatOptions,
     attr_depth: usize,
+    regular_element: bool,
 ) -> OpenTagRenderer<'a> {
     OpenTagRenderer::new(
         source,
@@ -307,6 +312,7 @@ fn open_tag_renderer<'a>(
         this_attr,
         options,
         attr_depth,
+        regular_element,
     )
 }
 
@@ -318,6 +324,7 @@ fn initial_open_tag_render<'a>(
     this_attr: Option<String>,
     options: &'a FormatOptions,
     attr_depth: usize,
+    regular_element: bool,
 ) -> Result<(OpenTagRenderer<'a>, bool, Vec<String>), FormatError> {
     let renderer = open_tag_renderer(
         source,
@@ -327,6 +334,7 @@ fn initial_open_tag_render<'a>(
         this_attr,
         options,
         attr_depth,
+        regular_element,
     );
     let has_line_comment = renderer.has_line_comment();
     let rendered_attrs = renderer.render_items(false)?;
@@ -358,6 +366,10 @@ pub(super) fn push_open_tag(
     // hug case (source-empty inline) whose `>` dedents onto its own line. See
     // [`is_empty_nonhug_element`].
     empty_nonhug: bool,
+    // prettier-plugin-svelte's `class`-value whitespace collapse is keyed on the
+    // parent being a `RegularElement`, which the tag name alone cannot decide
+    // (`title` / `slot` are their own node types).
+    regular_element: bool,
     options: &FormatOptions,
     edits: &mut Vec<(u32, u32, String)>,
 ) -> Result<bool, FormatError> {
@@ -392,6 +404,7 @@ pub(super) fn push_open_tag(
         this_attr,
         options,
         attr_depth,
+        regular_element,
     )?;
 
     let leading_indent_width = open_tag_leading_indent(source, element_start, depth, options);

--- a/crates/rsvelte_formatter/src/markup/value.rs
+++ b/crates/rsvelte_formatter/src/markup/value.rs
@@ -402,6 +402,7 @@ pub(super) fn render_attribute_node(
     options: &FormatOptions,
     attr_depth: usize,
     narrow_value: bool,
+    regular_element: bool,
 ) -> Result<String, FormatError> {
     let tw = tab_width(options);
     match &node.value {
@@ -427,6 +428,13 @@ pub(super) fn render_attribute_node(
             render_single_expression_value(node, inner_src, options, attr_depth, narrow_value)
         }
         AttributeValue::Sequence(parts) => {
+            // prettier-plugin-svelte collapses whitespace runs inside a `class`
+            // value, but only on a regular element.
+            let normalized = (regular_element && node.name.as_str() == "class")
+                .then(|| super::class_value::normalized_class_parts(parts))
+                .flatten();
+            let parts: &[AttributeValuePart] = normalized.as_deref().unwrap_or(parts);
+
             // Tailwind class sort: a fully static value (no `{expr}`) of a
             // configured class attribute is reordered before printing. Values
             // with interpolation are left to the normal path — their class list

--- a/crates/rsvelte_formatter/src/markup/walk.rs
+++ b/crates/rsvelte_formatter/src/markup/walk.rs
@@ -85,6 +85,7 @@ fn collect_svelte_window_open_tag_edits(
             None,
             &window.fragment,
             depth,
+            false,
             options,
             edits,
         );
@@ -97,6 +98,7 @@ fn collect_svelte_window_open_tag_edits(
         None,
         depth,
         true,
+        false,
         false,
         options,
         edits,
@@ -118,11 +120,22 @@ fn collect_element_open_tag_edits(
     expression: Option<&Expression>,
     fragment: &Fragment,
     depth: usize,
+    regular_element: bool,
     options: &FormatOptions,
     edits: &mut Vec<(u32, u32, String)>,
 ) -> Result<(), FormatError> {
     handle_element(
-        source, start, end, name, attributes, expression, fragment, depth, options, edits,
+        source,
+        start,
+        end,
+        name,
+        attributes,
+        expression,
+        fragment,
+        depth,
+        regular_element,
+        options,
+        edits,
     )
 }
 
@@ -144,6 +157,7 @@ fn collect_plain_element_open_tag_edits(
                 None,
                 &element.fragment,
                 depth,
+                true,
                 options,
                 edits,
             )?;
@@ -159,6 +173,7 @@ fn collect_plain_element_open_tag_edits(
                 None,
                 &element.fragment,
                 depth,
+                false,
                 options,
                 edits,
             )?;
@@ -174,6 +189,7 @@ fn collect_plain_element_open_tag_edits(
                 None,
                 &element.fragment,
                 depth,
+                false,
                 options,
                 edits,
             )?;
@@ -189,6 +205,7 @@ fn collect_plain_element_open_tag_edits(
                 None,
                 &element.fragment,
                 depth,
+                false,
                 options,
                 edits,
             )?;
@@ -210,6 +227,7 @@ fn collect_plain_element_open_tag_edits(
                 None,
                 &element.fragment,
                 depth,
+                false,
                 options,
                 edits,
             )?;
@@ -265,6 +283,7 @@ pub fn collect_options_open_tag_edit(
         &attrs,
         None,
         0,
+        false,
         false,
         false,
         options,
@@ -325,6 +344,7 @@ fn handle_element(
     this_expression: Option<&Expression>,
     fragment: &Fragment,
     depth: usize,
+    regular_element: bool,
     options: &FormatOptions,
     edits: &mut Vec<(u32, u32, String)>,
 ) -> Result<(), FormatError> {
@@ -339,6 +359,7 @@ fn handle_element(
         depth,
         is_empty,
         empty_nonhug,
+        regular_element,
         options,
         edits,
     )?;
@@ -380,6 +401,7 @@ fn collect_node_open_tag_edits(
             Some(&c.expression),
             &c.fragment,
             depth,
+            false,
             options,
             edits,
         )?,
@@ -392,6 +414,7 @@ fn collect_node_open_tag_edits(
             Some(&e.tag),
             &e.fragment,
             depth,
+            false,
             options,
             edits,
         )?,

--- a/crates/rsvelte_formatter/tests/class_attribute_whitespace.rs
+++ b/crates/rsvelte_formatter/tests/class_attribute_whitespace.rs
@@ -1,0 +1,118 @@
+//! prettier-plugin-svelte collapses whitespace runs inside a `class` attribute
+//! value, but only when the attribute sits on a `RegularElement`. Every
+//! expectation here was measured against the oxfmt(`svelte: true`) oracle.
+
+use rsvelte_formatter::{
+    FormatOptions, IndentStyle, IndentWidth, JsFormatOptions, LineWidth, format,
+};
+
+fn fmt(src: &str) -> String {
+    let js = JsFormatOptions {
+        indent_style: IndentStyle::Space,
+        indent_width: IndentWidth::try_from(2u8).unwrap(),
+        line_width: LineWidth::try_from(80u16).unwrap(),
+        ..JsFormatOptions::default()
+    };
+    let options = FormatOptions {
+        js,
+        typescript: false,
+        ..FormatOptions::new()
+    };
+    let out = format(src, &options).expect("format ok");
+    out.strip_suffix('\n').map(str::to_string).unwrap_or(out)
+}
+
+#[test]
+fn interior_runs_collapse_to_one_space() {
+    assert_eq!(
+        fmt("<div class=\"a  b   c\"></div>"),
+        "<div class=\"a b c\"></div>"
+    );
+}
+
+#[test]
+fn leading_whitespace_survives_and_trailing_is_dropped() {
+    assert_eq!(
+        fmt("<div class=\"  lead and trail  \"></div>"),
+        "<div class=\"  lead and trail\"></div>"
+    );
+}
+
+#[test]
+fn a_whitespace_only_value_is_untouched() {
+    assert_eq!(
+        fmt("<div class=\"   \"></div>"),
+        "<div class=\"   \"></div>"
+    );
+}
+
+#[test]
+fn another_attribute_on_the_same_element_is_untouched() {
+    assert_eq!(
+        fmt("<div class=\"a  b\" title=\"x  y\"></div>"),
+        "<div class=\"a b\" title=\"x  y\"></div>"
+    );
+}
+
+#[test]
+fn trailing_whitespace_before_a_newline_is_dropped() {
+    assert_eq!(
+        fmt("<div class=\"a  \n  b\"></div>"),
+        "<div\n  class=\"a\n  b\"\n></div>"
+    );
+}
+
+/// Both patterns anchor on a preceding `[^ \t\n]`, so the run that OPENS the
+/// text node after an interpolation has nothing to anchor on and survives —
+/// only the run inside `a  ` and the value's trailing run are rewritten.
+#[test]
+fn runs_are_rewritten_per_text_node() {
+    assert_eq!(
+        fmt("<div class=\"a  {x}  b  \"></div>"),
+        "<div class=\"a {x}  b\"></div>"
+    );
+}
+
+#[test]
+fn whitespace_only_text_around_an_interpolation_survives() {
+    assert_eq!(
+        fmt("<div class=\"{x}  \"></div>"),
+        "<div class=\"{x}  \"></div>"
+    );
+    assert_eq!(
+        fmt("<div class=\"  {x}\"></div>"),
+        "<div class=\"  {x}\"></div>"
+    );
+}
+
+#[test]
+fn a_component_class_is_not_normalized() {
+    assert_eq!(
+        fmt("<Comp class=\"a  b  \" />"),
+        "<Comp class=\"a  b  \" />"
+    );
+}
+
+#[test]
+fn a_svelte_element_class_is_not_normalized() {
+    assert_eq!(
+        fmt("<svelte:element this=\"div\" class=\"a  b  \"></svelte:element>"),
+        "<svelte:element this=\"div\" class=\"a  b  \"></svelte:element>"
+    );
+}
+
+#[test]
+fn a_slot_class_is_not_normalized() {
+    assert_eq!(
+        fmt("<slot class=\"a  b  \"></slot>"),
+        "<slot class=\"a  b  \"></slot>"
+    );
+}
+
+#[test]
+fn tabs_collapse_like_spaces() {
+    assert_eq!(
+        fmt("<div class=\"a\t\tb\"></div>"),
+        "<div class=\"a b\"></div>"
+    );
+}


### PR DESCRIPTION
Closes #3096

`prettier-plugin-svelte` collapses whitespace runs inside a `class` attribute value; `rsvelte-fmt` printed the value verbatim.

## The rule

It is the `Text` printer branch guarded by `parent.name === 'class' && path.getParentNode(1).type === 'RegularElement'` (`prettier-plugin-svelte` `print/index.ts`), two passes over each text node's raw source:

```js
rawText = rawText.replace(
  /([^ \t\n])(([ \t]+$)|([ \t]+(\r?\n))|[ \t]+)/g,
  (match, char, _, isEndOfString, isEndOfLine, endOfLine) =>
    isEndOfString ? match : char + (isEndOfLine ? endOfLine : ' '),
);
rawText = rawText.replace(
  /([^ \t\n])[ \t]+$/,
  parent.value.indexOf(node) === parent.value.length - 1 ? '$1' : '$1 ',
);
```

Both patterns anchor on a `[^ \t\n]` immediately before the run, which is the half that is easy to get wrong: a run that OPENS a text node — at the start of the value, or right after a newline, or right after an interpolation — has nothing to anchor on and survives. That is why the oracle prints `class="a  {x}  b  "` as `class="a {x}  b"` and not as `class="a {x} b"`.

## What changed

- New `markup/class_value.rs` — `normalize_class_text` (one text node, both passes, as a byte scan) and `normalized_class_parts` (the value's parts, returning `None` when nothing changes so the existing path is reached unallocated).
- `markup/value.rs` — `render_attribute_node` takes a `regular_element: bool` and applies `normalized_class_parts` in its `AttributeValue::Sequence` arm before the tailwind sort / `render_attribute_value_sequence`.
- The flag is threaded from the walker, not inferred from the tag name: `title` and `slot` are `TitleElement` / `SlotElement` rather than `RegularElement` upstream, and that depends on the parent (`parent_is_head` / `parent_is_shadowroot_template`), which a name test cannot see. Touched signatures: `markup/walk.rs` `collect_element_open_tag_edits` / `handle_element`, `markup/open_tag.rs` `push_open_tag` / `initial_open_tag_render` / `open_tag_renderer` / `OpenTagRenderer::{new,render_items}` (new `regular_element` field), `markup/attribute.rs` `render_attribute`, `markup/value.rs` `render_attribute_node`. Every non-`RegularElement` walker arm passes `false`.

## Verification

Everything below is measured against the oxfmt(`svelte: true`) oracle; no expectation is hand-written.

- **Matrix probe, 10 hosts × 3 attribute names × 19 whitespace shapes.** Excluding the `\r\n` rows and the `<svelte:head>` rows — two pre-existing divergences unrelated to this change and present for `title` / `data-class` too — the population is 486 cases. **446/486 before, 486/486 after.**
  - The `\r\n` row is the oracle rewriting CRLF to LF in the value; with this change rsvelte's *whitespace* handling on that row already matches (`class="a  \r\n  b"` → `a` + newline), and only the line terminator still differs.
- `crates/rsvelte_formatter/tests/class_attribute_whitespace.rs` — 11 new tests, including the non-`RegularElement` hosts and the per-text-node anchoring case above.
- `svelte_dev_corpus_parity` (the byte-exact gate, no baseline tolerance): **passes** — 556 `.svelte` files + 546 markdown blocks + 644 whole markdown files.
- Full `rsvelte_formatter` suite green (30 binaries), full `rsvelte_fmt` suite green.
- `compatibility/pattern-corpus`: 0 of 697 components carry a `class` value with a multi-space run, a tab, or a trailing space, so none of them can move.

No `compatibility/*known-failures*` file is touched.
