### PR TITLE
Fix restricted identifiers in templates

### DIFF
--- a/.changeset/quiet-badgers-restrict.md
+++ b/.changeset/quiet-badgers-restrict.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/compiler": patch
+---
+
+Match Svelte's diagnostics for `arguments` in template expressions and for restricted template binding names.

--- a/crates/rsvelte_core/src/compiler/phases/1_parse/read/expression.rs
+++ b/crates/rsvelte_core/src/compiler/phases/1_parse/read/expression.rs
@@ -11730,6 +11730,28 @@ fn is_plain_ascii_identifier(s: &str) -> bool {
     bytes.all(|b| b.is_ascii_alphanumeric() || b == b'_' || b == b'$')
 }
 
+struct RestrictedBindingIdentifier {
+    first: Option<(u32, String)>,
+}
+
+impl<'a> oxc_ast_visit::Visit<'a> for RestrictedBindingIdentifier {
+    fn visit_binding_identifier(&mut self, id: &oxc_ast::ast::BindingIdentifier<'a>) {
+        if self.first.is_none() && matches!(id.name.as_str(), "arguments" | "eval") {
+            self.first = Some((id.span.start, id.name.to_string()));
+        }
+    }
+}
+
+fn restricted_binding_identifier(
+    pattern: &oxc_ast::ast::BindingPattern<'_>,
+) -> Option<(u32, String)> {
+    use oxc_ast_visit::Visit;
+
+    let mut visitor = RestrictedBindingIdentifier { first: None };
+    visitor.visit_binding_pattern(pattern);
+    visitor.first
+}
+
 pub fn parse_binding_pattern<'a>(
     arena: &ParseArena,
     content: &str,
@@ -11799,6 +11821,15 @@ pub fn parse_binding_pattern<'a>(
             result.program.body.first()
             && let Some(decl) = var_decl.declarations.first()
         {
+            if let Some((wrapped_start, name)) = restricted_binding_identifier(&decl.id) {
+                let start = offset + wrapped_start as usize - 4;
+                return Err(crate::error::ParseError::svelte(
+                    "js_parse_error",
+                    format!("Assigning to {name} in strict mode"),
+                    (start, start),
+                ));
+            }
+
             if let oxc_ast::ast::BindingPattern::BindingIdentifier(id) = &decl.id {
                 let start = offset + id.span.start as usize - 4;
                 let end = offset + id.span.end as usize - 4;

--- a/crates/rsvelte_core/src/compiler/phases/1_parse/state/tag.rs
+++ b/crates/rsvelte_core/src/compiler/phases/1_parse/state/tag.rs
@@ -1402,7 +1402,18 @@ impl<'a> Parser<'a> {
                     self.advance();
                 }
             } else {
-                index = Some(CompactString::from(&self.source[idx_start..idx_end]));
+                let name = &self.source[idx_start..idx_end];
+                if super::super::utils::is_reserved(name) {
+                    return Err(crate::error::ParseError::svelte(
+                        "unexpected_reserved_word",
+                        format!(
+                            "'{}' is a reserved word in JavaScript and cannot be used here",
+                            name
+                        ),
+                        (idx_start, idx_start),
+                    ));
+                }
+                index = Some(CompactString::from(name));
                 self.index = idx_end;
             }
             self.skip_whitespace();
@@ -2333,39 +2344,10 @@ impl<'a> Parser<'a> {
                     // For destructuring like `{ x, y }: Point`, strip `: Point`.
                     let pattern_clean = strip_type_annotation(pattern_str);
 
-                    // Parse the pattern (LHS)
-                    // For destructuring patterns ({...} or [...]), use the dedicated
-                    // pattern parser which wraps in `let ... = null` to handle
-                    // default values (e.g., {x = 1, y}) that are not valid as
-                    // standalone expressions.
-                    let pattern_expr =
-                        if pattern_clean.starts_with('{') || pattern_clean.starts_with('[') {
-                            match super::super::read::expression::parse_destructuring_pattern(
-                                &self.arena,
-                                &pattern_clean,
-                                expr_start,
-                                self.expression_line_offsets(),
-                                self.ts,
-                            ) {
-                                Some(expr) => expr,
-                                // A pattern that does not parse in the component's
-                                // mode is upstream's `read_pattern` throwing, not a
-                                // reason to fall back to expression parsing.
-                                None => self.parse_js_expression_head_strict(
-                                    &pattern_clean,
-                                    expr_start,
-                                    false,
-                                )?,
-                            }
-                        } else {
-                            // A plain-identifier pattern goes through upstream's
-                            // `read_identifier`, not acorn, so its `loc` carries
-                            // `character`; only destructuring falls through.
-                            super::super::read::expression::with_read_identifier_loc(
-                                self.parse_js_expression_eager_strict(&pattern_clean, expr_start)?,
-                                self.expression_line_offsets(),
-                            )
-                        };
+                    // Parse the LHS through the same binding-pattern path as
+                    // each/await. Besides defaults and TypeScript annotations,
+                    // this preserves upstream's reserved-name diagnostics.
+                    let pattern_expr = self.parse_binding_pattern(&pattern_clean, expr_start)?;
 
                     // Calculate the offset for the init expression in the
                     // original source.  `trimmed` starts at `expr_start` in

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/mod.rs
@@ -370,6 +370,10 @@ pub struct VisitorContext<'a> {
     pub parent_element: Option<String>,
     /// Current function depth.
     pub function_depth: usize,
+    /// Depth inside functions which provide their own `arguments` binding.
+    /// Arrow functions inherit `arguments` from an enclosing ordinary function,
+    /// so they increment `function_depth` but not this counter.
+    pub arguments_function_depth: usize,
     /// Depth inside $derived(...) expressions (but not $derived.by(...)) or @const
     pub derived_function_depth: usize,
     /// Whether we have a $props() rune.
@@ -604,6 +608,7 @@ impl<'a> VisitorContext<'a> {
             bind_has_await: false,
             parent_element: None,
             function_depth: 0,
+            arguments_function_depth: 0,
             derived_function_depth: 0,
             has_props_rune: false,
             component_slots: rustc_hash::FxHashSet::default(),

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/shared/utils.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/shared/utils.rs
@@ -1229,6 +1229,10 @@ pub fn walk_js_expression_node(
         JsNode::Identifier {
             name, start, end, ..
         } => {
+            if name == "arguments" && context.arguments_function_depth == 0 {
+                return Err(super::super::super::errors::invalid_arguments_usage().at(*start, *end));
+            }
+
             // Handle legacy mode special variables
             if !context.analysis.runes {
                 if name == "$$props" {
@@ -1508,7 +1512,11 @@ pub fn walk_js_expression_node(
             body: Some(body),
             ..
         } => {
+            let provides_arguments = !matches!(expression, JsNode::ArrowFunctionExpression { .. });
             context.function_depth += 1;
+            if provides_arguments {
+                context.arguments_function_depth += 1;
+            }
 
             let decl_undo_mark = context.decl_undo_log.len();
 
@@ -1598,6 +1606,9 @@ pub fn walk_js_expression_node(
                 }
             }
             context.function_depth -= 1;
+            if provides_arguments {
+                context.arguments_function_depth -= 1;
+            }
         }
         JsNode::FunctionExpression { body: None, .. }
         | JsNode::FunctionDeclaration { body: None, .. } => {

--- a/crates/rsvelte_core/tests/template_restricted_identifiers_3707_3728.rs
+++ b/crates/rsvelte_core/tests/template_restricted_identifiers_3707_3728.rs
@@ -1,0 +1,152 @@
+//! Restricted identifiers in template expressions and binding patterns.
+//!
+//! The template expression walker used to bypass the script-side `Identifier`
+//! visitor, while several template binding hosts parsed patterns through
+//! different paths. These tables pin the official diagnostic, message and byte
+//! range at the two boundaries (#3707 and #3728).
+
+use rsvelte_core::{CompileOptions, GenerateMode, compile};
+
+fn diagnostic(src: &str, generate: GenerateMode) -> Option<(String, String, (u32, u32))> {
+    compile(
+        src,
+        CompileOptions {
+            filename: Some("Comp.svelte".into()),
+            generate,
+            ..Default::default()
+        },
+    )
+    .err()
+    .map(|err| {
+        let d = err.diagnostic();
+        (
+            d.code.unwrap_or_default(),
+            d.message.lines().next().unwrap_or_default().to_string(),
+            d.span.unwrap_or((u32::MAX, u32::MAX)),
+        )
+    })
+}
+
+fn assert_error(src: &str, anchor: &str, code: &str, message: &str, end_delta: usize) {
+    let start = src.find(anchor).expect("anchor must occur") as u32;
+    let expected = (
+        code.to_string(),
+        message.to_string(),
+        (start, start + end_delta as u32),
+    );
+    for generate in [GenerateMode::Client, GenerateMode::Server] {
+        assert_eq!(
+            diagnostic(src, generate),
+            Some(expected.clone()),
+            "for {src:?}"
+        );
+    }
+}
+
+const ARGUMENTS_MESSAGE: &str =
+    "The arguments keyword cannot be used within the template or at the top level of a component";
+
+#[test]
+fn arguments_is_rejected_in_every_template_expression_host() {
+    for src in [
+        "{arguments}",
+        "<div title={arguments}></div>",
+        "{#if arguments}<p />{/if}",
+        "{#each arguments as value}<p />{/each}",
+        "{#if true}{@const value = arguments}{/if}",
+        "{@html arguments}",
+        "{arguments.value}",
+        "{arguments['value']}",
+        "{String(arguments)}",
+        "{(() => arguments)()}",
+    ] {
+        assert_error(
+            src,
+            "arguments",
+            "invalid_arguments_usage",
+            ARGUMENTS_MESSAGE,
+            "arguments".len(),
+        );
+    }
+}
+
+#[test]
+fn an_ordinary_function_provides_arguments_but_an_arrow_does_not() {
+    for src in [
+        "{(function () { return arguments })()}",
+        "{(function () { return () => arguments })()}",
+    ] {
+        for generate in [GenerateMode::Client, GenerateMode::Server] {
+            assert_eq!(diagnostic(src, generate), None, "must compile: {src:?}");
+        }
+    }
+
+    assert_error(
+        "{(() => arguments)()}",
+        "arguments",
+        "invalid_arguments_usage",
+        ARGUMENTS_MESSAGE,
+        "arguments".len(),
+    );
+}
+
+const RESERVED_ARGUMENTS: &str =
+    "'arguments' is a reserved word in JavaScript and cannot be used here";
+const RESERVED_EVAL: &str = "'eval' is a reserved word in JavaScript and cannot be used here";
+
+#[test]
+fn plain_template_bindings_use_the_reserved_word_diagnostic() {
+    for (src, name, message) in [
+        (
+            "{#each [] as arguments}{/each}",
+            "arguments",
+            RESERVED_ARGUMENTS,
+        ),
+        ("{#each [] as value, eval}{/each}", "eval", RESERVED_EVAL),
+        (
+            "{#if true}{@const arguments = 1}{/if}",
+            "arguments",
+            RESERVED_ARGUMENTS,
+        ),
+        ("{#if true}{@const eval = 1}{/if}", "eval", RESERVED_EVAL),
+    ] {
+        assert_error(src, name, "unexpected_reserved_word", message, 0);
+    }
+}
+
+#[test]
+fn destructured_template_bindings_use_the_strict_assignment_diagnostic() {
+    for (src, name) in [
+        ("{#each [] as { arguments }}{/each}", "arguments"),
+        ("{#each [] as [eval]}{/each}", "eval"),
+        (
+            "{#await Promise.resolve() then { arguments }}{/await}",
+            "arguments",
+        ),
+        ("{#await Promise.reject() catch [eval]}{/await}", "eval"),
+        ("{#if true}{@const { arguments } = {}}{/if}", "arguments"),
+        ("{#if true}{@const [eval] = []}{/if}", "eval"),
+    ] {
+        assert_error(
+            src,
+            name,
+            "js_parse_error",
+            &format!("Assigning to {name} in strict mode"),
+            0,
+        );
+    }
+}
+
+#[test]
+fn neighbouring_ordinary_bindings_still_compile() {
+    for src in [
+        "{#each [] as value, index}{value}{index}{/each}",
+        "{#each [] as { value }}{value}{/each}",
+        "{#await Promise.resolve() then { value }}{value}{/await}",
+        "{#if true}{@const { value } = { value: 1 }}{value}{/if}",
+    ] {
+        for generate in [GenerateMode::Client, GenerateMode::Server] {
+            assert_eq!(diagnostic(src, generate), None, "must compile: {src:?}");
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- reject `arguments` references reached through the typed template-expression walker
- distinguish ordinary functions, which provide `arguments`, from arrows, which inherit it
- apply the official restricted-word diagnostic to each indices and `{@const}` bindings
- report Acorn-compatible strict-mode assignment diagnostics for restricted names inside destructuring patterns
- add client/server regression grids for expression hosts, binding hosts, and neighbouring accepted controls

Closes #3707.
Closes #3728.

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`

Per repository guidance, Rust builds and tests were not run locally; CI is the execution oracle.
