### PR TITLE
docs(corpus): say that the pattern-corpus provenance table is enforced

### DIFF
--- a/scripts/compat-corpus/README.md
+++ b/scripts/compat-corpus/README.md
@@ -915,6 +915,11 @@ manifest is shared — they also flow through the fmt and svelte2tsx gates.
    [`compatibility/pattern-corpus/README.md`](../../compatibility/pattern-corpus/README.md)
    instead — that table is the only provenance record.
 
+   `scripts/ci/check-pattern-corpus-docs.mjs` enforces this in both directions,
+   per section: an `issues/` file needs a row in the `issues/` table, a
+   `matrix/<axis>/` file needs one under that axis's `### ` heading, and an
+   `adversarial/<theme>/` directory needs a row in the themes table.
+
 3. **Land it with the fix.** A repro for a still-open divergence would have to be
    seeded into `known-failures.*`; add it in the fix PR (or right after it
    merges) so it lands green.


### PR DESCRIPTION
Follow-up to #3671, which added `scripts/ci/check-pattern-corpus-docs.mjs`.

`scripts/compat-corpus/README.md` step 2 already told contributors to record provenance in the table rather than in an HTML comment, and said why (a removed comment is itself a whitespace-sensitive compiler input, #1975). What it did not say is that **anything checks it** — nothing did until #3670 — or that `matrix/` and `adversarial/` are documented in two other shapes, which is where fifteen of the twenty-two undocumented files were.

Four lines. A contributor who hits the new gate now finds out from the instructions rather than from a red job.

No code change; `node scripts/ci/check-pattern-corpus-docs.mjs` still passes on this tree.