### PR TITLE
fix(server): order $$slots by the component's children

### DIFF
--- a/.changeset/server-slots-children-order.md
+++ b/.changeset/server-slots-children-order.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/compiler": patch
+---
+
+Order the server's `$$slots` object by the component's children. Upstream keys one `children` record by slot name while walking the children and later emits `Object.keys(children)`, so the object follows the position at which each slot name is first seen; the server port seeded `default` into its own list before walking, so `default` always led and `<C><b slot="named">…</b><i>…</i></C>` emitted `{ default: true, named: … }` where official emits `{ named: …, default: true }`. Object key order is observable JS, and the client target was already correct.

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/visitors/component.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/visitors/component.rs
@@ -415,6 +415,10 @@ fn build_component_children<'a, 'b>(
         Vec<&'b TemplateNode<'a>>,
         Vec<&'b crate::ast::template::LetDirective<'a>>,
     )> = Vec::new();
+    // Upstream keys one `children` record by slot name and later walks
+    // `Object.keys(children)`, so `$$slots` follows the order the slot names
+    // first appear among the children — `default` is not seeded ahead of them.
+    let mut slot_order: Vec<String> = Vec::new();
 
     for child in &fragment.nodes {
         if let TemplateNode::SnippetBlock(snippet) = child {
@@ -445,7 +449,7 @@ fn build_component_children<'a, 'b>(
             continue;
         }
 
-        match slot_name_of(child) {
+        let slot = match slot_name_of(child) {
             // An explicit `slot="default"` IS the default slot (upstream
             // `slot_name === 'default'`): its `let:` directives become the
             // default-slot lets and its content joins the `children` snippet,
@@ -453,6 +457,7 @@ fn build_component_children<'a, 'b>(
             Some(name) if name == "default" => {
                 default_lets = let_directives_of(child);
                 default_children.push(child);
+                name
             }
             // A `slot="name"` child: its OWN `let:` directives scope the named
             // slot (upstream `lets[slot_name] = child.attributes.filter(...)`).
@@ -463,8 +468,9 @@ fn build_component_children<'a, 'b>(
                         nodes.push(child);
                         *lets = child_lets;
                     }
-                    None => named_slots.push((name, vec![child], child_lets)),
+                    None => named_slots.push((name.clone(), vec![child], child_lets)),
                 }
+                name
             }
             None => {
                 // A `<svelte:fragment>` (no `slot=`) in the default slot
@@ -474,9 +480,17 @@ fn build_component_children<'a, 'b>(
                     default_lets.extend(let_directives_of(child));
                 }
                 default_children.push(child);
+                "default".to_string()
             }
+        };
+        if !slot_order.contains(&slot) {
+            slot_order.push(slot);
         }
     }
+
+    // Both loops below only *build* their `$$slots` entry; the object is
+    // assembled afterwards in `slot_order`.
+    let mut slot_entries: Vec<(String, ObjectPropertyKind<'a>)> = Vec::new();
 
     // Default slot → `children` prop + `$$slots.default: true`.
     if !default_children.is_empty() {
@@ -502,7 +516,7 @@ fn build_component_children<'a, 'b>(
                 // through to `serialized_slots.push(b.init(slot_name, slot_fn))`).
                 // The `children="foo"` attribute keeps its own `children: 'foo'`
                 // prop (emitted from the attribute loop), NOT overwritten here.
-                serialized_slots.push(state.b.init("default", slot_fn));
+                slot_entries.push(("default".to_string(), state.b.init("default", slot_fn)));
             } else if default_lets.is_empty() {
                 // No `let:` directives → the usual `children` prop path.
                 let children = if state.options.dev {
@@ -513,12 +527,15 @@ fn build_component_children<'a, 'b>(
                     slot_fn
                 };
                 push_prop(groups, state.b.init("children", children));
-                serialized_slots.push(state.b.init("default", state.b.bool(true)));
+                slot_entries.push((
+                    "default".to_string(),
+                    state.b.init("default", state.b.bool(true)),
+                ));
             } else {
                 // Scoped default slot (`let:`): expose `$$slots.default` as the
                 // slot function and point `children` at the invalid-snippet guard
                 // (upstream's `else` branch, lines 281-287).
-                serialized_slots.push(state.b.init("default", slot_fn));
+                slot_entries.push(("default".to_string(), state.b.init("default", slot_fn)));
                 push_prop(
                     groups,
                     state
@@ -541,7 +558,13 @@ fn build_component_children<'a, 'b>(
             continue;
         }
         let slot_fn = make_slot_fn(body, lets, state);
-        serialized_slots.push(state.b.init(name, slot_fn));
+        slot_entries.push((name.clone(), state.b.init(name, slot_fn)));
+    }
+
+    for name in &slot_order {
+        if let Some(index) = slot_entries.iter().position(|(n, _)| n == name) {
+            serialized_slots.push(slot_entries.remove(index).1);
+        }
     }
 
     if !serialized_slots.is_empty() {

--- a/crates/rsvelte_core/tests/server_slots_order_3434.rs
+++ b/crates/rsvelte_core/tests/server_slots_order_3434.rs
@@ -1,0 +1,209 @@
+//! `$$slots` key order follows the children, not a seeded `default`.
+//!
+//! Upstream keys one `children` record by slot name while walking the
+//! component's children and later emits `Object.keys(children)`, so the object
+//! is ordered by the position at which each slot name is *first seen*. The
+//! server port seeded `default` before walking, so `default` always led.
+//!
+//! Object key order is observable JS, so this is an output divergence rather
+//! than a formatting one. Every expectation below is the official compiler's
+//! own output for the same source, measured one compiler process per case on
+//! all four targets (the four agree on every row, which is why the helper
+//! asserts it rather than picking one).
+
+use rsvelte_core::{CompileOptions, GenerateMode, compile};
+
+fn code(src: &str, generate: GenerateMode, dev: bool) -> String {
+    compile(
+        src,
+        CompileOptions {
+            filename: Some("T.svelte".into()),
+            generate,
+            dev,
+            ..Default::default()
+        },
+    )
+    .expect("compile")
+    .js
+    .code
+}
+
+/// The top-level keys of the `$$slots: { … }` object literal, in source order.
+fn slot_keys_of(out: &str) -> Option<Vec<String>> {
+    let at = out.find("$$slots: {")?;
+    let bytes: Vec<char> = out[at + "$$slots: ".len()..].chars().collect();
+    let mut keys = Vec::new();
+    let mut depth = 0i32;
+    let mut i = 0usize;
+    while i < bytes.len() {
+        let c = bytes[i];
+        match c {
+            '{' | '(' | '[' => depth += 1,
+            '}' | ')' | ']' => {
+                depth -= 1;
+                if depth == 0 {
+                    break;
+                }
+            }
+            '`' | '"' | '\'' => {
+                i += 1;
+                while i < bytes.len() && bytes[i] != c {
+                    i += if bytes[i] == '\\' { 2 } else { 1 };
+                }
+            }
+            _ if depth == 1 && (c.is_alphabetic() || c == '_' || c == '$') => {
+                let start = i;
+                while i < bytes.len()
+                    && (bytes[i].is_alphanumeric() || bytes[i] == '_' || bytes[i] == '$')
+                {
+                    i += 1;
+                }
+                let name: String = bytes[start..i].iter().collect();
+                let mut j = i;
+                while j < bytes.len() && bytes[j].is_whitespace() {
+                    j += 1;
+                }
+                if bytes.get(j) == Some(&':') {
+                    keys.push(name);
+                }
+                continue;
+            }
+            _ => {}
+        }
+        i += 1;
+    }
+    Some(keys)
+}
+
+/// Compiles on all four targets and asserts they agree before returning the
+/// key order, so a target-dependent answer fails instead of being averaged away.
+fn slot_keys(body: &str) -> Vec<String> {
+    let src = format!("<script>\n\tlet {{ C, n }} = $props();\n</script>\n\n{body}\n");
+    let mut agreed: Option<Vec<String>> = None;
+    for (generate, dev) in [
+        (GenerateMode::Server, false),
+        (GenerateMode::Server, true),
+        (GenerateMode::Client, false),
+        (GenerateMode::Client, true),
+    ] {
+        let out = code(&src, generate, dev);
+        let keys = slot_keys_of(&out)
+            .unwrap_or_else(|| panic!("no `$$slots` in {generate:?} dev={dev} output:\n{out}"));
+        match &agreed {
+            None => agreed = Some(keys),
+            Some(first) => assert_eq!(
+                first, &keys,
+                "targets disagree on `$$slots` order for `{body}`"
+            ),
+        }
+    }
+    agreed.unwrap()
+}
+
+fn assert_order(body: &str, expected: &[&str]) {
+    assert_eq!(slot_keys(body), expected, "`$$slots` order for `{body}`");
+}
+
+/// The issue's repro: a named slot written before the default content.
+#[test]
+fn a_named_slot_before_the_default_content_comes_first() {
+    assert_order(
+        "<C><b slot=\"named\">{n}</b><i>{n}</i></C>",
+        &["named", "default"],
+    );
+}
+
+/// The control in the other direction — this shape was already correct, so a
+/// fix that merely moved `default` to the end would break it.
+#[test]
+fn default_content_before_a_named_slot_still_comes_first() {
+    assert_order(
+        "<C><i>{n}</i><b slot=\"named\">{n}</b></C>",
+        &["default", "named"],
+    );
+}
+
+/// `default` is not pinned to either end: it takes the position of the first
+/// child that has no `slot` attribute.
+#[test]
+fn default_takes_its_position_among_the_named_slots() {
+    assert_order(
+        "<C><b slot=\"a\">{n}</b><i>{n}</i><u slot=\"z\">{n}</u></C>",
+        &["a", "default", "z"],
+    );
+}
+
+/// Named slots keep their own relative order too, which alphabetical or
+/// sorted-map storage would silently normalise away.
+#[test]
+fn named_slots_keep_the_order_they_appear_in() {
+    assert_order(
+        "<C><b slot=\"z\">{n}</b><u slot=\"m\">{n}</u><s slot=\"a\">{n}</s></C>",
+        &["z", "m", "a"],
+    );
+}
+
+/// A `{#snippet}` child is lifted into a prop before the slots are assembled,
+/// so it leads regardless of where it sits among the children — measured
+/// identical for a snippet written first, in the middle and last.
+#[test]
+fn a_snippet_leads_from_any_position_among_the_children() {
+    for body in [
+        "<C>{#snippet s(v)}<b>{v}</b>{/snippet}<u slot=\"z\">{n}</u><i>{n}</i></C>",
+        "<C><u slot=\"z\">{n}</u>{#snippet s(v)}<b>{v}</b>{/snippet}<i>{n}</i></C>",
+        "<C><u slot=\"z\">{n}</u><i>{n}</i>{#snippet s(v)}<b>{v}</b>{/snippet}</C>",
+    ] {
+        assert_order(body, &["s", "z", "default"]);
+    }
+}
+
+/// Two snippets keep their source order — the same "not sorted" check one level
+/// down, on the path that never reaches the slot map.
+#[test]
+fn snippets_keep_the_order_they_appear_in() {
+    assert_order(
+        "<C>{#snippet z(v)}<b>{v}</b>{/snippet}{#snippet a(v)}<b>{v}</b>{/snippet}</C>",
+        &["z", "a"],
+    );
+}
+
+/// The four container / child shapes that reach different arms of the slot
+/// builder — an explicit `slot="default"`, a `let:` on the named slot, a `let:`
+/// on the default one, and `<svelte:fragment>` — all order the same way.
+#[test]
+fn every_slot_builder_arm_orders_by_the_children() {
+    for body in [
+        "<C><b slot=\"named\">{n}</b><i slot=\"default\">{n}</i></C>",
+        "<C><b slot=\"named\" let:v>{v}</b><i>{n}</i></C>",
+        "<C><b slot=\"named\">{n}</b><svelte:fragment let:v>{v}</svelte:fragment></C>",
+        "<C><svelte:fragment slot=\"named\">{n}</svelte:fragment><i>{n}</i></C>",
+    ] {
+        assert_order(body, &["named", "default"]);
+    }
+}
+
+/// A comment between the children is not a slot and does not take a position.
+#[test]
+fn a_comment_between_the_children_does_not_take_a_position() {
+    assert_order(
+        "<C><b slot=\"named\">{n}</b><!-- c --><i>{n}</i></C>",
+        &["named", "default"],
+    );
+}
+
+/// `<svelte:component>` reaches the same builder as `<C>`.
+#[test]
+fn svelte_component_orders_by_the_children_too() {
+    assert_order(
+        "<svelte:component this={C}><b slot=\"named\">{n}</b><i>{n}</i></svelte:component>",
+        &["named", "default"],
+    );
+}
+
+/// A single slot of either kind is the shape every earlier test used, and is
+/// the reason this survived: with one entry the order cannot be wrong.
+#[test]
+fn a_lone_slot_of_either_kind_is_unaffected() {
+    assert_order("<C><b slot=\"named\">{n}</b></C>", &["named"]);
+    assert_order("<C><i>{n}</i></C>", &["default"]);
+}


### PR DESCRIPTION
On the **server** target the `$$slots` object listed `default: true` first, while official
follows the order the slot names first appear among the children.

```svelte
<C><b slot="named">{n}</b><i>{n}</i></C>
```

```js
// official                    // rsvelte (before)
$$slots: {                     $$slots: {
    named: ($$renderer) => …,      default: true,
    default: true                  named: ($$renderer) => …
}                              }
```

Object key order is observable JS, so this is an output divergence rather than a formatting
one — the comparison-side oxfmt pass does not erase it.

## Cause

Upstream keys **one** `children` record by slot name while walking the children and later
emits `Object.keys(children)`, so the object is ordered by first appearance. The server port
kept two separate lists — `default_children` and `named_slots` — and pushed the default
entry into `serialized_slots` before the named loop ran, so `default` always led. The child
walk now records the slot names in the order it meets them and the object is assembled from
that afterwards.

`default` is not pinned to either end, which is the part a "move `default` last" fix would
get wrong:

| children | official (and now rsvelte) |
|---|---|
| `<b slot="a">` `<i>` `<u slot="z">` | `a, default, z` |
| `<b slot="z">` `<u slot="m">` `<s slot="a">` | `z, m, a` |
| `<i>` `<b slot="named">` | `default, named` |

## Second path

`$$slots` is built in exactly two places. The **client**
(`3_transform/client/visitors/shared/component.rs`) walks a single insertion-ordered
`children` map, exactly as upstream does, so it was correct by construction and stays
untouched. Every case in the test file is compiled on all four targets and the helper
asserts the four **agree** before returning the order, so the client is a live control on
every row rather than an assumption.

## Verification

Every expectation is the official compiler's own output for the same source, measured one
compiler process per case on all four targets (client / client-dev / server / server-dev).
Two shapes were dropped from the set after measuring, because official rejects them:
`slot_attribute_duplicate` for two children with the same `slot=`, and `snippet_conflict`
for a `{#snippet children}` beside a named slot.

Measured facts the tests pin, each of which I would have guessed wrong:

- A `{#snippet}` child leads **regardless of its position** among the children — written
  first, in the middle or last, official emits `s, z, default` for all three. rsvelte lifts
  snippets into props during the same walk, which reproduces this; the test drives all three
  positions so a future refactor cannot quietly make snippet order positional.
- Two snippets keep their own source order (`z, a`, not sorted).

Negative control: with the source hunk reverted and the test file kept, 6 of the 10 tests
fail and the 4 controls pass — and they fail on the *targets-disagree* assertion
(`left: ["default","named"] right: ["named","default"]`), i.e. for the predicted reason and
on the predicted target, not merely by failing.

Suites run: `server_slots_order_3434`, `ssr`, `compiler_fixtures`, `validator`,
`compiler_errors`. `runtime` is not re-run here: the change is inside
`3_transform/server`, and the client output is byte-identical (which every case in the test
file asserts, since it compares all four targets to each other).

Closes #3434

🤖 Generated with [Claude Code](https://claude.com/claude-code)
