### PR TITLE
Fix legacy export const diagnostic precedence

### DIFF
--- a/.changeset/quiet-dragons-agree.md
+++ b/.changeset/quiet-dragons-agree.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/compiler": patch
+---
+
+Match Svelte's legacy export-const diagnostic precedence when an exported constant is updated and referenced from the template.

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/mod.rs
@@ -413,6 +413,7 @@ pub(crate) fn analyze_prepared_component_with_retained(
     let has_export = memchr::memmem::find(source.as_bytes(), b"export").is_some();
     if !analysis.runes && has_export {
         process_legacy_exports(ast, &mut analysis);
+        promote_legacy_export_const_state_bindings(ast, &mut analysis);
     }
 
     // Validate and analyze scripts (JavaScript AST)
@@ -1832,6 +1833,73 @@ fn process_legacy_exports(ast: &Root, analysis: &mut ComponentAnalysis) {
                 }
             }
             _ => {}
+        }
+    }
+}
+
+/// Promote a directly declared legacy `export const` before script validation
+/// when it is updated and referenced by the template.
+///
+/// Upstream builds the complete scope reference graph before analysis, then
+/// performs legacy state promotion before visiting the export declaration. Its
+/// `state_invalid_export` diagnostic therefore outranks a later
+/// `constant_assignment` at the write. Our full reference lists are populated
+/// visitor-time, so the scope builder carries this narrow, scope-resolved fact
+/// forward to preserve the same precedence without a name-only pre-scan.
+fn promote_legacy_export_const_state_bindings(ast: &Root, analysis: &mut ComponentAnalysis) {
+    use crate::ast::typed_expr::JsNode;
+
+    let Some(instance) = &ast.instance else {
+        return;
+    };
+    let JsNode::Program { body, .. } = instance.content.as_node().as_ref() else {
+        return;
+    };
+    let instance_scope = analysis.root.instance_scope_index;
+    let arena = &ast.arena;
+
+    for statement in arena.get_js_children(*body) {
+        let JsNode::ExportNamedDeclaration {
+            declaration: Some(declaration),
+            ..
+        } = statement
+        else {
+            continue;
+        };
+        let JsNode::VariableDeclaration {
+            kind, declarations, ..
+        } = arena.get_js_node(*declaration)
+        else {
+            continue;
+        };
+        if kind != "const" {
+            continue;
+        }
+
+        for declarator in arena.get_js_children(*declarations) {
+            let JsNode::VariableDeclarator { id, .. } = declarator else {
+                continue;
+            };
+            let mut names = Vec::new();
+            pattern_ids::collect_pattern_identifiers(arena.get_js_node(*id), arena, &mut names);
+            for name in names {
+                let Some(&binding_idx) = analysis.root.all_scopes[instance_scope]
+                    .declarations
+                    .get(&name)
+                else {
+                    continue;
+                };
+                let binding = &analysis.root.bindings[binding_idx];
+                if binding.kind == BindingKind::Normal
+                    && binding.is_updated()
+                    && analysis
+                        .root
+                        .preanalysis_template_references
+                        .contains(&binding_idx)
+                {
+                    analysis.root.bindings[binding_idx].kind = BindingKind::State;
+                }
+            }
         }
     }
 }

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/mod.rs
@@ -1852,7 +1852,8 @@ fn promote_legacy_export_const_state_bindings(ast: &Root, analysis: &mut Compone
     let Some(instance) = &ast.instance else {
         return;
     };
-    let JsNode::Program { body, .. } = instance.content.as_node().as_ref() else {
+    let content = instance.content.as_node();
+    let JsNode::Program { body, .. } = content.as_ref() else {
         return;
     };
     let instance_scope = analysis.root.instance_scope_index;

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/scope.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/scope.rs
@@ -61,6 +61,11 @@ pub struct ScopeRoot {
     /// bindings to lexically reachable scopes (mirrors upstream
     /// `scope.evaluate`, which resolves identifiers through the scope chain).
     pub snippet_scope_indices: FxHashSet<usize>,
+    /// Binding indices resolved from template expressions while scopes are
+    /// built. Unlike `Binding::references`, this is available before the
+    /// analysis visitors run, which is needed for diagnostics whose precedence
+    /// depends on upstream's already-complete scope reference graph.
+    pub(crate) preanalysis_template_references: FxHashSet<usize>,
     /// All declaration names from all scopes, used for unique name generation.
     /// Mirrors the `conflicts` set in the official Svelte compiler's ScopeRoot.
     /// Every `declare()` call adds the name here.
@@ -95,6 +100,7 @@ impl ScopeRoot {
             root_fragment_scope_index: 0,
             each_fallback_scope_map: FxHashMap::default(),
             snippet_scope_indices: FxHashSet::default(),
+            preanalysis_template_references: FxHashSet::default(),
             conflicts: FxHashSet::default(),
             bindings_by_name: FxHashMap::default(),
             reference_bindings: std::cell::OnceCell::new(),

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/scope_builder.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/scope_builder.rs
@@ -12,7 +12,7 @@ use crate::ast::template::{
     SnippetBlock, TemplateNode,
 };
 use crate::ast::typed_expr::{JsNode, LiteralValue};
-use rustc_hash::FxHashMap;
+use rustc_hash::{FxHashMap, FxHashSet};
 
 use oxc_allocator::Allocator;
 use oxc_ast::ast::{
@@ -103,6 +103,10 @@ pub struct ScopeBuilder<'a> {
     /// Scope indices created for `{#snippet …}` bodies (see
     /// `ScopeRoot::snippet_scope_indices`).
     snippet_scope_indices: rustc_hash::FxHashSet<usize>,
+    /// Scope-resolved binding indices read or written by template expressions.
+    /// This is deliberately separate from `Binding` so its cost is paid once
+    /// per component rather than once per binding.
+    preanalysis_template_references: FxHashSet<usize>,
     /// Identifier names found in template expression arrow function parameters.
     /// These need to be in the conflicts set so that generated variable names
     /// (like `node`, `$$array`, etc.) don't collide with them.
@@ -158,6 +162,7 @@ impl<'a> ScopeBuilder<'a> {
             root_fragment_scope_index: 0,
             each_fallback_scope_map: FxHashMap::default(),
             snippet_scope_indices: rustc_hash::FxHashSet::default(),
+            preanalysis_template_references: FxHashSet::default(),
             template_expression_params: Vec::new(),
             nested_declared_names: rustc_hash::FxHashSet::default(),
             bindings_by_name: FxHashMap::default(),
@@ -375,6 +380,7 @@ impl<'a> ScopeBuilder<'a> {
                 root_fragment_scope_index: self.root_fragment_scope_index,
                 each_fallback_scope_map: self.each_fallback_scope_map,
                 snippet_scope_indices: self.snippet_scope_indices,
+                preanalysis_template_references: self.preanalysis_template_references,
                 conflicts,
                 bindings_by_name: self.bindings_by_name,
                 reference_bindings: std::cell::OnceCell::new(),
@@ -2744,6 +2750,23 @@ impl<'a> ScopeBuilder<'a> {
             }
             TemplateNode::ConstTag(tag) => self.visit_const_tag(tag),
             TemplateNode::DeclarationTag(tag) => self.visit_declaration_tag(tag),
+            TemplateNode::ExpressionTag(tag) => {
+                self.process_template_expression(&tag.expression);
+            }
+            TemplateNode::HtmlTag(tag) => {
+                self.process_template_expression(&tag.expression);
+            }
+            TemplateNode::DebugTag(tag) => {
+                for identifier in &tag.identifiers {
+                    self.process_template_expression(identifier);
+                }
+            }
+            TemplateNode::RenderTag(tag) => {
+                self.process_template_expression(&tag.expression);
+            }
+            TemplateNode::AttachTag(tag) => {
+                self.process_template_expression(&tag.expression);
+            }
             // SvelteBoundary gets its own scope so that {@const} declarations
             // inside separate <svelte:boundary> blocks don't conflict.
             TemplateNode::SvelteBoundary(elem) => {
@@ -2969,6 +2992,9 @@ impl<'a> ScopeBuilder<'a> {
                         transition_dir.start,
                         transition_dir.end,
                     );
+                    if let Some(expression) = &transition_dir.expression {
+                        self.process_template_expression(expression);
+                    }
                 }
                 Attribute::AnimateDirective(animate_dir) => {
                     // "animate:".len() == 8
@@ -2979,6 +3005,9 @@ impl<'a> ScopeBuilder<'a> {
                         animate_dir.start,
                         animate_dir.end,
                     );
+                    if let Some(expression) = &animate_dir.expression {
+                        self.process_template_expression(expression);
+                    }
                 }
                 Attribute::SpreadAttribute(spread) => {
                     // Process spread attribute expression
@@ -3032,6 +3061,18 @@ impl<'a> ScopeBuilder<'a> {
         let binding = &mut self.bindings[binding_idx];
         binding.add_reference(start, end, true, false, false);
         binding.has_direct_template_read = true;
+        self.preanalysis_template_references.insert(binding_idx);
+    }
+
+    /// Record the binding a template identifier resolves to before the Phase 2
+    /// visitors populate the full reference lists.
+    fn record_preanalysis_template_reference(&mut self, name: &str) {
+        if !self.in_template {
+            return;
+        }
+        if let Some(binding_idx) = self.find_binding_in_scope_chain(name) {
+            self.preanalysis_template_references.insert(binding_idx);
+        }
     }
 
     /// Process a template expression (from attributes, event handlers, etc.) to track updates.
@@ -3068,6 +3109,7 @@ impl<'a> ScopeBuilder<'a> {
 
             // For direct Identifier (bind:value={x}), mark as reassigned
             JsNode::Identifier { name, .. } => {
+                self.record_preanalysis_template_reference(name);
                 self.updates.push(Update {
                     name: name.to_string(),
                     is_direct_assignment: true,
@@ -3086,6 +3128,7 @@ impl<'a> ScopeBuilder<'a> {
                             current_id = *object;
                         }
                         JsNode::Identifier { name, .. } => {
+                            self.record_preanalysis_template_reference(name);
                             self.updates.push(Update {
                                 name: name.to_string(),
                                 is_direct_assignment: false, // mutation, not reassignment
@@ -3265,13 +3308,14 @@ impl<'a> ScopeBuilder<'a> {
             JsNode::ChainExpression { expression, .. } => {
                 self.track_node_expression_updates(self.arena.get_js_node(*expression));
             }
-            JsNode::Identifier { name, .. }
+            JsNode::Identifier { name, .. } => {
+                self.record_preanalysis_template_reference(name);
                 // Check for store subscription scoping errors
                 if name.starts_with('$')
                     && !name.starts_with("$$")
                     && name.len() > 1
                     && self.function_depth > 0
-                => {
+                {
                     let is_rune_name = matches!(
                         name.as_str(),
                         "$state"
@@ -3286,6 +3330,7 @@ impl<'a> ScopeBuilder<'a> {
                         self.check_store_scoped_subscription(&name.as_str()[1..]);
                     }
                 }
+            }
             JsNode::ClassExpression { body, .. } => {
                 let body_id = *body;
                 // Walk class body looking for method/property updates
@@ -3338,6 +3383,7 @@ impl<'a> ScopeBuilder<'a> {
     fn track_node_assignment_target(&mut self, node: &JsNode) {
         match node {
             JsNode::Identifier { name, .. } => {
+                self.record_preanalysis_template_reference(name);
                 // Check for store subscription errors in assignment targets
                 if name.starts_with('$')
                     && !name.starts_with("$$")
@@ -3368,6 +3414,7 @@ impl<'a> ScopeBuilder<'a> {
                 if let Some(name) =
                     base_identifier_name(self.arena.get_js_node(*object), self.arena)
                 {
+                    self.record_preanalysis_template_reference(&name);
                     self.updates.push(Update {
                         name,
                         is_direct_assignment: false,
@@ -3405,6 +3452,7 @@ impl<'a> ScopeBuilder<'a> {
     fn track_node_simple_assignment_target(&mut self, node: &JsNode) {
         match node {
             JsNode::Identifier { name, .. } => {
+                self.record_preanalysis_template_reference(name);
                 self.updates.push(Update {
                     name: name.to_string(),
                     is_direct_assignment: true,
@@ -3415,6 +3463,7 @@ impl<'a> ScopeBuilder<'a> {
                 if let Some(name) =
                     base_identifier_name(self.arena.get_js_node(*object), self.arena)
                 {
+                    self.record_preanalysis_template_reference(&name);
                     self.updates.push(Update {
                         name,
                         is_direct_assignment: false,

--- a/crates/rsvelte_core/tests/error_check_precedence_3262_3268.rs
+++ b/crates/rsvelte_core/tests/error_check_precedence_3262_3268.rs
@@ -9,11 +9,12 @@
 //!   their whole "does this element take arbitrary attributes at all" loop before
 //!   `context.next()` descends into any `bind:`. rsvelte validated the `bind:`
 //!   target first.
-//! - #3262 (**open**, pinned in `KNOWN_3262` below): upstream promotes a legacy
+//! - #3262 (**fixed here**): upstream promotes a legacy
 //!   `export const` that the template writes to `state` (`2-analyze/index.js`
 //!   L627-645) and then rejects the **export** from `ExportNamedDeclaration`
-//!   during the *instance* walk. rsvelte cannot do that yet — see the comment on
-//!   `KNOWN_3262` for the measurement that says why.
+//!   during the *instance* walk. The scope builder now carries its already
+//!   resolved template-reference set into analysis so the export diagnostic has
+//!   the same precedence.
 //!
 //! Every expectation was measured on the official compiler in a fresh process,
 //! and is compared on `(code, message, start, end)` for an error and on the full
@@ -58,50 +59,7 @@ fn observed(src: &str, generate: GenerateMode) -> Observed {
     }
 }
 
-/// Cells rsvelte still gets wrong, recorded with the answer it produces today.
-/// A two-sided pin: if rsvelte's answer changes at all — including to upstream's —
-/// the assertion fails and the row has to move into the grid proper.
-///
-/// #3262 stays open because closing it needs binding **references** to be
-/// collected before the visitor walk, the way upstream's `create_scopes` does.
-/// rsvelte collects them *during* the walk (`visitors/identifier.rs`), so when
-/// `ExportNamedDeclaration` is visited a legacy `export const` the template writes
-/// to is still `Normal` — `promote_legacy_state_bindings` cannot have run yet — and
-/// `state_invalid_export` therefore cannot fire. The template-reference half of
-/// upstream's criterion is load-bearing rather than incidental: the
-/// `export_const_written_not_in_template` row is `constant_assignment` on both
-/// sides, so "is it updated" alone does not decide it.
-#[rustfmt::skip]
-const KNOWN_3262: &[(&str, &str, (u32, u32))] = &[
-    ("export_const/handler_assign", "constant_assignment", (63, 68)),
-    ("export_const/handler_update", "constant_assignment", (63, 66)),
-    ("export_const/script_fn_assign", "constant_assignment", (46, 51)),
-    ("export_const/bind_value", "constant_binding", (47, 61)),
-    ("export_const_destructured/handler_assign", "constant_assignment", (74, 79)),
-    ("export_const_destructured/handler_update", "constant_assignment", (74, 77)),
-    ("export_const_destructured/script_fn_assign", "constant_assignment", (57, 62)),
-    ("export_const_destructured/bind_value", "constant_binding", (58, 72)),
-    ("export_const_array/handler_assign", "constant_assignment", (67, 72)),
-    ("export_const_array/handler_update", "constant_assignment", (67, 70)),
-    ("export_const_array/script_fn_assign", "constant_assignment", (50, 55)),
-    ("export_const_array/bind_value", "constant_binding", (51, 65)),
-];
-
 fn check(id: &str, src: &str, expect: &Expect) {
-    if let Some((_, want_code, want_span)) = KNOWN_3262.iter().find(|(i, _, _)| *i == id) {
-        for generate in [GenerateMode::Client, GenerateMode::Server] {
-            let Err((code, _, span)) = observed(src, generate) else {
-                panic!("[{id}] generate={generate:?}: #3262 row unexpectedly compiles");
-            };
-            assert_eq!(code, *want_code, "[{id}] generate={generate:?} #3262 code");
-            assert_eq!(
-                span,
-                Some(*want_span),
-                "[{id}] generate={generate:?} #3262 span"
-            );
-        }
-        return;
-    }
     for generate in [GenerateMode::Client, GenerateMode::Server] {
         match (observed(src, generate), expect) {
             (Ok(warnings), Expect::Ok(want)) => {


### PR DESCRIPTION
## Summary

- carry scope-resolved template binding references from scope construction into early analysis
- promote directly declared legacy `export const` bindings before the instance visitor when upstream's updated-and-template-referenced criterion applies
- turn all 12 pinned #3262 divergences into exact client/server diagnostic parity assertions

## Why

Upstream constructs its complete scope reference graph before analysis and performs legacy state promotion before visiting exports. rsvelte populated full references during the visitor walk, so a later write produced `constant_assignment` or `constant_binding` before the export could produce `state_invalid_export`.

The pre-analysis set stores binding indices rather than names, preserving template shadowing behavior. The promotion is intentionally restricted to direct legacy `export const` declarations, leaving renamed specifier exports, runes mode, and constants without a qualifying template reference unchanged.

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- full build and test validation deferred to CI as requested

Fixes #3262
