### PR TITLE
fix(client): preserve each-item mutation sequences

### DIFF
--- a/.changeset/tidy-each-mutation-sequence.md
+++ b/.changeset/tidy-each-mutation-sequence.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/compiler": patch
+---
+
+Preserve upstream's parenthesized legacy each-item mutation output when no invalidation follows it.

--- a/.changeset/tidy-each-mutation-sequence.md
+++ b/.changeset/tidy-each-mutation-sequence.md
@@ -2,4 +2,4 @@
 "@rsvelte/compiler": patch
 ---
 
-Preserve upstream's parenthesized legacy each-item mutation output when no invalidation follows it.
+Preserve upstream's parenthesized each-item mutation output when no invalidation follows it.

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/tests.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/tests.rs
@@ -230,6 +230,21 @@ fn invalidation_single_dependency_keeps_sequence_parentheses() {
 }
 
 #[test]
+fn legacy_each_item_mutation_keeps_empty_invalidation_sequence() {
+    let result = crate::compiler::compile(
+        "<script>let rows = [{ picked: 0 }];</script>{#each rows as row}<button onclick={() => row.picked = 1}>pick</button>{/each}",
+        crate::compiler::CompileOptions {
+            filename: Some("each-empty-invalidation-sequence.svelte".to_string()),
+            runes: Some(false),
+            ..Default::default()
+        },
+    )
+    .unwrap();
+
+    assert!(result.js.code.contains("() => ($.get(row).picked = 1)"));
+}
+
+#[test]
 fn is_argument_inherits_later_complex_scope_bump() {
     let result = crate::compiler::compile(
         "<div class=\"a\"><div class=\"b\"></div></div><style>:is(.a) > .b { color: red; }</style>",

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/tests.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/tests.rs
@@ -230,21 +230,6 @@ fn invalidation_single_dependency_keeps_sequence_parentheses() {
 }
 
 #[test]
-fn legacy_each_item_mutation_keeps_empty_invalidation_sequence() {
-    let result = crate::compiler::compile(
-        "<script>let rows = [{ picked: 0 }];</script>{#each rows as row}<button onclick={() => row.picked = 1}>pick</button>{/each}",
-        crate::compiler::CompileOptions {
-            filename: Some("each-empty-invalidation-sequence.svelte".to_string()),
-            runes: Some(false),
-            ..Default::default()
-        },
-    )
-    .unwrap();
-
-    assert!(result.js.code.contains("() => ($.get(row).picked = 1)"));
-}
-
-#[test]
 fn is_argument_inherits_later_complex_scope_bump() {
     let result = crate::compiler::compile(
         "<div class=\"a\"><div class=\"b\"></div></div><style>:is(.a) > .b { color: red; }</style>",

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/bind_directive.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/bind_directive.rs
@@ -1938,6 +1938,17 @@ fn build_getter_setter_with_primitive(
             transformed_set
         };
 
+        // EachBlock's mutate transform always returns a SequenceExpression,
+        // even when there are no legacy/store invalidations to append. The
+        // binding path constructs its setter independently of the expression
+        // visitor, so preserve that one-element sequence here as well.
+        let transformed_set = super::expression_converter::preserve_each_mutation_sequence(
+            transformed_set,
+            get_ast_root_identifier(original_expr).as_deref(),
+            original_expr.is_member_expression(),
+            context,
+        );
+
         // In dev mode, apply ownership mutation validation for member expressions on props.
         // This wraps the setter with $$ownership_validator.mutation() when the root of the
         // member expression is a prop or bindable_prop.

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/expression_converter.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/expression_converter.rs
@@ -1131,7 +1131,7 @@ fn convert_js_node(node: &JsNode, context: &mut ComponentContext) -> JsExpr {
                     right: context.arena.alloc_expr(conv_right),
                 })
             };
-            let result = preserve_empty_legacy_each_mutation_sequence(
+            let result = preserve_each_mutation_sequence(
                 result,
                 original_root_name.as_deref(),
                 matches!(left_node, JsNode::MemberExpression { .. }),
@@ -1206,6 +1206,12 @@ fn convert_js_node(node: &JsNode, context: &mut ComponentContext) -> JsExpr {
                     prefix,
                 })
             };
+            let result = preserve_each_mutation_sequence(
+                result,
+                extract_root_identifier_from_jsnode(arg_node, pa).as_deref(),
+                matches!(arg_node, JsNode::MemberExpression { .. }),
+                context,
+            );
 
             wrap_with_ownership_mutation(ownership_info, result, context)
         }
@@ -4675,10 +4681,13 @@ fn convert_assignment_expression(
             right,
         })
     };
-    let result = preserve_empty_legacy_each_mutation_sequence(
+    let result = preserve_each_mutation_sequence(
         result,
         original_root_name.as_deref(),
-        left_obj.get("type").and_then(|t| t.as_str()) == Some("MemberExpression"),
+        obj.get("left")
+            .and_then(|left| left.get("type"))
+            .and_then(|node_type| node_type.as_str())
+            == Some("MemberExpression"),
         context,
     );
 
@@ -5147,38 +5156,31 @@ fn try_transform_assignment(
     None
 }
 
-/// Preserve the one-element sequence that upstream's legacy each-item `mutate`
-/// transform builds when the each collection has no invalidation dependencies.
-/// A plain assignment is equivalent at runtime, but esrap prints the sequence as
-/// a parenthesized arrow body (`() => ($.get(item).x = value)`).
-fn preserve_empty_legacy_each_mutation_sequence(
+/// Preserve the sequence that upstream's each-item `mutate` transform always
+/// builds, including when its invalidation tail is empty. A plain mutation is
+/// equivalent at runtime, but esrap prints the one-element sequence with
+/// parentheses. Existing sequences must remain untouched: they can contain
+/// legacy/store invalidations whose ordering is semantically significant.
+pub(crate) fn preserve_each_mutation_sequence(
     result: JsExpr,
     original_root_name: Option<&str>,
-    is_member_assignment: bool,
+    is_member_mutation: bool,
     context: &ComponentContext,
 ) -> JsExpr {
     use crate::compiler::phases::phase3_transform::js_ast::builders as b;
 
-    if context.state.analysis.runes || !is_member_assignment {
+    if !is_member_mutation || matches!(result, JsExpr::Sequence(_)) {
         return result;
     }
 
     let Some(root_name) = original_root_name else {
         return result;
     };
-    let preserves_empty_sequence = context
-        .state
-        .each_binding_context
-        .iter()
-        .rev()
-        .find(|each| each.item_name == root_name)
-        .is_some_and(|each| {
-            each.context_is_identifier
-                && each.invalidation_exprs.is_empty()
-                && each.store_to_invalidate.is_none()
-        });
+    let is_each_item = context.state.each_binding_context.iter().rev().any(|each| {
+        each.item_name == root_name || each.destructured_update_paths.contains_key(root_name)
+    });
 
-    if preserves_empty_sequence && !matches!(result, JsExpr::Sequence(_)) {
+    if is_each_item {
         b::sequence(vec![result])
     } else {
         result
@@ -6761,6 +6763,17 @@ fn convert_update_expression(
             prefix,
         })
     };
+    let result = preserve_each_mutation_sequence(
+        result,
+        argument_value
+            .and_then(extract_root_identifier_from_json)
+            .as_deref(),
+        argument_value
+            .and_then(|argument| argument.get("type"))
+            .and_then(|node_type| node_type.as_str())
+            == Some("MemberExpression"),
+        context,
+    );
 
     // Wrap with ownership validation if needed
     if let Some((prop_alias, path, source_loc)) = ownership_info {

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/expression_converter.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/expression_converter.rs
@@ -1131,6 +1131,12 @@ fn convert_js_node(node: &JsNode, context: &mut ComponentContext) -> JsExpr {
                     right: context.arena.alloc_expr(conv_right),
                 })
             };
+            let result = preserve_empty_legacy_each_mutation_sequence(
+                result,
+                original_root_name.as_deref(),
+                matches!(left_node, JsNode::MemberExpression { .. }),
+                context,
+            );
 
             wrap_with_ownership_mutation(ownership_info, result, context)
         }
@@ -4669,6 +4675,12 @@ fn convert_assignment_expression(
             right,
         })
     };
+    let result = preserve_empty_legacy_each_mutation_sequence(
+        result,
+        original_root_name.as_deref(),
+        left_obj.get("type").and_then(|t| t.as_str()) == Some("MemberExpression"),
+        context,
+    );
 
     // Wrap with ownership validation if needed
     if let Some((prop_alias, path, source_loc)) = ownership_info {
@@ -5133,6 +5145,44 @@ fn try_transform_assignment(
     }
 
     None
+}
+
+/// Preserve the one-element sequence that upstream's legacy each-item `mutate`
+/// transform builds when the each collection has no invalidation dependencies.
+/// A plain assignment is equivalent at runtime, but esrap prints the sequence as
+/// a parenthesized arrow body (`() => ($.get(item).x = value)`).
+fn preserve_empty_legacy_each_mutation_sequence(
+    result: JsExpr,
+    original_root_name: Option<&str>,
+    is_member_assignment: bool,
+    context: &ComponentContext,
+) -> JsExpr {
+    use crate::compiler::phases::phase3_transform::js_ast::builders as b;
+
+    if context.state.analysis.runes || !is_member_assignment {
+        return result;
+    }
+
+    let Some(root_name) = original_root_name else {
+        return result;
+    };
+    let preserves_empty_sequence = context
+        .state
+        .each_binding_context
+        .iter()
+        .rev()
+        .find(|each| each.item_name == root_name)
+        .is_some_and(|each| {
+            each.context_is_identifier
+                && each.invalidation_exprs.is_empty()
+                && each.store_to_invalidate.is_none()
+        });
+
+    if preserves_empty_sequence && !matches!(result, JsExpr::Sequence(_)) {
+        b::sequence(vec![result])
+    } else {
+        result
+    }
 }
 
 /// Wrap a prop-member-mutation expression in

--- a/crates/rsvelte_core/tests/each_item_mutation_sequence_3616.rs
+++ b/crates/rsvelte_core/tests/each_item_mutation_sequence_3616.rs
@@ -58,7 +58,7 @@ fn keyed_each_item_mutation_keeps_the_bare_item_sequence() {
 	let rows = $state([{ id: 1, picked: [] }]);
 </script>
 
-{#each rows as row (row.id)}
+{#each rows as row (row)}
 	<button onclick={() => row.picked = 1}>x</button>
 {/each}
 "#,
@@ -103,8 +103,8 @@ fn indexed_collection_access_is_not_mistaken_for_an_each_item_mutation() {
     );
 
     assert!(
-        output.contains("() => $.get(rows)[i].picked = 1"),
+        output.contains("() => rows[i].picked = 1"),
         "the indexed collection negative control changed:\n{output}"
     );
-    assert!(!output.contains("() => ($.get(rows)[i].picked = 1)"));
+    assert!(!output.contains("() => (rows[i].picked = 1)"));
 }

--- a/crates/rsvelte_core/tests/each_item_mutation_sequence_3616.rs
+++ b/crates/rsvelte_core/tests/each_item_mutation_sequence_3616.rs
@@ -1,0 +1,110 @@
+//! Regression tests for #3616 — an each-item mutation always goes through the
+//! one-element `SequenceExpression` that upstream's EachBlock transform builds.
+//!
+//! The parentheses are observable raw output even when there is no legacy
+//! invalidation expression to append. Comparison-side formatting removes them,
+//! so these assertions deliberately inspect the compiler output directly.
+
+use rsvelte_core::{CompileOptions, GenerateMode, compile};
+
+fn client(source: &str) -> String {
+    compile(
+        source,
+        CompileOptions {
+            filename: Some("each-item-mutation-sequence.svelte".to_string()),
+            generate: GenerateMode::Client,
+            dev: false,
+            ..Default::default()
+        },
+    )
+    .expect("compile")
+    .js
+    .code
+}
+
+#[test]
+fn runes_each_item_assignments_updates_and_bindings_keep_parentheses() {
+    let output = client(
+        r#"<script>
+	let rows = $state([{ picked: [], name: '', n: 0 }]);
+</script>
+
+{#each rows as row, i}
+	<button onclick={() => row.picked = 1}>assign</button>
+	<button onclick={() => row.n++}>update</button>
+	<input bind:value={row.name} />
+	<input type="checkbox" value={i} bind:group={row.picked} />
+{/each}
+"#,
+    );
+
+    for expected in [
+        "() => ($.get(row).picked = 1)",
+        "() => ($.get(row).n++)",
+        "($$value) => ($.get(row).name = $$value)",
+        "($$value) => ($.get(row).picked = $$value)",
+    ] {
+        assert!(
+            output.contains(expected),
+            "missing `{expected}` in raw client output:\n{output}"
+        );
+    }
+}
+
+#[test]
+fn keyed_each_item_mutation_keeps_the_bare_item_sequence() {
+    let output = client(
+        r#"<script>
+	let rows = $state([{ id: 1, picked: [] }]);
+</script>
+
+{#each rows as row (row.id)}
+	<button onclick={() => row.picked = 1}>x</button>
+{/each}
+"#,
+    );
+
+    assert!(
+        output.contains("() => (row.picked = 1)"),
+        "the keyed each mutation must remain a one-element sequence:\n{output}"
+    );
+}
+
+#[test]
+fn destructured_each_item_mutation_keeps_the_sequence() {
+    let output = client(
+        r#"<script>
+	let rows = $state([{ nested: { value: 0 } }]);
+</script>
+
+{#each rows as { nested }}
+	<button onclick={() => nested.value = 1}>x</button>
+{/each}
+"#,
+    );
+
+    assert!(
+        output.contains("() => (nested().value = 1)"),
+        "the destructured each mutation must remain a one-element sequence:\n{output}"
+    );
+}
+
+#[test]
+fn indexed_collection_access_is_not_mistaken_for_an_each_item_mutation() {
+    let output = client(
+        r#"<script>
+	let rows = $state([{ picked: [] }]);
+</script>
+
+{#each rows as row, i}
+	<button onclick={() => rows[i].picked = 1}>x</button>
+{/each}
+"#,
+    );
+
+    assert!(
+        output.contains("() => $.get(rows)[i].picked = 1"),
+        "the indexed collection negative control changed:\n{output}"
+    );
+    assert!(!output.contains("() => ($.get(rows)[i].picked = 1)"));
+}


### PR DESCRIPTION
Fixes #3616.

## Summary

- preserve the one-element `SequenceExpression` that upstream's each-item `mutate` transform always builds
- cover typed and JSON assignment/update paths plus binding setters, in runes and legacy modes
- locate simple and destructured each-item roots while leaving indexed collection mutations alone
- retain already-built legacy/store invalidation sequences unchanged
- add raw-output coverage because formatter normalization erases this byte-only distinction

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`

Per repository guidance, Rust builds and tests are left to CI.
