### PR TITLE
ci: map rsvelte_napi, rsvelte_fmt and the language server to their own artifacts

### DIFF
--- a/.changeset/option-error-compile-error-shape.md
+++ b/.changeset/option-error-compile-error-shape.md
@@ -1,5 +1,7 @@
 ---
-"@rsvelte/compiler": patch
+"@rsvelte/vite-plugin-svelte-native": patch
 ---
 
 Raise option-validation failures in upstream's `CompileError` shape. `compile()` and `compileModule()` now throw an error carrying `code: 'options_invalid_value'`, `name: 'CompileError'`, the `filename` that was passed in, and the `https://svelte.dev/e/options_invalid_value` message tail — previously the thrown value was a plain `Error` whose `code` was napi's `"GenericFailure"`, so a consumer branching on `err.code` could not tell an invalid option from any other failure. `customElement`'s message also loses the `, if specified` tail it never had upstream (it is validated by `parametric`, not `boolean`).
+
+The change is in `crates/rsvelte_napi`, which ships only in the `@rsvelte/vite-plugin-svelte-native-*` binaries; the wasm `@rsvelte/compiler` carries its own port of `validate-options.js` and is unaffected (#3664).

--- a/.github/workflows/changeset.yml
+++ b/.github/workflows/changeset.yml
@@ -81,6 +81,12 @@ jobs:
         # later, on main, where it blocks every release until fixed.
         run: node scripts/release/check-changeset-package-names.mjs
 
+      - name: Self-test the core-consumer rule table
+        # The guard's coverage is a hand-maintained list, so it needs a control
+        # on the LIST and not only on the lookup: `crates/rsvelte_napi` was
+        # missing from it while its own header explained why it should not be.
+        run: node scripts/release/test-core-consumer-changesets.mjs
+
       - name: Require consumer changesets for shared-core changes
         env:
           SKIP: ${{ contains(github.event.pull_request.labels.*.name, 'skip-changeset') }}

--- a/scripts/release/check-core-consumer-changesets.mjs
+++ b/scripts/release/check-core-consumer-changesets.mjs
@@ -71,6 +71,25 @@ const RULES = [
     prefix: 'crates/rsvelte_check/src/',
     requires: ['@rsvelte/svelte-check'],
   },
+  {
+    prefix: 'crates/rsvelte_napi/src/',
+    // Ships only as the `rsvelte.node` cdylib inside the vps-native binaries,
+    // whose fixed group has no dependency edge to any other artifact. A
+    // changeset naming `@rsvelte/compiler` republishes wasm that does not
+    // contain the change while this one stays on a stale build (#3665).
+    requires: ['@rsvelte/vite-plugin-svelte-native'],
+  },
+  {
+    prefix: 'crates/rsvelte_fmt/src/',
+    requires: ['@rsvelte/fmt'],
+  },
+  {
+    prefix: 'crates/rsvelte_language_server/src/',
+    requires: ['@rsvelte/language-server'],
+  },
+  // NOTE: `crates/rsvelte_capi/**` and `crates/rsvelte_fmt_wasm/**` are
+  // deliberately absent because they are published NOWHERE — neither appears in
+  // release.yml's build matrix, so there is no artifact to leave stale.
   // NOTE: `crates/rsvelte_lint/**` and `crates/rsvelte_lint_bindings/**` are
   // intentionally NOT listed. Their code ships in two separate artifacts — the
   // `@rsvelte/compiler` wasm (`build:wasm:core`, built from the bindings crate)
@@ -135,7 +154,40 @@ function namedPackages() {
   return named;
 }
 
+// A `fixed` group is one independently-published artifact family. If no rule
+// names any member of a group, then no source path maps to it and the guard is
+// blind to that whole artifact — which is how `crates/rsvelte_napi` went
+// unlisted while its own header explained why it should not be (#3665).
+//
+// This is a proxy: it answers "did anyone decide about this group", not "is the
+// decision right". That is deliberately the question, because the failure being
+// guarded is nobody having asked.
+export function uncoveredFixedGroups(config) {
+  const named = new Set(RULES.flatMap((rule) => rule.requires));
+  return config.fixed.filter((group) => !group.some((pkg) => named.has(pkg)));
+}
+
+function checkFixedGroupCoverage() {
+  const config = JSON.parse(
+    readFileSync(path.join(repoRoot, '.changeset', 'config.json'), 'utf8'),
+  );
+  const uncovered = uncoveredFixedGroups(config);
+  if (uncovered.length === 0) return;
+  for (const group of uncovered) {
+    console.error(
+      `::error::No rule in check-core-consumer-changesets.mjs names any package in the ` +
+        `fixed group [${group.join(', ')}]. Either add the crate prefix whose code that ` +
+        `artifact embeds, or say in a comment why it needs no rule.`,
+    );
+  }
+  process.exit(1);
+}
+
 function main() {
+  // Not behind SKIP: the table's completeness is a property of the repository,
+  // not of the pull request asking to skip its changeset.
+  checkFixedGroupCoverage();
+
   if (process.env.SKIP === 'true') {
     console.log('skip-changeset label present — skipping core-consumer changeset check.');
     return;
@@ -180,4 +232,10 @@ function main() {
   console.log('All required consumer packages are named. ✓');
 }
 
-main();
+// Guarded so the coverage helper can be imported by a self-test without the
+// script resolving a merge base it does not need.
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}
+
+export { RULES };

--- a/scripts/release/test-core-consumer-changesets.mjs
+++ b/scripts/release/test-core-consumer-changesets.mjs
@@ -1,0 +1,102 @@
+#!/usr/bin/env node
+// Controls for check-core-consumer-changesets.mjs.
+//
+// That guard exists because several Rust crates compile into npm artifacts with
+// no dependency edge between them, so Changesets cannot cascade a fix from one
+// to another. Its own header says so — and `crates/rsvelte_napi` was still
+// missing from its table, so a changeset naming `@rsvelte/compiler` would have
+// republished wasm that did not contain the change while the package that did
+// stayed on a stale build (#3665).
+//
+// A guard whose coverage is a hand-maintained list needs a control on the LIST,
+// not only on the lookup. `uncoveredFixedGroups` is that control: every
+// independently-published artifact family in `.changeset/config.json` must be
+// named by some rule, or nobody has decided about it.
+
+import assert from 'node:assert/strict';
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { RULES, uncoveredFixedGroups } from './check-core-consumer-changesets.mjs';
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
+
+const CONFIG = JSON.parse(readFileSync(join(ROOT, '.changeset/config.json'), 'utf8'));
+
+let failures = 0;
+
+function check(name, fn) {
+	try {
+		fn();
+		console.log(`  ok   ${name}`);
+	} catch (err) {
+		failures += 1;
+		console.log(`  FAIL ${name}\n       ${err.message}`);
+	}
+}
+
+check('every fixed group in .changeset/config.json is named by some rule', () => {
+	const uncovered = uncoveredFixedGroups(CONFIG);
+	assert.deepEqual(
+		uncovered.map((g) => g[0]),
+		[],
+		'these artifact families map from no source path',
+	);
+});
+
+// The control: the check must be able to say "no". A group nobody named is
+// exactly the state rsvelte_napi's was in.
+check('a fixed group nobody names is reported', () => {
+	const invented = { fixed: [...CONFIG.fixed, ['@rsvelte/nobody-owns-this']] };
+	const uncovered = uncoveredFixedGroups(invented);
+	assert.equal(uncovered.length, 1, JSON.stringify(uncovered));
+	assert.deepEqual(uncovered[0], ['@rsvelte/nobody-owns-this']);
+});
+
+// A crate that ships in exactly one artifact family must map to that family and
+// nothing else; naming a second package would force an unrelated republish.
+const SOLE_ARTIFACT = {
+	'crates/rsvelte_napi/src/': '@rsvelte/vite-plugin-svelte-native',
+	'crates/rsvelte_check/src/': '@rsvelte/svelte-check',
+	'crates/rsvelte_fmt/src/': '@rsvelte/fmt',
+	'crates/rsvelte_language_server/src/': '@rsvelte/language-server',
+};
+
+for (const [prefix, pkg] of Object.entries(SOLE_ARTIFACT)) {
+	check(`${prefix} requires exactly ${pkg}`, () => {
+		const rule = RULES.find((r) => r.prefix === prefix);
+		assert.ok(rule, `no rule for ${prefix}`);
+		assert.deepEqual(rule.requires, [pkg]);
+	});
+}
+
+// Every package a rule names must be a real workspace package, or the
+// requirement can never be satisfied. Fixed-group membership is NOT the test:
+// `@rsvelte/svelte2tsx` is in no group and is correct there, because it depends
+// on `@rsvelte/compiler` and receives the cascade that way.
+check('every required package is a real workspace package', () => {
+	const published = new Set(
+		readdirSync(join(ROOT, 'apps/npm'))
+			.map((dir) => join(ROOT, 'apps/npm', dir, 'package.json'))
+			.filter(existsSync)
+			.map((file) => JSON.parse(readFileSync(file, 'utf8')).name),
+	);
+	const unknown = [...new Set(RULES.flatMap((r) => r.requires))].filter((p) => !published.has(p));
+	assert.deepEqual(unknown, [], 'required by a rule but not a workspace package');
+});
+
+check('changeset.yml still runs the guard', () => {
+	const yml = readFileSync(join(ROOT, '.github/workflows/changeset.yml'), 'utf8');
+	assert.ok(
+		yml.includes('scripts/release/check-core-consumer-changesets.mjs'),
+		'changeset.yml no longer runs the guard',
+	);
+});
+
+console.log(
+	failures === 0
+		? '\ncore-consumer-changesets self-test: all checks passed'
+		: `\ncore-consumer-changesets self-test: ${failures} failure(s)`,
+);
+process.exit(failures === 0 ? 0 : 1);


### PR DESCRIPTION
Closes #3665. Both halves the issue asked for, plus the coverage question it posed.

## The instance

`.changeset/option-error-compile-error-shape.md` named `@rsvelte/compiler` while the commit it
describes (`051e9a6f2`) touched `crates/rsvelte_napi/src/lib.rs` and a dev script and nothing else.
`crates/rsvelte_napi` ships only as the `rsvelte.node` cdylib inside
`@rsvelte/vite-plugin-svelte-native-*`, whose `fixed` group has no dependency edge to anything. On
the next release that changeset would have republished wasm that does not contain the change while
the package that does contain it stayed on a stale build — Changesets publishes only bumped
packages, so the fix would have been built by `build-vps-native` and then not published.

Corrected to name `@rsvelte/vite-plugin-svelte-native`, with a line saying why the wasm compiler is
unaffected (it carries its own port of `validate-options.js` — #3664).

`check-changeset-package-names.mjs` passes this input, and correctly: it asks whether a named
package exists, not whether it contains the changed code.

## The coverage question

`.changeset/config.json` declares **five** `fixed` groups — one per independently-published
artifact family. `check-core-consumer-changesets.mjs`'s `RULES` table named packages in **two** of
them:

| fixed group | crate | before |
|---|---|---|
| `@rsvelte/svelte-check` | `rsvelte_check` | ✅ |
| `@rsvelte/compiler` + `@rsvelte/lint` | `rsvelte`, `rsvelte_core`, `rsvelte_projection` | ✅ |
| `@rsvelte/vite-plugin-svelte-native` | `rsvelte_napi` | ❌ |
| `@rsvelte/fmt` | `rsvelte_fmt` | ❌ |
| `@rsvelte/language-server` | `rsvelte_language_server` | ❌ |

Each of the three added crates is a leaf whose code reaches exactly one artifact family, so each
rule requires exactly one package — no routine PR gains a multi-package changeset.

`crates/rsvelte_capi` and `crates/rsvelte_fmt_wasm` are deliberately left out and said so in a
comment: **neither appears in release.yml's build matrix**, so there is no artifact to leave stale.
That is a decision recorded, not an omission.

## The generalisation

The issue's suggestion was to check the list "against `.changeset/config.json`'s fixed groups
rather than against memory". `uncoveredFixedGroups(config)` does that: a group no rule names maps
from no source path, so the guard is blind to that artifact entirely — which is exactly the state
`rsvelte_napi`'s was in, while the file's own header explained why it should not be.

It is a **proxy**, and the code says so: it answers "did anyone decide about this group", not "is
the decision right". That is the right question here, because the failure being guarded is nobody
having asked.

It runs **before** the `skip-changeset` label is honoured. The label exempts a PR from naming
packages; it has nothing to say about whether the table is complete.

## Controls

`scripts/release/test-core-consumer-changesets.mjs`, wired into `changeset.yml` next to the
existing `Self-test the rsvelte_esrap version gate` step. 8 checks.

Ablation, run on this tree — emptying the napi rule's `requires`:

```
::error::No rule in check-core-consumer-changesets.mjs names any package in the fixed group
[@rsvelte/vite-plugin-svelte-native, …-darwin-arm64, …-darwin-x64, …-linux-arm64-gnu,
 …-linux-x64-gnu, …-win32-x64-msvc]. …
```

and the self-test goes to **3 failures**. Restored and re-run green (8/8).

## One assertion I had to correct, and it is worth stating

My first version asserted *every package a rule requires belongs to a fixed group*. It failed —
on `@rsvelte/svelte2tsx`, which is in no group and is **right** there: it depends on
`@rsvelte/compiler` and receives the cascade through that edge. The reduction, not the tree, was
wrong. The assertion now checks that each required package is a real workspace package, which is
the property that actually has to hold for a requirement to be satisfiable.

## Not claimed

- The rules stay narrow by design. A `crates/rsvelte_core/src/` change still requires only
  `@rsvelte/compiler`, not all five families, exactly as before — widening that is a policy change
  the file's header argues against and this PR does not make.
- Nothing here verifies that a named package's artifact actually rebuilds from the changed crate.
  That is a release-time property; this is a pre-merge table.
