### PR TITLE
fix(client): fold dev equality declaration initializers

### DIFF
--- a/.changeset/calm-equalities-fold.md
+++ b/.changeset/calm-equalities-fold.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/core": patch
+---
+
+Fold constant equality expressions reached through declaration initializers in development builds.

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/tests.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/tests.rs
@@ -2767,6 +2767,56 @@ fn globals_fold_client_code(source: &str) -> String {
     .code
 }
 
+fn dev_fold_client_code(source: &str) -> String {
+    crate::compiler::compile(
+        source,
+        crate::compiler::CompileOptions {
+            generate: crate::compiler::GenerateMode::Client,
+            filename: Some("dev-fold.svelte".to_string()),
+            dev: true,
+            ..Default::default()
+        },
+    )
+    .expect("compiles")
+    .js
+    .code
+}
+
+#[test]
+fn dev_equality_in_declaration_initializers_still_folds_template_reads() {
+    for (operator, expected, helper) in [
+        ("===", "2", "$.strict_equals"),
+        ("!==", "1", "$.strict_equals"),
+        ("==", "1", "$.equals"),
+        ("!=", "2", "$.equals"),
+    ] {
+        let declaration = dev_fold_client_code(&format!(
+            "<script>\n\tconst v = '1' {operator} 1 ? 1 : 2;\n</script>\n<b>{{v}}</b>\n"
+        ));
+        assert!(
+            declaration.contains(&format!(".textContent = '{expected}';")),
+            "a declaration initializer using `{operator}` must fold: {declaration}"
+        );
+        assert!(
+            !declaration.contains("$.template_effect"),
+            "a folded declaration read must stay non-reactive: {declaration}"
+        );
+
+        // Control: a template equality is evaluated after the dev visitor has
+        // converted it to a runtime helper call, so it must not be folded as if
+        // it were the original BinaryExpression.
+        let inline = dev_fold_client_code(&format!("<b>{{'1' {operator} 1 ? 1 : 2}}</b>\n"));
+        assert!(
+            inline.contains(helper),
+            "an inline `{operator}` must retain dev instrumentation: {inline}"
+        );
+        assert!(
+            !inline.contains(".textContent = "),
+            "an inline dev equality must not take the static text fast path: {inline}"
+        );
+    }
+}
+
 /// Upstream's `globals` table folds a call to a known-pure global over known
 /// arguments, so an element whose only child is such a value keeps the
 /// `textContent` fast path. Every row was read off svelte 5.56.9.

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/utils.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/utils.rs
@@ -4467,11 +4467,17 @@ fn get_literal_value_complex(
         "BinaryExpression" => {
             let operator = obj.get("operator").and_then(|v| v.as_str())?;
 
-            // Upstream evaluates the *converted* expression, and in dev the
-            // `BinaryExpression` visitor has already turned an equality into a
-            // `$.strict_equals` / `$.equals` call — which never evaluates to a
-            // known value, so the chunk stays a call instead of folding.
-            if context.state.options.dev && matches!(operator, "===" | "!==" | "==" | "!=") {
+            // At the template-expression root upstream evaluates the
+            // *converted* expression, and in dev the `BinaryExpression` visitor
+            // has already turned an equality into a `$.strict_equals` /
+            // `$.equals` call. Once `scope.evaluate` follows an identifier into
+            // its binding initializer, however, it evaluates that original AST
+            // node. Keep the dev bail at depth zero only so declaration
+            // initializers retain their normal constant-folding semantics.
+            if context.state.options.dev
+                && INITIAL_EVAL_DEPTH.with(|d| d.get()) == 0
+                && matches!(operator, "===" | "!==" | "==" | "!=")
+            {
                 return None;
             }
 


### PR DESCRIPTION
## Summary
- keep dev equality folding disabled for converted template expressions
- allow constant folding after evaluation follows an identifier into its original declaration initializer
- cover all four equality operators plus inline-expression controls

## Validation
- cargo fmt --all -- --check
- git diff --check
- heavy tests intentionally deferred to CI

Closes #3570