### PR TITLE
Make HTML content tags breakable

### DIFF
--- a/crates/rsvelte_formatter/src/collapse/doc_build.rs
+++ b/crates/rsvelte_formatter/src/collapse/doc_build.rs
@@ -254,6 +254,12 @@ pub(super) fn content_tag_breakable_doc(
             };
             ("@render ", out.get(s as usize..e as usize)?.trim())
         }
+        TemplateNode::HtmlTag(t) => {
+            let (Some(s), Some(e)) = (t.expression.start(), t.expression.end()) else {
+                return None;
+            };
+            ("@html ", out.get(s as usize..e as usize)?.trim())
+        }
         _ => return None,
     };
     if expr_src.is_empty() {
@@ -337,7 +343,7 @@ fn append_non_text_doc(
     if let Some(options) = options
         && matches!(
             node,
-            TemplateNode::ExpressionTag(_) | TemplateNode::RenderTag(_)
+            TemplateNode::ExpressionTag(_) | TemplateNode::HtmlTag(_) | TemplateNode::RenderTag(_)
         )
         && let Some(doc) = content_tag_breakable_doc(out, node, options)
     {

--- a/crates/rsvelte_formatter/tests/hugged_tag_run_break.rs
+++ b/crates/rsvelte_formatter/tests/hugged_tag_run_break.rs
@@ -135,6 +135,14 @@ fn render_tag_first_in_a_run() {
 }
 
 #[test]
+fn html_tag_first_in_a_run() {
+    assert_fmt(
+        "<b>{@html o[\"aaaa\"]}{o.bbbbbbbb}{o.cccccccc}{o.dddddddd}{o.eeeeeeee}{o.ffffffff}{o.gggggggg}</b>\n",
+        "<b\n  >{@html o[\n    \"aaaa\"\n  ]}{o.bbbbbbbb}{o.cccccccc}{o.dddddddd}{o.eeeeeeee}{o.ffffffff}{o.gggggggg}</b\n>\n",
+    );
+}
+
+#[test]
 fn the_group_that_breaks_is_the_one_that_misses_its_fit() {
     assert_fmt(
         "<b>{o[\"aaaaaaaaaaaa\"]}{o.bbbbbbbb}{o.cccccccc}{p[\"ddddddddddddddd\"]}{o.eeeeeeee}{o.ffffffff}{o.gggggggg}</b>\n",


### PR DESCRIPTION
## Summary

- model `{@html ...}` with the same breakable content-tag document used by expression and render tags
- allow HTML tags to reach the breakable path in children runs
- add the oracle-measured hugged-run regression from #3676, including idempotence

## Verification

- `cargo fmt --all -- --check`
- `git diff --check`
- compilation and tests are left to CI as requested

Fixes #3676
