### PR TITLE
ci(release): gate publishing on main CI verdicts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1236,6 +1236,9 @@ jobs:
       - name: Run Tests aggregator verdict tests
         run: node scripts/ci/test-tests-aggregate-verdict.mjs
 
+      - name: Run release verdict waiter tests
+        run: node scripts/release/test-wait-for-release-verdicts.mjs
+
       - name: Run differential corpus workflow tests
         run: node scripts/ci/test-differential-corpus-workflow.mjs
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,7 @@ on:
 # write to pull-requests (open the "Version Packages" PR), and id-token: write
 # is left available so we can opt into npm provenance later if desired.
 permissions:
+  actions: read
   contents: write
   pull-requests: write
   id-token: write
@@ -457,6 +458,26 @@ jobs:
           if-no-files-found: error
           retention-days: 7
 
+  verify-release-commit:
+    name: Verify release commit
+    if: "${{ startsWith(github.event.head_commit.message, 'chore(release): version packages') }}"
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          submodules: false
+
+      # The Version Packages PR is opened with GITHUB_TOKEN, so GitHub normally
+      # leaves its pull_request workflows in action_required. Do not duplicate
+      # the test/corpus matrices here: the merge commit already starts their
+      # push workflows. Wait for those exact-SHA verdicts and make the
+      # irreversible publish job depend on them instead (#3695).
+      - name: Wait for main CI verdicts
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: node scripts/release/wait-for-release-verdicts.mjs
+
   publish:
     name: Publish
     # Publish only runs on the "Version Packages" merge commit, once the
@@ -464,6 +485,9 @@ jobs:
     # changesets consumed. This is the only path that needs staged binaries.
     if: "${{ startsWith(github.event.head_commit.message, 'chore(release): version packages') }}"
     runs-on: ubuntu-latest
+    # The five build jobs prove that the release artifacts can be produced;
+    # verify-release-commit separately reuses the ordinary main CI verdicts so
+    # publishing cannot proceed after an unverified Version Packages PR.
     # Deliberately NOT `needs: close-version-cycle`: that job shares the
     # cancel-in-progress group with `version-pr` so it can supersede an
     # in-flight updater, which also means any later push to main cancels it —
@@ -476,6 +500,7 @@ jobs:
         build-rsvelte-fmt,
         build-rsvelte-lint,
         build-rsvelte-language-server,
+        verify-release-commit,
       ]
     timeout-minutes: 30
     # Publishing is non-atomic across packages and must never be interrupted.

--- a/scripts/release/test-wait-for-release-verdicts.mjs
+++ b/scripts/release/test-wait-for-release-verdicts.mjs
@@ -1,0 +1,81 @@
+#!/usr/bin/env node
+
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { verdict } from './wait-for-release-verdicts.mjs';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const RELEASE_WORKFLOW = join(HERE, '..', '..', '.github', 'workflows', 'release.yml');
+let failures = 0;
+
+function check(name, fn) {
+	try {
+		fn();
+		console.log(`  ok   ${name}`);
+	} catch (error) {
+		failures += 1;
+		console.log(`  FAIL ${name}\n       ${error.message}`);
+	}
+}
+
+function assert(condition, message) {
+	if (!condition) throw new Error(message);
+}
+
+function run(name, status = 'completed', conclusion = 'success', updated = 1) {
+	return {
+		name,
+		status,
+		conclusion,
+		updated_at: new Date(updated).toISOString(),
+		html_url: `https://example.test/${encodeURIComponent(name)}`,
+	};
+}
+
+check('an absent required CI run is pending, not green', () => {
+	assert(verdict([]).state === 'pending', 'zero runs must not pass');
+});
+
+check('the required CI run alone can pass when path-filtered workflows are absent', () => {
+	assert(verdict([run('CI')]).state === 'success', 'successful CI should pass');
+});
+
+check('an observed optional workflow is part of the verdict', () => {
+	const result = verdict([run('CI'), run('Corpus Compat', 'in_progress', null)]);
+	assert(result.state === 'pending', `expected pending, got ${result.state}`);
+});
+
+check('failure, cancellation and action_required are all non-verdicts', () => {
+	for (const conclusion of ['failure', 'cancelled', 'action_required']) {
+		const result = verdict([run('CI'), run('C ABI', 'completed', conclusion)]);
+		assert(result.state === 'failure', `${conclusion} must fail, got ${result.state}`);
+	}
+});
+
+check('the newest rerun decides the workflow verdict', () => {
+	const result = verdict([run('CI', 'completed', 'failure', 1), run('CI', 'completed', 'success', 2)]);
+	assert(result.state === 'success', `expected newest success, got ${result.state}`);
+});
+
+check('release.yml wires verification into publish and grants read access', () => {
+	const yml = readFileSync(RELEASE_WORKFLOW, 'utf8');
+	assert(yml.includes('actions: read'), 'release workflow cannot read Actions verdicts');
+	assert(
+		yml.includes('node scripts/release/wait-for-release-verdicts.mjs'),
+		'release workflow does not invoke the waiter',
+	);
+	const publish = yml.slice(yml.indexOf('\n  publish:'), yml.indexOf('\n  release-language-server-archives:'));
+	assert(
+		publish.includes('verify-release-commit'),
+		'publish does not depend on release-commit verification',
+	);
+});
+
+console.log(
+	failures === 0
+		? '\nrelease verdict waiter self-test: all checks passed'
+		: `\nrelease verdict waiter self-test: ${failures} failure(s)`,
+);
+process.exit(failures === 0 ? 0 : 1);

--- a/scripts/release/wait-for-release-verdicts.mjs
+++ b/scripts/release/wait-for-release-verdicts.mjs
@@ -1,0 +1,135 @@
+#!/usr/bin/env node
+
+// A Changesets PR created with GITHUB_TOKEN normally has no PR verdict because
+// GitHub suppresses recursively-triggered workflows. The merge commit does
+// start the ordinary push workflows, so publishing can reuse those runs rather
+// than compiling the repository a second time inside release.yml.
+
+export const WORKFLOWS = [
+	{ name: 'CI', required: true },
+	{ name: 'Corpus Compat', required: false },
+	{ name: 'Type-aware Lint', required: false },
+	{ name: 'C ABI', required: false },
+	{ name: 'crates.io packages', required: false },
+];
+
+const SUCCESS = new Set(['success']);
+const ACTIVE = new Set(['queued', 'in_progress', 'pending', 'waiting', 'requested']);
+
+function latestByName(runs) {
+	const latest = new Map();
+	for (const run of runs) {
+		if (!WORKFLOWS.some((workflow) => workflow.name === run.name)) continue;
+		const previous = latest.get(run.name);
+		if (!previous || Date.parse(run.updated_at) > Date.parse(previous.updated_at)) {
+			latest.set(run.name, run);
+		}
+	}
+	return latest;
+}
+
+export function verdict(runs) {
+	const latest = latestByName(runs);
+	const missing = WORKFLOWS.filter(
+		(workflow) => workflow.required && !latest.has(workflow.name),
+	);
+	if (missing.length > 0) {
+		return {
+			state: 'pending',
+			message: `waiting for ${missing.map((workflow) => workflow.name).join(', ')}`,
+		};
+	}
+
+	const observed = WORKFLOWS.filter((workflow) => latest.has(workflow.name)).map(
+		(workflow) => latest.get(workflow.name),
+	);
+	const active = observed.filter((run) => ACTIVE.has(run.status));
+	if (active.length > 0) {
+		return {
+			state: 'pending',
+			message: `waiting for ${active.map((run) => `${run.name}=${run.status}`).join(', ')}`,
+		};
+	}
+
+	const failed = observed.filter(
+		(run) => run.status !== 'completed' || !SUCCESS.has(run.conclusion),
+	);
+	if (failed.length > 0) {
+		return {
+			state: 'failure',
+			message: failed
+				.map((run) => `${run.name}=${run.status}/${run.conclusion || 'none'} (${run.html_url})`)
+				.join(', '),
+		};
+	}
+
+	return {
+		state: 'success',
+		message: observed.map((run) => `${run.name}=success`).join(', '),
+	};
+}
+
+async function listRuns(repository, sha, token) {
+	const query = new URLSearchParams({ head_sha: sha, event: 'push', per_page: '100' });
+	const response = await fetch(
+		`https://api.github.com/repos/${repository}/actions/runs?${query}`,
+		{
+			headers: {
+				Accept: 'application/vnd.github+json',
+				Authorization: `Bearer ${token}`,
+				'X-GitHub-Api-Version': '2022-11-28',
+			},
+		},
+	);
+	if (!response.ok) {
+		throw new Error(`GitHub Actions API returned ${response.status}: ${await response.text()}`);
+	}
+	return (await response.json()).workflow_runs;
+}
+
+const delay = (milliseconds) => new Promise((resolve) => setTimeout(resolve, milliseconds));
+
+async function main() {
+	const repository = process.env.GITHUB_REPOSITORY;
+	const sha = process.env.GITHUB_SHA;
+	const token = process.env.GH_TOKEN;
+	if (!repository || !sha || !token) {
+		throw new Error('GITHUB_REPOSITORY, GITHUB_SHA and GH_TOKEN are required');
+	}
+
+	const interval = Number(process.env.RELEASE_VERDICT_POLL_MS || 30_000);
+	const deadline = Date.now() + Number(process.env.RELEASE_VERDICT_TIMEOUT_MS || 5_100_000);
+	let consecutiveSuccesses = 0;
+
+	while (Date.now() < deadline) {
+		const result = verdict(await listRuns(repository, sha, token));
+		console.log(`${new Date().toISOString()} ${result.state}: ${result.message}`);
+
+		if (result.state === 'failure') {
+			console.error(`::error::Release commit verification failed: ${result.message}`);
+			return 1;
+		}
+		if (result.state === 'success') {
+			consecutiveSuccesses += 1;
+			// A second successful poll prevents a late-registered path-filtered
+			// workflow from being mistaken for an absent (therefore irrelevant) one.
+			if (consecutiveSuccesses >= 2) return 0;
+		} else {
+			consecutiveSuccesses = 0;
+		}
+
+		await delay(interval);
+	}
+
+	console.error('::error::Timed out waiting for release-commit workflow verdicts.');
+	return 1;
+}
+
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+	main()
+		.then((code) => process.exit(code))
+		.catch((error) => {
+			console.error(`::error::${error.stack || error.message}`);
+			process.exit(1);
+		});
+}


### PR DESCRIPTION
Fixes #3695.\n\nVersion Packages PR workflows can remain action_required because GitHub suppresses events raised by GITHUB_TOKEN. This change leaves that credential model intact and instead makes publish wait for the ordinary push workflows on the exact release merge SHA.\n\nCI is always required. Corpus Compat, Type-aware Lint, C ABI, and crates.io packages are also required whenever their path filters start them. The waiter uses the existing runs, so it does not duplicate any build or test matrix, and two consecutive successful polls protect against late workflow registration.\n\nAdds pure verdict controls plus a workflow wiring test under the existing trigger-guard job.\n\nLocal validation was intentionally lightweight: Node syntax checks, YAML parse, and git diff --check. Execution is delegated to CI.