### PR TITLE
fix(fmt): let a content tag break inside a hugged element's line

### DIFF
--- a/.changeset/hugged-tag-run-break.md
+++ b/.changeset/hugged-tag-run-break.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/fmt": patch
+---
+
+An expression tag glued into a run inside an element whose open tag hugs (`<span\n  >{a}{b}</span\n>`) now breaks where prettier-plugin-svelte breaks it. The hug puts the `>` before the run and the `</tag` after it on the same printed line, and both doc-building paths modelled a single-line tag as an unbreakable text atom — `collapse::node_to_child` only built a breakable group for a tag that was already multi-line, and `build_children_doc` was never given the options it needs to build one at all — so no group could absorb those columns and the run stayed flat however far it overflowed. Measured against the oxfmt(`svelte: true`) oracle over a one-column threshold sweep: 398 of 419 previously divergent widths now agree, across `<span>` / `<b>` / `<p>` / `<Comp>` / `<svelte:element>` / `<button>` hosts, `{#if}` and `{#each}` bodies, nested inline elements, and a `{@render}` at the head of the run. A run whose tags contain nothing breakable, a tag with prose on either side, an attribute value and a `{@const}` are unchanged.

--- a/crates/rsvelte_formatter/src/collapse/children_port.rs
+++ b/crates/rsvelte_formatter/src/collapse/children_port.rs
@@ -173,7 +173,13 @@ pub(super) fn node_to_child(
                     .flatten()
                     .map(Child::Other);
             }
-            Some(Child::Other(Doc::Text(span.to_string())))
+            // A tag that fits its own source line still has to break when the
+            // printed line it lands on overflows, and only the enclosing doc
+            // knows that column — so model it as prettier does, a group.
+            Some(Child::Other(
+                content_tag_breakable_doc(out, node, options)
+                    .unwrap_or_else(|| Doc::Text(span.to_string())),
+            ))
         }
         // Flow blocks. `isBlockElement` requires `type === 'RegularElement'`, so
         // these are NOT block children — like a mustache they go through

--- a/crates/rsvelte_formatter/src/collapse/doc_build.rs
+++ b/crates/rsvelte_formatter/src/collapse/doc_build.rs
@@ -220,8 +220,16 @@ pub(super) fn build_attrs_concat(
 /// place (the preceding text fill's trailing `line` stays flat) or move to a
 /// fresh line (a `hardline`). The first child's leading and last child's trailing
 /// whitespace are dropped (the element wrapper owns that newline).
-pub(super) fn build_children_doc(out: &str, fragment: &Fragment) -> Option<crate::doc::Doc> {
-    build_children_doc_nodes(out, &fragment.nodes, false, false, None)
+///
+/// `options` is what lets a content tag be modelled as a breakable group rather
+/// than an atom; without it the hug's `>` … `</tag` columns are measured against
+/// a tag that can never absorb them.
+pub(super) fn build_children_doc(
+    out: &str,
+    fragment: &Fragment,
+    options: Option<&FormatOptions>,
+) -> Option<crate::doc::Doc> {
+    build_children_doc_nodes(out, &fragment.nodes, false, false, options)
 }
 
 /// Build a breakable `group([RawExpr{flat, broken}])` for a content-level tag
@@ -964,7 +972,7 @@ pub(super) fn element_doc(out: &str, node: &TemplateNode) -> Option<crate::doc::
                     // the element is inside a multi-element run and overflows.
                     // Fall back to a flat text atom when the content has no fill
                     // break points (e.g. a pure text "resolve" that fits inline).
-                    let inner_content_doc = build_children_doc(out, &e.fragment).map_or_else(
+                    let inner_content_doc = build_children_doc(out, &e.fragment, None).map_or_else(
                         || Doc::Group(vec![Doc::Text(format!(">{content}</{tag}"))]),
                         |body| {
                             Doc::Group(vec![Doc::Concat(vec![
@@ -1048,7 +1056,7 @@ pub(super) fn element_doc(out: &str, node: &TemplateNode) -> Option<crate::doc::
                     }
                 });
                 let inner_body_doc = if has_attr_element && body_text_safe {
-                    build_children_doc(out, &e.fragment).and_then(|body| {
+                    build_children_doc(out, &e.fragment, None).and_then(|body| {
                         // Flat-match guard: only switch to the recursive doc when it
                         // prints identically to the opaque text (modulo boundary
                         // whitespace that `build_children_doc_nodes` trims from the
@@ -1130,7 +1138,7 @@ pub(super) fn element_doc(out: &str, node: &TemplateNode) -> Option<crate::doc::
             // attributes when the enclosing group breaks.  Flat-match guard for
             // 0-regression: only switch when the body prints flat-identically to
             // `content` (modulo boundary trimming by build_children_doc_nodes).
-            let inner_body_doc = build_children_doc(out, &e.fragment).and_then(|body| {
+            let inner_body_doc = build_children_doc(out, &e.fragment, None).and_then(|body| {
                 let flat_body = crate::doc::print(&body, 1_000_000, IndentUnit::new("  ", 2), 0, 0);
                 if flat_body.trim() == content.trim() {
                     let recursive_content = Doc::Concat(vec![

--- a/crates/rsvelte_formatter/src/collapse/hug.rs
+++ b/crates/rsvelte_formatter/src/collapse/hug.rs
@@ -530,7 +530,7 @@ pub(super) fn try_hug_mixed(
         if !raw_trail_ws_only
             && inner_line > line_width
             && !raw.contains('\n')
-            && let Some(body) = build_children_doc(out, fragment)
+            && let Some(body) = build_children_doc(out, fragment, Some(options))
         {
             let base_level = if options.js.indent_style.is_tab() {
                 inner_indent
@@ -565,7 +565,7 @@ pub(super) fn try_hug_mixed(
         // `simple == whole` — already in the hug form but content still overflows.
         // Use the Doc IR to reformat the inner content, allowing component attributes
         // to break.
-        let body_opt = build_children_doc(out, fragment);
+        let body_opt = build_children_doc(out, fragment, Some(options));
         if let Some(body) = body_opt {
             let inner_col = inner_indent.visual_width(tw) + 1; // column after the `>`
             let base_level = if options.js.indent_style.is_tab() {
@@ -649,7 +649,7 @@ pub(super) fn try_hug_mixed(
     // fits (only the outer `>` drops to its own line, e.g. `<text …>…</text`\n`>`)
     // and otherwise moves `>{body}</tag` to its own indented line (e.g. `<title`\n
     // `  >…</title`\n`>`).
-    let body_opt = build_children_doc(out, fragment);
+    let body_opt = build_children_doc(out, fragment, Some(options));
     let body = body_opt?;
     let open_no_bracket = open[..open.len() - 1].to_string();
     let inner = Doc::Group(vec![Doc::Concat(vec![

--- a/crates/rsvelte_formatter/tests/hugged_tag_run_break.rs
+++ b/crates/rsvelte_formatter/tests/hugged_tag_run_break.rs
@@ -1,0 +1,231 @@
+//! An expression tag glued into a run inside an element that hugs
+//! (`<span\n  >{…}{…}</span\n>`) shares its printed line with the hug's `>` and
+//! the trailing `</tag` — columns its own source position cannot see. Both
+//! doc-building paths modelled such a tag as an unbreakable atom, so the run
+//! never broke where prettier-plugin-svelte breaks it (#3423, #3565).
+//!
+//! Every expectation below is the oxfmt(`svelte: true`) oracle's own output for
+//! the input above it, not a hand-written guess.
+
+use rsvelte_formatter::{FormatOptions, JsFormatOptions, LineWidth, format};
+
+fn fmt(src: &str) -> String {
+    let opts = FormatOptions {
+        js: JsFormatOptions {
+            line_width: LineWidth::try_from(80u16).expect("valid line width"),
+            ..JsFormatOptions::default()
+        },
+        ..FormatOptions::default()
+    };
+    format(src, &opts).expect("format ok")
+}
+
+/// A formatter that decides a width from the source column instead of the
+/// printed one is unstable on its own output, so every case is also a fixed
+/// point.
+fn assert_fmt(src: &str, expected: &str) {
+    let out = fmt(src);
+    assert_eq!(out, expected, "got:\n{out}");
+    let again = fmt(&out);
+    assert_eq!(again, out, "not idempotent:\n{again}");
+}
+
+#[test]
+fn issue_3423_hugged_span_breaks_the_first_group() {
+    assert_fmt(
+        "<div>\n\t<span>{someValue['a quoted key here']}{otherValue}{thirdValue}{fourthValue}{fifth}</span>\n</div>\n",
+        "<div>\n  <span\n    >{someValue[\n      \"a quoted key here\"\n    ]}{otherValue}{thirdValue}{fourthValue}{fifth}</span\n  >\n</div>\n",
+    );
+}
+
+#[test]
+fn run_of_identifiers_has_nothing_to_break() {
+    assert_fmt(
+        "<b>{aaaaaaaaaa}{bbbbbbbbbb}{cccccccccc}{dddddddddd}{eeeeeeeeee}{ffffffffff}{gg}</b>\n",
+        "<b\n  >{aaaaaaaaaa}{bbbbbbbbbb}{cccccccccc}{dddddddddd}{eeeeeeeeee}{ffffffffff}{gg}</b\n>\n",
+    );
+}
+
+#[test]
+fn run_of_dotted_members_has_nothing_to_break() {
+    assert_fmt(
+        "<b>{o.aaaaaaaa}{o.bbbbbbbb}{o.cccccccc}{o.dddddddd}{o.eeeeeeee}{o.ffffffff}{o.g}</b>\n",
+        "<b\n  >{o.aaaaaaaa}{o.bbbbbbbb}{o.cccccccc}{o.dddddddd}{o.eeeeeeee}{o.ffffffff}{o.g}</b\n>\n",
+    );
+}
+
+#[test]
+fn computed_member_key_breaks_in_a_run() {
+    assert_fmt(
+        "<b>{o[\"aaaa\"]}{o.bbbbbbbb}{o.cccccccc}{o.dddddddd}{o.eeeeeeee}{o.ffffffff}{o.gg}</b>\n",
+        "<b\n  >{o[\n    \"aaaa\"\n  ]}{o.bbbbbbbb}{o.cccccccc}{o.dddddddd}{o.eeeeeeee}{o.ffffffff}{o.gg}</b\n>\n",
+    );
+}
+
+#[test]
+fn call_argument_list_breaks_in_a_run() {
+    assert_fmt(
+        "<b>{f(1, 2)}{o.bbbbbbbb}{o.cccccccc}{o.dddddddd}{o.eeeeeeee}{o.ffffffff}{o.gggg}</b>\n",
+        "<b\n  >{f(\n    1,\n    2,\n  )}{o.bbbbbbbb}{o.cccccccc}{o.dddddddd}{o.eeeeeeee}{o.ffffffff}{o.gggg}</b\n>\n",
+    );
+}
+
+#[test]
+fn host_component() {
+    assert_fmt(
+        "<Comp>{o[\"aaaa\"]}{o.bbbbbbbb}{o.cccccccc}{o.dddddddd}{o.eeeeeeee}{o.ffffffff}{o.gggggggg}</Comp>\n",
+        "<Comp\n  >{o[\n    \"aaaa\"\n  ]}{o.bbbbbbbb}{o.cccccccc}{o.dddddddd}{o.eeeeeeee}{o.ffffffff}{o.gggggggg}</Comp\n>\n",
+    );
+}
+
+#[test]
+fn host_svelte_element() {
+    assert_fmt(
+        "<svelte:element this={tag}>{o[\"aaaa\"]}{o.bbbbbbbb}{o.cccccccc}{o.dddddddd}{o.eeeeeeee}{o.ffffffff}{o.gggggggg}</svelte:element>\n",
+        "<svelte:element this={tag}\n  >{o[\n    \"aaaa\"\n  ]}{o.bbbbbbbb}{o.cccccccc}{o.dddddddd}{o.eeeeeeee}{o.ffffffff}{o.gggggggg}</svelte:element\n>\n",
+    );
+}
+
+#[test]
+fn host_inline_block_button() {
+    assert_fmt(
+        "<button>{o[\"aaaa\"]}{o.bbbbbbbb}{o.cccccccc}{o.dddddddd}{o.eeeeeeee}{o.ffffffff}{o.gggggggg}</button>\n",
+        "<button\n  >{o[\n    \"aaaa\"\n  ]}{o.bbbbbbbb}{o.cccccccc}{o.dddddddd}{o.eeeeeeee}{o.ffffffff}{o.gggggggg}</button\n>\n",
+    );
+}
+
+#[test]
+fn host_nested_inline_element() {
+    assert_fmt(
+        "<b><i>{o[\"aaaa\"]}{o.bbbbbbbb}{o.cccccccc}{o.dddddddd}{o.eeeeeeee}{o.ffffffff}{o.gggggggg}</i></b>\n",
+        "<b\n  ><i\n    >{o[\n      \"aaaa\"\n    ]}{o.bbbbbbbb}{o.cccccccc}{o.dddddddd}{o.eeeeeeee}{o.ffffffff}{o.gggggggg}</i\n  ></b\n>\n",
+    );
+}
+
+#[test]
+fn host_block_element() {
+    assert_fmt(
+        "<p>{o[\"aaaa\"]}{o.bbbbbbbb}{o.cccccccc}{o.dddddddd}{o.eeeeeeee}{o.ffffffff}{o.gggggggg}</p>\n",
+        "<p>\n  {o[\n    \"aaaa\"\n  ]}{o.bbbbbbbb}{o.cccccccc}{o.dddddddd}{o.eeeeeeee}{o.ffffffff}{o.gggggggg}\n</p>\n",
+    );
+}
+
+#[test]
+fn host_if_block() {
+    assert_fmt(
+        "{#if flag}\n\t<span>{o[\"aaaa\"]}{o.bbbbbbbb}{o.cccccccc}{o.dddddddd}{o.eeeeeeee}{o.ffffffff}{o.gggggggg}</span>\n{/if}\n",
+        "{#if flag}\n  <span\n    >{o[\n      \"aaaa\"\n    ]}{o.bbbbbbbb}{o.cccccccc}{o.dddddddd}{o.eeeeeeee}{o.ffffffff}{o.gggggggg}</span\n  >\n{/if}\n",
+    );
+}
+
+#[test]
+fn host_each_block() {
+    assert_fmt(
+        "{#each list as item}\n\t<span>{o[\"aaaa\"]}{o.bbbbbbbb}{o.cccccccc}{o.dddddddd}{o.eeeeeeee}{o.ffffffff}{o.gggggggg}</span>\n{/each}\n",
+        "{#each list as item}\n  <span\n    >{o[\n      \"aaaa\"\n    ]}{o.bbbbbbbb}{o.cccccccc}{o.dddddddd}{o.eeeeeeee}{o.ffffffff}{o.gggggggg}</span\n  >\n{/each}\n",
+    );
+}
+
+#[test]
+fn render_tag_first_in_a_run() {
+    assert_fmt(
+        "<b>{@render foo(\"aaaa\")}{o.bbbbbbbb}{o.cccccccc}{o.dddddddd}{o.eeeeeeee}{o.ffffffff}{o.gggggggg}</b>\n",
+        "<b\n  >{@render foo(\n    \"aaaa\",\n  )}{o.bbbbbbbb}{o.cccccccc}{o.dddddddd}{o.eeeeeeee}{o.ffffffff}{o.gggggggg}</b\n>\n",
+    );
+}
+
+#[test]
+fn the_group_that_breaks_is_the_one_that_misses_its_fit() {
+    assert_fmt(
+        "<b>{o[\"aaaaaaaaaaaa\"]}{o.bbbbbbbb}{o.cccccccc}{p[\"ddddddddddddddd\"]}{o.eeeeeeee}{o.ffffffff}{o.gggggggg}</b>\n",
+        "<b\n  >{o[\"aaaaaaaaaaaa\"]}{o.bbbbbbbb}{o.cccccccc}{p[\n    \"ddddddddddddddd\"\n  ]}{o.eeeeeeee}{o.ffffffff}{o.gggggggg}</b\n>\n",
+    );
+}
+
+#[test]
+fn threshold_flat_one_column_under() {
+    assert_fmt(
+        "<div>\n\t<span>{o['kkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkk']}{otherValue}{thirdValue}</span>\n</div>\n",
+        "<div>\n  <span\n    >{o[\"kkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkk\"]}{otherValue}{thirdValue}</span\n  >\n</div>\n",
+    );
+}
+
+#[test]
+fn threshold_breaks_one_column_over() {
+    assert_fmt(
+        "<div>\n\t<span>{o['kkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkk']}{otherValue}{thirdValue}</span>\n</div>\n",
+        "<div>\n  <span\n    >{o[\n      \"kkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkk\"\n    ]}{otherValue}{thirdValue}</span\n  >\n</div>\n",
+    );
+}
+
+#[test]
+fn control_single_tag_flat_one_column_under() {
+    assert_fmt(
+        "<div>\n\t<span>{o['kkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkk']}</span>\n</div>\n",
+        "<div>\n  <span\n    >{o[\"kkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkk\"]}</span\n  >\n</div>\n",
+    );
+}
+
+#[test]
+fn control_single_tag_breaks_one_column_over() {
+    assert_fmt(
+        "<div>\n\t<span>{o['kkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkk']}</span>\n</div>\n",
+        "<div>\n  <span\n    >{o[\n      \"kkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkk\"\n    ]}</span\n  >\n</div>\n",
+    );
+}
+
+#[test]
+fn control_breakable_tag_last_in_the_run() {
+    assert_fmt(
+        "<div>\n\t<span>{otherValue}{thirdValue}{o['kkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkk']}</span>\n</div>\n",
+        "<div>\n  <span\n    >{otherValue}{thirdValue}{o[\n      \"kkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkk\"\n    ]}</span\n  >\n</div>\n",
+    );
+}
+
+#[test]
+fn control_block_host_run_on_its_own_line() {
+    assert_fmt(
+        "<div>\n\t{o[\"aaaa\"]}{o.bbbbbbbb}{o.cccccccc}{o.dddddddd}{o.eeeeeeee}{o.ffffffff}{o.gggggggg}\n</div>\n",
+        "<div>\n  {o[\n    \"aaaa\"\n  ]}{o.bbbbbbbb}{o.cccccccc}{o.dddddddd}{o.eeeeeeee}{o.ffffffff}{o.gggggggg}\n</div>\n",
+    );
+}
+
+#[test]
+fn control_prose_after_the_tag() {
+    assert_fmt(
+        "<b>{o[\"aaaaaaaaaaaaaaaaaaaa\"]} some words here that go on and on and on and on x</b>\n",
+        "<b\n  >{o[\"aaaaaaaaaaaaaaaaaaaa\"]} some words here that go on and on and on and on x</b\n>\n",
+    );
+}
+
+#[test]
+fn control_prose_before_the_tag() {
+    assert_fmt(
+        "<b>some words here that go on and on and on and on and on {o[\"aaaaaaaaaaaaaaaaaa\"]}</b>\n",
+        "<b\n  >some words here that go on and on and on and on and on {o[\n    \"aaaaaaaaaaaaaaaaaa\"\n  ]}</b\n>\n",
+    );
+}
+
+#[test]
+fn control_attribute_value() {
+    assert_fmt(
+        "<div data-a={o[\"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\"]}>x</div>\n",
+        "<div\n  data-a={o[\"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\"]}\n>\n  x\n</div>\n",
+    );
+}
+
+#[test]
+fn control_run_that_fits() {
+    assert_fmt(
+        "<span>{o[\"aaaa\"]}{o.bb}{o.cc}</span>\n",
+        "<span>{o[\"aaaa\"]}{o.bb}{o.cc}</span>\n",
+    );
+}
+
+#[test]
+fn corpus_carrier_bigint_comparison_run() {
+    assert_fmt(
+        "<script>\n\tconst fraction = 2n < 2.5;\n\tconst rounded = 2n > 2.5;\n\tconst nullish = 2n > null;\n\tconst undef = 2n < undefined;\n\tconst bigints = 7n <= 7n;\n\tconst numericText = 2n < '3';\n\tconst nonNumericText = 2n < 'x';\n\tconst boolean = 0n < true;\n</script>\n\n<p>{fraction}{rounded}{nullish}{undef}{bigints}{numericText}{nonNumericText}{boolean}</p>\n<p>{2n == 2}{2n === 2}{2n != 2}{2n == '2'}{2n == 'x'}{1n == true}{2n == null}{0 == '0'}</p>\n",
+        "<script>\n  const fraction = 2n < 2.5;\n  const rounded = 2n > 2.5;\n  const nullish = 2n > null;\n  const undef = 2n < undefined;\n  const bigints = 7n <= 7n;\n  const numericText = 2n < \"3\";\n  const nonNumericText = 2n < \"x\";\n  const boolean = 0n < true;\n</script>\n\n<p>\n  {fraction}{rounded}{nullish}{undef}{bigints}{numericText}{nonNumericText}{boolean}\n</p>\n<p>\n  {2n == 2}{2n === 2}{2n != 2}{2n == \"2\"}{2n == \"x\"}{1n == true}{2n ==\n    null}{0 == \"0\"}\n</p>\n",
+    );
+}


### PR DESCRIPTION
Closes #3423. Closes #3565.

## What is actually wrong

Not what #3423 says. The issue attributes the miss to `push_expression_tag`'s
`prefix_lead` reading the tag's **source** column, and predicts the fix belongs in
the splice path. That is measurably not the mechanism here: `prefix_lead` is only
computed when the tag is preceded by a `}`, and in #3423's own repro the tag that
must break is the **first** in the run, so `prefix_lead` is 1 and the source column
is never read. The whole splice arithmetic comes out at 79 against a print width of
80 — it does not miss by a rounding error, it is measuring a different line.

The line the run actually lands on is the hug's:

```
  <span
    >{someValue["a quoted key here"]}{otherValue}{thirdValue}{fourthValue}{fifth}</span
  >
```

`>` before it and `</span` after it, both on the same printed line, both invisible
to anything that measures the tag by itself. Charging them is not the fix either,
because the layout that owns that line is already a real doc — `try_hug_mixed`
builds prettier's own

```
group(['<span', group(indent([softline, group(['>', body, '</span'])])), softline, '>'])
```

and the printer's `fits` already implements prettier's rule exactly. **The tag just
had nothing to break with.** Two places model a content tag, and both handed the
printer an atom:

- `collapse::node_to_child` built a breakable `group([RawExpr])` only for a tag
  whose span was **already multi-line**; a single-line one became `Doc::Text`.
- `build_children_doc` — the three `try_hug_mixed` call sites — passed `None` for
  `options`, and `append_non_text_doc` reaches `content_tag_breakable_doc` only
  `if let Some(options)`. So on that path *no* tag was ever breakable.

Those two are why the defect is host-shaped rather than tag-shaped: `<span>` / `<b>`
/ `<p>` / `<Comp>` go through the children port, `<button>` / `<select>` are
inline-block so the port declines and the hug pass owns them, and both were broken
for different reasons. +23/−9 across three files.

Getting the group back also gets the rule right where the obvious reading is wrong.
#3565 says the oracle "breaks the **first** breakable group in the run". It does not
— it breaks the one that misses its fit, and an earlier group's measurement stops at
the later one's break opportunity, so the earlier one can stay flat:

```
<b>{o["aaaaaaaaaaaa"]}{o.bbbbbbbb}{o.cccccccc}{p["ddddddddddddddd"]}{o.eeeeeeee}…</b>
                                               ^ the oracle breaks THIS one
```

That falls out of `Doc::RawExpr`'s existing `fits` arm (in break mode it charges only
`broken[0]` and returns), so it is pinned as a test rather than implemented.

## Threshold sweep

The break point was pinned by growing the breakable group's key **one character at a
time** from 1 to 70 and recording the first width at which each side breaks — 14
cases × 3 nesting depths × 70 widths = 2,940 compared pairs per run, oracle
`oxfmt -c scripts/fixtures/fmt-corpus.oxfmtrc.json` against
`rsvelte-fmt --stdin --stdin-filepath`. "Both break somewhere" is not the claim;
equal thresholds is.

| case | depth | oracle | rsvelte before | rsvelte after | widths diverging before → after |
|---|---|---|---|---|---|
| hug / breakable **first**, tail run | 0 / 1 / 2 | 41 / 39 / 37 | never / 70 / 68 | **41 / 39 / 37** | 30+31+31 → 0 |
| hug / call argument list | 0 / 1 / 2 | 53 / 51 / 49 | never / 70 / 68 | **53 / 51 / 49** | 18+19+19 → 0 |
| hug / long tag name (`<abbreviation>`) | 0 / 1 / 2 | 45 / 43 / 41 | never / 70 / 68 | **45 / 43 / 41** | 26+27+27 → 0 |
| hug / component host | 0 / 1 / 2 | 53 / 51 / 49 | never / 70 / 68 | **53 / 51 / 49** | 18+19+19 → 0 |
| hugged span inside `{#if}` | 0 / 1 / 2 | 51 / 49 / 47 | 70 / 68 / 66 | **51 / 49 / 47** | 19×3 → 0 |
| hugged span inside `{#each}` | 0 / 1 / 2 | 51 / 49 / 47 | 70 / 68 / 66 | **51 / 49 / 47** | 19×3 → 0 |
| **root-level run, no element** | 0 | 50 | never | never | 21 → **21** (see residue) |

**398 of 419 divergent widths fixed; the 21 that remain are one row and are not this
defect.** The long-tag-name row is the direct evidence that the closing `</tag` is
charged: three extra characters in the tag name move the oracle's threshold by
exactly three, and rsvelte now tracks it.

## Controls

Measured against the oracle, not asserted from reasoning. Every one is a test in
`crates/rsvelte_formatter/tests/hugged_tag_run_break.rs`.

| control | before | after | why it is a control |
|---|---|---|---|
| run of plain identifiers (`{aaaa}{bbbb}…`) | match | match | nothing in the run is breakable — a fix that breaks *something* would break this |
| run of dotted members (`{o.a}{o.b}…`) | match | match | same, one level up |
| hug, single tag, **no** trailing run, k=62 / k=63 | 63 | 63 | the pre-existing threshold must not move |
| hug, breakable tag **last** in the run | 41 / 39 / 37 | unchanged | the leading-run half already worked; this proves the fix did not replace it |
| block host, run on its own line (`<div>\n\t{…}{…}\n</div>`) | match | match | no `>` / `</tag` on that line — must stay flat-thresholded |
| prose **after** the tag | match | match | fill path, already correct |
| prose **before** the tag | match | match | fill path, already correct |
| attribute value at 80 columns | 65 / 63 / 61 | unchanged | different pipeline entirely |
| `{@const}` in an `{#if}` | 69 / 67 | unchanged | different pipeline entirely |
| run that fits (`<span>{o["aaaa"]}{o.bb}{o.cc}</span>`) | match | match | nothing may break below the width |

**Idempotency.** A width computed from the source column rather than the printed one
is exactly the shape that breaks `format(format(x)) == format(x)`, so every one of
the 25 tests asserts it as a second leg rather than trusting the single-pass answer.

**Gates.** `svelte_dev_corpus_parity` (the hard, no-tolerance gate) is
**1102/1102 before and 1102/1102 after** — same tree, same oracle, measured both
ways rather than assumed. The count is printed by the test itself, so it is a
positive control that the corpus was actually compared and not silently absent.

## Naturally occurring carrier

`compatibility/pattern-corpus/issues/3539-bigint-comparison-fold.svelte`, written for
a **compiler** issue (#3539, bigint constant folding) with no formatter intent, hit
this on #3658's `Formatter parity` job. Its exact blob is carried here as a fixture
(`corpus_carrier_bigint_comparison_run`) so the carrier survives whatever #3658 does
with its own repro. It now agrees with the oracle byte-for-byte:

```
<p>
  {2n == 2}{2n === 2}{2n != 2}{2n == "2"}{2n == "x"}{1n == true}{2n ==
    null}{0 == "0"}
</p>
```

Worth noting what shape it really is, because the first description of it was wrong:
the run is glued to both tags of a **block-display `<p>`**, not a bare root-level
run, and it is reached because `try_children_port` claims block elements too.

## Revert control

With the three source hunks reverted (`git checkout HEAD~1 -- crates/rsvelte_formatter/src/collapse/`)
and all 25 tests kept: **14 fail, 11 pass, and the 11 are exactly the controls.**
Every failure is the predicted shape — the tag stays flat:

```
---- issue_3423_hugged_span_breaks_the_first_group stdout ----
assertion `left == right` failed: got:
<div>
  <span
    >{someValue["a quoted key here"]}{otherValue}{thirdValue}{fourthValue}{fifth}</span
  >
</div>
```

```
failures:
    call_argument_list_breaks_in_a_run          host_nested_inline_element
    computed_member_key_breaks_in_a_run         host_svelte_element
    corpus_carrier_bigint_comparison_run        issue_3423_hugged_span_breaks_the_first_group
    host_block_element                          render_tag_first_in_a_run
    host_component                              the_group_that_breaks_is_the_one_that_misses_its_fit
    host_each_block                             threshold_breaks_one_column_over
    host_if_block
    host_inline_block_button

test result: FAILED. 11 passed; 14 failed
```

Restored afterwards; `git status --porcelain` and `git diff HEAD` are both empty.

## What I deliberately left out

- **#3086 — "adjacent expression tags are measured individually"** (open, PR #3330).
  A different host: the run sits on its **own line** inside a block or inline-block
  element, with no `>` and no `</tag` beside it. Its repro still diverges on this
  branch, unchanged, and I left it that way. No file overlap with #3330 either —
  that PR is `expression/splice.rs` + `expression/width.rs`, this one is
  `collapse/`. Whichever lands second should re-run the sweep, because #3330's
  `suffix_trail` and this fix can both reach the same tag at different widths.
- **#3613 — a tag whose expression ends in a `//` comment** (open, PR #3631). Not
  this mechanism and someone else's open PR.
- **`{@html}` at the head of a glued run.** Still diverges (`{@html o["aaaa"]}{…}`).
  `content_tag_breakable_doc` models an `ExpressionTag` and a `RenderTag` and has no
  `HtmlTag` arm, so this fix — "use the breakable model in the one place it was not
  used" — cannot reach it. Extending the model to a new node type is a different
  claim, and I would rather it be measured on its own. Filed as #3676.

## Residue (measured, not guessed)

Two shapes still diverge after this change. Both are stated because "this fix does
not reach X, here is the measurement" is worth more than a clean-looking table.

1. **A glued run at the document root, depth 0, with no element at all.**
   `{o["aaaa"]}{o.bbbbbbbb}…{o.gggggg}` — the oracle breaks at key length 50, rsvelte
   never does; 21 of 70 widths. Inside a `<div>` the same run matches at every depth.
   It is #3086's mechanism (nothing charges the trailing run) with no element for
   the collapse passes to own, so it may or may not fall out of #3330.
2. **`{#if flag}<span>…</span>{/if}` written on one line** never hugs the `<span>`
   at all, however long it gets. That is element-level, not tag-level: it diverges
   identically for plain text and for a run with nothing breakable in it, so it is
   not this defect and predates it. Filed as #3675.

## Test plan

- `cargo test --release -p rsvelte_formatter --test hugged_tag_run_break` — 25 pass.
- `cargo test --release -p rsvelte_formatter --test svelte_dev_corpus` — 1102/1102.
- `cargo test --release -p rsvelte_formatter -p rsvelte_fmt` — **619 pass, 0 fail** across 38 test binaries.
- `cargo fmt --all -- --check` clean; CI's `Clippy` job green in 59s (workspace-wide, `-D warnings`).
- The three Changeset gates, pre-run green; CI `Changeset`, `Test fmt corpus`, `Clippy`, `Format` all green on the first push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
