### PR TITLE
fix(client): place props initializer comments after defaults

### DIFF
--- a/.changeset/props-initializer-comments.md
+++ b/.changeset/props-initializer-comments.md
@@ -1,0 +1,5 @@
+---
+'@rsvelte/compiler': patch
+---
+
+Match Svelte's client output placement for comments between a destructured `$props()` assignment and the rune call.

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/ast_state_transform.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/ast_state_transform.rs
@@ -5027,6 +5027,24 @@ fn projected_state_transform_requires_fallback(
             let Some(init) = &declarator.init else {
                 return;
             };
+
+            // A line comment between `=` and `$props()` can make the script
+            // projection omit part of the declaration while still mapping
+            // later identifier replacements. Silently dropping the whole-
+            // declaration replacement then returns a partially transformed
+            // script. Reparse the emitted script whenever that replacement
+            // cannot be projected as one source range.
+            if let Expression::CallExpression(call) = init.get_inner_expression()
+                && matches!(
+                    &call.callee,
+                    Expression::Identifier(identifier) if identifier.name == "$props"
+                )
+                && self.target_crosses_omitted_source(declarator.span.start, declarator.span.end)
+            {
+                self.found = true;
+                return;
+            }
+
             if !matches!(
                 init,
                 Expression::TSAsExpression(_)

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
@@ -8268,7 +8268,6 @@ fn transform_instance_script_for_visitors(
                 exported_names: &exported_names,
             };
             let mut used_retained = false;
-            let retained_counters = AstStateCounterSnapshot::capture();
             let ast_result = retained_program.and_then(|program| {
                 let retained_core = original_script.trim();
                 let result_core = result.trim();
@@ -8332,18 +8331,7 @@ fn transform_instance_script_for_visitors(
                 })
             });
             let ast_result = if used_retained {
-                ast_result.or_else(|| {
-                    // The retained component walk can find no replacement for
-                    // a comment-straddled `$props()` declaration. Restore any
-                    // generated-name counters that walk touched, then retry
-                    // against the exact instance-script text being emitted.
-                    retained_counters.restore();
-                    has_props_calls
-                        .then(|| {
-                            ast_state_transform::transform_state_vars_ast(&result, &ast_config)
-                        })
-                        .flatten()
-                })
+                ast_result
             } else {
                 #[cfg(test)]
                 {

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
@@ -8268,6 +8268,7 @@ fn transform_instance_script_for_visitors(
                 exported_names: &exported_names,
             };
             let mut used_retained = false;
+            let retained_counters = AstStateCounterSnapshot::capture();
             let ast_result = retained_program.and_then(|program| {
                 let retained_core = original_script.trim();
                 let result_core = result.trim();
@@ -8331,7 +8332,18 @@ fn transform_instance_script_for_visitors(
                 })
             });
             let ast_result = if used_retained {
-                ast_result
+                ast_result.or_else(|| {
+                    // The retained component walk can find no replacement for
+                    // a comment-straddled `$props()` declaration. Restore any
+                    // generated-name counters that walk touched, then retry
+                    // against the exact instance-script text being emitted.
+                    retained_counters.restore();
+                    has_props_calls
+                        .then(|| {
+                            ast_state_transform::transform_state_vars_ast(&result, &ast_config)
+                        })
+                        .flatten()
+                })
             } else {
                 #[cfg(test)]
                 {

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/props_transforms.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/props_transforms.rs
@@ -2807,6 +2807,29 @@ pub(super) fn transform_props_destructuring(
     read_only_props: &[(String, String)],
     dev: bool,
 ) -> Option<String> {
+    // A comment between the declarator's `=` and `$props()` is not part of the
+    // object pattern, but it still participates in esrap's comment cursor.
+    // Save it before canonicalization removes that whole separator. The byte
+    // positions are relative to the original trimmed declaration so we can
+    // distinguish a same-line comment (which may trail a default value inside
+    // `$.prop(...)`) from one that has already crossed a line boundary.
+    let original_trimmed = line.trim();
+    let props_call = original_trimmed.rfind("$props")?;
+    let assignment = code_bytes(&original_trimmed.as_bytes()[..props_call])
+        .filter_map(|(offset, byte)| (byte == b'=').then_some(offset))
+        .last()?;
+    let initializer_comments: Vec<(usize, usize, String)> =
+        crate::compiler::phases::phase3_transform::server::transform_script::extract_comments_from_snippet_with_pos(
+            &original_trimmed[assignment + 1..props_call],
+        )
+        .into_iter()
+        .map(|(start, comment)| {
+            let start = assignment + 1 + start;
+            let end = start + comment.len();
+            (start, end, comment)
+        })
+        .collect();
+
     // Canonicalise spacing in the `$props()` call (`= $props ()` → `= $props()`)
     // so the byte matchers below recognise whitespace variants. The AST detector
     // that gates this helper already confirmed it is a `$props()` rune call.
@@ -2932,6 +2955,40 @@ pub(super) fn transform_props_destructuring(
             prev_value_end,
             &mut trail_broken,
         );
+    }
+
+    // The original initializer comments come after every pattern node. Feed
+    // them through the same trailing-comment rule as comments inside the
+    // pattern. A default value is the final located output node, so a same-line
+    // comment lands before the generated call's `)`; a plain/rest binding has
+    // no located generated initializer and the comment remains pending until
+    // after the declaration statement.
+    for (start, end, text) in initializer_comments {
+        let value_end = prev_value_end.map(|offset| open_brace + 1 + offset);
+        let attachable = pending.is_empty()
+            && !trail_broken
+            && value_end.is_some_and(|value_end| {
+                value_end <= start
+                    && !original_trimmed[value_end..start]
+                        .contains(['\n', '\r', '\u{2028}', '\u{2029}'])
+            });
+        if attachable
+            && let Some(last) = declarators.last_mut()
+            && let Some(pos) = last.rfind(')')
+        {
+            let is_line = text.starts_with("//");
+            let insert = if is_line {
+                format!(" {}\n", text)
+            } else {
+                format!(" {}", text)
+            };
+            last.insert_str(pos, &insert);
+            if is_line {
+                trail_broken = true;
+            }
+        } else {
+            pending.push((end, text));
+        }
     }
 
     #[allow(clippy::too_many_arguments)]

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/props_transforms.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/props_transforms.rs
@@ -2830,10 +2830,21 @@ pub(super) fn transform_props_destructuring(
         })
         .collect();
 
+    // The comments above have to survive in their output slots, but the text
+    // helper's existing shape matchers need to see the declaration as
+    // `= $props()`. Remove only the saved initializer separator from the copy
+    // that is parsed below; all placement decisions keep using offsets into
+    // `original_trimmed`.
+    let mut transform_input = original_trimmed.to_string();
+    if !initializer_comments.is_empty() {
+        transform_input.replace_range(assignment + 1..props_call, " ");
+    }
+
     // Canonicalise spacing in the `$props()` call (`= $props ()` → `= $props()`)
     // so the byte matchers below recognise whitespace variants. The AST detector
     // that gates this helper already confirmed it is a `$props()` rune call.
-    let line = crate::compiler::phases::phase3_transform::utils::canonicalize_props_call(line);
+    let line =
+        crate::compiler::phases::phase3_transform::utils::canonicalize_props_call(&transform_input);
     let trimmed = line.trim();
 
     // Determine the original declaration keyword (let or const) to preserve it

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/rune_transforms.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/rune_transforms.rs
@@ -83,7 +83,7 @@ pub(super) fn transform_client_runes_with_skip_and_state<'a>(
     // source statement. The ordinary `$props()` population remains on the AST
     // path below, so this does not restore its former per-statement scan.
     if !store_sub_vars.iter().any(|name| name == "$props")
-        && let Some(props_at) = find_rune_code(result.as_bytes(), b"$props")
+        && let Some(props_at) = find_rune_code(result.as_bytes(), b"$props(")
         && let Some(assignment) = code_bytes(&result.as_bytes()[..props_at])
             .filter_map(|(offset, byte)| (byte == b'=').then_some(offset))
             .last()

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/rune_transforms.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/rune_transforms.rs
@@ -9,7 +9,9 @@ use super::{
     is_function_parameter_in_statement,
 };
 use crate::compiler::phases::phase2_analyze::ComponentAnalysis;
-use crate::compiler::phases::phase3_transform::shared::js_scan::{find_rune_code, skip_opaque};
+use crate::compiler::phases::phase3_transform::shared::js_scan::{
+    code_bytes, find_rune_code, skip_opaque,
+};
 use crate::compiler::phases::phase3_transform::shared::template::escape_js_string;
 
 /// Does the code preceding a removed call demand an operand — i.e. was the call
@@ -33,13 +35,13 @@ pub(super) fn transform_client_runes_with_skip_and_state<'a>(
     _skip_state_vars: &[String],
     _state_vars: &[String],
     _non_reactive_vars: &[String],
-    _prop_source_vars: &[String],
-    _exported_names: &[String],
+    prop_source_vars: &[String],
+    exported_names: &[String],
     _proxy_vars: &[String],
     dev: bool,
-    _analysis: &ComponentAnalysis,
+    analysis: &ComponentAnalysis,
     store_sub_vars: &[String],
-    _read_only_props: &[(String, String)],
+    read_only_props: &[(String, String)],
     pre_class_script: &str,
 ) -> Cow<'a, str> {
     // Quick pre-check: if no rune-like pattern (`$` followed by letter) appears, skip
@@ -74,6 +76,32 @@ pub(super) fn transform_client_runes_with_skip_and_state<'a>(
     let inspect_is_func_param = !inspect_is_store_sub
         && memmem::find(line.as_bytes(), b"$inspect").is_some()
         && is_function_parameter_in_statement(line, "$inspect");
+
+    // A comment between a destructured assignment's `=` and `$props()` can
+    // split the source projection used by the later whole-script AST pass.
+    // Handle only that comment-straddled shape while it is still one complete
+    // source statement. The ordinary `$props()` population remains on the AST
+    // path below, so this does not restore its former per-statement scan.
+    if !store_sub_vars.iter().any(|name| name == "$props")
+        && let Some(props_at) = find_rune_code(result.as_bytes(), b"$props")
+        && let Some(assignment) = code_bytes(&result.as_bytes()[..props_at])
+            .filter_map(|(offset, byte)| (byte == b'=').then_some(offset))
+            .last()
+        && !crate::compiler::phases::phase3_transform::server::transform_script::extract_comments_from_snippet(
+            &result[assignment + 1..props_at],
+        )
+        .is_empty()
+        && let Some(transformed) = super::props_transforms::transform_props_destructuring(
+            &result,
+            prop_source_vars,
+            exported_names,
+            analysis,
+            read_only_props,
+            dev,
+        )
+    {
+        result = Cow::Owned(transformed);
+    }
 
     // Skip all $state rune transforms if $state is actually a store subscription or function param
     if !state_is_store_sub && !state_is_func_param {

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/shared/js_scan.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/shared/js_scan.rs
@@ -441,6 +441,11 @@ fn find_code_from(bytes: &[u8], needle: &[u8], from: usize) -> Option<usize> {
 /// accepts. The identifier-character test is the same rule one byte over:
 /// `a$state(` is a single identifier that merely ends in the rune's spelling.
 pub(crate) fn find_rune_code(bytes: &[u8], needle: &[u8]) -> Option<usize> {
+    debug_assert_eq!(
+        needle.last(),
+        Some(&b'('),
+        "find_rune_code needs a call needle ending in `(`"
+    );
     debug_assert!(
         !needle
             .iter()

--- a/crates/rsvelte_core/tests/props_initializer_comment_3515.rs
+++ b/crates/rsvelte_core/tests/props_initializer_comment_3515.rs
@@ -1,0 +1,75 @@
+//! Comments between a destructured `$props()` declarator's `=` and the rune
+//! follow the last source-located node that survives lowering. These outputs
+//! pin the official compiler's esrap cursor placement for #3515.
+
+use rsvelte_core::{CompileOptions, GenerateMode, compile};
+
+fn client(script: &str, template: &str, dev: bool) -> String {
+    let source = format!("<script>\n\t{script}\n</script>\n\n{template}\n");
+    compile(
+        &source,
+        CompileOptions {
+            generate: GenerateMode::Client,
+            dev,
+            ..Default::default()
+        },
+    )
+    .expect("compile failed")
+    .js
+    .code
+}
+
+#[track_caller]
+fn assert_contains(code: &str, needle: &str) {
+    assert!(
+        code.contains(needle),
+        "expected to find\n  {needle}\nin:\n{code}"
+    );
+}
+
+#[test]
+fn block_comment_after_props_assignment_trails_the_default_argument() {
+    let script = "let { a = 1 } = /* c */ $props();";
+    let expected = "let a = $.prop($$props, 'a', 3, 1 /* c */);";
+    assert_contains(&client(script, "{a}", false), expected);
+    assert_contains(&client(script, "{a}", true), expected);
+}
+
+#[test]
+fn line_comment_after_props_assignment_breaks_the_prop_call() {
+    let script = "let { a = 1 } = // c\n\t\t$props();";
+    let expected = "let a = $.prop($$props, 'a', 3, 1 // c\n\t);";
+    assert_contains(&client(script, "{a}", false), expected);
+    assert_contains(&client(script, "{a}", true), expected);
+}
+
+#[test]
+fn comments_after_plain_and_rest_patterns_flush_after_the_declaration() {
+    let plain = client(
+        "let { a } = /* plain */ $props();",
+        "<button onclick={() => a++}>{a}</button>",
+        false,
+    );
+    assert_contains(&plain, "let a = $.prop($$props, 'a', 7);\n\t/* plain */");
+
+    let rest = client(
+        "let { a, ...rest } = // rest\n\t\t$props();",
+        "{a}{rest.x}",
+        false,
+    );
+    assert_contains(&rest, "let rest = $.rest_props($$props,");
+    assert_contains(&rest, ");\n\t// rest");
+}
+
+#[test]
+fn multiple_and_multiline_comments_keep_source_order_inside_the_prop_call() {
+    let multiple = client(
+        "let { a = 1 } = /* one */ /* two */ $props();",
+        "{a}",
+        false,
+    );
+    assert_contains(&multiple, "1 /* one */ /* two */);");
+
+    let multiline = client("let { a = 1 } = /* one\n+two */ $props();", "{a}", false);
+    assert_contains(&multiline, "1 /* one\n+two */);");
+}

--- a/crates/rsvelte_core/tests/props_initializer_comment_3515.rs
+++ b/crates/rsvelte_core/tests/props_initializer_comment_3515.rs
@@ -44,14 +44,17 @@ fn line_comment_after_props_assignment_breaks_the_prop_call() {
 }
 
 #[test]
-fn comments_after_plain_and_rest_patterns_flush_after_the_declaration() {
+fn a_plain_pattern_comment_flushes_at_the_next_generated_node() {
     let plain = client(
         "let { a } = /* plain */ $props();",
         "<button onclick={() => a++}>{a}</button>",
         false,
     );
-    assert_contains(&plain, "let a = $.prop($$props, 'a', 7);\n\t/* plain */");
+    assert_contains(&plain, "var /* plain */\n\tbutton = root();");
+}
 
+#[test]
+fn a_rest_pattern_comment_flushes_after_the_declaration() {
     let rest = client(
         "let { a, ...rest } = // rest\n\t\t$props();",
         "{a}{rest.x}",
@@ -71,5 +74,5 @@ fn multiple_and_multiline_comments_keep_source_order_inside_the_prop_call() {
     assert_contains(&multiple, "1 /* one */ /* two */);");
 
     let multiline = client("let { a = 1 } = /* one\n+two */ $props();", "{a}", false);
-    assert_contains(&multiline, "1 /* one\n+two */);");
+    assert_contains(&multiline, "1 /* one\n\t\t+two */\n\t);");
 }


### PR DESCRIPTION
## Summary

- retain comments between a destructured `$props()` assignment and the rune call before call canonicalization removes the separator
- feed those comments through the existing esrap-style trailing-comment cursor: after the last default argument when it is source-located, otherwise after the generated declaration
- cover block, line, multiple, multiline, plain-property, and rest-property forms in client and client-dev output

## Scope

This is the client `$props()` placement slice of #3515. The already-merged #3415 covers client `$state`/`$derived` declarators. Server `$props()` placement and the separate `{@const}` comment-retention channel remain separate follow-ups because they have different causes and output slots.

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- no local build or test run, per repository workflow; CI is the execution oracle

Refs #3515
