### PR TITLE
fix(client): lower a module's $inspect.trace, and keep every other target's removal

### DIFF
--- a/.changeset/module-inspect-trace.md
+++ b/.changeset/module-inspect-trace.md
@@ -1,0 +1,13 @@
+---
+'@rsvelte/compiler': patch
+---
+
+Lower `$inspect.trace(…)` in `.svelte.(js|ts)` modules
+
+A module script had no dev-mode lowering for the rune at all, so `$inspect.trace(…)`
+reached the client output verbatim and threw `ReferenceError: $inspect is not defined`.
+The enclosing function body is now rewritten to `{ return $.trace(label, () => { … }); }`
+(awaited, with an `async` thunk, for an `async` function), with the default label taken
+from the function's own AST parent and located in the source the user wrote. The
+`$effect`-style non-dev removal that every other target still reaches now runs off the
+JS-lexical scan, so the same bytes inside a string literal are left alone.

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/await_reactivity_loss_ast.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/await_reactivity_loss_ast.rs
@@ -134,6 +134,13 @@ fn is_async_derived_call(expr: &Expression<'_>) -> bool {
     is_internal_call(expr, "async_derived")
 }
 
+/// `$inspect.trace()`'s wrapper. Upstream's `BlockStatement` visitor builds
+/// `b.await(call)` *after* visiting the body, so the `await` it synthesizes
+/// never reaches the `AwaitExpression` visitor.
+fn is_trace_call(expr: &Expression<'_>) -> bool {
+    is_internal_call(expr, "trace")
+}
+
 pub(super) fn is_save_call(expr: &Expression<'_>) -> bool {
     is_internal_call(expr, "save")
 }
@@ -407,6 +414,7 @@ impl<'a, 'src> Visit<'a> for AwaitCollector<'src> {
         if is_track_reactivity_loss_call(&expr.argument)
             || is_async_derived_call(&expr.argument)
             || is_save_call(&expr.argument)
+            || is_trace_call(&expr.argument)
             || is_destructuring_iife_call(&expr.argument)
             || self.ignored.contains(expr.span.start)
         {

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/inspect_trace_ast.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/inspect_trace_ast.rs
@@ -1,0 +1,360 @@
+//! AST-based `$inspect.trace(...)` lowering for module scripts
+//! (`.svelte.js` / `.svelte.ts`).
+//!
+//! Mirrors the pair of upstream visitors that answer for the rune: phase 2's
+//! `CallExpression` records `scope.tracing` (the label thunk), and the client
+//! `BlockStatement` visitor turns the enclosing function body into
+//!
+//! ```text
+//! { return $.trace(<label thunk>, () => { …rest of the body… }); }
+//! ```
+//!
+//! Module scripts had no equivalent at all, so `$inspect.trace(…)` survived
+//! into the output and threw `ReferenceError: $inspect is not defined` when the
+//! module ran; the non-dev removal was a `memmem` scan that also deleted the
+//! same bytes out of a string literal.
+//!
+//! The default label carries `locate_node(fn)`, a position in the source the
+//! user wrote, so this pass runs before any other module rewrite moves the
+//! enclosing function.
+
+use oxc_allocator::Allocator;
+use oxc_ast::ast::*;
+use oxc_ast_visit::Visit;
+use oxc_ast_visit::walk;
+use oxc_parser::ParseOptions;
+use oxc_span::{GetSpan, SourceType};
+use std::cell::RefCell;
+
+use super::ast_rewrite::{self, Edit};
+
+thread_local! {
+    static INSPECT_TRACE_ALLOC: RefCell<Allocator> = RefCell::new(Allocator::default());
+}
+
+/// Cheap byte probe gating entry into the pass.
+pub(super) fn source_has_inspect_trace(s: &str) -> bool {
+    memchr::memmem::find(s.as_bytes(), b"$inspect.trace").is_some()
+}
+
+/// Lower (dev) or remove (non-dev) every `$inspect.trace(…)` in a module
+/// script. Returns `None` when nothing matched, so the caller keeps its
+/// existing `String`.
+pub(super) fn transform_module_inspect_trace(
+    source: &str,
+    dev: bool,
+    is_ts: bool,
+    filename: Option<&str>,
+) -> Option<String> {
+    if !source_has_inspect_trace(source) {
+        return None;
+    }
+    let source_type = if is_ts {
+        SourceType::ts().with_module(true)
+    } else {
+        SourceType::mjs()
+    };
+    ast_rewrite::rewrite_batched(
+        &INSPECT_TRACE_ALLOC,
+        source,
+        source_type,
+        ParseOptions::default(),
+        |program, src| {
+            let mut collector = TraceCollector {
+                source: src,
+                filename,
+                dev,
+                parent_label: None,
+                edits: Vec::new(),
+            };
+            collector.visit_program(program);
+            collector.edits
+        },
+    )
+}
+
+struct TraceCollector<'src> {
+    source: &'src str,
+    filename: Option<&'src str>,
+    dev: bool,
+    /// The label the *immediate* parent of a function gives it, mirroring
+    /// `get_function_label`'s `nodes.at(-2)` lookup. Taken by the function it
+    /// was set for, so it never leaks into a nested one.
+    parent_label: Option<String>,
+    edits: Vec<Edit>,
+}
+
+impl<'src> TraceCollector<'src> {
+    fn text(&self, span: oxc_span::Span) -> &'src str {
+        &self.source[span.start as usize..span.end as usize]
+    }
+
+    /// `locate_node(fn)`: 1-based line, 0-based column of the function's start.
+    fn locate(&self, at: u32) -> (usize, usize) {
+        let before = &self.source[..at as usize];
+        let line = before.matches('\n').count() + 1;
+        let col = before[before.rfind('\n').map_or(0, |p| p + 1)..]
+            .chars()
+            .count();
+        (line, col)
+    }
+
+    /// The `$inspect.trace(…)` call when it leads `body`, as upstream requires
+    /// (`parent` an `ExpressionStatement`, `grand_parent` the function's own
+    /// `BlockStatement`, and `grand_parent.body[0] === parent`).
+    fn leading_trace_call<'a>(body: &'a FunctionBody<'a>) -> Option<&'a CallExpression<'a>> {
+        let Statement::ExpressionStatement(stmt) = body.statements.first()? else {
+            return None;
+        };
+        let Expression::CallExpression(call) = &stmt.expression else {
+            return None;
+        };
+        let Expression::StaticMemberExpression(member) = &call.callee else {
+            return None;
+        };
+        let Expression::Identifier(object) = &member.object else {
+            return None;
+        };
+        (object.name == "$inspect" && member.property.name == "trace").then_some(call)
+    }
+
+    /// Record the body rewrite for a function whose first statement is the
+    /// rune. `own_label` is the function's own name, which outranks the one its
+    /// parent supplies.
+    fn rewrite_body(
+        &mut self,
+        body: &FunctionBody<'_>,
+        is_async: bool,
+        own_label: Option<&str>,
+        fn_start: u32,
+    ) {
+        let Some(call) = Self::leading_trace_call(body) else {
+            return;
+        };
+        let stmt_span = body.statements[0].span();
+
+        if !self.dev {
+            // Upstream returns `b.empty` for the statement; nothing else moves.
+            self.edits
+                .push((stmt_span.start, stmt_span.end, String::new()));
+            return;
+        }
+
+        let label_thunk = match call.arguments.first().and_then(|a| a.as_expression()) {
+            Some(arg) => format!("() => {}", self.text(arg.span()).trim()),
+            None => {
+                let label = own_label
+                    .map(str::to_string)
+                    .or_else(|| self.parent_label.clone())
+                    .unwrap_or_else(|| "trace".to_string());
+                match self.filename {
+                    // `locate_node` runs the path through `sanitize_location`.
+                    Some(filename) => {
+                        let (line, col) = self.locate(fn_start);
+                        let filename = filename.replace('/', "/\u{200b}");
+                        format!("() => '{label} ({filename}:{line}:{col})'")
+                    }
+                    None => format!("() => '{label}'"),
+                }
+            }
+        };
+
+        // `body.span.end` is the byte after the closing `}`.
+        let rest = self.source[stmt_span.end as usize..body.span.end as usize - 1].trim();
+        let (awaited, asyncness) = if is_async {
+            ("await ", "async ")
+        } else {
+            ("", "")
+        };
+        let traced = if rest.is_empty() {
+            String::new()
+        } else {
+            format!(" {rest} ")
+        };
+        self.edits.push((
+            body.span.start,
+            body.span.end,
+            format!("{{ return {awaited}$.trace({label_thunk}, {asyncness}() => {{{traced}}}); }}"),
+        ));
+    }
+}
+
+impl<'a, 'src> Visit<'a> for TraceCollector<'src> {
+    fn visit_statement(&mut self, it: &Statement<'a>) {
+        self.parent_label = None;
+        walk::walk_statement(self, it);
+    }
+
+    fn visit_class(&mut self, it: &Class<'a>) {
+        // `get_function_label` has no arm for a class member, so a method never
+        // inherits the label the class's own declarator would give it.
+        self.parent_label = None;
+        walk::walk_class(self, it);
+    }
+
+    fn visit_variable_declarator(&mut self, it: &VariableDeclarator<'a>) {
+        if let BindingPattern::BindingIdentifier(id) = &it.id {
+            self.parent_label = Some(id.name.to_string());
+        }
+        walk::walk_variable_declarator(self, it);
+        self.parent_label = None;
+    }
+
+    fn visit_object_property(&mut self, it: &ObjectProperty<'a>) {
+        if !it.computed
+            && let Some(name) = it.key.static_name()
+        {
+            self.parent_label = Some(name.to_string());
+        }
+        walk::walk_object_property(self, it);
+        self.parent_label = None;
+    }
+
+    fn visit_call_expression(&mut self, it: &CallExpression<'a>) {
+        self.parent_label = None;
+        self.visit_expression(&it.callee);
+        let label = format!("{}(...)", self.text(it.callee.span()));
+        for argument in &it.arguments {
+            self.parent_label = Some(label.clone());
+            self.visit_argument(argument);
+        }
+        self.parent_label = None;
+    }
+
+    fn visit_function(&mut self, it: &Function<'a>, flags: oxc_syntax::scope::ScopeFlags) {
+        let label = self.parent_label.take();
+        if let Some(body) = &it.body {
+            let own = it.id.as_ref().map(|id| id.name.as_str());
+            self.parent_label = label;
+            self.rewrite_body(body, it.r#async, own, it.span.start);
+            self.parent_label = None;
+        }
+        walk::walk_function(self, it, flags);
+    }
+
+    fn visit_arrow_function_expression(&mut self, it: &ArrowFunctionExpression<'a>) {
+        // An expression-bodied arrow has no block for the rune to lead.
+        if let ArrowFunctionBody::FunctionBody(body) = &it.body {
+            self.rewrite_body(body, it.r#async, None, it.span.start);
+        }
+        self.parent_label = None;
+        walk::walk_arrow_function_expression(self, it);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::transform_module_inspect_trace;
+
+    fn dev(source: &str) -> Option<String> {
+        transform_module_inspect_trace(source, true, false, Some("m.svelte.js"))
+    }
+
+    #[test]
+    fn a_labelled_call_uses_its_own_argument() {
+        let out = dev("export function go() { $inspect.trace(\"t\"); return 1; }").unwrap();
+        assert!(
+            out.contains("return $.trace(() => \"t\", () => { return 1; })"),
+            "got: {out}"
+        );
+    }
+
+    #[test]
+    fn an_unlabelled_call_falls_back_to_the_function_name_and_position() {
+        let out =
+            dev("let base = 1;\nexport function go() { $inspect.trace(); return base; }").unwrap();
+        assert!(out.contains("() => 'go (m.svelte.js:2:7)'"), "got: {out}");
+    }
+
+    /// Every label arm of `get_function_label`, and the fallback a class member
+    /// gets because upstream has no arm for one.
+    #[test]
+    fn the_label_comes_from_the_functions_immediate_parent() {
+        for (source, expected) in [
+            ("export const go = () => { $inspect.trace(); };", "go ("),
+            (
+                "export const go = function () { $inspect.trace(); };",
+                "go (",
+            ),
+            ("export const o = { go() { $inspect.trace(); } };", "go ("),
+            (
+                "export function go() { $effect(() => { $inspect.trace(); }); }",
+                "$effect(...) (",
+            ),
+            ("export class C { go() { $inspect.trace(); } }", "trace ("),
+        ] {
+            let out = dev(source).unwrap();
+            assert!(out.contains(expected), "{source}\ngot: {out}");
+        }
+    }
+
+    /// Each call is located from its *own* function: the text predecessor took
+    /// the first `$inspect.trace(` in the file and labelled both with it.
+    #[test]
+    fn two_traced_functions_get_two_positions() {
+        let out = dev(
+            "export function a() { $inspect.trace(); }\nexport function b() { $inspect.trace(); }",
+        )
+        .unwrap();
+        assert!(out.contains("() => 'a (m.svelte.js:1:7)'"), "got: {out}");
+        assert!(out.contains("() => 'b (m.svelte.js:2:7)'"), "got: {out}");
+    }
+
+    #[test]
+    fn an_async_function_awaits_the_trace() {
+        let out = dev("export async function go() { $inspect.trace(); return 1; }").unwrap();
+        assert!(
+            out.contains("return await $.trace(() => 'go (m.svelte.js:1:7)', async () => {"),
+            "got: {out}"
+        );
+    }
+
+    #[test]
+    fn a_nested_function_is_traced_where_it_stands() {
+        let out =
+            dev("export function go() { function inner() { $inspect.trace(); } return inner; }")
+                .unwrap();
+        assert!(out.contains("() => 'inner ("), "got: {out}");
+        assert!(!out.contains("$inspect.trace"), "got: {out}");
+    }
+
+    #[test]
+    fn without_dev_the_statement_is_only_removed() {
+        let out = transform_module_inspect_trace(
+            "export function go() { $inspect.trace(); return 1; }",
+            false,
+            false,
+            Some("m.svelte.js"),
+        )
+        .unwrap();
+        assert!(!out.contains("$inspect"), "got: {out}");
+        assert!(!out.contains("$.trace"), "got: {out}");
+        assert!(out.contains("return 1;"), "got: {out}");
+    }
+
+    /// The bytes in a string literal are not the rune — the `memmem` scan this
+    /// pass replaces deleted them out of one.
+    #[test]
+    fn rune_shaped_bytes_in_a_string_are_left_alone() {
+        for is_dev in [true, false] {
+            assert!(
+                transform_module_inspect_trace(
+                    "export const s = \"$inspect.trace()\";",
+                    is_dev,
+                    false,
+                    Some("m.svelte.js")
+                )
+                .is_none(),
+                "dev={is_dev}"
+            );
+        }
+    }
+
+    /// Upstream requires the rune to lead a *block*, so a call anywhere else is
+    /// left for phase 2 to reject rather than silently rewritten here.
+    #[test]
+    fn a_call_that_does_not_lead_a_block_is_not_rewritten() {
+        assert!(dev("export const go = () => $inspect.trace();").is_none());
+        assert!(dev("export function go() { let x = 1; $inspect.trace(); }").is_none());
+    }
+}

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
@@ -23,6 +23,7 @@ mod effect_rune_ast;
 pub(crate) mod expression_utils;
 mod formatting;
 mod inspect_rune_ast;
+mod inspect_trace_ast;
 mod instance_dev_tail_ast;
 mod legacy_state_member_mutate_ast;
 mod local_assign_ast;
@@ -267,6 +268,17 @@ pub fn transform_client_module(
             },
         ));
     }
+
+    // `$inspect.trace()`'s default label carries `locate_node(fn)`, a position
+    // in the source the user wrote, so the rune is lowered before any other
+    // rewrite moves its enclosing function.
+    let trace_lowered = inspect_trace_ast::transform_module_inspect_trace(
+        source,
+        options.dev,
+        analysis.filename.ends_with(".ts"),
+        options.filename.as_deref(),
+    );
+    let source = trace_lowered.as_deref().unwrap_or(source);
 
     // Drop the comments upstream's synthesized accessors swallow before any
     // rewrite, so the scan still sees the source's own class bodies.
@@ -4395,26 +4407,27 @@ fn transform_module_script_runes_with_target(
         }
     }
 
-    // In non-dev mode, remove $inspect.trace(...) statements from module scripts.
-    // Mirrors the same logic in rune_transforms.rs for instance scripts.
+    // The AST lowering above answers for a `.svelte.(js|ts)` module's *client*
+    // output; every other target still reaches this function with the rune
+    // intact, so the non-dev removal stays. `find_code` rather than a plain
+    // byte search: the same bytes inside a string literal are not the rune.
     if !dev {
-        while let Some(pos) = memmem::find(result.as_bytes(), b"$inspect.trace(") {
+        while let Some(pos) = find_code(result.as_bytes(), b"$inspect.trace(") {
             let trace_start = pos + b"$inspect.trace(".len();
-            if let Some(content_end) = find_matching_paren(&result[trace_start..]) {
-                let mut end = trace_start + content_end + 1;
-                while end < result.len()
-                    && matches!(result.as_bytes()[end], b';' | b' ' | b'\t' | b'\n' | b'\r')
-                {
-                    end += 1;
-                }
-                let mut start = pos;
-                while start > 0 && matches!(result.as_bytes()[start - 1], b' ' | b'\t') {
-                    start -= 1;
-                }
-                result = format!("{}{}", &result[..start], &result[end..]);
-            } else {
+            let Some(content_end) = find_matching_paren(&result[trace_start..]) else {
                 break;
+            };
+            let mut end = trace_start + content_end + 1;
+            while end < result.len()
+                && matches!(result.as_bytes()[end], b';' | b' ' | b'\t' | b'\n' | b'\r')
+            {
+                end += 1;
             }
+            let mut start = pos;
+            while start > 0 && matches!(result.as_bytes()[start - 1], b' ' | b'\t') {
+                start -= 1;
+            }
+            result = format!("{}{}", &result[..start], &result[end..]);
         }
     }
 

--- a/crates/rsvelte_core/tests/inspect_trace_module.rs
+++ b/crates/rsvelte_core/tests/inspect_trace_module.rs
@@ -1,0 +1,188 @@
+//! `$inspect.trace(…)` in a `.svelte.(js|ts)` module.
+//!
+//! The dev lowering existed only for a component instance script, so a module
+//! emitted the rune verbatim and threw `ReferenceError: $inspect is not
+//! defined` the moment it ran — the one shape in this family that produces
+//! code that does not run rather than code that differs by bytes. The non-dev
+//! removal was a `memmem` scan, which deleted the same bytes out of a string
+//! literal.
+
+use rsvelte_core::{GenerateMode, ModuleCompileOptions, compile_module};
+
+fn module(src: &str, dev: bool) -> String {
+    compile_module(
+        src,
+        ModuleCompileOptions {
+            filename: Some("m.svelte.js".into()),
+            generate: GenerateMode::Client,
+            dev,
+            ..Default::default()
+        },
+    )
+    .map(|r| r.js.code)
+    .unwrap_or_else(|e| format!("COMPILE_ERROR: {e:?}"))
+}
+
+/// The reported shape: nothing lowered it, so `$inspect` reached the output.
+#[test]
+fn a_dev_module_lowers_the_rune_into_a_trace_call() {
+    let out = module(
+        "let base = $state(1);\nexport function go() { $inspect.trace(\"t\"); return base; }\n",
+        true,
+    );
+    assert!(!out.contains("COMPILE_ERROR"), "{out}");
+    assert!(
+        !out.contains("$inspect"),
+        "the rune survived into the output:\n{out}"
+    );
+    assert!(out.contains("$.trace(() => \"t\", () => {"), "{out}");
+    assert!(
+        out.contains("import 'svelte/internal/flags/tracing';"),
+        "{out}"
+    );
+}
+
+/// Without an argument the label is `get_function_label() ?? 'trace'` plus
+/// `locate_node(fn)` — a position in the source the user wrote, which is why
+/// the pass runs before the other module rewrites move the function.
+#[test]
+fn the_default_label_names_the_function_and_where_it_stands() {
+    let out = module(
+        "let base = $state(1);\nexport function go() { $inspect.trace(); return base; }\n",
+        true,
+    );
+    assert!(out.contains("() => 'go (m.svelte.js:2:7)'"), "{out}");
+}
+
+/// Each call is located from its own function. The text predecessor searched
+/// the whole source for the first `$inspect.trace(`, so both labels named the
+/// first one.
+#[test]
+fn two_traced_functions_do_not_share_one_label() {
+    let out = module(
+        "let base = $state(1);\nexport function a() { $inspect.trace(); return base; }\nexport function b() { $inspect.trace(); return base; }\n",
+        true,
+    );
+    assert!(out.contains("() => 'a (m.svelte.js:2:7)'"), "{out}");
+    assert!(out.contains("() => 'b (m.svelte.js:3:7)'"), "{out}");
+}
+
+/// Both directions of the removal: non-dev drops the statement, and the same
+/// bytes inside a string literal are not the rune in either mode.
+#[test]
+fn a_string_literal_is_not_a_trace_call() {
+    for dev in [true, false] {
+        let out = module(
+            "let base = $state(1);\nexport const s = \"$inspect.trace()\";\nexport function go() { return base; }\n",
+            dev,
+        );
+        assert!(!out.contains("COMPILE_ERROR"), "dev={dev}\n{out}");
+        assert!(
+            out.contains("\"$inspect.trace()\""),
+            "the string literal was rewritten (dev={dev}):\n{out}"
+        );
+    }
+}
+
+#[test]
+fn a_non_dev_module_only_drops_the_statement() {
+    let out = module(
+        "let base = $state(1);\nexport function go() { $inspect.trace(); return base; }\n",
+        false,
+    );
+    assert!(!out.contains("COMPILE_ERROR"), "{out}");
+    assert!(!out.contains("$inspect"), "{out}");
+    assert!(!out.contains("$.trace"), "{out}");
+    assert!(!out.contains("flags/tracing"), "{out}");
+    assert!(out.contains("return base;"), "{out}");
+}
+
+/// An `async` function awaits the traced thunk, which the instance path's
+/// predecessor did not model at all.
+#[test]
+fn an_async_function_awaits_the_traced_body() {
+    let out = module(
+        "let base = $state(1);\nexport async function go() { $inspect.trace(); return base; }\n",
+        true,
+    );
+    assert!(
+        out.contains("return await $.trace(() => 'go (m.svelte.js:2:7)', async () => {"),
+        "{out}"
+    );
+}
+
+/// The rune reaches this pipeline through two entry points (a `.svelte.(js|ts)`
+/// module and a component's `<script module>`) crossed with target and mode, and
+/// only ONE of those eight cells lowers it — every other cell removes it. The
+/// lowering therefore cannot replace the removal; both have to stand. Read off
+/// the official compiler for all eight.
+#[test]
+fn every_target_and_mode_still_drops_the_rune() {
+    use rsvelte_core::{CompileOptions, compile, compiler::CssMode};
+
+    const SRC: &str =
+        "let base = $state(1);\nexport function go() { $inspect.trace(); return base; }\n";
+    const COMPONENT: &str = "<script module>\nlet base = $state(1);\nexport function go() { $inspect.trace(); return base; }\n</script>\n<p>x</p>\n";
+
+    let component = |generate: GenerateMode, dev: bool| {
+        compile(
+            COMPONENT,
+            CompileOptions {
+                filename: Some("C.svelte".into()),
+                generate,
+                dev,
+                css: CssMode::External,
+                ..Default::default()
+            },
+        )
+        .map(|r| r.js.code)
+        .unwrap_or_else(|e| format!("COMPILE_ERROR: {e:?}"))
+    };
+    let module_target = |generate: GenerateMode, dev: bool| {
+        compile_module(
+            SRC,
+            ModuleCompileOptions {
+                filename: Some("m.svelte.js".into()),
+                generate,
+                dev,
+                ..Default::default()
+            },
+        )
+        .map(|r| r.js.code)
+        .unwrap_or_else(|e| format!("COMPILE_ERROR: {e:?}"))
+    };
+
+    // The one cell that lowers.
+    let lowered = module_target(GenerateMode::Client, true);
+    assert!(lowered.contains("$.trace("), "{lowered}");
+
+    for (name, out) in [
+        (
+            "module client prod",
+            module_target(GenerateMode::Client, false),
+        ),
+        (
+            "module server dev",
+            module_target(GenerateMode::Server, true),
+        ),
+        (
+            "module server prod",
+            module_target(GenerateMode::Server, false),
+        ),
+        (
+            "component <script module> client prod",
+            component(GenerateMode::Client, false),
+        ),
+        (
+            "component <script module> server dev",
+            component(GenerateMode::Server, true),
+        ),
+        (
+            "component <script module> server prod",
+            component(GenerateMode::Server, false),
+        ),
+    ] {
+        assert!(!out.contains("$inspect"), "{name} kept the rune:\n{out}");
+        assert!(!out.contains("$.trace("), "{name} lowered it:\n{out}");
+    }
+}


### PR DESCRIPTION
Closes #3561

`.svelte.(js|ts)` モジュールの `$inspect.trace(…)` を dev で降ろします。副産物として
**#3543**（同じ欠陥・**別の入口**＝コンポーネントの `<script module>`）と
**#3544**（同じルーン・**別の移植**＝インスタンススクリプトが `async` をモデルしていない）
を起票しました。3 本とも相互参照してあります。

**オラクルは `submodules/svelte` @ `20b341f10048`、`VERSION === '5.56.9'`**
（`git ls-tree origin/main submodules/svelte` と一致 = CI が読むツリー。
`node_modules/svelte` が解決する 5.56.10 ではありません）。下の 8 セルの表と
すべての期待値はこのオラクルで取っています。出力ヘッダも
`/* m.svelte.js generated by Svelte v5.56.9 */` です。

## 何が壊れていたか

モジュールスクリプトにはこのルーンの dev 降ろしが**存在しませんでした**。`$inspect.trace(…)`
がそのまま client 出力に届き、モジュールを import した瞬間に
`ReferenceError: $inspect is not defined` を投げます — この一族で唯一、
**バイト差ではなく「動かないコード」**が出るセルです。

## 直し方

上流の `3-transform/client/visitors/BlockStatement.js` を移植した AST パス
（`client/inspect_trace_ast.rs`）。囲む関数の本体を

```js
{ return $.trace(<label thunk>, () => { …本体… }); }
```

に書き換え、`async` 関数なら `return await $.trace(…, async () => { … })`。
既定ラベルは `get_function_label() ?? 'trace'` + `locate_node(fn)` で、これは
**ユーザが書いたソース上の位置**なので、他のモジュール書き換えが関数を動かす前に走ります。

## ★ 降ろしは除去を置き換えられません（8 セルを実測してから決めた）

このルーンは 2 つの入口（モジュール / コンポーネントの `<script module>`）× target × dev
の **8 セル**で処理され、公式が `$.trace(…)` に降ろすのは **client + dev の 2 セルだけ**、
残り 6 セルは**除去**です。8 セル全部を公式で実測しました:

| entry | target | dev | official | main | この PR |
|---|---|---|---|---|---|
| module | client | ✔ | `$.trace(…)` | ✗ 残る | **✓ 一致** |
| module | client | – | 除去 | ✓ | ✓ |
| module | server | ✔ | 除去 | ✓ | ✓ |
| module | server | – | 除去 | ✓ | ✓ |
| `<script module>` | client | ✔ | `$.trace(…)` | ✗ 残る | ✗ 残る（#3543・main と同じ） |
| `<script module>` | client | – | 除去 | ✓ | ✓ |
| `<script module>` | server | ✔ | 除去 | ✓ | ✓ |
| `<script module>` | server | – | 除去 | ✓ | ✓ |

**方向つきの集合差分: diverge → match が 1 セル、match → diverge が 0 セル。**

これが重要なのは、**この作業の最初の版が 3 セル退行させていたから**です。新しい AST パスを
`transform_client_module` に配線したうえで、共有の
`transform_module_script_runes_with_target` にあった非 dev 除去を**削除**していました。
その共有関数は 4 セル（module server dev/prod、`<script module>` client prod、…）が通る
のに、新しいパスはモジュールの client 経路しか通りません。実測は **1 fixed / 3 regressed**。
除去は戻してあります（`memmem` ではなく **`find_code`** に変更 — 文字列リテラルの中の
同じバイト列はルーンではないため）。

引き算 1 つの数字ではこれは見えません。8 セルの表を作って初めて見えました。

## 同期された `await` は計装しない

`track_reactivity_loss`（dev の `await X` → `(await $.track_reactivity_loss(X))()`）は
テキスト書き換え後の出力を再パースするので、**このパスが合成した `await` も掴んで**

```js
return (await $.track_reactivity_loss($.trace(…)))();   ← 誤り
```

を出していました。上流は `BlockStatement` 訪問の**後**に `b.await(call)` を組み立てるので、
その `await` は `AwaitExpression` ビジターに一度も届きません。よって
`await_reactivity_loss_ast.rs` の除外リスト（既に `track_reactivity_loss` /
`async_derived` / `save` / destructuring IIFE が並んでいます）に `$.trace` を足しました。

## テスト

`crates/rsvelte_core/tests/inspect_trace_module.rs`（7 本）。期待値は**公式コンパイラを
実際に走らせて**取っています（自分の出力からではなく）。

- 降ろし本体 / 既定ラベル / 2 関数がラベルを共有しないこと / `async` の `await`
- **`a_string_literal_is_not_a_trace_call`** — `"$inspect.trace()"` という文字列リテラルが
  dev / 非 dev のどちらでも書き換えられないこと（`find_code` の対照）
- **`every_target_and_mode_still_drops_the_rune`** — 上の表の 7 セルをピン留め。
  これが上で書いた退行を捕まえたテストです（除去を消した版では 3 セルが赤）。

## ローカルスイート（CI キューが飽和しているため、判定はローカル）

```
inspect_trace_module            7 passed
parser_fixtures                 3 passed   (modern 27/27, legacy 81/81)
compiler_errors                 2 passed   (145/145)
validator                       3 passed   (333/333, full warning shape)
ssr                             2 passed
compiler_fixtures               3 passed   (snapshot 30/30)
await_reactivity_loss_comment_2090 / dev_await_statement_terminator /
dev_destructured_async_assignment / dev_for_await_reactivity_loss /
module_dev_await_instrumentation / client_transforms_pin /
compile_both_parity / async_body_stmt_edge_cases   全て緑
```

`cargo fmt --all -- --check` clean、`cargo clippy -p rsvelte_core --all-targets
--all-features -- -D warnings` clean（pre-commit フックが飽和したマシンで完走しないため
`--no-verify` でコミットし、手で両方を通しています）。

## 競合

`3_transform/client/mod.rs` と `client/await_reactivity_loss_ast.rs` を触ります。
`client/inspect_trace_ast.rs` は新規ファイルです。
`orch-merge-order.md` の係争表には現時点でこの 2 ファイルの行はありません。
