### PR TITLE
fix(server): lower a $effect.pending() declarator initializer to void 0

### DIFF
--- a/.changeset/lucky-jokes-invite.md
+++ b/.changeset/lucky-jokes-invite.md
@@ -1,0 +1,5 @@
+---
+'@rsvelte/compiler': patch
+---
+
+Lower a `$effect.pending()` declarator initializer to `void 0` on the server, matching upstream's `VariableDeclaration` visitor, instead of applying the call-expression rule that produces `0`. The `.svelte.js` module path already did this; the component instance script did not.

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/script.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/script.rs
@@ -1081,6 +1081,32 @@ impl<'a> VisitMut<'a> for EffectValueLower<'a> {
         }
         oxc_ast_visit::walk_mut::walk_expression(self, expr);
     }
+
+    fn visit_variable_declarator(&mut self, decl: &mut oxc_ast::ast::VariableDeclarator<'a>) {
+        // Upstream's server `VariableDeclaration` visitor takes `args[0] ?? void 0`
+        // for a rune it does not special-case, so a declarator initializer never
+        // reaches the `CallExpression` visitor that lowers `$effect.pending()`
+        // to `0`. `effect_pending_ast.rs` already implements this for modules.
+        if decl.init.as_ref().is_some_and(is_effect_pending_call) {
+            decl.init = Some(self.b.void0());
+            return;
+        }
+        oxc_ast_visit::walk_mut::walk_variable_declarator(self, decl);
+    }
+}
+
+/// `$effect.pending(…)` as a call expression.
+fn is_effect_pending_call(expr: &OxcExpression) -> bool {
+    let OxcExpression::CallExpression(call) = expr else {
+        return false;
+    };
+    let OxcExpression::StaticMemberExpression(m) = &call.callee else {
+        return false;
+    };
+    let OxcExpression::Identifier(obj) = &m.object else {
+        return false;
+    };
+    obj.name.as_str() == "$effect" && m.property.name.as_str() == "pending"
 }
 
 /// Tree-wide nested-rune lowering for the bodies of NESTED functions / blocks

--- a/crates/rsvelte_core/tests/server_effect_pending_declarator_3213.rs
+++ b/crates/rsvelte_core/tests/server_effect_pending_declarator_3213.rs
@@ -1,0 +1,81 @@
+//! Upstream's server `VariableDeclaration` visitor takes `args[0] ?? void 0`
+//! for a rune it does not special-case, so a declarator initializer never
+//! reaches the `CallExpression` visitor that lowers `$effect.pending()` to `0`
+//! (#3213). rsvelte applied the call-expression rule everywhere, so a component
+//! instance script emitted `let v = 0`.
+//!
+//! `server/effect_pending_ast.rs` — the `.svelte.js` module path — already had
+//! the declarator rule and its own test for it, so the two ports of one
+//! upstream visitor disagreed with each other.
+//!
+//! Every expectation here is the official compiler's output for the same source.
+
+use rsvelte_core::{CompileOptions, GenerateMode, compile};
+
+fn server(script: &str) -> String {
+    compile(
+        &format!("<script>\n\t{script}\n</script>\n<b>x</b>"),
+        CompileOptions {
+            filename: Some("T.svelte".into()),
+            generate: GenerateMode::Server,
+            dev: false,
+            ..Default::default()
+        },
+    )
+    .map(|r| r.js.code)
+    .unwrap_or_else(|e| format!("COMPILE_ERROR: {e:?}"))
+}
+
+#[test]
+fn a_declarator_initializer_is_void_0() {
+    for (script, expected) in [
+        ("let v = $effect.pending();", "let v = void 0;"),
+        ("const v = $effect.pending();", "const v = void 0;"),
+        (
+            "let a = 1, v = $effect.pending(), c = 3;",
+            "let v = void 0;",
+        ),
+        (
+            "function f() { let v = $effect.pending(); return v; }\n\tlet q = f();",
+            "let v = void 0;",
+        ),
+    ] {
+        let out = server(script);
+        assert!(
+            out.contains(expected),
+            "{script}\nexpected {expected}\n{out}"
+        );
+    }
+}
+
+#[test]
+fn every_other_position_is_still_zero() {
+    // The negative control: outside a declarator initializer the call-expression
+    // rule still applies, so the fix must not become a blanket `void 0`.
+    for (script, expected) in [
+        ("let v = 1 + $effect.pending();", "let v = 1 + 0;"),
+        ("const o = { p: $effect.pending() };", "p: 0"),
+    ] {
+        let out = server(script);
+        assert!(
+            out.contains(expected),
+            "{script}\nexpected {expected}\n{out}"
+        );
+    }
+}
+
+#[test]
+fn an_allow_listed_rune_keeps_its_call_lowering() {
+    // `$effect.tracking` and `$effect.root` ARE on upstream's declarator
+    // allow-list, so their initializers do reach the call-expression visitor.
+    assert!(
+        server("let v = $effect.tracking();").contains("let v = false;"),
+        "{}",
+        server("let v = $effect.tracking();")
+    );
+    assert!(
+        server("let v = $effect.root(() => {});").contains("let v = () => {};"),
+        "{}",
+        server("let v = $effect.root(() => {});")
+    );
+}

--- a/upstream_issues/3213-svelte-inspect-declarator-emits-two-semicolons.md
+++ b/upstream_issues/3213-svelte-inspect-declarator-emits-two-semicolons.md
@@ -1,0 +1,81 @@
+# Svelte emits `let v = ;;` for a declarator initialized by `$inspect(...)`
+
+The official Svelte compiler (v5.56.9) emits text no JavaScript parser accepts when
+`$inspect(...)` is used as a declarator initializer, on **both** the client and the server.
+`$inspect(...).with(...)` in the same position is worse: the client drops the declaration
+and the server keeps the `.with` **handler** as the declared value.
+
+`$inspect` is a statement rune — it returns nothing — so the input is degenerate. But
+"degenerate" is what `e.rune_invalid_usage` exists for; emitting a `SyntaxError` from a
+compile that reports success is a different outcome from rejecting it.
+
+## Mechanism
+
+`phases/3-transform/{client,server}/visitors/VariableDeclaration.js` open their runes branch
+with a skip list that keeps the declarator and visits it normally:
+
+```js
+if (!rune || rune === '$effect.tracking' || rune === '$effect.root' ||
+    rune === '$inspect' || rune === '$inspect.trace' ||
+    rune === '$state.snapshot' || rune === '$host') {
+    declarations.push(context.visit(declarator));
+    continue;
+}
+```
+
+`$inspect` is on that list, so the declarator survives — and then the `CallExpression`
+visitor lowers `$inspect(...)` to a statement-shaped replacement with no expression value,
+so the printer emits an empty initializer followed by the lowered statement's own `;`.
+
+This is the mirror image of [#3173](https://github.com/baseballyama/rsvelte/issues/3173):
+there, `$effect.pending` / `$state.eager` are **absent** from the list and the declarator is
+dropped; here, `$inspect` is **present** and the declarator is kept but has nothing to
+initialize it with. One list, two opposite failures.
+
+## Reproduction
+
+```js
+// m.svelte.js — compileModule(src, { generate: 'client' | 'server' })
+let v = $inspect(1);
+```
+
+| source | client | server |
+|---|---|---|
+| `let v = $inspect(1);` | `let v = ;;` | `let v = ;;` |
+| `const v = $inspect(1);` | `const v = ;;` | `const v = ;;` |
+| `export const v = $inspect(1);` | `export const v = ;;` | `export const v = ;;` |
+| `for (let v = $inspect(1); ; ) {}` | `for (let v = ;; ; ) {}` | `for (let v = ;; ; ) {}` |
+| `let a = 1, v = $inspect(1), c = 3;` | `let a = 1, v = ;, c = 3;` | `let a = 1, v = ;, c = 3;` |
+| `let v = $inspect(1).with(() => {});` | *(whole declaration dropped)* | `let v = () => {};` |
+
+Every row in the first five is a `SyntaxError` for every JS parser, so a build using this
+output fails at bundle time rather than at run time.
+
+The last row is the quiet one: on the server `v` is bound to the `.with` **callback**, which
+is a plausible-looking value the author never wrote, and nothing warns.
+
+The same shapes reproduce in a component `<script>` as well as in a `.svelte.js` module.
+
+## What rsvelte does today
+
+Neither compiler is right here, and rsvelte is wrong differently:
+
+| source | rsvelte client | rsvelte server |
+|---|---|---|
+| `let v = $inspect(1);` | `let v = ;` — **also does not parse** | `let v = $inspect(1);` — `$inspect is not defined` at run time |
+| `let v = $inspect(1).with(() => {});` | `let v = ;` | `let v = $inspect(1).with(() => {});` |
+
+So this is not only an upstream report. rsvelte's client output is unparseable on its own
+account, and its server output leaves a rune call in the emitted module. Tracked locally as
+[#3213](https://github.com/baseballyama/rsvelte/issues/3213) row 3.
+
+Byte equality with upstream is this project's goal, but reproducing `let v = ;;` would mean
+deliberately emitting text no parser accepts — the class the parse gate exists to prevent —
+so matching is not the obvious answer and the cells want an explicit decision. The
+well-formed option consistent with #3173's reasoning is `let v = void 0;` on both targets:
+it parses, it is what upstream's own server visitor produces for a rune with no dedicated
+arm (`args[0] ?? void 0`), and it makes `typeof v` answer `"undefined"` rather than throwing.
+
+Desired upstream behavior: either reject `$inspect` in a value position with
+`rune_invalid_usage`, or give the skip-listed statement runes the same
+`args[0] ?? b.void0` fall-through the server's non-skip-listed path already has.


### PR DESCRIPTION
Part of #3213 — the **server** half of its row 1. The other two rows and the
client half of row 1 are decisions rather than fixes, and are written up at the
bottom rather than guessed at.

Refs #3213

## Cause

Upstream's server `VariableDeclaration` visitor handles a rune declarator before
the `CallExpression` visitor ever sees it:

```js
// 3-transform/server/visitors/VariableDeclaration.js
if (!rune || rune === '$effect.tracking' || rune === '$inspect' || rune === '$effect.root') {
    declarations.push(context.visit(declarator));   // ← allow-list: keep visiting
    continue;
}
…
const args = init.arguments;
const value = args.length > 0 ? context.visit(args[0]) : b.void0;   // ← everything else
```

`$effect.pending` is not on that allow-list and takes no arguments, so a
declarator initializer becomes `void 0`. rsvelte instead applied the
call-expression rule (`$effect.pending()` → `b.literal(0)`,
`server/ast/script.rs::EffectValueLower`) tree-wide, including inside declarator
initializers, and emitted `let v = 0`.

**rsvelte already had this rule — in the other port.**
`server/effect_pending_ast.rs` is the `.svelte.(js|ts)` module path and its test
`a_declarator_initializer_folds_to_void_0` asserts exactly `let x = void 0;`.
The component instance script is a second port of the same upstream visitor and
did not. That is the "two ports of one upstream function, and no gate compares
the ports" shape recorded in AGENTS.md for #3027, one file over.

## Measurement

Generated grid: 14 declaration shapes × 7 reference bodies × 2 targets (196
cells), official vs rsvelte, comparing generated JS.

| group | server cells on `main` | after |
|---|---|---|
| `let v = $effect.pending()` | 7 diverging | **0** |
| `const v = $effect.pending()` | 7 diverging | **0** |

Server total goes 28 → 14; the remaining 14 are the `$inspect` rows, which are
#3213's row 3 and are **not** a fix (see below). Client cells are untouched by
this PR.

## Negative control

`every_other_position_is_still_zero`: outside a declarator initializer the call
rule still applies, so `let v = 1 + $effect.pending()` stays `1 + 0` and
`{ p: $effect.pending() }` stays `{ p: 0 }`. A blanket `void 0` would break both.

`an_allow_listed_rune_keeps_its_call_lowering`: `$effect.tracking` and
`$effect.root` **are** on upstream's allow-list, so their initializers do reach
the call visitor — `let v = false` and `let v = () => {}` must not move.

The declarator rule also applies at any nesting depth and to any declarator in a
list, both of which are covered (`function f() { let v = … }`,
`let a = 1, v = …, c = 3`) because upstream's visitor is a tree-wide zimmerframe
visitor, not a top-level pass.

## What this PR deliberately does not do

**Row 1, client half — already decided, and the issue text did not know it.**
Upstream drops the whole declaration, so a later `typeof v` references an
undeclared name and throws. That is
`upstream_issues/3173-svelte-client-drops-an-eager-declarator.md`, already in
the tree: `$effect.pending` and `$state.eager` are missing from
`client/visitors/VariableDeclaration.js`'s skip list and match none of its arms,
so the loop iteration pushes nothing. The recorded decision is that rsvelte
**deliberately does not reproduce it** — it keeps the declarator and lowers the
initializer to `$.eager($.pending)` — and the cells are an accepted divergence.
Nothing to do here; #3213's row 1 is closed on the client side by that entry.

**Row 3, `$inspect` in a value position — the entry it asked for is in this PR.**
`$inspect` **is** on the skip list, so the declarator is kept and visited, and
the visit yields nothing. Same list as row 1, opposite failure. Measured on both
targets and five declarator shapes:

| source | official (both targets) | rsvelte client | rsvelte server |
|---|---|---|---|
| `let v = $inspect(1);` | `let v = ;;` | `let v = ;` | `let v = $inspect(1);` |
| `export const v = $inspect(1);` | `export const v = ;;` | — | — |
| `for (let v = $inspect(1); ; ) {}` | `for (let v = ;; ; ) {}` | — | — |
| `let a = 1, v = $inspect(1), c = 3;` | `let a = 1, v = ;, c = 3;` | `let v = ;` | `let v = $inspect(1);` |
| `let v = $inspect(1).with(() => {});` | client: declaration dropped; server: `let v = () => {};` | `let v = ;` | verbatim |

Two things the issue's one-line summary does not say. **rsvelte's client output
does not parse either** — `let v = ;` is its own defect, not a byte-equality
question — and its server output leaves the rune call in the emitted module, so
it throws `$inspect is not defined`. And upstream's `.with` row is the quiet
one: the server binds `v` to the `.with` **callback**, a plausible-looking value
nobody wrote.

`upstream_issues/3213-svelte-inspect-declarator-emits-two-semicolons.md` (second
commit) records all of that and proposes `let v = void 0;` on both targets as
the well-formed option — it parses, it is what upstream's own server visitor
produces for a rune with no dedicated arm (`args[0] ?? void 0`), and it makes
`typeof v` answer `"undefined"` instead of throwing. That is a product decision,
so it is written down rather than implemented here.

**Row 2 is not what the issue describes and is filed separately.** The issue
reads it as a `typeof`-specific disagreement; it is not. Upstream's rule is
`has_state ||= … && !scope.evaluate(node).is_known` (`2-analyze/visitors/Identifier.js`),
so **any** read of a `$derived` whose argument evaluates to a known constant is
non-reactive — `b.textContent = $.get(v)` with a `<b></b>` template, no
`template_effect`. Measured across the same grid it is 12 client cells
(`$derived` and `$derived.by` × bare / `typeof` / `void` / `!` / concat /
attribute), not 3, and `$derived.by(() => { return 1; })` is the control that
stays reactive because upstream only evaluates expression-bodied arrows.
rsvelte sets `has_state` from the binding **kind** alone with no `is_known`
gate, and phase 2 has no `scope.evaluate` port to add one with. AGENTS.md
already records that "is this value known" has five implementations in the
client plus the server's typed `EvalValue`, and that the recorded direction is
unification rather than a sixth — so this needs its own issue and its own
design, not a patch here. Filed as **#3437**.

The same grid also found a fourth thing the issue does not mention: `void
<unknown>` is not folded. `void` is `undefined` whatever the operand is, so
upstream's `Evaluation` gives it one concrete value even on the unknown-operand
arm; rsvelte folds only when the operand is already known, and otherwise emits a
reactive effect. 16 of 100 cells across 10 declaration shapes, all client, with
`let v = 1` / `$state(1)` / `{void 0}` as the byte-identical control. Filed as
**#3439**; it is the same client evaluator as #3437, so the two want one
evaluator between them rather than two arm-level patches.

## Tests

`crates/rsvelte_core/tests/server_effect_pending_declarator_3213.rs` (3 tests,
every expectation taken from the official compiler's output for the same
source). Suites run green: `ssr`, `compiler_fixtures`.
