### PR TITLE
test(client): pin the reactive lowering of a bare `case`-clause `$state`

### DIFF
--- a/crates/rsvelte_core/tests/case_clause_state_3420.rs
+++ b/crates/rsvelte_core/tests/case_clause_state_3420.rs
@@ -1,0 +1,84 @@
+//! A `$state` declared bare in a `case` clause stays reactive.
+//!
+//! **This is a deliberate divergence from the official compiler — do not "fix" it
+//! toward official.** For this one shape official lowers the declaration to
+//! `$.state(...)` but leaves the references alone, so its own output does `s++` on a
+//! `Source` object and the component renders `NaN`. rsvelte emits `$.update(s)` /
+//! `$.get(s)`, which is what the braced form of the same case clause compiles to on
+//! *both* compilers.
+//!
+//! The rule: an upstream defect is reproduced only when both outputs behave identically
+//! and the disagreement is bytes alone. This one computes a different answer at runtime,
+//! so byte parity does not get to require it — byte equality serves the drop-in
+//! replacement goal rather than outranking it.
+//!
+//! `upstream_issues/3420-svelte-case-clause-state-references-untransformed.md` carries the
+//! measurement, the brace control that rules out intent, and the open cause attribution.
+//! If upstream fixes this, that file and this test are what have to go.
+
+use rsvelte_core::{CompileOptions, GenerateMode, compile};
+
+fn client(script: &str, dev: bool) -> String {
+    let source = format!(
+        "<script>\n\t{script}\n</script>\n\n<button onclick={{() => a++}}>{{a}}{{f(1)}}</button>\n"
+    );
+    compile(
+        &source,
+        CompileOptions {
+            generate: GenerateMode::Client,
+            dev,
+            ..Default::default()
+        },
+    )
+    .expect("compile failed")
+    .js
+    .code
+}
+
+/// `$.state(1)` rather than `let s = $.state(1)`, because dev wraps the declaration in
+/// `$.tag(...)`; the two reference forms are what this test is actually about.
+#[track_caller]
+fn assert_reactive(code: &str) {
+    for needle in ["$.state(1)", "$.update(s)", "return $.get(s)"] {
+        assert!(
+            code.contains(needle),
+            "expected to find\n  {needle}\nin:\n{code}"
+        );
+    }
+    // The negative half, and the one that fails if someone moves rsvelte toward official:
+    // upstream's brace-less output keeps the source's `s++` on a `Source` object.
+    assert!(
+        !code.contains("s++"),
+        "the untransformed `s++` is upstream's NaN-producing output; rsvelte must not \
+         emit it:\n{code}"
+    );
+}
+
+/// The diverging shape. Official emits `s++` and `return s` here, which is `NaN` at
+/// runtime; the braced control below is what says that is not intentional.
+#[test]
+fn a_bare_case_clause_declaration_stays_reactive() {
+    let script = "let a = $state(0);\n\tfunction f(k) {\n\t\tswitch (k) {\n\t\t\tcase 1:\n\t\t\t\tlet s = $state(1);\n\t\t\t\ts++;\n\t\t\t\treturn s;\n\t\t}\n\t}";
+    assert_reactive(&client(script, false));
+    assert_reactive(&client(script, true));
+}
+
+/// Control, and the reason the row above is read as an upstream defect rather than a
+/// deliberate deopt: adding braces changes nothing else about the declaration, and both
+/// compilers then agree on exactly the output rsvelte produces without them.
+#[test]
+fn a_braced_case_clause_declaration_stays_reactive() {
+    let script = "let a = $state(0);\n\tfunction f(k) {\n\t\tswitch (k) {\n\t\t\tcase 1: {\n\t\t\t\tlet s = $state(1);\n\t\t\t\ts++;\n\t\t\t\treturn s;\n\t\t\t}\n\t\t}\n\t}";
+    assert_reactive(&client(script, false));
+    assert_reactive(&client(script, true));
+}
+
+/// Control: the other statement kind that can host a declaration without a function
+/// boundary. Both compilers handle it, which is what narrows the defect to `SwitchCase`
+/// rather than "a declaration somewhere unusual".
+#[test]
+fn a_labeled_block_declaration_stays_reactive() {
+    let script = "let a = $state(0);\n\tfunction f() {\n\t\touter: {\n\t\t\tlet s = $state(1);\n\t\t\ts++;\n\t\t\treturn s;\n\t\t}\n\t}";
+    assert_reactive(&client(script, false));
+    assert_reactive(&client(script, true));
+}

--- a/upstream_issues/3420-svelte-case-clause-state-references-untransformed.md
+++ b/upstream_issues/3420-svelte-case-clause-state-references-untransformed.md
@@ -1,0 +1,130 @@
+# A `$state` declared bare in a `case` clause keeps `$.state(...)` but loses its reference transforms
+
+A `let` declared **directly in a `case` clause** — legal JavaScript, no block braces — is
+lowered to `$.state(...)` by the official compiler while its *references* are left
+untransformed. The result is valid JavaScript that computes the wrong answer at runtime.
+
+```svelte
+<!-- input.svelte -->
+<script>
+	let a = $state(0);
+	function f(k) {
+		switch (k) {
+			case 1:
+				let s = $state(1);
+				s++;
+				return s;
+		}
+	}
+</script>
+
+<button onclick={() => a++}>{a}{f(1)}</button>
+```
+
+`compile(source, { generate: 'client' })`:
+
+```js
+	function f(k) {
+		switch (k) {
+			case 1:
+				let s = $.state(1);
+				s++;
+				return s;
+		}
+	}
+```
+
+`$.state(1)` returns a `Source` object, so `s++` evaluates `{…} + 1` → `NaN` and `return s`
+hands back `NaN`. The component renders `NaN`.
+
+The two halves of that output contradict each other, which is what makes this a defect
+rather than a design choice: if `s` were meant to stay a plain value, `$state(1)` would
+have been folded away instead of being turned into `$.state(1)`.
+
+## The control that rules out intent
+
+Add braces to the same case clause. Nothing else changes — same declaration, same
+reassignment, same scope depth:
+
+```svelte
+			case 1: {
+				let s = $state(1);
+				s++;
+				return s;
+			}
+```
+
+```js
+			case 1:
+				{
+					let s = $.state(1);
+
+					$.update(s);
+
+					return $.get(s);
+				}
+```
+
+So the switch turns on **whether the case clause introduces a `BlockStatement`**, not on
+`switch`, not on the declaration, and not on where the declaration sits. That is the
+evidence that upstream is not deliberately treating switch-local state as non-reactive —
+if it were, the braced form would behave the same way.
+
+## The axis, measured (Svelte 5.56.10, `generate: 'client'`, dev on and off)
+
+| shape | verdict |
+|---|---|
+| `case 1: { let s = $state(1); s++; return s }` | agrees with rsvelte |
+| `case 1: let s = $state(1); s++; return s` | **diverges, both dev and non-dev** |
+| `outer: { let s = $state(1); s++; return s }` (labeled block) | agrees |
+| `case 1: { let s = $state(1); let d = $derived(s * 2) }` | agrees |
+| `case 1: { let s = /* c */ $state(1) }` | agrees |
+| `outer: { let s = /* c */ $state(1) }` | agrees |
+
+The labeled-block row is the second control: it is the other statement kind that can host
+a declaration without a function boundary, and it is handled correctly. So the defect is
+specific to `SwitchCase`, not to "a declaration somewhere unusual".
+
+## Cause — not attributed
+
+Two upstream sites are certainly involved, but the attribution is **not finished** and is
+deliberately left open rather than filled with a plausible guess:
+
+* `phases/scope.js:1173` registers `SwitchStatement: create_block_scope`, so the
+  declaration is bound on the **`SwitchStatement`**, not per `SwitchCase`.
+* `3-transform/client/transform-client.js:67-70` (`set_scope`) rebuilds `state.transform`
+  through `get_transform` on every node that owns a scope, and
+  `3-transform/client/utils.js:187-199` is the only place an entry is *deleted*.
+
+What is unexplained is that the declarator still sees `is_state_source` as true — it emits
+`$.state(...)`, which that predicate gates — while the reference has no transform. Those
+two readings cannot both be taken against the same `transform` map. Anyone continuing this
+should start by printing `binding.kind` and `binding.reassigned` for `s` in the braced and
+brace-less shapes, since the control above says that pair is where they part.
+
+## What rsvelte does about it, and why
+
+**Decision: do not reproduce. rsvelte keeps emitting the correct output** —
+`$.update(s)` / `$.get(s)` — and `crates/rsvelte_core/tests/case_clause_state_3420.rs`
+pins that against the day someone reads the divergence as an rsvelte bug and "fixes" it
+toward official.
+
+The rule this follows: **reproduce an upstream defect only when both outputs behave
+identically and only the bytes differ; do not reproduce when the upstream output computes
+a different answer at runtime.**
+
+That is why this lands differently from
+[2990](2990-svelte-class-accessor-drops-later-comments.md) and
+[3070](3070-svelte-template-comment-leaks-into-generated-code.md), which rsvelte does
+reproduce. A comment's position does not change what the program does, so for those rows
+byte equality is the whole of the disagreement and matching upstream costs nothing. Here
+the user's component renders `NaN`. Byte equality is a means to the drop-in-replacement
+goal, not a goal above it, so it does not get to require shipping a broken component.
+
+Consequence to keep in mind: this is a permanent byte divergence. If a corpus file ever
+uses the shape, the resulting ratchet entry must be justified as *upstream computes the
+wrong value at runtime and rsvelte deliberately emits the correct output* — not as an
+unexplained mismatch. And if upstream fixes it, this file and the pinning test are what
+have to go.
+
+Tracked in rsvelte issue #3420.


### PR DESCRIPTION
No behaviour change. This pins output rsvelte already produces, and records why it is
deliberately **not** equal to the official compiler's.

Refs #3420.

## What diverges

A `let` declared directly in a `case` clause — legal JavaScript, no block braces — is
lowered to `$.state(...)` by official while its *references* are left untransformed:

```svelte
<script>
	let a = $state(0);
	function f(k) {
		switch (k) {
			case 1:
				let s = $state(1);
				s++;
				return s;
		}
	}
</script>
```

```js
// official, client                 // rsvelte, client
let s = $.state(1);                 let s = $.state(1);
s++;                                $.update(s);
return s;                           return $.get(s);
```

`$.state(1)` returns a `Source`, so official's `s++` evaluates `{…} + 1` → `NaN` and the
component renders `NaN` where rsvelte renders `2`. Official's own two halves contradict
each other: if `s` were meant to stay a plain value, `$state(1)` would have been folded
away rather than turned into `$.state(1)`.

## The control that rules out intent

Adding braces to the same case clause — same declaration, same reassignment, nothing else
changed — makes official emit exactly what rsvelte emits without them:

```js
			case 1:
				{
					let s = $.state(1);

					$.update(s);

					return $.get(s);
				}
```

So the behaviour turns on **whether the case clause introduces a `BlockStatement`**, not on
`switch` and not on the declaration. That is the evidence that upstream is not deliberately
deopting switch-local state. A labeled block — the other statement kind that can host a
declaration without a function boundary — is also handled correctly on both sides, which
narrows it to `SwitchCase`.

Measured over 6 shapes × dev on/off against the pinned official compiler (5.56.10); only
the brace-less `case` row diverges.

## Why rsvelte does not reproduce it

The rule this follows: **reproduce an upstream defect only when both outputs behave
identically and the disagreement is bytes alone; do not reproduce when the upstream output
computes a different answer at runtime.**

That is what separates this from the rows rsvelte *does* reproduce (#2990's comment drop,
#3070's comment leak): a comment's position does not change what the program does, so
matching upstream there costs nothing. Here it would mean shipping a component that
renders `NaN`. Byte equality is a means to the drop-in-replacement goal, not a goal above
it.

## What is in this PR

* `upstream_issues/3420-svelte-case-clause-state-references-untransformed.md` — the
  measurement, the brace control, and the decision.
* `crates/rsvelte_core/tests/case_clause_state_3420.rs` — three tests, each run in dev and
  non-dev. The negative assertion is the load-bearing one: the output must **not** contain
  the untransformed `s++`, so the test fails if someone later reads the divergence as an
  rsvelte bug and moves it toward official. Without that, the decision holds exactly once.
  The two control tests (braced case, labeled block) are what keep the first test honest —
  they are the shapes where both compilers already agree, so a change that broke reactive
  lowering generally would fail all three rather than looking like a targeted divergence.

## Cause: deliberately not attributed

Two upstream sites are certainly involved — `phases/scope.js:1173`
(`SwitchStatement: create_block_scope`) and `transform-client.js:67-70` (`set_scope`) with
`client/utils.js:187-199` (`get_transform`, the only place an entry is deleted). What is
unexplained is that the declarator still sees `is_state_source` as true (it emits
`$.state(...)`, which that predicate gates) while the reference has no transform; those two
readings cannot both be taken against the same `transform` map.

That row is left blank on purpose rather than filled with a plausible guess. The write-up
names where to start instead: print `binding.kind` / `binding.reassigned` for `s` in the
braced and brace-less shapes, since the control says that pair is where they part.

## Ratchets

None touched, and none expected — a brace-less `case` declaration is the shape ESLint's
`no-case-declarations` discourages, so published code is thin on it. If a corpus file ever
does use it, the entry must be justified as *upstream computes the wrong value at runtime
and rsvelte deliberately emits the correct output*, not as an unexplained mismatch. The
write-up says so, and says that this file plus the test are what have to go if upstream
fixes it.

No changeset: behaviour is unchanged, and `changeset.yml` only requires one for
`fix` / `feat` titles.
