### PR TITLE
fix(client): proxy bindable rune identifier defaults

### DIFF
--- a/.changeset/clean-cats-proxy.md
+++ b/.changeset/clean-cats-proxy.md
@@ -1,0 +1,5 @@
+---
+"rsvelte_core": patch
+---
+
+Fix lazy proxying for bindable prop defaults that reference rune bindings

--- a/.changeset/clean-cats-proxy.md
+++ b/.changeset/clean-cats-proxy.md
@@ -1,5 +1,5 @@
 ---
-"rsvelte_core": patch
+"@rsvelte/compiler": patch
 ---
 
 Fix lazy proxying for bindable prop defaults that reference rune bindings

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/props_transforms.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/props_transforms.rs
@@ -2276,9 +2276,11 @@ fn ast_expr_is_simple(value: &str, analysis: &ComponentAnalysis) -> Option<bool>
 /// `analysis` enables upstream's one-level scope recursion: a bare identifier
 /// default resolves to its (non-reassigned, non-function) binding's initial and
 /// that initial's node type decides proxy-ability — e.g. `= DEFAULT_ALPHA` where
-/// `const DEFAULT_ALPHA = 1` is not proxied. Pass `None` to disable recursion (as
-/// upstream does by threading `null` scope on the recursed call), so it is at
-/// most one level deep.
+/// `const DEFAULT_ALPHA = 1` is not proxied. Rune bindings need special care:
+/// rsvelte stores the rune argument in `binding.initial`, while upstream keeps
+/// the complete `$state(...)` / `$derived(...)` CallExpression, which is always
+/// proxyable. Pass `None` to disable recursion (as upstream does by threading a
+/// null scope on the recursed call), so it is at most one level deep.
 fn ast_should_proxy(value: &str, analysis: Option<&ComponentAnalysis>) -> Option<bool> {
     use oxc_allocator::Allocator;
     use oxc_ast::ast::Statement;
@@ -2334,8 +2336,18 @@ fn expr_should_proxy(
                 && let Some(binding) = analysis.root.bindings.get(idx)
                 && !binding.reassigned
                 && !binding.initial_is_function
-                && let Some(initial) = binding.initial.as_deref()
             {
+                // Upstream recurses into the declaration initializer node. A
+                // rune declaration's initializer is the call itself, not its
+                // argument, so even `$state(1)` is a proxyable CallExpression.
+                // `binding.initial` deliberately stores `1` for other analysis
+                // consumers; `init_rune` preserves the lost outer node shape.
+                if binding.init_rune.is_some() {
+                    return true;
+                }
+                let Some(initial) = binding.initial.as_deref() else {
+                    return true;
+                };
                 // `None` disables further identifier recursion (upstream `null` scope).
                 return ast_should_proxy(initial, None).unwrap_or(true);
             }

--- a/crates/rsvelte_core/tests/bindable_rune_default_3615.rs
+++ b/crates/rsvelte_core/tests/bindable_rune_default_3615.rs
@@ -1,0 +1,70 @@
+//! Regression tests for #3615: `$bindable(<identifier>)` must decide whether to
+//! proxy from the identifier binding's original initializer node.
+//!
+//! Upstream keeps `$state(1)` as a CallExpression on the binding. rsvelte keeps
+//! its argument (`1`) for constant analysis, so the proxy check mistook a state
+//! identifier for a primitive default and emitted eager `$.prop(..., 11, s)`.
+
+use rsvelte_core::{CompileOptions, GenerateMode, compile};
+
+fn client_with_options(options: &str, script: &str) -> String {
+    compile(
+        &format!("{options}<script>{script}</script><b>{{typeof p}}</b>"),
+        CompileOptions {
+            filename: Some("X.svelte".to_string()),
+            generate: GenerateMode::Client,
+            ..Default::default()
+        },
+    )
+    .expect("compile")
+    .js
+    .code
+}
+
+fn client(script: &str) -> String {
+    client_with_options("", script)
+}
+
+fn prop_line(code: &str) -> &str {
+    code.lines()
+        .find(|line| line.trim_start().starts_with("let p = $.prop("))
+        .unwrap_or_else(|| panic!("no prop declaration in:\n{code}"))
+        .trim()
+}
+
+#[test]
+fn rune_identifier_defaults_are_proxied_lazily() {
+    for (declaration, expected_default) in [
+        ("let s = $state(1);", "$.proxy(s)"),
+        ("let s = $state.raw(1);", "$.proxy($.get(s))"),
+        ("let s = $derived(1);", "$.proxy($.get(s))"),
+        ("let s = $derived.by(() => 1);", "$.proxy($.get(s))"),
+    ] {
+        let code = client(&format!(
+            "{declaration} let {{ p = $bindable(s) }} = $props();"
+        ));
+        assert_eq!(
+            prop_line(&code),
+            format!("let p = $.prop($$props, 'p', 27, () => {expected_default});"),
+            "for {declaration}"
+        );
+    }
+}
+
+#[test]
+fn primitive_const_identifier_default_stays_eager_and_unproxied() {
+    let code = client("const s = 1; let { p = $bindable(s) } = $props();");
+    assert_eq!(prop_line(&code), "let p = $.prop($$props, 'p', 11, s);");
+}
+
+#[test]
+fn accessors_host_uses_the_same_lazy_proxy_default() {
+    let code = client_with_options(
+        "<svelte:options accessors />",
+        "let s = $state(1); let { p = $bindable(s) } = $props();",
+    );
+    assert_eq!(
+        prop_line(&code),
+        "let p = $.prop($$props, 'p', 27, () => $.proxy(s));"
+    );
+}

--- a/crates/rsvelte_core/tests/bindable_rune_default_3615.rs
+++ b/crates/rsvelte_core/tests/bindable_rune_default_3615.rs
@@ -36,7 +36,7 @@ fn prop_line(code: &str) -> &str {
 fn rune_identifier_defaults_are_proxied_lazily() {
     for (declaration, expected_default) in [
         ("let s = $state(1);", "$.proxy(s)"),
-        ("let s = $state.raw(1);", "$.proxy($.get(s))"),
+        ("let s = $state.raw(1);", "$.proxy(s)"),
         ("let s = $derived(1);", "$.proxy($.get(s))"),
         ("let s = $derived.by(() => 1);", "$.proxy($.get(s))"),
     ] {


### PR DESCRIPTION
Closes #3615.

## Summary
- preserve upstream `should_proxy` semantics when a bindable default resolves to a rune binding
- use `init_rune` to recover the original CallExpression shape while keeping the rune argument representation used by analysis
- cover state, raw state, derived, accessors, and a primitive const control

## Validation
- `cargo fmt --all -- --check`
- `git diff --check`
- full build and test suite delegated to CI as requested