### PR TITLE
fix(compiler): finish template comment cursor parity

### DIFF
--- a/.changeset/template-block-expression-comments.md
+++ b/.changeset/template-block-expression-comments.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/compiler": patch
+---
+
+Comments inside template block and directive expressions now follow the official compiler's source cursor on client and server output, including each collections, if and key tests, html and render arguments, and event handlers.

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/source_anchor.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/source_anchor.rs
@@ -65,7 +65,11 @@ impl CommentRegion {
             oxc_span::SourceType::mjs().with_typescript(true),
         )
         .parse();
-        if !ret.diagnostics.is_empty() || ret.program.comments.is_empty() {
+        // A caller may deliberately span template punctuation between two
+        // source nodes (for example an each header and a following `{@const}`).
+        // The slice is not necessarily a valid JS program, but the lexer still
+        // reports its comments accurately.
+        if ret.program.comments.is_empty() {
             return None;
         }
         let comments = ret
@@ -101,6 +105,26 @@ impl CommentRegion {
             comments: self.comments.clone(),
             at,
             at_end,
+            preserve_inner_spans: false,
+        }))
+    }
+
+    /// As [`Self::anchor`], but retain source spans on descendants of a
+    /// generated wrapper. This is needed when upstream's cursor reaches an
+    /// original identifier inside a rebuilt array/call before it reaches the
+    /// wrapper itself.
+    pub fn anchor_inner(&self, arena: &JsArena, expr: JsExpr, at: u32, at_end: u32) -> JsExpr {
+        if at < self.start || at_end > self.end {
+            return expr;
+        }
+        JsExpr::SourceAnchored(Box::new(JsSourceAnchor {
+            inner: arena.alloc_expr(expr),
+            region_start: self.start,
+            region: self.text.clone(),
+            comments: self.comments.clone(),
+            at,
+            at_end,
+            preserve_inner_spans: true,
         }))
     }
 }

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/source_anchor.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/source_anchor.rs
@@ -37,8 +37,19 @@ impl CommentRegion {
         tag: &ExpressionTag<'_>,
         from: u32,
     ) -> Option<Self> {
+        Self::between(state, tag.start + 1, tag.end.saturating_sub(1), from)
+    }
+
+    /// Comments in an arbitrary source region containing a template
+    /// expression. Block/directive visitors use this for regions whose opener
+    /// is longer than `{` (for example `{#each ` and `{@html `).
+    pub fn between(
+        state: &ComponentClientTransformState<'_>,
+        inner_start: u32,
+        inner_end: u32,
+        from: u32,
+    ) -> Option<Self> {
         let source: &str = &state.options.source;
-        let (inner_start, inner_end) = (tag.start + 1, tag.end.saturating_sub(1));
         if inner_end <= inner_start || inner_end as usize > source.len() || from > inner_start {
             return None;
         }

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/source_anchor.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/source_anchor.rs
@@ -18,6 +18,7 @@ use super::types::ComponentClientTransformState;
 use crate::ast::template::ExpressionTag;
 use crate::compiler::phases::phase3_transform::js_ast::arena::JsArena;
 use crate::compiler::phases::phase3_transform::js_ast::nodes::{JsExpr, JsSourceAnchor};
+use crate::compiler::phases::phase3_transform::shared::js_scan;
 use compact_str::CompactString;
 
 /// One `{ … }` region and the comments written in it.
@@ -67,12 +68,9 @@ impl CommentRegion {
         .parse();
         // A caller may deliberately span template punctuation between two
         // source nodes (for example an each header and a following `{@const}`).
-        // The slice is not necessarily a valid JS program, but the lexer still
-        // reports its comments accurately.
-        if ret.program.comments.is_empty() {
-            return None;
-        }
-        let comments = ret
+        // Preserve whatever comments the parser reaches, then supplement them
+        // below when that punctuation stops parsing early.
+        let mut comments: Vec<_> = ret
             .program
             .comments
             .iter()
@@ -85,6 +83,27 @@ impl CommentRegion {
                 )
             })
             .collect();
+        // Some callers deliberately include Svelte template punctuation or a
+        // declaration such as `const c = ...`. Such a slice is not a valid
+        // parenthesized expression, and the parser can stop before lexing a
+        // later comment. Supplement its results with the shared opaque-aware
+        // scanner. Keeping both matters for comments inside `${...}`, which
+        // the parser sees while the scanner treats the template as opaque.
+        for (relative_start, relative_end) in js_scan::comment_ranges(inner.as_bytes()) {
+            let line = inner.as_bytes()[relative_start + 1] == b'/';
+            let start = relative_start as u32 + inner_start;
+            let end = relative_end as u32 + inner_start;
+            if comments.iter().any(|&(comment_start, comment_end, _)| {
+                comment_start == start && comment_end == end
+            }) {
+                continue;
+            }
+            comments.push((start, end, line));
+        }
+        if comments.is_empty() {
+            return None;
+        }
+        comments.sort_unstable_by_key(|&(start, _, _)| start);
         Some(Self {
             start: from,
             end: inner_end,

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/attribute.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/attribute.rs
@@ -4,6 +4,7 @@
 //! `svelte/packages/svelte/src/compiler/phases/3-transform/client/visitors/Attribute.js`.
 
 use crate::ast::template::{Attribute, AttributeNode};
+use crate::compiler::phases::phase3_transform::client::source_anchor::CommentRegion;
 use crate::compiler::phases::phase3_transform::client::types::ComponentContext;
 use crate::compiler::phases::phase3_transform::client::visitors::shared::events::{
     build_event, convert_arrow_to_named_function,
@@ -176,12 +177,18 @@ pub fn visit_event_attribute(node: &AttributeNode, context: &mut ComponentContex
     // Only generate a name if the handler is actually an arrow function, to avoid consuming
     // names from the conflicts set unnecessarily.
     // Reference: events.js build_event(): `if (dev && handler.type === 'ArrowFunctionExpression')`
-    let handler = if context.state.options.dev && matches!(handler, JsExpr::Arrow(_)) {
+    let mut handler = if context.state.options.dev && matches!(handler, JsExpr::Arrow(_)) {
         let name = context.state.memoizer.generate_id(event_name);
         convert_arrow_to_named_function(handler, name.into())
     } else {
         handler
     };
+
+    if let (Some(start), Some(end)) = (expr_tag.expression.start(), expr_tag.expression.end())
+        && let Some(region) = CommentRegion::of(&context.state, expr_tag, expr_tag.start + 1)
+    {
+        handler = region.anchor(&context.arena, handler, start, end);
+    }
 
     let statement = b::stmt(
         &context.arena,

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/attribute.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/attribute.rs
@@ -187,7 +187,7 @@ pub fn visit_event_attribute(node: &AttributeNode, context: &mut ComponentContex
     if let (Some(start), Some(end)) = (expr_tag.expression.start(), expr_tag.expression.end())
         && let Some(region) = CommentRegion::of(&context.state, expr_tag, expr_tag.start + 1)
     {
-        handler = region.anchor(&context.arena, handler, start, end);
+        handler = region.anchor_inner(&context.arena, handler, start, end);
     }
 
     let statement = b::stmt(

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/each_block.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/each_block.rs
@@ -94,7 +94,7 @@ pub fn each_block(node: &EachBlock, context: &mut ComponentContext) {
         && let Some(region) =
             CommentRegion::between(&context.state, node.start + 7, end, node.start + 7)
     {
-        collection = region.anchor(&context.arena, collection, start, end);
+        collection = region.anchor_inner(&context.arena, collection, start, end);
     }
 
     // Add comment placeholder for uncontrolled blocks
@@ -515,7 +515,20 @@ pub fn each_block(node: &EachBlock, context: &mut ComponentContext) {
     let key_function = build_key_function(node, context, key_uses_index, &index);
 
     // Build render arguments: ($$anchor, item, [index], [collection_id])
-    let render_args = build_render_args(&index, &item, uses_index, collection_id.as_ref());
+    let mut render_args = build_render_args(&index, &item, uses_index, collection_id.as_ref());
+    if let Some(TemplateNode::ConstTag(tag)) = node.body.nodes.first()
+        && let (Some(item_start), Some(item_end), Some(comment_start), Some(comment_end)) = (
+            node.context.as_ref().and_then(|e| e.start()),
+            node.context.as_ref().and_then(|e| e.end()),
+            tag.declaration.start(),
+            tag.declaration.end(),
+        )
+        && let Some(region) =
+            CommentRegion::between(&context.state, comment_start, comment_end, node.start + 7)
+        && let Some(item) = render_args.get_mut(1)
+    {
+        *item = region.anchor(&context.arena, item.clone(), item_start, item_end);
+    }
 
     // Combine declarations and body statements
     // This matches JS: b.arrow(render_args, b.block(declarations.concat(block.body)))

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/each_block.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/each_block.rs
@@ -515,8 +515,8 @@ pub fn each_block(node: &EachBlock, context: &mut ComponentContext) {
     let key_function = build_key_function(node, context, key_uses_index, &index);
 
     // Build render arguments: ($$anchor, item, [index], [collection_id])
-    let mut render_args = build_render_args(&index, &item, uses_index, collection_id.as_ref());
-    if let Some(TemplateNode::ConstTag(tag)) = node.body.nodes.first()
+    let render_args = build_render_args(&index, &item, uses_index, collection_id.as_ref());
+    let const_comment_region = if let Some(TemplateNode::ConstTag(tag)) = node.body.nodes.first()
         && let (Some(item_start), Some(item_end), Some(comment_start), Some(comment_end)) = (
             node.context.as_ref().and_then(|e| e.start()),
             node.context.as_ref().and_then(|e| e.end()),
@@ -525,10 +525,11 @@ pub fn each_block(node: &EachBlock, context: &mut ComponentContext) {
         )
         && let Some(region) =
             CommentRegion::between(&context.state, comment_start, comment_end, node.start + 7)
-        && let Some(item) = render_args.get_mut(1)
     {
-        *item = region.anchor(&context.arena, item.clone(), item_start, item_end);
-    }
+        Some((region, item_start, item_end))
+    } else {
+        None
+    };
 
     // Combine declarations and body statements
     // This matches JS: b.arrow(render_args, b.block(declarations.concat(block.body)))
@@ -536,13 +537,20 @@ pub fn each_block(node: &EachBlock, context: &mut ComponentContext) {
     render_body.extend(body_block.body);
 
     // Build the render function
-    let render_fn = b::arrow_block(
+    let mut render_fn = b::arrow_block(
         render_args
             .iter()
             .map(|expr| convert_expr_to_pattern(expr, &context.arena))
             .collect(),
         render_body,
     );
+    if let Some((region, item_start, item_end)) = const_comment_region {
+        // The source position belongs to the callback identifier. Anchor the
+        // completed arrow so conversion can remap that parameter's existing
+        // `SpannedIdentifier`; wrapping the render argument itself changes its
+        // variant before `convert_expr_to_pattern` and loses the parameter.
+        render_fn = region.anchor_inner(&context.arena, render_fn, item_start, item_end);
+    }
 
     // Handle async expressions
     let has_await = node.metadata.expression.has_await();

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/each_block.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/each_block.rs
@@ -44,6 +44,7 @@ use crate::compiler::phases::phase3_transform::client::types::{
 use crate::compiler::phases::phase3_transform::client::visitors::expression_converter::convert_expression;
 use crate::compiler::phases::phase3_transform::client::visitors::fragment::fragment as visit_fragment_impl;
 // Note: get_value from declarations is available if needed for reactive index/item access
+use crate::compiler::phases::phase3_transform::client::source_anchor::CommentRegion;
 use crate::compiler::phases::phase3_transform::client::types::ExpressionMetadata;
 use crate::compiler::phases::phase3_transform::client::visitors::shared::utils::{
     add_svelte_meta, apply_transforms_to_expression, build_expression,
@@ -88,7 +89,13 @@ pub fn each_block(node: &EachBlock, context: &mut ComponentContext) {
     // Expression should be evaluated in the parent scope, not the scope
     // created by the each block itself
     // Build the collection expression
-    let collection = build_collection_expression(node, context);
+    let mut collection = build_collection_expression(node, context);
+    if let (Some(start), Some(end)) = (node.expression.start(), node.expression.end())
+        && let Some(region) =
+            CommentRegion::between(&context.state, node.start + 7, end, node.start + 7)
+    {
+        collection = region.anchor(&context.arena, collection, start, end);
+    }
 
     // Add comment placeholder for uncontrolled blocks
     if !is_controlled {

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/expression_converter.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/expression_converter.rs
@@ -1164,7 +1164,7 @@ fn convert_js_node(node: &JsNode, context: &mut ComponentContext) -> JsExpr {
                     update_transform,
                     &context.arena,
                     update_op,
-                    JsExpr::Identifier(name_str.into()),
+                    source_spanned(arg_node, JsExpr::Identifier(name_str.into()), context),
                     prefix,
                 );
             }

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/fragment.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/fragment.rs
@@ -293,20 +293,23 @@ pub fn fragment(
 
             // Append to anchor
             let mut append_id = JsExpr::Spanned(context.arena.alloc_expr(id), name_start, name_end);
+            let mut comment_anchored = false;
             if let [TemplateNode::ExpressionTag(tag)] = element.fragment.nodes.as_slice()
                 && let Some(region) = CommentRegion::of(&context.state, tag, name_start)
             {
                 append_id = region.anchor(&context.arena, append_id, name_start, name_end);
+                comment_anchored = true;
             }
-            let append = b::call(
+            let mut append = b::call(
                 &context.arena,
                 b::member_path(&context.arena, "$.append"),
                 vec![b::id("$$anchor"), append_id],
             );
-            close = Some(b::stmt(
-                &context.arena,
-                JsExpr::Spanned(context.arena.alloc_expr(append), element.start, element.end),
-            ));
+            if !comment_anchored {
+                append =
+                    JsExpr::Spanned(context.arena.alloc_expr(append), element.start, element.end);
+            }
+            close = Some(b::stmt(&context.arena, append));
         }
     } else if is_single_child_not_needing_template {
         // Single child not needing template (SvelteFragment or TitleElement)

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/fragment.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/fragment.rs
@@ -10,6 +10,7 @@
 use std::{cell::Cell, rc::Rc};
 
 use crate::ast::template::{Fragment, TemplateNode};
+use crate::compiler::phases::phase3_transform::client::source_anchor::CommentRegion;
 use crate::compiler::phases::phase3_transform::client::transform_template::{
     Namespace, Template, transform_template,
 };
@@ -291,13 +292,16 @@ pub fn fragment(
             );
 
             // Append to anchor
+            let mut append_id = JsExpr::Spanned(context.arena.alloc_expr(id), name_start, name_end);
+            if let [TemplateNode::ExpressionTag(tag)] = element.fragment.nodes.as_slice()
+                && let Some(region) = CommentRegion::of(&context.state, tag, name_start)
+            {
+                append_id = region.anchor(&context.arena, append_id, name_start, name_end);
+            }
             let append = b::call(
                 &context.arena,
                 b::member_path(&context.arena, "$.append"),
-                vec![
-                    b::id("$$anchor"),
-                    JsExpr::Spanned(context.arena.alloc_expr(id), name_start, name_end),
-                ],
+                vec![b::id("$$anchor"), append_id],
             );
             close = Some(b::stmt(
                 &context.arena,

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/html_tag.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/html_tag.rs
@@ -4,6 +4,7 @@
 //! `svelte/packages/svelte/src/compiler/phases/3-transform/client/visitors/HtmlTag.js`.
 
 use crate::ast::template::HtmlTag;
+use crate::compiler::phases::phase3_transform::client::source_anchor::CommentRegion;
 use crate::compiler::phases::phase3_transform::client::types::*;
 use crate::compiler::phases::phase3_transform::client::visitors::expression_converter::convert_expression;
 use crate::compiler::phases::phase3_transform::client::visitors::shared::utils::build_expression;
@@ -52,7 +53,13 @@ pub fn html_tag(node: &HtmlTag, context: &mut ComponentContext) -> JsStatement {
     // reactivity wrapping (deep_read_state/untrack) based on metadata from phase 2.
     // This matches the official compiler's: build_expression(context, node.expression, node.metadata.expression)
     let metadata = ExpressionMetadata::from_template_metadata(&node.metadata.expression);
-    let built_expression = build_expression(context, &expression, &metadata);
+    let mut built_expression = build_expression(context, &expression, &metadata);
+    if let (Some(start), Some(end)) = (node.expression.start(), node.expression.end())
+        && let Some(region) =
+            CommentRegion::between(&context.state, node.start + 7, end, node.start + 7)
+    {
+        built_expression = region.anchor(&context.arena, built_expression, start, end);
+    }
 
     // Check blocker_map for blocked identifiers referenced in the built expression
     let blocker_exprs_for_html = context

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/key_block.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/key_block.rs
@@ -4,6 +4,7 @@
 //! `svelte/packages/svelte/src/compiler/phases/3-transform/client/visitors/KeyBlock.js`.
 
 use crate::ast::template::KeyBlock;
+use crate::compiler::phases::phase3_transform::client::source_anchor::CommentRegion;
 use crate::compiler::phases::phase3_transform::client::types::*;
 use crate::compiler::phases::phase3_transform::client::visitors::expression_converter::convert_expression;
 use crate::compiler::phases::phase3_transform::client::visitors::fragment::fragment;
@@ -38,7 +39,13 @@ pub fn key_block(node: &KeyBlock, context: &mut ComponentContext) -> TransformRe
     // This applies both transforms AND legacy $.untrack() wrapping
     let expression = convert_expression(&node.expression, context);
     let expr_metadata = ExpressionMetadata::from_template_metadata(&node.metadata.expression);
-    let transformed_expression = build_expression(context, &expression, &expr_metadata);
+    let mut transformed_expression = build_expression(context, &expression, &expr_metadata);
+    if let (Some(start), Some(end)) = (node.expression.start(), node.expression.end())
+        && let Some(region) =
+            CommentRegion::between(&context.state, node.start + 6, end, node.start + 6)
+    {
+        transformed_expression = region.anchor(&context.arena, transformed_expression, start, end);
+    }
 
     // Check blocker_map for blocked identifiers referenced in the expression
     let blocker_exprs_for_key = context

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/program.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/program.rs
@@ -338,7 +338,7 @@ fn store_sub_assign(
     b::call(
         arena,
         b::member_path(arena, "$.store_set"),
-        vec![store_source(transform, &node), value],
+        vec![store_source(transform, arena, &node), value],
     )
 }
 
@@ -378,7 +378,7 @@ fn store_sub_mutate(
         arena,
         b::member_path(arena, "$.store_mutate"),
         vec![
-            store_source(transform, &node),
+            store_source(transform, arena, &node),
             transformed_mutation,
             untracked,
         ],
@@ -453,7 +453,7 @@ fn store_sub_update(
     argument: JsExpr,
     prefix: bool,
 ) -> JsExpr {
-    let store = store_source(transform, &argument);
+    let store = store_source(transform, arena, &argument);
 
     let method = if prefix {
         "$.update_pre_store"

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/render_tag.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/render_tag.rs
@@ -8,6 +8,7 @@
 
 use crate::ast::js::Expression;
 use crate::ast::template::RenderTag;
+use crate::compiler::phases::phase3_transform::client::source_anchor::CommentRegion;
 use crate::compiler::phases::phase3_transform::client::types::*;
 use crate::compiler::phases::phase3_transform::client::visitors::expression_converter::convert_expression;
 use crate::compiler::phases::phase3_transform::client::visitors::shared::utils::build_expression;
@@ -54,6 +55,9 @@ pub fn render_tag(node: &RenderTag, context: &mut ComponentContext) -> JsStateme
     // Extract arguments and wrap them in thunks
     // Reference: RenderTag.js lines 22-33
     let raw_args = extract_call_arguments(&call_expr, context.state.parse_arena);
+    let comment_region = node.expression.end().and_then(|end| {
+        CommentRegion::between(&context.state, node.start + 9, end, node.start + 9)
+    });
 
     // Track async values for $.async() wrapping
     let mut async_values: Vec<JsExpr> = Vec::new();
@@ -82,7 +86,12 @@ pub fn render_tag(node: &RenderTag, context: &mut ComponentContext) -> JsStateme
             let template_metadata = node.metadata.arguments.get(i).cloned().unwrap_or_default();
             let metadata = ExpressionMetadata::from_template_metadata(&template_metadata);
             // Apply transforms ($.get() wrapping for reactive state variables)
-            let built = build_expression(context, &converted, &metadata);
+            let mut built = build_expression(context, &converted, &metadata);
+            if let (Some(region), Some(start), Some(end)) =
+                (comment_region.as_ref(), arg.start(), arg.end())
+            {
+                built = region.anchor(&context.arena, built, start, end);
+            }
 
             // Check if this argument has await
             let arg_has_await =

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/declarations.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/declarations.rs
@@ -351,11 +351,19 @@ fn store_sub_read(arena: &JsArena, node: JsExpr) -> JsExpr {
 /// Upstream's `get_store()`: how the store variable behind a `$store`
 /// subscription reads. Resolved once per transform map, so a single pass
 /// already produces the final form instead of relying on a second visit.
-pub(crate) fn store_source(transform: &IdentifierTransform, node: &JsExpr) -> JsExpr {
+pub(crate) fn store_source(
+    transform: &IdentifierTransform,
+    arena: &JsArena,
+    node: &JsExpr,
+) -> JsExpr {
     if let Some(ref resolved) = transform.store_source {
         return resolved.clone();
     }
-    let name = match node {
+    let mut unspanned = node;
+    while let JsExpr::Spanned(inner, _, _) = unspanned {
+        unspanned = arena.get_expr(*inner);
+    }
+    let name = match unspanned {
         JsExpr::Identifier(name) => name.strip_prefix('$').unwrap_or(name).to_string(),
         _ => "unknown".to_string(),
     };
@@ -386,7 +394,7 @@ fn store_sub_assign(
     b::svelte_call(
         arena,
         "store_set",
-        vec![store_source(transform, &node), value],
+        vec![store_source(transform, arena, &node), value],
     )
 }
 
@@ -427,7 +435,7 @@ fn store_sub_mutate(
         arena,
         b::member_path(arena, "$.store_mutate"),
         vec![
-            store_source(transform, &node),
+            store_source(transform, arena, &node),
             transformed_mutation,
             untracked,
         ],
@@ -510,7 +518,7 @@ fn store_sub_update(
 
     // Build args: store, $store()
     let mut args = vec![
-        store_source(transform, &argument),
+        store_source(transform, arena, &argument),
         b::call(arena, argument.clone(), vec![]), // $store()
     ];
 
@@ -840,6 +848,18 @@ mod tests {
             replacement_id: None,
             store_source: None,
         }
+    }
+
+    #[test]
+    fn store_source_reads_through_a_source_span() {
+        let arena = JsArena::new();
+        let inner = arena.alloc_expr(b::id("$count"));
+        let node = JsExpr::Spanned(inner, 10, 16);
+
+        assert!(matches!(
+            store_source(&noop_transform(), &arena, &node),
+            JsExpr::Identifier(name) if name == "count"
+        ));
     }
 
     #[test]

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/js_ast/nodes.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/js_ast/nodes.rs
@@ -468,6 +468,9 @@ pub struct JsSourceAnchor {
     /// Absolute source span this node claims as its location.
     pub at: u32,
     pub at_end: u32,
+    /// Preserve source spans carried by descendants, remapping them into the
+    /// synthetic comment region. Generated wrappers stay location-less.
+    pub preserve_inner_spans: bool,
 }
 
 /// Literal value.

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/js_ast/to_oxc.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/js_ast/to_oxc.rs
@@ -68,6 +68,7 @@ use oxc_syntax::operator::{
 };
 use rsvelte_esrap::LocRange;
 use std::cell::RefCell;
+use std::collections::HashSet;
 
 /// A converted program plus the comment coordinate space it needs to be printed
 /// in (see the module docs). `comment_source` is `None` for the common
@@ -417,6 +418,11 @@ struct Synth {
     source: String,
     loc_base: u32,
     comments: Vec<Comment>,
+    /// Original-source comment ranges already copied into an anchored region.
+    /// Overlapping [`JsSourceAnchor`] regions share the upstream comment
+    /// cursor, so the same source comment must only enter the synthetic buffer
+    /// once even when their `region_start`s differ.
+    source_comments: HashSet<(u32, u32)>,
     /// Comment-space ranges resolving back to original-source offsets, for
     /// source maps: one per chunk region, plus one per reserved anchor.
     loc_map: Vec<LocRange>,
@@ -452,6 +458,7 @@ impl Synth {
             source,
             loc_base,
             comments: Vec::new(),
+            source_comments: HashSet::new(),
             loc_map: Vec::new(),
             pending_region: None,
             last_region_source: None,
@@ -653,27 +660,25 @@ impl<'a, 'arena, 'source> Cx<'a, 'arena, 'source> {
             synth.source.push_str(&anchor.region);
             synth.source.push('\n');
             let region_start = anchor.region_start;
-            synth.comments.extend(
-                anchor
-                    .comments
-                    .iter()
-                    .map(|&(start, end, line)| -> Comment {
-                        let start = base + (start - region_start);
-                        let end = base + (end - region_start);
-                        let kind = if line {
-                            CommentKind::Line
-                        } else if anchor.region[(start - base) as usize..(end - base) as usize]
-                            .contains('\n')
-                        {
-                            CommentKind::MultiLineBlock
-                        } else {
-                            CommentKind::SingleLineBlock
-                        };
-                        let mut comment = Comment::new(start, end, kind);
-                        comment.attached_to = end;
-                        comment
-                    }),
-            );
+            for &(source_start, source_end, line) in &anchor.comments {
+                if !synth.source_comments.insert((source_start, source_end)) {
+                    continue;
+                }
+                let start = base + (source_start - region_start);
+                let end = base + (source_end - region_start);
+                let kind = if line {
+                    CommentKind::Line
+                } else if anchor.region[(start - base) as usize..(end - base) as usize]
+                    .contains('\n')
+                {
+                    CommentKind::MultiLineBlock
+                } else {
+                    CommentKind::SingleLineBlock
+                };
+                let mut comment = Comment::new(start, end, kind);
+                comment.attached_to = end;
+                synth.comments.push(comment);
+            }
             synth.open_source_region = Some(anchor.region_start);
             synth.open_source_base = base;
         }

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/js_ast/to_oxc.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/js_ast/to_oxc.rs
@@ -1581,7 +1581,21 @@ impl<'a, 'arena, 'source> Cx<'a, 'arena, 'source> {
             JsExpr::SourceAnchored(anchor) => {
                 let mut e = self.expr_id(anchor.inner)?;
                 if let Some(span) = self.open_source_region(anchor) {
-                    *e.span_mut() = span;
+                    if anchor.preserve_inner_spans {
+                        let base = span.start - (anchor.at - anchor.region_start);
+                        let mut remap = SourceRegionRemap {
+                            source_start: anchor.region_start,
+                            source_end: anchor.region_start + anchor.region.len() as u32,
+                            base,
+                            remapped: false,
+                        };
+                        remap.visit_expression(&mut e);
+                        if !remap.remapped {
+                            *e.span_mut() = span;
+                        }
+                    } else {
+                        *e.span_mut() = span;
+                    }
                 }
                 Some(e)
             }
@@ -2607,6 +2621,25 @@ impl<'a, 'arena, 'source> Cx<'a, 'arena, 'source> {
             out.push(argument);
         }
         Some(out)
+    }
+}
+
+struct SourceRegionRemap {
+    source_start: u32,
+    source_end: u32,
+    base: u32,
+    remapped: bool,
+}
+
+impl<'a> VisitMut<'a> for SourceRegionRemap {
+    fn visit_span(&mut self, span: &mut Span) {
+        if span.start >= self.source_start && span.end <= self.source_end && span.start < span.end {
+            *span = Span::new(
+                self.base + span.start - self.source_start,
+                self.base + span.end - self.source_start,
+            );
+            self.remapped = true;
+        }
     }
 }
 

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/jsnode_to_oxc.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/jsnode_to_oxc.rs
@@ -22,15 +22,18 @@
 //!
 //! All construction patterns are lifted verbatim from the proven
 //! `js_ast::to_oxc` converter (variant-complete against oxc 0.136), so the
-//! nodes produced print byte-identically through esrap. All spans are the
-//! dummy [`oxc_span::SPAN`]: esrap formats structurally.
+//! nodes produced print byte-identically through esrap. Container spans are the
+//! dummy [`oxc_span::SPAN`]: esrap formats structurally. Identifier references
+//! and literals retain their source spans so a caller rebuilding an expression
+//! can place the comment cursor on surviving tokens rather than on a generated
+//! wrapper.
 
 use crate::ast::arena::{IdRange, JsNodeId, ParseArena};
 use crate::ast::typed_expr::{JsNode, LiteralValue};
 use oxc_allocator::{Allocator, ArenaBox, ArenaVec, GetAllocator};
 use oxc_ast::ast::*;
 use oxc_ast::builder::AstBuilder;
-use oxc_span::SPAN;
+use oxc_span::{GetSpanMut, SPAN, Span};
 use oxc_syntax::number::NumberBase;
 use oxc_syntax::operator::{
     AssignmentOperator, BinaryOperator, LogicalOperator, UnaryOperator, UpdateOperator,
@@ -832,10 +835,17 @@ impl<'a, 'arena> Cx<'a, 'arena> {
 
     fn expr(&self, node: &JsNode) -> Option<Expression<'a>> {
         match node {
-            JsNode::Identifier { name, .. } => {
-                Some(Expression::new_identifier(SPAN, self.str(name), &self.ab))
-            }
-            JsNode::Literal { .. } => self.literal(node),
+            JsNode::Identifier {
+                start, end, name, ..
+            } => Some(Expression::new_identifier(
+                Span::new(*start, *end),
+                self.str(name),
+                &self.ab,
+            )),
+            JsNode::Literal { start, end, .. } => self.literal(node).map(|mut expr| {
+                *expr.span_mut() = Span::new(*start, *end);
+                expr
+            }),
             JsNode::ThisExpression { .. } => Some(Expression::ThisExpression(
                 ThisExpression::boxed(SPAN, &self.ab),
             )),

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/jsnode_to_oxc.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/jsnode_to_oxc.rs
@@ -867,6 +867,7 @@ impl<'a, 'arena> Cx<'a, 'arena> {
                 callee,
                 arguments,
                 optional,
+                loc: _,
             } => {
                 let callee = self.expr_id(*callee)?;
                 let args = self.arguments(*arguments)?;

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/jsnode_to_oxc.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/jsnode_to_oxc.rs
@@ -862,15 +862,21 @@ impl<'a, 'arena> Cx<'a, 'arena> {
             }
             JsNode::MemberExpression { .. } => Some(Expression::from(self.member_expr(node)?)),
             JsNode::CallExpression {
+                start,
+                end,
                 callee,
                 arguments,
                 optional,
-                ..
             } => {
                 let callee = self.expr_id(*callee)?;
                 let args = self.arguments(*arguments)?;
                 Some(Expression::CallExpression(CallExpression::boxed(
-                    SPAN, callee, None, args, *optional, &self.ab,
+                    Span::new(*start, *end),
+                    callee,
+                    None,
+                    args,
+                    *optional,
+                    &self.ab,
                 )))
             }
             JsNode::NewExpression {

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/jsnode_to_oxc.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/jsnode_to_oxc.rs
@@ -22,18 +22,20 @@
 //!
 //! All construction patterns are lifted verbatim from the proven
 //! `js_ast::to_oxc` converter (variant-complete against oxc 0.136), so the
-//! nodes produced print byte-identically through esrap. Container spans are the
-//! dummy [`oxc_span::SPAN`]: esrap formats structurally. Identifier references
-//! and literals retain their source spans so a caller rebuilding an expression
-//! can place the comment cursor on surviving tokens rather than on a generated
-//! wrapper.
+//! nodes produced print byte-identically through esrap. Most container spans
+//! are the dummy [`oxc_span::SPAN`]: esrap formats structurally. Identifier
+//! references and call expressions retain their source spans so a caller
+//! rebuilding an expression can place the comment cursor on surviving tokens
+//! rather than on a generated wrapper. Literals deliberately keep the dummy
+//! span to match upstream cursor placement: an interior comment remains pending
+//! until the enclosing argument boundary instead of moving before the literal.
 
 use crate::ast::arena::{IdRange, JsNodeId, ParseArena};
 use crate::ast::typed_expr::{JsNode, LiteralValue};
 use oxc_allocator::{Allocator, ArenaBox, ArenaVec, GetAllocator};
 use oxc_ast::ast::*;
 use oxc_ast::builder::AstBuilder;
-use oxc_span::{GetSpanMut, SPAN, Span};
+use oxc_span::{SPAN, Span};
 use oxc_syntax::number::NumberBase;
 use oxc_syntax::operator::{
     AssignmentOperator, BinaryOperator, LogicalOperator, UnaryOperator, UpdateOperator,
@@ -842,10 +844,7 @@ impl<'a, 'arena> Cx<'a, 'arena> {
                 self.str(name),
                 &self.ab,
             )),
-            JsNode::Literal { start, end, .. } => self.literal(node).map(|mut expr| {
-                *expr.span_mut() = Span::new(*start, *end);
-                expr
-            }),
+            JsNode::Literal { .. } => self.literal(node),
             JsNode::ThisExpression { .. } => Some(Expression::ThisExpression(
                 ThisExpression::boxed(SPAN, &self.ab),
             )),

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/comments.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/comments.rs
@@ -173,6 +173,14 @@ pub enum Place {
     /// it, so comments interior to the statement land where the source put
     /// them (upstream keeps the original nodes' `loc` for the same effect).
     Shift(u32),
+    /// Remap original absolute source spans into a registered template region.
+    /// Generated wrappers use the empty span and remain location-less, while
+    /// retained descendants keep the cursor positions upstream sees.
+    Remap {
+        source_start: u32,
+        source_end: u32,
+        base: u32,
+    },
 }
 
 impl VisitMut<'_> for Place {
@@ -186,6 +194,18 @@ impl VisitMut<'_> for Place {
             // no re-parsed node is empty at offset 0.
             Place::Shift(_) if span.start == 0 && span.end == 0 => {}
             Place::Shift(by) => *span = Span::new(span.start + by, span.end + by),
+            Place::Remap { .. } if span.start == 0 && span.end == 0 => {}
+            Place::Remap {
+                source_start,
+                source_end,
+                base,
+            } if span.start >= source_start && span.end <= source_end => {
+                *span = Span::new(
+                    base + span.start - source_start,
+                    base + span.end - source_start,
+                );
+            }
+            Place::Remap { .. } => {}
         }
     }
 }

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/mod.rs
@@ -28,8 +28,9 @@ use crate::compiler::phases::phase2_analyze::ComponentAnalysis;
 use crate::compiler::phases::phase3_transform::builders::B;
 use crate::compiler::phases::phase3_transform::jsnode_to_oxc::jsnode_to_oxc_expr;
 use crate::compiler::phases::phase3_transform::server::evaluate::EvalValue;
+use crate::compiler::phases::phase3_transform::shared::js_scan;
 use oxc_allocator::Allocator;
-use oxc_ast::ast::{Comment, Expression as OxcExpression, Statement};
+use oxc_ast::ast::{Comment, CommentKind, Expression as OxcExpression, Statement};
 use oxc_ast_visit::VisitMut;
 use oxc_span::{GetSpan, GetSpanMut, SPAN, Span};
 use visitors::shared::TemplateEntry;
@@ -398,7 +399,8 @@ impl<'a> ServerTransformState<'a> {
             oxc_span::SourceType::mjs().with_typescript(true),
         )
         .parse();
-        ret.program
+        let mut comments: Vec<_> = ret
+            .program
             .comments
             .iter()
             .map(|comment| {
@@ -407,7 +409,38 @@ impl<'a> ServerTransformState<'a> {
                 comment.attached_to = comment.span.end;
                 comment
             })
-            .collect()
+            .collect();
+        // A template region can include Svelte punctuation between otherwise
+        // valid JavaScript fragments. The parser may stop at that punctuation
+        // before reaching a later comment, so supplement its comments with a
+        // lexical pass that skips strings, templates, regexes and comments.
+        // Retain the parser results as well because it sees comments inside
+        // `${...}`, while the scanner deliberately treats templates as opaque.
+        for (comment_start, comment_end) in js_scan::comment_ranges(slice.as_bytes()) {
+            let comment_start = comment_start as u32 + start;
+            let comment_end = comment_end as u32 + start;
+            if comments
+                .iter()
+                .any(|comment| comment.span == Span::new(comment_start, comment_end))
+            {
+                continue;
+            }
+            let relative_start = (comment_start - start) as usize;
+            let relative_end = (comment_end - start) as usize;
+            let raw = &slice[relative_start..relative_end];
+            let kind = if raw.starts_with("//") {
+                CommentKind::Line
+            } else if raw.contains('\n') || raw.contains('\r') {
+                CommentKind::MultiLineBlock
+            } else {
+                CommentKind::SingleLineBlock
+            };
+            let mut comment = Comment::new(comment_start, comment_end, kind);
+            comment.attached_to = comment_end;
+            comments.push(comment);
+        }
+        comments.sort_unstable_by_key(|comment| comment.span.start);
+        comments
     }
 
     /// Restrict a template expression's interior to the part reachable by

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/mod.rs
@@ -31,7 +31,7 @@ use crate::compiler::phases::phase3_transform::server::evaluate::EvalValue;
 use oxc_allocator::Allocator;
 use oxc_ast::ast::{Comment, Expression as OxcExpression, Statement};
 use oxc_ast_visit::VisitMut;
-use oxc_span::{SPAN, Span};
+use oxc_span::{GetSpan, GetSpanMut, SPAN, Span};
 use visitors::shared::TemplateEntry;
 
 /// Mutable state threaded through the AST-based server transform.
@@ -461,11 +461,8 @@ impl<'a> ServerTransformState<'a> {
         }
         let mut comments = carried.map(|pending| pending.comments).unwrap_or_default();
         comments.extend(own);
-        comments.retain(|comment| {
-            comment.span.start >= region_start
-                && comment.span.end <= region_end
-                && (comment.span.end <= expr_start || comment.span.start >= expr_end)
-        });
+        comments
+            .retain(|comment| comment.span.start >= region_start && comment.span.end <= region_end);
         if comments.is_empty() {
             return;
         }
@@ -480,8 +477,21 @@ impl<'a> ServerTransformState<'a> {
             comment.attached_to = comment.span.end;
         }
         if let Some(base) = self.comments.register_expression(text, &comments) {
-            let mut place = comments::Place::At(base + (expr_start - region_start));
+            let mut place = comments::Place::Remap {
+                source_start: region_start,
+                source_end: region_end,
+                base,
+            };
             place.visit_expression(expr);
+            // A wholly synthesized replacement carries no original descendant
+            // span. Give its root the expression's source position so the
+            // region is still reached and preceding comments are retained.
+            if expr.span().start < base || expr.span().start >= base + (region_end - region_start) {
+                *expr.span_mut() = Span::new(
+                    base + (expr_start - region_start),
+                    base + (expr_end - region_start),
+                );
+            }
         }
     }
 

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/visitors/each_block.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/visitors/each_block.rs
@@ -126,11 +126,18 @@ pub fn visit_each_block<'a>(node: &EachBlock<'a>, state: &mut ServerTransformSta
     // The collection argument to `$.ensure_array_like(...)`: an await-bearing
     // iterable is `$.save`-wrapped (`(await $.save(expr))()`); otherwise the
     // plain read-wrapped expression.
-    let collection = if has_await {
+    let mut collection = if has_await {
         save_wrap_expr_text(state, iterable_src.as_deref().unwrap_or(""))
     } else {
         state.visit_expr_claiming(&node.expression)
     };
+    if let (Some(start), Some(end)) = (node.expression.start(), node.expression.end()) {
+        state.place_template_expression_comments(
+            (node.start + 7, end),
+            (start, end),
+            &mut collection,
+        );
+    }
     let b = state.b;
 
     // statements[0] = const each_array = $.ensure_array_like(collection);

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/visitors/each_block.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/visitors/each_block.rs
@@ -132,8 +132,14 @@ pub fn visit_each_block<'a>(node: &EachBlock<'a>, state: &mut ServerTransformSta
         state.visit_expr_claiming(&node.expression)
     };
     if let (Some(start), Some(end)) = (node.expression.start(), node.expression.end()) {
+        let region_end = match node.body.nodes.first() {
+            Some(crate::ast::template::TemplateNode::ConstTag(tag)) => {
+                tag.end.saturating_sub(1).max(end)
+            }
+            _ => end,
+        };
         state.place_template_expression_comments(
-            (node.start + 7, end),
+            (node.start + 7, region_end),
             (start, end),
             &mut collection,
         );

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/visitors/html_tag.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/visitors/html_tag.rs
@@ -47,7 +47,14 @@ pub fn visit_html_tag<'a>(tag: &HtmlTag, state: &mut ServerTransformState<'a>) {
     // 写经 `is_async()` = `has_await || has_blockers()`.
     if !has_await && blocker_indices.is_empty() {
         // Sync path: interpolate `$.html(expr)` into the surrounding push.
-        let visited = state.visit_expr_claiming(&tag.expression);
+        let mut visited = state.visit_expr_claiming(&tag.expression);
+        if let (Some(start), Some(end)) = (tag.expression.start(), tag.expression.end()) {
+            state.place_template_expression_comments(
+                (tag.start + 7, tag.end - 1),
+                (start, end),
+                &mut visited,
+            );
+        }
         let html = state.b.call("$.html", vec![visited]);
         state.template.push(TemplateEntry::Template {
             quasis: vec![String::new(), String::new()],
@@ -59,11 +66,18 @@ pub fn visit_html_tag<'a>(tag: &HtmlTag, state: &mut ServerTransformState<'a>) {
     // Async path. `context.visit(node.expression)` → `$.save`-wrap any inline
     // await when the html-tag is a direct child of an element (the
     // `AwaitExpression` parent-walk gate, mirrored by `in_element_children`).
-    let visited = if has_await && state.in_element_children {
+    let mut visited = if has_await && state.in_element_children {
         save_wrap_expr_text(state, expr_text.as_deref().unwrap_or(""))
     } else {
         state.visit_expr_claiming(&tag.expression)
     };
+    if let (Some(start), Some(end)) = (tag.expression.start(), tag.expression.end()) {
+        state.place_template_expression_comments(
+            (tag.start + 7, tag.end - 1),
+            (start, end),
+            &mut visited,
+        );
+    }
     let b = state.b;
     let html = b.call("$.html", vec![visited]);
     let push = b.stmt(b.call("$$renderer.push", vec![html]));

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/visitors/if_block.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/visitors/if_block.rs
@@ -190,12 +190,17 @@ fn build_test<'a>(
     node: &IfBlock,
     state: &mut ServerTransformState<'a>,
 ) -> oxc_ast::ast::Expression<'a> {
-    if let Some(text) = state.expr_source(&node.test)
+    let mut test = if let Some(text) = state.expr_source(&node.test)
         && text_has_await(text)
     {
-        return save_wrap_expr_text(state, text);
+        save_wrap_expr_text(state, text)
+    } else {
+        state.visit_expr_claiming(&node.test)
+    };
+    if let (Some(start), Some(end)) = (node.test.start(), node.test.end()) {
+        state.place_template_expression_comments((node.start + 5, end), (start, end), &mut test);
     }
-    state.visit_expr_claiming(&node.test)
+    test
 }
 
 /// Build the `else` arm. If `frag` is a single FLATTENABLE `{:else if}` (nested

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/visitors/if_block.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/visitors/if_block.rs
@@ -198,7 +198,19 @@ fn build_test<'a>(
         state.visit_expr_claiming(&node.test)
     };
     if let (Some(start), Some(end)) = (node.test.start(), node.test.end()) {
-        state.place_template_expression_comments((node.start + 5, end), (start, end), &mut test);
+        // Upstream's cursor drops a leading line comment in an if header: the
+        // newline ends that comment before the rebuilt test is encountered.
+        let header = state
+            .source
+            .get((node.start + 5) as usize..end as usize)
+            .unwrap_or_default();
+        if !header.contains("//") {
+            state.place_template_expression_comments(
+                (node.start + 5, end),
+                (start, end),
+                &mut test,
+            );
+        }
     }
     test
 }

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/visitors/render_tag.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/visitors/render_tag.rs
@@ -105,6 +105,7 @@ pub fn visit_render_tag<'a>(node: &RenderTag, state: &mut ServerTransformState<'
     // each argument is also read-wrapped (a `$derived` arg becomes `arg()`) and
     // routed through the optimiser so a blocked argument makes the tag async.
     let mut args = vec![state.b.id("$$renderer")];
+    let mut comment_cursor = c_end as u32;
     if let Some(arg_list) = call_json.get("arguments").and_then(Value::as_array) {
         for arg in arg_list {
             if let (Some(a_start), Some(a_end)) = (
@@ -117,6 +118,12 @@ pub fn visit_render_tag<'a>(node: &RenderTag, state: &mut ServerTransformState<'
                 if let Some(t) = source_slice(state, a_start, a_end) {
                     arg_expr = optimiser.transform(state, &t, arg_expr);
                 }
+                state.place_template_expression_comments(
+                    (comment_cursor, a_end as u32),
+                    (a_start as u32, a_end as u32),
+                    &mut arg_expr,
+                );
+                comment_cursor = a_end as u32;
                 args.push(arg_expr);
             }
         }

--- a/crates/rsvelte_core/tests/comment_cursor_3070_3098.rs
+++ b/crates/rsvelte_core/tests/comment_cursor_3070_3098.rs
@@ -116,7 +116,7 @@ fn client_render_argument_comment_reaches_the_generated_thunk_parameter() {
     for dev in [false, true] {
         assert_has(
             &client("{@render s(/* c */ v)}", dev),
-            "s($$anchor, (/* c */) => v);",
+            "s($$anchor, (/* c */) => v)",
         );
     }
 }

--- a/crates/rsvelte_core/tests/comment_cursor_3070_3098.rs
+++ b/crates/rsvelte_core/tests/comment_cursor_3070_3098.rs
@@ -1,0 +1,166 @@
+//! Remaining comment-cursor rows from #3070 and #3098.
+//!
+//! Every expected fragment below was measured against the pinned official
+//! compiler.  These are placement assertions, not merely retention checks: a
+//! comment in a generated sibling call is still a mismatch even when the text
+//! happens to survive somewhere in the output.
+
+use rsvelte_core::{CompileOptions, GenerateMode, compile};
+
+fn compile_to(source: &str, generate: GenerateMode, dev: bool) -> String {
+    compile(
+        source,
+        CompileOptions {
+            generate,
+            dev,
+            filename: Some("CommentCursor.svelte".to_string()),
+            ..Default::default()
+        },
+    )
+    .expect("component should compile")
+    .js
+    .code
+}
+
+fn client(template: &str, dev: bool) -> String {
+    compile_to(
+        &format!(
+            "<script>\n\tlet v = $state(1);\n\tconst s = (x) => x;\n</script>\n\n{template}\n"
+        ),
+        GenerateMode::Client,
+        dev,
+    )
+}
+
+fn server(template: &str) -> String {
+    compile_to(
+        &format!(
+            "<script>\n\tlet v = $state(1);\n\tconst s = (x) => x;\n</script>\n\n{template}\n"
+        ),
+        GenerateMode::Server,
+        false,
+    )
+}
+
+#[track_caller]
+fn assert_has(output: &str, expected: &str) {
+    assert!(
+        output.contains(expected),
+        "expected to find\n  {expected}\nin:\n{output}"
+    );
+}
+
+#[test]
+fn client_expression_tag_comment_uses_the_generated_append_slot() {
+    for dev in [false, true] {
+        assert_has(
+            &client("<p>{/* c */ v}</p>", dev),
+            "$.append($$anchor, p /* c */);",
+        );
+    }
+}
+
+#[test]
+fn client_each_collection_comment_stays_in_the_collection_thunk() {
+    for dev in [false, true] {
+        assert_has(
+            &client("{#each [/* c */ v] as i}<p>{i}</p>{/each}", dev),
+            "() => [/* c */ v]",
+        );
+    }
+}
+
+#[test]
+fn client_const_initializer_comment_reaches_the_generated_callback_parameter() {
+    for dev in [false, true] {
+        let output = client(
+            "{#each [1] as i}{@const c = /* c */ v * i}<p>{c}</p>{/each}",
+            dev,
+        );
+        assert_has(&output, "i /* c */) => {");
+    }
+}
+
+#[test]
+fn client_event_arrow_comment_stays_with_the_rewritten_update() {
+    for dev in [false, true] {
+        assert_has(
+            &client("<button onclick={() => /* c */ v++}>x</button>", dev),
+            "() => $.update(/* c */ v)",
+        );
+    }
+}
+
+#[test]
+fn client_html_comment_reaches_the_generated_thunk_parameter() {
+    for dev in [false, true] {
+        assert_has(
+            &client("{@html /* c */ v}", dev),
+            "$.html(node, (/* c */) => v);",
+        );
+    }
+}
+
+#[test]
+fn client_key_comment_reaches_the_generated_thunk_parameter() {
+    for dev in [false, true] {
+        assert_has(
+            &client("{#key /* c */ v}<p>x</p>{/key}", dev),
+            "$.key(node, (/* c */) => v,",
+        );
+    }
+}
+
+#[test]
+fn client_render_argument_comment_reaches_the_generated_thunk_parameter() {
+    for dev in [false, true] {
+        assert_has(
+            &client("{@render s(/* c */ v)}", dev),
+            "s($$anchor, (/* c */) => v);",
+        );
+    }
+}
+
+#[test]
+fn server_if_comment_stays_with_the_test() {
+    assert_has(&server("{#if /* c */ v}<p>x</p>{/if}"), "if (/* c */ v) {");
+}
+
+#[test]
+fn server_each_comment_stays_with_the_collection() {
+    assert_has(
+        &server("{#each [/* c */ v] as i}<p>{i}</p>{/each}"),
+        "$.ensure_array_like([/* c */ v])",
+    );
+}
+
+#[test]
+fn server_const_comment_follows_the_official_cursor_slot() {
+    assert_has(
+        &server("{#each [1] as i}{@const c = /* c */ v * i}<p>{c}</p>{/each}"),
+        "$.ensure_array_like([1] /* c */)",
+    );
+}
+
+#[test]
+fn server_html_comment_stays_with_the_argument() {
+    assert_has(&server("{@html /* c */ v}"), "$.html(/* c */ v)");
+}
+
+#[test]
+fn server_render_comment_stays_with_the_argument() {
+    assert_has(
+        &server("{@render s(/* c */ v)}"),
+        "s($$renderer, /* c */ v);",
+    );
+}
+
+#[test]
+fn server_rune_declaration_keeps_a_comment_before_the_binding_name() {
+    let output = compile_to(
+        "<script>\n\tlet /* c */ x = $state(2);\n</script>\n\n<p>{x}</p>\n",
+        GenerateMode::Server,
+        false,
+    );
+    assert_has(&output, "let /* c */ x = 2;");
+}

--- a/crates/rsvelte_core/tests/template_expression_comments_3112_3214.rs
+++ b/crates/rsvelte_core/tests/template_expression_comments_3112_3214.rs
@@ -112,16 +112,14 @@ fn a_component_with_no_instance_script_drops_the_comment() {
     }
 }
 
-/// The expression is stamped at ONE address, so a comment written *inside* it
-/// cannot be placed where upstream puts it. It is dropped rather than pushed
-/// past the node it was written in — the pre-existing behaviour, recorded here
-/// as the boundary of the fix.
+/// Interior expression comments now travel with the rebuilt expression rather
+/// than being lost when the server wraps it for escaping.
 #[test]
-fn an_interior_comment_is_still_dropped() {
+fn interior_comments_survive_expression_rewrites() {
     let out = server(&format!("{SCRIPT}\n<p>{{f(n) /* c */ + 1}}</p>\n"));
-    assert!(out.contains("$.escape(f(n) + 1)"), "{out}");
+    assert!(out.contains("$.escape(f(n) + 1 /* c */)"), "{out}");
     let out = server(&format!("{SCRIPT}\n<p>{{f(/* c */ n)}}</p>\n"));
-    assert!(out.contains("$.escape(f(n))"), "{out}");
+    assert!(out.contains("$.escape(f(/* c */ n))"), "{out}");
 }
 
 /// A statement that owns no comment still has to hold its position, or the


### PR DESCRIPTION
## Summary

Carry comments written inside rebuilt template/block expressions through the same source-position cursor the official compiler uses.

This completes the measured #3098 slots for ordinary expression tags, each collections, `{@const}`, event-handler rewrites, `{@html}`, `{#key}`, and `{@render}`, plus the corresponding server if/each/const/html/render paths. It also fixes #3070's remaining server interior binding-name row while preserving the documented deliberate divergence for upstream's unrelated template-comment leaks.

The implementation extends the existing client `SourceAnchor` region mechanism to non-`{expr}` openers and registers the equivalent expression regions in the server chunk registry. Placement stays on the source identifier/expression rather than on its generated wrapper.

This also addresses the matching if/each/key/html/render rows reported in #3603; await headers, snippet parameters, and each keys remain separate generated positions and are not claimed here.

## Verification

- `cargo fmt --all -- --check`
- `git diff --check`
- behavioral verification: GitHub Actions only (no local build or test run)

Tracks #3070.
Closes #3098.
Contributes to #3603.

