### PR TITLE
fix: expose find_code to production builds

### DIFF
--- a/crates/rsvelte_core/src/compiler/phases/3_transform/shared/js_scan.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/shared/js_scan.rs
@@ -421,9 +421,7 @@ pub(crate) fn skip_ws_and_comments_back(
 ///
 /// `needle` must contain no byte that can open an opaque run (`'`, `"`,
 /// `` ` ``, `/`), so testing its first byte settles the whole match.
-/// Every production caller is a rune scan and so wants [`find_rune_code`]; this
-/// stays as the negative control the rune tests contrast against.
-#[cfg(test)]
+/// This is also used by production scans whose needles are not rune keypaths.
 pub(crate) fn find_code(bytes: &[u8], needle: &[u8]) -> Option<usize> {
     find_code_filtered(bytes, needle, |_, _| true)
 }


### PR DESCRIPTION
Removes the accidental test-only gate from `find_code`, which has production callers after #3614.\n\nVerified with:\n- `cargo fmt --check`\n- `cargo build -p rsvelte_fmt --bin rsvelte-fmt`\n- `cargo test -p rsvelte_core --lib`