### PR TITLE
fix(napi): align secondary compile entry validation

### DIFF
--- a/.changeset/tidy-buffers-wave.md
+++ b/.changeset/tidy-buffers-wave.md
@@ -1,0 +1,6 @@
+---
+'@rsvelte/compiler': patch
+'@rsvelte/vite-plugin-svelte-native': patch
+---
+
+Align the secondary N-API compile entries with the main compiler boundary: `compileBuffers` and `compileModuleBuffers` now throw structured `CompileError` objects, `compileBuffers` accepts `modernAst`, and `compileWithCssHash` no longer hides an invalid non-function `cssHash` option.

--- a/crates/rsvelte_napi/src/lib.rs
+++ b/crates/rsvelte_napi/src/lib.rs
@@ -494,7 +494,9 @@ pub async fn napi_compile_with_css_hash(
     // options object is this same function — drop it instead of rejecting it the
     // way the synchronous entries do.
     let mut options = options;
-    if let Some(o) = options.as_mut() {
+    if let Some(o) = options.as_mut()
+        && matches!(o.inner.css_hash, Some(LenientScalar::Function))
+    {
         o.inner.css_hash = None;
     }
     // An `async` export's arguments must be `Send`; `Env` is not, so this is
@@ -2323,7 +2325,7 @@ pub fn napi_compile_buffers(
     options: Option<NapiCompileOptionsArg>,
 ) -> napi::Result<CompileBuffersResult> {
     let opts = options_to_compile(Some(&env), options)?;
-    reject_modern_ast_for_binary_result(&opts, "compileBuffers")?;
+    let filename = opts.filename.clone();
     match rust_compile(&source, opts) {
         Ok(result) => Ok(CompileBuffersResult {
             js: CompileBuffersJs {
@@ -2342,7 +2344,7 @@ pub fn napi_compile_buffers(
                 .collect::<napi::Result<Vec<_>>>()?,
             runes: result.metadata.runes,
         }),
-        Err(e) => Err(napi::Error::from_reason(format!("{e:?}"))),
+        Err(e) => Err(compile_error(env, &source, filename.as_deref(), &e)),
     }
 }
 
@@ -2362,6 +2364,7 @@ pub fn napi_compile_module_buffers(
     options: Option<NapiModuleCompileOptionsArg>,
 ) -> napi::Result<CompileBuffersResult> {
     let opts = options_to_module_compile(Some(&env), options)?;
+    let filename = opts.filename.clone();
 
     match rust_compile_module(&source, opts) {
         Ok(result) => Ok(CompileBuffersResult {
@@ -2373,7 +2376,7 @@ pub fn napi_compile_module_buffers(
             warnings: Vec::new(),
             runes: true,
         }),
-        Err(e) => Err(napi::Error::from_reason(format!("{e:?}"))),
+        Err(e) => Err(compile_error(env, &source, filename.as_deref(), &e)),
     }
 }
 

--- a/scripts/dev/test-napi-compile-options.mjs
+++ b/scripts/dev/test-napi-compile-options.mjs
@@ -580,6 +580,14 @@ assert(
 		JSON.stringify(Object.keys(defaultAst).sort()) === JSON.stringify(officialDefaultKeys),
 	`default ast keys ${JSON.stringify(defaultAst && Object.keys(defaultAst).sort())} vs official ${JSON.stringify(officialDefaultKeys)}`
 );
+const modernAstBuffers = napi.compileBuffers(MODERN_AST_SRC, {
+	filename: 'A.svelte',
+	modernAst: true,
+});
+assert(
+	'compileBuffers.modernAst: accepts the legal option while omitting AST from its binary result',
+	Buffer.isBuffer(modernAstBuffers.js.code) && modernAstBuffers.js.code.length > 0,
+);
 let modernAstEnvelopeError;
 try {
 	napi.compileEnvelope(MODERN_AST_SRC, { filename: 'A.svelte', modernAst: true });

--- a/scripts/dev/test-napi-css-hash.mjs
+++ b/scripts/dev/test-napi-css-hash.mjs
@@ -126,6 +126,22 @@ assert(
 	typeMessage ?? 'no error thrown',
 );
 
+let asyncTypeMessage = null;
+try {
+	await napi.compileWithCssHash(
+		SRC,
+		{ ...OPTS, cssHash: 'not-a-function' },
+		() => 'fixed-hash',
+	);
+} catch (e) {
+	asyncTypeMessage = String(e?.message ?? e);
+}
+assert(
+	'compileWithCssHash validates a non-function cssHash instead of dropping it',
+	asyncTypeMessage != null && /cssHash should be a function/.test(asyncTypeMessage),
+	asyncTypeMessage ?? 'no error thrown',
+);
+
 const defaultResult = napi.compile(SRC, OPTS);
 assert(
 	'compile without cssHash is unaffected',

--- a/scripts/dev/test-vps-shim.mjs
+++ b/scripts/dev/test-vps-shim.mjs
@@ -118,6 +118,9 @@ await assertCompileError('compile() surfaces a shaped CompileError', () =>
 await assertCompileError('compileAsync() surfaces a shaped CompileError', () =>
 	r.compileAsync(invalidCompileSource, { filename: 'Invalid.svelte' }),
 );
+await assertCompileError('compileBuffers() surfaces a shaped CompileError', () =>
+	Promise.resolve(r.compileBuffers(invalidCompileSource, { filename: 'Invalid.svelte' })),
+);
 
 const asyncBatchInputs = [
 	{ source: compileSource, options: { filename: 'Foo.svelte', generate: 'client' } },


### PR DESCRIPTION
Closes #3662.
Closes #3663.

- throw the same structured `CompileError` from `compileBuffers` and `compileModuleBuffers` as the primary entries
- accept legal `modernAst: true` in `compileBuffers` while omitting AST from its binary-only result
- only strip a function-valued `cssHash` in `compileWithCssHash`, preserving validation for wrong types
- extend the existing N-API option, cssHash, and shim regression gates

Validation: `cargo fmt --all -- --check`; `git diff --check`. Per request, compilation and runtime suites are left to CI.