### PR TITLE
fix(parse): read an identifier before deciding what a `{…}` attribute is

### DIFF
--- a/.changeset/attribute-shorthand-diagnosis.md
+++ b/.changeset/attribute-shorthand-diagnosis.md
@@ -1,0 +1,12 @@
+---
+'@rsvelte/compiler': patch
+---
+
+Diagnose a non-identifier `{…}` in attribute position as an empty shorthand
+
+Upstream reads an identifier after the `{` and reports `attribute_empty_shorthand`
+at the brace when it is empty. rsvelte brace-scanned the body and handed it to the
+expression parser instead, so `{@attac f}` — a one-character typo of `@attach` —
+and every other non-identifier body came out as `expected_token` one column late,
+while `{#…}` / `{/…}` abandoned the opening tag entirely (which upstream does only
+in loose mode).

--- a/crates/rsvelte_core/src/compiler/phases/1_parse/state/element.rs
+++ b/crates/rsvelte_core/src/compiler/phases/1_parse/state/element.rs
@@ -1108,7 +1108,10 @@ impl<'a> Parser<'a> {
             {
                 break;
             }
-            if b == b'{'
+            // Upstream abandons an opening tag on a block token only in loose
+            // mode; strict mode lets `read_attribute` raise the shorthand error.
+            if self.options.loose
+                && b == b'{'
                 && self.index + 1 < self.bytes.len()
                 && (self.bytes[self.index + 1] == b'/' || self.bytes[self.index + 1] == b'#')
             {
@@ -1317,7 +1320,7 @@ impl<'a> Parser<'a> {
                     return Err(crate::error::ParseError::svelte(
                         "attribute_empty_shorthand",
                         "Attribute shorthand cannot be empty",
-                        (expr_start, expr_start),
+                        (start, start),
                     ));
                 }
 
@@ -1385,6 +1388,17 @@ impl<'a> Parser<'a> {
             if !self.options.loose
                 && let Some(bad) = shorthand_first_invalid_offset(&name)
             {
+                // Upstream reads an identifier first, so nothing identifier-like
+                // at the front means it read an *empty* one — the shorthand
+                // error, at the `{`. Only once it has one does the missing `}`
+                // become the complaint.
+                if bad == 0 {
+                    return Err(crate::error::ParseError::svelte(
+                        "attribute_empty_shorthand",
+                        "Attribute shorthand cannot be empty",
+                        (start, start),
+                    ));
+                }
                 let leading_ws = expr_content.len() - expr_content.trim_start_ws().len();
                 return Err(crate::error::ParseError::expected_token(
                     "}",

--- a/crates/rsvelte_core/tests/attribute_shorthand_diagnosis_3409.rs
+++ b/crates/rsvelte_core/tests/attribute_shorthand_diagnosis_3409.rs
@@ -1,0 +1,124 @@
+//! Issue #3409 — a `{…}` in attribute position that is not a shorthand.
+//!
+//! Upstream's `read_attribute` reads an **identifier** after the `{`; an empty
+//! one is `attribute_empty_shorthand`, reported at the `{`. rsvelte instead
+//! brace-scanned the whole body and handed it to the expression parser, so
+//! everything that does not begin with an identifier — `{@attac f}` (a one-
+//! character typo of `@attach`), `{@ attach f}`, `{@ATTACH f}`, `{@}`,
+//! `{@html x}`, `{:x}` — came out as `expected_token` one column late, and the
+//! genuinely empty `{}` was reported after the brace rather than at it.
+//! `{#…}` / `{/…}` never even reached the check: the attribute loop abandoned
+//! the opening tag on them, which upstream does only in loose mode.
+//!
+//! Every expectation was measured against the official compiler on the same
+//! source. `{a.b}` and `{a()}` are the controls — upstream *does* read an
+//! identifier there, so they stay `expected_token` at the offending character.
+
+use rsvelte_core::{CompileOptions, GenerateMode, compile};
+
+/// `(code, start)` of the parse error, or `None` when the source compiles.
+fn diagnose(source: &str) -> Option<(String, usize)> {
+    match compile(
+        source,
+        CompileOptions {
+            filename: Some("A.svelte".to_string()),
+            generate: GenerateMode::Client,
+            ..Default::default()
+        },
+    ) {
+        Ok(_) => None,
+        Err(err) => {
+            let text = format!("{err:?}");
+            let code = text
+                .split("code: \"")
+                .nth(1)
+                .and_then(|rest| rest.split('"').next())
+                .unwrap_or_default()
+                .to_string();
+            let start = text
+                .split("span: (")
+                .nth(1)
+                .and_then(|rest| rest.split(',').next())
+                .and_then(|n| n.trim().parse::<usize>().ok())
+                .unwrap_or(usize::MAX);
+            Some((code, start))
+        }
+    }
+}
+
+#[track_caller]
+fn assert_empty_shorthand_at_brace(source: &str) {
+    let brace = source.find('{').expect("the source has no `{`");
+    match diagnose(source) {
+        None => panic!("{source:?} compiled; official rejects it"),
+        Some((code, start)) => {
+            assert_eq!(
+                code, "attribute_empty_shorthand",
+                "wrong code for {source:?}"
+            );
+            assert_eq!(start, brace, "wrong point for {source:?}");
+        }
+    }
+}
+
+/// Nothing identifier-like after the `{`: upstream read an empty identifier.
+#[test]
+fn a_body_that_is_not_an_identifier_is_the_shorthand_error() {
+    for source in [
+        "<div {@attac f}>x</div>",
+        "<div {@ attach f}>x</div>",
+        "<div {@ATTACH f}>x</div>",
+        "<div {@}>x</div>",
+        "<div {@html x}>x</div>",
+        "<div {:x}>x</div>",
+    ] {
+        assert_empty_shorthand_at_brace(source);
+    }
+}
+
+/// A block token in attribute position is the same error, not an abandoned tag.
+#[test]
+fn a_block_token_in_attribute_position_is_the_shorthand_error() {
+    for source in ["<div {#if a}>x</div>", "<div {/x}>x</div>"] {
+        assert_empty_shorthand_at_brace(source);
+    }
+}
+
+/// An actually empty shorthand points at the `{`, not past it.
+#[test]
+fn an_empty_shorthand_points_at_the_brace() {
+    for source in ["<div {}>x</div>", "<div {  }>x</div>"] {
+        assert_empty_shorthand_at_brace(source);
+    }
+}
+
+/// `start` is taken after any attribute-position comment, so a comment before
+/// the `{` must move the point with it rather than leave it behind.
+#[test]
+fn a_comment_before_the_shorthand_moves_the_point() {
+    assert_empty_shorthand_at_brace("<div /* c */ {@attac f}>x</div>");
+    assert_empty_shorthand_at_brace("<div id=\"i\" {@attac f}>x</div>");
+}
+
+/// The controls: upstream reads an identifier here, so the complaint stays the
+/// missing `}` at the offending character.
+#[test]
+fn a_shorthand_that_starts_with_an_identifier_still_wants_its_brace() {
+    for source in ["<div {a.b}>x</div>", "<div {a()}>x</div>"] {
+        let (code, start) = diagnose(source).expect("official rejects these too");
+        assert_eq!(code, "expected_token", "wrong code for {source:?}");
+        assert_eq!(start, 7, "wrong point for {source:?}");
+    }
+}
+
+/// The controls that compile on both sides.
+#[test]
+fn the_valid_shorthands_still_compile() {
+    for source in [
+        "<div {a}>x</div>",
+        "<div {...a}>x</div>",
+        "<div {@attach f}>x</div>",
+    ] {
+        assert!(diagnose(source).is_none(), "{source:?} was rejected");
+    }
+}


### PR DESCRIPTION
Part of #3409 — the `{@attac f}` row, which turned out to be 48 cells rather than one.

## What was wrong

Upstream's `read_attribute` reads an **identifier** after the `{`. An empty one is
`attribute_empty_shorthand`, reported **at the `{`**. rsvelte never asked that
question: it brace-scanned the whole body and handed it to the expression parser.

```svelte
<div {@attac f}>x</div>
```

| | |
|---|---|
| official | `attribute_empty_shorthand@1:5` — the `{` |
| rsvelte | `expected_token@1:6` |

`@attac` is a one-character typo of `@attach`, so the realistic failure is a wrong
diagnosis pointing one column past the construct that is actually wrong.

Three distinct causes, found by widening the issue's single row into a family:

1. **The point.** A genuinely empty `{}` was reported at `expr_start` (after the
   brace) instead of at the `{`.
2. **The reach.** Anything that does not begin with an identifier — `{@attac f}`,
   `{@ attach f}`, `{@ATTACH f}`, `{@}`, `{@html x}`, `{:x}` — fell through to
   `shorthand_first_invalid_offset`, which reported the missing `}`. Upstream had
   already failed one step earlier, on the empty identifier.
3. **The unreached path.** `{#…}` / `{/…}` never got that far at all: the
   attribute loop abandoned the opening tag on a block token — which upstream does
   **only in loose mode** — so the caller demanded `>` instead.

## Measurement

15 bodies × 4 hosts = 60 cells, official as the oracle, comparing `code` and
`line:column` of both endpoints. Hosts include `<div>`, a component, an attribute
before the shorthand, and a **comment** before it (because `start` is taken after
`read_attr_comment`, so a comment must move the point with it):

| | on `origin/main` | with this PR | with this PR **and #3331** |
|---|---|---|---|
| match | 12 / 60 | **52 / 60** | **60 / 60** |
| fixed | — | **40** | **48** |
| regressed | — | **0** | **0** |

`fixed` and `regressed` are counted per cell against a stored baseline rather than
netted, so a cell that was right and became wrong could not hide inside the total.

The 8 cells this PR leaves are `{a.b}` and `{a()}`, which diverge **only on the end
of the span** (`1:7-1:8` vs `1:7-1:7`) — the `expected_token` point-span shape that
#3331 fixes. Verified by applying this patch on top of PR #3331 and re-measuring:
60/60. Those two bodies are also this PR's **controls**: upstream *does* read an
identifier there, so the missing `}` must stay the complaint, and it does.

On #3409's own 25-input grid the score goes 19/25 (`main`) → 22/25 (#3331 alone) →
**23/25** (both). The two that remain are `<p>{v</p>`, which is #3210's deliberate
residue and belongs to #3333, and `{#nope}x{/nope}`, which lands in the
three-way-contested `parse_special_tag`.

## Tests

`crates/rsvelte_core/tests/attribute_shorthand_diagnosis_3409.rs`, every
expectation measured against the official compiler on the same source.

**Negative control, taken separately for each of the three edits** — each fails a
different test, for its own reason, with both control tests green throughout:

| reverted | fails | on |
|---|---|---|
| the loose-mode gate on the block-token break | `a_block_token_in_attribute_position_...` | code |
| the `bad == 0` branch | `a_body_that_is_not_an_identifier_...`, `a_comment_before_...`, `a_block_token_...` | code |
| the empty-shorthand point | `an_empty_shorthand_points_at_the_brace` | point |

The middle row is a real dependency rather than noise: once the loop stops
abandoning the tag, the block-token cells route through the `bad == 0` branch too.

Suites run locally: `parser_fixtures`, `parser_hardening`, `compiler_errors`,
`compiler_fixtures`.

## Coordination

Checked with @errH: this touches `parse_attribute`'s `{` block and the
`parse_element` attribute loop, neither of which #3495 (`read_attribute_value`
consolidation) or #3331 touches. Confirmed by applying this patch to #3331 cleanly.
