### PR TITLE
fix(analyze): give an each fallback its own scope

### DIFF
--- a/.changeset/each-fallback-own-scope.md
+++ b/.changeset/each-fallback-own-scope.md
@@ -1,0 +1,8 @@
+---
+"@rsvelte/compiler": patch
+---
+
+Give an `{#each}`'s `{:else}` fallback its own scope, as upstream does. A `{@const}` or
+`{#snippet}` in the fallback no longer collides with the each item or index (which are not
+in scope there), and no longer leaks into the each scope — which had been adding unused
+`$$index, $$array` parameters to the each *body* callback.

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/scope.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/scope.rs
@@ -43,6 +43,14 @@ pub struct ScopeRoot {
     /// with the other links of the chain), so the alternates live in their own
     /// map under the enclosing block's unique start.
     pub if_alternate_scope_map: FxHashMap<u32, usize>,
+    /// Scope indices of `{:else}` fragments, keyed by their `{#each}`'s start
+    /// position. Upstream's `EachBlock` visitor walks the body's *nodes* with
+    /// the each scope but visits the fallback as a `Fragment`, so only the
+    /// fallback reaches the `Fragment` visitor's `scope.child(...)` — which is
+    /// why `{@const it = 1}` duplicates the item binding in the body and merely
+    /// shadows it in the fallback. Keyed like `if_alternate_scope_map` and for
+    /// the same reason: the fallback has no start offset of its own.
+    pub each_fallback_scope_map: FxHashMap<u32, usize>,
     /// Scope indices created for `{#snippet …}` bodies. Snippet bodies become
     /// separate functions in the generated output, so template declarations
     /// (`{@const}` / `{const}` / `{let}`) made inside one snippet are NOT
@@ -82,6 +90,7 @@ impl ScopeRoot {
             each_block_collection_infos: Vec::new(),
             template_scope_map: FxHashMap::default(),
             if_alternate_scope_map: FxHashMap::default(),
+            each_fallback_scope_map: FxHashMap::default(),
             snippet_scope_indices: FxHashSet::default(),
             conflicts: FxHashSet::default(),
             bindings_by_name: FxHashMap::default(),

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/scope_builder.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/scope_builder.rs
@@ -90,6 +90,9 @@ pub struct ScopeBuilder<'a> {
     /// `{:else}` fragment scopes keyed by the enclosing `{#if}`'s start (see
     /// `ScopeRoot::if_alternate_scope_map`).
     if_alternate_scope_map: FxHashMap<u32, usize>,
+    /// `{:else}` fragment scopes keyed by the enclosing `{#each}`'s start (see
+    /// `ScopeRoot::each_fallback_scope_map`).
+    each_fallback_scope_map: FxHashMap<u32, usize>,
     /// Scope indices created for `{#snippet …}` bodies (see
     /// `ScopeRoot::snippet_scope_indices`).
     snippet_scope_indices: rustc_hash::FxHashSet<usize>,
@@ -144,6 +147,7 @@ impl<'a> ScopeBuilder<'a> {
             each_block_collection_infos: Vec::new(),
             template_scope_map: FxHashMap::default(),
             if_alternate_scope_map: FxHashMap::default(),
+            each_fallback_scope_map: FxHashMap::default(),
             snippet_scope_indices: rustc_hash::FxHashSet::default(),
             template_expression_params: Vec::new(),
             nested_declared_names: rustc_hash::FxHashSet::default(),
@@ -354,6 +358,7 @@ impl<'a> ScopeBuilder<'a> {
                 each_block_collection_infos,
                 template_scope_map: self.template_scope_map,
                 if_alternate_scope_map: self.if_alternate_scope_map,
+                each_fallback_scope_map: self.each_fallback_scope_map,
                 snippet_scope_indices: self.snippet_scope_indices,
                 conflicts,
                 bindings_by_name: self.bindings_by_name,
@@ -3447,9 +3452,16 @@ impl<'a> ScopeBuilder<'a> {
         // Visit body
         self.visit_fragment(&block.body);
 
-        // Visit fallback if present
+        // Upstream walks the body's NODES with the each scope but visits the
+        // fallback as a `Fragment`, so only the fallback reaches the `Fragment`
+        // visitor's `scope.child(...)`: a `{@const}` naming the item duplicates
+        // it in the body and shadows it here.
         if let Some(ref fallback) = block.fallback {
+            let fallback_outer = self.push_scope();
+            self.each_fallback_scope_map
+                .insert(block.start, self.current_scope);
             self.visit_fragment(fallback);
+            self.pop_scope(fallback_outer);
         }
 
         // Official Svelte compiler logic (index.js lines 638-674):

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/each_block.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/each_block.rs
@@ -161,11 +161,22 @@ pub fn visit<'a, 'b: 'a>(
     // Visit the body and fallback
     fragment::analyze(&mut block.body, context)?;
 
-    // Fallback is still in the each block's scope (same scope as body), and
-    // upstream's `animate:` rule reads the parent's key and BODY child count for
-    // a fallback element too — so the frame stays pushed across it.
+    // The fallback gets its own child scope (upstream visits it as a `Fragment`
+    // while the body's nodes are walked with the each scope), but upstream's
+    // `animate:` rule reads the parent's key and BODY child count for a fallback
+    // element too — so the frame stays pushed across it.
     if let Some(ref mut fallback) = block.fallback {
+        let body_scope = context.scope;
+        if let Some(&fallback_scope) = context
+            .analysis
+            .root
+            .each_fallback_scope_map
+            .get(&block.start)
+        {
+            context.scope = fallback_scope;
+        }
         fragment::analyze(fallback, context)?;
+        context.scope = body_scope;
     }
 
     // Pop EachBlock context

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/evaluate.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/evaluate.rs
@@ -964,6 +964,7 @@ impl<'a> EvalCtx<'a> {
                         .template_scope_map
                         .values()
                         .chain(a.root.if_alternate_scope_map.values())
+                        .chain(a.root.each_fallback_scope_map.values())
                         .copied()
                         .collect()
                 });

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/helpers.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/helpers.rs
@@ -70,6 +70,7 @@ pub(crate) fn compute_eval_inputs(
             .template_scope_map
             .values()
             .chain(analysis.root.if_alternate_scope_map.values())
+            .chain(analysis.root.each_fallback_scope_map.values())
             .copied()
             .collect();
         for binding in &analysis.root.bindings {

--- a/crates/rsvelte_core/tests/each_fallback_const_scope_3377.rs
+++ b/crates/rsvelte_core/tests/each_fallback_const_scope_3377.rs
@@ -1,0 +1,162 @@
+//! An `{#each}`'s `{:else}` fallback is its own scope, and its body is not.
+//!
+//! Upstream's `EachBlock` scope visitor walks the body's *nodes* with the each
+//! scope (`for (const child of node.body.nodes) visit(child, { scope })`) but
+//! visits the fallback as a whole `Fragment` (`if (node.fallback) visit(node.fallback,
+//! { scope })`). Only the second reaches the `Fragment` visitor, which is what calls
+//! `scope.child(...)`. So a declaration naming the each item is a **duplicate** in the
+//! body and a **shadow** in the fallback, and rsvelte had them sharing one scope.
+//!
+//! That single mismatch produced two visible defects, which is why both directions are
+//! pinned here: an over-rejection (rsvelte refused a component official accepts) and a
+//! silent output difference (two unused parameters on the each *body* callback — a
+//! sibling the declaration is not even in).
+
+use rsvelte_core::{CompileOptions, GenerateMode, compile};
+
+const HEAD: &str =
+    "<script>\n\tlet items = $state([1]);\n\tlet other = $state([2]);\n</script>\n\n";
+
+fn try_compile(template: &str, generate: GenerateMode) -> Result<String, String> {
+    compile(
+        &format!("{HEAD}{template}\n"),
+        CompileOptions {
+            generate,
+            ..Default::default()
+        },
+    )
+    .map(|result| result.js.code)
+    .map_err(|err| format!("{err:?}"))
+}
+
+#[track_caller]
+fn client(template: &str) -> String {
+    try_compile(template, GenerateMode::Client).expect("compile should succeed")
+}
+
+// --- the over-rejection half -------------------------------------------------------
+
+/// The each item is not in scope in the fallback, so naming a `{@const}` after it
+/// shadows rather than collides. rsvelte used to reject this with
+/// `declaration_duplicate`; official compiles it.
+#[test]
+fn a_fallback_const_may_reuse_the_item_name() {
+    for generate in [GenerateMode::Client, GenerateMode::Server] {
+        try_compile(
+            "{#each items as it}x{:else}{@const it = 1}{/each}",
+            generate,
+        )
+        .expect("a fallback `{@const}` may shadow the item name");
+    }
+}
+
+/// Same for the index binding.
+#[test]
+fn a_fallback_const_may_reuse_the_index_name() {
+    try_compile(
+        "{#each items as it, i}x{:else}{@const i = 1}{/each}",
+        GenerateMode::Client,
+    )
+    .expect("a fallback `{@const}` may shadow the index name");
+}
+
+/// Control, and the reason the two above are not just "stop checking for duplicates":
+/// in the BODY the item really is in scope, so the same declaration is still a
+/// duplicate — upstream rejects it there at the same position.
+#[test]
+fn a_body_const_reusing_the_item_name_is_still_a_duplicate() {
+    let err = try_compile(
+        "{#each items as it}{@const it = 1}x{/each}",
+        GenerateMode::Client,
+    )
+    .expect_err("a body `{@const}` naming the item is a duplicate");
+    assert!(
+        err.contains("declaration_duplicate"),
+        "expected declaration_duplicate, got: {err}"
+    );
+}
+
+// --- the silent-output half --------------------------------------------------------
+
+/// The body callback takes only the parameters it uses. A declaration in the fallback
+/// used to leak into the each scope and push `$$index, $$array` onto the *body*
+/// callback, which is a sibling the declaration is not in.
+#[track_caller]
+fn assert_body_callback_params(template: &str, expected: &str) {
+    let code = client(template);
+    assert!(
+        code.contains(expected),
+        "expected body callback `{expected}` in:\n{code}"
+    );
+    assert!(
+        !code.contains("$$index, $$array"),
+        "the body callback must not take parameters nothing uses:\n{code}"
+    );
+}
+
+#[test]
+fn a_fallback_const_shadowing_the_collection_leaves_the_body_callback_alone() {
+    assert_body_callback_params(
+        "{#each items as it}x{:else}{@const items = 1}{/each}",
+        "($$anchor, it) =>",
+    );
+}
+
+/// The name does not have to be the collection's. Any script-scope binding reproduced
+/// it, which is what says the trigger is the declaration reaching the each scope rather
+/// than anything about the collection expression.
+#[test]
+fn a_fallback_const_shadowing_an_unrelated_binding_leaves_the_body_callback_alone() {
+    assert_body_callback_params(
+        "{#each items as it}x{:else}{@const other = 1}{/each}",
+        "($$anchor, it) =>",
+    );
+}
+
+/// Nor does it have to be a `{@const}`: a `{#snippet}` in the fallback declares a name
+/// the same way, so a fix keyed on `ConstTag` would have missed this.
+#[test]
+fn a_fallback_snippet_shadowing_the_collection_leaves_the_body_callback_alone() {
+    assert_body_callback_params(
+        "{#each items as it}x{:else}{#snippet items()}y{/snippet}{@render items()}{/each}",
+        "($$anchor, it) =>",
+    );
+}
+
+#[test]
+fn a_keyed_each_is_unaffected_too() {
+    assert_body_callback_params(
+        "{#each items as it (it)}x{:else}{@const items = 1}{/each}",
+        "($$anchor, it) =>",
+    );
+}
+
+/// Control: a fallback declaration whose name collides with nothing never reproduced
+/// the divergence, so it is what keeps the two tests above honest — if the body
+/// callback lost its parameters for every each block, this would fail too.
+#[test]
+fn a_non_colliding_fallback_const_is_unchanged() {
+    assert_body_callback_params(
+        "{#each items as it}x{:else}{@const fresh = 1}{/each}",
+        "($$anchor, it) =>",
+    );
+}
+
+// --- the fallback's own scope still resolves ---------------------------------------
+
+/// The new scope must not hide the fallback's own declarations from the server's
+/// constant fold: `{@const items = 1}` still folds to `1` where the fallback reads it.
+/// Without this, "give the fallback a scope" would pass every test above while
+/// silently un-folding the branch it created.
+#[test]
+fn a_fallback_const_still_folds_in_its_own_branch() {
+    let code = try_compile(
+        "{#each items as it}x{:else}{@const items = 1}<i>{items}</i>{/each}",
+        GenerateMode::Server,
+    )
+    .expect("compile should succeed");
+    assert!(
+        code.contains("<i>1</i>"),
+        "the fallback's own `{{@const}}` must still fold in its branch:\n{code}"
+    );
+}


### PR DESCRIPTION
Closes #3377.

## One missing scope, two visible defects

An `{#each}`'s `{:else}` fallback is its own scope and its body is not. Upstream's
`EachBlock` scope visitor makes that distinction by *how* it descends
(`phases/scope.js:1277-1281`):

```js
for (const child of node.body.nodes) {
	visit(child, { scope });          // the body's NODES — no Fragment visitor, no child scope
}
if (node.fallback) visit(node.fallback, { scope });  // the fallback FRAGMENT — child scope
```

Only the second reaches the `Fragment` visitor, which is the thing that calls
`scope.child(...)` (`scope.js:1349-1353`). So a declaration naming the each item is a
**duplicate** in the body and a **shadow** in the fallback. rsvelte ran both fragments in
the each scope, with an explicit comment in `visitors/each_block.rs` asserting the fallback
"is still in the each block's scope (same scope as body)".

That one mismatch produced two defects in opposite directions, which is why the fix is the
scope rather than either symptom:

**An over-rejection.** `{#each items as it}x{:else}{@const it = 1}{/each}` — official
compiles it, rsvelte rejected it with `declaration_duplicate`. Same for the index name.
This was not in the issue; the grid found it.

**A silent output difference** (the reported one). A fallback declaration reached the each
scope, and the each *body* callback — a sibling the declaration is not even in — grew two
parameters nothing uses:

```js
// official                          // rsvelte, before
($$anchor, it) => { … }              ($$anchor, it, $$index, $$array) => { … }
```

## The issue's stated trigger was too narrow

#3377 reads the trigger as "the `{@const}` shadows the each **collection**", with
`{@const fresh = 1}` as the discriminating control. The grid says otherwise on two axes:

* **It does not have to be the collection.** `{@const other = 1}`, naming an unrelated
  script binding, reproduces it identically. The trigger is a declaration reaching the each
  scope at all, not anything about the collection expression.
* **It does not have to be a `{@const}`.** `{#snippet items()}` in the fallback reproduces
  it too — so a fix keyed on `ConstTag` would have passed the issue's matrix and missed
  this.

Both are pinned as tests, because both are cases where a narrower fix would still look
correct.

## Measurement

16 shapes × 4 targets = 64 comparisons against the pinned official compiler (5.56.10):

| | diverging |
|---|---|
| merge base | 26 |
| this branch | **0** |

Checked as a set difference, not a count. The 16 shapes extend the issue's 5 with: the item
name, the index name, an unrelated binding, a member-expression collection, a keyed each, a
nested each shadowing the outer collection, a snippet, two consts where only one collides,
an `{#if}` inside the fallback, and a body that genuinely uses its item.

## The fix

* `2_analyze/scope_builder.rs` — push a scope around the fallback fragment, recorded in a
  new `each_fallback_scope_map` keyed by the each block's start. Keyed exactly like the
  existing `if_alternate_scope_map`, and for the same reason: a fallback has no start offset
  of its own.
* `2_analyze/visitors/each_block.rs` — switch `context.scope` to it while analysing the
  fallback.
* `3_transform/server/{evaluate,helpers}.rs` — add the new map to the two "template-visible
  scopes" sets.

That last one is not cosmetic, and it is the reason this PR has the test it does. Adding the
scope alone took the grid 26 → 2, and the 2 that remained were a **new** regression I had
introduced: the fallback's own `{@const items = 1}` stopped folding in its own branch,
because its binding now lived in a scope the server's fold did not count as template-visible.
`a_fallback_const_still_folds_in_its_own_branch` pins that, so "give the fallback a scope"
cannot pass while silently un-folding the branch it created.

`server/ast/mod.rs` is deliberately untouched — its `enter_if_alternate_scope` has no
fallback counterpart and the grid says none is needed. That also keeps this off cmtA's
#3326.

## Tests

`crates/rsvelte_core/tests/each_fallback_const_scope_3377.rs`, 9 tests. The controls are
the load-bearing part:

* `a_body_const_reusing_the_item_name_is_still_a_duplicate` — the body really does still
  reject, so this is not "stop checking for duplicates".
* `a_non_colliding_fallback_const_is_unchanged` — if the body callback lost its parameters
  for every each block, this fails too.
* `a_fallback_const_still_folds_in_its_own_branch` — the regression above.

Suites verified locally: `--lib` (1732), `compiler_fixtures`, `css` (181), `ssr` (99), `validator` (333). `runtime` (5 suites, 1732s). `cargo fmt` and the workspace `cargo clippy --all-targets --all-features -- -D warnings` both pass.

## Adjacent findings, not fixed here

Two more over-rejections turned up while building the grid for #3375. Both are valid
programs rsvelte rejects, so they matter more than the error-code ordering #3375 reports:

* `{#snippet C()}…{/snippet}` at the root, where `C` is an **import** — official accepts,
  rsvelte rejects `declaration_duplicate`. A root snippet shadowing a `let` or a `$state`
  is rejected by *both*, so it is specifically the import row.
* `<svelte:head>{#snippet items()}…{/snippet}</svelte:head>` — official accepts, rsvelte
  rejects.

My first reading was that these were the same missing-scope shape as this PR. Reading
upstream says otherwise, so recording the corrected cause rather than the guess:
`2-analyze/visitors/SnippetBlock.js:28-35` raises `declaration_duplicate` only when the
snippet **is a direct child of the root Fragment** *and* the name is in
`analysis.instance.scope.declarations`. Imports are not there — `Scope.declare` forwards
`declaration_kind === 'import'` to the parent (module) scope — and a snippet in
`<svelte:head>` is not top-level, so upstream never runs the check for either. rsvelte's
check (`scope_builder.rs`, `visit_snippet_block`) instead asks whether the name is in the
*current* scope, which at the root and inside `<svelte:head>` is the instance scope.

So the fix there is the check's condition, not a scope, and it is independent of both this
PR and #3375. The caveat for whoever takes #3375: its own `{@const}` rows *are* the scope
shape — the root fragment and the `<svelte:head>` / `<svelte:body>` / `<svelte:window>`
fragments get no scope of their own in rsvelte, so a root `{@const}` collides where
upstream shadows. Two different causes behind one issue's symptom list.

## Ratchets

None touched.
