### PR TITLE
Preserve legacy reactive dependency parentheses

### DIFF
--- a/.changeset/calm-reactive-parens.md
+++ b/.changeset/calm-reactive-parens.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/compiler": patch
+---
+
+Preserve dependency-thunk parentheses when legacy reactive compound assignments and blocks are rewritten.

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/state_assigns_combined_ast.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/state_assigns_combined_ast.rs
@@ -42,7 +42,7 @@
 
 use std::cell::RefCell;
 
-use oxc_allocator::Allocator;
+use oxc_allocator::{Allocator, ArenaVec, ReplaceWith};
 use oxc_ast::ast::*;
 use oxc_ast_visit::{Visit, walk};
 use oxc_parser::ParseOptions;
@@ -442,9 +442,62 @@ fn transform_state_assigns_in_place(
                 changed: false,
             };
             oxc_ast_visit::VisitMut::visit_program(&mut rewriter, program);
+            if rewriter.changed {
+                restore_legacy_pre_effect_deps(program, allocator);
+            }
             rewriter.changed
         },
     )
+}
+
+/// Preserve the builder-made single-element dependency sequence when this pass
+/// reprints a generated legacy reactive statement.
+///
+/// The reactive transform emits `() => (dep)` because upstream builds the body
+/// as a `SequenceExpression`. Parsing that generated text produces a
+/// `ParenthesizedExpression`, which esrap correctly prints without redundant
+/// parentheses. Rebuild only the known generated thunk; ordinary source
+/// parentheses must keep following the parser/printer rules.
+fn restore_legacy_pre_effect_deps<'a>(program: &mut Program<'a>, allocator: &'a Allocator) {
+    let ab = oxc_ast::builder::AstBuilder::new(allocator);
+    for stmt in program.body.iter_mut() {
+        let Statement::ExpressionStatement(es) = stmt else {
+            continue;
+        };
+        let Expression::CallExpression(call) = &mut es.expression else {
+            continue;
+        };
+        let Expression::StaticMemberExpression(member) = &call.callee else {
+            continue;
+        };
+        if !matches!(&member.object, Expression::Identifier(id) if id.name == "$")
+            || member.property.name != "legacy_pre_effect"
+        {
+            continue;
+        }
+        let Some(Argument::ArrowFunctionExpression(arrow)) = call.arguments.first_mut() else {
+            continue;
+        };
+        let Some(body) = arrow.get_expression_mut() else {
+            continue;
+        };
+        if !matches!(&*body, Expression::ParenthesizedExpression(paren)
+            if !matches!(paren.expression, Expression::SequenceExpression(_)))
+        {
+            continue;
+        }
+        body.replace_with(|expression| {
+            let Expression::ParenthesizedExpression(paren) = expression else {
+                unreachable!()
+            };
+            let span = paren.span;
+            Expression::SequenceExpression(SequenceExpression::boxed(
+                span,
+                ArenaVec::from_value_in(paren.unbox().expression, &ab),
+                &ab,
+            ))
+        });
+    }
 }
 
 #[derive(Clone, Copy)]

--- a/crates/rsvelte_core/tests/legacy_pre_effect_parens_3411_3579.rs
+++ b/crates/rsvelte_core/tests/legacy_pre_effect_parens_3411_3579.rs
@@ -1,0 +1,61 @@
+//! Regression coverage for the two reactive statement forms whose generated
+//! dependency thunk was reprinted by the state-assignment pass (issues #3411
+//! and #3579). Upstream builds even one dependency as a sequence, so its
+//! redundant-looking parentheses are part of output parity.
+
+use rsvelte_core::{CompileOptions, GenerateMode, compile, compiler::CssMode};
+
+fn client(src: &str) -> String {
+    compile(
+        src,
+        CompileOptions {
+            filename: Some("main.svelte".to_string()),
+            generate: GenerateMode::Client,
+            dev: false,
+            css: CssMode::External,
+            ..Default::default()
+        },
+    )
+    .expect("compile")
+    .js
+    .code
+}
+
+#[test]
+fn compound_assignment_keeps_single_dependency_parens() {
+    let out = client(
+        r#"<script>
+	let q;
+	$: q += 1;
+</script>
+<p>{q}</p>
+"#,
+    );
+
+    assert!(
+        out.contains("$.legacy_pre_effect(() => ($.get(q)), () => {")
+            && out.contains("$.set(q, $.get(q) + 1);"),
+        "generated reactive statement diverged:\n{out}"
+    );
+}
+
+#[test]
+fn bare_block_keeps_single_dependency_parens() {
+    let out = client(
+        r#"<script>
+	let d = 0;
+	$: {
+		let x = 1;
+		d += x;
+	}
+</script>
+<b>{d}</b>
+"#,
+    );
+
+    assert!(
+        out.contains("$.legacy_pre_effect(() => ($.get(d)), () => {")
+            && out.contains("$.set(d, $.get(d) + x);"),
+        "generated reactive block diverged:\n{out}"
+    );
+}


### PR DESCRIPTION
## Summary

- preserve the upstream single-element dependency sequence when the state-assignment AST pass reprints a generated legacy reactive statement
- cover both the compound-assignment and bare-block forms that reached this intermediate printer
- leave ordinary user-authored parentheses under the existing parser/printer behavior

Closes #3411.
Closes #3579.

## Verification

- `cargo fmt --all -- --check`
- `git diff --check`
- `node scripts/ci/check-upstream-issues.mjs`
- full builds and tests deferred to CI per repository workflow
