### PR TITLE
fix(parser): accept let declarations without initializers

### DIFF
--- a/.changeset/calm-otters-declare.md
+++ b/.changeset/calm-otters-declare.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/compiler": patch
+---
+
+Accept declaration tags containing a `let` declarator without an initializer.

--- a/crates/rsvelte_core/src/compiler/phases/1_parse/read/expression.rs
+++ b/crates/rsvelte_core/src/compiler/phases/1_parse/read/expression.rs
@@ -1981,6 +1981,27 @@ pub fn check_js_statement_parse_error(content: &str, ts: bool) -> Option<(String
     })
 }
 
+/// Whether `content` parses as a JavaScript/TypeScript variable declaration.
+///
+/// Upstream's declaration-tag reader distinguishes a successfully parsed
+/// `VariableDeclaration` from an `ExpressionStatement`; parse success alone is
+/// not enough to commit a `{let ...}`-shaped tag to the declaration path.
+pub fn is_js_variable_declaration(content: &str, ts: bool) -> bool {
+    with_oxc_allocator(|allocator| {
+        let source_type = if ts {
+            SourceType::ts()
+        } else {
+            SourceType::mjs()
+        };
+        let result = OxcParser::new(allocator, content, source_type).parse();
+        result.diagnostics.is_empty()
+            && matches!(
+                result.program.body.first(),
+                Some(oxc_ast::ast::Statement::VariableDeclaration(_))
+            )
+    })
+}
+
 /// [`trailing_token_offset`], confirmed by re-parsing the leading slice.
 ///
 /// The probe reports where OXC's first label sits, which is also where an error

--- a/crates/rsvelte_core/src/compiler/phases/1_parse/state/tag.rs
+++ b/crates/rsvelte_core/src/compiler/phases/1_parse/state/tag.rs
@@ -261,10 +261,11 @@ impl<'a> Parser<'a> {
         // Single declarator: split at the first top-level assignment `=`.
         let first_equals = find_top_level_assignment(body_text);
 
-        // The body must contain an assignment with an initializer — upstream
-        // emits `declaration_tag_invalid_type` in strict mode, and falls back
-        // to a placeholder VariableDeclaration with an empty-name identifier
-        // in loose mode so editor tooling sees a continuous AST shape.
+        // An initializer is optional for `let` but required for `const`.
+        // Upstream accepts a successfully parsed `VariableDeclaration` here,
+        // including `{let x}`, and rejects any other statement shape. Loose
+        // mode falls back to a placeholder declaration when parsing fails so
+        // editor tooling sees a continuous AST shape.
         let eq_idx = match first_equals {
             Some(i) => i,
             None => {
@@ -296,6 +297,14 @@ impl<'a> Parser<'a> {
                             msg,
                             (abs, abs),
                         ));
+                    }
+                    if super::super::read::expression::is_js_variable_declaration(
+                        stmt_text, self.ts,
+                    ) {
+                        let owned = vec![(0, body_text.to_string())];
+                        return Ok(Some(self.build_multi_declarator_tag(
+                            start, decl_start, body_start, body_end, kind, &owned,
+                        )));
                     }
                     return Err(crate::error::ParseError::svelte(
                         "declaration_tag_invalid_type",

--- a/crates/rsvelte_core/tests/declaration_tag_without_initializer_3705.rs
+++ b/crates/rsvelte_core/tests/declaration_tag_without_initializer_3705.rs
@@ -1,0 +1,91 @@
+//! Regression coverage for #3705: a declaration tag may contain a single
+//! `let` declarator without an initializer.
+//!
+//! Upstream parses the whole tag body as a statement and accepts it whenever
+//! the result is a `VariableDeclaration`. rsvelte's single-declarator path
+//! instead required a top-level `=`, even though its multi-declarator builder
+//! already represented a missing initializer as ESTree `null`.
+
+use rsvelte_core::ast::arena::with_serialize_arena;
+use rsvelte_core::{CompileOptions, GenerateMode, ParseOptions, compile, parse};
+
+fn ast_json(source: &str) -> serde_json::Value {
+    let ast = parse(
+        source,
+        &oxc_allocator::Allocator::default(),
+        ParseOptions::default(),
+    )
+    .expect("declaration tag should parse");
+    let json = with_serialize_arena(&ast.arena, || serde_json::to_string(&ast).unwrap());
+    serde_json::from_str(&json).unwrap()
+}
+
+fn find_declaration_tag(value: &serde_json::Value) -> Option<&serde_json::Value> {
+    match value {
+        serde_json::Value::Object(object) => {
+            if object.get("type").and_then(|value| value.as_str()) == Some("DeclarationTag") {
+                return Some(value);
+            }
+            object.values().find_map(find_declaration_tag)
+        }
+        serde_json::Value::Array(items) => items.iter().find_map(find_declaration_tag),
+        _ => None,
+    }
+}
+
+#[test]
+fn a_bare_let_declarator_has_a_null_initializer_and_exact_spans() {
+    let source = "{let x}";
+    let json = ast_json(source);
+    let tag = find_declaration_tag(&json).expect("DeclarationTag");
+    let declaration = &tag["declaration"];
+    let declarator = &declaration["declarations"][0];
+
+    assert_eq!(tag["start"], 0);
+    assert_eq!(tag["end"], 7);
+    assert_eq!(declaration["type"], "VariableDeclaration");
+    assert_eq!(declaration["kind"], "let");
+    assert_eq!(declaration["start"], 1);
+    assert_eq!(declaration["end"], 6);
+    assert_eq!(declarator["id"]["type"], "Identifier");
+    assert_eq!(declarator["id"]["name"], "x");
+    assert_eq!(declarator["id"]["start"], 5);
+    assert_eq!(declarator["id"]["end"], 6);
+    assert!(declarator["init"].is_null());
+}
+
+#[test]
+fn a_bare_let_compiles_in_every_template_slot_and_target() {
+    for source in [
+        "{let x}<p>ok</p>",
+        "{#if true}{let x}<p>ok</p>{/if}",
+        "{#each [1] as item}{let x}<p>{item}</p>{/each}",
+    ] {
+        for generate in [GenerateMode::Client, GenerateMode::Server] {
+            compile(
+                source,
+                CompileOptions {
+                    filename: Some("Component.svelte".to_string()),
+                    generate,
+                    ..Default::default()
+                },
+            )
+            .unwrap_or_else(|error| panic!("{source:?} must compile for {generate:?}: {error:?}"));
+        }
+    }
+}
+
+#[test]
+fn const_without_an_initializer_remains_invalid() {
+    let error = compile(
+        "{const x}",
+        CompileOptions {
+            filename: Some("Component.svelte".to_string()),
+            generate: GenerateMode::Client,
+            ..Default::default()
+        },
+    )
+    .expect_err("const declarations still require an initializer");
+
+    assert!(format!("{error:?}").contains("js_parse_error"), "{error:?}");
+}


### PR DESCRIPTION
Closes #3705.

## What changed

- recognize a successfully parsed single `let` variable declaration even when it has no initializer
- reuse the existing declarator builder so the ESTree initializer is `null` with source-accurate spans
- keep non-declaration statement shapes and initializer-less `const` declarations rejected
- add AST and client/server coverage for top-level, `{#if}`, and `{#each}` slots

## Verification

- `cargo fmt --all -- --check`
- `git diff --check`
- changeset JSON configuration validation

Per project guidance, Rust builds and tests were not run locally; CI is the execution oracle.
