### PR TITLE
fix(svelte2tsx): read the generics attribute with a TypeScript parse, not a comma scan

### DIFF
--- a/.changeset/s2t-generics-attribute-parse.md
+++ b/.changeset/s2t-generics-attribute-parse.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/svelte2tsx": patch
+---
+
+Read the `<script generics="…">` attribute with a TypeScript parse instead of a comma scan. The scan knew only about `<…>`, so a comma at the top level of an object type, a tuple, a parameter list or a string literal split the type parameter and the fragments were emitted as *type arguments* — `<T,b:>` is not a type argument list, so the whole component's TSX stopped parsing. Whether a component has generics at all now comes from the same parse (upstream's `Generics.has()`), so an attribute that is not a type parameter list keeps the non-generic component export while still reaching `function $$render<…>` verbatim.

--- a/crates/rsvelte_projection/src/svelte2tsx/add_component_export.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/add_component_export.rs
@@ -9,7 +9,7 @@ use super::interfaces::{Svelte2TsxOptions, SvelteVersion};
 use super::magic_string::MagicString;
 use super::nodes::component_documentation::extract_component_documentation;
 use super::nodes::component_events::build_events_str;
-use super::nodes::generics::{compact_generic_params, split_generic_param_names};
+use super::nodes::generics::parse_generics_attr;
 use super::nodes::slot::build_slots_str;
 use super::script::{ComponentEvents, ExportedNames};
 use super::template;
@@ -199,8 +199,12 @@ pub fn add_component_export(
         ""
     };
 
-    // Determine if this component has generics (either from generics= attribute or $$Generic)
-    let has_generics = !exported_names.dollar_generics.is_empty() || generics_attribute.is_some();
+    // Upstream keys the component export on `Generics.has()`, i.e. the attribute
+    // parsed as a type parameter list — not on the attribute merely being there.
+    let attribute_generics = generics_attribute
+        .map(parse_generics_attr)
+        .unwrap_or_default();
+    let has_generics = !exported_names.dollar_generics.is_empty() || attribute_generics.has();
 
     // Build generics strings for component export
     let (generics_params, generics_names) = if !exported_names.dollar_generics.is_empty() {
@@ -220,12 +224,11 @@ pub fn add_component_export(
             .map(|(name, _)| name.clone())
             .collect();
         (params.join(","), names.join(","))
-    } else if let Some(g) = generics_attribute {
-        // Create compact params string (strip leading spaces from each param)
-        let params_str = compact_generic_params(g);
-        // Split generic params at top-level commas (not inside angle brackets)
-        let names = split_generic_param_names(g);
-        (params_str, names.join(","))
+    } else if attribute_generics.has() {
+        (
+            attribute_generics.definitions_str(),
+            attribute_generics.references_str(),
+        )
     } else {
         (String::new(), String::new())
     };

--- a/crates/rsvelte_projection/src/svelte2tsx/nodes/generics.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/nodes/generics.rs
@@ -112,81 +112,73 @@ pub fn type_text_typeof_references_local_value(
     false
 }
 
-/// Split a generics string like "T extends Record<string, any>, U" into
-/// just the type parameter names: `["T", "U"]`.
-/// Handles nested angle brackets and commas inside constraints.
+/// The parsed `generics="…"` attribute: upstream's `Generics` lists.
+///
+/// `definitions` are `param.getText()` and `references` are
+/// `param.name.getText()` over the type parameters of
+/// `` `<${raw}>() => {}` ``, so no bracket kind is special-cased — a comma
+/// inside an object type, tuple, parameter list or string literal belongs to
+/// the parameter it sits in.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct ParsedGenerics {
+    pub definitions: Vec<String>,
+    pub references: Vec<String>,
+}
+
+impl ParsedGenerics {
+    /// Upstream `Generics.has()` — the attribute being present is not enough;
+    /// it must parse as a type parameter list.
+    pub fn has(&self) -> bool {
+        !self.definitions.is_empty()
+    }
+
+    /// Upstream `toDefinitionString()` without the surrounding `<`/`>`.
+    pub fn definitions_str(&self) -> String {
+        self.definitions.join(",")
+    }
+
+    /// Upstream `toReferencesString()` without the surrounding `<`/`>`.
+    pub fn references_str(&self) -> String {
+        self.references.join(",")
+    }
+}
+
+/// Parse a `generics="…"` attribute value the way upstream does: wrap it in an
+/// arrow function's type parameter list and read the parameters back off the
+/// TypeScript AST. Mirrors `Generics.getGenericTypeParameters`.
+pub fn parse_generics_attr(raw: &str) -> ParsedGenerics {
+    let mut out = ParsedGenerics::default();
+    if raw.is_empty() {
+        return out;
+    }
+    let probe = format!("<{raw}>() => {{}}");
+    let allocator = oxc_allocator::Allocator::default();
+    let parsed = oxc_parser::Parser::new(&allocator, &probe, oxc_span::SourceType::ts()).parse();
+    let Some(oxc_ast::ast::Statement::ExpressionStatement(stmt)) = parsed.program.body.first()
+    else {
+        return out;
+    };
+    let oxc_ast::ast::Expression::ArrowFunctionExpression(arrow) = &stmt.expression else {
+        return out;
+    };
+    let Some(type_parameters) = arrow.type_parameters.as_ref() else {
+        return out;
+    };
+    for param in &type_parameters.params {
+        let span = param.span;
+        let (start, end) = (span.start as usize, span.end as usize);
+        if start > end || end > probe.len() || !probe.is_char_boundary(start) {
+            return ParsedGenerics::default();
+        }
+        out.definitions.push(probe[start..end].to_string());
+        out.references.push(param.name.name.to_string());
+    }
+    out
+}
+
+/// Just the type parameter names of a `generics="…"` attribute value.
 pub fn split_generic_param_names(generics: &str) -> Vec<String> {
-    let mut names = Vec::new();
-    let mut depth = 0; // angle bracket depth
-    let mut current_start = 0;
-
-    for (i, ch) in generics.char_indices() {
-        match ch {
-            '<' => depth += 1,
-            '>' if depth > 0 => depth -= 1,
-            ',' if depth == 0 => {
-                let param = generics[current_start..i].trim();
-                names.push(extract_param_name(param));
-                current_start = i + 1;
-            }
-            _ => {}
-        }
-    }
-    // Handle the last parameter
-    let param = generics[current_start..].trim();
-    if !param.is_empty() {
-        names.push(extract_param_name(param));
-    }
-    names
-}
-
-/// Compact a generics string by stripping leading spaces from each top-level parameter.
-/// "A, B extends keyof A, C extends boolean" → "A,B extends keyof A,C extends boolean"
-pub fn compact_generic_params(generics: &str) -> String {
-    let mut result = String::new();
-    let mut depth = 0;
-    let mut after_comma = false;
-
-    for ch in generics.chars() {
-        match ch {
-            '<' => {
-                depth += 1;
-                result.push(ch);
-            }
-            '>' => {
-                if depth > 0 {
-                    depth -= 1;
-                }
-                result.push(ch);
-            }
-            ',' if depth == 0 => {
-                result.push(',');
-                after_comma = true;
-            }
-            ' ' | '\t' if after_comma => {
-                // Skip leading whitespace after comma at top level
-                continue;
-            }
-            _ => {
-                after_comma = false;
-                result.push(ch);
-            }
-        }
-    }
-    result
-}
-
-/// Extract the type parameter name from a parameter declaration,
-/// handling the `const` modifier (e.g., `const T extends ...` → `T`).
-fn extract_param_name(param: &str) -> String {
-    let mut words = param.split_whitespace();
-    let first = words.next().unwrap_or("");
-    if first == "const" {
-        // Skip `const` modifier, take the next word
-        words.next().unwrap_or(first).to_string()
-    } else {
-        first.to_string()
-    }
+    parse_generics_attr(generics).references
 }
 
 /// Extract the `generics` attribute value from a script tag text.

--- a/crates/rsvelte_projection/tests/svelte2tsx_generics_attribute_parse.rs
+++ b/crates/rsvelte_projection/tests/svelte2tsx_generics_attribute_parse.rs
@@ -1,0 +1,118 @@
+//! #3252 / #3253: the `generics="…"` attribute is a type parameter list, and
+//! upstream reads it back off a TypeScript parse of `` `<${raw}>() => {}` ``.
+//!
+//! Expectations were measured against the official `svelte2tsx` from
+//! `submodules/language-tools` on the same sources.
+
+use rsvelte_projection::svelte2tsx::{Svelte2TsxOptions, svelte2tsx};
+
+fn convert(generics: &str) -> String {
+    let src = format!(
+        "<script lang=\"ts\" generics=\"{generics}\">\n\tlet x: T = null as any; void x;\n</script>\n"
+    );
+    let opts = Svelte2TsxOptions {
+        filename: "Probe.svelte".to_string(),
+        ..Default::default()
+    };
+    svelte2tsx(&src, opts).expect("svelte2tsx ok").code
+}
+
+/// A comma at the top level of any bracket kind other than `<…>` used to split
+/// the parameter, and the fragments were emitted as *type arguments* — `<T,b:>`
+/// is not a type argument list, so the whole file stopped parsing as TSX.
+#[test]
+fn a_comma_inside_another_bracket_kind_does_not_split_the_parameter() {
+    for (generics, definition) in [
+        (
+            "T extends { a: string, b: number }",
+            "T extends { a: string, b: number }",
+        ),
+        ("T extends [a, b]", "T extends [a, b]"),
+        ("T extends [a: 1, b: 2]", "T extends [a: 1, b: 2]"),
+        (
+            "T extends (a: 1, b: 2) => void",
+            "T extends (a: 1, b: 2) => void",
+        ),
+        ("T = { a: 1, b: 2 }", "T = { a: 1, b: 2 }"),
+        ("T extends 'a,b'", "T extends 'a,b'"),
+    ] {
+        let code = convert(generics);
+        assert!(
+            code.contains(&format!("class __sveltets_Render<{definition}> {{")),
+            "definition must survive verbatim for {generics:?}:\n{code}"
+        );
+        assert!(
+            code.contains("return $$render<T>().props;"),
+            "the reference list is the parameter NAMES for {generics:?}:\n{code}"
+        );
+    }
+}
+
+/// Several parameters still join with a bare `,` and each definition keeps the
+/// source spelling from its own `getText()` — no leading whitespace.
+#[test]
+fn multiple_parameters_join_on_the_parameter_boundary() {
+    let code = convert("T extends A, U extends B");
+    assert!(
+        code.contains("class __sveltets_Render<T extends A,U extends B> {"),
+        "{code}"
+    );
+    assert!(code.contains("return $$render<T,U>().props;"), "{code}");
+}
+
+/// #3253: upstream answers "does this component have generics?" from
+/// `Generics.has()` — the attribute must PARSE as a type parameter list. An
+/// attribute that does not is written onto `$$render` verbatim while the
+/// component export stays non-generic.
+#[test]
+fn an_unparseable_attribute_keeps_the_non_generic_component_export() {
+    for generics in [
+        "T extends string ? 1 : 2",
+        ",T",
+        "in T",
+        "in out T",
+        "extends string",
+        "1",
+        " ",
+    ] {
+        let code = convert(generics);
+        assert!(
+            code.contains(
+                "__sveltets_2_isomorphic_component(__sveltets_2_partial(__sveltets_2_with_any_event($$render())))"
+            ),
+            "{generics:?} must not make the export generic:\n{code}"
+        );
+        assert!(
+            !code.contains("class __sveltets_Render<"),
+            "{generics:?} must not emit the generic render class:\n{code}"
+        );
+    }
+}
+
+/// The raw attribute still reaches `function $$render<…>` even when it does not
+/// parse — upstream keys that on `genericsAttr`, not on `has()`.
+#[test]
+fn the_raw_attribute_still_reaches_the_render_header() {
+    let code = convert("T extends string ? 1 : 2");
+    assert!(
+        code.contains(
+            ";function $$render</*\u{03A9}ignore_start\u{03A9}*/T extends string ? 1 : 2>/*\u{03A9}ignore_end\u{03A9}*/() {"
+        ),
+        "{code}"
+    );
+}
+
+/// A `const` modifier and a trailing comma are part of the parse, not of a
+/// hand-written splitter.
+#[test]
+fn modifiers_and_a_trailing_comma_are_read_from_the_parse() {
+    let code = convert("const T extends string");
+    assert!(
+        code.contains("class __sveltets_Render<const T extends string> {"),
+        "{code}"
+    );
+    assert!(code.contains("return $$render<T>().props;"), "{code}");
+
+    let code = convert("T,");
+    assert!(code.contains("class __sveltets_Render<T> {"), "{code}");
+}


### PR DESCRIPTION
Closes #3252
Closes #3253

## What

`generics="…"` was split into type parameters by a textual comma scan that knew only about `<…>`, and "does this component have generics?" was answered from the raw attribute being non-empty. Both now come from the same place upstream reads them from: `Generics.getGenericTypeParameters` parses `` `<${raw}>() => {}` `` and reads `arrowFunction.typeParameters`, with `definitions = param.getText()` and `references = param.name.getText()`.

`parse_generics_attr` does the same with oxc (`SourceType::ts()`), so no bracket kind is special. `Generics.has()` becomes `!definitions.is_empty()`, which is what `add_component_export` now keys on; the raw attribute still reaches `function $$render<…>` verbatim, exactly as upstream's `createRenderFunction` keys that on `genericsAttr` rather than on `has()`.

## Measurement

Oracle: the official `svelte2tsx` built from `submodules/language-tools` at the pinned svelte (5.56.9). Grid: 28 attribute values × 2 script bodies (a plain `T` annotation, and a `$props()` destructuring) = 56 cells, all 56 compiled on both sides, compared byte-for-byte.

| | identical |
|---|---|
| before | **10 / 56** |
| after | **52 / 56** |

The 4 that remain are two attribute values — `T extends Array<infer U> ? U : never` and `T = ({ a: 1 } satisfies object)` — where TypeScript's parser *error-recovers* into three bogus type parameters and official then emits text that is itself not valid TSX (`<T = ({ a: 1 },satisfies,object>`). oxc bails to non-generic instead. Both inputs are invalid TypeScript and neither side produces usable output; matching them would mean porting TS's recovery, so they are left as they are rather than chased.

Two measurements worth recording because the issue text predicts otherwise, and the oracle disagrees with it:

- `out T` **is** generic on both sides (TS parses `<out T>() => {}` as an arrow with one type parameter). `in T` and `in out T` are not, on both sides. The regression test uses the two that bail.
- `T,` and `  T  ` were divergent before and are fixed too — they are not in the issue's table.

## Which gate sees this

The svelte2tsx **TSX-text** gate (`compatibility/svelte2tsx-known-failures.json`). The source-map gate is untouched by this change: nothing about the MagicString layout of the instance script moves — the corrected text is all in the appended component export, which is generated content with no source mapping.

Neither gate had a chance of catching it: the attribute values that reach the splitter need a comma that is *not* inside angle brackets, and the collected corpus holds none.

## Tests

`crates/rsvelte_projection/tests/svelte2tsx_generics_attribute_parse.rs` — 5 tests, expectations measured against the oracle: the six bracket kinds that used to split, multi-parameter joining, the non-generic export for an attribute that does not parse, the raw attribute still reaching the render header, and `const` / trailing-comma handling.
