### PR TITLE
fix(parse): validate template expression JS restrictions (#3694, #3707)

### DIFF
--- a/.changeset/template-expression-js-validation.md
+++ b/.changeset/template-expression-js-validation.md
@@ -1,0 +1,5 @@
+---
+'@rsvelte/compiler': patch
+---
+
+Reject invalid `super`, `await`, and `arguments` references in template expressions.

--- a/crates/rsvelte_core/src/compiler/phases/1_parse/read/expression.rs
+++ b/crates/rsvelte_core/src/compiler/phases/1_parse/read/expression.rs
@@ -7175,9 +7175,18 @@ fn acorn_only_violation(
             oxc_ast_visit::walk::walk_expression(self, expr);
         }
         fn visit_identifier_reference(&mut self, ident: &oxc_ast::ast::IdentifierReference<'a>) {
-            if ident.name == "await" && self.await_at.is_none() {
+            let next = self.content[ident.span.end as usize..]
+                .bytes()
+                .find(|byte| !byte.is_ascii_whitespace());
+            if ident.name == "await"
+                && self.await_at.is_none()
+                && matches!(next, Some(b')' | b'.' | b'?'))
+            {
                 // Acorn reads `await` as the start of an AwaitExpression in a
-                // module and stops on the token immediately following it.
+                // module and stops on the token immediately following it. OXC
+                // also represents the leading word of Svelte's valid
+                // `await expression` form as an identifier here, so only the
+                // bare/member continuations distinguish the acorn rejection.
                 self.await_at = Some(ident.span.end);
             }
         }

--- a/crates/rsvelte_core/src/compiler/phases/1_parse/read/expression.rs
+++ b/crates/rsvelte_core/src/compiler/phases/1_parse/read/expression.rs
@@ -7147,6 +7147,10 @@ fn acorn_only_violation(
         check_ts_modifier: bool,
         content: &'c str,
         ts_modifier_at: Option<u32>,
+        super_at: Option<u32>,
+        await_at: Option<u32>,
+        super_allowed: bool,
+        next_function_is_method: bool,
     }
     impl Scan<'_> {
         fn record_ts_modifier(&mut self, carries_modifier: bool, span: oxc_span::Span) {
@@ -7161,6 +7165,38 @@ fn acorn_only_violation(
         }
     }
     impl<'a> Visit<'a> for Scan<'_> {
+        fn visit_expression(&mut self, expr: &oxc_ast::ast::Expression<'a>) {
+            if let oxc_ast::ast::Expression::Super(super_expr) = expr
+                && !self.super_allowed
+                && self.super_at.is_none()
+            {
+                self.super_at = Some(super_expr.span.start);
+            }
+            oxc_ast_visit::walk::walk_expression(self, expr);
+        }
+        fn visit_identifier_reference(&mut self, ident: &oxc_ast::ast::IdentifierReference<'a>) {
+            if ident.name == "await" && self.await_at.is_none() {
+                // Acorn reads `await` as the start of an AwaitExpression in a
+                // module and stops on the token immediately following it.
+                self.await_at = Some(ident.span.end);
+            }
+        }
+        fn visit_function(
+            &mut self,
+            func: &oxc_ast::ast::Function<'a>,
+            flags: oxc_syntax::scope::ScopeFlags,
+        ) {
+            let saved = self.super_allowed;
+            self.super_allowed = std::mem::take(&mut self.next_function_is_method);
+            oxc_ast_visit::walk::walk_function(self, func, flags);
+            self.super_allowed = saved;
+        }
+        fn visit_object_property(&mut self, prop: &oxc_ast::ast::ObjectProperty<'a>) {
+            let saved = self.next_function_is_method;
+            self.next_function_is_method = prop.method;
+            oxc_ast_visit::walk::walk_object_property(self, prop);
+            self.next_function_is_method = saved;
+        }
         fn visit_decorator(&mut self, dec: &oxc_ast::ast::Decorator<'a>) {
             if self.check_decorator && self.decorator_at.is_none() {
                 self.decorator_at = Some(dec.span.start);
@@ -7189,7 +7225,10 @@ fn acorn_only_violation(
                     || def.r#type == oxc_ast::ast::MethodDefinitionType::TSAbstractMethodDefinition,
                 def.span,
             );
+            let saved = self.next_function_is_method;
+            self.next_function_is_method = true;
             oxc_ast_visit::walk::walk_method_definition(self, def);
+            self.next_function_is_method = saved;
         }
         fn visit_property_definition(&mut self, def: &oxc_ast::ast::PropertyDefinition<'a>) {
             self.record_ts_modifier(
@@ -7213,6 +7252,8 @@ fn acorn_only_violation(
     let check_decorator = !is_typescript && content.contains('@');
     let check_with = content.contains("with");
     let check_ts_modifier = !is_typescript && content.contains("class");
+    let check_super = content.contains("super");
+    let check_await = content.contains("await");
     let mut finder = Scan {
         check_decorator,
         decorator_at: None,
@@ -7221,11 +7262,21 @@ fn acorn_only_violation(
         check_ts_modifier,
         content,
         ts_modifier_at: None,
+        super_at: None,
+        await_at: None,
+        super_allowed: false,
+        next_function_is_method: false,
     };
     // The TypeScript-only rule below needs a token that is cheap to rule out, so
     // a plain-JS script keeps the walk it had.
     let check_ts_acorn = is_typescript && content.contains("global");
-    if check_decorator || check_with || check_ts_modifier || check_ts_acorn {
+    if check_decorator
+        || check_with
+        || check_ts_modifier
+        || check_ts_acorn
+        || check_super
+        || check_await
+    {
         finder.visit_program(program);
     }
 
@@ -7249,6 +7300,12 @@ fn acorn_only_violation(
         super::strict_mode::find_violation(program, content, is_typescript),
         finder
             .ts_modifier_at
+            .map(|at| (at, "Unexpected token".to_string())),
+        finder
+            .super_at
+            .map(|at| (at, "'super' keyword outside a method".to_string())),
+        finder
+            .await_at
             .map(|at| (at, "Unexpected token".to_string())),
     ]
     .into_iter()

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/mod.rs
@@ -430,6 +430,9 @@ pub struct VisitorContext<'a> {
     /// within a template expression are NOT suspending and must not trigger
     /// the `experimental_async` / `legacy_await_invalid` errors.
     pub in_template_function: bool,
+    /// Whether a template expression is inside a non-arrow function that owns
+    /// an `arguments` binding. Arrow functions inherit this from their parent.
+    pub in_template_arguments_function: bool,
     /// Stack of ignored warning codes.
     /// Each entry is a set of warning codes that should be ignored at that nesting level.
     /// Corresponds to ignore_stack in Svelte's state.js.
@@ -627,6 +630,7 @@ impl<'a> VisitorContext<'a> {
             uses_event_attributes: false,
             in_expression_tag: false,
             in_template_function: false,
+            in_template_arguments_function: false,
             ignore_stack: Vec::new(),
             script_ignore_comments: rustc_hash::FxHashMap::default(),
             element_ancestors: Vec::new(),

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/shared/utils.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/shared/utils.rs
@@ -1242,6 +1242,10 @@ pub fn walk_js_expression_node(
                 context.analysis.uses_slots = true;
             }
 
+            if name == "arguments" && !context.in_template_arguments_function {
+                return Err(errors::invalid_arguments_usage().at(*start, *end));
+            }
+
             // Bare `$` and `$$xxx` (other than the reserved `$$props` /
             // `$$restProps` / `$$slots`) are illegal as variable names.
             // Mirrors `visit_identifier_inner` for the JS-side identifier
@@ -1550,6 +1554,10 @@ pub fn walk_js_expression_node(
 
             let saved_in_template_function = context.in_template_function;
             context.in_template_function = true;
+            let saved_in_arguments_function = context.in_template_arguments_function;
+            if !matches!(expression, JsNode::ArrowFunctionExpression { .. }) {
+                context.in_template_arguments_function = true;
+            }
             for param in arena.get_js_children(*params) {
                 walk_parameter_evaluations(param, context, metadata)?;
             }
@@ -1584,6 +1592,7 @@ pub fn walk_js_expression_node(
             }
 
             context.in_template_function = saved_in_template_function;
+            context.in_template_arguments_function = saved_in_arguments_function;
             context.expression = saved_expression;
             context.scope = saved_scope;
             while context.decl_undo_log.len() > decl_undo_mark {

--- a/crates/rsvelte_core/tests/template_expression_js_validation_3694_3707.rs
+++ b/crates/rsvelte_core/tests/template_expression_js_validation_3694_3707.rs
@@ -1,0 +1,60 @@
+//! Template expressions use specialized parse and analysis walks. These cases
+//! pin JavaScript restrictions that the ordinary script walks already enforce.
+
+use rsvelte_core::{CompileOptions, compile};
+
+fn error(source: &str) -> rsvelte_core::CompileError {
+    compile(source, CompileOptions::default()).expect_err(source)
+}
+
+#[test]
+fn super_and_await_match_the_module_parser_restrictions() {
+    let super_error = error("{super.x}");
+    let diagnostic = super_error.diagnostic();
+    assert_eq!(diagnostic.code.as_deref(), Some("js_parse_error"));
+    assert_eq!(diagnostic.span, Some((1, 1)));
+
+    for source in ["{await}", "{await.x}"] {
+        let await_error = error(source);
+        let diagnostic = await_error.diagnostic();
+        assert_eq!(
+            diagnostic.code.as_deref(),
+            Some("js_parse_error"),
+            "{source}"
+        );
+        assert_eq!(diagnostic.span, Some((6, 6)));
+    }
+}
+
+#[test]
+fn super_is_still_legal_in_a_method_and_await_is_legal_as_a_property() {
+    compile(
+        "{class A extends B { m() { return super.x } }}",
+        CompileOptions::default(),
+    )
+    .expect("super in a method must remain valid");
+    compile("{obj.await}", CompileOptions::default())
+        .expect("await as a property name must remain valid");
+}
+
+#[test]
+fn arguments_is_rejected_in_template_references_but_not_in_function_expressions() {
+    for source in [
+        "{arguments}",
+        "{arguments.length}",
+        "{String(arguments)}",
+        "{(() => arguments)()}",
+    ] {
+        assert_eq!(
+            error(source).diagnostic().code.as_deref(),
+            Some("invalid_arguments_usage"),
+            "{source}"
+        );
+    }
+
+    compile(
+        "{(function () { return arguments; })()}",
+        CompileOptions::default(),
+    )
+    .expect("a regular function owns arguments");
+}

--- a/crates/rsvelte_core/tests/template_expression_js_validation_3694_3707.rs
+++ b/crates/rsvelte_core/tests/template_expression_js_validation_3694_3707.rs
@@ -35,6 +35,14 @@ fn super_is_still_legal_in_a_method_and_await_is_legal_as_a_property() {
     .expect("super in a method must remain valid");
     compile("{obj.await}", CompileOptions::default())
         .expect("await as a property name must remain valid");
+
+    for source in ["{await promise}", "{await (await (value.nested)).one}"] {
+        assert_eq!(
+            error(source).diagnostic().code.as_deref(),
+            Some("experimental_async"),
+            "an await expression must reach analysis: {source}"
+        );
+    }
 }
 
 #[test]


### PR DESCRIPTION
## What

Fixes two validation gaps caused by template expressions bypassing the ordinary JavaScript parse/analyze visitors:

- reject `super` outside a method and module-reserved `await` references with `js_parse_error` (#3694)
- reject template references to `arguments` outside a regular function with `invalid_arguments_usage` (#3707)

The Acorn-compatibility scan now preserves legal `super` inside class/object methods and arrow functions nested in those methods. The template analysis walk separately tracks whether a regular function owns `arguments`, so a top-level arrow still rejects it while a function expression accepts it.

## Coverage

`template_expression_js_validation_3694_3707.rs` pins:

- `super.x`, `await`, and `await.x`, including official error positions
- legal method `super` and `obj.await` controls
- direct, member, call-argument, and arrow-captured `arguments`
- the legal regular-function `arguments` control

## Local checks

- `cargo fmt --all -- --check`
- `git diff --check`

Per the requested workflow, compilation and test execution are left to CI to avoid loading the local machine.

Closes #3694
Closes #3707
