### PR TITLE
fix(parser): one table decides whether a repeated block clause is legal

### DIFF
--- a/.changeset/duplicate-clause-table.md
+++ b/.changeset/duplicate-clause-table.md
@@ -1,0 +1,11 @@
+---
+"@rsvelte/compiler": patch
+---
+
+Decide whether a repeated block clause is legal from one table
+
+`{#if}` and `{#each}` re-create their fragment on every `{:else}`, so a repeat is
+accepted and replaces the earlier branch; `{#await}` rejects a second `{:then}`
+or `{:catch}` with `block_duplicate_clause`. The two directions were reported as
+separate issues pointing opposite ways, because the answer was written at each
+parse site rather than once.

--- a/crates/rsvelte_core/src/compiler/phases/1_parse/state/tag.rs
+++ b/crates/rsvelte_core/src/compiler/phases/1_parse/state/tag.rs
@@ -24,6 +24,68 @@ use crate::error::ParseResult;
 use super::super::parser::{Parser, StackEntry, is_js_whitespace};
 use super::super::utils::TrimWs;
 
+/// A `{:…}` continuation clause.
+///
+/// Whether a *second* one is legal is decided per block type, and the two
+/// directions are easy to drift apart: upstream's `next()`
+/// (`1-parse/state/tag.js:527-635`) re-creates `block.alternate` for `{#if}` and
+/// `block.fallback` for `{#each}` unconditionally — a repeat is **accepted** and
+/// replaces the earlier branch — while `{#await}` guards both of its clauses
+/// with `block_duplicate_clause` and **rejects** it. Two issues found the two
+/// directions separately (#3284 accepted-but-rejected, #3349
+/// rejected-but-accepted), so the decision lives here rather than at each site.
+///
+/// The `match` is the invariant: a new clause cannot be added without answering
+/// the question for it.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub(crate) enum Clause {
+    Else,
+    // `expect` rather than `allow`: the `{#await}` clause loop reads these arms
+    // as soon as its duplicate check lands, and an unfulfilled `expect` is a
+    // compile error — so the placeholder cannot outlive its reason.
+    #[cfg_attr(
+        not(test),
+        expect(dead_code, reason = "the {#await} clause loop constructs these")
+    )]
+    Then,
+    #[cfg_attr(
+        not(test),
+        expect(dead_code, reason = "the {#await} clause loop constructs these")
+    )]
+    Catch,
+}
+
+impl Clause {
+    /// The spelling upstream puts in `block_duplicate_clause`'s message.
+    const fn tag(self) -> &'static str {
+        match self {
+            Self::Else => "{:else}",
+            Self::Then => "{:then}",
+            Self::Catch => "{:catch}",
+        }
+    }
+
+    /// Whether a second occurrence of this clause in one block is an error.
+    const fn duplicate_is_error(self) -> bool {
+        match self {
+            Self::Else => false,
+            Self::Then | Self::Catch => true,
+        }
+    }
+
+    /// Upstream positions every clause diagnostic at the `:`.
+    fn duplicate_error(self, at: usize) -> crate::error::ParseError {
+        crate::error::ParseError::svelte(
+            "block_duplicate_clause",
+            format!(
+                "{} cannot appear more than once within a block\nhttps://svelte.dev/e/block_duplicate_clause",
+                self.tag()
+            ),
+            (at, at),
+        )
+    }
+}
+
 impl<'a> Parser<'a> {
     /// Try to parse a declaration tag (`{let x = …}` / `{const x = …}`,
     /// Svelte 5.56.0 #18282). Returns `Ok(None)` when the source at
@@ -762,10 +824,9 @@ impl<'a> Parser<'a> {
             self.eat("}", true, true)?;
             let mut alt_fragment = self.parse_fragment()?;
 
-            // Upstream's `next()` re-creates `block.alternate` on every `{:else}`
-            // it sees, so a second one silently replaces the first branch rather
-            // than being a parse error (tag.js L537-541).
-            while let Some(replacement) = self.parse_if_alternate()? {
+            while !Clause::Else.duplicate_is_error()
+                && let Some(replacement) = self.parse_if_alternate()?
+            {
                 alt_fragment = replacement;
             }
 
@@ -1319,10 +1380,11 @@ impl<'a> Parser<'a> {
         // Parse body
         let body = self.parse_fragment()?;
 
-        // Check for {:else}. Upstream re-creates `block.fallback` on every
-        // `{:else}` it sees, so a second one replaces the first (tag.js L582-591).
         let mut fallback = None;
         while let Some(colon_pos) = self.match_block_continuation_marker() {
+            if fallback.is_some() && Clause::Else.duplicate_is_error() {
+                return Err(Clause::Else.duplicate_error(colon_pos));
+            }
             let continuation_start = self.index;
             self.index = colon_pos + 1;
             self.skip_whitespace();
@@ -2829,5 +2891,41 @@ fn expression_into_node(expr: Expression<'_>) -> JsNode {
         Expression::Lazy { .. } => {
             panic!("Expression::Lazy must be resolved before building a declaration")
         }
+    }
+}
+
+#[cfg(test)]
+mod duplicate_clause_table {
+    use super::Clause;
+
+    /// Pins the table against upstream's `next()`. `{#if}` / `{#each}` re-create
+    /// their fragment on every `{:else}`; `{#await}` guards `block.then` and
+    /// `block.catch`. The `{#await}` call sites read these arms.
+    #[test]
+    fn matches_upstream() {
+        assert!(!Clause::Else.duplicate_is_error());
+        assert!(Clause::Then.duplicate_is_error());
+        assert!(Clause::Catch.duplicate_is_error());
+    }
+
+    #[test]
+    fn tags_are_the_spellings_upstream_reports() {
+        assert_eq!(Clause::Else.tag(), "{:else}");
+        assert_eq!(Clause::Then.tag(), "{:then}");
+        assert_eq!(Clause::Catch.tag(), "{:catch}");
+    }
+
+    /// The diagnostic is a point span on the `:`, which is upstream's
+    /// `start = parser.index - 1` in `next()`.
+    #[test]
+    fn the_error_is_a_point_span_on_the_colon() {
+        let error = Clause::Catch.duplicate_error(33);
+        let text = format!("{error:?}");
+        assert!(text.contains("block_duplicate_clause"), "{text}");
+        assert!(
+            text.contains("{:catch} cannot appear more than once within a block"),
+            "{text}"
+        );
+        assert!(text.contains("(33, 33)"), "{text}");
     }
 }

--- a/crates/rsvelte_core/tests/duplicate_clause_table_3349.rs
+++ b/crates/rsvelte_core/tests/duplicate_clause_table_3349.rs
@@ -1,0 +1,123 @@
+//! One table decides whether a repeated `{:…}` clause is legal (#3284 / #3349).
+//!
+//! The two directions were reported as separate issues — `{:else}` **rejected**
+//! where upstream accepts, `{:then}` / `{:catch}` **accepted** where upstream
+//! rejects — and they are opposite arms of one question. Keeping the answer at
+//! each parse site is what let them drift, so the sites read
+//! `Clause::duplicate_is_error` instead and this file pins it against the
+//! official compiler's behaviour.
+//!
+//! Every expectation is the official Svelte compiler's verdict for the same
+//! source.
+
+use rsvelte_core::{CompileOptions, GenerateMode, compile};
+
+fn try_compile(markup: &str) -> Result<String, (String, String)> {
+    let source = format!("<script>\n\tlet arr = [], p, c;\n</script>\n{markup}");
+    compile(
+        &source,
+        CompileOptions {
+            filename: Some("Test.svelte".to_string()),
+            generate: GenerateMode::Client,
+            ..Default::default()
+        },
+    )
+    .map(|result| result.js.code)
+    .map_err(|error| {
+        let text = format!("{error:?}");
+        let code = text
+            .split("code: \"")
+            .nth(1)
+            .and_then(|rest| rest.split('"').next())
+            .unwrap_or("<no code>")
+            .to_string();
+        (code, text)
+    })
+}
+
+#[track_caller]
+fn assert_accepted(markup: &str) {
+    if let Err((code, text)) = try_compile(markup) {
+        panic!("official accepts `{markup}`; rsvelte raised {code}\n{text}");
+    }
+}
+
+#[track_caller]
+fn assert_rejected(markup: &str, expected: &str) {
+    match try_compile(markup) {
+        Ok(code) => {
+            panic!("official rejects `{markup}` with {expected}; rsvelte compiled it:\n{code}")
+        }
+        Err((actual, text)) => {
+            assert_eq!(actual, expected, "wrong code for `{markup}`\n{text}");
+        }
+    }
+}
+
+/// The hosts a block can sit in. A per-arm rule drifts per host, so the table is
+/// checked in all of them rather than at the root only.
+const HOSTS: [&str; 5] = [
+    "{BLOCK}",
+    "<div>{BLOCK}</div>",
+    "{#if c}{BLOCK}{/if}",
+    "{#each arr as _}{BLOCK}{/each}",
+    "{#snippet s()}{BLOCK}{/snippet}",
+];
+
+fn in_every_host(block: &str, mut check: impl FnMut(&str)) {
+    for host in HOSTS {
+        check(&host.replace("{BLOCK}", block));
+    }
+}
+
+// ---------------------------------------------------------------------------
+// `{:else}` — a repeat is ACCEPTED and replaces the earlier branch
+// ---------------------------------------------------------------------------
+
+#[test]
+fn a_repeated_else_is_accepted_in_an_if_block() {
+    in_every_host("{#if c}a{:else}b{:else}d{/if}", assert_accepted);
+}
+
+#[test]
+fn a_repeated_else_is_accepted_in_an_each_block() {
+    in_every_host(
+        "{#each arr as v}{v}{:else}b{:else}d{/each}",
+        assert_accepted,
+    );
+}
+
+#[test]
+fn an_else_if_before_an_else_is_still_accepted() {
+    in_every_host("{#if c}a{:else if p}b{:else}e{/if}", assert_accepted);
+}
+
+// ---------------------------------------------------------------------------
+// Neighbours the table must not disturb
+// ---------------------------------------------------------------------------
+
+#[test]
+fn a_single_clause_of_each_kind_is_accepted() {
+    for block in [
+        "{#if c}a{:else}b{/if}",
+        "{#each arr as v}{v}{:else}b{/each}",
+        "{#await p}w{:then v}{v}{:catch e}{e}{/await}",
+        "{#await p}w{:catch e}{e}{:then v}{v}{/await}",
+        "{#await p then v}{v}{/await}",
+        "{#await p catch e}{e}{/await}",
+        "{#await p}w{:then}done{/await}",
+    ] {
+        in_every_host(block, assert_accepted);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// A misplaced clause is not a duplicate — it keeps its own diagnostic
+// ---------------------------------------------------------------------------
+
+#[test]
+fn an_else_in_an_await_block_is_still_expected_token() {
+    in_every_host("{#await p}w{:else}z{/await}", |source| {
+        assert_rejected(source, "expected_token");
+    });
+}


### PR DESCRIPTION
**Stacked on #3348** (`fix/3274-3276-3284-legacy-errors`). Review that one first;
this adds two commits on top and will be rebased once the base merges.

**Both #3321 and #3348 are prerequisites for the full behaviour.** Either alone
changes semantics: #3321 supplies the `{#await}` rejection, #3348 supplies the
`{:else}` acceptance. See the `tag.rs` ordering
`3478 → 3504 → 3321 → 3348 → 3331 → 3351 → 3357 → 3358` and its follow-up row.

## Why

Whether a repeated `{:…}` clause is legal is decided per block type, and the two
directions drifted apart because the answer was written at each parse site:

| block | clause | upstream `next()` | reported as |
|---|---|---|---|
| `{#if}` | `{:else}` | re-creates `block.alternate` → **accepted**, replaces the branch | #3284 (rsvelte rejected it, three different ways depending on the host) |
| `{#each}` | `{:else}` | re-creates `block.fallback` → **accepted** | #3284 |
| `{#await}` | `{:then}` | `if (block.then) e.block_duplicate_clause(...)` → **rejected** | #3349 (rsvelte accepted it) |
| `{#await}` | `{:catch}` | `if (block.catch) e.block_duplicate_clause(...)` → **rejected** | #3349 |

Two issues, opposite directions, one question. `Clause::duplicate_is_error` is
that question, and the `match` is the invariant — a new clause cannot be added
without answering it. `duplicate_error` puts `block_duplicate_clause` at the `:`,
which is upstream's `start = parser.index - 1`.

The `{:else}` call sites read it here. The `{#await}` arms are **table entries,
not a TODO**: they are `#[cfg_attr(not(test), expect(dead_code, …))]`, and an
unfulfilled `expect` is a compile error — so the placeholder cannot outlive its
reason. The `{#await}` loop reads them on rebase, after #3321 lands.

## Negative control

Flipping one arm, `Self::Else => false` → `true`, fails **2 of 5** integration
tests and **1 of 3** unit tests, and the two integration failures come through
**two different mechanisms** — which is how you can tell both sites genuinely
read the table rather than being guarded by a constant the optimiser folded:

```
a_repeated_else_is_accepted_in_an_each_block  official accepts `{#each arr as v}{v}{:else}b{:else}d{/each}`;
                                              rsvelte raised block_duplicate_clause
a_repeated_else_is_accepted_in_an_if_block    official accepts `{#if c}a{:else}b{:else}d{/if}`;
                                              rsvelte raised block_unclosed
```

The `{#each}` site raises from the table; the `{#if}` site stops looping, so the
second `{:else}` is left unconsumed and the block reads as open. The other three
pass, as predicted: they carry one clause each.

## Neighbours

Every case runs in **all five hosts** (root, element, `{#if}`, `{#each}`,
`{#snippet}`) — `CLAUDE.md`'s `directive-element` lesson is that a per-arm rule
drifts per host, so checking at the root only measures one cell of the product.
Alongside the repeats, the file pins seven single-clause shapes that must keep
compiling (including `{:catch}` before `{:then}`, and `{#await p then v}`), and
that a `{:else}` in an `{#await}` block is still `expected_token` — a misplaced
clause is not a duplicate and keeps its own diagnostic.

## Verification

`duplicate_clause_table_3349` (5), the in-file table unit tests (3),
`duplicate_else_clause_3284` (4), `legacy_error_parity_3274_3276` (9),
`compiler_errors`, `parser_fixtures`, `validator`, `ssr` — all green.
`cargo clippy -p rsvelte_core --lib --tests -- -D warnings` clean.

Also measured on a 260-cell block-header grid (21 invalid + 31 **valid** shapes ×
5 hosts) against the official oracle: this branch keeps #3348's
`OVER-REJECT: 0` / `both-accept: 155` and adds no regression. Full table in the
comment on #3321.
