### PR TITLE
fix(compiler): lower inspect trace in component module scripts

### DIFF
--- a/.changeset/tidy-module-traces.md
+++ b/.changeset/tidy-module-traces.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/core": patch
+---
+
+Lower `$inspect.trace()` in development component module scripts.

--- a/.changeset/tidy-module-traces.md
+++ b/.changeset/tidy-module-traces.md
@@ -1,5 +1,5 @@
 ---
-"@rsvelte/core": patch
+"@rsvelte/compiler": patch
 ---
 
 Lower `$inspect.trace()` in development component module scripts.

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/inspect_trace_ast.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/inspect_trace_ast.rs
@@ -46,6 +46,19 @@ pub(super) fn transform_module_inspect_trace(
     is_ts: bool,
     filename: Option<&str>,
 ) -> Option<String> {
+    transform_module_inspect_trace_with_prefix(source, dev, is_ts, filename, "")
+}
+
+/// Component module scripts are parsed as a source slice, but their default
+/// trace labels are located in the whole `.svelte` file. `source_prefix` is
+/// the source before that slice, including the opening `<script module>` tag.
+pub(super) fn transform_module_inspect_trace_with_prefix(
+    source: &str,
+    dev: bool,
+    is_ts: bool,
+    filename: Option<&str>,
+    source_prefix: &str,
+) -> Option<String> {
     if !source_has_inspect_trace(source) {
         return None;
     }
@@ -62,6 +75,7 @@ pub(super) fn transform_module_inspect_trace(
         |program, src| {
             let mut collector = TraceCollector {
                 source: src,
+                source_prefix,
                 filename,
                 dev,
                 parent_label: None,
@@ -75,6 +89,7 @@ pub(super) fn transform_module_inspect_trace(
 
 struct TraceCollector<'src> {
     source: &'src str,
+    source_prefix: &'src str,
     filename: Option<&'src str>,
     dev: bool,
     /// The label the *immediate* parent of a function gives it, mirroring
@@ -92,10 +107,18 @@ impl<'src> TraceCollector<'src> {
     /// `locate_node(fn)`: 1-based line, 0-based column of the function's start.
     fn locate(&self, at: u32) -> (usize, usize) {
         let before = &self.source[..at as usize];
-        let line = before.matches('\n').count() + 1;
-        let col = before[before.rfind('\n').map_or(0, |p| p + 1)..]
-            .chars()
-            .count();
+        let prefix_lines = self.source_prefix.matches('\n').count();
+        let local_lines = before.matches('\n').count();
+        let line = prefix_lines + local_lines + 1;
+        let col = if let Some(last_newline) = before.rfind('\n') {
+            before[last_newline + 1..].chars().count()
+        } else {
+            let prefix_column = self.source_prefix
+                [self.source_prefix.rfind('\n').map_or(0, |p| p + 1)..]
+                .chars()
+                .count();
+            prefix_column + before.chars().count()
+        };
         (line, col)
     }
 
@@ -258,7 +281,7 @@ impl<'a, 'src> Visit<'a> for TraceCollector<'src> {
 
 #[cfg(test)]
 mod tests {
-    use super::transform_module_inspect_trace;
+    use super::{transform_module_inspect_trace, transform_module_inspect_trace_with_prefix};
 
     fn dev(source: &str) -> Option<String> {
         transform_module_inspect_trace(source, true, false, Some("m.svelte.js"))
@@ -278,6 +301,19 @@ mod tests {
         let out =
             dev("let base = 1;\nexport function go() { $inspect.trace(); return base; }").unwrap();
         assert!(out.contains("() => 'go (m.svelte.js:2:7)'"), "got: {out}");
+    }
+
+    #[test]
+    fn a_component_module_label_includes_the_script_tags_source_prefix() {
+        let out = transform_module_inspect_trace_with_prefix(
+            "\nexport function go() { $inspect.trace(); return 1; }\n",
+            true,
+            false,
+            Some("C.svelte"),
+            "<script module>",
+        )
+        .unwrap();
+        assert!(out.contains("() => 'go (C.svelte:2:7)'"), "got: {out}");
     }
 
     /// Every label arm of `get_function_label`, and the fallback a class member

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
@@ -2143,9 +2143,30 @@ pub(crate) fn transform_client(
     // Reference: transform-client.js line 513: body = [...imports, ...state.module_level_snippets, ...body];
     let module_script_non_imports: Option<(String, Option<String>)> =
         if let Some(ref module_content) = analysis.module_script_content {
+            // `$inspect.trace()`'s default label is located in the original
+            // component, so lower it before TypeScript stripping, comment
+            // removal, import extraction, or any other rewrite moves the
+            // enclosing function. The AST pass parses only the script body;
+            // its prefix supplies the whole-file line and column base.
+            let trace_lowered = if options.dev {
+                source
+                    .get(..module_content.start as usize)
+                    .zip(source.get(module_content.start as usize..module_content.end as usize))
+                    .and_then(|(prefix, module_source)| {
+                        inspect_trace_ast::transform_module_inspect_trace_with_prefix(
+                            module_source,
+                            true,
+                            analysis.is_typescript,
+                            options.filename.as_deref(),
+                            prefix,
+                        )
+                    })
+            } else {
+                None
+            };
             // Strip TypeScript syntax before processing
             let raw = crate::compiler::phases::phase2_analyze::types::strip_typescript(
-                &module_content.raw,
+                trace_lowered.as_deref().unwrap_or(&module_content.raw),
             );
             // Then the comments the accessors swallow, while the class the scan
             // keys on is still in its source shape — the rune transforms below

--- a/crates/rsvelte_core/tests/inspect_trace_module.rs
+++ b/crates/rsvelte_core/tests/inspect_trace_module.rs
@@ -113,11 +113,11 @@ fn an_async_function_awaits_the_traced_body() {
 
 /// The rune reaches this pipeline through two entry points (a `.svelte.(js|ts)`
 /// module and a component's `<script module>`) crossed with target and mode, and
-/// only ONE of those eight cells lowers it — every other cell removes it. The
+/// only the two client-dev cells lower it — every other cell removes it. The
 /// lowering therefore cannot replace the removal; both have to stand. Read off
 /// the official compiler for all eight.
 #[test]
-fn every_target_and_mode_still_drops_the_rune() {
+fn every_entry_target_and_mode_handles_the_rune_like_upstream() {
     use rsvelte_core::{CompileOptions, compile, compiler::CssMode};
 
     const SRC: &str =
@@ -152,9 +152,19 @@ fn every_target_and_mode_still_drops_the_rune() {
         .unwrap_or_else(|e| format!("COMPILE_ERROR: {e:?}"))
     };
 
-    // The one cell that lowers.
-    let lowered = module_target(GenerateMode::Client, true);
-    assert!(lowered.contains("$.trace("), "{lowered}");
+    // The two client-dev entry points lower the rune. The component label is
+    // located in the whole `.svelte` file, including the opening script tag.
+    let lowered_module = module_target(GenerateMode::Client, true);
+    assert!(lowered_module.contains("$.trace("), "{lowered_module}");
+    let lowered_component = component(GenerateMode::Client, true);
+    assert!(
+        lowered_component.contains("$.trace("),
+        "{lowered_component}"
+    );
+    assert!(
+        lowered_component.contains("() => 'go (C.svelte:3:7)'"),
+        "{lowered_component}"
+    );
 
     for (name, out) in [
         (


### PR DESCRIPTION
Closes #3543.

## Summary
- run the existing AST `$inspect.trace()` lowering for development `<script module>` content
- transform the original script body before TypeScript stripping and import extraction
- locate default labels against the complete `.svelte` source prefix
- pin both client-dev entry points and all remaining target/mode cells

## Checks
- `cargo fmt --all -- --check`
- `git diff --check`
- builds/tests deferred to CI per request