### PR TITLE
Remove unreachable phase-two has-call writers

### DIFF
--- a/.changeset/remove-unreachable-has-call.md
+++ b/.changeset/remove-unreachable-has-call.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/compiler": patch
+---
+
+Remove unreachable phase-two call metadata writes.

--- a/compatibility/two-ports-inventory.md
+++ b/compatibility/two-ports-inventory.md
@@ -368,13 +368,22 @@ picked.
 ### 11. Does this expression contain a call? — [S]
 
 Filed as **#3569**; recorded here so the inventory is complete rather than restated.
-`ast/template.rs:1342` `set_has_call` has seven writers, and phase 3 re-derives the same bit at
+`ast/template.rs` `set_has_call` has three reachable phase-2 writers, and phase 3 re-derives the same bit at
 least three more times — `shared/element.rs:518` `json_contains_call`, `shared/element.rs:452`
 `walk_metadata_flags` (which additionally sets `has_call` for a `SpreadElement`, unlike the other
 two), and `shared/utils.rs:5944` `expression_has_call`.
 
 Upstream computes it once in phase 2 into `node.metadata.expression.has_call`; phase 3 only reads
-it. Whether the copies disagree on a reachable input: `未測定` — see #3569.
+it. Whether the reachable copies disagree on an input: `未測定` — see #3569.
+
+Three phase-2 writes listed when #3569 was opened were structurally unreachable and were removed:
+the `SpreadElement` and `TaggedTemplateExpression` arms in the typed script walker, and the typed
+`CallExpression` visitor. `VisitorContext.expression` starts as `None`; the only site that installs
+`Some` is the `{#if}` visitor, and it walks its condition through `walk_js_expression_node`, not the
+typed script walker. This is a static reachability result, not an ablation result: deleting those
+three writes cannot change output while that single producer and consumer remain disjoint. The
+remaining phase-2 writers are the reachable call, object-spread and top-level-spread arms in the
+template-expression walker.
 
 ### 12. "Selector unused" and "element scoped" are two engines over two element models — [S]
 

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/call_expression.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/call_expression.rs
@@ -922,16 +922,6 @@ pub fn visit_typed(node: &JsNode, context: &mut VisitorContext) -> Result<(), An
     let args = arena.get_js_children(*arguments);
     let rune = super::shared::utils::get_rune_from_node(node, &context.analysis.root.scope, arena);
 
-    // Track expression metadata for non-rune calls
-    let is_pure_call = super::shared::utils::is_pure_node(callee_node, context);
-    if let Some(expression) = context.current_expression() {
-        let has_dependencies = !expression.dependencies.is_empty();
-        if !is_pure_call || has_dependencies {
-            expression.set_has_call(true);
-            expression.set_has_state(true);
-        }
-    }
-
     // For $derived and $inspect, increment function_depth when visiting arguments
     let increment_depth = matches!(rune.as_deref(), Some("$derived") | Some("$inspect"));
     // For `$derived(...)` (not `$derived.by`), mirror upstream's

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/script.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/script.rs
@@ -265,13 +265,10 @@ fn visit_children_typed(node: &JsNode, context: &mut VisitorContext) -> Result<(
             Ok(())
         }
 
-        // SpreadElement: `[...x]` is treated like `[...x.values()]` — the
-        // spread itself is a call/state read for blocker tracking.
+        // SpreadElement children are still walked here, but expression
+        // metadata is populated by the template-expression walker. This
+        // script walker is never entered while `context.expression` is set.
         JsNode::SpreadElement { argument, .. } => {
-            if let Some(expression) = context.current_expression() {
-                expression.set_has_call(true);
-                expression.set_has_state(true);
-            }
             walk_js_node_typed(arena.get_js_node(*argument), context)?;
             Ok(())
         }
@@ -385,17 +382,11 @@ fn visit_children_typed(node: &JsNode, context: &mut VisitorContext) -> Result<(
             Ok(())
         }
 
-        // TaggedTemplateExpression: tag + quasi (JsNodeId).
-        // `tag\`...\`` invokes `tag(strings, ...exprs)` — counts as a call
-        // and state read unless the tag is a pure reference.
+        // TaggedTemplateExpression: tag + quasi (JsNodeId). Expression
+        // metadata is populated by the template-expression walker; this
+        // script walker is never entered while `context.expression` is set.
         JsNode::TaggedTemplateExpression { tag, quasi, .. } => {
             let tag_node = arena.get_js_node(*tag);
-            if !super::shared::utils::is_pure_node(tag_node, context)
-                && let Some(expression) = context.current_expression()
-            {
-                expression.set_has_call(true);
-                expression.set_has_state(true);
-            }
             walk_js_node_typed(tag_node, context)?;
             walk_js_node_typed(arena.get_js_node(*quasi), context)?;
             Ok(())


### PR DESCRIPTION
## Summary

- remove three `has_call` writes that cannot be reached while expression metadata is installed
- keep the reachable template-expression call and spread writers unchanged
- record the static reachability result and the remaining duplicated decision sites in the two-ports inventory

## Reachability proof

`VisitorContext.expression` is initialized to `None`. The only Phase 2 assignment of `Some` is in the `{#if}` visitor, which passes its condition to `walk_js_expression_node`. It never enters the typed script walker.

The removed writes lived only in that typed script walker and its typed `CallExpression` visitor. Therefore no input can observe them while the current single producer and consumer remain disjoint. This answers three of the unattributed rows in #3569 without treating a green test population as proof of dead code.

The three reachable Phase 2 writers remain in `walk_js_expression_node`: ordinary calls, object spreads, and top-level spreads. Phase 3's independent re-derivations remain explicitly unmeasured, so this PR progresses rather than closes the issue.

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- writer and `context.expression` assignments audited with `rg`
- no local build or test suite was run; CI is the execution oracle

Progresses #3569
