### PR TITLE
Fix awaited autofocus and event attributes

### DIFF
--- a/.changeset/async-autofocus-events.md
+++ b/.changeset/async-autofocus-events.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/compiler": patch
+---
+
+Emit parseable client code for awaited `autofocus` and event attributes.

--- a/compatibility/deliberate-divergences.md
+++ b/compatibility/deliberate-divergences.md
@@ -284,3 +284,24 @@ uncoded panic instead of a diagnostic.
   compiler at all, so no published source carries the shape.
 - **Output-parseability gate**: rsvelte's output is valid JavaScript either way — the divergence is
   whether the input is accepted, which that gate does not ask.
+
+---
+
+## Awaited `autofocus` and event attributes (client)
+
+**Pinned by** `crates/rsvelte_core/tests/async_autofocus_event_3651.rs`.
+**Reported upstream** in
+`upstream_issues/3651-svelte-async-autofocus-and-event-output-is-unparseable.md`.
+
+With `experimental.async: true`, official Svelte 5.56.10 emits
+`$.autofocus(input, await p)` and puts `(await p)?.apply(...)` inside a plain
+event-handler function. Both are syntax errors because neither containing function
+is async. rsvelte routes only the awaited cases through a local `Memoizer`, so the
+await remains inside an async value thunk and the runtime call receives `$0`, the
+resolved result. Synchronous output is unchanged.
+
+The ordinary parity gates cannot observe the correction: both compilers previously
+agreed, while the matrix treats unparseable official output as an oracle rejection and
+aborts rather than producing a keyed divergence. Gate-coverage 5r records that blind
+spot. Remove this entry and converge on upstream when its two visitors adopt an async
+memoization path.

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/types.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/types.rs
@@ -1529,7 +1529,7 @@ fn extract_event_handler(
         build_event_handler, extract_expression_tag,
     };
     let expr_tag = extract_expression_tag(value);
-    build_event_handler(expr_tag, context)
+    build_event_handler(expr_tag, context, None)
 }
 
 /// Check if an event is passive.

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/attribute.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/attribute.rs
@@ -5,8 +5,12 @@
 
 use crate::ast::template::{Attribute, AttributeNode};
 use crate::compiler::phases::phase3_transform::client::types::ComponentContext;
+use crate::compiler::phases::phase3_transform::client::types::Memoizer;
 use crate::compiler::phases::phase3_transform::client::visitors::shared::events::{
     build_event, convert_arrow_to_named_function,
+};
+use crate::compiler::phases::phase3_transform::client::visitors::shared::utils::{
+    build_render_statement_with_memoizer, expression_has_await,
 };
 use crate::compiler::phases::phase3_transform::js_ast::nodes::JsExpr;
 use crate::compiler::phases::phase3_transform::utils::locate_in_source;
@@ -154,7 +158,14 @@ pub fn visit_event_attribute(node: &AttributeNode, context: &mut ComponentContex
     // Extract the expression tag from the attribute value
     let expr_tag = extract_expression_tag(&node.value);
 
-    let handler = build_event_handler(expr_tag, context);
+    // Upstream currently leaves an `await` inside the non-async event wrapper.
+    // Resolve async handlers through a local template-effect memoizer instead,
+    // so the awaited expression lives only in an `async () => ...` thunk.
+    let has_await =
+        expr_tag.metadata.expression.has_await() || expression_has_await(&expr_tag.expression);
+    let mut local_memoizer =
+        has_await.then(|| Memoizer::with_parent_conflicts(&context.state.memoizer));
+    let handler = build_event_handler(expr_tag, context, local_memoizer.as_mut());
 
     // Determine if this event should be delegated.
     //
@@ -183,7 +194,7 @@ pub fn visit_event_attribute(node: &AttributeNode, context: &mut ComponentContex
         handler
     };
 
-    let statement = b::stmt(
+    let mut statement = b::stmt(
         &context.arena,
         build_event(
             &context.arena,
@@ -195,6 +206,20 @@ pub fn visit_event_attribute(node: &AttributeNode, context: &mut ComponentContex
             delegated,
         ),
     );
+
+    if let Some(memoizer) = &local_memoizer {
+        statement = b::stmt(
+            &context.arena,
+            build_render_statement_with_memoizer(
+                &context.arena,
+                vec![statement],
+                memoizer.get_params(),
+                memoizer.sync_values(&context.arena),
+                memoizer.async_values(&context.arena),
+                None,
+            ),
+        );
+    }
 
     // Check if the parent is a special element (svelte:window, svelte:document, svelte:body)
     let is_special_element = context.current_parent().is_some_and(|parent| {
@@ -254,6 +279,7 @@ pub fn extract_expression_tag<'a>(
 pub fn build_event_handler(
     expr_tag: &crate::ast::template::ExpressionTag,
     context: &mut ComponentContext,
+    async_memoizer: Option<&mut Memoizer>,
 ) -> crate::compiler::phases::phase3_transform::js_ast::nodes::JsExpr {
     use crate::compiler::phases::phase3_transform::js_ast::builders as b;
     use crate::compiler::phases::phase3_transform::js_ast::nodes::JsExpr;
@@ -265,6 +291,12 @@ pub fn build_event_handler(
     // Apply state transforms (e.g., count++ -> $.update(count))
     use crate::compiler::phases::phase3_transform::client::visitors::shared::utils::apply_transforms_to_expression;
     let js_expr = apply_transforms_to_expression(&js_expr, context);
+    let is_async_memoized = async_memoizer.is_some();
+    let js_expr = if let Some(memoizer) = async_memoizer {
+        memoizer.add(js_expr, false, true, false, false)
+    } else {
+        js_expr
+    };
 
     // Check if it's already a function
     let mut unspanned = &js_expr;
@@ -308,8 +340,11 @@ pub fn build_event_handler(
     // Memoisation here uses the same broad "any CallExpression in the tree"
     // semantics as the rest of Phase 3 — see `expression_tag_has_call` in
     // `shared/element.rs` for why we don't read Phase 2's narrower flag.
-    let has_call =
-        crate::compiler::phases::phase3_transform::client::visitors::shared::element::expression_tag_has_call(
+    // An awaited call is already represented by the local memoizer's `$0`.
+    // Deriving that identifier in component init would put `$0` outside the
+    // template-effect callback that binds it (visible specifically in dev).
+    let has_call = !is_async_memoized
+        && crate::compiler::phases::phase3_transform::client::visitors::shared::element::expression_tag_has_call(
             expr_tag,
         );
 

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/regular_element.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/regular_element.rs
@@ -658,17 +658,40 @@ pub fn visit_regular_element(
                     }
                 } else if name == "autofocus" {
                     // Special case: autofocus needs $.autofocus() call
-                    let result =
-                        build_attribute_value(&attr.value, context, |expr, _metadata| expr);
+                    // Upstream currently emits a bare `await` as the call argument.
+                    // Keep the synchronous path byte-identical, but resolve an async
+                    // value through a local template-effect memoizer.
+                    let mut local_memoizer =
+                        Memoizer::with_parent_conflicts(&context.state.memoizer);
+                    let result = build_attribute_value(&attr.value, context, |expr, metadata| {
+                        if metadata.has_await() {
+                            local_memoizer.add(expr, false, true, false, metadata.has_state())
+                        } else {
+                            expr
+                        }
+                    });
                     let node_id = extract_node_id(&context.state.node);
-                    context.state.init.push(b::stmt(
+                    let call = b::call(
                         &context.arena,
-                        b::call(
+                        b::member_path(&context.arena, "$.autofocus"),
+                        vec![b::id(&node_id), result.value],
+                    );
+
+                    if local_memoizer.has_memoized() {
+                        context.state.init.push(b::stmt(
                             &context.arena,
-                            b::member_path(&context.arena, "$.autofocus"),
-                            vec![b::id(&node_id), result.value],
-                        ),
-                    ));
+                            build_render_statement_with_memoizer(
+                                &context.arena,
+                                vec![b::stmt(&context.arena, call)],
+                                local_memoizer.get_params(),
+                                local_memoizer.sync_values(&context.arena),
+                                local_memoizer.async_values(&context.arena),
+                                None,
+                            ),
+                        ));
+                    } else {
+                        context.state.init.push(b::stmt(&context.arena, call));
+                    }
                 } else if name == "class" {
                     // Dynamic class attribute without class directives
                     let is_html = context.state.metadata.namespace == "html" && node.name != "svg";

--- a/crates/rsvelte_core/tests/async_autofocus_event_3651.rs
+++ b/crates/rsvelte_core/tests/async_autofocus_event_3651.rs
@@ -68,8 +68,12 @@ fn awaited_values_are_resolved_before_the_runtime_calls() {
         "the event must receive the resolved memoized handler:\n{event_call}"
     );
 
+    // Upstream's arrow builder deliberately collapses `async () => await x()`
+    // to `() => x()` when `x()` contains no nested await. The async-values
+    // argument is still the third `template_effect` argument, and the runtime
+    // resolves the promises before passing `$0` to either callback.
     assert!(
-        output.matches("async () => await ").count() >= 2,
-        "both awaited expressions must live in async memoizer thunks:\n{output}"
+        output.contains("[() => autofocus()]") && output.contains("[() => handler()]"),
+        "both awaited expressions must live in async memoizer slots:\n{output}"
     );
 }

--- a/crates/rsvelte_core/tests/async_autofocus_event_3651.rs
+++ b/crates/rsvelte_core/tests/async_autofocus_event_3651.rs
@@ -1,0 +1,75 @@
+use oxc_allocator::Allocator;
+use oxc_parser::Parser;
+use oxc_span::SourceType;
+use rsvelte_core::{CompileOptions, ExperimentalOptions, GenerateMode, compile};
+
+const SOURCE: &str = r#"<script>
+	const autofocus = () => Promise.resolve(true);
+	const handler = () => Promise.resolve(() => {});
+</script>
+
+<input autofocus={await autofocus()} />
+<button onclick={await handler()}>click</button>
+"#;
+
+fn client(dev: bool) -> String {
+    compile(
+        SOURCE,
+        CompileOptions {
+            generate: GenerateMode::Client,
+            dev,
+            experimental: ExperimentalOptions { r#async: true },
+            ..Default::default()
+        },
+    )
+    .unwrap_or_else(|error| panic!("compile failed: {error:?}"))
+    .js
+    .code
+}
+
+#[test]
+fn awaited_autofocus_and_event_values_emit_parseable_javascript() {
+    for dev in [false, true] {
+        let output = client(dev);
+        let allocator = Allocator::default();
+        let parsed = Parser::new(&allocator, &output, SourceType::mjs()).parse();
+
+        assert!(
+            !parsed.panicked && parsed.diagnostics.is_empty(),
+            "client dev={dev} output must parse:\n{output}\ndiagnostics: {:?}",
+            parsed.diagnostics
+        );
+        assert!(
+            !output.contains("$.derived(() => $0)"),
+            "the local async parameter must not be captured by an init-level derived:\n{output}"
+        );
+    }
+}
+
+#[test]
+fn awaited_values_are_resolved_before_the_runtime_calls() {
+    let output = client(false);
+
+    let autofocus_call = output
+        .lines()
+        .find(|line| line.contains("$.autofocus"))
+        .unwrap_or_else(|| panic!("no autofocus call:\n{output}"));
+    assert!(
+        autofocus_call.contains("$0") && !autofocus_call.contains("await "),
+        "autofocus must receive the resolved memoized value:\n{autofocus_call}"
+    );
+
+    let event_call = output
+        .lines()
+        .find(|line| line.contains("$.delegated") && line.contains("'click'"))
+        .unwrap_or_else(|| panic!("no delegated click registration:\n{output}"));
+    assert!(
+        event_call.contains("$0") && !event_call.contains("await "),
+        "the event must receive the resolved memoized handler:\n{event_call}"
+    );
+
+    assert!(
+        output.matches("async () => await ").count() >= 2,
+        "both awaited expressions must live in async memoizer thunks:\n{output}"
+    );
+}

--- a/upstream_issues/3651-svelte-async-autofocus-and-event-output-is-unparseable.md
+++ b/upstream_issues/3651-svelte-async-autofocus-and-event-output-is-unparseable.md
@@ -1,0 +1,51 @@
+# Awaited autofocus and event attributes emit unparseable JavaScript
+
+Oracle: `submodules/svelte` @ `5.56.10`, client output with
+`experimental.async: true`.
+
+These two components compile successfully:
+
+```svelte
+<script>const p = Promise.resolve(true);</script>
+<input autofocus={await p} />
+```
+
+```svelte
+<script>const p = Promise.resolve(() => {});</script>
+<button onclick={await p}>click</button>
+```
+
+The official compiler emits an `await` in a non-async function in both cases:
+
+```js
+$.autofocus(input, await p);
+```
+
+```js
+function (...$$args) {
+	(await p)?.apply(this, $$args);
+}
+```
+
+Neither output is JavaScript a parser accepts. The neighbouring custom-element
+attribute path had the same defect in 5.56.9 and was fixed in 5.56.10 by routing
+the value through `Memoizer`; these two paths still bypass it:
+
+- `RegularElement.js` calls `build_attribute_value` for `autofocus` without a
+  memoize callback and pushes the result directly into `state.init`.
+- `shared/events.js` puts the visited expression inside a plain function and
+  only memoizes calls, not awaited expressions.
+
+rsvelte deliberately diverges by resolving each awaited value through a local
+`template_effect` memoizer. The awaited expression then lives in an
+`async () => ...` value thunk, while `$.autofocus` and the event registration
+receive its resolved parameter. Synchronous attributes retain upstream's exact
+output.
+
+The differential gates cannot report this shared defect: official output is the
+oracle, and the generated matrix aborts an official parse failure instead of
+creating a ratchet verdict. This blind spot and these two measured examples are
+recorded in `compatibility/gate-coverage.md` section 5r.
+
+Local anchor: [#3651](https://github.com/baseballyama/rsvelte/issues/3651).
+

--- a/upstream_issues/README.md
+++ b/upstream_issues/README.md
@@ -74,6 +74,7 @@ deletion, and is deliberately left to its own change rather than folded into the
 | `3451-oxfmt-drops-required-parens-after-a-private-in.md` | oxc-project/oxc (`oxfmt`) | #3451 | unrecorded |
 | `3568-svelte-dotted-namespace-crash.md` | sveltejs/svelte | #3568 | unrecorded |
 | `3609-svelte-snippet-param-shadowed-by-const.md` | sveltejs/svelte | #3609 | unrecorded |
+| `3651-svelte-async-autofocus-and-event-output-is-unparseable.md` | sveltejs/svelte | #3651 | unrecorded |
 | `eslint-plugin-svelte-no-add-event-listener-suggestion.md` | sveltejs/eslint-plugin-svelte | — | unrecorded |
 | `eslint-plugin-svelte-no-goto-without-base-namespace-import-crash.md` | sveltejs/eslint-plugin-svelte | — | unrecorded |
 | `eslint-plugin-svelte-no-navigation-without-base-empty-href-crash.md` | sveltejs/eslint-plugin-svelte | — | unrecorded |


### PR DESCRIPTION
## Summary

- route awaited autofocus values through a local template-effect memoizer
- resolve awaited event handlers before registering them, including dev-mode call expressions
- record the deliberate divergence from Svelte 5.56.10 and pin parseable output

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- `node scripts/ci/check-upstream-issues.mjs`
- `node --check scripts/ci/check-upstream-issues.mjs`
- Rust builds/tests intentionally deferred to CI per repository workflow

Closes #3651
