### PR TITLE
Align C ABI and wasm compile-option validation

### DIFF
--- a/.changeset/tidy-option-validators.md
+++ b/.changeset/tidy-option-validators.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/compiler": patch
+---
+
+Validate WebAssembly compiler options against Svelte's public option contract, including unknown and removed keys, invalid values, legacy warnings, and nested options.

--- a/compatibility/gate-coverage.md
+++ b/compatibility/gate-coverage.md
@@ -3597,17 +3597,18 @@ playground (`apps/playground/src/lib/compiler.ts`) and the published wasm build 
 
 ## 40. Wasm compile-option boundary — `scripts/dev/test-wasm-compile-options.mjs`
 
-**Unit.** Six invalid option objects are compiled by the wasm binding and official Svelte; the
-error `code` and first message line must agree. Independent assertions cover the six legacy
-warning codes, truthy non-boolean `runes`, the three parametric options, `warningFilter`, and
-`cssHash` callback arguments, fallback and throws. Hard gate, no ratchet.
+**Unit.** Six invalid option objects are compiled by the wasm binding and the
+workspace-pinned official `svelte/compiler`; the error `code` and first message line must
+agree. Independent assertions cover the six legacy warning codes, truthy non-boolean `runes`,
+the three parametric options, `warningFilter`, and `cssHash` callback arguments, fallback and
+throws. Hard gate, no ratchet.
 
 **Sharpest blind spots [S].** The rejection grid samples six of the declared keys and only one
 invalid value per key. It does not compare error positions, two-invalid-key ordering, most
 successful scalar values, or any C ABI/NAPI result. Callback parity is mostly property-based
 rather than full output equality, and all cases compile one small component. The key list is
 manually mirrored in the binding, so adding the same option to every list without a behavioural
-case can still pass.
+case can still pass. The npm oracle version can briefly lead or lag the Svelte submodule pin.
 
 ---
 

--- a/compatibility/gate-coverage.md
+++ b/compatibility/gate-coverage.md
@@ -150,6 +150,7 @@ samples) — see `AGENTS.md` § "Generated shape matrix" and issue #2281.
 | 39 | svelte2tsx option axis | full TSX text per (option variant x source) against the official tool, options carried in the fixture | option values outside its grid (`rewriteExternalImports`, `runes`, most `namespace` x `mode` products); `emitDts`; the map, `exportedNames` and `events` | [S] [D] |
 | 38 | NAPI `cssHash` | the scope class the callback produces, and the callback's own argument list, against **official** | one component shape and one option set; only `css.code` / the class in `js.code`; nothing about the wasm or facade ports of the same option | [S] |
 | 39 | Print fixture suite (`tests/print.rs`) | per-sample printed Svelte text vs upstream's `output.svelte` | it compares the text, not **which code produced it** — a source-text shortcut around the whole AST printer was invisible for 43 of 43 samples | [D] |
+| 40 | Wasm compile-option boundary | six rejection outcomes against **official**, plus named callback/warning behaviours | most valid option values; error positions; interaction/order between two invalid keys; C ABI and NAPI ports | [S] |
 
 Cross-cutting blind spots (**ratchet keys losing in both directions**, path filters, ratchet-doc
 drift, vacuity floors, the **performance**
@@ -3477,8 +3478,8 @@ list would pass, since `includes()` only needs one occurrence.
 ### 38c — the other two ports of the same option are not here [S]
 
 `cssHash` is implemented three times: the napi bridge, the wasm bridge
-(`crates/rsvelte_lint_bindings/src/compiler_wasm/mod.rs`, exercised only by
-`scripts/dev/test-wasm-compile-options.mjs`, which compares rsvelte to rsvelte), and the
+(`crates/rsvelte_lint_bindings/src/compiler_wasm/mod.rs`, exercised by
+`scripts/dev/test-wasm-compile-options.mjs`, whose rejection matrix compares against official), and the
 `rsvelte` facade's `options.rs`, which no gate drives at all. This is the "two ports of one
 function and no gate compares the ports" shape recorded for the constant fold: the wasm port
 already passed the official argument shape while the napi port did not, and nothing would have
@@ -3591,6 +3592,22 @@ already disagree: the NAPI one sets `capture_comments: true`
 comments at all. Only the NAPI port is driven here. This is the "two ports of one function, and
 no gate compares the ports" shape from `two-ports-inventory.md`, and the wasm one is what the
 playground (`apps/playground/src/lib/compiler.ts`) and the published wasm build call.
+
+---
+
+## 40. Wasm compile-option boundary — `scripts/dev/test-wasm-compile-options.mjs`
+
+**Unit.** Six invalid option objects are compiled by the wasm binding and official Svelte; the
+error `code` and first message line must agree. Independent assertions cover the six legacy
+warning codes, truthy non-boolean `runes`, the three parametric options, `warningFilter`, and
+`cssHash` callback arguments, fallback and throws. Hard gate, no ratchet.
+
+**Sharpest blind spots [S].** The rejection grid samples six of the declared keys and only one
+invalid value per key. It does not compare error positions, two-invalid-key ordering, most
+successful scalar values, or any C ABI/NAPI result. Callback parity is mostly property-based
+rather than full output equality, and all cases compile one small component. The key list is
+manually mirrored in the binding, so adding the same option to every list without a behavioural
+case can still pass.
 
 ---
 

--- a/compatibility/two-ports-inventory.md
+++ b/compatibility/two-ports-inventory.md
@@ -88,6 +88,7 @@ whose oracle is the other implementation is only as good as its independent expe
 | [12](#12-selector-unused-and-element-scoped-are-two-engines-over-two-element-models--s) | "Selector unused" vs "element scoped" | 2 engines, 2 element models | **[S]** | no |
 | [13](#13-what-does-a-call-to-one-of-upstreams-globals-keypaths-evaluate-to--d-closed-by-degree-1) | What does a call to one of upstream's `globals` keypaths evaluate to? | 2 tables | **[D]** | closed by #3471 (degree 1) |
 | [14](#14-what-options-does-the-public-parse-run-with--d) | What options does the public `parse()` run with? | 2 bindings | **[D]** | #3688 open |
+| [15](#15-how-are-public-compile-options-validated--d) | How are public compile options validated? | 3 bindings | **[D]** | #3664 defended at degree 2 |
 
 ---
 
@@ -465,6 +466,25 @@ this went unobserved.
 is gate-coverage **39g**. Corpus growth cannot reach the wasm port, because it is in no gate's
 population. And the wasm build is what `@rsvelte/compiler` and the playground ship, so the port a
 user installs is the unmeasured one.
+
+### 15. How are public compile options validated? — [D]
+
+**Upstream:** `packages/svelte/src/compiler/validate-options.js` owns one ordered schema for
+`compile` and `compileModule`, including parametric values, removed-option errors and process-wide
+legacy warnings.
+
+**Ports.** The NAPI conversion in `crates/rsvelte_napi/src/lib.rs`, the C ABI JSON conversion in
+`crates/rsvelte_capi/src/lib.rs`, and the wasm conversion in
+`crates/rsvelte_lint_bindings/src/compiler_wasm/mod.rs` each implement that schema. #3664 recorded
+demonstrated disagreements on unknown keys, wrong scalar types, nested keys, aliases, removed
+options and truthy `runes` values.
+
+**Defended at degree 2.** `scripts/dev/test-wasm-compile-options.mjs` now compares representative
+rejections directly with official Svelte and pins the warning and parametric cases independently;
+the C ABI suite spells the same exact messages and behaviours as independent expectations. The
+ports remain separate because their value domains differ (JS callbacks versus JSON and native
+callbacks), so this closes the demonstrated cells rather than removing the row. A new option or
+validator kind still has to be added to all three ports and their boundary gates.
 
 ## Adding a row, and closing one
 

--- a/crates/rsvelte_capi/src/lib.rs
+++ b/crates/rsvelte_capi/src/lib.rs
@@ -587,13 +587,13 @@ fn success_envelope(result: Value) -> RsvelteBuf {
 // --- options parsing ------------------------------------------------------
 
 #[derive(Debug, Deserialize, Default)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 struct CapiExperimentalOptions {
     r#async: Option<bool>,
 }
 
 #[derive(Debug, Deserialize, Default)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 struct CapiCompatibilityOptions {
     component_api: Option<u32>,
 }
@@ -602,7 +602,7 @@ struct CapiCompatibilityOptions {
 #[serde(rename_all = "camelCase", default)]
 struct CapiCompileOptionsJson {
     dev: Option<bool>,
-    generate: Option<String>,
+    generate: Value,
     filename: Option<String>,
     root_dir: Option<String>,
     name: Option<String>,
@@ -613,7 +613,7 @@ struct CapiCompileOptionsJson {
     css: Option<String>,
     preserve_comments: Option<bool>,
     preserve_whitespace: Option<bool>,
-    runes: Option<bool>,
+    runes: Value,
     disclose_version: Option<bool>,
     sourcemap: Option<Value>,
     output_filename: Option<String>,
@@ -630,36 +630,256 @@ struct CapiCompileOptionsJson {
 #[serde(rename_all = "camelCase", default)]
 struct CapiModuleCompileOptionsJson {
     dev: Option<bool>,
-    generate: Option<String>,
+    generate: Value,
     filename: Option<String>,
     root_dir: Option<String>,
     experimental: Option<CapiExperimentalOptions>,
 }
 
+const CAPI_RECOGNISED_COMPILE_OPTIONS: &[&str] = &[
+    "filename",
+    "rootDir",
+    "dev",
+    "generate",
+    "warningFilter",
+    "experimental",
+    "accessors",
+    "css",
+    "cssHash",
+    "cssHashOverride",
+    "cssOutputFilename",
+    "customElement",
+    "discloseVersion",
+    "immutable",
+    "legacy",
+    "compatibility",
+    "loopGuardTimeout",
+    "name",
+    "namespace",
+    "modernAst",
+    "outputFilename",
+    "preserveComments",
+    "fragments",
+    "preserveWhitespace",
+    "runes",
+    "hmr",
+    "sourcemap",
+    "enableSourcemap",
+    "hydratable",
+    "format",
+    "tag",
+    "sveltePath",
+    "errorMode",
+    "varsReport",
+];
+
+static WARNED_GENERATE_DOM_SSR: std::sync::atomic::AtomicBool =
+    std::sync::atomic::AtomicBool::new(false);
+
+fn parse_generate_option(value: &Value) -> Result<(GenerateMode, bool), String> {
+    match value {
+        Value::String(value) if value == "client" => Ok((GenerateMode::Client, false)),
+        Value::String(value) if value == "dom" => Ok((GenerateMode::Client, true)),
+        Value::String(value) if value == "server" => Ok((GenerateMode::Server, false)),
+        Value::String(value) if value == "ssr" => Ok((GenerateMode::Server, true)),
+        Value::Bool(false) => Ok((GenerateMode::None, false)),
+        _ => Err("Invalid compiler option: generate must be \"client\", \"server\" or false\nhttps://svelte.dev/e/options_invalid_value".to_string()),
+    }
+}
+
+fn invalid_capi_option(detail: impl std::fmt::Display) -> String {
+    format!("Invalid compiler option: {detail}\nhttps://svelte.dev/e/options_invalid_value")
+}
+
+fn validate_capi_option_types(value: &Value, component: bool) -> Result<(), String> {
+    let object = value
+        .as_object()
+        .expect("parse_options_value checked object");
+    let validate_string = |key: &str| -> Result<(), String> {
+        if object.get(key).is_some_and(|value| !value.is_string()) {
+            return Err(invalid_capi_option(format!(
+                "{key} should be a string, if specified"
+            )));
+        }
+        Ok(())
+    };
+    let validate_bool = |key: &str| -> Result<(), String> {
+        if object.get(key).is_some_and(|value| !value.is_boolean()) {
+            return Err(invalid_capi_option(format!(
+                "{key} should be true or false, if specified"
+            )));
+        }
+        Ok(())
+    };
+
+    // Keep this in validate-options.js order so an object containing multiple
+    // invalid values reports the same first failure as upstream.
+    for key in ["filename", "rootDir"] {
+        validate_string(key)?;
+    }
+    validate_bool("dev")?;
+    if let Some(generate) = object.get("generate") {
+        parse_generate_option(generate)?;
+    }
+    if object.contains_key("warningFilter") {
+        return Err(invalid_capi_option(
+            "warningFilter should be a function, if specified",
+        ));
+    }
+    if let Some(experimental) = object.get("experimental").filter(|value| !value.is_null()) {
+        let nested = experimental
+            .as_object()
+            .ok_or_else(|| invalid_capi_option("experimental should be an object"))?;
+        if let Some(key) = nested.keys().find(|key| key.as_str() != "async") {
+            return Err(format!(
+                "Unrecognised compiler option experimental.{key}\nhttps://svelte.dev/e/options_unrecognised"
+            ));
+        }
+        if nested.get("async").is_some_and(|value| !value.is_boolean()) {
+            return Err(invalid_capi_option(
+                "experimental.async should be true or false, if specified",
+            ));
+        }
+    }
+
+    // validate_module_options maps every component-only key to a no-op.
+    if !component {
+        return Ok(());
+    }
+
+    validate_bool("accessors")?;
+    if let Some(css) = object.get("css") {
+        match css {
+            Value::Bool(_) => {
+                return Err(invalid_capi_option(
+                    "The boolean options have been removed from the css option. Use \"external\" instead of false and \"injected\" instead of true",
+                ));
+            }
+            Value::String(value) if value == "none" => {
+                return Err(invalid_capi_option(
+                    "css: \"none\" is no longer a valid option. If this was crucial for you, please open an issue on GitHub with your use case.",
+                ));
+            }
+            Value::String(value) if value == "external" || value == "injected" => {}
+            _ => {
+                return Err(invalid_capi_option(
+                    "css should be either \"external\" (default, recommended) or \"injected\"",
+                ));
+            }
+        }
+    }
+    if object.contains_key("cssHash") {
+        return Err(invalid_capi_option(
+            "cssHash should be a function, if specified",
+        ));
+    }
+    for key in ["cssOutputFilename", "cssHashOverride"] {
+        validate_string(key)?;
+    }
+    if object
+        .get("customElement")
+        .is_some_and(|value| !value.is_boolean())
+    {
+        return Err(invalid_capi_option("customElement should be true or false"));
+    }
+    for key in ["discloseVersion", "immutable"] {
+        validate_bool(key)?;
+    }
+    if object.contains_key("legacy") {
+        return Err("Invalid compiler option: The legacy option has been removed. If you are using this because of legacy.componentApi, use compatibility.componentApi instead\nhttps://svelte.dev/e/options_removed".to_string());
+    }
+
+    if let Some(compatibility) = object.get("compatibility").filter(|value| !value.is_null()) {
+        let nested = compatibility
+            .as_object()
+            .ok_or_else(|| invalid_capi_option("compatibility should be an object"))?;
+        if let Some(key) = nested.keys().find(|key| key.as_str() != "componentApi") {
+            return Err(format!(
+                "Unrecognised compiler option compatibility.{key}\nhttps://svelte.dev/e/options_unrecognised"
+            ));
+        }
+        if let Some(component_api) = nested.get("componentApi")
+            && component_api.as_u64() != Some(4)
+            && component_api.as_u64() != Some(5)
+        {
+            return Err(invalid_capi_option(
+                "compatibility.componentApi should be either \"4\" or \"5\"",
+            ));
+        }
+    }
+    validate_string("name")?;
+    if let Some(namespace) = object.get("namespace")
+        && !matches!(namespace.as_str(), Some("html" | "mathml" | "svg"))
+    {
+        return Err(invalid_capi_option(
+            "namespace should be one of \"html\", \"mathml\" or \"svg\"",
+        ));
+    }
+    for key in ["modernAst", "preserveComments", "preserveWhitespace", "hmr"] {
+        validate_bool(key)?;
+    }
+    validate_string("outputFilename")?;
+    if let Some(fragments) = object.get("fragments")
+        && !matches!(fragments.as_str(), Some("html" | "tree"))
+    {
+        return Err(invalid_capi_option(
+            "fragments should be either \"html\" or \"tree\"",
+        ));
+    }
+    Ok(())
+}
+
+unsafe fn parse_options_value(ptr: *const u8, len: usize) -> Result<Value, String> {
+    if len == 0 {
+        return Ok(Value::Object(serde_json::Map::new()));
+    }
+    // SAFETY: upheld by the caller's documented pointer/length contract.
+    let source = unsafe { borrow_utf8(ptr, len) }
+        .ok_or_else(|| "options_json is not valid UTF-8".to_string())?;
+    let value: Value =
+        serde_json::from_str(source).map_err(|e| format!("options_json parse error: {e}"))?;
+    let object = value
+        .as_object()
+        .ok_or_else(|| "Invalid compiler option: options should be an object".to_string())?;
+    if let Some(key) = object
+        .keys()
+        .find(|key| !CAPI_RECOGNISED_COMPILE_OPTIONS.contains(&key.as_str()))
+    {
+        return Err(format!(
+            "Unrecognised compiler option {key}\nhttps://svelte.dev/e/options_unrecognised"
+        ));
+    }
+    Ok(value)
+}
+
 /// # Safety
 /// See [`borrow_utf8`].
 unsafe fn parse_compile_options(ptr: *const u8, len: usize) -> Result<CompileOptions, String> {
-    let raw: CapiCompileOptionsJson = if len == 0 {
-        CapiCompileOptionsJson::default()
-    } else {
-        // SAFETY: upheld by this function's documented `# Safety` contract
-        // (valid pointers/lengths and a writable out-pointer supplied by the caller).
-        let s = unsafe { borrow_utf8(ptr, len) }
-            .ok_or_else(|| "options_json is not valid UTF-8".to_string())?;
-        serde_json::from_str(s).map_err(|e| format!("options_json parse error: {e}"))?
+    // SAFETY: upheld by this function's documented pointer/length contract.
+    let value = unsafe { parse_options_value(ptr, len)? };
+    let supplied = |key: &str| {
+        value
+            .as_object()
+            .is_some_and(|object| object.contains_key(key))
     };
+    validate_capi_option_types(&value, true)?;
+    let raw: CapiCompileOptionsJson = serde_json::from_value(value.clone())
+        .map_err(|e| format!("options_json parse error: {e}"))?;
 
     let mut opts = CompileOptions::default();
     if let Some(v) = raw.dev {
         opts.dev = v;
     }
-    if let Some(v) = raw.generate.as_deref() {
-        opts.generate = match v {
-            "client" => GenerateMode::Client,
-            "server" | "ssr" => GenerateMode::Server,
-            "false" => GenerateMode::None,
-            _ => return Err(format!("invalid generate option: {v:?}")),
-        };
+    if supplied("generate") {
+        let (generate, renamed) = parse_generate_option(&raw.generate)?;
+        opts.generate = generate;
+        if renamed {
+            opts.legacy_options.generate_dom_ssr =
+                !WARNED_GENERATE_DOM_SSR.swap(true, std::sync::atomic::Ordering::Relaxed);
+        }
+    }
+    if supplied("warningFilter") {
+        return Err("Invalid compiler option: warningFilter should be a function, if specified\nhttps://svelte.dev/e/options_invalid_value".to_string());
     }
     if let Some(v) = raw.filename {
         opts.filename = Some(v);
@@ -689,7 +909,9 @@ unsafe fn parse_compile_options(ptr: *const u8, len: usize) -> Result<CompileOpt
             "html" => Namespace::Html,
             "svg" => Namespace::Svg,
             "mathml" => Namespace::Mathml,
-            _ => return Err(format!("invalid namespace option: {v:?}")),
+            _ => {
+                return Err("Invalid compiler option: namespace should be one of \"html\", \"mathml\" or \"svg\"\nhttps://svelte.dev/e/options_invalid_value".to_string());
+            }
         };
     }
     if let Some(v) = raw.immutable {
@@ -699,12 +921,29 @@ unsafe fn parse_compile_options(ptr: *const u8, len: usize) -> Result<CompileOpt
         opts.legacy_options.immutable =
             !WARNED_IMMUTABLE.swap(true, std::sync::atomic::Ordering::Relaxed);
     }
+    if supplied("legacy") {
+        return Err("Invalid compiler option: The legacy option has been removed. If you are using this because of legacy.componentApi, use compatibility.componentApi instead\nhttps://svelte.dev/e/options_removed".to_string());
+    }
+    if supplied("loopGuardTimeout") {
+        static WARNED_LOOP_GUARD_TIMEOUT: std::sync::atomic::AtomicBool =
+            std::sync::atomic::AtomicBool::new(false);
+        opts.legacy_options.loop_guard_timeout =
+            !WARNED_LOOP_GUARD_TIMEOUT.swap(true, std::sync::atomic::Ordering::Relaxed);
+    }
     if let Some(v) = raw.css.as_deref() {
         opts.css = match v {
             "external" => CssMode::External,
             "injected" => CssMode::Injected,
-            _ => return Err(format!("invalid css option: {v:?}")),
+            "none" => {
+                return Err("Invalid compiler option: css: \"none\" is no longer a valid option. If this was crucial for you, please open an issue on GitHub with your use case.\nhttps://svelte.dev/e/options_invalid_value".to_string());
+            }
+            _ => {
+                return Err("Invalid compiler option: css should be either \"external\" (default, recommended) or \"injected\"\nhttps://svelte.dev/e/options_invalid_value".to_string());
+            }
         };
+    }
+    if supplied("cssHash") {
+        return Err("Invalid compiler option: cssHash should be a function, if specified\nhttps://svelte.dev/e/options_invalid_value".to_string());
     }
     if let Some(v) = raw.preserve_comments {
         opts.preserve_comments = v;
@@ -712,11 +951,59 @@ unsafe fn parse_compile_options(ptr: *const u8, len: usize) -> Result<CompileOpt
     if let Some(v) = raw.preserve_whitespace {
         opts.preserve_whitespace = v;
     }
-    if let Some(v) = raw.runes {
-        opts.runes = Some(v);
+    if !raw.runes.is_null() {
+        opts.runes = match &raw.runes {
+            Value::Bool(value) => Some(*value),
+            Value::Number(value) if value.as_f64().is_some_and(|n| n != 0.0 && !n.is_nan()) => {
+                Some(true)
+            }
+            Value::String(value) if !value.is_empty() => Some(true),
+            Value::Array(_) | Value::Object(_) => Some(true),
+            _ => None,
+        };
     }
     if let Some(v) = raw.disclose_version {
         opts.disclose_version = v;
+    }
+    if supplied("enableSourcemap") {
+        static WARNED_ENABLE_SOURCEMAP: std::sync::atomic::AtomicBool =
+            std::sync::atomic::AtomicBool::new(false);
+        opts.legacy_options.enable_sourcemap =
+            !WARNED_ENABLE_SOURCEMAP.swap(true, std::sync::atomic::Ordering::Relaxed);
+    }
+    if supplied("hydratable") {
+        static WARNED_HYDRATABLE: std::sync::atomic::AtomicBool =
+            std::sync::atomic::AtomicBool::new(false);
+        opts.legacy_options.hydratable =
+            !WARNED_HYDRATABLE.swap(true, std::sync::atomic::Ordering::Relaxed);
+    }
+    for (key, message) in [
+        (
+            "format",
+            "The format option has been removed in Svelte 4, the compiler only outputs ESM now. Remove \"format\" from your compiler options. If you did not set this yourself, bump the version of your bundler plugin (vite-plugin-svelte/rollup-plugin-svelte/svelte-loader)",
+        ),
+        (
+            "tag",
+            "The tag option has been removed in Svelte 5. Use `<svelte:options customElement=\"tag-name\" />` inside the component instead. If that does not solve your use case, please open an issue on GitHub with details.",
+        ),
+        (
+            "sveltePath",
+            "The sveltePath option has been removed in Svelte 5. If this option was crucial for you, please open an issue on GitHub with your use case.",
+        ),
+        (
+            "errorMode",
+            "The errorMode option has been removed. If you are using this through svelte-preprocess with TypeScript, use the https://www.typescriptlang.org/tsconfig#verbatimModuleSyntax setting instead",
+        ),
+        (
+            "varsReport",
+            "The vars option has been removed. If you are using this through svelte-preprocess with TypeScript, use the https://www.typescriptlang.org/tsconfig#verbatimModuleSyntax setting instead",
+        ),
+    ] {
+        if supplied(key) {
+            return Err(format!(
+                "Invalid compiler option: {message}\nhttps://svelte.dev/e/options_removed"
+            ));
+        }
     }
     if let Some(v) = raw.sourcemap {
         if let Some(s) = v.as_str() {
@@ -751,7 +1038,9 @@ unsafe fn parse_compile_options(ptr: *const u8, len: usize) -> Result<CompileOpt
         opts.compatibility.component_api = match v {
             4 => rsvelte_core::compiler::ComponentApi::V4,
             5 => rsvelte_core::compiler::ComponentApi::V5,
-            _ => return Err(format!("invalid compatibility.componentApi option: {v}")),
+            _ => {
+                return Err("Invalid compiler option: compatibility.componentApi should be either \"4\" or \"5\"\nhttps://svelte.dev/e/options_invalid_value".to_string());
+            }
         };
     }
     if let Some(hash_override) = raw.css_hash_override {
@@ -763,7 +1052,9 @@ unsafe fn parse_compile_options(ptr: *const u8, len: usize) -> Result<CompileOpt
         opts.fragments = match v {
             "html" => rsvelte_core::compiler::FragmentMode::Html,
             "tree" => rsvelte_core::compiler::FragmentMode::Tree,
-            _ => return Err(format!("invalid fragments option: {v:?}")),
+            _ => {
+                return Err("Invalid compiler option: fragments should be either \"html\" or \"tree\"\nhttps://svelte.dev/e/options_invalid_value".to_string());
+            }
         };
     }
     Ok(opts)
@@ -772,27 +1063,28 @@ unsafe fn parse_compile_options(ptr: *const u8, len: usize) -> Result<CompileOpt
 /// # Safety
 /// See [`borrow_utf8`].
 unsafe fn parse_module_options(ptr: *const u8, len: usize) -> Result<ModuleCompileOptions, String> {
-    let raw: CapiModuleCompileOptionsJson = if len == 0 {
-        CapiModuleCompileOptionsJson::default()
-    } else {
-        // SAFETY: upheld by this function's documented `# Safety` contract
-        // (valid pointers/lengths and a writable out-pointer supplied by the caller).
-        let s = unsafe { borrow_utf8(ptr, len) }
-            .ok_or_else(|| "options_json is not valid UTF-8".to_string())?;
-        serde_json::from_str(s).map_err(|e| format!("options_json parse error: {e}"))?
-    };
+    // Module compilation recognises component-only keys as no-ops, matching
+    // `validate_module_options`; truly unknown keys must still be rejected.
+    // SAFETY: upheld by this function's documented pointer/length contract.
+    let value = unsafe { parse_options_value(ptr, len)? };
+    validate_capi_option_types(&value, false)?;
+    let generate_supplied = value
+        .as_object()
+        .is_some_and(|object| object.contains_key("generate"));
+    let raw: CapiModuleCompileOptionsJson =
+        serde_json::from_value(value).map_err(|e| format!("options_json parse error: {e}"))?;
 
     let mut opts = ModuleCompileOptions::default();
     if let Some(v) = raw.dev {
         opts.dev = v;
     }
-    if let Some(v) = raw.generate.as_deref() {
-        opts.generate = match v {
-            "client" => GenerateMode::Client,
-            "server" | "ssr" => GenerateMode::Server,
-            "false" => GenerateMode::None,
-            _ => return Err(format!("invalid generate option: {v:?}")),
-        };
+    if generate_supplied {
+        let (generate, renamed) = parse_generate_option(&raw.generate)?;
+        opts.generate = generate;
+        if renamed {
+            opts.legacy_options.generate_dom_ssr =
+                !WARNED_GENERATE_DOM_SSR.swap(true, std::sync::atomic::Ordering::Relaxed);
+        }
     }
     if let Some(v) = raw.filename {
         opts.filename = Some(v);

--- a/crates/rsvelte_capi/tests/module.rs
+++ b/crates/rsvelte_capi/tests/module.rs
@@ -45,3 +45,23 @@ fn module_compile_handles_malformed_options() {
             .contains("options_json")
     );
 }
+
+#[test]
+fn module_compile_rejects_unknown_but_ignores_component_only_options() {
+    let unknown = compile_module("export const x = 1;", r#"{"nonsense":1}"#);
+    assert_eq!(unknown["ok"], serde_json::Value::Bool(false));
+    assert!(
+        unknown["error"]["message"]
+            .as_str()
+            .unwrap()
+            .contains("options_unrecognised")
+    );
+
+    // Upstream's module validator recognises every component-only option and
+    // maps it to a no-op validator, including removed and wrong-typed values.
+    let ignored = compile_module(
+        "export const x = 1;",
+        r#"{"legacy":null,"accessors":"not-a-boolean"}"#,
+    );
+    assert_eq!(ignored["ok"], serde_json::Value::Bool(true));
+}

--- a/crates/rsvelte_capi/tests/options_coverage.rs
+++ b/crates/rsvelte_capi/tests/options_coverage.rs
@@ -172,8 +172,7 @@ fn enum_options_reject_unknown_values_and_accept_documented_aliases() {
     for options in [
         r#"{"generate":"client"}"#,
         r#"{"generate":"server"}"#,
-        r#"{"generate":"ssr"}"#,
-        r#"{"generate":"false"}"#,
+        r#"{"generate":false}"#,
         r#"{"namespace":"html"}"#,
         r#"{"namespace":"svg"}"#,
         r#"{"namespace":"mathml"}"#,
@@ -195,6 +194,59 @@ fn enum_options_reject_unknown_values_and_accept_documented_aliases() {
             .unwrap()
             .contains("componentApi")
     );
+}
+
+#[test]
+fn option_validation_rejects_unknown_removed_and_nested_unknown_keys() {
+    for (options, expected) in [
+        (
+            r#"{"nonsense":1}"#,
+            "Unrecognised compiler option nonsense\nhttps://svelte.dev/e/options_unrecognised",
+        ),
+        (
+            r#"{"legacy":null}"#,
+            "Invalid compiler option: The legacy option has been removed. If you are using this because of legacy.componentApi, use compatibility.componentApi instead\nhttps://svelte.dev/e/options_removed",
+        ),
+        (
+            r#"{"experimental":{"async":true,"nonsense":1}}"#,
+            "Unrecognised compiler option experimental.nonsense\nhttps://svelte.dev/e/options_unrecognised",
+        ),
+        (
+            r#"{"compatibility":{"componentApi":5,"nonsense":1}}"#,
+            "Unrecognised compiler option compatibility.nonsense\nhttps://svelte.dev/e/options_unrecognised",
+        ),
+        (
+            r#"{"dev":"yes"}"#,
+            "Invalid compiler option: dev should be true or false, if specified\nhttps://svelte.dev/e/options_invalid_value",
+        ),
+        (
+            r#"{"customElement":"x-a"}"#,
+            "Invalid compiler option: customElement should be true or false\nhttps://svelte.dev/e/options_invalid_value",
+        ),
+        (
+            r#"{"css":false}"#,
+            "Invalid compiler option: The boolean options have been removed from the css option. Use \"external\" instead of false and \"injected\" instead of true\nhttps://svelte.dev/e/options_invalid_value",
+        ),
+    ] {
+        let env = compile("<p>x</p>", options);
+        assert_eq!(env["ok"], serde_json::Value::Bool(false), "{options}");
+        assert_eq!(env["error"]["message"], expected, "{options}");
+    }
+}
+
+#[test]
+fn truthy_non_boolean_runes_matches_parametric_semantics() {
+    let env = compile("<p>x</p>", r#"{"runes":1}"#);
+    assert_eq!(
+        ok_result(&env)["metadata"]["runes"],
+        serde_json::Value::Bool(true)
+    );
+}
+
+#[test]
+fn legacy_generate_alias_is_accepted_and_warns() {
+    let env = compile("<p>x</p>", r#"{"generate":"dom"}"#);
+    assert!(warning_codes(&env).contains(&"options_renamed_ssr_dom".to_string()));
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/rsvelte_lint_bindings/src/compiler_wasm/mod.rs
+++ b/crates/rsvelte_lint_bindings/src/compiler_wasm/mod.rs
@@ -3,15 +3,18 @@
 //! This module provides JavaScript-accessible functions for compiling
 //! Svelte components in the browser.
 
-use std::sync::{Arc, Mutex};
+use std::sync::{
+    Arc, Mutex,
+    atomic::{AtomicBool, Ordering},
+};
 
 use wasm_bindgen::prelude::*;
 
 use crate::compiler::phases::phase1_parse::{ParseOptions, parse};
 use crate::compiler::phases::phase3_transform::css::generate_css_hash;
 use crate::compiler::{
-    CompileOptions, CompileResult, CssHashFn, CssHashInput, CssMode, GenerateMode, Namespace,
-    Warning, WarningFilterFn, compile,
+    CompileOptions, CompileResult, ComponentApi, CssHashFn, CssHashInput, CssMode,
+    ExperimentalOptions, FragmentMode, GenerateMode, Namespace, Warning, WarningFilterFn, compile,
 };
 use crate::svelte2tsx::{Svelte2TsxOptions, svelte2tsx as rust_svelte2tsx};
 
@@ -249,6 +252,110 @@ fn get_prop(obj: &JsValue, key: &str) -> JsValue {
     js_sys::Reflect::get(obj, &JsValue::from_str(key)).unwrap_or(JsValue::UNDEFINED)
 }
 
+const RECOGNISED_COMPILE_OPTIONS: &[&str] = &[
+    "filename",
+    "rootDir",
+    "dev",
+    "generate",
+    "warningFilter",
+    "experimental",
+    "accessors",
+    "css",
+    "cssHash",
+    "cssHashOverride",
+    "cssOutputFilename",
+    "customElement",
+    "discloseVersion",
+    "immutable",
+    "legacy",
+    "compatibility",
+    "loopGuardTimeout",
+    "name",
+    "namespace",
+    "modernAst",
+    "outputFilename",
+    "preserveComments",
+    "fragments",
+    "preserveWhitespace",
+    "runes",
+    "hmr",
+    "sourcemap",
+    "enableSourcemap",
+    "hydratable",
+    "format",
+    "tag",
+    "sveltePath",
+    "errorMode",
+    "varsReport",
+];
+
+fn present(value: &JsValue) -> bool {
+    !value.is_undefined()
+}
+
+fn invalid_option(detail: impl std::fmt::Display) -> String {
+    format!("Invalid compiler option: {detail}\nhttps://svelte.dev/e/options_invalid_value")
+}
+
+fn option_error_to_js(message: String) -> JsValue {
+    let error = js_sys::Error::new(&message);
+    error.set_name("CompileError");
+    let code = if message.contains("/options_unrecognised") {
+        "options_unrecognised"
+    } else if message.contains("/options_removed") {
+        "options_removed"
+    } else {
+        "options_invalid_value"
+    };
+    let _ = js_sys::Reflect::set(
+        error.as_ref(),
+        &JsValue::from_str("code"),
+        &JsValue::from_str(code),
+    );
+    error.into()
+}
+
+fn require_bool(options: &JsValue, key: &str) -> Result<Option<bool>, String> {
+    let value = get_prop(options, key);
+    if !present(&value) {
+        return Ok(None);
+    }
+    value
+        .as_bool()
+        .map(Some)
+        .ok_or_else(|| invalid_option(format!("{key} should be true or false, if specified")))
+}
+
+fn require_string(options: &JsValue, key: &str) -> Result<Option<String>, String> {
+    let value = get_prop(options, key);
+    if !present(&value) {
+        return Ok(None);
+    }
+    value
+        .as_string()
+        .map(Some)
+        .ok_or_else(|| invalid_option(format!("{key} should be a string, if specified")))
+}
+
+fn warn_once(flag: &AtomicBool) -> bool {
+    !flag.swap(true, Ordering::Relaxed)
+}
+
+fn reject_unrecognised_options(options: &JsValue) -> Result<(), String> {
+    if options.is_null() || options.is_undefined() {
+        return Ok(());
+    }
+    for key in js_sys::Object::keys(&js_sys::Object::from(options.clone())).iter() {
+        let Some(key) = key.as_string() else { continue };
+        if !RECOGNISED_COMPILE_OPTIONS.contains(&key.as_str()) {
+            return Err(format!(
+                "Unrecognised compiler option {key}\nhttps://svelte.dev/e/options_unrecognised"
+            ));
+        }
+    }
+    Ok(())
+}
+
 /// Read `options[key]`, evaluating it once with `{ filename }` if it is a
 /// function (Svelte's `parametric()` normalization); otherwise return the raw
 /// value.
@@ -369,76 +476,253 @@ fn build_compile_options(
         return Ok(opts);
     }
 
-    let filename = get_prop(options, "filename").as_string();
+    reject_unrecognised_options(options)?;
+
+    let filename = require_string(options, "filename")?;
     // Svelte defaults `filename` to '(unknown)' before invoking parametric fns.
     let meta_filename = filename.clone().unwrap_or_else(|| "(unknown)".to_string());
     opts.filename = filename;
-    opts.root_dir = get_prop(options, "rootDir").as_string();
-    if let Some(n) = get_prop(options, "name").as_string() {
-        opts.name = Some(n);
+    opts.root_dir = require_string(options, "rootDir")?;
+
+    if let Some(value) = require_bool(options, "dev")? {
+        opts.dev = value;
     }
 
-    let generate = resolve_maybe_fn(options, "generate", &meta_filename);
-    if let Some(s) = generate.as_string() {
-        opts.generate = match s.as_str() {
-            "client" | "dom" => GenerateMode::Client,
-            "server" | "ssr" => GenerateMode::Server,
-            "false" => GenerateMode::None,
-            _ => return Err("generate must be \"client\", \"server\" or false".to_string()),
+    // `generate` is not parametric — functions are invalid values rather than
+    // callbacks receiving `{ filename }`.
+    let generate = get_prop(options, "generate");
+    if present(&generate) {
+        let (mode, renamed) = match generate.as_string().as_deref() {
+            Some("client") => (GenerateMode::Client, false),
+            Some("dom") => (GenerateMode::Client, true),
+            Some("server") => (GenerateMode::Server, false),
+            Some("ssr") => (GenerateMode::Server, true),
+            _ if generate.as_bool() == Some(false) => (GenerateMode::None, false),
+            _ => {
+                return Err(invalid_option(
+                    "generate must be \"client\", \"server\" or false",
+                ));
+            }
         };
-    } else if generate.as_bool() == Some(false) {
-        opts.generate = GenerateMode::None;
+        opts.generate = mode;
+        if renamed {
+            static WARNED: AtomicBool = AtomicBool::new(false);
+            opts.legacy_options.generate_dom_ssr = warn_once(&WARNED);
+        }
+    }
+
+    let warning_filter = get_prop(options, "warningFilter");
+    if present(&warning_filter) && warning_filter.dyn_ref::<js_sys::Function>().is_none() {
+        return Err(invalid_option(
+            "warningFilter should be a function, if specified",
+        ));
+    }
+
+    let experimental = get_prop(options, "experimental");
+    if present(&experimental) {
+        if !experimental.is_object() || js_sys::Array::is_array(&experimental) {
+            return Err(invalid_option("experimental should be an object"));
+        }
+        for key in js_sys::Object::keys(&js_sys::Object::from(experimental.clone())).iter() {
+            if key.as_string().as_deref() != Some("async") {
+                return Err(format!(
+                    "Unrecognised compiler option experimental.{}\nhttps://svelte.dev/e/options_unrecognised",
+                    key.as_string().unwrap_or_default()
+                ));
+            }
+        }
+        let value = get_prop(&experimental, "async");
+        if present(&value) {
+            opts.experimental = ExperimentalOptions {
+                r#async: value.as_bool().ok_or_else(|| {
+                    invalid_option("experimental.async should be true or false, if specified")
+                })?,
+            };
+        }
+    }
+
+    if let Some(value) = require_bool(options, "accessors")? {
+        opts.accessors = value;
+        static WARNED: AtomicBool = AtomicBool::new(false);
+        opts.legacy_options.accessors = warn_once(&WARNED);
     }
 
     let css = resolve_maybe_fn(options, "css", &meta_filename);
-    if let Some(s) = css.as_string() {
-        opts.css = match s.as_str() {
-            "external" => CssMode::External,
-            "injected" => CssMode::Injected,
+    if present(&css) {
+        opts.css = match css.as_string().as_deref() {
+            Some("external") => CssMode::External,
+            Some("injected") => CssMode::Injected,
+            Some("none") => {
+                return Err(invalid_option(
+                    "css: \"none\" is no longer a valid option. If this was crucial for you, please open an issue on GitHub with your use case.",
+                ));
+            }
+            _ if css.as_bool().is_some() => {
+                return Err(invalid_option(
+                    "The boolean options have been removed from the css option. Use \"external\" instead of false and \"injected\" instead of true",
+                ));
+            }
             _ => {
-                return Err(
-                    "css should be either \"external\" (default, recommended) or \"injected\""
-                        .to_string(),
-                );
+                return Err(invalid_option(
+                    "css should be either \"external\" (default, recommended) or \"injected\"",
+                ));
             }
         };
     }
 
-    if let Some(b) = resolve_maybe_fn(options, "customElement", &meta_filename).as_bool() {
-        opts.custom_element = b;
+    let css_hash = get_prop(options, "cssHash");
+    if present(&css_hash) && css_hash.dyn_ref::<js_sys::Function>().is_none() {
+        return Err(invalid_option("cssHash should be a function, if specified"));
     }
-    // `runes` is tri-state: a boolean forces the mode, anything else auto-detects.
-    if let Some(b) = resolve_maybe_fn(options, "runes", &meta_filename).as_bool() {
-        opts.runes = Some(b);
+    opts.css_output_filename = require_string(options, "cssOutputFilename")?;
+
+    let custom_element = resolve_maybe_fn(options, "customElement", &meta_filename);
+    if present(&custom_element) {
+        opts.custom_element = custom_element
+            .as_bool()
+            .ok_or_else(|| invalid_option("customElement should be true or false"))?;
     }
 
-    if let Some(b) = get_prop(options, "dev").as_bool() {
-        opts.dev = b;
+    if let Some(value) = require_bool(options, "discloseVersion")? {
+        opts.disclose_version = value;
     }
-    if let Some(b) = get_prop(options, "accessors").as_bool() {
-        opts.accessors = b;
+    if let Some(value) = require_bool(options, "immutable")? {
+        opts.immutable = value;
+        static WARNED: AtomicBool = AtomicBool::new(false);
+        opts.legacy_options.immutable = warn_once(&WARNED);
     }
-    if let Some(b) = get_prop(options, "immutable").as_bool() {
-        opts.immutable = b;
+
+    if present(&get_prop(options, "legacy")) {
+        return Err("Invalid compiler option: The legacy option has been removed. If you are using this because of legacy.componentApi, use compatibility.componentApi instead\nhttps://svelte.dev/e/options_removed".to_string());
     }
-    if let Some(b) = get_prop(options, "preserveComments").as_bool() {
-        opts.preserve_comments = b;
+
+    let compatibility = get_prop(options, "compatibility");
+    if present(&compatibility) {
+        if !compatibility.is_object() || js_sys::Array::is_array(&compatibility) {
+            return Err(invalid_option("compatibility should be an object"));
+        }
+        for key in js_sys::Object::keys(&js_sys::Object::from(compatibility.clone())).iter() {
+            if key.as_string().as_deref() != Some("componentApi") {
+                return Err(format!(
+                    "Unrecognised compiler option compatibility.{}\nhttps://svelte.dev/e/options_unrecognised",
+                    key.as_string().unwrap_or_default()
+                ));
+            }
+        }
+        let value = get_prop(&compatibility, "componentApi");
+        if present(&value) {
+            opts.compatibility.component_api = match value.as_f64() {
+                Some(4.0) => ComponentApi::V4,
+                Some(5.0) => ComponentApi::V5,
+                _ => {
+                    return Err(invalid_option(
+                        "compatibility.componentApi should be either \"4\" or \"5\"",
+                    ));
+                }
+            };
+        }
     }
-    if let Some(b) = get_prop(options, "preserveWhitespace").as_bool() {
-        opts.preserve_whitespace = b;
+
+    if present(&get_prop(options, "loopGuardTimeout")) {
+        static WARNED: AtomicBool = AtomicBool::new(false);
+        opts.legacy_options.loop_guard_timeout = warn_once(&WARNED);
     }
-    if let Some(b) = get_prop(options, "discloseVersion").as_bool() {
-        opts.disclose_version = b;
-    }
-    if let Some(b) = get_prop(options, "hmr").as_bool() {
-        opts.hmr = b;
-    }
-    if let Some(s) = get_prop(options, "namespace").as_string() {
-        opts.namespace = match s.as_str() {
-            "svg" => Namespace::Svg,
-            "mathml" => Namespace::Mathml,
-            _ => Namespace::Html,
+    opts.name = require_string(options, "name")?;
+
+    let namespace = get_prop(options, "namespace");
+    if present(&namespace) {
+        opts.namespace = match namespace.as_string().as_deref() {
+            Some("html") => Namespace::Html,
+            Some("svg") => Namespace::Svg,
+            Some("mathml") => Namespace::Mathml,
+            _ => {
+                return Err(invalid_option(
+                    "namespace should be one of \"html\", \"mathml\" or \"svg\"",
+                ));
+            }
         };
+    }
+    if let Some(value) = require_bool(options, "modernAst")? {
+        opts.modern_ast = value;
+    }
+    opts.output_filename = require_string(options, "outputFilename")?;
+    if let Some(value) = require_bool(options, "preserveComments")? {
+        opts.preserve_comments = value;
+    }
+    let fragments = get_prop(options, "fragments");
+    if present(&fragments) {
+        opts.fragments = match fragments.as_string().as_deref() {
+            Some("html") => FragmentMode::Html,
+            Some("tree") => FragmentMode::Tree,
+            _ => {
+                return Err(invalid_option(
+                    "fragments should be either \"html\" or \"tree\"",
+                ));
+            }
+        };
+    }
+    if let Some(value) = require_bool(options, "preserveWhitespace")? {
+        opts.preserve_whitespace = value;
+    }
+
+    let runes = resolve_maybe_fn(options, "runes", &meta_filename);
+    if present(&runes) {
+        opts.runes = match runes.as_bool() {
+            Some(value) => Some(value),
+            None if runes.as_f64().is_some_and(|n| n != 0.0 && !n.is_nan()) => Some(true),
+            None if runes.as_string().is_some_and(|s| !s.is_empty()) => Some(true),
+            None if runes.is_object() => Some(true),
+            None => None,
+        };
+    }
+    if let Some(value) = require_bool(options, "hmr")? {
+        opts.hmr = value;
+    }
+
+    let sourcemap = get_prop(options, "sourcemap");
+    if present(&sourcemap) {
+        opts.sourcemap = sourcemap.as_string().or_else(|| {
+            js_sys::JSON::stringify(&sourcemap)
+                .ok()
+                .and_then(|value| value.as_string())
+        });
+    }
+    if present(&get_prop(options, "enableSourcemap")) {
+        static WARNED: AtomicBool = AtomicBool::new(false);
+        opts.legacy_options.enable_sourcemap = warn_once(&WARNED);
+    }
+    if present(&get_prop(options, "hydratable")) {
+        static WARNED: AtomicBool = AtomicBool::new(false);
+        opts.legacy_options.hydratable = warn_once(&WARNED);
+    }
+
+    for (key, message) in [
+        (
+            "format",
+            "The format option has been removed in Svelte 4, the compiler only outputs ESM now. Remove \"format\" from your compiler options. If you did not set this yourself, bump the version of your bundler plugin (vite-plugin-svelte/rollup-plugin-svelte/svelte-loader)",
+        ),
+        (
+            "tag",
+            "The tag option has been removed in Svelte 5. Use `<svelte:options customElement=\"tag-name\" />` inside the component instead. If that does not solve your use case, please open an issue on GitHub with details.",
+        ),
+        (
+            "sveltePath",
+            "The sveltePath option has been removed in Svelte 5. If this option was crucial for you, please open an issue on GitHub with your use case.",
+        ),
+        (
+            "errorMode",
+            "The errorMode option has been removed. If you are using this through svelte-preprocess with TypeScript, use the https://www.typescriptlang.org/tsconfig#verbatimModuleSyntax setting instead",
+        ),
+        (
+            "varsReport",
+            "The vars option has been removed. If you are using this through svelte-preprocess with TypeScript, use the https://www.typescriptlang.org/tsconfig#verbatimModuleSyntax setting instead",
+        ),
+    ] {
+        if present(&get_prop(options, key)) {
+            return Err(format!(
+                "Invalid compiler option: {message}\nhttps://svelte.dev/e/options_removed"
+            ));
+        }
     }
 
     if let Some(func) = get_prop(options, "warningFilter").dyn_ref::<js_sys::Function>() {
@@ -531,7 +815,7 @@ fn compile_result_to_json(result: CompileResult) -> String {
 #[wasm_bindgen(js_name = compile)]
 pub fn compile_svelte(source: &str, options: JsValue) -> Result<String, JsValue> {
     let error_slot: ErrorSlot = Arc::new(Mutex::new(None));
-    let opts = build_compile_options(&options, &error_slot).map_err(|e| JsValue::from_str(&e))?;
+    let opts = build_compile_options(&options, &error_slot).map_err(option_error_to_js)?;
     let result = compile(source, opts);
     if let Some(msg) = error_slot.lock().unwrap().take() {
         return Err(JsValue::from_str(&msg));

--- a/scripts/dev/test-wasm-compile-options.mjs
+++ b/scripts/dev/test-wasm-compile-options.mjs
@@ -12,6 +12,7 @@
 
 import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
+import { compile as officialCompile } from '../../submodules/svelte/packages/svelte/src/compiler/index.js';
 
 const jsUrl = new URL('../../pkg/rsvelte_lint.js', import.meta.url).href;
 const wasmPath = fileURLToPath(new URL('../../pkg/rsvelte_lint_bg.wasm', import.meta.url));
@@ -32,6 +33,65 @@ function assert(name, cond, detail) {
 }
 
 const compile = (source, options) => JSON.parse(compiler.compile(source, options));
+
+function thrownBy(fn) {
+	try {
+		fn();
+		return null;
+	} catch (error) {
+		return {
+			code: error?.code ?? null,
+			message: String(error?.message ?? error).split('\n')[0],
+		};
+	}
+}
+
+// Validation is a separate compatibility surface from successful option
+// forwarding. Keep official Svelte as the independent oracle: comparing this
+// wasm port to either of rsvelte's other two ports would pass if both drifted
+// in the same direction (#3664).
+for (const [name, options] of [
+	['unknown key', { nonsense: 1 }],
+	['wrong boolean type', { dev: 'yes' }],
+	['wrong parametric result', { customElement: 'x-a' }],
+	['invalid namespace', { namespace: 'nope' }],
+	['removed css none', { css: 'none' }],
+	['removed option', { legacy: {} }],
+]) {
+	const official = thrownBy(() => officialCompile('<p>x</p>', options));
+	const rsvelte = thrownBy(() => compiler.compile('<p>x</p>', options));
+	assert(
+		`validation matches official: ${name}`,
+		official != null &&
+			rsvelte != null &&
+			official.code === rsvelte.code &&
+			official.message === rsvelte.message,
+		JSON.stringify({ official, rsvelte }),
+	);
+}
+
+const legacyWarnings = compile('<p>x</p>', {
+	generate: 'dom',
+	accessors: false,
+	immutable: false,
+	loopGuardTimeout: 100,
+	enableSourcemap: true,
+	hydratable: true,
+});
+const legacyWarningCodes = new Set(legacyWarnings.warnings.map((warning) => warning.code));
+for (const code of [
+	'options_renamed_ssr_dom',
+	'options_deprecated_accessors',
+	'options_deprecated_immutable',
+	'options_removed_loop_guard_timeout',
+	'options_removed_enable_sourcemap',
+	'options_removed_hydratable',
+]) {
+	assert(`legacy option emits ${code}`, legacyWarningCodes.has(code), [...legacyWarningCodes].join(', '));
+}
+
+const numericRunes = compile('<p>x</p>', { runes: 1 });
+assert('truthy non-boolean runes matches parametric semantics', numericRunes.metadata.runes === true);
 
 // 1. Function-form customElement resolves to the same output as the boolean.
 const ceBool = compile('<svelte:options customElement="my-el" /><h1>hi</h1>', {

--- a/scripts/dev/test-wasm-compile-options.mjs
+++ b/scripts/dev/test-wasm-compile-options.mjs
@@ -12,7 +12,7 @@
 
 import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
-import { compile as officialCompile } from '../../submodules/svelte/packages/svelte/src/compiler/index.js';
+import { compile as officialCompile } from 'svelte/compiler';
 
 const jsUrl = new URL('../../pkg/rsvelte_lint.js', import.meta.url).href;
 const wasmPath = fileURLToPath(new URL('../../pkg/rsvelte_lint_bg.wasm', import.meta.url));


### PR DESCRIPTION
Fixes #3664.

- validates unknown, removed, wrong-typed, nested, enum, and parametric option values at the C ABI and wasm boundaries
- reproduces legacy option warnings and truthy `runes` semantics
- adds an official-vs-wasm rejection oracle and exact C ABI expectations
- records the remaining boundary blind spots in the compatibility inventories

Static checks only, per the requested workflow: `cargo fmt --all -- --check`, `node --check scripts/dev/test-wasm-compile-options.mjs`, and `git diff --check`. Compilation and test execution are left to CI.