### PR TITLE
fix(analyze): three scope-resolution defects where a binding slot was read as the outer name

### DIFF
--- a/.changeset/reactive-cycle-block-scope.md
+++ b/.changeset/reactive-cycle-block-scope.md
@@ -1,0 +1,5 @@
+---
+'@rsvelte/compiler': patch
+---
+
+Resolve a name declared inside a `$:` statement to that declaration rather than to the instance binding of the same name. A `catch (e)` parameter, a block `let`/`const e`, and a `for` head's own binding were all attributed to the outer `e`, so a second reactive statement assigning `e` was reported as `reactive_declaration_cycle` on code the official compiler compiles. A function parameter was already scoped correctly, which is what made this a scoping gap rather than a missing feature; the shadowing is per block, so an inner block does not silence an outer read of the same name

--- a/.changeset/rune-named-binding-slots.md
+++ b/.changeset/rune-named-binding-slots.md
@@ -1,0 +1,5 @@
+---
+'@rsvelte/compiler': patch
+---
+
+Stop counting a `$`-prefixed name as a rune use when the slot only binds or labels it. A statement label (`$state: for (;;) break $state;`) and a `catch ($state)` parameter both declare rather than read, and counting them flipped the component into runes mode — which turned a working Svelte 4 component into `legacy_export_invalid`. The same two slots also decide store subscriptions from a separate scan, where `catch ($count)` now shadows the store for its own block and a label is not a read

--- a/.changeset/ts-duplicate-function-implementation.md
+++ b/.changeset/ts-duplicate-function-implementation.md
@@ -1,0 +1,5 @@
+---
+'@rsvelte/compiler': patch
+---
+
+Reject a second `function` **implementation** with the same name. TypeScript lets a name carry any number of body-less overload signatures, and rsvelte turned that into "exempt every function-vs-function redeclaration", so `function f() {} function f() {}` compiled in a `lang="ts"` script — and in a plain one, where a function declaration always has a body. The exemption is now about the body rather than the `function` keyword, which also gives `declare function f(): void; function f() {}` the right answer, and the error carries acorn's code, wording and zero-width position

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/errors.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/errors.rs
@@ -125,6 +125,12 @@ diagnostics! {
     /// `%name%` has already been declared
     declaration_duplicate(name: &str) => "`{}` has already been declared", name;
 
+    /// acorn's own wording and code for a redeclaration. Raised from the
+    /// analyze phase only where TypeScript hides it from the parser: OXC's TS
+    /// mode exempts every function-vs-function redeclaration, so `1_parse` has
+    /// no diagnostic to map onto acorn's.
+    js_parse_error(name: &str) => "Identifier '{}' has already been declared", name;
+
     // Class-related errors
 
     /// `%name%` has already been declared

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/mod.rs
@@ -1391,6 +1391,7 @@ fn collect_legacy_reactive_statement_metadata(
             arena,
             &mut assignments,
             &mut cycle_dependencies,
+            &mut Vec::new(),
         );
 
         let instance_scope_idx = analysis.root.instance_scope_index;
@@ -1485,27 +1486,120 @@ fn cycle_collect_assignments_and_deps(
     arena: &ParseArena,
     assignments: &mut Vec<String>,
     dependencies: &mut Vec<String>,
+    locals: &mut Vec<String>,
 ) {
     match node {
         JsNode::Identifier { name, .. } => {
-            if !dependencies.iter().any(|s| s == name.as_str()) {
+            if !locals.iter().any(|l| l == name.as_str())
+                && !dependencies.iter().any(|s| s == name.as_str())
+            {
                 dependencies.push(name.to_string());
             }
         }
-        JsNode::AssignmentExpression { left, right, .. } => {
-            // LHS targets are assignments; the RHS (and any nested
-            // assignments within it) is walked for dependencies.
-            cycle_extract_pattern_ids(arena.get_js_node(*left), arena, assignments);
+        // A name declared inside the `$:` body is a different binding from the
+        // instance-level one that happens to share its spelling, so it is
+        // neither a dependency nor an assignment of the reactive statement.
+        // Upstream never has to say so: it resolves through the scope tree.
+        JsNode::BlockStatement { body, .. } => {
+            let mark = locals.len();
+            let stmts = arena.get_js_children(*body);
+            for stmt in stmts {
+                collect_block_local_decls(stmt, arena, locals);
+            }
+            for stmt in stmts {
+                cycle_collect_assignments_and_deps(stmt, arena, assignments, dependencies, locals);
+            }
+            locals.truncate(mark);
+        }
+        JsNode::CatchClause { param, body, .. } => {
+            let mark = locals.len();
+            if let Some(param) = param {
+                extract_param_names(arena.get_js_node(*param), arena, locals);
+            }
+            cycle_collect_assignments_and_deps(
+                arena.get_js_node(*body),
+                arena,
+                assignments,
+                dependencies,
+                locals,
+            );
+            locals.truncate(mark);
+        }
+        JsNode::ForStatement {
+            init,
+            test,
+            update,
+            body,
+            ..
+        } => {
+            let mark = locals.len();
+            if let Some(init) = init {
+                collect_block_local_decls(arena.get_js_node(*init), arena, locals);
+            }
+            for child in [init, test, update].into_iter().flatten() {
+                cycle_collect_assignments_and_deps(
+                    arena.get_js_node(*child),
+                    arena,
+                    assignments,
+                    dependencies,
+                    locals,
+                );
+            }
+            cycle_collect_assignments_and_deps(
+                arena.get_js_node(*body),
+                arena,
+                assignments,
+                dependencies,
+                locals,
+            );
+            locals.truncate(mark);
+        }
+        JsNode::ForOfStatement {
+            left, right, body, ..
+        }
+        | JsNode::ForInStatement {
+            left, right, body, ..
+        } => {
             cycle_collect_assignments_and_deps(
                 arena.get_js_node(*right),
                 arena,
                 assignments,
                 dependencies,
+                locals,
+            );
+            let mark = locals.len();
+            collect_block_local_decls(arena.get_js_node(*left), arena, locals);
+            for child in [left, body] {
+                cycle_collect_assignments_and_deps(
+                    arena.get_js_node(*child),
+                    arena,
+                    assignments,
+                    dependencies,
+                    locals,
+                );
+            }
+            locals.truncate(mark);
+        }
+        JsNode::AssignmentExpression { left, right, .. } => {
+            // LHS targets are assignments; the RHS (and any nested
+            // assignments within it) is walked for dependencies.
+            cycle_extract_assignment_targets(arena.get_js_node(*left), arena, assignments, locals);
+            cycle_collect_assignments_and_deps(
+                arena.get_js_node(*right),
+                arena,
+                assignments,
+                dependencies,
+                locals,
             );
         }
         // `x++` / `--x` assigns its argument.
         JsNode::UpdateExpression { argument, .. } => {
-            cycle_extract_pattern_ids(arena.get_js_node(*argument), arena, assignments);
+            cycle_extract_assignment_targets(
+                arena.get_js_node(*argument),
+                arena,
+                assignments,
+                locals,
+            );
         }
         // Function bodies create their own scope.
         JsNode::FunctionExpression { .. }
@@ -1522,6 +1616,7 @@ fn cycle_collect_assignments_and_deps(
                 arena,
                 assignments,
                 dependencies,
+                locals,
             );
             if *computed {
                 cycle_collect_assignments_and_deps(
@@ -1529,6 +1624,7 @@ fn cycle_collect_assignments_and_deps(
                     arena,
                     assignments,
                     dependencies,
+                    locals,
                 );
             }
         }
@@ -1544,6 +1640,7 @@ fn cycle_collect_assignments_and_deps(
                     arena,
                     assignments,
                     dependencies,
+                    locals,
                 );
             }
             cycle_collect_assignments_and_deps(
@@ -1551,6 +1648,7 @@ fn cycle_collect_assignments_and_deps(
                 arena,
                 assignments,
                 dependencies,
+                locals,
             );
         }
         // The annotation blob follows `properties` / `elements` in the JSON
@@ -1561,7 +1659,7 @@ fn cycle_collect_assignments_and_deps(
             ..
         } => {
             for prop in arena.get_js_children(*properties) {
-                cycle_collect_assignments_and_deps(prop, arena, assignments, dependencies);
+                cycle_collect_assignments_and_deps(prop, arena, assignments, dependencies, locals);
             }
             if let Some(ta) = type_annotation {
                 for_each_blob_identifier(ta, &mut |name, _| {
@@ -1577,7 +1675,7 @@ fn cycle_collect_assignments_and_deps(
             ..
         } => {
             for elem in elements.iter().flatten() {
-                cycle_collect_assignments_and_deps(elem, arena, assignments, dependencies);
+                cycle_collect_assignments_and_deps(elem, arena, assignments, dependencies, locals);
             }
             if let Some(ta) = type_annotation {
                 for_each_blob_identifier(ta, &mut |name, _| {
@@ -1595,18 +1693,40 @@ fn cycle_collect_assignments_and_deps(
                 arena,
                 assignments,
                 dependencies,
+                locals,
             );
             cycle_collect_assignments_and_deps(
                 arena.get_js_node(*body),
                 arena,
                 assignments,
                 dependencies,
+                locals,
             );
         }
         _ => {
             for_each_js_child(node, arena, &mut |child| {
-                cycle_collect_assignments_and_deps(child, arena, assignments, dependencies);
+                cycle_collect_assignments_and_deps(child, arena, assignments, dependencies, locals);
             });
+        }
+    }
+}
+
+/// `cycle_extract_pattern_ids`, minus the names a scope inside the `$:` body
+/// declares — writing to a block-local `e` is not writing to the instance `e`.
+fn cycle_extract_assignment_targets(
+    node: &JsNode,
+    arena: &ParseArena,
+    assignments: &mut Vec<String>,
+    locals: &[String],
+) {
+    let mark = assignments.len();
+    cycle_extract_pattern_ids(node, arena, assignments);
+    let mut i = mark;
+    while i < assignments.len() {
+        if locals.iter().any(|l| *l == assignments[i]) {
+            assignments.remove(i);
+        } else {
+            i += 1;
         }
     }
 }

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/mod.rs
@@ -3922,6 +3922,12 @@ fn js_node_check_features(
             collect_dollar_param_names(param, arena, shadowed);
         }
     }
+    if let JsNode::CatchClause {
+        param: Some(param), ..
+    } = node
+    {
+        collect_dollar_param_names(arena.get_js_node(*param), arena, shadowed);
+    }
 
     for_each_js_reference_child(node, arena, &mut |child| {
         if results.all_found() {
@@ -3940,12 +3946,21 @@ fn js_node_check_features(
     shadowed.truncate(shadow_base);
 }
 
-/// Like [`for_each_js_child`], but skips a non-computed class member NAME.
-/// `for_each_js_child` walks it because the legacy JSON walker did; upstream's
-/// `scope.references` — the set runes-mode detection reads — never holds a
-/// declaration slot, so `class P { $inspect = 1 }` must not read as a rune.
+/// Like [`for_each_js_child`], but skips the slots that BIND or LABEL a name
+/// rather than reading one. `for_each_js_child` walks them because the legacy
+/// JSON walker did; upstream's `scope.references` — the set runes-mode
+/// detection reads — holds neither a declaration slot nor a label, so
+/// `class P { $inspect = 1 }`, `$state: for (;;) break $state;` and
+/// `catch ($state) {}` must none of them read as a rune.
 fn for_each_js_reference_child(node: &JsNode, arena: &ParseArena, f: &mut impl FnMut(&JsNode)) {
     match node {
+        // A label lives in its own namespace: it is not an ESTree reference,
+        // and neither is the `break` / `continue` that names it.
+        JsNode::LabeledStatement { body, .. } => f(arena.get_js_node(*body)),
+        JsNode::BreakStatement { .. } | JsNode::ContinueStatement { .. } => {}
+        // The catch parameter is a declaration, and it shadows the name for the
+        // block — `js_node_check_features` pushes it onto `shadowed`.
+        JsNode::CatchClause { body, .. } => f(arena.get_js_node(*body)),
         JsNode::MethodDefinition {
             key,
             value,

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/scope.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/scope.rs
@@ -354,6 +354,11 @@ pub struct Binding {
     /// compiler's behavior where snippet blocks (declared with DeclarationKind::Function) are
     /// NOT considered functions since their initial type is SnippetBlock.
     pub initial_is_function: bool,
+    /// Whether this binding is a function declaration WITH a body. TypeScript
+    /// lets a name carry any number of body-less overload signatures, so the
+    /// duplicate check has to be about implementations rather than about the
+    /// `function` keyword.
+    pub is_function_implementation: bool,
     /// The AST node type of the initial value expression (e.g., "BinaryExpression", "Literal").
     /// Used by should_proxy() to determine if an identifier's initial value needs deep reactivity.
     pub initial_node_type: Option<String>,
@@ -463,6 +468,7 @@ impl Binding {
             init_expr_json: None,
             initial_is_defined: false,
             initial_is_function: false,
+            is_function_implementation: false,
             initial_node_type: None,
             initial_identifier_name: None,
             init_rune: None,
@@ -502,6 +508,7 @@ impl Binding {
             init_expr_json: None,
             initial_is_defined: false,
             initial_is_function: false,
+            is_function_implementation: false,
             initial_node_type: None,
             initial_identifier_name: None,
             init_rune: None,

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/scope_builder.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/scope_builder.rs
@@ -538,6 +538,38 @@ impl<'a> ScopeBuilder<'a> {
         }
     }
 
+    /// acorn-typescript separates an overload SIGNATURE from an
+    /// IMPLEMENTATION: any number of body-less declarations may share a name,
+    /// two bodies may not. `declare_binding` exempts every `Function` from the
+    /// duplicate check so that overload sets and snippets stay legal, so the
+    /// implementation-vs-implementation half is answered here, at the only
+    /// three sites that declare a real `function`.
+    fn report_duplicate_function_implementation(
+        &mut self,
+        name: &str,
+        has_body: bool,
+        span: Option<(u32, u32)>,
+    ) {
+        if !has_body {
+            return;
+        }
+        let Some(&existing) = self.scopes[self.current_scope].declarations.get(name) else {
+            return;
+        };
+        if !self.bindings[existing].is_function_implementation {
+            return;
+        }
+        // Zero width, at the redeclaring identifier — acorn reports a single
+        // `pos` and stops there, and this has to be indistinguishable from the
+        // `js_parse_error` the parser raises for the same source without
+        // `lang="ts"`.
+        let mut error = errors::js_parse_error(name);
+        if let Some((start, _)) = span {
+            error = error.at(start, start);
+        }
+        self.validation_errors.push(error);
+    }
+
     /// Declare a binding in the current scope. `span` is the declaring
     /// identifier's source range, which `declaration_duplicate` is attributed to.
     fn declare_binding(
@@ -747,6 +779,12 @@ impl<'a> ScopeBuilder<'a> {
                         name, start, end, ..
                     } = id_node
                     {
+                        let has_body = body.is_some();
+                        self.report_duplicate_function_implementation(
+                            name,
+                            has_body,
+                            Some((*start, *end)),
+                        );
                         let idx = self.declare_binding(
                             name.to_string(),
                             BindingKind::Normal,
@@ -754,6 +792,7 @@ impl<'a> ScopeBuilder<'a> {
                             Some((*start, *end)),
                         );
                         self.bindings[idx].initial_is_function = true;
+                        self.bindings[idx].is_function_implementation = has_body;
                         self.bindings[idx].declaration_start = Some(*start);
                     }
                 }
@@ -1576,6 +1615,12 @@ impl<'a> ScopeBuilder<'a> {
                 if let Some(id) = &func_decl.id {
                     let name = id.name.to_string();
                     let offset = self.current_script_offset as u32;
+                    let has_body = func_decl.body.is_some();
+                    self.report_duplicate_function_implementation(
+                        &name,
+                        has_body,
+                        Some((id.span.start + offset, id.span.end + offset)),
+                    );
                     let idx = self.declare_binding(
                         name,
                         BindingKind::Normal,
@@ -1584,6 +1629,7 @@ impl<'a> ScopeBuilder<'a> {
                     );
                     // Mark as a true JS function (not a snippet block)
                     self.bindings[idx].initial_is_function = true;
+                    self.bindings[idx].is_function_implementation = has_body;
                     self.bindings[idx].declaration_start = Some(id.span.start + offset);
                 }
                 // Create a new scope for the function body (non-porous: function_depth + 1)
@@ -2348,6 +2394,12 @@ impl<'a> ScopeBuilder<'a> {
                 if let Some(id) = &func_decl.id {
                     let name = id.name.to_string();
                     let offset = self.current_script_offset as u32;
+                    let has_body = func_decl.body.is_some();
+                    self.report_duplicate_function_implementation(
+                        &name,
+                        has_body,
+                        Some((id.span.start + offset, id.span.end + offset)),
+                    );
                     let idx = self.declare_binding(
                         name,
                         BindingKind::Normal,
@@ -2355,6 +2407,7 @@ impl<'a> ScopeBuilder<'a> {
                         Some((id.span.start + offset, id.span.end + offset)),
                     );
                     self.bindings[idx].initial_is_function = true;
+                    self.bindings[idx].is_function_implementation = has_body;
                 }
                 // Process function body to track assignments inside exported functions.
                 // Without this, reassignments like `export function update() { x = 'new'; }`

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/store_subscriptions.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/store_subscriptions.rs
@@ -686,6 +686,77 @@ fn dollar_param_body_range(
     None
 }
 
+/// The `catch (…)` parameter binding, and the range of the block it scopes.
+///
+/// A catch parameter is a declaration slot, so upstream's `scope.references` —
+/// which this scan stands in for — never holds it, and a `$name` read inside the
+/// block resolves to it rather than to a store. `dollar_param_body_range` cannot
+/// answer this because it requires the parenthesised list to be followed by
+/// `=>`, and a catch clause is followed by `{`.
+fn dollar_catch_param_body_range(
+    chars: &[char],
+    ident_start: usize,
+    ident_end: usize,
+) -> Option<(usize, usize)> {
+    let len = chars.len();
+    let mut k = ident_start as isize - 1;
+    while k >= 0 && is_js_whitespace(chars[k as usize]) {
+        k -= 1;
+    }
+    if k < 0 || chars[k as usize] != '(' {
+        return None;
+    }
+    let mut j = k - 1;
+    while j >= 0 && is_js_whitespace(chars[j as usize]) {
+        j -= 1;
+    }
+    if !keyword_ends_at(chars, j, "catch") {
+        return None;
+    }
+    let mut m = ident_end;
+    while m < len && is_js_whitespace(chars[m]) {
+        m += 1;
+    }
+    if m >= len || chars[m] != ')' {
+        return None;
+    }
+    let mut b = m + 1;
+    while b < len && is_js_whitespace(chars[b]) {
+        b += 1;
+    }
+    if b >= len || chars[b] != '{' {
+        return None;
+    }
+    let mut depth = 0usize;
+    let mut e = b;
+    while e < len {
+        match chars[e] {
+            '{' => depth += 1,
+            '}' => {
+                depth -= 1;
+                if depth == 0 {
+                    return Some((b, e + 1));
+                }
+            }
+            _ => {}
+        }
+        e += 1;
+    }
+    Some((b, len))
+}
+
+/// The target of a `break` / `continue`, which names a LABEL rather than a
+/// binding. ESTree keeps labels out of the reference set, so upstream never sees
+/// one; counting it made `break $state;` read as a rune use and flipped the
+/// component into runes mode.
+fn is_dollar_ident_jump_label(chars: &[char], ident_start: usize) -> bool {
+    let mut k = ident_start as isize - 1;
+    while k >= 0 && is_js_whitespace(chars[k as usize]) {
+        k -= 1;
+    }
+    keyword_ends_at(chars, k, "break") || keyword_ends_at(chars, k, "continue")
+}
+
 /// Check if a `$xxx` identifier at `ident_end` is being used as an object property key.
 ///
 /// Returns true if `$xxx` is followed (ignoring whitespace) by `:` but NOT `::`.
@@ -1158,7 +1229,8 @@ fn collect_dollar_identifiers_pass(
                 // Only add if we have more than just $
                 // (bare $ detection is handled separately via proper AST analysis)
                 if ident.len() > 1 {
-                    let param_range = dollar_param_body_range(chars, ident_start, i);
+                    let param_range = dollar_param_body_range(chars, ident_start, i)
+                        .or_else(|| dollar_catch_param_body_range(chars, ident_start, i));
                     let is_var_decl = is_dollar_ident_variable_declaration(chars, ident_start)
                         || is_dollar_ident_destructuring_declaration(chars, ident_start);
                     let is_class_member_name = class_bodies.last() == Some(&brace_depth)
@@ -1183,6 +1255,7 @@ fn collect_dollar_identifiers_pass(
                             .iter()
                             .any(|(n, s, e)| n == &ident && ident_start >= *s && ident_start < *e)
                         && !is_dollar_ident_object_property_key(chars, ident_start, i)
+                        && !is_dollar_ident_jump_label(chars, ident_start)
                         && !is_dollar_ident_type_declaration(chars, ident_start)
                     {
                         let byte_offset = match &char_byte_offsets {

--- a/crates/rsvelte_core/tests/reactive_cycle_block_scope_3197.rs
+++ b/crates/rsvelte_core/tests/reactive_cycle_block_scope_3197.rs
@@ -1,0 +1,91 @@
+//! A name declared INSIDE a `$:` statement is a different binding from the
+//! instance-level one that shares its spelling (#3197).
+//!
+//! The cycle detector walked the reactive body with no notion of scope, so a
+//! `catch (e)` parameter or a block `let e` was attributed to the instance `e`
+//! and a second `$:` that assigns `e` closed a cycle that does not exist.
+//! Upstream never has to say any of this: it resolves through the scope tree.
+//!
+//! A function parameter was already handled, which is what makes this a scoping
+//! gap rather than a missing feature — and why the population below has to
+//! carry the shapes that were NOT handled, not the one that was.
+
+use rsvelte_core::{CompileOptions, GenerateMode, compile, compiler::CssMode};
+
+/// Two reactive statements. The first is `body`; the second assigns `e`, so any
+/// spurious `e` in the first statement's dependency set closes a cycle.
+fn two_statements(body: &str) -> String {
+    format!(
+        "<script>\n\texport let a = 1;\n\tlet d = 0;\n\tlet e = 0;\n\t{body}\n\t$: e = d + 1;\n</script>\n\n<b>{{d}}{{e}}</b>\n"
+    )
+}
+
+fn compile_both(src: &str) -> Result<(), String> {
+    for generate in [GenerateMode::Client, GenerateMode::Server] {
+        compile(
+            src,
+            CompileOptions {
+                filename: Some("Test.svelte".to_string()),
+                generate,
+                dev: false,
+                css: CssMode::External,
+                ..Default::default()
+            },
+        )
+        .map_err(|e| format!("{generate:?}: {e:?}"))?;
+    }
+    Ok(())
+}
+
+/// Every one of these compiles upstream. Each declares `e` in a scope inside the
+/// `$:` body, and none of them reads the instance `e`.
+const SCOPED_LOCALS: &[&str] = &[
+    "$: try { d = a; } catch (e) { d = 0; }",
+    "$: { let e = a; d = e; }",
+    "$: { const e = a; d = e; }",
+    "$: for (let e = 0; e < a; e++) { d = e; }",
+    "$: for (const e of [a]) { d = e; }",
+    // Already correct before the fix — the control that makes this a scoping
+    // gap rather than a missing feature.
+    "$: d = ((e) => e)(a);",
+];
+
+#[test]
+fn a_name_declared_inside_a_reactive_statement_is_not_the_outer_one() {
+    for body in SCOPED_LOCALS {
+        compile_both(&two_statements(body)).unwrap_or_else(|err| {
+            panic!("{body:?} must compile; got: {err}");
+        });
+    }
+}
+
+/// The other direction, and the row that separates a scope stack from a flat
+/// "any name declared anywhere inside the body is local" list: the inner block
+/// shadows `e` for itself only, so the outer `d = e` still reads the instance
+/// `e` and the cycle is real. Upstream rejects all three.
+#[test]
+fn a_real_cycle_is_still_a_cycle() {
+    for body in [
+        "$: d = e;",
+        "$: { d = e; }",
+        "$: { d = e; { let e = 1; d = e; } }",
+    ] {
+        let err = compile(
+            &two_statements(body),
+            CompileOptions {
+                filename: Some("Test.svelte".to_string()),
+                generate: GenerateMode::Server,
+                dev: false,
+                css: CssMode::External,
+                ..Default::default()
+            },
+        )
+        .map_err(|e| format!("{e:?}"))
+        .err()
+        .unwrap_or_else(|| panic!("{body:?} is a real cycle and must not compile"));
+        assert!(
+            err.contains("reactive_declaration_cycle"),
+            "expected a cycle for {body:?}, got: {err}"
+        );
+    }
+}

--- a/crates/rsvelte_core/tests/rune_named_label_mode_3238.rs
+++ b/crates/rsvelte_core/tests/rune_named_label_mode_3238.rs
@@ -1,0 +1,159 @@
+//! A `$`-prefixed name in a slot that only BINDS or LABELS it is not a rune use
+//! (#3238).
+//!
+//! The runes-mode detector and the store-subscription collector read one set of
+//! `$name` occurrences, so a slot the collector mis-reads changes the compiler's
+//! MODE, not just one expression. `$state:` as a statement label and
+//! `catch ($state)` both declare rather than read, and counting them turned a
+//! working Svelte 4 component into `legacy_export_invalid`.
+//!
+//! The flag is the cheap half. The expensive half is that the same file has to
+//! still compile — which is why every row here carries `export let`, a `$:`
+//! statement and a template read, i.e. things that only work in legacy mode.
+
+use rsvelte_core::{CompileOptions, GenerateMode, compile, compiler::CssMode};
+
+fn server(src: &str) -> Result<String, String> {
+    compile(
+        src,
+        CompileOptions {
+            filename: Some("Test.svelte".to_string()),
+            generate: GenerateMode::Server,
+            dev: false,
+            css: CssMode::External,
+            ..Default::default()
+        },
+    )
+    .map(|r| r.js.code)
+    .map_err(|e| format!("{e:?}"))
+}
+
+fn client(src: &str) -> Result<String, String> {
+    compile(
+        src,
+        CompileOptions {
+            filename: Some("Test.svelte".to_string()),
+            generate: GenerateMode::Client,
+            dev: false,
+            css: CssMode::External,
+            ..Default::default()
+        },
+    )
+    .map(|r| r.js.code)
+    .map_err(|e| format!("{e:?}"))
+}
+
+/// Each of these is a `$`-name that binds or labels. None is a rune use, and
+/// official compiles every one of them in legacy mode.
+const BINDING_SLOTS: &[&str] = &[
+    "$state: for (;;) { break $state; }",
+    "$derived: for (;;) { break $derived; }",
+    "$effect: for (;;) { continue $effect; }",
+    "$props: while (0) { break $props; }",
+    "try { n = 1; } catch ($state) { n = 2; }",
+    "try { n = 1; } catch ($derived) { n = 2; }",
+    "try { n = 1; } catch ($effect) { n = 2; }",
+    // The catch parameter shadows for its own block, so a read inside it is the
+    // parameter and not a store.
+    "try { n = 1; } catch ($state) { n = $state ? 1 : 2; }",
+];
+
+fn legacy_component(body: &str) -> String {
+    format!(
+        "<script>\n\texport let p = 1;\n\tlet n = 0;\n\t$: doubled = n * 2;\n\tfunction f() {{\n\t\t{body}\n\t}}\n</script>\n\n<div>{{p}} {{doubled}} {{f}}</div>\n"
+    )
+}
+
+/// The loud half: a legacy component must not become a compile error.
+#[test]
+fn a_binding_slot_does_not_turn_a_legacy_component_into_an_error() {
+    for body in BINDING_SLOTS {
+        let src = legacy_component(body);
+        let err = match server(&src) {
+            Ok(_) => continue,
+            Err(err) => err,
+        };
+        panic!("{body:?} must not stop a legacy component compiling; got: {err}");
+    }
+}
+
+/// The quiet half, and the one an "it compiles" test cannot see: the component
+/// has to be in LEGACY mode, not merely accepted. Upstream marks that with the
+/// `svelte/internal/flags/legacy` import on the client.
+#[test]
+fn a_binding_slot_does_not_flip_the_mode() {
+    let baseline_src = legacy_component("n = 1;");
+    let baseline = client(&baseline_src).expect("the control compiles");
+    assert!(
+        baseline.contains("svelte/internal/flags/legacy"),
+        "the control must itself be in legacy mode, or this test measures nothing:\n{baseline}"
+    );
+
+    for body in BINDING_SLOTS {
+        let code = client(&legacy_component(body)).expect("compiles");
+        assert!(
+            code.contains("svelte/internal/flags/legacy"),
+            "{body:?} must stay in legacy mode; got:\n{code}"
+        );
+    }
+}
+
+/// The other direction. A real rune use still reaches the detector, and a
+/// `$store` read next to the same names is still a subscription — an exclusion
+/// that swallowed either of those would pass both tests above.
+#[test]
+fn a_real_rune_and_a_real_store_are_still_seen() {
+    let runes = "<script>\n\tlet n = $state(0);\n</script>\n\n<div>{n}</div>\n";
+    let code = client(runes).expect("compiles");
+    assert!(
+        !code.contains("svelte/internal/flags/legacy"),
+        "an actual rune must still select runes mode:\n{code}"
+    );
+
+    let store = "<script>\n\timport { writable } from 'svelte/store';\n\tconst state = writable(0);\n\tfunction f() {\n\t\t$state: for (;;) { break $state; }\n\t}\n</script>\n\n<div>{$state} {f}</div>\n";
+    let code = server(store).expect("compiles");
+    assert!(
+        code.contains("store_get"),
+        "a template `$state` read next to a `$state:` label is still a subscription:\n{code}"
+    );
+}
+
+/// The same two slots decide STORE subscriptions, from a different scan —
+/// `2_analyze/store_subscriptions.rs` reads characters where the mode detector
+/// reads the AST. Both had the same gap, and only measuring the emitted
+/// `store_get` calls separates them: a mode test cannot see a wrong
+/// subscription and a subscription test cannot see a wrong mode.
+#[test]
+fn a_binding_slot_is_not_a_store_subscription_either() {
+    let head = "<script>\n\timport { writable } from 'svelte/store';\n\tconst count = writable(0);\n\tlet n = 0;\n";
+
+    // The catch parameter shadows the store for its own block.
+    let shadowed = format!(
+        "{head}\tfunction f() {{ try {{ n = 1; }} catch ($count) {{ n = $count; }} }}\n</script>\n\n<div>{{n}} {{f}}</div>\n"
+    );
+    let code = server(&shadowed).expect("compiles");
+    assert!(
+        !code.contains("store_get"),
+        "a catch parameter shadows the store inside its block:\n{code}"
+    );
+
+    // Positive control on the same file: outside the block it is still a store.
+    let outside = format!(
+        "{head}\tfunction f() {{ try {{ n = 1; }} catch ($count) {{ n = 2; }} }}\n</script>\n\n<div>{{$count}} {{n}} {{f}}</div>\n"
+    );
+    let code = server(&outside).expect("compiles");
+    assert!(
+        code.contains("store_get"),
+        "the same name outside the catch block is still a subscription:\n{code}"
+    );
+
+    // A label and its `break` target name no binding at all.
+    let labelled = format!(
+        "{head}\tfunction f() {{ $count: for (;;) {{ break $count; }} }}\n</script>\n\n<div>{{n}} {{f}}</div>\n"
+    );
+    let code = server(&labelled).expect("compiles");
+    assert!(
+        !code.contains("store_get"),
+        "a label is not a store read:\n{code}"
+    );
+}

--- a/crates/rsvelte_core/tests/ts_duplicate_function_3484.rs
+++ b/crates/rsvelte_core/tests/ts_duplicate_function_3484.rs
@@ -1,0 +1,146 @@
+//! A TypeScript overload SIGNATURE may repeat a name; a second IMPLEMENTATION
+//! may not (#3484).
+//!
+//! rsvelte answered this with "TypeScript has overloads, therefore exempt every
+//! function-vs-function redeclaration" — the same over-broad rule in two
+//! independent places. OXC's TS mode raises no diagnostic at all, so the
+//! parse-phase check ported for #3243 has nothing to map, and
+//! `2_analyze/scope_builder.rs` carried the same blanket exemption. The real
+//! boundary is the BODY, which is why the rows below vary the number of bodies
+//! while holding the number of `function` keywords fixed.
+//!
+//! Every expectation was measured against `submodules/svelte`; the wording,
+//! the code and the zero-width span are acorn's.
+
+use rsvelte_core::{CompileOptions, GenerateMode, compile, compiler::CssMode};
+
+fn compile_script(body: &str, lang_ts: bool) -> Result<String, String> {
+    let open = if lang_ts {
+        "<script lang=\"ts\">"
+    } else {
+        "<script>"
+    };
+    let src = format!("{open}\n\t{body}\n</script>\n\n<p>ok</p>\n");
+    compile(
+        &src,
+        CompileOptions {
+            filename: Some("Test.svelte".to_string()),
+            generate: GenerateMode::Server,
+            dev: false,
+            css: CssMode::External,
+            ..Default::default()
+        },
+    )
+    .map(|r| r.js.code)
+    .map_err(|e| format!("{e:?}"))
+}
+
+/// `|` marks the offset official reports, and the marker is stripped before
+/// compiling — a fix that rejects at the wrong byte fails here rather than
+/// passing.
+const DUPLICATE_IMPLEMENTATIONS: &[&str] = &[
+    "function f() {} function |f() {}",
+    "function f() {} function |f(a: any) {}",
+    "function f(a: number): void; function f(a: any) {} function |f(a: any) {}",
+];
+
+// `export function f() {} export function f() {}` is deliberately NOT here.
+// Both compilers reject it, but rsvelte answers from an earlier export check
+// (`Duplicated export 'f'` at the first `f`) where acorn answers
+// `Identifier 'f' has already been declared` at the second. That is a message
+// and position divergence on an input already rejected, which is #3432's
+// subject, not this one's — and asserting it here would make this test fail for
+// a reason that has nothing to do with the exemption being narrowed.
+
+/// The whole reason the exemption exists. A body-less declaration may repeat a
+/// name any number of times, and `declare function` is the same shape.
+const OVERLOAD_SETS: &[&str] = &[
+    "function f(a: number): void; function f(a: any) {}",
+    "function f(a: number): void; function f(a: string): void; function f(a: any) {}",
+    "declare function f(a: number): void; function f(a: any) {}",
+    "function f(a: number): void;\nfunction f(a: any) {}",
+    // Not a redeclaration at all: a nested block is its own scope.
+    "function f() {} { function f() {} }",
+    "function f() {}",
+];
+
+#[test]
+fn a_second_implementation_is_rejected_where_acorn_rejects_it() {
+    for marked in DUPLICATE_IMPLEMENTATIONS {
+        let body = marked.replace('|', "");
+        let at = format!("<script lang=\"ts\">\n\t{marked}")
+            .find('|')
+            .expect("the marker survives wrapping");
+        let err = match compile_script(&body, true) {
+            Err(err) => err,
+            Ok(code) => panic!("{body:?} must not compile with lang=\"ts\"; emitted:\n{code}"),
+        };
+        assert!(
+            err.contains("js_parse_error"),
+            "expected acorn's code for {body:?}, got: {err}"
+        );
+        assert!(
+            err.contains("Identifier 'f' has already been declared"),
+            "expected acorn's wording for {body:?}, got: {err}"
+        );
+        assert!(
+            err.contains(&format!("start: Some({at}), end: Some({at})")),
+            "expected the zero-width span at {at} for {body:?}, got: {err}"
+        );
+    }
+}
+
+#[test]
+fn an_overload_set_still_compiles() {
+    for body in OVERLOAD_SETS {
+        assert!(
+            compile_script(body, true).is_ok(),
+            "{body:?} must compile with lang=\"ts\""
+        );
+    }
+}
+
+/// The plain-JS half of the same rule, where a function declaration always has
+/// a body — so every one of these is a second implementation.
+#[test]
+fn the_javascript_side_is_rejected_too() {
+    for body in ["function f() {} function f() {}"] {
+        let err = compile_script(body, false)
+            .expect_err("two implementations must not compile without lang=\"ts\" either");
+        assert!(
+            err.contains("Identifier 'f' has already been declared"),
+            "expected acorn's wording for {body:?}, got: {err}"
+        );
+    }
+    for body in ["function f() {} { function f() {} }", "function f() {}"] {
+        assert!(
+            compile_script(body, false).is_ok(),
+            "{body:?} must still compile"
+        );
+    }
+}
+
+/// Two snippets share `DeclarationKind::Function` with a function declaration,
+/// and their duplicate check is a separate one. Narrowing the function
+/// exemption must neither silence it nor make it fire twice.
+#[test]
+fn duplicate_snippets_still_report_exactly_once() {
+    let src = "<script>\n\tlet a = 1;\n</script>\n\n{#snippet s()}{a}{/snippet}\n{#snippet s()}{a}{/snippet}\n";
+    let err = compile(
+        src,
+        CompileOptions {
+            filename: Some("Test.svelte".to_string()),
+            generate: GenerateMode::Server,
+            dev: false,
+            css: CssMode::External,
+            ..Default::default()
+        },
+    )
+    .map(|r| r.js.code)
+    .map_err(|e| format!("{e:?}"))
+    .expect_err("two snippets with one name are a duplicate declaration");
+    assert!(
+        err.contains("declaration_duplicate"),
+        "the snippet check owns this one, not the function check: {err}"
+    );
+}


### PR DESCRIPTION
Closes #3484
Closes #3238
Closes #3197

Three scope-resolution defects with one shape: **a `$name` or a plain name in a slot that BINDS or LABELS it was attributed to the outer binding that shares its spelling.** Upstream never has to state any of this — it resolves through the scope tree — so each of these is a place where rsvelte answers the question by a different means and gets a different answer.

Branch name mentions #3115; **it is not in this PR** (see the end).

---

## #3484 — a second `function` implementation is a redeclaration, a signature is not

TypeScript lets a name carry any number of body-less overload signatures, which rsvelte generalised to *"exempt every function-vs-function redeclaration"*. The same over-broad rule sat in two independent places, which is why neither the parse phase nor the analyze phase caught it:

* OXC's TypeScript mode raises **no diagnostic at all** for function-vs-function, so the `SemanticBuilder` check added in #3499 has nothing to map.
* `2_analyze/scope_builder.rs` carried the same blanket exemption.

The boundary acorn-typescript actually draws is the **body**. Measured against `submodules/svelte`:

| input (`lang="ts"`) | official |
|---|---|
| `function f(a: number): void; function f(a: any) {}` | accepted |
| `function f(a: number): void; function f(a: string): void; function f(a: any) {}` | accepted |
| `declare function f(a: number): void; function f(a: any) {}` | accepted |
| `function f() {} function f() {}` | **rejected** — `Identifier 'f' has already been declared`, zero-width at the second `f` |

So the fix asks whether **both** sides have a body, which gives `declare function` the right answer for free. `Binding.is_function_implementation` records it, and the check runs at the three sites that declare a real `function` rather than inside `declare_binding` — that keeps `DeclarationKind::Function` exempt for **snippets**, whose own duplicate check is separate and must neither be silenced nor made to fire twice (there is a test for exactly that).

The error carries acorn's **code**, wording and zero-width position. Raising `js_parse_error` from the analyze phase is deliberate and commented: this is an acorn-typescript verdict that the parse phase structurally cannot produce, and the observable output has to be indistinguishable from the same source without `lang="ts"`.

**Not in scope, deliberately:** `export function f() {} export function f() {}` is rejected by both compilers but rsvelte answers from an earlier export check (`Duplicated export 'f'` at the *first* `f`) where acorn answers `Identifier 'f' has already been declared` at the second. That is a message/position divergence on an already-rejected input — #3432's subject — and the test says so rather than asserting it.

## #3238 — a rune-named label or catch parameter is not a rune use

`$state:` as a statement label and `catch ($state)` both **declare**; neither is an ESTree reference. Counting them flipped the component into runes mode, and one label inside a function body turned a working Svelte 4 component into a compile error:

```
legacy_export_invalid: Cannot use `export let` in runes mode — use `$props()` instead
```

Two independent scans decide this, and **both had the same gap**:

* the mode detector walks the AST (`for_each_js_reference_child` in `2_analyze/mod.rs`) — it now skips a `LabeledStatement`'s label, a `Break`/`ContinueStatement` entirely, and a `CatchClause`'s param, and pushes the catch param onto the same `shadowed` list function parameters already use;
* the store-subscription collector reads **characters** (`2_analyze/store_subscriptions.rs`) — it now excludes a `break`/`continue` target and treats a catch parameter as a binding that shadows for its own block.

The second half is not decoration. Measured against official:

| source | official emits |
|---|---|
| `catch ($count) { n = $count; }` | **no** `store_get` — the parameter shadows |
| the same file with `{$count}` in the template | `store_get(…, '$count', count)` — outside the block it is still a store |
| `$count: for (;;) { break $count; }` | **no** `store_get` |

**A mode test cannot see a wrong subscription and a subscription test cannot see a wrong mode**, so the file carries both, and each half fails on its own when the other's fix is ablated.

The flag is the cheap half of the mode assertion; the expensive half is that the same file must still *compile*, which is why every row carries `export let`, a `$:` statement and a template read — things that only work in legacy mode. The control asserts the baseline component is itself in legacy mode, or the test would measure nothing.

## #3197 — a name declared inside a `$:` statement is not the outer one

The cycle detector walked a reactive body with **no notion of scope**, so a `catch (e)` parameter, a block `let e`, and a `for` head's own binding were all attributed to the instance-level `e`. A second `$:` assigning `e` then closed a cycle that does not exist:

```svelte
$: try { d = a; } catch (e) { d = 0; }
$: e = d + 1;                            <!-- official: OK; rsvelte: reactive_declaration_cycle -->
```

A **function parameter was already handled**, which is what makes this a scoping gap rather than a missing feature — and why the population is the shapes that were not handled, not the one that was.

`cycle_collect_assignments_and_deps` now carries the same `locals` scope stack `collect_reactive_refs` has had all along, with arms for `BlockStatement`, `CatchClause`, `ForStatement` and `For(In|Of)Statement`, and assignment targets filtered through it too.

**The row that separates a scope stack from a flat "any name declared anywhere in the body" list** is in the test: `$: { d = e; { let e = 1; d = e; } }` — the inner block shadows for itself only, so the outer `d = e` still reads the instance `e` and the cycle is **real**. Official rejects it; so does this.

---

## Negative controls

Every fix was reverted on its own and the suite re-run, and each failed **for the predicted reason** rather than merely failing:

| ablation | result |
|---|---|
| `report_duplicate_function_implementation` returns early | `"function f() {} function f() {}" must not compile with lang="ts"` — and the overload-set and snippet controls still pass |
| `for_each_js_reference_child` label/catch arms | both mode tests fail with `legacy_export_invalid`; the store test still passes |
| the `store_subscriptions.rs` half | **only** the store test fails, showing `$.store_get(…, '$count', count)` emitted inside the catch block |
| the `locals` filter in the cycle walk | `"$: { let e = a; d = e; }" must compile; got reactive_declaration_cycle: d → e → d` — and the real-cycle control still passes |

## Local verification

The pre-commit hook does not finish inside 10 minutes on this box, so the commits used `--no-verify` and the checks were run by hand:

* `cargo fmt --all` — clean.
* `cargo clippy -p rsvelte_core --lib --all-features -- -D warnings` — clean.
* `cargo test -p rsvelte_core` over `reactive_cycle_block_scope_3197`, `rune_named_label_mode_3238`, `ts_duplicate_function_3484`, `compiler_errors`, `parser_fixtures`, `validator`, `ssr`, **`runtime`** — all green (runtime 707 s). The over-rejection risk of all three fixes lives in that set.

## Conflicts

* `2_analyze/scope_builder.rs` — coordinated with **@metA**: my change is confined to the three `FunctionDeclaration` declaration sites plus a new helper above `declare_binding`. I did **not** touch `visit_snippet_block`, the `declare_binding` condition, or the comment about the root `Fragment` not being materialised, all of which #3375 moves.
* `2_analyze/mod.rs` — two functions, `for_each_js_reference_child` (#3238) and `cycle_collect_assignments_and_deps` (#3197), committed separately.

## Not in this PR

**#3115** (a local declaration shadowing a rune name does not turn the call into a store subscription). The branch name mentions it; it is a larger job — six rune names, and `$derived`'s declaration side and read side disagree with each other, not only with upstream — and it belongs in `get_rune_name_node`, which asks `analysis.root.scope.declarations.contains_key("$props")` where upstream asks `scope.get('$props')` and finds the **store-subscription** binding that the local `props` created. Left open deliberately rather than half-done.
