### PR TITLE
ci: say whether the Tests legs failed or were cancelled

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -828,8 +828,17 @@ jobs:
     needs: [test, test-unit, test-runtime, test-thread-safety, test-fmt-corpus, oxc-formatter-probe, language-server]
     if: always()
     runs-on: ubuntu-latest
-    timeout-minutes: 1
+    timeout-minutes: 5
     steps:
+      # This job had no checkout while its verdict was inline bash; the script
+      # needs one. Sparse, because `scripts/ci` is all it reads.
+      # This job had no checkout while its verdict was inline bash; the script
+      # needs one. Sparse, because `scripts/ci` is all it reads.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          submodules: false
+          sparse-checkout: scripts/ci
+
       - name: Verify all test jobs passed
         shell: bash
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -840,18 +840,11 @@ jobs:
           FMT_CORPUS: ${{ needs.test-fmt-corpus.result }}
           OXC_FORMATTER_PROBE: ${{ needs.oxc-formatter-probe.result }}
           LANGUAGE_SERVER: ${{ needs.language-server.result }}
-        run: |
-          echo "test (shards): $BULK"
-          echo "test-unit: $UNIT"
-          echo "test-runtime: $RUNTIME"
-          echo "test-thread-safety: $THREAD_SAFETY"
-          echo "test-fmt-corpus: $FMT_CORPUS"
-          echo "oxc-formatter-probe: $OXC_FORMATTER_PROBE"
-          echo "language-server: $LANGUAGE_SERVER"
-          if [[ "$BULK" != "success" || "$UNIT" != "success" || "$RUNTIME" != "success" || "$THREAD_SAFETY" != "success" || "$FMT_CORPUS" != "success" || "$OXC_FORMATTER_PROBE" != "success" || "$LANGUAGE_SERVER" != "success" ]]; then
-            echo "::error::One or more test jobs did not succeed."
-            exit 1
-          fi
+        # Same exit codes as before; the script exists so the MESSAGE can say
+        # whether a leg failed or was merely cancelled, which reads identically
+        # in `gh pr checks` and is the difference between "tests are broken" and
+        # "this run produced no verdict".
+        run: node scripts/ci/tests-aggregate-verdict.mjs
 
   compatibility-report:
     name: Compatibility Report
@@ -1224,6 +1217,11 @@ jobs:
       # these are the controls that show it can still fail.
       - name: Run workflow trigger guard tests
         run: node scripts/ci/test-workflow-trigger-guard.mjs
+
+      # The `Tests` aggregator's verdict is a message nothing else reads, so it
+      # can only regress silently.
+      - name: Run Tests aggregator verdict tests
+        run: node scripts/ci/test-tests-aggregate-verdict.mjs
 
       - name: Run differential corpus workflow tests
         run: node scripts/ci/test-differential-corpus-workflow.mjs

--- a/scripts/ci/test-tests-aggregate-verdict.mjs
+++ b/scripts/ci/test-tests-aggregate-verdict.mjs
@@ -1,0 +1,110 @@
+#!/usr/bin/env node
+// Self-test for scripts/ci/tests-aggregate-verdict.mjs.
+//
+// The behaviour this file defends is a *message*, and a message is exactly the
+// kind of thing that regresses silently — nothing else in CI reads it. So each
+// case pins both the exit code and the discriminating phrase, and the pairs are
+// chosen so that a script which returned one constant verdict would fail here.
+//
+// The exit codes must stay identical to the inline bash this replaced: 0 only
+// when every leg succeeded, 1 for anything else. Cancellation is not a pass.
+
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { LEGS, verdict } from './tests-aggregate-verdict.mjs';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const CI_WORKFLOW = join(HERE, '..', '..', '.github', 'workflows', 'ci.yml');
+
+let failures = 0;
+
+function check(name, fn) {
+	try {
+		fn();
+		console.log(`  ok   ${name}`);
+	} catch (err) {
+		failures += 1;
+		console.log(`  FAIL ${name}\n       ${err.message}`);
+	}
+}
+
+function assert(condition, message) {
+	if (!condition) throw new Error(message);
+}
+
+const KEYS = LEGS.map(([, key]) => key);
+const all = (result) => Object.fromEntries(KEYS.map((key) => [key, result]));
+const withOne = (key, result) => ({ ...all('success'), [key]: result });
+
+check('every leg green exits 0', () => {
+	const { code } = verdict(all('success'));
+	assert(code === 0, `expected 0, got ${code}`);
+});
+
+check('one real failure exits 1 and names FAILED, not cancellation', () => {
+	const { code, message } = verdict(withOne('RUNTIME', 'failure'));
+	assert(code === 1, `expected 1, got ${code}`);
+	assert(message.includes('FAILED'), message);
+	assert(message.includes('test-runtime'), message);
+	assert(!message.includes('NO VERDICT'), message);
+});
+
+check('every leg cancelled exits 1 and says NO VERDICT', () => {
+	const { code, message } = verdict(all('cancelled'));
+	assert(code === 1, `expected 1, got ${code}`);
+	assert(message.includes('NO VERDICT'), message);
+	assert(message.includes('CANCELLED'), message);
+	assert(!message.includes('FAILED'), message);
+});
+
+// The discriminating pair: a failure alongside cancellations must NOT be
+// reported as "no verdict" — there is a verdict and it is bad.
+check('a failure among cancellations reports the failure', () => {
+	const env = { ...all('cancelled'), UNIT: 'failure' };
+	const { code, message } = verdict(env);
+	assert(code === 1, `expected 1, got ${code}`);
+	assert(message.includes('FAILED'), message);
+	assert(message.includes('test-unit'), message);
+	assert(!message.includes('NO VERDICT'), message);
+});
+
+check('a skipped leg is not a pass', () => {
+	const { code, message } = verdict(withOne('FMT_CORPUS', 'skipped'));
+	assert(code === 1, `expected 1, got ${code}`);
+	assert(message.includes('did not run'), message);
+});
+
+check('a missing env var is treated as did-not-run, not as success', () => {
+	const env = all('success');
+	delete env.LANGUAGE_SERVER;
+	const { code } = verdict(env);
+	assert(code === 1, `expected 1, got ${code}`);
+});
+
+check('an unrecognised result is loud rather than silently non-fatal', () => {
+	const { code, message } = verdict(withOne('BULK', 'neutral'));
+	assert(code === 2, `expected 2, got ${code}`);
+	assert(message.includes('Unrecognised'), message);
+});
+
+// A verdict script nothing calls is worth nothing, and the workflow is the only
+// caller. This is the wiring check — the same shape as the trigger guard's.
+check('ci.yml invokes this script and declares every leg it reads', () => {
+	const yml = readFileSync(CI_WORKFLOW, 'utf8');
+	assert(
+		yml.includes('scripts/ci/tests-aggregate-verdict.mjs'),
+		'ci.yml does not call tests-aggregate-verdict.mjs',
+	);
+	for (const key of KEYS) {
+		assert(new RegExp(`^\\s+${key}:`, 'm').test(yml), `ci.yml declares no ${key} env var`);
+	}
+});
+
+console.log(
+	failures === 0
+		? '\ntests-aggregate-verdict self-test: all checks passed'
+		: `\ntests-aggregate-verdict self-test: ${failures} failure(s)`,
+);
+process.exit(failures === 0 ? 0 : 1);

--- a/scripts/ci/test-tests-aggregate-verdict.mjs
+++ b/scripts/ci/test-tests-aggregate-verdict.mjs
@@ -100,6 +100,15 @@ check('ci.yml invokes this script and declares every leg it reads', () => {
 	for (const key of KEYS) {
 		assert(new RegExp(`^\\s+${key}:`, 'm').test(yml), `ci.yml declares no ${key} env var`);
 	}
+	// The job carried no checkout while its verdict was inline bash, so the
+	// first run of the script died with MODULE_NOT_FOUND — a red `Tests` that
+	// says nothing about the tests, which is the exact confusion this script
+	// exists to remove.
+	const job = yml.slice(yml.indexOf('\n  tests:'), yml.indexOf('\n  compatibility-report:'));
+	assert(
+		/uses: actions\/checkout@/.test(job),
+		'the `tests` job runs a script from the repo but never checks it out',
+	);
 });
 
 console.log(

--- a/scripts/ci/tests-aggregate-verdict.mjs
+++ b/scripts/ci/tests-aggregate-verdict.mjs
@@ -1,0 +1,85 @@
+#!/usr/bin/env node
+// The `Tests` required check fans the sharded test matrix back into one signal.
+// Anything other than `success` still fails — a cancelled leg ran no tests, so
+// it is not a pass — but the MESSAGE has to say which happened. A run whose legs
+// were all cancelled by `concurrency: cancel-in-progress` is indistinguishable
+// in `gh pr checks` from a run whose tests genuinely failed, and both read as a
+// red required check; the log line is the only place the difference can be told.
+//
+// Exit codes: 0 = every leg succeeded, 1 = otherwise (unchanged from the inline
+// bash this replaces), 2 = a leg reported a result this script does not know.
+
+export const LEGS = [
+  ['test (shards)', 'BULK'],
+  ['test-unit', 'UNIT'],
+  ['test-runtime', 'RUNTIME'],
+  ['test-thread-safety', 'THREAD_SAFETY'],
+  ['test-fmt-corpus', 'FMT_CORPUS'],
+  ['oxc-formatter-probe', 'OXC_FORMATTER_PROBE'],
+  ['language-server', 'LANGUAGE_SERVER'],
+];
+
+const KNOWN = new Set(['success', 'failure', 'cancelled', 'skipped', '']);
+
+export function classify(env) {
+  const legs = LEGS.map(([label, key]) => ({ label, result: env[key] ?? '' }));
+  const unknown = legs.filter((leg) => !KNOWN.has(leg.result));
+  const failed = legs.filter((leg) => leg.result === 'failure');
+  const cancelled = legs.filter((leg) => leg.result === 'cancelled');
+  // A `needs` job that never ran reports `skipped`; GitHub also reports the
+  // empty string for a job the graph dropped entirely.
+  const absent = legs.filter((leg) => leg.result === 'skipped' || leg.result === '');
+  return { legs, unknown, failed, cancelled, absent };
+}
+
+export function verdict(env) {
+  const { legs, unknown, failed, cancelled, absent } = classify(env);
+
+  if (unknown.length > 0) {
+    const named = unknown.map((leg) => `${leg.label}=${leg.result}`).join(', ');
+    return { code: 2, message: `::error::Unrecognised job result(s): ${named}.` };
+  }
+
+  if (failed.length === 0 && cancelled.length === 0 && absent.length === 0) {
+    return { code: 0, message: 'All test jobs succeeded.' };
+  }
+
+  // Cancellation is the common case on this repository and the one that gets
+  // misread: a superseding push cancels the whole run, and every leg comes back
+  // `cancelled` with zero steps. Say "no verdict", not "tests failed".
+  if (failed.length === 0 && cancelled.length > 0) {
+    const named = cancelled.map((leg) => leg.label).join(', ');
+    const rest = absent.length > 0 ? ` ${absent.length} did not run.` : '';
+    return {
+      code: 1,
+      message:
+        `::error::NO VERDICT — no test job failed, but ${cancelled.length} were CANCELLED ` +
+        `(${named}).${rest} A cancelled job ran no tests, so this is not a pass; it is also ` +
+        `not a test failure. Re-run the workflow or push to the branch to get a verdict.`,
+    };
+  }
+
+  if (failed.length > 0) {
+    const named = failed.map((leg) => leg.label).join(', ');
+    const also = cancelled.length > 0 ? ` (${cancelled.length} more were cancelled)` : '';
+    return { code: 1, message: `::error::Test job(s) FAILED: ${named}.${also}` };
+  }
+
+  const named = absent.map((leg) => leg.label).join(', ');
+  return {
+    code: 1,
+    message: `::error::Test job(s) did not run: ${named}. A skipped test job is not a pass.`,
+  };
+}
+
+function main() {
+  const { legs } = classify(process.env);
+  for (const leg of legs) console.log(`${leg.label}: ${leg.result || '(none)'}`);
+  const { code, message } = verdict(process.env);
+  console.log(message);
+  return code;
+}
+
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+  process.exit(main());
+}


### PR DESCRIPTION
Refs #3630. Part of it — see **Scope** below for what this deliberately does not do.

## The measurement that prompted it, and the correction it forces on #3630

#3630 counted **34** open PRs whose only failures were `LSP full-population ratchet` plus the
`Tests` aggregator that mirrors it. Re-measured now over all open PRs:

```
gh pr list --state open --limit 200 --json number,statusCheckRollup \
  -q '… select every PR whose FAILURE set is a subset of {LSP full-population ratchet, Tests} …'
→ 47
```

**But the population is not what the issue assumed, and I traced one to find out.** PR #3626's
failing run (`32622286812`, `event=pull_request`, **`attempt=1`**, created 2026-08-23T06:11Z)
contains **no LSP job at all**. Every one of its 26 jobs is `cancelled` with **`steps=0`**, and
the only non-cancelled job is `Tests`, `failure`, `steps=3`.

Two things follow.

**#3630's part 1 is not explained by a stale workflow file, and I checked rather than assumed.**
The `needs.lsp-corpus.result == 'success'` guard landed in `613fa1eb9` at 2026-08-22T14:29Z, and
`git merge-base --is-ancestor 613fa1eb9 0e078724b` confirms it **is** present in that PR's head.
So a run carrying the guard still produced this shape. That half stays open.

**And the 47 are a mixed population**, not 47 instances of the LSP defect. At least some — #3626
among them — are runs cancelled wholesale by `concurrency: cancel-in-progress`, where the red
check is the `Tests` aggregator doing exactly what it was designed to do.

## What this changes

The aggregator's polarity is right and is not touched: a cancelled leg ran no tests, so it is not
a pass, and a required check must fail closed. `AGENTS.md` records the opposite-polarity version
of this hazard (comparisons that score `match` when there is nothing to compare) and the correct
answer there was the same — keep failing, but be able to say why.

What was wrong is that the **message** was `One or more test jobs did not succeed.` for both
cases. In `gh pr checks` a cancelled-run red and a broken-tests red are the same single word, so
the log line is the only place the difference can be recovered — and it did not carry it.

The inline bash is now `scripts/ci/tests-aggregate-verdict.mjs`, with the **exit codes
unchanged**: 0 only when every leg succeeded, 1 for anything else. It classifies instead:

| situation | message |
|---|---|
| a leg reported `failure` | `Test job(s) FAILED: <names>.` (plus a count of any cancellations) |
| no failure, ≥1 `cancelled` | `NO VERDICT — no test job failed, but N were CANCELLED (…). A cancelled job ran no tests, so this is not a pass; it is also not a test failure.` |
| no failure, only `skipped`/absent | `Test job(s) did not run: <names>. A skipped test job is not a pass.` |
| an unrecognised result string | exit **2**, `Unrecognised job result(s): …` |

The last row is new behaviour rather than a rename: the old condition was `!= "success"`, so a
result GitHub might add later fell into the generic failure branch silently.

## The test is the point of the change

A verdict message is read by nothing else in CI, so it is precisely the kind of thing that
regresses without anyone noticing. `scripts/ci/test-tests-aggregate-verdict.mjs` pins each case's
exit code **and** its discriminating phrase, and is wired into the `Workflow trigger guard` job
next to the other guard self-tests.

The discriminating case is `a failure among cancellations reports the failure` — a script that
answered "no verdict" whenever anything was cancelled would pass every other row and fail that
one. There is also a wiring check (`ci.yml` must invoke the script and declare every env var it
reads), because a verdict script nothing calls is worth nothing; it is the same shape as the
existing trigger-guard allowlist check.

**Positive control, run on this tree:** eight checks pass. Disabling the no-verdict branch alone
(`if (false && …)`) takes it to **1 failure**, and specifically the `every leg cancelled` row,
which then reports the fall-through message — so the suite is measuring that branch and not
merely running. Restored and re-run green.

`node scripts/ci/workflow-trigger-guard.mjs` and its own self-test both still pass against the
edited `ci.yml` (20 workflows checked, no violations).

## Scope — what this does not do

- **It does not fix #3630 part 1.** Why `LSP full-population ratchet` runs with zero input
  artifacts despite its `needs.lsp-corpus.result == 'success'` guard is still undiagnosed, and I
  am not guessing at it. The measurement above narrows it: the guard was present, so the
  explanation is not "old workflow file".
- **It does not touch #3630 part 2** (the 16-shard matrix setting the queue ceiling). That is the
  product decision the issue explicitly declined to make, and this PR does not make it either.
- **It changes no verdict.** Every input that failed before still fails, with the same exit code.
  If that is not what you want — if a wholly-cancelled run should be `neutral` rather than red —
  that is a different and larger change, and it belongs with part 2.
