### PR TITLE
fix(parse): report a `{@const}` with no `=` as the missing token

### DIFF
--- a/.changeset/const-tag-missing-equals.md
+++ b/.changeset/const-tag-missing-equals.md
@@ -1,0 +1,5 @@
+---
+'@rsvelte/compiler': patch
+---
+
+Report a `{@const …}` with no `=` as the missing token upstream raises. `{@const c}` compiled, dropped the declaration and left the body referencing a name no module declares, so the branch threw `ReferenceError` when it rendered — output that parses, which is why only equality could see it. The body is now read as a pattern followed by `=`, as upstream does, so the position lands where the pattern ends and a non-pattern body (`{@const 1}`, `{@const let}`) carries its own error code

--- a/crates/rsvelte_core/src/compiler/phases/1_parse/state/tag.rs
+++ b/crates/rsvelte_core/src/compiler/phases/1_parse/state/tag.rs
@@ -2188,8 +2188,10 @@ impl<'a> Parser<'a> {
                         declarator_end,
                     )
                 } else {
-                    // No `=` found – fall back to parsing as a single expression
-                    self.parse_js_expression(trimmed, expr_start)
+                    // Upstream reads a PATTERN and then `parser.eat('=', true)`,
+                    // so a const tag with no initializer is a missing `=` rather
+                    // than an expression to be parsed and dropped.
+                    return Err(self.const_tag_missing_equals(expr_content, expr_start));
                 };
 
                 Ok(Some(TemplateNode::ConstTag(Box::new(ConstTag {
@@ -2282,6 +2284,54 @@ impl<'a> Parser<'a> {
                 Ok(None)
             }
         }
+    }
+
+    /// The error upstream raises for a `{@const …}` body with no top-level `=`.
+    ///
+    /// `read_pattern` reads an identifier or a bracketed destructuring pattern
+    /// and stops, so the missing `=` is reported where that pattern ends, past
+    /// the whitespace `allow_whitespace` then skips — which is why `{@const c}`
+    /// and `{@const c }` report a byte apart.
+    fn const_tag_missing_equals(
+        &self,
+        expr_content: &str,
+        expr_start: usize,
+    ) -> crate::error::ParseError {
+        let pattern_end = match expr_content.chars().next() {
+            Some(open @ ('{' | '[')) => {
+                match find_matching_bracket(self.source, expr_start + 1, open) {
+                    Some(close) => close + 1 - expr_start,
+                    None => expr_content.len(),
+                }
+            }
+            Some(first) if first.is_alphabetic() || first == '_' || first == '$' => {
+                let len = expr_content
+                    .char_indices()
+                    .find(|(_, c)| !(c.is_alphanumeric() || *c == '_' || *c == '$'))
+                    .map_or(expr_content.len(), |(at, _)| at);
+                let name = &expr_content[..len];
+                if crate::compiler::phases::phase1_parse::utils::is_reserved(name) {
+                    return crate::error::ParseError::svelte(
+                        "unexpected_reserved_word",
+                        format!(
+                            "'{name}' is a reserved word in JavaScript and cannot be used here"
+                        ),
+                        (expr_start, expr_start),
+                    );
+                }
+                len
+            }
+            _ => {
+                return crate::error::ParseError::svelte(
+                    "expected_pattern",
+                    "Expected identifier or destructure pattern",
+                    (expr_start, expr_start),
+                );
+            }
+        };
+        let rest = &expr_content[pattern_end..];
+        let at = expr_start + pattern_end + (rest.len() - rest.trim_start_ws().len());
+        crate::error::ParseError::expected_token("=", at)
     }
 
     /// Parse a JavaScript expression and return as Expression (internal version).

--- a/crates/rsvelte_core/tests/const_tag_missing_equals_3246.rs
+++ b/crates/rsvelte_core/tests/const_tag_missing_equals_3246.rs
@@ -1,0 +1,136 @@
+//! `{@const c}` — a const tag with no `=` — compiled, dropped the declaration
+//! and left the body referring to a name that was never declared (issue #3246).
+//!
+//! Upstream's `special()` reads a PATTERN and then `parser.eat('=', true)`, so
+//! the missing `=` is reported where the pattern ends, past the whitespace
+//! `allow_whitespace` skips. Every position below was measured against
+//! `svelte.compile`, which is why `{@const c}` and `{@const c }` differ by a
+//! byte: the whitespace is part of what upstream consumes before it looks for
+//! the `=`.
+
+use rsvelte_core::{CompileOptions, GenerateMode, compile, compiler::CssMode};
+
+fn error(src: &str) -> Option<(String, String, u32)> {
+    compile(
+        src,
+        CompileOptions {
+            filename: Some("Test.svelte".to_string()),
+            generate: GenerateMode::Client,
+            css: CssMode::External,
+            ..Default::default()
+        },
+    )
+    .err()
+    .map(|err| {
+        let d = err.diagnostic();
+        (
+            d.code.unwrap_or_default(),
+            d.message.lines().next().unwrap_or_default().to_string(),
+            d.span.map(|(start, _)| start).unwrap_or(u32::MAX),
+        )
+    })
+}
+
+fn assert_error(src: &str, code: &str, message: &str, at: u32) {
+    let actual = error(src).unwrap_or_else(|| panic!("must not compile: {src:?}"));
+    assert_eq!(
+        actual,
+        (code.to_string(), message.to_string(), at),
+        "for {src:?}"
+    );
+}
+
+const EXPECTED_EQUALS: &str = "Expected token =";
+
+#[test]
+fn a_const_tag_without_an_initializer_is_a_missing_equals() {
+    for (src, at) in [
+        ("{#if true}{@const c}<b>x</b>{/if}", 19),
+        ("{#if true}{@const {a}}<b>x</b>{/if}", 21),
+        ("{#if true}{@const [a]}<b>x</b>{/if}", 21),
+        ("{#if true}{@const {a = 1}}<b>x</b>{/if}", 25),
+        ("{@const c}", 9),
+        ("{#each [1] as v}{@const c}<b>x</b>{/each}", 25),
+    ] {
+        assert_error(src, "expected_token", EXPECTED_EQUALS, at);
+    }
+}
+
+/// `read_type_annotation` rewinds when there is no `:`, so the whitespace after
+/// the pattern is consumed by the `allow_whitespace()` that precedes the `=`.
+#[test]
+fn the_position_moves_past_the_whitespace_after_the_pattern() {
+    for (src, at) in [
+        ("{#if true}{@const c }<b>x</b>{/if}", 20),
+        ("{#if true}{@const c  }<b>x</b>{/if}", 21),
+        ("{#if true}{@const c\n}<b>x</b>{/if}", 20),
+    ] {
+        assert_error(src, "expected_token", EXPECTED_EQUALS, at);
+    }
+}
+
+/// A pattern is an identifier or a bracketed destructuring and nothing else, so
+/// the `=` is expected right after the name — not after the call or the member
+/// access that follows it.
+#[test]
+fn a_pattern_stops_at_the_identifier() {
+    for (src, at) in [
+        ("{#if true}{@const f()}<b>x</b>{/if}", 19),
+        ("{#if true}{@const a.b}<b>x</b>{/if}", 19),
+        ("{#if true}{@const c d}<b>x</b>{/if}", 20),
+    ] {
+        assert_error(src, "expected_token", EXPECTED_EQUALS, at);
+    }
+}
+
+#[test]
+fn a_body_that_cannot_start_a_pattern_reports_its_own_code() {
+    assert_error(
+        "{#if true}{@const 1}<b>x</b>{/if}",
+        "expected_pattern",
+        "Expected identifier or destructure pattern",
+        18,
+    );
+    assert_error(
+        "{#if true}{@const let}<b>x</b>{/if}",
+        "unexpected_reserved_word",
+        "'let' is a reserved word in JavaScript and cannot be used here",
+        18,
+    );
+}
+
+/// The two neighbouring shapes already agreed with upstream before the fix, and
+/// have to keep doing so — the missing-`=` branch sits between them.
+#[test]
+fn the_neighbouring_shapes_are_unchanged() {
+    assert_error(
+        "{#if true}{@const}<b>x</b>{/if}",
+        "expected_whitespace",
+        "Expected whitespace",
+        17,
+    );
+    assert_error(
+        "{#if true}{@const a = 1, b = 2}<b>x</b>{/if}",
+        "const_tag_invalid_expression",
+        "{@const ...} must consist of a single variable declaration",
+        22,
+    );
+}
+
+#[test]
+fn a_const_tag_with_an_initializer_still_compiles() {
+    for src in [
+        "{#if true}{@const c = 1}<b>{c}</b>{/if}",
+        "{#if true}{@const {a} = {a: 1}}<b>{a}</b>{/if}",
+        "{#if true}{@const [a] = [1]}<b>{a}</b>{/if}",
+        "{#each [1] as v}{@const d = v * 2}<b>{d}</b>{/each}",
+        // A `=` inside a destructuring default is not the assignment.
+        "{#if true}{@const {a = 1} = {}}<b>{a}</b>{/if}",
+        // Nor is one inside a string, a comparison or an arrow.
+        "{#if true}{@const c = '='}<b>{c}</b>{/if}",
+        "{#if true}{@const c = 1 === 1}<b>{c}</b>{/if}",
+        "{#if true}{@const c = () => 1}<b>{c()}</b>{/if}",
+    ] {
+        assert_eq!(error(src), None, "must compile: {src:?}");
+    }
+}


### PR DESCRIPTION
Closes #3246

## What

`{@const c}` — a const tag with no `=` — was accepted, the declaration was dropped, and the body kept referring to a name that no module declares:

```js
var consequent = ($$anchor) => {
	var b = root();
	b.textContent = c;   // ReferenceError: c is not defined
	$.append($$anchor, b);
};
```

The output **parses**, so the parse oracle cannot see it; only output equality can.

## Why the position is what it is

Upstream's `special()` (`1-parse/state/tag.js`) does

```js
const id = read_pattern(parser);
parser.allow_whitespace();
parser.eat('=', true);
```

so the missing `=` is reported where the **pattern** ends, past the whitespace `allow_whitespace` then skips. rsvelte instead had a fall-through that parsed the whole body as an expression and threw the result away. It now mirrors the two steps, which is what makes the following all land on upstream's byte:

| source | official / rsvelte |
|---|---|
| `{@const c}` | `expected_token` "Expected token =" @19 |
| `{@const c }` | @20 |
| `{@const c  }` | @21 |
| `{@const c⏎}` | @20 |
| `{@const {a}}` | @21 |
| `{@const [a]}` | @21 |
| `{@const {a = 1}}` | @25 |
| `{@const f()}` | @19 |
| `{@const a.b}` | @19 |
| `{@const c d}` | @20 |

The last three are the ones that show a pattern is **not** an expression: `read_pattern` reads an identifier (or a bracketed destructuring) and stops, so the `=` is expected right after the name — not after the call or the member access that follows it. A fix that parsed the body as an expression and pointed at its end would put all three in the wrong place.

Two shapes are not a missing `=` at all and carry their own code, also measured:

| source | official / rsvelte |
|---|---|
| `{@const 1}` | `expected_pattern` "Expected identifier or destructure pattern" @18 |
| `{@const let}` | `unexpected_reserved_word` "'let' is a reserved word …" @18 |

Every expectation above was read off `svelte.compile`, not written by hand.

## Over-reach is the risk, so the neighbours are pinned

The issue notes the two adjacent shapes already agreed with upstream, which is what localises the defect to "identifier but no initialiser". They are now regression tests, so a fix that widens into them fails:

- `{@const}` → `expected_whitespace` @17
- `{@const a = 1, b = 2}` → `const_tag_invalid_expression` @22

And eight const tags that **do** have an initialiser are asserted to still compile, including the four shapes where a `=` appears without being the assignment: a destructuring default (`{@const {a = 1} = {}}`), a string (`{@const c = '='}`), a comparison (`{@const c = 1 === 1}`) and an arrow (`{@const c = () => 1}`).

## Tests

`crates/rsvelte_core/tests/const_tag_missing_equals_3246.rs`, 6 tests, 24 inputs. Positions are asserted, not just codes.

## Scope note

`{@const}` swallowing a *parse error in its initialiser* (#3202) and the unterminated-`{` attribution (#3247) are separate defects; #3247 in particular has two independent causes, both written up in [a comment on that issue](https://github.com/baseballyama/rsvelte/issues/3247#issuecomment-5378179477).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
