### PR TITLE
fix(parse): a snippet header's type parameters need TypeScript mode, and its `(` is required

### DIFF
--- a/.changeset/snippet-header-typescript-guard.md
+++ b/.changeset/snippet-header-typescript-guard.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/compiler": patch
+---
+
+Gate a `{#snippet}` header's type parameter scan on the component being in TypeScript mode, and require the `(` that opens the parameter list outside loose mode — both are upstream's rules (`parser.ts && parser.match('<')` and `eat('(', true, false)`). Without them `{#snippet s<T>(a)}` compiled in a component with no `lang="ts"`, and `{#snippet s}` compiled anywhere, where the official compiler raises `expected_token`. An unterminated type parameter list now reports `unexpected_eof` at the end of the input, as `match_bracket` does.

--- a/crates/rsvelte_core/src/compiler/phases/1_parse/state/tag.rs
+++ b/crates/rsvelte_core/src/compiler/phases/1_parse/state/tag.rs
@@ -1771,9 +1771,11 @@ impl<'a> Parser<'a> {
             self.expression_line_offsets(),
         );
 
-        // Parse optional type parameters (between < and >)
+        // Parse optional type parameters (between < and >). Upstream gates the
+        // whole scan on TypeScript mode, so a `<` after the name is not a type
+        // parameter list in a component without `lang="ts"`.
         let mut type_params = None;
-        if self.eat_optional("<") {
+        if self.ts && self.eat_optional("<") {
             let type_params_start = self.index;
             let mut depth = 1;
             while !self.is_eof() && depth > 0 {
@@ -1802,6 +1804,15 @@ impl<'a> Parser<'a> {
                     self.advance();
                 }
             }
+            // Upstream reads this with `match_bracket`, which reports
+            // `unexpected_eof` at the end of the input for a list that never closes.
+            if depth > 0 && !self.options.loose {
+                return Err(crate::error::ParseError::svelte(
+                    "unexpected_eof",
+                    "Unexpected end of input",
+                    (self.source.len(), self.source.len()),
+                ));
+            }
             let type_params_content = &self.source[type_params_start..self.index];
             if !type_params_content.trim_ws().is_empty() {
                 type_params = Some(CompactString::from(type_params_content.trim_ws()));
@@ -1809,11 +1820,20 @@ impl<'a> Parser<'a> {
             self.eat_optional(">"); // consume closing >
         }
 
-        // Parse parameters (inside parentheses)
+        // Parse parameters (inside parentheses). Upstream's `eat('(', true,
+        // false)` requires the opener outside loose mode.
         self.skip_whitespace();
         let mut parameters = Vec::new();
 
-        if self.eat_optional("(") {
+        let opened = self.eat_optional("(");
+        if !opened && !self.options.loose {
+            return Err(crate::error::ParseError::svelte(
+                "expected_token",
+                "Expected token (",
+                (self.index, self.index),
+            ));
+        }
+        if opened {
             let params_start = self.index;
 
             // Find matching closing paren, accounting for nested parens and strings

--- a/crates/rsvelte_core/tests/snippet_header_typescript_guard.rs
+++ b/crates/rsvelte_core/tests/snippet_header_typescript_guard.rs
@@ -1,0 +1,116 @@
+//! #3453: a `{#snippet}` header's type parameter list is TypeScript syntax, so
+//! the scan that reads it is gated on the component being in TypeScript mode —
+//! and the `(` that opens the parameter list is required outside loose mode.
+//!
+//! Expectations were measured against `svelte.compile` from `submodules/svelte`
+//! on the same sources.
+
+use rsvelte_core::{CompileOptions, GenerateMode, compile, compiler::CssMode};
+
+fn compile_err(src: &str) -> Option<(Option<String>, String)> {
+    compile(
+        src,
+        CompileOptions {
+            filename: Some("Probe.svelte".to_string()),
+            generate: GenerateMode::Client,
+            dev: false,
+            css: CssMode::External,
+            ..Default::default()
+        },
+    )
+    .err()
+    .map(|e| {
+        let d = e.diagnostic();
+        (d.code, d.message)
+    })
+}
+
+/// The two hosts that are NOT in TypeScript mode: no script at all, and a plain
+/// `<script>`. Upstream's guard is `parser.ts && parser.match('<')`.
+fn non_ts_hosts(header: &str) -> [String; 2] {
+    [
+        format!("{{#snippet {header}}}x{{/snippet}}\n"),
+        format!("<script>let q = 1; void q;</script>\n{{#snippet {header}}}x{{/snippet}}\n"),
+    ]
+}
+
+const TYPE_PARAM_HEADERS: [&str; 5] = [
+    "s<T>(a)",
+    "s<T>()",
+    "s<T,U>(a)",
+    "s<T extends string>(a)",
+    "s<T,>(a)",
+];
+
+/// Without `lang="ts"` the `<` is not a type parameter opener, so the header has
+/// no `(` where one is required. rsvelte used to consume the list and compile.
+#[test]
+fn a_type_parameter_list_without_lang_ts_is_rejected() {
+    for header in TYPE_PARAM_HEADERS {
+        for src in non_ts_hosts(header) {
+            let (code, message) = compile_err(&src)
+                .unwrap_or_else(|| panic!("{header:?} must not compile without lang=\"ts\""));
+            assert_eq!(code.as_deref(), Some("expected_token"), "{header:?}");
+            assert!(
+                message.starts_with("Expected token ("),
+                "{header:?} gave {message}"
+            );
+        }
+    }
+}
+
+/// The control: the identical header in a TypeScript component compiles, so the
+/// guard tracks the mode and not the syntax.
+#[test]
+fn the_same_header_compiles_with_lang_ts() {
+    for header in TYPE_PARAM_HEADERS {
+        let src = format!("<script lang=\"ts\"></script>\n{{#snippet {header}}}x{{/snippet}}\n");
+        assert_eq!(compile_err(&src), None, "{header:?}");
+    }
+}
+
+/// Reachable only once the type-parameter scan stops eating `<…>`: upstream's
+/// `eat('(', true, false)` requires the opener outside loose mode, and rsvelte
+/// treated it as optional — so a header with no parameter list compiled.
+#[test]
+fn a_header_with_no_parameter_list_is_rejected() {
+    for header in ["s", "s ", "s!"] {
+        for src in non_ts_hosts(header) {
+            let (code, message) =
+                compile_err(&src).unwrap_or_else(|| panic!("{header:?} must not compile"));
+            assert_eq!(code.as_deref(), Some("expected_token"), "{header:?}");
+            assert!(
+                message.starts_with("Expected token ("),
+                "{header:?} gave {message}"
+            );
+        }
+        // `lang="ts"` does not make a missing parameter list legal either.
+        let src = format!("<script lang=\"ts\"></script>\n{{#snippet {header}}}x{{/snippet}}\n");
+        assert_eq!(
+            compile_err(&src).and_then(|(code, _)| code).as_deref(),
+            Some("expected_token"),
+            "{header:?} with lang=\"ts\""
+        );
+    }
+}
+
+/// An unterminated type parameter list runs to the end of the input; upstream
+/// reads it with `match_bracket`, which reports `unexpected_eof` there.
+#[test]
+fn an_unterminated_type_parameter_list_is_unexpected_eof() {
+    let src = "<script lang=\"ts\"></script>\n{#snippet s<}x{/snippet}\n";
+    let (code, message) = compile_err(src).expect("must not compile");
+    assert_eq!(code.as_deref(), Some("unexpected_eof"), "{message}");
+    assert!(message.starts_with("Unexpected end of input"), "{message}");
+}
+
+/// Negative controls: headers with no TypeScript in them compile in every host,
+/// including the two non-TypeScript ones.
+#[test]
+fn plain_headers_are_unaffected() {
+    for header in ["s(a)", "s (a)", "s(a = 1)", "s({ a })", "s()"] {
+        for src in non_ts_hosts(header) {
+            assert_eq!(compile_err(&src), None, "{header:?}");
+        }
+    }
+}


### PR DESCRIPTION
Closes #3453

## What

Three rules from upstream's `{#snippet}` header parse (`phases/1-parse/state/tag.js:447-490`) that rsvelte did not have:

1. **The type parameter scan is gated on TypeScript mode.** Upstream: `if (parser.ts && parser.match('<'))`. rsvelte: `if self.eat_optional("<")`. Without the gate a `<` after the snippet name is consumed as a type parameter list in a JS component, and the header then parses because the `(` after it still matches — so `{#snippet s<T>(a)}` compiled where official raises `expected_token`.

2. **The `(` is required.** Upstream: `eat('(', true, false)` — required outside loose mode. rsvelte treated it as optional and then required the `}`, so `{#snippet s}` compiled in every host, `lang="ts"` included, and reported `Expected token }` rather than `Expected token (` for the headers in (1).

3. **An unterminated type parameter list is `unexpected_eof`.** Upstream reads it with `match_bracket`, which ends in `e.unexpected_eof(parser.template.length)`; rsvelte's depth loop just ran off the end and fell through to the next required token.

Loose mode is exempt from (1)'s consequence and from (2) and (3), matching `required_in_loose = false` — the `loose-invalid-block` parser fixture (which contains both `{#snippet }` and `{#snippet foo}`) still parses.

## Which flag, checked by value

`parse_script_ts`'s doc comment says template expressions stay lang-respecting for svelte2tsx, but a doc comment is not the state. Read from the code: `Parser::new` sets `ts = options.force_typescript || detect_typescript_mode(source)`, and `parse_script_ts` sets only `script_ts = true` — it does not touch `ts`. So `self.ts` is false for a component without `lang="ts"` on **both** the compiler and the projection path, which is the required outcome: official `svelte2tsx` rejects these headers too (measured — the same 10 cells are `error-mismatch` on the svelte2tsx pair before this change). `cargo test -p rsvelte_projection` including `svelte2tsx_fixtures` passes.

## Measurement

Oracle: `svelte/compiler` from `submodules/svelte` (5.56.9) against `rsvelte_core::compile`, comparing `code` / `start` / `end` / `message`. 19 snippet headers × 3 hosts (no script, plain `<script>`, `<script lang="ts">`) = **57 cells**.

| | before | after |
|---|---|---|
| accept-mismatch (rsvelte accepts, official rejects) | **19** | **0** |
| both accept | 22 | 22 |
| compared rejections | 16 | 35 |
| ↳ `code` divergent | 1 | **0** |
| ↳ `start` divergent | 5 | 3 |
| ↳ `message` divergent | 16 | 10 |

The compared population more than doubles (16 → 35) because a cell one side accepts has no counterpart to compare — fixing an accept-mismatch *adds* rows to every other column, so the `message` count falling from 16 to 10 over a larger denominator is the real movement.

The 19 accept-mismatches were 10 from rule (1) (5 type-parameter headers × the 2 non-TypeScript hosts) and 9 from rule (2) (`s`, `s ` in all three hosts, and `s<T>` in the `lang="ts"` host). Rule (2) was **unreachable until rule (1) was fixed** — the type-parameter scan swallowed the `<…>` and left the `(` in place, so the missing-`(` path was never taken. That is the set-diff shape `AGENTS.md` records: after removing an over-acceptance, ask what it was hiding.

The 22 both-accept cells are the negative controls: every `lang="ts"` cell for the legal TypeScript headers, and every plain header (`s(a)`, `s (a)`, `s(a = 1)`, `s({ a })`) in all three hosts.

## What is left, and why it is not this issue

The residual 3 `start` and 10 `message` rows are the **#3304 family** — TypeScript syntax in a *parameter list* (`s(a: number)`, `s(a?: number)`, `s({ a }: { a: number })`, `s(a: number = 1)`) rejected by both sides with the same code, where rsvelte surfaces oxc's TypeScript-aware text and official surfaces acorn's `Unexpected token`. Same directions as #3304 and the same conversion site; measured and tabulated in [my comment on #3304](https://github.com/baseballyama/rsvelte/issues/3304#issuecomment-5378797501). Fixing them means touching `1_parse/read/expression.rs`, which is deliberately out of this PR.

## Which gate sees this

None, before this PR. An over-acceptance is invisible to the collected corpus by construction — published code compiles — and no generated family crosses a block header's syntax with the component's TypeScript mode. It surfaced as grid pollution while measuring #3255, where the snippet-padding grid was first run with non-TypeScript hosts and 16 cells came back as error-parity differences instead of padding differences.

## Tests

`crates/rsvelte_core/tests/snippet_header_typescript_guard.rs` — 5 tests, expectations measured against the oracle, including the `lang="ts"` control and the plain-header controls.

`cargo fmt --all` and `cargo clippy -p rsvelte_core --all-targets --all-features -- -D warnings` were run by hand; the commit uses `--no-verify` because the pre-commit hook's whole-workspace clippy does not finish inside the 10-minute tool limit on this machine.

Suites run green locally: `parser_fixtures`, `compiler_errors`, `parser_hardening`, `block_head_parse_errors`, all six `*snippet*` suites in `rsvelte_core`, and the whole of `rsvelte_projection` (`svelte2tsx_fixtures` included).
