### PR TITLE
Report state references in computed pattern keys

### DIFF
--- a/.changeset/quiet-computed-keys.md
+++ b/.changeset/quiet-computed-keys.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/compiler": patch
+---
+
+Report state references used as computed keys in object destructuring patterns.

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/identifier.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/identifier.rs
@@ -265,17 +265,33 @@ fn visit_identifier_inner(
     // The official compiler has `node !== binding.node` check to skip warnings for the
     // declaration identifier itself. We approximate this by checking if the identifier
     // is inside a VariableDeclarator's `id` pattern (which is the declaration site).
-    let is_declaration_node = context.js_path.iter().any(|ancestor| {
-        if ancestor.get_type_str() == Some("VariableDeclarator") {
-            // Check if the current node's position falls within the `id` pattern range
-            let id_start = ancestor.get_child_field_start("id", context.parse_arena);
-            let id_end = ancestor.get_child_field_end("id", context.parse_arena);
-            if let (Some(id_s), Some(id_e)) = (id_start, id_end) {
-                return start >= id_s && start < id_e;
+    // A computed key inside the pattern is evaluated rather than bound. Keep
+    // identifiers in that key out of the broad `VariableDeclarator.id` guard;
+    // the property's value remains a declaration slot.
+    let is_computed_pattern_key = context.js_path.iter().any(|ancestor| {
+        ancestor.get_type_str() == Some("Property")
+            && ancestor.get_field_bool("computed").unwrap_or(false)
+            && match (
+                ancestor.get_child_field_start("key", context.parse_arena),
+                ancestor.get_child_field_end("key", context.parse_arena),
+            ) {
+                (Some(key_start), Some(key_end)) => start >= key_start && start < key_end,
+                _ => false,
             }
-        }
-        false
     });
+
+    let is_declaration_node = !is_computed_pattern_key
+        && context.js_path.iter().any(|ancestor| {
+            if ancestor.get_type_str() == Some("VariableDeclarator") {
+                // Check if the current node's position falls within the `id` pattern range
+                let id_start = ancestor.get_child_field_start("id", context.parse_arena);
+                let id_end = ancestor.get_child_field_end("id", context.parse_arena);
+                if let (Some(id_s), Some(id_e)) = (id_start, id_end) {
+                    return start >= id_s && start < id_e;
+                }
+            }
+            false
+        });
 
     if context.analysis.runes && !is_declaration_node {
         let binding = &context.analysis.root.bindings[binding_idx];

--- a/crates/rsvelte_core/tests/state_referenced_locally_computed_key_3590.rs
+++ b/crates/rsvelte_core/tests/state_referenced_locally_computed_key_3590.rs
@@ -1,0 +1,44 @@
+//! Regression coverage for #3590.
+//!
+//! A computed key in an object binding pattern is evaluated, so its identifiers
+//! are references rather than declarations. The phase-2 declaration guard used
+//! to classify every identifier inside `VariableDeclarator.id` as a declaration
+//! and consequently dropped this warning entirely.
+
+use rsvelte_core::{CompileOptions, GenerateMode, Warning, compile};
+
+const SOURCE: &str =
+    "<script>\n\tlet s = $state(1);\n\tconst { [s]: value } = {};\n</script>\n\n<b>1</b>";
+
+fn state_warnings(mode: GenerateMode) -> Vec<Warning> {
+    compile(
+        SOURCE,
+        CompileOptions {
+            filename: Some("Main.svelte".to_string()),
+            generate: mode,
+            ..Default::default()
+        },
+    )
+    .expect("compile")
+    .warnings
+    .into_iter()
+    .filter(|warning| warning.code == "state_referenced_locally")
+    .collect()
+}
+
+#[test]
+fn computed_destructuring_key_is_a_reference_on_both_targets() {
+    for mode in [GenerateMode::Client, GenerateMode::Server] {
+        let warnings = state_warnings(mode);
+        assert_eq!(
+            warnings.len(),
+            1,
+            "expected one state warning: {warnings:#?}"
+        );
+
+        let start = warnings[0].start.as_ref().expect("warning has a start");
+        let end = warnings[0].end.as_ref().expect("warning has an end");
+        assert_eq!((start.line, start.column), (3, 9));
+        assert_eq!((end.line, end.column), (3, 10));
+    }
+}


### PR DESCRIPTION
## Summary

- treat identifiers evaluated inside computed object-pattern keys as references, not declarations
- preserve declaration treatment for the corresponding binding value
- cover exact warning positions on both client and server targets

The property-key span issue described by #3590 was already fixed by merged PR #3519. The remaining destructuring arm emitted no warning because phase 2 classified every identifier inside `VariableDeclarator.id` as a declaration, including evaluated computed keys.

Fixes #3590

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`

Per project policy, compilation and the Rust test suite are delegated to CI.
