### PR TITLE
fix(parse): reject strict template binding names

### DIFF
--- a/.changeset/tidy-dodos-bind.md
+++ b/.changeset/tidy-dodos-bind.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/compiler": patch
+---
+
+Reject strict-mode reserved names in template binding patterns.

--- a/crates/rsvelte_core/src/compiler/phases/1_parse/read/expression.rs
+++ b/crates/rsvelte_core/src/compiler/phases/1_parse/read/expression.rs
@@ -11730,6 +11730,69 @@ fn is_plain_ascii_identifier(s: &str) -> bool {
     bytes.all(|b| b.is_ascii_alphanumeric() || b == b'_' || b == b'$')
 }
 
+/// Apply the strict-mode binding-name restrictions that upstream's acorn
+/// parser enforces while reading a template pattern.
+///
+/// A bare reserved word is rejected by Svelte's `read_identifier`, while
+/// `eval` / `arguments` nested in a destructuring pattern reach acorn's
+/// assignment-pattern path and therefore use its "Assigning to …" wording.
+pub fn validate_template_binding_pattern(
+    content: &str,
+    offset: usize,
+    ts: bool,
+) -> Result<(), crate::error::ParseError> {
+    let trimmed = content.trim_ws();
+    let leading_ws = content.len() - content.trim_start_ws().len();
+    let start = offset + leading_ws;
+
+    if is_plain_ascii_identifier(trimmed) && super::super::utils::is_reserved(trimmed) {
+        return Err(crate::error::ParseError::svelte(
+            "unexpected_reserved_word",
+            format!(
+                "'{}' is a reserved word in JavaScript and cannot be used here",
+                trimmed
+            ),
+            (start, start),
+        ));
+    }
+
+    if !(trimmed.starts_with('{') || trimmed.starts_with('['))
+        || (!trimmed.contains("arguments") && !trimmed.contains("eval"))
+    {
+        return Ok(());
+    }
+
+    let source_type = if ts {
+        SourceType::ts()
+    } else {
+        SourceType::mjs()
+    };
+    with_oxc_allocator(|allocator| {
+        let wrapped = wrap_for_parse("let ", trimmed, "= null");
+        let result = OxcParser::new(allocator, &wrapped, source_type).parse();
+        if !result.diagnostics.is_empty() {
+            return Ok(());
+        }
+
+        if let Some((at, message)) =
+            super::strict_mode::find_violation(&result.program, &wrapped, ts)
+            && let Some(name) = message
+                .strip_prefix("Binding ")
+                .and_then(|message| message.strip_suffix(" in strict mode"))
+            && matches!(name, "eval" | "arguments")
+        {
+            let at = start + at as usize - 4;
+            return Err(crate::error::ParseError::svelte(
+                "js_parse_error",
+                format!("Assigning to {name} in strict mode"),
+                (at, at),
+            ));
+        }
+
+        Ok(())
+    })
+}
+
 pub fn parse_binding_pattern<'a>(
     arena: &ParseArena,
     content: &str,
@@ -11737,23 +11800,8 @@ pub fn parse_binding_pattern<'a>(
     line_offsets: &[usize],
     ts: bool,
 ) -> Result<Expression<'a>, crate::error::ParseError> {
-    // Check for reserved words in simple identifier contexts
-    // (e.g., {#each cases as case} where "case" is a reserved word)
     let trimmed = content.trim_ws();
-    if !trimmed.is_empty()
-        && !trimmed.starts_with('{')
-        && !trimmed.starts_with('[')
-        && super::super::utils::is_reserved(trimmed)
-    {
-        return Err(crate::error::ParseError::svelte(
-            "unexpected_reserved_word",
-            format!(
-                "'{}' is a reserved word in JavaScript and cannot be used here",
-                trimmed
-            ),
-            (offset, offset),
-        ));
-    }
+    validate_template_binding_pattern(content, offset, ts)?;
 
     // `{#each xs as item}` / `{#await p then v}` bind a bare identifier in the
     // vast majority of cases; skip the `let … = null` wrap + full JS parse.

--- a/crates/rsvelte_core/src/compiler/phases/1_parse/state/tag.rs
+++ b/crates/rsvelte_core/src/compiler/phases/1_parse/state/tag.rs
@@ -1402,6 +1402,11 @@ impl<'a> Parser<'a> {
                     self.advance();
                 }
             } else {
+                super::super::expression::validate_template_binding_pattern(
+                    &self.source[idx_start..idx_end],
+                    idx_start,
+                    self.ts,
+                )?;
                 index = Some(CompactString::from(&self.source[idx_start..idx_end]));
                 self.index = idx_end;
             }
@@ -2332,6 +2337,12 @@ impl<'a> Parser<'a> {
                     // For a simple identifier like `area: number`, strip `: number`.
                     // For destructuring like `{ x, y }: Point`, strip `: Point`.
                     let pattern_clean = strip_type_annotation(pattern_str);
+
+                    super::super::read::expression::validate_template_binding_pattern(
+                        &pattern_clean,
+                        expr_start,
+                        self.ts,
+                    )?;
 
                     // Parse the pattern (LHS)
                     // For destructuring patterns ({...} or [...]), use the dedicated

--- a/crates/rsvelte_core/tests/template_binding_strict_names_3728.rs
+++ b/crates/rsvelte_core/tests/template_binding_strict_names_3728.rs
@@ -96,7 +96,7 @@ fn destructured_strict_names_are_rejected_in_every_pattern_host() {
 #[test]
 fn property_keys_and_ordinary_bindings_remain_legal() {
     for src in [
-        "{@const { arguments: value } = { arguments: 1 }}{value}",
+        "{#if true}{@const { arguments: value } = { arguments: 1 }}{value}{/if}",
         "{#each [{ eval: 1 }] as { eval: value }}{value}{/each}",
         "{#await promise then { arguments: value }}{value}{/await}",
         "{#each [1] as value, index}{value}{index}{/each}",

--- a/crates/rsvelte_core/tests/template_binding_strict_names_3728.rs
+++ b/crates/rsvelte_core/tests/template_binding_strict_names_3728.rs
@@ -1,0 +1,108 @@
+//! Template binding-name validation (#3728).
+//!
+//! Every template binding host is parsed in module/strict mode upstream. A
+//! bare reserved word is rejected by `read_identifier`; inside destructuring,
+//! acorn reports the binding identifier as an assignment-pattern violation.
+
+use rsvelte_core::{CompileOptions, GenerateMode, compile, compiler::CssMode};
+
+fn diagnose(src: &str) -> Result<(), (String, String, (u32, u32))> {
+    match compile(
+        src,
+        CompileOptions {
+            filename: Some("Test.svelte".to_string()),
+            generate: GenerateMode::Client,
+            dev: false,
+            css: CssMode::External,
+            ..Default::default()
+        },
+    ) {
+        Ok(_) => Ok(()),
+        Err(error) => {
+            let diagnostic = error.diagnostic();
+            Err((
+                diagnostic.code.unwrap_or_default(),
+                diagnostic
+                    .message
+                    .split('\n')
+                    .next()
+                    .unwrap_or_default()
+                    .to_string(),
+                diagnostic.span.unwrap_or((u32::MAX, u32::MAX)),
+            ))
+        }
+    }
+}
+
+#[test]
+fn bare_reserved_names_are_rejected_in_every_template_binding_host() {
+    for name in ["arguments", "eval"] {
+        let sources = [
+            format!("{{@const {name} = 1}}"),
+            format!("{{#each [1] as {name}}}x{{/each}}"),
+            format!("{{#each [1] as value, {name}}}x{{/each}}"),
+            format!("{{#await promise then {name}}}x{{/await}}"),
+            format!("{{#await promise catch {name}}}x{{/await}}"),
+        ];
+
+        for src in sources {
+            let expected_at = src.find(name).unwrap() as u32;
+            let expected_message =
+                format!("'{name}' is a reserved word in JavaScript and cannot be used here");
+            assert_eq!(
+                diagnose(&src),
+                Err((
+                    "unexpected_reserved_word".to_string(),
+                    expected_message,
+                    (expected_at, expected_at),
+                )),
+                "wrong diagnostic for {src:?}"
+            );
+        }
+    }
+}
+
+#[test]
+fn destructured_strict_names_are_rejected_in_every_pattern_host() {
+    for name in ["arguments", "eval"] {
+        for pattern in [
+            format!("{{ {name} }}"),
+            format!("[{name}]"),
+            format!("{{ key: {name} }}"),
+        ] {
+            let sources = [
+                format!("{{@const {pattern} = value}}"),
+                format!("{{#each values as {pattern}}}x{{/each}}"),
+                format!("{{#await promise then {pattern}}}x{{/await}}"),
+                format!("{{#await promise catch {pattern}}}x{{/await}}"),
+            ];
+
+            for src in sources {
+                let expected_at = src.find(name).unwrap() as u32;
+                assert_eq!(
+                    diagnose(&src),
+                    Err((
+                        "js_parse_error".to_string(),
+                        format!("Assigning to {name} in strict mode"),
+                        (expected_at, expected_at),
+                    )),
+                    "wrong diagnostic for {src:?}"
+                );
+            }
+        }
+    }
+}
+
+#[test]
+fn property_keys_and_ordinary_bindings_remain_legal() {
+    for src in [
+        "{@const { arguments: value } = { arguments: 1 }}{value}",
+        "{#each [{ eval: 1 }] as { eval: value }}{value}{/each}",
+        "{#await promise then { arguments: value }}{value}{/await}",
+        "{#each [1] as value, index}{value}{index}{/each}",
+    ] {
+        if let Err(error) = diagnose(src) {
+            panic!("{src:?} was rejected: {error:?}");
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- validate reserved names in every template binding host
- apply strict-mode binding checks to destructuring patterns without rejecting property keys
- match Svelte's diagnostic code, message, and point span for `eval` and `arguments`
- add a cross-host regression matrix and legal controls

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- compile/tests intentionally left to CI to avoid loading the local machine

Closes #3728
