### PR TITLE
perf(napi): skip unused AST in binary compile APIs

### DIFF
--- a/.changeset/quiet-binary-ast.md
+++ b/.changeset/quiet-binary-ast.md
@@ -1,0 +1,6 @@
+---
+"@rsvelte/compiler": patch
+"@rsvelte/vite-plugin-svelte-native": patch
+---
+
+Skip materializing the public component AST for native buffer and envelope APIs whose binary formats do not expose it.

--- a/crates/rsvelte_core/src/compiler/mod.rs
+++ b/crates/rsvelte_core/src/compiler/mod.rs
@@ -699,6 +699,20 @@ pub fn compile(source: &str, options: CompileOptions) -> Result<CompileResult, C
     crate::toolchain::PreparedComponent::new(source, options)?.compile_mode(generate)
 }
 
+/// Compile without materializing the public AST for bindings whose wire format
+/// does not expose it.
+#[doc(hidden)]
+pub fn compile_without_ast(
+    source: &str,
+    options: CompileOptions,
+) -> Result<CompileResult, CompileError> {
+    let generate = options.generate;
+    let normalized = identifier_escapes::normalize_component_source(source, options.modern_ast);
+    let source = normalized.as_deref().unwrap_or(source);
+    crate::toolchain::PreparedComponent::new(source, options)?
+        .compile_mode_without_ast(generate, true)
+}
+
 /// Compile a client component while exposing its generated JS program to an
 /// in-process consumer. The callback must not retain either borrow.
 pub fn compile_client_with_program_sink(
@@ -725,6 +739,18 @@ pub fn compile_with_external_sourcemap_content(
     let source = normalized.as_deref().unwrap_or(source);
     crate::toolchain::PreparedComponent::new(source, options)?
         .compile_mode_with_sourcemap_content(generate, false)
+}
+
+#[doc(hidden)]
+pub fn compile_without_ast_with_external_sourcemap_content(
+    source: &str,
+    options: CompileOptions,
+) -> Result<CompileResult, CompileError> {
+    let generate = options.generate;
+    let normalized = identifier_escapes::normalize_component_source(source, options.modern_ast);
+    let source = normalized.as_deref().unwrap_or(source);
+    crate::toolchain::PreparedComponent::new(source, options)?
+        .compile_mode_without_ast(generate, false)
 }
 
 /// Compile a single component to **both** client (CSR) and server (SSR) output in
@@ -1557,6 +1583,34 @@ pub fn compile_batch_with_external_sourcemap_content(
         .par_iter()
         .map(|(source, options)| {
             catch_compile_panic(|| compile_with_external_sourcemap_content(source, options.clone()))
+        })
+        .collect()
+}
+
+#[doc(hidden)]
+#[cfg(feature = "parallel")]
+pub fn compile_batch_without_ast(
+    inputs: &[(&str, CompileOptions)],
+) -> Vec<Result<CompileResult, CompileError>> {
+    inputs
+        .par_iter()
+        .map(|(source, options)| {
+            catch_compile_panic(|| compile_without_ast(source, options.clone()))
+        })
+        .collect()
+}
+
+#[doc(hidden)]
+#[cfg(feature = "parallel")]
+pub fn compile_batch_without_ast_with_external_sourcemap_content(
+    inputs: &[(&str, CompileOptions)],
+) -> Vec<Result<CompileResult, CompileError>> {
+    inputs
+        .par_iter()
+        .map(|(source, options)| {
+            catch_compile_panic(|| {
+                compile_without_ast_with_external_sourcemap_content(source, options.clone())
+            })
         })
         .collect()
 }

--- a/crates/rsvelte_core/src/toolchain.rs
+++ b/crates/rsvelte_core/src/toolchain.rs
@@ -434,10 +434,12 @@ impl<'source> PreparedComponent<'source> {
         let client = self.compile_mode_with_source_token_positions(
             GenerateMode::Client,
             true,
+            true,
             source_token_positions.as_mut(),
         )?;
         let server = self.compile_mode_with_source_token_positions(
             GenerateMode::Server,
+            true,
             true,
             source_token_positions.as_mut(),
         )?;
@@ -456,13 +458,32 @@ impl<'source> PreparedComponent<'source> {
         generate: GenerateMode,
         include_sourcemap_content: bool,
     ) -> Result<CompileResult, CompileError> {
-        self.compile_mode_with_source_token_positions(generate, include_sourcemap_content, None)
+        self.compile_mode_with_source_token_positions(
+            generate,
+            include_sourcemap_content,
+            true,
+            None,
+        )
+    }
+
+    pub(crate) fn compile_mode_without_ast(
+        &mut self,
+        generate: GenerateMode,
+        include_sourcemap_content: bool,
+    ) -> Result<CompileResult, CompileError> {
+        self.compile_mode_with_source_token_positions(
+            generate,
+            include_sourcemap_content,
+            false,
+            None,
+        )
     }
 
     fn compile_mode_with_source_token_positions(
         &mut self,
         generate: GenerateMode,
         include_sourcemap_content: bool,
+        include_ast: bool,
         source_token_positions: Option<&mut SourceTokenPositions<'source>>,
     ) -> Result<CompileResult, CompileError> {
         // SAFETY: `self.ast` cannot move for the duration of this mutable borrow.
@@ -493,10 +514,13 @@ impl<'source> PreparedComponent<'source> {
             options,
             self.runes_mode,
         );
-        // Upstream fills `result.ast` unconditionally — the modern tree under
-        // `modernAst`, the legacy one otherwise — from the same post-analysis
-        // AST this holds.
-        result.ast = Some(self.ast_json().to_string());
+        if include_ast {
+            // Upstream fills `result.ast` unconditionally — the modern tree under
+            // `modernAst`, the legacy one otherwise — from the same post-analysis
+            // AST this holds. Binary-only bindings opt out because their wire
+            // formats deliberately omit this field.
+            result.ast = Some(self.ast_json().to_string());
+        }
         Ok(result)
     }
 

--- a/crates/rsvelte_core/tests/toolchain_api.rs
+++ b/crates/rsvelte_core/tests/toolchain_api.rs
@@ -42,6 +42,20 @@ fn assert_compile_result_eq(
 }
 
 #[test]
+fn compile_without_ast_preserves_every_encoded_field() {
+    let source = r#"<script>let count = $state(0);</script>
+<button onclick={() => count++}>{count}</button>"#;
+    let compile_options = options(GenerateMode::Client);
+    let normal = rsvelte_core::compile(source, compile_options.clone()).expect("normal compile");
+    let without_ast = rsvelte_core::compiler::compile_without_ast(source, compile_options)
+        .expect("compile without AST");
+
+    assert_compile_result_eq(&without_ast, &normal);
+    assert!(normal.ast.is_some());
+    assert!(without_ast.ast.is_none());
+}
+
+#[test]
 fn prepared_component_reuses_analysis_and_is_repeatable() {
     let source = r#"<script context="module" lang="ts">
   export const answer: number = 42;

--- a/crates/rsvelte_napi/src/lib.rs
+++ b/crates/rsvelte_napi/src/lib.rs
@@ -62,8 +62,8 @@ use serde_json::Value;
 use rsvelte_core::compiler::{
     CompileOptions, CssMode, ExperimentalOptions, GenerateMode, ModuleCompileOptions, Namespace,
     compile as rust_compile, compile_both as rust_compile_both,
-    compile_module as rust_compile_module,
-    compile_with_external_sourcemap_content as rust_compile_with_external_sourcemap_content,
+    compile_module as rust_compile_module, compile_without_ast as rust_compile_without_ast,
+    compile_without_ast_with_external_sourcemap_content as rust_compile_without_ast_external,
 };
 use rsvelte_projection::svelte2tsx::{Svelte2TsxOptions, svelte2tsx as rust_svelte2tsx};
 
@@ -2324,7 +2324,7 @@ pub fn napi_compile_buffers(
 ) -> napi::Result<CompileBuffersResult> {
     let opts = options_to_compile(Some(&env), options)?;
     reject_modern_ast_for_binary_result(&opts, "compileBuffers")?;
-    match rust_compile(&source, opts) {
+    match rust_compile_without_ast(&source, opts) {
         Ok(result) => Ok(CompileBuffersResult {
             js: CompileBuffersJs {
                 code: Buffer::from(result.js.code.into_bytes()),
@@ -2487,9 +2487,9 @@ fn compile_envelope(
 ) -> napi::Result<Buffer> {
     reject_modern_ast_for_binary_result(&options, "compileEnvelope")?;
     let result = if externalize_sourcemap_content {
-        rust_compile_with_external_sourcemap_content(source, options)
+        rust_compile_without_ast_external(source, options)
     } else {
-        rust_compile(source, options)
+        rust_compile_without_ast(source, options)
     };
     match result {
         Ok(result) => {
@@ -2617,7 +2617,7 @@ pub fn napi_compile_envelope_zero_copy(
 ) -> napi::Result<JsBuffer> {
     let opts = options_to_compile(Some(&env), options)?;
     reject_modern_ast_for_binary_result(&opts, "compileEnvelopeZeroCopy")?;
-    let result = match rust_compile(&source, opts) {
+    let result = match rust_compile_without_ast(&source, opts) {
         Ok(r) => r,
         Err(e) => return Err(napi::Error::from_reason(format!("{e:?}"))),
     };
@@ -2767,9 +2767,9 @@ fn compile_batch_envelope(
         .map(|(s, o)| (s.as_str(), o.clone()))
         .collect();
     let results = if externalize_sourcemap_content {
-        rsvelte_core::compiler::compile_batch_with_external_sourcemap_content(&borrowed)
+        rsvelte_core::compiler::compile_batch_without_ast_with_external_sourcemap_content(&borrowed)
     } else {
-        rsvelte_core::compiler::compile_batch(&borrowed)
+        rsvelte_core::compiler::compile_batch_without_ast(&borrowed)
     };
 
     // Build the BatchEntry view over the results so the encoder can
@@ -2845,9 +2845,9 @@ impl Task for CompileEnvelopeTask {
         // field has to be re-Arc'd). Clone is fine here — options are
         // small and we only pay it once per call.
         let result = if self.externalize_sourcemap_content {
-            rust_compile_with_external_sourcemap_content(&self.source, self.options.clone())
+            rust_compile_without_ast_external(&self.source, self.options.clone())
         } else {
-            rust_compile(&self.source, self.options.clone())
+            rust_compile_without_ast(&self.source, self.options.clone())
         };
         match result {
             Ok(result) => {
@@ -2943,9 +2943,11 @@ impl Task for CompileBatchTask {
             .map(|(s, o)| (s.as_str(), o.clone()))
             .collect();
         let results = if self.externalize_sourcemap_content {
-            rsvelte_core::compiler::compile_batch_with_external_sourcemap_content(&borrowed)
+            rsvelte_core::compiler::compile_batch_without_ast_with_external_sourcemap_content(
+                &borrowed,
+            )
         } else {
-            rsvelte_core::compiler::compile_batch(&borrowed)
+            rsvelte_core::compiler::compile_batch_without_ast(&borrowed)
         };
         let err_strings: Vec<Option<String>> = results
             .iter()


### PR DESCRIPTION
## Summary

- add an internal core compile path that preserves generated JS, CSS, warnings, metadata, and sourcemaps without materializing `CompileResult.ast`
- use that path for `compileBuffers` and every component envelope/batch variant, including zero-copy and async entry points
- keep the public `compile` and `compileBoth` AST contract unchanged
- add a core regression test that compares every encoded field and asserts only the AST is omitted

This progresses #3572 by removing legacy AST conversion from native binary APIs whose wire formats cannot expose it. It deliberately does not close the issue: moving expression locations off the parser hot path still needs the issue's requested differential measurement.

## Validation

- `cargo fmt --all -- --check`
- `git diff --check origin/main...HEAD`
- `node scripts/release/check-changeset-package-names.mjs`
- `node scripts/release/check-core-consumer-changesets.mjs`

Per the task constraint, no local build or test suite was run; CI is the execution oracle.
