### PR TITLE
fix(server): preserve empty folded SSR chunks

### DIFF
--- a/.changeset/empty-folded-ssr-chunk.md
+++ b/.changeset/empty-folded-ssr-chunk.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/compiler": patch
+---
+
+Preserve empty SSR renderer chunks produced by constant-folded template expressions.

--- a/compatibility/pattern-corpus/README.md
+++ b/compatibility/pattern-corpus/README.md
@@ -46,6 +46,7 @@ Ids are `pattern/issues/<file>`, `pattern/matrix/<axis>/<file>` and
 
 | File | Issue | What it pins |
 |---|---|---|
+| `3457-empty-folded-ssr-chunk.svelte` | [#3457](https://github.com/baseballyama/rsvelte/issues/3457) | An SSR expression chunk that constant-folds to the empty string must remain a template and emit `$$renderer.push(\`\`)` after its adjacent `{@const}` is hoisted. Literal, concatenated and global-call initializers cover the production/dev folding paths; the client targets are controls. |
 | `008-comment-props-destructure.svelte` | [debt 008](../../debt_list/008-mutation-gate-has-behavioral-code-mismatches.md) | A block comment between `=` and `$props()` in a read-only destructure. The AST-confirmed rune call must be lowered despite the trivia, not survive as a runtime reference to `$props`. |
 | `008-comment-shadowed-state.svelte` | [debt 008](../../debt_list/008-mutation-gate-has-behavioral-code-mismatches.md) | A comment containing `}` between a shadowed local `$state` declaration and its reads. The local binding must still win over the outer function of the same name, so reads and updates remain `$.get(multiplier)` / `$.update(multiplier)` rather than becoming plain values. |
 | `1973-derived-ternary-default.svelte` | [#1973](https://github.com/baseballyama/rsvelte/issues/1973) | Destructured `$derived` with a **ternary** default — the property splitter must not mistake the ternary's `:` for the key separator |

--- a/compatibility/pattern-corpus/issues/3457-empty-folded-ssr-chunk.svelte
+++ b/compatibility/pattern-corpus/issues/3457-empty-folded-ssr-chunk.svelte
@@ -1,0 +1,14 @@
+{#if true}
+	{@const literal = ""}
+	{literal}
+{/if}
+
+{#if true}
+	{@const concatenated = "" + ""}
+	{concatenated}
+{/if}
+
+{#if true}
+	{@const called = String()}
+	{called}
+{/if}

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/tests.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/tests.rs
@@ -265,6 +265,25 @@ fn norm(s: &str) -> String {
         .join("\n")
 }
 
+/// A constant-folded expression is still a rendered template chunk, even when
+/// its value is the empty string. In particular, hoisting the adjacent
+/// `{@const}` must not classify that chunk as removable source whitespace.
+#[test]
+fn folded_empty_expression_keeps_renderer_push() {
+    for source in [
+        "{#if true}{@const c = \"\"}{c}{/if}",
+        "{#if true}{@const c = \"\" + \"\"}{c}{/if}",
+        "{#if true}{@const c = String()}{c}{/if}",
+    ] {
+        let output = run(source);
+        assert_eq!(norm(&output), norm(&oracle_dump(source)), "{source}");
+        assert!(
+            output.contains("$$renderer.push(``);"),
+            "missing empty renderer push for {source}:\n{output}"
+        );
+    }
+}
+
 /// Destructured `$derived` / `$derived.by` SSR expansion (写经
 /// `VariableDeclaration.js:97-156` + `_extract_paths`). Each runtime-runes
 /// fixture below destructures a derived; the AST pipeline must expand it into

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/visitors/shared.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/visitors/shared.rs
@@ -9,7 +9,10 @@
 //!   pure text). Upstream's `b.literal('<p')` / `b.literal('>')`.
 //! - [`TemplateEntry::Template`] — a `b.template(quasis, expressions)` produced by
 //!   [`process_children`] when a run of text / comment / expression-tag siblings
-//!   is flushed; dynamic `{expr}` interpolations become `${$.escape(expr)}`.
+//!   is flushed; dynamic `{expr}` interpolations become `${$.escape(expr)}`. A
+//!   known expression can fold into a quasi and leave `expressions` empty; it
+//!   must remain a `Template` so an empty rendered chunk is not mistaken for
+//!   removable source whitespace.
 //! - [`TemplateEntry::Stmt`] — an opaque statement (e.g. an `if` for `<textarea>`
 //!   value handling, or an async `$$renderer.push(...)`); these break the
 //!   coalescing run. Not produced by the simple visitors ported so far.
@@ -45,7 +48,8 @@ pub enum TemplateEntry<'a> {
     Literal(String),
     /// A `b.template(quasis, expressions)`: `quasis.len() == expressions.len() + 1`.
     /// `quasis` are cooked strings; `exprs` are already-built oxc expressions
-    /// (typically `$.escape(expr)`).
+    /// (typically `$.escape(expr)`). `exprs` may be empty when every expression
+    /// in the source sequence constant-folded into its surrounding quasi.
     Template {
         quasis: Vec<String>,
         exprs: Vec<OxcExpression<'a>>,
@@ -693,10 +697,11 @@ fn is_plain_identifier(src: &str) -> bool {
     chars.all(|c| c.is_alphanumeric() || c == '_' || c == '$')
 }
 
-/// Convert the accumulated `sequence` into one [`TemplateEntry::Template`]
-/// (skipped when empty). Mirrors the inner `flush()` of upstream
-/// `process_children`: cooked text accumulates into the current quasi, and each
-/// dynamic expression splits a new quasi and pushes `$.escape(expr)`.
+/// Convert the accumulated `sequence` into one template entry (skipped when
+/// empty). Mirrors the inner `flush()` of upstream `process_children`: cooked
+/// text accumulates into the current quasi, and each dynamic expression splits
+/// a new quasi and pushes `$.escape(expr)`. A sequence containing an expression
+/// remains a [`TemplateEntry::Template`] even when every expression folds away.
 fn flush_sequence<'a>(sequence: &[SeqNode<'_>], state: &mut ServerTransformState<'a>) {
     if sequence.is_empty() {
         return;
@@ -704,6 +709,9 @@ fn flush_sequence<'a>(sequence: &[SeqNode<'_>], state: &mut ServerTransformState
 
     let mut quasis: Vec<String> = vec![String::new()];
     let mut exprs: Vec<OxcExpression<'a>> = Vec::new();
+    let had_expression_tag = sequence
+        .iter()
+        .any(|node| matches!(node, SeqNode::Expr(..)));
 
     for node in sequence {
         match node {
@@ -819,10 +827,11 @@ fn flush_sequence<'a>(sequence: &[SeqNode<'_>], state: &mut ServerTransformState
         }
     }
 
-    if exprs.is_empty() {
-        // Pure-text/comment run: a plain literal (matches upstream where the
-        // template degenerates to a single-quasi literal that build_template
-        // then folds into the surrounding string).
+    if !had_expression_tag {
+        // Pure-text/comment run: a plain literal. Do not use `exprs.is_empty()`
+        // here: upstream still builds a template when every source expression
+        // folds to an empty quasi, and that template must produce an empty
+        // renderer push after an adjacent declaration is hoisted (#3457).
         state
             .template
             .push(TemplateEntry::Literal(quasis.pop().unwrap()));


### PR DESCRIPTION
Fixes #3457.

A source sequence containing an expression tag now remains a TemplateEntry::Template even when every expression constant-folds away. This preserves the empty renderer push after adjacent declarations are hoisted instead of misclassifying the chunk as removable source whitespace.

The regression coverage includes literal, concatenated, and global-call empty values in the server AST test and the four-target pattern corpus.

Static checks run:
- cargo fmt --all -- --check
- git diff --check

Per project guidance, no local build or test suite was run; CI is the execution oracle.