### PR TITLE
fix(parse): end a tag where upstream ends it, and close one level per new tag

### DIFF
--- a/.changeset/tag-scanning-closers.md
+++ b/.changeset/tag-scanning-closers.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/compiler": patch
+---
+
+End a tag where the official compiler ends it. A closing tag now requires its `>` after the name and optional whitespace, so `</div x>` is `expected_token` instead of compiling with the junk silently dropped — `<textarea>` keeps taking everything up to the `>`, because upstream's closer for it really is `/<\/textarea(\s[^>]*)?>/i`. What sits between `</style` and the `>` is template text again (`<style>…</style x>` renders `x>`), since upstream reads `/\s*>/y` and consumes nothing when no `>` follows. A root `<script>` is no longer closed by `</script x>`, matching upstream's `/<\/script\s*>/`, and the resulting `element_unclosed` is reported at the end of the right-trimmed template. And a new tag now closes exactly one element: `<optgroup>` after a nested `<option>` popped the whole ancestor chain, so the new group became a sibling of the old one instead of its child. `p`'s auto-closing table also loses `details`, `figcaption` and `figure`, which upstream's `autoclosing_children` does not list.

--- a/crates/rsvelte_core/src/compiler/phases/1_parse/parser.rs
+++ b/crates/rsvelte_core/src/compiler/phases/1_parse/parser.rs
@@ -143,6 +143,11 @@ pub struct Parser<'a> {
     ///
     /// Corresponds to `last_auto_closed_tag` field in JavaScript Parser.
     pub(crate) last_auto_closed_tag: Option<LastAutoClosedTag>,
+    /// Offset of the `<` whose tag already closed an element implicitly.
+    /// Upstream pops exactly once per new tag; rsvelte re-enters the check from
+    /// each enclosing element's read loop, so without this one tag would walk
+    /// the whole ancestor chain.
+    pub(crate) implicit_close_at: Option<usize>,
     /// Parser-level warnings (e.g., element_implicitly_closed).
     pub(crate) parse_warnings: Vec<crate::ast::template::ParseWarning>,
     /// JS-style comments collected across the parse. Mirrors upstream
@@ -281,6 +286,7 @@ impl<'a> Parser<'a> {
             in_svelte_options: false,
             meta_tags: FxHashMap::default(),
             last_auto_closed_tag: None,
+            implicit_close_at: None,
             parse_warnings: Vec::new(),
             root_comments: std::cell::RefCell::new(Vec::new()),
             arena: ParseArena::new(),
@@ -324,6 +330,7 @@ impl<'a> Parser<'a> {
         self.pending_leading_comments.clear();
         self.meta_tags.clear();
         self.last_auto_closed_tag = None;
+        self.implicit_close_at = None;
         self.parse_warnings.clear();
         self.root_comments.borrow_mut().clear();
         self.depth = 0;

--- a/crates/rsvelte_core/src/compiler/phases/1_parse/read/script.rs
+++ b/crates/rsvelte_core/src/compiler/phases/1_parse/read/script.rs
@@ -19,7 +19,7 @@ use crate::ast::template::{
 };
 use crate::error::ParseResult;
 
-use super::super::parser::Parser;
+use super::super::parser::{Parser, is_js_whitespace};
 
 /// Ensure a Script's content has been fully parsed from raw_content.
 /// This performs the deferred OXC parse. Call this before accessing script.content in analysis.
@@ -132,6 +132,16 @@ impl<'a> Parser<'a> {
         })]
     }
 
+    /// Whether `/\s*>/` matches at `i` — upstream's closing-`<script>` regex
+    /// tail, which junk before the `>` fails.
+    fn script_closer_at(&self, i: usize) -> bool {
+        let mut i = i;
+        while self.is_js_whitespace_at(i) {
+            i += self.source[i..].chars().next().map_or(1, |c| c.len_utf8());
+        }
+        self.bytes.get(i) == Some(&b'>')
+    }
+
     /// Parse a `<script>` tag and store it in instance_script or module_script.
     ///
     /// `self_closing` is only ever `true` in lenient (lint) mode, where a
@@ -151,7 +161,9 @@ impl<'a> Parser<'a> {
             loop {
                 if let Some(offset) = SCRIPT_END_FINDER.find(&self.bytes[self.index..]) {
                     self.index += offset;
-                    if self.is_valid_closing_tag("</script") {
+                    // Upstream stops on `/<\/script\s*>/`: junk before the `>`
+                    // does not close the script, it runs to EOF instead.
+                    if self.script_closer_at(self.index + 8) {
                         break;
                     }
                     // Not a valid closing tag (e.g., </scripting), skip past it
@@ -171,8 +183,7 @@ impl<'a> Parser<'a> {
             // Nothing to consume — the self-closing `/>` was already eaten.
         } else if self.match_str("</script") {
             self.advance_by(8); // consume '</script'
-            // Skip whitespace before >
-            while !self.is_eof() && self.current_char() != '>' {
+            while !self.is_eof() && is_js_whitespace(self.current_char()) {
                 self.advance();
             }
             self.eat_optional(">"); // consume '>'
@@ -182,10 +193,13 @@ impl<'a> Parser<'a> {
             // If it's empty/only whitespace at EOF, it's unexpected_eof
             let has_html_content = script_content.contains('<') || script_content.contains('{');
             if has_html_content {
+                // Upstream reports at `template.length`, and its template is
+                // right-trimmed.
+                let at = self.content_end;
                 return Err(crate::error::ParseError::svelte(
                     "element_unclosed",
                     "`<script>` was left open",
-                    (self.index, self.index),
+                    (at, at),
                 ));
             } else {
                 return Err(crate::error::ParseError::svelte(

--- a/crates/rsvelte_core/src/compiler/phases/1_parse/read/style.rs
+++ b/crates/rsvelte_core/src/compiler/phases/1_parse/read/style.rs
@@ -325,14 +325,17 @@ impl<'a> Parser<'a> {
             }
         }
 
-        // Consume </style followed by optional whitespace and >
         if self.match_str("</style") {
             self.advance_by(7); // consume '</style'
-            // Skip whitespace before >
-            while !self.is_eof() && self.current_char() != '>' {
+            // Upstream reads `/\s*>/y`, so the run is consumed only when a `>`
+            // really follows: `</style x>` leaves ` x>` as template text.
+            let after_name = self.index;
+            while !self.is_eof() && is_js_whitespace(self.current_char()) {
                 self.advance();
             }
-            self.eat_optional(">"); // consume '>'
+            if !self.eat_optional(">") {
+                self.index = after_name;
+            }
         } else if self.is_eof() {
             // Style tag was not closed - check if there was invalid '<' in content
             if let Some(lt_pos) = first_invalid_lt {

--- a/crates/rsvelte_core/src/compiler/phases/1_parse/state/element.rs
+++ b/crates/rsvelte_core/src/compiler/phases/1_parse/state/element.rs
@@ -382,15 +382,18 @@ impl<'a> Parser<'a> {
                 let closing_name = &self.source[cn_start..cn_end];
                 if closing_name == name.as_str() {
                     found_closing_tag = true;
-                    // For raw text elements, the closing tag might have garbage before >
-                    // (e.g., </textarea\n\n\n</textarea\n\n>)
-                    // Scan forward to find the actual >
                     if is_raw_text_element {
+                        // `/<\/textarea(\s[^>]*)?>/i`: once whitespace follows the
+                        // name, everything up to the `>` belongs to the closer.
                         while !self.is_eof() && self.current_char() != '>' {
                             self.advance();
                         }
+                        self.eat_optional(">");
+                    } else {
+                        // Upstream `parser.eat('>', true)` — a closing tag carries
+                        // nothing but whitespace between the name and the `>`.
+                        self.expect(">")?;
                     }
-                    self.eat_optional(">"); // consume '>'
 
                     // Upstream clears `last_auto_closed_tag` once a closing tag
                     // pops the stack below the depth recorded when the tag was
@@ -485,6 +488,7 @@ impl<'a> Parser<'a> {
                 // `block_invalid_continuation_placement` before reaching here.)
                 found_closing_tag = true;
             } else if let Some(reason) = self.should_implicitly_close() {
+                self.implicit_close_at = Some(self.index);
                 // Element was implicitly closed by the next element (sibling).
                 // Emit element_implicitly_closed warning.
                 // Corresponds to element.js L203-205:
@@ -972,12 +976,9 @@ impl<'a> Parser<'a> {
                 "article",
                 "aside",
                 "blockquote",
-                "details",
                 "div",
                 "dl",
                 "fieldset",
-                "figcaption",
-                "figure",
                 "footer",
                 "form",
                 "h1",
@@ -1012,6 +1013,12 @@ impl<'a> Parser<'a> {
 
         // Check if the next tag would implicitly close the current element
         if !self.match_byte(b'<') || self.match_str("</") || self.match_str("<!") {
+            return None;
+        }
+
+        // Upstream pops exactly one level per new tag, so a tag that has already
+        // closed an element must not walk further up the ancestor chain.
+        if self.implicit_close_at == Some(self.index) {
             return None;
         }
 

--- a/crates/rsvelte_core/tests/tag_scanning_3393_3395_3450.rs
+++ b/crates/rsvelte_core/tests/tag_scanning_3393_3395_3450.rs
@@ -1,0 +1,176 @@
+//! Regression tests for #3393 (a closing tag accepted arbitrary text before the
+//! `>`), #3395 (text after `</style` was dropped instead of becoming a text
+//! node) and #3450 (one new tag popped the whole ancestor chain, and `p`'s
+//! closer list carried three tags upstream does not have).
+//!
+//! Every expectation was taken from the official compiler (`submodules/svelte`,
+//! v5.56.9) with `generate: 'client', css: 'external'`.
+
+use rsvelte_core::{CompileOptions, GenerateMode, compile, compiler::CssMode};
+
+fn opts() -> CompileOptions {
+    CompileOptions {
+        filename: Some("input.svelte".to_string()),
+        generate: GenerateMode::Client,
+        dev: false,
+        css: CssMode::External,
+        ..Default::default()
+    }
+}
+
+/// `code@start-byte` for a rejected source, `<ok>` for one that compiles.
+fn err(src: &str) -> String {
+    match compile(src, opts()) {
+        Ok(_) => "<ok>".to_string(),
+        Err(e) => {
+            let d = e.diagnostic();
+            format!(
+                "{}@{}",
+                d.code.as_deref().unwrap_or("<none>"),
+                d.span.map_or(-1, |(s, _)| i64::from(s))
+            )
+        }
+    }
+}
+
+fn js(src: &str) -> String {
+    compile(src, opts()).expect("compile").js.code
+}
+
+// ---------------------------------------------------------------------------
+// #3393 — a closing tag carries nothing but whitespace before the `>`
+// ---------------------------------------------------------------------------
+
+#[test]
+fn junk_between_a_closing_tag_name_and_its_bracket_is_rejected() {
+    // Upstream reads the name, allows whitespace, then `parser.eat('>', true)`,
+    // so the error lands on the first character that is not the `>`.
+    assert_eq!(err("<div>y</div x>"), "expected_token@12");
+    assert_eq!(err("<div>y</div a=b>"), "expected_token@12");
+    assert_eq!(err("<div>y</div />"), "expected_token@12");
+    assert_eq!(err("<x-a>y</x-a z>"), "expected_token@12");
+    assert_eq!(err("<svelte:boundary>y</svelte:boundary x>"), {
+        let at = "<svelte:boundary>y</svelte:boundary ".len();
+        format!("expected_token@{at}")
+    });
+    assert_eq!(
+        err("<svelte:head><title>t</title x></svelte:head>"),
+        format!("expected_token@{}", "<svelte:head><title>t</title ".len())
+    );
+}
+
+#[test]
+fn a_closing_tag_still_takes_whitespace_and_a_component_name() {
+    // The controls: whitespace before the `>` is legal, and the rejection is
+    // not about which element it is.
+    assert_eq!(err("<div>y</div >"), "<ok>");
+    assert_eq!(err("<div\n>y</div\n>"), "<ok>");
+    assert_eq!(err("<div>y</div>"), "<ok>");
+}
+
+#[test]
+fn a_textarea_closer_keeps_taking_everything_up_to_the_bracket() {
+    // Upstream's closer is `/<\/textarea(\s[^>]*)?>/i`, so unlike every other
+    // element the junk belongs to the closing tag.
+    assert_eq!(err("<textarea>y</textarea x>"), "<ok>");
+    assert_eq!(err("<textarea>y</textarea>"), "<ok>");
+}
+
+#[test]
+fn a_root_script_is_not_closed_by_a_closer_carrying_junk() {
+    // `read_script` reads until `/<\/script\s*>/`; `</script x>` is not that,
+    // so the script runs to the end of the (right-trimmed) template.
+    let src = "<script x>let a=1;</script x>\n";
+    assert_eq!(
+        err(src),
+        format!("element_unclosed@{}", src.trim_end().len())
+    );
+    assert_eq!(err("<script>let a=1;</script >"), "<ok>");
+}
+
+// ---------------------------------------------------------------------------
+// #3395 — what sits between `</style` and the `>` is template text
+// ---------------------------------------------------------------------------
+
+#[test]
+fn text_after_a_style_closer_survives() {
+    // Upstream eats `</style` and then reads `/\s*>/y`, which does not match
+    // here — so the leftover is markup, not part of the tag.
+    assert!(js("<style>a{color:red}</style x>").contains("'x>'"));
+    assert!(js("<style>a{color:red}</style x y>").contains("'x y>'"));
+    assert!(js("<style>a{color:red}</style x>after").contains("'x>after'"));
+    // A following sibling is compiled into a different template, not merely
+    // preceded by a lost text node.
+    assert!(js("<style>a{color:red}</style x><b>sib</b>").contains("x><b>sib</b>"));
+}
+
+#[test]
+fn a_style_closer_with_only_whitespace_is_consumed_whole() {
+    let out = js("<style>a{color:red}</style ><b>sib</b>");
+    assert!(!out.contains("'>'"), "{out}");
+    assert!(out.contains("<b>sib</b>"), "{out}");
+}
+
+// ---------------------------------------------------------------------------
+// #3450 — one pop per new tag, and `p`'s closer list
+// ---------------------------------------------------------------------------
+
+#[test]
+fn a_new_tag_closes_one_level_not_the_whole_ancestor_chain() {
+    // `<optgroup h>` closes the `<option>` and becomes a child of `<optgroup
+    // g>`; upstream then rejects that placement. Before the fix rsvelte popped
+    // `<optgroup g>` as well, making them siblings — and compiling.
+    let src = "<select><optgroup label=\"g\"><option>a<optgroup label=\"h\"><option>b</select>";
+    assert_eq!(
+        err(src),
+        format!(
+            "node_invalid_placement@{}",
+            "<select><optgroup label=\"g\"><option>a".len()
+        )
+    );
+    // The same rule one level shallower still closes exactly one `<option>`.
+    assert_eq!(
+        err("<select><optgroup label=\"g\"><option>a<option>b</select>"),
+        "<ok>"
+    );
+}
+
+#[test]
+fn details_figure_and_figcaption_do_not_close_a_paragraph() {
+    // Upstream's `autoclosing_children.p.descendant` does not list them, so the
+    // `<p>` stays open and is unclosed at EOF.
+    for src in [
+        "<p>a<details>b</details>",
+        "<p>a<figure>b</figure>",
+        "<p>a<figcaption>b</figcaption>",
+    ] {
+        assert_eq!(err(src), "element_unclosed@0", "{src}");
+    }
+}
+
+#[test]
+fn the_rest_of_the_closer_table_is_unchanged() {
+    // The positive controls for the same table: every other entry still
+    // auto-closes exactly one level. The verdicts are official's, which is why
+    // three of them are not `<ok>` — an auto-closed `<p>` leaves the second one
+    // open, and a `<tr>` / `<optgroup>` that lands one level up is rejected by
+    // the placement check rather than by the parser.
+    for (src, expected) in [
+        ("<p>a<div>b</div>", "<ok>"),
+        ("<ul><li>a<li>b</ul>", "<ok>"),
+        ("<dl><dt>a<dd>b<dt>c</dl>", "<ok>"),
+        ("<ruby><rt>a<rp>b</ruby>", "<ok>"),
+        ("<p>a<p>b", "element_unclosed@4"),
+        (
+            "<table><tr><td>a<tr><td>b</table>",
+            "node_invalid_placement@7",
+        ),
+        (
+            "<table><tbody><tr><td>a<tr><td>b</tbody></table>",
+            "node_invalid_placement@23",
+        ),
+    ] {
+        assert_eq!(err(src), expected, "{src}");
+    }
+    assert!(js("<p>a<div>b</div>").contains("<p>a</p><div>b</div>"));
+}


### PR DESCRIPTION
Closes #3393. Closes #3395. Closes #3450.

Four scans answered "where does this tag end / what does this tag close", and each answered
differently from upstream. They are one PR because they are one file and one question, and
because two of them are only visible through each other: `<style>…</style x>` is #3393's row 12
and #3395's whole subject.

## What each one was

| | rsvelte before | upstream |
|---|---|---|
| a closing tag's `>` | `eat_optional`, so `</div x>` compiled and the junk vanished | `parser.eat('>', true)` |
| `</style` tail | scan to the next `>`, discarding what sat between | `parser.read(/\s*>/y)` — consumes nothing when no `>` follows |
| root `</script` | same scan | `read_until(/<\/script\s*>/)` — junk means the script never closes |
| a new tag's pop | re-entered from each enclosing element's read loop | exactly one `parser.pop()` per tag |

`<textarea>` is the exception that had to stay: upstream's closer for it really is
`/<\/textarea(\s[^>]*)?>/i`, so junk before the `>` belongs to the closing tag there and nowhere
else. That row is the reason this is not one blanket "require `>`" — it is four rules, and the
grid contains the control that separates them.

`p`'s auto-closing table also loses `details`, `figcaption` and `figure`. Upstream's
`autoclosing_children.p.descendant` does not list them, so `<p>a<details>` leaves the `<p>` open
and unclosed at EOF, which is `element_unclosed` rather than a silently different tree.

## Measurements

Official vs rsvelte, `js` + `css` + warnings (or the error code and position), client and server:

| grid | before | after |
|---|---|---|
| #3393's 14 tag shapes | 4/28 cells | **28/28** |
| #3395's 6 sources | 2/12 cells | **12/12** |
| #3450's 11 sources | 14/22 cells | **22/22** |
| controls (10 well-formed shapes, incl. `</div >`, `</textarea x>`, `</script >`, `</style >`) | 20/20 | **20/20** |

Suites: `parser_fixtures`, `compiler_errors`, `parser_hardening`, `parser_scanner_lexical`,
`css`, `validator`, `print`, `preprocess`, `sourcemaps`, `ssr`, `runtime` — all pass.
`corpus:matrix` reports **no regressions** (22272 match / 388 known, byte-identical counts to the
run before the change). The pattern corpus compiles **38 diverging of 2091** raw comparisons,
the same 38 as before the change.

## The regression control, because a sweep number is not one

A full-output sweep of every `.svelte` under `submodules/` (4,863 files × 2 targets) reports 599
diverging cells — and **595 of them are diverging without this change too**. The two files in the
delta are `parser-{legacy,modern}/samples/loose-unclosed-open-tag`, and they are **not** this
change: the divergence is `expected_token` at column 0 instead of 2 for `<Comp foo={bar}⏎</div>`,
which is #3486 (the attribute loop breaks on `</` where upstream reads `<` as an attribute name),
raised from `element.rs:304` — a line this PR does not touch (`git diff origin/main` covers 382,
485, 976 and 1016). The control binary that shows those two files clean is a peer agent's build,
which carries a fix for #3486 that `main` does not.

Independently: of the 429 diverging files, **3 carry any shape this change can act on**, and all
three diverge identically under the control binary (a JSDoc indent, a `let {}` printed on one
line, and a `</script-foo>` that neither closer predicate matches).

## No pattern-corpus repro, and the reason is measurable

- **#3393 and #3450 have no input the corpus can hold.** Every source that shows the divergence
  is one official *rejects* (`expected_token`, `element_unclosed`, `node_invalid_placement`), and
  this corpus holds only inputs official accepts. I wrote the accepted half anyway
  (`<select><optgroup><option>a<option>b`, `<ul><li>a<li>b`, `<dl><dt>a<dd>b<dt>c`,
  `<ruby><rt>a<rp>b`) and measured it against the pre-fix binary: **identical on all three
  targets**, i.e. zero discriminating power. It is a control, not a repro, so it is not in the
  tree pretending to be one.
- **#3395's repro exists but the fmt oracle destroys it.** `<style>a{color:red}</style x>` does
  discriminate (pre-fix binary diverges on all three targets, post-fix matches), but
  oxfmt(`svelte: true`) rewrites the file to `<b>sib</b> x>` + `<style></style>` — the CSS body is
  dropped and the text hoisted — and rsvelte-fmt prints something else again. Adding it would
  turn the hard fmt-parity gate red on a formatter question that has nothing to do with this
  change. Same call as the `2n of .a` row in #3130.

All of it lives in `crates/rsvelte_core/tests/tag_scanning_3393_3395_3450.rs` instead, with
official's verdict for every row — including the six that are **not** `<ok>`. Two of those were
wrong in the first draft (I had written `<p>a<p>b` and `<table><tr>…` as compiling), and the
assertions caught it: a grid that only counts matches cannot tell "we agree" from "we agree that
this is an error".
