### PR TITLE
fix(compiler): preserve comments on rewritten module reads

### DIFF
--- a/.changeset/fuzzy-pandas-read.md
+++ b/.changeset/fuzzy-pandas-read.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/compiler": patch
+---
+
+Preserve trailing comment placement when compileModule rewrites reactive reads.

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/state_pipeline_ast.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/state_pipeline_ast.rs
@@ -855,8 +855,13 @@ impl<'a> PipelineRewriter<'a> {
         if !self.sites.reads.contains(&(id.span.start, id.span.end)) {
             return;
         }
-        let name = id.name;
-        *expr = self.state_read(name.as_str());
+        // Keep the source identifier node inside the builder-made wrapper.
+        // Upstream does `b.call('$.get', identifier)`, so the identifier's loc
+        // remains the cursor anchor while the synthesized call itself has no
+        // loc. This matters for a same-line trailing comment: esrap flushes it
+        // inside `$.get(...)`, not after the containing statement (#3610).
+        let identifier = std::mem::replace(expr, self.b.void0());
+        *expr = self.b.call("$.get", vec![identifier]);
         self.changed = true;
     }
 

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/state_pipeline_ast.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/state_pipeline_ast.rs
@@ -848,6 +848,20 @@ impl<'a> PipelineRewriter<'a> {
         self.b.call("$.get", vec![self.b.id(name)])
     }
 
+    fn state_read_with_source_identifier(&self, identifier: Expression<'a>) -> Expression<'a> {
+        // `SPAN` is a real location to rsvelte_esrap, whereas upstream's
+        // builder-created wrapper has `loc: null`. Unlocate the synthesized
+        // call first, then put the original located identifier back as its
+        // argument so only that identifier advances the comment cursor.
+        let mut call = self.b.call("$.get", vec![self.b.void0()]);
+        ast_rewrite::mark_synthesized_expression(&mut call);
+        let Expression::CallExpression(call_expression) = &mut call else {
+            unreachable!("B::call always creates a call expression")
+        };
+        call_expression.arguments[0] = Argument::from(identifier);
+        call
+    }
+
     fn rewrite_read(&mut self, expr: &mut Expression<'a>) {
         let Expression::Identifier(id) = &*expr else {
             return;
@@ -855,13 +869,8 @@ impl<'a> PipelineRewriter<'a> {
         if !self.sites.reads.contains(&(id.span.start, id.span.end)) {
             return;
         }
-        // Keep the source identifier node inside the builder-made wrapper.
-        // Upstream does `b.call('$.get', identifier)`, so the identifier's loc
-        // remains the cursor anchor while the synthesized call itself has no
-        // loc. This matters for a same-line trailing comment: esrap flushes it
-        // inside `$.get(...)`, not after the containing statement (#3610).
         let identifier = std::mem::replace(expr, self.b.void0());
-        *expr = self.b.call("$.get", vec![identifier]);
+        *expr = self.state_read_with_source_identifier(identifier);
         self.changed = true;
     }
 

--- a/crates/rsvelte_core/tests/module_rewritten_read_comment_3610.rs
+++ b/crates/rsvelte_core/tests/module_rewritten_read_comment_3610.rs
@@ -26,7 +26,7 @@ fn trailing_line_comment_follows_a_rewritten_derived_read() {
 
     let array = client("return [a, d]; // trailing");
     assert!(
-        array.contains("return [a, // trailing\n\t\t$.get(d)];"),
+        array.contains("return [a, // trailing\n\t$.get(d)];"),
         "comment did not follow esrap's sequence cursor:\n{array}"
     );
 

--- a/crates/rsvelte_core/tests/module_rewritten_read_comment_3610.rs
+++ b/crates/rsvelte_core/tests/module_rewritten_read_comment_3610.rs
@@ -1,0 +1,47 @@
+use rsvelte_core::{GenerateMode, ModuleCompileOptions, compile_module};
+
+fn client(body: &str) -> String {
+    compile_module(
+        &format!(
+            "let a = $state(1);\nconst d = $derived(a + 1);\nexport function read() {{\n\t{body}\n}}"
+        ),
+        ModuleCompileOptions {
+            filename: Some("X.svelte.js".to_string()),
+            generate: GenerateMode::Client,
+            ..Default::default()
+        },
+    )
+    .expect("module should compile")
+    .js
+    .code
+}
+
+#[test]
+fn trailing_line_comment_follows_a_rewritten_derived_read() {
+    let direct = client("return d; // trailing");
+    assert!(
+        direct.contains("return $.get(d // trailing\n\t);"),
+        "comment did not land in the synthesized getter:\n{direct}"
+    );
+
+    let array = client("return [a, d]; // trailing");
+    assert!(
+        array.contains("return [a, // trailing\n\t\t$.get(d)];"),
+        "comment did not follow esrap's sequence cursor:\n{array}"
+    );
+
+    let nested = client("return String(d); // trailing");
+    assert!(
+        nested.contains("return String($.get(d // trailing\n\t));"),
+        "comment did not land inside the nested getter:\n{nested}"
+    );
+}
+
+#[test]
+fn trailing_block_comment_follows_a_rewritten_derived_read() {
+    let out = client("return [a, d]; /* trailing */");
+    assert!(
+        out.contains("return [a, /* trailing */ $.get(d)];"),
+        "block comment did not follow esrap's sequence cursor:\n{out}"
+    );
+}


### PR DESCRIPTION
Closes #3610

## Summary

- preserve the original located identifier when the in-place module state pipeline wraps a reactive read in `$.get(...)`
- match upstream’s AST shape, where the synthesized call is unlocated and its identifier argument remains the comment cursor anchor
- cover direct, array, nested-call, line-comment, and block-comment placements

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- build and test execution delegated to CI as requested