### PR TITLE
fix(fmt): keep the parentheses an ES2022 brand check needs

### DIFF
--- a/.changeset/fmt-private-in-parens.md
+++ b/.changeset/fmt-private-in-parens.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/fmt": patch
+---
+
+The formatter no longer rewrites an ES2022 brand check into a different program. `oxc_formatter` treats only `BinaryExpression` and `LogicalExpression` as binary-like parents, so oxc's separate `PrivateInExpression` node falls through the precedence comparison and both sides of `#x in o` lose required parentheses — `#value in (o || {})` printed as `#value in o || {}` (which returns `true` or `{}` instead of `true`/`false`), and `(#value in o) * 2` printed as `#value in o * 2`. 12 of 24 measured shapes changed meaning; the same shapes with an ordinary `"k" in (…)` were all correct. The formatter now records each brand check's right operand, re-parses its own output, and keeps the input when the two disagree — so it declines to reformat rather than change what the code means. Reported upstream in `upstream_issues/3451-oxc-private-in-parens.md`; a program with no brand check is unaffected and never re-parsed.

--- a/crates/rsvelte_formatter/src/lib.rs
+++ b/crates/rsvelte_formatter/src/lib.rs
@@ -20,6 +20,7 @@ mod json;
 mod markup;
 mod options;
 mod prettier_ignore;
+mod private_in_guard;
 mod reindent;
 mod scratch;
 mod script;

--- a/crates/rsvelte_formatter/src/private_in_guard.rs
+++ b/crates/rsvelte_formatter/src/private_in_guard.rs
@@ -1,0 +1,59 @@
+//! Guard against oxc's formatter dropping parentheses a brand check needs.
+//!
+//! `oxc_formatter`'s `binary_like_needs_parens` treats only `BinaryExpression`
+//! and `LogicalExpression` as binary-like parents, so a `PrivateInExpression` —
+//! oxc's own node for `#x in o` — falls to its `_ => return false` arm and both
+//! sides of the check lose required parentheses:
+//! `#x in (o || {})` prints as `#x in o || {}`, and `(#x in o) * 2` prints as
+//! `#x in o * 2`. Both are different programs. See
+//! `upstream_issues/3451-oxc-private-in-parens.md`.
+//!
+//! The guard verifies rather than predicts: it records the kind of every brand
+//! check's right operand before and after formatting, and the caller keeps the
+//! input when the two disagree. A program with no brand check produces an empty
+//! record and never re-parses anything.
+
+use oxc_ast::ast::{Expression, PrivateInExpression, Program};
+use oxc_ast_visit::Visit;
+
+/// A coarse class for the right operand of a brand check. Only the distinction
+/// matters: both directions of the defect move the operand between classes
+/// (a parenthesised `o || {}` collapses to a bare identifier; a bare `o` grows
+/// into `o * 2` or `o.toString()`).
+fn right_kind(expression: &Expression) -> u8 {
+    match expression {
+        Expression::LogicalExpression(_) => 1,
+        Expression::BinaryExpression(_) => 2,
+        Expression::ConditionalExpression(_) => 3,
+        Expression::AssignmentExpression(_) => 4,
+        Expression::SequenceExpression(_) => 5,
+        Expression::StaticMemberExpression(_)
+        | Expression::ComputedMemberExpression(_)
+        | Expression::PrivateFieldExpression(_) => 6,
+        Expression::CallExpression(_) => 7,
+        Expression::PrivateInExpression(_) => 8,
+        Expression::ChainExpression(_) => 9,
+        Expression::TSAsExpression(_) | Expression::TSSatisfiesExpression(_) => 10,
+        Expression::AwaitExpression(_) => 11,
+        Expression::TaggedTemplateExpression(_) => 12,
+        _ => 0,
+    }
+}
+
+#[derive(Default)]
+struct BrandChecks(Vec<u8>);
+
+impl<'a> Visit<'a> for BrandChecks {
+    fn visit_private_in_expression(&mut self, it: &PrivateInExpression<'a>) {
+        self.0.push(right_kind(&it.right));
+        oxc_ast_visit::walk::walk_private_in_expression(self, it);
+    }
+}
+
+/// The right-operand class of every brand check in `program`, in source order.
+/// Empty when the program has none, which is the overwhelmingly common case.
+pub(crate) fn brand_check_shapes(program: &Program) -> Vec<u8> {
+    let mut visitor = BrandChecks::default();
+    visitor.visit_program(program);
+    visitor.0
+}

--- a/crates/rsvelte_formatter/src/script.rs
+++ b/crates/rsvelte_formatter/src/script.rs
@@ -36,11 +36,46 @@ pub fn format_js_source(
             parser_ret.diagnostics
         )));
     }
-    let formatted = format_program(&allocator, &parser_ret.program, options.js.clone())
+    let formatted = print_program_guarded(
+        &allocator,
+        &parser_ret.program,
+        options.js.clone(),
+        source_type,
+    )?;
+    Ok(formatted.unwrap_or_else(|| source.to_string()))
+}
+
+/// Print a program through `oxc_formatter`, returning `None` when the formatted
+/// text would be a DIFFERENT program.
+///
+/// oxc drops parentheses that a brand check needs — `#x in (o || {})` prints as
+/// `#x in o || {}` and `(#x in o) * 2` as `#x in o * 2`
+/// (`upstream_issues/3451-oxc-private-in-parens.md`). A formatter must not
+/// rewrite what the code means, so this verifies the brand checks survived
+/// instead of predicting which ones oxc gets wrong. A program with no brand
+/// check takes the empty-record fast path and never re-parses.
+fn print_program_guarded<'a>(
+    allocator: &'a Allocator,
+    program: &oxc_ast::ast::Program<'a>,
+    js: JsFormatOptions,
+    source_type: SourceType,
+) -> Result<Option<String>, FormatError> {
+    let formatted = format_program(allocator, program, js)
         .print()
         .map_err(|e| FormatError::ScriptParse(format!("{e:?}")))?
         .into_code();
-    Ok(formatted)
+    let before = crate::private_in_guard::brand_check_shapes(program);
+    if before.is_empty() {
+        return Ok(Some(formatted));
+    }
+    let reparsed = Parser::new(allocator, &formatted, source_type)
+        .with_options(formatter_parse_options())
+        .parse();
+    if !reparsed.diagnostics.is_empty() {
+        return Ok(None);
+    }
+    let after = crate::private_in_guard::brand_check_shapes(&reparsed.program);
+    Ok((before == after).then_some(formatted))
 }
 
 /// The single indent unit (one nesting level) implied by `JsFormatOptions`.
@@ -135,10 +170,10 @@ pub fn format_script(
         js.line_width =
             oxc_formatter_core::LineWidth::try_from(nested_width).unwrap_or(js.line_width);
     }
-    let formatted = format_program(allocator, &parser_ret.program, js)
-        .print()
-        .map_err(|e| FormatError::ScriptParse(format!("{e:?}")))?
-        .into_code();
+    let Some(formatted) = print_program_guarded(allocator, &parser_ret.program, js, source_type)?
+    else {
+        return Ok(None);
+    };
 
     // oxc_formatter emits a trailing newline. Add one indent level to
     // every non-empty line so the body is nested under `<script>` using
@@ -223,10 +258,10 @@ pub fn format_nested_script(
             .min(js.line_width.value().saturating_sub(1));
     let nested_width = js.line_width.value().saturating_sub(narrow);
     js.line_width = oxc_formatter_core::LineWidth::try_from(nested_width).unwrap_or(js.line_width);
-    let formatted = format_program(allocator, &parser_ret.program, js)
-        .print()
-        .map_err(|e| FormatError::ScriptParse(format!("{e:?}")))?
-        .into_code();
+    let Some(formatted) = print_program_guarded(allocator, &parser_ret.program, js, source_type)?
+    else {
+        return Ok(None);
+    };
 
     let reindented = crate::reindent::reindent(formatted.trim_end(), &body_indent, false);
     let tag_indent = unit.repeat(depth);

--- a/crates/rsvelte_formatter/tests/private_in_parens.rs
+++ b/crates/rsvelte_formatter/tests/private_in_parens.rs
@@ -1,0 +1,96 @@
+//! `oxc_formatter` drops parentheses an ES2022 brand check needs, which changes
+//! the program (`upstream_issues/3451-oxc-private-in-parens.md`). The formatter
+//! keeps the input rather than rewriting what the code means.
+//!
+//! This is a DELIBERATE divergence from the oxfmt oracle: the oracle is the same
+//! engine, so it reproduces the defect and a parity comparison scores a match by
+//! construction. The assertions below are about the program, not about parity.
+
+use rsvelte_formatter::{
+    FormatOptions, IndentStyle, IndentWidth, JsFormatOptions, LineWidth, format,
+};
+
+fn fmt(src: &str) -> String {
+    let js = JsFormatOptions {
+        indent_style: IndentStyle::Space,
+        indent_width: IndentWidth::try_from(2u8).unwrap(),
+        line_width: LineWidth::try_from(80u16).unwrap(),
+        ..JsFormatOptions::default()
+    };
+    let options = FormatOptions {
+        js,
+        typescript: false,
+        ..FormatOptions::new()
+    };
+    format(src, &options).expect("format ok")
+}
+
+fn script(body: &str) -> String {
+    format!(
+        "<script>\n  class Box {{\n    static #value;\n    static holds(o, p) {{\n      return {body};\n    }}\n  }}\n</script>\n"
+    )
+}
+
+/// The reported shape: `in` binds tighter than `||`, so dropping the
+/// parentheses returns `true`/`{}` where the source returns `true`/`false`.
+#[test]
+fn a_logical_right_operand_keeps_its_parentheses() {
+    let out = fmt(&script("#value in (o || {})"));
+    assert!(out.contains("#value in (o || {})"), "{out}");
+}
+
+#[test]
+fn a_coalesce_right_operand_keeps_its_parentheses() {
+    let out = fmt(&script("#value in (o ?? {})"));
+    assert!(out.contains("#value in (o ?? {})"), "{out}");
+}
+
+#[test]
+fn a_conditional_right_operand_keeps_its_parentheses() {
+    let out = fmt(&script("#value in (o ? o : p)"));
+    assert!(out.contains("#value in (o ? o : p)"), "{out}");
+}
+
+/// The other direction: the brand check is itself the child of a tighter
+/// operator, and losing its own parentheses re-associates the whole expression.
+#[test]
+fn a_brand_check_under_a_tighter_operator_keeps_its_parentheses() {
+    let out = fmt(&script("(#value in o) * 2"));
+    assert!(out.contains("(#value in o) * 2"), "{out}");
+}
+
+#[test]
+fn a_brand_check_before_a_member_access_keeps_its_parentheses() {
+    let out = fmt(&script("(#value in o).toString()"));
+    assert!(out.contains("(#value in o).toString()"), "{out}");
+}
+
+/// The discriminating control: same operator, same right operand, ordinary left
+/// operand. oxc parenthesises this correctly, so the body is still FORMATTED —
+/// the guard must not disable formatting for every class.
+#[test]
+fn an_ordinary_in_is_untouched_and_still_formatted() {
+    let out = fmt(
+        "<script>\n  class Box {\n        static holds(o) {\n            return \"k\" in (o || {});\n        }\n  }\n</script>\n",
+    );
+    assert!(out.contains("\"k\" in (o || {})"), "{out}");
+    assert!(
+        out.contains("    static holds(o) {"),
+        "the body must still be re-indented:\n{out}"
+    );
+}
+
+/// Negative control: a brand check whose parentheses oxc does NOT drop leaves
+/// the body formatted as usual, so the guard is keyed on the defect and not on
+/// the mere presence of a `#x in o`.
+#[test]
+fn a_brand_check_oxc_prints_correctly_is_still_formatted() {
+    let out = fmt(
+        "<script>\n  class Box {\n    static #value;\n        static holds(o) {\n            return #value in o;\n        }\n  }\n</script>\n",
+    );
+    assert!(out.contains("#value in o"), "{out}");
+    assert!(
+        out.contains("    static holds(o) {"),
+        "the body must still be re-indented:\n{out}"
+    );
+}

--- a/upstream_issues/3451-oxc-private-in-parens.md
+++ b/upstream_issues/3451-oxc-private-in-parens.md
@@ -1,0 +1,123 @@
+# oxc_formatter drops parentheses that a `PrivateInExpression` needs
+
+- **Upstream**: [oxc-project/oxc](https://github.com/oxc-project/oxc), `oxc_formatter`
+- **Observed at**: rev `b6f1458dece6bbd7f934d1d26c049d0d0c2bd68c` (the rev this repo pins), reproduced with the published `oxfmt` 0.63.0
+- **rsvelte issue**: [#3451](https://github.com/baseballyama/rsvelte/issues/3451)
+- **Severity**: the formatted output is a **different program**
+
+## Repro
+
+No rsvelte code is involved — plain `oxfmt` on a `.js` file:
+
+```js
+class C {
+  static #value;
+  static a(o) { return #value in (o || {}); }
+  static b(o) { return "k" in (o || {}); }
+  static c(o) { return #value in (o ?? {}); }
+}
+```
+
+```js
+// oxfmt --config {"printWidth":80,"tabWidth":2,"useTabs":false}
+  static a(o) { return #value in o || {}; }   // ((#value in o) || {})  <- different
+  static b(o) { return "k" in (o || {}); }    // correct
+  static c(o) { return #value in o ?? {}; }   // ((#value in o) ?? {})  <- different
+```
+
+`in` binds tighter than `||`, so `a` now returns `true` or `{}` where the source
+returns `true`/`false`.
+
+## Cause
+
+`crates/oxc_formatter/src/parentheses/expression.rs`, `binary_like_needs_parens`
+(~L974) maps a binary-like **parent** to `BinaryLikeExpression`:
+
+```rust
+AstNodes::BinaryExpression(binary) => BinaryLikeExpression::BinaryExpression(binary),
+AstNodes::LogicalExpression(logical) => BinaryLikeExpression::LogicalExpression(logical),
+parent if parent.is_call_like_callee_span(binary_like.span()) => return true,
+_ => return false,
+```
+
+`BinaryLikeExpression` (`crates/oxc_formatter/src/print/binary_like_expression.rs:56`)
+has only those two variants, and oxc models `#x in o` as its own
+`PrivateInExpression` rather than as a `BinaryExpression` with a
+`PrivateIdentifier` left operand (which is how ESTree models it). So a
+`PrivateInExpression` parent reaches `_ => return false` and its child is told no
+parentheses are needed.
+
+The other direction is the same omission seen from the node itself
+(`expression.rs:506`):
+
+```rust
+impl NeedsParentheses<'_> for AstNode<'_, PrivateInExpression<'_>> {
+    fn needs_parentheses(&self, f: &JsFormatter<'_, '_>) -> bool {
+        // ...
+        is_class_extends(self.span, self.parent())
+            || matches!(self.parent(), AstNodes::UnaryExpression(_))
+    }
+}
+```
+
+A `BinaryExpression` in that position consults `binary_like_needs_parens` and
+compares precedences; `PrivateInExpression` checks only `extends` and a unary
+parent, so it loses its own parentheses under any tighter operator.
+
+`"k" in (…)` is the discriminating control throughout: identical operator,
+identical right operand, but a real `BinaryExpression`, which **is** in the match.
+
+## Measured scope
+
+48 cells — 24 shapes × {`#x in …`, `"k" in …`} — formatted by `oxfmt` and then
+re-parsed with acorn, comparing the fully-parenthesised rendering of the parsed
+tree rather than the text. **12 changed, all of them private; 0 of the 24
+controls changed.**
+
+Right operand of the brand check (`#x in (RIGHT)`):
+
+| RIGHT | printed | re-parses as |
+|---|---|---|
+| `o \|\| {}` | `#x in o \|\| {}` | `(#x in o) \|\| {}` |
+| `o && p` | `#x in o && p` | `(#x in o) && p` |
+| `o ?? {}` | `#x in o ?? {}` | `(#x in o) ?? {}` |
+| `a ? b : c` | `#x in a ? b : c` | `(#x in a) ? b : c` |
+| `o < p` | `#x in o < p` | `(#x in o) < p` |
+| `o instanceof P` | `#x in o instanceof P` | `(#x in o) instanceof P` |
+| `o \| p` | `#x in o \| p` | `(#x in o) \| p` |
+| `o === p` | `#x in o === p` | `(#x in o) === p` |
+
+The brand check as a child (`WRAP((#x in o))`):
+
+| WRAP | printed | re-parses as |
+|---|---|---|
+| `E * 2` | `#x in o * 2` | `#x in (o * 2)` |
+| `E + 1` | `#x in o + 1` | `#x in (o + 1)` |
+| `E ** 2` | `#x in o ** 2` | `#x in (o ** 2)` |
+| `E.toString()` | `#x in o.toString()` | `#x in o.toString()` |
+
+Correctly left alone: `o = p` and `(o, p)` as right operands (assignment and
+sequence are special-cased elsewhere), `o + p` / `o.p` / `o ** p` as right
+operands (genuinely redundant parentheses), and `-E`, `E ? a : b`, `E ?? d`,
+`E || d`, `E < 1`, `[...E]`, `E in q` as wrappers.
+
+## Suggested fix
+
+Give `BinaryLikeExpression` a `PrivateInExpression` variant (operator `in`,
+precedence `Relational`) and add the arm to `binary_like_needs_parens`, so both
+directions fall out of the existing precedence comparison.
+
+## What rsvelte does meanwhile
+
+`@rsvelte/fmt` ships `oxc_formatter`, so it inherited this. Because the
+formatter-parity corpus uses **oxfmt as its oracle**, a defect inside oxfmt is
+reproduced identically on both sides and scores as a match by construction — the
+formatter analogue of comparing two ports of one function. No gate could have
+seen it, and a brand check appears nowhere in svelte.dev.
+
+`crates/rsvelte_formatter/src/private_in_guard.rs` records the kind of every
+brand check's right operand, and `script.rs`'s `print_program_guarded` re-parses
+the formatted text and keeps the input when the record changed. It verifies
+rather than predicts, so it does not re-implement oxc's precedence rules, and a
+program with no brand check takes an empty-record fast path that never
+re-parses. Remove it when the oxc rev is bumped past the fix.


### PR DESCRIPTION
Closes #3451

`rsvelte-fmt` rewrote an ES2022 brand check into a **different program**: `#value in (o || {})` came out as `#value in o || {}`, which returns `true`/`{}` where the source returns `true`/`false`.

## Where it lives, and why it is not #3445

The defect is inside **`oxc_formatter`**, not rsvelte. Plain `oxfmt 0.63.0` on a `.js` file — no rsvelte code in the path — reproduces it, so this is a different layer from #3445 (`rsvelte_esrap`'s printer, which the compiler uses and the formatter does not).

`crates/oxc_formatter/src/parentheses/expression.rs`'s `binary_like_needs_parens` maps only `AstNodes::BinaryExpression` and `AstNodes::LogicalExpression` onto `BinaryLikeExpression` — that enum has exactly those two variants — and everything else hits `_ => return false`. oxc models `#x in o` as its own `PrivateInExpression` rather than as ESTree's `BinaryExpression` with a `PrivateIdentifier` left operand, so a brand-check parent never reaches the precedence comparison. The mirror image is at `expression.rs:506`, where `PrivateInExpression::needs_parentheses` checks only `is_class_extends` and a `UnaryExpression` parent, so the brand check also loses *its own* parentheses under a tighter operator.

## Measured scope: much wider than the report

48 cells — 24 shapes × {`#x in …`, `"k" in …`} — formatted by oxfmt, then re-parsed with acorn and compared as **fully-parenthesised trees** rather than as text, so the verdict is about the program and not about the spelling.

**12 changed, every one of them private; 0 of the 24 controls changed.**

| direction | shapes that change meaning |
|---|---|
| right operand `#x in (R)` | `o \|\| {}`, `o && p`, `o ?? {}`, `a ? b : c`, `o < p`, `o instanceof P`, `o \| p`, `o === p` |
| brand check as child | `E * 2`, `E + 1`, `E ** 2`, `E.toString()` |

Correctly left alone: `o = p` / `(o, p)` as right operands, the genuinely-redundant `o + p` / `o.p` / `o ** p`, and the `-E`, `E ? a : b`, `E ?? d`, `E \|\| d`, `E < 1`, `[...E]`, `E in q` wrappers. The `"k" in (…)` row of every one of those is the discriminating control: same operator, same operand, ordinary left side, all correct.

## The fix here: verify, don't predict

`private_in_guard.rs` records the kind of each brand check's right operand, and `script.rs`'s `print_program_guarded` re-parses its own output and keeps the input when the record changed. It does **not** re-implement oxc's precedence rules — a shape it fails to anticipate degrades to today's behaviour rather than to a wrong guess. A program with no brand check produces an empty record and never re-parses, so the cost is nil on everything else.

**This is a deliberate divergence from the oracle**, and it has to be: the formatter-parity gate's oracle *is* oxfmt, so a defect inside oxfmt is reproduced identically on both sides and scores a match by construction — the formatter analogue of comparing two ports of one function. No gate could have caught this, and a brand check appears nowhere in svelte.dev. The trade-off is that a `<script>` carrying one of the 12 shapes is left unformatted instead of being silently rewritten; I took "declines to reformat" over "changes what the code means", but it is a product call and easy to revert to the oracle's behaviour if you disagree.

Reported upstream in `upstream_issues/3451-oxc-private-in-parens.md`, with the suggested fix (give `BinaryLikeExpression` a `PrivateInExpression` variant so both directions fall out of the existing precedence comparison). **Remove the guard when the oxc rev is bumped past it** — the doc comment says so.

## Verification

- `crates/rsvelte_formatter/tests/private_in_parens.rs` — 7 tests. **Positive control taken on the same build**: with the one comparison line replaced by `Ok(Some(formatted))`, exactly the 5 defect tests fail (with the predicted text, e.g. `#value in o.toString()`) and **both controls still pass**, so the controls are not merely insensitive.
- Two of the seven are controls that assert the guard is keyed on the defect and not on the syntax: an ordinary `"k" in (o || {})` and a brand check oxc prints correctly (`#value in o`) are both still **re-indented**, proving the guard does not silently disable formatting for every class.
- `svelte_dev_corpus_parity` (byte-exact, no baseline tolerance): **passes** — 556 `.svelte` + 546 markdown blocks + 644 whole markdown files.
- Full `rsvelte_formatter` suite green; full `rsvelte_fmt` suite green.
- Blast radius measured rather than assumed: **0** files in `compatibility/pattern-corpus` (697), **0** in `submodules/svelte.dev`, **0** in `submodules/svelte` contain a brand check, so no ratchet can move. Note that PR #3445 adds the first corpus file that will contain one (`3413-private-in-brand-check.svelte`); its shape is `#value in other`, which oxc prints correctly, so it takes the `a_brand_check_oxc_prints_correctly_is_still_formatted` path and stays formatted.

Residual risk I could not measure locally: the collected-corpus fmt gate (`fmt-verify.mjs`) runs over corpus submodules that are not checked out here. If one of them carries a brand check in one of the 12 shapes it would become a new `fmt-known-failures.json` entry — a divergence that is rsvelte being *more correct*.

Hooks were skipped for the commit (they exceed 10 minutes under the current machine load); `cargo fmt` and `cargo clippy -p rsvelte_formatter --all-targets --all-features -- -D warnings` were run by hand and are clean.
