### PR TITLE
fix(napi): raise option-validation failures as a coded `CompileError`

### DIFF
--- a/.changeset/option-error-compile-error-shape.md
+++ b/.changeset/option-error-compile-error-shape.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/compiler": patch
+---
+
+Raise option-validation failures in upstream's `CompileError` shape. `compile()` and `compileModule()` now throw an error carrying `code: 'options_invalid_value'`, `name: 'CompileError'`, the `filename` that was passed in, and the `https://svelte.dev/e/options_invalid_value` message tail — previously the thrown value was a plain `Error` whose `code` was napi's `"GenericFailure"`, so a consumer branching on `err.code` could not tell an invalid option from any other failure. `customElement`'s message also loses the `, if specified` tail it never had upstream (it is validated by `parametric`, not `boolean`).

--- a/crates/rsvelte_napi/src/lib.rs
+++ b/crates/rsvelte_napi/src/lib.rs
@@ -153,7 +153,12 @@ impl NapiParseOptions {
     /// rejecting a non-boolean with the same message shape as the compile
     /// options.
     fn flag(field: Option<&LenientScalar>, keypath: &str) -> napi::Result<bool> {
-        field.map_or_else(|| Ok(false), |value| coerce_bool(keypath, value))
+        // These are rsvelte-only `parse()` flags — upstream's `parse()` validates
+        // nothing — so there is no upstream code to carry and the message alone
+        // is the whole diagnostic.
+        field
+            .map_or_else(|| Ok(false), |value| coerce_bool(keypath, value))
+            .map_err(|e| napi::Error::from_reason(e.message))
     }
 }
 
@@ -357,7 +362,7 @@ pub fn napi_compile(
     source: String,
     options: Option<NapiCompileOptions>,
 ) -> napi::Result<Value> {
-    let opts = options_to_compile(options)?;
+    let opts = options_to_compile(Some(&env), options)?;
     let filename = opts.filename.clone();
 
     match rust_compile(&source, opts) {
@@ -383,7 +388,7 @@ pub fn napi_compile_both(
     source: String,
     options: Option<NapiCompileOptions>,
 ) -> napi::Result<Value> {
-    let opts = options_to_compile(options)?;
+    let opts = options_to_compile(Some(&env), options)?;
     let filename = opts.filename.clone();
 
     match rust_compile_both(&source, opts) {
@@ -460,7 +465,9 @@ pub async fn napi_compile_with_css_hash(
     if let Some(o) = options.as_mut() {
         o.css_hash = None;
     }
-    let mut opts = options_to_compile(options)?;
+    // An `async` export's arguments must be `Send`; `Env` is not, so this is
+    // the one entry whose option failure cannot carry the coded shape.
+    let mut opts = options_to_compile(None, options)?;
     let filename = opts.filename.clone();
     let handle: css_hash_bridge::Handle =
         std::sync::Arc::new(std::sync::RwLock::new(Some(css_hash)));
@@ -833,11 +840,71 @@ impl napi::bindgen_prelude::ToNapiValue for LenientScalar {
     }
 }
 
-fn invalid_option(detail: impl std::fmt::Display) -> napi::Error {
-    napi::Error::from_reason(format!("Invalid compiler option: {detail}"))
+/// An option-validation failure carried as data.
+///
+/// `napi::Error`'s `code` is its `Status`, a closed enum with no room for
+/// `options_invalid_value`, so the coded shape has to be an object built from an
+/// `Env` — which option parsing does not have. Keeping the failure as a value
+/// lets the entry point raise it in upstream's `CompileError` shape while every
+/// raising site still goes through one constructor.
+struct OptionError {
+    /// `None` is an rsvelte-only refusal, which upstream has no code for;
+    /// `compile_error_object` writes `null` for the same reason.
+    code: Option<&'static str>,
+    message: String,
 }
 
-fn coerce_bool(keypath: &str, v: &LenientScalar) -> napi::Result<bool> {
+impl OptionError {
+    /// Upstream throws these as a `CompileError` with `message`, `name`, `code`
+    /// and (when supplied) `filename` enumerable, and no span — the diagnostic
+    /// node is `null`, so `start`/`end`/`frame` never exist.
+    ///
+    /// `env` is `None` only where one cannot exist — an `async` export's
+    /// arguments must be `Send`, and `Env` is not — and there the failure keeps
+    /// the message but loses the coded shape.
+    fn into_napi(self, env: Option<&Env>, filename: Option<&str>) -> napi::Error {
+        let Some(env) = env else {
+            return napi::Error::from_reason(self.message);
+        };
+        let build = || -> napi::Result<napi::Error> {
+            let mut obj = env.create_error(napi::Error::from_reason(self.message.clone()))?;
+            obj.set("name", "CompileError")?;
+            match self.code {
+                Some(code) => obj.set("code", code)?,
+                None => obj.set("code", napi::bindgen_prelude::Null)?,
+            }
+            if let Some(filename) = filename {
+                obj.set("filename", filename)?;
+            }
+            Ok(napi::Error::from(obj.to_unknown()))
+        };
+        build().unwrap_or_else(|_| napi::Error::from_reason(self.message))
+    }
+}
+
+/// Every option-validation failure upstream raises through
+/// `validate-options.js`'s `throw_error`, which is `e.options_invalid_value`.
+fn invalid_option(detail: impl std::fmt::Display) -> OptionError {
+    OptionError {
+        code: Some("options_invalid_value"),
+        message: format!(
+            "Invalid compiler option: {detail}\nhttps://svelte.dev/e/options_invalid_value"
+        ),
+    }
+}
+
+/// A value upstream accepts that this entry point cannot honour. There is no
+/// upstream code for it because upstream never raises it.
+fn unsupported_option(detail: impl std::fmt::Display) -> OptionError {
+    OptionError {
+        code: None,
+        message: detail.to_string(),
+    }
+}
+
+type OptionResult<T> = Result<T, OptionError>;
+
+fn coerce_bool(keypath: &str, v: &LenientScalar) -> OptionResult<bool> {
     match v {
         LenientScalar::Bool(b) => Ok(*b),
         _ => Err(invalid_option(format!(
@@ -846,7 +913,7 @@ fn coerce_bool(keypath: &str, v: &LenientScalar) -> napi::Result<bool> {
     }
 }
 
-fn coerce_string(keypath: &str, v: &LenientScalar) -> napi::Result<String> {
+fn coerce_string(keypath: &str, v: &LenientScalar) -> OptionResult<String> {
     match v {
         LenientScalar::Str(s) => Ok(s.clone()),
         _ => Err(invalid_option(format!(
@@ -887,7 +954,7 @@ fn coerce_runes(v: &LenientScalar) -> Option<bool> {
 
 /// Returns the mode plus whether the pre-Svelte-5 `dom`/`ssr` spelling was used
 /// (which upstream reports as `options_renamed_ssr_dom`).
-fn coerce_generate(v: &LenientScalar) -> napi::Result<(GenerateMode, bool)> {
+fn coerce_generate(v: &LenientScalar) -> OptionResult<(GenerateMode, bool)> {
     let msg = "generate must be \"client\", \"server\" or false";
     match v {
         LenientScalar::Bool(false) => Ok((GenerateMode::None, false)),
@@ -908,7 +975,7 @@ fn coerce_generate(v: &LenientScalar) -> napi::Result<(GenerateMode, bool)> {
 static WARNED_RENAMED_SSR_DOM: std::sync::atomic::AtomicBool =
     std::sync::atomic::AtomicBool::new(false);
 
-fn coerce_namespace(v: &LenientScalar) -> napi::Result<Namespace> {
+fn coerce_namespace(v: &LenientScalar) -> OptionResult<Namespace> {
     let msg = "namespace should be one of \"html\", \"mathml\" or \"svg\"";
     match v {
         LenientScalar::Str(s) => match s.as_str() {
@@ -921,7 +988,7 @@ fn coerce_namespace(v: &LenientScalar) -> napi::Result<Namespace> {
     }
 }
 
-fn coerce_css(v: &LenientScalar) -> napi::Result<CssMode> {
+fn coerce_css(v: &LenientScalar) -> OptionResult<CssMode> {
     match v {
         LenientScalar::Bool(_) => Err(invalid_option(
             "The boolean options have been removed from the css option. Use \"external\" instead of false and \"injected\" instead of true",
@@ -939,7 +1006,7 @@ fn coerce_css(v: &LenientScalar) -> napi::Result<CssMode> {
     }
 }
 
-fn coerce_fragments(v: &LenientScalar) -> napi::Result<rsvelte_core::compiler::FragmentMode> {
+fn coerce_fragments(v: &LenientScalar) -> OptionResult<rsvelte_core::compiler::FragmentMode> {
     let msg = "fragments should be either \"html\" or \"tree\"";
     match v {
         LenientScalar::Str(s) => match s.as_str() {
@@ -953,7 +1020,7 @@ fn coerce_fragments(v: &LenientScalar) -> napi::Result<rsvelte_core::compiler::F
 
 // Upstream `list([4, 5], 5)` accepts only the numbers 4 and 5 (the string
 // `"4"` is rejected).
-fn coerce_component_api(v: &LenientScalar) -> napi::Result<rsvelte_core::compiler::ComponentApi> {
+fn coerce_component_api(v: &LenientScalar) -> OptionResult<rsvelte_core::compiler::ComponentApi> {
     match v {
         LenientScalar::Number(n) if n.to_bits() == 4.0_f64.to_bits() => {
             Ok(rsvelte_core::compiler::ComponentApi::V4)
@@ -969,7 +1036,7 @@ fn coerce_component_api(v: &LenientScalar) -> napi::Result<rsvelte_core::compile
 
 // Upstream `experimental: object({ async: boolean(false) })`: a non-object is
 // rejected; a missing/`null`/`undefined` `async` keeps the default.
-fn coerce_experimental(v: &LenientScalar) -> napi::Result<ExperimentalOptions> {
+fn coerce_experimental(v: &LenientScalar) -> OptionResult<ExperimentalOptions> {
     if !v.is_object() {
         return Err(invalid_option("experimental should be an object"));
     }
@@ -980,7 +1047,7 @@ fn coerce_experimental(v: &LenientScalar) -> napi::Result<ExperimentalOptions> {
     Ok(exp)
 }
 
-fn coerce_compatibility(v: &LenientScalar) -> napi::Result<rsvelte_core::compiler::ComponentApi> {
+fn coerce_compatibility(v: &LenientScalar) -> OptionResult<rsvelte_core::compiler::ComponentApi> {
     if !v.is_object() {
         return Err(invalid_option("compatibility should be an object"));
     }
@@ -1056,7 +1123,7 @@ impl NapiCompileOptions {
         clippy::too_many_lines,
         reason = "option conversion stays contiguous to make the JavaScript-to-compiler mapping auditable"
     )]
-    fn into_compile_options(self) -> napi::Result<CompileOptions> {
+    fn into_compile_options(self) -> OptionResult<CompileOptions> {
         let mut opts = CompileOptions::default();
         if let Some(v) = &self.dev {
             opts.dev = coerce_bool("dev", v)?;
@@ -1087,7 +1154,12 @@ impl NapiCompileOptions {
             opts.name = Some(coerce_string("name", v)?);
         }
         if let Some(v) = &self.custom_element {
-            opts.custom_element = coerce_bool("customElement", v)?;
+            // `parametric`, not `boolean`: upstream's message has no
+            // ", if specified" tail here.
+            opts.custom_element = match v {
+                LenientScalar::Bool(b) => *b,
+                _ => return Err(invalid_option("customElement should be true or false")),
+            };
         }
         if let Some(v) = &self.accessors {
             opts.accessors = coerce_bool("accessors", v)?;
@@ -1148,8 +1220,8 @@ impl NapiCompileOptions {
         }
         if let Some(v) = &self.css_hash {
             return Err(match v {
-                LenientScalar::Function => napi::Error::from_reason(
-                    "A function-valued `cssHash` cannot be called from this entry point; use `compileWithCssHash` (or `compileAsync`, which routes to it).".to_string(),
+                LenientScalar::Function => unsupported_option(
+                    "A function-valued `cssHash` cannot be called from this entry point; use `compileWithCssHash` (or `compileAsync`, which routes to it).",
                 ),
                 _ => invalid_option("cssHash should be a function, if specified"),
             });
@@ -1192,7 +1264,7 @@ pub struct NapiModuleCompileOptions {
 }
 
 impl NapiModuleCompileOptions {
-    fn into_module_compile_options(self) -> napi::Result<ModuleCompileOptions> {
+    fn into_module_compile_options(self) -> OptionResult<ModuleCompileOptions> {
         let mut opts = ModuleCompileOptions::default();
         if let Some(v) = &self.dev {
             opts.dev = coerce_bool("dev", v)?;
@@ -1220,20 +1292,37 @@ impl NapiModuleCompileOptions {
 /// Compatibility wrapper: convert an Option<NapiCompileOptions> (the
 /// typed surface) into `CompileOptions`. `None` and `Some(empty)`
 /// both produce the defaults.
-fn options_to_compile(opts: Option<NapiCompileOptions>) -> napi::Result<CompileOptions> {
-    opts.map_or_else(
-        || Ok(CompileOptions::default()),
-        NapiCompileOptions::into_compile_options,
-    )
+fn options_to_compile(
+    env: Option<&Env>,
+    opts: Option<NapiCompileOptions>,
+) -> napi::Result<CompileOptions> {
+    let Some(opts) = opts else {
+        return Ok(CompileOptions::default());
+    };
+    // Upstream seeds `state.filename` from the raw option before validating, so
+    // the option error carries it even when a *later* option is what failed.
+    let filename = raw_filename(opts.filename.as_ref());
+    opts.into_compile_options()
+        .map_err(|e| e.into_napi(env, filename.as_deref()))
 }
 
 fn options_to_module_compile(
+    env: Option<&Env>,
     opts: Option<NapiModuleCompileOptions>,
 ) -> napi::Result<ModuleCompileOptions> {
-    opts.map_or_else(
-        || Ok(ModuleCompileOptions::default()),
-        NapiModuleCompileOptions::into_module_compile_options,
-    )
+    let Some(opts) = opts else {
+        return Ok(ModuleCompileOptions::default());
+    };
+    let filename = raw_filename(opts.filename.as_ref());
+    opts.into_module_compile_options()
+        .map_err(|e| e.into_napi(env, filename.as_deref()))
+}
+
+fn raw_filename(v: Option<&LenientScalar>) -> Option<String> {
+    match v {
+        Some(LenientScalar::Str(s)) => Some(s.clone()),
+        _ => None,
+    }
 }
 
 /// Compile a Svelte module (.svelte.js/.svelte.ts).
@@ -1251,7 +1340,7 @@ pub fn napi_compile_module(
     source: String,
     options: Option<NapiModuleCompileOptions>,
 ) -> napi::Result<Value> {
-    let opts = options_to_module_compile(options)?;
+    let opts = options_to_module_compile(Some(&env), options)?;
     let filename = opts.filename.clone();
     match rust_compile_module(&source, opts) {
         Ok(result) => {
@@ -1495,7 +1584,7 @@ pub fn napi_preprocess(
     let extracted = preprocess_bridge::extract_groups(groups)?;
     let rust_groups = preprocess_bridge::build_groups(extracted);
     let filename = match options.as_ref().and_then(|o| o.filename.as_ref()) {
-        Some(v) => Some(coerce_string("filename", v)?),
+        Some(v) => Some(coerce_string("filename", v).map_err(|e| e.into_napi(Some(&env), None))?),
         None => None,
     };
 
@@ -1882,10 +1971,11 @@ pub struct CompileBuffersResult {
 )]
 #[napi(js_name = "compileBuffers", catch_unwind)]
 pub fn napi_compile_buffers(
+    env: Env,
     source: String,
     options: Option<NapiCompileOptions>,
 ) -> napi::Result<CompileBuffersResult> {
-    let opts = options_to_compile(options)?;
+    let opts = options_to_compile(Some(&env), options)?;
     reject_modern_ast_for_binary_result(&opts, "compileBuffers")?;
     match rust_compile(&source, opts) {
         Ok(result) => Ok(CompileBuffersResult {
@@ -1920,10 +2010,11 @@ pub fn napi_compile_buffers(
 )]
 #[napi(js_name = "compileModuleBuffers", catch_unwind)]
 pub fn napi_compile_module_buffers(
+    env: Env,
     source: String,
     options: Option<NapiModuleCompileOptions>,
 ) -> napi::Result<CompileBuffersResult> {
-    let opts = options_to_module_compile(options)?;
+    let opts = options_to_module_compile(Some(&env), options)?;
 
     match rust_compile_module(&source, opts) {
         Ok(result) => Ok(CompileBuffersResult {
@@ -2015,7 +2106,7 @@ pub fn napi_compile_envelope(
     source: String,
     options: Option<NapiCompileOptions>,
 ) -> napi::Result<Buffer> {
-    let opts = options_to_compile(options)?;
+    let opts = options_to_compile(Some(&env), options)?;
     let filename = opts.filename.clone();
     compile_envelope(env, &source, filename.as_deref(), opts, false)
 }
@@ -2035,7 +2126,7 @@ pub fn napi_compile_envelope_external_sources(
     source: String,
     options: Option<NapiCompileOptions>,
 ) -> napi::Result<Buffer> {
-    let opts = options_to_compile(options)?;
+    let opts = options_to_compile(Some(&env), options)?;
     let filename = opts.filename.clone();
     compile_envelope(env, &source, filename.as_deref(), opts, true)
 }
@@ -2177,7 +2268,7 @@ pub fn napi_compile_envelope_zero_copy(
     source: String,
     options: Option<NapiCompileOptions>,
 ) -> napi::Result<JsBuffer> {
-    let opts = options_to_compile(options)?;
+    let opts = options_to_compile(Some(&env), options)?;
     reject_modern_ast_for_binary_result(&opts, "compileEnvelopeZeroCopy")?;
     let result = match rust_compile(&source, opts) {
         Ok(r) => r,
@@ -2201,7 +2292,7 @@ pub fn napi_compile_module_envelope_zero_copy(
     source: String,
     options: Option<NapiModuleCompileOptions>,
 ) -> napi::Result<JsBuffer> {
-    let opts = options_to_module_compile(options)?;
+    let opts = options_to_module_compile(Some(&env), options)?;
     let result = match rust_compile_module(&source, opts) {
         Ok(r) => r,
         Err(e) => return Err(napi::Error::from_reason(format!("{e:?}"))),
@@ -2229,10 +2320,11 @@ pub fn napi_compile_module_envelope_zero_copy(
 )]
 #[napi(js_name = "compileModuleEnvelope", catch_unwind)]
 pub fn napi_compile_module_envelope(
+    env: Env,
     source: String,
     options: Option<NapiModuleCompileOptions>,
 ) -> napi::Result<Buffer> {
-    let opts = options_to_module_compile(options)?;
+    let opts = options_to_module_compile(Some(&env), options)?;
     match rust_compile_module(&source, opts) {
         Ok(result) => {
             // Adapt the module result into the same `CompileResult` shape
@@ -2287,8 +2379,8 @@ pub struct CompileBatchInput {
 ///
 /// Returns an error when options or envelope encoding are invalid.
 #[napi(js_name = "compileBatch", catch_unwind)]
-pub fn napi_compile_batch(inputs: Vec<CompileBatchInput>) -> napi::Result<Buffer> {
-    compile_batch_envelope(inputs, false)
+pub fn napi_compile_batch(env: Env, inputs: Vec<CompileBatchInput>) -> napi::Result<Buffer> {
+    compile_batch_envelope(&env, inputs, false)
 }
 
 /// Batch-compiles with externalized source-map contents.
@@ -2297,11 +2389,15 @@ pub fn napi_compile_batch(inputs: Vec<CompileBatchInput>) -> napi::Result<Buffer
 ///
 /// Returns an error when options or envelope encoding are invalid.
 #[napi(js_name = "compileBatchExternalSources", catch_unwind)]
-pub fn napi_compile_batch_external_sources(inputs: Vec<CompileBatchInput>) -> napi::Result<Buffer> {
-    compile_batch_envelope(inputs, true)
+pub fn napi_compile_batch_external_sources(
+    env: Env,
+    inputs: Vec<CompileBatchInput>,
+) -> napi::Result<Buffer> {
+    compile_batch_envelope(&env, inputs, true)
 }
 
 fn compile_batch_envelope(
+    env: &Env,
     inputs: Vec<CompileBatchInput>,
     externalize_sourcemap_content: bool,
 ) -> napi::Result<Buffer> {
@@ -2311,7 +2407,7 @@ fn compile_batch_envelope(
     // rayon stage focused on the actual compile.
     let parsed: Vec<(String, rsvelte_core::compiler::CompileOptions)> = inputs
         .into_iter()
-        .map(|item| Ok((item.source, options_to_compile(item.options)?)))
+        .map(|item| Ok((item.source, options_to_compile(Some(env), item.options)?)))
         .collect::<napi::Result<_>>()?;
     for (_, options) in &parsed {
         reject_modern_ast_for_binary_result(options, "compileBatch")?;
@@ -2443,10 +2539,11 @@ impl Task for CompileEnvelopeTask {
 )]
 #[napi(js_name = "compileEnvelopeAsync", catch_unwind)]
 pub fn napi_compile_envelope_async(
+    env: Env,
     source: String,
     options: Option<NapiCompileOptions>,
 ) -> napi::Result<AsyncTask<CompileEnvelopeTask>> {
-    let options = options_to_compile(options)?;
+    let options = options_to_compile(Some(&env), options)?;
     reject_modern_ast_for_binary_result(&options, "compileEnvelopeAsync")?;
     Ok(AsyncTask::new(CompileEnvelopeTask {
         source,
@@ -2467,10 +2564,11 @@ pub fn napi_compile_envelope_async(
 )]
 #[napi(js_name = "compileEnvelopeExternalSourcesAsync", catch_unwind)]
 pub fn napi_compile_envelope_external_sources_async(
+    env: Env,
     source: String,
     options: Option<NapiCompileOptions>,
 ) -> napi::Result<AsyncTask<CompileEnvelopeTask>> {
-    let options = options_to_compile(options)?;
+    let options = options_to_compile(Some(&env), options)?;
     reject_modern_ast_for_binary_result(&options, "compileEnvelopeExternalSourcesAsync")?;
     Ok(AsyncTask::new(CompileEnvelopeTask {
         source,
@@ -2543,9 +2641,10 @@ impl Task for CompileBatchTask {
 /// Returns an error when option conversion fails.
 #[napi(js_name = "compileBatchAsync", catch_unwind)]
 pub fn napi_compile_batch_async(
+    env: Env,
     inputs: Vec<CompileBatchInput>,
 ) -> napi::Result<AsyncTask<CompileBatchTask>> {
-    compile_batch_async_task(inputs, false)
+    compile_batch_async_task(&env, inputs, false)
 }
 
 /// Starts an asynchronous batch compile with externalized source-map contents.
@@ -2555,18 +2654,20 @@ pub fn napi_compile_batch_async(
 /// Returns an error when option conversion fails.
 #[napi(js_name = "compileBatchExternalSourcesAsync", catch_unwind)]
 pub fn napi_compile_batch_external_sources_async(
+    env: Env,
     inputs: Vec<CompileBatchInput>,
 ) -> napi::Result<AsyncTask<CompileBatchTask>> {
-    compile_batch_async_task(inputs, true)
+    compile_batch_async_task(&env, inputs, true)
 }
 
 fn compile_batch_async_task(
+    env: &Env,
     inputs: Vec<CompileBatchInput>,
     externalize_sourcemap_content: bool,
 ) -> napi::Result<AsyncTask<CompileBatchTask>> {
     let parsed: Vec<(String, CompileOptions)> = inputs
         .into_iter()
-        .map(|item| Ok((item.source, options_to_compile(item.options)?)))
+        .map(|item| Ok((item.source, options_to_compile(Some(env), item.options)?)))
         .collect::<napi::Result<_>>()?;
     for (_, options) in &parsed {
         reject_modern_ast_for_binary_result(options, "compileBatchAsync")?;

--- a/scripts/dev/test-napi-compile-options.mjs
+++ b/scripts/dev/test-napi-compile-options.mjs
@@ -726,6 +726,102 @@ console.log('\n# boundary result fields');
 }
 
 // ---------------------------------------------------------------------------
+// Option-validation FAILURES: the shape of the error, not that it threw
+// ---------------------------------------------------------------------------
+//
+// The cases above assert that a valid option reaches the compiler. This asserts
+// what happens when it does not: upstream raises every option failure through
+// `validate-options.js`'s `throw_error` -> `e.options_invalid_value(null, msg)`,
+// so the thrown value is a `CompileError` carrying `code`, `name`, `filename`
+// and the `https://svelte.dev/e/…` message tail, with no span (the node is
+// `null`). A consumer branching on `err.code` needs all of that; "it threw" does
+// not distinguish an invalid option from any other failure.
+//
+// The accepting rows are not decoration. A population of only-invalid inputs is
+// blind to over-rejection, which is the opposite failure of the same check.
+
+const INVALID_OPTIONS = [
+	['cssHash-string', { cssHash: 'a-string' }],
+	['cssHash-number', { cssHash: 1 }],
+	['namespace-bogus', { namespace: 'foreign' }],
+	['namespace-number', { namespace: 1 }],
+	['css-true', { css: true }],
+	['css-bogus', { css: 'nope' }],
+	['dev-number', { dev: 1 }],
+	['generate-bogus', { generate: 'nope' }],
+	['customElement-string', { customElement: 'my-el' }],
+	['customElement-number', { customElement: 1 }],
+	['accessors-string', { accessors: 'yes' }],
+	['immutable-number', { immutable: 0 }],
+	['preserveComments-string', { preserveComments: 'y' }],
+	['preserveWhitespace-number', { preserveWhitespace: 1 }],
+	['discloseVersion-string', { discloseVersion: 'n' }],
+	['name-number', { name: 1 }],
+	['outputFilename-number', { outputFilename: 1 }],
+	['cssOutputFilename-bool', { cssOutputFilename: true }],
+	['fragments-bogus', { fragments: 'nope' }],
+	['modernAst-string', { modernAst: 'y' }],
+	['hmr-number', { hmr: 1 }],
+	['rootDir-number', { rootDir: 1 }],
+	['experimental-number', { experimental: 1 }],
+	['experimental-async-string', { experimental: { async: 'y' } }],
+	['compatibility-number', { compatibility: 2 }],
+	['componentApi-3', { compatibility: { componentApi: 3 } }],
+	['componentApi-string', { compatibility: { componentApi: '4' } }],
+];
+
+const VALID_OPTIONS = [
+	['baseline', {}],
+	['css-external', { css: 'external' }],
+	['namespace-svg', { namespace: 'svg' }],
+	['generate-server', { generate: 'server' }],
+	['fragments-tree', { fragments: 'tree' }],
+	['componentApi-4', { compatibility: { componentApi: 4 } }],
+];
+
+function errorShape(compile, opts) {
+	try {
+		compile(CSS_SRC, { filename: 'A.svelte', ...opts });
+		return { threw: false };
+	} catch (e) {
+		return {
+			threw: true,
+			code: e.code === undefined ? '(absent)' : String(e.code),
+			name: String(e.name),
+			filename: e.filename === undefined ? '(absent)' : String(e.filename),
+			message: String(e.message),
+		};
+	}
+}
+
+console.log('\n# option-validation error shape');
+for (const [label, opts] of INVALID_OPTIONS) {
+	const sv = errorShape(officialCompile, opts);
+	const rs = errorShape(napi.compile, opts);
+	if (!sv.threw) {
+		assert(`invalid.${label}: official rejects it`, false, 'the oracle accepted — fix the row');
+		continue;
+	}
+	if (!rs.threw) {
+		assert(`invalid.${label}: rsvelte rejects it too`, false, 'rsvelte compiled it');
+		continue;
+	}
+	for (const field of ['code', 'name', 'filename', 'message']) {
+		assert(
+			`invalid.${label}: ${field}`,
+			rs[field] === sv[field],
+			`official ${JSON.stringify(sv[field])} vs rsvelte ${JSON.stringify(rs[field])}`
+		);
+	}
+}
+for (const [label, opts] of VALID_OPTIONS) {
+	const sv = errorShape(officialCompile, opts);
+	const rs = errorShape(napi.compile, opts);
+	assert(`valid.${label}: official accepts it`, !sv.threw, sv.message);
+	assert(`valid.${label}: rsvelte accepts it`, !rs.threw, rs.message);
+}
+
+// ---------------------------------------------------------------------------
 // Reconcile: declared == covered + uncovered, both directions
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Closes #3467

## What upstream actually does — and the one thing the issue got wrong

`validate-options.js` raises every option failure through `throw_error` →
`e.options_invalid_value(null, msg)`, so the thrown value is a `CompileError` with
`code`, `name`, `filename` and the `https://svelte.dev/e/…` tail, and **no span**
(the diagnostic node is `null`).

The issue says upstream's message carries "no `Invalid compiler option:` prefix".
That is false. `errors.js:57` is

```js
e(node, 'options_invalid_value',
  `Invalid compiler option: ${details}\nhttps://svelte.dev/e/options_invalid_value`);
```

so the prefix **is** upstream's and rsvelte already had it; what rsvelte was
missing is the URL tail, not the prefix. Measured by running the official
compiler, not read off the issue.

**Which official**: the oracle every gate here uses is the pinned submodule,
which is **5.56.9** (`submodules/svelte` is at `20b341f1`; the `svelte@5.56.10`
in `package.json` is an npm devDependency and the submodule bump is still open
as #3195). Every number below is 5.56.9. Cross-checked against the npm 5.56.10
build: the enumerable key set, `code`, `name`, `filename` and the message text
are identical on both, so nothing here depends on which one lands.

Official, `compile('<h1>x</h1>', { filename: 'A.svelte', cssHash: 'a-string' })`:

```
enumerable keys ["message","name","code","filename"]
code            "options_invalid_value"
name            "CompileError"
filename        "A.svelte"
message         "Invalid compiler option: cssHash should be a function, if specified\n
                 https://svelte.dev/e/options_invalid_value"
```

`start` / `end` / `position` / `frame` are absent, because the node is `null`.

## Measurement

39 cells: **30 option values official rejects** × the four fields it carries, plus
**9 it accepts**. The accepting rows are not decoration — a population of
only-invalid inputs is blind to over-rejection, which is the opposite failure of
the same check.

| arm | direction | `code` | `name` | `filename` | `message` | fully agreeing |
|---|---|---|---|---|---|---|
| BEFORE (`origin/main`, md5 `9a69dcae…`) | 0 | **30** | **30** | **30** | **30** | 9/39 |
| AFTER (this PR, md5 `f7c78ff3…`) | 0 | **0** | **0** | **0** | **0** | **39/39** |

**fixed 30 / regressed 0.** `direction` is 0 in both arms — rsvelte accepts and
rejects exactly the same option values as official, before and after; what moved
is only the shape of the error. Each arm ran against a private copy of the
binding, `md5` taken in the same shell call as the build.

The same split shows up in the committed harness, which is the negative control:
against the BEFORE binding `test:napi-options` reports **224 passed → 116 passed,
108 failed**, and the 108 partition as **27 `invalid.*: code` + 27 `name` + 27
`filename` + 27 `message`, with 0 `valid.*` failures** — predicted before running.

## Two findings the issue does not list

1. **`customElement`'s message.** Upstream validates it with `parametric`, not
   `boolean`, so its message is `customElement should be true or false` — with no
   `, if specified` tail. rsvelte went through `coerce_bool` and produced the
   tail. Fixed here.
2. **`filename` was absent from the error object entirely.** Upstream seeds
   `state.filename` from the raw option *before* validating, so the error carries
   it even when a later option is what failed.

## How it is done, and why not per-site

`napi::Error`'s `code` is its `Status` — a closed enum with no room for
`options_invalid_value` — so the coded shape has to be a JS object built from an
`Env`, which option parsing does not have.

The failure is therefore carried as a **value** (`OptionError { code, message }`)
and converted in **one** place, `options_to_compile` / `options_to_module_compile`.
`invalid_option` stays the single construction site, so any raising site added
later (including the four function-valued-option rejections on parenA's #3396
branch) picks the coded shape up without touching this file. There is no
`env.create_error` at a coercion site.

`code` is `null` — the convention `compile_error_object` already uses for a
diagnostic with no Svelte code — for the one rsvelte-only refusal here (a
function-valued `cssHash`, which upstream accepts and this entry point cannot
call).

**One entry point cannot carry it**: `compileWithCssHash` is an `async` export,
whose arguments must be `Send`, and `Env` is not. It passes `None` and its option
failures keep message-only shape. That is stated at the call site; the other 16
conversion sites are coded.

## Not fixed here, and not silently

Two neighbouring upstream behaviours the NAPI boundary does not implement at all
— both **silent**, both out of this issue's scope:

- `options_unrecognised`: official rejects an unknown key
  (`compile(src, { nonsense: 1 })`), rsvelte ignores it. `#[napi(object)]`'s typed
  struct never sees a key it does not declare, so this needs a different
  mechanism, not a different code.
- `options_removed`: `legacy` / `format` / `tag` / `sveltePath` / `errorMode` /
  `varsReport` are `removed(...)` upstream and absent from `NapiCompileOptions`.

Filed as #3535.

## Test

`scripts/dev/test-napi-compile-options.mjs` (CI job `test:napi-options`) gains an
`option-validation error shape` section: the 30 invalid values × 4 fields against
the official compiler, plus the 9 valid controls. That harness is the right home
because `rsvelte_napi` sets `test = false`, so no `cargo test` ever links it.
