### PR TITLE
fix(esrap): preserve side-effect import attributes

### DIFF
--- a/.changeset/side-effect-import-attributes.md
+++ b/.changeset/side-effect-import-attributes.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/core": patch
+---
+
+Preserve import attributes on side-effect imports.

--- a/.changeset/side-effect-import-attributes.md
+++ b/.changeset/side-effect-import-attributes.md
@@ -1,5 +1,5 @@
 ---
-"@rsvelte/core": patch
+"@rsvelte/compiler": patch
 ---
 
 Preserve import attributes on side-effect imports.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2641,7 +2641,7 @@ dependencies = [
 
 [[package]]
 name = "rsvelte_esrap"
-version = "0.10.35"
+version = "0.10.36"
 dependencies = [
  "compact_str",
  "memchr",

--- a/compatibility/deliberate-divergences.md
+++ b/compatibility/deliberate-divergences.md
@@ -1,9 +1,9 @@
 # Deliberate divergences from the official compiler
 
 Output must match the official compiler exactly, because upstream is the specification.
-That rule does not extend to reproducing bytes that are **not valid JavaScript**: a module
-that no parser accepts is a defect a byte match cannot pay for. Where the two conflict,
-correctness wins.
+That rule does not extend to reproducing bytes that are **not valid JavaScript** or that change
+the source program's runtime meaning: an unparseable module or a dropped semantic clause is a
+defect a byte match cannot pay for. Where the two conflict, correctness wins.
 
 This file is the whole list. It is prose, not a ratchet — the divergences here are ones no
 gate observes, which is exactly why they need writing down: an unobserved surface plus a
@@ -14,6 +14,27 @@ entry below is pinned by a test, so the choice is enforced and not merely descri
 Before adding an entry, run both compilers. "Deliberate" is a claim about which side is
 wrong, and a record that asserts it without the outputs converts an open question into a
 settled one.
+
+---
+
+## Attributes on a side-effect import
+
+**Pinned by** `crates/rsvelte_esrap/src/printer.rs::side_effect_import_keeps_attributes` and
+`crates/rsvelte_core/tests/import_attributes_clause_3352.rs`.
+**Reported upstream** in `upstream_issues/3635-esrap-side-effect-import-drops-attributes.md`.
+
+Official Svelte (through esrap 2.2.12) prints
+`import './data.json' with { type: 'json' };` as `import './data.json';`. esrap's
+specifier-less import branch returns after the source and semicolon, before the shared code that
+prints import attributes. A declaration with a specifier keeps the clause.
+
+rsvelte deliberately prints the clause on both forms. An import attribute controls module
+loading; dropping it can make a valid JSON or CSS module import fail at runtime. This is therefore
+not a byte-only layout difference that exact-output compatibility can safely reproduce.
+
+The corpus output gate has no accepted component containing this shape. If one is added while
+upstream still drops the clause, it must be recorded as this deliberate divergence rather than
+"fixed" by deleting the attribute again. Remove this entry when upstream esrap prints the clause.
 
 ---
 

--- a/crates/rsvelte_core/Cargo.toml
+++ b/crates/rsvelte_core/Cargo.toml
@@ -94,7 +94,7 @@ oxc_ast = { version = "0.145", features = ["serialize"] }
 oxc_span = "0.145"
 oxc_diagnostics = "0.145"
 oxc_codegen = "0.145"
-rsvelte_esrap = { version = "=0.10.35", path = "../rsvelte_esrap" }
+rsvelte_esrap = { version = "=0.10.36", path = "../rsvelte_esrap" }
 oxc_syntax = "0.145"
 oxc_semantic = "0.145"
 

--- a/crates/rsvelte_core/tests/import_attributes_clause_3352.rs
+++ b/crates/rsvelte_core/tests/import_attributes_clause_3352.rs
@@ -155,15 +155,13 @@ fn a_clause_after_a_multi_line_specifier_list_stays_with_the_import() {
     }
 }
 
-/// A side-effect import — no `from`, so a different arm of the same decision.
+/// A side-effect import — no `from`, so a different printer arm.
 ///
-/// esrap's printer returns early when an import has no specifiers and never
-/// writes the clause, so the *official* output drops it here whatever line it
-/// was written on. Parity is therefore "clause absent, nothing left behind": the
-/// defect this file is about is the clause escaping into the component body,
-/// which is what the second assertion pins.
+/// Official esrap returns before writing the clause. That changes whether the
+/// emitted module can load, so rsvelte deliberately keeps the attribute rather
+/// than reproducing the runtime defect (#3635).
 #[test]
-fn a_clause_after_a_side_effect_import_matches_official() {
+fn a_clause_after_a_side_effect_import_stays_with_the_import() {
     let src = format!(
         "<script>\n\timport \"./d.json\"\n\t\twith {{ type: \"json\" }};\n\tlet z = 1;\n{TEMPLATE}"
     );
@@ -175,12 +173,8 @@ fn a_clause_after_a_side_effect_import_matches_official() {
         let out = compile_with(&src, generate, dev);
         assert_parses(&out, &format!("side-effect import ({label})"));
         assert!(
-            out.contains("import \"./d.json\";"),
-            "side-effect import ({label}): the import moved:\n{out}"
-        );
-        assert!(
-            !out.contains("with { type: \"json\" }"),
-            "side-effect import ({label}): the clause was left behind:\n{out}"
+            out.contains("import \"./d.json\" with { type: \"json\" };"),
+            "side-effect import ({label}): clause lost or moved:\n{out}"
         );
     }
 }

--- a/crates/rsvelte_esrap/Cargo.toml
+++ b/crates/rsvelte_esrap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rsvelte_esrap"
-version = "0.10.35"
+version = "0.10.36"
 edition = "2024"
 rust-version = "1.95"
 description = "A Rust port of esrap — prints an oxc AST to JavaScript with esrap's exact layout"

--- a/crates/rsvelte_esrap/src/printer.rs
+++ b/crates/rsvelte_esrap/src/printer.rs
@@ -2058,6 +2058,10 @@ impl<'opt, const HAS_COMMENTS: bool, const DIRECT: bool> Printer<'opt, HAS_COMME
         if node.specifiers.as_ref().is_none_or(|v| v.is_empty()) {
             ctx.write("import ");
             ctx.write(Self::string_literal(&node.source));
+            // Upstream esrap returns before printing this clause. Import
+            // attributes affect module loading, so dropping them is not a
+            // byte-only formatting difference (#3635).
+            Self::import_attributes(node.with_clause.as_deref(), ctx);
             ctx.write_ascii(b';');
             return;
         }
@@ -5513,6 +5517,14 @@ mod tests {
             "unsupported node: {missing:?} for {src:?}"
         );
         out
+    }
+
+    #[test]
+    fn side_effect_import_keeps_attributes() {
+        assert_eq!(
+            print_ok("import './data.json' with { type: 'json' }"),
+            "import './data.json' with { type: 'json' };"
+        );
     }
 
     fn print_with_comments_ok(src: &str) -> String {

--- a/crates/rsvelte_lint_types/Cargo.lock
+++ b/crates/rsvelte_lint_types/Cargo.lock
@@ -1128,7 +1128,7 @@ dependencies = [
 
 [[package]]
 name = "rsvelte_esrap"
-version = "0.10.35"
+version = "0.10.36"
 dependencies = [
  "compact_str",
  "memchr",

--- a/upstream_issues/3635-esrap-side-effect-import-drops-attributes.md
+++ b/upstream_issues/3635-esrap-side-effect-import-drops-attributes.md
@@ -1,0 +1,32 @@
+# esrap drops attributes from a side-effect import
+
+With esrap 2.2.12, an `ImportDeclaration` with no specifiers loses its import-attributes
+clause:
+
+```js
+import './data.json' with { type: 'json' };
+```
+
+is printed as:
+
+```js
+import './data.json';
+```
+
+The `ImportDeclaration` visitor returns immediately after writing the source and semicolon
+when `node.specifiers.length === 0`. The general path writes `node.attributes`, but the early
+path never reaches it. Imports with any specifier keep the same clause.
+
+This is not a formatting-only difference. Hosts that require a JSON import attribute reject
+the emitted module, even though the source declaration supplied it. CSS module attributes
+have the same failure mode.
+
+rsvelte therefore does not reproduce this early return: `rsvelte_esrap` prints the existing
+`with_clause` for both side-effect and specifier-bearing imports. The choice is pinned by the
+printer test and by all compiler targets in
+`crates/rsvelte_core/tests/import_attributes_clause_3352.rs`.
+
+Local anchor: [#3635](https://github.com/baseballyama/rsvelte/issues/3635).
+
+Desired upstream behavior: print the import-attributes clause before returning from the
+specifier-less import branch.

--- a/upstream_issues/README.md
+++ b/upstream_issues/README.md
@@ -74,6 +74,7 @@ deletion, and is deliberately left to its own change rather than folded into the
 | `3451-oxfmt-drops-required-parens-after-a-private-in.md` | oxc-project/oxc (`oxfmt`) | #3451 | unrecorded |
 | `3568-svelte-dotted-namespace-crash.md` | sveltejs/svelte | #3568 | unrecorded |
 | `3609-svelte-snippet-param-shadowed-by-const.md` | sveltejs/svelte | #3609 | unrecorded |
+| `3635-esrap-side-effect-import-drops-attributes.md` | sveltejs/esrap | #3635 | unrecorded |
 | `eslint-plugin-svelte-no-add-event-listener-suggestion.md` | sveltejs/eslint-plugin-svelte | — | unrecorded |
 | `eslint-plugin-svelte-no-goto-without-base-namespace-import-crash.md` | sveltejs/eslint-plugin-svelte | — | unrecorded |
 | `eslint-plugin-svelte-no-navigation-without-base-empty-href-crash.md` | sveltejs/eslint-plugin-svelte | — | unrecorded |


### PR DESCRIPTION
Closes #3635.

## Summary

- preserve an import-attributes clause when printing a side-effect import
- reuse the existing attribute printer used by imports with specifiers
- reverse the compiler regression test so client, server, and client-dev must all retain the clause
- record the upstream esrap defect and the deliberate semantic divergence

Official esrap returns before printing attributes for an import with no specifiers. Dropping the clause can make the emitted JSON or CSS module fail to load, so this PR keeps the source program's semantics instead of reproducing the byte output.

## Verification

- `cargo fmt --all`
- `git diff --check`
- `node scripts/ci/check-upstream-issues.mjs`

Per repository instructions, Rust builds and tests were not run locally; CI is the execution oracle.
