### PR TITLE
fix(parse): a computed property key carries its own span, not the bracket's

### DIFF
--- a/.changeset/computed-property-key-span.md
+++ b/.changeset/computed-property-key-span.md
@@ -1,0 +1,19 @@
+---
+'@rsvelte/compiler': patch
+---
+
+Give a computed property key in a `<script>` its own span instead of the bracket's
+
+`convert_property_key` is the program-path key converter — every one of its callers is a
+`*_for_program` function — but its computed branch reached for `convert_expression`, which
+subtracts one byte "for the paren we added": the wrapper a **template** expression is parsed
+inside and a script is not. So a computed key's whole subtree landed one byte early, pointing at
+the `[`. The identifier branches beside it never had that subtraction, which is why a plain key
+was right and only a computed one was wrong.
+
+Everything that reads a position out of the serialized program was one column early on this
+shape: the `bidirectional_control_characters` warning, `rsvelte-lint` (where it had already cost
+six lost findings on a fixture no other gate grades), svelte2tsx and the language server. Eight
+positions across five hosts — an object literal, a class field, a class method, a destructuring
+pattern and `<script module>` — now match the official compiler, and the five neighbouring
+shapes that were already correct are unchanged.

--- a/crates/rsvelte_core/src/compiler/phases/1_parse/read/expression.rs
+++ b/crates/rsvelte_core/src/compiler/phases/1_parse/read/expression.rs
@@ -11198,9 +11198,17 @@ fn convert_property_key(
             ))
         }
         _ => {
-            // For computed keys, try to get the expression
+            // A computed key is program-path like its siblings above: reaching for
+            // `convert_expression` would subtract the paren a template expression
+            // is wrapped in but a script is not, putting the whole subtree one
+            // byte early.
             if let Some(expr) = key.as_expression() {
-                expr_to_node(convert_expression(arena, expr, offset, line_offsets))
+                expr_to_node(convert_expression_for_program(
+                    arena,
+                    expr,
+                    offset,
+                    line_offsets,
+                ))
             } else {
                 JsNode::Null
             }

--- a/crates/rsvelte_core/tests/computed_property_key_span_3345.rs
+++ b/crates/rsvelte_core/tests/computed_property_key_span_3345.rs
@@ -1,0 +1,135 @@
+//! A **computed** property key in a `<script>` carried a span one byte early,
+//! so every position derived from it — the `bidirectional_control_characters`
+//! warning here, and anything else that reads a position out of the serialized
+//! program — pointed at the `[` instead of at the key expression.
+//!
+//! Cause: `convert_property_key` is the program-path key converter (its callers
+//! are all `*_for_program`), but its computed branch reached for
+//! `convert_expression`, which subtracts one byte "for the paren we added" —
+//! the wrapper a **template** expression is parsed inside and a script is not.
+//! The identifier branches beside it never had the subtraction, which is why a
+//! plain key was right and only a computed one was wrong.
+//!
+//! Every expectation below was read off the official compiler
+//! (`submodules/svelte`), **one input per process** — the upstream bidi regex
+//! carries the `g` flag and `.test()` advances its `lastIndex`, so a multi-case
+//! run in one process reports different answers than a real compile does.
+
+use rsvelte_core::{CompileOptions, GenerateMode, Warning, compile};
+
+/// U+202E RIGHT-TO-LEFT OVERRIDE.
+const RLO: &str = "\u{202e}";
+
+fn warnings(src: &str) -> Vec<Warning> {
+    compile(
+        src,
+        CompileOptions {
+            filename: Some("Main.svelte".to_string()),
+            generate: GenerateMode::Client,
+            dev: false,
+            ..Default::default()
+        },
+    )
+    .expect("compile")
+    .warnings
+}
+
+/// `line:column` of every bidi warning, in emission order.
+fn bidi(src: &str) -> Vec<String> {
+    warnings(src)
+        .iter()
+        .filter(|w| w.code == "bidirectional_control_characters")
+        .map(|w| {
+            let pos = w.start.as_ref().expect("warning has a start position");
+            format!("{}:{}", pos.line, pos.column)
+        })
+        .collect()
+}
+
+/// Every host a computed property key has in a script: an object literal, a
+/// class field, a class method, a destructuring pattern, and `<script module>`.
+/// All were one column early.
+#[test]
+fn a_computed_key_in_a_script_is_not_one_column_early() {
+    assert_eq!(
+        bidi(&format!("<script>let o = {{[\"a{RLO}b\"]: 1}};</script>")),
+        ["1:18"]
+    );
+    assert_eq!(
+        bidi(&format!(
+            "<script>let o = {{a: 1, [\"a{RLO}b\"]: 1}};</script>"
+        )),
+        ["1:24"]
+    );
+    assert_eq!(
+        bidi(&format!(
+            "<script>class K {{ [\"a{RLO}b\"] = 1; }}</script>"
+        )),
+        ["1:19"]
+    );
+    assert_eq!(
+        bidi(&format!(
+            "<script>class K {{ [\"a{RLO}b\"]() {{}} }}</script>"
+        )),
+        ["1:19"]
+    );
+    assert_eq!(
+        bidi(&format!(
+            "<script>let {{[\"a{RLO}b\"]: v}} = {{}};</script>"
+        )),
+        ["1:14"]
+    );
+    assert_eq!(
+        bidi(&format!(
+            "<script module>let o = {{[\"a{RLO}b\"]: 1}};</script>"
+        )),
+        ["1:25"]
+    );
+}
+
+/// The key's whole subtree moved, not just a string literal directly under the
+/// bracket: a template literal and a nested binary operand were equally early.
+#[test]
+fn the_whole_key_subtree_moves_with_it() {
+    assert_eq!(
+        bidi(&format!("<script>let o = {{[`a{RLO}b`]: 1}};</script>")),
+        ["1:19"]
+    );
+    assert_eq!(
+        bidi(&format!(
+            "<script>let o = {{[1 + \"a{RLO}b\"]: 1}};</script>"
+        )),
+        ["1:22"]
+    );
+}
+
+/// Controls. A plain key, a bare literal and a computed **member** all take
+/// different paths and were already correct — the fix must not move them, or it
+/// is paying for the computed key with its neighbours.
+#[test]
+fn the_neighbouring_positions_are_unaffected() {
+    assert_eq!(
+        bidi(&format!("<script>let o = {{k: \"a{RLO}b\"}};</script>")),
+        ["1:20"]
+    );
+    assert_eq!(
+        bidi(&format!("<script>let s = \"a{RLO}b\";</script>")),
+        ["1:16"]
+    );
+    assert_eq!(
+        bidi(&format!("<script>let v = ({{}})[\"a{RLO}b\"];</script>")),
+        ["1:21"]
+    );
+}
+
+/// A template expression IS parsed inside the paren wrapper, so it was already
+/// right and must stay right — this is the case whose converter the script path
+/// was borrowing.
+#[test]
+fn a_template_expression_keeps_its_positions() {
+    assert_eq!(
+        bidi(&format!("<b>{{JSON.stringify({{[\"a{RLO}b\"]: 1}})}}</b>")),
+        ["1:21"]
+    );
+    assert_eq!(bidi(&format!("<b>{{({{}})[\"a{RLO}b\"]}}</b>")), ["1:9"]);
+}


### PR DESCRIPTION
Closes #3345

A **computed** property key in a `<script>` carried a span one byte early, so every position
derived from it pointed at the `[` instead of at the key expression.

## Cause

`convert_property_key` is the **program-path** key converter — all eight of its callers are
`*_for_program` functions (`convert_expression_for_program`,
`convert_class_element_for_program`, `convert_class_element_for_program_as_node`,
`convert_assignment_target_property_for_program`, `convert_binding_property`). Its
`StaticIdentifier` / `PrivateIdentifier` branches build the node from the key's own span, but the
computed branch reached for `convert_expression`, whose every arm reads

```rust
let start = offset + id.span.start as usize - 1; // -1 for the paren we added
```

A **template** expression is parsed inside that `(...)` wrapper. A script is not. So the whole
computed-key subtree — not just a string literal directly under the bracket — moved one byte
left. The identifier branches beside it never had the subtraction, which is exactly why a plain
key was right and only a computed one was wrong.

The fix routes the computed branch through `convert_expression_for_program`, the converter its
siblings already use. One line of behaviour.

## Measurement — 13 shapes, before → after

Each input compiled with the official compiler (`submodules/svelte`) **one per process** — the
upstream bidi regex carries the `g` flag and `.test()` advances its `lastIndex`, so a multi-case
run in one process answers differently than a real compile does.

| shape | official | rsvelte before | after |
|---|---|---|---|
| object literal, computed key | 1:18 | **1:17** | 1:18 |
| object literal, computed key second | 1:24 | **1:23** | 1:24 |
| class **field**, computed key | 1:19 | **1:18** | 1:19 |
| class **method**, computed key | 1:19 | **1:18** | 1:19 |
| computed key, template literal | 1:19 | **1:18** | 1:19 |
| computed key, nested binary operand | 1:22 | **1:21** | 1:22 |
| **destructuring pattern**, computed key | 1:14 | **1:13** | 1:14 |
| `<script module>`, computed key | 1:25 | **1:24** | 1:25 |
| object literal, plain key | 1:20 | 1:20 | 1:20 |
| bare string literal | 1:16 | 1:16 | 1:16 |
| computed **member** in a script | 1:21 | 1:21 | 1:21 |
| template expression, computed key | 1:21 | 1:21 | 1:21 |
| template expression, computed member | 1:9 | 1:9 | 1:9 |

**8 wrong → 0 wrong**, and the 5 that were already right did not move — so the fix is not paying
for the computed key with its neighbours.

The reported repro is the first row; the other seven hosts are wider than the issue described.
It is not "the script path is off by one" (a plain key and a bare literal are right) and not
"computed members are off by one" (both member rows are right) — it is a computed **property
key** in a script, in every host one has.

## Negative control

With the one line reverted:

- `a_computed_key_in_a_script_is_not_one_column_early` fails `left: ["1:17"], right: ["1:18"]`
- `the_whole_key_subtree_moves_with_it` fails `left: ["1:18"], right: ["1:19"]`

— the predicted one-column-early, not some other failure. The two control tests
(`the_neighbouring_positions_are_unaffected`, `a_template_expression_keeps_its_positions`) and the
whole `bidirectional_control_characters_slots_3227` suite stay **green** under the revert, so
they are not witnessing the fix.

## Gates run

`parser_fixtures` (the AST-equality gate against the official parser, after
`pnpm run generate-fixtures`), `validator`, `ssr`, `compiler_errors`, the full `rsvelte_projection`
(svelte2tsx) suite, `bidirectional_control_characters_slots_3227` — all green.

## Contested file

`1_parse/read/expression.rs` has seven open PRs against it (#3491, #3499, #3358, #3357, #3351,
#3348, #3417). None of them touches `convert_property_key` — measured, not assumed:
`gh pr diff <n> | grep -c convert_property_key` is **0** for all seven. The hunk here is 12 lines
inside that function.

## One thing to watch

Positions in the serialized program feed svelte2tsx, the language server and `rsvelte-lint`, so a
corpus entry currently listed for a computed-key position could start passing and trip the
two-sided ratchet. I could not measure that here (the corpus submodules are not checked out in
this worktree). All three collected `lint-known-failures` entries are the CSS `svelte-ignore` /
`lang="scss"` case, so none of them is this shape; if a `svelte2tsx-known-failures` entry moves,
it needs re-baselining in this PR rather than a revert.

## Not included

The issue notes three further gaps in the same serializer, all recorded in AGENTS.md: a
`TSTypeAliasDeclaration` dropped whole, `params.rest` omitted for a `function` **statement** while
the exported form already guards it, and a missing `returnType`. They are deliberately left out —
each needs its own measurement, and the `params.rest` one is not a guard copy: the exported path
falls back to `JsNode::from_value(...)` while the statement path returns `None`, so mirroring the
condition without checking what `None` does to the statement would risk dropping it. Keeping this
PR at one line also keeps the conflict surface in a seven-way contested file minimal.
