### PR TITLE
fix(client): preserve each-item mutation sequence parentheses

### DIFF
--- a/.changeset/each-item-mutation-sequence.md
+++ b/.changeset/each-item-mutation-sequence.md
@@ -1,0 +1,5 @@
+---
+"rsvelte": patch
+---
+
+Preserve upstream's sequence-expression parentheses around each-item mutations in client output.

--- a/.changeset/each-item-mutation-sequence.md
+++ b/.changeset/each-item-mutation-sequence.md
@@ -1,5 +1,5 @@
 ---
-"rsvelte": patch
+"@rsvelte/compiler": patch
 ---
 
 Preserve upstream's sequence-expression parentheses around each-item mutations in client output.

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/utils.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/utils.rs
@@ -1252,51 +1252,56 @@ pub fn apply_transforms_to_expression_with_shadowed(
                 // Also handle legacy mode each item mutation: append $.invalidate_inner_signals()
                 if let JsExpr::Identifier(name) = &base_object
                     && !local_scope.contains(name)
-                    && context.state.each_item_names.contains(name)
+                    && let Some(each_ctx) = context
+                        .state
+                        .each_binding_context
+                        .iter()
+                        .rev()
+                        .find(|ctx| {
+                            ctx.item_name == *name
+                                || ctx.destructured_update_paths.contains_key(name.as_str())
+                        })
+                        .cloned()
                 {
-                    context.state.each_item_assign_or_mutate.set(true);
+                    if each_ctx.context_is_identifier {
+                        each_ctx.binding_used.set(true);
+                    }
 
-                    // In legacy mode, wrap the mutation with $.invalidate_inner_signals()
                     // This mirrors the official compiler's `mutate` transform on each items:
                     //   mutate: (_, mutation) => {
                     //     uses_index = true;
                     //     return b.sequence([mutation, ...sequence]);
                     //   }
-                    if !context.state.analysis.runes
-                        && let Some(each_ctx) = context
-                            .state
-                            .each_binding_context
-                            .iter()
-                            .rev()
-                            .find(|ctx| ctx.item_name == *name)
-                            .cloned()
-                        && !each_ctx.invalidation_exprs.is_empty()
-                    {
-                        // Transform the full assignment (apply read transforms to both sides)
-                        let transformed_left = recurse!(context.arena.get_expr(assign.left));
-                        let transformed_right = recurse!(context.arena.get_expr(assign.right));
-                        let mutation = JsExpr::Assignment(JsAssignmentExpression {
-                            operator: assign.operator,
-                            left: context.arena.alloc_expr(transformed_left),
-                            right: context.arena.alloc_expr(transformed_right),
-                        });
+                    // `b.sequence` deliberately remains a SequenceExpression when this
+                    // vector has one element. esrap prints that node with parentheses,
+                    // unlike a bare assignment expression. This matters in runes mode
+                    // and keyed each blocks, where `sequence` is commonly empty.
+                    let transformed_left = recurse!(context.arena.get_expr(assign.left));
+                    let transformed_right = recurse!(context.arena.get_expr(assign.right));
+                    let mutation = JsExpr::Assignment(JsAssignmentExpression {
+                        operator: assign.operator,
+                        left: context.arena.alloc_expr(transformed_left),
+                        right: context.arena.alloc_expr(transformed_right),
+                    });
 
-                        let invalidation_exprs = each_ctx.invalidation_exprs.clone();
-                        let mut seq_exprs = vec![mutation];
-                        let invalidate_inner =
-                            build_invalidate_inner_signals(&invalidation_exprs, &context.arena);
+                    let mut seq_exprs = vec![mutation];
+                    if !each_ctx.is_runes && !each_ctx.invalidation_exprs.is_empty() {
+                        let invalidate_inner = build_invalidate_inner_signals(
+                            &each_ctx.invalidation_exprs,
+                            &context.arena,
+                        );
                         seq_exprs.push(invalidate_inner);
-
-                        if let Some(ref store_name) = each_ctx.store_to_invalidate {
-                            seq_exprs.push(b::call(
-                                &context.arena,
-                                b::member_path(&context.arena, "$.invalidate_store"),
-                                vec![b::id("$$stores"), b::string(store_name)],
-                            ));
-                        }
-
-                        return b::sequence(seq_exprs);
                     }
+
+                    if let Some(ref store_name) = each_ctx.store_to_invalidate {
+                        seq_exprs.push(b::call(
+                            &context.arena,
+                            b::member_path(&context.arena, "$.invalidate_store"),
+                            vec![b::id("$$stores"), b::string(store_name)],
+                        ));
+                    }
+
+                    return b::sequence(seq_exprs);
                 }
 
                 // If the left side's base chain already goes through a Call node,
@@ -1560,45 +1565,48 @@ pub fn apply_transforms_to_expression_with_shadowed(
                 // Also handle legacy mode each item mutation: append $.invalidate_inner_signals()
                 if let JsExpr::Identifier(name) = &base_object
                     && !local_scope.contains(name)
-                    && context.state.each_item_names.contains(name)
+                    && let Some(each_ctx) = context
+                        .state
+                        .each_binding_context
+                        .iter()
+                        .rev()
+                        .find(|ctx| {
+                            ctx.item_name == *name
+                                || ctx.destructured_update_paths.contains_key(name.as_str())
+                        })
+                        .cloned()
                 {
-                    context.state.each_item_assign_or_mutate.set(true);
-
-                    // In legacy mode, wrap the update with $.invalidate_inner_signals()
-                    if !context.state.analysis.runes
-                        && let Some(each_ctx) = context
-                            .state
-                            .each_binding_context
-                            .iter()
-                            .rev()
-                            .find(|ctx| ctx.item_name == *name)
-                            .cloned()
-                        && !each_ctx.invalidation_exprs.is_empty()
-                    {
-                        // Transform the update expression (apply read transforms)
-                        let transformed_arg = recurse!(context.arena.get_expr(update.argument));
-                        let mutation = JsExpr::Update(JsUpdateExpression {
-                            operator: update.operator,
-                            argument: context.arena.alloc_expr(transformed_arg),
-                            prefix: update.prefix,
-                        });
-
-                        let invalidation_exprs = each_ctx.invalidation_exprs.clone();
-                        let mut seq_exprs = vec![mutation];
-                        let invalidate_inner =
-                            build_invalidate_inner_signals(&invalidation_exprs, &context.arena);
-                        seq_exprs.push(invalidate_inner);
-
-                        if let Some(ref store_name) = each_ctx.store_to_invalidate {
-                            seq_exprs.push(b::call(
-                                &context.arena,
-                                b::member_path(&context.arena, "$.invalidate_store"),
-                                vec![b::id("$$stores"), b::string(store_name)],
-                            ));
-                        }
-
-                        return b::sequence(seq_exprs);
+                    if each_ctx.context_is_identifier {
+                        each_ctx.binding_used.set(true);
                     }
+
+                    // As with assignments above, preserve the one-element sequence
+                    // that upstream builds even when there is nothing to invalidate.
+                    let transformed_arg = recurse!(context.arena.get_expr(update.argument));
+                    let mutation = JsExpr::Update(JsUpdateExpression {
+                        operator: update.operator,
+                        argument: context.arena.alloc_expr(transformed_arg),
+                        prefix: update.prefix,
+                    });
+
+                    let mut seq_exprs = vec![mutation];
+                    if !each_ctx.is_runes && !each_ctx.invalidation_exprs.is_empty() {
+                        let invalidate_inner = build_invalidate_inner_signals(
+                            &each_ctx.invalidation_exprs,
+                            &context.arena,
+                        );
+                        seq_exprs.push(invalidate_inner);
+                    }
+
+                    if let Some(ref store_name) = each_ctx.store_to_invalidate {
+                        seq_exprs.push(b::call(
+                            &context.arena,
+                            b::member_path(&context.arena, "$.invalidate_store"),
+                            vec![b::id("$$stores"), b::string(store_name)],
+                        ));
+                    }
+
+                    return b::sequence(seq_exprs);
                 }
 
                 if let JsExpr::Identifier(name) = base_object

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/utils.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/utils.rs
@@ -1264,7 +1264,7 @@ pub fn apply_transforms_to_expression_with_shadowed(
                         .cloned()
                 {
                     if each_ctx.context_is_identifier {
-                        each_ctx.binding_used.set(true);
+                        context.state.each_item_assign_or_mutate.set(true);
                     }
 
                     // This mirrors the official compiler's `mutate` transform on each items:
@@ -1446,6 +1446,14 @@ pub fn apply_transforms_to_expression_with_shadowed(
         }
 
         JsExpr::Sequence(seq) => {
+            // JavaScript source cannot contain a one-element SequenceExpression;
+            // this shape is only produced by builders such as the each-item
+            // mutate transform. Its child has already been transformed, so
+            // descending again would wrap the same mutation repeatedly.
+            if seq.expressions.len() == 1 {
+                return JsExpr::Sequence(seq.clone());
+            }
+
             let transformed_exprs: Vec<JsExpr> =
                 seq.expressions.iter().map(|e| recurse!(e)).collect();
 
@@ -1577,7 +1585,7 @@ pub fn apply_transforms_to_expression_with_shadowed(
                         .cloned()
                 {
                     if each_ctx.context_is_identifier {
-                        each_ctx.binding_used.set(true);
+                        context.state.each_item_assign_or_mutate.set(true);
                     }
 
                     // As with assignments above, preserve the one-element sequence

--- a/crates/rsvelte_core/tests/each_item_mutation_sequence_3616.rs
+++ b/crates/rsvelte_core/tests/each_item_mutation_sequence_3616.rs
@@ -1,0 +1,110 @@
+//! Regression tests for #3616 — an each-item mutation always goes through the
+//! one-element `SequenceExpression` that upstream's `EachBlock` transform builds.
+//!
+//! The parentheses are observable raw output even when there is no legacy
+//! invalidation expression to append. Comparison-side formatting removes them,
+//! so these assertions deliberately inspect the compiler output directly.
+
+use rsvelte_core::{CompileOptions, GenerateMode, compile};
+
+fn client(source: &str) -> String {
+    compile(
+        source,
+        CompileOptions {
+            filename: Some("each-item-mutation-sequence.svelte".to_string()),
+            generate: GenerateMode::Client,
+            dev: false,
+            ..Default::default()
+        },
+    )
+    .expect("compile")
+    .js
+    .code
+}
+
+#[test]
+fn runes_each_item_assignments_updates_and_bindings_keep_parentheses() {
+    let output = client(
+        r#"<script>
+	let rows = $state([{ picked: [], name: '', n: 0 }]);
+</script>
+
+{#each rows as row, i}
+	<button onclick={() => row.picked = 1}>assign</button>
+	<button onclick={() => row.n++}>update</button>
+	<input bind:value={row.name} />
+	<input type="checkbox" value={i} bind:group={row.picked} />
+{/each}
+"#,
+    );
+
+    for expected in [
+        "() => ($.get(row).picked = 1)",
+        "() => ($.get(row).n++)",
+        "($$value) => ($.get(row).name = $$value)",
+        "($$value) => ($.get(row).picked = $$value)",
+    ] {
+        assert!(
+            output.contains(expected),
+            "missing `{expected}` in raw client output:\n{output}"
+        );
+    }
+}
+
+#[test]
+fn keyed_each_item_mutation_keeps_the_bare_item_sequence() {
+    let output = client(
+        r#"<script>
+	let rows = $state([{ id: 1, picked: [] }]);
+</script>
+
+{#each rows as row (row.id)}
+	<button onclick={() => row.picked = 1}>x</button>
+{/each}
+"#,
+    );
+
+    assert!(
+        output.contains("() => (row.picked = 1)"),
+        "the keyed each mutation must remain a one-element sequence:\n{output}"
+    );
+}
+
+#[test]
+fn destructured_each_item_mutation_keeps_the_sequence() {
+    let output = client(
+        r#"<script>
+	let rows = $state([{ nested: { value: 0 } }]);
+</script>
+
+{#each rows as { nested }}
+	<button onclick={() => nested.value = 1}>x</button>
+{/each}
+"#,
+    );
+
+    assert!(
+        output.contains("() => (nested().value = 1)"),
+        "the destructured each mutation must remain a one-element sequence:\n{output}"
+    );
+}
+
+#[test]
+fn indexed_collection_access_is_not_mistaken_for_an_each_item_mutation() {
+    let output = client(
+        r#"<script>
+	let rows = $state([{ picked: [] }]);
+</script>
+
+{#each rows as row, i}
+	<button onclick={() => rows[i].picked = 1}>x</button>
+{/each}
+"#,
+    );
+
+    assert!(
+        output.contains("() => $.get(rows)[i].picked = 1"),
+        "the indexed collection negative control changed:\n{output}"
+    );
+    assert!(!output.contains("() => ($.get(rows)[i].picked = 1)"));
+}

--- a/crates/rsvelte_core/tests/each_item_mutation_sequence_3616.rs
+++ b/crates/rsvelte_core/tests/each_item_mutation_sequence_3616.rs
@@ -52,7 +52,7 @@ fn runes_each_item_assignments_updates_and_bindings_keep_parentheses() {
 }
 
 #[test]
-fn keyed_each_item_mutation_keeps_the_bare_item_sequence() {
+fn keyed_each_item_mutation_keeps_the_sequence() {
     let output = client(
         r#"<script>
 	let rows = $state([{ id: 1, picked: [] }]);
@@ -65,7 +65,7 @@ fn keyed_each_item_mutation_keeps_the_bare_item_sequence() {
     );
 
     assert!(
-        output.contains("() => (row.picked = 1)"),
+        output.contains("() => ($.get(row).picked = 1)"),
         "the keyed each mutation must remain a one-element sequence:\n{output}"
     );
 }
@@ -103,8 +103,8 @@ fn indexed_collection_access_is_not_mistaken_for_an_each_item_mutation() {
     );
 
     assert!(
-        output.contains("() => $.get(rows)[i].picked = 1"),
+        output.contains("() => rows[i].picked = 1"),
         "the indexed collection negative control changed:\n{output}"
     );
-    assert!(!output.contains("() => ($.get(rows)[i].picked = 1)"));
+    assert!(!output.contains("() => (rows[i].picked = 1)"));
 }


### PR DESCRIPTION
## Summary

- preserve the one-element `SequenceExpression` that upstream's each-item `mutate` transform always builds
- locate the owning each context for simple and destructured item names, including ancestor each blocks
- keep legacy inner/store invalidations after the mutation while retaining parentheses when that tail is empty
- add raw client-output coverage for assignments, updates, bindings, keyed and destructured items, plus an indexed-collection negative control

## Why

Upstream returns `b.sequence([mutation, ...sequence])` even when `sequence` is empty. rsvelte only built a sequence when legacy invalidations were present, so runes and keyed each-item mutations lost the parentheses emitted by esrap. Comparison-side formatting removes those parentheses, so the regression tests inspect raw compiler output.

Closes #3616.

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- full builds/tests intentionally left to CI to avoid the project's heavy local workload
