### PR TITLE
fix(analyze): read only the first <track> for a11y_media_has_caption

### DIFF
--- a/.changeset/a11y-media-first-track.md
+++ b/.changeset/a11y-media-first-track.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/compiler": patch
+---
+
+`a11y_media_has_caption` now reads only the first `<track>` child of a `<video>`, as upstream does (`nodes.find(...)`). rsvelte ran the caption predicate over every `track` child, so a `<video>` whose caption track is not the first one stayed silent where the official compiler warns. `find` and `any` agree whenever there is exactly one `<track>`, which is the shape every earlier test used.

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/shared/a11y/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/shared/a11y/mod.rs
@@ -618,22 +618,17 @@ pub fn check_element(node: &A11yElement, ancestors: &A11yAncestors) -> Vec<w::An
             } else if !attribute_map.contains_key("src") {
                 // Skip video caption check if no src attribute
             } else {
+                // Upstream reads only the FIRST `<track>` (`nodes.find(...)`), so a
+                // `<video>` whose caption track is not the first one still warns.
                 let has_caption = node
                     .fragment
                     .nodes
                     .iter()
-                    .filter_map(|n| {
-                        if let TemplateNode::RegularElement(el) = n {
-                            if el.name == "track" {
-                                Some(el)
-                            } else {
-                                None
-                            }
-                        } else {
-                            None
-                        }
+                    .find_map(|n| match n {
+                        TemplateNode::RegularElement(el) if el.name == "track" => Some(el),
+                        _ => None,
                     })
-                    .any(|track| {
+                    .is_some_and(|track| {
                         track.attributes.iter().any(|a| {
                             matches!(a, AttributeNode::SpreadAttribute(_))
                                 || matches!(a, AttributeNode::Attribute(attr) if attr.name == "kind" && get_static_value(a) == Some(StaticValue::Text("captions")))

--- a/crates/rsvelte_core/tests/a11y_media_first_track_3353.rs
+++ b/crates/rsvelte_core/tests/a11y_media_first_track_3353.rs
@@ -1,0 +1,109 @@
+//! `a11y_media_has_caption` reads only the FIRST `<track>` child.
+//!
+//! Upstream's `video` case does `node.fragment.nodes.find(...)` and then tests
+//! that one element's attributes
+//! (`2-analyze/visitors/shared/a11y/index.js:500-511`); rsvelte ran the same
+//! predicate over *every* `track` child with `filter(...).any(...)`, so a
+//! `<video>` whose caption track is not the first one stayed silent where the
+//! official compiler warns. `find` and `any` agree only when there is exactly
+//! one `<track>`, which is the shape every earlier test used.
+//!
+//! Every expectation is the official compiler's own verdict for the same source.
+
+use rsvelte_core::{CompileOptions, GenerateMode, compile};
+
+fn warns(src: &str) -> bool {
+    // The rule lives in phase 2, so it must hold on every target.
+    [
+        (GenerateMode::Client, false),
+        (GenerateMode::Client, true),
+        (GenerateMode::Server, false),
+        (GenerateMode::Server, true),
+    ]
+    .into_iter()
+    .map(|(generate, dev)| {
+        compile(
+            src,
+            CompileOptions {
+                filename: Some("T.svelte".into()),
+                generate,
+                dev,
+                ..Default::default()
+            },
+        )
+        .expect("compile")
+        .warnings
+        .iter()
+        .any(|w| w.code == "a11y_media_has_caption")
+    })
+    .reduce(|a, b| {
+        assert_eq!(a, b, "targets disagree for:\n{src}");
+        a
+    })
+    .unwrap()
+}
+
+/// The reported shape: the caption track is second, so upstream never sees it.
+#[test]
+fn a_caption_track_after_the_first_track_does_not_silence_the_warning() {
+    assert!(warns(
+        "<video src=\"a\"><track kind=\"subtitles\" /><track kind=\"captions\" /></video>"
+    ));
+    assert!(warns(
+        "<video src=\"a\"><track kind=\"descriptions\" /><track kind=\"chapters\" /><track kind=\"captions\" /></video>"
+    ));
+    // Whitespace text between the children does not make the caption track first.
+    assert!(warns(
+        "<video src=\"a\">\n\t<track kind=\"subtitles\" />\n\t<track kind=\"captions\" />\n</video>"
+    ));
+}
+
+/// A spread on the first track still counts as possibly-captions; a spread on a
+/// later one is never read.
+#[test]
+fn only_a_spread_on_the_first_track_counts() {
+    assert!(!warns(
+        "<video src=\"a\"><track {...rest} /><track kind=\"subtitles\" /></video>"
+    ));
+    assert!(warns(
+        "<video src=\"a\"><track kind=\"subtitles\" /><track {...rest} /></video>"
+    ));
+}
+
+/// The single-track shapes, which `filter`/`any` and `find` cannot tell apart —
+/// they are what made the divergence survive, so they are pinned as controls.
+#[test]
+fn the_single_track_verdicts_are_unchanged() {
+    assert!(!warns(
+        "<video src=\"a\"><track kind=\"captions\" /></video>"
+    ));
+    assert!(warns(
+        "<video src=\"a\"><track kind=\"subtitles\" /></video>"
+    ));
+    assert!(warns("<video src=\"a\"></video>"));
+    // A caption track first, junk after, is still silent.
+    assert!(!warns(
+        "<video src=\"a\"><track kind=\"captions\" /><track kind=\"subtitles\" /></video>"
+    ));
+}
+
+/// The suppressing attributes still suppress, so "first track only" did not
+/// widen into "always warn".
+#[test]
+fn muted_and_srcless_video_stay_silent() {
+    assert!(!warns(
+        "<video src=\"a\" muted><track kind=\"subtitles\" /><track kind=\"captions\" /></video>"
+    ));
+    assert!(!warns(
+        "<video><track kind=\"subtitles\" /><track kind=\"captions\" /></video>"
+    ));
+}
+
+/// `find` searches the direct children only: a `<track>` nested in an element is
+/// not the first track, and does not become one.
+#[test]
+fn a_track_nested_in_a_child_element_is_not_the_first_track() {
+    assert!(warns(
+        "<video src=\"a\"><div><track kind=\"captions\" /></div><track kind=\"subtitles\" /></video>"
+    ));
+}


### PR DESCRIPTION
`a11y_media_has_caption` inspected **every** `<track>` child of a `<video>`; upstream
inspects only the **first**.

```js
// 2-analyze/visitors/shared/a11y/index.js:500-511
const track = node.fragment.nodes.find((i) => i.type === 'RegularElement' && i.name === 'track');
if (track) {
    has_caption = track.attributes.some(
        (a) => a.type === 'SpreadAttribute' ||
            (a.type === 'Attribute' && a.name === 'kind' && get_static_value(a) === 'captions')
    );
}
```

rsvelte built the same predicate and ran it over `filter(...).any(...)`. `find` and `any`
are the same function only when a `<video>` has exactly one `<track>` — which is the shape
every existing test uses, and why this survived.

```svelte
<video src="a"><track kind="subtitles" /><track kind="captions" /></video>
```

| | official | rsvelte (before) |
|---|---|---|
| | `a11y_media_has_caption` @ 1:0 | *(silent)* |

It is an **under**-warning, so a "does rsvelte emit noise?" pass does not surface it.

## Verification

Every verdict in `crates/rsvelte_core/tests/a11y_media_first_track_3353.rs` was measured
against the official compiler on the same source, one compiler process per input, on all
four targets (client / client-dev / server / server-dev — the helper asserts the four agree
before returning, so a target-dependent answer fails rather than being averaged away).

A 13-shape × 4-target grid over `<video>`/`<track>` goes from 16 divergent cells to 0.

Negative control: with the one-line source change reverted and the test file kept,
`a_caption_track_after_the_first_track_does_not_silence_the_warning` and
`only_a_spread_on_the_first_track_counts` fail, and the three control tests pass on both
trees. Those controls are the point — they pin that the change did not widen into "always
warn": the single-track verdicts, `muted`, a missing `src`, and a caption track that *is*
first all stay exactly as they were.

`only_a_spread_on_the_first_track_counts` is the pair that isolates the rule rather than the
symptom: a spread on the first track still suppresses (it might be `kind="captions"`), a
spread on a later one does not, because upstream never reads that element.

## A note on reproducing upstream here

Upstream's "first track only" is arguably an upstream defect — a `<video>` whose second
track is the caption track does have captions. It is reproduced anyway, and deliberately:

- it changes **no** compiled output, only which diagnostics the user sees;
- the direction is that rsvelte now emits a warning it previously swallowed, so a user
  migrating from `svelte` sees the same a11y report rather than a quietly smaller one;
- warning parity is an explicit, ratcheted goal in this repo
  (`compatibility/warning-known-failures.*`), so diverging on purpose would have to be
  recorded there as a deliberate difference rather than fixed silently.

Suites run: `a11y_media_first_track_3353`, `validator`, `compiler_errors`,
`compiler_fixtures`, `ssr`.

Closes #3353

🤖 Generated with [Claude Code](https://claude.com/claude-code)
