### PR TITLE
fix(ci): remove stale mutation fuzz baseline

### DIFF
--- a/compatibility/mutation-known-failures.json
+++ b/compatibility/mutation-known-failures.json
@@ -18,7 +18,6 @@
 	"svelte/documentation/docs/02-runes/07-$inspect.md/2__m0__line-with-semi.svelte [code-mismatch] (client)",
 	"svelte/packages/svelte/tests/runtime-runes/samples/inspect-multiple/main__m0__line-with-semi.svelte [code-mismatch] (client)",
 	"svelte/packages/svelte/tests/runtime-runes/samples/inspect-with-untracked/main__m0__line-with-paren.svelte [code-mismatch] (client)",
-	"svelte/packages/svelte/tests/validator/samples/runes-conflicting-store-in-module/input__m0__line-with-brace.svelte.js [code-mismatch] (client)",
 	"svelte/packages/svelte/tests/validator/samples/unreferenced-variables/input__m0__line-with-semi.svelte [code-mismatch] (client)",
 	"svelte/packages/svelte/tests/validator/samples/unreferenced-variables/input__m0__line-with-semi.svelte [code-mismatch] (client-dev)"
 ]

--- a/compatibility/mutation-known-failures.md
+++ b/compatibility/mutation-known-failures.md
@@ -63,22 +63,22 @@ re-measured under 0.62, so it is in for honest reporting rather than to change a
 the gate prints must be the reason for the verdict, and before this a reviewer could see
 `import 'x'` vs `import "x"` and dismiss a real finding sitting further down the same file.
 
-## Mutation known failures (`mutation-known-failures.json`, 22 entries)
+## Mutation known failures (`mutation-known-failures.json`, 21 entries)
 
-Full sweep: 14,229 seeds, under oxfmt 0.63.0.
+Full sweep: 14,846 seeds, under oxfmt 0.64.0.
 
-The `mutation-known-failures.provenance.json` file records 11 entries, one SHA-256 seed-content
+The `mutation-known-failures.provenance.json` file records 10 entries, one SHA-256 seed-content
 hash for each source represented by the failure ratchet. A full sweep reports a changed
 hash as re-keyed instead of claiming that the old mutation now passes.
 
 | verdict | entries |
 |---|---|
-| `code-mismatch` | 22 |
+| `code-mismatch` | 21 |
 | `unparseable` | **0** |
 | `compiler-crash` | 0 |
 | `error-mismatch` | 0 |
 
-By target: `client` 12, `client-dev` 6, `server` 6, `server-dev` 6.
+By target: `client` 11, `client-dev` 6, `server` 6, `server-dev` 6.
 
 ### `unparseable` is now 0 — [#2546](https://github.com/baseballyama/rsvelte/issues/2546) closed
 

--- a/compatibility/mutation-known-failures.provenance.json
+++ b/compatibility/mutation-known-failures.provenance.json
@@ -8,6 +8,5 @@
 	"svelte/documentation/docs/02-runes/07-$inspect.md/2.svelte": "6474daddf2f38349d9d3c1a67dc20e3d62bf4acc59dcaf54f466786cab3a395a",
 	"svelte/packages/svelte/tests/runtime-runes/samples/inspect-multiple/main.svelte": "d7099100fb1e08f5a37a8a7839f10a039528c8902c82aea7f4ee4a3c08117bdd",
 	"svelte/packages/svelte/tests/runtime-runes/samples/inspect-with-untracked/main.svelte": "c4b58ef8bfead0591e47d48e23c17bf8c3a9cd84e43fcfd3696fa463ca2fb09e",
-	"svelte/packages/svelte/tests/validator/samples/runes-conflicting-store-in-module/input.svelte.js": "729e19c86c907954d917a3a01826dbf7ea019ef3d4043ddcf7deee3b24fa8487",
 	"svelte/packages/svelte/tests/validator/samples/unreferenced-variables/input.svelte": "3771bd95c200e34b46cd1a535949f5cecd9dcb07171bb612bd48f8d1febf67b8"
 }


### PR DESCRIPTION
The full main-branch mutation sweep now reports one previously known divergence as passing after #3704. Remove that stale ratchet entry and its seed provenance, and update the measured counts from the failing run.\n\nValidation:\n- node scripts/compat-corpus/known-failures-md-check.mjs\n- git diff --check