### PR TITLE
fix(compiler): preserve reactive block dependency sequences

### DIFF
--- a/.changeset/quiet-sequences-rest.md
+++ b/.changeset/quiet-sequences-rest.md
@@ -2,4 +2,4 @@
 "@rsvelte/compiler": patch
 ---
 
-Preserve parentheses around single-dependency legacy reactive block thunks.
+Preserve parentheses around single-dependency legacy reactive statement and block thunks.

--- a/.changeset/quiet-sequences-rest.md
+++ b/.changeset/quiet-sequences-rest.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/compiler": patch
+---
+
+Preserve parentheses around single-dependency legacy reactive block thunks.

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/state_assigns_combined_ast.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/state_assigns_combined_ast.rs
@@ -42,7 +42,7 @@
 
 use std::cell::RefCell;
 
-use oxc_allocator::Allocator;
+use oxc_allocator::{Allocator, ArenaVec, ReplaceWith};
 use oxc_ast::ast::*;
 use oxc_ast_visit::{Visit, walk};
 use oxc_parser::ParseOptions;
@@ -442,9 +442,60 @@ fn transform_state_assigns_in_place(
                 changed: false,
             };
             oxc_ast_visit::VisitMut::visit_program(&mut rewriter, program);
+            if rewriter.changed {
+                restore_legacy_pre_effect_deps(program, allocator);
+            }
             rewriter.changed
         },
     )
+}
+
+/// Preserve the builder-made one-element sequence in a legacy dependency thunk.
+///
+/// This pass receives generated `$.legacy_pre_effect(() => (dep), …)` text. OXC
+/// parses the dependency as a `ParenthesizedExpression`, while upstream's
+/// `b.sequence([dep])` is a `SequenceExpression`; esrap deliberately drops the
+/// former and parenthesizes the latter. Rebuild only this generated slot before
+/// the in-place path prints the whole program.
+fn restore_legacy_pre_effect_deps<'a>(program: &mut Program<'a>, allocator: &'a Allocator) {
+    let ab = oxc_ast::builder::AstBuilder::new(allocator);
+    for stmt in &mut program.body {
+        let Statement::ExpressionStatement(es) = stmt else {
+            continue;
+        };
+        let Expression::CallExpression(call) = &mut es.expression else {
+            continue;
+        };
+        let Expression::StaticMemberExpression(member) = &call.callee else {
+            continue;
+        };
+        if !matches!(&member.object, Expression::Identifier(id) if id.name == "$")
+            || member.property.name != "legacy_pre_effect"
+        {
+            continue;
+        }
+        let Some(Argument::ArrowFunctionExpression(arrow)) = call.arguments.first_mut() else {
+            continue;
+        };
+        let Some(body) = arrow.get_expression_mut() else {
+            continue;
+        };
+        if !matches!(&*body, Expression::ParenthesizedExpression(p)
+            if !matches!(p.expression, Expression::SequenceExpression(_)))
+        {
+            continue;
+        }
+        body.replace_with(|expression| {
+            let Expression::ParenthesizedExpression(paren) = expression else {
+                unreachable!()
+            };
+            Expression::SequenceExpression(SequenceExpression::boxed(
+                oxc_span::SPAN,
+                ArenaVec::from_value_in(paren.unbox().expression, &ab),
+                &ab,
+            ))
+        });
+    }
 }
 
 #[derive(Clone, Copy)]
@@ -696,6 +747,22 @@ mod tests {
         let out =
             transform_state_assigns_ast("let x; x += 5;", &ssv(&["x"]), &[], false, &[]).unwrap();
         assert_eq!(out, "let x;\n\n$.set(x, $.get(x) + 5);");
+    }
+
+    #[test]
+    fn reactive_dependency_thunk_keeps_its_one_element_sequence() {
+        let out = transform_state_assigns_ast(
+            "$.legacy_pre_effect(() => ($.get(d)), () => { d += x; });",
+            &ssv(&["d"]),
+            &[],
+            false,
+            &[],
+        )
+        .unwrap();
+        assert_eq!(
+            out,
+            "$.legacy_pre_effect(() => ($.get(d)), () => {\n\t$.set(d, $.get(d) + x);\n});"
+        );
     }
 
     #[test]

--- a/crates/rsvelte_core/tests/legacy_pre_effect_parens_1783.rs
+++ b/crates/rsvelte_core/tests/legacy_pre_effect_parens_1783.rs
@@ -55,6 +55,29 @@ fn single_dependency_thunk_keeps_its_parens() {
     );
 }
 
+/// Issue #3579: rewriting a state assignment made the in-place AST pass print
+/// the whole generated reactive block. Its one dependency then ceased to be a
+/// builder-made sequence and lost the otherwise-redundant parentheses.
+#[test]
+fn single_dependency_block_thunk_keeps_its_parens() {
+    let out = client(
+        r#"<script>
+	let d = 0;
+	$: {
+		let x = 1;
+		d += x;
+	}
+</script>
+
+<b>{d}</b>
+"#,
+    );
+    assert!(
+        out.contains("$.legacy_pre_effect(() => ($.get(d)), () => {"),
+        "single-dep block thunk lost its parens:\n{out}"
+    );
+}
+
 /// Parens the *user* wrote must still be dropped, exactly as acorn + esrap do
 /// upstream — the fix must not turn into a blanket "preserve every paren".
 #[test]

--- a/crates/rsvelte_core/tests/legacy_pre_effect_parens_1783.rs
+++ b/crates/rsvelte_core/tests/legacy_pre_effect_parens_1783.rs
@@ -78,6 +78,25 @@ fn single_dependency_block_thunk_keeps_its_parens() {
     );
 }
 
+/// Issue #3411 is the statement-form twin: expanding a compound assignment
+/// also makes the state-assignment pass reprint the generated effect.
+#[test]
+fn compound_assignment_dependency_thunk_keeps_its_parens() {
+    let out = client(
+        r#"<script>
+	let q;
+	$: q += 1;
+</script>
+
+<p>{q}</p>
+"#,
+    );
+    assert!(
+        out.contains("$.legacy_pre_effect(() => ($.get(q)), () => {"),
+        "compound-assignment thunk lost its parens:\n{out}"
+    );
+}
+
 /// Parens the *user* wrote must still be dropped, exactly as acorn + esrap do
 /// upstream — the fix must not turn into a blanket "preserve every paren".
 #[test]


### PR DESCRIPTION
## Summary

- rebuild the builder-made one-element dependency sequence after the state-assignment AST pass
- preserve the exact `legacy_pre_effect` thunk shape for bare reactive blocks and compound-assignment statements
- add unit and compiler-output regressions for #3579 and #3411

Closes #3579
Closes #3411

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- local builds/tests intentionally skipped; CI is the verification environment
