### PR TITLE
Fix TypeScript newline import assertions

### DIFF
--- a/.changeset/tidy-pandas-assert.md
+++ b/.changeset/tidy-pandas-assert.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/compiler": patch
+---
+
+Accept a deprecated TypeScript import-assertions clause when `assert` begins on the line after the module specifier, matching the official Svelte compiler while retaining the clause in generated output.

--- a/crates/rsvelte_core/src/ast/oxc_program.rs
+++ b/crates/rsvelte_core/src/ast/oxc_program.rs
@@ -11,12 +11,18 @@ use self_cell::self_cell;
 struct ProgramOwner<'source> {
     allocator: Allocator,
     source: Cow<'source, str>,
+    /// Same-length parser-only repair. The AST's spans still index `source`.
+    parse_source: Option<String>,
     source_type: SourceType,
 }
 
 impl ProgramOwner<'_> {
     fn source(&self) -> &str {
         &self.source
+    }
+
+    fn parse_source(&self) -> &str {
+        self.parse_source.as_deref().unwrap_or(&self.source)
     }
 }
 
@@ -49,8 +55,25 @@ impl<'source> RetainedProgram<'source> {
         Self::parse_cow(Cow::Owned(source), is_typescript)
     }
 
+    /// Parse a same-length repaired spelling while retaining the original text
+    /// as the program's source. This keeps every span and source projection in
+    /// the component's coordinate space.
+    #[must_use]
+    pub fn parse_repaired(source: &'source str, repaired: String, is_typescript: bool) -> Self {
+        debug_assert_eq!(source.len(), repaired.len());
+        Self::parse_sources(Cow::Borrowed(source), Some(repaired), is_typescript)
+    }
+
     #[must_use]
     fn parse_cow(source: Cow<'source, str>, is_typescript: bool) -> Self {
+        Self::parse_sources(source, None, is_typescript)
+    }
+
+    fn parse_sources(
+        source: Cow<'source, str>,
+        parse_source: Option<String>,
+        is_typescript: bool,
+    ) -> Self {
         let source_type = if is_typescript {
             SourceType::ts()
         } else {
@@ -60,11 +83,16 @@ impl<'source> RetainedProgram<'source> {
             ProgramOwner {
                 allocator: Allocator::default(),
                 source,
+                parse_source,
                 source_type,
             },
             |owner| {
-                let parsed =
-                    Parser::new(&owner.allocator, owner.source(), owner.source_type).parse();
+                let mut parsed =
+                    Parser::new(&owner.allocator, owner.parse_source(), owner.source_type).parse();
+                // The repaired spelling is byte-for-byte the same length, so
+                // all AST spans address the original source. Downstream source
+                // projections must also see that original text.
+                parsed.program.source_text = owner.source();
                 ParsedProgram {
                     program: parsed.program,
                     diagnostics: parsed.diagnostics.into_vec(),
@@ -223,5 +251,16 @@ mod tests {
             cloned.comments[0].attached_to,
             retained.program().comments[0].attached_to + 7
         );
+    }
+
+    #[test]
+    fn repaired_parse_retains_the_original_source() {
+        let source = "import d from './d.json'\nassert { type: 'json' };";
+        let repaired = source.replacen("assert", "with  ", 1);
+        let retained = RetainedProgram::parse_repaired(source, repaired, true);
+
+        assert!(retained.diagnostics().is_empty());
+        assert_eq!(retained.source(), source);
+        assert_eq!(retained.program().source_text, source);
     }
 }

--- a/crates/rsvelte_core/src/compiler/phases/1_parse/read/expression.rs
+++ b/crates/rsvelte_core/src/compiler/phases/1_parse/read/expression.rs
@@ -7407,8 +7407,7 @@ fn repair_ts_newline_import_assert(content: &str, is_typescript: bool) -> Option
         let Some((keyword_start, keyword_end)) = keyword else {
             return changed.then_some(repaired);
         };
-        if repaired[..keyword_start]
-            .as_bytes()
+        if repaired.as_bytes()[..keyword_start]
             .last()
             .is_some_and(|byte| byte.is_ascii_alphanumeric() || matches!(*byte, b'_' | b'$'))
         {

--- a/crates/rsvelte_core/src/compiler/phases/1_parse/read/expression.rs
+++ b/crates/rsvelte_core/src/compiler/phases/1_parse/read/expression.rs
@@ -7370,7 +7370,10 @@ fn realign_missing_semicolon(content: &str, at: usize, message: &str) -> (usize,
 /// after ASI it reports the `{` following an `assert` expression statement.
 /// Re-parsing after each replacement proves the token was grammar, rather than
 /// the same bytes in a string, comment, regex, or unrelated identifier.
-fn repair_ts_newline_import_assert(content: &str, is_typescript: bool) -> Option<String> {
+pub(crate) fn repair_ts_newline_import_assert(
+    content: &str,
+    is_typescript: bool,
+) -> Option<String> {
     if !is_typescript || !content.contains("assert") {
         return None;
     }

--- a/crates/rsvelte_core/src/compiler/phases/1_parse/read/expression.rs
+++ b/crates/rsvelte_core/src/compiler/phases/1_parse/read/expression.rs
@@ -6962,7 +6962,12 @@ pub fn parse_program_with_error<'a>(
         } else {
             SourceType::mjs()
         };
-        let result = OxcParser::new(allocator, params.content, source_type).parse();
+        let repaired = repair_ts_newline_import_assert(params.content, params.is_typescript);
+        let parse_source = repaired.as_deref().unwrap_or(params.content);
+        let mut result = OxcParser::new(allocator, parse_source, source_type).parse();
+        // A repair is byte-length preserving. Typed conversion and every later
+        // source slice must stay in the component's original coordinate space.
+        result.program.source_text = params.content;
         convert_parsed_program(
             arena,
             &result.program,
@@ -6981,8 +6986,22 @@ pub fn parse_program_retained_with_error<'ast, 'source>(
     Option<crate::error::ParseError>,
     crate::ast::oxc_program::RetainedProgram<'source>,
 ) {
-    let retained =
-        crate::ast::oxc_program::RetainedProgram::parse(params.content, params.is_typescript);
+    let retained = repair_ts_newline_import_assert(params.content, params.is_typescript)
+        .map_or_else(
+            || {
+                crate::ast::oxc_program::RetainedProgram::parse(
+                    params.content,
+                    params.is_typescript,
+                )
+            },
+            |repaired| {
+                crate::ast::oxc_program::RetainedProgram::parse_repaired(
+                    params.content,
+                    repaired,
+                    params.is_typescript,
+                )
+            },
+        );
     let (program, parse_error) = convert_parsed_program(
         arena,
         retained.program(),
@@ -7340,6 +7359,65 @@ fn realign_missing_semicolon(content: &str, at: usize, message: &str) -> (usize,
         return (at, message.to_string());
     }
     (i, "Unexpected token".to_string())
+}
+
+/// Repair the one import-attributes spelling acorn-typescript accepts and OXC
+/// rejects: `assert` after a line terminator. Replacing it with `with  ` keeps
+/// the byte length, every span, and the output spelling (upstream normalizes the
+/// deprecated clause to `with`) unchanged.
+///
+/// The candidate comes from OXC's *first* effective diagnostic, not a text scan:
+/// after ASI it reports the `{` following an `assert` expression statement.
+/// Re-parsing after each replacement proves the token was grammar, rather than
+/// the same bytes in a string, comment, regex, or unrelated identifier.
+fn repair_ts_newline_import_assert(content: &str, is_typescript: bool) -> Option<String> {
+    if !is_typescript || !content.contains("assert") {
+        return None;
+    }
+
+    let mut repaired = content.to_string();
+    let mut changed = false;
+    loop {
+        let allocator = Allocator::default();
+        let parsed = OxcParser::new(&allocator, &repaired, SourceType::ts()).parse();
+        let Some(diagnostic) = parsed
+            .diagnostics
+            .iter()
+            .find(|diagnostic| !is_acorn_unchecked_ts_grammar_rule(diagnostic))
+        else {
+            return changed.then_some(repaired);
+        };
+        let Some(label) = diagnostic.labels.first() else {
+            return changed.then_some(repaired);
+        };
+        let reported = (label.offset() as usize).min(repaired.len());
+        let (brace, message) = realign_missing_semicolon(&repaired, reported, &diagnostic.message);
+        if message != "Unexpected token" || repaired.as_bytes().get(brace) != Some(&b'{') {
+            return changed.then_some(repaired);
+        }
+
+        // OXC labels the insertion point at the end of `assert`; the realigned
+        // brace is the useful fallback when only whitespace separates them.
+        // Trying both also admits a comment between the keyword and `{`.
+        let keyword = [reported, brace].into_iter().find_map(|end| {
+            let end = repaired[..end].trim_end().len();
+            let start = end.checked_sub("assert".len())?;
+            (&repaired[start..end] == "assert").then_some((start, end))
+        });
+        let Some((keyword_start, keyword_end)) = keyword else {
+            return changed.then_some(repaired);
+        };
+        if repaired[..keyword_start]
+            .as_bytes()
+            .last()
+            .is_some_and(|byte| byte.is_ascii_alphanumeric() || matches!(*byte, b'_' | b'$'))
+        {
+            return changed.then_some(repaired);
+        }
+
+        repaired.replace_range(keyword_start..keyword_end, "with  ");
+        changed = true;
+    }
 }
 
 /// The first offset oxc classified as irregular whitespace that ECMAScript does

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
@@ -3902,7 +3902,8 @@ fn scan_import_line(s: &str, in_block_comment: bool, carry: ImportCarry) -> Impo
             }
             b'{' => {
                 if out.carry.depth == 0
-                    && (out.carry.expect_attributes || token_before_is_with(bytes, i))
+                    && (out.carry.expect_attributes
+                        || token_before_is_import_attributes_keyword(bytes, i))
                 {
                     out.carry.in_attributes = true;
                     out.carry.expect_attributes = false;
@@ -3926,14 +3927,13 @@ fn scan_import_line(s: &str, in_block_comment: bool, carry: ImportCarry) -> Impo
     out
 }
 
-/// Is the token immediately before `i` the `with` keyword that opens an
-/// import-attributes clause?
+/// Is the token immediately before `i` an import-attributes keyword?
 ///
 /// Called on a `{`, so anything else there — a specifier list's brace, or a
 /// `with` that is the tail of a longer identifier — must answer `false`. A
 /// comment before the brace ends on a byte that cannot be part of an
 /// identifier, so it yields an empty run rather than a false match.
-fn token_before_is_with(bytes: &[u8], at: usize) -> bool {
+fn token_before_is_import_attributes_keyword(bytes: &[u8], at: usize) -> bool {
     let mut end = at;
     while end > 0 && bytes[end - 1].is_ascii_whitespace() {
         end -= 1;
@@ -3942,21 +3942,22 @@ fn token_before_is_with(bytes: &[u8], at: usize) -> bool {
     while start > 0 && is_ident_byte(bytes[start - 1]) {
         start -= 1;
     }
-    &bytes[start..end] == b"with"
+    matches!(&bytes[start..end], b"with" | b"assert")
 }
 
-/// Does `s` begin — after whitespace and comments — with the `with { … }`
-/// import-attributes clause that continues an `import` statement?
+/// Does `s` begin — after whitespace and comments — with an import-attributes
+/// clause that continues an `import` statement?
 ///
 /// The clause carries no `[no LineTerminator here]` restriction, so it may start
-/// on any later line; `with` is a reserved word, so in module code nothing else
-/// can begin there. The deprecated `assert` spelling is deliberately not
-/// accepted: both compilers reject it while parsing, so no such source reaches
-/// this pass, and `assert` is a plain identifier that a call on the next line
-/// would collide with.
+/// on any later line. Acorn-typescript also accepts the deprecated `assert`
+/// spelling after a line terminator (#3198). Requiring the following `{` keeps
+/// an `assert(...)` call or an unrelated identifier from extending the import.
 fn starts_import_attributes(s: &str) -> bool {
     let keyword = skip_js_whitespace_and_comments(s, 0);
-    let Some(after_keyword) = s[keyword..].strip_prefix("with") else {
+    let Some(after_keyword) = s[keyword..]
+        .strip_prefix("with")
+        .or_else(|| s[keyword..].strip_prefix("assert"))
+    else {
         return false;
     };
     if after_keyword
@@ -4151,11 +4152,12 @@ fn cleanup_import_line(import: &str) -> String {
     // that. String literals (the module specifier) are respected.
     let import = props_transforms::strip_js_comments(import);
     // Normalize whitespace (join multi-line imports into a single line)
-    let single_line = import
+    let mut single_line = import
         .lines()
         .map(|l| l.trim())
         .collect::<Vec<_>>()
         .join(" ");
+    normalize_import_assert_keyword(&mut single_line);
 
     // Find the { ... } block
     if let Some(open) = single_line.find('{')
@@ -4193,6 +4195,46 @@ fn cleanup_import_line(import: &str) -> String {
     }
 
     single_line
+}
+
+/// Esrap prints the deprecated `assert` import-attributes spelling as `with`.
+/// The client string pipeline must mirror that normalization without touching
+/// the same bytes in a module specifier or an attribute value.
+fn normalize_import_assert_keyword(import: &mut String) {
+    let assert_start = {
+        let bytes = import.as_bytes();
+        let mut i = 0usize;
+        let mut previous = None;
+        let mut found = None;
+        while i < bytes.len() {
+            if let Some((next, _)) = skip_opaque(bytes, i, previous) {
+                previous = Some(b'x');
+                i = next;
+                continue;
+            }
+            if bytes[i..].starts_with(b"assert")
+                && (i == 0 || !is_ident_byte(bytes[i - 1]))
+                && bytes
+                    .get(i + "assert".len())
+                    .is_none_or(|byte| !is_ident_byte(*byte))
+            {
+                let brace = skip_js_whitespace_and_comments(import, i + "assert".len());
+                if bytes.get(brace) == Some(&b'{') {
+                    found = Some(i);
+                    break;
+                }
+            }
+            if !bytes[i].is_ascii_whitespace() {
+                previous = Some(bytes[i]);
+            }
+            i += 1;
+        }
+        found
+    };
+
+    if let Some(start) = assert_start {
+        import.replace_range(start..start + "assert".len(), "with");
+    }
 }
 
 /// Extract variable names from top-level (non-nested) declarations that are NOT

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/tests.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/tests.rs
@@ -1281,6 +1281,31 @@ fn extract_imports_keeps_an_import_attributes_clause() {
         extract_imports("import d from \"./d.json\"\nconst s = \"with { a: 'b' }\";\n");
     assert_eq!(imports, vec!["import d from \"./d.json\"".to_string()]);
     assert_eq!(rest, "const s = \"with { a: 'b' }\";");
+
+    // Acorn-typescript accepts the deprecated spelling here. The parser repair
+    // proves this is grammar; the client splitter must keep the same statement
+    // together so cleanup can normalize it to `with`.
+    let (imports, rest) =
+        extract_imports("import d from \"./d.json\"\nassert { type: \"json\" };\nlet z = d;\n");
+    assert_eq!(imports.len(), 1);
+    assert!(imports[0].contains("assert { type: \"json\" }"));
+    assert_eq!(rest, "let z = d;");
+}
+
+#[test]
+fn cleanup_import_normalizes_only_the_assert_clause_keyword() {
+    let mut import =
+        "import d from \"./assert { literal }.json\" assert { type: \"assert { value }\" }"
+            .to_string();
+    normalize_import_assert_keyword(&mut import);
+    assert_eq!(
+        import,
+        "import d from \"./assert { literal }.json\" with { type: \"assert { value }\" }"
+    );
+    assert_eq!(
+        cleanup_import_line("import d from \"./d.json\"\nassert { type: \"json\" }"),
+        "import d from \"./d.json\" with { type: \"json\" }"
+    );
 }
 
 #[test]

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/script.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/script.rs
@@ -54,6 +54,7 @@ use crate::ast::template::Script;
 use crate::compiler::phases::phase2_analyze::scope::BindingKind;
 use crate::compiler::phases::phase3_transform::builders::B;
 use crate::compiler::phases::phase3_transform::client::expression_utils::wrap_await_with_save_in_async_derived;
+use oxc_allocator::CloneIn;
 use oxc_ast::ast::{Comment, Expression as OxcExpression, Statement, VariableDeclarationKind};
 use oxc_ast_visit::VisitMut;
 use oxc_span::{GetSpan, Span};
@@ -943,12 +944,13 @@ fn transform_script<'a>(
                 // inside it, so replaying them in place would put them in the
                 // wrong function.
                 Statement::ImportDeclaration(imp) => {
-                    let slice = &src[imp.span.start as usize..imp.span.end as usize];
-                    if let Some(rehomed) = state.reparse_statement(slice) {
-                        match import_sink.as_deref_mut() {
-                            Some(sink) => sink.push(rehomed),
-                            None => out.push(rehomed),
-                        }
+                    // Keep parser repairs such as deprecated `assert` import
+                    // attributes normalized to `with`; re-parsing the original
+                    // source would either undo the repair or reject the import.
+                    let rehomed = Statement::ImportDeclaration(imp.clone_in(state.allocator));
+                    match import_sink.as_deref_mut() {
+                        Some(sink) => sink.push(rehomed),
+                        None => out.push(rehomed),
                     }
                 }
                 Statement::VariableDeclaration(vd) => {
@@ -3569,12 +3571,13 @@ fn transform_script_legacy<'a>(
                 // inside it, so replaying them in place would put them in the
                 // wrong function.
                 Statement::ImportDeclaration(imp) => {
-                    let slice = &src[imp.span.start as usize..imp.span.end as usize];
-                    if let Some(rehomed) = state.reparse_statement(slice) {
-                        match import_sink.as_deref_mut() {
-                            Some(sink) => sink.push(rehomed),
-                            None => out.push(rehomed),
-                        }
+                    // Keep parser repairs such as deprecated `assert` import
+                    // attributes normalized to `with`; re-parsing the original
+                    // source would either undo the repair or reject the import.
+                    let rehomed = Statement::ImportDeclaration(imp.clone_in(state.allocator));
+                    match import_sink.as_deref_mut() {
+                        Some(sink) => sink.push(rehomed),
+                        None => out.push(rehomed),
                     }
                 }
                 Statement::ExportNamedDeclaration(_) | Statement::ExportFromDeclaration(_) => {
@@ -4878,7 +4881,6 @@ impl<'a> PipePrint for oxc_ast::ast::Program<'a> {
 /// needs the body as TEXT; cloning lets us print a throwaway copy while keeping
 /// the originals available for the non-async fall-through path.
 fn body_clone<'a>(state: &ServerTransformState<'a>, body: &[Statement<'a>]) -> Vec<Statement<'a>> {
-    use oxc_allocator::CloneIn;
     body.iter().map(|s| s.clone_in(state.allocator)).collect()
 }
 

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/script.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/script.rs
@@ -848,6 +848,20 @@ fn record_classification_failure(
     ));
 }
 
+/// Prepare a TypeScript script for the server's independent JavaScript
+/// classification parse. Phase 1 accepts one deprecated import-attributes
+/// spelling through a same-length parser-only repair, so every server port must
+/// apply that repair before erasing types as well.
+fn strip_typescript_for_classification(source: &str) -> String {
+    let repaired =
+        crate::compiler::phases::phase1_parse::expression::repair_ts_newline_import_assert(
+            source, true,
+        );
+    crate::compiler::phases::phase2_analyze::types::strip_typescript(
+        repaired.as_deref().unwrap_or(source),
+    )
+}
+
 fn transform_script<'a>(
     script: &Script,
     state: &mut ServerTransformState<'a>,
@@ -871,21 +885,21 @@ fn transform_script<'a>(
     // index into the local `src`, and the reparse helpers copy the slice text into
     // the state allocator — none of them index `state.source` directly. So binding
     // `src` to the stripped buffer keeps offsets internally consistent.
+    let script_is_typescript =
+        super::super::helpers::script_is_typescript(script) || state.analysis.is_typescript;
+    let source_slice = &state.source[start..end];
     let stripped;
     // TS is detected COMPONENT-wide, not per-script: if EITHER script carries
     // `lang="ts"` the whole component is parsed as TS (upstream `force_typescript`),
     // so a `<script>` with no `lang` attribute can still hold TS syntax
     // (`import type …`, `satisfies …`) when a sibling `<script lang="ts">` exists.
     // Strip in that case too — mirrors the OLD oracle's component-wide `is_ts`.
-    let src: &str =
-        if super::super::helpers::script_is_typescript(script) || state.analysis.is_typescript {
-            stripped = crate::compiler::phases::phase2_analyze::types::strip_typescript(
-                &state.source[start..end],
-            );
-            &stripped
-        } else {
-            &state.source[start..end]
-        };
+    let src: &str = if script_is_typescript {
+        stripped = strip_typescript_for_classification(source_slice);
+        &stripped
+    } else {
+        source_slice
+    };
 
     // Every decision below reads this text (directly, or through spans into it),
     // so the grouping parens around a rune call have to be gone first.
@@ -3475,21 +3489,21 @@ fn transform_script_legacy<'a>(
 
     // TypeScript components: strip TS from the slice before parsing (see the
     // matching note in `transform_script` for the offset-consistency rationale).
+    let script_is_typescript =
+        super::super::helpers::script_is_typescript(script) || state.analysis.is_typescript;
+    let source_slice = &state.source[start..end];
     let stripped;
     // TS is detected COMPONENT-wide, not per-script: if EITHER script carries
     // `lang="ts"` the whole component is parsed as TS (upstream `force_typescript`),
     // so a `<script>` with no `lang` attribute can still hold TS syntax
     // (`import type …`, `satisfies …`) when a sibling `<script lang="ts">` exists.
     // Strip in that case too — mirrors the OLD oracle's component-wide `is_ts`.
-    let src: &str =
-        if super::super::helpers::script_is_typescript(script) || state.analysis.is_typescript {
-            stripped = crate::compiler::phases::phase2_analyze::types::strip_typescript(
-                &state.source[start..end],
-            );
-            &stripped
-        } else {
-            &state.source[start..end]
-        };
+    let src: &str = if script_is_typescript {
+        stripped = strip_typescript_for_classification(source_slice);
+        &stripped
+    } else {
+        source_slice
+    };
 
     // Every decision below reads this text (directly, or through spans into it),
     // so the grouping parens around a rune call have to be gone first.

--- a/crates/rsvelte_core/tests/import_assert_newline_3198.rs
+++ b/crates/rsvelte_core/tests/import_assert_newline_3198.rs
@@ -5,11 +5,10 @@
 //! clause in TypeScript (accepting the file) and, in JavaScript, rejects at the
 //! `{` that cannot continue the `assert` expression statement.
 //!
-//! The JavaScript rows and the `with` spelling are pinned here. The TypeScript
-//! row — where acorn-typescript keeps the clause and official compiles the file
-//! — is still an over-rejection: OXC's guard lives in
-//! `parse_import_attributes`, and a repaired re-parse cannot be threaded through
-//! `RetainedProgram`, whose owner borrows the component source for `'source`.
+//! The JavaScript rows and the `with` spelling pin the discriminating controls.
+//! For TypeScript, rsvelte repairs only OXC's first matching diagnostic with a
+//! same-length parser spelling, so retained spans continue to address the
+//! component source and the emitted import keeps its attributes clause.
 
 use rsvelte_core::{CompileOptions, GenerateMode, compile, compiler::CssMode};
 
@@ -94,6 +93,36 @@ fn with_clause_on_a_new_line_compiles_everywhere() {
         if let Err((code, message, start, _)) = outcome(&src) {
             panic!(
                 "expected <script{attrs}> with `with` to compile, got `{code}` {message:?} at {start}"
+            );
+        }
+    }
+}
+
+#[test]
+fn typescript_newline_assert_compiles_and_keeps_the_clause() {
+    for attrs in [" lang=\"ts\"", " module lang=\"ts\""] {
+        let src = wrap(attrs);
+        for (generate, dev, target) in [
+            (GenerateMode::Client, false, "client"),
+            (GenerateMode::Server, false, "server"),
+            (GenerateMode::Client, true, "client-dev"),
+        ] {
+            let output = compile(
+                &src,
+                CompileOptions {
+                    filename: Some("Test.svelte".to_string()),
+                    generate,
+                    dev,
+                    css: CssMode::External,
+                    ..Default::default()
+                },
+            )
+            .unwrap_or_else(|error| panic!("{target} <script{attrs}>: {error:?}"))
+            .js
+            .code;
+            assert!(
+                output.contains("import d from \"./d.json\" with { type: \"json\" };"),
+                "{target} <script{attrs}> lost or failed to normalize the clause:\n{output}"
             );
         }
     }


### PR DESCRIPTION
Closes #3198.

## Summary

- recover the TypeScript-only `import …` newline `assert { … }` shape that acorn-typescript accepts and OXC rejects
- parse a same-length `with  ` spelling while retaining the original component source and all source coordinates
- keep the repaired retained AST eligible for TypeScript stripping, source projection, and AST-based codegen
- pin instance/module scripts across client, server, and client-dev output, including preservation and normalization of the attributes clause

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- `node --check scripts/ci/check-upstream-issues.mjs`
- `jq empty .changeset/config.json`

Per repository instructions, no local build or test suite was run; GitHub CI is the execution oracle.
