### PR TITLE
fix(client): keep a rune declarator's leading comment inside the lowered call

### DIFF
--- a/.changeset/rune-declarator-lead-comment.md
+++ b/.changeset/rune-declarator-lead-comment.md
@@ -1,0 +1,8 @@
+---
+"@rsvelte/compiler": patch
+---
+
+Keep a comment written between a declarator's `=` and its rune call inside the lowered
+call, the way the official compiler places it: inside `$.tag(...)` for `$state`, inside
+`$.proxy(...)` for a non-reactive proxied initializer, inside the synthesized thunk's
+parameter parens for `$derived(expr)`, and before the argument for `$derived.by(fn)`.

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/ast_state_transform.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/ast_state_transform.rs
@@ -905,6 +905,52 @@ impl<'a, 's> StateVarCollector<'a, 's> {
         None
     }
 
+    /// The comment run written between a declarator's binding and its rune
+    /// call. Any code byte restarts the run, so a comment inside a type
+    /// annotation — which is not adjacent to the call — is not one of them.
+    ///
+    /// Upstream never leaves these ahead of the declarator: the lowered call
+    /// either inherits the source callee's `loc` (`$state`) or hands the
+    /// argument to a node esrap flushes them inside, so they end up within the
+    /// wrapper rather than before it.
+    fn declarator_lead_comment_spans(&self, from: u32, to: u32) -> Vec<(u32, u32)> {
+        let bytes = self.source.as_bytes();
+        let mut i = from as usize;
+        let end = (to as usize).min(bytes.len());
+        let mut run: Vec<(u32, u32)> = Vec::new();
+        while i < end {
+            match bytes[i] {
+                b if b.is_ascii_whitespace() => i += 1,
+                b'/' if bytes.get(i + 1) == Some(&b'/') && i + 1 < end => {
+                    let stop = memchr::memchr(b'\n', &bytes[i..end]).map_or(end, |p| i + p);
+                    run.push((i as u32, stop as u32));
+                    i = stop;
+                }
+                b'/' if bytes.get(i + 1) == Some(&b'*') && i + 1 < end => {
+                    let Some(close) = memchr::memmem::find(&bytes[i + 2..end], b"*/") else {
+                        return Vec::new();
+                    };
+                    let stop = i + 2 + close + 2;
+                    run.push((i as u32, stop as u32));
+                    i = stop;
+                }
+                quote @ (b'\'' | b'"' | b'`') => {
+                    run.clear();
+                    i += 1;
+                    while i < end && bytes[i] != quote {
+                        i += if bytes[i] == b'\\' { 2 } else { 1 };
+                    }
+                    i += 1;
+                }
+                _ => {
+                    run.clear();
+                    i += 1;
+                }
+            }
+        }
+        run
+    }
+
     /// Same-line trailing comments (esrap's `flush_trailing_comments`): each is
     /// emitted after a space; a `//` comment forces a newline so it cannot
     /// swallow what the caller appends. Comments past the first newline are not
@@ -1020,16 +1066,37 @@ impl<'a, 's> StateVarCollector<'a, 's> {
     /// no longer has to walk the script in dev mode, eliminating one
     /// O(text_len) buffer pass per component.
     fn maybe_tag_declarator(&self, var_name: &str, replacement: String) -> String {
+        self.maybe_tag_declarator_with_lead(var_name, replacement, "")
+            .0
+    }
+
+    /// [`Self::maybe_tag_declarator`], with the declarator's leading comment run
+    /// placed just inside the tag call and a flag saying whether a wrap
+    /// happened — the caller needs it to decide whether its replacement span
+    /// has to swallow those comments.
+    ///
+    /// `lead` only belongs inside the wrap for `$.state(`: upstream builds that
+    /// callee with the source `$state` callee's `loc`, so esrap flushes the
+    /// comments right before it. `$.proxy(` is built with a plain string callee
+    /// and carries no `loc`, which puts the comments before its argument
+    /// instead — its caller folds them into the argument text rather than
+    /// passing them here.
+    fn maybe_tag_declarator_with_lead(
+        &self,
+        var_name: &str,
+        replacement: String,
+        lead: &str,
+    ) -> (String, bool) {
         if !self.dev {
-            return replacement;
+            return (replacement, false);
         }
         let head = replacement.as_str();
         if head.starts_with("$.state(") || head.starts_with("$.derived(") {
-            format!("$.tag({}, '{}')", replacement, var_name)
+            (format!("$.tag({lead}{replacement}, '{var_name}')"), true)
         } else if head.starts_with("$.proxy(") {
-            format!("$.tag_proxy({}, '{}')", replacement, var_name)
+            (format!("$.tag_proxy({replacement}, '{var_name}')"), true)
         } else {
-            replacement
+            (replacement, false)
         }
     }
 
@@ -1105,15 +1172,22 @@ impl<'a, 's> StateVarCollector<'a, 's> {
             self.split_trailing_comments(&post_comments, arg_end)
         };
 
-        let mut replacement = if is_non_reactive {
+        let replacement = if is_non_reactive {
             arg_text
         } else {
             format!("$.state({arg_text}{trailing})")
         };
 
-        replacement = self.maybe_tag_declarator(var_name, replacement);
+        let lead_spans = self.declarator_lead_comment_spans(id.span().end, call.span.start);
+        let lead = self.flush_trivia_comments(&lead_spans, call.span.start, true);
+        let (mut replacement, tagged) =
+            self.maybe_tag_declarator_with_lead(var_name, replacement, &lead);
+        let start = match lead_spans.first() {
+            Some(&(first, _)) if tagged => first,
+            _ => call.span.start,
+        };
         let end = self.append_comments_past_semicolon(&spilled, call.span.end, &mut replacement);
-        self.add_replacement(call.span.start, end, replacement);
+        self.add_replacement(start, end, replacement);
         true
     }
 
@@ -1190,7 +1264,17 @@ impl<'a, 's> StateVarCollector<'a, 's> {
         } else {
             "void 0".to_string()
         };
-        let arg_text = format!("{pre_comments}{arg_text}");
+        // `$.proxy` is the only wrapper here built with a plain string callee,
+        // so it carries no `loc` and the declarator's leading comments flush
+        // before its ARGUMENT rather than before the call.
+        let lead_spans = self.declarator_lead_comment_spans(id.span().end, call.span.start);
+        let proxy_is_head = is_non_reactive && needs_proxy;
+        let lead_before_arg = if proxy_is_head {
+            self.flush_trivia_comments(&lead_spans, call.span.start, true)
+        } else {
+            String::new()
+        };
+        let arg_text = format!("{lead_before_arg}{pre_comments}{arg_text}");
 
         let bare = is_non_reactive && !needs_proxy;
         // A wrapper call keeps same-line trailing comments inside its parens
@@ -1202,7 +1286,7 @@ impl<'a, 's> StateVarCollector<'a, 's> {
             self.split_trailing_comments(&post_comments, arg_end)
         };
 
-        let mut replacement = if is_non_reactive {
+        let replacement = if is_non_reactive {
             if needs_proxy {
                 format!("$.proxy({arg_text}{trailing})")
             } else {
@@ -1216,9 +1300,19 @@ impl<'a, 's> StateVarCollector<'a, 's> {
             format!("$.state({arg_text}{trailing})")
         };
 
-        replacement = self.maybe_tag_declarator(var_name, replacement);
+        let lead_before_call = if proxy_is_head {
+            String::new()
+        } else {
+            self.flush_trivia_comments(&lead_spans, call.span.start, true)
+        };
+        let (mut replacement, tagged) =
+            self.maybe_tag_declarator_with_lead(var_name, replacement, &lead_before_call);
+        let start = match lead_spans.first() {
+            Some(&(first, _)) if proxy_is_head || tagged => first,
+            _ => call.span.start,
+        };
         let end = self.append_comments_past_semicolon(&spilled, call.span.end, &mut replacement);
-        self.add_replacement(call.span.start, end, replacement);
+        self.add_replacement(start, end, replacement);
         true
     }
 
@@ -1994,7 +2088,15 @@ impl<'a, 's> StateVarCollector<'a, 's> {
         let arg = &call.arguments[0];
         self.visit_argument(arg);
         let arg_span = arg.span();
-        let (pre_spans, post_spans) = self.rune_call_comment_slots(call, arg_span);
+        let (mut pre_spans, post_spans) = self.rune_call_comment_slots(call, arg_span);
+        // `$.derived` is built with a plain string callee and takes the user's
+        // own function unchanged, so the declarator's leading comments flush
+        // before that argument just like the ones written inside the parens.
+        let lead_spans = self.declarator_lead_comment_spans(id.span().end, call.span.start);
+        let start = lead_spans
+            .first()
+            .map_or(call.span.start, |&(first, _)| first);
+        pre_spans.splice(0..0, lead_spans);
         let lead_comments = self.flush_trivia_comments(&pre_spans, arg_span.start, true);
         let transformed_arg = self.apply_and_drain_inner_replacements(arg_span.start, arg_span.end);
 
@@ -2004,7 +2106,7 @@ impl<'a, 's> StateVarCollector<'a, 's> {
         let replacement = format!("$.derived({lead_comments}{transformed_arg}{trail})");
         let mut replacement = self.maybe_tag_declarator(var_name, replacement);
         let end = self.append_comments_past_semicolon(&spilled, call.span.end, &mut replacement);
-        self.add_replacement(call.span.start, end, replacement);
+        self.add_replacement(start, end, replacement);
         true
     }
 
@@ -2076,8 +2178,16 @@ impl<'a, 's> StateVarCollector<'a, 's> {
         // Comments between the call's `(` and the argument ride along: into the
         // synthesized thunk's empty parameter parens (where esrap flushes them
         // — the params sequence runs until the body's start), or straight
-        // before the argument when no thunk is added.
-        let (pre_spans, post_spans) = self.rune_call_comment_slots(call, arg_span);
+        // before the argument when no thunk is added. The ones written between
+        // the declarator's `=` and `$derived(` reach the same slot, because
+        // upstream builds `$.derived` with a plain string callee that carries
+        // no `loc` of its own.
+        let (mut pre_spans, post_spans) = self.rune_call_comment_slots(call, arg_span);
+        let lead_spans = self.declarator_lead_comment_spans(id.span().end, call.span.start);
+        let start = lead_spans
+            .first()
+            .map_or(call.span.start, |&(first, _)| first);
+        pre_spans.splice(0..0, lead_spans);
         let param_comments = self.flush_trivia_comments(&pre_spans, arg_span.start, false);
         let lead_comments = self.flush_trivia_comments(&pre_spans, arg_span.start, true);
 
@@ -2108,7 +2218,7 @@ impl<'a, 's> StateVarCollector<'a, 's> {
             let mut replacement = self.maybe_tag_declarator(var_name, replacement);
             let end =
                 self.append_comments_past_semicolon(&post_spans, call.span.end, &mut replacement);
-            self.add_replacement(call.span.start, end, replacement);
+            self.add_replacement(start, end, replacement);
             return true;
         }
 
@@ -2158,6 +2268,8 @@ impl<'a, 's> StateVarCollector<'a, 's> {
             };
             let end =
                 self.append_comments_past_semicolon(&post_spans, call.span.end, &mut replacement);
+            // The async form drops the thunk parens the leading comments would
+            // have gone into, so they keep their source position here.
             self.add_replacement(call.span.start, end, replacement);
             return true;
         }
@@ -2168,7 +2280,7 @@ impl<'a, 's> StateVarCollector<'a, 's> {
             let mut replacement = self.maybe_tag_declarator(var_name, replacement);
             let end =
                 self.append_comments_past_semicolon(&post_spans, call.span.end, &mut replacement);
-            self.add_replacement(call.span.start, end, replacement);
+            self.add_replacement(start, end, replacement);
             return true;
         }
 
@@ -2184,7 +2296,7 @@ impl<'a, 's> StateVarCollector<'a, 's> {
                 let mut replacement = self.maybe_tag_declarator(var_name, replacement);
                 let end =
                     self.append_comments_past_semicolon(&spilled, call.span.end, &mut replacement);
-                self.add_replacement(call.span.start, end, replacement);
+                self.add_replacement(start, end, replacement);
                 return true;
             }
         }
@@ -2205,7 +2317,7 @@ impl<'a, 's> StateVarCollector<'a, 's> {
         let replacement = format!("$.derived({derived_arg}{trail})");
         let mut replacement = self.maybe_tag_declarator(var_name, replacement);
         let end = self.append_comments_past_semicolon(&spilled, call.span.end, &mut replacement);
-        self.add_replacement(call.span.start, end, replacement);
+        self.add_replacement(start, end, replacement);
         true
     }
 

--- a/crates/rsvelte_core/tests/rune_declarator_leading_comment_3070.rs
+++ b/crates/rsvelte_core/tests/rune_declarator_leading_comment_3070.rs
@@ -1,0 +1,198 @@
+//! A comment written between a declarator's `=` and its rune call belongs
+//! *inside* whatever the rune lowers to, not ahead of the declaration.
+//!
+//! Upstream never leaves it outside, and the four rune forms put it in four
+//! different slots because of how `VariableDeclaration.js` builds them:
+//!
+//! | rune | built as | where esrap flushes the comment |
+//! |---|---|---|
+//! | `$state` / `$state.raw` | `b.id('$.state', init.callee.loc)` — the callee inherits the source `loc` | before `$.state`, i.e. just inside `$.tag(` |
+//! | `$state({…})` non-reactive | `b.call('$.proxy', value)` — plain string callee, no `loc` | before the argument, inside `$.proxy(` |
+//! | `$derived(expr)` | `b.call('$.derived', b.thunk(expr))` — the arrow has no `loc`, its body does | inside the synthesized thunk's empty parameter parens |
+//! | `$derived.by(fn)` | `b.call('$.derived', fn)` — the argument is the user's own located function | before that argument |
+//!
+//! The rule under all four is one thing: the comment prints just before the
+//! first node of the OUTPUT that still carries a source range at or after it.
+//! Every expectation here is the pinned official compiler's own output.
+
+use rsvelte_core::{CompileOptions, GenerateMode, compile};
+
+fn client(script: &str, template: &str, dev: bool) -> String {
+    let source = format!("<script>\n\t{script}\n</script>\n\n{template}\n");
+    compile(
+        &source,
+        CompileOptions {
+            generate: GenerateMode::Client,
+            dev,
+            ..Default::default()
+        },
+    )
+    .expect("compile failed")
+    .js
+    .code
+}
+
+/// `a` is reassigned from the template, so every shape below that names it
+/// lowers to a real state source rather than being folded to a constant.
+const COUNTER: &str = "<button onclick={() => a++}>{a}</button>";
+
+#[track_caller]
+fn assert_contains(code: &str, needle: &str) {
+    assert!(
+        code.contains(needle),
+        "expected to find\n  {needle}\nin:\n{code}"
+    );
+}
+
+#[test]
+fn state_lead_comment_goes_inside_the_dev_tag_call() {
+    let script = "let a = /* c */ $state(0);";
+    assert_contains(
+        &client(script, COUNTER, false),
+        "let a = /* c */ $.state(0);",
+    );
+    assert_contains(
+        &client(script, COUNTER, true),
+        "let a = $.tag(/* c */ $.state(0), 'a');",
+    );
+}
+
+#[test]
+fn state_raw_lead_comment_goes_inside_the_dev_tag_call() {
+    let script = "let a = /* c */ $state.raw(0);";
+    assert_contains(
+        &client(script, COUNTER, false),
+        "let a = /* c */ $.state(0);",
+    );
+    assert_contains(
+        &client(script, COUNTER, true),
+        "let a = $.tag(/* c */ $.state(0), 'a');",
+    );
+}
+
+/// A proxied state source still leads with `$.state(`, so the comment sits at
+/// the tag call's opening paren rather than descending into `$.proxy(`.
+#[test]
+fn proxied_state_lead_comment_stays_ahead_of_the_state_call() {
+    let script = "let a = /* c */ $state({ n: 0 });";
+    let template = "<button onclick={() => (a = { n: 1 })}>{a.n}</button>";
+    assert_contains(
+        &client(script, template, false),
+        "let a = /* c */ $.state($.proxy({ n: 0 }));",
+    );
+    assert_contains(
+        &client(script, template, true),
+        "let a = $.tag(/* c */ $.state($.proxy({ n: 0 })), 'a');",
+    );
+}
+
+/// The discriminating row for the `$.proxy` slot: with no `$.state` wrapper the
+/// only located node left is the argument, so the comment moves inside the
+/// proxy call. A rule that always put it after the tag's `(` would print
+/// `$.tag_proxy(/* c */ $.proxy({ n: 0 }), 'o')` here.
+#[test]
+fn non_reactive_proxy_lead_comment_goes_before_the_argument() {
+    let script = "let a = $state(0);\n\tlet o = /* c */ $state({ n: 0 });";
+    let template = "<button onclick={() => a++}>{a}</button>{o.n}";
+    assert_contains(
+        &client(script, template, false),
+        "let o = $.proxy(/* c */ { n: 0 });",
+    );
+    assert_contains(
+        &client(script, template, true),
+        "let o = $.tag_proxy($.proxy(/* c */ { n: 0 }), 'o');",
+    );
+}
+
+#[test]
+fn derived_lead_comment_goes_into_the_synthesized_thunk_parens() {
+    let script = "let a = $state(0);\n\tlet d = /* c */ $derived(a * 2);";
+    let template = "<button onclick={() => a++}>{a}</button>{d}";
+    assert_contains(
+        &client(script, template, false),
+        "let d = $.derived((/* c */) => $.get(a) * 2);",
+    );
+    assert_contains(
+        &client(script, template, true),
+        "let d = $.tag($.derived((/* c */) => $.get(a) * 2), 'd');",
+    );
+}
+
+#[test]
+fn derived_object_lead_comment_goes_into_the_synthesized_thunk_parens() {
+    let script = "let a = $state(0);\n\tlet d = /* c */ $derived({ n: a });";
+    let template = "<button onclick={() => a++}>{a}</button>{d.n}";
+    assert_contains(
+        &client(script, template, false),
+        "let d = $.derived((/* c */) => ({ n: $.get(a) }));",
+    );
+}
+
+/// `$derived.by` hands its argument through unchanged, so there is no
+/// synthesized arrow to park the comment in and it lands before the user's own
+/// function instead.
+#[test]
+fn derived_by_lead_comment_goes_before_the_user_function() {
+    let script = "let a = $state(0);\n\tlet d = /* c */ $derived.by(() => a * 2);";
+    let template = "<button onclick={() => a++}>{a}</button>{d}";
+    assert_contains(
+        &client(script, template, false),
+        "let d = $.derived(/* c */ () => $.get(a) * 2);",
+    );
+    assert_contains(
+        &client(script, template, true),
+        "let d = $.tag($.derived(/* c */ () => $.get(a) * 2), 'd');",
+    );
+}
+
+/// A `//` comment cannot be followed by code on the same line, so the closing
+/// paren esrap writes after it starts a line of its own.
+#[test]
+fn a_line_comment_breaks_the_thunk_parens_across_lines() {
+    let script = "let a = $state(0);\n\tlet d = // c\n\t\t$derived(a * 2);";
+    let template = "<button onclick={() => a++}>{a}</button>{d}";
+    assert_contains(
+        &client(script, template, false),
+        "let d = $.derived((// c\n\t) => $.get(a) * 2);",
+    );
+}
+
+/// Control: a comment before the binding NAME is not part of the run adjacent
+/// to the call, and upstream leaves it where the source put it.
+#[test]
+fn a_comment_before_the_binding_name_does_not_move() {
+    let script = "let /* c */ a = $state(0);";
+    assert_contains(
+        &client(script, COUNTER, false),
+        "let /* c */ a = $.state(0);",
+    );
+    assert_contains(
+        &client(script, COUNTER, true),
+        "let /* c */ a = $.tag($.state(0), 'a');",
+    );
+}
+
+/// Control: a comment already inside the rune's parens reaches the same slot,
+/// and must not be moved a second time or duplicated.
+#[test]
+fn a_comment_inside_the_rune_parens_is_unchanged() {
+    let script = "let a = $state(/* c */ 0);";
+    assert_contains(
+        &client(script, COUNTER, false),
+        "let a = $.state(/* c */ 0);",
+    );
+    assert_contains(
+        &client(script, COUNTER, true),
+        "let a = $.tag($.state(/* c */ 0), 'a');",
+    );
+}
+
+/// Control: a declarator that lowers to its bare argument has no wrapper for
+/// the comment to move into, so it stays ahead of the initializer.
+#[test]
+fn a_folded_declarator_keeps_its_lead_comment_outside() {
+    let script = "let a = $state(0);\n\tlet o = /* c */ $state(1);";
+    let template = "<button onclick={() => a++}>{a}</button>{o}";
+    assert_contains(&client(script, template, false), "let o = /* c */ 1;");
+    assert_contains(&client(script, template, true), "let o = /* c */ 1;");
+}

--- a/upstream_issues/3070-svelte-template-comment-leaks-into-generated-code.md
+++ b/upstream_issues/3070-svelte-template-comment-leaks-into-generated-code.md
@@ -1,0 +1,153 @@
+# A comment written in a template expression is emitted inside unrelated generated code
+
+A comment inside a mustache or an attribute value does not stay with the expression it
+was written in. For the client target it is printed inside a generated DOM-wiring call
+whose position has nothing to do with the comment, and whether it appears at all depends
+on the source *line* of an element's tag name and on how many template updates the
+component happens to have.
+
+```svelte
+<!-- input.svelte -->
+<script>
+	let n = $state(0);
+</script>
+
+<button onclick={() => n++}>{/* c */ n}</button>
+```
+
+`compile(source, { generate: 'client' })`:
+
+```js
+var button = root();
+var text = $.child(button, /* c */ true);
+```
+
+The comment is now the trailing comment of the generated `button` binding, one argument
+ahead of a `true` that means "this child is a text node".
+
+## Why
+
+Three upstream decisions compose into it.
+
+1. `phases/3-transform/client/transform-client.js:394` —
+   `component_block.loc = instance.loc;`, commented *"trick esrap into including
+   comments"*. The component body is given the instance script's `loc`, so
+   `body(context, node)` calls `reset_comment_index` on a located node and the cursor is
+   live for the whole body. The comment list it walks is the **file's**, so template
+   comments are in it.
+
+2. `phases/3-transform/client/visitors/shared/fragment.js:47-52,113-117` — `flush_node`
+   builds each generated element binding as `b.id(scope.generate(name), loc)` with
+   `loc = node.name_loc`, i.e. **the source location of the element's tag name**. So the
+   synthesized identifier `button` reports itself as living at `<button` on line 5.
+
+3. esrap's `CallExpression` visitor (`esrap@2.2.12`, `src/languages/ts/index.js:561-617`)
+   writes the argument
+   separator *before* flushing that argument's trailing comments:
+
+   ```js
+   context.visit(arg);
+   if (!is_last) context.write(',');
+   ...
+   flush_trailing_comments(context, arg.loc?.end ?? null, next);
+   ```
+
+   `flush_trailing_comments` takes any pending comment whose start line equals
+   `arg.loc.end.line`. The comment is on line 5; `button`'s `loc` ends on line 5; so it is
+   written after the comma, giving `$.child(button, /* c */ true)`.
+
+The fourth ingredient decides whether it survives at all: `$.template_effect` is emitted
+as a **concise arrow** when there is one update and as a **block** when there are several,
+and a builder-made block hits `reset_comment_index`'s `if (!node.loc) { comment_index =
+comments.length; return; }` — the same cursor kill as
+[2990](2990-svelte-class-accessor-drops-later-comments.md). So the same comment can be
+printed or dropped depending on how many things the template updates.
+
+## The axis, measured (Svelte 5.56.10)
+
+Each row is one comment, spelled `/* c */`, moved to a different slot. "official" is where
+the pinned compiler puts it.
+
+| input | target | official |
+|---|---|---|
+| `<button …>{/* c */ n}</button>` | client | `$.child(button, /* c */ true)` |
+| `<button …>{n /* c */}</button>` | client | `$.child(button, /* c */ true)` — leading and trailing land in the same slot |
+| `<button … title={/* c */ n}>x</button>` | client | `$.set_attribute(button, /* c */ 'title', $.get(n))` |
+| `{#each items as it (/* c */ it)}` | client | `$.each(node, 16, () => items, (it /* c */) => it, …)` — the generated key arrow's parameter list |
+| `{@html String(n) /* c */}` | client | `$.html(node, () => String($.get(n /* c */)))` |
+| `<button …><span></span>{/* c */ n}</button>` | client | `$.sibling($.child(button /* c1 */), 1, true)` — one argument, so no comma to sit behind |
+| `<button …>{n}</button><p>{/* c */ n}</p>` | client | the **first** `$.child`, not the `<p>`'s one |
+| `<button …>{n}</button>`⏎`<p title={/* c */ n}></p>` | client | **dropped** — the comment is on line 6, `button`'s tag name ends on line 5 |
+| `{/* c */ n}` | server | `$.escape(/* c */ n)` |
+| `<p title={/* c */ n}>` | server | `$.attr('title', /* c */ n)` |
+
+The discriminating rows are the last four. Moving the comment from line 5 to line 6
+without changing anything else turns "printed inside `$.child`" into "not printed at all",
+which is what shows the placement is decided by an unrelated tag name's line rather than
+by the expression the comment belongs to. And the two server rows are the control: on that
+target the same comments land next to their own expression, so this is a client-codegen
+artifact, not a general property of how Svelte handles comments in expressions.
+
+rsvelte currently drops every client row and every server row above.
+
+## Suggested fix
+
+Give the synthesized element binding no `loc` (it exists for source mapping, and a
+mapping is not the same claim as "a comment written here belongs to this node"), or move
+`flush_trailing_comments` in esrap's `CallExpression` visitor to before the separator so
+a comment at least cannot cross an argument boundary. Neither is sufficient on its own —
+the cursor kill on builder-made blocks is the other half, and that is
+[2990](2990-svelte-class-accessor-drops-later-comments.md)'s repair.
+
+## What rsvelte does about it, and why
+
+The standing rule here is: **reproduce an upstream defect when its output runs; do not
+reproduce it when the output is not JavaScript.** Every row above is valid JavaScript that
+runs identically, so the default is to reproduce all of them, and that is the intent
+recorded here. rsvelte drops every row today.
+
+The two halves are at different distances from that, and the distinction is a
+prerequisite, not a preference.
+
+**The server rows are reachable now and are a plain rsvelte defect.** On that target the
+comment lands next to the expression the user wrote it in, the server's comment placement
+already runs through `3_transform/server/ast/comments.rs`, and the missing piece is that a
+pending run is not claimed at an attribute value, an `{#if}` test, an `{#each}` collection
+or a `{@html}` argument. That is the template half of rsvelte #3098 and is where the work
+belongs; nothing in this file argues against doing it.
+
+**The client rows have no slot to place a comment into yet.** rsvelte's client comment
+coordinate space is the *generated* script text, not the `.svelte` source:
+`js_ast/to_oxc.rs::into_coordinate_free_program` clears `program.comments` outright, on the
+stated grounds that "a comment's position is a coordinate too" and the spans would index
+the wrong text. Template expressions are rebuilt structurally by
+`client/visitors/expression_converter.rs`, whose only comment handling is own-line
+statement raws and the `svelte-ignore` scan — a comment written inside a mustache or an
+attribute value never enters the printed comment stream at all. So reproducing these rows
+is not a placement decision that could be made in the element visitors; it needs the
+comments to exist in that stream first. That is the coordinate-space unification, and it
+is the same prerequisite that blocks #3098's client half.
+
+So this is not "we decline". It is: the client rows stay divergent until the comment
+stream exists, and the rule to implement at that point is already derived, so nobody has
+to re-measure it:
+
+1. The comment must be flushed against a cursor that is live across the whole component
+   body — upstream gets that from `component_block.loc = instance.loc`.
+2. The generated element binding must report the element's **tag-name** location, so a
+   pending comment on that line becomes its trailing comment.
+3. The flush must happen after the argument separator, which is what puts the comment one
+   argument to the right.
+4. A generated block (the multi-update `$.template_effect(() => { … })` form) kills the
+   cursor, so the comment is dropped there while the single-update concise-arrow form
+   keeps it.
+
+Two things to hold on to while that is outstanding. First, these rows are invisible to the
+corpus output gate — byte-different pairs fall through to `ast_equiv_batch`, which is
+invoked with an empty argv and ignores comments — so they surface only under the matrix
+gate's `comment-mismatch` verdict and the mutation gate; a green corpus run says nothing
+about them. Second, if upstream repairs any of this, step 2 and step 4 are the parts that
+move, and the server rows would then be the only ones left — so re-measure before
+concluding from a divergence which side is wrong.
+
+Tracked in rsvelte issue #3070 (class 5); the server half is rsvelte #3098.


### PR DESCRIPTION
A comment written between a declarator's `=` and its rune call was emitted ahead of the
whole declaration. Upstream never leaves it there — and the four rune forms put it in four
*different* slots, which is why one rule ("hoist it into the wrapper") would have been
wrong for three of them.

Addresses #3070 class 4, plus three sibling classes the same grid found.

## The rule, and where it comes from

The comment prints just before the first node of the **output** that still carries a
source range at or after it. `VariableDeclaration.js` decides which node that is:

| rune | how upstream builds it | where the comment lands |
|---|---|---|
| `$state` / `$state.raw` | `b.id('$.state', init.callee.loc)` — the callee **inherits the source `loc`** (`VariableDeclaration.js:149`) | before `$.state`, i.e. just inside `$.tag(` |
| `$state({…})`, non-reactive | `b.call('$.proxy', value)` — plain string callee, no `loc` | before the **argument**, inside `$.proxy(` |
| `$derived(expr)` | `b.call('$.derived', b.thunk(expr))` — the arrow has no `loc`, its body does | inside the synthesized thunk's **empty parameter parens** |
| `$derived.by(fn)` | `b.call('$.derived', fn)` — the argument is the user's own located function | before that argument |

rsvelte emitted `/* c */ $.tag(…)` / `/* c */ $.derived(…)` for all four.

```svelte
<script>
	let a = /* c */ $state(0);
	let d = /* c */ $derived(a * 2);
</script>
```

```js
// official (dev)                            // rsvelte, before
let a = $.tag(/* c */ $.state(0), 'a');      let a = /* c */ $.tag($.state(0), 'a');
let d = $.tag($.derived((/* c */) => …), 'd');  let d = /* c */ $.tag($.derived(() => …), 'd');
```

## The fix

All in `3_transform/client/ast_state_transform.rs`, using the comment helpers that were
already there (`rune_call_comment_slots`, `flush_trivia_comments`, `maybe_tag_declarator`).
No coordinate-space change, no new scan of the script:

* `declarator_lead_comment_spans` returns the comment run **adjacent** to the call. Any
  code byte restarts the run, so a comment inside a type annotation
  (`let d: Record<string, "/*"> = /* c */ $derived(…)`) is not one of them; string literals
  are skipped so a `/*` inside one cannot open a comment.
* `maybe_tag_declarator_with_lead` places the run inside `$.tag(` and reports whether it
  wrapped, so the caller knows whether its replacement span has to swallow those bytes.
  `$.tag_proxy` deliberately does **not** take it — `$.proxy` has no `loc`, so its caller
  folds the run into the argument text instead.
* The two `$derived` handlers prepend the run to the `pre_spans` they already collect from
  inside the parens, which is the same slot; `$derived(await …)` is left alone, because the
  async form drops the thunk parens the comments would have gone into.

## Measurement

24 declarator shapes × 4 targets = 96 comparisons against the pinned official compiler
(`submodules/svelte`, 5.56.10):

| | diverging |
|---|---|
| merge base | 29 |
| this branch | **4** |

25 fixed, **0 regressions** — checked as a set difference: all 4 remaining are in the
merge base's 29. They are two classes this PR does not claim: a **trailing** comment after
the rune call (`$.state(0 /* c */)` vs `$.state(0); /* c */`, client), and the server's
interior slot for a comma declarator, which is #3070 class 1.

A second grid printed the declarator line for 13 shapes × dev on/off: **26/26 match**,
including the `//` spellings, where esrap breaks `$.tag(` across lines and puts the closing
paren of the thunk on its own line.

`crates/rsvelte_core/tests/rune_declarator_leading_comment_3070.rs` pins all four slots
with every expectation taken from the official compiler's own output, plus four negative
controls that are the reason the four slots had to be separated:

* `let /* c */ a = $state(0)` — a comment before the **name** is not adjacent to the call
  and must not move.
* `let a = $state(/* c */ 0)` — a comment already in the right slot must not move twice or
  duplicate.
* `let o = /* c */ $state(1)` folded to `let o = /* c */ 1` — no wrapper to move into.
* the non-reactive proxy row, which is what falsifies "always put it after the tag's `(`":
  that rule would print `$.tag_proxy(/* c */ $.proxy({ n: 0 }), 'o')` and official prints
  `$.tag_proxy($.proxy(/* c */ { n: 0 }), 'o')`.

Suites run green: `--lib` (1732), `compiler_fixtures`, `ssr`, `runtime`, and the ten
comment/rune-adjacent suites (`client_script_comments_pin`, `client_transforms_pin`,
`class_field_leading_comment_2437`, `class_field_tag_label_2021`,
`async_derived_comment_2755`, `comment_delimiters_in_initializer`,
`comment_before_continuation_decl`, `comma_declaration_split`,
`client_function_body_comment_2527`, `client_effect_trailing_comment_2718`).

## #3070 class 5 — upstream is the one that is wrong, and this records the decision

Class 5 is the row where upstream leaks a template-expression comment into unrelated
generated code. `upstream_issues/3070-svelte-template-comment-leaks-into-generated-code.md`
carries the report. The mechanism is three upstream decisions composing, and I traced all
three rather than describing the symptom:

1. `transform-client.js:394` `component_block.loc = instance.loc` — literally commented
   *"trick esrap into including comments"* — keeps one cursor live over the **file's**
   comment list for the whole component body, template comments included.
2. `shared/fragment.js:47-52,113-117` builds each generated element binding as
   `b.id(scope.generate(name), node.name_loc)`, so `button` reports itself as living at the
   `<button` **tag name**.
3. esrap's `CallExpression` writes the argument separator *before*
   `flush_trailing_comments(arg.loc?.end, next)` (`esrap@2.2.12`, `ts/index.js:611` then
   `:617`), and that flush keys on the comment's **line** matching `arg.loc.end.line`.

So `{/* c */ n}` becomes `$.child(button, /* c */ true)`; move the `<p>` to the next line
and the same comment is **dropped instead**, because it no longer shares a line with a tag
name. That line-move is the discriminating case, and the server rows are the control — the
same comments land beside their own expression there, so this is a client-codegen artifact
rather than how Svelte treats comments in expressions.

Per the standing rule (reproduce an upstream defect when the output runs; do not when the
output is not JavaScript) the default here is **reproduce** — the output is valid JS. The
write-up records that intent and splits the work by what is actually reachable:

* **Server rows: reproduce, and they are a plain rsvelte defect.** That is #3098's template
  half; cmtA's #3326 already built the `ChunkRegistry` machinery it needs.
* **Client rows: blocked on a prerequisite, not declined.** rsvelte's client comment space
  is the generated script text —
  `js_ast/to_oxc.rs::into_coordinate_free_program` clears `program.comments` outright
  because "a comment's position is a coordinate too", and
  `client/visitors/expression_converter.rs` rebuilds template expressions with no comment
  channel at all. There is nothing to place yet. So the write-up states the four-step rule
  to implement once the comment stream exists, so it is a lookup rather than a
  re-derivation.

## Not fixed

* #3070 classes 1-3 (server interior slot, own-line spill, dangling instance tail) — cmtA's
  #3326 territory; this branch touches none of its files.
* #3070 class 5 client rows — above.
* A **trailing** comment after a rune call (`$.state(0 /* c */)`). Diverges on the merge
  base too; this change does not widen it.

## Ratchets

None touched. Comment-only divergences are invisible to the corpus output gate
(`ast_equiv_batch` runs with an empty argv and ignores comments), so `--update-baseline`
was not run. If the matrix gate's `comment-mismatch` verdict moves, I will re-baseline off
a fresh `origin/main`.

Refs #3070 — this closes class 4 and three siblings; classes 1-3 and 5 stay open (see
*Not fixed*), so the issue is deliberately not auto-closed.
