### PR TITLE
Fix shadowed binding diagnostic parity

### DIFF
--- a/.changeset/shadowed-diagnostic-spans.md
+++ b/.changeset/shadowed-diagnostic-spans.md
@@ -1,0 +1,5 @@
+---
+"rsvelte": patch
+---
+
+Match upstream diagnostics for shadowed each bindings and snippet parameter assignments.

--- a/.changeset/shadowed-diagnostic-spans.md
+++ b/.changeset/shadowed-diagnostic-spans.md
@@ -1,5 +1,5 @@
 ---
-"rsvelte": patch
+"@rsvelte/compiler": patch
 ---
 
 Match upstream diagnostics for shadowed each bindings and snippet parameter assignments.

--- a/compatibility/error-end-known-failures.client-dev.json
+++ b/compatibility/error-end-known-failures.client-dev.json
@@ -38,8 +38,6 @@
 	"svelte/packages/svelte/tests/compiler-errors/samples/export-state-indirect/main.svelte.js",
 	"svelte/packages/svelte/tests/compiler-errors/samples/invalid-rune-name-shadowed/main.svelte.js",
 	"svelte/packages/svelte/tests/compiler-errors/samples/invalid-rune-name/main.svelte.js",
-	"svelte/packages/svelte/tests/compiler-errors/samples/invalid-snippet-binding/main.svelte",
-	"svelte/packages/svelte/tests/compiler-errors/samples/invalid-snippet-mutation/main.svelte",
 	"svelte/packages/svelte/tests/compiler-errors/samples/malformed-snippet-2/main.svelte",
 	"svelte/packages/svelte/tests/compiler-errors/samples/runes-module-store-subscription/main.svelte.js",
 	"svelte/packages/svelte/tests/compiler-errors/samples/runes-no-rune-each/main.svelte",

--- a/compatibility/error-end-known-failures.client.json
+++ b/compatibility/error-end-known-failures.client.json
@@ -38,8 +38,6 @@
 	"svelte/packages/svelte/tests/compiler-errors/samples/export-state-indirect/main.svelte.js",
 	"svelte/packages/svelte/tests/compiler-errors/samples/invalid-rune-name-shadowed/main.svelte.js",
 	"svelte/packages/svelte/tests/compiler-errors/samples/invalid-rune-name/main.svelte.js",
-	"svelte/packages/svelte/tests/compiler-errors/samples/invalid-snippet-binding/main.svelte",
-	"svelte/packages/svelte/tests/compiler-errors/samples/invalid-snippet-mutation/main.svelte",
 	"svelte/packages/svelte/tests/compiler-errors/samples/malformed-snippet-2/main.svelte",
 	"svelte/packages/svelte/tests/compiler-errors/samples/runes-module-store-subscription/main.svelte.js",
 	"svelte/packages/svelte/tests/compiler-errors/samples/runes-no-rune-each/main.svelte",

--- a/compatibility/error-end-known-failures.server-dev.json
+++ b/compatibility/error-end-known-failures.server-dev.json
@@ -38,8 +38,6 @@
 	"svelte/packages/svelte/tests/compiler-errors/samples/export-state-indirect/main.svelte.js",
 	"svelte/packages/svelte/tests/compiler-errors/samples/invalid-rune-name-shadowed/main.svelte.js",
 	"svelte/packages/svelte/tests/compiler-errors/samples/invalid-rune-name/main.svelte.js",
-	"svelte/packages/svelte/tests/compiler-errors/samples/invalid-snippet-binding/main.svelte",
-	"svelte/packages/svelte/tests/compiler-errors/samples/invalid-snippet-mutation/main.svelte",
 	"svelte/packages/svelte/tests/compiler-errors/samples/malformed-snippet-2/main.svelte",
 	"svelte/packages/svelte/tests/compiler-errors/samples/runes-module-store-subscription/main.svelte.js",
 	"svelte/packages/svelte/tests/compiler-errors/samples/runes-no-rune-each/main.svelte",

--- a/compatibility/error-end-known-failures.server.json
+++ b/compatibility/error-end-known-failures.server.json
@@ -38,8 +38,6 @@
 	"svelte/packages/svelte/tests/compiler-errors/samples/export-state-indirect/main.svelte.js",
 	"svelte/packages/svelte/tests/compiler-errors/samples/invalid-rune-name-shadowed/main.svelte.js",
 	"svelte/packages/svelte/tests/compiler-errors/samples/invalid-rune-name/main.svelte.js",
-	"svelte/packages/svelte/tests/compiler-errors/samples/invalid-snippet-binding/main.svelte",
-	"svelte/packages/svelte/tests/compiler-errors/samples/invalid-snippet-mutation/main.svelte",
 	"svelte/packages/svelte/tests/compiler-errors/samples/malformed-snippet-2/main.svelte",
 	"svelte/packages/svelte/tests/compiler-errors/samples/runes-module-store-subscription/main.svelte.js",
 	"svelte/packages/svelte/tests/compiler-errors/samples/runes-no-rune-each/main.svelte",

--- a/compatibility/error-known-failures.md
+++ b/compatibility/error-known-failures.md
@@ -102,8 +102,8 @@ of two unrelated errors say nothing, and the code divergence is an
 `error-message-known-failures.client-dev.json` holds 10 entries;
 `error-message-known-failures.server.json` holds 10 entries; and
 `error-message-known-failures.server-dev.json` holds 10 entries. All four of
-`error-position-known-failures.<target>.json` hold 50 entries, all four of
-`error-end-known-failures.<target>.json` hold 63 entries, and all four of
+`error-position-known-failures.<target>.json` hold 48 entries, all four of
+`error-end-known-failures.<target>.json` hold 61 entries, and all four of
 `error-frame-known-failures.<target>.json` hold 0 entries. The wave-2 enrolment
 (#3130) added 1 message, 16 position and 24 end entries — and **no frame entries
 at all**, which keeps that comparison's population saturated at 0 across a corpus

--- a/compatibility/error-position-known-failures.client-dev.json
+++ b/compatibility/error-position-known-failures.client-dev.json
@@ -26,8 +26,6 @@
 	"svelte/packages/svelte/tests/compiler-errors/samples/export-state-indirect/main.svelte.js",
 	"svelte/packages/svelte/tests/compiler-errors/samples/invalid-rune-name-shadowed/main.svelte.js",
 	"svelte/packages/svelte/tests/compiler-errors/samples/invalid-rune-name/main.svelte.js",
-	"svelte/packages/svelte/tests/compiler-errors/samples/invalid-snippet-binding/main.svelte",
-	"svelte/packages/svelte/tests/compiler-errors/samples/invalid-snippet-mutation/main.svelte",
 	"svelte/packages/svelte/tests/compiler-errors/samples/malformed-snippet-2/main.svelte",
 	"svelte/packages/svelte/tests/compiler-errors/samples/runes-module-store-subscription/main.svelte.js",
 	"svelte/packages/svelte/tests/compiler-errors/samples/runes-no-rune-each/main.svelte",

--- a/compatibility/error-position-known-failures.client.json
+++ b/compatibility/error-position-known-failures.client.json
@@ -26,8 +26,6 @@
 	"svelte/packages/svelte/tests/compiler-errors/samples/export-state-indirect/main.svelte.js",
 	"svelte/packages/svelte/tests/compiler-errors/samples/invalid-rune-name-shadowed/main.svelte.js",
 	"svelte/packages/svelte/tests/compiler-errors/samples/invalid-rune-name/main.svelte.js",
-	"svelte/packages/svelte/tests/compiler-errors/samples/invalid-snippet-binding/main.svelte",
-	"svelte/packages/svelte/tests/compiler-errors/samples/invalid-snippet-mutation/main.svelte",
 	"svelte/packages/svelte/tests/compiler-errors/samples/malformed-snippet-2/main.svelte",
 	"svelte/packages/svelte/tests/compiler-errors/samples/runes-module-store-subscription/main.svelte.js",
 	"svelte/packages/svelte/tests/compiler-errors/samples/runes-no-rune-each/main.svelte",

--- a/compatibility/error-position-known-failures.server-dev.json
+++ b/compatibility/error-position-known-failures.server-dev.json
@@ -26,8 +26,6 @@
 	"svelte/packages/svelte/tests/compiler-errors/samples/export-state-indirect/main.svelte.js",
 	"svelte/packages/svelte/tests/compiler-errors/samples/invalid-rune-name-shadowed/main.svelte.js",
 	"svelte/packages/svelte/tests/compiler-errors/samples/invalid-rune-name/main.svelte.js",
-	"svelte/packages/svelte/tests/compiler-errors/samples/invalid-snippet-binding/main.svelte",
-	"svelte/packages/svelte/tests/compiler-errors/samples/invalid-snippet-mutation/main.svelte",
 	"svelte/packages/svelte/tests/compiler-errors/samples/malformed-snippet-2/main.svelte",
 	"svelte/packages/svelte/tests/compiler-errors/samples/runes-module-store-subscription/main.svelte.js",
 	"svelte/packages/svelte/tests/compiler-errors/samples/runes-no-rune-each/main.svelte",

--- a/compatibility/error-position-known-failures.server.json
+++ b/compatibility/error-position-known-failures.server.json
@@ -26,8 +26,6 @@
 	"svelte/packages/svelte/tests/compiler-errors/samples/export-state-indirect/main.svelte.js",
 	"svelte/packages/svelte/tests/compiler-errors/samples/invalid-rune-name-shadowed/main.svelte.js",
 	"svelte/packages/svelte/tests/compiler-errors/samples/invalid-rune-name/main.svelte.js",
-	"svelte/packages/svelte/tests/compiler-errors/samples/invalid-snippet-binding/main.svelte",
-	"svelte/packages/svelte/tests/compiler-errors/samples/invalid-snippet-mutation/main.svelte",
 	"svelte/packages/svelte/tests/compiler-errors/samples/malformed-snippet-2/main.svelte",
 	"svelte/packages/svelte/tests/compiler-errors/samples/runes-module-store-subscription/main.svelte.js",
 	"svelte/packages/svelte/tests/compiler-errors/samples/runes-no-rune-each/main.svelte",

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/mod.rs
@@ -6382,6 +6382,10 @@ mod tests {
     use rustc_hash::{FxHashMap, FxHashSet};
 
     fn analyze(source: &str) -> ComponentAnalysis {
+        try_analyze(source).unwrap()
+    }
+
+    fn try_analyze(source: &str) -> Result<ComponentAnalysis, AnalysisError> {
         let mut ast = parse(
             source,
             &oxc_allocator::Allocator::default(),
@@ -6393,7 +6397,54 @@ mod tests {
         .unwrap();
         // SAFETY: `ast` outlives the guard and analysis call.
         let _guard = unsafe { SerializeArenaGuard::new(&ast.arena as *const _) };
-        analyze_component(&mut ast, source, &CompileOptions::default()).unwrap()
+        analyze_component(&mut ast, source, &CompileOptions::default())
+    }
+
+    #[test]
+    fn each_binding_references_do_not_mark_shadowed_export_as_used() {
+        let source = r#"<script>
+export let value = "outer";
+</script>
+{#each ["inner"] as value (value)}{String(value)}{/each}"#;
+        let analysis = analyze(source);
+        let warnings = analysis
+            .warnings
+            .iter()
+            .filter(|warning| warning.code == "export_let_unused")
+            .collect::<Vec<_>>();
+        let start = source.find("value =").unwrap() as u32;
+
+        assert_eq!(warnings.len(), 1);
+        assert_eq!(warnings[0].start, Some(start));
+        assert_eq!(warnings[0].end, Some(start + "value".len() as u32));
+    }
+
+    #[test]
+    fn snippet_parameter_assignment_uses_the_assignment_or_binding_span() {
+        for (source, marked) in [
+            (
+                r#"{#snippet s(value)}<button onclick={() => { value = "next"; }}>x</button>{/snippet}"#,
+                r#"value = "next""#,
+            ),
+            (
+                r#"{#snippet s(value)}<input bind:value={value}>{/snippet}"#,
+                "bind:value={value}",
+            ),
+        ] {
+            let start = source.find(marked).unwrap() as u32;
+            let error = try_analyze(source).unwrap_err();
+            assert!(matches!(
+                error,
+                AnalysisError::ValidationWithCode {
+                    ref code,
+                    start: Some(actual_start),
+                    end: Some(actual_end),
+                    ..
+                } if code == "snippet_parameter_assignment"
+                    && actual_start == start
+                    && actual_end == start + marked.len() as u32
+            ));
+        }
     }
 
     #[test]

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/shared/utils.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/shared/utils.rs
@@ -923,7 +923,7 @@ pub fn validate_no_const_assignment_node(
                 let binding = &context.analysis.root.bindings[idx];
 
                 if binding.kind == BindingKind::SnippetParam {
-                    return Err(errors::snippet_parameter_assignment());
+                    return Err(errors::snippet_parameter_assignment().at(node_span.0, node_span.1));
                 }
 
                 if context.function_depth > 1 {
@@ -1006,7 +1006,7 @@ pub fn validate_assignment_node(
             }
 
             if matches!(binding.kind, BindingKind::SnippetParam) {
-                return Err(errors::snippet_parameter_assignment());
+                return Err(errors::snippet_parameter_assignment().at(node_span.0, node_span.1));
             }
         }
     }


### PR DESCRIPTION
## Summary

- attach the assignment/update/bind node span to `snippet_parameter_assignment`
- pin that an `{#each}` item shadowing an exported prop does not count as a use of the prop
- cover both snippet mutation and `bind:` validation paths

The shadowed-reference half is now handled by the lexical each-scope resolution landed in #3594. This PR adds the missing regression coverage and fixes the remaining diagnostic-position divergence.

Fixes #3297.

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`

Per repository guidance, I did not run local builds or tests; CI is the build/test oracle.
