### PR TITLE
fix(parse): `Root.end` is the source length, not the last non-whitespace byte

### DIFF
--- a/.changeset/parse-root-end-source-length.md
+++ b/.changeset/parse-root-end-source-length.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/compiler": patch
+---
+
+`parse()`'s `Root.end` is now the source length rather than the last non-whitespace byte. Upstream parses `template.trimEnd()` but sets `this.root.end = template.length` on the untrimmed source, so the root span always covers the whole file; rsvelte stopped short on every component ending in a newline — 12,324 of 14,102 real-world components — which loses the trailing bytes for any consumer round-tripping a document through `source.slice(root.start, root.end)`. The parser fixture harness now also trims its input the way upstream's `tests/parser-{modern,legacy}/test.ts` does; without that the two errors cancelled and the suite was green because both sides were wrong.

--- a/compatibility/parse-ast-known-failures.json
+++ b/compatibility/parse-ast-known-failures.json
@@ -520,7 +520,6 @@
 	"modern::ReturnStatement.leadingComments[]#length": "comment-attachment",
 	"modern::ReturnStatement.trailingComments#missing": "comment-attachment",
 	"modern::ReturnStatement.type#value": "node-type",
-	"modern::Root#span": "root-span",
 	"modern::Root.comments[]#length": "child-count",
 	"modern::Root.options.customElement.props.anArray#missing": "unclustered",
 	"modern::Root.options.customElement.props.camelCase#missing": "unclustered",

--- a/compatibility/parse-ast-known-failures.md
+++ b/compatibility/parse-ast-known-failures.md
@@ -1,7 +1,7 @@
 # Public `parse()` AST parity ratchet
 
 Gate: `scripts/compat-corpus/parse-ast-verify.mjs`.
-Ratchet: `parse-ast-known-failures.json`, currently **652 entries**.
+Ratchet: `parse-ast-known-failures.json`, currently **651 entries**.
 
 ## The question it asks
 
@@ -34,11 +34,15 @@ Acceptance divergences are the one exception: "official rejects this document an
 not" is a fact about the document, so those keys carry the entry id. A single shared key could not
 tell two such entries from one, which is the whole shrink the ratchet exists to observe.
 
-## Why the baseline is 652 and not 0
+## Why the baseline is 651 and not 0
 
-Because the API was never compared. The last run measured **28,208 compared pairs** over 14,331
-corpus components — 1,075 modern-axis entries are byte-identical, 0 legacy-axis entries are, and
-the remainder produce these 652 field-level keys.
+Because the API was never compared. The last run measured **28,208 compared pairs** over 14,102
+corpus components — 5,252 modern-axis entries are byte-identical, 0 legacy-axis entries are, and
+the remainder produce these 651 field-level keys.
+
+The modern-axis identical count was **1,075** when this ratchet was first baselined. #3386
+(`Root.end`) accounted for the other 4,177 on its own: it diverged on 12,324 of 14,102 entries, so
+one key was suppressing more than a quarter of the population from ever being byte-identical.
 
 **The comparator manufactures none of them.** Running the same `diffKeys` with the official
 compiler on *both* sides over the same population produces **0 keys from 28,178 self-compared
@@ -52,7 +56,7 @@ parsed all 11 without complaint. The verdict named the loudest thing it could se
 one line of the harness. Serialization now sits outside the parse `try`, and a bigint goes through
 a replacer so its value stays comparable instead of being dropped.
 
-Partition of `parse-ast-known-failures.json` by cluster: `141 + 140 + 132 + 86 + 75 + 35 + 10 + 10 + 9 + 6 + 4 + 3 + 1`
+Partition of `parse-ast-known-failures.json` by cluster: `141 + 140 + 132 + 86 + 75 + 35 + 10 + 10 + 9 + 6 + 4 + 3`
 
 | cluster | keys | what it is |
 |---|---|---|
@@ -68,7 +72,6 @@ Partition of `parse-ast-known-failures.json` by cluster: `141 + 140 + 132 + 86 +
 | `directive-null-fields` | 9 | official keeps `expression: null` / `modifiers: []` on a directive; rsvelte omits the key, so it is absent through the JSON boundary a binding actually uses. |
 | `loc-presence` | 6 | a node that has a `loc` on one side and none on the other — kept apart from `span` because "no position at all" is a different defect from "wrong position". |
 | `rejects-what-official-accepts` | 3 | the three loose sources rsvelte throws on. See below. |
-| `root-span` | 1 | #3386 — `modern::Root#span`, 12,324 of 14,102 entries. |
 
 ## The two acceptance rows are the interesting ones
 

--- a/crates/rsvelte_core/src/compiler/phases/1_parse/parser.rs
+++ b/crates/rsvelte_core/src/compiler/phases/1_parse/parser.rs
@@ -45,7 +45,7 @@ static COMMENT_END_FINDER: std::sync::LazyLock<memchr::memmem::Finder<'static>> 
 /// `1-parse/index.js`, a `\s` regex or `String.prototype.trim*`. Rust's
 /// `char::is_whitespace` is the Unicode `White_Space` property, which has the
 /// same 25 members but excludes `U+FEFF` and includes `U+0085`.
-pub(crate) fn is_js_whitespace(c: char) -> bool {
+pub fn is_js_whitespace(c: char) -> bool {
     matches!(
         c,
         '\u{9}'..='\u{d}'

--- a/crates/rsvelte_core/src/compiler/phases/1_parse/state/fragment.rs
+++ b/crates/rsvelte_core/src/compiler/phases/1_parse/state/fragment.rs
@@ -180,44 +180,9 @@ impl<'a> Parser<'a> {
             }
         }
 
-        // Calculate end position - consider fragment nodes, script, and style
-        let fragment_end = fragment
-            .nodes
-            .last()
-            .map(|node| match node {
-                TemplateNode::Text(t) => t.end,
-                TemplateNode::Comment(c) => c.end,
-                TemplateNode::ExpressionTag(e) => e.end,
-                TemplateNode::HtmlTag(h) => h.end,
-                TemplateNode::ConstTag(c) => c.end,
-                TemplateNode::DeclarationTag(d) => d.end,
-                TemplateNode::DebugTag(d) => d.end,
-                TemplateNode::RenderTag(r) => r.end,
-                TemplateNode::AttachTag(a) => a.end,
-                TemplateNode::IfBlock(b) => b.end,
-                TemplateNode::EachBlock(b) => b.end,
-                TemplateNode::AwaitBlock(b) => b.end,
-                TemplateNode::KeyBlock(b) => b.end,
-                TemplateNode::SnippetBlock(b) => b.end,
-                TemplateNode::RegularElement(e) => e.end,
-                TemplateNode::Component(c) => c.end,
-                TemplateNode::TitleElement(t) => t.end,
-                TemplateNode::SlotElement(s) => s.end,
-                TemplateNode::SvelteBody(s)
-                | TemplateNode::SvelteDocument(s)
-                | TemplateNode::SvelteFragment(s)
-                | TemplateNode::SvelteBoundary(s)
-                | TemplateNode::SvelteHead(s)
-                | TemplateNode::SvelteOptions(s)
-                | TemplateNode::SvelteSelf(s)
-                | TemplateNode::SvelteWindow(s) => s.end,
-                TemplateNode::SvelteComponent(c) => c.end,
-                TemplateNode::SvelteElement(e) => e.end,
-            })
-            .unwrap_or(0);
-
-        // End is the maximum of fragment end, script end, and style end
-        let end = fragment_end.max(max_special_end);
+        // Upstream parses `template.trimEnd()` but sets `this.root.end =
+        // template.length` on the UNTRIMMED source (`phases/1-parse/index.js`).
+        let end = self.source.len() as u32;
 
         Ok(Root {
             css: self.stylesheet.take().map(Box::new),

--- a/crates/rsvelte_core/src/lib.rs
+++ b/crates/rsvelte_core/src/lib.rs
@@ -45,6 +45,10 @@ pub mod measure_stmt_chain;
 pub mod toolchain;
 
 pub use compiler::legacy::convert_to_legacy;
+// JavaScript's `\s`, which is also upstream's `is_whitespace` in
+// `phases/1-parse/index.js`. Exported so a test harness can mirror
+// upstream's own `.replace(/\s+$/, '')` exactly.
+pub use compiler::phases::phase1_parse::parser::is_js_whitespace;
 #[cfg(not(feature = "parallel"))]
 pub use compiler::phases::phase1_parse::{ParseOptions, parse};
 #[cfg(feature = "parallel")]

--- a/crates/rsvelte_core/tests/parse_root_span.rs
+++ b/crates/rsvelte_core/tests/parse_root_span.rs
@@ -1,0 +1,56 @@
+//! `Root.start` / `Root.end` from the public AST (#3386).
+//!
+//! Upstream parses `template.trimEnd()` but sets `this.root.end = template.length`
+//! on the untrimmed source (`phases/1-parse/index.js`), so the root span always
+//! covers the whole file. rsvelte stopped at the last non-whitespace byte, which
+//! is every `.svelte` file that ends with a newline.
+//!
+//! The upstream parser fixtures cannot see this: their harness does
+//! `input.replace(/\s+$/, '')` before parsing, so every checked-in `output.json`
+//! records the end of a *trimmed* input and agrees with the truncated value by
+//! coincidence.
+
+use rsvelte_core::{ParseOptions, parse};
+
+fn root_span(source: &str) -> (u32, u32) {
+    let allocator = oxc_allocator::Allocator::default();
+    let ast = parse(
+        source,
+        &allocator,
+        ParseOptions {
+            modern: true,
+            ..Default::default()
+        },
+    )
+    .expect("source parses");
+    (ast.start, ast.end)
+}
+
+#[test]
+fn root_span_covers_the_whole_source() {
+    // Every row of #3386's matrix, plus the three that already agreed — they are
+    // the control: with no trailing whitespace the two answers coincide, so a
+    // suite of only those rows measures nothing.
+    for source in [
+        "<b>x</b>",
+        "<b>x</b>\n",
+        "<b>x</b>\n\n",
+        "<b>x</b>  ",
+        "<b>x</b>\t\n",
+        "<b>x</b>\r\n",
+        "\n<b>x</b>",
+        "\n<b>x</b>\n",
+        "   \n",
+        "",
+        "hello\n",
+        "<script>let a = 1;</script>\n",
+        "<style>a{color:red}</style>\n",
+        "<b>x</b>\u{a0}",
+    ] {
+        assert_eq!(
+            root_span(source),
+            (0, source.len() as u32),
+            "root span of {source:?}"
+        );
+    }
+}

--- a/crates/rsvelte_core/tests/parser_fixtures.rs
+++ b/crates/rsvelte_core/tests/parser_fixtures.rs
@@ -39,10 +39,17 @@ fn load_fixture(sample_dir: &Path) -> Result<(String, String, String), SkipReaso
 
     // Normalize CRLF to LF so AST byte offsets line up regardless of how the
     // submodule was checked out (Windows runners default to autocrlf=true,
-    // which would otherwise shift every span by one byte per line).
+    // which would otherwise shift every span by one byte per line), then strip
+    // trailing whitespace exactly as upstream's own harness does
+    // (`tests/parser-{modern,legacy}/test.ts`: `.replace(/\s+$/, '')`). Every
+    // checked-in `output.json` records the spans of the TRIMMED input, so a
+    // harness that passes the untrimmed file compares two different documents —
+    // which is how `Root.end` agreed here while being wrong (#3386).
     let input = fs::read_to_string(&input_path)
         .map_err(|_| SkipReason::MissingInput("readable input.svelte"))?
-        .replace("\r\n", "\n");
+        .replace("\r\n", "\n")
+        .trim_end_matches(rsvelte_core::is_js_whitespace)
+        .to_string();
     let expected_output = fs::read_to_string(&output_path)
         .map_err(|_| SkipReason::MissingInput("readable output.json"))?
         .replace("\r\n", "\n");


### PR DESCRIPTION
> **Stacked on #3683** (the `parse-ast` gate), because the ratchet this PR shrinks is created
> there. Base is `gate/parse-ast-parity`, not `main`. #3683 squash-merges to a single commit
> that is not an ancestor of this branch, so **rebase this onto `main` after #3683 lands**
> rather than merging it against a base ref that no longer exists.

Closes #3386.

Upstream's `Parser` constructor parses `template.trimEnd()` but sets the root's end on the
**untrimmed** source (`phases/1-parse/index.js`):

```js
this.template = template.trimEnd();
...
this.root = { ..., start: 0, end: template.length, ... };
```

rsvelte instead derived `Root.end` from the last child / last special block, so a component
ending in whitespace reported an end short of `source.len()`. Replaced the ~35-line
`fragment_end` match with the one line upstream has.

## The suite is green by compensation, and that is why both halves are one commit

`crates/rsvelte_core/tests/parser_fixtures.rs` did **not** mirror upstream's harness. Upstream's
`tests/parser-modern/test.ts` reads the input and trims it before parsing; rsvelte's harness fed
the raw file. With the compiler bug in place the two errors cancelled, so the fixture suite was
green *because* both were wrong. Fixing only the compiler turns 24 of 27 modern fixtures red.
Measured as a 2x2:

| compiler | harness | `parser_fixtures` |
|---|---|---|
| buggy | untrimmed (before) | **pass** (compensating) |
| buggy | trimmed | **pass** |
| fixed | untrimmed | **FAIL** — 24/27 modern |
| fixed | trimmed (this PR) | **pass** |

Only one of the four cells is red, which is exactly why a fixture-suite verdict could never have
found this. The harness now applies `.replace("\r\n", "\n")` and
`.trim_end_matches(is_js_whitespace)`, mirroring `test.ts`.

## Revert control, both directions

**Control 1 — back out the compiler fix, keep the harness trim.** `parse_root_span` must fail,
and for the predicted reason (an end at the last non-whitespace byte, not the source length):

```
CARGO_EXIT=101
assertion `left == right` failed: root span of "<b>x</b>\n"
  left: (0, 8)
 right: (0, 9)
```

**Control 2 — keep the compiler fix, back out the harness trim.** `parser_fixtures` must fail,
and for the predicted reason (the harness feeds one byte more than upstream's does):

```
test result: FAILED
```

24 of 27 modern fixtures; `if-block/_actual.json` reports `"end": 18` against `output.json`'s
`"end": 17`, and the input is 18 bytes — i.e. the fixture's expectation is written against the
trimmed source.

**Compensation, measured rather than argued.** Compiler reverted *and* harness trim kept:
`parser_fixtures` `CARGO_EXIT=0`, 3 suites passed. That is the second green cell in the table.

With both halves applied: `parser_fixtures` 27/27 modern + 81/81 legacy, and the new
`crates/rsvelte_core/tests/parse_root_span.rs` (14 rows, including three controls whose span
already agreed) passes.

## Ratchet re-baseline

The `parse-ast` gate lands in #3683 and lists `Root#span` at **12,324 of 14,102** modern-axis
pairs; this PR removes it, so the ratchet must shrink in the same PR (it is two-sided).

**Command:** `node scripts/compat-corpus/parse-ast-verify.mjs --update-baseline`, over a
**complete** run — `28,208 compared pairs` (modern 14,102 / legacy 14,102 / loose 4), no
`--filter`, no `--no-fmt`. The binding was staged from a clean tree at the fix commit
(`[binding] built from db129520`, no `DIRTY`), which is what `unattributedBindingReason` demands
before it will let the rewrite run.

**What the rewrite changed:** one line.

```
 compatibility/parse-ast-known-failures.json | 1 -
-	"modern::Root#span": "root-span",
```

652 -> 651 keys. That single-line diff is the audit: a false shrink deletes every key it did not
measure, so a rewrite that removes exactly the key the fix targets is a complete run by
construction.

**Non-rewriting re-verification afterwards**, which is the run CI performs:

```
$ node scripts/compat-corpus/parse-ast-verify.mjs
[parse-ast]   modern: 14102 compared, 5252 identical, 8850 divergent, 229 both-reject
[parse-ast]   legacy: 14102 compared, 0 identical, 14102 divergent, 229 both-reject
[parse-ast]   loose: 4 compared, 1 identical, 3 divergent, 3 both-reject
[parse-ast] compared pairs: 28208
[parse-ast] OK — 651 listed divergence keys, none new, none stale
```

And the pre-rewrite run, for the other direction — the gate reports the shrink itself rather than
me asserting it:

```
[parse-ast] 1 ratchet violation(s):
  - listed key no longer diverges: modern::Root#span
```

**The identical count is the size of this.** Modern-axis byte-identical entries go from **1,075 to
5,252**. `Root#span` diverged on 12,324 of 14,102 entries, so one key was holding more than a
quarter of the population away from full agreement.

## Suites that did NOT run

`cargo test` was not run whole. Run here: `parser_fixtures`, `parse_root_span`, and the
`parse-ast` corpus gate. Not run: runtime, ssr, hydration, css, validator, svelte2tsx,
language-server, formatter, lint. CI carries those.
