### PR TITLE
fix(analyze): separate the slot-owner and svelte:fragment-parent rules

### DIFF
--- a/.changeset/direct-component-parent-split.md
+++ b/.changeset/direct-component-parent-split.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/compiler": patch
+---
+
+Separate the two questions asked of a node's component-like parent. Upstream's `validate_slot_attribute` treats `Component`, `SvelteComponent`, `SvelteSelf` **and** `SvelteElement` as slot owners, while `SvelteFragment.js` accepts only `Component` and `SvelteComponent` as a `<svelte:fragment>` parent. rsvelte answered both from one boolean, so `<svelte:self>` rejected a legal `<b slot="named">` child and `<svelte:element>` accepted a `<svelte:fragment>` the official compiler rejects. The flag is now a three-valued `DirectComponentParent`, which cannot desync the way two parallel booleans would.

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/await_block.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/await_block.rs
@@ -148,11 +148,11 @@ pub fn visit<'a, 'b: 'a>(
     // Increment block depth for child analysis
     context.block_depth += 1;
 
-    // Clear is_direct_child_of_component since children of control flow blocks
+    // Clear direct_component_parent since children of control flow blocks
     // are not direct children of a component
-    let was_direct_child = context.is_direct_child_of_component;
+    let was_direct_child = context.direct_component_parent;
     let was_direct_snippet = context.is_direct_child_of_snippet;
-    context.is_direct_child_of_component = false;
+    context.direct_component_parent = super::DirectComponentParent::None;
     context.is_direct_child_of_snippet = false;
 
     // Push fragment owner type for const_tag placement validation
@@ -206,8 +206,8 @@ pub fn visit<'a, 'b: 'a>(
     // Pop fragment owner type
     context.fragment_owner_stack.pop();
 
-    // Restore is_direct_child_of_component
-    context.is_direct_child_of_component = was_direct_child;
+    // Restore direct_component_parent
+    context.direct_component_parent = was_direct_child;
     context.is_direct_child_of_snippet = was_direct_snippet;
 
     // Decrement block depth

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/each_block.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/each_block.rs
@@ -126,11 +126,11 @@ pub fn visit<'a, 'b: 'a>(
         child_count,
     }));
 
-    // Clear is_direct_child_of_component since children of control flow blocks
+    // Clear direct_component_parent since children of control flow blocks
     // are not direct children of a component
-    let was_direct_child = context.is_direct_child_of_component;
+    let was_direct_child = context.direct_component_parent;
     let was_direct_snippet = context.is_direct_child_of_snippet;
-    context.is_direct_child_of_component = false;
+    context.direct_component_parent = super::DirectComponentParent::None;
     context.is_direct_child_of_snippet = false;
 
     // Push fragment owner type for const_tag placement validation
@@ -177,8 +177,8 @@ pub fn visit<'a, 'b: 'a>(
     // Pop fragment owner type
     context.fragment_owner_stack.pop();
 
-    // Restore is_direct_child_of_component
-    context.is_direct_child_of_component = was_direct_child;
+    // Restore direct_component_parent
+    context.direct_component_parent = was_direct_child;
     context.is_direct_child_of_snippet = was_direct_snippet;
 
     // Visit the key expression if present

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/if_block.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/if_block.rs
@@ -70,11 +70,11 @@ pub fn visit<'a, 'b: 'a>(
     context.block_depth += 1;
     context.svelte_self_parent_depth += 1;
 
-    // Clear is_direct_child_of_component since children of control flow blocks
+    // Clear direct_component_parent since children of control flow blocks
     // are not direct children of a component
-    let was_direct_child = context.is_direct_child_of_component;
+    let was_direct_child = context.direct_component_parent;
     let was_direct_snippet = context.is_direct_child_of_snippet;
-    context.is_direct_child_of_component = false;
+    context.direct_component_parent = super::DirectComponentParent::None;
     context.is_direct_child_of_snippet = false;
 
     // Push fragment owner type for const_tag placement validation
@@ -111,8 +111,8 @@ pub fn visit<'a, 'b: 'a>(
     // Pop fragment owner type
     context.fragment_owner_stack.pop();
 
-    // Restore is_direct_child_of_component
-    context.is_direct_child_of_component = was_direct_child;
+    // Restore direct_component_parent
+    context.direct_component_parent = was_direct_child;
     context.is_direct_child_of_snippet = was_direct_snippet;
 
     // Decrement block depth

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/key_block.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/key_block.rs
@@ -57,11 +57,11 @@ pub fn visit<'a, 'b: 'a>(
         context.parse_arena,
     );
 
-    // Clear is_direct_child_of_component since children of control flow blocks
+    // Clear direct_component_parent since children of control flow blocks
     // are not direct children of a component
-    let was_direct_child = context.is_direct_child_of_component;
+    let was_direct_child = context.direct_component_parent;
     let was_direct_snippet = context.is_direct_child_of_snippet;
-    context.is_direct_child_of_component = false;
+    context.direct_component_parent = super::DirectComponentParent::None;
     context.is_direct_child_of_snippet = false;
 
     // Push fragment owner type for const_tag placement validation
@@ -82,8 +82,8 @@ pub fn visit<'a, 'b: 'a>(
     // Pop fragment owner type
     context.fragment_owner_stack.pop();
 
-    // Restore is_direct_child_of_component
-    context.is_direct_child_of_component = was_direct_child;
+    // Restore direct_component_parent
+    context.direct_component_parent = was_direct_child;
     context.is_direct_child_of_snippet = was_direct_snippet;
 
     Ok(())

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/mod.rs
@@ -446,10 +446,10 @@ pub struct VisitorContext<'a> {
     /// it checks if its direct parent is an EachBlock by checking the top of this stack.
     /// When entering an element, we push None to indicate we're no longer directly in the EachBlock.
     pub each_block_stack: Vec<Option<EachBlockContext>>,
-    /// Tracks if we're directly inside a component (for svelte:fragment validation).
-    /// This is set to true when entering a Component/SvelteComponent, and reset to false
-    /// when entering any other element type.
-    pub is_direct_child_of_component: bool,
+    /// Which component-like node is the immediate parent, if any. Set when
+    /// entering a Component / `<svelte:component>` / `<svelte:self>`, and reset
+    /// when entering any other element or block.
+    pub direct_component_parent: DirectComponentParent,
     /// True while analyzing the *direct* children of a `{#snippet}` body. Mirrors
     /// upstream's `context.path.at(-2)?.type === 'SnippetBlock'` check in
     /// `validate_slot_attribute`: a `slot="…"` text attribute on an element whose
@@ -485,6 +485,36 @@ pub struct VisitorContext<'a> {
     /// on exit, pops entries back to that marker in LIFO order to reverse exactly the
     /// declarations added during that scope — replacing a full clone/restore of the map.
     pub decl_undo_log: Vec<(String, Option<usize>)>,
+}
+
+/// Which component-like node, if any, is the immediate parent of the node being
+/// visited. Upstream reads two different sets off this position and they are not
+/// the same: `<svelte:fragment>` is legal only under `Component` /
+/// `SvelteComponent` (`SvelteFragment.js`), while `validate_slot_attribute`'s
+/// owner set also holds `SvelteSelf` and `SvelteElement`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum DirectComponentParent {
+    /// Anything that owns no slots — a plain element, a block, the root.
+    #[default]
+    None,
+    /// `<Foo>` or `<svelte:component>` — also the only legal `<svelte:fragment>`
+    /// parents.
+    Component,
+    /// `<svelte:self>` or `<svelte:element>`: a slot owner that `SvelteFragment.js`
+    /// does not name.
+    SlotOwnerOnly,
+}
+
+impl DirectComponentParent {
+    /// Whether a `slot="…"` on a direct child has a component owner here.
+    pub fn owns_slots(self) -> bool {
+        self != DirectComponentParent::None
+    }
+
+    /// Whether a `<svelte:fragment>` may sit directly inside.
+    pub fn hosts_svelte_fragment(self) -> bool {
+        self == DirectComponentParent::Component
+    }
 }
 
 /// Type of ancestor that can "own" a slot attribute.
@@ -589,7 +619,7 @@ impl<'a> VisitorContext<'a> {
             element_ancestors: Vec::new(),
             block_depth_at_element: Vec::new(),
             each_block_stack: Vec::new(),
-            is_direct_child_of_component: false,
+            direct_component_parent: DirectComponentParent::None,
             is_direct_child_of_snippet: false,
             slot_owner_ancestors: Vec::new(),
             fragment_owner_stack: vec![FragmentOwnerType::Root],

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/regular_element.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/regular_element.rs
@@ -872,10 +872,10 @@ pub fn visit<'a, 'b: 'a>(
     // Push None to each_block_stack to indicate we're no longer directly in an EachBlock
     context.each_block_stack.push(None);
 
-    // Clear is_direct_child_of_component since we're now inside an element
-    let was_direct_child = context.is_direct_child_of_component;
+    // Clear direct_component_parent since we're now inside an element
+    let was_direct_child = context.direct_component_parent;
     let was_direct_snippet = context.is_direct_child_of_snippet;
-    context.is_direct_child_of_component = false;
+    context.direct_component_parent = super::DirectComponentParent::None;
     context.is_direct_child_of_snippet = false;
 
     // Push fragment owner type for const_tag placement validation
@@ -1090,8 +1090,8 @@ pub fn visit<'a, 'b: 'a>(
     // Pop fragment owner type
     context.fragment_owner_stack.pop();
 
-    // Restore is_direct_child_of_component
-    context.is_direct_child_of_component = was_direct_child;
+    // Restore direct_component_parent
+    context.direct_component_parent = was_direct_child;
     context.is_direct_child_of_snippet = was_direct_snippet;
 
     // Pop from each_block_stack

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/shared/attribute.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/shared/attribute.rs
@@ -115,7 +115,7 @@ pub fn validate_slot_attribute(
     attribute: &AttributeNode,
 ) -> Result<(), AnalysisError> {
     // Check if we're a direct child of a component
-    if context.is_direct_child_of_component {
+    if context.direct_component_parent.owns_slots() {
         return Ok(());
     }
 

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/shared/component.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/shared/component.rs
@@ -251,10 +251,10 @@ pub fn visit_component<'a, 'b: 'a>(
     // 3. Visit each slot's content with the correct scope
     //
     // For now, just visit the fragment normally
-    // Set is_direct_child_of_component for svelte:fragment validation
-    let was_direct_child = context.is_direct_child_of_component;
+    // Set direct_component_parent for svelte:fragment validation
+    let was_direct_child = context.direct_component_parent;
     let was_direct_snippet = context.is_direct_child_of_snippet;
-    context.is_direct_child_of_component = true;
+    context.direct_component_parent = super::super::DirectComponentParent::Component;
     context.is_direct_child_of_snippet = false;
     // Track component depth for slot attribute validation
     context.component_depth += 1;
@@ -295,7 +295,7 @@ pub fn visit_component<'a, 'b: 'a>(
     context.slot_owner_ancestors.pop();
     context.component_depth -= 1;
     context.svelte_self_parent_depth -= 1;
-    context.is_direct_child_of_component = was_direct_child;
+    context.direct_component_parent = was_direct_child;
     context.is_direct_child_of_snippet = was_direct_snippet;
 
     Ok(())

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/svelte_component.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/svelte_component.rs
@@ -99,9 +99,9 @@ pub fn visit<'a, 'b: 'a>(
 
     // Set up component context for slot attribute validation
     // svelte:component is a component, so children with slot attributes should be valid
-    let was_direct_child = context.is_direct_child_of_component;
+    let was_direct_child = context.direct_component_parent;
     let was_direct_snippet = context.is_direct_child_of_snippet;
-    context.is_direct_child_of_component = true;
+    context.direct_component_parent = super::DirectComponentParent::Component;
     context.is_direct_child_of_snippet = false;
     context.component_depth += 1;
     context
@@ -138,7 +138,7 @@ pub fn visit<'a, 'b: 'a>(
     context.fragment_owner_stack.pop();
     context.slot_owner_ancestors.pop();
     context.component_depth -= 1;
-    context.is_direct_child_of_component = was_direct_child;
+    context.direct_component_parent = was_direct_child;
     context.is_direct_child_of_snippet = was_direct_snippet;
 
     Ok(())

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/svelte_element.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/svelte_element.rs
@@ -222,9 +222,9 @@ pub fn visit<'a, 'b: 'a>(
     // <svelte:element> can dynamically resolve to any element including custom elements,
     // so children with slot attributes should be allowed (they may be valid at runtime).
     // This matches how <svelte:component> allows slot attributes on its children.
-    let was_direct_child = context.is_direct_child_of_component;
+    let was_direct_child = context.direct_component_parent;
     let was_direct_snippet = context.is_direct_child_of_snippet;
-    context.is_direct_child_of_component = true;
+    context.direct_component_parent = super::DirectComponentParent::SlotOwnerOnly;
     context.is_direct_child_of_snippet = false;
     context
         .slot_owner_ancestors
@@ -300,7 +300,7 @@ pub fn visit<'a, 'b: 'a>(
     // Restore context
     context.fragment_owner_stack.pop();
     context.slot_owner_ancestors.pop();
-    context.is_direct_child_of_component = was_direct_child;
+    context.direct_component_parent = was_direct_child;
     context.is_direct_child_of_snippet = was_direct_snippet;
 
     Ok(())

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/svelte_fragment.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/svelte_fragment.rs
@@ -16,7 +16,7 @@ pub fn visit<'a, 'b: 'a>(
     context: &mut VisitorContext<'a>,
 ) -> Result<(), AnalysisError> {
     // svelte:fragment must be a direct child of a component
-    if !context.is_direct_child_of_component {
+    if !context.direct_component_parent.hosts_svelte_fragment() {
         return Err(errors::svelte_fragment_invalid_placement().at(frag.start, frag.end));
     }
 
@@ -55,13 +55,13 @@ pub fn visit<'a, 'b: 'a>(
     // Children are the fragment's, not the component's, so a `slot="…"` on one
     // is `slot_attribute_invalid_placement` upstream (`owner !== parent`) and a
     // nested `<svelte:fragment>` is invalid too.
-    let was_direct_child = context.is_direct_child_of_component;
-    context.is_direct_child_of_component = false;
+    let was_direct_child = context.direct_component_parent;
+    context.direct_component_parent = super::DirectComponentParent::None;
 
     // Analyze children
     fragment::analyze(&mut frag.fragment, context)?;
 
-    context.is_direct_child_of_component = was_direct_child;
+    context.direct_component_parent = was_direct_child;
 
     // Restore scope
     context.scope = old_scope;

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/svelte_self.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/svelte_self.rs
@@ -115,10 +115,25 @@ pub fn visit<'a, 'b: 'a>(
         }
     }
 
+    // Upstream reaches this node through `visit_component`, so a child carrying
+    // `slot="…"` has a component owner here exactly as it does under
+    // `<svelte:component>`.
+    let was_direct_child = context.direct_component_parent;
+    let was_direct_snippet = context.is_direct_child_of_snippet;
+    context.direct_component_parent = super::DirectComponentParent::SlotOwnerOnly;
+    context.is_direct_child_of_snippet = false;
+    context.component_depth += 1;
+    context
+        .slot_owner_ancestors
+        .push(super::SlotOwnerType::Component);
+
     // Analyze children
     // Enter the template scope the scope builder created for this node, the way
     // the plain-component visitor does. Without it a `{@render}` cannot see a
     // `{#snippet}` declared as its sibling here, so the tag reads as dynamic.
+    let saved_element_ancestors = std::mem::take(&mut context.element_ancestors);
+    let saved_block_depth_at_element = std::mem::take(&mut context.block_depth_at_element);
+    let saved_parent_element = context.parent_element.take();
     let saved_scope = context.scope;
     if let Some(&node_scope) = context.analysis.root.template_scope_map.get(&self_.start) {
         context.scope = node_scope;
@@ -129,6 +144,13 @@ pub fn visit<'a, 'b: 'a>(
     let result = fragment::analyze(&mut self_.fragment, context);
     context.fragment_owner_stack.pop();
     context.scope = saved_scope;
+    context.element_ancestors = saved_element_ancestors;
+    context.block_depth_at_element = saved_block_depth_at_element;
+    context.parent_element = saved_parent_element;
+    context.slot_owner_ancestors.pop();
+    context.component_depth -= 1;
+    context.direct_component_parent = was_direct_child;
+    context.is_direct_child_of_snippet = was_direct_snippet;
     result?;
 
     Ok(())

--- a/crates/rsvelte_core/tests/direct_component_parent_3141.rs
+++ b/crates/rsvelte_core/tests/direct_component_parent_3141.rs
@@ -1,0 +1,168 @@
+//! Which component-like node is the immediate parent decides two different
+//! upstream questions, and they name different sets.
+//!
+//! `validate_slot_attribute` (`2-analyze/visitors/shared/attribute.js`) treats
+//! `Component`, `SvelteComponent`, `SvelteSelf` **and** `SvelteElement` as slot
+//! owners, while `SvelteFragment.js` accepts only `Component` and
+//! `SvelteComponent` as a legal `<svelte:fragment>` parent. rsvelte answered both
+//! from one boolean, so `<svelte:self>` lost the first and `<svelte:element>` won
+//! the second.
+//!
+//! Every verdict here is the official compiler's, measured on the same source.
+
+use rsvelte_core::{CompileOptions, GenerateMode, compile};
+
+fn outcome(src: &str, generate: GenerateMode, dev: bool) -> Result<String, String> {
+    compile(
+        src,
+        CompileOptions {
+            filename: Some("T.svelte".to_string()),
+            generate,
+            dev,
+            ..Default::default()
+        },
+    )
+    .map(|r| r.js.code)
+    .map_err(|e| e.to_string())
+}
+
+/// All four targets the corpus compiles, since a placement rule lives in phase 2
+/// and must hold for every one of them.
+fn for_each_target(src: &str, mut check: impl FnMut(Result<String, String>, &str)) {
+    for (generate, dev, label) in [
+        (GenerateMode::Client, false, "client"),
+        (GenerateMode::Client, true, "client-dev"),
+        (GenerateMode::Server, false, "server"),
+        (GenerateMode::Server, true, "server-dev"),
+    ] {
+        check(outcome(src, generate, dev), label);
+    }
+}
+
+const HEAD: &str = "<script>\n\tlet { C, n, x, depth = 0 } = $props();\n</script>\n\n";
+
+/// Upstream's slot-owner walk names `SvelteSelf`, so this is legal code that
+/// rsvelte rejected.
+#[test]
+fn svelte_self_owns_the_slots_of_its_direct_children() {
+    let src = format!(
+        "{HEAD}{{#if depth < 2}}<svelte:self depth={{depth + 1}}><b slot=\"named\">{{n}}</b></svelte:self>{{/if}}\n"
+    );
+    for_each_target(&src, |result, label| {
+        let code = result.unwrap_or_else(|e| panic!("[{label}] rejected legal source: {e}"));
+        assert!(
+            code.contains("named:"),
+            "[{label}] the child did not become a slot prop:\n{code}"
+        );
+    });
+}
+
+/// The same shape one node over, which already worked and must keep working —
+/// it is what makes the row above a `<svelte:self>` statement rather than a
+/// statement about slots.
+#[test]
+fn svelte_component_owns_the_slots_of_its_direct_children() {
+    let src = format!(
+        "{HEAD}<svelte:component this={{C}}><b slot=\"named\">{{n}}</b></svelte:component>\n"
+    );
+    for_each_target(&src, |result, label| {
+        let code = result.unwrap_or_else(|e| panic!("[{label}] rejected legal source: {e}"));
+        assert!(
+            code.contains("named:"),
+            "[{label}] the child did not become a slot prop:\n{code}"
+        );
+    });
+}
+
+/// `<svelte:element>` is a slot owner too.
+#[test]
+fn svelte_element_owns_the_slots_of_its_direct_children() {
+    let src =
+        format!("{HEAD}<svelte:element this={{x}}><b slot=\"named\">{{n}}</b></svelte:element>\n");
+    for_each_target(&src, |result, label| {
+        result.unwrap_or_else(|e| panic!("[{label}] rejected legal source: {e}"));
+    });
+}
+
+/// …but it is not a legal `<svelte:fragment>` parent: `SvelteFragment.js` lists
+/// `Component` and `SvelteComponent` only. rsvelte accepted this.
+#[test]
+fn svelte_element_is_not_a_svelte_fragment_parent() {
+    let src = format!(
+        "{HEAD}<svelte:element this={{x}}><svelte:fragment slot=\"named\">{{n}}</svelte:fragment></svelte:element>\n"
+    );
+    for_each_target(&src, |result, label| {
+        let err = result.expect_err(&format!("[{label}] accepted what official rejects"));
+        assert!(
+            err.contains("svelte_fragment_invalid_placement"),
+            "[{label}] wrong diagnostic: {err}"
+        );
+    });
+}
+
+/// Neither is `<svelte:self>` — the case that a single "is a component" flag
+/// cannot tell apart from the slot-owner question above.
+#[test]
+fn svelte_self_is_not_a_svelte_fragment_parent() {
+    let src = format!(
+        "{HEAD}{{#if depth < 2}}<svelte:self depth={{depth + 1}}><svelte:fragment slot=\"named\">{{n}}</svelte:fragment></svelte:self>{{/if}}\n"
+    );
+    for_each_target(&src, |result, label| {
+        let err = result.expect_err(&format!("[{label}] accepted what official rejects"));
+        assert!(
+            err.contains("svelte_fragment_invalid_placement"),
+            "[{label}] wrong diagnostic: {err}"
+        );
+    });
+}
+
+/// The positive half of that pair, so the rule above is not satisfied by
+/// rejecting `<svelte:fragment>` everywhere.
+#[test]
+fn a_component_is_a_svelte_fragment_parent() {
+    let src = format!("{HEAD}<C><svelte:fragment slot=\"named\">{{n}}</svelte:fragment></C>\n");
+    for_each_target(&src, |result, label| {
+        result.unwrap_or_else(|e| panic!("[{label}] rejected legal source: {e}"));
+    });
+}
+
+/// `{@const}` placement reads a different stack, and `<svelte:self>` is absent
+/// from upstream's list there while `<svelte:component>` is present. Pinned
+/// because the fix above moves `<svelte:self>` closer to a component and must
+/// not move it here.
+#[test]
+fn const_tag_placement_still_separates_the_two() {
+    let under_self = format!(
+        "{HEAD}{{#if depth < 2}}<svelte:self depth={{depth + 1}}>{{@const c = n}}<b>{{c}}</b></svelte:self>{{/if}}\n"
+    );
+    for_each_target(&under_self, |result, label| {
+        let err = result.expect_err(&format!("[{label}] accepted what official rejects"));
+        assert!(
+            err.contains("const_tag_invalid_placement"),
+            "[{label}] wrong diagnostic: {err}"
+        );
+    });
+
+    let under_component = format!(
+        "{HEAD}<svelte:component this={{C}}>{{@const c = n}}<b>{{c}}</b></svelte:component>\n"
+    );
+    for_each_target(&under_component, |result, label| {
+        result.unwrap_or_else(|e| panic!("[{label}] rejected legal source: {e}"));
+    });
+}
+
+/// A `slot="…"` that is not a *direct* child is still a placement error, so the
+/// widened owner set did not widen into "anywhere below a component".
+#[test]
+fn a_slot_attribute_below_an_element_is_still_rejected() {
+    let src = format!(
+        "{HEAD}{{#if depth < 2}}<svelte:self depth={{depth + 1}}><div><b slot=\"named\">{{n}}</b></div></svelte:self>{{/if}}\n"
+    );
+    for_each_target(&src, |result, label| {
+        let err = result.expect_err(&format!("[{label}] accepted what official rejects"));
+        assert!(
+            err.contains("slot_attribute_invalid_placement"),
+            "[{label}] wrong diagnostic: {err}"
+        );
+    });
+}


### PR DESCRIPTION
One boolean was answering two upstream questions, and they name different sets.

| question | upstream site | accepted parents |
|---|---|---|
| does a child's `slot="…"` have an owner here? | `validate_slot_attribute`, `2-analyze/visitors/shared/attribute.js:68-77` | `Component`, `SvelteComponent`, **`SvelteSelf`**, **`SvelteElement`**, custom element |
| may a `<svelte:fragment>` sit here? | `SvelteFragment.js:12` | `Component`, `SvelteComponent` — **and nothing else** |

rsvelte read both off `is_direct_child_of_component: bool`, so it got one wrong in each
direction:

- `<svelte:self depth={depth + 1}><b slot="named">{n}</b></svelte:self>` — rsvelte
  `slot_attribute_invalid_placement`, official compiles it into a `named:` slot prop.
  **Over-rejection of legal code.**
- `<svelte:element this={x}><svelte:fragment slot="named">{n}</svelte:fragment></svelte:element>`
  — rsvelte compiles, official `svelte_fragment_invalid_placement`.
  **Over-acceptance.**

Both reproduce on all four targets.

## Fix

`DirectComponentParent { None, Component, SlotOwnerOnly }` replaces the flag, with the two
questions as two methods (`owns_slots()`, `hosts_svelte_fragment()`). `<svelte:self>` and
`<svelte:element>` set `SlotOwnerOnly`; `<Foo>` and `<svelte:component>` set `Component`.

Two parallel booleans would have worked and are the wrong shape: every block that clears
the flag on entry (`{#if}`, `{#each}`, `{#key}`, `{#await}`, an element, a
`<svelte:fragment>` body) would have to clear both, and a site that updates one is a
silent bug. One field cannot desync.

`<svelte:self>` additionally now enters the same child context `<svelte:component>` already
did — `component_depth`, `element_ancestors`, `parent_element` — which is what upstream's
shared `visit_component` does for all three nodes.

## How this was found, and what it says about #3141

#3141 reports two symptoms (`{#snippet}` under `<svelte:component>` / `<svelte:self>` not
becoming a slot prop, and `{@const}` accepted under `<svelte:self>`). **Both are already
fixed on `main`** by `fb0f87019` and `2873d6e75`; I re-measured the issue's own repros
against official and all 16 cells agree, so this PR does not close it.

What it does close is the rest of that family. Re-running the issue's approach — a
generated container × content × target grid, **11 containers × 26 contents × 4 targets =
1,144 cells**, comparing `js.code` *and* the warning `(code, line, column)` set against the
official compiler — left 8 divergences, and all 8 are the two shapes above.

Negative control: with the analyze hunks reverted and the test file kept, exactly
`svelte_self_owns_the_slots_of_its_direct_children` and
`svelte_element_is_not_a_svelte_fragment_parent` fail, on the predicted diagnostic; the six
control tests pass on both trees. Four of those six exist to stop the widened owner set
from widening too far — `{@const}` under `<svelte:self>` must **still** be
`const_tag_invalid_placement` (a different stack, and upstream's list there really does
omit `SvelteSelf`), a `<svelte:fragment>` under `<svelte:self>` must **still** be rejected,
and a `slot="…"` one element below a component must **still** be rejected.

After the fix the grid is at **1,144 compared, 10 divergent**, and those 10 are one
unrelated pre-existing shape now filed as #3434 (SSR `$$slots` emits `default: true`
before a named slot; reproduces on a plain `<C>`, so it is outside this change).

Suites run green: `direct_component_parent_3141`, `validator`, `compiler_errors`,
`compiler_fixtures`, `ssr`.

Refs #3141

🤖 Generated with [Claude Code](https://claude.com/claude-code)
