### PR TITLE
fix(parser): reject super and await template references

### DIFF
--- a/.changeset/sharp-cats-wait.md
+++ b/.changeset/sharp-cats-wait.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/compiler": patch
+---
+
+Reject `super` and module-reserved `await` references in template expressions with Acorn-compatible diagnostics.

--- a/crates/rsvelte_core/src/compiler/phases/1_parse/read/expression.rs
+++ b/crates/rsvelte_core/src/compiler/phases/1_parse/read/expression.rs
@@ -7145,6 +7145,11 @@ fn acorn_only_violation(
         with_at: Option<u32>,
         export_declare_global_at: Option<u32>,
         check_ts_modifier: bool,
+        check_super: bool,
+        super_at: Option<u32>,
+        method_depth: u32,
+        check_await_identifier: bool,
+        await_identifier_at: Option<u32>,
         content: &'c str,
         ts_modifier_at: Option<u32>,
     }
@@ -7189,7 +7194,34 @@ fn acorn_only_violation(
                     || def.r#type == oxc_ast::ast::MethodDefinitionType::TSAbstractMethodDefinition,
                 def.span,
             );
+            self.method_depth += 1;
             oxc_ast_visit::walk::walk_method_definition(self, def);
+            self.method_depth -= 1;
+        }
+        fn visit_object_property(&mut self, prop: &oxc_ast::ast::ObjectProperty<'a>) {
+            let is_method = prop.method || prop.kind != oxc_ast::ast::PropertyKind::Init;
+            self.method_depth += u32::from(is_method);
+            oxc_ast_visit::walk::walk_object_property(self, prop);
+            self.method_depth -= u32::from(is_method);
+        }
+        fn visit_super(&mut self, super_: &oxc_ast::ast::Super) {
+            if self.check_super
+                && self.method_depth == 0
+                && self.super_at.is_none_or(|seen| super_.span.start < seen)
+            {
+                self.super_at = Some(super_.span.start);
+            }
+        }
+        fn visit_identifier_reference(&mut self, ident: &oxc_ast::ast::IdentifierReference<'a>) {
+            if self.check_await_identifier
+                && ident.name == "await"
+                && self
+                    .await_identifier_at
+                    .is_none_or(|seen| ident.span.start < seen)
+            {
+                self.await_identifier_at = Some(ident.span.start);
+            }
+            oxc_ast_visit::walk::walk_identifier_reference(self, ident);
         }
         fn visit_property_definition(&mut self, def: &oxc_ast::ast::PropertyDefinition<'a>) {
             self.record_ts_modifier(
@@ -7213,19 +7245,32 @@ fn acorn_only_violation(
     let check_decorator = !is_typescript && content.contains('@');
     let check_with = content.contains("with");
     let check_ts_modifier = !is_typescript && content.contains("class");
+    let check_super = content.contains("super");
+    let check_await_identifier = content.contains("await");
     let mut finder = Scan {
         check_decorator,
         decorator_at: None,
         with_at: None,
         export_declare_global_at: None,
         check_ts_modifier,
+        check_super,
+        super_at: None,
+        method_depth: 0,
+        check_await_identifier,
+        await_identifier_at: None,
         content,
         ts_modifier_at: None,
     };
     // The TypeScript-only rule below needs a token that is cheap to rule out, so
     // a plain-JS script keeps the walk it had.
     let check_ts_acorn = is_typescript && content.contains("global");
-    if check_decorator || check_with || check_ts_modifier || check_ts_acorn {
+    if check_decorator
+        || check_with
+        || check_ts_modifier
+        || check_ts_acorn
+        || check_super
+        || check_await_identifier
+    {
         finder.visit_program(program);
     }
 
@@ -7250,6 +7295,15 @@ fn acorn_only_violation(
         finder
             .ts_modifier_at
             .map(|at| (at, "Unexpected token".to_string())),
+        finder
+            .super_at
+            .map(|at| (at, "'super' keyword outside a method".to_string())),
+        finder.await_identifier_at.map(|at| {
+            (
+                at,
+                "Cannot use keyword 'await' outside an async function".to_string(),
+            )
+        }),
     ]
     .into_iter()
     .flatten()

--- a/crates/rsvelte_core/tests/template_super_await_3694.rs
+++ b/crates/rsvelte_core/tests/template_super_await_3694.rs
@@ -1,0 +1,87 @@
+//! Regression tests for #3694 — OXC accepts two expression forms that Acorn
+//! rejects when Svelte parses template expressions as ES modules.
+//!
+//! These are AST checks, not text checks: `obj.await` is a legal property and
+//! `super` remains legal in a class method. Every diagnostic below was measured
+//! against the official compiler (Svelte v5.56.9).
+
+use rsvelte_core::compiler::CompileError;
+use rsvelte_core::{CompileOptions, GenerateMode, compile};
+
+fn result(src: &str) -> Result<String, CompileError> {
+    compile(
+        src,
+        CompileOptions {
+            filename: Some("X.svelte".to_string()),
+            generate: GenerateMode::Client,
+            ..Default::default()
+        },
+    )
+    .map(|compiled| compiled.js.code)
+}
+
+fn assert_parse_error(src: &str, token: &str, message: &str) {
+    let err = result(src).expect_err("official rejects this expression");
+    let CompileError::Parse(parse) = &err else {
+        panic!("expected a parse error: {err:?}")
+    };
+    let text = format!("{parse:?}");
+    assert!(text.contains("js_parse_error"), "{text}");
+    assert!(text.contains(message), "{text}");
+    assert_eq!(parse.span().0, src.find(token).expect("token is in source"));
+}
+
+#[test]
+fn acorn_only_module_keywords_are_rejected_in_template_expressions() {
+    for (src, token, message) in [
+        ("{super.x}", "super", "'super' keyword outside a method"),
+        (
+            "{await}",
+            "await",
+            "Cannot use keyword 'await' outside an async function",
+        ),
+        (
+            "{await.x}",
+            "await",
+            "Cannot use keyword 'await' outside an async function",
+        ),
+    ] {
+        assert_parse_error(src, token, message);
+    }
+}
+
+#[test]
+fn the_expression_slot_does_not_change_the_answer() {
+    for src in [
+        "<div title={super.x}></div>",
+        "{#if true}{@const x = super.x}<p>{x}</p>{/if}",
+        "<div title={await}></div>",
+        "{#if true}{@const x = await.x}<p>{x}</p>{/if}",
+    ] {
+        let token = if src.contains("super") {
+            "super"
+        } else {
+            "await"
+        };
+        let message = if token == "super" {
+            "'super' keyword outside a method"
+        } else {
+            "Cannot use keyword 'await' outside an async function"
+        };
+        assert_parse_error(src, token, message);
+    }
+}
+
+#[test]
+fn legal_property_and_nested_function_forms_stay_accepted() {
+    for src in [
+        "<p>{obj.await}</p>",
+        "<p>{(async () => await value)()}</p>",
+        "<p>{({ m() { return super.x; } }).m()}</p>",
+        "<p>{({ get x() { return super.x; } }).x}</p>",
+        "{@const C = class extends Base { m() { return super.m(); } }}<p>{C}</p>",
+        "<script>class A extends B { m() { return super.m(); } }</script><p>ok</p>",
+    ] {
+        result(src).unwrap_or_else(|err| panic!("{src:?} must compile: {err:?}"));
+    }
+}


### PR DESCRIPTION
Closes #3694.

## Summary

- reject top-level `super` references in template expressions with Acorn-compatible wording and position
- reject module-reserved `await` identifier references without rejecting legal property names such as `obj.await`
- preserve legal `super` use in class and object methods
- cover mustache, attribute, and `{@const}` expression slots plus positive controls

## Verification

- `cargo fmt --all -- --check`
- `git diff --check`

Per repository instructions, compilation and tests were left to CI.
