### PR TITLE
fix(parse): reject a TypeScript namespace with non-type nodes through every modifier

### DIFF
--- a/.changeset/ts-namespace-modifiers-3244.md
+++ b/.changeset/ts-namespace-modifiers-3244.md
@@ -1,0 +1,5 @@
+---
+'@rsvelte/compiler': patch
+---
+
+Reject a TypeScript namespace with non-type nodes through every modifier: `export namespace N { … }`, `declare module "x" { … }` and `declare global { … }` now raise `typescript_invalid_feature` at upstream's span instead of compiling.

--- a/crates/rsvelte_core/src/compiler/phases/1_parse/read/expression.rs
+++ b/crates/rsvelte_core/src/compiler/phases/1_parse/read/expression.rs
@@ -8253,84 +8253,82 @@ fn convert_statement_for_program(
 
         // TypeScript module/namespace declarations - emit so remove_typescript_nodes can detect them
         oxc_ast::ast::Statement::TSExternalModuleDeclaration(module_decl) => {
-            // `declare module`, `declare global`, `declare namespace` etc. are
-            // type-only and must be stripped.
-            if module_decl.declare {
-                let start = offset + module_decl.span.start as usize;
-                let end = offset + module_decl.span.end as usize;
-                return Some(JsNode::EmptyStatement {
-                    start: start as u32,
-                    end: end as u32,
-                    loc: create_typed_loc(start, end, line_offsets),
-                });
-            }
-            let start = offset + module_decl.span.start as usize;
-            let end = offset + module_decl.span.end as usize;
-            let loc = create_typed_loc(start, end, line_offsets);
-
-            // Include body so remove_typescript_nodes can check for non-type nodes
-            let body = module_decl.body.as_ref().map(|block| {
-                let block_body: Vec<JsNode> = block
-                    .body
-                    .iter()
-                    .filter_map(|stmt| {
-                        convert_statement_for_program(arena, stmt, offset, line_offsets)
-                    })
-                    .collect();
-                arena.alloc_js_node(JsNode::BlockStatement {
-                    start: start as u32,
-                    end: end as u32,
-                    loc: loc.clone(),
-                    body: arena.alloc_js_children(block_body),
-                })
-            });
-
-            Some(JsNode::TSModuleDeclaration {
-                start: start as u32,
-                end: end as u32,
-                loc,
-                body,
-            })
+            Some(convert_ts_module_declaration_as_node(
+                arena,
+                module_decl.span,
+                module_decl.body.as_deref(),
+                offset,
+                line_offsets,
+            ))
         }
         oxc_ast::ast::Statement::TSNamespaceDeclaration(module_decl) => {
-            let start = offset + module_decl.span.start as usize;
-            let end = offset + module_decl.span.end as usize;
-            let loc = create_typed_loc(start, end, line_offsets);
-            if module_decl.declare {
-                return Some(JsNode::EmptyStatement {
-                    start: start as u32,
-                    end: end as u32,
-                    loc,
-                });
-            }
-            let body = match &module_decl.body {
-                oxc_ast::ast::TSNamespaceDeclarationBody::TSModuleBlock(block) => {
-                    let block_body = block
-                        .body
-                        .iter()
-                        .filter_map(|stmt| {
-                            convert_statement_for_program(arena, stmt, offset, line_offsets)
-                        })
-                        .collect();
-                    Some(arena.alloc_js_node(JsNode::BlockStatement {
-                        start: start as u32,
-                        end: end as u32,
-                        loc: loc.clone(),
-                        body: arena.alloc_js_children(block_body),
-                    }))
-                }
-                oxc_ast::ast::TSNamespaceDeclarationBody::TSNamespaceDeclaration(_) => None,
-            };
-            Some(JsNode::TSModuleDeclaration {
-                start: start as u32,
-                end: end as u32,
-                loc,
-                body,
-            })
+            Some(convert_ts_module_declaration_as_node(
+                arena,
+                module_decl.span,
+                ts_namespace_block(&module_decl.body),
+                offset,
+                line_offsets,
+            ))
+        }
+        oxc_ast::ast::Statement::TSGlobalDeclaration(module_decl) => {
+            Some(convert_ts_module_declaration_as_node(
+                arena,
+                module_decl.span,
+                Some(&module_decl.body),
+                offset,
+                line_offsets,
+            ))
         }
 
         // Add more statement types as needed
         _ => None,
+    }
+}
+
+/// The `TSModuleBlock` a namespace body carries, or `None` for the dotted form
+/// (`namespace N.M {}`), which nests another declaration instead of a block.
+fn ts_namespace_block<'a>(
+    body: &'a oxc_ast::ast::TSNamespaceDeclarationBody<'a>,
+) -> Option<&'a oxc_ast::ast::TSModuleBlock<'a>> {
+    match body {
+        oxc_ast::ast::TSNamespaceDeclarationBody::TSModuleBlock(block) => Some(block),
+        oxc_ast::ast::TSNamespaceDeclarationBody::TSNamespaceDeclaration(_) => None,
+    }
+}
+
+/// Build the `TSModuleDeclaration` node `remove_typescript_nodes` inspects.
+/// `declare` is deliberately not consulted: upstream's visitor keys only on
+/// whether the module has a body, so `declare module "x" { … }` has to reach it.
+fn convert_ts_module_declaration_as_node(
+    arena: &ParseArena,
+    span: oxc_span::Span,
+    block: Option<&oxc_ast::ast::TSModuleBlock>,
+    offset: usize,
+    line_offsets: &[usize],
+) -> JsNode {
+    let start = offset + span.start as usize;
+    let end = offset + span.end as usize;
+    let loc = create_typed_loc(start, end, line_offsets);
+
+    let body = block.map(|block| {
+        let block_body: Vec<JsNode> = block
+            .body
+            .iter()
+            .filter_map(|stmt| convert_statement_for_program(arena, stmt, offset, line_offsets))
+            .collect();
+        arena.alloc_js_node(JsNode::BlockStatement {
+            start: start as u32,
+            end: end as u32,
+            loc: loc.clone(),
+            body: arena.alloc_js_children(block_body),
+        })
+    });
+
+    JsNode::TSModuleDeclaration {
+        start: start as u32,
+        end: end as u32,
+        loc,
+        body,
     }
 }
 
@@ -8526,6 +8524,32 @@ fn convert_declaration_for_program_as_node(
         {
             convert_class_declaration_as_node(arena, class_decl, offset, line_offsets)
         }
+        // `export namespace N { … }` / `export module M { … }` — upstream walks
+        // through the export into the declaration, so the module node has to
+        // survive the wrapper.
+        Declaration::TSExternalModuleDeclaration(module_decl) => {
+            convert_ts_module_declaration_as_node(
+                arena,
+                module_decl.span,
+                module_decl.body.as_deref(),
+                offset,
+                line_offsets,
+            )
+        }
+        Declaration::TSNamespaceDeclaration(module_decl) => convert_ts_module_declaration_as_node(
+            arena,
+            module_decl.span,
+            ts_namespace_block(&module_decl.body),
+            offset,
+            line_offsets,
+        ),
+        Declaration::TSGlobalDeclaration(module_decl) => convert_ts_module_declaration_as_node(
+            arena,
+            module_decl.span,
+            Some(&module_decl.body),
+            offset,
+            line_offsets,
+        ),
         _ => JsNode::from_value(convert_declaration_for_program(
             arena,
             decl,
@@ -8696,50 +8720,8 @@ fn convert_declaration_for_program(
             push_span_fields(&mut obj, start, end, line_offsets);
             Value::Object(obj)
         }
-        // TypeScript module/namespace declarations
-        oxc_ast::ast::Declaration::TSExternalModuleDeclaration(module_decl) => {
-            // `declare module`, `declare global`, `declare namespace` etc. are
-            // type-only and must be stripped from output. Emit an EmptyStatement
-            // so remove_typescript_nodes can filter it out.
-            if module_decl.declare {
-                let mut empty_obj = Map::new();
-                empty_obj.set_field("type", Value::String("EmptyStatement".to_string()));
-                return Value::Object(empty_obj);
-            }
-            let start = offset + module_decl.span.start as usize;
-            let end = offset + module_decl.span.end as usize;
-            let mut obj = Map::new();
-            obj.set_field("type", Value::String("TSModuleDeclaration".to_string()));
-            push_span_fields(&mut obj, start, end, line_offsets);
-
-            // Include body for non-type node detection
-            if let Some(block) = &module_decl.body {
-                let block_body: Vec<Value> = block
-                    .body
-                    .iter()
-                    .filter_map(|stmt| {
-                        convert_statement_for_program(arena, stmt, offset, line_offsets)
-                    })
-                    .map(|n| n.to_value())
-                    .collect();
-                let mut block_obj = Map::new();
-                block_obj.set_field("body", Value::Array(block_body));
-                obj.set_field("body", Value::Object(block_obj));
-            }
-
-            Value::Object(obj)
-        }
-        oxc_ast::ast::Declaration::TSNamespaceDeclaration(module_decl) => {
-            let mut obj = Map::new();
-            obj.set_field("type", Value::String("EmptyStatement".to_string()));
-            push_span_fields(
-                &mut obj,
-                offset + module_decl.span.start as usize,
-                offset + module_decl.span.end as usize,
-                line_offsets,
-            );
-            Value::Object(obj)
-        }
+        // TypeScript module / namespace declarations are handled by the typed
+        // `convert_ts_module_declaration_as_node` before this function is reached.
         _ => Value::Null,
     }
 }

--- a/crates/rsvelte_core/src/compiler/phases/1_parse/remove_typescript_nodes.rs
+++ b/crates/rsvelte_core/src/compiler/phases/1_parse/remove_typescript_nodes.rs
@@ -263,9 +263,10 @@ pub fn remove_typescript_nodes_typed(
     visit_typed_children(node, arena)
 }
 
-/// Strip a `TSModuleDeclaration` (typed). Mirrors the Value-mutator namespace
-/// logic: error when the body contains non-type nodes, otherwise replace with an
-/// empty statement.
+/// Strip a `TSModuleDeclaration` (typed). Mirrors upstream: visit every body
+/// entry, and error when any of them survived the visit. Upstream compares the
+/// visited entry against the `b.empty` singleton, so an `EmptyStatement` the
+/// source itself wrote is *not* a match — hence the pre-visit node type.
 fn strip_ts_module_declaration_typed(
     node: &mut JsNode,
     arena: &ParseArena,
@@ -282,10 +283,17 @@ fn strip_ts_module_declaration_typed(
             JsNode::BlockStatement { body, .. } => *body,
             _ => IdRange::empty(),
         };
-        let stmts = arena.get_js_children(stmts_range);
-        let has_non_type_nodes = stmts
+        let was_empty_statement: Vec<bool> = arena
+            .get_js_children(stmts_range)
             .iter()
-            .any(|entry| !is_type_only_namespace_member(entry));
+            .map(|entry| entry.node_type() == Some("EmptyStatement"))
+            .collect();
+        recurse_range(stmts_range, arena)?;
+        let has_non_type_nodes = arena
+            .get_js_children(stmts_range)
+            .iter()
+            .zip(&was_empty_statement)
+            .any(|(entry, was_empty)| *was_empty || entry.node_type() != Some("EmptyStatement"));
         if has_non_type_nodes {
             return Err(ParseError::typescript_invalid_feature(
                 "namespaces with non-type nodes",
@@ -299,27 +307,6 @@ fn strip_ts_module_declaration_typed(
 
     *node = typed_empty_statement(node);
     Ok(())
-}
-
-/// Classify a single namespace-body member as "safe to strip" (type-only).
-/// Mirrors the Value mutator's per-entry predicate (lines for `TSModuleDeclaration`).
-fn is_type_only_namespace_member(entry: &JsNode) -> bool {
-    match entry.node_type() {
-        Some("EmptyStatement")
-        | Some("TSInterfaceDeclaration")
-        | Some("TSTypeAliasDeclaration")
-        | Some("TSEnumDeclaration") => true,
-        Some("ExportNamedDeclaration") => {
-            // `export type ...`
-            if let JsNode::ExportNamedDeclaration { export_kind, .. } = entry
-                && export_kind.as_deref() == Some("type")
-            {
-                return true;
-            }
-            false
-        }
-        _ => false,
-    }
 }
 
 /// Strip type-only imports (typed). Whole `import type {...}` → empty; otherwise

--- a/crates/rsvelte_core/tests/ts_namespace_3244.rs
+++ b/crates/rsvelte_core/tests/ts_namespace_3244.rs
@@ -1,0 +1,162 @@
+//! Upstream's `remove_typescript_nodes` visits a `TSModuleDeclaration` whatever
+//! wraps it and whatever modifier it carries: `declare` is never consulted (the
+//! visitor keys only on whether the module has a body) and an `export` is walked
+//! through. rsvelte dropped a `declare`d module to an `EmptyStatement` at
+//! conversion time and turned an exported namespace into one unconditionally, so
+//! three non-erasable shapes compiled.
+//!
+//! Every code, message and span below was read off the official compiler at the
+//! pinned `submodules/svelte` revision, on all three entry points rsvelte has.
+
+use rsvelte_core::{
+    CompileOptions, GenerateMode, ModuleCompileOptions, compile, compile_module, compiler::CssMode,
+};
+
+fn compile_result(src: &str, generate: GenerateMode) -> Result<String, String> {
+    compile(
+        src,
+        CompileOptions {
+            filename: Some("Test.svelte".to_string()),
+            generate,
+            dev: false,
+            css: CssMode::External,
+            ..Default::default()
+        },
+    )
+    .map(|result| result.js.code)
+    .map_err(|e| format!("{e:?}"))
+}
+
+fn compile_module_result(src: &str) -> Result<String, String> {
+    compile_module(
+        src,
+        ModuleCompileOptions {
+            filename: Some("Test.svelte.ts".to_string()),
+            generate: GenerateMode::Client,
+            dev: false,
+            ..Default::default()
+        },
+    )
+    .map(|result| result.js.code)
+    .map_err(|e| format!("{e:?}"))
+}
+
+/// The instance script; the reported node starts `body_offset` bytes into `body`.
+fn instance(body: &str) -> String {
+    format!("<script lang=\"ts\">\n{body}\nconst s = 1;\n</script>\n\n<p>{{s}}</p>\n")
+}
+const INSTANCE_OFFSET: usize = 19;
+
+/// The module script — a second entry point into the same strip.
+fn module_script(body: &str) -> String {
+    format!("<script module lang=\"ts\">\n{body}\nexport const s = 1;\n</script>\n\n<p>{{s}}</p>\n")
+}
+const MODULE_SCRIPT_OFFSET: usize = 26;
+
+/// `(body, offset of the reported node inside `body`)`.
+const REJECTED: &[(&str, usize)] = &[
+    ("namespace N { export const a = 1; }", 0),
+    ("export namespace N { export const a = 1; }", 7),
+    ("declare module \"x\" { export const a: number; }", 0),
+    ("declare global { const g: number }", 0),
+    ("declare namespace N { const a: number }", 0),
+    ("module M { export const a = 1; }", 0),
+    ("export module M { export const a = 1; }", 7),
+];
+
+/// Shapes the official compiler accepts. `export declare namespace` is here
+/// because acorn-typescript gives the export `exportKind: 'type'`, so upstream
+/// returns `b.empty` before the namespace is ever visited — the `declare` is not
+/// what makes it legal, the export kind is. A `declare` module with an empty (or
+/// absent) body is legal for the opposite reason: there is nothing to visit.
+const ACCEPTED: &[&str] = &[
+    "export declare namespace N { const a: number }",
+    "export declare module \"x\" { const a: number }",
+    "namespace N { }",
+    "export namespace N { }",
+    "namespace N { export type T = 1; }",
+    "export namespace N { export type T = 1; }",
+    "namespace N { interface I {} }",
+    "export namespace N { interface I {} }",
+    "declare module \"x\";",
+    "declare module \"x\" { }",
+    "declare global { }",
+    "declare namespace N { }",
+    "declare namespace N { type T = 1 }",
+    "declare const dc: number;",
+    "declare function df(): void;",
+    "declare class DC {}",
+];
+
+#[test]
+fn a_namespace_with_non_type_nodes_is_rejected_through_every_modifier() {
+    for generate in [GenerateMode::Client, GenerateMode::Server] {
+        for (wrap, offset) in [
+            (instance as fn(&str) -> String, INSTANCE_OFFSET),
+            (module_script as fn(&str) -> String, MODULE_SCRIPT_OFFSET),
+        ] {
+            for (body, node_offset) in REJECTED {
+                let src = wrap(body);
+                let err = match compile_result(&src, generate) {
+                    Err(err) => err,
+                    Ok(code) => panic!("{body:?} must not compile; emitted:\n{code}"),
+                };
+                assert!(
+                    err.contains("typescript_invalid_feature"),
+                    "expected typescript_invalid_feature for {body:?}, got: {err}"
+                );
+                assert!(
+                    err.contains("namespaces with non-type nodes"),
+                    "message must be upstream's for {body:?}, got: {err}"
+                );
+                let start = offset + node_offset;
+                let end = offset + body.len();
+                assert!(
+                    err.contains(&format!("span: ({start}, {end})")),
+                    "span must be ({start}, {end}) for {body:?}, got: {err}"
+                );
+            }
+        }
+    }
+}
+
+#[test]
+fn the_erasable_neighbours_still_compile() {
+    for generate in [GenerateMode::Client, GenerateMode::Server] {
+        for wrap in [
+            instance as fn(&str) -> String,
+            module_script as fn(&str) -> String,
+        ] {
+            for body in ACCEPTED {
+                let src = wrap(body);
+                if let Err(err) = compile_result(&src, generate) {
+                    panic!("{body:?} must compile, got: {err}");
+                }
+            }
+        }
+    }
+}
+
+/// The third entry point. `compileModule` parses as JavaScript whatever the
+/// filename says, so upstream answers every one of these with acorn's own
+/// `js_parse_error` rather than `typescript_invalid_feature` — including the
+/// shapes a component script accepts.
+#[test]
+fn compile_module_rejects_every_namespace_shape_as_a_js_parse_error() {
+    for body in REJECTED.iter().map(|(body, _)| *body).chain(
+        ACCEPTED
+            .iter()
+            .copied()
+            .filter(|body| body.starts_with("namespace") || body.starts_with("export namespace")),
+    ) {
+        let src = format!("{body}\nexport const s = 1;\n");
+        let err = match compile_module_result(&src) {
+            Err(err) => err,
+            Ok(code) => panic!("{body:?} must not compile as a module; emitted:\n{code}"),
+        };
+        assert!(
+            err.contains("js_parse_error"),
+            "expected js_parse_error for {body:?}, got: {err}"
+        );
+    }
+}

--- a/crates/rsvelte_core/tests/ts_namespace_3244.rs
+++ b/crates/rsvelte_core/tests/ts_namespace_3244.rs
@@ -86,6 +86,49 @@ const ACCEPTED: &[&str] = &[
     "declare const dc: number;",
     "declare function df(): void;",
     "declare class DC {}",
+    // The body-content axis: upstream's decision is "did visiting this entry
+    // return `b.empty`", so anything the visitor erases keeps the namespace legal.
+    "namespace N { type T = 1; }",
+    "namespace N { export interface I {} }",
+    "namespace N { declare const a: number; }",
+    "namespace N { namespace M { } }",
+];
+
+/// The other half of the same decision: `(body, node start, node end, feature)`,
+/// offsets relative to the script body. A nested namespace and an enum raise from
+/// *inside* the visit, so the node upstream reports is not the outer module — and
+/// for an enum the feature is not even "namespaces". A bare `;` is rejected
+/// because upstream compares each visited entry against the `b.empty` **singleton**,
+/// which an `EmptyStatement` the source wrote is not.
+const REJECTED_BODY_CONTENT: &[(&str, usize, usize, &str)] = &[
+    ("namespace N { ; }", 0, 17, "namespaces with non-type nodes"),
+    (
+        "namespace N { class C {} }",
+        0,
+        26,
+        "namespaces with non-type nodes",
+    ),
+    (
+        "namespace N { function f() {} }",
+        0,
+        31,
+        "namespaces with non-type nodes",
+    ),
+    (
+        "namespace N { const a = 1; }",
+        0,
+        28,
+        "namespaces with non-type nodes",
+    ),
+    (
+        "namespace N { namespace M { const a = 1; } }",
+        14,
+        42,
+        "namespaces with non-type nodes",
+    ),
+    ("namespace N { enum E { A } }", 14, 26, "enums"),
+    ("namespace N { const enum E { A } }", 14, 32, "enums"),
+    ("export namespace N { enum E { A } }", 21, 33, "enums"),
 ];
 
 #[test]
@@ -111,6 +154,38 @@ fn a_namespace_with_non_type_nodes_is_rejected_through_every_modifier() {
                 );
                 let start = offset + node_offset;
                 let end = offset + body.len();
+                assert!(
+                    err.contains(&format!("span: ({start}, {end})")),
+                    "span must be ({start}, {end}) for {body:?}, got: {err}"
+                );
+            }
+        }
+    }
+}
+
+#[test]
+fn the_node_and_the_feature_come_from_the_visit_not_from_the_outer_module() {
+    for generate in [GenerateMode::Client, GenerateMode::Server] {
+        for (wrap, offset) in [
+            (instance as fn(&str) -> String, INSTANCE_OFFSET),
+            (module_script as fn(&str) -> String, MODULE_SCRIPT_OFFSET),
+        ] {
+            for (body, node_start, node_end, feature) in REJECTED_BODY_CONTENT {
+                let src = wrap(body);
+                let err = match compile_result(&src, generate) {
+                    Err(err) => err,
+                    Ok(code) => panic!("{body:?} must not compile; emitted:\n{code}"),
+                };
+                assert!(
+                    err.contains("typescript_invalid_feature"),
+                    "expected typescript_invalid_feature for {body:?}, got: {err}"
+                );
+                assert!(
+                    err.contains(feature),
+                    "feature must be {feature:?} for {body:?}, got: {err}"
+                );
+                let start = offset + node_start;
+                let end = offset + node_end;
                 assert!(
                     err.contains(&format!("span: ({start}, {end})")),
                     "span must be ({start}, {end}) for {body:?}, got: {err}"


### PR DESCRIPTION
A TypeScript namespace carrying non-type nodes is rejected through every
modifier, and the decision about its body is now upstream's rather than a
hand-written predicate.

Closes #3244.

## What was wrong

Two independent causes, both measured against `submodules/svelte` on the same
input.

**1. The module node never reached the stripper.** Upstream's
`TSModuleDeclaration` visitor keys on one thing — `if (!node.body) return
b.empty` — and never looks at `declare`; `ExportNamedDeclaration` walks
`context.next()` into its declaration. rsvelte's converter answered both
differently:

| shape | rsvelte before |
|---|---|
| `declare module "x" { … }` / `declare namespace N { … }` | an early `if (module_decl.declare)` returned an `EmptyStatement` |
| `declare global { … }` | oxc models it as a third variant (`TSGlobalDeclaration`); there was no arm at all, so `filter_map` dropped it |
| `export namespace N { … }` | the `Declaration` (export) path returned an `EmptyStatement` unconditionally |

`export declare namespace N { … }` stays legal, and the reason is not the
`declare`: acorn-typescript gives that export `exportKind: 'type'`, so upstream
returns `b.empty` before the namespace is ever visited. oxc's
`ExportDeclaration::export_kind()` already derives the same thing from
`declaration.declare()`, so that row needed no code.

**2. The body test was a predicate, not a visit.** Upstream maps its *whole*
visitor over `node.body.body` and errors when any result is not the `b.empty`
singleton. rsvelte had a hand-written `is_type_only_namespace_member`, and it
diverges on every shape its author did not enumerate — in both directions:

| body | upstream | predicate |
|---|---|---|
| `enum E { A }`, `const enum E { A }` | `typescript_invalid_feature` **'enums'**, reported on the *enum* | accepted |
| `namespace M { const a = 1 }` | rejected, reported on the *inner* namespace | accepted |
| `class C {}`, `function f() {}`, `const a = 1` | rejected | accepted |
| `;` | rejected — a source `EmptyStatement` is not the `b.empty` singleton | accepted |
| `declare const a: number` | accepted (`VariableDeclaration` → `b.empty`) | **rejected** |
| `namespace M { }` | accepted | **rejected** |

Recursing with `recurse_range` reproduces the decision exactly, including which
node and which *feature* a nested raise reports.

## Measurement

A 37-construct × 4-modifier grid (`''` / `export ` / `declare ` /
`export declare `) × 2 entry points = 296 cells, verdicts read off the official
compiler and diffed against rsvelte before and after:

```
unchanged 244, fixed 38, regressed 0
```

The regression column is the point of the exercise: the first version of this
fix — modifiers only, predicate untouched — scored **fixed 18, regressed 8**,
and every one of the 8 was the predicate meeting a body shape it did not
enumerate. The number came from the grid, not from review.

## What still diverges, and why it is not this PR

80 of the 290 comparable cells still differ, all pre-existing and all one cause:
**oxc enforces TypeScript's ambient-context rules and acorn-typescript does
not.** `declare class D { constructor(private x: number) {} }` and
`declare function f() {}` are `js_parse_error` here and legal upstream;
`declare namespace N { const a = 1 }` is `js_parse_error` upstream (an
initializer in an ambient context) and reaches `typescript_invalid_feature`
here. Every one of these was already divergent on `main` — the delta above
moved none of them — and closing them means reconciling two JS parsers, not
this visitor. `namespace N { export default 1; }` (4 cells) is the one residue
with a different cause: the statement never reaches the module body.

## Tests

`crates/rsvelte_core/tests/ts_namespace_3244.rs`, four cases over both
`GenerateMode`s and all three entry points rsvelte has:

- the seven modifier shapes, each asserted on code, message **and** span;
- the body-content axis asserted on the node *and* the feature, so
  `namespace N { enum E { A } }` pins `'enums'` at the enum's own span rather
  than `'namespaces…'` at the module's;
- 20 legal neighbours as the over-rejection control;
- `compileModule`, which parses as JavaScript whatever the filename says and so
  answers every one of these with acorn's `js_parse_error` — including the
  shapes a component script accepts.

Every code, message and span in the file was read off the official compiler at
the pinned revision.

`ts_namespace_3244`, `ts_decorators_2597`, `compiler_errors` (145),
`parser_fixtures`, `compiler_fixtures`, `validator` (333) and `ssr` (99) pass.
