### PR TITLE
test: 期限切れの HMR skip エントリ 2 件を外して main の赤を解消する

### DIFF
--- a/crates/rsvelte_core/tests/common/mod.rs
+++ b/crates/rsvelte_core/tests/common/mod.rs
@@ -467,12 +467,6 @@ pub const RUNTIME_RUNES_SKIP_NAMES: &[&str] = &[
     // wrapper for the IfBlock branch — the awaited `@const` blocker is not
     // propagated across the closure boundary.
     "async-style-after-await",
-    // `hmr: true` fixtures whose SERVER output drops the `<!---->` anchor the
-    // official compiler emits around a dev-mode dynamic component (and, for
-    // `hmr-each-keyed-unshift`, a preserved JSDoc comment). Client output
-    // matches for both; the other four `hmr: true` fixtures pass outright.
-    "hmr-removal",
-    "hmr-each-keyed-unshift",
 ];
 
 /// runtime-legacy fixtures still failing on the rsvelte port.


### PR DESCRIPTION
## 症状

**`main` が赤いままです。** `audit_skipped_fixtures` が STALE SKIP 2 件で panic します:

```
2 STALE SKIP ENTRIES — these fixtures pass but are still skipped, so they contribute no coverage:
  - runtime-runes/hmr-removal
  - runtime-runes/hmr-each-keyed-unshift
```

## 原因

**#3362（`fix: hmr output parity, cssHash at the NAPI boundary, and two fabricated js.map fields`）が赤いままマージされています。**

同 PR が HMR の出力パリティを直したことで上記 2 fixture が通るようになり、その時点で skip エントリは無効になりました。本来は同じコミットで外すべきものです。外れなかったのは、**#3362 自身の `Test (ubuntu-latest, 3)` が枯渇したキューの下で 5 時間 5 分かかり、23:45:42Z のマージ時点でまだ走っていた**ためです（`Tests` ゲートも同じ失敗を報告しています）。

そして **それ以降 `main` は一度も判定を持っていません** — 後続の CI は全て cancelled か queued のままです。つまりこの破損は「無かった」のではなく「見えなかった」だけです。これは AGENTS.md が #2435 / #2593 で記録している *cancelled run と green run は区別が付かない* の実例です。

## 変更

`crates/rsvelte_core/tests/common/mod.rs` の `RUNTIME_RUNES_SKIP_NAMES` から当該 2 エントリを削除（コメント含め 6 行）。**コンパイラの挙動変更はゼロです** — #3362 が既に直した挙動に、テスト側の記述を合わせるだけなので `test:` としています。

## 検証

pinned submodule（svelte@5.56.9）の fixture に対してローカル実測:

```
cargo test -p rsvelte_core --test audit_skipped     ok

cargo test -p rsvelte_core --test runtime -- test_runtime_runes
  === runtime-runes Tests ===
  Total: 1011/1011 passed (1 skipped)
    Client: 1011/1011
    Server: 1011/1011
```

削除前は同じツリーで `audit_skipped` が上記の panic で落ちることも確認済みです（陰性対照）。残る 1 skip は `async-style-after-await` で、audit は従来どおり「まだ失敗中」と正しく報告します。

## 残す判断

AGENTS.md の互換表はこの suite を `1007/1007` と書いていますが、**これは v5.56.8 時点の `pnpm run compatibility-report` が出典で、submodule は既に 5.56.9** です。つまり本 PR の前から stale です。1 行だけ書き換えると「他の行は正しい」という誤った含意が付くので、`pnpm run test-and-update` で全体を取り直す作業として分離し、ここでは触っていません。

## 影響

`main` が赤い間、**この tree から切られた全 PR が同じ `Test (ubuntu-latest, 3)` で落ちます**（並行キャンペーンで確認されているだけで 56 本以上）。本物の退行と区別が付かない形なので、他の作業より先にこれを通す価値があります。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
