### PR TITLE
docs(fmt): document the embedded CSS engine boundary

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1015,19 +1015,22 @@ target — regenerate the baseline with `UPDATE_SOURCEMAP_RATCHET=1 cargo test -
 ### Formatter parity corpus (svelte.dev)
 
 Asserts rsvelte formats real svelte.dev sources byte-for-byte like an **oxfmt(`svelte: true`)**
-oracle (`prettier-plugin-svelte` for Svelte structure + the oxc engine for embedded JS/CSS),
-so a diff isolates rsvelte's Svelte-structure formatting. Oracle outputs are precomputed by
+oracle (`prettier-plugin-svelte` for Svelte structure, oxc for embedded JS, and PostCSS for
+embedded CSS). Oracle outputs are precomputed by
 `pnpm run generate-fmt-corpus` (gitignored, CI-cached by svelte.dev SHA). Stage 1+2
 (`crates/rsvelte_formatter/tests/svelte_dev_corpus.rs`) covers every `.svelte` file and
 ` ```svelte ` markdown block; Stage 3 (`crates/rsvelte_fmt/tests/svelte_dev_markdown.rs`) runs
 the real `rsvelte-fmt` CLI on whole `.md` files. Both need a runnable `oxfmt` and no-op when
 absent. **Hard gate, no baseline tolerance:** any divergence fails CI.
 
-`rsvelte-fmt` formats CSS in-process via the Rust `oxc_formatter_css` crate (the same engine
-`oxfmt` uses, byte-identical without a subprocess) — for embedded `<style>` blocks, standalone
-`.css`/`.scss`/`.less` files, and the wasm formatter. `--no-native-css` reverts to the legacy
-`oxfmt`-subprocess path. Native-CSS parity is covered by
-`crates/rsvelte_formatter/tests/css_native.rs` and `crates/rsvelte_fmt/tests/cli.rs`.
+`rsvelte-fmt` formats CSS in-process via the Rust `oxc_formatter_css` crate — for embedded
+`<style>` blocks, standalone `.css`/`.scss`/`.less` files, and the wasm formatter. This is the
+engine `oxfmt` uses for standalone CSS, but it is **not** the PostCSS path used by the
+`svelte: true` oracle for embedded styles. `--no-native-css` reverts to the legacy
+`oxfmt`-subprocess path; the Rust svelte.dev gate exercises that non-default standalone path.
+The large `scripts/compat-corpus/fmt.mjs` gate intentionally keeps native CSS enabled, so its
+ratchet includes CSS-engine differences. `css_native.rs` and the CLI tests are small literal
+behavior tests, not an oracle-parity replacement.
 
 `rsvelte_fmt` is a lib + bin: `rsvelte_fmt::FormatSession` runs the CLI's
 `--stdin --stdin-filepath` pipeline (config discovery, option layering, extension

--- a/compatibility/fmt-known-failures.md
+++ b/compatibility/fmt-known-failures.md
@@ -2,8 +2,10 @@
 
 The formatter-parity corpus formats every `.svelte` component with both
 `rsvelte-fmt` and the `oxfmt(svelte:true)` oracle (prettier-plugin-svelte for the
-Svelte structure + oxc for embedded JS/CSS — rsvelte-fmt's exact layering) and
-requires **byte-identical** output. The ratchet may only shrink.
+Svelte structure, oxc for embedded JS, and PostCSS for embedded CSS) and requires
+**byte-identical** output. rsvelte-fmt uses in-process `oxc_formatter_css` for
+embedded CSS by default, so the ratchet intentionally includes CSS-engine parity
+as well as Svelte-structure parity. The ratchet may only shrink.
 
 **Current baseline: `fmt-known-failures.json`, 796 entries** — 22 from before the
 wave-2 corpus enrolment and 774 in the current expanded-corpus population.
@@ -81,6 +83,22 @@ whitespace → **intra-line-ws**; anything else → **other**.
 | 0 | **25 — extra-line** | rsvelte emits a line where the oracle has none |
 | 2 | **26 — missing-line** | the reverse; both are CRLF sources where rsvelte leaves a bare `\r` |
 | 1 | **27 — quote-style** | an import specifier printed with single quotes where the oracle uses double |
+
+Two #3404 pattern files make the CSS-engine part of Cluster 22 explicit (they
+are included in its count of 85, not additional clusters):
+
+- `pattern/issues/3404-repeated-combinators.svelte` contains `.card >> .a`.
+  The embedded PostCSS oracle accepts the repeated combinator and removes its
+  spaces; `oxc_formatter_css` rejects that selector, so rsvelte-fmt's documented
+  parse-failure fallback preserves the source spelling.
+- `pattern/issues/3404-unhandled-combinator-scope.svelte` contains the valid
+  column combinator `.a || .b`. Both engines accept it, but PostCSS removes the
+  spaces around `||` while OXC retains them.
+
+The native parse-failure fallback's former extra leading blank line was a
+separate product bug and was fixed by #3629. These two entries remain because
+gate 9 intentionally compares the shipped native CSS path rather than replacing
+it with `--no-native-css`; #3628 records that decision and the engine boundary.
 
 **627 of 774 (81%) are cluster 20 or 21 — one question, where a line breaks** —
 and that is the burndown target, not the tail. Nothing here is an oracle bug: the
@@ -291,16 +309,14 @@ stray space+tab mix on the comment line, and a 2-space-narrower indent on
 every subsequent `repeating-linear-gradient` argument line. Root cause
 (byte-level reproduction of both pipelines, minimal repro with identical
 input): this is NOT an `oxc_formatter_css` indent-tracking bug but a
-**mode difference in oxfmt itself** — its svelte-embedded mode preserves a
+**engine difference in the two sides** — the oracle's PostCSS path preserves a
 multi-line function value's interior lines verbatim (1:1 tab→space mapping
-of the source's uneven indents), while its standalone CSS mode (the only
-mode rsvelte's dedent→format→reindent wrapper can use) parses the function
+of the source's uneven indents), while the OXC CSS formatter parses the function
 and normalizes the arguments to one canonical level. The comment-line
 whitespace mix is a secondary rsvelte dedent artifact, but fixing it alone
-cannot clear the entry while the mode difference remains. Unfixable in-repo;
-a root fix would need oxfmt's standalone path to preserve multi-line
-function-value interiors verbatim (high blast radius upstream). Cluster 11
-is the same oxfmt mode difference reached through a different construct.
+cannot clear the entry while the engine difference remains. Changing the shipped
+engine or reproducing PostCSS's source-preservation rule has a high blast radius.
+Cluster 11 is the same engine split reached through a different construct.
 
 ## Cluster 11 — CSS selector source spelling, native engine (2)
 
@@ -317,12 +333,12 @@ selectors the CSS printer re-emits from the AST rather than from the source:
   spaces where the oracle has one.
 
 Same root cause as Cluster 8, reached from the selector side rather than the
-declaration side: **oxfmt's svelte-embedded mode preserves selector source
-text, its standalone CSS mode re-prints selectors from the parsed AST**, and
-the standalone path is the only one rsvelte's in-process `oxc_formatter_css`
-wrapper has. Running oxfmt over the same two selectors as standalone CSS
+declaration side: **the embedded PostCSS oracle preserves selector source text,
+while the OXC CSS formatter re-prints selectors from the parsed AST**. Running
+oxfmt over the same two selectors as standalone CSS
 reproduces rsvelte's output byte for byte. Neither spelling changes what the
-selector matches. Unfixable in-repo for the same reason as Cluster 8.
+selector matches. Changing the product engine or teaching the AST printer to
+preserve these spellings has the same high blast radius as Cluster 8.
 
 ## Resolved
 

--- a/compatibility/gate-coverage.md
+++ b/compatibility/gate-coverage.md
@@ -1635,6 +1635,14 @@ That is not a hole in this gate (it does compare `css.code`). It is a fact about
 (`fmt-verify.mjs:102`). No normalization — this is the one gate that compares raw bytes.
 Population: manifest entries with `kind === 'component'` (`fmt.mjs:170`).
 
+**The two sides deliberately do not share a CSS engine.** The oracle reaches
+prettier-plugin-svelte's PostCSS path for an embedded `<style>`; rsvelte-fmt's default reaches
+in-process `oxc_formatter_css`. **[D] #3628:** `.card >> .a` is accepted and respaced by
+PostCSS but rejected and preserved by OXC, while both accept `.a || .b` and choose opposite
+spacing. Both committed pattern files are ratcheted in `fmt-known-failures.json`. This is part
+of the unit, not a blind spot: changing `fmt.mjs` to pass `--no-native-css` would stop the only
+large-corpus comparison of the shipped default identified in 10a.
+
 ### Blind spot 9a — ids with no oracle file are skipped silently, and nothing counts
 
 `fmt-verify.mjs:97`: `if (oracle === null) continue; // not part of the parity set`.
@@ -1679,14 +1687,15 @@ here so it is not mistaken for a blind spot. Its staleness check is `console.war
 
 ### Blind spot 10a — it exercises the non-default CSS path
 
-`svelte_dev_corpus.rs:100-102` claims its style callback "mirrors the production one" and pipes
-each `<style>` body through an `oxfmt` subprocess (`:127-152`). **[S]** In shipped
+`svelte_dev_corpus.rs:100-106` identifies its style callback as the legacy `--no-native-css`
+path and pipes each `<style>` body through an `oxfmt` subprocess (`:130-155`). **[S]** In shipped
 `rsvelte-fmt` that function is reached **only** under `--no-native-css`
 (`crates/rsvelte_fmt/src/options.rs:154-157`); the default is the in-process
-`rsvelte_formatter::native_style_formatter`. The comment asserting production parity is stale.
-Consequence: the default native CSS engine's parity with oxfmt is measured only by gate 9's
-whole-file compare, and `crates/rsvelte_formatter/tests/css_native.rs` is 5 hand-written
-`assert_eq!`s against literal strings, not a parity gate.
+`rsvelte_formatter::native_style_formatter`. Consequence: the default native CSS engine's parity
+with the embedded PostCSS oracle is measured only by gate 9's whole-file compare, and
+`crates/rsvelte_formatter/tests/css_native.rs` is 5 hand-written `assert_eq!`s against literal
+strings, not a parity gate. #3628 corrected the stale comments but did not change this coverage
+boundary.
 
 ### Blind spot 10b — `Err(_)` from `format` does not fail the test
 

--- a/crates/rsvelte_formatter/src/options.rs
+++ b/crates/rsvelte_formatter/src/options.rs
@@ -18,9 +18,9 @@ pub struct FormatOptions {
     /// attribute says (e.g. `"scss"`, `"less"`, `"postcss"`).
     ///
     /// When `None` (the default), `<style>` content survives verbatim.
-    /// The `rsvelte-fmt` CLI wires this up to spawn `oxfmt`, so
-    /// CSS / SCSS / Less formatting happens through the same engine
-    /// `oxfmt` uses for standalone `.css` files.
+    /// The `rsvelte-fmt` CLI supplies the in-process `oxc_formatter_css`
+    /// callback by default; `--no-native-css` supplies a standalone `oxfmt`
+    /// callback instead.
     ///
     /// The callback must be `Send + Sync` so the same `FormatOptions`
     /// can drive parallel file formatting via `rayon`.

--- a/crates/rsvelte_formatter/src/style.rs
+++ b/crates/rsvelte_formatter/src/style.rs
@@ -1,11 +1,10 @@
 //! `<style>` block formatting.
 //!
-//! `rsvelte_formatter` doesn't ship its own CSS engine. Instead it
-//! exposes a callback on [`crate::FormatOptions::style_formatter`] that
-//! receives the body and the lang (`css` / `scss` / `less` / ...). The
-//! `rsvelte-fmt` CLI wires this up to spawn
-//! `oxfmt --stdin-filepath style.<lang>`, so CSS formatting goes through
-//! the same engine `oxfmt` uses for standalone files.
+//! `rsvelte_formatter` exposes a callback on
+//! [`crate::FormatOptions::style_formatter`] that receives the body and the lang
+//! (`css` / `scss` / `less` / ...). The `rsvelte-fmt` CLI uses the in-process
+//! [`crate::native_style_formatter`] by default and swaps in a standalone
+//! `oxfmt --stdin-filepath style.<lang>` callback under `--no-native-css`.
 //!
 //! When no callback is set the style body is left verbatim.
 

--- a/crates/rsvelte_formatter/src/style_css.rs
+++ b/crates/rsvelte_formatter/src/style_css.rs
@@ -38,8 +38,8 @@ pub fn css_variant_from_lang(lang: &str) -> CssVariant {
 /// Format `source` as CSS of the given `variant` with `options`. `variant`
 /// overrides any value already on `options`.
 ///
-/// Returns a parse error for input the CSS parser rejects (the caller falls back to `oxfmt`, mirroring the native-JS
-/// and native-JSON paths).
+/// Returns a parse error for input the CSS parser rejects. Callers choose whether
+/// to preserve the input or fall back to an external formatter.
 ///
 /// # Errors
 ///
@@ -69,8 +69,9 @@ pub fn format_css_source(
 /// `base` supplies the indent / quote / EOL settings.
 ///
 /// The callback narrows `line_width` to each block's column and picks the dialect
-/// from its `lang`. A body the CSS parser rejects round-trips unchanged, mirroring
-/// how `oxfmt` leaves unparseable CSS in place.
+/// from its `lang`. A body this parser rejects round-trips unchanged. That can
+/// differ from the embedded PostCSS oracle, which accepts some selector syntax
+/// that `oxc_formatter_css` rejects.
 #[must_use]
 pub fn native_style_formatter(base: CssFormatOptions) -> StyleFormatter {
     Arc::new(

--- a/crates/rsvelte_formatter/tests/svelte_dev_corpus.rs
+++ b/crates/rsvelte_formatter/tests/svelte_dev_corpus.rs
@@ -3,8 +3,9 @@
 //! Formats every `.svelte` file from the `submodules/svelte.dev` checkout with
 //! `rsvelte_formatter` and asserts the result matches the oracle produced by
 //! `oxfmt` (with `svelte: true`, i.e. `prettier-plugin-svelte` for the Svelte
-//! structure + the oxc engine for embedded JS/CSS — the same layering rsvelte
-//! uses). The oracle is precomputed into `fixtures/fmt-corpus/<svelte.dev-sha>/`
+//! structure, oxc for embedded JS, and PostCSS for embedded CSS). The actual
+//! side delegates each style body to standalone oxfmt. The oracle is precomputed
+//! into `fixtures/fmt-corpus/<svelte.dev-sha>/`
 //! by `pnpm run generate-fmt-corpus`.
 //!
 //! Because real-world components surface many not-yet-implemented gaps, the
@@ -96,9 +97,11 @@ fn oxfmt_runnable(oxfmt: &Path) -> bool {
         .is_ok_and(|s| s.success())
 }
 
-/// Build a style callback that mirrors the production one in
-/// `crates/rsvelte_fmt/src/main.rs::make_oxfmt_style_formatter`: pipe the
-/// dedented `<style>` body through oxfmt with the canonical config.
+/// Build the legacy `--no-native-css` style callback: pipe the dedented
+/// `<style>` body through standalone oxfmt with the canonical config.
+///
+/// This is intentionally not rsvelte-fmt's default in-process CSS path; the
+/// full compatibility corpus is the parity gate for that shipped path.
 fn make_style_formatter(oxfmt: PathBuf, config: PathBuf) -> StyleFormatter {
     let base = std::fs::read_to_string(&config).unwrap_or_default();
     std::sync::Arc::new(

--- a/scripts/compat-corpus/README.md
+++ b/scripts/compat-corpus/README.md
@@ -597,10 +597,12 @@ do not move when a submodule bumps.
 A second, independent track verifies that **rsvelte-fmt** formats every
 `.svelte` component in the corpus byte-for-byte like the
 **oxfmt(`svelte: true`)** oracle — `prettier-plugin-svelte` for the Svelte
-structure plus the oxc engine for embedded JS/CSS, which is exactly
-rsvelte-fmt's own layering, so a surviving diff isolates rsvelte's
-Svelte-structure formatting (the JS/CSS layer is identical on both sides by
-construction). Unlike the compile track this is a **hard byte gate** — a
+structure, oxc for embedded JS, and PostCSS for embedded CSS. The actual side
+uses rsvelte-fmt's shipped default: rsvelte's Svelte structure, oxc for JS, and
+the in-process `oxc_formatter_css` engine for CSS. A surviving diff may therefore
+be either Svelte-structure parity or CSS-engine parity; both affect product
+output and share the same shrink-only ratchet. Unlike the compile track this is
+a **hard byte gate** — a
 formatter must match exactly, so there is no AST-equivalence fallback.
 
 ```bash
@@ -617,8 +619,10 @@ Stages:
      oxfmt rejects (or whose embedded code it can't parse) are excluded — they
      aren't valid, formattable Svelte.
    - `compatibility/fmt/actual/<id>` — rsvelte-fmt (`--stdin`, column-aware
-     `<style>` narrowing). Rebuilt every iteration; restrict to a subset with
-     `--actual --only <ids-file>` for tight burn-down.
+     `<style>` narrowing, native CSS enabled). Rebuilt every iteration; restrict
+     to a subset with `--actual --only <ids-file>` for tight burn-down. Do not
+     add `--no-native-css`: this is the large-corpus gate for the shipped default
+     CSS path.
 2. `fmt-verify.mjs` — byte-compares, writes `fmt-report.json`, ratchets against
    `compatibility/fmt-known-failures.json` (checked in; may only shrink). Exits
    non-zero only on a **regression** (a divergence not in the baseline).

--- a/scripts/compat-corpus/fmt.mjs
+++ b/scripts/compat-corpus/fmt.mjs
@@ -7,17 +7,20 @@
  * and sveltejs/svelte.dev):
  *
  *   compatibility/fmt/oracle/<id>   oxfmt with `svelte: true` (prettier-plugin-svelte
- *                                   for the Svelte structure + oxc for embedded JS/CSS)
+ *                                   for the Svelte structure, oxc for embedded JS,
+ *                                   and PostCSS for embedded CSS)
  *   compatibility/fmt/actual/<id>   rsvelte-fmt (rsvelte_formatter for the structure,
- *                                   oxc for embedded JS/CSS)
+ *                                   oxc for embedded JS, and oxc_formatter_css for CSS)
  *
- * Both pipelines format embedded JS/CSS with the same oxc engine, so any
- * surviving byte difference is a real Svelte-structure divergence. The
- * comparison + ratchet lives in fmt-verify.mjs.
+ * The JS layer is shared, but the CSS layer is deliberately not: this stage
+ * exercises rsvelte-fmt's shipped, in-process default against the embedded
+ * PostCSS oracle. CSS-engine differences are therefore product parity
+ * divergences and stay in the same shrink-only ratchet as structure differences.
+ * The comparison + ratchet lives in fmt-verify.mjs.
  *
- * The actual tree is formatted in one directory invocation. Native CSS parity
- * with oxfmt is covered separately, and keeping styles in-process avoids a
- * subprocess per component.
+ * The actual tree is formatted in one directory invocation. Passing
+ * `--no-native-css` here would hide the default path; gate-coverage.md records
+ * why the smaller Rust corpus and literal CSS tests are not substitutes.
  *
  * The oracle depends only on (svelte sha, svelte.dev sha, pattern-corpus tree
  * hash, oxfmt version, config hash); it is cached and skipped on re-runs unless

--- a/scripts/fixtures/generate-fmt-corpus.mjs
+++ b/scripts/fixtures/generate-fmt-corpus.mjs
@@ -6,9 +6,9 @@
  * Oracle = `oxfmt` with the canonical config (`fmt-corpus.oxfmtrc.json`, which
  * enables `svelte: true`). With `svelte: true`, oxfmt formats `.svelte` through
  * `prettier-plugin-svelte` for the Svelte structure while formatting embedded
- * JS/CSS with its own (oxc) engine — exactly rsvelte-fmt's own architecture, so
- * a full diff isolates rsvelte's Svelte-structure formatting from the JS/CSS
- * layer (identical on both sides by construction).
+ * JS with oxc and embedded CSS with prettier-plugin-svelte's PostCSS path. The
+ * actual Rust corpus callback formats CSS through standalone oxfmt instead, so
+ * CSS-engine differences are observable alongside Svelte-structure differences.
  *
  * Three stages, all keyed by the svelte.dev SHA:
  *   Stage 1  files/<relpath>/{input,expected}.svelte


### PR DESCRIPTION
## Summary

- document that the `oxfmt(svelte: true)` oracle formats embedded CSS through PostCSS while rsvelte-fmt's shipped default uses `oxc_formatter_css`
- keep the large corpus on the shipped native-CSS path and record why `--no-native-css` would hide product parity
- explicitly justify the two #3404 CSS-engine failures already in the formatter ratchet, and correct stale API/test comments about the legacy subprocess path

## Context

The parse-failure blank-line defect reported in #3628 was fixed by #3629. The two remaining reproductions are genuine engine-boundary differences: repeated combinators reach OXC's verbatim fallback, while the valid `||` combinator is printed differently by both engines. This PR records the decision to leave those differences ratcheted instead of switching the corpus away from rsvelte-fmt's default behavior.

Closes #3628.

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`

Per the requested workflow, no local build or test suite was run; CI is the execution oracle.
