### PR TITLE
refactor(client): consume standalone attribute metadata

### DIFF
--- a/compatibility/pattern-corpus/issues/3569-single-attribute-metadata.svelte
+++ b/compatibility/pattern-corpus/issues/3569-single-attribute-metadata.svelte
@@ -1,0 +1,13 @@
+<script>
+	let title = $state('title');
+
+	function local(value) {
+		return value;
+	}
+</script>
+
+<div title={local(title)}></div>
+<div title="{local(title).toUpperCase()}"></div>
+<div title={String(title)}></div>
+<Widget prop={local(title)} />
+<svelte:element this="div" title={local(title)}></svelte:element>

--- a/compatibility/pattern-corpus/issues/3569-single-attribute-metadata.svelte
+++ b/compatibility/pattern-corpus/issues/3569-single-attribute-metadata.svelte
@@ -9,5 +9,6 @@
 <div title={local(title)}></div>
 <div title="{local(title).toUpperCase()}"></div>
 <div title={String(title)}></div>
+<button onclick={globalThis.make()}>global handler</button>
 <Widget prop={local(title)} />
 <svelte:element this="div" title={local(title)}></svelte:element>

--- a/compatibility/two-ports-inventory.md
+++ b/compatibility/two-ports-inventory.md
@@ -387,7 +387,7 @@ template-expression walker.
 
 The first migration slices now attach and consume that Phase 2 metadata for `AttachTag`,
 `SpreadAttribute`, `StyleDirective`, the expressions inside a regular `style=` attribute, and
-standalone generic attribute values. The generic attribute builder's multi-part
+standalone generic attribute values and event handlers. The generic attribute builder's multi-part
 `walk_metadata_flags` / `json_contains_call` path and the shared `expression_has_call` helper
 remain separate Phase 3 decisions, so this row stays open rather than treating deletion of these
 local re-walks as agreement of the whole port family.

--- a/compatibility/two-ports-inventory.md
+++ b/compatibility/two-ports-inventory.md
@@ -386,10 +386,11 @@ remaining phase-2 writers are the reachable call, object-spread and top-level-sp
 template-expression walker.
 
 The first migration slices now attach and consume that Phase 2 metadata for `AttachTag`,
-`SpreadAttribute`, `StyleDirective`, and the expressions inside a regular `style=` attribute.
-The generic attribute builder's `walk_metadata_flags` / `json_contains_call` path and the shared
-`expression_has_call` helper remain separate Phase 3 decisions, so this row stays open rather
-than treating deletion of four local re-walks as agreement of the whole port family.
+`SpreadAttribute`, `StyleDirective`, the expressions inside a regular `style=` attribute, and
+standalone generic attribute values. The generic attribute builder's multi-part
+`walk_metadata_flags` / `json_contains_call` path and the shared `expression_has_call` helper
+remain separate Phase 3 decisions, so this row stays open rather than treating deletion of these
+local re-walks as agreement of the whole port family.
 
 ### 12. "Selector unused" and "element scoped" are two engines over two element models — [S]
 

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/attribute.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/attribute.rs
@@ -305,13 +305,9 @@ pub fn build_event_handler(
         }
     }
 
-    // Memoisation here uses the same broad "any CallExpression in the tree"
-    // semantics as the rest of Phase 3 — see `expression_tag_has_call` in
-    // `shared/element.rs` for why we don't read Phase 2's narrower flag.
-    let has_call =
-        crate::compiler::phases::phase3_transform::client::visitors::shared::element::expression_tag_has_call(
-            expr_tag,
-        );
+    // Upstream passes the ExpressionTag's Phase 2 metadata into
+    // `build_event_handler`; use the same analyzed call classification here.
+    let has_call = expr_tag.metadata.expression.has_call();
 
     let mut js_expr = js_expr;
 

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/element.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/element.rs
@@ -82,7 +82,8 @@ where
         AttributeValue::Expression(expr_tag) => {
             // Extract the expression from the ExpressionTag using the full expression converter
             let expression = extract_expression_from_tag_with_context(expr_tag, context);
-            let mut metadata = extract_metadata_from_tag(expr_tag);
+            let mut metadata =
+                ExpressionMetadata::from_template_metadata(&expr_tag.metadata.expression);
 
             // Check for reactive state using the comprehensive check that considers transforms
             let has_reactive_state =
@@ -94,11 +95,7 @@ where
             // `build_attribute_value`, so feeding it the broad walk would
             // wrap pure calls like `<Child prop={encodeURIComponent('x')}>`
             // in `$.derived(...)` (regresses the `purity` snapshot fixture).
-            let has_call = expr_tag.metadata.expression.has_call();
-            // `build_expression` reads the same flag upstream does, so a pure
-            // call (`String(1)`) must not be wrapped just because the phase-3
-            // walk saw a `CallExpression`.
-            metadata.set_has_call(has_call);
+            let has_call = metadata.has_call();
 
             // Apply transforms via build_expression (handles props: x -> x())
             let transformed = build_expression(context, &expression, &metadata);
@@ -136,7 +133,8 @@ where
 
                 AttributeValuePart::ExpressionTag(expr_tag) => {
                     let expression = extract_expression_from_tag_with_context(expr_tag, context);
-                    let mut metadata = extract_metadata_from_tag(expr_tag);
+                    let mut metadata =
+                        ExpressionMetadata::from_template_metadata(&expr_tag.metadata.expression);
 
                     // Check for reactive state using the comprehensive check that considers transforms
                     let has_reactive_state =
@@ -145,8 +143,7 @@ where
                     // Use Phase 2's narrow has_call (matches the official
                     // compiler) — see the matching comment in the
                     // `AttributeValue::Expression` arm above for why.
-                    let has_call = expr_tag.metadata.expression.has_call();
-                    metadata.set_has_call(has_call);
+                    let has_call = metadata.has_call();
 
                     // Apply transforms via build_expression (handles props: x -> x())
                     let transformed = build_expression(context, &expression, &metadata);

--- a/crates/rsvelte_core/tests/attribute_expression_metadata_3569.rs
+++ b/crates/rsvelte_core/tests/attribute_expression_metadata_3569.rs
@@ -1,0 +1,125 @@
+//! Issue #3569: a standalone regular attribute expression carries the Phase 2
+//! metadata consumed by the client attribute transform.
+
+use rsvelte_core::{
+    CompileOptions, ParseOptions,
+    ast::{
+        arena::SerializeArenaGuard,
+        template::{Attribute, AttributeValue, AttributeValuePart, TemplateNode},
+    },
+    compiler::phases::analyze_component,
+    parse,
+};
+
+#[derive(Debug, PartialEq, Eq)]
+struct Flags {
+    has_state: bool,
+    has_call: bool,
+    has_member_expression: bool,
+    quoted: bool,
+}
+
+fn attribute_flags(source: &str) -> Flags {
+    let mut root = parse(
+        source,
+        &oxc_allocator::Allocator::default(),
+        ParseOptions::default(),
+    )
+    .expect("parse");
+    // SAFETY: `root.arena` outlives the guard and analysis below.
+    let _arena_guard = unsafe { SerializeArenaGuard::new(&raw const root.arena) };
+    analyze_component(&mut root, source, &CompileOptions::default()).expect("analyze");
+
+    let attributes = match &root.fragment.nodes[0] {
+        TemplateNode::RegularElement(element) => &element.attributes,
+        TemplateNode::Component(component) => &component.attributes,
+        TemplateNode::SvelteComponent(component) => &component.attributes,
+        TemplateNode::SvelteElement(element) => &element.attributes,
+        TemplateNode::SlotElement(element) => &element.attributes,
+        other => panic!("expected an element host, got {other:?}"),
+    };
+    let Some(Attribute::Attribute(attribute)) = attributes.last() else {
+        panic!("expected regular attribute");
+    };
+
+    let (metadata, quoted) = match &attribute.value {
+        AttributeValue::Expression(tag) => (&tag.metadata.expression, false),
+        AttributeValue::Sequence(parts) => {
+            let [AttributeValuePart::ExpressionTag(tag)] = parts.as_slice() else {
+                panic!("expected one expression chunk");
+            };
+            (&tag.metadata.expression, true)
+        }
+        AttributeValue::True(_) => panic!("expected attribute expression"),
+    };
+
+    Flags {
+        has_state: metadata.has_state(),
+        has_call: metadata.has_call(),
+        has_member_expression: metadata.has_member_expression(),
+        quoted,
+    }
+}
+
+#[test]
+fn every_legal_host_populates_local_call_metadata() {
+    for source in [
+        "<script>function make() {}</script><div title={make()}></div>",
+        "<script>function make() {}</script><Widget prop={make()} />",
+        "<script>function make() {}</script><svelte:component this={Widget} prop={make()} />",
+        "<script>function make() {}</script><svelte:element this=\"div\" title={make()} />",
+        "<script>function make() {}</script><slot title={make()} />",
+    ] {
+        assert_eq!(
+            attribute_flags(source),
+            Flags {
+                has_state: true,
+                has_call: true,
+                has_member_expression: false,
+                quoted: false,
+            },
+            "{source}"
+        );
+    }
+}
+
+#[test]
+fn one_part_quoted_value_keeps_call_and_member_metadata() {
+    let source = "<script>function make() {}</script><div title=\"{make().value}\"></div>";
+    assert_eq!(
+        attribute_flags(source),
+        Flags {
+            has_state: true,
+            has_call: true,
+            has_member_expression: true,
+            quoted: true,
+        }
+    );
+}
+
+#[test]
+fn global_call_is_not_promoted_to_an_impure_call() {
+    assert_eq!(
+        attribute_flags("<div title={globalThis.make()}></div>"),
+        Flags {
+            has_state: false,
+            has_call: false,
+            has_member_expression: true,
+            quoted: false,
+        }
+    );
+}
+
+#[test]
+fn state_reference_does_not_invent_a_call() {
+    let source = "<script>let title = $state();</script><div title={title}></div>";
+    assert_eq!(
+        attribute_flags(source),
+        Flags {
+            has_state: true,
+            has_call: false,
+            has_member_expression: false,
+            quoted: false,
+        }
+    );
+}


### PR DESCRIPTION
## Summary

- consume each standalone regular attribute expression's Phase 2 metadata in the client transform
- preserve the analyzed narrow `has_call` decision and binding-reference set instead of rebuilding broad flags in Phase 3
- cover regular, component, dynamic-component, dynamic-element, slot, and one-part quoted attribute forms
- add a pattern-corpus repro and narrow the remaining two-ports inventory entry to multi-part attributes

## Context

This is a stacked follow-up to #3835 and another bounded slice of #3569. Upstream passes `chunk.metadata.expression` directly into `build_expression`. Rsvelte's standalone attribute branches instead called `extract_metadata_from_tag`, which re-walked the expression in Phase 3 and did not carry Phase 2's binding-reference set.

The existing transformed-state and async-blocker checks are unchanged. Multi-part attribute values also remain on their existing broad Phase 3 walker so this PR does not claim the full two-ports row is resolved.

## Verification

- `cargo fmt --all -- --check`
- `git diff --check`
- `node --check scripts/compat-corpus/verify.mjs`

Per the repository task constraints, no local build or test command was run. CI is the build and test oracle.
