### PR TITLE
Consume metadata for component CSS properties

### DIFF
--- a/compatibility/pattern-corpus/issues/3569-single-attribute-metadata.svelte
+++ b/compatibility/pattern-corpus/issues/3569-single-attribute-metadata.svelte
@@ -12,4 +12,9 @@
 <div title={String(title)}></div>
 <button onclick={globalThis.make()}>global handler</button>
 <Widget prop={local(title)} />
+<Widget
+	--single={local(title)}
+	--pure={globalThis.make()}
+	--mixed="pure:{globalThis.make()};dependent-global:{String(title)};local:{local(title)}"
+/>
 <svelte:element this="div" title={local(title)}></svelte:element>

--- a/compatibility/two-ports-inventory.md
+++ b/compatibility/two-ports-inventory.md
@@ -385,14 +385,16 @@ three writes cannot change output while that single producer and consumer remain
 remaining phase-2 writers are the reachable call, object-spread and top-level-spread arms in the
 template-expression walker.
 
-The first migration slices now attach and consume that Phase 2 metadata for `AttachTag`,
+The migration slices now attach and consume that Phase 2 metadata for `AttachTag`,
 `SpreadAttribute`, `StyleDirective`, the expressions inside a regular `style=` attribute, and
-every generic attribute-value chunk and generic event attribute. The old generic attribute
+every generic attribute-value chunk, generic event attribute and component CSS custom property.
+The old generic attribute
 `walk_metadata_flags` / `json_contains_call` implementations and the tests that only compared
-those unused walkers were then removed. The shared `expression_has_call` helper remains a
-separate production Phase 3 decision, while `shared/events.rs` independently asks the broader
-"contains any call" question for `OnDirective`. This row therefore stays open rather than
-treating migration of the generic attribute consumers as agreement of the whole port family.
+those unused walkers were then removed. The component CSS-property migration also removed the
+last production caller and definition of the shared `expression_has_call` helper, so Phase 3 no
+longer independently answers this question for generic attribute values. `shared/events.rs`
+still asks the broader "contains any call" question for `OnDirective`, so the inventory row
+remains open for that separate path.
 
 ### 12. "Selector unused" and "element scoped" are two engines over two element models — [S]
 

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/component.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/component.rs
@@ -1209,46 +1209,30 @@ fn process_regular_attribute(
     );
     // Handle custom CSS properties (--var)
     if attr.name.starts_with("--") {
-        // Build the attribute value with potential memoization
-        // This matches the official Svelte behavior where CSS prop values
-        // can be memoized if they contain function calls with state
-        let result = build_attribute_value(&attr.value, context, |value, _metadata| value);
-
-        // Check if this value needs memoization
-        let has_call =
-            super::utils::expression_has_call(&get_original_expression(&attr.value), context);
-        let _has_await = false; // TODO: detect await
-
-        // For CSS props, memoization happens when there's a call with state
-        let final_value = if has_call && result.has_state {
-            // Add to memoizer - this creates a derived variable
+        let arena_ptr = (&context.arena) as *const _;
+        let result = build_attribute_value(&attr.value, context, |value, metadata| {
             let memo_id = memoizer.add(
-                result.value.clone(),
-                true,  // has_call
-                false, // has_await
-                false, // memoize_if_state
-                true,  // has_state
+                value.clone(),
+                metadata.has_call(),
+                metadata.has_await(),
+                false,
+                metadata.has_state(),
             );
 
-            // If memoization happened (memo_id is $N), wrap in $.get()
             if let JsExpr::Identifier(name) = &memo_id {
                 if name.starts_with('$') && name.chars().skip(1).all(|c| c.is_ascii_digit()) {
-                    b::call(
-                        &context.arena,
-                        b::member_path(&context.arena, "$.get"),
-                        vec![memo_id],
-                    )
+                    // SAFETY: the arena outlives this `build_attribute_value` call.
+                    let arena = unsafe { &*arena_ptr };
+                    b::call(arena, b::member_path(arena, "$.get"), vec![memo_id])
                 } else {
-                    result.value
+                    value
                 }
             } else {
-                result.value
+                memo_id
             }
-        } else {
-            result.value
-        };
+        });
 
-        custom_css_props.push(b::prop(&context.arena, attr.name.as_str(), final_value));
+        custom_css_props.push(b::prop(&context.arena, attr.name.as_str(), result.value));
         return;
     }
 
@@ -1338,31 +1322,6 @@ fn process_regular_attribute(
             props_and_spreads,
             b::prop(&context.arena, attr.name.as_str(), final_value),
         );
-    }
-}
-
-/// Extract the original AST expression from an AttributeValue.
-fn get_original_expression<'a>(value: &AttributeValue<'a>) -> crate::ast::js::Expression<'a> {
-    match value {
-        AttributeValue::Expression(expr_tag) => expr_tag.expression.clone(),
-        AttributeValue::Sequence(parts) if parts.len() == 1 => {
-            if let AttributeValuePart::ExpressionTag(expr_tag) = &parts[0] {
-                expr_tag.expression.clone()
-            } else {
-                // Text - create a dummy literal expression
-                crate::ast::js::Expression::from_json(serde_json::json!({
-                    "type": "Literal",
-                    "value": ""
-                }))
-            }
-        }
-        _ => {
-            // Other cases - create a dummy literal expression
-            crate::ast::js::Expression::from_json(serde_json::json!({
-                "type": "Literal",
-                "value": ""
-            }))
-        }
     }
 }
 

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/utils.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/visitors/shared/utils.rs
@@ -4885,9 +4885,8 @@ pub struct ExpressionProperties {
 /// Analyze an expression for reactive state, calls, member expressions, and await
 /// expressions in a single pass over the JSON AST.
 ///
-/// This is equivalent to calling `expression_has_reactive_state`, `expression_has_call`,
-/// `expression_has_member`, and `expression_has_await` individually, but avoids
-/// walking the tree 4 times.
+/// This is equivalent to computing the reactive-state, call, member-expression,
+/// and await properties separately, but avoids walking the tree 4 times.
 pub fn analyze_expression_properties(
     expr: &crate::ast::js::Expression,
     context: &ComponentContext,
@@ -6111,25 +6110,6 @@ fn has_reactive_state_json(json_value: &serde_json::Value, context: &ComponentCo
     }
 }
 
-/// Check if an expression contains a non-pure function call.
-///
-/// Matches the official Svelte compiler's behavior: a call is only considered
-/// "has_call" if the callee is NOT pure. Pure callees are global identifiers
-/// (no local binding) like console.log, Math.max, and literals.
-/// Pure calls with only pure arguments are not counted.
-#[inline]
-pub fn expression_has_call(expr: &crate::ast::js::Expression, context: &ComponentContext) -> bool {
-    // Fast path: a leaf expression (Identifier, Literal, …) trivially
-    // contains no call. Returning early here avoids the `as_json()`
-    // serialization for `Expression::Typed` inputs, which would
-    // otherwise lower the whole JsNode into a `serde_json::Value`
-    // just to discover there's no CallExpression to find.
-    if is_call_member_await_free_leaf(expr) {
-        return false;
-    }
-    has_call_json(expr.as_json(), context)
-}
-
 /// Check if an expression (or its callee) is "pure" in the Svelte sense.
 /// Pure means: the expression doesn't reference any local bindings.
 /// Globals (identifiers without scope bindings) are pure.
@@ -6692,15 +6672,14 @@ fn has_member_json(json_value: &serde_json::Value) -> bool {
 /// Returns true if the expression contains an AwaitExpression at any level.
 #[inline]
 pub fn expression_has_await(expr: &crate::ast::js::Expression) -> bool {
-    // Leaf short-circuit — see `expression_has_call` for the rationale.
+    // Leaf short-circuit avoids materializing a typed leaf as JSON.
     if is_call_member_await_free_leaf(expr) {
         return false;
     }
     has_await_json(expr.as_json())
 }
 
-/// Type-dispatch fast path used by `expression_has_call` /
-/// `expression_has_member` / `expression_has_await` to skip the
+/// Type-dispatch fast path used by expression-property queries to skip the
 /// full `as_json()` serialization for expressions that can't
 /// possibly contain a CallExpression / MemberExpression /
 /// AwaitExpression.


### PR DESCRIPTION
## Summary

- feed each component CSS custom-property expression chunk's Phase 2 metadata to the client memoizer
- preserve upstream handling for calls and awaits in both standalone and multipart values
- remove the last attribute-path caller of the Phase 3 `expression_has_call` re-walk
- add a pattern-corpus discriminator for local versus pure calls in CSS custom properties

## Verification

- `cargo fmt --all -- --check`
- `git diff --check`
- `node --check scripts/compat-corpus/verify.mjs`

Local builds and tests were intentionally not run per repository instructions; CI is the test oracle.

Part of #3569. Stacked on #3838.
