### PR TITLE
refactor(client): consume spread expression metadata

### DIFF
--- a/crates/rsvelte_core/src/ast/template.rs
+++ b/crates/rsvelte_core/src/ast/template.rs
@@ -900,11 +900,20 @@ impl serde::Serialize for AttributeValuePart<'_> {
 }
 
 /// A spread attribute: `{...props}`.
+#[derive(Debug, Clone, Default)]
+pub struct SpreadAttributeMetadata {
+    /// Expression metadata populated during Phase 2 analysis.
+    pub expression: ExpressionMetadata,
+}
+
+/// A spread attribute: `{...props}`.
 #[derive(Debug, Clone)]
 pub struct SpreadAttribute<'a> {
     pub start: u32,
     pub end: u32,
     pub expression: Expression<'a>,
+    /// Internal metadata, omitted from the public AST serialization.
+    pub metadata: SpreadAttributeMetadata,
 }
 
 impl serde::Serialize for SpreadAttribute<'_> {

--- a/crates/rsvelte_core/src/compiler/phases/1_parse/state/element.rs
+++ b/crates/rsvelte_core/src/compiler/phases/1_parse/state/element.rs
@@ -1341,6 +1341,7 @@ impl<'a> Parser<'a> {
                         start: start as u32,
                         end: self.index as u32,
                         expression,
+                        metadata: Default::default(),
                     },
                 )));
             }

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/scope_builder.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/scope_builder.rs
@@ -3942,12 +3942,23 @@ impl<'a> ScopeBuilder<'a> {
             JsNode::ObjectPattern { properties, .. }
             | JsNode::ObjectExpression { properties, .. } => {
                 for prop in self.arena.get_js_children(*properties) {
-                    if let Some(value_id) = prop.value_node() {
-                        self.declare_decl_tag_bindings_node(
-                            self.arena.get_js_node(value_id),
-                            decl_kind,
-                            binding_kind,
-                        );
+                    match prop {
+                        JsNode::RestElement { argument, .. } => {
+                            self.declare_decl_tag_bindings_node(
+                                self.arena.get_js_node(*argument),
+                                decl_kind,
+                                binding_kind,
+                            );
+                        }
+                        _ => {
+                            if let Some(value_id) = prop.value_node() {
+                                self.declare_decl_tag_bindings_node(
+                                    self.arena.get_js_node(value_id),
+                                    decl_kind,
+                                    binding_kind,
+                                );
+                            }
+                        }
                     }
                 }
             }
@@ -4071,8 +4082,16 @@ impl<'a> ScopeBuilder<'a> {
             JsNode::ObjectPattern { properties, .. }
             | JsNode::ObjectExpression { properties, .. } => {
                 for prop in self.arena.get_js_children(*properties) {
-                    if let Some(value_id) = prop.value_node() {
-                        self.process_binding_pattern_from_node(self.arena.get_js_node(value_id));
+                    match prop {
+                        JsNode::RestElement { argument, .. } => self
+                            .process_binding_pattern_from_node(self.arena.get_js_node(*argument)),
+                        _ => {
+                            if let Some(value_id) = prop.value_node() {
+                                self.process_binding_pattern_from_node(
+                                    self.arena.get_js_node(value_id),
+                                );
+                            }
+                        }
                     }
                 }
             }

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/regular_element.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/regular_element.rs
@@ -448,7 +448,7 @@ pub fn visit<'a, 'b: 'a>(
 
     for attr in &mut element.attributes {
         if let Attribute::SpreadAttribute(spread) = attr {
-            spread_attribute::visit(spread, context)?;
+            spread_attribute::visit(spread, context, true)?;
         }
     }
 

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/regular_element.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/regular_element.rs
@@ -446,7 +446,7 @@ pub fn visit<'a, 'b: 'a>(
             super::shared::element::collect_css_attribute_facts(&element.attributes, context);
     }
 
-    for attr in &element.attributes {
+    for attr in &mut element.attributes {
         if let Attribute::SpreadAttribute(spread) = attr {
             spread_attribute::visit(spread, context)?;
         }

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/shared/component.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/shared/component.rs
@@ -233,7 +233,7 @@ pub fn visit_component<'a, 'b: 'a>(
                 }
             }
             Attribute::SpreadAttribute(spread) => {
-                super::attribute::walk_template_expression(&spread.expression, context)?;
+                super::super::spread_attribute::visit(spread, context)?;
             }
             Attribute::AttachTag(attach) => {
                 super::super::attach_tag::visit(attach, context)?;

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/shared/component.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/shared/component.rs
@@ -233,7 +233,7 @@ pub fn visit_component<'a, 'b: 'a>(
                 }
             }
             Attribute::SpreadAttribute(spread) => {
-                super::super::spread_attribute::visit(spread, context)?;
+                super::super::spread_attribute::visit(spread, context, false)?;
             }
             Attribute::AttachTag(attach) => {
                 super::super::attach_tag::visit(attach, context)?;

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/slot_element.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/slot_element.rs
@@ -91,7 +91,7 @@ pub fn visit<'a, 'b: 'a>(
                 super::attribute::visit_attribute_value_expressions(&mut a.value, context)?;
             }
             Attribute::SpreadAttribute(spread) => {
-                super::script::walk_expression(&spread.expression, context)?;
+                super::spread_attribute::visit(spread, context)?;
             }
             _ => {}
         }

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/slot_element.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/slot_element.rs
@@ -91,7 +91,7 @@ pub fn visit<'a, 'b: 'a>(
                 super::attribute::visit_attribute_value_expressions(&mut a.value, context)?;
             }
             Attribute::SpreadAttribute(spread) => {
-                super::spread_attribute::visit(spread, context)?;
+                super::spread_attribute::visit(spread, context, false)?;
             }
             _ => {}
         }

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/spread_attribute.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/spread_attribute.rs
@@ -10,7 +10,7 @@ use crate::compiler::phases::phase2_analyze::AnalysisError;
 
 /// Visit a spread attribute.
 pub fn visit(
-    attribute: &SpreadAttribute,
+    attribute: &mut SpreadAttribute,
     context: &mut VisitorContext,
 ) -> Result<(), AnalysisError> {
     // Spreads can contain class/style/id, so we can't safely prune CSS
@@ -29,17 +29,22 @@ pub fn visit(
         }
     }
 
-    // Walk the spread expression to trigger needs_context detection.
+    // Walk the spread expression to populate its Phase 2 metadata and trigger
+    // needs_context detection.
     // In the official Svelte compiler, SpreadAttribute.js uses `context.next()` which
-    // recursively visits the expression, calling CallExpression visitor which sets
-    // `needs_context = true` for calls to imported or prop functions.
+    // recursively visits the expression with `node.metadata.expression` installed.
     // Corresponds to SpreadAttribute.js: `context.next({ ...context.state, expression: node.metadata.expression })`
     // Mark the reactive expression context so the AwaitExpression visitor applies
     // the `suspend` gate (`experimental_async` / `legacy_await_invalid`), mirroring
     // upstream's `expression: node.metadata.expression`.
     let saved_in_expression_tag = context.in_expression_tag;
     context.in_expression_tag = true;
-    let result = super::script::walk_expression(&attribute.expression, context);
+    let node = attribute.expression.as_node();
+    let result = super::shared::utils::walk_js_expression_node(
+        &node,
+        context,
+        &mut attribute.metadata.expression,
+    );
     context.in_expression_tag = saved_in_expression_tag;
     result?;
 

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/spread_attribute.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/spread_attribute.rs
@@ -12,10 +12,15 @@ use crate::compiler::phases::phase2_analyze::AnalysisError;
 pub fn visit(
     attribute: &mut SpreadAttribute,
     context: &mut VisitorContext,
+    can_set_dom_attributes: bool,
 ) -> Result<(), AnalysisError> {
-    // Spreads can contain class/style/id, so we can't safely prune CSS
-    context.analysis.css.has_dynamic_classes = true;
-    context.analysis.css.has_dynamic_ids = true;
+    // A spread on a DOM element can contain class/style/id, so we can't safely
+    // prune CSS. Component and slot spreads pass props instead and must not
+    // affect selector matching.
+    if can_set_dom_attributes {
+        context.analysis.css.has_dynamic_classes = true;
+        context.analysis.css.has_dynamic_ids = true;
+    }
 
     // Check if this is a $$restProps or $$props spread (for legacy mode)
     if !context.analysis.runes

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/svelte_component.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/svelte_component.rs
@@ -84,7 +84,7 @@ pub fn visit<'a, 'b: 'a>(
                 }
             }
             Attribute::SpreadAttribute(spread) => {
-                super::shared::attribute::walk_template_expression(&spread.expression, context)?;
+                super::spread_attribute::visit(spread, context)?;
             }
             Attribute::Attribute(a) => {
                 super::shared::attribute::warn_attribute_quoted(context, a);

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/svelte_component.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/svelte_component.rs
@@ -84,7 +84,7 @@ pub fn visit<'a, 'b: 'a>(
                 }
             }
             Attribute::SpreadAttribute(spread) => {
-                super::spread_attribute::visit(spread, context)?;
+                super::spread_attribute::visit(spread, context, false)?;
             }
             Attribute::Attribute(a) => {
                 super::shared::attribute::warn_attribute_quoted(context, a);

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/svelte_element.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/svelte_element.rs
@@ -279,7 +279,7 @@ pub fn visit<'a, 'b: 'a>(
                 }
             }
             Attribute::SpreadAttribute(spread) => {
-                super::spread_attribute::visit(spread, context)?;
+                super::spread_attribute::visit(spread, context, true)?;
             }
             Attribute::OnDirective(on) => {
                 super::on_directive::visit(on, context)?;

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/svelte_self.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/svelte_self.rs
@@ -113,7 +113,7 @@ pub fn visit<'a, 'b: 'a>(
                 }
             }
             Attribute::SpreadAttribute(spread) => {
-                super::spread_attribute::visit(spread, context)?;
+                super::spread_attribute::visit(spread, context, false)?;
             }
             Attribute::AttachTag(attach) => {
                 super::attach_tag::visit(attach, context)?;

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/svelte_self.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/svelte_self.rs
@@ -113,7 +113,7 @@ pub fn visit<'a, 'b: 'a>(
                 }
             }
             Attribute::SpreadAttribute(spread) => {
-                super::shared::attribute::walk_template_expression(&spread.expression, context)?;
+                super::spread_attribute::visit(spread, context)?;
             }
             Attribute::AttachTag(attach) => {
                 super::attach_tag::visit(attach, context)?;

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/component.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/component.rs
@@ -1146,8 +1146,8 @@ fn process_spread_attribute(
     //   } else {
     //       props_and_spreads.push(expression);
     //   }
-    let has_state = super::utils::expression_has_reactive_state(&spread.expression, context);
-    let has_call = super::utils::expression_has_call(&spread.expression, context);
+    let has_state = spread.metadata.expression.has_state();
+    let has_call = spread.metadata.expression.has_call();
     let has_await = crate::compiler::phases::phase3_transform::js_ast::builders::js_expr_has_await(
         &context.arena,
         &expression,

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/element.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/element.rs
@@ -1498,9 +1498,8 @@ pub fn build_attribute_effect(
                     super::utils::apply_transforms_to_expression(&spread_expr, context);
 
                 // Check if the spread expression has function calls or reactive state
-                let has_call = super::utils::expression_has_call(&spread.expression, context);
-                let has_state =
-                    super::utils::expression_has_reactive_state(&spread.expression, context);
+                let has_call = spread.metadata.expression.has_call();
+                let has_state = spread.metadata.expression.has_state();
 
                 // Check if spread expression has await
                 let spread_has_await = super::utils::expression_has_await(&spread.expression);

--- a/crates/rsvelte_core/tests/spread_expression_metadata_3569.rs
+++ b/crates/rsvelte_core/tests/spread_expression_metadata_3569.rs
@@ -40,6 +40,24 @@ fn spread_flags(source: &str) -> (bool, bool) {
     )
 }
 
+fn css_dynamic_flags(source: &str) -> (bool, bool) {
+    let mut root = parse(
+        source,
+        &oxc_allocator::Allocator::default(),
+        ParseOptions::default(),
+    )
+    .expect("parse");
+    // SAFETY: `root.arena` outlives the guard and analysis below.
+    let _arena_guard = unsafe { SerializeArenaGuard::new(&raw const root.arena) };
+    let analysis =
+        analyze_component(&mut root, source, &CompileOptions::default()).expect("analyze");
+
+    (
+        analysis.css.has_dynamic_classes,
+        analysis.css.has_dynamic_ids,
+    )
+}
+
 #[test]
 fn every_legal_host_populates_local_call_metadata() {
     for source in [
@@ -65,6 +83,21 @@ fn global_call_is_not_promoted_to_an_impure_call() {
 fn state_reference_does_not_invent_a_call() {
     let source = "<script>let props = $state();</script><div {...props}></div>";
     assert_eq!(spread_flags(source), (true, false));
+}
+
+#[test]
+fn only_dom_spreads_make_css_attributes_dynamic() {
+    assert_eq!(css_dynamic_flags("<div {...props}></div>"), (true, true));
+    assert_eq!(
+        css_dynamic_flags("<svelte:element this=\"div\" {...props} />"),
+        (true, true)
+    );
+    assert_eq!(css_dynamic_flags("<Widget {...props} />"), (false, false));
+    assert_eq!(
+        css_dynamic_flags("<svelte:component this={Widget} {...props} />"),
+        (false, false)
+    );
+    assert_eq!(css_dynamic_flags("<slot {...props} />"), (false, false));
 }
 
 #[test]

--- a/crates/rsvelte_core/tests/spread_expression_metadata_3569.rs
+++ b/crates/rsvelte_core/tests/spread_expression_metadata_3569.rs
@@ -1,0 +1,68 @@
+//! Issue #3569: `SpreadAttribute` owns the expression metadata that Phase 3
+//! uses for memoisation decisions.
+
+use rsvelte_core::{
+    CompileOptions, ParseOptions,
+    ast::{
+        arena::SerializeArenaGuard,
+        template::{Attribute, TemplateNode},
+    },
+    compiler::phases::analyze_component,
+    parse,
+};
+
+fn spread_flags(source: &str) -> (bool, bool) {
+    let mut root = parse(
+        source,
+        &oxc_allocator::Allocator::default(),
+        ParseOptions::default(),
+    )
+    .expect("parse");
+    // SAFETY: `root.arena` outlives the guard and analysis below.
+    let _arena_guard = unsafe { SerializeArenaGuard::new(&raw const root.arena) };
+    analyze_component(&mut root, source, &CompileOptions::default()).expect("analyze");
+
+    let attributes = match &root.fragment.nodes[0] {
+        TemplateNode::RegularElement(element) => &element.attributes,
+        TemplateNode::Component(component) => &component.attributes,
+        TemplateNode::SvelteComponent(component) => &component.attributes,
+        TemplateNode::SvelteElement(element) => &element.attributes,
+        TemplateNode::SlotElement(element) => &element.attributes,
+        other => panic!("expected an element host, got {other:?}"),
+    };
+    let Some(Attribute::SpreadAttribute(spread)) = attributes.last() else {
+        panic!("expected spread attribute");
+    };
+
+    (
+        spread.metadata.expression.has_state(),
+        spread.metadata.expression.has_call(),
+    )
+}
+
+#[test]
+fn every_legal_host_populates_local_call_metadata() {
+    for source in [
+        "<script>function make() {}</script><div {...make()}></div>",
+        "<script>function make() {}</script><Widget {...make()} />",
+        "<script>function make() {}</script><svelte:component this={Widget} {...make()} />",
+        "<script>function make() {}</script><svelte:element this=\"div\" {...make()} />",
+        "<script>function make() {}</script><slot {...make()} />",
+    ] {
+        assert_eq!(spread_flags(source), (true, true), "{source}");
+    }
+}
+
+#[test]
+fn global_call_is_not_promoted_to_an_impure_call() {
+    assert_eq!(
+        spread_flags("<div {...globalThis.make()}></div>"),
+        (false, false)
+    );
+}
+
+#[test]
+fn state_reference_does_not_invent_a_call() {
+    let source = "<script>let props = $state();</script><div {...props}></div>";
+    assert_eq!(spread_flags(source), (true, false));
+}

--- a/crates/rsvelte_core/tests/spread_expression_metadata_3569.rs
+++ b/crates/rsvelte_core/tests/spread_expression_metadata_3569.rs
@@ -66,3 +66,39 @@ fn state_reference_does_not_invent_a_call() {
     let source = "<script>let props = $state();</script><div {...props}></div>";
     assert_eq!(spread_flags(source), (true, false));
 }
+
+#[test]
+fn const_tag_object_rest_is_reactive() {
+    let source = concat!(
+        "<script>let props = $state({});</script>",
+        "<Widget>{@const { ...rest } = props}<Inner {...rest} /></Widget>",
+    );
+    let mut root = parse(
+        source,
+        &oxc_allocator::Allocator::default(),
+        ParseOptions::default(),
+    )
+    .expect("parse");
+    // SAFETY: `root.arena` outlives the guard and analysis below.
+    let _arena_guard = unsafe { SerializeArenaGuard::new(&raw const root.arena) };
+    analyze_component(&mut root, source, &CompileOptions::default()).expect("analyze");
+
+    let TemplateNode::Component(outer) = &root.fragment.nodes[0] else {
+        panic!("expected outer component");
+    };
+    let inner = outer
+        .fragment
+        .nodes
+        .iter()
+        .find_map(|node| match node {
+            TemplateNode::Component(component) => Some(component),
+            _ => None,
+        })
+        .expect("inner component");
+    let Some(Attribute::SpreadAttribute(spread)) = inner.attributes.last() else {
+        panic!("expected spread attribute");
+    };
+
+    assert!(spread.metadata.expression.has_state());
+    assert!(!spread.metadata.expression.has_call());
+}


### PR DESCRIPTION
## Summary

- add upstream-shaped expression metadata to `SpreadAttribute`
- populate it in Phase 2 on regular elements, dynamic elements, components, `svelte:component`, `svelte:self`, and slots
- consume the saved call/state flags in both client spread transform paths instead of walking the expression again
- cover host traversal and the local-call, pure-global-call, and state-only decisions directly

## Scope

This is the next independently reviewable slice of #3569 and is stacked on #3832. It progresses the issue but does not close the remaining duplicate metadata walkers.

## Verification

- `cargo fmt --all -- --check`
- `git diff --check`
- confirmed the only `SpreadAttribute` constructor initializes the metadata
- confirmed the client transform has no remaining spread-specific `expression_has_call` / `expression_has_reactive_state` walk

Per project instructions, compilation and tests were not run locally; CI is the execution oracle.
