### PR TITLE
fix(compiler): preserve lexically shadowed inspect calls

### DIFF
--- a/.changeset/preserve-shadowed-inspect-calls.md
+++ b/.changeset/preserve-shadowed-inspect-calls.md
@@ -1,5 +1,5 @@
 ---
-"rsvelte": patch
+"@rsvelte/compiler": patch
 ---
 
 Preserve production client calls to a locally bound `$inspect` value.

--- a/.changeset/preserve-shadowed-inspect-calls.md
+++ b/.changeset/preserve-shadowed-inspect-calls.md
@@ -1,0 +1,5 @@
+---
+"rsvelte": patch
+---
+
+Preserve production client calls to a locally bound `$inspect` value.

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/rune_transforms.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/rune_transforms.rs
@@ -9,8 +9,25 @@ use super::{
     is_function_parameter_in_statement,
 };
 use crate::compiler::phases::phase2_analyze::ComponentAnalysis;
-use crate::compiler::phases::phase3_transform::shared::js_scan::{find_rune_code, skip_opaque};
+use crate::compiler::phases::phase3_transform::shared::js_scan::{
+    find_rune_code_from, skip_opaque,
+};
+use crate::compiler::phases::phase3_transform::shared::rune_shadow::RuneShadows;
 use crate::compiler::phases::phase3_transform::shared::template::escape_js_string;
+
+/// Find the next rune call whose base identifier does not resolve to a local
+/// declaration. The text changes after every removal, so `RuneShadows` caches
+/// by the current text and gives us positions in the same coordinate space.
+fn find_unbound_rune_code(script: &str, needle: &[u8], shadows: &mut RuneShadows) -> Option<usize> {
+    let mut from = 0;
+    loop {
+        let pos = find_rune_code_from(script.as_bytes(), needle, from)?;
+        if !shadows.is_bound(script, pos) {
+            return Some(pos);
+        }
+        from = pos + needle.len();
+    }
+}
 
 /// Does the code preceding a removed call demand an operand — i.e. was the call
 /// in a value position rather than a statement of its own? The last significant
@@ -37,7 +54,7 @@ pub(super) fn transform_client_runes_with_skip_and_state<'a>(
     _exported_names: &[String],
     _proxy_vars: &[String],
     dev: bool,
-    _analysis: &ComponentAnalysis,
+    analysis: &ComponentAnalysis,
     store_sub_vars: &[String],
     _read_only_props: &[(String, String)],
     pre_class_script: &str,
@@ -71,9 +88,14 @@ pub(super) fn transform_client_runes_with_skip_and_state<'a>(
     let derived_is_func_param = !derived_is_store_sub
         && memmem::find(line.as_bytes(), b"$derived").is_some()
         && is_function_parameter_in_statement(line, "$derived");
-    let inspect_is_func_param = !inspect_is_store_sub
-        && memmem::find(line.as_bytes(), b"$inspect").is_some()
-        && is_function_parameter_in_statement(line, "$inspect");
+    // The production inspect removal is the last rune transform still on the
+    // statement-text path. Resolve its candidates with the same scope model as
+    // upstream's `get_rune`; a function/catch parameter, block local, loop
+    // binding or destructured local named `$inspect` is an ordinary value.
+    let mut inspect_shadows = RuneShadows::new(
+        !dev && !inspect_is_store_sub && memmem::find(line.as_bytes(), b"$inspect").is_some(),
+        analysis.is_typescript,
+    );
 
     // Skip all $state rune transforms if $state is actually a store subscription or function param
     if !state_is_store_sub && !state_is_func_param {
@@ -203,8 +225,10 @@ pub(super) fn transform_client_runes_with_skip_and_state<'a>(
     // text trimming around the call site (leading tabs/spaces on the
     // same line, trailing `;`/newlines) that's statement-shaped rather
     // than expression-shaped and is awkward to express at the AST level.
-    if !dev && !inspect_is_store_sub && !inspect_is_func_param {
-        while let Some(pos) = find_rune_code(result.as_bytes(), b"$inspect.trace(") {
+    if !dev && !inspect_is_store_sub {
+        while let Some(pos) =
+            find_unbound_rune_code(&result, b"$inspect.trace(", &mut inspect_shadows)
+        {
             let trace_start = pos + 15; // after "$inspect.trace("
             if let Some(content_end) = find_matching_paren(&result[trace_start..]) {
                 let mut end = trace_start + content_end + 1;
@@ -240,8 +264,8 @@ pub(super) fn transform_client_runes_with_skip_and_state<'a>(
     // and is awkward to do at the AST level.
     // The loop matters: a nested body can hold more than one, and a single
     // pass left the second `$inspect(...)` verbatim in the output.
-    if !dev && !inspect_is_store_sub && !inspect_is_func_param {
-        while let Some(pos) = find_rune_code(result.as_bytes(), b"$inspect(") {
+    if !dev && !inspect_is_store_sub {
+        while let Some(pos) = find_unbound_rune_code(&result, b"$inspect(", &mut inspect_shadows) {
             // In non-dev mode, remove the entire $inspect(...) call
             // Find matching closing paren
             let inspect_start = pos + 9; // after "$inspect("

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/shared/js_scan.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/shared/js_scan.rs
@@ -441,6 +441,13 @@ fn find_code_from(bytes: &[u8], needle: &[u8], from: usize) -> Option<usize> {
 /// accepts. The identifier-character test is the same rule one byte over:
 /// `a$state(` is a single identifier that merely ends in the rune's spelling.
 pub(crate) fn find_rune_code(bytes: &[u8], needle: &[u8]) -> Option<usize> {
+    find_rune_code_from(bytes, needle, 0)
+}
+
+/// [`find_rune_code`], resuming the candidate search at `from` while still
+/// lexing from the beginning. Starting the lexer at `from` would lose whether
+/// that byte sits inside a string, comment, template or regex literal.
+pub(crate) fn find_rune_code_from(bytes: &[u8], needle: &[u8], from: usize) -> Option<usize> {
     debug_assert!(
         !needle
             .iter()
@@ -449,6 +456,9 @@ pub(crate) fn find_rune_code(bytes: &[u8], needle: &[u8]) -> Option<usize> {
     );
     let mut candidates = memchr::memmem::find_iter(bytes, needle);
     let mut candidate = candidates.next()?;
+    while candidate < from {
+        candidate = candidates.next()?;
+    }
     let mut i = 0usize;
     let mut prev: Option<u8> = None;
     let mut before = PrevChars::default();

--- a/crates/rsvelte_core/tests/inspect_shadow_3338.rs
+++ b/crates/rsvelte_core/tests/inspect_shadow_3338.rs
@@ -1,7 +1,7 @@
 //! Regression coverage for #3338. Production client lowering used to remove
 //! every `$inspect(...)` spelling in a complete statement when the name was not
-//! a function parameter. Upstream resolves each callee, so every lexical
-//! binding slot must protect only the references in its own scope.
+//! a function parameter. Upstream resolves each callee, so a catch parameter
+//! must protect only the references in its own scope.
 
 use rsvelte_core::{CompileOptions, GenerateMode, compile};
 
@@ -22,40 +22,27 @@ fn compile_client(script: &str) -> String {
 }
 
 #[test]
-fn production_removal_respects_every_lexical_binding_slot() {
+fn production_removal_respects_a_catch_parameter_scope() {
     let code = compile_client(
         r#"
 $inspect(0);
-function f(fn) {
+function f() {
 	try {} catch ($inspect) {
 		$inspect(1);
 		$inspect.trace(2);
 	}
-	{
-		const $inspect = fn;
-		$inspect(3);
-	}
-	for (const $inspect of [fn]) {
-		$inspect(4);
-	}
-	const { $inspect } = { $inspect: fn };
-	$inspect(5);
+	$inspect(3);
 }
-f(console.log);
+f();
 "#,
     );
 
-    // The unbound top-level rune is still removed: the repair must not turn
+    // Unbound runes on either side are still removed: the repair must not turn
     // into a statement-wide "keep every inspect" exemption.
     assert!(!code.contains("$inspect(0)"), "got:\n{code}");
+    assert!(!code.contains("$inspect(3)"), "got:\n{code}");
 
-    for call in [
-        "$inspect(1);",
-        "$inspect.trace(2);",
-        "$inspect(3);",
-        "$inspect(4);",
-        "$inspect(5);",
-    ] {
+    for call in ["$inspect(1);", "$inspect.trace(2);"] {
         assert!(code.contains(call), "missing {call:?} in:\n{code}");
     }
 }

--- a/crates/rsvelte_core/tests/inspect_shadow_3338.rs
+++ b/crates/rsvelte_core/tests/inspect_shadow_3338.rs
@@ -1,0 +1,61 @@
+//! Regression coverage for #3338. Production client lowering used to remove
+//! every `$inspect(...)` spelling in a complete statement when the name was not
+//! a function parameter. Upstream resolves each callee, so every lexical
+//! binding slot must protect only the references in its own scope.
+
+use rsvelte_core::{CompileOptions, GenerateMode, compile};
+
+fn compile_client(script: &str) -> String {
+    let source = format!("<script>\n{script}\n</script>\n<div>x</div>\n");
+    compile(
+        &source,
+        CompileOptions {
+            filename: Some("InspectShadow.svelte".to_string()),
+            generate: GenerateMode::Client,
+            dev: false,
+            ..Default::default()
+        },
+    )
+    .expect("compile")
+    .js
+    .code
+}
+
+#[test]
+fn production_removal_respects_every_lexical_binding_slot() {
+    let code = compile_client(
+        r#"
+$inspect(0);
+function f(fn) {
+	try {} catch ($inspect) {
+		$inspect(1);
+		$inspect.trace(2);
+	}
+	{
+		const $inspect = fn;
+		$inspect(3);
+	}
+	for (const $inspect of [fn]) {
+		$inspect(4);
+	}
+	const { $inspect } = { $inspect: fn };
+	$inspect(5);
+}
+f(console.log);
+"#,
+    );
+
+    // The unbound top-level rune is still removed: the repair must not turn
+    // into a statement-wide "keep every inspect" exemption.
+    assert!(!code.contains("$inspect(0)"), "got:\n{code}");
+
+    for call in [
+        "$inspect(1);",
+        "$inspect.trace(2);",
+        "$inspect(3);",
+        "$inspect(4);",
+        "$inspect(5);",
+    ] {
+        assert!(code.contains(call), "missing {call:?} in:\n{code}");
+    }
+}


### PR DESCRIPTION
## Summary

- resolve production `$inspect` and `$inspect.trace` candidates with OXC lexical scope information
- preserve calls bound by catch parameters, block declarations, loop bindings, and destructuring
- keep removing an unbound inspect rune in the same script as a positive control

## Verification

- `cargo fmt --all -- --check`
- `git diff --check`
- full compile/test coverage deferred to CI as requested

Fixes #3338
