### PR TITLE
fix(server): resolve a template binding before the SSR constant fold

### DIFF
--- a/.changeset/olive-pandas-shave.md
+++ b/.changeset/olive-pandas-shave.md
@@ -1,0 +1,5 @@
+---
+'@rsvelte/compiler': patch
+---
+
+Stop the SSR constant fold from resolving a template binding to a same-named instance binding. An `{#await … then n}` value, an `{#each … as _, n}` index used directly as the loop variable, and every each-block binding read inside the `{:else}` fallback were missing from the fold's shadow set, so `{n}` rendered the outer value as a frozen literal.

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/visitors/await_block.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/visitors/await_block.rs
@@ -111,7 +111,10 @@ pub fn visit_await_block<'a>(node: &AwaitBlock<'a>, state: &mut ServerTransformS
     if let Some(v) = &node.value {
         super::snippet_block::collect_param_pattern_names(v, &mut shadow);
     }
-    state.shadowed_names.push(shadow);
+    // `slot_let_shadows` as well: the awaited value is a runtime value, so a
+    // body read must not constant-fold to a same-named instance literal.
+    state.shadowed_names.push(shadow.clone());
+    state.slot_let_shadows.push(shadow);
     // The `then` fragment's scope is recorded under `block.start + 1` (an await
     // block owns three fragment scopes under one start offset).
     let then_block = match &node.then {
@@ -123,6 +126,7 @@ pub fn visit_await_block<'a>(node: &AwaitBlock<'a>, state: &mut ServerTransformS
         }
         None => state.b.block(vec![]),
     };
+    state.slot_let_shadows.pop();
     state.shadowed_names.pop();
     let then_params = match &node.value {
         Some(v) => vec![value_pattern(v, state)],

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/visitors/each_block.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/visitors/each_block.rs
@@ -160,10 +160,13 @@ pub fn visit_each_block<'a>(node: &EachBlock<'a>, state: &mut ServerTransformSta
     if let Some(ctx) = &node.context {
         collect_context_names(ctx, state, &mut each_shadow);
     }
-    if let Some(alias) = &index_alias {
-        each_shadow.insert(alias.clone());
+    // The source-level index name, not `index_alias` — without a group binding
+    // the loop variable *is* the user's name and there is no alias to record.
+    if let Some(idx) = &node.index {
+        each_shadow.insert(idx.to_string());
     }
     let pushed_shadow = !each_shadow.is_empty();
+    let fallback_shadow = each_shadow.clone();
     if pushed_shadow {
         // Push to BOTH shadow sets: `slot_let_shadows` suppresses the SSR
         // constant-fold (each-item reads are runtime values), and
@@ -207,10 +210,20 @@ pub fn visit_each_block<'a>(node: &EachBlock<'a>, state: &mut ServerTransformSta
         // EachBlock node, so it IS an `is_text_first` parent (upstream
         // `clean_nodes`: `parent.type === 'EachBlock'`) — a text-first fallback
         // gets a leading `<!---->` anchor, same as the loop body.
-        // rsvelte's scope builder visits the fallback inside the each block's
-        // scope, so enter it here too (the item bindings are shadow-vetoed above).
+        // Upstream visits the fallback with the each block's scope
+        // (`if (node.fallback) visit(node.fallback, { scope })`), so an item
+        // name still shadows a same-named instance binding here even though
+        // nothing is bound to it at runtime — the shadow frame goes back on.
         let saved_scope = state.enter_template_scope(node.start);
+        if pushed_shadow {
+            state.shadowed_names.push(fallback_shadow.clone());
+            state.slot_let_shadows.push(fallback_shadow);
+        }
         let mut fallback_body = build_fragment_body(&fallback.nodes, true, false, state);
+        if pushed_shadow {
+            state.slot_let_shadows.pop();
+            state.shadowed_names.pop();
+        }
         state.restore_scope(saved_scope);
         let b = state.b;
         let open_else_push = b.stmt(b.call("$$renderer.push", vec![b.string(BLOCK_OPEN_ELSE)]));

--- a/crates/rsvelte_core/tests/server_shadow_constant_fold_3215.rs
+++ b/crates/rsvelte_core/tests/server_shadow_constant_fold_3215.rs
@@ -1,0 +1,68 @@
+//! The SSR constant fold is vetoed by name through `slot_let_shadows`, and
+//! three template bindings were missing from it (#3215): an `{#await … then n}`
+//! value, an `{#each … as _, n}` index used directly as the loop variable, and
+//! every each-block binding inside the `{:else}` fallback — which upstream
+//! visits with the each block's own scope.
+//!
+//! Every expectation here is the official compiler's output for the same source.
+
+use rsvelte_core::{CompileOptions, GenerateMode, compile};
+
+const PRELUDE: &str =
+    "<script>\n\tlet n = 7;\n\tconst pr = Promise.resolve(1);\n\tlet items = [1, 2];\n</script>\n";
+
+fn server(body: &str) -> String {
+    compile(
+        &format!("{PRELUDE}{body}"),
+        CompileOptions {
+            filename: Some("T.svelte".into()),
+            generate: GenerateMode::Server,
+            dev: false,
+            ..Default::default()
+        },
+    )
+    .map(|r| r.js.code)
+    .unwrap_or_else(|e| format!("COMPILE_ERROR: {e:?}"))
+}
+
+#[test]
+fn an_await_value_shadows_the_instance_binding() {
+    for body in [
+        "{#await pr then n}<b>{n}</b>{/await}",
+        "{#await pr then { n }}<b>{n}</b>{/await}",
+    ] {
+        let out = server(body);
+        assert!(out.contains("${$.escape(n)}"), "{body}\n{out}");
+        assert!(!out.contains("<b>7</b>"), "{body}\n{out}");
+    }
+}
+
+#[test]
+fn an_each_index_used_as_the_loop_variable_shadows_the_instance_binding() {
+    // No group binding, so the loop variable IS the user's name and there is no
+    // alias declaration to record the shadow from.
+    let out = server("{#each items as _, n}<b>{n}</b>{/each}");
+    assert!(out.contains("${$.escape(n)}"), "{out}");
+    assert!(!out.contains("<b>7</b>"), "{out}");
+}
+
+#[test]
+fn the_else_fallback_is_inside_the_each_scope() {
+    // Nothing is bound to `n` when the fallback runs, but upstream still visits
+    // it with the each scope (`if (node.fallback) visit(node.fallback, { scope })`),
+    // so the read must not fold to the instance literal.
+    let out = server("{#each items as n}<b>{n}</b>{:else}<i>{n}</i>{/each}");
+    assert!(out.contains("<i>${$.escape(n)}</i>"), "{out}");
+    assert!(!out.contains("<i>7</i>"), "{out}");
+}
+
+#[test]
+fn a_non_shadowing_name_still_folds() {
+    // The negative control: without a shadow the instance literal must still be
+    // inlined, or the fix would be a blanket disable of the fold.
+    let out = server("{#each items as q}<b>{n}</b>{/each}");
+    assert!(out.contains("<b>7</b>"), "{out}");
+
+    let out = server("{#await pr then q}<b>{n}</b>{/await}");
+    assert!(out.contains("<b>7</b>"), "{out}");
+}


### PR DESCRIPTION
Part 1 of #3215. The issue reports three symptoms with two different causes, so
it ships as two PRs; this one is the **server** half. The client half (the
missing `?? ''`) is a different mechanism in a different file and is a separate
PR.

Closes #3215

## Cause

The SSR constant fold decides whether a bare `{name}` read can be inlined by
consulting `slot_let_shadows` — a stack of name sets that veto the fold for
runtime-valued template bindings — *before* looking `name` up in
`eval_inputs.constant_vars`, which is keyed by name alone
(`server/ast/visitors/shared.rs::flush_sequence`). Three bindings never reached
that veto:

| binding | why it was missing |
|---|---|
| `{#await pr then n}` value | `await_block.rs` pushed the pattern names to `shadowed_names` (which suppresses the derived/store read-wrap) but **not** to `slot_let_shadows` (which suppresses the fold) |
| `{#each … as _, n}` index | `each_block.rs` recorded `index_alias`, which is `None` unless `contains_group_binding` — without a group binding the loop variable **is** the user's name, so nothing was recorded |
| any each binding read in `{:else}` | the fallback was deliberately built outside the shadow push, on the reasoning that "the context isn't bound there" |

The `{:else}` row is the one worth stating separately, because rsvelte's
reasoning was locally sensible and upstream disagrees. `scope.js`:

```js
for (const child of node.body.nodes) visit(child, { scope });
if (node.fallback) visit(node.fallback, { scope });
```

The fallback is visited with the each block's scope, so `n` still *resolves* to
the each binding there even though nothing is bound to it at runtime. Official
emits `$.escape(n)` in the `{:else}`; rsvelte emitted the instance literal.
rsvelte's own phase 2 already agrees with upstream here
(`2_analyze/visitors/each_block.rs` analyses the fallback inside the each
scope) — only phase 3 diverged, so this was two ports of one rule disagreeing
with each other.

## Measurement

Two generated grids, official vs rsvelte, client **and** server, comparing
generated JS:

| grid | `main` | after (server + client PRs) |
|---|---|---|
| 9 shadowing constructs × 8 reference bodies × 2 targets (144 cells) | 14 diverging — **12 server**, 2 client | **0** |
| 4 script shapes (legacy `let`, `$state`, `$derived`, `const` literal) × 20 block shapes × 2 targets (160 cells) | 19 diverging — **16 server**, 3 client | **0** |

This PR owns the 28 server cells; the client PR owns the 5 client cells. The
split was measured, not assumed: built with only the client patch applied, the
server halves still report 12/72 and 16/80 divergences — unchanged from `main` —
so the two halves do not overlap.

The 16 server cells of the second grid are exactly 4 script shapes × the 4 block
shapes this PR names (`await-shadow`, `await-destructure`, `each-index-shadow`,
`each-else`), which is the check that the cause list is complete rather than
merely sufficient.

The second grid is the regression surface for this change and is where the
`{:else}` row came from — it is **not** in the issue, and no committed test
covered it. Its remaining rows are the controls that must not move: nested
`{#each}`, a keyed `{#each … (n)}`, `{@const}` inside an each, a `{#snippet}`
inside an each, an `{#await}` inside an each, `{#await}` pending/catch reads,
and a plain non-block read.

## Negative control

`a_non_shadowing_name_still_folds` is the direction that a blanket "stop
folding in blocks" would break: `{#each items as q}<b>{n}</b>{/each}` and
`{#await pr then q}<b>{n}</b>{/await}` must **still** inline `7`, and both do
on either side. The shadow sets are keyed per name, not per block.

## Tests

`crates/rsvelte_core/tests/server_shadow_constant_fold_3215.rs` (4 tests, every
expectation taken from the official compiler's output for the same source).
Suites run green: `ssr`, `compiler_fixtures`, `validator`.
