### PR TITLE
fix(svelte2tsx): keep a module-only component's template whitespace

### DIFF
--- a/.changeset/s2t-module-only-template-whitespace.md
+++ b/.changeset/s2t-module-only-template-whitespace.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/svelte2tsx": patch
+---
+
+Stop blanking the whitespace around a module-only component's template. Upstream has no such step — it leaves the template text alone — so a component whose only script is `<script module>` and whose template is whitespace lost the newline inside the generated arrow, and lost one of the two runs entirely when whitespace sat on both sides of the script.

--- a/crates/rsvelte_projection/src/svelte2tsx/create_render_function.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/create_render_function.rs
@@ -13,7 +13,6 @@ use super::magic_string::MagicString;
 use super::nodes::scripts::find_instance_imports;
 use super::nodes::slot::escape_js_single_quoted;
 use super::script::StoreScanContext;
-use super::svelte2tsx::slice_src;
 
 /// Prepend the reference-types header and open the `$$render()` wrapper.
 /// Which of the three shapes is emitted depends on whether the component has an
@@ -92,29 +91,6 @@ pub fn create_render_function(
             ";function $$render() {{{dollar_decls}{slot_decl_mod}\nasync () => {{{store_decls}"
         );
         str.append_left(mod_end, &render_open);
-
-        // Blank out trailing whitespace after the module script ONLY when
-        // there's no template content following. This ensures the async
-        // wrapper closes immediately for module-script-only components.
-        let has_non_whitespace_template = ast.fragment.nodes.iter().any(|node| {
-            !matches!(node, crate::ast::template::TemplateNode::Text(t)
-                if slice_src(source, t.start as usize, t.end as usize).chars().all(char::is_whitespace))
-        });
-        if !has_non_whitespace_template && (mod_end as usize) < source.len() {
-            let bytes = source.as_bytes();
-            let mut trailing_end = mod_end;
-            while (trailing_end as usize) < bytes.len() {
-                let b = bytes[trailing_end as usize];
-                if b == b' ' || b == b'\t' || b == b'\n' || b == b'\r' {
-                    trailing_end += 1;
-                } else {
-                    break;
-                }
-            }
-            if trailing_end > mod_end {
-                str.overwrite(mod_end, trailing_end, "");
-            }
-        }
 
         str.prepend_str(header_str);
     } else {

--- a/crates/rsvelte_projection/tests/svelte2tsx_module_only_template.rs
+++ b/crates/rsvelte_projection/tests/svelte2tsx_module_only_template.rs
@@ -1,0 +1,59 @@
+//! #3307: a component whose only script is `<script module>` kept its template
+//! whitespace blanked, so the generated template arrow lost the newline (and,
+//! with two whitespace runs around the script, one of them entirely).
+//!
+//! Expectations were measured against the official `svelte2tsx` from
+//! `submodules/language-tools` on the same sources.
+
+use rsvelte_projection::svelte2tsx::{Svelte2TsxOptions, svelte2tsx};
+
+fn convert(src: &str) -> String {
+    let opts = Svelte2TsxOptions {
+        filename: "Probe.svelte".to_string(),
+        ..Default::default()
+    };
+    svelte2tsx(src, opts).expect("svelte2tsx ok").code
+}
+
+#[test]
+fn a_whitespace_only_template_keeps_its_text_in_the_arrow() {
+    for (src, body) in [
+        ("<script module>void x;</script>\n", "\n"),
+        ("<script module>void x;</script>\n\n\n", "\n\n\n"),
+        ("<script module>void x;</script>   ", "   "),
+        ("<script module>void x;</script>\n\t\n", "\n\t\n"),
+        ("<script module>void x;</script>", ""),
+    ] {
+        let code = convert(src);
+        assert!(
+            code.contains(&format!("async () => {{{body}}};")),
+            "{src:?} must keep its template text:\n{code}"
+        );
+    }
+}
+
+/// Whitespace on BOTH sides of the module script is two runs, and only the
+/// trailing one used to be blanked — so the arrow held one newline instead of
+/// two.
+#[test]
+fn whitespace_before_and_after_the_module_script_both_survive() {
+    let code = convert("\n<script module>void x;</script>\n");
+    assert!(code.contains("async () => {\n\n};"), "{code}");
+
+    let code = convert("<style>a{color:red}</style>\n<script module>void x;</script>\n");
+    assert!(code.contains("async () => {\n\n};"), "{code}");
+}
+
+/// Negative controls: a content-bearing template node and an instance script
+/// both already worked, and must keep working.
+#[test]
+fn a_content_bearing_template_and_an_instance_script_are_unchanged() {
+    let code = convert("<script module>void x;</script>\n<div></div>\n");
+    assert!(
+        code.contains("async () => {\n { svelteHTML.createElement(\"div\", {}); }\n};"),
+        "{code}"
+    );
+
+    let code = convert("<script>void x;</script>\n");
+    assert!(code.contains("async () => {\n};"), "{code}");
+}


### PR DESCRIPTION
Closes #3307

## What

`create_render_function`'s module-script-only branch carried a step with no upstream counterpart: "blank out trailing whitespace after the module script ONLY when there's no template content following". Upstream's `createRenderFunction` does nothing of the sort — it `prependRight`s the wrapper and leaves the template text alone — so the step is deleted.

## Measurement

Oracle: the official `svelte2tsx` built from `submodules/language-tools` at the pinned svelte (5.56.9). Grid: 14 module-script/template layouts, all compiled on both sides, compared byte-for-byte.

| | identical |
|---|---|
| before | **7 / 14** |
| after | **14 / 14** |

The 7 that moved are wider than the issue's single case, and two of them are a second symptom the issue does not name: because only the *trailing* run was blanked, a component with whitespace on **both** sides of the module script kept one newline where upstream keeps two.

| source | official arrow body | before |
|---|---|---|
| `<script module>…</script>\n` | `{\n}` | `{}` |
| `<script module>…</script>\n\n\n` | `{\n\n\n}` | `{}` |
| `<script module>…</script>   ` | `{   }` | `{}` |
| `<script module>…</script>\n\t\n` | `{\n\t\n}` | `{}` |
| `\n<script module>…</script>\n` | `{\n\n}` | `{\n}` |
| `<style>…</style>\n<script module>…</script>\n` | `{\n\n}` | `{\n}` |

Negative controls that were already identical and stay identical: a content-bearing template node (`<div></div>`), an instance script, `<script module lang="ts">`, a comment node, a second `<script>`, and a component with no trailing whitespace at all.

## Which gate sees this

The svelte2tsx **TSX-text** gate (`compatibility/svelte2tsx-known-failures.json`). The **source-map** gate is also affected in principle — the blanking was an `overwrite` on a real source range, so the mappings of everything after it moved — but the shift is at the very end of the file, after the last mapped template node, so no mapping anchor changes.

Neither gate could have caught it from the collected corpus: 0 of the 4,468 `.svelte` files under `submodules/svelte/packages/svelte/tests` reach the shape, which is what you would expect of published components — they have either a template or an instance script.

## Tests

`crates/rsvelte_projection/tests/svelte2tsx_module_only_template.rs` — 3 tests, expectations measured against the oracle, including the both-sides case and the two negative controls.
