### PR TITLE
fix(svelte2tsx): count a snippet header's padding from the gaps between kept ranges

### DIFF
--- a/.changeset/s2t-snippet-header-padding.md
+++ b/.changeset/s2t-snippet-header-padding.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/svelte2tsx": patch
+---
+
+Count the padding in front of a standalone `{#snippet}`'s `const` from the gaps between the source ranges upstream's `transform()` keeps, instead of measuring the region after the last one. A header with anything between the name and the first parameter — a space, a tab, a type parameter list, or a formatted multi-line parameter list — was one space short, and svelte2tsx is one MagicString, so the shortfall shifted every mapping after it.

--- a/crates/rsvelte_projection/src/svelte2tsx/template/nodes/snippet_block.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/template/nodes/snippet_block.rs
@@ -103,13 +103,9 @@ pub fn handle_snippet_block_as_component_prop(
 /// attaches every comment between `(` and that parameter to it, and no comment
 /// can precede the `(` (the parser only allows whitespace there), so the first
 /// `/` after the `(` opens that comment.
-fn params_text<'a>(block: &SnippetBlock, source: &'a str) -> &'a str {
-    let Some((first_start, _)) = block.parameters.first().and_then(get_expression_range) else {
-        return "";
-    };
-    let Some((_, last_end)) = block.parameters.last().and_then(get_expression_range) else {
-        return "";
-    };
+fn params_range(block: &SnippetBlock, source: &str) -> Option<(usize, usize)> {
+    let (first_start, _) = block.parameters.first().and_then(get_expression_range)?;
+    let (_, last_end) = block.parameters.last().and_then(get_expression_range)?;
     let start = params_open_paren(block, source)
         .and_then(|open| {
             let region = open + 1;
@@ -121,7 +117,14 @@ fn params_text<'a>(block: &SnippetBlock, source: &'a str) -> &'a str {
                 .map(|offset| region + offset)
         })
         .unwrap_or(first_start as usize);
-    slice_src(source, start, last_end as usize)
+    Some((start, last_end as usize))
+}
+
+fn params_text<'a>(block: &SnippetBlock, source: &'a str) -> &'a str {
+    match params_range(block, source) {
+        Some((start, end)) => slice_src(source, start, end),
+        None => "",
+    }
 }
 
 /// Byte offset of the `(` that opens the snippet's parameter list. Only
@@ -170,28 +173,54 @@ fn params_open_paren(block: &SnippetBlock, source: &str) -> Option<usize> {
     (bytes.get(index) == Some(&b'(')).then_some(index)
 }
 
-/// Upstream reaches the standalone form through `transform()`, which turns the
-/// gap in front of the moved name into one space and then collapses whatever is
-/// left before `}` into a second one — so a snippet whose header ends flush
-/// against `}` gets a single space and every other shape gets two.
-fn opener_pad(block: &SnippetBlock, source: &str) -> &'static str {
-    let anchor = block
-        .parameters
-        .last()
-        .or(Some(&block.expression))
-        .and_then(get_expression_range)
-        .map(|(_, end)| end as usize);
-    let Some(mut kept_end) = anchor else {
-        return " ";
+/// Upstream reaches the standalone form through `transform()`, which overwrites
+/// every non-empty gap *before* a kept source range with one space and may
+/// leave one more before the header's `}` — so the count is the number of gaps,
+/// not the width of the tail.
+fn opener_pad(block: &SnippetBlock, source: &str) -> String {
+    let Some((expr_start, expr_end)) = get_expression_range(&block.expression) else {
+        return " ".to_string();
     };
-    let Some(rel) = source.get(kept_end..).and_then(|rest| rest.find('}')) else {
-        return " ";
+    let params = params_range(block, source).filter(|(start, end)| start != end);
+    let anchor = params.map_or(expr_end as usize, |(_, end)| end);
+    let Some(rel) = source.get(anchor..).and_then(|rest| rest.find('}')) else {
+        return " ".to_string();
     };
-    let close = kept_end + rel + 1;
-    if kept_end < close - 1 {
-        kept_end += 1;
+    let end = anchor + rel + 1;
+    // `transform` widens a kept range by one character so the mapping of what
+    // follows is not one character short.
+    let widen = |(start, stop): (usize, usize)| {
+        if stop + 1 < end {
+            (start, stop + 1)
+        } else {
+            (start, stop)
+        }
+    };
+    let mut ranges = Vec::with_capacity(2);
+    if expr_start != expr_end {
+        ranges.push(widen((expr_start as usize, expr_end as usize)));
     }
-    if close - kept_end >= 2 { "  " } else { " " }
+    if let Some(range) = params {
+        ranges.push(widen(range));
+    }
+    ranges.sort_unstable();
+    let mut remove_start = block.start as usize;
+    let mut spaces = 0usize;
+    for (start, stop) in ranges {
+        if remove_start < start && start < end {
+            spaces += 1;
+        }
+        remove_start = stop;
+    }
+    // The first character after the last kept range is deleted outright; only
+    // what is still left before `}` collapses into a final space.
+    if remove_start < end {
+        remove_start += 1;
+    }
+    if remove_start < end {
+        spaces += 1;
+    }
+    " ".repeat(spaces)
 }
 
 pub fn handle_snippet_block_inner(

--- a/crates/rsvelte_projection/tests/svelte2tsx_snippet_header_padding.rs
+++ b/crates/rsvelte_projection/tests/svelte2tsx_snippet_header_padding.rs
@@ -1,0 +1,82 @@
+//! #3255: the padding in front of a standalone `{#snippet}`'s `const` is the
+//! number of non-empty gaps between the ranges upstream's `transform()` keeps,
+//! not the width of the region after the last one. Everything svelte2tsx emits
+//! is one MagicString, so one missing space shifts every later mapping.
+//!
+//! Expectations were measured against the official `svelte2tsx` from
+//! `submodules/language-tools` on the same sources.
+
+use rsvelte_projection::svelte2tsx::{Svelte2TsxOptions, svelte2tsx};
+
+fn convert(header: &str) -> String {
+    let src = format!("<script lang=\"ts\"></script>\n{{#snippet {header}}}x{{/snippet}}\n");
+    let opts = Svelte2TsxOptions {
+        filename: "Probe.svelte".to_string(),
+        ..Default::default()
+    };
+    svelte2tsx(&src, opts).expect("svelte2tsx ok").code
+}
+
+fn pad_width(code: &str) -> usize {
+    let at = code.find("const s").expect("snippet declaration");
+    code[..at].len() - code[..at].trim_end_matches(' ').len()
+}
+
+/// One space when the parameter range starts flush against the name range —
+/// i.e. only the `(` separates them, and `transform`'s widening consumed it.
+#[test]
+fn a_flush_parameter_list_gets_one_space() {
+    for header in ["s(a)", "s(a, b)", "s(a , b)"] {
+        assert_eq!(pad_width(&convert(header)), 1, "header {header:?}");
+    }
+}
+
+/// Two spaces once anything sits between the name and the first parameter —
+/// a space, a tab, a type parameter list, or a line break. rsvelte measured the
+/// tail instead, so every one of these was one space short.
+#[test]
+fn a_gap_before_the_first_parameter_adds_a_space() {
+    for header in [
+        "s (a)",
+        "s  (a)",
+        "s( a)",
+        "s(  a)",
+        "s\t(a)",
+        "s<T>(a)",
+        "s<T,U>(a)",
+        "s<T extends string>(a)",
+        "s<T,>(a)",
+    ] {
+        assert_eq!(pad_width(&convert(header)), 2, "header {header:?}");
+    }
+}
+
+/// A parameterless snippet keeps its single kept range, and the tail collapses
+/// into the second space — unchanged by the fix.
+#[test]
+fn a_parameterless_snippet_is_unaffected() {
+    for header in ["s()", "s( )", "s<T>()"] {
+        assert_eq!(pad_width(&convert(header)), 2, "header {header:?}");
+    }
+}
+
+/// A formatted multi-line parameter list opens a gap *and* leaves a tail, so it
+/// takes three spaces.
+#[test]
+fn a_multi_line_parameter_list_counts_both_gaps_and_the_tail() {
+    assert_eq!(pad_width(&convert("s(\n\ta\n)")), 3);
+    assert_eq!(pad_width(&convert("s (\n\ta\n)")), 3);
+}
+
+/// Padding is emitted before `const`, so a missing space shifts the offset of
+/// everything downstream of it in the generated text.
+#[test]
+fn the_pad_shifts_every_later_offset() {
+    let flush = convert("s(a)");
+    let gapped = convert("s (a)");
+    assert_eq!(
+        gapped.find("const s").unwrap(),
+        flush.find("const s").unwrap() + 1,
+        "the extra gap must move the declaration by exactly one character"
+    );
+}


### PR DESCRIPTION
Closes #3255

## What

`opener_pad` was a hand-derived reimplementation of upstream's `transform()` padding that measured the **tail** — the region between the last kept range and the header's `}`. The real rule is about the **gaps between the kept ranges**: `transform` (`htmlxtojsx_v2/utils/node-utils.ts`) walks the sorted moves and overwrites each non-empty gap *before* a range with exactly one space, then deletes one character after the last range and collapses whatever is still left before `end` into one more.

So the count is (number of non-empty gaps preceding a kept range) + (a trailing space, if anything survives the one-character delete). The two coincide only when the parameter range starts flush against the name range, which is every shape the corpus contains.

`params_text` is now split so the parameter range is computed once and shared with the pad, and the pad reproduces `transform`'s widening (`tEnd += 1` while `tEnd < end - 1`) rather than approximating it.

## Measurement

Oracle: the official `svelte2tsx` built from `submodules/language-tools` at the pinned svelte (5.56.9). Grid: 32 `{#snippet}` headers × 3 hosts (standalone in the template, as an implicit component prop, and standalone after a sibling so the hoisting path runs) = 96 cells, all compiled on both sides, compared byte-for-byte.

| | identical |
|---|---|
| before | **80 / 96** |
| after | **96 / 96** |

The 16 that moved are the "no" column of the issue's table plus the multi-line forms: `s (a)`, `s  (a)`, `s( a)`, `s(  a)`, `s\t(a)`, `s<T>(a)`, `s<T,U>(a)`, `s<T extends string>(a)`, `s<T,>(a)`, and a formatted `s(\n\ta\n)` — which needs **three** spaces, because it opens a gap *and* leaves a tail. That third case is the one a tail-measuring heuristic can never reach, and it is the realistic one: an ordinary prettier-formatted parameter list.

Every "yes" row is kept as a negative control in the grid and in the test.

## Which gate sees this

Both, and this is the point of the issue. The svelte2tsx **TSX-text** gate (`compatibility/svelte2tsx-known-failures.json`) sees the missing space as a text divergence, but the **source-map** gate (`compatibility/svelte2tsx-map-known-failures.json`) is where the damage is: svelte2tsx is MagicString-based, so one dropped character in the padding shifts the generated offset of every mapping after it in the file. A text gate that happened to be listed for the entry would suppress the mapping shift with it.

The last test in the new file asserts that shift directly: `s (a)` must place `const s` exactly one character later than `s(a)`.

## Tests

`crates/rsvelte_projection/tests/svelte2tsx_snippet_header_padding.rs` — 5 tests, expectations measured against the oracle.
