### PR TITLE
fix: match reactive comment cursor endings

### DIFF
--- a/.changeset/reactive-comment-line-endings.md
+++ b/.changeset/reactive-comment-line-endings.md
@@ -1,0 +1,5 @@
+---
+"rsvelte": patch
+---
+
+Match Svelte's comment placement before a final legacy reactive statement with CR and Unicode line endings

--- a/.changeset/reactive-comment-line-endings.md
+++ b/.changeset/reactive-comment-line-endings.md
@@ -1,5 +1,5 @@
 ---
-"rsvelte": patch
+'@rsvelte/compiler': patch
 ---
 
 Match Svelte's comment placement before a final legacy reactive statement with CR and Unicode line endings

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/formatting.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/formatting.rs
@@ -284,12 +284,27 @@ fn reactive_statement_spans(source: &str) -> Vec<ReactiveSpan> {
             // A string is a code token, and so — for attachment purposes — is a
             // comment that trails code on the same line: it belongs to the
             // statement above, not to whatever follows.
-            let trails_code = starts_comment && !source[after_last_code..i].contains('\n');
+            //
+            // There is one deliberate exception. Upstream's client declaration
+            // lowering does not flush a trailing `//` comment when its line is
+            // ended by a lone CR or U+2028/U+2029. If the last thing after it is
+            // a rebuilt `$:` statement, the span-less effect kills the cursor and
+            // the comment disappears. CRLF follows the ordinary LF path.
+            let exotic_line_comment_end = starts_comment
+                && bytes.get(i + 1) == Some(&b'/')
+                && has_non_lf_line_comment_end(bytes, next);
+            let trails_code = starts_comment
+                && !source[after_last_code..i].contains('\n')
+                && !exotic_line_comment_end;
             if !starts_comment || trails_code {
                 after_last_code = next;
                 after_last_surviving_code = next;
             }
             i = next;
+            continue;
+        }
+        if let Some(width) = line_terminator_len(bytes, i) {
+            i += width;
             continue;
         }
         let c = bytes[i];
@@ -356,7 +371,7 @@ fn statement_can_begin(scan: &JsScan, bytes: &[u8], after_last_code: usize, at: 
         Some(c) => {
             (c.is_ascii_alphanumeric()
                 || matches!(c, b'_' | b'$' | b')' | b']' | b'\'' | b'"' | b'`'))
-                && bytes[after_last_code..at].contains(&b'\n')
+                && contains_line_terminator(&bytes[after_last_code..at])
         }
     }
 }
@@ -382,16 +397,19 @@ fn reactive_statement_end(source: &str, scan: &mut JsScan, from: usize) -> usize
             i = next;
             continue;
         }
-        let c = bytes[i];
-        if c == b'\n'
-            && body_started
-            && scan.depth == base_depth
-            && !opened_block
-            && !continues_statement(scan.last_code)
-            && !next_line_continues(source, i + 1)
-        {
-            return i;
+        if let Some(width) = line_terminator_len(bytes, i) {
+            if body_started
+                && scan.depth == base_depth
+                && !opened_block
+                && !continues_statement(scan.last_code)
+                && !next_line_continues(source, i + width)
+            {
+                return i;
+            }
+            i += width;
+            continue;
         }
+        let c = bytes[i];
         if c.is_ascii_whitespace() {
             i += 1;
             continue;
@@ -537,7 +555,7 @@ fn extend_over_trailing_comment(source: &str, end: usize) -> usize {
     match bytes.get(i + 1) {
         Some(b'/') => {
             let mut j = i + 2;
-            while j < bytes.len() && bytes[j] != b'\n' {
+            while j < bytes.len() && line_terminator_len(bytes, j).is_none() {
                 j += 1;
             }
             j
@@ -839,7 +857,7 @@ impl JsScan {
 
         if c == b'/' && bytes.get(i + 1) == Some(&b'/') {
             let mut end = i + 2;
-            while end < len && bytes[end] != b'\n' {
+            while end < len && line_terminator_len(bytes, end).is_none() {
                 end += 1;
             }
             return Some(end);
@@ -866,6 +884,40 @@ impl JsScan {
 
         None
     }
+}
+
+/// Width in bytes of an ECMAScript `LineTerminator` at `i`.
+fn line_terminator_len(bytes: &[u8], i: usize) -> Option<usize> {
+    match bytes.get(i) {
+        Some(b'\n') => Some(1),
+        Some(b'\r') if bytes.get(i + 1) == Some(&b'\n') => Some(2),
+        Some(b'\r') => Some(1),
+        Some(0xE2)
+            if bytes.get(i + 1) == Some(&0x80) && matches!(bytes.get(i + 2), Some(0xA8 | 0xA9)) =>
+        {
+            Some(3)
+        }
+        _ => None,
+    }
+}
+
+fn contains_line_terminator(bytes: &[u8]) -> bool {
+    let mut i = 0;
+    while i < bytes.len() {
+        if line_terminator_len(bytes, i).is_some() {
+            return true;
+        }
+        i += 1;
+    }
+    false
+}
+
+/// `end` is the first byte after a scanned line comment. Only the three line
+/// endings for which upstream misses the declaration's trailing-comment flush
+/// take the dead-cursor path; CRLF behaves like LF.
+fn has_non_lf_line_comment_end(bytes: &[u8], end: usize) -> bool {
+    (matches!(bytes.get(end), Some(b'\r')) && bytes.get(end + 1) != Some(&b'\n'))
+        || matches!(line_terminator_len(bytes, end), Some(3))
 }
 
 /// Strip `/* $$async_noop... */;` placeholders from script output.
@@ -1517,6 +1569,41 @@ mod reactive_comment_tests {
         assert_kept("/** @type {number} */\nlet x = 1;\n$: y = x;\n");
         assert_kept("let x = 1; // trailing\n$: y = x;\n");
         assert_kept("// leading the whole script\nlet x = 1;\n$: y = x;\n");
+    }
+
+    /// Upstream does not flush the declaration's trailing comment for these
+    /// three line endings. The last reactive statement is rebuilt without a
+    /// location, so its effect kills the still-pending comment cursor.
+    #[test]
+    fn drops_an_exotic_line_comment_before_the_last_reactive_statement() {
+        for terminator in ["\r", "\u{2028}", "\u{2029}"] {
+            let source = format!("let x = 1; // gone{terminator}$: y = x;{terminator}");
+            let out = rehome_reactive_statement_comments(&source);
+            assert!(
+                !out.contains("// gone"),
+                "terminator {terminator:?}: {out:?}"
+            );
+            assert!(
+                out.contains("$: y = x;"),
+                "terminator {terminator:?}: {out:?}"
+            );
+        }
+    }
+
+    /// LF and CRLF take esrap's normal trailing-comment path, and a later
+    /// located statement revives the cursor even after an exotic terminator.
+    #[test]
+    fn keeps_the_controls_for_an_exotic_reactive_comment() {
+        assert_kept("let x = 1; // kept\n$: y = x;\n");
+        assert_kept("let x = 1; // kept\r\n$: y = x;\r\n");
+        for terminator in ["\r", "\u{2028}", "\u{2029}"] {
+            let source = format!("let x = 1; // kept{terminator}$: y = x;{terminator}let z = 2;");
+            assert_eq!(
+                rehome_reactive_statement_comments(&source),
+                source,
+                "terminator {terminator:?}"
+            );
+        }
     }
 
     #[test]

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/script.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/server/ast/script.rs
@@ -673,7 +673,7 @@ fn trailing_comment_end(src: &str, all: &[Comment], stmt_end: u32) -> u32 {
             continue;
         }
         let gap = &src[end as usize..comment.span.start as usize];
-        if gap.contains(['\n', '\r']) || !gap.trim().is_empty() {
+        if gap.contains(['\n', '\r', '\u{2028}', '\u{2029}']) || !gap.trim().is_empty() {
             break;
         }
         end = comment.span.end;
@@ -683,7 +683,9 @@ fn trailing_comment_end(src: &str, all: &[Comment], stmt_end: u32) -> u32 {
         return stmt_end;
     }
     let after = &src[end as usize..];
-    let line_end = after.find(['\n', '\r']).unwrap_or(after.len());
+    let line_end = after
+        .find(['\n', '\r', '\u{2028}', '\u{2029}'])
+        .unwrap_or(after.len());
     if after[..line_end].trim().is_empty() {
         end
     } else {

--- a/crates/rsvelte_core/tests/reactive_comment_attachment_3469.rs
+++ b/crates/rsvelte_core/tests/reactive_comment_attachment_3469.rs
@@ -1,0 +1,73 @@
+//! Issue #3469 — a line comment between a surviving declaration and the last
+//! legacy `$:` statement follows esrap's comment cursor, not source ownership.
+//!
+//! LF and CRLF let the declaration flush the comment as trailing trivia. With a
+//! lone CR or U+2028/U+2029, upstream leaves it pending; the synthesized,
+//! location-less `legacy_pre_effect` then kills the cursor and the client drops
+//! it. The server's hoisted reactive declarator is located, so it flushes the
+//! comment for every spelling.
+
+use rsvelte_core::{CompileOptions, GenerateMode, compile};
+
+fn compile_to(source: &str, generate: GenerateMode) -> String {
+    compile(
+        source,
+        CompileOptions {
+            filename: Some("Test.svelte".to_string()),
+            generate,
+            ..Default::default()
+        },
+    )
+    .expect("compile failed")
+    .js
+    .code
+}
+
+fn source(terminator: &str) -> String {
+    format!(
+        "<script>{t}let a = 1; // c{t}$: b = a + 1;{t}</script>{t}<p>{{b}}</p>\n",
+        t = terminator
+    )
+}
+
+#[test]
+fn client_drops_the_comment_for_the_three_exotic_line_endings() {
+    for terminator in ["\r", "\u{2028}", "\u{2029}"] {
+        let output = compile_to(&source(terminator), GenerateMode::Client);
+        assert!(
+            !output.contains("// c"),
+            "terminator {terminator:?} must follow upstream's dead cursor:\n{output}"
+        );
+        assert!(
+            output.contains("$.legacy_pre_effect(() => {}, () => {"),
+            "the comment fix must not lose the reactive effect:\n{output}"
+        );
+    }
+}
+
+#[test]
+fn client_keeps_the_lf_and_crlf_controls() {
+    for terminator in ["\n", "\r\n"] {
+        let output = compile_to(&source(terminator), GenerateMode::Client);
+        assert!(
+            output.contains("// c"),
+            "terminator {terminator:?} must keep the declaration's trailing comment:\n{output}"
+        );
+    }
+}
+
+#[test]
+fn server_flushes_the_comment_at_the_hoisted_declarator_for_every_terminator() {
+    for terminator in ["\n", "\r\n", "\r", "\u{2028}", "\u{2029}"] {
+        let output = compile_to(&source(terminator), GenerateMode::Server);
+        assert!(
+            output.contains("let // c\n\tb;"),
+            "terminator {terminator:?} must flush at the located hoist:\n{output}"
+        );
+        assert_eq!(
+            output.matches("// c").count(),
+            1,
+            "terminator {terminator:?} must print the comment once:\n{output}"
+        );
+    }
+}

--- a/crates/rsvelte_core/tests/reactive_comment_attachment_3469.rs
+++ b/crates/rsvelte_core/tests/reactive_comment_attachment_3469.rs
@@ -25,7 +25,7 @@ fn compile_to(source: &str, generate: GenerateMode) -> String {
 
 fn source(terminator: &str) -> String {
     format!(
-        "<script>{t}let a = 1; // c{t}$: b = a + 1;{t}</script>{t}<p>{{b}}</p>\n",
+        "<script>\nlet a = 1; // c{t}$: b = a + 1;\n</script>\n<p>{{b}}</p>\n",
         t = terminator
     )
 }
@@ -39,7 +39,7 @@ fn client_drops_the_comment_for_the_three_exotic_line_endings() {
             "terminator {terminator:?} must follow upstream's dead cursor:\n{output}"
         );
         assert!(
-            output.contains("$.legacy_pre_effect(() => {}, () => {"),
+            output.contains("$.set(b, a + 1);"),
             "the comment fix must not lose the reactive effect:\n{output}"
         );
     }


### PR DESCRIPTION
## Summary

- match Svelte's client comment cursor for a line comment immediately before the final legacy reactive statement
- recognize every ECMAScript line terminator while scanning reactive statement spans
- preserve the LF, CRLF, and later-located-statement controls while dropping the comment only for lone CR, U+2028, and U+2029 in the measured dead-cursor shape
- add focused client/server regression coverage and a patch changeset

The server half reported in #3469 was already fixed by #3339: its located hoisted reactive declarator flushes the comment for all five line-ending spellings. This PR addresses only the three remaining client matrix cells.

## Verification

- `cargo fmt --all`
- `cargo fmt --all -- --check`
- `git diff --check`

Per the requested workflow, I did not run a local Rust build or test suite. CI is the authoritative build and test result.

Closes #3469
