### PR TITLE
refactor(client): carry hoisted import source spans

### DIFF
--- a/.changeset/curly-import-maps.md
+++ b/.changeset/curly-import-maps.md
@@ -1,5 +1,5 @@
 ---
-"rsvelte_core": patch
+"@rsvelte/compiler": patch
 ---
 
 Preserve source-map spans for hoisted client imports.

--- a/.changeset/curly-import-maps.md
+++ b/.changeset/curly-import-maps.md
@@ -1,0 +1,5 @@
+---
+"rsvelte_core": patch
+---
+
+Preserve source-map spans for hoisted client imports.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2641,7 +2641,7 @@ dependencies = [
 
 [[package]]
 name = "rsvelte_esrap"
-version = "0.10.35"
+version = "0.10.36"
 dependencies = [
  "compact_str",
  "memchr",

--- a/compatibility/gate-coverage.md
+++ b/compatibility/gate-coverage.md
@@ -2031,6 +2031,11 @@ the gate separates them. Deleting a pass on a 0 therefore needs a population tha
 the passes deleted in #3015 (`default_function_wrapper` 84 → 0, `effect_callback` 8 → 0)
 carry a *movement*, which is the reading a 0 cannot give.
 
+The later `verbatim_import` deletion has a separate positive discriminator: module- and
+instance-script tests assert the source coordinate of the `{` in `import { name }` after the
+client import matcher is absent. That punctuation is the shape the matcher supplied, rather
+than a zero-count inference; the server still retains its independent import matcher.
+
  There is no corpus-wide source-map gate to fall back on: `verify.mjs` compares generated
  code, and the svelte2tsx map gate (§ 12) covers a different artifact.
 

--- a/crates/rsvelte_core/Cargo.toml
+++ b/crates/rsvelte_core/Cargo.toml
@@ -94,7 +94,7 @@ oxc_ast = { version = "0.145", features = ["serialize"] }
 oxc_span = "0.145"
 oxc_diagnostics = "0.145"
 oxc_codegen = "0.145"
-rsvelte_esrap = { version = "=0.10.35", path = "../rsvelte_esrap" }
+rsvelte_esrap = { version = "=0.10.36", path = "../rsvelte_esrap" }
 oxc_syntax = "0.145"
 oxc_semantic = "0.145"
 

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
@@ -596,7 +596,7 @@ pub(crate) fn transform_client(
     // Transform the instance script once with the real reactive_import_names.
     // This also determines how many $$array names it consumes (for template generation)
     // and is used for blocker_map computation and the final output.
-    let mut instance_script_imports = Vec::new();
+    let mut instance_script_imports: Vec<HoistedImport> = Vec::new();
     let mut pre_transformed_script = if let Some(instance_script) =
         &analysis.instance_script_content
     {
@@ -691,7 +691,7 @@ pub(crate) fn transform_client(
         } else {
             composed_body_projection.as_ref()
         };
-        instance_script_imports = imports;
+        instance_script_imports = attach_hoisted_import_spans(imports, retained_instance);
         let split_top_level_declarations =
             instance_has_top_level_multi_declarator(ast, instance_raw);
         let _script_start = super::profile::timer_start();
@@ -2159,6 +2159,10 @@ pub(crate) fn transform_client(
             // the grouping parens around one have to be gone before the first runs.
             let raw = super::shared::rune_parens::strip_rune_parens(&raw).unwrap_or(raw);
             let (module_imports, rest) = extract_imports(&raw);
+            let module_imports = attach_hoisted_import_spans(
+                module_imports,
+                retained_scripts.and_then(|scripts| scripts.module.as_ref()),
+            );
             let retained_comment_stripped = if !analysis.is_typescript {
                 retained_scripts
                     .and_then(|scripts| scripts.module.as_ref())
@@ -2175,19 +2179,17 @@ pub(crate) fn transform_client(
                 None
             };
             // Add module script imports first (from module.body in official compiler)
-            for import_line in module_imports {
-                let cleaned = cleanup_import_line(&import_line);
-                if cleaned.is_empty() {
-                    continue;
+            for import in module_imports {
+                if let Some(statement) = hoisted_import_statement(
+                    import,
+                    retained_scripts
+                        .and_then(|scripts| scripts.module.as_ref())
+                        .map_or(module_content.raw.as_str(), |retained| retained.source()),
+                    module_content.start,
+                    options.enable_sourcemap,
+                ) {
+                    body.push(statement);
                 }
-                let trimmed = cleaned.trim();
-                // Ensure import statements end with semicolons, matching esrap behavior.
-                let with_semi = if !trimmed.ends_with(';') {
-                    format!("{};", trimmed)
-                } else {
-                    trimmed.to_string()
-                };
-                body.push(JsStatement::Raw(with_semi.into()));
             }
             let rest_trimmed = rest.trim();
             // A module `<script module>` whose only non-import content is comments
@@ -2216,21 +2218,18 @@ pub(crate) fn transform_client(
     // Extract and add imports from instance script
     // These are in state.hoisted after import * as $ (from analysis.instance_body.hoisted)
     if analysis.instance_script_content.is_some() {
-        for import_line in instance_script_imports {
-            let cleaned = cleanup_import_line(&import_line);
-            if cleaned.is_empty() {
-                continue;
+        let instance_content = analysis.instance_script_content.as_ref().unwrap();
+        for import in instance_script_imports {
+            if let Some(statement) = hoisted_import_statement(
+                import,
+                retained_scripts
+                    .and_then(|scripts| scripts.instance.as_ref())
+                    .map_or(instance_content.raw.as_str(), |retained| retained.source()),
+                instance_content.start,
+                options.enable_sourcemap,
+            ) {
+                body.push(statement);
             }
-            let trimmed = cleaned.trim();
-            // Ensure import statements end with semicolons, matching esrap behavior.
-            // User code may omit semicolons (ASI), but the Svelte compiler's esrap
-            // printer always adds them.
-            let with_semi = if !trimmed.ends_with(';') {
-                format!("{};", trimmed)
-            } else {
-                trimmed.to_string()
-            };
-            body.push(JsStatement::Raw(with_semi.into()));
         }
     }
 
@@ -3504,6 +3503,90 @@ impl ScanState {
             }
         }
     }
+}
+
+struct HoistedImport {
+    code: String,
+    source: Option<std::ops::Range<u32>>,
+}
+
+/// Pair the imports selected by the compatibility-preserving text extractor
+/// with the locations already held by the Phase-1 OXC program. The text check
+/// proves that both views selected the same declarations; it does not discover
+/// a location. If TypeScript erasure changed one declaration, that declaration
+/// keeps the location-free fallback while its siblings can still carry spans.
+fn attach_hoisted_import_spans(
+    imports: Vec<String>,
+    retained: Option<&crate::ast::oxc_program::RetainedProgram<'_>>,
+) -> Vec<HoistedImport> {
+    use oxc_span::GetSpan as _;
+
+    let spans = retained
+        .filter(|program| !program.panicked() && program.diagnostics().is_empty())
+        .map(|program| {
+            program
+                .program()
+                .body
+                .iter()
+                .filter_map(|statement| match statement {
+                    oxc_ast::ast::Statement::ImportDeclaration(_) => Some(statement.span()),
+                    _ => None,
+                })
+                .collect::<Vec<_>>()
+        })
+        .filter(|spans| spans.len() == imports.len());
+
+    imports
+        .into_iter()
+        .enumerate()
+        .map(|(index, code)| {
+            let source = spans.as_ref().and_then(|spans| {
+                let span = spans[index];
+                let retained = retained?;
+                let original = retained
+                    .source()
+                    .get(span.start as usize..span.end as usize)?;
+                (format_hoisted_import(&code) == format_hoisted_import(original))
+                    .then_some(span.start..span.end)
+            });
+            HoistedImport { code, source }
+        })
+        .collect()
+}
+
+fn format_hoisted_import(import: &str) -> Option<String> {
+    let cleaned = cleanup_import_line(import);
+    let trimmed = cleaned.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    Some(if trimmed.ends_with(';') {
+        trimmed.to_string()
+    } else {
+        format!("{trimmed};")
+    })
+}
+
+fn hoisted_import_statement(
+    import: HoistedImport,
+    original_script: &str,
+    script_offset: u32,
+    enable_sourcemap: bool,
+) -> Option<JsStatement> {
+    let code = format_hoisted_import(&import.code)?;
+    let Some(source) = import.source.filter(|_| enable_sourcemap) else {
+        return Some(JsStatement::Raw(code.into()));
+    };
+    let Some(original) = original_script.get(source.start as usize..source.end as usize) else {
+        return Some(JsStatement::Raw(code.into()));
+    };
+    let source_offset = script_offset + source.start;
+    Some(JsStatement::RawMapped {
+        copied_spans: copied_spans_for_normalized_code(&code, original, source_offset, None),
+        code: code.into(),
+        source_offset,
+        comment_anchor: None,
+    })
 }
 
 pub(crate) fn extract_imports(script: &str) -> (Vec<String>, String) {

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/mod.rs
@@ -2217,8 +2217,7 @@ pub(crate) fn transform_client(
 
     // Extract and add imports from instance script
     // These are in state.hoisted after import * as $ (from analysis.instance_body.hoisted)
-    if analysis.instance_script_content.is_some() {
-        let instance_content = analysis.instance_script_content.as_ref().unwrap();
+    if let Some(instance_content) = &analysis.instance_script_content {
         for import in instance_script_imports {
             if let Some(statement) = hoisted_import_statement(
                 import,

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/tests.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/tests.rs
@@ -15,8 +15,7 @@ fn retained_instance_statements_match_a_normalized_script_after_import_hoisting(
 
 #[test]
 fn retained_instance_script_preserves_identifier_and_literal_source_map_spans() {
-    let source =
-        "<script>\nimport dependency from 'dependency';\nconst answer = 42;\n</script>\n<p>ok</p>";
+    let source = "<script>\nimport { dependency } from 'dependency';\nconst answer = 42;\n</script>\n<p>ok</p>";
     let result = crate::compiler::compile(
         source,
         crate::compiler::CompileOptions {
@@ -36,9 +35,24 @@ fn retained_instance_script_preserves_identifier_and_literal_source_map_spans() 
         result
             .js
             .code
-            .contains("import dependency from 'dependency';"),
+            .contains("import { dependency } from 'dependency';"),
         "hoisted import must retain its normal output: {}",
         result.js.code
+    );
+    let import_line = result
+        .js
+        .code
+        .lines()
+        .position(|line| line.contains("import { dependency } from 'dependency';"))
+        .expect("hoisted import is printed") as i64;
+    let generated_import = result.js.code.lines().nth(import_line as usize).unwrap();
+    let brace_column = generated_import.find('{').unwrap() as i64;
+    assert!(
+        mappings[import_line as usize]
+            .iter()
+            .any(|segment| segment.as_slice() == [brace_column, 0, 1, 7]),
+        "hoisted import punctuation must retain its source span; generated={generated_import:?}, segments={:?}",
+        mappings[import_line as usize]
     );
     let generated_line = result
         .js
@@ -61,6 +75,43 @@ fn retained_instance_script_preserves_identifier_and_literal_source_map_spans() 
             .any(|segment| segment.as_slice() == [literal_column, 0, 2, 15]),
         "literal must retain its original token span; generated={generated:?}, segments={line:?}"
     );
+}
+
+#[test]
+fn hoisted_module_and_instance_imports_preserve_source_map_spans() {
+    let source = "<script module>\nimport { moduleDependency } from 'module-dependency';\n</script>\n<script>\nimport { instanceDependency } from 'instance-dependency';\n</script>\n<p>ok</p>";
+    let result = crate::compiler::compile(
+        source,
+        crate::compiler::CompileOptions {
+            filename: Some("hoisted-import-source-map.svelte".to_string()),
+            enable_sourcemap: true,
+            ..Default::default()
+        },
+    )
+    .expect("compiles");
+    let map: serde_json::Value =
+        serde_json::from_str(result.js.map.as_deref().expect("map")).expect("valid source map");
+    let mappings = crate::compiler::phases::phase3_transform::js_ast::codegen::decode_vlq_mappings(
+        map["mappings"].as_str().expect("VLQ mappings"),
+    );
+
+    for (identifier, original_line) in [("moduleDependency", 1), ("instanceDependency", 4)] {
+        let generated_line = result
+            .js
+            .code
+            .lines()
+            .position(|line| line.contains(&format!("import {{ {identifier} }} from")))
+            .expect("hoisted import is printed");
+        let generated = result.js.code.lines().nth(generated_line).unwrap();
+        let generated_column = generated.find('{').unwrap() as i64;
+        assert!(
+            mappings[generated_line]
+                .iter()
+                .any(|segment| segment.as_slice() == [generated_column, 0, original_line, 7]),
+            "{identifier}'s import punctuation must retain its source span; generated={generated:?}, segments={:?}",
+            mappings[generated_line]
+        );
+    }
 }
 
 #[test]

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/client/tests.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/client/tests.rs
@@ -46,12 +46,12 @@ fn retained_instance_script_preserves_identifier_and_literal_source_map_spans() 
         .position(|line| line.contains("import { dependency } from 'dependency';"))
         .expect("hoisted import is printed") as i64;
     let generated_import = result.js.code.lines().nth(import_line as usize).unwrap();
-    let brace_column = generated_import.find('{').unwrap() as i64;
+    let dependency_column = generated_import.find("dependency").unwrap() as i64;
     assert!(
         mappings[import_line as usize]
             .iter()
-            .any(|segment| segment.as_slice() == [brace_column, 0, 1, 7]),
-        "hoisted import punctuation must retain its source span; generated={generated_import:?}, segments={:?}",
+            .any(|segment| segment.as_slice() == [dependency_column, 0, 1, 9]),
+        "hoisted import identifier must retain its source span; generated={generated_import:?}, segments={:?}",
         mappings[import_line as usize]
     );
     let generated_line = result
@@ -103,12 +103,12 @@ fn hoisted_module_and_instance_imports_preserve_source_map_spans() {
             .position(|line| line.contains(&format!("import {{ {identifier} }} from")))
             .expect("hoisted import is printed");
         let generated = result.js.code.lines().nth(generated_line).unwrap();
-        let generated_column = generated.find('{').unwrap() as i64;
+        let generated_column = generated.find(identifier).unwrap() as i64;
         assert!(
             mappings[generated_line]
                 .iter()
-                .any(|segment| segment.as_slice() == [generated_column, 0, original_line, 7]),
-            "{identifier}'s import punctuation must retain its source span; generated={generated:?}, segments={:?}",
+                .any(|segment| segment.as_slice() == [generated_column, 0, original_line, 9]),
+            "{identifier} must retain its source span; generated={generated:?}, segments={:?}",
             mappings[generated_line]
         );
     }

--- a/crates/rsvelte_core/src/compiler/phases/3_transform/mod.rs
+++ b/crates/rsvelte_core/src/compiler/phases/3_transform/mod.rs
@@ -290,16 +290,6 @@ pub(crate) fn transform_component_with_scripts<'source>(
                         &mapping_starts,
                     )
                 };
-                let import_mappings = if !map_pass_disabled("import") && source.contains("import ")
-                {
-                    generate_verbatim_import_mappings_with_starts(
-                        &result.code,
-                        source,
-                        &mapping_starts,
-                    )
-                } else {
-                    Vec::new()
-                };
                 let token_mappings = if map_pass_disabled("token") {
                     Vec::new()
                 } else {
@@ -344,7 +334,6 @@ pub(crate) fn transform_component_with_scripts<'source>(
                     + legacy_prop_read_mappings.len()
                     + template_element_mappings.len()
                     + inline_script_mappings.len()
-                    + import_mappings.len()
                     + template_name_mappings.len()
                     + token_mappings.len()
                     + rune_mappings.len()
@@ -357,7 +346,6 @@ pub(crate) fn transform_component_with_scripts<'source>(
                 mappings.extend(legacy_prop_read_mappings);
                 mappings.extend(template_element_mappings);
                 mappings.extend(inline_script_mappings);
-                mappings.extend(import_mappings);
                 mappings.extend(template_name_mappings);
                 mappings.extend(token_mappings);
                 mappings.extend(rune_mappings);

--- a/crates/rsvelte_esrap/Cargo.toml
+++ b/crates/rsvelte_esrap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rsvelte_esrap"
-version = "0.10.35"
+version = "0.10.36"
 edition = "2024"
 rust-version = "1.95"
 description = "A Rust port of esrap — prints an oxc AST to JavaScript with esrap's exact layout"

--- a/crates/rsvelte_esrap/src/lib.rs
+++ b/crates/rsvelte_esrap/src/lib.rs
@@ -233,7 +233,7 @@ fn print_split_impl<const HAS_COMMENTS: bool>(
         let mut printer =
             printer::Printer::<HAS_COMMENTS, true>::with_comments(options, comments, line_starts)
                 .with_placement_source(comment_source)
-                .with_split_coordinates(map_line_starts, loc_base, loc_map, false);
+                .with_split_coordinates(map_line_starts, map_source, loc_base, loc_map, false);
         let mut ctx = context::Context::new_direct(&options.indent, program.source_text.len());
         printer.print_program(program, &mut ctx);
         let (buffer, returned, indent, dirty) = ctx.into_direct_parts();
@@ -247,7 +247,13 @@ fn print_split_impl<const HAS_COMMENTS: bool>(
     let mut printer =
         printer::Printer::<HAS_COMMENTS, false>::with_comments(options, comments, line_starts)
             .with_placement_source(comment_source)
-            .with_split_coordinates(map_line_starts, loc_base, loc_map, map_source.is_some());
+            .with_split_coordinates(
+                map_line_starts,
+                map_source,
+                loc_base,
+                loc_map,
+                map_source.is_some(),
+            );
     let mut ctx = context::Context::new();
     printer.print_program(program, &mut ctx);
     let capacity = ctx.measure();

--- a/crates/rsvelte_esrap/src/printer.rs
+++ b/crates/rsvelte_esrap/src/printer.rs
@@ -866,16 +866,19 @@ impl<'opt, const HAS_COMMENTS: bool, const DIRECT: bool> Printer<'opt, HAS_COMME
         }
     }
 
-    fn map_position(&self, offset: u32) -> Option<(u32, u32)> {
+    fn source_position(&self, offset: u32) -> Option<(u32, u32)> {
         let map_line_starts = self.map_line_starts.as_deref().unwrap_or(&self.line_starts);
         if map_line_starts.is_empty() {
             return None;
         }
-        let offset = self.mapped_offset(offset)?;
         let line = usize_to_u32(map_line_starts.partition_point(|&s| s <= offset));
         // `line` is 1-based; its start offset lives at index `line - 1`.
         let line_start = map_line_starts[(line - 1) as usize];
         Some((line, offset.saturating_sub(line_start)))
+    }
+
+    fn map_position(&self, offset: u32) -> Option<(u32, u32)> {
+        self.source_position(self.mapped_offset(offset)?)
     }
 
     /// esrap's `write_source_keyword`: bracket the literal `keyword` with
@@ -2119,7 +2122,7 @@ impl<'opt, const HAS_COMMENTS: bool, const DIRECT: bool> Printer<'opt, HAS_COMME
                 && let Some(relative) = source
                     .get(start as usize..end as usize)
                     .and_then(|prefix| prefix.rfind('{'))
-                && let Some((line, column)) = self.map_position(start + relative as u32)
+                && let Some((line, column)) = self.source_position(start + relative as u32)
             {
                 ctx.location(line, column);
             }

--- a/crates/rsvelte_esrap/src/printer.rs
+++ b/crates/rsvelte_esrap/src/printer.rs
@@ -116,6 +116,9 @@ pub struct Printer<'opt, const HAS_COMMENTS: bool = true, const DIRECT: bool = f
     /// resolved against. Same as `line_starts` unless the caller split the two
     /// coordinate spaces (see [`crate::print_split`]).
     map_line_starts: Option<Vec<u32>>,
+    /// The buffer source-map offsets index into. This differs from
+    /// `placement_source` for a reassembled program.
+    map_source: Option<&'opt str>,
     /// Spans below this offset are synthesized and carry no source location, so
     /// they take no part in comment placement — the Rust equivalent of esrap's
     /// `if (node.loc)` guards. `None` = every span is a real location.
@@ -697,6 +700,7 @@ impl<'opt, const HAS_COMMENTS: bool, const DIRECT: bool> Printer<'opt, HAS_COMME
             comment_source: None,
             placement_source: None,
             map_line_starts: None,
+            map_source: None,
             loc_base: None,
             loc_map: Vec::new(),
             map_nodes: true,
@@ -718,6 +722,7 @@ impl<'opt, const HAS_COMMENTS: bool, const DIRECT: bool> Printer<'opt, HAS_COMME
             borrowed_comments: None,
             comment_index: 0,
             map_line_starts: None,
+            map_source: None,
             line_starts,
             comment_source: None,
             placement_source: None,
@@ -751,12 +756,14 @@ impl<'opt, const HAS_COMMENTS: bool, const DIRECT: bool> Printer<'opt, HAS_COMME
     pub fn with_split_coordinates(
         mut self,
         map_line_starts: Vec<u32>,
+        map_source: Option<&'opt str>,
         loc_base: u32,
         loc_map: &[LocRange],
         emit_locations: bool,
     ) -> Self {
         self.emit_locations = emit_locations;
         self.map_line_starts = Some(map_line_starts);
+        self.map_source = map_source;
         self.loc_base = Some(loc_base);
         self.loc_map = loc_map.to_vec();
         self
@@ -826,39 +833,45 @@ impl<'opt, const HAS_COMMENTS: bool, const DIRECT: bool> Printer<'opt, HAS_COMME
     /// location" *for comments*, but it is still exactly the position a source
     /// map segment wants. Formatting decisions must keep using
     /// [`Self::offset_to_line_col`], which cannot compare across the two spaces.
-    fn map_position(&self, offset: u32) -> Option<(u32, u32)> {
+    fn mapped_offset(&self, offset: u32) -> Option<u32> {
         if offset == u32::MAX {
             return None;
         }
+        if self.loc_map.is_empty() {
+            Some(offset)
+        } else {
+            Some(
+                match self
+                    .loc_map
+                    .binary_search_by(|range| {
+                        if offset < range.start {
+                            std::cmp::Ordering::Greater
+                        } else if offset >= range.end {
+                            std::cmp::Ordering::Less
+                        } else {
+                            std::cmp::Ordering::Equal
+                        }
+                    })
+                    .ok()
+                    .map(|i| &self.loc_map[i])
+                {
+                    Some(range) => match range.source {
+                        Some(mapped) if range.linear => mapped + (offset - range.start),
+                        Some(mapped) => mapped,
+                        None => return None,
+                    },
+                    None => offset,
+                },
+            )
+        }
+    }
+
+    fn map_position(&self, offset: u32) -> Option<(u32, u32)> {
         let map_line_starts = self.map_line_starts.as_deref().unwrap_or(&self.line_starts);
         if map_line_starts.is_empty() {
             return None;
         }
-        let offset = if self.loc_map.is_empty() {
-            offset
-        } else {
-            match self
-                .loc_map
-                .binary_search_by(|range| {
-                    if offset < range.start {
-                        std::cmp::Ordering::Greater
-                    } else if offset >= range.end {
-                        std::cmp::Ordering::Less
-                    } else {
-                        std::cmp::Ordering::Equal
-                    }
-                })
-                .ok()
-                .map(|i| &self.loc_map[i])
-            {
-                Some(range) => match range.source {
-                    Some(mapped) if range.linear => mapped + (offset - range.start),
-                    Some(mapped) => mapped,
-                    None => return None,
-                },
-                None => offset,
-            }
-        };
+        let offset = self.mapped_offset(offset)?;
         let line = usize_to_u32(map_line_starts.partition_point(|&s| s <= offset));
         // `line` is 1-based; its start offset lives at index `line - 1`.
         let line_start = map_line_starts[(line - 1) as usize];
@@ -2075,6 +2088,12 @@ impl<'opt, const HAS_COMMENTS: bool, const DIRECT: bool> Printer<'opt, HAS_COMME
             }
         }
 
+        if self.emit_locations
+            && !self.loc_map.is_empty()
+            && let Some((line, column)) = self.map_position(node.span.start)
+        {
+            ctx.location(line, column);
+        }
         ctx.write("import ");
         if import_type {
             ctx.write("type ");
@@ -2090,6 +2109,20 @@ impl<'opt, const HAS_COMMENTS: bool, const DIRECT: bool> Printer<'opt, HAS_COMME
             ctx.write(ns.local.name.as_str());
         }
         if !named.is_empty() {
+            if self.emit_locations
+                && !self.loc_map.is_empty()
+                && let (Some(source), Some(start), Some(end)) = (
+                    self.map_source,
+                    self.mapped_offset(node.span.start),
+                    self.mapped_offset(named[0].span().start),
+                )
+                && let Some(relative) = source
+                    .get(start as usize..end as usize)
+                    .and_then(|prefix| prefix.rfind('{'))
+                && let Some((line, column)) = self.map_position(start + relative as u32)
+            {
+                ctx.location(line, column);
+            }
             ctx.write_ascii(b'{');
             self.sequence_slice(
                 &named,

--- a/crates/rsvelte_esrap/tests/split_coordinates.rs
+++ b/crates/rsvelte_esrap/tests/split_coordinates.rs
@@ -101,6 +101,27 @@ impl<'a> Assembler<'a> {
         self.body.extend(program.body);
     }
 
+    /// A verbatim-copied chunk whose individual byte positions map back to the
+    /// corresponding bytes in the original source.
+    fn push_linear_chunk(&mut self, text: &str, maps_to: u32) {
+        let base = source_offset(self.source.len());
+        let mut padded = " ".repeat(base as usize - 1);
+        padded.push('\n');
+        padded.push_str(text);
+        let owned = self.ab.allocator().alloc_str(&padded);
+        let program = self.parse(owned);
+        self.source.push_str(text);
+        self.source.push('\n');
+        self.comments.extend(program.comments.iter().copied());
+        self.loc_map.push(LocMapEntry {
+            start: base,
+            end: base + source_offset(text.len()),
+            source: Some(maps_to),
+            linear: true,
+        });
+        self.body.extend(program.body);
+    }
+
     fn wrap_body(&mut self, span: Span) {
         let body = ArenaVec::from_iter_in(std::mem::take(&mut self.body), &self.ab);
         self.body
@@ -316,6 +337,31 @@ fn loc_map_resolves_chunk_positions_back_into_the_source() {
             "every chunk offset maps to the anchor line: {seg:?}"
         );
     }
+}
+
+#[test]
+fn named_import_brace_uses_source_space_after_linear_mapping() {
+    let import = "import { dependency } from 'dependency';";
+    let map_source = format!("<script>\n{import}\n</script>\n");
+    let anchor = source_offset(map_source.find(import).expect("import in map source"));
+
+    let allocator = Allocator::default();
+    let mut a = Assembler::new(&allocator, 512);
+    a.push_linear_chunk(import, anchor);
+    let mapped = a.finish().print_mapped(&map_source);
+    let brace_column = source_offset(mapped.code.find('{').expect("brace in generated import"));
+
+    assert!(
+        mapped.mappings.iter().any(|segment| {
+            segment.gen_line == 0
+                && segment.gen_column == brace_column
+                && segment.source_line == 1
+                && segment.source_column == 7
+        }),
+        "named import brace must resolve in source space: code={:?}, mappings={:?}",
+        mapped.code,
+        mapped.mappings
+    );
 }
 
 #[test]

--- a/crates/rsvelte_lint_types/Cargo.lock
+++ b/crates/rsvelte_lint_types/Cargo.lock
@@ -1128,7 +1128,7 @@ dependencies = [
 
 [[package]]
 name = "rsvelte_esrap"
-version = "0.10.35"
+version = "0.10.36"
 dependencies = [
  "compact_str",
  "memchr",

--- a/docs/phase3-ast-refactor-plan.md
+++ b/docs/phase3-ast-refactor-plan.md
@@ -677,8 +677,8 @@ Segments lost when exactly one client pass is disabled, everything else on:
 | `rune` | 0 | 0 |
 
 `default_function_wrapper` and `effect_callback` are deleted: both are now produced by a
-span, and the before/after column is the attribution. The other nine stay, and what each
-still carries is a named lowering, not a mystery:
+span, and the before/after column is the attribution. At this measurement the other nine
+stayed, and what each still carried was a named lowering, not a mystery:
 
 | still carried by a pass | why the position is lost |
 | --- | --- |
@@ -691,6 +691,17 @@ still carries is a named lowering, not a mystery:
 Every row is a `Raw` fragment or a builder call that had a span available and dropped it —
 i.e. #3015's step 1 really is the prerequisite it claims to be, and this measurement names
 which fragments to eradicate first by how many segments they hold.
+
+**2026-08-26 follow-up — `verbatim_import` is deleted from the client pipeline.** Import
+selection still uses `extract_imports` for output compatibility, but each selected import is
+paired by declaration order with the retained OXC program and accepted only when both views
+normalize to the same output. The retained declaration supplies the source range; a mismatch
+(including a TypeScript erasure the cleanup cannot prove equivalent) keeps the location-free
+fallback. `RawMapped` then restores the retained range onto the reparsed import nodes, so the
+brace in `import { name }` is emitted from its source span instead of the generated/source text
+matcher. Module- and instance-import regression cases assert that punctuation mapping after
+the client pass has been removed. The table above remains the attribution measurement that
+priced the row before this follow-up.
 
 **`collapsed_declaration` and `rune` cost 0 on both trees, and that is not evidence they
 are redundant.** They were already contributing nothing before this change, so deleting


### PR DESCRIPTION
> Status: the retained-import implementation in #3853 supersedes this PR because it also handles TypeScript type-only cleanup and the standalone phase-3 API. Static inspection shows that #3854 cannot decide the remaining esrap punctuation work: the generated-token pass visits identifiers and literals, but not import punctuation such as the named-import `{`. The final esrap-only changes from this branch will therefore be split into a small PR stacked after #3853, with their split-coordinate regression test as the direct oracle. This draft remains unmerged and will be closed once that replacement PR exists.

## Summary

- carry retained Phase-1 import declaration ranges alongside hoisted client imports
- emit source-mapped hoisted imports only when the retained declaration formats to the exact extracted output; otherwise preserve the existing unmapped fallback
- remove the client `verbatim_import` generated-text matching pass
- add discriminating source-map coverage for named-import punctuation in both module and instance scripts
- document the removed pass and the gate coverage it now has

This is a focused part of #3015. It does not close the issue.

## Safety

The retained AST supplies the source range. Text equality is used only to prove that an extracted import is the declaration at that range, not to discover a generated position. TypeScript-erased or otherwise changed declarations remain on the prior `Raw` path, so failure to establish that pairing cannot drop or misattribute an import.

The server-side import matcher is independent and remains unchanged.

## Verification

- `cargo fmt --all`
- `cargo fmt --all -- --check`
- `git diff --check`

Per repository instructions, I did not run local builds or tests; CI is the execution oracle.
