### PR TITLE
fix(parse): raise the JS early errors that need the surrounding context

### DIFF
--- a/.changeset/js-early-errors-needing-context.md
+++ b/.changeset/js-early-errors-needing-context.md
@@ -1,0 +1,5 @@
+---
+'@rsvelte/compiler': patch
+---
+
+Reject the JavaScript early errors that need the surrounding class, function or label context to decide — a duplicate constructor, `super` outside a method, `super()` outside a derived constructor, an unsyntactic `break` / `continue`, a duplicate label, an undeclared or duplicated private name, `delete` on a private field, a nested `import` / `export`, and a `'use strict'` directive in a function with a non-simple parameter list — which OXC leaves to a semantic pass this pipeline never runs, so each was copied into output no JS parser accepts

--- a/crates/rsvelte_core/src/compiler/phases/1_parse/read/early_errors.rs
+++ b/crates/rsvelte_core/src/compiler/phases/1_parse/read/early_errors.rs
@@ -1,0 +1,516 @@
+//! JavaScript early errors acorn raises and OXC does not.
+//!
+//! Every one of these is syntactically shaped but illegal, and none is decidable
+//! from the token stream alone: each needs the class, function or label context
+//! the construct sits in. OXC leaves them to `SemanticBuilder`, which this
+//! pipeline never runs, so without this pass they are copied into the output and
+//! produce text no JS engine accepts.
+//!
+//! acorn is single-pass and non-recovering, so it throws on the first violation
+//! it reaches and never sees any that follow — the caller takes the earliest by
+//! position.
+
+use oxc_ast::ast::{
+    AccessorProperty, ArrowFunctionExpression, BindingPattern, CallExpression, Class, ClassElement,
+    Expression, FormalParameters, Function, MethodDefinition, MethodDefinitionKind, ObjectProperty,
+    Program, PropertyDefinition, PropertyKey, PropertyKind, Statement, StaticBlock, Super,
+    TSModuleBlock,
+};
+use oxc_ast_visit::{Visit, walk};
+use oxc_span::GetSpan;
+use rustc_hash::{FxHashMap, FxHashSet};
+
+/// The earliest early error in `program`, as `(offset, message)`.
+pub fn find_violation(program: &Program<'_>, source: &str) -> Option<(u32, String)> {
+    // Every check below needs one of these spellings in the source. `class`
+    // covers the private-name and constructor families, `:` the labels.
+    if !(source.contains("super")
+        || source.contains("break")
+        || source.contains("continue")
+        || source.contains("import")
+        || source.contains("export")
+        || source.contains("class")
+        || source.contains('#')
+        || source.contains(':')
+        || source.contains("use strict"))
+    {
+        return None;
+    }
+    let mut scan = Scan::default();
+    scan.visit_program(program);
+    scan.hits.into_iter().min_by_key(|(at, _)| *at)
+}
+
+/// What a label can be a destination for. acorn's `loopLabel` / `switchLabel`
+/// carry no name; a labelled statement carries a name and takes its kind from
+/// the statement it ultimately labels.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum LabelKind {
+    Loop,
+    Switch,
+}
+
+struct Label {
+    name: Option<String>,
+    kind: Option<LabelKind>,
+}
+
+impl Label {
+    fn loop_label() -> Self {
+        Label {
+            name: None,
+            kind: Some(LabelKind::Loop),
+        }
+    }
+
+    fn switch_label() -> Self {
+        Label {
+            name: None,
+            kind: Some(LabelKind::Switch),
+        }
+    }
+}
+
+/// One class body's private names: what it declares, and every `#name` read
+/// inside it that has not been resolved yet.
+#[derive(Default)]
+struct PrivateFrame {
+    declared: FxHashSet<String>,
+    used: Vec<(String, u32)>,
+}
+
+#[derive(Default)]
+struct Scan {
+    hits: Vec<(u32, String)>,
+    /// Set for the direct children of `Program` only, and consumed by the first
+    /// `visit_statement` that follows — acorn's `topLevel` argument.
+    top_level: bool,
+    /// acorn-typescript parses a namespace body with its own statement rules,
+    /// and upstream rejects the whole construct as `typescript_invalid_feature`
+    /// before any of this can apply.
+    in_ts_module: bool,
+    super_allowed: bool,
+    direct_super_allowed: bool,
+    /// Handed to the next `Function` visited, which is how a method's body gets
+    /// `super` while a plain function nested in the same place does not.
+    pending_super: bool,
+    pending_direct_super: bool,
+    /// Whether the class currently being walked has an `extends` clause.
+    class_has_super: Vec<bool>,
+    labels: Vec<Label>,
+    private_stack: Vec<PrivateFrame>,
+}
+
+impl Scan {
+    fn hit(&mut self, at: u32, message: impl Into<String>) {
+        self.hits.push((at, message.into()));
+    }
+
+    /// acorn's `parseBreakContinueStatement`: a destination is any label whose
+    /// name matches (or any label at all, when the statement carries no name)
+    /// and whose kind admits the keyword.
+    fn check_break_continue(&mut self, at: u32, label: Option<&str>, is_break: bool) {
+        let reachable = self.labels.iter().any(|entry| {
+            if label.is_some() && entry.name.as_deref() != label {
+                return false;
+            }
+            if entry.kind.is_some() && (is_break || entry.kind == Some(LabelKind::Loop)) {
+                return true;
+            }
+            label.is_some() && is_break
+        });
+        if !reachable {
+            let keyword = if is_break { "break" } else { "continue" };
+            self.hit(at, format!("Unsyntactic {keyword}"));
+        }
+    }
+
+    /// A `#name` read. With no enclosing class acorn raises immediately;
+    /// otherwise the read is recorded and resolved when the class body closes.
+    fn use_private_name(&mut self, name: &str, at: u32, in_expression: bool) {
+        if let Some(frame) = self.private_stack.last_mut() {
+            frame.used.push((name.to_string(), at));
+        } else if in_expression {
+            // `#a in o` outside a class never reaches `parsePrivateIdent`.
+            self.hit(at, "Unexpected token");
+        } else {
+            self.hit(at, undeclared_private_message(name));
+        }
+    }
+
+    /// acorn's `parseClassBody`: at most one constructor, and each private name
+    /// declared once — with a getter/setter pair of the same staticness the one
+    /// legal repetition.
+    fn check_class_members(&mut self, class: &Class<'_>) -> FxHashSet<String> {
+        let mut declared = FxHashSet::default();
+        let mut slots: FxHashMap<String, PrivateSlot> = FxHashMap::default();
+        let mut had_constructor = false;
+
+        for element in &class.body.body {
+            let (key, slot, is_overload) = match element {
+                ClassElement::MethodDefinition(method) => {
+                    if method.kind == MethodDefinitionKind::Constructor {
+                        // A TypeScript overload signature carries no body and
+                        // is not the class's constructor.
+                        if method.value.body.is_some() {
+                            if had_constructor {
+                                self.hit(
+                                    method.span.start,
+                                    "Duplicate constructor in the same class",
+                                );
+                            }
+                            had_constructor = true;
+                        }
+                        continue;
+                    }
+                    (
+                        &method.key,
+                        method_slot(method),
+                        method.value.body.is_none(),
+                    )
+                }
+                ClassElement::PropertyDefinition(property) => {
+                    (&property.key, PrivateSlot::Plain, false)
+                }
+                ClassElement::AccessorProperty(accessor) => {
+                    (&accessor.key, PrivateSlot::Plain, false)
+                }
+                _ => continue,
+            };
+
+            let PropertyKey::PrivateIdentifier(id) = key else {
+                continue;
+            };
+            let name = id.name.as_str();
+            declared.insert(name.to_string());
+            // A TypeScript overload signature names the member without defining
+            // it, so it neither claims the slot nor collides with the body.
+            if !is_overload && is_private_name_conflicted(&mut slots, name, slot) {
+                self.hit(
+                    id.span.start,
+                    format!("Identifier '#{name}' has already been declared"),
+                );
+            }
+        }
+        declared
+    }
+}
+
+/// acorn's `privateNameMap` values: an accessor records which half it is so the
+/// matching half may follow it, and anything else occupies the name outright.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum PrivateSlot {
+    Plain,
+    Get { r#static: bool },
+    Set { r#static: bool },
+}
+
+fn method_slot(method: &MethodDefinition<'_>) -> PrivateSlot {
+    match method.kind {
+        MethodDefinitionKind::Get => PrivateSlot::Get {
+            r#static: method.r#static,
+        },
+        MethodDefinitionKind::Set => PrivateSlot::Set {
+            r#static: method.r#static,
+        },
+        _ => PrivateSlot::Plain,
+    }
+}
+
+fn is_private_name_conflicted(
+    slots: &mut FxHashMap<String, PrivateSlot>,
+    name: &str,
+    next: PrivateSlot,
+) -> bool {
+    let Some(&current) = slots.get(name) else {
+        slots.insert(name.to_string(), next);
+        return false;
+    };
+    let complementary = matches!(
+        (current, next),
+        (PrivateSlot::Get { r#static: a }, PrivateSlot::Set { r#static: b })
+            | (PrivateSlot::Set { r#static: a }, PrivateSlot::Get { r#static: b })
+            if a == b
+    );
+    if complementary {
+        slots.insert(name.to_string(), PrivateSlot::Plain);
+        return false;
+    }
+    true
+}
+
+const USE_STRICT_MESSAGE: &str =
+    "Illegal 'use strict' directive in function with non-simple parameter list";
+
+/// acorn's `isSimpleParamList`: every parameter is a bare identifier. A default,
+/// a rest element and a destructuring pattern each make the list non-simple.
+fn is_simple_parameter_list(params: &FormalParameters<'_>) -> bool {
+    params.rest.is_none()
+        && params.items.iter().all(|param| {
+            param.initializer.is_none()
+                && matches!(param.pattern, BindingPattern::BindingIdentifier(_))
+        })
+}
+
+fn undeclared_private_message(name: &str) -> String {
+    format!("Private field '#{name}' must be declared in an enclosing class")
+}
+
+/// The kind a labelled statement takes, following a chain of labels down to the
+/// statement they all label.
+fn label_kind(body: &Statement<'_>) -> Option<LabelKind> {
+    match body {
+        Statement::ForStatement(_)
+        | Statement::ForInStatement(_)
+        | Statement::ForOfStatement(_)
+        | Statement::WhileStatement(_)
+        | Statement::DoWhileStatement(_) => Some(LabelKind::Loop),
+        Statement::SwitchStatement(_) => Some(LabelKind::Switch),
+        Statement::LabeledStatement(inner) => label_kind(&inner.body),
+        _ => None,
+    }
+}
+
+impl<'a> Visit<'a> for Scan {
+    fn visit_program(&mut self, program: &Program<'a>) {
+        for stmt in &program.body {
+            self.top_level = true;
+            self.visit_statement(stmt);
+        }
+        self.top_level = false;
+    }
+
+    fn visit_statement(&mut self, stmt: &Statement<'a>) {
+        let top_level = std::mem::take(&mut self.top_level);
+        if !top_level && !self.in_ts_module && stmt.is_module_declaration() {
+            self.hit(
+                stmt.span().start,
+                "'import' and 'export' may only appear at the top level",
+            );
+        }
+        walk::walk_statement(self, stmt);
+    }
+
+    fn visit_ts_module_block(&mut self, block: &TSModuleBlock<'a>) {
+        let outer = std::mem::replace(&mut self.in_ts_module, true);
+        walk::walk_ts_module_block(self, block);
+        self.in_ts_module = outer;
+    }
+
+    fn visit_super(&mut self, node: &Super) {
+        if !self.super_allowed {
+            self.hit(node.span.start, "'super' keyword outside a method");
+        }
+    }
+
+    fn visit_call_expression(&mut self, call: &CallExpression<'a>) {
+        // acorn raises "outside a method" first and never reaches this check,
+        // so gate on the same condition rather than on position order.
+        if self.super_allowed
+            && !self.direct_super_allowed
+            && matches!(call.callee, Expression::Super(_))
+        {
+            self.hit(
+                call.callee.span().start,
+                "super() call outside constructor of a subclass",
+            );
+        }
+        walk::walk_call_expression(self, call);
+    }
+
+    fn visit_unary_expression(&mut self, expr: &oxc_ast::ast::UnaryExpression<'a>) {
+        if expr.operator == oxc_syntax::operator::UnaryOperator::Delete {
+            let mut target = &expr.argument;
+            while let Expression::ParenthesizedExpression(inner) = target {
+                target = &inner.expression;
+            }
+            if matches!(target, Expression::PrivateFieldExpression(_)) {
+                self.hit(expr.span.start, "Private fields can not be deleted");
+            }
+        }
+        walk::walk_unary_expression(self, expr);
+    }
+
+    fn visit_function(&mut self, func: &Function<'a>, flags: oxc_semantic::ScopeFlags) {
+        if func.has_use_strict_directive() && !is_simple_parameter_list(&func.params) {
+            self.hit(func.span.start, USE_STRICT_MESSAGE);
+        }
+        let super_allowed = std::mem::take(&mut self.pending_super);
+        let direct_super_allowed = std::mem::take(&mut self.pending_direct_super);
+        let outer_super = std::mem::replace(&mut self.super_allowed, super_allowed);
+        let outer_direct = std::mem::replace(&mut self.direct_super_allowed, direct_super_allowed);
+        let outer_labels = std::mem::take(&mut self.labels);
+        walk::walk_function(self, func, flags);
+        self.super_allowed = outer_super;
+        self.direct_super_allowed = outer_direct;
+        self.labels = outer_labels;
+    }
+
+    fn visit_arrow_function_expression(&mut self, func: &ArrowFunctionExpression<'a>) {
+        // A concise body has no directive prologue to carry `'use strict'`.
+        if func.has_use_strict_directive() && !is_simple_parameter_list(&func.params) {
+            self.hit(func.span.start, USE_STRICT_MESSAGE);
+        }
+        // An arrow has no `this` scope of its own, so `super` carries through;
+        // its body is still a function body, so the labels do not.
+        let outer_labels = std::mem::take(&mut self.labels);
+        walk::walk_arrow_function_expression(self, func);
+        self.labels = outer_labels;
+    }
+
+    fn visit_class(&mut self, class: &Class<'a>) {
+        let declared = self.check_class_members(class);
+        self.private_stack.push(PrivateFrame {
+            declared,
+            used: Vec::new(),
+        });
+        self.class_has_super.push(class.heritage.is_some());
+
+        walk::walk_class(self, class);
+
+        self.class_has_super.pop();
+        let frame = self.private_stack.pop().unwrap_or_default();
+        let unresolved: Vec<(String, u32)> = frame
+            .used
+            .into_iter()
+            .filter(|(name, _)| !frame.declared.contains(name))
+            .collect();
+        match self.private_stack.last_mut() {
+            Some(parent) => parent.used.extend(unresolved),
+            None => {
+                for (name, at) in unresolved {
+                    self.hit(at, undeclared_private_message(&name));
+                }
+            }
+        }
+    }
+
+    fn visit_method_definition(&mut self, method: &MethodDefinition<'a>) {
+        self.pending_super = true;
+        self.pending_direct_super = method.kind == MethodDefinitionKind::Constructor
+            && self.class_has_super.last().copied().unwrap_or(false);
+        walk::walk_method_definition(self, method);
+        self.pending_super = false;
+        self.pending_direct_super = false;
+    }
+
+    fn visit_property_definition(&mut self, property: &PropertyDefinition<'a>) {
+        let outer_super = std::mem::replace(&mut self.super_allowed, true);
+        let outer_direct = std::mem::replace(&mut self.direct_super_allowed, false);
+        walk::walk_property_definition(self, property);
+        self.super_allowed = outer_super;
+        self.direct_super_allowed = outer_direct;
+    }
+
+    fn visit_accessor_property(&mut self, property: &AccessorProperty<'a>) {
+        let outer_super = std::mem::replace(&mut self.super_allowed, true);
+        let outer_direct = std::mem::replace(&mut self.direct_super_allowed, false);
+        walk::walk_accessor_property(self, property);
+        self.super_allowed = outer_super;
+        self.direct_super_allowed = outer_direct;
+    }
+
+    fn visit_static_block(&mut self, block: &StaticBlock<'a>) {
+        let outer_super = std::mem::replace(&mut self.super_allowed, true);
+        let outer_direct = std::mem::replace(&mut self.direct_super_allowed, false);
+        let outer_labels = std::mem::take(&mut self.labels);
+        walk::walk_static_block(self, block);
+        self.super_allowed = outer_super;
+        self.direct_super_allowed = outer_direct;
+        self.labels = outer_labels;
+    }
+
+    fn visit_object_property(&mut self, property: &ObjectProperty<'a>) {
+        // A shorthand or a plain data property holds an ordinary expression; a
+        // method and an accessor are parsed by acorn's `parseMethod`.
+        if property.method || property.kind != PropertyKind::Init {
+            self.pending_super = true;
+            self.pending_direct_super = false;
+        }
+        walk::walk_object_property(self, property);
+        self.pending_super = false;
+        self.pending_direct_super = false;
+    }
+
+    fn visit_private_field_expression(&mut self, expr: &oxc_ast::ast::PrivateFieldExpression<'a>) {
+        self.use_private_name(expr.field.name.as_str(), expr.field.span.start, false);
+        walk::walk_private_field_expression(self, expr);
+    }
+
+    fn visit_private_in_expression(&mut self, expr: &oxc_ast::ast::PrivateInExpression<'a>) {
+        self.use_private_name(expr.left.name.as_str(), expr.left.span.start, true);
+        walk::walk_private_in_expression(self, expr);
+    }
+
+    fn visit_labeled_statement(&mut self, stmt: &oxc_ast::ast::LabeledStatement<'a>) {
+        let name = stmt.label.name.as_str();
+        if self
+            .labels
+            .iter()
+            .any(|entry| entry.name.as_deref() == Some(name))
+        {
+            self.hit(
+                stmt.label.span.start,
+                format!("Label '{name}' is already declared"),
+            );
+        }
+        self.labels.push(Label {
+            name: Some(name.to_string()),
+            kind: label_kind(&stmt.body),
+        });
+        walk::walk_labeled_statement(self, stmt);
+        self.labels.pop();
+    }
+
+    fn visit_break_statement(&mut self, stmt: &oxc_ast::ast::BreakStatement<'a>) {
+        self.check_break_continue(
+            stmt.span.start,
+            stmt.label.as_ref().map(|l| l.name.as_str()),
+            true,
+        );
+    }
+
+    fn visit_continue_statement(&mut self, stmt: &oxc_ast::ast::ContinueStatement<'a>) {
+        self.check_break_continue(
+            stmt.span.start,
+            stmt.label.as_ref().map(|l| l.name.as_str()),
+            false,
+        );
+    }
+
+    fn visit_for_statement(&mut self, stmt: &oxc_ast::ast::ForStatement<'a>) {
+        self.labels.push(Label::loop_label());
+        walk::walk_for_statement(self, stmt);
+        self.labels.pop();
+    }
+
+    fn visit_for_in_statement(&mut self, stmt: &oxc_ast::ast::ForInStatement<'a>) {
+        self.labels.push(Label::loop_label());
+        walk::walk_for_in_statement(self, stmt);
+        self.labels.pop();
+    }
+
+    fn visit_for_of_statement(&mut self, stmt: &oxc_ast::ast::ForOfStatement<'a>) {
+        self.labels.push(Label::loop_label());
+        walk::walk_for_of_statement(self, stmt);
+        self.labels.pop();
+    }
+
+    fn visit_while_statement(&mut self, stmt: &oxc_ast::ast::WhileStatement<'a>) {
+        self.labels.push(Label::loop_label());
+        walk::walk_while_statement(self, stmt);
+        self.labels.pop();
+    }
+
+    fn visit_do_while_statement(&mut self, stmt: &oxc_ast::ast::DoWhileStatement<'a>) {
+        self.labels.push(Label::loop_label());
+        walk::walk_do_while_statement(self, stmt);
+        self.labels.pop();
+    }
+
+    fn visit_switch_statement(&mut self, stmt: &oxc_ast::ast::SwitchStatement<'a>) {
+        self.labels.push(Label::switch_label());
+        walk::walk_switch_statement(self, stmt);
+        self.labels.pop();
+    }
+}

--- a/crates/rsvelte_core/src/compiler/phases/1_parse/read/expression.rs
+++ b/crates/rsvelte_core/src/compiler/phases/1_parse/read/expression.rs
@@ -6998,6 +6998,7 @@ fn acorn_only_violation(
         }),
         await_or_yield_in_params(program, content).map(|(at, message)| (at, message.to_string())),
         super::strict_mode::find_violation(program, content, is_typescript),
+        super::early_errors::find_violation(program, content),
     ]
     .into_iter()
     .flatten()

--- a/crates/rsvelte_core/src/compiler/phases/1_parse/read/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/1_parse/read/mod.rs
@@ -4,6 +4,7 @@
 //! The expression module provides JavaScript/TypeScript expression parsing using OXC.
 //! The style module also provides CSS parsing functionality.
 
+pub(crate) mod early_errors;
 pub mod expression;
 mod options;
 pub(crate) mod script;

--- a/crates/rsvelte_core/tests/js_early_errors_3243.rs
+++ b/crates/rsvelte_core/tests/js_early_errors_3243.rs
@@ -1,0 +1,379 @@
+//! JavaScript early errors that acorn raises and OXC does not (issue #3243).
+//!
+//! None of these is decidable from the token stream alone — each needs the
+//! class, function or label context around the construct — so OXC leaves them
+//! to `SemanticBuilder`, which this pipeline never runs. Every one was accepted
+//! and copied verbatim into output no JS parser will read.
+//!
+//! Each expectation below was measured against `svelte.compile` /
+//! `svelte.compileModule`, message and byte offset included; a `@` in a source
+//! marks the offset and is removed before compiling. The `legal_*` tests are
+//! the other half of the same check: adding a rejection always risks an
+//! over-rejection, and every shape there is one acorn accepts.
+
+use rsvelte_core::{
+    CompileOptions, GenerateMode, ModuleCompileOptions, compile, compile_module, compiler::CssMode,
+};
+
+/// `(code, message, start offset)` for a rejected input, or `None`.
+fn component_error(src: &str) -> Option<(String, String, u32)> {
+    diagnostic(
+        compile(
+            src,
+            CompileOptions {
+                filename: Some("Test.svelte".to_string()),
+                generate: GenerateMode::Client,
+                css: CssMode::External,
+                ..Default::default()
+            },
+        )
+        .err(),
+    )
+}
+
+fn module_error(src: &str) -> Option<(String, String, u32)> {
+    diagnostic(
+        compile_module(
+            src,
+            ModuleCompileOptions {
+                filename: Some("m.svelte.js".to_string()),
+                generate: GenerateMode::Client,
+                ..Default::default()
+            },
+        )
+        .err(),
+    )
+}
+
+fn diagnostic(err: Option<rsvelte_core::CompileError>) -> Option<(String, String, u32)> {
+    err.map(|err| {
+        let d = err.diagnostic();
+        (
+            d.code.unwrap_or_default(),
+            d.message.lines().next().unwrap_or_default().to_string(),
+            d.span.map(|(start, _)| start).unwrap_or(u32::MAX),
+        )
+    })
+}
+
+fn assert_rejected(
+    src_with_marker: &str,
+    message: &str,
+    compiler: fn(&str) -> Option<(String, String, u32)>,
+) {
+    let at = src_with_marker
+        .find('@')
+        .unwrap_or_else(|| panic!("no `@` offset marker in {src_with_marker}"));
+    let src = src_with_marker.replacen('@', "", 1);
+    let (code, actual, start) =
+        compiler(&src).unwrap_or_else(|| panic!("must not compile: {src_with_marker}"));
+    assert_eq!(code, "js_parse_error", "{src_with_marker}");
+    assert_eq!(actual, message, "{src_with_marker}");
+    assert_eq!(start as usize, at, "offset for {src_with_marker}");
+}
+
+/// The same statement in a `.svelte.js` module and in a component's instance
+/// script — the two entry points that reach `parse_program`.
+fn assert_rejected_everywhere(statement_with_marker: &str, message: &str) {
+    assert_rejected(
+        &format!("export {statement_with_marker}\n"),
+        message,
+        module_error,
+    );
+    assert_rejected(
+        &format!("<script>{statement_with_marker}</script>\n"),
+        message,
+        component_error,
+    );
+}
+
+#[test]
+fn duplicate_constructor() {
+    assert_rejected_everywhere(
+        "class K { constructor() {} @constructor() {} }",
+        "Duplicate constructor in the same class",
+    );
+    assert_rejected_everywhere(
+        "class K { \"constructor\"() {} @constructor() {} }",
+        "Duplicate constructor in the same class",
+    );
+    assert_rejected_everywhere(
+        "class K { m() { return class { constructor() {} @constructor() {} }; } }",
+        "Duplicate constructor in the same class",
+    );
+}
+
+#[test]
+fn super_outside_a_method() {
+    assert_rejected_everywhere(
+        "function f() { @super(); }",
+        "'super' keyword outside a method",
+    );
+    assert_rejected_everywhere(
+        "class K extends Object { m() { return function () { return @super.toString(); }; } }",
+        "'super' keyword outside a method",
+    );
+}
+
+#[test]
+fn super_call_outside_a_derived_constructor() {
+    assert_rejected_everywhere(
+        "class K { constructor() { @super(); } }",
+        "super() call outside constructor of a subclass",
+    );
+    assert_rejected_everywhere(
+        "class K extends Object { m() { @super(); } }",
+        "super() call outside constructor of a subclass",
+    );
+}
+
+#[test]
+fn unsyntactic_break() {
+    assert_rejected_everywhere("function f() { @break nope; }", "Unsyntactic break");
+    // A function boundary is not crossed, by either spelling.
+    assert_rejected_everywhere(
+        "function f() { for (;;) { (function () { @break; })(); } }",
+        "Unsyntactic break",
+    );
+    assert_rejected_everywhere(
+        "function f() { for (;;) { (() => { @break; })(); } }",
+        "Unsyntactic break",
+    );
+    // A class static block is a function body too.
+    assert_rejected_everywhere(
+        "function f() { a: for (;;) { class L { static { @break a; } } } }",
+        "Unsyntactic break",
+    );
+}
+
+#[test]
+fn unsyntactic_continue() {
+    assert_rejected_everywhere("function f() { @continue; }", "Unsyntactic continue");
+    // A `switch` is a destination for `break` and not for `continue`.
+    assert_rejected_everywhere(
+        "function f(x) { switch (x) { case 1: @continue; } }",
+        "Unsyntactic continue",
+    );
+    // So is a labelled block.
+    assert_rejected_everywhere(
+        "function f() { a: { @continue a; } }",
+        "Unsyntactic continue",
+    );
+    assert_rejected_everywhere(
+        "function f() { a: b: { @continue a; } }",
+        "Unsyntactic continue",
+    );
+}
+
+#[test]
+fn duplicate_label() {
+    assert_rejected_everywhere(
+        "function f() { a: @a: for (;;) break a; }",
+        "Label 'a' is already declared",
+    );
+    assert_rejected_everywhere(
+        "function f() { a: for (;;) { @a: for (;;) break a; } }",
+        "Label 'a' is already declared",
+    );
+}
+
+#[test]
+fn undeclared_private_name() {
+    assert_rejected_everywhere(
+        "class K { m() { return this.@#nope; } }",
+        "Private field '#nope' must be declared in an enclosing class",
+    );
+    assert_rejected_everywhere(
+        "class K { m() { return class { n(o) { return o.@#nope; } }; } }",
+        "Private field '#nope' must be declared in an enclosing class",
+    );
+    assert_rejected_everywhere(
+        "class K { static has(o) { return @#b in o; } }",
+        "Private field '#b' must be declared in an enclosing class",
+    );
+}
+
+#[test]
+fn duplicate_private_name() {
+    assert_rejected_everywhere(
+        "class K { #a = 1; @#a = 2; }",
+        "Identifier '#a' has already been declared",
+    );
+    assert_rejected_everywhere(
+        "class K { #a() {} @#a = 1; }",
+        "Identifier '#a' has already been declared",
+    );
+    // A getter/setter pair is the one legal repetition — but only when the two
+    // halves agree on `static`.
+    assert_rejected_everywhere(
+        "class K { get #a() { return 1; } static set @#a(v) {} }",
+        "Identifier '#a' has already been declared",
+    );
+}
+
+#[test]
+fn private_fields_can_not_be_deleted() {
+    assert_rejected_everywhere(
+        "class K { #a = 1; m() { @delete this.#a; } }",
+        "Private fields can not be deleted",
+    );
+}
+
+#[test]
+fn import_and_export_only_at_the_top_level() {
+    assert_rejected_everywhere(
+        "function f() { @import \"./x.js\"; }",
+        "'import' and 'export' may only appear at the top level",
+    );
+    assert_rejected_everywhere(
+        "function f() { @export const a = 1; }",
+        "'import' and 'export' may only appear at the top level",
+    );
+    assert_rejected_everywhere(
+        "function f() { @export * from \"./x.js\"; }",
+        "'import' and 'export' may only appear at the top level",
+    );
+    assert_rejected("{ @import \"./x.js\"; }\n", MODULE_LEVEL, module_error);
+    assert_rejected("if (1) @export const a = 1;\n", MODULE_LEVEL, module_error);
+}
+
+const MODULE_LEVEL: &str = "'import' and 'export' may only appear at the top level";
+
+#[test]
+fn use_strict_with_a_non_simple_parameter_list() {
+    for statement in [
+        "@function f(a = 1) { 'use strict'; return a; }",
+        "@function f(...a) { 'use strict'; return a; }",
+        "@function f({ a }) { 'use strict'; return a; }",
+        "@function f([a]) { 'use strict'; return a; }",
+        "@function* g(a = 1) { 'use strict'; return a; }",
+        "@async function f(a = 1) { 'use strict'; return a; }",
+        // A later directive in the same prologue still counts.
+        "@function f(a = 1) { 'other'; 'use strict'; return a; }",
+    ] {
+        assert_rejected_everywhere(statement, USE_STRICT);
+    }
+    assert_rejected(
+        "export const f = @(a = 1) => { 'use strict'; return a; };\n",
+        USE_STRICT,
+        module_error,
+    );
+    assert_rejected(
+        "export class K { m@(a = 1) { 'use strict'; return a; } }\n",
+        USE_STRICT,
+        module_error,
+    );
+}
+
+const USE_STRICT: &str =
+    "Illegal 'use strict' directive in function with non-simple parameter list";
+
+/// Every shape below is accepted by `svelte.compile`, and each sits one step
+/// away from a rejection above.
+#[test]
+fn legal_shapes_still_compile() {
+    for statement in [
+        "class K extends Object { constructor() { super(); } }",
+        "class K extends Object { m() { return super.toString(); } }",
+        "class K extends Object { a = super.toString(); }",
+        "class K extends Object { a = () => super.toString(); }",
+        "class K extends Object { static { super.toString(); } }",
+        "class K extends Object { m() { return () => super.toString(); } }",
+        "class K extends Object { m() { return { n() { return super.toString(); } }; } }",
+        "const o = { __proto__: {}, m() { return super.toString(); } };",
+        "class K { static constructor() {} constructor() {} }",
+        "class K { [\"constructor\"]() {} constructor() {} }",
+        "class K { #a = 1; m() { return this.#a; } }",
+        "class K { #a = 1; static has(o) { return #a in o; } }",
+        "class K { get #a() { return 1; } set #a(v) {} }",
+        "class K { #a = 1; m() { class L { #a = 2; n() { return this.#a; } } return L; } }",
+        "class K { #a = 1; m() { return class { n(o) { return o.#a; } }; } }",
+        "function f() { a: for (;;) break a; }",
+        "function f() { a: for (;;) break a; a: for (;;) break a; }",
+        "function f() { a: b: for (;;) { continue a; } }",
+        "function f() { a: { break a; } }",
+        "function f(x) { switch (x) { case 1: break; } }",
+        "function f(x) { a: switch (x) { case 1: break a; } }",
+        "function f() { a: for (;;) { (function () { a: for (;;) break a; })(); break a; } }",
+        "function f() { do { continue; } while (0); }",
+        "function f() { return import(\"./x.js\"); }",
+        "function f() { return import.meta.url; }",
+        "class K { static { a: for (;;) break a; } }",
+        "function f(a, b) { 'use strict'; return a + b; }",
+        "function f() { 'use strict'; return 1; }",
+        "const g = (a = 1) => a;",
+        "function f(a = 1) { const b = 1; 'use strict'; return a + b; }",
+        "const o = { get a() { 'use strict'; return 1; } };",
+    ] {
+        assert_eq!(
+            module_error(&format!("export {statement}\n")),
+            None,
+            "module must accept: {statement}"
+        );
+        assert_eq!(
+            component_error(&format!("<script>{statement}</script>\n")),
+            None,
+            "instance script must accept: {statement}"
+        );
+    }
+}
+
+/// A TypeScript overload signature repeats the member's name without defining
+/// it, so neither the constructor count nor the private-name map may see it.
+#[test]
+fn legal_typescript_overloads() {
+    for statement in [
+        "class K { constructor(a: string); constructor(a: number); constructor(a: any) {} }",
+        "class K { #m(a: string): void; #m(a: any) {} }",
+        "class K { declare a: number; }",
+        "abstract class K { abstract m(): void; }",
+        // An optional parameter is still a plain identifier binding.
+        "function f(a?: number) { 'use strict'; return a; }",
+        "function f(a: number) { 'use strict'; return a; }",
+    ] {
+        assert_eq!(
+            component_error(&format!("<script lang=\"ts\">{statement}</script>\n")),
+            None,
+            "lang=\"ts\" instance script must accept: {statement}"
+        );
+    }
+}
+
+/// The same rejections apply to `lang="ts"`, which upstream parses with
+/// acorn-typescript — the base parser's early errors are still in force.
+#[test]
+fn typescript_scripts_are_rejected_too() {
+    for (statement, message) in [
+        (
+            "class K { constructor() {} constructor() {} }",
+            "Duplicate constructor in the same class",
+        ),
+        (
+            "function f() { super(); }",
+            "'super' keyword outside a method",
+        ),
+        ("function f() { break nope; }", "Unsyntactic break"),
+        (
+            "function f() { a: a: for (;;) break a; }",
+            "Label 'a' is already declared",
+        ),
+        (
+            "class K { #a = 1; #a = 2; }",
+            "Identifier '#a' has already been declared",
+        ),
+        (
+            "class K { m() { return this.#nope; } }",
+            "Private field '#nope' must be declared in an enclosing class",
+        ),
+        (
+            "function f() { import \"./x.js\"; }",
+            "'import' and 'export' may only appear at the top level",
+        ),
+    ] {
+        let src = format!("<script lang=\"ts\">{statement}</script>\n");
+        let (code, actual, _) =
+            component_error(&src).unwrap_or_else(|| panic!("lang=\"ts\" must reject: {statement}"));
+        assert_eq!(code, "js_parse_error", "lang=\"ts\": {statement}");
+        assert_eq!(actual, message, "lang=\"ts\": {statement}");
+    }
+}


### PR DESCRIPTION
Closes #3243

## What

acorn raises a family of JavaScript **early errors** that OXC does not, because none of them is decidable from the token stream alone — each needs the class, function or label context the construct sits in, which OXC leaves to `SemanticBuilder` and this pipeline never runs it. Every one was accepted and copied verbatim into output no JS parser reads.

The check is a single visitor (`1_parse/read/early_errors.rs`) reached from the existing `acorn_only_violation` seam, so it competes with every other acorn-only restriction by source position — acorn is single-pass and non-recovering, so the earliest violation is the one it would have thrown.

`expression.rs` gains exactly one line (a new entry in that seam's array); the logic lives in its own module.

## Rules implemented

Each was ported from acorn's own site and each expectation below — message **and** byte offset — was measured against `svelte.compile` / `svelte.compileModule`, never written by hand.

| shape | acorn's message |
|---|---|
| `class K { constructor() {} constructor() {} }` | `Duplicate constructor in the same class` |
| `function f() { super(); }` | `'super' keyword outside a method` |
| `class K { constructor() { super(); } }` | `super() call outside constructor of a subclass` |
| `function f() { break nope; }` | `Unsyntactic break` |
| `function f() { continue; }` | `Unsyntactic continue` |
| `function f() { a: a: for (;;) break a; }` | `Label 'a' is already declared` |
| `class K { m() { return this.#nope; } }` | `Private field '#nope' must be declared in an enclosing class` |
| `class K { #a = 1; #a = 2; }` | `Identifier '#a' has already been declared` |
| `class K { #a = 1; m() { delete this.#a; } }` | `Private fields can not be deleted` |
| `function f() { import "./x.js"; }` | `'import' and 'export' may only appear at the top level` |
| `function f(a = 1) { 'use strict'; }` | `Illegal 'use strict' directive in function with non-simple parameter list` |

All three entry points — `.svelte.js` / `.svelte.ts` via `compileModule`, and a component's instance script including `lang="ts"`.

## How the set was closed

The issue names eight classes. Rather than trust that list, I enumerated **every `raise` / `raiseRecoverable` message literal in acorn 8.17.0** (90 distinct) and wrote an input for each context-dependent one, then diffed rsvelte against the official compiler on all of them. That found a ninth class the issue does not list — the `'use strict'` directive with a non-simple parameter list, which reproduces on 13 of 20 shapes — and `super()` outside a derived constructor, and `delete` on a private field.

After the fix that independent sweep reports **zero** accept-divergences over 50 inputs. The 17 rows that still differ are all cases where **both** compilers reject and only the message wording or the byte offset diverges (`Missing catch or finally clause` at a different offset, `Invalid regular expression flag` vs OXC's wording, and so on) — a separate defect family, and not one this PR touches.

## Over-rejection is the other half

Adding a rejection is the easy direction to get wrong, so 55 of the 141 measured inputs are shapes acorn **accepts** and each sits one step from a rejection above: `super` in a method / field initialiser / static block / arrow-inside-a-method / object method, a getter-setter private pair, a private name declared in an enclosing class, a label reused across a function boundary, a chained label on a loop, `break` in a `switch`, `import()` and `import.meta` nested, a simple-parameter `'use strict'`, and a `'use strict'` that is not in the directive prologue.

Two TypeScript shapes needed their own handling and are pinned as tests, because a naive port rejects them:

- an **overload signature** repeats the member's name without defining it, so `constructor(a: string); constructor(a: any) {}` must not count as two constructors and `#m(a: string): void; #m(a: any) {}` must not collide;
- a statement inside a `TSModuleBlock` is not measured for the top-level `import`/`export` rule — upstream rejects the whole namespace as `typescript_invalid_feature` first, and firing here would replace that diagnostic with the wrong one.

## Negative control

Removing the one wiring line in `expression.rs` and re-running the suite: **12 of 14 tests fail, every one of them at `must not compile` / `must reject`** — the predicted symptom, not a different assertion — while both control tests (`legal_shapes_still_compile`, `legal_typescript_overloads`) stay **green**, so the legal half was never being carried by the new code.

## Tests

`crates/rsvelte_core/tests/js_early_errors_3243.rs`, 14 tests. Positions are asserted, not just codes: a `@` in each source marks the byte the official compiler reports and is stripped before compiling, so a fix that rejects at the wrong place fails.

Existing suites re-run green on this tree: `compiler_errors`, `parser_fixtures`, `compiler_fixtures`, `validator`, `ssr`, `runtime`.

## Scope note

`{@const}` / `{#await}` / `{@render}` swallowing JS parse errors (#3202), `{@const c}` with no value (#3246) and the unterminated-`{` attribution (#3247) are separate defects in `1_parse/state/tag.rs` and are **not** in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
