### PR TITLE
fix(compile): return the legacy AST from compile(), as upstream does

### DIFF
--- a/.changeset/compile-returns-legacy-ast.md
+++ b/.changeset/compile-returns-legacy-ast.md
@@ -1,0 +1,5 @@
+---
+'@rsvelte/compiler': patch
+---
+
+Return the Svelte-4 legacy AST from `compile()` when `modernAst` is not set, as the official compiler does. `result.ast` was `null`, so tooling that reads it received nothing instead of a tree.

--- a/compatibility/gate-coverage.md
+++ b/compatibility/gate-coverage.md
@@ -2241,6 +2241,22 @@ which build the map in Rust. Neither covers `compileBuffers`, `compileModuleBuff
 `*ZeroCopy` entries, or `compileModule`'s map — and no assertion generalizes: each is a named
 field on a named entry.
 
+### 22g — the legacy `result.ast` is compared as a top-level KEY SET, nothing below it [D]
+
+`modernAst: true` is compared to official as a whole canonicalized tree; the **default** `ast` —
+the Svelte-4 legacy tree, wired in #3295 — is compared only as `Object.keys(ast).sort()`, so
+`{css, html, instance, module, _comments}` agreeing is the entire verdict. Everything inside is
+unobserved here and nowhere else: no gate in this repo compares the legacy tree's contents on
+either shape. Measured over 400 `runtime-legacy` components, **22 are byte-identical to official
+and 378 diverge** in nine classes (`.raw`/`.data` on 199 files from upstream's in-place
+`clean_nodes` mutation, expression `loc` coverage on 311 files, computed-key positions on 15,
+`.modifiers`, `_comments`/`leadingComments`/`trailingComments`, `name_loc`, `importKind`, an
+extra `attributes`) — every one of which this gate scores as a pass. The byte-exact pin is one
+component in `crates/rsvelte_core/tests/compile_result_legacy_ast_3295.rs`; a differential over
+the corpus is #3295's follow-up, not this gate. Official is round-tripped through JSON before its
+keys are read, because upstream assigns `undefined` to absent blocks and `Object.keys` reports
+those.
+
 ---
 
 ## 23. Escaped-quote lookback shape — `crates/rsvelte_core/tests/escaped_quote_lookback_guard.rs`

--- a/crates/rsvelte_core/src/compiler/legacy.rs
+++ b/crates/rsvelte_core/src/compiler/legacy.rs
@@ -225,18 +225,22 @@ pub fn convert_positions_to_utf16(value: &mut Value, pos_conv: &Utf8ToUtf16) {
 
 /// Convert a modern AST to legacy AST format.
 pub fn convert_to_legacy(source: &str, ast: Root) -> Value {
+    convert_to_legacy_ref(source, &ast)
+}
+
+/// Convert a borrowed modern AST to legacy AST format. `compile()` needs this
+/// form: it still owns the `Root` when it fills the public `ast` field.
+pub fn convert_to_legacy_ref(source: &str, ast: &Root) -> Value {
     // RAII install of the serialize arena so as_json() calls can resolve
     // JsNodeIds. The guard restores the prior pointer on drop, preserving
     // any outer scope (e.g. when this is invoked from inside `compile()`).
     //
-    // SAFETY: `ast.arena` lives until `ast` is dropped at the end of
-    // `convert_to_legacy_inner`, which runs *before* the guard is
-    // dropped because `_guard` is declared first.
+    // SAFETY: `ast` outlives this call, so `ast.arena` outlives the guard.
     let _guard = unsafe { crate::ast::arena::SerializeArenaGuard::new(&ast.arena as *const _) };
     convert_to_legacy_inner(source, ast)
 }
 
-fn convert_to_legacy_inner(source: &str, ast: Root) -> Value {
+fn convert_to_legacy_inner(source: &str, ast: &Root) -> Value {
     let mut result = Map::new();
 
     // Calculate html fragment start/end
@@ -304,24 +308,24 @@ fn convert_to_legacy_inner(source: &str, ast: Root) -> Value {
     estree_fields!(result, "html" => html);
 
     // Convert instance script
-    if let Some(instance) = ast.instance {
-        let mut script = convert_script(&instance);
+    if let Some(instance) = &ast.instance {
+        let mut script = convert_script(instance);
         // Remove attributes field from instance
         script.remove("attributes");
         result.insert("instance".to_string(), Value::Object(script));
     }
 
     // Convert module script
-    if let Some(module) = ast.module {
-        let mut script = convert_script(&module);
+    if let Some(module) = &ast.module {
+        let mut script = convert_script(module);
         // Remove attributes field from module
         script.remove("attributes");
         result.insert("module".to_string(), Value::Object(script));
     }
 
     // Convert CSS
-    if let Some(css) = ast.css {
-        result.insert("css".to_string(), convert_css(&css));
+    if let Some(css) = &ast.css {
+        result.insert("css".to_string(), convert_css(css));
     }
 
     // Emit `_comments` mirroring upstream `legacy.js`. The legacy AST uses

--- a/crates/rsvelte_core/src/compiler/mod.rs
+++ b/crates/rsvelte_core/src/compiler/mod.rs
@@ -546,7 +546,7 @@ pub(crate) fn parse_component(
     let parse_options = crate::ParseOptions {
         modern: true,
         loose: false,
-        skip_expression_loc: !modern_ast,
+        skip_expression_loc: false,
         defer_script_parse: true,
         force_typescript: false,
         lenient_script: false,

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/mod.rs
@@ -6152,12 +6152,10 @@ mod tests {
 
     #[test]
     fn directive_name_is_referenced_even_without_expression_loc() {
-        // Regression: the real `compile()` entry point (`parse_component` in
-        // compiler/mod.rs) always parses with `skip_expression_loc: true`, so
-        // directive-name reference tracking must not be gated on `name_loc`
-        // being `Some` — otherwise `use:`/`transition:`/`animate:`-only usages
-        // are invisible to `non_reactive_update` / unused-`export let` checks
-        // in production compiles.
+        // Regression: directive-name reference tracking must not be gated on
+        // `name_loc` being `Some` — otherwise `use:`/`transition:`/`animate:`-only
+        // usages are invisible to `non_reactive_update` / unused-`export let`
+        // checks under every entry point that sets `skip_expression_loc`.
         let source = r#"<script>
     let count = $state(0);
 </script>

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/scope_builder.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/scope_builder.rs
@@ -2898,9 +2898,9 @@ impl<'a> ScopeBuilder<'a> {
     /// (`state.scope.reference(b.id(node.name.split('.')[0]), path)`), which
     /// runs unconditionally — the reference must be recorded even when we
     /// can't compute an exact source span for it (`name_loc` is `None` under
-    /// `skip_expression_loc`, the mode the real `compile()` entry point always
-    /// uses), otherwise `non_reactive_update` / unused-`export let` detection
-    /// silently stop seeing directive-only usages in production compiles.
+    /// `skip_expression_loc`, which the formatter, svelte2tsx and the language
+    /// server all parse with), otherwise `non_reactive_update` /
+    /// unused-`export let` detection silently stop seeing directive-only usages.
     ///
     /// `prefix_len` is the byte length of the directive keyword the parser
     /// stripped before `name` (`"use:"` / `"in:"` / `"out:"` / `"transition:"` /

--- a/crates/rsvelte_core/src/toolchain.rs
+++ b/crates/rsvelte_core/src/toolchain.rs
@@ -324,6 +324,9 @@ pub struct PreparedComponent<'source> {
     runes_mode: bool,
     retained_scripts: RetainedScripts<'source>,
     facts: OnceCell<ComponentFacts>,
+    // `compile_both` emits two results from one immutable AST, so the
+    // serialized public tree is shared rather than rebuilt per target.
+    ast_json: OnceCell<String>,
 }
 
 impl std::fmt::Debug for PreparedComponent<'_> {
@@ -361,6 +364,7 @@ impl<'source> PreparedComponent<'source> {
             runes_mode,
             retained_scripts,
             facts: OnceCell::new(),
+            ast_json: OnceCell::new(),
         })
     }
 
@@ -486,10 +490,23 @@ impl<'source> PreparedComponent<'source> {
             options,
             self.runes_mode,
         );
-        if options.modern_ast {
-            result.ast = Some(self.public_ast_json());
-        }
+        // Upstream fills `result.ast` unconditionally — the modern tree under
+        // `modernAst`, the legacy one otherwise — from the same post-analysis
+        // AST this holds.
+        result.ast = Some(self.ast_json().to_string());
         Ok(result)
+    }
+
+    // Keyed on `self.options` rather than on the per-target copy, which only
+    // ever differs in `generate`.
+    fn ast_json(&self) -> &str {
+        self.ast_json.get_or_init(|| {
+            if self.options.modern_ast {
+                self.public_ast_json()
+            } else {
+                self.legacy_ast_json()
+            }
+        })
     }
 
     fn public_ast_json(&self) -> String {
@@ -505,6 +522,11 @@ impl<'source> PreparedComponent<'source> {
             crate::compiler::legacy::convert_positions_to_utf16(&mut value, &positions);
         }
         serde_json::to_string(&value).expect("the public AST JSON is serializable")
+    }
+
+    fn legacy_ast_json(&self) -> String {
+        let value = crate::compiler::legacy::convert_to_legacy_ref(self.source, &self.ast);
+        serde_json::to_string(&value).expect("the legacy AST JSON is serializable")
     }
 }
 

--- a/crates/rsvelte_core/tests/compile_result_legacy_ast_3295.rs
+++ b/crates/rsvelte_core/tests/compile_result_legacy_ast_3295.rs
@@ -1,0 +1,87 @@
+//! `compile()` fills `result.ast` unconditionally, as upstream's
+//! `to_public_ast` (`compiler/index.js:177`) does: the modern tree under
+//! `modernAst`, the Svelte-4 legacy tree otherwise.
+//!
+//! The byte-exact case is `runtime-legacy/samples/action-receives-element-mounted`,
+//! one of the 22 of 400 sampled components whose legacy tree already matches
+//! official exactly. It is pinned here rather than sampled from the submodule so
+//! a Svelte bump cannot silently change what is being compared. It carries a
+//! `use:` directive and a script, so it fails if either `name_loc` or the
+//! statement `loc`s stop being produced.
+
+use rsvelte_core::{CompileOptions, GenerateMode, compile, compile_both};
+use serde_json::Value;
+
+const ACTION_SRC: &str = r#"<script>
+  export let result;
+  function onMountAction(node) {
+    result.parentElement = node.parentElement;
+  }
+</script>
+
+<h1 use:onMountAction>Hello!</h1>
+"#;
+
+/// `svelte.compile(ACTION_SRC, { filename: 'main.svelte', generate: 'client' }).ast`
+/// on the pinned submodule.
+const ACTION_LEGACY_AST: &str = r#"{"html":{"type":"Fragment","start":125,"end":158,"children":[{"type":"Text","start":123,"end":125,"raw":"\n\n","data":"\n\n"},{"type":"Element","start":125,"end":158,"name":"h1","attributes":[{"start":129,"end":146,"type":"Action","name":"onMountAction","name_loc":{"start":{"line":8,"column":4,"character":129},"end":{"line":8,"column":21,"character":146}},"expression":null,"modifiers":[]}],"children":[{"type":"Text","start":147,"end":153,"raw":"Hello!","data":"Hello!"}]}]},"instance":{"type":"Script","start":0,"end":123,"context":"default","content":{"type":"Program","start":8,"end":114,"loc":{"start":{"line":1,"column":0},"end":{"line":6,"column":9}},"body":[{"type":"ExportNamedDeclaration","start":11,"end":29,"loc":{"start":{"line":2,"column":2},"end":{"line":2,"column":20}},"declaration":{"type":"VariableDeclaration","start":18,"end":29,"loc":{"start":{"line":2,"column":9},"end":{"line":2,"column":20}},"declarations":[{"type":"VariableDeclarator","start":22,"end":28,"loc":{"start":{"line":2,"column":13},"end":{"line":2,"column":19}},"id":{"type":"Identifier","start":22,"end":28,"loc":{"start":{"line":2,"column":13},"end":{"line":2,"column":19}},"name":"result"},"init":null}],"kind":"let"},"specifiers":[],"source":null,"attributes":[]},{"type":"FunctionDeclaration","start":32,"end":113,"loc":{"start":{"line":3,"column":2},"end":{"line":5,"column":3}},"id":{"type":"Identifier","start":41,"end":54,"loc":{"start":{"line":3,"column":11},"end":{"line":3,"column":24}},"name":"onMountAction"},"expression":false,"generator":false,"async":false,"params":[{"type":"Identifier","start":55,"end":59,"loc":{"start":{"line":3,"column":25},"end":{"line":3,"column":29}},"name":"node"}],"body":{"type":"BlockStatement","start":61,"end":113,"loc":{"start":{"line":3,"column":31},"end":{"line":5,"column":3}},"body":[{"type":"ExpressionStatement","start":67,"end":109,"loc":{"start":{"line":4,"column":4},"end":{"line":4,"column":46}},"expression":{"type":"AssignmentExpression","start":67,"end":108,"loc":{"start":{"line":4,"column":4},"end":{"line":4,"column":45}},"operator":"=","left":{"type":"MemberExpression","start":67,"end":87,"loc":{"start":{"line":4,"column":4},"end":{"line":4,"column":24}},"object":{"type":"Identifier","start":67,"end":73,"loc":{"start":{"line":4,"column":4},"end":{"line":4,"column":10}},"name":"result"},"property":{"type":"Identifier","start":74,"end":87,"loc":{"start":{"line":4,"column":11},"end":{"line":4,"column":24}},"name":"parentElement"},"computed":false,"optional":false},"right":{"type":"MemberExpression","start":90,"end":108,"loc":{"start":{"line":4,"column":27},"end":{"line":4,"column":45}},"object":{"type":"Identifier","start":90,"end":94,"loc":{"start":{"line":4,"column":27},"end":{"line":4,"column":31}},"name":"node"},"property":{"type":"Identifier","start":95,"end":108,"loc":{"start":{"line":4,"column":32},"end":{"line":4,"column":45}},"name":"parentElement"},"computed":false,"optional":false}}}]}}],"sourceType":"module"}}}"#;
+
+fn client_options() -> CompileOptions {
+    CompileOptions {
+        filename: Some("main.svelte".to_string()),
+        generate: GenerateMode::Client,
+        dev: false,
+        ..Default::default()
+    }
+}
+
+fn ast_of(source: &str, options: CompileOptions) -> Value {
+    let result = compile(source, options).expect("compiles");
+    let ast = result.ast.expect("compile() must fill `ast`");
+    serde_json::from_str(&ast).expect("`ast` is JSON")
+}
+
+#[test]
+fn default_options_return_the_legacy_ast() {
+    let actual = ast_of(ACTION_SRC, client_options());
+    let expected: Value = serde_json::from_str(ACTION_LEGACY_AST).unwrap();
+    assert_eq!(
+        actual, expected,
+        "legacy AST diverges from svelte/compiler\n  actual: {actual}"
+    );
+}
+
+#[test]
+fn modern_ast_option_still_returns_the_modern_tree() {
+    let options = CompileOptions {
+        modern_ast: true,
+        ..client_options()
+    };
+    let ast = ast_of(ACTION_SRC, options);
+    assert_eq!(ast["type"], "Root");
+    assert!(
+        ast.get("html").is_none(),
+        "the modern tree must not carry the legacy `html` key"
+    );
+}
+
+#[test]
+fn server_and_client_share_one_ast() {
+    let (client, server) = compile_both(ACTION_SRC, client_options()).expect("compiles");
+    assert_eq!(client.ast, server.ast);
+    assert!(client.ast.is_some());
+}
+
+#[test]
+fn a_module_script_and_style_reach_their_legacy_keys() {
+    let source = "<script module>\n\texport const a = 1;\n</script>\n<script>\n\tlet b = 2;\n</script>\n<b>{b}</b>\n<style>b { color: red }</style>\n";
+    let ast = ast_of(source, client_options());
+    let object = ast.as_object().expect("the legacy AST is an object");
+    let mut keys: Vec<&str> = object.keys().map(String::as_str).collect();
+    keys.sort_unstable();
+    assert_eq!(keys, ["css", "html", "instance", "module"]);
+    assert_eq!(ast["css"]["type"], "Style");
+    assert_eq!(ast["module"]["type"], "Script");
+    assert_eq!(ast["instance"]["type"], "Script");
+    assert_eq!(ast["html"]["type"], "Fragment");
+}

--- a/scripts/dev/test-napi-compile-options.mjs
+++ b/scripts/dev/test-napi-compile-options.mjs
@@ -493,9 +493,20 @@ assert(
 		),
 	'modern AST differs from svelte/compiler'
 );
+// Upstream fills `ast` either way — the modern tree under `modernAst`, the
+// Svelte-4 legacy tree otherwise. Key sets are compared rather than whole trees
+// because the legacy tree still diverges inside (#3295), and official is
+// round-tripped first: it sets absent blocks to `undefined`, which `Object.keys`
+// reports and no serialization boundary carries.
+const defaultAst = napi.compile(MODERN_AST_SRC, { filename: 'A.svelte' }).ast;
+const officialDefaultKeys = Object.keys(
+	JSON.parse(JSON.stringify(officialCompile(MODERN_AST_SRC, { filename: 'A.svelte' }).ast))
+).sort();
 assert(
-	'compile.modernAst: default remains null',
-	napi.compile(MODERN_AST_SRC, { filename: 'A.svelte' }).ast === null
+	'compile.modernAst: the default is the legacy AST, keyed as official',
+	defaultAst !== null &&
+		JSON.stringify(Object.keys(defaultAst).sort()) === JSON.stringify(officialDefaultKeys),
+	`default ast keys ${JSON.stringify(defaultAst && Object.keys(defaultAst).sort())} vs official ${JSON.stringify(officialDefaultKeys)}`
 );
 let modernAstEnvelopeError;
 try {


### PR DESCRIPTION
Closes #3295

Upstream's `compile()` fills `result.ast` unconditionally — the modern tree under
`modernAst`, the Svelte-4 legacy tree otherwise
(`compiler/index.js:177`, `to_public_ast` → `convert(source, ast)`). rsvelte returned
`null` for the legacy shape, so a caller reading `result.ast` got nothing. Items **2**
and **3** of #3295 (`js.map.file`, the `./` prefix on `js.map.sources`) landed in #3362;
this is item **1**.

The converter itself already exists — `compiler/legacy.rs`, which `parse({ modern: false })`
has always used. What was missing was the wiring plus the expression locations the
`compile()` path was discarding.

## Which official compiler the numbers were measured against

Stated because a measurement that does not name its oracle is not reproducible, and this repo
currently has two Sveltes on disk.

* **Oracle: the submodule, `submodules/svelte/packages/svelte/src/compiler/index.js`** — the same
  module every gate in this repo loads. Asserted from its own output, not from the path it was
  loaded by: its `VERSION` export prints **5.56.9**.
* Submodule pin `20b341f10048cf1016a2028ac7eee5595cfef6a5`, **identical on this branch and on
  `origin/main`** (`git ls-tree`), so this PR does not move the oracle.
* `node_modules/svelte` in this checkout resolves to **5.56.10** and was **not** loaded by any arm.
  (The submodule bump is #3195, still open.)
* Inputs: **400 of 400** compared components come from that same submodule's
  `packages/svelte/tests/runtime-legacy/samples`.
* The NAPI gate edited below imports `officialCompile` from
  `../../submodules/svelte/…/compiler/index.js`; that import is untouched, so the gate keeps the
  same oracle.

## What this does not do

**This wires the field. It does not close parity, and it will not become 400/400 by
iterating on the same approach.** Measured over the 400 components in
`submodules/svelte/packages/svelte/tests/runtime-legacy/samples` that both compilers
accept, comparing `svelte.compile(src, { filename, generate: 'client' }).ast` against
`compile()`'s:

**22 of 400 are byte-identical. 378 diverge**, in these nine classes (`occ` = diverging
JSON positions, `files` = components carrying the class):

| # | class | occ | files | what it is |
|---|---|---|---|---|
| 1 | `loc` **presence** | 1494 missing / 8 extra | 311 / 4 | the two compilers disagree about which nodes carry a `loc` at all — e.g. official has one on `attributes[].expression`, rsvelte does not, and on `class:`-shorthand attributes rsvelte has one where official does not |
| 2 | `loc.character` | 114 | 44 | where both sides have the `loc`, official's carries `character` and rsvelte's does not (PR #3517 is open on exactly this axis) |
| 3 | `.raw` / `.data` | 515 + 515 | 199 | **structural, see below** — official `" "`, rsvelte `"\n"` |
| 4 | computed-key positions | 324 `.column`, 25 `.start`, 25 `.end` | 15 / 9 / 9 | a computed property key serializes with its start at the `[`; already recorded in AGENTS.md as an rsvelte-wide ESTree quirk |
| 5 | `.modifiers` | 60 | 42 | official emits `modifiers: []` on a directive shape rsvelte omits it from |
| 6 | script comments | 7 `_comments` + 7 `leadingComments` missing, 7 `trailingComments` extra | 7 | rsvelte hangs the script's comments off `instance.content.trailingComments`; official puts them in a root `_comments` array *and* as `leadingComments` on the statement they precede |
| 7 | `name_loc` | 7 | 5 | residual after the fix below (was 848 occ / 328 files) |
| 8 | `importKind` | 6 | 3 | official emits `importKind: "value"` on an `ImportDeclaration`; rsvelte omits it |
| 9 | extra `attributes` | 4 | 3 | rsvelte emits `attributes: []` on an `ImportDeclaration` where official has no such key |

### Class 3 is structural, not a bug to be fixed here

Upstream's `compile()` runs `to_public_ast` **after** `analyze_component` and
`transform_component`, both of which mutate the shared parse tree **in place**:
`phases/3-transform/utils.js:187-243` (`clean_nodes`) and
`phases/2-analyze/visitors/RegularElement.js:50-51` rewrite `node.raw` / `node.data`
while trimming whitespace. The legacy AST upstream returns is therefore a
*post-transform* tree. rsvelte's design forbids that — "Retained Phase-1 programs are
immutable" (AGENTS.md) — so rsvelte returns the source's own text. Closing this class
means either mutating the parse tree or replaying the trim during conversion; neither is
in scope here, and 199 of the 378 diverging files carry only this class plus class 1.

## The `capture_comments` measurement, and why (B) is a separate issue

The obvious companion knob to `skip_expression_loc` is `capture_comments`, which
`parse_component` also gates on `modern_ast`. **Turning it on changes nothing:** with
`capture_comments: true` forced on the `compile()` path, all **400 of 400** produced
legacy trees are byte-identical to the ones produced with it off (`Buffer.equals`, not a
normalized compare).

The reason is structural: `convert_script` reads `script.content.as_json()`, a
`serde_json::Value` materialized when the deferred script is resolved, while
`capture_comments` installs a thread-local `CommentCaptureGuard` consulted during
arena-node serialization. The legacy converter never reaches that side table. So class 6
above is a converter gap, not a parse-flag gap — and the follow-up (post-fill `loc`
during conversion, build `name_loc` at parse, hot path 0) does not need to touch the
comment flag at all. Filed as a separate issue.

## The cost, as a deterministic counter

Not a share of time. Counted over the same 400 components — JSON objects, object
entries, `loc` objects, and serialized bytes of the `ast` field:

| arm | objects | entries | `loc` objects | bytes |
|---|---|---|---|---|
| `origin/main` (`ast` is `null`) | 0 | 0 | 0 | 0 |
| **this PR** | **54,506** | **179,301** | **10,948** | **2,193,294** |
| this PR, `skip_expression_loc` hunk ablated | 19,139 | 94,770 | 0 | 1,353,075 |
| official `svelte.compile(…).ast` | 59,000 | 189,976 | 12,443 | 2,296,989 |

Per component: **+136 objects, +448 entries, +5.5 KB**. Of that, the
`skip_expression_loc` hunk alone accounts for +35,367 objects and +84,531 entries — 65%
of the objects, because a `loc` is three objects and six entries and there are 27 of them
per component.

**The framing that survives: upstream builds this tree on every `compile()` too, and
builds slightly more of it than we do** (rsvelte materializes 92.4% of official's objects
and 94.4% of its entries for the same field). A caller who was paying nothing was also
getting nothing.

One place where that framing does **not** hold, stated so it is not discovered later:
`compileEnvelope` (the Vite plugin's entry point) goes through the same `compile()`, and
the envelope format has no AST field — `reject_modern_ast_for_binary_result` refuses
`modernAst` for exactly that reason. On that path the tree is built and discarded. It is
the same counter above, all of it dead. Suppressing it needs an entry-point-level opt-out
and belongs in the follow-up issue, not in a correctness fix.

`compile_both` used to be a second instance of the same waste; it now serializes the tree
once and shares it (`ast_json: OnceCell<String>`, keyed on `self.options` rather than on
the per-target copy, which only ever differs in `generate`). Pinned by
`server_and_client_share_one_ast`.

## Changes

* `toolchain.rs` — `result.ast` is filled on every compile; the serialized tree is
  memoized per `PreparedComponent`.
* `compiler/mod.rs` — `parse_component` no longer sets `skip_expression_loc: !modern_ast`.
  This is what takes `name_loc` from missing on 328 files to missing on 5.
* `compiler/legacy.rs` — `convert_to_legacy_ref` borrows the `Root` instead of consuming
  it, because `compile()` still owns it when it fills the field. `convert_to_legacy` is
  unchanged for existing callers.
* `scripts/dev/test-napi-compile-options.mjs` — the assertion `compile.modernAst: default
  remains null` **pinned the defect**. It now compares the default `ast`'s top-level key
  set to official's. Official is JSON-round-tripped first: it assigns `undefined` to
  absent blocks (`module`, `_comments`), which `Object.keys` reports and no serialization
  boundary carries — comparing raw would have compared 5 keys against 3.
* Two comments in `2_analyze/` asserted "the real `compile()` entry point always parses
  with `skip_expression_loc: true`". That is now false; both are corrected. The behaviour
  they guard (`reference_directive_name` recording a reference even without a `name_loc`)
  is unchanged and still covered by its own test.
* `compatibility/gate-coverage.md` — new row **22g**: the legacy `ast` is compared as a
  top-level key set and nothing below it, so all nine classes above score as a pass there.

## Verification

* `cargo test -p rsvelte_core` — **3,256 tests / 332 targets, 0 failures** (run in
  segments; the heavy fixture suites `runtime`, `ssr`, `validator`, `parser_fixtures`,
  `sourcemaps_gate` were additionally run on their own and are green). `cargo clippy
  --all-targets --all-features -- -D warnings` clean workspace-wide.
* New: `crates/rsvelte_core/tests/compile_result_legacy_ast_3295.rs`. The byte-exact case
  is `runtime-legacy/samples/action-receives-element-mounted`, one of the 22 that already
  match; its source is pinned in the test rather than read from the submodule so a Svelte
  bump cannot silently change what is compared.

**Negative controls** — each hunk ablated, and the test fails for the predicted reason:

* Remove `result.ast = Some(…)`: all four tests fail, three at
  `` `compile()` must fill `ast` `` and `server_and_client_share_one_ast` at
  `assert!(client.ast.is_some())`.
* Restore `skip_expression_loc: !modern_ast`: `default_options_return_the_legacy_ast`
  fails with `legacy AST diverges from svelte/compiler`, and the produced tree shows
  exactly the predicted loss — the `use:onMountAction` attribute comes out as
  `{"start":129,"end":146,"type":"Action","name":"onMountAction","expression":Null,"modifiers":[]}`
  with **no `name_loc`**, and every `Program` / statement node has **no `loc`**. Over the
  400-component corpus the same ablation moves the score from 22 identical to **0**, with
  `.loc` missing at 12,434 positions in 388 files and `.name_loc` at 848 positions in 328.

Non-ASCII positions were checked separately, because the 400 sampled components contain
none and the counter cannot see it: a component with `名前` / `αβγ` / `été` / `中文`
produces zero position divergences, so the UTF-8 → UTF-16 conversion inside
`convert_to_legacy_inner` covers this path.

CI is not a verdict today (the scheduler is not dispatching), so the above is local.
