### PR TITLE
fix(release): refresh lint-types lock during versioning

### DIFF
--- a/package.json
+++ b/package.json
@@ -163,7 +163,7 @@
 		"lsp:update": "node scripts/compat-lsp/merge-current.mjs .lsp-current --update-baseline",
 		"lsp:merge": "node scripts/compat-lsp/merge-current.mjs",
 		"changeset": "changeset",
-		"version-packages": "changeset version && pnpm run sync-version && node scripts/ci/check-lint-types-lock.mjs --allow-unresolved",
+		"version-packages": "changeset version && pnpm run sync-version && pnpm run fix:lint-types-lock",
 		"release": "pnpm run sync-version && pnpm run build:wasm && pnpm run finalize-pkg && pnpm run publish-platform-binaries && pnpm run build:language-server && changeset publish",
 		"corpus:scss": "node scripts/compat-corpus/scss-verify.mjs"
 	},

--- a/scripts/ci/check-lint-types-lock.mjs
+++ b/scripts/ci/check-lint-types-lock.mjs
@@ -23,8 +23,9 @@
 // `git submodule update --init submodules/corsa-bind`. If resolution still
 // cannot happen (no network, no cargo), that is reported as a distinct,
 // non-passing outcome — never printed or exit-coded like a real pass — unless
-// the caller opted in with `--allow-unresolved` (used by `version-packages`,
-// which must not hard-fail on infra flakiness; see that script for why).
+// the caller opted in with `--allow-unresolved`. `version-packages` instead
+// runs this script with `--fix`, which syncs and re-resolves the lock while
+// still tolerating submodule checkout failures after the text-pin repair.
 
 import { execFileSync } from 'node:child_process';
 import { existsSync, readFileSync, readdirSync, writeFileSync } from 'node:fs';


### PR DESCRIPTION
## Summary
- run the existing lint-types lock fixer after Changesets version synchronization
- re-resolve the standalone lint-types Cargo workspace during Release PR generation
- document the versioning caller's actual recovery behavior

## Verification
- reproduced the full Changesets + sync-version sequence in an isolated worktree
- `node scripts/ci/check-lint-types-lock.mjs --fix`
- `node scripts/ci/check-lint-types-lock.mjs --require-resolve`
- `git diff --check`
- `node --check scripts/ci/check-lint-types-lock.mjs`