### PR TITLE
Fix post-merge integration regressions

### DIFF
--- a/crates/rsvelte_core/src/compiler/mod.rs
+++ b/crates/rsvelte_core/src/compiler/mod.rs
@@ -781,11 +781,10 @@ pub(crate) fn finalize_compile_result(
             phases::phase2_analyze::warnings::options_renamed_ssr_dom(),
         ));
     }
-    // Presence, not value: upstream's `deprecate()` fires on the option being
-    // SUPPLIED (`accessors: false` warns too) and exactly once per process, so
-    // the entry point that parsed the option owns the decision. Reading
-    // `options.accessors` here would re-derive it from the behavioural field and
-    // warn on every compile.
+    // Presence, not value: entry points that can distinguish a supplied
+    // `accessors` option record it in `legacy_options` and own warn-once
+    // semantics. The behavioural `options.accessors` field alone does not
+    // imply that this diagnostic should be emitted.
     if options.legacy_options.accessors {
         option_warnings.push(phases::phase3_transform::TransformWarning {
             code: "options_deprecated_accessors".to_string(),
@@ -968,6 +967,10 @@ pub fn compile_module(
     source: &str,
     options: ModuleCompileOptions,
 ) -> Result<CompileResult, CompileError> {
+    // A rune name spelled with a unicode escape is the same identifier to the
+    // parser and a different one to every text scan below.
+    let normalized = identifier_escapes::normalize_module_source(source);
+    let source = normalized.as_deref().unwrap_or(source);
     let source = remove_bom(source);
     // Parse JS source into an AST using the same infrastructure as component scripts.
     // Upstream `compileModule` → `analyze_module` always parses with

--- a/crates/rsvelte_core/src/compiler/phases/1_parse/parser.rs
+++ b/crates/rsvelte_core/src/compiler/phases/1_parse/parser.rs
@@ -1154,14 +1154,45 @@ impl<'a> Parser<'a> {
         }
         // A complete leading expression leaves the brace demanded at the first
         // token acorn did not consume.
-        if let Some(offset) = trailing_token_offset(rest)
-            && check_js_parse_error_with_pos(&rest[..offset]).is_none()
+        if let Some(offset) = trailing_token_offset(rest, self.ts)
+            && check_js_parse_error_with_pos(&rest[..offset], self.ts).is_none()
         {
             return Err(ParseError::expected_token("}", from + offset));
         }
+        if let Some(self_close) = memchr::memmem::find(rest.as_bytes(), b"/>") {
+            let before_self_close = rest[..self_close].trim_matches(is_js_whitespace);
+            // With no expression before `/>`, upstream's expression reader
+            // reaches the slash and the enclosing attribute reader reports the
+            // missing `}` at the `>`. There is no valid prefix to probe in this
+            // case, so treat it like the complete-expression path below.
+            if before_self_close.is_empty()
+                || check_js_parse_error_with_pos(before_self_close, self.ts).is_none()
+            {
+                return Err(ParseError::expected_token("}", from + self_close + 1));
+            }
+        }
+        // Acorn continues `1</div>` as `1 < /div...` and reports immediately
+        // after the `/` that starts the unterminated regexp. OXC's bare-program
+        // recovery instead stops at `<`, so preserve the expression-reader
+        // coordinate used by upstream for an enclosing close tag.
+        if let Some(close_tag) = memchr::memmem::find(rest.as_bytes(), b"</") {
+            // With two close tags the two `/` bytes form a complete regexp;
+            // acorn then consumes the remaining tag text and fails at EOF.
+            let after_first = close_tag + 2;
+            let at = if memchr::memmem::find(&rest.as_bytes()[after_first..], b"</").is_some() {
+                self.content_end
+            } else {
+                from + after_first
+            };
+            return Err(ParseError::svelte(
+                "js_parse_error",
+                "Unexpected token".to_string(),
+                (at, at),
+            ));
+        }
         // Otherwise acorn never got an expression out of the rest of the file,
         // so upstream reports the JS parser's own error rather than the brace.
-        if let Some((message, pos)) = check_js_parse_error_with_pos(rest) {
+        if let Some((message, pos)) = check_js_parse_error_with_pos(rest, self.ts) {
             let at = from + pos;
             return Err(ParseError::svelte("js_parse_error", message, (at, at)));
         }

--- a/crates/rsvelte_core/src/compiler/phases/1_parse/read/early_errors.rs
+++ b/crates/rsvelte_core/src/compiler/phases/1_parse/read/early_errors.rs
@@ -55,12 +55,23 @@ enum Message {
     Jump,
 }
 
+/// Which parses raise a row. Upstream clears acorn's `undefinedExports` after
+/// every statement when it parses a component `<script>` (`1-parse/acorn.js`
+/// `is_script`), because the exported name may be declared elsewhere in the
+/// component — so the undefined-export row is live only for a module.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Hosts {
+    Both,
+    ModuleOnly,
+}
+
 struct EarlyError {
     /// A substring of OXC's message. Chosen to survive a reworded tail, and
     /// pinned by a repro per row so a bump that breaks it fails loudly.
     needle: &'static str,
     at: At,
     message: Message,
+    hosts: Hosts,
 }
 
 const TABLE: &[EarlyError] = &[
@@ -68,61 +79,73 @@ const TABLE: &[EarlyError] = &[
         needle: "Multiple constructor implementations are not allowed",
         at: At::Last,
         message: Message::Fixed("Duplicate constructor in the same class"),
+        hosts: Hosts::Both,
     },
     EarlyError {
         needle: "Super calls are not permitted outside constructors",
         at: At::First,
         message: Message::Fixed("'super' keyword outside a method"),
+        hosts: Hosts::Both,
     },
     EarlyError {
         needle: "'super' can only be referenced in members of derived classes",
         at: At::First,
         message: Message::Fixed("'super' keyword outside a method"),
+        hosts: Hosts::Both,
     },
     EarlyError {
         needle: "'super' can only be referenced in a derived class",
         at: At::First,
         message: Message::Fixed("super() call outside constructor of a subclass"),
+        hosts: Hosts::Both,
     },
     EarlyError {
         needle: "Illegal break statement",
         at: At::First,
         message: Message::Fixed("Unsyntactic break"),
+        hosts: Hosts::Both,
     },
     EarlyError {
         needle: "Illegal continue statement",
         at: At::First,
         message: Message::Fixed("Unsyntactic continue"),
+        hosts: Hosts::Both,
     },
     EarlyError {
         needle: "Jump target cannot cross function boundary",
         at: At::JumpKeyword,
         message: Message::Jump,
+        hosts: Hosts::Both,
     },
     EarlyError {
         needle: "Label `",
         at: At::Last,
         message: Message::Named("Label '{}' is already declared"),
+        hosts: Hosts::Both,
     },
     EarlyError {
         needle: "must be declared in an enclosing class",
         at: At::First,
         message: Message::Named("Private field '{}' must be declared in an enclosing class"),
+        hosts: Hosts::Both,
     },
     EarlyError {
         needle: "has already been declared",
         at: At::Last,
         message: Message::Redeclaration,
+        hosts: Hosts::Both,
     },
     EarlyError {
         needle: "declaration can only be used at the top level of a module",
         at: At::First,
         message: Message::Fixed("'import' and 'export' may only appear at the top level"),
+        hosts: Hosts::Both,
     },
     EarlyError {
         needle: "The operand of a 'delete' operator cannot be a private identifier",
         at: At::DeleteKeyword,
         message: Message::Fixed("Private fields can not be deleted"),
+        hosts: Hosts::Both,
     },
     EarlyError {
         needle: "Illegal 'use strict' directive in function with non-simple parameter list",
@@ -130,6 +153,25 @@ const TABLE: &[EarlyError] = &[
         message: Message::Fixed(
             "Illegal 'use strict' directive in function with non-simple parameter list",
         ),
+        hosts: Hosts::Both,
+    },
+    EarlyError {
+        needle: "'arguments' is not allowed in class field initializer",
+        at: At::First,
+        message: Message::Fixed("Cannot use 'arguments' in class field initializer"),
+        hosts: Hosts::Both,
+    },
+    EarlyError {
+        needle: "'arguments' is not allowed in static initialization block",
+        at: At::First,
+        message: Message::Fixed("Cannot use arguments in class static initialization block"),
+        hosts: Hosts::Both,
+    },
+    EarlyError {
+        needle: "Export '",
+        at: At::First,
+        message: Message::Named("Export '{}' is not defined"),
+        hosts: Hosts::ModuleOnly,
     },
 ];
 
@@ -138,12 +180,16 @@ const TABLE: &[EarlyError] = &[
 /// Runs ONCE per script. It must not be reached from the per-expression parse
 /// paths: a template expression is its own `Program` with no enclosing class or
 /// loop, so every one of these checks would answer a question it was not asked.
-pub fn find_early_error(program: &Program<'_>, source: &str) -> Option<(u32, String)> {
+pub fn find_early_error(
+    program: &Program<'_>,
+    source: &str,
+    is_script: bool,
+) -> Option<(u32, String)> {
     let diagnostics = SemanticBuilder::new_compiler().build(program).diagnostics;
     let mut functions = None;
     diagnostics
         .iter()
-        .filter_map(|d| translate(d, source, program, &mut functions))
+        .filter_map(|d| translate(d, source, program, is_script, &mut functions))
         .min_by_key(|(at, _)| *at)
 }
 
@@ -151,10 +197,14 @@ fn translate(
     diagnostic: &OxcDiagnostic,
     source: &str,
     program: &Program<'_>,
+    is_script: bool,
     functions: &mut Option<FunctionStarts>,
 ) -> Option<(u32, String)> {
     let text = diagnostic.message.as_ref();
     let entry = TABLE.iter().find(|e| text.contains(e.needle))?;
+    if is_script && entry.hosts == Hosts::ModuleOnly {
+        return None;
+    }
 
     let first = diagnostic.labels.first()?;
     let label = match entry.at {

--- a/crates/rsvelte_core/src/compiler/phases/1_parse/read/expression.rs
+++ b/crates/rsvelte_core/src/compiler/phases/1_parse/read/expression.rs
@@ -1637,9 +1637,10 @@ pub fn parse_destructuring_pattern<'a>(
         SourceType::mjs()
     };
 
-            let wrapped = wrap_for_parse("let ", content, "= null");
-            let parser = OxcParser::new(allocator, &wrapped, source_type);
-            let result = parser.parse();
+    with_oxc_allocator(|allocator| {
+        let wrapped = wrap_for_parse("let ", content, "= null");
+        let parser = OxcParser::new(allocator, &wrapped, source_type);
+        let result = parser.parse();
 
         if !result.diagnostics.is_empty() {
             return None;
@@ -1747,6 +1748,19 @@ fn expression_source_type(ts: bool) -> SourceType {
     }
 }
 
+/// Parse `content` unwrapped and return the first diagnostic at the offending token.
+fn bare_parse_error(content: &str, source_type: SourceType) -> Option<(String, usize)> {
+    with_oxc_allocator(|allocator| {
+        let result = OxcParser::new(allocator, content, source_type).parse();
+        let first_error = result.diagnostics.first()?;
+        let pos = first_error
+            .labels
+            .first()
+            .map_or(0, |label| (label.offset() as usize).min(content.len()));
+        Some((first_error.message.to_string(), pos))
+    })
+}
+
 /// Check if a JavaScript expression has parse errors, returning the failure
 /// position alongside the message.
 ///
@@ -1765,7 +1779,7 @@ fn expression_source_type(ts: bool) -> SourceType {
 /// because the clamp lands it on the close token, so when the wrapper is what
 /// failed, [`bare_parse_error`] re-reads the body and reports acorn's position
 /// directly.
-pub fn check_js_parse_error_with_pos(content: &str) -> Option<(String, usize)> {
+pub fn check_js_parse_error_with_pos(content: &str, ts: bool) -> Option<(String, usize)> {
     // Two inputs acorn rejects on their very first token are described by the
     // `(…)` wrapper below instead of by themselves — nothing is left for OXC to
     // complain about but the parentheses it never saw in the source. Answer
@@ -1804,6 +1818,7 @@ pub fn check_js_parse_error_with_pos(content: &str) -> Option<(String, usize)> {
                             "Shorthand property assignments are valid only in destructuring patterns"
                                 .to_string(),
                             (label_start + eq).saturating_sub(1).min(content.len()),
+                            false,
                         ));
                     }
                 }
@@ -1848,7 +1863,11 @@ pub fn check_js_parse_error_with_pos(content: &str) -> Option<(String, usize)> {
                     "Empty parenthesized expression" => "Unexpected token",
                     other => other,
                 };
-                return Some((message.to_string(), pos, true));
+                // A label which is itself the offending token already has the
+                // acorn position above. Re-parsing it bare can turn that token
+                // into consumed input (for example `do`) and move the point to
+                // its end.
+                return Some((message.to_string(), pos, !report_at_label_start));
             }
             // Check for invalid assignment targets that OXC doesn't report as errors
             if let Some(oxc_ast::ast::Statement::ExpressionStatement(expr_stmt)) =
@@ -1881,24 +1900,12 @@ pub fn check_js_parse_error_with_pos(content: &str) -> Option<(String, usize)> {
         Some((message, pos))
     };
 
-    // Try TypeScript first
-    let ts_result = probe(SourceType::ts());
-
-    // No TS errors means valid
-    ts_result.as_ref()?;
-
-    // Try JavaScript
-    let js_result = probe(SourceType::mjs());
-
-    // No JS errors means valid
-    js_result.as_ref()?;
-
-    let result = js_result.or(ts_result);
+    let result = probe(expression_source_type(ts));
 
     // A body with no code in it has nothing of its own to fail on, so whatever
     // OXC reported describes the `(…)` this probe wrapped it in. Acorn is given
     // the unwrapped text and says `Unexpected token` at the delimiter.
-    if is_code_empty(content) {
+    if is_code_empty(content, ts) {
         return result.map(|(_, pos)| ("Unexpected token".to_string(), pos));
     }
     result
@@ -1907,12 +1914,12 @@ pub fn check_js_parse_error_with_pos(content: &str) -> Option<(String, usize)> {
 /// Whether `content` carries no JavaScript at all — only whitespace and
 /// comments. Answered by the parser rather than by a scan so that a `//` or
 /// `/*` inside a string cannot be mistaken for one.
-fn is_code_empty(content: &str) -> bool {
+fn is_code_empty(content: &str, ts: bool) -> bool {
     if content.is_empty() {
         return true;
     }
     with_oxc_allocator(|allocator| {
-        let result = OxcParser::new(allocator, content, SourceType::mjs()).parse();
+        let result = OxcParser::new(allocator, content, expression_source_type(ts)).parse();
         result.program.body.is_empty() && result.diagnostics.is_empty()
     })
 }
@@ -1987,12 +1994,12 @@ pub fn check_js_statement_parse_error(content: &str, ts: bool) -> Option<(String
 /// *inside* the expression lands (`s(42 = nope)`, `1</div>`). Only a prefix that
 /// parses on its own is a place upstream's `read_expression` would have stopped,
 /// leaving the missing close token as the diagnostic.
-pub fn trailing_close_offset(content: &str) -> Option<usize> {
-    trailing_token_offset(content).filter(|&off| {
+pub fn trailing_close_offset(content: &str, ts: bool) -> Option<usize> {
+    trailing_token_offset(content, ts).filter(|&off| {
         off > 0
-            && content
-                .get(..off)
-                .is_some_and(|prefix| check_js_parse_error_with_pos(prefix.trim_end()).is_none())
+            && content.get(..off).is_some_and(|prefix| {
+                check_js_parse_error_with_pos(prefix.trim_end(), ts).is_none()
+            })
     })
 }
 
@@ -2008,6 +2015,35 @@ pub fn trailing_close_offset(content: &str) -> Option<usize> {
 /// This mirrors upstream Svelte's `read_expression` + `eat(close, true)` flow:
 /// acorn parses one maximal expression, and any leftover surfaces as
 /// `expected_token` while a broken expression surfaces as `js_parse_error`.
+fn shorthand_assign_offset(slice: &str) -> Option<usize> {
+    use crate::compiler::phases::phase3_transform::shared::js_scan::code_bytes;
+    let bytes = slice.as_bytes();
+    let is_ident = |b: u8| b.is_ascii_alphanumeric() || b == b'_' || b == b'$' || b >= 0x80;
+    let mut iter = code_bytes(bytes);
+    let (_, first) = iter.next()?;
+    if first.is_ascii_digit() || !is_ident(first) {
+        return None;
+    }
+    let mut seen_gap = false;
+    for (i, b) in iter {
+        if is_ident(b) {
+            if seen_gap {
+                return None;
+            }
+            continue;
+        }
+        if b.is_ascii_whitespace() {
+            seen_gap = true;
+            continue;
+        }
+        if b == b'=' && !matches!(bytes.get(i + 1), Some(b'=') | Some(b'>')) {
+            return Some(i);
+        }
+        return None;
+    }
+    None
+}
+
 pub fn trailing_token_offset(content: &str, ts: bool) -> Option<usize> {
     // Wrap in parens so a *complete* leading expression is consumed greedily and
     // the error label lands on the offending region. (Parsing the bare string as
@@ -2025,7 +2061,7 @@ pub fn trailing_token_offset(content: &str, ts: bool) -> Option<usize> {
         // it as a diagnostic over the whole expression; acorn has no such node
         // and stops where the operator begins.
         if !ts && let Some(at) = typescript_operator_start(&result.program) {
-            return (at as usize).checked_sub(1);
+            return Some(at as usize);
         }
         let first_error = result.diagnostics.first()?;
         let label = first_error.labels.first()?;
@@ -2040,6 +2076,13 @@ pub fn trailing_token_offset(content: &str, ts: bool) -> Option<usize> {
     // A trailing-token error has leftover input *before* the synthetic closing
     // `)`; an incomplete expression errors at/after the end.
     if content_pos >= content.len() {
+        return None;
+    }
+    // A comma continues the expression (as a SequenceExpression); acorn does
+    // not return the complete prefix and leave it for the caller's close-token
+    // check. With no following operand (`a,`) or another comma (`a,,b`) it
+    // throws a JS parse error at the missing operand instead.
+    if content.as_bytes().get(content_pos) == Some(&b',') {
         return None;
     }
     // acorn parses ONE maximal expression and only then expects the close token,
@@ -2104,12 +2147,13 @@ pub fn close_token_or_parse_error(
     trimmed: &str,
     trimmed_offset: usize,
     close_char: char,
+    ts: bool,
 ) -> crate::error::ParseError {
-    let trailing = trailing_token_offset(trimmed).filter(|&off| {
+    let trailing = trailing_token_offset(trimmed, ts).filter(|&off| {
         off > 0
             && trimmed
                 .get(..off)
-                .is_some_and(|prefix| check_js_parse_error_with_pos(prefix).is_none())
+                .is_some_and(|prefix| check_js_parse_error_with_pos(prefix, ts).is_none())
     });
     if let Some(off) = trailing {
         let mut buf = [0u8; 4];
@@ -2118,7 +2162,7 @@ pub fn close_token_or_parse_error(
             trimmed_offset + off,
         );
     }
-    let at = check_js_parse_error_with_pos(trimmed)
+    let at = check_js_parse_error_with_pos(trimmed, ts)
         .map_or(trimmed_offset + trimmed.len(), |(_, pos)| {
             trimmed_offset + pos
         });
@@ -2272,23 +2316,28 @@ fn parse_expression_with_typescript<'a>(
                             comment.span.start as usize - 1,
                         );
                     }
+                    let comment_text = CompactString::from(value.as_str());
+                    let comment_value = create_comment_object(
+                        comment.kind,
+                        value,
+                        comment_start,
+                        comment_end,
+                        line_offsets,
+                    )
+                    .to_value();
                     comment_entries.push(CommentEntry {
                         start: comment_start as u32,
-                        text: CompactString::from(value.as_str()),
+                        text: comment_text,
+                        value: comment_value.clone(),
                     });
-                    comment_values.push(
-                        create_comment_object(
-                            comment.kind,
-                            value,
-                            comment_start,
-                            comment_end,
-                            line_offsets,
-                        )
-                        .to_value(),
-                    );
+                    comment_values.push(comment_value);
                 }
 
                 let json_val = expr.as_json();
+                let root_type = json_val
+                    .get("type")
+                    .and_then(Value::as_str)
+                    .map(str::to_owned);
                 let root_span = json_val
                     .get("start")
                     .and_then(Value::as_u64)
@@ -2297,29 +2346,46 @@ fn parse_expression_with_typescript<'a>(
                 let mut ignore_comment_map: Vec<(u32, Vec<CompactString>)> = Vec::new();
                 let mut attacher = CommentAttacher {
                     comments: &comment_entries,
-                    values: &comment_values,
-                    arena: Some(arena),
                     next: 0,
                     content,
                     offset: offset as u32,
                     map: &mut ignore_comment_map,
+                    captured: Some(std::collections::HashMap::default()),
                 };
                 attacher.visit(json_val, None);
                 let claimed = attacher.next;
+                if let Some(captured) = attacher.captured.take() {
+                    for ((node_type, start, end), (leading, trailing)) in captured {
+                        arena.record_node_comments(
+                            &node_type,
+                            start,
+                            end,
+                            (!leading.is_empty()).then_some(leading),
+                            (!trailing.is_empty()).then_some(trailing),
+                        );
+                    }
+                }
 
                 // Upstream's "trailing comments after the root node" case, which
                 // is what lets a caller find the end of the expression tag.
-                if let Some((root_start, root_end)) = root_span
+                if let (Some(root_type), Some((root_start, root_end))) =
+                    (root_type.as_deref(), root_span)
                     && comment_entries
                         .get(claimed)
                         .is_some_and(|c| c.start >= root_end)
                 {
                     let (leading, claimed_trailing) = arena
-                        .node_comments(root_start, root_end)
+                        .node_comments(root_type, root_start, root_end)
                         .unwrap_or((None, None));
                     let mut trailing = claimed_trailing.unwrap_or_default();
                     trailing.extend(comment_values[claimed..].iter().cloned());
-                    arena.record_node_comments(root_start, root_end, leading, Some(trailing));
+                    arena.record_node_comments(
+                        root_type,
+                        root_start,
+                        root_end,
+                        leading,
+                        Some(trailing),
+                    );
                 }
             }
 
@@ -7339,16 +7405,28 @@ fn convert_parsed_program<'ast>(
             crate::error::ParseError::svelte("js_parse_error", message.clone(), (pos, pos))
         });
 
-        if parse_error.is_none()
-            && let Some((at, message)) = acorn_only_violation(program, content, is_typescript)
-        {
-            let pos = at as usize + offset;
-            reported_at = Some((at as usize, message.clone()));
-            parse_error = Some(crate::error::ParseError::svelte(
-                "js_parse_error",
-                message,
-                (pos, pos),
-            ));
+        if parse_error.is_none() {
+            // An early error needs the enclosing scope, so it comes from a
+            // `SemanticBuilder` run rather than from the walk; acorn checks both
+            // while parsing and stops at whichever comes first. This is the only
+            // caller that may run it — the per-expression paths above parse a
+            // fragment with no enclosing class or loop.
+            let earliest = [
+                acorn_only_violation(program, content, is_typescript),
+                super::early_errors::find_early_error(program, content, is_script),
+            ]
+            .into_iter()
+            .flatten()
+            .min_by_key(|(at, _)| *at);
+            if let Some((at, message)) = earliest {
+                let pos = at as usize + offset;
+                reported_at = Some((at as usize, message.clone()));
+                parse_error = Some(crate::error::ParseError::svelte(
+                    "js_parse_error",
+                    message,
+                    (pos, pos),
+                ));
+            }
         }
 
         // acorn stops at the first thing it cannot read, so a character it does
@@ -7467,6 +7545,7 @@ fn convert_parsed_program<'ast>(
                 comment_entries.push(CommentEntry {
                     start: comment.start,
                     text: comment.value.clone(),
+                    value: js_comment_value(comment),
                 });
                 comment_values.push(js_comment_value(comment));
             }
@@ -7477,6 +7556,7 @@ fn convert_parsed_program<'ast>(
                 comment_entries.push(CommentEntry {
                     start: offset as u32 + comment.span.start,
                     text: CompactString::from(extract_comment_value(raw_text, comment.kind)),
+                    value: build_comment_value(comment, content, offset),
                 });
                 if capture {
                     comment_values.push(build_comment_value(comment, content, offset));
@@ -7485,13 +7565,11 @@ fn convert_parsed_program<'ast>(
 
             let mut attacher = CommentAttacher {
                 comments: &comment_entries,
-                values: &comment_values,
-                arena: capture.then_some(arena),
                 next: 0,
                 content,
                 offset: offset as u32,
                 map: &mut ignore_comment_map,
-                captured: capture_comments.then(std::collections::HashMap::default),
+                captured: capture.then(std::collections::HashMap::default),
             };
             let last_index = program.body.len().saturating_sub(1);
 
@@ -7514,8 +7592,6 @@ fn convert_parsed_program<'ast>(
                     attacher.skip_past(offset as u32 + stmt.span().end);
                 }
             }
-            claimed = attacher.next;
-
             claimed = attacher.next;
             if let Some(captured) = attacher.captured.take() {
                 for ((node_type, start, end), (leading, trailing)) in captured {
@@ -7666,14 +7742,6 @@ struct ParentInfo {
 /// the key Phase 2 looks up while walking the typed AST.
 struct CommentAttacher<'a> {
     comments: &'a [CommentEntry],
-    /// The full `{type, value, start, end}` comment objects, parallel to
-    /// `comments`. Empty unless `arena` is set.
-    values: &'a [Value],
-    /// When set, the walk also records `leadingComments`/`trailingComments` on
-    /// each node — upstream's `add_comments`, which the public `parse()` output
-    /// carries. Left `None` on the compile path, where the side table is dead
-    /// weight (codegen re-parses script text).
-    arena: Option<&'a ParseArena>,
     next: usize,
     content: &'a str,
     offset: u32,
@@ -7696,17 +7764,13 @@ impl CommentAttacher<'_> {
         let end = obj.get("end").and_then(|v| v.as_u64()).map(|v| v as u32);
         let node_type = obj.get("type").and_then(|t| t.as_str());
 
-        let mut leading: Option<Vec<Value>> = None;
         if let Some(start) = start {
             while self
                 .comments
                 .get(self.next)
                 .is_some_and(|comment| comment.start < start)
             {
-                self.record_leading(start, self.next);
-                if let Some(value) = self.arena.and(self.values.get(self.next)) {
-                    leading.get_or_insert_with(Vec::new).push(value.clone());
-                }
+                self.record_leading(node_type, start, end, self.next);
                 self.next += 1;
             }
         }
@@ -7755,12 +7819,30 @@ impl CommentAttacher<'_> {
             }
         }
 
-        let trailing = self.claim_trailing(end, parent.as_ref());
-        if let Some(arena) = self.arena
-            && (leading.is_some() || trailing.is_some())
-            && let (Some(start), Some(end)) = (start, end)
-        {
-            arena.record_node_comments(start, end, leading, trailing);
+        self.claim_trailing(node_type, start, end, parent.as_ref());
+    }
+
+    fn capture(
+        &mut self,
+        node_type: Option<&str>,
+        start: Option<u32>,
+        end: Option<u32>,
+        index: usize,
+        leading: bool,
+    ) {
+        let (Some(node_type), Some(start), Some(end), Some(map)) =
+            (node_type, start, end, self.captured.as_mut())
+        else {
+            return;
+        };
+        let slot = map
+            .entry((CompactString::from(node_type), start, end))
+            .or_default();
+        let value = self.comments[index].value.clone();
+        if leading {
+            slot.0.push(value);
+        } else {
+            slot.1.push(value);
         }
     }
 
@@ -7779,36 +7861,34 @@ impl CommentAttacher<'_> {
     /// comments of a later node.
     fn claim_trailing(
         &mut self,
+        node_type: Option<&str>,
+        start: Option<u32>,
         end: Option<u32>,
         parent: Option<&ParentInfo>,
-    ) -> Option<Vec<Value>> {
-        let comment = self.comments.get(self.next)?;
+    ) {
+        let Some(comment) = self.comments.get(self.next) else {
+            return;
+        };
         let parent_end = parent.and_then(|p| p.end);
         if matches!((end, parent_end), (Some(e), Some(pe)) if e == pe) {
-            return None;
+            return;
         }
 
-        let mut claimed: Option<Vec<Value>> = None;
         if parent.is_some_and(|p| p.is_last_in_body) {
             while let Some(comment) = self.comments.get(self.next) {
                 if parent_end.is_some_and(|pe| comment.start >= pe) {
                     break;
                 }
-                if let Some(value) = self.arena.and(self.values.get(self.next)) {
-                    claimed.get_or_insert_with(Vec::new).push(value.clone());
-                }
+                self.capture(node_type, start, end, self.next, false);
                 self.next += 1;
             }
         } else if let Some(node_end) = end
             && node_end <= comment.start
             && self.is_separator_slice(node_end, comment.start)
         {
-            if let Some(value) = self.arena.and(self.values.get(self.next)) {
-                claimed = Some(vec![value.clone()]);
-            }
+            self.capture(node_type, start, end, self.next, false);
             self.next += 1;
         }
-        claimed
     }
 
     /// `/^[,) \t]*$/` over the source between a node's end and a comment's start.
@@ -12886,6 +12966,8 @@ mod tests {
             ("y!.k", Some(1), None),
             // Broken before any complete expression exists.
             ("a +", None, None),
+            ("a,", None, None),
+            ("a,,b", None, None),
             ("<string>y", None, None),
             ("f<string>()", None, None),
             ("((a: string) => a)(\"\")", None, None),

--- a/crates/rsvelte_core/src/compiler/phases/1_parse/read/style.rs
+++ b/crates/rsvelte_core/src/compiler/phases/1_parse/read/style.rs
@@ -297,7 +297,7 @@ fn nth_of_tail(text: &str, anb: usize) -> Option<usize> {
         return Some(anb);
     }
 
-    // `\s+of\s+`
+    // `\s+of` followed by whitespace or an unambiguous selector-start token.
     let ws = leading_ws_len(rest);
     if ws == 0 {
         return None;
@@ -305,10 +305,15 @@ fn nth_of_tail(text: &str, anb: usize) -> Option<usize> {
     let after = &rest[ws..];
     let after = after.strip_prefix("of")?;
     let trailing_ws = leading_ws_len(after);
-    if trailing_ws == 0 {
-        return None;
+    if trailing_ws > 0 {
+        return Some(anb + ws + 2 + trailing_ws);
     }
-    Some(anb + ws + 2 + trailing_ws)
+
+    matches!(
+        after.as_bytes().first(),
+        Some(b'.' | b'#' | b'[' | b'*' | b':' | b'&')
+    )
+    .then_some(anb + ws + 2)
 }
 
 /// A comment where a compound selector should begin. Upstream's `read_selector`
@@ -2435,7 +2440,12 @@ impl<'a> SelectorParser<'a> {
                 obj.insert("start".to_string(), Value::Number((start as i64).into()));
                 obj.insert("end".to_string(), Value::Number((end as i64).into()));
                 selectors.push(Value::Object(obj));
-            } else if c.is_alphabetic() || c == '-' || c == '_' || c == '\\' || (c as u32) >= 160 {
+            } else if c.is_alphabetic()
+                || (c == '-' && !self.peek_next_char().is_ascii_digit())
+                || c == '_'
+                || c == '\\'
+                || (c as u32) >= 160
+            {
                 // Type selector (element name) - mirrors the official
                 // `read_identifier` valid character set: ASCII letters/digits,
                 // `-`, `_`, code points >= 160, and `\`-escapes.
@@ -2569,6 +2579,7 @@ impl<'a> SelectorParser<'a> {
             }
             let content_end = self.index;
             self.advance(); // consume ')'
+
             let content = &self.source[content_start..content_end];
             let leading = content.len() - content.trim_start_ws().len();
             let trailing = content.len() - content.trim_end_ws().len();
@@ -2603,7 +2614,6 @@ impl<'a> SelectorParser<'a> {
         self.advance(); // consume ':'
 
         let name = self.read_identifier();
-
         // Check for arguments in parentheses
         let args = if self.current_char() == '(' {
             let args_start = self.offset + self.index + 1;
@@ -2653,165 +2663,6 @@ impl<'a> SelectorParser<'a> {
                     ),
                 );
                 None
-            } else if is_nth_pseudo {
-                // For nth-* pseudo-classes, parse the An+B syntax and optional 'of S' selector
-                let trimmed = content.trim_ws();
-                let leading_ws = content.len() - content.trim_start_ws().len();
-                let nth_start = args_start + leading_ws;
-
-                // Check for 'of ' keyword to split An+B from selector
-                let (nth_value, selector_part, nth_end_pos) = if let Some(split) =
-                    find_nth_of(trimmed)
-                {
-                    // Everything up to and including the `of` (plus the
-                    // whitespace after it, if any) is the Nth value.
-                    let nth_val = &trimmed[..split];
-                    let sel_part = &trimmed[split..];
-                    let end_pos = nth_start + split;
-                    (nth_val, Some((sel_part, end_pos)), end_pos)
-                } else {
-                    // Check if it's a valid An+B expression or just a selector
-                    // An+B patterns: contains n, digits, +/-, or is even/odd
-                    let is_nth_pattern = trimmed == "even"
-                        || trimmed == "odd"
-                        || trimmed.contains('n')
-                        || trimmed.chars().any(|c| c.is_ascii_digit())
-                        || trimmed.starts_with('+')
-                        || trimmed.starts_with('-');
-
-                    if is_nth_pattern {
-                        let trailing_ws = content.len() - content.trim_end_ws().len();
-                        let end_pos = self.offset + content_end - trailing_ws;
-                        (trimmed, None, end_pos)
-                    } else {
-                        // Not an An+B pattern, treat as regular selector
-                        // Fall through to the non-nth parsing below
-                        let mut trimmed_inner = content.trim_ws();
-                        let mut leading_skip = content.len() - content.trim_start_ws().len();
-
-                        loop {
-                            if trimmed_inner.starts_with("/*") {
-                                if let Some(end_pos) = memmem::find(trimmed_inner.as_bytes(), b"*/")
-                                {
-                                    leading_skip += end_pos + 2;
-                                    trimmed_inner = &trimmed_inner[end_pos + 2..];
-                                    let ws_skip =
-                                        trimmed_inner.len() - trimmed_inner.trim_start_ws().len();
-                                    leading_skip += ws_skip;
-                                    trimmed_inner = trimmed_inner.trim_start_ws();
-                                } else {
-                                    break;
-                                }
-                            } else {
-                                break;
-                            }
-                        }
-
-                        let trailing_ws = content.len() - content.trim_end_ws().len();
-                        let trimmed_start = args_start + leading_skip;
-                        let trimmed_end = self.offset + content_end - trailing_ws;
-
-                        // Parse as regular selector list and set as args for the PseudoClassSelector
-                        let args = self.parse_args_selector_list(
-                            trimmed_inner,
-                            trimmed_start,
-                            trimmed_end,
-                        );
-                        let end = self.offset + self.index;
-
-                        let mut obj = Map::new();
-                        obj.insert(
-                            "type".to_string(),
-                            Value::String("PseudoClassSelector".to_string()),
-                        );
-                        obj.insert("name".to_string(), Value::String(name));
-                        obj.insert("args".to_string(), args);
-                        obj.insert("start".to_string(), Value::Number((start as i64).into()));
-                        obj.insert("end".to_string(), Value::Number((end as i64).into()));
-
-                        return Some(Value::Object(obj));
-                    }
-                };
-
-                // Build the Nth node
-                let mut nth_obj = Map::new();
-                nth_obj.insert("type".to_string(), Value::String("Nth".to_string()));
-                nth_obj.insert("value".to_string(), Value::String(nth_value.to_string()));
-                nth_obj.insert(
-                    "start".to_string(),
-                    Value::Number((nth_start as i64).into()),
-                );
-                nth_obj.insert(
-                    "end".to_string(),
-                    Value::Number((nth_end_pos as i64).into()),
-                );
-
-                // Get the actual end position
-                let trailing_ws = content.len() - content.trim_end_ws().len();
-                let actual_end = self.offset + content_end - trailing_ws;
-
-                // What follows `of` is an ordinary selector list, not a single
-                // selector: `:nth-child(2n of .a, .b)` has two complex
-                // selectors, and only the first one carries the `Nth`.
-                let of_list = selector_part.and_then(|(sel_text, sel_start)| {
-                    let mut list = self.parse_args_selector_list(sel_text, sel_start, actual_end);
-                    prepend_nth(&mut list, Value::Object(nth_obj.clone()), nth_start)
-                        .then_some(list)
-                });
-
-                let mut selectors = vec![Value::Object(nth_obj)];
-
-                // Only reached when there is nothing after `of` to attach to.
-                if of_list.is_none()
-                    && let Some((sel_text, sel_start)) = selector_part
-                {
-                    let mut sel_parser = self.nested(sel_text, sel_start);
-                    let mut parsed = Vec::new();
-                    sel_parser.parse_selectors(&mut parsed);
-                    self.absorb_nesting_error(&sel_parser);
-                    selectors.extend(parsed);
-                }
-
-                // Wrap in RelativeSelector
-                let mut rel_sel = Map::new();
-                rel_sel.insert(
-                    "type".to_string(),
-                    Value::String("RelativeSelector".to_string()),
-                );
-                rel_sel.insert("combinator".to_string(), Value::Null);
-                rel_sel.insert("selectors".to_string(), Value::Array(selectors));
-                rel_sel.insert(
-                    "start".to_string(),
-                    Value::Number((nth_start as i64).into()),
-                );
-                rel_sel.insert("end".to_string(), Value::Number((actual_end as i64).into()));
-
-                    let mut complex_sel = Map::new();
-                    complex_sel.insert(
-                        "type".to_string(),
-                        Value::String("ComplexSelector".to_string()),
-                    );
-                    complex_sel.insert("start".to_string(), nth_start_value.clone());
-                    complex_sel
-                        .insert("end".to_string(), Value::Number((actual_end as i64).into()));
-                    complex_sel.insert(
-                        "children".to_string(),
-                        Value::Array(vec![Value::Object(rel_sel)]),
-                    );
-
-                    let mut sel_list = Map::new();
-                    sel_list.insert(
-                        "type".to_string(),
-                        Value::String("SelectorList".to_string()),
-                    );
-                    sel_list.insert("start".to_string(), nth_start_value);
-                    sel_list.insert("end".to_string(), Value::Number((actual_end as i64).into()));
-                    sel_list.insert(
-                        "children".to_string(),
-                        Value::Array(vec![Value::Object(complex_sel)]),
-                    );
-
-                Some(of_list.unwrap_or(Value::Object(sel_list)))
             } else {
                 // Calculate trimmed content positions (strip whitespace and leading comments)
                 let mut trimmed = content.trim_ws();

--- a/crates/rsvelte_core/src/compiler/phases/1_parse/resolve_lazy.rs
+++ b/crates/rsvelte_core/src/compiler/phases/1_parse/resolve_lazy.rs
@@ -451,7 +451,7 @@ fn resolve_expression(
         Err((msg, pos)) => {
             // Store the first parse error encountered
             if first_error.is_none() {
-                *first_error = lazy_parse_error(kind, msg, content, start, ts);
+                *first_error = lazy_parse_error(kind, msg, content, start, source, ts);
             }
             // Still set the expression to something valid to allow continued processing
             *expr = super::read::expression::create_empty_identifier("", pos, pos + content.len());
@@ -467,11 +467,12 @@ fn lazy_parse_error(
     msg: String,
     content: &str,
     start: usize,
+    source: &str,
     ts: bool,
 ) -> Option<crate::error::ParseError> {
-    let close = match kind {
+    Some(match kind {
         LazyKind::Lenient => return None,
-        LazyKind::AwaitHead => super::state::tag::await_head_parse_error(source, start, msg),
+        LazyKind::AwaitHead => super::state::tag::await_head_parse_error(source, start, msg, ts),
         // Upstream's `read_expression` parses ONE maximal expression with acorn
         // and then `eat('}', true)`: a complete leading expression followed by
         // leftover tokens (e.g. `{foo();}` — the `;` is left over) surfaces as
@@ -509,7 +510,7 @@ fn lazy_parse_error(
             } else {
                 '}'
             };
-            super::read::expression::close_token_or_parse_error(msg, content, start, close)
+            super::read::expression::close_token_or_parse_error(msg, content, start, close, ts)
         }
     })
 }

--- a/crates/rsvelte_core/src/compiler/phases/1_parse/state/element.rs
+++ b/crates/rsvelte_core/src/compiler/phases/1_parse/state/element.rs
@@ -1504,7 +1504,7 @@ impl<'a> Parser<'a> {
             // `get_directive_type` recognises — and only after the value has been
             // read, so a malformed value is what gets reported.
             if is_directive_prefix(prefix) && directive_name_is_empty(&name, colon_pos) {
-                self.discard_attribute_value()?;
+                self.read_attribute_value_for_error()?;
                 return Err(crate::error::ParseError::svelte(
                     "directive_missing_name",
                     format!("`{name}` name cannot be empty"),
@@ -1601,6 +1601,57 @@ impl<'a> Parser<'a> {
         Ok(())
     }
 
+    fn read_directive_value(
+        &mut self,
+        name_end: usize,
+    ) -> ParseResult<(AttributeValue<'a>, usize)> {
+        if !self.eat_optional("=") {
+            if !self.is_eof() && (self.current_char() == '"' || self.current_char() == '\'') {
+                return Err(crate::error::ParseError::svelte(
+                    "expected_token",
+                    "Expected token =\nhttps://svelte.dev/e/expected_token",
+                    (self.index, self.index),
+                ));
+            }
+            return Ok((AttributeValue::True(true), name_end));
+        }
+        self.skip_whitespace();
+        let value = self.parse_attribute_value()?;
+        Ok((value, self.index))
+    }
+
+    fn read_directive_expression(
+        &mut self,
+        name_end: usize,
+    ) -> ParseResult<(Option<Expression<'a>>, usize)> {
+        let (value, end) = self.read_directive_value(name_end)?;
+        let expression = match value {
+            AttributeValue::True(_) => None,
+            AttributeValue::Expression(tag) => Some(tag.expression),
+            AttributeValue::Sequence(mut parts) => {
+                let single_expression =
+                    parts.len() == 1 && matches!(parts[0], AttributeValuePart::ExpressionTag(_));
+                if !single_expression {
+                    let at = match parts.first() {
+                        Some(AttributeValuePart::Text(text)) => text.start as usize,
+                        Some(AttributeValuePart::ExpressionTag(tag)) => tag.start as usize,
+                        None => end.saturating_sub(1),
+                    };
+                    return Err(crate::error::ParseError::svelte(
+                        "directive_invalid_value",
+                        "Directive value must be a JavaScript expression enclosed in curly braces\nhttps://svelte.dev/e/directive_invalid_value",
+                        (at, at),
+                    ));
+                }
+                match parts.remove(0) {
+                    AttributeValuePart::ExpressionTag(tag) => Some(tag.expression),
+                    AttributeValuePart::Text(_) => unreachable!("checked above"),
+                }
+            }
+        };
+        Ok((expression, end))
+    }
+
     /// Parse an on: directive (event handler).
     pub fn parse_on_directive(
         &mut self,
@@ -1693,59 +1744,7 @@ impl<'a> Parser<'a> {
         name_end: usize,
     ) -> ParseResult<Option<crate::ast::Attribute<'a>>> {
         let (action_name, modifiers) = Self::extract_name_and_modifiers(&full_name[4..]);
-
-        let (expression, end_pos) = if self.eat_optional("=") {
-            self.skip_whitespace();
-            // Handle quoted value: ="{expression}" or ="value"
-            if self.eat_optional("\"") || self.eat_optional("'") {
-                let quote = if self.bytes[self.index - 1] == b'"' {
-                    '"'
-                } else {
-                    '\''
-                };
-                // Look for expression inside quotes: "{expr}"
-                if self.eat_optional("{") {
-                    let expr_start = self.index;
-                    self.scan_to_closing_brace();
-                    let expr_end = self.index;
-                    let expr_content = &self.source[expr_start..expr_end];
-                    self.advance(); // consume '}'
-                    // Consume the closing quote
-                    if self.current_char() == quote {
-                        self.advance();
-                    }
-                    (
-                        Some(self.parse_head_expression(expr_content, expr_start, false, '}')?),
-                        self.index,
-                    )
-                } else {
-                    // Plain quoted string - skip until closing quote
-                    while !self.is_eof() && self.current_char() != quote {
-                        self.advance();
-                    }
-                    if self.current_char() == quote {
-                        self.advance();
-                    }
-                    (None, self.index)
-                }
-            } else if self.eat_optional("{") {
-                // Unquoted expression: ={expression}
-                let expr_start = self.index;
-                self.scan_to_closing_brace();
-                let expr_end = self.index;
-                let expr_content = &self.source[expr_start..expr_end];
-                self.advance(); // consume '}'
-                (
-                    Some(self.parse_head_expression(expr_content, expr_start, false, '}')?),
-                    self.index,
-                )
-            } else {
-                (None, self.index)
-            }
-        } else {
-            // No value - use name_end as the end position
-            (None, name_end)
-        };
+        let (expression, end_pos) = self.read_directive_expression(name_end)?;
 
         Ok(Some(crate::ast::Attribute::UseDirective(
             crate::ast::template::UseDirective {
@@ -1770,43 +1769,10 @@ impl<'a> Parser<'a> {
     ) -> ParseResult<Option<crate::ast::Attribute<'a>>> {
         let (class_name, modifiers) = Self::extract_name_and_modifiers(&full_name[6..]);
 
-        let had_value = self.eat_optional("=");
-        let expression = if had_value {
-            self.skip_whitespace();
-            // Handle both bare {expr} and quoted "{expr}" / '{expr}'
-            let quote =
-                if !self.is_eof() && (self.current_char() == '"' || self.current_char() == '\'') {
-                    let q = self.current_char();
-                    self.advance(); // consume opening quote
-                    Some(q)
-                } else {
-                    None
-                };
-            if self.eat_optional("{") {
-                let expr_start = self.index;
-                self.scan_to_closing_brace();
-                let expr_end = self.index;
-                let expr_content = &self.source[expr_start..expr_end];
-                self.advance(); // consume '}'
-                if quote.is_some() {
-                    self.advance(); // consume closing quote
-                }
-                self.parse_head_expression(expr_content, expr_start, false, '}')?
-            } else {
-                if quote.is_some() {
-                    self.index -= 1; // revert quote consumption
-                }
-                // Shorthand: class:name means expression is Identifier("name")
-                super::super::expression::create_identifier_with_character(
-                    class_name,
-                    name_start + 6, // start after "class:"
-                    name_end,
-                    self.expression_line_offsets(),
-                )
-            }
-        } else {
-            // Shorthand: class:name without = means expression is Identifier("name")
-            super::super::expression::create_identifier_with_character(
+        let (expression, end) = self.read_directive_expression(name_end)?;
+        let expression = match expression {
+            Some(expression) => expression,
+            None => super::super::expression::create_identifier_with_character(
                 class_name,
                 name_start + 6,
                 name_end,
@@ -1849,6 +1815,13 @@ impl<'a> Parser<'a> {
         let has_value = self.eat_optional("=");
         let value = if has_value {
             self.skip_whitespace();
+            if self.index < self.bytes.len() && self.bytes[self.index] == b'>' {
+                return Err(crate::error::ParseError::svelte(
+                    "expected_attribute_value",
+                    "Expected attribute value",
+                    (self.index, self.index),
+                ));
+            }
             if self.eat_optional("{") {
                 let expr_start = self.index;
                 self.scan_to_closing_brace();
@@ -2033,52 +2006,7 @@ impl<'a> Parser<'a> {
                 return Ok(None);
             };
 
-        let (expression, end_pos) = if self.eat_optional("=") {
-            self.skip_whitespace();
-            // Handle quoted value: ="{expression}"
-            if self.eat_optional("\"") || self.eat_optional("'") {
-                let quote = if self.bytes[self.index - 1] == b'"' {
-                    '"'
-                } else {
-                    '\''
-                };
-                if self.eat_optional("{") {
-                    let expr_start = self.index;
-                    self.scan_to_closing_brace();
-                    let expr_content = &self.source[expr_start..self.index];
-                    self.advance(); // consume '}'
-                    if self.current_char() == quote {
-                        self.advance();
-                    }
-                    (
-                        Some(self.parse_head_expression(expr_content, expr_start, false, '}')?),
-                        self.index,
-                    )
-                } else {
-                    // Plain quoted - skip
-                    while !self.is_eof() && self.current_char() != quote {
-                        self.advance();
-                    }
-                    if self.current_char() == quote {
-                        self.advance();
-                    }
-                    (None, self.index)
-                }
-            } else if self.eat_optional("{") {
-                let expr_start = self.index;
-                self.scan_to_closing_brace();
-                let expr_content = &self.source[expr_start..self.index];
-                self.advance(); // consume '}'
-                (
-                    Some(self.parse_head_expression(expr_content, expr_start, false, '}')?),
-                    self.index,
-                )
-            } else {
-                (None, self.index)
-            }
-        } else {
-            (None, name_end)
-        };
+        let (expression, end_pos) = self.read_directive_expression(name_end)?;
 
         Ok(Some(crate::ast::Attribute::TransitionDirective(
             crate::ast::template::TransitionDirective {
@@ -2183,20 +2111,8 @@ impl<'a> Parser<'a> {
         )))
     }
 
-    /// Run the value-reading half of upstream's `read_attribute` for its errors
-    /// alone; the value is discarded because the only caller is about to raise.
-    fn discard_attribute_value(&mut self) -> ParseResult<()> {
-        if self.eat_optional("=") {
-            self.skip_whitespace();
-            self.parse_attribute_value()?;
-        } else if !self.is_eof() && (self.current_char() == '"' || self.current_char() == '\'') {
-            return Err(crate::error::ParseError::svelte(
-                "expected_token",
-                "Expected token =\nhttps://svelte.dev/e/expected_token",
-                (self.index, self.index),
-            ));
-        }
-        Ok(())
+    fn attribute_expression_close(&self, expr_start: usize) -> ParseResult<usize> {
+        self.find_mustache_close(expr_start)
     }
 
     /// Parse attribute value.
@@ -2300,9 +2216,11 @@ impl<'a> Parser<'a> {
                 // comments (// and /* */), and regex expressions.
                 // The simple depth-tracking approach fails when JS comments
                 // contain quote characters (e.g., `don't` in a // comment).
-                let close_pos = self.attribute_expression_close(expr_start + 1).inspect_err(|_| {
-                    self.index = self.source.len();
-                })?;
+                let close_pos = self
+                    .attribute_expression_close(expr_start + 1)
+                    .inspect_err(|_| {
+                        self.index = self.source.len();
+                    })?;
                 self.index = close_pos + 1;
 
                 let expr_end = self.index;
@@ -2621,6 +2539,28 @@ fn is_valid_tag_name(name: &str) -> bool {
         && name[i + 1..]
             .chars()
             .all(is_potential_custom_element_name_char)
+}
+
+fn is_directive_prefix(prefix: &[u8]) -> bool {
+    matches!(
+        prefix,
+        b"use"
+            | b"animate"
+            | b"bind"
+            | b"class"
+            | b"style"
+            | b"on"
+            | b"let"
+            | b"in"
+            | b"out"
+            | b"transition"
+    )
+}
+
+/// Upstream splits `tag.name.slice(colon_index + 1)` on `|` and tests the first
+/// part, so `style:|important` has an empty name just as `style:` does.
+fn directive_name_is_empty(name: &str, colon_pos: usize) -> bool {
+    matches!(name.as_bytes().get(colon_pos + 1), None | Some(b'|'))
 }
 
 /// The `PCENChar` continuation set of the HTML custom-element-name production.

--- a/crates/rsvelte_core/src/compiler/phases/1_parse/state/tag.rs
+++ b/crates/rsvelte_core/src/compiler/phases/1_parse/state/tag.rs
@@ -22,8 +22,17 @@ use crate::compiler::phases::phase3_transform::shared::js_scan::slash_starts_reg
 use crate::compiler::utils::is_escaped;
 use crate::error::ParseResult;
 
-use super::super::parser::{Parser, StackEntry, is_js_whitespace, is_js_whitespace_byte};
+use super::super::parser::{Parser, StackEntry, is_js_whitespace};
 use super::super::utils::TrimWs;
+
+fn leftover_token_offset(content: &str, ts: bool) -> Option<usize> {
+    super::super::read::expression::trailing_token_offset(content, ts).filter(|&off| {
+        off > 0
+            && content.get(..off).is_some_and(|prefix| {
+                super::super::read::expression::check_js_parse_error_with_pos(prefix, ts).is_none()
+            })
+    })
+}
 
 /// A `{:…}` continuation clause.
 ///
@@ -44,15 +53,7 @@ pub(crate) enum Clause {
     // `expect` rather than `allow`: the `{#await}` clause loop reads these arms
     // as soon as its duplicate check lands, and an unfulfilled `expect` is a
     // compile error — so the placeholder cannot outlive its reason.
-    #[cfg_attr(
-        not(test),
-        expect(dead_code, reason = "the {#await} clause loop constructs these")
-    )]
     Then,
-    #[cfg_attr(
-        not(test),
-        expect(dead_code, reason = "the {#await} clause loop constructs these")
-    )]
     Catch,
 }
 
@@ -78,10 +79,7 @@ impl Clause {
     fn duplicate_error(self, at: usize) -> crate::error::ParseError {
         crate::error::ParseError::svelte(
             "block_duplicate_clause",
-            format!(
-                "{} cannot appear more than once within a block\nhttps://svelte.dev/e/block_duplicate_clause",
-                self.tag()
-            ),
+            format!("{} cannot appear more than once within a block", self.tag()),
             (at, at),
         )
     }
@@ -1248,9 +1246,10 @@ impl<'a> Parser<'a> {
             // Parse body fragment
             let body = self.parse_fragment()?;
 
-            // Check for {:else}
+            // Check for {:else}. Upstream replaces the fallback when another
+            // {:else} follows it, so keep consuming continuation clauses.
             let mut fallback = None;
-            if let Some(colon_pos) = self.match_block_continuation_marker() {
+            while let Some(colon_pos) = self.match_block_continuation_marker() {
                 self.index = colon_pos + 1;
                 self.skip_whitespace();
                 if self.eat_optional("else") {
@@ -1482,8 +1481,9 @@ impl<'a> Parser<'a> {
         // Parse body
         let body = self.parse_fragment()?;
 
+        // Like `{#if}`, a repeated `{:else}` replaces the earlier fallback.
         let mut fallback = None;
-        if let Some(colon_pos) = self.match_block_continuation_marker() {
+        while let Some(colon_pos) = self.match_block_continuation_marker() {
             self.index = colon_pos + 1;
             self.skip_whitespace();
             if self.eat_optional("else") {
@@ -1555,15 +1555,6 @@ impl<'a> Parser<'a> {
             offset,
             self.expression_line_offsets(),
             self.ts,
-        )
-    }
-
-    /// Upstream anchors this at the `:` of the continuation marker, not the `{`.
-    fn block_duplicate_clause(colon_pos: usize, name: &str) -> crate::error::ParseError {
-        crate::error::ParseError::svelte(
-            "block_duplicate_clause",
-            format!("{name} cannot appear more than once within a block"),
-            (colon_pos, colon_pos),
         )
     }
 
@@ -1786,7 +1777,7 @@ impl<'a> Parser<'a> {
         // to avoid find_matching_bracket finding the block's closing }
         let head = trimmed_content.trim_ws();
         let expression =
-            if let Some(lazy) = self.defer_expression(head, adjusted_start, LazyKind::HeadBrace) {
+            if let Some(lazy) = self.defer_expression(head, adjusted_start, LazyKind::AwaitHead) {
                 lazy
             } else {
                 match super::super::expression::parse_expression_with_end(
@@ -1816,6 +1807,7 @@ impl<'a> Parser<'a> {
                             head,
                             adjusted_start,
                             '}',
+                            self.ts,
                         ));
                     }
                 }
@@ -1875,8 +1867,11 @@ impl<'a> Parser<'a> {
             self.skip_whitespace();
 
             if self.eat_optional("then") {
-                if !self.options.loose && then_fragment.is_some() {
-                    return Err(Self::block_duplicate_clause(colon_pos, "{:then}"));
+                if !self.options.loose
+                    && Clause::Then.duplicate_is_error()
+                    && then_fragment.is_some()
+                {
+                    return Err(Clause::Then.duplicate_error(colon_pos));
                 }
                 // Upstream eats `}` before requiring the separator, so `{:then}`
                 // stays legal while `{:thenv}` is not.
@@ -1889,8 +1884,11 @@ impl<'a> Parser<'a> {
 
                 then_fragment = Some(self.parse_fragment()?);
             } else if self.eat_optional("catch") {
-                if !self.options.loose && catch_fragment.is_some() {
-                    return Err(Self::block_duplicate_clause(colon_pos, "{:catch}"));
+                if !self.options.loose
+                    && Clause::Catch.duplicate_is_error()
+                    && catch_fragment.is_some()
+                {
+                    return Err(Clause::Catch.duplicate_error(colon_pos));
                 }
                 if !self.match_str("}") {
                     self.require_whitespace()?;
@@ -2263,10 +2261,8 @@ impl<'a> Parser<'a> {
                 // the call test would otherwise report as a semantic error.
                 // The retry runs only on the failing path, so a well-formed
                 // render tag still costs one parse.
-                let leading_ws = expr_content.len() - expr_content.trim_start_ws().len();
-                let offset = expr_start + leading_ws;
-                let trimmed = expr_content.trim_ws();
-                let expression = self.parse_head_expression(trimmed, expr_start, false, '}')?;
+                let (expression, leftover) =
+                    self.parse_head_expression_split(expr_content, expr_start, false, '}', false)?;
 
                 // Upstream rejects anything but a call (optionally chained) here:
                 // `new foo()` and `foo` are parse errors, `foo?.()` is not.
@@ -2278,6 +2274,10 @@ impl<'a> Parser<'a> {
                         "`{@render ...}` tags can only contain call expressions\nhttps://svelte.dev/e/render_tag_invalid_expression",
                         (err_start, err_end),
                     ));
+                }
+
+                if let Some(err) = leftover {
+                    return Err(err);
                 }
 
                 Ok(Some(TemplateNode::RenderTag(Box::new(RenderTag {
@@ -2397,18 +2397,30 @@ impl<'a> Parser<'a> {
                                 )?,
                             }
                         } else {
-                            self.parse_js_expression_eager_strict(&pattern_clean, expr_start)?
+                            // A plain-identifier pattern goes through upstream's
+                            // `read_identifier`, not acorn, so its `loc` carries
+                            // `character`; only destructuring falls through.
+                            super::super::read::expression::with_read_identifier_loc(
+                                self.parse_js_expression_eager_strict(&pattern_clean, expr_start)?,
+                                self.expression_line_offsets(),
+                            )
                         };
 
                     // Calculate the offset for the init expression in the
                     // original source.  `trimmed` starts at `expr_start` in
                     // the source, and `eq_idx` is the position of `=` within
                     // `trimmed`.
-                    let init_offset = expr_start
-                        + eq_idx
-                        + 1
-                        + (trimmed[eq_idx + 1..].len()
-                            - trimmed[eq_idx + 1..].trim_start_ws().len());
+                    let init_offset = if init_str.is_empty() {
+                        // `read_expression` starts after `allow_whitespace`, at
+                        // the closing brace when the initializer is empty.
+                        expr_end
+                    } else {
+                        expr_start
+                            + eq_idx
+                            + 1
+                            + (trimmed[eq_idx + 1..].len()
+                                - trimmed[eq_idx + 1..].trim_start_ws().len())
+                    };
                     let init_expr = self.parse_const_initializer(init_str, init_offset)?;
 
                     // Reject a sequence-expression initializer, mirroring
@@ -2704,7 +2716,7 @@ impl<'a> Parser<'a> {
             // The deferred twin of this arm (`LazyKind::Mustache`) classifies
             // leftover input as a missing `}`; without the same test here the
             // two disagree whenever the parse is not deferred.
-            if let Some(pos) = leftover_token_offset(trimmed) {
+            if let Some(pos) = leftover_token_offset(trimmed, self.ts) {
                 return crate::error::ParseError::expected_token("}", trimmed_offset + pos);
             }
             // Recover the precise failure position from OXC's labeled span,
@@ -2833,6 +2845,24 @@ impl<'a> Parser<'a> {
         }
     }
 
+    pub fn parse_js_expression_head_strict(
+        &self,
+        content: &str,
+        offset: usize,
+        defer: bool,
+    ) -> crate::error::ParseResult<Expression<'a>> {
+        if defer {
+            self.parse_head_expression(content, offset, false, '}')
+        } else {
+            let (expression, leftover) =
+                self.parse_head_expression_eager(content, offset, false, '}')?;
+            match leftover {
+                Some(err) => Err(err),
+                None => Ok(expression),
+            }
+        }
+    }
+
     /// [`Self::parse_head_expression`], but with the leading expression and the
     /// `expected_token` its leftover input would raise handed back separately.
     ///
@@ -2872,7 +2902,7 @@ impl<'a> Parser<'a> {
         offset: usize,
         disallow_loose: bool,
         close_char: char,
-    ) -> crate::error::ParseResult<Expression<'a>> {
+    ) -> crate::error::ParseResult<(Expression<'a>, Option<crate::error::ParseError>)> {
         let leading_ws = content.len() - content.trim_start_ws().len();
         let trimmed = content.trim_ws();
         let trimmed_offset = offset + leading_ws;
@@ -2907,15 +2937,32 @@ impl<'a> Parser<'a> {
                         None,
                     ));
                 }
-                // Strict mode: classify the failure the way upstream does. A
-                // complete leading expression followed by leftover input is an
-                // `expected_token` (missing `close_char`); anything else is a
-                // `js_parse_error` at the point acorn/OXC stopped.
+                // Upstream validates the maximal leading expression before the
+                // caller consumes the closing token. Preserve both results so
+                // callers such as `{@debug}` and `{@render}` can apply their
+                // node-shape diagnostics before reporting leftover input.
+                if let Some(off) = leftover_token_offset(trimmed, self.ts)
+                    && let Some(prefix) = trimmed.get(..off)
+                    && let Ok(expression) = parse(prefix, trimmed_offset)
+                {
+                    let mut buf = [0u8; 4];
+                    return Ok((
+                        expression,
+                        Some(crate::error::ParseError::expected_token(
+                            close_char.encode_utf8(&mut buf),
+                            trimmed_offset + off,
+                        )),
+                    ));
+                }
+
+                // Otherwise this is a malformed expression rather than a
+                // complete expression followed by leftover input.
                 Err(super::super::read::expression::close_token_or_parse_error(
                     msg,
                     trimmed,
                     trimmed_offset,
                     close_char,
+                    self.ts,
                 ))
             }
         }
@@ -2955,6 +3002,7 @@ impl<'a> Parser<'a> {
                 trimmed,
                 trimmed_offset,
                 '}',
+                self.ts,
             )),
         }
     }
@@ -2969,16 +3017,17 @@ pub(crate) fn await_head_parse_error(
     source: &str,
     start: usize,
     message: String,
+    ts: bool,
 ) -> crate::error::ParseError {
     use super::super::read::expression::{check_js_parse_error_with_pos, trailing_close_offset};
 
     let end = find_matching_bracket(source, start, '{').unwrap_or(source.len());
     let head = source[start..end].trim_end_ws();
-    if let Some(pos) = trailing_close_offset(head) {
+    if let Some(pos) = trailing_close_offset(head, ts) {
         return crate::error::ParseError::expected_token("}", start + pos);
     }
     let (message, pos) =
-        check_js_parse_error_with_pos(head).unwrap_or((message, head.trim_end_ws().len()));
+        check_js_parse_error_with_pos(head, ts).unwrap_or((message, head.trim_end_ws().len()));
     let at = start + pos;
     crate::error::ParseError::svelte("js_parse_error", message, (at, at))
 }

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/mod.rs
@@ -1388,15 +1388,14 @@ fn collect_legacy_reactive_statement_metadata(
         }
 
         let body_node = arena.get_js_node(*body);
-        let mut assignments = Vec::new();
-        let mut cycle_dependencies = Vec::new();
-        cycle_collect_assignments_and_deps(
-            body_node,
-            arena,
-            &mut assignments,
-            &mut cycle_dependencies,
-            &mut Vec::new(),
-        );
+        let mut facts = CycleFacts::default();
+        cycle_collect_assignments_and_deps(body_node, arena, &mut facts);
+        let CycleFacts {
+            mut assignments,
+            shadowed_assignments,
+            dependencies: mut cycle_dependencies,
+            ..
+        } = facts;
 
         let instance_scope_idx = analysis.root.instance_scope_index;
         let is_instance_binding = |name: &str| {
@@ -1523,53 +1522,75 @@ impl CycleFacts {
 /// update targets into `assignments` and every other read identifier into
 /// `dependencies`. Recurses like a generic identifier collector for the read
 /// case, but recognises `AssignmentExpression` / `UpdateExpression` so targets
-/// nested in
-/// block / if / for / sequence bodies (`$: { a = b + 1; }`) are recorded as
-/// assignments rather than dependencies — otherwise such statements collect an
-/// empty assignment set and get dropped from the cycle graph entirely.
-fn cycle_collect_assignments_and_deps(
-    node: &JsNode,
-    arena: &ParseArena,
-    assignments: &mut Vec<String>,
-    dependencies: &mut Vec<String>,
-    locals: &mut Vec<String>,
-) {
+/// nested in block / if / for / sequence bodies (`$: { a = b + 1; }`) are
+/// recorded as assignments rather than dependencies — otherwise such statements
+/// collect an empty assignment set and get dropped from the cycle graph
+/// entirely.
+///
+/// A function body is walked rather than skipped: upstream's `scope.reference`
+/// propagates out of a function scope for every name the function does not
+/// itself declare, so `$: a = (() => b)()` really does depend on `b`.
+fn cycle_collect_assignments_and_deps(node: &JsNode, arena: &ParseArena, facts: &mut CycleFacts) {
     match node {
-        JsNode::Identifier { name, .. } => {
-            if !locals.iter().any(|l| l == name.as_str())
-                && !dependencies.iter().any(|s| s == name.as_str())
-            {
-                dependencies.push(name.to_string());
-            }
+        JsNode::Identifier { name, .. } => facts.push_dependency(name.as_str()),
+        JsNode::AssignmentExpression { left, right, .. } => {
+            // LHS targets are assignments; the RHS (and any nested
+            // assignments within it) is walked for dependencies.
+            facts.push_assignment_targets(arena.get_js_node(*left), arena);
+            cycle_collect_assignments_and_deps(arena.get_js_node(*right), arena, facts);
         }
-        // A name declared inside the `$:` body is a different binding from the
-        // instance-level one that happens to share its spelling, so it is
-        // neither a dependency nor an assignment of the reactive statement.
-        // Upstream never has to say so: it resolves through the scope tree.
-        JsNode::BlockStatement { body, .. } => {
-            let mark = locals.len();
-            let stmts = arena.get_js_children(*body);
-            for stmt in stmts {
-                collect_block_local_decls(stmt, arena, locals);
-            }
-            for stmt in stmts {
-                cycle_collect_assignments_and_deps(stmt, arena, assignments, dependencies, locals);
-            }
-            locals.truncate(mark);
+        // `x++` / `--x` assigns its argument.
+        JsNode::UpdateExpression { argument, .. } => {
+            facts.push_assignment_targets(arena.get_js_node(*argument), arena);
         }
+        JsNode::ArrowFunctionExpression { params, body, .. } => {
+            cycle_walk_function(*params, Some(*body), arena, facts);
+        }
+        JsNode::FunctionExpression { params, body, .. }
+        | JsNode::FunctionDeclaration { params, body, .. } => {
+            cycle_walk_function(*params, *body, arena, facts);
+        }
+        // A `catch` parameter is a declaration, not a reference, and it shadows
+        // the instance binding of the same name inside the handler.
         JsNode::CatchClause { param, body, .. } => {
-            let mark = locals.len();
+            let mark = facts.locals.len();
             if let Some(param) = param {
-                extract_param_names(arena.get_js_node(*param), arena, locals);
+                extract_param_names(arena.get_js_node(*param), arena, &mut facts.locals);
             }
-            cycle_collect_assignments_and_deps(
-                arena.get_js_node(*body),
-                arena,
-                assignments,
-                dependencies,
-                locals,
-            );
-            locals.truncate(mark);
+            cycle_collect_assignments_and_deps(arena.get_js_node(*body), arena, facts);
+            facts.locals.truncate(mark);
+        }
+        JsNode::BlockStatement { body, .. } => {
+            let mark = facts.locals.len();
+            for stmt in arena.get_js_children(*body) {
+                collect_block_local_decls(stmt, arena, &mut facts.locals);
+            }
+            for stmt in arena.get_js_children(*body) {
+                cycle_collect_assignments_and_deps(stmt, arena, facts);
+            }
+            facts.locals.truncate(mark);
+        }
+        // The cases share ONE block scope, so a `let` in the first case is
+        // declared for every later case too; the discriminant is outside it.
+        JsNode::SwitchStatement {
+            discriminant,
+            cases,
+            ..
+        } => {
+            cycle_collect_assignments_and_deps(arena.get_js_node(*discriminant), arena, facts);
+            let mark = facts.locals.len();
+            let cases = arena.get_js_children(*cases);
+            for case in cases {
+                if let JsNode::SwitchCase { consequent, .. } = case {
+                    for stmt in arena.get_js_children(*consequent) {
+                        collect_block_local_decls(stmt, arena, &mut facts.locals);
+                    }
+                }
+            }
+            for case in cases {
+                cycle_collect_assignments_and_deps(case, arena, facts);
+            }
+            facts.locals.truncate(mark);
         }
         JsNode::ForStatement {
             init,
@@ -1578,27 +1599,16 @@ fn cycle_collect_assignments_and_deps(
             body,
             ..
         } => {
-            let mark = locals.len();
+            let mark = facts.locals.len();
             if let Some(init) = init {
-                collect_block_local_decls(arena.get_js_node(*init), arena, locals);
+                collect_block_local_decls(arena.get_js_node(*init), arena, &mut facts.locals);
+                cycle_collect_assignments_and_deps(arena.get_js_node(*init), arena, facts);
             }
-            for child in [init, test, update].into_iter().flatten() {
-                cycle_collect_assignments_and_deps(
-                    arena.get_js_node(*child),
-                    arena,
-                    assignments,
-                    dependencies,
-                    locals,
-                );
+            for part in [test, update].into_iter().flatten() {
+                cycle_collect_assignments_and_deps(arena.get_js_node(*part), arena, facts);
             }
-            cycle_collect_assignments_and_deps(
-                arena.get_js_node(*body),
-                arena,
-                assignments,
-                dependencies,
-                locals,
-            );
-            locals.truncate(mark);
+            cycle_collect_assignments_and_deps(arena.get_js_node(*body), arena, facts);
+            facts.locals.truncate(mark);
         }
         JsNode::ForOfStatement {
             left, right, body, ..
@@ -1606,46 +1616,35 @@ fn cycle_collect_assignments_and_deps(
         | JsNode::ForInStatement {
             left, right, body, ..
         } => {
-            cycle_collect_assignments_and_deps(
-                arena.get_js_node(*right),
-                arena,
-                assignments,
-                dependencies,
-                locals,
-            );
-            let mark = locals.len();
-            collect_block_local_decls(arena.get_js_node(*left), arena, locals);
-            for child in [left, body] {
-                cycle_collect_assignments_and_deps(
-                    arena.get_js_node(*child),
-                    arena,
-                    assignments,
-                    dependencies,
-                    locals,
-                );
+            cycle_collect_assignments_and_deps(arena.get_js_node(*right), arena, facts);
+            let mark = facts.locals.len();
+            collect_block_local_decls(arena.get_js_node(*left), arena, &mut facts.locals);
+            cycle_collect_assignments_and_deps(arena.get_js_node(*left), arena, facts);
+            cycle_collect_assignments_and_deps(arena.get_js_node(*body), arena, facts);
+            facts.locals.truncate(mark);
+        }
+        // The declared names are declarations, not references; only the
+        // initializers are read.
+        JsNode::VariableDeclaration { declarations, .. } => {
+            for decl in arena.get_js_children(*declarations) {
+                if let JsNode::VariableDeclarator {
+                    init: Some(init), ..
+                } = decl
+                {
+                    cycle_collect_assignments_and_deps(arena.get_js_node(*init), arena, facts);
+                }
             }
-            locals.truncate(mark);
         }
-        JsNode::AssignmentExpression { left, right, .. } => {
-            // LHS targets are assignments; the RHS (and any nested
-            // assignments within it) is walked for dependencies.
-            cycle_extract_assignment_targets(arena.get_js_node(*left), arena, assignments, locals);
-            cycle_collect_assignments_and_deps(
-                arena.get_js_node(*right),
-                arena,
-                assignments,
-                dependencies,
-                locals,
-            );
+        JsNode::ClassDeclaration {
+            super_class, body, ..
         }
-        // `x++` / `--x` assigns its argument.
-        JsNode::UpdateExpression { argument, .. } => {
-            cycle_extract_assignment_targets(
-                arena.get_js_node(*argument),
-                arena,
-                assignments,
-                locals,
-            );
+        | JsNode::ClassExpression {
+            super_class, body, ..
+        } => {
+            if let Some(super_class) = super_class {
+                cycle_collect_assignments_and_deps(arena.get_js_node(*super_class), arena, facts);
+            }
+            cycle_collect_assignments_and_deps(arena.get_js_node(*body), arena, facts);
         }
         JsNode::MemberExpression {
             object,
@@ -1653,21 +1652,9 @@ fn cycle_collect_assignments_and_deps(
             computed,
             ..
         } => {
-            cycle_collect_assignments_and_deps(
-                arena.get_js_node(*object),
-                arena,
-                assignments,
-                dependencies,
-                locals,
-            );
+            cycle_collect_assignments_and_deps(arena.get_js_node(*object), arena, facts);
             if *computed {
-                cycle_collect_assignments_and_deps(
-                    arena.get_js_node(*property),
-                    arena,
-                    assignments,
-                    dependencies,
-                    locals,
-                );
+                cycle_collect_assignments_and_deps(arena.get_js_node(*property), arena, facts);
             }
         }
         JsNode::Property {
@@ -1677,21 +1664,9 @@ fn cycle_collect_assignments_and_deps(
             ..
         } => {
             if *computed {
-                cycle_collect_assignments_and_deps(
-                    arena.get_js_node(*key),
-                    arena,
-                    assignments,
-                    dependencies,
-                    locals,
-                );
+                cycle_collect_assignments_and_deps(arena.get_js_node(*key), arena, facts);
             }
-            cycle_collect_assignments_and_deps(
-                arena.get_js_node(*value),
-                arena,
-                assignments,
-                dependencies,
-                locals,
-            );
+            cycle_collect_assignments_and_deps(arena.get_js_node(*value), arena, facts);
         }
         // The annotation blob follows `properties` / `elements` in the JSON
         // field order, so its identifiers must be seen after theirs.
@@ -1701,7 +1676,7 @@ fn cycle_collect_assignments_and_deps(
             ..
         } => {
             for prop in arena.get_js_children(*properties) {
-                cycle_collect_assignments_and_deps(prop, arena, assignments, dependencies, locals);
+                cycle_collect_assignments_and_deps(prop, arena, facts);
             }
             if let Some(ta) = type_annotation {
                 let mut names = Vec::new();
@@ -1717,7 +1692,7 @@ fn cycle_collect_assignments_and_deps(
             ..
         } => {
             for elem in elements.iter().flatten() {
-                cycle_collect_assignments_and_deps(elem, arena, assignments, dependencies, locals);
+                cycle_collect_assignments_and_deps(elem, arena, facts);
             }
             if let Some(ta) = type_annotation {
                 let mut names = Vec::new();
@@ -1730,47 +1705,38 @@ fn cycle_collect_assignments_and_deps(
         // `for_each_js_child` skips `label` (it is not a rune reference); this
         // walker counted it as a dependency, so keep reading it here.
         JsNode::LabeledStatement { label, body, .. } => {
-            cycle_collect_assignments_and_deps(
-                arena.get_js_node(*label),
-                arena,
-                assignments,
-                dependencies,
-                locals,
-            );
-            cycle_collect_assignments_and_deps(
-                arena.get_js_node(*body),
-                arena,
-                assignments,
-                dependencies,
-                locals,
-            );
+            cycle_collect_assignments_and_deps(arena.get_js_node(*label), arena, facts);
+            cycle_collect_assignments_and_deps(arena.get_js_node(*body), arena, facts);
         }
         _ => {
             for_each_js_child(node, arena, &mut |child| {
-                cycle_collect_assignments_and_deps(child, arena, assignments, dependencies, locals);
+                cycle_collect_assignments_and_deps(child, arena, facts);
             });
         }
     }
 }
 
-/// `cycle_extract_pattern_ids`, minus the names a scope inside the `$:` body
-/// declares — writing to a block-local `e` is not writing to the instance `e`.
-fn cycle_extract_assignment_targets(
-    node: &JsNode,
+/// Parameters shadow inside the body; their default-value expressions are
+/// evaluated before the shadowing takes effect.
+fn cycle_walk_function(
+    params: crate::ast::arena::IdRange,
+    body: Option<crate::ast::arena::JsNodeId>,
     arena: &ParseArena,
-    assignments: &mut Vec<String>,
-    locals: &[String],
+    facts: &mut CycleFacts,
 ) {
-    let mark = assignments.len();
-    cycle_extract_pattern_ids(node, arena, assignments);
-    let mut i = mark;
-    while i < assignments.len() {
-        if locals.iter().any(|l| *l == assignments[i]) {
-            assignments.remove(i);
-        } else {
-            i += 1;
-        }
+    for param in arena.get_js_children(params) {
+        collect_param_evaluations(param, arena, &mut |evaluated| {
+            cycle_collect_assignments_and_deps(evaluated, arena, facts);
+        });
     }
+    let mark = facts.locals.len();
+    for param in arena.get_js_children(params) {
+        extract_param_names(param, arena, &mut facts.locals);
+    }
+    if let Some(body) = body {
+        cycle_collect_assignments_and_deps(arena.get_js_node(body), arena, facts);
+    }
+    facts.locals.truncate(mark);
 }
 
 /// Process legacy mode exports.
@@ -3695,10 +3661,14 @@ fn collect_dollar_param_names(node: &JsNode, arena: &ParseArena, out: &mut Vec<S
     }
 }
 
-/// Collect the `$`-prefixed names a single block-level statement declares.
-/// Only the binding slot matters: the initializer is walked by the caller.
-fn collect_dollar_declared_names(node: &JsNode, arena: &ParseArena, out: &mut Vec<String>) {
-    match node {
+/// Collect the `$`-prefixed names a single statement declares in the scope that
+/// holds it, so a reference to one of them inside that scope is resolved rather
+/// than counted as a rune.
+///
+/// `var` hoisting out of a nested block is not modelled: only the statements
+/// directly in the scope's own list are inspected.
+fn collect_dollar_declared_names(stmt: &JsNode, arena: &ParseArena, out: &mut Vec<String>) {
+    match stmt {
         JsNode::VariableDeclaration { declarations, .. } => {
             for decl in arena.get_js_children(*declarations) {
                 if let JsNode::VariableDeclarator { id, .. } = decl {
@@ -3709,6 +3679,64 @@ fn collect_dollar_declared_names(node: &JsNode, arena: &ParseArena, out: &mut Ve
         JsNode::FunctionDeclaration { id: Some(id), .. }
         | JsNode::ClassDeclaration { id: Some(id), .. } => {
             collect_dollar_param_names(arena.get_js_node(*id), arena, out);
+        }
+        JsNode::ImportDeclaration { specifiers, .. } => {
+            for spec in arena.get_js_children(*specifiers) {
+                match spec {
+                    JsNode::ImportSpecifier { local, .. }
+                    | JsNode::ImportDefaultSpecifier { local, .. }
+                    | JsNode::ImportNamespaceSpecifier { local, .. } => {
+                        collect_dollar_param_names(arena.get_js_node(*local), arena, out);
+                    }
+                    _ => {}
+                }
+            }
+        }
+        JsNode::ExportNamedDeclaration {
+            declaration: Some(decl),
+            ..
+        }
+        | JsNode::ExportDefaultDeclaration {
+            declaration: decl, ..
+        } => collect_dollar_declared_names(arena.get_js_node(*decl), arena, out),
+        _ => {}
+    }
+}
+
+/// Push every `$`-prefixed name declared by the scope `node` opens.
+fn push_dollar_shadows(node: &JsNode, arena: &ParseArena, shadowed: &mut Vec<String>) {
+    let push_statements = |range, shadowed: &mut Vec<String>| {
+        for stmt in arena.get_js_children(range) {
+            collect_dollar_declared_names(stmt, arena, shadowed);
+        }
+    };
+
+    match node {
+        JsNode::FunctionDeclaration { params, .. }
+        | JsNode::FunctionExpression { params, .. }
+        | JsNode::ArrowFunctionExpression { params, .. } => {
+            for param in arena.get_js_children(*params) {
+                collect_dollar_param_names(param, arena, shadowed);
+            }
+        }
+        JsNode::CatchClause {
+            param: Some(param), ..
+        } => collect_dollar_param_names(arena.get_js_node(*param), arena, shadowed),
+        JsNode::Program { body, .. }
+        | JsNode::BlockStatement { body, .. }
+        | JsNode::StaticBlock { body, .. } => push_statements(*body, shadowed),
+        JsNode::SwitchStatement { cases, .. } => {
+            for case in arena.get_js_children(*cases) {
+                if let JsNode::SwitchCase { consequent, .. } = case {
+                    push_statements(*consequent, shadowed);
+                }
+            }
+        }
+        JsNode::ForStatement {
+            init: Some(init), ..
+        } => collect_dollar_declared_names(arena.get_js_node(*init), arena, shadowed),
+        JsNode::ForInStatement { left, .. } | JsNode::ForOfStatement { left, .. } => {
+            collect_dollar_declared_names(arena.get_js_node(*left), arena, shadowed);
         }
         _ => {}
     }
@@ -4116,32 +4144,8 @@ fn js_node_check_features(
                 | JsNode::FunctionDeclaration { .. }
         );
 
-    // Shadow-aware rune detection: a `$`-prefixed name declared in an enclosing
-    // scope (a function parameter, a `catch` parameter, or a block-scoped
-    // declaration) shadows the rune inside it, mirroring upstream where such a
-    // reference resolves to that binding and stops bubbling before
-    // `module.scope.references` — the set runes-mode detection is computed from.
-    // Only nested scopes are collected: a script's own top level declares into
-    // the module/instance scope, which `validate_identifier_name` rejects first.
     let shadow_base = shadowed.len();
-    match node {
-        JsNode::FunctionDeclaration { params, .. }
-        | JsNode::FunctionExpression { params, .. }
-        | JsNode::ArrowFunctionExpression { params, .. } => {
-            for param in arena.get_js_children(*params) {
-                collect_dollar_param_names(param, arena, shadowed);
-            }
-        }
-        JsNode::CatchClause {
-            param: Some(param), ..
-        } => collect_dollar_param_names(arena.get_js_node(*param), arena, shadowed),
-        JsNode::BlockStatement { body, .. } | JsNode::StaticBlock { body, .. } => {
-            for stmt in arena.get_js_children(*body) {
-                collect_dollar_declared_names(stmt, arena, shadowed);
-            }
-        }
-        _ => {}
-    }
+    push_dollar_shadows(node, arena, shadowed);
 
     for_each_js_reference_child(node, arena, &mut |child| {
         if results.all_found() {
@@ -4199,8 +4203,6 @@ fn for_each_js_reference_child(node: &JsNode, arena: &ParseArena, f: &mut impl F
                 f(arena.get_js_node(*value));
             }
         }
-        // A `break`/`continue` target names a statement label, not a binding.
-        JsNode::BreakStatement { .. } | JsNode::ContinueStatement { .. } => {}
         JsNode::VariableDeclarator { id, init, .. } => {
             for_each_pattern_reference_child(arena.get_js_node(*id), arena, f);
             if let Some(init) = init {
@@ -4244,7 +4246,6 @@ fn for_each_js_reference_child(node: &JsNode, arena: &ParseArena, f: &mut impl F
             }
             f(arena.get_js_node(*body));
         }
-        JsNode::CatchClause { body, .. } => f(arena.get_js_node(*body)),
         // Every identifier an import or an export specifier carries is a
         // declared or an exported name; the rest of the node is literals.
         JsNode::ImportDeclaration { .. } | JsNode::ExportSpecifier { .. } => {}

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/scope.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/scope.rs
@@ -43,6 +43,8 @@ pub struct ScopeRoot {
     /// with the other links of the chain), so the alternates live in their own
     /// map under the enclosing block's unique start.
     pub if_alternate_scope_map: FxHashMap<u32, usize>,
+    /// Scope owned by the root template fragment.
+    pub root_fragment_scope_index: usize,
     /// Scope indices of `{:else}` fragments, keyed by their `{#each}`'s start
     /// position. Upstream's `EachBlock` visitor walks the body's *nodes* with
     /// the each scope but visits the fallback as a `Fragment`, so only the
@@ -90,6 +92,7 @@ impl ScopeRoot {
             each_block_collection_infos: Vec::new(),
             template_scope_map: FxHashMap::default(),
             if_alternate_scope_map: FxHashMap::default(),
+            root_fragment_scope_index: 0,
             each_fallback_scope_map: FxHashMap::default(),
             snippet_scope_indices: FxHashSet::default(),
             conflicts: FxHashSet::default(),

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/scope_builder.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/scope_builder.rs
@@ -95,6 +95,8 @@ pub struct ScopeBuilder<'a> {
     /// `{:else}` fragment scopes keyed by the enclosing `{#if}`'s start (see
     /// `ScopeRoot::if_alternate_scope_map`).
     if_alternate_scope_map: FxHashMap<u32, usize>,
+    /// Scope of the root template fragment.
+    root_fragment_scope_index: usize,
     /// `{:else}` fragment scopes keyed by the enclosing `{#each}`'s start (see
     /// `ScopeRoot::each_fallback_scope_map`).
     each_fallback_scope_map: FxHashMap<u32, usize>,
@@ -153,6 +155,7 @@ impl<'a> ScopeBuilder<'a> {
             each_block_collection_infos: Vec::new(),
             template_scope_map: FxHashMap::default(),
             if_alternate_scope_map: FxHashMap::default(),
+            root_fragment_scope_index: 0,
             each_fallback_scope_map: FxHashMap::default(),
             snippet_scope_indices: rustc_hash::FxHashSet::default(),
             template_expression_params: Vec::new(),
@@ -369,6 +372,7 @@ impl<'a> ScopeBuilder<'a> {
                 each_block_collection_infos,
                 template_scope_map: self.template_scope_map,
                 if_alternate_scope_map: self.if_alternate_scope_map,
+                root_fragment_scope_index: self.root_fragment_scope_index,
                 each_fallback_scope_map: self.each_fallback_scope_map,
                 snippet_scope_indices: self.snippet_scope_indices,
                 conflicts,
@@ -3917,6 +3921,22 @@ impl<'a> ScopeBuilder<'a> {
     ) {
         match pattern {
             JsNode::Identifier { name, .. } => {
+                // A declaration tag at the root fragment may not shadow an
+                // instance-script declaration. Upstream checks this explicitly
+                // because the fragment and instance script are separate scopes.
+                let is_top_level = self.instance_scope_index != 0
+                    && self.current_scope == self.root_fragment_scope_index;
+                if is_top_level
+                    && self.scopes[self.instance_scope_index]
+                        .declarations
+                        .contains_key(name.as_str())
+                {
+                    let mut error = errors::declaration_duplicate(name.as_str());
+                    if let Some((start, end)) = span_of(pattern) {
+                        error = error.at(start, end);
+                    }
+                    self.validation_errors.push(error);
+                }
                 self.declare_binding(name.to_string(), binding_kind, decl_kind, span_of(pattern));
             }
             JsNode::ObjectPattern { properties, .. }

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/types.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/types.rs
@@ -1137,6 +1137,17 @@ mod ts_removals {
             walk::walk_formal_parameter(self, it);
         }
 
+        fn visit_formal_parameter_rest(&mut self, it: &FormalParameterRest<'a>) {
+            if it.type_annotation.is_some() {
+                collect_optional_marker_removal(
+                    it.rest.argument.span().end,
+                    self.source,
+                    self.removals,
+                );
+            }
+            walk::walk_formal_parameter_rest(self, it);
+        }
+
         fn visit_variable_declaration(&mut self, it: &VariableDeclaration<'a>) {
             if it.declare {
                 self.remove(it.span);

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/bind_directive.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/bind_directive.rs
@@ -64,8 +64,6 @@ pub(super) fn validate_expression_shape(
         // This is important for cases like:
         //   bind:checked={()=>check, (v)=>{ check = v }}
         // where the setter contains an assignment that marks `check` as reassigned
-        walk_get_set_pair(directive, context)?;
-
         return Ok(());
     }
 
@@ -114,19 +112,7 @@ fn visit_common(
     validate_expression_shape(directive, context)?;
 
     if directive.expression.node_type() == Some("SequenceExpression") {
-        // Visit getter and setter expressions to track assignments and dependencies
-        // This is important for cases like:
-        //   bind:checked={()=>check, (v)=>{ check = v }}
-        // where the setter contains an assignment that marks `check` as reassigned
-        let node = directive.expression.as_node();
-        let expressions = node.expressions();
-        let arena = context.parse_arena;
-        for expr in arena.get_js_children(expressions) {
-            // Walk the expression to track mutations (e.g., assignments in setters).
-            // Use typed dispatch to skip the `to_value()` materialization.
-            super::script::walk_js_node_typed(expr, context)?;
-        }
-
+        walk_get_set_pair(directive, context)?;
         return Ok(());
     }
 

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/each_block.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/each_block.rs
@@ -146,6 +146,17 @@ pub fn visit<'a, 'b: 'a>(
         context.scope = each_scope;
     }
 
+    // The key is evaluated in the each scope, so item/index references resolve
+    // there. Keep its metadata separate from the collection expression: key
+    // dependencies must not make the each item itself reactive, but the normal
+    // expression walk is still required for calls, rune validation and
+    // `needs_context`.
+    if let Some(key) = &block.key {
+        let key_node = key.as_node();
+        let mut key_metadata = crate::ast::template::ExpressionMetadata::default();
+        walk_js_expression_node(&key_node, context, &mut key_metadata)?;
+    }
+
     // Walk the context pattern's default values so that identifiers in defaults
     // (e.g., `{#each array as { a = default_value_1 }}`) are visited and references counted.
     // The official Svelte's zimmerframe walker automatically visits the context pattern,

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/shared/component.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/shared/component.rs
@@ -11,7 +11,9 @@ use super::super::super::errors;
 use super::super::VisitorContext;
 use super::super::attribute::visit_attribute_value_expressions;
 use super::fragment;
-use super::utils::validate_attribute_name as validate_attribute_name_colon;
+use super::utils::{
+    validate_assignment_node, validate_attribute_name as validate_attribute_name_colon,
+};
 use crate::ast::template::{Attribute, Component};
 
 /// Visit a component and perform full analysis.

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/svelte_body.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/svelte_body.rs
@@ -76,10 +76,9 @@ pub fn visit(body: &mut SvelteElement, context: &mut VisitorContext) -> Result<(
             Attribute::Attribute(attribute) => {
                 super::attribute::visit_attribute_value_expressions(&mut attribute.value, context)?;
             }
-            Attribute::StyleDirective(style) => {
-                super::style_directive::visit(style, context)?;
+            other => {
+                super::shared::attribute::walk_remaining_attribute_expressions(other, context)?;
             }
-            _ => {}
         }
     }
 

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/svelte_component.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/svelte_component.rs
@@ -7,6 +7,7 @@
 use super::super::{AnalysisError, errors, warnings};
 use super::VisitorContext;
 use super::shared::fragment;
+use super::shared::utils::validate_assignment_node;
 use crate::ast::template::{Attribute, SvelteComponentElement};
 
 /// Visit a svelte:component.

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/svelte_document.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/svelte_document.rs
@@ -82,10 +82,9 @@ pub fn visit(
             Attribute::Attribute(a) => {
                 super::attribute::visit_attribute_value_expressions(&mut a.value, context)?;
             }
-            Attribute::StyleDirective(style) => {
-                super::style_directive::visit(style, context)?;
+            other => {
+                super::shared::attribute::walk_remaining_attribute_expressions(other, context)?;
             }
-            _ => {}
         }
     }
 

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/svelte_self.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/svelte_self.rs
@@ -10,6 +10,7 @@ use super::super::warnings;
 use super::VisitorContext;
 use super::shared::fragment;
 use super::shared::special_element::validate_special_element_placement;
+use super::shared::utils::validate_assignment_node;
 use crate::ast::template::{Attribute, SvelteElement};
 
 /// Visit a svelte:self.

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/svelte_window.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/svelte_window.rs
@@ -84,10 +84,9 @@ pub fn visit(
             Attribute::Attribute(a) => {
                 super::attribute::visit_attribute_value_expressions(&mut a.value, context)?;
             }
-            Attribute::StyleDirective(style) => {
-                super::style_directive::visit(style, context)?;
+            other => {
+                super::shared::attribute::walk_remaining_attribute_expressions(other, context)?;
             }
-            _ => {}
         }
     }
 

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/variable_declarator.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/variable_declarator.rs
@@ -802,6 +802,11 @@ fn process_props_object_pattern_typed(
                         *n,
                     ),
                 ),
+                // Upstream takes `String(key.value)`, and a BigInt stringifies to
+                // its decimal digits — which is what this variant already holds.
+                crate::ast::typed_expr::LiteralValue::BigInt(digits) => {
+                    Some(digits.to_string())
+                }
                 _ => None,
             },
             _ => None,

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/ast_state_transform.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/ast_state_transform.rs
@@ -2122,7 +2122,7 @@ impl<'a, 's> StateVarCollector<'a, 's> {
         let arg = &call.arguments[0];
         self.visit_argument(arg);
         let arg_span = arg.span();
-        let (mut pre_spans, post_spans) = self.rune_call_comment_slots(call, arg_span);
+        let (mut pre_spans, post_spans) = self.rune_call_comment_slots(call, arg_span, init_span);
         // `$.derived` is built with a plain string callee and takes the user's
         // own function unchanged, so the declarator's leading comments flush
         // before that argument just like the ones written inside the parens.
@@ -2217,7 +2217,7 @@ impl<'a, 's> StateVarCollector<'a, 's> {
         // the declarator's `=` and `$derived(` reach the same slot, because
         // upstream builds `$.derived` with a plain string callee that carries
         // no `loc` of its own.
-        let (mut pre_spans, post_spans) = self.rune_call_comment_slots(call, arg_span);
+        let (mut pre_spans, post_spans) = self.rune_call_comment_slots(call, arg_span, init_span);
         let lead_spans = self.declarator_lead_comment_spans(id.span().end, call.span.start);
         let start = lead_spans
             .first()

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/class_transforms.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/class_transforms.rs
@@ -1045,9 +1045,7 @@ fn transform_class_fields_client_with_options_at(
     };
     let class_pos = header.keyword;
     let brace_pos = header.body_brace - class_pos;
-
     let after_class = &script[class_pos..];
-    let class_header = &after_class[..brace_pos + 1];
 
     // Synthesized members are printed relative to the class's own source
     // indentation: hard-coding one level made a module-level `class` (column 0)

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
@@ -50,6 +50,7 @@ mod rune_transforms;
 mod sanitized_props;
 mod scan_index;
 mod scope_analysis;
+pub(crate) mod source_anchor;
 mod state_assigns_combined_ast;
 mod state_call_ast;
 mod state_eager_ast;
@@ -97,9 +98,10 @@ use std::sync::LazyLock;
 
 use crate::compiler::phases::phase1_parse::parser::is_js_whitespace;
 use crate::compiler::phases::phase3_transform::shared::js_scan::{
-    after_keyword, after_keywords, contains_identifier, find_code, find_rune_code, is_ident_byte,
-    skip_opaque,
+    after_keyword, after_keywords, code_bytes, contains_identifier, find_code, find_rune_code,
+    is_ident_byte, skip_opaque,
 };
+use crate::compiler::phases::phase3_transform::shared::rune_shadow;
 use compact_str::CompactString;
 use memchr::memmem;
 // rustc_hash is used by submodules via their own imports
@@ -631,13 +633,31 @@ pub(crate) fn transform_client(
                 .as_deref()
                 .unwrap_or(&instance_script.raw),
         );
-        let instance_raw = paren_stripped
+        // In runes mode this is a user binding, and upstream renames it before
+        // generation so compiler-built `$$props` uses remain untouched.
+        let sanitized_props_renamed = analysis
+            .runes
+            .then(|| {
+                sanitized_props::rename_dollar_props(
+                    paren_stripped
+                        .as_deref()
+                        .or(dead_comments_stripped.as_deref())
+                        .unwrap_or(&instance_script.raw),
+                )
+            })
+            .flatten();
+        let instance_raw = sanitized_props_renamed
             .as_deref()
+            .or(paren_stripped.as_deref())
             .or(dead_comments_stripped.as_deref())
             .unwrap_or(&instance_script.raw);
         let retained_instance = retained_scripts
             .and_then(|scripts| scripts.instance.as_ref())
-            .filter(|_| dead_comments_stripped.is_none() && paren_stripped.is_none());
+            .filter(|_| {
+                dead_comments_stripped.is_none()
+                    && paren_stripped.is_none()
+                    && sanitized_props_renamed.is_none()
+            });
         let needs_projection = analysis.runes
             && retained_instance.is_some()
             && instance_script.source_projection.is_some();
@@ -5005,7 +5025,9 @@ fn transform_module_script_runes_with_target(
     // `find_code`, not `memmem::find`: the AST batch above leaves a `$state(`
     // that sits in a string / template / regex / comment untouched, and this
     // fallback would otherwise rewrite that text as if it were a call (#2988).
-    while let Some(pos) = find_rune_code(result.as_bytes(), b"$state(") {
+    let mut state_from = 0usize;
+    while let Some(rel) = find_rune_code(&result.as_bytes()[state_from..], b"$state(") {
+        let pos = state_from + rel;
         // Make sure this is not $state.something
         if pos + 7 < result.len() && result.as_bytes()[pos + 6] != b'(' {
             break;
@@ -5140,7 +5162,9 @@ fn transform_module_script_runes_with_target(
     // / regex / comment is text. Matching it either rewrote the literal (#2988)
     // or aborted the loop on its unbalanced parens, leaving the real rune call
     // unlowered and the module referencing a global `$derived` (#2987).
-    while let Some(pos) = find_rune_code(result.as_bytes(), b"$derived(") {
+    let mut derived_from = 0usize;
+    while let Some(rel) = find_rune_code(&result.as_bytes()[derived_from..], b"$derived(") {
+        let pos = derived_from + rel;
         if result[..pos].ends_with('$') {
             // Already transformed to $.derived() - skip
             break;
@@ -6088,7 +6112,15 @@ fn transform_instance_script_for_visitors(
     let separated = matches!(separated_script, Cow::Owned(_));
     let retained_program = retained_program.filter(|_| !separated);
     let source_projection = source_projection.filter(|_| !separated);
-    let script = separated_script.as_ref();
+    let normalized_labels = if analysis.runes {
+        Cow::Borrowed(separated_script.as_ref())
+    } else {
+        close_reactive_label_gaps(separated_script.as_ref(), analysis.is_typescript)
+    };
+    let labels_changed = matches!(normalized_labels, Cow::Owned(_));
+    let retained_program = retained_program.filter(|_| !labels_changed);
+    let source_projection = source_projection.filter(|_| !labels_changed);
+    let script = normalized_labels.as_ref();
     let original_script = script;
 
     // Instance imports are removed by the caller before this pipeline.
@@ -7841,9 +7873,15 @@ fn transform_instance_script_for_visitors(
         // is reached, and the name still resolves — `$$exports` reads the hoisted
         // `const`. Keeping it emitted `const x` twice in one scope, which is not
         // parseable JS. H-060.
-        if at_statement_boundary && is_props_id_declaration(trimmed) {
-            line_idx += 1;
-            continue;
+        if at_statement_boundary && let Some(tail) = props_id_declaration_tail(trimmed) {
+            if tail.trim().is_empty() {
+                line_idx += 1;
+                continue;
+            }
+            // Another statement shares the line. Dropping the whole line drops
+            // that one too, and keeping it emits the hoisted `const` twice.
+            line = tail;
+            trimmed = tail.trim();
         }
 
         // Add line to accumulator (zero-copy borrow from script_lines)

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/private_class_assign_ast.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/private_class_assign_ast.rs
@@ -572,21 +572,6 @@ impl<'a, 'ast> Visit<'ast> for PrivateClassAssignCollector<'a> {
             _ => set,
         };
 
-        let rewrite = match short_circuit {
-            None => set_call,
-            Some(op) => {
-                let logical = format!("{} {} {}", read(), op.as_str(), set_call);
-                if self
-                    .tight_parents
-                    .contains(&(expr.span.start, expr.span.end))
-                {
-                    format!("({})", logical)
-                } else {
-                    logical
-                }
-            }
-        };
-
         self.replacements
             .push((expr.span.start, expr.span.end, rewrite));
     }

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/props_transforms.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/props_transforms.rs
@@ -1967,10 +1967,40 @@ pub(super) fn calculate_prop_flags(
 /// passes `b.literal(key.value)`, so a numeric destructuring key stays a
 /// **number** (and carries its value, not its spelling: `0x10` → `16`).
 pub(super) fn prop_key_js_literal(raw_key: &str, prop_name: &str) -> String {
+    if let Some(digits) = bigint_key_digits(raw_key) {
+        return digits;
+    }
     if let Some(n) = numeric_key_value(raw_key) {
         return crate::compiler::phases::phase3_transform::server::evaluate::js_number_to_string(n);
     }
     format!("'{}'", prop_name)
+}
+
+/// `Some(decimal digits)` when the raw key text is a BigInt literal. Parsed
+/// rather than pattern-matched, so `0x10n` / `1_000n` carry their value, and an
+/// identifier that merely ends in `n` is not mistaken for one.
+fn bigint_key_digits(raw_key: &str) -> Option<String> {
+    use oxc_allocator::Allocator;
+    use oxc_ast::ast::{Expression, Statement};
+    use oxc_parser::Parser;
+    use oxc_span::SourceType;
+
+    let trimmed = raw_key.trim();
+    if !trimmed.ends_with('n') || !trimmed.starts_with(|c: char| c.is_ascii_digit()) {
+        return None;
+    }
+    let alloc = Allocator::default();
+    let parsed = Parser::new(&alloc, trimmed, SourceType::mjs()).parse();
+    if parsed.panicked || !parsed.diagnostics.is_empty() {
+        return None;
+    }
+    let [Statement::ExpressionStatement(stmt)] = parsed.program.body.as_slice() else {
+        return None;
+    };
+    match &stmt.expression {
+        Expression::BigIntLiteral(lit) => Some(lit.value.to_string()),
+        _ => None,
+    }
 }
 
 /// `Some(value)` when the raw key text is a numeric literal, parsed rather than

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/rune_transforms.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/rune_transforms.rs
@@ -9,9 +9,7 @@ use super::{
     is_function_parameter_in_statement,
 };
 use crate::compiler::phases::phase2_analyze::ComponentAnalysis;
-use crate::compiler::phases::phase3_transform::shared::js_scan::{
-    find_code, find_rune_code, skip_opaque,
-};
+use crate::compiler::phases::phase3_transform::shared::js_scan::{find_rune_code, skip_opaque};
 use crate::compiler::phases::phase3_transform::shared::template::escape_js_string;
 
 /// Does the code preceding a removed call demand an operand — i.e. was the call
@@ -205,7 +203,7 @@ pub(super) fn transform_client_runes_with_skip_and_state<'a>(
     // text trimming around the call site (leading tabs/spaces on the
     // same line, trailing `;`/newlines) that's statement-shaped rather
     // than expression-shaped and is awkward to express at the AST level.
-    if !dev && !inspect_is_store_sub {
+    if !dev && !inspect_is_store_sub && !inspect_is_func_param {
         while let Some(pos) = find_rune_code(result.as_bytes(), b"$inspect.trace(") {
             let trace_start = pos + 15; // after "$inspect.trace("
             if let Some(content_end) = find_matching_paren(&result[trace_start..]) {
@@ -242,8 +240,8 @@ pub(super) fn transform_client_runes_with_skip_and_state<'a>(
     // and is awkward to do at the AST level.
     // The loop matters: a nested body can hold more than one, and a single
     // pass left the second `$inspect(...)` verbatim in the output.
-    if !dev && !inspect_is_store_sub {
-        while let Some(pos) = find_code(result.as_bytes(), b"$inspect(") {
+    if !dev && !inspect_is_store_sub && !inspect_is_func_param {
+        while let Some(pos) = find_rune_code(result.as_bytes(), b"$inspect(") {
             // In non-dev mode, remove the entire $inspect(...) call
             // Find matching closing paren
             let inspect_start = pos + 9; // after "$inspect("
@@ -278,10 +276,10 @@ pub(super) fn transform_client_runes_with_skip_and_state<'a>(
                 // and later transforms, then gets converted to ;; before OXC processing
                 return Cow::Owned(format!("/* $$async_hole:{} */", args));
             } else {
-                let trailing_comment = after.strip_prefix(';').unwrap_or(after).trim_start();
-                let marker = if before.is_empty() && trailing_comment.starts_with("/*") {
-                    // The trailing `;` of the removed call is one of the
-                    // `;;` upstream prints for the empty-as-expression.
+                let marker = if before.is_empty() && after.starts_with(';') {
+                    // A leading statement-position call keeps its own trailing
+                    // semicolon as the second half of upstream's `;;`, even
+                    // when another statement follows on the same source line.
                     "/* $$inspect_removed$$ */;"
                 } else if after.starts_with(';')
                     && matches!(before.as_bytes().last(), Some(b'{' | b'}' | b';'))
@@ -291,7 +289,10 @@ pub(super) fn transform_client_runes_with_skip_and_state<'a>(
                     // `ExpressionStatement` and replaces its expression with
                     // `b.empty` at every depth. The call's own `;` is the
                     // second one.
-                    ";"
+                    // Keep the pair identifiable after the Raw fragment is
+                    // parsed into the final AST; ordinary user-written empty
+                    // statements are intentionally elided by the printer.
+                    "/* $$inspect_removed$$ */;"
                 } else if operand_expected_before(before) {
                     // Upstream drops in an `EmptyStatement` wherever the call
                     // was; in an operand slot that prints as a bare `;`, which

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/regular_element.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/regular_element.rs
@@ -9,6 +9,8 @@ use crate::ast::template::{
     Attribute, AttributeNode, AttributeValue, BindDirective, ClassDirective, Fragment,
     LetDirective, RegularElement as RegularElementNode, StyleDirective, TemplateNode,
 };
+use crate::ast::template::{AttributeValuePart, ExpressionTag};
+use crate::compiler::phases::phase3_transform::client::source_anchor::CommentRegion;
 use crate::compiler::phases::phase3_transform::client::transform_template::Template;
 use crate::compiler::phases::phase3_transform::client::types::*;
 use crate::compiler::phases::phase3_transform::client::visitors::animate_directive::animate_directive;
@@ -30,8 +32,6 @@ use crate::compiler::phases::phase3_transform::client::visitors::shared::utils::
 };
 use crate::compiler::phases::phase3_transform::client::visitors::transition_directive::transition_directive;
 use crate::compiler::phases::phase3_transform::client::visitors::use_directive::use_directive;
-use crate::ast::template::{AttributeValuePart, ExpressionTag};
-use crate::compiler::phases::phase3_transform::client::source_anchor::CommentRegion;
 use crate::compiler::phases::phase3_transform::js_ast::builders as b;
 use crate::compiler::phases::phase3_transform::js_ast::nodes::{
     JsExpr, JsLiteral, JsPattern, JsStatement,
@@ -2002,7 +2002,9 @@ fn node_id_expr(
     anchors: Option<&ElementAnchors<'_>>,
 ) -> JsExpr {
     match anchors {
-        Some(a) => a.region.anchor(arena, b::id(node_id), a.name_start, a.name_end),
+        Some(a) => a
+            .region
+            .anchor(arena, b::id(node_id), a.name_start, a.name_end),
         None => b::id(node_id),
     }
 }
@@ -2107,7 +2109,11 @@ fn build_element_attribute_update(
         "$.set_attribute"
     };
 
-    let mut args = vec![node_id_expr(arena, node_id, anchors), b::string(name), value];
+    let mut args = vec![
+        node_id_expr(arena, node_id, anchors),
+        b::string(name),
+        value,
+    ];
     if dev
         && element
             .metadata
@@ -2522,7 +2528,6 @@ mod tests {
         assert!(!is_dom_property("id"));
     }
 }
-
 
 /// The single `{ … }` an attribute's value consists of, in either spelling.
 fn expression_tag_of<'a>(value: &'a AttributeValue<'a>) -> Option<&'a ExpressionTag<'a>> {

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/utils.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/utils.rs
@@ -13,7 +13,8 @@ use crate::compiler::phases::phase3_transform::js_ast::nodes::*;
 // The `scope.evaluate` port lives with the server transform, but it is the one
 // shared model of a folded JS value; the client fold must agree with it.
 use crate::compiler::phases::phase3_transform::server::evaluate::{
-    EvalValue, eval_binary, eval_unary, to_js_string,
+    EvalScope, EvalValue, Evaluation, eval_binary, eval_unary, evaluate_binding_initial,
+    evaluate_estree, to_js_string,
 };
 
 /// Local scope information for tracking shadowed variables and their init expression types.
@@ -1121,7 +1122,7 @@ pub fn apply_transforms_to_expression_with_shadowed(
                         local_scope,
                     );
 
-                return assign_fn(
+                let assigned = assign_fn(
                     transform,
                     &context.arena,
                     JsExpr::Identifier(name.clone()),
@@ -6163,7 +6164,7 @@ fn is_pure_json(json_value: &serde_json::Value, context: &ComponentContext) -> b
 
     match expr_type {
         "Literal" | "BooleanLiteral" | "NumericLiteral" | "StringLiteral" | "NullLiteral"
-        | "BigIntLiteral" | "RegExpLiteral" | "ThisExpression" => true,
+        | "BigIntLiteral" | "RegExpLiteral" => true,
         "Identifier" => {
             if let Some(name) = obj.get("name").and_then(|v| v.as_str()) {
                 // Rune identifiers ($effect, $state, etc.) are globals with no scope
@@ -6247,7 +6248,7 @@ fn typed_is_pure(
     use crate::ast::typed_expr::JsNode;
 
     match node {
-        JsNode::Literal { .. } | JsNode::Null | JsNode::ThisExpression { .. } => true,
+        JsNode::Literal { .. } | JsNode::Null => true,
         JsNode::Identifier { name, .. } => {
             context.state.get_binding(name.as_str()).is_none()
                 && !context.state.transform.contains_key(name.as_str())
@@ -6955,268 +6956,10 @@ struct ClientEvalScope<'a, 'b> {
     context: &'a ComponentContext<'b>,
 }
 
-    match expr_type {
-        "Literal" => true,
-
-        "Identifier" => {
-            if let Some(name) = obj.get("name").and_then(|v| v.as_str()) {
-                if name == "undefined" {
-                    return true;
-                }
-                // Prefer `binding_at_reference` (the exact binding Phase 2 resolved
-                // this reference to — see its doc comment) over a plain
-                // `get_binding`, which walks the root-scope-polluted map and can
-                // return an outer binding shadowed by a template declaration
-                // (`{@const}`, `{#snippet}`, ...).
-                if let Some(binding) = obj
-                    .get("start")
-                    .and_then(|v| v.as_u64())
-                    .and_then(|start| {
-                        context
-                            .state
-                            .scope_root
-                            .binding_at_reference(name, start as u32)
-                    })
-                    .or_else(|| context.state.get_binding(name))
-                {
-                    use crate::compiler::phases::phase2_analyze::scope::BindingKind;
-
-                    // Props are never known (external values)
-                    if matches!(
-                        binding.kind,
-                        BindingKind::Prop
-                            | BindingKind::BindableProp
-                            | BindingKind::RestProp
-                            | BindingKind::Store
-                            | BindingKind::StoreSub
-                            | BindingKind::EachItem
-                            | BindingKind::SnippetParam
-                    ) {
-                        return false;
-                    }
-
-                    // Updated bindings are not known
-                    if binding.reassigned || binding.mutated {
-                        return false;
-                    }
-
-                    // For State bindings, check if state source
-                    // `scope.evaluate` follows `binding.initial` and never asks
-                    // how the declaration was lowered, so `accessors` must not
-                    // make a never-written `$state(1)` unknown. `reassigned` /
-                    // `mutated` were already rejected above.
-                    if matches!(binding.kind, BindingKind::State | BindingKind::RawState) {
-                        // A bare `$state()` carries no argument: `undefined`.
-                        if binding.initial_node_type.is_none() && binding.initial.is_none() {
-                            return true;
-                        }
-                        return is_initial_value_literal_or_known(&binding.initial);
-                    }
-
-                    // For Derived bindings, recursively check the initial
-                    if matches!(binding.kind, BindingKind::Derived) {
-                        if let Some(initial_json) = binding.initial_json() {
-                            return is_expression_known_json(initial_json, context);
-                        }
-                        return false;
-                    }
-
-                    // For Template bindings (@const), recursively check the initial
-                    if matches!(binding.kind, BindingKind::Template) {
-                        if let Some(initial_json) = binding.initial_json() {
-                            return is_expression_known_json(initial_json, context);
-                        }
-                        return false;
-                    }
-
-                    // A function value is never `is_known` to upstream's
-                    // `scope.evaluate` — it recurses into the initializer and a
-                    // function expression falls through to `UNKNOWN`. Reading a
-                    // function is kept out of `has_state` by the separate
-                    // `!binding.is_function()` term, not by this one.
-                    // A non-literal initializer lives in `init_expr_json`, and
-                    // upstream's `scope.evaluate` recurses into the init node
-                    // whatever its shape (`const b = `${a}y`` is known when `a` is).
-                    if binding.initial.is_none()
-                        && let Some(init_json) = binding.init_expr_json_parsed()
-                    {
-                        return REACTIVE_INIT_DEPTH.with(|d| {
-                            if d.get() >= 8 {
-                                return false;
-                            }
-                            d.set(d.get() + 1);
-                            let known = is_expression_known_json(init_json, context);
-                            d.set(d.get() - 1);
-                            known
-                        });
-                    }
-                    return is_initial_value_literal_or_known(&binding.initial);
-                }
-                // Unknown identifier - not known (could be a global)
-                false
-            } else {
-                false
-            }
-        }
-
-        "BinaryExpression" => {
-            // Both operands must be known
-            if let (Some(left), Some(right)) = (obj.get("left"), obj.get("right")) {
-                is_expression_known_json(left, context) && is_expression_known_json(right, context)
-            } else {
-                false
-            }
-        }
-
-        "UnaryExpression" => {
-            if let Some(arg) = obj.get("argument") {
-                is_expression_known_json(arg, context)
-            } else {
-                false
-            }
-        }
-
-        // Upstream takes the chosen side when the left operand is known, so the
-        // result is known whenever the folder can name it.
-        "LogicalExpression" => fold_binding_initializer(json_value, context).is_some(),
-
-        "ConditionalExpression" => {
-            // Port of upstream scope.js ConditionalExpression case (lines 374-393):
-            //
-            // If the test evaluates to a known constant, prune to only the taken
-            // branch — e.g. `pin ? pin.replace(…) : 'enter your pin'` where
-            // `pin = $state('')` (non-state-source, known `""`) folds to the
-            // alternate `'enter your pin'`, which is known.
-            //
-            // If the test is unknown, the result is known only when BOTH branches
-            // evaluate to the SAME single known value (upstream: values.size === 1).
-            // e.g. `der1 ? "1" : "0"` → two different values → not known.
-            let (Some(test), Some(consequent), Some(alternate)) =
-                (obj.get("test"), obj.get("consequent"), obj.get("alternate"))
-            else {
-                return false;
-            };
-            // Try to fold the test to a constant via get_literal_value.
-            match fold_binding_initializer(test, context).and_then(|v| v.truthy()) {
-                Some(truthy) => {
-                    // Test is a known constant — only the taken branch needs to be known.
-                    if truthy {
-                        is_expression_known_json(consequent, context)
-                    } else {
-                        is_expression_known_json(alternate, context)
-                    }
-                }
-                None => {
-                    // Test is unknown — result is known only if both branches yield the
-                    // SAME single compile-time value (mirrors upstream values.size === 1
-                    // after adding both branches' values to the set).
-                    let c_val = fold_binding_initializer(consequent, context);
-                    let a_val = fold_binding_initializer(alternate, context);
-                    match (c_val, a_val) {
-                        (Some(c), Some(a)) => c.same(&a),
-                        _ => false,
-                    }
-                }
-            }
-        }
-
-        "TemplateLiteral" => {
-            // Known only if all expressions are known
-            if let Some(expressions) = obj.get("expressions").and_then(|e| e.as_array()) {
-                expressions
-                    .iter()
-                    .all(|e| is_expression_known_json(e, context))
-            } else {
-                true // No expressions = just a string
-            }
-        }
-
-        // Function calls are generally NOT known (can't evaluate at compile time)
-        // except for rune calls $state / $state.raw / $derived whose argument IS known.
-        // Mirrors upstream scope.js lines 465-507.
-        "CallExpression" => {
-            let callee = obj.get("callee").and_then(|v| v.as_object());
-            if let Some(callee) = callee {
-                let callee_type = callee.get("type").and_then(|t| t.as_str());
-                // $state(arg) / $derived(arg)
-                if callee_type == Some("Identifier") {
-                    let rune_name = callee.get("name").and_then(|n| n.as_str()).unwrap_or("");
-                    if matches!(rune_name, "$state" | "$derived")
-                        && is_rune_callee(rune_name, context)
-                    {
-                        if let Some(args) = obj.get("arguments").and_then(|a| a.as_array())
-                            && let Some(first_arg) = args.first()
-                        {
-                            return is_expression_known_json(first_arg, context);
-                        }
-                        return true; // no arg → undefined (known)
-                    }
-                }
-                // $state.raw(arg)
-                if callee_type == Some("MemberExpression") {
-                    let obj_name = callee
-                        .get("object")
-                        .and_then(|o| o.as_object())
-                        .and_then(|o| o.get("name"))
-                        .and_then(|n| n.as_str())
-                        .unwrap_or("");
-                    let prop_name = callee
-                        .get("property")
-                        .and_then(|p| p.as_object())
-                        .and_then(|p| p.get("name"))
-                        .and_then(|n| n.as_str())
-                        .unwrap_or("");
-                    if obj_name == "$state"
-                        && prop_name == "raw"
-                        && is_rune_callee(obj_name, context)
-                    {
-                        if let Some(args) = obj.get("arguments").and_then(|a| a.as_array())
-                            && let Some(first_arg) = args.first()
-                        {
-                            return is_expression_known_json(first_arg, context);
-                        }
-                        return true; // no arg → undefined (known)
-                    }
-                }
-            }
-            // Upstream's `globals` table makes a pure global call over known
-            // arguments known too (`Math.max(1, 2)`); the folder already knows
-            // which, so ask it rather than keeping a second list.
-            fold_binding_initializer(json_value, context).is_some()
-        }
-
-        // Arrow/function expressions are NOT "known" in the scope.evaluate sense:
-        // upstream evaluates them to the `FUNCTION` symbol, and a symbol value
-        // forces `is_known = false` (scope.js). So a `$derived(() => …)` (a
-        // function-valued derived) stays reactive — its prop must be emitted as a
-        // getter, not inlined by value. A plain `const fn = () => {}` reference is
-        // handled separately by the `binding.is_function()` fast-path above and
-        // never reaches here.
-        "ArrowFunctionExpression" | "FunctionExpression" => false,
-
-        // A member expression is known only when it is one of the eight
-        // `global_constants` keypaths upstream lists (`Math.PI`, `Math.E`, …);
-        // every other member evaluates to UNKNOWN there, `Number.MAX_VALUE`
-        // and a misspelt `Math.NOPE` included.
-        "MemberExpression" => {
-            if obj.get("computed").and_then(|c| c.as_bool()) == Some(true) {
-                return false;
-            }
-            let Some(object) = obj.get("object") else {
-                return false;
-            };
-            if object.get("type").and_then(|t| t.as_str()) != Some("Identifier") {
-                return false;
-            }
-            let Some(root) = object.get("name").and_then(|n| n.as_str()) else {
-                return false;
-            };
-            context.state.get_binding(root).is_none()
-                && json_keypath(json_value).is_some_and(|k| is_global_constant(&k))
-        }
-
-        // Default: not known
-        _ => false,
+impl EvalScope for ClientEvalScope<'_, '_> {
+    fn identifier_has_binding(&self, name: &str) -> bool {
+        self.context.state.get_binding(name).is_some()
+            || self.context.state.transform.contains_key(name)
     }
 
     fn evaluate_identifier(&self, node: &serde_json::Value, name: &str, depth: u8) -> Evaluation {
@@ -7604,8 +7347,9 @@ mod tests {
             ("[konst, konst]", false),
             ("[, count]", true),
             ("[...konst]", true),
-            // `this` is a pure, non-reactive member base.
-            ("this.foo", false),
+            // The leaf is non-reactive, but a member rooted at `this` is not
+            // pure and therefore follows the dynamic member-expression path.
+            ("this.foo", true),
             // Shapes the typed walk deliberately does NOT answer — these reach
             // the JSON fallback, so they agree by construction.
             ("tag`x`", true),

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/css.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/css.rs
@@ -226,7 +226,8 @@ fn collect_is_where_unused_warnings(
                 // substituted into the enclosing chain, and upstream's `css-warn.js`
                 // never recurses into it — so it is marked but never reported.
                 if sel_name == "has" {
-                    let flags = has_argument_unused_flags(rel_selectors, ri, selectors, sel, ctx);
+                    let flags =
+                        has_pseudo_unused_under_every_host(rel_selectors, ri, selectors, sel, ctx);
                     for (bi, inner_complex) in children.iter().enumerate() {
                         let unused = flags.as_ref().is_some_and(|f| f.get(bi) == Some(&true))
                             || is_functional_branch_unused(inner_complex, None, ctx);
@@ -986,6 +987,44 @@ impl CssWriter {
         self.marks.insert(offset as u32);
     }
 
+    fn apply_insertions(&mut self, insertions: &[(u32, u32)]) {
+        if insertions.is_empty() {
+            return;
+        }
+        let mut rebased: Vec<(u32, u32, u32)> = Vec::with_capacity(self.copies.len());
+        for &(gen_start, src_start, len) in &self.copies {
+            let mut shift = 0u32;
+            let mut piece_gen = gen_start;
+            let mut piece_src = src_start;
+            let mut consumed = 0u32;
+            for &(at, ins_len) in insertions {
+                if at <= gen_start {
+                    shift += ins_len;
+                } else if at < gen_start + len {
+                    let cut = at - gen_start;
+                    rebased.push((piece_gen + shift, piece_src, cut - consumed));
+                    shift += ins_len;
+                    piece_gen = gen_start + cut;
+                    piece_src = src_start + cut;
+                    consumed = cut;
+                }
+            }
+            rebased.push((piece_gen + shift, piece_src, len - consumed));
+        }
+        self.copies = rebased;
+    }
+
+    fn copy_verbatim(&mut self, css_source: &str, css_start: usize, src_start: usize, text: &str) {
+        if src_start >= css_start
+            && let from = src_start - css_start
+            && css_source.as_bytes().get(from..from + text.len()) == Some(text.as_bytes())
+        {
+            self.copy(src_start, text);
+        } else {
+            self.push_str(text);
+        }
+    }
+
     /// Drop the whitespace already emitted, mirroring upstream's
     /// `remove_preceding_whitespace(node.start)` — which walks back over the
     /// source rather than over a gap, so it can also cut into the tail of the
@@ -1451,21 +1490,27 @@ fn is_animation_declaration(property: &str) -> bool {
 /// Emit a declaration the way upstream's minifier does: the whitespace run that
 /// starts immediately after `property.length + 1` bytes is dropped, so
 /// `color : red` (space before the colon) is left alone and custom properties
-/// are skipped entirely.
-fn push_minified_declaration(output: &mut CssWriter, decl_text: &str, property: &str) {
+/// are skipped entirely. `src_start` is the declaration's source offset, so the
+/// surviving runs remain mapped like MagicString's `remove` leaves them.
+fn push_minified_declaration(
+    output: &mut CssWriter,
+    src_start: usize,
+    decl_text: &str,
+    property: &str,
+) {
     if property.starts_with("--") {
-        output.push_str(decl_text);
+        output.copy(src_start, decl_text);
         return;
     }
     let start = property.len() + 1;
     if start > decl_text.len() || !decl_text.is_char_boundary(start) {
-        output.push_str(decl_text);
+        output.copy(src_start, decl_text);
         return;
     }
     let rest = &decl_text[start..];
     let value = rest.trim_start_matches(|c: char| c.is_whitespace() || c == '\u{feff}');
-    output.push_str(&decl_text[..start]);
-    output.push_str(value);
+    output.copy(src_start, &decl_text[..start]);
+    output.copy(src_start + decl_text.len() - value.len(), value);
 }
 
 fn has_nested_rules(block: &Value) -> bool {
@@ -4588,8 +4633,8 @@ fn is_has_selector_unused(rel_selectors: &[Value], ctx: &CssContext) -> bool {
             if !is_has_pseudo(sel) {
                 continue;
             }
-            if let Some(flags) = has_argument_unused_flags(rel_selectors, ri, selectors, sel, ctx)
-                && flags.iter().all(|&unused| unused)
+            if has_pseudo_unused_under_every_host(rel_selectors, ri, selectors, sel, ctx)
+                .is_some_and(|flags| flags.iter().all(|&unused| unused))
             {
                 return true;
             }
@@ -4597,6 +4642,212 @@ fn is_has_selector_unused(rel_selectors: &[Value], ctx: &CssContext) -> bool {
     }
 
     false
+}
+
+/// Per-argument verdicts for one `:has()`, taken under every way the enclosing
+/// rule's `&` can resolve. An argument is unused only when every resolution
+/// says it is unused.
+fn has_pseudo_unused_under_every_host(
+    rel_selectors: &[Value],
+    ri: usize,
+    selectors: &[Value],
+    sel: &Value,
+    ctx: &CssContext,
+) -> Option<Vec<bool>> {
+    let mut merged: Option<Vec<bool>> = None;
+    for (chain, offset) in effective_host_chains(rel_selectors, ctx) {
+        let flags = has_argument_unused_flags(&chain, offset + ri, selectors, sel, ctx)?;
+        merged = Some(match merged {
+            None => flags,
+            Some(prev) => prev
+                .iter()
+                .zip(flags.iter())
+                .map(|(a, b)| *a && *b)
+                .collect(),
+        });
+    }
+    merged
+}
+
+fn effective_host_chains(rel_selectors: &[Value], ctx: &CssContext) -> Vec<(Vec<Value>, usize)> {
+    let bare = || vec![(rel_selectors.to_vec(), 0usize)];
+
+    if rel_selectors.iter().any(relative_selector_has_nesting) {
+        return bare();
+    }
+    let parent_preludes = ctx.parent_preludes.borrow();
+    if parent_preludes.is_empty() {
+        return bare();
+    }
+    let Some(chains) = build_parent_chains(&parent_preludes, parent_preludes.len()) else {
+        return bare();
+    };
+
+    chains
+        .into_iter()
+        .map(|mut chain| {
+            let offset = chain.len();
+            for (i, rel) in rel_selectors.iter().enumerate() {
+                chain.push(if i == 0 {
+                    with_descendant_head(rel)
+                } else {
+                    rel.clone()
+                });
+            }
+            (chain, offset)
+        })
+        .collect()
+}
+
+/// What a `&` stands for inside an argument list: the subject compound of each
+/// alternative the enclosing rules resolve to. Reuses [`build_parent_chains`],
+/// this file's port of upstream's `get_relative_selectors`, so there is one
+/// answer to "what is the parent" rather than a second one here.
+///
+/// Only the chain's **last** compound is taken. A multi-part parent (`.x .y`)
+/// therefore contributes `.y` alone, dropping the `.x` ancestor requirement —
+/// which weakens the test, so a branch can only come out *less* unused, never
+/// more.
+fn nesting_substitute_alternatives(ctx: &CssContext) -> Option<Vec<Vec<Value>>> {
+    let parent_preludes = ctx.parent_preludes.borrow();
+    if parent_preludes.is_empty() {
+        return None;
+    }
+    let chains = build_parent_chains(&parent_preludes, parent_preludes.len())?;
+    let alternatives: Vec<Vec<Value>> = chains
+        .iter()
+        .filter_map(|chain| {
+            chain
+                .last()?
+                .get("selectors")
+                .and_then(|s| s.as_array())
+                .cloned()
+        })
+        .collect();
+    (!alternatives.is_empty()).then_some(alternatives)
+}
+
+/// Whether any relative selector of `complex` carries a top-level `&`.
+fn relative_selectors_carry_nesting(complex: &Value) -> bool {
+    complex
+        .get("children")
+        .and_then(|c| c.as_array())
+        .is_some_and(|rels| {
+            rels.iter().any(|rel| {
+                rel.get("selectors")
+                    .and_then(|s| s.as_array())
+                    .is_some_and(|sels| {
+                        sels.iter().any(|s| {
+                            s.get("type").and_then(|t| t.as_str()) == Some("NestingSelector")
+                        })
+                    })
+            })
+        })
+}
+
+/// The forms one `:is()` / `:where()` argument compound takes once its `&` is
+/// resolved — one per way the enclosing rules resolve it. `None` when the
+/// compound carries no `&`, or when no parent can resolve it, in which case the
+/// compound is used as written.
+fn branch_alternatives(branch: &[Value], ctx: &CssContext) -> Option<Vec<Vec<Value>>> {
+    if !branch
+        .iter()
+        .any(|s| s.get("type").and_then(|t| t.as_str()) == Some("NestingSelector"))
+    {
+        return None;
+    }
+    let alternatives: Vec<Vec<Value>> = nesting_substitute_alternatives(ctx)?
+        .iter()
+        .filter_map(|sub| replace_nesting_in_selectors(branch, sub))
+        .collect();
+    // An empty list would make the `all()` below vacuously true.
+    (!alternatives.is_empty()).then_some(alternatives)
+}
+
+/// Evaluate `f` as if the rule were not nested — the counterpart of resolving
+/// `&` by substitution, since the substituted selector already carries the
+/// parent and must not also be required to sit below it.
+fn without_parent_preludes<T>(ctx: &CssContext, f: impl FnOnce() -> T) -> T {
+    let saved = ctx.parent_preludes.replace(Vec::new());
+    let out = f();
+    ctx.parent_preludes.replace(saved);
+    out
+}
+
+/// Rewrite one argument-list compound, replacing its `&` with `substitute`.
+/// `None` when the compound has no `&` to replace.
+fn replace_nesting_in_selectors(selectors: &[Value], substitute: &[Value]) -> Option<Vec<Value>> {
+    if !selectors
+        .iter()
+        .any(|s| s.get("type").and_then(|t| t.as_str()) == Some("NestingSelector"))
+    {
+        return None;
+    }
+    let mut out = Vec::with_capacity(selectors.len() + substitute.len());
+    for sel in selectors {
+        if sel.get("type").and_then(|t| t.as_str()) == Some("NestingSelector") {
+            out.extend(substitute.iter().cloned());
+        } else {
+            out.push(sel.clone());
+        }
+    }
+    Some(out)
+}
+
+/// Rewrite an argument `ComplexSelector` so each `&` becomes `substitute`.
+fn replace_nesting_in_complex(complex: &Value, substitute: &[Value]) -> Option<Value> {
+    let rels = complex.get("children")?.as_array()?;
+    let mut children = Vec::with_capacity(rels.len());
+    let mut replaced = false;
+    for rel in rels {
+        let selectors = rel.get("selectors").and_then(|s| s.as_array());
+        match selectors.and_then(|s| replace_nesting_in_selectors(s, substitute)) {
+            Some(new_selectors) => {
+                replaced = true;
+                let mut cloned = rel.clone();
+                if let Value::Object(map) = &mut cloned {
+                    map.insert("selectors".to_string(), Value::Array(new_selectors));
+                }
+                children.push(cloned);
+            }
+            None => children.push(rel.clone()),
+        }
+    }
+    if !replaced {
+        return None;
+    }
+    let mut out = complex.clone();
+    if let Value::Object(map) = &mut out {
+        map.insert("children".to_string(), Value::Array(children));
+    }
+    Some(out)
+}
+
+/// Whether a `&` appears anywhere in this compound, a pseudo-class's argument
+/// list included — upstream finds it with a `walk`, which descends into `args`.
+fn relative_selector_has_nesting(rel: &Value) -> bool {
+    rel.get("selectors")
+        .and_then(|s| s.as_array())
+        .is_some_and(|sels| sels.iter().any(simple_selector_has_nesting))
+}
+
+fn simple_selector_has_nesting(sel: &Value) -> bool {
+    match sel.get("type").and_then(|t| t.as_str()) {
+        Some("NestingSelector") => true,
+        Some("PseudoClassSelector") => sel
+            .get("args")
+            .and_then(|a| a.get("children"))
+            .and_then(|c| c.as_array())
+            .is_some_and(|complexes| {
+                complexes.iter().any(|complex| {
+                    complex
+                        .get("children")
+                        .and_then(|c| c.as_array())
+                        .is_some_and(|rels| rels.iter().any(relative_selector_has_nesting))
+                })
+            }),
+        _ => false,
+    }
 }
 
 fn is_has_pseudo(sel: &Value) -> bool {
@@ -4630,27 +4881,28 @@ fn has_argument_unused_flags(
         .and_then(|c| c.as_array())
         .filter(|c| !c.is_empty())?;
 
-    // `&` inside the argument refers to the parent CSS rule, not to an element,
-    // so it cannot be resolved through the DOM structure.
-    let has_nesting_in_args = has_children.iter().any(|complex| {
-        complex
-            .get("children")
-            .and_then(|c| c.as_array())
-            .is_some_and(|rels| {
-                rels.iter().any(|rel| {
-                    rel.get("selectors")
-                        .and_then(|s| s.as_array())
-                        .is_some_and(|sels| {
-                            sels.iter().any(|s| {
-                                s.get("type").and_then(|t| t.as_str()) == Some("NestingSelector")
-                            })
-                        })
-                })
+    // `&` inside the argument refers to the parent CSS rule, not to an element.
+    // Resolve it against the enclosing preludes; if it cannot be resolved,
+    // nothing may be concluded about this `:has()`.
+    let resolved;
+    let has_children: &[Value] = if has_children.iter().any(relative_selectors_carry_nesting) {
+        let alternatives = nesting_substitute_alternatives(ctx)?;
+        // One alternative only: with several, an argument would have to be
+        // unreachable under all of them, which this per-argument shape cannot
+        // express — so decline rather than guess.
+        let [substitute] = alternatives.as_slice() else {
+            return None;
+        };
+        resolved = has_children
+            .iter()
+            .map(|complex| {
+                replace_nesting_in_complex(complex, substitute).unwrap_or_else(|| complex.clone())
             })
-    });
-    if has_nesting_in_args {
-        return None;
-    }
+            .collect::<Vec<_>>();
+        &resolved
+    } else {
+        has_children
+    };
 
     // The subject is the compound the `:has()` sits in, `:has()` itself excluded.
     let subject_info = extract_selector_info_from_selectors(selectors);
@@ -5988,7 +6240,7 @@ fn transform_block_with_nested_rules<'a>(
                 let ws_start = last_end.saturating_sub(css_start);
                 let ws_end = child_start.saturating_sub(css_start);
                 if ws_end <= css_source.len() && ws_start < ws_end {
-                    output.push_str(&css_source[ws_start..ws_end]);
+                    output.copy(last_end, &css_source[ws_start..ws_end]);
                 }
             }
 
@@ -6050,11 +6302,12 @@ fn transform_block_with_nested_rules<'a>(
                     if decl_end <= css_source.len() && decl_start < decl_end {
                         let decl_text = &css_source[decl_start..decl_end];
                         let prop = child.get("property").and_then(|p| p.as_str()).unwrap_or("");
+                        mark_node(output, child);
                         if ctx.minify && !is_animation_declaration(prop) {
                             output.trim_preceding_whitespace();
-                            push_minified_declaration(output, decl_text, prop);
+                            push_minified_declaration(output, child_start, decl_text, prop);
                         } else {
-                            output.push_str(decl_text);
+                            output.copy(child_start, decl_text);
                         }
                     }
                 }
@@ -6072,7 +6325,7 @@ fn transform_block_with_nested_rules<'a>(
         let ws_start = last_end.saturating_sub(css_start);
         let ws_end = (block_end - 1).saturating_sub(css_start); // -1 to exclude the '}'
         if ws_end <= css_source.len() && ws_start < ws_end {
-            output.push_str(&css_source[ws_start..ws_end]);
+            output.copy(last_end, &css_source[ws_start..ws_end]);
         }
     }
     if ctx.minify {
@@ -6176,7 +6429,7 @@ fn transform_nested_atrule<'a>(
             // Copy content before this child; the whitespace run immediately
             // before it is dropped per child kind below, so comments survive.
             if child_start > last_end {
-                output.push_str(src(last_end, child_start));
+                output.copy(last_end, src(last_end, child_start));
             }
 
             match child_type {
@@ -6231,11 +6484,12 @@ fn transform_nested_atrule<'a>(
                 Some("Declaration") => {
                     let prop = child.get("property").and_then(|p| p.as_str()).unwrap_or("");
                     let decl_text = src(child_start, child_end);
+                    mark_node(output, child);
                     if ctx.minify && !is_animation_declaration(prop) {
                         output.trim_preceding_whitespace();
-                        push_minified_declaration(output, decl_text, prop);
+                        push_minified_declaration(output, child_start, decl_text, prop);
                     } else {
-                        output.push_str(decl_text);
+                        output.copy(child_start, decl_text);
                     }
                 }
                 _ => {}
@@ -6249,7 +6503,7 @@ fn transform_nested_atrule<'a>(
     // `remove_preceding_whitespace(node.block.end - 1)` lives in the Rule
     // visitor, so an at-rule's own closing brace keeps its whitespace.
     if block_end > last_end + 1 {
-        output.push_str(src(last_end, block_end - 1));
+        output.copy(last_end, src(last_end, block_end - 1));
     }
 
     output.copy_verbatim(css_source, css_start, block_end.saturating_sub(1), "}");
@@ -6348,11 +6602,12 @@ fn transform_global_block<'a>(
                             let to = child_end.saturating_sub(css_start);
                             if to <= css_source.len() && from < to {
                                 let decl_text = &css_source[from..to];
+                                mark_node(output, child);
                                 if is_animation_declaration(prop) {
-                                    output.push_str(decl_text);
+                                    output.copy(child_start, decl_text);
                                 } else {
                                     output.trim_preceding_whitespace();
-                                    push_minified_declaration(output, decl_text, prop);
+                                    push_minified_declaration(output, child_start, decl_text, prop);
                                 }
                             }
                         }
@@ -6607,7 +6862,7 @@ fn transform_atrule_preserving<'a>(
                 let trail_start = inner_last_end.saturating_sub(css_start);
                 let trail_end = (block_end - 1).saturating_sub(css_start); // -1 to exclude closing brace
                 if trail_end <= css_source.len() && trail_start < trail_end {
-                    output.push_str(&css_source[trail_start..trail_end]);
+                    output.copy(inner_last_end, &css_source[trail_start..trail_end]);
                 }
             }
         }

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/js_ast/to_oxc.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/js_ast/to_oxc.rs
@@ -653,24 +653,27 @@ impl<'a, 'arena, 'source> Cx<'a, 'arena, 'source> {
             synth.source.push_str(&anchor.region);
             synth.source.push('\n');
             let region_start = anchor.region_start;
-            synth.comments.extend(anchor.comments.iter().map(
-                |&(start, end, line)| -> Comment {
-                    let start = base + (start - region_start);
-                    let end = base + (end - region_start);
-                    let kind = if line {
-                        CommentKind::Line
-                    } else if anchor.region[(start - base) as usize..(end - base) as usize]
-                        .contains('\n')
-                    {
-                        CommentKind::MultiLineBlock
-                    } else {
-                        CommentKind::SingleLineBlock
-                    };
-                    let mut comment = Comment::new(start, end, kind);
-                    comment.attached_to = end;
-                    comment
-                },
-            ));
+            synth.comments.extend(
+                anchor
+                    .comments
+                    .iter()
+                    .map(|&(start, end, line)| -> Comment {
+                        let start = base + (start - region_start);
+                        let end = base + (end - region_start);
+                        let kind = if line {
+                            CommentKind::Line
+                        } else if anchor.region[(start - base) as usize..(end - base) as usize]
+                            .contains('\n')
+                        {
+                            CommentKind::MultiLineBlock
+                        } else {
+                            CommentKind::SingleLineBlock
+                        };
+                        let mut comment = Comment::new(start, end, kind);
+                        comment.attached_to = end;
+                        comment
+                    }),
+            );
             synth.open_source_region = Some(anchor.region_start);
             synth.open_source_base = base;
         }

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/comments.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/comments.rs
@@ -136,6 +136,7 @@ impl ChunkRegistry {
             position_only: true,
             expression_anchor: true,
             component_tail: false,
+            component_tail_nested: false,
         });
         Some(prov_base)
     }

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/mod.rs
@@ -231,6 +231,12 @@ pub struct ServerTransformState<'a> {
     /// rebuilds loc-less. Their final anchor is decided after the reordered
     /// script body is assembled.
     pub pending_tail_comments: Vec<PendingTailComment>,
+    /// Comments from a template expression that folded away, waiting for the
+    /// next located expression to flush them.
+    pending_template_comments: Option<PendingTemplateComments>,
+    /// Upstream only carries template comments through the component block
+    /// when an instance script supplied that block's location.
+    pub has_instance_script: bool,
     /// Set when [`Self::reparse_program`] rejected text this compiler generated.
     /// The instance body cannot be reconstructed after that, so assembly aborts
     /// instead of shipping a component whose `<script>` silently did nothing.
@@ -339,6 +345,8 @@ impl<'a> ServerTransformState<'a> {
             current_scope_index: analysis.root.root_fragment_scope_index,
             comments: comments::ChunkRegistry::default(),
             pending_tail_comments: Vec::new(),
+            pending_template_comments: None,
+            has_instance_script: false,
             reparse_failure: std::cell::RefCell::new(None),
         }
     }
@@ -376,34 +384,153 @@ impl<'a> ServerTransformState<'a> {
         }
     }
 
+    fn template_region_comments(&self, start: u32, end: u32) -> Vec<Comment> {
+        let Some(slice) = self.source.get(start as usize..end as usize) else {
+            return Vec::new();
+        };
+        if start >= end || memchr::memchr(b'/', slice.as_bytes()).is_none() {
+            return Vec::new();
+        }
+        let allocator = Allocator::default();
+        let ret = oxc_parser::Parser::new(
+            &allocator,
+            slice,
+            oxc_span::SourceType::mjs().with_typescript(true),
+        )
+        .parse();
+        ret.program
+            .comments
+            .iter()
+            .map(|comment| {
+                let mut comment = *comment;
+                comment.span = Span::new(comment.span.start + start, comment.span.end + start);
+                comment.attached_to = comment.span.end;
+                comment
+            })
+            .collect()
+    }
+
+    /// Restrict a template expression's interior to the part reachable by
+    /// upstream's comment cursor. The component block borrows the instance
+    /// script's location, so comments before that script (and every template
+    /// comment when there is no script) are deliberately skipped.
+    fn live_template_region(&self, region: (u32, u32)) -> Option<(u32, u32)> {
+        let cursor_start = self.analysis.instance_script_content.as_ref()?.start;
+        let start = region.0.max(cursor_start);
+        (start < region.1 && (region.1 as usize) <= self.source.len()).then_some((start, region.1))
+    }
+
+    pub fn defer_template_expression_comments(&mut self, region: (u32, u32)) {
+        let Some((start, end)) = self.live_template_region(region) else {
+            return;
+        };
+        let comments = self.template_region_comments(start, end);
+        if comments.is_empty() {
+            return;
+        }
+        match &mut self.pending_template_comments {
+            Some(pending) => pending.comments.extend(comments),
+            None => {
+                self.pending_template_comments = Some(PendingTemplateComments { start, comments });
+            }
+        }
+    }
+
+    pub fn place_template_expression_comments(
+        &mut self,
+        region: (u32, u32),
+        expr_span: (u32, u32),
+        expr: &mut OxcExpression<'a>,
+    ) {
+        let Some((start, end)) = self.live_template_region(region) else {
+            return;
+        };
+        let (expr_start, expr_end) = expr_span;
+        let own = self.template_region_comments(start, end);
+        let carried = match self.pending_template_comments.take() {
+            Some(pending) if pending.start < start => Some(pending),
+            _ => None,
+        };
+        if own.is_empty() && carried.is_none() {
+            return;
+        }
+        let region_start = carried.as_ref().map_or(start, |pending| pending.start);
+        let region_end = end.max(expr_end);
+        if expr_start < region_start || region_end as usize > self.source.len() {
+            return;
+        }
+        let mut comments = carried.map(|pending| pending.comments).unwrap_or_default();
+        comments.extend(own);
+        comments.retain(|comment| {
+            comment.span.start >= region_start
+                && comment.span.end <= region_end
+                && (comment.span.end <= expr_start || comment.span.start >= expr_end)
+        });
+        if comments.is_empty() {
+            return;
+        }
+        let Some(text) = self.source.get(region_start as usize..region_end as usize) else {
+            return;
+        };
+        for comment in &mut comments {
+            comment.span = Span::new(
+                comment.span.start - region_start,
+                comment.span.end - region_start,
+            );
+            comment.attached_to = comment.span.end;
+        }
+        if let Some(base) = self.comments.register_expression(text, &comments) {
+            let mut place = comments::Place::At(base + (expr_start - region_start));
+            place.visit_expression(expr);
+        }
+    }
+
+    pub fn visit_expression_tag(
+        &mut self,
+        tag: &crate::ast::template::ExpressionTag,
+    ) -> OxcExpression<'a> {
+        let mut visited = self.visit_expr(&tag.expression);
+        let source = self.expr_source(&tag.expression).map(str::to_owned);
+        if let (Some(start), Some(end)) = (tag.expression.start(), tag.expression.end()) {
+            self.place_template_expression_comments(
+                (tag.start + 1, tag.end - 1),
+                (start, end),
+                &mut visited,
+            );
+        }
+        self.claim_on_visited(source.as_deref(), &mut visited);
+        visited
+    }
+
     /// The first template expression flushes every still-pending comment, the way
     /// esrap's cursor writes the whole run before the next node it finds a
-    /// location on. A comment a script successor already took is not among them.
-    pub fn claim_deferred_tail_comment(&mut self, expression: &mut OxcExpression<'a>) {
-        if self
-            .pending_tail_comments
-            .iter()
-            .all(|comment| comment.replay_at_tail)
-        {
-            return;
+    /// location on. Position-anchored script comments remain eligible here when
+    /// their upstream cursor would not have advanced past the template boundary.
+    pub fn claim_deferred_tail_comment(&mut self, expression: &mut OxcExpression<'a>) -> bool {
+        if self.pending_tail_comments.is_empty() {
+            return false;
         }
         let mut text = String::from("x");
         let mut comments: Vec<Comment> = Vec::new();
-        let mut kept = Vec::new();
         for entry in std::mem::take(&mut self.pending_tail_comments) {
-            if entry.replay_at_tail {
-                kept.push(entry);
-                continue;
-            }
             let base = text.len() as u32;
             text.push_str(&entry.suffix);
-            comments.extend(entry.comments.into_iter().map(|mut comment| {
-                comment.span.start += base;
-                comment.span.end += base;
-                comment
-            }));
+            if !entry.replay_at_tail {
+                comments.extend(entry.comments.into_iter().map(|mut comment| {
+                    comment.span.start += base;
+                    comment.span.end += base;
+                    comment
+                }));
+            }
         }
-        self.pending_tail_comments = kept;
+        if comments.is_empty() {
+            if let Some(base) = self.comments.register_anchor() {
+                let mut place = comments::Place::At(base);
+                place.visit_expression(expression);
+                return true;
+            }
+            return false;
+        }
         // The anchor goes on the line after the run, so a line comment cannot
         // swallow it and a block one still gets its own line — which is what
         // upstream produces, the script always sitting above the template.

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/script.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/script.rs
@@ -471,7 +471,7 @@ fn inspect_residue_local<'a>(
     origin: u32,
     state: &ServerTransformState<'a>,
 ) -> Option<Vec<Statement<'a>>> {
-    inspect_residue(expr, stmt_start, src.get(origin as usize..)?, state)
+    inspect_residue(expr, stmt_start, src.get(origin as usize..)?, false, state)
 }
 
 /// The statements a removed `$inspect(…)` / `$inspect(…).with(…)` expression
@@ -482,6 +482,7 @@ fn inspect_residue<'a>(
     expr: &OxcExpression<'_>,
     stmt_start: u32,
     src: &str,
+    wrap_reads: bool,
     state: &ServerTransformState<'a>,
 ) -> Option<Vec<Statement<'a>>> {
     let rune_store_subs = rune_names_are_store_subs(state.analysis);
@@ -497,7 +498,7 @@ fn inspect_residue<'a>(
     }
     let (args_src, with_fn_src) = inspect_call_srcs(expr, &kind, src);
     Some(
-        build_dev_inspect(&kind, &args_src, with_fn_src.as_deref(), state)
+        build_dev_inspect(&kind, &args_src, with_fn_src.as_deref(), wrap_reads, state)
             .into_iter()
             .collect(),
     )
@@ -519,7 +520,7 @@ fn inspect_value_expr<'a>(
         return Some(state.b.id("undefined"));
     }
     let (args_src, with_fn_src) = inspect_call_srcs(expr, &kind, src.get(origin as usize..)?);
-    match build_dev_inspect(&kind, &args_src, with_fn_src.as_deref(), state)? {
+    match build_dev_inspect(&kind, &args_src, with_fn_src.as_deref(), false, state)? {
         Statement::ExpressionStatement(es) => Some(es.unbox().expression),
         _ => None,
     }
@@ -556,6 +557,22 @@ fn inspect_call_srcs(
             (inner_args, fn_src)
         }
     }
+}
+
+fn call_args_src(call: &oxc_ast::ast::CallExpression<'_>, src: &str) -> String {
+    let start = call.callee.span().end as usize;
+    let end = call.span.end as usize;
+    let Some(tail) = src.get(start..end) else {
+        return String::new();
+    };
+    let Some(open) = tail.find('(') else {
+        return String::new();
+    };
+    let args_start = start + open + 1;
+    let args_end = end.saturating_sub(1);
+    src.get(args_start..args_end)
+        .unwrap_or_default()
+        .to_string()
 }
 
 /// Build the dev-mode lowering of a `$inspect(...)` / `$inspect(...).with(...)`
@@ -1087,7 +1104,7 @@ fn transform_script<'a>(
                         // returning `b.empty` — a *bare* `EmptyStatement` that esrap
                         // elides (prints nothing), so those keep being dropped.
                         if let Some(residue) =
-                            inspect_residue(&es.expression, es.span.start, src, state)
+                            inspect_residue(&es.expression, es.span.start, src, true, state)
                         {
                             out.extend(residue);
                         }
@@ -3513,12 +3530,16 @@ fn transform_script_legacy<'a>(
     let mut region_start: u32 = 0;
     let mut reactive_leading_comment_pending = false;
     let mut deferred_reactive_comment: Option<usize> = None;
+    let mut previous_was_reactive_block = false;
 
     let body_len = ret.program.body.len();
     for (stmt_index, stmt) in ret.program.body.iter().enumerate() {
         let stmt_span = stmt.span();
         let is_last_stmt = stmt_index + 1 == body_len;
         let is_reactive = matches!(stmt, Statement::LabeledStatement(ls) if is_instance && ls.label.name.as_str() == "$");
+        let is_reactive_block = matches!(stmt, Statement::LabeledStatement(ls) if is_instance
+            && ls.label.name.as_str() == "$"
+            && reactive_body_has_direct_block(&ls.body));
         // Upstream rebuilds the `$` label as a loc-less `b.labeled(...)`, so
         // `body()` never flushes a comment trailing it on the same line; being the
         // last statement, nothing located is left in the script to take it either.
@@ -3845,7 +3866,21 @@ fn transform_script_legacy<'a>(
                     other => place.visit_statement(other),
                 }
             }
+            let had_deferred_reactive_comment = deferred_reactive_comment.is_some();
             if let Some(index) = deferred_reactive_comment.take() {
+                state.mark_deferred_tail_comment_landed(index);
+            }
+            if previous_was_reactive_block
+                && !had_deferred_reactive_comment
+                && stmt_span.start > region_start
+            {
+                let index = state.pending_tail_comments.len();
+                state.defer_tail_comments(
+                    src,
+                    &ret.program.comments,
+                    region_start,
+                    stmt_span.start,
+                );
                 state.mark_deferred_tail_comment_landed(index);
             }
         }
@@ -3854,6 +3889,7 @@ fn transform_script_legacy<'a>(
         } else if !is_reactive && anchor.is_some() {
             reactive_leading_comment_pending = false;
         }
+        previous_was_reactive_block = is_reactive_block;
         let trailing_end = trailing_comment_end(src, &ret.program.comments, stmt_span.end);
         region_start = if defer_reactive_tail {
             stmt_span.end

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/visitors/element.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/visitors/element.rs
@@ -2244,9 +2244,11 @@ fn attr_expr_value<'a>(
         return super::shared::save_wrap_expr_text(state, &text);
     }
     let mut visited = state.visit_expr(expr);
+    let source = state.expr_source(expr).map(str::to_owned);
     if let (Some(start), Some(end)) = (expr.start(), expr.end()) {
         state.place_template_expression_comments(region, (start, end), &mut visited);
     }
+    state.claim_on_visited(source.as_deref(), &mut visited);
     visited
 }
 

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/visitors/shared.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/visitors/shared.rs
@@ -660,7 +660,7 @@ enum SeqNode<'n> {
 /// — and the store arm builds the whole `$.store_get(...)` call fresh, so
 /// neither gives esrap's cursor a stop here. Every other read keeps the source
 /// expression's own `loc`.
-fn read_loses_its_location(state: &ServerTransformState<'_>, source: &str) -> bool {
+pub(crate) fn read_loses_its_location(state: &ServerTransformState<'_>, source: &str) -> bool {
     let name = source.trim();
     if !is_plain_identifier(name) {
         return false;
@@ -739,12 +739,13 @@ fn flush_sequence<'a>(sequence: &[SeqNode<'_>], state: &mut ServerTransformState
                     && !state.nearest_declaration_is_template_const(src.trim())
                 {
                     let mut visited = state.visit_expr(expr);
-                    state.place_template_expression_comments(
-                        tag_start,
-                        tag_end,
-                        expr,
-                        &mut visited,
-                    );
+                    if let (Some(start), Some(end)) = (expr.start(), expr.end()) {
+                        state.place_template_expression_comments(
+                            (tag_start + 1, tag_end - 1),
+                            (start, end),
+                            &mut visited,
+                        );
+                    }
                     let escaped = state.b.call("$.escape", vec![visited]);
                     exprs.push(escaped);
                     quasis.push(String::new());
@@ -775,7 +776,7 @@ fn flush_sequence<'a>(sequence: &[SeqNode<'_>], state: &mut ServerTransformState
                         let last = quasis.last_mut().unwrap();
                         last.push_str(&escape_html(&rendered));
                     }
-                    state.carry_template_expression_comments(tag_start, tag_end);
+                    state.defer_template_expression_comments((tag_start + 1, tag_end - 1));
                     continue;
                 }
                 // SSR constant-folding (`scope.evaluate`): upstream's
@@ -793,11 +794,18 @@ fn flush_sequence<'a>(sequence: &[SeqNode<'_>], state: &mut ServerTransformState
                         let last = quasis.last_mut().unwrap();
                         last.push_str(&escape_html(&content));
                     }
-                    state.carry_template_expression_comments(tag_start, tag_end);
+                    state.defer_template_expression_comments((tag_start + 1, tag_end - 1));
                     continue;
                 }
 
                 let mut visited = state.visit_expr(expr);
+                if let (Some(start), Some(end)) = (expr.start(), expr.end()) {
+                    state.place_template_expression_comments(
+                        (tag_start + 1, tag_end - 1),
+                        (start, end),
+                        &mut visited,
+                    );
+                }
                 if !state
                     .expr_source(expr)
                     .is_some_and(|src| read_loses_its_location(state, src))

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/evaluate.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/evaluate.rs
@@ -707,7 +707,7 @@ fn push_code_point(n: f64, units: &mut Vec<u16>) -> Option<()> {
 
 /// Returns `Some((marker, computed))` where `computed` is `Some(value)` when
 /// all arguments are known and the function is computable.
-pub(crate) fn eval_global_call(keypath: &str, args: &[Evaluation]) -> Option<EvalValue> {
+fn eval_global_call(keypath: &str, args: &[Evaluation]) -> Option<EvalValue> {
     let nums = || -> Option<Vec<f64>> {
         args.iter()
             .map(|e| e.known_value().and_then(to_number))
@@ -785,15 +785,15 @@ pub(crate) fn eval_global_call(keypath: &str, args: &[Evaluation]) -> Option<Eva
         "Number" => {
             if args.is_empty() {
                 Some(0.0)
-            } else if !all_known {
-                None
-            } else if let Some(EvalValue::BigInt(v)) = args[0].known_value() {
-                // `Number(1n)` is ToNumber on a bigint, which is defined —
-                // unlike the arithmetic operators, which throw on one, so
-                // `to_number` is right to refuse it.
-                Some(*v as f64)
+            } else if all_known {
+                // `Number()` is an explicit conversion, so unlike every
+                // implicit `ToNumber` above it accepts a bigint — and rounds.
+                match args[0].known_value() {
+                    Some(EvalValue::BigInt(v)) => Some(*v as f64),
+                    other => other.and_then(to_number),
+                }
             } else {
-                num_at(0)
+                None
             }
         }
         "Number.parseFloat" => str_at(0).map(|s| js_parse_float(&s)),
@@ -806,7 +806,6 @@ pub(crate) fn eval_global_call(keypath: &str, args: &[Evaluation]) -> Option<Eva
             // These return booleans, but upstream's table marks them NUMBER.
             // None of them coerces: a missing or non-number argument is `false`.
             if !all_known {
-                // Falls through to the NUMBER marker, as upstream's `else` does.
                 return Some(EvalValue::NumberMarker);
             }
             let b = match args.first().and_then(|e| e.known_value()) {
@@ -870,9 +869,7 @@ fn js_pow(base: f64, exponent: f64) -> f64 {
     base.powf(exponent)
 }
 
-/// `Math.round` — half UP, not Rust's half-away-from-zero. The doubles just
-/// under `0.5` are the exception the naive `(n + 0.5).floor()` gets wrong:
-/// adding `0.5` rounds them up to exactly `1`.
+/// `Math.round` — half UP, not Rust's half-away-from-zero.
 fn js_round(n: f64) -> f64 {
     if !n.is_finite() || n == 0.0 {
         return n;
@@ -916,7 +913,6 @@ fn js_parse_float(s: &str) -> f64 {
     if i == digits_start || (i == digits_start + 1 && b[digits_start] == b'.') {
         return f64::NAN;
     }
-    // An exponent counts only when it is complete.
     if i < b.len() && (b[i] == b'e' || b[i] == b'E') {
         let mut j = i + 1;
         if j < b.len() && (b[j] == b'+' || b[j] == b'-') {
@@ -933,8 +929,7 @@ fn js_parse_float(s: &str) -> f64 {
     t[..i].parse::<f64>().unwrap_or(f64::NAN)
 }
 
-/// `Number.parseInt`: the longest prefix of digits in `radix`, defaulting to
-/// 16 for an `0x` prefix and 10 otherwise.
+/// `Number.parseInt`: the longest prefix of digits in `radix`.
 fn js_parse_int(s: &str, radix: f64) -> f64 {
     let t = s.trim_start_matches(js_whitespace);
     let mut b = t.as_bytes();
@@ -970,8 +965,6 @@ fn js_parse_int(s: &str, radix: f64) -> f64 {
         return f64::NAN;
     }
     let text = &t[t.len() - b.len()..][..digits];
-    // Accumulating in `f64` rounds at every step; V8 converts the whole digit
-    // string once, so `parseInt('9'.repeat(24))` is `1e24` and not `1.0000…3e24`.
     let value = if radix == 10 {
         text.parse::<f64>().unwrap_or(f64::NAN)
     } else {
@@ -995,8 +988,6 @@ fn js_parse_int(s: &str, radix: f64) -> f64 {
     sign * value
 }
 
-/// The `StrWhiteSpace` production, which `parseInt` / `parseFloat` skip. Rust's
-/// `char::is_whitespace` is the `White_Space` property, which admits U+0085.
 fn js_whitespace(c: char) -> bool {
     matches!(
         c,
@@ -1017,15 +1008,12 @@ fn js_whitespace(c: char) -> bool {
     ) || ('\u{2000}'..='\u{200a}').contains(&c)
 }
 
-/// [`eval_global_call`] applied to argument values a caller has already folded.
-///
-/// Upstream keeps ONE `globals` table (`scope.js`), whose entries pair a type
-/// marker with the real JS function; the client's constant folder carried a
-/// second copy holding eight `Math.*` names, so `String('a')` and
-/// `Math.trunc(1.5)` folded on the server and not on the client.
+/// The `globals` fold over arguments that are already concrete values. The
+/// client's constant folder asks the same question, and a second table there
+/// would be a second answer to it.
 pub(crate) fn eval_known_global_call(keypath: &str, args: &[EvalValue]) -> Option<EvalValue> {
-    let evaluations: Vec<Evaluation> = args.iter().cloned().map(Evaluation::single).collect();
-    eval_global_call(keypath, &evaluations)
+    let args: Vec<Evaluation> = args.iter().cloned().map(Evaluation::single).collect();
+    eval_global_call(keypath, &args)
 }
 
 fn is_global_keypath(keypath: &str) -> bool {
@@ -1406,31 +1394,6 @@ impl<'a> EvalCtx<'a> {
 
         static DEBUG_EVAL: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
         if *DEBUG_EVAL.get_or_init(|| std::env::var_os("DEBUG_EVAL").is_some()) {
-            // Print the UNFILTERED candidates too: an empty `bindings` is the
-            // interesting state, and a loop over it says nothing about why.
-            if let Some(a) = self.analysis {
-                let template_scopes = self
-                    .template_scopes_cache
-                    .get()
-                    .cloned()
-                    .unwrap_or_default();
-                eprintln!(
-                    "[evaluate] name={name} current_scope={:?} instance_scope={} kept={}",
-                    self.current_scope_index,
-                    a.root.instance_scope_index,
-                    bindings.len()
-                );
-                for b in a.root.bindings.iter().filter(|b| b.name == name) {
-                    eprintln!(
-                        "[evaluate]   cand scope={} template_scope={} reachable={} depth={:?} kind={:?}",
-                        b.scope_index,
-                        template_scopes.contains(&b.scope_index),
-                        self.template_binding_is_reachable(b.scope_index),
-                        self.scope_chain_depth(b.scope_index),
-                        b.kind
-                    );
-                }
-            }
             for b in &bindings {
                 eprintln!(
                     "[evaluate] name={} kind={:?} scope={} decl_start={:?} updated={} initial={:?} initial_type={:?}",
@@ -1571,311 +1534,445 @@ impl<'a> EvalCtx<'a> {
     /// Core evaluator over estree-JSON, mirroring upstream's `Evaluation`
     /// constructor switch.
     pub(crate) fn evaluate_estree(&self, node: &Value, depth: u8) -> Evaluation {
-        if depth > MAX_DEPTH {
-            return Evaluation::unknown();
+        evaluate_estree(self, node, depth)
+    }
+}
+
+/// The only two things the `scope.evaluate` recursion asks of its environment.
+/// Splitting them out lets the server generator and the client transform share
+/// ONE port of upstream's `Evaluation` walk with two identifier resolvers.
+pub(crate) trait EvalScope {
+    /// Upstream `scope.evaluate`'s `Identifier` case. `node` is the estree node
+    /// (its `start` lets a resolver replay Phase 2's scope-correct lookup);
+    /// `name` is its `name` field.
+    fn evaluate_identifier(&self, node: &Value, name: &str, depth: u8) -> Evaluation;
+
+    /// Upstream `get_global_keypath` requires `scope.get(name) === null`.
+    fn identifier_has_binding(&self, name: &str) -> bool;
+
+    /// Whether `<name> = $props.id()` appears in the source. The analyzer keeps
+    /// no `initial` for that shape, so only a resolver with the source text can
+    /// answer it; the client resolver has `analysis.props_id` instead.
+    fn binding_initial_is_props_id(&self, _name: &str) -> bool {
+        false
+    }
+}
+
+impl EvalScope for EvalCtx<'_> {
+    fn evaluate_identifier(&self, _node: &Value, name: &str, depth: u8) -> Evaluation {
+        EvalCtx::evaluate_identifier(self, name, depth)
+    }
+
+    fn identifier_has_binding(&self, name: &str) -> bool {
+        EvalCtx::identifier_has_binding(self, name)
+    }
+
+    fn binding_initial_is_props_id(&self, name: &str) -> bool {
+        EvalCtx::binding_initial_is_props_id(self, name)
+    }
+}
+
+/// Port of upstream `Evaluation`'s expression walk (`phases/scope.js`).
+pub(crate) fn evaluate_estree<S: EvalScope + ?Sized>(
+    scope: &S,
+    node: &Value,
+    depth: u8,
+) -> Evaluation {
+    if depth > MAX_DEPTH {
+        return Evaluation::unknown();
+    }
+    let Some(ty) = node_type(node) else {
+        return Evaluation::unknown();
+    };
+
+    match ty {
+        "Literal" => {
+            if let Some(digits) = node.get("bigint").and_then(|b| b.as_str()) {
+                return match digits.parse::<i128>() {
+                    Ok(v) => Evaluation::single(EvalValue::BigInt(v)),
+                    Err(_) => Evaluation::unknown(),
+                };
+            }
+            // A regex stringifies to its source, but its value is still an object.
+            if let Some(regex) = node.get("regex") {
+                let pattern = regex.get("pattern").and_then(|p| p.as_str()).unwrap_or("");
+                let flags = regex.get("flags").and_then(|f| f.as_str()).unwrap_or("");
+                return Evaluation::single(EvalValue::Regex(format!("/{}/{}", pattern, flags)));
+            }
+            match node.get("value") {
+                Some(Value::String(s)) => Evaluation::single(EvalValue::Str(s.clone())),
+                Some(Value::Number(n)) => {
+                    Evaluation::single(EvalValue::Num(n.as_f64().unwrap_or(f64::NAN)))
+                }
+                Some(Value::Bool(b)) => Evaluation::single(EvalValue::Bool(*b)),
+                Some(Value::Null) => Evaluation::single(EvalValue::Null),
+                _ => Evaluation::unknown(),
+            }
         }
-        let Some(ty) = node_type(node) else {
-            return Evaluation::unknown();
-        };
 
-        match ty {
-            "Literal" => {
-                if let Some(digits) = node.get("bigint").and_then(|b| b.as_str()) {
-                    return match digits.parse::<i128>() {
-                        Ok(v) => Evaluation::single(EvalValue::BigInt(v)),
-                        Err(_) => Evaluation::unknown(),
-                    };
+        "Identifier" => {
+            let Some(name) = node.get("name").and_then(|n| n.as_str()) else {
+                return Evaluation::unknown();
+            };
+            scope.evaluate_identifier(node, name, depth)
+        }
+
+        "BinaryExpression" => {
+            let (Some(left), Some(right), Some(op)) = (
+                node.get("left"),
+                node.get("right"),
+                node.get("operator").and_then(|o| o.as_str()),
+            ) else {
+                return Evaluation::unknown();
+            };
+            let a = evaluate_estree(scope, left, depth + 1);
+            let b = evaluate_estree(scope, right, depth + 1);
+            if let (Some(av), Some(bv)) = (a.known_value(), b.known_value()) {
+                let r = eval_binary(op, av, bv);
+                if !matches!(r, EvalValue::Unknown) {
+                    return Evaluation::single(r);
                 }
-                // A regex literal stringifies to its source but is an object, so
-                // it cannot be folded as a `Str` (`typeof` would print `string`).
-                if let Some(regex) = node.get("regex") {
-                    let pattern = regex.get("pattern").and_then(|p| p.as_str()).unwrap_or("");
-                    let flags = regex.get("flags").and_then(|f| f.as_str()).unwrap_or("");
-                    return Evaluation::single(EvalValue::Regex(format!("/{}/{}", pattern, flags)));
-                }
-                match node.get("value") {
-                    Some(Value::String(s)) => Evaluation::single(EvalValue::Str(s.clone())),
-                    Some(Value::Number(n)) => {
-                        Evaluation::single(EvalValue::Num(n.as_f64().unwrap_or(f64::NAN)))
-                    }
-                    Some(Value::Bool(b)) => Evaluation::single(EvalValue::Bool(*b)),
-                    Some(Value::Null) => Evaluation::single(EvalValue::Null),
-                    _ => Evaluation::unknown(),
-                }
+                return Evaluation::unknown();
             }
-
-            "Identifier" => {
-                let Some(name) = node.get("name").and_then(|n| n.as_str()) else {
-                    return Evaluation::unknown();
-                };
-                self.evaluate_identifier(name, depth)
-            }
-
-            "BinaryExpression" => {
-                let (Some(left), Some(right), Some(op)) = (
-                    node.get("left"),
-                    node.get("right"),
-                    node.get("operator").and_then(|o| o.as_str()),
-                ) else {
-                    return Evaluation::unknown();
-                };
-                let a = self.evaluate_estree(left, depth + 1);
-                let b = self.evaluate_estree(right, depth + 1);
-                if let (Some(av), Some(bv)) = (a.known_value(), b.known_value()) {
-                    let r = eval_binary(op, av, bv);
-                    if !matches!(r, EvalValue::Unknown) {
-                        return Evaluation::single(r);
-                    }
-                    return Evaluation::unknown();
+            // Partial knowledge → type markers (mirrors upstream)
+            let mut ev = Evaluation::new();
+            match op {
+                "!=" | "!==" | "<" | "<=" | ">" | ">=" | "==" | "===" | "in" | "instanceof" => {
+                    ev.add(EvalValue::Bool(true));
+                    ev.add(EvalValue::Bool(false));
                 }
-                // Partial knowledge → type markers (mirrors upstream)
-                let mut ev = Evaluation::new();
-                match op {
-                    "!=" | "!==" | "<" | "<=" | ">" | ">=" | "==" | "===" | "in" | "instanceof" => {
-                        ev.add(EvalValue::Bool(true));
-                        ev.add(EvalValue::Bool(false));
-                    }
-                    "%" | "&" | "*" | "**" | "-" | "/" | "<<" | ">>" | ">>>" | "^" | "|" => {
+                "%" | "&" | "*" | "**" | "-" | "/" | "<<" | ">>" | ">>>" | "^" | "|" => {
+                    ev.add(EvalValue::NumberMarker);
+                }
+                "+" => {
+                    let a_is_string = a.is_string();
+                    let b_is_string = b.is_string();
+                    let a_is_number = a
+                        .values
+                        .iter()
+                        .all(|v| matches!(v, EvalValue::Num(_) | EvalValue::NumberMarker))
+                        && !a.values.is_empty();
+                    let b_is_number = b
+                        .values
+                        .iter()
+                        .all(|v| matches!(v, EvalValue::Num(_) | EvalValue::NumberMarker))
+                        && !b.values.is_empty();
+                    if a_is_string || b_is_string {
+                        ev.add(EvalValue::StringMarker);
+                    } else if a_is_number && b_is_number {
+                        ev.add(EvalValue::NumberMarker);
+                    } else {
+                        ev.add(EvalValue::StringMarker);
                         ev.add(EvalValue::NumberMarker);
                     }
-                    "+" => {
-                        let a_is_string = a.is_string();
-                        let b_is_string = b.is_string();
-                        let a_is_number = a
-                            .values
-                            .iter()
-                            .all(|v| matches!(v, EvalValue::Num(_) | EvalValue::NumberMarker))
-                            && !a.values.is_empty();
-                        let b_is_number = b
-                            .values
-                            .iter()
-                            .all(|v| matches!(v, EvalValue::Num(_) | EvalValue::NumberMarker))
-                            && !b.values.is_empty();
-                        if a_is_string || b_is_string {
-                            ev.add(EvalValue::StringMarker);
-                        } else if a_is_number && b_is_number {
-                            ev.add(EvalValue::NumberMarker);
-                        } else {
-                            ev.add(EvalValue::StringMarker);
-                            ev.add(EvalValue::NumberMarker);
-                        }
+                }
+                _ => ev.add(EvalValue::Unknown),
+            }
+            ev
+        }
+
+        "ConditionalExpression" => {
+            let (Some(test), Some(consequent), Some(alternate)) = (
+                node.get("test"),
+                node.get("consequent"),
+                node.get("alternate"),
+            ) else {
+                return Evaluation::unknown();
+            };
+            let t = evaluate_estree(scope, test, depth + 1);
+            let c = evaluate_estree(scope, consequent, depth + 1);
+            let a = evaluate_estree(scope, alternate, depth + 1);
+            let mut ev = Evaluation::new();
+            if let Some(tv) = t.known_value()
+                && let Some(truthy) = tv.truthy()
+            {
+                ev.extend(if truthy { c } else { a });
+                return ev;
+            }
+            ev.extend(c);
+            ev.extend(a);
+            ev
+        }
+
+        "LogicalExpression" => {
+            let (Some(left), Some(right), Some(op)) = (
+                node.get("left"),
+                node.get("right"),
+                node.get("operator").and_then(|o| o.as_str()),
+            ) else {
+                return Evaluation::unknown();
+            };
+            let a = evaluate_estree(scope, left, depth + 1);
+            let b = evaluate_estree(scope, right, depth + 1);
+            let mut ev = Evaluation::new();
+            if let Some(av) = a.known_value() {
+                let take_left = match op {
+                    "&&" => av.truthy().map(|t| !t),
+                    "||" => av.truthy(),
+                    "??" => av.is_nullish().map(|n| !n),
+                    _ => None,
+                };
+                match take_left {
+                    Some(true) => {
+                        ev.add(av.clone());
+                        return ev;
                     }
-                    _ => ev.add(EvalValue::Unknown),
+                    Some(false) => {
+                        ev.extend(b);
+                        return ev;
+                    }
+                    None => return Evaluation::unknown(),
                 }
-                ev
             }
+            ev.extend(a);
+            ev.extend(b);
+            ev
+        }
 
-            "ConditionalExpression" => {
-                let (Some(test), Some(consequent), Some(alternate)) = (
-                    node.get("test"),
-                    node.get("consequent"),
-                    node.get("alternate"),
-                ) else {
-                    return Evaluation::unknown();
+        "UnaryExpression" => {
+            let (Some(arg), Some(op)) = (
+                node.get("argument"),
+                node.get("operator").and_then(|o| o.as_str()),
+            ) else {
+                return Evaluation::unknown();
+            };
+            let a = evaluate_estree(scope, arg, depth + 1);
+            if let Some(av) = a.known_value() {
+                return match eval_unary(op, av) {
+                    EvalValue::Unknown => Evaluation::unknown(),
+                    v => Evaluation::single(v),
                 };
-                let t = self.evaluate_estree(test, depth + 1);
-                let c = self.evaluate_estree(consequent, depth + 1);
-                let a = self.evaluate_estree(alternate, depth + 1);
-                let mut ev = Evaluation::new();
-                if let Some(tv) = t.known_value()
-                    && let Some(truthy) = tv.truthy()
+            }
+            let mut ev = Evaluation::new();
+            match op {
+                "!" | "delete" => {
+                    ev.add(EvalValue::Bool(false));
+                    ev.add(EvalValue::Bool(true));
+                }
+                "+" | "-" | "~" => ev.add(EvalValue::NumberMarker),
+                "typeof" => ev.add(EvalValue::StringMarker),
+                "void" => ev.add(EvalValue::Undefined),
+                _ => ev.add(EvalValue::Unknown),
+            }
+            ev
+        }
+
+        "CallExpression" => {
+            let Some(callee) = node.get("callee") else {
+                return Evaluation::unknown();
+            };
+            let empty = Vec::new();
+            let args = node
+                .get("arguments")
+                .and_then(|a| a.as_array())
+                .unwrap_or(&empty);
+
+            if let Some((base, keypath)) = get_keypath(callee)
+                && !scope.identifier_has_binding(&base)
+            {
+                if is_rune(&keypath) {
+                    match keypath.as_str() {
+                        "$state" | "$state.raw" | "$derived" => {
+                            if let Some(arg) = args.first() {
+                                return evaluate_estree(scope, arg, depth + 1);
+                            }
+                            return Evaluation::single(EvalValue::Undefined);
+                        }
+                        "$props.id" => {
+                            return Evaluation::single(EvalValue::StringMarker);
+                        }
+                        "$effect.tracking" => {
+                            let mut ev = Evaluation::new();
+                            ev.add(EvalValue::Bool(false));
+                            ev.add(EvalValue::Bool(true));
+                            return ev;
+                        }
+                        "$derived.by" => {
+                            if let Some(arg) = args.first()
+                                && node_type(arg) == Some("ArrowFunctionExpression")
+                                && arg
+                                    .get("body")
+                                    .and_then(node_type)
+                                    .is_some_and(|t| t != "BlockStatement")
+                                && let Some(body) = arg.get("body")
+                            {
+                                return evaluate_estree(scope, body, depth + 1);
+                            }
+                            return Evaluation::unknown();
+                        }
+                        _ => return Evaluation::unknown(),
+                    }
+                }
+
+                if is_global_keypath(&keypath)
+                    && args.iter().all(|a| node_type(a) != Some("SpreadElement"))
                 {
-                    ev.extend(if truthy { c } else { a });
-                    return ev;
+                    let evaluated: Vec<Evaluation> = args
+                        .iter()
+                        .map(|a| evaluate_estree(scope, a, depth + 1))
+                        .collect();
+                    if let Some(v) = eval_global_call(&keypath, &evaluated) {
+                        return Evaluation::single(v);
+                    }
+                    return Evaluation::unknown();
                 }
-                ev.extend(c);
-                ev.extend(a);
-                ev
             }
 
-            "LogicalExpression" => {
-                let (Some(left), Some(right), Some(op)) = (
-                    node.get("left"),
-                    node.get("right"),
-                    node.get("operator").and_then(|o| o.as_str()),
-                ) else {
-                    return Evaluation::unknown();
-                };
-                let a = self.evaluate_estree(left, depth + 1);
-                let b = self.evaluate_estree(right, depth + 1);
-                let mut ev = Evaluation::new();
-                if let Some(av) = a.known_value() {
-                    let take_left = match op {
-                        "&&" => av.truthy().map(|t| !t),
-                        "||" => av.truthy(),
-                        "??" => av.is_nullish().map(|n| !n),
-                        _ => None,
-                    };
-                    match take_left {
-                        Some(true) => {
-                            ev.add(av.clone());
-                            return ev;
-                        }
-                        Some(false) => {
-                            ev.extend(b);
-                            return ev;
-                        }
+            Evaluation::unknown()
+        }
+
+        "TemplateLiteral" => {
+            let (Some(quasis), Some(exprs)) = (
+                node.get("quasis").and_then(|q| q.as_array()),
+                node.get("expressions").and_then(|e| e.as_array()),
+            ) else {
+                return Evaluation::unknown();
+            };
+            let cooked = |i: usize| -> Option<String> {
+                quasis
+                    .get(i)?
+                    .get("value")?
+                    .get("cooked")?
+                    .as_str()
+                    .map(String::from)
+            };
+            let Some(mut result) = cooked(0) else {
+                return Evaluation::unknown();
+            };
+            for (i, e) in exprs.iter().enumerate() {
+                let ev = evaluate_estree(scope, e, depth + 1);
+                if let Some(v) = ev.known_value().and_then(to_js_string) {
+                    result.push_str(&v);
+                    match cooked(i + 1) {
+                        Some(q) => result.push_str(&q),
                         None => return Evaluation::unknown(),
                     }
+                } else {
+                    return Evaluation::single(EvalValue::StringMarker);
                 }
-                ev.extend(a);
-                ev.extend(b);
-                ev
             }
-
-            "UnaryExpression" => {
-                let (Some(arg), Some(op)) = (
-                    node.get("argument"),
-                    node.get("operator").and_then(|o| o.as_str()),
-                ) else {
-                    return Evaluation::unknown();
-                };
-                let a = self.evaluate_estree(arg, depth + 1);
-                if let Some(av) = a.known_value() {
-                    return match eval_unary(op, av) {
-                        EvalValue::Unknown => Evaluation::unknown(),
-                        v => Evaluation::single(v),
-                    };
-                }
-                let mut ev = Evaluation::new();
-                match op {
-                    "!" | "delete" => {
-                        ev.add(EvalValue::Bool(false));
-                        ev.add(EvalValue::Bool(true));
-                    }
-                    "+" | "-" | "~" => ev.add(EvalValue::NumberMarker),
-                    "typeof" => ev.add(EvalValue::StringMarker),
-                    "void" => ev.add(EvalValue::Undefined),
-                    _ => ev.add(EvalValue::Unknown),
-                }
-                ev
-            }
-
-            "CallExpression" => {
-                let Some(callee) = node.get("callee") else {
-                    return Evaluation::unknown();
-                };
-                let empty = Vec::new();
-                let args = node
-                    .get("arguments")
-                    .and_then(|a| a.as_array())
-                    .unwrap_or(&empty);
-
-                if let Some((base, keypath)) = get_keypath(callee)
-                    && !self.identifier_has_binding(&base)
-                {
-                    if is_rune(&keypath) {
-                        match keypath.as_str() {
-                            "$state" | "$state.raw" | "$derived" => {
-                                if let Some(arg) = args.first() {
-                                    return self.evaluate_estree(arg, depth + 1);
-                                }
-                                return Evaluation::single(EvalValue::Undefined);
-                            }
-                            "$props.id" => {
-                                return Evaluation::single(EvalValue::StringMarker);
-                            }
-                            "$effect.tracking" => {
-                                let mut ev = Evaluation::new();
-                                ev.add(EvalValue::Bool(false));
-                                ev.add(EvalValue::Bool(true));
-                                return ev;
-                            }
-                            "$derived.by" => {
-                                if let Some(arg) = args.first()
-                                    && node_type(arg) == Some("ArrowFunctionExpression")
-                                    && arg
-                                        .get("body")
-                                        .and_then(node_type)
-                                        .is_some_and(|t| t != "BlockStatement")
-                                    && let Some(body) = arg.get("body")
-                                {
-                                    return self.evaluate_estree(body, depth + 1);
-                                }
-                                return Evaluation::unknown();
-                            }
-                            _ => return Evaluation::unknown(),
-                        }
-                    }
-
-                    if is_global_keypath(&keypath)
-                        && args.iter().all(|a| node_type(a) != Some("SpreadElement"))
-                    {
-                        let evaluated: Vec<Evaluation> = args
-                            .iter()
-                            .map(|a| self.evaluate_estree(a, depth + 1))
-                            .collect();
-                        if let Some(v) = eval_global_call(&keypath, &evaluated) {
-                            return Evaluation::single(v);
-                        }
-                        return Evaluation::unknown();
-                    }
-                }
-
-                Evaluation::unknown()
-            }
-
-            "TemplateLiteral" => {
-                let (Some(quasis), Some(exprs)) = (
-                    node.get("quasis").and_then(|q| q.as_array()),
-                    node.get("expressions").and_then(|e| e.as_array()),
-                ) else {
-                    return Evaluation::unknown();
-                };
-                let cooked = |i: usize| -> Option<String> {
-                    quasis
-                        .get(i)?
-                        .get("value")?
-                        .get("cooked")?
-                        .as_str()
-                        .map(String::from)
-                };
-                let Some(mut result) = cooked(0) else {
-                    return Evaluation::unknown();
-                };
-                for (i, e) in exprs.iter().enumerate() {
-                    let ev = self.evaluate_estree(e, depth + 1);
-                    if let Some(v) = ev.known_value().and_then(to_js_string) {
-                        result.push_str(&v);
-                        match cooked(i + 1) {
-                            Some(q) => result.push_str(&q),
-                            None => return Evaluation::unknown(),
-                        }
-                    } else {
-                        return Evaluation::single(EvalValue::StringMarker);
-                    }
-                }
-                Evaluation::single(EvalValue::Str(result))
-            }
-
-            "MemberExpression" => {
-                if let Some((base, keypath)) = get_keypath(node)
-                    && !self.identifier_has_binding(&base)
-                    && let Some(v) = global_constant(&keypath)
-                {
-                    return Evaluation::single(EvalValue::Num(v));
-                }
-                Evaluation::unknown()
-            }
-
-            "ArrowFunctionExpression" | "FunctionExpression" | "FunctionDeclaration" => {
-                Evaluation::single(EvalValue::FunctionMarker)
-            }
-
-            // TypeScript wrappers: evaluate the inner expression.
-            "TSAsExpression"
-            | "TSNonNullExpression"
-            | "TSSatisfiesExpression"
-            | "TSTypeAssertion"
-            | "ParenthesizedExpression" => {
-                if let Some(inner) = node.get("expression") {
-                    return self.evaluate_estree(inner, depth + 1);
-                }
-                Evaluation::unknown()
-            }
-
-            _ => Evaluation::unknown(),
+            Evaluation::single(EvalValue::Str(result))
         }
+
+        "MemberExpression" => {
+            if let Some((base, keypath)) = get_keypath(node)
+                && !scope.identifier_has_binding(&base)
+                && let Some(v) = global_constant(&keypath)
+            {
+                return Evaluation::single(EvalValue::Num(v));
+            }
+            Evaluation::unknown()
+        }
+
+        "ArrowFunctionExpression" | "FunctionExpression" | "FunctionDeclaration" => {
+            Evaluation::single(EvalValue::FunctionMarker)
+        }
+
+        // TypeScript wrappers: evaluate the inner expression.
+        "TSAsExpression"
+        | "TSNonNullExpression"
+        | "TSSatisfiesExpression"
+        | "TSTypeAssertion"
+        | "ParenthesizedExpression" => {
+            if let Some(inner) = node.get("expression") {
+                return evaluate_estree(scope, inner, depth + 1);
+            }
+            Evaluation::unknown()
+        }
+
+        _ => Evaluation::unknown(),
+    }
+}
+
+/// Port of upstream `scope.evaluate`'s recursion into `binding.initial`
+/// (`phases/scope.js`, the `Identifier` case).
+pub(crate) fn evaluate_binding_initial<S: EvalScope + ?Sized>(
+    scope: &S,
+    binding: &crate::compiler::phases::phase2_analyze::scope::Binding,
+    depth: u8,
+) -> Evaluation {
+    use BindingKind::*;
+
+    // Props (and prop-like bindings) are never known.
+    if matches!(binding.kind, Prop | BindableProp | RestProp) {
+        return Evaluation::unknown();
+    }
+    // Template-loop bindings: upstream marks each indexes NUMBER and
+    // items/await/snippet params unknown.
+    if matches!(binding.kind, EachIndex) {
+        return Evaluation::single(EvalValue::NumberMarker);
+    }
+    if matches!(
+        binding.kind,
+        EachItem | AwaitThen | AwaitCatch | SnippetParam | Let
+    ) {
+        return Evaluation::unknown();
+    }
+    if binding.initial_node_type.as_deref() == Some("SnippetBlock")
+        || binding.initial_node_type.as_deref() == Some("ImportDeclaration")
+    {
+        return Evaluation::unknown();
+    }
+    if binding.is_updated() {
+        return Evaluation::unknown();
+    }
+    // `$state()` / `$state.raw()` with no argument evaluates to
+    // `undefined` (upstream scope.js CallExpression rune case: no
+    // argument → `values.add(undefined)`). The analyzer stores the rune
+    // ARGUMENT as `initial`, so a no-arg rune leaves both `initial` and
+    // `initial_node_type` unset — distinguishable from a non-literal
+    // argument, which sets `initial_node_type`.
+    if matches!(binding.kind, State | RawState)
+        && binding.initial.is_none()
+        && binding.initial_node_type.is_none()
+    {
+        return Evaluation::single(EvalValue::Undefined);
+    }
+    let Some(initial) = binding.initial.as_deref() else {
+        // A template-literal initializer (`const w = `…${x}…``) is always a
+        // defined string (upstream scope.js `TemplateLiteral` → STRING marker),
+        // so reads of it must NOT be wrapped in `$.stringify(...)`. Its quasis
+        // and expressions still fold to a concrete value when every
+        // interpolation is known, so try that before settling for the marker.
+        if binding.initial_node_type.as_deref() == Some("TemplateLiteral") {
+            if depth < MAX_DEPTH
+                && let Some(init_json) = binding.init_expr_json_parsed()
+            {
+                return evaluate_estree(scope, init_json, depth + 1);
+            }
+            return Evaluation::single(EvalValue::StringMarker);
+        }
+        // The analyzer does not capture non-literal initials in
+        // `binding.initial`, but upstream's `scope.evaluate` still knows
+        // `const uid = $props.id()` is a (defined) string — `$props.id`
+        // returns STRING (scope.js `case '$props.id'`). Recognize the
+        // `<name> = $props.id()` initializer from the source text.
+        if matches!(binding.kind, Normal) && scope.binding_initial_is_props_id(&binding.name) {
+            return Evaluation::single(EvalValue::StringMarker);
+        }
+        // A non-literal initializer is kept as AST JSON instead; upstream's
+        // `scope.evaluate` recurses into the init node whatever its shape.
+        if !matches!(binding.kind, Derived)
+            && depth < MAX_DEPTH
+            && let Some(init_json) = binding.init_expr_json_parsed()
+        {
+            return evaluate_estree(scope, init_json, depth + 1);
+        }
+        return Evaluation::unknown();
+    };
+
+    let trimmed = initial.trim_start();
+    if trimmed.starts_with('{') {
+        // estree-JSON dump (from `$derived(...)` / `{@const ...}` initials)
+        if let Ok(json) = serde_json::from_str::<Value>(initial) {
+            return evaluate_estree(scope, &json, depth + 1);
+        }
+        return Evaluation::unknown();
+    }
+
+    match parse_literal_text(initial) {
+        Some(v) => Evaluation::single(v),
+        None => Evaluation::unknown(),
     }
 }
 

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/helpers.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/helpers.rs
@@ -1060,6 +1060,26 @@ fn is_whole_string_literal(value: &str) -> bool {
     false
 }
 
+/// ECMA-262 TV/TRV line-terminator normalisation for a template literal body.
+fn normalize_template_line_terminators(body: &str) -> std::borrow::Cow<'_, str> {
+    if memchr::memchr(b'\r', body.as_bytes()).is_none() {
+        return std::borrow::Cow::Borrowed(body);
+    }
+    let mut out = String::with_capacity(body.len());
+    let mut rest = body;
+    while let Some(i) = memchr::memchr(b'\r', rest.as_bytes()) {
+        out.push_str(&rest[..i]);
+        out.push('\n');
+        rest = if rest.as_bytes().get(i + 1) == Some(&b'\n') {
+            &rest[i + 2..]
+        } else {
+            &rest[i + 1..]
+        };
+    }
+    out.push_str(rest);
+    std::borrow::Cow::Owned(out)
+}
+
 /// A literal's source text as the JS VALUE it denotes. `'1'` and `1` are two
 /// different values that render as the same text, and `+` is the operator that
 /// can tell them apart.
@@ -1068,8 +1088,13 @@ fn literal_eval_value(value: &str) -> Option<EvalValue> {
         // The cooked string, matching upstream's `scope.evaluate`; the emitter
         // re-escapes it for the quasi.
         let content = &value[1..value.len() - 1];
+        let content = if value.as_bytes()[0] == b'`' {
+            normalize_template_line_terminators(content)
+        } else {
+            std::borrow::Cow::Borrowed(content)
+        };
         return Some(EvalValue::Str(
-            crate::compiler::phases::phase3_transform::client::visitors::shared::utils::cook_string_literal(content),
+            crate::compiler::phases::phase3_transform::client::visitors::shared::utils::cook_string_literal(&content),
         ));
     }
     match value {

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/mod.rs
@@ -26,7 +26,7 @@ use super::js_ast::nodes::{JsImportDeclaration, JsImportSpecifier, JsStatement};
 use crate::ast::template::Root;
 use crate::compiler::CompileOptions;
 use crate::compiler::phases::phase2_analyze::ComponentAnalysis;
-use crate::compiler::phases::phase3_transform::shared::js_scan::is_ident_byte;
+use crate::compiler::phases::phase3_transform::shared::{js_scan, rune_shadow};
 use memchr::memmem;
 use std::cell::RefCell;
 
@@ -263,16 +263,11 @@ fn code_match_positions(haystack: &str, needle: &[u8]) -> Vec<usize> {
             }
             _ => {}
         }
-        if i + needle.len() <= n && &bytes[i..i + needle.len()] == needle {
-            // A rune name in the property slot of `o.$effect(cb)` is a method
-            // call, not a rune — upstream's `get_global_keypath` walks a member
-            // chain down to its BASE identifier, which this one never is. Same
-            // rule one byte over for `a$effect(`, a single longer identifier.
-            let is_rune_head = needle.first() != Some(&b'$')
-                || (!last_significant_is_dot(bytes, i) && (i == 0 || !is_ident_byte(bytes[i - 1])));
-            if is_rune_head {
-                out.push(i);
-            }
+        if i + needle.len() <= n
+            && &bytes[i..i + needle.len()] == needle
+            && (!rune_needle || js_scan::is_rune_call_at(bytes, i, needle, &before))
+        {
+            out.push(i);
         }
         if !bytes[i].is_ascii_whitespace() {
             before.push_code_byte(bytes, i);
@@ -462,10 +457,10 @@ fn kept_comments_of_removed_range(source: &str, start: usize, end: usize) -> Str
 /// `CallExpression` visitor at every expression depth.
 fn lower_module_dev_inspect(source: &str) -> String {
     use super::client::find_matching_paren;
-    use super::shared::js_scan::find_code;
+    use super::shared::js_scan::find_rune_code;
 
     let mut result = source.to_string();
-    while let Some(pos) = find_code(result.as_bytes(), b"$inspect(") {
+    while let Some(pos) = find_rune_code(result.as_bytes(), b"$inspect(") {
         let args_start = pos + b"$inspect(".len();
         let Some(args_len) = find_matching_paren(&result[args_start..]) else {
             break;
@@ -568,7 +563,7 @@ fn previous_significant_code_byte(s: &str, pos: usize) -> Option<u8> {
     last
 }
 
-fn strip_effects_from_source(source: &str) -> String {
+fn strip_effects_from_source(source: &str, binds_rune_name: bool) -> String {
     use super::client::find_matching_paren;
 
     // A `$effect` that resolves to a declaration (`function f($effect) { $effect(1) }`)

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/shared/class_body.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/shared/class_body.rs
@@ -156,11 +156,25 @@ pub(crate) fn find_class_header(source: &str) -> Option<ClassHeader> {
     let mut seen_after_keyword = false;
     let mut nesting = 0i32;
     let mut angle = 0i32;
+    let mut heritage_start: Option<usize> = None;
+    let mut nested_classes = 0u32;
+    let mut skip_depth = 0i32;
     // One past the last byte of a multi-byte JS whitespace character, whose
     // continuation bytes `is_ident_byte` would otherwise read as identifier.
     let mut whitespace_until = 0usize;
 
     for (i, byte) in js_scan::code_bytes(bytes) {
+        if skip_depth > 0 {
+            match byte {
+                b'{' => skip_depth += 1,
+                b'}' => skip_depth -= 1,
+                _ => {}
+            }
+            run_start = None;
+            prev_end = i + 1;
+            prev_sig = Some(byte);
+            continue;
+        }
         // `class\u{a0}Foo` separates two tokens exactly as `class Foo` does, and
         // `\u{b}` is JS whitespace that `is_ascii_whitespace` excludes (#3470).
         let is_whitespace = if i < whitespace_until {

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/shared/js_scan.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/shared/js_scan.rs
@@ -423,7 +423,12 @@ pub(crate) fn skip_ws_and_comments_back(
 /// `` ` ``, `/`), so testing its first byte settles the whole match.
 /// This is also used by production scans whose needles are not rune keypaths.
 pub(crate) fn find_code(bytes: &[u8], needle: &[u8]) -> Option<usize> {
-    find_code_filtered(bytes, needle, |_, _| true)
+    find_code_filtered(bytes, needle, 0, |_, _| true)
+}
+
+#[cfg(test)]
+fn find_code_from(bytes: &[u8], needle: &[u8], from: usize) -> Option<usize> {
+    find_code_filtered(bytes, needle, from, |_, _| true)
 }
 
 /// [`find_code`], but only for a match that can head a rune keypath.
@@ -436,28 +441,55 @@ pub(crate) fn find_code(bytes: &[u8], needle: &[u8]) -> Option<usize> {
 /// accepts. The identifier-character test is the same rule one byte over:
 /// `a$state(` is a single identifier that merely ends in the rune's spelling.
 pub(crate) fn find_rune_code(bytes: &[u8], needle: &[u8]) -> Option<usize> {
-    find_code_filtered(bytes, needle, |at, significant| {
-        // `.` / `?.` — a member property. Read off the last SIGNIFICANT byte so
-        // `o\n\t.$state(` and `o /*c*/ . $state(` answer the same as `o.$state(`.
-        if significant == Some(b'.') {
-            return false;
+    debug_assert!(
+        !needle
+            .iter()
+            .any(|b| matches!(b, b'\'' | b'"' | b'`' | b'/')),
+        "find_rune_code needs a needle that cannot open an opaque run"
+    );
+    let mut candidates = memchr::memmem::find_iter(bytes, needle);
+    let mut candidate = candidates.next()?;
+    let mut i = 0usize;
+    let mut prev: Option<u8> = None;
+    let mut before = PrevChars::default();
+    while i < bytes.len() {
+        if let Some((next, is_comment)) = skip_opaque(bytes, i, prev) {
+            while candidate < next {
+                candidate = candidates.next()?;
+            }
+            if !is_comment {
+                prev = Some(b'x');
+                before.push_opaque();
+            }
+            i = next;
+            continue;
         }
-        // A longer identifier ending in the rune's spelling. This one reads the
-        // IMMEDIATE predecessor: the significant byte skips whitespace, and
-        // `return $state(1)` would otherwise be rejected on the `n` of `return`.
-        if at > 0 && is_ident_byte(bytes[at - 1]) {
-            return false;
+        if i == candidate {
+            if is_rune_call_at(bytes, candidate, needle, &before) {
+                return Some(candidate);
+            }
+            candidate = candidates.next()?;
         }
-        // `function $inspect(v) {}` declares the name; the `(` belongs to the
-        // parameter list, not to a call. Left un-tested, the `$inspect(` removal
-        // deleted the name and emitted `function  {` — text no parser accepts.
-        preceding_word(bytes, at) != Some(b"function")
-    })
+        if !bytes[i].is_ascii_whitespace() {
+            prev = Some(bytes[i]);
+            before.push_code_byte(bytes, i);
+        }
+        i += 1;
+    }
+    None
+}
+
+/// Whether a rune-shaped match names a rune call rather than a property,
+/// longer identifier, function declaration, or class/object method.
+pub(crate) fn is_rune_call_at(bytes: &[u8], at: usize, needle: &[u8], before: &PrevChars) -> bool {
+    before.starts_a_rune(bytes, at)
+        && !is_method_definition(bytes, at, needle, before)
+        && preceding_word(bytes, at) != Some(b"function")
 }
 
 /// The identifier token ending immediately before `at`, skipping ASCII
-/// whitespace. Reads bytes only: a comment between the keyword and the name
-/// makes this `None`, which leaves the caller's answer where it already was.
+/// whitespace. A comment between the keyword and the name deliberately yields
+/// `None`; the shared scanner has already skipped that opaque region.
 fn preceding_word(bytes: &[u8], at: usize) -> Option<&[u8]> {
     let mut end = at;
     while end > 0 && bytes[end - 1].is_ascii_whitespace() {
@@ -470,11 +502,58 @@ fn preceding_word(bytes: &[u8], at: usize) -> Option<&[u8]> {
     (start < end).then(|| &bytes[start..end])
 }
 
+#[cfg(test)]
+fn find_rune_call(bytes: &[u8], needle: &[u8]) -> Option<usize> {
+    find_rune_code(bytes, needle)
+}
+
+fn is_method_definition(bytes: &[u8], at: usize, needle: &[u8], before: &PrevChars) -> bool {
+    if !before.could_start_a_member() {
+        return false;
+    }
+    let Some(after_params) = end_of_parens(bytes, at + needle.len() - 1) else {
+        return false;
+    };
+    next_code_byte(bytes, after_params) == Some(b'{')
+}
+
+fn end_of_parens(bytes: &[u8], open: usize) -> Option<usize> {
+    debug_assert_eq!(bytes.get(open), Some(&b'('));
+    let mut depth = 0usize;
+    let mut prev: Option<u8> = None;
+    let mut i = open;
+    while i < bytes.len() {
+        if let Some((next, is_comment)) = skip_opaque(bytes, i, prev) {
+            if !is_comment {
+                prev = Some(b'x');
+            }
+            i = next;
+            continue;
+        }
+        match bytes[i] {
+            b'(' => depth += 1,
+            b')' => {
+                depth -= 1;
+                if depth == 0 {
+                    return Some(i + 1);
+                }
+            }
+            _ => {}
+        }
+        if !bytes[i].is_ascii_whitespace() {
+            prev = Some(bytes[i]);
+        }
+        i += 1;
+    }
+    None
+}
+
 /// `accept(match_start, last_significant_code_byte_before_it)` decides whether a
 /// code match counts; a rejected one is skipped and scanning continues.
 fn find_code_filtered(
     bytes: &[u8],
     needle: &[u8],
+    from: usize,
     accept: impl Fn(usize, Option<u8>) -> bool,
 ) -> Option<usize> {
     debug_assert!(
@@ -573,13 +652,14 @@ impl PrevChars {
     /// Can a rune name start here? Not when the previous character continues an
     /// identifier, and not after the `.` of a member access — but `...` is a
     /// spread, whose operand may well be a rune call.
-    pub(crate) fn starts_a_rune(&self) -> bool {
-        match self.last {
-            None => true,
-            Some(c) if is_ident_char(c) => false,
-            Some('.') => self.before_last == Some('.'),
-            Some(_) => true,
+    pub(crate) fn starts_a_rune(&self, bytes: &[u8], at: usize) -> bool {
+        if self.last == Some('.') && self.before_last != Some('.') {
+            return false;
         }
+        std::str::from_utf8(&bytes[..at])
+            .ok()
+            .and_then(|prefix| prefix.chars().next_back())
+            .is_none_or(|c| !is_ident_char(c))
     }
 
     /// Could a class / object member start here? `get`, `set`, `async` and
@@ -615,8 +695,8 @@ fn is_js_whitespace(c: char) -> bool {
 #[cfg(test)]
 mod tests {
     use super::{
-        KEYWORDS_BEFORE_REGEX, contains_identifier, find_code, find_rune_code, skip_opaque,
-        slash_starts_regex_at,
+        KEYWORDS_BEFORE_REGEX, contains_identifier, find_code, find_code_from, find_rune_call,
+        find_rune_code, skip_opaque, slash_starts_regex_at,
     };
 
     #[test]

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/shared/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/shared/mod.rs
@@ -9,6 +9,7 @@ pub mod class_body;
 pub mod js_scan;
 pub mod offsets;
 pub mod rune_parens;
+pub mod rune_shadow;
 pub mod template;
 
 pub use template::*;

--- a/crates/rsvelte_core/tests/block_header_pattern_validation.rs
+++ b/crates/rsvelte_core/tests/block_header_pattern_validation.rs
@@ -159,7 +159,7 @@ const ACCEPTED: &[&str] = &[
     "{#each arr as { a /*c*/ }}{a}{/each}",
     "{#each arr /*c*/ as x}{x}{/each}",
     "{#each arr\n as \n x \n, \n i \n (x)\n}{x}{/each}",
-    "{#each arr as const as item}{item}{/each}",
+    "<script lang=\"ts\"></script>{#each arr as const as item}{item}{/each}",
     "{#await p then v}{v}{/await}",
     "{#await p then [a]}{a}{/await}",
     "{#await p then }w{/await}",

--- a/crates/rsvelte_core/tests/client_attribute_expression_comments_3214.rs
+++ b/crates/rsvelte_core/tests/client_attribute_expression_comments_3214.rs
@@ -30,7 +30,10 @@ const SCRIPT: &str = "<script>\n\tlet s = 'a';\n\tlet n = 0;\n\tconst f = (x) =>
 fn both(markup: &str, expected: &str) {
     for dev in [false, true] {
         let out = client(&format!("{SCRIPT}\n{markup}\n"), dev);
-        assert!(out.contains(expected), "dev={dev} {markup}\nwant {expected}\n{out}");
+        assert!(
+            out.contains(expected),
+            "dev={dev} {markup}\nwant {expected}\n{out}"
+        );
     }
 }
 
@@ -67,7 +70,10 @@ fn the_placement_does_not_depend_on_the_attribute() {
             "<div aria-label={/* c */ s}>x</div>",
             "$.set_attribute(div, /* c */ 'aria-label', s);",
         ),
-        ("<a href={/* c */ s}>x</a>", "$.set_attribute(a, /* c */ 'href', s);"),
+        (
+            "<a href={/* c */ s}>x</a>",
+            "$.set_attribute(a, /* c */ 'href', s);",
+        ),
         (
             "<img src={/* c */ s} alt=\"a\" />",
             "$.set_attribute(img, /* c */ 'src', s);",
@@ -81,7 +87,10 @@ fn the_placement_does_not_depend_on_the_attribute() {
 /// call breaks open — the same rule esrap applies to any argument list.
 #[test]
 fn a_line_comment_breaks_the_call_open() {
-    both("<div title={// c\n\ts}>x</div>", "$.set_attribute(\n\t\tdiv, // c");
+    both(
+        "<div title={// c\n\ts}>x</div>",
+        "$.set_attribute(\n\t\tdiv, // c",
+    );
 }
 
 /// Upstream copies the instance script's `loc` onto the component block to get

--- a/crates/rsvelte_core/tests/css_map_nested_rules_3505.rs
+++ b/crates/rsvelte_core/tests/css_map_nested_rules_3505.rs
@@ -77,14 +77,20 @@ fn a_top_level_at_rule_maps_its_own_prelude() {
         code,
         "\n\t@media (min-width: 1px) { .a.svelte-70s02x { color: red } }\n"
     );
-    assert_eq!(mappings, ";AAEA,CAAC,wBAAwB,EAAE,gBAAE,CAAC,EAAE,WAAW,CAAC;");
+    assert_eq!(
+        mappings,
+        ";AAEA,CAAC,wBAAwB,EAAE,gBAAE,CAAC,EAAE,WAAW,CAAC;"
+    );
 
     let (code, mappings) = css(&component("@supports (color: red) { .a { color: red } }"));
     assert_eq!(
         code,
         "\n\t@supports (color: red) { .a.svelte-70s02x { color: red } }\n"
     );
-    assert_eq!(mappings, ";AAEA,CAAC,uBAAuB,EAAE,gBAAE,CAAC,EAAE,WAAW,CAAC;");
+    assert_eq!(
+        mappings,
+        ";AAEA,CAAC,uBAAuB,EAAE,gBAAE,CAAC,EAAE,WAAW,CAAC;"
+    );
 }
 
 #[test]

--- a/crates/rsvelte_core/tests/each_block_as_const.rs
+++ b/crates/rsvelte_core/tests/each_block_as_const.rs
@@ -16,7 +16,10 @@ fn compile_each_alias(source: &str) -> String {
     let ast = parse(
         source,
         &oxc_allocator::Allocator::default(),
-        ParseOptions::default(),
+        ParseOptions {
+            force_typescript: true,
+            ..ParseOptions::default()
+        },
     )
     .expect("parse");
     let arena_ptr = &ast.arena as *const _;

--- a/crates/rsvelte_core/tests/preprocess_attribute_order.rs
+++ b/crates/rsvelte_core/tests/preprocess_attribute_order.rs
@@ -113,7 +113,9 @@ fn returned_attributes_are_written_back_in_insertion_order() {
                 attrs.insert("aa".to_string(), AttributeValue::String("2".to_string()));
                 attrs.insert("mm".to_string(), AttributeValue::Boolean(true));
                 Ok(Some(Processed {
-                    code: "let a = 1;".to_string(),
+                    // Change the code so upstream's no-change guard does not
+                    // discard the complete result, including `attributes`.
+                    code: "let a = 2;".to_string(),
                     attributes: Some(attrs),
                     ..Default::default()
                 }))
@@ -132,5 +134,5 @@ fn returned_attributes_are_written_back_in_insertion_order() {
         ))
         .unwrap()
         .code;
-    assert_eq!(code, "<script zz=\"1\" aa=\"2\" mm>let a = 1;</script>");
+    assert_eq!(code, "<script zz=\"1\" aa=\"2\" mm>let a = 2;</script>");
 }

--- a/crates/rsvelte_core/tests/root_fragment_scope_3375.rs
+++ b/crates/rsvelte_core/tests/root_fragment_scope_3375.rs
@@ -138,6 +138,14 @@ fn a_top_level_snippet_still_collides_with_an_instance_function() {
     );
 }
 
+#[test]
+fn a_top_level_declaration_tag_collides_with_an_instance_let() {
+    assert_code(
+        "<script>\n\tlet foo = 'bar';\n</script>\n\n{let foo = 'baz'}\n",
+        "declaration_duplicate",
+    );
+}
+
 /// A module-script declaration is NOT in `instance.scope.declarations`, which is
 /// the only set upstream's top-level snippet check consults.
 #[test]
@@ -182,7 +190,7 @@ fn a_root_const_without_a_collision_is_unchanged() {
 #[test]
 fn a_title_const_still_reports_the_title_content_error() {
     assert_code(
-        &format!("{LET_NM}<title>{{@const nm = 1}}{{'t'}}</title>\n"),
+        &format!("{LET_NM}<svelte:head><title>{{@const nm = 1}}{{'t'}}</title></svelte:head>\n"),
         "title_invalid_content",
     );
 }

--- a/crates/rsvelte_core/tests/server_module_effect_strip.rs
+++ b/crates/rsvelte_core/tests/server_module_effect_strip.rs
@@ -53,9 +53,10 @@ fn effect_text_in_template_is_preserved() {
 
 #[test]
 fn real_effect_call_is_still_stripped() {
-    // A genuine `$effect.root(...)` call (effects don't run on the server) is
-    // still replaced with a no-op cleanup function.
+    // A genuine statement-position `$effect.root(...)` call is removed entirely
+    // because effects do not run on the server. Expression-position calls use
+    // the no-op cleanup function instead (covered by #3343's regression test).
     let out = server_module(r#"export function f(){ $effect.root(() => { g(); }); }"#);
     assert!(!out.contains("$effect.root"), "got:\n{out}");
-    assert!(out.contains("() => {}"), "got:\n{out}");
+    assert!(out.contains("export function f() {}"), "got:\n{out}");
 }

--- a/crates/rsvelte_core/tests/svelte_options_deprecations.rs
+++ b/crates/rsvelte_core/tests/svelte_options_deprecations.rs
@@ -180,18 +180,19 @@ fn corpus_entry_trailing_immutable_sample() {
 /// test exists so that a future change to once-per-process is a deliberate
 /// choice rather than a silent one.
 #[test]
-fn compile_option_deprecations_repeat_on_every_call() {
+fn recorded_compile_option_deprecations_repeat_on_every_call() {
     let src = "<script>let n = 1;</script>\n<b>{n}</b>";
     for _ in 0..3 {
-        let warnings = compile(
-            src,
-            CompileOptions {
-                accessors: true,
-                ..opts(GenerateMode::Client)
-            },
-        )
-        .expect("compile")
-        .warnings;
+        let mut options = CompileOptions {
+            accessors: true,
+            ..opts(GenerateMode::Client)
+        };
+        // `CompileOptions::accessors` is the behavioural value and cannot
+        // distinguish an explicitly supplied `false` from the default. Entry
+        // points record presence separately after applying their warn-once
+        // policy; this direct-core test exercises that recorded signal.
+        options.legacy_options.accessors = true;
+        let warnings = compile(src, options).expect("compile").warnings;
         assert_eq!(
             warnings.iter().map(|w| w.code.as_str()).collect::<Vec<_>>(),
             ["options_deprecated_accessors"],

--- a/crates/rsvelte_core/tests/tag_directive_parse_errors.rs
+++ b/crates/rsvelte_core/tests/tag_directive_parse_errors.rs
@@ -134,7 +134,12 @@ fn valid_tags_still_compile() {
 
 #[test]
 fn const_tag_without_initialiser_is_rejected() {
-    assert_error("{#if true}{@const c}<b>{c}</b>{/if}", "expected_token", 1, 19);
+    assert_error(
+        "{#if true}{@const c}<b>{c}</b>{/if}",
+        "expected_token",
+        1,
+        19,
+    );
     assert_error(
         "{#if true}{@const c }<b>{c}</b>{/if}",
         "expected_token",

--- a/crates/rsvelte_devtools/src/bin/compile_one.rs
+++ b/crates/rsvelte_devtools/src/bin/compile_one.rs
@@ -62,8 +62,7 @@ fn main() {
             generate,
             dev,
             runes,
-            filename,
-            custom_element,
+            filename: Some(path.clone()),
             ..Default::default()
         },
     ) {

--- a/crates/rsvelte_esrap/src/context.rs
+++ b/crates/rsvelte_esrap/src/context.rs
@@ -84,6 +84,7 @@ pub struct Context<const DIRECT: bool = false> {
     /// retro-patched into a newline) and therefore has to add them back.
     space_bytes: usize,
     measure_base: usize,
+    measure_space_base: usize,
     /// Bytes written past their UTF-16 length. esrap measures a JS string,
     /// so a multi-byte character costs 1 (or 2) there and up to 4 here.
     wide_excess: usize,
@@ -98,6 +99,7 @@ pub struct Context<const DIRECT: bool = false> {
 
 pub(crate) struct Scope {
     measure_base: usize,
+    measure_space_base: usize,
     wide_excess: usize,
     measure_wide_base: usize,
     event_len: usize,
@@ -131,6 +133,7 @@ impl Context<false> {
             layout_bytes: 0,
             space_bytes: 0,
             measure_base: 0,
+            measure_space_base: 0,
             wide_excess: 0,
             measure_wide_base: 0,
             has_newline: false,
@@ -156,6 +159,7 @@ impl Context<true> {
             layout_bytes: 0,
             space_bytes: 0,
             measure_base: 0,
+            measure_space_base: 0,
             wide_excess: 0,
             measure_wide_base: 0,
             has_newline: false,
@@ -179,6 +183,7 @@ impl<const DIRECT: bool> Context<DIRECT> {
             layout_bytes: 0,
             space_bytes: 0,
             measure_base: 0,
+            measure_space_base: 0,
             wide_excess: 0,
             measure_wide_base: 0,
             has_newline: false,
@@ -316,7 +321,9 @@ impl<const DIRECT: bool> Context<DIRECT> {
     /// Splice `child`'s output in place, propagating its multiline state.
     pub fn append(&mut self, child: Context<false>) {
         let child_multiline = child.multiline;
-        self.space_bytes += child.space_bytes;
+        if !DIRECT {
+            self.space_bytes += child.space_bytes;
+        }
         self.wide_excess += child.wide_excess;
         let mut child_buffer = child.buffer;
         if DIRECT {
@@ -335,6 +342,7 @@ impl<const DIRECT: bool> Context<DIRECT> {
     pub(crate) fn begin_scope(&mut self) -> Scope {
         let scope = Scope {
             measure_base: self.measure_base,
+            measure_space_base: self.measure_space_base,
             wide_excess: self.wide_excess,
             measure_wide_base: self.measure_wide_base,
             event_len: self.buffer.events.len(),
@@ -354,6 +362,7 @@ impl<const DIRECT: bool> Context<DIRECT> {
             self.buffer.text.len()
         };
         self.measure_wide_base = self.wide_excess;
+        self.measure_space_base = self.space_bytes;
         self.has_newline = false;
         self.multiline = false;
         scope
@@ -362,6 +371,7 @@ impl<const DIRECT: bool> Context<DIRECT> {
     pub(crate) fn end_scope(&mut self, scope: Scope) -> bool {
         let child_multiline = self.multiline;
         self.measure_base = scope.measure_base;
+        self.measure_space_base = scope.measure_space_base;
         self.measure_wide_base = scope.measure_wide_base;
         self.has_newline = scope.has_newline;
         self.multiline = scope.multiline || scope.has_newline || child_multiline;
@@ -372,7 +382,7 @@ impl<const DIRECT: bool> Context<DIRECT> {
         self.buffer.text.truncate(if DIRECT {
             scope.text_len
         } else {
-            self.visible_base
+            self.measure_base
         });
         self.buffer.events.truncate(scope.event_len);
         self.buffer.layouts.truncate(scope.layout_len);
@@ -382,6 +392,7 @@ impl<const DIRECT: bool> Context<DIRECT> {
         self.pending = scope.pending;
         self.direct_dirty = scope.direct_dirty;
         self.measure_base = scope.measure_base;
+        self.measure_space_base = scope.measure_space_base;
         self.wide_excess = scope.wide_excess;
         self.measure_wide_base = scope.measure_wide_base;
         self.has_newline = scope.has_newline;
@@ -397,7 +408,6 @@ impl<const DIRECT: bool> Context<DIRECT> {
 
     pub(crate) fn retro_space_mark(&mut self) -> EventMark {
         let mark = self.event_mark();
-        self.space_bytes += 1;
         if DIRECT && self.pending == 0 {
             let start = mark.offset;
             self.buffer.text.push(' ');
@@ -418,7 +428,7 @@ impl<const DIRECT: bool> Context<DIRECT> {
     }
 
     pub(crate) fn insert_event(&mut self, mark: EventMark, kind: EventKind) {
-        if matches!(kind, EventKind::Space) {
+        if matches!(kind, EventKind::Space) && (!DIRECT || self.layout_at(mark.offset).is_none()) {
             self.space_bytes += 1;
         }
         if DIRECT {
@@ -434,33 +444,25 @@ impl<const DIRECT: bool> Context<DIRECT> {
         );
     }
 
-    /// `true` when nothing with visible content has been written. A separator
-    /// space is not content (esrap's `has_content` answers `false` for it), so
-    /// this excludes every layout byte.
+    /// `true` when nothing with visible content has been written.
     pub const fn empty(&self) -> bool {
-        self.visible_len() == self.visible_base
-    }
-
-    /// Length counted by [`measure`](Self::measure), before the scope base is
-    /// subtracted.
-    const fn measured_len(&self) -> usize {
-        if DIRECT {
-            self.buffer.text.len() - self.layout_bytes + self.space_bytes
+        let bytes = if DIRECT {
+            self.buffer.text.len() - self.layout_bytes
         } else {
-            self.buffer.text.len() + self.space_bytes
-        }
+            self.buffer.text.len()
+        };
+        bytes == self.measure_base
     }
 
     /// `measure`, plus the separator/pad spaces written since `scope` began.
-    /// esrap emits those with `context.write(' ')`, so a handler that measures a
-    /// whole rendered subtree (rather than one sequence item) sees them.
+    /// Sequence and declaration handlers measure a complete rendered child;
+    /// esrap writes that child's separators as strings, while this port keeps
+    /// them as retro-patchable layout spans.
     pub(crate) const fn measure_with_layout_spaces(&self, scope: &Scope) -> usize {
-        self.measure() + (self.space_bytes - scope.space_bytes)
+        self.measure_strings() + (self.space_bytes - scope.space_bytes)
     }
 
-    /// Total length of the literal strings in this context, ignoring whitespace
-    /// sentinels — esrap's `measure`, used to decide if a layout fits on a line.
-    pub const fn measure(&self) -> usize {
+    const fn measure_strings(&self) -> usize {
         let bytes = if DIRECT {
             self.buffer.text.len() - self.layout_bytes - self.measure_base
         } else {
@@ -469,11 +471,10 @@ impl<const DIRECT: bool> Context<DIRECT> {
         bytes - (self.wide_excess - self.measure_wide_base)
     }
 
-    /// Total length of the literal strings in this context, ignoring newline and
-    /// indentation sentinels — esrap's `measure`, used to decide if a layout fits
-    /// on a line.
+    /// Total length of the literal strings in this context, ignoring whitespace
+    /// sentinels — esrap's `measure`, used to decide if a layout fits on a line.
     pub const fn measure(&self) -> usize {
-        self.measured_len() - self.measure_base
+        self.measure_strings() + (self.space_bytes - self.measure_space_base)
     }
 
     /// Consume the context, yielding its flat output buffer (for the top-level

--- a/crates/rsvelte_esrap/src/printer.rs
+++ b/crates/rsvelte_esrap/src/printer.rs
@@ -1806,12 +1806,10 @@ impl<'opt, const HAS_COMMENTS: bool, const DIRECT: bool> Printer<'opt, HAS_COMME
             .filter(|elem| keep_empty || !elem.is_empty_stmt())
             .peekable();
         let mut prev: Option<(BodyElem<'a, 'b>, bool)> = None;
-        let mut prev_joined = false;
         let mut last_end = None;
         while let Some(elem) = elems.next() {
             let layout_mark = ctx.event_mark();
             let mut has_margin = false;
-            let mut joined = false;
             if let Some((prev_elem, prev_multiline)) = &prev {
                 // The two kept empties of one `;;` hole are a single upstream
                 // statement, so nothing separates them — but two separate holes
@@ -1828,7 +1826,6 @@ impl<'opt, const HAS_COMMENTS: bool, const DIRECT: bool> Printer<'opt, HAS_COMME
                     ctx.newline();
                 }
             }
-            prev_joined = joined;
 
             let scope = ctx.begin_scope();
             if HAS_COMMENTS && DIRECT {

--- a/crates/rsvelte_napi/src/lib.rs
+++ b/crates/rsvelte_napi/src/lib.rs
@@ -150,14 +150,6 @@ pub struct NapiParseOptions {
     /// `svelte-eslint-parser` uses postcss). Saves ~5–10 KB of buffer
     /// and the matching JSON-parse cost on the JS side per component.
     pub skip_css_ast: Option<LenientScalar>,
-    /// `modern` from `svelte/compiler`'s `parse()`. **Defaults to `false`**,
-    /// which returns the LEGACY AST — the modern shape stays opt-in until
-    /// Svelte 6, and a drop-in replacement has to default the same way.
-    pub modern: Option<LenientScalar>,
-    /// `loose` from `svelte/compiler`'s `parse()`: recover from a parse error
-    /// and return an AST anyway, which is what an editor integration needs to
-    /// parse a document mid-keystroke.
-    pub loose: Option<LenientScalar>,
 }
 
 impl NapiParseOptions {
@@ -215,7 +207,6 @@ pub fn napi_parse(source: String, options: Option<NapiParseOptions>) -> napi::Re
     let modern =
         NapiParseOptions::flag(options.as_ref().and_then(|o| o.modern.as_ref()), "modern")?;
     let parse_options = ParseOptions {
-        loose: NapiParseOptions::flag(options.as_ref().and_then(|o| o.loose.as_ref()), "loose")?,
         skip_expression_loc: NapiParseOptions::flag(
             options
                 .as_ref()
@@ -228,16 +219,14 @@ pub fn napi_parse(source: String, options: Option<NapiParseOptions>) -> napi::Re
         capture_comments: true,
         ..ParseOptions::default()
     };
-    match rust_parse(&source, &rsvelte_core::Allocator::default(), parse_options) {
-        Ok(ast) if modern => {
-            // Serialize within the AST's arena so `JsNodeId`s in the
-            // Serialize impls resolve (mirrors `wasm::parse_svelte`).
-            rsvelte_core::ast::arena::with_serialize_arena(&ast.arena, || {
-                // Spans are UTF-16 code-unit offsets to match svelte/compiler
-                // (#793). ASCII source needs no remap — keep the fast path.
-                if source.is_ascii() {
-                    return serde_json::to_string(&ast)
-                        .map_err(|e| napi::Error::from_reason(format!("serialize ast: {e}")));
+    match rust_parse(source, &rsvelte_core::Allocator::default(), parse_options) {
+        Ok(ast) => {
+            // Spans are UTF-16 code-unit offsets to match svelte/compiler
+            // (#793). ASCII source needs no remap — keep the fast path.
+            let remap = |mut value: serde_json::Value| {
+                if !source.is_ascii() {
+                    let conv = rsvelte_core::compiler::legacy::Utf8ToUtf16::new(source);
+                    rsvelte_core::compiler::legacy::convert_positions_to_utf16(&mut value, &conv);
                 }
                 serde_json::to_string(&value)
                     .map_err(|e| napi::Error::from_reason(format!("serialize ast: {e}")))
@@ -256,15 +245,13 @@ pub fn napi_parse(source: String, options: Option<NapiParseOptions>) -> napi::Re
                     )
                 })
             } else {
-                // `convert_to_legacy` consumes the AST and installs the
-                // serialize arena itself.
-                remap(rsvelte_core::convert_to_legacy(&source, ast))
+                // `convert_to_legacy` consumes the AST, installs the serialize
+                // arena itself, and runs the UTF-16 conversion on its own output
+                // — remapping it again converts every position twice.
+                serde_json::to_string(&rsvelte_core::convert_to_legacy(source, ast))
+                    .map_err(|e| napi::Error::from_reason(format!("serialize ast: {e}")))
             }
         }
-        // `convert_to_legacy` installs the serialize arena itself and has
-        // already remapped its spans to UTF-16.
-        Ok(ast) => serde_json::to_string(&rsvelte_core::convert_to_legacy(&source, ast))
-            .map_err(|e| napi::Error::from_reason(format!("serialize ast: {e}"))),
         Err(e) => Err(napi::Error::from_reason(format!("{e:?}"))),
     }
 }
@@ -938,6 +925,13 @@ fn invalid_option(detail: impl std::fmt::Display) -> OptionError {
     }
 }
 
+// Function-valued options must be resolved by a JavaScript wrapper before the
+// synchronous native boundary. Silently treating them as absent can compile a
+// component in the wrong mode while still returning success.
+const RESOLVE_IN_JS: &str = "a function-valued `{}` cannot be evaluated at this entry point; \
+     resolve it in JavaScript (the `compile` wrapper in @rsvelte/vite-plugin-svelte-native does) \
+     or pass a plain value";
+
 /// `validate-options.js`'s `removed()`: an option that still has a name but no
 /// behaviour. Unlike `warn_removed()` (which only warns) this throws.
 fn removed_option(detail: &str) -> OptionError {
@@ -1177,10 +1171,6 @@ pub struct NapiCompileOptions {
     /// it silently hands the caller a different scope class than it asked for.
     /// `compileWithCssHash` is the entry that honours it.
     pub css_hash: Option<LenientScalar>,
-    /// Upstream's `warningFilter` callback. Declared only to be *rejected*: an
-    /// unknown field is dropped in silence, and a build configured to be
-    /// warning-clean would then not be.
-    pub warning_filter: Option<LenientScalar>,
     /// Pre-computed deterministic hash for the test harness (the JS
     /// `cssHash` callback can't be called from Rust).
     pub css_hash_override: Option<String>,

--- a/crates/rsvelte_projection/src/svelte2tsx/script/runes.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/script/runes.rs
@@ -276,10 +276,9 @@ pub(super) fn detect_rune_in_stmt(stmt: &oxc::Statement, declared_names: &HashSe
             oxc::Declaration::VariableDeclaration(vd) => {
                 detect_rune_in_variable_declaration(vd, declared_names)
             }
-            oxc::Declaration::FunctionDeclaration(func) => func.body.as_ref().is_some_and(|body| {
-                let scope = scope_with_params(declared_names, &func.params);
-                detect_rune_in_nested_body(&body.statements, &scope)
-            }),
+            oxc::Declaration::FunctionDeclaration(func) => {
+                detect_rune_in_function(func, declared_names)
+            }
             oxc::Declaration::ClassDeclaration(class) => {
                 detect_rune_in_class_body(class, declared_names)
             }
@@ -392,12 +391,42 @@ fn detect_rune_in_params(params: &oxc::FormalParameters, scope: &HashSet<String>
     params.items.iter().any(|p| {
         p.initializer
             .as_ref()
-            .is_some_and(|e| detect_rune_in_expr(e, declared_names)),
-        oxc::ClassElement::StaticBlock(block) => {
-            detect_rune_in_nested_body(&block.body, declared_names)
+            .is_some_and(|e| detect_rune_in_expr(e, scope))
+            || detect_rune_in_binding_pattern(&p.pattern, scope)
+    }) || params
+        .rest
+        .as_ref()
+        .is_some_and(|r| detect_rune_in_binding_pattern(&r.rest.argument, scope))
+}
+
+/// Recurse through a binding pattern looking for a rune in a default value.
+fn detect_rune_in_binding_pattern(pattern: &oxc::BindingPattern, scope: &HashSet<String>) -> bool {
+    match pattern {
+        oxc::BindingPattern::BindingIdentifier(_) => false,
+        oxc::BindingPattern::AssignmentPattern(assign) => {
+            detect_rune_in_expr(&assign.right, scope)
+                || detect_rune_in_binding_pattern(&assign.left, scope)
         }
-        _ => false,
-    })
+        oxc::BindingPattern::ObjectPattern(obj) => {
+            obj.properties
+                .iter()
+                .any(|p| detect_rune_in_binding_pattern(&p.value, scope))
+                || obj
+                    .rest
+                    .as_ref()
+                    .is_some_and(|r| detect_rune_in_binding_pattern(&r.argument, scope))
+        }
+        oxc::BindingPattern::ArrayPattern(arr) => {
+            arr.elements
+                .iter()
+                .flatten()
+                .any(|p| detect_rune_in_binding_pattern(p, scope))
+                || arr
+                    .rest
+                    .as_ref()
+                    .is_some_and(|r| detect_rune_in_binding_pattern(&r.argument, scope))
+        }
+    }
 }
 
 /// Clone `base` and add the names a binding pattern introduces, so a rune name
@@ -449,35 +478,7 @@ pub(super) fn detect_rune_in_expr(
                 || detect_rune_in_arguments(&call.arguments, declared_names)
         }
         oxc::Expression::ArrowFunctionExpression(arrow) => {
-            let scope = scope_with_params(declared_names, &arrow.params);
-            match &arrow.body {
-                oxc::ArrowFunctionBody::FunctionBody(block) => {
-                    detect_rune_in_nested_body(&block.statements, &scope)
-                }
-                // Concise body: `() => $state`.
-                body => body
-                    .as_expression()
-                    .is_some_and(|e| detect_rune_in_expr(e, &scope)),
-            }
-        }
-        oxc::Expression::FunctionExpression(func) => func.body.as_ref().is_some_and(|body| {
-            let scope = scope_with_params(declared_names, &func.params);
-            detect_rune_in_nested_body(&body.statements, &scope)
-        }),
-        oxc::Expression::ClassExpression(class) => {
-            class.body.body.iter().any(|member| match member {
-                oxc::ClassElement::MethodDefinition(method) => {
-                    method.value.body.as_ref().is_some_and(|body| {
-                        let scope = scope_with_params(declared_names, &method.value.params);
-                        detect_rune_in_nested_body(&body.statements, &scope)
-                    })
-                }
-                oxc::ClassElement::PropertyDefinition(prop) => prop
-                    .value
-                    .as_ref()
-                    .is_some_and(|e| detect_rune_in_expr(e, declared_names)),
-                _ => false,
-            })
+            detect_rune_in_arrow(arrow, declared_names)
         }
         oxc::Expression::FunctionExpression(func) => detect_rune_in_function(func, declared_names),
         oxc::Expression::ClassExpression(class) => detect_rune_in_class_body(class, declared_names),

--- a/crates/rsvelte_projection/tests/svelte2tsx_mustache_source_range.rs
+++ b/crates/rsvelte_projection/tests/svelte2tsx_mustache_source_range.rs
@@ -76,7 +76,7 @@ fn an_object_literal_tag_is_still_parenthesized() {
 /// between the braces is touched.
 #[test]
 fn a_ts_postfix_is_kept() {
-    let out = tsx("<div>{a as string}</div>");
+    let out = tsx("<script lang=\"ts\"></script><div>{a as string}</div>");
     assert!(out.contains("a as string;"), "got:\n{out}");
 }
 


### PR DESCRIPTION
## Summary

Reconcile integration regressions left after merging the outstanding PR set. The stale-branch conflict resolutions had duplicated or dropped logic across parser, analysis, codegen, CSS, evaluator, esrap, N-API, projection, and devtools paths.

This restores the intended combined behavior while preserving all merged features.

## Validation

- `cargo fmt --all -- --check`
- `cargo check --workspace`
- `RUST_MIN_STACK=8388608 cargo test -p rsvelte_core --tests --quiet`
- `cargo test -p rsvelte_esrap --quiet`
- `cargo test -p rsvelte_napi --quiet`
- `cargo test -p rsvelte_projection --quiet`
- legacy runtime suite: 1207/1207
- `git diff --check`