### PR TITLE
test(parse): pin attribute close error position

### DIFF
--- a/crates/rsvelte_core/tests/malformed_markup_positions.rs
+++ b/crates/rsvelte_core/tests/malformed_markup_positions.rs
@@ -61,6 +61,10 @@ const POINT_ERRORS: &[(&str, &str, u32)] = &[
     ("<div>x</div\n", "expected_token", 11),
     ("<span></span\n", "expected_token", 12),
     ("<div><span>x</span\n</div>\n", "expected_token", 19),
+    // An apparent close after an unquoted attribute value is first read as an
+    // attribute named `<`; upstream then consumes `/` and demands `>` at `b`.
+    // Stopping the attribute loop at `<` reports two columns too early (#3486).
+    ("<div data-x=a</b></div>", "expected_token", 15),
     // A mustache with no `}` anywhere demands one where the expression stopped.
     ("{@html z\n", "expected_token", 8),
     ("{@render f()\n", "expected_token", 12),


### PR DESCRIPTION
Closes #3486.

## Summary

- pin the official `expected_token` point for an apparent closing tag after an unquoted attribute value
- document why the parser must report at the name after `/`, not at the opening `<`

The strict-mode parser behavior was corrected incidentally by #3558 (`a9d859885`), which limited the early `</` stop to loose recovery. This PR adds the missing discriminating regression so that fix cannot silently regress.

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`

Per the requested workflow, I did not run local builds or tests; CI is the execution oracle.
