### PR TITLE
fix(ci): exclude oxlint bindings from release age gate

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -18,3 +18,4 @@ minimumReleaseAgeExclude:
   - svelte
   - vite
   - oxlint
+  - '@oxlint/*'


### PR DESCRIPTION
The oxlint Renovate upgrade also updates its freshly published platform binding packages. The existing minimumReleaseAgeExclude entry only covers the oxlint package itself, so Release and other pnpm-install jobs fail on all @oxlint/binding-* entries. Exclude the reviewed @oxlint/* package family as intended by the existing policy comment.\n\nValidated: CI=true pnpm install --frozen-lockfile passed the supply-chain lockfile verification; local package downloads were then limited by the sandbox registry DNS.