### PR TITLE
fix(napi): reject an unrecognised compile option and the six removed ones

### DIFF
--- a/.changeset/napi-unrecognised-and-removed-options.md
+++ b/.changeset/napi-unrecognised-and-removed-options.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/vite-plugin-svelte-native": patch
+---
+
+Reject the compile options upstream rejects. `compile()` and `compileModule()` now raise `options_unrecognised` for a key `validate-options.js` does not declare — so a typo in `svelte.config.js`'s `compilerOptions` is an error instead of a silently-ignored default — and `compile()` raises `options_removed` for the six Svelte-4 options upstream declares only in order to reject (`legacy`, `format`, `tag`, `sveltePath`, `errorMode`, `varsReport`). `warningFilter` is now declared and type-checked like upstream's `fun()`, `css: 'none'` carries upstream's own message rather than the generic one, and when two options are bad the one reported is the one upstream reports: the unrecognised-key scan runs before every validator, the rest run in upstream's key-declaration order, and `customElement`/`css` come last because their `parametric()` normalizer runs on first call rather than during validation. `compileModule` follows upstream in accepting every component-only key as a no-op, so a removed option is an error there only on `compile`.

--- a/crates/rsvelte_napi/src/lib.rs
+++ b/crates/rsvelte_napi/src/lib.rs
@@ -360,7 +360,7 @@ fn position_object<'env>(
 pub fn napi_compile(
     env: Env,
     source: String,
-    options: Option<NapiCompileOptions>,
+    options: Option<NapiCompileOptionsArg>,
 ) -> napi::Result<Value> {
     let opts = options_to_compile(Some(&env), options)?;
     let filename = opts.filename.clone();
@@ -386,7 +386,7 @@ pub fn napi_compile(
 pub fn napi_compile_both(
     env: Env,
     source: String,
-    options: Option<NapiCompileOptions>,
+    options: Option<NapiCompileOptionsArg>,
 ) -> napi::Result<Value> {
     let opts = options_to_compile(Some(&env), options)?;
     let filename = opts.filename.clone();
@@ -452,7 +452,7 @@ fn compile_result_to_json(result: rsvelte_core::compiler::CompileResult) -> Valu
 #[napi(js_name = "compileWithCssHash", catch_unwind, ts_return_type = "any")]
 pub async fn napi_compile_with_css_hash(
     source: String,
-    options: Option<NapiCompileOptions>,
+    options: Option<NapiCompileOptionsArg>,
     #[napi(
         ts_arg_type = "(input: { hash: (str: string) => string, css: string, name: string, filename: string }) => string"
     )]
@@ -463,7 +463,7 @@ pub async fn napi_compile_with_css_hash(
     // way the synchronous entries do.
     let mut options = options;
     if let Some(o) = options.as_mut() {
-        o.css_hash = None;
+        o.inner.css_hash = None;
     }
     // An `async` export's arguments must be `Send`; `Env` is not, so this is
     // the one entry whose option failure cannot carry the coded shape.
@@ -893,6 +893,26 @@ fn invalid_option(detail: impl std::fmt::Display) -> OptionError {
     }
 }
 
+/// `validate-options.js`'s `removed()`: an option that still has a name but no
+/// behaviour. Unlike `warn_removed()` (which only warns) this throws.
+fn removed_option(detail: &str) -> OptionError {
+    OptionError {
+        code: Some("options_removed"),
+        message: format!("Invalid compiler option: {detail}\nhttps://svelte.dev/e/options_removed"),
+    }
+}
+
+/// `validate-options.js`'s `object()` reports a key it does not declare, before
+/// running any per-option validator.
+fn unrecognised_option(keypath: &str) -> OptionError {
+    OptionError {
+        code: Some("options_unrecognised"),
+        message: format!(
+            "Unrecognised compiler option {keypath}\nhttps://svelte.dev/e/options_unrecognised"
+        ),
+    }
+}
+
 /// A value upstream accepts that this entry point cannot honour. There is no
 /// upstream code for it because upstream never raises it.
 fn unsupported_option(detail: impl std::fmt::Display) -> OptionError {
@@ -996,6 +1016,9 @@ fn coerce_css(v: &LenientScalar) -> OptionResult<CssMode> {
         LenientScalar::Str(s) => match s.as_str() {
             "external" => Ok(CssMode::External),
             "injected" => Ok(CssMode::Injected),
+            "none" => Err(invalid_option(
+                "css: \"none\" is no longer a valid option. If this was crucial for you, please open an issue on GitHub with your use case.",
+            )),
             _ => Err(invalid_option(
                 "css should be either \"external\" (default, recommended) or \"injected\"",
             )),
@@ -1040,6 +1063,7 @@ fn coerce_experimental(v: &LenientScalar) -> OptionResult<ExperimentalOptions> {
     if !v.is_object() {
         return Err(invalid_option("experimental should be an object"));
     }
+    reject_unrecognised_child(v, "experimental", &["async"])?;
     let mut exp = ExperimentalOptions::default();
     if let Some(a) = v.field("async") {
         exp.r#async = coerce_bool("experimental.async", a)?;
@@ -1051,10 +1075,25 @@ fn coerce_compatibility(v: &LenientScalar) -> OptionResult<rsvelte_core::compile
     if !v.is_object() {
         return Err(invalid_option("compatibility should be an object"));
     }
+    reject_unrecognised_child(v, "compatibility", &["componentApi"])?;
     v.field("componentApi").map_or_else(
         || Ok(rsvelte_core::compiler::ComponentApi::default()),
         coerce_component_api,
     )
+}
+
+/// A nested `object()` validator reports an unknown key under its own keypath,
+/// at the point the parent walks it rather than before every other option.
+fn reject_unrecognised_child(v: &LenientScalar, keypath: &str, known: &[&str]) -> OptionResult<()> {
+    let LenientScalar::Object(fields) = v else {
+        return Ok(());
+    };
+    fields
+        .iter()
+        .find(|(k, _)| !known.contains(&k.as_str()))
+        .map_or(Ok(()), |(k, _)| {
+            Err(unrecognised_option(&format!("{keypath}.{k}")))
+        })
 }
 
 /// Typed mirror of `CompileOptions` for the NAPI boundary.
@@ -1106,7 +1145,66 @@ pub struct NapiCompileOptions {
     /// Svelte-4 `loopGuardTimeout`, kept only to raise
     /// `options_removed_loop_guard_timeout`.
     pub loop_guard_timeout: Option<LenientScalar>,
+    /// Upstream's `warningFilter` callback. Declared so a wrong type is rejected
+    /// the way upstream's `fun()` rejects it, and so the callback form is not
+    /// mistaken for an unrecognised key; the synchronous entries still cannot
+    /// call it, and `@rsvelte/vite-plugin-svelte-native` applies it in JS.
+    pub warning_filter: Option<LenientScalar>,
+    /// The six Svelte-4 options upstream declares only so that using one is an
+    /// error. Presence alone is the signal — `undefined` is absence, `null` is
+    /// not.
+    pub legacy: Option<LenientScalar>,
+    pub format: Option<LenientScalar>,
+    pub tag: Option<LenientScalar>,
+    pub svelte_path: Option<LenientScalar>,
+    pub error_mode: Option<LenientScalar>,
+    pub vars_report: Option<LenientScalar>,
 }
+
+/// The keys upstream's `validate-options.js` declares: `common_options` plus
+/// `component_options`. Anything else is `options_unrecognised`. One list serves
+/// both entry points because `validate_module_options` reuses the same key set,
+/// mapping every component key to a no-op validator. `cssHashOverride` is
+/// rsvelte's own constant-hash hatch and has no upstream counterpart.
+///
+/// This must stay equal to the two option structs' declared fields;
+/// `scripts/dev/test-napi-compile-options.mjs` reconciles it against them.
+const RECOGNISED_COMPILE_OPTIONS: &[&str] = &[
+    "filename",
+    "rootDir",
+    "dev",
+    "generate",
+    "warningFilter",
+    "experimental",
+    "accessors",
+    "css",
+    "cssHash",
+    "cssOutputFilename",
+    "customElement",
+    "discloseVersion",
+    "immutable",
+    "legacy",
+    "compatibility",
+    "loopGuardTimeout",
+    "name",
+    "namespace",
+    "modernAst",
+    "outputFilename",
+    "preserveComments",
+    "fragments",
+    "preserveWhitespace",
+    "runes",
+    "hmr",
+    "sourcemap",
+    "enableSourcemap",
+    "hydratable",
+    "format",
+    "tag",
+    "sveltePath",
+    "errorMode",
+    "varsReport",
+    "cssHashOverride",
+];
 
 // Upstream's `warn_once` keeps its `warned` set for the lifetime of the
 // compiler module, so a removed option is reported once per process no matter
@@ -1125,16 +1223,10 @@ impl NapiCompileOptions {
     )]
     fn into_compile_options(self) -> OptionResult<CompileOptions> {
         let mut opts = CompileOptions::default();
-        if let Some(v) = &self.dev {
-            opts.dev = coerce_bool("dev", v)?;
-        }
-        if let Some(v) = &self.generate {
-            let (mode, renamed) = coerce_generate(v)?;
-            opts.generate = mode;
-            if renamed {
-                opts.legacy_options.generate_dom_ssr = warn_once(&WARNED_RENAMED_SSR_DOM);
-            }
-        }
+        // The arms below run in `validate-options.js`'s key-declaration order,
+        // which is the order its `object()` validator walks them in — with two
+        // bad options the one that surfaces is the earlier key, not an arbitrary
+        // one.
         if let Some(v) = &self.filename {
             opts.filename = Some(coerce_string("filename", v)?);
         }
@@ -1150,33 +1242,80 @@ impl NapiCompileOptions {
         {
             opts.root_dir = Some(cwd);
         }
-        if let Some(v) = &self.name {
-            opts.name = Some(coerce_string("name", v)?);
+        if let Some(v) = &self.dev {
+            opts.dev = coerce_bool("dev", v)?;
         }
-        if let Some(v) = &self.custom_element {
-            // `parametric`, not `boolean`: upstream's message has no
-            // ", if specified" tail here.
-            opts.custom_element = match v {
-                LenientScalar::Bool(b) => *b,
-                _ => return Err(invalid_option("customElement should be true or false")),
-            };
+        if let Some(v) = &self.generate {
+            let (mode, renamed) = coerce_generate(v)?;
+            opts.generate = mode;
+            if renamed {
+                opts.legacy_options.generate_dom_ssr = warn_once(&WARNED_RENAMED_SSR_DOM);
+            }
+        }
+        if let Some(v) = &self.warning_filter {
+            // `fun()`: the type is validated here even though the synchronous
+            // entries cannot invoke the callback.
+            if !matches!(v, LenientScalar::Function) {
+                return Err(invalid_option(
+                    "warningFilter should be a function, if specified",
+                ));
+            }
+        }
+        if let Some(v) = &self.experimental {
+            opts.experimental = coerce_experimental(v)?;
         }
         if let Some(v) = &self.accessors {
             opts.accessors = coerce_bool("accessors", v)?;
             opts.legacy_options.accessors = true;
         }
-        if let Some(v) = &self.namespace {
-            opts.namespace = coerce_namespace(v)?;
+        if let Some(v) = &self.css_hash {
+            return Err(match v {
+                LenientScalar::Function => unsupported_option(
+                    "A function-valued `cssHash` cannot be called from this entry point; use `compileWithCssHash` (or `compileAsync`, which routes to it).",
+                ),
+                _ => invalid_option("cssHash should be a function, if specified"),
+            });
+        }
+        if let Some(v) = &self.css_output_filename {
+            opts.css_output_filename = Some(coerce_string("cssOutputFilename", v)?);
+        }
+        if let Some(v) = &self.disclose_version {
+            opts.disclose_version = coerce_bool("discloseVersion", v)?;
         }
         if let Some(v) = &self.immutable {
             opts.immutable = coerce_bool("immutable", v)?;
             opts.legacy_options.immutable = true;
         }
-        if let Some(v) = &self.css {
-            opts.css = coerce_css(v)?;
+        if self.legacy.is_some() {
+            return Err(removed_option(
+                "The legacy option has been removed. If you are using this because of legacy.componentApi, use compatibility.componentApi instead",
+            ));
+        }
+        if let Some(v) = &self.compatibility {
+            opts.compatibility.component_api = coerce_compatibility(v)?;
+        }
+        if self.loop_guard_timeout.is_some() {
+            static WARNED: std::sync::atomic::AtomicBool =
+                std::sync::atomic::AtomicBool::new(false);
+            opts.legacy_options.loop_guard_timeout = warn_once(&WARNED);
+        }
+        if let Some(v) = &self.name {
+            opts.name = Some(coerce_string("name", v)?);
+        }
+        if let Some(v) = &self.namespace {
+            opts.namespace = coerce_namespace(v)?;
+        }
+        if let Some(v) = &self.modern_ast {
+            opts.modern_ast = coerce_bool("modernAst", v)?;
+        }
+        if let Some(v) = &self.output_filename {
+            opts.output_filename = Some(coerce_string("outputFilename", v)?);
         }
         if let Some(v) = &self.preserve_comments {
             opts.preserve_comments = coerce_bool("preserveComments", v)?;
+        }
+        if let Some(v) = &self.fragments {
+            opts.fragments = coerce_fragments(v)?;
         }
         if let Some(v) = &self.preserve_whitespace {
             opts.preserve_whitespace = coerce_bool("preserveWhitespace", v)?;
@@ -1184,8 +1323,8 @@ impl NapiCompileOptions {
         if let Some(v) = &self.runes {
             opts.runes = coerce_runes(v);
         }
-        if let Some(v) = &self.disclose_version {
-            opts.disclose_version = coerce_bool("discloseVersion", v)?;
+        if let Some(v) = &self.hmr {
+            opts.hmr = coerce_bool("hmr", v)?;
         }
         if let Some(v) = self.sourcemap {
             // Preprocessors pass the map as an object; the test harness
@@ -1200,45 +1339,6 @@ impl NapiCompileOptions {
                 opts.sourcemap = serde_json::to_string(&v).ok();
             }
         }
-        if let Some(v) = &self.output_filename {
-            opts.output_filename = Some(coerce_string("outputFilename", v)?);
-        }
-        if let Some(v) = &self.css_output_filename {
-            opts.css_output_filename = Some(coerce_string("cssOutputFilename", v)?);
-        }
-        if let Some(v) = &self.hmr {
-            opts.hmr = coerce_bool("hmr", v)?;
-        }
-        if let Some(v) = &self.modern_ast {
-            opts.modern_ast = coerce_bool("modernAst", v)?;
-        }
-        if let Some(v) = &self.experimental {
-            opts.experimental = coerce_experimental(v)?;
-        }
-        if let Some(v) = &self.compatibility {
-            opts.compatibility.component_api = coerce_compatibility(v)?;
-        }
-        if let Some(v) = &self.css_hash {
-            return Err(match v {
-                LenientScalar::Function => unsupported_option(
-                    "A function-valued `cssHash` cannot be called from this entry point; use `compileWithCssHash` (or `compileAsync`, which routes to it).",
-                ),
-                _ => invalid_option("cssHash should be a function, if specified"),
-            });
-        }
-        if let Some(hash_override) = self.css_hash_override {
-            opts.css_hash = Some(std::sync::Arc::new(
-                move |_: &rsvelte_core::compiler::CssHashInput| hash_override.clone(),
-            ));
-        }
-        if let Some(v) = &self.fragments {
-            opts.fragments = coerce_fragments(v)?;
-        }
-        if self.loop_guard_timeout.is_some() {
-            static WARNED: std::sync::atomic::AtomicBool =
-                std::sync::atomic::AtomicBool::new(false);
-            opts.legacy_options.loop_guard_timeout = warn_once(&WARNED);
-        }
         if self.enable_sourcemap.is_some() {
             static WARNED: std::sync::atomic::AtomicBool =
                 std::sync::atomic::AtomicBool::new(false);
@@ -1249,11 +1349,62 @@ impl NapiCompileOptions {
                 std::sync::atomic::AtomicBool::new(false);
             opts.legacy_options.hydratable = warn_once(&WARNED);
         }
+        if self.format.is_some() {
+            return Err(removed_option(
+                "The format option has been removed in Svelte 4, the compiler only outputs ESM now. Remove \"format\" from your compiler options. If you did not set this yourself, bump the version of your bundler plugin (vite-plugin-svelte/rollup-plugin-svelte/svelte-loader)",
+            ));
+        }
+        if self.tag.is_some() {
+            return Err(removed_option(
+                "The tag option has been removed in Svelte 5. Use `<svelte:options customElement=\"tag-name\" />` inside the component instead. If that does not solve your use case, please open an issue on GitHub with details.",
+            ));
+        }
+        if self.svelte_path.is_some() {
+            return Err(removed_option(
+                "The sveltePath option has been removed in Svelte 5. If this option was crucial for you, please open an issue on GitHub with your use case.",
+            ));
+        }
+        if self.error_mode.is_some() {
+            return Err(removed_option(
+                "The errorMode option has been removed. If you are using this through svelte-preprocess with TypeScript, use the https://www.typescriptlang.org/tsconfig#verbatimModuleSyntax setting instead",
+            ));
+        }
+        if self.vars_report.is_some() {
+            return Err(removed_option(
+                "The vars option has been removed. If you are using this through svelte-preprocess with TypeScript, use the https://www.typescriptlang.org/tsconfig#verbatimModuleSyntax setting instead",
+            ));
+        }
+        // `customElement` and `css` are `parametric()`, whose normalizer runs on
+        // the first CALL rather than during validation — so upstream reports
+        // them only after every plain validator has passed, and `customElement`
+        // (read during analysis) before `css`.
+        if let Some(v) = &self.custom_element {
+            // `parametric`, not `boolean`: upstream's message has no
+            // ", if specified" tail here.
+            opts.custom_element = match v {
+                LenientScalar::Bool(b) => *b,
+                _ => return Err(invalid_option("customElement should be true or false")),
+            };
+        }
+        if let Some(v) = &self.css {
+            opts.css = coerce_css(v)?;
+        }
+        // rsvelte-only, and never a failure: it has no upstream position.
+        if let Some(hash_override) = self.css_hash_override {
+            opts.css_hash = Some(std::sync::Arc::new(
+                move |_: &rsvelte_core::compiler::CssHashInput| hash_override.clone(),
+            ));
+        }
         Ok(opts)
     }
 }
 
 /// Typed mirror of `ModuleCompileOptions`.
+///
+/// Upstream's `validate_module_options` is `common_options` plus every
+/// *component* key mapped to a no-op, so a component-only key is accepted and
+/// ignored here rather than validated — that is why this declares fewer fields
+/// than `RECOGNISED_COMPILE_OPTIONS` lists.
 #[napi(object)]
 pub struct NapiModuleCompileOptions {
     pub dev: Option<LenientScalar>,
@@ -1261,11 +1412,20 @@ pub struct NapiModuleCompileOptions {
     pub filename: Option<LenientScalar>,
     pub root_dir: Option<LenientScalar>,
     pub experimental: Option<LenientScalar>,
+    /// A `common_options` key, so — unlike the component options — its type is
+    /// validated on this entry point too.
+    pub warning_filter: Option<LenientScalar>,
 }
 
 impl NapiModuleCompileOptions {
     fn into_module_compile_options(self) -> OptionResult<ModuleCompileOptions> {
         let mut opts = ModuleCompileOptions::default();
+        if let Some(v) = &self.filename {
+            opts.filename = Some(coerce_string("filename", v)?);
+        }
+        if let Some(v) = &self.root_dir {
+            opts.root_dir = Some(coerce_string("rootDir", v)?);
+        }
         if let Some(v) = &self.dev {
             opts.dev = coerce_bool("dev", v)?;
         }
@@ -1276,11 +1436,12 @@ impl NapiModuleCompileOptions {
                 opts.legacy_options.generate_dom_ssr = warn_once(&WARNED_RENAMED_SSR_DOM);
             }
         }
-        if let Some(v) = &self.filename {
-            opts.filename = Some(coerce_string("filename", v)?);
-        }
-        if let Some(v) = &self.root_dir {
-            opts.root_dir = Some(coerce_string("rootDir", v)?);
+        if let Some(v) = &self.warning_filter
+            && !matches!(v, LenientScalar::Function)
+        {
+            return Err(invalid_option(
+                "warningFilter should be a function, if specified",
+            ));
         }
         if let Some(v) = &self.experimental {
             opts.experimental = coerce_experimental(v)?;
@@ -1289,32 +1450,132 @@ impl NapiModuleCompileOptions {
     }
 }
 
-/// Compatibility wrapper: convert an Option<NapiCompileOptions> (the
+/// The one thing `#[napi(object)]` structurally cannot see: the keys it does
+/// *not* declare. Its generated decoder reads declared fields by name and never
+/// enumerates the object, so an unrecognised key reaches the compiler as
+/// silence. These wrappers decode the key list alongside the fields, letting the
+/// conversion raise `options_unrecognised` first — the position upstream's
+/// `object()` validator reports it from.
+pub struct NapiCompileOptionsArg {
+    inner: NapiCompileOptions,
+    unrecognised: Option<String>,
+}
+
+/// The module entry's counterpart. Its recognised set is the same one: upstream
+/// declares every component key on the module validator as a no-op.
+pub struct NapiModuleCompileOptionsArg {
+    inner: NapiModuleCompileOptions,
+    unrecognised: Option<String>,
+}
+
+/// Upstream's `object()` walks `for (const key in input)`, so an inherited
+/// enumerable key counts and a key whose value is `undefined` still counts.
+/// `napi_get_property_names` — what `Object::keys` calls — enumerates the same
+/// set, so `{ nonsense: undefined }` is rejected on both sides.
+unsafe fn first_unrecognised_key(
+    env: napi::sys::napi_env,
+    napi_val: napi::sys::napi_value,
+) -> napi::Result<Option<String>> {
+    let mut val_type = 0;
+    // SAFETY: `env`/`napi_val` are valid handles from Node-API; `napi_typeof`
+    // only reads them and writes the type tag.
+    let status = unsafe { napi::sys::napi_typeof(env, napi_val, &raw mut val_type) };
+    if status != napi::sys::Status::napi_ok {
+        return Err(napi::Error::from_status(napi::Status::from(status)));
+    }
+    if val_type != napi::sys::ValueType::napi_object {
+        return Ok(None);
+    }
+    // SAFETY: confirmed object; properties are read through the safe `Object` API.
+    let obj = napi::bindgen_prelude::Object::from_raw(env, napi_val);
+    Ok(napi::bindgen_prelude::Object::keys(&obj)?
+        .into_iter()
+        .find(|key| !RECOGNISED_COMPILE_OPTIONS.contains(&key.as_str())))
+}
+
+macro_rules! option_arg_wrapper {
+    ($wrapper:ty, $inner:ty, $name:literal) => {
+        impl napi::bindgen_prelude::TypeName for $wrapper {
+            fn type_name() -> &'static str {
+                $name
+            }
+            fn value_type() -> napi::ValueType {
+                napi::ValueType::Object
+            }
+        }
+
+        impl napi::bindgen_prelude::ValidateNapiValue for $wrapper {}
+
+        impl napi::bindgen_prelude::FromNapiValue for $wrapper {
+            unsafe fn from_napi_value(
+                env: napi::sys::napi_env,
+                napi_val: napi::sys::napi_value,
+            ) -> napi::Result<Self> {
+                // SAFETY: valid handles from Node-API, forwarded to the key scan.
+                let unrecognised = unsafe { first_unrecognised_key(env, napi_val)? };
+                // SAFETY: the same valid handles, forwarded to the field decoder
+                // `#[napi(object)]` derived for the inner struct.
+                let inner = unsafe { <$inner>::from_napi_value(env, napi_val)? };
+                Ok(Self {
+                    inner,
+                    unrecognised,
+                })
+            }
+        }
+
+        impl napi::bindgen_prelude::ToNapiValue for $wrapper {
+            unsafe fn to_napi_value(
+                env: napi::sys::napi_env,
+                val: Self,
+            ) -> napi::Result<napi::sys::napi_value> {
+                // SAFETY: `env` is the valid env Node-API passed in; the derived
+                // impl does the work. Input-only in practice — this exists so
+                // `#[napi(object)]` structs holding the type satisfy the bound.
+                unsafe { <$inner>::to_napi_value(env, val.inner) }
+            }
+        }
+    };
+}
+
+option_arg_wrapper!(NapiCompileOptionsArg, NapiCompileOptions, "CompileOptions");
+option_arg_wrapper!(
+    NapiModuleCompileOptionsArg,
+    NapiModuleCompileOptions,
+    "ModuleCompileOptions"
+);
+
+/// Compatibility wrapper: convert an Option<NapiCompileOptionsArg> (the
 /// typed surface) into `CompileOptions`. `None` and `Some(empty)`
 /// both produce the defaults.
 fn options_to_compile(
     env: Option<&Env>,
-    opts: Option<NapiCompileOptions>,
+    opts: Option<NapiCompileOptionsArg>,
 ) -> napi::Result<CompileOptions> {
     let Some(opts) = opts else {
         return Ok(CompileOptions::default());
     };
     // Upstream seeds `state.filename` from the raw option before validating, so
     // the option error carries it even when a *later* option is what failed.
-    let filename = raw_filename(opts.filename.as_ref());
-    opts.into_compile_options()
+    let filename = raw_filename(opts.inner.filename.as_ref());
+    opts.unrecognised
+        .as_deref()
+        .map_or(Ok(()), |key| Err(unrecognised_option(key)))
+        .and_then(|()| opts.inner.into_compile_options())
         .map_err(|e| e.into_napi(env, filename.as_deref()))
 }
 
 fn options_to_module_compile(
     env: Option<&Env>,
-    opts: Option<NapiModuleCompileOptions>,
+    opts: Option<NapiModuleCompileOptionsArg>,
 ) -> napi::Result<ModuleCompileOptions> {
     let Some(opts) = opts else {
         return Ok(ModuleCompileOptions::default());
     };
-    let filename = raw_filename(opts.filename.as_ref());
-    opts.into_module_compile_options()
+    let filename = raw_filename(opts.inner.filename.as_ref());
+    opts.unrecognised
+        .as_deref()
+        .map_or(Ok(()), |key| Err(unrecognised_option(key)))
+        .and_then(|()| opts.inner.into_module_compile_options())
         .map_err(|e| e.into_napi(env, filename.as_deref()))
 }
 
@@ -1338,7 +1599,7 @@ fn raw_filename(v: Option<&LenientScalar>) -> Option<String> {
 pub fn napi_compile_module(
     env: Env,
     source: String,
-    options: Option<NapiModuleCompileOptions>,
+    options: Option<NapiModuleCompileOptionsArg>,
 ) -> napi::Result<Value> {
     let opts = options_to_module_compile(Some(&env), options)?;
     let filename = opts.filename.clone();
@@ -1973,7 +2234,7 @@ pub struct CompileBuffersResult {
 pub fn napi_compile_buffers(
     env: Env,
     source: String,
-    options: Option<NapiCompileOptions>,
+    options: Option<NapiCompileOptionsArg>,
 ) -> napi::Result<CompileBuffersResult> {
     let opts = options_to_compile(Some(&env), options)?;
     reject_modern_ast_for_binary_result(&opts, "compileBuffers")?;
@@ -2012,7 +2273,7 @@ pub fn napi_compile_buffers(
 pub fn napi_compile_module_buffers(
     env: Env,
     source: String,
-    options: Option<NapiModuleCompileOptions>,
+    options: Option<NapiModuleCompileOptionsArg>,
 ) -> napi::Result<CompileBuffersResult> {
     let opts = options_to_module_compile(Some(&env), options)?;
 
@@ -2104,7 +2365,7 @@ fn reject_modern_ast_for_binary_result(options: &CompileOptions, api: &str) -> n
 pub fn napi_compile_envelope(
     env: Env,
     source: String,
-    options: Option<NapiCompileOptions>,
+    options: Option<NapiCompileOptionsArg>,
 ) -> napi::Result<Buffer> {
     let opts = options_to_compile(Some(&env), options)?;
     let filename = opts.filename.clone();
@@ -2124,7 +2385,7 @@ pub fn napi_compile_envelope(
 pub fn napi_compile_envelope_external_sources(
     env: Env,
     source: String,
-    options: Option<NapiCompileOptions>,
+    options: Option<NapiCompileOptionsArg>,
 ) -> napi::Result<Buffer> {
     let opts = options_to_compile(Some(&env), options)?;
     let filename = opts.filename.clone();
@@ -2266,7 +2527,7 @@ fn create_zero_copy_envelope(
 pub fn napi_compile_envelope_zero_copy(
     env: Env,
     source: String,
-    options: Option<NapiCompileOptions>,
+    options: Option<NapiCompileOptionsArg>,
 ) -> napi::Result<JsBuffer> {
     let opts = options_to_compile(Some(&env), options)?;
     reject_modern_ast_for_binary_result(&opts, "compileEnvelopeZeroCopy")?;
@@ -2290,7 +2551,7 @@ pub fn napi_compile_envelope_zero_copy(
 pub fn napi_compile_module_envelope_zero_copy(
     env: Env,
     source: String,
-    options: Option<NapiModuleCompileOptions>,
+    options: Option<NapiModuleCompileOptionsArg>,
 ) -> napi::Result<JsBuffer> {
     let opts = options_to_module_compile(Some(&env), options)?;
     let result = match rust_compile_module(&source, opts) {
@@ -2322,7 +2583,7 @@ pub fn napi_compile_module_envelope_zero_copy(
 pub fn napi_compile_module_envelope(
     env: Env,
     source: String,
-    options: Option<NapiModuleCompileOptions>,
+    options: Option<NapiModuleCompileOptionsArg>,
 ) -> napi::Result<Buffer> {
     let opts = options_to_module_compile(Some(&env), options)?;
     match rust_compile_module(&source, opts) {
@@ -2367,7 +2628,7 @@ pub fn napi_compile_module_envelope(
 #[napi(object)]
 pub struct CompileBatchInput {
     pub source: String,
-    pub options: Option<NapiCompileOptions>,
+    pub options: Option<NapiCompileOptionsArg>,
 }
 
 /// Compile multiple Svelte components in parallel via rayon, packing
@@ -2541,7 +2802,7 @@ impl Task for CompileEnvelopeTask {
 pub fn napi_compile_envelope_async(
     env: Env,
     source: String,
-    options: Option<NapiCompileOptions>,
+    options: Option<NapiCompileOptionsArg>,
 ) -> napi::Result<AsyncTask<CompileEnvelopeTask>> {
     let options = options_to_compile(Some(&env), options)?;
     reject_modern_ast_for_binary_result(&options, "compileEnvelopeAsync")?;
@@ -2566,7 +2827,7 @@ pub fn napi_compile_envelope_async(
 pub fn napi_compile_envelope_external_sources_async(
     env: Env,
     source: String,
-    options: Option<NapiCompileOptions>,
+    options: Option<NapiCompileOptionsArg>,
 ) -> napi::Result<AsyncTask<CompileEnvelopeTask>> {
     let options = options_to_compile(Some(&env), options)?;
     reject_modern_ast_for_binary_result(&options, "compileEnvelopeExternalSourcesAsync")?;

--- a/scripts/dev/test-napi-compile-options.mjs
+++ b/scripts/dev/test-napi-compile-options.mjs
@@ -31,7 +31,10 @@ import { readFileSync } from 'node:fs';
 import { createRequire } from 'node:module';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { compile as officialCompile } from '../../submodules/svelte/packages/svelte/src/compiler/index.js';
+import {
+	compile as officialCompile,
+	compileModule as officialCompileModule,
+} from '../../submodules/svelte/packages/svelte/src/compiler/index.js';
 
 const here = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(here, '../..');
@@ -171,6 +174,8 @@ const DECLARED = new Map([
 
 // Keys no input can discriminate, each with the reason. A guess here is worse
 // than a gap: it reads as surveyed.
+const REMOVED_KEY_REASON =
+	'declared only so that using it is an error — upstream `validate-options.js` gives it a `removed()` validator with no behaviour, so there is no compile result for a baseline/variant pair to differ in; the error SHAPE is covered by the `removed-*` rows of INVALID_OPTIONS below and its absence on `compileModule` by MODULE_VALID_OPTIONS';
 const UNCOVERED = new Map([
 	[
 		'compile.cssHash',
@@ -180,7 +185,60 @@ const UNCOVERED = new Map([
 		'compileModule.rootDir',
 		'forwarded to CompileOptions but every consumer of `root_dir` (the `$.FILENAME` / HMR key in the client component transform, and the CSS scope hash) is component-only, so a module compile has nothing to observe',
 	],
+	[
+		'compile.warningFilter',
+		'a callback the synchronous entries cannot invoke: declared so a wrong TYPE is rejected the way upstream `fun()` rejects it, and so the callback form is not mistaken for an unrecognised key. Its type check is covered by the `warningFilter-*` rows of INVALID_OPTIONS and the function form by VALID_OPTIONS; applying it is `@rsvelte/vite-plugin-svelte-native`\'s job and is covered by `test:vps-shim` (see #3396)',
+	],
+	['compileModule.warningFilter', 'as compile.warningFilter — a `common_options` key, so its type is validated on this entry point too'],
+	['compile.legacy', REMOVED_KEY_REASON],
+	['compile.format', REMOVED_KEY_REASON],
+	['compile.tag', REMOVED_KEY_REASON],
+	['compile.sveltePath', REMOVED_KEY_REASON],
+	['compile.errorMode', REMOVED_KEY_REASON],
+	['compile.varsReport', REMOVED_KEY_REASON],
 ]);
+
+// ---------------------------------------------------------------------------
+// 1b. The keys the boundary must NOT reject
+// ---------------------------------------------------------------------------
+//
+// `#[napi(object)]` reads the fields it declares and never enumerates the
+// object, so until an explicit key scan landed there was no key it could see as
+// unrecognised. That scan has a list, and a list can drift from the structs it
+// mirrors in the direction that hurts: a key dropped from it makes the boundary
+// reject an option the compiler still supports. Reconcile both ways.
+
+function recognisedKeyList(src) {
+	const m = src.match(/const RECOGNISED_COMPILE_OPTIONS: &\[&str\] = &\[([\s\S]*?)\n\];/);
+	if (!m) return null;
+	return [...m[1].matchAll(/"([^"]+)"/g)].map((x) => x[1]);
+}
+
+console.log('\n# unrecognised-key scan');
+const recognised = recognisedKeyList(libSource);
+assert('lib.rs still declares RECOGNISED_COMPILE_OPTIONS', recognised != null);
+if (recognised) {
+	const declaredKeys = new Set([
+		...(structs.get('NapiCompileOptions') ?? []),
+		...(structs.get('NapiModuleCompileOptions') ?? []),
+	]);
+	const notDeclared = recognised.filter((k) => !declaredKeys.has(k));
+	assert(
+		'every recognised key is a declared field of one of the option structs',
+		notDeclared.length === 0,
+		notDeclared.join(', ')
+	);
+	const notRecognised = [...declaredKeys].filter((k) => !recognised.includes(k));
+	assert(
+		'every declared option field is in the recognised set (else the boundary rejects a supported key)',
+		notRecognised.length === 0,
+		notRecognised.join(', ')
+	);
+	assert(
+		'the recognised set has no duplicates',
+		new Set(recognised).size === recognised.length
+	);
+}
 
 // ---------------------------------------------------------------------------
 // 2. Per-key discriminating cases
@@ -768,6 +826,43 @@ const INVALID_OPTIONS = [
 	['compatibility-number', { compatibility: 2 }],
 	['componentApi-3', { compatibility: { componentApi: 3 } }],
 	['componentApi-string', { compatibility: { componentApi: '4' } }],
+	// A key `validate-options.js` does not declare. `#[napi(object)]` has no
+	// field for one, so this was silence until the boundary learned to
+	// enumerate the object's own keys (#3535).
+	['unknown-key', { nonsense: 1 }],
+	// Presence, not definedness: upstream walks `for (const key in input)`.
+	['unknown-key-undefined', { nonsense: undefined }],
+	['unknown-key-null', { nonsense: null }],
+	['unknown-key-typo', { preserveComment: true }],
+	// A nested `object()` reports under its own keypath.
+	['unknown-child-experimental', { experimental: { nope: 1 } }],
+	['unknown-child-compatibility', { compatibility: { nope: 1 } }],
+	// `removed()`, not `warn_removed()`: these throw.
+	['removed-legacy', { legacy: {} }],
+	['removed-legacy-null', { legacy: null }],
+	['removed-format', { format: 'esm' }],
+	['removed-tag', { tag: 'x-a' }],
+	['removed-sveltePath', { sveltePath: 'svelte' }],
+	['removed-errorMode', { errorMode: 'warn' }],
+	['removed-varsReport', { varsReport: 'full' }],
+	['warningFilter-string', { warningFilter: 'nope' }],
+	['warningFilter-number', { warningFilter: 3 }],
+	// css: 'none' has its own upstream message, distinct from the generic one.
+	['css-none', { css: 'none' }],
+	// Which of two failures surfaces is upstream's key-declaration order, and
+	// the unrecognised-key loop runs before every validator.
+	['prec-unknown-beats-dev', { nonsense: 1, dev: 'yes' }],
+	['prec-unknown-beats-removed', { nonsense: 1, legacy: {} }],
+	['prec-dev-beats-removed', { legacy: {}, dev: 'yes' }],
+	['prec-removed-beats-namespace', { legacy: {}, namespace: 'nope' }],
+	['prec-name-beats-fragments', { fragments: 'nope', name: 3 }],
+	// `css` and `customElement` are `parametric()`: their normalizer runs on the
+	// first CALL, so upstream reports them only after every plain validator has
+	// passed — and `customElement` before `css`.
+	['prec-varsReport-beats-css', { css: 'none', varsReport: 'x' }],
+	['prec-name-beats-css', { css: 'none', name: 3 }],
+	['prec-name-beats-customElement', { customElement: 'x-a', name: 3 }],
+	['prec-customElement-beats-css', { css: 'none', customElement: 'x-a' }],
 ];
 
 const VALID_OPTIONS = [
@@ -777,6 +872,52 @@ const VALID_OPTIONS = [
 	['generate-server', { generate: 'server' }],
 	['fragments-tree', { fragments: 'tree' }],
 	['componentApi-4', { compatibility: { componentApi: 4 } }],
+	// `removed()` fires on `input !== undefined`, so an explicitly-undefined
+	// removed key is absence. An over-eager `is_some()` would reject this.
+	['removed-legacy-undefined', { legacy: undefined }],
+	['removed-format-undefined', { format: undefined }],
+	// Callback-shaped and map-shaped keys the vite plugin forwards: both must
+	// survive the unrecognised-key scan.
+	['warningFilter-function', { warningFilter: (w) => w.code !== 'nope' }],
+	['sourcemap-object', { sourcemap: INPUT_MAP }],
+	// `warn_removed()` warns; it must not throw.
+	['hydratable', { hydratable: true }],
+	['enableSourcemap', { enableSourcemap: false }],
+	['loopGuardTimeout', { loopGuardTimeout: 100 }],
+];
+
+// The entry point is a second axis, and upstream answers differently on it:
+// `validate_module_options` is `common_options` plus every COMPONENT key mapped
+// to a no-op, so a removed option is an error on `compile` and silence on
+// `compileModule`, while an unrecognised key is an error on both. A grid that
+// only drives `compile` cannot see either half.
+// A module whose compilation cannot itself fail, so a thrown value is the option check.
+const MODULE_OPT_SRC = 'export const x = 1;\n';
+
+const MODULE_INVALID_OPTIONS = [
+	['unknown-key', { nonsense: 1 }],
+	['unknown-key-undefined', { nonsense: undefined }],
+	['unknown-child-experimental', { experimental: { nope: 1 } }],
+	['warningFilter-string', { warningFilter: 'nope' }],
+	['dev-string', { dev: 'yes' }],
+	['prec-unknown-beats-dev', { nonsense: 1, dev: 'yes' }],
+];
+
+const MODULE_VALID_OPTIONS = [
+	['baseline', {}],
+	// Every one of these is a component option, which the module validator
+	// declares as a no-op — accepted here and rejected on `compile`.
+	['removed-legacy', { legacy: {} }],
+	['removed-format', { format: 'esm' }],
+	['removed-tag', { tag: 'x-a' }],
+	['removed-sveltePath', { sveltePath: 'svelte' }],
+	['removed-errorMode', { errorMode: 'warn' }],
+	['removed-varsReport', { varsReport: 'full' }],
+	['namespace-bogus', { namespace: 'nope' }],
+	['css-none', { css: 'none' }],
+	['name-number', { name: 1 }],
+	['unknown-child-compatibility', { compatibility: { nope: 1 } }],
+	['warningFilter-function', { warningFilter: (w) => w.code !== 'nope' }],
 ];
 
 function errorShape(compile, opts) {
@@ -819,6 +960,62 @@ for (const [label, opts] of VALID_OPTIONS) {
 	const rs = errorShape(napi.compile, opts);
 	assert(`valid.${label}: official accepts it`, !sv.threw, sv.message);
 	assert(`valid.${label}: rsvelte accepts it`, !rs.threw, rs.message);
+}
+
+// `cssHashOverride` is rsvelte-only, so it cannot be compared against the oracle
+// — official rejects it as unrecognised, correctly. It still has to survive
+// rsvelte's own key scan, which is the half a shared row would have covered.
+{
+	const rs = errorShape(napi.compile, { cssHashOverride: 's-DEADBEEF' });
+	assert('rsvelte-only.cssHashOverride: the key scan does not reject it', !rs.threw, rs.message);
+	const sv = errorShape(officialCompile, { cssHashOverride: 's-DEADBEEF' });
+	assert(
+		'rsvelte-only.cssHashOverride: official rejects it, which is why it cannot be a shared row',
+		sv.threw && sv.code === 'options_unrecognised',
+		sv.code
+	);
+}
+
+function moduleErrorShape(compileModule, opts) {
+	try {
+		compileModule(MODULE_OPT_SRC, { filename: 'a.svelte.js', ...opts });
+		return { threw: false };
+	} catch (e) {
+		return {
+			threw: true,
+			code: e.code === undefined ? '(absent)' : String(e.code),
+			name: String(e.name),
+			filename: e.filename === undefined ? '(absent)' : String(e.filename),
+			message: String(e.message),
+		};
+	}
+}
+
+console.log('\n# compileModule option-validation error shape');
+for (const [label, opts] of MODULE_INVALID_OPTIONS) {
+	const sv = moduleErrorShape(officialCompileModule, opts);
+	const rs = moduleErrorShape(napi.compileModule, opts);
+	if (!sv.threw) {
+		assert(`module.invalid.${label}: official rejects it`, false, 'the oracle accepted — fix the row');
+		continue;
+	}
+	if (!rs.threw) {
+		assert(`module.invalid.${label}: rsvelte rejects it too`, false, 'rsvelte compiled it');
+		continue;
+	}
+	for (const field of ['code', 'name', 'filename', 'message']) {
+		assert(
+			`module.invalid.${label}: ${field}`,
+			rs[field] === sv[field],
+			`official ${JSON.stringify(sv[field])} vs rsvelte ${JSON.stringify(rs[field])}`
+		);
+	}
+}
+for (const [label, opts] of MODULE_VALID_OPTIONS) {
+	const sv = moduleErrorShape(officialCompileModule, opts);
+	const rs = moduleErrorShape(napi.compileModule, opts);
+	assert(`module.valid.${label}: official accepts it`, !sv.threw, sv.message);
+	assert(`module.valid.${label}: rsvelte accepts it`, !rs.threw, rs.message);
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #3535.

## What was wrong

`NapiCompileOptions` is `#[napi(object)]`, whose derived `FromNapiValue` reads the fields it
declares **by name** and never enumerates the JavaScript object. There is therefore no key it
does not declare for it to see, so every key upstream's `validate-options.js` rejects reached the
compiler as silence: an unrecognised key, and the six Svelte-4 options upstream declares *only*
in order to reject.

The user-visible half is `options_unrecognised`. It is what turns a typo in `svelte.config.js`'s
`compilerOptions` into an error. Under rsvelte a misspelled option was accepted, ignored, and the
build succeeded with the default — the failure surfaced later as wrong output, or never.

## What the oracle actually does

Everything below is **read off a run**, not from the issue text. Official `VERSION`, asserted
from the compiler's own export rather than from a filename: **5.56.9** (`AGENTS.md` says 5.56.8
and the repo-root `node_modules` devDependency is 5.56.10; the submodule is the one every gate
here compiles against).

The issue treats one behaviour; there are three, and they differ on the entry point:

| input | `compile` | `compileModule` | `parse` |
|---|---|---|---|
| `{ nonsense: 1 }` | `options_unrecognised` | `options_unrecognised` | accepted |
| `{ nonsense: undefined }` | **`options_unrecognised`** | **`options_unrecognised`** | accepted |
| `{ legacy: {} }` and the other five | `options_removed` | **accepted, silently** | accepted |
| `{ legacy: undefined }` | **accepted** | accepted | accepted |
| `{ legacy: null }` | `options_removed` | accepted | accepted |
| `{ namespace: 'nope' }` | `options_invalid_value` | **accepted, silently** | accepted |
| `{ warningFilter: 'nope' }` | `options_invalid_value` | `options_invalid_value` | accepted |
| `{ experimental: { nope: 1 } }` | `options_unrecognised experimental.nope` | same | accepted |

Four things there are not guessable from the issue and each changed the fix:

1. **Presence, not definedness, for an unknown key.** `object()` walks `for (const key in input)`,
   so `{ nonsense: undefined }` throws. `removed()` is the opposite — it tests `input !== undefined`,
   so `{ legacy: undefined }` does not. The scan uses `napi_get_property_names`, which enumerates
   the same set `for…in` does; the `removed` arms test `is_some()`, which `#[napi(object)]` already
   maps `undefined` to `None`.
2. **`compileModule` is a different validator.** `validate_module_options` is `common_options` plus
   every *component* key mapped to a no-op, so a removed option is an error on `compile` and
   silence on `compileModule`, while an unrecognised key is an error on both and `warningFilter`
   is type-checked on both. One recognised-key list serves both entry points; only the six
   `common_options` are validated on the module one.
3. **`parse()` validates nothing**, upstream and here. It is the control that must not move.
4. **`css` and `customElement` are `parametric()`, and their normalizer runs on the first CALL,
   not during validation.** So upstream reports them only after every plain validator has passed.
   Measured: `{css:'none', varsReport:'x'}` → `options_removed`; `{css:'none', name:3}` → `name`;
   `{customElement:'x-a', css:'none'}` → `customElement`. My first draft put both at their
   declaration position, which would have **regressed** those cells — the grid caught it before
   the commit, not review.

## The fix

- A key scan at the boundary. `NapiCompileOptionsArg` / `NapiModuleCompileOptionsArg` wrap the
  derived decoders and read the object's own key list alongside the fields, so the conversion can
  raise `options_unrecognised` **first** — the position upstream's `object()` reports it from.
  `RECOGNISED_COMPILE_OPTIONS` is the list, and it is reconciled against the two structs' declared
  fields **in both directions** by `test:napi-options` (a key dropped from it would make the
  boundary reject an option the compiler still supports — the failure mode that hurts).
- Seven new declared fields: the six `removed()` options, raising `options_removed` with upstream's
  exact prose, plus `warningFilter`, type-checked like upstream's `fun()`. `warningFilter` **had** to
  be declared — without it the new scan would have rejected every call the vite plugin makes.
- `into_compile_options` now runs in upstream's key-declaration order, with `customElement` and then
  `css` last for the `parametric()` reason above.
- `css: 'none'` gets upstream's own message instead of the generic one.
- Nested `object()` children (`experimental.*`, `compatibility.*`) report `options_unrecognised`
  under their own keypath.

## The grid

**option × value × entry point**, official vs the raw NAPI addon, every cell in its own process
because upstream's `warn_once` latches are per-process and a shared one would score the second
cell as silent. 69 option variants × 3 shared entry points = 207 cells, plus 3 rsvelte-only
entries. The key is **the thrown error and the warning set as well as the output**, because an
ignored option produces no error, no warning and often identical output — a key of `(output)`
cannot see this defect at all.

| verdict | before | after |
|---|---|---|
| `match` (both compiled; same warnings, js, css) | 133 | 133 |
| `both-reject` (same `code` **and** same `message`) | 31 | **63** |
| `both-reject-msg` (same code, different prose) | 2 | **0** |
| `both-reject-code` | 6 | **2** |
| **`silent`** (official rejects, rsvelte compiles) | **29** | **3** |
| `rs-rejects` (official compiles, rsvelte rejects) | 3 | 3 |
| `output-differs` | 2 | 2 |
| `warn-differs` | 1 | 1 |
| **divergent (everything but match/both-reject)** | **43** | **11** |

The verdict is not one bit, for #3384's reason: collapsing `silent` and `rs-rejects` into
"divergent" would score this PR as *no change at all* on the cells it converts.

**All 11 remaining cells are accounted for and none is attributable to #3535:**

| cells | what | status |
|---|---|---|
| 5 | function-valued `css` / `customElement` / `cssHash` / `warningFilter` / `runes` | **#3396**, open, not closed here |
| 1 | `css: 'injected'` output | **#3226**, open |
| 1 | `customElement: true` output | **#3382**, open |
| 2 | `cssHashOverride` | rsvelte-only by design — official rejects it as unrecognised. Asserted as an rsvelte-only row rather than a shared one, with the oracle's refusal pinned so the row cannot silently become a parity claim |
| 2 | `filename: 3` | official throws a bare `TypeError` with `code: undefined` from `state.reset` **before** its own `string()` validator runs; rsvelte throws the coded `options_invalid_value` that validator specifies. rsvelte is the more faithful of the two |

Per entry point after the fix: `parse` **69/69 match** (the control — neither side validates);
`compile` and `compileBoth` identical to each other; `compileModule` 49 match + 18 both-reject.

## Controls

Every row below was measured against the oracle before being asserted, and every one stayed green
through the revert control.

| control | why it is here | before | after |
|---|---|---|---|
| `parse` with each of the 69 variants | upstream validates nothing here; the scan must not leak into it | 69 match | 69 match |
| `{ legacy: undefined }`, `{ format: undefined }` | `removed()` tests `!== undefined`; an eager `is_some()` would reject these | accepted | accepted |
| `compileModule` with all six removed options, `namespace:'nope'`, `css:'none'`, `name:1`, `compatibility:{nope:1}` | the module validator declares component keys as no-ops | accepted | accepted |
| `warningFilter: (w) => …`, `sourcemap: <v3 map>` | the vite plugin forwards both; the scan must not reject them | accepted | accepted |
| `hydratable` / `enableSourcemap` / `loopGuardTimeout` | `warn_removed()` warns, it must not throw | warn | warn |
| the 27 pre-existing `INVALID_OPTIONS` rows and every discrimination case | no regression in what already worked | green | green |
| `test:vps-shim` (62), `test:napi-csshash` (29), `test:vps-fixture` (6), `test:vps-unit` (32), `test:envelope`, `test:parse-envelope` | the shim pre-resolves function options and deletes `warningFilter`; these are the consumers the new refusal could break | green | green |

Three precedence rows — `prec-name-beats-css`, `prec-name-beats-customElement`,
`prec-customElement-beats-css` — **passed before the fix too**. They are controls, not evidence:
the old order happened to agree with upstream on them. The rows that discriminate the reorder are
`prec-removed-beats-namespace` and `prec-varsReport-beats-css`, and both were red.

## Revert control

Pre-fix binary, post-fix tests: **29 failures, 0 control failures**, each for the predicted reason.
A sample of the actual text:

```
FAIL invalid.unknown-key: rsvelte rejects it too — rsvelte compiled it
FAIL invalid.removed-varsReport: rsvelte rejects it too — rsvelte compiled it
FAIL invalid.css-none: message — official "…css: \"none\" is no longer a valid option…"
                                 vs rsvelte "…css should be either \"external\" … or \"injected\"…"
FAIL invalid.prec-unknown-beats-dev: code — official "options_unrecognised" vs rsvelte "options_invalid_value"
FAIL invalid.prec-varsReport-beats-css: code — official "options_removed" vs rsvelte "options_invalid_value"
FAIL module.invalid.warningFilter-string: rsvelte rejects it too — rsvelte compiled it
```

Restoring the fixed artifact returns `400 passed, 0 failed`.

## Where the coverage lives, and why there is no `pattern-corpus` repro

**A `pattern-corpus` file cannot carry a compile option.** That corpus compiles every entry with
`scripts/compat-corpus/targets.mjs`'s fixed targets, which vary `generate` and `dev` and nothing
else (#3384) — there is no place in a `.svelte` file to say `{ nonsense: 1 }`. The coverage is
therefore in `scripts/dev/test-napi-compile-options.mjs`, the gate that already owns this
boundary, which gains: the recognised-key reconciliation, 26 new `INVALID_OPTIONS` rows compared
on `code` + `name` + `filename` + `message`, 10 new `VALID_OPTIONS` rows, an rsvelte-only
`cssHashOverride` row that also pins the oracle's refusal, and a **new `compileModule` half** —
the entry-point axis, which no gate had.

## What this does *not* close

**#3396 stays open, deliberately.** Its five function-valued options are five of the eleven
remaining cells. Two of them (`runes`, `warningFilter`) are still accepted and ignored by the raw
addon. Making them refuse is a behaviour decision about a published entry point, and it interacts
with this PR only in that `warningFilter` now has to be *declared* — so the decision is now one
`match` arm away, in a place a gate watches, instead of absent.

**#3384 stays open.** This PR gates the option axis at the NAPI boundary; it does not add the
`compiler-option` matrix family that would cross option × component *shape* over the corpus
targets. Its own lesson applies to what I did here, though, and I applied it: the grid's source
carries an `<img src="a.png" />` precisely so `warningFilter` has a warning to filter — without it
that row is green whether or not the callback is honoured.

## Separate defects found, filed rather than folded in

Four, none of them touched by this PR: three rsvelte-only NAPI entry points that answer
differently from `compile()`, and a release-plumbing gap. Filed as their own issues; see the
comment below.
