### PR TITLE
fix(svelte2tsx): preserve snippet props hoist order

### DIFF
--- a/.changeset/calm-snippets-order.md
+++ b/.changeset/calm-snippets-order.md
@@ -1,5 +1,7 @@
 ---
 "@rsvelte/svelte2tsx": patch
+"@rsvelte/compiler": patch
+"@rsvelte/svelte-check": patch
 ---
 
 Match upstream ordering when a top-level snippet and an inferred component props type share the render-function hoist target

--- a/.changeset/calm-snippets-order.md
+++ b/.changeset/calm-snippets-order.md
@@ -4,4 +4,4 @@
 "@rsvelte/svelte-check": patch
 ---
 
-Match upstream ordering when a top-level snippet and an inferred component props type share the render-function hoist target
+Match upstream ordering when a top-level snippet and a generated component props type share the render-function hoist target, including generic props annotations

--- a/.changeset/calm-snippets-order.md
+++ b/.changeset/calm-snippets-order.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/svelte2tsx": patch
+---
+
+Match upstream ordering when a top-level snippet and an inferred component props type share the render-function hoist target

--- a/crates/rsvelte_projection/src/svelte2tsx/nodes/snippet_hoisting.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/nodes/snippet_hoisting.rs
@@ -6,7 +6,6 @@ use std::collections::VecDeque;
 use crate::ast::template::{Fragment, Root, TemplateNode};
 use rustc_hash::FxHashMap;
 
-use super::super::magic_string::MagicString;
 use super::super::script::ExportedNames;
 use super::super::svelte2tsx::slice_src;
 use super::super::utils::lexical::{lexical_identifiers, lexical_identifiers_in_expressions};
@@ -33,16 +32,18 @@ fn propagate_blocked_dependencies(dependents: &[Vec<u32>], blocked: &mut [bool])
     }
 }
 
-/// Analyze and relocate top-level `{#snippet}` blocks. Non-hoistable snippets
+/// Analyze top-level `{#snippet}` blocks. Non-hoistable snippets
 /// (those closing over instance-script values, or referencing a non-hoistable
 /// snippet) are moved to the top of the instance script; the returned ranges are
-/// the module-hoistable snippets, which the caller relocates to module scope.
+/// the module-hoistable and instance-hoistable snippets, which the caller
+/// relocates after rewriting the script tags. Upstream performs those moves
+/// after the instance-script edits, and that ordering matters when a moved
+/// snippet and a synthesised declaration share the render-function anchor.
 pub fn hoist_top_level_snippets(
     ast: &Root,
     source: &str,
     exported_names: &ExportedNames,
-    str: &mut MagicString<'_>,
-) -> Vec<(u32, u32)> {
+) -> (Vec<(u32, u32)>, Vec<(u32, u32)>) {
     let mut hoistable_snippet_ranges: Vec<(u32, u32)> = Vec::new();
     let mut nonhoistable_snippet_ranges: Vec<(u32, u32)> = Vec::new();
     let module_script_present = ast.module.is_some();
@@ -139,15 +140,7 @@ pub fn hoist_top_level_snippets(
         }
     }
 
-    // Inside-target moves require an instance script to anchor against.
-    if let Some(instance) = ast.instance.as_ref() {
-        let inside_target = instance.content_offset;
-        for (s, e) in &nonhoistable_snippet_ranges {
-            str.move_range(*s, *e, inside_target);
-        }
-    }
-
-    hoistable_snippet_ranges
+    (hoistable_snippet_ranges, nonhoistable_snippet_ranges)
 }
 
 /// Collect the component names a snippet body instantiates (`<Icon />`,

--- a/crates/rsvelte_projection/src/svelte2tsx/process_instance_script_tag.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/process_instance_script_tag.rs
@@ -361,18 +361,13 @@ pub fn process_instance_script_tag(
                 "/*\u{03A9}ignore_start\u{03A9}*/;type $$ComponentProps = {type_text};/*\u{03A9}ignore_end\u{03A9}*/"
             )
         };
-        // The JS reference relocates the annotation itself, so the alias is a
-        // moved chunk that lands before the snippets moved to the same index
-        // later. Only a props declaration that opens the script shares an index
-        // with them; there `append_left` reproduces that order by riding the
-        // `function $$render() {` chunk's outro. Anywhere else `append_right` is
-        // required, so the alias stays behind when the import ending at
-        // `let_pos` is hoisted away.
-        if let_pos == content_start {
-            str.append_left(let_pos, &decl);
-        } else {
-            str.append_right(let_pos, &decl);
-        }
+        // `preprendStr` overwrites the source character at `let_pos`, so the
+        // declaration belongs to the chunk starting there. A snippet moved to
+        // that same position later therefore lands before the declaration;
+        // attaching it to the left chunk's outro reverses that order (#3461).
+        // Keeping it on the right also prevents an import ending at `let_pos`
+        // from carrying the declaration away when the import is hoisted.
+        str.append_right(let_pos, &decl);
     }
 
     // Overwrite `</script>` with slot declaration + `async () => {`.

--- a/crates/rsvelte_projection/src/svelte2tsx/process_instance_script_tag.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/process_instance_script_tag.rs
@@ -361,13 +361,18 @@ pub fn process_instance_script_tag(
                 "/*\u{03A9}ignore_start\u{03A9}*/;type $$ComponentProps = {type_text};/*\u{03A9}ignore_end\u{03A9}*/"
             )
         };
-        // `preprendStr` overwrites the source character at `let_pos`, so the
-        // declaration belongs to the chunk starting there. A snippet moved to
-        // that same position later therefore lands before the declaration;
-        // attaching it to the left chunk's outro reverses that order (#3461).
-        // Keeping it on the right also prevents an import ending at `let_pos`
-        // from carrying the declaration away when the import is hoisted.
-        str.append_right(let_pos, &decl);
+        // An inferred props alias is inserted by `preprendStr`, so a snippet
+        // moved to the same position later lands before it (#3461). An explicit
+        // inline annotation is itself moved to the declaration start, however,
+        // and that moved alias stays before a later snippet move. Attach that
+        // one to the left chunk's outro only when the declaration opens the
+        // script; elsewhere the right chunk also prevents a preceding import
+        // from carrying the alias away when it is hoisted.
+        if force_inside_render && let_pos == content_start {
+            str.append_left(let_pos, &decl);
+        } else {
+            str.append_right(let_pos, &decl);
+        }
     }
 
     // Overwrite `</script>` with slot declaration + `async () => {`.

--- a/crates/rsvelte_projection/src/svelte2tsx/svelte2tsx.rs
+++ b/crates/rsvelte_projection/src/svelte2tsx/svelte2tsx.rs
@@ -675,8 +675,8 @@ pub fn svelte2tsx(
     // i.e. the byte position of the `>` of `<script>`. The script-tag overwrite
     // in Step 10 is split there so the moved snippet chunks land between the
     // imports / `;type` block and the `function $$render() {` declaration.
-    let hoistable_snippet_ranges =
-        hoist_top_level_snippets(&ast, source, &exported_names, &mut str);
+    let (hoistable_snippet_ranges, instance_snippet_ranges) =
+        hoist_top_level_snippets(&ast, source, &exported_names);
 
     // Step 9.5: Collect slot and event information from the template
     let template_info = template::collect_template_info_if_needed(
@@ -804,6 +804,16 @@ pub fn svelte2tsx(
             &hoistable_snippet_ranges,
             &instance_imports,
         );
+
+        // Upstream moves snippets that close over instance bindings only after
+        // `processInstanceScriptContent` has applied the script/type edits.
+        // At the shared render-function anchor, a later MagicString move lands
+        // before those edits. Doing this in Step 9 instead reverses a snippet
+        // and the synthetic `$$ComponentProps` alias (#3461).
+        let render_function_start = ast.instance.as_ref().unwrap().content_offset;
+        for (start, end) in &instance_snippet_ranges {
+            str.move_range(*start, *end, render_function_start);
+        }
     }
 
     // Phase 3: Move scripts to their target positions (after all overwrites)

--- a/crates/rsvelte_projection/tests/svelte2tsx_snippet_props_order_3461.rs
+++ b/crates/rsvelte_projection/tests/svelte2tsx_snippet_props_order_3461.rs
@@ -1,0 +1,38 @@
+//! A top-level snippet that closes over an instance binding moves to the same
+//! render-function anchor used by an inferred `$$ComponentProps` declaration.
+//! Upstream applies the script edits first and moves the snippet afterwards,
+//! so the moved snippet precedes the declaration at that shared anchor.
+
+use rsvelte_projection::svelte2tsx::{Svelte2TsxOptions, svelte2tsx};
+
+#[test]
+fn instance_hoisted_snippet_precedes_inferred_component_props() {
+    let source = r#"<script lang="ts">
+	let { x = 1 } = $props();
+</script>
+
+{#snippet row(v: number)}<i>{v}</i>{/snippet}
+{@render row(x)}
+"#;
+    let code = svelte2tsx(
+        source,
+        Svelte2TsxOptions {
+            filename: "snip.svelte".into(),
+            is_ts_file: true,
+            ..Default::default()
+        },
+    )
+    .expect("svelte2tsx")
+    .code;
+
+    let snippet = code
+        .find("const row")
+        .unwrap_or_else(|| panic!("hoisted snippet missing:\n{code}"));
+    let props = code
+        .find("type $$ComponentProps")
+        .unwrap_or_else(|| panic!("inferred component props missing:\n{code}"));
+    assert!(
+        snippet < props,
+        "the later snippet move must precede the props edit at their shared anchor:\n{code}"
+    );
+}

--- a/crates/rsvelte_projection/tests/svelte2tsx_snippet_props_order_3461.rs
+++ b/crates/rsvelte_projection/tests/svelte2tsx_snippet_props_order_3461.rs
@@ -36,3 +36,36 @@ fn instance_hoisted_snippet_precedes_inferred_component_props() {
         "the later snippet move must precede the props edit at their shared anchor:\n{code}"
     );
 }
+
+#[test]
+fn moved_generic_props_type_precedes_instance_hoisted_snippet() {
+    let source = r#"<script lang="ts" generics="T">
+	let { prop }: { prop?: T } = $props();
+	const promise = Promise.resolve();
+</script>
+
+{#snippet row()}<i>{await promise}</i>{/snippet}
+{@render row()}
+"#;
+    let code = svelte2tsx(
+        source,
+        Svelte2TsxOptions {
+            filename: "generic.svelte".into(),
+            is_ts_file: true,
+            ..Default::default()
+        },
+    )
+    .expect("svelte2tsx")
+    .code;
+
+    let props = code
+        .find("type $$ComponentProps")
+        .unwrap_or_else(|| panic!("moved props type missing:\n{code}"));
+    let snippet = code
+        .find("const row")
+        .unwrap_or_else(|| panic!("hoisted snippet missing:\n{code}"));
+    assert!(
+        props < snippet,
+        "the moved annotation must precede a later snippet move at the shared anchor:\n{code}"
+    );
+}


### PR DESCRIPTION
## Summary

- defer instance-scoped top-level snippet moves until after instance-script and type rewrites
- preserve the existing module-hoist classification and destinations
- pin same-anchor ordering between a moved snippet and inferred `$$ComponentProps`

Closes #3461.

## Why

Upstream processes instance-script type edits before moving root snippets. rsvelte moved instance snippets one phase earlier, so MagicString's same-anchor insertion ordering was reversed.

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- added a focused svelte2tsx ordering regression test
- per repository instructions, no local build or test run; CI is the execution oracle
