### PR TITLE
docs(upstream): two TypeScript class members that survive type stripping

### DIFF
--- a/upstream_issues/3421-svelte-class-method-overload-signature-emits-unparseable-output.md
+++ b/upstream_issues/3421-svelte-class-method-overload-signature-emits-unparseable-output.md
@@ -1,0 +1,86 @@
+# A TypeScript class method overload signature is emitted as a bodiless method, so the output does not parse
+
+A method overload signature inside a class survives type stripping and is printed with no body,
+which is not a legal class member. `compile()` returns successfully and the JavaScript it hands
+back is rejected by every parser.
+
+```svelte
+<script lang="ts">
+	class K {
+		m(a: number): number;
+		m(a: any) { return a; }
+	}
+	const v = new K().m(1);
+</script>
+<b>{v}</b>
+```
+
+```js
+/* generate: 'client' */
+class K {
+	m(a) 
+
+	m(a) {
+		return a;
+	}
+}
+```
+
+`acorn` rejects that at the second `m`. `generate: 'server'` and `dev: true` produce the same
+shape. Measured on svelte `5.56.9` (submodule `20b341f1`).
+
+Six member forms reproduce it — an instance method, two stacked signatures, `static`, a
+`constructor` overload, a `#private` method, and a class *expression* — from both the instance
+script and `<script module>`.
+
+## The function form is already handled, which is what makes this look like an oversight
+
+```ts
+function f(a: number): number;
+function f(a: any) { return a; }
+```
+
+compiles correctly. `acorn-typescript` models a bodiless *function* overload as a
+`TSDeclareFunction`, and `phases/1-parse/remove_typescript_nodes.js` drops it:
+
+```js
+TSDeclareFunction() {
+    return b.empty;
+},
+```
+
+A bodiless *method* is not a distinct node type — it is an ordinary `MethodDefinition` whose
+`value.body` is absent — and the visitor for that node only removes the abstract case:
+
+```js
+MethodDefinition(node, context) {
+    if (node.abstract) {
+        return b.empty;
+    }
+    return context.next();
+},
+```
+
+so the overload signature is kept and printed. `abstract m(a: number): number;` inside an
+`abstract class` is correct today, via that same `node.abstract` branch, which isolates the axis
+to a missing `value.body`.
+
+## Suggested fix
+
+Extend the `MethodDefinition` branch to drop a signature with no body:
+
+```js
+MethodDefinition(node, context) {
+    if (node.abstract || !node.value.body) {
+        return b.empty;
+    }
+    return context.next();
+},
+```
+
+## Related
+
+The same sweep found a class index signature reaching the printer with a required field deleted,
+crashing with a bare `TypeError` — see
+[`3422-svelte-class-index-signature-crashes-the-compiler.md`](./3422-svelte-class-index-signature-crashes-the-compiler.md).
+Both are `ClassBody` keeping a member that has no JavaScript form.

--- a/upstream_issues/3422-svelte-class-index-signature-crashes-the-compiler.md
+++ b/upstream_issues/3422-svelte-class-index-signature-crashes-the-compiler.md
@@ -1,0 +1,92 @@
+# A TypeScript class index signature crashes `compile()` with a bare `TypeError`
+
+A class index signature is valid TypeScript and `parse()` accepts it, but `compile()` throws a
+plain `TypeError` — no `code`, no position, no frame. A consumer catching `CompileError` gets an
+unhandled exception instead of a diagnostic.
+
+```svelte
+<script lang="ts">
+	class K { [k: string]: unknown }
+	void K;
+</script>
+<b>x</b>
+```
+
+```
+TypeError: Cannot read properties of undefined (reading 'type')
+    at Context.visit (esrap/src/context.js:90:39)
+    at TSIndexSignature (esrap/src/languages/ts/index.js:2004:12)
+```
+
+Measured on svelte `5.56.9` (submodule `20b341f1`) with esrap `2.2.12`, on `generate: 'client'`,
+`generate: 'server'` and `dev: true` alike. `parse(source, { modern: true })` succeeds and yields
+a `TSIndexSignature` whose `typeAnnotation` is a `TSTypeAnnotation`, so the node is well-formed
+coming out of the parser.
+
+Five variants reproduce it: `[k: string]: unknown`, `[k: number]: string`,
+`readonly [k: string]: unknown`, `static [k: string]: unknown`, and one inside a class
+*expression*. An **interface** index signature is fine, because `TSInterfaceDeclaration` is
+removed wholesale.
+
+## Cause
+
+Two things have to be true at once, and they are.
+
+`phases/1-parse/remove_typescript_nodes.js`'s catch-all visitor strips annotation fields from
+every node it walks:
+
+```js
+_(node, context) {
+    const n = context.next() ?? node;
+    // TODO there may come a time when we decide to preserve type annotations.
+    // until that day comes, we just delete them so they don't confuse esrap
+    delete n.typeAnnotation;
+    …
+}
+```
+
+For a `TSIndexSignature`, `typeAnnotation` is not decoration — it is the required value type. And
+the node itself is not removed: `ClassBody` in the same file filters only one member kind,
+
+```js
+ClassBody(node, context) {
+    const body = [];
+    for (const _child of node.body) {
+        const child = context.visit(_child);
+        if (child.type !== 'PropertyDefinition' || !child.declare) {
+            body.push(child);
+        }
+    }
+    …
+}
+```
+
+so the signature reaches the printer with its required child deleted. esrap then dereferences it
+without a guard — note that the line immediately above it already uses optional chaining on the
+same field:
+
+```js
+TSIndexSignature(node, context) {
+    context.write('[');
+    sequence(context, node.parameters, node.typeAnnotation?.loc?.start ?? null, false);
+    context.write(']');
+    context.visit(node.typeAnnotation);   // <- undefined by the time we get here
+},
+```
+
+## Suggested fix
+
+A class index signature has no runtime meaning, so `ClassBody` should drop it the way
+`TSInterfaceDeclaration` and `TSTypeAliasDeclaration` are dropped — filtering `TSIndexSignature`
+alongside the `declare` `PropertyDefinition` case is enough to make the crash unreachable.
+
+Guarding esrap's `context.visit(node.typeAnnotation)` is worth doing independently: an index
+signature with no value type is not printable, and the current failure mode is a `TypeError` from
+inside the printer rather than anything a caller can act on.
+
+## Related
+
+The same sweep found a second class-member shape that survives `remove_typescript_nodes` and
+should not — see
+[`3421-svelte-class-method-overload-signature-emits-unparseable-output.md`](./3421-svelte-class-method-overload-signature-emits-unparseable-output.md).
+Both are `ClassBody` keeping a member that has no JavaScript form.


### PR DESCRIPTION
Two TypeScript class members reach the printer with no JavaScript form, found while sweeping the
instance-script acceptance surface. Documentation only — no compiler change.

- **`3422`** — a class index signature crashes `compile()` with a bare `TypeError` (no `code`, no
  position). `remove_typescript_nodes`'s catch-all deletes `TSIndexSignature.typeAnnotation` —
  which is the node's required value type, not decoration — while `ClassBody` filters only a
  `declare` `PropertyDefinition`, so the signature reaches esrap's unguarded
  `context.visit(node.typeAnnotation)`.
- **`3421`** — a class method overload signature is printed as a bodiless member, so the output
  does not parse. The function form is already dropped as a `TSDeclareFunction`; a bodiless
  *method* is an ordinary `MethodDefinition`, and that visitor removes only `node.abstract`.

Both were measured on the pinned submodule (svelte `5.56.9`, `20b341f1`) with esrap `2.2.12`, on
all three targets. The rsvelte-side halves are tracked separately in #3421 and #3422 — the server
target already strips index signatures correctly, and the overload shape drops the whole instance
script there.

Refs #3421
Refs #3422
