### PR TITLE
test(compiler): pin inspect with declarator semantics

### DIFF
--- a/compatibility/deliberate-divergences.md
+++ b/compatibility/deliberate-divergences.md
@@ -284,3 +284,31 @@ uncoded panic instead of a diagnostic.
   compiler at all, so no published source carries the shape.
 - **Output-parseability gate**: rsvelte's output is valid JavaScript either way — the divergence is
   whether the input is accepted, which that gate does not ask.
+
+---
+
+## Module `$inspect(…).with(fn)` in a declarator initializer
+
+**Pinned by** `crates/rsvelte_core/tests/module_inspect_slot_3611.rs`
+(`an_inspect_with_declarator_keeps_its_binding_and_value`).
+**Reported upstream** in `upstream_issues/svelte-inspect-with-in-a-declarator.md`.
+
+Official omits `'$inspect().with'` from the rune allow-list used by both client and server
+`VariableDeclaration` visitors. The outer call therefore bypasses the inspect visitor and falls
+through to a state-shaped declarator path:
+
+| target | official | rsvelte |
+|---|---|---|
+| client prod/dev | drops the declarator, leaving later `t` reads free | keeps `const t = undefined` in prod and the `$.inspect(...)` result in dev |
+| server prod/dev | emits `const t = fn`, binding the inspector instead of the rune result | keeps `const t = undefined` in prod and the inspector call result in dev |
+
+Both official outputs parse, so this is not covered by the invalid-JavaScript exception alone.
+They are nevertheless runtime-wrong: the client turns a declared local into a `ReferenceError`,
+and the server changes the value from the callback's return value (or `undefined` in prod) to the
+callback function itself. rsvelte keeps the semantics of the same rune in every other expression
+slot. Exported declarators follow the same decision.
+
+No collected corpus source binds an inspect rune's result, and the #3611 generated slot grid
+compares official output rather than evaluating the later reference. Remove this entry and change
+the eight pinned expectations to byte parity when upstream includes `'$inspect().with'` in both
+declarator allow-lists.

--- a/crates/rsvelte_core/tests/module_inspect_slot_3611.rs
+++ b/crates/rsvelte_core/tests/module_inspect_slot_3611.rs
@@ -181,6 +181,7 @@ fn an_inspect_with_declarator_keeps_its_binding_and_value() {
                         "$.inspect(() => [a], (...$$args) => console.log(...$$args))"
                     }
                     (GenerateMode::Server, true) => "console.log('init', a)",
+                    (GenerateMode::None, true) => unreachable!("the test only compiles targets"),
                 };
                 assert!(
                     code.contains(&format!("{prefix} = {value};")),

--- a/crates/rsvelte_core/tests/module_inspect_slot_3611.rs
+++ b/crates/rsvelte_core/tests/module_inspect_slot_3611.rs
@@ -158,6 +158,47 @@ fn the_server_lowers_a_module_inspect_in_dev() {
     }
 }
 
+/// Official omits `$inspect().with` from the rune allow-list used for a
+/// declarator initializer. The client drops the declaration (making `t` a
+/// free reference), while the server binds the inspector itself. Both are
+/// runtime-wrong, so rsvelte deliberately keeps the rune's actual result.
+#[test]
+fn an_inspect_with_declarator_keeps_its_binding_and_value() {
+    for (declaration, prefix) in [
+        ("const t = $inspect(a).with(console.log);", "const t"),
+        (
+            "export const t = $inspect(a).with(console.log);",
+            "export const t",
+        ),
+    ] {
+        let body = format!("{declaration}\nexport function read_t() {{ return t; }}");
+        for generate in [GenerateMode::Client, GenerateMode::Server] {
+            for dev in [false, true] {
+                let code = compile_mod(&body, generate, dev);
+                let value = match (generate, dev) {
+                    (_, false) => "undefined",
+                    (GenerateMode::Client, true) => {
+                        "$.inspect(() => [a], (...$$args) => console.log(...$$args))"
+                    }
+                    (GenerateMode::Server, true) => "console.log('init', a)",
+                };
+                assert!(
+                    code.contains(&format!("{prefix} = {value};")),
+                    "({generate:?} dev={dev}) in:\n{code}"
+                );
+                assert!(
+                    code.contains("return t;"),
+                    "({generate:?} dev={dev}) in:\n{code}"
+                );
+                assert!(
+                    !code.contains("$inspect"),
+                    "({generate:?} dev={dev}) in:\n{code}"
+                );
+            }
+        }
+    }
+}
+
 /// A derived argument is read through its call, the same as any other server
 /// read — the lowering happens before the read rewriting, not after it.
 #[test]

--- a/upstream_issues/README.md
+++ b/upstream_issues/README.md
@@ -88,7 +88,7 @@ deletion, and is deliberately left to its own change rather than folded into the
 | `svelte-declaration-tag-dollar-identifier.md` | sveltejs/svelte | #3614 | unrecorded |
 | `svelte-eslint-parser-self-closing-style-lookalike-component.md` | sveltejs/svelte-eslint-parser | — | unrecorded |
 | `svelte-fromcodepoint-rangeerror.md` | sveltejs/svelte | #3617 | unrecorded |
-| `svelte-inspect-with-in-a-declarator.md` | sveltejs/svelte | #3614 | unrecorded |
+| `svelte-inspect-with-in-a-declarator.md` | sveltejs/svelte | #3614, #3627 | unrecorded |
 | `svelte-snippet-name-colliding-with-an-import.md` | sveltejs/svelte | #3567 | unrecorded |
 | `svelte2tsx-shorthand-style-directive-modifier.md` | sveltejs/language-tools (svelte2tsx) | #3567 | unrecorded |
 

--- a/upstream_issues/svelte-inspect-with-in-a-declarator.md
+++ b/upstream_issues/svelte-inspect-with-in-a-declarator.md
@@ -49,3 +49,16 @@ Related: the same file's prod output for a plain `$inspect` in a declarator, `co
 itself unparseable — that is the separate report in
 `3441-svelte-inspect-in-an-operand-slot.md`. This one is different because the output *parses*
 and means something else.
+
+## rsvelte decision
+
+rsvelte does not reproduce either runtime-wrong result. In prod, where `$inspect` evaluates to
+nothing, it keeps the declaration as `const t = undefined`; in dev it keeps the normal rune
+lowering (`$.inspect(...)` on the client and the inspector callback on the server). This also
+applies to an exported declarator.
+
+The eight cells — `{declarator, export-declarator}` × `{client, client-dev, server, server-dev}`
+— are pinned by
+`module_inspect_slot_3611.rs::an_inspect_with_declarator_keeps_its_binding_and_value` for #3627.
+Delete the deliberate-divergence entry and change those expectations to parity if upstream adds
+`'$inspect().with'` to both declarator allow-lists.


### PR DESCRIPTION
## Summary
- pin `$inspect(a).with(fn)` declarator and export-declarator semantics across client/server and dev/prod module compilation
- require the binding and later references to survive instead of reproducing official's dropped client declaration
- document why rsvelte keeps `undefined`/the inspector result instead of official's runtime-wrong server binding
- connect the existing upstream report and deliberate-divergence inventory to #3627

Closes #3627

## Validation
- `cargo fmt --all -- --check`
- `git diff --check`
- `node --check scripts/ci/check-upstream-issues.mjs`

Heavy builds and test suites are intentionally delegated to CI.
