### PR TITLE
Fix snippet array temporary declaration order

### DIFF
--- a/.changeset/order-snippet-array-inserts.md
+++ b/.changeset/order-snippet-array-inserts.md
@@ -1,5 +1,5 @@
 ---
-'@rsvelte/core': patch
+'@rsvelte/compiler': patch
 ---
 
 Emit nested snippet array-pattern temporaries before leaf bindings to match Svelte.

--- a/.changeset/order-snippet-array-inserts.md
+++ b/.changeset/order-snippet-array-inserts.md
@@ -1,0 +1,5 @@
+---
+'@rsvelte/core': patch
+---
+
+Emit nested snippet array-pattern temporaries before leaf bindings to match Svelte.

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/snippet_block.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/snippet_block.rs
@@ -357,16 +357,19 @@ fn process_destructured_pattern(
     arg_alias: &str,
     context: &mut ComponentContext,
 ) -> Vec<JsStatement> {
-    let mut declarations = Vec::new();
+    let mut inserts = Vec::new();
+    let mut paths = Vec::new();
     let base = b::optional_call(&context.arena, b::id(arg_alias), vec![]);
     extract_snippet_paths(
         &serde_json::Value::Object(obj.clone()),
         base,
         false,
-        &mut declarations,
+        &mut inserts,
+        &mut paths,
         context,
     );
-    declarations
+    inserts.extend(paths);
+    inserts
 }
 
 /// Emit a leaf binding `let name = needs_derived ? $.derived_safe_equal(() => access)
@@ -421,8 +424,10 @@ fn emit_snippet_path(
 ///
 /// Walks a destructuring `pattern` (JSON), threading the access expression
 /// `base` (the AST that reads the current sub-value). Array patterns push an
-/// intermediate `var $$array = $.derived(() => $.to_array(base, len?))` and read
-/// elements as `$.get($$array)[i]`; object rest emits
+/// intermediate `var $$array = $.derived(() => $.to_array(base, len?))` into
+/// `inserts` and read elements as `$.get($$array)[i]`; leaf declarations go into
+/// `paths`. Upstream returns those collections separately and the caller emits
+/// every insert before every path. Object rest emits
 /// `$.exclude_from_object(base, [keys])`; defaults wrap the access in
 /// `$.fallback(...)`; the whole path collapses to `$.derived_safe_equal(...)`
 /// when any default is involved. (issue #446, H-100..H-103)
@@ -430,7 +435,8 @@ fn extract_snippet_paths(
     pattern: &serde_json::Value,
     base: JsExpr,
     has_default: bool,
-    declarations: &mut Vec<JsStatement>,
+    inserts: &mut Vec<JsStatement>,
+    paths: &mut Vec<JsStatement>,
     context: &mut ComponentContext,
 ) {
     let obj = match pattern.as_object() {
@@ -440,7 +446,7 @@ fn extract_snippet_paths(
     match obj.get("type").and_then(|t| t.as_str()) {
         Some("Identifier") => {
             if let Some(name) = obj.get("name").and_then(|n| n.as_str()) {
-                emit_snippet_path(name, base, has_default, declarations, context);
+                emit_snippet_path(name, base, has_default, paths, context);
             }
         }
         Some("ObjectPattern") => {
@@ -472,7 +478,8 @@ fn extract_snippet_paths(
                                 arg,
                                 rest_expr,
                                 has_default,
-                                declarations,
+                                inserts,
+                                paths,
                                 context,
                             );
                         }
@@ -485,7 +492,8 @@ fn extract_snippet_paths(
                                 value,
                                 access,
                                 has_default,
-                                declarations,
+                                inserts,
+                                paths,
                                 context,
                             );
                         }
@@ -517,7 +525,7 @@ fn extract_snippet_paths(
                 b::member_path(&context.arena, "$.to_array"),
                 to_array_args,
             );
-            declarations.push(b::var_decl(
+            inserts.push(b::var_decl(
                 &context.arena,
                 &array_name,
                 Some(b::call(
@@ -555,13 +563,20 @@ fn extract_snippet_paths(
                         vec![b::number(i as f64)],
                     );
                     if let Some(arg) = elem_obj.get("argument") {
-                        extract_snippet_paths(arg, slice_expr, has_default, declarations, context);
+                        extract_snippet_paths(
+                            arg,
+                            slice_expr,
+                            has_default,
+                            inserts,
+                            paths,
+                            context,
+                        );
                     }
                 } else {
                     // `$.get($$array)[i]`
                     let access =
                         b::member_computed(&context.arena, array_get(), b::number(i as f64));
-                    extract_snippet_paths(elem, access, has_default, declarations, context);
+                    extract_snippet_paths(elem, access, has_default, inserts, paths, context);
                 }
             }
         }
@@ -575,7 +590,7 @@ fn extract_snippet_paths(
                     b::member_path(&context.arena, "$.fallback"),
                     fallback_args,
                 );
-                extract_snippet_paths(left, fallback_call, true, declarations, context);
+                extract_snippet_paths(left, fallback_call, true, inserts, paths, context);
             }
         }
         _ => {}
@@ -737,18 +752,21 @@ fn process_assignment_pattern(
         fallback_args,
     );
 
-    let mut declarations = Vec::new();
+    let mut inserts = Vec::new();
+    let mut paths = Vec::new();
     extract_snippet_paths(
         &serde_json::Value::Object(left.clone()),
         fallback_call,
         true,
-        &mut declarations,
+        &mut inserts,
+        &mut paths,
         context,
     );
+    inserts.extend(paths);
 
     Some(ParameterInfo {
         pattern,
-        declarations,
+        declarations: inserts,
     })
 }
 

--- a/crates/rsvelte_core/tests/snippet_param_destructuring.rs
+++ b/crates/rsvelte_core/tests/snippet_param_destructuring.rs
@@ -88,6 +88,44 @@ fn array_pattern_nested_and_rest() {
 }
 
 #[test]
+fn array_temporaries_precede_every_leaf_binding() {
+    // #3556: upstream collects array materialisation statements separately from
+    // leaf paths, then emits all materialisations first. Cover a leaf before the
+    // first array, a nested array, and a second sibling array so DFS interleaving
+    // cannot accidentally reproduce the expected order.
+    let src = r#"{#snippet foo({ before, xs: [[x]], middle, ys: [y] })}<p>{before}{x}{middle}{y}</p>{/snippet}{@render foo({before:1,xs:[[2]],middle:3,ys:[4]})}"#;
+
+    for dev in [false, true] {
+        let out = compile(
+            src,
+            CompileOptions {
+                filename: Some("T.svelte".to_string()),
+                generate: GenerateMode::Client,
+                dev,
+                css: CssMode::External,
+                runes: Some(true),
+                ..Default::default()
+            },
+        )
+        .expect("compile")
+        .js
+        .code;
+
+        let array = out.find("var $$array =").expect("outer array temporary");
+        let nested = out.find("var $$array_1 =").expect("nested array temporary");
+        let sibling = out
+            .find("var $$array_2 =")
+            .expect("sibling array temporary");
+        let first_leaf = out.find("let before =").expect("first leaf binding");
+
+        assert!(
+            array < nested && nested < sibling && sibling < first_leaf,
+            "all array temporaries must precede every leaf binding (dev={dev}):\n{out}"
+        );
+    }
+}
+
+#[test]
 fn whole_parameter_default_is_applied() {
     // H-103: a whole-parameter default `= { id: 1 }` wraps the base in `$.fallback`.
     assert_contains(


### PR DESCRIPTION
## Summary
- collect snippet array-pattern temporaries separately from leaf bindings, matching upstream extract_paths
- emit every array materialisation before any leaf binding
- cover nested and sibling arrays in client prod and dev output

Fixes #3556

## Validation
- cargo fmt --all -- --check
- git diff --check
- full build/test deferred to CI as requested