### PR TITLE
docs(upstream): record why bidi warnings are not suppressed like upstream's

### DIFF
--- a/crates/rsvelte_core/tests/bidi_every_occurrence_3344.rs
+++ b/crates/rsvelte_core/tests/bidi_every_occurrence_3344.rs
@@ -1,0 +1,126 @@
+//! `bidirectional_control_characters` is reported for **every** occurrence.
+//!
+//! Upstream shares one module-level `g` regex between `Text.js`, `Literal.js`
+//! and `TemplateElement.js`. Only `Text.js` resets `lastIndex`, so a `.test()`
+//! that matched leaves the cursor mid-string and the next `.test()` — on a
+//! different string — starts from there and can answer `false` for a string that
+//! does contain the character. rsvelte's checks are stateless, so it reports all
+//! of them.
+//!
+//! This is deliberately NOT byte-compatible with the official compiler. The
+//! warning exists to surface invisible characters that make source read in a
+//! different order than it runs; withholding it is a diagnostic difference, not
+//! a formatting one. See `upstream_issues/3344-svelte-bidi-regex-lastindex.md`
+//! for the mechanism, the control, and the measured official verdicts.
+//!
+//! Without this file the divergence looks like an rsvelte defect to the next
+//! person who diffs against official.
+
+use rsvelte_core::{CompileOptions, GenerateMode, compile};
+
+/// U+202E RIGHT-TO-LEFT OVERRIDE.
+const RLO: char = '\u{202e}';
+
+fn bidi_warnings(src: &str) -> usize {
+    let counts: Vec<usize> = [
+        (GenerateMode::Client, false),
+        (GenerateMode::Client, true),
+        (GenerateMode::Server, false),
+        (GenerateMode::Server, true),
+    ]
+    .into_iter()
+    .map(|(generate, dev)| {
+        compile(
+            src,
+            CompileOptions {
+                filename: Some("T.svelte".into()),
+                generate,
+                dev,
+                ..Default::default()
+            },
+        )
+        .expect("compile")
+        .warnings
+        .iter()
+        .filter(|w| w.code == "bidirectional_control_characters")
+        .count()
+    })
+    .collect();
+    assert!(
+        counts.iter().all(|c| *c == counts[0]),
+        "targets disagree ({counts:?}) for:\n{src}"
+    );
+    counts[0]
+}
+
+/// Two string literals in one script. Official reports one — the second
+/// `.test()` starts at the index the first one left behind.
+#[test]
+fn two_string_literals_in_a_script_report_twice() {
+    let src = format!("<script>let a = \"x{RLO}y\"; let b = \"p{RLO}q\";</script>\n");
+    assert_eq!(bidi_warnings(&src), 2);
+}
+
+/// Three of them. Official reports the first and the *third*: the failing second
+/// `.test()` resets the cursor. The count alone cannot show that, which is why
+/// the two-literal case above is kept separately.
+#[test]
+fn three_string_literals_in_a_script_report_three_times() {
+    let src = format!(
+        "<script>let a = \"x{RLO}y\"; let b = \"p{RLO}q\"; let c = \"m{RLO}n\";</script>\n"
+    );
+    assert_eq!(bidi_warnings(&src), 3);
+}
+
+/// Two quasis of one template literal — consecutive `TemplateElement` visits
+/// with nothing in between to reset the cursor.
+#[test]
+fn two_quasis_of_one_template_literal_report_twice() {
+    let src = format!("<b>{{`a{RLO}b${{1}}c{RLO}d`}}</b>\n");
+    assert_eq!(bidi_warnings(&src), 2);
+}
+
+/// Two separate string literals in the template.
+#[test]
+fn two_template_expressions_report_twice() {
+    let src = format!("<b>{{\"a{RLO}b\"}}{{\"c{RLO}d\"}}</b>\n");
+    assert_eq!(bidi_warnings(&src), 2);
+}
+
+/// The shapes where official already reports every occurrence, as controls: a
+/// `Text` visit resets `lastIndex`, so these agree with the official compiler
+/// and must keep agreeing.
+#[test]
+fn the_shapes_official_already_gets_right_are_unchanged() {
+    // Two Text nodes.
+    assert_eq!(bidi_warnings(&format!("<b>a{RLO}b c{RLO}d</b>\n")), 2);
+    // Text between two string literals resets the cursor twice.
+    assert_eq!(
+        bidi_warnings(&format!("<b>{{\"a{RLO}b\"}}t{RLO}x{{\"c{RLO}d\"}}</b>\n")),
+        3
+    );
+    // A single occurrence has nothing to be suppressed by.
+    assert_eq!(
+        bidi_warnings(&format!("<script>let a = \"x{RLO}y\";</script>\n")),
+        1
+    );
+    // The second occurrence sits past the carried-over index, so official finds
+    // it too — the same count for a different reason.
+    assert_eq!(
+        bidi_warnings(&format!(
+            "<script>let a = \"x{RLO}y\"; let b = \"pppppppppp{RLO}q\";</script>\n"
+        )),
+        2
+    );
+}
+
+/// Source with no bidi character warns zero times — the negative control for a
+/// check that is now "always on".
+#[test]
+fn source_without_a_bidi_character_warns_zero_times() {
+    assert_eq!(
+        bidi_warnings("<script>let a = \"xy\"; let b = \"pq\";</script>\n"),
+        0
+    );
+    assert_eq!(bidi_warnings("<b>{`ab${1}cd`}</b>\n"), 0);
+}

--- a/upstream_issues/3344-svelte-bidi-regex-lastindex.md
+++ b/upstream_issues/3344-svelte-bidi-regex-lastindex.md
@@ -1,0 +1,71 @@
+# Svelte's shared bidi regex carries `lastIndex`, so it misses occurrences after the first
+
+`regex_bidirectional_control_characters` (`phases/patterns.js:23`) is a module-level object
+carrying the `g` flag:
+
+```js
+export const regex_bidirectional_control_characters =
+	/[‪‫‬‭‮⁦⁧⁨⁩]+/g;
+```
+
+`Text.js` sets `lastIndex = 0` before its `matchAll`, but `Literal.js:10` and
+`TemplateElement.js:9` call `.test()` on that same object and never reset it. `.test()` on a
+`g` regex starts at `lastIndex` and advances it on a match, so the *next* call begins
+mid-string.
+
+**Control that this is not intended behaviour**, with no compiler involved — the same string
+answers `false` and then `true`:
+
+```js
+import { regex_bidirectional_control_characters as RX } from './phases/patterns.js';
+const a = 'x‮y', b = 'p‮q';
+RX.test(a);  // true,  lastIndex -> 2
+RX.test(b);  // false, lastIndex -> 0   ← b DOES contain U+202E
+RX.test(b);  // true,  lastIndex -> 2
+```
+
+A predicate whose answer for one string depends on how many times it was called on *other*
+strings is not a design choice, and `Text.js` resetting `lastIndex` on the very same object
+shows the hazard was known at one of the three call sites and missed at the other two.
+
+## Effect on the compiler
+
+Measured against the official compiler at v5.56.10, **one input per process** (batching
+several `compile()` calls into one process changes the answer, for exactly this reason):
+
+| source | occurrences | official warns |
+|---|---|---|
+| `<script>let a = "x␮y";</script>` | 1 | 1 |
+| `<script>let a = "x␮y"; let b = "p␮q";</script>` | 2 | **1** |
+| `<script>let a = "x␮y"; let b = "p␮q"; let c = "m␮n";</script>` | 3 | **2** (first and third) |
+| `<script>let a = "x␮y"; let b = "pppppppppp␮q";</script>` | 2 | 2 |
+| `` <b>{`a␮b${1}c␮d`}</b> `` | 2 | **1** |
+| `<b>{"a␮b"}{"c␮d"}</b>` | 2 | **1** |
+| `<b>a␮b c␮d</b>` (two Text nodes) | 2 | 2 |
+| `<b>{"a␮b"}t␮x{"c␮d"}</b>` | 3 | 3 |
+
+(`␮` stands for U+202E RIGHT-TO-LEFT OVERRIDE.)
+
+The suppression is **position-dependent**, not "every second one": row 3 reports the first
+and the third because the second `.test()` resets `lastIndex` to 0 on failing, and row 4
+reports both because the second occurrence happens to sit past the carried-over index. A
+`Text` node anywhere in between restores the cursor, which is why rows 7 and 8 are complete.
+
+## Why rsvelte does not reproduce it
+
+This is a warning whose whole purpose is to surface **invisible** characters that can make
+source read in a different order than it executes. Suppressing it is not a byte-level
+difference — it withholds a security-relevant diagnostic from the user, and which
+occurrences get withheld depends on unrelated earlier strings. Under the project rule
+("reproduce an upstream defect only when the two behave identically and only the bytes
+differ") this is not reproducible, so rsvelte reports every occurrence.
+
+rsvelte's checks use Rust's `regex`, which has no `lastIndex` and is stateless by
+construction (`2_analyze/visitors/literal.rs`, `template_element.rs`, `text.rs`), so the
+behaviour is pinned by `crates/rsvelte_core/tests/bidi_every_occurrence_3344.rs` rather than
+by the absence of a mechanism.
+
+Local anchor: [#3344](https://github.com/baseballyama/rsvelte/issues/3344).
+
+Desired upstream behaviour: drop the `g` flag (neither `.test()` call needs it, and `Text.js`
+can keep a local `g` copy for its `matchAll`), or reset `lastIndex` at every call site.


### PR DESCRIPTION
**No behaviour change.** This records a deliberate divergence from the official compiler that
was previously undocumented, so the next person who diffs `bidirectional_control_characters`
against official does not read it as an rsvelte defect and "fix" it into the upstream bug.

## What upstream does

`regex_bidirectional_control_characters` (`phases/patterns.js:23`) is one module-level object
carrying the `g` flag, shared by three visitors. `Text.js` resets `lastIndex` before its
`matchAll`; `Literal.js:10` and `TemplateElement.js:9` call `.test()` on the same object and
never do. `.test()` on a `g` regex starts at `lastIndex` and advances it, so the next call —
on a *different* string — begins mid-string.

Control, with no compiler involved: the same string answers `false` and then `true`.

```js
import { regex_bidirectional_control_characters as RX } from './phases/patterns.js';
const a = 'x‮y', b = 'p‮q';
RX.test(a);  // true,  lastIndex -> 2
RX.test(b);  // false, lastIndex -> 0   ← b DOES contain U+202E
RX.test(b);  // true,  lastIndex -> 2
```

That is the half that makes this an upstream *defect* rather than an upstream *decision*: a
predicate whose answer for one string depends on how many times it was called on other
strings is not a design choice, and `Text.js` resetting `lastIndex` on the very same object
shows the hazard was known at one of the three call sites and missed at the other two.

## Measured effect

Official v5.56.10, **one input per process** — batching several `compile()` calls into one
process changes the answer, for exactly this reason, so a batched harness would have measured
a different bug.

| source | occurrences | official warns |
|---|---|---|
| `let a = "x␮y";` | 1 | 1 |
| `let a = "x␮y"; let b = "p␮q";` | 2 | **1** |
| `let a = "x␮y"; let b = "p␮q"; let c = "m␮n";` | 3 | **2** (first and third) |
| `let a = "x␮y"; let b = "pppppppppp␮q";` | 2 | 2 |
| `` {`a␮b${1}c␮d`} `` | 2 | **1** |
| `{"a␮b"}{"c␮d"}` | 2 | **1** |
| `a␮b c␮d` (two Text nodes) | 2 | 2 |
| `{"a␮b"}t␮x{"c␮d"}` | 3 | 3 |

The suppression is **position-dependent**, not "every second one": row 3 reports the first and
the *third*, because the failing second `.test()` resets the cursor to 0; row 4 reports both,
because the second occurrence happens to sit past the carried-over index. A `Text` visit
anywhere in between restores the cursor, which is why rows 7 and 8 are complete. A test that
only counted warnings on row 2 would be satisfied by three different wrong models, so rows 3
and 4 are in the file specifically to separate them.

## Why this one is not reproduced

Applying the same three questions as #3497, where the answers went the other way:

| | #3497 (reproduced) | #3344 (not reproduced) |
|---|---|---|
| does it change compiled output? | no | no |
| direction | emits a warning rsvelte was swallowing → closer to official | reproducing would make rsvelte *swallow* warnings |
| is it a ratcheted project goal? | warning parity — yes | warning parity — yes, and this is the case where it loses to the rule above it |

The project rule is *reproduce an upstream defect only when the two behave identically and
only the byte sequence differs*, and the presence or absence of a warning is not a byte
difference. This particular warning exists to surface **invisible** characters that make
source read in a different order than it executes; withholding it hands the user a
security-relevant blind spot, and *which* occurrences get withheld depends on unrelated
earlier strings in the same file. So rsvelte reports every occurrence.

## What lands

- `upstream_issues/3344-svelte-bidi-regex-lastindex.md` — mechanism, the no-compiler control
  above, the measured table, and the desired upstream fix (drop the `g` flag; neither
  `.test()` needs it, and `Text.js` can keep a local `g` copy for its `matchAll`).
- `crates/rsvelte_core/tests/bidi_every_occurrence_3344.rs` — 6 tests pinning rsvelte's
  behaviour on all four targets, including the four shapes where official is already complete
  (so the file is not a one-directional "always warn more" assertion) and a zero-warning
  negative control.

No ratchet entry grows: rsvelte's behaviour is unchanged by this PR, and the shape does not
occur in the collected corpus — a bidi control character in two separate string literals of
one component is not something published code contains.

rsvelte's checks use Rust's `regex`, which has no `lastIndex` and is stateless by
construction, so the correct behaviour here is currently an accident of the port rather than a
decision. That is the other reason for the test file: it turns "we happen not to have the
mechanism" into "this is pinned".

Suites run: `bidi_every_occurrence_3344`, `validator`, `compiler_fixtures`.

Closes #3344

🤖 Generated with [Claude Code](https://claude.com/claude-code)
