### PR TITLE
Pin correct shorthand style modifier output

### DIFF
--- a/compatibility/pattern-corpus/README.md
+++ b/compatibility/pattern-corpus/README.md
@@ -808,8 +808,9 @@ carrying `"` has no fmt fixed point because the oracle normalizes the quotes; an
 the `style:x|important` shorthand, #3578 — an upstream svelte2tsx defect recorded
 in `upstream_issues/`, where rsvelte's output is the *correct* TSX and official's
 references a free `important`. The fmt oracle rewrites `style:x|important={x}`
-into that shorthand, so neither spelling of the modifier is landable until it is
-decided.
+into that shorthand. The correct rsvelte output is pinned as a deliberate
+divergence, while both spellings remain outside the equality corpus until
+upstream fixes the semantic defect.
 
 Its third half held back two more, and one of them is the sweep's largest find.
 `elements/nested-namespace-switching` is #3582: an element whose tag name is a JS

--- a/crates/rsvelte_projection/tests/svelte2tsx_class_style_directive.rs
+++ b/crates/rsvelte_projection/tests/svelte2tsx_class_style_directive.rs
@@ -89,6 +89,26 @@ fn style_shorthand_directive_uses_ensure_type() {
 }
 
 #[test]
+fn style_shorthand_modifier_does_not_become_an_identifier() {
+    // Deliberate divergence from upstream svelte2tsx: official emits
+    // `color|important`, which TypeScript reads as a bitwise-or with a free
+    // `important` identifier. See
+    // upstream_issues/svelte2tsx-shorthand-style-directive-modifier.md.
+    let out = to_tsx(
+        "<script lang=\"ts\">\n  let color = 'red';\n</script>\n\
+         <div style:color|important>hi</div>",
+    );
+    assert!(
+        out.contains("__sveltets_2_ensureType(String, Number, color);"),
+        "style: shorthand modifier changed the value expression:\n{out}"
+    );
+    assert!(
+        !out.contains("color|important"),
+        "style: modifier leaked into the generated expression:\n{out}"
+    );
+}
+
+#[test]
 fn class_style_alongside_real_attributes() {
     // A real attribute stays in props; the directive does not.
     let out = to_tsx(

--- a/upstream_issues/README.md
+++ b/upstream_issues/README.md
@@ -90,7 +90,7 @@ deletion, and is deliberately left to its own change rather than folded into the
 | `svelte-fromcodepoint-rangeerror.md` | sveltejs/svelte | #3617 | unrecorded |
 | `svelte-inspect-with-in-a-declarator.md` | sveltejs/svelte | #3614 | unrecorded |
 | `svelte-snippet-name-colliding-with-an-import.md` | sveltejs/svelte | #3567 | unrecorded |
-| `svelte2tsx-shorthand-style-directive-modifier.md` | sveltejs/language-tools (svelte2tsx) | #3567 | unrecorded |
+| `svelte2tsx-shorthand-style-directive-modifier.md` | sveltejs/language-tools (svelte2tsx) | #3567, #3578 | unrecorded |
 
 The six unnumbered reports came out of the lint-parity campaign rather than from a single rsvelte
 issue, and none of them names one internally — `—` records that, rather than inventing a number.

--- a/upstream_issues/svelte2tsx-shorthand-style-directive-modifier.md
+++ b/upstream_issues/svelte2tsx-shorthand-style-directive-modifier.md
@@ -37,10 +37,12 @@ form already ignores the modifier, which is the behaviour the shorthand should
 share — the shorthand's meaning is "use the variable named by the property", and
 the property is `color`, not `color|important`.
 
-rsvelte's port emits `color`, which is the correct TSX and therefore a **byte
-divergence** from official. Byte parity is the goal here, so the shape is held
-out of `compatibility/pattern-corpus` until upstream decides; matching official
-would mean reproducing a spurious diagnostic on valid source.
+rsvelte's port emits `color`, which is the correct TSX and therefore a
+**deliberate byte divergence** from official. Matching official would reproduce
+a spurious diagnostic on valid source, so rsvelte retains and regression-tests
+the correct output under the project's upstream-defect rule. The shape remains
+outside the output-equality corpus until upstream fixes its lowering; otherwise
+the parity gate would require the known semantic defect.
 
 Desired upstream behaviour: strip everything from the first `|` before using a
 shorthand directive's name as an expression, the same way the value-carrying


### PR DESCRIPTION
## Summary

- pin rsvelte's correct svelte2tsx lowering for shorthand `style:` directives with modifiers
- document the output as a deliberate divergence from an upstream semantic defect
- keep the known-bad shape outside the byte-equality corpus until upstream fixes it

Official svelte2tsx emits `color|important` for `style:color|important`, which TypeScript interprets as a bitwise-or with a free `important` identifier. rsvelte already emits the semantically correct `color`; this PR makes that decision explicit and regression-tested.

Fixes #3578

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- `node scripts/ci/check-upstream-issues.mjs`

The full test suite is intentionally delegated to CI.
