### PR TITLE
fix(svelte2tsx): raise the three $$Generic errors and match the exported declaration form

### DIFF
--- a/.changeset/s2t-dollar-generic-errors-and-export.md
+++ b/.changeset/s2t-dollar-generic-errors-and-export.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/svelte2tsx": patch
+---
+
+Raise the three `$$Generic` errors upstream raises — in the module script, alongside a `generics` attribute, and with more than one type argument — and recognise the declaration when it carries an `export` modifier, which upstream models as one type alias with a modifier so its matcher reaches it. The `$$Generic` reference is now matched on the AST rather than on the annotation's source text, so `type T = $$Generic < string >` is recognised too.

--- a/crates/rsvelte_projection/src/svelte2tsx/script/exported_names.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/script/exported_names.rs
@@ -38,6 +38,10 @@ pub struct ExportedNames {
     pub dollar_generics: Vec<(String, Option<String>)>,
     /// Source positions of `type X = $$Generic...` statements to blank out.
     pub dollar_generic_positions: Vec<(u32, u32)>,
+    /// Message of the first invalid `$$Generic` declaration found in the
+    /// instance script. Upstream throws from inside its walk; the walk here has
+    /// no error channel, so the caller turns this into the returned error.
+    pub dollar_generic_error: Option<String>,
     /// Type/interface declarations from instance script that should be hoisted
     /// before $$`render()`. Each entry is (start, end) relative to source (absolute positions).
     pub hoistable_type_ranges: Vec<(u32, u32)>,
@@ -310,6 +314,7 @@ impl ExportedNames {
             events_type_decl_pos: None,
             dollar_generics: Vec::new(),
             dollar_generic_positions: Vec::new(),
+            dollar_generic_error: None,
             hoistable_type_ranges: Vec::new(),
             dollar_generic_referenced_ranges: Vec::new(),
             props_let_abs_pos: None,

--- a/crates/rsvelte_projection/src/svelte2tsx/script/mod.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/script/mod.rs
@@ -110,6 +110,7 @@ pub fn process_instance_script(
     emit_jsdoc: bool,
     is_dts_mode: bool,
     script_generic_names: &HashSet<String>,
+    has_generics_attr: bool,
 ) -> Vec<LiftedImport> {
     let offset = script.content_offset;
     let mut instance_imports = Vec::new();
@@ -366,6 +367,18 @@ pub fn process_instance_script(
                                         rel_end: type_alias.span.end,
                                     });
                                 }
+                                // Upstream models `export type T = …` as one
+                                // TypeAliasDeclaration carrying an `export`
+                                // modifier, so `addIfIsGeneric` reaches it and
+                                // removes the declaration from the `export`
+                                // keyword onwards.
+                                add_if_is_dollar_generic(
+                                    type_alias,
+                                    export.span.start,
+                                    raw_content,
+                                    has_generics_attr,
+                                    exported_names,
+                                );
                             }
                             oxc::Declaration::TSInterfaceDeclaration(iface) => {
                                 let name = iface.id.name.to_string();
@@ -418,24 +431,13 @@ pub fn process_instance_script(
                             rel_end: type_alias.span.end,
                         });
                     }
-                    // Detect `type X = $$Generic;` or `type X = $$Generic<constraint>;`
-                    let type_text = &raw_content[type_alias.type_annotation.span().start as usize
-                        ..type_alias.type_annotation.span().end as usize];
-                    if type_text == "$$Generic" || type_text.starts_with("$$Generic<") {
-                        let name = type_alias.id.name.to_string();
-                        let constraint = if type_text.starts_with("$$Generic<") {
-                            // Extract the constraint from $$Generic<constraint>
-                            let inner = &type_text[10..type_text.len() - 1]; // skip "$$Generic<" and ">"
-                            Some(inner.to_string())
-                        } else {
-                            None
-                        };
-                        exported_names.dollar_generics.push((name, constraint));
-                        // Record the position to blank out later
-                        exported_names
-                            .dollar_generic_positions
-                            .push((type_alias.span.start, type_alias.span.end));
-                    }
+                    add_if_is_dollar_generic(
+                        type_alias,
+                        type_alias.span.start,
+                        raw_content,
+                        has_generics_attr,
+                        exported_names,
+                    );
                 }
                 // Detect rune globals used as standalone expression statements,
                 // e.g. `$effect(() => { ... })` or `$effect.pre(() => { ... })`.
@@ -857,6 +859,9 @@ fn collect_module_names(
                 collect_exported_module_declaration(&export.declaration, exported_names)?;
             }
             oxc::Statement::TSTypeAliasDeclaration(t) => {
+                if dollar_generic_type_args(t).is_some() {
+                    return Err(dollar_generic_in_module_script_error());
+                }
                 let name = t.id.name.to_string();
                 if is_special_type_name(&name) {
                     return Err(sentinel_type_in_module_script_error(&name));
@@ -923,6 +928,9 @@ fn collect_exported_module_declaration(
             }
         }
         oxc::Declaration::TSTypeAliasDeclaration(declaration) => {
+            if dollar_generic_type_args(declaration).is_some() {
+                return Err(dollar_generic_in_module_script_error());
+            }
             add_module_type_name(declaration.id.name.to_string(), exported_names)?;
         }
         oxc::Declaration::TSInterfaceDeclaration(declaration) => {
@@ -952,6 +960,65 @@ fn sentinel_type_in_module_script_error(name: &str) -> super::utils::error::Svel
     super::utils::error::Svelte2TsxError::Script(format!(
         "{name} can only be declared in the instance script"
     ))
+}
+
+/// The type arguments of a `type X = $$Generic<…>` alias, or `None` when the
+/// alias is not a `$$Generic` one. Mirrors upstream's `is$$GenericType`, which
+/// tests the AST node rather than the annotation's source text.
+fn dollar_generic_type_args<'a, 'b>(
+    type_alias: &'b oxc::TSTypeAliasDeclaration<'a>,
+) -> Option<Option<&'b oxc::TSTypeParameterInstantiation<'a>>> {
+    let oxc::TSType::TSTypeReference(reference) = &type_alias.type_annotation else {
+        return None;
+    };
+    let oxc::TSTypeName::IdentifierReference(ident) = &reference.type_name else {
+        return None;
+    };
+    (ident.name == "$$Generic").then(|| reference.type_arguments.as_deref())
+}
+
+/// Upstream `Generics.addIfIsGeneric`: turn `type X = $$Generic<C>` into a
+/// `$$render` type parameter and blank the declaration. `decl_start` is where
+/// the removal begins, which is the `export` keyword for the exported form.
+fn add_if_is_dollar_generic(
+    type_alias: &oxc::TSTypeAliasDeclaration<'_>,
+    decl_start: u32,
+    raw_content: &str,
+    has_generics_attr: bool,
+    exported_names: &mut ExportedNames,
+) {
+    let Some(type_arguments) = dollar_generic_type_args(type_alias) else {
+        return;
+    };
+    if has_generics_attr {
+        exported_names.dollar_generic_error.get_or_insert_with(|| {
+            "Invalid $$Generic declaration: $$Generic definitions are not allowed when the generics attribute is present on the script tag".to_string()
+        });
+        return;
+    }
+    let params = type_arguments.map(|args| &args.params);
+    if params.is_some_and(|params| params.len() > 1) {
+        exported_names.dollar_generic_error.get_or_insert_with(|| {
+            "Invalid $$Generic declaration: Only one type argument allowed".to_string()
+        });
+        return;
+    }
+    let constraint = params.and_then(|params| params.first()).map(|arg| {
+        let span = arg.span();
+        raw_content[span.start as usize..span.end as usize].to_string()
+    });
+    exported_names
+        .dollar_generics
+        .push((type_alias.id.name.to_string(), constraint));
+    exported_names
+        .dollar_generic_positions
+        .push((decl_start, type_alias.span.end));
+}
+
+fn dollar_generic_in_module_script_error() -> super::utils::error::Svelte2TsxError {
+    super::utils::error::Svelte2TsxError::Script(
+        "$$Generic declarations are only allowed in the instance script".to_string(),
+    )
 }
 
 #[cfg(test)]

--- a/crates/rsvelte_projection/src/svelte2tsx/svelte2tsx.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/svelte2tsx.rs
@@ -546,7 +546,7 @@ pub fn svelte2tsx(
         .and_then(|s| s.to_str())
         .unwrap_or("")
         .to_string();
-    let script_generic_names: std::collections::HashSet<String> = ast
+    let script_generics_attr: Option<String> = ast
         .instance
         .as_ref()
         .map(|instance| {
@@ -558,8 +558,12 @@ pub fn svelte2tsx(
             extract_generics_from_script_tag(tag_text)
         })
         .unwrap_or_default()
+        .filter(|raw| !raw.is_empty());
+    let has_generics_attr = script_generics_attr.is_some();
+    let script_generic_names: std::collections::HashSet<String> = script_generics_attr
+        .as_deref()
         .map(|raw| {
-            split_generic_param_names(&raw)
+            split_generic_param_names(raw)
                 .into_iter()
                 .collect::<std::collections::HashSet<String>>()
         })
@@ -583,7 +587,11 @@ pub fn svelte2tsx(
             options.emit_jsdoc,
             matches!(options.mode, Svelte2TsxMode::Dts),
             &script_generic_names,
+            has_generics_attr,
         );
+        if let Some(message) = exported_names.dollar_generic_error.take() {
+            return Err(super::utils::error::Svelte2TsxError::Script(message));
+        }
     }
 
     // Step 7.48: Find and remove embedded `<script>` tags (those NOT matching

--- a/crates/rsvelte_projection/tests/svelte2tsx_dollar_generic.rs
+++ b/crates/rsvelte_projection/tests/svelte2tsx_dollar_generic.rs
@@ -1,0 +1,129 @@
+//! #3254: the legacy `$$Generic` type alias — its three upstream errors, and
+//! the `export`ed declaration form the matcher did not see.
+//!
+//! Expectations were measured against the official `svelte2tsx` from
+//! `submodules/language-tools` on the same sources.
+
+use rsvelte_projection::svelte2tsx::{Svelte2TsxOptions, svelte2tsx};
+
+fn convert(src: &str) -> Result<String, String> {
+    let opts = Svelte2TsxOptions {
+        filename: "Probe.svelte".to_string(),
+        ..Default::default()
+    };
+    svelte2tsx(src, opts)
+        .map(|result| result.code)
+        .map_err(|error| error.to_string())
+}
+
+fn instance(decl: &str) -> String {
+    format!("<script lang=\"ts\">\n\t{decl}\n\tlet x: T = null as any; void x;\n</script>\n")
+}
+
+/// `throwIfIsGeneric`, called on every module-script node.
+#[test]
+fn a_dollar_generic_in_the_module_script_is_rejected() {
+    for decl in [
+        "type T = $$Generic;",
+        "type T = $$Generic<string>;",
+        "export type T = $$Generic;",
+        "type $$Generic = 1; type T = $$Generic;",
+    ] {
+        let error = convert(&format!(
+            "<script module lang=\"ts\">\n\t{decl}\n</script>\n"
+        ))
+        .expect_err("must be rejected");
+        assert!(
+            error.contains("$$Generic declarations are only allowed in the instance script"),
+            "{decl:?} gave {error}"
+        );
+    }
+}
+
+/// The first `throw` in `addIfIsGeneric`, and it is checked BEFORE the type
+/// argument count — so it wins even for a two-argument declaration.
+#[test]
+fn a_dollar_generic_next_to_the_generics_attribute_is_rejected() {
+    for decl in [
+        "type T = $$Generic;",
+        "type T = $$Generic<string>;",
+        "type T = $$Generic<string, number>;",
+        "export type T = $$Generic;",
+    ] {
+        let src = format!(
+            "<script lang=\"ts\" generics=\"U\">\n\t{decl}\n\tlet x: T = null as any; void x;\n</script>\n"
+        );
+        let error = convert(&src).expect_err("must be rejected");
+        assert!(
+            error.contains(
+                "Invalid $$Generic declaration: $$Generic definitions are not allowed when the generics attribute is present on the script tag"
+            ),
+            "{decl:?} gave {error}"
+        );
+    }
+}
+
+/// The second `throw` in `addIfIsGeneric`.
+#[test]
+fn a_dollar_generic_with_two_type_arguments_is_rejected() {
+    let error = convert(&instance("type T = $$Generic<string, number>;")).expect_err("rejected");
+    assert!(
+        error.contains("Invalid $$Generic declaration: Only one type argument allowed"),
+        "{error}"
+    );
+}
+
+/// Upstream models `export type T = …` as one `TypeAliasDeclaration` carrying
+/// an `export` modifier, so `addIfIsGeneric` reaches it: the alias is removed
+/// and `T` becomes a `$$render` type parameter. rsvelte matched the un-exported
+/// form only, so the alias survived into the render body as invalid TSX.
+#[test]
+fn an_exported_dollar_generic_becomes_a_type_parameter() {
+    let code = convert(&instance("export type T = $$Generic;")).expect("svelte2tsx ok");
+    assert!(
+        code.contains(
+            ";function $$render/*\u{03A9}ignore_start\u{03A9}*/<T>/*\u{03A9}ignore_end\u{03A9}*/() {"
+        ),
+        "{code}"
+    );
+    assert!(
+        !code.contains("$$Generic"),
+        "the alias must be blanked, `export` keyword included:\n{code}"
+    );
+
+    let code = convert(&instance("export type T = $$Generic<string>;")).expect("svelte2tsx ok");
+    assert!(
+        code.contains(
+            ";function $$render/*\u{03A9}ignore_start\u{03A9}*/<T extends string>/*\u{03A9}ignore_end\u{03A9}*/() {"
+        ),
+        "{code}"
+    );
+}
+
+/// The detection is structural, so whitespace inside the type argument list no
+/// longer decides whether the declaration is recognised.
+#[test]
+fn whitespace_around_the_type_argument_does_not_hide_the_declaration() {
+    let code = convert(&instance("type T = $$Generic < string >;")).expect("svelte2tsx ok");
+    assert!(
+        code.contains(
+            ";function $$render/*\u{03A9}ignore_start\u{03A9}*/<T extends string>/*\u{03A9}ignore_end\u{03A9}*/() {"
+        ),
+        "{code}"
+    );
+}
+
+/// A shadowing `type $$Generic = 1` is still matched by name — upstream reads
+/// the type reference and never resolves it.
+#[test]
+fn a_shadowed_alias_is_still_matched_by_name() {
+    let code =
+        convert(&instance("type $$Generic = 1; type T = $$Generic;")).expect("svelte2tsx ok");
+    assert!(
+        code.contains(
+            ";function $$render/*\u{03A9}ignore_start\u{03A9}*/<T>/*\u{03A9}ignore_end\u{03A9}*/() {"
+        ),
+        "{code}"
+    );
+    assert!(code.contains("type $$Generic = 1;"), "{code}");
+}


### PR DESCRIPTION
Closes #3254

## What

Three things, all in the legacy `$$Generic` path (`svelte2tsx/nodes/Generics.ts` upstream):

1. **The three errors are raised.** `throwIfIsGeneric` on the module script, and the two `throw`s inside `addIfIsGeneric` — a `$$Generic` alongside a `generics` attribute, and one with more than one type argument. Upstream checks the attribute *before* the argument count, so a two-argument declaration under a `generics` attribute reports the attribute message; that precedence is reproduced and tested.

2. **`export type T = $$Generic` is recognised.** TypeScript models it as one `TypeAliasDeclaration` carrying an `export` modifier, so upstream's matcher reaches it and removes the declaration from the `export` keyword onwards. oxc wraps it in an `ExportNamedDeclaration`, so the arm has to unwrap it — the same shape as #3077, where a store exported from `<script module>` got no shim because the loop matched `Statement::VariableDeclaration` and not `Statement::ExportDeclaration`. The alias used to survive into the render body verbatim, which is not valid inside a function.

3. **Detection is structural.** The old test was `type_text == "$$Generic" || type_text.starts_with("$$Generic<")` over the annotation's source text; it is now a `TSTypeReference` whose `type_name` is `$$Generic`, mirroring upstream's `is$$GenericType`. That is why `type T = $$Generic < string >` now works — the text scan could not see it, and the constraint is read from the type argument's own span rather than by slicing between the brackets.

The instance-script walk has no error channel, so the message is parked on `ExportedNames::dollar_generic_error` and turned into the returned error by the caller, immediately after `process_instance_script`.

## Measurement

Oracle: the official `svelte2tsx` built from `submodules/language-tools` at the pinned svelte (5.56.9). Grid: 10 declaration forms × 3 hosts (instance TS script, module TS script, instance script with `generics="U"`) = 30 cells, all compiled on both sides, compared byte-for-byte (an error compares as its message).

| | identical |
|---|---|
| before | **6 / 30** |
| after | **30 / 30** |

The forms are `bare`, `one_arg`, `two_args`, `exported`, `exported_one`, `shadowed` (`type $$Generic = 1; type T = $$Generic;` — upstream matches by name and never resolves, so this still becomes a type parameter), `two_aliases`, `no_semi`, `spaced` (`$$Generic < string >`), and `nested` (`$$Generic<Array<string>>`).

## Known remaining divergence, deliberately not chased

Upstream walks both scripts with a full-depth `ts.forEachChild`, so a `$$Generic` alias nested inside a function body is also collected/rejected; rsvelte's statement loop is top-level only. And upstream processes the **instance** script before the module one, so when both scripts carry a bad `$$Generic` the instance message wins, where rsvelte's step order reports the module one. Both are pre-existing structural differences of the walk shared by every `$$…` sentinel error here, not introduced by this change, and neither is reachable from any grid cell above.

## Which gate sees this

The svelte2tsx **TSX-text** gate (`compatibility/svelte2tsx-known-failures.json`) sees the `export type T = $$Generic` and `$$Generic < string >` rows as text divergences. The three errors are `error-parity` on that same gate, which compares error **presence** and not the message — so a message regression would still be invisible there, which is why the new tests assert the exact upstream message text. The source-map gate is unaffected: the error cases emit no map, and the export-form fix removes a range that was previously left in place, which the text gate already covers.

## Tests

`crates/rsvelte_projection/tests/svelte2tsx_dollar_generic.rs` — 6 tests, expectations measured against the oracle, including the error precedence and the shadowed-alias negative control.
