### PR TITLE
refactor(client): consume style directive metadata

### DIFF
--- a/crates/rsvelte_core/src/ast/template.rs
+++ b/crates/rsvelte_core/src/ast/template.rs
@@ -1055,6 +1055,13 @@ impl serde::Serialize for ClassDirective<'_> {
 }
 
 /// A style directive: `style:property={expression}`.
+#[derive(Debug, Clone, Default)]
+pub struct StyleDirectiveMetadata {
+    /// Expression metadata merged from every expression chunk in the value.
+    pub expression: ExpressionMetadata,
+}
+
+/// A style directive: `style:property={expression}`.
 #[derive(Debug, Clone)]
 pub struct StyleDirective<'a> {
     pub start: u32,
@@ -1063,6 +1070,9 @@ pub struct StyleDirective<'a> {
     pub name_loc: Option<SourceLocation>,
     pub value: AttributeValue<'a>,
     pub modifiers: SmallVec<[CompactString; 2]>,
+    /// Internal metadata populated during Phase 2 analysis. Boxed so adding
+    /// analysis-only fields does not enlarge every `Attribute` enum value.
+    pub metadata: Box<StyleDirectiveMetadata>,
 }
 
 impl serde::Serialize for StyleDirective<'_> {

--- a/crates/rsvelte_core/src/compiler/phases/1_parse/state/element.rs
+++ b/crates/rsvelte_core/src/compiler/phases/1_parse/state/element.rs
@@ -1980,6 +1980,7 @@ impl<'a> Parser<'a> {
                 name_loc,
                 value,
                 modifiers,
+                metadata: Box::default(),
             },
         )))
     }

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/regular_element.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/regular_element.rs
@@ -802,8 +802,8 @@ pub fn visit<'a, 'b: 'a>(
                 // `class_directive::visit` can populate `directive.metadata`.
             }
             Attribute::StyleDirective(_) => {
-                // Re-borrow the style directive for the visit call
-                if let Attribute::StyleDirective(style_dir) = &element.attributes[i] {
+                // Re-borrow the style directive mutably so analysis can populate metadata.
+                if let Attribute::StyleDirective(style_dir) = &mut element.attributes[i] {
                     super::style_directive::visit(style_dir, context)?;
                 }
             }

--- a/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/style_directive.rs
+++ b/crates/rsvelte_core/src/compiler/phases/2_analyze/visitors/style_directive.rs
@@ -6,13 +6,15 @@
 
 use super::super::errors;
 use super::VisitorContext;
+use super::shared::fragment::mark_subtree_dynamic;
 use super::shared::utils::walk_js_expression_node;
 use crate::ast::template::{AttributeValue, AttributeValuePart, StyleDirective};
 use crate::compiler::phases::phase2_analyze::AnalysisError;
+use crate::compiler::phases::phase2_analyze::scope::BindingKind;
 
 /// Visit a style directive.
 pub fn visit(
-    directive: &StyleDirective,
+    directive: &mut StyleDirective,
     context: &mut VisitorContext,
 ) -> Result<(), AnalysisError> {
     // style: directives set individual CSS properties
@@ -27,6 +29,8 @@ pub fn visit(
         return Err(errors::style_directive_invalid_modifier().at(directive.start, directive.end));
     }
 
+    mark_subtree_dynamic(&context.path);
+
     // Analyze the expression value
     match &directive.value {
         AttributeValue::True(_) => {
@@ -34,7 +38,19 @@ pub fn visit(
             // Look up the binding for the directive name and add a reference
             // This corresponds to the official compiler's handling at StyleDirective.js L18-29
             let name = directive.name.as_str();
-            if let Some(&binding_idx) = context.analysis.root.scope.declarations.get(name) {
+            if let Some(binding_idx) = context.analysis.root.get_binding(name, context.scope) {
+                let binding = &context.analysis.root.bindings[binding_idx];
+                if binding.kind != BindingKind::Normal {
+                    directive.metadata.expression.set_has_state(true);
+                }
+                if binding.blocker.is_some() {
+                    directive
+                        .metadata
+                        .expression
+                        .dependencies
+                        .insert(binding_idx);
+                }
+
                 // Add a style directive reference for legacy state promotion
                 context.analysis.root.bindings[binding_idx].add_reference(
                     directive.start,
@@ -48,8 +64,7 @@ pub fn visit(
         AttributeValue::Expression(expr_tag) => {
             // Single expression: `style:color={expr}`
             let node = expr_tag.expression.as_node();
-            let mut metadata = crate::ast::template::ExpressionMetadata::default();
-            walk_js_expression_node(&node, context, &mut metadata)?;
+            walk_js_expression_node(&node, context, &mut directive.metadata.expression)?;
         }
         AttributeValue::Sequence(parts) => {
             // Mixed content: `style:color="prefix{expr}suffix"`
@@ -57,8 +72,11 @@ pub fn visit(
                 match part {
                     AttributeValuePart::ExpressionTag(expr_tag) => {
                         let node = expr_tag.expression.as_node();
-                        let mut metadata = crate::ast::template::ExpressionMetadata::default();
-                        walk_js_expression_node(&node, context, &mut metadata)?;
+                        walk_js_expression_node(
+                            &node,
+                            context,
+                            &mut directive.metadata.expression,
+                        )?;
                     }
                     AttributeValuePart::Text(text) => {
                         super::text::check_bidirectional_control_characters(

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/element.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/element.rs
@@ -700,14 +700,10 @@ pub fn build_style_directives_object_with_memoizer(
     let mut has_await = false;
 
     for directive in style_directives {
-        // Track metadata for memoization decision
-        for expr in &get_directive_expressions(directive) {
-            has_call = has_call || super::utils::expression_has_call(expr, context);
-            has_state = has_state
-                || super::utils::expression_has_reactive_state(expr, context)
-                || super::utils::expression_has_call(expr, context);
-            has_await = has_await || super::utils::expression_has_await(expr);
-        }
+        let metadata = &directive.metadata.expression;
+        has_call |= metadata.has_call();
+        has_state |= metadata.has_state();
+        has_await |= metadata.has_await();
 
         // Build the expression for this directive
         let expression = if matches!(&directive.value, AttributeValue::True(true)) {
@@ -1047,60 +1043,16 @@ pub fn build_set_style(
         // Build style directives object
         next = Some(build_style_directives_object(style_directives, context));
 
-        // Check if any style directive has state, non-pure function calls, or async blockers
-        // In the official compiler, has_call implies has_state for template_effect routing
-        // Also check for async blockers - variables that depend on async promises should be
-        // treated as having state so they end up in template_effect with proper promise deps
-        for directive in style_directives {
-            // Upstream analyzes a SHORTHAND directive by binding KIND alone
-            // (`binding.kind !== 'normal'`, StyleDirective.js) — it never
-            // evaluates the value, so an unmutated `$state` stays reactive
-            // here even though the explicit `style:x={x}` form would fold it
-            // as a known constant via `scope.evaluate`.
-            if matches!(&directive.value, AttributeValue::True(_)) {
-                let name = directive.name.as_str();
-                let shadowed = context.state.each_binding_context.iter().any(|c| {
-                    c.item_name == name || (!c.index_name.is_empty() && c.index_name == name)
-                });
-                let non_normal_binding = context
-                    .state
-                    .scope_root
-                    .binding_at_reference(name, directive.start)
-                    .or_else(|| context.state.get_binding(name))
-                    .is_some_and(|b| {
-                        !matches!(
-                            b.kind,
-                            crate::compiler::phases::phase2_analyze::scope::BindingKind::Normal
-                        )
-                    });
-                if shadowed || non_normal_binding {
-                    has_state = true;
-                    break;
-                }
-            } else {
-                if get_directive_expressions(directive).iter().any(|expr| {
-                    super::utils::expression_has_reactive_state(expr, context)
-                        || super::utils::expression_has_call(expr, context)
-                }) {
-                    has_state = true;
-                    break;
-                }
-            }
-            // Check for async blockers: convert directive expression to JS and check blockers
-            let js_expr = if matches!(&directive.value, AttributeValue::True(true)) {
-                b::id(directive.name.as_str())
-            } else {
-                let result = build_attribute_value(&directive.value, context, |expr, _| expr);
-                result.value
-            };
-            if context
-                .state
-                .has_blockers_for_expr(&js_expr, &context.arena)
-            {
-                has_state = true;
-                break;
-            }
-        }
+        has_state |= style_directives.iter().any(|directive| {
+            let metadata = &directive.metadata.expression;
+            metadata.has_state()
+                || metadata.has_await()
+                || metadata.dependencies.iter().any(|binding_idx| {
+                    context.state.scope_root.bindings[*binding_idx]
+                        .blocker
+                        .is_some()
+                })
+        });
 
         if has_state {
             let id = context.state.memoizer.generate_id("styles");
@@ -1366,36 +1318,6 @@ fn build_style_attribute_value_with_memoization(
             });
             (value, has_state)
         }
-    }
-}
-
-/// Helper to get the expressions from a style directive value.
-///
-/// Upstream's phase-2 `StyleDirective` visitor merges the metadata of EVERY
-/// `ExpressionTag` chunk, so a directive is reactive when any chunk is.
-fn get_directive_expressions<'a>(
-    directive: &StyleDirective<'a>,
-) -> Vec<crate::ast::js::Expression<'a>> {
-    use crate::ast::js::Expression;
-
-    match &directive.value {
-        AttributeValue::Expression(expr_tag) => vec![expr_tag.expression.clone()],
-        AttributeValue::True(_) => {
-            // For style:color shorthand, create an identifier expression
-            vec![Expression::from_json(serde_json::json!({
-                "type": "Identifier",
-                "name": directive.name.to_string()
-            }))]
-        }
-        AttributeValue::Sequence(parts) => parts
-            .iter()
-            .filter_map(|part| match part {
-                crate::ast::template::AttributeValuePart::ExpressionTag(expr_tag) => {
-                    Some(expr_tag.expression.clone())
-                }
-                _ => None,
-            })
-            .collect(),
     }
 }
 

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/element.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/element.rs
@@ -702,7 +702,16 @@ pub fn build_style_directives_object_with_memoizer(
     for directive in style_directives {
         let metadata = &directive.metadata.expression;
         has_call |= metadata.has_call();
-        has_state |= metadata.has_state();
+        has_state |= if matches!(&directive.value, AttributeValue::True(_)) {
+            metadata.has_state()
+        } else {
+            get_directive_expressions(directive)
+                .iter()
+                .any(|expr| super::utils::expression_has_reactive_state(expr, context))
+        };
+        // Upstream treats a call as stateful for style memoization even when
+        // its callee is otherwise pure.
+        has_state |= metadata.has_call();
         has_await |= metadata.has_await();
 
         // Build the expression for this directive
@@ -1045,8 +1054,14 @@ pub fn build_set_style(
 
         has_state |= style_directives.iter().any(|directive| {
             let metadata = &directive.metadata.expression;
-            metadata.has_state()
-                || metadata.has_await()
+            (if matches!(&directive.value, AttributeValue::True(_)) {
+                metadata.has_state()
+            } else {
+                metadata.has_call()
+                    || get_directive_expressions(directive)
+                        .iter()
+                        .any(|expr| super::utils::expression_has_reactive_state(expr, context))
+            }) || metadata.has_await()
                 || metadata.dependencies.iter().any(|binding_idx| {
                     context.state.scope_root.bindings[*binding_idx]
                         .blocker
@@ -1318,6 +1333,34 @@ fn build_style_attribute_value_with_memoization(
             });
             (value, has_state)
         }
+    }
+}
+
+/// Return the expression chunks whose compile-time-known status still needs
+/// the client scope evaluator.
+///
+/// Phase 2 owns call/await/dependency metadata, but its conservative binding
+/// check cannot yet reproduce `scope.evaluate` for values such as an
+/// unmodified `$state('red')`. Keep this one state-only lookup until that
+/// evaluator is shared; treating the conservative bit as exact changes whether
+/// `$.set_style` runs during init or in a template effect.
+fn get_directive_expressions<'a>(
+    directive: &StyleDirective<'a>,
+) -> Vec<crate::ast::js::Expression<'a>> {
+    use crate::ast::js::Expression;
+
+    match &directive.value {
+        AttributeValue::Expression(expr_tag) => vec![expr_tag.expression.clone()],
+        AttributeValue::True(_) => Vec::new(),
+        AttributeValue::Sequence(parts) => parts
+            .iter()
+            .filter_map(|part| match part {
+                crate::ast::template::AttributeValuePart::ExpressionTag(expr_tag) => {
+                    Some(expr_tag.expression.clone())
+                }
+                _ => None,
+            })
+            .collect(),
     }
 }
 

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/element.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/element.rs
@@ -1347,8 +1347,6 @@ fn build_style_attribute_value_with_memoization(
 fn get_directive_expressions<'a>(
     directive: &StyleDirective<'a>,
 ) -> Vec<crate::ast::js::Expression<'a>> {
-    use crate::ast::js::Expression;
-
     match &directive.value {
         AttributeValue::Expression(expr_tag) => vec![expr_tag.expression.clone()],
         AttributeValue::True(_) => Vec::new(),

--- a/crates/rsvelte_core/tests/style_directive_expression_metadata_3569.rs
+++ b/crates/rsvelte_core/tests/style_directive_expression_metadata_3569.rs
@@ -1,5 +1,7 @@
-//! Issue #3569: `StyleDirective` owns the aggregate expression metadata that
-//! Phase 3 uses for memoisation and update routing.
+//! Issue #3569: `StyleDirective` owns aggregate call, await, dependency, and
+//! shorthand-state metadata that Phase 3 uses for memoisation and update
+//! routing. Explicit-expression state remains with the client scope evaluator
+//! until Phase 2 can represent its compile-time-known result exactly.
 
 use rsvelte_core::{
     CompileOptions, ParseOptions,
@@ -34,7 +36,10 @@ fn style_flags(source: &str) -> (bool, bool, bool) {
         TemplateNode::SvelteDocument(element) => &element.attributes,
         other => panic!("expected an element host, got {other:?}"),
     };
-    let Some(Attribute::StyleDirective(directive)) = attributes.last() else {
+    let Some(Attribute::StyleDirective(directive)) = attributes
+        .iter()
+        .find(|attribute| matches!(attribute, Attribute::StyleDirective(_)))
+    else {
         panic!("expected style directive");
     };
 

--- a/crates/rsvelte_core/tests/style_directive_expression_metadata_3569.rs
+++ b/crates/rsvelte_core/tests/style_directive_expression_metadata_3569.rs
@@ -1,0 +1,86 @@
+//! Issue #3569: `StyleDirective` owns the aggregate expression metadata that
+//! Phase 3 uses for memoisation and update routing.
+
+use rsvelte_core::{
+    CompileOptions, ParseOptions,
+    ast::{
+        arena::SerializeArenaGuard,
+        template::{Attribute, TemplateNode},
+    },
+    compiler::phases::analyze_component,
+    parse,
+};
+
+fn style_flags(source: &str) -> (bool, bool, bool) {
+    let mut root = parse(
+        source,
+        &oxc_allocator::Allocator::default(),
+        ParseOptions::default(),
+    )
+    .expect("parse");
+    // SAFETY: `root.arena` outlives the guard and analysis below.
+    let _arena_guard = unsafe { SerializeArenaGuard::new(&raw const root.arena) };
+    analyze_component(&mut root, source, &CompileOptions::default()).expect("analyze");
+
+    let node = match &root.fragment.nodes[0] {
+        TemplateNode::EachBlock(block) => &block.body.nodes[0],
+        node => node,
+    };
+    let attributes = match node {
+        TemplateNode::RegularElement(element) => &element.attributes,
+        TemplateNode::SvelteElement(element) => &element.attributes,
+        TemplateNode::SvelteBody(element) => &element.attributes,
+        TemplateNode::SvelteWindow(element) => &element.attributes,
+        TemplateNode::SvelteDocument(element) => &element.attributes,
+        other => panic!("expected an element host, got {other:?}"),
+    };
+    let Some(Attribute::StyleDirective(directive)) = attributes.last() else {
+        panic!("expected style directive");
+    };
+
+    let metadata = &directive.metadata.expression;
+    (
+        metadata.has_state(),
+        metadata.has_call(),
+        metadata.has_await(),
+    )
+}
+
+#[test]
+fn every_legal_host_populates_local_call_metadata() {
+    for source in [
+        "<script>function make() {}</script><div style:color={make()}></div>",
+        "<script>function make() {}</script><svelte:element this=\"div\" style:color={make()} />",
+        "<script>function make() {}</script><svelte:body style:color={make()} />",
+        "<script>function make() {}</script><svelte:window style:color={make()} />",
+        "<script>function make() {}</script><svelte:document style:color={make()} />",
+    ] {
+        assert_eq!(style_flags(source), (true, true, false), "{source}");
+    }
+}
+
+#[test]
+fn every_expression_chunk_contributes_to_the_aggregate() {
+    let source = "<script>let color = $state(); function make() {}</script><div style:color=\"{color}-{make()}\"></div>";
+    assert_eq!(style_flags(source), (true, true, false));
+}
+
+#[test]
+fn global_call_is_not_promoted_to_an_impure_call() {
+    assert_eq!(
+        style_flags("<div style:color={globalThis.make()}></div>"),
+        (false, false, false)
+    );
+}
+
+#[test]
+fn shorthand_uses_the_lexically_resolved_binding_kind() {
+    assert_eq!(
+        style_flags("{#each [1] as color}<div style:color></div>{/each}"),
+        (true, false, false)
+    );
+    assert_eq!(
+        style_flags("<script>let color = 'red';</script><div style:color></div>"),
+        (false, false, false)
+    );
+}


### PR DESCRIPTION
## Summary

- add upstream-style aggregate expression metadata to `StyleDirective`
- populate it once during Phase 2 for shorthand, single-expression, and multi-chunk values
- replace the client transform's duplicate expression walks and binding-kind inference with the stored metadata
- resolve shorthand bindings from the current lexical scope, including each-block bindings

## Scope

This is the next independently reviewable slice of #3569. It is stacked on #3833; only the top commit belongs to this PR.

The existing shorthand-only blocker compatibility path remains intact. Phase 3 now derives its update-routing blocker check from the binding indices recorded in Phase 2 instead of re-scanning generated expressions.

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- `node --check scripts/ci/check-upstream-issues.mjs`
- added metadata coverage for every legal host, multi-chunk values, pure global calls, and lexically scoped shorthand bindings

Per project instruction, no local build or test suite was run; CI is the execution oracle.
