### PR TITLE
fix(compiler): erase a TypeScript class index signature

### DIFF
--- a/.changeset/ts-class-index-signature.md
+++ b/.changeset/ts-class-index-signature.md
@@ -1,0 +1,22 @@
+---
+'@rsvelte/compiler': patch
+---
+
+Erase a TypeScript class index signature instead of leaving it in the output
+
+`class K { [k: string]: unknown }` reached the `client` JavaScript verbatim — TypeScript in a
+`.js` artifact, which no parser accepts — and on `server` it was worse: the erased script is
+re-parsed to classify its statements, that parse rejected the surviving TypeScript, and the whole
+instance script was discarded, leaving output that parses and does nothing.
+
+The eraser left it alone on purpose ("upstream passes these through verbatim"), which was the
+wrong reading of upstream's behaviour: the official compiler does not print it either, it
+**throws** a bare `TypeError: Cannot read properties of undefined (reading 'type')` from esrap's
+`TSIndexSignature` printer, because `remove_typescript_nodes.js` deletes the signature's
+`typeAnnotation` while `ClassBody` keeps the node. A crash is not an output to be byte-equal to.
+
+An index signature is type-only and has no runtime representation, so it is now removed like an
+interface and a type alias already were — measured over 8 spellings × 3 class hosts × 2 entry
+points × 3 targets, taking 96 unparseable outputs, 96 TypeScript leaks and 48 silently-dropped
+scripts to zero with the 198 control cells unchanged. Recorded in
+`compatibility/deliberate-divergences.md` and reported in `upstream_issues/`.

--- a/compatibility/deliberate-divergences.md
+++ b/compatibility/deliberate-divergences.md
@@ -192,3 +192,49 @@ measurement rather than being folded into a fix for the two rows above.
 - **Corpus gate**: `pattern/issues/2573-ctor-private-derived-write.svelte.js` covers the two
   fixed rows on all three targets. Nothing in the collected corpus writes a private `$derived`
   field through any receiver — `known-failures.server.json` is `[]`.
+
+---
+
+## TypeScript class index signature
+
+**Pinned by** `crates/rsvelte_core/tests/ts_index_signature_3422.rs`.
+**Reported upstream** in `upstream_issues/3422-svelte-class-index-signature-crash.md`.
+
+`class K { [k: string]: unknown }` makes the official compiler throw a bare
+`TypeError: Cannot read properties of undefined (reading 'type')` — no `code`, no position, no
+frame — from esrap's `TSIndexSignature` printer, because `remove_typescript_nodes.js` deletes the
+signature's `typeAnnotation` while `ClassBody` keeps the node itself. rsvelte erases the member,
+so rsvelte compiles what upstream cannot.
+
+**This entry exists because the previous behaviour was a deliberate parity choice, and it shipped
+two defects.** `2_analyze/types.rs` carried the comment *"Upstream passes these through verbatim
+(a class index signature even makes it throw), so they are left exactly as written"* — locally
+reasonable, and wrong, because "upstream throws" is not an output to be equal to.
+
+### What leaving it in cost, measured
+
+A grid of 8 index-signature spellings + 11 TypeScript-only control members × 3 class hosts
+(declaration, expression, one carrying a `$state` field) × 2 entry points (instance script,
+`<script module>`) × 3 targets = **342 cells**:
+
+| | before | after |
+|---|---|---|
+| rsvelte output rejected by acorn | 96 | **0** |
+| TypeScript left in the `.js` output | 96 | **0** |
+| instance/module script silently dropped (`server`) | 48 | **0** |
+| control cells clean | 198 | 198 |
+
+The 96 client/client-dev cells emitted `class K { [k: string]: unknown }` into a `.js` artifact.
+The 48 `server` cells are the more dangerous half and are **not** what the report described: the
+erased script is re-parsed to classify it, that parse rejected the surviving TypeScript, and the
+whole instance script was discarded — output that parses and does nothing. (#3421 made that
+failure loud; this change removes its cause.)
+
+### Why no gate sees it
+
+- **Output-equality gates**: there is no official output at all for these inputs, so nothing to
+  compare; a crash is not a `code` the error ratchets can key on either.
+- **Output-parseability gate**: parses rsvelte's side only, and the `server` half parses fine
+  while being empty.
+- **Collected corpus**: a component with a class index signature cannot be built with the official
+  compiler, so no published source can carry the shape.

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/types.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/types.rs
@@ -1036,9 +1036,15 @@ mod ts_removals {
             self.remove(it.span);
         }
 
-        // Upstream passes these through verbatim (a class index signature even
-        // makes it throw), so they are left exactly as written.
-        fn visit_ts_index_signature(&mut self, _it: &TSIndexSignature<'a>) {}
+        // A class index signature is type-only and has no runtime form; upstream
+        // leaves it in and then throws while printing it, so there is no oracle
+        // to reproduce. See
+        // `upstream_issues/3422-svelte-class-index-signature-crash.md`.
+        fn visit_ts_index_signature(&mut self, it: &TSIndexSignature<'a>) {
+            self.remove(it.span);
+        }
+
+        // Upstream passes these through verbatim, so they are left as written.
         fn visit_ts_export_assignment(&mut self, _it: &TSExportAssignment<'a>) {}
         fn visit_ts_import_equals_declaration(&mut self, _it: &TSImportEqualsDeclaration<'a>) {}
         fn visit_ts_namespace_export_declaration(

--- a/crates/rsvelte_core/tests/ts_erasure_visitor_coverage.rs
+++ b/crates/rsvelte_core/tests/ts_erasure_visitor_coverage.rs
@@ -130,18 +130,14 @@ fn for_of_and_for_in_non_declaration_targets() {
     );
 }
 
-/// The four node kinds below are deliberately *not* walked. Erasing them is not
-/// worth attempting, because the official compiler does not erase them either —
-/// a class index signature makes it throw, and `import … = require(…)` /
-/// `export =` / `export as namespace` are passed through verbatim.
+/// The three node kinds below are deliberately *not* walked, because the
+/// official compiler passes `import … = require(…)` / `export =` /
+/// `export as namespace` through verbatim.
 ///
-/// The generic walk reaches everything by default, so leaving them alone now
-/// takes an explicit no-op override. Dropping the `TSIndexSignature` one turns
-/// `class A { [key: string]: unknown; }` into `class A { [key]; }` — a bogus
-/// field the bundler happily accepts — which is what these tests guard. The
-/// other three currently hold no annotation for the walk to delete, so their
-/// overrides are guards rather than live fixes; the tests pin the pass-through
-/// either way.
+/// The generic walk reaches everything by default, so leaving them alone takes
+/// an explicit no-op override. None of the three currently holds an annotation
+/// for the walk to delete, so their overrides are guards rather than live fixes;
+/// the tests pin the pass-through either way.
 ///
 /// Each case pairs the construct with an ordinary annotated declaration, so a
 /// pass also proves the collector really walked the program rather than bailing
@@ -159,9 +155,26 @@ fn assert_left_alone(construct: &str) {
     );
 }
 
+/// A class index signature is the one member the walk must remove WHOLE rather
+/// than leave behind: deleting only its `typeAnnotation` would leave `[key];`,
+/// which is the shape upstream's eraser produces and then crashes esrap on. See
+/// `compatibility/deliberate-divergences.md` and
+/// `crates/rsvelte_core/tests/ts_index_signature_3422.rs`.
 #[test]
-fn class_index_signature_is_left_alone() {
-    assert_left_alone("class A { [key: string]: unknown; }");
+fn class_index_signature_is_erased_whole() {
+    let out = strip_typescript("class A { [key: string]: unknown; }\nconst n: number = 1;\n");
+    assert!(
+        !out.contains("[key"),
+        "the index signature survived in some form:\n{out}"
+    );
+    assert!(
+        out.contains("class A {"),
+        "the class itself was dropped:\n{out}"
+    );
+    assert!(
+        out.contains("const n = 1;"),
+        "the collector never reached the rest of the program:\n{out}"
+    );
 }
 
 #[test]

--- a/crates/rsvelte_core/tests/ts_index_signature_3422.rs
+++ b/crates/rsvelte_core/tests/ts_index_signature_3422.rs
@@ -1,0 +1,164 @@
+//! Pins the deliberate divergence recorded in
+//! `compatibility/deliberate-divergences.md`: a TypeScript **class index
+//! signature** is erased, the way an interface and a type alias already are.
+//!
+//! It is type-only and has no runtime representation. The official compiler
+//! neither erases it nor prints it: `remove_typescript_nodes.js` deletes its
+//! `typeAnnotation` while `ClassBody` keeps the node, and esrap's
+//! `TSIndexSignature` printer then reads `.type` off `undefined` — a bare
+//! `TypeError` with no code, no position and no frame. There is no output to be
+//! byte-equal to.
+//!
+//! The previous behaviour was a deliberate parity choice ("upstream passes these
+//! through verbatim"), and it shipped two defects: the client emitted TypeScript
+//! into a `.js` artifact, and the server discarded the whole instance script
+//! because the erased source no longer parsed as JavaScript.
+
+use rsvelte_core::{CompileOptions, GenerateMode, compile};
+
+fn compile_target(src: &str, generate: GenerateMode, dev: bool) -> String {
+    compile(
+        src,
+        CompileOptions {
+            generate,
+            dev,
+            filename: Some("A.svelte".to_string()),
+            ..Default::default()
+        },
+    )
+    .expect("compile")
+    .js
+    .code
+}
+
+fn parse_errors(code: &str) -> Vec<String> {
+    let allocator = oxc_allocator::Allocator::default();
+    oxc_parser::Parser::new(&allocator, code, oxc_span::SourceType::mjs())
+        .parse()
+        .diagnostics
+        .iter()
+        .map(|d| d.to_string())
+        .collect()
+}
+
+#[track_caller]
+fn assert_parses(code: &str, what: &str) {
+    let errors = parse_errors(code);
+    assert!(
+        errors.is_empty(),
+        "{what}: emitted JS does not parse: {errors:?}\n--- output ---\n{code}"
+    );
+}
+
+const TARGETS: [(&str, GenerateMode, bool); 3] = [
+    ("client", GenerateMode::Client, false),
+    ("client-dev", GenerateMode::Client, true),
+    ("server", GenerateMode::Server, false),
+];
+
+/// The divergence is only worth taking if the alternative really is invalid, so
+/// the checker has to reject the text rsvelte declines to emit.
+#[test]
+fn the_verbatim_shape_is_rejected_by_the_parser_used_here() {
+    for shape in [
+        "class K { [k: string]: unknown }",
+        "class K { readonly [k: string]: unknown }",
+        "class K { static [k: string]: unknown }",
+    ] {
+        assert!(
+            !parse_errors(shape).is_empty(),
+            "the parser accepts {shape}, so it cannot witness this divergence"
+        );
+    }
+}
+
+/// Every spelling, every class host, every entry point, every target.
+#[test]
+fn a_class_index_signature_is_erased() {
+    let members = [
+        ("string-key", "[k: string]: unknown"),
+        ("number-key", "[k: number]: string"),
+        ("readonly", "readonly [k: string]: unknown"),
+        ("static", "static [k: string]: unknown"),
+        ("trailing-semi", "[k: string]: unknown;"),
+        ("two", "[k: string]: unknown; [n: number]: string"),
+        ("with-field", "[k: string]: unknown;\n\t\tname = 1"),
+        (
+            "with-method",
+            "[k: string]: unknown;\n\t\tm() { return 1; }",
+        ),
+    ];
+    let hosts = [
+        ("class-decl", "class K {\n\t\t{M}\n\t}\n\tvoid K;"),
+        ("class-expr", "const K = class {\n\t\t{M}\n\t};\n\tvoid K;"),
+        (
+            "with-state",
+            "class K {\n\t\t{M}\n\t\tcount = $state(0);\n\t}\n\tvoid K;",
+        ),
+    ];
+    let entries = [
+        (
+            "instance",
+            "<script lang=\"ts\">\n\t{B}\n</script>\n<b>x</b>\n",
+        ),
+        (
+            "module",
+            "<script module lang=\"ts\">\n\t{B}\n</script>\n<b>x</b>\n",
+        ),
+    ];
+
+    for (m_name, member) in members {
+        for (h_name, host) in hosts {
+            for (e_name, entry) in entries {
+                let src = entry.replace("{B}", &host.replace("{M}", member));
+                for (target, generate, dev) in TARGETS {
+                    let what = format!("{m_name} / {h_name} / {e_name} / {target}");
+                    let out = compile_target(&src, generate, dev);
+                    assert_parses(&out, &what);
+                    // The whole script must still be there — the server's failure
+                    // mode was output that parses and is empty.
+                    assert!(
+                        out.contains("void K;"),
+                        "{what}: the script was dropped:\n{out}"
+                    );
+                    assert!(
+                        !out.contains(": unknown") && !out.contains("[k:"),
+                        "{what}: TypeScript reached the JS output:\n{out}"
+                    );
+                }
+            }
+        }
+    }
+}
+
+/// Controls: the TypeScript-only class members that were already erased
+/// correctly must not move, or the fix is paying for one member kind with its
+/// neighbours.
+#[test]
+fn the_neighbouring_members_are_unaffected() {
+    for member in [
+        "declare x: number",
+        "y?: number",
+        "z!: number",
+        "private p = 1",
+        "protected q = 1",
+        "public r = 1",
+        "readonly s = 1",
+        "m(a: number): number { return a; }",
+        "g<T>(a: T): T { return a; }",
+        "get v(): number { return 1; }",
+        "name = 1",
+    ] {
+        let src = format!(
+            "<script lang=\"ts\">\n\tclass K {{\n\t\t{member}\n\t}}\n\tvoid K;\n</script>\n<b>x</b>\n"
+        );
+        for (target, generate, dev) in TARGETS {
+            let out = compile_target(&src, generate, dev);
+            assert_parses(&out, &format!("control {member} / {target}"));
+            assert!(
+                out.contains("void K;"),
+                "control {member} / {target}: the script was dropped:\n{out}"
+            );
+        }
+    }
+}

--- a/upstream_issues/3422-svelte-class-index-signature-crash.md
+++ b/upstream_issues/3422-svelte-class-index-signature-crash.md
@@ -1,0 +1,63 @@
+# A TypeScript class index signature crashes the compiler with a bare `TypeError`
+
+A class **index signature** — `[k: string]: unknown` — makes `svelte.compile` throw a
+`TypeError` with no `code`, no position and no frame, on every target.
+
+```svelte
+<script lang="ts">
+	class K { [k: string]: unknown }
+	void K;
+</script>
+<b>x</b>
+```
+
+```
+TypeError: Cannot read properties of undefined (reading 'type')
+    at Context.visit (esrap/src/context.js:90:39)
+    at TSIndexSignature (esrap/src/languages/ts/index.js:2004:12)
+```
+
+Measured against `submodules/svelte` at 5.56.9 with esrap 2.2.12.
+
+## Cause
+
+`phases/1-parse/remove_typescript_nodes.js` erases type-only syntax with a catch-all visitor that
+deletes `typeAnnotation` wherever it finds one, and its `ClassBody` visitor keeps every child that
+is not a `declare` `PropertyDefinition`. A `TSIndexSignature` is neither removed nor emptied: it
+survives into the printed program with its `typeAnnotation` gone. esrap's `TSIndexSignature`
+printer then visits that field unguarded, and `Context.visit` reads `.type` off `undefined`.
+
+So the two halves disagree — the eraser assumes nothing will print a `TSIndexSignature`, and the
+printer assumes nothing will delete its `typeAnnotation`.
+
+## Reproduces on
+
+Every spelling and every host, on `client`, `client` + `dev` and `server`:
+
+| member | crashes |
+|---|---|
+| `[k: string]: unknown` | yes |
+| `[k: number]: string` | yes |
+| `readonly [k: string]: unknown` | yes |
+| `static [k: string]: unknown` | yes |
+| two index signatures in one body | yes |
+| an index signature beside a `$state` field | yes |
+| the same, in a class **expression** | yes |
+| the same, in `<script module lang="ts">` | yes |
+
+## Controls
+
+Eleven other TypeScript-only class-body constructs compile cleanly on all three targets:
+`declare x: number`, `y?: number`, `z!: number`, `private` / `protected` / `public` / `readonly`
+modifiers, a typed method, a generic method, a typed getter, and a plain field. So this is one
+member kind, not TypeScript erasure in general.
+
+## Desired upstream behavior
+
+Drop a `TSIndexSignature` from a `ClassBody` the way `remove_typescript_nodes.js` already drops a
+`TSInterfaceDeclaration` and a `TSTypeAliasDeclaration`. An index signature is type-only and has no
+runtime representation; TypeScript's own emit removes it.
+
+rsvelte erases it, so rsvelte compiles these inputs and upstream does not — there is no output to
+be byte-equal to. No corpus entry carries the shape, because a component containing one cannot be
+built with the official compiler at all.


### PR DESCRIPTION
Closes #3422

A TypeScript **class index signature** — `[k: string]: unknown` — was copied into the generated
JavaScript, so the `client` output did not parse. The direct sibling of #3421 (PR #3496): the same
family of "a TypeScript-only construct is not erased and leaks into a `.js` artifact".

## The report understated the server half — measured

The issue says `server` strips it correctly (`class K {}`). It does not. On `main`:

```js
/* rsvelte, generate: 'server' */
import * as $ from 'svelte/internal/server';

export default function A($$renderer) {
	$$renderer.push(`<b>x</b>`);
}
```

`class K` **and** `void K;` are both gone. This is the #3421 mechanism again: the server re-parses
the **erased** script to classify its statements, that parse rejects the surviving TypeScript, and
the body is discarded — output that parses and does nothing, which no gate can observe. (#3496
makes that failure loud; this PR removes its cause, so the two compose.)

## Fix

One visitor in `2_analyze/types.rs`:

```rust
fn visit_ts_index_signature(&mut self, it: &TSIndexSignature<'a>) {
    self.remove(it.span);
}
```

It removes the member **whole**. That distinction is the whole fix: the previous code's comment
argued that dropping it "turns `class A { [key: string]: unknown; }` into `class A { [key]; }` —
a bogus field" — true of deleting only the `typeAnnotation` (which is what upstream's generic
eraser does, and why esrap then crashes), and not true of removing the node. Measured output is
`class A {  }`.

## Why this is not upstream parity, and why the old code thought it was

`types.rs` carried:

> Upstream passes these through verbatim (a class index signature even makes it throw), so they
> are left exactly as written.

Locally reasonable, and wrong: **"upstream throws" is not an output to be equal to.** The official
compiler produces no artifact at all —

```
TypeError: Cannot read properties of undefined (reading 'type')
    at Context.visit (esrap/src/context.js:90:39)
    at TSIndexSignature (esrap/src/languages/ts/index.js:2004:12)
```

— no `code`, no position, no frame, so not even the error ratchets have a key for it.
`remove_typescript_nodes.js` deletes the signature's `typeAnnotation` while `ClassBody` keeps the
node, and esrap's printer then visits that field unguarded: the two halves disagree.

Recorded in `compatibility/deliberate-divergences.md` and reported in
`upstream_issues/3422-svelte-class-index-signature-crash.md`.

## Measurement — grid, before → after

8 index-signature spellings + 11 TypeScript-only control members × 3 class hosts (declaration,
expression, one also carrying a `$state` field) × 2 entry points (instance script,
`<script module>`) × 3 targets = **342 cells**, each compiled with rsvelte and each output run
through acorn.

| | before | after |
|---|---|---|
| rsvelte output rejected by acorn | 96 | **0** |
| TypeScript left in the `.js` output | 96 | **0** |
| instance/module script silently dropped (`server`) | 48 | **0** |
| control cells clean | 198 | 198 |

96 = 8 spellings × 3 hosts × 2 entries × 2 client targets; 48 = the same × the `server` target.
The 198 control cells — `declare x: number`, `y?: number`, `z!: number`, the four accessibility /
`readonly` modifiers, a typed method, a generic method, a typed getter, a plain field — were clean
before and are clean after, so the fix is not paying for one member kind with its neighbours.

Spot-checked beyond parseability: `static [k: string]: unknown` → `class K {}`; two signatures in
one body → `class K {}`; a signature beside `name = 1` → `class K { name = 1; }`; a signature
beside `count = $state(0)` → the usual `#count = $.state(0)` getter/setter lowering, unchanged.

## Negative control

With the visitor reverted, `a_class_index_signature_is_erased` fails on the first cell with the
emitted `class K {\n\t\t[k: string]: unknown\n\t}` and an acorn rejection — the predicted leak, not
some other failure. `the_verbatim_shape_is_rejected_by_the_parser_used_here` and
`the_neighbouring_members_are_unaffected` stay **green** under the revert, so neither is witnessing
the fix.

## An existing test pinned the old behaviour

`ts_erasure_visitor_coverage::class_index_signature_is_left_alone` asserted the pass-through. It is
replaced by `class_index_signature_is_erased_whole`, which pins the new shape *and* the reason —
that the node must go whole rather than lose only its annotation. Its doc comment (which described
"four node kinds deliberately not walked") is corrected to three; the remaining three
(`import … = require(…)`, `export =`, `export as namespace`) really are upstream pass-through and
are untouched.

## Gates run

`ts_index_signature_3422`, `ts_erasure_visitor_coverage`, `ssr_typescript_erasure`,
`module_compile_ts_strip`, `ts_svelte_ignore_suppression`,
`typescript_strip_recoverable_parse_error`, `compiler_errors`, `validator` — all green.

## Relationship to #3496

Independent files, and they compose in one direction: #3496 (#3421) turns the server's silent
script drop into a compile error; this PR removes the input that reaches it. Neither depends on the
other landing first.
