### PR TITLE
fix(fmt): close implicitly-closed elements

### DIFF
--- a/.changeset/fmt-implicitly-closed-elements.md
+++ b/.changeset/fmt-implicitly-closed-elements.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/fmt": patch
+---
+
+The formatter now closes implicitly-closed HTML elements, matching prettier-plugin-svelte: `<ul><li>a<li>b</ul>` formats to one `<li>…</li>` per line instead of surviving unrepaired. Three things had to line up — a synthetic close tag when the element's end abuts its next sibling (nothing to replace, so nothing was emitted), coincident zero-length inserts now emitting in push order so the close tag lands before the separator that follows it, and the mismatched-close-tag fallback no longer claiming a `</…>` that belongs to the element's last child.

--- a/crates/rsvelte_formatter/src/indent.rs
+++ b/crates/rsvelte_formatter/src/indent.rs
@@ -483,22 +483,13 @@ fn collect_indent_edits_inner(
                         TemplateNode::Text(t) if is_whitespace_only(t.data.as_ref()));
                 if !has_trailing_ws {
                     let last_end = crate::collapse::template_node_span(last).1;
-                    // The `\n{parent_indent}` insert and any synthetic close
-                    // tag for an empty implicitly-closed element are both
-                    // zero-length inserts at `last_end`. We push the newline
-                    // FIRST so it ends up earlier in the vec; the close tag is
-                    // pushed second. When applied in descending-start order the
-                    // close tag insert fires last and lands at the same position
-                    // as the newline (now the position of the newly-inserted
-                    // `\n`), placing `</tag>` BEFORE the `\n`:
-                    //   `<duiv>\n</duiv>\n</div>` — correct layout.
-                    // Note: non-empty implicitly-closed elements (e.g. `<li>a`)
-                    // are handled by `push_close_tag` case 4 in markup.rs
-                    // (replaces trailing whitespace span with `</tag>`), so we
-                    // only insert `</tag>` here for EMPTY elements.
-                    edits.push((last_end, last_end, format!("\n{parent_indent}")));
-                    // Implicitly-closed RegularElement with EMPTY content: insert
-                    // synthetic </tag> (pushed second so it lands before the \n).
+                    // A synthetic close tag for an empty implicitly-closed
+                    // element and the `\n{parent_indent}` separator are both
+                    // zero-length inserts at `last_end`; coincident inserts emit
+                    // in push order, so the close tag goes first:
+                    //   `<duiv>\n</duiv>\n</div>`.
+                    // Non-empty implicitly-closed elements are `push_close_tag`'s
+                    // job in markup.rs, which also pushes before this pass runs.
                     if let TemplateNode::RegularElement(e) = last {
                         let is_implicitly_closed =
                             source.as_bytes().get(e.end as usize - 1).copied() != Some(b'>');
@@ -509,6 +500,7 @@ fn collect_indent_edits_inner(
                             edits.push((last_end, last_end, format!("</{}>", e.name.as_str())));
                         }
                     }
+                    edits.push((last_end, last_end, format!("\n{parent_indent}")));
                 }
             }
         }
@@ -536,8 +528,15 @@ fn collect_indent_edits_inner(
                     && matches!(&fragment.nodes[last_idx + 1],
                         TemplateNode::Text(t) if is_whitespace_only(t.data.as_ref()));
                 if !has_trailing_ws {
-                    let is_implicitly_closed =
-                        source.as_bytes().get(e.end as usize - 1).copied() != Some(b'>');
+                    // Only the trailing-whitespace shape needs a newline back:
+                    // when the content abuts the parent's close tag markup.rs
+                    // inserts `</tag>` and consumes nothing, so the oracle keeps
+                    // `<ul><li>a</li></ul>` on one line.
+                    let is_implicitly_closed = source
+                        .as_bytes()
+                        .get(e.end as usize - 1)
+                        .copied()
+                        .is_some_and(|b| b.is_ascii_whitespace());
                     let is_nonempty =
                         !e.fragment.nodes.iter().all(
                             |n| matches!(n, TemplateNode::Text(t) if crate::is_blank_text(t.data.as_ref())),

--- a/crates/rsvelte_formatter/src/lib.rs
+++ b/crates/rsvelte_formatter/src/lib.rs
@@ -362,8 +362,8 @@ fn format_attempt(
 ///   corpus doesn't currently produce this shape, so making it explicit leaves
 ///   every corpus output byte-identical; the unit tests below lock in the
 ///   intended semantics.
-/// - Multiple inserts at one position keep the order the old apply produced
-///   (last-pushed first).
+/// - Multiple inserts at one position emit in push order, so markup's
+///   synthetic close tag precedes indent.rs's separator at the same offset.
 fn apply_edits(source: &str, edits: &mut Vec<(u32, u32, String)>) -> String {
     // Select survivors in descending-start order so the overlap tie-break
     // matches the historical back-to-front `replace_range` loop.
@@ -387,11 +387,12 @@ fn apply_edits(source: &str, edits: &mut Vec<(u32, u32, String)>) -> String {
         survivors.push((start, end, new_text));
     }
 
-    // `reverse` turns the descending-start survivors into ascending start with
-    // same-start edits in reverse push order (what the old loop produced for
-    // coincident inserts). The stable re-sort then pins the one deliberate
-    // rule: at a shared start a zero-length insert precedes the range edit.
-    survivors.reverse();
+    // Survivors are in descending start with same-start entries in push order
+    // (both sorts above are stable). The stable re-sort to ascending start
+    // therefore keeps push order at a shared position and pins two rules: a
+    // zero-length insert precedes a range edit at the same start, and two
+    // coincident inserts emit in the order their passes pushed them — markup
+    // structure (a synthetic close tag) before indentation whitespace.
     survivors.sort_by_key(|(start, end, _)| (*start, u8::from(*end > *start)));
 
     let out_cap = source.len() + survivors.iter().map(|(_, _, t)| t.len()).sum::<usize>();
@@ -449,10 +450,10 @@ mod tests {
     }
 
     #[test]
-    fn multiple_inserts_at_one_position_keep_reverse_push_order() {
-        // Matches the old back-to-front apply: the last-pushed insert prints
-        // first (each `replace_range` at the same offset prepends).
-        assert_eq!(apply("abcd", vec![e(2, 2, "1"), e(2, 2, "2")]), "ab21cd");
+    fn multiple_inserts_at_one_position_keep_push_order() {
+        // A markup pass pushes before the indent pass, so a synthetic close tag
+        // lands before the separator that follows it.
+        assert_eq!(apply("abcd", vec![e(2, 2, "1"), e(2, 2, "2")]), "ab12cd");
     }
 
     #[test]

--- a/crates/rsvelte_formatter/src/markup/close_tag.rs
+++ b/crates/rsvelte_formatter/src/markup/close_tag.rs
@@ -21,6 +21,11 @@ pub(super) fn push_close_tag(
     // tag wraps, the close tag drops to its own line and the whitespace body is
     // absorbed into that break. See [`is_empty_nonhug_element`].
     empty_nonhug: bool,
+    // Whether the element's last child ends exactly at `element_end` — then the
+    // `</…>` sitting there is that CHILD's close tag (`<li><span>x</span></ul>`),
+    // not a mis-typed close tag for this element, and the mismatch fallback must
+    // not claim it.
+    last_child_ends_here: bool,
     options: &FormatOptions,
     edits: &mut Vec<(u32, u32, String)>,
 ) {
@@ -33,8 +38,9 @@ pub(super) fn push_close_tag(
     // `element_end`.  This mirrors the oracle (prettier-plugin-svelte), which
     // always emits a close tag based on the AST element name regardless of what
     // the source contains.
-    let span = find_close_tag_span(source, element_end, tag_name)
-        .or_else(|| find_any_close_tag_span(source, element_end));
+    let span = find_close_tag_span(source, element_end, tag_name).or_else(|| {
+        (!last_child_ends_here).then(|| find_any_close_tag_span(source, element_end))?
+    });
     let Some((start, end)) = span else {
         // No explicit close tag at element_end.  There are three cases:
         //
@@ -120,6 +126,11 @@ pub(super) fn push_close_tag(
                     element_end,
                     format!("\n{parent_indent}</{tag_name}>"),
                 ));
+            } else {
+                // The implicit close sits directly against the next sibling's
+                // `<` (`<li>a<li>b`), so there is no whitespace to replace —
+                // insert the close tag. The indent pass owns the separator.
+                edits.push((element_end, element_end, format!("</{tag_name}>")));
             }
         }
         return;

--- a/crates/rsvelte_formatter/src/markup/walk.rs
+++ b/crates/rsvelte_formatter/src/markup/walk.rs
@@ -330,6 +330,14 @@ fn handle_element(
 ) -> Result<(), FormatError> {
     let is_empty = is_empty_fragment(fragment);
     let empty_nonhug = is_empty_nonhug_element(name, fragment);
+    let last_child_ends_here = fragment
+        .nodes
+        .iter()
+        .rev()
+        .find(|n| !matches!(n, TemplateNode::Text(t) if crate::is_blank_text(t.data.as_ref())))
+        .is_some_and(|n| {
+            !matches!(n, TemplateNode::Text(_)) && crate::collapse::template_node_span(n).1 == end
+        });
     let wrapped = push_open_tag(
         source,
         start,
@@ -342,6 +350,10 @@ fn handle_element(
         options,
         edits,
     )?;
+    // Children first: an element and its last descendant can both close
+    // implicitly at the same offset (`<tr><td>a<td>b</tr>`), and coincident
+    // inserts emit in push order, so the inner close tag has to be pushed first.
+    collect_open_tag_edits(source, fragment, depth + 1, options, edits)?;
     push_close_tag(
         source,
         end,
@@ -350,10 +362,10 @@ fn handle_element(
         depth,
         is_empty,
         empty_nonhug,
+        last_child_ends_here,
         options,
         edits,
     );
-    collect_open_tag_edits(source, fragment, depth + 1, options, edits)?;
     Ok(())
 }
 

--- a/crates/rsvelte_formatter/tests/implicit_close.rs
+++ b/crates/rsvelte_formatter/tests/implicit_close.rs
@@ -1,0 +1,107 @@
+//! An element the parser closed implicitly (`<ul><li>a<li>b</ul>`) must be
+//! printed with its close tag, like prettier-plugin-svelte. Every expectation
+//! here was measured against the oxfmt(`svelte: true`) oracle.
+
+use rsvelte_formatter::{
+    FormatOptions, IndentStyle, IndentWidth, JsFormatOptions, LineWidth, format,
+};
+
+fn fmt(src: &str) -> String {
+    let js = JsFormatOptions {
+        indent_style: IndentStyle::Space,
+        indent_width: IndentWidth::try_from(2u8).unwrap(),
+        line_width: LineWidth::try_from(80u16).unwrap(),
+        ..JsFormatOptions::default()
+    };
+    let options = FormatOptions {
+        js,
+        typescript: false,
+        ..FormatOptions::new()
+    };
+    format(src, &options).expect("format ok")
+}
+
+#[test]
+fn two_list_items() {
+    assert_eq!(
+        fmt("<ul><li>a<li>b</ul>\n"),
+        "<ul>\n  <li>a</li>\n  <li>b</li>\n</ul>\n"
+    );
+}
+
+/// One block child does not trigger `forceBreakContent`, so the repaired
+/// element stays on its line.
+#[test]
+fn a_sole_list_item_stays_on_one_line() {
+    assert_eq!(fmt("<ul><li>a</ul>\n"), "<ul><li>a</li></ul>\n");
+}
+
+#[test]
+fn paragraphs() {
+    assert_eq!(
+        fmt("<div><p>one<p>two</div>\n"),
+        "<div>\n  <p>one</p>\n  <p>two</p>\n</div>\n"
+    );
+}
+
+#[test]
+fn description_list_alternates_dt_and_dd() {
+    assert_eq!(
+        fmt("<dl><dt>a<dd>b<dt>c<dd>d</dl>\n"),
+        "<dl>\n  <dt>a</dt>\n  <dd>b</dd>\n  <dt>c</dt>\n  <dd>d</dd>\n</dl>\n"
+    );
+}
+
+/// The `</span>` sitting at the implicitly-closed `<li>`'s end belongs to the
+/// CHILD, so the mismatched-close-tag fallback must not rename it.
+#[test]
+fn a_child_close_tag_at_the_boundary_is_not_claimed() {
+    assert_eq!(
+        fmt("<ul><li>a<li><span>x</span></ul>\n"),
+        "<ul>\n  <li>a</li>\n  <li><span>x</span></li>\n</ul>\n"
+    );
+}
+
+/// A row and its last cell close at the same offset; the inner close tag has to
+/// be emitted first.
+#[test]
+fn nested_implicit_closes_nest_inside_out() {
+    assert_eq!(
+        fmt("<table><tbody><tr><td>a</td><td>b</td><tr><td>c</td><td>d</td></tbody></table>\n"),
+        "<table>\n  <tbody><tr><td>a</td><td>b</td></tr><tr><td>c</td><td>d</td></tr></tbody>\n</table>\n"
+    );
+}
+
+#[test]
+fn inline_ruby_annotations_stay_glued() {
+    assert_eq!(
+        fmt("<ruby>a<rt>b<rp>c</ruby>\n"),
+        "<ruby>a<rt>b</rt><rp>c</rp></ruby>\n"
+    );
+}
+
+/// The pre-existing trailing-whitespace shape must keep working — the close tag
+/// replaces the whitespace rather than being inserted.
+#[test]
+fn implicit_close_with_trailing_whitespace() {
+    assert_eq!(
+        fmt("<ul>\n  <li>a\n  <li>b\n</ul>\n"),
+        "<ul>\n  <li>a</li>\n  <li>b</li>\n</ul>\n"
+    );
+}
+
+#[test]
+fn two_repaired_lists_in_a_row() {
+    assert_eq!(
+        fmt("<ul><li>a<li>b</ul><ul><li>c<li>d</ul>\n"),
+        "<ul>\n  <li>a</li>\n  <li>b</li>\n</ul>\n<ul>\n  <li>c</li>\n  <li>d</li>\n</ul>\n"
+    );
+}
+
+#[test]
+fn options_in_a_select() {
+    assert_eq!(
+        fmt("<select><option>a<option>b</select>\n"),
+        "<select><option>a</option><option>b</option></select>\n"
+    );
+}


### PR DESCRIPTION
Closes #3097

`prettier-plugin-svelte` prints an implicitly-closed HTML element with its close tag; `rsvelte-fmt` reindented and left the source shape (`<ul>` + `<li>a<li>b</ul>`).

## Three causes, and the middle one is the interesting half

**1. Nothing was emitted when there was no whitespace to replace.** `push_close_tag` already had a case for the implicit close — it walks back from the element's end over trailing whitespace and *replaces* that whitespace with `\n{indent}</tag>`. When the end abuts the next sibling's `<` (`<li>a<li>b`) that run is empty, so the branch did nothing at all. It now inserts `</tag>` there.

**2. The insert landed on the wrong side of the separator.** `indent.rs` inserts `\n{child_indent}` at exactly that offset for two adjacent block siblings, so both passes emit a zero-length insert at one position, and `apply_edits` ordered coincident inserts **last-pushed-first**. Markup pushes before indent, so the separator won out and the output was `<li>a` + `\n  </li><li>b` — which the collapse pass then pulled back onto one line, hiding the newline entirely and making the bug look like "no separator at all".

That order was documented as incidental ("keep the order the old apply produced"). It is now **push order**, which states a rule rather than a history: at one offset, markup structure precedes indentation whitespace. The change is one line (`survivors.reverse()` dropped — the survivor list already carries same-start entries in push order, and the following sort is stable). Exactly one existing site depended on the old order — indent.rs's synthetic close tag for an *empty* implicitly-closed element, whose comment says it pushes the newline first so the close tag lands before it — and its two pushes are swapped to match.

**3. The mismatched-close-tag fallback claimed a child's close tag.** `find_any_close_tag_span` accepts any `</…>` ending at the element's end, which is how `<duiv>x</div>` is repaired. For `<li><span>x</span></ul>` the `</span>` ends exactly at the `<li>`'s end, so the fallback renamed it — `<li><span>x</li>`, losing the `</span>`. `push_close_tag` now takes `last_child_ends_here` (computed in `walk.rs` from the fragment) and skips the fallback when the `</…>` there belongs to the last child.

`handle_element` also recurses into the fragment **before** pushing its own close tag, because an element and its last descendant can close implicitly at the same offset (`<tr><td>a<td>b</tr>`) and, under the push-order rule, the inner one has to be pushed first.

## Verification

Measured against the oxfmt(`svelte: true`) oracle; no expectation is hand-written.

- **Implicit-close probe matrix.** The original 23-row set: **4/23 before → 19/23 after**. A second 29-row set covering every `closing_tag_omitted` pair upstream declares (`li` / `p` / `dt` / `dd` / `rt` / `rp` / `td` / `th` / `tr` / `thead` / `tbody` / `tfoot` / `option` / `optgroup`) across several hosts: **27/29**.
- The residual rows are **not** this fix's shape:
  - `<table><tbody><tr><td>a<td>b<tr>…` — the oracle emits `</tr></tr>`, an artifact of prettier's own repaired tree on malformed input; rsvelte's output is well-formed.
  - `<optgroup g><option>a<optgroup h>` — a **parser** difference, not a formatter one: upstream's `element.js` does a single `parser.pop()` per new tag, while rsvelte's `should_implicitly_close` is re-entered and pops the whole chain, so `<optgroup h>` becomes a sibling here and a child upstream. Filed separately.
- `svelte_dev_corpus_parity` (the byte-exact gate, no baseline tolerance): **passes** — 556 `.svelte` files + 546 markdown blocks + 644 whole markdown files. This is the check that matters for the edit-ordering change.
- `compatibility/pattern-corpus`, all 697 components against the oracle, **before and after**: the diverging set is **identical** — 0 added, 0 removed. (The 70 standing diffs are the probe's missing CSS formatter plus ids already in `fmt-known-failures.json`.)
- Full `rsvelte_formatter` suite green (31 binaries, including 10 new `implicit_close.rs` tests and the updated `apply_edits` ordering unit test); full `rsvelte_fmt` suite green.

No `compatibility/*known-failures*` file is touched.
