### PR TITLE
fix: preserve await and snippet comments

### DIFF
--- a/.changeset/template-await-snippet-comments.md
+++ b/.changeset/template-await-snippet-comments.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/compiler": patch
+---
+
+Keep comments in await headers and snippet parameter lists in the same generated positions as the official compiler on client and server output.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2641,7 +2641,7 @@ dependencies = [
 
 [[package]]
 name = "rsvelte_esrap"
-version = "0.10.35"
+version = "0.10.36"
 dependencies = [
  "compact_str",
  "memchr",

--- a/crates/rsvelte_core/Cargo.toml
+++ b/crates/rsvelte_core/Cargo.toml
@@ -94,7 +94,7 @@ oxc_ast = { version = "0.145", features = ["serialize"] }
 oxc_span = "0.145"
 oxc_diagnostics = "0.145"
 oxc_codegen = "0.145"
-rsvelte_esrap = { version = "=0.10.35", path = "../rsvelte_esrap" }
+rsvelte_esrap = { version = "=0.10.36", path = "../rsvelte_esrap" }
 oxc_syntax = "0.145"
 oxc_semantic = "0.145"
 

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/source_anchor.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/source_anchor.rs
@@ -17,7 +17,9 @@
 use super::types::ComponentClientTransformState;
 use crate::ast::template::ExpressionTag;
 use crate::compiler::phases::phase3_transform::js_ast::arena::JsArena;
-use crate::compiler::phases::phase3_transform::js_ast::nodes::{JsExpr, JsSourceAnchor};
+use crate::compiler::phases::phase3_transform::js_ast::nodes::{
+    JsExpr, JsPattern, JsSourceAnchor, JsSourcePatternAnchor,
+};
 use crate::compiler::phases::phase3_transform::shared::js_scan;
 use compact_str::CompactString;
 
@@ -112,6 +114,53 @@ impl CommentRegion {
         })
     }
 
+    /// Like [`Self::between`], but only asks OXC's lexer for comments. This is
+    /// used for block headers whose full spelling is not a JavaScript
+    /// expression (`promise /* c */ then value`, snippet parameter lists).
+    pub fn lexical_between(
+        state: &ComponentClientTransformState<'_>,
+        inner_start: u32,
+        inner_end: u32,
+        from: u32,
+    ) -> Option<Self> {
+        let source: &str = &state.options.source;
+        if inner_end <= inner_start || inner_end as usize > source.len() || from > inner_start {
+            return None;
+        }
+        let inner = source.get(inner_start as usize..inner_end as usize)?;
+        if !inner.contains("//") && !inner.contains("/*") {
+            return None;
+        }
+        let allocator = oxc_allocator::Allocator::default();
+        let ret = oxc_parser::Parser::new(
+            &allocator,
+            inner,
+            oxc_span::SourceType::mjs().with_typescript(true),
+        )
+        .parse();
+        if ret.program.comments.is_empty() {
+            return None;
+        }
+        let comments = ret
+            .program
+            .comments
+            .iter()
+            .map(|comment| {
+                (
+                    comment.span.start + inner_start,
+                    comment.span.end + inner_start,
+                    comment.is_line(),
+                )
+            })
+            .collect();
+        Some(Self {
+            start: from,
+            end: inner_end,
+            text: source.get(from as usize..inner_end as usize)?.into(),
+            comments,
+        })
+    }
+
     /// Wrap `expr` so it claims `[at, at_end)` inside this region.
     pub fn anchor(&self, arena: &JsArena, expr: JsExpr, at: u32, at_end: u32) -> JsExpr {
         if at < self.start || at_end > self.end {
@@ -144,6 +193,21 @@ impl CommentRegion {
             at,
             at_end,
             preserve_inner_spans: true,
+        }))
+    }
+
+    /// Wrap a generated binding pattern at its upstream source location.
+    pub fn anchor_pattern(&self, pattern: JsPattern, at: u32, at_end: u32) -> JsPattern {
+        if at < self.start || at_end > self.end {
+            return pattern;
+        }
+        JsPattern::SourceAnchored(Box::new(JsSourcePatternAnchor {
+            inner: Box::new(pattern),
+            region_start: self.start,
+            region: self.text.clone(),
+            comments: self.comments.clone(),
+            at,
+            at_end,
         }))
     }
 }

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/await_block.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/await_block.rs
@@ -42,6 +42,7 @@
 
 use crate::ast::js::Expression;
 use crate::ast::template::{AwaitBlock, Fragment};
+use crate::compiler::phases::phase3_transform::client::source_anchor::CommentRegion;
 use crate::compiler::phases::phase3_transform::client::types::{
     ComponentContext, ExpressionMetadata,
 };
@@ -84,7 +85,23 @@ pub fn await_block(node: &AwaitBlock, context: &mut ComponentContext) {
     // Build expression with metadata
     let expr_metadata = ExpressionMetadata::from_template_metadata(&node.metadata.expression);
 
-    let built_expr = build_expression(context, &converted_expr, &expr_metadata);
+    let mut built_expr = build_expression(context, &converted_expr, &expr_metadata);
+    if let (Some(start), Some(end), Some(header_end)) = (
+        node.expression.start(),
+        node.expression.end(),
+        crate::compiler::phases::phase1_parse::utils::find_matching_bracket(
+            &context.state.options.source,
+            node.start as usize + 1,
+            '{',
+        ),
+    ) && let Some(region) = CommentRegion::lexical_between(
+        &context.state,
+        node.start + 7,
+        header_end as u32,
+        node.start + 7,
+    ) {
+        built_expr = region.anchor(&context.arena, built_expr, start, end);
+    }
 
     // Check for blockers before moving built_expr into thunk
     let blocker_exprs = context

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/await_block.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/await_block.rs
@@ -86,7 +86,7 @@ pub fn await_block(node: &AwaitBlock, context: &mut ComponentContext) {
     let expr_metadata = ExpressionMetadata::from_template_metadata(&node.metadata.expression);
 
     let mut built_expr = build_expression(context, &converted_expr, &expr_metadata);
-    if let (Some(start), Some(end), Some(header_end)) = (
+    let has_header_comments = if let (Some(start), Some(end), Some(header_end)) = (
         node.expression.start(),
         node.expression.end(),
         crate::compiler::phases::phase1_parse::utils::find_matching_bracket(
@@ -101,7 +101,10 @@ pub fn await_block(node: &AwaitBlock, context: &mut ComponentContext) {
         node.start + 7,
     ) {
         built_expr = region.anchor(&context.arena, built_expr, start, end);
-    }
+        true
+    } else {
+        false
+    };
 
     // Check for blockers before moving built_expr into thunk
     let blocker_exprs = context
@@ -150,11 +153,15 @@ pub fn await_block(node: &AwaitBlock, context: &mut ComponentContext) {
     if let Some(catch_fn) = catch_block {
         await_args.push(catch_fn);
     }
-    let await_call = b::call(
-        &context.arena,
-        b::member_path(&context.arena, "$.await"),
-        await_args,
-    );
+    let mut await_callee = b::member_path(&context.arena, "$.await");
+    if has_header_comments {
+        await_callee = JsExpr::Spanned(
+            context.arena.alloc_expr(await_callee),
+            rsvelte_esrap::COMMENT_ARGUMENT_CALLEE_BASE + 1,
+            rsvelte_esrap::COMMENT_ARGUMENT_CALLEE_BASE + 1,
+        );
+    }
+    let await_call = b::call(&context.arena, await_callee, await_args);
 
     // Add svelte metadata
     let stmt = if context.state.dev {

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/expression_converter.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/expression_converter.rs
@@ -3636,6 +3636,7 @@ pub fn convert_param_pattern(value: &Value, context: &mut ComponentContext) -> O
 pub fn pattern_to_string(pattern: &JsPattern) -> String {
     match pattern {
         JsPattern::Identifier(name) | JsPattern::SpannedIdentifier { name, .. } => name.to_string(),
+        JsPattern::SourceAnchored(anchor) => pattern_to_string(&anchor.inner),
         JsPattern::Array(arr) => {
             let mut s = String::from("[");
             for (i, elem) in arr.elements.iter().enumerate() {

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/utils.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/utils.rs
@@ -143,6 +143,7 @@ fn extract_pattern_names(pattern: &JsPattern, names: &mut FxHashSet<String>) {
         JsPattern::Identifier(name) | JsPattern::SpannedIdentifier { name, .. } => {
             names.insert(name.to_string());
         }
+        JsPattern::SourceAnchored(anchor) => extract_pattern_names(&anchor.inner, names),
         JsPattern::Array(array) => {
             for p in array.elements.iter().flatten() {
                 extract_pattern_names(p, names);
@@ -212,6 +213,9 @@ fn collect_pattern_evaluations(
             }
         }
         JsPattern::Identifier(_) | JsPattern::SpannedIdentifier { .. } => {}
+        JsPattern::SourceAnchored(anchor) => {
+            collect_pattern_evaluations(&anchor.inner, context, getters, seen)
+        }
     }
 }
 

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/snippet_block.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/snippet_block.rs
@@ -46,6 +46,7 @@
 
 use crate::ast::js::Expression;
 use crate::ast::template::{Fragment, SnippetBlock};
+use crate::compiler::phases::phase3_transform::client::source_anchor::CommentRegion;
 use crate::compiler::phases::phase3_transform::client::types::ComponentContext;
 use crate::compiler::phases::phase3_transform::js_ast::builders as b;
 use crate::compiler::phases::phase3_transform::js_ast::nodes::*;
@@ -114,8 +115,20 @@ pub fn snippet_block(node: &SnippetBlock, context: &mut ComponentContext) {
     }
 
     // Process each parameter
+    let mut parameter_region_start = node.expression.end().unwrap_or(node.start + 9);
     for (i, param) in node.parameters.iter().enumerate() {
-        if let Some(arg_info) = process_parameter(param, i, context) {
+        if let Some(mut arg_info) = process_parameter(param, i, context) {
+            if let (Some(start), Some(end)) = (param.start(), param.end()) {
+                if let Some(region) = CommentRegion::lexical_between(
+                    &context.state,
+                    parameter_region_start,
+                    end,
+                    parameter_region_start,
+                ) {
+                    arg_info.pattern = region.anchor_pattern(arg_info.pattern, start, end);
+                }
+                parameter_region_start = end;
+            }
             args.push(arg_info.pattern);
             declarations.extend(arg_info.declarations);
         }

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/js_ast/codegen.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/js_ast/codegen.rs
@@ -959,9 +959,15 @@ impl<'a> JsCodegen<'a> {
                 self.output.push_str(code);
             }
             JsExpr::Spanned(inner_id, start, end) => {
-                self.record_span_start(*start, *end);
+                let is_comment_argument_marker =
+                    *start >= rsvelte_esrap::COMMENT_ARGUMENT_CALLEE_BASE;
+                if !is_comment_argument_marker {
+                    self.record_span_start(*start, *end);
+                }
                 self.emit_expression(self.arena.get_expr(*inner_id));
-                self.record_span_start(*end, *end);
+                if !is_comment_argument_marker {
+                    self.record_span_start(*end, *end);
+                }
             }
             // The comment coordinates only reach the oxc printer; the text
             // fallback has no comment channel to place them in.

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/js_ast/codegen.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/js_ast/codegen.rs
@@ -1841,6 +1841,7 @@ impl<'a> JsCodegen<'a> {
                 self.output.push_str(name);
                 self.record_span_start(*end, *end);
             }
+            JsPattern::SourceAnchored(anchor) => self.emit_pattern(&anchor.inner),
             JsPattern::Array(arr) => {
                 self.output.push('[');
                 for (i, elem) in arr.elements.iter().enumerate() {

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/js_ast/nodes.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/js_ast/nodes.rs
@@ -965,6 +965,10 @@ pub enum JsPattern {
         start: u32,
         end: u32,
     },
+    /// A binding pattern whose COMMENT-space coordinates come from a slice of
+    /// the original source. Boxed so the rare template-comment carrier does
+    /// not increase the size paid by every pattern.
+    SourceAnchored(Box<JsSourcePatternAnchor>),
     /// Array destructuring
     Array(JsArrayPattern),
     /// Object destructuring
@@ -973,6 +977,19 @@ pub enum JsPattern {
     Rest(Box<JsPattern>),
     /// Assignment pattern (default value)
     Assignment(JsAssignmentPattern),
+}
+
+/// Pattern counterpart of [`JsSourceAnchor`]. Template snippet parameters keep
+/// their source location upstream even when the client wraps an identifier in
+/// a generated assignment pattern (`value = $.noop`).
+#[derive(Debug, Clone)]
+pub struct JsSourcePatternAnchor {
+    pub inner: Box<JsPattern>,
+    pub region_start: u32,
+    pub region: CompactString,
+    pub comments: Vec<(u32, u32, bool)>,
+    pub at: u32,
+    pub at_end: u32,
 }
 
 /// Array pattern.

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/js_ast/to_oxc.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/js_ast/to_oxc.rs
@@ -666,8 +666,7 @@ impl<'a, 'arena, 'source> Cx<'a, 'arena, 'source> {
             let base = synth.cursor();
             synth.source.push_str(region);
             synth.source.push('\n');
-            let region_start = anchor.region_start;
-            for &(source_start, source_end, line) in &anchor.comments {
+            for &(source_start, source_end, line) in comments {
                 if !synth.source_comments.insert((source_start, source_end)) {
                     continue;
                 }
@@ -675,9 +674,7 @@ impl<'a, 'arena, 'source> Cx<'a, 'arena, 'source> {
                 let end = base + (source_end - region_start);
                 let kind = if line {
                     CommentKind::Line
-                } else if anchor.region[(start - base) as usize..(end - base) as usize]
-                    .contains('\n')
-                {
+                } else if region[(start - base) as usize..(end - base) as usize].contains('\n') {
                     CommentKind::MultiLineBlock
                 } else {
                     CommentKind::SingleLineBlock
@@ -686,7 +683,7 @@ impl<'a, 'arena, 'source> Cx<'a, 'arena, 'source> {
                 comment.attached_to = end;
                 synth.comments.push(comment);
             }
-            synth.open_source_region = Some(anchor.region_start);
+            synth.open_source_region = Some(region_start);
             synth.open_source_base = base;
         }
         Some(Span::new(

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/js_ast/to_oxc.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/js_ast/to_oxc.rs
@@ -639,25 +639,32 @@ impl<'a, 'arena, 'source> Cx<'a, 'arena, 'source> {
     /// which is what upstream measures, its whole client output sharing one
     /// cursor over that file. `None` on the probe pass, or when the region
     /// carries nothing to place.
-    fn open_source_region(&self, anchor: &JsSourceAnchor) -> Option<Span> {
-        if anchor.at < anchor.region_start || anchor.at_end < anchor.at {
+    fn open_source_region_parts(
+        &self,
+        region_start: u32,
+        region: &str,
+        comments: &[(u32, u32, bool)],
+        at: u32,
+        at_end: u32,
+    ) -> Option<Span> {
+        if at < region_start || at_end < at {
             return None;
         }
-        let offset = anchor.at - anchor.region_start;
-        let offset_end = anchor.at_end - anchor.region_start;
-        if offset_end as usize > anchor.region.len() {
+        let offset = at - region_start;
+        let offset_end = at_end - region_start;
+        if offset_end as usize > region.len() {
             return None;
         }
-        if !anchor.comments.is_empty() {
+        if !comments.is_empty() {
             self.synth.borrow_mut().saw_comments = true;
         }
         let mut synth = self.synth.borrow_mut();
         if !synth.enabled {
             return None;
         }
-        if synth.open_source_region != Some(anchor.region_start) {
+        if synth.open_source_region != Some(region_start) {
             let base = synth.cursor();
-            synth.source.push_str(&anchor.region);
+            synth.source.push_str(region);
             synth.source.push('\n');
             let region_start = anchor.region_start;
             for &(source_start, source_end, line) in &anchor.comments {
@@ -686,6 +693,16 @@ impl<'a, 'arena, 'source> Cx<'a, 'arena, 'source> {
             synth.open_source_base + offset,
             synth.open_source_base + offset_end,
         ))
+    }
+
+    fn open_source_region(&self, anchor: &JsSourceAnchor) -> Option<Span> {
+        self.open_source_region_parts(
+            anchor.region_start,
+            &anchor.region,
+            &anchor.comments,
+            anchor.at,
+            anchor.at_end,
+        )
     }
 
     /// Append a retained island's own source to the comment buffer, so the
@@ -1297,6 +1314,19 @@ impl<'a, 'arena, 'source> Cx<'a, 'arena, 'source> {
                     self.str(name),
                     &self.ab,
                 ))
+            }
+            JsPattern::SourceAnchored(anchor) => {
+                let mut pattern = self.binding_pattern(&anchor.inner)?;
+                if let Some(span) = self.open_source_region_parts(
+                    anchor.region_start,
+                    &anchor.region,
+                    &anchor.comments,
+                    anchor.at,
+                    anchor.at_end,
+                ) {
+                    *pattern.span_mut() = span;
+                }
+                Some(pattern)
             }
             JsPattern::Object(obj) => {
                 let mut props = ArenaVec::with_capacity_in(obj.properties.len(), &self.ab);

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/js_ast/to_oxc.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/js_ast/to_oxc.rs
@@ -1599,13 +1599,16 @@ impl<'a, 'arena, 'source> Cx<'a, 'arena, 'source> {
                 )))
             }
             JsExpr::Class(class) => self.class(class),
-            // `Spanned` wraps a real inner expression with the original-source
-            // byte span (start, end). Convert the inner expression and stamp its
-            // span so esrap's `print_with_map` maps it back to the user source.
+            // `Spanned` normally wraps a real inner expression with the
+            // original-source byte span (start, end). The reserved callee
+            // range is printer metadata, not a source position, so it must not
+            // raise the boundary below which source spans live.
             JsExpr::Spanned(inner, start, end) => {
                 let mut e = self.expr_id(*inner)?;
                 *e.span_mut() = Span::new(*start, *end);
-                self.note_span(*end);
+                if *start < rsvelte_esrap::COMMENT_ARGUMENT_CALLEE_BASE {
+                    self.note_span(*end);
+                }
                 Some(e)
             }
             // `Raw` carries opaque JS expression text. Parse it into a real oxc

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/mod.rs
@@ -30,7 +30,9 @@ use crate::compiler::phases::phase3_transform::jsnode_to_oxc::jsnode_to_oxc_expr
 use crate::compiler::phases::phase3_transform::server::evaluate::EvalValue;
 use crate::compiler::phases::phase3_transform::shared::js_scan;
 use oxc_allocator::Allocator;
-use oxc_ast::ast::{Comment, CommentKind, Expression as OxcExpression, Statement};
+use oxc_ast::ast::{
+    BindingPattern, Comment, CommentKind, Expression as OxcExpression, Statement,
+};
 use oxc_ast_visit::VisitMut;
 use oxc_span::{GetSpan, GetSpanMut, SPAN, Span};
 use visitors::shared::TemplateEntry;
@@ -525,6 +527,42 @@ impl<'a> ServerTransformState<'a> {
                     base + (expr_end - region_start),
                 );
             }
+        }
+    }
+
+    pub fn place_template_pattern_comments(
+        &mut self,
+        region: (u32, u32),
+        pattern_span: (u32, u32),
+        pattern: &mut BindingPattern<'a>,
+    ) {
+        let Some((start, end)) = self.live_template_region(region) else {
+            return;
+        };
+        let (pattern_start, pattern_end) = pattern_span;
+        let mut comments = self.template_region_comments(start, end);
+        comments.retain(|comment| {
+            comment.span.start >= start
+                && comment.span.end <= end
+                && (comment.span.end <= pattern_start || comment.span.start >= pattern_end)
+        });
+        if comments.is_empty()
+            || pattern_start < start
+            || pattern_end < pattern_start
+            || end as usize > self.source.len()
+        {
+            return;
+        }
+        let Some(text) = self.source.get(start as usize..end as usize) else {
+            return;
+        };
+        for comment in &mut comments {
+            comment.span = Span::new(comment.span.start - start, comment.span.end - start);
+            comment.attached_to = comment.span.end;
+        }
+        if let Some(base) = self.comments.register_expression(text, &comments) {
+            let mut place = comments::Place::At(base + (pattern_start - start));
+            place.visit_binding_pattern(pattern);
         }
     }
 

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/mod.rs
@@ -30,9 +30,7 @@ use crate::compiler::phases::phase3_transform::jsnode_to_oxc::jsnode_to_oxc_expr
 use crate::compiler::phases::phase3_transform::server::evaluate::EvalValue;
 use crate::compiler::phases::phase3_transform::shared::js_scan;
 use oxc_allocator::Allocator;
-use oxc_ast::ast::{
-    BindingPattern, Comment, CommentKind, Expression as OxcExpression, Statement,
-};
+use oxc_ast::ast::{BindingPattern, Comment, CommentKind, Expression as OxcExpression, Statement};
 use oxc_ast_visit::VisitMut;
 use oxc_span::{GetSpan, GetSpanMut, SPAN, Span};
 use visitors::shared::TemplateEntry;

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/mod.rs
@@ -476,9 +476,9 @@ impl<'a> ServerTransformState<'a> {
         region: (u32, u32),
         expr_span: (u32, u32),
         expr: &mut OxcExpression<'a>,
-    ) {
+    ) -> bool {
         let Some((start, end)) = self.live_template_region(region) else {
-            return;
+            return false;
         };
         let (expr_start, expr_end) = expr_span;
         let own = self.template_region_comments(start, end);
@@ -487,22 +487,22 @@ impl<'a> ServerTransformState<'a> {
             _ => None,
         };
         if own.is_empty() && carried.is_none() {
-            return;
+            return false;
         }
         let region_start = carried.as_ref().map_or(start, |pending| pending.start);
         let region_end = end.max(expr_end);
         if expr_start < region_start || region_end as usize > self.source.len() {
-            return;
+            return false;
         }
         let mut comments = carried.map(|pending| pending.comments).unwrap_or_default();
         comments.extend(own);
         comments
             .retain(|comment| comment.span.start >= region_start && comment.span.end <= region_end);
         if comments.is_empty() {
-            return;
+            return false;
         }
         let Some(text) = self.source.get(region_start as usize..region_end as usize) else {
-            return;
+            return false;
         };
         for comment in &mut comments {
             comment.span = Span::new(
@@ -527,7 +527,9 @@ impl<'a> ServerTransformState<'a> {
                     base + (expr_end - region_start),
                 );
             }
+            return true;
         }
+        false
     }
 
     pub fn place_template_pattern_comments(

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/visitors/await_block.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/visitors/await_block.rs
@@ -40,6 +40,7 @@
 use crate::ast::template::AwaitBlock;
 use crate::compiler::phases::phase3_transform::server::ast::ServerTransformState;
 use oxc_ast::ast::BindingPattern;
+use oxc_span::GetSpanMut;
 
 use super::shared::{
     BLOCK_CLOSE, TemplateEntry, build_fragment_block, create_child_block, expr_text_blockers,
@@ -76,7 +77,7 @@ pub fn visit_await_block<'a>(node: &AwaitBlock<'a>, state: &mut ServerTransformS
     } else {
         state.visit_expr_claiming(&node.expression)
     };
-    if let (Some(start), Some(end), Some(header_end)) = (
+    let has_header_comments = if let (Some(start), Some(end), Some(header_end)) = (
         node.expression.start(),
         node.expression.end(),
         crate::compiler::phases::phase1_parse::utils::find_matching_bracket(
@@ -89,8 +90,10 @@ pub fn visit_await_block<'a>(node: &AwaitBlock<'a>, state: &mut ServerTransformS
             (node.start + 7, header_end as u32),
             (start, end),
             &mut expression,
-        );
-    }
+        )
+    } else {
+        false
+    };
     // `has_await` → async-IIFE-wrap so `$.await` receives a promise (the inner
     // await is not eagerly awaited).
     if has_await {
@@ -151,10 +154,16 @@ pub fn visit_await_block<'a>(node: &AwaitBlock<'a>, state: &mut ServerTransformS
     let then_body = b.body(unwrap_block(then_block, state));
     let then_arrow = b.arrow(b.params(then_params, None), then_body, false, false);
 
-    let call = b.call(
+    let mut call = b.call(
         "$.await",
         vec![b.id("$$renderer"), expression, pending_thunk, then_arrow],
     );
+    if has_header_comments && let oxc_ast::ast::Expression::CallExpression(call) = &mut call {
+        *call.callee.span_mut() = oxc_span::Span::new(
+            rsvelte_esrap::COMMENT_ARGUMENT_CALLEE_BASE + 1,
+            rsvelte_esrap::COMMENT_ARGUMENT_CALLEE_BASE + 1,
+        );
+    }
 
     // create_child_block: blockers → `$$renderer.async_block([…], …)`, an inline
     // await → `$$renderer.child_block(async …)`, else the statement verbatim.

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/visitors/await_block.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/visitors/await_block.rs
@@ -76,6 +76,21 @@ pub fn visit_await_block<'a>(node: &AwaitBlock<'a>, state: &mut ServerTransformS
     } else {
         state.visit_expr_claiming(&node.expression)
     };
+    if let (Some(start), Some(end), Some(header_end)) = (
+        node.expression.start(),
+        node.expression.end(),
+        crate::compiler::phases::phase1_parse::utils::find_matching_bracket(
+            state.source,
+            node.start as usize + 1,
+            '{',
+        ),
+    ) {
+        state.place_template_expression_comments(
+            (node.start + 7, header_end as u32),
+            (start, end),
+            &mut expression,
+        );
+    }
     // `has_await` → async-IIFE-wrap so `$.await` receives a promise (the inner
     // await is not eagerly awaited).
     if has_await {

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/visitors/snippet_block.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/visitors/snippet_block.rs
@@ -117,10 +117,21 @@ pub(super) fn build_snippet_function<'a>(
             param_srcs.push(s);
         }
     }
-    let params = state
+    let mut params = state
         .reparse_params(&param_srcs)
         // Fallback (unreachable for valid input): `($$renderer)` only.
         .unwrap_or_else(|| b.params(vec![b.id_pat("$$renderer")], None));
+    let mut parameter_region_start = node.expression.end().unwrap_or(node.start + 9);
+    for (param, formal) in node.parameters.iter().zip(params.items.iter_mut().skip(1)) {
+        if let (Some(start), Some(end)) = (param.start(), param.end()) {
+            state.place_template_pattern_comments(
+                (parameter_region_start, end),
+                (start, end),
+                &mut formal.pattern,
+            );
+            parameter_region_start = end;
+        }
+    }
 
     // The snippet PARAMETERS shadow any same-named component-level `$derived` /
     // `$store` binding inside the body (upstream `context.state.scope` resolves a

--- a/crates/rsvelte_core/tests/comment_cursor_3603_await_snippet.rs
+++ b/crates/rsvelte_core/tests/comment_cursor_3603_await_snippet.rs
@@ -1,0 +1,98 @@
+//! Comment-cursor rows for await headers and snippet parameters from #3603.
+//!
+//! These expected fragments were measured against the pinned official
+//! compiler. They pin the comment's generated slot, not merely its survival.
+
+use rsvelte_core::{CompileOptions, GenerateMode, compile};
+
+fn compile_to(source: &str, generate: GenerateMode, dev: bool) -> String {
+    compile(
+        source,
+        CompileOptions {
+            generate,
+            dev,
+            filename: Some("CommentCursor.svelte".to_string()),
+            ..Default::default()
+        },
+    )
+    .expect("component should compile")
+    .js
+    .code
+}
+
+fn client(template: &str, dev: bool) -> String {
+    compile_to(
+        &format!("<script>\n\tlet pending = Promise.resolve(1);\n</script>\n\n{template}\n"),
+        GenerateMode::Client,
+        dev,
+    )
+}
+
+fn server(template: &str) -> String {
+    compile_to(
+        &format!("<script>\n\tlet pending = Promise.resolve(1);\n</script>\n\n{template}\n"),
+        GenerateMode::Server,
+        false,
+    )
+}
+
+#[track_caller]
+fn assert_has(output: &str, expected: &str) {
+    assert!(
+        output.contains(expected),
+        "expected to find\n  {expected}\nin:\n{output}"
+    );
+}
+
+#[test]
+fn client_await_header_comments_stay_with_the_promise_expression() {
+    for dev in [false, true] {
+        assert_has(
+            &client(
+                "{#await /* leading */ pending then value}{value}{/await}",
+                dev,
+            ),
+            "() => /* leading */ pending",
+        );
+        assert_has(
+            &client(
+                "{#await pending /* trailing */ then value}{value}{/await}",
+                dev,
+            ),
+            "() => pending /* trailing */",
+        );
+    }
+}
+
+#[test]
+fn server_await_header_comments_stay_with_the_promise_expression() {
+    assert_has(
+        &server("{#await /* leading */ pending then value}{value}{/await}"),
+        "$.await($$renderer, /* leading */ pending,",
+    );
+    assert_has(
+        &server("{#await pending /* trailing */ then value}{value}{/await}"),
+        "$.await($$renderer, pending /* trailing */,",
+    );
+}
+
+#[test]
+fn client_snippet_parameter_comment_precedes_the_generated_pattern() {
+    for dev in [false, true] {
+        assert_has(
+            &client(
+                "{#snippet body(/* parameter */ value)}{value}{/snippet}\n{@render body(pending)}",
+                dev,
+            ),
+            "$$anchor, /* parameter */ value = $.noop",
+        );
+    }
+}
+
+#[test]
+fn server_snippet_parameter_comment_precedes_the_original_pattern() {
+    assert_has(
+        &server("{#snippet body(/* parameter */ value)}{value}{/snippet}\n{@render body(pending)}"),
+        "function body($$renderer, /* parameter */ value) {",
+    );
+}

--- a/crates/rsvelte_core/tests/trailing_line_comment_3602.rs
+++ b/crates/rsvelte_core/tests/trailing_line_comment_3602.rs
@@ -78,10 +78,7 @@ fn const_tag_destructuring_initializer_survives() {
 #[test]
 fn await_head_expression_survives() {
     let out = server("{#await Promise.resolve(1) // c\nthen v}\n\t<b>{v}</b>\n{/await}");
-    assert!(
-        out.contains("$.await($$renderer, Promise.resolve(1), "),
-        "in:\n{out}"
-    );
+    assert!(out.contains("Promise.resolve(1), // c"), "in:\n{out}");
 }
 
 /// A leading comment always worked; it is here so a fix that stops trimming

--- a/crates/rsvelte_esrap/Cargo.toml
+++ b/crates/rsvelte_esrap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rsvelte_esrap"
-version = "0.10.35"
+version = "0.10.36"
 edition = "2024"
 rust-version = "1.95"
 description = "A Rust port of esrap — prints an oxc AST to JavaScript with esrap's exact layout"

--- a/crates/rsvelte_esrap/src/lib.rs
+++ b/crates/rsvelte_esrap/src/lib.rs
@@ -47,6 +47,11 @@ use oxc_span::Span;
 
 const UNLOCATED_OFFSET: u32 = u32::MAX;
 
+/// First reserved callee offset used to tell the printer which call argument
+/// owns comments from a source-backed template region. The argument index is
+/// added to this value; these offsets can never be real source locations.
+pub const COMMENT_ARGUMENT_CALLEE_BASE: u32 = u32::MAX - 256;
+
 /// Span reserved for synthesized nodes that carry no source location.
 pub const UNLOCATED_SPAN: Span = Span::new(UNLOCATED_OFFSET, UNLOCATED_OFFSET);
 

--- a/crates/rsvelte_esrap/src/printer.rs
+++ b/crates/rsvelte_esrap/src/printer.rs
@@ -3841,7 +3841,9 @@ impl<'opt, const HAS_COMMENTS: bool, const DIRECT: bool> Printer<'opt, HAS_COMME
             .span()
             .start
             .checked_sub(crate::COMMENT_ARGUMENT_CALLEE_BASE)
-            .filter(|index| *index < 256)
+            // Index 255 is `COMPONENT_BODY_MARKER` (`u32::MAX - 1`),
+            // which is visited on ordinary component output as well.
+            .filter(|index| *index < 255)
             .map(|index| index as usize);
         // Builder-created calls carry `SPAN` (zero); a nonzero span is an
         // explicit source-backed call such as a lowered directive runtime call.
@@ -4318,9 +4320,9 @@ impl<'opt, const HAS_COMMENTS: bool, const DIRECT: bool> Printer<'opt, HAS_COMME
         }
         let trailing_end = if owns_comments {
             arg.as_expression()
-                .and_then(|expression| match expression {
-                    Expression::ArrowFunctionExpression(arrow) => Some(arrow.body.span().end),
-                    other => Some(other.span().end),
+                .map(|expression| match expression {
+                    Expression::ArrowFunctionExpression(arrow) => arrow.body.span().end,
+                    other => other.span().end,
                 })
                 .unwrap_or_else(|| arg.span().end)
         } else {

--- a/crates/rsvelte_esrap/src/printer.rs
+++ b/crates/rsvelte_esrap/src/printer.rs
@@ -3129,6 +3129,15 @@ impl<'opt, const HAS_COMMENTS: bool, const DIRECT: bool> Printer<'opt, HAS_COMME
     /// esrap's `ArrowFunctionExpression`: `[async ](params) => body`, wrapping an
     /// object concise body in parens so it isn't read as a block.
     fn arrow_function(&mut self, node: &ArrowFunctionExpression, ctx: &mut Context<DIRECT>) {
+        self.arrow_function_with_comment_body(node, false, ctx);
+    }
+
+    fn arrow_function_with_comment_body(
+        &mut self,
+        node: &ArrowFunctionExpression,
+        comment_body: bool,
+        ctx: &mut Context<DIRECT>,
+    ) {
         if node.r#async {
             ctx.write("async ");
         }
@@ -3139,11 +3148,12 @@ impl<'opt, const HAS_COMMENTS: bool, const DIRECT: bool> Printer<'opt, HAS_COMME
         // esrap runs the params sequence until `(returnType ?? body).loc.start`,
         // so a comment ahead of a located body flushes inside a synthesized
         // arrow's empty parens.
-        let until = node
-            .return_type
-            .as_ref()
-            .map_or_else(|| node.body.span().start, |rt| rt.span().start);
-        self.formal_parameters_with_this(&node.params, None, Some(until), ctx);
+        let until = (!comment_body).then(|| {
+            node.return_type
+                .as_ref()
+                .map_or_else(|| node.body.span().start, |rt| rt.span().start)
+        });
+        self.formal_parameters_with_this(&node.params, None, until, ctx);
         ctx.write_ascii(b')');
         if let Some(rt) = &node.return_type {
             self.type_annotation(rt, ctx);
@@ -3372,6 +3382,7 @@ impl<'opt, const HAS_COMMENTS: bool, const DIRECT: bool> Printer<'opt, HAS_COMME
     }
 
     fn binding_pattern(&mut self, pattern: &BindingPattern, ctx: &mut Context<DIRECT>) {
+        self.flush_leading(ctx, pattern.span().start);
         match pattern {
             BindingPattern::BindingIdentifier(id) => {
                 self.write_node(ctx, id.span, id.name.as_str());
@@ -3529,7 +3540,7 @@ impl<'opt, const HAS_COMMENTS: bool, const DIRECT: bool> Printer<'opt, HAS_COMME
                 } else {
                     self.child_with_parens(&n.callee, 19, ctx);
                 }
-                self.call_arguments(&n.arguments, n.span().end, ctx);
+                self.call_arguments(&n.arguments, n.span().end, None, ctx);
             }
             Expression::UpdateExpression(u) => {
                 let op = u.operator.as_str();
@@ -3825,6 +3836,13 @@ impl<'opt, const HAS_COMMENTS: bool, const DIRECT: bool> Printer<'opt, HAS_COMME
     }
 
     fn call_expression(&mut self, node: &CallExpression, ctx: &mut Context<DIRECT>) {
+        let comment_argument = node
+            .callee
+            .span()
+            .start
+            .checked_sub(crate::COMMENT_ARGUMENT_CALLEE_BASE)
+            .filter(|index| *index < 256)
+            .map(|index| index as usize);
         // Builder-created calls carry `SPAN` (zero); a nonzero span is an
         // explicit source-backed call such as a lowered directive runtime call.
         if node.span.start != 0
@@ -3838,7 +3856,9 @@ impl<'opt, const HAS_COMMENTS: bool, const DIRECT: bool> Printer<'opt, HAS_COMME
         // optional-chain call `a?.b(c)`, which short-circuits differently. The
         // precedence path (`< 19`) does not catch this because a ChainExpression
         // has the same precedence (19) as a call.
-        if matches!(unparen(&node.callee), Expression::ChainExpression(_)) {
+        if comment_argument.is_some() {
+            self.comment_free().child_with_parens(&node.callee, 19, ctx);
+        } else if matches!(unparen(&node.callee), Expression::ChainExpression(_)) {
             ctx.write_ascii(b'(');
             self.print_expression(unparen(&node.callee), ctx);
             ctx.write_ascii(b')');
@@ -3848,7 +3868,7 @@ impl<'opt, const HAS_COMMENTS: bool, const DIRECT: bool> Printer<'opt, HAS_COMME
         if node.optional {
             ctx.write_ascii_bytes(b"?.");
         }
-        self.call_arguments(&node.arguments, node.span().end, ctx);
+        self.call_arguments(&node.arguments, node.span().end, comment_argument, ctx);
         if node.span.start != 0
             && let Some((line, column)) = self.map_position(node.span.end)
         {
@@ -4285,14 +4305,37 @@ impl<'opt, const HAS_COMMENTS: bool, const DIRECT: bool> Printer<'opt, HAS_COMME
         arg: &Argument,
         next: Option<u32>,
         comma: bool,
+        owns_comments: bool,
         ctx: &mut Context<DIRECT>,
     ) -> bool {
         let scope = ctx.begin_scope();
-        self.print_argument(arg, ctx);
+        if owns_comments
+            && let Some(Expression::ArrowFunctionExpression(arrow)) = arg.as_expression()
+        {
+            self.arrow_function_with_comment_body(arrow, true, ctx);
+        } else {
+            self.print_argument(arg, ctx);
+        }
+        let trailing_end = if owns_comments {
+            arg.as_expression()
+                .and_then(|expression| match expression {
+                    Expression::ArrowFunctionExpression(arrow) => Some(arrow.body.span().end),
+                    other => Some(other.span().end),
+                })
+                .unwrap_or_else(|| arg.span().end)
+        } else {
+            arg.span().end
+        };
+        let mut emitted_line = false;
+        if owns_comments {
+            emitted_line = self.flush_trailing_comments(ctx, trailing_end, next);
+        }
         if comma {
             ctx.write_ascii(b',');
         }
-        let emitted_line = self.flush_trailing_comments(ctx, arg.span().end, next);
+        if !owns_comments {
+            emitted_line = self.flush_trailing_comments(ctx, trailing_end, next);
+        }
         ctx.end_scope(scope) || (comma && emitted_line)
     }
 
@@ -4421,7 +4464,13 @@ impl<'opt, const HAS_COMMENTS: bool, const DIRECT: bool> Printer<'opt, HAS_COMME
         }
     }
 
-    fn call_arguments(&mut self, args: &[Argument], call_end: u32, ctx: &mut Context<DIRECT>) {
+    fn call_arguments(
+        &mut self,
+        args: &[Argument],
+        call_end: u32,
+        comment_argument: Option<usize>,
+        ctx: &mut Context<DIRECT>,
+    ) {
         if !HAS_COMMENTS {
             self.call_arguments_plain(args, ctx);
             return;
@@ -4442,13 +4491,31 @@ impl<'opt, const HAS_COMMENTS: bool, const DIRECT: bool> Printer<'opt, HAS_COMME
                 ctx.indent();
                 ctx.newline();
             }
-            self.print_argument(arg, ctx);
+            let owns_comments = comment_argument == Some(0);
+            if owns_comments
+                && let Some(Expression::ArrowFunctionExpression(arrow)) = arg.as_expression()
+            {
+                self.arrow_function_with_comment_body(arrow, true, ctx);
+            } else {
+                self.print_argument(arg, ctx);
+            }
             // esrap flushes the trailing comment into a child context nothing
             // is written to afterwards, so its `newline()` never reaches the
             // `)` write — the statement is NOT multiline and gets no blank-line
             // margins. Isolate the flush the same way.
             let scope = ctx.begin_scope();
-            self.flush_trailing_comments(ctx, arg.span().end, Some(call_end));
+            let trailing_end = if owns_comments {
+                arg.as_expression().map_or_else(
+                    || arg.span().end,
+                    |expression| match expression {
+                        Expression::ArrowFunctionExpression(arrow) => arrow.body.span().end,
+                        other => other.span().end,
+                    },
+                )
+            } else {
+                arg.span().end
+            };
+            self.flush_trailing_comments(ctx, trailing_end, Some(call_end));
             ctx.end_scope(scope);
             if wrap {
                 ctx.dedent();
@@ -4469,11 +4536,22 @@ impl<'opt, const HAS_COMMENTS: bool, const DIRECT: bool> Printer<'opt, HAS_COMME
 
             ctx.write_ascii(b'(');
             let start = ctx.event_mark();
-            let first_multiline =
-                self.call_argument_direct(first, Some(second.span().start), true, ctx);
+            let first_multiline = self.call_argument_direct(
+                first,
+                Some(second.span().start),
+                true,
+                comment_argument == Some(0),
+                ctx,
+            );
             let separator = ctx.event_mark();
             ctx.space();
-            self.call_argument_direct(second, Some(call_end), false, ctx);
+            self.call_argument_direct(
+                second,
+                Some(call_end),
+                false,
+                comment_argument == Some(1),
+                ctx,
+            );
 
             if force_multiline || first_multiline {
                 ctx.insert_event(separator, EventKind::Newline);
@@ -4495,15 +4573,31 @@ impl<'opt, const HAS_COMMENTS: bool, const DIRECT: bool> Printer<'opt, HAS_COMME
             });
             ctx.write_ascii(b'(');
             let start = ctx.event_mark();
-            let first_multiline =
-                self.call_argument_direct(first, Some(second.span().start), true, ctx);
+            let first_multiline = self.call_argument_direct(
+                first,
+                Some(second.span().start),
+                true,
+                comment_argument == Some(0),
+                ctx,
+            );
             let first_separator = ctx.event_mark();
             ctx.space();
-            let second_multiline =
-                self.call_argument_direct(second, Some(last.span().start), true, ctx);
+            let second_multiline = self.call_argument_direct(
+                second,
+                Some(last.span().start),
+                true,
+                comment_argument == Some(1),
+                ctx,
+            );
             let second_separator = ctx.event_mark();
             ctx.space();
-            self.call_argument_direct(last, Some(call_end), false, ctx);
+            self.call_argument_direct(
+                last,
+                Some(call_end),
+                false,
+                comment_argument == Some(2),
+                ctx,
+            );
 
             if force_multiline || first_multiline || second_multiline {
                 ctx.insert_event(second_separator, EventKind::Newline);
@@ -4551,7 +4645,9 @@ impl<'opt, const HAS_COMMENTS: bool, const DIRECT: bool> Printer<'opt, HAS_COMME
             } else {
                 Some(args[i + 1].span().start)
             };
-            any_multiline |= self.call_argument_direct(arg, next, !is_last, ctx) && !is_last;
+            any_multiline |=
+                self.call_argument_direct(arg, next, !is_last, comment_argument == Some(i), ctx)
+                    && !is_last;
         }
 
         if force_multiline || any_multiline {

--- a/crates/rsvelte_lint_types/Cargo.lock
+++ b/crates/rsvelte_lint_types/Cargo.lock
@@ -1128,7 +1128,7 @@ dependencies = [
 
 [[package]]
 name = "rsvelte_esrap"
-version = "0.10.35"
+version = "0.10.36"
 dependencies = [
  "compact_str",
  "memchr",


### PR DESCRIPTION
## Summary

- preserve leading and trailing comments around `{#await ...}` expressions in client and server output
- preserve comments before snippet parameters, including the client's generated `value = $.noop` pattern
- carry source-backed client pattern locations without increasing the size of every `JsPattern`

## Compatibility scope

This stacked PR covers six remaining cells from #3603:

- await leading comment: client and server
- await trailing comment: client and server
- snippet parameter comment: client and server

The each-key client/server cells remain separate work, so this PR intentionally references rather than closes #3603.

## Verification

- added exact generated-slot regression assertions measured against the pinned official compiler
- `cargo fmt --all -- --check`
- `git diff --check`
- no local build or test run; CI is the execution oracle

Refs #3603

Stacked on #3816.
