### PR TITLE
fix(parse): report the JS parse error a const/await/render tag swallowed

### DIFF
--- a/.changeset/tag-expression-parse-errors.md
+++ b/.changeset/tag-expression-parse-errors.md
@@ -1,0 +1,5 @@
+---
+'@rsvelte/compiler': patch
+---
+
+Report the JS parse error in a `{@const …}` initializer, a `{#await …}` head and a `{@render …}` tag instead of swallowing it. All three routed their expression through a parse that recovers with an empty identifier, so ordinary broken JavaScript compiled — and in the `{@render}` case the empty identifier then failed the downstream call check, so a second error stood in for the one that was dropped. Upstream's `read_expression` throws unless the parser is loose, and its caller then expects the `}`, so leftover input after a complete expression is an `expected_token` while a malformed expression is a `js_parse_error`; both classifications now reach all three tags

--- a/crates/rsvelte_core/src/compiler/phases/1_parse/read/expression.rs
+++ b/crates/rsvelte_core/src/compiler/phases/1_parse/read/expression.rs
@@ -1858,6 +1858,41 @@ pub fn trailing_token_offset(content: &str) -> Option<usize> {
     probe(SourceType::ts()).or_else(|| probe(SourceType::mjs()))
 }
 
+/// Classify a failed `read_expression` for a construct terminated by
+/// `close_char`, the way upstream's caller does: acorn parses ONE maximal
+/// expression and the caller then `eat(close_char, true)`, so leftover input
+/// after a *complete* expression is a missing close token while a malformed
+/// expression is a `js_parse_error` at the byte where the parse stopped.
+///
+/// The prefix re-parse is what separates the two: OXC labels an invalid
+/// assignment target at the target's start, which the leftover-input probe
+/// would otherwise read as "the expression ended here".
+pub fn close_token_or_parse_error(
+    msg: String,
+    trimmed: &str,
+    trimmed_offset: usize,
+    close_char: char,
+) -> crate::error::ParseError {
+    let trailing = trailing_token_offset(trimmed).filter(|&off| {
+        off > 0
+            && trimmed
+                .get(..off)
+                .is_some_and(|prefix| check_js_parse_error_with_pos(prefix).is_none())
+    });
+    if let Some(off) = trailing {
+        let mut buf = [0u8; 4];
+        return crate::error::ParseError::expected_token(
+            close_char.encode_utf8(&mut buf),
+            trimmed_offset + off,
+        );
+    }
+    let at = check_js_parse_error_with_pos(trimmed)
+        .map_or(trimmed_offset + trimmed.len(), |(_, pos)| {
+            trimmed_offset + pos
+        });
+    crate::error::ParseError::svelte("js_parse_error", msg, (at, at))
+}
+
 /// Create an identifier for invalid expressions
 fn create_invalid_identifier<'a>(
     start: usize,

--- a/crates/rsvelte_core/src/compiler/phases/1_parse/resolve_lazy.rs
+++ b/crates/rsvelte_core/src/compiler/phases/1_parse/resolve_lazy.rs
@@ -506,16 +506,11 @@ fn lazy_parse_error(
         // a missing close token; anything else is a point `js_parse_error`.
         LazyKind::HeadBrace | LazyKind::HeadParen => {
             let close = if kind == LazyKind::HeadParen {
-                ")"
+                ')'
             } else {
-                "}"
+                '}'
             };
-            if let Some(pos) = super::read::expression::trailing_token_offset(content) {
-                return Some(crate::error::ParseError::expected_token(close, start + pos));
-            }
-            let abs_pos = super::read::expression::check_js_parse_error_with_pos(content)
-                .map_or(start + content.len(), |(_, pos)| start + pos);
-            crate::error::ParseError::svelte("js_parse_error", msg, (abs_pos, abs_pos))
+            super::read::expression::close_token_or_parse_error(msg, content, start, close)
         }
     })
 }

--- a/crates/rsvelte_core/src/compiler/phases/1_parse/state/tag.rs
+++ b/crates/rsvelte_core/src/compiler/phases/1_parse/state/tag.rs
@@ -1534,33 +1534,42 @@ impl<'a> Parser<'a> {
         let adjusted_end = expr_end - (expr_content.len() - trimmed_content.trim_end_ws().len());
         // For await blocks, we parse the expression with a known end position
         // to avoid find_matching_bracket finding the block's closing }
-        let expression = if let Some(lazy) =
-            self.defer_expression(trimmed_content.trim_ws(), adjusted_start, LazyKind::Lenient)
-        {
-            lazy
-        } else {
-            super::super::expression::parse_expression_with_end(
-                &self.arena,
-                trimmed_content.trim_ws(),
-                adjusted_start,
-                adjusted_end,
-                self.expression_line_offsets(),
-                self.source,
-                self.options.loose,
-                false,
-                '{',
-                self.ts,
-            )
-            .unwrap_or_else(|(_, pos)| {
-                // Return an invalid identifier on parse error (empty name)
-                super::super::expression::create_identifier_with_character(
-                    "",
-                    pos,
+        let head = trimmed_content.trim_ws();
+        let expression =
+            if let Some(lazy) = self.defer_expression(head, adjusted_start, LazyKind::HeadBrace) {
+                lazy
+            } else {
+                match super::super::expression::parse_expression_with_end(
+                    &self.arena,
+                    head,
+                    adjusted_start,
                     adjusted_end,
                     self.expression_line_offsets(),
-                )
-            })
-        };
+                    self.source,
+                    self.options.loose,
+                    false,
+                    '{',
+                    self.ts,
+                ) {
+                    Ok(expr) => expr,
+                    Err((_, pos)) if self.options.loose => {
+                        super::super::expression::create_identifier_with_character(
+                            "",
+                            pos,
+                            adjusted_end,
+                            self.expression_line_offsets(),
+                        )
+                    }
+                    Err((msg, _)) => {
+                        return Err(super::super::read::expression::close_token_or_parse_error(
+                            msg,
+                            head,
+                            adjusted_start,
+                            '}',
+                        ));
+                    }
+                }
+            };
 
         // Parse 'then' value if present
         if has_then {
@@ -2007,7 +2016,7 @@ impl<'a> Parser<'a> {
                 // not reject it here at parse time (svelte2tsx, which only parses,
                 // would otherwise diverge from official by erroring).
                 let trimmed = expr_content.trim_ws();
-                let expression = self.parse_js_expression_lenient(trimmed, expr_start);
+                let expression = self.parse_head_expression(trimmed, expr_start, false, '}')?;
 
                 // Upstream rejects anything but a call (optionally chained) here:
                 // `new foo()` and `foo` are parse errors, `foo?.()` is not.
@@ -2141,7 +2150,7 @@ impl<'a> Parser<'a> {
                         + 1
                         + (trimmed[eq_idx + 1..].len()
                             - trimmed[eq_idx + 1..].trim_start_ws().len());
-                    let init_expr = self.parse_js_expression(init_str, init_offset);
+                    let init_expr = self.parse_const_initializer(init_str, init_offset)?;
 
                     // Reject a sequence-expression initializer, mirroring
                     // upstream: `{@const a = (b, c)}` is allowed but
@@ -2413,18 +2422,6 @@ impl<'a> Parser<'a> {
         })
     }
 
-    /// Parse an expression whose parse failures are swallowed into an empty
-    /// identifier: `{@render …}` (its invalid-call check is an analysis-phase
-    /// error) and the `{#await …}` head.
-    pub fn parse_js_expression_lenient(&self, content: &str, offset: usize) -> Expression<'a> {
-        let leading_ws = content.len() - content.trim_start_ws().len();
-        let trimmed = content.trim_ws();
-        match self.defer_expression(trimmed, offset + leading_ws, LazyKind::Lenient) {
-            Some(lazy) => lazy,
-            None => self.parse_js_expression_internal(content, offset, false, '{'),
-        }
-    }
-
     /// Parse an attribute-value expression, propagating `js_parse_error` for
     /// invalid expressions like upstream's `read_expression`. Deferred unless
     /// the value belongs to `<svelte:options>`, whose values `read_options`
@@ -2523,23 +2520,51 @@ impl<'a> Parser<'a> {
                 // complete leading expression followed by leftover input is an
                 // `expected_token` (missing `close_char`); anything else is a
                 // `js_parse_error` at the point acorn/OXC stopped.
-                if let Some(pos) = super::super::read::expression::trailing_token_offset(trimmed) {
-                    return Err(crate::error::ParseError::expected_token(
-                        &close_char.to_string(),
-                        trimmed_offset + pos,
-                    ));
-                }
-                let abs_pos =
-                    super::super::read::expression::check_js_parse_error_with_pos(trimmed)
-                        .map_or(trimmed_offset + trimmed.len(), |(_, pos)| {
-                            trimmed_offset + pos
-                        });
-                Err(crate::error::ParseError::svelte(
-                    "js_parse_error",
+                Err(super::super::read::expression::close_token_or_parse_error(
                     msg,
-                    (abs_pos, abs_pos),
+                    trimmed,
+                    trimmed_offset,
+                    close_char,
                 ))
             }
+        }
+    }
+
+    /// `read_expression` for a `{@const …}` initializer.
+    ///
+    /// Eager on purpose: the sequence-expression rejection that follows reads
+    /// the parsed node, and a deferred expression has no node to read — the
+    /// rejection would go silently missing.
+    fn parse_const_initializer(
+        &self,
+        trimmed: &str,
+        trimmed_offset: usize,
+    ) -> crate::error::ParseResult<Expression<'a>> {
+        match super::super::read::expression::parse_expression(
+            &self.arena,
+            trimmed,
+            trimmed_offset,
+            self.expression_line_offsets(),
+            self.source,
+            self.options.loose,
+            false,
+            '{',
+            self.ts,
+        ) {
+            Ok(expr) => Ok(expr),
+            Err(_) if self.options.loose => {
+                Ok(super::super::read::expression::create_empty_identifier(
+                    "",
+                    trimmed_offset,
+                    trimmed_offset + trimmed.len(),
+                ))
+            }
+            Err((msg, _)) => Err(super::super::read::expression::close_token_or_parse_error(
+                msg,
+                trimmed,
+                trimmed_offset,
+                '}',
+            )),
         }
     }
 }

--- a/crates/rsvelte_core/tests/tag_expression_parse_errors_3202.rs
+++ b/crates/rsvelte_core/tests/tag_expression_parse_errors_3202.rs
@@ -1,0 +1,212 @@
+//! `{@const}`, the `{#await}` head and `{@render}` swallowed every JS parse
+//! error: all three route their expression through a parse whose contract is
+//! `.unwrap_or_else(|_| create_empty_identifier(…))`, so ordinary broken
+//! JavaScript compiled (issue #3202).
+//!
+//! Upstream's `read_expression` throws unless `parser.loose`, and the caller
+//! then does `allow_whitespace(); eat('}', true)` — which is why a *complete*
+//! expression with leftover input after it is an `expected_token` while a
+//! malformed one is a `js_parse_error`. Both classifications are asserted
+//! below, and every code, message and byte offset was measured against
+//! `svelte.compile`.
+//!
+//! `{@render}` is the row that shows the shape: the swallowed expression became
+//! an empty identifier, which is not a call, so the *downstream* validation
+//! fired with a different code standing in for the error that was dropped.
+
+use rsvelte_core::{CompileOptions, GenerateMode, compile, compiler::CssMode};
+
+fn error(src: &str) -> Option<(String, String, u32)> {
+    compile(
+        src,
+        CompileOptions {
+            filename: Some("Test.svelte".to_string()),
+            generate: GenerateMode::Client,
+            css: CssMode::External,
+            ..Default::default()
+        },
+    )
+    .err()
+    .map(|err| {
+        let d = err.diagnostic();
+        (
+            d.code.unwrap_or_default(),
+            d.message.lines().next().unwrap_or_default().to_string(),
+            d.span.map(|(start, _)| start).unwrap_or(u32::MAX),
+        )
+    })
+}
+
+fn assert_error(src: &str, code: &str, message: &str, at: u32) {
+    let actual = error(src).unwrap_or_else(|| panic!("must not compile: {src:?}"));
+    assert_eq!(
+        actual,
+        (code.to_string(), message.to_string(), at),
+        "for {src:?}"
+    );
+}
+
+const UNEXPECTED: &str = "Unexpected token";
+const RVALUE: &str = "Assigning to rvalue";
+const EXPECTED_BRACE: &str = "Expected token }";
+
+#[test]
+fn a_const_tag_initializer_reports_its_parse_error() {
+    assert_error(
+        "{#if true}{@const c = 1 +}<b>{c}</b>{/if}",
+        "js_parse_error",
+        UNEXPECTED,
+        25,
+    );
+    assert_error(
+        "{#if true}{@const c = 42 = nope}<b>{c}</b>{/if}",
+        "js_parse_error",
+        RVALUE,
+        22,
+    );
+}
+
+#[test]
+fn an_await_head_reports_its_parse_error() {
+    for src in [
+        "{#await 42 = nope}<b>x</b>{/await}",
+        "{#await 42 = nope then v}<b>{v}</b>{/await}",
+        "{#await 42 = nope catch e}<b>{e}</b>{/await}",
+    ] {
+        assert_error(src, "js_parse_error", RVALUE, 8);
+    }
+    assert_error(
+        "{#await 1 +}<b>x</b>{/await}",
+        "js_parse_error",
+        UNEXPECTED,
+        11,
+    );
+}
+
+#[test]
+fn a_render_tag_reports_its_parse_error() {
+    assert_error("{@render s(42 = nope)}", "js_parse_error", RVALUE, 11);
+    assert_error("{@render 1 +}", "js_parse_error", UNEXPECTED, 12);
+}
+
+/// The residual: rsvelte's `js_parse_error` MESSAGE and offset come from OXC,
+/// which labels some failures a token away from acorn and spells a truncated
+/// input `Expected `)` but found `EOF`` where acorn says `Unexpected token`.
+/// That is one pre-existing property of `check_js_parse_error_with_pos`, shared
+/// with the mustache path this issue does not touch — measured on `{f(}`
+/// (official 3, rsvelte 3, message diverges) and `{s(1 +)}` (official 6,
+/// rsvelte 7). So the three tag entry points must now answer *identically to a
+/// mustache carrying the same expression*: whatever that residual is, it is not
+/// a property of the tag.
+#[test]
+fn a_tag_classifies_exactly_as_a_mustache_carrying_the_same_expression() {
+    // (source, byte offset at which the expression starts). An `{#await}` head
+    // is absent from the unbalanced-`(` group on purpose: nothing terminates it,
+    // so that shape is `block_unclosed` — issue #3247, not this one.
+    let groups: [&[(&str, u32)]; 2] = [
+        &[
+            ("{f(}", 1),
+            ("{@render f(}", 9),
+            ("{#if true}{@const c = f(}<b>{c}</b>{/if}", 22),
+        ],
+        &[
+            ("{s(1 +)}", 1),
+            ("{@render s(1 +)}", 9),
+            ("{#await s(1 +)}x{/await}", 8),
+            ("{#if true}{@const c = s(1 +)}<b>{c}</b>{/if}", 22),
+        ],
+    ];
+    let relative = |&(src, base): &(&str, u32)| {
+        let (code, message, at) = error(src).unwrap_or_else(|| panic!("must not compile: {src:?}"));
+        (code, message, at - base)
+    };
+    for group in groups {
+        let expected = relative(&group[0]);
+        for row in &group[1..] {
+            assert_eq!(relative(row), expected, "for {:?}", row.0);
+        }
+    }
+}
+
+/// Upstream reads ONE expression and then expects the `}`, so leftover input
+/// after a complete expression is a missing token rather than a JS error — the
+/// two halves of `read_expression`'s contract, and the reason a fix that maps
+/// every failure to `js_parse_error` is wrong.
+#[test]
+fn leftover_input_after_a_complete_expression_is_a_missing_brace() {
+    assert_error(
+        "{#if true}{@const c = 1 2}<b>{c}</b>{/if}",
+        "expected_token",
+        EXPECTED_BRACE,
+        24,
+    );
+    assert_error(
+        "{#if true}{@const c = 1;}<b>{c}</b>{/if}",
+        "expected_token",
+        EXPECTED_BRACE,
+        23,
+    );
+    assert_error(
+        "{#await a b}<b>x</b>{/await}",
+        "expected_token",
+        EXPECTED_BRACE,
+        10,
+    );
+    assert_error(
+        "{#await a b then v}<b>{v}</b>{/await}",
+        "expected_token",
+        EXPECTED_BRACE,
+        10,
+    );
+    assert_error("{@render s() x}", "expected_token", EXPECTED_BRACE, 13);
+    assert_error("{@render s();}", "expected_token", EXPECTED_BRACE, 12);
+}
+
+/// A render tag whose expression PARSES but is not a call keeps its own
+/// analysis-phase code: the parse error and the invalid-expression error are
+/// two different verdicts and the fix must not collapse them.
+#[test]
+fn a_render_tag_that_parses_still_reaches_the_call_check() {
+    assert_error(
+        "{@render 1}",
+        "render_tag_invalid_expression",
+        "`{@render ...}` tags can only contain call expressions",
+        9,
+    );
+}
+
+#[test]
+fn valid_tags_still_compile() {
+    for src in [
+        "{@render s(1)}",
+        "{@render s?.()}",
+        "{#await p then v}<b>{v}</b>{/await}",
+        "{#await p}<b>w</b>{:then v}<b>{v}</b>{:catch e}<b>{e}</b>{/await}",
+        // `then` as part of the expression, not as the clause keyword.
+        "{#await obj.then}<b>x</b>{/await}",
+        "{#if true}{@const c = 1}<b>{c}</b>{/if}",
+        "{#if true}{@const c = (a) => a}<b>{c(1)}</b>{/if}",
+        // A parenthesised sequence is legal where a bare one is not.
+        "{#if true}{@const c = (1, 2)}<b>{c}</b>{/if}",
+    ] {
+        assert_eq!(error(src), None, "must compile: {src:?}");
+    }
+}
+
+/// The sequence-expression rejection reads the PARSED initializer, so it only
+/// survives if the const tag keeps parsing eagerly rather than deferring.
+///
+/// Negative control (measured): route this through the deferring
+/// `parse_head_expression` and every test here that carries a `{@const}` fails
+/// — `node_type()` is `None` for a deferred expression, so the rejection is
+/// skipped, and `expression_into_node` then panics because the declaration
+/// builder takes ownership of the typed node.
+#[test]
+fn a_sequence_initializer_is_still_rejected() {
+    assert_error(
+        "{#if true}{@const a = 1, b = 2}<b>x</b>{/if}",
+        "const_tag_invalid_expression",
+        "{@const ...} must consist of a single variable declaration",
+        22,
+    );
+}


### PR DESCRIPTION
Refs #3202
Closes #3354

Not `Closes #3202`: four of that issue's five rows are fixed here, and the fifth (`{#await 1 + then v}`) has a different cause that belongs to #3350 — see the last section.

`Closes #3354` because that issue's grid is measured and fully closed on this branch — all nine cells, see [the measurement](https://github.com/baseballyama/rsvelte/issues/3354#issuecomment-5379080540). Its three `{@render}` rows keep a +1 byte offset, and the control in that comment shows the identical +1 in the mustache, attribute and `{#if}` slots this PR does not touch, so it is #3432 rather than an unfixed part of #3354.

## What

`{@const …}`'s initializer, the `{#await …}` head and `{@render …}` all routed their expression through a parse whose contract is `.unwrap_or_else(|_| create_empty_identifier(…))`. Ordinary broken JavaScript compiled:

```svelte
{#if true}{@const c = 1 +}<b>{c}</b>{/if}
{#await 42 = nope then v}<b>{v}</b>{/await}
```

Upstream's `read_expression` **throws** unless `parser.loose`, so all three are hard errors there.

`{@render}` is the row that shows the shape rather than restating it: the swallowed expression became an empty identifier, that identifier is not a call, and so the *downstream* `render_tag_invalid_expression` fired — a second error standing in for the one that was dropped, with a different code.

## Both halves of `read_expression`'s contract, not just the error half

Upstream parses **one** expression and the caller then does `allow_whitespace(); eat('}', true)`. So a failure has two possible verdicts, and a fix that maps every failure to `js_parse_error` is wrong in half the cases. Measured on `svelte.compile`, both verdicts occur at all three entry points:

| input | official / rsvelte after this PR |
|---|---|
| `{@const c = 1 +}` | `js_parse_error` "Unexpected token" @25 |
| `{@const c = 42 = nope}` | `js_parse_error` "Assigning to rvalue" @22 |
| `{@const c = 1 2}` | `expected_token` "Expected token }" @24 |
| `{@const c = 1;}` | `expected_token` "Expected token }" @23 |
| `{#await 42 = nope}` | `js_parse_error` "Assigning to rvalue" @8 |
| `{#await 42 = nope then v}` | same, @8 |
| `{#await 42 = nope catch e}` | same, @8 |
| `{#await 1 +}` | `js_parse_error` "Unexpected token" @11 |
| `{#await a b}` | `expected_token` "Expected token }" @10 |
| `{#await a b then v}` | `expected_token` "Expected token }" @10 |
| `{@render s(42 = nope)}` | `js_parse_error` "Assigning to rvalue" @11 |
| `{@render 1 +}` | `js_parse_error` "Unexpected token" @12 |
| `{@render s() x}` | `expected_token` "Expected token }" @13 |
| `{@render s();}` | `expected_token` "Expected token }" @12 |

## One classifier, because there were three copies of the decision

The leftover-input probe (`trailing_token_offset`) is not sufficient on its own: OXC labels an invalid assignment target **at the target's start**, so `42 = nope` looks exactly like "the expression ended at offset 0 and everything after is leftover". The mustache path already guards against that with a prefix re-parse; `parse_head_expression` and `resolve_lazy.rs`'s `HeadBrace` arm did **not**, so the same input would have been classified two ways depending on whether the expression was deferred.

That matters here rather than in the abstract, because `compile` sets `defer_script_parse: true` — so the path this PR must get right is the **deferred** one, and the eager one is what the tests reach in other configurations. The decision is now one function, `close_token_or_parse_error`, called from all three.

## `{@const}` cannot defer, and the negative control says why

The const initializer keeps parsing **eagerly**. Two things below it read the parsed node: the sequence-expression rejection (`init_expr.node_type() == Some("SequenceExpression")`) and `build_const_variable_declaration`, which takes ownership of it.

**Negative control, measured** — swap `parse_const_initializer` for the deferring `parse_head_expression` and rebuild:

```
test a_sequence_initializer_is_still_rejected ... FAILED
test a_const_tag_initializer_reports_its_parse_error ... FAILED
test a_tag_classifies_exactly_as_a_mustache_carrying_the_same_expression ... FAILED
test leftover_input_after_a_complete_expression_is_a_missing_brace ... FAILED
test valid_tags_still_compile ... FAILED
test result: FAILED. 3 passed; 5 failed
```

Every failure is `panicked at .../state/tag.rs:2904` — `expression_into_node`'s `Expression::Lazy must be resolved before building a declaration`. So the prediction I wrote before measuring ("the rejection goes silently missing") was only half right: `node_type()` does return `None` and the rejection *is* skipped, but the builder panics one statement later, so **every** const tag aborts, not just the sequence one. The three tests that stay green are the ones with no `{@const}` in them, which is the control moving in the right direction.

## Over-reach

Eight valid tags are asserted to still compile, chosen against the specific ways this change could over-reject: `{@render s?.()}` (a chained call), `{#await obj.then}` (`then` inside the expression rather than as the clause keyword), `{#await p}…{:then v}…{:catch e}…{/await}`, `{@const c = (1, 2)}` (a parenthesised sequence, which is legal where a bare one is not) and `{@const c = (a) => a}`.

`{@render 1}` — an expression that *parses* but is not a call — is asserted to still reach the analysis-phase `render_tag_invalid_expression` at @9. The parse error and the invalid-expression error are two verdicts and the fix must not collapse them.

Loose (editor) mode keeps recovering with a placeholder at all three sites, as before.

## The residual, and why it is not this defect

rsvelte's `js_parse_error` message and offset come from OXC, which labels some failures a token away from acorn and spells a truncated input `` Expected `)` but found `EOF` `` where acorn says `Unexpected token`. Measured:

| input | official | rsvelte |
|---|---|---|
| `{f(}` | `Unexpected token` @3 | `` Expected `)` but found `EOF` `` @3 |
| `{s(1 +)}` | `Unexpected token` @6 | `Unexpected token` @7 |

Both rows are **mustaches** — the path this PR does not touch — so this is one pre-existing property of `check_js_parse_error_with_pos`, not something the three tags introduce. `a_tag_classifies_exactly_as_a_mustache_carrying_the_same_expression` states exactly that: for the same expression at four entry points (mustache, `{@render}`, `{#await}` head, `{@const}` initializer) the code, the message and the offset *relative to where the expression starts* must be identical. Whatever the residual is, it is now the same everywhere, and closing it is a change to that one function.

(The `{#await f(}` row is deliberately absent from the unbalanced-`(` group: nothing terminates that head, so it is `block_unclosed` — #3247, not this.)

## The fifth row is not this defect

`{#await 1 + then v}` — official raises `expected_token` "Expected token }" @17. rsvelte finds the ` then ` keyword by **text scan** and splits the head there, so it parses `1 +` and fails inside the expression; upstream parses the expression first and only then looks at what follows, so its `then` is part of the expression and the error lands on `v`. That is the await header's end detection, which #3350 covers, and it is untouched here.

## Tests

`crates/rsvelte_core/tests/tag_expression_parse_errors_3202.rs` — code, message and byte offset asserted for every row, all measured against `svelte.compile`.

## Verification

`cargo fmt --all` and `cargo clippy -p rsvelte_core --all-targets --all-features -- -D warnings` were run by hand (the pre-commit hook was bypassed with `--no-verify`; it builds a second multi-GB `target/` and does not finish inside the shared-machine budget right now).

Green on this branch: `compiler_errors`, `parser_fixtures`, `compiler_fixtures`, `ssr`, `runtime`, `validator`, `css`, `block_head_parse_errors`, `const_tag_pattern_pin`, `const_tag_multibyte`, `await_block_multibyte`, `await_ideographic_space_2409`, `render_tag_invalid_expression`, `render_tag_multiline_args`, `special_tag_bracket_scan`, `parser_hardening`, `expected_whitespace_2581`, `js_whitespace_parser_2561`, `block_close_mismatch`, and the new file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
