### PR TITLE
fix(parse): end an unquoted attribute value on the HTML terminator set

### DIFF
--- a/.changeset/unquoted-attribute-value-terminators.md
+++ b/.changeset/unquoted-attribute-value-terminators.md
@@ -1,0 +1,11 @@
+---
+'@rsvelte/compiler': patch
+---
+
+End an unquoted attribute value on `"`, `'`, `=`, `<` and a backtick
+
+An unquoted value was read as one run up to whitespace, `>` or `/>`. The HTML
+"attribute value (unquoted) state" — upstream's
+`regex_invalid_unquoted_attribute_value` — also ends it on `"`, `'`, `=`, `<`
+and a backtick, so `<div data-x=a<b>` produced one attribute where official
+produces two, and documents official rejects were accepted.

--- a/crates/rsvelte_core/src/compiler/phases/1_parse/state/element.rs
+++ b/crates/rsvelte_core/src/compiler/phases/1_parse/state/element.rs
@@ -1957,8 +1957,7 @@ impl<'a> Parser<'a> {
 
                 while !self.is_eof() {
                     let c = self.current_char();
-                    // End of unquoted value (but NOT / alone)
-                    if is_js_whitespace(c) || c == '>' {
+                    if ends_unquoted_attribute_value(self.source, self.index) {
                         break;
                     }
                     // Expression start
@@ -2341,30 +2340,8 @@ impl<'a> Parser<'a> {
                 if cur_byte == q {
                     break;
                 }
-            } else {
-                // Unquoted value ends at whitespace or >
-                if cur_byte == b'>'
-                    || cur_byte == b' '
-                    || cur_byte == b'\t'
-                    || cur_byte == b'\n'
-                    || cur_byte == b'\r'
-                {
-                    break;
-                }
-                // Stop at /> (self-closing tag marker)
-                if cur_byte == b'/'
-                    && self.index + 1 < self.bytes.len()
-                    && self.bytes[self.index + 1] == b'>'
-                {
-                    break;
-                }
-                // Non-ASCII whitespace check
-                if cur_byte >= 0x80 {
-                    let c = self.source[self.index..].chars().next().unwrap_or('\0');
-                    if is_js_whitespace(c) {
-                        break;
-                    }
-                }
+            } else if ends_unquoted_attribute_value(self.source, self.index) {
+                break;
             }
 
             // Check for expression
@@ -2487,34 +2464,21 @@ impl<'a> Parser<'a> {
                     self.index += offset;
                     entity_before_stop = Some(seen);
                 } else {
-                    // Unquoted: scan for '{', whitespace, '>', or '/>'
+                    // Unquoted: `{` opens an expression, and everything else
+                    // ends where upstream's terminator set says it does.
                     while self.index < self.bytes.len() {
                         let b = self.bytes[self.index];
-                        if b == b'{'
-                            || b == b'>'
-                            || b == b' '
-                            || b == b'\t'
-                            || b == b'\n'
-                            || b == b'\r'
-                        {
+                        if b == b'{' || ends_unquoted_attribute_value(self.source, self.index) {
                             break;
                         }
-                        if b == b'/'
-                            && self.index + 1 < self.bytes.len()
-                            && self.bytes[self.index + 1] == b'>'
-                        {
-                            break;
-                        }
-                        if b < 0x80 {
-                            self.index += 1;
+                        self.index += if b < 0x80 {
+                            1
                         } else {
-                            // Non-ASCII: check for Unicode whitespace
-                            let c = self.source[self.index..].chars().next().unwrap_or('\0');
-                            if is_js_whitespace(c) {
-                                break;
-                            }
-                            self.index += c.len_utf8();
-                        }
+                            self.source[self.index..]
+                                .chars()
+                                .next()
+                                .map_or(1, char::len_utf8)
+                        };
                     }
                 }
                 let text_end = self.index;
@@ -2840,6 +2804,27 @@ fn is_identifier_continue(c: char) -> bool {
 /// Check if a character is valid in a component name (after the first char).
 fn is_component_name_char(c: char) -> bool {
     is_identifier_continue(c) || c == '.'
+}
+
+/// Upstream's `regex_invalid_unquoted_attribute_value`, `/(\/>|[\s"'=<>`])/y` —
+/// the HTML "attribute value (unquoted) state" terminators plus the `/>`
+/// self-closing marker. A lone `/` is part of the value.
+fn ends_unquoted_attribute_value(source: &str, index: usize) -> bool {
+    let bytes = source.as_bytes();
+    let Some(&byte) = bytes.get(index) else {
+        return true;
+    };
+    if matches!(byte, b'"' | b'\'' | b'=' | b'<' | b'>' | b'`') {
+        return true;
+    }
+    if byte == b'/' {
+        return bytes.get(index + 1) == Some(&b'>');
+    }
+    if byte.is_ascii() {
+        super::super::parser::is_js_whitespace_byte(byte)
+    } else {
+        source[index..].chars().next().is_some_and(is_js_whitespace)
+    }
 }
 
 /// Returns the byte offset within `name` of the first character that prevents

--- a/crates/rsvelte_core/tests/unquoted_attribute_terminators_3332.rs
+++ b/crates/rsvelte_core/tests/unquoted_attribute_terminators_3332.rs
@@ -1,0 +1,96 @@
+//! Issue #3332 — the terminator set of an unquoted attribute value.
+//!
+//! An unquoted value was read as one run up to whitespace, `>` or `/>`. The
+//! HTML "attribute value (unquoted) state" — upstream's
+//! `regex_invalid_unquoted_attribute_value`, `/(\/>|[\s"'=<>`])/y` — also ends
+//! it on `"`, `'`, `=`, `<` and a backtick. Swallowing those produced a
+//! different attribute *set* on inputs official splits, and accepted documents
+//! official rejects.
+//!
+//! Every expectation was measured against the official compiler on the same
+//! source. The controls are the value shapes that already agreed: `>`, `&`, an
+//! entity, and a trailing `/` — so this is the terminator set, not unquoted
+//! values in general.
+
+use rsvelte_core::{CompileOptions, GenerateMode, compile};
+
+fn try_compile(source: &str) -> Result<String, String> {
+    match compile(
+        source,
+        CompileOptions {
+            filename: Some("A.svelte".to_string()),
+            generate: GenerateMode::Client,
+            ..Default::default()
+        },
+    ) {
+        Ok(result) => Ok(result.js.code),
+        Err(err) => Err(format!("{err:?}")),
+    }
+}
+
+fn compile_ok(source: &str) -> String {
+    try_compile(source).expect("compile failed")
+}
+
+#[test]
+fn a_less_than_ends_the_value_and_starts_an_attribute() {
+    let out = compile_ok("<div data-x=a<b></div>\n");
+    // Official: `<div data-x="a" <b=""></div>`.
+    assert!(
+        out.contains(r#"<div data-x="a" <b=""></div>"#),
+        "the `<` did not end the value:\n{out}"
+    );
+}
+
+#[test]
+fn a_backtick_ends_the_value_and_starts_an_attribute() {
+    let out = compile_ok("<div data-x=a`b></div>\n");
+    assert!(
+        out.contains("<div data-x=\"a\" \\`b=\"\"></div>"),
+        "the backtick did not end the value:\n{out}"
+    );
+}
+
+#[test]
+fn a_quote_or_equals_after_the_value_is_rejected() {
+    // Official rejects all three with `expected_token` ("Expected token >").
+    for source in [
+        "<div data-x=a\"b></div>\n",
+        "<div data-x=a'b></div>\n",
+        "<div data-x=a=b></div>\n",
+    ] {
+        let err = try_compile(source).expect_err(&format!("{source:?} was accepted"));
+        assert!(
+            err.contains("expected_token"),
+            "{source:?} produced the wrong error:\n{err}"
+        );
+    }
+}
+
+#[test]
+fn a_missing_value_before_another_attribute_is_rejected() {
+    // `<div data-x= id="i">`: official `expected_token` — the `=` of `id="i"`
+    // ends the (empty) value, so the tag is not closed where one is demanded.
+    let err = try_compile("<div data-x= id=\"i\"></div>\n").expect_err("was accepted");
+    assert!(err.contains("expected_token"), "{err}");
+}
+
+/// The controls: the four value shapes that were already byte-identical.
+#[test]
+fn the_previously_matching_value_shapes_are_unchanged() {
+    assert!(compile_ok("<div data-x=abc></div>\n").contains(r#"data-x="abc""#));
+    assert!(compile_ok("<div data-x=a&b></div>\n").contains(r#"data-x="a&amp;b""#));
+    assert!(compile_ok("<div data-x=&amp;></div>\n").contains(r#"data-x="&amp;""#));
+    // A lone `/` is part of the value; only `/>` ends it.
+    assert!(compile_ok("<input data-x=abc/>\n").contains(r#"data-x="abc""#));
+}
+
+/// A quoted value is untouched by the unquoted terminator set.
+#[test]
+fn a_quoted_value_still_holds_the_terminators() {
+    let out = compile_ok("<div data-x=\"a<b=c`d\"></div>\n");
+    assert!(
+        out.contains(r"a&lt;b=c\`d"),
+        "a quoted value lost its content:\n{out}"
+    );
+}


### PR DESCRIPTION
Closes #3332

## What was wrong

An unquoted attribute value was read as one run up to whitespace, `>` or `/>`. The
HTML *attribute value (unquoted) state* — upstream's
`regex_invalid_unquoted_attribute_value`, `/(\/>|[\s"'=<>`])/y` — also ends it on
`"`, `'`, `=`, `<` and a backtick.

```svelte
<div data-x=a<b></div>
```

```js
// official                                     // rsvelte before
<div data-x="a" <b=""></div>                    <div data-x="a&lt;b"></div>
```

So rsvelte produced a different attribute *set* on inputs official splits, and
accepted documents official rejects.

## Three scanners answered one question

The interesting part is not the terminator list, it is that **three separate scans
decided where an unquoted value ends, and fixing two of them changed nothing**:

| site | what it is |
|---|---|
| `parse_attribute_value`, outer per-byte guard | stops the value loop |
| `parse_attribute_value`, inner run scanner | consumes a whole text run at once — **this is the one that reaches first** |
| `parse_style_directive`'s own unquoted reader | `style:color=red` |

The run scanner advances past `<` before the outer guard ever looks at it, so the
grid was byte-for-byte unchanged after the first fix — the same numbers, which read
exactly like "the change had no effect" rather than "you fixed the wrong copy". All
three now call one predicate, `ends_unquoted_attribute_value`, named after the
upstream regex it ports.

## Measurement

16 value shapes × 5 hosts × 2 targets = 160 cells, official as the oracle, comparing
accept/reject, the emitted text when both accept, and `code` + `line:column` when
both reject:

| | before | after |
|---|---|---|
| match | 60 | **130** |
| over-accepted (official rejects, rsvelte compiles) | 66 | **0** |
| under-accepted | 0 | 0 |
| wrong value (both accept, different text) | 22 | **0** |
| error field (both reject, different code/position) | 12 | 30 |

The `before` column reproduces the issue's counts exactly (66 / 22 / 12).

**The error-field count going up is the point, not a regression.** 66 cells that used
to compile now reject; a cell that compiled had no error to compare, so fixing the
over-acceptance is what made its position observable. All 30 are one of two shapes,
and neither is an over-acceptance any more:

- **20 cells** — `data-x=a</b` and `data-x=a</script>b`: right code (`expected_token`),
  position 2 columns early. Upstream reads `<` as an attribute name, eats the `/`,
  then demands `>`; rsvelte's attribute loop breaks on `<` + `/` and reports there.
  Changing that break is element-recovery territory (`element_unclosed`), so it is
  filed as #3486 rather than bundled here.
- **10 cells** — `data-x=a{b`: the `{` row, which #3332 itself calls "a separate
  defect in the same lexer". It is #3333's cause (a mustache's extent decided by a
  brace scan) and is being handled there.

## Tests

`crates/rsvelte_core/tests/unquoted_attribute_terminators_3332.rs`, every expectation
measured against the official compiler on the same source.

**Negative control**: narrowing `ends_unquoted_attribute_value` back to `>` +
whitespace + `/>` fails exactly the four tests that assert the new terminators, each
with its predicted message (`the `<` did not end the value`, `the backtick did not
end the value`, and `was accepted` for the two rejection tests), while both controls —
the four previously-matching value shapes, and a *quoted* value containing all five
terminators — stay green.

Suites run locally: `parser_fixtures`, `parser_hardening`, `compiler_errors`,
`compiler_fixtures`, `runtime`, `ssr`, `validator`.
