### PR TITLE
fix(parse): share public binding options

### DIFF
--- a/.changeset/fuzzy-parsers-listen.md
+++ b/.changeset/fuzzy-parsers-listen.md
@@ -1,5 +1,6 @@
 ---
 "@rsvelte/compiler": patch
+"@rsvelte/vite-plugin-svelte-native": patch
 ---
 
 Preserve JavaScript comments in every public parse API binding.

--- a/.changeset/fuzzy-parsers-listen.md
+++ b/.changeset/fuzzy-parsers-listen.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/compiler": patch
+---
+
+Preserve JavaScript comments in every public parse API binding.

--- a/crates/rsvelte_core/src/compiler/phases/1_parse/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/1_parse/mod.rs
@@ -127,6 +127,22 @@ pub struct ParseOptions {
     pub reparse_leading_slash_expression: bool,
 }
 
+impl ParseOptions {
+    /// Options shared by every public `parse()` binding.
+    ///
+    /// Compilation deliberately skips the all-or-nothing JS comment attachment
+    /// walk, but a public AST must retain `leadingComments` and
+    /// `trailingComments` like `svelte/compiler` does. Keeping that decision
+    /// here prevents the NAPI, raw-envelope, and wasm entry points from
+    /// silently drifting apart.
+    pub fn public_api() -> Self {
+        Self {
+            capture_comments: true,
+            ..Self::default()
+        }
+    }
+}
+
 /// Extended parse options with filename (separate to keep ParseOptions Copy).
 #[derive(Debug, Clone, Default)]
 pub struct ParseOptionsWithFilename {
@@ -527,5 +543,15 @@ mod tests {
             "Should parse // in HTML attributes: {:?}",
             result.err()
         );
+    }
+
+    #[test]
+    fn public_parse_options_capture_node_comments() {
+        let public = ParseOptions::public_api();
+        assert!(public.capture_comments);
+
+        // The compiler hot path keeps the expensive whole-program comment
+        // attachment walk disabled; only public AST entry points opt into it.
+        assert!(!ParseOptions::default().capture_comments);
     }
 }

--- a/crates/rsvelte_lint_bindings/src/compiler_wasm/mod.rs
+++ b/crates/rsvelte_lint_bindings/src/compiler_wasm/mod.rs
@@ -85,7 +85,7 @@ pub fn parse_svelte(source: &str) -> ParseResultWasm {
     // Same as the NAPI entry: upstream strips it before the parser, so every
     // position below is relative to the trimmed source.
     let source = crate::compiler::phases::phase1_parse::remove_bom(source);
-    let options = ParseOptions::default();
+    let options = ParseOptions::public_api();
 
     match parse(source, &oxc_allocator::Allocator::default(), options) {
         Ok(ast) => {

--- a/crates/rsvelte_napi/src/lib.rs
+++ b/crates/rsvelte_napi/src/lib.rs
@@ -214,10 +214,7 @@ pub fn napi_parse(source: String, options: Option<NapiParseOptions>) -> napi::Re
             "skipExpressionLoc",
         )?,
         loose: NapiParseOptions::flag(options.as_ref().and_then(|o| o.loose.as_ref()), "loose")?,
-        // The public AST API mirrors svelte/compiler `parse()`, which keeps
-        // `leadingComments`/`trailingComments` on nodes.
-        capture_comments: true,
-        ..ParseOptions::default()
+        ..ParseOptions::public_api()
     };
     match rust_parse(source, &rsvelte_core::Allocator::default(), parse_options) {
         Ok(ast) => {
@@ -287,7 +284,7 @@ pub fn napi_parse_envelope(
                 .and_then(|o| o.skip_expression_loc.as_ref()),
             "skipExpressionLoc",
         )?,
-        ..ParseOptions::default()
+        ..ParseOptions::public_api()
     };
     let skip_loc = parse_options.skip_expression_loc;
     let skip_css = NapiParseOptions::flag(


### PR DESCRIPTION
Fixes #3688.

Adds one core factory for public parse options and uses it from the NAPI string API, NAPI raw envelope API, and wasm API. All public AST bindings now retain leadingComments/trailingComments, while the compiler default keeps the comment attachment walk disabled.

Also adds a focused invariant test and a changeset.

Local builds/tests were intentionally not run per the requested workflow; cargo fmt --check and git diff --check pass.