### PR TITLE
fix(client): carry the each block's scope while building its body

### DIFF
--- a/.changeset/soft-pugs-repeat.md
+++ b/.changeset/soft-pugs-repeat.md
@@ -1,0 +1,5 @@
+---
+'@rsvelte/compiler': patch
+---
+
+Carry the `{#each}` block's own scope while building its body and `{:else}` fallback on the client, so an item name that shadows an instance binding resolves to the item. Previously the outer binding answered `is_defined`, which dropped the `?? ''` guard from a concatenated interpolation and constant-folded a fallback read.

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/each_block.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/each_block.rs
@@ -434,7 +434,23 @@ pub fn each_block(node: &EachBlock, context: &mut ComponentContext) {
     // forces level 1.
     let prev_nesting = context.state.template_nesting_level;
     context.state.template_nesting_level += 1;
+    // Carry the each block's own Phase-2 scope while building the body, the way
+    // the snippet and declaring-element visitors do. `get_binding` consults
+    // `state.scope` first, so without this an item name that shadows an
+    // instance binding resolves to the OUTER one and `scope.evaluate`-style
+    // checks (`is_defined`, which decides the `?? ''` guard) answer for it.
+    let saved_scope = context.state.scope;
+    if let Some(each_scope) = context
+        .state
+        .scope_root
+        .template_scope_map
+        .get(&node.start)
+        .and_then(|idx| context.state.scope_root.all_scopes.get(*idx))
+    {
+        context.state.scope = each_scope;
+    }
     let body_block = visit_fragment(&node.body, context);
+    context.state.scope = saved_scope;
     context.state.template_nesting_level = prev_nesting;
     context.state.in_control_flow_block = prev_in_control_flow;
 
@@ -554,7 +570,20 @@ pub fn each_block(node: &EachBlock, context: &mut ComponentContext) {
         // `{:else}` fallback must stay local, not hoist to the component root.
         let prev_nesting = context.state.template_nesting_level;
         context.state.template_nesting_level += 1;
+        // Upstream visits the fallback with the each block's scope too, so an
+        // item name still shadows a same-named instance binding here.
+        let saved_scope = context.state.scope;
+        if let Some(each_scope) = context
+            .state
+            .scope_root
+            .template_scope_map
+            .get(&node.start)
+            .and_then(|idx| context.state.scope_root.all_scopes.get(*idx))
+        {
+            context.state.scope = each_scope;
+        }
         let fallback_block = visit_fragment(fallback, context);
+        context.state.scope = saved_scope;
         context.state.template_nesting_level = prev_nesting;
         let fallback_fn = b::arrow_block(vec![b::id_pattern("$$anchor")], fallback_block.body);
         each_args.push(fallback_fn);

--- a/crates/rsvelte_core/tests/client_each_scope_shadow_3215.rs
+++ b/crates/rsvelte_core/tests/client_each_scope_shadow_3215.rs
@@ -1,0 +1,69 @@
+//! The client each-block visitor never carried the each block's own Phase-2
+//! scope while building the body, so `get_binding` resolved an item name that
+//! shadows an instance binding to the OUTER one (#3215). That decides
+//! `is_defined`, which decides the `?? ''` guard on a concatenated
+//! interpolation, and the constant fold in the `{:else}` fallback.
+//!
+//! Every expectation here is the official compiler's output for the same source.
+
+use rsvelte_core::{CompileOptions, GenerateMode, compile};
+
+const PRELUDE: &str = "<script>\n\tlet n = 7;\n\tlet items = [1, 2];\n</script>\n";
+
+fn client(body: &str) -> String {
+    compile(
+        &format!("{PRELUDE}{body}"),
+        CompileOptions {
+            filename: Some("T.svelte".into()),
+            generate: GenerateMode::Client,
+            dev: false,
+            ..Default::default()
+        },
+    )
+    .map(|r| r.js.code)
+    .unwrap_or_else(|e| format!("COMPILE_ERROR: {e:?}"))
+}
+
+#[test]
+fn a_shadowing_each_item_keeps_the_nullish_guard() {
+    // The outer `let n = 7` is a non-updated literal, so it evaluates as
+    // defined and needs no guard; the item does not.
+    let out = client("{#each items as n}<b title=\"v{n}\">x</b>{/each}");
+    assert!(
+        out.contains("$.set_attribute(b, 'title', `v${$.get(n) ?? ''}`)"),
+        "{out}"
+    );
+
+    let out = client("{#each items as n}<b>v{n}</b>{/each}");
+    assert!(
+        out.contains("$.set_text(text, `v${$.get(n) ?? ''}`)"),
+        "{out}"
+    );
+}
+
+#[test]
+fn the_else_fallback_resolves_to_the_each_binding() {
+    // Upstream visits the fallback with the each scope, so the read is the
+    // (unbound) item rather than the instance literal.
+    let out = client("{#each items as n}<b>{n}</b>{:else}<i>{n}</i>{/each}");
+    assert!(
+        out.contains("$.template_effect(() => $.set_text(text_1, n))"),
+        "{out}"
+    );
+    assert!(!out.contains("nodeValue = '7'"), "{out}");
+}
+
+#[test]
+fn a_non_shadowing_read_still_folds() {
+    // The negative control: an instance read from inside an each body must
+    // still constant-fold, and an each INDEX is always a number, so it keeps
+    // reading bare with no guard.
+    let out = client("{#each items as q}<b title=\"v{n}\">x</b>{/each}");
+    assert!(out.contains("$.set_attribute(b, 'title', 'v7')"), "{out}");
+
+    let out = client("{#each items as _, n}<b title=\"v{n}\">x</b>{/each}");
+    assert!(
+        out.contains("$.set_attribute(b, 'title', `v${n}`)"),
+        "{out}"
+    );
+}


### PR DESCRIPTION
Part 2 of #3215 — the **client** half. Part 1 (#3414) is the server constant
fold; the two symptoms have different causes in different files, so they ship
separately.

Closes #3215

## Cause

`ComponentContext::get_binding` consults `state.scope` first and then walks the
parent chain, so it is scope-aware — but the client `{#each}` visitor never
swapped `state.scope` to the block's own Phase-2 scope while building the body.
The snippet visitor does (`snippet_block.rs`), and so does a declaring element
(`regular_element.rs`); the each visitor was the one that did not. So an item
name that shadows an instance binding resolved to the **outer** binding.

What that decides is `identifier_is_defined` → `is_js_expr_defined` → upstream's
`scope.evaluate(value).is_defined`, which is what omits the `?? ''` guard on a
concatenated interpolation. With `let n = 7` in the instance script, the outer
binding is a non-updated literal and therefore *defined*, so the guard was
dropped for the each item:

```js
// official
$.template_effect(() => $.set_attribute(b, 'title', `v${$.get(n) ?? ''}`));
// rsvelte
$.template_effect(() => $.set_attribute(b, 'title', `v${$.get(n)}`));
```

A nullish item then renders `vnull` instead of `v`.

## The `{:else}` fallback is the same bug one step further out

Not in the issue, and found by the regression grid rather than by the report.
Upstream visits the fallback with the each block's scope as well:

```js
for (const child of node.body.nodes) visit(child, { scope });
if (node.fallback) visit(node.fallback, { scope });   // scope.js
```

so `{#each items as n}<b>{n}</b>{:else}<i>{n}</i>{/each}` reads the (unbound)
item in the `{:else}`, not the instance literal. rsvelte constant-folded it to
`text_1.nodeValue = '7'`. rsvelte's own phase 2 already analyses the fallback
inside the each scope, so this was two ports of one rule disagreeing — the same
shape as the server half.

## Not the same defect as #3323

#3323 is a `SequenceExpression` missing its `?? ''` in a concatenation: the
guard is decided per expression **kind**, and that one kind is mishandled
regardless of scope. This PR does not touch `is_js_expr_defined` or any kind
dispatch — only which binding an `Identifier` resolves to — and it is in a
different file (`client/visitors/each_block.rs` vs
`client/visitors/shared/utils.rs`). #3323's own repro (`{(n, s)}` next to
`{q}`) still diverges after this change, so the two do not overlap.

## Measurement

Two generated grids, official vs rsvelte:

| grid (client cells) | `main` | after |
|---|---|---|
| 9 shadowing constructs × 8 reference bodies (72 cells) | 2 diverging | **0** |
| 4 script shapes (legacy `let`, `$state`, `$derived`, `const` literal) × 20 block shapes (80 cells) | 3 diverging | **0** |

Built with only this patch, the **server** halves of the same two grids still
report 12/72 and 16/80 — unchanged from `main` — which is the control that the
split between this PR and #3414 is real rather than assumed.

The second grid's other rows are the controls that must not move: nested
`{#each}`, a keyed `{#each … (n)}`, `{@const}` inside an each, a `{#snippet}`
inside an each, an `{#await}` inside an each, and a plain non-block read.

## Negative control

`a_non_shadowing_read_still_folds` is the direction a blanket "never fold inside
an each" would break. Both must keep their `main` behaviour, and both do:

| source | expected |
|---|---|
| `{#each items as q}<b title="v{n}">x</b>{/each}` | `$.set_attribute(b, 'title', 'v7')` — the instance read still folds |
| `{#each items as _, n}<b title="v{n}">x</b>{/each}` | `` `v${n}` `` — an each **index** is always a number, so no guard |

## Tests

`crates/rsvelte_core/tests/client_each_scope_shadow_3215.rs` (3 tests, every
expectation taken from the official compiler's output for the same source).
Suites run green: `compiler_fixtures`, `validator`, `print`, `sourcemaps`.
