### PR TITLE
fix(compiler): take a legacy `$:` boundary from the parser, and count every ECMAScript line terminator

### DIFF
--- a/.changeset/legacy-reactive-boundary-line-terminators.md
+++ b/.changeset/legacy-reactive-boundary-line-terminators.md
@@ -1,0 +1,17 @@
+---
+'@rsvelte/compiler': patch
+---
+
+Fix the legacy `$:` boundary when a statement shares its line, and treat CR / U+2028 / U+2029 as line terminators
+
+The client instance-script pipeline read one physical line as one statement, so a
+`$:` sharing its line with another statement put the boundary in the wrong place —
+splicing the next statement into the `$.set(...)` call (output no JS parser
+accepts), swallowing it into the effect body, or dropping the `legacy_pre_effect`
+wrapper and emitting a bare `$:` label. Top-level statement boundaries now come
+from the parser.
+
+The same "line" notion was `\n`-only in two places: that split, and the printer's
+decision about whether a comment and the node after it share a line. A `//`
+comment terminated by CR / U+2028 / U+2029 therefore absorbed the statement that
+followed it, which disappeared from the output.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2642,7 +2642,7 @@ dependencies = [
 
 [[package]]
 name = "rsvelte_esrap"
-version = "0.10.32"
+version = "0.10.33"
 dependencies = [
  "compact_str 0.10.0",
  "memchr",

--- a/crates/rsvelte_core/Cargo.toml
+++ b/crates/rsvelte_core/Cargo.toml
@@ -94,7 +94,7 @@ oxc_ast = { version = "0.145", features = ["serialize"] }
 oxc_span = "0.145"
 oxc_diagnostics = "0.145"
 oxc_codegen = "0.145"
-rsvelte_esrap = { version = "=0.10.32", path = "../rsvelte_esrap" }
+rsvelte_esrap = { version = "=0.10.33", path = "../rsvelte_esrap" }
 oxc_syntax = "0.145"
 oxc_semantic = "0.145"
 

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
@@ -5097,13 +5097,23 @@ fn starts_with_else_keyword(line: &str) -> bool {
     })
 }
 
+/// A top-level `$:` label, which is what the legacy pipeline rewrites.
+fn is_legacy_reactive_label(statement: &oxc_ast::ast::Statement<'_>) -> bool {
+    matches!(
+        statement,
+        oxc_ast::ast::Statement::LabeledStatement(labeled) if labeled.label.name == "$"
+    )
+}
+
 /// Makes an AST statement boundary visible to the legacy per-line pipeline.
 ///
-/// The pipeline historically treated each physical line as one statement. That
-/// lets an `export let` rewrite consume a following declaration on the same
-/// line. We use the parser's top-level statement spans rather than scanning
-/// for semicolons, whose grammar is precisely what this path must not infer.
-fn separate_same_line_legacy_export_declarations<'a>(
+/// The pipeline treats each physical line as one statement, and it reads a line
+/// as `\n`-delimited text. So two top-level statements reach it as one whenever
+/// they share a line — and also when the only thing between them is a CR or a
+/// U+2028 / U+2029, which end a line in ECMAScript but not in `str::lines`. We
+/// use the parser's top-level statement spans rather than scanning for
+/// semicolons, whose grammar is precisely what this path must not infer.
+fn separate_same_line_top_level_statements<'a>(
     script: &'a str,
     is_typescript: bool,
 ) -> Cow<'a, str> {
@@ -5111,7 +5121,9 @@ fn separate_same_line_legacy_export_declarations<'a>(
     use oxc_parser::Parser;
     use oxc_span::{GetSpan as _, SourceType};
 
-    if !script.contains("export let ") && !script.contains("export var ") {
+    let has_export = script.contains("export let ") || script.contains("export var ");
+    let has_label = memmem::find(script.as_bytes(), b"$:").is_some();
+    if !has_export && !has_label {
         return Cow::Borrowed(script);
     }
 
@@ -5132,8 +5144,11 @@ fn separate_same_line_legacy_export_declarations<'a>(
         let next = pair[1].span();
         let previous_text = &script[previous.start as usize..previous.end as usize];
         let gap = &script[previous.end as usize..next.start as usize];
-        if (previous_text.trim_start().starts_with("export let ")
-            || previous_text.trim_start().starts_with("export var "))
+        let export_declaration = previous_text.trim_start().starts_with("export let ")
+            || previous_text.trim_start().starts_with("export var ");
+        if (export_declaration
+            || is_legacy_reactive_label(&pair[0])
+            || is_legacy_reactive_label(&pair[1]))
             && !gap.contains('\n')
             && gap.chars().all(char::is_whitespace)
         {
@@ -5639,8 +5654,12 @@ fn transform_instance_script_for_visitors(
     if script.is_empty() {
         return String::new();
     }
-    let separated_script =
-        separate_same_line_legacy_export_declarations(script, analysis.is_typescript);
+    let separated_script = separate_same_line_top_level_statements(script, analysis.is_typescript);
+    // A cut moves every byte after it, so the spans and the projection that were
+    // built for the caller's text no longer describe this one.
+    let separated = matches!(separated_script, Cow::Owned(_));
+    let retained_program = retained_program.filter(|_| !separated);
+    let source_projection = source_projection.filter(|_| !separated);
     let script = separated_script.as_ref();
     let original_script = script;
 

--- a/crates/rsvelte_core/tests/legacy_reactive_same_line_3272.rs
+++ b/crates/rsvelte_core/tests/legacy_reactive_same_line_3272.rs
@@ -1,0 +1,115 @@
+//! Issue #3272 — a legacy `$:` statement that shares its physical line.
+//!
+//! The client instance-script pipeline reads one physical line as one
+//! statement, so anything written before or after a `$:` on the same line
+//! landed on the wrong side of the reactive boundary: the following statement
+//! was spliced *inside* the `$.set(...)` call (output no JS parser accepts),
+//! or swallowed into the effect body (reactivity silently added), or the
+//! reactive wrapper was dropped and a bare `$:` label reached the output
+//! (reactivity silently removed).
+//!
+//! Every expectation below was measured against the official compiler
+//! (`submodules/svelte/.../compiler/index.js`) on the same source. The server
+//! target is pure AST and was already byte-identical on all of these, so it is
+//! the control.
+
+use rsvelte_core::{CompileOptions, GenerateMode, compile};
+
+fn compile_to(source: &str, generate: GenerateMode) -> String {
+    compile(
+        source,
+        CompileOptions {
+            filename: Some("A.svelte".to_string()),
+            generate,
+            ..Default::default()
+        },
+    )
+    .expect("compile failed")
+    .js
+    .code
+}
+
+/// A statement after a `$: <assignment>` on the same line.
+const TRAILING_AFTER_ASSIGNMENT: &str =
+    "<script>\n\tlet q;\n\t$: q = 1; void q;\n</script>\n<p>{q}</p>\n";
+
+/// A statement after a `$:` whose body is not an assignment.
+const TRAILING_AFTER_CALL: &str =
+    "<script>\n\tlet q; function f() {}\n\t$: f(); q = 2;\n</script>\n<p>{q}</p>\n";
+
+/// A statement before the `$:` on the same line.
+const LEADING_BEFORE_REACTIVE: &str =
+    "<script>\n\tlet q;\n\tlet z = 1; void z; $: q = 1;\n</script>\n<p>{q}</p>\n";
+
+#[test]
+fn a_statement_after_a_reactive_assignment_is_not_spliced_into_the_set_call() {
+    let out = compile_to(TRAILING_AFTER_ASSIGNMENT, GenerateMode::Client);
+    // Official: `void $.get(q);` stands on its own, before the effect.
+    assert!(
+        out.contains("$.set(q, 1);"),
+        "the reactive assignment lost its own boundary:\n{out}"
+    );
+    assert!(
+        out.contains("void $.get(q);"),
+        "the trailing statement did not survive as a statement:\n{out}"
+    );
+    assert!(
+        !out.contains("$.set(q, 1; void"),
+        "the trailing statement was spliced into the argument list:\n{out}"
+    );
+}
+
+#[test]
+fn a_statement_after_a_reactive_call_is_not_swallowed_by_the_effect() {
+    let out = compile_to(TRAILING_AFTER_CALL, GenerateMode::Client);
+    let set = out.find("$.set(q, 2)").expect("the assignment is missing");
+    let effect = out
+        .find("$.legacy_pre_effect(")
+        .expect("the reactive effect is missing");
+    // Official emits the one-time assignment before the effect; inside it, the
+    // assignment would re-run on every dependency change.
+    assert!(
+        set < effect,
+        "the trailing assignment was pulled into the effect body:\n{out}"
+    );
+}
+
+#[test]
+fn a_reactive_statement_after_another_statement_keeps_its_effect() {
+    let out = compile_to(LEADING_BEFORE_REACTIVE, GenerateMode::Client);
+    assert!(
+        out.contains("$.legacy_pre_effect(() => {}, () => {"),
+        "the reactive wrapper was dropped:\n{out}"
+    );
+    assert!(
+        !out.contains("$: $.set(q, 1)"),
+        "a bare `$:` label reached the output:\n{out}"
+    );
+}
+
+/// The control: the server target derives its boundaries from the typed AST and
+/// matched official on all three shapes before the fix.
+#[test]
+fn the_server_target_keeps_the_reactive_label() {
+    for source in [
+        TRAILING_AFTER_ASSIGNMENT,
+        TRAILING_AFTER_CALL,
+        LEADING_BEFORE_REACTIVE,
+    ] {
+        let out = compile_to(source, GenerateMode::Server);
+        assert!(out.contains("$:"), "the server dropped the label:\n{out}");
+    }
+}
+
+/// The negative control from the issue: the same layout with a plain assignment
+/// in place of the `$:` was byte-identical to official before the fix and must
+/// stay that way.
+#[test]
+fn a_plain_assignment_sharing_its_line_is_unaffected() {
+    let out = compile_to(
+        "<script>\n\tlet q;\n\tq = 1; void q;\n</script>\n<p>{q}</p>\n",
+        GenerateMode::Client,
+    );
+    assert!(out.contains("$.set(q, 1);"), "{out}");
+    assert!(out.contains("void $.get(q);"), "{out}");
+}

--- a/crates/rsvelte_core/tests/script_line_terminators_3278.rs
+++ b/crates/rsvelte_core/tests/script_line_terminators_3278.rs
@@ -1,0 +1,85 @@
+//! Issue #3278 — CR, U+2028 and U+2029 are ECMAScript line terminators.
+//!
+//! Two places read "line" as `\n`-delimited text. The client instance-script
+//! pipeline splits statements with `str::lines`, so a `$:` alone on a
+//! CR / U+2028 / U+2029 separated line reached it glued to its neighbour and
+//! lost its `legacy_pre_effect` wrapper. And the printer decided whether a
+//! comment and the node after it share a line by looking for `\n`, so a `//`
+//! comment terminated by U+2028 was emitted with the following statement
+//! appended to it — the declaration became comment text and disappeared from
+//! the output.
+//!
+//! Expectations were measured against the official compiler on the same
+//! sources; the LF spelling of each case is the control and was byte-identical
+//! throughout.
+
+use rsvelte_core::{CompileOptions, GenerateMode, compile};
+
+fn compile_to(source: &str) -> String {
+    compile(
+        source,
+        CompileOptions {
+            filename: Some("A.svelte".to_string()),
+            generate: GenerateMode::Client,
+            ..Default::default()
+        },
+    )
+    .expect("compile failed")
+    .js
+    .code
+}
+
+fn reactive_source(terminator: &str) -> String {
+    format!(
+        "<script>{t}let a = 1;{t}$: b = a + 1;{t}</script>{t}<p>{{b}}</p>\n",
+        t = terminator
+    )
+}
+
+fn line_comment_source(terminator: &str) -> String {
+    format!("<script>\n// c{terminator}const a = 1;\n</script>\n<p>{{a}}</p>\n")
+}
+
+#[test]
+fn a_reactive_statement_on_a_cr_or_separator_line_keeps_its_effect() {
+    for terminator in ["\r", "\u{2028}", "\u{2029}"] {
+        let out = compile_to(&reactive_source(terminator));
+        assert!(
+            out.contains("$.legacy_pre_effect(() => {}, () => {"),
+            "terminator {terminator:?} lost the reactive wrapper:\n{out}"
+        );
+        assert!(
+            !out.contains("$: $.set(b,"),
+            "terminator {terminator:?} left a bare `$:` label:\n{out}"
+        );
+    }
+}
+
+#[test]
+fn a_line_comment_ends_at_a_separator() {
+    for terminator in ["\r", "\u{2028}", "\u{2029}"] {
+        let out = compile_to(&line_comment_source(terminator));
+        assert!(
+            out.contains("// c\n"),
+            "terminator {terminator:?} did not end the comment:\n{out}"
+        );
+        assert!(
+            out.contains("const a = 1;"),
+            "terminator {terminator:?} swallowed the declaration:\n{out}"
+        );
+    }
+}
+
+/// The control: LF spells the same two shapes and was already correct.
+#[test]
+fn the_lf_spelling_is_unchanged() {
+    let out = compile_to(&reactive_source("\n"));
+    assert!(
+        out.contains("$.legacy_pre_effect(() => {}, () => {"),
+        "{out}"
+    );
+
+    let out = compile_to(&line_comment_source("\n"));
+    assert!(out.contains("// c\n"), "{out}");
+    assert!(out.contains("const a = 1;"), "{out}");
+}

--- a/crates/rsvelte_esrap/Cargo.toml
+++ b/crates/rsvelte_esrap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rsvelte_esrap"
-version = "0.10.32"
+version = "0.10.33"
 edition = "2024"
 rust-version = "1.95"
 description = "A Rust port of esrap — prints an oxc AST to JavaScript with esrap's exact layout"

--- a/crates/rsvelte_esrap/src/lib.rs
+++ b/crates/rsvelte_esrap/src/lib.rs
@@ -194,6 +194,7 @@ pub fn print_split(
         print_split_impl::<false>(
             program,
             loc_base,
+            comment_source,
             map_source,
             loc_map,
             options,
@@ -205,6 +206,7 @@ pub fn print_split(
         print_split_impl::<true>(
             program,
             loc_base,
+            comment_source,
             map_source,
             loc_map,
             options,
@@ -219,6 +221,7 @@ pub fn print_split(
 fn print_split_impl<const HAS_COMMENTS: bool>(
     program: &Program<'_>,
     loc_base: u32,
+    comment_source: &str,
     map_source: Option<&str>,
     loc_map: &[LocRange],
     options: &PrintOptions,
@@ -229,6 +232,7 @@ fn print_split_impl<const HAS_COMMENTS: bool>(
     if !HAS_COMMENTS && map_source.is_none() {
         let mut printer =
             printer::Printer::<HAS_COMMENTS, true>::with_comments(options, comments, line_starts)
+                .with_placement_source(comment_source)
                 .with_split_coordinates(map_line_starts, loc_base, loc_map, false);
         let mut ctx = context::Context::new_direct(&options.indent, program.source_text.len());
         printer.print_program(program, &mut ctx);
@@ -242,6 +246,7 @@ fn print_split_impl<const HAS_COMMENTS: bool>(
     }
     let mut printer =
         printer::Printer::<HAS_COMMENTS, false>::with_comments(options, comments, line_starts)
+            .with_placement_source(comment_source)
             .with_split_coordinates(map_line_starts, loc_base, loc_map, map_source.is_some());
     let mut ctx = context::Context::new();
     printer.print_program(program, &mut ctx);
@@ -285,20 +290,22 @@ pub fn print_with_map(program: &Program<'_>, source: &str, options: &PrintOption
     let line_starts = printer::line_starts(source);
     let comments = printer::build_comments(program, source, &line_starts);
     if comments.is_empty() {
-        print_with_map_impl::<false>(program, options, comments, line_starts)
+        print_with_map_impl::<false>(program, source, options, comments, line_starts)
     } else {
-        print_with_map_impl::<true>(program, options, comments, line_starts)
+        print_with_map_impl::<true>(program, source, options, comments, line_starts)
     }
 }
 
 fn print_with_map_impl<const HAS_COMMENTS: bool>(
     program: &Program<'_>,
+    source: &str,
     options: &PrintOptions,
     comments: Vec<printer::Cmt>,
     line_starts: Vec<u32>,
 ) -> PrintWithMap {
     let mut printer =
         printer::Printer::<HAS_COMMENTS, false>::with_comments(options, comments, line_starts)
+            .with_placement_source(source)
             .with_source_map();
     let mut ctx = context::Context::new();
     printer.print_program(program, &mut ctx);

--- a/crates/rsvelte_esrap/src/printer.rs
+++ b/crates/rsvelte_esrap/src/printer.rs
@@ -260,7 +260,9 @@ impl<'a> BorrowedCommentDriver<'a> {
             }
             first = false;
             self.write(comment, ctx);
-            if self.has_newline(comment.span.end, to) {
+            if self.has_newline(comment.span.end, to)
+                || matches!(comment.kind, oxc_ast::ast::CommentKind::Line)
+            {
                 ctx.newline();
             } else if pad {
                 ctx.write_ascii(b' ');
@@ -1086,7 +1088,9 @@ impl<'opt, const HAS_COMMENTS: bool, const DIRECT: bool> Printer<'opt, HAS_COMME
             }
             first = false;
             self.write_comment_at(self.comment_index, ctx);
-            if self.has_newline_between(cmt.end, to) {
+            if !cmt.block {
+                ctx.newline();
+            } else if self.has_newline_between(cmt.end, to) {
                 ctx.newline();
             } else if pad {
                 ctx.write_ascii(b' ');
@@ -4365,7 +4369,8 @@ impl<'opt, const HAS_COMMENTS: bool, const DIRECT: bool> Printer<'opt, HAS_COMME
                 .as_expression()
                 .map_or_else(|| second.span().start, |e| unparen(e).span().start);
             let force_multiline = self.comment_at(self.comment_index).is_some_and(|c| {
-                c.start < second_start && self.comment_starts_on_earlier_line(c, second_start)
+                c.start < second_start
+                    && (!c.block || self.comment_starts_on_earlier_line(c, second_start))
             });
 
             ctx.write_ascii(b'(');

--- a/crates/rsvelte_esrap/src/printer.rs
+++ b/crates/rsvelte_esrap/src/printer.rs
@@ -1088,9 +1088,7 @@ impl<'opt, const HAS_COMMENTS: bool, const DIRECT: bool> Printer<'opt, HAS_COMME
             }
             first = false;
             self.write_comment_at(self.comment_index, ctx);
-            if !cmt.block {
-                ctx.newline();
-            } else if self.has_newline_between(cmt.end, to) {
+            if !cmt.block || self.has_newline_between(cmt.end, to) {
                 ctx.newline();
             } else if pad {
                 ctx.write_ascii(b' ');

--- a/crates/rsvelte_esrap/src/printer.rs
+++ b/crates/rsvelte_esrap/src/printer.rs
@@ -289,7 +289,7 @@ impl<'a> BorrowedCommentDriver<'a> {
         debug_assert!(start <= end);
         self.source
             .get(start as usize..end as usize)
-            .is_some_and(|text| text.as_bytes().contains(&b'\n'))
+            .is_some_and(contains_line_terminator)
     }
 
     fn write<const DIRECT: bool>(
@@ -334,13 +334,49 @@ impl<'a> BorrowedCommentDriver<'a> {
     }
 }
 
+/// Whether `text` holds an ECMAScript `LineTerminator`. esrap asks this by
+/// comparing acorn `loc.line` numbers, which advance on CR and on U+2028 /
+/// U+2029 as well as on LF.
+pub(crate) fn contains_line_terminator(text: &str) -> bool {
+    text.as_bytes().iter().any(|&b| b == b'\n' || b == b'\r')
+        || text.contains(['\u{2028}', '\u{2029}'])
+}
+
 /// Byte offsets at which each source line begins (line 1 starts at 0).
+///
+/// The line breaks counted are ECMAScript `LineTerminator`s, because esrap
+/// reads its line numbers off acorn's `loc`, which advances on CR and on
+/// U+2028 / U+2029 as well as on LF.
 pub fn line_starts(source: &str) -> Vec<u32> {
     // Sized off an assumed ~32 bytes per line so a long source does not walk the
     // whole doubling sequence.
     let mut starts = Vec::with_capacity(source.len() / 32 + 8);
     starts.push(0);
-    starts.extend(memchr::memchr_iter(b'\n', source.as_bytes()).map(|i| usize_to_u32(i) + 1));
+    let bytes = source.as_bytes();
+    let mut index = 0;
+    while let Some(offset) = memchr::memchr3(b'\n', b'\r', 0xE2, &bytes[index..]) {
+        let at = index + offset;
+        // U+2028 / U+2029 are `E2 80 A8` / `E2 80 A9`; any other `E2` lead byte
+        // is an ordinary character.
+        let next_line_start = match bytes[at] {
+            b'\n' => Some(at + 1),
+            b'\r' if bytes.get(at + 1) == Some(&b'\n') => Some(at + 2),
+            b'\r' => Some(at + 1),
+            _ if bytes.get(at + 1) == Some(&0x80)
+                && matches!(bytes.get(at + 2), Some(0xA8 | 0xA9)) =>
+            {
+                Some(at + 3)
+            }
+            _ => None,
+        };
+        match next_line_start {
+            Some(start) => {
+                starts.push(usize_to_u32(start));
+                index = start;
+            }
+            None => index = at + 1,
+        }
+    }
     starts
 }
 
@@ -744,7 +780,7 @@ impl<'opt, const HAS_COMMENTS: bool, const DIRECT: bool> Printer<'opt, HAS_COMME
             |source| {
                 source
                     .get(start as usize..end as usize)
-                    .is_some_and(|text| text.as_bytes().contains(&b'\n'))
+                    .is_some_and(contains_line_terminator)
             },
         )
     }

--- a/crates/rsvelte_esrap/src/printer.rs
+++ b/crates/rsvelte_esrap/src/printer.rs
@@ -106,6 +106,12 @@ pub struct Printer<'opt, const HAS_COMMENTS: bool = true, const DIRECT: bool = f
     /// without comments.
     line_starts: Vec<u32>,
     comment_source: Option<&'opt str>,
+    /// The text the comment spans index into, consulted only to decide whether
+    /// a line break separates two offsets. `line_starts` cannot answer that: it
+    /// doubles as the source-map coordinate table, so it counts LF alone, while
+    /// esrap reads placement off acorn's `loc.line`, which advances on CR and on
+    /// U+2028 / U+2029 too. `None` falls back to `line_starts`.
+    placement_source: Option<&'opt str>,
     /// Byte offsets of each line start in the buffer source-map positions are
     /// resolved against. Same as `line_starts` unless the caller split the two
     /// coordinate spaces (see [`crate::print_split`]).
@@ -344,39 +350,15 @@ pub(crate) fn contains_line_terminator(text: &str) -> bool {
 
 /// Byte offsets at which each source line begins (line 1 starts at 0).
 ///
-/// The line breaks counted are ECMAScript `LineTerminator`s, because esrap
-/// reads its line numbers off acorn's `loc`, which advances on CR and on
-/// U+2028 / U+2029 as well as on LF.
+/// LF only: this table also resolves source-map positions, whose line numbering
+/// is the generated buffer's. Comment *placement* asks a different question —
+/// see [`contains_line_terminator`].
 pub fn line_starts(source: &str) -> Vec<u32> {
     // Sized off an assumed ~32 bytes per line so a long source does not walk the
     // whole doubling sequence.
     let mut starts = Vec::with_capacity(source.len() / 32 + 8);
     starts.push(0);
-    let bytes = source.as_bytes();
-    let mut index = 0;
-    while let Some(offset) = memchr::memchr3(b'\n', b'\r', 0xE2, &bytes[index..]) {
-        let at = index + offset;
-        // U+2028 / U+2029 are `E2 80 A8` / `E2 80 A9`; any other `E2` lead byte
-        // is an ordinary character.
-        let next_line_start = match bytes[at] {
-            b'\n' => Some(at + 1),
-            b'\r' if bytes.get(at + 1) == Some(&b'\n') => Some(at + 2),
-            b'\r' => Some(at + 1),
-            _ if bytes.get(at + 1) == Some(&0x80)
-                && matches!(bytes.get(at + 2), Some(0xA8 | 0xA9)) =>
-            {
-                Some(at + 3)
-            }
-            _ => None,
-        };
-        match next_line_start {
-            Some(start) => {
-                starts.push(usize_to_u32(start));
-                index = start;
-            }
-            None => index = at + 1,
-        }
-    }
+    starts.extend(memchr::memchr_iter(b'\n', source.as_bytes()).map(|i| usize_to_u32(i) + 1));
     starts
 }
 
@@ -698,6 +680,7 @@ impl<'opt, const HAS_COMMENTS: bool, const DIRECT: bool> Printer<'opt, HAS_COMME
             comment_index: 0,
             line_starts: Vec::new(),
             comment_source: None,
+            placement_source: None,
             map_line_starts: None,
             loc_base: None,
             loc_map: Vec::new(),
@@ -722,10 +705,18 @@ impl<'opt, const HAS_COMMENTS: bool, const DIRECT: bool> Printer<'opt, HAS_COMME
             map_line_starts: None,
             line_starts,
             comment_source: None,
+            placement_source: None,
             loc_base: None,
             loc_map: Vec::new(),
             map_nodes: true,
         }
+    }
+
+    /// Decide comment placement by reading `source`, not by comparing lines in
+    /// `line_starts` (which is the source-map coordinate table).
+    pub(crate) const fn with_placement_source(mut self, source: &'opt str) -> Self {
+        self.placement_source = Some(source);
+        self
     }
 
     pub(crate) const fn with_borrowed_comments(
@@ -775,7 +766,7 @@ impl<'opt, const HAS_COMMENTS: bool, const DIRECT: bool> Printer<'opt, HAS_COMME
         if start >= end {
             return false;
         }
-        self.comment_source.map_or_else(
+        self.placement_text().map_or_else(
             || self.line_of(start) < self.line_of(end),
             |source| {
                 source
@@ -786,10 +777,15 @@ impl<'opt, const HAS_COMMENTS: bool, const DIRECT: bool> Printer<'opt, HAS_COMME
     }
 
     fn comment_starts_on_earlier_line(&self, comment: CommentMeta, offset: u32) -> bool {
-        self.comment_source.map_or_else(
+        self.placement_text().map_or_else(
             || comment.start_line < self.line_of(offset),
             |_| self.has_newline_between(comment.start, offset),
         )
+    }
+
+    /// The text placement decisions are read from, if the caller supplied one.
+    fn placement_text(&self) -> Option<&'opt str> {
+        self.comment_source.or(self.placement_source)
     }
 
     /// esrap's `if (node.loc)`: whether a span offset is a real source position

--- a/crates/rsvelte_lint_types/Cargo.lock
+++ b/crates/rsvelte_lint_types/Cargo.lock
@@ -1128,7 +1128,7 @@ dependencies = [
 
 [[package]]
 name = "rsvelte_esrap"
-version = "0.10.32"
+version = "0.10.33"
 dependencies = [
  "compact_str",
  "memchr",


### PR DESCRIPTION
Closes #3272
Closes #3278

Both issues are the same question asked twice — **where does a statement end** — so
they land together: #3278's `$:` half is the same cut as #3272's, and its comment
half is the same "what ends a line" answer one layer down in the printer.

## What was wrong

**1. A legacy `$:` sharing its physical line (#3272).** The client instance-script
pipeline reads one physical line as one statement. Anything on the `$:`'s line
therefore landed on the wrong side of the reactive boundary, three different ways:

| input | rsvelte before | official |
|---|---|---|
| `$: q = 1; void q;` | `$.set(q, 1; void $.get(q))` — **not JavaScript** | `void $.get(q);` then the effect |
| `$: f(); q = 2;` | `q = 2` swallowed into the effect body — **reactivity added** | `$.set(q, 2)` before the effect |
| `let z = 1; void z; $: q = 1;` | a bare `$: $.set(q, 1)` label — **reactivity dropped** | `$.legacy_pre_effect(...)` |

**2. CR / U+2028 / U+2029 (#3278).** The same split reads a line as `\n`-delimited
text, so a `$:` alone on a CR- or separator-terminated line arrived glued to its
neighbour and produced the third row above. And the printer answers "do this
comment and the next node share a line?" the same `\n`-only way, while esrap reads
that off acorn's `loc.line`, which advances on CR and U+2028 / U+2029 too — so a
`//` comment terminated by one of those absorbed the statement after it, which
then **disappeared from the output** on client and server alike.

## The fix

- `separate_same_line_legacy_export_declarations` already cut a same-line pair
  using the parser's top-level statement spans; it becomes
  `separate_same_line_top_level_statements` and also cuts on either side of a `$`
  label. A gap holding no `\n` is what makes a pair same-line, so CR / U+2028 /
  U+2029 cut as well. Formatted source has a `\n` in every gap, so the pass
  returns `Cow::Borrowed` and changes nothing there. When it does cut, the
  retained program and the source projection built for the caller's text no
  longer describe this one, so both are dropped for the rest of the pass.
- `rsvelte_esrap`'s two "is there a line break between these offsets" predicates
  (`line_starts` and the `has_newline` text scan) now count every ECMAScript
  `LineTerminator`.

Boundaries come from the parser, never from a semicolon scan.

## Measurement

A generated grid — 13 `$:` body shapes × 14 same-line trailing forms, plus 7
leading forms × the same 14 — compiled with both compilers, plus an acorn parse
oracle on both sides and a 15-cell line-terminator axis:

| | before | after |
|---|---|---|
| divergent (of 270 compared) | 218 | **32** |
| rsvelte output no JS parser accepts | 54 | **0** |
| official output no JS parser accepts | 0 | 0 |
| line-terminator axis divergent (of 15) | 9 | **0** |
| negative control (same layouts, plain `q = 1;` instead of `$:`) | 0 of 78 | 0 of 78 |

The six repros from the two issues are now **byte-identical to official** on the
client; the server was already identical and is the control.

**The 32 residual cells are two pre-existing defects that have nothing to do with
layout**, each confirmed against the pre-fix binary with a one-statement-per-line
repro:

- 21 cells: a trailing `;;` leaves stray empty statements official drops —
  reproduces with the `;;` on its own line, filed as #3410.
- 14 cells (`$: q += 1`): the dependency thunk prints
  `() => $.get(q)` where official prints `() => ($.get(q))` — reproduces with
  nothing else on the line, filed as #3411.

## Tests

`crates/rsvelte_core/tests/legacy_reactive_same_line_3272.rs` and
`crates/rsvelte_core/tests/script_line_terminators_3278.rs`, every expectation
measured against the official compiler on the same source.

Negative controls, taken separately for each of the two fixes:

- reverting the statement separator fails exactly the three #3272 tests and
  #3278's reactive test, each with its predicted message (`spliced into the
  argument list` / `pulled into the effect body` / `the reactive wrapper was
  dropped`); the plain-assignment control and the server control stay green.
- reverting the esrap change fails exactly `a_line_comment_ends_at_a_separator`
  with the predicted `// c const a = 1;`; the LF control and every #3272 test
  stay green.

Suites run locally: `compiler_fixtures`, `sourcemaps_gate`, `runtime`, `ssr`,
`validator`, `print`, `client_transforms_pin`, `client_script_comments_pin`, and
the whole `rsvelte_esrap` suite — all green.


---

## Revision (3rd commit): the esrap fix is contained to comment placement

The second commit widened `printer::line_starts` itself to count every ECMAScript
`LineTerminator`. **That was wrong, and @legD caught it: the same table is the
source-map coordinate table.** The third commit replaces it with a contained fix.

### Call-site audit of `printer::line_starts`

Two disjoint sets of readers:

| reader | decides |
|---|---|
| `line_of` → `has_newline_between`, `comment_starts_on_earlier_line` | comment **placement** |
| `source_map_line_starts()` → `command::flatten_with_map`; `offset_to_line_col` (`printer.rs:757`); the two column computations (`printer.rs:810`, `889`) | source-map **coordinates** |

The coordinate readers take `map_line_starts.as_deref().unwrap_or(&self.line_starts)`
and `print_with_map` never sets `map_line_starts`, so there it *is* `line_starts`.
`print_split` does set it — but builds it with the same `printer::line_starts`
(`lib.rs:191`) from `map_source`, which for a component is the Svelte source text
(`3_transform/client/mod.rs:2554`). Both map paths were in scope of the 2nd commit.

### The coordinate path

Official counts original positions with **LF alone**. @legD decoded `mappings` and
counted which original lines are referenced, for
`<script>\nlet aaa = 1;{T}let bbb = 2;\n</script>\n<p>{aaa}{bbb}</p>`:

| `{T}` | official | rsvelte on `main` | rsvelte, 2nd commit | rsvelte, this PR now |
|---|---|---|---|---|
| `\n`, `\r\n` | 1,2,3,4,5 | 1,2,3,4,5 | 1,2,3,4,5 | 1,2,3,4,5 |
| `\r`, U+2028, U+2029 | **1,2,3,4** | 1,2,3,4 | **1,2,3,4,5** | **1,2,3,4** |

The last column holds **by construction, not by measurement**: the body of
`line_starts` in this branch is byte-identical to `main` (`diff` of the function
between `origin/main` and `HEAD` is empty — only its doc comment changed, to record
why it counts LF alone), and nothing else the coordinate readers touch was
modified. There is no input on which the map can move.

`sourcemaps_gate` was **green through the 2nd commit as well** (3 passed, 1 ignored).
It asserts structural invariants rather than equality with official, and a uniform
line shift satisfies every one of them — **the gate is not a negative control for
this**, which is why the table above is in the PR body.

### What replaced it

`Printer` gains `placement_source: Option<&'opt str>`, threaded from the
`comment_source` / `source` the callers already hold, and **only** the two placement
predicates consult it (`placement_text()` = `comment_source.or(placement_source)`),
scanning for any `LineTerminator`. @legD reached the same design independently.

### Still fixed, and what is not

The same six line-terminator cells pass, the LF control stays green, and the three
`#3272` tests are unaffected (suites re-run on the contained version:
`rsvelte_esrap` 55, `sourcemaps_gate`, `print`, `compiler_fixtures`,
`compile_both_parity`, plus both new suites).

@legD's grid separately measured **8 residual cells** of the shape
`let a = 1; // c{T}$: b = a + 1;`. They diverge on `main` too and the server half
diverges under LF as well, so they are comment *attachment*, not line termination —
filed as #3469, out of scope here.
