### PR TITLE
Preserve single legacy reactive dependency sequences

### DIFF
--- a/.changeset/fair-reactive-sequences.md
+++ b/.changeset/fair-reactive-sequences.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/compiler": patch
+---
+
+Preserve upstream's parenthesized single dependency in legacy reactive effect thunks after assignment rewrites.

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/ast_state_transform.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/ast_state_transform.rs
@@ -39,7 +39,7 @@ use super::rune_transforms::{process_derived_destructuring_pattern, wrap_state_v
 use super::{DERIVED_TMP_COUNTER, SCRIPT_ARRAY_COUNTER, STATE_TMP_COUNTER, VAR_STATE_VARS};
 use crate::compiler::phases::phase2_analyze::ComponentAnalysis;
 use crate::compiler::phases::phase2_analyze::types::ScriptProjection;
-use crate::compiler::phases::phase3_transform::js_ast::to_oxc::SINGLE_TARGET_DESTRUCTURE_SEQUENCE_MARKER;
+use crate::compiler::phases::phase3_transform::js_ast::to_oxc::SINGLE_ELEMENT_SEQUENCE_MARKER;
 use crate::compiler::phases::phase3_transform::shared::template::escape_js_string;
 
 thread_local! {
@@ -4278,10 +4278,10 @@ impl<'a, 's> StateVarCollector<'a, 's> {
                 // esrap always self-parenthesizes a `SequenceExpression`. The marker
                 // call keeps that "must be a sequence" decision alive across the
                 // eventual raw-text reparse. See
-                // `SINGLE_TARGET_DESTRUCTURE_SEQUENCE_MARKER`.
+                // `SINGLE_ELEMENT_SEQUENCE_MARKER`.
                 Some(format!(
                     "{}({})",
-                    SINGLE_TARGET_DESTRUCTURE_SEQUENCE_MARKER,
+                    SINGLE_ELEMENT_SEQUENCE_MARKER,
                     assignments.into_iter().next().unwrap()
                 ))
             } else {
@@ -4374,7 +4374,7 @@ impl<'a, 's> StateVarCollector<'a, 's> {
                 // the same "always a real SequenceExpression" rule applies here.
                 format!(
                     "{}({})",
-                    SINGLE_TARGET_DESTRUCTURE_SEQUENCE_MARKER,
+                    SINGLE_ELEMENT_SEQUENCE_MARKER,
                     assignments.into_iter().next().unwrap()
                 )
             } else {

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/destructure_transforms.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/destructure_transforms.rs
@@ -5,7 +5,7 @@ use super::rune_transforms::{
     derived_prop_access, exclude_from_object_keys, find_default_equals,
     find_derived_property_colon, split_derived_array_elements, split_derived_object_properties,
 };
-use crate::compiler::phases::phase3_transform::js_ast::to_oxc::SINGLE_TARGET_DESTRUCTURE_SEQUENCE_MARKER;
+use crate::compiler::phases::phase3_transform::js_ast::to_oxc::SINGLE_ELEMENT_SEQUENCE_MARKER;
 use crate::compiler::phases::phase3_transform::shared::js_scan::{code_bytes, code_bytes_from};
 use crate::compiler::phases::phase3_transform::shared::offsets::{
     ByteOffset, CharOffset, CharToByte,
@@ -1608,11 +1608,8 @@ pub(super) fn generate_destructure_iife(
             // `(assignment)` would reparse as a plain (non-sequence) expression
             // and lose those parens downstream; the marker call preserves the
             // "must be a sequence" decision through the reparse. See
-            // `SINGLE_TARGET_DESTRUCTURE_SEQUENCE_MARKER`.
-            return format!(
-                "{}({})",
-                SINGLE_TARGET_DESTRUCTURE_SEQUENCE_MARKER, expressions[0]
-            );
+            // `SINGLE_ELEMENT_SEQUENCE_MARKER`.
+            return format!("{}({})", SINGLE_ELEMENT_SEQUENCE_MARKER, expressions[0]);
         }
         // Single-line comma expression format.
         // IMPORTANT: Must be single-line because downstream processing in

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/reactive_transforms.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/reactive_transforms.rs
@@ -4,6 +4,7 @@ use memchr::memmem;
 use std::borrow::Cow;
 
 use crate::compiler::phases::phase2_analyze::ComponentAnalysis;
+use crate::compiler::phases::phase3_transform::js_ast::to_oxc::SINGLE_ELEMENT_SEQUENCE_MARKER;
 
 use super::{
     extract_destructure_targets, extract_member_expression_base, find_assignment_position,
@@ -800,7 +801,7 @@ pub(super) fn transform_reactive_statement(
     // `3-transform/client/visitors/LabeledStatement.js`'s build_getter +
     // deep_read_state. A name that matches no `*_vars` list is a plain local /
     // non-reactive `normal` binding and is skipped (upstream `continue`).
-    let deps_expr = {
+    let (deps_expr, dep_count) = {
         let mut parts: Vec<String> = Vec::with_capacity(dep_names.len());
         for name in dep_names {
             if name == "$$props" || name == "$$restProps" {
@@ -826,7 +827,8 @@ pub(super) fn transform_reactive_statement(
                 parts.push(name.clone());
             }
         }
-        parts.join(", ")
+        let count = parts.len();
+        (parts.join(", "), count)
     };
 
     // Replace `break $;` with `return;` since the reactive block becomes a function callback.
@@ -850,6 +852,11 @@ pub(super) fn transform_reactive_statement(
     // 2. Single dep: () => (dep) - keeps consistent formatting with expected output
     let deps_thunk = if deps_expr.is_empty() {
         "() => {}".to_string()
+    } else if dep_count == 1 {
+        // Intermediate AST rewrites discard ordinary redundant parentheses.
+        // Keep upstream's one-element SequenceExpression identity in-band so
+        // the final raw-to-AST conversion can rebuild it.
+        format!("() => {}({})", SINGLE_ELEMENT_SEQUENCE_MARKER, deps_expr)
     } else {
         format!("() => ({})", deps_expr)
     };

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/tests.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/tests.rs
@@ -2929,3 +2929,25 @@ fn only_the_listed_global_constants_are_known_members() {
         );
     }
 }
+
+#[test]
+fn legacy_reactive_single_dependency_keeps_sequence_parens_through_assignment_rewrites() {
+    for source in [
+        "<script>\nlet q = 0;\n$: q += 1;\n</script>\n",
+        "<script>\nlet d = 0;\n$: { let x = 1; d += x; }\n</script>\n",
+    ] {
+        let code = crate::compiler::compile(source, Default::default())
+            .expect("compiles")
+            .js
+            .code;
+
+        assert!(
+            code.contains("$.legacy_pre_effect(() => ($.get("),
+            "the one dependency must remain a one-element sequence: {code}"
+        );
+        assert!(
+            !code.contains("__rsvelte_seq1"),
+            "the internal sequence marker must not reach output: {code}"
+        );
+    }
+}

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/bind_directive.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/bind_directive.rs
@@ -22,7 +22,7 @@ use crate::compiler::phases::phase3_transform::client::visitors::expression_conv
 use crate::compiler::phases::phase3_transform::js_ast::JsArena;
 use crate::compiler::phases::phase3_transform::js_ast::builders as b;
 use crate::compiler::phases::phase3_transform::js_ast::nodes::*;
-use crate::compiler::phases::phase3_transform::js_ast::to_oxc::SINGLE_TARGET_DESTRUCTURE_SEQUENCE_MARKER;
+use crate::compiler::phases::phase3_transform::js_ast::to_oxc::SINGLE_ELEMENT_SEQUENCE_MARKER;
 
 // Note: We implement bind_this directly here rather than using shared/utils
 // to avoid complex borrow checker issues with the context
@@ -2524,7 +2524,7 @@ fn build_invalidation_expr(
         let inner = if each_ctx.invalidation_exprs.len() == 1 {
             format!(
                 "{}({})",
-                SINGLE_TARGET_DESTRUCTURE_SEQUENCE_MARKER, each_ctx.invalidation_exprs[0]
+                SINGLE_ELEMENT_SEQUENCE_MARKER, each_ctx.invalidation_exprs[0]
             )
         } else {
             each_ctx.invalidation_exprs.join(", ")

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/js_ast/codegen.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/js_ast/codegen.rs
@@ -5,9 +5,49 @@
 use super::arena::JsArena;
 use super::nodes::*;
 use rustc_hash::FxHashMap;
+use std::borrow::Cow;
 use std::cell::RefCell;
 use std::fmt::Write;
 use std::rc::Rc;
+
+/// Remove the internal callee from generated one-element sequence markers.
+/// The remaining `(expression)` is exactly what the text fallback must print;
+/// the direct-AST path rebuilds the corresponding `SequenceExpression`.
+fn restore_single_element_sequence_markers(code: &str) -> Cow<'_, str> {
+    let marker = super::to_oxc::SINGLE_ELEMENT_SEQUENCE_MARKER;
+    let bytes = code.as_bytes();
+    let mut positions = Vec::new();
+    let mut cursor = 0;
+
+    while cursor < bytes.len() {
+        let Some(relative) =
+            super::super::shared::js_scan::find_code(&bytes[cursor..], marker.as_bytes())
+        else {
+            break;
+        };
+        let at = cursor + relative;
+        let end = at + marker.len();
+        let starts_identifier =
+            at > 0 && super::super::shared::js_scan::is_ident_byte(bytes[at.saturating_sub(1)]);
+        if !starts_identifier && bytes.get(end) == Some(&b'(') {
+            positions.push(at);
+        }
+        cursor = end;
+    }
+
+    if positions.is_empty() {
+        return Cow::Borrowed(code);
+    }
+
+    let mut restored = String::with_capacity(code.len() - positions.len() * marker.len());
+    let mut copied = 0;
+    for at in positions {
+        restored.push_str(&code[copied..at]);
+        copied = at + marker.len();
+    }
+    restored.push_str(&code[copied..]);
+    Cow::Owned(restored)
+}
 
 /// A raw source span recorded during codegen: (output_byte_offset, source_start, source_end).
 /// output_byte_offset is the position in the generated output string.
@@ -388,11 +428,13 @@ impl<'a> JsCodegen<'a> {
             JsStatement::Try(try_stmt) => self.emit_try_statement(try_stmt),
             JsStatement::Raw(code) => {
                 // Output raw JavaScript code verbatim
-                self.output.push_str(code);
+                self.output
+                    .push_str(&restore_single_element_sequence_markers(code));
                 self.needs_semicolon = false; // Raw code handles its own semicolons
             }
             JsStatement::RawEffect(code) => {
-                self.output.push_str(code);
+                self.output
+                    .push_str(&restore_single_element_sequence_markers(code));
                 self.needs_semicolon = false;
             }
             JsStatement::RawMapped {
@@ -432,6 +474,8 @@ impl<'a> JsCodegen<'a> {
     /// and match each token to its position in the original source, creating
     /// precise source map entries.
     fn emit_raw_mapped(&mut self, code: &str, source_offset: u32) {
+        let restored = restore_single_element_sequence_markers(code);
+        let code = restored.as_ref();
         if !self.track_mappings {
             self.output.push_str(code);
             return;
@@ -956,7 +1000,8 @@ impl<'a> JsCodegen<'a> {
             }
             JsExpr::Raw(code) => {
                 // Emit raw JavaScript code as-is
-                self.output.push_str(code);
+                self.output
+                    .push_str(&restore_single_element_sequence_markers(code));
             }
             JsExpr::Spanned(inner_id, start, end) => {
                 self.record_span_start(*start, *end);
@@ -3185,6 +3230,16 @@ pub fn generate_sourcemap_json_multi(
 mod tests {
     use super::*;
     use crate::compiler::phases::phase3_transform::js_ast::builders::*;
+
+    #[test]
+    fn text_fallback_restores_only_code_sequence_markers() {
+        let source =
+            "__rsvelte_seq1(a); '__rsvelte_seq1(b)'; /* __rsvelte_seq1(c) */ __rsvelte_seq1(d)";
+        assert_eq!(
+            restore_single_element_sequence_markers(source),
+            "(a); '__rsvelte_seq1(b)'; /* __rsvelte_seq1(c) */ (d)"
+        );
+    }
 
     #[test]
     fn sourcemap_can_externalize_single_source_content() {

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/js_ast/to_oxc.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/js_ast/to_oxc.rs
@@ -34,7 +34,7 @@
 //!
 //! Re-parsing **fails loudly when the text does not parse** (`chunk-parse`) and
 //! **can differ silently when it does**: `restore_legacy_pre_effect_deps`
-//! and `restore_single_target_destructure_sequences` exist precisely
+//! and `restore_single_element_sequences` exist precisely
 //! because a round-trip that parses can still print differently from the text it
 //! came from.
 //!
@@ -364,14 +364,14 @@ fn erase_generated_effect_call_locs(
     }
 }
 
-/// Rebuilds any `SINGLE_TARGET_DESTRUCTURE_SEQUENCE_MARKER(expr)` call — however
+/// Rebuilds any `SINGLE_ELEMENT_SEQUENCE_MARKER(expr)` call — however
 /// deeply nested — into a one-element `SequenceExpression`. See the marker's doc
-/// comment and [`Cx::restore_single_target_destructure_sequences`].
-struct SingleTargetSequenceRebuilder<'a, 'x> {
+/// comment and [`Cx::restore_single_element_sequences`].
+struct SingleElementSequenceRebuilder<'a, 'x> {
     ab: &'x AstBuilder<'a>,
 }
 
-impl<'a, 'x> VisitMut<'a> for SingleTargetSequenceRebuilder<'a, 'x> {
+impl<'a, 'x> VisitMut<'a> for SingleElementSequenceRebuilder<'a, 'x> {
     fn visit_expression(&mut self, expr: &mut Expression<'a>) {
         oxc_ast_visit::walk_mut::walk_expression(self, expr);
 
@@ -383,7 +383,7 @@ impl<'a, 'x> VisitMut<'a> for SingleTargetSequenceRebuilder<'a, 'x> {
                     && matches!(
                         &call.callee,
                         Expression::Identifier(id)
-                            if id.name == SINGLE_TARGET_DESTRUCTURE_SEQUENCE_MARKER
+                            if id.name == SINGLE_ELEMENT_SEQUENCE_MARKER
                     )
         );
         if !is_marker_call {
@@ -473,10 +473,14 @@ impl Synth {
     }
 }
 
-/// Marker callee wrapping a single-target destructuring-assignment collapse
-/// (`({ a } = obj)` → `a = obj.a`) so the "this must reprint as a
-/// `SequenceExpression`" decision survives the raw-text reparse. Upstream's
-/// `visit_assignment_expression` (`shared/assignments.js`) always lowers a
+/// Marker callee wrapping generated expressions that must reprint as a
+/// one-element `SequenceExpression`, so that decision survives raw-text
+/// reparses. This is used for single-target destructuring-assignment collapses
+/// (`({ a } = obj)` → `a = obj.a`) and one-dependency legacy reactive
+/// thunks.
+///
+/// For destructuring, upstream's `visit_assignment_expression`
+/// (`shared/assignments.js`) always lowers a
 /// destructuring assignment through `b.sequence(assignments)` — an ESTree
 /// `SequenceExpression` *unconditionally*, even for a single assignment — and
 /// esrap's `SequenceExpression` printer always self-parenthesizes, `(expr)`,
@@ -486,11 +490,13 @@ impl Synth {
 /// treats as redundantly parenthesized (matching upstream's behavior for any
 /// plain, user-written `(x = 1)`, where the parens really are dropped) and
 /// removes — silently losing upstream's parens for the destructuring case.
-/// Wrapping the single assignment in a call to this marker keeps the
-/// "force sequence" decision attached to the generated text itself;
-/// [`Cx::restore_single_target_destructure_sequences`] finds the marker call
+/// The reactive-statement visitor similarly builds its dependency list with
+/// `b.sequence(deps)`, including when there is only one dependency. Wrapping
+/// either generated expression in a call to this marker keeps the "force
+/// sequence" decision attached to the generated text itself;
+/// [`Cx::restore_single_element_sequences`] finds the marker call
 /// after reparse and rebuilds the real single-element `SequenceExpression`.
-pub(crate) const SINGLE_TARGET_DESTRUCTURE_SEQUENCE_MARKER: &str = "__rsvelte_seq1";
+pub(crate) const SINGLE_ELEMENT_SEQUENCE_MARKER: &str = "__rsvelte_seq1";
 
 /// Conversion context: holds the oxc [`AstBuilder`] and the IR arena used to
 /// resolve [`ExprId`] handles.
@@ -1594,7 +1600,7 @@ impl<'a, 'arena, 'source> Cx<'a, 'arena, 'source> {
     fn parse_raw_expression(&self, code: &str) -> Option<Expression<'a>> {
         let wrapped = format!("({})", code.trim());
         let mut stmts = self.parse_chunk(&wrapped)?;
-        self.restore_single_target_destructure_sequences(&mut stmts);
+        self.restore_single_element_sequences(&mut stmts);
         // The synthetic parens are part of the chunk text, so the region already
         // covers them; no caller needs it for an expression.
         self.take_chunk_region(None, &[]);
@@ -1622,7 +1628,7 @@ impl<'a, 'arena, 'source> Cx<'a, 'arena, 'source> {
     ) -> Option<Vec<Statement<'a>>> {
         let mut stmts = self.parse_chunk(code.trim())?;
         self.restore_legacy_pre_effect_deps(&mut stmts);
-        self.restore_single_target_destructure_sequences(&mut stmts);
+        self.restore_single_element_sequences(&mut stmts);
         if unlocate_effect_calls {
             erase_generated_effect_call_locs(&mut stmts, effect_spans);
         }
@@ -1674,14 +1680,14 @@ impl<'a, 'arena, 'source> Cx<'a, 'arena, 'source> {
         }
     }
 
-    /// See [`SINGLE_TARGET_DESTRUCTURE_SEQUENCE_MARKER`]. Unlike
+    /// See [`SINGLE_ELEMENT_SEQUENCE_MARKER`]. Unlike
     /// [`Cx::restore_legacy_pre_effect_deps`] (which only ever sits at the top
     /// of its own dedicated chunk), a destructuring-assignment collapse can be
     /// nested arbitrarily deep (inside a function body, a block, another
     /// expression, …), so this walks the whole chunk rather than just its
     /// top-level statements.
-    fn restore_single_target_destructure_sequences(&self, stmts: &mut [Statement<'a>]) {
-        let mut rebuilder = SingleTargetSequenceRebuilder { ab: &self.ab };
+    fn restore_single_element_sequences(&self, stmts: &mut [Statement<'a>]) {
+        let mut rebuilder = SingleElementSequenceRebuilder { ab: &self.ab };
         for stmt in stmts {
             rebuilder.visit_statement(stmt);
         }


### PR DESCRIPTION
## Summary

- preserve upstream's one-element `SequenceExpression` for legacy reactive thunks with exactly one dependency
- carry the sequence identity through intermediate raw-text AST rewrites with the existing internal marker mechanism
- make the text-printer fallback restore the marker too, without touching strings or comments
- cover both the single-statement (#3411) and block-statement (#3579) forms

## Validation

- `cargo fmt --all`
- `cargo fmt --all -- --check`
- `git diff --check`
- full builds and tests intentionally delegated to CI

Fixes #3411
Fixes #3579
