### PR TITLE
docs(upstream): a rune allow-list gap in svelte and an oxfmt paren drop

### DIFF
--- a/upstream_issues/3441-svelte-rune-in-a-declarator-initializer.md
+++ b/upstream_issues/3441-svelte-rune-in-a-declarator-initializer.md
@@ -1,0 +1,126 @@
+# A rune in a declarator initializer is decided by a hard-coded allow-list, and two entries are wrong
+
+`phases/3-transform/{client,server}/visitors/VariableDeclaration.js` each open with a list of the
+runes that may sit in a `VariableDeclarator`'s initializer and be visited as an ordinary
+expression. Anything not on the list must be matched by one of the branches below it, or the
+declarator is silently not pushed.
+
+```js
+/* client */
+if (
+    !rune ||
+    rune === '$effect.tracking' ||
+    rune === '$effect.root' ||
+    rune === '$inspect' ||
+    rune === '$inspect.trace' ||
+    rune === '$state.snapshot' ||
+    rune === '$host'
+) {
+    declarations.push(/** @type {VariableDeclarator} */ (context.visit(declarator)));
+    continue;
+}
+```
+
+```js
+/* server */
+if (!rune || rune === '$effect.tracking' || rune === '$inspect' || rune === '$effect.root') {
+```
+
+Two entries produce broken output. Measured on svelte `5.56.9` (submodule `20b341f1`).
+
+## 1. `$inspect` is on both lists and must not be — `const t = ;;`
+
+`$inspect` on the list means `context.visit(declarator)` runs, and the `CallExpression` visitor
+replaces an `$inspect` call with an empty statement. The declarator keeps its `=` and loses its
+initializer:
+
+```svelte
+<svelte:options runes={true} />
+<script>
+	const t = $inspect(1);
+	void t;
+</script>
+<b>x</b>
+```
+
+```js
+/* generate: 'client' */
+export default function A($$anchor) {
+	const t = ;;
+
+	void t;
+	…
+}
+```
+
+`generate: 'server'` produces the same `const t = ;;`. `dev: true` is correct, which is why this
+survives — the dev build is the one people run. Four shapes reproduce it: `const`, `let`, a second
+declarator in the same declaration (`const q = 1, t = $inspect(q)`), and `$inspect` over a
+`$state` variable.
+
+## 2. `$effect.pending` is on neither list — the declaration disappears
+
+```svelte
+<svelte:options runes={true} />
+<script>
+	const t = $effect.pending();
+	void t;
+</script>
+<b>x</b>
+```
+
+```js
+/* generate: 'client' — `t` is never declared */
+export default function A($$anchor) {
+	void t;
+
+	var b = root();
+	$.append($$anchor, b);
+}
+```
+
+Rendering throws `ReferenceError: t is not defined`. The output parses, so nothing upstream of a
+browser reports it.
+
+On the server the declarator falls through to a different branch and yields `void 0` where the
+rune's value is `0`:
+
+```js
+/* generate: 'server' */
+const t = void 0;      // should be `const t = 0;`
+```
+
+`phases/3-transform/server/visitors/CallExpression.js:35` returns `b.literal(0)` for
+`$effect.pending`, and that is what the same rune produces in every other position — so the
+declarator path is inconsistent with the compiler's own answer.
+
+## Every other position is correct
+
+For `$effect.pending`, all of these produce `$.eager($.pending)` on the client and `0` on the
+server:
+
+| position | client | server |
+|---|---|---|
+| `$effect.pending();` as a statement | ok | ok |
+| `{$effect.pending()}` in the template | ok | ok |
+| `$derived($effect.pending())` | ok | ok |
+| inside an `$effect` callback | ok | ok |
+| `return $effect.pending()` in a function | ok | ok |
+| `let t; t = $effect.pending();` (plain assignment) | ok | ok |
+| **`const t = $effect.pending();`** | **declaration dropped** | **`void 0`** |
+
+The assignment row is the sharpest control: the same rune, the same binding, and only the
+declarator syntax differs.
+
+## Suggested fix
+
+Add `$effect.pending` to both lists and remove `$inspect` from both. More durably, the two lists
+are the same decision written twice and they already disagree — the client allows
+`$inspect.trace`, `$state.snapshot` and `$host` while the server does not — so deriving them from
+one table would keep the next rune from landing in the same gap.
+
+## Where this is referenced
+
+rsvelte #3441 records the neighbouring `$inspect(...).with(...)` declarator, which **is** an
+rsvelte defect — official handles that form correctly on all three targets — and points here for
+the plain `$inspect` and `$effect.pending` halves above.

--- a/upstream_issues/3451-oxfmt-drops-required-parens-after-a-private-in.md
+++ b/upstream_issues/3451-oxfmt-drops-required-parens-after-a-private-in.md
@@ -1,0 +1,58 @@
+# oxfmt drops the required parentheses around a private-in's right operand
+
+`oxfmt 0.63.0` removes parentheses that carry meaning when the left operand of `in` is a private
+name, while keeping them for the identical expression with an ordinary left operand.
+
+```js
+class Box {
+  #value = 1;
+  static a(o) { return #value in (o || {}); }
+  static b(o) { return "k" in (o || {}); }
+}
+```
+
+```js
+/* oxfmt -c … --stdin-filepath x.js */
+class Box {
+  #value = 1;
+  static a(o) {
+    return #value in o || {};       // <- now ((#value in o) || {})
+  }
+  static b(o) {
+    return "k" in (o || {});        // <- correct
+  }
+}
+```
+
+`in` binds tighter than `||`, so `a` returns `true`/`{}` after formatting where the source returns
+`true`/`false`.
+
+## Scope
+
+| source | formatted | verdict |
+|---|---|---|
+| `#value in (o \|\| {})` | `#value in o \|\| {}` | **meaning changed** |
+| `#value in (o ?? {})` | `#value in o ?? {}` | **meaning changed** |
+| `#value in (o, {})` | unchanged | ok |
+| `(#value in o) \|\| f` | `#value in o \|\| f` | ok — genuinely redundant |
+| `"k" in (o \|\| {})` | unchanged | ok |
+| `("k" in (o \|\| {})) && f` | `"k" in (o \|\| {}) && f` | ok |
+
+The last two rows are the control: same operator, same right operand, ordinary left operand,
+parentheses kept. So the needs-parens computation is reached for `BinaryExpression` and missed for
+the private-name form — the same shape as the ESTree/oxc split that produced the rsvelte-side
+defect in #3413, where `#x in o` is a `BinaryExpression` with a `PrivateIdentifier` left in ESTree
+and a dedicated `PrivateInExpression` node in oxc. A formatter that computes parenthesisation per
+node kind will miss the second unless it is enumerated.
+
+## Impact here
+
+`rsvelte-fmt` delegates embedded and standalone JavaScript to this engine, so
+`rsvelte-fmt --stdin --stdin-filepath x.svelte` reproduces it on a `<script>` block and silently
+rewrites the user's program (#3451).
+
+The formatter-parity gate cannot see it: the oracle **is** oxfmt, so the defect is reproduced
+identically on both sides and scores as a match by construction. A brand check also appears
+nowhere in svelte.dev, which is the whole population that gate formats.
+
+Measured with `scripts/fixtures/fmt-corpus.oxfmtrc.json`, the config the gate itself uses.


### PR DESCRIPTION
Two upstream defects found while sweeping the rune surface and formatting the repro files.
Documentation only — no compiler change.

- **`3441`** (svelte) — both `VariableDeclaration` visitors decide by a hard-coded allow-list which
  runes may sit in a declarator initializer, and two entries are wrong. `$inspect` is on both lists
  and must not be: the `CallExpression` visitor replaces the call with an empty statement, leaving
  `const t = ;;` on `client` and `server` (`dev` is correct, which is why it survives).
  `$effect.pending` is on neither, so the client never pushes the declarator — the binding is
  undeclared and rendering throws `ReferenceError` — while the server yields `void 0` where its own
  `CallExpression` visitor returns `0`. Every other position for that rune is correct, including a
  plain assignment to the same binding.
- **`3451`** (oxc / oxfmt 0.63.0) — required parentheses around a private-in's right operand are
  dropped: `#value in (o || {})` becomes `#value in o || {}`, a different program. `"k" in (o || {})`
  keeps them, which isolates it to the private-name node. `rsvelte-fmt` inherits it (#3451).

Measured on the pinned submodule (svelte `5.56.9`, `20b341f1`) and on the gate's own
`fmt-corpus.oxfmtrc.json`.

Refs #3441
Refs #3451
