### PR TITLE
fix(client): decide the dev console wrap by upstream's rule, not by argument spelling (#3472)

### DIFF
--- a/.changeset/dev-console-wrap-layout.md
+++ b/.changeset/dev-console-wrap-layout.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/compiler": patch
+---
+
+Decide the dev-mode `console.METHOD(...)` wrap by upstream's rule in the text fallback too. The instance-script pipeline splits on source lines, so a declaration sharing a line with the head of a multi-line statement yields fragments that are not standalone programs; oxc rejects those, and the fallback then chose by argument spelling (`!all_args_are_literals`) rather than by `scope.evaluate(arg).has_unknown`. An identifier that folds to a known value, a binary expression, an arrow and a `!x` were all wrapped, so moving two statements onto one line changed the emitted code.

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/console_dev_ast.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/console_dev_ast.rs
@@ -101,7 +101,7 @@ pub(super) fn transform_console_calls_dev_fragment(
         |_| Some(()),
     )
     .is_some();
-    (!parsed).then(|| super::props_transforms::transform_console_calls_dev(source))
+    (!parsed).then(|| super::props_transforms::transform_console_calls_dev(source, is_ts, analysis))
 }
 
 /// Collect leaf `console.METHOD(args)` wraps (calls whose arguments

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/console_wrap.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/console_wrap.rs
@@ -19,11 +19,14 @@
 //! operator branch that upstream resolves to a `STRING` / `NUMBER` / boolean
 //! value set without consulting a binding.
 
+use oxc_allocator::Allocator;
 use oxc_ast::ast::{
-    BindingIdentifier, BindingPattern, Program, VariableDeclaration, VariableDeclarationKind,
-    VariableDeclarator,
+    ArrayExpressionElement, BindingIdentifier, BindingPattern, Program, Statement,
+    VariableDeclaration, VariableDeclarationKind, VariableDeclarator,
 };
 use oxc_ast_visit::{Visit, walk};
+use oxc_parser::Parser;
+use oxc_span::SourceType;
 use rustc_hash::FxHashMap;
 use serde_json::Value;
 
@@ -76,6 +79,47 @@ pub(super) fn args_need_wrap(args: &[Value], analysis: &ComponentAnalysis) -> bo
                 || ctx.evaluate_estree(arg, 0).has_unknown()
         })
     })
+}
+
+/// Upstream's `arguments.some(...)` test applied to an argument list that is
+/// only available as text — the fallback the fragment path takes when oxc
+/// rejects the whole statement.
+///
+/// `Some(verdict)` when the list parses; `None` when it does not, which is the
+/// caller's cue to keep its own heuristic. Parsing the arguments as an array
+/// literal maps them one-to-one onto elements, spreads included, without
+/// needing the statement around them to be well-formed.
+pub(super) fn args_text_need_wrap(
+    args: &str,
+    is_ts: bool,
+    analysis: Option<&ComponentAnalysis>,
+) -> Option<bool> {
+    let source = format!("[{args}]");
+    let source_type = if is_ts {
+        SourceType::ts()
+    } else {
+        SourceType::mjs()
+    };
+    let allocator = Allocator::default();
+    let parsed = Parser::new(&allocator, &source, source_type).parse();
+    if !parsed.diagnostics.is_empty() {
+        return None;
+    }
+    let [Statement::ExpressionStatement(stmt)] = parsed.program.body.as_slice() else {
+        return None;
+    };
+    let oxc_ast::ast::Expression::ArrayExpression(array) = &stmt.expression else {
+        return None;
+    };
+    Some(array.elements.iter().any(|element| {
+        match element {
+            ArrayExpressionElement::SpreadElement(_) => true,
+            ArrayExpressionElement::Elision(_) => true,
+            other => other
+                .as_expression()
+                .is_none_or(|expr| shape_can_be_unknown(expr, analysis, None)),
+        }
+    }))
 }
 
 /// The generated program's own `const` declarations, indexed by name.

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/props_transforms.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/props_transforms.rs
@@ -4382,14 +4382,19 @@ pub(super) fn find_prop_mutation_location(source: &str, var_name: &str) -> (usiz
 /// The transformation is:
 ///   `console.log(x, y)` -> `console.log(...$.log_if_contains_state("log", x, y))`
 ///
-/// This is only applied when at least one argument could potentially reference
-/// reactive state (i.e., not all arguments are simple literals).
+/// Applied when some argument can evaluate to `UNKNOWN`, which is upstream's
+/// rule; the literal test below is reached only for an argument list that does
+/// not parse on its own.
 ///
 /// Console calls inside `$.inspect()` callbacks are excluded, as those are
 /// already handled by the inspect infrastructure.
 ///
 /// Reference: CallExpression.js in the official Svelte compiler
-pub(super) fn transform_console_calls_dev(stmt: &str) -> String {
+pub(super) fn transform_console_calls_dev(
+    stmt: &str,
+    is_ts: bool,
+    analysis: Option<&crate::compiler::phases::phase2_analyze::ComponentAnalysis>,
+) -> String {
     const CONSOLE_METHODS: &[&str] = &[
         "debug",
         "dir",
@@ -4433,9 +4438,14 @@ pub(super) fn transform_console_calls_dev(stmt: &str) -> String {
             if let Some(args_end) = find_matching_paren(&result[args_start..]) {
                 let args_content = &result[args_start..args_start + args_end];
 
-                // Only wrap if arguments could contain reactive state.
-                // Skip if all arguments are simple literals (strings, numbers, booleans).
-                if !args_content.is_empty() && !all_args_are_literals(args_content) {
+                // Upstream's rule is `scope.evaluate(arg).has_unknown`, not "is a
+                // literal": a binary expression, an arrow, a `!x` and a folded
+                // binding are all known. Ask the shared predicate whenever the
+                // argument list parses on its own.
+                let needs_wrap =
+                    super::console_wrap::args_text_need_wrap(args_content, is_ts, analysis)
+                        .unwrap_or_else(|| !all_args_are_literals(args_content));
+                if !args_content.is_empty() && needs_wrap {
                     // Transform: console.METHOD(args) -> console.METHOD(...$.log_if_contains_state("METHOD", args))
                     let new_call = format!(
                         "console.{}(...$.log_if_contains_state('{}', {}))",

--- a/crates/rsvelte_core/tests/console_wrap_layout_3472.rs
+++ b/crates/rsvelte_core/tests/console_wrap_layout_3472.rs
@@ -1,0 +1,175 @@
+//! A console call in a statement fragment oxc cannot parse was wrapped by
+//! argument *spelling* instead of by upstream's rule (#3472).
+//!
+//! The instance-script pipeline splits on source lines, so a declaration that
+//! shares a line with the head of a multi-line statement produces fragments
+//! that are not standalone programs. `with_program` refuses those, and the
+//! text fallback then decided the wrap with `!all_args_are_literals` — which
+//! says "wrap" for an identifier, a binary expression, an arrow and a `!x`,
+//! all of which upstream evaluates to a known value.
+//!
+//! The grid is argument shape x source layout. Only the layout moves between
+//! the two columns; the program is otherwise identical, so a cell that differs
+//! between them is layout-dependence and nothing else. Every expected string is
+//! the official compiler's own output (`submodules/svelte`, 5.56.9,
+//! 20b341f10), read from the same module instance that compiled the sources.
+
+use rsvelte_core::{CompileOptions, GenerateMode, compile};
+
+/// `(id, source, the console line official emits)`.
+const GRID: &[(&str, &str, &str)] = &[
+    (
+        "state_known/separate",
+        "<script>\n\tlet n = $state(1);\n\tlet m = $state(2);\n\tlet a = 1;\n\tlet b = 2;\n\tfunction f() { return 1; }\n\tfunction bump() { m = 3; }\n\t$effect(() => {\n\t\tconsole.log(n);\n\t});\n</script>\n<b onclick={bump}>x</b>\n",
+        "console.log(n);",
+    ),
+    (
+        "state_known/same_line",
+        "<script>\n\tlet n = $state(1);\n\tlet m = $state(2);\n\tlet a = 1;\n\tlet b = 2;\n\tfunction f() { return 1; }\n\tfunction bump() { m = 3; } $effect(() => {\n\t\tconsole.log(n);\n\t});\n</script>\n<b onclick={bump}>x</b>\n",
+        "console.log(n);",
+    ),
+    (
+        "state_reassigned/separate",
+        "<script>\n\tlet n = $state(1);\n\tlet m = $state(2);\n\tlet a = 1;\n\tlet b = 2;\n\tfunction f() { return 1; }\n\tfunction bump() { m = 3; }\n\t$effect(() => {\n\t\tconsole.log(m);\n\t});\n</script>\n<b onclick={bump}>x</b>\n",
+        "console.log(...$.log_if_contains_state('log', $.get(m)));",
+    ),
+    (
+        "state_reassigned/same_line",
+        "<script>\n\tlet n = $state(1);\n\tlet m = $state(2);\n\tlet a = 1;\n\tlet b = 2;\n\tfunction f() { return 1; }\n\tfunction bump() { m = 3; } $effect(() => {\n\t\tconsole.log(m);\n\t});\n</script>\n<b onclick={bump}>x</b>\n",
+        "console.log(...$.log_if_contains_state('log', $.get(m)));",
+    ),
+    (
+        "string/separate",
+        "<script>\n\tlet n = $state(1);\n\tlet m = $state(2);\n\tlet a = 1;\n\tlet b = 2;\n\tfunction f() { return 1; }\n\tfunction bump() { m = 3; }\n\t$effect(() => {\n\t\tconsole.log(\"hi\");\n\t});\n</script>\n<b onclick={bump}>x</b>\n",
+        "console.log(\"hi\");",
+    ),
+    (
+        "string/same_line",
+        "<script>\n\tlet n = $state(1);\n\tlet m = $state(2);\n\tlet a = 1;\n\tlet b = 2;\n\tfunction f() { return 1; }\n\tfunction bump() { m = 3; } $effect(() => {\n\t\tconsole.log(\"hi\");\n\t});\n</script>\n<b onclick={bump}>x</b>\n",
+        "console.log(\"hi\");",
+    ),
+    (
+        "number/separate",
+        "<script>\n\tlet n = $state(1);\n\tlet m = $state(2);\n\tlet a = 1;\n\tlet b = 2;\n\tfunction f() { return 1; }\n\tfunction bump() { m = 3; }\n\t$effect(() => {\n\t\tconsole.log(1);\n\t});\n</script>\n<b onclick={bump}>x</b>\n",
+        "console.log(1);",
+    ),
+    (
+        "number/same_line",
+        "<script>\n\tlet n = $state(1);\n\tlet m = $state(2);\n\tlet a = 1;\n\tlet b = 2;\n\tfunction f() { return 1; }\n\tfunction bump() { m = 3; } $effect(() => {\n\t\tconsole.log(1);\n\t});\n</script>\n<b onclick={bump}>x</b>\n",
+        "console.log(1);",
+    ),
+    (
+        "binary/separate",
+        "<script>\n\tlet n = $state(1);\n\tlet m = $state(2);\n\tlet a = 1;\n\tlet b = 2;\n\tfunction f() { return 1; }\n\tfunction bump() { m = 3; }\n\t$effect(() => {\n\t\tconsole.log(a + b);\n\t});\n</script>\n<b onclick={bump}>x</b>\n",
+        "console.log(a + b);",
+    ),
+    (
+        "binary/same_line",
+        "<script>\n\tlet n = $state(1);\n\tlet m = $state(2);\n\tlet a = 1;\n\tlet b = 2;\n\tfunction f() { return 1; }\n\tfunction bump() { m = 3; } $effect(() => {\n\t\tconsole.log(a + b);\n\t});\n</script>\n<b onclick={bump}>x</b>\n",
+        "console.log(a + b);",
+    ),
+    (
+        "template/separate",
+        "<script>\n\tlet n = $state(1);\n\tlet m = $state(2);\n\tlet a = 1;\n\tlet b = 2;\n\tfunction f() { return 1; }\n\tfunction bump() { m = 3; }\n\t$effect(() => {\n\t\tconsole.log(`x${n}`);\n\t});\n</script>\n<b onclick={bump}>x</b>\n",
+        "console.log(`x${n}`);",
+    ),
+    (
+        "template/same_line",
+        "<script>\n\tlet n = $state(1);\n\tlet m = $state(2);\n\tlet a = 1;\n\tlet b = 2;\n\tfunction f() { return 1; }\n\tfunction bump() { m = 3; } $effect(() => {\n\t\tconsole.log(`x${n}`);\n\t});\n</script>\n<b onclick={bump}>x</b>\n",
+        "console.log(`x${n}`);",
+    ),
+    (
+        "undefined/separate",
+        "<script>\n\tlet n = $state(1);\n\tlet m = $state(2);\n\tlet a = 1;\n\tlet b = 2;\n\tfunction f() { return 1; }\n\tfunction bump() { m = 3; }\n\t$effect(() => {\n\t\tconsole.log(undefined);\n\t});\n</script>\n<b onclick={bump}>x</b>\n",
+        "console.log(undefined);",
+    ),
+    (
+        "undefined/same_line",
+        "<script>\n\tlet n = $state(1);\n\tlet m = $state(2);\n\tlet a = 1;\n\tlet b = 2;\n\tfunction f() { return 1; }\n\tfunction bump() { m = 3; } $effect(() => {\n\t\tconsole.log(undefined);\n\t});\n</script>\n<b onclick={bump}>x</b>\n",
+        "console.log(undefined);",
+    ),
+    (
+        "arrow/separate",
+        "<script>\n\tlet n = $state(1);\n\tlet m = $state(2);\n\tlet a = 1;\n\tlet b = 2;\n\tfunction f() { return 1; }\n\tfunction bump() { m = 3; }\n\t$effect(() => {\n\t\tconsole.log((x) => x);\n\t});\n</script>\n<b onclick={bump}>x</b>\n",
+        "console.log((x) => x);",
+    ),
+    (
+        "arrow/same_line",
+        "<script>\n\tlet n = $state(1);\n\tlet m = $state(2);\n\tlet a = 1;\n\tlet b = 2;\n\tfunction f() { return 1; }\n\tfunction bump() { m = 3; } $effect(() => {\n\t\tconsole.log((x) => x);\n\t});\n</script>\n<b onclick={bump}>x</b>\n",
+        "console.log((x) => x);",
+    ),
+    (
+        "not/separate",
+        "<script>\n\tlet n = $state(1);\n\tlet m = $state(2);\n\tlet a = 1;\n\tlet b = 2;\n\tfunction f() { return 1; }\n\tfunction bump() { m = 3; }\n\t$effect(() => {\n\t\tconsole.log(!n);\n\t});\n</script>\n<b onclick={bump}>x</b>\n",
+        "console.log(!n);",
+    ),
+    (
+        "not/same_line",
+        "<script>\n\tlet n = $state(1);\n\tlet m = $state(2);\n\tlet a = 1;\n\tlet b = 2;\n\tfunction f() { return 1; }\n\tfunction bump() { m = 3; } $effect(() => {\n\t\tconsole.log(!n);\n\t});\n</script>\n<b onclick={bump}>x</b>\n",
+        "console.log(!n);",
+    ),
+    (
+        "call/separate",
+        "<script>\n\tlet n = $state(1);\n\tlet m = $state(2);\n\tlet a = 1;\n\tlet b = 2;\n\tfunction f() { return 1; }\n\tfunction bump() { m = 3; }\n\t$effect(() => {\n\t\tconsole.log(f());\n\t});\n</script>\n<b onclick={bump}>x</b>\n",
+        "console.log(...$.log_if_contains_state('log', f()));",
+    ),
+    (
+        "call/same_line",
+        "<script>\n\tlet n = $state(1);\n\tlet m = $state(2);\n\tlet a = 1;\n\tlet b = 2;\n\tfunction f() { return 1; }\n\tfunction bump() { m = 3; } $effect(() => {\n\t\tconsole.log(f());\n\t});\n</script>\n<b onclick={bump}>x</b>\n",
+        "console.log(...$.log_if_contains_state('log', f()));",
+    ),
+    (
+        "spread/separate",
+        "<script>\n\tlet n = $state(1);\n\tlet m = $state(2);\n\tlet a = 1;\n\tlet b = 2;\n\tfunction f() { return 1; }\n\tfunction bump() { m = 3; }\n\t$effect(() => {\n\t\tconsole.log(...[1, 2]);\n\t});\n</script>\n<b onclick={bump}>x</b>\n",
+        "console.log(...$.log_if_contains_state('log', ...[1, 2]));",
+    ),
+    (
+        "spread/same_line",
+        "<script>\n\tlet n = $state(1);\n\tlet m = $state(2);\n\tlet a = 1;\n\tlet b = 2;\n\tfunction f() { return 1; }\n\tfunction bump() { m = 3; } $effect(() => {\n\t\tconsole.log(...[1, 2]);\n\t});\n</script>\n<b onclick={bump}>x</b>\n",
+        "console.log(...$.log_if_contains_state('log', ...[1, 2]));",
+    ),
+    (
+        "mixed/separate",
+        "<script>\n\tlet n = $state(1);\n\tlet m = $state(2);\n\tlet a = 1;\n\tlet b = 2;\n\tfunction f() { return 1; }\n\tfunction bump() { m = 3; }\n\t$effect(() => {\n\t\tconsole.log(\"x:\", n);\n\t});\n</script>\n<b onclick={bump}>x</b>\n",
+        "console.log(\"x:\", n);",
+    ),
+    (
+        "mixed/same_line",
+        "<script>\n\tlet n = $state(1);\n\tlet m = $state(2);\n\tlet a = 1;\n\tlet b = 2;\n\tfunction f() { return 1; }\n\tfunction bump() { m = 3; } $effect(() => {\n\t\tconsole.log(\"x:\", n);\n\t});\n</script>\n<b onclick={bump}>x</b>\n",
+        "console.log(\"x:\", n);",
+    ),
+];
+
+#[test]
+fn console_wrap_does_not_depend_on_source_layout() {
+    let mut failures = Vec::new();
+    for (id, source, want) in GRID {
+        let code = compile(
+            source,
+            CompileOptions {
+                generate: GenerateMode::Client,
+                dev: true,
+                filename: Some("T.svelte".into()),
+                ..Default::default()
+            },
+        )
+        .map(|r| r.js.code)
+        .unwrap_or_else(|err| format!("ERROR {:?}", err.diagnostic().code));
+
+        let got = code
+            .lines()
+            .find(|line| line.contains("console."))
+            .unwrap_or("<no console call>")
+            .trim();
+        if got != *want {
+            failures.push(format!("{id}:\n   want {want}\n   got  {got}"));
+        }
+    }
+    assert!(
+        failures.is_empty(),
+        "{} of {} cells diverge from the official compiler:\n{}",
+        failures.len(),
+        GRID.len(),
+        failures.join("\n")
+    );
+}


### PR DESCRIPTION
Closes #3472.

> **Oracle**: `submodules/svelte` at `20b341f10` — `VERSION` **5.56.9**, printed
> in-process from the same module instance that compiled the expected strings.
> Both sides read the **same generated cases file**, so the two source lists
> cannot drift apart.

## What the issue reports, and what is actually wrong

The issue frames this as a `$state` declaration sharing a line with the next
statement. The `$state` is incidental. The mechanism is:

1. The instance-script pipeline splits on `script_rest.lines()`.
2. A declaration sharing a line with the head of a multi-line statement makes it
   emit fragments that are **not standalone programs** — traced:

   ```
   separate lines            same line
   "\tlet n = $state(1);"    "\tlet n = $state(1); $effect(() => {"
   "\t$effect(() => {        "\t\tconsole.log(n);\n\t});"
     console.log(n);\n});"     ^ unbalanced: a statement plus a dangling `});`
   ```
3. `ast_rewrite::with_program` returns `None` whenever `parsed.diagnostics` is
   non-empty, so the unbalanced fragment never reaches the AST console pass.
4. The fallback is `props_transforms::transform_console_calls_dev`, which had no
   `analysis` at all and decided by **argument spelling**:
   `!all_args_are_literals(args_content)`.

Upstream's rule is `node.arguments.some(arg => arg.type === 'SpreadElement' ||
scope.evaluate(arg).has_unknown)` (`CallExpression.js`). "Not a literal" is a
different predicate, and it disagrees on four shapes that have nothing to do
with `$state`.

## Measured

Grid: **12 argument shapes × 2 source layouts = 24 cells**. Only the layout
moves between the two columns — the program is otherwise identical — so a cell
that differs between them is layout-dependence and nothing else.

| | before | after |
|---|---|---|
| cells compared | 24 | 24 |
| divergences vs official | **5** | **0** |
| all of them | rsvelte wraps, official does not | — |

| diverging cell | argument | why upstream does not wrap |
|---|---|---|
| `state_known/same_line` | `n` | `$state(1)` never reassigned → folds to a known value |
| `binary/same_line` | `a + b` | a binary expression contributes only `STRING`/`NUMBER` |
| `arrow/same_line` | `(x) => x` | a function expression is never `UNKNOWN` |
| `not/same_line` | `!n` | `!` resolves to a boolean value set |
| `mixed/same_line` | `"x:", n` | both arguments are known |

The seven shapes that already agreed are kept as the negative control, and they
cover both directions: `spread` and `call` are wrapped on **both** sides (so the
fix is not "wrap less"), and `string` / `number` / `template` / `undefined` were
already unwrapped by the literal heuristic. **Every `separate` cell agreed
before and after**, which is what makes the axis layout rather than argument.

## The fix

The predicate already exists in one place — `console_wrap::shape_can_be_unknown`
plus `identifier_can_be_unknown`, which the AST path calls. The text path now
calls it too, by parsing the argument list on its own as `[<args>]`: an array
literal maps arguments one-to-one onto elements, spreads included, and it parses
without the statement around it being well-formed. The old heuristic is kept
only for an argument list that does not parse even that way.

This is the "two ports of one upstream function, and no gate compares the ports"
shape AGENTS.md records — the ports are now one function with two callers.

## Deliberately *not* fixed here: the splitter

The root cause one level up is that the line splitter emits fragments that are
not programs. **That is #3435's territory and another agent has it**, so this PR
does not touch `client/mod.rs` — verified by a check in the commit script that
refuses to commit if `client/mod.rs` differs from `origin/main` by a byte (I had
temporary tracing in it while diagnosing).

The two fixes compose rather than conflict: if the splitter stops emitting
unparseable fragments, this fallback simply stops being reached, and it is still
the right answer for any *other* fragment oxc rejects.

## Tests

`crates/rsvelte_core/tests/console_wrap_layout_3472.rs` — the 24 cells, each
expecting the official compiler's own emitted line verbatim.

Suites re-run (debug, `RUST_MIN_STACK=33554432`, private target dir):

```
console_wrap_layout_3472        1 passed (24 cells)
rsvelte_core --lib           1732 passed
parser_fixtures                 3 passed
compiler_errors                 2 passed
validator                       3 passed
compiler_fixtures               3 passed
ssr                             2 passed
dev_console_wrap_quotes         1 passed
dev_console_wrap_shadowing      3 passed
dev_inspect_trace_label         1 passed
client_transforms_pin           3 passed
```

`cargo fmt --check` clean; `cargo clippy -p rsvelte_core --all-targets
--all-features -- -D warnings` clean.

### Negative control

Restore the one expression — `!all_args_are_literals(args_content)` in place of
the shared predicate — and the test fails on exactly the five predicted cells,
for the predicted reason:

```
5 of 24 cells diverge from the official compiler:
state_known/same_line:  want console.log(n);        got console.log(...$.log_if_contains_state('log', n));
binary/same_line:       want console.log(a + b);    got console.log(...$.log_if_contains_state('log', a + b));
arrow/same_line:        want console.log((x) => x); got console.log(...$.log_if_contains_state('log', (x) => x));
not/same_line:          want console.log(!n);       got console.log(...$.log_if_contains_state('log', !n));
mixed/same_line:        want console.log("x:", n);  got console.log(...$.log_if_contains_state('log', "x:", n));
```

Note the ablation leaves all 12 `separate` cells passing, so the control
discriminates the layout axis and not merely "the file changed".

## Not measured

The corpus gate (~0.57 GiB, CI stalled). This changes dev-mode client output
only where a console call sits in a fragment oxc rejects, which the collected
corpus may well contain — if `client-dev` moves, it should move toward official.
