### PR TITLE
fix(parse): report an unclosed <textarea> as unexpected_eof

### DIFF
--- a/.changeset/textarea-unclosed-end-of-input.md
+++ b/.changeset/textarea-unclosed-end-of-input.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/compiler": patch
+---
+
+Report an unclosed `<textarea>` as `unexpected_eof` at the end of the template, matching the official compiler. `<textarea>` is escapable raw text, so upstream reads its body with `read_sequence`, which raises `unexpected_eof` when the closing tag never arrives; rsvelte reported the generic `element_unclosed` at the opening tag instead.

--- a/crates/rsvelte_core/src/compiler/phases/1_parse/state/element.rs
+++ b/crates/rsvelte_core/src/compiler/phases/1_parse/state/element.rs
@@ -365,6 +365,17 @@ impl<'a> Parser<'a> {
             // For raw text elements, parse content as raw text instead of HTML
             if is_raw_text_element {
                 fragment = self.parse_raw_text_content(&name)?;
+                // `<textarea>` is escapable raw text, so upstream reads its body
+                // with `read_sequence`, which raises `unexpected_eof` at the
+                // trimmed end when the closing tag never arrives — the element is
+                // not "left open", the input ran out inside it.
+                if !self.options.loose && name == "textarea" && self.index >= self.content_end {
+                    return Err(crate::error::ParseError::svelte(
+                        "unexpected_eof",
+                        "Unexpected end of input",
+                        (self.content_end, self.content_end),
+                    ));
+                }
             } else {
                 fragment = self.parse_fragment()?;
             }

--- a/crates/rsvelte_core/tests/textarea_unclosed_eof_3509.rs
+++ b/crates/rsvelte_core/tests/textarea_unclosed_eof_3509.rs
@@ -1,0 +1,113 @@
+//! Issue #3509 — a `<textarea>` whose closing tag never arrives.
+//!
+//! `<textarea>` is escapable raw text, so upstream reads its body with
+//! `read_sequence` (`1-parse/state/element.js:401-411`), and `read_sequence`
+//! raises `unexpected_eof` at the **trimmed** end of the template when its
+//! `done()` predicate never matches. rsvelte's `parse_raw_text_content` instead
+//! returned whatever it had consumed, `found_closing_tag` stayed false, and the
+//! generic unclosed-element path reported at the opening tag — a different
+//! diagnosis pointing at a different construct.
+//!
+//! Every expectation was measured against the official compiler on the same
+//! source. `<title>` and `<div>` are the controls: neither is a raw-text element
+//! in Svelte, so both must keep `element_unclosed` at the opening tag.
+
+use rsvelte_core::{CompileOptions, GenerateMode, compile};
+
+/// `(code, start, end)` of the parse error, or `None` when the source compiles.
+fn diagnose(source: &str) -> Option<(String, usize, usize)> {
+    match compile(
+        source,
+        CompileOptions {
+            filename: Some("A.svelte".to_string()),
+            generate: GenerateMode::Client,
+            ..Default::default()
+        },
+    ) {
+        Ok(_) => None,
+        Err(err) => {
+            let text = format!("{err:?}");
+            let code = text
+                .split("code: \"")
+                .nth(1)
+                .and_then(|rest| rest.split('"').next())
+                .unwrap_or_default()
+                .to_string();
+            let mut span = text
+                .split("span: (")
+                .nth(1)
+                .unwrap_or_default()
+                .split(')')
+                .next()
+                .unwrap_or_default()
+                .split(',')
+                .filter_map(|n| n.trim().parse::<usize>().ok());
+            let start = span.next().unwrap_or(usize::MAX);
+            let end = span.next().unwrap_or(usize::MAX);
+            Some((code, start, end))
+        }
+    }
+}
+
+/// The point official reports is the end of the *right-trimmed* template.
+fn trimmed_end(source: &str) -> usize {
+    source.trim_end().len()
+}
+
+#[track_caller]
+fn assert_eof_at_trimmed_end(source: &str) {
+    match diagnose(source) {
+        None => panic!("{source:?} compiled; official rejects it"),
+        Some((code, start, end)) => {
+            assert_eq!(code, "unexpected_eof", "wrong code for {source:?}");
+            let at = trimmed_end(source);
+            assert_eq!((start, end), (at, at), "wrong point for {source:?}");
+        }
+    }
+}
+
+#[test]
+fn an_unclosed_textarea_is_end_of_input() {
+    for source in [
+        "<textarea>abc",
+        "<textarea>",
+        "<textarea>a{b}c",
+        "<textarea>abc</textarea",
+        "<textarea>abc</div>",
+        "<div><textarea>abc",
+        "<textarea rows=\"2\">abc",
+    ] {
+        assert_eof_at_trimmed_end(source);
+    }
+}
+
+/// Trailing whitespace is not part of the template upstream measures.
+#[test]
+fn the_point_is_the_trimmed_end_not_the_files_end() {
+    let source = "<textarea>abc   ";
+    assert_eof_at_trimmed_end(source);
+    let (_, start, _) = diagnose(source).expect("rejected");
+    assert_eq!(start, 13, "the file ends at 16; the template ends at 13");
+}
+
+/// The controls: not raw-text elements, so they keep the generic diagnosis.
+#[test]
+fn a_non_raw_text_element_still_reports_element_unclosed() {
+    for source in ["<title>abc", "<div>abc"] {
+        let (code, start, end) = diagnose(source).expect("official rejects these too");
+        assert_eq!(code, "element_unclosed", "wrong code for {source:?}");
+        assert_eq!((start, end), (0, 1), "wrong point for {source:?}");
+    }
+}
+
+/// The controls that compile on both sides.
+#[test]
+fn a_closed_textarea_still_compiles() {
+    for source in [
+        "<textarea>abc</textarea>",
+        "<textarea>a{b}c</textarea>",
+        "<textarea></textarea>",
+    ] {
+        assert!(diagnose(source).is_none(), "{source:?} was rejected");
+    }
+}


### PR DESCRIPTION
Closes #3509.

## What was wrong

`<textarea>` is escapable raw text, so upstream reads its body with `read_sequence`
(`1-parse/state/element.js:401-411`), and `read_sequence` raises
`unexpected_eof(template.length)` when it runs out before its `done()` predicate
matches. rsvelte's `parse_raw_text_content` instead returned whatever it had
consumed, `found_closing_tag` stayed false, and the generic unclosed-element path
reported at the opening tag.

```svelte
<textarea>abc
```

| | |
|---|---|
| official | `unexpected_eof@1:13` — the end of the template |
| rsvelte | `element_unclosed@1:0-1:1` — "`<textarea>` was left open" |

Not "the same error one column off": a different code naming a different construct.
Note also `<textarea>abc   ` — official points at the **trimmed** end (13), not the
file's end (16), the same rule #3210 established for `<script>` / `<style>`.

## Measurement

15 cells, official as the oracle, comparing `code` and `line:column` of both
endpoints:

| | on `origin/main` | with this PR |
|---|---|---|
| match | 5 / 15 | **13 / 15** |
| fixed | — | **8** |
| regressed | — | **0** |

`fixed` / `regressed` are counted per cell against a stored baseline rather than
netted. The 2 remaining are the nested `<div><script>a` / `<div><style>a` cells,
which **PR #3331 fixes** — measured by building `pull/3331/head` rather than assumed.
The controls that already matched and still do: `<textarea>abc</textarea>`,
`<textarea>a{b}c</textarea>`, `<div><script>a</script></div>`, `<title>abc`,
`<div>abc`. `<title>` is not a raw-text element in Svelte, so it must keep
`element_unclosed` — that is what makes this the textarea path specifically rather
than unclosed elements in general.

## Tests

`crates/rsvelte_core/tests/textarea_unclosed_eof_3509.rs`, every expectation measured
against the official compiler on the same source.

**Negative control:** reverting the new block makes
`an_unclosed_textarea_is_end_of_input` and
`the_point_is_the_trimmed_end_not_the_files_end` fail on **code**
(`element_unclosed` where official says `unexpected_eof`) — the predicted reason —
while `a_non_raw_text_element_still_reports_element_unclosed` and
`a_closed_textarea_still_compiles` stay green.

Suites run locally: `parser_fixtures`, `parser_hardening`, `compiler_errors`,
`compiler_fixtures`.

## Coordination

The insertion point is four lines from **#3331**'s raw-text hunk, in the same
`if is_raw_text_element` block — #3331 guards `name == "script" || name == "style"`,
this guards `name == "textarea"`, so they are disjoint in behaviour but adjacent in
text. **Whoever merges second rebases**; the rebase is a two-line context shift.

@entA owns `<textarea>` character-reference decoding (#3205 / #3337), which lives
*inside* `parse_raw_text_content`; this only adds lines after that call returns.
