### PR TITLE
refactor(client): consume attachment expression metadata

### DIFF
--- a/.changeset/quiet-attachments-listen.md
+++ b/.changeset/quiet-attachments-listen.md
@@ -1,0 +1,5 @@
+---
+"@rsvelte/compiler": patch
+---
+
+Preserve reactive attachment bindings when Phase 3 consumes expression metadata produced during analysis.

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/shared/attribute.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/shared/attribute.rs
@@ -40,11 +40,11 @@ pub fn walk_template_expression(
 /// that drops the expression on the floor — which is what made `{@attach await
 /// …}` legal on six hosts and `use:act={await …}` legal on every host.
 pub fn walk_remaining_attribute_expressions(
-    attr: &Attribute,
+    attr: &mut Attribute,
     context: &mut VisitorContext,
 ) -> Result<(), AnalysisError> {
     match attr {
-        Attribute::AttachTag(t) => walk_template_expression(&t.expression, context),
+        Attribute::AttachTag(t) => super::super::attach_tag::visit(t, context),
         Attribute::SpreadAttribute(s) => walk_template_expression(&s.expression, context),
         Attribute::UseDirective(u) => match &u.expression {
             Some(e) => walk_template_expression(e, context),

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/shared/component.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/shared/component.rs
@@ -236,7 +236,7 @@ pub fn visit_component<'a, 'b: 'a>(
                 super::attribute::walk_template_expression(&spread.expression, context)?;
             }
             Attribute::AttachTag(attach) => {
-                super::attribute::walk_template_expression(&attach.expression, context)?;
+                super::super::attach_tag::visit(attach, context)?;
             }
             Attribute::LetDirective(_) => {
                 // Let directives don't have expressions to visit for needs_context

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/shared/utils.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/shared/utils.rs
@@ -1218,6 +1218,31 @@ fn get_rune_name_node(callee: &JsNode, context: &VisitorContext) -> Option<Strin
     }
 }
 
+/// Whether Phase 2 can prove that a binding read is compile-time known without
+/// running the full scope evaluator. Unknown is deliberately conservative: it
+/// keeps the expression reactive, which is the behavior upstream uses when
+/// `scope.evaluate(identifier).is_known` is false.
+fn binding_is_obviously_known(
+    binding: &crate::compiler::phases::phase2_analyze::scope::Binding,
+) -> bool {
+    if binding.reassigned || binding.mutated {
+        return false;
+    }
+
+    if !matches!(binding.kind, BindingKind::Normal | BindingKind::Template) {
+        return false;
+    }
+
+    match binding.initial_node_type.as_deref() {
+        Some("Literal") => true,
+        Some("Identifier") => binding.initial_identifier_name.as_deref() == Some("undefined"),
+        // Interpolated templates retain their AST in `init_expr_json`; a
+        // template with no cached expression is a static string.
+        Some("TemplateLiteral") => binding.init_expr_json.is_none(),
+        _ => false,
+    }
+}
+
 /// Visit a JavaScript expression (typed JsNode) and track identifier references.
 pub fn walk_js_expression_node(
     expression: &JsNode,
@@ -1319,10 +1344,20 @@ pub fn walk_js_expression_node(
                     metadata.references.insert(binding_idx);
                 }
 
-                if matches!(
-                    binding.kind,
-                    BindingKind::State | BindingKind::RawState | BindingKind::Derived
-                ) {
+                // Mirror the Identifier visitor's expression-metadata rule. A
+                // template expression reaches this typed walker directly, so
+                // limiting this to rune bindings loses props, stores,
+                // `{@const}` values, and ordinary variables whose initializer
+                // cannot be evaluated at compile time. Attach tags are one
+                // visible consumer: `const attachment = make_attachment()`
+                // must be re-read through a thunk rather than passed once.
+                let involves_state = binding.kind != BindingKind::Static
+                    && (matches!(
+                        binding.kind,
+                        BindingKind::Prop | BindingKind::BindableProp | BindingKind::RestProp
+                    ) || !binding.is_function());
+
+                if involves_state && !binding_is_obviously_known(binding) {
                     metadata.set_has_state(true);
                 }
 
@@ -1341,6 +1376,12 @@ pub fn walk_js_expression_node(
                         context,
                     )?;
                 }
+            }
+
+            // These generated legacy bindings are not present in the scope,
+            // but upstream still evaluates their reads as reactive state.
+            if matches!(name.as_str(), "$$props" | "$$restProps") {
+                metadata.set_has_state(true);
             }
         }
         JsNode::MemberExpression {

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/svelte_component.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/svelte_component.rs
@@ -92,7 +92,7 @@ pub fn visit<'a, 'b: 'a>(
                 super::attribute::visit_attribute_value_expressions(&mut a.value, context)?;
             }
             Attribute::AttachTag(attach) => {
-                super::shared::attribute::walk_template_expression(&attach.expression, context)?;
+                super::attach_tag::visit(attach, context)?;
             }
             Attribute::LetDirective(_) => {
                 // Allowed on components (matches the shared component validator)

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/svelte_element.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/svelte_element.rs
@@ -284,6 +284,9 @@ pub fn visit<'a, 'b: 'a>(
             Attribute::OnDirective(on) => {
                 super::on_directive::visit(on, context)?;
             }
+            Attribute::AttachTag(attach) => {
+                super::attach_tag::visit(attach, context)?;
+            }
             other => {
                 super::shared::attribute::walk_remaining_attribute_expressions(other, context)?;
             }

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/svelte_self.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/svelte_self.rs
@@ -116,7 +116,7 @@ pub fn visit<'a, 'b: 'a>(
                 super::shared::attribute::walk_template_expression(&spread.expression, context)?;
             }
             Attribute::AttachTag(attach) => {
-                super::shared::attribute::walk_template_expression(&attach.expression, context)?;
+                super::attach_tag::visit(attach, context)?;
             }
             other => {
                 super::shared::attribute::walk_remaining_attribute_expressions(other, context)?;

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/component.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/component.rs
@@ -2255,12 +2255,11 @@ fn process_attach_tag(
     );
     let expression = convert_expression(&attach.expression, context);
 
-    // Check if expression has reactive state using the proper check.
-    // In the official Svelte compiler's phase 2 analysis (CallExpression.js lines 269-272),
-    // non-pure call expressions also set has_state=true. So we need to check both
-    // expression_has_reactive_state AND expression_has_call to match the official behavior.
-    let has_state = super::utils::expression_has_reactive_state(&attach.expression, context);
-    let has_call = super::utils::expression_has_call(&attach.expression, context);
+    // Phase 2's AttachTag visitor walks this expression with the same metadata
+    // object upstream passes to its visitor context. Consume that single source
+    // of truth instead of independently re-deriving the two flags in Phase 3.
+    let has_state = attach.metadata.expression.has_state();
+    let has_call = attach.metadata.expression.has_call();
 
     let final_expr = if has_state || has_call {
         // Apply transforms to the expression to convert state references to $.get() calls

--- a/crates/rsvelte_core/tests/attach_expression_metadata_3569.rs
+++ b/crates/rsvelte_core/tests/attach_expression_metadata_3569.rs
@@ -22,10 +22,15 @@ fn attach_flags(source: &str) -> (bool, bool) {
     let _arena_guard = unsafe { SerializeArenaGuard::new(&raw const root.arena) };
     analyze_component(&mut root, source, &CompileOptions::default()).expect("analyze");
 
-    let TemplateNode::RegularElement(element) = &root.fragment.nodes[0] else {
-        panic!("expected regular element");
+    let attributes = match &root.fragment.nodes[0] {
+        TemplateNode::RegularElement(element) => &element.attributes,
+        TemplateNode::Component(component) => &component.attributes,
+        TemplateNode::SvelteComponent(component) => &component.attributes,
+        TemplateNode::SvelteElement(element) => &element.attributes,
+        TemplateNode::SvelteBody(element) => &element.attributes,
+        other => panic!("expected an element host, got {other:?}"),
     };
-    let Attribute::AttachTag(attach) = &element.attributes[0] else {
+    let Some(Attribute::AttachTag(attach)) = attributes.last() else {
         panic!("expected attach tag");
     };
 
@@ -36,9 +41,16 @@ fn attach_flags(source: &str) -> (bool, bool) {
 }
 
 #[test]
-fn local_call_is_stateful_and_impure() {
-    let source = "<script>function make() {}</script><div {@attach make()}></div>";
-    assert_eq!(attach_flags(source), (true, true));
+fn every_legal_host_populates_local_call_metadata() {
+    for source in [
+        "<script>function make() {}</script><div {@attach make()}></div>",
+        "<script>function make() {}</script><Widget {@attach make()} />",
+        "<script>function make() {}</script><svelte:component this={Widget} {@attach make()} />",
+        "<script>function make() {}</script><svelte:element this=\"div\" {@attach make()} />",
+        "<script>function make() {}</script><svelte:body {@attach make()} />",
+    ] {
+        assert_eq!(attach_flags(source), (true, true), "{source}");
+    }
 }
 
 #[test]

--- a/crates/rsvelte_core/tests/attach_expression_metadata_3569.rs
+++ b/crates/rsvelte_core/tests/attach_expression_metadata_3569.rs
@@ -64,3 +64,22 @@ fn state_reference_does_not_invent_a_call() {
     let source = "<script>let attachment = $state();</script><div {@attach attachment}></div>";
     assert_eq!(attach_flags(source), (true, false));
 }
+
+#[test]
+fn call_initialized_binding_is_reactive_without_inventing_a_call_at_the_read() {
+    let source =
+        "<script>const attachment = make_attachment();</script><div {@attach attachment}></div>";
+    assert_eq!(attach_flags(source), (true, false));
+}
+
+#[test]
+fn legacy_props_member_is_reactive_without_a_scope_binding() {
+    let source = "<div {@attach $$props.attach}></div>";
+    assert_eq!(attach_flags(source), (true, false));
+}
+
+#[test]
+fn runes_prop_binding_is_reactive_without_inventing_a_call() {
+    let source = "<script>let { attach } = $props();</script><div {@attach attach}></div>";
+    assert_eq!(attach_flags(source), (true, false));
+}

--- a/crates/rsvelte_core/tests/attach_expression_metadata_3569.rs
+++ b/crates/rsvelte_core/tests/attach_expression_metadata_3569.rs
@@ -1,0 +1,54 @@
+//! Issue #3569: `AttachTag` owns expression metadata populated by Phase 2, so
+//! Phase 3 must not maintain a second implementation of the same decisions.
+
+use rsvelte_core::{
+    CompileOptions, ParseOptions,
+    ast::{
+        arena::SerializeArenaGuard,
+        template::{Attribute, TemplateNode},
+    },
+    compiler::phases::analyze_component,
+    parse,
+};
+
+fn attach_flags(source: &str) -> (bool, bool) {
+    let mut root = parse(
+        source,
+        &oxc_allocator::Allocator::default(),
+        ParseOptions::default(),
+    )
+    .expect("parse");
+    // SAFETY: `root.arena` outlives the guard and analysis below.
+    let _arena_guard = unsafe { SerializeArenaGuard::new(&raw const root.arena) };
+    analyze_component(&mut root, source, &CompileOptions::default()).expect("analyze");
+
+    let TemplateNode::RegularElement(element) = &root.fragment.nodes[0] else {
+        panic!("expected regular element");
+    };
+    let Attribute::AttachTag(attach) = &element.attributes[0] else {
+        panic!("expected attach tag");
+    };
+
+    (
+        attach.metadata.expression.has_state(),
+        attach.metadata.expression.has_call(),
+    )
+}
+
+#[test]
+fn local_call_is_stateful_and_impure() {
+    let source = "<script>function make() {}</script><div {@attach make()}></div>";
+    assert_eq!(attach_flags(source), (true, true));
+}
+
+#[test]
+fn global_call_is_not_promoted_to_an_impure_call() {
+    let source = "<div {@attach globalThis.make()}></div>";
+    assert_eq!(attach_flags(source), (false, false));
+}
+
+#[test]
+fn state_reference_does_not_invent_a_call() {
+    let source = "<script>let attachment = $state();</script><div {@attach attachment}></div>";
+    assert_eq!(attach_flags(source), (true, false));
+}


### PR DESCRIPTION
## Summary

- consume `AttachTag` expression metadata populated during Phase 2
- remove the duplicate Phase 3 `has_state` and `has_call` tree walks for attachments
- pin the Phase 2 decisions for local calls, global pure calls, and state-only references

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- compile and test execution intentionally deferred to CI per repository workflow

## Stack

- base: #3830
- progresses #3569
